### PR TITLE
fix(hicasso): the member-key classification is total, so a foreign object key cannot fall through (rf2-2rtt6.104)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -1472,13 +1472,45 @@
   [k]
   (or (string? k) (number? k) (keyword? k)))
 
+(defn- ^boolean stable-object-key?
+  "The two non-primitive `:key` values deliberately classified SAFE.
+
+  A `uuid` and a `symbol` are objects, so [[plain-key?]] rejects both —
+  but each string-coerces to its own NAME, which is the identity the
+  author means rather than the content of anything they will edit. A
+  `uuid` in particular is the canonical entity identifier: warning on
+  `{:key (:id entity)}` because that id happens to be a UUID would be
+  the false positive that teaches authors to ignore the warning, and a
+  guard everyone routes around is worse than the silence this repair
+  closes. A `symbol` coerces exactly as the `keyword` [[plain-key?]]
+  already admits does.
+
+  Asked only inside [[check-member-key!]]'s classification, never on the
+  keyed walk — see that docstring's ordering note."
+  [k]
+  (or (uuid? k) (symbol? k)))
+
 (defn- key-shape
   "What the author put at `:key`, named rather than printed. The VALUE
   never reaches the console: a foreign or cyclic value would blow
   `pr-str` inside a diagnostic, and the author already knows what they
-  wrote — what they need is the view, the child and the hazard."
+  wrote — what they need is the view, the child and the hazard.
+
+  TOTAL over everything [[check-member-key!]] rejects, which is the
+  repair rf2-2rtt6.104 asked for. The strings below are the ONLY text
+  this diagnostic can produce, so the totality and the never-print
+  guarantee are one property: no arm falls through to the value.
+  `coll?` sits here rather than at the call site because it is the
+  dearest predicate on the path and this function runs on detection
+  rather than on the walk."
   [k]
-  (cond (map? k) "a map" (vector? k) "a vector" (set? k) "a set" :else "a collection"))
+  (cond (map? k)     "a map"
+        (vector? k)  "a vector"
+        (set? k)     "a set"
+        (coll? k)    "a collection"
+        (boolean? k) "a boolean"
+        (fn? k)      "a function"
+        :else        "a foreign object"))
 
 (defn- warn-member-key!
   "One console line per site, where a site is *(enclosing view, member
@@ -1513,19 +1545,63 @@
                         (if owner (str " in the body of " owner) "")
                         ": a seq of " member " members carries " kind
                         " at :key (first at index " i ")."
-                        " React coerces a key to a string, so a collection keys"
-                        " the child by its CONTENT — edit the entity and the"
-                        " child silently remounts, losing focus, scroll position"
-                        " and any presence retention. Key on a stable identifier"
-                        " instead — [child {:key (:id entity), …}]. Warned once"
-                        " per site, in development builds only."
+                        " React coerces a key to a string, so a value like this"
+                        " keys the child by its CONTENT — edit the entity and"
+                        " the child silently remounts, losing focus, scroll"
+                        " position and any presence retention. A foreign object"
+                        " is the sharper case: every one of them coerces to the"
+                        " same `[object Object]`, so distinct children collapse"
+                        " onto a single key. Key on a stable identifier instead"
+                        " — [child {:key (:id entity), …}]. Warned once per"
+                        " site, in development builds only."
                         " [:rf.warning/hicasso-entity-key]")))))))
   nil)
 
 (defn- check-member-key!
   "One member of a lowered child seq, at index `i`. Warns when it is a
   boundary-headed vector React will reconcile by position — no `:key`, or
-  a `:key` whose value is a collection.
+  a `:key` whose value is not one React can coerce to a stable identity.
+
+  ## The classification is TOTAL (rf2-2rtt6.104)
+
+  This `cond` shipped with two arms and no `:else`, so every non-nil
+  `:key` that was neither primitive nor a CLJS collection fell out of the
+  check in silence. The shape that made that a bug rather than a gap is
+  the FOREIGN JS ENTITY OBJECT: `createElement` does `key = '' + key`, so
+  every plain object reaches `Object.prototype.toString` and every member
+  of the list is keyed `[object Object]`. Distinct rows, one key. The
+  codec was already careful never to PRINT such a value ([[key-shape]]);
+  it simply never reached the printing.
+
+  Every non-nil value [[plain-key?]] rejects now goes exactly one of two
+  ways — classified safe by [[stable-object-key?]], or named by
+  [[key-shape]], which is total. Nothing falls through.
+
+  ## What React says, and where it is genuinely silent
+
+  Verified against the vendored React 19.2 rather than assumed. React's
+  duplicate-key warning (`react-dom-client.development.js`,
+  `warnOnInvalidKey`) bails on `if (\"string\" !== typeof key) break` —
+  but the coercion above has already happened, so the key IS a string and
+  the check DOES apply. React therefore does warn `Encountered two
+  children with the same key, ` + \"`[object Object]`\" whenever two or
+  more foreign-object keys collide.
+
+  That is worth stating plainly because it means this warning is NOT the
+  only signal in the collision case. Where React is genuinely silent is
+  the larger half of the same hole: a key whose coercion is
+  CONTENT-DERIVED and therefore distinct per member — a `js/Date`, a JS
+  array, a CLJS map — collides with nothing, so React never warns, and
+  the row silently remounts the moment the author edits the entity. That
+  is the same hazard the `:rf.warning/hicasso-entity-key` row already
+  existed for, and the foreign object is simply its unhandled case.
+
+  The reason to warn on BOTH rather than defer the collision half to
+  React is cost, and here it is zero: see the ordering note below. The
+  cost argument that keeps this lane quiet where React already speaks
+  (rf2-2rtt6.134, the missing key on a host or `[:>]` child) is an
+  argument about a ~150 ns/member charge on the hot walk. Nothing here
+  touches the hot walk.
 
   ## What it costs, clocked rather than asserted
 
@@ -1569,9 +1645,26 @@
   The predicate order is the rest of the cost: `vector?` first, then the
   props-map `:key` read, then [[plain-key?]] — which is where a keyed
   member leaves, on a `typeof`. [[boundary-head?]]'s own-property read is
-  asked LAST, so an unkeyed `[:li …]` costs one `fn?` and no more, and
-  `coll?` — the dearest predicate on this path — is reached only by a
-  member that is already unkeyed or already odd.
+  asked LAST, so an unkeyed `[:li …]` costs one `fn?` and no more.
+
+  THE TOTALITY REPAIR IS FREE, and the ordering is why. Both new arms sit
+  INSIDE the `cond`, which is reached only by a member already known to
+  be boundary-headed AND already known to carry a non-plain `:key`. The
+  keyed steady state never arrives — it left at [[plain-key?]], three
+  `typeof`s up. The unkeyed fast path never arrives at the new arms
+  either: `nil?` is still the FIRST arm, so an unkeyed boundary member
+  short-circuits exactly where it did before. Neither of the two
+  populations in the table above executes one added instruction, so the
+  numbers stand as clocked.
+
+  The one population whose cost MOVED is a list keyed by `uuid`, and it
+  got cheaper. `coll?` — the dearest predicate on this path, because
+  anything without the `ICollection` marker falls through to
+  `native-satisfies?` — used to be asked on the walk, so a legitimate
+  UUID-keyed member paid it on every member of every render only to fall
+  out of the `cond` unhandled. It now lives in [[key-shape]], which runs
+  on detection, and a UUID leaves at [[stable-object-key?]] on two
+  `instanceof`-class tests instead.
 
   Every member is checked every time, uniform with the keyed steady
   state. Stopping at the first offender would save work only on the
@@ -1588,8 +1681,9 @@
         (let [h (nth m 0 nil)]
           (when (boundary-head? h)
             (cond
-              (nil? k)  (warn-member-key! h "missing" i)
-              (coll? k) (warn-member-key! h (key-shape k) i)))))))
+              (nil? k)               (warn-member-key! h "missing" i)
+              (stable-object-key? k) nil
+              :else                  (warn-member-key! h (key-shape k) i)))))))
   nil)
 
 (defn- check-seq-keys!

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
@@ -1038,6 +1038,99 @@
       (is (re-find #"carries a vector at :key" (first out)))
       (is (re-find #"carries a set at :key" (second out))))))
 
+;; ---------------------------------------------------------------------------
+;; THE TOTALITY REPAIR (rf2-2rtt6.104)
+;;
+;; `check-member-key!`'s `cond` shipped with two arms and no `:else`, so every
+;; non-nil `:key` that was neither primitive nor a CLJS collection fell out of
+;; the check in silence. The foreign JS object is the shape that makes that a
+;; bug rather than a gap: every one of them string-coerces to the SAME
+;; `[object Object]`, so distinct rows share one key. The rows below pin the
+;; collision on our own lowering first, then the warning, then — just as
+;; load-bearing — the two shapes deliberately classified SAFE, because a
+;; warning that fires on a `uuid` key would teach authors to ignore it.
+;; ---------------------------------------------------------------------------
+
+(deftest a-foreign-object-key-collapses-distinct-children-onto-one-key
+  (testing "the hazard pinned on OUR lowering rather than argued from React's
+            source: two DISTINCT entities mint two elements with ONE key"
+    (let [row  (named-view "w24.ns/row")
+          seen (atom nil)]
+      (warnings-during
+        #(reset! seen (child-vec
+                        (codec/as-element
+                          [:ul (list [row {:key #js {:id 1}}]
+                                     [row {:key #js {:id 2}}])]))))
+      (is (= 2 (count @seen)))
+      (is (= "[object Object]" (el-key (first @seen)))
+          "React's `key = '' + config.key` reaches Object.prototype.toString")
+      (is (= (el-key (first @seen)) (el-key (second @seen)))
+          "two entities, one key — React reconciles them as the same child")))
+  (testing "and it warns, naming the shape without ever printing the value"
+    (let [row  (named-view "w25.ns/row")
+          out  (warnings-during
+                 #(lowering-as "w25.ns/list"
+                               [:ul (list [row {:key #js {:secret "s3cr3t"}}])]))
+          line (first out)]
+      (is (= 1 (count out)))
+      (is (re-find #"w25\.ns/list" line) "the enclosing view")
+      (is (re-find #"w25\.ns/row" line) "the member head")
+      (is (re-find #"carries a foreign object at :key" line))
+      (is (re-find #"first at index 0" line))
+      (is (re-find #":rf\.warning/hicasso-entity-key" line))
+      (is (nil? (re-find #"s3cr3t" line))
+          "the VALUE never reaches the console"))))
+
+(deftest the-diagnostic-holds-on-a-value-that-would-blow-a-printer
+  (testing "a cyclic foreign object warns rather than throwing inside the
+            warning — the check names shapes, so no arm of it can reach the
+            value that would recur"
+    (let [row    (named-view "w26.ns/row")
+          cyclic (js-obj "id" 1)]
+      (unchecked-set cyclic "self" cyclic)
+      (let [out (warnings-during
+                  #(lowering-as "w26.ns/list" [:ul (list [row {:key cyclic}])]))]
+        (is (= 1 (count out)))
+        (is (re-find #"carries a foreign object at :key" (first out)))))))
+
+(deftest every-other-non-primitive-key-shape-is-named-rather-than-dropped
+  (testing "the shapes that used to fall through the missing `:else`"
+    (doseq [[label k pattern]
+            [["boolean"  true         #"carries a boolean at :key"]
+             ["function" (fn [] 1)    #"carries a function at :key"]
+             ["date"     (js/Date. 0) #"carries a foreign object at :key"]
+             ["js-array" #js [1 2]    #"carries a foreign object at :key"]]]
+      (let [row (named-view (str "w27.ns/" label))
+            out (warnings-during
+                  #(lowering-as (str "w27.ns/list-" label)
+                                [:ul (list [row {:key k}])]))]
+        (is (= 1 (count out)) (str "a " label " key must not fall through"))
+        (is (re-find pattern (first out)) (str "a " label " key is named"))))))
+
+(deftest the-object-key-shapes-deliberately-classified-safe-stay-silent
+  (testing "a uuid string-coerces to the identifier the author MEANS, so it is
+            the canonical entity key and warning on it would be the false
+            positive that teaches authors to ignore the warning"
+    (let [row  (named-view "w28.ns/row")
+          ids  [(uuid "00000000-0000-0000-0000-000000000001")
+                (uuid "00000000-0000-0000-0000-000000000002")]
+          seen (atom nil)]
+      (is (= [] (warnings-during
+                  #(reset! seen
+                           (child-vec
+                             (codec/as-element
+                               [:ul (for [id ids] [row {:key id}])]))))))
+      (is (= "00000000-0000-0000-0000-000000000001" (el-key (first @seen)))
+          "the coercion is the identity itself — this is WHY it is classified safe")
+      (is (not= (el-key (first @seen)) (el-key (second @seen)))
+          "distinct entities keep distinct keys, which is the whole test")))
+  (testing "a symbol coerces to its own NAME, exactly as the keyword that
+            `plain-key?` already admits does"
+    (let [row (named-view "w29.ns/row")]
+      (is (= [] (warnings-during
+                  #(lowering-as "w29.ns/list"
+                                [:ul (list [row {:key 'a}] [row {:key 'ns/b}])])))))))
+
 (deftest the-scope-line-holds-in-both-directions
   (testing "native-tag members are React's beat — there is no boundary head to name"
     (is (= [] (warnings-during


### PR DESCRIPTION
`check-member-key!`'s `cond` shipped with two arms and no `:else`. Every non-nil
`:key` that was neither primitive nor a CLJS collection left the check in
silence — and the shape that makes that a bug rather than a gap is the foreign
JS entity object.

## The reproduction, on unmodified `main`

`createElement` does `key = '' + config.key`, so a plain object reaches
`Object.prototype.toString`. Pinned on our own lowering, not argued from React's
source:

```
[:ul (list [row {:key #js {:id 1}}] [row {:key #js {:id 2}}])]
  → child 0 .key = "[object Object]"
  → child 1 .key = "[object Object]"     ; distinct entities, one key
```

and the codec said nothing. On unmodified `main` the new rows report `count out`
= 0 for a foreign object, a cyclic object, a boolean, a function, a `js/Date`
and a JS array: 6 failures / 11 errors of 353 assertions.

## What changed

- `stable-object-key?` (new) classifies the two non-primitive shapes that are
  deliberately SAFE: a `uuid` and a `symbol` each coerce to their own *name* —
  the identity the author means, not the content of something they will edit. A
  warning on `{:key (:id entity)}` because that id is a UUID would be the false
  positive that teaches authors to ignore the warning.
- `key-shape` is now total, and still names shapes rather than printing values,
  so totality and the never-print guarantee are one property.
- The `cond` gains `:else`; `(coll? k)` as a call-site arm is gone, subsumed.

## Cost: free on the hot walk, and one population got cheaper

Both new arms sit **inside** the `cond`, which is reached only by a member
already known to be boundary-headed *and* already carrying a non-plain `:key`.
The keyed steady state left three `typeof`s earlier at `plain-key?`; `nil?` is
still the **first** arm, so the unkeyed path short-circuits exactly where it
did. Neither population in the docstring's clocked table executes an added
instruction, so those numbers stand as measured.

The one cost that *moved* went down. `coll?` — the dearest predicate on this
path, since anything without the `ICollection` marker falls through to
`native-satisfies?` — used to be asked **on the walk**, so a legitimate
UUID-keyed list paid it per member per render only to fall out unhandled. It now
lives in `key-shape`, which runs on detection; a UUID leaves at
`stable-object-key?` on two `instanceof`-class tests.

## What React actually does — verified, not assumed

Against the vendored React 19.2. `warnOnInvalidKey` bails on
`if ("string" !== typeof key) break`, but the coercion has already happened, so
the key **is** a string and the check applies: React **does** warn `Encountered
two children with the same key, \`[object Object]\`` when two or more collide.
That is recorded in the docstring rather than glossed.

Where React is genuinely silent is the larger half of the same hole: a key whose
coercion is *content-derived* and therefore distinct per member — a `js/Date`, a
JS array, a CLJS map — collides with nothing, so nothing warns and the row
silently remounts the moment the author edits the entity. That is the hazard
`:rf.warning/hicasso-entity-key` already existed for; the foreign object is its
unhandled case.

## Quality gates

| gate | rc | result |
|---|---|---|
| `compile-node-test.cjs node-test` (reproduction, pre-fix) | 0 | 2160 files, 0 warnings |
| `node out/node-test.js --test=…codec-cljs-test` (pre-fix) | **1** | 58 tests / 353 assertions, **6 failures, 11 errors** — the reproduction |
| `compile-node-test.cjs node-test` (post-fix) | 0 | 2160 files, 0 warnings |
| `node out/node-test.js --test=…codec-cljs-test` (post-fix) | 0 | 58 tests / 353 assertions, 0 failures, 0 errors |
| `npm run test:hicasso-compile` | 0 | lane compile gate |
| `npm run test:cljs` (full node suite) | 0 | see below |
| `scripts/test-fast-pr.sh` | 0 | fast-PR spine |

Mutation proofs (both directions) are in the thread below.
