### PR TITLE
fix(bench): a bar with no adjudication verdict is unadjudicated, in both clock seats (rf2-y7mw7)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -68,6 +68,17 @@
 // both require every published bar to carry a band, and both are driven below
 // on the mixed-bar case that neither used to have.
 //
+// AND THEN THAT REPAIR'S REMAINDER, which #7550's merged-PR audit found: the
+// strict rule was asking TRUTHINESS, so absence read as cleanliness one level
+// down. A bar stored as `{}` — present, carrying no verdict at all — counted
+// as adjudicated in both seats. `rowAdjudication` returned `adjudicable: true`
+// beside an `unadjudicatedWhy` reading "the run adjudicated no bar on this row
+// at all", contradicting itself inside one returned object; `adjudicated`
+// returned true and the reader pooled the run into the published mean. A bar
+// stored as `null` did not even fail open — it threw. Both now require an
+// EXPLICIT `unadjudicated === false`, absence and null included, and the
+// fixtures for it are in both blocks below.
+//
 // Wired into implementation/package.json via `test:script-helpers`.
 
 const assert = require('node:assert');
@@ -501,6 +512,58 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     assert.doesNotMatch(v.lines[1], /0 of 0/);
   });
 
+  // --- AND THE FIELD, not merely the bar set (#7550's merged-PR audit) ------
+  //
+  // The strict rule above still asked TRUTHINESS — `src[n].unadjudicated` —
+  // so absence read as cleanliness one level down: a bar the dataset stored
+  // as `{}` counted as adjudicated, and `rowAdjudication` returned
+  // `adjudicable: true` beside `unadjudicatedWhy: "the run adjudicated no bar
+  // on this row at all"`. A function contradicting itself inside one returned
+  // object is what a fail-open looks like from the inside. Reproduced against
+  // 57e0e68 before the repair, and driven here.
+
+  t('THE FIELD: a bar with NO `unadjudicated` field is unadjudicated — absent is not clean', () => {
+    const a = rowAdjudication({ 'h / r': ADJ, 'h / u': {} });
+    assert.strictEqual(a.adjudicable, false, 'a bar carrying no verdict has not been adjudicated');
+    assert.strictEqual(a.barCount, 2);
+    assert.deepStrictEqual(a.unadjudicatedBars, ['h / u']);
+    assert.strictEqual(a.unadjudicatedWhy, 'the bar carries no adjudication verdict at all');
+  });
+
+  t('a row of nothing but fieldless bars cannot exit 0, and it used to exit 0', () => {
+    // The exact shape the audit named: every bar `{}`, which before the repair
+    // produced `{adjudicable: true, unadjudicatedWhy: "the run adjudicated no
+    // bar on this row at all"}` and a green run.
+    const a = rowAdjudication({ 'h / r': {}, 'h / u': {} });
+    assert.strictEqual(a.adjudicable, false);
+    const v = reportability([clockRow({ rowId: 'keystroke', ...a })]);
+    assert.strictEqual(v.code, 1, 'a run that adjudicated nothing must not announce success');
+    assert.match(v.lines[0], /not every published bar can be ADJUDICATED on: keystroke/);
+    assert.match(v.lines[1], /2 of 2 published bars carry no band \(h \/ r, h \/ u\)/);
+    assert.match(v.lines[1], /the bar carries no adjudication verdict at all/);
+  });
+
+  t('a bar stored as null or undefined is unadjudicated rather than a crash', () => {
+    // Truthiness dereferenced the record before testing it, so a null bar did
+    // not fail open — it threw `Cannot read properties of null`, which is a
+    // driver that dies mid-report rather than one that refuses.
+    for (const missing of [null, undefined]) {
+      const a = rowAdjudication({ 'h / r': ADJ, 'h / u': missing });
+      assert.strictEqual(a.adjudicable, false, `bar=${String(missing)} must not be adjudicable`);
+      assert.deepStrictEqual(a.unadjudicatedBars, ['h / u']);
+      assert.strictEqual(a.unadjudicatedWhy, 'the bar carries no adjudication verdict at all');
+    }
+  });
+
+  t('an EXPLICIT clean verdict is what adjudicates — the tightening is not vacuous', () => {
+    // Without this, everything above would pass if the rule returned false for
+    // every bar. `unadjudicated: false` is the one value that means adjudicated.
+    const a = rowAdjudication({ 'h / r': { unadjudicated: false }, 'h / u': { unadjudicated: false, why: 'x' } });
+    assert.strictEqual(a.adjudicable, true);
+    assert.deepStrictEqual(a.unadjudicatedBars, []);
+    assert.strictEqual(reportability([clockRow({ ...a })]).code, 0);
+  });
+
   // --- and the sentence that invited the publication -----------------------
 
   t('REPORTABLE no longer says "Publish those" without saying "adjudicated"', () => {
@@ -760,6 +823,47 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     assert.strictEqual(reportable(undefined), false);
   });
 
+  // --- AND THE FIELD, which #7550's merged-PR audit found still open here ---
+  //
+  // The predicate asked `!bars[n].unadjudicated`, so a bar the FILE stored as
+  // `{}` — present, and carrying no verdict — read as adjudicated and the run
+  // was pooled into the published mean for every pair. This is the seat where
+  // it matters most: the driver reads an object built moments earlier in its
+  // own process, this program reads a file, and a file is where a field goes
+  // missing. Reproduced against 57e0e68 before the repair.
+
+  t('THE FIELD: a bar with no `unadjudicated` field keeps the run OUT of the subset', () => {
+    const row = dsRow({ 'h / r': ADJ, 'h / u': {} });
+    assert.strictEqual(adjudicated(row), false, 'a bar carrying no verdict has not been adjudicated');
+    assert.strictEqual(reportable(row), false, 'and a lost verdict may not reach the published mean');
+  });
+
+  t('a dataset whose every bar is fieldless is out, and it used to be IN', () => {
+    // The exact shape the audit named: `adjudicated` returned true, and with a
+    // passing control and no ceiling breach `reportable` returned true too.
+    const row = dsRow({ 'h / r': {}, 'h / u': {} });
+    assert.strictEqual(adjudicated(row), false);
+    assert.strictEqual(reportable(row), false);
+  });
+
+  t('a bar stored as null or undefined is out rather than a crash', () => {
+    // Truthiness dereferenced the record before testing it, so these threw
+    // `Cannot read properties of null` — a reader that dies over a dataset
+    // rather than one that declines to publish from it.
+    for (const missing of [null, undefined]) {
+      assert.strictEqual(adjudicated(dsRow({ 'h / r': ADJ, 'h / u': missing })), false, `bar=${String(missing)}`);
+      assert.strictEqual(reportable(dsRow({ 'h / r': ADJ, 'h / u': missing })), false, `bar=${String(missing)}`);
+    }
+  });
+
+  t('an EXPLICIT clean verdict is what pools a run — the tightening is not vacuous', () => {
+    // Without this, everything above would pass if the predicate always said
+    // false and no run would ever be published again.
+    const row = dsRow({ 'h / r': { unadjudicated: false }, 'h / u': { unadjudicated: false, band: 0.2 } });
+    assert.strictEqual(adjudicated(row), true);
+    assert.strictEqual(reportable(row), true);
+  });
+
   t('the OTHER two terms are unchanged — adjudication was ADDED, never substituted', () => {
     const bars = { 'h / r': ADJ, 'h / u': ADJ };
     // A failed control still excludes a fully adjudicated run ...
@@ -808,7 +912,10 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     // pointing the other way.
     const body = RJSRC.slice(RJSRC.indexOf('function main(argv)'));
     assert.match(body, /const barRec = \(row\.seamTask && row\.seamTask\.rows && row\.seamTask\.rows\[pair\]\)/);
-    assert.match(body, /const barUnadjudicated = barRec \? !!barRec\.unadjudicated/);
+    // ... and with `adjudicated`'s own token. A column reading `!!` beside a
+    // subset reading `=== false` would print "clears its band" for a silent
+    // bar the subset had just refused — the disagreement one field further in.
+    assert.match(body, /const barUnadjudicated = barRec \? barRec\.unadjudicated !== false/);
     // and the column's UNADJUDICATED branch is taken from THAT, not from the
     // row-wide band.
     assert.match(body, /: barUnadjudicated\s*\r?\n\s*\? 'UNADJUDICATED/);

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
@@ -86,12 +86,23 @@ const SEGMENTS = ['reagent-subs', 'uix-subs', 'hicasso'];
  * predicate that is correct only for the files that happen to exist now is a
  * fail-open waiting for the first file that does not.
  *
+ * AND EVERY BAR MUST SAY SO, which #7550's merged-PR audit found this
+ * predicate still not asking. It read `!bars[n].unadjudicated` — truthiness —
+ * so a bar the file stored as `{}`, with no verdict in it at all, came back
+ * ADJUDICATED and the run was pooled into the published mean. That is the
+ * absent-is-not-clean contract two paragraphs up being contradicted by the
+ * line below it, and it matters MORE here than in the driver: the driver reads
+ * an object `seam.assess` built moments earlier in the same process, while
+ * this program reads a file, and a file is where a field goes missing. A bar
+ * counts as adjudicated only on `unadjudicated === false`; a bar that is
+ * missing, null, or silent has not been adjudicated, it has been lost.
+ *
  * `row` is one entry of a dataset's `rows`, as `clock_run.cjs` wrote it.
  */
 function adjudicated(row) {
   const bars = (row && row.seamTask && row.seamTask.rows) || {};
   const names = Object.keys(bars);
-  return names.length > 0 && names.every((n) => !bars[n].unadjudicated);
+  return names.length > 0 && names.every((n) => !!bars[n] && bars[n].unadjudicated === false);
 }
 
 /**
@@ -294,8 +305,13 @@ function main(argv) {
         // program's to depend on. The sentence is left row-phrased because no
         // dataset yet exists in which a row's bars disagree; the bar's own
         // `why` is in the dataset for the day one does.
+        //
+        // And it is read with `adjudicated`'s OWN token, `=== false`, for the
+        // same reason: a bar record present but silent is not a bar that
+        // cleared anything, and a column reading `!!` while the subset reads
+        // `=== false` is that disagreement again, one field further in.
         const barRec = (row.seamTask && row.seamTask.rows && row.seamTask.rows[pair]) || null;
-        const barUnadjudicated = barRec ? !!barRec.unadjudicated : !Number.isFinite(bandPct);
+        const barUnadjudicated = barRec ? barRec.unadjudicated !== false : !Number.isFinite(bandPct);
         const verdict = breached
           ? `BAND CEILING BREACHED — whole run refused before any control is consulted`
           : barUnadjudicated

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
@@ -1878,13 +1878,24 @@ function reportability(rows, opts) {
  * them back years later, and a fail-closed contract that holds only by
  * coincidence of an unrelated function is not a contract.
  *
+ * AND THE FIELD ITSELF, which #7550's merged-PR audit found still fail-open.
+ * The strict rule above counted a bar as unadjudicated only when its flag was
+ * TRUTHY, so a bar the dataset stored as `{}` — no verdict at all — read as
+ * adjudicated, and this function returned `adjudicable: true` beside an
+ * `unadjudicatedWhy` reading "the run adjudicated no bar on this row at all".
+ * A function contradicting itself in one object is the clearest possible sign
+ * that absence was being read as cleanliness. ADJUDICATED now means a bar that
+ * SAYS SO — `unadjudicated === false` and nothing else. A bar that is missing,
+ * null, or carries no verdict has not been adjudicated; it has been LOST, and
+ * a lost verdict is exactly what this whole bead is about.
+ *
  * `bars` is `seamTask.rows` — `{barName: {unadjudicated, why, ...}}`, the same
  * object the report printed and the dataset stored, never a recomputation.
  */
 function rowAdjudication(bars) {
   const src = bars || {};
   const names = Object.keys(src);
-  const unadjudicatedBars = names.filter((n) => src[n].unadjudicated);
+  const unadjudicatedBars = names.filter((n) => !(src[n] && src[n].unadjudicated === false));
   return {
     // Fail closed on a row that adjudicated no bar at all, too: an empty
     // verdict is an absent one, not a clean one.
@@ -1893,7 +1904,8 @@ function rowAdjudication(bars) {
     unadjudicatedBars,
     unadjudicatedWhy:
       unadjudicatedBars.length > 0
-        ? src[unadjudicatedBars[0]].why
+        ? (src[unadjudicatedBars[0]] && src[unadjudicatedBars[0]].why) ||
+          'the bar carries no adjudication verdict at all'
         : 'the run adjudicated no bar on this row at all',
   };
 }
@@ -2143,6 +2155,24 @@ function reportabilitySelfTest() {
   check(
     'and a verdict that went missing entirely is absent, not clean',
     rowAdjudication(undefined).adjudicable === false && rowAdjudication(null).adjudicable === false
+  );
+  // AND THE FIELD, not merely the bar (#7550's audit). A bar present but
+  // carrying no verdict used to read as adjudicated, because the rule asked
+  // truthiness rather than `=== false`.
+  const absentField = rowAdjudication({ 'hicasso / reagent-subs': ADJ, 'hicasso / uix-subs': {} });
+  check(
+    'a bar with NO `unadjudicated` field is unadjudicated — absent is not clean',
+    absentField.adjudicable === false &&
+      absentField.barCount === 2 &&
+      absentField.unadjudicatedBars.length === 1 &&
+      absentField.unadjudicatedBars[0] === 'hicasso / uix-subs' &&
+      absentField.unadjudicatedWhy === 'the bar carries no adjudication verdict at all',
+    JSON.stringify(absentField)
+  );
+  check(
+    'and a bar stored as null is unadjudicated rather than a crash',
+    rowAdjudication({ 'hicasso / reagent-subs': null }).adjudicable === false,
+    JSON.stringify(rowAdjudication({ 'hicasso / reagent-subs': null }))
   );
 
   // THE REGIMES (rf2-jcm3p, rf2-swwud). Every fixture above carries no


### PR DESCRIPTION
rf2-y7mw7, third pass. #7550 tightened the bar-level rule to "every published bar", but both exported seats still asked **truthiness**, so absence read as cleanliness one field down.

## The reproduction, on unmodified main

Run first, before changing anything — the bead's own standing instruction about this defect class. Against `57e0e68`:

```
-- clock_run.cjs rowAdjudication --
  bar is {} (no unadjudicated field)   {"adjudicable":true,"barCount":1,"unadjudicatedBars":[],
                                        "unadjudicatedWhy":"the run adjudicated no bar on this row at all"}
  bar is null                          THREW: Cannot read properties of null (reading 'unadjudicated')
  flag is undefined                    {"adjudicable":true, ... same}

-- clock_readjudicate.cjs adjudicated / reportable --
  bar is {} (no unadjudicated field)   adjudicated=true   reportable=true
  bar is null                          THREW: Cannot read properties of null (reading 'unadjudicated')
  flag is undefined                    adjudicated=true   reportable=true
```

The driver's return value contradicts itself inside one object: `adjudicable: true` beside an `unadjudicatedWhy` reading *"the run adjudicated no bar on this row at all"*. That is what a fail-open looks like from the inside.

The reader is worse, and is the seat that matters: `reportable` true means the run is pooled into the **published mean, for every pair**. The driver reads an object `seam.assess` built moments earlier in its own process; the readjudicator reads a file, and a file is where a field goes missing.

A `null` bar did not even fail open — it **threw**, in both seats. A driver that dies mid-report is not a driver that refuses.

## The fix — two Boolean conditions

Adjudicated now means a bar that **says so**: `unadjudicated === false` and nothing else. Missing, null, or silent is unadjudicated, not clean.

```js
// clock_run.cjs
- const unadjudicatedBars = names.filter((n) => src[n].unadjudicated);
+ const unadjudicatedBars = names.filter((n) => !(src[n] && src[n].unadjudicated === false));

// clock_readjudicate.cjs
- return names.length > 0 && names.every((n) => !bars[n].unadjudicated);
+ return names.length > 0 && names.every((n) => !!bars[n] && bars[n].unadjudicated === false);
```

`unadjudicatedWhy` gains a fallback (`the bar carries no adjudication verdict at all`) so a bar with no verdict is named for what it is rather than borrowing the empty-row sentence or dereferencing null.

No schema framework, no dataset validator, no new abstraction, no measurement/arm/threshold/dataset/published row touched.

### One judgement call beyond the two conditions — flagging it explicitly

The reader's **printed verdict column** moved to the same token:

```js
- const barUnadjudicated = barRec ? !!barRec.unadjudicated : !Number.isFinite(bandPct);
+ const barUnadjudicated = barRec ? barRec.unadjudicated !== false : !Number.isFinite(bandPct);
```

Left alone, a column reading `!!` would print "clears its band" for a silent bar the subset beside it had just refused. `clock_readjudicate.cjs`'s own comment on that line says that disagreement "is [...] what rf2-y7mw7 is about". It is the same Boolean contract one field further in, not a third rule. **One token to revert if the mayor reads it as scope.** The null-`barRec` fallback is deliberately untouched — that is a legacy dataset-shape path.

## Proof that no published figure moves

Every retained dataset carries an explicit boolean on every bar — 14 files, 12 bars, 0 missing flags, 0 null bars — so the old rule and the new one agree on the whole corpus. Checked directly rather than assumed, and confirmed end to end: the readjudicator's 137 lines of published output over `data/clock-0qj9w/run{1,2}.json` are **byte-identical** before and after (`diff` empty, both exit 0).

## Quality gates

| Gate | Result | Exit |
|---|---|---|
| `node freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs` | 119 passed (111 before; 8 fixtures added) | **0** |
| `npm run test:script-helpers` (full chain, 23 runners) | all green | **0** |
| Readjudicator output vs `origin/main`, real datasets | byte-identical, 137 lines | **0** / **0** |

### Mutation proofs — each seat certified independently

Each mutation was confirmed applied (`git diff --stat` **and** the token grepped back out of the file, plus the replacement token confirmed absent), then reverted and confirmed byte-identical (`git diff` empty, `git status` clean).

**A — `clock_run.cjs`, truthiness filter restored.** Exit **1**, 4/119 failed, all in the `clock_run.cjs` block:
- `THE FIELD: a bar with NO 'unadjudicated' field is unadjudicated — absent is not clean` → `true !== false`
- `a row of nothing but fieldless bars cannot exit 0, and it used to exit 0` → `true !== false`
- `a bar stored as null or undefined is unadjudicated rather than a crash` → `Cannot read properties of null`
- `the decision's own self-test passes, every case` → `Cannot read properties of null`

The `clock_readjudicate.cjs` block stayed **green** throughout — one blanket mutation certifies nothing about the other seat, which is why they were run separately. Restored → **0**, 119 passed.

**B — `clock_readjudicate.cjs`, `!bars[n].unadjudicated` restored.** Exit **1**, 3/119 failed, all in the `clock_readjudicate.cjs` block:
- `THE FIELD: a bar with no 'unadjudicated' field keeps the run OUT of the subset` → `true !== false`
- `a dataset whose every bar is fieldless is out, and it used to be IN` → `true !== false`
- `a bar stored as null or undefined is out rather than a crash` → `Cannot read properties of null`

The `clock_run.cjs` block stayed **green**. Restored → **0**, 119 passed.

**C — the printed column, `!!` restored.** Exit **1**, 1/119 failed: `the printed verdict column reads the SAME per-bar record the subset does`. Restored → **0**, 119 passed.

Each block also carries a non-vacuity case (`an EXPLICIT clean verdict is what adjudicates / pools a run`), so none of the above would pass if the rule simply returned false for everything.

## Fixtures

Both exported-function blocks of `clock_exit_path.test.cjs` (4 each), plus the driver's own `reportabilitySelfTest`, which `clock_run.cjs --selftest` runs before the browser opens.

## Not in scope

`rf2-sib23` (bench-driver pageerror) is held by a sibling worker; the shared page-error masker/classifier is untouched here.
