### PR TITLE
docs(hicasso): guide 02 states the minted key warning that now exists (rf2-2rtt6.110)

### DIFF
--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -66,10 +66,24 @@ the source. Keys go in the props map (no Reagent `^{:key}` metadata):
      [todo-row {:key id :id id}])])
 ```
 
-A bare seq of boundary children needs keys. Forget one today and you get React's
-own key warning in development; a Hicasso-minted warning is planned but not
-built. Putting a plain `defn` in head position — `[badge {...}]` where `badge`
-was never minted by `defview` — raises `:rf.error/hicasso-bad-head`.
+A bare seq of children needs keys whatever the head. Forget one on a boundary
+child and development gives you two warnings: React's own, and
+`:rf.warning/hicasso-missing-key`, which names the enclosing view, the child
+head, the index of the first offender, and the `:key` spelling that fixes it.
+Neither suppresses the other, and the second earns its keep because React dedupes
+its key warning per parent tag name for the life of the page — under a `:ul`,
+every list after the first is silent. Hicasso's fires once per site instead:
+enclosing view, child head, hazard. A `^{:key id}` carried over from Reagent is
+the commonest way to trip it, because the metadata is not read here.
+
+It fires at a crossing too — `[a-view {…} (for …)]`, where the seq becomes the
+view's children. Flattening one level turns those members into direct children,
+which React marks validated and never warns about, so there the Hicasso line is
+the only signal that shape gets. Both call sites are development-only: the check
+and its message strings are absent from a production build.
+
+Putting a plain `defn` in head position — `[badge {...}]` where `badge` was never
+minted by `defview` — raises `:rf.error/hicasso-bad-head`.
 
 **You write `:key` yourself, and that is the answer** rather than a gap waiting
 on sugar. A `for`-lowering would have to assume the binding value *is* the
@@ -77,7 +91,9 @@ identity, which stops being true the moment you iterate whole entities: React
 coerces a non-primitive key to a string, so editing a row would quietly change
 its key and remount it. And it could not retire the explicit `:key` anyway, so
 every list would carry two spellings forever in exchange for saving about a dozen
-characters.
+characters. Write a whole entity at `:key` yourself and you get
+`:rf.warning/hicasso-entity-key` for that same coercion, naming the child and
+pointing you at a stable identifier.
 
 ### The component ABI
 
@@ -275,6 +291,8 @@ the collector mechanics.
 | A read after the render throws, naming the query | A handler closure, stashed lazy seq, or `delay` deferred a `sub` past the render | Read during the render and close over the value |
 | Index thrash, subscriptions constantly re-created | Query args not *value*-stable (timestamp, real sort-order change, or JS/fn identity) | Make the args equal under `=` between renders; allocation of equal persistent values is fine |
 | A body's side effect fires twice | StrictMode double-invoke | Bodies are pure; move the effect out |
+| `:rf.warning/hicasso-missing-key` names a view and a child head | A seq of boundary children has no `:key` — absent, or an expression that computed `nil` | Put a `:key` in each member's props map. A Reagent `^{:key}` on the form is not read |
+| `:rf.warning/hicasso-entity-key`, and a row remounts when you edit it | `:key` holds a collection, which React coerces to a string — the key moves with the content | Key on a stable identifier: `{:key (:id todo)}` |
 
 ## When not to use a boundary
 
@@ -318,4 +336,3 @@ not a surgical add/remove of one key. That is the cost of legal dynamic reads.
 |---|---|
 | `sub` and `defview` spellings | Working names; **[unfrozen]** until API freeze |
 | Whether value-equality bail-out stays the **default** | **Open.** Runtime implements memo-by-default today; explicit opt-in is still on the table |
-| Dev warning for an unkeyed seq — id and whether dev-only | **Open.** Today you see React's own key warning |


### PR DESCRIPTION
`rf2-2rtt6.104`'s minted key warning shipped in **PR #7567**, which was fenced out of `draft-guide/**` and so left two claims on this page false. **rf2-2rtt6.110** owns the teaching; both edits land here.

One file: `docs/design/hicasso/draft-guide/02-views-and-reads.md`. **+23 / −6, net +17.**

## The two false claims

**The tense-flip.** The keys paragraph said the warning was planned but not built:

> A bare seq of boundary children needs keys. Forget one today and you get React's own key warning in development; **a Hicasso-minted warning is planned but not built.** Putting a plain `defn` in head position — `[badge {...}]` where `badge` was never minted by `defview` — raises `:rf.error/hicasso-bad-head`.

It now teaches what landed, in three paragraphs: what the message names, why the second warning earns its keep, the crossing, and the dev-only guarantee.

**The answered row.** `## Not settled yet` carried:

> \| Dev warning for an unkeyed seq — id and whether dev-only \| **Open.** Today you see React's own key warning \|

The question is settled in both halves, so the row is **deleted** rather than restated — a table headed *Not settled yet* that carries a settled row is the same class of stale claim this PR is fixing. The answers live in the body, where a reader meets them.

## What the teaching says, and where each claim comes from

Every claim was read off the tree, not the brief.

- **The id and what it names** — `warn-member-key!` in `implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs`: enclosing view, child head, index of the first offender, the `:key` spelling, `[:rf.warning/hicasso-missing-key]`.
- **Once per site** — a site is *(enclosing view, member head, hazard)*, per `keywarn`'s nested tables; page-load lifetime.
- **Why it exists** — React dedupes its key warning per parent tag name for the life of the page (`ownerHasKeyUseWarning`, cited in `keywarn_dom_cljs_test`'s docstring), so under a `:ul` every list after the first is silent on React's channel. Neither warning suppresses the other; no suppression machinery exists.
- **The crossing** — `realize-children`'s `seq?` branch. The one-level flatten turns those members into direct children, which React marks validated and never warns about, so Hicasso's line is the only signal that shape gets.
- **Reagent metadata** — `^{:key id}` is not read under this ABI, and the message says so. Named as the way you trip it, since the page already states the props-map rule.
- **Dev-only** — both call sites sit behind `^boolean js/goog.DEBUG`; `keywarn_elision_run.cjs` proves the strings are absent from an `:advanced` bundle and present in a `goog.DEBUG=true` control.
- **The entity-key twin** — `:rf.warning/hicasso-entity-key` is named in the paragraph that already explains the string-coercion hazard it catches, rather than re-explaining it beside the first id.

**Two troubleshooting rows** added, one per id, symptom → cause → fix.

**No provisional id is printed.** `:rf.error/ambient-frame-refused` (`rf2-k0rbk`) appears nowhere on the page; the only ids written are the two settled warnings and the pre-existing `:rf.error/hicasso-bad-head`.

**No new sample.** Every code shape quoted (`[a-view {…} (for …)]`, `{:key (:id todo)}`) is prose-inline and matches the runtime's own message text.

## One correction to the dispatch brief

The brief said `:rf.warning/hicasso-missing-key` is *"catalogued in `Conventions.md` §Reserved namespaces"*. It is not, and PR #7567 says so explicitly under *"A Spec 009 catalogue row is not owed"*: `spec/Conventions.md` reserves the **`:rf.warning/*` namespace**, which these ids sit inside, but no Hicasso id appears anywhere under `spec/`. `git grep hicasso -- spec/` is empty. Nothing in this PR claims otherwise.

The brief's other facts checked out — two ids, the DEV gate, the `realize-children` blind spot, the ~150 ns/member figure (`check-member-key!`'s docstring, 10.3% of dev lowering, 4x the analytic estimate), and the 1,685-byte mutation. The benchmark and byte figures are deliberately **not** in the guide: this is an authoring page, and its register is what the author must do, not what the check costs.

## Contended files

Untouched: `01-getting-started.md`, `11-performance.md`, `README.md` (contended by #7527/#7528), and `studio/**`, `decisions.md`, `spec/**`, `implementation/**`, `scripts/**`, `.github/**`. `git grep -n 'Users/miket'` over the diff is empty.

## Quality gates

Foreground, to completion, on the rebased base (`a89a1f87a7`).

| gate | exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_doc_slugs.py` **under mutation** | **1** |
| `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine` |

`test-fast-pr.sh` printed its own classification line: `=== fast PR spine: docs=true jvm=false node=false (classified) ===`.

**Mutation proof for the slug gate.** `mkdocs build --strict` does not cover `docs/design/hicasso/**` (`exclude_docs`), so it is not nominated. `check_doc_slugs.py` does cover it, and was proven to have teeth on *this file*: a bad intra-page anchor was appended to the edited paragraph, grep-confirmed present at `:77` **before** the exit code was read, and the checker went red —

```
1 broken anchor link(s) found:
  BROKEN ANCHOR: docs\design\hicasso\draft-guide\02-views-and-reads.md:77 -> #g02-no-such-anchor-here
```

— then reverted, grep-confirmed absent, and green again.

**Tables hand-counted**, because nothing validates them. Troubleshooting: header `| Symptom | What went wrong | Fix |` = **3 columns**, delimiter `|---|---|---|` = 3, and all **9** body rows (7 pre-existing + 2 new) = 3 cells each. Not settled yet: header = **2 columns**, delimiter = 2, both surviving rows = 2 cells each. No cell contains a `|`.

Closes rf2-2rtt6.110.
