### PR TITLE
ci: gate-scheduling reachability reads what CI executes, not what it explains (rf2-6ckzl, rf2-cvqyi)

### DIFF
--- a/docs/the-mayor-method/bootstrap.md
+++ b/docs/the-mayor-method/bootstrap.md
@@ -159,6 +159,8 @@ of a drain; the binding rule is hot-zone parallelism, not strict same-surface.
 
 Codify the loop bodies as commands (this repo: `.claude/commands/mayor-*.md`)
 so each is a single invocation and one source of truth, rather than re-pasted prose.
+When a method rule changes in this tree, re-read the matching `mayor-*.md`
+command files — the link gate catches renamed files, not semantic drift.
 
 **Establish the stance (first session only).** Every project has a stance
 (pre-alpha, production-stable, refactor-only, greenfield, perf-critical,

--- a/scripts/check_gate_scheduling.py
+++ b/scripts/check_gate_scheduling.py
@@ -19,10 +19,10 @@ THE RULE, NOT A LIST
 --------------------
 Every `test:*` / `bench:*` script in `implementation/package.json` must either
 
-  (a) be reachable from a `npm run` in some `.github/workflows/*.yml` — direct,
-      or through another npm script's command body (the closure is walked, so
-      `test:script-policy` chaining thirty-odd checkers counts for all of
-      them); or
+  (a) be reachable from a `npm run` in an EXECUTABLE `run:` value of some
+      `.github/workflows/*.yml` — direct, or through another npm script's
+      command body (the closure is walked, so `test:script-policy` chaining
+      thirty-odd checkers counts for all of them); or
 
   (b) carry an entry in `DISPOSITIONS` below, declaring WHY, in a kind whose
       premise this script then CHECKS.
@@ -39,9 +39,17 @@ A reason is a claim about the world, and claims rot — the sibling guard
 hard way (a pin reading "never in the nightly sweep" stayed in the file for six
 weeks after a commit put it there).  So `covered-by` names the covering script
 and this checker asserts THAT one is scheduled; `ci-runs-it-directly` names a
-literal the workflow corpus must still contain.  Only `not-a-gate` is a bare
-declaration, because "this produces records rather than a verdict" is not a
+literal some workflow's `run:` value must still contain.  Only `not-a-gate` is a
+bare declaration, because "this produces records rather than a verdict" is not a
 fact about the CI graph.
+
+A CHECKED CLAIM MUST READ EXECUTABLE TEXT (rf2-6ckzl, audit of PR #7542)
+-----------------------------------------------------------------------
+Both of those checks originally matched against the raw workflow YAML, comments
+and all, which made the checker vulnerable to precisely the failure it exists to
+catch: a `run:` line deleted while the paragraph describing it stayed put left
+the gate reading as scheduled.  Reachability is now derived from `run:` values
+only — see `run_commands` below for what counts and why.
 
 `unscheduled` is the honest kind: a gate that genuinely runs nowhere, named,
 with the bead that will give it a home.  It is deliberately NOT an error, and
@@ -78,14 +86,104 @@ import sys
 NPM_RUN_RE = re.compile(r"npm run (?:--silent )?([A-Za-z0-9:._-]+)")
 GATE_PREFIXES = ("test:", "bench:")
 
+# REACHABILITY IS AN EXECUTION FACT, SO IT IS READ OFF EXECUTABLE TEXT ONLY
+# (rf2-6ckzl, audit follow-up on PR #7542).
+#
+# The first cut of this checker matched `npm run <script>` and each
+# `ci-runs-it-directly` probe against the RAW concatenated workflow YAML. That
+# corpus is mostly prose: `.github/workflows/test.yml` carries paragraph-long
+# comments above nearly every job, and those comments name the commands they
+# explain. So a line like
+#
+#     # historic: this job used to `npm run test:orphan` before rf2-xxxxx
+#
+# was enough to mark `test:orphan` scheduled, and a probe named only in a
+# comment satisfied its own premise. That is the checker committing the exact
+# defect it exists to catch — reporting success over a case nothing exercises —
+# and it fails in the worst direction: an edit that DELETES a `run:` line while
+# leaving the paragraph that describes it keeps the gate green, which is the
+# most likely way for a gate to lose its home in the first place.
+#
+# So the corpus is now the `run:` VALUES: the inline form, and the body of a
+# block scalar (`run: |`, `run: >`, and their chomping/indentation variants),
+# which is where every multi-line CI command lives. Nothing else in the YAML
+# counts — not `name:`, not `if:`, not `with:`, and not a comment at any
+# indentation. Measured on the live tree the scheduled set is IDENTICAL either
+# way (38 scripts), so no real gate was leaning on prose; what changes is that
+# it can no longer start to.
+#
+# `run:` is also a MAPPING key under `defaults:` / `jobs.<id>.defaults:`, where
+# its children are `shell:` and `working-directory:` rather than a command. A
+# bare `run:` with neither an inline value nor a block indicator is therefore
+# skipped rather than descended into.
+_RUN_KEY_RE = re.compile(r"^\s*(?:-\s+)?run:(?P<rest>.*)$")
+_BLOCK_SCALAR_RE = re.compile(r"^[|>][+-]?\d*\s*(?:#.*)?$")
+# A whole-line shell comment inside a block-scalar body. YAML hands these to the
+# shell verbatim (they are scalar content, not YAML comments), and the shell
+# does not execute them — so the same prose hole reappears one level in unless
+# they are dropped. Only WHOLE-LINE comments are stripped: a trailing `# ...` on
+# a command line cannot be removed without quote- and heredoc-awareness this
+# script deliberately does not have. Stripping only ever SHRINKS the corpus, so
+# the failure direction is a false alarm, never a false green.
+_SHELL_COMMENT_RE = re.compile(r"^\s*#")
+
+# A `ci-runs-it-directly` probe must match a COMPLETE command token, not merely
+# a prefix of a longer one. Found the hard way while re-pointing
+# `test:mcp-conformance` (rf2-6ckzl): the probe `npm run test:re-frame2-pair`
+# was still satisfied after its own step was deleted, because the sibling step
+# `npm run test:re-frame2-pair-live-overflow` contains it as a prefix. A premise
+# confirmed by a DIFFERENT command than the one it names is the same defect as a
+# premise confirmed by a comment, one size down. The lookahead rejects any
+# following character that would make the probe part of a longer token, so
+# `... --self-test` or a trailing newline still matches and `...-live-overflow`
+# does not.
+_PROBE_TAIL = r"(?![\w:.-])"
+
+
+def run_commands(workflow_text: str) -> list[str]:
+    """Every executable `run:` value in a workflow corpus, in file order."""
+    commands: list[str] = []
+    lines = workflow_text.splitlines()
+    i = 0
+    while i < len(lines):
+        match = _RUN_KEY_RE.match(lines[i])
+        if not match:
+            i += 1
+            continue
+        column = lines[i].index("run:")
+        rest = match.group("rest").strip()
+        i += 1
+        if _BLOCK_SCALAR_RE.match(rest):
+            body: list[str] = []
+            while i < len(lines):
+                line = lines[i]
+                # The body ends at the first non-blank line indented no further
+                # than the `run:` key itself.
+                if line.strip() and len(line) - len(line.lstrip()) <= column:
+                    break
+                if not _SHELL_COMMENT_RE.match(line):
+                    body.append(line)
+                i += 1
+            commands.append("\n".join(body))
+        elif rest:
+            # An inline command, possibly wrapped in a YAML quote pair.
+            if len(rest) >= 2 and rest[0] == rest[-1] and rest[0] in "\"'":
+                rest = rest[1:-1]
+            commands.append(rest)
+    return commands
+
 # Every gate command that is NOT reachable from a workflow, and why.  Each
 # entry's `kind` is a CHECKED claim — see the module docstring.
 #
 #   covered-by          `by` is a scheduled npm script whose run exercises the
 #                       same teeth.  CHECKED: `by` must itself be scheduled.
-#   ci-runs-it-directly the workflow runs this gate's teeth without going
-#                       through `npm run`.  CHECKED: `probe` must appear in the
-#                       workflow corpus.
+#   ci-runs-it-directly a workflow runs this gate's teeth without going through
+#                       `implementation/`'s own `npm run`.  CHECKED: `probe`
+#                       must appear in an executable `run:` value.  A probe has
+#                       to be a COMMAND literal for that reason — a job id or a
+#                       step name proves only that the YAML mentions something,
+#                       which is the claim-that-reads-true this checker is
+#                       supposed to refuse.
 #   not-a-gate          produces artefacts or records; a non-zero exit is not a
 #                       verdict about the tree.  Declaration only.
 #   unscheduled         a real gate that really runs nowhere.  CHECKED: `bead`
@@ -123,10 +221,20 @@ DISPOSITIONS: dict[str, dict] = {
     },
     "test:mcp-conformance": {
         "kind": "ci-runs-it-directly",
-        "probe": "mcp-conformance-re-frame2-pair",
+        "probe": "npm run test:re-frame2-pair",
         "why": "an operator-facing wrapper that chains six MCP-conformance "
                "gates PR CI already runs as six separate jobs — the script's "
-               "own header says so. It exists for a local one-command run",
+               "own header enumerates them. It exists for a local one-command "
+               "run. The probe is the wrapper's gate #4, the re-frame2-pair-mcp "
+               "end-to-end MCP-client conformance run, which test.yml's "
+               "`mcp-conformance-re-frame2-pair` job executes from "
+               "tools/mcp-conformance/ (so it never reaches implementation/'s "
+               "package.json and never enters the closure). The probe was "
+               "`mcp-conformance-re-frame2-pair` — the JOB ID — until rf2-6ckzl "
+               "found it satisfied by prose alone: that string appears in five "
+               "workflow comments and a cache key, and in no `run:` value at "
+               "all, so the premise was being confirmed by the job's own "
+               "explanatory text rather than by anything CI executes",
     },
     "bench:hicasso": {
         "kind": "not-a-gate",
@@ -165,10 +273,18 @@ DISPOSITIONS: dict[str, dict] = {
 KINDS = {"covered-by", "ci-runs-it-directly", "not-a-gate", "unscheduled"}
 
 
-def scheduled_scripts(scripts: dict[str, str], workflow_text: str) -> set[str]:
-    """Every npm script reachable from a `npm run` in the workflow corpus,
-    walked transitively through script bodies."""
-    seeds = [s for s in NPM_RUN_RE.findall(workflow_text) if s in scripts]
+def probe_runs(probe: str, executable_text: str) -> bool:
+    """Does `probe` appear in `executable_text` as a complete command token?"""
+    if not probe:
+        return False
+    return re.search(re.escape(probe) + _PROBE_TAIL, executable_text) is not None
+
+
+def _scheduled_from_commands(scripts: dict[str, str],
+                             commands: list[str]) -> set[str]:
+    """The transitive closure, seeded from already-extracted run commands."""
+    seeds = [s for command in commands
+             for s in NPM_RUN_RE.findall(command) if s in scripts]
     reached = set(seeds)
     queue = list(seeds)
     while queue:
@@ -179,11 +295,27 @@ def scheduled_scripts(scripts: dict[str, str], workflow_text: str) -> set[str]:
     return reached
 
 
+def scheduled_scripts(scripts: dict[str, str], workflow_text: str) -> set[str]:
+    """Every npm script reachable from a `npm run` in an EXECUTABLE `run:` value
+    of the workflow corpus, walked transitively through script bodies.
+
+    `workflow_text` is raw workflow YAML; only its run values seed the walk (see
+    `run_commands`). The closure through `package.json` bodies is unchanged — a
+    chaining script still counts for everything it chains."""
+    return _scheduled_from_commands(scripts, run_commands(workflow_text))
+
+
 def audit(scripts: dict[str, str], workflow_text: str,
           dispositions: dict[str, dict]) -> list[str]:
-    """Return the list of violations; empty means clean."""
+    """Return the list of violations; empty means clean.
+
+    `workflow_text` is raw workflow YAML. Both reachability tests below read the
+    EXECUTABLE half of it and nothing else: the `npm run` closure is seeded from
+    run values, and a `ci-runs-it-directly` probe must appear in one."""
     problems: list[str] = []
-    scheduled = scheduled_scripts(scripts, workflow_text)
+    commands = run_commands(workflow_text)
+    executable_text = "\n".join(commands)
+    scheduled = _scheduled_from_commands(scripts, commands)
     gates = [s for s in scripts if s.startswith(GATE_PREFIXES)]
 
     for name, entry in dispositions.items():
@@ -209,11 +341,11 @@ def audit(scripts: dict[str, str], workflow_text: str,
                     f"this gate now runs nowhere")
         elif kind == "ci-runs-it-directly":
             probe = entry.get("probe") or ""
-            if probe not in workflow_text:
+            if not probe_runs(probe, executable_text):
                 problems.append(
                     f"{name}: pinned `ci-runs-it-directly` on the probe "
-                    f"`{probe}`, which no longer appears in any workflow — "
-                    f"CI has stopped running this gate's teeth")
+                    f"`{probe}`, which no longer appears in any workflow's "
+                    f"`run:` value — CI has stopped running this gate's teeth")
         elif kind == "unscheduled":
             if not entry.get("bead"):
                 problems.append(
@@ -346,6 +478,100 @@ def self_test(verbose: bool) -> int:
         "test:orphan": {"kind": "because-i-said-so", "why": "x"},
         "bench:thing": {"kind": "not-a-gate", "why": "x"}})
     check("an unknown kind FAILS", any("unknown kind" in p for p in bad_kind))
+
+    # THE PROSE MUTATIONS (rf2-6ckzl, audit of PR #7542). Each pair below
+    # deletes the executable invocation and leaves the sentence that describes
+    # it — the shape of a real workflow edit, and the shape that used to pass.
+    declared = {"bench:thing": {"kind": "not-a-gate", "why": "x"}}
+
+    commented_out = ("      # rf2-xxxxx retired this step; it used to "
+                     "`npm run test:orphan` here.\n"
+                     "      - name: something else\n"
+                     "        run: node teeth.cjs\n")
+    check("a `npm run` in a COMMENT does not schedule a gate",
+          "test:orphan" not in scheduled_scripts(scripts, commented_out),
+          repr(scheduled_scripts(scripts, commented_out)))
+    check("...and that gate is then reported undeclared",
+          any("test:orphan" in p for p in audit(scripts, commented_out, declared)))
+
+    other_field = ("      - name: npm run test:orphan\n"
+                   "        if: contains(github.event.head_commit.message, "
+                   "'npm run test:orphan')\n"
+                   "        with:\n"
+                   "          args: npm run test:orphan\n"
+                   "        run: node teeth.cjs\n")
+    check("a `npm run` in `name:`/`if:`/`with:` does not schedule a gate",
+          "test:orphan" not in scheduled_scripts(scripts, other_field),
+          repr(scheduled_scripts(scripts, other_field)))
+
+    shell_commented = ("        run: |\n"
+                       "          # npm run test:orphan   (dropped in rf2-xxxxx)\n"
+                       "          node teeth.cjs\n")
+    check("a `npm run` in a SHELL comment inside a run body does not schedule",
+          "test:orphan" not in scheduled_scripts(scripts, shell_commented),
+          repr(scheduled_scripts(scripts, shell_commented)))
+
+    probe_prose = ("      # This job used to run `node teeth.cjs` before "
+                   "rf2-xxxxx moved it.\n"
+                   "      - name: node teeth.cjs\n"
+                   "        run: node something-else.cjs\n")
+    check("a `ci-runs-it-directly` probe found only in prose FAILS",
+          any("stopped running this gate's teeth" in p for p in audit(
+              scripts, probe_prose,
+              {**declared,
+               "test:orphan": {"kind": "ci-runs-it-directly",
+                               "probe": "node teeth.cjs", "why": "x"}})))
+
+    prefix_only = ("      - name: the sibling gate\n"
+                   "        run: node teeth.cjs-but-longer --x\n")
+    check("a probe satisfied only as a PREFIX of a longer command FAILS",
+          any("stopped running this gate's teeth" in p for p in audit(
+              scripts, prefix_only,
+              {**declared,
+               "test:orphan": {"kind": "ci-runs-it-directly",
+                               "probe": "node teeth.cjs", "why": "x"}})))
+    with_args = ("      - run: npm run test:chain\n"
+                 "      - run: node teeth.cjs --self-test\n")
+    check("...but a probe followed by ARGUMENTS still passes",
+          audit(scripts, with_args,
+                {**declared,
+                 "test:orphan": {"kind": "ci-runs-it-directly",
+                                 "probe": "node teeth.cjs", "why": "x"}}) == [])
+
+    # ...while every EXECUTABLE form still counts, including the block scalars
+    # every multi-line CI step uses.
+    block = ("        run: |\n"
+             "          set -euo pipefail\n"
+             "          npm run test:chain\n"
+             "      - name: next step\n"
+             "        run: echo done\n")
+    check("a multiline `run: |` body schedules what it invokes",
+          scheduled_scripts(scripts, block) == {"test:chain", "test:a", "test:b"},
+          repr(scheduled_scripts(scripts, block)))
+    folded = "        run: >-\n          npm run test:a\n"
+    check("a folded `run: >-` body schedules what it invokes",
+          scheduled_scripts(scripts, folded) == {"test:a"},
+          repr(scheduled_scripts(scripts, folded)))
+    quoted = '        run: "npm run test:a"\n'
+    check("a quoted inline run value schedules what it invokes",
+          scheduled_scripts(scripts, quoted) == {"test:a"},
+          repr(scheduled_scripts(scripts, quoted)))
+    dash_form = "      - run: npm run test:a\n"
+    check("the `- run:` first-key step form is executable text",
+          scheduled_scripts(scripts, dash_form) == {"test:a"},
+          repr(scheduled_scripts(scripts, dash_form)))
+
+    # `run:` is also a MAPPING key under `defaults:`, whose children are
+    # `shell:` / `working-directory:` — never a command.
+    defaults_block = ("    defaults:\n"
+                      "      run:\n"
+                      "        working-directory: implementation\n"
+                      "        shell: npm run test:orphan\n"
+                      "    steps:\n"
+                      "      - run: node teeth.cjs\n")
+    check("a `defaults: run:` MAPPING contributes no commands",
+          scheduled_scripts(scripts, defaults_block) == set(),
+          repr(scheduled_scripts(scripts, defaults_block)))
 
     # An `unscheduled` entry that LATER gains a schedule must NOT go red: that
     # transition is the hole closing, and reddening main would punish the fix.


### PR DESCRIPTION
Closes rf2-6ckzl. Closes rf2-cvqyi.

## rf2-6ckzl — the classifier half was already on main

The bead's title/description half (arm `cljs_prod` + `bundle_isolation` from the
generic `examples/*)` case) shipped in `c1e833bb4c`. Verified here rather than
re-done — see the proof below. What this PR closes is the bead's **newest note**,
the audit follow-up on merged PR #7542, which the title does not mention.

## The defect

`scripts/check_gate_scheduling.py` decided whether a gate has a scheduled home by
matching `npm run <script>` and each `ci-runs-it-directly` probe against the RAW
concatenated workflow YAML. Measured on the live corpus, only **8% of that text is
executable** — 39,567 of 511,152 characters. The rest is the paragraph-long comments
`test.yml` carries above nearly every job, and those comments name the commands they
explain.

So the checker committed the exact defect it exists to catch: reporting success over
a case nothing exercises. And it failed in the worst direction — delete a `run:` line
while leaving the paragraph that describes it, and the gate still reads as scheduled.
That is precisely how a gate loses its home in practice.

## The fix

Reachability now derives from `run:` **values**: the inline form and block-scalar
bodies (`|`, `>`, chomping variants), where every multi-line CI command lives. Nothing
else counts — not `name:`, not `if:`, not `with:`, not a comment at any indentation,
and not the `defaults: run:` MAPPING whose children are `shell:` / `working-directory:`
rather than a command. Whole-line shell comments inside a run body are dropped too:
YAML hands them to the shell as scalar content and the shell does not execute them.
Stripping only ever shrinks the corpus, so the failure direction is a false alarm,
never a false green.

The transitive package-script closure and the pure-static implementation are preserved,
as the note required — no new dependency, no YAML parser.

## One disposition was already resting on prose

`test:mcp-conformance` pinned `ci-runs-it-directly` on the probe
`mcp-conformance-re-frame2-pair` — a **job id**. It appears 8 times in the raw YAML
(five comments, a cache key, the job header, a `needs:`) and **zero** times in any
`run:` value. Its premise had never once been confirmed by anything CI executes.

It now pins `npm run test:re-frame2-pair`, the wrapper's gate #4, which both
`test.yml`'s `mcp-conformance-re-frame2-pair` job and `expensive-tests.yml` really run.

Re-pointing it surfaced a second, smaller instance of the same disease, found by
mutation rather than by reading: a bare substring probe is satisfied by a **different**
command that merely starts the same way — `npm run test:re-frame2-pair` matched the
sibling `...-live-overflow` step, so the mutation stayed green. Probes now require a
complete-token match: followed by arguments still passes, satisfied only as a prefix
does not.

## Proof — the checker, both directions

Mutations applied to a copy of the real corpus, each **confirmed applied** before the
verdict was read.

| # | corpus | checker | exit |
|---|---|---|---|
| A | live tree, unmutated | fixed | **0** (40 gates, 34 scheduled, 6 declared) |
| A' | live tree, unmutated | baseline (pre-fix, from git) | **0** (40 / 34 / 6 — identical) |
| B | `run: npm run test:perf-bundle` deleted from `test.yml`, the comment 86 lines above that names the same command KEPT | baseline (pre-fix) | **0 — GREEN, the fail-open** |
| B' | same mutated corpus | fixed | **1** — `test:perf-bundle: … invoked by no workflow` |
| C | both executable sites of the mcp probe commented out, all 5 prose mentions kept | fixed | **1** — `probe … no longer appears in any workflow's run: value` |

A/A' is the load-bearing pair: the scheduled set is **identical** before and after, so
no real gate was leaning on prose and this cannot red main. B/B' is the hole closing.

An intermediate C attempt removed only one of the probe's two executable sites and
correctly stayed green — reported here because it is the reason the token-boundary
rule exists.

## Proof — the `examples/*` classifier arm, both directions

Invoked with REAL CHANGED PATHS, not refs.

| path | `cljs_prod` | `bundle_isolation` |
|---|---|---|
| `examples/core/counter/core.cljs` | true | true |
| `examples/real-apps/realworld_resources/core.cljs` | true | true |
| `docs/the-mayor-method/bootstrap.md` | false | false |
| `spec/API.md` | false | false |
| `README.md` | false | false |
| `scripts/check_gate_scheduling.py` | false | false |
| `examples/scripts/port-resolver.cjs` | false | false (own earlier case, correctly scoped) |

The arm fires on the examples the two gates compile and stays quiet elsewhere — it is
coverage, not noise.

**The ref-trap is real and was re-confirmed**: `report-changed-surfaces.sh origin/main`
returns `cljs_prod=false bundle_isolation=false cljs_browser=false cljs_node_test=false`
— "skip everything" — with no error and no usage message, because the script takes
PATHS and treats `origin/main` as a literal filename. Anyone testing an arm that way
will conclude it does not work.

## rf2-cvqyi

One sentence appended to `docs/the-mayor-method/bootstrap.md`'s command-files
paragraph, exact wording from the rf2-zh8wh ruling. The five `normative source:`
destination lines were **DECLINED** in that ruling (they would duplicate gate-checked
references in four files and assert an unidentifiable dependency in `mayor-merge.md`,
which carries no method-doc reference) and are not added here.

## Quality gates

All run locally, foreground, to completion.

| gate | exit | result |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`; classified `docs=true jvm=false node=false` |
| `python -m mkdocs build --strict` | **0** | run SEPARATELY — the spine soft-skips mkdocs when it is off PATH and still exits 0, so a green spine is not evidence docs were checked. (In this environment the spine did also run it; both are green.) Built in 21.63s, no warnings escalated |
| `python scripts/check_readme_links.py --ci` | **0** | covers `bootstrap.md` |
| `python scripts/check_doc_slugs.py` | **0** | also runs inside the spine |
| `python scripts/check_gate_scheduling.py --self-test --verbose` | **0** | **24/24** checks pass (12 pre-existing + 12 new) |
| `python scripts/check_gate_scheduling.py --verbose` | **0** | 40 gate commands, 34 scheduled, 6 declared, 0 known holes |

The 12 new self-tests cover both halves the audit named (comment-only `npm run`,
comment-only direct probe) and the executable forms that must keep counting: block and
folded scalars, quoted inline values, the `- run:` first-key step form, `defaults: run:`
mappings, `npm run` in `name:`/`if:`/`with:`, shell comments inside run bodies, and the
probe prefix/argument boundary.

**Workflow YAML parse: not applicable — no workflow file is touched by this PR.** The
`.github/workflows/**` hot zone is not entered; the diff is two files,
`scripts/check_gate_scheduling.py` and `docs/the-mayor-method/bootstrap.md`.

Not run: CLJS/JVM/browser suites. This PR changes one pure-static Python checker and one
documentation paragraph — no CLJS, no JVM artefact, no workflow, no example.
