### PR TITLE
docs(hicasso): two studio stamps say what the drivers print (rf2-zn7pj, rf2-uu81y)

### DIFF
--- a/docs/design/hicasso/studio/ssr-spike-witness.md
+++ b/docs/design/hicasso/studio/ssr-spike-witness.md
@@ -73,23 +73,23 @@ byte digest separates them. **This is not a repair of the instrument** — the
 repair is a server *and* client contract and it is `rf2-2rtt6.91`'s. It is the
 reason X1(a) is stated as a SHA-256 over the document.
 
+**Erratum, 2026-08-06 — the heading of the addendum that follows is false, and
+its wording is left standing so that what was claimed stays legible
+(`rf2-zn7pj`).** It is false in a particular way worth naming. `rf2-2rtt6.91` did
+not merely leave the measurement alone: its `861ac3a059` removed the
+` data-rf-render-hash="…"` attribute from the app root, so the bead that addendum
+credits with keeping the figures live is the one that changed the document being
+hashed. Rewiring where the render hash is *read* keeps the hash column live and
+does nothing for a SHA-256 taken over bytes the markup no longer carries. Its
+first two bullets are unaffected and stand as written; the third does not, and
+carries its own note. Which quantities here are pre-drift, and why the digests
+cannot simply be recomputed, is the 2026-08-06 addendum further below.
+
 **Addendum, 2026-08-05 — `rf2-2rtt6.91` has closed (PR #7510); every figure on
 this page is unchanged and still reproduces.** The repair deliberately kept the
 measurement live, so this is a status correction and not a re-measurement. Three
 things, covering this rationale, the `:rf/render-hash` column in the table above,
 and the §X5 passage below that reports both pages taking `83b865f8`:
-
-**Erratum, 2026-08-06 — the claim in that heading is false, and its wording is
-left standing above so that what was claimed stays legible (`rf2-zn7pj`).** It is
-false in a particular way worth naming. `rf2-2rtt6.91` did not merely leave the
-measurement alone: its `861ac3a059` removed the ` data-rf-render-hash="…"`
-attribute from the app root, so the bead this addendum credits with keeping the
-figures live is the one that changed the document being hashed. Rewiring where
-the render hash is *read* keeps the hash column live and does nothing for a
-SHA-256 taken over bytes the markup no longer carries. The first two bullets
-below are unaffected and stand as written; the third does not, and carries its
-own note. Which quantities here are pre-drift, and why the digests cannot simply
-be recomputed, is the 2026-08-06 addendum below.
 
 - **The column is now a fact about the hash function, not about the wire.** An
   adoption-tier root — a compiled `re-frame.ui` root, a native UIx root, or a

--- a/docs/design/hicasso/studio/ssr-spike-witness.md
+++ b/docs/design/hicasso/studio/ssr-spike-witness.md
@@ -79,6 +79,18 @@ measurement live, so this is a status correction and not a re-measurement. Three
 things, covering this rationale, the `:rf/render-hash` column in the table above,
 and the §X5 passage below that reports both pages taking `83b865f8`:
 
+**Erratum, 2026-08-06 — the claim in that heading is false, and its wording is
+left standing above so that what was claimed stays legible (`rf2-zn7pj`).** It is
+false in a particular way worth naming. `rf2-2rtt6.91` did not merely leave the
+measurement alone: its `861ac3a059` removed the ` data-rf-render-hash="…"`
+attribute from the app root, so the bead this addendum credits with keeping the
+figures live is the one that changed the document being hashed. Rewiring where
+the render hash is *read* keeps the hash column live and does nothing for a
+SHA-256 taken over bytes the markup no longer carries. The first two bullets
+below are unaffected and stand as written; the third does not, and carries its
+own note. Which quantities here are pre-drift, and why the digests cannot simply
+be recomputed, is the 2026-08-06 addendum below.
+
 - **The column is now a fact about the hash function, not about the wire.** An
   adoption-tier root — a compiled `re-frame.ui` root, a native UIx root, or a
   Freehand root — emits no `:rf/render-hash` in its payload and stamps no
@@ -93,6 +105,10 @@ and the §X5 passage below that reports both pages taking `83b865f8`:
   digests over the hash were rewired to take it from `ssr-hash/render-tree-hash`
   directly rather than from the payload, precisely so this page and the
   server-arm dossier would keep reproducing after the entry stopped emitting.
+  **Erratum, 2026-08-06 (`rf2-zn7pj`):** true of the `:rf/render-hash` column,
+  false of the byte digests. The rewiring moved where the hash is read from; the
+  SHA-256 rows are taken over the document, and the same repair shortened the
+  document by 59 code units.
 
 The sentence above stands as written: this page was not the repair of the
 instrument. The repair was `rf2-2rtt6.91`'s, and it has landed.

--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -194,10 +194,19 @@ magnitude must clear to be one.
   it is unaffected — that page carries no form — and is unchanged at 27,224.)*
 - **B/E/Q stamp**: `B = 300` boundaries, `E = 300` boundary-query edges (one
   read each), `Q = 300` unique live query keys — so **Q = E**, fan-out 1, the
-  mandatory distinct-query regime. The keystroke witness is `B = 101`,
-  `E = 101`, `Q = 101`. Cache cardinality is part of the witness by ruling, and
+  mandatory distinct-query regime. The keystroke witness is `B = 104`,
+  `E = 104`, `Q = 104`. Cache cardinality is part of the witness by ruling, and
   a clock row stamps it for the same reason a heap row does: two arms at
-  different cardinalities are not the same experiment.
+  different cardinalities are not the same experiment. *(2026-08-06,
+  `rf2-uu81y`: the keystroke figures read `101` — the one-field form's, moved by
+  the same `rf2-0qj9w` change that took 9,117 → 9,320 above. The `104` is read
+  off a run rather than counted off this page: `clock_witness.cjs`'s `format`
+  stamps `100 grid cells + 4 fields = 104 layer-1 recomputes per keystroke on a
+  substrate arm`, over the census
+  [§3.5](#35-the-rebooked-window-which-refuses-in-the-same-two-places-rf2-0qj9w-2026-08-04)
+  reports. One edge per boundary, each on its own indexed key, so `Q = E = B`.
+  No line in this driver's output is labelled `B/E/Q` — that name is this
+  page's, for what the shape stamp and that census jointly say.)*
 - **Schedule**: 6 rounds × (4 warm-up + 10 samples) per arm per segment, arms in
   the shared guard's reflecting order, segment order rotating with the round.
 - **Verification**: every mount is read back against the arm's own element


### PR DESCRIPTION
Two studio stamps, each corrected from a reading rather than from its neighbours. One of the two beads closes; the other does not, and why it does not is most of this PR.

## `rf2-uu81y` — the keystroke B/E/Q stamp: 101 → 104, read off a run

`the-candidates-clock.md` §3 stamped the keystroke witness at `B = 101, E = 101, Q = 101` — the one-field form's figure, moved by the same `rf2-0qj9w` change that took 9,117 → 9,320 in the bullet directly above it.

**What the driver actually stamps.** A cold `HCLOCK_ONLY=keystroke` run of `clock_run.cjs` at HEAD prints:

```
;;   the witness states 100 grid cells + 4 fields = 104 layer-1 recomputes per
;;   keystroke on a substrate arm, and NONE on a floor arm. Exactly one field's
;;   value moves; all four are read back.
;;   ---- sub-recompute localisation (validation.md's per-keystroke budget) ----
;;   reagent-subs/reagent-subs    p0/cell x100, p0/draft x4
;;   uix-subs/uix-subs            p0/cell x100, p0/draft x4
;;   hicasso/hicasso              p0/cell x100, p0/draft x4
;;   (the six floor and control arms: no subscriptions at all)
```

104 is therefore **read, not inferred from §3.5's census**. The same run reprints two neighbours the bead flagged, and both hold unchanged, so neither was touched:

- `;; parity   6 non-control arms across 3 segments, canonical DOM IDENTICAL (9320 bytes)`
- `;; writes   0 unverified of 756`

The shipped adjudicator replayed over **both** retained datasets (`data/clock-0qj9w/run1.json` and `run2.json`, via `clock_witness.cjs`'s own `adjudicate` + `format`, nothing modified and nothing written) prints the identical 104 stamp, so the live reading and the retained runs agree.

### Two premises in the bead do not hold, and the note now says so

1. **`B/E/Q` is not a line this driver prints.** `clock_run.cjs` emits no such label — not at HEAD, and not at blob `22b53abe9e2fcf172dbb752ed0c2d56c4ec6869c`, the instrument §7 pins. `grep B/E/Q` over the whole 361-line run log returns nothing. The only `B/E/Q` stamp in the repository is `hd8_clock_run.cjs`'s hardcoded `B/E/Q = 300/300/300`, which belongs to a different driver and a different page. `B/E/Q` is this page's own name for what the shape stamp and the census jointly say, and the added note records that so the next reader does not go hunting for a line that was never there.
2. **`clock_readjudicate.cjs` cannot answer this.** It never reads `census` or `kbShape` — it computes ensemble ratios and the additive constant. The bead's suggested route to the figure does not exist.

Neither premise changes the answer, and the census-derived 104 the bead predicted is what the run stamps. The correction stands on the reading.

## `rf2-zn7pj` — the false global claim is fixed; the digests are not republished

**The claim.** The 2026-08-05 addendum asserts *"every figure on this page is unchanged and still reproduces"*. Measured cold at HEAD, that is false:

| quantity | page publishes | HEAD |
|---|---|---|
| X1(a) `dogfood-snapshot` SHA-256 | `a510149b…fa681` | `23734116…251dd` |
| X1(a)-mutation, seed-9 | `d7097b5d…2203e` | `50797b1e…b019c` |
| Conduit feed SHA-256 | `4308c288…` | `2ae24c07…3b165` |
| `dogfood-snapshot` document | 3,060 bytes | **3,060 bytes — reproduces** |
| `:rf/render-hash` | `83b865f8` | **`83b865f8` — reproduces** |

Three digests miss; the size row `rf2-8smbe` repaired and the shared hash both hold. That is an independent reproduction of the bead's own measurement.

**The sharper half, which the erratum names.** The addendum credits `rf2-2rtt6.91` with deliberately keeping the measurement live — and `861ac3a059`, verified as *"fix(hicasso): the interpreted root ships no render-hash (rf2-2rtt6.91)"*, is precisely the commit that removed ` data-rf-render-hash="…"` from the app root. The bead this addendum thanks for the figures surviving is the one that changed the document being hashed. Its third bullet's reasoning is right about the `:rf/render-hash` column — rewiring it to `ssr-hash/render-tree-hash` did keep that column live — and wrong about the byte digests, because moving where a hash is *read* does not restore bytes the markup no longer carries.

**Why nothing was republished.** Every row on the page is pinned to producing commit `952a3f2024`. Publishing HEAD digests under that pin would make the page look right while breaking the pin that makes it verifiable at all. An honest re-take needs:

1. **A nominated, durable producing commit.** A worker-branch SHA will not do — a rebase-merge mints a new landed SHA, the hazard `the-candidates-clock.md`'s own provenance table records ("*filled on merge … which is why the blob table below is the real pin*"). This page has no blob table, so it needs either one or a post-merge fill.
2. **A re-run of the four browser rows at that same commit** — X1(b)'s canonical DOM at 2,422 bytes, X2's 13/13/12/13 counts and its three mutation proofs, X4's 17 steps / 15 intents, X5's five zeros — via `npm run test:browser`, plus `adoption_witness_run.cjs` for X3. The page's whole contract is that every row was taken at one commit, so re-taking one row without the rest breaks it differently.

That is a measured pass, not a figure edit, and it is outside this PR's fence. **`rf2-zn7pj` stays open.** Only `rf2-uu81y` closes.

## Idiom followed, per page

Checked individually rather than imposed:

- **`the-candidates-clock.md`** uses an italic dated parenthetical appended to the bullet — exactly the form the neighbouring Witness bullet already carries for 9,117 → 9,320 (`*(2026-08-06, rf2-8smbe: …)*`). The new note matches it: `*(2026-08-06, rf2-uu81y: …)*`.
- **`ssr-spike-witness.md`** uses bold-led dated addenda (`**Addendum, 2026-08-05 — …**`, `**Addendum, 2026-08-06 — …**`) and carries no italic parentheticals anywhere, so the erratum is bold-led to match. Per EP-0009 rule 3 the original wording is **left standing** and marked, rather than rewritten — freeze meaning, not bytes.

**Deliberately not touched.** The page header's *"every figure reproduced, including X1(a)'s digest byte-for-byte"* is past tense and explicitly scoped to `952a3f2024` and `6f40304011`, so it is historically true; and the re-take rewrites that provenance pin anyway, so a note there would collide with `rf2-zn7pj`'s own work. `756` needed no edit — the live run reprints it.

Nothing under `data/`. No measurement method, arm, threshold, exit code or dataset changed. No `implementation/**`, `tools/**`, `spec/**`, `scripts/**`, `.github/**`, `draft-guide/**` or `production-server-arm.md`.

## One bead filed

**`rf2-moe9a`** (P3) — §3's *"Residue: zero on both censuses after every row"* is wrong about one integer, and always was. The driver prints `:lane {:body-children 2, …}`; `lane/residue` reads `document.body.childElementCount` and the harness serves `<div id="app"></div><script src="main.js"></script>`, so 2 is the floor and 0 is unreachable. It matters because `lane/residue`'s docstring makes a surviving container visible as a reading *against a baseline* — 3 where 2 was expected — and a reader holding "zero" as the criterion has the wrong baseline, which is the direction that gets a real leak explained away. Left for a separate judgement call rather than fixed here.

## Quality gates

| gate | exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_doc_slugs.py` (mutated) | **1** — mutation proof, see below |
| `sh scripts/test-fast-pr.sh` | **0** — run twice, second time on the final tree |
| `node scripts/compile-node-test.cjs node-test out/node-test.js` (cold) | **0** |
| `node out/node-test.js --test=re-frame.bench.hicasso.ssr.spike-cljs-test` | **0** — 3 tests, 10 assertions, 0 failures |
| `HCLOCK_ONLY=keystroke node …/clock_run.cjs` (cold) | **1** — expected, see below |
| `clock_witness.cjs` replay over `run1.json` + `run2.json` | **0** |

Spine classification line, reported rather than predicted:

```
=== fast PR spine: docs=true jvm=false node=false (classified) ===
```

The spine classified this diff docs-only, so the JVM and node phases did not run — which is also why the known local-only `per-ns test isolation` red in a worker worktree was never reached here. Nothing was chased.

**The clock driver's exit 1 is the documented one, not a regression.** It terminates with `[clock] FAILED: not every published bar can be ADJUDICATED on: keystroke … 3 of 3 published bars carry no band … UNADJUDICATED — this row's control burns a fixed 50 ms rather than doubling the page` and `[clock] REPORTABLE: none.` — which is precisely what §3.4 and §3.5 already publish about this row. Both long runs were detached and read at their own terminal markers; neither was terminated mid-flight.

**`mkdocs build --strict` is not nominated**: `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site, so it cannot gate this diff. `check_doc_slugs.py` does, and it ran.

**Mutation proof.** The edit adds a `§3.5` anchor link. Repointing it at `#35-zn7pj-mutation-proof-this-anchor-does-not-exist`, then grep-confirming the mutation had landed in the file **before** reading any exit code:

```
206:  [§3.5](#35-zn7pj-mutation-proof-this-anchor-does-not-exist)     <- grep exit 0
```

the checker exits **1** and names the line:

```
BROKEN ANCHOR: docs\design\hicasso\studio\the-candidates-clock.md:206
    -> #35-zn7pj-mutation-proof-this-anchor-does-not-exist
```

Reverted; clean tree; checker back to **0**. So the gate demonstrably reads the line this PR added.

**Tables, hand-counted, because nothing validates them.** The diff adds and removes **zero** table rows (`git show … | grep -E "^[+-]\s*\|"` returns nothing). All tables on both pages were counted anyway — header, separator and every data row compared for column count: `ssr-spike-witness.md` **12 tables, 0 mismatched**; `the-candidates-clock.md` **22 tables, 0 mismatched**.

**Net line delta: +28 / −3 = +25.**

The mayor's `implementation/node_modules` was 101 top-level / 2,933 files before and after — the worktree took its own real `npm ci` in both root and `implementation/`, so no junction was ever created and none needed removing.
