### PR TITLE
fix(bench): require EVERY published bar to be adjudicated, in both places (rf2-y7mw7)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -49,6 +49,25 @@
 // Its decision now has one seat too, and the last section of this file is
 // that seat's fixtures plus the wiring that makes them load-bearing.
 //
+// AND THEN THE REPAIR'S OWN REMAINDER, which #7489's merged-PR audit found.
+// The bar-level term reached the exit code but was derived one notch too
+// loose, in BOTH places that carry it: `clock_run.cjs` asked
+// `unadj.length < names.length` and `clock_readjudicate.cjs` asked
+// `names.some(...)`, so ONE adjudicated bar carried a row whose other
+// published bars had no band at all — the driver exiting 0 under a sentence
+// reading "every published bar adjudicated", the readjudicator pooling that
+// run into the published mean for every pair including the unadjudicated one.
+//
+// The reason it survived a landing is the lesson: both rules lived where no
+// test could reach them — inline in the driver's `main`, and in a file that
+// read `process.argv` at module scope so requiring it ran it — and the only
+// thing holding the driver's was a regex over its own source, which matched
+// the wrong rule as faithfully as it would have matched the right one. A rule
+// a test cannot drive is not a checked rule however exactly it is quoted.
+// Both are pure exported functions now (`rowAdjudication`, `adjudicated`),
+// both require every published bar to carry a band, and both are driven below
+// on the mixed-bar case that neither used to have.
+//
 // Wired into implementation/package.json via `test:script-helpers`.
 
 const assert = require('node:assert');
@@ -325,11 +344,14 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
 
 {
   const CLOCK = path.join(__dirname, 'clock_run.cjs');
-  const { reportability, reportabilitySelfTest } = require('./clock_run.cjs');
+  const { reportability, rowAdjudication, reportabilitySelfTest } = require('./clock_run.cjs');
   const SRC = fs.readFileSync(CLOCK, 'utf8');
   const t = (what, fn) => test(`clock_run.cjs: ${what}`, fn);
   const KEYSTROKE_WHY = "UNADJUDICATED — this row's control burns a fixed 50 ms rather than doubling the page";
   const clockRow = (over) => ({ rowId: 'M1', ctlOk: true, ctlNote: '', adjudicable: true, ...over });
+  // A bar as `seam.assess` writes it into `seamTask.rows`.
+  const ADJ = { unadjudicated: false, why: 'margin 34.8% clears the band 21.4%' };
+  const UNADJ = { unadjudicated: true, why: KEYSTROKE_WHY };
 
   // --- the driver's own fixtures, which `--selftest` also runs --------------
 
@@ -348,7 +370,7 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     ]);
     assert.notStrictEqual(v.code, 0, 'a run with no adjudicable bar must not exit 0');
     assert.strictEqual(v.code, 1);
-    assert.match(v.lines[0], /no published bar can be ADJUDICATED on: keystroke/);
+    assert.match(v.lines[0], /not every published bar can be ADJUDICATED on: keystroke/);
     assert.match(v.lines[1], /keystroke: UNADJUDICATED/);
     assert.strictEqual(v.lines[2], '[clock] REPORTABLE: none.');
   });
@@ -401,8 +423,82 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     ]);
     assert.strictEqual(v.code, 1);
     assert.match(v.lines[0], /positive control/);
-    assert.match(v.lines[1], /no published bar can be ADJUDICATED/);
+    assert.match(v.lines[1], /not every published bar can be ADJUDICATED/);
     assert.strictEqual(v.lines[3], '[clock] REPORTABLE: none.');
+  });
+
+  // --- THE REMAINDER: a row whose bars DISAGREE (#7489's merged-PR audit) ---
+  //
+  // The first repair put the bar-level verdict into the exit code but derived
+  // it with `unadj.length < names.length` — "at least one bar carries a band"
+  // — while the REPORTABLE line it printed claimed "every published bar
+  // adjudicated". A row publishing three bars of which one had no band
+  // therefore satisfied the code and contradicted the sentence, and the run
+  // exited 0. Nothing caught it because the rule lived inline in `main`, which
+  // needs an `:advanced` build and a headless Chromium to reach; the only
+  // check on it was a regex over the source, and the regex matched the wrong
+  // rule faithfully. It is a pure function now, and these drive it.
+
+  t('THE REMAINDER: ONE unadjudicated bar makes the row unadjudicable', () => {
+    const a = rowAdjudication({
+      'hicasso / reagent-subs': ADJ,
+      'hicasso / uix-subs': UNADJ,
+      'uix-subs / reagent-subs': ADJ,
+    });
+    assert.strictEqual(a.adjudicable, false, 'two adjudicated bars may not carry a third that has no band');
+    assert.strictEqual(a.barCount, 3);
+    assert.deepStrictEqual(a.unadjudicatedBars, ['hicasso / uix-subs']);
+    assert.strictEqual(a.unadjudicatedWhy, KEYSTROKE_WHY);
+  });
+
+  t('and that row cannot exit 0 — the refusal reaches the code, naming the bar', () => {
+    const mixed = rowAdjudication({ 'h / r': ADJ, 'h / u': UNADJ, 'u / r': ADJ });
+    const v = reportability([clockRow({}), clockRow({ rowId: 'keystroke', ...mixed })]);
+    assert.notStrictEqual(v.code, 0, 'a row with a bar it cannot adjudicate must not exit 0');
+    assert.strictEqual(v.code, 1);
+    assert.match(v.lines[0], /not every published bar can be ADJUDICATED on: keystroke/);
+    assert.match(v.lines[1], /1 of 3 published bars carry no band \(h \/ u\)/);
+    assert.match(v.lines[1], new RegExp(KEYSTROKE_WHY.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  });
+
+  t('the clean rows beside it are still reportable — the refusal stays per-row', () => {
+    const mixed = rowAdjudication({ 'h / r': ADJ, 'h / u': UNADJ });
+    const v = reportability([clockRow({}), clockRow({ rowId: 'keystroke', ...mixed })]);
+    const last = v.lines[v.lines.length - 1];
+    assert.match(last, /^\[clock\] REPORTABLE: M1 —/);
+    assert.doesNotMatch(last, /keystroke/, 'a row with an unadjudicated bar must never appear in REPORTABLE');
+  });
+
+  t('a row whose every bar carries a band is adjudicable — the gate is not vacuous', () => {
+    // Without this, every assertion above would still pass if `rowAdjudication`
+    // simply always returned false.
+    const a = rowAdjudication({ 'h / r': ADJ, 'h / u': ADJ, 'u / r': ADJ });
+    assert.strictEqual(a.adjudicable, true);
+    assert.strictEqual(a.barCount, 3);
+    assert.deepStrictEqual(a.unadjudicatedBars, []);
+    assert.strictEqual(reportability([clockRow({ ...a })]).code, 0);
+  });
+
+  t('the case #7489 DID catch is still caught — the rule was tightened, not swapped', () => {
+    const a = rowAdjudication({ 'h / r': UNADJ, 'h / u': UNADJ });
+    assert.strictEqual(a.adjudicable, false);
+    assert.deepStrictEqual(a.unadjudicatedBars, ['h / r', 'h / u']);
+    assert.strictEqual(reportability([clockRow({ rowId: 'keystroke', ...a })]).code, 1);
+  });
+
+  t('an empty or missing bar set fails CLOSED — absent is not clean', () => {
+    for (const bars of [{}, undefined, null]) {
+      const a = rowAdjudication(bars);
+      assert.strictEqual(a.adjudicable, false, `bars=${JSON.stringify(bars)} must not be adjudicable`);
+      assert.strictEqual(a.barCount, 0);
+      assert.strictEqual(a.unadjudicatedWhy, 'the run adjudicated no bar on this row at all');
+    }
+    // And with no bar names to print, the refusal falls back to the row's own
+    // reason rather than printing "0 of 0 published bars".
+    const v = reportability([clockRow({ ...rowAdjudication({}) })]);
+    assert.strictEqual(v.code, 1);
+    assert.match(v.lines[1], /M1: the run adjudicated no bar on this row at all/);
+    assert.doesNotMatch(v.lines[1], /0 of 0/);
   });
 
   // --- and the sentence that invited the publication -----------------------
@@ -420,15 +516,22 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
 
   t('the driver exposes its decision and does not drive itself on require', () => {
     assert.ok(MAIN.length > 0, 'the driver must expose its run as `main`');
-    assert.match(SRC, /module\.exports = \{ reportability, reportabilitySelfTest \};/);
+    assert.match(SRC, /module\.exports = \{ reportability, rowAdjudication, reportabilitySelfTest \};/);
     assert.match(SRC, /if \(require\.main === module\) \{\s*main\(\);/);
   });
 
   t('the summary reads the adjudication the report printed, rather than recomputing it', () => {
     // A second computation is a second decision, and a second decision is
     // this whole file's subject.
-    assert.match(MAIN, /o\.verdict\.seamTask && o\.verdict\.seamTask\.rows/);
-    assert.match(MAIN, /adjudicable: names\.length > 0 && unadj\.length < names\.length,/);
+    assert.match(MAIN, /rowAdjudication\(o\.verdict\.seamTask && o\.verdict\.seamTask\.rows\)/);
+    // And the rule itself is NOT written out here. It used to be, and the only
+    // thing checking it was a regex on this line — which held the loose rule
+    // happily for as long as the regex agreed with it. The behavioural cases
+    // are below; this asserts the inline copy has not grown back.
+    assert.ok(
+      !/unadj\.length|Object\.keys\(bars\)/.test(MAIN),
+      'the bar-level rule must live in `rowAdjudication`, not inline in `main` where no test can drive it'
+    );
   });
 
   t('the exit code comes from `reportability` and from nothing else', () => {
@@ -450,6 +553,124 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     const block = SRC.slice(SRC.indexOf('if (SELFTEST_ONLY) {'), SRC.indexOf('if (!NO_BUILD)'));
     assert.match(block, /reportabilitySelfTest\(\)/);
     assert.match(block, /\[\.\.\.g\.checks, \.\.\.s\.checks, \.\.\.x\.checks\]\.filter/);
+  });
+}
+
+// --- clock_readjudicate.cjs: the SAME term, on the persisted datasets --------
+//
+// rf2-y7mw7's second place. The driver adjudicates one run; the readjudicator
+// pools an ENSEMBLE of the driver's stored datasets and prints the figure that
+// gets published, so the same fail-open has two homes and the second one
+// outlives the first — a dataset is re-read long after the `seam.assess` that
+// wrote it.
+//
+// #7489 added the adjudication term here as `names.some((n) => !unadjudicated)`
+// and its audit found that wrong for the reason the driver's was: ONE
+// adjudicated bar admitted the whole run into the "control-passing subset",
+// FOR EVERY PAIR — including the pair whose own bar had no band. The predicate
+// was also unreachable, because the file read `process.argv` at module scope
+// and exited, so requiring it ran it. Both are repaired below.
+
+{
+  const RJ = path.join(__dirname, 'clock_readjudicate.cjs');
+  const { adjudicated, reportable } = require('./clock_readjudicate.cjs');
+  const RJSRC = fs.readFileSync(RJ, 'utf8');
+  const t = (what, fn) => test(`clock_readjudicate.cjs: ${what}`, fn);
+  const ADJ = { unadjudicated: false, band: 0.21, why: 'margin 34.8% clears the band 21.4%' };
+  const UNADJ = { unadjudicated: true, band: null, why: 'UNADJUDICATED — no proportional control on this row' };
+  // A dataset row as `clock_run.cjs` writes it, reduced to the fields this
+  // predicate reads.
+  const dsRow = (bars, over) => ({
+    rowId: 'M1',
+    ctlTask: { ok: true },
+    seam: { verdict: { ceilingBreached: false } },
+    seamTask: { ceilingBreached: false, rows: bars },
+    ...over,
+  });
+
+  t('THE REMAINDER: one unadjudicated bar keeps the whole run OUT of the subset', () => {
+    const row = dsRow({ 'h / r': ADJ, 'h / u': UNADJ, 'u / r': ADJ });
+    assert.strictEqual(adjudicated(row), false, 'two adjudicated bars may not carry a third with no band');
+    assert.strictEqual(reportable(row), false, 'and the run may not be pooled into the published mean');
+  });
+
+  t('a run whose every bar carries a band IS pooled — the predicate is not vacuous', () => {
+    const row = dsRow({ 'h / r': ADJ, 'h / u': ADJ, 'u / r': ADJ });
+    assert.strictEqual(adjudicated(row), true);
+    assert.strictEqual(reportable(row), true, 'a clean run must still reach the reportable subset');
+  });
+
+  t('a run whose every bar is UNADJUDICATED is still out — the term was tightened, not swapped', () => {
+    assert.strictEqual(adjudicated(dsRow({ 'h / r': UNADJ, 'h / u': UNADJ })), false);
+  });
+
+  t('a dataset that stored no bar verdict at all fails closed', () => {
+    assert.strictEqual(adjudicated(dsRow({})), false, 'an empty bar set is absent, not clean');
+    assert.strictEqual(adjudicated({ rowId: 'M1' }), false, 'a row with no seamTask at all is absent, not clean');
+    assert.strictEqual(adjudicated(undefined), false);
+    assert.strictEqual(reportable(undefined), false);
+  });
+
+  t('the OTHER two terms are unchanged — adjudication was ADDED, never substituted', () => {
+    const bars = { 'h / r': ADJ, 'h / u': ADJ };
+    // A failed control still excludes a fully adjudicated run ...
+    assert.strictEqual(reportable(dsRow(bars, { ctlTask: { ok: false } })), false);
+    assert.strictEqual(reportable(dsRow(bars, { ctlTask: null })), false);
+    // ... and so does either ceiling, which fires before any control.
+    assert.strictEqual(
+      reportable(dsRow(bars, { seam: { verdict: { ceilingBreached: true } } })),
+      false,
+      'a breached net-band ceiling still excludes the run'
+    );
+    assert.strictEqual(
+      reportable(dsRow(bars, { seamTask: { ceilingBreached: true, rows: bars } })),
+      false,
+      'a breached task-band ceiling still excludes the run'
+    );
+  });
+
+  t('requiring the readjudicator does not RUN it, which is what made this reachable', () => {
+    assert.match(RJSRC, /module\.exports = \{ adjudicated, reportable \};/);
+    assert.match(RJSRC, /if \(require\.main === module\) \{/);
+    assert.match(RJSRC, /main\(process\.argv\.slice\(2\)\)/);
+  });
+
+  t('the subset is chosen by `reportable` alone, not by a second predicate inline', () => {
+    const body = RJSRC.slice(RJSRC.indexOf('function main(argv)'));
+    assert.match(body, /runs\.map\(\(\{ row \}, i\) => \(reportable\(row\) \? i : -1\)\)/);
+    assert.ok(
+      !/\.some\(\(n\) => !bars\[n\]\.unadjudicated\)/.test(RJSRC),
+      'the loose `some` rule must not survive anywhere in this file'
+    );
+    // `main` may still READ a bar verdict to print it — the per-run table is
+    // a description, not a decision. What it may not do is quantify over the
+    // bars, because that is the predicate above being written a second time.
+    assert.ok(
+      !/(names|Object\.keys)[^\n]*\.(some|every)\(/.test(body),
+      'quantifying over a row\'s bars inside `main` is the subset predicate written twice'
+    );
+  });
+
+  t('the printed verdict column reads the SAME per-bar record the subset does', () => {
+    // The column used to be derived from row-wide `bandTask` while the subset
+    // was derived per bar, so a row whose bars disagreed would print "clears
+    // its band" for a bar the subset had just refused. That is this bead's own
+    // complaint — a column and a decision disagreeing about the same run —
+    // pointing the other way.
+    const body = RJSRC.slice(RJSRC.indexOf('function main(argv)'));
+    assert.match(body, /const barRec = \(row\.seamTask && row\.seamTask\.rows && row\.seamTask\.rows\[pair\]\)/);
+    assert.match(body, /const barUnadjudicated = barRec \? !!barRec\.unadjudicated/);
+    // and the column's UNADJUDICATED branch is taken from THAT, not from the
+    // row-wide band.
+    assert.match(body, /: barUnadjudicated\s*\r?\n\s*\? 'UNADJUDICATED/);
+  });
+
+  t('it still SELECTS no run away from the table — only from the subset', () => {
+    // The file's own stated refusal, and the reason the predicate above may
+    // never be used to drop a row from the per-run listing.
+    assert.match(RJSRC, /It does not select runs\./);
+    const body = RJSRC.slice(RJSRC.indexOf('function main(argv)'));
+    assert.match(body, /runs\.forEach\(\(\{ file, row \}, i\) => \{/);
   });
 }
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
@@ -48,12 +48,6 @@
 
 const fs = require('node:fs');
 
-const files = process.argv.slice(2).filter((a) => !a.startsWith('--'));
-if (files.length === 0) {
-  console.error('usage: clock_readjudicate.cjs <run1.json> [run2.json ...]');
-  process.exit(1);
-}
-
 const fmt = (x, n = 4) => (Number.isFinite(x) ? x.toFixed(n) : 'n/a');
 const mean = (xs) => xs.reduce((a, b) => a + b, 0) / xs.length;
 
@@ -70,266 +64,332 @@ function ens(xs) {
   return { n: v.length, mean: mean(v), min: Math.min(...v), max: Math.max(...v) };
 }
 
-const datasets = files.map((f) => ({ file: f, data: JSON.parse(fs.readFileSync(f, 'utf8')) }));
-
-// Row ids in the order the first dataset produced them, so the report reads
-// in run order rather than in whatever order Object.keys happens to give.
-const rowIds = [];
-for (const { data } of datasets) {
-  for (const r of data.rows) if (!rowIds.includes(r.rowId)) rowIds.push(r.rowId);
-}
-
 const PAIRS = ['hicasso / reagent-subs', 'hicasso / uix-subs', 'uix-subs / reagent-subs'];
 const SEGMENTS = ['reagent-subs', 'uix-subs', 'hicasso'];
 
-console.log(';; ==== ENSEMBLE RE-ADJUDICATION (rf2-emvod) ====');
-console.log(`;; datasets ${datasets.length}`);
-for (const { file, data } of datasets) {
-  console.log(
-    `;;   ${file}  label=${data.label || '-'}  when=${data.when}  chromium=${data.chromium}  ` +
-      `design=${data.design.rounds}x(${data.design.warmup}+${data.design.samples}) tare=${data.design.tare}`
+/**
+ * IS EVERY BAR THIS RUN PUBLISHED ON THIS ROW ADJUDICATED?
+ *
+ * rf2-y7mw7's term, and the one this file was missing entirely: a row whose
+ * bars have no band has a magnitude and nothing to tell it from parity, and
+ * this program prints its ensemble mean under the label "control-passing
+ * subset". A dataset that stored no bar verdict at all is not adjudicated
+ * either — absent is not clean.
+ *
+ * EVERY bar, not one of them. #7489's merged-PR audit found this predicate
+ * asking `some`, which admitted a run into the reportable subset — for every
+ * pair, including the unadjudicated one — on the strength of a single
+ * adjudicated bar elsewhere on the row. The driver that wrote these datasets
+ * sets `unadjudicated` from a row-wide flag, so no dataset in the tree today
+ * contains a mixed row; but this program's whole reason for existing is that
+ * datasets are re-read long after the driver that produced them, and a
+ * predicate that is correct only for the files that happen to exist now is a
+ * fail-open waiting for the first file that does not.
+ *
+ * `row` is one entry of a dataset's `rows`, as `clock_run.cjs` wrote it.
+ */
+function adjudicated(row) {
+  const bars = (row && row.seamTask && row.seamTask.rows) || {};
+  const names = Object.keys(bars);
+  return names.length > 0 && names.every((n) => !bars[n].unadjudicated);
+}
+
+/**
+ * MAY THIS RUN'S MAGNITUDE ON THIS ROW BE POOLED INTO THE REPORTABLE SUBSET?
+ *
+ * Its control held, its band stayed under the ceiling — the ceiling is a
+ * whole-run refusal that fires before any control is consulted, so a run that
+ * breached it contributes no magnitude even if its control passed — AND every
+ * bar it published carries a band.
+ *
+ * This selects nothing away from the TABLE. Every dataset handed to this
+ * program appears in the per-run table whatever this returns; the subset is
+ * printed beside the whole ensemble and never instead of it.
+ */
+function reportable(row) {
+  return !!(
+    row &&
+    row.ctlTask &&
+    row.ctlTask.ok &&
+    !(row.seam && row.seam.verdict && row.seam.verdict.ceilingBreached) &&
+    !(row.seamTask && row.seamTask.ceilingBreached) &&
+    adjudicated(row)
   );
 }
 
-for (const rowId of rowIds) {
-  const runs = datasets
-    .map(({ file, data }) => ({ file, row: data.rows.find((r) => r.rowId === rowId) }))
-    .filter((x) => x.row);
-  if (runs.length === 0) continue;
+function main(argv) {
+  const files = argv.filter((a) => !a.startsWith('--'));
+  if (files.length === 0) {
+    console.error('usage: clock_readjudicate.cjs <run1.json> [run2.json ...]');
+    return 1;
+  }
 
-  console.log('');
-  console.log(`;; ======== ROW ${rowId} — ${runs.length} runs ========`);
+  const datasets = files.map((f) => ({ file: f, data: JSON.parse(fs.readFileSync(f, 'utf8')) }));
 
-  // --- gates, per run -------------------------------------------------------
-  console.log(';; run  guard(net/task)  ctl-2x task   ctlPASS  band(task)  band(net)  floor abs ms');
-  for (const { file, row } of runs) {
-    const floorAbs = p50(
-      SEGMENTS.map((s) => {
-        const d = row.decomposition[`${s}/floor`];
-        return d ? d.task / d.n : NaN;
-      }).filter(Number.isFinite)
-    );
+  // Row ids in the order the first dataset produced them, so the report reads
+  // in run order rather than in whatever order Object.keys happens to give.
+  const rowIds = [];
+  for (const { data } of datasets) {
+    for (const r of data.rows) if (!rowIds.includes(r.rowId)) rowIds.push(r.rowId);
+  }
+
+  console.log(';; ==== ENSEMBLE RE-ADJUDICATION (rf2-emvod) ====');
+  console.log(`;; datasets ${datasets.length}`);
+  for (const { file, data } of datasets) {
     console.log(
-      `;;  ${shortName(file).padEnd(6)} ${(row.guardRefuse ? 'REFUSE' : 'ok').padEnd(7)}` +
-        `${(row.guardRefuseTask ? 'REFUSE' : 'ok').padEnd(8)}` +
-        `${row.ctlTask ? fmt(row.ctlTask.measured.mean, 3).padStart(10) : '       n/a'}` +
-        `${row.ctlTask ? (row.ctlTask.ok ? '   PASS' : '   FAIL') : '    n/a'}` +
-        `${row.bandTask === null || row.bandTask === undefined ? '       n/a' : (fmt(row.bandTask * 100, 1) + '%').padStart(10)}` +
-        `${row.seam && row.seam.band !== null ? (fmt(row.seam.band * 100, 1) + '%').padStart(11) : '        n/a'}` +
-        `${fmt(floorAbs, 3).padStart(13)}`
+      `;;   ${file}  label=${data.label || '-'}  when=${data.when}  chromium=${data.chromium}  ` +
+        `design=${data.design.rounds}x(${data.design.warmup}+${data.design.samples}) tare=${data.design.tare}`
     );
   }
 
-  // --- the three clocks, per pair -------------------------------------------
-  for (const pair of PAIRS) {
-    const inPage = runs.map(({ row }) => (row.inPageBar && row.inPageBar[pair] ? row.inPageBar[pair].mean : NaN));
-    const net = runs.map(({ row }) => (row.bar && row.bar[pair] ? row.bar[pair].tared.mean : NaN));
-    const task = runs.map(({ row }) => (row.barTask && row.barTask[pair] ? row.barTask[pair].mean : NaN));
-    if (!task.some(Number.isFinite)) continue;
+  for (const rowId of rowIds) {
+    const runs = datasets
+      .map(({ file, data }) => ({ file, row: data.rows.find((r) => r.rowId === rowId) }))
+      .filter((x) => x.row);
+    if (runs.length === 0) continue;
 
-    // The REPORTABLE subset, beside the whole ensemble and never instead of
-    // it. A run is reportable on this row when its control held, its band
-    // stayed under the ceiling, AND the row has an adjudicated bar at all —
-    // the ceiling is a whole-run refusal that fires before any control is
-    // consulted, so a run that breached it contributes no magnitude even if
-    // its control passed.
-    //
-    // THE THIRD TERM IS rf2-y7mw7's, and it was missing here for the same
-    // reason it was missing from the driver's exit code: a row whose bars are
-    // all UNADJUDICATED has a magnitude and no band to tell it from parity,
-    // and this function prints its ensemble mean under the label
-    // "control-passing subset". A dataset that stored no bar verdict at all
-    // is not adjudicated either — absent is not clean.
-    const adjudicated = (row) => {
-      const bars = (row.seamTask && row.seamTask.rows) || {};
-      const names = Object.keys(bars);
-      return names.length > 0 && names.some((n) => !bars[n].unadjudicated);
-    };
-    const reportable = ({ row }) =>
-      row.ctlTask && row.ctlTask.ok && !(row.seam && row.seam.verdict && row.seam.verdict.ceilingBreached) &&
-      !(row.seamTask && row.seamTask.ceilingBreached) && adjudicated(row);
-    const passIdx = runs.map((r, i) => (reportable(r) ? i : -1)).filter((i) => i >= 0);
-    const taskPass = passIdx.map((i) => task[i]);
-
-    const e = ens(task);
-    const en = ens(net);
-    const ei = ens(inPage);
     console.log('');
-    console.log(`;;   PAIR ${pair}`);
-    console.log(
-      `;;     raw TaskDuration (PUBLISHED)  ${fmt(e.mean)}x  [${fmt(e.min)} – ${fmt(e.max)}]  n=${e.n}` +
-        (taskPass.length
-          ? `   control-passing subset ${fmt(ens(taskPass).mean)}x n=${taskPass.length}`
-          : '   control-passing subset: NONE')
-    );
-    console.log(`;;     taskNet (frame-only, superseded) ${fmt(en.mean)}x  [${fmt(en.min)} – ${fmt(en.max)}]`);
-    console.log(`;;     in-page performance.now()        ${fmt(ei.mean)}x  [${fmt(ei.min)} – ${fmt(ei.max)}]`);
-    console.log(';;     run   in-page   taskNet   TaskDuration   band   margin   verdict');
-    runs.forEach(({ file, row }, i) => {
-      const b = row.bandTask;
-      const margin = Math.abs(task[i] - 1) * 100;
-      const bandPct = Number.isFinite(b) ? b * 100 : NaN;
-      const breached =
-        (row.seam && row.seam.verdict && row.seam.verdict.ceilingBreached) ||
-        (row.seamTask && row.seamTask.ceilingBreached);
-      const verdict = breached
-        ? `BAND CEILING BREACHED — whole run refused before any control is consulted`
-        : !Number.isFinite(bandPct)
-          ? 'UNADJUDICATED — no proportional control on this row'
-          : !(row.ctlTask && row.ctlTask.ok)
-            ? `control FAILED — no magnitude reportable`
-            : margin > bandPct
-              ? `clears its ${fmt(bandPct, 1)}% band`
-              : `INSIDE the band — instrument-limited`;
-      console.log(
-        `;;     ${shortName(file).padEnd(5)} ${fmt(inPage[i]).padStart(8)} ${fmt(net[i]).padStart(9)}` +
-          `${fmt(task[i]).padStart(14)} ${(Number.isFinite(bandPct) ? fmt(bandPct, 1) + '%' : 'n/a').padStart(7)}` +
-          ` ${(fmt(margin, 1) + '%').padStart(7)}   ${verdict}`
+    console.log(`;; ======== ROW ${rowId} — ${runs.length} runs ========`);
+
+    // --- gates, per run -------------------------------------------------------
+    console.log(';; run  guard(net/task)  ctl-2x task   ctlPASS  band(task)  band(net)  floor abs ms');
+    for (const { file, row } of runs) {
+      const floorAbs = p50(
+        SEGMENTS.map((s) => {
+          const d = row.decomposition[`${s}/floor`];
+          return d ? d.task / d.n : NaN;
+        }).filter(Number.isFinite)
       );
-    });
-  }
-
-  // --- absolutes, pooled over the ensemble ----------------------------------
-  //
-  // PRINTED FOR EVERY ROW, because both of this instrument's defects were
-  // visible here and in no ratio anywhere.
-  console.log('');
-  console.log(';;   ABSOLUTES — mean ms per sample, pooled over the ensemble');
-  console.log(';;     arm                          task   taskNet   in-page  devtools    script    layout');
-  const armKeys = [];
-  for (const { row } of runs) for (const k of Object.keys(row.decomposition)) if (!armKeys.includes(k)) armKeys.push(k);
-  for (const k of armKeys) {
-    const acc = { task: [], taskNet: [], devtools: [], script: [], layout: [], inPage: [] };
-    for (const { row } of runs) {
-      const d = row.decomposition[k];
-      if (!d || !d.n) continue;
-      acc.task.push(d.task / d.n);
-      acc.taskNet.push(d.taskNet / d.n);
-      acc.devtools.push(d.devtools / d.n);
-      acc.script.push(d.script / d.n);
-      acc.layout.push(d.layout / d.n);
+      console.log(
+        `;;  ${shortName(file).padEnd(6)} ${(row.guardRefuse ? 'REFUSE' : 'ok').padEnd(7)}` +
+          `${(row.guardRefuseTask ? 'REFUSE' : 'ok').padEnd(8)}` +
+          `${row.ctlTask ? fmt(row.ctlTask.measured.mean, 3).padStart(10) : '       n/a'}` +
+          `${row.ctlTask ? (row.ctlTask.ok ? '   PASS' : '   FAIL') : '    n/a'}` +
+          `${row.bandTask === null || row.bandTask === undefined ? '       n/a' : (fmt(row.bandTask * 100, 1) + '%').padStart(10)}` +
+          `${row.seam && row.seam.band !== null ? (fmt(row.seam.band * 100, 1) + '%').padStart(11) : '        n/a'}` +
+          `${fmt(floorAbs, 3).padStart(13)}`
+      );
     }
-    // The in-page window is not in `decomposition`; it is in the raw
-    // per-sample readings, which is where it has to be read from.
-    for (const { row } of runs) {
-      if (!row.inPageRounds) continue;
-      const [seg, arm] = k.split('/');
-      const xs = row.inPageRounds.flatMap((rd) => (rd[seg] && rd[seg][arm]) || []);
-      if (xs.length) acc.inPage.push(p50(xs));
-    }
-    if (acc.task.length === 0) continue;
-    console.log(
-      `;;     ${k.padEnd(28)} ${fmt(mean(acc.task), 3).padStart(6)} ${fmt(mean(acc.taskNet), 3).padStart(9)}` +
-        ` ${(acc.inPage.length ? fmt(mean(acc.inPage), 3) : 'n/a').padStart(9)} ${fmt(mean(acc.devtools), 3).padStart(9)}` +
-        ` ${fmt(mean(acc.script), 3).padStart(9)} ${fmt(mean(acc.layout), 3).padStart(9)}`
-    );
-  }
 
-  // --- THE DOOR -------------------------------------------------------------
-  //
-  // `DevToolsCommandDuration` absorbs page script that runs INSIDE a protocol
-  // command. Which door the driver uses therefore decides whether `taskNet`
-  // is a frame-only reading or an honest one, and the rows here disagree
-  // about the door: `M1`, `bulk300`, `bulk100` and `narrow` drive the
-  // operation through `page.evaluate` (`Runtime.callFunctionOn`), while
-  // `keystroke` drives it through `page.keyboard.press` (the Input domain).
-  //
-  // Two numbers settle it per row, and neither needs the other harness:
-  //
-  //   * whether `devtools` TRACKS the arm. If it carries the arm's script it
-  //     must move with the arm; if it is only the protocol's round trip it is
-  //     roughly constant across arms that differ by milliseconds of work.
-  //   * what `ScriptDuration` reads. The renderer's own script counter does
-  //     not see script run through a protocol command either, so a row whose
-  //     script is being absorbed reports a mount of 901 elements as costing
-  //     hundredths of a millisecond of script.
-  {
-    const armsIn = (row) => Object.keys(row.decomposition).filter((k) => !k.endsWith('/plumb'));
-    const per = (sel) =>
-      mean(
+    // --- the three clocks, per pair -------------------------------------------
+    for (const pair of PAIRS) {
+      const inPage = runs.map(({ row }) => (row.inPageBar && row.inPageBar[pair] ? row.inPageBar[pair].mean : NaN));
+      const net = runs.map(({ row }) => (row.bar && row.bar[pair] ? row.bar[pair].tared.mean : NaN));
+      const task = runs.map(({ row }) => (row.barTask && row.barTask[pair] ? row.barTask[pair].mean : NaN));
+      if (!task.some(Number.isFinite)) continue;
+
+      // The REPORTABLE subset, beside the whole ensemble and never instead of
+      // it. `reportable` is at module scope (above) so it can be driven by a
+      // test. rf2-y7mw7's third term landed here wrong, and it took a merged-PR
+      // audit rather than a gate to find it, precisely because nothing could
+      // reach it.
+      const passIdx = runs.map(({ row }, i) => (reportable(row) ? i : -1)).filter((i) => i >= 0);
+      const taskPass = passIdx.map((i) => task[i]);
+
+      const e = ens(task);
+      const en = ens(net);
+      const ei = ens(inPage);
+      console.log('');
+      console.log(`;;   PAIR ${pair}`);
+      console.log(
+        `;;     raw TaskDuration (PUBLISHED)  ${fmt(e.mean)}x  [${fmt(e.min)} – ${fmt(e.max)}]  n=${e.n}` +
+          (taskPass.length
+            ? `   control-passing subset ${fmt(ens(taskPass).mean)}x n=${taskPass.length}`
+            : '   control-passing subset: NONE')
+      );
+      console.log(`;;     taskNet (frame-only, superseded) ${fmt(en.mean)}x  [${fmt(en.min)} – ${fmt(en.max)}]`);
+      console.log(`;;     in-page performance.now()        ${fmt(ei.mean)}x  [${fmt(ei.min)} – ${fmt(ei.max)}]`);
+      console.log(';;     run   in-page   taskNet   TaskDuration   band   margin   verdict');
+      runs.forEach(({ file, row }, i) => {
+        const b = row.bandTask;
+        const margin = Math.abs(task[i] - 1) * 100;
+        const bandPct = Number.isFinite(b) ? b * 100 : NaN;
+        const breached =
+          (row.seam && row.seam.verdict && row.seam.verdict.ceilingBreached) ||
+          (row.seamTask && row.seamTask.ceilingBreached);
+        // WHETHER THIS BAR IS ADJUDICATED IS READ PER BAR, not off the row's
+        // `bandTask`. `bandTask` is row-wide, and a row-wide reading here
+        // would print "clears its 21.4% band" for the very bar the subset
+        // above has just refused for carrying no band — the same disagreement
+        // between a printed column and a decision that rf2-y7mw7 is about,
+        // pointing the other way. They agree on every dataset in the tree,
+        // and that agreement is `seam.assess`'s to withdraw, not this
+        // program's to depend on. The sentence is left row-phrased because no
+        // dataset yet exists in which a row's bars disagree; the bar's own
+        // `why` is in the dataset for the day one does.
+        const barRec = (row.seamTask && row.seamTask.rows && row.seamTask.rows[pair]) || null;
+        const barUnadjudicated = barRec ? !!barRec.unadjudicated : !Number.isFinite(bandPct);
+        const verdict = breached
+          ? `BAND CEILING BREACHED — whole run refused before any control is consulted`
+          : barUnadjudicated
+            ? 'UNADJUDICATED — no proportional control on this row'
+            : !(row.ctlTask && row.ctlTask.ok)
+              ? `control FAILED — no magnitude reportable`
+              : margin > bandPct
+                ? `clears its ${fmt(bandPct, 1)}% band`
+                : `INSIDE the band — instrument-limited`;
+        console.log(
+          `;;     ${shortName(file).padEnd(5)} ${fmt(inPage[i]).padStart(8)} ${fmt(net[i]).padStart(9)}` +
+            `${fmt(task[i]).padStart(14)} ${(Number.isFinite(bandPct) ? fmt(bandPct, 1) + '%' : 'n/a').padStart(7)}` +
+            ` ${(fmt(margin, 1) + '%').padStart(7)}   ${verdict}`
+        );
+      });
+    }
+
+    // --- absolutes, pooled over the ensemble ----------------------------------
+    //
+    // PRINTED FOR EVERY ROW, because both of this instrument's defects were
+    // visible here and in no ratio anywhere.
+    console.log('');
+    console.log(';;   ABSOLUTES — mean ms per sample, pooled over the ensemble');
+    console.log(';;     arm                          task   taskNet   in-page  devtools    script    layout');
+    const armKeys = [];
+    for (const { row } of runs) for (const k of Object.keys(row.decomposition)) if (!armKeys.includes(k)) armKeys.push(k);
+    for (const k of armKeys) {
+      const acc = { task: [], taskNet: [], devtools: [], script: [], layout: [], inPage: [] };
+      for (const { row } of runs) {
+        const d = row.decomposition[k];
+        if (!d || !d.n) continue;
+        acc.task.push(d.task / d.n);
+        acc.taskNet.push(d.taskNet / d.n);
+        acc.devtools.push(d.devtools / d.n);
+        acc.script.push(d.script / d.n);
+        acc.layout.push(d.layout / d.n);
+      }
+      // The in-page window is not in `decomposition`; it is in the raw
+      // per-sample readings, which is where it has to be read from.
+      for (const { row } of runs) {
+        if (!row.inPageRounds) continue;
+        const [seg, arm] = k.split('/');
+        const xs = row.inPageRounds.flatMap((rd) => (rd[seg] && rd[seg][arm]) || []);
+        if (xs.length) acc.inPage.push(p50(xs));
+      }
+      if (acc.task.length === 0) continue;
+      console.log(
+        `;;     ${k.padEnd(28)} ${fmt(mean(acc.task), 3).padStart(6)} ${fmt(mean(acc.taskNet), 3).padStart(9)}` +
+          ` ${(acc.inPage.length ? fmt(mean(acc.inPage), 3) : 'n/a').padStart(9)} ${fmt(mean(acc.devtools), 3).padStart(9)}` +
+          ` ${fmt(mean(acc.script), 3).padStart(9)} ${fmt(mean(acc.layout), 3).padStart(9)}`
+      );
+    }
+
+    // --- THE DOOR -------------------------------------------------------------
+    //
+    // `DevToolsCommandDuration` absorbs page script that runs INSIDE a protocol
+    // command. Which door the driver uses therefore decides whether `taskNet`
+    // is a frame-only reading or an honest one, and the rows here disagree
+    // about the door: `M1`, `bulk300`, `bulk100` and `narrow` drive the
+    // operation through `page.evaluate` (`Runtime.callFunctionOn`), while
+    // `keystroke` drives it through `page.keyboard.press` (the Input domain).
+    //
+    // Two numbers settle it per row, and neither needs the other harness:
+    //
+    //   * whether `devtools` TRACKS the arm. If it carries the arm's script it
+    //     must move with the arm; if it is only the protocol's round trip it is
+    //     roughly constant across arms that differ by milliseconds of work.
+    //   * what `ScriptDuration` reads. The renderer's own script counter does
+    //     not see script run through a protocol command either, so a row whose
+    //     script is being absorbed reports a mount of 901 elements as costing
+    //     hundredths of a millisecond of script.
+    {
+      const armsIn = (row) => Object.keys(row.decomposition).filter((k) => !k.endsWith('/plumb'));
+      const per = (sel) =>
+        mean(
+          runs.map(({ row }) => {
+            const vals = armsIn(row).map((k) => sel(row.decomposition[k]));
+            return Math.max(...vals) - Math.min(...vals);
+          })
+        );
+      const scriptMax = mean(
+        runs.map(({ row }) => Math.max(...armsIn(row).map((k) => row.decomposition[k].script / row.decomposition[k].n)))
+      );
+      const dvSpread = per((d) => d.devtools / d.n);
+      const ipSpread = per((d) => d.taskNet / d.n); // stand-in scale for "how much arms differ"
+      console.log('');
+      console.log(
+        `;;   THE DOOR — devtools spread across arms ${fmt(dvSpread, 3)} ms; largest ScriptDuration on any arm ` +
+          `${fmt(scriptMax, 4)} ms. ` +
+          (scriptMax < 0.2
+            ? `ScriptDuration sees essentially NOTHING, so the operation ran inside a protocol command and ` +
+              `taskNet on this row is FRAME-ONLY.`
+            : `ScriptDuration SEES the arms' work, so the operation did not run inside a protocol command and ` +
+              `taskNet on this row was never corrupted.`) +
+          `  (taskNet spread ${fmt(ipSpread, 3)} ms, for scale)`
+      );
+    }
+
+    // --- THE ADDITIVE RESIDUAL ------------------------------------------------
+    const ctlMeans = runs.map(({ row }) => (row.ctlTask ? row.ctlTask.measured.mean : NaN)).filter(Number.isFinite);
+    if (ctlMeans.length) {
+      const r = mean(ctlMeans);
+      const cOverW = (2 - r) / (r - 1);
+      const floorTared = mean(
         runs.map(({ row }) => {
-          const vals = armsIn(row).map((k) => sel(row.decomposition[k]));
-          return Math.max(...vals) - Math.min(...vals);
+          const f = p50(
+            SEGMENTS.map((s) => {
+              const d = row.decomposition[`${s}/floor`];
+              return d ? d.task / d.n : NaN;
+            }).filter(Number.isFinite)
+          );
+          const pl = p50(
+            SEGMENTS.map((s) => {
+              const d = row.decomposition[`${s}/plumb`];
+              return d ? d.task / d.n : NaN;
+            }).filter(Number.isFinite)
+          );
+          return f - pl;
         })
       );
-    const scriptMax = mean(
-      runs.map(({ row }) => Math.max(...armsIn(row).map((k) => row.decomposition[k].script / row.decomposition[k].n)))
-    );
-    const dvSpread = per((d) => d.devtools / d.n);
-    const ipSpread = per((d) => d.taskNet / d.n); // stand-in scale for "how much arms differ"
-    console.log('');
-    console.log(
-      `;;   THE DOOR — devtools spread across arms ${fmt(dvSpread, 3)} ms; largest ScriptDuration on any arm ` +
-        `${fmt(scriptMax, 4)} ms. ` +
-        (scriptMax < 0.2
-          ? `ScriptDuration sees essentially NOTHING, so the operation ran inside a protocol command and ` +
-            `taskNet on this row is FRAME-ONLY.`
-          : `ScriptDuration SEES the arms' work, so the operation did not run inside a protocol command and ` +
-            `taskNet on this row was never corrupted.`) +
-        `  (taskNet spread ${fmt(ipSpread, 3)} ms, for scale)`
-    );
+      // floorTared = W + c, so W = floorTared / (1 + c/W) and c = W * (c/W).
+      const W = floorTared / (1 + cOverW);
+      console.log('');
+      console.log(
+        `;;   ADDITIVE RESIDUAL — ctl-2x reads ${fmt(r, 4)}x where the page it builds is exactly 2.00x. ` +
+          `Inverting (2W+c)/(W+c): c/W = ${fmt(cOverW, 3)}, and with the floor's tared absolute at ` +
+          `${fmt(floorTared, 3)} ms that is W = ${fmt(W, 3)} ms of page-proportional work and ` +
+          `c = ${fmt(floorTared - W, 3)} ms that the plumb tare does not remove.`
+      );
+    }
   }
 
-  // --- THE ADDITIVE RESIDUAL ------------------------------------------------
-  const ctlMeans = runs.map(({ row }) => (row.ctlTask ? row.ctlTask.measured.mean : NaN)).filter(Number.isFinite);
-  if (ctlMeans.length) {
+  console.log('');
+  console.log(';; ==== CROSS-ROW: is the residual the same constant everywhere? ====');
+  console.log(';; row        ctl-2x(task)   implied c/W   implied c ms   floor tared ms');
+  for (const rowId of rowIds) {
+    const runs = datasets.map(({ data }) => data.rows.find((r) => r.rowId === rowId)).filter(Boolean);
+    const ctlMeans = runs.map((row) => (row.ctlTask ? row.ctlTask.measured.mean : NaN)).filter(Number.isFinite);
+    if (!ctlMeans.length) {
+      console.log(`;; ${rowId.padEnd(11)} (no proportional control on this row)`);
+      continue;
+    }
     const r = mean(ctlMeans);
     const cOverW = (2 - r) / (r - 1);
     const floorTared = mean(
-      runs.map(({ row }) => {
-        const f = p50(
-          SEGMENTS.map((s) => {
-            const d = row.decomposition[`${s}/floor`];
-            return d ? d.task / d.n : NaN;
-          }).filter(Number.isFinite)
-        );
-        const pl = p50(
-          SEGMENTS.map((s) => {
-            const d = row.decomposition[`${s}/plumb`];
-            return d ? d.task / d.n : NaN;
-          }).filter(Number.isFinite)
-        );
+      runs.map((row) => {
+        const f = p50(SEGMENTS.map((s) => (row.decomposition[`${s}/floor`] ? row.decomposition[`${s}/floor`].task / row.decomposition[`${s}/floor`].n : NaN)).filter(Number.isFinite));
+        const pl = p50(SEGMENTS.map((s) => (row.decomposition[`${s}/plumb`] ? row.decomposition[`${s}/plumb`].task / row.decomposition[`${s}/plumb`].n : NaN)).filter(Number.isFinite));
         return f - pl;
       })
     );
-    // floorTared = W + c, so W = floorTared / (1 + c/W) and c = W * (c/W).
     const W = floorTared / (1 + cOverW);
-    console.log('');
     console.log(
-      `;;   ADDITIVE RESIDUAL — ctl-2x reads ${fmt(r, 4)}x where the page it builds is exactly 2.00x. ` +
-        `Inverting (2W+c)/(W+c): c/W = ${fmt(cOverW, 3)}, and with the floor's tared absolute at ` +
-        `${fmt(floorTared, 3)} ms that is W = ${fmt(W, 3)} ms of page-proportional work and ` +
-        `c = ${fmt(floorTared - W, 3)} ms that the plumb tare does not remove.`
+      `;; ${rowId.padEnd(11)} ${fmt(r, 4).padStart(11)} ${fmt(cOverW, 3).padStart(13)} ${fmt(floorTared - W, 3).padStart(14)} ${fmt(floorTared, 3).padStart(16)}`
     );
   }
-}
 
-console.log('');
-console.log(';; ==== CROSS-ROW: is the residual the same constant everywhere? ====');
-console.log(';; row        ctl-2x(task)   implied c/W   implied c ms   floor tared ms');
-for (const rowId of rowIds) {
-  const runs = datasets.map(({ data }) => data.rows.find((r) => r.rowId === rowId)).filter(Boolean);
-  const ctlMeans = runs.map((row) => (row.ctlTask ? row.ctlTask.measured.mean : NaN)).filter(Number.isFinite);
-  if (!ctlMeans.length) {
-    console.log(`;; ${rowId.padEnd(11)} (no proportional control on this row)`);
-    continue;
-  }
-  const r = mean(ctlMeans);
-  const cOverW = (2 - r) / (r - 1);
-  const floorTared = mean(
-    runs.map((row) => {
-      const f = p50(SEGMENTS.map((s) => (row.decomposition[`${s}/floor`] ? row.decomposition[`${s}/floor`].task / row.decomposition[`${s}/floor`].n : NaN)).filter(Number.isFinite));
-      const pl = p50(SEGMENTS.map((s) => (row.decomposition[`${s}/plumb`] ? row.decomposition[`${s}/plumb`].task / row.decomposition[`${s}/plumb`].n : NaN)).filter(Number.isFinite));
-      return f - pl;
-    })
-  );
-  const W = floorTared / (1 + cOverW);
-  console.log(
-    `;; ${rowId.padEnd(11)} ${fmt(r, 4).padStart(11)} ${fmt(cOverW, 3).padStart(13)} ${fmt(floorTared - W, 3).padStart(14)} ${fmt(floorTared, 3).padStart(16)}`
-  );
+  return 0;
 }
 
 function shortName(f) {
   const m = /([^/\\]+)\.json$/.exec(f);
   return m ? m[1] : f;
+}
+
+module.exports = { adjudicated, reportable };
+
+// Requiring this file must not run it: `clock_exit_path.test.cjs` drives the
+// two predicates above directly, which it cannot do if the module body reads
+// argv and exits.
+if (require.main === module) {
+  const code = main(process.argv.slice(2));
+  if (code !== 0) process.exit(code);
 }

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
@@ -1732,8 +1732,12 @@ function report(out) {
  *   rowId             the row's id, as printed
  *   ctlOk             its positive control saw the change its arithmetic predicts
  *   ctlNote           the parenthetical a control refusal prints, if any
- *   adjudicable       at least one PUBLISHED bar carries a band
- *   unadjudicatedWhy  why it does not, in the adjudicator's own words
+ *   adjudicable       EVERY published bar carries a band, and there is at least
+ *                     one — derived by `rowAdjudication`, below, which is where
+ *                     the rule can be driven
+ *   barCount          how many bars the row published
+ *   unadjudicatedBars the ones carrying no band, by name
+ *   unadjudicatedWhy  why they do not, in the adjudicator's own words
  *
  * EXIT 1 HERE IS PER-ROW, AND THE ROWS THAT PASSED ARE STILL ROWS. Reaching
  * this point means every whole-run gate cleared on every row; these two are
@@ -1761,7 +1765,7 @@ function reportability(rows, opts) {
       );
     }
   }
-  // AND A ROW MAY HAVE NO ADJUDICABLE BAR AT ALL (rf2-y7mw7). This is a
+  // AND A ROW MAY HAVE A BAR IT CANNOT ADJUDICATE (rf2-y7mw7). This is a
   // different claim from the control's and it used to reach nothing: the
   // driver labelled every bar on such a row UNADJUDICATED four hundred lines
   // above, then exited 0 because the control had passed. A control that
@@ -1769,14 +1773,28 @@ function reportability(rows, opts) {
   // magnitude is adjudicated AGAINST, and a driver that cannot adjudicate a
   // figure may not announce it. Refused after the control and never instead
   // of it — a row can fail both, and both are said.
+  //
+  // ONE unadjudicated bar is enough, and #7489's audit is why that is spelled
+  // out here: the first repair refused only a row on which NO bar carried a
+  // band, so a row publishing three bars of which one had none was reportable
+  // and the run exited 0 saying "every published bar adjudicated". The
+  // sentence below is the contract; `rowAdjudication` is now the only place
+  // that decides whether a row meets it.
   if (unadjudicated.length > 0) {
     lines.push(
-      `[clock] FAILED: no published bar can be ADJUDICATED on: ` +
-        `${unadjudicated.map((r) => r.rowId).join(', ')}. The row has a magnitude and nothing to tell it ` +
-        `from parity, so no figure from it is reportable — a passing control is not a band:`
+      `[clock] FAILED: not every published bar can be ADJUDICATED on: ` +
+        `${unadjudicated.map((r) => r.rowId).join(', ')}. The row publishes a bar with nothing to tell it ` +
+        `from parity, so no figure from that row is reportable — a passing control is not a band:`
     );
     for (const r of unadjudicated) {
-      lines.push(`[clock]   ${r.rowId}: ${r.unadjudicatedWhy || 'no proportional control on this row'}`);
+      // Which bars, when the caller knows: on a row whose bars disagree, the
+      // first one's `why` printed alone reads as though it were the row's.
+      const which =
+        r.unadjudicatedBars && r.unadjudicatedBars.length > 0
+          ? `${r.unadjudicatedBars.length} of ${r.barCount} published bars carry no band ` +
+            `(${r.unadjudicatedBars.join(', ')}) — `
+          : '';
+      lines.push(`[clock]   ${r.rowId}: ${which}${r.unadjudicatedWhy || 'no proportional control on this row'}`);
     }
   }
   if (ctlFailed.length === 0 && unadjudicated.length === 0) return { code: 0, lines };
@@ -1788,6 +1806,47 @@ function reportability(rows, opts) {
       : `[clock] REPORTABLE: none.`
   );
   return { code: 1, lines };
+}
+
+/**
+ * THE ROW'S HALF OF THE DECISION, derived where it can be driven.
+ *
+ * `reportability` takes `adjudicable` as a boolean, so until this function
+ * existed the rule that PRODUCED that boolean lived inline in `main` — the one
+ * place in this driver a unit test cannot reach, because getting there needs
+ * an `:advanced` build and a headless Chromium. The only thing holding it was
+ * a regex over the source, and #7489's merged-PR audit found that what the
+ * regex was holding was wrong: `unadj.length < names.length` made ONE
+ * adjudicated bar carry a row whose other bars had no band at all, and the run
+ * then exited 0 announcing "every published bar adjudicated".
+ *
+ * The rule is the strict one that sentence has always claimed — a nonempty bar
+ * set, and NO bar without a band. It matters even though nothing generates a
+ * mixed row today: `seam.assess` sets `unadjudicated` from a single row-wide
+ * `unavailable`, so every bar set this driver currently produces is uniform and
+ * the strict rule and the loose one agree. That agreement is incidental. The
+ * datasets outlive the assessor that wrote them, `clock_readjudicate.cjs` reads
+ * them back years later, and a fail-closed contract that holds only by
+ * coincidence of an unrelated function is not a contract.
+ *
+ * `bars` is `seamTask.rows` — `{barName: {unadjudicated, why, ...}}`, the same
+ * object the report printed and the dataset stored, never a recomputation.
+ */
+function rowAdjudication(bars) {
+  const src = bars || {};
+  const names = Object.keys(src);
+  const unadjudicatedBars = names.filter((n) => src[n].unadjudicated);
+  return {
+    // Fail closed on a row that adjudicated no bar at all, too: an empty
+    // verdict is an absent one, not a clean one.
+    adjudicable: names.length > 0 && unadjudicatedBars.length === 0,
+    barCount: names.length,
+    unadjudicatedBars,
+    unadjudicatedWhy:
+      unadjudicatedBars.length > 0
+        ? src[unadjudicatedBars[0]].why
+        : 'the run adjudicated no bar on this row at all',
+  };
 }
 
 /**
@@ -1818,7 +1877,7 @@ function reportabilitySelfTest() {
   );
   check(
     'and the refusal NAMES the row and the adjudicator\'s own reason',
-    /no published bar can be ADJUDICATED on: keystroke/.test(unadj.lines[0] || '') &&
+    /not every published bar can be ADJUDICATED on: keystroke/.test(unadj.lines[0] || '') &&
       unadj.lines.some((l) => l.includes(KEYSTROKE_WHY)),
     unadj.lines.join(' | ')
   );
@@ -1861,13 +1920,84 @@ function reportabilitySelfTest() {
     'a row that fails BOTH is refused for both — neither verdict masks the other',
     both.code === 1 &&
       both.lines.some((l) => l.includes('the positive control did not see the change')) &&
-      both.lines.some((l) => l.includes('no published bar can be ADJUDICATED')),
+      both.lines.some((l) => l.includes('not every published bar can be ADJUDICATED')),
     both.lines.join(' | ')
   );
 
   const empty = reportability([]);
   check('a run that took no rows is not a refusal', empty.code === 0 && empty.lines.length === 0);
   check('and neither is one that never ran', reportability(undefined).code === 0);
+
+  // THE RULE THAT PRODUCES `adjudicable`, which #7489's audit found was the
+  // loose one while the sentence above it claimed the strict one. Driven here
+  // over the bar object `seam.assess` actually writes, because the fault was
+  // never in `reportability` — it was in what `main` handed it.
+  const bar = (unadjudicated, why) => ({ unadjudicated, why: why || null });
+  const ADJ = bar(false);
+  const UNADJ = bar(true, KEYSTROKE_WHY);
+
+  const allAdj = rowAdjudication({ 'hicasso / reagent-subs': ADJ, 'hicasso / uix-subs': ADJ });
+  check(
+    'a row whose every bar carries a band is adjudicable',
+    allAdj.adjudicable === true && allAdj.barCount === 2 && allAdj.unadjudicatedBars.length === 0,
+    JSON.stringify(allAdj)
+  );
+
+  const mixedBars = rowAdjudication({
+    'hicasso / reagent-subs': ADJ,
+    'hicasso / uix-subs': UNADJ,
+    'uix-subs / reagent-subs': ADJ,
+  });
+  check(
+    'THE REMAINDER: ONE unadjudicated bar makes the whole row unadjudicable, ' +
+      'even with two adjudicated beside it',
+    mixedBars.adjudicable === false,
+    JSON.stringify(mixedBars)
+  );
+  check(
+    'and the mixed row names WHICH bar has no band, rather than the first reason alone',
+    mixedBars.barCount === 3 &&
+      mixedBars.unadjudicatedBars.length === 1 &&
+      mixedBars.unadjudicatedBars[0] === 'hicasso / uix-subs' &&
+      mixedBars.unadjudicatedWhy === KEYSTROKE_WHY,
+    JSON.stringify(mixedBars)
+  );
+  const mixedLines = reportability([
+    row({}),
+    row({ rowId: 'keystroke', ...mixedBars }),
+  ]);
+  check(
+    'a mixed row refuses the run, and the refusal counts the bars it is about',
+    mixedLines.code !== 0 &&
+      mixedLines.lines.some((l) => l.includes('1 of 3 published bars carry no band (hicasso / uix-subs)')),
+    mixedLines.lines.join(' | ')
+  );
+  check(
+    'and the mixed row never appears in REPORTABLE while the clean row still does',
+    /REPORTABLE: M1 —/.test(mixedLines.lines[mixedLines.lines.length - 1]) &&
+      !/keystroke/.test(mixedLines.lines[mixedLines.lines.length - 1]),
+    mixedLines.lines[mixedLines.lines.length - 1]
+  );
+
+  const allUnadj = rowAdjudication({ 'hicasso / reagent-subs': UNADJ, 'hicasso / uix-subs': UNADJ });
+  check(
+    'a row whose every bar is UNADJUDICATED is still unadjudicable — the strict rule ' +
+      'did not lose the case the loose one caught',
+    allUnadj.adjudicable === false && allUnadj.unadjudicatedBars.length === 2,
+    JSON.stringify(allUnadj)
+  );
+  const noBars = rowAdjudication({});
+  check(
+    'a row that published no bar at all fails closed, and says so in its own words',
+    noBars.adjudicable === false &&
+      noBars.barCount === 0 &&
+      noBars.unadjudicatedWhy === 'the run adjudicated no bar on this row at all',
+    JSON.stringify(noBars)
+  );
+  check(
+    'and a verdict that went missing entirely is absent, not clean',
+    rowAdjudication(undefined).adjudicable === false && rowAdjudication(null).adjudicable === false
+  );
 
   return { checks };
 }
@@ -2277,19 +2407,16 @@ async function main() {
       // THE ADJUDICATION OF THE PUBLISHED CLOCK, read off the same object the
       // report printed and the dataset stored — not recomputed here, because a
       // second computation is a second decision.
-      const bars = (o.verdict.seamTask && o.verdict.seamTask.rows) || {};
-      const names = Object.keys(bars);
-      const unadj = names.filter((n) => bars[n].unadjudicated);
       return {
         rowId: o.out.rowId,
         ctlOk: !(ctlBad(o) || (o.verdict.etVerdict && !o.verdict.etVerdict.ok)),
         ctlNote: o.verdict.ctl3
           ? ` (three-point ${o.verdict.ctl3.measured.mean.toFixed(4)}x vs ${o.verdict.ctl3.predicted}x)`
           : '',
-        // Fail closed on a row that adjudicated no bar at all: an empty
-        // verdict is an absent one, not a clean one.
-        adjudicable: names.length > 0 && unadj.length < names.length,
-        unadjudicatedWhy: unadj.length > 0 ? bars[unadj[0]].why : 'the run adjudicated no bar on this row at all',
+        // THE BAR-LEVEL RULE HAS ONE SEAT TOO (`rowAdjudication`, above), for
+        // the reason the run-level one does: a rule written out here is a rule
+        // no test can drive.
+        ...rowAdjudication(o.verdict.seamTask && o.verdict.seamTask.rows),
       };
     }),
     { sabotage: CTL3_SABOTAGE }
@@ -2299,7 +2426,7 @@ async function main() {
   console.error('[clock] ok');
 }
 
-module.exports = { reportability, reportabilitySelfTest };
+module.exports = { reportability, rowAdjudication, reportabilitySelfTest };
 
 if (require.main === module) {
   main();


### PR DESCRIPTION
Closes the remainder that #7489's merged-PR audit reopened `rf2-y7mw7` for.

## The audit's remainder, verbatim

> The fix correctly closes the concrete "every bar UNADJUDICATED" path, but the new fold does not implement its own stronger contract. `clock_run.cjs` sets `adjudicable` with `names.length > 0 && unadj.length < names.length`, and `clock_readjudicate.cjs` uses `names.some(!unadjudicated)`: one adjudicated bar therefore makes a row reportable even when another published bar is UNADJUDICATED. The driver then exits 0 and says "every published bar adjudicated," and the readjudicator admits that run into the reportable subset for every pair, including the unadjudicated one. Current `seam.assess` makes availability row-wide, so today's generated rows are uniform, but the persisted-data reader and advertised fail-closed contract must not rely on that incidental coupling. Require a nonempty bar set and zero unadjudicated bars in both places, and add the missing mixed-bar fixture/mutation proof.

## What changed

Both places now require a nonempty bar set **and zero unadjudicated bars**.

| | before | after |
|---|---|---|
| `clock_run.cjs` | `names.length > 0 && unadj.length < names.length` | `names.length > 0 && unadjudicatedBars.length === 0` |
| `clock_readjudicate.cjs` | `names.length > 0 && names.some((n) => !bars[n].unadjudicated)` | `names.length > 0 && names.every((n) => !bars[n].unadjudicated)` |

**And both rules moved to where a test can reach them, which is why the audit had to find this rather than a gate.** In `clock_run.cjs` the rule lived inline in `main` — reachable only through an `:advanced` build and a headless Chromium — so the only thing checking it was a regex over the driver's own source, and that regex held the *loose* rule exactly as faithfully as it would have held the right one. In `clock_readjudicate.cjs` the predicate was a closure inside a loop in a file that read `process.argv` at module scope and exited, so requiring it ran it and nothing could drive it at all. They are pure exported functions now — `rowAdjudication` and `adjudicated`/`reportable` — following the same extraction #7489 used for `reportability`. The readjudicator's script body is wrapped in `main(argv)` behind a `require.main === module` guard; that is the whole of its large diff, and `git diff -w` reduces it to 122 lines.

The refusal sentence changed with the rule, because a row with two adjudicated bars and one without is not a row on which "no published bar can be ADJUDICATED":

```
[clock] FAILED: not every published bar can be ADJUDICATED on: keystroke. The row publishes a
        bar with nothing to tell it from parity, so no figure from that row is reportable —
        a passing control is not a band:
[clock]   keystroke: 1 of 3 published bars carry no band (h / u) — UNADJUDICATED — ...
[clock] REPORTABLE: none.
```

**One thing beyond the audit's two lines, in the same file and the same defect class.** The readjudicator's printed per-pair verdict column derived from row-wide `bandTask` while the subset predicate derived per bar, so a row whose bars disagreed would print `clears its 21.4% band` for the very bar the same program had just refused for carrying no band — this bead's own complaint (a column and a decision disagreeing about one run) pointing the other way. The column reads the per-bar record now. The message string is deliberately unchanged so published output stays byte-identical.

## Mutation proof, both directions, including breaking the fix

`clock_run.cjs`, on a row publishing three bars of which one has no band:

| | `adjudicable` | exit code | report still prints |
|---|---|---|---|
| this PR | `false` | **1**, naming the row and the bar | `UNADJ` |
| fix reverted to `< names.length` | `true` | **0** | `UNADJ` |

The broken column is the fail-open verbatim: exit 0 while the driver's own table prints `UNADJ` for a bar in the run it just called reportable.

`clock_readjudicate.cjs`, same shape, driven through the real dataset reader on a copy of the retained `clock-0qj9w/run1.json` with one bar's `unadjudicated` flipped:

| dataset | HEAD (before this PR) | this PR |
|---|---|---|
| every bar adjudicated | pooled — `control-passing subset 1.0886x n=1` | pooled, identical |
| **one bar of three unadjudicated** | **pooled for all three pairs, including the unadjudicated one** | `control-passing subset: NONE` |
| every bar unadjudicated | `NONE` | `NONE` |

The middle row is the audit's sentence reproduced end-to-end on real data. The first row is there because a gate that only ever refuses proves nothing: it confirms the strict rule still admits a genuinely clean run.

## What did not change

- **No measurement, no arm, no threshold, no exit code, nothing under `data/`.** Re-running `clock_readjudicate.cjs` over the retained `clock-0qj9w/run1.json` + `run2.json` produces output **byte-identical** to `HEAD`'s, verified by `diff` before and after the display-column change.
- **`unadjudicated` is still ADDED to the control's decision, never substituted.** A row failing both is refused for both, and both sentences are printed — pinned by `a row that fails BOTH is refused for both` in the driver's fixtures and `neither verdict masks the other` in the harness. In the readjudicator, `the OTHER two terms are unchanged` drives the failed control and both band ceilings against a fully adjudicated row.
- **No refusal suppresses output.** The decision is still built from the object the report printed and the dataset stored, still taken in one seat, and still consulted only after every table and raw artefact is written.

## Quality gates

| gate | exit | notes |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | GATE_FASTPR | |
| `npm run lint:js` (repo root) | GATE_LINT | required on a `.cjs` diff; the spine does not run it |
| `npm run test:script-helpers` | GATE_HELPERS | the chained JS harness gate that carries `clock_exit_path.test.cjs` |
| `node clock_exit_path.test.cjs` | GATE_EXITPATH | **86 passed** (79 before) |
| `node clock_run.cjs --selftest` | GATE_SELFTEST | **ALL ADJUDICATORS OK** |

`--selftest` check counts, before and after:

| | `HEAD` | this PR |
|---|---|---|
| guard | 12 | 12 |
| seam | 17 | 17 |
| **exit (the decision's own fixtures)** | **11** | **19** |
| gated total (`g + s + x`) | 40 | 48 |
| grand total incl. always-on ctl3 (11) + keystroke witness (20) | 71 | 79 |

Docs are untouched. The blob-hash provenance table in `rows-re-adjudicated-on-the-corrected-clock.md` records the version each published ensemble was *run at* and was already stale for both clock files before this PR, so it is correctly left alone.
