### PR TITLE
docs(hicasso): the candidate's clock page states a superseded magnitude (rf2-jcm3p, rf2-cvvb7)

### DIFF
--- a/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
+++ b/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
@@ -1,10 +1,14 @@
 # The candidate's rows, re-adjudicated on the corrected clock
 
-**The mount deficit is worse than published and the other three rows are still
+**The mount deficit ~~is worse than published~~ reads larger on the corrected
+clock than on the clock it replaced, and the other three rows are still
 refused.** On raw `TaskDuration` — the arm's own JavaScript *and* the frame it
 causes — `hicasso / reagent-subs` on `M1` reads **1.4896×** [1.3488 – 1.5989] on
 ~~the ensemble that has standing~~ the ensemble this page was written against,
-compared with the **1.2107×** the candidate's clock publishes. This page's own
+against the **1.2107×** ~~the candidate's clock publishes~~ the candidate's
+clock read before the correction *(2026-08-06, `rf2-jcm3p`: that page publishes
+no mount magnitude either — both readings are annotated there as historical
+observations stated under a failing `ctl-2x`)*. This page's own
 seven runs, taken at a heavier load regime, read **1.3737×** [1.3289 – 1.4331]
 and are published as a second regime rather than as the magnitude, because the
 corroboration control they were pre-registered against **failed**

--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -984,19 +984,32 @@ explicitly: relabel the three segments *within* each round — keeping every
 round's three blocks together and destroying only which segment owned which —
 and recompute the same statistic.
 
-| the seam's own null, pooled over 19 runs × 2,000 relabellings | |
+| the seam's own null — **Monte Carlo**, pooled over 19 runs × 2,000 sampled relabellings | |
 |---|---:|
 | median | 5.5% |
 | q95 | 14.1% |
 | q99 | 17.6% |
 | q99.9 | 23.9% |
-| largest of 38,000 draws | 26.8% |
+| largest of the 38,000 draws | 26.8% |
+
+**That null is SAMPLED and its draw count is not pinned** *(2026-08-06,
+`rf2-cvvb7`)*. `seamNull()` in `seam.cjs` takes seeded random within-round
+relabellings — one of the six permutations of three segments per round, so
+6⁶ = 46,656 assignments over a six-round run — and does not enumerate them. So
+*"beyond all draws"* below means beyond every draw **taken**, not beyond every
+relabelling possible; the two are not the same claim and this section used to
+read as though they were. Nor is the 2,000 checkable from the tree:
+`NULL_DRAWS` is **4,000** both at this study's `seam.cjs` blob (`a6789197…`,
+[§7.1](#71-the-seam-study-rf2-cvvb7)) and at HEAD, and no landed caller passes
+2,000. The finite null is small enough to enumerate exactly — but that is a
+re-run rather than a prose repair, and these nineteen runs cannot be re-analysed
+at all, because their datasets do not survive.
 
 Every observed seam sat at or below that null's median, and **not one of the
 nineteen runs reached p < 0.2**. The published 22% is a 1-in-400 draw from it.
-The published 34% is beyond all 38,000 draws — which is the honest shape of the
-finding: it is not noise of this kind either, and nothing this study could
-produce reproduced it.
+The published 34% is beyond every one of those 38,000 draws — which is the
+honest shape of the finding: it is not noise of this kind either, and nothing
+this study could produce reproduced it.
 
 Where the floor's variation actually lives is the **round**, not the segment.
 The rotation makes segment, round and position-in-round mutually orthogonal
@@ -1199,10 +1212,13 @@ Filed rather than attempted here, because each is a different instrument:
     `(T(2D) − T(ε)) / (T(D) − T(ε))`. Carried by `rf2-7iqb5`.
 - ~~**The segment seam, measured rather than assumed to cancel.**~~ **Done —
   [§6.1](#61-the-seam-measured-against-load), `rf2-cvvb7`.** A nineteen-run load
-  ladder and an exact within-round relabelling null answered it without needing
-  a second floor arm: the variation is on the **round**, the perturbation is
-  multiplicative and cancels exactly, and the seam is not attributable to the
-  segment. The band in [§6.2](#62-what-replaces-it-the-band-a-magnitude-must-clear)
+  ladder and a **Monte Carlo** within-round relabelling null answered it without
+  needing a second floor arm: the variation is on the **round**, ~~the
+  perturbation is multiplicative and cancels exactly,~~ and the seam is not
+  attributable to the segment. *(2026-08-06, `rf2-cvvb7`: the multiplicativity
+  clause is **withdrawn** — [§6.1](#61-the-seam-measured-against-load)'s banner
+  records the re-take that refuted it. The null was never an enumeration
+  either.)* The band in [§6.2](#62-what-replaces-it-the-band-a-magnitude-must-clear)
   replaces it as the gate.
 - **More rounds.** The strict rule bites on round-level variance, and 6 × 10 is
   what the mount row needed rather than what these rows need.
@@ -1277,12 +1293,21 @@ and `clock_views.cljs` are at the blobs in the table above, unchanged.
 | Load windows | two, 23:10–23:17 and 23:18–23:23 AUSEST 2026-08-01, each rung a single ~40 s run with the load released between runs |
 | Reproduction | `node freehand/test/re_frame/bench/hicasso/seam_ladder.cjs --load 12 --label x --json out/x.json`, and `node freehand/test/re_frame/bench/hicasso/seam.cjs` for the adjudicator's own self-test |
 | Discarded | none. Every run that started finished; the driver writes no dataset for a run that died part-way, so a partial one cannot be analysed by mistake |
+| Producing commit | **`362b883285726adf1458e43be4f897d770545a33`** — on `main`, so it resolves. `seam.cjs` and `seam_ladder.cjs` are at the blobs above there; `clock_run.cjs` is not, since at that commit `clock_run.cjs` is `ede7bf73…` and the driver had moved on before the page landed |
+| Driver blob, unlanded | the blob the runs executed, `f5bb751d…`, is on **no** commit reachable from `main` — thirty commits touch `clock_run.cjs` there and not one carries it. It is annotated rather than re-pinned, because recovering a landed SHA restores the patch and not the tree |
+| Analysis inputs | **none survive** — the nineteen runs' datasets went to a gitignored `out/`, as the paragraphs below record. `NULL_DRAWS` is `4,000` at the adjudicator blob above, against the 2,000 a run that [§6.1](#61-the-seam-measured-against-load)'s null table states, and no landed caller settles which was used |
 
 The 19 ladder runs were taken with the seam adjudicator **not yet wired in**, so
 nothing they measured was influenced by the gate they calibrate; the ladder
-figures in [§6.1](#61-the-seam-measured-against-load) are recomputed from their
-stored raw readings using the shipped `seam.cjs`, so the published figures and
-the instrument's figures are the same figures.
+figures in [§6.1](#61-the-seam-measured-against-load) ~~are recomputed from
+their stored raw readings using the shipped `seam.cjs`, so the published figures
+and the instrument's figures are the same figures~~ **were computed from raw
+readings that were then thrown away** *(2026-08-06, `rf2-cvvb7`)*. They did come
+out of the shipped `seam.cjs`, so the published figures and the instrument's
+figures were the same figures *when they were taken* — but nothing in the landed
+tree recomputes them now, as the paragraph below and
+[§6.1](#61-the-seam-measured-against-load)'s banner both record. The durable
+answer was a **re-run**, not a restatement.
 
 **The clock and the door for the whole study (`rf2-ymi6j`).** `seam_ladder.cjs`
 does not measure anything itself: it forks its spinners, spawns
@@ -1303,6 +1328,19 @@ failure mode can recur: `ladder_band.cjs` recomputes every figure from the
 driver's own datasets using `seam.cjs`'s exported adjudicators, and the compact
 per-block dataset it emits is **committed** at
 `implementation/freehand/test/re_frame/bench/hicasso/data/ladder-ymi6j.json`.
+That is the one command this section's own audit asked for, and it runs from a
+clean clone against a file the clone already has:
+
+```bash
+cd implementation
+node freehand/test/re_frame/bench/hicasso/ladder_band.cjs \
+  --from freehand/test/re_frame/bench/hicasso/data/ladder-ymi6j.json
+```
+
+It regenerates every published aggregate of the re-taken ladder — every band,
+every `ctl-2x / floor`, every bar row — and `--selftest` fails closed on the
+resampling model. What it cannot do is restore **these** nineteen runs, whose
+inputs are gone; the durable path starts at the re-run and not before it.
 
 ---
 

--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -67,7 +67,11 @@ report.
 > ensemble reads `hicasso / reagent-subs` on `M1` at **1.4896×**
 > [1.3488 – 1.5989] against the **1.2107×** below, and `hicasso / uix-subs` at
 > **1.5001×** against **1.1865×**. The candidate's mount deficit is *materially
-> worse* than this page publishes, not better. `ctl-2x` is untouched — it reads
+> worse* than ~~this page publishes~~ this page read before the correction, not
+> better. *(2026-08-06, `rf2-jcm3p`: neither mount figure is a published
+> magnitude any longer — both are stated under a failing `ctl-2x`, and
+> [§4](#4-the-mount-row--a-regime-not-a-magnitude) states the row as a regime.)*
+> `ctl-2x` is untouched — it reads
 > 1.69–1.83× the floor on both clocks — so [§6](#6-the-three-rows-this-page-refuses)'s
 > refusals stand unchanged.
 >
@@ -648,7 +652,9 @@ On the substrate arms the two windows differ by a factor of three to nine and �
 the part that matters — **by a different factor per arm**. It is not a scale
 error that cancels in a ratio: on M1 the in-page window puts
 `hicasso / reagent` at 1.56× where `taskNet` reads 1.21×, and raw
-`TaskDuration` — the clock that holds both halves — reads **1.4896×**.
+`TaskDuration` — the clock that holds both halves — reads **1.4896×** (a
+reading under a failing `ctl-2x`; the row publishes no magnitude —
+[§4](#4-the-mount-row--a-regime-not-a-magnitude)).
 
 > **THE SEPARATION IS REAL AND THIS MECHANISM STATEMENT IS WRONG (`rf2-yd52q`,
 > measured by `rf2-emvod`).** The `+300–610%` above is not one window
@@ -1146,7 +1152,7 @@ readings; the **magnitudes** are superseded row by row on
 
 | run 5 row *(all figures `taskNet`)* | margin from 1.0 | against | verdict |
 |---|---:|---|---|
-| `M1`, `hicasso / reagent-subs` ~~1.2107~~ | 21.1% | its own band, ≤ 11.7% | **clears** — published, as it was; the magnitude is now **1.4896×** |
+| `M1`, `hicasso / reagent-subs` ~~1.2107~~ | 21.1% | its own band, ≤ 11.7% | **clears the band** — ~~published, as it was; the magnitude is now **1.4896×**~~ **and still publishes no magnitude** *(2026-08-06, `rf2-jcm3p`)*. The corrected clock read **1.4896×** [1.3488 – 1.5989] on this row, under a failing `ctl-2x`; clearing the band is not clearing the control, and [§4](#4-the-mount-row--a-regime-not-a-magnitude) states the row as a regime |
 | `bulk300` ~~1.0100~~ | 1.0% | smaller than every band ever measured here | instrument-limited — refused, as it was; **1.1494×** corrected |
 | `bulk100` ~~0.9902~~ | 1.0% | the same | instrument-limited — refused, as it was; **1.1089×** corrected, a sign change |
 | `narrow` 1.0369 | 3.7% | the same | instrument-limited — refused, as it was; **1.0236×** corrected |
@@ -1303,8 +1309,15 @@ per-block dataset it emits is **committed** at
 ## 8. What this hands the programme
 
 - **The candidate has clock rows.** It did not before.
-- **On mount it is 1.4896× Reagent-on-subs** on the clock of record
-  [1.3488 – 1.5989], against a `≤ 1.0×` win condition and a `1.0150×` red zone.
+- **On mount it is materially slower than Reagent-on-subs — a REGIME, and not a
+  magnitude** *(2026-08-06, `rf2-jcm3p`;
+  [§4](#4-the-mount-row--a-regime-not-a-magnitude))*. ~~On mount it is 1.4896×
+  Reagent-on-subs on the clock of record [1.3488 – 1.5989], against a `≤ 1.0×`
+  win condition and a `1.0150×` red zone.~~ That reading stands as a historical
+  observation *stated under a failing `ctl-2x`*: it sits above the `≤ 1.0×` win
+  condition and the `1.0150×` red zone, as does every other corroborated
+  reading, and `≤ 1.10×` has not been demonstrated — but the row publishes no
+  number.
   This page's own `1.21×` is the frame-only reading of the same row, above
   parity in all five of its runs; the correction moved the figure *up*. Still
   not a clear K1 kill — K1 asks for `> Reagent` *after two serious runtime


### PR DESCRIPTION
A prose-correctness pass over the candidate's clock page and its re-adjudication
sibling. **No measurement was taken, no benchmark run, nothing re-timed** — five
other workers were live on this box, so any wall-clock row taken now would be
invalid by construction. Every number below is read out of the tree or recomputed
from a committed dataset.

Two ordered commits, one per bead.

---

## `rf2-jcm3p` — the mount row's superseded magnitude (9d25a45c12)

PR #7595's roster claimed both fenced pages were fully annotated under the
2026-08-06 regime ruling. They were not. The audit named three sites; a re-grep
of both pages found two more of the same class.

| # | site | was | now |
|---|---|---|---|
| 1 | `the-candidates-clock.md`, run-5 table (was L1149) | "**clears** — published, as it was; the magnitude is now **1.4896×**" | "**clears the band** … **and still publishes no magnitude**" — the band verdict is kept and separated from the control, because clearing the band is not clearing the control |
| 2 | `the-candidates-clock.md`, §8 handoff (was L1306) | "**On mount it is 1.4896× Reagent-on-subs** on the clock of record" | the regime, with the reading struck through beneath it and its failing-`ctl-2x` status stated |
| 3 | `the-candidates-clock.md`, `rf2-yd52q` banner (L69) — **found by re-grep** | "the candidate's mount deficit is *materially worse* than this page publishes" | the page publishes no mount magnitude; restated as what it read *before* the correction, annotated |
| 4 | `the-candidates-clock.md`, two-windows comparison (L651) — **found by re-grep** | raw `TaskDuration` "reads **1.4896×**", no control status | annotated in one clause, as the ruling requires at every occurrence |
| 5 | `rows-re-adjudicated-on-the-corrected-clock.md`, opening (L3–8) | "The mount deficit **is worse than published**" / "the **1.2107×** the candidate's clock **publishes**" | reads larger on the corrected clock than on the clock it replaced, against what that clock read before the correction |

Every reading stays visible and is struck through rather than deleted, per the
ruling's *history is annotated, never erased*.

**No further sites.** Re-grepped both pages for `1.4896` / `1.5001` / `1.4656` /
`1.2107` and for the phrasings *magnitude is*, *figure of record*, *clock of
record*, *publishes*, *deficit is*, *is established*. Every remaining occurrence
is either the annotation itself, a struck-through historical row, or a reading
inside an explicitly annotated block (lead paras 3–21, §4 banner 503–557, bar
table 590–591, gates para 597–604, `rows-re-adjudicated` 328–337).

### The control ruling remains OPEN and is untouched

Nothing in this PR resolves the control question. It does **not** decide whether
`M1` gets a mount-axis three-point control, does **not** declare the mount row
valid or invalid, and does **not** remove or soften the caveat that `ctl-2x`
fails — that caveat is preserved at every site it appears, and is *added* at two
sites that lacked it. The conditional trigger for construction (1) stands exactly
as ruled. What this PR fixes is the separable half: the pages stated a
**magnitude** that had been superseded, which is a factual error independent of
how the ruling lands.

---

## `rf2-cvvb7` — the seam study's null, provenance and recomputation claim (32a5a3e2bd)

**Item 1 is falsified — verified in tree, not asserted.** It asked for preserved
inputs plus one fail-closed analysis command regenerating every published
aggregate. `rf2-ymi6j` delivered exactly that by re-running this bead's own
nineteen-run ladder design on both clocks: `ladder_band.cjs` recomputes from
`seam.cjs`'s exported adjudicators, and the compact dataset is **committed** at
`implementation/freehand/test/re_frame/bench/hicasso/data/ladder-ymi6j.json`.
Both verified from a clean checkout (exit codes below). Item 1 is not work; the
command is now named on the page as a runnable block.

What it cannot reach — and the page now says so consistently — is *this* study's
own nineteen runs, whose datasets went to a gitignored `out/`. §7.1 still claimed
the §6.1 figures "are recomputed from their stored raw readings", flatly
contradicted by its own next paragraph and by §6.1's banner. Struck through and
restated.

**Item 2 stands, and is repaired as prose rather than by re-analysis.**
`seamNull()` samples seeded random within-round relabellings — one of six
permutations of three segments per round, so 6⁶ = 46,656 assignments over a
six-round run — and does not enumerate them. The null table and §6.3's bullet
(which called it *exact*) now say **Monte Carlo**; "beyond all 38,000 draws" now
reads "beyond every one of those draws", which is the claim the sampling
supports. The draw count is unpinnable and now says so: `NULL_DRAWS` is **4,000**
both at the study's `seam.cjs` blob `a6789197…` and at HEAD, and no landed caller
passes the 2,000 the prose records. **Enumerating the finite null exactly is a
re-run, and these runs cannot be re-analysed at all — left undone, and stated as
left.**

**Item 3 stands, and is repaired from the tree.** §7.1 now pins producing commit
`362b883285726adf1458e43be4f897d770545a33` — verified to resolve, verified an
ancestor of `origin/main`, and verified to carry the `seam.cjs` `a6789197…` and
`seam_ladder.cjs` `ae0ddf6e…` blobs the section already lists. The driver blob is
the exception and is **annotated rather than re-pinned**: `clock_run.cjs` is
`ede7bf73…` at that commit, and the executed blob `f5bb751d…` is on no commit
reachable from `main` (30 commits touch that path; none carries it). Re-pinning
would swap an unresolvable pin for a resolvable but wrong one.

Fixed in passing: §6.3's bullet still asserted the perturbation "is
multiplicative and cancels exactly", a conclusion §6.1 already marks **WITHDRAWN**
by the re-take.

---

## Quality gates

All foreground, to completion, each redirected to a worktree-local log with the
runner's own exit code captured separately — never piped through `tail`/`grep`,
whose exit status would be the pipeline's last command.

| # | command | result | exit code |
|---|---|---|---:|
| 1 | `python scripts/check_doc_slugs.py` | green, no findings (0 lines of output) | **0** |
| 2 | `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | `2 files, 5 cited pins (4 landed, 1 stranded, 0 unresolvable)` — "every cited pin is an ancestor of origin/main or shares its block with one" | **0** |
| 3 | `sh scripts/test-fast-pr.sh` | `docs=true jvm=false node=false (classified)`; docs lane ran the link/anchor/status gates; **268 PASS** assertions, **0 failures** | **0** |
| 4 | `node freehand/.../ladder_band.cjs --from freehand/.../data/ladder-ymi6j.json` | regenerates the whole re-taken ladder from the committed dataset — the `rf2-cvvb7` item-1 evidence | **0** |
| 5 | `node freehand/.../ladder_band.cjs --selftest` | `ladder_band self-test ok`; fails closed if the pooled resampling model is reinstated | **0** |

On gate 2: the cited-pin count rose 4 → 5 because §7.1's new producing commit is
the fifth, and it is **landed**. The one stranded pin is pre-existing (§7's
authoring anchor `fdff3fd488…`) and shares its block with the landed whole-tree
anchor, which is what the accompaniment rule requires.

**`mkdocs build --strict` is not nominated and would verify nothing here** —
`mkdocs.yml`'s `exclude_docs` keeps `docs/design/` out of the site. Nothing
validates this tree's tables or rendering, so the hand-check below **is** the
gate.

### Hand-verification of heading anchors

Every anchor used in this PR is a same-page link reusing a form already live on
the page, and `check_doc_slugs.py` (gate 1) resolves all of them:

- `#4-the-mount-row--a-regime-not-a-magnitude` → `## 4. The mount row — a REGIME, not a magnitude` (the double hyphen is the em-dash, matching the existing uses at L11 and L522)
- `#61-the-seam-measured-against-load` → `### 6.1 The seam, measured against load`
- `#62-what-replaces-it-the-band-a-magnitude-must-clear` → `### 6.2 What replaces it: the band a magnitude must clear`
- `#71-the-seam-study-rf2-cvvb7` → `### 7.1 The seam study (rf2-cvvb7)`

No new headings were added, so no anchor elsewhere in the corpus can have been
broken by this PR.

### Hand-verification of table column counts

Checked every table on both pages with a reader that skips fenced code blocks and
does not split on pipes inside backticks:

- `the-candidates-clock.md` — **22 tables, 0 column-count mismatches**
- `rows-re-adjudicated-on-the-corrected-clock.md` — **9 tables, 0 column-count mismatches**
- code fences balanced on both pages (the one new `bash` block closes)

The three tables this PR actually touches, checked by eye as well:

- run-5 verdict table — 4 columns; the rewritten `M1` row has exactly 4 cells and its new prose contains no bare `|`
- §6.1 null table — 2 columns; the caption cell and the "largest of the 38,000 draws" cell were edited in place, both still 2 cells
- §7.1 metadata table — 2 columns (`| | |` header); the three added rows have exactly 2 cells each

---

Docs only. No code, no `spec/`, no `.beads` database paths. Both beads carry a
dated note recording what landed, what was verified, and what was deliberately
left.
