### PR TITLE
fix(tools): the remaining byte labels count bytes (rf2-2rtt6.132)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/context_redaction.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/context_redaction.cljc
@@ -98,17 +98,57 @@
 ;; Large-value heuristic
 
 (def ^:private default-large-char-cap
-  "A printed value longer than this many chars is elided as large even
-  when the schema did not mark it `:large?`. A defensive size guard so a
-  big unmarked slot cannot bloat (and leak its content into) the export.
-  Conservative — ordinary context values render well under this."
+  "A printed value longer than this many CHARACTERS is elided as large
+  even when the schema did not mark it `:large?`. A defensive size guard
+  so a big unmarked slot cannot bloat (and leak its content into) the
+  export. Conservative — ordinary context values render well under this.
+
+  Two units live side by side here, on purpose: this CAP is characters
+  (what the band paints), while the `:rf.size/large-elided` marker's
+  `:bytes` slot is UTF-8 bytes (the framework's wire vocabulary). The
+  cap's threshold therefore does not move under rf2-2rtt6.132 — nothing
+  that rendered inline before is elided now, and nothing that was elided
+  is admitted."
   512)
 
 (defn- printed-size
-  "The char length of `(pr-str v)` — the size the band would otherwise
-  render — used both for the large heuristic and the `:bytes` diagnostic."
+  "The CHARACTER length of `(pr-str v)` — UTF-16 code units, which is what
+  `count` answers on both hosts — i.e. how much TEXT the band would
+  otherwise render. This is the ruler the large heuristic uses, and
+  `default-large-char-cap` is named for it.
+
+  Characters, deliberately: the cap guards how much a chart band paints,
+  which is a count of glyphs on screen, not of octets on a wire. It is
+  the `:bytes` MARKER slot that must speak the framework's unit — see
+  `utf8-bytes` below (rf2-2rtt6.132)."
   [v]
   (count (pr-str v)))
+
+(defn- utf8-bytes
+  "UTF-8 BYTE length of `(pr-str v)` — the figure the `:rf.size/large-elided`
+  marker publishes, matching what `re-frame.elision`'s walker means by
+  `:bytes` so a machines-viz chip and a framework one report the same
+  quantity.
+
+  Until rf2-2rtt6.132 the marker's `:bytes` slot carried `printed-size`,
+  i.e. UTF-16 CODE UNITS under a byte name. That fails OPEN: the two
+  rulers agree exactly on ASCII, so the wrong expression printed the
+  right number and a green suite never noticed — until a context value
+  grew an em-dash or an emoji, at which point the published figure
+  under-reported by up to 3x (4x for astral code points).
+
+  `TextEncoder` and not `Buffer.byteLength`: this ns compiles into the
+  BROWSER viewer bundle (`:machines-viz-viewer`, and under `:advanced`),
+  where `Buffer` is not there; `^js` hints so `:advanced` cannot rename
+  the call. TextEncoder is UTF-8 BY DEFINITION and carries no encoding
+  argument a later edit could silently drop. Same helper shape as
+  `day8.re-frame2-xray.panels.epoch.format/pr-str-bytes` (rf2-2rtt6.131)."
+  [v]
+  (let [s (pr-str v)]
+    #?(:clj  (alength (.getBytes ^String s "UTF-8"))
+       :cljs (let [^js enc (js/TextEncoder.)
+                   ^js buf (.encode enc s)]
+               (.-length buf)))))
 
 (defn- value-type
   "Coarse type tag for the `:rf.size/large-elided` marker payload.
@@ -134,11 +174,17 @@
 
   Content-free: carries only the size diagnostic (`:bytes`/`:type`) and
   provenance (`:path`/`:reason`), never a content head, preserving the
-  export-safety property."
+  export-safety property.
+
+  `:bytes` is UTF-8 bytes (`utf8-bytes`), NOT the `printed-size`
+  characters the cap is measured in — the slot is the framework's wire
+  vocabulary and must mean what the framework means by it
+  (rf2-2rtt6.132). The two agree on ASCII and diverge on everything
+  else, which is precisely why the mismatch went unnoticed."
   [k v]
   {:rf.size/large-elided
    {:path   [k]
-    :bytes  (printed-size v)
+    :bytes  (utf8-bytes v)
     :type   (value-type v)
     :reason :schema}})
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/context_redaction_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/context_redaction_cljs_test.cljc
@@ -88,6 +88,81 @@
     (is (nil? (r/redact-context {} {})))))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-2rtt6.132 - TWO units, side by side, each honest about what it bounds.
+;;
+;; The marker's `:bytes` slot is the framework's wire vocabulary and now
+;; carries UTF-8 BYTES; the large heuristic's `large-char-cap` is what the
+;; band would PAINT and stays in CHARACTERS. Before this bead both were
+;; `(count (pr-str v))` - UTF-16 code units - so the published figure lied
+;; by up to 3x (4x on astral code points) while the cap was fine.
+;;
+;; ASCII is the fail-open condition: the two rulers agree there EXACTLY,
+;; so every ASCII fixture above measured the right number by accident.
+;; The fixture here is DISCRIMINATING - code units, code points and bytes
+;; are three different numbers - and is asserted so BEFORE it is used.
+;; Written as \uXXXX escapes so the source stays pure ASCII, and as a
+;; `.cljc` so BOTH hosts are proven: the JVM arm is `String.getBytes`,
+;; the CLJS arm is `TextEncoder`.
+
+(def ^:private utf8-discriminating-value
+  "Twenty U+2014 EM DASH (1 code unit / 1 code point / 3 UTF-8 bytes each)
+  followed by one ASTRAL U+1D11E (2 code units / 1 code point / 4 bytes)."
+  (str (apply str (repeat 20 "\u2014")) "\uD834\uDD1E"))
+
+(def ^:private ascii-control-value
+  "Same CODE-UNIT length as `utf8-discriminating-value`, pure ASCII."
+  (apply str (repeat 22 "x")))
+
+(defn- utf8-len [s]
+  #?(:clj  (alength (.getBytes ^String s "UTF-8"))
+     :cljs (let [^js enc (js/TextEncoder.)]
+             (.-length (.encode enc s)))))
+
+(defn- code-points [s]
+  #?(:clj  (.codePointCount ^String s 0 (count s))
+     :cljs (count (js/Array.from s))))
+
+(deftest redaction-byte-fixture-is-discriminating
+  (testing "code units, code points and UTF-8 bytes are three different numbers"
+    (is (= 22 (count utf8-discriminating-value)))
+    (is (= 21 (code-points utf8-discriminating-value)))
+    (is (= 64 (utf8-len utf8-discriminating-value))))
+  (testing "the ASCII control's two rulers agree exactly - the fail-open condition"
+    (is (= 22 (count ascii-control-value)))
+    (is (= 22 (utf8-len ascii-control-value)))))
+
+(deftest large-marker-bytes-counts-utf8-bytes-not-code-units
+  (testing "a schema-marked large value publishes UTF-8 bytes"
+    ;; `pr-str` wraps the string in two quote characters, so the printed
+    ;; form is 24 code units / 66 UTF-8 bytes. The old expression
+    ;; published 24; the slot means bytes, so it must publish 66.
+    (let [body (-> (r/redact-value :blob utf8-discriminating-value {:large #{:blob}})
+                   :rf.size/large-elided)]
+      (is (= 66 (:bytes body)) "UTF-8 bytes of the pr-str form")
+      (is (not= 24 (:bytes body)) "NOT the 24 UTF-16 code units of the same form")))
+  (testing "an ASCII value of the same code-unit length is unchanged by the correction"
+    (let [body (-> (r/redact-value :blob ascii-control-value {:large #{:blob}})
+                   :rf.size/large-elided)]
+      (is (= 24 (:bytes body)) "both rulers agree on ASCII, so this number never moved"))))
+
+(deftest large-char-cap-is-characters-and-did-not-move
+  ;; The correction is to the PUBLISHED figure only. Had the cap been
+  ;; converted too, this 400-character value (1,200 UTF-8 bytes) would
+  ;; have started eliding where it used to render inline - a live
+  ;; behaviour change on non-ASCII context. It does not.
+  (let [four-hundred-dashes (apply str (repeat 400 "\u2014"))]
+    (is (= 400 (count four-hundred-dashes)))
+    (is (= 1200 (utf8-len four-hundred-dashes)) "well over the 512 cap in BYTES")
+    (is (= four-hundred-dashes (r/redact-value :ctx four-hundred-dashes {}))
+        "under the 512-CHARACTER cap, so it still renders inline"))
+  (testing "the cap still fires on a genuinely long value"
+    (let [six-hundred (apply str (repeat 600 "x"))
+          out         (r/redact-value :ctx six-hundred {})]
+      (is (contains? out :rf.size/large-elided))
+      (is (= 602 (:bytes (:rf.size/large-elided out)))
+          "602 = 600 + two pr-str quotes, identical under either ruler on ASCII"))))
+
+;; ---------------------------------------------------------------------------
 ;; display-string — the content-FREE export-safe text
 
 (deftest display-string-redacted-is-content-free

--- a/tools/mcp-base/spec/cursor.md
+++ b/tools/mcp-base/spec/cursor.md
@@ -11,7 +11,7 @@ Per `spec/Principles.md` §Pagination and `spec/Tool-Pair.md` §Cursor paginatio
 
 `cursor` owns:
 
-- `max-cursor-bytes` const (**1024**) — hard ceiling on a cursor token's character length.
+- `max-cursor-chars` const (**1024**) — hard ceiling on a cursor token's character length.
 - `b64-encode` / `b64-decode` — the base64 codec, resolving to `java.util.Base64` (JVM) / `js/Buffer` (CLJS) via reader-conditional.
 - `parse-limit-arg` — the `:limit` clamp (`default` and `max` per-consumer).
 - `encode-cursor` / `decode-cursor` — opaque codec around the consumer's payload map.
@@ -26,9 +26,11 @@ Per `spec/Principles.md` §Pagination and `spec/Tool-Pair.md` §Cursor paginatio
 
 ## Surface
 
-### `max-cursor-bytes` — const, 1024
+### `max-cursor-chars` — const, 1024
 
-Hard ceiling on the cursor token's character length. Cursors are short opaque tokens (a base64'd EDN map of a handful of scalar slots); anything longer is rejected before parsing as a cheap DoS / malformed guard. 1 KB is far past any legitimate cursor.
+Hard ceiling on the cursor token's character length — UTF-16 code units, which is what `count` answers on both hosts. Cursors are short opaque tokens (a base64'd EDN map of a handful of scalar slots); anything longer is rejected before parsing as a cheap DoS / malformed guard. 1,024 characters is far past any legitimate cursor.
+
+**Characters, deliberately** (rf2-2rtt6.132). This const was named `max-cursor-bytes` until that bead, while its guard was — and remains — `(> (count s) …)`. It was relabelled rather than converted to UTF-8 bytes: the guard runs *before* any decode, to bound **parse** cost, which scales with the characters the reader walks rather than with the bytes the token occupied on a wire this process never saw; and a well-formed cursor is `b64-encode`d, hence pure ASCII, where the two rulers agree exactly. So the units can only diverge on a non-ASCII token, and every non-ASCII token is `::malformed` regardless — refused by `decode-canonical-b64` for a reason wholly independent of this cap. The cap's *unit* is therefore not observable through `decode-cursor`; the name was the only thing that could be wrong. Pinned by `cursor_test/decode-cursor-cap-is-characters-and-the-unit-is-unobservable`.
 
 ### `b64-encode s` — string → base64 string
 
@@ -55,7 +57,7 @@ Decode an opaque base64 cursor back to its EDN payload map.
 Returns:
 
 - `nil` — the cursor arg is absent (nil / undefined) or blank. The caller treats this as "start from the beginning" (offset 0 / head).
-- `::malformed` — the cursor exists but is not a well-formed, `valid?`-passing payload map: it failed to base64/EDN-decode, was a **noncanonical Base64 alias** (see [§Canonical Base64 enforcement](#canonical-base64-enforcement)), carried a tagged literal, decoded to more than one EDN form, exceeded `max-cursor-bytes`, or failed the consumer's `valid?` predicate. Callers treat `::malformed` like a stale cursor — drop it and restart.
+- `::malformed` — the cursor exists but is not a well-formed, `valid?`-passing payload map: it failed to base64/EDN-decode, was a **noncanonical Base64 alias** (see [§Canonical Base64 enforcement](#canonical-base64-enforcement)), carried a tagged literal, decoded to more than one EDN form, exceeded `max-cursor-chars`, or failed the consumer's `valid?` predicate. Callers treat `::malformed` like a stale cursor — drop it and restart.
 
 `valid?` is the consumer's payload-shape predicate. Story validates `:v`, natural `:offset`/`:total`, and a string `:sig`. Pair requires a present, non-nil `:after-id` of any EDN-printable type because epoch ids are opaque.
 
@@ -88,7 +90,7 @@ The raw host decoders do not enforce this, and they diverge:
 - `js/Buffer.from … "base64"` (CLJS) **silently drops** characters outside the standard alphabet — `ez!!p2…` decodes as if the `!!` were absent — whereas `java.util.Base64/getDecoder` (JVM) **throws** on them. So the alphabet-alias case alone was host-dependent: the same corrupted token was `::malformed` on story-mcp (JVM) but accepted on pair-mcp (CLJS).
 - **Both** hosts ignore non-zero **trailing pad bits**, so alternate pad-bit spellings (`Zg==`, `Zh==`, `Zi==` all decode to `"f"`) alias one logical token on both runtimes.
 
-`decode-canonical-b64` normalises this with **one shared rule**: decode with the raw `b64-decode`, then require the token to equal `b64-encode` of the decoded bytes — a round-trip against the local encoder, which is the sole source of every legitimate cursor spelling. Any inserted/appended non-alphabet character, extra/invalid padding, or alternate pad-bit spelling re-encodes to a **different** token and is rejected as `::malformed` **before** EDN parsing, **identically on CLJ and CLJS**. The round-trip is strictly stronger than a lexical alphabet/padding regex, which would still admit the alternate pad-bit spellings. The pre-decode `max-cursor-bytes` cap still runs first, and the `nil`/blank, tagged-literal, one-form, `map?`, and consumer `valid?` behaviours are unchanged. Pinned in `cursor_test/decode-cursor-rejects-noncanonical-base64-aliases` and its CLJS mirror `cursor-rejects-noncanonical-base64-aliases-cljs`.
+`decode-canonical-b64` normalises this with **one shared rule**: decode with the raw `b64-decode`, then require the token to equal `b64-encode` of the decoded bytes — a round-trip against the local encoder, which is the sole source of every legitimate cursor spelling. Any inserted/appended non-alphabet character, extra/invalid padding, or alternate pad-bit spelling re-encodes to a **different** token and is rejected as `::malformed` **before** EDN parsing, **identically on CLJ and CLJS**. The round-trip is strictly stronger than a lexical alphabet/padding regex, which would still admit the alternate pad-bit spellings. The pre-decode `max-cursor-chars` cap still runs first, and the `nil`/blank, tagged-literal, one-form, `map?`, and consumer `valid?` behaviours are unchanged. Pinned in `cursor_test/decode-cursor-rejects-noncanonical-base64-aliases` and its CLJS mirror `cursor-rejects-noncanonical-base64-aliases-cljs`.
 
 ## Tagged-literal rejection
 

--- a/tools/mcp-base/src/re_frame/mcp_base/cursor.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cursor.cljc
@@ -66,8 +66,8 @@
   CHARACTERS, deliberately, and the name says so since rf2-2rtt6.132 — it
   read `max-cursor-bytes` while the guard was, and remains, `(> (count s)
   …)`. Renaming it rather than converting it to UTF-8 bytes is the
-  correct repair for three reasons that were already true and one that
-  settles it:
+  correct repair, for two reasons that were already true and a third
+  that settles it:
 
     - the guard runs BEFORE any decode, to bound PARSE cost, and parse
       cost scales with the characters the reader walks, not with the

--- a/tools/mcp-base/src/re_frame/mcp_base/cursor.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cursor.cljc
@@ -29,7 +29,8 @@
   ## What is parameterised vs fixed
 
   - The base64 codec, the tagged-literal-rejecting EDN reader, the
-    1 KB size cap, and the `::malformed` sentinel are FIXED here.
+    1,024-CHARACTER size cap, and the `::malformed` sentinel are FIXED
+    here.
   - The cursor SHAPE is the consumer's — `decode-cursor` takes a
     `valid?` predicate so each server validates its own payload map
     while sharing the codec + recovery flow.
@@ -55,11 +56,33 @@
   #?(:cljs (:require [cljs.reader]))
   #?(:clj (:import (java.util Base64))))
 
-(def ^:const max-cursor-bytes
-  "Hard ceiling on a cursor token's character length. Cursors are short
-  opaque tokens (a base64'd EDN map of a handful of scalar slots);
-  anything longer is rejected before parsing as a cheap DoS / malformed
-  guard. 1 KB is far past any legitimate cursor."
+(def ^:const max-cursor-chars
+  "Hard ceiling on a cursor token's CHARACTER length — UTF-16 code units,
+  which is what `count` answers on both hosts. Cursors are short opaque
+  tokens (a base64'd EDN map of a handful of scalar slots); anything
+  longer is rejected before parsing as a cheap DoS / malformed guard.
+  1,024 characters is far past any legitimate cursor.
+
+  CHARACTERS, deliberately, and the name says so since rf2-2rtt6.132 — it
+  read `max-cursor-bytes` while the guard was, and remains, `(> (count s)
+  …)`. Renaming it rather than converting it to UTF-8 bytes is the
+  correct repair for three reasons that were already true and one that
+  settles it:
+
+    - the guard runs BEFORE any decode, to bound PARSE cost, and parse
+      cost scales with the characters the reader walks, not with the
+      bytes the token occupied on some wire this process never saw;
+    - a well-formed cursor is `b64-encode`d, hence pure ASCII, where code
+      units and UTF-8 bytes agree exactly;
+    - so the two rulers can only diverge on a NON-ASCII token — and every
+      non-ASCII token is `::malformed` anyway, rejected by
+      `decode-canonical-b64` for a reason wholly independent of this cap.
+
+  That last point is decisive: the cap's UNIT is not observable through
+  `decode-cursor`, because the only inputs that could tell the two units
+  apart are refused either way. Converting would move no behaviour and
+  buy no honesty; the NAME was the only thing that could be wrong, and it
+  was."
   1024)
 
 ;; ---------------------------------------------------------------------------
@@ -298,7 +321,7 @@
                       `b64-encode` would emit), carried a tagged literal,
                       decoded to MORE THAN ONE EDN form (a trailing
                       object after the payload map),
-                      exceeded `max-cursor-bytes`, or its payload map
+                      exceeded `max-cursor-chars`, or its payload map
                       failed the consumer's `valid?` predicate. Callers
                       treat `::malformed` exactly like a STALE cursor —
                       drop it and restart.
@@ -322,7 +345,9 @@
     (not (string? s))
     ::malformed
 
-    (> (count s) max-cursor-bytes)
+    ;; CHARACTERS (UTF-16 code units — what `count` answers on both
+    ;; hosts), not UTF-8 bytes. See `max-cursor-chars`.
+    (> (count s) max-cursor-chars)
     ::malformed
 
     :else

--- a/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
+++ b/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
@@ -406,6 +406,39 @@
     (let [token (cursor/encode-cursor {:v 1 :after-id "x"})]
       (is (= :re-frame.mcp-base.cursor/malformed
              (cursor/decode-cursor token (fn [_] false))))))
+  (testing "the size cap is CHARACTERS on CLJS too - the same ruler the JVM applies"
+    ;; rf2-2rtt6.132 - this const was named `max-cursor-bytes` while its
+    ;; guard was, and remains, `(> (count s) ...)`: UTF-16 CODE UNITS on
+    ;; BOTH hosts. It was RELABELLED rather than converted, and this is
+    ;; the CLJS half of the cross-host pin (`cursor_test/decode-cursor-
+    ;; cap-is-characters-and-the-unit-is-unobservable` carries the JVM
+    ;; half). Fixtures are \uXXXX escapes so the source stays pure ASCII:
+    ;; U+2014 EM DASH is 1 code unit / 3 UTF-8 bytes, and the ASTRAL
+    ;; U+1D11E is 2 code units / 1 code point / 4 UTF-8 bytes.
+    (let [utf8-len (fn [s]
+                     (let [^js enc (js/TextEncoder.)]
+                       (.-length (.encode enc s))))
+          dashes   (apply str (repeat 400 "\u2014"))
+          astral   (apply str (repeat 400 "\uD834\uDD1E"))]
+      (is (= 400 (count dashes)))
+      (is (= 1200 (utf8-len dashes)) "the fixture discriminates: bytes /= code units")
+      (is (= 800 (count astral)) "the astral fixture is 2 code units per code point")
+      (is (= 1600 (utf8-len astral)))
+      ;; Both sit UNDER the 1,024-CHARACTER cap and OVER 1,024 UTF-8
+      ;; bytes, so a byte cap would refuse them at the guard where the
+      ;; character cap lets them through. Both are `::malformed` anyway -
+      ;; refused by `decode-canonical-b64` for a reason independent of the
+      ;; cap. The unit is therefore unobservable and the relabel complete.
+      (is (<= (count dashes) cursor/max-cursor-chars))
+      (is (> (utf8-len dashes) cursor/max-cursor-chars))
+      (is (= :re-frame.mcp-base.cursor/malformed (cursor/decode-cursor dashes any?)))
+      (is (<= (count astral) cursor/max-cursor-chars))
+      (is (> (utf8-len astral) cursor/max-cursor-chars))
+      (is (= :re-frame.mcp-base.cursor/malformed (cursor/decode-cursor astral any?)))
+      ;; And the boundary itself, in characters, on this host.
+      (is (= :re-frame.mcp-base.cursor/malformed
+             (cursor/decode-cursor (apply str (repeat (inc cursor/max-cursor-chars) "a")) any?))
+          "one CHARACTER over the cap => ::malformed, same 1,024 as the JVM")))
   (testing "tagged literals in the cursor are rejected"
     (let [evil (cursor/b64-encode "#js {:a 1}")]
       (is (= :re-frame.mcp-base.cursor/malformed

--- a/tools/mcp-base/test/re_frame/mcp_base/cursor_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cursor_test.clj
@@ -120,8 +120,54 @@
         (is (= ::cursor/malformed (cursor/decode-cursor alias pair?)))))))
 
 (deftest decode-cursor-oversize-is-malformed-before-parse
-  (let [oversize (apply str (repeat (inc cursor/max-cursor-bytes) "a"))]
+  (let [oversize (apply str (repeat (inc cursor/max-cursor-chars) "a"))]
     (is (= ::cursor/malformed (cursor/decode-cursor oversize offset-cursor?)))))
+
+(deftest decode-cursor-cap-is-characters-and-the-unit-is-unobservable
+  ;; rf2-2rtt6.132 - the cap was named `max-cursor-bytes` while the guard
+  ;; was `(> (count s) ...)`, i.e. UTF-16 CODE UNITS on both hosts. It was
+  ;; RELABELLED rather than converted, and this pins the reasoning so a
+  ;; later author does not "fix" it into UTF-8 bytes.
+  ;;
+  ;; The two rulers agree exactly on ASCII, so they can only diverge on a
+  ;; NON-ASCII token - and a non-ASCII token is `::malformed` regardless,
+  ;; because `decode-canonical-b64` refuses anything outside the base64
+  ;; alphabet. The cap's unit is therefore NOT observable through
+  ;; `decode-cursor`: both units answer `::malformed` on every input that
+  ;; could tell them apart. Converting would move no behaviour at all.
+  ;;
+  ;; Fixtures are \uXXXX escapes so the source stays pure ASCII, and are
+  ;; asserted DISCRIMINATING before they are used: U+2014 EM DASH is 1
+  ;; code unit / 1 code point / 3 UTF-8 bytes, and the ASTRAL U+1D11E is
+  ;; 2 code units / 1 code point / 4 UTF-8 bytes.
+  (let [utf8-len #(alength (.getBytes ^String % "UTF-8"))
+        dashes   (apply str (repeat 400 "\u2014"))
+        astral   (apply str (repeat 400 "\uD834\uDD1E"))]
+    (testing "the fixtures make code units, code points and bytes three different numbers"
+      (is (= 400 (count dashes)))
+      (is (= 400 (.codePointCount ^String dashes 0 (count dashes))))
+      (is (= 1200 (utf8-len dashes)))
+      (is (= 800 (count astral)) "the astral fixture is 2 code units per code point")
+      (is (= 400 (.codePointCount ^String astral 0 (count astral))))
+      (is (= 1600 (utf8-len astral))))
+    (testing "under the CHARACTER cap but over a hypothetical BYTE cap - still ::malformed"
+      ;; Both sit under 1,024 code units and over 1,024 UTF-8 bytes, so a
+      ;; byte cap would refuse them AT THE GUARD while the character cap
+      ;; lets them through to the decoder. Same verdict either way, which
+      ;; is exactly why the relabel is a complete fix.
+      (is (<= (count dashes) cursor/max-cursor-chars))
+      (is (> (utf8-len dashes) cursor/max-cursor-chars))
+      (is (= ::cursor/malformed (cursor/decode-cursor dashes offset-cursor?))
+          "non-base64 => ::malformed for a reason independent of the cap")
+      (is (<= (count astral) cursor/max-cursor-chars))
+      (is (> (utf8-len astral) cursor/max-cursor-chars))
+      (is (= ::cursor/malformed (cursor/decode-cursor astral offset-cursor?))))
+    (testing "every legitimate cursor is base64, where the two rulers agree exactly"
+      (let [token (cursor/encode-cursor {:v 1 :offset 25 :total 137
+                                         :sig "abc\u2014123\uD834\uDD1E"})]
+        (is (= (count token) (utf8-len token))
+            "a cursor whose PAYLOAD carries an em-dash and an astral glyph still encodes to a pure-ASCII token")
+        (is (<= (count token) cursor/max-cursor-chars))))))
 
 (deftest decode-cursor-failing-payload-predicate-is-malformed
   ;; Valid base64+EDN map, but the consumer's shape predicate rejects it.
@@ -156,15 +202,15 @@
 
 (deftest decode-cursor-at-inclusive-size-boundary-is-not-rejected
   ;; The size guard is a STRICT `>`
-  ;; (`(> (count s) max-cursor-bytes)` ⇒ ::malformed). This pins the
+  ;; (`(> (count s) max-cursor-chars)` ⇒ ::malformed). This pins the
   ;; INCLUSIVE side (a real cursor whose token length is
-  ;; `<= max-cursor-bytes`), complementing the oversize test that feeds
-  ;; `(inc max-cursor-bytes)` chars. A regression that flipped the guard
+  ;; `<= max-cursor-chars`), complementing the oversize test that feeds
+  ;; `(inc max-cursor-chars)` chars. A regression that flipped the guard
   ;; to `>=` would reject a legitimate at-or-near-cap cursor; this test
   ;; trips on that flip.
   ;;
   ;; Build the largest real, decodable cursor whose token length is
-  ;; still `<= max-cursor-bytes` (grow the payload's `:sig` to the cap).
+  ;; still `<= max-cursor-chars` (grow the payload's `:sig` to the cap).
   ;; Under strict `>` it round-trips; under `>=` (if the token landed
   ;; exactly on the cap) it would size-reject. The round-trip is the
   ;; load-bearing assertion.
@@ -173,21 +219,21 @@
         token-len (fn [n] (count (cursor/encode-cursor (grow n))))
         ;; largest sig length whose token is still within the cap.
         max-n     (loop [n 0]
-                    (if (> (token-len (inc n)) cursor/max-cursor-bytes)
+                    (if (> (token-len (inc n)) cursor/max-cursor-chars)
                       n
                       (recur (inc n))))
         payload   (grow max-n)
         token     (cursor/encode-cursor payload)]
-    (is (<= (count token) cursor/max-cursor-bytes)
+    (is (<= (count token) cursor/max-cursor-chars)
         "constructed cursor sits AT or just under the inclusive boundary")
-    (is (> (token-len (inc max-n)) cursor/max-cursor-bytes)
+    (is (> (token-len (inc max-n)) cursor/max-cursor-chars)
         "one more sig char would push the token over the cap — boundary is tight")
     (is (= payload (cursor/decode-cursor token offset-cursor?))
         "a cursor at the inclusive size boundary is NOT size-rejected (strict >)"))
   ;; Unconditional companion: a realistic small cursor is well under cap.
   (let [payload {:v 1 :offset 25 :total 137 :sig "abc123"}
         token   (cursor/encode-cursor payload)]
-    (is (< (count token) cursor/max-cursor-bytes)
+    (is (< (count token) cursor/max-cursor-chars)
         "a realistic cursor is well under the byte cap")
     (is (= payload (cursor/decode-cursor token offset-cursor?)))))
 

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab/schemas.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab/schemas.clj
@@ -73,7 +73,7 @@
      [:map
       {:closed true}
       [:type [:= :map]]
-      [:bytes :int]                                           ;; pr-str char count
+      [:bytes :int]                                           ;; pr-str UTF-8 byte estimate (rf2-2rtt6.132)
       [:keys [:sequential :any]]                              ;; required for maps
       [:keys-truncated? {:optional true} :boolean]            ;; only when clamped
       [:count  {:optional true} :int]                         ;; cardinality (scalar form)

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/summary.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/summary.cljs
@@ -44,7 +44,25 @@
   The estimate is still intentionally rough — the marker is consumed by
   agents for *planning* (\"is this slice worth drilling into?\"), not
   for precise budgeting. Agents needing a precise size measure their
-  drill-down result directly.")
+  drill-down result directly.
+
+  ## The unit is UTF-8 BYTES (rf2-2rtt6.132)
+
+  Approximate in MAGNITUDE, exact in UNIT. Until rf2-2rtt6.132 the
+  sampled per-entry size was `(count (pr-str sample))` — UTF-16 CODE
+  UNITS — under a slot the wire vocabulary names `:bytes`, the same
+  slot `{:rf.size/large-elided …}` carries. Code units equal UTF-8
+  bytes only for ASCII, which is what makes the mistake fail OPEN: on
+  an ASCII payload the wrong expression prints the right number and a
+  green suite never notices, until a slice grows an em-dash or an
+  emoji. The figure is PUBLISHED on the wire to an agent, so it is now
+  measured with `TextEncoder` — UTF-8 by definition, carrying no
+  encoding argument a later edit could silently drop. Sampling still
+  serialises exactly one entry, so the cost model is unchanged.
+
+  Correcting the unit can only ever RAISE the estimate (UTF-8 bytes are
+  never fewer than UTF-16 code units), and nothing in this server gates
+  on it — the marker is a planning hint, not a budget.")
 
 (def summary-keys-cap
   "Top-N keys included verbatim in a tree-summary marker. Above this,
@@ -71,29 +89,53 @@
 ;; value's), so the cost is `O(one-entry-depth)` — independent of N.
 ;; Floors keep tiny scalar entries from rounding to zero and preserve a
 ;; sensible order-of-magnitude shape for shallow collections.
+;;
+;; The unit is UTF-8 BYTES on every path here (rf2-2rtt6.132) — see the
+;; ns docstring for why `count`'s UTF-16 code units were the wrong ruler
+;; under a `:bytes` slot the wire vocabulary shares with
+;; `{:rf.size/large-elided …}`.
 ;; ---------------------------------------------------------------------------
+
+(defn- utf8-bytes
+  "UTF-8 byte count of `s`. `TextEncoder` is UTF-8 BY DEFINITION — it
+  takes no encoding argument a later edit could drop — and is a global
+  in Node (which is the only host this `:node-script` server runs on)
+  as well as in every browser. `^js` hints so `:advanced` cannot rename
+  the call. Same helper shape as
+  `day8.re-frame2-xray.panels.epoch.format/pr-str-bytes` (rf2-2rtt6.131)
+  and `re-frame.bench.hicasso.lane/utf8-bytes` (rf2-2rtt6.121)."
+  [s]
+  (let [^js enc (js/TextEncoder.)
+        ^js buf (.encode enc s)]
+    (.-length buf)))
 
 (def ^:const ^:private map-key-overhead-bytes
   "Per map-entry overhead for the key + `:`/space punctuation under
-  `pr-str`, on TOP of the sampled value size. ~16 chars for a typical
-  keyword key."
+  `pr-str`, on TOP of the sampled value size. ~16 BYTES for a typical
+  keyword key — keyword keys are ASCII in practice, where a byte and a
+  character are the same thing, so this constant needs no conversion;
+  only its prose was wrong (rf2-2rtt6.132)."
   16)
 
 (def ^:const ^:private coll-entry-floor-bytes
   "Floor for a sampled vector / set / seq entry — a bare scalar entry
-  (`1`, `:x`) prints to ~1-4 chars; floor at 8 to keep a sensible shape
+  (`1`, `:x`) prints to 1-4 bytes; floor at 8 to keep a sensible shape
   for shallow collections and avoid zero-byte estimates."
   8)
 
 (defn- sample-entry-bytes
-  "Serialised size of ONE sample value under `pr-str`, floored at
+  "UTF-8 byte size of ONE sample value's `pr-str` form, floored at
   `coll-entry-floor-bytes`. The single-entry `pr-str` is the whole cost
   of the sampled estimate — bounded by the entry's own depth, NOT by
-  the collection's `:count`. nil / empty sample ⇒ the floor."
+  the collection's `:count`. nil / empty sample ⇒ the floor.
+
+  BYTES, not `count`'s UTF-16 code units (rf2-2rtt6.132): the sampled
+  figure is multiplied up into the marker's `:bytes` slot and shipped to
+  an agent, and the two rulers agree only on ASCII."
   [sample]
   (if (nil? sample)
     coll-entry-floor-bytes
-    (max coll-entry-floor-bytes (count (pr-str sample)))))
+    (max coll-entry-floor-bytes (utf8-bytes (pr-str sample)))))
 
 (defn- approx-coll-bytes
   "Estimate the full-expansion byte cost of a collection: `count ×

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dedup_benchmark_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dedup_benchmark_test.cljs
@@ -53,7 +53,7 @@
     variance dominates): **1.4-1.5× compression** (28-31%
     reduction). Only the shared `:rf.trace/trigger-handler`
     subtree and `:dispatch-id` backbone collapse; per-event
-    uniqueness dominates the wire bytes.
+    uniqueness dominates the serialised payload.
   - **High-share replays** (the lazy-summary projection strips
     `:id` / `:time` envelope fields, leaving structurally-
     identical event subtrees across replays of a recurring
@@ -191,26 +191,42 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- measure
-  "Apply `base-dedup/dedup-value` to `payload`, count `pr-str` bytes before
-  and after, and return a measurement map for logging + assertion.
+  "Apply `base-dedup/dedup-value` to `payload`, count `pr-str` CHARACTERS
+  before and after, and return a measurement map for logging + assertion.
 
-  Returns `{:label .. :events .. :raw-bytes .. :deduped-bytes ..
+  Returns `{:label .. :events .. :raw-chars .. :deduped-chars ..
   :reduction-pct .. :ratio ..}` where `:ratio` is `raw/deduped`
-  (the 'Nx compression' the spec quotes)."
+  (the 'Nx compression' the spec quotes).
+
+  ## Characters, and why that is the honest name (rf2-2rtt6.132)
+
+  `(count (pr-str …))` answers UTF-16 CODE UNITS, on both hosts. These
+  two slots were called `:raw-bytes` / `:deduped-bytes` and printed with
+  a literal `B` suffix, which was untrue of the expression that produced
+  them — the same fail-open shape rf2-2rtt6.121 and rf2-2rtt6.131 swept.
+
+  They are RELABELLED rather than converted. Nothing here needs bytes:
+  the figures the spec quotes are `:ratio` and `:reduction-pct`, both
+  same-vs-same quotients in which the unit cancels exactly, so no
+  measured number in this file's ns docstring moves. The corpus is
+  machine-generated keywords, integers and ASCII strings, so a UTF-8
+  count would print the identical absolutes today — and would start
+  lying again the moment someone widened the corpus. A true value under
+  a true name is the fix that stays true."
   [label events payload]
-  (let [raw-bytes     (count (pr-str payload))
+  (let [raw-chars     (count (pr-str payload))
         wrapped       (base-dedup/dedup-value payload true)
-        deduped-bytes (count (pr-str wrapped))
-        ratio         (if (pos? deduped-bytes)
-                        (/ raw-bytes deduped-bytes 1.0)
+        deduped-chars (count (pr-str wrapped))
+        ratio         (if (pos? deduped-chars)
+                        (/ raw-chars deduped-chars 1.0)
                         0.0)
-        reduction-pct (if (pos? raw-bytes)
-                        (- 100.0 (* 100.0 (/ deduped-bytes raw-bytes 1.0)))
+        reduction-pct (if (pos? raw-chars)
+                        (- 100.0 (* 100.0 (/ deduped-chars raw-chars 1.0)))
                         0.0)]
     {:label         label
      :events        events
-     :raw-bytes     raw-bytes
-     :deduped-bytes deduped-bytes
+     :raw-chars     raw-chars
+     :deduped-chars deduped-chars
      :ratio         ratio
      :reduction-pct reduction-pct
      :wrapped       wrapped}))
@@ -219,8 +235,8 @@
   (str "[rf2-li2cw]"
        " " (:label m)
        "  events=" (:events m)
-       "  raw=" (:raw-bytes m) "B"
-       "  deduped=" (:deduped-bytes m) "B"
+       "  raw=" (:raw-chars m) " chars"
+       "  deduped=" (:deduped-chars m) " chars"
        "  ratio=" (.toFixed (:ratio m) 2) "×"
        "  reduction=" (.toFixed (:reduction-pct m) 1) "%"))
 
@@ -246,7 +262,7 @@
   width = lower shared-subtree density; wide cascade width = higher
   density). These represent the **raw trace-burst regime** — events
   with per-event unique `:id`, `:time`, and per-tag variance dominate
-  the wire bytes. The deduper's win is the shared
+  the serialised payload. The deduper's win is the shared
   `:rf.trace/trigger-handler` subtree and `:dispatch-id` backbone
   across same-cascade events."
   [{:label "100ev / cascade=8 / variety=8"   :events 100   :cascade-width 8  :variety 8}

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/path_slicing_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/path_slicing_test.cljs
@@ -142,6 +142,85 @@
   (is (= :set (-> (summary/tree-summary #{1 2 3}) :rf.mcp/summary :type)))
   (is (= :seq (-> (summary/tree-summary (list 1 2 3)) :rf.mcp/summary :type))))
 
+;; ---------------------------------------------------------------------------
+;; rf2-2rtt6.132 - the marker's `:bytes` slot counts UTF-8 BYTES.
+;;
+;; `sample-entry-bytes` was `(count (pr-str sample))` - UTF-16 CODE UNITS -
+;; multiplied up into a slot the cross-MCP wire vocabulary names `:bytes`,
+;; the same slot `{:rf.size/large-elided ...}` carries. The two rulers agree
+;; EXACTLY on ASCII, which is why the defect survived a green suite: every
+;; fixture above is ASCII, so the wrong expression printed the right number.
+;;
+;; The fixture below is DISCRIMINATING by construction - code units, code
+;; points and UTF-8 bytes are three different numbers - and is asserted so
+;; BEFORE it is used, so a future editor that ASCII-fies the source reds the
+;; anti-vacuity assertions rather than silently neutering the pin. It is
+;; written as \uXXXX escapes so this file stays pure ASCII.
+;;
+;; Both directions are pinned: the non-ASCII entry DIVERGES (the estimate
+;; nearly doubles), and an ASCII entry of the SAME code-unit length AGREES
+;; with what the old expression produced.
+;; ---------------------------------------------------------------------------
+
+(def ^:private utf8-discriminating-entry
+  "Three U+2014 EM DASH (1 code unit / 1 code point / 3 UTF-8 bytes each)
+  followed by one ASTRAL U+1D11E (2 code units / 1 code point / 4 bytes)."
+  "\u2014\u2014\u2014\uD834\uDD1E")
+
+(def ^:private ascii-control-entry
+  "Same CODE-UNIT length as `utf8-discriminating-entry`, pure ASCII - so
+  the two rulers must agree on it exactly."
+  "aaaaa")
+
+(defn- utf8-len [s]
+  (let [^js enc (js/TextEncoder.)]
+    (.-length (.encode enc s))))
+
+(deftest tree-summary-bytes-fixture-is-discriminating
+  ;; Anti-vacuity FIRST: if these stop holding, every assertion in
+  ;; `tree-summary-bytes-counts-utf8-bytes-not-code-units` measures nothing.
+  (let [e utf8-discriminating-entry]
+    (is (= 5 (count e)) "5 UTF-16 code units")
+    (is (= 4 (count (js/Array.from e))) "4 code points")
+    (is (= 13 (utf8-len e)) "13 UTF-8 bytes - three different numbers")
+    (is (= 5 (count ascii-control-entry)))
+    (is (= 5 (utf8-len ascii-control-entry))
+        "the ASCII control's rulers agree exactly - that is the fail-open condition"))
+  ;; And the printed form the estimator actually samples (quotes included).
+  (is (= 7 (count (pr-str utf8-discriminating-entry))))
+  (is (= 15 (utf8-len (pr-str utf8-discriminating-entry))))
+  (is (= 7 (count (pr-str ascii-control-entry))))
+  (is (= 7 (utf8-len (pr-str ascii-control-entry)))))
+
+(deftest tree-summary-bytes-counts-utf8-bytes-not-code-units
+  ;; All FOUR emit sites in `summary.cljs` - map / vector / set / seq.
+  ;;
+  ;; Sampled per-entry size is `(max 8 (utf8-bytes (pr-str sample)))`:
+  ;;   non-ASCII entry -> max(8, 15) = 15   (code units gave max(8, 7) = 8)
+  ;;   ASCII control   -> max(8,  7) =  8   (identical under either ruler)
+  ;; Maps add the 16-byte key overhead on top.
+  (let [bytes-of #(-> % summary/tree-summary :rf.mcp/summary :bytes)
+        e        utf8-discriminating-entry
+        a        ascii-control-entry]
+    (testing "vector"
+      (is (= 60 (bytes-of [e e e e])) "4 x 15 UTF-8 bytes")
+      (is (= 32 (bytes-of [a a a a])) "4 x the 8-byte floor - ASCII agrees"))
+    (testing "set"
+      (is (= 15 (bytes-of #{e})))
+      (is (= 8  (bytes-of #{a}))))
+    (testing "seq"
+      (is (= 15 (bytes-of (list e))))
+      (is (= 8  (bytes-of (list a)))))
+    (testing "map - the 16-byte key overhead plus the sampled value"
+      (is (= 31 (bytes-of {:k e})) "16 + 15")
+      (is (= 24 (bytes-of {:k a})) "16 + 8"))
+    (testing "the correction can only ever RAISE the estimate"
+      ;; UTF-8 bytes are never fewer than UTF-16 code units, so no slice
+      ;; that read as small before reads as smaller now. Nothing in this
+      ;; server gates on the figure, so no budget's direction moves.
+      (is (> (bytes-of [e e e e]) (bytes-of [a a a a]))
+          "same code-unit length, larger byte estimate"))))
+
 (deftest tree-summary-map-truncates-huge-key-lists
   ;; A 5k-entry map's key list alone would blow the cap. The summary
   ;; marker MUST stay bounded.


### PR DESCRIPTION
Closes rf2-2rtt6.132.

The bead names four sites carrying the rf2-2rtt6.121 / .131 shape — a value that
is `(count s)`, UTF-16 code units on both platforms, published or enforced under
a bytes name — and asks for a convert-vs-relabel judgement on each rather than a
patch. **Three of its four are inside this PR's fence; a fourth in-fence site the
bead does not name turned up in the sweep, so four sites are repaired here.** The
bead's site 4 and two more found by the sweep are outside `tools/**` and carry
forward on **rf2-2rtt6.135**.

## The four repaired sites

| Site | Call | Why |
|---|---|---|
| `mcp-base/cursor` `max-cursor-bytes` | **relabel** → `max-cursor-chars` | the guard is parse-cost, and the unit is not observable |
| `pair-mcp/tools/summary` `sample-entry-bytes` | **convert** | the figure is published on the wire in a `:bytes` slot |
| `pair-mcp/dedup_benchmark_test` `:raw-bytes` / `:deduped-bytes` | **relabel** → `-chars` | the quoted figures are ratios; the unit cancels |
| `machines-viz/chart/context-redaction` | **split** — convert the marker, relabel nothing else | the cap is honest about characters; the `:bytes` slot is not |

### 1. `max-cursor-bytes` → `max-cursor-chars` — the bead's call, and I agree

The bead had already made this one and gave three reasons: the docstring already
said "character length", the guard bounds *parse* cost (which scales with
characters), and a well-formed cursor is base64 and therefore ASCII. All three
hold. The sweep adds a fourth that settles it:

**The cap's unit is not observable through `decode-cursor`.** The two rulers agree
exactly on ASCII, so they can only diverge on a non-ASCII token — and every
non-ASCII token is `::malformed` regardless, refused by `decode-canonical-b64`
for a reason wholly independent of the cap. Both units return the same verdict on
every input that could tell them apart. Converting would move no behaviour at all;
the name was the only thing that could be wrong.

That reasoning is now in the const's docstring, in `spec/cursor.md`, and pinned by
`cursor_test/decode-cursor-cap-is-characters-and-the-unit-is-unobservable` — which
feeds 400 em-dashes (1,200 UTF-8 bytes) and 400 astral U+1D11E (1,600 bytes),
both **under** the 1,024-character cap and **over** it in bytes, and shows both
verdicts identical. `cljs_branches_cljs_test` carries the CLJS half, pinning the
same 1,024-character boundary on the other host.

Blast radius was narrower than the bead expected: `cursor.cljc`, `cursor_test.clj`,
the CLJS mirror and `spec/cursor.md`. Neither story-mcp nor pair-mcp references the
symbol.

### 2. `tools/summary.cljs` — convert (the bead's "worst of the four")

`sample-entry-bytes` was `(count (pr-str sample))`, multiplied up into the
`:rf.mcp/summary` `:bytes` slot at four emit sites (map / vector / set / seq).
It now measures UTF-8 bytes through a `TextEncoder`-based `utf8-bytes` helper —
UTF-8 by definition, no encoding argument a later edit can drop, `^js` hinted.

Convert rather than relabel, because the slot is shared **wire vocabulary**: the
pair spec defines it against "a precise byte count", and the same `:bytes` name
rides `{:rf.size/large-elided …}` on the same wire. Renaming the wire slot would
break the cross-server contract (the mcp-conformance `Summary` schema, `Tool-Pair.md`)
and diverge two slots that mean the same thing. The estimate is approximate in
**magnitude** — it is still one sampled entry × N, still `O(one-entry-depth)` —
and it should be exact in **unit**.

One stray comment in the conformance schema (`;; pr-str char count`) said the
opposite of what the spec says; corrected.

*Bead correction, minor:* the bead describes these as feeding a
`{:rf.size/large-elided …}` marker. They feed `{:rf.mcp/summary …}`. The "four emit
sites in this file" count is exactly right.

### 3. `dedup_benchmark_test.cljs` — relabel, as the bead ruled

`:raw-bytes` / `:deduped-bytes` → `:raw-chars` / `:deduped-chars`, and the literal
`B` suffix in `row-str` becomes ` chars`. Agreed with the bead: the figures the
spec quotes are `:ratio` and `:reduction-pct`, both same-vs-same quotients in
which the unit cancels exactly, so **no measured number in the ns docstring's
table moves**. The corpus is machine-generated keywords, integers and ASCII
strings, so a UTF-8 count would print identical absolutes today — and would start
lying the moment someone widened the corpus. Two prose "wire bytes" claims about
the same figures became "the serialised payload".

### 4. `machines-viz/chart/context_redaction.cljc` — not on the bead's list

Same shape, outside `.131`'s xray/story fence and not carried by `.132`.
`printed-size` was `(count (pr-str v))`, used for **two** different things:

- the `:bytes` slot of a real `{:rf.size/large-elided …}` marker — the framework's
  wire vocabulary, rendered to the operator by `display-string` and serialised
  into SVG / PNG / clipboard exports; and
- the `default-large-char-cap` (512) elision threshold.

These want **different units**, so this is a split rather than a single call. The
marker converts (new `utf8-bytes`, `.cljc`, `String.getBytes` on the JVM /
`TextEncoder` with `^js` hints in the browser viewer bundle, where `Buffer` is not
available). The **cap stays characters** and is untouched: it is already honestly
named `large-char-cap`, it guards how much text a chart band *paints*, and
`large-char-cap` is a caller-visible option key. Converting it would have started
eliding non-ASCII context that renders inline today — a live behaviour change for
no gain. `large-char-cap-is-characters-and-did-not-move` pins exactly that: a
400-character / 1,200-byte value still renders inline.

## No budget's direction changed

The correction is monotone-tightening by construction — UTF-8 bytes are never
fewer than UTF-16 code units — so nothing previously refused becomes admitted.
And in this PR nothing is refused differently at all: **not one of the four sites
is an enforcement gate on the corrected expression.** Sites 2 and 4's converted
figures are published-only (the summary marker is a planning hint; the machines-viz
marker is a display/export diagnostic), site 3 is a test log line, and site 1's
guard keeps the ruler it always had. No ruling is owed and none was taken.

## Mutation proofs — both directions, both hosts, non-ASCII

An ASCII-only test cannot see this bug, which is why it survived. Every fixture
is `\uXXXX`-escaped so the source stays pure ASCII, uses **U+2014** (1 code unit /
1 code point / 3 bytes) **and the astral U+1D11E** (2 units / 1 point / 4 bytes)
so code units, code points and bytes are three different numbers, and asserts its
own discriminating property **before** it is used.

| Mutation | Result |
|---|---|
| machines-viz marker `utf8-bytes` → `printed-size` | **2 failures, JVM** (`641 tests`) and **2 failures, CLJS** (`841 tests`) — same two assertions, both hosts |
| summary `utf8-bytes` → `count` | **5 failures** — all four emit sites (60→32, 15→8, 15→8, 31→24) plus the direction assertion |
| cursor fixture ASCII-fied (em-dash → `-`) | **2 failures** — the anti-vacuity assertions red, so the pin is live |
| restored | all green |

Opposite direction, unmutated: an ASCII control of the **same code-unit length**
produces the identical number under either ruler at every converted site (summary
vector 32, machines-viz marker 24, machines-viz 602-byte cap case) — which is the
fail-open condition itself, asserted rather than assumed.

## No dead platform arm

`.131` deleted story-mcp's unreachable `:cljs` arm on the principle that a phantom
host publishing a wrong number is worse than no second host. Applying the same
test here: `cursor.cljc`'s two arms are both live (story-mcp on the JVM, pair-mcp
on CLJS); `context_redaction.cljc`'s new reader conditional is live on both (the
JVM `:test` alias and the `machines-viz-node-test` build each run its `.cljc`
tests — proven by the mutation reddening both); `summary.cljs` and the benchmark
are CLJS-only by file type. **Nothing to delete.**

## Carried forward — rf2-2rtt6.135 (P2)

Three sites outside this fence, filed with the convert-vs-relabel reasoning and
the one genuine ruling identified:

1. **`skills/re-frame2-pair/preload/…/pure.cljc`** — the only remaining **live
   refusal gate** in the repo. `:queue-bytes` accumulates `(count (pr-str ev))`
   and `evict-oldest` drops events against `max-buffered-bytes` (default
   5,000,000). This is the one place the correction is **not** free: counting
   honestly makes the queue evict *sooner*, so either the cap converts and the
   default is re-derived, or the whole chain relabels. Three in-fence surfaces
   move in lockstep with that decision and were therefore left alone rather than
   half-fixed: the pair-mcp descriptor text (which today reads "cap in **BYTES**
   (pr-str **char** count)" — both units in one sentence, to an agent), the
   `003-Tool-Catalogue.md` `:queue-bytes` row, and `subscribe_test.cljs`'s
   deliberate parallel fixture of the runtime.
2. **`implementation/core/src/re_frame/elision.cljc` `pr-str-bytes`** — the exact
   CLJ/CLJS asymmetry `.131` repaired in xray and story-mcp, still standing in the
   **framework the tools imitate**: published on every `:rf.size/large-elided`
   marker and enforced against `:rf.size/threshold-bytes`. Xray's docstring claims
   parity with this walker; since `.131` that claim holds only on the JVM arm.
3. **`observation_render_law_drift_test.clj`** — the bead's site 4, still out of
   fence.

## Quality gates

All foreground to completion. Every exit code echoed.

| Gate | Exit |
|---|---|
| `scripts/test-fast-pr.sh` | `0` — `PASS fast PR spine`; classification `PLAN docs=true jvm=false node=true` |
| `npm run lint:js` (root) | `0` |
| `tools/mcp-base` JVM `clojure -M:test` | `0` — 277 tests / 948 assertions |
| `tools/mcp-base` CLJS `npm run test:cljs` | `0` — 37 tests / 239 assertions |
| `tools/re-frame2-pair-mcp` CLJS `npm test` | `0` — 1219 tests / 4322 assertions |
| `tools/machines-viz` JVM `clojure -M:test` | `0` — 641 tests / 2784 assertions |
| `tools/machines-viz` CLJS `npm run test:tools-machines-viz` | `0` — 841 tests / 3717 assertions |
| `tools/xray` JVM `clojure -M:test` | `0` — 1272 tests / 5919 assertions |
| `tools/story` JVM `clojure -M:test` | `0` — 1847 tests / 6824 assertions |
| `tools/story-mcp` JVM `clojure -M:test` | `0` — 308 tests / 1619 assertions |
| `npm run test:mcp-conformance` | `0` — all 6 gates green (6 live-server rows SKIP without `$SHADOW_CLJS_NREPL_PORT`); wire-vocab 100 tests / 1069 assertions |

**`tools/xray/spec/*` unchanged, because no file under `tools/xray/` is in this
diff** — `git diff --stat origin/main...HEAD` lists ten files across mcp-base,
pair-mcp, machines-viz and mcp-conformance, and none under `tools/xray/`.
`tools/mcp-base/spec/cursor.md` **is** updated in this PR, for the symbol rename
and the reasoning behind it.
