### PR TITLE
fix(ci): the provenance gate must see bare provenance citations (rf2-kqac1)

### DIFF
--- a/scripts/check_provenance_pins.py
+++ b/scripts/check_provenance_pins.py
@@ -704,7 +704,7 @@ _EXTRACTION_CASES: List[Tuple[str, List[str], List[str]]] = [
     # BARE PROVENANCE.  This case used to assert the opposite — that prose hex
     # outside a code span is never a citation — and that assertion pinned the
     # fail-open: explicit commit prose without backticks passed the gate
-    # unexamined (rf2-kqac1).  It reads the other way now, and the three cases
+    # unexamined (rf2-kqac1).  It reads the other way now, and the four cases
     # under it hold the narrowness in place.
     (
         "bare prose hex the writer calls a commit is a citation",

--- a/scripts/check_provenance_pins.py
+++ b/scripts/check_provenance_pins.py
@@ -61,12 +61,28 @@ roster of known digests (which rots) and never by asking git (see above):
     than 40 characters cannot be an object id here at all, and every 64-char
     token in the corpus is a SHA-256 document digest.
 
-When none of those speaks, the token is treated as a PIN.  That is the failure
-direction again: an unclassifiable token costs a finding, and the cost of the
-opposite default is a corpus of broken pins that reports success.  A handful of
-genuinely ambiguous lines are reported for that reason — "at `e145597127` the
-gate reads …" is a sentence a reader cannot classify either, which is the
-finding.
+When none of those speaks, a token IN A CODE SPAN is treated as a PIN.  That is
+the failure direction again: an unclassifiable token costs a finding, and the
+cost of the opposite default is a corpus of broken pins that reports success.  A
+handful of genuinely ambiguous lines are reported for that reason — "at
+`e145597127` the gate reads …" is a sentence a reader cannot classify either,
+which is the finding.
+
+BARE HEX, OUTSIDE A CODE SPAN, IS READ TOO, but only when the vocabulary above
+positively calls it a commit.  Reading code spans alone was a fail-open against
+the very rule at the top of this file: `Authored at deadbeef00 on worker/x.`
+extracted nothing, so a page could cite an authored head in explicit commit
+prose, omit the backticks, and pass `--changed-since` without the accompaniment
+rule ever running (rf2-kqac1).  Backticks are a convention here, not a
+guarantee, and dropping them is ordinary formatting drift.
+
+The default flips at that boundary, and deliberately.  Inside a code span the
+writer has already said "this is an id" and only the KIND is open, so silence
+means pin.  In open prose nothing separates an unremarked hex run from a version
+string or a large decimal, so silence means NOT a citation, and arbitrary bare
+hex and bare decimals stay invisible exactly as before.  The narrow reading is
+what keeps the whole idea affordable: it costs the corpus a handful of newly
+visible citations rather than a column of noise.
 
 WHAT THIS DOES NOT DO: it never re-pins.  rf2-owq6p established that recovering
 the landed SHA restores the PATCH, not the TREE — where the rebase did not
@@ -114,10 +130,34 @@ BASELINE_REF = "origin/main"
 # abbreviation; 64 admits a full SHA-256.
 _BARE_HEX = re.compile(r"^[0-9a-f]{7,64}$")
 
-# Inline code spans.  Pins and digests in this corpus are ALWAYS written in a
-# code span; bare prose hex is not a citation, and reading it invents findings
-# out of version strings and decimal numbers ("0.0999999 ms").
+# Inline code spans.  This corpus writes pins and digests in a code span by
+# convention, but a convention is not a guarantee — see _BARE_PROSE_HEX.
 _CODE_SPAN = re.compile(r"`([^`\n]{1,200})`")
+
+# A provenance id written WITHOUT backticks.  Extraction used to read code spans
+# only, so `Authored at deadbeef00 on worker/x.` yielded nothing at all: a page
+# could cite an authored head in completely explicit commit prose, omit the
+# backticks, and sail through `--changed-since` without the accompaniment rule
+# ever running (rf2-kqac1).  That is ordinary formatting drift, not camouflage,
+# and silence is the one direction this gate must never fail in.
+#
+# So bare hex is read, but ONLY when the writer's own vocabulary classifies it
+# as a commit — the same nearest-word-wins machinery `classify` already runs,
+# with the fail-toward-refusal default switched off.  Inside a code span the
+# writer has said "this is an id" and only the KIND is in question, so silence
+# there still means pin; in open prose nothing distinguishes an unremarked hex
+# run from a version string or a large decimal, so silence means not a citation.
+# Arbitrary bare hex and bare decimals stay invisible, which is what keeps this
+# checker off the digests and off the disable list.
+#
+# The boundaries carry the rest of that load.  A run may not touch an
+# alphanumeric, `_`, `/`, `\`, `#` or `-` on either side, and may not FOLLOW a
+# `.` — which is what keeps the "0999999" inside "0.0999999 ms" out, and every
+# version string with it — while a `.` AFTER it is allowed as sentence
+# punctuation unless a word character follows.
+_BARE_PROSE_HEX = re.compile(
+    r"(?<![0-9A-Za-z._/\\#-])([0-9a-f]{7,64})(?![0-9A-Za-z_/\\-])(?!\.[0-9A-Za-z])"
+)
 
 # Separators that appear INSIDE a single span carrying more than one id:
 # `a=b` (an authored=landed mapping), `sha:path` (a rev-parse argument),
@@ -173,6 +213,21 @@ class Finding(NamedTuple):
     detail: str
 
 
+class Verdict(NamedTuple):
+    """What `classify` made of one hex token.
+
+    `spoken` records whether the WRITER's own words decided it — a vocabulary
+    word, a file path, a table header — as against the fail-toward-refusal
+    default.  Only the bare-prose reader consults it, and it is the whole of
+    what keeps that reader narrow: outside a code span, a token nobody called a
+    commit is not a citation.
+    """
+
+    is_pin: bool
+    reason: str
+    spoken: bool
+
+
 # --------------------------------------------------------------------------
 # Extraction
 # --------------------------------------------------------------------------
@@ -194,6 +249,17 @@ def _split_span(inner: str, max_id_len: int) -> List[str]:
             continue
         out.append(part)
     return out
+
+
+def _mask_code_spans(line: str) -> str:
+    """The line with every code span blanked out, OFFSETS PRESERVED.
+
+    The bare-prose reader runs over this so it cannot re-read a token the span
+    reader already took, while `classify` still sees the real line — the left
+    context needs the surrounding spans intact to spot the file path that marks
+    a blob.
+    """
+    return _CODE_SPAN.sub(lambda m: " " * (m.end() - m.start()), line)
 
 
 def _strip_quote(line: str) -> str:
@@ -253,12 +319,11 @@ def _left_context(lines: Sequence[str], index: int, span_start: int) -> str:
 
 def classify(
     lines: Sequence[str], index: int, span_start: int, span_end: int
-) -> Tuple[bool, str]:
+) -> Verdict:
     """Decide whether one hex token is a cited PIN.
 
-    Returns (is_pin, reason).  Nearest signal in the left context wins; then a
-    tight right apposition; then the enclosing table's header; and silence
-    means PIN.
+    Nearest signal in the left context wins; then a tight right apposition;
+    then the enclosing table's header; and silence means PIN.
     """
     context = _left_context(lines, index, span_start)
 
@@ -280,17 +345,17 @@ def classify(
         # silently, whereas calling it a pin costs at worst one finding.
         signals.sort(key=lambda s: (s[0], s[1]))
         _, is_pin, reason = signals[-1]
-        return is_pin, reason
+        return Verdict(is_pin, reason, True)
 
     # The ORIGINAL line, not a quote-stripped one: `span_end` is an offset into
     # the line as read, and stripping a `> ` prefix first would slide the
     # window two characters past the apposition it exists to see.
     right = lines[index][span_end : span_end + _RIGHT_APPOSITION]
     if _DIGEST_WORDS.search(right):
-        return False, "digest word in apposition to the right"
+        return Verdict(False, "digest word in apposition to the right", True)
     if _table_header_is_digest(lines, index):
-        return False, "table header names a digest"
-    return True, "unclassified — read as a pin (fail toward refusal)"
+        return Verdict(False, "table header names a digest", True)
+    return Verdict(True, "unclassified — read as a pin (fail toward refusal)", False)
 
 
 def scan_file(
@@ -325,9 +390,20 @@ def scan_file(
             )
         for match in _CODE_SPAN.finditer(line):
             for token in _split_span(match.group(1), max_id_len):
-                is_pin, reason = classify(lines, i, match.start(), match.end())
-                if is_pin:
-                    citations.append(Citation(path, i + 1, block, token, reason))
+                verdict = classify(lines, i, match.start(), match.end())
+                if verdict.is_pin:
+                    citations.append(Citation(path, i + 1, block, token, verdict.reason))
+        # Then the same line with its code spans blanked out, so a token cannot
+        # be read twice, and with the default reading switched off.
+        for match in _BARE_PROSE_HEX.finditer(_mask_code_spans(line)):
+            token = match.group(1)
+            if len(token) > max_id_len:
+                continue
+            verdict = classify(lines, i, match.start(), match.end())
+            if verdict.is_pin and verdict.spoken:
+                citations.append(
+                    Citation(path, i + 1, block, token, verdict.reason + ", uncoded")
+                )
     return citations, anchors
 
 
@@ -625,9 +701,36 @@ _EXTRACTION_CASES: List[Tuple[str, List[str], List[str]]] = [
         ["the ten-turn aggregate resolved at `0.0999999 ms`, the bulk row's floor"],
         [],
     ),
+    # BARE PROVENANCE.  This case used to assert the opposite — that prose hex
+    # outside a code span is never a citation — and that assertion pinned the
+    # fail-open: explicit commit prose without backticks passed the gate
+    # unexamined (rf2-kqac1).  It reads the other way now, and the three cases
+    # under it hold the narrowness in place.
     (
-        "prose hex outside a code span is not a citation",
+        "bare prose hex the writer calls a commit is a citation",
         ["Commit 08344cb500 was measured on one box."],
+        ["08344cb500"],
+    ),
+    (
+        "bare prose hex the writer calls authored is a citation",
+        ["Authored at deadbeef00 on worker/x."],
+        ["deadbeef00"],
+    ),
+    (
+        "bare hex nobody calls a commit is not a citation",
+        ["The bulk row settled at 5f2c8a1b3d across all ten turns."],
+        [],
+    ),
+    (
+        "bare hex the writer calls a blob is not a citation",
+        ["The instrument blob 0304f489bb is byte-identical to the last arm."],
+        [],
+    ),
+    (
+        # The boundary rule, not the vocabulary rule: "commit" is right there,
+        # so only the `.` in front of `0999999` keeps the decimal out.
+        "a bare decimal beside a commit word is not a citation",
+        ["The commit's ten-turn aggregate resolved at 0.0999999 ms on the bulk row."],
         [],
     ),
     # THE FAILURE DIRECTION, pinned.  A token with no vocabulary either way is
@@ -706,6 +809,29 @@ _RULE_CASES: List[Tuple[str, List[str], Dict[str, str], List[str]]] = [
         ["Authored as `aaaaaaaaaa`, superseded by `dddddddddd` on `worker/x`."],
         {"aaaaaaaaaa": "STRANDED", "dddddddddd": "STRANDED"},
         ["aaaaaaaaaa", "dddddddddd"],
+    ),
+    # BARE PROVENANCE, end to end.  The first is the finding the code-span-only
+    # reader let through; the second is the noise the repair must still ignore —
+    # with no status table behind it, anything extracted here would resolve to
+    # UNRESOLVABLE and become a finding, so an empty expectation is a real
+    # assertion that nothing was extracted at all.
+    (
+        "a bare authored head, no backticks, is still a finding",
+        ["Authored at aaaaaaaaaa on worker/x, before the rebase mints its landed id."],
+        {"aaaaaaaaaa": "STRANDED"},
+        ["aaaaaaaaaa"],
+    ),
+    (
+        "a bare digest and a bare number raise no finding",
+        ["The instrument blob 0304f489bb held at 0.0999999 ms across ten turns."],
+        {},
+        [],
+    ),
+    (
+        "a bare landed id accompanies the stranded head beside it",
+        ["Authored at aaaaaaaaaa on worker/x; it landed on main as bbbbbbbbbb."],
+        {"aaaaaaaaaa": "STRANDED", "bbbbbbbbbb": "LANDED"},
+        [],
     ),
 ]
 


### PR DESCRIPTION
Closes the fail-open the merged-PR audit of #7622 found against rf2-kqac1.

`scan_file` visited `_CODE_SPAN` only, so a provenance citation written without
Markdown backticks was invisible to the gate:

```
Authored at deadbeef00 on worker/x.     ->  []             (nothing found)
Authored at `deadbeef00` on `worker/x`. ->  ['deadbeef00']  (the expected pin)
```

A new or edited page could therefore cite an authored head in completely
explicit commit/authored prose, omit the backticks, and make `--changed-since`
exit 0 without checking accompaniment at all — a fail-open against the one rule
this gate exists to enforce ("every cited **authored** head must be accompanied
by a resolvable landed SHA"), in the one direction it is documented never to
fail in. Backticks are a convention in this corpus, not a guarantee, and
dropping them is ordinary formatting drift rather than camouflage.

## The remedy taken, of the two the audit allowed

**Recognise bare hex when provenance vocabulary classifies it** — not "report
that explicit bare provenance must be code-formatted". The vocabulary route
enforces the bead's actual rule on the actual text, where the reporting route
would have added a second, weaker rule about formatting that a writer can
satisfy without the accompaniment ever being checked. It also cost nothing to
adopt: the landed corpus is unchanged by it (numbers below), so this is a real
tooth with no backlog churn attached.

No second classifier was introduced. Bare hex runs through the same
nearest-word-wins left-context machinery as everything else; the only change is
that **the default flips at the code-span boundary**. Inside a span the writer
has already said "this is an id" and only the *kind* is open, so silence still
means pin. In open prose nothing separates an unremarked hex run from a version
string or a large decimal, so silence means **not a citation** — arbitrary bare
hex and bare decimals stay invisible, which is the property that keeps this
checker off the corpus's digests and off the disable list.

`classify` now returns a `Verdict` carrying a `spoken` bit — did the *writer's*
words decide this, or the fail-toward-refusal default. Only the bare-prose
reader consults it, and it is the whole of what keeps that reader narrow.
Boundaries carry the rest: a bare run may not touch an alphanumeric, `_`, `/`,
`\`, `#` or `-` on either side, and may not *follow* a `.`, which is what keeps
the `0999999` inside `0.0999999 ms` out along with every version string.

The checker still never re-pins. No auto-repair was added; it reports, a human
decides.

## The flipped test

Named explicitly, per the audit: **`"prose hex outside a code span is not a
citation"`** is flipped and renamed to **`"bare prose hex the writer calls a
commit is a citation"`**. Same fixture line, `Commit 08344cb500 was measured on
one box.`, now expecting `['08344cb500']` instead of `[]`. It was not deleted,
and it was not loosened to accept both outcomes — a test that accepts either
answer discards the only coverage of the case.

Cases added beside it, including the end-to-end pair the audit requires:

| direction | case | expectation |
|---|---|---|
| finding | rule: `a bare authored head, no backticks, is still a finding` | `aaaaaaaaaa` STRANDED -> finding |
| non-finding | rule: `a bare digest and a bare number raise no finding` | nothing extracted at all |
| finding | extraction: `bare prose hex the writer calls authored is a citation` | `['deadbeef00']` |
| non-finding | extraction: `bare hex nobody calls a commit is not a citation` | `[]` |
| non-finding | extraction: `bare hex the writer calls a blob is not a citation` | `[]` |
| non-finding | extraction: `a bare decimal beside a commit word is not a citation` | `[]` |
| pass | rule: `a bare landed id accompanies the stranded head beside it` | no finding |

The bare-digest/number rule case runs with an **empty** status table, so
anything wrongly extracted resolves UNRESOLVABLE and becomes a finding — the
empty expectation is a real assertion that nothing was extracted, not a vacuous
one.

## Does the tightening newly flag any page?

**No. Not one.** The landed corpus is identical before and after: 59 files, 254
cited pins (156 landed, 88 stranded, 10 unresolvable), **50 findings**, and
`diff` of the two finding lists is empty.

This is not a silent no-op. Instrumented over the corpus, the bare reader sees
**7 candidate runs across the 59 pages and reads none of them as pins**:

- six are blockquoted `git rev-parse` reproduction arguments in
  `studio/p0-converged-witness-set.md:322-324` — arguments to an example, not
  the page's own provenance. The narrow default is precisely what excludes them;
  a bare-hex-defaults-to-pin reading would have added six findings on lines that
  are **not** in the backlog today.
- one is `studio/hd8-composed-donor-arm.md:668`, an id inside an HTML `<code>`
  element rather than Markdown backticks, with no provenance vocabulary beside
  it. Outside the ruled scope, and that block is already a backlog finding at
  that exact line. Noted, not widened for.

### `studio/reads-per-boundary-heap-ladder.md` specifically — PR #7626

Asked for by name because #7626 is in flight against this very gate. **This
change does not affect it, in either merge order.**

- On `main` today the page has three findings: lines 70 (`09ec4e6b3c`), 1054 and
  1260 (`4a33c61e1c`), all STRANDED. After the tightening: **the same three,
  same tokens, same lines.** Already in the backlog; nothing added.
- Against **#7626's head** (`worker/shellbytes-2rtt6-82`), the repaired page
  yields 59 citations and **0 findings** under the tightened checker.

So #7626 stays green whether it lands before or after this. Merge order remains
the mayor's call; this PR simply does not constrain it. This PR does not touch
that page, or any page under `docs/design/hicasso/**`.

The backlog itself is untouched — no pin was re-pinned and no page was edited.

## Quality gates

All foreground to completion, each redirected to a worktree-local log with the
runner's own exit code captured separately (never piped, so no pipeline can
launder a red into a green).

| gate | command | exit | result |
|---|---|---|---|
| self-test | `python scripts/check_provenance_pins.py --self-test --verbose` | **0** | **all 33 passed** |
| full-corpus AUDIT | `python scripts/check_provenance_pins.py --verbose` | **1** | 50 findings — **expected, not a failure** |
| changed-since (BLOCKING gate) | `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** | no corpus page changed |
| byte-compile | `python -m py_compile scripts/check_provenance_pins.py` | **0** | clean |
| fast-PR spine | `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`, 72 stages |

**Which is which:** the bare full-corpus run is the **audit** and exits 1 by
design — the corpus carries a deliberate backlog of unrepaired pins, each a
judgement a human owes individually. The **blocking** gate is `--changed-since`,
which holds only the pages a change touches to the rule, and it is green. The 50
is the same 50 as on `main`; this PR neither adds to it nor works it off.

**Self-test count: 26 before, 33 after.** The flipped case is renamed in place;
4 extraction cases and 3 rule cases are added. The audit note says "the 24
existing self-tests"; the measured count on `main` is 26, reported here as
measured.

`scripts/check_provenance_pins.py` is named on the fast-PR spine's doc-surface
list and in `docs.yml`'s `detect` classifier, so changing it arms the whole docs
tier; the spine ran both provenance arms (`==> provenance pin self-test`,
`==> provenance pins on changed pages`) and reported `all 33 self-tests passed`.

Changed files: `scripts/check_provenance_pins.py` only.
