### PR TITLE
spec(schemas): type the :where slot and strike the dead :recovery declarations (rf2-j4bg3, rf2-v1sg5)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -734,9 +734,13 @@
 
     {:rf.error/id :rf.error/no-frame-context
      :operation   <op-kw>     ;; e.g. :dispatch / :subscribe
-     :where       <sym-or-kw> ;; the resolving call site
+     :where       <sym>       ;; the resolving call site, a SYMBOL
      :event-id    <kw>        ;; the in-flight op's id, when known
      :recovery    :supply-frame}
+
+  `:where` is a SYMBOL naming the resolving fn (`'re-frame.subs/subscribe`),
+  never a keyword — `NoFrameContextTags` in spec/Spec-Schemas.md declares the
+  slot `:symbol`, and every call site in the corpus emits a quoted symbol.
 
   `:reason` is always composed, and `:rf.trace/dispatch-id` (the capture-site
   correlation key) is merged whenever a handler scope is in effect. There is
@@ -954,10 +958,11 @@
   target fails loudly at the provider rather than being silently coerced to
   a registered keyword frame by the lower-level context reader.
 
-  `where` (sym/kw) names the validating call site for the payload. The nil
-  branch threads `where` + a `:supply-frame` recovery into the
-  no-frame-context payload, matching each provider surface's nil
-  handling."
+  `where` is a SYMBOL naming the validating call site for the payload (every
+  caller passes a quoted fn symbol, e.g.
+  `'re-frame.views.provider/frame-provider`). The nil branch threads `where` +
+  a `:supply-frame` recovery into the no-frame-context payload, matching each
+  provider surface's nil handling."
   [frame-target where]
   (cond
     (keyword? frame-target) frame-target

--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -112,6 +112,14 @@
             [clojure.java.io :as io]
             [clojure.set :as set]
             [clojure.string :as str]
+            ;; Malli reaches this ns through the schemas artefact's test-only
+            ;; dep (see implementation/core/deps.edn — core's PRODUCTION
+            ;; classpath deliberately carries none). Used by the `:where`
+            ;; type-mutation witness below, which is the only assertion here
+            ;; that VALIDATES a payload rather than diffing key sets.
+            ;; aliased `malli`, not `m` — `parse-tags-schemas` binds a local
+            ;; `m` for its matcher and a shadowed alias reads as a bug.
+            [malli.core :as malli]
             ;; The dual-runtime exercise leg's always-on literal — Test A
             ;; pins it against the parsed catalogue (invariant #4), Test B
             ;; iterates it. Requiring it here closes the coupling in code.
@@ -951,6 +959,26 @@
                        (schema-map-keys (read-form-at text (.start m)))))
          acc)))))
 
+(defn- tags-schema-form
+  "The Malli FORM a named `*Tags` schema declares in Spec-Schemas.md — the
+  `[:map …]` vector itself, not its key set.
+
+  `parse-tags-schemas` throws the types away by design (its arm diffs key
+  sets), so a slot's declared TYPE is unreachable through it. This reader
+  keeps the form so the `:where` witness below can validate real payloads
+  against the schema the spec actually ships."
+  [schema-name]
+  (let [text    (slurp spec-schemas-file)
+        matcher (re-matcher tags-schema-def-re text)]
+    (loop []
+      (when (.find matcher)
+        (if (= schema-name (.group matcher 1))
+          (let [form (read-form-at text (.start matcher))]
+            (->> (tree-seq coll? seq form)
+                 (filter #(and (vector? %) (= :map (first %))))
+                 first))
+          (recur))))))
+
 (def ^:private tags-cell-key-re
   "A `:tags` cell entry: a back-ticked span that is EXACTLY one keyword.
   Anchored on the whole span on purpose — the cells carry long prose in which
@@ -1057,9 +1085,25 @@
           rows))
 
 (def ^:private envelope-only-tag-keys
-  "The two slots 009 excludes from every row's `:tags` cell BY RULE, so a
-  schema declaring them is not evidence of a row defect."
-  #{:recovery :category})
+  "The slot 009 excludes from every row's `:tags` cell BY RULE, so a schema
+  declaring it is not evidence of a row defect.
+
+  `:recovery` used to sit here too, and its removal (rf2-v1sg5) is what makes
+  this set an exemption rather than a blind spot. The slot was exempted because
+  `re-frame.trace/build-event` strips it and hoists it to the envelope top
+  level, so a schema declaring it convicted no row — but subtracting it from
+  the SCHEMA side of the diff meant a schema could over-declare `:recovery`
+  with no mechanical consequence, which is exactly the tolerance 009
+  §'The `:tags` column is pinned, not documentary' calls a defect. With the six
+  over-declaring schemas struck from Spec-Schemas.md (`MalformedSchemaTags`,
+  `NoFrameContextTags`, `BadFrameProviderArgTags`, `EffectHandlerBadReturnTags`,
+  `PrefetchBadAddressTags`, `NoAdapterSpecifiedTags`), the exemption is dead and
+  dropping it makes this arm STRICTLY STRONGER: a schema that re-declares
+  `:recovery` under `:tags` now reds instead of being silently absolved.
+
+  `:category` stays: the `:warning` branch synthesizes none and the closed
+  schemas pin it, so it is genuinely envelope-level on every row."
+  #{:category})
 
 (defn tags-column-findings
   "`[{:category … :schema … :missing #{…}} …]` — every paired row whose `:tags`
@@ -1082,15 +1126,18 @@
 
 (defn tags-column-recovery-listings
   "`[category …]` — every ACTIVE catalogue row whose `:tags` cell LISTS
-  `:recovery`. The other direction of `envelope-only-tag-keys`' first slot, and
-  the reason the drift it retires reached 134 rows unseen (rf2-mb8yp).
+  `:recovery`. The CELL-side guard on the slot, and the reason the drift it
+  retires reached 134 rows unseen (rf2-mb8yp).
 
-  That exempt set stops a SCHEMA declaring `:recovery` from convicting its row,
-  correctly: `re-frame.trace/build-event` strips the slot and hoists it to the
-  envelope top level on every branch, so no schema's declaration is evidence of
-  a row defect. But subtracting the slot exempted BOTH sides of the diff — a
-  row was equally free to LIST a key no consumer can read under `:tags`, with
-  no mechanical consequence either way. 009 §Reading the two right-hand columns
+  `envelope-only-tag-keys` used to carry `:recovery` as its first slot, which
+  stopped a SCHEMA declaring it from convicting its row: `re-frame.trace/build-
+  event` strips the slot and hoists it to the envelope top level on every
+  branch, so no schema's declaration was evidence of a row defect. But
+  subtracting the slot exempted BOTH sides of the diff — a row was equally free
+  to LIST a key no consumer can read under `:tags`, with no mechanical
+  consequence either way. This fn closed the CELL side; rf2-v1sg5 then struck
+  `:recovery` from the six over-declaring schemas and dropped the exemption, so
+  the SCHEMA side is now closed by the ordinary keys diff rather than exempted. 009 §Reading the two right-hand columns
   has always called that 'a row defect, not a counterexample', and the
   `Default :recovery` column is where a row states its disposition; the listing
   is now caught rather than tolerated.
@@ -1316,6 +1363,95 @@
                "`tags-column-paired-floor` still records "
                tags-column-paired-floor ". Raise it to " paired " in this PR: "
                "a floor below live coverage protects nothing above itself.")))))
+
+;; --- the :where slot's TYPE (rf2-j4bg3) --------------------------------------
+;;
+;; THE ARM ABOVE DIFFS KEY SETS AND IS BLIND TO TYPES BY CONSTRUCTION.
+;; `schema-map-keys` keeps entry KEYS and discards every declared type, so a
+;; slot declared `:any` validates a string, a number, a map or an arbitrary
+;; host object with no gate anywhere disagreeing. For `:where` that is not a
+;; harmless looseness: the declared type is the ONLY thing standing between
+;; `NoFrameContextTags` and an arbitrary object, so `:any` there enforced
+;; nothing while reading as though it did — which is how PR #7560 could claim a
+;; producer/schema agreement the corpus never checked.
+;;
+;; The contract is a SYMBOL, and that is a reading of the producers rather than
+;; of the prose: every call site that supplies `:where` into a
+;; no-frame-context payload emits a QUOTED SYMBOL naming the resolving fn —
+;; `re-frame.subs/subscribe`, `re-frame.router/build-envelope`,
+;; `re-frame.core/capture-frame`, `rf.ssr/hydrate!`, `rf.http/managed`,
+;; `rf.machine/spawn`, `rf.route/navigate-handler`, … across core, http,
+;; machines, routing, flows, resources, ssr, freehand and ui — as does the
+;; `where` argument threaded through `require-frame-provider-target!` and
+;; `re-frame.ui.frames/resolve-frame`. There is no keyword producer in src or
+;; in test. Spec 009's row and the schema's own comment both already said
+;; "a SYMBOL … not a keyword"; only the slot disagreed.
+
+(def ^:private no-frame-context-where-mutants
+  "The type mutants the `:any` declaration silently accepted. A STRING is the
+  realistic drift (a call site interpolating a name), the NUMBER and the MAP
+  stand for `anything at all`."
+  {"a string"        "re-frame.subs/subscribe"
+   "a number"        42
+   "a map"           {:ns 're-frame.subs :name 'subscribe}
+   "a bare keyword"  :re-frame.subs/subscribe})
+
+(deftest no-frame-context-where-is-typed-not-any
+  (testing "`NoFrameContextTags` declares `:where` as `:symbol`, and the
+            declaration is load-bearing: the keys-set arm above cannot see a
+            type, so this is the only assertion that reads one."
+    (let [schema (tags-schema-form "NoFrameContextTags")
+          entry  (->> (rest schema)
+                      (filter #(and (vector? %) (= :where (first %))))
+                      first)]
+      (is (some? schema) "NoFrameContextTags parsed out of Spec-Schemas.md")
+      (is (some? entry) "NoFrameContextTags declares a `:where` entry")
+      (is (= :symbol (last entry))
+          (str "`:where` must be declared `:symbol` — every producer emits a "
+               "quoted symbol, and `:any` here enforces nothing because the "
+               "Tags-column arm diffs keys only. Found: " (pr-str entry)))
+      (is (= {:optional true} (second entry))
+          (str "`:where` stays OPTIONAL — the 1-arity requiring forms omit it. "
+               "Found: " (pr-str entry)))))
+
+  (testing "A legitimate symbol validates, and the slot may be omitted."
+    (let [schema (tags-schema-form "NoFrameContextTags")
+          base   {:category  :rf.error/no-frame-context
+                  :operation :subscribe
+                  :reason    "a frame-scoped subscribe ran with no frame context"}]
+      (is (malli/validate schema (assoc base :where 're-frame.subs/subscribe))
+          "a quoted symbol — what every producer actually emits — validates")
+      (is (malli/validate schema (assoc base :where 'rf.ssr/hydrate!))
+          "a namespaced symbol from the carried-stamp seam validates")
+      (is (malli/validate schema base)
+          "`:where` omitted validates — the 1-arity requiring forms omit it")))
+
+  (testing "THE MUTATION WITNESS. Each mutant is REJECTED by the shipped
+            `:symbol` slot and ACCEPTED by the `:any` slot it replaced — so the
+            tightening, and not some unrelated guard, is what rejects them.
+            Without the second half this test could pass against a schema that
+            rejected everything."
+    (let [shipped (tags-schema-form "NoFrameContextTags")
+          ;; The pre-fix declaration, rebuilt from the shipped schema so the
+          ;; two differ in exactly one token.
+          as-any  (mapv (fn [e]
+                          (if (and (vector? e) (= :where (first e)))
+                            [:where {:optional true} :any]
+                            e))
+                        shipped)
+          base    {:category  :rf.error/no-frame-context
+                   :operation :subscribe
+                   :reason    "a frame-scoped subscribe ran with no frame context"}]
+      (is (not= shipped as-any)
+          "the `:any` control really differs from the shipped schema")
+      (doseq [[label v] no-frame-context-where-mutants]
+        (is (not (malli/validate shipped (assoc base :where v)))
+            (str "`:where` = " label " (" (pr-str v) ") must be REJECTED by the "
+                 "shipped `:symbol` slot"))
+        (is (malli/validate as-any (assoc base :where v))
+            (str "`:where` = " label " (" (pr-str v) ") was ACCEPTED by the old "
+                 "`:any` slot — this is the blindness the tightening removes. If "
+                 "this assertion fails the control is wrong, not the fix."))))))
 
 ;; --- non-vacuity ------------------------------------------------------------
 ;;

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -1193,8 +1193,7 @@ A schema and its catalogue row are **co-edited**, and a conformance test holds t
    [:path            {:optional true} [:vector :any]]   ;; registration root (structural locator; no user value)
    [:registered-path {:optional true} [:vector :any]]
    [:schema          {:optional true} :any]             ;; the malformed registration form to fix
-   [:rollback?       {:optional true} :boolean]
-   [:recovery        {:optional true} :keyword]])
+   [:rollback?       {:optional true} :boolean]])
 
 (def DrainDepthExceededTags
   ;; rf2-fcbrjo — the DEV-TRACE tags for `:rf.error/drain-depth-exceeded`.
@@ -1327,14 +1326,20 @@ A schema and its catalogue row are **co-edited**, and a conformance test holds t
   ;; `:rf.route/navigate`, `:rf.ssr/hydrate`, …), and whatever a pass-through
   ;; caller supplies (`re-frame.schemas.storage` forwards its own caller's).
   ;; `:where` is a SYMBOL naming the resolving call site (`'re-frame.subs/subscribe`,
-  ;; `'re-frame.router/build-envelope`), not a keyword.
+  ;; `'re-frame.router/build-envelope`), not a keyword. The slot is TYPED `:symbol`
+  ;; rather than `:any` because the catalogue conformance gate diffs KEY SETS only:
+  ;; the declared type is the sole thing standing between this payload and a string,
+  ;; number or arbitrary object at `:where`, so `:any` there enforced nothing. Every
+  ;; producer emits a quoted symbol — the requiring primitives' call sites across
+  ;; core, http, machines, routing, flows, resources, ssr, freehand and ui, plus the
+  ;; `where` argument threaded through `require-frame-provider-target!` and
+  ;; `re-frame.ui.frames/resolve-frame`.
   [:map
    [:category    :keyword]                         ;; [:= :rf.error/no-frame-context] in a closed schema
    [:operation   :keyword]                          ;; the failing frame-scoped op — open set (above)
-   [:where       {:optional true} :any]             ;; the resolving call site, a symbol; the 1-arity requiring forms omit it
+   [:where       {:optional true} :symbol]          ;; the resolving call site, a SYMBOL; the 1-arity requiring forms omit it
    [:event-id    {:optional true} :keyword]         ;; the query-id / event-id the op carried
    [:reason      :string]                           ;; the composed "establish a scope one of three ways" sentence
-   [:recovery    {:optional true} :keyword]         ;; :supply-frame
    ;; capture-site ancestry (frameless correlation) — the in-scope handler
    ;; scope's dispatch-id, present when the op fired inside a continuation
    ;; captured during a known run. There is no parent key here: per
@@ -1356,7 +1361,6 @@ A schema and its catalogue row are **co-edited**, and a conformance test holds t
    [:category :keyword]                              ;; [:= :rf.error/bad-frame-provider-arg] in a closed schema
    [:received :any]                                  ;; the offending value (neither keyword nor frame value)
    [:where    {:optional true} :any]                 ;; the validating provider call site (symbol)
-   [:recovery {:optional true} :keyword]             ;; :supply-frame-target
    [:reason   {:optional true} :string]])
 
 (def EffectMapShapeTags
@@ -1376,8 +1380,7 @@ A schema and its catalogue row are **co-edited**, and a conformance test holds t
    [:event         [:vector :any]]
    [:returned      :any]
    [:returned-type :any]
-   [:reason        :string]
-   [:recovery      [:= :no-recovery]]])
+   [:reason        :string]])
 
 (def FlowEvalExceptionTags
   [:map
@@ -1781,8 +1784,7 @@ A schema and its catalogue row are **co-edited**, and a conformance test holds t
    [:where     :keyword]                  ;; :event
    [:reason    :keyword]                  ;; the first extraction-law violation (e.g. :unknown-keys / :bad-address)
    [:keys      {:optional true} [:vector :any]]
-   [:frame     {:optional true} :any]
-   [:recovery  {:optional true} :keyword]])
+   [:frame     {:optional true} :any]])
 
 (def ResourceRouteBlockingTags
   ;; a BLOCKING route resource FAILED its first load — the runtime flips the
@@ -1884,7 +1886,6 @@ A schema and its catalogue row are **co-edited**, and a conformance test holds t
    [:where    [:or :symbol :string]]
    [:received {:optional true} :any]
    [:expected {:optional true} :string]
-   [:recovery {:optional true} :keyword]
    [:reason   :string]])
 
 (def AdapterMap


### PR DESCRIPTION
Two coupled beads, one PR: **rf2-j4bg3** (the `:where` slot's type) and **rf2-v1sg5** (the `:recovery` strike). They share `spec/Spec-Schemas.md`, and `NoFrameContextTags` is touched by both, so splitting them would put two workers on one hot-zone file.

Net effect is a deletion — six over-declared schema slots removed and one exemption dropped — plus one slot that changes from `:any` to `:symbol`.

---

## rf2-j4bg3 (a) — audit #7533's `:recovery` charge was ALREADY LANDED

The bead's first note asks to remove `:recovery` from the `:rf.error/ambient-frame-refused` row's `:tags` cell in `spec/009-Instrumentation.md`. **That work is already on main and this PR does not redo it.**

`1c7846e544` ("strike the redundant `:recovery` cell from the 009 error catalogue", rf2-mb8yp) struck the slot from 134 catalogue rows, the ambient row among them. Verified two ways: parsing the sixth column of every `| :rf.* |` row finds no `:recovery` in the ambient row's `:tags` cell (nor in its `:rf.error/no-frame-context` sibling's), and the six rows that still mention the token are exactly the six that commit message enumerates as deliberate survivors — the closed record-slot sets on `:rf.error/ssr-ring-response-status-invalid` and the three safe-redirect rows, and the axis-asymmetry sentences on `:rf.error/unsupported-scroll-strategy` and `:rf.warning/cross-frame-carried-op`. Those state a contract about the slot rather than restating a universal, which is 009's own listed-not-merely-mentioned rule.

`spec/009-Instrumentation.md` is therefore untouched by this PR.

## rf2-j4bg3 (b) — `NoFrameContextTags`' `:where` is now `:symbol`, not `:any`

The load-bearing half. The Tags-column conformance arm diffs **key sets** — `schema-map-keys` keeps entry keys and discards every declared type — so a slot declared `:any` is not weakly enforced, it is **unenforced**. A string, a number, a map or an arbitrary host object validated at `:where` with no gate anywhere disagreeing, which is how PR #7560 could claim a producer/schema agreement the corpus never checked.

**What the real producers emit, having read them rather than the prose:** every call site that supplies `:where` into a no-frame-context payload emits a **quoted symbol**. 48 distinct values across `implementation/*/src` — `re-frame.subs/subscribe`, `re-frame.subs/subscribe-once`, `re-frame.subs/unsubscribe`, `re-frame.router/build-envelope`, `re-frame.core/capture-frame`, `re-frame.core/current-frame-id`, `re-frame.elision/declarations`, `rf.http/managed`, `rf.machine/spawn`, `rf.machine/after-schedule`, `rf.route/navigate-handler`, `rf.ssr/hydrate!`, `rf/reg-flow`, `rf/reg-app-schema`, and so on across core, http, machines, routing, flows, resources, ssr, freehand and ui. The three pass-through sites resolve the same way: `require-frame-provider-target!`'s `where` parameter receives `'re-frame.adapter.uix/frame-provider`, `'re-frame.views.provider/frame-provider` and `'re-frame.substrate.spine/build-frame-provider-element`, and `re-frame.ui.frames/resolve-frame`'s receives `'re-frame.ui/frame`. **There is no keyword producer in `src` or in `test`.**

So the bead's "symbol if callers are deliberately normalized" branch is the one the corpus supports, and it is what both spec statements already said: 009's row reads "`:where` (the resolving call site — a SYMBOL … )" and the schema's own comment read "a SYMBOL … not a keyword". Only the slot disagreed. Declaring `[:or :symbol :keyword]` would have contradicted the comment sitting two lines above it.

Two stale implementation docstrings that the audit note itself cited as the "sym-or-kw" contract are corrected to match (`no-frame-context-payload` and `require-frame-provider-target!` in `implementation/core/src/re_frame/frame.cljc`). Leaving them would have re-created exactly the schema/prose drift that produced this bead.

### The type-mutation witness

`no-frame-context-where-is-typed-not-any` is added to the catalogue conformance test. It is the only assertion in that file that **validates a payload** rather than diffing key sets, and it carries its own control: each mutant must be rejected by the shipped `:symbol` slot **and accepted by the `:any` slot it replaced**, rebuilt from the shipped schema so the two differ in exactly one token. Without that second half the test would pass against a schema that rejected everything.

Mutation-proven by reverting the slot to `:any` (confirmed applied before reading the verdict — `:symbol` token absent, `:any` token present, `git diff --stat` unchanged in size):

```
EXIT=1 … 6 failures, 0 errors
FAIL (= :symbol (last entry))         actual: (not (= :symbol :any))
FAIL (not (malli/validate shipped …))  actual: (not (not true))   ×4
```

Those four `(not (not true))` lines are the audit's claim reproduced exactly: under `:any`, **a string, a number, a map and a bare keyword all validated**. Restored, the suite is green.

---

## rf2-v1sg5 — the mayor's ruling, reproduced

> **MAYOR RULING (2026-08-06): take option (b)** — STRIKE `:recovery` from the six `*Tags` schemas, then narrow `envelope-only-tag-keys` from `#{:recovery :category}` to `#{:category}`. **Strike FIRST, narrow SECOND, same PR**: striking leaves the exemption dead-but-harmless, whereas narrowing before striking would red the gate.
>
> **THE ARTEFACT'S OWN RULE DECIDES THIS, not my preference.** Spec 009 section *"The `:tags` column is pinned, not documentary"* states that a schema declaring a key the category never actually carries IS the defect and the fix belongs in Spec-Schemas. The cell side is now uniform after rf2-mb8yp, so these six schemas are the last place `:recovery` appears as a `:tags` key. Option (a) would leave the artefact knowingly in breach of a rule it states about itself.
>
> **WHY THIS IS NOT GOLD-PLATING**, since the bead is honest that the current state is harmless: the change is a NET DELETION that makes the gate STRICTLY STRONGER. The exemption exists to subtract `:recovery` from the schema side of the keys diff, and its own docstring says "a schema declaring them is not evidence of a row defect" — that tolerance is precisely what makes the schema side unable to red. Removing the need for the tolerance removes a blind spot rather than adding machinery. Fewer lines, one less exemption, and a gate that can now see a class it could not.

Struck from `MalformedSchemaTags`, `NoFrameContextTags`, `BadFrameProviderArgTags`, `EffectHandlerBadReturnTags`, `PrefetchBadAddressTags`, `NoAdapterSpecifiedTags`, then `envelope-only-tag-keys` narrowed to `#{:category}` — in that order.

The roster of six was independently re-derived rather than taken on trust: reading each `(def …Tags …)` as a balanced form gives exactly those six and no others. (A first pass that split on `def` boundaries rather than balanced parens reported a seventh, `CrossFrameCarriedOpTags` — that was a scan artifact. The `:recovery` line it saw belongs to the `CrossFrameCarriedOpEvent` envelope that follows, where the slot is legitimately top-level; `CrossFrameCarriedOpTags` itself already says "NO `:recovery` (hoisted top-level)".)

---

## Both halves proved independently

**1. Strike alone, exemption still `#{:recovery :category}`** — green. `Ran 25 tests containing 67 assertions. 0 failures, 0 errors.` (exit 0). The strike does not depend on the narrowing.

**2. Strike + narrowing** — green, and the ordering claim is measured rather than asserted. Driving the pure `tags-column-findings` with the **pre-strike** schema corpus (`origin/main:spec/Spec-Schemas.md`) against today's rows under the **narrowed** exemption:

```
=== A. narrow-before-strike (pre-strike schemas + narrowed exemption) ===
findings: 6
   RED  :rf.error/bad-frame-provider-arg      missing= (:recovery)
   RED  :rf.error/effect-handler-bad-return   missing= (:recovery)
   RED  :rf.error/malformed-schema            missing= (:recovery)
   RED  :rf.error/no-adapter-specified        missing= (:recovery)
   RED  :rf.error/no-frame-context            missing= (:recovery)
   RED  :rf.error/prefetch-bad-address        missing= (:recovery)

=== B. strike-then-narrow (shipped schemas + narrowed exemption) ===
findings: 0
```

Narrowing first would have redded on exactly the six schemas the ruling names — the ordering is load-bearing, and the six-schema roster is confirmed from the other direction. Those six findings are also the proof that the gate is now **strictly stronger**: a schema that re-declares `:recovery` under `:tags` now reds instead of being silently absolved.

**3. The direction not under test.** `:category` is still exempted correctly, and its exemption is load-bearing rather than decorative:

```
findings with the SHIPPED exemption #{:category}:  0
findings if :category were ALSO dropped:          81
findings under the OLD exemption:                  0
schemas still declaring :recovery:                ()
```

No unrelated row reds in any configuration.

---

## Quality gates

| Gate | Result | Exit |
|---|---|---|
| `implementation/core` JVM — `clojure -M:test` | **2225 tests, 11580 assertions, 0 failures, 0 errors** | `0` |
| conformance ns alone — `clojure -M:test -n re-frame.error-catalogue-channel-conformance-test` | **26 tests, 83 assertions, 0 failures** (was 25/67; +1 test, +16 assertions = the witness) | `0` |
| witness mutation proof (`:symbol` → `:any`) | **6 failures — fires as designed**; all four mutants accepted by `:any` | `1` (expected) |
| `python -m mkdocs build --strict` | built in 24.92s, no warnings | `0` |
| `python scripts/check_doc_slugs.py` | clean | `0` |
| `python scripts/check_keyword_catalogue_drift.py` | clean | `0` |
| `python scripts/check_keyword_catalogue_drift.py --self-test` | clean | `0` |
| `sh scripts/test-fast-pr.sh` | all 76 stages clean | `0` |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | "No beads-database paths in this PR diff." | `0` |

The fast-PR spine was run twice. The **first** run reported `FAST_PR_EXIT=1` at its own terminal marker — `CLJS node integration` failed with `could not resolve shadow-cljs: Cannot find module 'shadow-cljs/cli/runner.js'`, because this worker worktree had no `implementation/node_modules`. That is an environment gap, not a diff regression, but the diff does touch a `.cljc` on the CLJS compile path, so it was not waved through: the junction to the mayor checkout's real `node_modules` was created and the **whole spine re-run to completion**, giving `FAST_PR2_EXIT=0` across all 76 stages. The junction is removed again as the last act of this work (mayor `node_modules` re-checked at 101 entries afterwards).

Note the first run's wrapper reported "exit code 0" while the runner's own anchored marker said `1` — the marker is what was read.

The core JVM lane is run **because the gate parses `spec/009-Instrumentation.md` and `spec/Spec-Schemas.md`** — a spec-only edit can red `implementation/core` even with no core source file in the diff. `mkdocs` is run separately because `test-fast-pr.sh` soft-skips it when it is off PATH and still exits 0 (`mkdocs` is not on PATH here; `python -m mkdocs` is).

`spec/**` is CRLF in this repo; `git diff --numstat` on `spec/Spec-Schemas.md` is `12 / 11`, and the file's CRLF count still equals its LF count — the change is the change, not a line-ending normalisation.

## Follow-up filed

**rf2-am6qs** (P3) — the general form of the defect this PR fixed in one place. Of the 13 `:where` slots in `spec/Spec-Schemas.md`, ten are typed; three are still `:any`: `FrameDestroyedTags`, `BadFrameProviderArgTags` and `ResourceSsrBlockingTimeoutTags`. `BadFrameProviderArgTags` is the strongest case and the reason it is filed rather than left — `frame/require-frame-provider-target!` threads **one** `where` argument into **both** payloads, the nil branch building no-frame-context (now `:symbol`) and the else branch building bad-frame-provider-arg (still `:any`), so one argument now has two different declared types. It was deliberately not folded in here: this bead's audit charge named `NoFrameContextTags` specifically, and widening a hot-zone PR past its charge is how these files collide.

Closes rf2-j4bg3. Closes rf2-v1sg5.
