### PR TITLE
docs(hicasso): correct the in-page clock verdicts and the HD-008 donor status (rf2-8nqsl, rf2-ph85f)

### DIFF
--- a/docs/design/hicasso/studio/the-clock-behind-the-published-rows.md
+++ b/docs/design/hicasso/studio/the-clock-behind-the-published-rows.md
@@ -329,16 +329,52 @@ and neither is the corrected clock**, which has no donor bar for this row (see
 §3). A published row sitting 17.5% off parity, on a witness whose two halves
 split this far apart, is not safe to quote without the check.
 
+**The outstanding check is a ten-commits-per-window narrow row on raw
+`TaskDuration`, and naming the clock is not pedantry.** `rf2-ph85f` was filed
+asking for that row on "the frame-inclusive instrument", which is the label this
+page then wore for `taskNet` — the clock that reads the frame with the row's own
+script billed away, and the clock that produced the `1.0062×` struck above.
+Taking the check on it would re-run the error rather than close it. The row needs
+the box either way (§3: no dataset survives, and the corrected clock has no
+`uix-subs ÷ reagent-subs` donor bar for `narrow`), so nothing here is a
+recomputation and nothing here manufactures one.
+
 **`M2 mount 1.0601×` *(diagnostic)* — unchanged in status.** It sits on the
 100 µs clamp and was never quotable against the bar.
 
-**The HD-008 donor rows — EXPOSED, UNMEASURED.** They are in-page by §1 and they
-publish margins (`donor-r1/reagent` 1.333–1.473, `donor-fh/uix` 1.358–1.746).
-Their comparisons are mostly *between* arms on the same React-hook spine, which
-plausibly split their work across the frame boundary more alike than Reagent and
-UIx do — but *plausibly* is not measured. The bounded check is to add the donor
-arms to the corrected clock's harness and re-read the `M` and `U` mount rows on
-raw `TaskDuration`: about one run per row per arm-set at the cost recorded in §6.
+**The HD-008 donor rows — the mount half is now MEASURED, and this section's
+conjecture held.** They were in-page by §1 and they published margins
+(`donor-r1/reagent` 1.333–1.473, `donor-fh/uix` 1.358–1.746). This page asked for
+a bounded check — add the donor arms to a harness reading raw `TaskDuration` and
+re-read the `M` and `U` mount rows — and reasoned that these comparisons are
+mostly *between* arms on the same React-hook spine, so they plausibly split their
+work across the frame boundary more alike than Reagent and UIx do. **`rf2-2rtt6.31`
+took that check** on a purpose-built instrument pair (`hd8_clock_app.cljs` /
+`hd8_clock_run.cjs`), landed on `main` as `1ac48c4a0b`, and published it at
+[the HD-008 donor page's re-take](hd8-composed-donor-arm.md#the-re-take-on-the-current-tree-rf2-2rtt631).
+Three things came back.
+
+- **The conjecture is upheld, with a number on it.** On the same samples the
+  in-page window overstates the donor-vs-UIx margin by **~8–12%** and overstates
+  UIx's advantage over Reagent — real, and one to two orders of magnitude short
+  of the hundreds of points the Reagent-against-UIx rows split by. Same-spine
+  arms do divide script against frame alike; that is now measured rather than
+  assumed.
+- **The published deficit against stock Reagent does not reproduce.** Every
+  `donor / Reagent-path` range on the clock of record straddles 1.0, so the
+  1.333–1.473× (`M`) and 1.448–1.542× (`U`) margins are withdrawn as magnitudes
+  on that clock. It is a *thinner* result than it looks: replaying the driver's
+  current `verdict()` over the committed datasets exits `5`, five of the six
+  clock-of-record rows missed their positive control, and only `reagent-U`
+  carries the non-reproduction unaided.
+- **The write half is refused, not taken.** No bulk or narrow magnitude is
+  published on the clock of record for these rows (`rf2-d2tzk`, `rf2-7iqb5`).
+
+**What remains in-page here is `donor-fh`.** That arm was deliberately left out
+of the re-take — it is `rf2-2rtt6.29`'s subject, and including it would have
+changed `k` for a comparison that bead does not make — so `donor-fh/uix`
+1.358–1.746 is still a `flushSync`-window margin and is the one HD-008 family
+this audit's finding still reaches.
 
 ## 5. What could not be re-taken, and why
 
@@ -438,7 +474,7 @@ in this programme:
 | what | reading | door | class |
 |---|---|---|---|
 | the in-page column | `performance.now()` around the arm's drain | in-page | script, to where `flushSync` returns |
-| the second column | `TaskDuration − DevToolsCommandDuration` (`taskNet`) | `page.evaluate` → `Runtime.callFunctionOn`, `22b53abe9e…:433` | **frame only** — the command billed the arm's script away |
+| the second column | `TaskDuration − DevToolsCommandDuration` (`taskNet`) | `page.evaluate` → `Runtime.callFunctionOn`, at the `clock_run.cjs` blob `22b53abe9e…:433` | **frame only** — the command billed the arm's script away |
 | what supersedes it | raw `TaskDuration` | same door; the subtraction is simply not performed | script **and** frame |
 
 The door is read from the driver at the blob above, not from the prose around

--- a/docs/design/hicasso/studio/the-clock-behind-the-published-rows.md
+++ b/docs/design/hicasso/studio/the-clock-behind-the-published-rows.md
@@ -30,10 +30,13 @@ while the pure-React control arms standing in the same rounds divide it by
 **−12.5% to +7.9%** — because `floor` and `ctl-2x` are the two arms whose script
 is small and roughly proportional to their frame. That separation is real and it
 reproduces; the mechanism first attached to it does not. And it does not land
-evenly across the record. **`M1 mount 1.0150×` is robust**: `taskNet` puts the
+evenly across the record. **`M1 mount 1.0150×` survives**: `taskNet` puts the
 same components at `1.0110×` and raw `TaskDuration` at `1.0011×` — both inside
-the published interval, the second 0.2% off the point estimate. **`bulk broad
-0.6291×` is not**: the in-page window reproduces the published figure at
+the published interval, the second 0.2% off the point estimate. Read that as
+corroboration of the row's *parity verdict* and not of the row: no harness has
+read `p0_converge_app`'s own schedule past `flushSync`, and §4 says what that
+does and does not license. **`bulk broad 0.6291×` does not survive**: the in-page
+window reproduces the published figure at
 `0.6924×` on the same samples, and ~~`1.0509×` — parity~~ is a **frame-only**
 figure, superseded by the re-take's **`0.8602×`** [0.7709 – 0.9058] on raw
 `TaskDuration` ([bulk broad, re-taken](bulk-broad-re-taken.md)). The row's
@@ -134,13 +137,60 @@ round. That normalisation is load-bearing for a different fault — the segment
 seam, which this audit's runs read at **31.9%** in one round (`floor` at 3.348 ms
 in the Reagent segment against 4.406 ms in the UIx segment) — and it is exactly
 why `rf2-cvvb7` matters. But it gives no protection at all against the window
-boundary, because the floor divides out of both legs:
+boundary.
 
-> `(U/F) ÷ (R/F) = U/R` under either clock.
+> ### THIS SECTION FIRST PUBLISHED THE WRONG IDENTITY, AND IT MATTERED
+>
+> It said the floor *divides out of both legs* — `(U/F) ÷ (R/F) = U/R` under
+> either clock — and drew the conclusion that the published number is the
+> substrate arms' quotient. **The two floors are not one value.** The numerator
+> is normalised in the UIx segment and the denominator in the Reagent segment
+> ([`p0_converge_app.cljs`'s `ratios-of`](../../../../implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs),
+> whose own docstring says *every ratio against the floor measured in THAT
+> segment of THAT round*; the same shape in this audit's driver, whose
+> `crossSegment` takes a numerator segment and a denominator segment and
+> normalises inside each). So the identity is
+>
+> > `(U/F_U) ÷ (R/F_R) = (U/R) × (F_R/F_U)`
+>
+> and the seam this section measured at 31.9% **enters the published statistic
+> instead of dividing out of it**. The floor is not the arm that cancels; it is
+> the arm that contributes a second term.
+>
+> The identity travelled: [the candidate's clock §6.1](the-candidates-clock.md#61-the-seam-measured-against-load)
+> quotes it back and carves out an exception for "the converged witness, whose
+> arms share one segment". That witness has two segments and two floors, so the
+> exception is empty. `rf2-es04f` owns correcting it there.
 
-So the published number is the substrate arms' quotient, and it inherits their
-error in full. The one arm whose reading is nearly instrument-independent — the
-pure-React floor — is the one arm that cancels.
+**The conclusion survives the correction and the reasoning does not, so both are
+stated.** What the section set out to establish — that floor normalisation is no
+defence against the window boundary — still holds, and now holds for a reason it
+can point at: the substrate arms' quotient `U/R` is carried whole, and a seam
+factor is carried beside it. The window-boundary *comparison* between this page's
+two clocks is also largely undisturbed, because `F_R/F_U` is formed from the floor
+arm — pure React, the class §3 measures splitting by under 13% between the clocks
+where the substrate arms split by hundreds of points — so the factor is of similar
+size under either clock and mostly cancels *between* them. It does not cancel
+*within* either clock's magnitude, and that is the part the original text got
+backwards. That much is an inference from the class's measured behaviour and not
+a measurement of `F_R/F_U` itself, which needs the datasets §7 says are gone.
+
+**What can be said about the size of that term, and what cannot.** The estimator
+that touches neither floor — `uix-subs` p50 over `reagent-subs` p50 in the same
+round — is already published beside the normalised one for the in-page rows on
+[the converged page](p0-converged-witness-set.md#two-estimators-published-together):
+`bulk broad` 0.5939 against 0.6291, `bulk narrow` 1.1761 against 1.1754. The two
+agree on the verdict of every row and sit 5.6% and 0.06% apart on the mean, which
+bounds what the normalisation is doing to those published means — on the in-page
+clock, on those rows. **No such raw counterpart exists for this audit's two
+clocks and this page does not manufacture one.** Forming it needs the per-sample
+readings, and §7 records that no dataset from this ensemble survives; the driver's
+second estimator is un-tared rather than un-normalised, so it is not the quantity
+either. That is a run on the box, `rf2-w3yxd` owns it, and it is left as one
+rather than approximated from the absolutes quoted in the box at the top of this
+page — a single round of one row is not an ensemble. Raw readings for all three
+windows have been written since blob `84aa25d9…`, so the ensemble that closes
+this can publish both estimators off its own file.
 
 This is the mechanism the pure-React controls were never able to catch. A lane
 that certifies its instrument on `ctl-2x` alone is certifying the arm least
@@ -223,6 +273,24 @@ whose whole content is how two substrates divide script against frame, which is
 the one thing that column cannot see. It is kept rather than deleted because the
 gap between it and the in-page column *is* the measurement of the door.
 
+**The `M1` and `bulk300` ensemble means in the first two columns are
+DIRECTIONAL, by this page's own rule.** §7 states it: a run whose positive
+control refuses is directional only. `ctl-2x` passed strictly on **2 of 6** `M1`
+runs and **1 of 6** `bulk300` runs (**Controls**, below), so `0.8474×`,
+`0.6924×`, `1.0110×` and `1.0509×` each aggregate a majority of refused runs and
+none of the four is a reportable magnitude. What they carry is a direction, and a
+direction is the whole of what §4 reads off them: the in-page window puts
+`uix ÷ reagent` below parity on both rows, and every clock that looks past
+`flushSync` moves it up. The only control-valid figures either ensemble has are
+`taskNet`'s control-passing subsets — `M1` `0.9992×` over two runs, `bulk300`
+`1.0078×` over one — and a frame-only reading from one or two runs is not a bar
+row either. (`narrow` is the one row whose controls mostly held, 3 of 4, and it
+is the row that is not comparable to its published figure at all.) **A
+control-valid ensemble on the corrected clock is a run on the box, and it is left
+as one** — `rf2-w3yxd`, which would settle §2's missing raw estimator in the same
+sitting. Every magnitude this page now quotes comes from `rf2-yd52q`'s and
+`rf2-emvod`'s raw-`TaskDuration` ensembles instead, named where it appears.
+
 **`narrow` has no corrected-clock donor bar, and this page does not manufacture
 one.** `rf2-yd52q`'s ensemble ran `M1` and `bulk300` only. `rf2-emvod`'s
 seven-run ensemble does cover `narrow` on raw `TaskDuration`, but publishes
@@ -261,12 +329,15 @@ near the floor, an additive constant barely touches their quotient.
 sentence are frame-only readings, and the conclusion is unaffected: the corrected
 clock reaches `0.8602×`, which is likewise not `0.63×`.
 
-The refused runs are excluded from no conclusion drawn here because they point
-the same way as the passing ones on every row; where a magnitude is quoted the
-control-passing subset agrees with the full set (`bulk300` on `taskNet`
-`1.0078×` passing vs `1.0509×` all; `M1` `0.9992×` passing vs `1.0110×` all —
-four frame-only figures, kept because they show the refused runs are not the
-source of any conclusion).
+The refused runs are excluded from no *direction* drawn here, because they point
+the same way as the passing ones on every row, and the control-passing subset
+agrees with the full set wherever both exist (`bulk300` on `taskNet` `1.0078×`
+passing vs `1.0509×` all; `M1` `0.9992×` passing vs `1.0110×` all — four
+frame-only figures, kept because they show the refused runs are not the source of
+any conclusion). **Agreement is not standing.** It says the refusals did not
+manufacture the result; it does not make the result reportable, and the paragraph
+after the ensemble table above says which of these figures may be quoted as
+magnitudes. None of them may.
 
 ## 4. Which rows change
 
@@ -292,31 +363,47 @@ clock that sees the operation's script as well as its frame it reads `0.8602×`
 `1.0509×` above is a frame-only figure, for the reason in the box at the top of
 this page.
 
-**`M1 mount 1.0150×` [0.9820 – 1.0480] — ROBUST, and STRENGTHENED by the
-correction.** `taskNet` puts the same components at `1.0110×`, inside the
-published interval; the control-passing subset reads `0.9992×`, also inside it.
-**And the corrected clock lands closer still**: raw `TaskDuration` reads
-`1.0011×` [0.9464 – 1.0763] over `rf2-yd52q`'s eight runs, 0.2% off the
-published point estimate. The published verdict — *the interval contains 1.0, the
-mount line sits at parity, the red zone has closed* — is what a clock that sees
-the whole operation independently says, and it was already what the frame-only
-half said. Note the honest asymmetry: the cross-check's *in-page* reading for
-mount is `0.8474×`, which does **not** reproduce the published `1.0150×`, so the
-two pages are not measuring an identical quantity on this row (`clock_app`
-settles a frame between samples, which flushes Reagent's macrotask-scheduled
-disposals that `p0_converge_app` lets accumulate across a whole row). The claim
-here is therefore the weaker and safer one: **a clock that looks past `flushSync`
-lands on the published value, so the row's verdict does not depend on the window
-boundary.**
+**`M1 mount 1.0150×` [0.9820 – 1.0480] — the PARITY VERDICT is corroborated on
+three clocks; the ROW has had no comparable check.** Every reading past
+`flushSync` lands where the row does: `taskNet` puts the same components at
+`1.0110×`, inside the published interval (its control-passing subset reads
+`0.9992×`, also inside it — both directional, per §3, and both frame-only), and
+raw `TaskDuration` reads `1.0011×` [0.9464 – 1.0763] over `rf2-yd52q`'s eight
+runs, 0.2% off the published point estimate. The published verdict — *the interval
+contains 1.0, the mount line sits at parity, the red zone has closed* — is what a
+clock that sees the whole operation independently says.
 
-**`coldmount 1.0054×` [0.917 – 1.143] — ROBUST, by the same argument.** It is
-the same 901-element / 300-boundary witness at parity, taken on a second
-instrument by a second author. ~~`1.011×` is where a frame-inclusive clock puts
-that witness~~ — that figure is this page's frame-only `M1` reading rounded, and
-on the corrected clock the same witness reads `1.0011×`. Both are parity, which
-is what the row claims. Its verdict is *"strata overlap, magnitude resolved,
+**This page previously called that ROBUST and STRENGTHENED, and the inference
+does not carry.** The asymmetry it recorded is fatal to the stronger claim rather
+than a footnote on it: the cross-check's *in-page* reading for mount is
+`0.8474×`, which does **not** reproduce the published `1.0150×`. On the one clock
+where the two harnesses can be compared like for like, they disagree by sixteen
+points, because they are not measuring an identical quantity — `clock_app` settles
+a frame between samples, which flushes Reagent's macrotask-scheduled disposals
+that `p0_converge_app` lets accumulate across a whole row. A *different* protocol
+then landing at `1.0110×` and `1.0011×` past the boundary is agreement between
+two quantities, not a controlled measurement of one; it cannot show that the
+published row is independent of its own window boundary, because nothing here
+varies that boundary while holding the schedule fixed. Both frame-past readings
+come from the *same* harness, `clock_app`, so they are two clocks and not two
+witnesses of the schedule question. **What is established is the verdict and not
+the row: every instrument that has read this witness past `flushSync` puts it at
+parity, and parity is the whole of what the row claims.** The check that would
+license the stronger word is a frame-past reading on `p0_converge_app`'s own
+schedule, and §5 explains why that harness cannot be made to take one in place.
+
+**`coldmount 1.0054×` [0.917 – 1.143] — the same standing, reached by a longer
+chain and therefore held more loosely.** It is the same 901-element /
+300-boundary witness at parity, taken on a *third* instrument by a second author.
+~~`1.011×` is where a frame-inclusive clock puts that witness~~ — that figure is
+this page's frame-only `M1` reading rounded, and on the corrected clock the same
+witness reads `1.0011×`. Its verdict is *"strata overlap, magnitude resolved,
 excess mean 0.00 ms"* — a parity claim, and parity is what survives on every
-clock that has looked at it.
+clock that has looked at it. **But no clock has looked at `coldmount_app`.**
+Every frame-past figure quoted for this row is an `M1` figure carried across on
+the strength of a shared witness, so the chain is one link longer than the mount
+row's and inherits its gap: this is corroboration of a *parity verdict* by
+analogy, not a check of this harness at all.
 
 **`bulk narrow 1.1754×` — EXPOSED, NOT ADJUDICATED.** The cross-check's `narrow`
 row writes one commit per window (`k=1`) where the published row batches ten


### PR DESCRIPTION
Two beads, one page, one PR. `rf2-ph85f`'s two items are two of the four verdict
paragraphs on the page `rf2-8nqsl` owns, so they ride together with ordered
commits, smallest cleanup first.

**This is a prose/verdict-correctness pass. No measurement was taken, no driver
run, no dataset written, no published magnitude altered.** Five workers were on
this box, so any wall-clock row taken now would be invalid by construction. Every
figure quoted is a quotation of one already published on the page it cites.

The failure mode being avoided is specific: **both instruments in this programme
have been wrong, at different times.** `rf2-8nqsl` found the in-page window
mis-reads a substrate arm; `rf2-yd52q` then found the replacement was FRAME-ONLY,
near the in-page window's complement rather than its superset. So nothing below
treats "frame-inclusive" as the trustworthy label — where the page needs to name
the corrected clock it says raw `TaskDuration`, script and frame in one number,
and one edit exists purely to stop an outstanding check being re-specified on the
frame-only clock the old label pointed at.

## Which bead items were already falsified, and which were real

Both premises the brief flagged were checked at the source **before** anything was
written. Both hold, and one of them left a stale verdict on the page that had to
be corrected.

| bead · item | status | evidence |
|---|---|---|
| `rf2-ph85f` #2 — HD-008 donor rows | **ALREADY DONE** | Taken by `rf2-2rtt6.31`, PR #7378, on `main` as `1ac48c4a0b` (`git merge-base --is-ancestor` confirms). Purpose-built instrument pair `hd8_clock_app.cljs` / `hd8_clock_run.cjs`; provenance table names the clock of record as raw `TaskDuration`, frame-settled, plumb-tared. Results at `hd8-composed-donor-arm.md`. |
| `rf2-8nqsl` #4 — scope wording | **ALREADY DONE** | `rf2-aj15b`'s `afa1ff806f` rewrote the opening to "of the record as it stood on 2026-08-01", flipped the universal claim to past tense, added "That premise is now historical" and named the rows published since. Diff read. |
| `rf2-8nqsl` #1 — floor algebra | **REAL** — corrected | The doc half. The clock-runner half needed nothing (see below). |
| `rf2-8nqsl` #2 — control gate | **REAL** — narrowed | The item's own either/or; the non-measurement branch is taken. |
| `rf2-8nqsl` #3 — robustness inference | **REAL** — labels withdrawn | Restated as a verdict-level rather than row-level claim. |
| `rf2-ph85f` #1 — bulk narrow | **REAL, and LEFT** — it is a measurement | Only the clock it must be taken on is corrected. |

Neither falsified item was redone; both are recorded on their bead with the
evidence, dated.

## What changed, per bead

### `38e671f683` — `rf2-ph85f`

Section 4's HD-008 paragraph read **"EXPOSED, UNMEASURED"** over the top of a
landed re-take. That is exactly the class of error this cluster owns, so it is
restated rather than annotated:

* **the section's own conjecture is upheld, with a number on it** — the in-page
  window overstates the donor-vs-UIx margin by **~8–12%**, one to two orders short
  of the hundreds of points the Reagent-against-UIx rows split by, because these
  arms share a React-hook spine;
* **the published deficit against stock Reagent does not reproduce** — every
  `donor / Reagent-path` range on the clock of record straddles 1.0, so
  1.333–1.473× (`M`) and 1.448–1.542× (`U`) are withdrawn as magnitudes — but
  *thinly*: `verdict()` replays to exit `5`, five of six rows missed their
  control, and only `reagent-U` carries it unaided;
* **the write half is refused, not taken** (`rf2-d2tzk`, `rf2-7iqb5`).

`donor-fh` was deliberately excluded from that re-take (`hd8_clock_app`'s
`arm-ids-for` says so at the source), so `donor-fh/uix` 1.358–1.746 is the one
HD-008 family still in-page, and the paragraph now says so instead of implying the
family is settled.

Bulk narrow is **left untaken**. What is corrected is the clock it must be taken
on: `rf2-ph85f` asks for the row on "the frame-inclusive instrument", which is the
label this page wore for `taskNet` — the frame-only clock that produced the struck
`1.0062×`. Taking the check there would re-run the error rather than close it.

### `eada18505d` — `rf2-8nqsl`

**Item 1, floor algebra.** Section 2 published `(U/F) ÷ (R/F) = U/R` and concluded
the floor "divides out of both legs". The two floors are not one value —
`p0_converge_app`'s `ratios-of` normalises *against the floor measured in THAT
segment of THAT round*, `row-record`'s `rz` divides the UIx-segment ratio by the
Reagent-segment ratio, and this audit's driver normalises inside each of its three
segments the same way. The identity is `(U/F_U) ÷ (R/F_R) = (U/R) × (F_R/F_U)`, so
the 31.9% seam **enters** the statistic. The section's conclusion survives, now
for a reason it can point at; the old text is quoted so a reader who cited it can
see what moved. The cross-clock *comparison* is separately argued to be largely
undisturbed, and that argument is explicitly marked an inference from the
pure-React class's measured behaviour rather than a measurement of `F_R/F_U`.

**The clock runner needed nothing, and this was checked rather than assumed.**
`clock_run.cjs`'s `BAR_PAIRS` comment already states the arithmetic correctly —
*"each donor divided by the floor measured in its own segment of that round, then
one quotient over the other"* — and carries no cancellation claim. It is also held
by `rf2-7iqb5` and was not touched.

**Item 2, control gate.** `0.8474×`, `0.6924×`, `1.0110×` and `1.0509×` each
aggregate a majority of refused runs (`ctl-2x` strict on 2 of 6 `M1`, 1 of 6
`bulk300`). They are now marked DIRECTIONAL where they are presented, under the
page's own section 7 rule; the only control-valid figures are named for what they
are (`taskNet` subsets over two runs and one); the "refused runs are excluded from
no conclusion" defence is narrowed to *direction*, with agreement distinguished
from standing. `narrow`'s 3-of-4 is called out rather than swept in with them.

**Item 3, robustness inference.** `M1 mount` was ROBUST **and STRENGTHENED** on
the strength of a frame-past reading landing at the published value. It does not
carry: the cross-check's in-page reading is `0.8474×` against the published
`1.0150×`, so on the one clock where the two harnesses compare like for like they
disagree by sixteen points, and **both** frame-past readings come from the same
harness. It is restated as a corroborated **parity verdict** with no comparable
check on the **row**. `coldmount` is held more loosely still — no clock has looked
at `coldmount_app` at all, and every frame-past figure it quotes is an `M1` figure
carried across. The opening paragraph is restated to match, so the stronger word
is not what a reader meets first.

## Left as measurements, filed rather than approximated

* **`rf2-w3yxd`** — a control-valid corrected-clock ensemble that also publishes
  the raw, un-normalised cross-segment estimator beside the normalised one, **and
  retains its dataset**. This absorbs item 1's "publish the raw quotient" and item
  2's "obtain a sufficient control-valid ensemble". No dataset from this ensemble
  survives (section 7), and the driver's `raw` flag is *un-tared* rather than
  *un-normalised*, so it is not the quantity either — nothing here is a
  recomputation and no proxy was manufactured from the single-round absolutes in
  the page's own box. Sequenced behind `rf2-7iqb5`.
* **`rf2-es04f`** — `the-candidates-clock.md` section 6.1 quotes the same false
  identity back and carves out an empty exception ("the converged witness, whose
  arms share one segment" — that harness has two segments and two floors). The
  page is held by a live sibling cluster, so it is filed and sequenced rather than
  edited; this page carries a pointer at it.
* **Item 3's comparable check is *not* filed as work.** A frame-past reading on
  `p0_converge_app`'s own schedule would settle it, and section 5 already
  establishes that harness cannot take one in place — adding a settle changes what
  the row measures, so the result is a new row and not a re-take.

## Provenance: one pre-existing token accompanied, none re-pinned

Touching this page makes the PR responsible for its whole citation surface, and
one pre-existing token failed: section 7's door table wrote `22b53abe9e…:433` with
nothing on its line saying what it was, so the gate read it as an unresolvable
head. It is a **blob** — `clock_run.cjs`, named as such in the blob table three
lines above — and it is now labelled that way. **No SHA is re-pinned and no anchor
is invented**; the line is not one this PR otherwise touches (the diff over
section 7 is empty apart from this cell).

## Hand verification

`mkdocs build --strict` does **not** cover `docs/design/**`, so it is not
nominated. Nothing validates this tree's tables or rendering, so both were checked
by hand:

* **Heading anchors.** Three links added, each resolved against the target file's
  heading text: `hd8-composed-donor-arm.md#the-re-take-on-the-current-tree-rf2-2rtt631`
  to `## The re-take on the current tree (rf2-2rtt6.31)`;
  `p0-converged-witness-set.md#two-estimators-published-together` to
  `### Two estimators, published together`;
  `the-candidates-clock.md#61-the-seam-measured-against-load` to
  `### 6.1 The seam, measured against load` (already used elsewhere on this page).
  One new heading is added (the section 2 correction box, an H3 in a blockquote,
  matching the page's existing convention); nothing links to it. The only inbound
  anchor link to this page anywhere in `docs/` is
  `bulk-broad-re-taken.md#4-which-rows-change`, and no heading was renamed.
* **Table column counts.** Exactly one table cell is edited — section 7's
  `| what | reading | door | class |` table, 4 columns in header, separator and
  all three body rows. Read by hand, then cross-checked mechanically over the
  whole page: 5 tables at 4 / 4 / 5 / 2 / 4 columns, **0 mismatches**.

## Quality gates

Run in the worker worktree, foreground, to completion. Never piped — each
redirects to a worktree-local log and echoes the runner's own exit code, because a
pipeline's status is its last command's and a red runner would read green through
`tail`.

| command | result | exit code |
|---|---|---|
| `python scripts/check_doc_slugs.py` | clean, no findings | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | 1 file, 1 cited pin — **1 landed, 0 stranded, 0 unresolvable** | **0** |
| `sh scripts/test-fast-pr.sh` | docs lane classified in and run (`docs=true jvm=false node=false`); README link/anchor validator, docs-corpus anchor validator and the provenance-pin gate all clean; every self-test suite passed (58 anchor, 26 provenance, and the rest) | **0** |

The provenance gate first ran **exit 1** on the pre-existing `22b53abe9e…:433`
token described above; it is **0** after that token was accompanied. Both figures
are reported rather than only the green one.

GitHub Actions is in a major outage, so CI may not run on this PR — the local exit
codes above are the evidence.
