### PR TITLE
docs(hicasso): the residue criterion is one a reader can apply (rf2-moe9a)

### DIFF
--- a/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
+++ b/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
@@ -190,7 +190,12 @@ Seven runs, `6 × (4 warm-up + 10 samples)` per arm per segment — the publishe
 run 5 design, unchanged, so the two are comparable. Whole-run gates on all seven:
 **arm-order guard reportable on both clocks**, canonical DOM **identical**
 (27,224 bytes, 6 non-control arms, 3 segments), **0 unverified of 1,008** per row
-(756 on `keystroke`), residue zero on every counter, **0 page errors**.
+(756 on `keystroke`), residue back to baseline on every counter, **0 page
+errors**. `body-children` reads **2** throughout — the page's own `#app` and its
+script tag, constant, not residue — and every other counter is zero; a row
+reading 3 would be a container that survived its unmount *(2026-08-06,
+`rf2-moe9a`: this said ~~zero~~ on every counter, the same wrong baseline
+[the clock page](the-candidates-clock.md#3-the-design) carried)*.
 
 | row | `hicasso / reagent-subs`, raw `TaskDuration` | on `taskNet` | reportable runs | disposition |
 |---|---:|---:|---:|---|

--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -213,9 +213,18 @@ magnitude must clear to be one.
   arithmetic; every write is read back at both ends of the range it claims to
   have changed. **0 unverified of 1,008** on every row (756 on the keystroke
   row).
-- **Residue**: zero on both censuses after every row — the lane's
+- **Residue**: back to baseline on both censuses after every row — the lane's
   (`body-children`, `sub-entries`, `sub-ref-count`) and the candidate runtime's
-  own (`cells`, `cell-refs`, `boundaries`, `edges`, `entries`).
+  own (`cells`, `cell-refs`, `boundaries`, `edges`, `entries`). Every counter
+  reads zero except `body-children`, whose baseline is **2**: `lane/residue`
+  reads `document.body`'s attached element children, and the harness page has
+  two of its own — the `<div id="app">` and the `<script>`. **The criterion is
+  therefore 2, and a row that reads 3 is a container that survived its
+  unmount**, left standing as a page the next row would be measured on top of.
+  *(2026-08-06, `rf2-moe9a`: this read "zero on both censuses". `body-children`
+  is not zero on any row and cannot be — a reader holding zero as the criterion
+  reads a healthy run as already failing, which is the way round that explains a
+  real leak away.)*
 
 ### 3.1 Two instrument repairs, both forced by a control that refused
 


### PR DESCRIPTION
Closes `rf2-moe9a`.

`the-candidates-clock.md` §3's residue bullet stamped **"zero on both censuses
after every row"**. `body-children` is not zero on any row and *cannot* be:
`lane/residue` reads `document.body`'s attached element children, and
`clock_run.cjs`'s `serve` writes `<body><div id="app"></div><script
src="main.js"></script></body>`, so **2 is the floor for this harness on every
row** — and always was. This is a wording defect from when the page was written,
not a drift.

## Why it is worse than a wrong integer

`lane/residue`'s own docstring says a container whose arm survived its unmount
"shows up here as a page the NEXT row is measured on top of". That signal is a
**reading against a baseline** — 3 where 2 was expected. A reader holding
*"zero"* as the criterion has the wrong baseline and reads a healthy run as
already failing, which is the direction that gets a real leak explained away. A
pass condition that can never be met teaches the reader to dismiss the signal the
check exists to raise.

## Measured, not relayed

Cold live run at this branch's base (`origin/main` `dcf04a69ee`), fresh
`resetLaneBuildCache`, `:advanced`, `goog.DEBUG false`:

```
HCLOCK_ONLY=keystroke node implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs

;; residue  {:lane {:body-children 2, :sub-entries 0, :sub-ref-count 0},
             :arm1 {:cells 0, :cell-refs 0, :boundaries 0, :edges 0, :entries 0}}
```

Exit **1**, by design — `3 of 3 published bars carry no band ... UNADJUDICATED`,
`REPORTABLE: none`, which is what §3.4–3.5 publish. Every other whole-run gate
was clean in the same run: `0 unverified of 756`, canonical DOM identical at
**9,320 bytes** across all six non-control arms, arm-order guard **reportable on
both clocks**, `ctl-50ms` **PASS** on both the task and Event Timing arms, and
the recompute census reading `p0/cell ×100, p0/draft ×4` — the `9,320` and `104`
figures the page already carries, re-confirmed rather than re-stated.

The four other counters of the lane census and all five of the candidate
runtime's read exactly 0, so the old sentence was wrong about one integer of
eight — the one that carries the leak signal.

## The criterion as landed

> **The criterion is therefore 2, and a row that reads 3 is a container that
> survived its unmount**, left standing as a page the next row would be measured
> on top of.

Stated as baseline-plus-delta, which is what a reader can actually apply. **No
measurement changed** — the driver is untouched, and subtracting the scaffold in
`lane/residue` was rejected for exactly that reason.

## The same false criterion appeared once more

`git grep` for the *claim* rather than the line found one other site on the same
driver: `rows-re-adjudicated-on-the-corrected-clock.md` §4's whole-run gate list
said **"residue zero on every counter"**. Corrected in the form
`bulk-broad-re-taken.md` already uses for this exact gate line — "`body-children`
reads 2 throughout — the page's own `#app` and its script tag, constant, not
residue".

Every other site states it correctly and is left alone: `bulk-broad-re-taken.md`,
`p0-converged-witness-set.md` and `p0-reagent-on-subs-baseline.md` all publish
the literal `{:body-children 2, ...}`; `coldmount-double-build-priced.md` and
`the-cold-read-mount-term.md` say *baseline*, by equality, never *zero*. The two
"zero residue" claims in `ssr-spike-witness.md` / `production-server-arm.md` are
about `runtime/residue` (`cells`/`cell-refs`/`boundaries`/`edges`/`entries`),
which genuinely is all-zero. The instrument's own source was right all along —
`p0_harness/probe` already documents `:body-children` as the leak canary that
"must be constant across the whole run", and a number that CLIMBS as the fault.

## Idiom followed

Checked page by page rather than imposed. `the-candidates-clock.md` preserves
superseded wording in **italic dated parentheticals** (`*(2026-08-06,
rf2-8smbe: …)*` at §3's witness and B/E/Q bullets) — the new bullet ends in one.
`rows-re-adjudicated-on-the-corrected-clock.md` has no such idiom; it marks
superseded values with **strikethrough** (`~~1.2107×~~` at §3), so the superseded
word is struck there instead.

Net **+14 lines** (17 insertions, 3 deletions), both files under
`docs/design/hicasso/studio/`.

## Quality gates

| gate | result |
|---|---|
| `python scripts/check_doc_slugs.py` | **exit 0** |
| `python scripts/check_doc_slugs.py` — mutation | **exit 1**, named the edit |
| `sh scripts/test-fast-pr.sh` | **exit 0** — `PASS fast PR spine` |
| `HCLOCK_ONLY=keystroke node clock_run.cjs` (cold) | **exit 1** — `REPORTABLE: none`, by design |

Spine classification line, reported rather than predicted:

```
=== fast PR spine: docs=true jvm=false node=false (classified) ===
```

**`mkdocs build --strict` is not nominated as the gate for this diff.** The
spine ran it anyway (the documentation surface changed) and it built clean, but
`mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site, so it
does not reach either edited file. `check_doc_slugs.py` does, and the mutation
below proves it.

**Mutation proof.** `check_doc_slugs.py` passes on a tree with no broken
anchors, so a bare pass proves nothing. The new cross-link's anchor was
rewritten to `the-candidates-clock.md#3-the-design-moe9a-mutant`, the mutation
was **grep-confirmed present in the file before the checker ran**, and it then
failed:

```
1 broken anchor link(s) found:
  BROKEN ANCHOR: docs\design\hicasso\studio\rows-re-adjudicated-on-the-corrected-clock.md:198
      -> the-candidates-clock.md#3-the-design-moe9a-mutant
      (target: docs\design\hicasso\studio\the-candidates-clock.md)
```

Reverted; the checker returns 0 and the tree is clean.

**Tables hand-counted** (nothing validates them). The diff adds and edits no
table. The one table adjacent to an edit — §4's row table in
`rows-re-adjudicated-on-the-corrected-clock.md`, which the corrected paragraph
now runs into — was counted by hand: header 5 columns, separator 5, all five
data rows 5, and the blank line separating it from the paragraph survives.
