### PR TITLE
fix(ssr): the render-tree hash walk does not descend into a foreign JS value (rf2-56iys)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/hash.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hash.cljc
@@ -185,6 +185,10 @@
   the parent (this fn no-ops on nil; callers walking a collection use
   `append-children!` which skips nil children).
 
+  A foreign JS value — a plain object or a JS array — is NOT descended
+  into: it appends one fixed token (`#js{}` / `#js[]`). See the branch
+  comment below (rf2-56iys) for why those two predicates and no others.
+
   Output is byte-identical to (the now-thin) `canonical-edn`; the
   parity-pinned literals at `re-frame.ssr.hash-parity-fixtures` are
   the cross-runtime contract."
@@ -243,6 +247,59 @@
            :cljs (.push sb (canonical-number x)))
         sb)
 
+    ;; ---- the foreign crossing (rf2-56iys) ---------------------------------
+    ;;
+    ;; A FOREIGN JS VALUE IS OPAQUE TO THIS WALK: it serialises to one
+    ;; fixed identity-free token and is not descended into. Two branches,
+    ;; CLJS-only, spliced away entirely on the JVM — where a foreign value
+    ;; reaches `:else` as a Java object whose `pr-str` is its bounded
+    ;; `.toString`, and where no cyclic value can be built from the
+    ;; persistent collections this walk otherwise sees.
+    ;;
+    ;; WHY IT IS THESE TWO PREDICATES AND NO OTHERS. Without them a foreign
+    ;; value falls to `:else` → `pr-str`, and `cljs.core`'s printer has
+    ;; exactly two branches that DESCEND: `object?` (prints `#js {…}` by
+    ;; walking `js-keys`) and `array?` (prints `#js […]` by walking
+    ;; elements). Every other branch a foreign value can take — `#inst`,
+    ;; `#"regex"`, `#object[Symbol(x)]`, the terminal `#object[Ctor]` —
+    ;; emits bounded output and recurses into nothing. So stopping at
+    ;; `object?`/`array?` stops the descent precisely where `pr-str` would
+    ;; have started it, and `#inst`/regex/symbol keep the print forms they
+    ;; have today.
+    ;;
+    ;; WHY STOP AT ALL. Two reasons, and the second is why this is not
+    ;; merely defensive:
+    ;;
+    ;;   1. A FOREIGN OBJECT GRAPH CAN BE CYCLIC, and `pr-str` has no
+    ;;      seen-set. React 19's `createContext` returns an object carrying
+    ;;      a `Provider` key that points back AT THE CONTEXT ITSELF, so a
+    ;;      render tree holding a provider — `[ctx.Provider {:value …} …]`,
+    ;;      the ordinary way to write one — made this walk recur until the
+    ;;      stack blew (`RangeError: Maximum call stack size exceeded`)
+    ;;      rather than return a hash. That is the reported defect; the
+    ;;      cycle is a property of the object graph, not of React, and a
+    ;;      hand-built `(unchecked-set o "self" o)` reproduces it exactly.
+    ;;
+    ;;   2. A FOREIGN OBJECT'S PRINT FORM CARRIES FUNCTION IDENTITY, which
+    ;;      is the very leak the `fn?` branch above exists to close
+    ;;      (rf2-jsa2ml). `#js {"component" f}` printed
+    ;;      `#js {:component #object[f]}` — the JS function's `.name`, which
+    ;;      the `:advanced` compiler renames, so one render tree hashed
+    ;;      differently in dev and in release and could never agree with a
+    ;;      JVM-side hash of the same tree. Collapsing the object to a token
+    ;;      applies the rule the fn branch already states, at the one place
+    ;;      the value could smuggle a fn back in.
+    ;;
+    ;; The token discriminates object from array because that costs nothing
+    ;; and keeps two distinguishable shapes distinguishable; neither form
+    ;; carries identity.
+    #?@(:cljs
+        [(object? x)
+         (do (.push sb "#js{}") sb)
+
+         (array? x)
+         (do (.push sb "#js[]") sb)])
+
     :else
     (do #?(:clj  (.append ^StringBuilder sb ^String (pr-str x))
            :cljs (.push sb (pr-str x)))
@@ -255,7 +312,12 @@
   free token (`#fn[]`) — its `.toString` is not cross-runtime stable
   (rf2-jsa2ml); a Var reference keeps its `#'ns/name` print form (stable
   both runtimes). Numeric leaves are canonicalised via `canonical-number`
-  so whole-valued doubles / ratios agree cross-runtime (rf2-0ypnnk).
+  so whole-valued doubles / ratios agree cross-runtime (rf2-0ypnnk). A
+  foreign JS value (a plain object or a JS array) serialises to a fixed
+  token — `#js{}` / `#js[]` — rather than being descended into, for the
+  two reasons `canonical-edn-into`'s foreign branch gives (rf2-56iys):
+  the graph can be cyclic, and its print form leaks `:advanced`-munged
+  function names into the hash.
 
   Per Spec 011 §Hydration-mismatch detection: **nil pruned**. Two render
   trees that differ only by absent-key vs nil-value are structurally

--- a/implementation/ssr/test/re_frame/ssr/foreign_value_hash_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/foreign_value_hash_cljs_test.cljs
@@ -1,0 +1,160 @@
+(ns re-frame.ssr.foreign-value-hash-cljs-test
+  "THE FOREIGN CROSSING IN THE RENDER-TREE HASH (rf2-56iys).
+
+  `canonical-edn-into`'s `:else` branch delegates to `pr-str`, and
+  `cljs.core`'s printer descends into a plain JS object (`#js {…}`, over
+  `js-keys`) and a JS array (`#js […]`, over elements) with no seen-set.
+  A foreign object graph may be CYCLIC — React 19's `createContext`
+  returns an object whose `Provider` key points back at the context
+  itself — so hashing an ordinary provider-headed form recurred until the
+  stack blew (`RangeError: Maximum call stack size exceeded`) instead of
+  returning a hash. The walk now stops at those two predicates and emits
+  one fixed token.
+
+  ## How these rows OBSERVE a stack overflow
+
+  A `RangeError` raised inside `render-tree-hash` is an ordinary
+  synchronous JS throw — nothing routes it to `reportError`, so no row
+  here depends on the runner noticing an exception it never saw. Every
+  row calls the walk through [[outcome]], which returns a MAP — either
+  `{:hash …}` or `{:threw \"RangeError\" :message …}` — and asserts on
+  that map. A regression therefore fails with the error's own name in the
+  failure text rather than aborting the var.
+
+  [[the-fixtures-are-genuinely-cyclic]] is the non-vacuity control, and it
+  is the row that makes the rest of the file mean something: it asserts
+  that `cljs.core/pr-str` — the exact printer the `:else` branch would
+  reach — DOES blow the stack on these same fixtures. Without it every
+  row below could pass on an acyclic fixture and prove nothing."
+  (:require ["react" :as react]
+            [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.ssr.hash :as h]))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures — one hand-built cycle, one real React 19 context
+;; ---------------------------------------------------------------------------
+
+(defn- self-referential-object
+  "A plain JS object holding a reference to ITSELF. No React: the defect
+  is a property of a foreign object graph, and this is the smallest value
+  that has it."
+  []
+  (let [o #js {"tag" "cyclic"}]
+    (unchecked-set o "self" o)
+    o))
+
+(def ^:private corpus-context
+  "A real React context, so the rows below carry the shape that was
+  reported rather than a model of it."
+  (react/createContext "unset"))
+
+(def ^:private provider
+  "`ctx.Provider` — what an author writes in head position."
+  (.-Provider corpus-context))
+
+(defn- outcome
+  "Run `f` and describe what happened as DATA: `{:hash …}` on a return,
+  `{:threw <error name> :message …}` on a throw. Assertions read this map,
+  so a stack overflow shows up as a value in the failure text."
+  [f]
+  (try {:hash (f)}
+       (catch :default e {:threw (.-name e) :message (ex-message e)})))
+
+(defn- hex-hash?
+  [x]
+  (some? (re-matches #"[0-9a-f]{8}" (str x))))
+
+;; ---------------------------------------------------------------------------
+;; The control
+;; ---------------------------------------------------------------------------
+
+(deftest the-fixtures-are-genuinely-cyclic
+  (testing "THE NON-VACUITY CONTROL. `pr-str` is what the walk's `:else`
+           branch delegates to, and on these values it recurs until the
+           stack blows. If either row here ever goes green-by-termination,
+           the fixture has stopped being cyclic and every row below is
+           measuring nothing."
+    (is (= "RangeError" (:threw (outcome #(pr-str (self-referential-object)))))
+        "a hand-built self-referential JS object defeats cljs.core/pr-str")
+    (is (= "RangeError" (:threw (outcome #(pr-str provider))))
+        "and so does a real React 19 context provider")
+    (is (identical? provider (.-Provider provider))
+        "because React 19's ctx.Provider IS the context object, and that
+         object carries a Provider key pointing back at itself — the cycle
+         in one line")))
+
+;; ---------------------------------------------------------------------------
+;; The defect, inverted
+;; ---------------------------------------------------------------------------
+
+(deftest a-cyclic-foreign-value-hashes-instead-of-blowing-the-stack
+  (testing "THE REGRESSION GUARD. Revert the foreign branch in
+           `canonical-edn-into` and every row here reports
+           `{:threw \"RangeError\"}` where a hash was expected."
+    (doseq [[label v] [["a self-referential object" (self-referential-object)]
+                       ["a React 19 context"        corpus-context]
+                       ["a React 19 provider"       provider]
+                       ["a provider in head position"
+                        [provider {:value "dark"} [:p.render-subtree "SUBTREE"]]]
+                       ["a provider nested in markup"
+                        [:div.hosts [:h1 "hosts"] [provider {:value "dark"} "x"]]]
+                       ["a provider in an attribute value"
+                        [:div {:ctx provider} "x"]]
+                       ["a cycle reached through a JS array"
+                        #js [(self-referential-object)]]]]
+      (let [o (outcome #(h/render-tree-hash v))]
+        (is (hex-hash? (:hash o))
+            (str label " must hash to 8 lowercase hex chars; got "
+                 (pr-str o)))))))
+
+;; ---------------------------------------------------------------------------
+;; What the branch emits, pinned
+;; ---------------------------------------------------------------------------
+
+(deftest a-foreign-value-serialises-to-one-fixed-token
+  (testing "The token is identity-free, exactly as the `fn?` branch's
+           `#fn[]` is (rf2-jsa2ml) — and for the second of that branch's
+           reasons as well as the first: `#js {\"f\" some-fn}` used to
+           print `#js {:f #object[f]}`, smuggling a JS function's `.name`
+           — which the `:advanced` compiler renames — back into the hash
+           the fn branch exists to keep identity out of."
+    (is (= "#js{}" (h/canonical-edn #js {"a" 1 "b" "two"})))
+    (is (= "#js{}" (h/canonical-edn #js {})))
+    (is (= "#js{}" (h/canonical-edn #js {"f" (fn [] 1)}))
+        "no #object[<munged name>] survives the crossing")
+    (is (= "#js[]" (h/canonical-edn #js [1 2 3])))
+    (is (= "#js[]" (h/canonical-edn #js [])))
+    (is (= "#js{}" (h/canonical-edn provider)))))
+
+(deftest the-form-around-a-foreign-value-still-hashes
+  (testing "The token collapses the FOREIGN value and nothing else — the
+           props and children of a provider-headed form go on
+           discriminating, which is what keeps the hash a hash rather than
+           a constant."
+    (let [dark  (h/render-tree-hash [provider {:value "dark"} [:p "x"]])
+          light (h/render-tree-hash [provider {:value "light"} [:p "x"]])
+          other (h/render-tree-hash [provider {:value "dark"} [:p "y"]])]
+      (is (not= dark light) "a different prop is a different hash")
+      (is (not= dark other) "a different child is a different hash")
+      (is (= "[#js{} {:value \"dark\"} [:p \"x\"]]"
+             (h/canonical-edn [provider {:value "dark"} [:p "x"]]))))))
+
+;; ---------------------------------------------------------------------------
+;; The predicates, bounded
+;; ---------------------------------------------------------------------------
+
+(deftest only-the-two-descending-printer-branches-are-intercepted
+  (testing "`object?` and `array?` are precisely the two `cljs.core`
+           printer branches that DESCEND. Every other print form a
+           foreign value can take is bounded and recurses into nothing,
+           so it keeps the serialisation it has always had — this row is
+           what stops the foreign branch from quietly widening."
+    (is (= "#inst \"1970-01-01T00:00:00.000-00:00\"" (h/canonical-edn (js/Date. 0))))
+    (is (= "#\"ab+c\"" (h/canonical-edn #"ab+c")))
+    (is (= "#fn[]" (h/canonical-edn (fn [_] nil)))
+        "and a raw fn still takes the fn branch, ahead of either of these")
+    (is (= "[:div {:class \"x\"} [:p \"hi\"]]"
+           (h/canonical-edn [:div {:class "x"} [:p "hi"]]))
+        "ordinary CLJS data is untouched — the parity fixtures at
+         re-frame.ssr.hash-parity-fixtures are the full statement of
+         that, pinned on both runtimes")))


### PR DESCRIPTION
## What was wrong

`re-frame.ssr.hash/canonical-edn-into`'s `:else` branch delegates to `pr-str`. `cljs.core`'s printer has **exactly two branches that descend** into a foreign value — `object?` (prints `#js {…}` by walking `js-keys`) and `array?` (prints `#js […]` by walking elements) — and neither carries a seen-set. A cyclic foreign object graph therefore recurs until the stack blows.

React 19's `createContext` returns an object whose `Provider` key points back at the context itself (`ctx.Provider === ctx`, asserted in the new suite), so `render-tree-hash` over an ordinary provider-headed form raised `RangeError: Maximum call stack size exceeded` instead of returning a hash.

**It is a general cycle, not `Provider` specifically.** A hand-built `(unchecked-set o "self" o)` — no React anywhere — reproduces it identically, and so does a cycle reached through a JS *array*. Both are rows in the new suite.

## The fix

Two CLJS-only branches in `canonical-edn-into`, ahead of `:else`: a foreign JS object appends `#js{}`, a JS array appends `#js[]`, and neither is descended into.

**Why those two predicates and no others.** They are precisely the two `cljs.core` printer branches that recurse, so the walk stops exactly where `pr-str` would have started descending. Every other print form a foreign value can take — `#inst`, `#"regex"`, `#object[Symbol(x)]`, the terminal `#object[Ctor]` — is bounded and recurses into nothing, and keeps the serialisation it has today (pinned by `only-the-two-descending-printer-branches-are-intercepted`).

**Why not a seen-set.** A general cycle guard would have to thread through five functions on the production hash path to buy termination for a value class the walk should not have been descending into anyway. Not descending is cheaper and it is the treatment the `fn?` branch already gives a foreign callable.

**No hash is introduced anywhere.** This changes only what the walk *does when asked*; it does not add a caller, and the adoption tier goes on shipping no `:rf/render-hash` (rf2-2rtt6.91).

**Second reason, which makes this more than defensive.** Descending re-opened the identity leak the `fn?` branch exists to close (rf2-jsa2ml): `#js {"component" f}` printed `#js {:component #object[f]}` — a JS function's `.name`, which `:advanced` renames. One render tree hashed differently in dev and in release, and could never agree with a JVM-side hash of the same tree. The measured corpus below shows exactly that string.

## Existing hashes: measured, not asserted

A 75-entry corpus — all 23 `hash-parity-fixtures`, the nil-prune pairs, all 9 Hicasso SSR corpus rows, and 41 hand-built values covering every branch of the walk — was dumped to canonical-EDN **and** hash before and after, then diffed byte-for-byte.

**61 of 75 entries are byte-identical.** Every changed entry contains a foreign JS object or array; no entry without one moved. Four went from `RangeError` to a hash.

| entry | before | after |
|---|---|---|
| all 23 `parity/*` | unchanged | unchanged |
| all 4 `nilprune/*` | unchanged | unchanged |
| 7 of 9 `hicasso/*` (incl. every `[#fn[] {}]` root, `83b865f8`) | unchanged | unchanged |
| `hicasso/defhost-ssr-policy` | `c5a1cf91`, canonical carried `#object[re_frame$bench$hicasso$ssr$fixtures$client_widget]` | `93183e3c`, canonical carries `#js{}` |
| `hicasso/defhost-ssr-render` | **`RangeError`** | `76b17086` |
| 10 hand-built `#js` values | descended | one token |
| 4 hand-built cyclic values | **`RangeError`** | a hash |

The one existing hash that moves is `defhost-ssr-policy`, and it moves *because* it was carrying munged JS function names. Nothing pins it: `entry-cljs-test` asserts only `(not= dogfood markup)` (still true — `83b865f8` vs `93183e3c`), and `instance-key-payload-dom-cljs-test` asserts `(= dogfood green red)` over three `[#fn[] {}]` roots, all unchanged.

## Mutation, both directions

- **Forward** — `a-cyclic-foreign-value-hashes-instead-of-blowing-the-stack` covers seven shapes (bare cycle, context, provider, provider in head position, provider nested in markup, provider in an attribute value, cycle through a JS array). All hash.
- **Reverse** — reverting the branch and re-running the named test: **12 failures, 2 errors**, each reporting `{:threw "RangeError", :message "Maximum call stack size exceeded"}` in its failure text.

**How the test observes a stack overflow.** A `RangeError` inside `render-tree-hash` is an ordinary synchronous throw — nothing routes it to `reportError`, so no row depends on the runner noticing an exception it never saw. Every row calls the walk through a helper returning `{:hash …}` or `{:threw "RangeError" …}` and asserts on that **map**, so a regression fails with the error's own name in the text rather than aborting the var. `the-fixtures-are-genuinely-cyclic` is the non-vacuity control: it asserts `cljs.core/pr-str` — the exact printer the `:else` branch reaches — *does* blow the stack on these same fixtures, so the rows below cannot pass on an acyclic fixture and prove nothing.

## Hook ledger

Unchanged. The diff is one `.cljc` walker and one new test namespace: no React component, no hook, no render path. The `≤2-hook` shell is untouched.

## A verified sibling, deliberately not fixed here

The same mechanism is live in `re-frame.ssr.emit`. `reject-invalid-hiccup-head!` builds its message from `(pr-str (first el))` and `(pr-str el)`, so `emit-element` on `[ctx.Provider {…}]` raises `RangeError` **instead of** `:rf.error/invalid-hiccup-head` — measured, along with the acyclic control that still produces the correct error. There are six such sites in `emit.cljc`, four more in `ui_tree.cljc`, and the same values ride out in `:extra {:element el}` ex-data.

That is a different fix (bounded diagnostic printing plus ex-data payloads, across ten call sites in XSS-sensitive error paths), so it gets its own bead rather than widening a two-branch change. Filed as **rf2-9s68n**.

## Fence note for the reviewer

The brief fenced `implementation/ssr/**`. `render-tree-hash` lives there and nowhere else, so the fix could not land outside it. No open PR touches `implementation/ssr/` — checked before editing.

## Quality gates

All run in the worker worktree, foreground to completion, each verdict taken from the runner's own terminal line rather than from an exit code alone.

| gate | exit | the runner's own verdict |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` |
| ├ JVM `implementation/core` | — | `Ran 2215 tests containing 11527 assertions.` / `0 failures, 0 errors.` |
| ├ JVM `implementation/ssr` | — | `Ran 623 tests containing 3127 assertions.` / `0 failures, 0 errors.` — the JVM half of the parity pins |
| ├ `npm run test:cljs` (CLJS node integration) | — | `Ran 12647 tests containing 63357 assertions.` / `0 failures, 0 errors.` |
| └ `npm run test:hicasso-compile` | — | `[hicasso-compile] ok — 126 lane namespaces compiled with zero warnings` |
| `npm run test:browser` | **0** | `Browser tests: Ran 1101 tests containing 6818 assertions. 0 failures, 0 errors. (source: browser console)` |
| clj-kondo **2026.04.15** (the CI pin, via `-Sdeps`), CI's exact `--lint` roster | **0** | `linting took 65712ms, errors: 0, warnings: 4536` |

**clj-kondo: 0 errors**, warnings 4536 against the ~4,536 baseline, and **zero findings name either changed file**. Run at the CI pin rather than the local 2025.10.23.

**GitHub CI on this head: 50 pass / 35 skipping / 0 fail** — `All required checks passed`, `Lint required`, `Docs required` all green, including `CLJS (shadow-cljs :node-test)`, `CLJS (shadow-cljs :browser-test, headless Chromium)`, `JVM ssr`, `JVM ssr under the production gate`, `JVM ssr-ring`, `No hardcoded personal/home paths` and `Beads PR boundary`.

The measurement probe used to produce the before/after canonical dumps was a temporary namespace; it is **not in this diff**. The diff is one `.cljc` walker and one new test namespace.
