### PR TITLE
bench: which published rows predate the lane-cache clear (rf2-t84ee)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/bench/lane_cache.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/lane_cache.cjs
@@ -110,6 +110,15 @@
 // Both are inside the instruments' own round-to-round ranges, so a renaming
 // delta is not something a retained-heap row can see.
 //
+// THE SAME A/B ON THE CLOCK IS NOT EVIDENCE EITHER WAY, and is reported rather
+// than dropped. `b6_prod_run.cjs` over its two bundles exits 0 both times and
+// passes its parity gate both times, but two bundles mean two runs and this
+// studio's clock method interleaves arms WITHIN a round precisely because a
+// loaded box drifts between them. It duly did: the second run's interpreted W1
+// reads `[2.68-10.21]` against the first's `[2.75-4.32]`, so the means part
+// company while every range overlaps. A clock A/B across runs cannot separate
+// an artefact from the box, and nothing above rests on one.
+//
 // AND THE CONTROL THAT MAKES THAT LEGIBLE: a build warm over ITSELF is
 // byte-identical — the ladder built twice with no clear between compiles 0 the
 // second time and emits the same sha256. "Warm" is not the fault; "warm over a

--- a/implementation/freehand/test/re_frame/freehand/bench/lane_cache.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/lane_cache.cjs
@@ -69,6 +69,53 @@
 // 4,075 bytes. A reproduction command a studio page publishes should not emit
 // a different bundle depending on what the reader ran an hour ago.
 //
+// ## What the rows published BEFORE the clear are worth — rf2-t84ee
+//
+// The `hicasso-bench` lane got this call on 2026-07-31. The seven
+// `freehand-release` riders did not get it until `448d368bb9` on 2026-08-06,
+// so every row those seven have published was measured without it. Whether any
+// one run was warm over a SIBLING is operator shell history and cannot be
+// recovered. Whether the fault could have reached that row CAN be, and was:
+// each arm built once from a cleared cache and once with a sibling warm ahead
+// of it, at `5a08b14a29`, then loaded in headless Chromium.
+//
+//   arm             cold           warm over a sibling            loads?
+//   reads_ladder     649,251 B      649,251 B  (spine_ablation)    yes
+//                                   649,140 B  (b6_prod, b7)       NO
+//   spine_ablation   655,896 B      655,896 B  (reads_ladder)      yes
+//                                   655,770 B  (b6_prod, b7, …)    NO
+//   b7               824,837 B      824,837 B  (b6_prod)           yes
+//   b6_prod          841,215 B      841,215 B  (b7)                yes
+//   b8               813,777 B      813,572 B                      yes
+//   b10_prod         786,778 B      786,591 B                      yes
+//   b6_profile     3,413,752 B    3,411,573 B                      yes
+//
+// EVERY arm's bundle changes, and BOTH cases are real — which one you get
+// depends on what ran before, not on which arm you are. The loud one is
+// self-limiting BY CONSTRUCTION rather than by luck: every driver in this lane
+// waits on its own `*_READY`/`*_DONE` global raced against `sentinel.cjs`, and
+// a bundle that raises `Cannot read properties of undefined (reading 'd')`
+// before its entry runs sets no global at all, so it cannot reach a table.
+//
+// The quiet one is Closure renaming and nothing else — `b7`'s two bundles are
+// the same LENGTH, 4.03% of their bytes differ, and the first divergence is a
+// variable name in the `closure_uid_` preamble. **It does not move a reading.**
+// `reads_ladder_run.cjs` and `b7_run.cjs --only heap`, each run unchanged over
+// both of its own bundles, same arms, same rounds, same controls, exit 0 and
+// zero unverified mounts on all four:
+//
+//   ladder, Reagent      B/read 947 -> 948   R=0 shell 431 -> 430
+//   b7, reader A         worst arm moves 1 B/boundary of 244..4,303 (0.15%)
+//
+// Both are inside the instruments' own round-to-round ranges, so a renaming
+// delta is not something a retained-heap row can see.
+//
+// AND THE CONTROL THAT MAKES THAT LEGIBLE: a build warm over ITSELF is
+// byte-identical — the ladder built twice with no clear between compiles 0 the
+// second time and emits the same sha256. "Warm" is not the fault; "warm over a
+// SIBLING" is. A driver invoked twice in a row — which is how the ladder took
+// its two substrate pages — was never at risk.
+//
 // Rejected, with reasons, so the next reader does not re-litigate them:
 //
 //   * A build id per arm. Six hot-zone, sequenced edits to


### PR DESCRIPTION
Closes `rf2-t84ee`. **Nothing needs correcting, and no studio page, dataset, arm,
threshold or exit code is touched.** The diff is the lane's own record of the
answer, added where its cache rule already lives (`lane_cache.cjs`).

`rf2-t4j7c` gave the seven `freehand-release` riders `resetLaneBuildCache` at
`448d368bb9`, **2026-08-06 04:04 AUSEST**. Every row those seven had published
was therefore measured without it. `rf2-t84ee` asked whether any of them landed
in the *quiet* band — a bundle that differs from the one the driver meant to
build but still runs.

## The question that could be answered, and the one that could not

Whether any particular historical run was warm **over a sibling** is operator
shell history and is not recoverable. Whether the fault could have reached that
row is, so that is what was measured: each arm built once from a cleared cache
and once with a sibling warm ahead of it, then loaded in headless Chromium. All
figures below are at `5a08b14a29` + this branch, every verification build cold.

| arm | cold | warm over a sibling | loads? |
|---|---:|---:|---|
| `reads_ladder` | 649,251 B / 105 compiled | 649,251 B (over `spine_ablation`) | **yes** |
| | | 649,140 B (over `b6_prod`, `b7`) | **NO** |
| `spine_ablation` | 655,896 B / 105 | 655,896 B (over `reads_ladder`) | **yes** |
| | | 655,770 B (deeper chain) | **NO** |
| `b7` | 824,837 B / 149 | 824,837 B (over `b6_prod`) | yes |
| `b6_prod` | 841,215 B / 147 | 841,215 B (over `b7`) | yes |
| `b8` | 813,777 B / 148 | 813,572 B | yes |
| `b10_prod` | 786,778 B / 130 | 786,591 B | yes |
| `b6_profile` | 3,413,752 B / 148 | 3,411,573 B | yes |

**Every arm's bundle changes, and both cases are real** — which one you get
depends on what ran before, not on which arm you are. The bead's premise that
the loud case is self-limiting holds, and holds *by construction* rather than by
luck: every driver in the lane waits on its own `*_READY`/`*_DONE` global raced
against `sentinel.cjs`, and a dead bundle sets no global at all. The dead ones
raise `Cannot read properties of undefined (reading 'd')` before their entry runs
and expose no globals; the cold ones reach `LADDER_READY` / `ABL_READY`.

**Two controls make the rest legible.** A cleared-cache build is deterministic —
`reads_ladder` built cold on three separate occasions gives 649,251 B and
sha256 `fae288ec…` every time. And **a build warm over ITSELF is byte-identical**
(second build: 0 compiled, same sha256). *Warm* is not the fault; *warm over a
sibling* is — so a driver invoked twice in a row, which is how the ladder took
its two substrate pages, was never at risk.

## Which published rows feed a graduation verdict, and what they replay at

Two of the seven produce rows that `docs/design/hicasso/validation.md` states its
gates in, so they were checked first.

- **`reads_ladder_run.cjs`** → `reads-per-boundary-heap-ladder.md` §§1–5. The
  per-read gate table's **K3 line, 943 B/read**, the shell budget row's named
  shapes (Reagent ~418–428 B, UIx ~208 B) and graduation win condition (4)'s
  *"named paper path toward 943 B"* are all its. §6 onward is `p0_run.cjs`, a
  `hicasso-bench` rider that has had the clear since 2026-07-31.
- **`spine_ablation_run.cjs`** → `uix-spine-per-read-decomposition.md`, the
  2,774 B/read cross-check under the UIx line.
- `b6_prod_run.cjs` / `b6_profile_run.cjs` → `bulk-rerender-where-the-time-goes.md`,
  which `hd-002-adjudication.md` and validation.md's W1 carry-over cite.
- `b7_run.cjs` → `freehand-vs-reagent-memory.md`; `b8_run.cjs` →
  `freehand-vs-reagent-allocation.md`; `b10_prod_run.cjs` →
  `two-clock-operating-envelope.md`. No inbound gate citation.

**And the ladder and the ablation were measured in the same worktree.** The
ladder's §§1–5 were authored as `09ec4e6b3c` and the decomposition's confirmation
run as `fa09c5ad7a`, both on `worker/bench-audit-cluster`, **six minutes apart on
2026-07-31** — one `.shadow-cljs/builds/freehand-release`, two `:init-fn`s, five
days before the clear existed. That pairing is not the loud one: built in either
order, each emits a bundle the same **length** as its cold one, differently
renamed, **that runs**. So the highest-exposure driver in the lane is squarely in
the quiet band and the bead's question is live rather than moot.

### Replayed cold

`reads_ladder_run.cjs`, `LADDER_SUBSTRATES=reagent` (the substrate the K3 line is
drawn from, through the driver's own documented seam — the published run used the
same seam), six rounds, exit 0, 0 unverified of 93:

| | published 2026-07-31 | replayed cold 2026-08-06 | |
|---|---:|---:|---:|
| **B/read — the K3 gate line** | **943** [935–944] | **947** [945–948] | +0.42% |
| first-read increment | 1,137 [1,125–1,141] | 1,140 [1,126–1,156] | +0.26% |
| fitted intercept | 397 | 397 [383–418] | 0 |
| **R=0 shell — the budget row** | **428** [421–434] | **431** [420–441] | +0.70% |

`b7_run.cjs --only heap`, defaults unchanged (6 rounds, 10 roots, snapshot on),
exit 0, 0 unverified of 56, three positive controls ok, arm-order **reportable**:

| above the floor | published 2026-07-27 | replayed cold | |
|---|---:|---:|---:|
| `storm` UIx | 251 [248–255] | 250 | −0.4% |
| `storm` Reagent | 410 [406–416] | 412 | +0.5% |
| `reactive` Reagent | 1,037 [1,035–1,039] | 1,034 | −0.3% |
| `storm` **Freehand** | 2,430 [2,417–2,450] | **2,003** | **−17.6%** |
| `reactive` **Freehand** | 4,346 [4,332–4,361] | **4,059** | **−6.6%** |

**The two rows that moved are the two rows that page told the next reader to
re-take.** Its Provenance names `rf2-wxrrp` (`e5cf299fc2`) as having merged while
the run was in flight and *"not in these numbers"*, and says whoever next touches
the instrument should re-take the two Freehand arms first. Every arm on a
substrate the tree did not move reproduces inside 0.5%, nine days later. The
ruler moved; the artefact did not.

*(Subsidiary, because a reader may otherwise suspect the cache of it: the ladder's
§7 anchor table records the UIx sub-free boundary at 208 B against
`freehand-vs-reagent-memory.md`'s 251 B, −17.1%, and attributes it to the two
witnesses differing. The b7 side of that comparison replays cold at **250 B**, so
the published 251 is not a build artefact and the page's explanation stands.)*

### The quiet band, priced

Same tree, same driver, same arms, same rounds, same controls — **only the
artefact differs.** The build step is short-circuited so each run reads the
archived bundle already in its `out/` directory.

| `reads_ladder_run.cjs` | cold bundle | warm-over-`spine_ablation` bundle | Δ |
|---|---:|---:|---:|
| B/read | 947 [945–948] | 948 [946–948] | **+1 B** |
| R=0 shell | 431 [420–441] | 430 [420–444] | −1 B |
| first-read increment | 1,140 | 1,137 | −3 B |
| fitted intercept | 397 | 395 | −2 B |
| B/boundary @ R=3 (Curve A) | 3,189 | 3,188 | −1 B |
| exit / verification | 0 · 0 unverified of 93 | 0 · 0 unverified of 93 | |

| `b7_run.cjs --only heap`, reader A | cold bundle | warm bundle | Δ |
|---|---:|---:|---:|
| `storm` floor | 244 | 244 | 0 |
| `storm` Freehand | 2,247 | 2,248 | +1 |
| `storm` Reagent | 656 | 655 | −1 |
| `storm` UIx | 494 | 494 | 0 |
| `reactive` floor | 244 | 244 | 0 |
| `reactive` Freehand | 4,303 | 4,302 | −1 |
| `reactive` Reagent | 1,278 | 1,277 | −1 |
| exit / verification / controls | 0 · 0 of 56 · ok | 0 · 0 of 56 · ok | |

**Worst movement across both instruments: 1 byte per boundary, 1 byte per read.**
Against published ranges of ±0.7% that is not a signal. The delta is Closure
renaming and nothing else — `b7`'s two bundles are the **same length**, 4.03% of
their bytes differ, and the first divergence is a variable name in the
`closure_uid_` preamble.

### What is NOT established

The same A/B on the **clock** is reported rather than dropped, because it is not
evidence either way. `b6_prod_run.cjs` over its two bundles exits 0 and passes its
parity gate both times, but two bundles mean two runs, and this studio's clock
method interleaves arms *within* a round precisely because a loaded box drifts
between them. It duly did — the second run's interpreted W1 reads [2.68–10.21]
against the first's [2.75–4.32], so the means part company while every range
overlaps. A cross-run clock A/B cannot separate an artefact from the box. Nothing
in the verdict rests on one; the heap axis is where the bead's affected pages
publish, and it is settled.

## Verdict

**Answer to the bead: (a) — record it and close.** No row is withdrawn, no figure
is re-published, and no re-take is owed. The loud case cannot publish, by
construction. The quiet case is real for the whole lane, including the pairing
that demonstrably happened, and it moves a retained-heap reading by at most one
byte.

## Quality gates

| gate | result |
|---|---|
| `sh scripts/test-fast-pr.sh` | **exit 1** — classification line quoted below |
| `npm run lint:js` (root `package.json`) | exit 0 |
| `node --test …/bench/lane_cache_wiring.test.cjs` | exit 0 — 23 pass, 0 fail (the rider roster is still exactly seven) |
| `node --check …/bench/lane_cache.cjs` | exit 0 |
| `reads_ladder_run.cjs` × 2 (cold bundle, warm bundle) | exit 0, exit 0 |
| `b7_run.cjs --only heap` × 2 | exit 0, exit 0 |
| `b6_prod_run.cjs` × 2 | exit 0, exit 0 |
| 14-build cold/chain matrix + 8 pair/control builds | every build exit 0 |
| `git grep -n 'Users/miket'` over the diff | no match |

**The spine exits 1, and not on anything in this diff.** Its classification line,
verbatim:

```
FAIL per-ns test isolation
repro: cd implementation && node scripts/check-per-ns-isolation.cjs
```

Three CLJS namespaces are red when run alone and green in the consolidated
bundle — `re-frame.views-current-component-cljs-test`,
`re-frame.story.open-in-editor-ownership-cljs-test` and
`re-frame.story.play.presence-real-clock-cljs-test`, each exit 1 on module load —
and the gate states its own diagnosis: they pass together only because a sibling
left an installed adapter behind. **This diff is one comment block with no
executable line and nothing that can reach a CLJS namespace**, and CI on this PR
is **50 pass / 35 skipping / 0 fail**. Filed as `rf2-v8561` rather than left in a
log. Every other spine phase was green, including JVM core at 1,288 tests /
8,857 assertions / 0 failures.

**Diff scope:** one comment block in
`implementation/freehand/test/re_frame/freehand/bench/lane_cache.cjs`. No
executable line changes; `resetLaneBuildCache` is untouched. Nothing under
`data/`, `docs/design/hicasso/**`, `tools/**`, `implementation/subs/**`,
`spec/**`, `scripts/**` or `.github/**` is edited.
