### PR TITLE
fix(ui): the client-runtime diagnostics report instead of overflowing (rf2-q9q9y)

### DIFF
--- a/implementation/ui/src/re_frame/ui/events.cljs
+++ b/implementation/ui/src/re_frame/ui/events.cljs
@@ -313,10 +313,14 @@
                 :else
                 (error/throw-error!
                  :rf.error/ui-tree-malformed 're-frame.ui/event
-                 (str "a (ui/event …) body produced " (pr-str result)
+                 ;; rf2-q9q9y — `result` is whatever the AUTHOR's committed
+                 ;; `ui/event` body returned, so a foreign value lands here
+                 ;; verbatim. Message half `error/pr-form`, ex-data half
+                 ;; `error/safe-form`.
+                 (str "a (ui/event …) body produced " (error/pr-form result)
                       " — a committed ui/event handler must return an event "
                       "vector to dispatch, or nil to dispatch nothing")
-                 {:extra {:value result}})))
+                 {:extra (error/safe-form {:value result})})))
 
             :fn
             ((.-value desc) native-event)
@@ -611,17 +615,25 @@
       (when (or (seq unknown) (not (vector? event)))
         (error/throw-error!
          :rf.error/ui-tree-malformed 're-frame.ui/render
+         ;; rf2-q9q9y — `v` is the author's options map and a cycle is
+         ;; reachable through any of its values. `unknown` holds its KEYS,
+         ;; which are equally author-supplied, so the whole `:extra` crosses
+         ;; rather than the `:value` slot alone.
          (str "a dynamic handler options map needs a vector :event and only "
-              "the closed handler-option keys; got " (pr-str v))
-         {:extra {:value v :unknown-keys (vec unknown)}}))
+              "the closed handler-option keys; got " (error/pr-form v))
+         {:extra (error/safe-form {:value v :unknown-keys (vec unknown)})}))
       (when (or capture passive)
         (error/throw-error!
          :rf.error/ui-tree-malformed 're-frame.ui/render
          (str "dynamic :capture/:passive listener options cannot change the "
               "native listener phase after compilation; write this options "
               "map literally at the element site")
-         {:extra {:value v :unsupported-dynamic-options
-                  (cond-> [] capture (conj :capture) passive (conj :passive))}}))
+         ;; rf2-q9q9y — the EX-DATA-ONLY half: this message never prints `v`,
+         ;; so nothing overflowed at the thrower and a cyclic `:event` inside
+         ;; the options map rode out to explode at a downstream sink instead.
+         {:extra (error/safe-form
+                  {:value v :unsupported-dynamic-options
+                   (cond-> [] capture (conj :capture) passive (conj :passive))})}))
       (when interop/debug-enabled?
         (warn-dynamic-placeholder! event debug-site)
         (warn-unregistered! event (.-frameId ^js (capture-or-throw!)) debug-site))
@@ -642,6 +654,10 @@
     :else
     (error/throw-error!
      :rf.error/ui-tree-malformed 're-frame.ui/render
-     (str "a dynamic handler expression produced " (pr-str v) " — handlers "
+     ;; rf2-q9q9y — reached exactly when `v` is not nil/vector/map/fn, i.e.
+     ;; when it IS a foreign object: `:on-click ctx.Provider` is the shape.
+     ;; The CLJS twin of `tree/classify-event`, same message text, crossed in
+     ;; the same change so the two host arms cannot drift.
+     (str "a dynamic handler expression produced " (error/pr-form v) " — handlers "
           "classify by type: event vector, options map, handler fn, or nil")
-     {:extra {:value v}})))
+     {:extra (error/safe-form {:value v})})))

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -228,7 +228,12 @@
     (let [ks (rules/js-string-coerce k)]
       (if (unchecked-get seen ks)
         (js/console.warn
-         "[:rf.error/ui-duplicate-key] duplicate key in keyed list:" (pr-str k)
+         ;; rf2-q9q9y — `k` is a caller-supplied `:key` and reaches here only
+         ;; AFTER `js-string-coerce` (which is `(str v)`, bounded on a foreign
+         ;; value), so two cyclic keys collide at the same coerced string and
+         ;; arrive RAW at this warning. `error/pr-form` keeps the crossing
+         ;; total; a bare `pr-str` overflowed on the way into `console.warn`.
+         "[:rf.error/ui-duplicate-key] duplicate key in keyed list:" (error/pr-form k)
          "(keys compare after React string coercion)")
         (unchecked-set seen ks true))))
   k)
@@ -255,11 +260,15 @@
     (when (or (seq? x) (coll? x) (keyword? x) (symbol? x))
       (error/throw-error!
        :rf.error/ui-tree-malformed 're-frame.ui/render
-       (str "a dynamic child produced " (pr-str x) " — a runtime value "
+       ;; rf2-q9q9y — the guard admits only CLJS collections/seqs/keywords/
+       ;; symbols, so a raw foreign object never lands here; a collection
+       ;; HOLDING one does, and `[:p ctx.Provider]` is exactly that mixed
+       ;; chain. Message half `error/pr-form`, ex-data half `error/safe-form`.
+       (str "a dynamic child produced " (error/pr-form x) " — a runtime value "
             "cannot be a template. Strings/numbers/nil/false render; markup "
             "needs a view (or ui/raw for a host element); lists need "
             "(for ...) with :key")
-       {:extra {:value x}})))
+       {:extra (error/safe-form {:value x})})))
   x)
 
 ;; ---------------------------------------------------------------------------
@@ -298,11 +307,15 @@
   [x]
   (error/throw-error!
    :rf.error/ui-tree-malformed 're-frame.ui/slot
-   (str "a ui/slot received " (pr-str x) " — a slot accepts only a "
+   ;; rf2-q9q9y — `slot-ready?` routes EVERYTHING that is neither nil nor a
+   ;; marked render-fn here, so a React context provider (an ordinary
+   ;; authoring slip) arrives raw. Message half `error/pr-form`, ex-data half
+   ;; `error/safe-form`.
+   (str "a ui/slot received " (error/pr-form x) " — a slot accepts only a "
         "ui/render-fn value (author it as (ui/render-fn [args…] template)) "
         "or nil (renders nothing). Ordinary function props are opaque "
         "identity-compared values and are never invoked as slots")
-   {:extra {:value x}}))
+   {:extra (error/safe-form {:value x})}))
 
 (defn slot-ready?
   "Gate a `ui/slot` value: `nil` renders nothing (false); a `ui/render-fn`
@@ -936,11 +949,16 @@
   (when-not (or (fn? view) (object? view))
     (error/throw-error!
      :rf.error/ui-tree-malformed 're-frame.ui/->react
+     ;; rf2-q9q9y — the guard passes any `object?`, so a BARE provider never
+     ;; reaches this throw (measured). What does reach it: a hiccup vector,
+     ;; which the message itself anticipates, and a JS ARRAY, whose
+     ;; constructor is `js/Array` so `object?` is false. Both can carry a
+     ;; cycle. Message half `error/pr-form`, ex-data half `error/safe-form`.
      (str "(ui/->react view) needs a compiled re-frame.ui view (a `defview` "
-          "value — a React component), but received " (pr-str view)
+          "value — a React component), but received " (error/pr-form view)
           ". Pass the view itself, e.g. (def CartRow (ui/->react cart-row)); "
           "not its id keyword and not a rendered form")
-     {:extra {:value view}}))
+     {:extra (error/safe-form {:value view})}))
   (or (.get exported-component-cache view)
       (let [exported
             (fn rf-ui->react [props]

--- a/implementation/ui/src/re_frame/ui/tree.cljc
+++ b/implementation/ui/src/re_frame/ui/tree.cljc
@@ -135,15 +135,25 @@
             (error/throw-error!
              :rf.error/ui-tree-malformed 're-frame.ui/render
              "a list row lost its :key — compiled keyed runs must carry keys"
-             {:extra {:row row}}))
+             ;; rf2-q9q9y — the EX-DATA-ONLY half of the crossing: this
+             ;; message prints nothing, so nothing overflowed at the thrower
+             ;; and a cyclic `row` rode out intact to explode at a downstream
+             ;; logger / projector / trace sink instead. `error/safe-form`
+             ;; closes it at the boundary that owns the value.
+             {:extra (error/safe-form {:row row})}))
           (let [ks (rules/js-string-coerce (:key row))]
             (if-let [prev (get seen ks)]
               (error/throw-error!
                :rf.error/ui-duplicate-key 're-frame.ui/render
-               (str "duplicate key " (pr-str (:key row)) " in a keyed list "
+               ;; rf2-q9q9y — `:key` is caller-supplied and reaches here only
+               ;; after `js-string-coerce` (`(str v)`, bounded on a foreign
+               ;; value), so two cyclic keys COLLIDE and arrive raw. `prev` is
+               ;; a previously-seen key and is equally caller-supplied, so the
+               ;; whole `:extra` crosses rather than the `:key` slot alone.
+               (str "duplicate key " (error/pr-form (:key row)) " in a keyed list "
                     "(keys compare after React's string coercion: key 1 "
                     "collides with key \"1\"). Keys must be unique per list site")
-               {:extra {:key (:key row) :collides-with prev}})
+               {:extra (error/safe-form {:key (:key row) :collides-with prev})})
               (recur (assoc! seen ks (:key row)) (inc i)))))
         nil))
     (with-meta rows {:rf.ui.tree/run true})))
@@ -401,10 +411,12 @@
   [x]
   (error/throw-error!
    :rf.error/ui-tree-malformed 're-frame.ui/slot
-   (str "a ui/slot received " (pr-str x) " — a slot accepts only a "
+   ;; rf2-q9q9y — the `tree` twin of `runtime/invalid-slot!`, crossed at the
+   ;; same two halves so the two host arms cannot drift.
+   (str "a ui/slot received " (error/pr-form x) " — a slot accepts only a "
         "ui/render-fn value (author it as (ui/render-fn [args…] template)) "
         "or nil (renders nothing)")
-   {:extra {:value x}}))
+   {:extra (error/safe-form {:value x})}))
 
 (defn slot-ready?
   "Gate a `ui/slot` value: nil renders nothing (false); a `ui/render-fn`
@@ -457,10 +469,14 @@
     (fn? v)     opaque-fn
     :else (error/throw-error!
            :rf.error/ui-tree-malformed 're-frame.ui/render
-           (str "a dynamic handler expression produced " (pr-str v)
+           ;; rf2-q9q9y — the throw is reached exactly when `v` is not
+           ;; nil/vector/map/fn, i.e. when it IS a foreign object. Message
+           ;; text is shared verbatim with `events/dynamic-handler`'s `:else`
+           ;; arm, so both crossed in the same change.
+           (str "a dynamic handler expression produced " (error/pr-form v)
                 " — handlers classify by type: event vector, options map,"
                 " handler fn, or nil")
-           {:extra {:value v}})))
+           {:extra (error/safe-form {:value v})})))
 
 (defn jvm-host-op!
   "Raise the typed host-op error for host-bearing features hit on the JVM

--- a/implementation/ui/test/re_frame/ui/diagnostic_cycle_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/diagnostic_cycle_cljs_test.cljs
@@ -85,10 +85,20 @@
   "Run `f` and describe what happened as DATA. On a throw the map carries the
   host error NAME (so a stack overflow shows up as `\"RangeError\"` in the
   failure text), the framework error id, the message, and whether the ex-data
-  survives `pr-str` — which is the ex-data half of the defect."
+  survives `pr-str` — which is the ex-data half of the defect.
+
+  THE RETURN VALUE IS RECORDED AS A BOOLEAN, NEVER AS ITSELF, and that is
+  load-bearing rather than tidiness. Several sites here RETURN their input
+  (`check-key!` does; a guard that stopped firing would too), so a `:returned`
+  slot would hold the cyclic fixture — and every failure message below
+  `pr-str`s the outcome map. A regression would then raise the very
+  `RangeError` under test FROM THE ASSERTION, producing a red that looks
+  exactly like the product defect while the product is fine. Keeping only
+  `:returned?` makes the outcome map safe to print by construction, so the
+  failure text stays trustworthy under precisely the conditions it exists for."
   [f]
   (try
-    {:returned (f)}
+    (do (f) {:returned? true})
     (catch :default e
       (let [data (ex-data e)]
         {:threw    (.-name e)
@@ -256,11 +266,17 @@
                       (runtime/check-key! seen k)
                       (runtime/check-key! seen k))))]
       (is (nil? (:threw o))
-          (str "the duplicate-key warning must not overflow; got " (pr-str (dissoc o :warned))))
+          (str "the duplicate-key warning must not overflow; got "
+               (pr-str (dissoc o :warned))))
+      (is (true? (:returned? o))
+          "and `check-key!` still returns its key, warning being a side effect")
       (is (= 1 (count (:warned o)))
           (str "exactly one duplicate warning fires; got " (pr-str (:warned o))))
       (is (str/includes? (first (:warned o)) "duplicate key")
-          (str "and it is the duplicate-key warning; got " (pr-str (:warned o)))))))
+          (str "and it is the duplicate-key warning; got " (pr-str (:warned o))))
+      (is (str/includes? (first (:warned o)) "#js {…cyclic…}")
+          (str "with the cyclic key replaced by the fixed token; got "
+               (pr-str (:warned o)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; re-frame.ui.tree — the JVM-emitter substrate, measured on its CLJS arm

--- a/implementation/ui/test/re_frame/ui/diagnostic_cycle_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/diagnostic_cycle_cljs_test.cljs
@@ -22,9 +22,12 @@
 
   A `RangeError` raised inside a diagnostic is an ordinary synchronous JS
   throw. Every row calls through [[outcome]], which returns a MAP —
-  `{:returned …}` or `{:threw <name> :error-id … :message …
+  `{:returned? true}` or `{:threw <name> :error-id … :message …
   :ex-data-printable? …}` — and asserts on that map, so a regression fails
   with `\"RangeError\"` in its own failure text rather than aborting the var.
+  The map records THAT a call returned, never WHAT it returned, so the
+  failure text is itself safe to `pr-str` — see [[outcome]] for why that is
+  load-bearing rather than tidiness.
 
   ## The two halves, at every site
 
@@ -98,7 +101,8 @@
   failure text stays trustworthy under precisely the conditions it exists for."
   [f]
   (try
-    (do (f) {:returned? true})
+    (f)
+    {:returned? true}
     (catch :default e
       (let [data (ex-data e)]
         {:threw    (.-name e)

--- a/implementation/ui/test/re_frame/ui/diagnostic_cycle_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/diagnostic_cycle_cljs_test.cljs
@@ -1,0 +1,484 @@
+(ns re-frame.ui.diagnostic-cycle-cljs-test
+  "THE DIAGNOSTIC PATH ITSELF THREW — the `re-frame.ui` CLIENT-RUNTIME sites
+  (rf2-q9q9y).
+
+  Same defect as its three predecessors, one tier down. `cljs.core`'s printer
+  descends into a foreign JS value through exactly two `pr-writer-impl`
+  branches — `object?` (own enumerable keys) and `array?` (elements) — and
+  NEITHER carries a seen-set, so a cyclic foreign object graph makes `pr-str`
+  raise `RangeError: Maximum call stack size exceeded`. React 19's
+  `createContext` returns an object whose `Provider` key points back at the
+  context itself, so `ctx.Provider` IS such a graph, and leaking one into a
+  slot / child / handler position is an ordinary authoring mistake.
+
+  WHAT MAKES THIS GROUP DIFFERENT FROM ITS PREDECESSORS. `re-frame.ssr.emit`,
+  `re-frame.ssr.ui-tree` and `re-frame.ui.semantic` are server / test-tier
+  surfaces. These are the CLIENT RUNTIME — `ui/slot`, `ui/render`'s dynamic
+  child check, `ui/->react`, and the committed-event vocabulary in
+  `re-frame.ui.events`. An author hits them in the browser, in dev, on the
+  path their own mistake took.
+
+  ## How these rows OBSERVE a stack overflow
+
+  A `RangeError` raised inside a diagnostic is an ordinary synchronous JS
+  throw. Every row calls through [[outcome]], which returns a MAP —
+  `{:returned …}` or `{:threw <name> :error-id … :message …
+  :ex-data-printable? …}` — and asserts on that map, so a regression fails
+  with `\"RangeError\"` in its own failure text rather than aborting the var.
+
+  ## The two halves, at every site
+
+  `error/pr-form` on the message half; `error/safe-form` on the `:extra`
+  ex-data half. BOTH matter: a cyclic value that merely rides out in
+  `{:extra {:value v}}` explodes at a DOWNSTREAM logger / error projector /
+  trace sink — someone else's boundary rather than the thrower's.
+
+  [[the-fixtures-are-genuinely-cyclic]] is the non-vacuity control. Without
+  it every row below could pass on an acyclic fixture and prove nothing."
+  (:require ["react" :as react]
+            [clojure.string :as str]
+            [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.ui.events :as events]
+            [re-frame.ui.runtime :as runtime]
+            [re-frame.ui.tree :as tree]))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures
+;; ---------------------------------------------------------------------------
+
+(defn- self-referential-object
+  "A plain JS object holding a reference to ITSELF. No React: the defect is a
+  property of a foreign object graph, and this is the smallest value that has
+  it."
+  []
+  (let [o #js {"tag" "cyclic"}]
+    (unchecked-set o "self" o)
+    o))
+
+(defn- self-referential-array
+  "The ARRAY half of the same crossing — `pr-str`'s other descending branch."
+  []
+  (let [a #js ["cyclic"]]
+    (.push a a)
+    a))
+
+(def ^:private corpus-context
+  "A real React context, so the rows below carry the shape that was reported
+  rather than a model of it."
+  (react/createContext "unset"))
+
+(def ^:private provider
+  "`ctx.Provider` — the value an author most plausibly leaks into a slot,
+  a child position, or a handler prop."
+  (.-Provider corpus-context))
+
+(def ^:private acyclic-object
+  "The ACYCLIC control. A plain JS object `pr-str` renders in full and
+  terminates on: every row that pins byte-identity uses this."
+  #js {"theme" "dark" "level" 3})
+
+;; ---------------------------------------------------------------------------
+;; Observation
+;; ---------------------------------------------------------------------------
+
+(defn- outcome
+  "Run `f` and describe what happened as DATA. On a throw the map carries the
+  host error NAME (so a stack overflow shows up as `\"RangeError\"` in the
+  failure text), the framework error id, the message, and whether the ex-data
+  survives `pr-str` — which is the ex-data half of the defect."
+  [f]
+  (try
+    {:returned (f)}
+    (catch :default e
+      (let [data (ex-data e)]
+        {:threw    (.-name e)
+         :error-id (:rf.error/id data)
+         :message  (ex-message e)
+         :ex-data-printable?
+         (try (string? (pr-str data)) (catch :default _ false))}))))
+
+(defn- rejected-with
+  "Assert `f` threw the framework error `id` — with the whole outcome map in
+  the failure text, and with the ex-data proven printable at the same time."
+  [id label f]
+  (let [o (outcome f)]
+    (is (= id (:error-id o))
+        (str label " must throw " id "; got " (pr-str o)))
+    (is (true? (:ex-data-printable? o))
+        (str label "'s ex-data must survive pr-str at a downstream sink; got "
+             (pr-str (dissoc o :message))))
+    o))
+
+(defn- warning-outcome
+  "`check-key!` DIAGNOSES BY `js/console.warn`, not by throwing, so its
+  crossing is observed by capturing the warn arguments. The `pr-str` call is
+  an ARGUMENT to `console.warn`, so an overflow still propagates out of
+  `check-key!` as an ordinary throw — [[outcome]] catches that, and
+  `:warned` carries the joined arguments when it does not."
+  [f]
+  (let [seen     (atom [])
+        original js/console.warn]
+    (set! js/console.warn (fn [& args] (swap! seen conj (str/join " " args))))
+    (let [o (try (outcome f) (finally (set! js/console.warn original)))]
+      (assoc o :warned @seen))))
+
+;; ---------------------------------------------------------------------------
+;; The `re-frame.ui.events` committed-callback seam
+;;
+;; `commit!`'s three-argument arity is the documented host-agnostic test seam:
+;; it supplies the frame-op bundle directly, so a committed `ui/event` site can
+;; be invoked without a React host.
+;; ---------------------------------------------------------------------------
+
+(def ^:private inert-frame-ops
+  {:frame nil :dispatch (fn [& _]) :dispatch-sync (fn [& _])})
+
+(defn- committed-event-callback
+  "Publish one `ui/event` site whose body returns `result`, commit it, and
+  return the stable committed callback. Invoking it runs the outcome
+  classification in `invoke-site!` — the `:else` arm is the site under test."
+  [result]
+  (let [owner   (events/make-owner ::cycle-probe)
+        cb      (atom nil)
+        capture (nth (events/with-capture
+                       owner nil
+                       (fn []
+                         (reset! cb (events/event-handler
+                                     "evt-0" (fn [_] result) 0 nil))
+                         nil))
+                     1)]
+    (events/commit! owner capture inert-frame-ops)
+    @cb))
+
+;; ---------------------------------------------------------------------------
+;; The control
+;; ---------------------------------------------------------------------------
+
+(deftest the-fixtures-are-genuinely-cyclic
+  (testing "THE NON-VACUITY CONTROL. `pr-str` is what every message site below
+           called, and on these values it recurs until the stack blows. If any
+           row here ever goes green-by-termination, the fixture has stopped
+           being cyclic and the whole file is measuring nothing."
+    (is (= "RangeError" (:threw (outcome #(pr-str (self-referential-object)))))
+        "a hand-built self-referential JS object defeats cljs.core/pr-str")
+    (is (= "RangeError" (:threw (outcome #(pr-str (self-referential-array)))))
+        "and so does a cycle reached through a JS array")
+    (is (= "RangeError" (:threw (outcome #(pr-str provider))))
+        "and so does a real React 19 context provider")
+    (is (= "RangeError" (:threw (outcome #(pr-str [:p provider]))))
+        "and so does a MIXED chain — persistent vector, foreign object —
+         which is the shape that reaches the guards keyed on `coll?`")
+    (is (= "RangeError" (:threw (outcome #(pr-str #js {"held" [:p provider]}))))
+        "and so does the other direction of the same mixed chain — foreign
+         object, persistent vector, foreign object — because the printer
+         crosses between the two freely, which is why the detector has to")
+    (is (= "RangeError" (:threw (outcome #(pr-str {:event [:x provider]}))))
+        "and so does a handler options map holding one inside its :event")
+    (is (identical? provider (.-Provider provider))
+        "because React 19's ctx.Provider IS the context object, and that
+         object carries a Provider key pointing back at itself — the cycle
+         in one line")
+    (is (string? (pr-str [:p acyclic-object]))
+        "while the ACYCLIC control prints fine, which is what makes it a
+         control for the byte-identity rows")))
+
+(deftest string-coercion-cannot-save-the-duplicate-key-sites
+  (testing "Both duplicate-key diagnostics coerce the key through
+           `rules/js-string-coerce` BEFORE comparing, and that coercion is
+           `(str v)` — bounded on a foreign value. So a cyclic key survives
+           coercion, two of them COLLIDE at the same coerced string, and the
+           diagnostic that fires then prints the raw key. This is why the
+           duplicate-key sites are reachable at all."
+    (is (string? (str provider))
+        "(str provider) is bounded — it does not descend the object graph")
+    (is (= (str provider) (str (react/createContext "other")))
+        "two distinct foreign values coerce to the SAME key string, so a
+         keyed list carrying two of them is a genuine duplicate")))
+
+;; ---------------------------------------------------------------------------
+;; re-frame.ui.runtime — the client runtime (all four sites reach a browser)
+;; ---------------------------------------------------------------------------
+
+(deftest runtime-slot-rejects-a-cyclic-value-with-its-own-error
+  (testing "`slot-ready?` routes anything that is neither nil nor a marked
+           `ui/render-fn` to `invalid-slot!`, which prints it. A React
+           context provider is exactly such a value and passing one to a
+           `ui/slot` is an ordinary authoring mistake."
+    (doseq [[label v] [["a provider in a slot"            provider]
+                       ["a hand-built cyclic object"      (self-referential-object)]
+                       ["a cyclic array"                  (self-referential-array)]
+                       ["a mixed chain in a slot"         #js {"held" [:p provider]}]]]
+      (rejected-with :rf.error/ui-tree-malformed label
+                     #(runtime/slot-ready? v)))))
+
+(deftest runtime-dynamic-child-rejects-a-cyclic-value-with-its-own-error
+  (testing "`child`'s guard is `(or (seq? x) (coll? x) (keyword? x)
+           (symbol? x))`, so a RAW foreign object does not reach the throw —
+           but a CLJS collection HOLDING one does, and `[:p ctx.Provider]` is
+           precisely the mixed chain the shared walker exists for."
+    (doseq [[label v] [["a vector holding a provider"     [:p provider]]
+                       ["a list holding a provider"       (list provider)]
+                       ["a map holding a provider"        {:ctx provider}]
+                       ["a seq holding a cyclic array"    (seq [(self-referential-array)])]]]
+      (rejected-with :rf.error/ui-tree-malformed label
+                     #(runtime/child v)))))
+
+(deftest runtime-react-export-rejects-a-cyclic-value-with-its-own-error
+  (testing "`->react-component`'s guard is `(when-not (or (fn? view)
+           (object? view)))`, so a BARE provider passes it (it is an
+           `object?`) and never reaches the throw — the bead flagged this
+           site as lower-confidence for exactly that reason. Two shapes DO
+           reach it: a hiccup vector, which the message itself anticipates
+           ('not its id keyword and not a rendered form'), and a JS ARRAY,
+           whose constructor is `js/Array` so `object?` is false."
+    (doseq [[label v] [["a hiccup vector holding a provider" [:p provider]]
+                       ["a cyclic JS array"                  (self-referential-array)]
+                       ["a map holding a provider"           {:ctx provider}]]]
+      (rejected-with :rf.error/ui-tree-malformed label
+                     #(runtime/->react-component v)))))
+
+(deftest runtime-react-export-still-passes-a-bare-foreign-object
+  (testing "The counterpart measurement: a bare `object?` value is NOT
+           rejected, so this site's cyclic exposure is the vector / array
+           shapes above and nothing else. Pinning it keeps a future widening
+           of the guard from silently re-opening an unmeasured crossing."
+    (is (nil? (:error-id (outcome #(runtime/->react-component provider))))
+        "a bare provider passes the guard rather than reaching the throw")))
+
+(deftest runtime-duplicate-key-warning-survives-a-cyclic-key
+  (testing "`check-key!` prints the offending `:key` into a
+           `js/console.warn`. The key coerces through `(str v)` — bounded —
+           so two cyclic keys collide and the warning fires with the RAW key,
+           which is where `pr-str` used to blow the stack."
+    (let [k (self-referential-object)
+          o (warning-outcome
+             (fn [] (let [seen (js-obj)]
+                      (runtime/check-key! seen k)
+                      (runtime/check-key! seen k))))]
+      (is (nil? (:threw o))
+          (str "the duplicate-key warning must not overflow; got " (pr-str (dissoc o :warned))))
+      (is (= 1 (count (:warned o)))
+          (str "exactly one duplicate warning fires; got " (pr-str (:warned o))))
+      (is (str/includes? (first (:warned o)) "duplicate key")
+          (str "and it is the duplicate-key warning; got " (pr-str (:warned o)))))))
+
+;; ---------------------------------------------------------------------------
+;; re-frame.ui.tree — the JVM-emitter substrate, measured on its CLJS arm
+;; ---------------------------------------------------------------------------
+
+(deftest tree-slot-rejects-a-cyclic-value-with-its-own-error
+  (testing "The `tree` twin of `runtime/invalid-slot!` — same didactic error,
+           same crossing, a different host arm."
+    (doseq [[label v] [["a provider in a slot"       provider]
+                       ["a cyclic array"             (self-referential-array)]
+                       ["a mixed chain in a slot"    #js {"held" [:p provider]}]]]
+      (rejected-with :rf.error/ui-tree-malformed label
+                     #(tree/slot-ready? v)))))
+
+(deftest tree-handler-classification-rejects-a-cyclic-value-with-its-own-error
+  (testing "`classify-event` reaches its throw for a `v` that is not
+           nil / vector / map / fn — i.e. a foreign object in a handler slot."
+    (doseq [[label v] [["a provider as a handler"    provider]
+                       ["a cyclic array as handler"  (self-referential-array)]
+                       ["a hand-built cyclic object" (self-referential-object)]]]
+      (rejected-with :rf.error/ui-tree-malformed label
+                     #(tree/classify-event v)))))
+
+(deftest tree-keyed-run-rejects-a-cyclic-key-and-a-cyclic-row
+  (testing "`keyed-run` crosses TWICE — the duplicate-key arm prints the raw
+           `:key`, and the lost-key arm rides the whole offending ROW out in
+           `:extra` without printing it. The second is the ex-data-only half
+           of the defect: nothing overflows at the thrower, and then a
+           downstream sink `pr-str`s the ex-data and does."
+    (rejected-with :rf.error/ui-duplicate-key
+                   "two cyclic keys colliding under string coercion"
+                   #(tree/keyed-run [{:key provider} {:key provider}]))
+    (rejected-with :rf.error/ui-tree-malformed
+                   "a foreign object where a keyed row belongs"
+                   #(tree/keyed-run [provider]))
+    (rejected-with :rf.error/ui-tree-malformed
+                   "a cyclic array where a keyed row belongs"
+                   #(tree/keyed-run [(self-referential-array)]))))
+
+;; ---------------------------------------------------------------------------
+;; re-frame.ui.events — the committed-event vocabulary (client runtime)
+;; ---------------------------------------------------------------------------
+
+(deftest event-body-outcome-rejects-a-cyclic-return-with-its-own-error
+  (testing "A committed `ui/event` body NAMES its outcome: a vector
+           dispatches, nil dispatches nothing, anything else is the didactic
+           diagnostic — which prints what the body returned. An author whose
+           body returns a foreign value gets that diagnostic, and it used to
+           overflow instead."
+    (doseq [[label result] [["a body returning a provider"     provider]
+                            ["a body returning a cyclic array" (self-referential-array)]
+                            ["a body returning a mixed chain"  #js {"held" [:p provider]}]]]
+      (let [cb (committed-event-callback result)]
+        (rejected-with :rf.error/ui-tree-malformed label #(cb #js {}))))))
+
+(deftest dynamic-handler-rejects-a-cyclic-value-with-its-own-error
+  (testing "`dynamic-handler` crosses at THREE arms, and all three throw
+           BEFORE `capture-or-throw!` runs, so each is reachable directly."
+    ;; the :else arm — a foreign object in a handler position
+    (doseq [[label v] [["a provider as a dynamic handler" provider]
+                       ["a cyclic array as one"           (self-referential-array)]]]
+      (rejected-with :rf.error/ui-tree-malformed label
+                     #(events/dynamic-handler "site-0" v nil)))
+
+    ;; the options-map arm — an unknown key, cycle reachable through the map
+    (rejected-with :rf.error/ui-tree-malformed
+                   "an options map whose unknown key holds a provider"
+                   #(events/dynamic-handler "site-0" {:event [:x] :bad provider} nil))
+
+    ;; the capture/passive arm — message carries no value, `:extra` does
+    (rejected-with :rf.error/ui-tree-malformed
+                   "a :capture options map whose :event holds a provider"
+                   #(events/dynamic-handler
+                     "site-0" {:event [:x provider] :capture true} nil))))
+
+;; ---------------------------------------------------------------------------
+;; The acyclic path, byte for byte
+;; ---------------------------------------------------------------------------
+
+(deftest an-acyclic-diagnostic-is-byte-identical
+  (testing "The expectation embeds `cljs.core/pr-str`'s OWN output, so these
+           rows fail the moment a message stops being what `pr-str` produced
+           before this fix existed. The acyclic foreign object keeps its
+           CONTENTS in the message — eliding every foreign value (what the
+           hash walk does, and rightly) would have cost the diagnostic exactly
+           the information it exists to carry."
+    ;; runtime/invalid-slot!
+    (let [o (outcome #(runtime/slot-ready? acyclic-object))]
+      (is (= :rf.error/ui-tree-malformed (:error-id o)))
+      (is (str/includes? (:message o) (str "a ui/slot received " (pr-str acyclic-object)))
+          (str "slot value printed byte-identically to pr-str; got "
+               (pr-str (:message o)))))
+
+    ;; runtime/child
+    (let [v [:p acyclic-object]
+          o (outcome #(runtime/child v))]
+      (is (= :rf.error/ui-tree-malformed (:error-id o)))
+      (is (str/includes? (:message o) (str "a dynamic child produced " (pr-str v)))
+          (str "child printed byte-identically to pr-str; got " (pr-str (:message o)))))
+
+    ;; runtime/->react-component
+    (let [v [:p acyclic-object]
+          o (outcome #(runtime/->react-component v))]
+      (is (= :rf.error/ui-tree-malformed (:error-id o)))
+      (is (str/includes? (:message o) (str "but received " (pr-str v)))
+          (str "view printed byte-identically to pr-str; got " (pr-str (:message o)))))
+
+    ;; runtime/check-key!
+    (let [o (warning-outcome
+             (fn [] (let [seen (js-obj)]
+                      (runtime/check-key! seen acyclic-object)
+                      (runtime/check-key! seen acyclic-object))))]
+      (is (str/includes? (first (:warned o)) (pr-str acyclic-object))
+          (str "key printed byte-identically to pr-str; got " (pr-str (:warned o)))))
+
+    ;; tree/invalid-slot!
+    (let [o (outcome #(tree/slot-ready? acyclic-object))]
+      (is (= :rf.error/ui-tree-malformed (:error-id o)))
+      (is (str/includes? (:message o) (str "a ui/slot received " (pr-str acyclic-object)))
+          (str "slot value printed byte-identically to pr-str; got "
+               (pr-str (:message o)))))
+
+    ;; tree/classify-event
+    (let [o (outcome #(tree/classify-event acyclic-object))]
+      (is (= :rf.error/ui-tree-malformed (:error-id o)))
+      (is (str/includes? (:message o)
+                         (str "a dynamic handler expression produced "
+                              (pr-str acyclic-object)))
+          (str "handler printed byte-identically to pr-str; got "
+               (pr-str (:message o)))))
+
+    ;; tree/keyed-run, the duplicate-key arm
+    (let [o (outcome #(tree/keyed-run [{:key acyclic-object} {:key acyclic-object}]))]
+      (is (= :rf.error/ui-duplicate-key (:error-id o)))
+      (is (str/includes? (:message o) (str "duplicate key " (pr-str acyclic-object)))
+          (str "key printed byte-identically to pr-str; got " (pr-str (:message o)))))
+
+    ;; events, the ui/event body outcome
+    (let [cb (committed-event-callback acyclic-object)
+          o  (outcome #(cb #js {}))]
+      (is (= :rf.error/ui-tree-malformed (:error-id o)))
+      (is (str/includes? (:message o)
+                         (str "a (ui/event …) body produced " (pr-str acyclic-object)))
+          (str "result printed byte-identically to pr-str; got "
+               (pr-str (:message o)))))
+
+    ;; events/dynamic-handler, the :else arm
+    (let [o (outcome #(events/dynamic-handler "site-0" acyclic-object nil))]
+      (is (= :rf.error/ui-tree-malformed (:error-id o)))
+      (is (str/includes? (:message o)
+                         (str "a dynamic handler expression produced "
+                              (pr-str acyclic-object)))
+          (str "handler printed byte-identically to pr-str; got "
+               (pr-str (:message o)))))
+
+    ;; events/dynamic-handler, the options-map arm
+    (let [v {:event [:x] :bad acyclic-object}
+          o (outcome #(events/dynamic-handler "site-0" v nil))]
+      (is (= :rf.error/ui-tree-malformed (:error-id o)))
+      (is (str/includes? (:message o) (str "got " (pr-str v)))
+          (str "options map printed byte-identically to pr-str; got "
+               (pr-str (:message o)))))))
+
+(deftest the-ex-data-value-slot-survives-a-downstream-sink
+  (testing "`:value` is the slot a tool reads to see the offending value. It
+           must still BE that value when the value is printable, and must be
+           printable when it is not — the two halves of the ex-data crossing."
+    (let [data (try (runtime/slot-ready? acyclic-object) nil
+                    (catch :default e (ex-data e)))]
+      (is (identical? acyclic-object (:value data))
+          "an acyclic value rides out IDENTICAL — safe-form returned its input"))
+
+    (let [data (try (runtime/slot-ready? provider) nil
+                    (catch :default e (ex-data e)))]
+      (is (string? (pr-str data))
+          "a cyclic value's ex-data is printable at a downstream sink")
+      (is (str/includes? (pr-str (:value data)) "#js {…cyclic…}")
+          "and the cycle inside it was replaced by the fixed token"))
+
+    (let [v    [:p provider]
+          data (try (runtime/child v) nil
+                    (catch :default e (ex-data e)))]
+      (is (string? (pr-str data))
+          "a mixed chain's ex-data is printable too")
+      (is (str/includes? (pr-str (:value data)) "#js {…cyclic…}")
+          "with the cycle elided INSIDE the surviving vector")
+      (is (str/includes? (pr-str (:value data)) ":p")
+          "and the acyclic part of the same value still readable"))
+
+    (let [data (try (tree/keyed-run [provider]) nil
+                    (catch :default e (ex-data e)))]
+      (is (string? (pr-str data))
+          "the lost-key arm's `:row` survives a downstream sink — the
+           ex-data-only crossing, where nothing overflowed at the thrower"))
+
+    (let [data (try (events/dynamic-handler
+                     "site-0" {:event [:x provider] :capture true} nil)
+                    nil
+                    (catch :default e (ex-data e)))]
+      (is (string? (pr-str data))
+          "and so does the capture/passive arm, whose message never printed
+           the value at all"))))
+
+;; ---------------------------------------------------------------------------
+;; The success paths are untouched
+;; ---------------------------------------------------------------------------
+
+(deftest the-valid-paths-still-work
+  (testing "The crossing is on the FAILURE path only — nothing about a valid
+           slot, child, handler or keyed run moves."
+    (is (false? (runtime/slot-ready? nil)))
+    (is (true? (runtime/slot-ready? (runtime/render-fn (fn []) 0))))
+    (is (= "hi" (runtime/child "hi")))
+    (is (= 42 (runtime/child 42)))
+    (is (false? (tree/slot-ready? nil)))
+    (is (true? (tree/slot-ready? (tree/render-fn (fn []) 0))))
+    (is (= [:evt 1] (tree/classify-event [:evt 1])))
+    (is (nil? (tree/classify-event nil)))
+    (is (= 2 (count (tree/keyed-run [{:key "a"} {:key "b"}]))))
+    (is (fn? (committed-event-callback nil))
+        "a body returning nil is the no-dispatch case, not a diagnostic")))


### PR DESCRIPTION
Fourth namespace group of the `rf2-9s68n` class. `cljs.core`'s printer descends into a foreign JS value through exactly two `pr-writer-impl` branches — `object?` (own enumerable keys) and `array?` (elements) — and **neither carries a seen-set**. React 19's `createContext` returns an object whose `Provider` key points back at the context itself, so `ctx.Provider` **is** a cyclic graph, and a diagnostic built with `pr-str` over such a value raised `RangeError: Maximum call stack size exceeded` instead of the error it exists to produce.

The three predecessors fixed `re-frame.ssr.emit`, `re-frame.ssr.ui-tree` and `re-frame.ui.semantic` — server and test-tier surfaces. **These are the client runtime**: `ui/slot`, `ui/render`'s dynamic child and handler checks, `ui/->react`, and the committed `ui/event` vocabulary. An author hits them in the browser, on the path their own mistake took.

No new helper and no new dependency edge — `error/pr-form` (message half) and `error/safe-form` (ex-data half) already live in `re-frame.error` under core, and all three namespaces already `:require` it.

## Twelve crossings, not five

The bead named five sites. The sweep found **twelve crossings across three namespaces** — and resolved the bead's two open questions by measurement rather than by reading. The bead also mis-named two of its five symbols (`check-dynamic-child!` is `child`; `classify-handler` is `classify-event`), which is worth knowing for anyone grepping its list.

| # | Site | Bead? | Halves crossed | Reaching shape (measured) | Can it reach a page? |
|---|---|---|---|---|---|
| 1 | `runtime/invalid-slot!` | named | message + ex-data | `ui/slot` given a provider / cyclic array / mixed chain | **No** — thrown, never rendered |
| 2 | `runtime/child` | named as `check-dynamic-child!` | message + ex-data | guard admits only CLJS colls, so `[:p provider]` — the mixed chain | **No** — thrown |
| 3 | `runtime/->react-component` | named (bead: "lower confidence, verify") | message + ex-data | **resolved:** a bare provider does *not* reach it (`object?` passes the guard). A hiccup vector, a **JS array** (`js/Array` ⇒ `object?` false) and a map all do | **No** — thrown |
| 4 | `runtime/check-key!` | **not named** | message | two cyclic keys collide at `"[object Object]"` after `js-string-coerce` | **No** — `console.warn`, DEV-only |
| 5 | `tree/invalid-slot!` | named | message + ex-data | provider / cyclic array / mixed chain | **No** — thrown |
| 6 | `tree/classify-event` | named as `classify-handler` | message + ex-data | a foreign object in a handler slot | **No** — thrown |
| 7 | `tree/keyed-run` duplicate-key arm | **not named** | message + ex-data | two cyclic `:key`s colliding under string coercion | **No** — thrown |
| 8 | `tree/keyed-run` lost-key arm | **not named** | **ex-data only** | a foreign object where a keyed row belongs | **No** — thrown |
| 9 | `events/invoke-site!` outcome arm | **not named** | message + ex-data | a committed `ui/event` body returning a foreign value | **No** — thrown |
| 10 | `events/dynamic-handler` `:else` | **not named** | message + ex-data | `:on-click ctx.Provider` | **No** — thrown |
| 11 | `events/dynamic-handler` options-map | **not named** | message + ex-data | `{:event [:x] :bad provider}` | **No** — thrown |
| 12 | `events/dynamic-handler` capture/passive | **not named** | **ex-data only** | `{:event [:x provider] :capture true}` | **No** — thrown |

**`rf2-y1jbaq` (never stringify an unescaped value into an XSS-sensitive path).** None of the twelve can reach a page. Eleven are `error/throw-error!` — the value goes into a thrown `ex-info`, never into rendered output — and #4 is a `js/console.warn` behind `goog.DEBUG`. This differs from `re-frame.ui.semantic` (rf2-1aj9s) only in *reachability*, not in wire exposure: `runtime` and `events` are live client-runtime paths with real production consumers, where `semantic` is test-only today. The elision token is a fixed constant carrying no input-derived text, so it cannot widen any surface either way.

### Sites cleared rather than crossed

- **`runtime/warn-bare-view-alias!`** (`runtime.cljs:92`) — `id` is read from the `rf$view_shell` marker that `register-view!` stamps, i.e. a compiler-generated **keyword**, never caller-supplied.
- **`runtime/assert-object-ref!`** — its guard is `(fn? ref-value)`, and a function is neither `object?` nor `array?`, so `pr-str` renders `#object[…]` and **cannot descend**. Its message prints nothing at all. Safe on both halves.

### Two crossings are ex-data-only, and they are the nastier half

`tree/keyed-run`'s lost-key arm and `events/dynamic-handler`'s capture/passive arm print **nothing** in their messages. Nothing overflowed at the thrower — the cyclic value rode out intact in `:extra` and exploded later, at a downstream logger / error projector / trace sink. That is someone else's boundary rather than the thrower's, and strictly harder to diagnose. Both are pinned by rows asserting the ex-data survives `pr-str`.

## Mutation proof, both directions

The suite was written **first** and run against unfixed code — so the probe, the reachability measurement and the reverse mutation are the same artefact.

- **Reverse (revert reproduces):** on unfixed `main`, `re-frame.ui.diagnostic-cycle-cljs-test` ran 15 tests / 105 assertions → **32 failures, 3 errors**, every one carrying `{:threw "RangeError", :message "Maximum call stack size exceeded"}` **as data in its own failure text**. Rows call through an `outcome` helper returning a map, so an overflow is never something the runner has to notice.
- **Forward (fix produces the correct error):** all 15 tests green, 0 failures, 0 errors.

**Non-vacuity control** (`the-fixtures-are-genuinely-cyclic`) asserts `cljs.core/pr-str` *itself* raises `RangeError` on every fixture — the hand-built self-referential object, the self-referential array, a real React 19 provider, `[:p provider]`, the **mixed chain** `#js {"held" [:p provider]}`, and `{:event [:x provider]}` — plus `(identical? provider (.-Provider provider))`, the cycle in one line. A second control pins *why* the duplicate-key sites are reachable at all: `js-string-coerce` is `(str v)`, bounded on a foreign value, so two distinct providers collide at the same coerced key.

**Byte-identity** is asserted at **nine** sites by embedding `cljs.core/pr-str`'s own output in the expectation, never a literal. `safe-form` returns its input *identically* when no cycle is reachable, so this holds by construction; `(identical? acyclic-object (:value data))` pins that the ex-data value is the input object itself.

## The `ssr` and `semantic` sites are undisturbed

- Full `npm run test:cljs` green, including every `re-frame.ssr.diagnostic-cycle-cljs-test` and `re-frame.ui.semantic-cycle-cljs-test` row.
- No file under `implementation/ssr/` or `implementation/ui/src/re_frame/ui/semantic.cljc` is touched by this diff.
- A triage sweep confirmed **`semantic.cljc` has no residual unfixed site**: its two remaining bare `pr-str` calls are framework-built — `:245` `path` is `(conj parent-path :children i)` (keywords and ints only) and `:269` `ds` is a subvector of the private constant `node-discriminators`. rf2-1aj9s's fix is complete.

## The class extends further — filed, not folded in

A full sweep of `implementation/ui/src` triaged every remaining `pr-str`. The compile/macro tier clears **by construction** (a reader-produced form cannot be a cyclic foreign JS object), which covers `compiler.cljc`, `compiler/analyze.cljc`, `compiler/header.cljc`, `compiler/root.cljc`, `compiler/a11y.cljc` and `fingerprint.cljc`. All 20 `client.cljs` sites clear too — `root-id` is compile-gated by `validate-authored-root-id!` and `identifier-prefix` by a `string?` check, and every `client.cljs` entry point is emitted only from `compiler/root.cljc`.

A residue does **not** clear: `rules/assert-safe-caller!` (production-reachable, not DEV-gated), `ui/sub`, `frames/maybe-warn-cross-frame-carried-subscribe!` (a warn, plus a raw `query-v` in the trace payload) and four `re-frame.ui.test` sites. Those are **different throwers on different paths** needing their own reachability measurement — the same reasoning this bead's own description gives for not folding into rf2-1aj9s — so they are **rf2-30dc7**, with the full triage (including everything cleared, so nobody re-treads it) recorded on the bead.

**No spec row is owed** — no error id, message text, or public contract changes.

## A test bug this suite caught in itself

Worth recording, because it is the failure mode these suites are most exposed to. The first full run came back with **one error** — `runtime-duplicate-key-warning-survives-a-cyclic-key`, `RangeError`, *uncaught, not in assertion* — while the product fix was working correctly.

`check-key!` **returns its key** (the warning is a side effect), so `outcome`'s `:returned` slot held the cyclic fixture, and every failure message in the file `pr-str`s the outcome map. The observation helper was raising the very defect it exists to detect, **from the assertion rather than from the product** — a red indistinguishable from the real bug.

`outcome` now records `:returned?` as a boolean and never the value itself, so the outcome map is safe to print by construction. This matters beyond the one row: several sites here return their input, and *a guard that stopped firing would too* — precisely the regression these rows exist to catch, and precisely when the failure text must stay trustworthy.

## Quality gates

All gates run to completion in the foreground or read from the runner's own terminal marker — no gate was piped through `tail`/`head`/`grep`, and no reported exit code comes from a terminated run.

| Gate | Exit | Result |
|---|---|---|
| `scripts/test-fast-pr.sh` | **0** | classification line: `=== fast PR spine: docs=false jvm=true node=true (classified) ===` |
| `npm run test:cljs` | **0** | 12,683 tests / 63,586 assertions — 0 failures, 0 errors |
| `npm run test:browser` | **0** | 1,101 tests / 6,818 assertions — 0 failures, 0 errors |
| `ui` JVM (`clojure -M:test`) | **0** | 702 tests / 17,607 assertions — 0 failures, 0 errors |
| `ssr` JVM (`clojure -M:test`) | **0** | 623 tests / 3,127 assertions — 0 failures, 0 errors |
| clj-kondo 2026.04.15 | **0** | **errors: 0**, warnings: 4,536 (baseline) |

`ui` JVM matters twice over: it exercises `tree.cljc` on the host where `safe-form` is `identity`, confirming the JVM arm is a genuine no-op.

**clj-kondo introduces no new finding.** The one warning reported against a changed file — `tree.cljc:28 namespace re-frame.interop is required but never used` — is **pre-existing on `main`**, verified by linting `main`'s copy of the file in isolation and getting the identical single warning. `interop/debug-enabled?` is used in the `:cljs` arm; kondo's `:clj` pass does not see it. Total warnings are unchanged at the 4,536 baseline, and no `:require` was added or removed by this diff.
