### PR TITLE
fix(hicasso): provenance-pin apposition window, and pin that the gate is scheduled (rf2-kqac1)

### DIFF
--- a/scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
+++ b/scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
@@ -422,6 +422,24 @@ assert "AB an ordinary scripts/ change does NOT arm the docs tier" \
 assert "AB1 an ordinary scripts/ change does NOT arm the spine self-test" \
   "PLAN-SELFTEST skip" "$(plan_selftest "$r")"
 
+# AB2 — rf2-kqac1.  The provenance-pin gate runs in the documentation tier and
+# reads `docs/design/hicasso/**`, so a change to the CHECKER has to arm that
+# tier — otherwise the one diff most likely to break the gate is the one diff
+# that never runs it.  Sits beside its neighbours above rather than being
+# swept in by a `scripts/*` widening, which case AB pins against.
+#
+# `docs=true jvm=false node=false` is the RECOGNISED-doc-script plan, and it is
+# what `scripts/check_doc_slugs.py` produces here too — verified by running
+# this same case against that path.  AB's `jvm=true node=true` above is the
+# different thing it looks like: an UNrecognised script falls back to arming
+# everything, so matching AB's numbers would have meant the classifier had
+# never learnt this path at all.
+r="$tmp_root/provenance-pins"; mkrepo "$r"
+mkdir -p "$r/scripts"; printf 'x\n' > "$r/scripts/check_provenance_pins.py"
+git -C "$r" add -A; git -C "$r" commit -q -m provenance
+assert "AB2 the provenance-pin checker arms the docs tier only" \
+  "PLAN docs=true jvm=false node=false" "$(plan "$r")"
+
 # ---------------------------------------------------------------------------
 # HERMETIC mkdocs RESOLUTION (rf2-03298).  Case X above consults the HOST, and
 # on the host that matters most — GitHub CI, which installs requirements.txt —

--- a/scripts/check_provenance_pins.py
+++ b/scripts/check_provenance_pins.py
@@ -182,11 +182,9 @@ def _split_span(inner: str, max_id_len: int) -> List[str]:
     """Yield every bare hex id inside one code span."""
     out: List[str] = []
     for part in _SPAN_SPLIT.split(inner.strip()):
+        # An abbreviated id trails an ellipsis, written both as the single
+        # character and as three dots; `rstrip` covers each.
         part = part.strip().strip("*").strip("()[]").rstrip(".").rstrip("…")
-        # A trailing ellipsis marks an abbreviated id and is written both as the
-        # single character and as three dots.
-        if part.endswith("..."):
-            part = part[:-3]
         if not _BARE_HEX.match(part):
             continue
         if len(part) > max_id_len:
@@ -284,7 +282,10 @@ def classify(
         _, is_pin, reason = signals[-1]
         return is_pin, reason
 
-    right = _strip_quote(lines[index])[span_end : span_end + _RIGHT_APPOSITION]
+    # The ORIGINAL line, not a quote-stripped one: `span_end` is an offset into
+    # the line as read, and stripping a `> ` prefix first would slide the
+    # window two characters past the apposition it exists to see.
+    right = lines[index][span_end : span_end + _RIGHT_APPOSITION]
     if _DIGEST_WORDS.search(right):
         return False, "digest word in apposition to the right"
     if _table_header_is_digest(lines, index):
@@ -640,6 +641,24 @@ _EXTRACTION_CASES: List[Tuple[str, List[str], List[str]]] = [
         "abbreviated id with an ellipsis still reads as one id",
         ["Producing commit `0642815dc2…` for the spine."],
         ["0642815dc2"],
+    ),
+    # The right-apposition window is measured on the line AS READ.  Stripping
+    # the `> ` first slid it two characters and lost the word it looks for,
+    # which mattered because this corpus writes whole blob callouts in
+    # blockquotes.
+    (
+        "right apposition survives a blockquote prefix",
+        ["> The instrument is `a1d7005d74` blob for the run."],
+        [],
+    ),
+    (
+        "a blockquoted blob table is still a blob table",
+        [
+            "> | file | blob |",
+            "> |---|---|",
+            "> | coldmount views | `335a37bb09233121e83ca2dc9f6a0a9ef88e037c` |",
+        ],
+        [],
     ),
 ]
 


### PR DESCRIPTION
Completes rf2-kqac1. PR #7622 merged mid-flight and took the first two commits;
these two were pushed after it and need their own PR. Both are corrections to
the checker that landed there — one a real bug, one the missing proof that the
gate is scheduled.

## The bug

`classify`'s right-apposition window (`the \`x\` blob` → digest) measured
`span_end` — an offset into the line **as read** — against a *quote-stripped*
copy of that line. On a blockquoted line the `> ` prefix slid the window two
characters past the word it exists to see, and this corpus writes whole blob
callouts inside `>` blockquotes, so the miss was aimed squarely at the shape it
matters for. Direction of the defect is the safe one — a missed digest becomes
a finding, not silence — but it is noise the gate cannot afford.

Two self-test cases pin it, and they are not the same case twice. Reintroducing
the bug was used to check which:

- **`right apposition survives a blockquote prefix`** — **fails** on the pre-fix
  code (`expected [], got ['a1d7005d74']`). This is the tooth.
- **`a blockquoted blob table is still a blob table`** — **passes either way**,
  because the table-header rule reaches that shape by its own path, which strips
  the quote marker correctly. It is a positive control, kept so the two routes
  to the same shape stay independently pinned, and it is described as one rather
  than counted as a second tooth.

Also drops an unreachable branch in `_split_span`: the preceding `rstrip(".")`
already removes the three-dot spelling of an abbreviated id, so the
`endswith("...")` test could never be true.

## The missing arming proof

A gate nothing schedules is a gate that does not run, and the diff most likely
to break this one is a change to the checker itself. Case **AB2** in the docs-gate
fixture asserts that `scripts/check_provenance_pins.py` arms the documentation
tier.

Its expectation is `docs=true jvm=false node=false` — the **recognised**-doc-script
plan, verified by running the identical case against `scripts/check_doc_slugs.py`,
which produces the same. Neighbouring case AB's `jvm=true node=true` is the
different thing it looks like: the fallback for an *unrecognised* script, which
arms everything. Copying AB's numbers would have meant asserting that the
classifier had never learnt the path at all — the exact hole the case exists to
close.

## Quality gates

| gate | result |
|---|---|
| `python scripts/check_provenance_pins.py --self-test --verbose` | **rc=0** — 26 cases (24 before this PR) |
| bug reintroduced, self-test re-run | **rc=1**, `right apposition survives a blockquote prefix` fails by name — the tooth bites |
| `sh scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh` | **rc=0** — 37/37 (36 before) |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **rc=0** — no corpus page touched by this branch |
| `python scripts/check_provenance_pins.py` (audit) | **rc=1**, 50 findings — unchanged by this PR, as expected |
| `.beads` paths vs merge base `70ec619187` | **0** |
| CLJS/JS/EDN files in the diff | **0** |

`mkdocs build --strict` is **not** a gate here: `exclude_docs` keeps
`design/hicasso/` out of the site, and this PR modifies no page under `docs/`.
