### PR TITLE
docs: make two records honest — W7's deliberate non-build, and the core-growth figure (rf2-zllp8, rf2-n9y35)

### DIFF
--- a/implementation/schemas/test/re_frame/schemas_bundle_control.cljs
+++ b/implementation/schemas/test/re_frame/schemas_bundle_control.cljs
@@ -19,6 +19,31 @@
   adapter the facade pulls in with it. Both bundles carry the same
   `cljs.core` and the same `re-frame.core`, so both cancel.
 
+  ## What this control's own quantity did across that quarter (rf2-n9y35)
+
+  That 43.8 KB IS this control's quantity — the Malli-free surface
+  under the probe, `cljs.core` + `re-frame.core` + the schemas facade
+  minus its adapter. It measured 50.3 KB gzipped at the 2026-05-14
+  baseline (`ce6c0f4784`, where rf2-fqbcy authored the gate) and
+  94.1 KB at the 2026-08-05 attribution, both under matched
+  `:advanced` + `goog.DEBUG=false` probe builds carrying malli 0.20.1
+  at each end. Malli's own marginal cost moved 29.8 -> 30.8 KB over the
+  same span, so all but 1.0 KB of the growth is core.
+
+  Where that sits, from the 2026-08-05 `shadow.cljs.build-report`
+  optimized (uncompressed) bytes: `cljs/core.cljs` is 186.0 KB of the
+  probe's 494 KB (37.6 %), and `re-frame.core` about 150 KB — its
+  largest contributors being router 22.7, cofx 12.6, fx 12.1,
+  classification 9.7, subs 7.8, frame 7.6 and elision 7.6.
+
+  The figure is recorded and DELIBERATELY left alone: no gate, no
+  remedy. Pre-alpha growth is expected, and per the rf2-kybsf ruling an
+  absolute core budget belongs on a representative app in its own gate
+  if one is ever wanted — this gate owns the schemas margin and nothing
+  else. It lives in the tree rather than only in a bead so the trend
+  stays a fact, and this control's build is what reproduces it when
+  someone wants the next reading.
+
   ## Why it requires ONLY the core facade
 
   The A/B has to price what a consumer can actually BUY. Per rf2-v96fh


### PR DESCRIPTION
Two P3 record-honesty beads on disjoint surfaces. Neither grows a gate, a mechanism, or a remedy — one of them says so in its own text. **One of the two needed no edit at all.**

## rf2-zllp8 — W7 is already recorded as deliberately unbuilt. No change.

The bead asks that `h/frame`'s W7 witness be recorded as unbuildable-until-`[:>]`-ships rather than as a shortfall. `docs/design/hicasso/studio/hframe-design.md` already says exactly that, in two places:

- **The table row itself** (§8, W7) carries `**NOT BUILT** — the raw escape is unbuilt, so there is no door to drive; see §8a and rf2-zllp8`. The row keeps its original text, so what W7 *will* assert is preserved, and the honesty is a note beside it rather than a deletion.
- **§8a** has a dedicated paragraph, *"W7 could not be built, and it is not a shortfall"*, which quotes `front/codec.cljs` at the site (*"stays unbuilt here, deliberately"* — verified live at `implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs:964`), explains that a witness would otherwise have to mint its own `[:>]`-shaped thing and would then be witnessing the test's construction, names the dependency, and lists what W7 depends on that *is* pinned elsewhere.
- §10's guide-debt paragraph independently notes the `[:>]` dev-warning's "plain closure" spelling is blocked on the same escape.

The record neither over-claims nor under-claims, and it names no bead as the escape's implementer because none is assigned — matching the bead's own *"whichever bead ships the escape"*. `[:>]` was **not** implemented here, and nothing in the design tree was edited.

## rf2-n9y35 — the headline figure was already durable; its provenance and composition were not.

A tracking bead only. Already in the tree before this PR, in two tracked source files:

- `implementation/scripts/check-schemas-bundle.cjs` header — both dated rows (2026-05-14 probe 80.1 KB / Malli marginal 29.8 KB; 2026-08-05 probe 124.9 KB / 30.8 KB), the `+43.8 KB` attribution to `cljs.core` + `re-frame.core`, the matched `:advanced` + `goog.DEBUG=false` A/B, malli 0.20.1, the 50.3 KB and 94.1 KB Malli-free readings, and coarse composition (`cljs.core` ~186 KB of ~494 KB).
- `implementation/schemas/test/re_frame/schemas_bundle_control.cljs` docstring — the same trend in one sentence.

So the number was **not** folklore. What existed *only* in the bead was the provenance and the fine composition, and that is all this PR adds — to the control docstring, because this control build *is* the Malli-free quantity the bead tracks:

- the 50.3 → 94.1 KB pairing stated as one quantity across one span, rather than two figures a reader must subtract out of the probe totals;
- the baseline SHA `ce6c0f4784`, and malli 0.20.1 at both ends;
- where the 94.1 KB sits — `cljs/core.cljs` 186.0 KB of the probe's 494 KB raw (37.6 %), `re-frame.core` about 150 KB led by router 22.7, cofx 12.6, fx 12.1, classification 9.7, subs 7.8, frame 7.6, elision 7.6.

**No gate and no remedy**, stated as deliberate in the docstring itself and carrying the rf2-kybsf reasoning: pre-alpha growth is expected, and an absolute core budget belongs on a representative app in its own gate if one is ever wanted. This gate owns the schemas margin. **Nothing was re-measured** — every figure is transcribed from the rf2-kybsf attribution.

`ce6c0f4784` was checked against main before being cited: `git merge-base --is-ancestor ce6c0f4784 origin/main` exits 0, and it resolves to *"refactor(schemas): add bundle-cost CI gate per Spec 010 §Bundle cost (rf2-fqbcy)"*, dated 2026-05-14 — the bead's own baseline date. It is an ancestor, not an authored head, so a rebase-merge cannot strand it.

## Quality gates

Docstring-only change to one CLJS test namespace. `ns` docstrings are compile-time metadata, so the `:schemas-bundle-control` build's emitted bytes — and therefore the gate's own margin — are unchanged by this PR.

| Gate | Result |
|---|---|
| Clojure reader parse of the edited namespace | `FORMS_READ_OK 2`, **rc=0** |
| `clojure -M:test` in `implementation/schemas` | Ran 363 tests, 19188 assertions, **0 failures, 0 errors**, **rc=0** |
| `git diff --cached --numstat` (CRLF check) | `25  0` — no line-ending blowup |
| `.beads` paths vs merge base `1ad824ba6a` | 0 |

Both gates run in the foreground to completion, unpiped, with exit codes captured on the line after the runner.

`mkdocs build --strict` is **not** claimed: `exclude_docs` keeps `docs/design/**` out of the site, so it verifies nothing for the file rf2-zllp8 concerns — and that file is unmodified in any case. For the same reason `scripts/check_doc_slugs.py` is not claimed either. The witness table in `hframe-design.md` was nonetheless column-counted by hand as part of certifying the record: header, separator and all nine rows are uniformly **3 columns**. No heading was added, renamed or removed anywhere.
