### PR TITLE
docs(spec): a theme switch re-renders one boundary, not nothing (rf2-ix9tk)

### DIFF
--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -1748,13 +1748,13 @@ roster. The ruling is
 **Tokens ride the cascade.** Colour, spacing, radius, typography and motion travel
 as CSS custom properties, selected by an ancestor scope the application renders
 once — conventionally a `data-theme` attribute or a class. Inheritance reaches every
-descendant, so switching themes changes that one attribute and **re-renders
-nothing**: no token subscription per leaf, no remount, and no reactive fan-out
-proportional to the tree. The residue is the value a stylesheet cannot know — a
-genuinely dynamic colour or measure supplied at a call site — and it rides as an
-inline namespaced custom property on the node that needs it. That is the escape,
-not the default path: a component given no dynamic value emits no inline style at
-all and takes everything from the cascade.
+descendant, so switching themes changes that one attribute and
+**re-renders one boundary, nothing after the flip**: no token subscription per
+leaf, no remount, and no reactive fan-out proportional to the tree. The residue is
+the value a stylesheet cannot know — a genuinely dynamic colour or measure supplied
+at a call site — and it rides as an inline namespaced custom property on the node
+that needs it. That is the escape, not the default path: a component given no
+dynamic value emits no inline style at all and takes everything from the cascade.
 
 **A part is a stable semantic address.** A component declares a finite roster of
 public part ids and emits each as a literal `data-part` value under a


### PR DESCRIPTION
Closes rf2-ix9tk.

## The defect

`spec/004-Views.md` §*Theming and semantic parts* claimed a theme switch
**re-renders nothing**. Under the taught theming default that bare phrase is
false: the same sentence's *"ancestor scope the application renders once"* is a
**rendered** scope that reads the theme sub, so the flip costs exactly one
boundary.

Two supports, both in-repo:

- `docs/design/hicasso/draft-guide/06-theming.md` §*Tradeoff* says it out loud —
  the value-equality bail-out is carried by heads `defview` mints, so a scope
  read inside a boundary re-renders that boundary.
- `implementation/freehand/test/re_frame/freehand/pilot_field.cljc` demonstrates
  it: it reads `[:acme.invoice/theme]` **inside** the `invoice-line` boundary.

## The change — one clause

```
- switching themes changes that one attribute and **re-renders nothing**: …
+ switching themes changes that one attribute and
+ **re-renders one boundary, nothing after the flip**: …
```

The qualification is **the split draft-guide 06 layer 1 already makes** — *"That
claim is about* after *the flip"* — so the spec and the guide now agree rather
than merely both being true. Naming the boundary carries the flip's cost;
"nothing after the flip" is the unconditionally-true half, and it stays true
whatever sits below the scope.

### What is deliberately untouched

- **The normative scope ruling** — *"selected by an ancestor scope the
  application renders once"* — is byte-identical and sits on an unchanged
  context line. This corrects a claim about **re-render cost**, never about
  **scope**. `docs/design/hicasso/decisions.md` (HD-010) and
  `docs/design/hicasso/studio/108-the-theming-taught-default-priced.md` both
  quote that ruling verbatim; neither quote moves.
- **The colon-clause** — *"no token subscription per leaf, no remount, and no
  reactive fan-out proportional to the tree"* — was already true and is
  byte-identical, only rewrapped. Proved by joining the paragraph and comparing
  substrings against `HEAD`.
- **The shipped witness pins the scope**:
  `pilot_theming_dom_cljs_test.cljs` sets `data-theme` on the mount container;
  `documentElement` appears nowhere in it. Nothing here disturbs that.

`7 7 spec/004-Views.md` — net-zero lines; the paragraph reflows in place. The
bolded phrase is now whole on one line, where the old one was split across two
(`**re-renders` / `nothing**`), which is why a repo-wide grep for the false
phrase did not hit this file.

### Verified-true neighbour, left alone

§*Where each plane is proved* says *"flipping an ancestor `data-theme`
recoloured a node the substrate never re-rendered."* That is scoped to a
**descendant node**, not to the tree, and it is exactly what
`a-theme-switch-recolours-through-the-cascade-without-remounting` asserts. Not
equally false; untouched.

### Equally-false siblings outside this fence — filed, not fixed

The same bare phrase survives in two `implementation/**` docstrings (outside
this PR's fence), named in a follow-up bead rather than widened into here:

- `re-frame.freehand.pilot-theming` — ns docstring, *"so a theme switch
  re-renders nothing"*.
- `re-frame.freehand.pilot-theming-dom-cljs-test` — ns-docstring bullet heading
  *"A theme switch re-renders nothing."* (its body, scoped to the chip, stays
  true).

`docs/design/freehand/fable-design.md`'s P11 row carries it too, but as a
historical design record rather than a live claim.

## Quality gates

Run from the worktree root; every exit code echoed.

| Gate | Command | Exit |
| --- | --- | --- |
| Fast PR spine | `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine` |
| MkDocs strict | `python -m mkdocs build --strict` | **0** |
| Doc slugs | `python scripts/check_doc_slugs.py` | **0** |
| Doc slugs (mutation proof) | same, with a broken anchor injected | **1** — teeth confirmed |
| Keyword catalogue drift | `python scripts/check_keyword_catalogue_drift.py` | **0** |
| Keyword catalogue self-test | `… --self-test` | **0** |

The spine classified `docs=true jvm=false node=false` — a spec-only diff — and
`mkdocs --strict` ran inside it as well as standalone. No `node_modules` was
needed, so no junction was created and none had to be removed.

**Mutation proof** that `check_doc_slugs.py` has teeth on *this* file: injecting
`#props-forwarding-ix9tk-mutant` into `spec/004-Views.md`'s §*Props forwarding*
back-reference made it exit **1** with `BROKEN ANCHOR: spec\004-Views.md:1782 ->
#props-forwarding-ix9tk-mutant`; reverting restored exit **0**.

**No gate pins this phrase by literal text.** Of the four scripts naming
`spec/004-Views.md`, only `check_adapter_disposition.py` scans the live file,
and only for superseded *adapter-status* sentence shapes; the other three use it
as a fixture string or a citation target. `check_ui_root_lifecycle_drift.py`
pins `spec/004C-Roots-and-Mount.md`, not this file. Nothing needs to move with
this edit.
