### PR TITLE
fix(ssr): the payload schema says what it means (rf2-cc7c6)

### DIFF
--- a/implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc
@@ -528,6 +528,20 @@
 ;; that drifts from the published schema (e.g. a non-integer :rf/version,
 ;; a missing required key) turns this test red. The schema is an OPEN map
 ;; (additive optional keys are tolerated per the v1 contract).
+;;
+;; rf2-cc7c6 — this def is the ONLY place in the corpus that types the
+;; payload's slots: `build-payload`'s emitted shape is otherwise unvalidated
+;; (the spec section's `> Conformance:` pointer, `ssr_hydration_test.clj`,
+;; exercises the CONSUMER — `:rf/hydrate` installing / failing closed — never
+;; the producer's slot types). Calling it canonical is therefore a claim worth
+;; keeping true, and every slot below is spelled exactly as Spec-Schemas
+;; spells it, with ONE documented deviation: Spec-Schemas types
+;; `:rf/runtime-db` as the registry ref `:rf/runtime-db` (resolving to
+;; `RuntimeDb`, a map of optional `:rf.runtime/*` sub-containers), and
+;; resolving a registry ref here would need a malli registry in this test ns
+;; — the payload-schema rewrite rf2-2rtt6.91's audit fenced. The base type
+;; `:map` is carried instead: weaker than the ref, but it holds the
+;; cardinality the ref holds, which is what the fail-open below was about.
 
 (def HydrationPayload
   [:map
@@ -537,7 +551,14 @@
    ;; when the deployment names a stable wire id.
    [:rf/frame-id        {:optional true} :keyword]
    [:rf/app-db          :any]
-   [:rf/runtime-db      {:optional true} [:maybe :map]]
+   ;; rf2-cc7c6 — `:map`, NOT `[:maybe :map]` (see the deviation note above for
+   ;; why the base type rather than the `:rf/runtime-db` ref). `build-payload`
+   ;; guards this arm with `(some? runtime-db)`, so a frame that hydrates no
+   ;; framework runtime state OMITS the key — the shape Spec-Schemas describes
+   ;; as "absent on a frame that hydrates no framework runtime state". A
+   ;; `[:maybe :map]` slot also admitted a present-and-nil key, which is a
+   ;; second spelling of absence the canonical schema does not have.
+   [:rf/runtime-db      {:optional true} :map]
    [:rf/ssr-rendered-at {:optional true} :int]
    ;; rf2-2rtt6.91 — `:string`, NOT `[:maybe :string]`. Spec-Schemas types the
    ;; slot `{:optional true} :string`, so a present-and-nil `:rf/render-hash`
@@ -546,7 +567,18 @@
    ;; needs the key OMITTED. A `[:maybe :string]` slot admitted the forbidden
    ;; shape, so this schema could not prove the contract it calls canonical.
    [:rf/render-hash     {:optional true} :string]
-   [:rf/schema-digest   {:optional true} [:maybe :string]]])
+   ;; rf2-cc7c6 — `:rf/head-hash` was ABSENT from this def while `build-payload`
+   ;; emits it. The map is OPEN, so the emitted key validated by never being
+   ;; looked at: not loose, SILENT. It is the SEPARATE head-model channel
+   ;; (rf2-1oxjxk) — `:string` like its `:rf/render-hash` sibling, and omitted
+   ;; on nil for the explicit-`:head`-STRING shape where the server knows the
+   ;; head is not client-reconstructible.
+   [:rf/head-hash       {:optional true} :string]
+   ;; rf2-cc7c6 — `:string`, NOT `[:maybe :string]`, for the same reason as
+   ;; `:rf/render-hash`: `build-payload` omits the key when the caller's app
+   ;; does not participate in the schema-digest check, so present-and-nil is
+   ;; not a shape the builder can produce and not one Spec-Schemas admits.
+   [:rf/schema-digest   {:optional true} :string]])
 
 (deftest build-payload-conforms-to-hydration-payload-schema
   (testing "rf2-g00l2t — build-payload output validates against the canonical
@@ -617,3 +649,112 @@
                          (assoc (payload-policy/build-payload :rf/default {} nil {})
                                 :rf/render-hash nil)))
         "a hand-stamped nil :rf/render-hash must not validate")))
+
+;; ---- the other three optional slots, same contract (rf2-cc7c6) ------------
+;;
+;; `:rf/render-hash` above was one of four optional slots `build-payload`
+;; assembles through `cond->` arms, and it was the only one this schema could
+;; prove anything about. The three below each get the same three-part case the
+;; hash channel gets — real value preserved, nil OMITS the key, hand-stamped
+;; nil REJECTED — because a tightened slot with no assertion against it is a
+;; claim, not a guard.
+
+(deftest build-payload-head-hash-is-optional
+  ;; The slot the schema did not carry at all. `build-payload` emits
+  ;; `:rf/head-hash` (rf2-1oxjxk — the SEPARATE client-reconstructible
+  ;; head-model channel, not covered by `:rf/render-hash`), and because the
+  ;; schema is an OPEN map the emitted key validated by never being examined:
+  ;; any value — nil, an int, a map — rode through. These are the first
+  ;; assertions in the corpus that look at it.
+  (testing "a real head hash is preserved verbatim"
+    (let [payload (payload-policy/build-payload
+                    :rf/default {:public/page :dashboard} "body-h"
+                    {:head-hash "head-h"})]
+      (is (= "head-h" (:rf/head-hash payload))
+          "a supplied head hash rides the payload unchanged")
+      (is (= "body-h" (:rf/render-hash payload))
+          "the head channel is SEPARATE from the body render-hash channel")
+      (is (m/validate HydrationPayload payload)
+          (str "a head-hashed payload conforms; explain: "
+               (pr-str (m/explain HydrationPayload payload))))))
+
+  (testing "a nil head hash OMITS the key (the explicit-:head-STRING shape,
+            where the head is not client-reconstructible)"
+    (let [payload (payload-policy/build-payload
+                    :rf/default {:public/page :dashboard} "body-h"
+                    {:head-hash nil})]
+      (is (not (contains? payload :rf/head-hash))
+          "a nil head-hash omits :rf/head-hash entirely")
+      (is (= "body-h" (:rf/render-hash payload))
+          "omitting the head channel leaves the body channel intact")
+      (is (m/validate HydrationPayload payload)
+          (str "a head-hashless payload conforms; explain: "
+               (pr-str (m/explain HydrationPayload payload))))))
+
+  (testing "a present-and-nil :rf/head-hash is REJECTED by the schema"
+    (is (not (m/validate HydrationPayload
+                         (assoc (payload-policy/build-payload :rf/default {} "h" {})
+                                :rf/head-hash nil)))
+        "a hand-stamped nil :rf/head-hash must not validate"))
+
+  (testing "a non-string :rf/head-hash is REJECTED — the point of typing a slot
+            the OPEN map previously let through unexamined"
+    (is (not (m/validate HydrationPayload
+                         (assoc (payload-policy/build-payload :rf/default {} "h" {})
+                                :rf/head-hash 42)))
+        "an integer head hash must not validate")))
+
+(deftest build-payload-schema-digest-is-optional
+  (testing "a real digest is preserved verbatim"
+    (let [payload (payload-policy/build-payload
+                    :rf/default {:public/page :dashboard} "h"
+                    {:schema-digest "digest-abc"})]
+      (is (= "digest-abc" (:rf/schema-digest payload))
+          "a supplied digest rides the payload unchanged")
+      (is (m/validate HydrationPayload payload)
+          (str "a digest-bearing payload conforms; explain: "
+               (pr-str (m/explain HydrationPayload payload))))))
+
+  (testing "a nil digest OMITS the key (the app does not participate in the
+            schema-digest check)"
+    (let [payload (payload-policy/build-payload
+                    :rf/default {:public/page :dashboard} "h"
+                    {:schema-digest nil})]
+      (is (not (contains? payload :rf/schema-digest))
+          "a nil schema-digest omits :rf/schema-digest entirely")
+      (is (m/validate HydrationPayload payload)
+          (str "a digestless payload conforms; explain: "
+               (pr-str (m/explain HydrationPayload payload))))))
+
+  (testing "a present-and-nil :rf/schema-digest is REJECTED by the schema"
+    (is (not (m/validate HydrationPayload
+                         (assoc (payload-policy/build-payload :rf/default {} "h" {})
+                                :rf/schema-digest nil)))
+        "a hand-stamped nil :rf/schema-digest must not validate")))
+
+(deftest build-payload-runtime-db-slot-is-typed
+  ;; `build-payload-emits-runtime-db-when-present` above already pins the VALUE
+  ;; contract (the projected slice rides; nil omits the key). What it could not
+  ;; pin, while the slot read `[:maybe :map]`, is that the omission is the only
+  ;; legal spelling of absence — so these are the schema-side arms.
+  (testing "a projected slice conforms under the tightened :map slot"
+    (let [payload (payload-policy/build-payload
+                    :rf/default {:public/page :dashboard} "h"
+                    {:runtime-db (payload-policy/project-runtime-db sample-runtime-db)})]
+      (is (map? (:rf/runtime-db payload)))
+      (is (m/validate HydrationPayload payload)
+          (str "a runtime-db-bearing payload conforms; explain: "
+               (pr-str (m/explain HydrationPayload payload))))))
+
+  (testing "a present-and-nil :rf/runtime-db is REJECTED by the schema — the
+            fail-open `[:maybe :map]` admitted a second spelling of absence"
+    (is (not (m/validate HydrationPayload
+                         (assoc (payload-policy/build-payload :rf/default {} "h" {})
+                                :rf/runtime-db nil)))
+        "a hand-stamped nil :rf/runtime-db must not validate"))
+
+  (testing "a non-map :rf/runtime-db is REJECTED"
+    (is (not (m/validate HydrationPayload
+                         (assoc (payload-policy/build-payload :rf/default {} "h" {})
+                                :rf/runtime-db "not-a-map")))
+        "a string runtime-db must not validate")))


### PR DESCRIPTION
Closes rf2-cc7c6.

`payload_policy_cljs_test.cljc` pins an inline `HydrationPayload` that calls itself
"the canonical v1 HydrationPayload schema (Spec-Schemas `:rf/hydration-payload`)".
rf2-2rtt6.91 made that true of one slot. Three were still false:

| slot | was | Spec-Schemas | now |
| --- | --- | --- | --- |
| `:rf/schema-digest` | `[:maybe :string]` | `{:optional true} :string` | `:string` |
| `:rf/runtime-db` | `[:maybe :map]` | `{:optional true} :rf/runtime-db` | `:map` (one documented deviation, below) |
| `:rf/head-hash` | **absent** | `{:optional true} :string` | `:string` |

## Tighten, not retract

The bead offered retracting the canonicity claim as the cheaper answer, to be argued
rather than defaulted into. The argument runs the other way, on one fact:

**Retraction has to say what guarantees the payload shape instead, and the answer is
nothing.** `git grep HydrationPayload` over `*.clj{,c,s}` returns this file and no
other — it is the only place in the corpus that types the payload's slots at all. The
spec section's own `> Conformance:` pointer names `ssr_hydration_test.clj`, but that
namespace exercises the **consumer** (`:rf/hydrate` installing, failing closed on a
malformed payload, round-tripping through the router); it holds no schema and calls no
`m/validate` on a payload shape. Retracting the claim would leave `build-payload`'s
emitted shape unvalidated corpus-wide, and would put a disclaimer directly above the
six-line comment rf2-2rtt6.91 wrote to explain why `:string` rather than `[:maybe
:string]` is what canonicity *means* here. The cost of keeping the claim true is what
the bead estimated: one token, one token, one line.

`:rf/head-hash` is the slot that settles it. `build-payload` emits it and the map is
open, so the key was not *loose* — it was **silent**. Mutation A3 below shows the
open map admitting both `nil` and `42` for it.

### The one deviation, now stated rather than implied

Spec-Schemas types `:rf/runtime-db` as the registry ref `:rf/runtime-db` (resolving to
`RuntimeDb`, a map of four optional `:rf.runtime/*` sub-containers). Resolving a ref
here needs a malli registry in the test ns — the payload-schema rewrite rf2-2rtt6.91's
audit fenced, and which the bead explicitly says not to do. The base type `:map` is
carried instead. That is weaker than the ref, so the header comment now names it as a
deviation instead of letting "canonical" imply an equivalence that does not hold. It
still holds the cardinality the fail-open `[:maybe :map]` gave away, which is what
this bead is about.

**No `spec/Spec-Schemas.md` co-edit is needed.** The spec block is correct as written
in all three slots; the test was the side that had drifted.

## `build-payload` is unchanged

All three arms already omit on nil — `(some? runtime-db)`, and truthy guards on
`schema-digest` / `head-hash` (neither slot has a legal `false` value, so truthy and
`some?` coincide). The defect was the schema admitting shapes the builder cannot
produce and the spec forbids. The fix is therefore the schema plus the assertions that
make each slot capable of failing.

## Mutation proof

Every change proved in both directions, against
`clojure -M:test -n re-frame.ssr.payload-policy-cljs-test` (baseline **34 tests /
96 assertions, 0 failures**).

**Schema side** — revert the slot, the new assertion goes red:

| mutation | result |
| --- | --- |
| A1 `:rf/schema-digest` → `[:maybe :string]` | **1 failure** — `a hand-stamped nil :rf/schema-digest must not validate` |
| A2 `:rf/runtime-db` → `[:maybe :map]` | **1 failure** — `a hand-stamped nil :rf/runtime-db must not validate` |
| A3 `:rf/head-hash` slot deleted | **2 failures** — the open map admits both `nil` **and** `42`, which is the silence this slot closes |

**Builder side** — force the `cond->` arm to always `assoc`, the omission assertion
*and* every schema assertion go red, each `explain` naming the slot:

| mutation | result | `explain` signature |
| --- | --- | --- |
| B1 `schema-digest` arm → `true` | **9 failures** | `{:path [:rf/schema-digest], :schema :string, :value nil}` |
| B2 `(some? runtime-db)` arm → `true` | **8 failures** | `{:path [:rf/runtime-db], :schema :map, :value nil, :type :malli.core/invalid-type}` |
| B3 `head-hash` arm → `true` | **10 failures** | `{:path [:rf/head-hash], :schema :string, :value nil}` |

All six mutations were reverted; the branch is the tightened schema plus its
assertions and nothing else.

## Scope

No broadening into a payload-schema rewrite. One file touched, test-only. No malli
registry introduced, no `:rf/runtime-db` ref resolved, no production code changed, no
`spec/**` edit.

One observation logged rather than actioned: `:rf/ssr-rendered-at` is in both the spec
block and this schema but is emitted by nothing under `implementation/` — a
spec-vs-implementation gap, correctly typed on both sides, and out of this bead's
scope.

## Quality gates

<!-- GATES -->
