### PR TITLE
fix(ui): the last two production-reachable diagnostics report instead of overflowing (rf2-30dc7)

### DIFF
--- a/implementation/ui/src/re_frame/ui.cljc
+++ b/implementation/ui/src/re_frame/ui.cljc
@@ -332,12 +332,16 @@
   into helpers, or make the helper a defview. Explicit headless probing belongs
   to the test/observation seam."
   [query]
+  ;; `error/pr-form` / `error/safe-form`, not bare `pr-str`: the whole body is
+  ;; the throw, so `query` is whatever the author passed — including a foreign
+  ;; JS value, and a cyclic one (a React context) would make `pr-str` blow the
+  ;; stack instead of producing this error (rf2-30dc7).
   (error/throw-error!
    :rf.error/ui-tree-malformed 're-frame.ui/sub
-   (str "(ui/sub " (pr-str query) ") executed outside compiler lowering — "
+   (str "(ui/sub " (error/pr-form query) ") executed outside compiler lowering — "
         "ui/sub is a lexical defview form, not a callable subscription helper. "
         "Pass the read value into the helper or extract a defview")
-   {:extra {:query query}}))
+   {:extra {:query (error/safe-form query)}}))
 
 (defn frame
   "(frame) is the compiler-owned ops-bundle body form: inside a compiled

--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -2150,11 +2150,19 @@
                (nil? slot)
                (error/throw-error!
                 :rf.error/ui-tree-malformed 're-frame.ui/spread-safe
-                (str "(ui/spread-safe owned caller) — the caller attr key " (pr-str k)
+                ;; `error/pr-form` / `error/safe-form`, not bare `pr-str`: this is
+                ;; the ONE branch of this guard reached with a value that is not
+                ;; provably nameable — `caller-key-slot` returned nil, so `k` is a
+                ;; foreign object used as a map key, and a cyclic one (a React
+                ;; context) would make `pr-str` blow the stack instead of
+                ;; producing this error (rf2-30dc7). The two sibling arms below
+                ;; are gated on a NON-nil slot, so their `k` provably IS nameable
+                ;; and stays a bare `pr-str`.
+                (str "(ui/spread-safe owned caller) — the caller attr key " (error/pr-form k)
                      " is not a nameable attribute key (a keyword, string, or symbol), "
                      "so it has no canonical DOM/React name to check against the "
                      "owned-key deny law. Use a keyword attr key")
-                {:extra {:key k}})
+                {:extra {:key (error/safe-form k)}})
 
                (or (contains? spread-safe-denied-structural-slots slot)
                    (contains? owned-slots slot))

--- a/implementation/ui/test/re_frame/ui/diagnostic_cycle_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/diagnostic_cycle_cljs_test.cljs
@@ -36,12 +36,31 @@
   `{:extra {:value v}}` explodes at a DOWNSTREAM logger / error projector /
   trace sink — someone else's boundary rather than the thrower's.
 
+  ## The AUTHORING-FORM tier (rf2-30dc7)
+
+  Two more sites join the file, and they are one tier UP from the client
+  runtime: the two ungated, both-host guards on the AUTHORING forms
+  themselves. `re-frame.ui.rules/assert-safe-caller!`'s nil-slot branch —
+  reached when a `ui/spread-safe` caller map carries a key that is not a
+  keyword, string or symbol, i.e. a foreign object used as a map key — and
+  `re-frame.ui/sub`'s body, which IS a throw and so prints whatever an
+  author passed a direct `(ui/sub …)` call. Neither is `goog.DEBUG`-gated,
+  so both reach a production page through the thrown error; both now print
+  through the same pair as every site above.
+
+  The seven remaining `pr-str` crossings under `implementation/ui/src` are
+  recorded triaged-out on rf2-30dc7 — debug-gated warn, test surface, or
+  tool-author — and the compile/macro tier is unreachable by construction (a
+  form read by the Clojure reader cannot be a cyclic foreign object).
+
   [[the-fixtures-are-genuinely-cyclic]] is the non-vacuity control. Without
   it every row below could pass on an acyclic fixture and prove nothing."
   (:require ["react" :as react]
             [clojure.string :as str]
             [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.ui :as ui]
             [re-frame.ui.events :as events]
+            [re-frame.ui.rules :as rules]
             [re-frame.ui.runtime :as runtime]
             [re-frame.ui.tree :as tree]))
 
@@ -188,6 +207,12 @@
          crosses between the two freely, which is why the detector has to")
     (is (= "RangeError" (:threw (outcome #(pr-str {:event [:x provider]}))))
         "and so does a handler options map holding one inside its :event")
+    (is (= "RangeError" (:threw (outcome #(pr-str [:q provider]))))
+        "and so does a SUBSCRIPTION VECTOR holding one — the exact value the
+         `ui/sub` misuse diagnostic prints (rf2-30dc7)")
+    (is (= "RangeError" (:threw (outcome #(pr-str [:q #js {"held" [:page provider]}]))))
+        "and so does the deeper mixed chain through a query vector — vector,
+         foreign object, vector, foreign object")
     (is (identical? provider (.-Provider provider))
         "because React 19's ctx.Provider IS the context object, and that
          object carries a Provider key pointing back at itself — the cycle
@@ -357,6 +382,85 @@
                      "site-0" {:event [:x provider] :capture true} nil))))
 
 ;; ---------------------------------------------------------------------------
+;; re-frame.ui.rules — the ui/spread-safe caller guard (rf2-30dc7)
+;;
+;; `assert-safe-caller!` is NOT `goog.DEBUG`-gated (that is the whole point of
+;; the owned-key deny law, and `spread-safe-deny-elision-prod-test` pins it in
+;; an :advanced build), so this crossing is production-reachable on both hosts.
+;;
+;; THE EMITTED PATH, not a hand-call: `(ui/spread-safe owned caller)` is a
+;; template form whose var throws `:rf.error/ui-spread-outside-template` when
+;; invoked directly, so an author reaches the guard through the compiler's
+;; lowering — `runtime/spread-safe->props` on the CLJS arm. These rows drive
+;; that function, and the direct `rules/assert-safe-caller!` row beside it is
+;; the host-agnostic guard the JVM tree builder calls at tree.cljc as well.
+;; ---------------------------------------------------------------------------
+
+(deftest spread-safe-caller-rejects-a-cyclic-key-with-its-own-error
+  (testing "`caller-key-slot` returns nil for a key that is not a keyword,
+           string or symbol — so a foreign JS object used as a caller attr
+           key lands on the nil-slot branch, which prints the key. That is
+           the ONE branch of this guard whose `k` is not provably nameable:
+           the two denied-slot arms below it are gated on a NON-nil slot and
+           stay bare `pr-str` by construction."
+    (doseq [[label k] [["a provider as a caller attr key"    provider]
+                       ["a hand-built cyclic object as one"  (self-referential-object)]
+                       ["a cyclic array as one"              (self-referential-array)]
+                       ["a mixed chain as one"               #js {"held" [:p provider]}]]]
+      (rejected-with :rf.error/ui-tree-malformed
+                     (str label " (through the emitted spread-safe lowering)")
+                     #(runtime/spread-safe->props "div" {k "x"} #{} nil nil))
+      (rejected-with :rf.error/ui-tree-malformed
+                     (str label " (through the both-host guard directly)")
+                     #(rules/assert-safe-caller! {k "x"} #{})))))
+
+(deftest spread-safe-caller-nameable-keys-are-unaffected
+  (testing "The counterpart measurement. A NAMEABLE key never reaches the
+           nil-slot branch, so the denied-slot arms keep printing through
+           bare `pr-str` — and the cleared sites stay cleared."
+    (let [o (outcome #(rules/assert-safe-caller! {:value "hijack"} #{}))]
+      (is (= :rf.error/ui-tree-malformed (:error-id o))
+          (str "a denied structural key still throws; got " (pr-str o))))
+    (is (= {:aria-label "x"} (rules/assert-safe-caller! {:aria-label "x"} #{}))
+        "and an allowed caller still canonicalizes and passes")))
+
+;; ---------------------------------------------------------------------------
+;; re-frame.ui/sub — the direct-call misuse diagnostic (rf2-30dc7)
+;;
+;; `ui/sub` is the TAUGHT spelling of a reactive read, and its var body IS the
+;; throw: no guard, no `goog.DEBUG` gate, both hosts. Any `(ui/sub …)` the view
+;; compiler did not lower — the documented case being a call from a plain
+;; helper fn — prints whatever the author passed. A React context passed into
+;; such a helper is an ordinary authoring mistake on an EXPERIMENTAL substrate,
+;; which is exactly the author this diagnostic is written for.
+;; ---------------------------------------------------------------------------
+
+(defn- helper-that-calls-sub
+  "A plain fn — not a `defview` body — so the view compiler cannot inspect it
+  and `(ui/sub …)` stays an ordinary call. This is the misuse the diagnostic
+  names, spelled the way the docstring names it."
+  [x]
+  (ui/sub [:q x]))
+
+(deftest ui-sub-direct-call-rejects-a-cyclic-query-with-its-own-error
+  (testing "The whole body is the throw, so every direct call reaches it and
+           the query is whatever the author built. A subscription vector
+           holding a provider is the mixed chain — persistent vector, foreign
+           object — that a walk stopping at the first CLJS collection would
+           wrongly call acyclic."
+    (doseq [[label x] [["a provider in the query"        provider]
+                       ["a cyclic object in the query"   (self-referential-object)]
+                       ["a cyclic array in the query"    (self-referential-array)]
+                       ["a mixed chain in the query"     #js {"held" [:p provider]}]]]
+      (rejected-with :rf.error/ui-tree-malformed
+                     (str label " (through the documented helper misuse)")
+                     #(helper-that-calls-sub x)))
+
+    (rejected-with :rf.error/ui-tree-malformed
+                   "a BARE foreign object as the whole query"
+                   #(ui/sub provider))))
+
+;; ---------------------------------------------------------------------------
 ;; The acyclic path, byte for byte
 ;; ---------------------------------------------------------------------------
 
@@ -442,6 +546,22 @@
       (is (= :rf.error/ui-tree-malformed (:error-id o)))
       (is (str/includes? (:message o) (str "got " (pr-str v)))
           (str "options map printed byte-identically to pr-str; got "
+               (pr-str (:message o)))))
+
+    ;; rules/assert-safe-caller!, the nil-slot branch (rf2-30dc7)
+    (let [o (outcome #(rules/assert-safe-caller! {acyclic-object "x"} #{}))]
+      (is (= :rf.error/ui-tree-malformed (:error-id o)))
+      (is (str/includes? (:message o)
+                         (str "the caller attr key " (pr-str acyclic-object)))
+          (str "caller key printed byte-identically to pr-str; got "
+               (pr-str (:message o)))))
+
+    ;; ui/sub, the direct-call misuse diagnostic (rf2-30dc7)
+    (let [q [:q acyclic-object]
+          o (outcome #(ui/sub q))]
+      (is (= :rf.error/ui-tree-malformed (:error-id o)))
+      (is (str/includes? (:message o) (str "(ui/sub " (pr-str q) ")"))
+          (str "query printed byte-identically to pr-str; got "
                (pr-str (:message o)))))))
 
 (deftest the-ex-data-value-slot-survives-a-downstream-sink
@@ -482,7 +602,35 @@
                     (catch :default e (ex-data e)))]
       (is (string? (pr-str data))
           "and so does the capture/passive arm, whose message never printed
-           the value at all"))))
+           the value at all"))
+
+    ;; rf2-30dc7 — the two authoring-form sites, both halves each.
+    (let [data (try (rules/assert-safe-caller! {acyclic-object "x"} #{}) nil
+                    (catch :default e (ex-data e)))]
+      (is (identical? acyclic-object (:key data))
+          "an acyclic caller key rides out IDENTICAL in `:key`"))
+
+    (let [data (try (rules/assert-safe-caller! {provider "x"} #{}) nil
+                    (catch :default e (ex-data e)))]
+      (is (string? (pr-str data))
+          "a cyclic caller key's ex-data is printable at a downstream sink")
+      (is (str/includes? (pr-str (:key data)) "#js {…cyclic…}")
+          "with the cycle replaced by the fixed token"))
+
+    (let [q [:q acyclic-object]
+          data (try (ui/sub q) nil (catch :default e (ex-data e)))]
+      (is (identical? q (:query data))
+          "an acyclic query rides out IDENTICAL in `:query` — safe-form
+           returned its input, so a tool still sees the author's own value"))
+
+    (let [q [:q provider]
+          data (try (ui/sub q) nil (catch :default e (ex-data e)))]
+      (is (string? (pr-str data))
+          "a cyclic query's ex-data is printable at a downstream sink")
+      (is (str/includes? (pr-str (:query data)) "#js {…cyclic…}")
+          "with the cycle elided INSIDE the surviving query vector")
+      (is (str/includes? (pr-str (:query data)) ":q")
+          "and the acyclic part of the query still readable"))))
 
 ;; ---------------------------------------------------------------------------
 ;; The success paths are untouched
@@ -501,4 +649,8 @@
     (is (nil? (tree/classify-event nil)))
     (is (= 2 (count (tree/keyed-run [{:key "a"} {:key "b"}]))))
     (is (fn? (committed-event-callback nil))
-        "a body returning nil is the no-dispatch case, not a diagnostic")))
+        "a body returning nil is the no-dispatch case, not a diagnostic")
+    (is (= {:aria-label "x" :class "c"}
+           (rules/assert-safe-caller! {:aria-label "x" "class" "c"} #{:on-change}))
+        "an allowed spread-safe caller still canonicalizes and passes")
+    (is (nil? (rules/assert-safe-caller! nil #{})))))


### PR DESCRIPTION
Closes rf2-30dc7 — the fifth and final namespace group of the rf2-9s68n class, narrowed by the 2026-08-06 ruling to the **two production-reachable sites** and no more.

## The defect

`cljs.core`'s printer descends into a foreign JS value through exactly two `pr-writer-impl` branches — `object?` (own enumerable keys) and `array?` (elements) — and **neither carries a seen-set**. So a cyclic foreign object graph makes `pr-str` raise `RangeError: Maximum call stack size exceeded`. React 19's `createContext` returns an object whose `Provider` key points back at the context, so `ctx.Provider` *is* such a graph, and leaking one into an authoring form is an ordinary mistake.

Two diagnostics under `implementation/ui/src` still printed an arbitrary runtime value through bare `pr-str`, so on such a value **the diagnostic threw instead of diagnosing**:

| site | reached when | gated? | reaches a page? |
|---|---|---|---|
| `re-frame.ui.rules/assert-safe-caller!`, the **nil-slot** branch | `caller-key-slot` returned nil — i.e. a `ui/spread-safe` caller map carries a key that is not a keyword, string or symbol, so a **foreign object used as a map key** | **no** — the owned-key deny law is an every-build production invariant (`spread-safe-deny-elision-prod-test` pins that under `:advanced` + `goog.DEBUG=false`) | **yes** — a thrown `:rf.error/ui-tree-malformed` on both hosts |
| `re-frame.ui/sub` | always — the **whole body is the throw**, so every `(ui/sub …)` the view compiler did not lower reaches it, the documented case being a call from a plain helper fn | **no** | **yes** — a thrown `:rf.error/ui-tree-malformed` on both hosts |

Per rf2-y1jbaq: both outputs can reach a page, through the thrown error's message and its `:extra` ex-data. Both are now **bounded** — a cycle becomes the fixed, identity-free token `#js {…cyclic…}` / `#js […cyclic…]`, which carries no value bytes at all, so neither site can stringify an unescaped author value into an unbounded payload.

## The fix

`error/pr-form` on the message half, `error/safe-form` on the `:extra` half — **the helper that already exists** in `re-frame.error` (landed by rf2-1aj9s, moved into core precisely so `ui` and `ssr` can share one walker, used 21 times across `events` / `semantic` / `runtime` / `tree`). **No new printer, no new walker, no new framework.**

Both halves matter and are proven separately below: a cyclic value that merely rides out in `{:extra {…}}` explodes at a **downstream** logger / error projector / trace sink — someone else's boundary rather than the thrower's.

**No error id or message text changes.** `safe-form` returns `form` **itself** when no cycle is reachable, so an acyclic diagnostic is byte-identical to what `pr-str` produced before this PR existed — and the acyclic foreign value keeps its **contents** in the message, which is the whole reason a diagnostic gets a walker rather than a hash.

The two sibling arms of `assert-safe-caller!` are **left alone deliberately**: both are gated on a **non-nil** slot, so their `k` is provably nameable and cannot be a foreign object. `spread-safe-caller-nameable-keys-are-unaffected` pins that they still throw and still pass through bare `pr-str`.

## Scope — what is NOT here, and why

The ruling took Option 1. The other seven `pr-str` crossings the rf2-30dc7 sweep found are **recorded triaged-out on the bead**, not deferred silently: `frames.cljc:1301/1305` (a debug-gated *warn* whose payload's consumer is a trace sink with its own appetite for the live value — the recorded witness of the deferred-explosion path), `test.cljc:160/214/601` (test surface), `evidence.cljc:789-790` (tool-author, debug-gated, CLJS-only). The whole compile/macro tier, `client.cljs`'s twenty sites, `hooks.cljc:372` and the remaining `rules`/`frames`/`reactive`/`semantic` sites are **cleared by construction** — a form read by the Clojure reader cannot be a cyclic foreign JS object, and the rest are framework-supplied keywords or already-string-coerced. The class invariant carries forward on the bead record rather than in an inert fence.

**One correction to the dispatch brief.** It proposed driving the first site through `(ui/spread-safe owned {cyclic-obj "x"})`. That does not reach the guard: `ui/spread-safe`'s var is a template-form stub that throws `:rf.error/ui-spread-outside-template` on a direct call. The real author path is the compiler's **lowering**, which calls `rules/assert-safe-caller!` from `runtime/spread-safe->props` on the CLJS arm (and from `tree.cljc` on the JVM arm). Every cyclic row therefore drives **both** — the emitted lowering *and* the both-host guard directly.

## Evidence

`re-frame.ui.diagnostic-cycle-cljs-test` gains an **authoring-form tier** on the landed rf2-q9q9y template: the `outcome` map, so an overflow is **data in the failure text** (`{:threw "RangeError" …}`) rather than an aborted var, and the map records `:returned?` as a **boolean, never the value** — several of these sites return their input, and a slot holding the fixture would make the assertion message explode on the very input under test.

**Non-vacuity control** (`the-fixtures-are-genuinely-cyclic`) gains two rows for the new fixtures, asserting `cljs.core/pr-str` **itself** blows the stack on `[:q ctx.Provider]` (the exact value the `ui/sub` diagnostic prints) and on the deeper **mixed chain** `[:q #js {"held" [:page ctx.Provider]}]` — vector, foreign object, vector, foreign object. Without these the new rows could pass on an acyclic fixture and prove nothing.

**Reverse mutation, four separate runs, each half of each site independently.** Every run reproduced the overflow in a *named* test, and in every run the **other 810+ tests stayed green — including every pre-existing `diagnostic-cycle` row**, which is the proof the `ssr` / `semantic` / `runtime` / `tree` sites are undisturbed:

| mutation | result |
|---|---|
| `rules.cljc` message half → bare `pr-str` (and `:extra` with it) | **9 failures**, all in the two new deftests; `{:threw "RangeError", :error-id nil, :message "Maximum call stack size exceeded"}` |
| **both** `:extra` halves → raw value, `pr-form` kept | **15 failures / 2 errors**: the correct `:rf.error/ui-tree-malformed` surfaces, but `:ex-data-printable? false` at every row and the downstream-sink rows raise `RangeError` **from the sink** — the half the message half had masked |
| `ui.cljc` message half → bare `pr-str` | **7 failures**, all in `ui-sub-direct-call-…` and the two `ui/sub` ex-data rows |
| unmutated | **0 failures** |

Byte-identity rows for both new sites embed **`cljs.core/pr-str`'s own output** in the expectation, as the landed suites do, so they red the moment a message stops being what `pr-str` produced. Ex-data rows assert `identical?` on the acyclic value (byte-identity by construction — `safe-form` returned its input) and, on the cyclic one, that the token replaced **only the cycle** while `:q` and the surrounding vector stay readable.

## Quality gates

All run locally in this branch's worktree.

| gate | exit | result |
|---|---|---|
| `scripts/test-fast-pr.sh` | **0** | terminal marker `PASS fast PR spine`; the runner's own classification line was `=== fast PR spine: docs=false jvm=true node=true (classified) ===` |
| &nbsp;&nbsp;↳ JVM `implementation/core` (in-spine) | — | `Ran 2222 tests containing 11559 assertions. 0 failures, 0 errors.` |
| &nbsp;&nbsp;↳ **JVM `implementation/ui`** (in-spine) | — | `Ran 702 tests containing 17606 assertions. 0 failures, 0 errors.` |
| &nbsp;&nbsp;↳ `npm run test:cljs` (in-spine) | — | `Ran 12717 tests containing 63774 assertions. 0 failures, 0 errors.` |
| &nbsp;&nbsp;↳ per-ns test isolation (in-spine) | — | `all 17 namespace(s) pass standalone` |
| `npm run test:browser` | **0** | `Ran 1104 tests containing 6831 assertions. 0 failures, 0 errors.` Build: 1120 files, **0 warnings** |
| `npm run test:ui` (the focused `ui` CLJS suite, `:node-test-ui`) | **0** | `Ran 826 tests containing 4251 assertions. 0 failures, 0 errors.` Build: 343 files, **0 warnings**; `[ui-adapter-isolation] PASS` |
| `clj-kondo` @ the CI pin **2026.04.15**, CI's exact `--lint` set, `--parallel --fail-level error` | **0** | **errors: 0**, warnings: 4536 — on the baseline exactly |

No new compiler warnings on any build, and no new clj-kondo findings: `error/pr-form` / `error/safe-form` come from a require both files already had, so neither site needed a new one (the bead description's claim that `ui.cljc` lacked it is corrected on the bead — `ui.cljc` requires `[re-frame.error :as error]` already).
