### PR TITLE
docs(hicasso): the spec's own claim about the conversion was wrong too (rf2-2rtt6.120)

### DIFF
--- a/docs/design/hicasso/studio/raw-escape-spec.md
+++ b/docs/design/hicasso/studio/raw-escape-spec.md
@@ -508,11 +508,32 @@ the same programme files `rf2-2rtt6.117` asking whether that fork should exist �
 crossing, and it does not exist in the taught surface.** Designs A (hiccup in a prop), C
 (diagnostics rows 8 and 9, *and its entire render-prop worked example*), B (an edge-5
 witness) and the parity design (E5) all named it. Verified: **zero occurrences of
-`as-element` anywhere under `docs/design/hicasso/draft-guide/`**; the guide's taught `h/`
-roster is `h/hicasso`, `h/root`, `h/fn`, `h/render`, `h/defhost`, `h/presence`,
-`h/child-key` and `h/boundary`; `arm1/lang.clj` exports three macros — `defview`, `hfn`,
-`defhost` — and no `as-element`. The *mechanism* is public as `codec/as-element`; the
-*taught name* is not. **An error message naming a spelling the reader cannot call is worse
+`as-element` anywhere under `docs/design/hicasso/draft-guide/`**, and `arm1/lang.clj`
+exports three macros — `defview`, `hfn`, `defhost` — and no `as-element`. Nothing an
+author writes reaches a conversion.
+
+The *mechanism* exists as `codec/as-element`; the *taught name* does not. **This clause
+called that mechanism "public" until 2026-08-06, where A, B, C and `decisions.md` all call
+it INTERNAL — and the operative fact is neither word.** `as-element` is a non-private
+`defn`, so a fixture that requires `re-frame.bench.hicasso.front.codec` can call it; but
+that namespace lives in the bench tree under `implementation/freehand/test/`,
+`arm1/lang.clj` does not export it, and the guide's `h` is `re-frame.hicasso` — a package
+that does not exist yet. Reachable from a test, reachable from nothing an author writes:
+that is the sense in which the sibling records are right, and the sense a reader of this
+page needs, because "public" invites the `.103` implementer to name it in a message.
+
+> **The roster this clause used to enumerate was itself unverified (2026-08-06).** It gave
+> the guide's taught `h/` roster as `h/hicasso`, `h/root`, `h/fn`, `h/render`, `h/defhost`,
+> `h/presence`, `h/child-key`, `h/boundary`. Two of those are not spellings: `h/hicasso` is
+> a substring of the bench path `re_frame/bench/hicasso/`, which appears in the draft banner
+> at the top of every guide page, and the guide writes `h/root!`, not `h/root`. It also
+> missed `h/frame`, `h/reg-state` and `h/hydrate-root!`. The enumeration is dropped rather
+> than repaired — the guide is explicitly unfrozen, so any transcription of it goes stale,
+> the same failure mode as the line numbers retired in §10 — and the load-bearing half is
+> stated directly above instead. **The clause recording a myth born of an unchecked grep had
+> itself been assembled by one**; that is the gap `rf2-2rtt6.128` is filed against.
+
+**An error message naming a spelling the reader cannot call is worse
 than no message.** Either the arm exports the taught spelling in the same PR — one line — or
 every refusal message and guide row names what the arm actually exposes. Filed as
 `rf2-2rtt6.120`; the escape's PR must not be where this is discovered.
@@ -531,7 +552,10 @@ every refusal message and guide row names what the arm actually exposes. Filed a
 > Since corrected: the docstring (PR #7543), the guide's `05-interop.md` (PR #7523, which
 > also removed a `:render` hiccup return the page called "fine" — `render-callback` ends in
 > a bare `(apply f args)`, so the return crosses **unconverted** and a vector is refused by
-> React), and A, B, C and `decisions.md` above (PR #7543). **The arm ruling this clause asks
+> React), and A, B, C and `decisions.md` above (PR #7543); and this clause's own "public"
+> and its unverified roster (2026-08-06), which had survived both sweeps because they swept
+> the string `h/as-element` and these say `codec/as-element` and nothing at all.
+> **The arm ruling this clause asks
 > for — export a spelling, or rule a different one — is still unmade**, so the records now
 > name the gap rather than a function; none of them invents a replacement. The parity
 > design is local-only and outside the tracked tree.


### PR DESCRIPTION
## What this found

The bead's charge was that the guide teaches an `h/as-element` recovery that does not exist. **It no longer does, and neither do the design records** — PR #7523 (guide) and PR #7543 (records + the upstream docstring) both merged on 2026-08-05. Verified on `origin/main`: zero occurrences of `as-element` under `docs/design/hicasso/draft-guide/`, and every surviving `h/as-element` in the tracked tree is an explicit negation of it or a quotation of the docstring that seeded it.

So the answer to "which of the three outcomes" is **the third**: the obligation needs an operator ruling, and the (a)-vs-(b) arm ruling is unmade. This PR does not make it. No new verb is added; nothing here invents a spelling.

## What it did fix

Both prior sweeps searched the string `h/as-element`. The synthesis spec's clause 6(e) carried two false claims that neither sweep could see, because neither of them says `h/as-element` — and 6(e) is the clause `rf2-2rtt6.103`'s implementer reads.

**1. "The *mechanism* is public as `codec/as-element`."** Designs A, B, C and `decisions.md` all say INTERNAL. One of the five is wrong, and it is the spec. The operative fact is neither word: `as-element` is a non-private `defn`, so a fixture requiring `re-frame.bench.hicasso.front.codec` can call it — but that namespace lives in the bench tree under `implementation/freehand/test/`, `arm1/lang.clj` exports exactly `defview`/`hfn`/`defhost`, and the guide's `h` is `re-frame.hicasso`, a package that does not exist yet. Reachable from a test, reachable from nothing an author writes. This matters concretely: "public" invites `.103` to name it in a refusal message, which is the exact failure the bead was filed against.

**2. The enumerated guide roster was itself an unchecked grep.** It gave the taught roster as `h/hicasso`, `h/root`, `h/fn`, `h/render`, `h/defhost`, `h/presence`, `h/child-key`, `h/boundary`. `h/hicasso` is **not a spelling at all** — it is a substring of the bench path `re_frame/bench/hicasso/`, which appears in the draft banner at the top of every guide page. And the guide writes `h/root!`, not `h/root`. It also missed `h/frame`, `h/reg-state` and `h/hydrate-root!`. Dropped rather than repaired: the guide is explicitly unfrozen, so any transcription goes stale — the same failure mode as the line numbers §10 already retired.

The clause recording a myth born of an unchecked grep had itself been assembled by one. That is now on the page, pointing at `rf2-2rtt6.128`.

## What remains, and is not mine

The (a)-vs-(b) arm ruling — export the taught spelling from `arm1/lang.clj`, or rule a different name. That is an operator call and it belongs with `rf2-2rtt6.103` (the raw escape, still open). The records and the guide are truthful under either answer, so nothing blocks on it; a stage-marked "not yet" is the honest end state until it lands.

## Quality gates

| Gate | Command | Exit |
|---|---|---|
| Doc slugs | `python scripts/check_doc_slugs.py` | **0** |
| Doc slugs, mutation-proved | broken file target + broken anchor appended | **1** (both classes fired) |
| Doc slugs, after revert | `python scripts/check_doc_slugs.py` | **0** |

*(3 rows, 3 columns.)*

**Mutation-proved rather than merely green.** A broken file target and a broken heading anchor were appended to `raw-escape-spec.md`, grep-confirmed present, and the gate reported both by name at `:737` and `:738` and exited 1. Reverted by exact-tail match, grep-confirmed gone, `--numstat` restored to the identical `30 6`, gate exit 0 again.

**Tables checked by hand, and none were touched.** `git diff -U0 | grep -E '^[+-]\s*\|'` returns no rows, and no heading lines changed either — so neither the table nor the anchor surface moved. The one table this PR *adds* is in this PR body, not the tree.

**`mkdocs build --strict` deliberately not nominated.** `exclude_docs` keeps `docs/design/hicasso/**` out of the site, so it would exit 0 having verified nothing about this file.

Docs-only, one file, `30 6`. No `.beads` path in the diff (verified against the merge base `5485de938f`, not a two-dot range).
