### PR TITLE
test(bench): make the lane_cache require check quote-agnostic like its siblings (rf2-t4j7c)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/bench/lane_cache_wiring.test.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/lane_cache_wiring.test.cjs
@@ -96,7 +96,7 @@ for (const { file, src } of RIDERS) {
   test(`${file} requires lane_cache.cjs`, () => {
     assert.match(
       src,
-      /require\('\.\/lane_cache\.cjs'\)/,
+      /require\(\s*['"]\.\/lane_cache\.cjs['"]\s*\)/,
       `${file} spawns a shared-build-id release and must require ./lane_cache.cjs`
     );
   });


### PR DESCRIPTION
One-line follow-on to #7569, which was merged between my second and third push — the third commit was stranded by the race and did not land.

`lane_cache_wiring.test.cjs`'s three per-rider checks are all documented as quote-agnostic, and two of them are. The `require` check was still keyed to single quotes:

```
-      /require\('\.\/lane_cache\.cjs'\)/,
+      /require\(\s*['"]\.\/lane_cache\.cjs['"]\s*\)/,
```

This is a **fail-closed** inconsistency, not a hole — a double-quoted `require` would have produced a false RED, never a false green — so nothing on main is unsound. It is worth closing because the file's own comment promises quote-agnosticism across all three checks, and because the sibling gate this one was modelled against was defeated by exactly this (single-vs-double quotes in both its check and its fallback).

No behaviour change on the current tree: all seven riders use single quotes today, so the gate's verdict is identical before and after.

## Quality gates

Run to completion in the foreground, read from each runner's own terminal marker.

| gate | exit |
|---|---|
| `node …/lane_cache_wiring.test.cjs` | **0** (23/23) |
| `npm run test:script-helpers` | **0** |
| `npm run lint:js` | **0** |

The full `sh scripts/test-fast-pr.sh` was **0** on the identical content before #7569 merged; this diff is one regex inside a node test file the spine reaches only through `test:script-helpers`, which is green above.