### PR TITLE
fix(pair): the queue cap counts the bytes it is holding (rf2-2rtt6.135)

### DIFF
--- a/skills/re-frame2-pair/docs/TESTING.md
+++ b/skills/re-frame2-pair/docs/TESTING.md
@@ -41,11 +41,20 @@ npm install          # one-time (shadow-cljs)
 npm run test:pure    # shadow-cljs compile pure-test && node target/pure-test.js
 ```
 
-> **CI note (rf2-etsj8p):** the `skills-structural` job currently runs only the
-> Babashka `tests/runtime/*_test.clj` loop. Wiring the `:pure-test` build into
-> CI needs a new step (JDK + Node + shadow-cljs, `cd skills/re-frame2-pair/tests/fixture
-> && npm ci && npm run test:pure`) in `.github/workflows/test.yml` — a HOT-ZONE
-> file, sequenced by the mayor rather than edited here.
+> **CI note (rf2-etsj8p):** this build now has its own required job,
+> `re-frame2-pair-fixture-pure`, gated on the same `skills_structural`
+> changed-surface flag as the Babashka loop. The earlier note here — that
+> wiring it up still needed a hot-zone edit — is superseded.
+
+The `:pure-test` build is where `event-byte-size`'s **UTF-8 byte** discipline
+is pinned (rf2-2rtt6.135): `event-byte-size-counts-utf8-bytes-not-code-units`
+and `byte-budget-evicts-sooner-on-multi-byte-payload` use fixtures that share
+one `pr-str` code-unit length across three different byte lengths, so the
+`(count (pr-str ev))` that used to sit under the `max-buffered-bytes` gate
+answers the same number for all three and reds only on the non-ASCII rows.
+Note this file is `.cljc` and the `:clj` arm is genuinely loadable — but only
+the `:cljs` arm has a CI lane, since the fixture's sole harness is the
+node-test build.
 
 ### 1b. Structural (AST) pins (`tests/runtime/*.clj`, Babashka)
 

--- a/skills/re-frame2-pair/preload/re_frame2_pair/pure.cljc
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/pure.cljc
@@ -158,8 +158,11 @@
 (def default-max-buffered-events 500)
 
 (def default-max-buffered-bytes
-  ;; ~5 MB — sized to the MCP egress wire-cap posture scaled by the per-tick
-  ;; batching ratio. See runtime.cljs §Streaming subscriptions for the sizing.
+  ;; ~5 MB of TRUE UTF-8 bytes — sized to the MCP egress wire-cap posture
+  ;; scaled by the per-tick batching ratio. See runtime.cljs §Streaming
+  ;; subscriptions for the sizing. The value is UNCHANGED by rf2-2rtt6.135:
+  ;; 5 MB was always the chosen BYTE budget, and only the ruler underneath it
+  ;; (`event-byte-size`) was wrong.
   5000000)
 
 (defn streaming-drop?
@@ -225,12 +228,41 @@
                                       (<= t0 (:time ev) t1)))))))
 
 (defn event-byte-size
-  "Cheap, monotonic estimate of an event's on-wire byte cost — the same
-   `pr-str`-char-count discipline as the wire-cap helper, so the runtime
-   queue's budget stays in the same units as the egress cap. `pr-str` failure
-   falls back to 0 rather than blowing up enqueue."
+  "UTF-8 BYTE cost of `event`'s `pr-str` form — the figure `evict-oldest`
+   enforces `:max-buffered-bytes` against, and the one `:queue-bytes` /
+   `:dropped-bytes` publish to the agent.
+
+   BYTES, not `count`'s UTF-16 code units (rf2-2rtt6.135). The sum used to be
+   `(count (pr-str event))`, which agrees with UTF-8 only on ASCII — so the
+   budget failed OPEN: an em-dash-heavy payload held up to 3x the intended
+   5 MB before eviction began, and the published figures under-reported by the
+   same margin. This is the one site in that class where honesty TIGHTENS a
+   LIVE gate — heavy non-ASCII now evicts sooner, which is the intended
+   conduct arriving late. ASCII traffic is unchanged, byte for byte.
+
+   The name was right and the ruler was wrong, so `max-buffered-bytes` /
+   `:queue-bytes` / `:dropped-bytes` keep their names and
+   `default-max-buffered-bytes` keeps its 5,000,000: the cap bounds MEMORY,
+   and the bug under-delivered eviction rather than the intent. The old
+   docstring's \"same units as the wire-cap helper\" claim is TRUE again —
+   `re-frame2-pair-mcp.tools.summary/utf8-bytes` has counted UTF-8 since
+   rf2-2rtt6.132.
+
+   `TextEncoder` and not `Buffer.byteLength`: this ns ships as a browser
+   PRELOAD and compiles under `:advanced`, where `Buffer` is absent.
+   `TextEncoder` is UTF-8 BY DEFINITION — no encoding argument a later edit
+   can silently drop — and is a global in every browser and in Node; the `^js`
+   hints keep `:advanced` from renaming the interop call. Same shape as
+   `re-frame.elision/pr-str-bytes`, which this figure must not drift from.
+
+   `pr-str` (or encode) failure still falls back to 0 rather than blowing up
+   enqueue."
   [event]
-  (try (count (pr-str event))
+  (try (let [s (pr-str event)]
+         #?(:clj  (alength (.getBytes ^String s "UTF-8"))
+            :cljs (let [^js enc (js/TextEncoder.)
+                        ^js buf (.encode enc s)]
+                    (.-length buf))))
        (catch #?(:cljs :default :clj Throwable) _ 0)))
 
 (defn evict-oldest

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -1474,9 +1474,11 @@
 ;;    :topic    :trace | :epoch | :fx | :error
 ;;    :filter   <filter-map>         ;; vocab depends on topic
 ;;    :queue    <vector of events>   ;; appended-to by the cb, drained by the server
-;;    :queue-bytes <integer>         ;; running sum of (count (pr-str ev)) for queued events
+;;    :queue-bytes <integer>         ;; running sum of the UTF-8 BYTE size of
+;;                                   ;; (pr-str ev) over the queued events
+;;                                   ;; (`pure/event-byte-size`; rf2-2rtt6.135)
 ;;    :dropped-events <integer>      ;; events evicted because EITHER budget tripped
-;;    :dropped-bytes  <integer>      ;; bytes evicted alongside :dropped-events
+;;    :dropped-bytes  <integer>      ;; UTF-8 bytes evicted alongside :dropped-events
 ;;    :overflow-reason :max-buffered-events | :max-buffered-bytes | nil
 ;;                                   ;; budget that tripped LAST — surfaced verbatim
 ;;                                   ;; so the AI client knows WHICH limit it should
@@ -1484,7 +1486,8 @@
 ;;                                   ;; counters.
 ;;    :created-at <ms>
 ;;    :max-buffered-events <integer> ;; queue cap in events; default 500
-;;    :max-buffered-bytes  <integer>} ;; queue cap in bytes; default 5_000_000 (~5 MB)
+;;    :max-buffered-bytes  <integer>} ;; queue cap in UTF-8 bytes of pr-str;
+;;                                   ;; default 5_000_000 (~5 MB)
 ;;
 ;; Overflow policy (drop-oldest, byte+event budget):
 ;;   On enqueue, we first append the new event, then evict from the
@@ -1742,7 +1745,8 @@
      :max-buffered-events  cap on the in-runtime queue in events.
                            Default 500. When either budget trips, the
                            OLDEST events are evicted (drop-oldest FIFO).
-     :max-buffered-bytes   cap on the in-runtime queue in pr-str bytes.
+     :max-buffered-bytes   cap on the in-runtime queue in UTF-8 BYTES of
+                           each event's `pr-str` form (rf2-2rtt6.135).
                            Default 5_000_000 (~5 MB). Same drop-oldest
                            policy. The two budgets are OR-combined:
                            whichever trips first evicts.
@@ -1876,7 +1880,12 @@
    Returns
    `{:ok? true :subs [{:id :topic :filter :queue-depth :queue-bytes
                        :dropped-events :dropped-bytes :overflow-reason
-                       :created-at}]}`."
+                       :created-at}]}`.
+
+   `:queue-bytes` and `:dropped-bytes` are UTF-8 BYTES of each event's
+   `pr-str` form — the same ruler `:max-buffered-bytes` is enforced against
+   (`pure/event-byte-size`; rf2-2rtt6.135), so an agent comparing the two
+   is comparing like with like."
   []
   {:ok? true
    :subs (mapv (fn [[sub-id sub]]

--- a/skills/re-frame2-pair/references/streaming-subscriptions.md
+++ b/skills/re-frame2-pair/references/streaming-subscriptions.md
@@ -133,7 +133,7 @@ The final summary the call resolves with:
  :topic    :epoch
  :delivered      <count>
  :dropped-events <count>   ;; events evicted from the runtime queue
- :dropped-bytes  <count>   ;; bytes evicted alongside (pr-str char count)
+ :dropped-bytes  <count>   ;; UTF-8 bytes of pr-str evicted alongside
  :ticks          <count>
  :reason         :max-events-reached  ;; or one of the four above
  ;; optional, only when overflow eviction occurred:
@@ -142,7 +142,7 @@ The final summary the call resolves with:
  :dropped-sensitive <count>}
 ```
 
-Byte+event buffer budget: the runtime queue is bounded by an OR-combined pair — `max-buffered-events` (default 500) and `max-buffered-bytes` (default 5_000_000, ~5 MB pr-str char count). On overflow the OLDEST queued events are evicted (drop-oldest FIFO); count/bytes/reason surface on the next `notifications/progress` tick and the final summary. The byte budget is the load-bearing bound; the event budget is a coarse backstop for chatty-filter overruns. Tune `max-buffered-bytes` when `:overflow-reason :max-buffered-bytes` keeps tripping — a large-payload storm.
+Byte+event buffer budget: the runtime queue is bounded by an OR-combined pair — `max-buffered-events` (default 500) and `max-buffered-bytes` (default 5_000_000, ~5 MB of UTF-8 bytes of `pr-str`). On overflow the OLDEST queued events are evicted (drop-oldest FIFO); count/bytes/reason surface on the next `notifications/progress` tick and the final summary. The byte budget is the load-bearing bound; the event budget is a coarse backstop for chatty-filter overruns. Tune `max-buffered-bytes` when `:overflow-reason :max-buffered-bytes` keeps tripping — a large-payload storm.
 
 ## Privacy posture
 

--- a/skills/re-frame2-pair/tests/fixture/test/re_frame2_pair/pure_test.cljs
+++ b/skills/re-frame2-pair/tests/fixture/test/re_frame2_pair/pure_test.cljs
@@ -129,9 +129,65 @@
   (is (pure/frameless-event? {:tags {:registry-kind :event}}))
   (is (not (pure/frameless-event? {:tags {:rf.trace/dispatch-id 1}}))))
 
-(deftest event-byte-size-is-pr-str-count
-  (is (= (count (pr-str {:a 1})) (pure/event-byte-size {:a 1})))
-  (is (number? (pure/event-byte-size {:x (range 5)}))))
+;; ---------------------------------------------------------------------------
+;; `event-byte-size` — the ruler the streaming byte budget is enforced against
+;; ---------------------------------------------------------------------------
+;;
+;; DISCRIMINATING FIXTURES (rf2-2rtt6.135). All three `pr-str` to the SAME 47
+;; UTF-16 code units and to THREE different UTF-8 byte lengths, so the
+;; defective `(count (pr-str ev))` answers 47 for all three while the honest
+;; ruler separates them. `astral-40` additionally separates code POINTS (20)
+;; from code UNITS (40). Built from `fromCodePoint` so this source file stays
+;; pure ASCII and no re-encoding can mangle the surrogate pair.
+
+(def ^:private em-dash   (.fromCodePoint js/String 0x2014)) ;; 1 unit / 1 point / 3 bytes
+(def ^:private g-clef    (.fromCodePoint js/String 0x1D11E)) ;; 2 units / 1 point / 4 bytes
+
+(def ^:private ascii-40  (apply str (repeat 40 "x")))
+(def ^:private emdash-40 (apply str (repeat 40 em-dash)))
+(def ^:private astral-40 (apply str (repeat 20 g-clef)))
+
+(defn- ev [s] {:s s})
+
+(deftest event-byte-size-counts-utf8-bytes-not-code-units
+  (testing "the fixtures are genuinely indistinguishable to `count`"
+    (is (= 40 (count ascii-40) (count emdash-40) (count astral-40))
+        "one code-unit length across all three")
+    (is (= 20 (.-length (js/Array.from astral-40)))
+        "astral-40 is 20 code POINTS in 40 code UNITS")
+    (is (= 47 (count (pr-str (ev ascii-40)))
+             (count (pr-str (ev emdash-40)))
+             (count (pr-str (ev astral-40))))
+        "the defective (count (pr-str ev)) answers 47 for all three"))
+  (testing "UTF-8 bytes separate them"
+    ;; ASCII stays green under an under-count -- the failure is specific to
+    ;; non-ASCII, which is what makes this a discriminator and not a smoke alarm.
+    (is (= 47 (pure/event-byte-size (ev ascii-40)))  "ASCII: bytes == code units")
+    (is (= 127 (pure/event-byte-size (ev emdash-40))) "40 x 3-byte em-dash + 7 ASCII")
+    (is (= 87 (pure/event-byte-size (ev astral-40)))  "20 x 4-byte astral + 7 ASCII"))
+  (testing "pr-str failure still falls back to 0 rather than blowing up enqueue"
+    (is (= 0 (pure/event-byte-size (reify IPrintWithWriter
+                                     (-pr-writer [_ _ _] (throw (js/Error. "nope")))))))))
+
+(deftest byte-budget-evicts-sooner-on-multi-byte-payload
+  ;; The behaviour change rf2-2rtt6.135 accepts, measured. One cap, one
+  ;; code-unit length, two payloads: the honest ruler holds 6 ASCII events and
+  ;; only 2 em-dash events. Under the old ruler BOTH held 6 -- the queue was
+  ;; sitting on 762 true bytes against a 300-byte budget.
+  (let [cap  300
+        fill (fn [payload]
+               (reduce #(pure/enqueue %1 "s" %2)
+                       {"s" (pure/make-subscription
+                              "s" {:topic :trace
+                                   :max-buffered-events 1000
+                                   :max-buffered-bytes  cap}
+                              0)}
+                       (repeat 20 (ev payload))))]
+    (is (= 6 (count (get-in (fill ascii-40) ["s" :queue])))
+        "6 x 47 bytes = 282, inside the 300-byte cap")
+    (is (= 2 (count (get-in (fill emdash-40) ["s" :queue])))
+        "2 x 127 bytes = 254; a 3rd would be 381 -- evicts at a THIRD the depth")
+    (is (= :max-buffered-bytes (get-in (fill emdash-40) ["s" :overflow-reason])))))
 
 (defn- trace-sub
   "A trace-topic subscription map for `sub-id` with the given budgets."

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -3198,8 +3198,9 @@ vocab `watch-epochs` already accepts):
   surface on the next progress tick as `:dropped-events` and
   `:overflow-reason :max-buffered-events`.
 - `max-buffered-bytes` (integer, default `5_000_000` ≈ 5 MB) —
-  runtime-side queue cap in BYTES (pr-str char count, the same
-  unit as the wire-boundary cap). Same drop-oldest policy; reports
+  runtime-side queue cap in UTF-8 BYTES of each event's `pr-str`
+  form, the same unit as the wire-boundary cap. Same drop-oldest
+  policy; reports
   `:dropped-bytes` and `:overflow-reason :max-buffered-bytes`. This
   exists (rf2-ho4ve) because an event-count-only budget can't bound
   memory pressure under large payloads — 500 small events fit in a
@@ -3254,7 +3255,7 @@ While the subscription is open, each non-empty batch tick emits
     "_meta": {
       "data": {
         "dropped-events": 0,                    // events evicted this tick
-        "dropped-bytes":  0,                    // bytes evicted this tick (pr-str)
+        "dropped-bytes":  0,                    // UTF-8 bytes of pr-str evicted this tick
         "overflow-reason": null                 // ":max-buffered-events" | ":max-buffered-bytes" | null
       }
     }
@@ -3528,7 +3529,7 @@ returns the sub only if it matches on both axes.
          :topic           :trace | :epoch | :fx | :error | :frameless
          :filter          <filter-map-as-supplied-to-subscribe>
          :queue-depth     <integer>       ; events buffered server-side
-         :queue-bytes     <integer>       ; pr-str chars buffered server-side
+         :queue-bytes     <integer>       ; UTF-8 bytes of pr-str buffered server-side
          :dropped-events  <integer>       ; cumulative drops by event-budget
          :dropped-bytes   <integer>       ; cumulative drops by byte-budget
          :overflow-reason :max-buffered-events | :max-buffered-bytes | nil

--- a/tools/re-frame2-pair-mcp/spec/Principles.md
+++ b/tools/re-frame2-pair-mcp/spec/Principles.md
@@ -754,11 +754,14 @@ OR-combined pair on the runtime side:
 
 - `:max-buffered-events` — integer event-count cap, default
   500. The coarse backstop.
-- `:max-buffered-bytes` — integer pr-str byte cap, default
-  5_000_000 (~5 MB). The load-bearing bound. The unit
-  matches the wire-cap's `pr-str` character count discipline
-  (`token-estimate = (quot bytes 4)`), so the budgets across
-  the upstream-queue and the egress-wire stay coherent.
+- `:max-buffered-bytes` — integer cap on the UTF-8 BYTES of each
+  event's `pr-str` form, default 5_000_000 (~5 MB). The
+  load-bearing bound. The unit matches the wire-cap's own UTF-8
+  `pr-str` byte discipline (`token-estimate = (quot bytes 4)`), so
+  the budgets across the upstream-queue and the egress-wire stay
+  coherent — a coherence that only became true when both rulers
+  stopped counting UTF-16 code units (rf2-2rtt6.132 on the wire
+  cap, rf2-2rtt6.135 on this one).
 
 The runtime's `enqueue!` admits the new event first, then
 evicts from the FRONT of the queue until BOTH budgets hold.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
@@ -1692,7 +1692,7 @@
                                                     :description "Runtime-side queue cap in EVENTS. Positive integer (>= 1); a non-positive value is rejected with :reason :invalid-numeric-arg. Default 500. On overflow the OLDEST events are evicted (drop-oldest FIFO) and reported as `:dropped-events` / `:overflow-reason :max-buffered-events` on the next progress tick. OR-combined with :max-buffered-bytes — whichever trips first evicts."}
                               :max-buffered-bytes  {:type "integer"
                                                     :minimum 1
-                                                    :description "Runtime-side queue cap in BYTES (pr-str char count). Positive integer (>= 1); a non-positive value is rejected with :reason :invalid-numeric-arg. Default 5_000_000 (~5 MB). Same drop-oldest policy; reports `:dropped-bytes` / `:overflow-reason :max-buffered-bytes`. Sized to fit the 5,000-token wire-cap posture across a normal poll cadence."}
+                                                    :description "Runtime-side queue cap in UTF-8 BYTES of each event's pr-str form. Positive integer (>= 1); a non-positive value is rejected with :reason :invalid-numeric-arg. Default 5_000_000 (~5 MB). Same drop-oldest policy; reports `:dropped-bytes` / `:overflow-reason :max-buffered-bytes` in the same unit. Sized to fit the 5,000-token wire-cap posture across a normal poll cadence."}
                               :poll-ms {:type "integer"
                                         :minimum 1
                                         :description "Server poll cadence in ms. Positive integer (>= 1); a non-positive value is rejected with :reason :invalid-numeric-arg. Default 100."}

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_test.cljs
@@ -361,16 +361,25 @@
 ;;
 ;; Parallel fixture of the runtime's `evict-oldest` / `enqueue!`
 ;; (drop-oldest, OR-combined budget) so the MCP-side test harness pins
-;; the contract. The runtime itself is bb-tested under
-;; `skills/re-frame2-pair/tests/runtime/streaming_subscriptions_test.clj`;
-;; this CLJS fixture lets `npm test` exercise the same contract
-;; alongside the MCP wire surface assertions above.
+;; the contract. The runtime itself is exercised directly under
+;; `skills/re-frame2-pair/tests/fixture` (`npm run test:pure`, against the
+;; SHIPPED `re-frame2-pair.pure`); this CLJS fixture lets `npm test`
+;; exercise the same contract alongside the MCP wire surface assertions
+;; above. Being a declared MIRROR, it moves whenever the runtime moves.
 
 (def ^:private default-max-events 500)
 (def ^:private default-max-bytes 5000000)
 
-(defn- event-byte-size [event]
-  (count (pr-str event)))
+(defn- event-byte-size
+  "Mirrors `re-frame2-pair.pure/event-byte-size`: UTF-8 BYTES of the event's
+   `pr-str` form, not `count`'s UTF-16 code units (rf2-2rtt6.135). The two
+   rulers agree only on ASCII, so a mirror left on `count` would keep
+   answering the right number for this file's ASCII fixtures while silently
+   ceasing to model the budget the runtime actually enforces."
+  [event]
+  (let [^js enc (js/TextEncoder.)
+        ^js buf (.encode enc (pr-str event))]
+    (.-length buf)))
 
 (defn- evict-oldest
   [sub max-events max-bytes]


### PR DESCRIPTION
Site 1 of `rf2-2rtt6.135` — the last of the three, and the only one that
needed a ruling. Sites 2 and 3 landed in #7582.

`re-frame2-pair.pure/event-byte-size` accumulated `(count (pr-str ev))` —
UTF-16 code units on both hosts — and `evict-oldest` enforced
`max-buffered-bytes` (default 5,000,000) against that running sum. On ASCII
the two rulers agree exactly, so the wrong expression printed the right
number and a green suite never noticed. On anything else the gate failed
**open**.

Every sibling correction in this class was monotone-tightening and free.
This one is not: the cap is on a buffer the runtime is **already holding**,
so counting honestly makes the queue evict **sooner**. Per the ruling
recorded on the bead — measure **true UTF-8 bytes**, cap **stays**
5,000,000, vocabulary **unchanged** (`max-buffered-bytes` / `:queue-bytes` /
`:dropped-bytes`; no rename, no compensating raise). The name was right and
the ruler was wrong.

## How much sooner, measured

Driven through the shipped `pure/enqueue` + `pure/evict-oldest` at the real
5,000,000 default. `old-depth` is what the queue used to hold under the
code-unit ruler; `held` is the true byte volume it was really sitting on.

**Small labels on ASCII trace scaffolding** — the common case, and barely
affected, because the event's keywords, ids and timestamps are ASCII and
dominate:

| payload | units | bytes | old depth | new depth | sooner | old queue really held |
|---|---|---|---|---|---|---|
| ASCII only | 304 | 304 | 16,447 | 16,447 | 1.00x | 5.0 MB |
| Western typographic (em-dash, curly quotes, ellipsis) | 319 | 331 | 15,673 | 15,105 | 1.04x | 5.19 MB |
| CJK label (Japanese) | 283 | 301 | 17,667 | 16,611 | 1.06x | 5.32 MB |
| Emoji-bearing (astral) | 300 | 310 | 16,666 | 16,129 | 1.03x | 5.17 MB |

**Payload-dominated events** — the large-payload storm this budget exists to
bound ("an event-count-only budget can't bound memory pressure under large
payloads", 003-Tool-Catalogue). Here the non-ASCII text *is* the event:

| payload (2 KB body) | units | bytes | old depth | new depth | sooner | old queue really held |
|---|---|---|---|---|---|---|
| ASCII document body | 3,139 | 3,139 | 1,592 | 1,592 | 1.00x | 4.77 MB |
| Western prose, typographic punctuation throughout | 5,146 | 5,814 | 971 | 859 | 1.13x | 5.38 MB |
| **Japanese document body (CJK)** | 2,918 | 8,482 | **1,713** | **589** | **2.91x** | **13.86 MB** |
| Emoji-dense chat log (astral) | 3,636 | 5,636 | 1,375 | 887 | 1.55x | 7.39 MB |

**The headline for anyone reading the default:** 5 MB used to mean 5 MB of
1-byte events *or up to ~14 MB of 3-byte ones*. It now means 5 MB. A CJK
document stream drops from 1,713 buffered events to 589 — the queue was
carrying **2.8x its stated memory budget**, which is precisely the failure
the byte budget was added to prevent. ASCII traffic is unchanged, byte for
byte.

The `depth = floor(cap / size)` model behind those numbers is not an
assumption: it was cross-checked against the real `enqueue`/`evict-oldest`
at 8 (profile, cap) pairs, exact match on all 8.

**The default does not need re-calibrating, and was not changed.** 5,000,000
was always the chosen *byte* budget — the introducing commit `b3d3ccf2b6`
describes it as wire-size-aligned, and nothing anywhere calibrates 5M code
units. The bug under-delivered eviction, not intent. Raising it to
compensate would also be unachievable: no single multiplier reproduces the
old behaviour, since the code-unit-to-byte ratio is payload-dependent
(1.00x on ASCII, 2.91x on the CJK body above, 3x worst case).

## The lockstep surfaces

The `.132` worker deliberately left these rather than half-fixing a contract
across a fence. All of them said something self-contradictory; all move now.

| surface | was | now |
|---|---|---|
| `pure/event-byte-size` | `(count (pr-str event))` under a `bytes` name | UTF-8 bytes, both arms |
| `descriptors_data.cljs` `max-buffered-bytes` | "queue cap in **BYTES** (pr-str **char** count)" — both units in one sentence, to an agent | "queue cap in UTF-8 BYTES of each event's pr-str form" |
| `003-Tool-Catalogue.md` `:queue-bytes` | "pr-str **chars** buffered server-side" under a `bytes` slot | "UTF-8 bytes of pr-str buffered server-side" |
| `subscribe_test.cljs` `event-byte-size` | `(count (pr-str event))` | TextEncoder, mirroring the runtime |

Three more carried the identical contradiction and would have simply
relocated it, so they move too:

- `003-Tool-Catalogue.md` `max-buffered-bytes` arg row — the descriptor's own
  spec twin, with the same "BYTES (pr-str char count)" phrasing.
- `Principles.md` §the budget — "integer pr-str **byte** cap … the unit
  matches the wire-cap's pr-str **character count** discipline". That
  coherence claim is now true on both sides, and says so.
- `references/streaming-subscriptions.md` — two "pr-str char count" readings
  of `:dropped-bytes` and the 5 MB default.

Plus the runtime's own prose: the `:queue-bytes` head comment (which spelled
out `(count (pr-str ev))` verbatim), the `:max-buffered-bytes` state-map row,
the `subscribe!` docstring, and the `subscription-info` return docstring, so
an agent comparing `:queue-bytes` against its cap is comparing like with like.

`subscribe_test.cljs`'s fixture is a **declared mirror** of the runtime, not
an independent site — its own comment says so — so it tracks. While there, its
comment pointed at `tests/runtime/streaming_subscriptions_test.clj`, a
Babashka behaviour mirror deleted when the pure core was extracted; it now
names the live gate.

## The witness

`event-byte-size-counts-utf8-bytes-not-code-units` uses three fixtures that
share **one** `pr-str` code-unit length (47) across **three** byte lengths
(47 / 127 / 87), so the defective expression answers 47 for all three.
`astral-40` additionally separates code **points** (20) from code **units**
(40). Built from `String.fromCodePoint` escapes, so the source file stays pure
ASCII and no re-encoding can mangle the surrogate pair.

`byte-budget-evicts-sooner-on-multi-byte-payload` pins the behaviour change
itself: one cap (300), one code-unit length, two payloads — 6 ASCII events
held, 2 em-dash events held.

Under an under-count the **ASCII assertions stay green** and only the
non-ASCII rows red. That is what makes it a discriminator rather than a smoke
alarm.

## Both hosts

`pure.cljc` is `.cljc`. The `:clj` arm is **not** dead — `implementation/core`
is a `:local/root` on the fixture's `deps.edn`, so `(require
're-frame2-pair.pure)` loads and runs on the JVM, and it reproduced the bug
there before the fix (`{:a "<em-dash>"}` answering 8 where the truth is 10).
So this is not the `story-mcp` case `.131` deleted; the conditional stays, and
it matches the two other `:clj` arms already in the file.

The same 12-check fixture set was run against the JVM arm directly: **12/12**,
identical to CLJS on every figure including the 6-vs-2 eviction depths.

**Mutation-proved in both directions on both hosts:**

| host | mutation | result |
|---|---|---|
| CLJS | `(count s)` — the historical under-count | RED: 3/188 assertions. em-dash 47≠127, astral 47≠87, eviction depth **6≠2**. ASCII green. |
| CLJS | `(* 2 (count s))` — UTF-16-bytes over-count | RED: 5/188, including the ASCII row (94≠47) and both depths |
| JVM | `(count s)` | RED: 9/12 — same three checks, ASCII green |
| JVM | `(* 2 (count s))` | RED: 7/12 — all four byte/depth checks |

**One finding worth recording:** only the `:cljs` arm has a CI lane. The
fixture's sole harness is the `:pure-test` node build, so nothing in CI would
catch a JVM-arm regression. Building a JVM harness for it would mean a new
required job in `.github/workflows/test.yml` — a hot-zone file, out of fence
here. Noted in `TESTING.md` rather than silently left as an unknown.

While confirming that, `TESTING.md`'s CI note turned out to be stale: it said
wiring `:pure-test` into CI "needs a new step … sequenced by the mayor", but
`re-frame2-pair-fixture-pure` has been a required job for some time — and it
is the lane that gates this PR's witness. Corrected, since it describes the
coverage this change depends on.

## Quality gates

Every command run to completion in the foreground; exit codes echoed, nothing
piped.

| gate | exit |
|---|---|
| `sh scripts/test-fast-pr.sh` | **0** — classification: `fast PR spine: docs=true jvm=false node=false (classified)` |
| `npm run lint:js` (root) | **0** |
| `tools/re-frame2-pair-mcp` `npm test` (shadow-cljs `:server-test`) | **0** — 1219 tests / 4322 assertions, 0 failures |
| `tools/re-frame2-pair-mcp` `npm run check:descriptors` | **0** — `tool-descriptors.edn` in sync (35 tools) |
| `tools/re-frame2-pair-mcp` `npm run build` | **0** |
| `tools/re-frame2-pair-mcp` `npm run stdio-roundtrip` | **0** — SERVER STDIO ROUND-TRIP GREEN |
| `implementation` `npm run test:mcp-conformance` | **0** — ALL MCP-CONFORMANCE GATES GREEN (6/6 lanes; 6 live-nREPL gates SKIP without a running server) |
| `skills/re-frame2-pair` `npm run test:pure` (the witness) | **0** — 43 tests / 188 assertions, 0 failures |
| `skills/re-frame2-pair` Babashka `tests/runtime/*` + `tests/prompts/*` | **0** — 13/13 files green, incl. `pure_delegation_test` |
| JVM-arm witness (ad-hoc, see above) | **0** — 12/12 |

Note on the brief's "pair-mcp JVM suite": there isn't one. `deps.edn`'s
`:test` alias is `-m shadow.cljs.devtools.cli compile server-test` — the same
CLJS node-test build `npm test` drives, exposed to Clojure CLI for editor
tooling. `test:mcp-conformance` is where the JVM lanes for the MCP surface
live (story-mcp and wire-vocab), and it ran.

No `implementation/**`, `tools/xray/**`, `docs/design/hicasso/**`, `spec/**`,
`scripts/**` or `.github/**` touched. No `.beads/` in the diff. No absolute
paths in committed content. The mayor checkout's `implementation/node_modules`
was verified unchanged before and after (104 / 1049 entries at depth 1 / 2); no
junction was created.

Closes `rf2-2rtt6.135` — sites 2 and 3 are already on main, so site 1
completes it.
