### PR TITLE
fix(ssr): the cycle detector crosses into persistent collections, as the printer does (rf2-9s68n)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/diagnostic.cljc
+++ b/implementation/ssr/src/re_frame/ssr/diagnostic.cljc
@@ -100,26 +100,39 @@
 
 #?(:cljs
    (defn- reaches-self?
-     "Depth-first over the descend-able foreign graph rooted at `x`,
-     carrying the ancestors on the CURRENT path. True as soon as a value
-     already on that path is reached again — which is precisely the
+     "Depth-first over everything `cljs.core`'s printer descends into,
+     carrying the FOREIGN ancestors on the CURRENT path. True as soon as a
+     value already on that path is reached again — which is precisely the
      condition under which `pr-str` would not terminate.
 
-     Path-scoped, not global: a value reachable twice by DIFFERENT paths
-     (a shared subtree) is not a cycle, and `pr-str` prints it twice and
+     IT DESCENDS PERSISTENT COLLECTIONS TOO, because the printer does: the
+     `object?` branch hands each value to `pr-writer`, which recurses into a
+     vector or map like any other, so a cycle can be reached by a MIXED
+     chain — `#js {\"held\" [:p ctx.Provider]}`. A walk that stopped at the
+     first persistent collection would call that value acyclic and hand
+     `pr-str` the overflow anyway. Only foreign values go ON the path: a
+     cycle cannot be built out of persistent collections, so nothing else
+     can close one.
+
+     Path-scoped, not global: a value reachable twice by DIFFERENT paths (a
+     shared subtree) is not a cycle, and `pr-str` prints it twice and
      terminates. Cost tracks `pr-str`'s own — it visits the same graph the
-     printer would — so a graph this is slow on is a graph `pr-str` was
-     already slow on. Failure path only."
+     printer would — so a graph this is slow on is one `pr-str` was already
+     slow on. Failure path only."
      [x path]
      (cond
-       (not (descends? x))            false
-       (some #(identical? % x) path)  true
-       :else
-       (let [path (conj path x)]
-         (boolean
-           (if (array? x)
-             (some #(reaches-self? % path) (array-seq x))
-             (some #(reaches-self? (unchecked-get x %) path) (js-keys x))))))))
+       (descends? x)
+       (or (boolean (some #(identical? % x) path))
+           (let [path (conj path x)]
+             (boolean
+               (if (array? x)
+                 (some #(reaches-self? % path) (array-seq x))
+                 (some #(reaches-self? (unchecked-get x %) path) (js-keys x))))))
+
+       (coll? x)
+       (boolean (some #(reaches-self? % path) (seq x)))
+
+       :else false)))
 
 #?(:cljs
    (defn- cyclic-foreign?
@@ -138,15 +151,15 @@
 
 #?(:cljs
    (defn- reaches-cycle?
-     "Does any value anywhere in `form` carry a foreign cycle? Walks the
-     persistent structure (`tree-seq` over `coll?`), which is where a
-     hiccup element / tree node keeps its foreign leaves.
+     "Is there a foreign cycle anywhere in `form`? One `reaches-self?` from
+     the root covers it, because that walk already crosses freely between
+     persistent collections and foreign values.
 
      This scan is what buys the byte-identity guarantee: when it says no,
      `safe-form` returns the input object itself and cannot have perturbed
      anything."
      [form]
-     (boolean (some cyclic-foreign? (tree-seq coll? seq form)))))
+     (reaches-self? form [])))
 
 ;; ---------------------------------------------------------------------------
 ;; Public surface.

--- a/implementation/ssr/test/re_frame/ssr/diagnostic_cycle_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/diagnostic_cycle_cljs_test.cljs
@@ -131,6 +131,10 @@
         "and so does a real React 19 context provider")
     (is (= "RangeError" (:threw (outcome #(pr-str [provider {:value "dark"}]))))
         "and so does an ordinary hiccup vector holding one")
+    (is (= "RangeError" (:threw (outcome #(pr-str #js {"held" [:p provider]}))))
+        "and so does a MIXED chain — foreign object, persistent vector,
+         foreign object — because the printer crosses between the two
+         freely, which is why the detector has to as well")
     (is (identical? provider (.-Provider provider))
         "because React 19's ctx.Provider IS the context object, and that
          object carries a Provider key pointing back at itself — the cycle
@@ -188,7 +192,28 @@
     (let [shared #js {"k" "v"}
           form   [:div {:a shared :b shared}]]
       (is (identical? form (diagnostic/safe-form form)))
+      (is (= (pr-str form) (diagnostic/pr-form form)))))
+  (testing "and a persistent collection nested INSIDE a foreign value is
+           crossed, not treated as the end of the graph — acyclic here, so
+           it must come back untouched."
+    (let [form [:div #js {"held" [:p "x"]}]]
+      (is (identical? form (diagnostic/safe-form form)))
       (is (= (pr-str form) (diagnostic/pr-form form))))))
+
+(deftest a-cycle-through-a-mixed-chain-is-found
+  (testing "`pr-str` alternates between foreign values and persistent
+           collections as it descends, so the detector must too. A walk that
+           stopped at the first persistent collection would report this form
+           acyclic and hand `pr-str` the overflow — which is exactly what
+           the control row above proves happens."
+    (is (= "[:div #js {…cyclic…}]"
+           (diagnostic/pr-form [:div #js {"held" [:p provider]}])))
+    (is (= "#js {…cyclic…}"
+           (diagnostic/pr-form #js {"held" #js [[:p provider]]}))
+        "two collections deep and through an array as well")
+    (rejected-with :rf.error/invalid-hiccup-head
+                   "a mixed-chain cycle in head position"
+                   #(emit/emit-element [#js {"held" [:p provider]} {}]))))
 
 ;; ---------------------------------------------------------------------------
 ;; re-frame.ssr.emit — four throw sites


### PR DESCRIPTION
Follow-up to PR #7562 (rf2-9s68n), which merged while its gates were still running.

## The gap, found by re-reading the printer rather than by a failing test

#7562 added `re-frame.ssr.diagnostic`, whose detector descended **only** into foreign JS values, and whose top-level scan walked `(tree-seq coll? seq form)` — which treats a JS object as a leaf.

`cljs.core`'s `pr-writer-impl` does not work that way. Its `object?` branch builds `MapEntry`s of `[keyword-key (unchecked-get obj k)]` and hands each **value** to `pr-writer`, which recurses into a vector or a map exactly as it would anywhere else. So the printer's descent alternates freely between foreign values and persistent collections, and a cycle can be reached by a **mixed chain**:

```clojure
#js {"held" [:p ctx.Provider]}
```

Both halves of #7562's detector call that acyclic. `pr-str` blows the stack on it. The very defect the bead is about, one indirection deeper — reachable from any hiccup prop that holds a JS object holding hiccup.

## The fix

One walker that descends exactly what the printer descends:

| kind | descends into |
| --- | --- |
| foreign object | `js-keys` values |
| foreign array | elements |
| persistent coll | `seq` |
| anything else | nothing |

Only **foreign** values go on the path, because a cycle cannot be built out of persistent collections, so nothing else can close one. The shared-subtree property is unchanged — the path is still per-branch, so a DAG that `pr-str` prints twice and terminates on is still left completely alone.

`reaches-cycle?` collapses to `(reaches-self? form [])`. The fix is a **net simplification**: the separate `tree-seq` scan is gone.

`elide-cyclic` is untouched and still correct — a foreign value from which a cycle is reachable *by any route* is one `pr-str` cannot survive, so eliding it whole is the right call.

## Proof

- **Non-vacuity extended**: the control row now asserts `cljs.core/pr-str` blows the stack on `#js {"held" [:p provider]}` too — so the new rows cannot pass vacuously, and the gap is demonstrated rather than asserted.
- **`a-cycle-through-a-mixed-chain-is-found`**: the mixed chain elides correctly at two depths (through an object, and through an object-then-array), and `emit-element` on a mixed-chain head produces `:rf.error/invalid-hiccup-head` with printable ex-data.
- **Byte-identity preserved**: a new row proves an *acyclic* persistent collection nested inside a foreign value comes back `identical?` and prints byte-identically — the widened walk must not cost the guarantee it was added to protect.

## Quality gates (this PR)

| gate | result |
| --- | --- |
| `npm run test:cljs` | **exit 0** — `Ran 12661 tests containing 63435 assertions. 0 failures, 0 errors.` |
| clj-kondo @ CI pin 2026.04.15 | **exit 0** — `errors: 0, warnings 4536` (baseline), zero findings on either changed file |
| ssr JVM (`clojure -M:test`) | **exit 0** — `Ran 623 tests containing 3127 assertions. 0 failures, 0 errors.` |
| reverse mutation (detector narrowed back to #7562's, then restored) | `Ran 12661 tests containing 63435 assertions. 1 failures, 2 errors.` — **all three in `a-cycle-through-a-mixed-chain-is-found` and nowhere else**, each carrying `RangeError: Maximum call stack size exceeded` |

Gates that moved on #7562 itself, for the record: fast-PR spine **PASS** (exit 0; classification `docs=false jvm=true node=true (classified)`; JVM core 2215/11527 clean, JVM ssr 623/3127 clean, CLJS node 12660/63428 clean, hicasso-compile 126 namespaces zero warnings), `npm run test:browser` exit 0 (1101 tests / 6818 assertions, 0 failures 0 errors), ssr-ring JVM 215/1034 clean, and 50 pass / 35 skipping / 0 fail on the PR head.

The mutation is the sharpest evidence in this PR, because of what it does **not** touch: narrowing the walker back to the merged version reds exactly the three mixed-chain rows and leaves all 12,658 other tests green. That is the widening being necessary and sufficient, measured rather than argued.

```
expected: (= "[:div #js {…cyclic…}]" (diagnostic/pr-form [:div #js {:held [:p provider]}]))
  actual: #object[RangeError RangeError: Maximum call stack size exceeded]

a mixed-chain cycle in head position must throw :rf.error/invalid-hiccup-head;
got {:threw "RangeError", :error-id nil, :message "Maximum call stack size exceeded", :ex-data-printable? true}
```
