### PR TITLE
ci(scripts): route a loader unlinked mid-read to the setup error, not the leak verdict (rf2-1wyyb)

### DIFF
--- a/implementation/scripts/check-ui-adapter-isolation.cjs
+++ b/implementation/scripts/check-ui-adapter-isolation.cjs
@@ -415,9 +415,27 @@ function classifyArm2(tree, expectedLocalRoot = requiredCoordinateLocalRoot) {
 // Read the focused loader's SHADOW_IMPORT closure. Split out (and injectable
 // via main's io seam) so the self-test can drive main() end-to-end with a
 // synthetic closure — no shadow-cljs build artefact required.
+// The existence probe and the read are two syscalls, and the gap between them
+// is the one place a moved bundle can still reach this gate (rf2-1wyyb).
+// `npm run test:ui-isolation` compiles through `compile-node-test.cjs`, which
+// UNLINKS `:output-to` before every compile so a failed one leaves nothing
+// stale (rf2-6t03c) — so a second compile of `node-test-ui` starting in that
+// gap deletes the loader after `existsSync` said it was there. An ENOENT
+// escaping here would be an UNCAUGHT throw, and node exits 1 for that: the
+// code this gate reserves for a real wrapper leak. That is the sibling gate's
+// three-causes-one-verdict defect in miniature (rf2-v8561, PR #7608) — an
+// ENVIRONMENT cause wearing the ISOLATION verdict's exit code. The bundle
+// vanishing is the `missing` case however late it is noticed, so route it
+// there and let main() report it as the setup error (exit 2) it is. Any OTHER
+// read error (EACCES, EISDIR) is not this class and still throws.
 function readFocusedLoaderImports() {
   if (!fs.existsSync(loaderPath)) return { missing: true };
-  return { imports: importsFrom(fs.readFileSync(loaderPath, 'utf8')) };
+  try {
+    return { imports: importsFrom(fs.readFileSync(loaderPath, 'utf8')) };
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return { missing: true };
+    throw err;
+  }
 }
 
 // --- self-test (hermetic; no build artefacts, no JVM, no shell) ------------
@@ -736,6 +754,59 @@ function selfTest() {
     }
   }
 
+  // --- Loader read under a mid-flight unlink (rf2-1wyyb) -------------------
+  // The bundle moving underneath the gate is an ENVIRONMENT cause and must
+  // never wear the ISOLATION verdict's exit code. Every other way that can
+  // happen already lands on exit 2 (absent loader, zero SHADOW_IMPORT rows,
+  // positive control missing); the ENOENT thrown by a `readFileSync` whose
+  // file was unlinked after `existsSync` did not, because an uncaught throw
+  // exits 1. Drive the interleaving directly — `existsSync` true, the file
+  // gone one syscall later, which is exactly what a concurrent
+  // `compile-node-test.cjs node-test-ui` produces (rf2-6t03c).
+  const withStubbedLoaderRead = (readImpl, fn) => {
+    const saved = { existsSync: fs.existsSync, readFileSync: fs.readFileSync };
+    fs.existsSync = () => true;
+    fs.readFileSync = readImpl;
+    try {
+      return fn();
+    } finally {
+      Object.assign(fs, saved);
+    }
+  };
+  const throwing = (code) => () => {
+    throw Object.assign(new Error(`${code}: synthetic loader read failure`), { code });
+  };
+
+  const unlinkedRead = withStubbedLoaderRead(throwing('ENOENT'), () => {
+    try {
+      return readFocusedLoaderImports();
+    } catch (err) {
+      return { threw: err };
+    }
+  });
+  if (unlinkedRead.threw) {
+    return fail(
+      'a loader unlinked between existsSync and readFileSync must be reported as missing, not thrown ' +
+        '(an uncaught ENOENT exits 1 — the wrapper-leak code — for an environment cause)'
+    );
+  }
+  if (!unlinkedRead.missing) {
+    return fail('a loader unlinked mid-read must classify as missing');
+  }
+
+  // Only THIS class is routed. A read error that does not mean "the bundle
+  // moved" (EACCES, EISDIR) is not silently converted into a setup error.
+  const otherRead = withStubbedLoaderRead(throwing('EACCES'), () => {
+    try {
+      return { value: readFocusedLoaderImports() };
+    } catch (err) {
+      return { threw: err };
+    }
+  });
+  if (!otherRead.threw || otherRead.threw.code !== 'EACCES') {
+    return fail('a non-ENOENT loader read error must still propagate, not be swallowed as missing');
+  }
+
   // --- End-to-end gate decisions (main() with injected IO) -----------------
   // Prove the previously-false-green conditions now go RED, and that genuinely
   // passing conditions stay green. Console is silenced for the intentional
@@ -745,6 +816,19 @@ function selfTest() {
   // configured root injected (POSIX-shaped by default; overridden per case).
   const runMain = (argv, io) =>
     withSilencedConsole(() => main(argv, { coreLocalRoot: POSIX_ROOT, ...io }));
+
+  // rf2-1wyyb, end-to-end: a loader unlinked between `existsSync` and
+  // `readFileSync` reaches main() as the setup error (exit 2) it is, NOT as a
+  // leak accusation. `readLoaderImports` is deliberately NOT injected here —
+  // this drives the real reader, which is where the ENOENT arises. Removing
+  // that routing makes the throw uncaught, and node's exit 1 for an uncaught
+  // throw is the code this gate reserves for a real wrapper leak.
+  const unlinkedExit = withStubbedLoaderRead(throwing('ENOENT'), () =>
+    runMain([], { resolveTree: () => ({ status: 0, stdout: cleanTree }) })
+  );
+  if (unlinkedExit !== 2) {
+    return fail(`a loader unlinked mid-read must fail closed (exit 2), got exit ${unlinkedExit}`);
+  }
 
   // MUTATION 1 — a direct `reagent2.core` import in the focused first-party UI
   // closure reds the gate (exit 1) EVEN WHEN no forbidden coordinate is
@@ -876,7 +960,8 @@ function selfTest() {
       'separator-bearing prose / plausible-shape WRONG-ROOT evidence all fail closed; missing / ' +
       'untrusted clojure fails closed; the positive control requires day8/re-frame2 to have ' +
       'resolved to the local root ui/deps.edn configures, and the real implementation/ui graph ' +
-      'still passes on Windows- and POSIX-shaped roots; --modules-only is explicit)'
+      'still passes on Windows- and POSIX-shaped roots; a loader unlinked mid-read is the setup ' +
+      'error it is, never a leak; --modules-only is explicit)'
   );
   return 0;
 }


### PR DESCRIPTION
## The answer to the bead

rf2-1wyyb asked whether `check-ui-adapter-isolation.cjs` shares the three-causes-one-verdict misclassification just fixed in its sibling `check-per-ns-isolation.cjs` (rf2-v8561, PR #7608).

**It does not, and the reason is structural.** The sibling spawns one node process per curated namespace over a **shared** `out/node-test.js` that links every test namespace, so `--test=<ns>` is a *runtime* selector: a module-load crash cannot single a namespace out, which is why a red without `Ran N tests containing M assertions.` was never a verdict about that namespace, and why a concurrent compile deleting the bundle mid-sweep made it accuse sixteen **contiguous** roster entries.

This gate spawns nothing per namespace. Arm 1 reads `out/node-test-ui.js` **once, as text**, and executes no test at all; Arm 2 spawns exactly one `clojure -Stree`. There is no roster, no sweep, and no runtime selector — **so the discriminator has no referent here.** The bead's own instruction applies: "If it does not — for instance because it does not spawn per-namespace over a shared bundle — say so."

## Evidence: the cause matrix

Driving `main()` through the analogue of each cause (via the file's existing `io` seam) shows the three-way split is **already present and already correct**:

| cause | case | exit |
|---|---|---|
| ISOLATION | Arm 1 adapter module in closure | 1 |
| ISOLATION | Arm 1 direct wrapper (`reagent2.core.js`) | 1 |
| ISOLATION | Arm 2 forbidden coordinate | 1 |
| ROSTER | Arm 1 positive control renamed away | 2 |
| ROSTER | Arm 2 core coordinate re-declared | 2 |
| ENVIRONMENT | loader absent (compile unlinked it) | 2 |
| ENVIRONMENT | loader half-written, zero rows | 2 |
| ENVIRONMENT | clojure absent / spawn failed / vacuous graph | 2 |
| GREEN | clean closure + clean graph | 0 |

The **non-zero-count floor** has an analogue too, present twice already: a loader with zero `SHADOW_IMPORT` rows, and one missing the `re_frame.ui.substrate.js` positive control, both fail closed at exit 2.

A **stale denylist** here cannot misattribute a red at all — an unlisted wrapper root simply passes, so staleness is a false **green**, a different failure mode from the sibling's stale roster (which produced a misattributed **red**).

**Adjacency check:** not applicable — this gate names modules and coordinates, never namespaces, and has no roster whose ordering could reveal a single external event.

## What the fault injection did find

Much smaller, and **not** the sibling's defect. `readFocusedLoaderImports()` probed existence and then read — two syscalls apart:

```js
if (!fs.existsSync(loaderPath)) return { missing: true };
return { imports: importsFrom(fs.readFileSync(loaderPath, 'utf8')) };
```

`npm run test:ui-isolation` compiles through `compile-node-test.cjs`, which unlinks `:output-to` before every compile so a failed one leaves nothing stale (rf2-6t03c) — **the same mechanism that invalidated the sibling's sweep.** A second compile of `node-test-ui` landing in that gap deletes the loader after `existsSync` said it was there, and the resulting `ENOENT` escaped **uncaught**. Node exits **1** for an uncaught throw, and 1 is the code this gate reserves for a real wrapper leak — an environment cause wearing the isolation verdict's exit code.

The window is two syscalls wide rather than the sibling's tens of seconds, so this is a far smaller thing than what PR #7608 fixed. It is nonetheless the one remaining hole in an otherwise complete exit-code contract, and the reader already has a `missing` channel to route it through. Any **other** read error (`EACCES`, `EISDIR`) is not this class and still throws.

## Mutation control

Reconstructing the pre-fix reader in a throwaway copy of the gate and running *its* self-test:

```
pre-fix (uncaught ENOENT) self-test exit = 1
[ui-adapter-isolation] self-test: a loader unlinked between existsSync and readFileSync
must be reported as missing, not thrown (an uncaught ENOENT exits 1 — the wrapper-leak
code — for an environment cause)

MUTATION KILLED — the new assertions are real teeth.
```

## Quality gates

Fence: `implementation/scripts/check-ui-adapter-isolation.cjs` and its self-test. One file, 87 insertions / 2 deletions. No `.beads` path in the diff against the merge base (verified, 0 files).

| gate | exit |
|---|---|
| `node scripts/check-ui-adapter-isolation.cjs --self-test` (baseline, before change) | 0 |
| `node scripts/check-ui-adapter-isolation.cjs --self-test` (after change) | 0 |
| mutation control (pre-fix reader reconstructed) | **1 — correctly red** |
| `npm ci` (repo root, `re-frame2-lint`) | 0 |
| `npm run lint:js` | 0 |
| real-file read: clean synthetic loader, `--modules-only` | 0 |
| real-file read: `reagent2.core.js` leak, `--modules-only` | 1 |
| real-file read: loader deleted | 2 |

`lint:js` lives in the **separate repo-root** `re-frame2-lint` project, so `npm ci` was run at the worktree root and `node_modules/.bin/eslint` confirmed present before running it — the gate was genuinely runnable, not silently absent.

The last three rows drive the **real** `readFocusedLoaderImports` against a real file on disk (a hand-written `SHADOW_IMPORT` loader, no shadow-cljs compile), covering the happy path that the injected-`io` self-test cases bypass. The full `npm run test:ui-isolation` (shadow-cljs `:node-test-ui` compile + Arm 2 `clojure -Stree`) is left to CI; the change touches only an error path in a `.cjs` script, and every branch of it is pinned hermetically by the self-test.
