### PR TITLE
test(freehand): make the observer latency the single source of truth for :tail-ms (rf2-drpa3.182.12)

### DIFF
--- a/docs/design/freehand/studio/two-clock-operating-envelope.md
+++ b/docs/design/freehand/studio/two-clock-operating-envelope.md
@@ -38,9 +38,11 @@ you dispatch, and do not build a throttle.**
 **One figure in the first two editions was wrong and is corrected here.** The
 settlement tail was read off a clock started at settle time rather than at the
 last offer; what it published was largely the polling delay that stood in for
-it. Section 6 states the correction, section 2's C3 is the control that now
-guards the anchor, and the corrected number turns out to strengthen the
-recommendation rather than soften it.
+it. Section 6 states the correction, section 2's C3 and C4 are the controls
+that now guard the anchor and the arithmetic, and the corrected number turns
+out to strengthen the recommendation rather than soften it. **No figure below
+changed when C4 landed** — the instrument's numbers were already right; what
+was missing was a gate that could fail if they stopped being.
 
 ---
 
@@ -95,7 +97,7 @@ the instrumentation seam costs, and it is worth publishing once.
 
 ---
 
-## 2. The instrument, and the three controls that make it readable
+## 2. The instrument, and the four controls that make it readable
 
 A crossing is timed across `react-dom/flushSync` with the dispatch inside it,
 and split at the instant the dispatch returns:
@@ -208,10 +210,49 @@ at the 30 Hz rung, where one interval is 33 ms, so the worst cell is within
 The control is also a **gate**, not only a table. `:tail-anchored?` fails a run
 whose gap is under half a requested period — a floor `setInterval` cannot
 violate, since it cannot fire faster than its period however far behind the
-browser has fallen. A tail read off a settle-time clock has no last-offer
-timestamp and cannot produce the gap at all, so it fails rather than
-publishing. It is asserted in the browser row and in the production entry's
-coherence filter, beside "applied cannot exceed offered".
+browser has fallen. It is asserted in the browser row and in the production
+entry's coherence filter, beside "applied cannot exceed offered".
+
+### C4 — a control of the tail's arithmetic
+
+C3 was introduced as the assertion that would fail if the tail clock were
+restarted at settle time. **It was not, and a merged-PR audit on
+`rf2-drpa3.182.12` said so.** C3 is derived from the last offer against the
+*settle decision*; the tail runs from the last offer to the *observer*. Two of
+the three instants differ, so `:tail-ms` could be re-anchored anywhere at all
+and C3 would not move — nor would the numeric and nonnegative checks beside it.
+Every control the third edition shipped could stay green while the published
+field measured the wrong interval again. A gate nobody has watched fail is not
+known to be a gate, and this surface had already shipped one that wasn't.
+
+Two changes close it. First, `:tail-ms` is no longer *computed* at publication
+time: the `MutationObserver` calculates each generation's latency once, and the
+final generation's is **retained and published verbatim**. The tail is lifted
+out of the `:latency` distribution rather than recomputed from it, so there is
+no start instant at the publication site left to get wrong. Second, the two
+readings it is the difference of are published beside it — `:tail-offer-at-ms`
+and `:tail-observed-at-ms` — and C4 asserts that exact identity. The comparison
+carries no tolerance and needs none: both operands are readings on one clock
+and the tail is their retained difference, so the check is a double subtraction
+reproduced rather than a rounded chain of them.
+
+The two controls are kept **separate**, and neither subsumes the other. C3 says
+*where the retained offer reading sits* — one interval before the settle
+decision. C4 says *the published tail was computed from that reading and the
+observer's, and from nothing else*. Re-anchoring the tail at settle time keeps
+C3 green and turns C4 red by a whole interval; re-anchoring the published offer
+reading to keep C4 green collapses the gap and turns C3 red. There is no
+remaining way to move the tail's start that leaves both standing.
+
+That is asserted rather than argued. `c4-a-settle-anchored-tail-cannot-pass-both-controls`
+performs the mutation on a synthetic record — one 30 Hz rung, one thing changed
+and one only — and checks that the three pre-C4 gates all stay green on it
+before checking that C4 does not. The mutation was also performed on the
+instrument itself and run: restoring the first two editions' settle-time clock
+turns the `bench:freehand-browser` gate red with **eight failures, all of them
+C4**, publishing 4.1–6.0 ms against true tails of 6.4–68.8 ms — the same
+poll-delay band the old field published, and under the third edition's gates
+that run would have been green.
 
 ---
 
@@ -457,8 +498,11 @@ the poll. The correction reads the tail from the last offer's retained
 timestamp to the `MutationObserver`'s sighting of the last generation — the
 same clock the latency distribution comes from, so the poll's 4 ms resolution
 no longer quantises a quantity that is often smaller than 4 ms. The poll and
-its 2 s ceiling remain, as the `settled?` detector they always were. C3 in
-section 2 is the control that now stands where the fault was.
+its 2 s ceiling remain, as the `settled?` detector they always were. C3 and C4
+in section 2 are the controls that now stand where the fault was — C3 on where
+the tail's anchor sits, C4 on the tail actually having been measured from it,
+the second added because a merged-PR audit showed the first could not fail on
+the value it existed to protect.
 
 | k | rate | **tail, production** | tail, dev | *what the old field published (the poll delay)* |
 |---:|---:|---|---|---|
@@ -834,6 +878,21 @@ every rung of both bundles. **What this cost is worth recording**: the wrong
 number was quoted in a durable recommendation for four days, and only reading
 the code found it. No clock caught it, because a clock cannot tell you where it
 was started.
+
+**~~The control that guarded that correction.~~** *Closed by the fourth
+edition.* C3 shipped described as the assertion that would fail if the tail
+clock were restarted at settle time, and a merged-PR audit found that it would
+not: C3 is derived from the settle decision, the tail from the observer, and no
+gate compared `:tail-ms` to anything. The repair is in section 2 — the tail is
+retained from the observer rather than recomputed, the two readings it is the
+difference of are published, and C4 asserts the identity, with C3 left standing
+separately so the one escape from C4 lands on it. **The lesson is the sharper
+half of the one above**: the wrong number was found by reading the code, and so
+was the fact that the control added to stop it recurring could not fire. Both
+times the instrument's own output looked fine. A control is worth what its
+demonstrated failure is worth, which is why the mutation is now performed in
+the suite and was performed once on the instrument itself, red, before this was
+written.
 
 **Real pointer streams.** The driver is a `setInterval`. A browser delivering
 coalesced `pointermove`, or `pointerrawupdate` bursts, can hand several events

--- a/implementation/freehand/test/re_frame/freehand/bench/b10_prod_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b10_prod_app.cljs
@@ -339,16 +339,21 @@
                 plan)
         (.then
           (fn [_]
-            ;; C3 rides here too: a driven run whose tail is not anchored at
-            ;; the last offer is incoherent in the same way a run that applied
-            ;; more than it offered is, and fails the arm rather than
-            ;; publishing a plausible wrong number.
-            (let [bad (filterv (fn [{:keys [offered applied tail-ms tail-anchored?]}]
+            ;; C3 and C4 ride here too: a driven run whose tail is not
+            ;; anchored at the last offer, or whose published tail is not the
+            ;; difference of the two instants published beside it, is
+            ;; incoherent in the same way a run that applied more than it
+            ;; offered is, and fails the arm rather than publishing a
+            ;; plausible wrong number. C4 is the check the third edition
+            ;; lacked: C3 alone left `:tail-ms` free to be re-anchored at
+            ;; settle time with every gate still green.
+            (let [bad (filterv (fn [{:keys [offered applied tail-ms tail-anchored?] :as run}]
                                  (or (not (pos? offered))
                                      (> applied offered)
                                      (not tail-anchored?)
                                      (not (number? tail-ms))
-                                     (neg? tail-ms)))
+                                     (neg? tail-ms)
+                                     (not (b10/tail-identity-holds? run))))
                                @runs)]
               (record! :m3
                        (b10/record
@@ -366,20 +371,27 @@
                                "measurement; :offered counts driver invocations; :applied is "
                                "incremented inside the reducer; :mutations counts DOM "
                                "records; :peak-backlog is the largest offered-minus-applied "
-                               "ever seen at an offer; :tail-ms is from the LAST OFFER'S OWN "
-                               "TIMESTAMP to the MutationObserver's sighting of the last "
-                               "generation, with a 4 ms poll and a 2000 ms ceiling serving "
-                               "only as the :settled? detector; :offer-to-poll-start-ms is "
-                               "the one-interval gap between those two instants and "
-                               ":tail-anchored? gates it against half a requested period, so "
-                               "a tail read off a clock restarted at settle time fails rather "
-                               "than publishes; :latency-ms is the offer-to-DOM distribution "
-                               "read from the MutationObserver callback that carried each "
-                               "generation.")}
+                               "ever seen at an offer; :tail-ms is the LAST GENERATION'S OWN "
+                               "OBSERVER LATENCY, retained by the MutationObserver that "
+                               "computed it rather than recomputed at publication time, so "
+                               "it is the same number that generation contributes to "
+                               ":latency-ms, with a 4 ms poll and a 2000 ms ceiling serving "
+                               "only as the :settled? detector; :tail-offer-at-ms and "
+                               ":tail-observed-at-ms publish the two readings it is the "
+                               "difference of, and that identity is asserted exactly (C4); "
+                               ":offer-to-poll-start-ms is the one-interval gap between the "
+                               "retained offer reading and the settle decision and "
+                               ":tail-anchored? gates it against half a requested period "
+                               "(C3), so re-anchoring the tail at settle time fails C4 by a "
+                               "whole interval and re-anchoring the published offer reading "
+                               "to match fails C3; :latency-ms is the offer-to-DOM "
+                               "distribution read from the MutationObserver callback that "
+                               "carried each generation.")}
                          {:warmup 0 :samples (count @runs)}
                          {:runs @runs}))
               (when (seq bad)
-                (fail! (str "M3 — a driven run is incoherent (offered/applied): "
+                (fail! (str "M3 — a driven run is incoherent "
+                            "(offered/applied, C3 anchor or C4 tail identity): "
                             (pr-str bad)))))
             nil))
         (.finally (fn [] (b10/release! mnt))))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b10_two_clock.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b10_two_clock.cljs
@@ -605,8 +605,9 @@
     :applied   reducer applications, counted in the reducer itself
     :mutations DOM records observed across the whole run
     :peak-backlog  max over offers of `offered − applied`
-    :tail-ms   from the LAST OFFER'S OWN TIMESTAMP to the page showing the
-               last generation
+    :tail-ms   the LAST GENERATION'S OWN OBSERVER LATENCY — the same
+               number its entry in `:latency` carries, retained rather
+               than recomputed
     :latency   per-generation offer→DOM distribution, read from the
                `MutationObserver` callback that carried it
 
@@ -634,12 +635,40 @@
   unchanged and still separate** — the poll remains the `settled?`
   detector and nothing else.
 
-  Four fields make the anchoring checkable rather than asserted:
+  ## The tail is not RECOMPUTED, it is RETAINED — and the algebra is published
 
+  The third edition anchored the tail correctly but published it as a
+  fresh subtraction, `(- t-settle t0)`, sitting beside a control derived
+  from a DIFFERENT pair of instants. `rf2-drpa3.182.12`'s merged-PR audit
+  found the consequence: moving that subtraction's start back to settle
+  time left the gap, `:tail-anchored?` and the numeric/nonnegative checks
+  every one of them green, so the control could not fail on the value it
+  existed to protect. A gate that cannot go red is not a gate.
+
+  So the observer computes each generation's latency ONCE, and the final
+  generation's is retained and published verbatim. `:tail-ms` is not a
+  subtraction performed at publication time; it is a number lifted out of
+  the `:latency` distribution, and there is no start instant at the
+  publication site left to get wrong. The two readings that produced it
+  are published beside it so the identity can be asserted rather than
+  believed — see `tail-identity-holds?`.
+
+  Six fields make the anchoring checkable rather than asserted:
+
+    :tail-offer-at-ms        the RETAINED last-offer reading, `t-offer`.
+                             Origin-relative and meaningful only as a
+                             difference (see `measure/now-ms`); published
+                             so the tail's algebra is checkable.
+    :tail-observed-at-ms     the instant the tail ended — the observer's
+                             own reading when `:tail-source` is
+                             `:observer`, the poll's when it is `:poll`.
     :offer-to-poll-start-ms  last offer → the settle decision. One
                              interval, by construction. This is exactly
                              the term the old reading dropped, so a clock
                              restarted at settle time cannot produce it.
+                             Derived from `:tail-offer-at-ms` itself, so
+                             moving that reading to escape the identity
+                             check lands on this one.
     :predicted-gap-ms        the run's own achieved period,
                              `duration-ms / offered` — what that gap is
                              predicted to be, computed from a different
@@ -652,7 +681,17 @@
                              `setInterval` cannot fire faster than its
                              period, so the floor holds however badly the
                              browser is falling behind; a settle-time
-                             clock fails it outright."
+                             clock fails it outright.
+
+  The two controls are deliberately SEPARATE and neither subsumes the
+  other. `:tail-anchored?` (C3) says WHERE the retained offer reading
+  sits — one interval before the settle decision. `tail-identity-holds?`
+  (C4) says the published tail was computed from THAT reading and the
+  observer's, and from nothing else. Re-anchoring the tail at settle time
+  keeps C3 green and turns C4 red by a whole interval; re-anchoring the
+  published offer reading to keep C4 green collapses the gap and turns C3
+  red. There is no longer a way to move the tail's start that leaves both
+  standing."
   [mnt rate k duration-ms]
   (let [{:keys [container observer]} mnt
         period    (/ 1000.0 rate)
@@ -664,7 +703,12 @@
         start     (m/now-ms)
         last-gen  (volatile! nil)
         t-offer   (volatile! nil)         ; the LAST offer's own timestamp
-        last-seen (volatile! nil)]        ; [generation when-the-page-showed-it]
+        ;; The newest generation the page has shown, retained WITH the two
+        ;; readings that produced its latency and with that latency itself:
+        ;; [generation offered-at observed-at latency-ms]. The tail is
+        ;; LIFTED from here, not recomputed, so the published figure and the
+        ;; generation's entry in the latency distribution are one number.
+        last-obs  (volatile! nil)]
     (.disconnect observer)
     (reset-applied!)
     (let [watcher (js/MutationObserver.
@@ -674,17 +718,26 @@
                             txt (cell-text container 0)
                             g   (js/parseInt txt 10)]
                         (when-not (js/isNaN g)
-                          ;; The newest generation the page has shown, and
-                          ;; WHEN it showed it. The tail is read from here
-                          ;; rather than from the settle poll, so it carries
-                          ;; this observer's resolution rather than the
-                          ;; poll's 4 ms — which in a shipped bundle is
-                          ;; larger than the quantity itself.
-                          (when (or (nil? @last-seen) (> g (nth @last-seen 0)))
-                            (vreset! last-seen [g now]))
+                          ;; ONE latency per generation, computed ONCE. The
+                          ;; distribution and the tail are the same numbers:
+                          ;; `latencies` collects them all and `last-obs`
+                          ;; keeps the newest, so the settle branch has
+                          ;; nothing left to subtract. Reading the tail here
+                          ;; rather than at the settle poll also carries this
+                          ;; observer's resolution rather than the poll's
+                          ;; 4 ms — which in a shipped bundle is larger than
+                          ;; the quantity itself.
+                          ;;
+                          ;; `offers` holds an entry from the moment a
+                          ;; generation is offered until its FIRST sighting,
+                          ;; so this branch runs exactly once per generation
+                          ;; and every newest-generation sighting reaches it.
                           (when-let [t (get @offers g)]
-                            (swap! latencies conj (- now t))
-                            (swap! offers dissoc g))))))]
+                            (let [lat (- now t)]
+                              (swap! latencies conj lat)
+                              (swap! offers dissoc g)
+                              (when (or (nil? @last-obs) (> g (nth @last-obs 0)))
+                                (vreset! last-obs [g t now lat]))))))))]
       (.observe watcher container #js {:subtree true :childList true :characterData true})
       (js/Promise.
         (fn [resolve]
@@ -713,11 +766,25 @@
                                 (when (or done? over?)
                                   (js/clearInterval @poll)
                                   (let [now      (m/now-ms)
-                                        seen     @last-seen
+                                        seen     @last-obs
                                         by-obs?  (boolean (and done? seen
                                                                (= (nth seen 0) @last-gen)))
-                                        t-settle (if by-obs? (nth seen 1) now)
+                                        ;; The retained last-offer reading. It
+                                        ;; anchors the gap AND is published, so
+                                        ;; C3 and C4 gate the same instant.
                                         t0       @t-offer
+                                        ;; LIFTED, not recomputed: when the
+                                        ;; observer saw the last generation the
+                                        ;; tail IS that generation's latency,
+                                        ;; the same number in the distribution.
+                                        ;; The `:poll` arm is the degraded
+                                        ;; fallback — the ceiling expired, or
+                                        ;; the page never showed the last
+                                        ;; generation — and is labelled as such.
+                                        t-end    (if by-obs? (nth seen 2) now)
+                                        tail     (if by-obs?
+                                                   (nth seen 3)
+                                                   (when t0 (- now t0)))
                                         n        @offered
                                         gap      (when t0 (- t-poll-start t0))]
                                     (.disconnect watcher)
@@ -734,8 +801,10 @@
                                        :applied         (applied)
                                        :mutations       @muts
                                        :peak-backlog    @backlog
-                                       :tail-ms         (when t0 (- t-settle t0))
+                                       :tail-ms         tail
                                        :tail-source     (if by-obs? :observer :poll)
+                                       :tail-offer-at-ms    t0
+                                       :tail-observed-at-ms t-end
                                        :offer-to-poll-start-ms gap
                                        :predicted-gap-ms       (when (pos? n)
                                                                  (/ duration-ms (double n)))
@@ -760,6 +829,42 @@
                       (swap! backlog max (- @offered (applied)))
                       (rf/dispatch [:b10/moved k gen] {:frame frame-id}))))
                 period))))))))
+
+;; ---------------------------------------------------------------------------
+;; C4 — the published tail IS the two retained readings
+;; ---------------------------------------------------------------------------
+
+(defn tail-identity-holds?
+  "True when a `drive!` record's `:tail-ms` is exactly the difference of
+  the two instants published beside it.
+
+  This is the gate C3 could not be. `:tail-anchored?` is derived from
+  `:offer-to-poll-start-ms` — the last offer against the SETTLE DECISION
+  — and the tail runs from the last offer to the OBSERVER. Two of the
+  three instants differ, so the third edition's `:tail-ms` could be
+  re-anchored anywhere and C3 would not notice; the merged-PR audit on
+  `rf2-drpa3.182.12` demonstrated exactly that, re-anchoring at settle
+  time and finding the gap, the anchor and the nonnegative check all
+  still green. This asserts the arithmetic itself.
+
+  The comparison is EXACT and can afford to be. Both operands are
+  `measure/now-ms` readings on one clock and the tail is their retained
+  difference — a double subtraction reproduced, not a rounded chain of
+  them, which is why the two instants are published raw (origin-relative,
+  meaningful only as a difference) rather than rebased on the run start.
+  Rebasing would introduce two roundings and put slack in a check whose
+  whole value is that it has none. The interval a re-anchoring moves the
+  tail by is 4 to 33 ms; there is no tolerance to trade away.
+
+  C3 is deliberately left standing beside this rather than folded into
+  it. This says the tail was computed from the retained offer reading;
+  C3 says that reading is the immediately preceding interval. Escaping
+  one lands on the other."
+  [{:keys [tail-ms tail-offer-at-ms tail-observed-at-ms]}]
+  (and (number? tail-ms)
+       (number? tail-offer-at-ms)
+       (number? tail-observed-at-ms)
+       (== tail-ms (- tail-observed-at-ms tail-offer-at-ms))))
 
 ;; ===========================================================================
 ;; Publication

--- a/implementation/freehand/test/re_frame/freehand/bench/b10_two_clock_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b10_two_clock_dom_cljs_test.cljs
@@ -366,32 +366,54 @@
               (.then
                 (fn [_]
                   (doseq [{:keys [rate siblings offered applied tail-ms tail-anchored?
-                                  offer-to-poll-start-ms predicted-gap-ms]} @runs]
+                                  tail-source tail-offer-at-ms tail-observed-at-ms
+                                  offer-to-poll-start-ms predicted-gap-ms]
+                           :as   run} @runs]
                     (is (pos? offered)
                         (str "rate " rate " / k=" siblings ": the driver ran at all"))
                     (is (<= applied offered)
                         (str "rate " rate " / k=" siblings
                              ": the reducer cannot apply more than was offered ("
                              applied " applied, " offered " offered)"))
-                    ;; C3 — the tail anchor. `:tail-ms` claims to start at the
-                    ;; last offer, and the callback that ends the drive is one
-                    ;; interval PAST that offer. So the gap must exist and must
-                    ;; be at least half a requested period — `setInterval`
-                    ;; cannot fire faster than its period, so the floor holds
-                    ;; however far behind the browser has fallen. A tail read
-                    ;; off a clock restarted at settle time reports the poll
-                    ;; delay and cannot produce this gap at all, which is the
-                    ;; fault this assertion exists for.
+                    ;; C3 — WHERE the retained offer reading sits. The
+                    ;; callback that ends the drive is one interval PAST the
+                    ;; last offer, so the gap must exist and must be at least
+                    ;; half a requested period — `setInterval` cannot fire
+                    ;; faster than its period, so the floor holds however far
+                    ;; behind the browser has fallen. This gates the reading
+                    ;; `:tail-ms` is measured FROM; C4 below gates that
+                    ;; `:tail-ms` was measured from it. Neither subsumes the
+                    ;; other and they are kept apart deliberately.
                     (is tail-anchored?
                         (str "rate " rate " / k=" siblings
-                             ": the tail is anchored at the last offer — gap "
+                             ": the retained offer reading is the immediately "
+                             "preceding interval — gap "
                              offer-to-poll-start-ms " ms against a "
                              (/ 1000.0 rate) " ms period (predicted "
                              predicted-gap-ms " ms from the achieved rate)"))
                     (is (and (number? tail-ms) (not (neg? tail-ms)))
                         (str "rate " rate " / k=" siblings
                              ": the tail is a real measurement, not nil ("
-                             (pr-str tail-ms) ")")))
+                             (pr-str tail-ms) ")"))
+                    ;; C4 — the published tail IS the two retained readings.
+                    ;; `:tail-ms` is the last generation's own observer
+                    ;; latency, lifted out of the distribution rather than
+                    ;; recomputed, and the two instants that produced it ride
+                    ;; beside it. Re-anchoring the tail at settle time — the
+                    ;; regression the first two editions shipped, and the one
+                    ;; C3 alone could not see — moves this by a whole
+                    ;; interval, 4 to 33 ms across the ladder. Exact
+                    ;; comparison; see `b10/tail-identity-holds?`.
+                    (is (b10/tail-identity-holds? run)
+                        (str "rate " rate " / k=" siblings
+                             ": the published tail is the two retained readings — "
+                             (pr-str tail-ms) " ms against "
+                             (pr-str tail-observed-at-ms) " − "
+                             (pr-str tail-offer-at-ms) " = "
+                             (pr-str (when (and (number? tail-observed-at-ms)
+                                                (number? tail-offer-at-ms))
+                                       (- tail-observed-at-ms tail-offer-at-ms)))
+                             " (source " (pr-str tail-source) ")")))
                   (h/publish!
                     "B10 M3 / driven rates"
                     (b10/record
@@ -409,13 +431,19 @@
                             ":offered counts driver invocations; :applied is incremented "
                             "inside the reducer; :mutations counts DOM records; "
                             ":peak-backlog is the largest offered-minus-applied ever seen at "
-                            "an offer; :tail-ms is from the LAST OFFER'S OWN TIMESTAMP to "
-                            "the MutationObserver's sighting of the last generation, with a "
-                            "4 ms poll and a 2000 ms ceiling serving only as the :settled? "
-                            "detector; :offer-to-poll-start-ms is the one-interval gap "
-                            "between those two instants and :tail-anchored? gates it against "
-                            "half a requested period, so a tail read off a clock restarted "
-                            "at settle time fails rather than publishes; :latency-ms is the "
+                            "an offer; :tail-ms is the LAST GENERATION'S OWN OBSERVER "
+                            "LATENCY, retained by the MutationObserver that computed it "
+                            "rather than recomputed at publication time, so it is the same "
+                            "number that generation contributes to :latency-ms, with a 4 ms "
+                            "poll and a 2000 ms ceiling serving only as the :settled? "
+                            "detector; :tail-offer-at-ms and :tail-observed-at-ms publish "
+                            "the two readings it is the difference of, and that identity is "
+                            "asserted exactly (C4); :offer-to-poll-start-ms is the "
+                            "one-interval gap between the retained offer reading and the "
+                            "settle decision and :tail-anchored? gates it against half a "
+                            "requested period (C3), so re-anchoring the tail at settle time "
+                            "fails C4 by a whole interval and re-anchoring the published "
+                            "offer reading to match fails C3; :latency-ms is the "
                             "offer-to-DOM distribution read from the MutationObserver "
                             "callback that carried each generation.")}
                       {:warmup 0 :samples (count @runs)}
@@ -423,6 +451,73 @@
                   nil))
               (.catch (fn [e] (is false (str "M3 rejected: " e))))
               (.finally (fn [] (b10/release! mnt) (done)))))))))
+
+;; ===========================================================================
+;; C4's witness — the mutation the old gate could not see
+;; ===========================================================================
+
+(deftest c4-a-settle-anchored-tail-cannot-pass-both-controls
+  (testing "A gate nobody has watched fail is not known to be a gate, and
+            this surface has already shipped one that wasn't. The third
+            edition's C3 was introduced as 'the assertion that fails if
+            the tail clock restarts at settle time'; it wasn't, and
+            `rf2-drpa3.182.12`'s merged-PR audit showed why — C3 is
+            derived from the last offer against the SETTLE DECISION while
+            the tail runs from the last offer to the OBSERVER, so
+            re-anchoring the tail left the gap, the anchor and the
+            numeric/nonnegative checks every one of them green.
+
+            This is that mutation, performed on the record rather than on
+            the source, so the witness rides in the suite instead of
+            living in a PR description. One thing changes and one only:
+            the tail's START. The three checks that WERE the whole gate
+            are asserted to stay green on it, which is the fault being
+            recorded, and then C4 is asserted to catch it. The single
+            escape — moving the published offer reading to match — is
+            asserted to land on C3, which is why the two controls are
+            kept apart.
+
+            The instants are one 30 Hz rung: an offer at 1000.0, the next
+            fire of the same `setInterval` 34.2 ms later deciding to
+            settle, and the observer seeing the last generation 3.3 ms
+            after that. 37.5 ms of tail, of which the settle-anchored
+            reading publishes 3.3 — the same order as the 4 ms poll delay
+            the first two editions actually published."
+    (let [period       (/ 1000.0 30)
+          t-offer      1000.0
+          t-poll-start 1034.2
+          t-observed   1037.5
+          ;; C3 exactly as `drive!` derives it, from the PUBLISHED offer
+          ;; reading — which is what makes the escape route land here.
+          anchored?    (fn [{:keys [tail-offer-at-ms]}]
+                         (let [gap (- t-poll-start tail-offer-at-ms)]
+                           (>= gap (* 0.5 period))))
+          honest       {:tail-ms             (- t-observed t-offer)
+                        :tail-offer-at-ms    t-offer
+                        :tail-observed-at-ms t-observed}
+          settle       (assoc honest :tail-ms (- t-observed t-poll-start))
+          both-moved   (assoc settle :tail-offer-at-ms t-poll-start)]
+      (is (b10/tail-identity-holds? honest)
+          "an honest record satisfies C4")
+      (is (anchored? honest)
+          "and C3, so the witness is measuring the mutation and not the fixture")
+      ;; The fault, recorded: every check that existed before C4 passes.
+      (is (anchored? settle)
+          "the settle-anchored tail still passes C3 — the gap is untouched")
+      (is (number? (:tail-ms settle))
+          "and is still numeric")
+      (is (not (neg? (:tail-ms settle)))
+          "and still nonnegative — 3.3 ms, precise, plausible and wrong")
+      ;; C4 is what closes it.
+      (is (not (b10/tail-identity-holds? settle))
+          (str "C4 catches the settle-anchored tail: " (:tail-ms settle)
+               " ms published against " t-observed " − " t-offer " = "
+               (- t-observed t-offer)))
+      ;; And the one way out of C4 is barred by C3.
+      (is (b10/tail-identity-holds? both-moved)
+          "moving the published offer reading restores C4 …")
+      (is (not (anchored? both-moved))
+          "… and collapses the gap, so C3 fails instead"))))
 
 ;; ===========================================================================
 ;; M4 — the controlled field, correctness FIRST


### PR DESCRIPTION
Closes the audit-reopen obligation on `rf2-drpa3.182.12`. **No measured figure
changes** — the instrument's numbers were already right. What was missing was a
gate that could fail if they stopped being.

## The defect

The third edition anchored `:tail-ms` correctly but published it as a fresh
subtraction, `(- t-settle t0)`, sitting beside a control derived from a
**different pair of instants**. C3 (`:tail-anchored?`) is the last offer against
the *settle decision*; the tail runs from the last offer to the *observer*. Two
of the three instants differ, so nothing compared `:tail-ms` to anything —
re-anchoring it left the gap, the anchor and the numeric/nonnegative checks
every one of them green, in the browser row (`b10_two_clock_dom_cljs_test.cljs`)
and in the production coherence filter (`b10_prod_app.cljs`) alike. The C3
assertions could not fail on the value they existed to protect.

## Which remedy, and why

The bead offered two. **Both are taken, because each is load-bearing and neither
is sufficient alone.**

*Make the final generation's observer latency the single source of truth.* The
`MutationObserver` now computes each generation's latency **once**; the final
generation's is retained (`last-obs` carries `[generation offered-at observed-at
latency-ms]`) and published verbatim. `:tail-ms` is lifted out of the `:latency`
distribution rather than recomputed from it, so there is no start instant left
at the publication site to get wrong. That is the structural half — but on its
own it is invisible to any gate, which is exactly how this surface got here.

*Expose the two timestamps and assert the exact identity.* `:tail-offer-at-ms`
and `:tail-observed-at-ms` are published beside the tail, and
`b10/tail-identity-holds?` — **C4** — asserts `tail-ms == observed − offer`
exactly. One predicate, three callers: the browser row, the production coherence
filter, and the witness below.

The comparison carries no tolerance and needs none. Both operands are
`measure/now-ms` readings on one clock and the tail is their retained
difference, so the check reproduces a single double subtraction rather than a
rounded chain of them. That is also why the two instants are published **raw**
(origin-relative, meaningful only as a difference) rather than rebased on the
run start: rebasing introduces two roundings and puts slack in a check whose
whole value is that it has none. The interval a re-anchoring moves the tail by
is 4–33 ms; there is no tolerance worth trading for tidier numbers.

**C3 is kept separate and is not folded into C4**, per the bead. C3 says *where
the retained offer reading sits* — one interval before the settle decision. C4
says *the published tail was computed from that reading and the observer's, and
from nothing else*. `:offer-to-poll-start-ms` is derived from the same
`:tail-offer-at-ms` binding that C4 checks, so the two interlock: re-anchoring
the tail at settle time keeps C3 green and turns C4 red by a whole interval;
re-anchoring the published offer reading to restore C4 collapses the gap and
turns C3 red. There is no remaining way to move the tail's start that leaves
both standing.

## The mutation witness — demonstrated red

Both halves. A **permanent** witness rides in the suite
(`c4-a-settle-anchored-tail-cannot-pass-both-controls`): it performs the
mutation on a synthetic 30 Hz record, asserts that all three pre-C4 gates stay
green on it, asserts C4 does not, and then asserts that the single escape from
C4 lands on C3. And the mutation was performed **on the instrument itself** and
run, twice, because the first form turned out not to isolate C4:

| mutation applied to `:tail-ms` | exit | failures | which gates |
|---|---:|---:|---|
| *(none — the committed tree)* | **0** | 0 of 497 | — |
| `(- t-end t-poll-start)` — the audit's literal expression | **1** | **16** | 8 × C4 **and** 8 × the pre-existing nonnegative check |
| `(- now t-poll-start)` — the first two editions' settle-time clock, verbatim | **1** | **8** | **8 × C4 and nothing else** |
| *(restored)* | **0** | 0 of 497 | — |

The second row is an honest finding worth recording: the audit's *literal*
expression goes negative at all eight rungs on this host (the observer sights
the last generation *before* the settle poll fires), so the old nonnegative
check catches that particular form too. The third row is the one that matters
and is the historical regression verbatim — positive by construction, therefore
invisible to every gate that existed before this PR. It published **4.1–6.0 ms**
against true tails of **6.4–68.8 ms**, and under the third edition's gates that
run would have been **green**. Sample failure line:

```
FAIL in (m3-the-offered-rate-is-not-the-observed-rate) (b10_two_clock_dom_cljs_test.cljs:407:25)
rate 240 / k=200: the published tail is the two retained readings — 6 ms against
27530.100000023842 − 27473.69999998808 = 56.40000003576279 (source :observer)
```

Note the permanent witness passes in *all* runs including the mutant ones — it
operates on synthetic records, so it proves the predicate discriminates, while
the M3 row proves the instrument feeds it. The two are deliberately different
questions.

The benchmark was **not** rebuilt. No `implementation/freehand/src/**` change,
no `spec/**` change, no FH- id, no roster change, no shared build configuration
touched. The rate ladder, sibling ladder, behaviour-config axis and
controlled-input contention are untouched and were not re-run.

## Quality gates

All foreground, to completion, each redirected to a worktree-local log with the
runner's own exit code captured separately — never piped through `tail`/`grep`,
whose exit status would be the pipeline's last command.

| gate | command | exit | result |
|---|---|---:|---|
| b10 two-clock DOM suite (owner of these assertions) | `npm run bench:freehand-browser` | **0** | 31 tests, 497 assertions, **0 failures 0 errors** |
| same, after the mutation was restored | `npm run bench:freehand-browser` | **0** | 31 tests, 497 assertions, **0 failures 0 errors** |
| b10 production run (exercises the prod C4 filter) | `node …/b10_prod_run.cjs` | **0** | 3 records; M3 coherence filter passed; all 8 driven runs carry `:tail-offer-at-ms` / `:tail-observed-at-ms` and satisfy the identity |
| fast-PR spine | `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`, 79 stages; `gate root: /c/Users/miket/code/re-frame2-worktrees/twoclock-182-12` |
| doc slugs | `python scripts/check_doc_slugs.py` | **0** | silent pass |

Assertion delta: **+1 test, +16 assertions** — 8 from the new C4 check in M3's
loop over eight driven runs (2 sibling rungs × 4 rates), and 8 from the
permanent witness. The merge base therefore stood at 30 tests / 481 assertions;
that base figure is derived from the added count rather than separately
measured.

The production run reports `:d021 :not-release-evidence` because `RF2_REVISION`
is unset on a local invocation, which is the instrument's own honest-reporting
path and is unchanged by this PR. The coherence filter — the thing this PR
touches — ran and passed regardless.

**Local green is not CI green.** `python scripts/check_fast_pr_gap.py --list`
enumerates **90 required checks the spine does not run**, under the three
required contexts `All required checks passed` (test.yml), `Lint required`
(lint.yml) and `Docs required` (docs.yml). The ones nearest this diff are
`jvm-freehand-prod-gate`, `cljs-freehand-evidence-elision` and
`cljs-freehand-reachability`; none is decided here.

**And the owning gate is not a PR gate at all.** `bench:freehand-browser` runs
only under `.github/workflows/freehand-bench.yml`, which is `schedule:` (05:41
UTC) + `workflow_dispatch:` — so the four browser runs above are the *only*
execution these assertions get before merge, and the nightly is where a
regression would otherwise surface.

**Docs verified by hand.** The evidence-page edit is confined to
`docs/design/freehand/studio/`, which `mkdocs.yml`'s `exclude_docs` keeps out of
the site, so `mkdocs build --strict` (which the spine runs) does **not** cover
it. `scripts/check_doc_slugs.py` validates its link targets and heading anchors
and passed. Nothing validates tables or rendering, so by hand: **no table was
added or altered** — the existing tables are untouched and their column counts
unchanged; one new heading `### C4 — a control of the tail's arithmetic` was
added under section 2, whose own heading was corrected from "three controls" to
"four controls"; no new links were introduced and no existing anchor was
renamed.

Beads: `rf2-drpa3.182.12`.
