### PR TITLE
fix(hicasso): the changed-set control must fail closed on an inverted signal (rf2-7iqb5)

### DIFF
--- a/docs/design/hicasso/studio/a-control-that-differences-the-constant-away.md
+++ b/docs/design/hicasso/studio/a-control-that-differences-the-constant-away.md
@@ -23,7 +23,9 @@ moving the control anywhere it would not matter
 
 The control is nonetheless real, and it is shown **refusing** under a
 falsification in which every other gate passes
-([§6](#6-the-control-is-shown-failing)).
+([§6](#6-the-control-is-shown-failing)) — under a rule since tightened, because
+differencing the constant away also costs the statistic its
+[**sign**](#the-band-is-necessary-and-not-sufficient).
 
 Owner: the operator-owned standard bead `rf2-2rtt6.1`; this page `rf2-7iqb5` and
 `rf2-5xrcd`.
@@ -233,13 +235,55 @@ probes follow the actual dirty set, and a cold cell is probed as well as two hot
 ones), canonical DOM identical across all 15 non-control arms, band 10.9%. The
 control was the only gate that fired, which is the whole claim.
 
-**Offline.** `node clock_run.cjs --selftest` runs eleven fixtures with no browser
-and is fatal in every run. They include: superlinear work refuses; an arm
+**Offline.** `node clock_run.cjs --selftest` runs fourteen fixtures with no
+browser and is fatal in every run. They include: superlinear work refuses; an arm
 declaring 200 while rendering 140 refuses; a degenerate denominator refuses
 rather than passing quietly; one nonlinear block in nine refuses, so eight good
-blocks cannot vouch for it; a large additive constant does *not* move the
-statistic; a multiplicative block perturbation does not either; and the doubling
-control is biased low on a world the three-point one reads exactly.
+blocks cannot vouch for it; a page on which more dirty work reads *faster*
+refuses ([below](#the-band-is-necessary-and-not-sufficient)); a large additive
+constant does *not* move the statistic; a multiplicative block perturbation does
+not either; and the doubling control is biased low on a world the three-point one
+reads exactly.
+
+### The band is necessary and not sufficient
+
+The first eleven fixtures adjudicated a block on its ratio alone, and that is a
+gate with a hole in it. **Cancelling the constant costs the statistic its sign.**
+`(T(2D) − T(ε)) / (T(D) − T(ε))` is unchanged when *both* differences flip, so a
+page on which more dirty work reads **faster** lands on exactly the same number
+as one on which it reads slower.
+
+It is not a corner case. For `T(d) = 10 − 0.006d`:
+
+| point | time | difference | value |
+|---|---|---|---|
+| `T(1)` | 9.994 ms | numerator `T(200) − T(1)` | **−1.194 ms** |
+| `T(100)` | 9.400 ms | denominator `T(100) − T(1)` | **−0.594 ms** |
+| `T(200)` | 8.800 ms | quotient | **2.0101×** |
+
+That is the prediction to four places, dead centre of the `[1.5076 – 2.5126]`
+band. The control passed on a page that had inverted underneath it.
+
+So each block must also carry the **monotonicity the control's own premise
+asserts** — `T` rising with `d` — and it is checked on the terms the statistic is
+built from: both differences finite and **strictly positive**. `≥ 0` would not
+do. A difference of exactly zero is a denominator gone to noise, or a numerator
+saying the top two points are indistinguishable; neither is a reading, and a
+control that admits one is admitting an arm it cannot see. The per-block rule is
+unchanged and still strict — one inverted block refuses the row exactly as one
+out-of-band block does — and an empty block set is refused rather than passing on
+a vacuous `every`.
+
+The fixture asserts **both halves**: that the band-only rule the driver shipped
+with admits this page, and that the shipped rule refuses it, on the sign rather
+than on the number. Two more fixtures cover the boundaries — negative or
+exactly-zero numerator, ditto denominator, an arm that read nothing — and one
+countercheck asserts the gate refuses nothing healthy, so `ctl-2x`'s bias, the
+superlinear world and the declaring-200-rendering-140 world are all still refused
+for their own reasons rather than swept up by this one.
+
+**None of the figures on this page moves.** The gate can only turn a pass into a
+refusal, and all three rows already refused.
 
 ### What it cannot catch, asserted rather than described
 
@@ -296,15 +340,23 @@ Two further constraints on any future attempt:
 | `implementation/freehand/test/re_frame/bench/hicasso/clock_views.cljs` | `7e48dbc0b3a974cd61a5c61e606333848877a31f` |
 
 These are the blobs **that produced the figures above**, and they are what a
-reproduction needs. Both harness files have since taken **comment-only**
-corrections — an over-stated negative-denominator count, a stale comment block
-left from the abandoned 3,000-cell design — and now hash
-`c5e8801569715e27c5a1ecb543badb88182063fc` and
-`0d54998103649cd8479d3a73eca9e8745a026a8c`.
-Behaviour is unchanged and the adjudicators' fixtures were re-run against them,
-but the table above names the blobs that **ran** rather than the blobs that
-**ship**, because those are different questions and only the first is
-provenance.
+reproduction needs. The table names the blobs that **ran** rather than the blobs
+that **ship**, because those are different questions and only the first is
+provenance — the shipping files have moved since, and they will move again.
+
+Two rounds of change so far. The first was **comment-only**: an over-stated
+negative-denominator count and a stale comment block left from the abandoned
+3,000-cell design. The second, `rf2-7iqb5`, is **behavioural** — the
+[sign gate](#the-band-is-necessary-and-not-sufficient), plus the last three
+diagnostics
+that still described the 3,000-cell arms. As of it, `clock_app.cljs` hashes
+`f9b31f14a9ed922beb416a436555f436fb2aa6c0` and `clock_run.cjs`
+`1aa4f3e9f4f20230596c71051a52d72facc12cff`.
+
+**No figure above moves under either round.** The sign gate can only convert a
+pass into a refusal, and all three rows already refused; the `LayoutDuration`
+column is quoted as a mean and a range rather than a verdict, so it does not move
+either. The adjudicators' fixtures were re-run against both.
 
 Commit `ef30c639162db98492cf0ebb53f00d411deb4bc4` — authored, and rebase-merged,
 so it is on no branch and **will not resolve in a fresh clone**. It landed on

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
@@ -335,6 +335,13 @@ function controlVerdict(predicted, perRound, slack) {
 //
 //     R3 = (T(d2) - T(d0)) / (T(d1) - T(d0))  ->  (d2 - d0) / (d1 - d0)
 //
+// AND THE RATIO IS ADJUDICATED ONLY ON A BLOCK WHOSE TWO DIFFERENCES ARE BOTH
+// FINITE AND POSITIVE. Cancelling the constant costs the statistic its sign:
+// flipping BOTH differences leaves the quotient alone, so `T(d) = 10 - 0.006d`
+// — a page where more dirty work reads FASTER — reads the predicted 2.0101x.
+// The band is a necessary condition; the monotonicity the control's premise
+// asserts is the other half, and it is checked per block (rf2-7iqb5).
+//
 // Both perturbations this lane has measured die in it:
 //
 //   * an ADDITIVE per-sample constant cancels in each difference;
@@ -425,10 +432,14 @@ function ctl3Verdict(rounds, plan, slack) {
   if (arms.length < 3) return null;
   const [a0, a1, a2] = arms;
   const [d0, d1, d2] = arms.map((a) => dirty[a]);
-  // The witness is a fourth point BELOW the control's range and is never a
-  // term in the statistic. It exists to re-measure, every run, the
-  // saturating paint term that refuted the first build of this control —
-  // see `clock-app/ctl3-witness-dirty`.
+  // The witness would be a fourth point BELOW the control's range, and it is
+  // never a term in the statistic: it exists to re-measure, every run, the
+  // saturating paint term that refuted the first build of this control.
+  // NO SHIPPED ARM DECLARES ITSELF ONE — `clock-app/ctl3-arms` emits the
+  // three control points and nothing else — so `wArm` is null on every run
+  // and the witness column of the regime table reads null. Read here rather
+  // than deleted because the page can declare one without the driver
+  // changing; a reader of a null witness column is reading its absence.
   const wArm = witness.length ? witness[0].id : null;
   const wD = witness.length ? witness[0].dirty : null;
   const predicted = (d2 - d0) / (d1 - d0);
@@ -465,10 +476,42 @@ function ctl3Verdict(rounds, plan, slack) {
       });
     }
   }
+  // THE BAND IS NECESSARY AND NOT SUFFICIENT: the quotient cannot see its own
+  // sign. `(T(d2) - T(d0)) / (T(d1) - T(d0))` is unchanged when BOTH
+  // differences flip, so a page on which MORE dirty work reads FASTER lands
+  // on exactly the same number as one on which it reads slower. It is not a
+  // corner: for `T(d) = 10 - 0.006d` the three times are 9.994 / 9.400 /
+  // 8.800 ms, the numerator is -1.194 ms, the denominator -0.594 ms, and the
+  // quotient is 2.0101x — the prediction, to four places. A band alone
+  // admits it.
+  //
+  // So each block must also carry the MONOTONICITY the control's own premise
+  // asserts — `T` rising with `d` — and it is checked as the two differences
+  // being finite and STRICTLY POSITIVE, which is that premise restated on
+  // the terms the statistic is actually built from. Fail closed: a block
+  // whose signal is absent (0), backwards (< 0) or unreadable (NaN) is
+  // refused before its ratio is looked at, and the per-block rule stays
+  // strict — one inverted block refuses the row exactly as one out-of-band
+  // block does. An empty block set is refused for the same reason: a
+  // vacuous `every` is not a control holding.
+  const signBad = blocks.filter(
+    (b) => !(Number.isFinite(b.num) && Number.isFinite(b.den) && b.num > 0 && b.den > 0)
+  );
+  const sign = {
+    ok: signBad.length === 0 && blocks.length > 0,
+    bad: signBad.length,
+    of: blocks.length,
+    blocks: signBad.map((b) => ({ seg: b.seg, round: b.round, num: b.num, den: b.den })),
+  };
   const v = controlVerdict(predicted, per, slack);
   const marg = (k) => band(blocks.map((b) => b.marginalUs[k]).filter(Number.isFinite));
   return {
     ...v,
+    ok: v.ok && sign.ok,
+    rule:
+      'strict — EVERY block inside the band, AND every block\'s numerator and denominator ' +
+      'finite and strictly positive',
+    sign,
     arms: { eps: a0, d: a1, twoD: a2, witness: wArm },
     dirty: { [a0]: d0, [a1]: d1, [a2]: d2 },
     witnessDirty: wD,
@@ -669,6 +712,92 @@ function ctl3SelfTest() {
     name: 'additiveConstant recovers c from a doubling ratio (rf2-emvod M1: 5.695 ms, 1.8173x -> 1.040 ms)',
     ok: Math.abs(additiveConstant(5.695, 1.8173) - 1.0405) < 0.001 &&
       Math.abs(additiveConstant(Wf + cf, ctl2xOnSameWorld) - cf) < 1e-9,
+  });
+
+  // 9. THE SIGN-INVERTED WORLD, which the band alone cannot refuse. `T(d) =
+  //    10 - 0.006d` is a page on which MORE dirty work reads FASTER — the
+  //    control's premise inverted, and the strongest possible statement that
+  //    the instrument is not measuring what it thinks it is. The quotient is
+  //    blind to it, because flipping BOTH differences leaves their ratio
+  //    alone: 8.800 - 9.994 = -1.194 over 9.400 - 9.994 = -0.594, which is
+  //    2.0101x to four places and lands dead centre of the band.
+  //
+  //    So the fixture asserts BOTH halves. Under the band-only rule — which
+  //    is `controlVerdict` on the same per-block readings, i.e. the exact
+  //    rule this driver shipped with — it PASSES. Under the shipped rule it
+  //    REFUSES, and refuses on the sign rather than on the number.
+  const decreasing = ctl3Verdict(synth((d) => 10 - A * d), plan, CONTROL_SLACK);
+  const bandOnlyOnDecreasing = controlVerdict(predicted, decreasing.perRound, CONTROL_SLACK);
+  checks.push({
+    name: 'a DECREASING linear page (more dirty work reads FASTER) REFUSES — though the band alone admits it',
+    ok:
+      // the band alone admits it, and admits it exactly: this is the defect,
+      // asserted rather than described.
+      bandOnlyOnDecreasing.ok &&
+      exact(decreasing.measured.mean) &&
+      // both differences are negative, which is the thing the ratio hid
+      decreasing.blocks.every((b) => b.num < 0 && b.den < 0) &&
+      // and the shipped rule refuses every one of the nine blocks
+      !decreasing.ok &&
+      !decreasing.sign.ok &&
+      decreasing.sign.bad === 9 &&
+      decreasing.sign.of === 9,
+  });
+
+  // 9b. THE SIGN-DEGENERATE BOUNDARIES, one per way a difference can fail to
+  //     be a positive reading. Each is otherwise unremarkable — three of the
+  //     four land a finite ratio, and the first two land one inside the band
+  //     — so each is a case the band alone would have waved through.
+  //
+  //     `>= 0` would not do for the threshold. A difference of exactly zero
+  //     is a denominator that has gone to noise (case 6's failure mode with
+  //     a numerator still attached) or a numerator saying the top two points
+  //     are indistinguishable; neither is a reading, and a control admitting
+  //     one is admitting an arm it cannot see.
+  const at = (m) => (d) => (d in m ? m[d] : 0); // an explicit three-point table
+  const negNum = ctl3Verdict(synth(at({ 1: 5.0, 100: 5.6, 200: 3.8 })), plan, CONTROL_SLACK);
+  const negDen = ctl3Verdict(synth(at({ 1: 5.0, 100: 4.7, 200: 4.4 })), plan, CONTROL_SLACK);
+  const zeroNum = ctl3Verdict(synth(at({ 1: 5.0, 100: 5.6, 200: 5.0 })), plan, CONTROL_SLACK);
+  const zeroDen = ctl3Verdict(synth(at({ 1: 5.0, 100: 5.0, 200: 6.2 })), plan, CONTROL_SLACK);
+  const nanArm = ctl3Verdict(synth((d) => (d === 100 ? NaN : A * d + C)), plan, CONTROL_SLACK);
+  checks.push({
+    name: 'sign-degenerate blocks REFUSE: negative numerator, negative denominator, either exactly zero, or unreadable',
+    ok:
+      // numerator negative, denominator positive: T rises then falls back
+      // below T(eps). The ratio is finite and NEGATIVE.
+      !negNum.ok && negNum.sign.bad === 9 && negNum.blocks.every((b) => b.num < 0 && b.den > 0) &&
+      // denominator negative, numerator negative-but-larger: a finite ratio
+      // INSIDE the band, which is the sign-inverted defect in another shape.
+      !negDen.ok && negDen.sign.bad === 9 &&
+      Math.abs(negDen.measured.mean - r4(0.6 / 0.3)) < 5e-5 &&
+      // numerator exactly zero: T(2D) indistinguishable from T(eps)
+      !zeroNum.ok && zeroNum.sign.bad === 9 && zeroNum.blocks.every((b) => b.num === 0) &&
+      // denominator exactly zero: the ratio is not a number at all
+      !zeroDen.ok && zeroDen.sign.bad === 9 && zeroDen.blocks.every((b) => b.den === 0) &&
+      // an arm that read nothing at all
+      !nanArm.ok && nanArm.sign.bad === 9,
+  });
+
+  // 9c. AND THE GATE IS NOT A BLANKET REFUSAL. A rule that fails closed is
+  //     worth nothing if it also refuses the healthy world — the whole
+  //     failure mode this lane keeps finding is a gate that no longer
+  //     discriminates. Every fixture above that PASSES must still pass, and
+  //     must pass with its sign check clean; and the vacuous case — no
+  //     blocks at all, where `every` returns true over an empty list — must
+  //     not read as a control holding.
+  const noBlocks = ctl3Verdict([], plan, CONTROL_SLACK);
+  checks.push({
+    name: 'the sign gate does not refuse a healthy world, and an EMPTY block set is not a pass',
+    ok:
+      lin.ok && lin.sign.ok && lin.sign.bad === 0 &&
+      mult.ok && mult.sign.ok &&
+      widerV.ok && widerV.sign.ok &&
+      // and the refusals above are still refusals FOR THEIR OWN REASON: the
+      // superlinear and sabotage worlds rise monotonically and are refused
+      // by the band, not swept up by the new rule.
+      sup.sign.ok && !sup.ok &&
+      sab.sign.ok && !sab.ok &&
+      !noBlocks.ok && noBlocks.sign.of === 0,
   });
 
   return { checks };
@@ -1550,12 +1679,14 @@ function report(out) {
   const ctl3 = ctl3Verdict(roundsTask, armPlan, CONTROL_SLACK);
   const ctl3Net = ctl3 ? ctl3Verdict(rounds, armPlan, CONTROL_SLACK) : null;
   const ctl3Layout = ctl3 ? ctl3Verdict(roundsLayout, armPlan, CONTROL_SLACK) : null;
-  // THE CONTROL'S ARMS MUST BUILD ONE PAGE AS EACH OTHER. They are exempt
-  // from the cross-arm canonical-DOM gate because their page is not the
-  // floor's — that is the price of the page size the signal needed — so the
-  // guarantee is re-established where it still means something: four arms
-  // compared only with one another have to be four renderings of the same
-  // page, and a row whose control arms disagree is refused.
+  // THE CONTROL'S ARMS MUST BUILD ONE PAGE AS EACH OTHER, and this checks it
+  // directly rather than by inference. They build the FLOOR's own page — the
+  // 3,000-boundary page of their own was tried, lost, and is recorded in
+  // `clock-app/ctl3-dirty` — so they are ALSO inside the cross-arm
+  // canonical-DOM gate above, and this is a second, tighter check rather
+  // than the only one: arms compared only with one another have to be
+  // renderings of the same page whatever the cross-arm gate says, and a row
+  // whose control arms disagree is refused.
   let ctl3Parity = null;
   if (ctl3) {
     const ids = new Set([...Object.keys(ctl3.dirty), ctl3.arms.witness].filter(Boolean));
@@ -1630,10 +1761,12 @@ function report(out) {
       const ordered = ctl3.signal.interceptMs.mean > constants.c2x.mean;
       console.log(
         `;;   c ORDER  c(3pt) ${ctl3.signal.interceptMs.mean.toFixed(4)} ms vs c(2x) ` +
-          `${constants.c2x.mean.toFixed(4)} ms, both tared — and they are constants of DIFFERENT PAGES, so ` +
-          `this is the weak form of the check and is labelled as such: c(3pt) carries React's whole-tree ` +
-          `walk over 3,000 elements and c(2x) carries only what survives doubling a 300-element page, so ` +
-          `c(3pt) > c(2x) is expected and its failure would be a real signal while its success proves little. ` +
+          `${constants.c2x.mean.toFixed(4)} ms, both tared — and they are recovered by DIFFERENT ` +
+          `CONSTRUCTIONS, so this is the weak form of the check and is labelled as such: c(3pt) is the ` +
+          `intercept of a fit along the DIRTY-SET axis on the floor's own ${cells}-boundary page, so it ` +
+          `carries React's whole-tree reconciliation walk in full, while c(2x) is recovered by inverting a ` +
+          `PAGE doubling and the walk scales with the page, so it is excluded there. c(3pt) > c(2x) is ` +
+          `expected on that reasoning and its failure would be a real signal while its success proves little. ` +
           (usable
             ? `${ordered ? 'AS PREDICTED.' : 'NOT AS PREDICTED — worth chasing.'}`
             : `WITHHELD: c(2x) ranges to ${constants.c2x.min.toFixed(4)} ms, and a negative recovered constant ` +
@@ -1665,6 +1798,28 @@ function report(out) {
         `;;            layout is the half of a commit that MUST scale with the dirty set; paint is the half ` +
           `that stops scaling once the damage region covers the viewport. A control that holds on layout and ` +
           `refuses on task is reporting the PAGE, not the clock.`
+      );
+    }
+    // THE SIGN, BEFORE THE NUMBER. The quotient is unchanged when both
+    // differences flip, so a band alone would admit a page on which MORE
+    // dirty work reads FASTER at exactly the predicted ratio. A block whose
+    // numerator or denominator is not a finite positive reading is refused
+    // here, and a report that did not say so would print a FAIL beside an
+    // in-band number with no reason attached.
+    if (!ctl3.sign.ok) {
+      const eg = ctl3.sign.blocks
+        .slice(0, 3)
+        .map((b) => `${b.seg} r${b.round} num ${b.num} ms / den ${b.den} ms`)
+        .join('; ');
+      console.log(
+        `;;   SIGN     REFUSED ${ctl3.sign.bad} of ${ctl3.sign.of} blocks — a numerator or denominator ` +
+          `that is not finite and strictly positive is not a reading of a rising cost` +
+          (eg ? `: ${eg}` : ` (no blocks at all)`)
+      );
+      console.log(
+        `;;            the quotient cannot see this by itself — flipping BOTH differences leaves their ` +
+          `ratio alone, so a page where more dirty work reads FASTER lands on the prediction. The band is ` +
+          `a necessary condition, never a sufficient one.`
       );
     }
     console.log(
@@ -2277,8 +2432,9 @@ async function main() {
   // launched. `ctl3SelfTest` is the one that matters for this driver's new
   // control: its cases are the REFUSALS — superlinear work, an arm that does
   // not do what it declares, a degenerate denominator, one bad block out of
-  // nine — stated as fixtures, plus the case that shows the doubling control
-  // failing on a world the three-point one passes.
+  // nine, and a page on which more dirty work reads FASTER at exactly the
+  // predicted ratio — stated as fixtures, plus the case that shows the
+  // doubling control failing on a world the three-point one passes.
   const c3st = ctl3SelfTest();
   const badCtl3 = c3st.checks.filter((c) => !c.ok);
   for (const c of c3st.checks) console.error(`[clock] ctl3 self-test  ${c.ok ? 'ok  ' : 'FAIL'}  ${c.name}`);
@@ -2547,9 +2703,10 @@ async function main() {
   if (badCtl3Parity.length > 0) {
     console.error(
       `[clock] FAILED: the three-point control's own arms built DIFFERENT PAGES on: ` +
-        `${badCtl3Parity.map((o) => o.out.rowId).join(', ')}. These arms are exempt from the cross-arm ` +
-        `canonical-DOM gate because their page is not the floor's, so this is the only thing checking ` +
-        `them, and a difference of differences between two different pages is not a difference.`
+        `${badCtl3Parity.map((o) => o.out.rowId).join(', ')}. These arms build the floor's own page and ` +
+        `are inside the cross-arm canonical-DOM gate as well, so a disagreement here that the cross-arm ` +
+        `gate did not raise means the control's own arms differ from each other — and a difference of ` +
+        `differences between two different pages is not a difference.`
     );
     process.exit(1);
   }


### PR DESCRIPTION
Reopened by the merged-PR audit of #7367, which named two required fixes. Those
two are the whole scope: no timing row is re-taken (five workers share this box
today, so any wall-clock reading taken now is invalid by construction), and M1's
control is untouched — a mount has no changed-set axis, and that gap is
`rf2-jcm3p`.

## 1. The gate could pass with the signal backwards

`ctl3Verdict` admitted a block whenever `(T(200) − T(1)) / (T(100) − T(1))`
landed in band. It never asked either difference, or the fitted slope, to be
positive.

**Cancelling the additive constant costs the statistic its sign.** Flipping
*both* differences leaves their quotient alone, so a page on which more dirty
work reads **faster** lands on exactly the same number as one on which it reads
slower. The audit's counter-example is not a corner:

| point | time | difference | value |
|---|---|---|---|
| `T(1)` | 9.994 ms | numerator `T(200) − T(1)` | **−1.194 ms** |
| `T(100)` | 9.400 ms | denominator `T(100) − T(1)` | **−0.594 ms** |
| `T(200)` | 8.800 ms | quotient | **2.0101×** |

That is the prediction to four places, dead centre of `[1.5076 – 2.5126]`.

### The fixture failing under the old rule and passing under the new one

Reproduced against `HEAD`'s own `clock_run.cjs` before touching it — the
pre-change file was checked out, the decreasing-linear fixture injected, and the
driver run:

```
[demo] decreasing T(d)=10-0.006d  T(1)=9.994 T(100)=9.4 T(200)=8.8
       num=-1.194 den=-0.594  measured=2.0101x  band=[1.5076,2.5126]  ok=true
[clock] ctl3 self-test  FAIL  a DECREASING linear page (more dirty work reads FASTER) REFUSES
[clock] the three-point control's own self-test FAILED: ...
exit 1
```

`ok=true` is the defect, live. Under the shipped rule the same fixture refuses,
and refuses on the sign rather than on the number:

```
[clock] ctl3 self-test  ok    a DECREASING linear page (more dirty work reads FASTER) REFUSES — though the band alone admits it
```

The temporary copy was deleted; nothing of it is in the diff.

### What the rule is now

Every block must also carry the **monotonicity the control's own premise
asserts** — `T` rising with `d` — checked as both differences being finite and
**strictly positive**. `>= 0` would not do: a difference of exactly zero is a
denominator gone to noise, or a numerator saying the top two points are
indistinguishable, and neither is a reading.

**The strict per-block rule is kept, not relaxed** — one inverted block refuses
the row exactly as one out-of-band block does. An empty block set is now refused
too, rather than passing on a vacuous `every`. A refusal on the sign prints its
own `;; SIGN` line naming the offending blocks and their millisecond terms, so
the report never shows a `FAIL` beside an in-band number with no reason attached.

I took the strictly-positive-differences form rather than the fitted-slope one.
The differences **are** the terms the statistic is built from, so the condition
is checked on the quantities that actually enter the verdict; a slope invariant
would adjudicate a least-squares artefact one step removed from them, and would
still admit a block whose denominator had collapsed to zero while its slope
stayed positive.

### Fixtures: eleven becomes fourteen

| # | fixture |
|---|---|
| 12 | a decreasing linear page refuses — **and** the band-only rule admits it (both halves asserted) |
| 13 | sign-degenerate boundaries: negative numerator, negative denominator (a finite ratio *inside* the band), numerator exactly zero, denominator exactly zero, an arm that read nothing |
| 14 | the gate refuses nothing healthy — the linear, multiplicative and derived-prediction worlds still pass with a clean sign check; the superlinear and declaring-200-rendering-140 worlds are still refused **by the band**, not swept up by this rule; and an empty block set is not a pass |

## 2. Diagnostics describing the abandoned 3,000-cell design

Three sites in `implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs`.
The shipped arms use the floor's own 300-boundary / 901-element page
(`clock-app/ctl3-cells`) and **are** inside the cross-arm canonical-DOM gate; the
3,000-boundary page was tried, lost, and is recorded in `clock-app/ctl3-dirty`.

1. **The `ctl3Parity` comment** (above the parity computation) claimed the
   control's arms are *"exempt from the cross-arm canonical-DOM gate because
   their page is not the floor's"*. They are not exempt. It now says they build
   the floor's page, are inside that gate, and that this parity check is a
   second, tighter one rather than the only one.
2. **The `c ORDER` printed line** said *"c(3pt) carries React's whole-tree walk
   over 3,000 elements"* and that the two constants are *"constants of DIFFERENT
   PAGES"*. Restated on the instrument that ran: the two are recovered by
   different **constructions** — `c(3pt)` is the intercept of a fit along the
   dirty-set axis on the floor's own 300-boundary page (interpolated from the
   plan, not a literal), so it carries the reconciliation walk in full, while
   `c(2x)` inverts a *page* doubling, which the walk scales with and so is
   excluded there. Same directional prediction, correct reason.
3. **The `badCtl3Parity` fatal message** repeated the exemption claim and said
   *"this is the only thing checking them"*. It now says a disagreement here that
   the cross-arm gate did not raise means the control's own arms differ from each
   other.

One adjacent correction of the same class, flagged for the reviewer: the
`ctl3Verdict` docstring pointed at `clock-app/ctl3-witness-dirty`, **which does
not exist** — no shipped arm sets `:ctl3-witness?`, so `wArm` is null on every
run and the witness column reads null. The comment now says so. The term is read
rather than deleted, because the page can declare a witness without the driver
changing.

## 3. The record

`docs/design/hicasso/studio/a-control-that-differences-the-constant-away.md`
gains a §6 subsection, *The band is necessary and not sufficient*, carrying the
counter-example table and the rule; the fixture count moves eleven to fourteen;
and §8 Provenance now distinguishes the **comment-only** first round from this
**behavioural** second one and names the current blobs.

**No figure on that page moves.** The gate can only convert a pass into a
refusal, and all three rows already refused; the `LayoutDuration` column is
quoted as a mean and a range rather than as a verdict.

`mkdocs build --strict` does **not** cover `docs/design/**` — `exclude_docs`
keeps that tree off the site. `scripts/check_doc_slugs.py` ran (exit 0), and I
**hand-verified the anchors and table column counts**: both uses of the anchor
added (`#the-band-is-necessary-and-not-sufficient`) resolve to a real heading,
`#6-the-control-is-shown-failing` still does, and every table in the page is
column-consistent across header, separator and body — 5/5/5/5/5, 4/4/4/4/4,
5/5/5/5/5, the new one 4/4/4/4/4, and 2/2/2/2/2.

## Quality gates

All foreground, to completion, redirected to worktree-local logs, exit code
echoed from the runner itself (never through a pipe). Every log's `gate root:`
line named `/c/Users/miket/code/re-frame2-worktrees/ctl3sign-7iqb5`.

| gate | command | result | exit |
|---|---|---|---|
| the control's own self-test | `node .../clock_run.cjs --selftest` | **14 checks, all ok** (was 11) | **0** |
| clock driver exit-path | `node .../clock_exit_path.test.cjs` | 119 passed | **0** |
| doc slugs/anchors | `python scripts/check_doc_slugs.py` | clean | **0** |
| CLJS node integration | `cd implementation && npm run test:cljs` | 12734 tests / 63868 assertions, **0 failures, 0 errors** | **0** |
| fast-PR spine | `sh scripts/test-fast-pr.sh` | 0 `FAIL` lines; JVM core 2233 tests / 11645 assertions, JVM freehand 1291 tests / 8874 assertions, both 0 failures 0 errors; `mkdocs --strict` built; provenance-pin check on changed pages passed | **0** |

Two notes on how that column was reached, because neither is invisible:

* **The spine's first run exited 1** on `CLJS node integration` only —
  `Cannot find module 'shadow-cljs/cli/runner.js'`, i.e. the worktree had no
  `implementation/node_modules`. I junctioned it at the mayor checkout's real
  one, ran the lane green, re-ran the **whole spine** for a single clean exit 0,
  and then removed the **junction** (`cmd /c rmdir`, never its target) with a
  before/after canary on the mayor's `node_modules` entry count.
* **`_changed-surfaces.test.cjs` reported 172 failures in that first run**, every
  one a `Command failed:` from a spawned `bash -lc` / `git` child. Run alone it
  is **295 passed, exit 0**, and the same commands succeed by hand. Five workers
  share this box; it is process-spawn contention, not a finding. It was green in
  the clean spine re-run.

`python scripts/check_fast_pr_gap.py --list` (exit 0) names **90 required CI
checks this spine does not decide**, so green here is not green in CI. The ones
this diff could plausibly reach: `beads-pr-boundary`, `eslint` and `clj-kondo`
under `Lint required`, and `Docs required`'s `detect` — noting the clj-kondo
caveat that CI pins 2026.04.15, so a differently-versioned local binary proves
nothing.

## Out of scope, deliberately

* **No timing row is re-taken.** Five workers are running on this machine; a
  wall-clock reading taken today is invalid by construction. If the mayor wants
  a re-measurement it needs a quiet box.
* **M1's control is untouched** — `rf2-jcm3p`.
* One inconsistency found and **not** fixed, because I cannot tell which side is
  right: `clock-app/ctl3-dirty`'s docstring says `c(3pt)` came out 7.93 ms on the
  3,000-cell page *"against 1.39 ms on the 300-cell one"*, while the studio page
  and the reopening bead note both say **1.24 ms**. One digit, in prose, on the
  abandoned design. Worth a bead rather than a guess.
