### PR TITLE
docs(method): a design pass lands its conclusion in the tracked record (rf2-7r4a9)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -62,7 +62,25 @@ You are implementing <BEAD_ID> in <project + one-line description>.
 Do NOT link gitignored working files (the ai/ tree, findings docs) from committed
 docs — the strict-docs link validator fails the build in cascade. Inline a
 one-sentence summary instead.
+Working notes may live in ai/findings/ (gitignored — check there first for prior
+passes), but before the bead closes the verdict must be self-contained on the
+bead and any implementation-governing conclusion must land in its owning tracked
+record (spec/, docs/, docs/design/) — a fresh maintainer must never need
+ai/findings/; do not promote transcripts.
 ```
+
+**A pass that concludes only in the gitignored tree concludes where nobody can
+read it.** The paths in that last sentence are this repo's; the rule is not —
+every project keeps some scratch tree git cannot see, and that invisibility is
+what makes the failure silent: a bead can cite a design by a path no maintainer
+has. Two audits (`rf2-cgcv`, `rf2-kfpf`) were lost exactly that way, and a mayor
+re-ran an entire three-design programme in one day for want of looking there
+first. Widening what git tracks is not the fix — working notes still stay local,
+and only the conclusion is promoted, into whichever tracked record already owns
+the surface, as a dated amendment where one exists and a new page only when the
+evidence stands on its own. Three workers in a single day found their design
+already written in that tree and promoted the surviving conclusion rather than
+re-deriving it, which is why the preamble tells the worker to look there first.
 
 ## Quality gates — the discipline
 


### PR DESCRIPTION
Closes rf2-7r4a9.

A design or audit pass whose conclusion lives only in the gitignored working
tree concludes where no maintainer can read it, and the failure is silent
because `git grep` cannot see into that tree. This lands the rule that closes
it, in the one place that reaches every worker.

## What landed, and where

Two additions to `docs/the-mayor-method/dispatch-prompt-template.md`, both in
**§ Common preamble (every dispatch)** — the placement the bead's ruling names,
adjacent to the existing don't-link-gitignored-files sentence.

1. **Inside the paste-verbatim `text` block**, the ruled sentence verbatim. The
   preamble block is what actually reaches a worker, so the rule has to be in
   it rather than in prose the worker never sees.
2. **One prose paragraph immediately after the block**, giving the rule the
   rule-then-incident shape the rest of the file uses (cf. § Worktree boundary,
   which is prose-then-block-then-prose). It carries the evidence: two audits
   (`rf2-cgcv`, `rf2-kfpf`) lost exactly this way, a mayor re-running a whole
   three-design programme in one day for want of looking there first, and three
   workers in a single day finding their design already written in that tree
   and promoting the surviving conclusion rather than re-deriving it.

## OS-neutral method vs. repo-specific paths

The file's own preamble says project-specifics live with the project. The split
here follows the file's existing practice: the **paste block** is instance-level
and already names this repo's tree (`the ai/ tree, findings docs`) alongside
`<BEAD_ID>` placeholders, because it is adapted at dispatch time — so the ruled
sentence keeps its concrete `ai/findings/` and `spec/, docs/, docs/design/`. The
**prose** is method-level and states the rule generically, opening by saying so
outright: *the paths in that last sentence are this repo's; the rule is not —
every project keeps some scratch tree git cannot see.* A repo that spells its
trees differently reads the paragraph and substitutes.

Widening what git tracks is explicitly not the fix: `CLAUDE.md` is clear that
`/ai/` is local-only by default and the end state is that nothing under it is
tracked.

## Quality gates

Spine classification line, verbatim:
`=== fast PR spine: docs=true jvm=false node=false (classified) ===`

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | 0 |
| `python scripts/check_readme_links.py --ci` | 0 |
| `sh scripts/test-fast-pr.sh` | 0 |

**Which gate covers this file, mutation-proven.** `check_doc_slugs.py` is the
one: `docs` is in its `DEFAULT_ROOTS` and `docs/the-mayor-method/` is on none of
its exclusion lists (`EXCLUDE_DIR_NAMES` excludes `findings`, `ai`, `site`,
`node_modules`). Proof rather than assertion — a deliberate broken link was
appended to this file and the gate red on it *by name* before the exit code was
read:

```
BROKEN TARGET: docs\the-mayor-method\dispatch-prompt-template.md:258 -> ./7r4a9-no-such-file.md
    (missing: docs\the-mayor-method\7r4a9-no-such-file.md)
```
exit 1. Probe reverted, edit confirmed still present, gate re-run green. The
spine runs the same check as its `==> docs corpus anchor validator` phase.

Secondary coverage, checked rather than assumed:
- `mkdocs.yml` `exclude_docs` does **not** list `the-mayor-method/`, so
  `mkdocs --strict` does build this page (it appears in the build's
  not-in-nav INFO list). It ran inside the spine and passed, but it is the
  weaker gate here — nav-orphan pages get built, not link-audited the way the
  slug gate audits them.
- `check_readme_links.py --ci` covers this tree only indirectly: its
  `.claude/commands/*.md` resolver checks that references *to*
  `docs/the-mayor-method/*.md` resolve. It passes; no filename changed.

**Nothing validates tables.** The one table in this PR is in the PR body, not
the diff; the diff adds no table. Hand-checked anyway: 2 columns, 2 delimiters,
4 rows.

`git diff --numstat`: `18  0  docs/the-mayor-method/dispatch-prompt-template.md`
— 18 added, 0 deleted, no CRLF rewrite. `git grep -n 'Users/miket' -- docs/the-mayor-method/`
is empty: no absolute paths in committed content.
