### PR TITLE
fix(bench): HD-008's bulk write floor cannot discriminate below its clock's grain, and now says so (rf2-d2tzk)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -755,6 +755,55 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     assert.strictEqual(verdict(summarise({ runs: [run({ correction: { r: { verdict: 'corrected' } } })] })).code, 0);
   });
 
+  // --- rf2-d2tzk: a LIMIT is not a FAULT, and the exit code says which -----
+  //
+  // The bulk row's floor is one write under one clock and reads 1.0 to 2.0
+  // ticks of a measured 0.1 ms grain, so `mask-below-grain` (hd8_rows.cljs)
+  // withdraws every figure normalised by it — the same marker SHAPE the DOM
+  // read-back uses and a different meaning. Nothing failed; a magnitude was
+  // never available. Exiting non-zero on it would exit non-zero on every run.
+  const belowGrain = () =>
+    run({
+      summary: {
+        'write-bulk': {
+          vsFloor: {
+            floor: { unpublished: 'below-clock-grain', arms: ['floor'], tick: 0.1, quanta: 1 },
+            'reagent-slim': { unpublished: 'below-clock-grain', arms: ['floor'], tick: 0.1, quanta: 1 },
+          },
+          headToHead: { 'donor-r1 vs uix': { min: 1.185, max: 1.313 } },
+        },
+      },
+      correction: { 'write-bulk': { verdict: 'moot', reason: 'no-published-figure-bears-it' } },
+    });
+
+  t('a window beneath the clock grain exits 0 — it is a limit, not a fault', () => {
+    const v = verdict(summarise({ runs: [belowGrain()] }));
+    assert.strictEqual(v.code, 0, 'nothing failed; the instrument could not resolve a magnitude');
+    assert.match(v.lines.join('\n'), /NO REPORTABLE MAGNITUDE/);
+    assert.match(v.lines.join('\n'), /floor at 1 tick\(s\) of 0\.1 ms/);
+    assert.ok(!/REFUSED/.test(v.lines.join('\n')), 'and it must not read as a refusal');
+  });
+
+  t('a `moot` yield correction is not a refusal', () => {
+    assert.strictEqual(verdict(summarise({ runs: [run({ correction: { r: { verdict: 'moot' } } })] })).code, 0);
+  });
+
+  t('the grain limit never swallows a real refusal standing beside it', () => {
+    const v = verdict(summarise({ runs: [belowGrain(), readBack()] }));
+    assert.strictEqual(v.code, 3, 'the read-back still decides the exit');
+    const all = v.lines.join('\n');
+    assert.match(all, /NO REPORTABLE MAGNITUDE/);
+    assert.match(all, /never reached the DOM/);
+  });
+
+  t('the two masks are told apart by their reason, not by their shape', () => {
+    // Both arrive as `{unpublished: …}` on the same channel. If the driver
+    // ever partitions them by anything other than the reason code, a fault
+    // starts exiting 0.
+    assert.match(SRC, /v\.unpublished === 'below-clock-grain'/);
+    assert.match(SRC, /instrumentLimited`? is DELIBERATELY absent/);
+  });
+
   // --- the gates that already existed are UNCHANGED, which is half the repair
 
   t('a hard failure still exits 1, exactly as before', () => {
@@ -806,7 +855,11 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     // In `runOne`, above `main` — the driver installed `watchPage` and then
     // read nobody's failures, alone among the six callers of it.
     assert.match(SRC, /const pageErrors = watch\.failures\.map/);
-    assert.match(SRC, /correction, contractSelfTest, userAgent, lines, pageErrors,/);
+    // The pin is on `pageErrors` REACHING the returned record, not on the
+    // shape of the record around it: this line grew a `clock` field for
+    // rf2-d2tzk and a pin that spelled every neighbour out went red for a
+    // change that could not touch what it is about.
+    assert.match(SRC, /lines, pageErrors,\s*\};/);
   });
 
   t('the exit code comes from `verdict` and from nothing else', () => {

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_app.cljs
@@ -132,10 +132,14 @@
                ;; correction's verdict on this channel. A reader who copies a
                ;; ratio out of the table gets the resolution of its
                ;; denominator on the line above it (rf2-d2tzk).
+               ;; The WORST round per arm and the grain it is measured
+               ;; against — the two numbers the table prints. The per-round
+               ;; series stays in the EDN record: exporting a figure nothing
+               ;; reads is how a driver ends up with three refusals it
+               ;; computes and never consults (rf2-rr6do).
                "grain" (when-let [g (:grain r)]
                          (clj->js {"tick"  (:tick g)
-                                   "worst" (into {} (map (fn [[k v]] [(name k) v])) (:worst g))
-                                   "quanta" (into {} (map (fn [[k v]] [(name k) v])) (:quanta g))}))})
+                                   "worst" (into {} (map (fn [[k v]] [(name k) v])) (:worst g))}))})
     (set! (.-HD8_SUMMARY js/window) acc)
     nil))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_app.cljs
@@ -45,6 +45,10 @@
 (def ^:private mount-sampling {:warmup 4 :samples 12})
 (def ^:private write-sampling {:warmup 3 :samples 10})
 (def ^:private control-sampling {:warmup 3 :samples 8})
+;; How many times the clock's grain is observed. Each observation spins until
+;; `performance.now()` advances, so the whole control costs `n` ticks — about
+;; 20 ms at a 100 µs grain — and it runs once, outside every measured window.
+(def ^:private clock-resolution-samples 200)
 
 ;; ---------------------------------------------------------------------------
 ;; Publication
@@ -182,10 +186,19 @@
   (let [which    (query-adapter)
         _        (install! which)
         arm-ids  (get rows/arm-ids-for which)
-        write-ids (get rows/write-arm-ids-for which)]
+        write-ids (get rows/write-arm-ids-for which)
+        ;; THE CLOCK'S OWN GRAIN, taken in the run it governs. Every page in
+        ;; this studio asserted "Chrome clamps performance.now() to 100 µs"
+        ;; and then reasoned against that constant; the write rows' floor is
+        ;; a single commit and sits ON it, so the number decides whether
+        ;; those rows have a magnitude at all and is measured rather than
+        ;; quoted (rf2-d2tzk).
+        clock    (rows/clock-resolution! clock-resolution-samples)]
     (lane/leave-act-environment!)
     (doseq [id arm-ids] (rows/ensure-frame! id))
     (record! :method (rows/method-record which arm-ids write-ids rounds mount-sampling write-sampling))
+    (record! :clock-resolution clock)
+    (set! (.-HD8_CLOCK js/window) (clj->js clock))
 
     ;; ---- gate 0: the correction contract's own self-test -------------------
     ;; Before anything is measured, because a harness that gets `false` here

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_app.cljs
@@ -96,9 +96,20 @@
     (into {} (map (fn [[k v]]
                     [(name k)
                      (if (:unpublished v)
-                       {"unpublished" (name (:unpublished v))
-                        "unverified"  (:unverified v)
-                        "of"          (:of v)}
+                       ;; ONE marker shape for both publication masks, so the
+                       ;; driver reads them with one reader and cannot end up
+                       ;; printing a number for either. The fields a mask does
+                       ;; not set are absent rather than zero: a failed
+                       ;; read-back carries its counts, a window beneath the
+                       ;; clock's grain carries the arms, the measured tick
+                       ;; and how many ticks the worst of them was worth
+                       ;; (rf2-d2tzk).
+                       (cond-> {"unpublished" (name (:unpublished v))}
+                         (:unverified v)   (assoc "unverified" (:unverified v))
+                         (:of v)           (assoc "of" (:of v))
+                         (:arms v)         (assoc "arms" (mapv name (:arms v)))
+                         (:tick v)         (assoc "tick" (:tick v))
+                         (:worst-quanta v) (assoc "quanta" (:worst-quanta v)))
                        {"min" (:min v) "max" (:max v)
                         "straddles1" (boolean (:straddles-1? v))})]))
           m)))
@@ -114,7 +125,17 @@
   (let [acc (or (.-HD8_SUMMARY js/window) #js {})]
     (aset acc (name row-name)
           #js {"vsFloor" (pack-bands (:summary r))
-               "headToHead" (pack-bands (:head-to-head r))})
+               "headToHead" (pack-bands (:head-to-head r))
+               ;; HOW MANY OF THE CLOCK'S OWN TICKS EACH ARM'S WINDOW IS
+               ;; WORTH, beside the figures it governs rather than in an EDN
+               ;; blob nobody parses — the same argument that put the yield
+               ;; correction's verdict on this channel. A reader who copies a
+               ;; ratio out of the table gets the resolution of its
+               ;; denominator on the line above it (rf2-d2tzk).
+               "grain" (when-let [g (:grain r)]
+                         (clj->js {"tick"  (:tick g)
+                                   "worst" (into {} (map (fn [[k v]] [(name k) v])) (:worst g))
+                                   "quanta" (into {} (map (fn [[k v]] [(name k) v])) (:quanta g))}))})
     (set! (.-HD8_SUMMARY js/window) acc)
     nil))
 
@@ -329,11 +350,11 @@
                                   (.then (fn [yc]
                                            (record! :yield-cost yc)
                                            (vreset! yc* yc)
-                                           (rows/measure-write! write-ids which :narrow rounds write-sampling)))
+                                           (rows/measure-write! write-ids which :narrow rounds write-sampling clock)))
                                   (.then (fn [r]
                                            (record-row! :write-narrow r)
                                            (rows/assert-teardown-clean! "write-narrow")
-                                           (-> (rows/measure-write! write-ids which :bulk rounds write-sampling)
+                                           (-> (rows/measure-write! write-ids which :bulk rounds write-sampling clock)
                                                (.then (fn [b] #js [r b])))))
                                   (.then
                                     (fn [pair]

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
@@ -1001,10 +1001,6 @@
     {:tick        tick
      :quanta      quanta
      :worst       worst
-     ;; What fraction of the WORST round's reading is the grain rather than
-     ;; the arm — the number the mask's rule is about, stated so a reader of
-     ;; a published band never has to divide it out.
-     :grain-share (into {} (map (fn [[id q]] [id (when (number? q) (round4 (/ 1.0 q)))])) worst)
      :below-grain below}))
 
 (defn- mask-below-grain

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
@@ -943,10 +943,119 @@
                                   (some #(re-find (re-pattern (name %)) (name k)) bad)))
                         m))))))
 
+(defn grain-record
+  "How many of the clock's own ticks each arm's window is worth, per round.
+
+  `tick` is [[clock-resolution!]]'s measured grain. A p50 of `v` against a
+  grain of `t` is `v/t` ticks, and the grain's SHARE of that reading is
+  `t/v` — the fraction of the number that is the instrument rather than the
+  arm. Both are recorded per arm per round, because the ratios are formed
+  WITHIN a round and it is each round's own p50 that becomes a published
+  endpoint.
+
+  Answers `{:tick :quanta {arm [q …]} :worst {arm q} :below-grain #{arm …}}`.
+  `:below-grain` is the set of arms whose p50 does not EXCEED the grain in
+  at least one round — two measured quantities with no constant between
+  them, the same shape as [[correct-round]]'s survival test. An arm in it
+  has a window the clock cannot tell from one half its size or twice it.
+
+  A `nil` tick (the clock never advanced, [[clock-resolution!]]'s spin cap)
+  puts EVERY arm below the grain: an instrument that cannot state its own
+  resolution has not earned a magnitude."
+  [row tick]
+  (let [arms   (:arms row)
+        rounds (mapv :p50 (:per-round row))
+        quanta (into {}
+                     (map (fn [id]
+                            [id (mapv (fn [p50]
+                                        (let [v (get p50 id)]
+                                          (when (and (number? v) (number? tick) (pos? tick))
+                                            (round4 (/ v tick)))))
+                                      rounds)]))
+                     arms)
+        worst  (into {} (map (fn [[id qs]] [id (when (every? number? qs) (apply min qs))])) quanta)]
+    {:tick        tick
+     :quanta      quanta
+     :worst       worst
+     :grain-share (into {} (map (fn [[id q]] [id (when (number? q) (round4 (/ 1.0 q)))])) worst)
+     :below-grain (into #{} (keep (fn [[id q]] (when-not (and (number? q) (> q 1.0)) id))) worst)}))
+
+(defn- mask-below-grain
+  "Apply the CLOCK-GRAIN publication mask to one write row's published
+  surfaces, and answer the row (rf2-d2tzk).
+
+  A WINDOW THAT DOES NOT EXCEED THE CLOCK'S OWN GRAIN HAS NO MAGNITUDE.
+  The reading is a real number and it is the instrument's resolution
+  wearing an arm's clothes: the bulk row's floor is a single commit under
+  one clock, it reads 1.0 to 2.0 ticks of a 0.1 ms grain, and its
+  neighbouring attainable values are 33 % to 100 % apart — so every ratio
+  normalised by it is determined only to within a factor of about two. The
+  row's own six rounds show it: the `reagent-slim` numerator moved 1.18x
+  across them while the published ratio moved 2.06x, and the whole of that
+  swing is the denominator stepping between one tick and two.
+
+  The mask is the DOM read-back's ([[mask-failed-read-backs]]) applied to
+  a second way of having no publishable timing, and it is deliberately the
+  same shape: `:summary` carries `:unpublished` in place of a number a
+  reader could quote, and every head-to-head pair touching an offending
+  arm is dropped. The two differ in what they mean and the driver keeps
+  them apart — a failed read-back is a FAULT and refuses the run; a window
+  beneath the grain is a LIMIT of the instrument, published as one.
+
+  WHICH FIGURES GO. The floor is the denominator of every floor-normalised
+  figure, so a floor beneath the grain takes the whole column. A
+  head-to-head pair is arm-over-arm and the floor cancels out of it
+  exactly, so those pairs SURVIVE — which is not a concession, it is the
+  measurement: the clamp destroys the cross-run column (the weaker
+  warrant) and leaves the within-run pairs (the stronger one) untouched.
+
+  The permanent repair is the batched window the narrow row got
+  (`narrow-batch-k`, rf2-9zysg): it lifts the sample clear of the clamp.
+  That changes a measured window and obliges a re-take of the row on every
+  adapter, which is a re-publication and rf2-2rtt6.7's to authorise — so
+  this mask states the limit rather than manufacturing resolution the
+  instrument does not have."
+  [row grain]
+  (let [bad (:below-grain grain)]
+    (if (empty? bad)
+      row
+      (let [marker (fn [arm]
+                     (let [offending (vec (sort (filter bad (distinct [:floor arm]))))
+                           qs        (keep #(get (:worst grain) %) offending)]
+                       {:unpublished  :below-clock-grain
+                        :arms         offending
+                        :tick         (:tick grain)
+                        :worst-quanta (when (seq qs) (apply min qs))}))]
+        (-> row
+            (update :summary
+                    (fn [m]
+                      (into {}
+                            (map (fn [[arm v]]
+                                   ;; An entry a mask has ALREADY taken keeps the
+                                   ;; marker it has: a failed DOM read-back is a
+                                   ;; page that never changed, which is the more
+                                   ;; serious thing to say about an arm than the
+                                   ;; resolution of the clock that timed it.
+                                   [arm (if (and (not (:unpublished v))
+                                                 (or (bad :floor) (bad arm)))
+                                          (marker arm)
+                                          v)]))
+                            m)))
+            (update :head-to-head
+                    (fn [m]
+                      (into {}
+                            (remove (fn [[_ v]] (or (bad (:numerator v)) (bad (:denominator v)))))
+                            m))))))))
+
 (defn measure-write!
   "`rounds` interleaved rounds of the write clock, `kind` ∈ `#{:narrow
-  :bulk}`. Answers a promise of the published record."
-  [arm-ids adapter kind rounds sampling]
+  :bulk}`. Answers a promise of the published record.
+
+  `clock` is [[clock-resolution!]]'s reading, and it decides which figures
+  in the row have a magnitude at all: a window that does not exceed the
+  clock's own grain publishes nothing a reader could quote
+  ([[mask-below-grain]], rf2-d2tzk)."
+  [arm-ids adapter kind rounds sampling clock]
   (doseq [id arm-ids] (reseed! id))
   (let [mounts (mount-write-arms! arm-ids adapter)]
     (-> (chain {:rounds-out [] :samples [] :unverified {} :total {} :position 0}
@@ -961,29 +1070,44 @@
                                :position   (:position r)})))))
         (.then (fn [acc]
                  (release-write-arms! mounts)
-                 ;; The publication mask — an arm whose writes did not reach
-                 ;; the DOM has NO figure — is [[mask-failed-read-backs]]'s,
-                 ;; applied over the raw summary and head-to-head, so the rule
-                 ;; the self-test's fixtures replay is the rule this row ships.
-                 (mask-failed-read-backs
-                  {:witness    (keyword (str "U-" (name kind)))
-                   :doc        (if (= kind :bulk)
-                                 "all 300 cells written in ONE commit — bulk view work"
-                                 (str narrow-batch-k " single-cell writes into a 300-cell "
-                                      "grid, each its own commit, all inside ONE timed "
-                                      "window — the narrow-write path. The per-write "
-                                      "figure is the sample divided by " narrow-batch-k))
-                   ;; Stated on the row, because a reader comparing this
-                   ;; against the pre-rf2-9zysg numbers is comparing two
-                   ;; different windows and has to be told so.
-                   :writes-per-sample (if (= kind :bulk) 1 narrow-batch-k)
-                   :arms       (vec arm-ids)
-                   :per-round  (:rounds-out acc)
-                   :summary    (lane/across-rounds (mapv :ratio (:rounds-out acc)))
-                   :head-to-head (head-to-head (:rounds-out acc))
-                   :unverified (:unverified acc)
-                   :writes     (:total acc)
-                   :samples    (:samples acc)})))
+                 ;; TWO PUBLICATION MASKS, both the instrument's own rule
+                 ;; applied over the raw summary and head-to-head rather than
+                 ;; a hand-written approximation of it, so the fixtures the
+                 ;; self-test replays are the rules this row ships.
+                 ;;
+                 ;;   read-back — an arm whose writes did not reach the DOM
+                 ;;               has no figure (rf2-x6g04). A FAULT.
+                 ;;   grain     — an arm whose window does not exceed the
+                 ;;               clock's own resolution has no magnitude
+                 ;;               (rf2-d2tzk). A LIMIT.
+                 ;;
+                 ;; The read-back mask runs FIRST so that an arm carrying both
+                 ;; keeps the fault marker: a page that never changed is the
+                 ;; more serious thing to say about it, and the grain mask must
+                 ;; not overwrite it with the milder one.
+                 (let [row   (mask-failed-read-backs
+                               {:witness      (keyword (str "U-" (name kind)))
+                                :doc          (if (= kind :bulk)
+                                                "all 300 cells written in ONE commit — bulk view work"
+                                                (str narrow-batch-k " single-cell writes into a 300-cell "
+                                                     "grid, each its own commit, all inside ONE timed "
+                                                     "window — the narrow-write path. The per-write "
+                                                     "figure is the sample divided by " narrow-batch-k))
+                                ;; Stated on the row, because a reader comparing this
+                                ;; against the pre-rf2-9zysg numbers is comparing two
+                                ;; different windows and has to be told so.
+                                :writes-per-sample (if (= kind :bulk) 1 narrow-batch-k)
+                                :arms         (vec arm-ids)
+                                :per-round    (:rounds-out acc)
+                                :summary      (lane/across-rounds (mapv :ratio (:rounds-out acc)))
+                                :head-to-head (head-to-head (:rounds-out acc))
+                                :unverified   (:unverified acc)
+                                :writes       (:total acc)
+                                :samples      (:samples acc)})
+                       grain (grain-record row (:tick clock))]
+                   (-> row
+                       (assoc :grain grain)
+                       (mask-below-grain grain)))))
         (.catch (fn [e] (release-write-arms! mounts) (throw e))))))
 
 ;; ===========================================================================
@@ -1176,8 +1300,14 @@
 
   Re-formed and not rescaled: the ratios are within-round by construction
   and the correction moves the DENOMINATOR whenever the floor is a bearer,
-  which no rescaling of the published ratio can express."
-  [{:keys [p50]} bearers bound]
+  which no rescaling of the published ratio can express.
+
+  `checked` is the subset of `bearers` the SURVIVAL test is applied to —
+  the ones a published figure is formed from ([[published-arms]]). Every
+  bearer is still subtracted from, because the turns were in its window
+  whatever the row prints; what a bearer with no published figure cannot
+  do is refuse a row on behalf of a number nobody may quote (rf2-d2tzk)."
+  [{:keys [p50]} bearers checked bound]
   (let [adj   (into {} (map (fn [[id v]] [id (if (contains? bearers id) (- v bound) v)])) p50)
         floor (get adj :floor)]
     ;; SURVIVAL: WHAT REMAINS MUST EXCEED WHAT WAS REMOVED.
@@ -1197,7 +1327,7 @@
     ;; window. That is not a threshold invented here — it is what makes a
     ;; correction a correction rather than the measurement, and it compares two
     ;; MEASURED quantities with no constant between them.
-    (when (every? (fn [[_ v]] (> v bound)) (select-keys adj bearers))
+    (when (every? (fn [[_ v]] (> v bound)) (select-keys adj checked))
       {:p50   adj
        :ratio (into {} (map (fn [[id v]] [id (round4 (/ v floor))])) adj)})))
 
@@ -1241,6 +1371,25 @@
                  [id (if (:unpublished o) o v)])))
         corrected))
 
+(defn- published-arms
+  "Every arm the row still publishes a figure ABOUT or a figure AGAINST.
+
+  A floor-normalised entry is formed from its own arm and from the floor,
+  which is its denominator; a head-to-head pair from the two arms
+  `lane/ratio-between` named in it. An entry a publication mask has
+  replaced with `:unpublished` contributes nothing, because there is no
+  longer a figure there for anything to change.
+
+  This is what [[yield-correction]] adjudicates over. A bearer that no
+  published figure is formed from cannot move one, and a contract that
+  refused on it would be refusing on a number the row does not print
+  (rf2-d2tzk)."
+  [row]
+  (let [normalised (into #{} (comp (remove (fn [[_ v]] (:unpublished v))) (map key)) (:summary row))
+        pairs      (into #{} (mapcat (fn [[_ v]] [(:numerator v) (:denominator v)])) (:head-to-head row))]
+    (cond-> (into pairs normalised)
+      (seq normalised) (conj :floor))))
+
 (defn yield-correction
   "Adjudicate one write row against the harness-microtask asymmetry, and
   answer a verdict rather than an observation (rf2-b69lw).
@@ -1258,12 +1407,25 @@
   `{:p50 0 :max 0.1 :n 10}`. A contract nothing enforces is a sentence,
   not a contract.
 
-  ## The four verdicts
+  ## The five verdicts
 
   `:not-owed` — every arm in the row shares one window shape, so the turns
   are in the numerator and the denominator alike. Only a row that MIXES
   shapes owes anything, and today that is the `slim` run's write rows and
   no others.
+
+  `:moot` — the row mixes shapes, but no figure it still PUBLISHES is
+  formed from a yield-bearing arm ([[published-arms]]), so the correction
+  has nothing to move and a refusal would have nothing to protect. This is
+  the BULK row on the slim run: its only bearer is the floor, the floor is
+  its denominator, and the floor sits on the clock's own grain — so
+  [[mask-below-grain]] has already withdrawn every figure normalised by it,
+  permanently and on stronger grounds than the harness turn. Before this
+  verdict existed the row's disposition was drawn from the clock rather
+  than from the measurement: a one-turn aggregate of `0.0` published it
+  unadjusted and an aggregate of `0.1` refused it and failed the whole
+  sweep, on the same page, the same arms and the same source, three times
+  and twice out of five observed runs (rf2-d2tzk).
 
   `:below-resolution` — the row owes, and the aggregate yield window's MAX
   is zero across every sample. Chrome clamps `performance.now()` to 100 µs;
@@ -1343,8 +1505,21 @@
         shapes   (into {} (map (fn [id] [id (window-shape id adapter)])) arms)
         bearers  (into #{} (keep (fn [[id s]] (when (= s :write-yield-drain) id))) shapes)
         exempt   (into #{} (keep (fn [[id s]] (when (= s :write-then-drain) id))) shapes)
+        ;; Only over the figures the row still PUBLISHES ([[published-arms]]).
+        ;; A bearer whose column a publication mask has already withdrawn has
+        ;; no figure left for the subtraction to move or for a refusal to
+        ;; protect, and the difference is not theoretical: the BULK row's
+        ;; floor is its only bearer on the slim run and it sits ON the clock's
+        ;; grain, so this row's disposition used to be a coin toss between
+        ;; publishing unadjusted (a 0.0 aggregate) and failing the whole sweep
+        ;; (a 0.1 aggregate) — the same page, the same arms, two opposite
+        ;; answers drawn from the clock rather than from the measurement
+        ;; (rf2-d2tzk).
+        published (published-arms row)
+        borne     (into #{} (filter published) bearers)
         base     {:row (:witness row) :k k :windows shapes
-                  :bearers (vec bearers) :exempt (vec exempt)}
+                  :bearers (vec bearers) :exempt (vec exempt)
+                  :bearers-published (vec borne)}
         agg      (cond
                    (= k narrow-batch-k) (let [b (:batched yc)]
                                           (when b {:source :batched-aggregate
@@ -1365,6 +1540,18 @@
                             (name (or (first (vals shapes)) :none))
                             "), so the harness turns are in the numerator and the denominator "
                             "alike and no arm is billed for a turn its rival escapes"))
+
+      (empty? borne)
+      (assoc base :verdict :moot
+                  :reason :no-published-figure-bears-it
+                  :why (str "this row mixes window shapes, but every figure it still publishes is "
+                            "formed only from arms that escape the harness turn ("
+                            (str/join ", " (map name exempt)) "). The yield-bearing arm(s) "
+                            (str/join ", " (map name bearers)) " carry no published figure — a "
+                            "publication mask has already withdrawn the column they denominate — "
+                            "so there is nothing for the subtraction to move and nothing for a "
+                            "refusal to protect. Head-to-head pairs are arm-over-arm and the "
+                            "floor cancels out of them exactly"))
 
       (nil? agg)
       (assoc base :verdict :refused
@@ -1388,7 +1575,7 @@
 
       :else
       (let [bound     (:max agg)
-            corrected (mapv #(correct-round % bearers bound) (:per-round row))]
+            corrected (mapv #(correct-round % bearers borne bound) (:per-round row))]
         (if (some nil? corrected)
           (assoc base :verdict :refused :reason :correction-exceeds-window
                       :aggregate agg :bound bound
@@ -1461,8 +1648,20 @@
      :summary           (lane/across-rounds (mapv :ratio per-round))
      :head-to-head      (head-to-head per-round)}))
 
+(defn- grain-fixture
+  "A [[fixture-row]] carried through the instrument's OWN clock-grain rule
+  at a stated `tick`, so a grain fixture is a handful of milliseconds and a
+  resolution rather than a hand-written marker that could drift from what
+  [[measure-write!]] applies (rf2-d2tzk). `tick` may be `nil` — that is the
+  reading a clock which never advanced produces, and it must fail closed."
+  [witness k arms rounds tick]
+  (let [row   (fixture-row witness k arms rounds)
+        grain (grain-record row tick)]
+    (-> row (assoc :grain grain) (mask-below-grain grain))))
+
 (defn yield-correction-self-test
-  "Replay [[yield-correction]] over recorded fixtures, and answer
+  "Replay the write rows' PUBLICATION RULES — [[mask-below-grain]] and
+  [[yield-correction]] — over recorded fixtures, and answer
   `{:ok? :checks}`.
 
   **A gate nobody has watched refuse is not a gate**, and this one refuses
@@ -1601,7 +1800,71 @@
                        (not (contains? (:head-to-head-corrected v) :donor-r1-over-reagent-slim)))
             :detail (str (name (:verdict v))
                          " reagent-slim-corrected=" (pr-str slim)
-                         " h2h-corrected=" (pr-str (vec (keys (:head-to-head-corrected v)))))})]]
+                         " h2h-corrected=" (pr-str (vec (keys (:head-to-head-corrected v)))))})
+
+         ;; 9. THE CLOCK-GRAIN MASK (rf2-d2tzk). The live bulk row: a floor
+         ;;    of one and two 0.1 ms ticks under a measured 0.1 ms grain. The
+         ;;    floor is every floor-normalised figure's DENOMINATOR, so the
+         ;;    whole column goes — and the head-to-head pairs, which are
+         ;;    arm-over-arm with the floor cancelling exactly, STAY. The
+         ;;    numbers are the run recorded on this bead, not invented.
+         (let [row   (grain-fixture :U-bulk 1 [:floor :reagent-slim :donor-r1]
+                                    [{:floor 0.1 :reagent-slim 1.75 :donor-r1 1.2}
+                                     {:floor 0.2 :reagent-slim 1.7  :donor-r1 1.3}]
+                                    0.1)
+               slim  (get-in row [:summary :reagent-slim])]
+           {:name "a floor at the clock's own grain unpublishes the floor-normalised column"
+            :ok   (and (= :below-clock-grain (:unpublished slim))
+                       (nil? (:min slim))
+                       (= [:floor] (:arms slim))
+                       (= :below-clock-grain (:unpublished (get-in row [:summary :floor])))
+                       (contains? (:head-to-head row) :donor-r1-over-reagent-slim))
+            :detail (str "reagent-slim=" (pr-str slim)
+                         " h2h=" (pr-str (vec (keys (:head-to-head row)))))})
+
+         ;; 10. AND THE CORRECTION OVER THAT ROW IS MOOT — which is the whole
+         ;;     of this bead. The same fixture, the same aggregate that made
+         ;;     the unmasked row REFUSE at check 4, now has no published
+         ;;     figure to refuse over: the bearer is the floor and the floor's
+         ;;     column is gone. Two draws of the clock, one answer.
+         (let [row  (grain-fixture :U-bulk 1 [:floor :reagent-slim]
+                                   [{:floor 0.1 :reagent-slim 1.5} {:floor 0.1 :reagent-slim 1.6}]
+                                   0.1)
+               live (verdict-of row :slim live-yc)
+               zero (verdict-of row :slim zero-yc)]
+           {:name "and the correction over a grain-masked row is MOOT on BOTH draws of the clock"
+            :ok   (and (= :moot (:verdict live)) (= :moot (:verdict zero))
+                       (= :no-published-figure-bears-it (:reason live)))
+            :detail (str "resolving=" (name (:verdict live)) " flat=" (name (:verdict zero)))})
+
+         ;; 11. THE MASK IS NOT A BLANKET. A floor well clear of the grain —
+         ;;     the batched NARROW row, 9 and 10 ticks on the same 0.1 ms
+         ;;     clock — publishes exactly as before, and its correction is
+         ;;     adjudicated exactly as before. Same rule, same clock, the
+         ;;     other answer: what separates the two rows is the measurement.
+         (let [row (grain-fixture :U-narrow narrow-batch-k [:floor :reagent-slim]
+                                  [{:floor 0.9 :reagent-slim 4.45} {:floor 1.0 :reagent-slim 5.3}]
+                                  0.1)
+               v   (verdict-of row :slim live-yc)]
+           {:name "a floor nine to ten ticks clear of the grain is untouched, and still corrected"
+            :ok   (and (number? (get-in row [:summary :reagent-slim :min]))
+                       (nil? (:unpublished (get-in row [:summary :reagent-slim])))
+                       (= :corrected (:verdict v)))
+            :detail (str "band=" (pr-str (get-in row [:summary :reagent-slim]))
+                         " verdict=" (name (:verdict v)))})
+
+         ;; 12. FAIL CLOSED ON AN UNMEASURABLE CLOCK. `clock-resolution!`
+         ;;     answers a nil tick when the clock never advanced inside its
+         ;;     spin cap. An instrument that cannot state its own resolution
+         ;;     has not earned a magnitude, so EVERY arm is below the grain —
+         ;;     never "no tick, so nothing is below it", which is the
+         ;;     fail-open reading of the same fact.
+         (let [row (grain-fixture :U-bulk 1 [:floor :reagent-slim]
+                                  [{:floor 5.0 :reagent-slim 50.0}]
+                                  nil)]
+           {:name "a clock that could not state its own resolution unpublishes everything"
+            :ok   (= :below-clock-grain (:unpublished (get-in row [:summary :reagent-slim])))
+            :detail (pr-str (get-in row [:summary :reagent-slim]))})]]
     {:ok?    (every? :ok checks)
      :checks (mapv (fn [c] (update c :ok boolean)) checks)}))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
@@ -954,40 +954,67 @@
   endpoint.
 
   Answers `{:tick :quanta {arm [q …]} :worst {arm q} :below-grain #{arm …}}`.
-  `:below-grain` is the set of arms whose p50 does not EXCEED the grain in
-  at least one round — two measured quantities with no constant between
-  them, the same shape as [[correct-round]]'s survival test. An arm in it
-  has a window the clock cannot tell from one half its size or twice it.
+
+  ## WHEN A WINDOW HAS A MAGNITUDE, AND WHY THE TEST IS THIS ONE
+
+  `:below-grain` holds every arm for which, in at least one round,
+
+      (v - tick) > tick     is FALSE
+
+  — what the clock RESOLVED of that window does not exceed what it could
+  not. That is not a threshold invented here. It is word for word the rule
+  [[correct-round]] already applies to the harness turn — *what remains
+  must exceed what was removed* — with the instrument's own grain in the
+  place of the correction, and like that one it compares two MEASURED
+  quantities with no constant between them.
+
+  The weaker test — `v > tick`, the reading merely exceeding the grain —
+  was tried first and IT DOES NOT DECIDE ANYTHING. Two consecutive cold
+  runs of this same source measured the bulk floor's rounds at
+  `1.0 1.0 1.0 2.0 1.5 2.0` ticks and then at a worst of `1.5`: the first
+  draw masked the row and the second published `9.333 – 10.500`, a band
+  whose own width is 12 % over a denominator no better than 67 % — the
+  same figure-from-the-clock coin toss this bead exists to remove, moved
+  one place along. A grain that is the MAJORITY of a reading has not
+  measured it.
 
   A `nil` tick (the clock never advanced, [[clock-resolution!]]'s spin cap)
   puts EVERY arm below the grain: an instrument that cannot state its own
   resolution has not earned a magnitude."
   [row tick]
-  (let [arms   (:arms row)
-        rounds (mapv :p50 (:per-round row))
-        quanta (into {}
-                     (map (fn [id]
-                            [id (mapv (fn [p50]
-                                        (let [v (get p50 id)]
-                                          (when (and (number? v) (number? tick) (pos? tick))
-                                            (round4 (/ v tick)))))
-                                      rounds)]))
-                     arms)
-        worst  (into {} (map (fn [[id qs]] [id (when (every? number? qs) (apply min qs))])) quanta)]
+  (let [arms     (:arms row)
+        rounds   (mapv :p50 (:per-round row))
+        resolved (fn [v] (and (number? v) (number? tick) (pos? tick) (> (- v tick) tick)))
+        quanta   (into {}
+                       (map (fn [id]
+                              [id (mapv (fn [p50]
+                                          (let [v (get p50 id)]
+                                            (when (and (number? v) (number? tick) (pos? tick))
+                                              (round4 (/ v tick)))))
+                                        rounds)]))
+                       arms)
+        worst    (into {} (map (fn [[id qs]] [id (when (every? number? qs) (apply min qs))])) quanta)
+        below    (into #{}
+                       (keep (fn [id]
+                               (when-not (every? (fn [p50] (resolved (get p50 id))) rounds) id)))
+                       arms)]
     {:tick        tick
      :quanta      quanta
      :worst       worst
+     ;; What fraction of the WORST round's reading is the grain rather than
+     ;; the arm — the number the mask's rule is about, stated so a reader of
+     ;; a published band never has to divide it out.
      :grain-share (into {} (map (fn [[id q]] [id (when (number? q) (round4 (/ 1.0 q)))])) worst)
-     :below-grain (into #{} (keep (fn [[id q]] (when-not (and (number? q) (> q 1.0)) id))) worst)}))
+     :below-grain below}))
 
 (defn- mask-below-grain
   "Apply the CLOCK-GRAIN publication mask to one write row's published
   surfaces, and answer the row (rf2-d2tzk).
 
-  A WINDOW THAT DOES NOT EXCEED THE CLOCK'S OWN GRAIN HAS NO MAGNITUDE.
+  A WINDOW THE CLOCK RESOLVED LESS OF THAN IT MISSED HAS NO MAGNITUDE.
   The reading is a real number and it is the instrument's resolution
   wearing an arm's clothes: the bulk row's floor is a single commit under
-  one clock, it reads 1.0 to 2.0 ticks of a 0.1 ms grain, and its
+  one clock, it reads 1.0 to 2.0 ticks of a MEASURED 0.1 ms grain, and its
   neighbouring attainable values are 33 % to 100 % apart — so every ratio
   normalised by it is determined only to within a factor of about two. The
   row's own six rounds show it: the `reagent-slim` numerator moved 1.18x
@@ -1836,6 +1863,29 @@
             :ok   (and (= :moot (:verdict live)) (= :moot (:verdict zero))
                        (= :no-published-figure-bears-it (:reason live)))
             :detail (str "resolving=" (name (:verdict live)) " flat=" (name (:verdict zero)))})
+
+         ;; 10b. THE RULE AT ITS OWN EDGE. `v > tick` — the reading merely
+         ;;      exceeding the grain — is NOT the test, and the difference is
+         ;;      two consecutive live runs of one source: the bulk floor's
+         ;;      worst round read 1.0 ticks on the first and 1.5 on the
+         ;;      second, so the weaker rule masked the row and then published
+         ;;      `9.333 – 10.500` off the same window. The test is
+         ;;      `(v - tick) > tick` — what was resolved must exceed what was
+         ;;      not — so 1.5 and 2.0 ticks are still grain and 3.0 is a
+         ;;      measurement. Both polarities, because a boundary nobody has
+         ;;      watched decide is not a boundary.
+         (let [at (fn [floor] (-> (grain-fixture :U-bulk 1 [:floor :reagent-slim]
+                                                 [{:floor floor :reagent-slim 1.7}]
+                                                 0.1)
+                                  (get-in [:summary :reagent-slim])))]
+           {:name "the grain must be the SMALLER part of the window: 1.5 and 2.0 ticks are still grain, 3.0 is not"
+            :ok   (and (= :below-clock-grain (:unpublished (at 0.15)))
+                       (= :below-clock-grain (:unpublished (at 0.2)))
+                       (nil? (:unpublished (at 0.3)))
+                       (number? (:min (at 0.3))))
+            :detail (str "1.5=" (pr-str (:unpublished (at 0.15)))
+                         " 2.0=" (pr-str (:unpublished (at 0.2)))
+                         " 3.0=" (pr-str (:min (at 0.3))))})
 
          ;; 11. THE MASK IS NOT A BLANKET. A floor well clear of the grain —
          ;;     the batched NARROW row, 9 and 10 ticks on the same 0.1 ms

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
@@ -1096,6 +1096,69 @@
                                "of multiplying (rf2-2rtt6.19)")}}))))))))
 
 ;; ===========================================================================
+;; The instrument's OWN resolution — measured, not asserted
+;; ===========================================================================
+
+(defn- tick-once
+  "One observation of the clock's grain: the first difference
+  [[lane/now-ms]] reports after a busy wait, or `nil` if it reported none
+  within `spin-cap` reads.
+
+  A clamped clock answers the SAME value for every read inside a tick, so
+  the first difference IS one tick. The cap is not a tolerance — it is the
+  only alternative to hanging the page on a clock that never advances, and
+  it answers `nil` so a missing reading fails closed rather than arriving
+  as a small number."
+  [spin-cap]
+  (let [t0 (lane/now-ms)]
+    (loop [i 0]
+      (let [t1 (lane/now-ms)]
+        (cond
+          (> t1 t0)      (round4 (- t1 t0))
+          (>= i spin-cap) nil
+          :else          (recur (inc i)))))))
+
+(defn clock-resolution!
+  "Measure the smallest interval this instrument's clock can report.
+
+  Every page in this studio states *Chrome clamps `performance.now()` to
+  100 µs* and then reasons against 100 µs as though it were a property of
+  the measurement. It is a property of a browser build and its
+  cross-origin-isolation state, and a row whose DENOMINATOR sits on that
+  grain is decided by it — so the number is taken in the run it governs
+  rather than quoted from a comment, on the same argument that made
+  [[yield-cost!]] measure the harness turn instead of asserting it was
+  small (rf2-d2tzk).
+
+  The method is the only one a clamped clock permits: read, spin until the
+  value CHANGES, record the difference. `:tick` is the MINIMUM across `n`
+  such observations, because a spin that overran a boundary reports a
+  multiple and the smallest observation is the only one that cannot.
+
+  Answers `{:tick :p50 :max :n :distinct :unresolved}`. `:distinct` is the
+  set of observed differences — on a clamped clock they are multiples of
+  `:tick`, which is what makes the reading a RESOLUTION and not a latency.
+  `:unresolved` counts observations that hit the spin cap; any of them
+  leaves `:tick` nil, and [[denominator-resolution]] treats a missing tick
+  as unevaluable rather than as zero."
+  [n]
+  (let [spin-cap 5000000
+        ds       (vec (repeatedly n #(tick-once spin-cap)))
+        good     (vec (remove nil? ds))
+        s        (lane/summarise good)]
+    {:control     :clock-resolution
+     :tick        (when (= (count good) (count ds)) (:min s))
+     :p50         (:p50 s)
+     :max         (:max s)
+     :n           (count ds)
+     :unresolved  (- (count ds) (count good))
+     :distinct    (vec (sort (distinct good)))
+     :note (str "the smallest difference lane/now-ms reports, measured by spinning until "
+                "the clock advances. A denominator at this size cannot be told from one "
+                "half its size or twice it, so a ratio taken against it carries the grain "
+                "rather than the arm (rf2-d2tzk)")}))
+
+;; ===========================================================================
 ;; THE CORRECTION-OR-REFUSAL CONTRACT — the asymmetry adjudicated, not noted
 ;; ===========================================================================
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
@@ -312,6 +312,11 @@ async function runOne(chromium, run) {
     const contractSelfTest = await page.evaluate(
       'window.HD8_CORRECTION_SELFTEST === undefined ? null : window.HD8_CORRECTION_SELFTEST'
     );
+    // THE CLOCK'S OWN GRAIN, measured in this page rather than quoted from a
+    // comment (rf2-d2tzk). It decides which of this run's magnitudes are
+    // reportable, so it rides the same JS-readable channel as the verdicts it
+    // governs instead of only the EDN blob.
+    const clock = await page.evaluate('window.HD8_CLOCK || null');
     const userAgent = await page.evaluate('navigator.userAgent');
     // THE SENTINEL'S OWN FAILURE LIST, read rather than discarded (rf2-x6g04).
     // `watch.race` throws on a failure that arrives while it is waiting, so
@@ -327,7 +332,7 @@ async function runOne(chromium, run) {
     watch.dispose();
     return {
       id: run.id, why: run.why, err, results, samples, summary,
-      correction, contractSelfTest, userAgent, lines, pageErrors,
+      correction, contractSelfTest, clock, userAgent, lines, pageErrors,
     };
   } finally {
     await browser.close();
@@ -353,10 +358,25 @@ function adjudicate(run) {
 // The table
 // ---------------------------------------------------------------------------
 
+// TWO PUBLICATION MASKS ARRIVE IN ONE SHAPE and print as two different
+// sentences, because they mean two different things and a reader must not
+// have to know which by looking up the reason code:
+//
+//   failed-dom-read-back   a FAULT — real milliseconds spent on a page that
+//                          never changed. Exit 3.
+//   below-clock-grain      a LIMIT — a window that does not exceed the clock's
+//                          own measured resolution, so the ratio taken against
+//                          it carries the grain rather than the arm. Exit 0,
+//                          and the row says so (rf2-d2tzk).
+//
+// Neither prints a number: that is the whole point of a mask.
 const band = (v) =>
-  v.unpublished
-    ? `UNPUBLISHED (${v.unverified}/${v.of} unverified)`
-    : `${v.min.toFixed(3)} – ${v.max.toFixed(3)}${v.straddles1 ? '  [STRADDLES 1.0 — indistinguishable]' : ''}`;
+  v.unpublished === 'below-clock-grain'
+    ? `NOT REPORTABLE — ${(v.arms || []).join(', ')} at ${v.quanta} tick(s) of this clock's ` +
+      `own ${v.tick} ms grain; no magnitude normalised by it is reportable`
+    : v.unpublished
+      ? `UNPUBLISHED (${v.unverified}/${v.of} unverified)`
+      : `${v.min.toFixed(3)} – ${v.max.toFixed(3)}${v.straddles1 ? '  [STRADDLES 1.0 — indistinguishable]' : ''}`;
 
 // The cross-run table. Every arm's figure is a ratio to the floor measured
 // in its OWN round, and the floor is the same hand-written `createElement`
@@ -372,6 +392,17 @@ function crossRun(runs) {
   out.push(';; ==== HD8 CROSS-RUN TABLE — every figure a RANGE over 6 rounds, ratio to the ====');
   out.push(';; ==== floor measured in the SAME round. The floor is identical code in an   ====');
   out.push(';; ==== identical bundle; only the installed adapter differs between runs.    ====');
+  // The clock that took every figure below, stated at the head of the table it
+  // governs. A ratio is only as resolved as its denominator, and a denominator
+  // is only as resolved as this number (rf2-d2tzk).
+  for (const run of runs) {
+    if (run.clock && run.clock.tick != null) {
+      out.push(
+        `;;   [${run.id.padEnd(7)}] clock grain ${run.clock.tick} ms, measured — ` +
+          `${run.clock.n} observations, differences ${JSON.stringify(run.clock.distinct)}`
+      );
+    }
+  }
   if (PARTIAL) {
     out.push(';;');
     out.push(`;;   PARTIAL RUN — HD8_ONLY=${ONLY}. This is not the published shape.`);
@@ -393,6 +424,18 @@ function crossRun(runs) {
       const s = run.summary[row];
       if (!s) continue;
       const mark = pub ? '' : ' [NON-PUBLISHING]';
+      // HOW MANY OF THE CLOCK'S OWN TICKS THIS ROW'S WINDOWS ARE WORTH,
+      // above the figures they form. A denominator worth one tick and a
+      // denominator worth ten produce the same-looking band, and only this
+      // line tells them apart (rf2-d2tzk). Printed for every write row,
+      // reportable or not: a reader who copies `11.000 – 13.667` needs to
+      // know that its denominator moved between one tick and two.
+      if (s.grain && s.grain.tick != null) {
+        const worst = Object.entries(s.grain.worst || {})
+          .map(([arm, q]) => `${arm} ${q == null ? '?' : q}`)
+          .join(', ');
+        out.push(`;;     [${run.id.padEnd(7)}] CLOCK GRAIN: ${s.grain.tick} ms measured — windows worth (ticks) ${worst}`);
+      }
       // The harness-microtask correction, stamped on the figures it governs.
       // `:not-owed` is the common case and says nothing; the other three all
       // change what a reader may do with the numbers on the line below.
@@ -501,6 +544,48 @@ function tableSelfTest() {
       ok: /donor-r1.*2\.000 – 2\.000.*\[UNADJUSTED\]/.test(out) && /donor-r1.*2\.200 – 2\.300.*\[CORRECTED\]/.test(out),
     },
   ];
+  // THE CLOCK-GRAIN MARKER, replayed through the same live `crossRun`
+  // (rf2-d2tzk). The live shape, from the run recorded on the bead: the bulk
+  // row's floor at one tick of a measured 0.1 ms grain takes the whole
+  // floor-normalised column, and the head-to-head pair — arm over arm, the
+  // floor cancelling exactly — is still printed as a number. A table that let
+  // either half of that slip is a table that publishes the grain.
+  const grainRuns = [
+    {
+      id: 'slim',
+      summary: {
+        'write-bulk': {
+          vsFloor: {
+            floor: { unpublished: 'below-clock-grain', arms: ['floor'], tick: 0.1, quanta: 1 },
+            'reagent-slim': { unpublished: 'below-clock-grain', arms: ['floor'], tick: 0.1, quanta: 1 },
+          },
+          headToHead: { 'donor-r1-over-reagent-slim': { min: 1.185, max: 1.313, straddles1: false } },
+          grain: { tick: 0.1, worst: { floor: 1, 'reagent-slim': 17 }, quanta: {} },
+        },
+      },
+      correction: { 'write-bulk': { verdict: 'moot', reason: 'no-published-figure-bears-it', bound: null, why: 'fixture' } },
+    },
+  ];
+  const gout = crossRun(grainRuns).join('\n');
+  checks.push(
+    {
+      name: 'a window beneath the clock grain prints NOT REPORTABLE and never a number',
+      ok:
+        /reagent-slim\s+vs floor\s+NOT REPORTABLE — floor at 1 tick\(s\) of this clock's own 0\.1 ms grain/.test(gout) &&
+        // and no numeric band anywhere on a vs-floor line of this row. The
+        // head-to-head line beside it carries the same arm's NAME and a real
+        // band, which is the point, so the check is anchored to the column.
+        !/vs floor\s+\d/.test(gout),
+    },
+    {
+      name: 'the head-to-head pair beside it still prints its band (the floor cancels)',
+      ok: /donor-r1-over-reagent-slim\s+1\.185 – 1\.313/.test(gout),
+    },
+    {
+      name: 'and the row states how many ticks each window was worth',
+      ok: /CLOCK GRAIN: 0\.1 ms measured — windows worth \(ticks\) floor 1, reagent-slim 17/.test(gout),
+    }
+  );
   return { ok: checks.every((c) => c.ok), checks };
 }
 
@@ -553,6 +638,14 @@ function tableSelfTest() {
 /** The flat record the exit is decided on. One entry per refusable thing. */
 function summarise({ hardFail, contractFailed, orderRefused, runs } = {}) {
   const unpublished = [];
+  // A LIMIT IS NOT A FAULT, and the exit code is where that distinction has
+  // to live or it does not exist. A window beneath the clock's own grain
+  // produces the same marker shape as a failed DOM read-back and must not
+  // produce the same exit: nothing is broken, the instrument simply cannot
+  // resolve that magnitude, and the row publishes THAT (rf2-d2tzk). Failing
+  // the sweep on it would also brick the driver — the bulk row's floor is one
+  // commit under one clock and sits on the grain by construction, every run.
+  const instrumentLimited = [];
   const refusedCorrections = [];
   const pageErrors = [];
   for (const run of runs || []) {
@@ -565,7 +658,12 @@ function summarise({ hardFail, contractFailed, orderRefused, runs } = {}) {
         ...Object.entries((s && s.headToHead) || {}),
       ];
       for (const [figure, v] of surfaces) {
-        if (v && v.unpublished) {
+        if (v && v.unpublished === 'below-clock-grain') {
+          instrumentLimited.push({
+            run: run.id, row, figure,
+            arms: (v.arms || []).join(', '), tick: v.tick, quanta: v.quanta,
+          });
+        } else if (v && v.unpublished) {
           unpublished.push({ run: run.id, row, figure, why: String(v.unpublished), unverified: v.unverified, of: v.of });
         }
       }
@@ -582,6 +680,7 @@ function summarise({ hardFail, contractFailed, orderRefused, runs } = {}) {
     orderRefused: Boolean(orderRefused),
     pageErrors,
     unpublished,
+    instrumentLimited,
     refusedCorrections,
   };
 }
@@ -591,6 +690,7 @@ function verdict(summary) {
   const s = summary || {};
   const pageErrors = s.pageErrors || [];
   const unpublished = s.unpublished || [];
+  const instrumentLimited = s.instrumentLimited || [];
   const refusedCorrections = s.refusedCorrections || [];
   const lines = [];
 
@@ -631,6 +731,23 @@ function verdict(summary) {
           .join('\n  ')
     );
   }
+  if (instrumentLimited.length) {
+    // NOT a refusal, and it deliberately does not read like one. The run
+    // measured what it could and states what it could not: a window that does
+    // not exceed the clock's own grain has no magnitude, so the table carries
+    // NOT REPORTABLE where a ratio would be. The permanent repair is the
+    // batched window the narrow row got, which changes a measured window and
+    // obliges a re-take of the row (rf2-2rtt6.7's to authorise).
+    lines.push(
+      '[hd8] NO REPORTABLE MAGNITUDE — a measured window does not exceed this clock\'s own grain ' +
+        '(rf2-d2tzk), so the figures normalised by it carry the instrument rather than the arm. ' +
+        'Everything else in this run stands, and the within-run head-to-head pairs are unaffected ' +
+        '(the floor cancels out of them exactly):\n  ' +
+        instrumentLimited
+          .map((u) => `${u.run} / ${u.row} / ${u.figure}: ${u.arms} at ${u.quanta} tick(s) of ${u.tick} ms`)
+          .join('\n  ')
+    );
+  }
   if (refusedCorrections.length) {
     lines.push(
       '[hd8] REFUSED — the harness-microtask yield correction could not be discharged ' +
@@ -640,6 +757,14 @@ function verdict(summary) {
     );
   }
 
+  // `instrumentLimited` is DELIBERATELY absent from this expression, and the
+  // deliberateness is written down because rf2-rr6do's recorded fault was
+  // exactly three refusals that printed and never reached the exit. This one
+  // is not a refusal: nothing failed, a magnitude was never available, and the
+  // run publishes that as its result. A driver that exited non-zero on it
+  // would exit non-zero on EVERY run — the bulk row's floor is one commit
+  // under one clock and sits on the grain by construction — which is a broken
+  // gate, not a strict one (rf2-d2tzk).
   const code =
     s.hardFail || pageErrors.length || s.contractFailed
       ? 1
@@ -764,6 +889,49 @@ function verdictSelfTest() {
   );
   const all = verdict(summarise({ hardFail: 'x', orderRefused: true, runs: [readBackRun(), refusedRun()] }));
   check('and the hardest code wins the exit while every line is still printed', all.code === 1 && all.lines.length === 4, `code ${all.code}, ${all.lines.length} lines`);
+
+  // --- (d) A WINDOW BENEATH THE CLOCK'S GRAIN — a LIMIT, not a fault ------
+  // The one condition here that must NOT reach a non-zero exit, and the
+  // fixtures say so from both sides: it is stated, it exits 0, and it does not
+  // become invisible when a real refusal fires beside it (rf2-d2tzk).
+  const grainRun = () =>
+    run({
+      summary: {
+        'write-bulk': {
+          vsFloor: {
+            floor: { unpublished: 'below-clock-grain', arms: ['floor'], tick: 0.1, quanta: 1 },
+            'reagent-slim': { unpublished: 'below-clock-grain', arms: ['floor'], tick: 0.1, quanta: 1 },
+          },
+          headToHead: { 'donor-r1 vs uix': { min: 1.185, max: 1.313 } },
+        },
+      },
+      correction: { 'write-bulk': { verdict: 'moot', reason: 'no-published-figure-bears-it' } },
+    });
+  const gl = verdict(summarise({ runs: [grainRun()] }));
+  check('a window beneath the clock grain exits 0 — nothing failed', gl.code === 0, `code ${gl.code}`);
+  check(
+    'and it is still STATED, naming the arm, the ticks and the grain',
+    /NO REPORTABLE MAGNITUDE/.test(gl.lines.join('\n')) &&
+      /slim \/ write-bulk \/ reagent-slim vs floor: floor at 1 tick\(s\) of 0\.1 ms/.test(gl.lines.join('\n')),
+    gl.lines.join(' | ')
+  );
+  check(
+    'and it does not read as a refusal — the word REFUSED is not in it',
+    !/REFUSED/.test(gl.lines.join('\n')),
+    gl.lines.join(' | ')
+  );
+  check(
+    'a `moot` correction is not a refusal either',
+    verdict(summarise({ runs: [run({ correction: { r: { verdict: 'moot' } } })] })).code === 0
+  );
+  const glrb = verdict(summarise({ runs: [grainRun(), readBackRun()] }));
+  check(
+    'and a real refusal beside it still exits 3, with BOTH sentences printed',
+    glrb.code === 3 &&
+      glrb.lines.some((l) => l.includes('NO REPORTABLE MAGNITUDE')) &&
+      glrb.lines.some((l) => l.includes('never reached the DOM')),
+    `code ${glrb.code}: ${glrb.lines.join(' | ')}`
+  );
 
   const empty = verdict(summarise({ runs: [] }));
   check('a run that took nothing is not a refusal', empty.code === 0 && empty.lines.length === 0);
@@ -940,7 +1108,15 @@ async function main() {
   if (decision.code !== 0) process.exit(decision.code);
   console.error(
     '[hd8] ok — measured; no arm reads differently for its position in the plan, every published ' +
-      'figure survived its DOM read-back, and no yield correction was refused'
+      'figure survived its DOM read-back, and no yield correction was refused' +
+      // The `ok` line must not claim more than the decision checked. A run can
+      // be entirely green and still have had a magnitude the clock could not
+      // resolve; the decision printed that above, and this line says which of
+      // the two it is rather than letting a green exit imply the stronger one
+      // (rf2-d2tzk).
+      (decision.lines.length
+        ? '. NOT every figure has a reportable magnitude — see above'
+        : '')
   );
 }
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
@@ -560,7 +560,7 @@ function tableSelfTest() {
             'reagent-slim': { unpublished: 'below-clock-grain', arms: ['floor'], tick: 0.1, quanta: 1 },
           },
           headToHead: { 'donor-r1-over-reagent-slim': { min: 1.185, max: 1.313, straddles1: false } },
-          grain: { tick: 0.1, worst: { floor: 1, 'reagent-slim': 17 }, quanta: {} },
+          grain: { tick: 0.1, worst: { floor: 1, 'reagent-slim': 17 } },
         },
       },
       correction: { 'write-bulk': { verdict: 'moot', reason: 'no-published-figure-bears-it', bound: null, why: 'fixture' } },


### PR DESCRIPTION
Closes rf2-d2tzk.

HD-008's bulk write row passes a batch of one — the pre-batch window exactly — and
its FLOOR arm is a single commit under one clock. The bead's complaint was that a
resolved harness-microtask yield makes the correction the whole of that floor, so
the row refuses. The measurement says the refusal was the smaller half of the
problem: **the row's disposition was drawn from the clock rather than from the
arms, and so was its magnitude.**

## What the row reported when the effect was absent, and when it was present

Same source, same host, same arms, four cold runs. Only the draw differs.

| run | bulk floor p50 per round (ms) | in ticks | `reagent-slim / floor` |
|---|---|---|---|
| baseline, before this branch | 0.10 0.10 0.10 0.20 0.15 0.20 | 1.0 – 2.0 | **8.500 – 17.500** |
| verify, on this branch | 0.20 0.20 0.20 0.20 0.15 0.20 | 1.5 – 2.0 | **9.333 – 10.500** |
| mutation A (+0.0064 ms) | 0.10 0.20 0.15 0.15 0.20 0.15 | 1.0 – 2.0 | **7.500 – 15.000** |
| mutation A2 (+0.0341 ms) | 0.20 0.20 0.20 0.20 0.15 0.15 | 1.5 – 2.0 | **8.000 – 10.667** |

The denominator only ever takes three values — `0.10`, `0.15`, `0.20` — because
the clock's grain, **measured in-page at 0.1 ms** (200 observations, every
observed difference a multiple of it), is the whole of its resolution. Adjacent
attainable denominators are 33 % to 100 % apart, so every ratio normalised by one
is determined only to within a factor of about two.

The row says so itself. In the baseline run the `reagent-slim` numerator moved
**1.18x** across the six rounds (1.70 → 2.00 ms) while the published ratio moved
**2.06x** (8.5 → 17.5). The whole of that swing is the denominator stepping
between one tick and two.

**Measured discriminating range.** The bulk row can separate effects larger than
about **2x** — one step of its denominator's lattice — and nothing finer. A band
like `11.000 – 13.667` (1.24x wide, four significant figures) is entirely inside
the uncertainty of a single one of its own endpoints.

## The option taken, and the two that were not

**A larger batch** is the repair the narrow row got (`narrow-batch-k`, rf2-9zysg)
and it is the right one. It changes a measured window and obliges a re-take of the
bulk row on every adapter — a re-publication, and rf2-2rtt6.7's to authorise. Not
taken here, exactly as the bead says.

**A finer clock** does not exist in this harness. The instrument now *measures*
that rather than asserting it: `clock-resolution!` reads the clock, spins until
the value changes, and records the difference. 0.1 ms, 200/200 observations
resolved, differences `[0.1]` / `[0.1 0.2 0.3]` — multiples of the grain, which is
what makes the reading a resolution and not a latency. Every studio page states
"Chrome clamps `performance.now()` to 100 µs" and reasons against 100 µs as a
constant; it is a constant of a browser build and its cross-origin-isolation
state, and the row it decides now takes it in the run it governs.

**So the claim narrows, and the instrument states the narrowing.** A window the
clock resolved less of than it missed has no magnitude:

    (v - tick) > tick

is the test — what was resolved must exceed what was not. That is word for word
the rule `correct-round` already applies to the harness turn (*what remains must
exceed what was removed*) with the instrument's own grain in place of the
correction. Two measured quantities, no constant between them. The weaker form,
`v > tick`, was tried first and **decided nothing**: it withheld the row on one
draw and published `9.333 – 10.500` on the next — the same coin toss moved one
place along. Fixture 10b now watches the boundary decide in both directions.

`mask-below-grain` withdraws what such a window forms, in the same marker shape
the DOM read-back mask uses and with a different meaning, kept apart at the exit:

* `failed-dom-read-back` — a **FAULT**. Real milliseconds spent on a page that
  never changed. Exit 3, unchanged.
* `below-clock-grain` — a **LIMIT**. Exit 0, stated as `NO REPORTABLE MAGNITUDE`,
  and the table prints `NOT REPORTABLE — floor at 1 tick(s) of this clock's own
  0.1 ms grain` where a ratio would be. Nothing failed; a magnitude was never
  available. Exiting non-zero here would exit non-zero on *every* run, which is a
  broken gate rather than a strict one — and the deliberateness is written down
  beside the exit expression, because rf2-rr6do's recorded fault was three
  refusals that printed and never reached the exit.

**Which figures go, and which do not.** The floor is the denominator of every
floor-normalised figure, so a floor beneath the grain takes that column. A
head-to-head pair is arm-over-arm and the floor cancels out of it exactly, so
those pairs **stand**. That is not a concession, it is the measurement: the clamp
destroys the cross-run column (which the studio page already calls *the weaker
warrant*) and leaves the within-run pairs (the stronger one) untouched.

## The refusal the bead filed on

`yield-correction` now adjudicates over the figures the row still **publishes**
(`published-arms`). On the slim run the bulk row's only yield-bearing arm is the
floor, the floor is its denominator, and that column is gone — so there is nothing
left for the subtraction to move or for a refusal to protect. The verdict is
`:moot`, and **it is the same on both draws of the clock**: fixture 10 replays the
identical row against a 0.0 aggregate and a 0.1 aggregate and gets `:moot` twice,
where before it got "publish unadjusted" and "fail the whole sweep".

The refusal itself is untouched. Fixture 4 — the row that made `pos?` publish
`15,518,934x` — is unmasked, so its bearer still carries a published figure and it
still refuses with `:correction-exceeds-window`. Every arm still has the bound
subtracted; only the survival *test* is restricted to bearers a published figure
is formed from.

## Mutation proofs, both directions

A calibrated burn injected into the floor arm's own write window, priced in-page
against the same clock (a thousand calls under one window, divided by a thousand),
run cold each time. The probe is temporary and is not in this diff.

* **A mutation that should move the row, and does not.** `+0.0341 ms` per write —
  34 % of a grain, a real +20–30 % on the floor's true cost. The row read
  `8.000 – 10.667`, which **overlaps all three unmutated draws** above. By this
  instrument's own house rule (overlapping ranges are indistinguishable), a
  one-third-of-a-grain change to the thing being measured is not resolved. That is
  the finding, not a failure.
* **A mutation that should move the row, and does.** `+0.263 ms` per write — 2.6
  grains. The floor read 4.0 – 5.5 ticks, the mask **released**, and the row
  published `3.250 – 4.500` — disjoint from every band above. The instrument is
  live, and the mask tracks the measurement rather than blanketing the row.

## A published claim that must narrow — for the operator to sequence

Not edited here (`docs/design/hicasso/**` is fenced, and there are live workers on
it). In `docs/design/hicasso/studio/hd8-composed-donor-arm.md`:

1. **"Write — bulk"**, the cross-run floor-normalised block — `donor-r1`
   `7.750 – 11.000`, `donor-r2` `8.250 – 11.750`, `reagent` `8.750 – 17.000`,
   `reagent-slim` `11.000 – 13.667`, and the `f5bd4b49` replication
   `9.500 – 13.000`. The instrument now withholds these: no magnitude in that
   column is reportable. The within-run head-to-head block directly above it
   (`donor-r1 / uix` `1.185 – 1.313` etc.) is unaffected and stands.
2. **The same paragraph's last sentence is inverted.** "Absolute p50s: ... floor
   0.15 – 0.20 ms — four to eighteen quanta, so this row is **far better resolved
   than the narrow one beside it**." Measured this session: the bulk floor is
   **1.5 – 2.0** quanta and the batched narrow floor is **9 – 10**. The narrow row
   is the better resolved of the two, by roughly five times.
3. **"Known limitations of this instrument"**, the bulk-floor bullet — "The
   published row was taken on a run whose harness-microtask aggregate read `0.0`,
   so nothing was owed and the figure stands." The *read-back counts* stand; the
   magnitude does not, and it is now withheld on every draw rather than on the
   unlucky ones.
4. **The re-take paragraph** — "The bulk row's one-turn aggregate read 0.0 in every
   window (`:below-resolution`), so `rf2-d2tzk`'s refusal did not arm on this
   draw." The verdict is `:moot` on every draw now, and nothing is drawn.

## What did not move

* **No other row's measurement, arm, threshold, dataset or exit code.** `mount-M`,
  `mount-U` and `write-narrow` take the same windows, the same arms and the same
  sampling; nothing under `data/` is touched. The narrow row's floor is 9 – 10
  ticks — `0.9 - 0.1 > 0.1` — so it is untouched by the mask and its correction is
  adjudicated exactly as before (fixture 11 pins both).
* **No refusal suppresses output.** Every table and raw record is written before
  the exit is consulted; the grain marker is printed, never withheld.
* **Every verification build was COLD.** `hd8_run.cjs`'s `build()` calls
  `resetLaneBuildCache()` before every run by construction (rf2-2rtt6.20).
* Two runs during this work fail-closed on the positive control (a loaded box,
  before any clock) and took nothing. They are reported rather than dropped: the
  fail-closed path is working, and neither is evidence about this change.

## Quality gates

Run from the worker worktree. **Every bench build was COLD** — `hd8_run.cjs`'s
`build()` calls `resetLaneBuildCache()` before every run by construction
(rf2-2rtt6.20), so a warm-cache reading is not reachable from this driver.

| gate | exit |
|---|---|
| `sh scripts/test-fast-pr.sh` | `0` — classification line: `=== fast PR spine: docs=false jvm=true node=true (classified) ===` |
| `npm run lint:js` (ROOT `package.json`) | `0` |
| `node …/hicasso/clock_exit_path.test.cjs` | `0` — **90 passed** (4 new) |
| `node …/hicasso/hd8_run.cjs --selftest` | `0` — guard 12/12, corrected-table **6/6** (3 new), exit-decision **24/24** (5 new) |
| `node …/hicasso/lane_build.test.cjs` | `0` |
| `cd implementation && npm run test:hicasso-compile` | `0` — 129 lane namespaces, **0 warnings** |
| `node …/hicasso/hd8_run.cjs` — the full three-run sweep, COLD | `0` — twice, at two different HEADs |
| `HD8_ONLY=slim node …/hicasso/hd8_run.cjs` — COLD | `0` |

In-bundle, before any clock, on every run of the sweep: the write rows'
publication contract replays **13/13** recorded fixtures through the live rules
(5 new — the grain mask, its boundary in both directions, the `:moot` correction
on both draws of the clock, the mask's release on a resolved floor, and the
fail-closed unmeasurable tick).

**What the final sweep printed** (at `cbe7fd9cd8`). `write-bulk` floor at
**2 ticks** in all three runs — *the draw the weaker `v > tick` rule would have
published* — and
every `vs floor` figure `NOT REPORTABLE`, every within-run
head-to-head pair printing a band (`donor-r1-over-uix` `1.100 – 1.200`,
`donor-r2-over-uix` `1.067 – 1.385`, `donor-fh-over-uix` `1.600 – 1.886`,
`donor-r2-over-donor-r1` `0.960 – 1.174` *straddles*, …), yield correction
`MOOT (no-published-figure-bears-it)` with `bearers-published []`.
`write-narrow` floor at **11 – 13 ticks**, every band printing, verdict
`:below-resolution` — unchanged. Mount rows untouched. Exit `0`.

The earlier sweep at `f0aaaa5272` read the bulk floor at **1 tick** in all three
runs and withheld the same column, so the mask has now been watched decide at
both of the values the row's denominator takes.

**Two runs during this work fail-closed on the positive control** (`2.9231` and
`3.8333` against a predicted `1.9934`, tolerance `0.30`) on a loaded box, before
any clock, and took nothing. Reported rather than dropped: the fail-closed path
is working and neither run is evidence about this change.
