### PR TITLE
fix(hicasso): refuse an h/fn at a defhost slot nothing claimed (rf2-2rtt6.116, rf2-2rtt6.115)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -418,6 +418,66 @@ instance props can express.
 
 ## HD-011 — The interop door
 
+> **Addendum, 2026-08-06 — an `h/fn` at a prop slot NOTHING CLAIMED is refused
+> at the crossing (`rf2-2rtt6.116`).** The door already refuses an intent
+> *vector* at an event-spelled slot the declaration does not name, on the stated
+> ground that the alternative is the author's intent crossing as inert data —
+> *"the silently dead handler class every loud error in this codec exists to
+> delete"*. This extends that refusal to the same defect one level of
+> indirection down, and it changes a shipped ACCEPT, which is why it was
+> escalated rather than simply fixed.
+>
+> **What was accepted, and why it was a hole.** `host-entry` routes a prop four
+> ways — the `ref` slot, the class slot, a slot the declaration NAMES, and
+> everything else — and the last of those passed `fn?` through by identity.
+> `h/fn` marks a function and returns *that function* (HD-024's whole deletion),
+> so a marked callback at a slot no position claimed crossed as an ordinary
+> function. It is callable, so nothing threw. But the author wrote `h/fn` to
+> ASK FOR A CONTRACT and nothing selected one, and the `:event` contract's own
+> convenience makes that concrete: `[my-host {:on-pick (h/fn [x] [:row/pick
+> x])}]`, with `:on-pick` absent from `:callbacks`, is called by the library,
+> returns the intent, has the return discarded, and dispatches nothing. The
+> user's click does nothing, in production, with no diagnostic at all.
+>
+> **It is derived, not new policy.** `mint-host!` refuses an option it does not
+> know (`:rf.error/hicasso-host-unknown-option`) on exactly this reasoning,
+> recorded in this decision's addendum below: a policy could be written and
+> never applied, and *the silent-ignore was its own defect*. An `h/fn` whose
+> contract is never selected **is** a policy written and never applied.
+> `spec/Conventions.md` states the same law repo-wide: a recognised input that
+> cannot be honoured is signalled, never swallowed.
+>
+> **A dev-only WARNING was the other live arm, and it loses on its own terms.**
+> A warning fires under `goog.DEBUG` and is gone in production, which is exactly
+> where the dead click happens — it converts a silent production failure into a
+> silent production failure with a development courtesy. There is no `[:>]`
+> warning to be at parity with, either: the synthesized `[:>]` spec retracted
+> that grant and pins the escape's conduct to the door's. Against the refusal,
+> the counter-case — an author who writes `h/fn` from habit at a prop that needs
+> no contract — costs a five-second loud fix at their own stack, and `h/fn` is
+> taught as the ONE callback form, i.e. the form you write when the position
+> should impose a contract.
+>
+> **The shape.** One branch in `host-entry`'s `:else` arm, beside the
+> event-shaped-data refusal and ahead of `host-prop-value`:
+> `:rf.error/hicasso-host-unclaimed-callback`, naming the host, the position,
+> the declared roster and the recovery (*declare the slot in `:callbacks`, or
+> hand a plain function*). The id is deliberately a PAIR with the sibling's —
+> `undeclared-callback` is intent DATA at an event-spelled slot,
+> `unclaimed-callback` is the marked form at any unclaimed slot. Cost is a
+> `fn?` test plus one own-property read, in the host walk's `:else` arm only;
+> no claimed slot pays it, and the native walk is not on that path.
+>
+> **The fence.** A PLAIN function at an unclaimed slot is untouched and stays
+> legal — it is a value handed to a foreign API rather than a position, and it
+> asked for nothing. The marked form stays legal at every CLAIMED slot: a
+> declared `:event`, `:handler` or `:render`, and React's own `:ref`. No warning
+> tier, no dedup, no config knob, no invocation-time wrapper, and no inference
+> from an `on*` name — the mark is the trigger, never the spelling. **`[:>]`,
+> when it is built, flows through this same branch**: its roster is empty, so
+> every slot at that crossing is unclaimed, and the escape inherits the door's
+> conduct with no fork of its own.
+
 > **Addendum, 2026-08-05 — there is a THIRD `:ssr` value, `:render`, and a
 > declared fallback is inert markup by enforcement (`rf2-l0wfx`, `rf2-nv07k`,
 > ruled together).** This amends the 2026-08-04 addendum immediately below,
@@ -1237,6 +1297,45 @@ cost is **unmeasured** and is named here rather than claimed away.
 
 ## HD-024 — One callback form; the position selects the contract
 
+> **Addendum, 2026-08-06 — the position table's row 3 OVER-RECORDS: it never
+> covered a `defhost` slot the declaration left unclaimed, and that slot now
+> REFUSES the marked form (`rf2-2rtt6.115`, `rf2-2rtt6.116`).** Two beads, one
+> row, and they must be read together or the row goes on being wrong.
+>
+> **The scope correction (`rf2-2rtt6.115`).** Row 3 reads *"any other walked
+> prop position (**a slot**, a foreign render prop) → render"*. The parenthesis
+> over-reaches by one position. A **native** non-event prop does render-wrap the
+> marked form, and a slot a `defhost` declaration gave the `:render` contract
+> does too — those are the row. But an **unclaimed `defhost` slot** never
+> did: `host-entry`'s `:else` arm handed it to `host-prop-value`, which passes
+> `fn?` through by identity. Three independent adjudications concur that the
+> CODE side was authoritative and the crossing deliberate — both tables landed
+> in one commit, and the walk that implemented identity the next day carried a
+> reasoned docstring saying so. The row is a record of what was ruled and stays
+> below unedited; this is its scope, which it never stated. **The "align
+> `defhost` with row 3" repair direction is struck as adverse** — it would have
+> installed the render-position purity gate at a foreign crossing and broken the
+> `React.memo` identity that `host-prop-value` preserves on purpose.
+>
+> **What the position does now (`rf2-2rtt6.116`, ruled 2026-08-06).** Identity
+> was the right answer to *"is this render-wrapped?"* and the wrong answer to
+> *"is a marked callback nothing reads acceptable?"*. It is not: at an unclaimed
+> slot the mark asks for a contract no position selected, so the crossing now
+> **refuses** — `:rf.error/hicasso-host-unclaimed-callback`. HD-011's dated
+> addendum carries the full ruling, its grounds, and its fence, because the DOOR
+> owns crossing conduct. A **plain** function at that slot is untouched and
+> still crosses by identity, which is the part of the row's deletion clause that
+> was always true of it.
+>
+> **So the record correction `rf2-2rtt6.115` was holding is discharged here,
+> and its recorded repair is superseded in one half.** That repair was *"a dated
+> scope-note on row 3 plus the witness pinning a marked `h/fn` at an unclaimed
+> door slot"* (carried as R4 of the synthesized `[:>]` spec). The scope-note is
+> above. The witness cannot pin identity for a marked `h/fn` any more, because
+> the marked form no longer crosses there — it is the RED refusal row in
+> `arm1/host_hatch_dom_cljs_test`, and the identity witness it names is the
+> PLAIN-function row beside it.
+
 > **Addendum, 2026-08-03 — render-position enforcement is INVOCATION-scoped, and
 > the owner forwards (`rf2-2rtt6.74`).** Both laws below stand: a `:render`
 > position is pure, and dispatching from inside the call is
@@ -1304,7 +1403,7 @@ the runtime already knows every position it walks:
 |---|---|
 | a native `:on-*` prop | **event** — a returned VECTOR is dispatched; any other return is ignored |
 | a `defhost` `:callbacks` entry | as **declared** (`:event`, `:handler` or `:render`), never inferred from an `on*` name |
-| any other walked prop position (a slot, a foreign render prop) | **render** — pure; the return is render output and is not dispatched, and dispatching from inside is `:rf.error/hicasso-dispatch-in-render-position`, **naming the position** |
+| any other walked prop position (a slot, a foreign render prop — but NOT an unclaimed `defhost` slot, which refuses; see the 2026-08-06 addendum) | **render** — pure; the return is render output and is not dispatched, and dispatching from inside is `:rf.error/hicasso-dispatch-in-render-position`, **naming the position** |
 | `:ref` | React's own: commit phase, node in, cleanup out. Excluded from lowering |
 | anywhere Hicasso does not walk (a raw `#js` prop) | it is a plain function; it runs, and its return is ignored |
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
@@ -815,6 +815,100 @@
           (is (= [:hatch/closed] (:value d)))
           (is (re-find #":on-imperative" (ex-message e))))))))
 
+;; ---------------------------------------------------------------------------
+;; 5c — and what the declaration does NOT govern, an `h/fn` may not ask
+;;      (rf2-2rtt6.116)
+;; ---------------------------------------------------------------------------
+;;
+;; The complement of 5b, and the same law read from the other side.  5b
+;; says the CONTRACT the declaration named governs every carrier at that
+;; position.  At a slot the declaration named NOTHING there is no
+;; contract to govern with — so the marked form, whose entire content is
+;; a request that the position impose one, is asking a position that
+;; cannot answer.
+;;
+;; Before this it crossed by identity and simply ran, which is fine for
+;; a plain function and is a SILENTLY DEAD HANDLER for the marked one:
+;; the `:event` convenience means an `h/fn` returning `[:row/pick x]` at
+;; an unclaimed slot is called by the library, returns the intent, has
+;; the return discarded, and dispatches nothing.  The user's click does
+;; nothing, in production, with no diagnostic — the same class the
+;; sibling refusal on an undeclared intent VECTOR exists to delete, one
+;; level of indirection down.
+;;
+;; The rows below are a pair by construction, because a refusal that
+;; also rejected legitimate usage would be strictly worse than the
+;; silence it replaces: the RED row asserts the id, the `:where` and the
+;; roster, and the GREEN rows re-assert that every CLAIMED slot — a
+;; declared `:event`, a declared `:handler`, a declared `:render`,
+;; React's own `:ref` — still takes the marked form, and that a PLAIN
+;; function is untouched at the very slot the red row refuses.
+
+(deftest an-hfn-at-a-slot-nothing-claimed-is-refused
+  (testing "the mark asks the POSITION for a contract, and an unclaimed
+            slot has none to give — so the request is refused where the
+            author wrote it, rather than answered by silence a phase and
+            a component away"
+    (try
+      (crossed render-picker {:on-value-change (hfn [city] [:hatch/picked city "dead"])})
+      (is false "should have thrown")
+      (catch :default e
+        (let [d (ex-data e)]
+          (is (= :rf.error/hicasso-host-unclaimed-callback (:rf.error/id d))
+              "its own id, distinct from the sibling's: that one is intent
+               DATA at an event-SPELLED undeclared slot, this one is the
+               marked form at ANY unclaimed slot")
+          (is (= 'front.codec/host-element (:where d)))
+          (is (= :on-value-change (:position d)))
+          (is (re-find #"/render-picker$" (:host d))
+              "the host names ITSELF, so the message points at the
+               declaration the author would have to change")
+          (is (= #{"onPick" "onImperative" "onRenderRow"} (:declared d))
+              "the roster is the DECLARED slots as a set, so the message can
+               say what the author could have claimed instead")
+          (is (= :declare-the-slot-or-hand-a-plain-function (:recovery d)))
+          (is (re-find #":on-value-change" (ex-message e)))
+          (is (re-find #"or hand a plain function" (ex-message e))
+              "and it states the recovery in the message, not only in the
+               data — the author reads the message")))))
+
+  (testing "an on*-SPELLED unclaimed slot is the same refusal and not the
+            sibling's: the spelling never selected anything here either"
+    (is (= :rf.error/hicasso-host-unclaimed-callback
+           (error-id #(crossed render-picker {:on-nope (hfn [_] [:hatch/closed])})))))
+
+  (testing "and a slot with no on* spelling at all is refused just the same —
+            the mark is the trigger, never the name"
+    (is (= :rf.error/hicasso-host-unclaimed-callback
+           (error-id #(crossed render-picker {:row-formatter (hfn [x] (str x))})))))
+
+  (testing "GREEN — a PLAIN function at the very slot the rows above refuse
+            still crosses by identity. This is the fence: the refusal is on
+            the unanswered REQUEST, never on functions at the crossing"
+    (let [[el _] (crossed render-picker {:on-value-change identity})]
+      (is (identical? identity (prop el "onValueChange")))))
+
+  (testing "GREEN — every CLAIMED slot still takes the marked form, so the
+            refusal is not a blanket ban on h/fn at a host"
+    (let [[el !seen] (crossed render-picker
+                              {:on-pick (hfn [city e] [:hatch/picked city (.-type e)])})]
+      ((prop el "onPick") "lisbon" #js {:type "click"})
+      (is (= [[:hatch/picked "lisbon" "click"]] @!seen)
+          "declared :event — still wrapped, and the returned intent still
+           dispatches"))
+    (let [[el _] (crossed render-picker {:on-imperative stable-imperative})]
+      (is (identical? stable-imperative (prop el "onImperative"))
+          "declared :handler — still the function itself, by identity"))
+    (let [[el _] (crossed render-picker {:on-render-row (hfn [label] (str "row:" label))})]
+      (is (= "row:x" ((prop el "onRenderRow") "x"))
+          "declared :render — still the render wrapper"))
+    (let [f (hfn [node] (swap! !instr assoc :hfn-ref node) nil)]
+      (is (some? (first (crossed render-picker {:ref f})))
+          ":ref is CLAIMED — by React's own contract rather than by the
+           declaration (HD-016) — and it is read BEFORE the unclaimed arm,
+           so a callback ref written as an h/fn crosses rather than
+           refusing"))))
+
 (deftest a-dispatch-from-a-declared-render-position-names-the-position
   (testing "HD-024's core law at the door: the CONTRACT the declaration named
             decides, and a :render contract poisons the ambient frame-locked

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -117,7 +117,7 @@
   |---|---|---|---|
   | Native tag | attr map | trailing forms; seqs realized once and flattened one level; `nil`/`false` render nothing, `true` errors | `:key` in the attr map |
   | Boundary (a marked `defview` product) | one props map, every lazy sequence in it realized and every unforced `delay` in it refused ([[realize-deep]]) | trailing forms as `(:children props)`, a realized vector | `:key` in the props map, extracted before the body sees props |
-  | Host (a `defhost` declaration — HD-011) | attr map: declared `:callbacks` slots lowered by their DECLARED contract, `:ref` a callback ref (HD-022's vector refusal holds here), the class slot coerced and composed by [[class-names]] exactly as at a native tag (rf2-2rtt6.119), everything else converted shallowly ([[host-prop-value]]) | trailing forms converted hiccup→element, handed to the foreign component as React children | `:key` in the attr map |
+  | Host (a `defhost` declaration — HD-011) | attr map: declared `:callbacks` slots lowered by their DECLARED contract, `:ref` a callback ref (HD-022's vector refusal holds here), the class slot coerced and composed by [[class-names]] exactly as at a native tag (rf2-2rtt6.119), an `h/fn` at any slot none of those claimed REFUSED (rf2-2rtt6.116), everything else converted shallowly ([[host-prop-value]]) | trailing forms converted hiccup→element, handed to the foreign component as React children | `:key` in the attr map |
   | Fragment `[:<> …]` | optional attr map | trailing forms | on the fragment's props map |
 
   A React element is a legal child anywhere. No metadata keys, no second
@@ -2054,10 +2054,13 @@
   name', and this refusal is the loud half of it: no contract is guessed
   — but the alternative to refusing is `clj->js` shipping the author's
   intent to the library as an inert array, which is the silently dead
-  handler class every loud error in this codec exists to delete. A
-  FUNCTION at an undeclared prop is different and legal: it is a value
-  handed to a foreign API — not a position — so it crosses by identity
-  and simply runs (the position table's deletion row)."
+  handler class every loud error in this codec exists to delete. An
+  ORDINARY function at an undeclared prop is different and legal: it is
+  a value handed to a foreign API — not a position — so it crosses by
+  identity and simply runs (the position table's deletion row). The
+  MARKED form is not, since rf2-2rtt6.116:
+  [[refuse-unclaimed-host-callback!]] takes an `h/fn` at the same
+  position, because that one asked for a contract."
   [^js head k v]
   (fail! :rf.error/hicasso-host-undeclared-callback
          'front.codec/host-element
@@ -2067,11 +2070,56 @@
               "prop names to :event, :handler or :render — never inferred "
               "from an on* spelling — so an undeclared intent would cross as "
               "inert data. Declare " (pr-str k) " in :callbacks, or hand a "
-              "function.")
+              "plain function.")
          :declare-the-callback-contract
          {:host     (unchecked-get head "displayName")
           :position k
           :value    v
+          :declared (into #{} (keys (unchecked-get head "callbacks")))}))
+
+(defn- refuse-unclaimed-host-callback!
+  "An `h/fn` at a host prop slot NOTHING CLAIMED — not the `:ref` slot,
+  not a slot the declaration named, not the class slot. The marked form
+  is a REQUEST that the position impose a contract, and at an unclaimed
+  slot no position selected one, so the mark reads nothing and the
+  function crosses to the foreign library as an ordinary function. It is
+  callable, so nothing throws.
+
+  **The trap is the `:event` contract's convenience.**
+  `[my-host {:on-pick (h/fn [x] [:row/pick x])}]`, with `:on-pick` absent
+  from `:callbacks`, crosses; the library calls it; it returns an intent
+  vector; the library discards the return; nothing dispatches. The user's
+  click does nothing, in production, with no diagnostic anywhere — the
+  silently dead handler class the sibling refusal above names as the one
+  every loud error in this codec exists to delete. An `h/fn` returning
+  that same vector is that defect one level of indirection down.
+
+  **This is derived, not new policy** (`rf2-2rtt6.116`). `mint-host!`
+  already refuses an option it does not know, on the reasoning HD-011's
+  addendum records: a policy could be written and never applied, and the
+  silent-ignore was its own defect. An `h/fn` whose contract is never
+  selected IS a policy written and never applied.
+
+  **A PLAIN function at the same slot stays legal and untouched.** It is
+  a value handed to a foreign API rather than a position, and it never
+  asked for anything, so there is nothing to leave unanswered. This
+  refuses the unanswered REQUEST — never functions at the crossing, and
+  never the form itself, which is legal at every slot a declaration
+  claims."
+  [^js head k]
+  (fail! :rf.error/hicasso-host-unclaimed-callback
+         'front.codec/host-element
+         (str "The host " (unchecked-get head "displayName") " was handed an "
+              "h/fn at " (pr-str k) ", which no position claims — its "
+              "declaration names " (pr-str (into #{} (keys (unchecked-get head "callbacks"))))
+              ". An h/fn asks the POSITION for a contract, and an unclaimed "
+              "slot has none to give: it would cross as an ordinary function "
+              "whose return the library discards, so an intent it returned "
+              "would never dispatch. Declare " (pr-str k) " in :callbacks, or "
+              "hand a plain function.")
+         :declare-the-slot-or-hand-a-plain-function
+         {:host     (unchecked-get head "displayName")
+          :position k
           :declared (into #{} (keys (unchecked-get head "callbacks")))}))
 
 (defn- host-entry
@@ -2091,7 +2139,10 @@
   a position MEANS here comes from the DECLARATION rather than from the
   key's spelling. A declared slot takes its declared contract; an
   event-spelled slot the declaration does not name is refused rather
-  than inferred; everything else crosses shallowly. `event?` is gated on
+  than inferred; an `h/fn` at any slot nothing claimed is refused too,
+  because the mark is a request for a contract and no position selected
+  one ([[refuse-unclaimed-host-callback!]], rf2-2rtt6.116); everything
+  else crosses shallowly. `event?` is gated on
   `keyword?` for the same reason the native walk gates it — a symbol
   spelled `on-click` shares the cache entry and is not an event
   position.
@@ -2156,6 +2207,18 @@
             :else
             (do (when (and event? (or (vector? v) (map? v)))
                   (refuse-undeclared-host-event! head k v))
+                ;; Beside its sibling, and for the sibling's own stated
+                ;; reason one indirection down (rf2-2rtt6.116). It is
+                ;; last of the two because `event?` is a flag already
+                ;; read, so that test costs a boolean, while this one
+                ;; costs a `fn?` — and it is ahead of
+                ;; [[host-prop-value]] because that function is where
+                ;; the marked form would silently become an ordinary
+                ;; one. Both live in the `:else` arm only: no claimed
+                ;; slot pays either, and the NATIVE walk
+                ;; ([[convert-entry]]) is not on this path at all.
+                (when (intent/callback? v)
+                  (refuse-unclaimed-host-callback! head k))
                 ;; The SLOT, never the key: `:class` and `:className` are
                 ;; one position, and the named-value rule is written
                 ;; against where the value lands (rf2-vrvv9).
@@ -2179,8 +2242,9 @@
   ([[re-frame.bench.hicasso.front.intent/lower-declared-prop]] — an
   `h/fn` takes the contract's wrapper, an intent vector or key-map
   lowers as at a native position), refuse an event-spelled intent at an
-  UNDECLARED slot, and convert everything else shallowly
-  ([[host-prop-value]]) under its camelCased name.
+  UNDECLARED slot and an `h/fn` at any UNCLAIMED one, and convert
+  everything else shallowly ([[host-prop-value]]) under its camelCased
+  name.
 
   Children are trailing forms converted hiccup→element and handed to the
   foreign component as ordinary React children — HD-011's third default.


### PR DESCRIPTION
Closes the fail-open `rf2-2rtt6.116` filed, executing the ruling recorded on that
bead (2026-08-06 11:26 AUSEST: **refuse in**; warn and leave both rejected).
Carries `rf2-2rtt6.115`'s record correction with it, for the reason set out below.

## The defect

`intent/callback` marks a function and returns *that function* — HD-024's whole
deletion. `host-entry` routes a host prop four ways (the `ref` slot, a slot the
declaration NAMES, the class slot, everything else) and the last of those went to
`host-prop-value`, which passes `fn?` through by identity. So an `h/fn` at a slot
no position claimed crossed as an ordinary function. Callable, so nothing threw.

The `:event` contract's convenience makes that concrete:

```clojure
[my-host {:on-pick (h/fn [x] [:row/pick x])}]   ;; :on-pick NOT in :callbacks
```

The library calls it, it returns an intent vector, the library discards the
return, nothing dispatches. Silently, in production. The sibling refusal one line
above is already loud for a bare intent VECTOR at an event-spelled undeclared
slot, on the stated ground that the alternative is *"the silently dead handler
class every loud error in this codec exists to delete"*. An `h/fn` returning that
same vector is that defect one indirection down.

## The change

One branch in `host-entry`'s `:else` arm, beside the event-shaped-data refusal and
ahead of `host-prop-value`:

- `:rf.error/hicasso-host-unclaimed-callback`, `:where` `front.codec/host-element`,
  recovery `:declare-the-slot-or-hand-a-plain-function`, data
  `{:host :position :declared}` with the roster as a set, matching the sibling's
  shape.
- The id is deliberately a PAIR with the sibling's: `undeclared-callback` is intent
  DATA at an event-spelled slot; `unclaimed-callback` is the marked form at any
  unclaimed slot.
- `[:>]`, when built, flows through this SAME branch — an empty roster means every
  slot is unclaimed, so the escape inherits the door's conduct with no fork.
  Nothing here forks for it.

No warn tier, no dedup, no config knob, no invocation-time wrapper, no `on*` name
inference — the mark is the trigger, never the spelling.

**Cost.** `intent/callback?` is a `fn?` test plus one own-property read. It sits in
the HOST walk's `:else` arm only, after the `ref`/declared/class arms and after the
`event?` test (which reads a flag already computed, so that test costs a boolean),
and ahead of `host-prop-value` because that is where the marked form would silently
become an ordinary one. No claimed slot pays it, and the NATIVE walk
(`convert-entry`) is not on this path at all — the hot walk is untouched.

## Two beads, not one — and why they land together

They are **separate defects at one position**, and only `.116` would have shipped
had the record not been in the way:

- `.116` is a **behaviour change** (a shipped accept becomes a refusal).
- `.115` is a **record correction**. HD-024's position table row 3 says any other
  walked prop position, *"a slot"*, render-wraps. Verified against the code: a
  NATIVE non-event prop does render-wrap (`intent/lower-prop`), and a declared
  `:render` slot does; an UNCLAIMED `defhost` slot never did. The **code side was
  authoritative** — already adjudicated on the bead by three independent reviews —
  and "align `defhost` with row 3" is struck as adverse.

`.115`'s execution was folded into `.103`'s implementation PR as R4 of the
synthesized `[:>]` spec, and its recorded repair is *"a dated scope-note on row 3
plus the witness pinning a marked `h/fn` at an unclaimed door slot"*. **`.116`'s
ruling supersedes half of that**: after this PR the marked form does not cross
there at all, so a witness pinning its identity cannot be written — it is this PR's
RED refusal row, and the identity witness R4 wanted is the PLAIN-function row
beside it. Writing R4's scope-note as recorded would have put a sentence in
`decisions.md` that this PR falsifies in the same tree.

So row 3 is trued up ONCE here, in its post-`.116` form. **`.115` is not closed by
this PR** — its closure is assigned to `.103`'s merge; the record half of R4 is
simply already discharged when that lands.

## Records

- **HD-011** takes the dated ruling addendum — the door owns crossing conduct.
- **HD-024** takes the row-3 scope correction plus the cross-ref, and row 3 itself
  gains an inline scope clause, so a reader who reads the table and not the
  addendum is not trapped the way this bead was filed in the first place.

## Sequencing

`.116`'s ruling says to serialise in `host-entry`, never parallel with `.103`. At
the time of writing `.103` has **no branch, no worktree and no open PR**, and
`bd list --status in_progress` is empty — so nothing is parallel with this, and
landing first IS the serialisation. `.103`'s implementer inherits the shared branch
its own design asked for rather than having to add it.

**Note for `.103`'s implementer:** the design synthesis E2 says marked `h/fn` and
plain fns cross BY IDENTITY at `[:>]`, plus a dev-only warning. `.116`'s ruling
supersedes both halves for the marked form — refuse, no warning, shared branch.

## Quality gates

All run foreground to completion in the worker worktree. Exit codes are the
runner's, captured on the line after the command.

| Gate | Exit | Result |
|---|---|---|
| `sh scripts/assert-worker-worktree.sh` | 0 | guard passed |
| `npm ci` (in-worktree, real dir, no junction) | 0 | installed clean |
| `npm run test:cljs` | 0 | Ran 12724 tests / 63819 assertions, 0 failures, 0 errors |
| `sh scripts/test-fast-pr.sh` | 0 | runner's own anchored marker `PASS fast PR spine` |
| `npm run test:browser` | 0 | Ran 1105 tests / 6846 assertions, 0 failures, 0 errors |

The spine's own tiers included `npm run test:cljs` (12724 / 63819, 0 failures,
0 errors — identical counts to the standalone run above), `mkdocs build --strict`,
the JVM freehand suite, and the hicasso bench-lane compile gate (129 lane
namespaces, 0 warnings). The wrapper exit and the runner's marker agree.

### Mutation proof, both directions

A refusal that also rejected valid usage would be strictly worse than the silence
it replaces, so the guard was mutated both ways. Each mutation was confirmed
APPLIED before any verdict was read — `git diff --stat`, the original token grepped
back out at count 0, and the replacement token grepped in.

**A — guard deleted** (`(when (intent/callback? v) …)` removed; marker
`MUTANT-A-GUARD-DELETED` present, call site count 0). Exit **1**, 3 failures, all
three in `an-hfn-at-a-slot-nothing-claimed-is-refused`, with `error-id` returning
`::did-not-throw`. Assertions dropped by exactly 7 — the catch block's 8 replaced
by the single `(is false "should have thrown")` — which is the arithmetic of the
red row actually executing. This also proves the new deftest is really in the
`:node-test` build rather than silently absent.

**B — guard over-broad** (`intent/callback?` replaced by `fn?`; marker
`MUTANT-B-OVERBROAD` present, original token count 0). Exit **1**, 3 errors:
this PR's own plain-function green control, plus **two pre-existing witnesses that
predate this change** — `host-props-convert-shallowly` (the `:plain-fn identity`
row) and `every-other-host-prop-value-crosses-exactly-as-it-did` in
`front/codec_cljs_test`. So the "plain functions still cross" fence has teeth from
three independent directions.

After both mutations the file was restored with `git checkout --`, and
`git status --porcelain` was verified empty with the real guard grepped back in
before the final gates ran.

### Witnesses

`arm1/host_hatch_dom_cljs_test` gains `an-hfn-at-a-slot-nothing-claimed-is-refused`,
which is node- and browser-runnable (no `browser?` gate), so the red row and its
controls run in both lanes:

- **RED** asserts `:rf.error/id` *and* `:where`, plus `:position`, `:host`,
  `:declared` (the roster as a set), `:recovery`, and that the message names both
  the position and the recovery. Asserting only "throws" would be vacuous.
  Asserting `:position` and `:host` separately also detects the CLJS
  single-fixed-arity trap, where a mis-arity call binds the wrong argument
  silently rather than raising.
- Two further red rows: an `on*`-spelled unclaimed slot, and a slot with no `on*`
  spelling at all — the mark is the trigger, not the name.
- **GREEN** controls: a plain function at the very slot the red rows refuse still
  crosses by identity; a declared `:event` `h/fn` still wraps and still dispatches;
  a declared `:handler` still crosses by identity; a declared `:render` still
  returns to the caller; and an `h/fn` at `:ref` still crosses, because `:ref` is
  claimed by React's own contract and is read before the unclaimed arm.

### Doc verification done by hand

`docs/design/hicasso/decisions.md` is under `exclude_docs`, so `mkdocs --strict`
does not cover it and is not the gate for these edits. `scripts/check_doc_slugs.py`
ran in the spine. Beyond it, verified by hand: the edits add **no** links and
**no** headings (two blockquote addenda plus one table-cell edit), and HD-024's
position table still has **2 columns / 3 pipes on every one of its 5 rows plus the
header and separator** — the edited row 3 introduces no `|` of its own.
