### PR TITLE
spec(004)+test(freehand): condition the theming quiet-subtree claim on a memoized view below the scope

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/pilot_theming.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_theming.cljc
@@ -17,8 +17,9 @@
 
   - **CSS TOKENS.** Visual values travel by the CSS cascade. An ancestor
     scope selects a named token bundle (`data-theme`) and inheritance
-    reaches every descendant, so a theme switch re-renders nothing — no
-    token subscription per leaf, no remount. The one value a stylesheet
+    reaches every descendant, so a theme switch re-renders one boundary,
+    and nothing behind a memoized view immediately below it — no token
+    subscription per leaf, no remount. The one value a stylesheet
     cannot know — a genuinely dynamic colour the caller supplies at the
     call site — rides as an inline namespaced custom property (`:accent`
     -> `--acme-chip-accent`). That is the whole token contract.

--- a/implementation/freehand/test/re_frame/freehand/pilot_theming_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_theming_dom_cljs_test.cljs
@@ -18,7 +18,7 @@
   - **An inline token reaches a part.** The dynamic-residue accent, carried
     as an inline `--acme-chip-accent` custom property, resolves through a
     `var()` on the dot's computed background.
-  - **A theme switch re-renders nothing.** With the token bundle selected
+  - **Restyling costs no React work.** With the token bundle selected
     by an ancestor `data-theme`, flipping that one attribute — never
     re-rendering the chip — recolours the chip through inheritance, and the
     chip's DOM node is the SAME object across the switch. No token

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -1749,8 +1749,8 @@ roster. The ruling is
 as CSS custom properties, selected by an ancestor scope the application renders
 once — conventionally a `data-theme` attribute or a class. Inheritance reaches every
 descendant, so switching themes changes that one attribute and
-**re-renders one boundary, nothing after the flip**: no token subscription per
-leaf, no remount, and no reactive fan-out proportional to the tree. The residue is
+**re-renders one boundary, and nothing behind a memoized view immediately below it**: no token
+subscription per leaf, no remount, and no reactive fan-out proportional to the tree. The residue is
 the value a stylesheet cannot know — a genuinely dynamic colour or measure supplied
 at a call site — and it rides as an inline namespaced custom property on the node
 that needs it. That is the escape, not the default path: a component given no


### PR DESCRIPTION
Closes rf2-ix9tk (reopened by the merged-PR audit of #7594) and rf2-m41sg.

## What was wrong

PR #7594 replaced spec/004's "re-renders nothing" with **"re-renders one boundary, nothing after the flip"**. That is still an unconditional claim about the subtree, and `docs/design/hicasso/draft-guide/06-theming.md` — the cited authority — says the opposite in its Tradeoff paragraph:

> What happens below it depends on *what sits there*. […] A native-tag subtree, a fragment, or a `defhost` crossing carries no wrapper and re-runs with the scope — and so does `app` called as a plain function, which mints no boundary at all. **Keep a `defview` head immediately below the scope and the rest of the tree stays quiet.**

I re-read guide 06 rather than taking the audit on trust; it confirms the audit exactly. It also shows why "after the flip" reads falsely in this position: guide 06 uses that phrase at **layer 1** for the *cascade recompute* ("After the attribute changes, restyling costs zero React work"), not for the subtree. Sitting immediately after "re-renders one boundary", it is read as a render claim about everything below — which is the false half.

## The change

`spec/004-Views.md`, one clause:

**Before**
> …changes that one attribute and **re-renders one boundary, nothing after the flip**: no token subscription per leaf, no remount, and no reactive fan-out proportional to the tree.

**After**
> …changes that one attribute and **re-renders one boundary, and nothing behind a memoized view immediately below it**: no token subscription per leaf, no remount, and no reactive fan-out proportional to the tree.

The condition is now carried, in guide 06's own terms and spec/004's own vocabulary (the ownership table already rules "memoization | on its one props map" for `[view props]` versus "none — re-runs with its caller" for a plain helper). The claim no longer says anything about a native-tag subtree, a fragment, a `defhost` crossing, or a view called as a plain function — none of those are behind a memoized view immediately below the scope.

`"after the flip"` is dropped rather than kept-and-qualified: its true meaning is already carried by the colon-clause, and one clause carrying two conditions would be the enumeration this bead explicitly does not want.

### Invariants proved, not asserted

Joining the paragraph from `HEAD` and from the working file and substring-comparing:

- colon-clause `no token subscription per leaf, no remount, and no reactive fan-out proportional to the tree.` — present in **both**, byte-identical.
- scope ruling `selected by an ancestor scope the application renders once` — present in **both**, untouched.
- paragraph-minus-phrase compares **equal**, so the bolded phrase is the *only* text that differs.

The phrase is kept **whole on one source line** (line 1752) — the old one was line-split, which is why `git grep "re-renders nothing"` missed it for so long. `git grep` on the full new phrase now returns it.

Line endings: the file is `i/lf w/crlf`. Edited byte-wise with CRLF preserved (2906 → 2906); `git diff --numstat` is **2/2**, not a whole-file normalisation. (A `-c core.autocrlf=false add` was tried first and staged 2906/2906 — reverted; the plain `add` is correct for this file.)

## rf2-m41sg — the two pilot docstrings

- `pilot_theming.cljc` ns docstring, CSS TOKENS bullet: states the general token contract, so it takes the corrected spec wording verbatim.
- `pilot_theming_dom_cljs_test.cljs` ns docstring: **heading only**. The body is scoped to a descendant node and stays true, as does `deftest a-theme-switch-recolours-through-the-cascade-without-remounting`. The suite flips `data-theme` on the mount container with `.setAttribute` — React is never involved — so the heading is now guide 06 layer 1's exact claim, `**Restyling costs no React work.**`, which is what the test actually isolates.

Docstrings only; no test behaviour changed.

`docs/design/freehand/fable-design.md`'s P11 row carries the phrase too and is **deliberately left alone** — a historical design record, per rf2-m41sg. The only other tracked hit, `controlled_burst_dom_cljs_test.cljs:349` ("moves no model and re-renders nothing"), is an unrelated input-burst assertion.

## Quality gates

| Gate | Exit | Result |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | **0** | Terminal marker `PASS fast PR spine` present. Classified `docs=true jvm=true node=true`. Totals across tiers: 2224 tests / 11564 assertions; 1288 / 8857; 12717 / 63774 — **0 failures, 0 errors** in every tier. |
| `python -m mkdocs build --strict` | **0** | Built in 22.09s. `spec/**` is covered (the pre-build hook mirrors it into `docs/spec/`). The `INFO` lines about links into `design/freehand/decisions/` are pre-existing excluded-page notices, not `--strict` errors. |
| `python scripts/check_doc_slugs.py` | **0** | **Mutation-proven on this file**: injecting a dangling `#this-anchor-does-not-exist-ix9tk` into the edited clause made it exit **1** with `BROKEN ANCHOR: spec\004-Views.md:1752`. Reverted; back to exit 0. The green is real. |
| `npm run test:freehand` | **0** | 1399 tests / 7753 assertions, **0 failures, 0 errors**. **Mutation-proven**: breaking the docstring in `pilot_theming.cljc` made it exit **1** with a compile `ERROR`. Reverted; back to exit 0. Bundle grep confirms `pilot_theming`, `pilot_theming_cljs_test` and `pilot_theming_dom_cljs_test` all compile into `out/node-test-freehand.js`, so the suite genuinely covers both edited files. |

Both doc gates were mutation-proven rather than trusted, because a docstring/prose change is exactly the shape that passes a gate which never read the file.

**Not run here, by design:** the classifier also reports `cljs_browser`, `cljs_prod` and `examples_compile` true, which the fast-PR spine deliberately leaves to CI; this diff is prose and docstrings only and changes no runtime behaviour. `clj-kondo` is CI-pinned to 2026.04.15, so a local pass would prove nothing — read the red in CI.
