### PR TITLE
feat(hicasso): the minted missing-key warning (rf2-2rtt6.104)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/keywarn_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/keywarn_dom_cljs_test.cljs
@@ -1,0 +1,189 @@
+(ns re-frame.bench.hicasso.arm1.keywarn-dom-cljs-test
+  "THE MINTED KEY WARNING, END TO END IN A REAL REACT DOM (rf2-2rtt6.104).
+
+  `front.codec-cljs-test` settles the predicate, the wording and the
+  dedupe at the element, without React. This file asserts the two things
+  only a real render can say:
+
+  1. **The owner threading works from the arm's own shell.** The codec
+     cannot name the enclosing view by itself — `as-element` carries no
+     context — so `run-once` records it around the lowering and clears it
+     in the `finally` it already had. A unit row can drive that seam by
+     hand; only a mounted `defview` proves the arm actually does.
+  2. **Both warnings arrive, and they are complementary rather than
+     duplicate.** React's own key warning is a `console.error` naming a
+     component stack; the Hicasso one is a `console.warn` naming the
+     view, the child head and the fix. Neither suppresses the other, and
+     no suppression machinery exists.
+
+  The parent tag is the custom element `:keywarn-list` on purpose. React
+  dedupes its key warning on the PARENT TAG NAME, module-globally and for
+  the life of the page (`ownerHasKeyUseWarning` in react-dom-client's
+  development build), so a row asserting React's channel under a `:ul`
+  would go green or red depending on whether some earlier namespace in
+  the bundle had already warned under a `:ul`. A tag only this file uses
+  makes the assertion deterministic — and the coarse dedupe it works
+  around is the whole reason the Hicasso warning names the view.
+
+  A `window` `error` listener rides alongside the two channel spies
+  because React routes a throw during a commit to `reportError`, where
+  `cljs.test` reads 0 failures over a live exception — the same guard
+  `host-ssr-dom-cljs-test`'s `watch-errors!` carries.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every claim degrades to a stated skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::arm1-keywarn)
+
+(defn- skip! [why]
+  (is true (str "a minted-key-warning claim needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (lane/leave-act-environment!)
+  (dogfood/make-frame! frame-id 3)
+  (dogfood/reseed! frame-id 3)
+  frame-id)
+
+;; ---------------------------------------------------------------------------
+;; The boundaries — one unkeyed list, one keyed control
+;; ---------------------------------------------------------------------------
+
+(defview keywarn-row
+  "An ordinary boundary child. Nothing about it is unusual: the defect is
+  entirely in how its parent spells the list."
+  [{:keys [label]}]
+  [:li.keywarn-row (str label)])
+
+(defview keywarn-list
+  "The shape the guide promises a warning for — a bare seq of boundary
+  children with no `:key` in sight."
+  [_]
+  [:keywarn-list
+   (for [i (range 3)]
+     [keywarn-row {:label i}])])
+
+(defview keyed-list
+  "The same list, written correctly. It is here so the row below is a
+  reading of the WARNING rather than of the fixture: this one must be
+  silent on the Hicasso channel in the same bundle, the same render pass
+  and the same spy."
+  [_]
+  [:keyed-keywarn-list
+   (for [i (range 3)]
+     [keywarn-row {:key i :label i}])])
+
+;; ---------------------------------------------------------------------------
+;; Both channels, plus the one React hides
+;; ---------------------------------------------------------------------------
+
+(defn- watch-console!
+  "Both channels and `reportError`, captured together. `console.warn` is
+  Hicasso's; `console.error` is React's; the `window` listener is the one
+  a green row would otherwise be hiding."
+  []
+  (let [warns    (atom [])
+        errors   (atom [])
+        thrown   (atom [])
+        o-warn   (.-warn js/console)
+        o-error  (.-error js/console)
+        on-error (fn [e] (swap! thrown conj (str (.-message e))))]
+    (set! (.-warn js/console) (fn [& args] (swap! warns conj (apply str args))))
+    (set! (.-error js/console) (fn [& args] (swap! errors conj (apply str args))))
+    (.addEventListener js/window "error" on-error)
+    {:warns   warns
+     :errors  errors
+     :thrown  thrown
+     :restore (fn []
+                (set! (.-warn js/console) o-warn)
+                (set! (.-error js/console) o-error)
+                (.removeEventListener js/window "error" on-error))}))
+
+(defn- one-matching [lines re]
+  (filterv #(re-find re %) lines))
+
+(deftest a-mounted-unkeyed-list-warns-on-both-channels-and-names-its-own-view
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [{:keys [warns errors thrown restore]} (watch-console!)
+            handle (try (mount/root! (mount/fresh-container!) frame-id [keywarn-list {}])
+                        (catch :default e (restore) (throw e)))]
+        (try
+          (mount/settle!)
+          (let [hicasso (one-matching @warns #"rf\.warning/hicasso-missing-key")
+                react   (one-matching @errors #"unique \"key\" prop")]
+            (is (= [] @thrown)
+                "no exception was routed to reportError — without this listener a
+                 live throw inside a render reads as 0 failures")
+            (is (= 1 (count hicasso)) "exactly one Hicasso line, once for the site")
+            (is (re-find #"keywarn-list" (first hicasso))
+                "**the owner threading, end to end**: the codec named the
+                 enclosing view, which it can only do because `run-once` told it")
+            (is (re-find #"keywarn-row" (first hicasso)) "and the child head")
+            (is (re-find #"first at index 0" (first hicasso)))
+            (is (= 1 (count react))
+                "React's own warning fired too — neither is suppressed, and no
+                 suppression machinery exists")
+            (is (not (re-find #"rf\.warning" (first react)))
+                "and they are visibly different lines on different channels"))
+          (finally (mount/release! handle) (restore)))))))
+
+(deftest the-keyed-control-is-silent-in-the-same-bundle-and-the-same-spy
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [{:keys [warns errors thrown restore]} (watch-console!)
+            handle (try (mount/root! (mount/fresh-container!) frame-id [keyed-list {}])
+                        (catch :default e (restore) (throw e)))]
+        (try
+          (mount/settle!)
+          (is (= [] @thrown))
+          (is (= [] (one-matching @warns #"rf\.warning/hicasso"))
+              "a correctly keyed list says nothing at all")
+          (is (= [] (one-matching @errors #"unique \"key\" prop"))
+              "and React agrees, which is the cross-check on the fixture")
+          (finally (mount/release! handle) (restore)))))))
+
+(deftest the-owner-slot-is-cleared-by-the-finally-not-merely-set-by-the-body
+  (testing "after a completed render, a lowering that is NOT inside any body
+            observes a nil owner and drops the owner clause — the end-to-end
+            witness for the clear half of the pair, which a set-only test
+            would pass without"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (do
+        (fresh!)
+        (let [handle (mount/root! (mount/fresh-container!) frame-id [keywarn-list {}])]
+          (mount/settle!)
+          (mount/release! handle))
+        (let [orphan (fn [_js-props] nil)
+              _      (unchecked-set orphan "displayName" "keywarn.dom/orphan")
+              _      (codec/mark-boundary! orphan)
+              seen   (atom [])
+              o-warn (.-warn js/console)]
+          (set! (.-warn js/console) (fn [& args] (swap! seen conj (apply str args))))
+          (try (codec/as-element [:ul (list [orphan {}])])
+               (finally (set! (.-warn js/console) o-warn)))
+          (let [line (first (filterv #(re-find #"hicasso-missing-key" %) @seen))]
+            (is (some? line) "the direct lowering still warns")
+            (is (re-find #"^\[hicasso\] Unkeyed boundary children: " line)
+                "with no owner clause — the slot was cleared when the render
+                 unwound, so nothing stale could be named")
+            (is (re-find #"keywarn\.dom/orphan" line))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -1534,7 +1534,16 @@
   "One body run. The scratch and both provenance flags are reset
   **unconditionally** — a reset guarded by \"if empty\" would concatenate
   two renders' reads, which is precisely what makes StrictMode's
-  double-invoke correct here rather than additive."
+  double-invoke correct here rather than additive.
+
+  The two `goog.DEBUG` lines around the lowering are the codec's key
+  warnings asking who is lowering (rf2-2rtt6.104). This is the arm's sole
+  body-lowering site — `render-body` is its only caller, and the fence's
+  re-runs are idempotent set/clear pairs — so the clear rides the
+  `finally` the frame reset already needed, and a throwing body, a thrown
+  Suspense promise and StrictMode's double-invoke all leave the slot nil
+  rather than stale. In production both lines fold away and
+  `set-lowering-owner!` folds to a return."
   [frame-kw body-fn props]
   (set! (.-length scratch) 0)
   (set! (.-collector rstate) false)
@@ -1546,10 +1555,14 @@
   ;; generation fence can run a body twice for one render, and a real
   ;; count is the one that says so.
   (set! (.-bodyRuns rstate) (inc (.-bodyRuns rstate)))
+  (when ^boolean js/goog.DEBUG
+    (codec/set-lowering-owner! (unchecked-get body-fn "displayName")))
   (try
     (intent/with-frame frame-kw (frame-dispatch frame-kw)
       (fn [] (codec/as-element (body-fn props))))
-    (finally (set! (.-frame rstate) nil))))
+    (finally
+      (set! (.-frame rstate) nil)
+      (when ^boolean js/goog.DEBUG (codec/set-lowering-owner! nil)))))
 
 (defn render-body
   "Run a boundary body under the generation fence and return its element;
@@ -1873,6 +1886,7 @@
   `arm1.render-measure-cljs-test` (the OFF half) and
   `arm1.render-measure-emit-nightly-test` (the ON half)."
   [view-name body-fn]
+  (when ^boolean js/goog.DEBUG (unchecked-set body-fn "displayName" view-name))
   (let [component (fn hicasso-boundary [js-props]
                     (performance/mark-and-measure :render view-name
                       (shell body-fn js-props)))]
@@ -1898,6 +1912,7 @@
   fns are the arm's two view-substrate wrappers, and a `:render` bucket
   wired to one of them and not the other would report half a page."
   [view-name body-fn]
+  (when ^boolean js/goog.DEBUG (unchecked-set body-fn "displayName" view-name))
   (let [component (fn hicasso-frame-prop-boundary [js-props]
                     (performance/mark-and-measure :render view-name
                       (frame-prop-shell body-fn js-props)))]

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -1385,14 +1385,191 @@
   [argv i]
   (map? (nth argv i nil)))
 
+;; ---------------------------------------------------------------------------
+;; The minted key warnings — DEVELOPMENT ONLY (rf2-2rtt6.104)
+;; ---------------------------------------------------------------------------
+;;
+;; React already warns about an unkeyed list, and this does not replace it
+;; or suppress it. What React cannot say is the AUTHORING fact: its message
+;; names a component stack and its dedupe is keyed on the parent TAG name
+;; (`ownerHasKeyUseWarning` in react-dom-client's development build), so
+;; after the first unkeyed list under any `:ul` on the page, every later
+;; `:ul` site is silent for the life of that page. At those later sites this
+;; warning is the only signal on the console — which is why it names the
+;; enclosing view rather than leaning on React's owner clause.
+
+(def ^:private keywarn
+  "The warning's whole state: who is lowering, and which sites have
+  already spoken. `nil` in production — every reader below sits behind
+  `goog.DEBUG`, so under `:advanced` the object, the `Set` and every
+  message string fold away with the branches that reach them.
+
+  Plain `def` rather than `defonce`: an app-code edit never re-mints it
+  (the codec requires no app code, so shadow-cljs's reload does not reach
+  it), while a framework-dev edit of THIS file does — which is the
+  behaviour a codec author wants and an app author cannot observe. A full
+  page reload resets it either way, which is React's own semantics for
+  the same dedupe."
+  (when ^boolean js/goog.DEBUG
+    #js {"owner" nil "warned" (js/Set.)}))
+
+(defn set-lowering-owner!
+  "Dev-only seam: name the view whose body is being lowered, or `nil` to
+  clear. A no-op in production builds.
+
+  **For the arm's runtime shell and for the tests, never for authors** —
+  the same class as [[reset-caches!]]. The arm's `run-once` sets it before
+  a body's hiccup is lowered and clears it in the `finally` it already
+  has, so an `as-element` reached outside a body run — the root, an
+  outward bridge, a deferred lowering inside `presence` or an error
+  boundary, a direct call from a test — observes `nil` and the warnings
+  below drop their owner clause rather than naming a stale view.
+
+  ## Two halves, one pinnable
+
+  *Forgetting to CLEAR* would mis-attribute, and is pinned: setting a
+  non-nil owner over a non-nil one is an unbalanced pair and says so on
+  the console. Any future lowering entry point that skips its `finally`
+  is caught deterministically at the next boundary render in dev.
+
+  *Forgetting to SET* is *not* pinnable, and this docstring is the
+  declaration the design owes: a test cannot cover an entry point that
+  does not exist yet. A future lowering entry point that adds no set/clear
+  pair degrades the warnings to their ownerless wording — never to a wrong
+  name, because the clear-in-`finally` guarantees `nil` rather than
+  staleness. The obligation is on the entry point: add the pair."
+  [view-name]
+  (when ^boolean js/goog.DEBUG
+    (let [prior (unchecked-get keywarn "owner")]
+      (when (and (some? view-name) (some? prior) (exists? js/console))
+        (.warn js/console
+               (str "[hicasso] A boundary body began lowering while `" prior
+                    "` was still recorded as the enclosing view. The "
+                    "set/clear pair around a body run is unbalanced, so a "
+                    "key warning may name the wrong view. The lowering entry "
+                    "point that set the owner must clear it in a `finally`.")))
+      (unchecked-set keywarn "owner" view-name)))
+  nil)
+
+(defn- ^boolean plain-key?
+  "Is this `:key` value one React can coerce to a stable string without
+  reading anything the author will edit? Asked FIRST of every member of
+  every seq in a dev build, so it is three `typeof`-class tests and
+  nothing dearer — deliberately not `coll?`, which for anything without
+  the `ICollection` marker falls through to `native-satisfies?` and is
+  the dearest predicate on this path (the same accounting as
+  [[realize-entry]]'s `keyword?` short-circuit)."
+  [k]
+  (or (string? k) (number? k) (keyword? k)))
+
+(defn- key-shape
+  "What the author put at `:key`, named rather than printed. The VALUE
+  never reaches the console: a foreign or cyclic value would blow
+  `pr-str` inside a diagnostic, and the author already knows what they
+  wrote — what they need is the view, the child and the hazard."
+  [k]
+  (cond (map? k) "a map" (vector? k) "a vector" (set? k) "a set" :else "a collection"))
+
+(defn- warn-member-key!
+  "One console line per site, where a site is *(enclosing view, member
+  head, which hazard)*. Built only on detection, never on the render
+  path."
+  [head kind i]
+  (let [owner  (unchecked-get keywarn "owner")
+        member (head-name head)
+        seen   (unchecked-get keywarn "warned")
+        site   (str owner "|" member "|" kind)]
+    (when-not (.has seen site)
+      (.add seen site)
+      (when (exists? js/console)
+        (.warn js/console
+               (if (= kind "missing")
+                 (str "[hicasso] Unkeyed boundary children"
+                      (if owner (str " in the body of " owner) "")
+                      ": a seq of " member " members has no :key (absent or "
+                      "nil; first at index " i ")."
+                      " Give each one a :key in its props map —"
+                      " [child {:key id, …}] — so the list keeps identity"
+                      " across reorder and removal; a key written as Reagent"
+                      " metadata is not read here. React's own warning names"
+                      " the component stack and fires once per parent tag"
+                      " name; this one names the authoring site and fires"
+                      " once per site, in development builds only."
+                      " [:rf.warning/hicasso-missing-key]")
+                 (str "[hicasso] Entity-valued :key on boundary children"
+                      (if owner (str " in the body of " owner) "")
+                      ": a seq of " member " members carries " kind
+                      " at :key (first at index " i ")."
+                      " React coerces a key to a string, so a collection keys"
+                      " the child by its CONTENT — edit the entity and the"
+                      " child silently remounts, losing focus, scroll position"
+                      " and any presence retention. Key on a stable identifier"
+                      " instead — [child {:key (:id entity), …}]. Warned once"
+                      " per site, in development builds only."
+                      " [:rf.warning/hicasso-entity-key]"))))))
+  nil)
+
+(defn- check-seq-keys!
+  "Scan one lowered child seq for boundary members React will reconcile
+  by position. Called from the two places a bare seq of children exists
+  as a value: [[expand-seq]], which every native, fragment and host
+  parent reaches through `make-element`; and [[realize-children]]'s
+  one-level flatten, which is the crossing INTO a boundary — a shape
+  whose array-ness the flatten erases before React can see it, so
+  without this call site nothing would warn at all.
+
+  Every member is scanned every time, uniform with the keyed steady
+  state that pays the full walk anyway. Stopping at the first offender
+  would save work only on the broken list the author is about to fix,
+  and would hide a second unkeyed head until the first was repaired.
+  The dedupe is on the SITE, so console volume stays at one line per
+  site per page load either way.
+
+  The predicate order is the cost: `vector?` first, then the props-map
+  `:key` read, then [[plain-key?]] — which is where a keyed member
+  leaves, on a `typeof`. [[boundary-head?]]'s own-property read is asked
+  LAST, so an unkeyed `[:li …]` costs one `fn?` and no more. Nested seqs
+  need no code: a seq member is not a vector, and its own expansion
+  checks its own members — HD-016's one level at a time.
+
+  Priced in a dev build rather than asserted (this file's standing rule):
+  see the pre-pass row in the PR that landed rf2-2rtt6.104."
+  [s]
+  (loop [items (seq s)
+         i     0]
+    (when items
+      (let [m (first items)]
+        (when (vector? m)
+          (let [p (nth m 1 nil)
+                k (when (map? p) (:key p))]
+            (when-not (plain-key? k)
+              (when (boundary-head? (nth m 0 nil))
+                (cond
+                  (nil? k)  (warn-member-key! (nth m 0 nil) "missing" i)
+                  (coll? k) (warn-member-key! (nth m 0 nil) (key-shape k) i)))))))
+      (recur (next items) (inc i))))
+  nil)
+
 (defn realize-children
   "The trailing forms of `argv` from `first-child`, realized once into a
   vector and flattened exactly one level — a nested seq splices, a nested
   *vector* does not, because a vector is hiccup. Returns nil when there
-  are none, so `(:children props)` is absent rather than empty."
+  are none, so `(:children props)` is absent rather than empty.
+
+  The dev-only [[check-seq-keys!]] call in the `seq?` branch is the one
+  place the CROSSING shape is visible. `[a-view {…} (for …)]` hands a
+  dynamic list to a view that will splice it, and the flatten below turns
+  those members into direct arguments — which React marks validated and
+  therefore never warns about. This branch, where the seq is still in hand
+  and the enclosing body's owner slot is still set, is the only chance
+  anything has to say so (rf2-2rtt6.104)."
   [argv first-child]
   (when (< first-child (count argv))
-    (let [flat (reduce (fn [acc c] (if (seq? c) (into acc c) (conj acc c)))
+    (let [flat (reduce (fn [acc c]
+                         (if (seq? c)
+                           (do (when ^boolean js/goog.DEBUG (check-seq-keys! c))
+                               (into acc c))
+                           (conj acc c)))
                        []
                        (subvec argv first-child))]
       (when (seq flat) flat))))
@@ -1608,8 +1785,17 @@
   "A seq of children as a JS array of elements. One pass, driven by the
   seq's own exhaustion rather than by each child's truthiness, so an
   interior `nil` — the `(for [x xs] (when pred [:li …]))` shape — does not
-  truncate the list."
+  truncate the list.
+
+  The dev-only [[check-seq-keys!]] pre-pass is a separate walk rather
+  than a test inside the loop below, so the shipping loop is byte-identical
+  to what it was: under `:advanced` the gate folds to `false` and the call
+  goes with it. A `LazySeq` caches, so the expansion re-reads cached cells;
+  anything the pre-pass forces is forced inside the same body-render window
+  it would have been forced in anyway, so attribution does not move
+  (rf2-2rtt6.104)."
   [s]
+  (when ^boolean js/goog.DEBUG (check-seq-keys! s))
   (let [a #js []]
     (loop [items (seq s)]
       (when items

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -1401,7 +1401,7 @@
 (def ^:private keywarn
   "The warning's whole state: who is lowering, and which sites have
   already spoken. `nil` in production — every reader below sits behind
-  `goog.DEBUG`, so under `:advanced` the object, the `Set` and every
+  `goog.DEBUG`, so under `:advanced` the object, the tables and every
   message string fold away with the branches that reach them.
 
   Plain `def` rather than `defonce`: an app-code edit never re-mints it
@@ -1409,9 +1409,19 @@
   it), while a framework-dev edit of THIS file does — which is the
   behaviour a codec author wants and an app author cannot observe. A full
   page reload resets it either way, which is React's own semantics for
-  the same dedupe."
+  the same dedupe.
+
+  `warned` is a `Map` of owner-name -> `Map` of member head -> the kinds
+  that head has already reported there, rather than the flat `Set` of
+  joined site strings the design proposed. The reason is a clocked one:
+  an ALREADY-WARNED site is re-encountered on every render of a list the
+  author has not fixed yet, and building `(str owner \"|\" member \"|\"
+  kind)` to look it up allocated a string per member per render — 420
+  ns/member, a third of dev lowering, on precisely the list the author is
+  sitting in front of. These lookups key on the owner string and the head
+  object as they already are, so the repeat path allocates nothing."
   (when ^boolean js/goog.DEBUG
-    #js {"owner" nil "warned" (js/Set.)}))
+    #js {"owner" nil "warned" (js/Map.)}))
 
 (defn set-lowering-owner!
   "Dev-only seam: name the view whose body is being lowered, or `nil` to
@@ -1475,78 +1485,124 @@
   head, which hazard)*. Built only on detection, never on the render
   path."
   [head kind i]
-  (let [owner  (unchecked-get keywarn "owner")
-        member (head-name head)
-        seen   (unchecked-get keywarn "warned")
-        site   (str owner "|" member "|" kind)]
-    (when-not (.has seen site)
-      (.add seen site)
+  (let [owner (unchecked-get keywarn "owner")
+        heads (let [by-owner (unchecked-get keywarn "warned")]
+                (or (.get by-owner owner)
+                    (let [m (js/Map.)] (.set by-owner owner m) m)))
+        kinds (or (.get heads head)
+                  (let [o #js {}] (.set heads head o) o))]
+    (when-not (unchecked-get kinds kind)
+      (unchecked-set kinds kind true)
       (when (exists? js/console)
-        (.warn js/console
-               (if (= kind "missing")
-                 (str "[hicasso] Unkeyed boundary children"
-                      (if owner (str " in the body of " owner) "")
-                      ": a seq of " member " members has no :key (absent or "
-                      "nil; first at index " i ")."
-                      " Give each one a :key in its props map —"
-                      " [child {:key id, …}] — so the list keeps identity"
-                      " across reorder and removal; a key written as Reagent"
-                      " metadata is not read here. React's own warning names"
-                      " the component stack and fires once per parent tag"
-                      " name; this one names the authoring site and fires"
-                      " once per site, in development builds only."
-                      " [:rf.warning/hicasso-missing-key]")
-                 (str "[hicasso] Entity-valued :key on boundary children"
-                      (if owner (str " in the body of " owner) "")
-                      ": a seq of " member " members carries " kind
-                      " at :key (first at index " i ")."
-                      " React coerces a key to a string, so a collection keys"
-                      " the child by its CONTENT — edit the entity and the"
-                      " child silently remounts, losing focus, scroll position"
-                      " and any presence retention. Key on a stable identifier"
-                      " instead — [child {:key (:id entity), …}]. Warned once"
-                      " per site, in development builds only."
-                      " [:rf.warning/hicasso-entity-key]"))))))
+        (let [member (head-name head)]
+          (.warn js/console
+                 (if (= kind "missing")
+                   (str "[hicasso] Unkeyed boundary children"
+                        (if owner (str " in the body of " owner) "")
+                        ": a seq of " member " members has no :key (absent or "
+                        "nil; first at index " i ")."
+                        " Give each one a :key in its props map —"
+                        " [child {:key id, …}] — so the list keeps identity"
+                        " across reorder and removal; a key written as Reagent"
+                        " metadata is not read here. React's own warning names"
+                        " the component stack and fires once per parent tag"
+                        " name; this one names the authoring site and fires"
+                        " once per site, in development builds only."
+                        " [:rf.warning/hicasso-missing-key]")
+                   (str "[hicasso] Entity-valued :key on boundary children"
+                        (if owner (str " in the body of " owner) "")
+                        ": a seq of " member " members carries " kind
+                        " at :key (first at index " i ")."
+                        " React coerces a key to a string, so a collection keys"
+                        " the child by its CONTENT — edit the entity and the"
+                        " child silently remounts, losing focus, scroll position"
+                        " and any presence retention. Key on a stable identifier"
+                        " instead — [child {:key (:id entity), …}]. Warned once"
+                        " per site, in development builds only."
+                        " [:rf.warning/hicasso-entity-key]")))))))
+  nil)
+
+(defn- check-member-key!
+  "One member of a lowered child seq, at index `i`. Warns when it is a
+  boundary-headed vector React will reconcile by position — no `:key`, or
+  a `:key` whose value is a collection.
+
+  ## What it costs, clocked rather than asserted
+
+  `keywarn_clock_run.cjs`, dev build, 300 boundary members, 200 walks per
+  round, 11 interleaved rounds, median-of-rounds, ns per member:
+
+  | population | shipping | check ablated | the check | share of dev lowering |
+  |---|---|---|---|---|
+  | keyed (the steady state) | 1523.7 | 1367.2 | **156.5** | 10.3% |
+  | unkeyed, site already warned | 936.7 | 789.0 | **147.8** | 15.8% |
+
+  ~150 ns per member on both populations; the share differs only because
+  an unkeyed boundary element is cheaper to mint than a keyed one, so the
+  same absolute cost is a larger fraction of a smaller number.
+
+  That is **4x the 15-40 ns/member the design derived analytically**, and
+  the reason is that this is a DEV build: `vector?`, `nth` and the `:key`
+  lookup are protocol dispatches through real function calls here, where
+  the analytic estimate priced them as the inlined shapes `:advanced`
+  produces — and under `:advanced` the check does not exist at all. The
+  figure is recorded rather than argued with; rf2-2rtt6.32 is this lane's
+  standing reminder of what an unclocked micro-claim is worth.
+
+  Two shapes were measured and rejected on the way to this one:
+
+  - **A pre-pass over the seq before the expansion loop** (the design's
+    proposal, chosen there to leave the shipping loop untouched):
+    316 ns/member, 18% of dev lowering. It TRAVERSES THE SPINE TWICE, and
+    `first`/`next` over the chunked seq a `for` produces allocates per
+    step. Riding the loop that is already walking costs the predicates
+    and nothing else — and costs production nothing either, because the
+    call site is gated and `(.-length a)` supplies the index without a
+    loop variable (see [[expand-seq]]).
+  - **A flat `Set` of joined site strings** for the dedupe (also the
+    design's): 420 ns/member on an already-warned list, because looking a
+    site up meant building its string on every member of every render of
+    the list the author had not fixed yet. The nested tables in
+    [[keywarn]] key on the owner string and the head object as they
+    already are.
+
+  The predicate order is the rest of the cost: `vector?` first, then the
+  props-map `:key` read, then [[plain-key?]] — which is where a keyed
+  member leaves, on a `typeof`. [[boundary-head?]]'s own-property read is
+  asked LAST, so an unkeyed `[:li …]` costs one `fn?` and no more, and
+  `coll?` — the dearest predicate on this path — is reached only by a
+  member that is already unkeyed or already odd.
+
+  Every member is checked every time, uniform with the keyed steady
+  state. Stopping at the first offender would save work only on the
+  broken list the author is about to fix, and would hide a second unkeyed
+  head until the first was repaired. The dedupe is on the SITE, so
+  console volume is one line per site per page load either way. Nested
+  seqs need no code: a seq member is not a vector, and its own expansion
+  checks its own members — HD-016's one level at a time."
+  [m i]
+  (when (vector? m)
+    (let [p (nth m 1 nil)
+          k (when (map? p) (:key p))]
+      (when-not (plain-key? k)
+        (let [h (nth m 0 nil)]
+          (when (boundary-head? h)
+            (cond
+              (nil? k)  (warn-member-key! h "missing" i)
+              (coll? k) (warn-member-key! h (key-shape k) i)))))))
   nil)
 
 (defn- check-seq-keys!
-  "Scan one lowered child seq for boundary members React will reconcile
-  by position. Called from the two places a bare seq of children exists
-  as a value: [[expand-seq]], which every native, fragment and host
-  parent reaches through `make-element`; and [[realize-children]]'s
-  one-level flatten, which is the crossing INTO a boundary — a shape
-  whose array-ness the flatten erases before React can see it, so
-  without this call site nothing would warn at all.
-
-  Every member is scanned every time, uniform with the keyed steady
-  state that pays the full walk anyway. Stopping at the first offender
-  would save work only on the broken list the author is about to fix,
-  and would hide a second unkeyed head until the first was repaired.
-  The dedupe is on the SITE, so console volume stays at one line per
-  site per page load either way.
-
-  The predicate order is the cost: `vector?` first, then the props-map
-  `:key` read, then [[plain-key?]] — which is where a keyed member
-  leaves, on a `typeof`. [[boundary-head?]]'s own-property read is asked
-  LAST, so an unkeyed `[:li …]` costs one `fn?` and no more. Nested seqs
-  need no code: a seq member is not a vector, and its own expansion
-  checks its own members — HD-016's one level at a time.
-
-  Priced in a dev build rather than asserted (this file's standing rule):
-  see the pre-pass row in the PR that landed rf2-2rtt6.104."
+  "[[check-member-key!]] over a whole seq, for the one caller that has no
+  loop of its own to ride: [[realize-children]]'s one-level flatten, the
+  crossing INTO a boundary. `into` walks the seq there rather than
+  stepping it, so a traversal is unavoidable — and it is the rare path,
+  taken only by a seq-valued trailing form of a boundary element."
   [s]
   (loop [items (seq s)
          i     0]
     (when items
-      (let [m (first items)]
-        (when (vector? m)
-          (let [p (nth m 1 nil)
-                k (when (map? p) (:key p))]
-            (when-not (plain-key? k)
-              (when (boundary-head? (nth m 0 nil))
-                (cond
-                  (nil? k)  (warn-member-key! (nth m 0 nil) "missing" i)
-                  (coll? k) (warn-member-key! (nth m 0 nil) (key-shape k) i)))))))
+      (check-member-key! (first items) i)
       (recur (next items) (inc i))))
   nil)
 
@@ -1787,18 +1843,26 @@
   interior `nil` — the `(for [x xs] (when pred [:li …]))` shape — does not
   truncate the list.
 
-  The dev-only [[check-seq-keys!]] pre-pass is a separate walk rather
-  than a test inside the loop below, so the shipping loop is byte-identical
-  to what it was: under `:advanced` the gate folds to `false` and the call
-  goes with it. A `LazySeq` caches, so the expansion re-reads cached cells;
-  anything the pre-pass forces is forced inside the same body-render window
-  it would have been forced in anyway, so attribution does not move
-  (rf2-2rtt6.104)."
+  The dev-only [[check-member-key!]] call RIDES this loop rather than
+  pre-scanning the seq, which costs the predicates and no second spine
+  traversal (rf2-2rtt6.104 clocked the difference; the fn's docstring
+  carries the numbers).
+
+  **The index it reports is `(.-length a)`, not a loop variable**, and
+  that is the reason the loop still has exactly the shape it had: one
+  element is pushed per member, so the array's length IS the index of the
+  member about to be pushed. Threading an `i` would have put an increment
+  per child on the production path for a dev message's benefit. As
+  written, `goog.DEBUG` folds to `false` under `:advanced`, the whole line
+  goes, and what is left is character for character the loop that was here
+  before the warning existed. `(first items)` is read twice in a dev build
+  and once in production for the same reason — it is a field read on a seq
+  the loop has already forced, while `next` is the step that allocates."
   [s]
-  (when ^boolean js/goog.DEBUG (check-seq-keys! s))
   (let [a #js []]
     (loop [items (seq s)]
       (when items
+        (when ^boolean js/goog.DEBUG (check-member-key! (first items) (.-length a)))
         (.push a (as-element (first items)))
         (recur (next items))))
     a))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
@@ -897,3 +897,233 @@
     (is (= {:tags 1 :props 3} (codec/cache-sizes))
         "one tag literal; `:class` is one of the three seeded prop names, so
          twenty renders with twenty distinct class VALUES add nothing")))
+
+;; ---------------------------------------------------------------------------
+;; The minted key warnings — development only (rf2-2rtt6.104)
+;; ---------------------------------------------------------------------------
+;;
+;; Every row below owns its own view and member NAMES, because the dedupe
+;; Set is deliberately page-lifetime and has no reset hook: "once per site"
+;; is the contract, and a fixture that reset it would be testing a
+;; different one. Distinct names are the cheaper discipline and they also
+;; make each row's site visible in its own source.
+
+(defn- named-view
+  "A distinct marked boundary head, stamped the way an arm's mint stamps
+  one, so the warning has a name to say."
+  [nm]
+  (let [f (fn [_js-props] nil)]
+    (unchecked-set f "displayName" nm)
+    (codec/mark-boundary! f)))
+
+(defn- warnings-during
+  "Everything the codec said on `console.warn` while `f` ran. The channel
+  matters: React's own key warning is a `console.error`, so a spy on the
+  wrong one would read a Hicasso row green off React's line."
+  [f]
+  (let [seen     (atom [])
+        original (.-warn js/console)]
+    (set! (.-warn js/console) (fn [& args] (swap! seen conj (apply str args))))
+    (try (f) (finally (set! (.-warn js/console) original)))
+    @seen))
+
+(defn- lowering-as
+  "Lower `hiccup` with `owner` recorded as the enclosing view, the way the
+  arm's `run-once` records it — and clear it afterwards, the way `run-once`
+  clears it in its `finally`."
+  [owner hiccup]
+  (codec/set-lowering-owner! owner)
+  (try (codec/as-element hiccup)
+       (finally (codec/set-lowering-owner! nil))))
+
+(deftest an-unkeyed-boundary-seq-warns-once-naming-the-view-the-child-and-the-index
+  (let [row  (named-view "w1.ns/row")
+        out  (warnings-during
+               #(lowering-as "w1.ns/list" [:ul (for [i (range 3)] [row {:id i}])]))
+        line (first out)]
+    (is (= 1 (count out)) "one line, not one per member")
+    (is (re-find #"w1\.ns/list" line) "the enclosing view — the fact React cannot name")
+    (is (re-find #"w1\.ns/row" line) "the member head")
+    (is (re-find #"first at index 0" line))
+    (is (re-find #":key in its props map" line) "the fix spelling, not just the complaint")
+    (is (re-find #":rf\.warning/hicasso-missing-key" line))))
+
+(deftest a-keyed-boundary-seq-is-silent-and-so-is-every-legitimate-key-shape
+  (testing "the canonical keyed list says nothing at all"
+    (let [row (named-view "w2.ns/row")]
+      (is (= [] (warnings-during
+                  #(lowering-as "w2.ns/list"
+                                [:ul (for [i (range 300)] [row {:key i}])]))))))
+  (testing "each primitive key shape individually — a warning that fired on
+            valid code would be worse than no warning"
+    (doseq [[label k] [["number" 1] ["string" "a"] ["keyword" :a]
+                       ["namespaced-keyword" :ns/a] ["negative-number" -1]
+                       ["zero" 0] ["empty-string" ""]]]
+      (let [row (named-view (str "w2b.ns/" label))]
+        (is (= [] (warnings-during
+                    #(lowering-as "w2b.ns/list" [:ul (list [row {:key k}])])))
+            (str "a " label " key is a legitimate key"))))))
+
+(deftest the-site-warns-exactly-once-however-many-renders-it-takes
+  (let [row     (named-view "w3.ns/row")
+        hiccup  [:ul (list [row {}] [row {}])]
+        first-r (warnings-during #(lowering-as "w3.ns/list" hiccup))
+        again   (warnings-during #(lowering-as "w3.ns/list" hiccup))]
+    (is (= 1 (count first-r)) "two unkeyed members of one head are one site")
+    (is (= [] again) "a second render of the same site re-fires nothing")))
+
+(deftest a-site-is-the-pair-of-the-enclosing-view-and-the-member-head
+  (testing "one view, two member heads — two sites"
+    (let [a   (named-view "w4.ns/a")
+          b   (named-view "w4.ns/b")
+          out (warnings-during
+                #(lowering-as "w4.ns/list" [:ul (list [a {}] [b {}])]))]
+      (is (= 2 (count out)) "scanning past the first offender is what finds the second")))
+  (testing "one member head, two views — two sites"
+    (let [row (named-view "w5.ns/row")
+          out (warnings-during
+                (fn []
+                  (lowering-as "w5.ns/one" [:ul (list [row {}])])
+                  (lowering-as "w5.ns/two" [:ul (list [row {}])])))]
+      (is (= 2 (count out))))))
+
+(deftest a-key-that-computed-nil-warns-because-the-emitted-element-is-keyless
+  (testing "`:key nil` and an absent `:key` mint the same keyless element, so
+            the check and the emission gate cannot disagree"
+    (let [row (named-view "w6.ns/row")
+          out (warnings-during
+                #(lowering-as "w6.ns/list" [:ul (list [row {:key nil :id 1}])]))]
+      (is (= 1 (count out)))
+      (is (re-find #"absent or nil" (first out))
+          "the author who DID write :key is pointed at the value")))
+  (testing "the conditional-key idiom that yields no key at all"
+    (let [row (named-view "w7.ns/row")
+          out (warnings-during
+                #(lowering-as "w7.ns/list"
+                              [:ul (list [row (when false {:key 1})])]))]
+      (is (= 1 (count out))))))
+
+(deftest a-mixed-seq-names-the-first-unkeyed-member
+  (let [row (named-view "w8.ns/row")
+        out (warnings-during
+              #(lowering-as "w8.ns/list"
+                            [:ul (list [row {:key 0}] [row {:key 1}]
+                                       [row {}] [row {:key 3}])]))]
+    (is (= 1 (count out)))
+    (is (re-find #"first at index 2" (first out))
+        "keyed members are scanned past and never named")))
+
+(deftest an-entity-valued-key-warns-about-the-coercion-hazard
+  (testing "a map at :key — React string-coerces it, so the child is keyed by
+            its own CONTENT and an edit silently remounts the row"
+    (let [row  (named-view "w9.ns/row")
+          out  (warnings-during
+                 #(lowering-as "w9.ns/list"
+                               [:ul (list [row {:key {:id 1 :label "a"}}])]))
+          line (first out)]
+      (is (= 1 (count out)))
+      (is (re-find #"w9\.ns/list" line))
+      (is (re-find #"carries a map at :key" line))
+      (is (re-find #"first at index 0" line))
+      (is (re-find #":rf\.warning/hicasso-entity-key" line))
+      (is (nil? (re-find #":label" line))
+          "the VALUE never reaches the console — a cyclic or throwing foreign
+           value would blow pr-str inside a diagnostic")))
+  (testing "a vector and a set are the same hazard, and two distinct sites"
+    (let [row (named-view "w10.ns/row")
+          out (warnings-during
+                #(lowering-as "w10.ns/list"
+                              [:ul (list [row {:key [1 2]}] [row {:key #{1}}])]))]
+      (is (= 2 (count out)))
+      (is (re-find #"carries a vector at :key" (first out)))
+      (is (re-find #"carries a set at :key" (second out))))))
+
+(deftest the-scope-line-holds-in-both-directions
+  (testing "native-tag members are React's beat — there is no boundary head to name"
+    (is (= [] (warnings-during
+                #(lowering-as "w11.ns/list" [:ul (for [i (range 3)] [:li i])])))))
+  (testing "host-headed members are silent in v1"
+    (is (= [] (warnings-during
+                #(lowering-as "w12.ns/list" [:ul (list [a-host {}])])))))
+  (testing "strings, numbers and nils in a seq are not elements"
+    (is (= [] (warnings-during
+                #(lowering-as "w13.ns/list" [:ul (list "a" 1 nil false)])))))
+  (testing "a headless vector is somebody else's refusal — the check tolerates
+            it silently and leaves `vec->element`'s loud error to speak"
+    (is (= [] (warnings-during
+                #(try (lowering-as "w14.ns/list" [:ul (list [])])
+                      (catch :default _ nil)))))))
+
+(deftest every-parent-class-reaches-the-check-through-the-one-site
+  (testing "a fragment parent"
+    (let [row (named-view "w15.ns/row")]
+      (is (= 1 (count (warnings-during
+                        #(lowering-as "w15.ns/list" [:<> (list [row {}])])))))))
+  (testing "a host parent — this is what the [:>] crossing will inherit"
+    (let [row (named-view "w16.ns/row")]
+      (is (= 1 (count (warnings-during
+                        #(lowering-as "w16.ns/list" [a-host {} (list [row {}])])))))))
+  (testing "a nested seq is checked at its own level, one level at a time"
+    (let [row (named-view "w17.ns/row")]
+      (is (= 1 (count (warnings-during
+                        #(lowering-as "w17.ns/list"
+                                      [:ul (list (list [row {}]))]))))))))
+
+(deftest the-crossing-into-a-boundary-warns-where-nothing-else-can
+  (testing "`[a-view {} (for …)]` — realize-children flattens the seq into
+            direct arguments, which React marks validated and never warns
+            about, so this call site is the only signal there is"
+    (let [outer (named-view "w18.ns/outer")
+          row   (named-view "w18.ns/row")
+          out   (warnings-during
+                  #(lowering-as "w18.ns/page"
+                                [outer {} (for [_ (range 3)] [row {}])]))]
+      (is (= 1 (count out)))
+      (is (re-find #"w18\.ns/page" (first out))
+          "the owner slot is the body that WROTE the crossing seq")
+      (is (re-find #"w18\.ns/row" (first out)))))
+  (testing "a keyed crossing seq is silent"
+    (let [outer (named-view "w19.ns/outer")
+          row   (named-view "w19.ns/row")]
+      (is (= [] (warnings-during
+                  #(lowering-as "w19.ns/page"
+                                [outer {} (for [i (range 3)] [row {:key i}])]))))))
+  (testing "a crossing seq of native members is silent — the presence fixture's
+            own shape, and every `[presence {…} (for … [:div.toast {:key id}])]`
+            the guide teaches"
+    (let [tray (named-view "w20.ns/tray")]
+      (is (= [] (warnings-during
+                  #(lowering-as "w20.ns/page"
+                                [tray {:timeout-ms 300}
+                                 (for [i (range 3)]
+                                   [:div.toast {:key i} "x"])])))))))
+
+(deftest the-owner-clause-is-dropped-rather-than-guessed-when-no-body-is-lowering
+  (let [row  (named-view "w21.ns/row")
+        out  (warnings-during
+               (fn []
+                 (codec/set-lowering-owner! nil)
+                 (codec/as-element [:ul (list [row {}])])))
+        line (first out)]
+    (is (= 1 (count out)))
+    (is (re-find #"^\[hicasso\] Unkeyed boundary children: " line)
+        "no owner clause at all, rather than a stale or invented one")
+    (is (re-find #"w21\.ns/row" line) "the member head still names itself")))
+
+(deftest an-unbalanced-owner-pair-is-pinned-on-the-console
+  (testing "setting a non-nil owner over a non-nil one says the pair is unbalanced"
+    (let [out (warnings-during
+                (fn []
+                  (codec/set-lowering-owner! "w22.ns/first")
+                  (codec/set-lowering-owner! "w22.ns/second")
+                  (codec/set-lowering-owner! nil)))]
+      (is (= 1 (count out)))
+      (is (re-find #"w22\.ns/first" (first out)))
+      (is (re-find #"unbalanced" (first out)))))
+  (testing "the set/clear/set the arm actually performs is silent"
+    (is (= [] (warnings-during
+                (fn []
+                  (codec/set-lowering-owner! "w23.ns/a")
+                  (codec/set-lowering-owner! nil)
+                  (codec/set-lowering-owner! "w23.ns/b")
+                  (codec/set-lowering-owner! nil)))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/keywarn_clock.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/keywarn_clock.cljs
@@ -1,0 +1,128 @@
+(ns re-frame.bench.hicasso.keywarn-clock
+  "THE KEY WARNING'S DEV PRE-PASS, CLOCKED (rf2-2rtt6.104).
+
+  This file exists because of a standing rule and a lane history. The
+  rule is [[re-frame.bench.hicasso.front.codec/realize-deep]]'s: figures
+  in the codec are **clocked rather than asserted**. The history is
+  rf2-2rtt6.32, whose \"impossible result\" is what an unclocked
+  micro-claim did in this lane last time. The design that ruled the
+  warning derived ~1-4% of dev lowering analytically; that number does
+  not go into a docstring without a measurement beside it, so here is the
+  measurement.
+
+  ## The ablation
+
+  `codec/as-element` on a seq IS
+  [[re-frame.bench.hicasso.front.codec/expand-seq]] — its `(seq? x)`
+  branch is `expand-seq`'s sole caller. So the ablated arm is a
+  five-line local copy of that loop with the dev pre-pass removed and
+  everything else identical, calling the same public `as-element` per
+  member. A local copy is this lane's own idiom for an ablation
+  (`walk_profile_app` keeps one deliberately); the delta between the two
+  arms is the pre-pass and nothing else.
+
+  ## The populations
+
+  Both are 300 members, the tier-1 feed shape the arm is measured on:
+
+  - **keyed** — the steady state, and the expensive one. Every member is
+    scanned to the end and rejected on the `:key` read plus one
+    `typeof`-class test; nothing early-exits. This is the number that
+    matters, because it is what a correct application pays forever.
+  - **unkeyed, already warned** — the broken list after its site has
+    spoken. Every member reaches [[boundary-head?]] and the dedupe
+    `Set.has`, which is the scan's dearest path.
+
+  ## What this is not
+
+  A DIAGNOSTIC, run on demand, not a gate row and not a published
+  figure. The clock is in-process `performance.now` over interleaved
+  rounds, median-of-rounds; it attributes cost between two arms of one
+  walk in one process. Nothing here is a threshold and nothing here is
+  compared across runs."
+  (:require [re-frame.bench.hicasso.front.codec :as codec]))
+
+(def ^:private members 300)
+(def ^:private reps 200)
+(def ^:private rounds 11)
+
+(defn- a-row
+  "A marked boundary head, stamped the way an arm's mint stamps one."
+  [nm]
+  (let [f (fn [_js-props] nil)]
+    (unchecked-set f "displayName" nm)
+    (codec/mark-boundary! f)))
+
+(def ^:private row (a-row "keywarn.clock/row"))
+
+(defn- expand-seq-ablated
+  "[[codec/expand-seq]] with the dev pre-pass removed — the shipping loop,
+  character for character, minus the one gated line."
+  [s]
+  (let [a #js []]
+    (loop [items (seq s)]
+      (when items
+        (.push a (codec/as-element (first items)))
+        (recur (next items))))
+    a))
+
+(defn- now [] (.now js/performance))
+
+(defn- median [xs]
+  (let [v (vec (sort xs))
+        n (count v)]
+    (if (odd? n)
+      (nth v (quot n 2))
+      (/ (+ (nth v (dec (quot n 2))) (nth v (quot n 2))) 2))))
+
+(defn- clock
+  "`reps` walks of `s` through `f`, in nanoseconds per member."
+  [f s]
+  (let [t0 (now)]
+    (dotimes [_ reps] (f s))
+    (/ (* 1e6 (- (now) t0)) (* reps members))))
+
+(defn- interleaved
+  "Both arms, alternating, `rounds` times — so drift, GC and JIT warm-up
+  land on both arms rather than on whichever ran second."
+  [s]
+  (let [ship (atom []) abl (atom [])]
+    (dotimes [_ rounds]
+      (swap! ship conj (clock codec/as-element s))
+      (swap! abl conj (clock expand-seq-ablated s)))
+    (let [m-ship (median @ship)
+          m-abl  (median @abl)]
+      {:ship m-ship
+       :ablated m-abl
+       :pre-pass (- m-ship m-abl)
+       :pct (* 100 (/ (- m-ship m-abl) m-ship))})))
+
+(defn- row3 [label {:keys [ship ablated pre-pass pct]}]
+  (println (str "| " label
+                " | " (.toFixed ship 1)
+                " | " (.toFixed ablated 1)
+                " | " (.toFixed pre-pass 2)
+                " | " (.toFixed pct 2) "% |")))
+
+(defn -main [& _]
+  (when-not ^boolean js/goog.DEBUG
+    (println ";; REFUSED — this clock only means anything in a DEV build; the")
+    (println ";;   pre-pass does not exist under :advanced with goog.DEBUG=false.")
+    (js/process.exit 2))
+  (let [keyed   (doall (map (fn [i] [row {:key i}]) (range members)))
+        unkeyed (doall (map (fn [_] [row {}]) (range members)))]
+    ;; Warm the dedupe: the unkeyed row is meant to price the SCAN after the
+    ;; site has spoken, not the one console.warn it speaks with.
+    (codec/set-lowering-owner! "keywarn.clock/list")
+    (codec/as-element unkeyed)
+    (codec/set-lowering-owner! nil)
+    (println (str ";; keywarn pre-pass — dev build, " members " members, "
+                  reps " walks/round, " rounds " interleaved rounds, "
+                  "median-of-rounds. ns per member."))
+    (println "")
+    (println "| population | shipping (ns) | pre-pass ablated (ns) | pre-pass (ns) | share of dev lowering |")
+    (println "|---|---|---|---|---|")
+    (row3 "keyed (the steady state)" (interleaved keyed))
+    (row3 "unkeyed, site already warned" (interleaved unkeyed))
+    (println "")
+    (println ";; DIAGNOSTIC — not a gate row, not a published figure.")))

--- a/implementation/freehand/test/re_frame/bench/hicasso/keywarn_clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/keywarn_clock_run.cjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+'use strict';
+//
+// DRIVER for the key warning's dev pre-pass clock (rf2-2rtt6.104).
+//
+//     node freehand/test/re_frame/bench/hicasso/keywarn_clock_run.cjs
+//
+// Stdout is the artefact: a markdown table quoted into the PR body, with the
+// human framing riding as `;;` comments. See `keywarn_clock.cljs` for what is
+// measured and why a local ablation copy is the right shape for it.
+//
+// ## NO EDIT TO shadow-cljs.edn
+//
+// A `:node-script` compile is what this needs, and the lane's own
+// `:hicasso-bench` is a `:browser` build. Rather than add a build id — HD-017
+// makes that a hot-zone edit to `implementation/shadow-cljs.edn` and therefore
+// a sequenced dispatch — this rides the existing `:freehand-bench-node`
+// `:node-script` id through `--config-merge`, supplying its own `:main` and
+// `:output-to`. Exactly the mechanism `compile_gate.cjs` and `jsfb_build.cjs`
+// use on `:hicasso-bench`; only the borrowed id differs.
+//
+// `compile`, not `release`: the pre-pass exists only where `goog.DEBUG` is
+// true, and a dev compile is the build the figure is ABOUT. The clock refuses
+// to run under a production build rather than reporting a zero.
+//
+// The shared build cache is cleared first (rf2-2rtt6.20): one build id serving
+// two entries is precisely the shape that trap has.
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const { shadowBuildVerdict, reportRefusal } = require('./lane_build.cjs');
+
+const IMPL = path.resolve(__dirname, '../../../../..');
+const BUILD_ID = 'freehand-bench-node';
+const OUT = 'out/keywarn-clock.js';
+const TAG = 'keywarn-clock';
+
+fs.rmSync(path.join(IMPL, '.shadow-cljs', 'builds', BUILD_ID), {
+  recursive: true, force: true,
+});
+
+// EDN, and ONE LINE: shadow-cljs's CLI re-splits `--config-merge` on
+// whitespace once the data contains a newline, then reports `EOF while
+// reading` from a fragment. JSON is not accepted at all.
+const merge =
+  `{:main re-frame.bench.hicasso.keywarn-clock/-main :output-to "${OUT}"}`;
+
+console.error(`[${TAG}] compiling ${BUILD_ID} -> ${OUT}`);
+const verdict = shadowBuildVerdict({
+  impl: IMPL, mode: 'compile', buildId: BUILD_ID, configMerge: merge,
+});
+if (!verdict.ok) {
+  reportRefusal(TAG, verdict);
+  process.exit(1);
+}
+
+const r = spawnSync(process.execPath, [path.join(IMPL, OUT)], {
+  cwd: IMPL, stdio: 'inherit',
+});
+process.exit(r.status === null ? 1 : r.status);

--- a/implementation/freehand/test/re_frame/bench/hicasso/keywarn_elision_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/keywarn_elision_run.cjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+'use strict';
+//
+// THE MINTED KEY WARNING'S PRODUCTION-ISOLATION PROBE (rf2-2rtt6.104).
+//
+//     node freehand/test/re_frame/bench/hicasso/keywarn_elision_run.cjs
+//
+// ## The claim
+//
+// Every line of the key warning — the carrier object, the owner seam's
+// pairing check, the per-member scan and every message string — sits behind
+// `^boolean js/goog.DEBUG`. Under `:advanced` with `goog.DEBUG=false` Closure
+// folds each gate to `false`, the branches die, and the strings die with
+// them. The ordinary render path is byte-identical to what it was.
+//
+// That is a claim about BYTES, so it is proven with bytes, the F3d way: a
+// CONTROL BUILD rather than a grep of source. Two `:advanced` bundles of the
+// SAME entry, differing ONLY in `goog.DEBUG`:
+//
+//   out/keywarn-elision-release   goog.DEBUG=false  — what ships
+//   out/keywarn-elision-control   goog.DEBUG=true   — the twin
+//
+// A string reachable only through the gated branches is a DISCRIMINATOR:
+//
+//   ABSENT  in the release bundle  (the branch DCE'd — the warning does not ship)
+//   PRESENT in the control bundle  (the branch is live — the grep has teeth)
+//
+// The control's PRESENT half is the positive control, and it is not
+// ceremony: `scripts/check-freehand-evidence-elision.cjs` records why the
+// naive oracles fail here (a debug flag survived 225 times inside prose;
+// Closure inlines a small function's name, so grepping for the name can never
+// go red). Without the control leg, a probe that stopped rooting the seam
+// entirely — the call sites deleted, the fns orphaned — would pass
+// vacuously. With it, that mistake goes red on the control.
+//
+// ## The entry has to REACH the codec, and the default one does not
+//
+// `:hicasso-bench`'s baked `:init-fn` is `p0-reagent-app/-main` — the Reagent
+// arm, which never requires `front.codec`. A pair built on the default entry
+// carries no sentinel in EITHER bundle: the control leg would fail loudly
+// rather than pass vacuously, but it would still be a guaranteed red run for
+// the wrong reason. Both legs therefore name `jsfb-hicasso-app/-main`, which
+// requires `arm1.mount` -> `arm1.runtime` -> `front.codec`.
+//
+// ## NO EDIT TO shadow-cljs.edn
+//
+// The pair rides `:hicasso-bench` through `--config-merge`, exactly as
+// `compile_gate.cjs` and `jsfb_build.cjs` do, supplying its own `:output-dir`
+// and `:closure-defines` per leg. HD-017 makes a new build id a hot-zone edit;
+// the lane was built so a sibling never has to pay that. The shared build
+// cache is cleared before EACH leg (rf2-2rtt6.20): one build id and two
+// configurations is precisely the shape that trap has.
+//
+// Two `:advanced` releases of one arm are ~2 minutes, which is too heavy for
+// the recurring PR spine. This is a runnable-on-demand probe, run once in the
+// PR that landed the warning with its output quoted in the PR body. Promoting
+// it to a nightly is the mayor's call, not this file's.
+//
+// Exit 0 on PASS, 1 on FAIL.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { shadowBuildVerdict, reportRefusal } = require('./lane_build.cjs');
+
+const IMPL = path.resolve(__dirname, '../../../../..');
+const BUILD_ID = 'hicasso-bench';
+const INIT_FN = 're-frame.bench.hicasso.jsfb-hicasso-app/-main';
+const TAG = 'keywarn-elision';
+
+// DEV-ONLY sentinels. Each is an EXACT runtime string literal from inside a
+// `goog.DEBUG` branch — never a fragment spanning a `(str …)` seam, because a
+// fragment synthesised across an interpolation greps absent in both bundles
+// and the probe would report a pass it never earned. Each must be ABSENT in
+// release and PRESENT in the control.
+const DEV_ONLY = [
+  // `front.codec/warn-member-key!` — the missing-key message's fix clause.
+  // One literal in the (str …) that builds the line.
+  { source: 'front.codec/warn-member-key! (the missing-key fix clause)',
+    sentinel: ' Give each one a :key in its props map —' },
+  // The same fn's ENTITY-key branch — an independent gated string, so the
+  // probe proves the whole warning is gone rather than one line of it.
+  { source: 'front.codec/warn-member-key! (the entity-key coercion clause)',
+    sentinel: ' React coerces a key to a string, so a collection keys' },
+  // `front.codec/set-lowering-owner!` — the staleness pin. A THIRD independent
+  // gated branch, and the one in a PUBLIC fn: `set-lowering-owner!` itself
+  // survives :advanced (the arm calls it), so this sentinel proves the gate
+  // inside a surviving fn folds, not merely that an unreferenced private fn
+  // was dropped.
+  { source: 'front.codec/set-lowering-owner! (the unbalanced-pair pin)',
+    sentinel: '[hicasso] A boundary body began lowering while `' },
+];
+
+// PROD-SURVIVING sentinels: strings this entry ships regardless of goog.DEBUG.
+// The non-vacuity floor for the grep itself — proof the release bundle is a
+// real, inspected artefact in which the absences above are a DCE result rather
+// than an accident of an empty or broken build.
+const PROD_SURVIVING = [
+  // `front.codec/vec->element`'s bad-head refusal — a production error path,
+  // ungated, in the very namespace the dev-only sentinels come from.
+  { source: 'front.codec/vec->element (the bad-head refusal survives :advanced)',
+    sentinel: 'is not a valid element head' },
+];
+
+function clearBuildCache() {
+  const dir = path.join(IMPL, '.shadow-cljs', 'builds', BUILD_ID);
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function build(leg, debug, outputDir) {
+  clearBuildCache();
+  const merge = JSON.stringify({
+    'output-dir': outputDir,
+    'compiler-options': { 'closure-defines': { 'goog.DEBUG': debug } },
+    modules: { main: { 'init-fn': INIT_FN } },
+  });
+  console.log(`[${TAG}] building ${leg} (goog.DEBUG=${debug}) -> ${outputDir}`);
+  const verdict = shadowBuildVerdict({
+    impl: IMPL, mode: 'release', buildId: BUILD_ID, configMerge: merge,
+  });
+  if (!verdict.ok) {
+    reportRefusal(TAG, verdict);
+    process.exit(1);
+  }
+  const bundle = path.join(IMPL, outputDir, 'main.js');
+  const blob = fs.readFileSync(bundle, 'utf8');
+  console.log(`[${TAG}]   ${bundle} — ${blob.length} bytes`);
+  return blob;
+}
+
+function assertSentinels(leg, blob, sentinels, mustContain) {
+  let ok = true;
+  for (const { source, sentinel } of sentinels) {
+    const present = blob.includes(sentinel);
+    const pass = present === mustContain;
+    if (!pass) ok = false;
+    console.log(
+      `[${TAG}]   ${pass ? 'ok  ' : 'FAIL'} ${leg}: ` +
+      `${mustContain ? 'PRESENT' : 'ABSENT'} expected, ` +
+      `${present ? 'present' : 'absent'} found — ${source}`,
+    );
+  }
+  return ok;
+}
+
+function main() {
+  const release = build('release', false, 'out/keywarn-elision-release');
+  const control = build('control', true, 'out/keywarn-elision-control');
+
+  console.log(`\n[${TAG}] the isolation contract`);
+  let ok = true;
+  ok = assertSentinels('release', release, DEV_ONLY, false) && ok;
+  ok = assertSentinels('control', control, DEV_ONLY, true) && ok;
+  ok = assertSentinels('release', release, PROD_SURVIVING, true) && ok;
+  ok = assertSentinels('control', control, PROD_SURVIVING, true) && ok;
+
+  console.log(
+    ok
+      ? `\n[${TAG}] PASS — the key warning carries no trace into production, ` +
+        'and the control proves the grep has teeth.'
+      : `\n[${TAG}] FAIL — see the rows above.`,
+  );
+  process.exit(ok ? 0 : 1);
+}
+
+main();

--- a/implementation/freehand/test/re_frame/bench/hicasso/keywarn_elision_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/keywarn_elision_run.cjs
@@ -82,10 +82,15 @@ const DEV_ONLY = [
   { source: 'front.codec/warn-member-key! (the entity-key coercion clause)',
     sentinel: ' React coerces a key to a string, so a collection keys' },
   // `front.codec/set-lowering-owner!` — the staleness pin. A THIRD independent
-  // gated branch, and the one in a PUBLIC fn: `set-lowering-owner!` itself
-  // survives :advanced (the arm calls it), so this sentinel proves the gate
-  // inside a surviving fn folds, not merely that an unreferenced private fn
-  // was dropped.
+  // gated branch, and the WEAKEST of the three: it is protected twice over,
+  // because the fn's only callers (`arm1.runtime/run-once`, the two mint
+  // stamps) are themselves inside `goog.DEBUG` branches, so under :advanced
+  // the fn is unreachable and Closure drops it whole regardless of its own
+  // gate. Measured, not assumed — a mutation run that replaced this fn's
+  // internal gate with `(when true …)` still came back ABSENT here, and only
+  // the mutation at `expand-seq`'s CALL SITE went red. Kept because a third
+  // independent string is still evidence the whole feature is gone rather
+  // than one line of it, but the load-bearing sentinels are the two above.
   { source: 'front.codec/set-lowering-owner! (the unbalanced-pair pin)',
     sentinel: '[hicasso] A boundary body began lowering while `' },
 ];

--- a/implementation/freehand/test/re_frame/bench/hicasso/keywarn_elision_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/keywarn_elision_run.cjs
@@ -108,11 +108,13 @@ function clearBuildCache() {
 
 function build(leg, debug, outputDir) {
   clearBuildCache();
-  const merge = JSON.stringify({
-    'output-dir': outputDir,
-    'compiler-options': { 'closure-defines': { 'goog.DEBUG': debug } },
-    modules: { main: { 'init-fn': INIT_FN } },
-  });
+  // EDN, and ONE LINE: shadow-cljs's CLI re-splits `--config-merge` on
+  // whitespace once the data contains a newline, then reports `EOF while
+  // reading` from a fragment. JSON is not accepted at all.
+  const merge =
+    `{:output-dir "${outputDir}" :asset-path "." ` +
+    `:compiler-options {:closure-defines {goog.DEBUG ${debug}}} ` +
+    `:modules {:main {:init-fn ${INIT_FN}}}}`;
   console.log(`[${TAG}] building ${leg} (goog.DEBUG=${debug}) -> ${outputDir}`);
   const verdict = shadowBuildVerdict({
     impl: IMPL, mode: 'release', buildId: BUILD_ID, configMerge: merge,


### PR DESCRIPTION
Builds the Hicasso-minted key warning ruled on **rf2-2rtt6.104** — the guide's outstanding promise at `02-views-and-reads.md` ("a Hicasso-minted warning is planned but not built"). React's own key warning names a component stack and dedupes **per parent tag name for the life of the page**, so at every list site after the first under a given tag it says nothing at all. This one names the authoring facts React cannot: the enclosing view, the child head, the index, and the fix.

Dev builds only. Production carries no trace, and that is proven with bytes rather than argued.

## What it says

```
[hicasso] Unkeyed boundary children in the body of my.ns/todo-list: a seq of
my.ns/todo-row members has no :key (absent or nil; first at index 2). Give each
one a :key in its props map — [child {:key id, …}] — so the list keeps identity
across reorder and removal; a key written as Reagent metadata is not read here.
React's own warning names the component stack and fires once per parent tag
name; this one names the authoring site and fires once per site, in development
builds only. [:rf.warning/hicasso-missing-key]
```

and, per the synthesis addendum, the entity-key twin:

```
[hicasso] Entity-valued :key on boundary children in the body of my.ns/todo-list:
a seq of my.ns/todo-row members carries a map at :key (first at index 0). React
coerces a key to a string, so a collection keys the child by its CONTENT — edit
the entity and the child silently remounts, losing focus, scroll position and any
presence retention. Key on a stable identifier instead — [child {:key (:id
entity), …}]. Warned once per site, in development builds only.
[:rf.warning/hicasso-entity-key]
```

**When it fires.** A member of a lowered child seq that is a boundary-headed vector whose props give `(nil? (:key props))` — the exact emission gate, so nil-and-absent are one case — or whose `:key` value is a collection. Once per site, where a site is *(enclosing view, member head, which hazard)*, page-load lifetime. Two call sites: inside `expand-seq`'s loop (every native, fragment and host parent reaches it) and at `realize-children`'s `seq?` branch (the crossing into a boundary).

**The warning prints no runtime value.** `key-shape` names the shape ("a map", "a vector", "a set") rather than printing it, so a cyclic or throwing foreign value at `:key` cannot blow the diagnostic. That also keeps the codec's `:require` list unchanged — it reaches for no `safe-form`/`pr-form` crossing because it never needs one.

## The three named repairs, and the addendum

**R1 — the id.** `:rf.warning/hicasso-missing-key` (and `:rf.warning/hicasso-entity-key`), in the catalogued `:rf.warning/*` family (`spec/Conventions.md` §Reserved namespaces). The design's `:rf.warn/*` "first of its family" claim was false and is not shipped; no API-freeze note is added, because the family is already catalogued.

**R2 — the `realize-children` blind spot.** Closed, not documented as a hole. `[a-view {…} (for …)]` hands a dynamic list across a crossing; the one-level flatten turns those members into direct arguments, which React marks validated and therefore never warns about — Hicasso's flatten *removes* React's own signal for that shape. The check now runs at the `(if (seq? c) …)` branch, where the seq is still in hand and the enclosing body's owner slot is still correct. Two witness rows (unkeyed crossing warns naming the writing body; keyed crossing silent).

**R3 — the cost number.** Clocked, and **the clocked number contradicted the analytic one** — see the finding below. The docstring carries the measured table, not the derivation.

**Addendum — the entity-key row.** Shipped as its own id rather than folded into the missing-key message: it is a different hazard with a different fix, and a separate id greps separately. `coll?` is the predicate (maps, vectors, sets, records — anything React string-coerces into content-derived identity); it is reached only by a member that already failed the cheap primitive test.

**The owner threading (fence delta, accepted on the bead).** Four `goog.DEBUG`-gated lines in `arm1/runtime.cljs`: `run-once` sets the codec's dev slot before lowering and clears it in the `finally` it already had, and the two mint fns stamp `displayName` on the body fn. The staleness pin is in `set-lowering-owner!` (a non-nil set over a non-nil owner warns that the pair is unbalanced, with a witness row); the forgot-to-*set* half is declared unpinnable in the seam's docstring, in those terms, with the obligation placed on future lowering entry points.

## FINDING — the design's cost estimate was 4x low, and its two data-structure choices were the reason

R3 asked for one clocked row. The row said the pre-pass cost **316 ns/member, ~18% of dev lowering** — against the design's analytic **1–4%**. Two shapes the design specified were the cause, and both were replaced:

1. **A pre-pass over the seq, before the expansion loop.** Chosen in the design to leave the shipping loop byte-identical. It traverses the spine **twice**, and `first`/`next` over the chunked seq a `for` produces allocates per step. The check now rides `expand-seq`'s existing loop. Production keeps its exact shape anyway: the call is gated, and the index reported is `(.-length a)` — the output array's own length — so no loop variable was threaded and no increment lands on the production path.
2. **A flat `Set` of joined site strings for the dedupe.** Looking a site up meant building `(str owner "|" member "|" kind)` on every member of every render of a list the author had *not fixed yet* — **420 ns/member, a third of dev lowering, on precisely the list the author is staring at.** Replaced with nested tables keyed on the owner string and the head object as they already are; the repeat path now allocates nothing.

After both repairs (dev build, 300 boundary members, 200 walks/round, 11 interleaved rounds, median-of-rounds, ns per member):

| population | shipping | check ablated | the check | share of dev lowering |
|---|---|---|---|---|
| keyed (the steady state) | 1523.7 | 1367.2 | **156.5** | 10.3% |
| unkeyed, site already warned | 936.7 | 789.0 | **147.8** | 15.8% |

~150 ns/member on both populations; the share differs only because an unkeyed boundary element is cheaper to mint, so the same absolute cost is a larger fraction of a smaller number.

**It is still ~4x the design's 15–40 ns/member**, and the reason is stated rather than argued away: this is a **dev** build, where `vector?`, `nth` and the `:key` lookup are protocol dispatches through real function calls, while the analytic estimate priced them as the inlined shapes `:advanced` produces — and under `:advanced` the check does not exist at all. The figure is recorded in `check-member-key!`'s docstring, with both rejected shapes and their numbers, per this file's standing "clocked rather than asserted" rule.

Reproduce: `node freehand/test/re_frame/bench/hicasso/keywarn_clock_run.cjs`.

## Production isolation, proven and mutation-tested

`keywarn_elision_run.cjs` — two `:advanced` bundles of `jsfb-hicasso-app` differing only in `goog.DEBUG`, riding `:hicasso-bench` through `--config-merge` (**no `shadow-cljs.edn` edit**, no new build id, cache cleared per leg).

```
release: ABSENT expected, absent found — warn-member-key! (the missing-key fix clause)
release: ABSENT expected, absent found — warn-member-key! (the entity-key coercion clause)
release: ABSENT expected, absent found — set-lowering-owner! (the unbalanced-pair pin)
control: PRESENT expected, present found — (all three)
release: PRESENT expected, present found — vec->element (the bad-head refusal survives :advanced)
control: PRESENT expected, present found — vec->element
PASS — the key warning carries no trace into production, and the control proves the grep has teeth.
```

**Made to fail.** Replacing `expand-seq`'s call-site gate with `(when true …)` put 1,685 bytes of warning strings into the release bundle and the probe went red (exit 1) on both message sentinels. A second mutation, on `set-lowering-owner!`'s *internal* gate, came back green — because that fn's only callers are themselves gated, so Closure drops it whole regardless. That makes it the weakest of the three sentinels, and the runner now says so in place of the over-claim it carried.

## Both mutation directions

*Detection disabled* (`check-member-key!` short-circuited) — **9 firing rows die**, node and browser:

```
an-unkeyed-boundary-seq-warns-once-naming-the-view-the-child-and-the-index
a-key-that-computed-nil-warns-because-the-emitted-element-is-keyless
a-mixed-seq-names-the-first-unkeyed-member
an-entity-valued-key-warns-about-the-coercion-hazard
the-crossing-into-a-boundary-warns-where-nothing-else-can
the-owner-clause-is-dropped-rather-than-guessed-when-no-body-is-lowering
a-site-is-the-pair-of-the-enclosing-view-and-the-member-head
the-site-warns-exactly-once-however-many-renders-it-takes
every-parent-class-reaches-the-check-through-the-one-site
+ (browser) a-mounted-unkeyed-list-warns-on-both-channels-and-names-its-own-view
+ (browser) the-owner-slot-is-cleared-by-the-finally-not-merely-set-by-the-body
```

*Every exclusion guard removed* (`plain-key?` neutralised, `boundary-head?` bypassed, `coll?` widened to `some?`) — **14 assertions across the four silence rows die**:

```
a-keyed-boundary-seq-is-silent-and-so-is-every-legitimate-key-shape
the-scope-line-holds-in-both-directions
a-mixed-seq-names-the-first-unkeyed-member
the-crossing-into-a-boundary-warns-where-nothing-else-can
```

**Legitimate positions are proven individually**, not as a bundle: the keyed row loops over seven key shapes with its own assertion each (number, string, keyword, namespaced keyword, negative number, zero, empty string), and the scope row separately proves silence for native-tag members, host-headed members, strings/numbers/nils in a seq, and a headless vector (which stays somebody else's loud refusal). The browser lane's keyed control is silent on both channels in the same bundle, the same render pass and the same spy.

**The `reportError` trap** is covered: the browser rows spy `console.warn` *and* `console.error` *and* add a `window` `error` listener, asserting `(= [] @thrown)` — without it a live throw inside a render reads as 0 failures.

## The ordinary path and the hook ledger

- **No hook added.** `arm1/runtime.cljs`'s edits are two `goog.DEBUG`-gated `displayName` stamps at **mint** time (once per `defview`, at definition) and two gated lines in `run-once`. `shell` / `frame-prop-shell` are untouched. `hook_ledger_dom_cljs_test` (the ≤2-hook budget counted at React's dispatcher) is green in the browser lane.
- **No per-render production cost.** Every added line is behind `^boolean js/goog.DEBUG`; `expand-seq`'s loop keeps its exact shape (no threaded index — `(.-length a)` is the index), and the elision mutation above shows what the bundle looks like when a gate stops folding.
- **`realize-children`'s reduce** gains one gated call inside the existing `seq?` branch; no new allocation, and the `(fn [acc c] …)` literal was already there.

## Scope, as ruled

Computed-nil keys **warn** (the emitted element is keyless, so this is a true positive); mixed seqs warn naming the first unkeyed index; nested seqs are checked per level by the recursion; `[:<>]` children are in; a `defhost` parent is in incidentally — which pins what `[:>]` will inherit when rf2-2rtt6.103 lands, with no code here; native-tag and host-headed members are silent (the bead's scope sentence — boundary children); a correct `presence` fixture is silent (its children are keyed native nodes) and an unkeyed presence child still meets its own loud `:rf.error/hicasso-presence-child-unkeyed` refusal.

Declared residual, in the docstrings rather than discovered later: a boundary-headed presence child that is unkeyed now gets this warning *and* that error. It fires earlier and in the author's own body, which is the better half of a duplicate.

## Not in this PR

- **Guide 02's tense-flip — deferred, and it needs a decision.** The synthesis puts the `02-views-and-reads.md` tense-flip in *this* PR, and rf2-2rtt6.110's description says the same ("the code PR carries the '02 planned-but-not-built' tense-flip; this bead is the teaching"). The dispatch fenced `docs/design/hicasso/draft-guide/**` out entirely because two PRs are open and conflicting there, and a live merge fence outranks a paper one. So **two guide edits are now owed and neither is here**: line 70's "a Hicasso-minted warning is planned but not built" is false the moment this merges, and line 321's open row ("Dev warning for an unkeyed seq — id and whether dev-only") is answered (`:rf.warning/hicasso-missing-key`, dev-only, zero production trace). Either fold both into **rf2-2rtt6.110** or sequence a one-file follow-up once the draft-guide PRs land — mayor's call; nothing else blocks on it.
- **A Spec 009 catalogue row is *not* owed.** No Hicasso id appears anywhere under `spec/` today — `:rf.error/hicasso-empty-vector`, `-bad-head`, `-presence-child-unkeyed`, `-host-fallback-boundary-head` all live only in `docs/design/hicasso/`. `spec/Conventions.md` reserves the `:rf.warning/*` **namespace**, which these ids sit inside; cataloguing the Hicasso family per-id would be a new precedent and a whole-family bead, not this one's edit.

## Quality gates

All foreground, to completion.

| gate | exit |
|---|---|
| `npm run test:hicasso-compile` | **0** — 128 lane namespaces, 0 warnings |
| `npm run test:cljs` | **0** — 12,698 tests / 63,640 assertions, 0 failures, 0 errors |
| `npm run test:browser` | **0** — 1,104 tests / 6,831 assertions, 0 failures, 0 errors |
| `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine` |
| clj-kondo 2026.04.15 (CI pin, JVM route) | **0** — **errors: 0**, warnings: 4536 (baseline), none in the touched files |
| `keywarn_elision_run.cjs` | **0** — PASS (and **1** under mutation) |
| `keywarn_clock_run.cjs` | **0** |

`test-fast-pr.sh` classified itself `docs=false jvm=true node=true`; the documentation surface is unchanged so it skipped the doc gates, which is correct — this PR touches no `docs/`.

No AI attribution. Closes rf2-2rtt6.104.
