### PR TITLE
bench,docs: the M1 and per-keystroke rows state their regime (rf2-jcm3p, rf2-swwud)

### DIFF
--- a/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
+++ b/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
@@ -3,11 +3,26 @@
 **The mount deficit is worse than published and the other three rows are still
 refused.** On raw `TaskDuration` — the arm's own JavaScript *and* the frame it
 causes — `hicasso / reagent-subs` on `M1` reads **1.4896×** [1.3488 – 1.5989] on
-the ensemble that has standing, against the **1.2107×** the candidate's clock
-publishes. This page's own seven runs, taken at a heavier load regime, read
-**1.3737×** [1.3289 – 1.4331] and are published as a second regime rather than
-as the magnitude, because the corroboration control they were pre-registered
-against **failed** ([§5](#5-what-this-ensemble-may-not-say)).
+~~the ensemble that has standing~~ the ensemble this page was written against,
+compared with the **1.2107×** the candidate's clock publishes. This page's own
+seven runs, taken at a heavier load regime, read **1.3737×** [1.3289 – 1.4331]
+and are published as a second regime rather than as the magnitude, because the
+corroboration control they were pre-registered against **failed**
+([§5](#5-what-this-ensemble-may-not-say)).
+
+**AND NEITHER MOUNT FIGURE IS A MAGNITUDE ANY LONGER (`rf2-jcm3p`, ruled
+2026-08-06).** `M1`'s own positive control fails — `ctl-2x` at ~~standing at
+2.00×~~ **1.8173×** against a predicted 2.00× on this very ensemble
+([§4.2](#42-ctl-2x-undershoots-on-the-mount-row-too-and-that-changes-its-diagnosis)),
+reproduced at 1.8443× and 1.8567× on two verifiably idle boxes — and a mount row
+has no changed-set axis a control could be linear in, so no control can
+adjudicate it. The strict rule that refuses `bulk300` and `bulk100` below binds
+on `M1` too, and the row is restated as a **regime**: *Hicasso mounts materially
+slower than both adapters, every corroborated reading is above the amended
+`≤ 1.10×` UIx gate, and `≤ 1.10×` has not been demonstrated.* Both figures stay
+on this page as historical observations, annotated with the control status they
+were taken under. The full restatement is on
+[the clock page's §4](the-candidates-clock.md#4-the-mount-row--a-regime-not-a-magnitude).
 
 **And the correction has a boundary nobody had drawn.** `rf2-yd52q` established
 that `DevToolsCommandDuration` carries the page script a protocol command
@@ -199,11 +214,11 @@ reading 3 would be a container that survived its unmount *(2026-08-06,
 
 | row | `hicasso / reagent-subs`, raw `TaskDuration` | on `taskNet` | reportable runs | disposition |
 |---|---:|---:|---:|---|
-| **`M1` mount** | **1.3737×** [1.3289 – 1.4331] | 1.1143× | **7 of 7** | every run clears its own band (margins 32.9–43.3% against bands 4.9–10.8%) — but see [§5](#5-what-this-ensemble-may-not-say) |
+| **`M1` mount** | **1.3737×** [1.3289 – 1.4331] | 1.1143× | **7 of 7** | ~~every run clears its own band (margins 32.9–43.3% against bands 4.9–10.8%)~~ **REGIME, no magnitude** *(2026-08-06, `rf2-jcm3p`)* — every run does clear its own band, and a band is not a control: `ctl-2x` reads 1.8173× against 2.00× on this ensemble, and no changed-set control can reach a mount. Direction only. See also [§5](#5-what-this-ensemble-may-not-say) |
 | `bulk300` | 1.1494× [1.1102 – 1.2032] | 1.0703× | 3 of 7 | **refused** — control failed on 4, ceiling breached on 1 |
 | `bulk100` | 1.1089× [1.0649 – 1.1545] | 0.9859× | 2 of 7 | **refused** — control failed on 5 |
 | `narrow` | 1.0236× [0.9855 – 1.0900] | 1.0352× | 4 of 7 | **parity, instrument-limited** — every reportable run's margin is inside its band |
-| `keystroke` | 1.0049× [0.9235 – 1.1192] | 1.0078× | — | **unadjudicated** — no proportional control; and the row needed no correction |
+| `keystroke` | 1.0049× [0.9235 – 1.1192] | 1.0078× | — | ~~**unadjudicated** — no proportional control~~ **DIAGNOSTIC — UNADJUDICATED, never a magnitude** *(2026-08-06, `rf2-swwud`: the row is adjudicated by Event Timing instead — indistinguishable at one frame, on the two retained runs)*; and the row needed no correction |
 
 **The two update rows change sign.** `bulk100` reads 0.9859× on the frame-only
 clock and **1.1089×** on the corrected one; `bulk300` goes 1.0703 → 1.1494. A
@@ -310,8 +325,13 @@ gates passing.
 
 Therefore:
 
-- **The published `M1` magnitude is `rf2-yd52q`'s `1.4896×`** [1.3488 – 1.5989],
-  whose corroboration control passed at `1.0011×` on a quiet box.
+- ~~**The published `M1` magnitude is `rf2-yd52q`'s `1.4896×`** [1.3488 – 1.5989],
+  whose corroboration control passed at `1.0011×` on a quiet box.~~ **There is no
+  published `M1` magnitude** *(2026-08-06, `rf2-jcm3p`)*. `rf2-yd52q`'s `1.4896×`
+  [1.3488 – 1.5989] remains the best-corroborated reading and its corroboration
+  control did pass at `1.0011×` on a quiet box — but the row's own **positive**
+  control fails there too, at `ctl-2x` `1.8173×` against `2.00×`, so the figure
+  is a historical observation and the row publishes a regime.
 - **This ensemble's `1.3737×` is published as a second regime**, not as the
   magnitude, and its agreement with `1.4896×` in direction and rough size is
   what it contributes.
@@ -347,7 +367,18 @@ any control was consulted.
 ## 6. What is refused, and what is not
 
 **Refused as magnitudes:** `bulk300`, `bulk100`, `narrow`, `keystroke`, and —
-on this ensemble — `M1`.
+~~on this ensemble —~~ `M1` *(2026-08-06, `rf2-jcm3p`: the qualifier is spent.
+`M1` is refused as a magnitude on every ensemble, this one and the two landed
+ones, because its control cannot adjudicate it anywhere. It publishes a
+mount **regime**.)*
+
+**What each refused row publishes instead** *(2026-08-06, `rf2-jcm3p`,
+`rf2-swwud`)*: `M1` a **mount regime** — direction only, materially slower than
+both adapters, `≤ 1.10×` not demonstrated. `keystroke` a **responsiveness
+regime** — indistinguishable from both donors at Event Timing's resolution,
+every observed interaction one frame, with the rider that the instrument
+resolves 8 ms buckets above a 16 ms floor and states no tie below it. The three
+bulk rows publish direction and no magnitude, as below.
 
 **Not refused, because they do not depend on a magnitude or on this box:**
 

--- a/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
+++ b/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
@@ -11,8 +11,8 @@ corroboration control they were pre-registered against **failed**
 ([§5](#5-what-this-ensemble-may-not-say)).
 
 **AND NEITHER MOUNT FIGURE IS A MAGNITUDE ANY LONGER (`rf2-jcm3p`, ruled
-2026-08-06).** `M1`'s own positive control fails — `ctl-2x` at ~~standing at
-2.00×~~ **1.8173×** against a predicted 2.00× on this very ensemble
+2026-08-06).** `M1`'s own positive control fails — `ctl-2x` reads **1.8173×**
+against a predicted 2.00× on this very ensemble
 ([§4.2](#42-ctl-2x-undershoots-on-the-mount-row-too-and-that-changes-its-diagnosis)),
 reproduced at 1.8443× and 1.8567× on two verifiably idle boxes — and a mount row
 has no changed-set axis a control could be linear in, so no control can

--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -1,14 +1,24 @@
 # The candidate's clock — mount, bulk K=100/300, narrow, per-keystroke
 
 **The candidate is slower on the clock, and the correction made it slower
-still.** On the mount row — the only row of five whose positive control passed —
-Hicasso Arm 1 mounts the 300-boundary witness at **1.4896× Reagent-on-subs**
-[1.3488 – 1.5989]. That is the figure of record: it is on raw `TaskDuration`,
-which holds the operation's own script as well as the frame it causes, and it is
-above the ship bar's `≤ 1.0×` and above
+still.** On the mount row, Hicasso Arm 1 mounts the 300-boundary witness at
+**1.4896× Reagent-on-subs** [1.3488 – 1.5989] — on raw `TaskDuration`, which
+holds the operation's own script as well as the frame it causes, above the ship
+bar's `≤ 1.0×` and above
 [the restated M1 red zone](../validation.md#the-clock-gates-restated-on-the-post-25-tree)
-of `1.0150×`. **Its interval does not straddle 1.0**, so the deficit is
-*established* and not merely indicated.
+of `1.0150×`, with an interval that does not straddle 1.0. **That figure is a
+historical observation and not a published magnitude**: the row's positive
+control fails, so [§4](#4-the-mount-row--a-regime-not-a-magnitude) states the
+mount as a **regime** — *Hicasso mounts materially slower than both adapters,
+and `≤ 1.10×` has not been demonstrated* — rather than as a number.
+*(2026-08-06, `rf2-jcm3p`: this called `1.4896×` ~~the figure of record~~ and
+the mount ~~the only row of five whose positive control passed~~, and read the
+deficit as ~~established and not merely indicated~~. The control that carries
+this figure — `rf2-emvod`'s seven-run ensemble — reads `ctl-2x` at `1.8173×`
+against a predicted `2.00×`, and two re-takes on verifiably idle boxes
+reproduced the miss. The strict rule that refuses the three bulk rows in
+[§6](#6-the-three-rows-this-page-refuses) binds here too; the asymmetry ends.
+The direction survives intact — it is what the regime states.)*
 
 **The number this page itself measured is `1.21×`** [0.9756 – 1.7208], and every
 magnitude below is on that same superseded clock — `taskNet`, which subtracts the
@@ -19,8 +29,10 @@ frame-only range *did* straddle 1.0 at n = 6, which is why this page originally
 declined to call the deficit established; that hedge is a property of the
 frame-only reading and does not carry onto the clock the row is now stated on.
 
-On per-keystroke it is **indistinguishable from both donors**, and all three are
-one frame. The three bulk rows **could not be measured honestly**; this page
+On per-keystroke it is **indistinguishable from both donors at Event Timing's
+resolution**, and all three are one frame — the row's published verdict, and
+[§5](#5-per-keystroke--every-arm-is-one-frame) says what that does and does not
+mean. The three bulk rows **could not be measured honestly**; this page
 publishes no magnitude for them and [§6](#6-the-three-rows-this-page-refuses)
 says exactly why — including one ground it has since **withdrawn as refuted**,
 and the measured band that replaced it
@@ -486,7 +498,65 @@ be expected to buy the same pair of refusals.
 
 ---
 
-## 4. The mount row — the one row published as a magnitude
+<a id="4-the-mount-row--the-one-row-published-as-a-magnitude"></a>
+
+## 4. The mount row — a REGIME, not a magnitude
+
+> ## THE MOUNT MAGNITUDE IS WITHDRAWN AND THE ROW IS RESTATED AS A REGIME (`rf2-jcm3p`, ruled 2026-08-06)
+>
+> **`1.4896×` [1.3488 – 1.5989] against Reagent-on-subs and `1.5001×` against
+> UIx-on-subs are withdrawn as MAGNITUDES.** The strict rule that refuses the
+> three bulk rows in [§6](#6-the-three-rows-this-page-refuses) binds here too,
+> and the asymmetry this section used to carry — a magnitude published under a
+> control that fails, beside three rows refused for that same failure — ends.
+>
+> **What the row publishes instead is a REGIME:** *Hicasso mounts materially
+> slower than both adapters.* Every corroborated reading sits above the amended
+> `≤ 1.10×` UIx gate — landed ensembles `1.5001×` and `1.4656×` against UIx,
+> `1.4896×` [1.3488 – 1.5989] and `1.3737×` against Reagent, raw quiet-window
+> recomputations `1.3484×` and `1.2066×` against UIx — and the direction is
+> corroborated three ways: worst-case witnesses, the census rows, and an outside
+> benchmark. **`≤ 1.10×` has NOT been demonstrated.**
+>
+> **Why no magnitude.** The row's positive control fails. `ctl-2x` reads
+> `1.8173×` against a predicted `2.00×` over `rf2-emvod`'s seven runs, and two
+> re-takes on verifiably idle boxes reproduced the miss at `1.8443×`
+> ([§3.4](#34-the-quiet-window-and-why-it-publishes-nothing-rf2-0qj9w-2026-08-04))
+> and `1.8567×`
+> ([§3.5](#35-the-rebooked-window-which-refuses-in-the-same-two-places-rf2-0qj9w-2026-08-04)).
+> The additive constant explains the undershoot arithmetically — `c ≈ 1.04 ms`,
+> and `(2W + c)/(W + c)` is below 2 for any positive `c` — so it is not a
+> property of mounts, and
+> [§4.2 of the re-adjudication](rows-re-adjudicated-on-the-corrected-clock.md#42-ctl-2x-undershoots-on-the-mount-row-too-and-that-changes-its-diagnosis)
+> measures the same constant on four rows that do wildly different work. **And
+> no changed-set control can reach a mount**: a mount row's operation *is* the
+> mount, so there is no standing page to write a changed set into and no
+> changed-set axis to be linear in. Two clean windows on two idle boxes bought
+> two refusals and no magnitude, which is what settled that more measuring
+> cannot move this.
+>
+> **The figures below stay visible and are annotated rather than erased.** Every
+> `1.4896×` on this page is a historical observation *stated under a failing
+> `ctl-2x`; withdrawn as a magnitude 2026-08-06*. History is annotated, never
+> deleted.
+>
+> **What would reopen it, precisely.** A sitting must declare in writing that
+> its go/stop turns on locating `M1` against the `1.10×` line at a precision
+> inside the corroborated spread — that the difference between ~`1.10×` and
+> ~`1.20×`, or finer, would change its ruling. Only then: **one** pre-registered
+> mount-axis three-point control (mount 150 / 300 / 600 boundaries, adjudicated
+> `(T(600) − T(150)) / (T(300) − T(150))` → `3.00×`), accepting up front that it
+> inherits the noise condition — `σ/T ≈ 3.5%` needed against a measured
+> within-block IQR of 28–48%, and the band is **widest on an idle box**
+> ([§6.2](#62-what-replaces-it-the-band-a-magnitude-must-clear): 24.6% at zero
+> competing cores against 8.3% at four, `corr(band, floor) = −0.49`), so the
+> quietest achievable box is that construction's *worst* case and it may refuse
+> after the spend. A refusal there is a valid terminal answer. Absent that
+> declaration, **no further `M1` instrument work.**
+>
+> `clock_run.cjs` labels this row `mount-regime` and prints its control status
+> on every run, so a reader of the driver's output meets the disposition rather
+> than inferring it.
 
 **Positive control: PASS.** `ctl-2x` measured 1.9534× [1.7258 – 2.1817] over 18
 segment-rounds against 2.00× ±25%, every round inside the band. **Arm-order
@@ -519,17 +589,22 @@ The bar arithmetic — two floor-normalised ratios, one against the other:
 
 | row | measured | range | disposition |
 |---|---:|---|---|
-| ~~**`hicasso / reagent-subs`**~~ | ~~1.2107×~~ | [0.9756 – 1.7208] | **SUPERSEDED — frame-only.** Reads **1.4896×** [1.3488 – 1.5989] on the corrected clock, and **1.3737×** [1.3289 – 1.4331] on `rf2-emvod`'s heavier-regime ensemble. Above the `≤ 1.0×` win condition and the `1.0150×` red zone on all three, and the range no longer straddles 1.0 |
-| ~~**`hicasso / uix-subs`**~~ | ~~1.1865×~~ | [0.9753 – 1.3722] | **SUPERSEDED.** Reads **1.5001×** on the corrected clock and **1.4656×** [1.3819 – 1.5088] on `rf2-emvod`'s ensemble; no longer straddles 1.0 |
+| ~~**`hicasso / reagent-subs`**~~ | ~~1.2107×~~ | [0.9756 – 1.7208] | ~~**SUPERSEDED — frame-only.**~~ **REGIME, no magnitude** *(2026-08-06, `rf2-jcm3p`)*. Read **1.4896×** [1.3488 – 1.5989] on the corrected clock and **1.3737×** [1.3289 – 1.4331] on `rf2-emvod`'s heavier-regime ensemble — both above the `≤ 1.0×` win condition and the `1.0150×` red zone, neither straddling 1.0, **both stated under a failing `ctl-2x` and therefore historical observations rather than published magnitudes** |
+| ~~**`hicasso / uix-subs`**~~ | ~~1.1865×~~ | [0.9753 – 1.3722] | ~~**SUPERSEDED.**~~ **REGIME, no magnitude** *(2026-08-06, `rf2-jcm3p`)*. Read **1.5001×** on the corrected clock and **1.4656×** [1.3819 – 1.5088] on `rf2-emvod`'s ensemble; neither straddles 1.0, and both are stated under the same failing control |
 
 **What that means against the gates.** The P1 win condition is *mount ≤ 1.0×
 Reagent-on-subs, same run and same instrument*, and the restated M1 red zone is
 `1.0150×` because under Ruling 1 the red zone **is** the measured UIx ratio. The
 candidate's point estimate is above both, in this run and in the four before it.
-**On the clock of record the deficit is established**: `1.4896×`
+~~**On the clock of record the deficit is established**: `1.4896×`
 [1.3488 – 1.5989] does not straddle 1.0, and `rf2-emvod`'s independent ensemble
-agrees in direction at `1.3737×` [1.3289 – 1.4331]. ~~Its range straddles 1.0,
-so at n = 6 the deficit is not *established*~~ — that was the frame-only
+agrees in direction at `1.3737×` [1.3289 – 1.4331].~~ **The deficit's DIRECTION
+is established and its SIZE is not published** *(2026-08-06, `rf2-jcm3p`: an
+interval that misses 1.0 establishes a magnitude only against a control that can
+adjudicate it, and this row's cannot — see the banner above. What the readings
+jointly establish is the regime: above the `≤ 1.10×` UIx gate on every
+corroborated reading, with `≤ 1.10×` not demonstrated.)* ~~Its range straddles
+1.0, so at n = 6 the deficit is not *established*~~ — that was the frame-only
 reading's hedge and it is spent. What still holds either way is
 validation.md's own rule that *a margin under 5% is instrument-limited rather
 than cleared*, which cuts against the candidate here: a 21% margin was already
@@ -631,18 +706,82 @@ itself only half an operation.
 > read 104 on a substrate arm and none on a floor arm — each of them a refusal
 > that exits non-zero naming itself.
 >
-> **Two re-takes exist and neither is published here.** They were taken in the
-> quiet windows of [§3.4](#34-the-quiet-window-and-why-it-publishes-nothing-rf2-0qj9w-2026-08-04)
+> ~~**Two re-takes exist and neither is published here.**~~ **Two re-takes exist
+> and BOTH are now published — as the re-adjudication in the banner below**
+> *(2026-08-06, `rf2-swwud`: this said the ruled posture was ~~to publish no
+> magnitude and rebook~~. No magnitude is published, and the rebook is spent:
+> the row is adjudicated by Event Timing rather than by the band, which the two
+> retained datasets already answer.)* They were taken in the quiet windows of
+> [§3.4](#34-the-quiet-window-and-why-it-publishes-nothing-rf2-0qj9w-2026-08-04)
 > and [§3.5](#35-the-rebooked-window-which-refuses-in-the-same-two-places-rf2-0qj9w-2026-08-04),
 > and both cleared every one of those gates — the second reconciling 540 keys
 > pressed against 449 observed and 91 censored, with the census reading 104 on
-> each substrate arm. But the bars of both are `UNADJUDICATED` for want of a
-> band — this row's fixed-50 ms control supplies none — and in both windows the
-> other row refused, so the ruled posture is to publish no magnitude and rebook.
+> each substrate arm. The bars of both are `UNADJUDICATED` for want of a band —
+> this row's fixed-50 ms control supplies none — and they are now labelled
+> **DIAGNOSTIC** rather than left as magnitudes waiting for one.
 > Both raw datasets are retained and re-adjudicable. **The figures
 > below therefore stand as the last published reading and not as a current one**;
 > the direction they report survives the correction (`rf2-emvod`), but their `n`
 > and their interaction accounting do not.
+
+> ## THIS ROW IS ADJUDICATED BY EVENT TIMING, NOT BY THE BAND (`rf2-swwud`, ruled 2026-08-06)
+>
+> **The section heading is the row's published verdict**, not a caveat on the
+> way to a number. Two clean runs on two verifiably idle boxes each cleared
+> every gate this row has and each produced three `UNADJUDICATED` bars, because
+> `ctl-50ms` burns a fixed 50 ms and `control / floor` therefore reads
+> `(F + 50) / F`, which moves with `F`. That is an excellent *sensitivity*
+> control and not a pair whose true ratio is a property of the page, so it
+> supplies no band, and [§6.2](#62-what-replaces-it-the-band-a-magnitude-must-clear)'s
+> rule is defined on exactly such a pair. **The obstruction is the rig, not the
+> box; no scheduling moves it, and the ruling adjudicates the row on the
+> instrument that can.**
+>
+> **RE-ADJUDICATED FROM THE TWO RETAINED RUNS — no new window was taken.**
+> `clock_readjudicate.cjs` reads the driver's own stored witness and prints
+> this; the datasets are under
+> `implementation/freehand/test/re_frame/bench/hicasso/data/clock-0qj9w/`.
+>
+> | arm | run 1 observed / censored | run 1 ET p50 | run 2 observed / censored | run 2 ET p50 |
+> |---|---:|---:|---:|---:|
+> | `reagent-subs` | 49 / 11 | **16.0 ms** | 47 / 13 | **16.0 ms** |
+> | `uix-subs` | 45 / 15 | **16.0 ms** | 41 / 19 | **16.0 ms** |
+> | **`hicasso`** | 49 / 11 | **16.0 ms** | 46 / 14 | **16.0 ms** |
+> | `floor` (per segment) | 46 – 49 / 11 – 14 | 16.0 ms | 44 – 46 / 14 – 16 | 16.0 ms |
+> | `ctl-50ms` (control) | 60 / 0 | 48.0 ms | 60 / 0 | 56.0 ms |
+>
+> Key accounting closes on both: **540 keys sent = 466 observed + 74 censored**
+> (run 1) and **540 = 449 + 91** (run 2), 60 sent on each of nine arms, censoring
+> published rather than dropped.
+>
+> **THE VERDICT.** *On this four-field / 100-cell witness, Hicasso,
+> Reagent-on-subs and UIx-on-subs are indistinguishable at Event Timing's
+> resolution; every observed interaction was one frame — 16.0 ms, both runs.*
+> The control moves when the work moves — `ctl-50ms` at 48.0 and 56.0 ms against
+> the arms' 16.0 — so the instrument is demonstrably not stuck.
+>
+> **POWERED TO DETECT, and this rider travels with the verdict.** Event Timing
+> resolves **8 ms buckets above a 16 ms floor**, so this row detects only a
+> difference that *crosses a bucket boundary*. The arms' separations are
+> sub-frame and sit two orders below that; the finest per-sample step either run
+> could resolve is 0.146 ms (run 1) and 0.181 ms (run 2); and every diagnostic
+> `TaskDuration` bar straddles 1.0 at this `n`, in both runs. **Do not read
+> "indistinguishable at one frame" as a measured tie below that resolution** —
+> it is a statement about what the instrument can separate, and the honest claim
+> the row is here to support is that no arm is near the frame budget.
+>
+> **The `TaskDuration` and `taskNet` bars below are DIAGNOSTIC and never
+> magnitudes.** A repair that merely gave this row a band would not survive the
+> resolution obstruction, so neither the three-point control on the dirty-cell
+> axis nor a second band-supplying control was built: both are instrument work
+> for a magnitude no current decision turns on, and the second would import
+> [§4](#4-the-mount-row--a-regime-not-a-magnitude)'s additive-constant
+> undershoot. They remain available **only** if a decision ever turns on a
+> pre-declared sub-frame effect size, at which point the experiment is powered
+> for that effect before its control is chosen. `clock_run.cjs` labels this row
+> `responsiveness-regime` and reports it only when key accounting, the recompute
+> census, the arm-order and canonical-DOM gates and **both** fixed-work controls
+> pass.
 
 **Both controls: PASS.** `ctl-50ms` produced 49.95 ms [49.44 – 50.49] of extra
 task time (predicted ≥ 40 ms, every segment-round) and Event Timing interactions
@@ -668,10 +807,17 @@ them.** 16.0 ms is one frame rounded to the nearest 8; the control proves the
 instrument moves when the work moves. The honest statement is that on
 paint-inclusive input latency the candidate and both donors are
 **indistinguishable, and all three are one frame** — a pass on the axis a user
-experiences, for all three, and not a finding *about* Hicasso.
+experiences, for all three, and not a finding *about* Hicasso. *(2026-08-06,
+`rf2-swwud`: that sentence is now the row's **published verdict** rather than a
+reading offered on the way to the finer one below. The re-adjudication in the
+banner above states it on the repaired witness and both retained runs.)*
 
-The finer instrument does separate them, and reports differences far below the
-frame budget:
+~~The finer instrument does separate them, and reports differences far below the
+frame budget:~~ **The finer instrument's readings are DIAGNOSTIC —
+UNADJUDICATED, never magnitudes** *(2026-08-06, `rf2-swwud`: this said the finer
+instrument ~~does separate them~~. It does not separate them at this `n` — every
+bar straddles 1.0, in this run and in both re-takes — and it carries no band to
+adjudicate one if it did. The numbers stay, as the diagnostics they are.)*
 
 | arm | task ms/keystroke | ×floor (tared) | range |
 |---|---:|---:|---|
@@ -682,7 +828,9 @@ frame budget:
 | `ctl-50ms` (control) | 51.9 – 52.1 | 34.4 – 37.3 | — |
 
 `hicasso / reagent-subs` = **0.9678×** [0.5318 – 1.3259] and
-`hicasso / uix-subs` = **1.0500×** [0.9119 – 1.2033]; both straddle 1.0.
+`hicasso / uix-subs` = **1.0500×** [0.9119 – 1.2033]; both straddle 1.0. **Both
+are `DIAGNOSTIC — UNADJUDICATED`**: this row has no band-supplying control, so
+neither is a magnitude and neither ever will be under this rig.
 
 > **THIS ROW SURVIVES THE CORRECTION UNCHANGED, and it is the only one that
 > does (`rf2-emvod`).** Its operation is a real key through the protocol's

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -344,7 +344,7 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
 
 {
   const CLOCK = path.join(__dirname, 'clock_run.cjs');
-  const { reportability, rowAdjudication, reportabilitySelfTest } = require('./clock_run.cjs');
+  const { reportability, rowAdjudication, rowRegime, ROW_REGIME, reportabilitySelfTest } = require('./clock_run.cjs');
   const SRC = fs.readFileSync(CLOCK, 'utf8');
   const t = (what, fn) => test(`clock_run.cjs: ${what}`, fn);
   const KEYSTROKE_WHY = "UNADJUDICATED — this row's control burns a fixed 50 ms rather than doubling the page";
@@ -510,13 +510,162 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     assert.doesNotMatch(line, /keystroke/, 'an unadjudicated row must never appear in REPORTABLE');
   });
 
+  // --- THE REGIMES: what a row publishes, declared (rf2-jcm3p, rf2-swwud) ---
+  //
+  // Two rows had spent months refusing for reasons no amount of measuring
+  // could move — `M1`'s positive control undershoots 2.00x by an additive
+  // constant and no changed-set control can reach a mount; `keystroke`'s
+  // control burns a fixed 50 ms and therefore supplies no band. Both rulings
+  // NARROW THE CLAIM rather than build a better instrument: the rows publish
+  // regimes, not magnitudes.
+  //
+  // THE THING THESE CASES EXIST TO PIN is that the narrowing did not soften
+  // anything. rf2-y7mw7 had just made `HCLOCK_ONLY=keystroke` exit 1, and a
+  // "relabelling" that let it exit 0 again would be that repair undone under
+  // a nicer name. Every case below asserts the code as well as the sentence.
+
+  const mountRow = (over) => clockRow({ rowId: 'M1', regime: 'mount-regime', ctlOk: false, ...over });
+  const respRow = (over) =>
+    clockRow({
+      rowId: 'keystroke',
+      regime: 'responsiveness-regime',
+      adjudicable: false,
+      unadjudicatedWhy: KEYSTROKE_WHY,
+      ...over,
+    });
+
+  t('THE ROSTER: M1 is a mount regime, keystroke a responsiveness regime', () => {
+    assert.strictEqual(rowRegime('M1'), 'mount-regime');
+    assert.strictEqual(rowRegime('keystroke'), 'responsiveness-regime');
+    assert.deepStrictEqual(ROW_REGIME, {
+      M1: 'mount-regime',
+      bulk300: 'magnitude',
+      bulk100: 'magnitude',
+      narrow: 'magnitude',
+      keystroke: 'responsiveness-regime',
+    });
+  });
+
+  t('a regime is granted by ruling and never by default — an unknown row is a magnitude row', () => {
+    assert.strictEqual(rowRegime('bulk300'), 'magnitude');
+    assert.strictEqual(rowRegime('some-row-nobody-ruled-on'), 'magnitude');
+    assert.strictEqual(rowRegime(undefined), 'magnitude');
+  });
+
+  t('THE EXIT DID NOT MOVE: a keystroke-only run exits 1 exactly as rf2-y7mw7 made it', () => {
+    const v = reportability([respRow()]);
+    assert.strictEqual(v.code, 1, 'a regime row publishes no magnitude, so it cannot exit 0');
+    assert.strictEqual(v.lines[v.lines.length - 1], '[clock] REPORTABLE: none.');
+  });
+
+  t('and an M1-only run exits 1 exactly as its failing control made it', () => {
+    assert.strictEqual(reportability([mountRow()]).code, 1);
+  });
+
+  t('the keystroke refusal now states a REGIME rather than an unadjudicated magnitude', () => {
+    const v = reportability([respRow()]);
+    const all = v.lines.join('\n');
+    assert.match(all, /REGIME: these rows publish a regime and never a magnitude/);
+    assert.match(all, /keystroke \[responsiveness-regime, rf2-swwud\] STATED/);
+    assert.match(all, /DIAGNOSTIC, never magnitudes/);
+    assert.doesNotMatch(
+      all,
+      /not every published bar can be ADJUDICATED/,
+      "a bandless bar on a regime row is a diagnostic, not a magnitude the run failed to adjudicate"
+    );
+  });
+
+  t('the M1 refusal now states a REGIME rather than a control that went wrong', () => {
+    const v = reportability([mountRow({ ctlNote: ' (ctl-2x 1.8173x vs 2.00x)' })]);
+    const all = v.lines.join('\n');
+    assert.match(all, /M1 \[mount-regime, rf2-jcm3p\] STATED/);
+    assert.match(all, /DIRECTION ONLY/);
+    assert.match(all, /positive control: FAIL \(ctl-2x 1\.8173x vs 2\.00x\) — expected, and the reason no magnitude/);
+    assert.doesNotMatch(all, /the positive control did not see the change/);
+  });
+
+  // --- MUTATION, BOTH DIRECTIONS -------------------------------------------
+  //
+  // A label that cannot be got wrong is a label nothing depends on. These two
+  // revert each row's regime and assert the run reads differently — the first
+  // is the relabelling's forward proof, the second its reverse.
+
+  t('MUTATION: relabel M1 back to a magnitude row and it reads as a fault again', () => {
+    const v = reportability([mountRow({ regime: 'magnitude', ctlNote: ' (ctl-2x 1.8173x vs 2.00x)' })]);
+    assert.strictEqual(v.code, 1, 'the exit is the same either way — only the sentence differs');
+    assert.match(v.lines[0], /the positive control did not see the change its own arithmetic predicts on: M1/);
+    assert.doesNotMatch(v.lines.join('\n'), /mount-regime/);
+  });
+
+  t('MUTATION: relabel keystroke back to a magnitude row and its bars read as unadjudicated', () => {
+    const v = reportability([respRow({ regime: 'magnitude' })]);
+    assert.strictEqual(v.code, 1);
+    assert.match(v.lines[0], /not every published bar can be ADJUDICATED on: keystroke/);
+    assert.doesNotMatch(v.lines.join('\n'), /responsiveness-regime/);
+  });
+
+  // --- the one condition rf2-swwud puts on the responsiveness regime --------
+
+  t('a responsiveness regime is WITHHELD when its fixed-work controls did not pass', () => {
+    const v = reportability([respRow({ ctlOk: false })]);
+    assert.strictEqual(v.code, 1);
+    assert.match(v.lines.join('\n'), /keystroke \[responsiveness-regime, rf2-swwud\] WITHHELD/);
+    assert.match(v.lines.join('\n'), /prove the instrument moves when the work moves/);
+  });
+
+  t('a mount regime is NOT withheld by a failing control — the two regimes differ deliberately', () => {
+    // rf2-jcm3p's premise IS that ctl-2x fails, so a mount regime that waited
+    // on it could never be stated at all.
+    const v = reportability([mountRow()]);
+    assert.match(v.lines.join('\n'), /M1 \[mount-regime, rf2-jcm3p\] STATED/);
+    assert.doesNotMatch(v.lines.join('\n'), /M1 .* WITHHELD/);
+  });
+
+  // --- the magnitude rows are untouched, which is the other half ------------
+
+  t('a magnitude row beside the regimes is still reportable, and no regime joins it', () => {
+    const v = reportability([clockRow({ rowId: 'bulk300' }), mountRow(), respRow()]);
+    assert.strictEqual(v.code, 1);
+    const last = v.lines[v.lines.length - 1];
+    assert.match(last, /^\[clock\] REPORTABLE: bulk300 —/);
+    assert.doesNotMatch(last, /M1|keystroke/, 'a regime row may never be announced as reportable');
+  });
+
+  t("a magnitude row's own gates still refuse it, beside the regimes", () => {
+    const v = reportability([clockRow({ rowId: 'bulk300', ctlOk: false }), mountRow()]);
+    assert.strictEqual(v.code, 1);
+    const all = v.lines.join('\n');
+    assert.match(all, /the positive control did not see the change.*bulk300/);
+    assert.match(all, /REGIME:/);
+    assert.doesNotMatch(
+      all,
+      /predicts on: bulk300, M1|predicts on: M1/,
+      'a regime row must not be listed among the control failures'
+    );
+  });
+
+  t('and a clean all-magnitude run still exits 0 — the regimes did not make the gate vacuous', () => {
+    assert.deepStrictEqual(reportability([clockRow({ rowId: 'bulk300' }), clockRow({ rowId: 'narrow' })]), {
+      code: 0,
+      lines: [],
+    });
+  });
+
+  t('the driver hands the DECLARED regime to the decision, not one it inferred from its numbers', () => {
+    const M = SRC.slice(SRC.indexOf('async function main()'), SRC.indexOf('\nmodule.exports'));
+    assert.match(M, /regime: rowRegime\(o\.out\.rowId\)/);
+  });
+
   // --- the wiring: `reportability` is load-bearing, not decorative ----------
 
   const MAIN = SRC.slice(SRC.indexOf('async function main()'), SRC.indexOf('\nmodule.exports'));
 
   t('the driver exposes its decision and does not drive itself on require', () => {
     assert.ok(MAIN.length > 0, 'the driver must expose its run as `main`');
-    assert.match(SRC, /module\.exports = \{ reportability, rowAdjudication, reportabilitySelfTest \};/);
+    assert.match(
+      SRC,
+      /module\.exports = \{ reportability, rowAdjudication, rowRegime, ROW_REGIME, reportabilitySelfTest \};/
+    );
     assert.match(SRC, /if \(require\.main === module\) \{\s*main\(\);/);
   });
 
@@ -573,7 +722,7 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
 
 {
   const RJ = path.join(__dirname, 'clock_readjudicate.cjs');
-  const { adjudicated, reportable } = require('./clock_readjudicate.cjs');
+  const { adjudicated, reportable, responsivenessRegime } = require('./clock_readjudicate.cjs');
   const RJSRC = fs.readFileSync(RJ, 'utf8');
   const t = (what, fn) => test(`clock_readjudicate.cjs: ${what}`, fn);
   const ADJ = { unadjudicated: false, band: 0.21, why: 'margin 34.8% clears the band 21.4%' };
@@ -630,7 +779,7 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   });
 
   t('requiring the readjudicator does not RUN it, which is what made this reachable', () => {
-    assert.match(RJSRC, /module\.exports = \{ adjudicated, reportable \};/);
+    assert.match(RJSRC, /module\.exports = \{ adjudicated, reportable, responsivenessRegime \};/);
     assert.match(RJSRC, /if \(require\.main === module\) \{/);
     assert.match(RJSRC, /main\(process\.argv\.slice\(2\)\)/);
   });
@@ -663,6 +812,131 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     // and the column's UNADJUDICATED branch is taken from THAT, not from the
     // row-wide band.
     assert.match(body, /: barUnadjudicated\s*\r?\n\s*\? 'UNADJUDICATED/);
+  });
+
+  // --- THE RESPONSIVENESS REGIME, off the retained datasets (rf2-swwud) -----
+  //
+  // The ruling re-adjudicates the per-keystroke row from the two runs already
+  // on disk — no new window, and none needed. These drive the predicate on
+  // synthetic rows and then on the real ones, because "re-adjudicated from
+  // disk" is a claim about files that must be checkable against those files.
+
+  const etArm = (durations, over) => ({
+    sent: 60,
+    observed: durations.length,
+    censored: 60 - durations.length,
+    durations,
+    ...over,
+  });
+  const frames = (n) => Array(n).fill(16);
+  const kbRow = (over) => ({
+    rowId: 'keystroke',
+    granularity: [0.146, 0.2, 0.3],
+    barTask: {
+      'hicasso / reagent-subs': { mean: 0.9491, min: 0.7328, max: 1.1596 },
+      'hicasso / uix-subs': { mean: 0.9968, min: 0.8059, max: 1.2172 },
+      'uix-subs / reagent-subs': { mean: 0.9548, min: 0.771, max: 1.0546 },
+    },
+    kbWitness: {
+      totals: { sent: 180, observed: 140, censored: 40 },
+      perArm: {
+        'hicasso/hicasso': etArm(frames(49)),
+        'reagent-subs/reagent-subs': etArm(frames(46)),
+        'uix-subs/uix-subs': etArm(frames(45)),
+        'hicasso/ctl-50ms': etArm(Array(60).fill(48)),
+      },
+    },
+    ...over,
+  });
+
+  t('every other row is not a responsiveness regime, and says so by returning nothing', () => {
+    assert.strictEqual(responsivenessRegime({ rowId: 'M1' }), null);
+    assert.strictEqual(responsivenessRegime(undefined), null);
+    assert.strictEqual(responsivenessRegime({ rowId: 'M1', kbWitness: {} }), null);
+  });
+
+  t('one bucket across every observed arm IS the verdict, and the control must have moved', () => {
+    const r = responsivenessRegime(kbRow());
+    assert.strictEqual(r.indistinguishable, true);
+    assert.strictEqual(r.frame, 16);
+    assert.strictEqual(r.controlP50, 48);
+    assert.strictEqual(r.controlMoved, true, 'a control that did not move is an instrument nobody saw respond');
+  });
+
+  t('THE GATE IS NOT VACUOUS: an arm in a second bucket refuses the frame statement', () => {
+    // If it always said "indistinguishable", it would be an assertion rather
+    // than a reading. Move one arm a bucket and the verdict must withdraw.
+    const r = responsivenessRegime(
+      kbRow({
+        kbWitness: {
+          totals: { sent: 180, observed: 140, censored: 40 },
+          perArm: {
+            'hicasso/hicasso': etArm(Array(49).fill(24)),
+            'reagent-subs/reagent-subs': etArm(frames(46)),
+            'hicasso/ctl-50ms': etArm(Array(60).fill(48)),
+          },
+        },
+      })
+    );
+    assert.strictEqual(r.indistinguishable, false, 'arms in two buckets are not indistinguishable');
+  });
+
+  t('a control that did not clear the arms is FAIL — the sensitivity claim is checked, not assumed', () => {
+    const r = responsivenessRegime(
+      kbRow({
+        kbWitness: {
+          totals: null,
+          perArm: { 'hicasso/hicasso': etArm(frames(49)), 'hicasso/ctl-50ms': etArm(frames(60)) },
+        },
+      })
+    );
+    assert.strictEqual(r.controlMoved, false);
+  });
+
+  t('THE RIDER is carried, not optional: the grain and the straddling bars come back with it', () => {
+    const r = responsivenessRegime(kbRow());
+    assert.strictEqual(r.grain, 0.146, "the run's own finest per-sample step, as the driver stored it");
+    assert.strictEqual(r.diagnosticBars.length, 3);
+    assert.ok(
+      r.diagnosticBars.every((b) => b.straddles1),
+      'every diagnostic bar straddles 1.0, which is why no magnitude is published'
+    );
+  });
+
+  t('it reads the WITNESS the driver stored rather than regrouping raw entries', () => {
+    // The witness owns what forms an interaction and what a censored key is.
+    // A second grouping here would be a second adjudicator, which is this
+    // whole file's subject.
+    const body = RJSRC.slice(RJSRC.indexOf('function responsivenessRegime('));
+    assert.match(body, /row && row\.kbWitness/);
+    assert.ok(
+      !/interactionId/.test(body.slice(0, body.indexOf('function main('))),
+      'grouping entries by interactionId here would be the witness written a second time'
+    );
+  });
+
+  // --- and against the retained runs themselves ----------------------------
+
+  t('THE RULING RE-ADJUDICATED FROM DISK, and the datasets still say what it said', () => {
+    const dir = path.join(__dirname, 'data', 'clock-0qj9w');
+    if (!fs.existsSync(dir)) return; // datasets are retained, not required to build
+    const expected = { 'run1.json': { observed: 466, censored: 74, ctl: 48 }, 'run2.json': { observed: 449, censored: 91, ctl: 56 } };
+    for (const [file, want] of Object.entries(expected)) {
+      const data = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
+      const row = data.rows.find((r) => r.rowId === 'keystroke');
+      assert.ok(row, `${file} must retain its keystroke row`);
+      const r = responsivenessRegime(row);
+      assert.strictEqual(r.indistinguishable, true, `${file}: every observed interaction must be one frame`);
+      assert.strictEqual(r.frame, 16, `${file}: and that frame is 16 ms`);
+      assert.strictEqual(r.controlP50, want.ctl, `${file}: ctl-50ms median`);
+      assert.strictEqual(r.totals.observed, want.observed, `${file}: observed keys`);
+      assert.strictEqual(r.totals.censored, want.censored, `${file}: censored keys`);
+      assert.strictEqual(r.totals.sent, 540, `${file}: keys sent`);
+      assert.ok(
+        r.diagnosticBars.every((b) => b.straddles1),
+        `${file}: every diagnostic bar must straddle 1.0 — no magnitude may be published from this row`
+      );
+    }
   });
 
   t('it still SELECTS no run away from the table — only from the subset', () => {

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
@@ -166,7 +166,9 @@ function responsivenessRegime(row) {
   const observedArms = perArm.filter((a) => !a.control && a.n > 0);
   const controlArms = perArm.filter((a) => a.control && a.n > 0);
   const buckets = [...new Set(observedArms.flatMap((a) => [a.min, a.max]))];
-  const controlDurations = controlArms.flatMap((a) => Array(a.n).fill(a.p50));
+  // The control's median over its OWN readings, pooled across segments —
+  // every duration once, rather than each arm's median re-weighted.
+  const controlDurations = controlArms.flatMap((a) => w.perArm[a.arm].durations || []);
   return {
     perArm,
     totals: w.totals || null,

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
@@ -117,6 +117,81 @@ function reportable(row) {
   );
 }
 
+/**
+ * THE RESPONSIVENESS REGIME, RE-ADJUDICATED OFF THE STORED RUN (rf2-swwud).
+ *
+ * The per-keystroke row has no band and never will: its control burns a fixed
+ * 50 ms, so `control/floor` reads `(F+50)/F` and moves with `F` — a fine
+ * sensitivity control, and not a pair whose true ratio is a property of the
+ * page. Two clean runs on two verifiably idle boxes produced two UNADJUDICATED
+ * rows for exactly that reason, which is what settled the question the row was
+ * raised on: the obstruction is the rig, not the box, and no scheduling moves
+ * it. The 2026-08-06 ruling therefore adjudicates this row by EVENT TIMING
+ * instead of by the band, and the tables above become diagnostics.
+ *
+ * WHY IT IS COMPUTED HERE. The re-adjudication is of the runs already on disk
+ * — no new window was taken and none is needed. `clock_run.cjs` stores the
+ * repaired witness's own per-arm accounting in every dataset, so this reads
+ * `kbWitness.perArm` rather than regrouping raw entries: the driver's witness
+ * owns what forms an interaction and what a censored key is, and a second
+ * grouping here would be a second adjudicator.
+ *
+ * IT PUBLISHES NO MAGNITUDE AND THE RIDER IS NOT OPTIONAL. Event Timing
+ * resolves 8 ms buckets above a 16 ms floor, so this row detects only a
+ * difference that crosses a bucket boundary. "Indistinguishable at one frame"
+ * is a statement about the instrument's resolution and NOT a measured tie
+ * below it — the arms' separations are sub-frame, the per-sample grid is
+ * coarser than they are, and every diagnostic bar straddles 1.0.
+ *
+ * `row` is one entry of a dataset's `rows`. Returns `null` for a row that
+ * carries no keystroke witness, which is every other row.
+ */
+function responsivenessRegime(row) {
+  const w = row && row.kbWitness;
+  if (!w || !w.perArm) return null;
+  const perArm = Object.entries(w.perArm).map(([arm, a]) => {
+    const ds = a.durations || [];
+    return {
+      arm,
+      control: /\/ctl-/.test(arm),
+      sent: a.sent,
+      observed: a.observed,
+      censored: a.censored,
+      n: ds.length,
+      p50: p50(ds),
+      min: ds.length ? Math.min(...ds) : NaN,
+      max: ds.length ? Math.max(...ds) : NaN,
+    };
+  });
+  const observedArms = perArm.filter((a) => !a.control && a.n > 0);
+  const controlArms = perArm.filter((a) => a.control && a.n > 0);
+  const buckets = [...new Set(observedArms.flatMap((a) => [a.min, a.max]))];
+  const controlDurations = controlArms.flatMap((a) => Array(a.n).fill(a.p50));
+  return {
+    perArm,
+    totals: w.totals || null,
+    // ONE BUCKET ACROSS EVERY OBSERVED ARM is the whole verdict. It is stated
+    // as a property of the readings rather than asserted, so a run in which
+    // the arms DID separate would say so here instead.
+    indistinguishable: observedArms.length > 0 && buckets.length === 1,
+    frame: buckets.length === 1 ? buckets[0] : NaN,
+    controlP50: controlDurations.length ? p50(controlDurations) : NaN,
+    // The instrument moved when the work moved, or this run states nothing.
+    controlMoved: controlArms.length > 0 && controlArms.every((a) => a.p50 > buckets[0]),
+    // THE RIDER'S OWN NUMBERS, both stored by the driver rather than derived
+    // here: the finest per-sample step this run could resolve, and whether the
+    // diagnostic bars separate the arms at this n. They do not.
+    grain: Array.isArray(row.granularity) && row.granularity.length ? row.granularity[0] : NaN,
+    diagnosticBars: PAIRS.filter((p) => row.barTask && row.barTask[p]).map((p) => ({
+      pair: p,
+      mean: row.barTask[p].mean,
+      min: row.barTask[p].min,
+      max: row.barTask[p].max,
+      straddles1: row.barTask[p].min <= 1 && row.barTask[p].max >= 1,
+    })),
+  };
+}
+
 function main(argv) {
   const files = argv.filter((a) => !a.startsWith('--'));
   if (files.length === 0) {
@@ -234,6 +309,56 @@ function main(argv) {
             ` ${(fmt(margin, 1) + '%').padStart(7)}   ${verdict}`
         );
       });
+    }
+
+    // --- the responsiveness regime, per run (rf2-swwud) -----------------------
+    //
+    // Printed immediately under the bars it re-labels, because the bars above
+    // are what this row USED to be published as and the ruling's whole content
+    // is that they are diagnostics.
+    for (const { file, row } of runs) {
+      const reg = responsivenessRegime(row);
+      if (!reg) continue;
+      console.log('');
+      console.log(
+        `;;   RESPONSIVENESS REGIME — ${shortName(file)}, re-adjudicated on EVENT TIMING rather than on the band`
+      );
+      console.log(';;     arm                        sent  observed  censored   ET p50   range');
+      for (const a of reg.perArm) {
+        console.log(
+          `;;     ${a.arm.padEnd(26)}${String(a.sent).padStart(4)}${String(a.observed).padStart(10)}` +
+            `${String(a.censored).padStart(10)}${(fmt(a.p50, 1) + ' ms').padStart(10)}   ` +
+            `[${fmt(a.min, 1)} – ${fmt(a.max, 1)}]${a.control ? '   (control)' : ''}`
+        );
+      }
+      if (reg.totals) {
+        console.log(
+          `;;     accounting: ${reg.totals.sent} keys sent = ${reg.totals.observed} observed + ` +
+            `${reg.totals.censored} censored under the 16 ms floor`
+        );
+      }
+      console.log(
+        `;;     VERDICT ${
+          reg.indistinguishable
+            ? `Hicasso, Reagent-on-subs and UIx-on-subs are INDISTINGUISHABLE at Event Timing's ` +
+              `resolution — every observed interaction was one frame (${fmt(reg.frame, 1)} ms)`
+            : `the arms did NOT fall in one bucket on this run — the frame statement does not hold here`
+        }`
+      );
+      console.log(
+        `;;     control ${reg.controlMoved ? 'PASS' : 'FAIL'} — ctl-50ms reads ${fmt(reg.controlP50, 1)} ms ` +
+          `against the arms' ${fmt(reg.frame, 1)} ms, so the instrument demonstrably moves when the work moves`
+      );
+      console.log(
+        `;;     POWERED TO DETECT: Event Timing resolves 8 ms buckets above a 16 ms floor, so this row ` +
+          `detects only a difference that CROSSES a bucket boundary. It is not a measured tie below that.`
+      );
+      console.log(
+        `;;       the arms' separations are sub-frame; this run's finest per-sample step is ` +
+          `${fmt(reg.grain, 3)} ms, and every diagnostic bar above straddles 1.0 ` +
+          `(${reg.diagnosticBars.filter((b) => b.straddles1).length} of ${reg.diagnosticBars.length}) — ` +
+          `no magnitude is published from this row.`
+      );
     }
 
     // --- absolutes, pooled over the ensemble ----------------------------------
@@ -384,7 +509,7 @@ function shortName(f) {
   return m ? m[1] : f;
 }
 
-module.exports = { adjudicated, reportable };
+module.exports = { adjudicated, reportable, responsivenessRegime };
 
 // Requiring this file must not run it: `clock_exit_path.test.cjs` drives the
 // two predicates above directly, which it cannot do if the module body reads

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
@@ -1747,9 +1747,20 @@ function report(out) {
 function reportability(rows, opts) {
   const list = Array.isArray(rows) ? rows : [];
   const sabotage = (opts && opts.sabotage) || null;
-  const ctlFailed = list.filter((r) => !r.ctlOk);
-  const unadjudicated = list.filter((r) => !r.adjudicable);
-  const passed = list.filter((r) => r.ctlOk && r.adjudicable).map((r) => r.rowId);
+  // A ROW'S REGIME DECIDES WHICH REFUSAL IS ITS OWN (rf2-jcm3p, rf2-swwud).
+  // The two gates below adjudicate MAGNITUDES, and a regime row has none to
+  // adjudicate: reading `M1`'s known control failure as "the positive control
+  // did not see the change its own arithmetic predicts" states a finding as a
+  // fault, and reading `keystroke`'s bandless bars as "not every published bar
+  // can be ADJUDICATED" states a diagnostic as a magnitude. Both rows still
+  // refuse — see the regime block below — so no exit code moves; what moves is
+  // which sentence the run prints about them.
+  const regimeOf = (r) => REGIMES[r.regime] || REGIMES.magnitude;
+  const magnitudeRows = list.filter((r) => regimeOf(r).publishesMagnitude);
+  const regimeRows = list.filter((r) => !regimeOf(r).publishesMagnitude);
+  const ctlFailed = magnitudeRows.filter((r) => !r.ctlOk);
+  const unadjudicated = magnitudeRows.filter((r) => !r.adjudicable);
+  const passed = magnitudeRows.filter((r) => r.ctlOk && r.adjudicable).map((r) => r.rowId);
   const lines = [];
   if (ctlFailed.length > 0) {
     lines.push(
@@ -1797,7 +1808,42 @@ function reportability(rows, opts) {
       lines.push(`[clock]   ${r.rowId}: ${which}${r.unadjudicatedWhy || 'no proportional control on this row'}`);
     }
   }
-  if (ctlFailed.length === 0 && unadjudicated.length === 0) return { code: 0, lines };
+  // AND A ROW MAY PUBLISH A REGIME RATHER THAN A MAGNITUDE (rf2-jcm3p,
+  // rf2-swwud). This is a refusal of the same weight as the two above — no
+  // figure from the row is reportable — and of an entirely different kind: the
+  // two above are things that went wrong, this one is what the row IS. It is
+  // printed last so a reader meets the run's faults before its dispositions.
+  //
+  // The statement itself is published here whatever the exit, because a regime
+  // withheld in silence is indistinguishable from a regime nobody took.
+  if (regimeRows.length > 0) {
+    lines.push(
+      `[clock] REGIME: these rows publish a regime and never a magnitude, by ruling — ` +
+        `${regimeRows.map((r) => `${r.rowId} (${r.regime})`).join(', ')}. ` +
+        `A regime is a statement about what the row's numbers MEAN, so no figure from it is ` +
+        `reportable and this run cannot exit 0 on one:`
+    );
+    for (const r of regimeRows) {
+      const g = regimeOf(r);
+      const stated = !g.statementNeedsControl || r.ctlOk;
+      lines.push(
+        `[clock]   ${r.rowId} [${r.regime}, ${g.bead}] ${stated ? 'STATED' : 'WITHHELD'} — ${g.publishes}`
+      );
+      lines.push(
+        `[clock]     ${stated ? g.why : `its fixed-work controls did not pass${r.ctlNote || ''}, and they are what prove the instrument moves when the work moves — the regime is withheld rather than stated`}`
+      );
+      // The control status, printed on every regime row whichever way it fell,
+      // because the ruling that made these rows regimes is ABOUT their
+      // controls and a reader must not have to infer one from the other.
+      lines.push(
+        `[clock]     positive control: ${r.ctlOk ? 'PASS' : 'FAIL'}${r.ctlNote || ''}` +
+          (r.ctlOk ? '' : g.statementNeedsControl ? '' : ' — expected, and the reason no magnitude is published')
+      );
+    }
+  }
+  if (ctlFailed.length === 0 && unadjudicated.length === 0 && regimeRows.length === 0) {
+    return { code: 0, lines };
+  }
   lines.push(
     passed.length > 0
       ? `[clock] REPORTABLE: ${passed.join(', ')} — control passed, guard clean, canonical DOM identical, ` +
@@ -1847,6 +1893,103 @@ function rowAdjudication(bars) {
         ? src[unadjudicatedBars[0]].why
         : 'the run adjudicated no bar on this row at all',
   };
+}
+
+/**
+ * WHAT A ROW PUBLISHES — its REGIME, declared rather than inferred
+ * (rf2-jcm3p, rf2-swwud, both ruled 2026-08-06).
+ *
+ * Until these two rulings every row of this driver was a magnitude row that
+ * either cleared its gates or refused, and two rows had spent months refusing
+ * for reasons no amount of measuring could move. Both rulings say the same
+ * thing about their row: the honest answer is to NARROW THE CLAIM rather than
+ * to build a better instrument for a magnitude no decision turns on.
+ *
+ *   `magnitude`               publishes an adjudicated figure. Needs its
+ *                             positive control AND a band on every published
+ *                             bar — `rowAdjudication`'s rule, unchanged, which
+ *                             is rf2-y7mw7's contract and is not re-opened
+ *                             here.
+ *
+ *   `mount-regime`            `M1` (rf2-jcm3p). Publishes DIRECTION and no
+ *                             magnitude. Its positive control `ctl-2x` fails —
+ *                             1.8173x against a predicted 2.00x, reproduced at
+ *                             1.8443x and 1.8567x on two verifiably idle boxes
+ *                             — and the additive constant `c ~ 1.04 ms`
+ *                             explains the undershoot arithmetically:
+ *                             `(2W+c)/(W+c)` is below 2 for any positive `c`.
+ *                             A mount's operation IS the mount, so there is no
+ *                             standing page to write a changed set into and no
+ *                             changed-set control can reach it. THE FAILING
+ *                             CONTROL IS THE PUBLISHED REASON there is no
+ *                             magnitude, not a defect of the run that meets it,
+ *                             which is why this regime's statement does not
+ *                             wait on that control.
+ *
+ *   `responsiveness-regime`   `keystroke` (rf2-swwud). Adjudicated by EVENT
+ *                             TIMING rather than by the band of
+ *                             `the-candidates-clock.md` sec 6.2. Its control
+ *                             burns a fixed 50 ms, so `control/floor` reads
+ *                             `(F+50)/F` and moves with `F` — an excellent
+ *                             sensitivity control and not a pair whose true
+ *                             ratio is a property of the page, so it supplies
+ *                             no band and the TaskDuration bars it prints are
+ *                             DIAGNOSTIC, never magnitudes. Its statement DOES
+ *                             wait on its fixed-work controls, because those
+ *                             are what prove the instrument moves when the work
+ *                             moves; without them a frame reading is not
+ *                             evidence of anything.
+ *
+ * A REGIME ROW REFUSES THE RUN, and that is not a change of temperature. It
+ * publishes no magnitude — ever, by ruling rather than by accident — so
+ * `REPORTABLE` cannot name it and the exit code, which answers "is there a
+ * publishable MAGNITUDE here", stays 1. `HCLOCK_ONLY=keystroke` exited 1
+ * before these rulings and exits 1 after them; what changes is that the
+ * refusal now states the row's regime instead of reading as a defect.
+ *
+ * The regime is carried ON THE ROW SUMMARY rather than looked up inside
+ * `reportability`, so the rule and the roster are separately drivable: the
+ * fixtures below exercise each regime's behaviour, and `rowRegime` is mutation-
+ * provable on its own — relabel a row and its case fails.
+ */
+const REGIMES = {
+  magnitude: { publishesMagnitude: true },
+  'mount-regime': {
+    publishesMagnitude: false,
+    bead: 'rf2-jcm3p',
+    // The statement is about DIRECTION, and direction does not turn on a
+    // control whose failure is itself the published finding.
+    statementNeedsControl: false,
+    publishes: 'DIRECTION ONLY — hicasso mounts materially slower than both adapters; no magnitude',
+    why:
+      'ctl-2x undershoots 2.00x by the additive constant c ~ 1.04 ms and no changed-set control ' +
+      'can reach a mount, so the control status is the published reason rather than a fault of this run',
+  },
+  'responsiveness-regime': {
+    publishesMagnitude: false,
+    bead: 'rf2-swwud',
+    // Event Timing is the adjudicator, and a fixed-work control that did not
+    // move is an instrument nobody has seen respond.
+    statementNeedsControl: true,
+    publishes: 'A FRAME STATEMENT read off Event Timing — the TaskDuration bars are DIAGNOSTIC, never magnitudes',
+    why:
+      "this row's control burns a fixed 50 ms, so control/floor reads (F+50)/F and supplies no band; " +
+      'Event Timing adjudicates it instead, at 8 ms buckets above a 16 ms floor',
+  },
+};
+
+/** THE ROSTER, as one table a test can read back. */
+const ROW_REGIME = {
+  M1: 'mount-regime',
+  bulk300: 'magnitude',
+  bulk100: 'magnitude',
+  narrow: 'magnitude',
+  keystroke: 'responsiveness-regime',
+};
+
+/** A row's declared regime, defaulting to the one every row used to have. */
+function rowRegime(rowId) {
+  return ROW_REGIME[rowId] || 'magnitude';
 }
 
 /**
@@ -1997,6 +2140,98 @@ function reportabilitySelfTest() {
   check(
     'and a verdict that went missing entirely is absent, not clean',
     rowAdjudication(undefined).adjudicable === false && rowAdjudication(null).adjudicable === false
+  );
+
+  // THE REGIMES (rf2-jcm3p, rf2-swwud). Every fixture above carries no
+  // `regime` and so is a magnitude row, which is deliberate: the rule those
+  // cases pin is rf2-y7mw7's and these rulings do not re-open it. What is
+  // added is a second disposition beside it, and the cases that matter are
+  // the ones showing a regime row REFUSES — the temperature of the exit did
+  // not change, only the sentence.
+  const mount = (over) => row({ rowId: 'M1', regime: 'mount-regime', ctlOk: false, ...over });
+  const resp = (over) =>
+    row({ rowId: 'keystroke', regime: 'responsiveness-regime', adjudicable: false, unadjudicatedWhy: KEYSTROKE_WHY, ...over });
+
+  const m = reportability([mount()]);
+  check(
+    'THE MOUNT REGIME: M1 refuses, exactly as it did when its control was read as a fault',
+    m.code === 1 && m.lines[m.lines.length - 1] === '[clock] REPORTABLE: none.',
+    m.lines.join(' | ')
+  );
+  check(
+    'and it is refused as a REGIME rather than as a control that went wrong',
+    m.lines.some((l) => /REGIME: these rows publish a regime and never a magnitude/.test(l)) &&
+      m.lines.some((l) => /M1 \[mount-regime, rf2-jcm3p\] STATED/.test(l)) &&
+      !m.lines.some((l) => /the positive control did not see the change/.test(l)),
+    m.lines.join(' | ')
+  );
+  check(
+    "the mount regime STATES itself although its control failed — the failure is the ruling's own premise",
+    m.lines.some((l) => /positive control: FAIL.*expected, and the reason no magnitude is published/.test(l)),
+    m.lines.join(' | ')
+  );
+
+  const k = reportability([resp()]);
+  check(
+    'THE RESPONSIVENESS REGIME: keystroke still cannot exit 0 — rf2-y7mw7 is not re-opened',
+    k.code === 1 && k.lines[k.lines.length - 1] === '[clock] REPORTABLE: none.',
+    k.lines.join(' | ')
+  );
+  check(
+    'and its bandless bars are named DIAGNOSTIC rather than unadjudicated magnitudes',
+    k.lines.some((l) => /keystroke \[responsiveness-regime, rf2-swwud\] STATED/.test(l)) &&
+      k.lines.some((l) => /DIAGNOSTIC, never magnitudes/.test(l)) &&
+      !k.lines.some((l) => /not every published bar can be ADJUDICATED/.test(l)),
+    k.lines.join(' | ')
+  );
+  check(
+    'THE ONE CONDITION rf2-swwud puts on it: fixed-work controls that did not pass WITHHOLD the regime',
+    (() => {
+      const w = reportability([resp({ ctlOk: false })]);
+      return w.code === 1 && w.lines.some((l) => /keystroke .* WITHHELD/.test(l));
+    })(),
+    reportability([resp({ ctlOk: false })]).lines.join(' | ')
+  );
+  check(
+    'and a mount regime is NOT withheld by the same control failure — the two regimes differ, deliberately',
+    m.lines.some((l) => /M1 .* STATED/.test(l)) && !m.lines.some((l) => /M1 .* WITHHELD/.test(l))
+  );
+
+  const mixedRegime = reportability([row({ rowId: 'bulk300' }), mount(), resp()]);
+  check(
+    'a magnitude row beside two regime rows is still reportable, and the regimes never join it',
+    mixedRegime.code === 1 &&
+      /REPORTABLE: bulk300 —/.test(mixedRegime.lines[mixedRegime.lines.length - 1]) &&
+      !/M1|keystroke/.test(mixedRegime.lines[mixedRegime.lines.length - 1]),
+    mixedRegime.lines[mixedRegime.lines.length - 1]
+  );
+  check(
+    'a magnitude row that fails is STILL refused as a fault, beside the regimes — the old gates are intact',
+    (() => {
+      const v = reportability([row({ rowId: 'bulk300', ctlOk: false }), mount()]);
+      return (
+        v.code === 1 &&
+        v.lines.some((l) => /the positive control did not see the change.*bulk300/.test(l)) &&
+        v.lines.some((l) => /REGIME:/.test(l))
+      );
+    })()
+  );
+
+  // THE ROSTER, which is the labelling this change actually ships. A row
+  // relabelled here reads as a different regime downstream, so the table is
+  // pinned by name rather than left to the fixtures that happen to use it.
+  check(
+    'the roster: M1 is a mount regime, keystroke a responsiveness regime, the bulk rows magnitudes',
+    rowRegime('M1') === 'mount-regime' &&
+      rowRegime('keystroke') === 'responsiveness-regime' &&
+      rowRegime('bulk300') === 'magnitude' &&
+      rowRegime('bulk100') === 'magnitude' &&
+      rowRegime('narrow') === 'magnitude',
+    JSON.stringify(ROW_REGIME)
+  );
+  check(
+    'and an unknown row is a MAGNITUDE row — a regime is granted by ruling, never by default',
+    rowRegime('a-row-nobody-has-ruled-on') === 'magnitude' && rowRegime(undefined) === 'magnitude'
   );
 
   return { checks };
@@ -2409,6 +2644,11 @@ async function main() {
       // second computation is a second decision.
       return {
         rowId: o.out.rowId,
+        // WHAT THIS ROW PUBLISHES, from the declared roster rather than from
+        // anything this run measured (rf2-jcm3p, rf2-swwud). A regime is a
+        // ruling about the row, so a run may not talk itself into or out of
+        // one on the strength of its own numbers.
+        regime: rowRegime(o.out.rowId),
         ctlOk: !(ctlBad(o) || (o.verdict.etVerdict && !o.verdict.etVerdict.ok)),
         ctlNote: o.verdict.ctl3
           ? ` (three-point ${o.verdict.ctl3.measured.mean.toFixed(4)}x vs ${o.verdict.ctl3.predicted}x)`
@@ -2426,7 +2666,7 @@ async function main() {
   console.error('[clock] ok');
 }
 
-module.exports = { reportability, rowAdjudication, reportabilitySelfTest };
+module.exports = { reportability, rowAdjudication, rowRegime, ROW_REGIME, reportabilitySelfTest };
 
 if (require.main === module) {
   main();

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
@@ -1835,9 +1835,12 @@ function reportability(rows, opts) {
       // The control status, printed on every regime row whichever way it fell,
       // because the ruling that made these rows regimes is ABOUT their
       // controls and a reader must not have to infer one from the other.
+      // A failure the regime PREDICTS says so; one that withholds the regime is
+      // already explained by the line above and is not annotated twice.
+      const predictedFailure = !r.ctlOk && !g.statementNeedsControl;
       lines.push(
         `[clock]     positive control: ${r.ctlOk ? 'PASS' : 'FAIL'}${r.ctlNote || ''}` +
-          (r.ctlOk ? '' : g.statementNeedsControl ? '' : ' — expected, and the reason no magnitude is published')
+          (predictedFailure ? ' — expected, and the reason no magnitude is published' : '')
       );
     }
   }


### PR DESCRIPTION
Two P1 beads, one PR, because both land in the clock driver's labelling and its
studio pages. Both were ruled on 2026-08-06 and **the rulings are the delivery**:
each narrows a claim rather than improving an instrument.

- **`rf2-jcm3p`** — the M1 mount row is restated as a **regime**. Option (2) of
  the bead, now; option (1) conditional only.
- **`rf2-swwud`** — the per-keystroke row is adjudicated by **Event Timing**
  rather than by the sec-6.2 band, re-adjudicated **from the two runs already on
  disk**. Repair (3) of the bead.

## The regime as restated, per row

| row | before | now |
|---|---|---|
| `M1` | a published **magnitude**, `1.4896×` [1.3488 – 1.5989] vs Reagent / `1.5001×` vs UIx, under a positive control that fails | a **`mount-regime`**: *Hicasso mounts materially slower than both adapters; every corroborated reading is above the amended `≤ 1.10×` UIx gate, and `≤ 1.10×` has NOT been demonstrated.* Direction only. No magnitude |
| `keystroke` | three `UNADJUDICATED` bars and no verdict at all | a **`responsiveness-regime`**: *on this four-field / 100-cell witness, Hicasso, Reagent-on-subs and UIx-on-subs are indistinguishable at Event Timing's resolution; every observed interaction was one frame — 16.0 ms, both runs.* The `TaskDuration` / `taskNet` bars become **DIAGNOSTIC**, never magnitudes |
| `bulk300`, `bulk100`, `narrow` | magnitude rows | unchanged — magnitude rows, gated exactly as before |

**Every figure the two rulings quote stays visible**, annotated with the control
status it was taken under rather than deleted. History is annotated, never
erased.

The mandatory **powered-to-detect rider** travels with the keystroke verdict, in
the page and in the driver's output: Event Timing resolves 8 ms buckets above a
16 ms floor, so the row detects only a difference that *crosses a bucket
boundary*. "Indistinguishable at one frame" is not a measured tie below that
resolution.

## Re-adjudicated from disk — no new measurement pass

`rf2-swwud`'s ruling re-adjudicates the retained runs, and that is what happened.
No fleet was re-run and no window was booked. The datasets are
`implementation/freehand/test/re_frame/bench/hicasso/data/clock-0qj9w/run{1,2}.json`,
untouched by this PR (`git status` on `data/` is empty).

`clock_readjudicate.cjs` gains `responsivenessRegime`, which reads the **witness
the driver already stored** (`kbWitness.perArm`) rather than regrouping raw Event
Timing entries — the witness owns what forms an interaction and what a censored
key is, and a second grouping here would be a second adjudicator. Everything it
prints reproduces the ruling exactly:

| | run 1 | run 2 |
|---|---|---|
| key accounting | 540 sent = **466 observed + 74 censored** | 540 = **449 + 91** |
| every non-control arm | min = max = **16.0 ms** | min = max = **16.0 ms** |
| `ctl-50ms` | **48.0 ms** | **56.0 ms** |
| finest per-sample step | **0.146 ms** | **0.181 ms** |
| diagnostic bars straddling 1.0 | 3 of 3 | 3 of 3 |

## No published figure moved

The shipped adjudicator replayed over both retained datasets prints **byte-identical**
output everywhere it printed before — the diff is a **pure insertion**:

```
$ diff readj-BEFORE.txt readj-AFTER.txt | grep -c '^<'   # removed/changed lines
0
$ diff readj-BEFORE.txt readj-AFTER.txt | grep -c '^>'   # added lines
34
```

No measurement, no arm, no threshold and nothing under `data/` changed. Two
figures the beads quote are **deliberately not re-derived here**: the per-key arm
separations (0.043 / 0.052 / 0.277 ms). My arithmetic off the stored
`decomposition` does not reproduce them, so rather than publish a differently
derived number under the same name, the rider is stated on figures the driver
itself stored — the grain floor and the bars' straddle status. Flagged rather
than quietly substituted.

## The driver disposition, and how it meshes with `rf2-y7mw7`

`rf2-y7mw7` is **not re-opened**. `rowAdjudication` is untouched — a nonempty bar
set and zero unadjudicated bars — and it remains the rule for **magnitude** rows.
What is added beside it is a declared regime, carried on the row summary rather
than looked up inside `reportability`, so the existing fixtures keep their exact
behaviour and the new rule is separately drivable.

**The exit code does not move, and that was the deciding constraint.** A regime
row publishes no magnitude — ever, by ruling rather than by accident — so it
cannot be named in `REPORTABLE` and the run cannot exit 0 on one.
`HCLOCK_ONLY=keystroke` exited 1 before these rulings and exits 1 after them;
`REPORTABLE: none.` is byte-identical. What changes is the *sentence*: the
refusal now states the row's regime instead of reading as a defect.

The alternative — making a regime row reportable at exit 0 once its gates pass —
was **rejected**: it would restore exit 0 on precisely the invocation `rf2-y7mw7`
was filed to make exit 1, which is that repair undone under a nicer name.
`rf2-swwud`'s "reportable ONLY when …" clause is honoured as the condition on
whether the **regime statement** is *stated* or *withheld*, which is what the
driver now prints.

The two regimes differ, deliberately, and each difference is a ruling:

- `mount-regime` **states itself although `ctl-2x` fails** — that failure is
  `rf2-jcm3p`'s own premise, so a regime waiting on it could never be stated at
  all. The control status is printed either way.
- `responsiveness-regime` **is withheld if its fixed-work controls do not pass** —
  those are what prove the instrument moves when the work moves, and without them
  a frame reading is evidence of nothing.

What the driver prints on the two retained runs' shape:

```
[clock] REGIME: these rows publish a regime and never a magnitude, by ruling — keystroke (responsiveness-regime). ...
[clock]   keystroke [responsiveness-regime, rf2-swwud] STATED — A FRAME STATEMENT read off Event Timing — the TaskDuration bars are DIAGNOSTIC, never magnitudes
[clock]     this row's control burns a fixed 50 ms, so control/floor reads (F+50)/F and supplies no band; Event Timing adjudicates it instead, at 8 ms buckets above a 16 ms floor
[clock]     positive control: PASS
[clock] REPORTABLE: none.
```

**One consequence stated plainly rather than buried.** `M1` is a regime row *by
ruling*, not conditionally on a given run's `ctl-2x`. A future run whose `ctl-2x`
happened to pass therefore exits 1 where it would once have exited 0. That is the
ruling's substance — the row no longer publishes a magnitude — and not a
side-effect of relabelling. The route back to a magnitude is the bead's
conditional trigger and nothing else.

## Mutation-proved, both directions

Every label and disposition this PR ships is load-bearing. Each mutation was
applied, the suite run, and the tree restored:

| mutation | result |
|---|---|
| A — `M1: 'mount-regime'` → `'magnitude'` | **2/111 fail** (roster + self-test) |
| B — `keystroke: 'responsiveness-regime'` → `'magnitude'` | **2/111 fail** |
| C — `mount-regime.publishesMagnitude: false` → `true` | **4/111 fail** — M1 reads as a fault again |
| D — `responsiveness-regime.statementNeedsControl: true` → `false` | **2/111 fail** — WITHHELD case dies |
| E — `indistinguishable: <read>` → `true` | **1/111 fail** — the frame verdict must be *read*, not asserted |
| F — break the new `#4-…-a-regime-not-a-magnitude` anchor | `check_doc_slugs.py` **exit 1**, 2 broken anchors |
| G — rename the compatibility `<a id>` for the old §4 slug | `check_doc_slugs.py` **exit 1** — `bulk-broad-re-taken.md:267` breaks |

The reverse direction is pinned too: relabel either row back to `magnitude` and
the run prints the *old* fault sentence again, at the *same* exit code — the test
asserts both.

## Docs

Each page keeps **its own** supersession idiom — a sibling checked them
individually rather than imposing one:

- `the-candidates-clock.md` — *italic dated parentheticals*, `*(2026-08-06,
  \`rf2-jcm3p\`: this said …)*`, with strikethrough inside them where the page
  already nests the two.
- `rows-re-adjudicated-on-the-corrected-clock.md` — **strikethrough**,
  `~~the ensemble that has standing~~`.

§4's heading becomes *"The mount row — a REGIME, not a magnitude"*. The old slug
survives as a **compatibility `<a id>`** so the inbound link from
`bulk-broad-re-taken.md:267` — which is **outside this PR's fence** — keeps
resolving without that file being touched. Mutation G proves the anchor is
load-bearing rather than decorative.

**Hand-verified, since nothing validates rendering under `docs/design/**`:** all
**32** tables across both pages have matching header / separator / row column
counts (verified by script, output in the run log); the new Event-Timing table is
5 columns × 5 rows, correctly `>`-prefixed inside its blockquote with bare `>` on
its blank lines. `mkdocs build --strict` does **not** cover `docs/design/**`
(`exclude_docs`), so it is not nominated as the gate here — `check_doc_slugs.py`
is, and it is mutation-proved above.

## Out of fence, filed

`rf2-jcm3p`'s ruling also names `census-real-clock-rows.md` and the
`README`/`validation` echoes. Those five pages still carry `1.4896×` as a
published magnitude and are **outside this PR's fence**, so they are untouched
and filed as **`rf2-r7nyt`** (P2), which also carries the option to retarget the
`bulk-broad-re-taken.md` link and retire the compatibility anchor in one green
change.

## Quality gates

| gate | exit |
|---|---|
| `sh scripts/test-fast-pr.sh` | **0** |
| `npm run lint:js` (root `package.json`) | **0** |
| `python scripts/check_doc_slugs.py` | **0** — mutation-proved (F, G above) |
| `npm run test:script-helpers` (chained JS harness gate) | **0** — `clock_exit_path.test.cjs: 111 passed` |
| `node clock_run.cjs --selftest` | **0** — all adjudicators ok, 30 exit-path checks |
| `HCLOCK_ONLY=keystroke node clock_run.cjs` (**cold**, `:advanced` + headless Chromium) | **1** — unchanged and by design; the run's own published refusal |
| `node clock_readjudicate.cjs data/clock-0qj9w/run{1,2}.json` | **0** — output a pure insertion vs the pre-change baseline |

The cold clock run rebuilt from scratch (`resetLaneBuildCache`, 169 files, 114
compiled) and cleared every gate it has: **canonical DOM IDENTICAL (9320 bytes)**,
**0 unverified of 756**, recompute census **`p0/cell x100, p0/draft x4`** on all
three substrate arms, `ctl-50ms` Event Timing **PASS**. Its exit 1 is the
published refusal, not a failure. It was taken on a working box and **publishes
nothing** — 250 of 540 keys censored against the retained runs' 74 and 91 — which
is exactly why the re-adjudication reads the retained datasets instead.

Closes `rf2-jcm3p`. Closes `rf2-swwud`.

**Spine phase note, since exit codes should be attributable to a tree.** The
spine run reported above was started before the last three commits on this branch
(two `.cjs` clarity refactors, both proved output-identical, and one docs fix
removing a strikethrough over wording the page never carried). It reached its
`implementation JS harness helpers`, `per-ns test isolation`, `CLJS node
integration` and `hicasso bench-lane compile` phases **after** all three landed,
so every phase that reads these files ran on the shipped tree.
`check_doc_slugs.py` and `npm run lint:js` were each re-run to green on the final
tree after the docs fix. `per-ns test isolation` was **green locally**, not the
known worker-worktree red.
