### PR TITLE
test(ci): the durable-reads roster reaches a wrapped host read (rf2-vcjpx)

### DIFF
--- a/scripts/_test_fixtures/check_ambient_durable_reads/negative/ambient_ok_getter_escape.cljc
+++ b/scripts/_test_fixtures/check_ambient_durable_reads/negative/ambient_ok_getter_escape.cljc
@@ -1,0 +1,22 @@
+(ns fixtures.ambient-ok-getter-escape
+  "NEGATIVE fixture: the conscious-allowlist escape applied to a CALL-WRAPPED
+  browser read (rf2-vcjpx). `ambient_ok_escape.cljc` proves the escape works
+  over an `(interop/now-ms)` clock read; this proves the same opt-out is
+  available over the getter spellings the widened roster now matches — a
+  deliberate diagnostic storage read in a durable-write namespace stays
+  possible with a reviewed annotation, rather than the widening leaving an
+  author no way out but to delete the read.
+
+  Without the marker each `assoc` below is a finding. Must stay GREEN
+  (0 findings)."
+  (:require [re-frame.interop :as interop]))
+
+(defn note-last-restore
+  [entry]
+  #_:rf.world/ambient-ok   ;; reviewed: dev-only breadcrumb, never folded into durable state
+  (assoc entry :restored-at (.getItem js/localStorage "last-restore")))
+
+(defn note-entry-url
+  [entry]
+  #_:rf.world/ambient-ok   ;; reviewed: diagnostic only, not consulted for durable writes
+  (assoc entry :detected-at (.-href js/location)))

--- a/scripts/_test_fixtures/check_ambient_durable_reads/negative/threaded_host_fact.cljc
+++ b/scripts/_test_fixtures/check_ambient_durable_reads/negative/threaded_host_fact.cljc
@@ -1,0 +1,57 @@
+(ns fixtures.threaded-host-fact
+  "NEGATIVE fixture: the CORRECT pattern for a BROWSER host fact, and the
+  counterpart to the call-wrapped positives (rf2-vcjpx). The saved session and
+  the viewport match are boundary facts, so they arrive on the token's flat
+  `:rf.cofx` map as recordable coeffects and are threaded into the durable
+  fields — the restore installer never reads storage, location or the media
+  query itself.
+
+  This fixture is green on its OWN merits, not via an allowlist wrapper: it
+  names no `trace/emit!`, no `getRandomValues` and no `#_:rf.world/ambient-ok`
+  escape. The suppliers below DO spell the ambient reads the widened roster now
+  matches, which is the point — they sit in an ambient cofx supplier where they
+  belong, not in a durable key's value position, so the gate's shape does not
+  match them. Must stay GREEN (0 findings)."
+  (:require [re-frame.interop :as interop]))
+
+;; Ambient cofx suppliers. These ARE the host reads — that is their whole job,
+;; and they are the sanctioned place for them. No durable field key is adjacent
+;; to any of them, so the violating shape never forms.
+(defn saved-session-supplier
+  []
+  (some-> (.-localStorage js/globalThis) (.getItem "session")))
+
+(defn saved-draft-supplier
+  []
+  (.getItem js/sessionStorage "draft"))
+
+(defn entry-url-supplier
+  []
+  (.-href js/location))
+
+(defn locale-supplier
+  []
+  (.-language js/navigator))
+
+(defn compact-viewport-supplier
+  []
+  (.-matches (js/matchMedia "(max-width: 40em)")))
+
+;; The durable write. Every value is threaded off the token's recordable
+;; coeffects; nothing here touches the host.
+(defn restore-session
+  [db token]
+  (let [cofx    (:rf.cofx token)
+        time-ms (:rf/time-ms cofx)]
+    (assoc db
+           :restored-at  time-ms
+           :installed-at time-ms
+           :instance-id  (:auth.session/token cofx)
+           :correlation-id (:app.route/entry-url cofx)
+           :resource-id  (:ui.viewport/compact? cofx))))
+
+;; An unrelated elapsed-time helper: an ambient read with no durable key in
+;; sight, the same near-miss `threaded_completed_at.cljc` carries for the clock.
+(defn elapsed-since
+  [start]
+  (- (interop/now-ms) start))

--- a/scripts/_test_fixtures/check_ambient_durable_reads/positive/every_ambient_read_form.cljc
+++ b/scripts/_test_fixtures/check_ambient_durable_reads/positive/every_ambient_read_form.cljc
@@ -1,20 +1,24 @@
 (ns fixtures.every-ambient-read-form
   "POSITIVE fixture: every EXERCISABLE entry in `_AMBIENT_READ_FORMS`, one per
   line, each written into the same durable `:instance-id` key so the only thing
-  that varies down the file is the read form itself. Fourteen findings, and the
-  self-test asserts the read forms BY NAME (rf2-g1xpb).
+  that varies down the file is the read form itself. Twenty-one findings, and
+  the self-test asserts the read forms BY NAME (rf2-g1xpb).
 
-  Two of the sixteen roster entries are absent, and deliberately — see
+  Two of the twenty-three roster entries are absent, and deliberately — see
   `_UNEXERCISABLE_READ_FORMS`: `js/crypto.getRandomValues` and
   `(.getRandomValues js/crypto …)` carry the very text the allowlist window
   searches for, so any line matching them exempts itself. The self-test holds
   that pair to being uncoverable rather than merely uncovered.
 
-  The host-fact entries are written as BARE symbol values because that is the
-  shape the roster describes: the gate matches a read sitting immediately in a
-  durable key's value position, so `js/localStorage` fires there while a call
-  WRAPPING it does not. Idiomatic these lines are not; the roster entry they
-  witness is exactly this spelling."
+  The browser host facts appear TWICE, because the roster spells them twice
+  (rf2-vcjpx). First as BARE symbol values: the gate matches a read sitting
+  immediately in a durable key's value position, so `js/localStorage` fires
+  there. Idiomatic those lines are not; the roster entry they witness is
+  exactly that spelling. Then again CALL-WRAPPED — `(.getItem js/localStorage
+  …)`, `(.-href js/location)`, `(js/matchMedia …)` — which is how the fact is
+  actually read, and which fired NOTHING before the roster carried it. Each
+  call-wrapped line witnesses a PAIR: its own entry and the bare entry whose
+  text it contains."
   (:require [re-frame.interop :as interop]))
 
 (def ^:private id-pool ["a" "b" "c"])
@@ -31,11 +35,22 @@
    (assoc (nth rows 4)  :instance-id (rand-int 1000))
    (assoc (nth rows 5)  :instance-id (rand-nth id-pool))
    (assoc (nth rows 6)  :instance-id (random-uuid))
-   ;; browser / host facts
+   ;; browser / host facts — bare symbol in the value position
    (assoc (nth rows 7)  :instance-id js/location)
    (assoc (nth rows 8)  :instance-id js/navigator)
    (assoc (nth rows 9)  :instance-id navigator.language)
    (assoc (nth rows 10) :instance-id js/localStorage)
    (assoc (nth rows 11) :instance-id js/sessionStorage)
    (assoc (nth rows 12) :instance-id (.matchMedia js/window "(min-width: 40em)"))
-   (assoc (nth rows 13) :instance-id js/matchMedia)])
+   (assoc (nth rows 13) :instance-id js/matchMedia)
+   ;; browser / host facts — call-wrapped, the spelling people actually write
+   (assoc (nth rows 14) :instance-id (.getItem js/localStorage "session"))
+   (assoc (nth rows 15) :instance-id (.getItem js/sessionStorage "session"))
+   (assoc (nth rows 16) :instance-id (.-href js/location))
+   (assoc (nth rows 17) :instance-id (.-language js/navigator))
+   (assoc (nth rows 18) :instance-id (js/matchMedia "(min-width: 40em)"))
+   ;; ... and this repo's own storage idiom, both halves
+   (assoc (nth rows 19) :instance-id (some-> (.-localStorage js/globalThis)
+                                             (.getItem "session")))
+   (assoc (nth rows 20) :instance-id (some-> (.-sessionStorage js/globalThis)
+                                             (.getItem "session")))])

--- a/scripts/check_ambient_durable_reads.py
+++ b/scripts/check_ambient_durable_reads.py
@@ -13,7 +13,12 @@ write durable frame-state:
   - random:  `rand`, `rand-int`, `rand-nth`, `random-uuid`,
              `js/crypto.getRandomValues`;
   - browser: `js/location`, `navigator`, `localStorage`, `sessionStorage`,
-             media-query (`matchMedia`).
+             media-query (`matchMedia`) — each in BOTH the bare-symbol
+             spelling and the getter / property / callable spelling that is
+             how the fact is actually read: `(.getItem js/localStorage …)`,
+             `(.-href js/location)`, `(.-language js/navigator)`,
+             `(js/matchMedia …)`, and this repo's own authoring idiom
+             `(some-> (.-localStorage js/globalThis) (.getItem …))`.
 
 The durable-write code paths the spec enumerates are: resource reducers,
 work-ledger writers, reply handlers, mutation handlers, restore/hydration
@@ -240,10 +245,33 @@ _DURABLE_ID_KEYS = (
 #           js/crypto.getRandomValues  (.getRandomValues js/crypto)
 #   browser: js/location  js/navigator  navigator.  js/localStorage
 #            js/sessionStorage  (.matchMedia ...)  js/matchMedia
+#            (.getItem js/localStorage ...)  (.getItem js/sessionStorage ...)
+#            (.-prop js/location)  (.-prop js/navigator)  (js/matchMedia ...)
+#            (some-> (.-localStorage js/globalThis) (.getItem ...))  + twin
 # Each entry is NAMED so a finding can say which read form produced it and the
 # self-test can hold the roster to owning a fixture (rf2-g1xpb). The names are
-# the roster's identity; the joined alternation below is byte-for-byte the
-# union that was here before, so the gate matches exactly what it always did.
+# the roster's identity.
+#
+# WHY THE CALL-WRAPPED BROWSER FORMS ARE ENUMERATED (rf2-vcjpx)
+#
+# `_VIOLATION_RE` anchors the read at the START of the durable key's value, so
+# only a read sitting IMMEDIATELY in value position matches. The clock and
+# random families already carry a roster entry per call spelling — `(.now
+# js/Date …)`, `(.getRandomValues js/crypto …)`, `(.matchMedia …)` — but the six
+# browser host-fact entries carried only their bare-symbol spelling. That made
+# them reachable only as `:restored-at js/localStorage`, which nobody writes;
+# the getter form `:restored-at (.getItem js/localStorage "session")` — which is
+# how the fact is actually read, and the same EP-0010 defect — produced ZERO
+# findings. A roster naming `localStorage` while missing `.getItem` is the
+# advertised-but-hollow class (rf2-rr6do / rf2-bml5u), so the getter, property
+# and callable spellings are enumerated here as their own entries, each ANCHORED
+# at value-form start exactly like `.now js/Date`.
+#
+# ENUMERATED, deliberately — NOT "an ambient read anywhere inside the value
+# form". Free-form value matching was REJECTED (this bead's own false-positive
+# caution): it would fire on a legitimately threaded value that merely mentions
+# a host symbol somewhere in its form. Each pattern below names a complete read
+# whose result IS the host fact, so there is no threading it can mistake.
 _AMBIENT_READ_FORMS: tuple[tuple[str, str], ...] = (
     # clock
     ("now-ms",       r"\(\s*(?:interop/)?(?:epoch-)?now-ms\b[^)]*\)"),
@@ -256,7 +284,7 @@ _AMBIENT_READ_FORMS: tuple[tuple[str, str], ...] = (
     ("random-uuid",  r"\(\s*random-uuid\b[^)]*\)"),
     ("js/crypto.getRandomValues",   r"js/crypto\.getRandomValues\b"),
     (".getRandomValues js/crypto",  r"\(\s*\.getRandomValues\s+js/crypto\b"),
-    # browser / host facts
+    # browser / host facts — the BARE symbol standing in the value position
     ("js/location",       r"js/location\b"),
     ("js/navigator",      r"js/navigator\b"),
     ("navigator.",        r"navigator\.\w"),
@@ -264,6 +292,27 @@ _AMBIENT_READ_FORMS: tuple[tuple[str, str], ...] = (
     ("js/sessionStorage", r"js/sessionStorage\b"),
     (".matchMedia",       r"\(\s*\.matchMedia\b"),
     ("js/matchMedia",     r"js/matchMedia\b"),
+    # browser / host facts — the CALL-WRAPPED spellings that actually read them
+    # (rf2-vcjpx). A line matching one of these also matches the bare entry it
+    # wraps, so it honestly witnesses BOTH — the same double attribution
+    # `(rand-nth …)` has against `rand`.
+    (".getItem js/localStorage",
+     r"\(\s*\.getItem\s+js/localStorage\b"),
+    (".getItem js/sessionStorage",
+     r"\(\s*\.getItem\s+js/sessionStorage\b"),
+    (".-prop js/location",   r"\(\s*\.-\w+\s+js/location\b"),
+    (".-prop js/navigator",  r"\(\s*\.-\w+\s+js/navigator\b"),
+    ("(js/matchMedia ...)",  r"\(\s*js/matchMedia\b"),
+    # This repo's own authoring idiom for a storage read — established at
+    # implementation/core/src/re_frame/cofx.cljc and examples/core/todomvc/db.cljs
+    # (both correctly OUTSIDE the scan surface: an ambient cofx supplier and an
+    # example, neither a durable-write namespace). Anchored from `(some->` so it
+    # matches whether the `(.getItem …)` step follows on the same line or the
+    # next — the value is the storage read either way.
+    ("some-> .-localStorage js/globalThis",
+     r"\(\s*some->\s+\(\s*\.-localStorage\s+js/globalThis\b"),
+    ("some-> .-sessionStorage js/globalThis",
+     r"\(\s*some->\s+\(\s*\.-sessionStorage\s+js/globalThis\b"),
 )
 _AMBIENT_READ_ALT = "|".join(pattern for _name, pattern in _AMBIENT_READ_FORMS)
 
@@ -752,6 +801,7 @@ _POSITIVE_WITNESSES: dict[str, frozenset[str]] = {
         "instance-id<-rand-int",
         "instance-id<-rand-nth",
         "instance-id<-random-uuid",
+        # browser host facts, bare symbol in the value position
         "instance-id<-js/location",
         "instance-id<-js/navigator",
         "instance-id<-navigator.",
@@ -759,6 +809,17 @@ _POSITIVE_WITNESSES: dict[str, frozenset[str]] = {
         "instance-id<-js/sessionStorage",
         "instance-id<-.matchMedia",
         "instance-id<-js/matchMedia",
+        # browser host facts, call-wrapped (rf2-vcjpx). Each of these lines
+        # ALSO witnesses the bare entry whose text it contains — listed above,
+        # and named again here so deleting either roster entry reds this
+        # fixture by name (the rand/rand-nth double-attribution precedent).
+        "instance-id<-.getItem js/localStorage",
+        "instance-id<-.getItem js/sessionStorage",
+        "instance-id<-.-prop js/location",
+        "instance-id<-.-prop js/navigator",
+        "instance-id<-(js/matchMedia ...)",
+        "instance-id<-some-> .-localStorage js/globalThis",
+        "instance-id<-some-> .-sessionStorage js/globalThis",
     }),
 }
 
@@ -773,8 +834,14 @@ _NEGATIVE_FIXTURES: tuple[str, ...] = (
     # durable key; the durable :updated-at threads the causal token) — green on
     # its own merits, NOT via a debug-proximity allowlist (rf2-nftz2s §3)
     "negative/debug_enabled_perf_probe.cljc",
+    # the browser-host-fact counterpart: storage / location / navigator /
+    # media-query facts threaded off the token's :rf.cofx, with the getter
+    # spellings confined to ambient cofx suppliers (rf2-vcjpx)
+    "negative/threaded_host_fact.cljc",
     # the conscious #_:rf.world/ambient-ok escape
     "negative/ambient_ok_escape.cljc",
+    # ... and the same escape over a call-wrapped getter read (rf2-vcjpx)
+    "negative/ambient_ok_getter_escape.cljc",
     # the symbol in a docstring / `;;` comment
     "negative/now_ms_in_docstring.cljc",
     # a freshness DECISION read (compared, not written durably)


### PR DESCRIPTION
Closes rf2-vcjpx.

`_VIOLATION_RE` anchors the ambient read at the **start** of a durable key's
value, so only a read sitting immediately in value position matches. The clock
and random families already carried a roster entry per call spelling — `(.now
js/Date …)`, `(.getRandomValues js/crypto …)`, `(.matchMedia …)` — but the six
browser host-fact entries carried only their bare-symbol spelling. That made
them reachable only as `:restored-at js/localStorage`, which nobody writes,
while the getter form produced **zero findings**:

```clojure
:restored-at js/localStorage                        ;; FLAGGED
:restored-at (.getItem js/localStorage "session")   ;; missed — same EP-0010 defect
```

Verified independently before touching anything: a probe fixture planting all
seven call spellings alongside one bare `js/localStorage` yielded **1 finding**
— the bare symbol, and nothing else.

## What changed

Seven enumerated `_AMBIENT_READ_FORMS` entries, each anchored at value-form
start exactly like `.now js/Date`:

| name | pattern |
|---|---|
| `.getItem js/localStorage` | `\(\s*\.getItem\s+js/localStorage\b` |
| `.getItem js/sessionStorage` | `\(\s*\.getItem\s+js/sessionStorage\b` |
| `.-prop js/location` | `\(\s*\.-\w+\s+js/location\b` |
| `.-prop js/navigator` | `\(\s*\.-\w+\s+js/navigator\b` |
| `(js/matchMedia ...)` | `\(\s*js/matchMedia\b` |
| `some-> .-localStorage js/globalThis` | `\(\s*some->\s+\(\s*\.-localStorage\s+js/globalThis\b` |
| `some-> .-sessionStorage js/globalThis` | `\(\s*some->\s+\(\s*\.-sessionStorage\s+js/globalThis\b` |

The last pair is this repo's own authoring idiom, established at
`implementation/core/src/re_frame/cofx.cljc` and
`examples/core/todomvc/db.cljs` — both correctly **outside** the scan surface
(an ambient cofx supplier and an example, neither a durable-write namespace).
Anchored from `(some->` so it matches whether the `(.getItem …)` step follows
on the same line or the next; the value is the storage read either way.

**Enumerated, not free-form.** "An ambient read anywhere inside the value form"
stays rejected per the bead's own false-positive caution. Every pattern above
names a *complete read whose result IS the host fact*, so none of them can
mistake a legitimately threaded value. The module docstring's browser roster and
the roster comment block were updated to match.

## Which entries are now reachable in call position

Scanning a file containing **only** the seven call-wrapped lines — every bare
host-fact line deleted — attributes these read forms:

| bare roster entry | reachable in call position? | via |
|---|---|---|
| `js/localStorage` | yes | `(.getItem js/localStorage "session")` |
| `js/sessionStorage` | yes | `(.getItem js/sessionStorage "session")` |
| `js/location` | yes | `(.-href js/location)` |
| `js/navigator` | yes | `(.-language js/navigator)` |
| `js/matchMedia` | yes | `(js/matchMedia "(min-width: 40em)")` |
| `navigator.` | **no** | — see below |

**Five of the six, not six.** `navigator.` is the property-dot spelling
`navigator.language`, which is already its own idiomatic bare-value form and
already fires; `(.-language js/navigator)` attributes `js/navigator`, not
`navigator.`, so no call wrapper in the ruling's miss list reaches it. The one
spelling that would — `(.query js/navigator.permissions …)` — is not in the
ruling's enumeration, and adding it (with three sibling near-forms measured at
the same time) is filed as **rf2-yt0pi** rather than widened here on a worker's
say-so. Measurements are in the bead.

## Fixtures, both directions

`positive/every_ambient_read_form.cljc` gains the seven call-wrapped lines —
**14 findings → 21**, and 21 of 23 roster entries covered (the same two
`getRandomValues` forms stay declared unexercisable; neither became
exercisable). Each call-wrapped line also witnesses the bare entry whose text it
contains, so the expectations name **both** — the same double attribution
`(rand-nth …)` has against `rand`, per the `rand_nth_into_temp_id.cljc`
precedent.

Two new negatives, one per direction the ruling named:

- `negative/threaded_host_fact.cljc` — storage / location / navigator /
  media-query facts threaded off the token's `:rf.cofx`, with the getter
  spellings confined to ambient cofx suppliers where they belong. Green on its
  **own merits**: it names no `trace/emit!`, no `getRandomValues` and no
  `#_:rf.world/ambient-ok`.
- `negative/ambient_ok_getter_escape.cljc` — the `#_:rf.world/ambient-ok`
  escape over a call-wrapped read, so the widening does not leave an author
  with no way out but to delete a deliberate diagnostic read.

Both proved non-vacuous: stripping the escape markers from the second yields
**2 findings**; replacing one threaded value in the first with the live read
yields **1**.

### Per-entry kill proof

Each new pattern was neutered in place (replaced with one that can never match —
the realistic regression, a typo'd detector) and the real CLI `--self-test` run.
All seven go red, **naming the entry**, on both assertion 1 (`DETECTOR DEAD —
this fixture plants instance-id<-…`) and assertion 4 (roster entry with no
positive witness):

```
PASS  killed '.getItem js/localStorage':             exit=1 named-witness=True detector-dead-msg=True roster-coverage-red=True
PASS  killed '.getItem js/sessionStorage':           exit=1 named-witness=True detector-dead-msg=True roster-coverage-red=True
PASS  killed '.-prop js/location':                   exit=1 named-witness=True detector-dead-msg=True roster-coverage-red=True
PASS  killed '.-prop js/navigator':                  exit=1 named-witness=True detector-dead-msg=True roster-coverage-red=True
PASS  killed '(js/matchMedia ...)':                  exit=1 named-witness=True detector-dead-msg=True roster-coverage-red=True
PASS  killed 'some-> .-localStorage js/globalThis':  exit=1 named-witness=True detector-dead-msg=True roster-coverage-red=True
PASS  killed 'some-> .-sessionStorage js/globalThis': exit=1 named-witness=True detector-dead-msg=True roster-coverage-red=True

7/7 new entries proved; 0 failure(s)
```

## What was deliberately not disturbed

- **The repaired self-test (rf2-g1xpb).** Expectations stay written out
  **literally**, never derived from a roster — the seven new witnesses are typed
  out one per line for exactly the reason the comment there gives. All five
  assertions are untouched.
- **The pruned walk (rf2-mjfj9).** `_EXCLUDE_DIR_NAMES`,
  `_iter_durable_write_files`'s in-place `dirnames[:]` prune, the single global
  `sorted()` after collection, and `_run_scope_self_test` have **zero diff
  hunks**. Every hunk in the checker is in the module docstring, the roster
  comment, the roster entries, `_POSITIVE_WITNESSES` or `_NEGATIVE_FIXTURES`.
- **`_UNEXERCISABLE_READ_FORMS`.** Both `getRandomValues` forms still contain
  the literal text that is itself an allowlist-window trigger, so both still sit
  inside their own exemption. Neither became exercisable; the roster is asserted
  both ways as before.
- **Scheduling and derivation.** No gate script added or renamed, and the
  spine's literal one-invocation-per-line form is untouched, so
  `check_gate_scheduling.py` and `check_fast_pr_gap.py` still derive.

## Equivalence: the gate's live behaviour is unchanged

The bead requires the gate to stay exit 0 on today's tree. Measured directly:
**none of the seven idioms appears anywhere in any of the 18 scanned files** —
not merely absent from durable value position, absent entirely (0 raw regex
occurrences across the whole scanned surface). Live arm before and after are
byte-identical: `scanning 18 durable-write namespace file(s)` → `no ambient
durable-world reads in any durable-write namespace`, exit 0.

## Quality gates

Run from this branch's worker worktree; the spine's `gate root:` line confirmed
it graded this checkout and not a neighbouring one (rf2-g2mxd).

| gate | exit | timing |
|---|---|---|
| `python scripts/check_ambient_durable_reads.py --self-test` | 0 | 0.412s (baseline 0.392s) |
| `python scripts/check_ambient_durable_reads.py --verbose` (live arm) | 0 | 0.665s (baseline 0.836s) — 18 files, 0 findings |
| `python scripts/check_gate_scheduling.py --self-test` | 0 | 0.464s |
| `python scripts/check_gate_scheduling.py --verbose` | 0 | 0.457s — 40 gate commands, 34 scheduled, 6 declared, 0 known holes |
| `python scripts/check_fast_pr_gap.py --self-test` | 0 | 0.427s |
| `python scripts/check_fast_pr_gap.py --check` | 0 | 0.359s — 77 required jobs, 26 fully covered, 4 partly, 47 not at all |
| `sh scripts/test-fast-pr.sh` | 0 — `PASS fast PR spine` | 33m28.712s |

Spine classification line: `=== fast PR spine: docs=false jvm=true node=true
(conservative fallback (unknown surface)) ===` — this diff touches only
`scripts/check_ambient_durable_reads.py` and its fixture tree, which is on no
runtime surface and (correctly) on no documentation surface, so the spine falls
back to the complete runtime run. `implementation/node_modules` was junctioned
from the mayor checkout for the node tier and removed afterwards; the mayor's
count re-checked at 2,933 files, unchanged.

Inside the spine, the gate under change reported:

```
==> ambient-durable-read gate self-test
==> ambient-durable-read gate (EP-0010)
scanning 18 durable-write namespace file(s)...
no ambient durable-world reads in any durable-write namespace.
```

Runtime tiers that did run: `implementation/core` JVM (2222 tests, 11559
assertions, 0 failures / 0 errors), the JS harness helpers, the CLJS
`:node-test` build (12714 tests, 63731 assertions, 0 failures / 0 errors),
per-namespace isolation (17/17 standalone), and the hicasso bench-lane compile
(129 lane namespaces, 0 warnings).

The spine's own `NOT RUN` enumeration, verbatim:

```
NOT RUN by this spine (3):
  - documentation gates (surface unchanged; --with-docs forces)
  - JVM artefact suites the diff did not touch: [22 artefacts]
  - browser lanes, prod-elision/bundle-isolation/perf gates, adapter probes +
    smokes, Xray feature matrix, mcp-conformance, tool JVM suites (CI only)
```

## rf2-cvqyi did not ride along

The carrier bead says it "may ride any **mayor-method-touching** PR". This PR
touches `scripts/check_ambient_durable_reads.py` and its fixtures — no
`docs/the-mayor-method/**`, no `.claude/commands/mayor-*.md`, nothing on that
surface at all. Its gate is `check_readme_links.py --ci` over `bootstrap.md`,
which this diff neither arms nor needs. Forcing it on would pair a CI-gate
roster widening with an unrelated method-doc sentence and pull a documentation
surface into a code-only PR. Nothing was closed on it; it still wants a genuine
mayor-method PR, or a solo one.
