### PR TITLE
docs(hicasso): the guide says what a boundary is, and how to carry a frame (rf2-cwmnz, rf2-2rtt6.102, rf2-u09ay)

### DIFF
--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -133,10 +133,11 @@ captured atom, kicking off a fetch, counting renders) does not belong in a body.
 
 ### Boundaries memoize by default
 
-A value-equality bail-out is the boundary **default**: every minted head carries
-one stable internal memo wrapper comparing the whole props map with CLJS `=`. If
-a boundary's props compare equal to last render, its body does not run — even
-though its parent's did.
+A value-equality bail-out is the boundary **default**: every head `defview` mints
+carries one stable internal memo wrapper comparing the whole props map with CLJS
+`=`. If a boundary's props compare equal to last render, its body does not run —
+even though its parent's did. Heads that are not boundaries do not carry one, and
+a `defhost` crossing is the case you will meet ([Interop](05-interop.md#memo-and-hosted-components)).
 
 Two things still outrank the bail-out, and both are the boundary's **own**
 invalidation. A subscription or context read that boundary made itself always

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -187,20 +187,34 @@ head written into one is refused at the declaration
 
 ## Memo and hosted components
 
-Every Hicasso boundary is a `React.memo` that compares props by value. That
-bail-out reaches a hosted component the same way it reaches a native one:
+A [boundary](02-views-and-reads.md#boundaries-memoize-by-default) carries a
+`React.memo` wrapper that compares props by value. A `defhost` crossing carries
+none, so it re-renders whenever the boundary that *wrote* it re-renders, and the
+foreign component runs again — unless the library exported a `memo`, which is
+its choice and not something the declaration arranges.
 
 ```clojure
 (defview chrome-page [_]
   [:div
-   [:span.chrome (str (sub [:hatch/label]))]   ;; re-renders on every write
-   [hosted-row {:label "fixed"}]])             ;; equal props → bail out
+   [:span.chrome (str (sub [:hatch/label]))]
+   [hosted-row {:label "fixed"}]])   ;; re-entered anyway — props are never compared
 ```
 
-A write that only moves `:hatch/label` re-renders `.chrome` and stops.
-`hosted-row` never re-enters the foreign component. If a host should react to a
-subscription, that value has to reach **its own** props — reading one boundary up
-and stopping looks identical, from the host's side, to the value never changing.
+A write that moves `:hatch/label` invalidates `chrome-page`, so its body runs
+again and rebuilds `hosted-row` with a fresh props object. Those props are equal
+by value; nothing on that head compares them.
+
+The bail-out you want is the enclosing boundary's — put the crossing behind a
+`defview` of its own and it is not re-entered while that view's props hold still:
+
+```clojure
+(defview labelled-row [{:keys [label]}]
+  [hosted-row {:label label}])
+```
+
+If a host should react to a subscription, that value has to reach **its own**
+props — reading one boundary up and stopping looks identical, from the host's
+side, to the value never changing.
 
 ## The escape: `[:>]` (unbuilt)
 


### PR DESCRIPTION
Delivers **rf2-u09ay**. Reports **rf2-cwmnz** and **rf2-2rtt6.102** as blocked
outside this PR's fence — see *Beads not delivered* below.

## What was wrong

Guide 05 taught that the memo bail-out reaches a hosted component. It does not.

`codec/memoize-boundary!` attaches a `React.memo` wrapper to a head's
`hicassoMemo` slot, and `codec/element-type` — the only reader of that slot — is
called from exactly one place, `boundary-element`. `host-element` does not go
through it: it builds the crossing from the head's `gate` slot with a freshly
reduced `#js {}` props object. `memoize-boundary!`'s only callers are
`runtime/mint-view!` and `runtime/mint-frame-prop-view!`; `mint-host!` is not
among them, and its docstring gives the reason the wrapper is opt-in ("heads that
are not reactive boundaries — `h/boundary`'s error-boundary class, presence —
keep the semantics they were written with"). `mint-host-gate!`'s product is a
plain `(fn [props] …)`, which React does not shallow-compare.

So a crossing re-renders whenever the boundary that *wrote* it re-renders. The
page's sample was built on a boundary that re-renders by construction — its own
`sub` moved — which is precisely the case where the claim fails. The chapter's
own troubleshooting table already carried the correct rule ("Boundary above
bailed out on equal props — host never re-entered"), so the page contradicted
itself.

The section now names the mechanism, keeps the honest caveat that a library may
have exported a `memo` of its own, and gives the remedy: put the crossing behind
a `defview` so the bail-out applies at that hop.

`02`'s "every minted head carries one stable internal memo wrapper" was false in
the same way — host heads are minted heads — and would have contradicted the
corrected 05. Narrowed to the heads `defview` mints, matching the boundary
definition thirty lines above it.

## Beads not delivered, and why

Both remaining beads are audit-reopened, and **the live scope of each is entirely
inside `11-performance.md`**, which this PR is fenced out of because #7527 and
#7528 are open on it and conflict with each other.

- **rf2-cwmnz** — the description's two items are already on `main`
  (`5ae20edda5`): `01`'s troubleshooting row is fx-first, `03` teaches
  `(rf/capture-frame (h/frame))` destructured as the map it returns, names
  `:rf.error/hicasso-frame-outside-boundary`, and states the refusal as
  deterministic without printing the provisional id. The audit's reopen cites
  only `11-performance.md` (:117, :121-123, :133, :204, :225).
- **rf2-2rtt6.102** — all four description items are discharged on `main`
  (`4807f61a33`): the narrowed definition in `02`, the forward link at `01`:214,
  the `h/boundary` distinction at `09`:22, and `06`'s anchor intact. The audit's
  reopen cites only `11-performance.md` (:67, :70). Item (4)'s judgement call in
  `05` is discharged here — the corrected section deep-links `02`.

**Neither open PR fixes those defects.** Both #7527 and #7528 re-add the exact
lines the audits reopened over: `A **vector** head is a boundary`,
`;; [unfrozen] — may still be landing`, and
``(rf/capture-frame (h/frame))` when available`. Both beads therefore remain
owed after whichever of the two merges, and want a dispatch fenced to
`11-performance.md` once that contention resolves.

## Flagged, not decided

The `h/boundary` name collision remains input for whoever freezes that API name.
A docs worker does not rename surface.

## Quality gates

| Gate | Result |
|---|---|
| `python scripts/check_doc_slugs.py` | exit 0 |
| `sh scripts/test-fast-pr.sh` | exit 0 |
| Spine surface classification | `docs=true jvm=false node=false (classified)` — as printed, not predicted |
| Mutation proof of the slug checker | exit 1, naming `02-views-and-reads.md:140` |

`mkdocs build --strict` is **not** nominated as the gate for this diff:
`mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site, so it
verifies nothing here. (It does run inside the spine, and passed there.)

**Mutation proof.** A bare exit 0 proves nothing, so the new link was mutated to
`#memo-and-hosted-components-BOGUS`. The mutation was grep-confirmed present at
`02-views-and-reads.md:140` *before* the exit code was read; the checker then
failed with `BROKEN ANCHOR: …02-views-and-reads.md:140 ->
05-interop.md#memo-and-hosted-components-BOGUS` and exit 1. Reverted,
re-greped, exit 0. The gate genuinely covers this edit.

**Anchors, hand-verified.** The new link `05-interop.md#memo-and-hosted-components`
resolves to the existing `## Memo and hosted components` heading, which this PR
does not rename. The new link from `05` to
`02-views-and-reads.md#boundaries-memoize-by-default` targets `### Boundaries
memoize by default`, which `06`:119 also depends on and which is unchanged.
`decisions.md`'s inbound link to
`05-interop.md#the-reserved-vector-and-the-gap-it-does-not-close` is untouched.

**Tables, hand-counted.** Nothing validates tables in this tree, so every table
in both touched files was counted cell by cell. No table row was added or edited
by this PR, and none is ragged:

| File | Table | Header cols | Body rows | Ragged rows |
|---|---|---|---|---|
| `05-interop.md` | Defaults | 2 | 5 | none |
| `05-interop.md` | Troubleshooting | 3 | 12 | none |
| `05-interop.md` | Not settled yet | 2 | 6 | none |
| `02-views-and-reads.md` | The component ABI | 5 | 3 | none |
| `02-views-and-reads.md` | Symptoms | 3 | 6 | none |
| `02-views-and-reads.md` | Not settled yet | 2 | 2 | none |

**Samples.** Both are true against the arm. `chrome-page`'s own `sub` moves, so
its own read outranks the comparator and its body re-runs, rebuilding the
crossing. `labelled-row` has no reads, and `boundary-props=` compares an
identical `rfFrame` and an `=` `rfProps`, so it bails out and the crossing is not
rebuilt.
