### PR TITLE
docs(ci): the smoke-tier costings say what the gate now measures (rf2-ano54)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3686,17 +3686,22 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       # PR-smoke tier (rf2-wa3oo + rf2-og36y). The full feature-load +
-      # full Xray matrix + Story static-export sweep is on the critical
-      # path of every Story/Xray PR at ~700s, and the identical sweep
-      # already runs nightly in expensive-tests.yml — so PR time ran the
-      # full matrix twice over. PR time now runs only the high-signal
-      # subset:
+      # full Xray matrix + Story static-export sweep sat on the critical
+      # path of every Story/Xray PR at ~700s for the THREE GATES
+      # TOGETHER — never the Xray matrix alone, which is 154–171s of a
+      # 509–564s three-gate nightly total (measured 2026-08-01..05).
+      # The identical sweep already runs nightly in expensive-tests.yml,
+      # so PR time ran the full matrix twice over. PR time now runs only
+      # the high-signal subset:
       #
-      #   - Xray feature gate in --smoke mode: the 3 highest-signal
-      #     scenarios (6-tab shell handoff, deterministic-exception →
-      #     Issues/Trace surfacing, Cmd-K palette) over just 2 staged
-      #     surfaces (counter + deliberate-throw), compiling 2 testbed
-      #     bundles instead of 13.
+      #   - Xray feature gate in --smoke mode: every scenario tagged
+      #     `smoke: true` in tools/xray/testbeds/feature_matrix/
+      #     scenarios.cjs, a set the gate counts and prints on each run.
+      #     As at 2026-08-06 that is 5 scenarios (9-tab shell handoff,
+      #     freehand-views Views roster, deterministic exceptions →
+      #     inline/Trace surfacing, Cmd-K palette, panel-gallery theme
+      #     tokens) over 4 staged surfaces, compiling 4 testbed bundles
+      #     instead of 12 — ~80s warm (rf2-ano54).
       #   - Story :play-script CI-as-test gate (rf2-3qcxk): drives the
       #     live Story shell over the single counter-with-stories
       #     testbed and runs every variant's :play-script. This is the

--- a/implementation/scripts/serve-and-run-xray-feature-gate.cjs
+++ b/implementation/scripts/serve-and-run-xray-feature-gate.cjs
@@ -58,11 +58,14 @@ const VERBOSE_TESTS = isVerboseTests();
 // rf2-wa3oo: PR-smoke vs nightly-full split. With `--smoke` (or
 // RF2_GATE_SMOKE=1) the gate runs only the scenarios tagged
 // `smoke: true` and compiles only the testbed surfaces those scenarios
-// actually load — cutting the 13-surface / 14-scenario nightly sweep
-// down to the 2-surface high-signal subset on the PR critical path.
-// The full sweep keeps running nightly in expensive-tests.yml. The CLI
-// flag is the cross-platform entry point (no cross-env dependency); the
-// env var stays supported for harness composition.
+// actually load — cutting the nightly sweep down to the high-signal
+// subset on the PR critical path. Both counts are DERIVED from
+// scenarios.cjs and main() prints the live pair every run, so read that
+// rather than a number frozen here (rf2-ano54). As at 2026-08-06 the
+// split is 5 scenarios over 4 surfaces against 17 over 12 nightly. The
+// full sweep keeps running nightly in expensive-tests.yml. The CLI flag
+// is the cross-platform entry point (no cross-env dependency); the env
+// var stays supported for harness composition.
 const SMOKE =
   process.env.RF2_GATE_SMOKE === '1' || process.argv.includes('--smoke');
 


### PR DESCRIPTION
Closes rf2-ano54.

A comment true-up, nothing else. **No threshold, tier, gate condition, scenario or scenario tag changed** — the diff is entirely inside two comment blocks. Net +8 lines.

## What was stale

The bead named two files. Both were stale and **no third file turned up** — but the two comments between them carried **eight individually wrong numbers, two truncated enumerations, and one figure that was right about its own subject and routinely misread**. The tables below are the whole census, not a sample.

### 1. `implementation/scripts/serve-and-run-xray-feature-gate.cjs` — the `SMOKE` block

| claim | was | is |
| --- | --- | --- |
| nightly sweep surfaces | 13 | 12 |
| nightly sweep scenarios | 14 | 17 |
| smoke subset surfaces | 2 | 4 |

Verified by `require`-ing `tools/xray/testbeds/feature_matrix/scenarios.cjs` and applying this launcher's own derivation — `SCENARIOS.filter(s => s.smoke === true)` for the scenario count, `surfaceForScenario` feeding the `ACTIVE_SURFACES` set for the surface count. `SCENARIOS.length` is 17, `STAGED_SURFACES.length` is 12, the smoke arm is 5 scenarios over 4 surfaces.

The rewrite also stops freezing a number that has now drifted twice: `main()` already prints `N scenario(s) over M surface(s)` on every run, so the comment points at that and dates the figure it quotes.

### 2. `.github/workflows/test.yml` — the `PR-smoke tier` block above the `Run Xray feature browser gate (PR-smoke)` step

| claim | was | is |
| --- | --- | --- |
| smoke scenario count | 3 | 5 |
| staged surface count | 2 | 4 |
| testbed bundles compiled at PR time | 2 | 4 |
| testbed bundles in the full sweep | 13 | 12 |
| tabs walked by the shell-handoff scenario | 6 | 9 |

Plus two enumerations that had been overtaken:

- **the scenario list** named three of five, omitting the freehand-views populated Views roster (rf2-6pohj) and the panel-gallery theme-token probe (rf2-azfct), both `smoke: true`;
- **the surface list** said "just 2 staged surfaces (counter + deliberate-throw)", omitting `testbeds/freehand-views` and `testbeds/panel-gallery`.

The `6-tab` figure was checked against `PANEL_HANDOFFS` in `scenarios.cjs`, which carries nine entries (`epoch`, `app-db`, `views`, `trace`, `machines`, `routing`, `resources`, `derivation-graph`, `module-view`) — matching the nine-surface tab bar recorded in `tools/xray/spec/018-Event-Spine.md`.

### The `~700s`

**Kept, but scoped rather than replaced.** It was never wrong about what it described — the *combined* feature-load + Xray matrix + Story static sweep — but nothing in the sentence stopped it being read as the Xray matrix's own cost, and it was so read (the bead records it materially overstating an option in rf2-rliq7). It now says `for the THREE GATES TOGETHER` and carries the measured decomposition.

Measured from the GitHub Actions job API, not estimated:

- **Xray matrix step, nightly `expensive-tests.yml`**, runs of 2026-08-01..05: 160s / 154s / 159s / 160s / 171s → **154–171s**.
- **Three-gate nightly total** (feature-load + matrix + static), same five runs: 510s / 509s / 522s / 564s / 542s → **509–564s**.
- **PR smoke step**, nine `story-xray-browser` jobs on 2026-08-05: 80 / 83 / 75 / 85 / 82 / 82 / 65 / 82 / 79 → **65–85s, mean 79s**, hence `~80s warm`.

## `tools/xray/spec/*`

**Spec unchanged because it is already correct.** `tools/xray/spec/017-Test-Coverage-Matrix.md` already reads "the split is 5 scenarios over 4 surfaces on the PR path against 17 over 12 nightly" — it is the one place that survived the drift, and both new comments now agree with it.

No other tracked file carries a smoke-tier costing. A repo-wide `git grep` for `~700`, for `N-surface` / `N-scenario` phrasings, and for every `PR-smoke` / `--smoke` / `xray-feature-gate` mention found the two blocks in this diff and nothing else: `TESTING.md`'s three smoke-tier passages are qualitative ("highest-signal scenarios over few staged surfaces"), `.github/scripts/report-changed-surfaces.sh`'s smoke commentary makes structural claims about which two commands the tier runs (both correct), and the remaining `~700` hits are unrelated MCP per-op latency figures.

No `TESTING.md` row is owed: the compensating convention for non-smoke scenarios is already there, and nothing in it quotes a count or a duration.

## Quality gates

| gate | exit |
| --- | --- |
| `python scripts/check_doc_slugs.py` | 0 |
| `python scripts/check_doc_slugs.py` (mutation-proof) | 1, as required |
| `sh scripts/test-fast-pr.sh` | 0 |
| `python scripts/check_fast_pr_gap.py --self-test` | 0 |
| `python scripts/check_fast_pr_gap.py --check` | 0 |
| `python scripts/check_gate_scheduling.py --self-test` | 0 |
| `python scripts/check_gate_scheduling.py --verbose` | 0 |

Mutation proof for the slug gate: appending `[mutation probe](017-Test-Coverage-Matrix.md#no-such-heading-ano54)` to `tools/xray/spec/017-Test-Coverage-Matrix.md` took it to exit 1 with `BROKEN ANCHOR: tools\xray\spec\017-Test-Coverage-Matrix.md:376`; reverting took it back to exit 0. The spine classified this diff as `docs=false jvm=true node=true`.

`test.yml` is hot-zone. Its comment block sits inside the `story-xray-browser` job that `_changed-surfaces.test.cjs` parses via `storyXrayJobBlock`, including the row asserting `doesNotMatch(block, /npm run test:xray-feature-gate(?!:smoke)/)` — the new text names `test:xray-feature-gate` only without the `npm run` prefix, exactly as the old text did, so that pin still holds. CI's `JS harness self-tests` job, which owns that assertion, is green on this PR.
