### PR TITLE
fix(freehand): publish the measure's own id as displayName (rf2-2rtt6.136)

### DIFF
--- a/implementation/core/src/re_frame/performance.cljc
+++ b/implementation/core/src/re_frame/performance.cljc
@@ -101,6 +101,35 @@
 
 ;; ---- name builder (used by the macro expansion at the call site) ----------
 
+(defn entry-id
+  "Render `id` — a registered keyword / symbol / string — as the `<id>`
+  half of an `rf:<bucket>:<id>` entry name. A keyword loses its leading
+  colon and keeps its namespace; everything else is stringified as
+  written.
+
+  PUBLIC, and public for one reason. Spec 009 §Naming convention does not
+  merely say what the measure is called; it says that the `<id>` in the
+  measure name and **the id the substrate publishes to the developer**
+  (React `displayName`, the registrar key) are ONE identifier, \"so a
+  name read off the User-Timing stream is directly jumpable in the
+  tooling\". A substrate that publishes a name has to spell it the way
+  the measure spells it, and the only way two spellings cannot drift is
+  for there to be one spelling — this fn.
+
+  `(str id)` is NOT that spelling. A keyword stringifies WITH its colon,
+  so a substrate stamping `(str view-id)` on a React component showed
+  `:app.todo/todo-row` while its own measure carried
+  `rf:render:app.todo/todo-row`; pasting the name DevTools showed into
+  the documented `rf:render:` filter produced a double colon and matched
+  nothing — the tool answering \"no such trace\" to a developer using it
+  exactly as documented (rf2-2rtt6.136)."
+  [id]
+  (if (keyword? id)
+    (if-let [n (namespace id)]
+      (str n "/" (name id))
+      (name id))
+    (str id)))
+
 (defn build-name
   "Build a `rf:<bucket>:<id>` entry name from the bucket keyword and the
   registered id keyword/symbol/string. Stable shape across every emit
@@ -121,15 +150,13 @@
        from the production bundle.
 
   The body is pure data-shaping with no platform-specific calls — one
-  `.cljc` definition serves both JVM and CLJS callers."
+  `.cljc` definition serves both JVM and CLJS callers.
+
+  The `<id>` half is [[entry-id]], which a substrate also stamps as the
+  name it publishes to the developer — that shared call is what makes
+  the two ONE identifier rather than two that happen to agree."
   [bucket id]
-  (str "rf:" (name bucket) ":"
-       (cond
-         (keyword? id) (if-let [n (namespace id)]
-                         (str n "/" (name id))
-                         (name id))
-         (symbol? id)  (str id)
-         :else         (str id))))
+  (str "rf:" (name bucket) ":" (entry-id id)))
 
 ;; ---- the macro -------------------------------------------------------------
 

--- a/implementation/freehand/src/re_frame/freehand/behaviors.cljc
+++ b/implementation/freehand/src/re_frame/freehand/behaviors.cljc
@@ -113,6 +113,7 @@
             #?@(:cljs [["react" :as react]
                        [re-frame.freehand.refs :as refs]
                        [re-frame.freehand.shell :as shell]
+                       [re-frame.performance :as performance]
                        [re-frame.router :as router]])))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -960,7 +961,10 @@
         set-node (use-attachment! opts)]
     (attach child set-node)))
 
-(set! (.-displayName behavior-el) (str behavior-view-id))
+;; The SAME spelling the interpreted twin publishes
+;; (`re-frame.freehand.react/behavior-component`) — one construct cannot show
+;; two names in DevTools depending on which tier lowered it.
+(set! (.-displayName behavior-el) (performance/entry-id behavior-view-id))
 
 (defn ^:no-doc compiled-attachment
   "The value a compiled body hands React for one `[v/behavior {…} node]`: the

--- a/implementation/freehand/src/re_frame/freehand/error_react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/error_react.cljs
@@ -60,7 +60,8 @@
             [goog.object :as gobj]
             [re-frame.adapter.context :as adapter-context]
             [re-frame.frame :as frame]
-            [re-frame.freehand.errors :as eb]))
+            [re-frame.freehand.errors :as eb]
+            [re-frame.performance :as performance]))
 
 (defn- props-map
   "The Clojure props map the React tree stashed under the `\"props\"` key —
@@ -113,7 +114,7 @@
         proto ^js (js/Object.create (.-prototype ^js react/Component))]
     (set! (.-prototype ^js ctor) proto)
     (set! (.-constructor proto) ctor)
-    (set! (.-displayName ^js ctor) (str eb/boundary-view-id))
+    (set! (.-displayName ^js ctor) (performance/entry-id eb/boundary-view-id))
     ;; The safe intent dispatches into the frame the boundary sits under.
     (set! (.-contextType ^js ctor) adapter-context/frame-context)
     ;; React-19 requires this static method for the boundary to catch; it

--- a/implementation/freehand/src/re_frame/freehand/react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/react.cljs
@@ -604,7 +604,7 @@
                           (catch :default e
                             (eb/note-failing-view! e view-id :normalize)
                             (throw e))))))))))]
-    (gobj/set c "displayName" (str view-id))
+    (gobj/set c "displayName" (performance/entry-id view-id))
     c))
 
 (defn- lowering-unavailable!
@@ -681,7 +681,7 @@
             (fn freehand-compiled-view [js-props]
               (performance/mark-and-measure :render view-id
                 (run (:body @slot) js-props))))]
-    (gobj/set c "displayName" (str view-id))
+    (gobj/set c "displayName" (performance/entry-id view-id))
     c))
 
 (defn- behavior-component
@@ -726,7 +726,7 @@
                         (catch :default e
                           (eb/note-failing-view! e view-id :normalize)
                           (throw e)))))))))]
-    (gobj/set c "displayName" (str view-id))
+    (gobj/set c "displayName" (performance/entry-id view-id))
     c))
 
 (defn- component-for

--- a/implementation/freehand/test/re_frame/freehand/render_display_name_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/render_display_name_cljs_test.cljc
@@ -1,0 +1,191 @@
+(ns re-frame.freehand.render-display-name-cljs-test
+  "ONE IDENTIFIER — the name React DevTools shows and the `<id>` in
+  `rf:render:<id>` (rf2-2rtt6.136).
+
+  Spec 009 §Naming convention does not stop at naming the measure. It
+  requires that the `<id>` in the measure name and **the id the substrate
+  publishes to the developer** (React `displayName`, the registrar key) be
+  ONE identifier, \"so a name read off the User-Timing stream is directly
+  jumpable in the tooling\". The whole ergonomic point is a gesture: read a
+  boundary's name in the React DevTools tree, paste it into a `rf:render:`
+  User-Timing filter, and see that boundary's renders.
+
+  ## What was wrong
+
+  `v/defview` mints a KEYWORD view id (`re-frame.freehand`'s `(keyword (str
+  ns-sym) (str sym))`), and the emitter stamped it with `(str view-id)` — a
+  keyword stringifies WITH its leading colon. So DevTools showed
+  `:app.todo/todo-row` while the bracket wrote
+  `rf:render:app.todo/todo-row`, and the documented paste produced
+  `rf:render::app.todo/todo-row` and matched NOTHING. A tool that returns
+  silence to a developer using it exactly as documented is worse than one
+  with no filter at all: the conclusion drawn is \"there is no trace\",
+  not \"the name is wrong\".
+
+  Nothing caught it. The Hicasso bench arm's `defview` mints a STRING
+  view name, so its `displayName` and its measure id are byte-identical by
+  construction and `arm1/render-measure-cljs-test` is green either way;
+  every other `displayName` assertion in this tree is against that arm or
+  against the `v/->react` codec. The product path — a keyword id through
+  `re-frame.freehand.react` — had no row at all.
+
+  ## Why the rows below are shaped the way they are
+
+  Asserting that each string is WELL-FORMED is exactly the shape that let
+  this through: `\":app.todo/todo-row\"` and `\"rf:render:app.todo/todo-row\"`
+  are both perfectly well-formed, and they are still two identifiers. So
+  the rows assert the two are **equal** — and the CLJS half performs the
+  developer's actual gesture against a real User-Timing buffer, because the
+  failure being pinned is a filter returning nothing, not a string
+  comparison.
+
+  Both hosts, deliberately. The shared builder is `.cljc`
+  (`re-frame.performance/entry-id`), and a wrong arity there does not throw
+  on ClojureScript — it silently binds something else — so a row green on
+  the JVM has not exercised the host the emitter actually runs on."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [clojure.string :as str]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.descriptor :as descriptor]
+            [re-frame.performance :as performance]
+            #?(:cljs [re-frame.freehand.behaviors :as behaviors])
+            #?(:cljs [re-frame.freehand.react :as fr])))
+
+;; The product path, minted the ordinary way. Nothing here is a fixture
+;; spelling: this is the declaration an application writes.
+(v/defview todo-row [_] [:li "row"])
+
+(def ^:private view-id (:view-id (descriptor/describe todo-row)))
+
+;; ---------------------------------------------------------------------------
+;; Cross-host — the shared builder, and the builder that is NOT shared
+;; ---------------------------------------------------------------------------
+
+(deftest the-product-mint-is-a-keyword-and-str-is-the-wrong-builder
+  (testing "`v/defview` mints a keyword view id, and `(str view-id)` — the
+            obvious way to publish it — is NOT the spelling the measure
+            carries. This is the reproduction, host-independent: the two
+            builders disagree on exactly the character the paste chokes on."
+    (is (keyword? view-id)
+        "non-vacuous: the product path really does mint a keyword — the
+         string-minted bench arm is the case that cannot fail")
+    (is (str/starts-with? (str view-id) ":")
+        "and a keyword stringifies WITH its colon")
+    (is (not (str/starts-with? (performance/entry-id view-id) ":"))
+        "while the id the measure carries has none")
+    (is (not= (str view-id) (performance/entry-id view-id))
+        "so `(str view-id)` and the measure's own builder are two
+         identifiers — a future simplification back to `str` reds here")))
+
+(deftest the-shared-builder-strips-the-colon-for-every-bucket
+  (testing "`build-name`'s id half is `entry-id`, and it is the SAME id half
+            in all four Spec 009 buckets — there is no per-bucket arm. That
+            is why the emitter's `displayName` moved rather than the name
+            builder: stripping the colon in `:render` alone would have to
+            special-case one of four correct buckets, and doing it in the
+            emitter instead leaves all four untouched."
+    (doseq [bucket [:event :sub :fx :render]]
+      (is (= (str "rf:" (name bucket) ":app.todo/todo-row")
+             (performance/build-name bucket :app.todo/todo-row))
+          (str bucket " strips the colon and keeps the namespace")))
+    (doseq [bucket [:event :sub :fx :render]]
+      (is (= (performance/build-name bucket :app.todo/todo-row)
+             (str "rf:" (name bucket) ":" (performance/entry-id :app.todo/todo-row)))
+          (str bucket "'s id half IS entry-id — one builder, not four")))))
+
+(deftest entry-id-leaves-a-string-minted-id-exactly-as-written
+  (testing "The bench arm mints `\"<ns>/<view>\"` STRINGS and its
+            `displayName`/measure agreement is already byte-identical. The
+            shared builder must be the identity there, or a fix for the
+            keyword path would break the path that was correct."
+    (is (= "my.ns/todo-row" (performance/entry-id "my.ns/todo-row")))
+    (is (= "bare-row"       (performance/entry-id "bare-row")))
+    (is (= "my.ns/todo-row" (performance/entry-id 'my.ns/todo-row))
+        "a symbol is stringified as written too")
+    (is (= "rf:render:my.ns/todo-row"
+           (performance/build-name :render "my.ns/todo-row"))
+        "so the bench arm's row is unmoved")
+    (is (= "login" (performance/entry-id :login))
+        "and a keyword with no namespace invents none")))
+
+;; ---------------------------------------------------------------------------
+;; CLJS — what React is actually handed, and the developer's actual gesture
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (defn- boundary-display-name
+     "The `displayName` React DevTools reads off the component the emitter
+      mounts `view` through — taken from a real element, which is the only
+      thing React itself ever sees."
+     [view]
+     (.-displayName (.-type (fr/element [view {}])))))
+
+#?(:cljs
+   (deftest the-boundary-publishes-the-name-the-measure-carries
+     (testing "The two strings are EQUAL, which is the assertion shape that
+               would have caught this — `displayName` and the measure's id
+               half are one identifier, not two that happen to be
+               well-formed."
+       (let [shown        (boundary-display-name todo-row)
+             measure-name (performance/build-name :render view-id)]
+         (is (= (performance/entry-id view-id) shown)
+             "React is handed the measure's own id half")
+         (is (= measure-name (str "rf:render:" shown))
+             "so prefixing the name DevTools shows REBUILDS the measure name
+              exactly — which is what 'directly jumpable' means")
+         (is (not (str/starts-with? shown ":"))
+             "non-vacuous: the colon really is gone from what React sees")))))
+
+#?(:cljs
+   (deftest the-behavior-boundary-publishes-one-name-across-both-tiers
+     (testing "`[v/behavior …]` lowers to a component in the interpreted
+               emitter and to `behaviors/behavior-el` in the compiled one.
+               They are one construct, so they publish one name — an app
+               mixing tiers must not show `re-frame.freehand/behavior` beside
+               `:re-frame.freehand/behavior` in the same tree."
+       (is (= (performance/entry-id behaviors/behavior-view-id)
+              (.-displayName behaviors/behavior-el))
+           "the compiled twin uses the shared builder too")
+       (is (not (str/starts-with? (.-displayName behaviors/behavior-el) ":"))
+           "non-vacuous: it carries no leading colon either"))))
+
+#?(:cljs
+   (defn- rf-measure-names []
+     (->> (.getEntriesByType js/performance "measure")
+          (map #(.-name %))
+          (filterv #(str/starts-with? % "rf:")))))
+
+#?(:cljs
+   (deftest pasting-the-devtools-name-into-the-filter-finds-the-trace
+     (testing "THE FAILURE, as the developer meets it. The guide says 'the id
+               is the head's displayName, so the name you filter the profile
+               on is the name React DevTools shows'. So: read the name off the
+               boundary, prefix it with `rf:render:`, and ask the User-Timing
+               stream. Before the fix this returned NOTHING and the developer
+               concluded the trace was absent.
+
+               The entry is written with the very call the bracket makes —
+               `(.measure js/performance (build-name :render view-id) #js
+               {start end})`. This build has the perf gate at its default-off
+               goog-define, so React cannot be made to emit one here; the
+               EMISSION is witnessed by the nightly `-emit-nightly-test`
+               runners, and what is witnessed here is the NAME agreement the
+               paste depends on."
+       (.clearMeasures js/performance)
+       (let [shown        (boundary-display-name todo-row)
+             measure-name (performance/build-name :render view-id)]
+         ;; The bracket's own emit, verbatim.
+         (.measure js/performance measure-name #js {"start" 0 "end" 1})
+         (is (= [measure-name] (rf-measure-names))
+             "non-vacuous: exactly one rf: entry is on the stream, and it is
+              the one the `:render` bracket would have written")
+         ;; The gesture.
+         (let [pasted (str "rf:render:" shown)
+               hits   (filterv #(= % pasted) (rf-measure-names))]
+           (is (= 1 (count hits))
+               (str "pasting " (pr-str shown) " into the rf:render: filter "
+                    "finds the boundary's trace"))
+           (is (= [measure-name] hits)
+               "and finds THAT boundary, not some other entry"))
+         (.clearMeasures js/performance)))))


### PR DESCRIPTION
Closes rf2-2rtt6.136.

## The defect, as the developer meets it

Spec 009 §Naming convention requires that the `<id>` in `rf:render:<id>` and **the id the substrate publishes to the developer** (React `displayName`, the registrar key) be **one identifier**, *"so a name read off the User-Timing stream is directly jumpable in the tooling"*. The Hicasso performance guide states the consequence: *"The id is the head's `displayName`, so the name you filter the profile on is the name React DevTools shows."*

On the product path that was false. `v/defview` mints a **keyword** view id (`freehand.cljc`'s `(keyword (str ns-sym) (str sym))`) and the emitter stamped it with `(str view-id)` — a keyword stringifies **with** its leading colon.

Reproduced against the real mint, before any change:

```
view-id           = :user/todo-row   keyword? = true
React DevTools    = ":user/todo-row"
User-Timing entry = "rf:render:user/todo-row"
pasted filter     = "rf:render::user/todo-row"
FILTER HITS       = []
PASTE FINDS THE TRACE?  false
```

The symptom is not that two strings differ. It is that a developer reads a name in DevTools, pastes it into the documented filter, gets **nothing**, and concludes the trace is absent rather than that the name is wrong.

## Which side moves, and why

The `displayName` moves, not the name builder. `build-name`'s id half already strips the colon, and it does so for **all four** buckets from a single `cond` with no per-bucket arm — verified in source and now pinned by a row that walks `:event`/`:sub`/`:fx`/`:render`. Changing it would break three buckets that are correct today or special-case one, and would emit `rf:render::app.todo/todo-row`.

So that id half is extracted as `re-frame.performance/entry-id`, `build-name` delegates to it, and the emitter calls the same fn. The two spellings cannot drift because there is now one spelling. No new mechanism: the `cond`'s symbol and `:else` arms were already identical, so it collapses to an `if`.

The bench arm's `defview` mints a **string** view name, so its two names were already byte-identical — `entry-id` is the identity on strings and `arm1/render-measure-cljs-test` is unmoved.

**No spec edit.** Spec 009 states the requirement correctly; the code diverged from it. The landed guide sentence in `docs/design/hicasso/draft-guide/11-performance.md` becomes true rather than needing a rewrite, which settles the reconciliation the bead's audit note asked for.

## Two stamps beyond the literal fence, and why

The bead scoped this to `react.cljs` (three identical stamps there). Two more stamps of the same expression live in the same substrate, and leaving them would have introduced a fresh defect rather than preserved the status quo:

- `behaviors/behavior-el` — the **compiled twin** of the interpreted `v/behavior` boundary. Fixing only `react.cljs` would make one construct show `re-frame.freehand/behavior` and `:re-frame.freehand/behavior` in the same DevTools tree depending on which tier lowered it. Pinned by a new row.
- the `v/error-boundary` class in `error_react.cljs` — the last `(str <keyword view-id>)` displayName in the substrate. Its neighbour `phase.cljs` already uses colon-free literals, so leaving exactly one behind is arbitrary.

`v/->react`'s `"v/->react(<view-id>)"` wrapper name is deliberately decorated, is not a boundary identifier, and is pinned by an existing witness — left alone.

## The same defect is live on the ADAPTER path — reported, not fixed here

The bead states the divergence is "confined to the product path". It is not. `implementation/core/src/re_frame/views.cljs` — the `reg-view` wrapper every adapter composes — brackets `(performance/mark-and-measure :render id …)` at L552 and stamps `(set! (.-displayName ^js wrapped) (str id))` at L586. Identical divergence, on the **first-class, actively-supported** substrate. The bench arm is simply the only one of the three paths that mints strings.

It is not fixed here because the current spelling is deliberate and **landed**: `rf2-fa4ly`'s comment says DevTools should show `<:cart/total-line>`, and `adapters/reagent/test/…/reg_view_devtools_cljs_test.cljs` pins it in two assertions. Changing a shipping substrate's DevTools names and deleting landed assertions is an operator call, not this bead's fence.

Filed as **rf2-976bw** (P2), with the one-token fix spelled out — `entry-id` was extracted public precisely so that path can reuse it.

## The witness

No test pinned the freehand-src `displayName` — every `displayName` assertion in that tree was against the bench arm or the `v/->react` codec, which is how this shipped.

`implementation/freehand/test/re_frame/freehand/render_display_name_cljs_test.cljc` asserts the two strings are **equal** for a **keyword-minted** view, and then performs the developer's actual gesture against a real User-Timing buffer: read the name off the boundary, prefix `rf:render:`, query the stream, expect a hit. Asserting that each string is merely well-formed is exactly the shape that let this through — `":app.todo/todo-row"` and `"rf:render:app.todo/todo-row"` are both well-formed and still two identifiers.

The entry is written with the very call the bracket makes. This build has the perf gate at its default-off `goog-define`, so React cannot be made to emit one here; the **emission** is witnessed by the nightly `-emit-nightly-test` runners, and what is witnessed here is the **name agreement** the paste depends on.

Cross-host by construction: `entry-id` is `.cljc`, and a wrong arity there does not throw on ClojureScript, so the builder rows run on both hosts and the emitter rows run on CLJS.

## Quality gates

All foreground to completion, exit code captured on the line after the runner, no piping through `tail`/`grep`, logs written per-gate.

| Gate | Exit | Result |
|---|---|---|
| `clojure -M:test -n …render-display-name-cljs-test` (freehand JVM, focused) | `rc=0` | 3 tests / 17 assertions |
| `clojure -M:test` (`implementation/freehand`, JVM) | `rc=0` | 1291 tests / 8874 assertions |
| `clojure -M:test` (`implementation/core`, JVM) | `rc=0` | 2233 tests / 11645 assertions |
| `npm run test:freehand` (`:node-test-freehand`, CLJS) | `rc=0` | 1405 tests / 7778 assertions |
| `npm run test:cljs` (`:node-test`, CLJS, whole repo) | `rc=0` | 12734 tests / 63868 assertions |

`npm ci` was run inside this worktree; `node_modules` is its own (2,933 files / 101 top-level, matching the canary), never a junction.

### Mutation proofs — both directions, both hosts

Each mutation was confirmed **applied** before any verdict was read: `git diff --stat`, the mutant token grepped back out, and the replaced token confirmed absent. Restoration was verified the same way.

**Direction 1 — revert the emitter to `(str view-id)`** (the shipped bug):

| Host | Exit | Result |
|---|---|---|
| CLJS `npm run test:freehand` | `rc=1` | **5 failures**, in `the-boundary-publishes-the-name-the-measure-carries` and `pasting-the-devtools-name-into-the-filter-finds-the-trace` |
| JVM focused | `rc=0` | **green — stated, not hidden** |

The CLJS failure is the reproduction verbatim: `actual: (not (= "rf:render:…todo-row" "rf:render::…todo-row"))`, and the paste row reports `(not (= 1 0))` — **zero hits**.

The JVM green is a real property of this defect, not a gap in the witness: `react.cljs` is ClojureScript-only, so no JVM run can discriminate this mutation. That is precisely why the emitter rows are CLJS-fenced and the builder rows are not.

**Direction 2 — stop stripping the colon in `entry-id`** (`(str id)` for every input):

| Host | Exit | Result |
|---|---|---|
| JVM focused | `rc=1` | **7 failures** across all three cross-host deftests |
| CLJS `npm run test:freehand` | `rc=1` | **9 failures** across five deftests, including the behavior-twin row |

Note which row does *not* fire: the paste row stays green, because this mutation moves the `displayName` and the measure name **together** and they still agree. That is correct and is why the "no leading colon" and per-bucket rows exist beside it — agreement alone is not the whole contract.

**Direction 3 — special-case the `:render` bucket in `build-name`** (the alternative the ruling rejected, which emits `rf:render::app.todo/todo-row`):

| Host | Exit | Result |
|---|---|---|
| JVM focused | `rc=1` | **2 failures** in `the-shared-builder-strips-the-colon-for-every-bucket` |
| CLJS `npm run test:freehand` | `rc=1` | **5 failures**; the paste row again reports zero hits |

The row that walks all four buckets is what catches it — the ruling's own reasoning, made executable.

No mutation came back green on shipped code on a host that can see it.

### Not run

Browser lanes, production-elision / bundle-isolation / perf-bundle gates, adapter smokes, Xray feature matrix, mcp-conformance, tool JVM suites. `mkdocs build --strict` — no documentation content changed.
