### PR TITLE
fix(core): a body has ONE frame — refuse a mismatched carried stamp inside a refusing render extent (rf2-nqj22)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -549,6 +549,21 @@
 ;; the two spellings of "I carried a frame" behaving identically inside a
 ;; refused extent, per EP-0002 ("frame identity is carried, not found") —
 ;; the refusal deletes the FINDING, never the carrying.
+;;
+;; WITH ONE EXCEPTION, WHICH IS OPT-IN AND SUBSTRATE-DECLARED (rf2-nqj22).
+;; The sentence above is the rule wherever a carried stamp is the only frame
+;; in play. It stops being the rule when the extent HAS a frame of its own
+;; and the stamp names a different one: the body then reads and dispatches
+;; against `:b` while its own reads, lowered intents, presence tray and
+;; children target `:a`, chosen by which spelling the author reached for and
+;; with no signal at all. Frames are ISOLATED contexts, so that is not a
+;; carried-stamp win but an ambiguity, and blessing it would leave exactly
+;; the silently-wrong-frame class this tier exists to delete alive in one
+;; configuration. A substrate declares its extent's frame as `:extent-frame`
+;; on the refusal detail and `require-current-frame!` refuses the mismatch;
+;; a substrate that names none is untouched, and a MATCHED stamp still
+;; carries — refusing that would make `with-frame` and `{:frame …}` disagree,
+;; which is worse than the bug.
 
 (def ^:private default-ambient-refusal-reason
   "The sentence a refusing substrate is expected to replace with its own —
@@ -575,8 +590,20 @@
 
   The map's keys are the substrate's to supply: `:substrate` (a keyword
   naming it), `:reason` (one sentence saying what the extent requires
-  INSTEAD — this is what the author reads), `:recovery` (a keyword), and
-  any additional detail, which is merged into the payload."
+  INSTEAD — this is what the author reads), `:recovery` (a keyword),
+  `:extent-frame` (below), and any additional detail, which is merged into
+  the payload.
+
+  `:extent-frame` — THE FRAME THIS EXTENT IS RENDERING (rf2-nqj22). The one
+  key core READS rather than passes through, and the only one that changes
+  what the tier does. A substrate that names it declares \"a body of mine has
+  ONE frame\", and [[require-current-frame!]] then refuses a carried stamp
+  that names a DIFFERENT one — because a body whose ambient ops target `:b`
+  while its own reads, lowered intents and children target `:a` is two frames
+  in one body, and frames are ISOLATED contexts. Omit it (or leave it nil)
+  and the tier behaves exactly as it did before: the ambient FIND is refused
+  and any carried stamp wins, which is right for an extent that has no frame
+  of its own to be mismatched against."
   nil)
 
 (defn call-with-ambient-frame-refused
@@ -598,7 +625,10 @@
 
   SCOPE. Refusal applies to the AMBIENT tier only. An explicitly carried
   stamp is untouched: `{:frame …}` opts never consult this resolver, and
-  `with-frame` inside the extent still answers through `*current-frame*`.
+  `with-frame` inside the extent still answers through `*current-frame*` —
+  with the ONE exception a substrate opts into by naming `:extent-frame` on
+  the refusal, which refuses a carried stamp that names a frame OTHER than
+  the one the extent is rendering (rf2-nqj22).
   Nesting is not tracked and does not need to be — React renders a child
   fiber only after the parent's render function has returned, so this
   binding has already unwound before any child component (an adapter
@@ -629,6 +659,30 @@
 ;; may bind a frame VALUE (`make-frame`'s token) into `*current-frame*`, and
 ;; ring attribution must key on the record id, never a value map.
 (late-bind/set-fn! :frame/current-frame-id (fn [] (frame-value->id *current-frame*)))
+
+(defn- carried-frame-admitted-by
+  "The carried (tier-1) stamp, normalized to an id, when `refusal` — the
+  in-effect refusal detail — ADMITS it; **nil** otherwise (rf2-nqj22).
+
+  A refusal that names no `:extent-frame` admits every carried stamp, which
+  is the pre-rf2-nqj22 contract and the right answer for an extent with no
+  frame of its own. One that names one admits only that frame: a body whose
+  ambient ops target `:b` while its own reads, lowered intents and children
+  target `:a` is two frames in one body, and frames are ISOLATED contexts.
+
+  Both sides go through `frame-value->id`, so a substrate that declared a
+  frame VALUE compares equal to the id the reader normalized to. The
+  comparison is BY VALUE and must stay that way — keywords are interned on
+  the JVM and are not guaranteed reference-equal in ClojureScript, so an
+  `identical?` written here would be green on one host and refuse every
+  carried stamp on the other."
+  [refusal]
+  (let [carried (frame-value->id (current-frame))]
+    (when (and (some? carried)
+               (if-some [extent-frame (:extent-frame refusal)]
+                 (= carried (frame-value->id extent-frame))
+                 true))
+      carried)))
 
 (defn resolve-current-frame
   "Resolve the active frame at a no-explicit-frame call site — the
@@ -667,7 +721,20 @@
   `require-current-frame!` turns that into the loud
   `:rf.error/ambient-frame-refused`. Being a reader, it still returns nil
   rather than throwing: tooling and frame pickers running inside such an
-  extent read 'no ambient frame', which is the truth."
+  extent read 'no ambient frame', which is the truth.
+
+  AND TIER 1 ANSWERS ONLY FOR THE EXTENT'S OWN FRAME (rf2-nqj22). When the
+  refusal names an `:extent-frame`, a carried stamp naming some OTHER frame
+  is not an ambient answer this extent will accept, and this reader says so
+  by answering nil — see [[carried-frame-admitted-by]]. THE CHECK BELONGS
+  HERE AND NOT ONLY IN `require-current-frame!`, which is not the single
+  funnel the catalogue describes it as: `subs/subscribe`'s 1-arity — the
+  framework's per-read path, and the very op HD-002 clause (a) is about —
+  inlines `(or (resolve-current-frame) (require-current-frame! …))` to keep
+  its error payload off the fast path (rf2-a8bw0), so a check living only in
+  the requiring primitive would have missed every ambient subscribe. Putting
+  it in the reader makes every reader-first caller correct by construction
+  and leaves that optimisation intact."
   []
   ;; Sticky hook — `:adapter/current-frame` is published
   ;; once per loaded React-shaped adapter at ns-load time and routed
@@ -687,14 +754,14 @@
   ;; byte-for-byte the one that was here before. When an extent HAS refused,
   ;; resolution collapses to the CARRIED tier alone, which is exactly the
   ;; `:clj` branch: the React-context tier is withdrawn, an explicit
-  ;; `with-frame` still answers.
-  (if (nil? *ambient-frame-refusal*)
+  ;; `with-frame` still answers — for the extent's OWN frame (rf2-nqj22).
+  (if-some [refusal *ambient-frame-refusal*]
+    (carried-frame-admitted-by refusal)
     (frame-value->id
       #?(:cljs (if-let [f (late-bind/get-fn-cached :adapter/current-frame)]
                  (f)
                  (current-frame))
-         :clj  (current-frame)))
-    (frame-value->id (current-frame))))
+         :clj  (current-frame)))))
 
 ;; ---- :rf.error/no-frame-context — the absence-is-the-corollary error ------
 ;;
@@ -842,29 +909,63 @@
   The substrate's own keys are merged in AFTER the frame, so `:substrate`,
   `:recovery` and any extra detail it carries reach the reader; its
   `:reason` is folded into the composed prose rather than replacing it, so
-  the payload always says both what happened and what to do instead."
+  the payload always says both what happened and what to do instead.
+
+  TWO REFUSALS, ONE ID, TWO SENTENCES (rf2-nqj22). `extra`'s
+  `:carried-frame` — set by [[require-current-frame!]] and by nothing else —
+  says which refusal this is. Absent: nothing was carried, the ambient FIND
+  was refused, and the prose is the one that has always been here. Present:
+  a stamp WAS carried and it names a frame other than the extent's
+  `:extent-frame`, so the composed sentence names BOTH frames and says why
+  a carried stamp lost for once — because the generic sentence's closing
+  promise (\"an explicitly carried frame still carries\") is precisely the
+  thing that just did not happen, and a diagnostic that says the opposite of
+  what occurred is worse than none."
   ([operation refusal] (ambient-frame-refused-payload operation refusal nil))
   ([operation refusal extra]
-   (merge {:rf.error/id :rf.error/ambient-frame-refused
-           :operation   operation
-           :recovery    :use-the-substrates-own-read-surface
-           :reason      (str "a frame-scoped " (name operation) " resolved its frame "
-                             "AMBIENTLY inside a render extent that refuses ambient "
-                             "frame resolution"
-                             (when-some [s (:substrate refusal)]
-                               (str " (" (name s) ")"))
-                             ". This is NOT an absence: a frame IS in scope here, so "
-                             "adding another frame boundary or a with-frame will not "
-                             "help. The extent refuses the AMBIENT reach specifically — "
-                             "an explicitly carried frame still carries, both as a "
-                             "{:frame <id>} option and through with-frame. "
-                             (:reason refusal default-ambient-refusal-reason))}
-          ;; Capture-site ancestry, exactly as `no-frame-context-payload`
-          ;; threads it — the refused op may sit under a captured callback.
-          (when-let [did (some-> trace/*handler-scope* :dispatch-id)]
-            {:rf.trace/dispatch-id did})
-          (dissoc refusal :reason)
-          extra)))
+   ;; The extent's frame is normalized to an id here and nowhere else: a
+   ;; substrate may declare a frame VALUE, and a payload — or worse, a
+   ;; sentence — carrying a whole frame map instead of `:app` is unreadable.
+   (let [extent-frame (frame-value->id (:extent-frame refusal))]
+     (merge {:rf.error/id :rf.error/ambient-frame-refused
+             :operation   operation
+             :recovery    :use-the-substrates-own-read-surface
+             :reason      (if-some [carried (:carried-frame extra)]
+                            (str "a frame-scoped " (name operation) " resolved its frame "
+                                 "AMBIENTLY inside a render extent that refuses ambient "
+                                 "frame resolution"
+                                 (when-some [s (:substrate refusal)]
+                                   (str " (" (name s) ")"))
+                                 ", and the stamp it found — " (pr-str carried)
+                                 " — is NOT the frame this extent is rendering ("
+                                 (pr-str extent-frame) "). A carried stamp "
+                                 "ordinarily wins, and everywhere it is the only frame in "
+                                 "play it still does; here it would put TWO frames in one "
+                                 "body — this " (name operation) " targeting " (pr-str carried)
+                                 " while the body's own reads, lowered intents and children "
+                                 "target " (pr-str extent-frame) " — and frames are "
+                                 "ISOLATED contexts. Carry the extent's own frame if that is "
+                                 "what you meant, or move the operation outside the render. "
+                                 (:reason refusal default-ambient-refusal-reason))
+                            (str "a frame-scoped " (name operation) " resolved its frame "
+                                 "AMBIENTLY inside a render extent that refuses ambient "
+                                 "frame resolution"
+                                 (when-some [s (:substrate refusal)]
+                                   (str " (" (name s) ")"))
+                                 ". This is NOT an absence: a frame IS in scope here, so "
+                                 "adding another frame boundary or a with-frame will not "
+                                 "help. The extent refuses the AMBIENT reach specifically — "
+                                 "an explicitly carried frame still carries, both as a "
+                                 "{:frame <id>} option and through a with-frame naming THIS "
+                                 "extent's own frame. "
+                                 (:reason refusal default-ambient-refusal-reason)))}
+            ;; Capture-site ancestry, exactly as `no-frame-context-payload`
+            ;; threads it — the refused op may sit under a captured callback.
+            (when-let [did (some-> trace/*handler-scope* :dispatch-id)]
+              {:rf.trace/dispatch-id did})
+            (dissoc refusal :reason :extent-frame)
+            (when (some? extent-frame) {:extent-frame extent-frame})
+            extra))))
 
 (defn emit-ambient-frame-refused!
   "Surface `:rf.error/ambient-frame-refused` through the always-on error axis
@@ -1003,13 +1104,37 @@
   ([[call-with-ambient-frame-refused]]), the mistake is not an absence and
   must not be reported as one: `:rf.error/ambient-frame-refused` is emitted
   and thrown instead, carrying the refusing substrate's own account of what
-  to write there. The discrimination costs nothing on the ordinary path —
-  it is read only after resolution has already failed."
+  to write there.
+
+  AND A MISMATCH IS A THIRD (rf2-nqj22). The reader now answers nil for one
+  more reason: inside an extent that declared its own `:extent-frame`, a
+  carried stamp naming a DIFFERENT frame is not an answer that extent will
+  accept, because the body would then read and dispatch against one frame
+  while its own reads, lowered intents and children target another. This
+  raises the same `:rf.error/ambient-frame-refused`, with the two frames
+  named on the payload so the author is not sent looking for the wrong one.
+  A MATCHED carried stamp still answers — refusing it would make `with-frame`
+  and `{:frame …}` disagree, which is strictly worse than the silence this
+  closes.
+
+  The discrimination costs the ordinary path nothing: it is read only after
+  resolution has already failed."
   ([operation] (require-current-frame! operation nil))
   ([operation extra]
    (or (resolve-current-frame)
        (if-some [refusal *ambient-frame-refusal*]
-         (let [payload (ambient-frame-refused-payload operation refusal extra)]
+         ;; Two refusals, one id. The reader answered nil either because
+         ;; nothing was carried at all (the ambient FIND was refused) or
+         ;; because what was carried is not this extent's frame — and only
+         ;; the second can name a stamp, so `:carried-frame` is what the
+         ;; payload builder discriminates on. Read here, on the failed path,
+         ;; rather than threaded down from the reader, so the ordinary
+         ;; resolution stays a single call returning a single value.
+         (let [payload (ambient-frame-refused-payload
+                         operation refusal
+                         (if-some [carried (frame-value->id (current-frame))]
+                           (assoc extra :carried-frame carried)
+                           extra))]
            (emit-ambient-frame-refused! payload)
            (throw (error/ex-info-from-data payload)))
          (let [payload (no-frame-context-payload operation extra)]

--- a/implementation/core/test/re_frame/frame_resolver_test.clj
+++ b/implementation/core/test/re_frame/frame_resolver_test.clj
@@ -237,6 +237,146 @@
           (is (= :rf/default (frame/require-current-frame! :subscribe))
               "and requiring it does not throw"))))))
 
+;; ---- the MISMATCH — a body has ONE frame, by construction (rf2-nqj22) -----
+;;
+;; The row above is the rule and stays the rule: a carried stamp wins inside
+;; a refused extent. These rows are its one exception, and it is opt-in — an
+;; extent that declares `:extent-frame` is saying "a body of mine has ONE
+;; frame", and core then refuses a carried stamp naming a DIFFERENT one.
+;; Without it, an `rf/with-frame :b` enclosing a boundary that renders `:a`
+;; leaves the body reading and dispatching against `:b` while its own reads,
+;; lowered intents and children target `:a` — two frames in one body, with no
+;; signal, which is the class the whole tier exists to delete.
+;;
+;; BOTH DIRECTIONS MATTER EQUALLY. A fix that refused a MATCHED carried stamp
+;; would make `with-frame` and `{:frame …}` disagree inside a body and would
+;; be strictly worse than the bug, so the matched case is asserted here as
+;; hard as the mismatched one.
+
+(deftest a-matched-carried-stamp-still-answers-inside-an-extent-that-names-its-frame
+  (testing "the EP-0002 behaviour, unchanged: the stamp names the frame the
+           extent is rendering, so there is no second frame and nothing to
+           be ambiguous about"
+    (frame/call-with-ambient-frame-refused
+      {:substrate :probe :extent-frame :app :reason "Use the probe's own reader."}
+      (fn []
+        (binding [frame/*current-frame* :app]
+          (is (= :app (frame/resolve-current-frame)))
+          (is (= :app (frame/require-current-frame! :subscribe))
+              "a matched carry is the one thing this change must not break"))))))
+
+(deftest a-mismatched-carried-stamp-is-refused
+  (testing "the stamp names a frame OTHER than the one the extent renders, so
+           the body would have two frames in it — an ambiguity, not a
+           carried-stamp win"
+    (is (= :rf.error/ambient-frame-refused
+           (refused-id #(frame/call-with-ambient-frame-refused
+                          {:substrate :probe :extent-frame :app
+                           :reason "Use the probe's own reader."}
+                          (fn []
+                            (binding [frame/*current-frame* :other]
+                              (frame/require-current-frame! :subscribe))))))
+        "the same id an ambient read gets — one refusal, two sentences")))
+
+(deftest the-mismatch-payload-names-both-frames
+  (testing "a diagnostic that cannot say WHICH two frames collided sends the
+           author looking for the wrong one"
+    (let [data (try (frame/call-with-ambient-frame-refused
+                      {:substrate :probe :extent-frame :app
+                       :reason "Use the probe's own reader."}
+                      (fn []
+                        (binding [frame/*current-frame* :other]
+                          (frame/require-current-frame! :capture-frame {:where 'probe/carry}))))
+                    (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+      (is (= :rf.error/ambient-frame-refused (:rf.error/id data)))
+      (is (= :other (:carried-frame data)) "the stamp that was carried")
+      (is (= :app (:extent-frame data)) "the frame the extent is rendering")
+      (is (= 'probe/carry (:where data)) "call-site detail still threads through")
+      (is (.contains ^String (:reason data) ":other"))
+      (is (.contains ^String (:reason data) ":app"))
+      (is (.contains ^String (:reason data) "ISOLATED contexts"))
+      (is (not (.contains ^String (:reason data) "an explicitly carried frame still carries"))
+          "the absence sentence's closing promise is precisely what did NOT
+           happen here; a payload that said it would be worse than none")
+      (is (.contains ^String (:reason data) "Use the probe's own reader.")
+          "and the substrate's own sentence is still carried verbatim"))))
+
+(deftest an-extent-that-names-no-frame-refuses-no-carried-stamp
+  (testing "the check is a declaration, not a policy core imposes: an extent
+           with no frame of its own has nothing to be mismatched against, so
+           the pre-rf2-nqj22 contract is exactly what it still gets"
+    (frame/call-with-ambient-frame-refused
+      {:substrate :probe :reason "Use the probe's own reader."}
+      (fn []
+        (binding [frame/*current-frame* :other]
+          (is (= :other (frame/require-current-frame! :subscribe))))))))
+
+(deftest the-reader-itself-answers-nil-for-a-mismatched-stamp
+  (testing "the check lives in `resolve-current-frame`, not only in
+           `require-current-frame!`, and that placement is load-bearing.
+           `require-current-frame!` is NOT the single funnel the catalogue
+           describes: `subs/subscribe`'s 1-arity — the framework's per-read
+           path, and the very op HD-002 clause (a) is about — inlines
+           `(or (resolve-current-frame) (require-current-frame! …))` to keep
+           its error payload off the fast path (rf2-a8bw0), so a check living
+           only in the requiring primitive would have let every ambient
+           subscribe through. Measured: it did"
+    (frame/call-with-ambient-frame-refused
+      {:substrate :probe :extent-frame :app :reason "Use the probe's own reader."}
+      (fn []
+        (binding [frame/*current-frame* :other]
+          (is (nil? (frame/resolve-current-frame))
+              "a stamp this extent will not accept is not an ambient answer"))
+        (binding [frame/*current-frame* :app]
+          (is (= :app (frame/resolve-current-frame))
+              "and the extent's own frame still is"))))))
+
+(deftest the-reader-first-subscribe-path-refuses-a-mismatched-stamp
+  (testing "the end-to-end consequence of the row above, taken through the
+           public surface that does the inlining rather than through the
+           primitive it inlines"
+    (rf/make-frame {:id :app})
+    (rf/reg-sub :probe/v (fn [db _] (:v db)))
+    (frame/replace-app-db! :app {:v 7})
+    (binding [frame/*current-frame* :app]
+      (is (= 7 @(rf/subscribe [:probe/v]))
+          "precondition: the ambient read works outside any refusal"))
+    (frame/call-with-ambient-frame-refused
+      {:substrate :probe :extent-frame :app :reason "Use the probe's own reader."}
+      (fn []
+        (binding [frame/*current-frame* :app]
+          (is (= 7 @(rf/subscribe [:probe/v]))
+              "a MATCHED carried stamp still reads inside the extent"))
+        (binding [frame/*current-frame* :other]
+          (is (= :rf.error/ambient-frame-refused
+                 (refused-id #(rf/subscribe [:probe/v])))
+              "and a mismatched one refuses instead of reading :other's db"))))
+    (rf/destroy-frame! :app)))
+
+(deftest the-mismatch-is-compared-by-value-not-by-reference
+  (testing "the two sides of the comparison need not be spelled the same way:
+           an extent may declare a frame VALUE (`make-frame`'s token) where
+           the reader has already normalized to an id, so both sides go
+           through `frame-value->id` first. A comparison written as a
+           reference test would pass here on the JVM — keywords are interned
+           — and silently never match on CLJS, so the CLJS half of this is
+           `arm1/ambient-refusal-cljs-test`"
+    (let [f (rf/make-frame {:id :valued})]
+      (frame/call-with-ambient-frame-refused
+        {:substrate :probe :extent-frame f :reason "Use the probe's own reader."}
+        (fn []
+          (binding [frame/*current-frame* :valued]
+            (is (= :valued (frame/require-current-frame! :subscribe))
+                "a declared frame VALUE normalizes to its id before comparing"))))
+      (frame/call-with-ambient-frame-refused
+        {:substrate :probe :extent-frame f :reason "Use the probe's own reader."}
+        (fn []
+          (binding [frame/*current-frame* :other]
+            (is (= :rf.error/ambient-frame-refused
+                   (refused-id #(frame/require-current-frame! :subscribe)))
+                "and a genuine mismatch against a declared VALUE still refuses"))))
+      (rf/destroy-frame! :valued))))
+
 (deftest the-refusal-is-fail-closed-and-unwinds
   (testing "a nil detail map still refuses — a fence that disarms because
            its argument was nil is the trap class the tier deletes"

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/ambient_refusal_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/ambient_refusal_cljs_test.cljs
@@ -44,6 +44,7 @@
   the refusal rather than a contract; the closing section below makes it
   one, together with each legitimate carry spelling proved individually."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
             [re-frame.adapter.context :as adapter-context]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.bench.hicasso.arm1.runtime :as rt]
@@ -447,3 +448,143 @@
       (is (= f (:frame @held)))
       ((:dispatch-sync @held) [:rt122/bump])
       (is (= 8 @(rf/subscribe [:rt122/v] {:frame f}))))))
+
+;; ---------------------------------------------------------------------------
+;; THE MISMATCH — a body has ONE frame, by construction (rf2-nqj22)
+;; ---------------------------------------------------------------------------
+;;
+;; The one configuration the refusal did not reach, and it is the silent
+;; wrong-frame class the whole tier exists to delete, surviving in a corner.
+;; `[[a-carried-with-frame-still-carries-inside-a-body]]` above stays green
+;; and must: that witness carries the SAME frame the boundary renders under,
+;; so there is only ever one frame in play and EP-0002 answers it. These rows
+;; are about the other case — an enclosing scope naming a DIFFERENT frame,
+;; where the body would read and dispatch against `:b` while the collector's
+;; reads, the lowered intents and the presence tray target `:a`.
+;;
+;; Reachable from any host that renders a Hicasso tree inside a scope: a
+;; `flushSync` mount under an `rf/with-frame`, an SSR host wrapping
+;; `renderToString`, a test fixture that root-binds an ambient frame. The SSR
+;; case is not hypothetical — `test-support`'s `:ambient-frame` default
+;; root-binds `*current-frame*` to `:rf/default`, so every witness in
+;; `ssr/entry-cljs-test` renders its per-request frame under a `:rf/default`
+;; stamp, and before this change a `(rf/capture-frame)` in one of those
+;; bodies answered `:rf/default`.
+
+(def ^:private other-frame-id ::rt122-other)
+
+(defn- make-other-frame!
+  "A SECOND live frame, so 'the carried stamp names a different frame' is a
+  real frame rather than a keyword nobody registered."
+  []
+  (live-frame/make-frame {:id other-frame-id})
+  (frame/replace-app-db! other-frame-id {:v 99})
+  other-frame-id)
+
+(deftest a-mismatched-carried-stamp-is-refused-inside-a-body
+  (testing "an enclosing `rf/with-frame` naming a frame the boundary is NOT
+           rendering. Core was behaving exactly as EP-0002 specifies — that
+           stamp WAS carried — but the body would then have two frames in it,
+           selected by which spelling the author reached for and with no
+           signal. Frames are ISOLATED contexts, so that is an ambiguity, not
+           a carried-stamp win"
+    (let [f     (make-frame!)
+          other (make-other-frame!)]
+      (with-context-frame f
+        (fn []
+          (let [data   (rf/with-frame other
+                         (outcome #(rt/render-body f (fn [_] (rf/capture-frame) [:li]) {})))
+                anchor (refusal-id f)]
+            (is (some? anchor)
+                "precondition: an ambient read refuses here at all, so the
+                 comparison below is not two nils agreeing")
+            (is (= anchor (:rf.error/id data))
+                (str "the mismatch is the SAME refusal, not a new id; got "
+                     (pr-str data)))
+            (is (= :capture-frame (:operation data)))
+            (is (= other (:carried-frame data))
+                "the payload names the stamp that was carried")
+            (is (= f (:extent-frame data))
+                "and the frame the boundary is actually rendering — a
+                 diagnostic that named only one of them would send the author
+                 looking for the wrong frame")))))))
+
+(deftest the-mismatch-refusal-reaches-every-ambient-door
+  (testing "it is the resolver's own funnel that refuses, so a read and a
+           dispatch meet it exactly as the carry does — there is no per-op
+           list to keep in step"
+    (let [f     (make-frame!)
+          other (make-other-frame!)]
+      (with-context-frame f
+        (fn []
+          (rf/with-frame other
+            (let [read     (outcome #(rt/render-body f (fn [_] @(rf/subscribe [:rt122/v]) [:li]) {}))
+                  dispatch (outcome #(rt/render-body f (fn [_] (rf/dispatch [:rt122/bump]) [:li]) {}))]
+              (is (= :subscribe (:operation read)))
+              (is (= other (:carried-frame read))
+                  (str "an ambient read under a mismatched scope refuses; got "
+                       (pr-str read)))
+              (is (= :dispatch (:operation dispatch)))
+              (is (= other (:carried-frame dispatch))
+                  (str "and so does an ambient dispatch; got " (pr-str dispatch))))))))))
+
+(deftest the-mismatch-refusal-says-which-two-frames-collided
+  (testing "the sentence has to be a DIFFERENT sentence. The refusal's
+           standing prose closes with `an explicitly carried frame still
+           carries` — which is precisely the thing that did not happen here,
+           so reusing it would tell the author the opposite of what occurred"
+    (let [f     (make-frame!)
+          other (make-other-frame!)]
+      (with-context-frame f
+        (fn []
+          (let [reason (:reason (rf/with-frame other
+                                  (outcome #(rt/render-body f (fn [_] (rf/capture-frame) [:li]) {}))))]
+            (is (string? reason))
+            (is (str/includes? reason (pr-str other)) "it names the carried stamp")
+            (is (str/includes? reason (pr-str f)) "and the extent's own frame")
+            (is (str/includes? reason "ISOLATED contexts")
+                "with the reason a carried stamp lost for once")
+            (is (not (str/includes? reason "an explicitly carried frame still carries"))
+                "and NOT the absence sentence's closing promise")
+            (is (str/includes? reason "(rf/capture-frame (h/frame))")
+                "the substrate's own advice is still carried verbatim")))))))
+
+(deftest a-matched-carried-stamp-is-what-makes-the-mismatch-row-mean-anything
+  (testing "the control. `[[a-carried-with-frame-still-carries-inside-a-body]]`
+           pins the matched carry through a subscription; this pins it through
+           the CARRY, one line away from the mismatch row above, so 'the
+           refusal is about the mismatch' is asserted rather than assumed. A
+           fix that refused a MATCHED stamp would make `with-frame` and
+           `{:frame id}` disagree inside a body — strictly worse than the
+           silence it replaces"
+    (let [f    (make-frame!)
+          held (volatile! nil)]
+      (with-context-frame f
+        (fn []
+          (rf/with-frame f
+            (rt/render-body f (fn [_] (vreset! held (rf/capture-frame)) [:li]) {}))))
+      (is (= f (:frame @held))
+          "the ambient carry still answers when the stamp IS the extent's frame")
+      ((:dispatch-sync @held) [:rt122/bump])
+      (is (= 8 @(rf/subscribe [:rt122/v] {:frame f}))
+          "and it carries all the way to a dispatch that lands"))))
+
+(deftest the-frames-are-compared-by-value-not-by-reference
+  (testing "THE CLJS HALF of the comparison contract. Keywords are interned
+           on the JVM and are NOT guaranteed reference-equal in
+           ClojureScript, so a comparison written as `identical?` would be
+           green in `frame-resolver-test` and silently never match here —
+           refusing every carried stamp, matched ones included. Pinned on the
+           host where it bites"
+    (let [f     (make-frame!)
+          built (keyword (namespace frame-id) (name frame-id))
+          held  (volatile! nil)]
+      (is (= built f) "precondition: equal as values")
+      (is (not (identical? built f))
+          "and NOT the same object — which is what makes this row a test")
+      (with-context-frame f
+        (fn []
+          (rf/with-frame built
+            (rt/render-body f (fn [_] (vreset! held (rf/capture-frame)) [:li]) {}))))
+      (is (= f (:frame @held))
+          "a stamp equal to the extent's frame is the extent's frame"))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/hframe_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/hframe_cljs_test.cljs
@@ -280,46 +280,51 @@
             "frames are isolated contexts — the sibling must not have moved")))))
 
 ;; ---------------------------------------------------------------------------
-;; The one configuration where the ambient carry still answers — and
-;; answers the WRONG frame
+;; The configuration where the ambient carry used to answer the WRONG frame
 ;; ---------------------------------------------------------------------------
 
-(deftest a-carried-outer-scope-makes-the-ambient-carry-answer-the-wrong-frame
+(deftest a-carried-outer-scope-refuses-rather-than-answering-the-wrong-frame
   (frames!)
-  (testing "FOUND while grounding the SSR rows, and pinned because it is
-           the residual case the whole primitive is for. rf2-2rtt6.122's
-           refusal withdraws the ambient FIND and never the CARRYING, so a
-           tier-1 stamp — an enclosing `rf/with-frame` — still answers
-           inside a body. Core is behaving exactly as EP-0002 specifies:
-           frame identity is carried, and that stamp WAS carried.
+  (testing "FOUND while grounding the SSR rows and pinned as a DEFECT
+           (rf2-nqj22); this row is its inversion, not a new claim.
+           rf2-2rtt6.122's refusal withdrew the ambient FIND and never the
+           CARRYING, so a tier-1 stamp — an enclosing `rf/with-frame` — still
+           answered inside a body. Core was behaving exactly as EP-0002
+           specifies: frame identity is carried, and that stamp WAS carried.
 
-           But the boundary is rendering under a different frame, and
-           everything else in the body targets THAT one: the collector's
-           reads, the lowered intents, the presence tray. So one body ends
-           up with two frames depending on which spelling the author
-           reached for, and the ambient one is silently the outer scope's.
+           But the boundary renders a different frame, and everything else in
+           the body targets THAT one: the collector's reads, the lowered
+           intents, the presence tray. One body, two frames, chosen by which
+           spelling the author reached for, and silent. Frames are ISOLATED
+           contexts, so the extent now declares its own frame to core and a
+           mismatched stamp refuses instead of quietly winning.
 
-           `(rf/capture-frame (h/frame))` is immune, because `h/frame`
-           reads the boundary's own binding. Behaviour is PINNED here, not
-           endorsed — whether the refusal should also withdraw a MISMATCHED
-           carried stamp inside a substrate render extent is a design
-           question filed separately (rf2-nqj22)"
+           `h/frame` and the composed carry are unchanged — they read the
+           boundary's own binding and never enter core's chain at all, which
+           is exactly what the primitive is for. The refusal's own rows live
+           with their siblings in `arm1/ambient_refusal_cljs_test`"
     (let [seen (volatile! ::unset)]
       (rf/with-frame frame-b
         (rt/render-body frame-a
                         (fn [_]
-                          (vreset! seen {:ambient  (rf/capture-frame)
+                          (vreset! seen {:ambient  (outcome #(rf/capture-frame))
                                          :composed (rf/capture-frame (intent/hframe))
                                          :hframe   (intent/hframe)})
                           [:li])
                         {}))
-      (is (= frame-b (:frame (:ambient @seen)))
-          "the ambient carry answered the ENCLOSING scope, not the boundary")
+      (is (= :rf.error/ambient-frame-refused (:rf.error/id (:ambient @seen)))
+          (str "the ambient carry must refuse rather than answer the ENCLOSING
+                scope; got " (pr-str (:ambient @seen))))
+      (is (= frame-b (:carried-frame (:ambient @seen)))
+          "naming the stamp that was carried")
+      (is (= frame-a (:extent-frame (:ambient @seen)))
+          "and the frame the boundary is rendering")
       (is (= frame-a (:hframe @seen))
           "while the boundary is unambiguously rendering under its own frame")
       (is (= frame-a (:frame (:composed @seen)))
           "and the composed spelling carries the boundary's — which is the
-           whole of what `h/frame` buys here"))))
+           whole of what `h/frame` buys here, and is the spelling that was
+           already correct before the refusal reached this case"))))
 
 ;; ---------------------------------------------------------------------------
 ;; W9 — an event-time read is not silently wrong

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
@@ -273,7 +273,11 @@
 
 (def ^:private ambient-frame-refusal
   "The detail this arm hands core's refusal tier (rf2-2rtt6.122). One
-  module-level constant, so establishing the extent allocates nothing.
+  module-level constant, so the prose — which is nearly all of it — is
+  built once at load and never per body. [[with-frame]] stamps the
+  rendering boundary's own frame onto a copy of it (rf2-nqj22); that
+  `assoc` is the whole per-extent cost, and it buys the one property a
+  shared constant cannot express: which frame THIS body has.
 
   The sentence has to be the one an author can act on, because the whole
   point of the tier is that the generic `:rf.error/no-frame-context` advice
@@ -337,13 +341,30 @@
 
   An explicitly carried frame is untouched, in this extent as everywhere:
   `{:frame <id>}` never consults the ambient resolver, and `rf/with-frame`
-  inside a body still answers. The refusal deletes the ambient FIND, not
-  the carrying."
+  naming THIS boundary's frame still answers inside a body. The refusal
+  deletes the ambient FIND, not the carrying.
+
+  A BODY HAS ONE FRAME, AND NOW BY CONSTRUCTION (rf2-nqj22). The one thing
+  the sentence above did not cover: an `rf/with-frame :b` ENCLOSING a
+  boundary that renders `:a`. Core was behaving exactly as EP-0002 says —
+  `:b` was carried, so `:b` answered — but the boundary is rendering `:a`,
+  and the collector's reads, the lowered intents and the presence tray all
+  target `:a`. One body, two frames, chosen by which spelling the author
+  reached for, and silent. It is reachable from any host that renders a
+  Hicasso tree inside a scope: a `flushSync` mount under a `with-frame`, an
+  SSR host wrapping `renderToString`, a test fixture that root-binds an
+  ambient frame. So this extent tells core WHICH frame it is rendering
+  (`:extent-frame`) and core refuses a carried stamp that names another —
+  the only carry that stops working is the one that was already wrong.
+  The 2-arity names no frame, so it declares none and nothing is refused
+  there: an extent with no frame of its own has nothing to be mismatched
+  against."
   ([dispatch body-fn] (with-frame nil dispatch body-fn))
   ([frame-kw dispatch body-fn]
    (binding [*frame*                       frame-kw
              *dispatch*                    dispatch
-             frame/*ambient-frame-refusal* ambient-frame-refusal]
+             frame/*ambient-frame-refusal* (cond-> ambient-frame-refusal
+                                             frame-kw (assoc :extent-frame frame-kw))]
      (body-fn))))
 
 (defn- fail! [id where reason recovery extra]

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry_cljs_test.cljs
@@ -22,6 +22,7 @@
             [re-frame.bench.hicasso.arm1.runtime :as rt]
             [re-frame.bench.hicasso.front.codec :as codec]
             [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.bench.hicasso.front.intent :as intent]
             [re-frame.bench.hicasso.ssr.entry :as entry]
             [re-frame.bench.hicasso.ssr.fixtures :as fixtures]
             [re-frame.core :as rf]
@@ -29,7 +30,9 @@
             ;; rf2-2rtt6.91 — the entry no longer computes a render hash, so
             ;; the row that keeps the measurement live takes it DIRECTLY.
             [re-frame.ssr.hash :as ssr-hash]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as frame]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 ;; The adapter is UIx's for the reason `arm1/runtime_cljs_test` gives: it
 ;; is the substrate with a real reactivity layer, and Spec 006 allows
@@ -425,3 +428,54 @@
             (str id " stamped a render-hash marker on an adoption-tier root"))
         (is (not (contains? payload :rf/render-hash))
             (str id " shipped :rf/render-hash in an adoption-tier payload"))))))
+
+;; ---------------------------------------------------------------------------
+;; The host scope does not leak into a per-request body (rf2-nqj22)
+;; ---------------------------------------------------------------------------
+;;
+;; THIS FILE IS WHERE THE DEFECT WAS FOUND, which is the only reason the row
+;; lives here rather than beside its siblings in
+;; `arm1/ambient_refusal_cljs_test`. `test-support`'s `:ambient-frame` default
+;; root-binds `*current-frame*` to `:rf/default`, and the fixture above takes
+;; that default — so every witness in this file renders its per-request frame
+;; inside a `:rf/default` stamp. Measured on the tree before the fix: a
+;; `(rf/capture-frame)` in a body under `renderToString` answered
+;; `:rf/default`, while `h/frame` in the same body answered the per-request
+;; frame the markup was actually built from. An SSR host is the worst place
+;; for that: the wrong frame is a long-lived process-wide one, and what it
+;; would carry away is a closure that outlives the request.
+
+(def ^:private scope-probe-seen (volatile! ::unset))
+
+(defview scope-probe
+  "A body that reaches for the ambient frame three ways, so the row can say
+  which of them the host's outer scope reached."
+  [_]
+  (vreset! scope-probe-seen
+           {:ambient  (try (rf/capture-frame)
+                           (catch :default e (ex-data e)))
+            :composed (:frame (rf/capture-frame (intent/hframe)))
+            :hframe   (intent/hframe)})
+  [:p.scope-probe "probe"])
+
+(deftest the-hosts-ambient-scope-does-not-answer-inside-a-per-request-body
+  (testing "the render entry mints a per-request frame and renders under it,
+           inside whatever scope the host happens to have established — here
+           the fixture's `:rf/default`. A body that resolves ambiently must
+           not silently answer the host's frame"
+    (is (= :rf/default frame/*current-frame*)
+        "precondition: the fixture's ambient scope IS live, so a green row
+         below is the refusal working rather than nothing to refuse")
+    (let [{:keys [frame-id html]} (entry/render {:hiccup  [scope-probe {}]
+                                                 :payload fixtures/dogfood-payload-keys})
+          {:keys [ambient composed hframe]} @scope-probe-seen]
+      (is (str/includes? html "scope-probe") "the body ran under renderToString")
+      (is (not= :rf/default frame-id)
+          "precondition: the per-request frame is not the host's")
+      (is (= frame-id hframe) "the boundary renders the per-request frame")
+      (is (= frame-id composed) "and the composed carry has always been immune")
+      (is (= :rf.error/ambient-frame-refused (:rf.error/id ambient))
+          (str "the ambient carry must refuse rather than answer the host's
+                scope; got " (pr-str ambient)))
+      (is (= :rf/default (:carried-frame ambient)))
+      (is (= frame-id (:extent-frame ambient))))))


### PR DESCRIPTION
Closes rf2-nqj22.

## The defect

An enclosing `rf/with-frame :b` around a Hicasso boundary rendering `:a` made the ambient carry answer `:b` inside the body:

```clojure
(rf/with-frame :b
  (render a boundary whose frame is :a
    (rf/capture-frame)))      ;; => captured :b, silently
```

Core was behaving exactly as EP-0002 specifies — `:b` WAS carried — but everything else in that body targets `:a`: the collector's reads, the lowered intents, the presence tray. One body, two frames, chosen by which spelling the author reached for, with no diagnostic.

**Reproduced before changing anything**, twice:

1. `arm1/hframe-cljs-test/a-carried-outer-scope-makes-the-ambient-carry-answer-the-wrong-frame` was green on unmodified `main` (25 tests / 76 assertions across the two arm1 suites, exit 0) — the behaviour was pinned, not endorsed.
2. **Live under `renderToString`.** A temporary probe added to `ssr/entry-cljs-test` on unmodified `main` and then reverted: `test-support`'s `:ambient-frame` default root-binds `*current-frame*` to `:rf/default`, the SSR entry mints a per-request frame, and a `(rf/capture-frame)` in a body rendered by `entry/render` answered `:rf/default` while `(h/frame)` in the same body answered the per-request frame. Green as an assertion of the defect: 18 tests / 141 assertions, exit 0. That probe is now a permanent inverted witness (`the-hosts-ambient-scope-does-not-answer-inside-a-per-request-body`).

## The ruling — option (b), and the alternatives it rejected

**(b) REFUSE A MISMATCHED CARRIED STAMP INSIDE A SUBSTRATE RENDER EXTENT.** The refusal detail carries the extent's own frame (`:extent-frame`), and a carried stamp naming a different one refuses. This makes "a body has ONE frame" true by construction rather than by convention, and it costs a comparison on a path that is already inside an extent refusing ambient reads.

**Rejected — (a) leave it.** "A carried stamp wins" is EP-0002's point and stays the rule everywhere a carried stamp is the only frame in play. But the standing principle that frames are ISOLATED CONTEXTS — subs must not reach into other frames — makes two frames in one body an ambiguity rather than a carried-stamp win, and (a) blesses it. The failure is silent and has already happened.

**Rejected — (c) diagnose only.** A dev-time warning elides in release builds, so the silent wrong-frame read would survive exactly where it is least recoverable. The refusal rides the always-on error axis for the same reason its sibling does.

## The acceptance check the ruling turned on

`a-carried-with-frame-still-carries-inside-a-body` pins that an explicit `with-frame` answers inside a body. The bead reasoned it stays green because that witness carries the SAME frame the boundary renders under, so nothing mismatches. **Run, not assumed** — green under the fix, in isolation:

```
$ node out/node-test.js --test=re-frame.bench.hicasso.arm1.ambient-refusal-cljs-test/a-carried-with-frame-still-carries-inside-a-body
Ran 1 tests containing 1 assertions.
0 failures, 0 errors.
```

It was not weakened; the diff does not touch it.

## The finding that changed where the fix goes

The ruling says "`require-current-frame!` raises when tier 1 answers something else". Implemented literally, that misses the most important op. **`require-current-frame!` is not the single funnel the Spec 009 catalogue row describes it as**: `subs/subscribe`'s 1-arity inlines `(or (frame/resolve-current-frame) (frame/require-current-frame! …))` so its error payload is built only on the path that reads it (rf2-a8bw0, whose comment says "Do NOT collapse this back"). An ambient subscribe inside a body therefore never reaches the requiring primitive when a stamp is carried — and an ambient subscribe is precisely what HD-002 clause (a) is about.

Measured, not reasoned: the first implementation put the check in `require-current-frame!` only, and `the-mismatch-refusal-reaches-every-ambient-door` went red on the subscribe arm with the read silently succeeding.

So the check lives in `resolve-current-frame` — the reader answers **nil** for a stamp the extent will not accept, which is the same shape the tier already uses for the withdrawn tier 2, and which makes every reader-first caller correct by construction while leaving the fast-path optimisation intact. `require-current-frame!` keeps its original `(or (resolve-current-frame) …)` shape and only reads `(current-frame)` on the already-failed path, to name the carried stamp on the payload.

## What is deliberately NOT closed

- `{:frame <id>}` inside a body still targets that frame. It never consults the resolver, it is an explicit act at the call site, and `an-explicit-frame-option-still-resolves-inside-a-body` still pins it.
- An extent that declares no `:extent-frame` (the arm's 2-arity `with-frame`) has nothing to be mismatched against and keeps the pre-change contract exactly.
- `(rf/capture-frame (h/frame))` was immune under every option and is unchanged.

## Scope kept

The provisional `:rf.error/ambient-frame-refused` spelling is untouched (rf2-k0rbk, closed) and the substrate's advice text is untouched (rf2-hnrww, closed) — the mismatch gets a second **core-composed** sentence because the standing one closes with "an explicitly carried frame still carries", which is precisely what did not happen; a payload asserting it would be worse than none.

**Spec obligation NOT discharged here, and it needs a follow-up:** `spec/009-Instrumentation.md`'s `:rf.error/ambient-frame-refused` row should gain `:extent-frame` / `:carried-frame` and lose the claim that every ambient resolution goes through `require-current-frame!`. `spec/009` is fenced to another worker this session, so nothing in `spec/` is touched by this PR.

## Quality gates

| Gate | Result |
|---|---|
| `implementation/core` JVM — `clojure -M:test` | **Ran 2231 tests containing 11584 assertions. 0 failures, 0 errors.** exit `0` |
| CLJS focused — `node out/node-test.js --test=arm1.hframe-cljs-test,arm1.ambient-refusal-cljs-test,ssr.entry-cljs-test` | **Ran 48 tests containing 241 assertions. 0 failures, 0 errors.** exit `0` |
| CLJS acceptance witness, isolated | **Ran 1 tests containing 1 assertions. 0 failures, 0 errors.** exit `0` |
| `npm run test:cljs` (full CLJS lane) | see comment below |
| `sh scripts/test-fast-pr.sh` | see comment below |

Full-lane results, the both-direction mutation proofs on both hosts, and every exit code are posted as a follow-up comment on this PR.
