### PR TITLE
spec(schemas): type the three remaining :where slots as :symbol (rf2-am6qs)

### DIFF
--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -1453,6 +1453,128 @@
                  "`:any` slot — this is the blindness the tightening removes. If "
                  "this assertion fails the control is wrong, not the fix."))))))
 
+;; --- the remaining `:where` slots (rf2-am6qs) --------------------------------
+;;
+;; rf2-j4bg3 typed ONE slot; three others were left declaring `:where` as
+;; `:any`, and the blindness argued above is a property of the DECLARATION, not
+;; of the category — so each of the three had the same nothing standing between
+;; its payload and an arbitrary object. Each type below is a reading of that
+;; slot's own producers, taken separately (the answer does not transfer just
+;; because rf2-j4bg3 found symbols):
+;;
+;;   FrameDestroyedTags — ONE producer. Only
+;;     `substrate/observation/throw-frame-destroyed!` stamps `:where`; its three
+;;     call sites pass `'re-frame.substrate.observation/acquire!` (twice) and
+;;     `'re-frame.substrate.observation/probe`. The other three emitters of this
+;;     category (router, subs, ui/frames) never stamp the slot at all.
+;;
+;;   BadFrameProviderArgTags — the SHARP one, and why the bead was filed rather
+;;     than left. `frame/require-frame-provider-target!` threads ONE `where`
+;;     argument into BOTH payloads: the nil branch builds `no-frame-context`
+;;     (typed `:symbol` by rf2-j4bg3) and the else branch builds this one. Until
+;;     this change a single argument from a single call site carried two
+;;     different declared types. Nine src call sites, all quoted fn symbols
+;;     (`'re-frame.views.provider/frame-provider`,
+;;     `'re-frame.adapter.uix/frame-provider`,
+;;     `'re-frame.substrate.spine/build-frame-provider-element`,
+;;     `'re-frame.freehand.substrate/frame-provider`, `'v/->react`,
+;;     `'re-frame.ui/frame-provider`, `'re-frame.ui/frame`,
+;;     `'re-frame.ui/->react`), plus `'test/where` / `'test` in test.
+;;
+;;   ResourceSsrBlockingTimeoutTags — ONE producer, one emit:
+;;     `re-frame.resources.ssr/settle-blocking-timeout` stamps its own quoted
+;;     name, which is also the literal the 009 catalogue row prints.
+;;
+;; No producer of any of the three emits a keyword, and the keyword mutant is
+;; the one that matters: OTHER categories genuinely carry a keyword `:where`
+;; (`:where :event`, `:where :flow-eval`, `:where :reactive`), so `:any` here
+;; admitted a spelling that is right elsewhere in the same corpus.
+
+(def ^:private where-type-mutants
+  "The type mutants an `:any` `:where` declaration silently accepted. Shared
+  with `no-frame-context-where-mutants` in intent; kept separate so tightening
+  one slot's mutant set cannot quietly weaken another's."
+  {"a string"       "re-frame.substrate.observation/probe"
+   "a number"       42
+   "a map"          {:ns 're-frame.substrate :name 'probe}
+   "a bare keyword" :probe})
+
+(def ^:private typed-where-slots
+  "The three slots rf2-am6qs tightened, each with a MINIMAL payload that
+  satisfies the schema's required slots — so the only thing an assertion below
+  can be reading is the `:where` type."
+  [{:schema   "FrameDestroyedTags"
+    :producer 're-frame.substrate.observation/probe
+    :base     {:category :rf.error/frame-destroyed
+               :frame    :app}}
+   {:schema   "BadFrameProviderArgTags"
+    :producer 're-frame.views.provider/frame-provider
+    :base     {:category :rf.error/bad-frame-provider-arg
+               :received "app"}}
+   {:schema   "ResourceSsrBlockingTimeoutTags"
+    :producer 're-frame.resources.ssr/settle-blocking-timeout
+    :base     {:category  :rf.error/resource-ssr-blocking-timeout
+               :timed-out [[:rf/scoped-resource-key :user]]
+               :limit-ms  250
+               :reason    "1 blocking SSR resource(s) did not settle"}}])
+
+(deftest remaining-tag-where-slots-are-typed-not-any
+  (testing "each slot declares `:where` as `:symbol`, and the declaration is
+            load-bearing: the keys-set arm cannot see a type, so these are the
+            only assertions that read one."
+    (doseq [{:keys [schema]} typed-where-slots]
+      (let [form  (tags-schema-form schema)
+            entry (->> (rest form)
+                       (filter #(and (vector? %) (= :where (first %))))
+                       first)]
+        (is (some? form) (str schema " parsed out of Spec-Schemas.md"))
+        (is (some? entry) (str schema " declares a `:where` entry"))
+        (is (= :symbol (last entry))
+            (str "`" schema "` must declare `:where` as `:symbol` — every "
+                 "producer emits a quoted symbol, and `:any` here enforces "
+                 "nothing because the Tags-column arm diffs keys only. Found: "
+                 (pr-str entry)))
+        (is (= {:optional true} (second entry))
+            (str "`" schema "`'s `:where` stays OPTIONAL — the type was wrong, "
+                 "not the arity. Found: " (pr-str entry))))))
+
+  (testing "each slot's REAL producer value validates, and the slot may be
+            omitted — so the tightening did not outrun the corpus."
+    (doseq [{:keys [schema producer base]} typed-where-slots]
+      (let [form (tags-schema-form schema)]
+        (is (malli/validate form (assoc base :where producer))
+            (str schema ": the symbol its producer actually emits ("
+                 (pr-str producer) ") validates"))
+        (is (malli/validate form base)
+            (str schema ": `:where` omitted validates — the slot is optional")))))
+
+  (testing "THE MUTATION WITNESS, one control per slot. Each mutant is REJECTED
+            by the shipped `:symbol` slot and ACCEPTED by the `:any` slot it
+            replaced, so the tightening — not some unrelated required-slot
+            guard — is what rejects it. Without the second half a slot that
+            rejected EVERYTHING would pass."
+    (doseq [{:keys [schema base]} typed-where-slots]
+      (let [shipped (tags-schema-form schema)
+            ;; This slot's OWN `:any` control, rebuilt from its OWN shipped
+            ;; schema so the two differ in exactly one token.
+            as-any  (mapv (fn [e]
+                            (if (and (vector? e) (= :where (first e)))
+                              [:where {:optional true} :any]
+                              e))
+                          shipped)]
+        (is (not= shipped as-any)
+            (str schema ": the `:any` control really differs from the shipped "
+                 "schema"))
+        (doseq [[label v] where-type-mutants]
+          (is (not (malli/validate shipped (assoc base :where v)))
+              (str schema ": `:where` = " label " (" (pr-str v) ") must be "
+                   "REJECTED by the shipped `:symbol` slot"))
+          (is (malli/validate as-any (assoc base :where v))
+              (str schema ": `:where` = " label " (" (pr-str v) ") was ACCEPTED "
+                   "by the old `:any` slot — this is the blindness the "
+                   "tightening removes. If this assertion fails the control is "
+                   "wrong, not the fix.")))))))
+
 ;; --- non-vacuity ------------------------------------------------------------
 ;;
 ;; An arm that cannot red on the defect that motivated it has not been tested,

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -1298,6 +1298,18 @@ A schema and its catalogue row are **co-edited**, and a conformance test holds t
   ;; replace
   ;; any `:event` slot with `:rf/redacted` / `:rf.size/large-elided` on egress.
   ;; Declaring a vector there would be a claim the runtime does not honour.
+  ;;
+  ;; `:where` is a SYMBOL, and — unlike `:event` — the tight type is honoured.
+  ;; The slot has exactly ONE producer (the ownership table above):
+  ;; `substrate/observation/throw-frame-destroyed!`, whose three call sites all
+  ;; pass a quoted fn symbol (`'re-frame.substrate.observation/acquire!` twice,
+  ;; `'re-frame.substrate.observation/probe` once). The three emitters that do
+  ;; NOT stamp `:where` — router, subs and ui/frames — cannot widen it. It is
+  ;; typed `:symbol` rather than `:any` for the reason rf2-j4bg3 established on
+  ;; `NoFrameContextTags`: the catalogue conformance gate diffs KEY SETS only,
+  ;; so the declared type is the sole thing standing between this payload and a
+  ;; string, number or arbitrary object at `:where`. OPTIONAL because three of
+  ;; the four emitters omit it.
   [:map
    [:category       :keyword]
    [:frame          :keyword]
@@ -1305,7 +1317,7 @@ A schema and its catalogue row are **co-edited**, and a conformance test holds t
    [:event          {:optional true} :any]
    [:query-v        {:optional true} [:vector :any]]
    [:reason         {:optional true} :keyword]
-   [:where          {:optional true} :any]
+   [:where          {:optional true} :symbol]
    [:rf.sub/id      {:optional true} :any]
    [:rf.sub/query-v {:optional true} [:vector :any]]])
 
@@ -1357,10 +1369,27 @@ A schema and its catalogue row are **co-edited**, and a conformance test holds t
   ;; usable `:frame` — the supplied target is the invalid value). `:where` is
   ;; the validating provider call site (a symbol).
   ;; Per the 009 error catalogue row and [002 §Frame target resolution].
+  ;;
+  ;; `:where` is TYPED `:symbol`, and the disagreement it closes is the sharp
+  ;; one rf2-am6qs was filed for: `frame/require-frame-provider-target!` threads
+  ;; ONE `where` argument into BOTH payloads — the nil branch builds
+  ;; `no-frame-context` (typed `:symbol` by rf2-j4bg3) and the else branch builds
+  ;; THIS one — so leaving it `:any` had a single argument from a single call
+  ;; site carrying two different declared types. Every producer emits a quoted
+  ;; fn symbol: `'re-frame.views.provider/frame-provider`,
+  ;; `'re-frame.adapter.uix/frame-provider`,
+  ;; `'re-frame.substrate.spine/build-frame-provider-element`,
+  ;; `'re-frame.freehand.substrate/frame-provider`, `'v/->react`,
+  ;; `'re-frame.ui/frame-provider`, `'re-frame.ui/frame`, `'re-frame.ui/->react`
+  ;; (the last three arriving through `re-frame.ui.frames`' `require-scope-frame!`
+  ;; and `resolve-frame`), plus `'test/where` / `'test` in test. There is no
+  ;; keyword, string or map producer in src or in test. The type carries the
+  ;; contract alone: the catalogue conformance gate diffs KEY SETS only, so
+  ;; `:any` here enforced nothing while reading as though it did.
   [:map
    [:category :keyword]                              ;; [:= :rf.error/bad-frame-provider-arg] in a closed schema
    [:received :any]                                  ;; the offending value (neither keyword nor frame value)
-   [:where    {:optional true} :any]                 ;; the validating provider call site (symbol)
+   [:where    {:optional true} :symbol]              ;; the validating provider call site, a SYMBOL
    [:reason   {:optional true} :string]])
 
 (def EffectMapShapeTags
@@ -1727,9 +1756,18 @@ A schema and its catalogue row are **co-edited**, and a conformance test holds t
   ;; settled as a structured first-load failure so the request never hangs
   ;; (Spec 016 §SSR and hydration — blocking timeout policy). A server-side
   ;; (JVM) trace, not a thrown ex-info — the render continues.
+  ;;
+  ;; `:where` is a SYMBOL. The slot has exactly one producer — the single
+  ;; `trace/emit-error!` inside `re-frame.resources.ssr/settle-blocking-timeout`,
+  ;; which stamps the quoted fn symbol
+  ;; `'re-frame.resources.ssr/settle-blocking-timeout` — and the 009 catalogue
+  ;; row names that same value. It is typed rather than `:any` for the reason
+  ;; rf2-j4bg3 established: the catalogue conformance gate diffs KEY SETS only,
+  ;; so a slot left `:any` is not weakly enforced but UNENFORCED. The slot stays
+  ;; OPTIONAL — the type is what was wrong, not the arity.
   [:map
    [:category  :keyword]
-   [:where     {:optional true} :any]
+   [:where     {:optional true} :symbol]
    [:frame     {:optional true} :any]
    [:timed-out [:vector :any]]        ;; the scoped resource keys that timed out
    [:limit-ms  :int]                  ;; the render deadline (ms)


### PR DESCRIPTION
Closes rf2-am6qs.

## What

`FrameDestroyedTags`, `BadFrameProviderArgTags` and `ResourceSsrBlockingTimeoutTags` declared `:where` as `:any`. rf2-j4bg3 (#7603) established why that is not a harmless looseness: the catalogue conformance gate's Tags-column arm compares **KEY SETS ONLY** (`schema-map-keys` keeps entry keys and discards every declared type), so a slot declared `:any` is not weakly enforced — it is **unenforced**. A string, a number, a map and a bare keyword all validate with no gate anywhere disagreeing. The declared type is the only thing between the payload and an arbitrary object.

All three are now `:symbol`, each read off **its own** producers rather than by inheriting rf2-j4bg3's answer.

## Producer census, per slot

**`FrameDestroyedTags`** — one producer. The category has four emitters (router, subs, ui/frames, observation port) but only `re-frame.substrate.observation/throw-frame-destroyed!` stamps `:where` (the per-slot ownership table in the schema's own comment says so, and reading the other three confirms it — they stamp `:event` / `:query-v` / `:op` / `:reason` and never `:where`). Its three call sites:

| site | value |
|---|---|
| `core/substrate/observation.cljc:1117` | `'re-frame.substrate.observation/acquire!` |
| `core/substrate/observation.cljc:1670` | `'re-frame.substrate.observation/probe` |
| `core/substrate/observation.cljc:2141` | `'re-frame.substrate.observation/acquire!` |

**`BadFrameProviderArgTags`** — the sharp one, and the reason the bead was filed rather than left. `frame/require-frame-provider-target!` threads **one** `where` argument into **both** payloads: the nil branch builds `no-frame-context` (typed `:symbol` by #7603) and the else branch builds this one. Until this change a single argument from a single call site carried two different declared types. Nine src call sites, all quoted fn symbols:

| site | value |
|---|---|
| `core/views/provider.cljs:161` | `'re-frame.views.provider/frame-provider` |
| `core/substrate/spine.cljs:1708` | `'re-frame.substrate.spine/build-frame-provider-element` |
| `adapters/uix/…/adapter/uix.cljs:102` | `'re-frame.adapter.uix/frame-provider` |
| `freehand/substrate.cljs:148` | `'re-frame.freehand.substrate/frame-provider` |
| `freehand/to_react.cljs:272` | `'v/->react` |
| `ui/substrate.cljs:96` | `'re-frame.ui/frame-provider` |
| `ui/frames.cljc:1465`, `:1514` (via `require-scope-frame!`) | `'re-frame.ui/frame-provider` |
| `ui/frames.cljc:1436` (via `resolve-frame`) | `'re-frame.ui/frame` |
| `ui/frames.cljc:1489` | `'re-frame.ui/->react` |

Plus `'test/where` (`core/test/…/frame_lifecycle_test.clj`) and `'test` (`ui/test/…/preflight_frame_wiring_cljs_test.cljs`).

**`ResourceSsrBlockingTimeoutTags`** — one producer, one emit: `re-frame.resources.ssr/settle-blocking-timeout` (`resources/src/re_frame/resources/ssr.cljc:1114`) stamps its own quoted name, which is also the literal the 009 catalogue row prints.

**No keyword, string or map producer in src or in test, for any of the three.** The keyword mutant is the one that matters: other categories genuinely carry a keyword `:where` (`:where :event`, `:where :flow-eval`, `:where :app-db`, `:where :reactive` / `:compute-sub`), so `:any` here admitted a spelling that is correct elsewhere in the same corpus. After this change **no `:where` slot in `spec/Spec-Schemas.md` is declared `:any`** — the thirteen are now `:enum` ×5, `:symbol` ×4, `:keyword` ×1, `[:or :symbol :string]` ×2, and one `[:enum …]` pair.

Optionality is unchanged on all three — the type was wrong, not the arity.

## The witness

`remaining-tag-where-slots-are-typed-not-any`, driving all three slots off a table. A key-level witness would prove nothing here (the keys arm is type-blind by construction), so each slot gets:

1. a declaration assertion — `:symbol`, still `{:optional true}`;
2. an acceptance assertion — the symbol its producer **actually emits** validates, and the slot may be omitted, so the tightening did not outrun the corpus;
3. **the mutation witness with its own control.** Four type mutants (a string, a number, a map, a bare keyword) must each be **rejected** by the shipped `:symbol` slot **and accepted** by the `:any` slot it replaced. The `:any` control is rebuilt from that slot's **own** shipped schema so the two differ in exactly one token. Without the second half a slot that rejected everything would pass.

**Mutation-proved, not merely asserted.** Reverting `BadFrameProviderArgTags`' slot to `:any` and re-running the namespace turns it red — 6 failures, including all four `must be REJECTED by the shipped :symbol slot` arms. Restored, green again. Each slot's base payload is minimal (only the schema's required slots), so the only thing an assertion can be reading is the `:where` type.

## Not touched

`spec/009-Instrumentation.md` — no row disagrees, so it is not in the diff. The `bad-frame-provider-arg` and `frame-destroyed` rows name `:where` without a type claim; the `resource-ssr-blocking-timeout` row prints the literal `re-frame.resources.ssr/settle-blocking-timeout`, which agrees with `:symbol`. No surface roster or authoring map is touched (rf2-mb8yp ruling stands).

No residual "sym-or-kw" prose survives anywhere in `spec/` or `implementation/` — #7603's two `frame.cljc` docstring corrections hold.

## Quality gates

All run in this worktree, foreground, to completion.

| gate | result | exit |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | 76 steps; runner's own terminal marker `PASS fast PR spine` (wrapper agrees) | 0 |
| `implementation/core` JVM suite (`clojure -M:test`) | Ran 2226 tests, 11625 assertions, 0 failures, 0 errors | 0 |
| `re-frame.error-catalogue-channel-conformance-test` (targeted, from `implementation/core`) | Ran 27 tests, 128 assertions, 0 failures, 0 errors | 0 |
| **mutation proof** — `BadFrameProviderArgTags` slot reverted to `:any`, same namespace | Ran 27 tests, 128 assertions, **6 failures** — the witness is non-vacuous | 1 (expected; slot restored, re-green) |
| `python scripts/check_keyword_catalogue_drift.py` | no output, no drift | 0 |
| `python scripts/check_keyword_catalogue_drift.py --self-test` | no output | 0 |
| `python -m mkdocs build --strict` | Documentation built in 40.99 seconds | 0 |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | `No beads-database paths in this PR diff` | 0 |

Nothing skipped. The core JVM suite was run explicitly even though the diff carries no core source file, because the core lane parses `spec/009-Instrumentation.md` and `spec/Spec-Schemas.md` — a spec-only diff can red it.

The spine's own PASS line names what it does not cover: the JVM artefact suites the diff did not touch, and the browser / prod-elision / bundle-isolation / perf / adapter-probe / Xray-matrix / mcp-conformance / tool-JVM lanes (CI only). No `.beads` path is in the diff.
