### PR TITLE
test(freehand): make the lane-cache gate enforce its own central claim (rf2-t4j7c)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/bench/lane_cache_fixtures/agreeing_ids_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/lane_cache_fixtures/agreeing_ids_run.cjs
@@ -1,0 +1,24 @@
+'use strict';
+// FIXTURE — legitimate wiring. Every check in `lane_cache_wiring.test.cjs`
+// must PASS on this file. It is the control: a gate that rejects valid wiring
+// is worse than one that admits invalid wiring, because everyone routes around
+// it. Read as TEXT and never executed — see the fixtures note in the gate.
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { resetLaneBuildCache } = require('./lane_cache.cjs');
+
+const IMPL = path.resolve(__dirname, '..', '..', '..', '..', '..');
+const BUILD = 'freehand-release';
+const CONFIG_MERGE = '{:output-dir "fixture" :init-fn fixture.arm/main}';
+const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
+
+// This driver merges its own `:init-fn` onto `BUILD`, so `BUILD`'s cache entry
+// was written by a different program (rf2-2rtt6.20).
+if (resetLaneBuildCache(IMPL, BUILD)) {
+  console.error(`[fixture] cleared .shadow-cljs/builds/${BUILD}`);
+}
+
+spawnSync(process.execPath, [runner, 'release', BUILD, '--config-merge', CONFIG_MERGE], {
+  cwd: IMPL,
+  stdio: 'inherit',
+});

--- a/implementation/freehand/test/re_frame/freehand/bench/lane_cache_fixtures/commented_clear_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/lane_cache_fixtures/commented_clear_run.cjs
@@ -1,0 +1,24 @@
+'use strict';
+// FIXTURE — the second hole. This driver NEVER clears the cache: its only
+// occurrence of the clear is COMMENT TEXT, the shape you get when a refactor
+// deletes the call and leaves the explanation behind. A text search for
+// `resetLaneBuildCache(` is satisfied; nothing executes. Read as TEXT and
+// never executed.
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { resetLaneBuildCache } = require('./lane_cache.cjs');
+
+const IMPL = path.resolve(__dirname, '..', '..', '..', '..', '..');
+const BUILD = 'freehand-release';
+const CONFIG_MERGE = '{:output-dir "fixture" :init-fn fixture.arm/main}';
+const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
+
+// This driver merges its own `:init-fn` onto `BUILD`, so `BUILD`'s cache entry
+// was written by a different program — resetLaneBuildCache(IMPL, BUILD) is how
+// that's handled. The apostrophes above are deliberate: a comment scanner that
+// treats them as string delimiters swallows the code below.
+
+spawnSync(process.execPath, [runner, 'release', BUILD, '--config-merge', CONFIG_MERGE], {
+  cwd: IMPL,
+  stdio: 'inherit',
+});

--- a/implementation/freehand/test/re_frame/freehand/bench/lane_cache_fixtures/commented_clear_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/lane_cache_fixtures/commented_clear_run.cjs
@@ -4,9 +4,21 @@
 // deletes the call and leaves the explanation behind. A text search for
 // `resetLaneBuildCache(` is satisfied; nothing executes. Read as TEXT and
 // never executed.
+//
+// IT REQUIRES `lane_cache.cjs` WITHOUT BINDING ANYTHING, which is the point
+// rather than an oversight — do not tidy it back into a destructure. A
+// refactor that deletes the clear can leave either shape behind, and the two
+// are not equally dangerous. Keep the binding and `no-unused-vars` reports the
+// orphan, so the lint gate catches that driver before this one ever sees it;
+// the repo's ESLint config names that arm outright ("a bad `require` whose
+// binding is NEVER read is caught, by `no-unused-vars`"). Drop the binding too
+// and nothing in the lint path can see anything wrong: the file parses, every
+// name is used, and only the missing CALL separates it from a correct driver.
+// That second variant is the one no other gate owns, so it is the one modelled
+// here — the fixture covers the hole its sibling gate cannot.
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
-const { resetLaneBuildCache } = require('./lane_cache.cjs');
+require('./lane_cache.cjs');
 
 const IMPL = path.resolve(__dirname, '..', '..', '..', '..', '..');
 const BUILD = 'freehand-release';

--- a/implementation/freehand/test/re_frame/freehand/bench/lane_cache_fixtures/mismatched_ids_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/lane_cache_fixtures/mismatched_ids_run.cjs
@@ -1,0 +1,24 @@
+'use strict';
+// FIXTURE — the hole rf2-t4j7c reopened for. The clear and the release name
+// TWO DIFFERENT build ids, so this driver empties a cache nobody builds into
+// and builds into a cache nobody cleared. It satisfies rider discovery, the
+// require, clear-before-spawn and the no-literal check; only the build-id
+// comparison can see it. Read as TEXT and never executed.
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { resetLaneBuildCache } = require('./lane_cache.cjs');
+
+const IMPL = path.resolve(__dirname, '..', '..', '..', '..', '..');
+const CLEAR_BUILD = 'freehand-release';
+const RELEASE_BUILD = 'freehand-release-arm';
+const CONFIG_MERGE = '{:output-dir "fixture" :init-fn fixture.arm/main}';
+const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
+
+if (resetLaneBuildCache(IMPL, CLEAR_BUILD)) {
+  console.error(`[fixture] cleared .shadow-cljs/builds/${CLEAR_BUILD}`);
+}
+
+spawnSync(process.execPath, [runner, 'release', RELEASE_BUILD, '--config-merge', CONFIG_MERGE], {
+  cwd: IMPL,
+  stdio: 'inherit',
+});

--- a/implementation/freehand/test/re_frame/freehand/bench/lane_cache_wiring.test.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/lane_cache_wiring.test.cjs
@@ -71,6 +71,15 @@
 // directory only, and they are read as TEXT and never executed; the `require`
 // path in them is part of the source shape under test, not a live path.
 //
+// The fixtures stay IN the ESLint path rather than being ignored out of it, and
+// are held to the same rules as real driver source, because being faithful
+// driver source is the whole of their value — an ignore would let them drift
+// into shapes no driver could take. That constrains the comment-only fixture in
+// a way worth knowing: it requires `lane_cache.cjs` and binds nothing, because
+// a deleted clear that LEAVES its import binding behind is already caught one
+// gate earlier by `no-unused-vars`. The variant that binds nothing is the one
+// no linter can see, so it is the one this gate has to own.
+//
 // Wired into implementation/package.json via `test:script-helpers`.
 
 const assert = require('node:assert');

--- a/implementation/freehand/test/re_frame/freehand/bench/lane_cache_wiring.test.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/lane_cache_wiring.test.cjs
@@ -14,7 +14,7 @@
 // found the carrier (`shadow-js/index.json.transit`) and the alternatives that
 // were rejected with reasons (rf2-2rtt6.20).
 //
-// MEASURED HERE, on unmodified `main`, at the commit this test lands against:
+// MEASURED, on unmodified `main`, at the commit this test first landed against:
 //
 //     cold  -> b7's config-merge      204 files, 149 compiled, exit 0
 //     warm  -> ladder's config-merge  160 files,  11 compiled, exit 0
@@ -38,6 +38,39 @@
 // the riders rather than listing them, so the eighth fails here instead of in
 // a published table.
 //
+// ## The two fail-opens this gate shipped with, and what closed them
+//
+// A merged-PR audit found this file did not enforce its own central claim.
+// Both holes were REPRODUCED against the unmodified gate before anything
+// changed, each by a synthetic rider dropped into this directory:
+//
+//   * DIFFERENT IDS. A rider calling `resetLaneBuildCache(IMPL, CLEAR_BUILD)`
+//     and spawning `[runner, 'release', RELEASE_BUILD, …]`, with the two
+//     constants naming different builds, passed every check — it empties a
+//     cache nobody builds into and builds into a cache nobody cleared, which
+//     is the defect itself. The old check only rejected a string LITERAL
+//     sitting in the argv slot; it never read either identifier back.
+//   * A COMMENT. The clear search was a text search, so `resetLaneBuildCache(`
+//     appearing in a comment satisfied it. That is the exact shape left behind
+//     when a refactor deletes the call and keeps the explanation.
+//
+// So the gate now reads the build id out of BOTH sites and requires them to be
+// the same name, and every scan runs over CODE, with comments blanked.
+//
+// COMMENT BLANKING IS NOT A JS PARSER, deliberately. `codeOnly` models line
+// comments, block comments and the three string forms; it does not model regex
+// literals. The failure direction is what makes that acceptable: a mis-scan
+// blanks code, and blanked code makes an assertion FIRE, never fall silent. It
+// also refuses outright on an unterminated string or block comment rather than
+// returning a plausible-looking result.
+//
+// FIXTURES. `lane_cache_fixtures/` holds three drivers with known verdicts —
+// one correctly wired, one naming two different ids, one whose clear is only a
+// comment — so the gate has a regression net of its own and cannot quietly
+// stop firing. They live in a subdirectory because discovery reads THIS
+// directory only, and they are read as TEXT and never executed; the `require`
+// path in them is part of the source shape under test, not a live path.
+//
 // Wired into implementation/package.json via `test:script-helpers`.
 
 const assert = require('node:assert');
@@ -46,6 +79,43 @@ const path = require('node:path');
 const test = require('node:test');
 
 const DIR = __dirname;
+const FIXTURE_DIR = path.join(DIR, 'lane_cache_fixtures');
+
+// Blanks comments to spaces, leaving string literals and total length intact
+// (so `--config-merge` and `'release'` still match, and offsets still compare).
+// Throws rather than guessing when it runs off the end of a string or block.
+function codeOnly(src, file) {
+  const out = src.split('');
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i];
+    const next = src[i + 1];
+    if (c === '/' && next === '/') {
+      while (i < src.length && src[i] !== '\n') {
+        out[i] = ' ';
+        i += 1;
+      }
+    } else if (c === '/' && next === '*') {
+      const end = src.indexOf('*/', i + 2);
+      assert.notStrictEqual(end, -1, `${file}: unterminated block comment`);
+      for (let j = i; j < end + 2; j += 1) if (src[j] !== '\n') out[j] = ' ';
+      i = end + 2;
+    } else if (c === '"' || c === "'" || c === '`') {
+      i += 1;
+      while (i < src.length && src[i] !== c) i += src[i] === '\\' ? 2 : 1;
+      assert.ok(i < src.length, `${file}: unterminated string opened with ${c}`);
+      i += 1;
+    } else {
+      i += 1;
+    }
+  }
+  return out.join('');
+}
+
+function read(dir, file) {
+  const src = fs.readFileSync(path.join(dir, file), 'utf8');
+  return { file, src, code: codeOnly(src, file) };
+}
 
 // A rider is any file here that spawns a shadow-cljs release build with its
 // own `--config-merge`. Discovered, never listed: a new driver is caught by
@@ -59,18 +129,89 @@ const DIR = __dirname;
 // and are required to agree; disagreement is a failure, not a silence.
 const SOURCES = fs.readdirSync(DIR)
   .filter((f) => f.endsWith('.cjs') && !f.endsWith('.test.cjs') && f !== 'lane_cache.cjs')
-  .map((f) => ({ file: f, src: fs.readFileSync(path.join(DIR, f), 'utf8') }));
+  .map((f) => read(DIR, f));
 
 // Signal 1: it hands `--config-merge` to shadow-cljs's own CLI runner.
 const byRunner = SOURCES.filter(
-  ({ src }) => /runner\.js/.test(src) && /['"]--config-merge['"]/.test(src)
+  ({ code }) => /runner\.js/.test(code) && /['"]--config-merge['"]/.test(code)
 );
 // Signal 2: it passes `release` as a spawn argument.
 const bySpawn = SOURCES.filter(
-  ({ src }) => /['"]release['"]\s*,/.test(src) && /['"]--config-merge['"]/.test(src)
+  ({ code }) => /['"]release['"]\s*,/.test(code) && /['"]--config-merge['"]/.test(code)
 );
 
 const RIDERS = byRunner;
+
+const IS_RIDER = ({ code }) =>
+  /runner\.js/.test(code) && /['"]--config-merge['"]/.test(code) && /['"]release['"]\s*,/.test(code);
+
+// The build id as each site NAMES it. Identifiers only, on purpose: a literal
+// in either slot is a separate, separately-reported fault.
+const CLEAR_CALL = /resetLaneBuildCache\s*\(/;
+const CLEAR_BUILD_ID = /resetLaneBuildCache\s*\(\s*[\w$.]+\s*,\s*([A-Za-z_$][\w$]*)\s*\)/;
+const SPAWN_SLOT = /['"]release['"]\s*,/;
+const SPAWN_BUILD_ID = /['"]release['"]\s*,\s*([A-Za-z_$][\w$]*)/;
+
+// Each check answers with a failure message or null, so a fixture can assert
+// WHICH one fires rather than merely that something did.
+const CHECKS = {
+  requires: {
+    title: 'requires lane_cache.cjs',
+    run: ({ file, code }) =>
+      /require\(\s*['"]\.\/lane_cache\.cjs['"]\s*\)/.test(code)
+        ? null
+        : `${file} spawns a shared-build-id release and must require ./lane_cache.cjs`,
+  },
+
+  clearsFirst: {
+    title: 'calls resetLaneBuildCache BEFORE it spawns the build',
+    run: ({ file, code }) => {
+      // Over CODE, so comment text cannot stand in for a call.
+      const clear = code.search(CLEAR_CALL);
+      const spawn = code.search(SPAWN_SLOT);
+      if (clear === -1) return `${file} never calls resetLaneBuildCache (a mention in a comment is not a call)`;
+      if (spawn === -1) return `${file} has no release spawn to guard`;
+      return clear < spawn
+        ? null
+        : `${file} clears the cache AFTER spawning the build, which clears nothing`;
+    },
+  },
+
+  noLiteralId: {
+    title: 'names the build id once, not as a literal in the spawn argv',
+    run: ({ file, code }) =>
+      /['"]release['"]\s*,\s*['"]/.test(code)
+        ? `${file} passes a literal build id to spawnSync; hoist it to a const and ` +
+          'pass that same const to resetLaneBuildCache'
+        : null,
+  },
+
+  sameBuildId: {
+    title: 'clears the SAME build id it releases',
+    run: ({ file, code }) => {
+      // The central claim of this gate, and what it did not check until
+      // rf2-t4j7c: clearing one id and building another is the defect, not a
+      // fix for it. Silent when there is no clear at all — `clearsFirst` owns
+      // that fault and reports it better.
+      if (!CLEAR_CALL.test(code)) return null;
+      const cleared = code.match(CLEAR_BUILD_ID);
+      const released = code.match(SPAWN_BUILD_ID);
+      if (!cleared) {
+        return `${file} calls resetLaneBuildCache but its build-id argument is not a plain ` +
+          'identifier, so it cannot be compared with the one it releases; pass the same const';
+      }
+      if (!released) {
+        return `${file} does not name the build id with an identifier in the spawn argv, so ` +
+          'it cannot be compared with the one it clears';
+      }
+      return cleared[1] === released[1]
+        ? null
+        : `${file} clears \`${cleared[1]}\` but releases \`${released[1]}\` — one build id, ` +
+          'two names: it empties a cache nobody builds into and builds into a cache nobody ' +
+          'cleared. Pass one const to both.';
+    },
+  },
+};
 
 test('the two independent rider scans agree (neither pattern has drifted)', () => {
   const a = byRunner.map((r) => r.file).sort();
@@ -92,35 +233,48 @@ test('the rider set is non-empty (a discovery that finds nothing is not a pass)'
   );
 });
 
-for (const { file, src } of RIDERS) {
-  test(`${file} requires lane_cache.cjs`, () => {
-    assert.match(
-      src,
-      /require\(\s*['"]\.\/lane_cache\.cjs['"]\s*\)/,
-      `${file} spawns a shared-build-id release and must require ./lane_cache.cjs`
-    );
-  });
+for (const rider of RIDERS) {
+  for (const check of Object.values(CHECKS)) {
+    test(`${rider.file} ${check.title}`, () => {
+      const failure = check.run(rider);
+      assert.ok(failure === null, failure);
+    });
+  }
+}
 
-  test(`${file} calls resetLaneBuildCache BEFORE it spawns the build`, () => {
-    // `search` with a quote-agnostic pattern, not `indexOf` on one spelling.
-    const clear = src.search(/resetLaneBuildCache\s*\(/);
-    const spawn = src.search(/['"]release['"]\s*,/);
-    assert.notStrictEqual(clear, -1, `${file} never calls resetLaneBuildCache`);
-    assert.notStrictEqual(spawn, -1, `${file} has no release spawn to guard`);
+// ## The gate's own regression net
+//
+// Each fixture is rider-shaped and carries the one check it must trip — or
+// null, for the correctly-wired control. A gate that rejects valid wiring is
+// worse than one that admits invalid wiring, because everyone routes around
+// it, so the control is not optional.
+const FIXTURES = {
+  'agreeing_ids_run.cjs': null,
+  'mismatched_ids_run.cjs': 'sameBuildId',
+  'commented_clear_run.cjs': 'clearsFirst',
+};
+
+for (const [file, expected] of Object.entries(FIXTURES)) {
+  test(`fixture ${file} is rider-shaped and outside discovery`, () => {
+    const fixture = read(FIXTURE_DIR, file);
+    assert.ok(IS_RIDER(fixture), `${file} is not rider-shaped, so its verdict proves nothing`);
     assert.ok(
-      clear < spawn,
-      `${file} clears the cache AFTER spawning the build, which clears nothing`
+      !RIDERS.some((r) => r.file === file),
+      `${file} was discovered as a real rider; fixtures must stay in ${path.basename(FIXTURE_DIR)}`
     );
   });
 
-  test(`${file} names the build id once, not as a literal in the spawn argv`, () => {
-    // The clear and the build must be incapable of naming different ids.
-    // A string literal in the argv slot is how they drift apart.
-    assert.doesNotMatch(
-      src,
-      /['"]release['"]\s*,\s*['"]/,
-      `${file} passes a literal build id to spawnSync; hoist it to a const and ` +
-        'pass that same const to resetLaneBuildCache'
+  test(`fixture ${file} trips exactly ${expected === null ? 'nothing' : expected}`, () => {
+    const fixture = read(FIXTURE_DIR, file);
+    const fired = Object.entries(CHECKS)
+      .filter(([, check]) => check.run(fixture) !== null)
+      .map(([id]) => id);
+    assert.deepStrictEqual(
+      fired,
+      expected === null ? [] : [expected],
+      expected === null
+        ? `${file} is correctly wired and must pass every check; it failed: ${fired.join(', ')}`
+        : `${file} must fail ${expected} and nothing else; it failed: ${fired.join(', ') || 'nothing'}`
     );
   });
 }


### PR DESCRIPTION
rf2-t4j7c, reopened by the merged-PR audit of #7569. The seven drivers are fixed and are untouched here. The charge is against the **gate** that was added to protect them: `lane_cache_wiring.test.cjs` did not enforce its own central claim that the clear and the release name the same build id.

## The two fail-opens, reproduced before anything changed

Both were reproduced against the **unmodified** gate, by dropping a synthetic rider into the real discovery directory and running the real gate. A fail-open claim deserves a reproduction, not a reading.

**A — different ids.** A rider calling `resetLaneBuildCache(IMPL, CLEAR_BUILD)` while spawning `[runner, 'release', RELEASE_BUILD, ...]`, the two constants naming different builds, passed **every** check on unmodified `main` — rider discovery, the require, clear-before-spawn and the no-literal check — exit 0, 26/26. It empties a cache nobody builds into and builds into a cache nobody cleared, which is precisely the defect the gate exists to catch. The old third test only rejected a string *literal* sitting in the argv slot; it never captured either identifier and never compared them.

**B — a comment.** The clear search was a text search, so `resetLaneBuildCache(` appearing inside a comment satisfied it. A rider that never clears anything passed all three checks, exit 0. That is the exact shape left behind when a refactor deletes the call and keeps the explanation.

PR #7570's later quote-agnostic require correction does not cover either gap.

## The repair

The gate now reads the build id out of **both** sites and requires the same identifier (`sameBuildId`), and every scan runs over **code**, with comments blanked (`codeOnly`), so comment text can no longer stand in for a call.

Comment blanking is deliberately **not** a JS parser. It models line comments, block comments and the three string forms; it does not model regex literals, and the riders do contain them. The failure direction is what makes that acceptable, and it is stated in the file: a mis-scan blanks code, and blanked code makes an assertion **fire**, never fall silent. It also refuses outright on an unterminated string or block rather than returning a plausible-looking result.

The four per-rider checks are now named predicates returning a message or `null`, so a fixture can assert *which* check fires rather than merely that something did.

`lane_cache_fixtures/` holds three drivers with known verdicts — one correctly wired, one naming two different ids, one whose clear is only a comment. They live in a subdirectory because discovery reads the bench directory only, and they are read as text, never executed. Each is asserted to be rider-shaped (so its verdict is not vacuous), to be absent from the discovered rider set, and to trip **exactly** its one expected check.

## The ESLint failure, and why the fixture changed rather than the config

The first push was red on `lint:js`: the comment-only fixture bound `resetLaneBuildCache` and never called it, so `no-unused-vars` fired. That unused binding is the exact property the fixture exists to have, so calling the function was never an option.

Neither escape hatch survives this repo's own conventions:

* **A suppression would be the only one in the tree.** The canonical check from the config header — `git grep -nE "(/\*|//) *eslint-(disable|enable)" -- '*.cjs' '*.js' '*.mjs'` — returns **nothing**. `rf2-kvsm1` has already retired the last live directive, so the tree is at zero, not one.
* **An ignore is what the ignores list forbids.** That list is for trees that are generated *and* can carry JS, "not when a file in it happens to have complained". These fixtures are hand-authored.

So the binding is simply gone — `require('./lane_cache.cjs');` with nothing bound. The gate's `requires` check matches the require *call*, not an assignment, so it still passes.

This makes the fixture **stronger rather than merely quieter**. A refactor that deletes the clear leaves one of two shapes, and they are not equally dangerous. Keep the binding and `no-unused-vars` reports the orphan — the lint config names that arm outright ("a bad `require` whose binding is NEVER read is caught") — so lint catches that driver a gate earlier. Drop the binding too and nothing in the lint path can see anything wrong. That second variant is the one no other gate owns, so it is the one worth modelling.

Demonstrated rather than asserted: with a comment-only rider sitting in the discovery directory, **`npm run lint:js` exits 0 while this gate exits 1 on the same file.**

The fixtures stay **in** the lint path and are held to the same rules as real driver source, because being faithful driver source is the whole of their value; an ignore would let them drift into shapes no driver could take.

## Quality gates

All run foreground to completion, exit code captured on the next line, nothing piped through `tail` or `grep`.

| gate | exit |
| --- | --- |
| `node …/lane_cache_wiring.test.cjs` — baseline on unmodified main | 0 (23/23) |
| same gate, unmodified, **+ differing-constants rider** (reproduction A) | **0 (26/26) — the fail-open** |
| same gate, unmodified, **+ comment-only-clear rider** (reproduction B) | **0 — the fail-open** |
| `npm run lint:js` — **before** the fixture fix (reproduces CI job 92560082596 exactly) | **1** |
| `npm run lint:js` — after | **0** |
| `npm run lint:js` — with a comment-only rider present (lint cannot see it) | **0**, while the gate is **1** |
| canonical zero-suppression grep, after | no output (contract intact) |
| repaired gate, clean tree | 0 (36/36) |
| repaired gate **+ differing-constants rider** (mutation A) | **1** |
| repaired gate **+ comment-only-clear rider** (mutation B) | **1** |
| repaired gate **+ legitimate double-quoted rider** (mutation C) | 0 |
| `node --check` on the gate and all three fixtures | 0, 0, 0, 0 |
| `npm ci` — root (lint) and `implementation/` | 0, 0 |
| `npm run test:script-helpers` (the suite this gate is wired into) | 0, `fail 0` |

All four files are pure CRLF on disk (line count equals CR-terminated line count, no mixed endings), so every run above already exercised the byte shape CI checks out. This lane has had CRLF anchoring silently no-op a mutation before, which is why it is verified rather than assumed.

### Mutation, both directions

Each mutation was confirmed **applied** before any verdict was read — `git status` showed the file, the new token was grepped back out, and the shape it replaced was confirmed absent. A mutation that silently does not apply is indistinguishable from a gate that did not fire.

**Must fail — A, different ids.** Exit 1, and it fails *by name* with both identifiers:

```
✖ zz_mut_a_run.cjs clears the SAME build id it releases
  AssertionError: zz_mut_a_run.cjs clears `CLEAR_BUILD` but releases `RELEASE_BUILD`
  — one build id, two names: it empties a cache nobody builds into and builds into
  a cache nobody cleared. Pass one const to both.
```

**Must fail — B, comment-only clear.** Exit 1, by name:

```
✖ zz_mut_b_run.cjs calls resetLaneBuildCache BEFORE it spawns the build
  AssertionError: zz_mut_b_run.cjs never calls resetLaneBuildCache
  (a mention in a comment is not a call)
```

**Must pass — C, legitimate wiring.** An eighth rider the gate has never seen, written in **double** quotes throughout and using a const named `LANE_BUILD` rather than `BUILD`, passes all four checks, exit 0. So a pass means the comparison is by identifier and stays quote-agnostic — not that the gate memorised the seven. A gate that rejects valid wiring is worse than one that admits invalid wiring, because everyone routes around it, which is why this direction is proven and not assumed.

All three temporary riders were removed; `git status` is clean apart from the intended diff.

### On vacuity

The seven real drivers all pass `sameBuildId`, and that pass cannot be vacuous. `sameBuildId` has exactly one silent path — no clear call at all — and in that case `clearsFirst` fails instead. All seven pass `clearsFirst`, so the clear matched on all seven, so `sameBuildId` extracted and compared two real identifiers on each. A mutation on a committed driver would have shown the same thing; the fence forbids touching them, and the argument above does not need one.

### Scope

The seven drivers are untouched — they re-diff empty against the merge base. No measurement, arm, threshold, sample count, exit code or dataset moves. No hot-zone file touched: `implementation/shadow-cljs.edn` and `implementation/package.json` are unchanged (the gate was already wired into `test:script-helpers`), and `eslint.config.mjs` is unchanged. No `.beads` path in the diff, verified against the merge base `b557ed71f4`.
