### PR TITLE
docs(hicasso): repair the React-relationship sentence in check-member-key! (rf2-2rtt6.104)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -1583,9 +1583,9 @@
   duplicate-key warning (`react-dom-client.development.js`,
   `warnOnInvalidKey`) bails on `if (\"string\" !== typeof key) break` —
   but the coercion above has already happened, so the key IS a string and
-  the check DOES apply. React therefore does warn `Encountered two
-  children with the same key, ` + \"`[object Object]`\" whenever two or
-  more foreign-object keys collide.
+  the check DOES apply. React therefore does emit its own *Encountered
+  two children with the same key, `[object Object]`* whenever two or more
+  foreign-object keys collide.
 
   That is worth stating plainly because it means this warning is NOT the
   only signal in the collision case. Where React is genuinely silent is


### PR DESCRIPTION
Follow-up to #7619, which merged before this landed.

The React-relationship paragraph that PR added to `check-member-key!`'s docstring
went in with a stray string-concatenation fragment left mid-prose — a backtick
run, a `+`, and an escaped quote — so a sentence describing what React prints read
like broken code:

```
React therefore does warn `Encountered two
children with the same key, ` + \"`[object Object]`\" whenever two or
more foreign-object keys collide.
```

Same claim, stated plainly. **Docstring text only** — no form changes, no
behaviour change, and the escaped `\"string\"` quotes elsewhere in the docstring
are untouched.

## Quality gates

This exact tree (the polish applied) is what the rf2-2rtt6.104 gate run
measured — the edit was in the working tree before the spine reached its CLJS
tier, so the numbers below cover it rather than the pre-polish text.

| gate | rc | result |
|---|---|---|
| `scripts/test-fast-pr.sh` | 0 | terminal marker `PASS fast PR spine`; 0 FAIL/ERROR in 1250 lines |
| ├ JVM `implementation/core` | 0 | 2233 tests / 11645 assertions, 0 failures |
| ├ JVM `implementation/freehand` | 0 | 1288 tests / 8857 assertions, 0 failures |
| ├ `test:cljs` | 0 | 12728 tests / 63843 assertions, 0 failures |
| ├ per-ns test isolation | 0 | 17/17 namespaces green standalone |
| └ hicasso bench-lane compile | 0 | 129 lane namespaces, 0 warnings |
| `node-test` compile (docstring parse) | 0 | 2160 files, 71 recompiled, **0 warnings** |

The compile is the load-bearing one for a docstring change: an unbalanced quote
would fail the read. Verified independently too — the only `"` characters inside
the docstring range are the pre-existing escaped `\"string\"` pair.
