### PR TITLE
hicasso: the intent row is three-quarters route-link, and one line tripled it (rf2-vw412)

### DIFF
--- a/docs/design/hicasso/studio/our-walk-against-reagents.md
+++ b/docs/design/hicasso/studio/our-walk-against-reagents.md
@@ -142,6 +142,14 @@ samples and the guard passed on both partitions.
 > from it are figures about a donor the programme has since repaired; and the
 > codec has itself moved on. Both are re-taken in one process on current `main`
 > in [the 2026-08-04 re-take](#2026-08-04-re-take-of-the-arms-on-current-main).
+>
+> **A third bullet was wrong when it was written.** "Hicasso's own authoring
+> surface costs 41 ns/element … 71 intent vectors lowered across 1,202
+> elements" — the 41 is right for this tree and the attribution is not: 207 of
+> the page's event positions carry an `[::h/navigate {…}]` that `route-link`
+> minted, and they are three-quarters of the figure. The authored surface is
+> nearer 12 ns/element. Measured and attributed in
+> [the 2026-08-06 attribution](#2026-08-06-attribution-of-the-intent-row-rf2-vw412).
 
 ## 3. The stages — absolute ns, because a ratio cannot be read against a frame
 

--- a/docs/design/hicasso/studio/our-walk-against-reagents.md
+++ b/docs/design/hicasso/studio/our-walk-against-reagents.md
@@ -48,6 +48,17 @@ legal, and identical work, for all three interpreters. A fourth arm,
 `hicasso-native`, then walks the page's OWN markup, so the authoring surface's
 term is named rather than hidden inside the comparison.
 
+> **The exemption above covers `route-url`, and not the navigate vector's
+> lowering.** Every `route-link` mints an `:on-click [::h/navigate {…}]` as well
+> as an `href`, and the href is indeed a plain string before any clock starts —
+> but `codec/as-element` lowers the navigate vector *inside* every timed window
+> of the `hicasso-native` arm, 207 times, where `plainify` has replaced all 207
+> with `noop` on the plain one. So the `hicasso-native` − `hicasso` gap is
+> three-quarters route-link and one-quarter the 71 author-written intents §2
+> attributes the whole of it to. Measured, attributed to a commit, and costed
+> against a repair in
+> [the 2026-08-06 attribution](#2026-08-06-attribution-of-the-intent-row-rf2-vw412).
+
 ### Workload matching is gated, not asserted
 
 Every arm's element tree is rendered into a fresh container and its canonical
@@ -557,3 +568,216 @@ across runs.
 adapter, codec or runtime file was touched by this run; `validation.md`,
 `decisions.md` and `rf2-2rtt6.1`'s standard-bead notes are unmodified; no bead
 was closed or reprioritised. The decider is the operator.
+
+## 2026-08-06 attribution of the intent row (rf2-vw412)
+
+**Why this run exists.** `rf2-vw412` put the two intent readings above side by
+side — §2's ~41 ns/element, the re-take's 125 — observed that both were resolved
+and both passed the guard, and asked for the one thing neither run had done:
+attribute the difference rather than re-take it. It named `front/codec.cljs`'s
+593 changed lines as the suspects and declined to guess among them.
+
+**The suspects were the wrong file, and no published row is wrong.** Both
+readings are correct for their trees. What is wrong is the sentence §2 attaches
+to its row — and it was already wrong when it was written, before anything
+regressed.
+
+### The gap holds two populations, and only one of them is authored
+
+The two witnesses differ at event positions and nowhere else, which is what
+earns the row its reading. What the arms cannot say is *which* event positions,
+and this page carries two kinds that cost nothing like each other:
+
+| carrier at an `:on-*` position | count | written by |
+|---|---|---|
+| `[:conduit/favorite slug]`, `[::h/prevent [:conduit/show-your-feed]]` | 71 | the author |
+| `[::h/navigate {:frame … :payload … :native? … :veto …}]` | 207 | `route-link`, one per link |
+
+Both are replaced by the shared `noop` on the plain witness, so **both are
+inside the gap**, and the minted population is three times the authored one.
+The instrument now counts them rather than assuming: `roster-navigate-positions
+207`, `roster-intent-positions 71`, `roster-other-event-positions 0` — the same
+207 links §1 counts, and exactly the 71 §2 names.
+
+§1 exempts route-link from this instrument, and the exemption is sound for the
+term it names: the `route-url` synthesis happens once, at `realize-deep`,
+outside every window. The navigate vector's **lowering** is a different term
+with the same owner, and it happens inside every timed window the native arm
+takes.
+
+### The rows, and the one term ablated
+
+Three runs of the unchanged driver, 2026-08-06, on the tree below. Runs A and C
+are the shipping code. Run B is run C's tree with **one line** of
+`front.intent/unwrap-navigate` ablated — `(set (keys m))` replaced by the
+roster it is compared against, which deletes the allocation and leaves every
+other line of the lowering standing.
+
+| run | `hicasso` ns/el | `hicasso-native` ns/el | gap ns/el | grid steps | `hicasso-native`/`hicasso` |
+|---|---|---|---|---|---|
+| A — shipping | 447 | 655 | 208 | 20 | **1.4651** |
+| B — one line ablated | 364 | 406 | 42 | 4 | **1.1143** |
+| C — shipping, restored | 447 | 645 | 198 | 19 | **1.4419** |
+
+**Read the ratios, not the absolutes, exactly as §2 and the re-take do.** All
+three gaps are resolved at the 0.0125 ms/walk grain (4 steps is the smallest).
+Run B's box was *busier* than run C's (16.0% against 12.3%), so box state does
+not explain it: the quieter of the two shipping runs still read 1.44.
+
+**Ablating one line puts the row back on §2's published figure.** 42 ns/element
+against §2's ~41, and a same-run ratio of 1.1143 against §2's 1.0729 and 1.0762.
+
+### The stage rows underneath, by carrier
+
+`lower-prop` over each carrier, against what the plain arm pays at the **same
+key** — so every row is a within-run difference, and the plain column is the
+`noop` the plain witness actually carries. ns per position:
+
+| stage | A — shipping | B — ablated | C — shipping |
+|---|---|---|---|
+| navigate carrier, native value | 821.3 | **173.9** | 1,135.3 |
+| navigate carrier, plain value | 79.7 | 74.9 | 94.2 |
+| authored intent, native value | 288.7 | 225.4 | 302.8 |
+| authored intent, plain value | 77.5 | 70.4 | 98.6 |
+| key-set check, shipping shape (local copy) | 529.0 | 584.5 | 654.6 |
+| key-set check, allocation-free | 82.1 | 74.9 | 106.3 |
+
+**The last two rows are the positive control, and they are the reason the
+ablation can be believed.** They price a LOCAL copy of the check, written into
+the instrument the way `guarded-lookup` is, so the ablation cannot reach them —
+and it does not: 529.0 → 584.5 → 654.6, tracking the box and nothing else,
+while the row that goes through the real `unwrap-navigate` collapses by a
+factor of five and comes straight back. The mutation landed where it was aimed
+and nowhere else.
+
+Carried onto the arm row's units — ns per position × roster ÷ 1,202 elements,
+done by the instrument so no reader has to:
+
+| carrier | A — shipping | B — ablated | C — shipping |
+|---|---|---|---|
+| navigate (207 links) | 127.7 | **17.1** | 179.3 |
+| authored intents (71 positions) | 12.5 | 9.2 | 12.1 |
+| named carriers, summed | 140.2 | 26.2 | 191.3 |
+| *observed arm gap* | *208.0* | *41.6* | *197.6* |
+
+**Attribution, not accounting** — §3's rule holds here and for the same reason.
+The named carriers come to 67% of the observed gap in run A and 97% in run C,
+which is the spread a micro table taken on this box is entitled to and is why
+no closure percentage is offered. What the table supports is which term is
+large: the navigate carrier is worth ten to fifteen times the authored one in
+every run, and the ablation moves the *arm* row by more than the micro row
+predicts (156 ns/element against 94) — the expected direction, since the walk
+pays the allocation's collection pressure that a warm 207-entry loop mostly
+does not.
+
+### The commit
+
+`unwrap-navigate` validated the navigate map's key **types** and asked nothing
+about its key **set**, so a map missing `:veto` passed and so did a map carrying
+a fifth key the lowering then dropped. `rf2-2rtt6.54` closed that, correctly,
+by asserting the exact set:
+
+    ks (when (map? m) (set (keys m)))
+    …
+    (= navigate-keys ks)
+
+One `PersistentHashSet` built and compared **per link per render**, 207 times a
+walk on this page.
+
+| | |
+|---|---|
+| **Commit** | `69678caee6` — `fix(hicasso): route-link's navigate grammar is closed, and prefetch is refused (rf2-2rtt6.54)`, committed 2026-08-03 15:52 AUSEST |
+| **Not** in §2's tree | `git merge-base --is-ancestor 69678caee6 02a440a4d1` → **1**. At `02a440a4d1` the line reads `(map? m)` |
+| **In** the re-take's tree | `git merge-base --is-ancestor 69678caee6 77a92185ea` → **0** |
+| **Unchanged since** | `unwrap-navigate` is byte-identical at `77a92185ea` and at this run's tree, so runs A–C measure the re-take's own code for this term |
+| **The other half of that commit** | `route-link/prefetch-declined!` runs at route-link render — `realize-deep` time, outside every window. It is not in any figure here |
+
+`front/codec.cljs`, the file `rf2-vw412` nominated, is not implicated. The
+navigate lowering is `front/intent.cljs`'s.
+
+### So: a regression, and a number nobody had published
+
+**On the bead's question — floor or regression — the honest answer is that it
+is a regression, and that the row it moved was never the number the question
+was about.** Three statements, and they are independent:
+
+1. **The intent surface the P2 fork is deciding about costs ~12 ns/element.**
+   The authored carrier reads 12.5, 9.2 and 12.1 across the three runs —
+   flat, and untouched by what the navigate carrier does — against a walk of
+   447, 364 and 447. That is **under 3% of the walk**, on an instrument whose
+   published sentence says 7%. This figure has not appeared on this page
+   before, and it is the one a ship/kill decision needs.
+2. **The move from ~41 to 125 is a regression with a named line**, and it is
+   **not** a semantic floor in §5's sense. §5's floor is the prop pipeline,
+   where every item is a shipped semantic and removing one removes a feature.
+   Nothing is removed here: a count and four `contains?` admit exactly the maps
+   the set equality admits, including the two shapes `rf2-2rtt6.54` closed the
+   grammar against. `agreement failures: []` on all three runs, over every
+   navigate map the page mints and over an eleven-shape hostile roster —
+   missing `:veto`, a fifth key, a four-key map with all four names wrong, a
+   vector, a string, `nil`.
+3. **The correctness that commit bought is not in question.** A closed grammar
+   that a fifth key can slip past is fail-open by construction and the fix was
+   right. What is at issue is that it is spent once per link per render, on the
+   hot path, when the same guarantee is available for nothing.
+
+**Costed, not landed.** This page's practice is that a candidate is timed
+beside the shipping shape and lands only on a bead of its own; the repair is
+one `let` binding moved into the failure branch and is filed as such.
+
+### What no row should move
+
+§2's rows, the re-take's rows and their arm ratios all stand: each is correct
+for the tree that produced it, and the two trees differ by a commit that is now
+named. §2's **sentence** is the thing that does not survive — "Hicasso's own
+authoring surface costs 41 ns/element … 71 intent vectors lowered across 1,202
+elements". The 41 was never 71 intent vectors: on that tree it was ~12
+ns/element of authored intent and ~29 of route-link's minted navigate carrier,
+and the arithmetic is the same one done three times above. The bullet is left
+exactly as taken, per this page's rule, and this section is where it is
+corrected.
+
+### Controls, the box, and provenance
+
+| control | A | B | C |
+|---|---|---|---|
+| arm-order guard self-test (12 cases) | all `ok` | all `ok` | all `ok` |
+| twin parity gate (fatal) | OK — 1,202 el / 58,474 B | OK | OK |
+| workload match | 58,474 B / 58,529 B, the same 55-byte whitespace difference §1 prices | same | same |
+| arm-order guard verdict | **reportable**, 4/4 by predecessor and by phase | **reportable** | **reportable** |
+| candidate agreement failures | `[]` | `[]` | `[]` |
+| `SLIM DECOMPOSED` agreement failures | `[]` | `[]` | `[]` |
+| intent agreement failures | `[]` | `[]` | `[]` |
+| exit code | **0** | **0** | **0** |
+| box, summed per-process CPU delta ÷ 24 cores | 46.6%, 3 `java` | 16.0%, 1 `java` | 12.3%, 1 `java` |
+
+**The box was NOT quiet and this section says so.** Other workers held
+shadow-cljs JVMs throughout. The absolutes are therefore ceilings and are not
+compared across runs; every claim above is a same-run ratio or a same-run
+difference, which is the discipline §7 established and the reason run B can be
+read against run C at all.
+
+| | |
+|---|---|
+| **Producing commit** | `ea04769e09` on `worker/intentprice-vw412`, merge-base `2cf3a48037` (`origin/main`) |
+| **Reproduction** | `HICASSO_INIT_FN=re-frame.bench.hicasso.walk-vs-reagent-app/-main HICASSO_OUT_DIR=out/hicasso-walkcmp HICASSO_PORT=8171 node implementation/freehand/test/re_frame/bench/hicasso/run.cjs` |
+| **Build** | `:hicasso-bench`, `:advanced`, `goog.DEBUG false`, **0 warnings** on all three builds |
+| **Runtime** | chromium `147.0.7727.15` (playwright), node `v24.13.0`, Windows NT 10.0 x64, 24 threads |
+| **Design** | 4 arms × 6 rounds × (4 warm-up + 10 samples), 8 whole-page walks per window — unchanged |
+| **Clock** | in-page `performance.now`, **diagnostic**; the clock of record is untouched here |
+| **Windows** | 2026-08-06 AUSEST, each ~35 s build + ~60 s measurement, completing A 23:18:09, B 23:21:26, C 23:23:32 |
+| **Exit codes** | A `0`, B `0`, C `0`; guard reportable on all three |
+
+| file | blob |
+|---|---|
+| `…/front/intent.cljs` | `a6716e5cdd` — `unwrap-navigate` byte-identical to `77a92185ea`'s |
+| `…/front/route_link.cljs` | `3663b326a2` |
+| `…/front/codec.cljs` | `6301d60db0` — moved again since the re-take's `2c0c26ccb5`, and not implicated |
+| `…/walk_vs_reagent_app.cljs` | `ee0666c3d6` — the re-take's `596d6c1220` plus this section's roster and rows; no arm, witness or window touched |
+| `…/run.cjs` | `1bc82c38ea` — the re-take's, unchanged |
+| `…/walk_profile_app.cljs` (the twin + its parity gate) | `43940c0227` |
+| `reagent2.impl.template` | `9b30b6b74c` — still byte-identical to `rf2-e7zxb`'s landing |
+
+**Advisory, and no row above is amended.** No adapter, codec or runtime file is
+changed by this work; the ablation of run B was reverted before anything was
+committed and appears in no shipped file.

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
@@ -523,6 +523,157 @@
     @bad))
 
 ;; ---------------------------------------------------------------------------
+;; THE INTENT SURFACE, DECOMPOSED (rf2-vw412)
+;; ---------------------------------------------------------------------------
+;;
+;; The `hicasso-native` − `hicasso` gap is the only figure on this page
+;; that prices the authoring surface, and the arms earn that reading
+;; honestly: the two witnesses differ at EVENT POSITIONS and nowhere else.
+;; What the arm row cannot say is WHICH event positions, and this page
+;; carries two populations of them that cost nothing like each other:
+;;
+;;   - the AUTHOR-WRITTEN intent vectors — `:on-click [:conduit/favorite
+;;     …]` on each card's favourite button, `[::h/prevent …]` on the two
+;;     feed toggles. This is the affordance the P2 fork is about.
+;;   - one `[::h/navigate {…}]` per `route-link`, MINTED by route-link
+;;     rather than written by anybody, and §1 counts 207 links here.
+;;
+;; [[plainify]] replaces both with the shared [[noop]], so BOTH are inside
+;; the gap, and the second population is three times the size of the
+;; first. §1's statement that the route-link term is "structurally absent
+;; from this instrument" is true of the `route-url` SYNTHESIS — that
+;; happens once, at `realize-deep`, outside every window — and is not true
+;; of the navigate vector's LOWERING, which `codec/as-element` performs
+;; inside every timed window of the native arm and never on the plain one.
+;;
+;; So the rows below split the gap by carrier and price each against what
+;; the plain arm pays at the SAME key. Every one of them runs inside the
+;; body door: lowering an intent with no ambient dispatch is
+;; `:rf.error/hicasso-intent-outside-boundary` by construction.
+
+(defn- collect-intent-roster
+  "The NATIVE witness's event positions, split by carrier. The plain arm's
+  value at every one of them is [[noop]] by construction, so the plain
+  column needs no second walk — it is the same key with the same handler
+  the plain witness carries."
+  [h]
+  (let [nav-ks #js [] nav-vs #js [] nav-maps #js []
+        int-ks #js [] int-vs #js []
+        other-ks #js [] other-vs #js []]
+    (letfn [(visit-child [c]
+              (cond (vector? c) (visit c)
+                    (seq? c)    (run! visit-child c)
+                    :else       nil))
+            (visit [argv]
+              (let [has-props? (map? (nth argv 1 nil))
+                    props      (when has-props? (nth argv 1))]
+                (when props
+                  (doseq [[k v] props]
+                    (when (and (keyword? k) (intent/event-prop? k))
+                      (cond
+                        (intent/navigate-head? v) (do (.push nav-ks k)
+                                                      (.push nav-vs v)
+                                                      (.push nav-maps (nth v 1 nil)))
+                        (vector? v)               (do (.push int-ks k) (.push int-vs v))
+                        :else                     (do (.push other-ks k)
+                                                      (.push other-vs v))))))
+                (doseq [c (subvec argv (if has-props? 2 1))]
+                  (visit-child c))))]
+      (visit h))
+    {:nav-keys nav-ks :nav-vals nav-vs :nav-maps nav-maps
+     :intent-keys int-ks :intent-vals int-vs
+     :other-keys other-ks :other-vals other-vs}))
+
+;; The one term inside navigate lowering that is neither a closure nor a
+;; field read: `unwrap-navigate`'s closed-grammar check. It is written
+;; here rather than reached for, exactly as [[guarded-lookup]] is, so the
+;; two shapes are local and comparable.
+
+(def ^:private navigate-key-set
+  "`front.intent/navigate-keys`, verbatim — the closed roster HD-027
+  names."
+  #{:frame :payload :native? :veto})
+
+(defn- navmap-keyset-shipping
+  "The shipping check: build the map's key SET and compare it to the
+  roster. One `PersistentHashSet` per link per render."
+  [m]
+  (= navigate-key-set (when (map? m) (set (keys m)))))
+
+(defn- navmap-keyset-scan
+  "The same CLOSED grammar with nothing allocated. The count is what
+  closes it — four presence tests alone are fail-open on a fifth key,
+  which is the defect `rf2-2rtt6.54` was fixing; four presence tests AND a
+  count of four admit exactly the same maps the set equality admits."
+  [m]
+  (and (map? m)
+       (== 4 (count m))
+       (contains? m :frame)
+       (contains? m :payload)
+       (contains? m :native?)
+       (contains? m :veto)))
+
+(def ^:private hostile-nav-maps
+  "The shapes `rf2-2rtt6.54` closed the grammar against, plus the ones it
+  already refused — the candidate must answer the shipping shape on every
+  one of them before either figure is read."
+  [{:frame :f :payload [:e] :native? false :veto nil}
+   {:frame :f :payload [:e] :native? false}                       ; missing :veto
+   {:frame :f :payload [:e] :native? false :veto nil :extra 1}    ; a fifth key
+   {:frame :f :payload [:e] :veto nil}                            ; missing :native?
+   {:payload [:e] :native? false :veto nil}                       ; missing :frame
+   {:frame :f :native? false :veto nil}                           ; missing :payload
+   {:a 1 :b 2 :c 3 :d 4}                                          ; four, all wrong
+   {}
+   nil
+   [:frame :payload :native? :veto]
+   "not a map"])
+
+(defn- intent-agreement
+  "The key-set candidate answers what the shipping shape answers, for
+  every navigate map the page actually mints AND for the hostile roster —
+  checked before any figure is read."
+  [{:keys [^js nav-maps]}]
+  (let [bad (atom [])]
+    (dotimes [i (.-length nav-maps)]
+      (let [m (aget nav-maps i)]
+        (when-not (= (navmap-keyset-shipping m) (navmap-keyset-scan m))
+          (swap! bad conj [:page-navmap i]))))
+    (doseq [m hostile-nav-maps]
+      (when-not (= (navmap-keyset-shipping m) (navmap-keyset-scan m))
+        (swap! bad conj [:hostile-navmap m])))
+    @bad))
+
+(def ^:private intent-roster-rows
+  "The rows of [[intent-table]] that are COUNTS and not ns figures."
+  #{:roster-navigate-positions :roster-intent-positions
+    :roster-other-event-positions})
+
+(defn- intent-table
+  "Ours at an event position, by carrier, against the plain arm's own
+  value at the same key. ns/POSITION — multiply by the roster count and
+  divide by 1,202 to read it against the arm rows' ns/element."
+  [{:keys [^js nav-keys ^js nav-vals ^js nav-maps
+           ^js intent-keys ^js intent-vals ^js other-keys]}]
+  (let [plain-of (fn [^js ks] (let [a #js []]
+                                (dotimes [_ (.-length ks)] (.push a noop))
+                                a))
+        nav-plain (plain-of nav-keys)
+        int-plain (plain-of intent-keys)]
+    [[:roster-navigate-positions     (.-length nav-keys)]
+     [:roster-intent-positions       (.-length intent-keys)]
+     [:roster-other-event-positions  (.-length other-keys)]
+     ;; --- the navigate carrier: minted by route-link, 1 per link -------
+     [:lower-navigate-native (ns-per-op2 micro-reps nav-keys nav-vals intent/lower-prop)]
+     [:lower-navigate-plain  (ns-per-op2 micro-reps nav-keys nav-plain intent/lower-prop)]
+     ;; --- the author-written carrier -----------------------------------
+     [:lower-intent-native   (ns-per-op2 micro-reps intent-keys intent-vals intent/lower-prop)]
+     [:lower-intent-plain    (ns-per-op2 micro-reps intent-keys int-plain intent/lower-prop)]
+     ;; --- the closed-grammar check inside the navigate carrier ---------
+     [:navmap-keyset-shipping (ns-per-op micro-reps nav-maps navmap-keyset-shipping)]
+     [:navmap-keyset-scan     (ns-per-op micro-reps nav-maps navmap-keyset-scan)]]))
+
+;; ---------------------------------------------------------------------------
 ;; SLIM, DECOMPOSED (rf2-lhdp0)
 ;; ---------------------------------------------------------------------------
 ;;
@@ -1084,6 +1235,12 @@
                   cands   (candidate-table roster)
                   slim-bad (slim-agreement roster)
                   slims    (slim-table roster)
+                  ;; The intent roster is the NATIVE witness's, and every
+                  ;; row of its table lowers — so the whole table runs
+                  ;; inside the body door (rf2-vw412).
+                  iroster  (collect-intent-roster native)
+                  intent-bad (intent-agreement iroster)
+                  intents  (wp/in-body (fn [] (intent-table iroster)))
                   hic     (:p50 (get rows :hicasso))
                   rgt     (:p50 (get rows :reagent))
                   slm     (:p50 (get rows :slim))]
@@ -1103,6 +1260,9 @@
               (lane/record! :walk-vs-reagent-slim
                             {:disagreements slim-bad
                              :ns-per-op (into {} (map (fn [[k v]] [k (lane/round4 v)])) slims)})
+              (lane/record! :walk-vs-reagent-intent
+                            {:disagreements intent-bad
+                             :ns-per-op (into {} (map (fn [[k v]] [k (lane/round4 v)])) intents)})
 
               (js/console.log ";; ==== WORKLOAD MATCH (every arm's own DOM, canonical) ====")
               (doseq [{:keys [id]} arms]
@@ -1141,6 +1301,41 @@
               (js/console.log (str ";;   agreement failures: " (pr-str slim-bad)))
               (doseq [[k v] slims]
                 (js/console.log (str ";;   " (name k) ": " (fmt v 1) " ns/op")))
+
+              (js/console.log ";; ==== INTENT SURFACE DECOMPOSED (rf2-vw412) ====")
+              (js/console.log (str ";;   agreement failures: " (pr-str intent-bad)))
+              (doseq [[k v] intents]
+                (js/console.log (str ";;   " (name k) ": " (fmt v 1)
+                                     (when-not (contains? intent-roster-rows k) " ns/op"))))
+              ;; The arm row is ns/ELEMENT over the whole page; these are
+              ;; ns/POSITION over a roster of a few hundred. Carried onto
+              ;; the arm row's units here so the two are readable together
+              ;; and the reader is not asked to do it.
+              (let [m       (into {} intents)
+                    per-el  (fn [delta n] (/ (* delta n) elements))
+                    nav-n   (:roster-navigate-positions m)
+                    int-n   (:roster-intent-positions m)
+                    nav-d   (- (:lower-navigate-native m) (:lower-navigate-plain m))
+                    int-d   (- (:lower-intent-native m) (:lower-intent-plain m))
+                    nav-el  (per-el nav-d nav-n)
+                    int-el  (per-el int-d int-n)
+                    keyset-el (per-el (- (:navmap-keyset-shipping m)
+                                         (:navmap-keyset-scan m))
+                                      nav-n)]
+                (js/console.log (str ";;   -> navigate carrier: " (fmt nav-d 1)
+                                     " ns/position x " nav-n " links / " elements
+                                     " elements = " (fmt nav-el 1) " ns/element"))
+                (js/console.log (str ";;   -> authored intents:  " (fmt int-d 1)
+                                     " ns/position x " int-n " positions / " elements
+                                     " elements = " (fmt int-el 1) " ns/element"))
+                (js/console.log (str ";;   -> named carriers sum: " (fmt (+ nav-el int-el) 1)
+                                     " ns/element; OBSERVED arm gap "
+                                     (fmt (* 1e6 (/ (- (:p50 (get rows :hicasso-native)) hic)
+                                                    elements))
+                                          1)
+                                     " ns/element"))
+                (js/console.log (str ";;   -> of the navigate carrier, the closed-grammar key-set "
+                                     "check is " (fmt keyset-el 1) " ns/element")))
 
               (when (:refuse? gv)
                 (set! (.-HICASSO_GUARD_REFUSED js/window) true))


### PR DESCRIPTION
`rf2-vw412` put the studio page's two intent readings side by side — §2's ~41 ns/element, the 2026-08-04 re-take's 125 — noted that both were resolved and both passed the guard, and asked for **attribution, not another sample**. It nominated `front/codec.cljs`'s 593 changed lines as the suspects and declined to guess among them.

**The suspects were the wrong file, and no published row is wrong.** Both readings are correct for their trees. What does not survive is the *sentence* §2 attaches to its row — and that sentence was already wrong when it was written, before anything regressed.

## The pins both resolve

`77a92185ea` (the re-take) and `02a440a4d1` (§2's landed twin) are both ancestors of `origin/main`, so this is one tree, not two. The comparison is legitimate.

## What the row actually contains

The two witnesses differ at event positions and nowhere else — that is what earns the row its reading. What the arms cannot say is *which* event positions, and the census page carries two kinds:

| carrier at an `:on-*` position | count | written by |
|---|---|---|
| `[:conduit/favorite slug]`, `[::h/prevent […]]` | 71 | the author |
| `[::h/navigate {…}]` | 207 | `route-link`, one per link |

`plainify` replaces **both** with the shared `noop`, so both are inside the gap, and the minted population is three times the authored one. The instrument now counts them rather than assuming: 207 / 71 / 0, matching §1's own link count and §2's own "71 intent vectors" exactly.

§1 exempts route-link from this instrument. That exemption is sound for the term it names — `route-url` synthesis happens once, at `realize-deep`, outside every window — but the navigate vector's **lowering** is a different term with the same owner, and `codec/as-element` performs it *inside* every timed window the native arm takes.

## What moved, and which commit moved it

`rf2-2rtt6.54` closed the navigate grammar's fail-open key-set seam. Correctly — a closed grammar a fifth key can slip past is fail-open by construction. It closed it by building a `PersistentHashSet` of the map's keys and comparing it to the roster, **once per link per render**: 207 hash sets a walk.

- `69678caee6`, committed 2026-08-03 15:52 AUSEST
- `git merge-base --is-ancestor 69678caee6 02a440a4d1` → **1** (not in §2's tree; there the line reads `(map? m)`)
- `git merge-base --is-ancestor 69678caee6 77a92185ea` → **0** (in the re-take's)
- `unwrap-navigate` is byte-identical at `77a92185ea` and at this branch, so these runs measure the re-take's own code for the term

`front/codec.cljs` is not implicated.

## Three runs, and a one-line ablation

Guard **reportable** on every arm of all three, exit `0`, `agreement failures: []` on every table, twin parity OK. Run B is run C's tree with one line of `unwrap-navigate` ablated.

| run | `hicasso` ns/el | `hicasso-native` ns/el | gap | grid steps | ratio |
|---|---|---|---|---|---|
| A — shipping | 447 | 655 | 208 | 20 | **1.4651** |
| B — one line ablated | 364 | 406 | 42 | 4 | **1.1143** |
| C — shipping, restored | 447 | 645 | 198 | 19 | **1.4419** |

**Ablating one line puts the row back on §2's published figure** — 42 ns/element against ~41, ratio 1.1143 against 1.0729 / 1.0762. Run B's box was *busier* than run C's (16.0% vs 12.3%), so box state does not explain it.

**Positive control:** the instrument holds a *local* copy of the key-set check, which the ablation cannot reach — and it does not move (529.0 → 584.5 → 654.6, tracking the box). The row that goes through the real `unwrap-navigate` collapses 821 → 174 and comes straight back to 1,135. The mutation landed where it was aimed and nowhere else.

## Gap or floor? Both — and the number nobody had

- **The floor moved and the gap widened**, and they are separate facts. The re-take's lower absolutes are its quiet box, exactly as it says. The *ratio* is the finding, and it went 1.076 → 1.44.
- **The authored intent surface costs ~12 ns/element** — 12.5, 9.2, 12.1 across the three runs, flat and untouched by what the navigate carrier does, against a 447/364/447 ns/element walk. **Under 3% of the walk**, where §2's sentence says 7%. This figure has never been published and it is the one the P2 fork needs.
- **125 ns/element is a regression, not a semantic floor.** §5's floor is the prop pipeline, where removing an item removes a feature. Nothing is removed here: a count plus four `contains?` admit exactly the maps the set equality admits — `agreement failures: []` on all three runs over every navigate map the page mints and an eleven-shape hostile roster.

**Costed, not landed.** Filed as `rf2-jr0tg` (P2, discovered-from `rf2-vw412`) with the repair, the acceptance and the fence.

## What this PR changes

- the instrument gains an intent roster, four `lower-prop` rows by carrier, the key-set candidate and its agreement check. **No arm, witness, window or guard is touched** — the arms, stage, candidate and slim tables are behaviour-identical to the run the page published.
- a new dated section beside the published ones, per the page's practice. **No published row is amended.**
- two forward pointers: one under §1's plain-witness paragraph, one appended to §2's existing stale-bullet blockquote.

## Quality gates

- `sh scripts/test-fast-pr.sh` — **`PASS fast PR spine`, rc=0**. Plan: docs=true jvm=true node=true; JVM tier `implementation/core` (1288 tests / 8857 assertions, 0 failures, 0 errors) + `implementation/freehand`; mkdocs `--strict`; CLJS node integration; per-ns isolation. Run at `a3758cf1f6`.
- `python scripts/check_doc_slugs.py` — rc=0, re-run **after** the final docs commit `fc12866d09` (rc=0 both times). This is the gate that covers `docs/design/**`; `mkdocs build --strict` does not (`exclude_docs`).
- **Tables counted by hand** (script in scratch, not committed): 8 tables in the new section, column counts consistent within every one — 3/6/4/4/2/4/2/2. Re-counted after the final commit.
- **Headings diffed against HEAD**: additions only, 8 new, none removed — so no heading vanished silently.
- Three `:hicasso-bench` `:advanced` builds, **0 warnings** on each.
- Run B's ablation was reverted before any commit; `grep` confirms `(set (keys m))` restored and the ablation token absent. `git diff` against the merge base is two files, no `.beads` path.