### PR TITLE
test(ci): repo-root markdown gets the link gate everything else has (rf2-znup0)

### DIFF
--- a/scripts/_test_fixtures/check_readme_links/root_markdown_broken_link/CHANGELOG.md
+++ b/scripts/_test_fixtures/check_readme_links/root_markdown_broken_link/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+The anchor `#no-such-heading` that `TESTING.md` links at is deliberately
+absent from this file, so the link is a BROKEN ANCHOR rather than a
+BROKEN TARGET.

--- a/scripts/_test_fixtures/check_readme_links/root_markdown_broken_link/TESTING.md
+++ b/scripts/_test_fixtures/check_readme_links/root_markdown_broken_link/TESTING.md
@@ -1,0 +1,12 @@
+# Root markdown with a broken link and a broken anchor
+
+Negative control for the repo-root roster (rf2-znup0), and the mutation the
+bead proved the docs gate exits 0 on: one broken relative target and one
+broken in-page anchor, in a root file that is not a README.
+
+* [broken target](does-not-exist.md) — no such file.
+* [broken anchor](CHANGELOG.md#no-such-heading) — the file exists, the
+  heading does not.
+
+Two findings, therefore.  A count of 0 means the roster stopped walking the
+repo root; a count above 2 means something else started firing.

--- a/scripts/_test_fixtures/check_readme_links/root_markdown_broken_link/mkdocs.yml
+++ b/scripts/_test_fixtures/check_readme_links/root_markdown_broken_link/mkdocs.yml
@@ -1,0 +1,2 @@
+# Self-test fixture marker.  Empty config is fine — the validator only
+# checks for this file's existence as the repo-root guard.

--- a/scripts/_test_fixtures/check_readme_links/root_markdown_ok/CHANGELOG.md
+++ b/scripts/_test_fixtures/check_readme_links/root_markdown_ok/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+
+A second tracked root document, so the fixture proves the roster picks up
+more than one file and that root-to-root links resolve.

--- a/scripts/_test_fixtures/check_readme_links/root_markdown_ok/TESTING.md
+++ b/scripts/_test_fixtures/check_readme_links/root_markdown_ok/TESTING.md
@@ -1,0 +1,14 @@
+# Root markdown, all links correct
+
+Positive control for the repo-root roster (rf2-znup0).  This file is NOT a
+README, so before the roster widened it was invisible to every link gate in
+the repo — the docs gate never walked the repo root and this gate only ever
+globbed for `README.md`.
+
+It links to [a sibling root document](CHANGELOG.md#unreleased) and to
+[a file below the root](sub/other.md), and both resolve, so the fixture must
+report zero findings.  Its mirror image is `root_markdown_broken_link/`.
+
+## Section one
+
+Same-file anchors are validated too: see [section one](#section-one).

--- a/scripts/_test_fixtures/check_readme_links/root_markdown_ok/mkdocs.yml
+++ b/scripts/_test_fixtures/check_readme_links/root_markdown_ok/mkdocs.yml
@@ -1,0 +1,2 @@
+# Self-test fixture marker.  Empty config is fine — the validator only
+# checks for this file's existence as the repo-root guard.

--- a/scripts/_test_fixtures/check_readme_links/root_markdown_ok/sub/other.md
+++ b/scripts/_test_fixtures/check_readme_links/root_markdown_ok/sub/other.md
@@ -1,0 +1,5 @@
+# Other
+
+Link target below the repo root.  It is NOT itself scanned — the root roster
+is non-recursive and this file is not a README — but it must still resolve as
+a target, which is what `root_markdown_ok/TESTING.md` asserts.

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -22,6 +22,18 @@ Exit code:
     2  invocation / setup error
 
 Notes on what is and isn't checked:
+    * REPO-ROOT MARKDOWN IS NOT THIS GATE'S (rf2-znup0). The roster is
+      DEFAULT_ROOTS plus tools/*/spec (see `_iter_markdown`), so `TESTING.md`,
+      `README.md`, `CHANGELOG.md`, `CLAUDE.md`, `AGENTS.md` and
+      `SKILL-REDIRECT.md` are never opened here — this gate exits 0 on a broken
+      link in any of them. Several dispatch briefs have nominated it as the gate
+      for a root-markdown edit and got a green exit code that verified nothing.
+      Root markdown appears nowhere in `mkdocs.yml`, so GitHub renders it and
+      `scripts/check_readme_links.py` owns it: that gate models GitHub's `-N`
+      duplicate-heading suffix where this one models MkDocs' `_N`, and it runs
+      on every PR. Widening THIS roster to the repo root was considered and
+      rejected — it would double-cover the root `README.md` under two
+      conflicting duplicate-suffix rules.
     * Only intra-repo links are validated. External http(s) URLs are skipped.
     * Only links to .md files are validated. Code, image, and asset links
       are skipped (their existence is mkdocs' concern, not the slug index's).

--- a/scripts/check_readme_links.py
+++ b/scripts/check_readme_links.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate links in every README.md in the repo.
+"""Validate links in every README.md — and in every repo-root markdown file.
 
 Companion gate to `scripts/check_doc_slugs.py` (rf2-br5u7).  Where
 `check_doc_slugs.py` covers the published docs corpus (docs/, spec/,
@@ -9,7 +9,38 @@ testbeds/, tools/, etc.  These READMEs are read on GitHub and in the
 local working tree but are **not** copied into the MkDocs site, so
 they need their own anchor-correctness gate.
 
-What this validates per README:
+REPO-ROOT MARKDOWN IS THE SAME SURFACE (rf2-znup0).  `AGENTS.md`,
+`CHANGELOG.md`, `CLAUDE.md`, `SKILL-REDIRECT.md` and `TESTING.md` sit
+beside the root `README.md` this gate has always walked, appear nowhere
+in `mkdocs.yml`, and are therefore rendered by GitHub exactly as the
+READMEs are — yet `check_doc_slugs.py`'s roster (DEFAULT_ROOTS +
+`tools/*/spec`) never opened them, so they had no link gate of any kind.
+A mutation carrying a broken relative link AND a broken in-page anchor
+was appended to `TESTING.md` and the docs gate still exited 0.
+
+They belong HERE rather than in the docs gate for three reasons, and the
+choice changes no finding on today's tree — it is decided on renderer
+authority and scheduling, not on findings:
+
+    * RENDERER.  The docs gate models MkDocs' `_N` duplicate-heading
+      suffix; this one models GitHub's `-N`, and the two deliberately
+      disagree because their renderers do (rf2-zzt2r).  Root markdown
+      renders on GitHub, so `-N` is the rule that actually resolves in a
+      browser.
+    * NO DOUBLE-COVERAGE.  The root `README.md` is already in this gate's
+      roster.  Adding root markdown to the docs gate instead would cover
+      that one file twice, under two conflicting duplicate-suffix rules.
+    * SCHEDULING.  `verify-readme-links` runs `--ci` on EVERY pull request
+      (test.yml's trigger is unfiltered and the job carries no surface
+      guard), where the docs gate is documentation-surface-gated.  Root
+      markdown gets the stronger of the two lanes for free.
+
+The root roster is GIT-TRACKED and NON-RECURSIVE (see `_iter_root_markdown`),
+so it cannot grow into `implementation/`, `tools/`, `node_modules` or any
+generated tree, and an untracked scratch file dropped at the repo root
+cannot red the gate on an author's machine (the rf2-k30r7 lesson).
+
+What this validates per file:
 
     * BROKEN TARGET   — internal link points at a .md file (or any
                         repo-internal path) that does not exist.
@@ -53,6 +84,9 @@ What this skips (deliberate scope cuts):
     * READMEs that live under directories check_doc_slugs.py already
       walks (docs/, spec/, migration/, skills/, tools/*/spec/) — those
       are covered by the docs gate.  No double-coverage.
+    * Markdown BELOW the repo root that is not a README.md.  The root
+      roster is deliberately non-recursive; everything deeper is either
+      the docs gate's or a README this gate already walks.
 
 CLI:
     --verbose       print progress + per-finding detail
@@ -71,6 +105,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import subprocess
 import sys
 import urllib.error
 import urllib.parse
@@ -214,6 +249,74 @@ def _iter_readmes(repo_root: Path) -> Iterable[Path]:
         yield path
 
 
+def _iter_root_markdown(repo_root: Path) -> Iterable[Path]:
+    """Yield every GIT-TRACKED markdown file sitting AT the repo root (rf2-znup0).
+
+    Two properties make this roster safe to add, and both are structural
+    rather than a list somebody has to maintain:
+
+    NON-RECURSIVE.  `git ls-files` pathspecs use fnmatch without
+    FNM_PATHNAME, so `*` matches `/` and a bare `*.md` pathspec would
+    return markdown at every depth — the whole of `docs/`, `implementation/`,
+    `tools/` and every generated tree.  Entries containing a separator are
+    therefore dropped, leaving exactly the files a reader sees when they open
+    the repository on GitHub.  The roster cannot grow silently: a new
+    directory is invisible to it by construction, while a genuinely new root
+    document (the next `TESTING.md`) is picked up the moment it is tracked —
+    which is the failure this closes, so an explicit six-name list would just
+    re-open it one file later.
+
+    GIT-TRACKED, NOT A FILESYSTEM WALK.  A `.glob("*.md")` would scan an
+    author's untracked scratch notes, so a stray root `PLAN.md` with a
+    speculative link could red the gate on one machine while CI — which runs
+    on a clean clone — stayed green.  That is the rf2-k30r7 defect, recorded
+    against this gate's sibling; the roster is Git tracking so it cannot
+    recur here.
+
+    `git ls-files` is scoped to (and reports relative to) `repo_root`, so the
+    self-tests point this at a fixture subtree unchanged.
+    """
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "--", "*.md"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git ls-files failed in {repo_root}: {result.stderr.strip()}"
+        )
+    for rel in sorted(entry for entry in result.stdout.split("\0") if entry):
+        if "/" in rel:
+            continue
+        path = repo_root / rel
+        # A tracked path can be absent from the working tree mid-rename; the
+        # index still lists it. Skip rather than crash the whole scan.
+        if path.is_file():
+            yield path
+
+
+def _iter_scanned(repo_root: Path) -> Iterable[Path]:
+    """Yield every file this gate validates: the README corpus plus root markdown.
+
+    Deduplicated by resolved path, because the repo-root `README.md` is a
+    member of both rosters.
+    """
+    seen: set[Path] = set()
+    for path in _iter_readmes(repo_root):
+        ap = path.resolve()
+        if ap in seen:
+            continue
+        seen.add(ap)
+        yield path
+    for path in _iter_root_markdown(repo_root):
+        ap = path.resolve()
+        if ap in seen:
+            continue
+        seen.add(ap)
+        yield path
+
+
 def _github_dedupe(slug: str, occurrences: dict[str, int]) -> str:
     """Return `slug` disambiguated per GitHub's duplicate-heading rule.
 
@@ -347,7 +450,7 @@ def check(
     verbose: bool = False,
     check_external: bool = False,
 ) -> int:
-    """Validate every README.md in the repo.  Return finding count.
+    """Validate every README.md plus every repo-root markdown file.  Return finding count.
 
     Findings:
         * BROKEN TARGET   — internal link to a missing file.
@@ -355,9 +458,11 @@ def check(
         * BROKEN EXTERNAL — only when check_external=True; HEAD-probe
                             failed or returned non-2xx/3xx.
     """
-    files = list(_iter_readmes(repo_root))
+    files = list(_iter_scanned(repo_root))
     if verbose:
-        sys.stderr.write(f"scanning {len(files)} README.md files...\n")
+        sys.stderr.write(
+            f"scanning {len(files)} file(s) (README corpus + repo-root markdown)...\n"
+        )
 
     slug_cache: dict[Path, set[str]] = {}
 
@@ -425,7 +530,8 @@ def check(
 
     if broken_target:
         sys.stderr.write(
-            f"\n{len(broken_target)} broken target file(s) in README links:\n\n"
+            f"\n{len(broken_target)} broken target file(s) in README / "
+            "repo-root markdown links:\n\n"
         )
         for src, line_no, dest, target_rel in broken_target:
             rel = src.relative_to(repo_root)
@@ -436,7 +542,8 @@ def check(
 
     if broken_anchor:
         sys.stderr.write(
-            f"\n{len(broken_anchor)} broken anchor link(s) in READMEs:\n\n"
+            f"\n{len(broken_anchor)} broken anchor link(s) in READMEs / "
+            "repo-root markdown:\n\n"
         )
         for src, line_no, dest, target_rel in broken_anchor:
             rel = src.relative_to(repo_root)
@@ -446,8 +553,8 @@ def check(
             )
         sys.stderr.write(
             "\nFix: confirm the heading still exists in the target file and "
-            "update the link, or rename the heading and re-link.  These "
-            "READMEs render on GitHub, so anchors follow GitHub's heading "
+            "update the link, or rename the heading and re-link.  These files "
+            "render on GitHub, so anchors follow GitHub's heading "
             "slugger: the visible title cased down with punctuation dropped "
             "and spaces hyphenated, and repeated headings disambiguated with "
             "`-1`, `-2`, ... on the second and later occurrences.  GitHub's "
@@ -457,7 +564,8 @@ def check(
 
     if broken_external:
         sys.stderr.write(
-            f"\n{len(broken_external)} broken external URL(s) in READMEs:\n\n"
+            f"\n{len(broken_external)} broken external URL(s) in READMEs / "
+            "repo-root markdown:\n\n"
         )
         for src, line_no, dest, reason in broken_external:
             rel = src.relative_to(repo_root)
@@ -467,7 +575,7 @@ def check(
             )
 
     if total == 0 and verbose:
-        sys.stderr.write("no broken README links.\n")
+        sys.stderr.write("no broken README / repo-root markdown links.\n")
 
     return total
 
@@ -519,6 +627,11 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("external_link_skipped_by_default", 0),  # off without --check-external
         ("explicit_id_full_title_ok",        0),  # `{#id}` is heading TEXT (rf2-w6ltl)
         ("explicit_id_brace_not_a_target",   1),  # ...so the brace id resolves nowhere
+        # rf2-znup0 — repo-root markdown that is NOT a README. Neither fixture
+        # contains a README.md at all, so every finding (and every non-finding)
+        # comes from the root roster and nothing else. Both directions:
+        ("root_markdown_ok",                 0),  # correct root links stay silent
+        ("root_markdown_broken_link",        2),  # broken target + broken anchor
     ]
 
     failures = 0
@@ -547,11 +660,100 @@ def _run_self_tests(verbose: bool = False) -> int:
             )
             failures += 1
 
+    # rf2-znup0 — the root roster's two structural properties, asserted
+    # directly rather than only through a fixture's aggregate count.
+    #
+    # NON-RECURSIVE. `git ls-files -- '*.md'` matches at EVERY depth (git
+    # pathspecs are fnmatch without FNM_PATHNAME, so `*` crosses `/`), which is
+    # the naive addition that would drag `docs/`, `implementation/` and every
+    # generated tree into this gate. `root_markdown_ok/sub/other.md` is a
+    # tracked markdown file one level down: it must resolve as a link TARGET
+    # while never entering the roster itself.
+    #
+    # GIT-TRACKED. An untracked scratch document at the repo root must be
+    # invisible. The tooth is causal in both directions, mirroring rf2-k30r7:
+    # the same file is first proven poisonous when the roster does reach it,
+    # then proven absent from the tracked roster — a filesystem walk passes the
+    # first half and fails the second.
+    ok_root = _SELF_TEST_FIXTURE_ROOT / "root_markdown_ok"
+    root_roster = {
+        p.relative_to(ok_root).as_posix() for p in _iter_root_markdown(ok_root)
+    }
+    if root_roster != {"CHANGELOG.md", "TESTING.md"}:
+        sys.stderr.write(
+            "self-test FAIL: root roster is not exactly the tracked root markdown "
+            f"(got {sorted(root_roster)})\n"
+        )
+        failures += 1
+    elif verbose:
+        sys.stderr.write(
+            "self-test PASS: root roster is non-recursive — tracked markdown one "
+            "level down resolves as a target but is not scanned\n"
+        )
+
+    scratch = ok_root / "znup0_untracked_scratch.md"
+    try:
+        scratch.write_text(
+            "# Untracked scratch\n\n"
+            "[a link nobody tracked](znup0-no-such-file.md)\n",
+            encoding="utf-8",
+        )
+        # The POISON half: the scratch carries a genuinely broken target, and a
+        # filesystem-walk roster would take it. If either stopped being true the
+        # green result below would prove nothing.
+        scratch_is_poisonous = not (ok_root / "znup0-no-such-file.md").exists()
+        walk_roster = {p.name for p in ok_root.glob("*.md")}
+        saved_stderr = sys.stderr
+        sys.stderr = _DevNull()
+        try:
+            findings_with_scratch = check(
+                ok_root, verbose=False, check_external=False
+            )
+        finally:
+            sys.stderr = saved_stderr
+        tracked_roster = {
+            p.relative_to(ok_root).as_posix() for p in _iter_root_markdown(ok_root)
+        }
+    finally:
+        scratch.unlink(missing_ok=True)
+
+    if not (scratch_is_poisonous and scratch.name in walk_roster):
+        sys.stderr.write(
+            "self-test FAIL: the untracked-scratch fixture is not actually "
+            "poisonous to a walk-based roster, so the tracking tooth proves "
+            f"nothing (broken-target={scratch_is_poisonous}, "
+            f"walk-roster={sorted(walk_roster)})\n"
+        )
+        failures += 1
+    elif scratch.name in tracked_roster:
+        sys.stderr.write(
+            "self-test FAIL: an untracked scratch document at the repo root "
+            f"reached the roster (got {sorted(tracked_roster)})\n"
+        )
+        failures += 1
+    elif findings_with_scratch != 0:
+        sys.stderr.write(
+            "self-test FAIL: the untracked scratch reded the gate anyway, so the "
+            f"tracked roster is not what is consulted (got {findings_with_scratch})\n"
+        )
+        failures += 1
+    elif "TESTING.md" not in tracked_roster:
+        sys.stderr.write(
+            "self-test FAIL: the roster lost a tracked root document while "
+            f"excluding the untracked one (got {sorted(tracked_roster)})\n"
+        )
+        failures += 1
+    elif verbose:
+        sys.stderr.write(
+            "self-test PASS: an untracked root scratch document cannot red the "
+            "gate while tracked root markdown stays covered\n"
+        )
+
     if failures:
         sys.stderr.write(f"\n{failures} self-test failure(s).\n")
         return 1
     if verbose:
-        sys.stderr.write(f"all {len(cases)} self-tests passed.\n")
+        sys.stderr.write(f"all {len(cases) + 2} self-tests passed.\n")
     return 0
 
 


### PR DESCRIPTION
Closes rf2-znup0.

## The gap, and one correction to how it was filed

`scripts/check_doc_slugs.py`'s roster is `DEFAULT_ROOTS` (`docs`, `spec`, `skills`, `migration`) plus `tools/*/spec`. The repo root is in none of them, and no root document appears in `mkdocs.yml`, so `mkdocs build --strict` is not a gate for them either. A mutation carrying **both** a broken relative link and a broken in-page anchor, appended at `TESTING.md:274`, left the docs gate at **exit 0** — confirmed again on this branch.

**The bead says six root files carrying 36 relative `.md` links are ungated. Five files carrying 11 are.** The root `README.md` — 25 of those 36 links — has been gated all along by `scripts/check_readme_links.py`, which `rglob`s for `README.md` from the repo root and excludes only `docs/`, `spec/`, `migration/`, `skills/` and `tools/*/spec/`. Mutation-proved before touching anything: a broken target and a broken anchor appended to `README.md` red it by name at exit 1, while the docs gate stays 0.

The real exposure, measured per file:

| file | `.md` links | in-page anchors | gated before? |
| --- | --- | --- | --- |
| `README.md` | 25 | 0 | **yes** — `check_readme_links.py` |
| `CLAUDE.md` | 5 | 1 | no |
| `TESTING.md` | 4 | 1 | no |
| `CHANGELOG.md` | 2 | 0 | no |
| `AGENTS.md` | 0 | 0 | no (nothing to gate) |
| `SKILL-REDIRECT.md` | 0 | 0 | no (nothing to gate) |

`TESTING.md`'s four are the load-bearing ones — `tools/story/spec/015`, `tools/story/spec/017` and `tools/xray/spec/017` are cited by name, and those documents cite `TESTING.md` back.

## Which roster, and why not the obvious one

**Widening `check_doc_slugs.py` to the repo root was measured and rejected.** Both candidates were built and run: adding a non-recursive root glob to the docs gate takes it 674 to 680 files, 8.09s to 8.56s, **0 findings**; adding one to the README gate takes it 67 to 72 files, 0.43s to 0.43s, **0 findings**. Neither flags anything on today's tree, so the choice turns on renderer authority and scheduling, not on findings.

Three reasons the README gate is the right home:

* **Renderer.** Root markdown appears nowhere in `mkdocs.yml`, so GitHub renders it. `check_readme_links.py` models GitHub's `-N` duplicate-heading suffix; `check_doc_slugs.py` models MkDocs' `_N`. The two **deliberately disagree** because their renderers do (rf2-zzt2r). `-N` is the rule that actually resolves in a browser for these files.
* **No double-coverage.** The root `README.md` is already in the README gate. Putting root markdown in the docs gate would cover that one file twice, under two conflicting duplicate-suffix rules — and would falsify `check_readme_links.py`'s stated "No double-coverage" invariant.
* **Scheduling.** `verify-readme-links` runs `--ci` on **every** pull request: `test.yml`'s `pull_request` trigger is unfiltered and the job carries no surface guard. The docs gate is documentation-surface-gated in both CI and the spine. Root markdown lands in the stronger of the two lanes.

A fourth, incidental: the README gate checks non-`.md` targets exist (`target.exists()`), which the docs gate skips entirely. `TESTING.md` links at `.github/workflows/test.yml` and `.github/scripts/report-changed-surfaces.sh`; those are now covered too.

`check_doc_slugs.py` gains a docstring note only — naming its roster boundary and pointing at the sibling that owns the root, since briefs nominating it as the gate for a root-markdown edit is the recurring error the bead was filed over.

## The roster is bounded and derived

`_iter_root_markdown` uses `git ls-files -- '*.md'` and drops every entry containing a separator:

* **Non-recursive.** Git pathspecs are fnmatch without `FNM_PATHNAME`, so `*` crosses `/` and a bare `*.md` returns markdown at every depth — the naive addition that would drag `docs/`, `implementation/`, `tools/` and every generated tree in. Dropping separator-bearing entries leaves exactly what a reader sees opening the repository on GitHub. The roster cannot grow silently, and a genuinely new root document is covered the moment it is tracked — which is why this is a glob rather than a six-name list, since a hand-list re-opens the same gap one file later.
* **Git-tracked, not a filesystem walk.** A `.glob("*.md")` would scan an author's untracked scratch notes, so a stray root `PLAN.md` could red the gate on one machine while CI stayed green on a clean clone. That is rf2-k30r7, recorded against this gate's sibling.

## Proof the new coverage fires, by name

The bead's own probe, appended to the real `TESTING.md` and grep-confirmed at line 274:

```
BROKEN TARGET: TESTING.md:274 -> znup0-does-not-exist.md
    (missing: znup0-does-not-exist.md)
BROKEN ANCHOR: TESTING.md:274 -> #znup0-no-such-anchor
    (target: TESTING.md)
```

`check_readme_links.py --ci` gives **exit 1**. `check_doc_slugs.py` gives exit 0, unchanged and by design. Probe reverted; `git diff -- TESTING.md` is empty.

Pinned in the self-test in both directions, so it stays armed:

* `root_markdown_ok` expects 0. Neither new fixture contains a `README.md` at all, so every finding and non-finding comes from the root roster and nothing else.
* `root_markdown_broken_link` expects 2 (broken target + broken anchor). A count of 0 means the roster stopped walking the root; above 2 means something else started firing.
* **Non-recursion tooth** — `root_markdown_ok/sub/other.md` is tracked markdown one level down: it must resolve as a link *target* while never entering the roster. The roster is asserted to be exactly `{CHANGELOG.md, TESTING.md}`.
* **Tracking tooth** — an untracked root scratch is first proven *poisonous* (its target genuinely does not exist, and a `.glob` roster does take it), then proven absent from the tracked roster with the gate still at 0. A filesystem walk passes the first half and fails the second.

Self-test count goes 16 to 18.

## Existing coverage, compared finding-by-finding

The old 67-file README roster is a **strict prefix of the new 72-file roster, identical in set and order**; the five appended entries are exactly `AGENTS.md`, `CHANGELOG.md`, `CLAUDE.md`, `SKILL-REDIRECT.md`, `TESTING.md`. Every pre-existing fixture keeps its exact expected count (14/14 unchanged). Full-corpus findings: 0 before, 0 after. `check_doc_slugs.py`'s 674-file roster and its 0 findings are untouched — the change there is a comment.

## Scheduled and derived

No new gate command, so nothing needs a lane: the widened roster rides `python scripts/check_readme_links.py --ci` and `--self-test`, both already invoked one-per-line in `scripts/test-fast-pr.sh` and both already required steps of `test.yml`'s `verify-readme-links`. `check_gate_scheduling.py --verbose` and `check_fast_pr_gap.py --check` both pass with no disposition added. No loop was introduced and no hyphenated `.github/scripts/` name. `check_retired_composition_vocab.py`'s own root roster is untouched.

## Quality gates

Run from the worker worktree. Every gate foregrounded to completion; nothing piped through `tail`/`head`/`grep`.

| gate | exit | timing | note |
| --- | --- | --- | --- |
| `sh scripts/test-fast-pr.sh` | **0** | full run | classification line as printed: `=== fast PR spine: docs=true jvm=false node=false (classified) ===` |
| `python scripts/check_readme_links.py --self-test --verbose` | **0** | 0.74s | 18/18, up from 16 |
| `python scripts/check_readme_links.py --ci` | **0** | 0.74s | 72 files |
| `python scripts/check_doc_slugs.py --self-test` | **0** | 0.70s | 58/58, unchanged |
| `python scripts/check_doc_slugs.py --verbose` | **0** | 9.95s | 674 files, unchanged |
| `python scripts/check_gate_scheduling.py --self-test` | **0** | 0.23s | |
| `python scripts/check_gate_scheduling.py --verbose` | **0** | 0.23s | 40 gate commands, 34 scheduled, 6 declared, 0 known holes |
| `python scripts/check_fast_pr_gap.py --self-test` | **0** | 0.24s | |
| `python scripts/check_fast_pr_gap.py --check` | **0** | 0.24s | 77 required jobs, map clean |

The spine executed the four new teeth in its own run — `root_markdown_ok (broken=0)`, `root_markdown_broken_link (broken=2)`, the non-recursion tooth and the tracking tooth all PASS under `README link validator self-test`, and `retired composition vocab` (which walks root markdown for a different purpose, untouched here) stayed green alongside them.

The spine skipped the JVM and CLJS tiers as classified — `implementation_jvm` and `cljs_node_test` surfaces are unchanged by this diff, which touches only `scripts/`.
