### PR TITLE
docs(EP): EP-0002 stops promising a payload key nothing sets (rf2-f7j00)

### DIFF
--- a/docs/EP/EP-0002-frame-target-resolution.md
+++ b/docs/EP/EP-0002-frame-target-resolution.md
@@ -1226,6 +1226,21 @@ The contract is authored as the appendix argues — *one carried invariant*, the
   single-frame apps" is **refined, not wholesale**: plurality stays invisible
   *inside a frame's scope*; only the absence of **any** scope is made loud.
 
+> **Erratum — 2026-08-06 (rf2-f7j00, recording the rf2-j4bg3 spec correction).**
+> Read R6's "through the … correlation graph" strictly. The frameless payload
+> carries the single `:rf.trace/dispatch-id` stamp; the parent link is *walked*
+> from it, never copied onto it. `re-frame.frame/no-frame-context-payload` and
+> `re-frame.frame/ambient-frame-refused-payload` each merge only
+> `:rf.trace/dispatch-id`, `re-frame.trace/HandlerScope` has no parent slot to
+> thread one from, and `:rf.trace/parent-dispatch-id` is scoped to
+> `:rf.event/dispatched` per
+> [009 §Dispatch correlation](../../spec/009-Instrumentation.md#dispatch-correlation-rftracedispatch-id--rftraceparent-dispatch-id),
+> so it never rides a frameless payload. Spec 009, Spec-Schemas and 002 had
+> listed it on that payload and were corrected; the identical two-key phrasing
+> in the
+> [appendix §G](#g-make-the-rationale-the-detection-and-the-error-more-re-frame2)
+> bullet R6 adopts is covered by this erratum.
+
 ### Open-Issue resolutions
 
 The seven Open Issues are resolved against their Recommendations (Mike accepted


### PR DESCRIPTION
Closes rf2-f7j00. Residue from rf2-j4bg3, which removed the same false claim from `spec/009-Instrumentation.md`, `spec/Spec-Schemas.md` and `spec/002-Frames.md`.

## The false claim

R6 of EP-0002's binding reframing ruling says the frameless error "carries **capture-site ancestry** through the existing `:rf.trace/dispatch-id` / `:rf.trace/parent-dispatch-id` correlation graph." Only the first key is on the payload:

- `re-frame.frame/no-frame-context-payload` and `re-frame.frame/ambient-frame-refused-payload` each merge exactly `(when-let [did (some-> trace/*handler-scope* :dispatch-id)] {:rf.trace/dispatch-id did})` — and `no-frame-context-payload`'s own docstring already says so in as many words.
- `re-frame.trace/HandlerScope` is `[trigger-handler call-site dispatch-id sensitive? no-emit?]` — five slots, no parent slot to thread one from.
- `spec/009-Instrumentation.md` §Dispatch correlation states independently that `:rf.trace/parent-dispatch-id` is scoped to `:rf.event/dispatched` only.

So the ruling's *intent* holds — ancestry is reachable — but the payload carries the single stamp and the parent link is **walked** from it. A documented payload key that no builder sets is the spec's own fail-open: a consumer written against it gets nothing and has no way to know it was promised.

## What changed

One dated erratum blockquote, +15 / −0, nothing removed and no other claim touched.

An EP body is a historical record, so R6's text stands verbatim and the correction lands beside it — per EP-0009 §Durability rules rule 3 ("anything past [mechanical] is recorded as a dated erratum/addendum beside the affected passage, preserving the original text — freeze meaning, not bytes") and the corpus idiom (`> **Erratum — <date> (<bead>).**` in EP-0031, EP-0035, EP-0037; EP-0001 does the same in-body beside its Decision 2).

Placement is after the `### The reframing ruling (binding)` bullet list rather than between R6 and R7, because a column-0 blockquote mid-list would split the list. EP-0002's ledger sections were considered and rejected: `### Open errata` says "None known." and this erratum is resolved, not open; `### Deliberate divergences from the EP body` is scoped to *the body*, which by this document's own vocabulary (§What is superseded: "the body above ... against this section") excludes §Resolved Decisions, where R6 lives.

The second mention — the appendix §G bullet R6 adopts — is named by the erratum rather than given a second blockquote. It is superseded source commentary, subordinate to the ruling per the preamble and §What is superseded, and one clause was the brief.

## Sweep — does any other EP carry the promise?

No. `git grep -n -i 'parent.dispatch|capture-site ancestry' -- docs/EP/` returns four hits, all in EP-0002: R6's two lines, the appendix §G bullet, and Open-Issue resolution 6 ("carries capture-site ancestry per R6") — which is **true** as written and now governed by the erratum it points at.

Widening the sweep to all of `docs/` found one further false instance outside this PR's fence, filed as **rf2-e96mm** (P4): `docs/core/how-to/report-errors-in-production.md` claims the frameless record "carries capture-site ancestry through the `:rf.trace/dispatch-id` / `:rf.trace/parent-dispatch-id` correlation keys." Three other `docs/` hits are correct and deliberately untouched: `docs/api/re-frame.core.md` and `docs/core/observability.md` describe the `group-by-event` **projection record's** `:parent-dispatch-id` slot and the true `:rf.event/dispatched`-scoped statement.

The bead also asked whether EP-0002 spells `:where` as a keyword (009 and 002 both did; the real value is a symbol). It does not — the §Central Resolver payload sketch reads `:where 're-frame.router/dispatch!`, a quoted symbol, which is correct. The only other `:where` in the file names the key, not a value. No fix needed.

## Quality gates

| Gate | Exit | Notes |
| --- | --- | --- |
| `python scripts/check_doc_slugs.py` | `0` | covers `docs/**` incl. `docs/EP/` |
| `sh scripts/test-fast-pr.sh` | `0` | classification line as printed: `=== fast PR spine: docs=true jvm=false node=false (classified) ===` |

**Mutation proof for `check_doc_slugs.py`** — the erratum adds two links, and each was independently broken, grep-confirmed as landed, and shown to red the checker:

1. `#g-make-the-rationale-the-detection-and-the-error-more-re-frame2` → `#g-make-the-rationale-MUTANT-more-re-frame2`; grep confirmed the mutant at the link site; checker printed `BROKEN ANCHOR: docs\EP\EP-0002-frame-target-resolution.md -> #g-make-the-rationale-MUTANT-more-re-frame2`, exit **1**.
2. `../../spec/009-Instrumentation.md#dispatch-correlation-rftracedispatch-id--rftraceparent-dispatch-id` → `...#dispatch-correlation-MUTANT-2`; grep confirmed the mutant; checker printed `BROKEN ANCHOR: ... -> ../../spec/009-Instrumentation.md#dispatch-correlation-MUTANT-2 (target: spec\009-Instrumentation.md)`, exit **1**.

Both reverted; the checker returns exit **0** on the committed state.

**Tables:** nothing validates them, so hand-counted. This diff adds **no** table and edits none — the erratum is a blockquote of prose, and `EP-0002-frame-target-resolution.md` contains no table at all. The only table in this PR is the gates table above: **3 columns**, hand-counted consistent across the header row, the delimiter row and both body rows.

No `Users/miket` in the diff (`git diff -- docs/EP/ | grep -c 'Users/miket'` → 0). `.beads/` untouched.

The spine ran to completion in the background and printed its own footer (the `check_fast_pr_gap.py --list` gap report); the exit code above is the completed run's, not a terminated one. No check came back cancelled.
