### PR TITLE
docs(hicasso): the taught theming sample survives a fresh app-db (rf2-2rtt6.133)

### DIFF
--- a/docs/design/hicasso/draft-guide/06-theming.md
+++ b/docs/design/hicasso/draft-guide/06-theming.md
@@ -81,7 +81,7 @@ visibility come free.
 
 ```clojure
 (rf/reg-sub :theme/current
-  (fn [db _query] (:theme/current db)))
+  (fn [db _query] (:theme/current db :light)))   ;; unset reads as :light
 
 (rf/reg-event :theme/choose
   (fn [{:keys [db]} [_ theme]] {:db (assoc db :theme/current theme)}))
@@ -89,6 +89,19 @@ visibility come free.
 
 App-db holds the *choice*. It does not hold the tokens, and it does not hold the
 part maps.
+
+**The default belongs in the sub, not in each reader.** A fresh app-db has made no
+choice, so a bare `(:theme/current db)` reads `nil`, and `nil` is then what every
+bridge below has to survive — starting with `name`, which throws on it and
+[takes the page down from a root view](09-when-a-view-throws.md). One extra
+argument makes the read total and states the fallback once. `:light` needs no rule
+of its own: `:root` in layer 1 *is* the light theme, so a `[data-theme="light"]`
+that matches nothing leaves it in force.
+
+An app that restores a remembered choice dispatches `:theme/choose` from
+[`:initial-events`](01-getting-started.md), which lands before first paint — so the
+default paints only when nobody has chosen, never as a flash in front of a late
+choice.
 
 ## Bridging the choice to the DOM
 
@@ -227,6 +240,7 @@ structural tests can see less of. Honest trade, stated once.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
+| Blank page on first load, console shows `Doesn't support name:` | Nobody had chosen a theme, the sub read `nil`, and `(name nil)` threw at the root | Give the sub a default, as layer 3 does |
 | The theme keyword changes in app-db and nothing on screen changes | No bridge is wired — app-db holds the choice; the cascade keys off a DOM attribute | Wire option A or B above; the event alone does nothing to the document |
 | Theme switch re-renders the whole app | Option A, with the themed content spliced in as a plain call rather than an `[app {}]` vector | Put the content behind a boundary (children or a direct `[app {}]`), or use option B |
 | A time-travel rewind shows the old theme | Option B — the attribute was asserted by an effect, so it is not derived from the state you rewound | Expected under B; it is the price named above |


### PR DESCRIPTION
Guide 06's layer-3 subscription read `(:theme/current db)`. On a fresh app-db —
before any `:theme/choose` has run, which is every first paint and every server
render that was not seeded — that returns `nil`, and option A's bridge then calls
`(name nil)`, which throws in ClojureScript. A throw in a root view unmounts the
whole tree, so the taught sample blanks the page on the state the app starts in.

## The defect is real, and both limbs are measured

Compiled and run under the repo-pinned ClojureScript 1.12.145, with the
subscription body exactly as the chapter writes it:

| app-db | `(:theme/current db)` | `(name …)` |
|---|---|---|
| `{}` (fresh) | `nil` | throws `Doesn't support name: ` |
| after `:theme/choose :dark` | `:dark` | `"dark"` |

Nothing in the chapter seeds the key, and `:initial-events` was not mentioned in
it at all, so `nil` is reachable at first paint by the chapter's own text. On the
client this reads as a blank page (guide 09: *"Nothing caught it — React unmounts
the root by default"*); on the server the render that produces the response is the
one that throws.

## The default goes in the subscription

`:theme/current` is the reader's own sub, written in this chapter — it appears
nowhere in `implementation/`, `tools/` or `spec/` — so this is a guide-only fix
and needs no product change.

Three repairs were on the table: default in the sub, default at each reader
(`(name (or (sub …) :light))`), or a boot event that seeds the key. The sub wins,
and the repo already voted: the worked pilot app that exercises this exact pattern
spells it the same way, defaulting inside its `reg-sub` for `:acme.invoice/theme`
in `implementation/freehand/test/re_frame/freehand/pilot_field.cljc` and putting
the value straight onto `data-theme`. Defaulting in the sub makes every consumer
total instead of repairing one call site, states the fallback once next to the
choice, and leaves option A's sample as the clean spelling a reader should copy.

The boot event is not rejected, it is relocated. Seeding at boot cannot be the
answer to `nil`, because a fixture, a second frame, or a snapshot restore that
skips `:initial-events` puts the crash straight back. What `:initial-events`
genuinely owns is a *remembered* choice arriving before first paint instead of
flashing in after it, and the chapter now says so — one sentence, in layer 3,
where it serves both bridges. Option B's own "boot needs its own hand" bullet
stays, because B's obligation is the larger one: the initial event must also carry
the effect.

One clause records why `:light` needs no CSS rule of its own: `:root` in layer 1
*is* the light theme, so a `[data-theme="light"]` matching nothing leaves it in
force. And one troubleshooting row names what the reader actually sees, which is a
blank page plus an obscure console string worth pasting into a search box.

## Quality gates

| Gate | Result |
|---|---|
| `python scripts/check_doc_slugs.py` | exit **0** |
| `sh scripts/test-fast-pr.sh` | exit **0**, classified `docs=true jvm=false node=false` |
| CLJS semantics probe, cljs 1.12.145, `-t node` | ran; table above |

`mkdocs build --strict` is **not** nominated: `exclude_docs` keeps
`design/hicasso/` out of the site, so it would exit 0 having verified nothing.
`check_doc_slugs.py` is the gate that reaches this tree, and it was
mutation-proved rather than trusted. Pointing the new `09-when-a-view-throws.md`
link at a non-existent anchor produced `BROKEN ANCHOR … 06-theming.md:96` and exit
**1**; pointing the new `01-getting-started.md` link at a non-existent file
produced `BROKEN TARGET … 06-theming.md:102` and exit **1**. Both mutations were
grep-confirmed present in the file before the exit code was read, and the restored
file returns to exit 0. The checker demonstrably reaches both lines this PR adds.

**Nothing validates the tables**, so both were hand-counted. Troubleshooting:
header, separator and 8 body rows, every one of them 3 cells — the new row
included, and it carries no pipe inside a cell. Not settled yet: header, separator
and 7 body rows, every one 2 cells, untouched.

The sample itself cannot be executed: there is no `implementation/hicasso/`
package, as the chapter's own draft banner says, so `re-frame.hicasso/defview` and
`sub` are spellings with no runtime yet. What the fix turns on is CLJS semantics,
and that was run rather than recalled.

Net **+15 / −1**, one file.

## Left alone deliberately

Option A's memo prose does **not** lean on the superseded "every minted head"
rule. It rests on `app` being a head `defview` mints, in both the `children` and
the direct-`[app {}]` spellings, which is exactly what the narrowed rule says; the
plain-call caveat and the matching troubleshooting row are consistent with it. No
change needed.

Option B's tradeoff still says *"nothing in the product says an effect can [reach
that node] today"*, which the 108 pricing page shows is now wrong twice over. That
sentence belongs to the 108 guide rewrite, which also owns the "Which one?"
section and the first "Not settled yet" row, and it is already named there. Left
untouched to keep this PR conflict-free against it.
