### PR TITLE
docs(hicasso): the bar reads the same at all four sites (rf2-0zj4r)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -519,6 +519,34 @@ adapter *registry*; overruled for the one-declaration-one-identity grain.
 
 ## HD-012 — The bar, and UIx's role in it
 
+> **Addendum, 2026-08-05 — the bar is PER-AXIS: the mount denominator moved to
+> UIx, the bulk denominator did not (`rf2-hyd50`).** The ruling below states
+> mount and bulk under a single Reagent-denominated number. That is superseded
+> **on the mount axis only**. The operative bar, as the operator-owned standard
+> `rf2-2rtt6.1` carries it:
+>
+> - **Mount** — **≤ 1.10× direct UIx-on-subs**, canonical `M1`,
+>   floor-normalised, on the clock of record (raw `TaskDuration`, script **and**
+>   frame). Reagent-on-subs stays co-instrumented and is **reported beside the
+>   mount row, not gating it**.
+> - **Bulk** — **≤ 1.0× Reagent-on-subs, like-for-like** — unchanged.
+>
+> **What stands, so the conflict cannot be re-derived.** Everything else in the
+> ruling below: the clock-only ship *number*, browser-only figures, memory
+> governing through the kill rules rather than the ship number, UIx as the
+> mandatory co-instrumented comparator, the 1.5× bulk architecture-kill
+> tripwire, K3, the heap gates and the red-zone ratios. Only the mount
+> denominator moved; every other number stands as written, Reagent-denominated
+> where written.
+>
+> **Provenance.** The operator relaxed "as fast as Reagent on mount" on
+> **2026-08-01** (`rf2-2rtt6.1`): "`mount M1 ≤ 1.0× Reagent-on-subs` is no
+> longer the bar". The **2026-08-02** mount-gate amendment set the replacement
+> as one line and **retired** the old pair rather than restating it. `rf2-hyd50`
+> adjudicated the two texts on **2026-08-05** — delegated and
+> **operator-overturnable**; if that ruling is overturned, this addendum reverts
+> with it.
+
 **Ruling.** Ship bar: mount and bulk view-work **≤ 1.0× Reagent on the clock**,
 like-for-like on re-frame2 subscriptions — the ship *number* is clock only,
 matching the locked ruling. **Every bar and kill number is a browser number** —

--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -6,6 +6,25 @@ as HD-nnn are normative in [decisions.md](decisions.md).
 
 ## The bar (HD-012)
 
+> **Amended, 2026-08-05 — the ship bar is PER-AXIS, and the first bullet below
+> is superseded on the mount axis (`rf2-hyd50`).** "Mount AND bulk view-work ≤
+> 1.0× Reagent" is no longer the mount bar. The operative pair, clock only:
+>
+> - **Ship bar (clock), mount**: **≤ 1.10× direct UIx-on-subs**, canonical `M1`,
+>   floor-normalised, clock of record raw `TaskDuration` (script **and** frame).
+>   The only ship *number* on this axis. Reagent-on-subs is co-instrumented and
+>   **reported beside the mount row, not gating it**.
+> - **Ship bar (clock), bulk**: **≤ 1.0× Reagent-on-subs, like-for-like** — both
+>   sides reading re-frame2 subscriptions — on the witness shapes. The only ship
+>   *number* on this axis. **Unchanged.**
+>
+> Every other bullet in this section stands as written: memory through the kill
+> rules, the UIx comparator and its red-zone ratios, and the 1.5× bulk
+> architecture-kill tripwire. Provenance: the operator's **2026-08-01**
+> relaxation of "as fast as Reagent on mount" and the **2026-08-02** mount-gate
+> amendment, both on `rf2-2rtt6.1`, adjudicated on **2026-08-05** by `rf2-hyd50`
+> — delegated and operator-overturnable, so this note reverts with that ruling.
+
 - **Ship bar (clock)**: mount AND bulk view-work **≤ 1.0× Reagent,
   like-for-like** — both sides reading re-frame2 subscriptions — on the witness
   shapes. The only ship *number*.
@@ -263,8 +282,9 @@ verdict's direction stands; its published magnitude was a property of the stale
 spine and the demoted clock. Full tables and provenance:
 [the re-take on the current tree](studio/hd8-composed-donor-arm.md#the-re-take-on-the-current-tree-rf2-2rtt631).
 
-Given continuation, the win conditions are (1) mount ≤ 1.0× Reagent-on-subs, same
-run and same instrument, with the codec inside 1.10× of direct UIx `$` on `M1`;
+Given continuation, the win conditions are (1) mount ≤ 1.10× direct UIx `$` on
+canonical `M1`, floor-normalised, on the clock of record — with Reagent-on-subs
+co-instrumented and reported beside that row rather than gating it;
 (2) bulk broad ≤ 1.0× Reagent, red below UIx's measured broad ratio, K2 at 1.5×;
 (3) narrow as a **law** rather than a ratio — commit-side dirty-set flat in `B`
 across 300/600/1,200/2,400 mounted subscribing boundaries, and ≤ 1.0× Reagent,
@@ -272,6 +292,15 @@ materially below UIx's measured narrow ratio; (4) grouped per-read retained heap
 ≤ ≈2,000 B/read on the bench instrument, with a named paper path toward 943 B;
 and (5) a measured ergonomic preference over **Adapter-Prime**, never over the
 floor. The nine pre-registered kill signals are on `rf2-2rtt6.7`.
+
+**Win condition (1) was amended on 2026-08-05 (`rf2-hyd50`); the pair it
+replaced is retired, not restated.** The clause read, verbatim: `mount ≤ 1.0×
+Reagent-on-subs, same run and same instrument, with the codec inside 1.10× of
+direct UIx $ on M1`. Those two halves are arithmetically unsatisfiable
+post-parity — 1.0243 × 1.10 = 1.127, so **they cannot both be met** (2026-07-31
+provisional, `rf2-2rtt6.1`) — and the operator's 2026-08-01 relaxation resolved
+it by dropping the Reagent half, not by tightening the UIx one. Conditions
+(2)–(5) are untouched and stay Reagent-denominated where written.
 
 **The advisory named one precondition, and it is now met.** The clock gate lines
 carried no post-landing restatement when the advisory was issued — the M1 mount
@@ -554,7 +583,7 @@ comparison this section schedules was originally written as
 
 | # | Kill if |
 |---|---|
-| K1 | Mount > Reagent on the reference list+form after two serious runtime iterations |
+| K1 | Mount above the amended mount gate (1.10× direct UIx on the clock of record) after two serious runtime iterations |
 | K2 | Bulk (≥ ~100 boundaries, one commit) > 1.5× Reagent view work after those iterations |
 | K3 | Per-boundary heap worse than Reagent with no paper path to the floor |
 | K4 | Controlled text fails same-tick echo / IME on Chromium and WebKit for a simple form |
@@ -562,6 +591,18 @@ comparison this section schedules was originally written as
 | K7 | Six weeks (HD-014) with no path that is both preferable and ≤ Reagent on K1–K2 |
 
 Red gates shrink scope; they never expand features.
+
+**K1's denominator was amended — mount-gate amendment 2026-08-02, consistency
+edit 2026-08-05 (`rf2-hyd50`).** Its row read, verbatim: `Mount > Reagent on the
+reference list+form after two serious runtime iterations`. That is the same
+stale Reagent denominator the operator relaxed on 2026-08-01, and **there is no
+second mount condition in play**: the mount gate is one line, and
+Reagent-on-subs is co-instrumented and reported beside the mount row rather than
+gating it. **K1 itself stands** — only its trigger is restated, and it still
+bites, on the amended denominator. A Reagent-denominated mount kill, if one is
+ever wanted, must be stated **as a kill** in this table; the 2026-08-02
+amendment rejected carrying one implicitly, on the ground that it would undo the
+operator's explicit relaxation. K2, K3, K4, K6 and K7 are untouched.
 
 **K5 was removed as an operative kill criterion — operator ruling, 2026-08-04.**
 Its row read, verbatim: `> ~8 public concepts or > ~8 guide pages to ship CRUD`.


### PR DESCRIPTION
Executes the `rf2-hyd50` adjudication (2026-08-05, delegated,
**operator-overturnable**) and the doc action the 2026-08-02 mount-gate amendment
on `rf2-2rtt6.1` named but explicitly did not perform ("a bounded consistency
edit to the stale HD-012/validation.md Reagent-parity wording (docs follow-up,
not performed here)"). `rf2-hvl5s` did not cover this — it was component-budget
rows only (PR #7319).

**The bar being restated, per-axis:** mount ≤ 1.10× direct UIx-on-subs, canonical
`M1`, floor-normalised, clock of record raw `TaskDuration` (script **and**
frame), with Reagent-on-subs co-instrumented and reported beside the mount row
rather than gating it; bulk ≤ 1.0× Reagent-on-subs like-for-like, **unchanged**.

These four records are what the P2/graduation sitting reads. A bar stated four
ways is four bars, and the failure mode is not confusion — it is that a reader
lands on whichever statement is nearest and treats it as the criterion. After
this PR the four sites say one thing.

## The four sites

| # | Site | Shape of the edit |
|---|---|---|
| 1 | `decisions.md` — `## HD-012 — The bar, and UIx's role in it` | Dated addendum inserted after the heading; the Ruling text below is **untouched and still visible**, named as superseded on the mount axis only |
| 2 | `validation.md` — `## The bar (HD-012)` | Dated amendment inserted after the heading, carrying the per-axis pair; the stale first bullet is **untouched and still visible**, named as superseded |
| 3 | `validation.md` — win condition (1) | Clause replaced in place (the conjunctive pair is the *retired* pair); the original is frozen **verbatim** in a dated note directly below |
| 4 | `validation.md` — K1 row in `## Kill criteria` | Trigger restated on the amended denominator; the original row frozen **verbatim** in a dated note below, beside the existing K5 note |

Sites 1 and 2 are pure insertions — no surrounding prose was rewritten. Sites 3
and 4 replace exactly one clause and one table cell respectively, and both freeze
the superseded text verbatim (EP-0009 rules 2 and 3: freeze meaning, not bytes).

The house idiom was followed **per site** rather than imposed uniformly:
`decisions.md` uses `> **Addendum, <date> — …**` blockquotes after the heading
(HD-019, HD-018, HD-021); `validation.md` uses the same blockquote form in its
bar section and a bold dated paragraph for prose and kill-table changes — the
latter matching the existing **K5** note verbatim in shape ("Its row read,
verbatim: …").

## What a `rf2-hyd50` revert would need to touch

Mike still owes an acknowledgement on the `rf2-hyd50` per-axis ruling, and **a
revert instruction there reverts this edit with it**. The change was written so
that revert is clean — four self-contained, dated, individually locatable
passages, each naming `rf2-hyd50`:

1. `decisions.md` — the `> **Addendum, 2026-08-05 — the bar is PER-AXIS…**`
   blockquote under `## HD-012`. **Delete the blockquote; nothing else.**
2. `validation.md` — the `> **Amended, 2026-08-05 — the ship bar is PER-AXIS…**`
   blockquote under `## The bar (HD-012)`. **Delete the blockquote; nothing
   else.**
3. `validation.md` — win condition (1), plus the `**Win condition (1) was amended
   on 2026-08-05…**` paragraph below it. **Restore clause (1) from the verbatim
   quote inside that paragraph, then delete the paragraph.**
4. `validation.md` — the K1 table row, plus the `**K1's denominator was
   amended…**` paragraph below the table. **Restore the row from the verbatim
   quote inside that paragraph, then delete the paragraph.**

Every superseded text a revert needs is quoted verbatim inside the note that
supersedes it, so no revert has to consult git history.

## Out of scope, untouched

Bulk / narrow / heap rows, K2, K3, K4, K6, K7, the red-zone ratios, Surface B,
and the ~1.18× Reagent figure (a stated *consequence* of the codec ceiling, not a
gate — it is quoted only as a measurement row and stays labelled so). No heading
was added, renamed or removed, so no inbound link in the tree is affected.

## One residual inconsistency found, deliberately NOT fixed here

**K7 carries the same stale denominator and is outside this bead's four sites.**
Its row reads `Six weeks (HD-014) with no path that is both preferable and ≤
Reagent on K1–K2`. K1 is now UIx-denominated, so "≤ Reagent on **K1**–K2" no
longer names a live condition; the K2 half is still correct. The bead enumerates
four sites and lists K7 among those that stand, so changing it here would be a
governance act beyond the ruling. Filed as a follow-up bead rather than actioned.

## Quality gates

`mkdocs build --strict` is **not** a valid gate for this change and was not run:
`mkdocs.yml`'s `exclude_docs` block keeps `design/hicasso/` out of the site, so it
exits 0 having verified nothing.

- `python scripts/check_doc_slugs.py` — **exit 0**.
- `sh scripts/test-fast-pr.sh` — **exit 0**.

**Mutation proof that the slug gate actually covers these files** (it is
otherwise a fail-open instrument). A broken anchor link was inserted *inside the
new site-2 blockquote*, grep-confirmed present at `validation.md:12`
(`#zzz-0zj4r-mutation-probe-anchor-does-not-exist`) before the gate was read —
a mutation that does not apply proves nothing. The gate then **failed with exit
1**, naming the file and line:

```
1 broken anchor link(s) found:
  BROKEN ANCHOR: docs\design\hicasso\validation.md:12 -> #zzz-0zj4r-mutation-probe-anchor-does-not-exist
```

The probe was reverted and `git status` confirmed byte-identical to the committed
state, so no residue remains.

**Hand-verified, because nothing in CI validates tables or anchors here:**

- **Table column counts.** The only table touched is `## Kill criteria`. Counted
  by hand: header `| # | Kill if |`, separator, and all six data rows (K1, K2,
  K3, K4, K6, K7) each carry exactly **3 pipes = 2 columns**. The amended K1 cell
  introduces no pipe character. The budgets table and the measurement tables were
  not touched.
- **Anchors.** No heading added, renamed or removed in either file. Swept the
  tracked tree for inbound links to the two affected sections
  (`#the-bar-hd-012`, `#kill-criteria…`) — there are none; the only inbound links
  to `validation.md` target `#p1-gate--the-composed-donor-arm-hd-008`,
  `#the-clock-gates-restated-on-the-post-25-tree` and `#the-per-read-gates`, all
  untouched.
- No hardcoded paths: `git grep -n 'Users/miket'` over both files returns no
  hits.

Net line delta: **+72 / −3** across exactly the two files in scope.

Closes `rf2-0zj4r`.
