### PR TITLE
docs(hicasso): draft-guide Performance chapter names the :render bucket (rf2-2rtt6.127)

### DIFF
--- a/docs/design/hicasso/draft-guide/11-performance.md
+++ b/docs/design/hicasso/draft-guide/11-performance.md
@@ -87,12 +87,41 @@ obviously a foreign/SDK boundary you never expected Hiccup to own.
 
 ### Name the island first
 
-You do not need Hicasso-private tooling.
+You do not need Hicasso-private tooling. The measurements are the browser's own.
 
 | Tool | What it shows |
 |---|---|
 | **React DevTools Profiler** | Which components commit (every Hicasso boundary is a real React FC) |
+| **Chrome DevTools Performance** | The `rf:*` User-Timing measures, natively, in the Timings track |
 | **Xray** (or Spec 009) | Which **subscriptions** recomputed for the event you care about |
+
+**All four Performance buckets are live for a Hicasso app.** Build with
+`:closure-defines {re-frame.performance/enabled? true}` and every `defview`
+boundary emits one `rf:render:<ns>/<view>` measure per render — alongside the
+`rf:event:*`, `rf:sub:*` and `rf:fx:*` measures core already emits, since those
+sit in the router, the subs layer and the fx layer Hicasso consumes unchanged.
+The id is the head's `displayName`, so the name you filter the profile on is the
+name React DevTools shows. The flag is compile-time and default-off: a shipped
+build carries no render timing at all.
+
+Two measure counts that look like bugs and are not. A **bail-out emits nothing**
+— React consults the comparator above the bracket, so a boundary it skipped is
+absent from the stream rather than present at zero, which is what makes the
+count a measure of work actually done. And a boundary React invokes twice under
+**StrictMode emits twice**, because the body really did run twice. Only
+boundaries are bracketed: a plain inlined helper's cost lands inside its
+enclosing boundary's measure, the same place its reads land.
+
+Entries are *delivered, not retained* — each bracket emits its measure and then
+clears it by name, so a `PerformanceObserver` and the DevTools timeline see
+everything while a later `getEntriesByType("measure")` poll finds nothing. Flip
+the companion `re-frame.performance/retain-entries?` define if you want a
+one-shot reader to work.
+
+Spec 009's view **trace** pair (`:rf.view/render` / `:rf.view/rendered`) is a
+different channel, and it is the **adapter path's** today — Hicasso boundaries
+do not emit it, by ruling rather than by omission. For render timing on
+Hicasso, the `rf:render:*` measures are the signal.
 
 Name the boundary, the sub, or the event **before** changing architecture.
 "The app is slow" is still the 98% problem wearing a costume.


### PR DESCRIPTION
Closes the last acceptance bullet of **rf2-2rtt6.125**, tracked as **rf2-2rtt6.127**.

## The brief's premise was wrong, in both directions

The dispatch said the chapter *claims* Hicasso owns `rf:render:*` "post-rename", so the claim names a surface that has moved. Neither half holds:

- **Nothing moved.** `rf:render:*` is the current, live entry name. `git grep` finds it in `spec/009-Instrumentation.md` §Naming convention, `spec/API.md`, `spec/Tool-Pair.md`, `implementation/core/src/re_frame/performance.cljc`, `implementation/freehand/src/re_frame/freehand/{shell,react}.cljs` and both arm1 render-measure suites. There is no rename. The rename named in rf2-2rtt6.127's own description was a **file** rename (`11-performance.md` → `11-below-hiccup.md`) that never landed — `git ls-tree origin/main docs/design/hicasso/draft-guide/` still lists `11-performance.md`.
- **The chapter made no such claim.** Before this PR the file contained no occurrence of `rf:render` at all.

So the defect is the **opposite** of the one briefed: the chapter *under*-claimed. Its "Name the island first" table offered React DevTools Profiler plus Xray-for-subs and said "You do not need Hicasso-private tooling" — advice that was exactly right *before* rf2-2rtt6.125 landed the `:render` wiring, and stale from the moment it did. A Hicasso author reading the guide had no way to learn that per-view render timing exists.

**Outcome: (1) the chapter is wrong → prose fixed.** Not (2) — the code does what Spec 009 says. Not (3) — the `:render` ownership is spec'd (009 §What gets bracketed names the compiled-view substrate's minted component fn) and rf2-2rtt6.126 *ruled* on the one part that could not ship.

## Every new claim, read from an emit site

| Claim in the prose | Source it was read from |
|---|---|
| `:event` / `:sub` / `:fx` ride core unchanged; `:render` is the substrate's | `implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs` (mint-view! docstring); `spec/009-Instrumentation.md` §What gets bracketed |
| One `rf:render:<view-id>` measure per boundary render | `freehand/shell.cljs` `render` (the shared shell chokepoint); `freehand/react.cljs` for the `:elided` compiled path; `performance/mark-and-measure :render` at both |
| Gated on `:closure-defines {re-frame.performance/enabled? true}`, default-off, `:advanced`-DCE'd | `implementation/core/src/re_frame/performance.cljc`; `spec/API.md` |
| Id is the head's `displayName` | `arm1/render-measure-cljs-test` asserts `displayName` == the `<view-id>` `build-name` produces, for both a namespaced `defview` head and a bare string |
| A bail-out emits nothing | `runtime.cljs` mint-view!: "React consults the comparator ABOVE this fn; a bailed-out boundary never enters it" |
| StrictMode emits twice | same docstring: "React ran the body twice and the measure stream should say so" |
| Boundaries only; an inlined helper lands in the enclosing measure | same docstring, §Boundaries only |
| Delivered, not retained; `retain-entries?` is the escape | `performance.cljc` §Observer-first; `spec/009` §Consumer access |
| The view **trace** pair is the adapter path's | Every `:rf.view/render` emit is `implementation/core/src/re_frame/views.cljs` (the `reg-view*` wrapper); `implementation/freehand/src/` contains **zero**. rf2-2rtt6.126 is CLOSED, ruled option (3) — ship without it, stated. |

The trace pair is deliberately **not** claimed, and is named as the adapter path's so nobody goes looking for it on Hicasso.

## One thing for the operator, not fixed here

The two live `:render` emit sites spell the view id differently, and only one of them satisfies Spec 009 §Naming convention's "one identifier" rule byte-for-byte:

- **arm1 bench** — `defview` mints a **string** `"my.ns/todo-row"`; `displayName` and the `<view-id>` in the measure are the same string. Witnessed by `render_measure_cljs_test.cljs`.
- **freehand src** — the descriptor's `view-id` is a **keyword** (`freehand.cljc:335`, `(keyword (str ns-sym) (str sym))`). `react.cljs` sets `displayName` to `(str view-id)`, which in CLJS renders a keyword *with* its leading colon (`":app.todo/todo-row"`), while `build-name`'s keyword arm strips it (`"rf:render:app.todo/todo-row"`). So DevTools shows one more character than the measure filter wants.

That is a code observation, outside this PR's fence (`implementation/**` is explicitly off-limits here) and arguably cosmetic — the spec's purpose clause is jumpability, and both spellings are jumpable. But "the same string React DevTools shows" is only literally true on the bench path today, so the prose says **"the name you filter the profile on is the name React DevTools shows"** rather than asserting byte-identity. Worth a bead before the product `defview` is minted and the spelling freezes; I have not filed one, since which side should move is an operator call.

## Quality gates

| Gate | Result |
|---|---|
| `python scripts/check_doc_slugs.py` | **rc=0** (link targets + heading anchors; runs in the fast-PR spine) |
| Headings vs HEAD | **identical** — `diff` of `grep '^#'` old vs new returns rc=0, 14 headings, none added, moved or dropped |
| Table column counts | **unchanged: 2 / 2 / 2 / 5 / 3 / 2** in document order, every row within each table uniform. The one new row joins the 2-column tool table. |
| CRLF | `git diff --cached --numstat` = **30 / 1**, i.e. a real diff and not a whole-file rewrite. Plain `git add`, no `core.autocrlf` override. |
| `.beads` paths in the diff | **none** — verified against the merge base |

`mkdocs build --strict` is deliberately **not** nominated: `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site, so a green mkdocs would verify nothing about this file. Nothing validates tables either, so the column counts above were checked by hand.

Scope is one file, docs-only: `docs/design/hicasso/draft-guide/11-performance.md`. No code touched.
