### PR TITLE
docs(hicasso): charter's v0 list carries the retired Reagent mount denominator (rf2-94eb7)

### DIFF
--- a/docs/design/hicasso/charter.md
+++ b/docs/design/hicasso/charter.md
@@ -152,13 +152,13 @@ canonical.
 
 The full roster is the product's definition of done — the existing witness corpus
 re-pointed at Hicasso, green. **v0 is deliberately narrower**: the five tier-1
-shapes beautiful; controlled input R-A1/R-A2; mount + bulk ≤ Reagent on the witness
-shapes; one host hatch proven; a dogfood list+form screen preferred over raw UIx by
-its authors; the event/sub loop not regressed; a short guide. **SSR is explicitly
-out of v0** (HD-020: bodies stay `.cljc`-compatible by construction; no JVM/SSR
-render path ships). Deferred past v0: the full buffered/revision input ladder,
-overlay excellence, batteries/library platform, SSR as identity, devtools glass,
-per-keystroke envelopes as a gate.
+shapes beautiful; controlled input R-A1/R-A2; mount inside the mount gate and bulk
+≤ Reagent on the witness shapes; one host hatch proven; a dogfood list+form screen
+preferred over raw UIx by its authors; the event/sub loop not regressed; a short
+guide. **SSR is explicitly out of v0** (HD-020: bodies stay `.cljc`-compatible by
+construction; no JVM/SSR render path ships). Deferred past v0: the full
+buffered/revision input ladder, overlay excellence, batteries/library platform,
+SSR as identity, devtools glass, per-keystroke envelopes as a gate.
 
 **Amended 2026-08-04 (operator ruling):** the out-of-v0 SSR posture above is
 superseded — **SSR + hydration is required Hicasso scope** ("hicasso is useless
@@ -169,6 +169,18 @@ SSR *speed* stays off the bar, and "SSR as identity" stays in the deferred
 list — SSR is a required capability, not the product's identity. Four pieces have
 since landed on the now-closed beads `rf2-2rtt6.84`–`.87`: the hydration door,
 the `defhost` `:ssr` policy, the Node render entry, and the X1–X5 spike witness.
+
+**Amended 2026-08-05 (`rf2-hyd50`, operator-acked 2026-08-07):** the v0 bar
+clause above is restated per-axis. It read, verbatim: `mount + bulk ≤ Reagent on
+the witness shapes`. The mount gate it now names is **≤ 1.10× direct
+UIx-on-subs** — canonical `M1`, floor-normalised, on the clock of record — with
+Reagent-on-subs co-instrumented and **reported beside the mount row rather than
+gating it**; bulk stays **≤ 1.0× Reagent-on-subs, like-for-like**, unchanged.
+This is consistency propagation of a ruling already carried by
+[validation.md](validation.md) and HD-012's addendum in
+[decisions.md](decisions.md), not a new one. That ruling is delegated and
+**operator-overturnable**: if it is overturned, this note reverts with it and the
+frozen clause is the live bar again.
 
 **A. The everyday SPA spine** (where the bar lives)
 1. Ordinary views — the ~50-element form/list/layout shape.

--- a/docs/design/hicasso/charter.md
+++ b/docs/design/hicasso/charter.md
@@ -92,6 +92,13 @@ canonical.
    CI-gated on the witnesses; UIx co-instrumented. The gate lives in an
    operator-owned standard bead with the kill bound and decider pre-registered:
    prose gates have historically been disposed of by ruling; beads survive.
+   **Amended 2026-08-05 (`rf2-hyd50`, operator-acked 2026-08-07):** the entry
+   gate is per-axis — **mount ≤ 1.10× direct UIx-on-subs** on the clock of
+   record, with Reagent-on-subs co-instrumented and reported beside that row
+   rather than gating it, and **bulk ≤ 1.0× Reagent-on-subs, like-for-like**,
+   unchanged. The sentence above stands as the record of what this charter
+   pre-registered, and is the live bar again if the operator overturns the
+   ruling. Same note, at length, under the v0 scope paragraph below.
 2. **Same authoring model; outcome-keeps only.** The model was independently
    re-derived from requirements alone, and no correctness failure was ever
    recorded against it. No keep-lists as architecture. Candidates for


### PR DESCRIPTION
Closes `rf2-94eb7`.

## What this is

Consistency propagation of an already-ruled decision, not a new ruling.

`rf2-hyd50` adjudicated the per-axis ship bar on **2026-08-05** (delegated,
operator-overturnable) and was closed **2026-08-07** on the operator's ack —
*"per-axis confirmed; K1 restatement approved"*. PR #7553 (`rf2-0zj4r`) then made
four records say one thing: HD-012's addendum in `decisions.md`, `validation.md`'s
"The bar (HD-012)" section, its win condition (1), and its K1 row.

The operative bar, unchanged by this PR and only restated by it:

- **Mount** — ≤ 1.10× direct UIx-on-subs, canonical `M1`, floor-normalised, clock
  of record raw `TaskDuration` (script and frame). Reagent-on-subs is
  co-instrumented and **reported beside the mount row, not gating it**.
- **Bulk** — ≤ 1.0× Reagent-on-subs, like-for-like, on the witness shapes.
  **Unchanged.**

## The two sites fixed, both in `charter.md`

**1. The v0 definition-of-done list (`charter.md:155`)** — the site the
`rf2-94eb7` disposition named. It read, verbatim:

> mount + bulk ≤ Reagent on the witness shapes

That is the old ship bar restated — "on the witness shapes" is lifted from the bar
text, not from K7's programme-exit framing — so its mount half contradicted the
merged per-axis bar. It fell outside #7553's four-site scope, which is why it
survived. The clause now names the mount gate, and a dated amendment note freezes
the original verbatim, states the operative pair, cites `rf2-hyd50`, and carries
the revert clause.

**2. Goal 1, "The bar as entry gate" (`charter.md:90`)** — a straggler found by the
re-grep this bead asked for, in the same file, and **not** named in the
disposition. It reads `ship ≤ 1.0× Reagent like-for-like on the clock (mount and
bulk) ... UIx co-instrumented` — the same defect, and slightly worse: it also has
the comparators the wrong way round on the mount axis, where UIx is now the
denominator and Reagent-on-subs is the co-instrumented row. Same treatment, and
deliberately a **separate commit** so it can be dropped if the mayor wants it ruled
rather than propagated.

Both notes use `charter.md`'s own established idiom — the inline
`**Amended <date> (…):**` paragraph already at lines 109, 127, 163, 219 and 297 —
rather than importing `validation.md`'s blockquote form into a file that does not
use it. Content matches the other four sites: what changed, the original frozen
verbatim, the adjudicating bead, and an explicit revert clause.

## What was deliberately NOT touched

**`validation.md`'s K7 stands as written, and that is not a judgement call.** The
K1 amendment's own what-stands sentence at `validation.md:625` reads verbatim:
*"K2, K3, K4, K6 and K7 are untouched."* The same dated amendment that restated
K1's trigger declared K7 out of its scope **by name**, so K7's `≤ Reagent on K1–K2`
at `:615` is not clerical fallout — it survived the amendment deliberately. It is
also the only criterion phrased as a programme-**exit** rather than a per-axis
measurement, and HD-012's rationale names Reagent as *"the incumbent being replaced
(the ship claim)"*. The amendment changed which comparator gates a **row**; it did
not change what the programme is **for**. The corollary the amendment states
directly still holds: a Reagent-denominated mount kill, if one is ever wanted, must
be stated **as a kill** in that table. None is, so none is in force.

**Downstream studio citations of HD-012 are left alone**, and named here so the
next reader does not re-derive the question. The re-grep over
`docs/design/hicasso/**` found four further sites that quote the old conjunctive
pair, all of them *citing* HD-012 rather than stating the bar in their own right:
`studio/p0-reagent-on-subs-baseline.md:1,4`, `studio/p0-uix-on-subs-frontier-arm.md:14`,
`studio/p0-converged-witness-set.md:121`, and `studio/README.md:90`. Each is a dated
lab record that links to `decisions.md`, which now carries the addendum at the
citation target, and each states in its own text that *only the operator amends the
bar*. #7553 fixed the four **records of the bar**, not every downstream citation of
it; retroactively amending measurement pages would falsify what they measured
against. `studio/hd8-freehand-codec-donor-arm.md:26` quotes `"mount ≤ 1.0× Reagent"`
inside a historical arithmetic argument and is deliberate. `decisions.md:1860`
refers to the **bulk** row, which is unchanged.

No `spec/` edits, no code edits, no `validation.md` edit, no `decisions.md` edit.

## Quality gates

Run foreground to completion from `C:/Users/miket/code/re-frame2-worktrees/charterbar-94eb7`,
each redirected to a worktree-local log with the runner's own exit code captured —
never piped, so no pipeline status can mask a red runner.

| Gate | Command | Result | Exit |
|---|---|---|---|
| Doc slugs | `python scripts/check_doc_slugs.py --verbose` | `scanning 676 markdown files... no broken links.` | **0** |
| Provenance pins | `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | `1 files, 0 cited pins (0 landed, 0 stranded, 0 unresolvable)`; every cited pin an ancestor of `origin/main` | **0** |
| Fast-PR spine | `sh scripts/test-fast-pr.sh` | classified `docs=true jvm=false node=false`; all doc-lane gates PASS (lockstep 18/18 artefacts, test-lane bijection 1805 files / 46 lanes, JVM roster↔CI bijection 31/31, keyword-catalogue, skill-drift, retired-spelling, thrown-error, UI Root lifecycle 32 teeth, …) | **0** |

`mkdocs build --strict` is **not** nominated: `mkdocs.yml`'s `exclude_docs` block
excludes `docs/design/**`, so a run here would exit green having verified nothing.

### Hand-verification (the gate for this surface)

Nothing validates this tree's tables or rendering, so both were checked by hand:

- **Heading anchors.** `git diff origin/main -- docs/design/hicasso/charter.md`
  filtered for `^[+-]#{1,6} ` returns **nothing** — no heading added, removed or
  renamed. `charter.md`'s ten headings are byte-identical to `origin/main`
  (`# Hicasso — charter`, `## The name`, `## Product identity`, `## The measured
  evidence base`, `## Goals`, `## Constraints`, `## Use cases`, `## What the fitness
  harness supplies`, `## Why Hicasso should fare better than its predecessors`,
  `## Known losses coming from Reagent`), so every existing anchor still resolves.
  A repo-wide grep for `charter.md#` finds **no inbound anchor links** at all, so
  there is nothing to break. The two links this PR adds — `[validation.md](validation.md)`
  and `[decisions.md](decisions.md)` — are bare file-relative targets with no
  fragment, both existing siblings, and both are covered by the slug gate's
  676-file sweep.
- **Table column counts.** `charter.md` contains exactly **one** table (lines
  12–17, the product-identity table). Counting pipe-delimited fields per row gives
  **2 columns on all six lines** — header, `|---|---|` separator, and four body rows
  — uniform and unchanged. The same diff filtered for `^[+-]\s*\|` returns
  **nothing**: this PR adds and removes no table line anywhere. Both edits are
  prose — one reflowed paragraph plus two `**Amended …:**` notes.

No residue: `*.log`/`*.exit` are gitignored (`.gitignore:14`, `.gitignore:37`) and
`git status --porcelain` is empty.
