### PR TITLE
docs(hicasso): three studio figures say what the lane now prints (rf2-8smbe)

### DIFF
--- a/docs/design/hicasso/production-server-arm.md
+++ b/docs/design/hicasso/production-server-arm.md
@@ -687,15 +687,22 @@ note. All five sites now measure `Buffer.byteLength(s, 'utf8')`, and the bake
 checks each manifest column against `fs.statSync` of the file it just wrote, so
 a column that disagrees with its own fixture now refuses instead of baking.
 
-Two things are deliberately unchanged. The SHA-256 never needed repair — it is
-computed with an explicit `'utf8'` encoding in `driver.cjs`'s `sha256`, so every
-digest row here was always a function of bytes. And the one byte count quoted from the
-corpus — X1(a)'s **3,101** — does **not** come from the manifest: it comes from
-the spike witness's own `report!` payload, which `rf2-2rtt6.114` left alone. It
-therefore still carries the UTF-16 caveat, and is still used here only as an
-identity claim (render #1 equals render #2), never as a size. Repairing it would
-move a published figure and is a decision rather than a chore; it is carried on
-the follow-up bead with the rest of the lane's `(count s)` byte claims.
+One thing never needed repair. The SHA-256 is computed with an explicit `'utf8'`
+encoding in `driver.cjs`'s `sha256`, so every digest row here was always a
+function of bytes.
+
+The one byte count quoted from the corpus — X1(a)'s **3,060** — does **not**
+come from the manifest: it comes from the spike witness's own `report!` payload,
+which `rf2-2rtt6.114` left alone. **`rf2-2rtt6.121` has since repaired that
+payload as well, so the UTF-16 caveat on this figure is discharged rather than
+outstanding** (2026-08-06, `rf2-8smbe`). The witness now publishes
+`lane/utf8-bytes`, a shared `TextEncoder` helper rather than a second
+`Buffer.byteLength` site — those arms also compile to a browser build, where
+`Buffer` is not reachable — with `fs.statSync` used at the sites that really are
+Node. The figure moved **3,101 → 3,060** as it did so, and both halves of that
+move are separated in the witness's own dated addendum: `+18` from the ruler, and
+`−59` because the document itself drifted after `952a3f2024`. It is still used
+here only as an identity claim (render #1 equals render #2), never as a size.
 
 ## 7. What the spike corpus licenses, and what it does not
 

--- a/docs/design/hicasso/studio/ssr-spike-witness.md
+++ b/docs/design/hicasso/studio/ssr-spike-witness.md
@@ -105,10 +105,11 @@ independent things moved it, and separating them is the point of this note.
   `report!` to publish `lane/utf8-bytes` where it had published `count`, which
   answers UTF-16 code units rather than bytes. Every corpus title on this screen
   carries an em dash, so the same document is **3,042 code units and 3,060
-  bytes**. That +18 is exactly the gap `rf2-2rtt6.114` derived on this same
-  document from the other side of the wire — `Buffer.byteLength` in the bake,
+  bytes**. That +18 is exactly the gap `rf2-2rtt6.114` derived on this document
+  from the other side of the wire — `Buffer.byteLength` in the bake,
   cross-checked against `fs.statSync` of the file it wrote — so two unrelated
-  instruments agree on the size of the error.
+  instruments agree on the size of the error. The gap survived the drift below
+  because the drift removed no em dash.
 - **The document changed, by −59.** `3,101` was the honest `count` of the
   document as it stood at the producing commit, and `rf2-2rtt6.114` read the
   same document at 3,101 code units / 3,119 bytes. `861ac3a059` (`rf2-2rtt6.91`)

--- a/docs/design/hicasso/studio/ssr-spike-witness.md
+++ b/docs/design/hicasso/studio/ssr-spike-witness.md
@@ -50,7 +50,7 @@ compared byte-for-byte and then hashed.
 
 | Quantity | Value |
 |---|---|
-| `dogfood-snapshot` document | 3,101 bytes |
+| `dogfood-snapshot` document | 3,060 bytes |
 | SHA-256, render #1 and #2 | `a510149b92f08901f83b516e0f644d348fa5ee6ecafccca3b5ad80ebb53fa681` |
 | Two different per-request frame ids | yes (asserted) |
 
@@ -96,6 +96,36 @@ and the §X5 passage below that reports both pages taking `83b865f8`:
 
 The sentence above stands as written: this page was not the repair of the
 instrument. The repair was `rf2-2rtt6.91`'s, and it has landed.
+
+**Addendum, 2026-08-06 — the X1(a) size row now reads 3,060 bytes; it read
+3,101, and that figure was not wrong when it was written (`rf2-8smbe`).** Two
+independent things moved it, and separating them is the point of this note.
+
+- **The ruler changed, by +18.** `rf2-2rtt6.121` repaired this witness's
+  `report!` to publish `lane/utf8-bytes` where it had published `count`, which
+  answers UTF-16 code units rather than bytes. Every corpus title on this screen
+  carries an em dash, so the same document is **3,042 code units and 3,060
+  bytes**. That +18 is exactly the gap `rf2-2rtt6.114` derived on this same
+  document from the other side of the wire — `Buffer.byteLength` in the bake,
+  cross-checked against `fs.statSync` of the file it wrote — so two unrelated
+  instruments agree on the size of the error.
+- **The document changed, by −59.** `3,101` was the honest `count` of the
+  document as it stood at the producing commit, and `rf2-2rtt6.114` read the
+  same document at 3,101 code units / 3,119 bytes. `861ac3a059` (`rf2-2rtt6.91`)
+  then removed the ` data-rf-render-hash="…"` attribute from the app root and
+  the `:render-hash` key from the payload, and five further commits have touched
+  the render path since `952a3f2024`. So the row was superseded by a real change
+  to what is being measured, not corrected for an error in the measuring.
+
+**What this means for the digests in this section, which are NOT re-published
+here.** A document whose byte length moved is a different document, so the
+SHA-256 rows above and below — and X1(b)'s canonical-DOM size — were taken on
+the pre-drift document and no longer reproduce at HEAD. The size row is repaired
+here because `rf2-2rtt6.121` ruled it a units defect and named the replacement.
+Re-taking the digests is a different job: every row on this page is pinned to
+`952a3f2024`, so new digests would need a new producing commit and a re-run of
+the browser rows beside them. That is carried on `rf2-zn7pj`, and until it lands
+the size row is the only quantity here measured at HEAD.
 
 ## X1(b) — canonical-DOM parity
 

--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -186,7 +186,12 @@ magnitude must clear to be one.
   and the canonical-DOM gate (attribute names sorted) proves it rather than this
   sentence: **6 non-control arms across 3 segments, byte-identical, 27,224
   bytes.** The keystroke witness is a controlled field over 100 boundaries,
-  9,117 bytes, identical across all six.
+  **9,320 bytes**, identical across all six. *(2026-08-06, `rf2-8smbe`: this
+  read `9,117` — the figure the published run measured, when the form had **one**
+  field. `rf2-0qj9w` later took it to four, and the rebooked window in
+  [§3.5](#35-the-rebooked-window-which-refuses-in-the-same-two-places-rf2-0qj9w-2026-08-04)
+  reports the four-field form's canonical DOM at 9,320 B. The `M1` figure beside
+  it is unaffected — that page carries no form — and is unchanged at 27,224.)*
 - **B/E/Q stamp**: `B = 300` boundaries, `E = 300` boundary-query edges (one
   read each), `Q = 300` unique live query keys — so **Q = E**, fan-out 1, the
   mandatory distinct-query regime. The keystroke witness is `B = 101`,


### PR DESCRIPTION
Three published figures had drifted from what their drivers print. Each is corrected against a measurement or an on-page publication, never against reasoning, and each carries its provenance rather than a silent overwrite.

## Site 1 — `ssr-spike-witness.md`, X1(a)'s determinism table: **3,101 → 3,060 bytes**

MEASURED at HEAD, not taken from the brief:

```
node scripts/compile-node-test.cjs node-test out/node-test.js   # exit 0, 2159 files, 71.82s
node out/node-test.js --test=re-frame.bench.hicasso.ssr.spike-cljs-test   # exit 0

;; HICASSO SSR SPIKE X1a {:row "dogfood-snapshot", :sha256 "23734116…", :bytes 3060, …}
```

**Where 3,101 came from.** It was not "somewhere else again" — it was the honest `(count document)` of this document at the page's producing commit `952a3f2024`, and `rf2-2rtt6.114` independently read the same document at 3,101 code units / 3,119 bytes. **Two things moved it, and the addendum separates them:**

- **+18, the ruler.** `rf2-2rtt6.121` swapped `count` for `lane/utf8-bytes`; every corpus title carries an em dash. Same gap `rf2-2rtt6.114` derived from the other side of the wire.
- **−59, the document.** `861ac3a059` (`rf2-2rtt6.91`) removed the ` data-rf-render-hash="…"` attribute from the app root and the `:render-hash` payload key. Five further commits have touched the render path since `952a3f2024`.

**A finding the bead did not anticipate: the page's SHA-256 rows are stale too.** A byte length that moved −59 with the ruler held constant is a different document, so the digests no longer reproduce (measured: X1(a) is `23734116…`, published `a510149b…`). They are **NOT** re-published here — every row on the page is pinned to `952a3f2024`, so new digests need a new producing commit and a re-run of the browser rows beside them. The addendum states this plainly and points at **`rf2-zn7pj`** (filed, P2).

## Site 2 — `production-server-arm.md`, the Node entry's byte accounting

Both false clauses retired: the figure no longer *"therefore still carries the UTF-16 caveat"*, and the repair is no longer deferred to a follow-up bead — `rf2-2rtt6.121` shipped it, using the shared `TextEncoder` helper `lane/utf8-bytes` rather than a second `Buffer.byteLength` site (those arms also compile to a browser build), with `fs.statSync` at the sites that really are Node. The quoted figure follows site 1 to **3,060**. `Two things are deliberately unchanged` became `One thing never needed repair`, since only the SHA-256 clause survives.

## Site 3 — `the-candidates-clock.md` §3: **9,117 → 9,320 bytes**

Not the units fix, and **the page already contradicted itself** — §3.5 publishes 9,320 B for `keystroke` as a whole-run canonical-DOM gate.

**The `kb-fields-n` 1→4 attribution holds, established from §7's own blob pin rather than assumed.** In `clock_views.cljs` blob `7e48dbc0b3a974cd61a5c61e606333848877a31f` — the instrument §7 names for the published run — `:draft` is a scalar string, `kb-form` holds one `[kb-field {}]`, `:p0/draft` takes no index, and `kb-elements` is `(+ 3 (* 3 n))`. At HEAD `kb-fields-n` is 4, `:p0/draft` is indexed as `[:p0/draft i]`, and `kb-elements` is `(+ 2 kb-fields-n (* 3 n))`. Timeline: 9,117 published 2026-08-01 → `bacb5dc4db` took the form to four fields 2026-08-03 → the 2026-08-04 re-take printed 9,320 and updated §3.5 but not §3. `M1`'s 27,224 is unaffected (that page carries no form) and is unchanged.

**Not fixed here, filed instead as `rf2-uu81y` (P3):** the same bullet list stamps `B = 101, E = 101, Q = 101` from that one-field form. §3.5's census implies 104, but B/E/Q is a stamp the driver prints — correcting it from the census would be derived rather than read off a run, which is the exact defect class this thread is about.

## Idiom followed, per page

Checked per page rather than imposed:

| page | its idiom | followed |
|---|---|---|
| `ssr-spike-witness.md` | `**Addendum, YYYY-MM-DD — …**` beside the passage (one already at 2026-08-05) | new dated addendum; original 3,101 preserved and explained |
| `production-server-arm.md` | in-place revision naming the bead — this passage was already revised that way for `rf2-2rtt6.114`, heading included | revised in place, `rf2-2rtt6.121` and the date named inline |
| `the-candidates-clock.md` | dated subsections (§3.4, §3.5); no inline-addendum idiom | short parenthetical dated note in the bullet, citing §3.5 as the source |

EP-0009 rule 3 satisfied on all three: the superseded figure survives as history in every case.

## Quality gates

| gate | exit | note |
|---|---|---|
| `python scripts/check_doc_slugs.py` | **0** | ran to completion |
| `sh scripts/test-fast-pr.sh` | **0** | ran to completion, not terminated |

Classification line printed by the spine, not predicted:

```
gate root: /c/Users/miket/code/re-frame2-worktrees/studiofigs-8smbe
=== fast PR spine: docs=true jvm=false node=false (classified) ===
```

**`mkdocs build --strict` is NOT nominated** — `exclude_docs` keeps `design/hicasso/**` out of the built site, so it would exit 0 having verified nothing.

**Mutation proof for the slug checker.** The one new anchor in this PR is site 3's `[§3.5](…)`. Broke it, grep-confirmed the mutation was on disk *before* reading any exit code, then read the code:

```
$ grep -n "THIS-ANCHOR-DOES-NOT-EXIST-8smbe" docs/design/hicasso/studio/the-candidates-clock.md
192:  [§3.5](#35-…-rf2-0qj9w-THIS-ANCHOR-DOES-NOT-EXIST-8smbe)

$ python scripts/check_doc_slugs.py
1 broken anchor link(s) found:
  BROKEN ANCHOR: docs\design\hicasso\studio\the-candidates-clock.md:192 -> …
MUTATED_SLUGS_EXIT=1
```

Reverted; tree clean; re-run exit 0. The checker demonstrably covers this tree.

**Tables hand-verified, since nothing validates them.** All 43 table blocks across the three files parsed and column-counted; **0 ragged**. The edited table (`ssr-spike-witness.md` X1(a), lines 51–55) is **5 rows × 2 columns** — header, separator, 3 data rows — and this PR changes one cell's content, not the structure. Sites 2 and 3 are prose-only edits and add no table.

`git grep -n 'Users/miket'` over `docs/` — no matches.

Net line delta: **+54 / −11** across three files (`git diff --stat origin/main...HEAD`).

Closes `rf2-8smbe`.
