### PR TITLE
docs(hicasso): citations point at symbols, not line numbers (rf2-2rtt6.129)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1135,7 +1135,7 @@ forfeited by a merge at all, because a merge cannot reach an owned literal. The
 case where a caller override *should* win is spelled by **not writing the literal**,
 which is the honest way round — the dangerous default is the other one. Spelling
 precedent: UIx already uses `:&` for exactly this in this repo
-(`examples/substrates/uix/login/core.cljs:148`).
+(`examples/substrates/uix/login/core.cljs` — `mount!`'s `frame-root` props).
 **Class composition needs no exception.** An element's own classes are written on
 the **tag** (`[:input.form-control {:& caller}]`), which is not a literal attribute
 key, so the shorthand merge composes them with whatever the remainder brought —
@@ -1143,7 +1143,8 @@ however the remainder spelled it (c″). A literal `:class` still wins outright,
 because it is a literal, and what composes is what SURVIVED the merge: an alias at a
 slot an owned literal claims never gets that far.
 **Demonstrated, not asserted.** The RealWorld article editor's four form fields
-(`examples/real-apps/realworld_resources/article_editor.cljs:496-522`) are ported
+(`examples/real-apps/realworld_resources/article_editor.cljs` — `editor-page`'s four
+`fieldset.form-group` blocks) are ported
 both ways in `front/census_article_editor_cljs_test`, with the produced elements
 and the dispatched intents asserted identical between the renderings. The
 authoring result: four repeated attribute maps become one `field` helper and four

--- a/docs/design/hicasso/studio/controlled-input-two-implementations.md
+++ b/docs/design/hicasso/studio/controlled-input-two-implementations.md
@@ -75,7 +75,7 @@ pins it explicitly, which is why the ruling did not move a single figure.
 The probe that found it read the props React had committed to the DOM node.
 Where the view had written `:value`, the node carried `defaultValue "12"` and
 a `ref` whose source was `function (el){ return (this$.inputEl = el); }` —
-`uix/compiler/input.cljs:110-127`.
+`uix/compiler/input.cljs`'s `input-render-setup`.
 
 ## What each implementation does
 
@@ -105,11 +105,12 @@ the end of the field.
 ### `:uix-reagent-input` — the element is made uncontrolled
 
 `value` is deleted from the props, `defaultValue` is set and a `ref` is
-installed (`uix/compiler/input.cljs:124-127`). React's restore now has
+installed (`uix/compiler/input.cljs`'s `input-render-setup`). React's restore now has
 nothing to restore — `updateInput` skips the write entirely when the `value`
 prop is absent. UIx drives the value itself, and schedules that work on
 `reagent.impl.batching/do-after-render`, a queue drained from
-`requestAnimationFrame` (`reagent/impl/batching.cljs:16-25`, `:57-59`).
+`requestAnimationFrame` (`reagent/impl/batching.cljs`'s `next-tick`, drained by
+`run-funs`).
 Value and caret both come back correct, by offset from the end of the
 string — Arm 2's algorithm, and Reagent's before it — but **one animation
 frame later, never inside the discrete event.**
@@ -172,7 +173,8 @@ Arm 2 restored both ends of a selection by distance from the end of the
 string and required `[2 5]`. Neither shipped implementation does, and neither
 is close: React resets the cursor to the end of the value it wrote, and the
 port writes one offset into both `selectionStart` and `selectionEnd`
-(`uix/compiler/input.cljs:68-69`), so a range collapses **by construction**.
+(`uix/compiler/input.cljs`'s `input-node-set-value`), so a range collapses **by
+construction**.
 `[2 2]`, the value the bead recorded, is the port's — correct as a cursor,
 never a range. This is not a defect to be fixed in passing; restoring a range
 means restoring two offsets, which is a different algorithm from the one both
@@ -319,7 +321,7 @@ an ordinary `:value`/`:on-change` pair, with no ref, no effect and no escape
 hatch. No hook in the boundary shell, so the ≤2-hook budget (HD-020) is
 untouched, and `arm1_hook_ledger_dom_cljs_test` reads the same ledger it did
 before. UIx's own answer to the same problem costs a wrapper *component* per
-input with three hooks in it (`uix/compiler/input.cljs:132-143`); this one
+input with three hooks in it (`uix/compiler/input.cljs`'s `reagent-input`); this one
 costs none, because it lives in the element path rather than in a component.
 `grid.cljs` — the 100-cell witness's view — did not change by a character.
 

--- a/docs/design/hicasso/studio/cross-checked-against-an-outside-instrument.md
+++ b/docs/design/hicasso/studio/cross-checked-against-an-outside-instrument.md
@@ -49,7 +49,7 @@ rather than lucky.**
 `page.evaluate` compiles to — owns the whole callback, so a harness that drives
 its operations that way subtracts them away. This harness drives every operation
 with `page.click`
-([`jsfb_ours_run.cjs:211`](../../../../implementation/freehand/test/re_frame/bench/hicasso/jsfb_ours_run.cjs)),
+([`jsfb_ours_run.cjs`'s `click`](../../../../implementation/freehand/test/re_frame/bench/hicasso/jsfb_ours_run.cjs)),
 an **Input-domain** command: `Input.dispatchMouseEvent` delivers an event and
 returns, and the page's handler runs afterwards in an input task the command does
 not own.

--- a/docs/design/hicasso/studio/raw-escape-design-b-correctness.md
+++ b/docs/design/hicasso/studio/raw-escape-design-b-correctness.md
@@ -550,7 +550,8 @@ counter must be unconditional, as `bodyRuns` deliberately is.
 **R4 — the X2 body-run restatement.** Not a new ruling so much as a correction that should
 be recorded before the escape lands: post-adoption body-run counts diverge from the
 server's at any `:client-only` crossing, by design. The row this reaches is concrete —
-`arm1/hydrate_dom_cljs_test.cljs:414`, `(is (= boundary-count (rt/body-runs)))`, read after
+`arm1/hydrate_dom_cljs_test`'s `the-body-run-count-across-adoption-is-counted-and-not-inferred`,
+`(is (= boundary-count (rt/body-runs)))`, read after
 the adoption resolves. It is green today because no page it drives carries a `:client-only`
 crossing, and it goes red the moment one is added — whether through `[:>]` or through a
 `defhost` declared `:client-only`. Nothing on `main` is broken; what is needed is that

--- a/docs/design/hicasso/studio/raw-escape-design-c-ergonomics.md
+++ b/docs/design/hicasso/studio/raw-escape-design-c-ergonomics.md
@@ -188,7 +188,7 @@ This is not the escape's fault and the escape cannot fix it. `defhost` has the
 same hole: `mint-host-gate!` returns a single pre-walked `placeholder` element
 when unadopted and never consults `props.children`, so `:ssr {:fallback …}`
 *replaces* the subtree rather than passing it through. **The guide's own
-provider example** (`05-interop.md:120`, `(h/defhost themed (.-Provider
+provider example** (under `05-interop.md`'s `## Providers`, `(h/defhost themed (.-Provider
 some-context))`) loses its subtree server-side today. See §Needs a ruling, R1.
 
 ### 5. A one-off migration site
@@ -668,7 +668,7 @@ down from 2,633 to 1,875 lines. This design's whole additional teaching surface:
 declaration" is *for*: it is a compression claim, not a slogan.
 
 The existing guide sites need only tense flips plus these, and one of them
-already says the right thing: `05-interop.md:174`'s troubleshooting row
+already says the right thing: `05-interop.md`'s `## Troubleshooting` row
 (*"A `[:>]` node (once built) has reduced structural identity | Prefer `defhost`,
 or assert around the node"*) is correct as written and needs the parenthetical
 removed, nothing more.
@@ -681,7 +681,7 @@ removed, nothing more.
 `mint-host-gate!` returns a single pre-walked `placeholder` and never consults
 `props.children`, so an unadopted crossing drops its subtree. For a leaf widget
 that is right; for a **provider** — one of HD-011's five named use cases, and the
-guide's own example at `05-interop.md:120` — it deletes the application from the
+guide's own example under `05-interop.md`'s `## Providers` — it deletes the application from the
 server response. The `:ssr` ruling says *"there is no third value."* Either a
 third value exists (`:ssr :children` / `:transparent`, meaning "render the
 children in place of the component"), or providers are ruled out of SSR and the

--- a/docs/design/hicasso/studio/raw-escape-spec.md
+++ b/docs/design/hicasso/studio/raw-escape-spec.md
@@ -96,9 +96,9 @@ any kind — not an option, not a prop, not a metadata key.**
 
 The gate is a function component whose single `useSyncExternalStore` reuses the landed
 module-level snapshot triple `gate-no-subscribe` / `gate-adopted` / `gate-unadopted`
-(`front/codec.cljs:1035-1037`) — the same three `mint-host-gate!` uses, with `placeholder`
+(`front/codec.cljs`) — the same three `mint-host-gate!` uses, with `placeholder`
 fixed at `nil`, which is what `:client-only` already compiles to at the door
-(`codec.cljs:1059`).
+(`mint-host-gate!`'s `placeholder` binding).
 
 **Why this discharges the hard half by construction.** The operator note's binding clause is
 that a server-absent node must *also* be absent from the client's hydration first pass, or
@@ -347,7 +347,8 @@ asserted on and never serialised into a golden.
 facts that reframe this edge, and both come from the guide's own testing chapter: Hicasso's
 headless structural render **does not exist** (`08-testing.md:16` calls it a sketch — "nothing
 in the tree implements this yet"), and **the foreign region is already out of its scope for
-both forms** (`08-testing.md:44`). So what `defhost` buys structurally is the crossing node's
+both forms** (`08-testing.md`'s `### Full headless render (not built)` — *"Hooks, `defhost`, and
+host edges stay mounted tests"*). So what `defhost` buys structurally is the crossing node's
 identity, not visibility into what the component renders — *neither form gives you that*. The
 cost today is therefore close to zero, and saying so honestly matters more than sounding
 careful. When that render lands, a `defhost` crossing has a declared name to project and a
@@ -592,8 +593,8 @@ crossing render, and a refusal of something React would have accepted. **Removab
 touching the mechanism** — it is a predicate and two message flavours.
 
 **R4 — `rf2-2rtt6.115`'s record correction must land before or with the escape.** Three
-independent adjudications concur that the **code** side is authoritative: HD-024's row 3 at
-`decisions.md:1015` over-records, and the door's unclaimed-slot identity crossing was
+independent adjudications concur that the **code** side is authoritative: HD-024's row 3 in
+`decisions.md` over-records, and the door's unclaimed-slot identity crossing was
 deliberate. The repair is a dated scope-note on row 3 plus the currently-missing witness
 pinning a *marked* `h/fn` at an unclaimed door slot (today only a *plain* fn is pinned). Edge
 2 rests on that resolution; it is `decisions.md`, outside this page's fence, and it is named
@@ -605,8 +606,8 @@ here so the implementation PR carries it rather than discovering it.
 
 Six facts that will bite, each verified against `main` on 2026-08-04.
 
-**1. `:>` is not currently an error.** `hiccup-tag?` (`codec.cljs:1673-1675`) accepts any
-keyword that is not `:<>`, and `vec->element` (`:1689`) routes it to `native-element` — so
+**1. `:>` is not currently an error.** `hiccup-tag?` (in `codec.cljs`) accepts any
+keyword that is not `:<>`, and `vec->element` routes it to `native-element` — so
 `[:> Foo {}]` today asks React for an element literally named `<>`. The new branch must
 **precede** `hiccup-tag?` and compare with **`=`, never `identical?`**, for the reason
 `fragment-head?`'s own docstring gives: keyword literals are shared constants only when the
@@ -620,7 +621,8 @@ fallback is not "it is only one `=`": it is to measure the walk on the census pa
 roster before and after and publish the delta in the PR body.
 
 **3. X2's body-run equality is deliberately broken by any `:client-only` crossing.**
-`arm1/hydrate_dom_cljs_test.cljs:414` asserts `(= boundary-count (rt/body-runs))`, read after
+`arm1/hydrate_dom_cljs_test`'s `the-body-run-count-across-adoption-is-counted-and-not-inferred`
+asserts `(= boundary-count (rt/body-runs))`, read after
 adoption resolves. It is green today **only** because no page it drives carries a client-only
 crossing, and it goes **red on correct code** the moment the first one is added — via `[:>]`
 **or** via a `defhost` `:ssr :client-only`, so this is not specific to the escape. The two
@@ -702,6 +704,8 @@ each names what would make it vacuous.
   `as-element`. **Cited by name, not by line.** This bullet carried line numbers until
   2026-08-05 and three of the five were wrong by then, including the `as-element` citation
   that clause (e) turns on; the file moves faster than a record of it can be trued up.
-- `arm1/hydrate_dom_cljs_test.cljs:414`; `arm1/lang.clj`; `docs/design/hicasso/draft-guide/`.
+- `arm1/hydrate_dom_cljs_test` →
+  `the-body-run-count-across-adoption-is-counted-and-not-inferred`; `arm1/lang.clj`;
+  `docs/design/hicasso/draft-guide/`.
 - Beads: `rf2-2rtt6.106`, `.109`, `.115`, `.116`, `.117`, `.118`, `.119`, `.120`,
   `rf2-l0wfx`, `rf2-d03av`, `rf2-vrvv9`.

--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -1108,8 +1108,8 @@ bead was filed from that sentence.
 
 #### Design: both arms in one session, and a third run to catch drift
 
-The two arms differ by **one line** at
-`arm1/runtime.cljs:1261` — `mint-view!` returning
+The two arms differ by **one line** in
+`arm1/runtime.cljs`'s `mint-view!` — it returns
 `(codec/memoize-boundary! (codec/mark-boundary! component))` against
 `(codec/mark-boundary! component)`. That is the wrapper's only call site in the
 repository, so removing it removes the wrapper and nothing else; the rest of the

--- a/docs/design/hicasso/studio/the-clock-behind-the-published-rows.md
+++ b/docs/design/hicasso/studio/the-clock-behind-the-published-rows.md
@@ -84,17 +84,17 @@ that looks past `flushSync`, and replaced by a direction rather than a number.
 Read from the harnesses, not from the prose around them. The lane defines one
 clock and every published row reaches it:
 
-| producer | clock, at file:line | window closes | class |
+| producer | clock, at file and symbol | window closes | class |
 |---|---|---|---|
-| `lane.cljs` — the shared clock | [`lane.cljs:86-92`](../../../../implementation/freehand/test/re_frame/bench/hicasso/lane.cljs) `now-ms` → `js/performance.now()` | — | in-page |
-| `lane/mount-arm!` — every single mount row | [`lane.cljs:185-187`](../../../../implementation/freehand/test/re_frame/bench/hicasso/lane.cljs) `t0 (now-ms)` · `flushSync` · `{:ms (- (now-ms) t0)}` | when `flushSync` returns | in-page |
-| `lane/mount-batch!` — every batched mount row | [`lane.cljs:208-213`](../../../../implementation/freehand/test/re_frame/bench/hicasso/lane.cljs) same shape, `k` mounts inside one window | when `flushSync` returns | in-page |
-| `p0_converge_app` — M1, M2, broad, narrow | [`p0_converge_app.cljs:750`](../../../../implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs) `(lane/mount-batch! arm props k)` | via the lane | in-page |
-| `coldmount_app` — the `1.0054×` witness | [`coldmount_app.cljs:425`](../../../../implementation/freehand/test/re_frame/bench/hicasso/coldmount_app.cljs) `(lane/mount-batch! arm props 1)` | via the lane | in-page |
-| `hd8_rows` — the HD-008 donor rows | [`hd8_rows.cljs:416`](../../../../implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs) `(lane/mount-arm! arm props)`; own windows at [`665-678`](../../../../implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs) and [`1005-1008`](../../../../implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs) | when the drain returns | in-page |
-| `p0_reagent_app` — the first author's baseline | [`p0_reagent_app.cljs:373`](../../../../implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_app.cljs) `(lane/mount-batch! arm props k)` | via the lane | in-page |
-| `p0_harness` — the UIx frontier arm's rows, in a **different tree** | [`p0_harness.cljs:64-69, 220-221`](../../../../implementation/core/test/re_frame/bench/p0_harness.cljs) its own `now-ms` → `js/performance.now()`, `t0` then `flushSync` | when `flushSync` returns | in-page |
-| `hicasso_narrow` — the ratom-spine narrow write, in a **third tree** | [`hicasso_narrow.cljs:179`](../../../../implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs) `(defn now [] (js/performance.now))` | when the forced drain returns | in-page |
+| `lane.cljs` — the shared clock | [`lane.cljs`'s `now-ms`](../../../../implementation/freehand/test/re_frame/bench/hicasso/lane.cljs) → `js/performance.now()` | — | in-page |
+| `lane/mount-arm!` — every single mount row | [`lane.cljs`'s `mount-arm!`](../../../../implementation/freehand/test/re_frame/bench/hicasso/lane.cljs) `t0 (now-ms)` · `flushSync` · `{:ms (- (now-ms) t0)}` | when `flushSync` returns | in-page |
+| `lane/mount-batch!` — every batched mount row | [`lane.cljs`'s `mount-batch!`](../../../../implementation/freehand/test/re_frame/bench/hicasso/lane.cljs) same shape, `k` mounts inside one window | when `flushSync` returns | in-page |
+| `p0_converge_app` — M1, M2, broad, narrow | [`p0_converge_app.cljs`'s `mount-round!`](../../../../implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs) `(lane/mount-batch! arm props k)` | via the lane | in-page |
+| `coldmount_app` — the `1.0054×` witness | [`coldmount_app.cljs`'s `mount-round!`](../../../../implementation/freehand/test/re_frame/bench/hicasso/coldmount_app.cljs) `(lane/mount-batch! arm props 1)` | via the lane | in-page |
+| `hd8_rows` — the HD-008 donor rows | [`hd8_rows.cljs`'s `mount-round!`](../../../../implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs) `(lane/mount-arm! arm props)`; own windows in [`window-of`](../../../../implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs) and [`yield-window!`](../../../../implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs) | when the drain returns | in-page |
+| `p0_reagent_app` — the first author's baseline | [`p0_reagent_app.cljs`'s `measure-mount!`](../../../../implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_app.cljs) `(lane/mount-batch! arm props k)` | via the lane | in-page |
+| `p0_harness` — the UIx frontier arm's rows, in a **different tree** | [`p0_harness.cljs`'s `now-ms` and `mount-arm!`](../../../../implementation/core/test/re_frame/bench/p0_harness.cljs) its own `now-ms` → `js/performance.now()`, `t0` then `flushSync` | when `flushSync` returns | in-page |
+| `hicasso_narrow` — the ratom-spine narrow write, in a **third tree** | [`hicasso_narrow.cljs`'s `now`](../../../../implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs) `(defn now [] (js/performance.now))` | when the forced drain returns | in-page |
 
 **The roster is closed and the answer is uniform — across all three producer
 trees.** A sweep of the whole `bench/hicasso` tree finds no
@@ -120,9 +120,9 @@ only; `arm1-lean-react-dogfood-judgement` and
 ## 2. Why the floor normalisation does not protect the ratio
 
 The published bar figure is not a raw quotient. It is a **double ratio** —
-[`p0_converge_app.cljs:1091-1092`](../../../../implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs),
-with `:numerator :uix-subs` and `:denominator :reagent-subs` declared at
-`1128-1129`:
+[`p0_converge_app.cljs`'s `row-record`](../../../../implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs),
+with `:numerator :uix-subs` and `:denominator :reagent-subs` declared in the same
+function's `:red-zone` map:
 
 ```clojure
 rz (mapv (fn [m] (/ (get-in m [:uix-subs      :ratio :uix-subs])
@@ -169,7 +169,7 @@ operation — see the box at the top. Every figure in this section is therefore
 `reagent-subs`, `uix-subs` and `floor` arms mount **the same components with the
 same props as the published M1 witness** — `v/subs-root v/m1-subs`,
 `ux/subs-root ux/m1` and `v/m1-floor` at `v/cells-n`
-([`clock_app.cljs:191, 233, 241`](../../../../implementation/freehand/test/re_frame/bench/hicasso/clock_app.cljs)) — and it computes the same
+([`clock_app.cljs`'s `m1-arms` and `floor-mount-arm`](../../../../implementation/freehand/test/re_frame/bench/hicasso/clock_app.cljs)) — and it computes the same
 floor-normalised, per-segment statistic, so dividing its two legs reproduces the
 published quantity on the second clock.
 
@@ -278,7 +278,7 @@ same quantity here. On those same samples ~~the frame-inclusive clock reads
 script removed and is superseded by the corrected clock's `0.8602×`**. The
 published verdict is *"UIx faster. All 60 rounds below 1.0; all
 20 strata wholly below it"*
-([p0-converged-witness-set.md:347](p0-converged-witness-set.md)); no reading past
+([p0-converged-witness-set.md — the RED-ZONE table's `bulk broad` row](p0-converged-witness-set.md)); no reading past
 the `flushSync` boundary is anywhere near it. A 37% margin measured
 on a window that closes before the frame is a margin in the fraction of the work
 that happens to land inside `flushSync`, and the two substrates divide that
@@ -399,8 +399,8 @@ definition and Chromium source — not from the summaries in this tree:
   because the number invites a mistake.** `clock_run.cjs` says `duration` is
   rounded to the nearest 8 ms and that **the minimum `durationThreshold` an
   observer may ask for is 16 ms** — both accurate — and it passes
-  `durationThreshold: 16` explicitly at
-  [`clock_run.cjs:293`](../../../../implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs).
+  `durationThreshold: 16` explicitly in
+  [`clock_run.cjs`'s `EVENT_TIMING_INIT`](../../../../implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs).
   The trap nearby is that the *default* threshold, absent that argument, is
   **104 ms** (W3C *Event Timing* §3.4: "let minDuration be 104"), not 16. The
   instrument does not rely on the default and does not claim it does. **No


### PR DESCRIPTION
Closes the citation-rot half of `rf2-2rtt6.129`. `production-server-arm.md` and
`raw-escape-spec.md` §10 were already converted and are the models this follows.

## The measurement

**72 line-number citations across `docs/design/hicasso/**`. 37 converted to symbol
names. 35 deliberately left as lines, each for a stated reason.** Nothing else in the
tree cites code by line — this is the whole population, found by sweeping
`file.ext:NNN`, bare `` `:NNN` ``, `line NNN` / `lines NNN–MMM`, `#LNNN`, and
parenthesised numeric ranges.

**Nine of the 37 were already wrong when this sweep ran**, which is the case for the
change in one table:

| citation | what it names | where that actually is | drift |
|---|---|---|---|
| `arm1/runtime.cljs:1261` | `mint-view!` | 1744 | **483** |
| `clock_run.cjs:293` | the explicit `durationThreshold: 16` | 763 | **470** |
| `codec.cljs:1673-1675` | `hiccup-tag?` | 1976 | **303** |
| `codec.cljs:1689` | `vec->element` | 1980 | **291** |
| `decisions.md:1015` | HD-024's row 3 | 1160 | **145** |
| `coldmount_app.cljs:425` | `(lane/mount-batch! arm props 1)` | 508 | **83** |
| `front/codec.cljs:1035-1037` | the `gate-*` snapshot triple | 1082-1084 | **47** |
| `clock_app.cljs:191, 241` | the `reagent-subs` / `uix-subs` arms | 444, 452 | **253, 211** |
| `hydrate_dom_cljs_test.cljs:414` | `(is (= boundary-count (rt/body-runs)))` | 437 | lands in a **different `deftest`** |

*(9 rows, 4 columns.)*

The last one is the sharpest: `:414` sits inside
`the-hydrated-controlled-input-keeps-its-mirror`, which asserts `(= 1 (rt/body-runs))`.
The assertion the record actually names lives in
`the-body-run-count-across-adoption-is-counted-and-not-inferred`. Three separate pages
carried that citation. A reader following it lands on a real assertion about body runs
that is not the one under discussion — worse than landing on nothing.

## Every symbol named here was verified to exist

Verified in the file it is named in, at HEAD: `now-ms`, `mount-arm!`, `mount-batch!`
(`lane.cljs`); `mount-round!`, `row-record` (`p0_converge_app.cljs`); `mount-round!`
(`coldmount_app.cljs`); `mount-round!`, `window-of`, `yield-window!` (`hd8_rows.cljs`);
`measure-mount!` (`p0_reagent_app.cljs`); `now-ms`, `mount-arm!` (`p0_harness.cljs`);
`now` (`hicasso_narrow.cljs`); `m1-arms`, `floor-mount-arm` (`clock_app.cljs`);
`EVENT_TIMING_INIT` (`clock_run.cjs`); `click` (`jsfb_ours_run.cjs`); `mint-view!`
(`arm1/runtime.cljs`); `hiccup-tag?`, `vec->element`, `mint-host-gate!`,
`gate-no-subscribe` / `gate-adopted` / `gate-unadopted` (`front/codec.cljs`);
`the-body-run-count-across-adoption-is-counted-and-not-inferred`
(`arm1/hydrate_dom_cljs_test`); `mount!` (`examples/substrates/uix/login/core.cljs`);
`editor-page` (`examples/real-apps/realworld_resources/article_editor.cljs`).

The two third-party ones were read out of the pinned jars rather than guessed —
**uix.core 1.4.4**: `input-render-setup`, `input-node-set-value`, `reagent-input`;
**reagent 2.0.1**: `next-tick`, `run-funs`.

## The 35 left as lines, and why

- **Blob- and commit-pinned citations (6).** `22b53abe9e…:433` / `…:426` and the
  `cb179b6b3c` orderings. The pin *is* the snapshot; the line cannot rot.
- **Pinned third-party build artefacts (8).** `react-dom@19.2.0`'s
  `cjs/react-dom-client.development.js` — a generated 20k-line bundle where the symbol
  is already the primary (`updateInput`, `restoreStateOfTarget`, `setDefaultValue`,
  `initInput`, `updateTextarea`, `createAndAccumulateChangeEvent`, `batchedUpdates$1`)
  and the line is the only way to find the one call site among many. The version pin is
  stated in the same paragraph.
- **Findings whose subject IS the line number (11).** `revision-prop-spec.md` §2 and
  §6.1 ("It is now at `742-743`") and `defhost-ssr-provider-costing.md` §3 ("The guide
  citation is stale"). Converting these deletes the finding.
- **Quotations anchored to a superseded revision (6).** The `08-testing.md` line-16 and
  line-44 citations in `raw-escape-design-a-minimal.md` and `raw-escape-spec.md` §4
  quote sentences that `aa9ea1b698` removed from the guide — verified with
  `git log -S`. Re-pointing them at today's section would attach a quotation that
  section does not contain, which is the exact failure mode this bead is about. Filed
  as `rf2-2rtt6.130` rather than laundered here.
- **Prose in dated amendment boxes where the symbol is already named (4).**
  `heapForArms` / `runOp` / `heapOnce` at their lines, in `decisions.md`,
  `reads-per-boundary-heap-ladder.md` and
  `the-page-chrome-row-and-what-the-bail-out-costs.md`. Symbol first, line
  supplementary, pinned to `cb179b6b3c`.

## Nothing else changed

No claim, figure, verdict or quotation moved. Net **+8 lines** across 8 files
(48 insertions / 40 deletions), and the roster is shorter wherever the symbol was
already in the prose beside the number.

**One residue, flagged rather than fixed.** `defhost-ssr-provider-costing.md` §3 says
`:120` is "the line the bead, design C §4, design C R1 and `raw-escape-spec.md` R2 all
cite". After this PR none of the docs do. `raw-escape-design-c-ergonomics.md`'s dated
addendum likewise opens "Also stale above" about something no longer stale. Both are
dated records, so a one-word tense flip is a records edit, not a citation sweep — say
the word and it is two characters.

## Quality gates

- `python scripts/check_doc_slugs.py` → **exit 0**.
  **Mutation-proved.** Injected `#cite129-deliberately-broken-anchor` onto the
  `p0-converged-witness-set.md` link in `the-clock-behind-the-published-rows.md`;
  `grep -n` confirmed it landed at line 281 **before** the exit code was read; the
  checker then exited **1** naming exactly that file and line. Reverted; exit 0 again,
  and `grep -c` for the marker returns 0.
- `sh scripts/test-fast-pr.sh` → **exit 0**, every phase. The spine classified this
  dispatch as `docs=true jvm=false node=false`, so the CLJS phase did not run and no
  `implementation/node_modules` junction was created. `mkdocs build --strict` ran and
  passed, but note it **excludes `docs/design/hicasso/**`** and verified nothing here;
  the phase that covers this tree is the docs-corpus anchor validator.
- **Tables hand-counted** (nothing validates them). The one table this PR edits —
  `the-clock-behind-the-published-rows.md` §1 — is **4 columns, header + separator +
  9 body rows**, unchanged in shape; only the header wording (`clock, at file:line` →
  `clock, at file and symbol`) and the cell contents moved. Every other table in the
  8 touched files was re-counted and is consistent; the two 7-column tables in
  `cross-checked-against-an-outside-instrument.md` use escaped `\|diff\|` in the header
  and are correct.
- `git grep -n 'Users/miket'` over the touched tree → **0 hits**.
