### PR TITLE
docs(schemas): retire four false claims in the bundle-probe docstring (rf2-v4o7e)

### DIFF
--- a/implementation/schemas/test/re_frame/schemas_bundle_probe.cljs
+++ b/implementation/schemas/test/re_frame/schemas_bundle_probe.cljs
@@ -1,42 +1,77 @@
 (ns re-frame.schemas-bundle-probe
-  "Bundle-cost probe (rf2-fqbcy) — measures the gzipped cost of
-  requiring `re-frame.schemas`, per Spec 010 §Bundle cost.
+  "SCHEMAS arm of the bundle-cost A/B (rf2-fqbcy, rf2-kybsf, rf2-v4o7e) —
+  the B arm whose A arm is `re-frame.schemas-bundle-control`.
+
+  ## What the pair measures
+
+  Spec 010 §Bundle cost budgets a MARGINAL quantity: what requiring
+  `re-frame.schemas` adds on top of an app that already uses re-frame2.
+  The two builds differ by EXACTLY ONE require —
+
+    schemas-bundle-control   `[re-frame.core]` only.
+    schemas-bundle-probe     `[re-frame.core]` + `[re-frame.schemas]`.
+
+  — so `probe - control` is the schemas opt-in and nothing else: both
+  arms carry the same `cljs.core` and the same `re-frame.core`, and
+  both cancel. `scripts/check-schemas-bundle.cjs` asserts that margin
+  TWO-SIDED — at most 45 KB gzipped, at least 20 KB. It asserts no
+  absolute size at all: a probe's absolute figure is mostly `cljs.core`
+  and `re-frame.core`, which the perf-bundle and bundle-isolation gates
+  own, and an absolute ceiling here duly spent 83 days measuring their
+  growth rather than the schemas artefact's (rf2-kybsf). The checker's
+  header carries the matched run both bounds were set from.
+
+  ## Why requiring the facade alone still prices Malli
 
   Per rf2-v96fh (schema implies validation) the `re-frame.schemas`
-  facade now `:require`s `re-frame.schemas.malli` itself, so this
-  probe — which requires ONLY `re-frame.schemas`, NOT the adapter —
+  facade `:require`s `re-frame.schemas.malli` in its own ns-form, so
+  this probe — which requires ONLY the facade, NOT the adapter —
   nonetheless pulls Malli's validation surface into the bundle. That
   is the deliberate Ruling-A tradeoff: requiring the schemas artefact
   implies Malli is wired, so a registered schema always validates
-  rather than soft-passing into a silent no-op. There is no longer a
-  'schemas required, no Malli' bundle posture (the only Malli-free
-  posture is not requiring the schemas artefact at all — the no-feature
-  counter app, pinned by the counter bundle-isolation gate).
+  rather than soft-passing into a silent no-op. There is no 'schemas
+  required, no Malli' posture to price (the only Malli-free posture is
+  not requiring the schemas artefact at all — the no-feature counter
+  app, pinned by the counter bundle-isolation gate). That is also why
+  the control is core-only: this probe's posture is the only schemas
+  posture a consumer can buy.
 
-  The companion probe `re-frame.schemas-bundle-probe-malli` requires
-  the adapter EXPLICITLY on top; under Ruling A the explicit require
-  is a no-op (the facade already loaded it), so the two bundles are now
-  the same size — `scripts/check-schemas-bundle.cjs` asserts that
-  equality as the schema-implies-validation regression guard (a revert
-  of the facade require would drop THIS probe back to the ~59 KB
-  Malli-free figure and break the equality).
+  The gate's FLOOR is where that invariant shows up in bundle shape.
+  Delete the adapter require from the facade's ns-form and Malli leaves
+  this bundle: the margin falls to a measured 9.7 KB and the checker
+  exits 1. The invariant's PRIMARY owner is the behavioural test
+  `schemas/test/re_frame/schemas_implies_validation_test.clj`; the floor
+  is the bundle-shaped corroboration, and it is what replaced the old
+  byte-equality guard — that guard compared this probe against a
+  near-identical `-malli` sibling, and both retired together, the
+  sibling being a redundant require rather than a distinct posture.
 
-  shadow-cljs build target `:schemas-bundle-probe` compiles this ns
-  under `:advanced` + `goog.DEBUG=false`. scripts/check-schemas-bundle.cjs
-  reads the bundle's gzipped size and asserts it sits within the
-  spec envelope.
+  ## Why `boot` touches only schemas symbols
 
   The probe namespace does NO runtime work — it exists only to root
   the schemas-artefact's dead-code-elimination graph so Closure
   retains the namespace's body. Each public symbol is touched once
-  to anchor it; the exported boot fn is the bundle's entry point."
+  to anchor it; the exported boot fn is the bundle's entry point. It
+  roots no `re-frame.core` symbol, and the control roots none either:
+  core surface rooted by one arm and not the other lands in the margin
+  and misprices the opt-in in whichever direction the asymmetry runs.
+
+  shadow-cljs build target `:schemas-bundle-probe` compiles this ns
+  under `:advanced` + `goog.DEBUG=false` — identical settings to
+  `:schemas-bundle-control`, which is what makes the two figures
+  subtractable."
   (:require [re-frame.core    :as rf]
             [re-frame.schemas :as schemas]))
 
 (defn ^:export boot
-  "Bundle-probe init-fn. Touches the schemas surface so DCE retains
-  every published symbol; the probe's bundle then reflects the cost
-  every consumer that requires `re-frame.schemas` would pay.
+  "Probe init-fn. Touches the schemas surface so DCE retains every
+  published symbol; the probe's MARGIN over `schemas-bundle-control`
+  then reflects the cost every consumer that requires
+  `re-frame.schemas` would pay.
+
+  Touches nothing from `re-frame.core` — that require is the arm the
+  two builds share, and rooting core surface here would inflate the
+  margin with a cost the control never subtracts away.
 
   Named `boot` (not `run!`) to avoid shadowing `cljs.core/run!`."
   []


### PR DESCRIPTION
Closes the audit residual on **rf2-v4o7e**. The bead's original charge — replace the absolute ceiling with a delta against a control — shipped in #7551. What #7551 missed is that it left `implementation/schemas/test/re_frame/schemas_bundle_probe.cljs` **byte-for-byte unchanged** while changing everything that file describes. Its ns/boot docstrings kept asserting four claims the same PR had falsified.

That matters more than a stale comment usually would: a probe's docstring is what the next reader uses to understand what the gate proves, and this file is the natural first stop when the gate reds. Four false claims there would regenerate exactly the belief #7551 removed.

## The four claims, verified against source

Each checked by reading `check-schemas-bundle.cjs` and `schemas_bundle_control.cljs` on `main`, not the audit's summary.

| Claim in the old docstring | Status | Evidence |
|---|---|---|
| the companion probe `re-frame.schemas-bundle-probe-malli` exists | **false** | the ns is gone; `git grep` finds its name in no tracked source file except this docstring. `implementation/shadow-cljs.edn` (`:schemas-bundle-control` / `:schemas-bundle-probe`) and `package.json`'s `test:schemas-bundle` both name the control. |
| the checker asserts *equality* between the two probes | **false** | `check-schemas-bundle.cjs` contains no equality assertion. It computes `margin = probe - control` and bounds it. |
| a reverted facade require breaks that equality | **false** | a revert now collapses the **margin** — the checker header records the measurement at 9.7 KB — through the 20 KB floor, `exit 1`. |
| the bundle is checked against a *spec envelope* | **false** | there is no absolute envelope. `MARGIN_MIN_BYTES` / `MARGIN_MAX_BYTES` bound the margin and nothing else; `spec/010-Schemas.md` §Bundle cost says so in its own words ("There is no absolute ceiling"). |

Nothing in the old docstring survived verification as still-true-but-stale, so nothing was preserved on those grounds.

## What the docstring says now

The three things the bead asked for — the core-only control, the 20–45 KB two-sided contract, and this ns's role as the schemas arm — plus the sibling control's `##` section shape, so opening either file of the pair gives the same outline.

One paragraph is **kept because it is still true**: per rf2-v96fh the `re-frame.schemas` facade still `:require`s `re-frame.schemas.malli` in its own ns-form, so requiring the facade alone still pulls Malli. It is now stated as the *reason* the control is core-only rather than adapter-stripped — the probe's posture is the only schemas posture a consumer can buy — which is the ruling's own argument, rather than as setup for the retired equality guard.

`boot` picks up the constraint its sibling already documents from the other side: it touches no `re-frame.core` symbol, because core surface rooted by one arm and not the other lands in the margin. The control's docstring warns against adding an `rf/…` call there; the probe now carries the mirror of that warning.

Docstrings only — no code, no threshold, no new checker, per the bead's explicit scope.

## Quality gates

Run from the worker worktree with a locally-installed `node_modules` (`npm ci` in-tree, no junction), foreground to completion, nothing piped through `tail`/`grep`.

| Gate | Exit | Result |
|---|---|---|
| `npm run test:schemas-bundle` | **0** | `PASS schemas-bundle: schemas-bundle-control=84.3 KB; schemas-bundle-probe=125.0 KB; margin=40.6 KB within 20.0 KB…45.0 KB` — both arms built `:advanced`, **0 warnings** |
| `clojure -M:test` in `implementation/schemas` | **0** | Ran **363** tests / **19188** assertions, 0 failures, 0 errors |
| `sh scripts/test-fast-pr.sh` | **0** | terminal marker `PASS fast PR spine`. Classified `docs=false jvm=true node=true`; JVM tier `implementation/core` + `implementation/schemas`. Ran **2233**/11645, **363**/19188 and **12724**/63819 tests-assertions across the three suites, 0 failures |

The schemas-bundle gate is the load-bearing one for this change: it is what compiles this file, so a malformed docstring would surface there as a read error and `:advanced` would not link. It links, at 0 warnings, and the margin reproduces the checker header's recorded matched run (control 84.3 KB, margin 40.6 KB) — confirming the edit is inert to the measurement, which for a docstring-only change is the point.

Bead: rf2-v4o7e
