### PR TITLE
fix(ssr): a diagnostic reports the error instead of overflowing (rf2-9s68n)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/diagnostic.cljc
+++ b/implementation/ssr/src/re_frame/ssr/diagnostic.cljc
@@ -1,0 +1,174 @@
+(ns ^:no-doc re-frame.ssr.diagnostic
+  "Cycle-safe printing for the SSR emitters' own DIAGNOSTICS (rf2-9s68n).
+
+  A validator that rejects a malformed form correctly but EXPLODES while
+  explaining why is still broken on hostile input. The SSR emitters build
+  their `:rf.error/invalid-hiccup-head` / `:rf.error/ui-tree-malformed`
+  messages with `(pr-str el)` over the offending runtime value, and on
+  ClojureScript that is a live stack-overflow: `cljs.core`'s printer has
+  exactly TWO branches that descend into a foreign JS value — `object?`
+  (prints `#js {…}` by walking `js-keys`) and `array?` (prints `#js […]`
+  by walking elements, `cljs/core.cljs` `pr-writer-impl`) — and NEITHER
+  carries a seen-set. Every other print form a foreign value can take
+  (`#inst`, `#\"re\"`, `#object[Ctor]`, `#object[Symbol(x)]`) is bounded
+  and recurses into nothing.
+
+  So an author who writes `[ThemeContext.Provider {…}]` on the hiccup
+  tier — the ordinary mistake `:rf.error/invalid-hiccup-head` exists to
+  catch, and one reachable straight from the shipped
+  `re-frame.ssr/render-to-string` — got `RangeError: Maximum call stack
+  size exceeded` and NO message at all. React 19's `createContext`
+  returns an object carrying a `Provider` key that points back at the
+  context itself, so `ctx.Provider` IS a cycle; the defect is a property
+  of the foreign object graph rather than of React, and a hand-built
+  `(unchecked-set o \"self\" o)` reproduces it exactly.
+
+  `re-frame.ssr.hash/canonical-edn-into` met the same crossing from the
+  other side (rf2-56iys) and STOPS at those two predicates: a hash wants
+  one identity-free token, so collapsing every foreign value is right
+  there. A DIAGNOSTIC wants the opposite — it exists to show the author
+  their value — so this namespace elides the strict minimum instead:
+
+    **A foreign JS value is replaced only when a cycle is REACHABLE from
+    it. Everything else, foreign or not, is handed to `pr-str`
+    untouched.**
+
+  Which is what makes the guarantee below hold by construction rather
+  than by inspection:
+
+    **An input from which no cycle is reachable is returned IDENTICAL, so
+    its diagnostic is byte-identical to the one it produced before this
+    namespace existed.** `safe-form` scans first and only rebuilds when
+    the scan finds a cycle; on the JVM it is `identity` outright (no
+    foreign objects, and no cyclic value can be built from the persistent
+    collections these walks otherwise see).
+
+  ## The values this protects, and where they go
+
+  `pr-form` is for the message string; `safe-form` for the `:extra`
+  ex-data payload. BOTH matter: a cyclic value that merely rides out in
+  `{:extra {:element el}}` explodes at a DOWNSTREAM logger / error
+  projector / trace sink that `pr-str`s the ex-data, i.e. at someone
+  else's boundary rather than at the emitter's, which is strictly worse
+  to diagnose.
+
+  ## rf2-y1jbaq (never stringify an unescaped hiccup form to the wire)
+
+  This does NOT widen the wire surface. A thrown-error message reaches
+  the trace bus, the always-on error axis and host logs; the HTTP body is
+  built by `re-frame.ssr.ring/render-error-body` from the PROJECTED
+  public-error's locked `{:status :code :message}` keys (default
+  `\"Something went wrong\"`) and rendered through the emitter's own
+  position-appropriate escaping. The elision token is a fixed constant
+  carrying no input-derived text, so the only content this namespace can
+  add to any surface is content an ACYCLIC form of the same shape already
+  put there."
+  ;; The WHOLE `:require` clause is CLJS-only: the JVM arm of `safe-form` is
+  ;; `identity`, so `clojure.walk` would be an unused namespace there.
+  #?(:cljs (:require [clojure.walk :as walk])))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---------------------------------------------------------------------------
+;; The foreign crossing — CLJS only.
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (deftype ElidedForeign [token]
+     Object
+     (toString [_] token)
+     IPrintWithWriter
+     (-pr-writer [_ writer _opts] (-write writer token))))
+
+#?(:cljs
+   (def ^:private elided-object
+     (ElidedForeign. "#js {…cyclic…}")))
+
+#?(:cljs
+   (def ^:private elided-array
+     (ElidedForeign. "#js […cyclic…]")))
+
+#?(:cljs
+   (defn- descends?
+     "Would `cljs.core`'s printer DESCEND into `x`? Exactly the two
+     branches of `pr-writer-impl` that do: `object?` (own enumerable keys,
+     via `js-keys`) and `array?` (elements). Deliberately the same pair
+     `re-frame.ssr.hash/canonical-edn-into` intercepts — widening it would
+     make the two walks disagree about what `pr-str` can survive."
+     [x]
+     (or (object? x) (array? x))))
+
+#?(:cljs
+   (defn- reaches-self?
+     "Depth-first over the descend-able foreign graph rooted at `x`,
+     carrying the ancestors on the CURRENT path. True as soon as a value
+     already on that path is reached again — which is precisely the
+     condition under which `pr-str` would not terminate.
+
+     Path-scoped, not global: a value reachable twice by DIFFERENT paths
+     (a shared subtree) is not a cycle, and `pr-str` prints it twice and
+     terminates. Cost tracks `pr-str`'s own — it visits the same graph the
+     printer would — so a graph this is slow on is a graph `pr-str` was
+     already slow on. Failure path only."
+     [x path]
+     (cond
+       (not (descends? x))            false
+       (some #(identical? % x) path)  true
+       :else
+       (let [path (conj path x)]
+         (boolean
+           (if (array? x)
+             (some #(reaches-self? % path) (array-seq x))
+             (some #(reaches-self? (unchecked-get x %) path) (js-keys x))))))))
+
+#?(:cljs
+   (defn- cyclic-foreign?
+     [x]
+     (and (descends? x) (reaches-self? x []))))
+
+#?(:cljs
+   (defn- elide-cyclic
+     "Leaf rewrite: a foreign value from which a cycle is reachable becomes
+     the fixed token; everything else — including an ACYCLIC foreign value,
+     which `pr-str` renders fully and terminates on — is returned as-is."
+     [x]
+     (if (cyclic-foreign? x)
+       (if (array? x) elided-array elided-object)
+       x)))
+
+#?(:cljs
+   (defn- reaches-cycle?
+     "Does any value anywhere in `form` carry a foreign cycle? Walks the
+     persistent structure (`tree-seq` over `coll?`), which is where a
+     hiccup element / tree node keeps its foreign leaves.
+
+     This scan is what buys the byte-identity guarantee: when it says no,
+     `safe-form` returns the input object itself and cannot have perturbed
+     anything."
+     [form]
+     (boolean (some cyclic-foreign? (tree-seq coll? seq form)))))
+
+;; ---------------------------------------------------------------------------
+;; Public surface.
+;; ---------------------------------------------------------------------------
+
+(defn safe-form
+  "`form` with every foreign JS value FROM WHICH A CYCLE IS REACHABLE
+  replaced by a fixed, identity-free, self-describing token
+  (`#js {…cyclic…}` / `#js […cyclic…]`), so the result is safe to `pr-str`
+  — by the caller building a message, and by any downstream consumer that
+  `pr-str`s it out of `:extra` ex-data.
+
+  Returns `form` ITSELF when no cycle is reachable (always, on the JVM)."
+  [form]
+  #?(:clj  form
+     :cljs (if (reaches-cycle? form)
+             (walk/postwalk elide-cyclic form)
+             form)))
+
+(defn pr-form
+  "`(pr-str form)`, made total: byte-identical to `pr-str` for every form
+  `pr-str` terminates on, and a bounded elision instead of `RangeError:
+  Maximum call stack size exceeded` for the ones it does not."
+  [form]
+  (pr-str (safe-form form)))

--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -40,6 +40,7 @@
   (:require [clojure.string]
             [re-frame.error :as error]
             [re-frame.late-bind :as late-bind]
+            [re-frame.ssr.diagnostic :as diagnostic]
             [re-frame.ssr.hash :as hash]
             [re-frame.ssr.html-helpers :as html]
             #?(:cljs [re-frame.substrate.plain-atom :as plain-atom-cljs])))
@@ -311,24 +312,29 @@
   Reuses `:rf.error/invalid-hiccup-head` rather than minting a near-
   duplicate id: the head genuinely has no HTML interpretation, which is
   precisely what that id names. The message and `:recovery` distinguish
-  the arm."
+  the arm.
+
+  `el` crosses `diagnostic/safe-form` FIRST (rf2-9s68n) — see
+  `re-frame.ssr.diagnostic`. `head` needs no such crossing: this arm is
+  reached only for a keyword in the reserved `:rf/*` namespace."
   [el head]
-  (error/throw-error!
-    :rf.error/invalid-hiccup-head
-    'rf.ssr/emit
-    (str "hiccup vector head " (pr-str head)
-         " (in element " (pr-str el) ") is in the framework-reserved"
-         " :rf/* namespace but is not a hiccup head this emitter"
-         " recognises. The recognised reserved heads are :<> (fragment),"
-         " :> (Reagent-native interop) and :rf/suspense-boundary"
-         " (streaming, shell walker only). The :rf/* scheme is framework-"
-         "owned (Conventions §Reserved namespaces), so this cannot be an"
-         " author DOM element — emitting it would paint a phantom <"
-         (name head) "> element silently. Check the spelling, or use an"
-         " unreserved keyword if you meant a custom element.")
-    {:recovery :use-a-recognised-reserved-head-or-an-unreserved-keyword
-     :extra    {:head    head
-                :element el}}))
+  (let [el (diagnostic/safe-form el)]
+    (error/throw-error!
+      :rf.error/invalid-hiccup-head
+      'rf.ssr/emit
+      (str "hiccup vector head " (pr-str head)
+           " (in element " (pr-str el) ") is in the framework-reserved"
+           " :rf/* namespace but is not a hiccup head this emitter"
+           " recognises. The recognised reserved heads are :<> (fragment),"
+           " :> (Reagent-native interop) and :rf/suspense-boundary"
+           " (streaming, shell walker only). The :rf/* scheme is framework-"
+           "owned (Conventions §Reserved namespaces), so this cannot be an"
+           " author DOM element — emitting it would paint a phantom <"
+           (name head) "> element silently. Check the spelling, or use an"
+           " unreserved keyword if you meant a custom element.")
+      {:recovery :use-a-recognised-reserved-head-or-an-unreserved-keyword
+       :extra    {:head    head
+                  :element el}})))
 
 (defn reject-invalid-hiccup-head!
   "Throw `:rf.error/invalid-hiccup-head` for a hiccup vector whose head is
@@ -345,21 +351,30 @@
   mirroring `validate-tag-name!` and the `:>` / `:rf/suspense-boundary`
   throws — never stringify an unescaped hiccup form to the wire. Shared by
   the sync emitter and the streaming shell walker so both paths reject the
-  same malformed shape identically."
+  same malformed shape identically.
+
+  rf2-9s68n — THIS ARM IS WHERE A FOREIGN HEAD LANDS, and it is the arm the
+  defect was reported against: a React context provider is neither
+  `keyword?` nor `ifn?`, so `[ctx.Provider {…}]` falls here, and `pr-str` of
+  a self-referential JS object blew the stack — `RangeError` instead of the
+  message this function exists to produce. `el` crosses
+  `diagnostic/safe-form` first; `(first el)` is read from the crossed value,
+  so the head is covered by the same one crossing."
   [el]
-  (error/throw-error!
-    :rf.error/invalid-hiccup-head
-    'rf.ssr/emit
-    (str "hiccup vector head " (pr-str (first el))
-         " (in element " (pr-str el) ") is not a valid hiccup head — a head"
-         " must be a keyword (DOM tag / :<> / :> /"
-         " :rf/suspense-boundary) or a callable component (fn / Var). A"
-         " string / nil / number / boolean / collection head has no HTML"
-         " interpretation; emitting its EDN form raw would bypass output"
-         " escaping (XSS). Produce a valid hiccup head.")
-    {:recovery :use-a-keyword-or-callable-hiccup-head
-     :extra    {:head    (first el)
-                :element el}}))
+  (let [el (diagnostic/safe-form el)]
+    (error/throw-error!
+      :rf.error/invalid-hiccup-head
+      'rf.ssr/emit
+      (str "hiccup vector head " (pr-str (first el))
+           " (in element " (pr-str el) ") is not a valid hiccup head — a head"
+           " must be a keyword (DOM tag / :<> / :> /"
+           " :rf/suspense-boundary) or a callable component (fn / Var). A"
+           " string / nil / number / boolean / collection head has no HTML"
+           " interpretation; emitting its EDN form raw would bypass output"
+           " escaping (XSS). Produce a valid hiccup head.")
+      {:recovery :use-a-keyword-or-callable-hiccup-head
+       :extra    {:head    (first el)
+                  :element el}})))
 
 (defn- invoke-form-2-render-fn
   "Invoke a Form-2 inner render fn with `args`, tolerating an inner that
@@ -495,23 +510,30 @@
          ;; hiccup → HTML function with no registry lookup. Nothing
          ;; resolves an id here; the CALLABLE head is what the emitter
          ;; invokes, which is why the spelling has to be in the message.
+         ;;
+         ;; rf2-9s68n — `el` crosses `diagnostic/safe-form` before it is
+         ;; printed OR put in ex-data. This arm is the one where a foreign
+         ;; JS value is not merely possible but EXPECTED: `[:> ctx.Provider
+         ;; …]` is what `:>` interop is FOR, and a React 19 provider is a
+         ;; cyclic object graph.
          (= :> head)
-         (error/throw-error!
-           :rf.error/ssr-reagent-native-head
-           'rf.ssr/emit
-           (str "Reagent-native interop head `:>` "
-                "(element " (pr-str el) ") cannot be "
-                "rendered server-side — it targets a "
-                "React component and there is no React "
-                "on the JVM. Wrap the component in a "
-                "reg-view and reference that view by its "
-                "CALLABLE head — the Var reg-view defs "
-                "(`[my-view …]`) or `[(rf/view :my/id) …]` "
-                "— or render it client-only. A bare "
-                "keyword head is an HTML element, not a "
-                "view reference.")
-           {:recovery :wrap-in-reg-view-or-render-client-only
-            :extra    {:element el}})
+         (let [el (diagnostic/safe-form el)]
+           (error/throw-error!
+             :rf.error/ssr-reagent-native-head
+             'rf.ssr/emit
+             (str "Reagent-native interop head `:>` "
+                  "(element " (pr-str el) ") cannot be "
+                  "rendered server-side — it targets a "
+                  "React component and there is no React "
+                  "on the JVM. Wrap the component in a "
+                  "reg-view and reference that view by its "
+                  "CALLABLE head — the Var reg-view defs "
+                  "(`[my-view …]`) or `[(rf/view :my/id) …]` "
+                  "— or render it client-only. A bare "
+                  "keyword head is an HTML element, not a "
+                  "view reference.")
+             {:recovery :wrap-in-reg-view-or-render-client-only
+              :extra    {:element el}}))
 
          ;; Reserved streaming marker `:rf/suspense-boundary` — recognised
          ;; ONLY by the streaming shell walker (`re-frame.ssr.streaming`).
@@ -525,24 +547,28 @@
          ;; streaming tree) surfaces a structured error rather than
          ;; silently producing malformed markup. Per Conventions §`:rf/*`
          ;; reserved hiccup heads + Spec 011 §Streaming SSR.
+         ;; rf2-9s68n — `el` crosses `diagnostic/safe-form` first: a
+         ;; boundary's `:fallback` is ordinary hiccup and can carry a
+         ;; foreign JS value anywhere inside it.
          (= :rf/suspense-boundary head)
-         (error/throw-error!
-           :rf.error/ssr-suspense-boundary-outside-stream
-           'rf.ssr/emit
-           (str ":rf/suspense-boundary (element "
-                (pr-str el) ") is a streaming-only "
-                "marker recognised by the streaming "
-                "shell walker (re-frame.ssr.ring/"
-                "stream-handler), not the standard "
-                "emitter. It reached render-to-string "
-                "outside a stream — that path cannot "
-                "resolve the boundary's continuation, "
-                "so it would emit a phantom "
-                "<suspense-boundary> DOM element. Use "
-                "stream-handler to render trees "
-                "containing :rf/suspense-boundary.")
-           {:recovery :render-via-stream-handler
-            :extra    {:element el}})
+         (let [el (diagnostic/safe-form el)]
+           (error/throw-error!
+             :rf.error/ssr-suspense-boundary-outside-stream
+             'rf.ssr/emit
+             (str ":rf/suspense-boundary (element "
+                  (pr-str el) ") is a streaming-only "
+                  "marker recognised by the streaming "
+                  "shell walker (re-frame.ssr.ring/"
+                  "stream-handler), not the standard "
+                  "emitter. It reached render-to-string "
+                  "outside a stream — that path cannot "
+                  "resolve the boundary's continuation, "
+                  "so it would emit a phantom "
+                  "<suspense-boundary> DOM element. Use "
+                  "stream-handler to render trees "
+                  "containing :rf/suspense-boundary.")
+             {:recovery :render-via-stream-handler
+              :extra    {:element el}}))
 
          ;; An unrecognised head in the framework-reserved `:rf/*` scheme.
          ;; The recognised reserved heads are consumed above (`:<>`, `:>`,

--- a/implementation/ssr/src/re_frame/ssr/ui_tree.cljc
+++ b/implementation/ssr/src/re_frame/ssr/ui_tree.cljc
@@ -58,6 +58,7 @@
   the conversion-table rows the seam needs ships here."
   (:require [clojure.string :as str]
             [re-frame.error :as error]
+            [re-frame.ssr.diagnostic :as diagnostic]
             [re-frame.ssr.hash :as hash]
             [re-frame.ssr.html-helpers :as html]))
 
@@ -87,7 +88,7 @@
         :rf.error/ssr-ui-tree-version-unsupported
         'rf.ssr/emit-ui-tree
         (str "re-frame.ssr/emit-ui-tree requires a root :rf.ui/tree-version in "
-             (pr-str supported-tree-versions) " — got " (pr-str v)
+             (pr-str supported-tree-versions) " — got " (diagnostic/pr-form v)
              ". The serialiser validates the version FIRST, before any emission, so "
              "a future-version or corrupt tree never emits plausible markup. This is "
              "an OPERATIONAL deploy-skew condition (the server is too old for the tree "
@@ -96,7 +97,11 @@
              "fix deploy skew) or fall back to client render — nothing is wrong with "
              "the view code.")
         {:recovery :no-recovery
-         :extra    {:got v :supported supported-tree-versions}}))))
+         ;; rf2-9s68n — `v` is read straight off a caller-supplied tree, so
+         ;; it crosses `diagnostic/safe-form` on the ex-data side exactly as
+         ;; it crosses `diagnostic/pr-form` on the message side above.
+         :extra    {:got (diagnostic/safe-form v)
+                    :supported supported-tree-versions}}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Conversion table — carried copies (provenance: re-frame.ui.rules /
@@ -711,13 +716,22 @@
   A malformed node PAST the version gate is a code bug — the closed variant
   set was violated — and reuses `:rf.error/ui-tree-malformed`, the id every
   tree consumer throws (004B §The node schema). `path` is the root-relative
-  `get-in` position that LOCATES the offending node."
+  `get-in` position that LOCATES the offending node.
+
+  rf2-9s68n — `extra` crosses `diagnostic/safe-form` HERE, once, for every
+  arm: its slots (`:value`, `:got`) carry runtime tree values, and a cyclic
+  foreign value riding out in ex-data explodes at a DOWNSTREAM logger /
+  error projector / trace sink that `pr-str`s it, which is someone else's
+  boundary and strictly harder to diagnose than this one. The callers own
+  the MESSAGE half of the same crossing (`diagnostic/pr-form`) because the
+  string is built before it arrives here. `path` is framework-built —
+  `:children` keywords and integers — so it needs no crossing."
   [reason path extra]
   (error/throw-error!
     :rf.error/ui-tree-malformed
     'rf.ssr/emit-ui-tree
     (str reason " (at tree path " (pr-str path) ")")
-    {:extra (assoc extra :path path)}))
+    {:extra (assoc (diagnostic/safe-form extra) :path path)}))
 
 (declare emit-node mark-selected selected-values)
 
@@ -765,7 +779,7 @@
       (str "a <" tag-lc "> raw-text element takes EITHER string content OR a "
            "single trusted-markup (:html) child — never a structural, mixed, or "
            "multi-child body (which the raw-text fast path would otherwise "
-           "stringify into the element): " (pr-str children))
+           "stringify into the element): " (diagnostic/pr-form children))
       path {:value children})))
 
 (defn- transparent-wrapper?
@@ -823,7 +837,7 @@
           (str "a <textarea> takes its content from EITHER :value / "
                ":default-value OR a single text child, never both — "
                "react-dom/server 19.2 rejects a textarea given a value AND a "
-               "child: " (pr-str c))
+               "child: " (diagnostic/pr-form c))
           p {:value raw-children}))
 
       (> (count eff) 1)
@@ -831,7 +845,7 @@
         (malformed-node!
           (str "a <textarea> takes at most ONE child, but " (count eff)
                " reached it after splicing — react-dom/server 19.2 rejects a "
-               "textarea with more than one child: " (pr-str (mapv first eff)))
+               "textarea with more than one child: " (diagnostic/pr-form (mapv first eff)))
           p {:value raw-children}))
 
       (= 1 (count eff))
@@ -842,7 +856,7 @@
             (str "a <textarea> cannot carry a trusted-markup (:html) child — "
                  "react-dom/server 19.2 rejects dangerouslySetInnerHTML on a "
                  "textarea (its content is value/defaultValue or a text child); "
-                 "supply the text via :value or a string child: " (pr-str c))
+                 "supply the text via :value or a string child: " (diagnostic/pr-form c))
             p {:value raw-children})
 
           (and (map? c) (contains? c :tag))
@@ -850,7 +864,7 @@
             (str "a <textarea> takes a single TEXT child, not a structural "
                  "element — react-dom/server 19.2 renders an element child as "
                  "\"[object Object]\"; supply the text via :value or a string "
-                 "child: " (pr-str c))
+                 "child: " (diagnostic/pr-form c))
             p {:value raw-children}))))))
 
 (defn- emit-element
@@ -980,7 +994,7 @@
                " — every map node is EXACTLY ONE of :tag (element), :view-id "
                "(view boundary), :html (trusted markup), or a fragment (none of "
                "these, splicing its :children); an ambiguous map must not be "
-               "interpreted by branch order: " (pr-str node))
+               "interpreted by branch order: " (diagnostic/pr-form node))
           path {:value node :got ds})
 
         (= 1 (count ds))
@@ -992,7 +1006,7 @@
                        h
                        (malformed-node!
                          (str "a trusted-HTML node's :html is not a string: "
-                              (pr-str node))
+                              (diagnostic/pr-form node))
                          path {:value node})))
           ;; view boundary erases — its children splice into the stream.
           :view-id (emit-children (:children node) path))
@@ -1007,12 +1021,12 @@
           (str "a tree node carries no node discriminator — every map node is "
                "an element (:tag), a view boundary (:view-id), trusted markup "
                "(:html), or a fragment (:children); a map with none is not a "
-               "renderable tree node: " (pr-str node))
+               "renderable tree node: " (diagnostic/pr-form node))
           path {:value node :got []})))
 
     :else
     (malformed-node!
-      (str "malformed tree node in re-frame.ssr/emit-ui-tree: " (pr-str node))
+      (str "malformed tree node in re-frame.ssr/emit-ui-tree: " (diagnostic/pr-form node))
       path {:value node})))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/ssr/test/re_frame/ssr/diagnostic_cycle_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/diagnostic_cycle_cljs_test.cljs
@@ -1,0 +1,319 @@
+(ns re-frame.ssr.diagnostic-cycle-cljs-test
+  "THE DIAGNOSTIC PATH ITSELF THREW (rf2-9s68n).
+
+  `re-frame.ssr.emit` and `re-frame.ssr.ui-tree` build their rejection
+  messages with `(pr-str el)` / `(pr-str node)` over the offending runtime
+  value, and `cljs.core`'s printer descends into a plain JS object
+  (`#js {…}`, over `js-keys`) and a JS array (`#js […]`, over elements)
+  with no seen-set. A foreign object graph may be CYCLIC — React 19's
+  `createContext` returns an object whose `Provider` key points back at the
+  context itself — so an author who wrote `[ThemeContext.Provider {…}]`, the
+  ordinary mistake `:rf.error/invalid-hiccup-head` exists to catch, got
+  `RangeError: Maximum call stack size exceeded` and NO message at all.
+  Unlike the sibling (rf2-56iys, the render-tree hash) this is reachable
+  from the shipped `re-frame.ssr/render-to-string`.
+
+  ## How these rows OBSERVE a stack overflow
+
+  A `RangeError` raised inside the emitter is an ordinary synchronous JS
+  throw — nothing routes it to `reportError`, so no row here depends on the
+  runner noticing an exception it never saw. Every row calls the emitter
+  through [[outcome]], which returns a MAP — `{:returned …}` or
+  `{:threw <name> :error-id … :message … :ex-data-printable? …}` — and
+  asserts on that map. A regression therefore fails with `\"RangeError\"`
+  in its own failure text rather than aborting the var.
+
+  ## The three things each fixed site has to prove
+
+  1. a CYCLIC input produces the site's OWN error id, not `RangeError`;
+  2. the thrown `ex-data` is `pr-str`-able, so the cyclic value cannot
+     ride out and explode at a downstream logger / projector / trace sink;
+  3. an ACYCLIC input's message is BYTE-IDENTICAL to the one `pr-str`
+     produces — asserted by embedding `cljs.core/pr-str`'s own output in
+     the expectation, not by eyeballing a literal.
+
+  [[the-fixtures-are-genuinely-cyclic]] is the non-vacuity control. Without
+  it every row below could pass on an acyclic fixture and prove nothing."
+  (:require ["react" :as react]
+            [clojure.string :as str]
+            [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.ssr.diagnostic :as diagnostic]
+            [re-frame.ssr.emit :as emit]
+            [re-frame.ssr.ui-tree :as ui-tree]))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures
+;; ---------------------------------------------------------------------------
+
+(defn- self-referential-object
+  "A plain JS object holding a reference to ITSELF. No React: the defect is
+  a property of a foreign object graph, and this is the smallest value that
+  has it."
+  []
+  (let [o #js {"tag" "cyclic"}]
+    (unchecked-set o "self" o)
+    o))
+
+(defn- self-referential-array
+  "The ARRAY half of the same crossing — `pr-str`'s other descending
+  branch."
+  []
+  (let [a #js ["cyclic"]]
+    (.push a a)
+    a))
+
+(def ^:private corpus-context
+  "A real React context, so the rows below carry the shape that was
+  reported rather than a model of it."
+  (react/createContext "unset"))
+
+(def ^:private provider
+  "`ctx.Provider` — what an author writes in head position."
+  (.-Provider corpus-context))
+
+(def ^:private acyclic-object
+  "The ACYCLIC control. A plain JS object `pr-str` renders in full and
+  terminates on: every row that pins byte-identity uses this."
+  #js {"theme" "dark" "level" 3})
+
+;; ---------------------------------------------------------------------------
+;; Observation
+;; ---------------------------------------------------------------------------
+
+(defn- outcome
+  "Run `f` and describe what happened as DATA. On a throw the map carries
+  the host error NAME (so a stack overflow shows up as `\"RangeError\"` in
+  the failure text), the framework error id, the message, and whether the
+  ex-data survives `pr-str` — which is the ex-data half of the defect."
+  [f]
+  (try
+    {:returned (f)}
+    (catch :default e
+      (let [data (ex-data e)]
+        {:threw    (.-name e)
+         :error-id (:rf.error/id data)
+         :message  (ex-message e)
+         :ex-data-printable?
+         (try (string? (pr-str data)) (catch :default _ false))}))))
+
+(defn- rejected-with
+  "Assert `f` threw the framework error `id` — with the whole outcome map in
+  the failure text, and with the ex-data proven printable at the same time."
+  [id label f]
+  (let [o (outcome f)]
+    (is (= id (:error-id o))
+        (str label " must throw " id "; got " (pr-str o)))
+    (is (true? (:ex-data-printable? o))
+        (str label "'s ex-data must survive pr-str at a downstream sink; got "
+             (pr-str (dissoc o :message))))
+    o))
+
+(defn- tree
+  "A version-1 structural tree wrapping `children` in a root fragment."
+  [& children]
+  {:rf.ui/tree-version 1 :children (vec children)})
+
+;; ---------------------------------------------------------------------------
+;; The control
+;; ---------------------------------------------------------------------------
+
+(deftest the-fixtures-are-genuinely-cyclic
+  (testing "THE NON-VACUITY CONTROL. `pr-str` is what every message site
+           below calls, and on these values it recurs until the stack
+           blows. If any row here ever goes green-by-termination, the
+           fixture has stopped being cyclic and the whole file is
+           measuring nothing."
+    (is (= "RangeError" (:threw (outcome #(pr-str (self-referential-object)))))
+        "a hand-built self-referential JS object defeats cljs.core/pr-str")
+    (is (= "RangeError" (:threw (outcome #(pr-str (self-referential-array)))))
+        "and so does a cycle reached through a JS array")
+    (is (= "RangeError" (:threw (outcome #(pr-str provider))))
+        "and so does a real React 19 context provider")
+    (is (= "RangeError" (:threw (outcome #(pr-str [provider {:value "dark"}]))))
+        "and so does an ordinary hiccup vector holding one")
+    (is (identical? provider (.-Provider provider))
+        "because React 19's ctx.Provider IS the context object, and that
+         object carries a Provider key pointing back at itself — the cycle
+         in one line")
+    (is (string? (pr-str [acyclic-object {:value "dark"}]))
+        "while the ACYCLIC control prints fine, which is what makes it a
+         control for the byte-identity rows")))
+
+;; ---------------------------------------------------------------------------
+;; The helper
+;; ---------------------------------------------------------------------------
+
+(deftest safe-form-returns-an-acyclic-input-identically
+  (testing "The byte-identity guarantee is BY CONSTRUCTION, not by
+           inspection: when no cycle is reachable `safe-form` hands back the
+           very object it was given, so `pr-str` of the result cannot differ
+           from `pr-str` of the input by any byte."
+    (doseq [[label v] [["ordinary hiccup"      [:div {:class "x"} [:p "hi"]]]
+                       ["an acyclic JS object" acyclic-object]
+                       ["hiccup holding one"   [acyclic-object {:value "dark"}]]
+                       ["an acyclic JS array"  #js [1 2 3]]
+                       ["a nested acyclic obj" [:div {} [:span {:ctx acyclic-object}]]]
+                       ["a string"             "text"]
+                       ["nil"                  nil]]]
+      (is (identical? v (diagnostic/safe-form v))
+          (str label " must come back identical")))
+    (is (= (pr-str [acyclic-object {:value "dark"}])
+           (diagnostic/pr-form [acyclic-object {:value "dark"}]))
+        "so pr-form IS pr-str wherever pr-str terminates — including on a
+         foreign object, whose contents stay in the diagnostic")))
+
+(deftest safe-form-elides-only-the-cyclic-foreign-value
+  (testing "The elision is the strict minimum: the token replaces the value
+           `pr-str` cannot survive and nothing else, so the props and
+           children around it go on discriminating the diagnostic."
+    (is (= "#js {…cyclic…}" (diagnostic/pr-form (self-referential-object))))
+    (is (= "#js […cyclic…]" (diagnostic/pr-form (self-referential-array))))
+    (is (= "#js {…cyclic…}" (diagnostic/pr-form provider)))
+    (is (= "[#js {…cyclic…} {:value \"dark\"} [:p \"x\"]]"
+           (diagnostic/pr-form [provider {:value "dark"} [:p "x"]])))
+    (is (= "[:div {:ctx #js {…cyclic…}} \"x\"]"
+           (diagnostic/pr-form [:div {:ctx provider} "x"]))
+        "a cycle nested in an attrs map is elided in place, leaving the map
+         around it intact")
+    (is (= "[:div #js […cyclic…]]"
+           (diagnostic/pr-form [:div #js [(self-referential-object)]]))
+        "a foreign value from which a cycle is REACHABLE is elided whole —
+         the array holding the cycle is itself unprintable")))
+
+(deftest a-shared-subtree-is-not-a-cycle
+  (testing "The detector is PATH-scoped, not global. A foreign value
+           reachable twice by different paths is a DAG, `pr-str` prints it
+           twice and terminates, and eliding it would be a diagnostic
+           regression dressed up as a fix."
+    (let [shared #js {"k" "v"}
+          form   [:div {:a shared :b shared}]]
+      (is (identical? form (diagnostic/safe-form form)))
+      (is (= (pr-str form) (diagnostic/pr-form form))))))
+
+;; ---------------------------------------------------------------------------
+;; re-frame.ssr.emit — four throw sites
+;; ---------------------------------------------------------------------------
+
+(deftest emit-rejects-a-cyclic-hiccup-head-with-its-own-error
+  (testing "THE REPORTED DEFECT. A React provider is neither `keyword?` nor
+           `ifn?`, so it falls to `reject-invalid-hiccup-head!` — which
+           raised RangeError from its own message instead of the error it
+           exists to produce. Reverting `diagnostic/safe-form` in that
+           function reds every row here with `{:threw \"RangeError\"}`."
+    (doseq [[label el] [["a provider in head position"  [provider {:value "dark"}]]
+                        ["a hand-built cycle as head"   [(self-referential-object) {}]]
+                        ["a cyclic array as head"       [(self-referential-array)]]
+                        ["a provider nested in markup"  [:div.hosts [:h1 "hosts"]
+                                                         [provider {:value "dark"} "x"]]]]]
+      (rejected-with :rf.error/invalid-hiccup-head label
+                     #(emit/emit-element el)))))
+
+(deftest render-to-string-is-the-shipped-entry-point-that-reaches-it
+  (testing "The severity claim, executed: this is not a test-only path. The
+           public `render-to-string` reaches the same throw."
+    (rejected-with :rf.error/invalid-hiccup-head "render-to-string on a provider head"
+                   #(emit/render-to-string [:main [provider {:value "dark"} "x"]] nil))))
+
+(deftest emit-rejects-a-cyclic-reserved-rf-head-with-its-own-error
+  (testing "`reject-reserved-rf-hiccup-head!` prints the ELEMENT, so a
+           cyclic value anywhere in the element blew it up even though the
+           head itself is an ordinary keyword."
+    (rejected-with :rf.error/invalid-hiccup-head "an unrecognised :rf/* head"
+                   #(emit/emit-element [:rf/suspense-boundry {:ctx provider}]))))
+
+(deftest emit-rejects-a-cyclic-reagent-native-head-with-its-own-error
+  (testing "`[:> ctx.Provider …]` is what `:>` interop is FOR, so this arm
+           is the one where a cyclic foreign value is not merely possible
+           but EXPECTED."
+    (rejected-with :rf.error/ssr-reagent-native-head "a :> provider element"
+                   #(emit/emit-element [:> provider {:value "dark"}]))))
+
+(deftest emit-rejects-a-cyclic-suspense-boundary-with-its-own-error
+  (testing "A boundary's `:fallback` is ordinary hiccup and can carry a
+           foreign value anywhere inside it."
+    (rejected-with :rf.error/ssr-suspense-boundary-outside-stream
+                   "a suspense boundary whose fallback holds a provider"
+                   #(emit/emit-element
+                      [:rf/suspense-boundary {:id :b :fallback [:div {:ctx provider}]}]))))
+
+;; ---------------------------------------------------------------------------
+;; re-frame.ssr.ui-tree — the malformed-node + version-gate throws
+;; ---------------------------------------------------------------------------
+
+(deftest ui-tree-rejects-a-cyclic-malformed-node-with-its-own-error
+  (testing "Every `malformed-node!` arm prints the offending node or child.
+           Reverting `diagnostic/pr-form` at any one of them reds its row
+           here with `{:threw \"RangeError\"}`."
+    (doseq [[label t]
+            [["a foreign node in child position"
+              (tree provider)]
+             ["a cyclic array in child position"
+              (tree (self-referential-array))]
+             ["a node with two discriminators"
+              (tree {:tag :div :view-id :v :attrs {:ctx provider}})]
+             ["a node with no discriminator and no children"
+              (tree {:attrs {:ctx provider}})]
+             ["a trusted-HTML node whose :html is not a string"
+              (tree {:html provider})]
+             ["a raw-text element with a structural child"
+              (tree {:tag :script :children [{:tag :b :children ["x"]} provider]})]
+             ["a textarea given both a value and a child"
+              (tree {:tag :textarea :attrs {:value "v"} :children [provider]})]
+             ["a textarea given more than one child"
+              (tree {:tag :textarea :children [provider provider]})]
+             ["a textarea given a trusted-markup child"
+              (tree {:tag :textarea :children [{:html "x" :ctx provider}]})]
+             ["a textarea given a structural child"
+              (tree {:tag :textarea :children [{:tag :b :attrs {:ctx provider}}]})]]]
+      (rejected-with :rf.error/ui-tree-malformed label
+                     #(ui-tree/emit-ui-tree t)))))
+
+(deftest ui-tree-version-gate-rejects-a-cyclic-version-with-its-own-error
+  (testing "The version gate runs FIRST and prints the version it got, so a
+           foreign value in that slot reached `pr-str` before any node did."
+    (rejected-with :rf.error/ssr-ui-tree-version-unsupported
+                   "a cyclic :rf.ui/tree-version"
+                   #(ui-tree/emit-ui-tree {:rf.ui/tree-version provider}))))
+
+;; ---------------------------------------------------------------------------
+;; The acyclic path, byte for byte
+;; ---------------------------------------------------------------------------
+
+(deftest an-acyclic-diagnostic-is-byte-identical
+  (testing "The expectation embeds `cljs.core/pr-str`'s OWN output, so these
+           rows fail the moment a message stops being what `pr-str`
+           produced before this fix existed. The acyclic foreign object
+           keeps its CONTENTS in the message — eliding every foreign value
+           (what the hash walk does, and rightly) would have cost the
+           diagnostic exactly the information it exists to carry."
+    (let [el [acyclic-object {:value "dark"}]
+          o  (outcome #(emit/emit-element el))]
+      (is (= :rf.error/invalid-hiccup-head (:error-id o))
+          (str "the acyclic control still produces the correct error; got " (pr-str o)))
+      (is (str/includes? (:message o) (str "hiccup vector head " (pr-str acyclic-object)))
+          (str "head printed byte-identically to pr-str; got " (pr-str (:message o))))
+      (is (str/includes? (:message o) (str "(in element " (pr-str el) ")"))
+          (str "element printed byte-identically to pr-str; got " (pr-str (:message o)))))
+
+    (let [el [:> acyclic-object {:value "dark"}]
+          o  (outcome #(emit/emit-element el))]
+      (is (= :rf.error/ssr-reagent-native-head (:error-id o)))
+      (is (str/includes? (:message o) (str "(element " (pr-str el) ")"))))
+
+    (let [node {:attrs {:ctx acyclic-object}}
+          o    (outcome #(ui-tree/emit-ui-tree (tree node)))]
+      (is (= :rf.error/ui-tree-malformed (:error-id o)))
+      (is (str/includes? (:message o) (str "renderable tree node: " (pr-str node)))))
+
+    (let [o (outcome #(ui-tree/emit-ui-tree {:rf.ui/tree-version acyclic-object}))]
+      (is (= :rf.error/ssr-ui-tree-version-unsupported (:error-id o)))
+      (is (str/includes? (:message o) (str " — got " (pr-str acyclic-object)))))))
+
+(deftest a-well-formed-tree-still-renders
+  (testing "The crossing is on the FAILURE path only — nothing about a
+           valid render moves."
+    (is (= "<div class=\"x\"><p>hi</p></div>"
+           (emit/render-to-string [:div {:class "x"} [:p "hi"]] nil)))
+    (is (= "<div><p>hi</p></div>"
+           (ui-tree/emit-ui-tree
+             (tree {:tag :div :children [{:tag :p :children ["hi"]}]}))))))


### PR DESCRIPTION
Closes rf2-9s68n.

## What was wrong

`re-frame.ssr.emit/reject-invalid-hiccup-head!` builds its message with `(pr-str el)`. A React 19 context provider is neither `keyword?` nor `ifn?`, so `[ThemeContext.Provider {…}]` — the ordinary mistake that message exists to catch — fell to that arm, and `cljs.core`'s printer has exactly two branches that descend into a foreign JS value (`object?`, over `js-keys`; `array?`, over elements) and neither carries a seen-set. The author got `RangeError: Maximum call stack size exceeded` and no message at all.

Sibling of rf2-56iys (PR #7558), which met the same crossing in `re-frame.ssr.hash/canonical-edn-into`. Unlike that one, this is reachable from the shipped `re-frame.ssr/render-to-string`, which is why the bead calls it the more reachable of the two.

## The fix — one helper, applied at every site

`re-frame.ssr.diagnostic` (new, `^:no-doc`) is the whole mechanism. Where the hash walk collapses **every** foreign value to one identity-free token — right for a hash — a diagnostic exists to show the author their value, so this elides the strict minimum:

> A foreign JS value is replaced only when a cycle is REACHABLE from it. Everything else, foreign or not, is handed to `pr-str` untouched.

That is what makes the byte-identity guarantee hold *by construction* rather than by inspection: `safe-form` scans first and, when no cycle is reachable, returns **the input object itself** — so `pr-str` of the result cannot differ from `pr-str` of the input by any byte. On the JVM it is `identity` outright (no foreign objects, and no cyclic value can be built from the persistent collections these walks otherwise see).

Two entry points, because the defect has two halves:

- `pr-form` — the message string.
- `safe-form` — the `:extra` ex-data payload. A cyclic value that merely rides out in `{:extra {:element el}}` explodes at a **downstream** logger / error projector / trace sink that `pr-str`s the ex-data — someone else's boundary, and strictly harder to diagnose than this one. Bounding only the message strings would have left that door open.

`emit` binds `(diagnostic/safe-form el)` once per throwing function, so message and ex-data cross together and no use site inside can be missed. `ui-tree` has a shared thrower, so `malformed-node!` owns the ex-data crossing for every arm at one point and the callers use `pr-form` for the message half (the string is already built by the time it reaches the thrower).

## Site roster

**Fixed and proven — `re-frame.ssr.emit` (4 throwers, 6 print sites):**

| site | crossing |
| --- | --- |
| `reject-invalid-hiccup-head!` — `(pr-str (first el))` + `(pr-str el)` + ex-data `:head`/`:element` | `safe-form` bound once |
| `reject-reserved-rf-hiccup-head!` — `(pr-str el)` + ex-data `:element` | `safe-form` bound once |
| `emit-element`'s `:>` throw — `(pr-str el)` + ex-data `:element` | `safe-form` bound once |
| `emit-element`'s `:rf/suspense-boundary` throw — `(pr-str el)` + ex-data `:element` | `safe-form` bound once |

**Fixed and proven — `re-frame.ssr.ui-tree` (10 print sites, 1 shared ex-data point):**

`validate-tree-version!`'s `(pr-str v)`; `emit-raw-text-children`'s `(pr-str children)`; all four `reject-textarea-content!` arms; and all four `emit-node` malformed-node arms. `malformed-node!` now crosses its whole `extra` map for every arm at once; `validate-tree-version!` crosses `:got`.

**THE BEAD UNDERCOUNTS THIS NAMESPACE.** It records "four `(pr-str node)` sites in the malformed-node throws". There are four *in `emit-node`* — but `emit-raw-text-children` and the four `reject-textarea-content!` arms print runtime child nodes through the same `malformed-node!` thrower and are the same class, and the version gate prints a caller-supplied `:rf.ui/tree-version`. All ten are fixed and each has its own proven row.

**Cleared, with the reason (deliberately left as `pr-str`):**

- `emit/validate-tag-name!` — `tag-name` is a string sliced out of `(name tag-kw)` by a regex and `source-kw` is the keyword head; neither can be a foreign value.
- `emit/reject-reserved-rf-hiccup-head!`'s `(pr-str head)` — that arm is reached only for a keyword in the reserved `:rf/*` namespace (`reserved-rf-head?` tests `keyword?` first).
- `ui-tree/malformed-node!`'s `(pr-str path)` — framework-built `:children` keywords and integers.
- `emit-node`'s and `norm-node`'s `(pr-str ds)` — the discriminator vector, keywords only.
- `validate-tree-version!`'s `(pr-str supported-tree-versions)` — a compile-time constant.
- The three the bead already cleared (`identity/canonical-bytes`, `resources.ssr/canonical-digest-token`, every compile-time `(pr-str form)`) were not re-audited, per the bead.

**NOT ATTEMPTED — `re-frame.ui.semantic/malformed-node!` (3 print sites + ex-data).** See "Where the brief is wrong".

## rf2-y1jbaq — can any of this reach a page?

**No, and the fix narrows rather than widens the surface.** Traced: a thrown-error message rides `ex-message` onto the trace bus, the always-on error axis and host logs. The HTTP body is built by `re-frame.ssr.ring/render-error-body` from the **projected** public-error's locked `{:status :code :message}` keys (`public-error-shape?` pins that key set exactly; the default is `"Something went wrong"`), and it is rendered *through `render-to-string` itself*, so even that flows through the emitter's own position-appropriate escaping. The opt-in `:dev-error-detail?` slot appends `:details` to the projection result, and `render-error-body` destructures only `status` / `code` / `message`.

The one thing worth stating plainly: a cyclic form's message is now *built* where before it threw, so the rest of that form now appears in a log line that previously did not exist. That is exactly the exposure an **acyclic** form of the same shape already had before this PR, on the same code path — and the elision token is a fixed constant carrying no input-derived text, so nothing attacker-controlled is added by this change. Eliding *more* (the hash-walk treatment) would have removed information the diagnostic exists to carry without closing any wire path, because there is no wire path.

## Where the brief is wrong

**The fence excludes the only home a cross-artefact fix can have.** `re-frame.ui.semantic` is a genuine site — its `malformed-node!` prints `(pr-str node)` in three arms and carries `{:value node}` in ex-data — but `re-frame.ui` and `re-frame.ssr` are sibling artefacts that both depend on core and neither may require the other (`ssr/deps.edn`: "Production `re-frame.ssr` never `:require`s `re-frame.ui`"). The shared home is `re-frame.error` in `implementation/core`, which all three namespaces **already** require, and where `diag-value-summary` — the repo's existing diagnostic-value primitive — already lives. `implementation/core/**` is outside the dispatch fence, and copying a walker into `re-frame.ui` to serve one thrower is precisely the "ten sites, ten mechanisms" the brief forbids. So `re-frame.ui.semantic` is left alone and filed; the follow-up is a core-fenced move of these two functions plus a one-line require swap in this PR.

(The same class of fence conflict the rf2-56iys worker reported on its own dispatch.)

## Quality gates

### How the tests observe an overflow

Copied from the sibling's shape: a `RangeError` here is an ordinary synchronous JS throw, so nothing depends on the runner noticing an exception it never saw (the `reportError` trap does not apply). Every row calls the emitter through `outcome`, which returns a **map** — `{:returned …}` or `{:threw <name> :error-id … :message … :ex-data-printable? …}` — and asserts on that map, so an overflow is *data in the failure text*:

```
render-to-string on a provider head must throw :rf.error/invalid-hiccup-head;
got {:threw "RangeError", :error-id nil, :message "Maximum call stack size exceeded", :ex-data-printable? true}
```

`:ex-data-printable?` is the ex-data half of the defect asserted at every site, not just the message half.

### Non-vacuity control

`the-fixtures-are-genuinely-cyclic` asserts that `cljs.core/pr-str` — the exact printer every fixed site calls — **does** blow the stack on the same fixtures: the hand-built `(unchecked-set o "self" o)` object, a self-referential JS array, the real `ctx.Provider`, and an ordinary hiccup vector holding one. Plus `(identical? provider (.-Provider provider))`, and a positive control that the acyclic fixture prints fine (which is what makes the byte-identity rows mean anything).

### Byte-identity, measured not asserted

`an-acyclic-diagnostic-is-byte-identical` builds its expectations by calling `cljs.core/pr-str` **on the same value** and asserting the message embeds that exact substring — at four sites across both namespaces — so the rows fail the moment a message stops being what `pr-str` produced before this PR. `safe-form-returns-an-acyclic-input-identically` proves the stronger structural claim (`identical?`, seven shapes), and `a-shared-subtree-is-not-a-cycle` proves the detector is path-scoped: a DAG that `pr-str` prints twice and terminates on is left completely alone.

### Runs

| gate | result |
| --- | --- |
| `npm run test:cljs` | **exit 0** — `Ran 12660 tests containing 63428 assertions. 0 failures, 0 errors.` |
| reverse mutation (`safe-form` neutralised, then restored) | **exit 1** — 19 failures + 6 errors, **all 25 in `re-frame.ssr.diagnostic-cycle-cljs-test`**, every one carrying `{:threw "RangeError", :message "Maximum call stack size exceeded"}` in its failure text |
| `sh scripts/test-fast-pr.sh` | _running — this section is updated when it reports_ |
| `npm run test:browser` | _running_ |
| ssr JVM (`clojure -M:test`) | _running_ |
| ssr-ring JVM (`clojure -M:test`) | _running_ |
| clj-kondo @ CI pin 2026.04.15 | _running_ |
