### PR TITLE
docs: three records say what is true now (rf2-yoh46, rf2-raqes, rf2-2rtt6.130)

### DIFF
--- a/docs/design/hicasso/studio/raw-escape-design-a-minimal.md
+++ b/docs/design/hicasso/studio/raw-escape-design-a-minimal.md
@@ -372,10 +372,10 @@ table ("a `[:>]` node has reduced structural identity — prefer `defhost`, or a
 around the node"). It has never been cashed out, and cashing it out needs one fact
 stated first, because it reframes the whole edge:
 
-> **Hicasso's headless structural render does not exist.** `draft-guide/08-testing.md`
-> line 16 calls the `h/render` block a sketch — *"Nothing in the tree implements this
-> yet"* — and its names are marked `[unfrozen]`. The built structural surface in this
-> repo is Freehand's (`re-frame.freehand.test`), whose node schema
+> **Hicasso's headless structural render does not exist.** `draft-guide/08-testing.md`'s
+> `### Full headless render (not built)` calls the `h/render` block a sketch — *"Nothing
+> implements that yet"* — and its names are marked `[unfrozen]`. The built structural
+> surface in this repo is Freehand's (`re-frame.freehand.test`), whose node schema
 > (`spec/004B-UI-Tree-and-Conversion.md`) carries a `:rf.ui/host` variant. Hicasso's is
 > designed, not built.
 
@@ -383,10 +383,13 @@ And one more, which is the sharpest thing on this edge and cuts *against* the ph
 apparent weight:
 
 > **The foreign region is already out of headless scope for both forms.**
-> `08-testing.md` line 44: *"If a body renders a foreign component through `defhost`
-> (or the `[:>]` escape, once it is built), the foreign region is out."* So what
-> `defhost` buys over `[:>]` structurally is **the crossing node's identity**, not
-> visibility into what the component renders. Neither form gives you that.
+> `08-testing.md`, as it read before `aa9ea1b698`: *"If a body renders a foreign
+> component through `defhost` (or the `[:>]` escape, once it is built), the foreign
+> region is out."* That sentence is gone; today's `### Full headless render (not built)`
+> states the same scope without naming the escape — *"Hooks, `defhost`, and host edges
+> stay mounted tests."* So what `defhost` buys over `[:>]` structurally is **the crossing
+> node's identity**, not visibility into what the component renders. Neither form gives
+> you that.
 
 ### Decision
 
@@ -813,9 +816,10 @@ up clause 5's named refusal for the plain-object case.
   `lower-declared-prop`.
 - `implementation/freehand/test/re_frame/bench/hicasso/arm1/host_ssr_dom_cljs_test.cljs`
   — the declared form's first-pass hydration row, whose shape edge 1 borrows.
-- `docs/design/hicasso/draft-guide/08-testing.md` — lines 16 and 44, which establish
-  that Hicasso's headless render is a sketch and that the foreign region is out of its
-  scope for both forms.
+- `docs/design/hicasso/draft-guide/08-testing.md` — its `### Full headless render (not
+  built)` section, which establishes that Hicasso's headless render is a sketch and (as
+  the file read before `aa9ea1b698`) that the foreign region is out of its scope for both
+  forms.
 - `spec/004B-UI-Tree-and-Conversion.md` — the shipped node schema's `:rf.ui/host`
   variant, and the silent-fragment-arm warning edge 3 borrows.
 - Beads `rf2-2rtt6.85` (the `:ssr` policy and its merged-PR audit), `rf2-2rtt6.86` (the

--- a/docs/design/hicasso/studio/raw-escape-spec.md
+++ b/docs/design/hicasso/studio/raw-escape-spec.md
@@ -345,9 +345,9 @@ asserted on and never serialised into a golden.
 
 **4. The forward obligation, recorded and not built.** Design A alone establishes the two
 facts that reframe this edge, and both come from the guide's own testing chapter: Hicasso's
-headless structural render **does not exist** (`08-testing.md:16` calls it a sketch — "nothing
-in the tree implements this yet"), and **the foreign region is already out of its scope for
-both forms** (`08-testing.md`'s `### Full headless render (not built)` — *"Hooks, `defhost`, and
+headless structural render **does not exist** (`08-testing.md`'s `### Full headless render
+(not built)` calls it a sketch — *"Nothing implements that yet"*), and **the foreign region
+is already out of its scope for both forms** (the same section — *"Hooks, `defhost`, and
 host edges stay mounted tests"*). So what `defhost` buys structurally is the crossing node's
 identity, not visibility into what the component renders — *neither form gives you that*. The
 cost today is therefore close to zero, and saying so honestly matters more than sounding

--- a/implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc
@@ -30,10 +30,14 @@
 
   ## Posture split (rf2-lwtlk)
 
-  This namespace guards `project-routing-egress` — what leaves the server
-  inside a hydration payload — so its exclusion from
-  `scripts/test-ssr-prod-gate.sh` was checked rather than assumed. The one
-  assertion that was red under `-Dre-frame.debug=false` is the
+  This namespace RUNS in `scripts/test-ssr-prod-gate.sh` and is green
+  there: rf2-lwtlk's known-red roster reached zero, the `-n` selector went
+  with it, and the lane is now the whole suite with no exclusions. The
+  split below is what let this namespace join, and because it guards
+  `project-routing-egress` — what leaves the server inside a hydration
+  payload — which assertion moved behind the posture guard was checked
+  rather than assumed. The one assertion that was red under
+  `-Dre-frame.debug=false` is the
   `:rf.ssr/invalid-version` WARNING trace in
   `resolve-version-coerces-and-rejects-to-integer`: the dev half. The
   REJECTION it accompanies — a semver string never reaches `:rf/version`,

--- a/tools/xray/spec/017-Test-Coverage-Matrix.md
+++ b/tools/xray/spec/017-Test-Coverage-Matrix.md
@@ -46,8 +46,8 @@ browser-level feature path, not that the path guards the PR that breaks
 it. Per `TESTING.md`, tag a scenario `smoke: true` only if it earns a
 slot on every PR **and** loads an already-staged smoke surface;
 everything else is nightly by default, and the author is expected to run
-the full gate locally (`scripts/test-rigorous-local.sh`) before merging
-a scenario the PR tier will not execute.
+the full gate locally (`cd implementation && npm run test:xray-feature-gate`)
+before merging a scenario the PR tier will not execute.
 
 ## Required shared testbed
 


### PR DESCRIPTION
Three records that described a state the tree no longer has. Each is a few lines; no claim, figure or verdict changed anywhere.

Net line delta across the branch: **+28 / -20 = +8**.

## rf2-yoh46 — FIXED (corrected, not retired)

`payload_policy_cljs_test`'s ns docstring opened by justifying its **exclusion** from `scripts/test-ssr-prod-gate.sh`. There is no exclusion. rf2-lwtlk's known-red roster reached zero, the `-n` selector went with it, and the script now prints `PASS implementation/ssr under -Dre-frame.debug=false (whole suite, no exclusions)` — so this namespace **runs in that lane and is green there**, which is the outcome the rest of the same paragraph describes earning. Only the framing was stale, so only the framing changed.

**The bead offered retiring the whole `## Posture split` section as the cheaper answer. Argued and rejected, on three grounds:**

1. **The section is the recorded rationale for a live form in this file.** `resolve-version-coerces-and-rejects-to-integer` carries a `(when interop/debug-enabled? …)` arm whose own inline comment reads *"rf2-lwtlk — dev-instrumentation arm (see ns docstring)"*. Retiring the section orphans that pointer and leaves a posture guard with no stated justification.
2. **The gate script warns specifically against guards of that shape.** Its FAIL message: *"A `when interop/debug-enabled?` arm around an assertion that had an always-on source moves a live contract out of the posture that ships."* This section is this namespace's answer to that warning — it names which assertion was red, why the REJECTION it accompanies is asserted separately and passes in both postures, and which always-on witness covers the egress (`re-frame.ssr-routing-egress-production-test`, rf2-u2x6w).
3. **The distinction is not dead.** It no longer partitions *namespaces* across the lane, but it still partitions *assertions* inside this one. And the tree's own idiom for this exact event is the script itself, which kept its whole roster history under `THERE USED TO BE A ROSTER. IT IS EMPTY, SO IT IS GONE` and closes by telling a future author to read it before reintroducing a list.

## rf2-raqes — FIXED

`tools/xray/spec/017` teaches the local-pre-merge convention and defers to `TESTING.md` **by name** for it, but spelled the command as `scripts/test-rigorous-local.sh`. Not wrong — that script invokes the same npm target at `:95` — but a whole rigorous sweep where the narrow gate suffices, and different advice from the document it cites. 017 now carries `TESTING.md`'s verified spelling: `cd implementation && npm run test:xray-feature-gate`.

**Standing convention, stated plainly:** a dispatch touching `tools/xray/` updates `tools/xray/spec/*` in the same PR. This IS that spec edit — `017-Test-Coverage-Matrix.md` is the file rf2-raqes names, and nothing else under `tools/xray/` is touched.

## rf2-2rtt6.130 — FIXED, without re-pointing the line numbers

Three sites quoted sentences that `aa9ea1b698` ("triple-pass draft guide") removed from `draft-guide/08-testing.md`. The rf2-2rtt6.129 citation sweep left them as line numbers **on purpose**: re-pointing them at today's section would have attached a quotation that section does not contain — precisely the failure that sweep exists to remove.

Verified first that the old numbers were *correct when written*: at `aa9ea1b698^`, quote 1 is on line 16 and quote 2 on line 44, exactly as cited. The guide moved under them.

Repaired the way that same sweep already repaired the sibling clause in `raw-escape-spec.md` — one of two moves per site, chosen by whether today's guide still carries the sentence:

- **`"Nothing in the tree implements this yet"`** → the guide now says **`"Nothing implements that yet"`** under `### Full headless render (not built)`. Near-verbatim, same claim, so both sites (`raw-escape-design-a-minimal.md`, `raw-escape-spec.md`) **re-quote today's wording and point at the section heading**. The line numbers go with them.
- **`"If a body renders a foreign component through defhost (or the [:>] escape, once it is built), the foreign region is out."`** is **gone with no near-equivalent that names the escape**. Today's guide states the same scope as *"Hooks, `defhost`, and host edges stay mounted tests"* — which does not mention `[:>]`, and the record's argument turns on *both forms*. So this quote is **pinned to the revision it came from** (`as it read before aa9ea1b698`) and kept verbatim, with today's scope line quoted beside it so a reader sees both. Superseded text preserved as history, per the file's own dated-note idiom.

The Sources bullet's `lines 16 and 44` follows the same split.

Both claims remain true of the guide today — this was a provenance defect, not a correctness one.

## Quality gates

Run from `C:/…/re-frame2-worktrees/trueups-yoh46` (navigation only; no path is in committed content — `git grep -n 'Users/miket'` over the four touched files exits 1).

| Gate | Exit | Result |
|---|---|---|
| `python scripts/check_doc_slugs.py` | **0** | clean |
| `python scripts/check_doc_slugs.py` (mutated) | **1** | mutation proof — see below |
| `clj-kondo` @ CI pin `2026.04.15`, `--fail-level error` | **0** | `errors: 0, warnings: 0` on the touched `.cljc` |
| `cd implementation && npm run test:cljs` | **0** | `Ran 12642 tests containing 63334 assertions. 0 failures, 0 errors.` |
| `sh <worktree>/scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` (log line 1457), ran to completion |

**Spine classification, as printed rather than predicted** (log line 2):

```
=== fast PR spine: docs=true jvm=true node=true (classified) ===
```

Also on the PR itself: **51 pass / 34 skipping / 0 fail / 0 cancelled**. Includes `JVM ssr under the production gate (-Dre-frame.debug=false)` — pass, 1m7s — whose log is the direct evidence for rf2-yoh46:

```
namespaces   : the WHOLE suite — every `.*-test$` namespace under
               `-n` selector went with it.
Ran 625 tests containing 2954 assertions.
PASS implementation/ssr under -Dre-frame.debug=false (whole suite, no exclusions)
```

The namespace's 34 `deftest`s carry no `^:slow` / `^:stress` / `^:prod-gate` metadata, so none is filtered out of that lane by the runner's `-e` selectors. The docstring now says what that job prints.

The spine's own advisory — *"clj-kondo: CI pins 2026.04.15. A pass from a differently-versioned local binary PROVES NOTHING"* — is discharged: the local `clj-kondo` on PATH is v2025.10.23, so the pin was fetched (`clojure -Sdeps '{:deps {clj-kondo/clj-kondo {:mvn/version "2026.04.15"}}}'`) and the reported run is at the pin, unpiped.

**Mutation proof that `check_doc_slugs.py` really covers `tools/xray/spec/017`.** Appended one line carrying a broken relative link *and* a broken in-page anchor, **grep-confirmed it landed at `017-Test-Coverage-Matrix.md:376` before reading any exit code**, then ran the checker:

```
BROKEN TARGET: tools\xray\spec\017-Test-Coverage-Matrix.md:376 -> ./tu-no-such-file-017.md
BROKEN ANCHOR: tools\xray\spec\017-Test-Coverage-Matrix.md:376 -> #tu-no-such-anchor-017
MUTATED_EXIT=1
```

Probe reverted; `grep -c` for it now returns 0 and the real edit is confirmed still in place at `:49`.

**`mkdocs build --strict` was NOT run and is NOT nominated.** `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site, so it would exit 0 having verified nothing about two of the three files. `check_doc_slugs.py` is the gate that does cover them.

**Hand-verified table column counts** (nothing validates tables). No table row appears anywhere in the diff (`git diff origin/main…HEAD -U0 | grep -c '^[+-].*|'` = **0**), and all three touched markdown files re-counted whole, every table uniform, none ragged:

| File | Tables | Columns per table |
|---|---|---|
| `tools/xray/spec/017-Test-Coverage-Matrix.md` | 6 | 2, 2, 2, 9, 2, 4 |
| `docs/design/hicasso/studio/raw-escape-design-a-minimal.md` | 4 | 3, 3, 2, 3 |
| `docs/design/hicasso/studio/raw-escape-spec.md` | 4 | 3, 3, 2, 2 |

**The `.cljc` diff is docstring-only.** The ns docstring's single opening `"` is on line 2 and its single closing `"` on line 52; every changed line (33–40) sits strictly inside that range, and the replacement text introduces no `"` character at all. No executable form, no `(require)`, no deftest touched.

## Bead filed

**`rf2-znup0` (P3)** — `check_doc_slugs.py` does not walk repo-root markdown. rf2-raqes recorded this as a second finding and invited a bead if the gap is judged real; it is. `_iter_markdown`'s roster is `docs`, `spec`, `skills`, `migration` plus `tools/*/spec` (`:69-82`, `:444-460`), so `TESTING.md`, `README.md` and four siblings — 36 relative `.md` links and 2 in-page anchors — have no link gate at all, and `mkdocs.yml` does not list them either. The mutation above proves the checker's machinery works; it is purely the roster that omits root. Several dispatch briefs have asserted this file covers `TESTING.md`. It does not.
