### PR TITLE
docs(hicasso): repair studio provenance pins stranded by rebase-merge (rf2-owq6p)

### DIFF
--- a/docs/design/hicasso/studio/a-control-that-differences-the-constant-away.md
+++ b/docs/design/hicasso/studio/a-control-that-differences-the-constant-away.md
@@ -306,7 +306,12 @@ but the table above names the blobs that **ran** rather than the blobs that
 **ship**, because those are different questions and only the first is
 provenance.
 
-Commit `ef30c639162db98492cf0ebb53f00d411deb4bc4`. Chromium 147.0.7727.15
+Commit `ef30c639162db98492cf0ebb53f00d411deb4bc4` — authored, and rebase-merged,
+so it is on no branch and **will not resolve in a fresh clone**. It landed on
+main as **`93ad80f097`** (same patch — identical `git patch-id --stable`), with
+the blob it contributed unchanged; check out the landed SHA, which sits on a
+later base and so carries the change rather than the whole measured tree.
+Chromium 147.0.7727.15
 (Playwright), `:advanced`, `goog.DEBUG` false. Design 6 rounds × (4 warm-up + 20
 samples) per arm per segment, three segments, segment order rotating with the
 round. Box quiet, 24 logical cores.

--- a/docs/design/hicasso/studio/cross-checked-against-an-outside-instrument.md
+++ b/docs/design/hicasso/studio/cross-checked-against-an-outside-instrument.md
@@ -474,8 +474,8 @@ The band is not widened after the fact. It is recorded as failed.
 
 | | |
 |---|---|
-| Landed whole-tree anchor | *(filled on merge — a rebase-merge mints a new landed SHA, which is why the blob table below is the real pin)* |
-| Authoring anchor | `19a3710bc9604684ddbc7b2b72ec901dcc0f0ea7` on `worker/xbench-rguy1`, the tree both runs were taken at. A later rebase moved it to `3680992949a6eec842ba033ae50f3a9a34af7884`; **every blob below is unchanged across that rebase**, which is the check that matters |
+| Landed whole-tree anchor | **`2f5af3db42`** — on main, so it resolves. Recovered by identical `git patch-id --stable`; every blob its commit contributed is unchanged there |
+| Authoring anchor | `19a3710bc9604684ddbc7b2b72ec901dcc0f0ea7` on `worker/xbench-rguy1`, the tree both runs were taken at. A later rebase moved it to `3680992949a6eec842ba033ae50f3a9a34af7884` — **but that SHA is itself authored and equally stranded**, so naming it repaired nothing; both are on no branch and neither resolves in a fresh clone. The landed anchor above is the one to check out. **Every blob below is unchanged across the rebase**, which is the check that matters |
 | Runtime, ours | Chromium `147.0.7727.15` headless, Playwright 1.59.1, node v24.13.0, `hardware-concurrency` 24, `device-memory` 32 |
 | Runtime, theirs | Chrome **150.0.7871.186** (system), puppeteer-core 25.3.0 via `webdriver-ts`, headless, chromedriver 150.0.1 present and version-matched |
 | Benchmark revision | `krausest/js-framework-benchmark` `master`, shallow clone taken 2026-08-01, kept at `%LOCALAPPDATA%\Temp\jsfb-rguy1\repo` — **outside this repository, never committed** |

--- a/docs/design/hicasso/studio/heap-fan-out-sweep.md
+++ b/docs/design/hicasso/studio/heap-fan-out-sweep.md
@@ -76,8 +76,12 @@ returns is identically the other two checks recombined —
 ## Provenance
 
 **Instrument.** Whole-tree anchor `cd99cded8227816848499b989a9981f194ac656e` on
-`worker/fanout-5prok`. A SHA does not survive a rebase, so the content checks
-are beside it:
+`worker/fanout-5prok` — authored, and the branch was rebase-merged, so that SHA
+is on no branch and **will not resolve in a fresh clone**. It landed on main as
+**`cca5c7ea84`** (same patch — identical `git patch-id --stable`), with every
+blob it contributed unchanged; that is the SHA to check out. The landed tree
+sits on a later base, so it carries the change rather than the whole measured
+tree, and the content checks are beside it:
 
 | file | blob |
 |---|---|

--- a/docs/design/hicasso/studio/our-walk-against-reagents.md
+++ b/docs/design/hicasso/studio/our-walk-against-reagents.md
@@ -381,7 +381,7 @@ Consequences, declared:
 
 | | |
 |---|---|
-| **Producing commit** | `90cc9ab338` on `worker/walkdecomp-2rtt6-63` (the after run); the before run is the same tree with `front/codec.cljs` at its pre-change blob |
+| **Producing commit** | `90cc9ab338` on `worker/walkdecomp-2rtt6-63` (the after run); the before run is the same tree with `front/codec.cljs` at its pre-change blob. **Authored, and rebase-merged, so this SHA is on no branch and will not resolve in a fresh clone.** It landed as **`02a440a4d1`** (same patch — identical `git patch-id --stable`), but **the rebase moved `front/codec.cljs` itself** — the one file this decomposition turns on — so the landed commit is not the measured tree and must not be read as one. The blob hashes below are what pin this run |
 | **Reproduction** | `HICASSO_INIT_FN=re-frame.bench.hicasso.walk-vs-reagent-app/-main HICASSO_OUT_DIR=out/hicasso-walkcmp HICASSO_PORT=8171 node implementation/freehand/test/re_frame/bench/hicasso/run.cjs` |
 | **Build** | `:hicasso-bench` (`--config-merge` entry swap), `:advanced`, `goog.DEBUG false`, lane cache cleared per `rf2-2rtt6.20`; **0 warnings** on every build |
 | **Runtime** | chromium `147.0.7727.15` (playwright), node `v24.13.0`, Windows NT 10.0 x64, 24 threads |

--- a/docs/design/hicasso/studio/slim-non-reactive-arm-diagnosis.md
+++ b/docs/design/hicasso/studio/slim-non-reactive-arm-diagnosis.md
@@ -46,7 +46,7 @@ Two corrections to the bead's statement of the symptom fall out of this:
 
 | | |
 |---|---|
-| Producing commit | `f998a74c4aeb44ddc4dc2830dff31cb7181d3dfb` |
+| Producing commit | `f998a74c4aeb44ddc4dc2830dff31cb7181d3dfb` — **authored, and rebase-merged, so it is on no branch and will not resolve in a fresh clone.** Landed on main as **`bf5cd5a2a3`** (same patch — identical `git patch-id --stable`), where all eight blobs this commit contributed are unchanged. Check out the landed SHA; it sits on a later base, so it carries the change rather than the whole measured tree |
 | Runtime | **chromium 147.0.7727.15** (playwright, headless), `:advanced`, `goog.DEBUG false` |
 | Host | Windows 11, 24 logical cores, 32 GB |
 | Taken | 2026-07-31 00:36 AUSEST |

--- a/docs/design/hicasso/studio/the-band-re-calibrated.md
+++ b/docs/design/hicasso/studio/the-band-re-calibrated.md
@@ -56,8 +56,10 @@ Owner: `rf2-ymi6j`. Companion question: `rf2-h8o80`.
 
 ## 0. Predictions, written before the run
 
-Committed in `295f26651a`, before the first ladder result was read; the commit
-order is the pre-registration. The box: 24 cores (Intel Core Ultra 9 275HX),
+Committed in `295f26651a` — landed on main as **`61ea82850f`**, which is the SHA
+to check, the authored one having been stranded by the rebase-merge — before the
+first ladder result was read; the commit order is the pre-registration, and it is
+checkable only against the landed SHA. The box: 24 cores (Intel Core Ultra 9 275HX),
 68.1 GB, node v24.13.0, Windows 11, sole occupant. Registered 2026-08-02 07:21
 AUSEST.
 

--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -1221,8 +1221,8 @@ not offered as a `bulk300` result: `bulk300` is refused.
 
 | | |
 |---|---|
-| Landed whole-tree anchor | *(filled on merge — a rebase-merge mints a new landed SHA, which is why the blob table below is the real pin)* |
-| Authoring anchor | `fdff3fd48855e86b34ec88b5ebc07f62903a6c0a` on `worker/clock-0qj9w` |
+| Landed whole-tree anchor | **`a878d71ab9`** — on main, so it resolves. Recovered from the authoring anchor by identical `git patch-id --stable`; every blob that commit contributed is unchanged there |
+| Authoring anchor | `fdff3fd48855e86b34ec88b5ebc07f62903a6c0a` on `worker/clock-0qj9w` — the tree the run executed on. The branch was rebase-merged, so this SHA is on no branch and **will not resolve in a fresh clone**; the landed anchor above is the one to check out, and the blob table below is what pins the instrument |
 | Runtime | Chromium `HeadlessChrome/147.0.7727.15` (Windows NT 10.0 x64), Playwright 1.59.1, React 19.2.0, node v24.13.0, `hardware-concurrency` 24, `device-memory` 32 |
 | Build | `:hicasso-bench`, `:advanced`, `goog.DEBUG false`, via `--config-merge` only — no build id added, `implementation/shadow-cljs.edn` untouched |
 | Reproduction | `cd implementation && npm ci && node freehand/test/re_frame/bench/hicasso/clock_run.cjs` |

--- a/docs/design/hicasso/studio/the-cold-read-mount-term.md
+++ b/docs/design/hicasso/studio/the-cold-read-mount-term.md
@@ -381,7 +381,7 @@ story — and the published run is the repaired page's.
 
 | | |
 |---|---|
-| **Producing commit** | `ac09504d74` on `worker/readopt-6c237` — the stamped code blobs are the commit's (the studio page and two diagnostic probe apps were uncommitted at run time; none is on the measured path) |
+| **Producing commit** | `ac09504d74` on `worker/readopt-6c237` — the stamped code blobs are the commit's (the studio page and two diagnostic probe apps were uncommitted at run time; none is on the measured path). **Authored, and rebase-merged, so this SHA is on no branch and will not resolve in a fresh clone**; it landed on main as **`fd01c070a7`** (same patch — identical `git patch-id --stable`), where every blob it contributed is unchanged. The landed SHA is the one to check out; it sits on a later base, so it carries the change rather than the whole measured tree |
 | **Reproduction** | `node implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs` with `C56CLOCK_DATA_DIR` → `data/censusclock-6c237/` (the y1jkm and 2rtt6.56 datasets stay intact) |
 | **Build** | `:hicasso-bench` (`--config-merge` entry swap), `:advanced`, `goog.DEBUG false`, lane cache cleared per rf2-2rtt6.20; 0 warnings |
 | **Runtime** | `HeadlessChrome/147.0.7727.15` (Windows NT 10.0 x64), node `v24.13.0`, hardware-concurrency 24, device-memory 32 |

--- a/docs/design/hicasso/studio/the-in-page-mount-term-decomposed.md
+++ b/docs/design/hicasso/studio/the-in-page-mount-term-decomposed.md
@@ -105,7 +105,7 @@ measurement failure — see §5.
 
 | | |
 |---|---|
-| **Producing commit** | `b8e6da66814e380cafe08a9ebdf58d74f3730828` on `worker/inpage-409ab`, based on `origin/main` `667c744dc8`. Working tree clean at every run (`out/` and `logs/` are ignored), so the stamped blobs are the commit's |
+| **Producing commit** | `b8e6da66814e380cafe08a9ebdf58d74f3730828` on `worker/inpage-409ab`, based on `origin/main` `667c744dc8`. Working tree clean at every run (`out/` and `logs/` are ignored), so the stamped blobs are the commit's. **Authored, and rebase-merged, so this SHA is on no branch and will not resolve in a fresh clone**; it landed on main as **`4866dfa90c`** (same patch — identical `git patch-id --stable`), with the blob it contributed unchanged. The landed SHA is the one to check out; it sits on a later base, so it carries the change rather than the whole measured tree |
 | **Reproduction** | `HICASSO_INIT_FN=re-frame.bench.hicasso.inpage-ladder-app/-main HICASSO_OUT_DIR=out/hicasso-inpage-ladder HICASSO_PORT=8152 node implementation/freehand/test/re_frame/bench/hicasso/run.cjs` |
 | **Re-deriving every figure below** | `node implementation/freehand/test/re_frame/bench/hicasso/inpage_ladder_aggregate.cjs` — fail-closed, see §7 |
 | **Build** | `:hicasso-bench` (`--config-merge` entry swap; `implementation/shadow-cljs.edn` untouched) — `:advanced`, `goog.DEBUG false`, cache cleared per `rf2-2rtt6.20`. 199 files, 144 compiled, **0 warnings** |

--- a/docs/design/hicasso/studio/the-interpreter-walk-profiled-and-cheapened.md
+++ b/docs/design/hicasso/studio/the-interpreter-walk-profiled-and-cheapened.md
@@ -262,7 +262,7 @@ attempt-1 refusal was the build's own heat decaying).
 
 | | |
 |---|---|
-| **Producing commit** | `8ccd9f4b41` on `worker/walkopt-y1jkm`, working tree clean — the stamped blobs are the commit's |
+| **Producing commit** | `8ccd9f4b41` on `worker/walkopt-y1jkm`, working tree clean — the stamped blobs are the commit's. **Authored, and rebase-merged, so this SHA is on no branch and will not resolve in a fresh clone**; it landed on main as **`a3ffe8380e`** (same patch — identical `git patch-id --stable`), with the blob it contributed unchanged. The landed SHA is the one to check out; it sits on a later base, so it carries the change rather than the whole measured tree |
 | **Reproduction** | `node implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs` (datasets redirected via `C56CLOCK_DATA_DIR` to `data/censusclock-y1jkm/` so the `rf2-2rtt6.56` before-datasets stay intact) |
 | **Build** | `:hicasso-bench` (`--config-merge` entry swap), `:advanced`, `goog.DEBUG false`, cache cleared per `rf2-2rtt6.20`; 0 warnings |
 | **Runtime** | `HeadlessChrome/147.0.7727.15` (Windows NT 10.0 x64), node `v24.13.0`, hardware-concurrency 24, device-memory 32 |

--- a/docs/design/hicasso/studio/the-page-chrome-row-and-what-the-bail-out-costs.md
+++ b/docs/design/hicasso/studio/the-page-chrome-row-and-what-the-bail-out-costs.md
@@ -16,7 +16,7 @@ and the same comparator ships as an explicit opt-in.
 
 | | |
 |---|---|
-| Producing commit | `2158869e2b226fb01af866ed4656c3dba6c58d86` |
+| Producing commit | `2158869e2b226fb01af866ed4656c3dba6c58d86` — **authored, and rebase-merged, so it is on no branch and will not resolve in a fresh clone.** It landed as **`870a7d1684`** (same subject and author date; recovered by that pairing, not by patch-id). **Do not treat the landed commit as the measured tree**: the rebase resolved conflicts in `arm1/runtime.cljs`, `front/codec.cljs` and `shapes/feed.cljs` — all three on the measured path — so its instrument differs from the one these rows were taken on. The measured tree survives nowhere; the run is pinned by this row's runtime, page and window, not by a checkout |
 | Command | `node implementation/freehand/test/re_frame/bench/hicasso/chrome_run.cjs` |
 | Runtime | HeadlessChrome **147.0.7727.15**, `:advanced`, **`goog.DEBUG=false`**, 24 cores, 32 GB |
 | Page | the shape roster's feed — 300 card boundaries under one page boundary, the roster's own card markup |

--- a/docs/design/hicasso/studio/the-route-link-render-term-priced.md
+++ b/docs/design/hicasso/studio/the-route-link-render-term-priced.md
@@ -340,7 +340,7 @@ feed controls both passed.
 
 | | |
 |---|---|
-| **Producing commit** | `08344cb500` on `worker/linkterm-cno31`. The working tree carried no uncommitted change to any measured file — the only untracked paths were a pinned clj-kondo binary, a PR draft and this run's own dataset, none on the measured path |
+| **Producing commit** | `08344cb500` on `worker/linkterm-cno31`. The working tree carried no uncommitted change to any measured file — the only untracked paths were a pinned clj-kondo binary, a PR draft and this run's own dataset, none on the measured path. **Authored, and rebase-merged, so this SHA is on no branch and will not resolve in a fresh clone**; it landed on main as **`d0c91ad811`** (same patch — identical `git patch-id --stable`). The rebase moved only `docs/design/hicasso/decisions.md`, which is not on the measured path; both measured blobs are unchanged. The landed SHA is the one to check out; it sits on a later base, so it carries the change rather than the whole measured tree |
 | **Reproduction** | `C56CLOCK_DATA_DIR=…/data/censusclock-cno31 node implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs` — both adapter runs, all three rows, nothing overridden |
 | **Build** | `:hicasso-bench` (`--config-merge` entry swap; `implementation/shadow-cljs.edn` untouched) — `:advanced`, `goog.DEBUG false`, lane cache cleared per `rf2-2rtt6.20`. **0 warnings**, 201 files |
 | **Runtime** | `HeadlessChrome/147.0.7727.15` (Windows NT 10.0 x64), node `v24.13.0`, hardware-concurrency 24, device-memory 32 |


### PR DESCRIPTION
## The census (the bead's primary ask)

Every git-SHA-shaped token under `docs/design/hicasso/**`, classified by
`git merge-base --is-ancestor <sha> origin/main`:

| | count |
|---|---|
| unique tokens examined | 319 |
| resolve to a commit **and on main** | 77 |
| resolve to a commit, **NOT on main (stranded)** | 44 |
| do not resolve to any commit (content digests, FNV hashes) | 188 |

**79 stranded occurrences across 24 pages** — 23 under `studio/`, one in
`production-server-arm.md`. The answer is emphatically *many*, not one.

**All 44 are reachable from no remote ref** (`git branch -r --contains` is empty
for every one), so none resolves in a fresh clone. This is not "my machine can
still see them" — it is genuinely unresolvable to a reader.

## Recovering the landed commit, and how it was validated

The corpus already documented three authored→landed pairs. Those were used as
ground truth *before* trusting any method:

| authored | documented landed | subject | author date | `patch-id --stable` |
|---|---|---|---|---|
| `19401ad083…` | `f03960a8da` | same | same | **same** |
| `44900cd4fd…` | `4c3f7189c4` | same | same | **same** |
| `bc5f38f10a` | `1415d9f7af` | same | same | **same** |

Stable patch-id is invariant across this repo's rebase-merge. **43 of 44**
stranded commits map to a commit on main by exact patch-id; the 44th
(`2158869e2b…`) maps uniquely by subject + author date, its patch-id differing
precisely because the rebase resolved conflicts.

## Where the "just re-pin to main" fix does not hold

Re-pinning restores the **patch**, not the **tree**: the landed commit sits on a
later base, so it is not what was measured. That is usually harmless — for 9 of
the 11 pins repaired here the rebase preserved every blob the commit
contributed, so the instrument is intact and the landed SHA is safe to check out.

For **two** it is not harmless, and those pages now say so rather than pointing
at a tree that was never measured:

- `the-page-chrome-row-and-what-the-bail-out-costs.md` — the rebase moved
  `arm1/runtime.cljs`, `front/codec.cljs` and `shapes/feed.cljs`, all on the
  measured path.
- `our-walk-against-reagents.md` — the rebase moved `front/codec.cljs`, the one
  file that decomposition turns on.

Silently re-pinning those two would have replaced an *unresolvable* pin with a
*resolvable but wrong* one — failing quietly, which is the exact defect the bead
objects to.

## Also fixed

- Two `*(filled on merge — …)*` anchors that were **never filled**
  (`the-candidates-clock.md`, `cross-checked-against-an-outside-instrument.md`).
- `cross-checked-against-an-outside-instrument.md` "repaired" its pin to
  `3680992949…`, which is **itself authored and equally stranded** — so the
  repair repaired nothing. Now pinned to `2f5af3db42` on main.

**No measurement was re-taken.** Every change is provenance only.

## Quality gates

| gate | result |
|---|---|
| `python scripts/check_doc_slugs.py` | **rc=0** |
| headings diffed against HEAD, all 12 files | **identical** — no heading dropped |
| table column counts, all 11 added rows | **2 cols each**, matching every `\|---\|---\|` header |
| every SHA in added lines re-checked against `origin/main` | **12/12 landed SHAs ON-MAIN**; retained authored heads all explicitly labelled non-resolving |
| `.beads` paths vs merge base `be15c6ebfa` | **0** |

`mkdocs build --strict` is *not* a gate here: `exclude_docs` keeps
`design/hicasso/` out of the site, so a green mkdocs would verify nothing.

## Not built, awaiting a ruling

A convention (**pin to a merged commit, never an authored head**) plus a CI
checker is clearly warranted — the check is one command per pin and this PR
shows the failure is systemic, not incidental. Left unbuilt deliberately.
