### PR TITLE
docs(hicasso): reconcile HD-008's correction contract with the grain-mask withdrawal (rf2-z8oiq)

### DIFF
--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -75,12 +75,17 @@ page's final `rf2-b69lw` record landed; it moved no figure.
 | **Rounds** | 6 · mount `{:warmup 4 :samples 12}` · write `{:warmup 3 :samples 10}` |
 
 **The instrument at `main`'s tip is no longer any of the three.** `ba0c215a73`
-batched the yield-cost control (`rf2-2rtt6.19`), and `rf2-b69lw` has since turned
+batched the yield-cost control (`rf2-2rtt6.19`), `rf2-b69lw` has since turned
 that control into an enforced gate — see [The correction contract is enforced,
-not stated](#the-correction-contract-is-enforced-not-stated). Neither touched an
-arm's window, so no figure on this page moves; but a run at the tip is a run of
-a *later* instrument over the same plan, and only a run at the landed commit in
-the row's own line reproduces that row's instrument exactly.
+not stated](#the-correction-contract-is-enforced-not-stated) — and `rf2-d2tzk`
+(PR #7585) added the clock-grain publication mask. ~~Neither touched an
+arm's window, so no figure on this page moves;~~ **None of the three touched an
+arm's window, so no figure on this page MOVES — but the mask WITHDRAWS one, and
+a run at the tip prints `NO REPORTABLE MAGNITUDE` where [the bulk row's
+cross-run column](#write--bulk-all-300-cells-in-one-commit) once printed
+figures.** A run at the tip is a run of a *later* instrument over the same plan,
+and only a run at the landed commit in the row's own line reproduces that row's
+instrument exactly.
 
 ### Spine stamp — three of the six arms read a spine that no longer ships
 
@@ -908,12 +913,16 @@ unadjusted ratios anyway. A contract nothing evaluates is a sentence.
 
 `hd8-rows/yield-correction` is that contract as code, run against **both write
 rows of every run**, and `hd8-app` fails the run on a refusal — the same
-fail-closed path a positive control that missed its prediction takes. Four
-verdicts, and they are the whole of it:
+fail-closed path a positive control that missed its prediction takes. ~~Four
+verdicts, and they are the whole of it:~~ **Five verdicts, and they are the
+whole of it** — the fifth, `:moot`, was added by `rf2-d2tzk` (PR #7585) and is
+marked as such below, so a reader can see which four this section was written
+against:
 
 | verdict | when | what happens to the row |
 |---|---|---|
 | `:not-owed` | every arm in the row shares one window shape | published unchanged — the harness turns are in numerator and denominator alike |
+| **`:moot`** *(added by `rf2-d2tzk`)* | the row mixes shapes, but every figure it still publishes is formed only from arms that escape the harness turn — its yield-bearing arms denominate a column a publication mask has already withdrawn | the correction has nothing to move and a refusal nothing to protect; the within-run pairs publish unchanged, the withdrawn column stays withdrawn, and the aggregate's reading cannot change the answer |
 | `:below-resolution` | the row mixes shapes and the **aggregate** yield window's max is `0.0` across every sample | published unadjusted, with the bound on the record rather than assumed |
 | `:corrected` | mixed shapes, aggregate nonzero | the subtraction is **applied**; both bands publish, labelled `[UNADJUSTED]` and `[CORRECTED]` in the cross-run table itself |
 | `:refused` | the correction cannot be discharged | **nothing in the row may be published**, and the run exits non-zero |
@@ -921,7 +930,10 @@ verdicts, and they are the whole of it:
 **Which rows owe anything: the `slim` run's, and no others.** A row owes only
 when it mixes the two window shapes, and only `reagent-slim` is
 microtask-scheduled. In the `reagent` and `uix` runs every arm carries the
-harness turns, so there is nothing asymmetric to correct.
+harness turns, so there is nothing asymmetric to correct. **And of the `slim`
+run's two write rows only the narrow one can now be owed anything**: the bulk
+row's sole yield-bearing arm is its floor, whose column the grain mask
+withdraws, which is what makes that row `:moot` (`rf2-d2tzk`).
 
 **Two ways to be refused, and neither has a tolerance of its own.**
 
@@ -979,24 +991,47 @@ So the contract has a **self-test**, replayed from recorded fixtures through the
 live rule, run inside the bundle **before any clock**, and fatal when it
 disagrees: `hd8-app` throws, `hd8_run.cjs` prints every check and exits `1`. It
 is `order_guard.cjs`'s technique and `parity-can-fail?`'s argument, applied to
-the newest gate rather than only the oldest ones. Seven fixtures: one per
-verdict, one per refusal reason, and one per repaired hole in the rule itself.
-**Fixture 4 is the `15,518,934×` row** and **fixture 7 is the whole-band
-crossing** — the `0.95× → 1.0556×` reversal the boolean test accepted — each
-kept so its repair cannot silently come undone.
+the newest gate rather than only the oldest ones. ~~Seven~~ **Thirteen**
+fixtures: one per verdict, one per refusal reason, and one per repaired hole in
+the rule itself. **Fixture 4 is the `15,518,934×` row** and **fixture 7 is the
+whole-band crossing** — the `0.95× → 1.0556×` reversal the boolean test accepted
+— each kept so its repair cannot silently come undone. **The count grew with the
+rule and the numbering is stable, so those two pins still point where they
+did**: seven when this paragraph was written, an eighth when the PR #7295 audit
+found a corrected band minting a figure the DOM read-back had refused, and five
+more from `rf2-d2tzk` — the grain mask itself, the `:moot` verdict on *both*
+draws of the clock, the `(v - tick) > tick` boundary at both polarities, the
+well-resolved narrow row the mask must **not** touch, and a clock that cannot
+state its own resolution.
 
-**No figure on this page moves.** The contract reads the rows; it does not take
-them. A full three-run sweep on the branch that added it returns `:not-owed` on
-every `uix` and `reagent` write row and `:below-resolution` on both `slim` write
-rows — the aggregate read `0.0` in all ten of its windows, both at `k = 10` and
-at `k = 1` — so the ratios above stand exactly as published, now with the bound
-checked rather than asserted. A full sweep at the three-state repair (authored
-`79de836f35`; the landed SHA is the merge's to mint) answers the same, exit
-`0`: `:not-owed` on all four
+~~**No figure on this page moves.**~~ **No figure on this page moves *for this
+contract*.** That is the narrower claim, and it is the only one this section is
+entitled to make. The contract reads the rows; it does not take them, and it
+withdraws none. A full three-run sweep on the branch that added it
+returned `:not-owed` on every `uix` and `reagent` write row and
+`:below-resolution` on both `slim` write rows — the aggregate read `0.0` in all
+ten of its windows, both at `k = 10` and at `k = 1` — so ~~the ratios above stand
+exactly as published~~ **the ratios stood exactly as published on the instrument
+of that day**, now with the bound checked rather than asserted. A full sweep at
+the three-state repair (authored `79de836f35`; the landed SHA is the merge's to
+mint) answered the same, exit `0`: `:not-owed` on all four
 `uix`/`reagent` write rows, `:below-resolution` on both `slim` rows with every
 aggregate window at `0.0`, every read-back `0` unverified, and every slim write
 range overlapping the published one — the repair moves gate logic and table
 labelling, not a number.
+
+**Both sweeps pre-date the grain mask, and one of the two `slim` verdicts they
+record has since changed.** `rf2-d2tzk` (PR #7585) made the **bulk** row's
+floor-normalised column withdrawable on the clock's own measured grain, so that
+row now reads ~~`:below-resolution`~~ **`:moot`** on every draw: its only
+yield-bearing arm is the floor, the floor's column is withdrawn, and a
+correction has nothing left to move. The **narrow** row is untouched by the
+mask — its batched floor sits nine to twelve-and-a-half ticks clear of the
+grain — and its ratios do stand exactly as published. Nothing the two sweeps recorded is
+retracted: the `:not-owed` verdicts, the `0.0` aggregates and the read-back
+counts all still read as they read, and the mask still moves no figure. [The
+bulk cross-run column](#write--bulk-all-300-cells-in-one-commit) is **withheld**
+rather than amended, and that row's within-run pairs publish unchanged.
 
 **And the contract has been watched doing the other thing, which is the only
 reason to trust it.** A `slim`-only run on the same branch and the same host


### PR DESCRIPTION
Closes **rf2-z8oiq** (P2, reopened by the merged-PR audit of #7592).

`hd8-composed-donor-arm.md` withdraws the bulk write row's cross-run column on the clock's own measured grain (`rf2-d2tzk`, PR #7585). Three later passages still read as though it had not. This PR supersedes all three **in place**, using the device the page already uses for a superseded claim — the wrong text struck through, followed by a bold replacement naming the bead — so the chronology stays legible: a reader can see the claim that was made, and then why it no longer holds. **No figure is re-taken, moved, added or deleted. No heading changed.**

## The three occurrences

The audit named the correction-contract section. Counting the claim across the whole page found it in the **Provenance** section too, which the audit had not named.

| # | where | the claim as it stood | why it no longer holds |
|---|---|---|---|
| 1 | Provenance (~line 77) | the tip's instrument is `ba0c215a73` + `rf2-b69lw`, and "Neither touched an arm's window, so no figure on this page moves" | `rf2-d2tzk` is at the tip too. A run there prints `NO REPORTABLE MAGNITUDE` where the bulk cross-run column used to print figures. The mask does not **move** a figure — it **withdraws** one, and the sentence now distinguishes the two |
| 2 | the correction contract (~line 913) | "Four verdicts, and they are the whole of it" | `hd8_rows.cljs`'s own docstring is headed **"The five verdicts"**, and `yield-correction` returns `:moot` / `:no-published-figure-bears-it` when every figure a row still publishes is formed from arms that escape the harness turn. The fifth row is added in the instrument's own order, marked as `rf2-d2tzk`'s addition |
| 3 | the correction contract (~line 991) | "**No figure on this page moves.** … so the ratios above stand exactly as published", both slim rows `:below-resolution` | The bulk slim row now reads `:moot` on every draw. The two sweeps are kept **verbatim** as the record of what that instrument answered, their tense made honest, and an amendment paragraph follows |

The other five "no figure moves" sentences on the page (lines ~255, ~896, ~1042, ~1089, ~1085) were each checked and are **correctly scoped** to their own change — the exit-code re-derivation, the ten-turn control, the reproduction check, the lane cache, `rf2-pq7d8`. They are left alone. The reproduction check at ~1042 already carries its own bulk-row qualification.

## Two consequential reconciliations

Adding a fifth verdict would have left the same section contradicting itself, so two adjacent claims are brought along:

- **"Which rows owe anything"** now names which of the two `slim` rows can still be owed — only the narrow one; the bulk row's sole bearer is its floor, whose column the mask withdraws.
- **The self-test fixture count**, "Seven fixtures: one per verdict, …". Verified against `hd8_rows.cljs`: there are now **13**. One was added by the PR #7295 publication-mask repair, five by `rf2-d2tzk` (the grain mask, `:moot` on both draws of the clock, the `(v - tick) > tick` boundary at both polarities, the well-resolved narrow row the mask must *not* touch, and an unmeasurable clock). The **"fixture 4"** and **"fixture 7"** pins in the same paragraph were re-checked against the source and still resolve — the comment numbering is stable.

Every claim added here was verified against `implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs`, not against the page's own prose.

## Quality gates

`docs/design/**` is inside `mkdocs.yml`'s `exclude_docs`, so `mkdocs build --strict` verifies nothing on this tree and was not run. The gate that does cover it is `check_doc_slugs.py`, and the two hand checks it does not perform are recorded below.

| gate | result |
|---|---|
| `python scripts/check_doc_slugs.py` | **exit 0**, no output |
| `check_doc_slugs.py` **positive control** | **exit 1** — one anchor deliberately broken in this file, reported as `BROKEN ANCHOR … :85`, then reverted. The green above is not vacuous |
| **Headings diffed against `HEAD`** | identical — **25 headings before, 25 after**, `diff` exit 0. Nothing dropped silently |
| **Table column counts, by hand** | **19 tables, 0 inconsistent.** Every table's every row has the same column count as its header. The verdict table is the only one that changed shape: **7 rows × 3 columns** (header + separator + five verdicts), up from 6 rows |
| `git diff --numstat` | `57 22` — a scoped diff, not a CRLF whole-file rewrite. Plain `git add`, no `core.autocrlf` override |

Two anchors are added, both to the existing `#write--bulk-all-300-cells-in-one-commit` heading, which the page already links twice; `check_doc_slugs.py` resolves same-file anchors (verified by the positive control landing on one).

No `.beads` path is in the diff — checked against the merge base `d668e0057766b3adaa826767bae0137316d9bec0`.

## Sequencing

Branched off `origin/main`. **PR #7616 was open and unmerged** when this started; `gh pr diff 7616 --name-only` lists 12 studio pages and **this page is not among them**, and a sweep of every open PR found none touching it. No sequencing hold was needed and no rebase was required.
