### PR TITLE
fix(ci): a cancelled nightly is not a green nightly (rf2-6sg25)

### DIFF
--- a/.github/scripts/nightly_failure_alert.py
+++ b/.github/scripts/nightly_failure_alert.py
@@ -45,12 +45,22 @@ changing any of the three.
 
 WHAT IT CANNOT SILENTLY DROP
 ----------------------------
+An empty signature is read as GREEN, so every way of reaching one without
+having actually observed a pass is a fail-open, and there are two.
+
 A job that failed but reports no failed STEP — infrastructure failure, runner
 loss, a job-level timeout that kills the run before a step records a conclusion
-— would otherwise produce an empty signature and be classified GREEN.  That is
-the exact fail-open this exercise is about, so such a job is synthesised into
-the signature as `<job> -> (job <conclusion>, no failing step)` and alerted on
-like any other.  `--self-test` pins it.
+— is synthesised into the signature as `<job> -> (job <conclusion>, no failing
+step)` and alerted on like any other.
+
+A job that never reached a verdict at all — `cancelled`, `startup_failure` —
+is the same fail-open by a different door, and worse, because it is silent in
+BOTH directions: three cancelled nights in a row would have advanced the green
+streak and CLOSED an open tracking issue, marking a system of record recovered
+that was never observed to recover.  Such a job contributes `<job> -> (job
+<conclusion>, no verdict)`.  The classification is `FAILED` and `ABORTED`
+below; the exclusion of `skipped` from both is as deliberate as the inclusions
+and is argued there.  `--self-test` pins every clause, in both directions.
 
 THE CHANNEL IS ONE FUNCTION
 ---------------------------
@@ -89,7 +99,24 @@ MARKER_RE = re.compile(
     r"\s+reds=(?P<reds>\d+)\s+greens=(?P<greens>\d+)\s*-->"
 )
 
+# A gate RAN and did not pass.  Applies to steps and to jobs.
 FAILED = ("failure", "timed_out")
+
+# A gate did NOT run to a verdict, because something stopped it.  Terminal, so
+# there is nothing further to wait for, and NOT a pass — which is the whole
+# point: everything absent from both tuples is read as green, so a conclusion
+# that means "we never found out" has to be named here or it silently becomes
+# "we found out it was fine".  `cancelled` and `startup_failure` are the two
+# that occur here; the list is a statement of the rule, not a patch for the
+# first one that bit.
+#
+# `skipped` is deliberately NOT in either tuple, and that is the load-bearing
+# exclusion.  A skipped job is the ordinary consequence of a `needs:`
+# dependency that did not succeed, and a skipped STEP is what every remaining
+# step of a cancelled job reports.  Counting `skipped` would red the nightly on
+# runs that are behaving exactly as designed, and an alert that fires on
+# ordinary nights gets muted — which is the original fail-open in a new suit.
+ABORTED = ("cancelled", "startup_failure")
 
 
 # ---------------------------------------------------------------------------
@@ -108,14 +135,25 @@ def derive_signature(jobs: list[dict]) -> list[str]:
     for job in jobs:
         if job.get("status") != "completed":
             continue
-        if job.get("conclusion") not in FAILED:
+        conclusion = job.get("conclusion")
+        if conclusion in ABORTED:
+            # No verdict at all.  Its steps are deliberately NOT read: the
+            # remaining steps of a cancelled job all report `skipped`, and the
+            # cheapest way to guarantee `skipped` can never leak into a
+            # signature is to never look at them.  One entry per aborted job,
+            # naming the abort — distinct from any failing-step entry, so a
+            # night the run was killed cannot masquerade as the same failure as
+            # the night before and be edited in silently.
+            entries.add(f"{job['name']}{SEP}(job {conclusion}, no verdict)")
+            continue
+        if conclusion not in FAILED:
             continue
         steps = [s for s in (job.get("steps") or []) if s.get("conclusion") in FAILED]
         if steps:
             for step in steps:
                 entries.add(f"{job['name']}{SEP}{step['name']}")
         else:
-            entries.add(f"{job['name']}{SEP}(job {job.get('conclusion')}, no failing step)")
+            entries.add(f"{job['name']}{SEP}(job {conclusion}, no failing step)")
     return sorted(entries)
 
 
@@ -461,6 +499,37 @@ def self_test(verbose: bool) -> int:
     headless = derive_signature([job("mcp-live", "failure", [("install", "success")])])
     check("a failed job with NO failed step is still red",
           headless == [f"mcp-live{SEP}(job failure, no failing step)"], repr(headless))
+
+    # THE SAME FAIL-OPEN BY THE OTHER DOOR: a job that reached no verdict.
+    cancelled = derive_signature([job("Gates", "cancelled",
+                                      [("Gate x", "cancelled"), ("Gate y", "skipped")])])
+    check("a CANCELLED job is red, and names the abort rather than a step",
+          cancelled == [f"Gates{SEP}(job cancelled, no verdict)"], repr(cancelled))
+    check("...so the `skipped` steps a cancellation leaves behind cannot leak in",
+          not any("Gate y" in e for e in cancelled), repr(cancelled))
+    startup = derive_signature([job("Gates", "startup_failure", [])])
+    check("a STARTUP_FAILURE job is red too (the rule is not cancellation-specific)",
+          startup == [f"Gates{SEP}(job startup_failure, no verdict)"], repr(startup))
+
+    # THE DIRECTION THAT IS NOT THE BUG, and the more expensive mistake of the
+    # two: classifying `skipped` would red the nightly on ordinary nights and
+    # get the whole alert muted.  A skipped job is the normal consequence of a
+    # `needs:` dependency that did not succeed — already reported by the job
+    # that actually failed.
+    # Both shapes at once: the STEPS after a failing step skip, and a whole
+    # dependent JOB skips.  Neither is news.
+    with_skipped = derive_signature([
+        job("Gates", "failure", [("Gate x", "success"), ("Gate y", "failure"),
+                                 ("Gate z", "skipped")]),
+        job("downstream", "skipped", [("Publish", "skipped")]),
+    ])
+    check("a benign SKIPPED dependent is NOT red (only the job that failed is)",
+          with_skipped == [f"Gates{SEP}Gate y"], repr(with_skipped))
+    all_green = derive_signature([job("A", "success", [("one", "success")]),
+                                  job("downstream", "skipped", [("Publish", "skipped")])])
+    check("...and a green run with a skipped dependent stays wholly green",
+          all_green == [], repr(all_green))
+
     check("an in-progress job (this script's own) is ignored",
           derive_signature([job("notify", None, [], status="in_progress")]) == [])
     check("the signature is order-independent",
@@ -516,6 +585,42 @@ def self_test(verbose: bool) -> int:
     back = decide(sig, issue_after(g2, []))
     check("a flake that reds on green-3 night reuses the SAME issue, silently",
           back[0] == "touch" and not back[1]["notifies"], repr(back))
+
+    # --- a cancelled night is not a green night ------------------------------
+    # Before this rule existed, `derive_signature` returned [] for a cancelled
+    # run and `decide([])` read that as green.  Two consequences, and they are
+    # asserted SEPARATELY because they fail independently: a cancelled run
+    # recorded no incident at all, and — the dangerous one — three of them in a
+    # row closed an open tracking issue, marking a system of record recovered
+    # that was never observed to recover.
+    cancelled_sig = derive_signature(
+        [job("Gates", "cancelled", [("Gate x", "cancelled"), ("Gate y", "skipped")])])
+    check("a cancelled run has a signature at all (it is not green)",
+          cancelled_sig != [], repr(cancelled_sig))
+
+    from_scratch = decide(cancelled_sig, None)
+    check("cancelled + no issue              -> open, LOUD (never `none`)",
+          from_scratch[0] == "open" and from_scratch[1]["notifies"], repr(from_scratch))
+
+    # DIRECTION 1: it cannot count toward recovery.
+    after_cancel = decide(cancelled_sig, iss)
+    check("a CANCELLED night does not advance the green streak",
+          after_cancel[1]["greens"] == 0, repr(after_cancel))
+    check("...it reads as a changed failure, LOUD (the run never gave a verdict)",
+          after_cancel[0] == "change" and after_cancel[1]["notifies"], repr(after_cancel))
+
+    # DIRECTION 2: it cannot close an open nightly-red issue.  The exact
+    # sequence that closed it before: one real red, then `close_after`
+    # cancellations.
+    iss_c, actions = issue_after(decide(sig, None), sig), []
+    for _ in range(CLOSE_AFTER_DEFAULT + 1):
+        a = decide(cancelled_sig, iss_c)
+        actions.append(a[0])
+        iss_c = issue_after(a, cancelled_sig)
+    check(f"{CLOSE_AFTER_DEFAULT + 1} CANCELLED nights running NEVER close the issue",
+          "close" not in actions, repr(actions))
+    check("...and only the first is loud; the rest are silent restatements",
+          actions == ["change"] + ["touch"] * CLOSE_AFTER_DEFAULT, repr(actions))
 
     # --- the two measured claims, as assertions ------------------------------
     iss2, loud = None, 0


### PR DESCRIPTION
Audit follow-up on merged PR #7536. The nightly alerter shipped, but its
decision layer had a fail-open of exactly the shape the alerter exists to
close.

## The defect

`derive_signature()` counted only conclusions in `("failure", "timed_out")`. A
*completed* job whose conclusion is `cancelled` matched neither, so it
contributed nothing and a wholly cancelled run produced an **empty signature**
— which `decide([])` reads as green.

Reproduced against unmodified `main` by driving the pure decision layer
directly:

```
DEFECT 1 -- derive_signature() of a wholly CANCELLED run
  signature = []
  empty?      True

DEFECT 2 -- a cancelled run produces NO incident at all
  decide(sig, no issue) -> action='none' notifies=False

DEFECT 3 -- a cancelled run ADVANCES the green streak and CLOSES an
            open nightly-red incident
  night 1 (real red)    -> open   (issue #1 open, notifies)
  night 2 (CANCELLED)   -> hold   greens=1 notifies=False
  night 3 (CANCELLED)   -> hold   greens=2 notifies=False
  night 4 (CANCELLED)   -> close  greens=3 notifies=True
```

The third is the dangerous one: three cancelled nights closed the tracking
issue on a system of record that was never observed to recover. The workflow
already states the requirement it was failing — `expensive-tests.yml` line
446, "a run cancelled or skipped part-way still has a verdict worth
recording".

**This is not hypothetical.** `gh run list` shows two real cancelled nightlies
in the history, on consecutive nights: 2026-06-30 (`28458640816`) and
2026-07-01 (`28531231200`). Run the pre-fix script against either and it
reports nothing at all — see the live check below.

## The fix

Two named tuples, with the reasoning at the definition rather than in a commit
message:

- `FAILED = ("failure", "timed_out")` — the gate ran and did not pass.
- `ABORTED = ("cancelled", "startup_failure")` — the gate never reached a
  verdict. Terminal, and not a pass. `startup_failure` is included so the rule
  reads as a stated principle rather than a patch for the one conclusion that
  bit.

An aborted job contributes `<job> -> (job <conclusion>, no verdict)` — one
entry, distinct from any failing-step entry, so a killed run cannot masquerade
as the previous night's failure and be edited in silently.

**`skipped` is in neither tuple, and that exclusion is load-bearing.** The
steps after a failing step skip, and a dependent job whose `needs:` did not
succeed skips — both on entirely ordinary nights. A rule that counted
`skipped` would red the nightly routinely and get the alert muted, which is
worse than the bug it fixes. An aborted job's steps are never read at all, so
that guarantee is structural rather than filter-based.

No change to `decide()` was needed: once the signature is non-empty the green
branch is unreachable, so `greens` cannot advance and `close` cannot be
returned. `.github/workflows/expensive-tests.yml` is untouched — the fix did
not need it.

## Quality gates

| gate | result | exit |
|---|---|---|
| `nightly_failure_alert.py --self-test` (37 checks, was 26) | all pass | 0 |
| reproduction vs unmodified `main` | defect reproduced, all 3 consequences | 0 |
| reproduction vs fixed code | defect gone | 1 (its "not reproduced" exit) |
| live `--dry-run` vs 2 real cancelled runs | incident now raised, was silent | 0 |
| live `--dry-run` vs 10 real non-aborted runs | verdict identical to pre-fix | 0 |
| `python -m py_compile` | pass | 0 |
| `yaml.safe_load` of `expensive-tests.yml` | parses, 5 jobs | 0 |
| mutation proofs, 4 rules x (red / restore / green) | each reds only its own checks | 1 / 0 each |
| `check-beads-pr-boundary.sh origin/main` | no beads-database paths | 0 |

Repo-wide CLJS/JVM/docs suites not run: this PR changes one standalone Python
script under `.github/scripts/` and touches no CLJS, JVM, spec or docs
surface. File mode is unchanged at `100644`; the script is invoked as
`python3 <path>`, so it needs no exec bit.

### Live check, on real run data

The pre-fix script (`git show HEAD~1:...`) and this one, both `--dry-run`,
against the two genuinely cancelled nightlies:

```
run 28531231200 (2026-07-01, cancelled)
  OLD: failing-steps=0  action=none  notifies=no
  NEW: failing-steps=1  action=open  notifies=yes
       RED  MCP live and client conformance -> (job cancelled, no verdict)

run 28458640816 (2026-06-30, cancelled)
  OLD: failing-steps=0  action=none  notifies=no
  NEW: failing-steps=2  action=open  notifies=yes
       RED  Browser, bundle, examples, Story/Xray gates -> (job cancelled, no verdict)
       RED  MCP live and client conformance -> (job cancelled, no verdict)
```

Note the second direction is visible here too: in `28531231200` only the one
job that was actually cancelled appears. The jobs that succeeded, and the
steps that skipped, are absent.

And across ten real non-aborted runs (five green, five red), old and new agree
exactly — the fix adds no noise to any ordinary night:

```
31022886145 0->0   30927127770 0->0   30645068521 1->1   30282895276 1->1
30106705162 1->1   29935235079 1->1   29845894642 1->1   29032463675 1->1
28806655565 1->1   28711202319 0->0                          all SAME
```

### Mutation proofs

Each new rule was planted-broken independently; one blanket mutation would
certify nothing about the others. Every mutation was confirmed applied
(`git diff --stat` showing 1 insertion / 1 deletion, the replacement token
grepped in with a complete-line anchor, the original grepped absent), then
restored byte-identical via `git checkout HEAD --` with `git diff` confirmed
empty and the suite re-run green.

| mutation | self-test | what reddened |
|---|---|---|
| drop `"cancelled"` from `ABORTED` | 7 FAIL | every cancellation check, and only those — `startup_failure` and both `skipped` checks stayed green |
| drop `"startup_failure"` from `ABORTED` | 1 FAIL | only the `startup_failure` check |
| add `"skipped"` to `ABORTED` | 2 FAIL | only the two benign-skipped checks — the direction that is *not* the bug |
| add `"skipped"` to the step-level filter | 1 FAIL | only the benign-skipped-dependent check; the cancellation checks stayed green, proving an aborted job's steps are never read |

The first mutation is worth reading closely: it reproduces the original bug
*inside the suite*, and the failure output is the defect verbatim —

```
FAIL 4 CANCELLED nights running NEVER close the issue: ['hold', 'hold', 'close', 'close']
```

Closes rf2-6sg25.
