### PR TITLE
perf(hicasso): close the navigate grammar without the per-render key set (rf2-jr0tg)

### DIFF
--- a/docs/design/hicasso/studio/our-walk-against-reagents.md
+++ b/docs/design/hicasso/studio/our-walk-against-reagents.md
@@ -789,3 +789,151 @@ read against run C at all.
 **Advisory, and no row above is amended.** No adapter, codec or runtime file is
 changed by this work; the ablation of run B was reverted before anything was
 committed and appears in no shipped file.
+
+## 2026-08-07 the key set is gone, and the row re-taken (rf2-jr0tg)
+
+**What landed.** The section above costed a repair and declined to land it, this
+page's practice being that a candidate is timed beside the shipping shape and
+lands on a bead of its own. `rf2-jr0tg` is that bead, and this is the arms row
+re-taken with the repair in place. It is one binding:
+
+    ks (when (map? m) (set (keys m)))      ; built on EVERY call
+    …
+    (= navigate-keys ks)
+
+became
+
+    (and (map? m) (== 4 (count m))
+         (contains? m :frame) (contains? m :payload)
+         (contains? m :native?) (contains? m :veto))
+
+with `ks` moved into the failure branch, which runs once, at the refusal, and
+still names what the author actually wrote.
+
+**Nothing was relaxed, and the count is the reason.** Four `contains?` alone are
+fail-open on a fifth key — the exact defect `rf2-2rtt6.54` closed — so the count
+is load-bearing, not decoration. Four presence tests AND a count of four admit
+precisely the maps the set equality admits.
+
+### The rows
+
+Three runs of the unchanged driver, 2026-08-07, bracketing the repair between
+two runs of the shape it replaces — D and F are `origin/main` at `c495a5e2df`,
+E is that tree with the one binding moved.
+
+| run | `hicasso` ns/el | `hicasso-native` ns/el | gap ns/el | grid steps | `hicasso-native`/`hicasso` |
+|---|---|---|---|---|---|
+| D — before | 385 | 572 | 187 | 18 | **1.4865** |
+| E — after | 437 | 510 | 73 | 7 | **1.1667** |
+| F — before, restored | 499 | 738 | 239 | 23 | **1.4792** |
+
+**Read the ratios, not the absolutes.** All three gaps are resolved at the
+0.0125 ms/walk grain, the smallest being E's 7 steps. The repaired ratio 1.1667
+sits against §2's published 1.0729 and 1.0762 and against the previous section's
+ablation at 1.1143; what remains above §2 is the rest of the navigate lowering,
+not the key check.
+
+**The bracket is the control, and it runs the wrong way for a sceptic.** The box
+got monotonically busier across the three runs — D's `hicasso` arm reads 385
+ns/el, E's 437, F's 499 — so the repaired run sits *between* the two shipping
+runs in absolute terms while carrying a *third* of either one's gap. A quiet box
+cannot be the explanation, because E's box was demonstrably busier than D's.
+
+### The stage rows underneath
+
+ns per position, each against what the plain arm pays at the same key:
+
+| stage | D — before | E — after | F — before |
+|---|---|---|---|
+| navigate carrier, native value | 710.1 | **239.1** | 992.8 |
+| navigate carrier, plain value | 67.6 | 70.0 | 113.5 |
+| authored intent, native value | 204.2 | 190.1 | 352.1 |
+| authored intent, plain value | 63.4 | 70.4 | 105.6 |
+| key-set check, shipping shape (local copy) | 451.7 | 591.8 | 792.3 |
+| key-set check, allocation-free (local copy) | 70.0 | 103.9 | 140.1 |
+
+**The last two rows are the positive control, exactly as they were in the
+previous section**, and they are why the collapse can be believed. They price
+LOCAL copies written into the instrument, which the change to `front/intent.cljs`
+cannot reach — and they do not collapse: 451.7 → 591.8 → 792.3 and 70.0 → 103.9
+→ 140.1, both rising monotonically with the box and nothing else. Meanwhile the
+row that goes through the real `unwrap-navigate` drops by a factor of three and
+comes straight back when the old shape is restored. The change landed where it
+was aimed and nowhere else.
+
+Carried onto the arm row's units — ns per position × roster ÷ 1,202 elements,
+done by the instrument:
+
+| carrier | D — before | E — after | F — before |
+|---|---|---|---|
+| navigate (207 links) | 110.6 | **29.1** | 151.4 |
+| authored intents (71 positions) | 8.3 | 7.1 | 14.6 |
+| named carriers, summed | 119.0 | 36.2 | 166.0 |
+| *observed arm gap* | *187.2* | *72.8* | *239.2* |
+
+**Attribution, not accounting**, per §3. The navigate carrier falls from ten to
+fifteen times the authored one to about four times it, and the authored carrier
+does not move — 8.3, 7.1, 14.6, tracking the box, which is the same flatness the
+previous section read.
+
+### The correctness, and how it was proven able to fail
+
+The repair is worth nothing if the grammar quietly re-opened, so the witnesses
+were made to fail on purpose:
+
+| | |
+|---|---|
+| **Witnesses** | `route_link_cljs_test`, 16 tests / 39 assertions, **0 failures, 0 errors** — including `the-navigate-map-is-a-closed-key-set` and, inside it, the two shapes `rf2-2rtt6.54` added: the map missing `:veto` and the map carrying a fifth key |
+| **The mutation** | `(== 4 (count m))` deleted from `unwrap-navigate`, leaving the four `contains?` — the fail-open shape the commit was fixing |
+| **What it did** | `the-navigate-map-is-a-closed-key-set` **FAILED** at `route_link_cljs_test.cljs:190`, on `{:frame … :payload [:x] :native? false :veto nil :replace? true}`: `expected: (thrown-with-msg? … #"hicasso-malformed-navigate" …)`, `actual: nil`. Runner exit `1`, exactly one failure |
+| **Blast radius** | the other four bad shapes in that witness — missing `:frame`, `:payload`, `:native?`, `:veto` — stayed green under the mutation, which is right: the `contains?` tests catch those, and only the fifth key needs the count |
+
+So the count is doing work no other line does, and the suite can see it go.
+
+### Provenance
+
+| | |
+|---|---|
+| **Producing commit** | `70304283e3` on `worker/navkeys-jr0tg`, merge-base `c495a5e2df` (`origin/main`) |
+| **Reproduction** | `HICASSO_INIT_FN=re-frame.bench.hicasso.walk-vs-reagent-app/-main HICASSO_OUT_DIR=out/hicasso-walkcmp HICASSO_PORT=8177 node implementation/freehand/test/re_frame/bench/hicasso/run.cjs` |
+| **Build** | `:hicasso-bench`, `:advanced`, `goog.DEBUG false`, **0 warnings** on all three builds |
+| **Runtime** | chromium `147.0.7727.15` (playwright), node `v24.13.0`, Windows NT 10.0 x64, 24 threads |
+| **Design** | 4 arms × 6 rounds × (4 warm-up + 10 samples), 8 whole-page walks per window — unchanged |
+| **Clock** | in-page `performance.now`, **diagnostic**; the clock of record is untouched here |
+| **Windows** | 2026-08-07 AUSEST, completing D 03:26:12, E 03:35:07, F 03:36:43 |
+| **Exit codes** | D `0`, E `0`, F `0`; guard **reportable** on every arm of all three |
+
+| control | D | E | F |
+|---|---|---|---|
+| arm-order guard self-test (12 cases) | all `ok` | all `ok` | all `ok` |
+| twin parity gate (fatal) | OK — 1,202 el / 58,474 B | OK | OK |
+| workload match | 58,474 B / 58,529 B, the same 55-byte whitespace difference §1 prices | same | same |
+| arm-order guard verdict | **reportable**, 4/4 by predecessor and by phase | **reportable** | **reportable** |
+| candidate agreement failures | `[]` | `[]` | `[]` |
+| `SLIM DECOMPOSED` agreement failures | `[]` | `[]` | `[]` |
+| intent agreement failures | `[]` | `[]` | `[]` |
+| exit code | **0** | **0** | **0** |
+
+**The box was not quiet, and it was not instrumented for these three runs.** The
+previous section measured summed per-process CPU delta; this one did not, and
+says so rather than inventing a figure. What stands in its place is stronger for
+this particular claim: the bracket puts the repaired run between a quieter run
+and a busier one, and the instrument's own local control rises monotonically
+across all three while the measured row collapses in the middle.
+
+| file | blob |
+|---|---|
+| `…/front/intent.cljs` | `a6716e5cdd` → **`6486fd532e`** — the one binding; runs D and F measured the former, E the latter |
+| `…/front/route_link.cljs` | `3663b326a2` — unchanged |
+| `…/front/codec.cljs` | `dc5f893416` — moved again since the attribution section's `6301d60db0`, by other work, and still not implicated |
+| `…/walk_vs_reagent_app.cljs` | `ee0666c3d6` — the attribution section's, and what runs D–F measured. Corrected by COMMENT ONLY after the runs, so `navmap-keyset-shipping` no longer claims to be what ships |
+| `…/run.cjs` | `1bc82c38ea` — unchanged since the re-take |
+| `…/walk_profile_app.cljs` (the twin + its parity gate) | `43940c0227` — unchanged |
+| `reagent2.impl.template` | `9b30b6b74c` — still byte-identical to `rf2-e7zxb`'s landing |
+
+**No row above this section is amended.** §2's rows, the re-take's and the
+attribution section's all stand for the trees that produced them; this section
+is the next tree. `navmap-keyset-shipping` keeps its name in the instrument for
+the same reason the `SLIM DECOMPOSED` `-ship` rows keep theirs — a costed pair is
+kept as a pair, and the row that lost is the one that names the shape it lost
+to.

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
@@ -902,15 +902,22 @@
   "The navigate map's key set, and it is CLOSED: `:frame`, `:payload`,
   `:native?`, `:veto` — those four, no fewer and no more (HD-027).
 
-  Held as a SET the map's own keys must EQUAL, rather than as four
-  presence tests, because a grammar that checks only the keys it knows is
-  fail-open by construction. Under presence tests a map missing `:veto`
-  passes — and `:veto` is the slot that decides whether the click can be
-  cancelled, so its absence is the difference between an uncancelable
-  navigation and a promised one. So does a map carrying a fifth key,
-  which the lowering then silently drops: the author wrote something and
-  nothing happened, which is the failure class every loud error in this
-  namespace exists to delete."
+  CLOSED means a COUNT and not just presence. A grammar that checks only
+  the keys it knows is fail-open by construction: under four bare
+  presence tests a map missing `:veto` passes — and `:veto` is the slot
+  that decides whether the click can be cancelled, so its absence is the
+  difference between an uncancelable navigation and a promised one — and
+  so does a map carrying a fifth key, which the lowering then silently
+  drops: the author wrote something and nothing happened, which is the
+  failure class every loud error in this namespace exists to delete.
+
+  `(== 4 (count m))` AND four `contains?` admit exactly the maps
+  `(= navigate-keys (set (keys m)))` admits, and allocate nothing to do
+  it, so that is what [[unwrap-navigate]] asks on the hot path. This set
+  is read by the REFUSAL, which runs once, at the error: building it per
+  call was ~156 ns/element of the census page's walk, one
+  `PersistentHashSet` per link per render (`rf2-jr0tg`, costed on
+  `walk_vs_reagent_app`)."
   #{:frame :payload :native? :veto})
 
 (defn- unwrap-navigate
@@ -918,43 +925,54 @@
   exactly two forms, the second a map whose keys are EXACTLY
   [[navigate-keys]]: `:frame` (a keyword), `:payload` (a non-empty
   vector), `:native?` (a boolean), and `:veto` (the [[lower-veto]]
-  roster, `nil` included — which is why its presence is asked of the key
-  set and never of its value). Everything else is
+  roster, `nil` included — which is why its presence is asked and its
+  value never is). Everything else is
   `:rf.error/hicasso-malformed-navigate`, named at the position. Answers
   the validated map; like [[unwrap-prevent]] it is not a walker — the
-  payload stays ordinary data all the way to routing."
+  payload stays ordinary data all the way to routing.
+
+  The key check RUNS ONCE PER LINK PER RENDER, so it allocates nothing:
+  the count closes the roster that the four `contains?` open, admitting
+  exactly what [[navigate-keys]] as a set admits. The set itself is built
+  only in the failure branch, where it names what the author actually
+  wrote."
   [k v]
   (let [m  (nth v 1 nil)
-        {:keys [frame payload native?]} m
-        ks (when (map? m) (set (keys m)))]
+        {:keys [frame payload native?]} m]
     (when-not (and (= 2 (count v))
-                   (= navigate-keys ks)
+                   (map? m)
+                   (== 4 (count m))
+                   (contains? m :frame)
+                   (contains? m :payload)
+                   (contains? m :native?)
+                   (contains? m :veto)
                    (keyword? frame)
                    (vector? payload)
                    (seq payload)
                    (boolean? native?))
-      (fail! :rf.error/hicasso-malformed-navigate
-             'front.intent/lower-prop
-             (str "The " (pr-str navigate-head) " decorator at " (pr-str k)
-                  " wraps EXACTLY ONE map carrying :frame (a keyword), :payload "
-                  "(a non-empty event vector), :native? (a boolean) and :veto — "
-                  "those four keys and no others; this one "
-                  (cond
-                    (not= 2 (count v))  (str "carries " (dec (count v)) " forms after the head")
-                    (not (map? m))      (str "wraps " (pr-str m) ", which is not a map")
-                    (not= navigate-keys ks)
-                    (str "carries " (pr-str (vec (sort ks)))
-                         (when-some [missing (seq (sort (remove ks navigate-keys)))]
-                           (str ", so it is missing " (pr-str (vec missing))))
-                         (when-some [extra (seq (sort (remove navigate-keys ks)))]
-                           (str ", and nothing reads " (pr-str (vec extra)))))
-                    (not (keyword? frame))  "names no :frame keyword"
-                    (not (and (vector? payload) (seq payload))) "carries no :payload event vector"
-                    :else               "answers no boolean at :native?")
-                  ". route-link mints this form; hand-written ones must carry all "
-                  "four slots and nothing else.")
-             :carry-frame-payload-native-and-veto
-             {:position k :form v}))
+      (let [ks (when (map? m) (set (keys m)))]
+        (fail! :rf.error/hicasso-malformed-navigate
+               'front.intent/lower-prop
+               (str "The " (pr-str navigate-head) " decorator at " (pr-str k)
+                    " wraps EXACTLY ONE map carrying :frame (a keyword), :payload "
+                    "(a non-empty event vector), :native? (a boolean) and :veto — "
+                    "those four keys and no others; this one "
+                    (cond
+                      (not= 2 (count v))  (str "carries " (dec (count v)) " forms after the head")
+                      (not (map? m))      (str "wraps " (pr-str m) ", which is not a map")
+                      (not= navigate-keys ks)
+                      (str "carries " (pr-str (vec (sort ks)))
+                           (when-some [missing (seq (sort (remove ks navigate-keys)))]
+                             (str ", so it is missing " (pr-str (vec missing))))
+                           (when-some [extra (seq (sort (remove navigate-keys ks)))]
+                             (str ", and nothing reads " (pr-str (vec extra)))))
+                      (not (keyword? frame))  "names no :frame keyword"
+                      (not (and (vector? payload) (seq payload))) "carries no :payload event vector"
+                      :else               "answers no boolean at :native?")
+                    ". route-link mints this form; hand-written ones must carry all "
+                    "four slots and nothing else.")
+               :carry-frame-payload-native-and-veto
+               {:position k :form v})))
     m))
 
 (defn- navigate-handler

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
@@ -595,16 +595,22 @@
   #{:frame :payload :native? :veto})
 
 (defn- navmap-keyset-shipping
-  "The shipping check: build the map's key SET and compare it to the
-  roster. One `PersistentHashSet` per link per render."
+  "The PRE-`rf2-jr0tg` check, and the name is historical the way the
+  `-ship` rows below are: build the map's key SET and compare it to the
+  roster, one `PersistentHashSet` per link per render. It WAS shipping
+  when this row was written; the twin beside it is what ships now. Kept
+  as the losing half of a costed pair, which is this lane's practice."
   [m]
   (= navigate-key-set (when (map? m) (set (keys m)))))
 
 (defn- navmap-keyset-scan
-  "The same CLOSED grammar with nothing allocated. The count is what
-  closes it — four presence tests alone are fail-open on a fifth key,
-  which is the defect `rf2-2rtt6.54` was fixing; four presence tests AND a
-  count of four admit exactly the same maps the set equality admits."
+  "The same CLOSED grammar with nothing allocated, and what
+  `front.intent/unwrap-navigate` now asks — `rf2-jr0tg` landed it. The
+  count is what closes it — four presence tests alone are fail-open on a
+  fifth key, which is the defect `rf2-2rtt6.54` was fixing; four presence
+  tests AND a count of four admit exactly the same maps the set equality
+  admits. This LOCAL copy stays, because a copy the change cannot reach
+  is the positive control the arm rows are read against."
   [m]
   (and (map? m)
        (== 4 (count m))


### PR DESCRIPTION
Closes rf2-jr0tg.

`front.intent/unwrap-navigate` asserted the navigate map's exact key set by
building a `PersistentHashSet` of its keys and comparing it to the roster —
**once per link per render**. The census page carries 207 route-links, so a
mount built and compared 207 hash sets. `rf2-vw412` costed that at ~156
ns/element of a ~450 ns/element walk and deliberately did **not** land the
repair: this page's practice is that a candidate is timed beside the shipping
shape and lands on a bead of its own.

This is that bead, and it is one binding:

```clojure
;; before
ks (when (map? m) (set (keys m)))      ; built on EVERY call
…
(= navigate-keys ks)

;; after
(and (map? m) (== 4 (count m))
     (contains? m :frame) (contains? m :payload)
     (contains? m :native?) (contains? m :veto))
```

`ks` stays bound for the error message and moves into the **failure branch**,
which runs once, at the refusal, and still names what the author actually wrote.

**Nothing was relaxed, and the count is why.** Four `contains?` alone are
fail-open on a fifth key — the exact defect `rf2-2rtt6.54` closed — so the count
is load-bearing, not decoration. Four presence tests AND a count of four admit
precisely the maps the set equality admits. Equivalence was proven before this
PR existed: the candidate has been sitting in `walk_vs_reagent_app` as
`navmap-keyset-scan` beside `navmap-keyset-shipping`, agreeing on every navigate
map the census page mints plus an eleven-shape hostile roster, `agreement
failures: []` on every run.

## The mutation was proven able to go red

A repair is worth nothing if the grammar quietly re-opened, so the witnesses were
made to fail on purpose. `(== 4 (count m))` was deleted, leaving the four
`contains?` — the fail-open shape `rf2-2rtt6.54` was fixing — and the suite was
recompiled and re-run:

```
FAIL in (the-navigate-map-is-a-closed-key-set) (route_link_cljs_test.cljs:190:11)
{:frame …/grammar, :payload [:x], :native? false, :veto nil, :replace? true}
expected: (thrown-with-msg? js/Error #"hicasso-malformed-navigate" (lower-navigate bad))
  actual: nil

Ran 16 tests containing 39 assertions.
1 failures, 0 errors.        ← runner exit 1
```

Exactly one failure, and it is the fifth-key witness. The other four bad shapes
in that witness — missing `:frame`, `:payload`, `:native?`, `:veto` — stayed
green under the mutation, which is right: the `contains?` tests catch those, and
only the fifth key needs the count. So the count does work no other line does,
and the suite can see it go. The count was restored, and the suite recompiled and
re-run green, before anything was committed.

## The arms row, re-taken

Three runs of the unchanged driver on 2026-08-07, bracketing the repair between
two runs of the shape it replaces. D and F are `origin/main` at `c495a5e2df`; E
is that tree with the one binding moved. Published **beside** the 2026-08-06
attribution section, this page's practice — no published row is amended.

| run | `hicasso` ns/el | `hicasso-native` ns/el | gap ns/el | grid steps | `hicasso-native`/`hicasso` |
|---|---|---|---|---|---|
| D — before | 385 | 572 | 187 | 18 | **1.4865** |
| E — after | 437 | 510 | **73** | 7 | **1.1667** |
| F — before, restored | 499 | 738 | 239 | 23 | **1.4792** |

Carried onto the arm row's units by the instrument, the navigate carrier itself
goes **110.6 and 151.4 → 29.1 ns/element**, while the authored carrier does not
move (8.3 / 7.1 / 14.6), tracking the box only.

**The bracket runs the wrong way for a sceptic, deliberately.** The box got
monotonically busier across the three runs (`hicasso` reads 385 → 437 → 499), so
the repaired run sits *between* the two shipping runs in absolute terms while
carrying a third of either one's gap. A quiet box cannot be the explanation.

**Positive control**, the same one the attribution section used: the instrument's
own LOCAL copies of both check shapes cannot be reached by a change to
`front/intent.cljs`, and they do not collapse — 451.7 → 591.8 → 792.3 (set
shape) and 70.0 → 103.9 → 140.1 (allocation-free), both rising monotonically with
the box — while the row through the real `unwrap-navigate` drops 710.1 → 239.1
and returns to 992.8. The change landed where it was aimed and nowhere else.

Guard **reportable** on every arm of all three runs, twin parity OK, `agreement
failures: []` on all three tables of all three runs, exit `0` on all three,
`0 warnings` on all three `:advanced` builds.

Reproduction:

```
HICASSO_INIT_FN=re-frame.bench.hicasso.walk-vs-reagent-app/-main \
HICASSO_OUT_DIR=out/hicasso-walkcmp HICASSO_PORT=8177 \
  node implementation/freehand/test/re_frame/bench/hicasso/run.cjs
```

## Scope

- `front/intent.cljs` — `unwrap-navigate`'s one binding, plus the two docstrings
  that justified the set (they now justify the count, which is the same closure
  argument stated of a cheaper mechanism).
- `walk_vs_reagent_app.cljs` — **comment only**, made after the runs:
  `navmap-keyset-shipping` no longer claims to be what ships. It keeps its name
  for the same reason the `SLIM DECOMPOSED` `-ship` rows keep theirs — a costed
  pair is kept as a pair. No arm, witness, roster or window is touched, and runs
  D–F measured blob `ee0666c3d6`, the attribution section's.
- The studio page — one new dated section appended.

`front/codec.cljs` is **not touched**: `rf2-vw412` established it is not
implicated, and `rf2-2rtt6.103` is editing it concurrently.

Manual verification the automated gates do not do, per `CLAUDE.md`'s rule for
`docs/design/**`: the new section's **7 tables were column-counted by hand** and
are internally consistent (6 / 4 / 4 / 2 / 2 / 4 / 2 columns), and the section
introduces **no markdown links**, so there is no link target to resolve. Its
`### The rows` and `### Provenance` sub-headings repeat headings the page already
carries in its earlier dated sections — that is the page's own established
pattern, and nothing in the corpus links to this page by anchor.

## Quality gates

All foreground, to completion. Each runner's exit code was captured from the
runner itself, never through a pipe (a pipeline's status is its last command's,
so a red runner reads green). Logs are worktree-local and gitignored.

| gate | result | exit |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | **PASS fast PR spine** — classified `docs=true jvm=true node=true`; `gate root: /c/Users/miket/code/re-frame2-worktrees/navkeys-jr0tg` | `0` |
| ├ JVM `implementation/core` | 2,233 tests / 11,645 assertions, **0 failures, 0 errors** | — |
| ├ JVM `implementation/freehand` | 1,291 tests / 8,874 assertions, **0 failures, 0 errors** | — |
| ├ CLJS `:node-test` (`npm run test:cljs`) | 12,734 tests / 63,868 assertions, **0 failures, 0 errors** | — |
| ├ per-ns isolation gate | pass | — |
| ├ hicasso bench-lane compile (`test:hicasso-compile`) | 129 lane namespaces, **0 warnings** | — |
| ├ docs corpus anchor validator (`check_doc_slugs.py`) | silent pass | — |
| └ provenance pins on changed pages | 1 file, 17 cited pins (14 landed, 3 stranded, 0 unresolvable) — every pin is an ancestor of `origin/main` or shares its block with one | — |
| `node out/node-test.js --test=…route-link-cljs-test` (repaired) | 16 tests / 39 assertions, **0 failures, 0 errors** | `0` |
| `--test=…route-link-cljs-test,…intent-cljs-test` (repaired, after the mutation was reverted) | 48 tests / 221 assertions, **0 failures, 0 errors** | `0` |
| the same route-link suite with `(== 4 (count m))` DELETED | **1 failure, 0 errors** — the fifth-key witness, as predicted | `1` |
| `walk_vs_reagent_app` run D (before) | guard reportable 4/4, agreement `[]` ×3, twin parity OK | `0` |
| `walk_vs_reagent_app` run E (after) | guard reportable 4/4, agreement `[]` ×3, twin parity OK | `0` |
| `walk_vs_reagent_app` run F (before, restored) | guard reportable 4/4, agreement `[]` ×3, twin parity OK | `0` |

**Local green is NOT CI green.** `python scripts/check_fast_pr_gap.py --list`
names **90 required checks this spine does not run**, under the three required
contexts `All required checks passed` (test.yml), `Lint required` (lint.yml) and
`Docs required` (docs.yml) — among them the browser lanes, the
production-elision / bundle-isolation / perf-bundle gates, the adapter smokes,
`clj-kondo` at its CI-pinned version, and every step nested inside a job the
spine only partially covers. None of them is decided here.
