### PR TITLE
docs(hicasso): guide 06 teaches the ruled theming default (rf2-2rtt6.108)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -306,6 +306,83 @@ signal, not verdicts.
 
 ## HD-010 — Theming; no native context API
 
+> **Addendum, 2026-08-06 — the bridge from layer 3 to layer 1 is a RENDERED
+> scope, and the attribute is PER-ROOT (`rf2-2rtt6.108`).** The ruling below
+> fixes the three layers and leaves unnamed the thing that joins the app-db
+> choice to the `data-theme` the cascade keys off; the guide carried both
+> candidates as open questions. A delegated design pass and an adversarial pass
+> ran on 2026-08-04 (0 FATAL / 4 MAJOR / 5 MINOR, verdict *ratify with the named
+> repairs*), and the shape was re-verified against `main` and priced on
+> 2026-08-06 in
+> [the studio dossier](studio/108-the-theming-taught-default-priced.md).
+> Operator-overturnable. Nothing below is withdrawn: the three layers, the two
+> laws and the no-context ruling stand unamended.
+>
+> **Option A is the taught default.** One view reads the theme sub and renders
+> `data-theme` on its own element; below it the value-equality bail-out keeps the
+> tree quiet. Its case is derivation (a rewind, a restored snapshot and a test
+> fixture that writes the theme all agree with the screen), SSR (the same
+> renderer emits the attribute from the same snapshot), boot coherence,
+> testability as an ordinary `:db` write, and Xray visibility. **Option B — an
+> app-owned fx flipping the attribute — stays documented rather than
+> deprecated**, as the zero-render alternative; what it costs is derivation, plus
+> a server response that carries no attribute at all, so an SSR'd page flashes
+> the wrong theme until the client boots.
+>
+> **The scope is per-root, and it is entailed rather than chosen.** A view
+> renders its own element and nothing above it, and `spec/011-SSR.md`
+> §*Head/meta contract* records that there is no DOM-head reconciler — so an
+> A-shaped per-document bridge is not a design that lost, it is not writable. The
+> space is three points, not four. Per-root is also what `spec/004-Views.md`
+> §*Theming and semantic parts* already rules — *"an ancestor scope the
+> application renders once"* — and what the shipped browser witness
+> `pilot_theming_dom_cljs_test.cljs` already does, setting `data-theme` on the
+> mount container and never on `documentElement`. The guide's second open
+> question therefore retires as **answered by the spec**, not as newly decided
+> here, which is the smaller and truer claim.
+>
+> **Page chrome is a projection, not a second carrier.** Document-level chrome —
+> the scrollbar, the `<body>` canvas, `theme-color` — sits above every frame, so
+> an app that wants it themed echoes the same db fact document-level *outside*
+> this contract: `:html-attrs` on the server, one app-owned fx on the client,
+> under an attribute name distinct from the scope selector. One source, two
+> projections, deliberately asymmetric — the rendered root attribute stays the
+> app's only theme carrier and the document attribute is a redundant cosmetic
+> copy, which is why doubling it is not the incoherence that doubling a carrier
+> would be.
+>
+> **The multi-frame cost question closes by argument. No measurement, no
+> quiet-box row.** A theme switch is a rare, user-initiated action, and per
+> switch per frame the cost is one small boundary body plus one `=` compare —
+> *a fortiori* the page-chrome shape
+> [HD-028](#hd-028--value-equality-is-the-boundary-default) already measured at
+> 300 bodies plain versus 0 memoized. **Conditioning clause:** that arithmetic
+> rides HD-028's *default* bail-out, whose own `Reopens` clause is live as of its
+> 2026-08-04 amendment. If the default is ever revised, option A's quiet tree is
+> re-derived on the successor mechanism — one explicit opt-in at the single
+> boundary below the scope — and this addendum survives either disposition. Only
+> the mechanism sentence moves.
+>
+> **Three 2026-08-05 landings neither pass could have seen, all folded into the
+> guide.** The memo default narrowed to the heads `defview` mints
+> (`rf2-2rtt6.102`, `rf2-u09ay`), so A's precondition is *what* sits below the
+> scope rather than *where* — a native-tag subtree, a fragment or a `defhost`
+> crossing carries no wrapper, and that is a second cause of the guide's
+> whole-app re-render row. A's SSR divergence is **attribute-only**, exactly the
+> class this adoption tier never reports, so A trades B's loud transient failure
+> for a silent persistent one, conditional on the payload carrying the choice;
+> "no flash by construction" is withdrawn and the guide carries a troubleshooting
+> row instead. And a scope below a `defhost` crossing is deleted from the server
+> response silently under `:client-only` and under `{:fallback …}`
+> (`rf2-l0wfx`, `rf2-nv07k`), which is why per-root **at the top** is the
+> load-bearing form. `::backdrop` is scope-neutral on every engine generation —
+> Chromium 122 / Firefox 120 / Safari 17.4 and later inherit it from the
+> originating element, and earlier engines stranded it under per-document too —
+> so per-root cannot strand the top layer.
+>
+> **No new public concept is minted by taking this ruling**, and no code, no new
+> fx and no measurement follow from it.
+
 **Ruling.** Hicasso ships **no context abstraction of its own**, and its native
 theming uses none; the substrate keeps exactly one internal context (frame
 identity). Ordinary React context remains available to advanced authors at the

--- a/docs/design/hicasso/draft-guide/06-theming.md
+++ b/docs/design/hicasso/draft-guide/06-theming.md
@@ -108,7 +108,17 @@ choice.
 The event above moves a keyword into app-db. Layer 1's cascade keys off a
 `data-theme` attribute on a DOM element. Something has to join them.
 
-Two practical options. Pick one for your app; neither needs a new Hicasso API.
+**A view renders the attribute. That is the default**, and the reason is the one
+this guide leans on everywhere else: the DOM stays derived from app-db, so a
+rewind in Xray, a restored snapshot and a test fixture that writes the theme all
+agree with what is on screen. Option B below asserts the attribute imperatively
+from an effect, and stays documented for apps that want literally zero render work
+on a switch.
+
+If all you want is *follow the OS*, you need no bridge at all — a
+`@media (prefers-color-scheme: dark)` block in layer 1's stylesheet themes the
+page with no app state, no subscription and no effect. Bridge the choice when the
+**user** picks the theme, or when their pick has to survive a reload.
 
 ### Option A — a scope view reads the choice
 
@@ -127,23 +137,78 @@ One view reads `:theme/current` and puts it on its own element:
 spliced with `into` rather than dropped in as one child —
 [Views and reads](02-views-and-reads.md#the-component-abi) has the rule.
 
+**Where the attribute lands.** A view renders its own element and nothing above
+it, so `data-theme` goes on `theme-scope`'s own `div`: per frame, never per
+document. That is not a second decision you make after picking A — it is the only
+place the attribute can go, and it happens to be what frame isolation needs. Two
+frames on one page, one light and one dark, is an ordinary story page and an
+unwritable one against a single `documentElement`.
+
+Keep the scope at the frame's root, above any [`defhost`](05-interop.md) crossing.
+Under the default `:ssr :client-only` policy — and under `{:fallback …}` — a
+crossing renders *instead of* its subtree, so a scope beneath one goes missing
+from the server response along with everything it was scoping, and nothing reports
+it ([Server-side rendering](10-server-side-rendering.md#render--when-the-region-has-to-be-in-the-response)).
+
+Per-root does not strand the top layer. `::backdrop` inherits from its originating
+element on Chromium 122, Firefox 120 and Safari 17.4 and later, so a dialog opened
+inside the scope takes the scope's tokens; on engines older than those it
+inherited from nothing, which a document-level attribute did not fix either.
+
 **Tradeoff.** The boundary that reads the theme re-renders on every switch — one
-boundary, known cost. What happens below it depends on the
-[default value-equality bail-out](02-views-and-reads.md#boundaries-memoize-by-default).
-`app` is a boundary either way (handed down as `children` or minted inside
-`theme-scope`), and its props are unaffected by the theme, so they compare `=` and
-its memo wrapper bails. Lose that only by calling `app` as a plain function instead
-of writing `[app {}]` — a plain call has no boundary of its own, so it re-runs with
-`theme-scope` every time.
+boundary, known cost. What happens below it depends on *what sits there*. The
+[value-equality bail-out](02-views-and-reads.md#boundaries-memoize-by-default) is
+carried by heads `defview` mints, so `[app {}]` bails because `app` is a `defview`
+and its props are unaffected by the theme. A native-tag subtree, a fragment, or a
+`defhost` crossing carries no wrapper and re-runs with the scope — and so does
+`app` called as a plain function, which mints no boundary at all. Keep a `defview`
+head immediately below the scope and the rest of the tree stays quiet.
 
 Element identity does not help here: children cross a boundary as hiccup data, not
 as React elements, so `theme-scope` mints a fresh element for `app` on every render.
 The skip is always the comparator's `=`, never a referential short-circuit — and
-`=` on an unchanged props map is cheap. Keep `app` a boundary and the rest of the
-tree stays quiet.
+`=` on an unchanged props map is cheap.
+
+That quiet subtree rides the bail-out being the **default**, which guide 02 still
+lists as unsettled. If it ever becomes something you ask for, the arithmetic does
+not move: one boundary asks, and the tree below it is quiet again.
 
 **Wins.** The DOM is derived from state. Rewind app-db in Xray and the attribute
-follows. Tests and restored snapshots stay consistent.
+follows; tests and restored snapshots stay consistent. The server render is the
+same view reading the same snapshot, so the response carries the attribute and
+hydration adopts it — **as long as the payload carries the choice**. If it does
+not, the two sides disagree about one attribute, and an attribute-only divergence
+is the one class React never reports
+([Server-side rendering](10-server-side-rendering.md#troubleshooting)): the page
+hydrates in the server's theme and stays there until that boundary next re-renders.
+B's cost is a flash you can watch happen; A's residual cost is a wrong attribute
+nobody tells you about.
+
+**Page chrome.** The document scrollbar, the `<body>` canvas and
+`<meta name="theme-color">` sit above every frame, so a per-root attribute does not
+reach them. Echo the same db fact document-level, outside Hicasso's contract — on
+the client, that is one app-owned effect:
+
+```clojure
+(rf/reg-fx :page/echo-theme!                    ;; a projection, not the bridge
+  {:platforms #{:client}}
+  (fn [_ctx theme]
+    (.setAttribute (.-documentElement js/document)
+                   "data-page-theme" (name theme))))
+```
+
+`:theme/choose` returns it as a row under `:fx` beside its `:db` write — option B
+below shows that shape. On the server the same keyword rides `:html-attrs` in the
+head model your route already declares, which is a pure function of app-db, so it
+is there on the first byte. Give the document copy a **different attribute name**
+than layer 1's scope selector, as above: reuse `data-theme` on `<html>` and the
+cascade honours it as a real second carrier for every frame that has no scope of
+its own.
+
+One source, two projections, and deliberately asymmetric: the rendered root
+attribute is the app's only theme carrier, the document copy is cosmetic, and a
+stale copy costs you a scrollbar colour. Doubling the *carrier* — mixing A and B
+over the same elements — is the incoherence worth avoiding.
 
 ### Option B — an effect writes the attribute
 
@@ -178,17 +243,28 @@ you give up:
   otherwise.
 - **Boot needs its own hand.** Apply the initial theme with an initial event that
   carries the same effect, or the first paint is unthemed.
-- **It is not frame-isolated.** `document.documentElement` is one element; two
-  frames on one page share it. Targeting each root's own node would need the
-  effect to reach that node, and nothing in the product says an effect can today.
+- **The server response carries no attribute.** The effect is client-only by
+  declaration, so an SSR'd page arrives unthemed and flips when the client boots.
+  That flash is visible, self-healing and about as diagnosable as a page load gets
+  — the opposite polarity to A's silent divergence.
+- **It is per-document as written.** `document.documentElement` is one element and
+  two frames on one page share it, so two themes at once is not expressible.
+  Per-frame B *is* writable: an fx handler receives the frame id in its context
+  ([Events as data](03-events-as-data.md#callbacks-carry-their-frame)), so an
+  app-owned `frame-id → node` map populated at mount plus one effect reading it
+  runs to about five lines. Five lines you then own.
 
 ### Which one?
 
-Ordinary trade: render a fact (A) vs assert it imperatively (B). A keeps derivation
-at the cost of one reading boundary; B has no render cost and gives up derivation.
-Neither is the taught default yet — whether A's cost holds at one boundary under
-multi-frame load, and whether the theme attribute is per-root or per-document, are
-still open. Until those settle, pick the tradeoff that matches your app.
+**A, unless you have a reason.** Rendering the fact keeps every derived-state
+property the rest of this guide builds on, and the cost is one boundary re-running
+on an action users take rarely.
+
+Take B when you have measured a need for zero render work on the switch and can
+live without derivation — no rewind, no snapshot restore, no fixture that themes
+by writing app-db — and when the page is client-rendered, so the flash never
+happens. Nothing about starting on A makes that move harder: B is `rf/reg-fx`,
+public API you have already met.
 
 ## The two laws
 
@@ -242,7 +318,8 @@ structural tests can see less of. Honest trade, stated once.
 |---|---|---|
 | Blank page on first load, console shows `Doesn't support name:` | Nobody had chosen a theme, the sub read `nil`, and `(name nil)` threw at the root | Give the sub a default, as layer 3 does |
 | The theme keyword changes in app-db and nothing on screen changes | No bridge is wired — app-db holds the choice; the cascade keys off a DOM attribute | Wire option A or B above; the event alone does nothing to the document |
-| Theme switch re-renders the whole app | Option A, with the themed content spliced in as a plain call rather than an `[app {}]` vector | Put the content behind a boundary (children or a direct `[app {}]`), or use option B |
+| Theme switch re-renders the whole app | Option A, and what sits below the scope carries no memo wrapper — a native-tag subtree, a fragment, a `defhost` crossing, or `app` called as a plain function | Put a `defview` head immediately below the scope, as `[app {}]` does; or use option B |
+| The hydrated page keeps the server's theme and never corrects itself | Option A, and the two sides disagreed about the choice — the payload did not carry `:theme/current`, or each derived it differently. An attribute-only divergence is the one class React never reports | Allowlist the key in the hydration payload; there is no diagnostic coming ([Server-side rendering](10-server-side-rendering.md#instance-state-and-the-payload-allowlist)) |
 | A time-travel rewind shows the old theme | Option B — the attribute was asserted by an effect, so it is not derived from the state you rewound | Expected under B; it is the price named above |
 | A controlled input's value gets clobbered by a theme | Should be impossible — law (a) | A runtime bug, not a usage error |
 | A part override doesn't take effect | Merge order: instance props beat app theme beat base | Check which layer you set it in |
@@ -263,8 +340,6 @@ order to remember, in exchange for flexibility nobody will use.
 
 | Question | Status |
 |---|---|
-| How the app-db choice reaches the `data-theme` scope | Open. Both bridges above work; neither is the taught default yet |
-| Whether the theme attribute is per-root or per-document | Open. Layer 3 promises frame isolation; a document-level attribute does not have it |
 | How a control declares a part | Open. "Controls emit keyword-tagged parts" is the claim; the attribute or macro is unnamed |
 | How an app installs a theme | Open. Merge order is fixed; the mechanism that supplies the app-theme layer is not |
 | The part-address shape | This guide writes `[:typeahead :root]` by analogy; the actual shape is unstated |


### PR DESCRIPTION
Implements the delegated ruling on `rf2-2rtt6.108` as re-verified and priced in
`docs/design/hicasso/studio/108-the-theming-taught-default-priced.md`. Docs-only,
two files, no code, no new fx, no measurement.

## What changed

**Guide 06 states the default up front.** A view renders the attribute; option B
stays documented as the zero-render alternative rather than deprecated. The
"Which one?" section now answers its own question instead of deferring it.

**Both "Not settled yet" rows retire, and for different reasons.** The bridge row
retires by this ruling. The per-root row retires as *answered by the spec* —
`spec/004-Views.md` §Theming and semantic parts already rules the scope as "an
ancestor scope the application renders once", and the shipped browser witness
`pilot_theming_dom_cljs_test.cljs` sets `data-theme` on the mount container and
never on `documentElement`. So the guide claims the smaller, truer thing.
Per-root is also *entailed*: a view renders its own element and nothing above it,
so there is no second decision for the reader to hold.

**Three 2026-08-05 landings folded in.**

- The memo default narrowed to the heads `defview` mints, so the tradeoff
  paragraph no longer says "a vector head is a boundary". A's precondition is now
  stated as *what* sits below the scope, not *where* — and the whole-app-re-render
  troubleshooting row gains that second cause (a native-tag subtree, a fragment,
  or a `defhost` crossing carries no wrapper).
- A's SSR divergence is attribute-only, exactly the class this adoption tier never
  reports. "No flash by construction" is gone; the Wins paragraph is conditioned on
  the payload carrying the choice, and a new troubleshooting row covers the silent
  persistent failure. The honest inversion is stated: A trades B's loud transient
  failure for a quiet one.
- A scope below a `defhost` crossing is deleted from the server response silently
  under `:client-only` and `{:fallback …}` — one cross-reference sentence, and the
  reason per-root-*at-the-top* is the load-bearing form.

**The now-false claim is gone.** 06 said "nothing in the product says an effect
can [reach that node] today". `h/frame` has shipped and guide 03 §Callbacks carry
their frame teaches "an fx handler receives the frame id in its context", so that
was wrong in spec and in the guide's own teaching. Option B's bullet now says
per-frame B *is* writable in about five lines, and A's case rests on SSR,
derivation and boot instead.

**Also folded:** the F1 conditioning sentence (the quiet subtree rides the
bail-out being the default, which guide 02 still lists as unsettled); the
document-chrome echo under a distinct fx name with the one-source-two-projections
asymmetry stated; the `prefers-color-scheme` note for readers who only want to
follow the OS; and the `::backdrop` version floor.

**`decisions.md`** gains one dated HD-010 addendum in the file's own idiom — a
blockquote directly after the heading, newest-first, with the ruling below left
untouched as the record it is.

## What was preserved

The `rf2-2rtt6.133` fix (PR #7580) is intact and untouched: layer 3's sub still
reads `(:theme/current db :light)`, the "the default belongs in the sub, not in
each reader" paragraph stands, the `:initial-events` sentence stands, and the
`Doesn't support name:` troubleshooting row stands. That fix is what makes option
A's `(name (sub [:theme/current]))` sample true, so it is load-bearing for this
rewrite rather than incidental to it.

## Quality gates

| Gate | Result |
|---|---|
| `python scripts/check_doc_slugs.py` | **exit 0** |
| `sh scripts/test-fast-pr.sh` | **exit 0** — classification line: `=== fast PR spine: docs=true jvm=false node=false (classified) ===` |
| `mkdocs build --strict` | **not applicable and not run** — `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site |

*Three columns; three body rows; hand-counted.*

**Mutation proof for the slug checker.** Replaced the new troubleshooting row's
`10-server-side-rendering.md#instance-state-and-the-payload-allowlist` with
`#mutation-proof-anchor-does-not-exist`; `grep` confirmed the edit had landed at
line 322 **before** the checker ran; the checker then printed
`1 broken anchor link(s) found` naming that line and exited **1**. Mutation
reverted, checker back to exit 0. The gate is live on this file's anchors.

**Tables, hand-verified** (nothing validates them):

- `06-theming.md` §Troubleshooting — 3 header columns, 3 separator columns,
  **9 body rows**, every row 3 cells. Was 8 rows; the SSR row is the addition.
- `06-theming.md` §Not settled yet — 2 header columns, 2 separator columns,
  **5 body rows**, every row 2 cells. Was 7 rows; two retired.
- `decisions.md` — **no table added or touched**; the diff contains zero
  pipe-leading lines.

**Anchors, hand-verified** (all six new cross-links, each confirmed against the
target file's headings): `05-interop.md`;
`10-server-side-rendering.md#render--when-the-region-has-to-be-in-the-response`;
`10-server-side-rendering.md#troubleshooting`;
`10-server-side-rendering.md#instance-state-and-the-payload-allowlist`;
`02-views-and-reads.md#boundaries-memoize-by-default`;
`03-events-as-data.md#callbacks-carry-their-frame`. In `decisions.md`:
`studio/108-the-theming-taught-default-priced.md` and
`#hd-028--value-equality-is-the-boundary-default`.

**What was verified how.** There is no `implementation/hicasso/` package, so the
literal samples have no runtime and none was executed. Every API shape in the new
prose was checked against the tree instead: `reg-fx`'s `{:platforms #{:client}}`
option against `implementation/core/src/re_frame/fx.cljc`; `reg-head` and
`:html-attrs` against `implementation/core/src/re_frame/core.cljc` and
`spec/011-SSR.md`; "an fx handler receives the frame id in its context" against
guide 03's own text; the memo narrowing against guide 02's
"every head `defview` mints"; the per-root witness against
`pilot_theming_dom_cljs_test.cljs`. No provisional error id is printed — the only
id in the chapter is the pre-existing `:rf.error/effect-map-shape`, which resolves
in `implementation/core/src/re_frame/fx.cljc`.

## Line delta

`06-theming.md` +97 / −22 (net **+75**, 272 → 347 lines). `decisions.md` +77 / −0.
The additions are the ruling's mandated content; the trims are the two retired
rows and the superseded tradeoff prose.
