### PR TITLE
docs(testing): run the full Xray gate before merging a non-smoke scenario (rf2-bb822)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -81,7 +81,7 @@ One exception, and it is the exception that keeps the split honest (rf2-65ajl, r
 
 Ordinary Story/Xray runtime changes are untouched and keep the cheap smoke path; the nightly sweep remains the system of record for the full matrix.
 
-The Xray full matrix is deliberately **not** a third such exception. `test:xray-feature-gate:smoke` — a command the PR job already runs — loads and validates the whole of `tools/xray/testbeds/feature_matrix/scenarios.cjs`, so the file cannot merge unparsed; what runs nightly is the non-smoke *rows*, which is this policy working as designed rather than a hole in it. When adding an Xray scenario, tag it `smoke: true` only if it earns a slot on every PR **and** loads an already-staged smoke surface; everything else is nightly by default. The gate fails loud if the smoke set is ever empty.
+The Xray full matrix is deliberately **not** a third such exception. `test:xray-feature-gate:smoke` — a command the PR job already runs — loads and validates the whole of `tools/xray/testbeds/feature_matrix/scenarios.cjs`, so the file cannot merge unparsed; what runs nightly is the non-smoke *rows*, which is this policy working as designed rather than a hole in it. When adding an Xray scenario, tag it `smoke: true` only if it earns a slot on every PR **and** loads an already-staged smoke surface; everything else is nightly by default. A non-smoke scenario does not run again until that night, so before merging one that is new or materially changed, run the full gate locally with `cd implementation && npm run test:xray-feature-gate` and note the result in the PR. The gate fails loud if the smoke set is ever empty.
 
 ## Test authoring policy
 


### PR DESCRIPTION
One-line docs rider from the `rf2-rliq7` wontfix ruling (rf2-bb822).

`rf2-rliq7` was wontfixed on measurement: 12 of 17 Xray scenarios and 8 of 12 staged surfaces never execute at PR time, and promoting the full sweep per-PR was costed at roughly +70s warm / +302s cold for a benefit that 53 commits to `scenarios.cjs` over 10 weeks put at 3 commits — 5.7%. The tier split stays as designed, so this line adds the compensating courtesy the ruling asked for: the author runs the sweep locally on the change that could break it.

It reads as a normal courtesy rather than a warning, because the nightly is a working backstop now that its known flake is fixed (`rf2-7jevo`) and it has failure alerting (`rf2-6sg25`).

## The change

One sentence, added inside the existing Xray two-tier paragraph in `TESTING.md` — no new section, heading, or table row. 1 insertion, 1 deletion.

> everything else is nightly by default. **A non-smoke scenario does not run again until that night, so before merging one that is new or materially changed, run the full gate locally with `cd implementation && npm run test:xray-feature-gate` and note the result in the PR.** The gate fails loud if the smoke set is ever empty.

The command spelling is the bead's verified one. `implementation/package.json:71` confirms `test:xray-feature-gate` maps to `node scripts/serve-and-run-xray-feature-gate.cjs` with no per-row filter — only `--smoke` / `RF2_GATE_SMOKE=1` selects a subset — so there is deliberately no `--only <scenario>` form to offer.

## Quality gates

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | 0 |
| `python scripts/check_retired_composition_vocab.py --verbose` | 0 |
| `sh scripts/test-fast-pr.sh` | 1 — environmental, see below |

**On the spine's exit 1.** It ran foreground to completion and failed only in its last phase, `CLJS node integration`, with `compile-node-test: could not resolve shadow-cljs: Cannot find module 'shadow-cljs/cli/runner.js'`. `implementation/node_modules` is absent in this worktree because the change is docs-only and no `npm ci` was run, so that phase cannot resolve its compiler. Every earlier phase passed, including `mkdocs --strict build`, `docs corpus anchor validator`, `retired composition vocab`, `JVM implementation/core`, and the JS harness helpers. The commit changes one markdown line and cannot affect Node module resolution. CI covers the CLJS lane on this PR.

**Mutation proof.** The gate that actually covers this file is `scripts/check_retired_composition_vocab.py`, which `docs.yml` runs and which scans a root-support roster naming `TESTING.md` explicitly (rf2-2c8zq6). Appending a line carrying the retired architecture prose (`event-program`, `realm-routing`) to `TESTING.md`, grep-confirming it landed at line 274, then re-running the gate produced `live-retired:retired-architecture-prose: TESTING.md:274` and **exit 1**. Mutation reverted, working tree confirmed clean, committed edit re-confirmed present.

**A correction to the dispatch brief.** The brief stated that `scripts/check_doc_slugs.py` covers `TESTING.md`. It does not. `_iter_markdown` builds its roster from `DEFAULT_ROOTS` (`docs`, `spec`, `skills`, `migration`) plus `tools/*/spec`; `TESTING.md` sits at the repo root and is in none of them. Proved by mutation rather than by reading: a line carrying both a broken relative link (`docs/definitely-not-a-real-page-bb822.md`) and a broken in-page anchor (`#bb822-no-such-heading`) was appended and grep-confirmed at line 274, and the checker still exited **0**. Its green result above is therefore real but not evidence about this file. `mkdocs.yml` does not list `TESTING.md` either, so `mkdocs build --strict` is not a gate for it — root-level markdown link rot is currently ungated.

No table is adjacent to the edited paragraph (nearest is line 35), so no column-count hand-check applies; the change adds no link and no heading, so nothing anchor-shaped is at risk in any case.

## Companion-doc drift (not fixed here — out of fence)

`tools/xray/spec/017-Test-Coverage-Matrix.md` already teaches this same convention and defers to `TESTING.md` by name, but spells the command differently: it says to run `scripts/test-rigorous-local.sh`. That is not wrong — `scripts/test-rigorous-local.sh:95` really does invoke `npm run test:xray-feature-gate` — but it is a whole rigorous sweep where the narrow command suffices. Now that `TESTING.md` carries the authoritative spelling the two should agree. Filed as **rf2-raqes** rather than edited here, since `tools/**` was fenced off for this change.
