### PR TITLE
feat(hicasso): build the [:>] raw escape (rf2-2rtt6.103)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -418,6 +418,78 @@ instance props can express.
 
 ## HD-011 — The interop door
 
+> **Addendum, 2026-08-07 — the `[:>]` raw escape is BUILT, and its shape is
+> "`defhost` with the declaration erased" (`rf2-2rtt6.103`).** The ruling below
+> adopted the escape and left five edges open; the design programme closed them
+> and [the synthesized spec](studio/raw-escape-spec.md) carries the argument.
+> This records what shipped, because a reader of this decision should not have
+> to reconstruct it from a studio page.
+>
+> **The model.** `[:> Component props & children]` is the same crossing as
+> `defhost` with the declaration erased, and **what erasing the declaration
+> costs is exactly what the declaration carried**: no author-chosen crossing
+> name, no `:callbacks` contracts, no `:ssr` policy, refusals at render time
+> rather than once at a declaration, one generic marker instead of a minted
+> identity, and the JS require landing in the view namespace rather than in a
+> `.cljc`-quarantined host one. Every remedy for every one of those is
+> `defhost`. That is what makes the escape **strictly weaker than the door by
+> construction**, which is the only way *"declare what you use twice"* has
+> teeth.
+>
+> **Props take the door's UNCLAIMED-slot conduct exactly, with no branch of
+> their own** — the same `host-entry` walk against an empty declared roster. So
+> an intent vector or key-map at an event-spelled slot refuses, a marked `h/fn`
+> at any slot refuses (the addendum immediately below, inherited rather than
+> forked), a plain function crosses by identity, `:&` merges before conversion
+> under HD-023(d), `:key` rides the crossing's outer element, `:ref` takes
+> HD-016 and HD-022 through the same `check-ref!`, and the class slot takes its
+> own coercion. The reason it is the same walk rather than a parallel one is
+> compositional: if the escape refused what the door accepts, `[:> X …]` →
+> `(defhost x X {})` would stop being behaviour-preserving, and that rewrite is
+> the whole theorem of `rf2-2rtt6.106`'s codemod.
+>
+> **SSR is hard `:client-only`, through ONE shared module-level gate**, reusing
+> the snapshot triple `mint-host-gate!` uses with the placeholder fixed at
+> `nil`. There is no declaration to carry a policy and **no inline spelling for
+> one** — a fallback is POLICY, and policy lives on declarations; an author who
+> wants one wraps the escape in a `defhost` that has one. Server-absent and
+> hydration-first-pass-absent are not two facts kept in step: they are one fact,
+> and React chooses it. **The escape must never grow an `:ssr` spelling of its
+> own.**
+>
+> **The Component value is refused AT THE CROSSING**, in the owner's render and
+> on the server too — React's own refusal is minted at fiber creation, which
+> behind the gate is post-adoption and client-only, and it names `typeof type`,
+> so every ClojureScript value reads *"got: object"*. The accepted set is what
+> React 19 mints a fiber for (functions and classes, the built-in `Symbol.for`
+> exotics, `$$typeof`-branded wrapper objects) minus three narrowings, each
+> with its own message: `nil` (the broken-import diagnosis); **strings and
+> keywords**, because the grammar owns tags and Reagent's `[:> "input" …]` took
+> the controlled-input wrapper on exactly this path, so accepting one would
+> silently drop caret protection at a site a migrator ports verbatim; and
+> **`defview`/`defhost` heads**, which React would accept and which are silent
+> breakage (a `defview` product is `fn?`-true, so mounting it raw hands the body
+> `undefined` for `rfProps`).
+>
+> **"Reduced structural identity" is exactly two things, and the DOM is not one
+> of them.** The hiccup data lane is reduced at one slot — slot 1 holds a JS
+> value compared by identity, total everywhere else. The fiber lane carries one
+> shared gate type named by the constant `"[:>]"`, with **no name derived from
+> the component**: React resolves `displayName || name || null`, Closure renames
+> `.name` under `:advanced`, and foreign production bundles ship without
+> `displayName`, so a derived identity would be build-dependent — where
+> `defhost`'s name is authored DATA. The canonical DOM is **not reduced at all**,
+> and that is witnessed rather than asserted.
+>
+> **Bare-head auto-hosting stays rejected** and `defhost` stays the taught,
+> policy-bearing, tooling-identified form. Witnessed in
+> `front/codec_cljs_test` (the carrier, conversion parity with the door
+> prop-for-prop, the value roster and its refusals, `:&`, `:key`, refs, the
+> `:>` mis-parse regression) and `arm1/raw_escape_dom_cljs_test` (server
+> absence, hydration with zero recoverable errors, canonical-DOM parity with the
+> door, and a child intent landing in the frame that wrote the crossing and in
+> no other).
+
 > **Addendum, 2026-08-06 — an `h/fn` at a prop slot NOTHING CLAIMED is refused
 > at the crossing (`rf2-2rtt6.116`).** The door already refuses an intent
 > *vector* at an event-spelled slot the declaration does not name, on the stated

--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -78,7 +78,7 @@ finished product package.
 | **Routing links as data** | `route-link` — href + click decision assertable with `=` | [Events as data](03-events-as-data.md) |
 | **Controlled inputs** | Value through app-db; same-tick echo; caret preservation; careful IME on the controlled path | [Controlled inputs](04-controlled-inputs.md) |
 | **Testing shape** | **Today:** assert intents / prevent / navigate / presence attrs with `=` (no browser). **Mounted** for hooks, caret, real React. **Planned:** full headless structural render (ruled, not built; no dedicated bead yet) | [Testing](08-testing.md) |
-| **Interop** | `defhost` for npm React components; policies at the declaration; `[:>]` secondary and still landing | [Interop](05-interop.md) |
+| **Interop** | `defhost` for npm React components; policies at the declaration; `[:>]` built, and explicitly secondary | [Interop](05-interop.md) |
 | **Ephemeral UI state** | No product `local`; `reg-state` sugar; placement rules | [Ephemeral state](07-ephemeral-state.md) |
 | **Exit / enter animation** | `h/presence` — node can outlive app-db for a fade-out | [Ephemeral state](07-ephemeral-state.md) |
 | **Lifecycle without `:on-mount`** | Page data → routes; seed → `:initial-events`; animation → presence; DOM/SDK → ref / `defhost` | [Ephemeral state](07-ephemeral-state.md) |

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -102,7 +102,7 @@ pointing you at a stable identifier.
 | Native tag — `[:div …]` | attribute map | trailing forms | `:key` in the attribute map | callback ref, legal |
 | Hicasso view — `[todo-row …]` | one props map | trailing forms, arriving as `(:children props)` | in the props map, **extracted before your body sees props** | not yet — use ids |
 | Fragment — `[:<> …]` | — | trailing forms | on the fragment's props map | — |
-| Foreign — `defhost` (and `[:>]`, once it is built) | converted per declaration | hiccup children become elements | `:key` in props | callback ref, legal |
+| Foreign — `defhost` and `[:>]` | converted per declaration | hiccup children become elements | `:key` in props | callback ref, legal |
 
 Children arrive realized and predictably flattened: nested and lazy sequences
 are realized once and flattened one level, `nil` and `false` render nothing,

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -52,7 +52,7 @@ Putting a raw JS component in the tree breaks three things at once:
 
 `defhost` quarantines the require in one `.cljs` host namespace and leaves the rest
 of the view tree as data. Friction once; free at every use site. The Reagent
-`[:> …]` escape is secondary, **not built** yet, and covered briefly below.
+`[:> …]` escape is built and explicitly secondary — covered briefly below.
 
 ## Defaults
 
@@ -216,20 +216,39 @@ If a host should react to a subscription, that value has to reach **its own**
 props — reading one boundary up and stopping looks identical, from the host's
 side, to the value never changing.
 
-## The escape: `[:>]` (unbuilt)
+## The escape: `[:>]`
 
 `[:> Component props & children]` is the secondary form for cases a static
-declaration cannot express. It is **not built** — there is nothing to call today.
-When it exists, it will use the same foreign path and accept the costs in
+declaration cannot express. It uses the same foreign path as `defhost` with the
+same default conversions, and it accepts the costs in
 [Why declare](#why-declare).
 
-Reach for it (once it exists) when the component is selected at runtime, is a
-`memo`/`lazy` value, arrives from a render prop, or is a one-off migration site.
+Reach for it when the component is selected at runtime, is a `memo`/`lazy`
+value, arrives from a render prop, or is a one-off migration site.
 **Declare what you use twice.** First use, escape if faster; second use, `defhost`.
 
+```clojure
+[:> Chart {:series data} [:span.legend "revenue"]]
+```
+
+**It is `defhost` with the declaration erased, and what erasing the declaration
+costs you is exactly what the declaration carried.** No crossing name for your
+tools; no `:callbacks`, so every prop here is unclaimed and an intent vector at
+an `on*` slot or an `h/fn` anywhere is a loud refusal; no `:ssr` policy, so a
+`[:>]` renders **nothing** server-side and there is no spelling to change that
+— wrap it in a `defhost` if you want a placeholder there. The JS require lands
+in the view namespace rather than a `.cljc`-quarantined host one, which is the
+cost you meet first: not "my structural test cannot match a node", but "my test
+namespace will not load."
+
+The Component position takes what React accepts as an element type — a function
+or class component, one of React's built-in wrappers, a `memo` / `lazy` /
+`forwardRef` / context value. A tag string, a keyword, a `defview` head and a
+`defhost` head are all refused, each naming the spelling to write instead.
+
 **Bare-head auto-hosting stays illegal.** `[DatePicker {…}]` with a raw JS
-component in head position is not a shortcut. One sentinel when the escape ships —
-not two ways to smuggle JS into the tree.
+component in head position is not a shortcut. One sentinel, not two ways to
+smuggle JS into the tree.
 
 A hand migration from Reagent is three moves per namespace: collect `[:> X …]`,
 emit `defhost`, rewrite call sites. A codemod is planned and not built.
@@ -245,7 +264,8 @@ emit `defhost`, rewrite call sites. A codemod is planned and not built.
 | `:rf.error/hicasso-intent-at-a-non-event-contract` | Slot is `:handler` or `:render`; neither dispatches | Declare `:event`, or write an `h/fn` for the real work |
 | `:rf.error/hicasso-intent-needs-the-event` | Vector spelling needs the DOM event at arg one; library put something else there | Use `h/fn` — full argument list, library order |
 | Namespace won't load on the JVM | A JS require reached a `.cljc` file | Quarantine the require in a `.cljs` host ns |
-| Structural test can't match a node | A `[:>]` node (once built) has reduced structural identity | Prefer `defhost`, or assert around the node |
+| Structural test can't match a node | A `[:>]` node has reduced structural identity — slot 1 holds a JS value compared by identity, and the crossing's fiber is named `[:>]` rather than by the component | Prefer `defhost`, or assert around the node |
+| A `[:>]` region is missing from the server HTML | `[:>]` is hard `:client-only` — no declaration, so no `:ssr` policy and no spelling for one | Declare it with `defhost` and choose `:ssr`, or wrap the escape in a host that carries a `{:fallback …}` |
 | Hosted component doesn't update when the page did | Boundary above bailed out on equal props — host never re-entered | Put the changing value on the host's *own* props |
 | SDK mounts twice in dev | StrictMode double-invoke plus a handle stored outside the attach closure | One attach, one handle, one cleanup, all in one closure |
 | SDK rebuilt on every unrelated render | Ref function has a fresh identity each render | `useCallback` with `#js []` |

--- a/docs/design/hicasso/draft-guide/11-performance.md
+++ b/docs/design/hicasso/draft-guide/11-performance.md
@@ -204,7 +204,7 @@ Keep the island **small**. Callback refs: [Interop](05-interop.md) Advanced.
 Someone else's component — date picker, chart, **virtualized list**:
 
 - **`defhost`** — declare once ([Interop](05-interop.md))
-- **`[:> …]`** — secondary raw escape; may lag `defhost`
+- **`[:> …]`** — the secondary raw escape, for what a declaration cannot express
 
 ```clojure
 (h/defhost chart Chart
@@ -253,7 +253,7 @@ mode. Multi-frame: [Getting started](01-getting-started.md).
 | Bare `rf/dispatch` from a timeout | An ambient `rf/*` in a body refuses, naming the collector — it never "sometimes works" | Own the async work through `:fx`; only a closure crossing to foreign code carries `(rf/capture-frame (h/frame))` |
 | Hooks in every cell "for speed" | Second architecture | One island; app-db for semantic state |
 | Structural test dies after a "perf fix" | Hooks or JS in a `.cljc` body | Quarantine host code in `.cljs` |
-| Bare `[DatePicker …]` head | Not legal | `defhost` (or `[:>]` when available) |
+| Bare `[DatePicker …]` head | Not legal | `defhost`, or the `[:>]` escape |
 | SDK mounts twice / leaks | Ref without paired teardown | Attach + cleanup as one ref (React 19) — [Interop](05-interop.md) |
 | Still slow after dropping to React | Wrong layer | Profile again — often reads or event volume |
 
@@ -269,7 +269,7 @@ mode. Multi-frame: [Getting started](01-getting-started.md).
 | Question | Status |
 |---|---|
 | Compile / dual-mode path | **Not planned** — one interpreted Hiccup product |
-| `[:>]` availability | Ruled; may lag `defhost` — [Interop](05-interop.md) |
+| `[:>]` availability | Built — [Interop](05-interop.md) |
 | `h/frame` spelling | Behaviour settled and proven in the arm; the product name is **[unfrozen]** |
 | Big-list bulk on our side | Outside numbers show risk; full own pricing still open |
 | Perf-island macro / scaffold | **None** — plain React + `defview` |

--- a/docs/design/hicasso/studio/raw-escape-spec.md
+++ b/docs/design/hicasso/studio/raw-escape-spec.md
@@ -1,5 +1,17 @@
 # The `[:>]` raw escape — the synthesized spec
 
+> **BUILT, 2026-08-07 (`rf2-2rtt6.103`).** This page was the implementation brief and is
+> now also the record of what shipped. The mechanism landed as ruled: one shared
+> module-level gate, the door's `host-entry` walk against an empty declared roster, the
+> value roster refused at the crossing, children through `make-element`'s existing arms.
+> Two of the four operator rulings in §7 were taken before implementation and are marked
+> there — **R1** by `rf2-2rtt6.116` (refuse, at the DOOR, and the escape inherits) and
+> **R2** by `rf2-l0wfx` (`:ssr :render`, and the escape is untouched). **R3** was taken as
+> recommended: a `defview` or `defhost` head in Component position is refused. **R4**'s
+> record obligation was discharged on `main` by PR #7607 before this page's implementer
+> reached it; the escape's PR carries the verification rather than a second copy. HD-011
+> carries a dated addendum recording the shipped shape.
+
 **This is the artefact `rf2-2rtt6.103`'s design-phase note promises** ("implementation
 re-dispatches from the synthesized spec"). `rf2-2rtt6.109` reads it too. It is a spec, not
 a survey: where the designs agree it says the agreement is genuine and cites it, where they
@@ -202,7 +214,7 @@ declared map — exactly, and with no branch of its own.**
 |---|---|
 | intent vector or key-map at an **event-spelled** slot | **loud refusal** — no contract is ever inferred from an `on*` name |
 | intent vector or key-map at any other slot | data — `clj->js`, the position's own conversion |
-| marked `h/fn`, any slot | crosses **by identity**; it runs, and its return is ignored |
+| marked `h/fn`, any slot | **loud refusal** — `:rf.error/hicasso-host-unclaimed-callback`, the door's own branch |
 | plain `fn` | crosses by identity — memo bail-outs keep working |
 | `:ref` | `check-ref!` on the canonical slot — callback ref through, vector refused |
 | `:&` | `merge-caller` **before** conversion, per HD-023(d) |
@@ -210,11 +222,19 @@ declared map — exactly, and with no branch of its own.**
 
 *(7 rows, 2 columns.)*
 
-The refusal's message must **not** copy the door's "or hand a function", because at a
-crossing with no declaration an `h/fn`'s returned intent does not dispatch. It names
-`defhost`'s `:callbacks` as the door and states the `h/fn` return fact pre-emptively, so the
-author who tries the taught spelling first is told the whole story before they can fall into
-the other half of it.
+> **Row 3 was `crosses by identity` until 2026-08-06.** `rf2-2rtt6.116` ruled the DOOR's
+> unclaimed slot a **refusal** (HD-011's dated addendum), PR #7607 landed that as one branch
+> in `host-entry`'s `:else` arm, and the escape's empty roster means **every** slot here is
+> unclaimed — so `[:>]` inherits it through the same branch, with no fork and no code of its
+> own. The ruling above is unchanged by that; only its answer moved. §7 R1 records what was
+> decided and why, and the pin below is what made the answer inheritable rather than a second
+> decision.
+
+The event-spelled refusal's message must **not** copy the door's "or hand a function",
+because at a crossing with no declaration an `h/fn`'s returned intent does not dispatch. It
+names `defhost`'s `:callbacks` as the door, which is the recovery at both crossings — at
+the door the author adds the slot to a declaration they already have, and at the escape they
+write one.
 
 ### The rejected reading, and why C falls with it
 
@@ -254,10 +274,10 @@ makes the system's answer to "is `on*` a contract?" positional — no at `defhos
 ### The decisive argument, which only one document states in full
 
 Design A and the local minimal design both take the other fork — **refuse a marked `h/fn` at
-a `[:>]` prop**, since the marker requests a contract the position cannot give. It is a
-serious position: it is the only stance with no silent cell, and A prices it honestly. It is
-rejected here on a consequence neither of them considers and only the attack on the migration
-design states:
+a `[:>]` prop, where the door accepts one**. Their reading of the defect is right: the marker
+requests a contract the position cannot give, and it is the only stance with no silent cell.
+What is rejected is the FORK, on a consequence neither of them considers and only the attack
+on the migration design states:
 
 > **If the escape refuses what the door accepts, `[:> X …] → (defhost x X {})` is no longer
 > behaviour-preserving — and that rewrite is the whole theorem of `rf2-2rtt6.106`'s codemod.**
@@ -266,6 +286,13 @@ The hoist is mechanical precisely because both spellings run the *same walk*. A
 `[:>]`-only refusal forks that walk, and the fork lands on the one transformation the
 migration story is built on. A refusal that is right in isolation and wrong in composition is
 wrong. **Whatever is ruled, the escape does what the door does.**
+
+> **And what was ruled is the refusal — at the door (`rf2-2rtt6.116`, 2026-08-06).** So A
+> and the minimal design were right about the CONDUCT and this page was right about where the
+> decision belongs, and the two are not in tension: the outcome A wanted is what ships, and it
+> ships at both crossings through one branch, so the codemod's hoist theorem survives intact.
+> That is the pin below doing its work rather than being overruled — it is what let a ruling
+> taken at the door arrive here with no line of this page's mechanism changing.
 
 ### The diagnostic, pinned to the door rather than forked from it
 
@@ -285,11 +312,12 @@ default; deferring to the door costs nothing and cannot be wrong in any branch.
 
 > **Answered 2026-08-05 (`rf2-2rtt6.117`) — no, and the question inverted before it could be
 > put.** `.117` was spun out as a *parity* question: the escape had just been given a dev-only
-> warning, so does the door get the same one? The pin above retracts that grant. There is now
-> no warning at `[:>]` to be at parity with — `[:>]` is unbuilt, and by this section's ruling
-> it will never carry a diagnostic the door lacks — so the answer to the question as asked is
-> **no**, on the premise rather than on the merits. The second horn the bead offers ("or is the
-> door's declaration story sufficient signal?") is not the reason either; it was never reached.
+> warning, so does the door get the same one? The pin above retracts that grant. There was then
+> no warning at `[:>]` to be at parity with — the escape was unbuilt, and by this section's
+> ruling it would never carry a diagnostic the door lacks — so the answer to the question as
+> asked is **no**, on the premise rather than on the merits. The second horn the bead offers
+> ("or is the door's declaration story sufficient signal?") is not the reason either; it was
+> never reached.
 >
 > What survives of `.117` is not a second decision. It is the **warn** arm of the one
 > three-way ruling §7 R1 states as *refuse, warn, or leave* — the ruling `rf2-2rtt6.116`
@@ -298,6 +326,10 @@ default; deferring to the door costs nothing and cannot be wrong in any branch.
 > is moot; if the door leaves the crossing alone, warn-versus-leave is live and is still one
 > question, not two. Whichever way it goes, the escape does what the door does and no line of
 > the mechanism above changes.
+>
+> **Closed the first way, 2026-08-06 (`rf2-2rtt6.116`): the door REFUSES, so the warning is
+> moot** — and the escape, built the next day, carries no diagnostic of its own. §7 R1 records
+> it.
 
 ---
 
@@ -572,14 +604,29 @@ Stated with the recommendation and its cost. **None is decided here.** In every 
 spec is written so that no line of the escape's mechanism changes with the answer.
 
 **R1 — `h/fn` at an unclaimed prop slot: refuse, warn, or leave? (`rf2-2rtt6.116`, P2; the
-door's diagnostic is `rf2-2rtt6.117`, P3.)** True on `main` today with no `[:>]` anywhere: a
-marked callback nothing reads. *Recommendation:* rule it for the **door**, and let the escape
-inherit — §3's pin means all three answers preserve the zero-fork invariant and the codemod's
-hoist theorem. *Cost of refusing:* it chips HD-024's cleanest claim, that the marked form is
-callable everywhere and degrades to "a defensible contract rather than a crash". *Cost of
-leaving:* a silent dead return on the guide's own taught path for value-first invokers.
-*Cost of warning:* a diagnostic surface the record has to justify against the anti-nag
-posture. **The escape works under all three.**
+door's diagnostic is `rf2-2rtt6.117`, P3.)**
+**RULED 2026-08-06 — REFUSE, at the door, and the escape inherits.** The recommendation
+below was taken exactly as written: the ruling was made about `defhost`, PR #7607 landed it
+as one branch in `host-entry`'s `:else` arm with
+`:rf.error/hicasso-host-unclaimed-callback`, and because the escape's roster is empty every
+`[:>]` slot is unclaimed and flows through that same branch. **No line of the mechanism above
+changed** — which is what the pin was for. The warn arm lost on its own terms: a warning fires
+under `goog.DEBUG` and is gone in production, which is exactly where the dead click happens,
+so it converts a silent production failure into a silent production failure with a development
+courtesy. `rf2-2rtt6.117` closed on the premise rather than the merits — there was no `[:>]`
+warning left to be at parity with. HD-011 and HD-024 carry the full ruling and the fence: a
+**plain** function at an unclaimed slot is untouched, and the marked form stays legal at every
+CLAIMED slot including React's own `:ref`.
+
+*The record of what was weighed, kept because a reversal would have to weigh it again:*
+true on `main` at the time with no `[:>]` anywhere — a marked callback nothing reads.
+*Recommendation:* rule it for the **door**, and let the escape inherit — §3's pin means all
+three answers preserve the zero-fork invariant and the codemod's hoist theorem. *Cost of
+refusing:* it chips HD-024's cleanest claim, that the marked form is callable everywhere and
+degrades to "a defensible contract rather than a crash". *Cost of leaving:* a silent dead
+return on the guide's own taught path for value-first invokers. *Cost of warning:* a
+diagnostic surface the record has to justify against the anti-nag posture. **The escape works
+under all three.**
 
 **R2 — `defhost`'s `:ssr` has no value that renders children (`rf2-l0wfx`, P1).**
 **RULED 2026-08-05, and the escape is unchanged.** `mint-host-gate!` returned a single
@@ -615,14 +662,31 @@ raw — the body reads `rfProps`, gets `undefined`, and receives nil props. That
 silent breakage, and it is the kind a migration produces. *Cost:* two own-property reads per
 crossing render, and a refusal of something React would have accepted. **Removable without
 touching the mechanism** — it is a predicate and two message flavours.
+**TAKEN AS RECOMMENDED, 2026-08-07.** Both heads are refused with
+`:rf.error/hicasso-raw-not-a-component`, each with its own recovery — `[my-view …]` and
+`[my-host …]`. It remains removable on the terms above: two `cond` arms and two message
+flavours, and nothing else reads them.
 
-**R4 — `rf2-2rtt6.115`'s record correction must land before or with the escape.** Three
-independent adjudications concur that the **code** side is authoritative: HD-024's row 3 in
-`decisions.md` over-records, and the door's unclaimed-slot identity crossing was
-deliberate. The repair is a dated scope-note on row 3 plus the currently-missing witness
-pinning a *marked* `h/fn` at an unclaimed door slot (today only a *plain* fn is pinned). Edge
-2 rests on that resolution; it is `decisions.md`, outside this page's fence, and it is named
-here so the implementation PR carries it rather than discovering it.
+**R4 — `rf2-2rtt6.115`'s record correction must land before or with the escape.**
+**DISCHARGED ON `main` BEFORE THE ESCAPE, 2026-08-06 (PR #7607) — do not write it twice.**
+Three independent adjudications concurred that the **code** side was authoritative: HD-024's
+row 3 over-records, and the door's unclaimed-slot identity crossing was deliberate. That
+scope correction landed as a dated addendum on HD-024 **plus an inline clause in row 3
+itself**, because a reader who reads the table and not the addendum is how `rf2-2rtt6.115`
+came to be filed at all.
+
+**The witness half of the repair was superseded in the same tree, and this is what the
+implementer must not reapply.** The repair as written asked for *"the witness pinning a
+marked `h/fn` at an unclaimed door slot"* — pinning IDENTITY. `rf2-2rtt6.116` was ruled
+REFUSE three minutes after that review pass, and the ruling deletes the thing the witness
+was to pin: a marked `h/fn` at an unclaimed door slot no longer crosses, it raises
+`:rf.error/hicasso-host-unclaimed-callback`. **The witness R4 asks for is therefore #7607's
+RED refusal row** in `arm1/host_hatch_dom_cljs_test`
+(`an-hfn-at-a-slot-nothing-claimed-is-refused`), **and the identity witness that survives is
+the PLAIN-function row beside it** — which was always the half of the row's deletion clause
+that was true of it. Writing R4's original text now would put a sentence in `decisions.md`
+that `.116`'s own code falsifies in the same tree. Edge 2 still rests on the resolution; the
+escape's PR verifies it rather than re-landing it.
 
 ---
 
@@ -644,17 +708,27 @@ same time — §6(a). If the implementer cannot get the accounting to come out a
 fallback is not "it is only one `=`": it is to measure the walk on the census page's child
 roster before and after and publish the delta in the PR body.
 
-**3. X2's body-run equality is deliberately broken by any `:client-only` crossing.**
+**3. X2's body-run equality, and the correction to what this item used to say.**
 `arm1/hydrate_dom_cljs_test`'s `the-body-run-count-across-adoption-is-counted-and-not-inferred`
-asserts `(= boundary-count (rt/body-runs))`, read after
-adoption resolves. It is green today **only** because no page it drives carries a client-only
-crossing, and it goes **red on correct code** the moment the first one is added — via `[:>]`
-**or** via a `defhost` `:ssr :client-only`, so this is not specific to the escape. The two
-obvious readings when it fires — "my change is wrong" and "this test is wrong" — are **both
-wrong**: the count is *supposed* to move, because a client-only crossing legitimately runs a
-body the server never ran. **Do not delete the assertion and do not loosen it to a range.**
-Restate it as boundary count **plus** the number of client-only crossings on the page, so it
-still fails if a body runs twice or a boundary is skipped.
+asserts `(= boundary-count (rt/body-runs))`, read after adoption resolves. This item used to
+instruct the implementer to restate it as boundary count **plus the number of client-only
+crossings on the page**. That formula is **wrong for the mechanism this page selects**, and
+following it would make a correct implementation's witness fail or encode a topology-dependent
+miscount (merged-PR audit #7497).
+
+**Why.** `runtime/body-runs` increments only inside `run-once`, where an actual Hicasso
+BOUNDARY body is invoked. Neither `mint-host-gate!` nor the shared raw gate is a boundary —
+no frame, no subscription, no body — so a plain foreign component behind `[:>]` or behind a
+`defhost` `:ssr :client-only` adds **zero** body runs. A gate adds runs only insofar as it
+DEFERS actual boundaries beneath it, which is zero, one or many depending on what the page
+puts under the crossing.
+
+**So: keep X2 exact, and derive its expected count from the boundary bodies in the fixture** —
+including any first mounted beneath a client-only gate — never from the number of crossings.
+The two obvious readings if it ever does move — "my change is wrong" and "this test is wrong"
+— can both still be wrong, so **do not delete the assertion and do not loosen it to a range**.
+As built, `rf2-2rtt6.103` adds no `[:>]` to any page that suite drives, so the assertion is
+untouched and stays green.
 
 **4. The argv indices shift by one.** The component is at 1; the attribute map is at 2 when
 `(map? (nth argv 2 nil))`; children run from 3, or from 2 when there is no attribute map.
@@ -709,6 +783,19 @@ each names what would make it vacuous.
 | **The `:>` mis-parse regression** — `[:> Foo {}]` no longer asks React for `<>` | — |
 
 *(8 rows, 2 columns.)*
+
+**Where they landed (2026-08-07).** The element-level rows are in
+`front/codec_cljs_test` — conversion parity with the door on one prop corpus prop-for-prop,
+the carrier never leaking either internal slot, `:key` on the outer element, `:&` before
+conversion, refs, the door's unclaimed-slot conduct inherited, the E4 accept-and-refuse
+roster, and the mis-parse regression (including a runtime-built `:>` keyword, which is what
+makes the `=`-not-`identical?` requirement falsifiable rather than merely stated). The three
+rows a mounted React is the only honest witness for are in
+`arm1/raw_escape_dom_cljs_test`: server absence with the component never invoked, hydration
+against those bytes with React itself asked whether it found anything to reconcile, and
+canonical-DOM parity with the door on the same component and props. The children-capture row
+is there too, on a page with a second live frame so that *the right frame* is distinguishable
+from *any frame*.
 
 ---
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/raw_escape_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/raw_escape_dom_cljs_test.cljs
@@ -1,0 +1,358 @@
+(ns re-frame.bench.hicasso.arm1.raw-escape-dom-cljs-test
+  "THE `[:>]` RAW ESCAPE AGAINST A REAL REACT (HD-011, rf2-2rtt6.103).
+
+  The element-level contract — the carrier, the prop walk, the value
+  roster, `:&`, `:key`, refs, the mis-parse regression — is
+  [[re-frame.bench.hicasso.front.codec-cljs-test]]'s, where it can be
+  read off the element without a DOM. This file carries the three claims
+  that a mounted React is the only honest witness for:
+
+  1. **SSR is hard `:client-only`, and hydration's first pass agrees.**
+     The escape carries no declaration, so it carries no `:ssr` policy
+     and there is no spelling for one. Server-absent and
+     first-pass-absent are not two facts kept in step — they are ONE
+     fact, because React reads the gate's SERVER snapshot under
+     `renderToString` and again on hydration's first client pass, then
+     re-renders with the client snapshot once adoption completes. The
+     row therefore asks REACT whether it found a mismatch, through
+     `onRecoverableError` and a console/window capture; a row that only
+     read the settled DOM would pass over a mismatch React repaired.
+
+  2. **The canonical DOM is not reduced at all.** HD-011's ruled phrase
+     is *reduced structural identity*, and the reduction is exactly one
+     slot of the hiccup vector (slot 1 holds a JS value compared by
+     identity). The DOM is not reduced, and that is provable rather than
+     asserted: the gate contributes no node of its own and
+     [[re-frame.bench.hicasso.lane/canonical]] serialises element and
+     text nodes only, so a nil-rendering gate is invisible to it. Same
+     component, same props, one through `[:>]` and one through `defhost`
+     — byte-equal.
+
+  3. **Children lower in the WRITING boundary's render window.** An
+     intent closure in a `[:>]` child captures that boundary's
+     frame-locked dispatch at lowering time and fires into it however
+     much later the foreign component renders it — a portal, a
+     virtualised window, a `Suspense` fallback. Two frames are live so
+     that \"the right frame\" is distinguishable from \"any frame\".
+
+  ## The mutation witnesses
+
+  Make the escape render its component server-side — `gate-unadopted`
+  answering `true`, or `raw-element` creating the component's element
+  directly — and [[the-escape-hydrates-with-nothing-there-and-mounts-after-adoption]]
+  goes red on React's own mismatch report. Give the gate a wrapper node
+  of its own and [[the-escape-and-the-door-produce-the-same-dom]] goes
+  red on the canonical bytes. Lower children lazily, or forward them
+  without the owner's frame, and [[a-child-intent-fires-into-the-frame-that-wrote-the-crossing]]
+  goes red on the recorder that should have been empty.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM. The `renderToString` rows need no DOM and run under
+  `:node-test` too."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]
+            ["react-dom/client" :as react-dom-client]
+            ["react-dom/server" :as react-dom-server])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview defhost]]))
+
+(def ^:private frame-id ::raw-escape)
+
+(rf/reg-sub :raw/title (fn [db _] (:title db)))
+
+(rf/reg-event :raw/seed (fn [_ _] {:db {:title "quarterly"}}))
+
+(rf/reg-event :raw/picked
+              (fn [{:keys [db]} [_ what]]
+                {:db (update db :picked (fnil conj []) what)}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     ;; the hydration row waits on a real clock, and `cljs.test`
+     ;; hard-errors on a fn-form fixture in a suite with an async test.
+     :async?        true
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(defn- skip! [why] (is true (str "a [:>] DOM claim needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (lane/leave-act-environment!)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [:raw/seed]))
+  frame-id)
+
+(defn- db [] (rf/app-db-value frame-id))
+
+;; ---------------------------------------------------------------------------
+;; One foreign component, reached two ways
+;; ---------------------------------------------------------------------------
+
+(def ^:private !renders
+  "How many times the foreign component's body ran. The server row's
+  strongest assertion: a `[:>]` crossing is not merely absent from the
+  HTML, its component was never INVOKED — which is the property an
+  author relies on when the reason they reached for the escape is a
+  widget that touches `window`."
+  (atom 0))
+
+(defn- widget
+  "A stand-in for the library's component. It renders REAL markup with
+  real attributes so that a canonical comparison has something to
+  compare, and it renders its children so the forwarding claim is
+  visible in the DOM."
+  [^js props]
+  (swap! !renders inc)
+  (react/createElement "div"
+    #js {:className "widget" :data-live "yes" :data-variant (.-variant props)}
+    (react/createElement "span" #js {:className "widget-label"} (.-label props))
+    (.-children props)))
+
+(defhost declared-widget
+  "The DOOR, on the same component and under the same default policy —
+  the control that makes every parity row below a fact about the
+  crossing rather than about the page."
+  widget)
+
+;; ---------------------------------------------------------------------------
+;; The pages
+;; ---------------------------------------------------------------------------
+
+(defview escape-page
+  "A native sibling beside the crossing, so \"the escape rendered
+  nothing\" stays distinguishable from \"nothing rendered at all\"."
+  [_]
+  [:div.page
+   [:h1.title (rt/sub [:raw/title])]
+   [:> widget {:label (rt/sub [:raw/title]) :variant "compact"}
+    [:span.kid "slotted"]]])
+
+(defview door-page
+  "[[escape-page]] through `defhost`, byte for byte the same authored
+  shape."
+  [_]
+  [:div.page
+   [:h1.title (rt/sub [:raw/title])]
+   [declared-widget {:label (rt/sub [:raw/title]) :variant "compact"}
+    [:span.kid "slotted"]]])
+
+(defview intent-child-page
+  "A crossing whose CHILD carries an intent. The child's handler is
+  lowered here, in this body's render window, and invoked much later —
+  after every render extent has unwound — from the click."
+  [_]
+  [:div.page
+   [:> widget {:label "rows" :variant "list"}
+    [:button.pick {:on-click [:raw/picked "child"]} "pick"]]])
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- server-html
+  "The page as a server render — the same runtime, under React's server
+  renderer."
+  [hiccup]
+  (react-dom-server/renderToString
+    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+
+(defn- q [root sel] (.querySelector root sel))
+
+(defn- watch-errors!
+  "Everything React has to say about a hydration, from all three
+  channels it uses. `console.error` carries the mismatch diff;
+  `onRecoverableError` carries the recovery; the `window` listener is
+  here because React routes a throw during a commit to `reportError`,
+  where `cljs.test` cannot see it and a row would read 0 failures over a
+  live exception."
+  []
+  (let [seen     (atom [])
+        original (.-error js/console)
+        on-error (fn [e] (swap! seen conj (str "window: " (.-message e))))]
+    (set! (.-error js/console)
+          (fn [& args] (swap! seen conj (str "console.error: " (pr-str (vec args))))))
+    (.addEventListener js/window "error" on-error)
+    {:seen    seen
+     :restore (fn []
+                (set! (.-error js/console) original)
+                (.removeEventListener js/window "error" on-error))}))
+
+;; ---------------------------------------------------------------------------
+;; 1 — the server render: nothing, and the component never ran
+;; ---------------------------------------------------------------------------
+
+(deftest the-escape-renders-nothing-on-the-server-and-cannot-say-otherwise
+  (fresh!)
+  (testing "hard `:client-only`. The escape carries no declaration, so it
+            carries no `:ssr` policy and there is no inline spelling for
+            one — a fallback is POLICY, and policy lives on declarations"
+    (reset! !renders 0)
+    (let [html (server-html [escape-page {}])]
+      (is (re-find #"quarterly" html)
+          (str "the page rendered — the sibling native node is there: " html))
+      (is (not (re-find #"class=\"widget\"" html))
+          (str "and the crossing rendered NOTHING: " html))
+      (is (not (re-find #"slotted" html))
+          (str "including its children, which lower eagerly and are then
+                discarded on the server: " html))
+      (is (zero? @!renders)
+          "the foreign component's body never ran on the server, which is
+           the property an author reaching for the escape is relying on")))
+  (testing "and the DOOR under its own default answers identically — the
+            escape inherits `:client-only`, it does not invent it"
+    (reset! !renders 0)
+    (let [html (server-html [door-page {}])]
+      (is (not (re-find #"class=\"widget\"" html)) (str "absent at the door too: " html))
+      (is (zero? @!renders)))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — a fresh mount, and the canonical DOM
+;; ---------------------------------------------------------------------------
+
+(deftest a-fresh-mount-renders-the-component-on-its-first-pass
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (testing "a `createRoot` mount never consults a server snapshot, so
+                the gate costs no placeholder pass — asserted on the line
+                after `root!` returns, which is inside its flushSync"
+        (let [h (mount/root! (mount/fresh-container!) frame-id [escape-page {}])]
+          (try
+            (is (some? (q (:container h) ".widget"))
+                "the component mounted immediately")
+            (is (= "yes" (.getAttribute (q (:container h) ".widget") "data-live"))
+                "the real one, not a placeholder")
+            (is (= "quarterly" (.-textContent (q (:container h) ".widget-label")))
+                "a prop reached the foreign component through the gate")
+            (is (= "compact" (.getAttribute (q (:container h) ".widget") "data-variant"))
+                "and so did the second one")
+            (is (some? (q (:container h) ".widget .kid"))
+                "and the children, in the component's own slot — forwarded
+                 by the gate as createElement's third argument")
+            (finally (mount/release! h))))))))
+
+(deftest the-escape-and-the-door-produce-the-same-dom
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (testing "HD-011's *reduced structural identity* is a claim about the
+                hiccup data lane — slot 1 holds a JS value compared by
+                identity — and about the fiber lane's crossing name. It is
+                NOT a claim about the DOM, and this row is why that can be
+                stated rather than hedged: the gate contributes no node of
+                its own, and `lane/canonical` serialises element and text
+                nodes and ignores comments, so a nil-rendering gate is
+                invisible to it"
+        (let [a (mount/root! (mount/fresh-container!) frame-id [escape-page {}])
+              b (mount/root! (mount/fresh-container!) frame-id [door-page {}])]
+          (try
+            (let [via-escape (lane/canonical (:container a))
+                  via-door   (lane/canonical (:container b))]
+              (is (re-find #"class=\"widget\"" via-escape)
+                  (str "precondition — the fixture renders something to
+                        compare, so the row cannot pass on two empty
+                        strings: " via-escape))
+              (is (= via-door via-escape)
+                  (str "BYTE-EQUAL. escape: " via-escape " / door: " via-door)))
+            (finally (mount/release! a) (mount/release! b)))))
+      (testing "and the crossing's own fiber is named by the CONSTANT, not
+                by the component — one greppable frame naming the form the
+                author wrote, with the component naming itself one level
+                down at zero cost"
+        (let [e (codec/as-element [:> widget {}])]
+          (is (= "[:>]" (.-displayName (.-type e)))))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — hydration: the first client pass matches, and adoption swaps
+;; ---------------------------------------------------------------------------
+
+(deftest the-escape-hydrates-with-nothing-there-and-mounts-after-adoption
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (do
+        (fresh!)
+        (reset! !renders 0)
+        (let [hiccup    [escape-page {}]
+              html      (server-html hiccup)
+              container (mount/fresh-container!)
+              {:keys [seen restore]} (watch-errors!)]
+          (set! (.-innerHTML container) html)
+          (let [root (react-dom-client/hydrateRoot
+                       container
+                       (mount/provider frame-id (codec/root-element frame-id hiccup))
+                       #js {:onRecoverableError
+                            (fn [err _info]
+                              (swap! seen conj (str "onRecoverableError: " (ex-message err))))})]
+            (js/setTimeout
+              (fn []
+                (try
+                  (is (not (re-find #"class=\"widget\"" html))
+                      (str "the markup hydrated FROM has no crossing in it — the
+                            row's own restatement of the policy, so a gate that
+                            stopped gating is red HERE and not only in the
+                            server-render row: " html))
+                  (is (empty? @seen)
+                      (str "REACT FOUND NOTHING TO RECONCILE. The client's first
+                            pass rendered what the server did — nothing — because
+                            both read the SAME snapshot, so there was no mismatch
+                            to repair: " (pr-str @seen)))
+                  (is (some? (q container ".widget"))
+                      "and after adoption the foreign component is mounted")
+                  (is (some? (q container ".widget .kid"))
+                      "with its children")
+                  (is (some? (q container ".title"))
+                      "and the server's own markup still in place around it —
+                       adoption, not a re-render of the page")
+                  (is (pos? @!renders)
+                      "the component ran on the client, and only on the client")
+                  (finally
+                    (restore)
+                    (.unmount root)
+                    (when-some [p (.-parentNode container)] (.removeChild p container))
+                    (rt/reset-runtime!)
+                    (done))))
+              150)))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — children capture the WRITING boundary's frame
+;; ---------------------------------------------------------------------------
+
+(deftest a-child-intent-fires-into-the-frame-that-wrote-the-crossing
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (testing "children lower EAGERLY at the crossing, inside the render
+                window of the boundary that wrote it, so a child's intent
+                closure captures that boundary's frame-locked dispatch at
+                lowering time — and fires into it however much later the
+                foreign component renders it. Two frames are live and the
+                page is mounted in ONE of them, so \"the right frame\" is
+                distinguishable from \"any frame\""
+        (let [other ::a-second-frame]
+          (fresh!)
+          (rf/make-frame {:id other})
+          (rf/with-frame other (rf/dispatch-sync [:raw/seed]))
+          (let [h (mount/root! (mount/fresh-container!) frame-id [intent-child-page {}])]
+            (try
+              (mount/settle!)
+              (is (some? (q (:container h) ".widget .pick"))
+                  "precondition: the child is mounted BENEATH the foreign
+                   component, so its handler really did cross")
+              (.click (q (:container h) ".pick"))
+              (mount/settle!)
+              (is (= ["child"] (:picked (db)))
+                  "the click dispatched into the frame that wrote the crossing")
+              (is (nil? (:picked (rf/app-db-value other)))
+                  "and nothing reached the other frame, which is what makes
+                   the ownership assertion non-vacuous")
+              (finally (mount/release! h)))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/raw_escape_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/raw_escape_dom_cljs_test.cljs
@@ -103,6 +103,16 @@
   widget that touches `window`."
   (atom 0))
 
+(def ^:private !own-props
+  "The OWN property names of the props object the foreign component was
+  last handed. Read by the childless row, which is the only place the
+  gate's `undefined?` branch is observable: `createElement(type, props,
+  undefined)` sets `children` to `undefined` rather than leaving it
+  absent, so a gate that forwarded unconditionally would hand the
+  component a key `defhost` never gives it — and conversion parity is a
+  claim about the object the component RECEIVES."
+  (atom nil))
+
 (defn- widget
   "A stand-in for the library's component. It renders REAL markup with
   real attributes so that a canonical comparison has something to
@@ -110,6 +120,7 @@
   visible in the DOM."
   [^js props]
   (swap! !renders inc)
+  (reset! !own-props (set (js/Object.keys props)))
   (react/createElement "div"
     #js {:className "widget" :data-live "yes" :data-variant (.-variant props)}
     (react/createElement "span" #js {:className "widget-label"} (.-label props))
@@ -142,6 +153,18 @@
    [:h1.title (rt/sub [:raw/title])]
    [declared-widget {:label (rt/sub [:raw/title]) :variant "compact"}
     [:span.kid "slotted"]]])
+
+(defview childless-escape-page
+  "A crossing with no children at all — the branch the gate takes when
+  `props.children` is absent."
+  [_]
+  [:div.page [:> widget {:label "bare" :variant "solo"}]])
+
+(defview childless-door-page
+  "Its control at the door, so the parity claim is measured rather than
+  assumed."
+  [_]
+  [:div.page [declared-widget {:label "bare" :variant "solo"}]])
 
 (defview intent-child-page
   "A crossing whose CHILD carries an intent. The child's handler is
@@ -238,6 +261,28 @@
                 "and the children, in the component's own slot — forwarded
                  by the gate as createElement's third argument")
             (finally (mount/release! h))))))))
+
+(deftest a-childless-crossing-hands-the-component-the-doors-own-props-object
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (testing "the gate forwards `props.children` as `createElement`'s
+                third argument, and forwarding it UNCONDITIONALLY would
+                write `children: undefined` onto a childless crossing —
+                a key the door never gives the component. Read off what
+                the component was actually handed, at both crossings"
+        (let [a (mount/root! (mount/fresh-container!) frame-id [childless-escape-page {}])
+              via-escape (do (mount/settle!) @!own-props)]
+          (mount/release! a)
+          (let [b (mount/root! (mount/fresh-container!) frame-id [childless-door-page {}])
+                via-door (do (mount/settle!) @!own-props)]
+            (mount/release! b)
+            (is (= #{"label" "variant"} via-escape)
+                (str "no `children` key at the escape: " (pr-str via-escape)))
+            (is (= via-door via-escape)
+                (str "and the same set the door hands it — escape: "
+                     (pr-str via-escape) " / door: " (pr-str via-door)))))))))
 
 (deftest the-escape-and-the-door-produce-the-same-dom
   (if-not (mount/browser?)

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -33,15 +33,15 @@
 
   Also absent, and worth naming so their absence reads as a decision
   rather than an omission: the `:r>` raw-props path, the class-component
-  `__rfArgv` crossing, the `[:>]` raw escape (HD-011 keeps it explicitly
-  secondary — the taught door is built below, and the escape stays
-  unbuilt until a case a static declaration cannot express actually
-  appears in the corpus), and the adapters' reserved-head and
-  keyword-prop diagnostics (public-boundary policy for a shipped
-  adapter; this codec has no public boundary, and the pre-alpha stance
-  is to trust the programmer). `defhost` — HD-011's taught door — is
-  NOT absent any more: [[mint-host!]] is the declaration and the host
-  head is the fourth element class, §Host heads below (rf2-2rtt6.65).
+  `__rfArgv` crossing, and the adapters' reserved-head and keyword-prop
+  diagnostics (public-boundary policy for a shipped adapter; this codec
+  has no public boundary, and the pre-alpha stance is to trust the
+  programmer). `defhost` — HD-011's taught door — is NOT absent any
+  more: [[mint-host!]] is the declaration and the host head is the
+  fourth element class, §Host heads below (rf2-2rtt6.65). Nor is the
+  `[:>]` raw escape, which HD-011 keeps explicitly secondary and which
+  is now built as [[raw-element]] — the same crossing with the
+  declaration erased (rf2-2rtt6.103).
   Neither is HD-011's SSR placeholder, which HD-020(d) left inert until
   the operator ruled SSR into scope: `:ssr` is a declaration option
   with three values (rf2-2rtt6.85, rf2-l0wfx). For the two gated ones
@@ -961,9 +961,10 @@
 ;; `defhost` is the door, and the only form taught. The declaration is a
 ;; VALUE — the foreign component, the finite `:callbacks` contract map,
 ;; and a name for the crossing — minted once and legal as a hiccup head
-;; anywhere. The `[:>]` raw escape stays unbuilt here, deliberately: it
-;; is HD-011's explicitly secondary form, for the cases a static
-;; declaration cannot express, and the census counts none.
+;; anywhere. The `[:>]` raw escape below is HD-011's explicitly
+;; secondary form, for the cases a static declaration cannot express;
+;; it is the SAME crossing with the declaration erased, and what erasing
+;; the declaration costs is exactly what the declaration carried.
 ;;
 ;; The declaration's `:callbacks` is a finite map from EXACT prop names
 ;; to `:event`, `:handler` or `:render` — NEVER inferred from an `on*`
@@ -2365,6 +2366,298 @@
     (when-some [k (:key props)] (unchecked-set js-props "key" k))
     (make-element (unchecked-get head "gate") js-props argv (if has-props? 2 1))))
 
+;; ---------------------------------------------------------------------------
+;; The `[:>]` raw escape (HD-011) — the door with the declaration erased
+;; ---------------------------------------------------------------------------
+;;
+;; `[:> Component props & children]` is HD-011's explicitly SECONDARY
+;; form, for the cases a static declaration cannot express: a component
+;; selected at runtime, a `memo`/`lazy` value, a component a render prop
+;; handed you, a provider an ecosystem library handed you, a one-off
+;; migration site. The guide's rule is unchanged — *declare what you use
+;; twice* — and bare-head auto-hosting stays rejected.
+;;
+;; **The model, in one sentence: `[:>]` is `defhost` with the
+;; declaration erased, and what erasing the declaration costs you is
+;; exactly what the declaration carried.** No author-chosen crossing
+;; name; no `:callbacks` contracts, so every prop here is UNCLAIMED; no
+;; `:ssr` policy, so the crossing is hard `:client-only` and that is
+;; unspellable; refusals at render time rather than once at a
+;; declaration; one generic marker for every crossing instead of a
+;; minted identity; and the JS require lands in the view namespace
+;; rather than in a `.cljc`-quarantined host one. Every remedy for every
+;; one of those is `defhost`. That is the design, not a coincidence.
+;;
+;; Three things follow, and they are the whole of the mechanism:
+;;
+;; 1. **The props walk is [[host-entry]], unchanged, with an EMPTY
+;;    declared roster.** Not a branch of its own — the same function,
+;;    reading a [[raw-crossing]] stand-in for the declaration it does not
+;;    have. That is what makes `[:> X …]` → `(defhost x X {})` a
+;;    behaviour-preserving rewrite, which is the whole theorem of the
+;;    migration codemod (rf2-2rtt6.106). A refusal that is right in
+;;    isolation and wrong in composition is wrong: whatever is ruled at
+;;    the door, the escape does the same thing.
+;;
+;; 2. **SSR is hard `:client-only`, through ONE shared module-level
+;;    gate** ([[raw-gate]]), reusing the snapshot triple `mint-host-gate!`
+;;    uses with the placeholder fixed at `nil`. There is no declaration
+;;    to carry a policy and no inline spelling for one — a fallback is
+;;    POLICY, and policy lives on declarations. The server emits nothing,
+;;    hydration's first client pass emits nothing, and adoption swaps the
+;;    component in: server-absent and first-pass-absent are not two facts
+;;    kept in step, they are ONE fact and React chooses it. A per-site
+;;    placeholder is still reachable with no new escape surface, by
+;;    wrapping the escape in a declared host that has one.
+;;
+;; 3. **The Component value is refused AT THE CROSSING**, in the owner's
+;;    render ([[raw-component]]). React's own "Element type is invalid"
+;;    is minted at fiber creation, which behind the gate is
+;;    post-adoption and client-only, and for any ClojureScript value it
+;;    reads *"got: object"* because it names `typeof` — naming nothing
+;;    the author wrote.
+;;
+;; What is NOT reduced: the canonical DOM. The gate contributes no node
+;; of its own and `lane/canonical` serialises element and text nodes, so
+;; a `[:>]` and a `defhost` on the same component produce the same DOM in
+;; every phase. The hiccup data lane is reduced at exactly ONE slot —
+;; slot 1 holds a JS value compared by identity — and that is the whole
+;; of HD-011's "reduced structural identity". The fiber lane carries one
+;; shared gate type named by the constant `"[:>]"`; no name is derived
+;; from the component, because React resolves `displayName || name ||
+;; null`, Closure renames `.name` under `:advanced`, and foreign
+;; production bundles routinely ship without `displayName` — a derived
+;; identity would be build-dependent. `defhost` has no such problem
+;; because its name is authored DATA. The component's own fiber sits
+;; directly beneath the gate and React names it there, so a tree reads
+;; `<[:>]>` → `<DatePicker>`: one greppable frame naming the form the
+;; author wrote, and the component naming itself one level down.
+
+(def ^:private raw-crossing
+  "What [[host-entry]] reads at a `[:>]` prop in place of a declaration:
+  a `displayName` for its refusal messages and an EMPTY roster. The
+  escape has no `mint-host!` and mints nothing per site — this is one
+  module-level value, and `callbacks` is a ClojureScript map because
+  that is what the refusals project into their `:declared` ex-data."
+  #js {"displayName" "[:>]"
+       "callbacks"   {}})
+
+(def ^:private raw-gate
+  "THE ONE GATE, shared by every `[:>]` crossing on every page.
+
+  A one-hook component whose `useSyncExternalStore` answers `false` from
+  its SERVER snapshot and `true` from its client one — the same triple
+  [[mint-host-gate!]] uses, with the placeholder fixed at `nil`, which
+  is what `:client-only` already compiles to at the door.
+
+  **Shared rather than minted per component**, and that is a ruling
+  rather than a saving. A component-keyed cache is the identity-keyed
+  auto-hosting HD-011 rejected, wearing a different hat; it also cannot
+  be built, because React's built-in wrapper types (`Fragment`,
+  `Suspense`, `StrictMode`, `Profiler`) are `Symbol.for` values and
+  ES2024 excludes REGISTERED symbols as `WeakMap` keys by design. One
+  constant type is stable for every component including those, and a
+  runtime component swap at one site keeps the gate's fiber while
+  remounting the inner subtree — which is the correct grain for the
+  escape's first named use case.
+
+  **The carrier is two slots on the gate's own props**, `c` and `p` —
+  the shape [[boundary-element]] already uses for `rfProps` — so the
+  object the foreign component receives is exactly the one
+  [[raw-element]] built, with nothing of ours in it. Carrying the
+  component BESIDE the converted props and stripping it inside would
+  cost a shallow copy per crossing per render and leave an internal key
+  one bug away from reaching React; two slots make that leak
+  unrepresentable instead. Children ride on the OUTER element via
+  [[make-element]]'s existing arms and are forwarded here as
+  `createElement`'s third argument — which is why the childless case is
+  its own branch: passing `undefined` as a third argument WRITES
+  `children` onto the inner props, and conversion parity with the door
+  is a claim about the object the component receives."
+  (let [gate (fn [^js props]
+               (if (react/useSyncExternalStore
+                     gate-no-subscribe gate-adopted gate-unadopted)
+                 (let [component (unchecked-get props "c")
+                       js-props  (unchecked-get props "p")
+                       kids      (unchecked-get props "children")]
+                   (if (undefined? kids)
+                     (react/createElement component js-props)
+                     (react/createElement component js-props kids)))
+                 nil))]
+    (unchecked-set gate "displayName" "[:>]")
+    gate))
+
+(defn- ^boolean react-exotic?
+  "Is `x` one of React's built-in wrapper TYPES — `Fragment`,
+  `Suspense`, `StrictMode`, `Profiler`, and whatever it ships next?
+
+  They are all `Symbol.for(…)` values, so the test is the JS type and
+  not a roster: enumerating them would false-refuse the next one React
+  adds, and a hatch that refuses a legal component is worse than one
+  that passes an illegal value through to React's own error."
+  [x]
+  (identical? "symbol" (goog/typeOf x)))
+
+(defn- ^boolean react-wrapper-object?
+  "Is `x` one of React's wrapper OBJECTS — a `memo` or `lazy` product, a
+  context, a consumer, a `forwardRef`? All of them are plain objects
+  carrying a `$$typeof` brand, and asking for the brand is what keeps
+  this open to the ones React has not shipped yet. A ClojureScript map,
+  vector, set, record or keyword is not a plain object and never reaches
+  the second test."
+  [x]
+  (and (object? x) (some? (unchecked-get x "$$typeof"))))
+
+(defn- raw-component-shape
+  "What sits in the Component position, NAMED rather than printed —
+  [[key-shape]]'s discipline, applied at the one crossing in this codec
+  most likely to be handed a foreign or cyclic value. TOTAL, so no arm
+  falls through to the value itself."
+  [c]
+  (cond
+    (string? c)              "a string"
+    (keyword? c)             "a keyword"
+    (symbol? c)              "a symbol"
+    (boundary-head? c)       "a defview product"
+    (host-head? c)           "a defhost product"
+    (react/isValidElement c) "a React element"
+    (map? c)                 "a map"
+    (vector? c)              "a vector"
+    (set? c)                 "a set"
+    (coll? c)                "a collection"
+    (ifn? c)                 "callable, but not a function"
+    :else                    "a foreign object"))
+
+(defn- raw-component-fix
+  "The recovery sentence for one confusion — the discriminating half of
+  the refusal, which is what makes a single error id enough."
+  [c]
+  (cond
+    (or (string? c) (keyword? c) (symbol? c))
+    (str "A tag belongs to the grammar, not to this position: write the tag "
+         "— [:div …] — or, for a tag chosen at runtime, a computed KEYWORD "
+         "head, which keeps the parse and the controlled-input door that "
+         "[:> \"input\" …] would silently drop.")
+
+    (boundary-head? c)
+    (str "A Hicasso view is a head in its own right: write [my-view …]. "
+         "Mounted raw it would read rfProps, get undefined, and receive nil "
+         "props — silently.")
+
+    (host-head? c)
+    (str "A declared host is a head in its own right: write [my-host …]. "
+         "The escape is for what a declaration cannot express, and this "
+         "one already is a declaration.")
+
+    (react/isValidElement c)
+    (str "An element is a legal CHILD, never a type: put it in child "
+         "position, or hand [:>] the component it was built from.")
+
+    (ifn? c)
+    (str "It is callable, but React takes a real function: wrap it — "
+         "(fn [props] (f props)) — or declare the crossing with defhost.")
+
+    :else
+    (str "[:>] takes what React accepts as an element type: a function or "
+         "class component, one of React's built-in wrappers (Fragment, "
+         "Suspense, …), or a memo / lazy / forwardRef / context value.")))
+
+(defn- fail-raw-component!
+  [c]
+  (let [shape (raw-component-shape c)]
+    (fail! :rf.error/hicasso-raw-not-a-component
+           'front.codec/raw-element
+           (str "[:>] was handed " shape " in the Component position. "
+                (raw-component-fix c))
+           :hand-the-escape-a-component-react-accepts
+           {:shape shape})))
+
+(defn- raw-component
+  "The Component slot of a `[:>]` vector, or a loud refusal.
+
+  The accepted set is what React 19's reconciler mints a fiber for —
+  functions (function and class components alike), the built-in
+  `Symbol.for` exotics, and objects branded with a `$$typeof` — MINUS
+  three deliberate narrowings:
+
+  - **`nil`**, which is the classic broken-interop symptom (`:default`
+    against a library with no default export) and gets the door's own
+    diagnosis. `[:>]` with nothing after it lands here too.
+  - **strings and keywords**, because the GRAMMAR owns tags. Reagent's
+    `[:> \"input\" …]` took its controlled-input wrapper on exactly this
+    path, so accepting a string here would silently drop caret and IME
+    protection at a site a migrator ports verbatim. A dynamic tag is a
+    computed KEYWORD head, which keeps the parse and the controlled
+    door.
+  - **`defview` and `defhost` heads**, which React would accept and
+    which are silent breakage: a `defview` product is `fn?`-true, so a
+    bare \"is it a function\" test mounts the shell raw, the body reads
+    `rfProps`, gets `undefined`, and receives nil props. That is the
+    shape a migration produces.
+
+  Refused HERE, in the owner's render window and on the server too,
+  rather than delegated to React: React's refusal is minted at fiber
+  creation, which behind [[raw-gate]] is post-adoption and client-only,
+  and its message names `typeof type` — so a keyword, map, vector, set
+  or record all read *\"got: object\"*."
+  [argv]
+  (let [c (nth argv 1 nil)]
+    (cond
+      (nil? c)
+      (fail! :rf.error/hicasso-raw-no-component
+             'front.codec/raw-element
+             (str "[:>] was given " (if (< (count argv) 2) "no component at all" "nil")
+                  " in the Component position. The usual cause is a JS import "
+                  "that resolved nothing — e.g. `:default` against a library "
+                  "with no default export. Write [:> Component props & "
+                  "children], or declare the crossing with defhost.")
+             :hand-the-escape-a-real-component
+             {:argv-count (count argv)})
+
+      ;; Ahead of `fn?`, because both marked heads ARE functions or carry
+      ;; one and React would accept them.
+      (boundary-head? c)   (fail-raw-component! c)
+      (host-head? c)       (fail-raw-component! c)
+
+      (fn? c)              c
+      (react-exotic? c)    c
+
+      ;; Ahead of the `$$typeof` accept, because a React ELEMENT is an
+      ;; object carrying one — and an element is a legal CHILD, never a
+      ;; type.
+      (react/isValidElement c) (fail-raw-component! c)
+
+      (react-wrapper-object? c) c
+      :else                     (fail-raw-component! c))))
+
+(defn- raw-element
+  "One `[:> Component props & children]` vector as a React element.
+
+  The indices are the door's, shifted by one: the component is at 1, the
+  attribute map at 2 when there is one, children from 3 or from 2.
+  `[:> Component]` with neither is legal.
+
+  Everything after the component is [[host-element]]'s own body: fold a
+  `:&` remainder under the owned-literal law BEFORE conversion (HD-023
+  clause (d) — the conversion that follows is the position's own),
+  extract `:key` onto the crossing's outer element, and walk every prop
+  through [[host-entry]] against an EMPTY declared roster. Children lower
+  eagerly, here, inside the render window of the boundary that wrote the
+  crossing — so an intent closure in a `[:>]` child captures that
+  boundary's frame-locked dispatch and fires into the right frame however
+  much later the foreign component renders it.
+
+  The element's TYPE is always [[raw-gate]]; the component rides in the
+  carrier's `c` slot."
+  [argv]
+  (let [component  (raw-component argv)
+        has-props? (props-map? argv 2)
+        props      (merge-caller (if has-props? (nth argv 2) {}))
+        js-props   (reduce-kv (partial host-entry raw-crossing {}) #js {} props)
+        carrier    #js {"c" component "p" js-props}]
+    (when-some [k (:key props)] (unchecked-set carrier "key" k))
+    (make-element raw-gate carrier argv (if has-props? 3 2))))
+
 (defn- fragment-element [argv]
   (let [has-props? (props-map? argv 1)
         props      (if has-props? (nth argv 1) nil)
@@ -2381,9 +2674,29 @@
   [head]
   (= :<> head))
 
-(defn- hiccup-tag? [head]
-  (and (or (keyword? head) (symbol? head) (string? head))
-       (not (fragment-head? head))))
+(defn- raw-head?
+  "Is this the raw-escape spelling? Compared with `=` for
+  [[fragment-head?]]'s own reason, and it is sharper here: `:>` was NOT
+  an error before rf2-2rtt6.103 — [[hiccup-tag?]] accepted any keyword
+  that is not `:<>`, so `[:> Foo {}]` asked React for an element
+  literally named `<>`. An `identical?` test would work under
+  `:advanced`, where the build interns keyword literals, and silently
+  route every escape back into that native path everywhere else."
+  [head]
+  (= :> head))
+
+(defn- hiccup-tag?
+  "Is this head a native tag? Asked AFTER the fragment and raw arms in
+  [[vec->element]]'s `cond`, which is its only caller — so the
+  `(not (fragment-head? head))` this body used to re-ask was provably
+  dead, and every native tag on every page paid the fragment `=` twice
+  for it. Dropping it is what pays for [[raw-head?]] exactly: a keyword
+  tag paid two `=` and one type predicate before, and pays two `=` and
+  one type predicate now. This codec has costed a `keyword?`
+  short-circuit at ±51–67% of a walk, so a new head test is not free by
+  assertion on this surface — it is free by accounting."
+  [head]
+  (or (keyword? head) (symbol? head) (string? head)))
 
 (defn vec->element
   "Interpret one hiccup vector."
@@ -2397,23 +2710,25 @@
   (let [head (nth argv 0)]
     (cond
       (fragment-head? head)   (fragment-element argv)
+      (raw-head? head)        (raw-element argv)
       (hiccup-tag? head)      (native-element argv)
       (boundary-head? head)   (boundary-element argv)
       (host-head? head)       (host-element argv)
       :else
       (throw (ex-info (str "Hiccup head " (pr-str head) " is not a valid element head; "
-                           "use a tag keyword, :<>, a view minted by defview, or a "
+                           "use a tag keyword, :<>, :>, a view minted by defview, or a "
                            "host minted by defhost. "
                            "A plain function in head position is never a silent "
                            "embedding — call it, or make it a view. A raw JS "
                            "component is never a silent embedding either — "
-                           "declare it (HD-011). "
+                           "declare it with defhost, or write the escape "
+                           "[:> Component …] (HD-011). "
                            "[:rf.error/hicasso-bad-head]")
                       {:rf.error/id :rf.error/hicasso-bad-head
                        :where       'front.codec/vec->element
                        :reason      (if (fn? head)
                                       "A plain function in head position is a loud error (HD-016)."
-                                      "Hiccup head must be a tag keyword, :<>, a defview product, or a defhost product.")
+                                      "Hiccup head must be a tag keyword, :<>, :>, a defview product, or a defhost product.")
                        :recovery    (if (fn? head) :call-it-or-make-it-a-view :supply-a-valid-hiccup-head)})))))
 
 (defn as-element

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
@@ -880,6 +880,347 @@
                             (codec/as-element [a-host {:ref reserved}]))))))
 
 ;; ---------------------------------------------------------------------------
+;; The `[:>]` raw escape (HD-011, rf2-2rtt6.103)
+;; ---------------------------------------------------------------------------
+;;
+;; The escape is `defhost` with the declaration erased, so almost every
+;; row below is a PARITY row: the same fixture component, the same prop
+;; corpus, one answer. What is not parity is stated as its own row — the
+;; carrier, the head test, the value roster, and the fact that no `:ssr`
+;; policy is spellable here (the DOM/SSR half of that lives in
+;; `arm1/raw_escape_dom_cljs_test`, which needs a server renderer).
+
+(defn- raw-carrier
+  "The gate element's own props — the two-slot carrier."
+  [e]
+  (.-props e))
+
+(defn- raw-component-of [e] (aget (raw-carrier e) "c"))
+
+(defn- raw-props
+  "The props object the FOREIGN component receives: the gate hands its
+  `p` slot straight through, so this is the object under test in every
+  parity row."
+  [e]
+  (aget (raw-carrier e) "p"))
+
+(defn- raw-prop
+  "The value the escape emitted at `slot` for a one-prop crossing —
+  [[host-prop]]'s twin, so the two can be read against each other."
+  [k v slot]
+  (aget (raw-props (codec/as-element [:> a-foreign-component {k v}])) slot))
+
+(defn- crossed-same?
+  "Did the two crossings answer the same thing? Functions by identity —
+  which is the point of the row — and everything else by value, through
+  `js->clj`, because two `clj->js` results are two distinct objects and
+  `=` on those is identity."
+  [a b]
+  (if (fn? a) (identical? a b) (= (js->clj a) (js->clj b))))
+
+(defn- error-id [f]
+  (try (f) ::did-not-throw (catch :default e (:rf.error/id (ex-data e)))))
+
+(deftest the-escape-is-a-crossing-and-not-a-tag-named-angle-bracket
+  (testing "THE MIS-PARSE REGRESSION. `:>` was not an error before this:
+            `hiccup-tag?` accepted any keyword that is not `:<>`, so
+            `[:> Foo {}]` routed to the native path and asked React for
+            an element literally named `<>`"
+    (let [e (codec/as-element [:> a-foreign-component {}])]
+      (is (not= ">" (el-type e)) "not a native tag any more")
+      (is (fn? (el-type e)) "a component — the shared gate")
+      (is (= "[:>]" (.-displayName (el-type e)))
+          "named by the CONSTANT, never by the component: React resolves
+           `displayName || name || null`, Closure renames `.name` under
+           :advanced, and foreign production bundles ship without
+           displayName — so any derived identity is build-dependent")
+      (is (identical? a-foreign-component (raw-component-of e))
+          "and the component rides in the carrier's `c` slot")))
+  (testing "the head is compared with `=` and never `identical?`. A
+            keyword built at runtime is a DIFFERENT object from the
+            literal, so an identity test would work under :advanced —
+            where the build interns literals — and silently route every
+            escape back into the native path everywhere else"
+    (let [computed (keyword ">")]
+      (is (not (identical? :> computed))
+          "precondition: the row is only meaningful because these are two
+           objects")
+      (is (= "[:>]" (.-displayName (el-type (codec/as-element [computed a-foreign-component {}])))))))
+  (testing "and the arms either side of the new one are untouched"
+    (is (= (.-Fragment react) (el-type (codec/as-element [:<> "x"]))))
+    (is (= "div" (el-type (codec/as-element [:div]))))
+    (is (= "toString" (el-type (codec/as-element [:toString])))
+        "the redundant second fragment test that paid for this arm is
+         gone; a native tag still parses as itself")))
+
+(deftest conversion-parity-with-the-door-on-one-prop-corpus
+  (testing "THE LOAD-BEARING ROW. HD-011 rules that the escape lowers
+            through the SAME foreign path with the SAME default
+            conversions, and one walk serves both — so this is an
+            identity by construction and the row is a tripwire against a
+            future fork rather than a detector of a present one"
+    (let [f       (fn [_])
+          ref-fn  (fn [_node])
+          corpus  {:on-thing   f
+                   :plain-fn   f
+                   :menu-items [{:day-of-week 1}]
+                   :options    {:pageSize 10}
+                   :variant    :compact
+                   :theme      :theme/dark
+                   :class      ["btn" nil :on]
+                   :className  "wide"
+                   :aria-label :close
+                   :data-kind  :row
+                   :id         :greeting
+                   :role       :dialog
+                   :label      "due date"
+                   :count      7
+                   :open       true
+                   :ref        ref-fn}
+          door    (.-props (codec/as-element [a-host corpus]))
+          raw     (raw-props (codec/as-element [:> a-foreign-component corpus]))]
+      (is (= (vec (sort (js/Object.keys door))) (vec (sort (js/Object.keys raw))))
+          "prop for prop, the same emitted slots")
+      (doseq [k (js/Object.keys door)]
+        (is (crossed-same? (aget door k) (aget raw k))
+            (str "the slot " k " crossed the same way at both")))))
+  (testing "including the two conversions that are the slot's own rather
+            than the walk's — the class coercion (rf2-2rtt6.119) and the
+            named value bound for an HTML attribute (rf2-vrvv9)"
+    (is (= "a b" (raw-prop :class ["a" nil :b] "className")))
+    (is (= "dark" (raw-prop :class :theme/dark "className")))
+    (is (= :theme/dark (raw-prop :value :theme/dark "value"))
+        "and NOT at an ordinary slot: the keyword crosses whole"))
+  (testing "the class slot composes across spellings here too, because the
+            rule is on the SLOT and the walk is the door's"
+    (let [e (codec/as-element [:> a-foreign-component {:class "a" :x/class ["b" :c]}])]
+      (is (= "a b c" (aget (raw-props e) "className"))))))
+
+(deftest the-carrier-never-leaks-and-key-rides-the-outer-element
+  (testing "the foreign component's props carry NEITHER internal slot.
+            Carrying the component beside the converted props and
+            stripping it inside would cost a shallow copy per crossing
+            per render and leave the key one bug away from React; two
+            slots make the leak unrepresentable instead"
+    (let [p (raw-props (codec/as-element [:> a-foreign-component {:label "x"}]))]
+      (is (= ["label"] (vec (sort (js/Object.keys p)))))))
+  (testing "and the carrier itself holds exactly the two slots, plus
+            children when there are any"
+    (is (= ["c" "p"] (vec (sort (js/Object.keys (raw-carrier (codec/as-element [:> a-foreign-component {}])))))))
+    (is (= ["c" "children" "p"]
+           (vec (sort (js/Object.keys (raw-carrier (codec/as-element [:> a-foreign-component {} [:span]]))))))))
+  (testing "`:key` is React's contract on the crossing's own element, not
+            an attribute and not a carrier slot — the door's rule,
+            unchanged"
+    (let [e (codec/as-element [:> a-foreign-component {:key "k7" :label "x"}])]
+      (is (= "k7" (el-key e)))
+      (is (nil? (aget (raw-carrier e) "key")))
+      (is (= ["label"] (vec (sort (js/Object.keys (raw-props e))))))))
+  (testing "a childless crossing does not write `children` onto the props
+            the component receives — which is what makes the parity row
+            above a claim about the object rather than about our walk"
+    (is (not (contains? (set (js/Object.keys (raw-props (codec/as-element [:> a-foreign-component {}]))))
+                        "children")))))
+
+(deftest the-escape-takes-the-doors-unclaimed-slot-conduct-exactly
+  (testing "every slot at this crossing is UNCLAIMED — the roster is
+            empty by construction — so the escape inherits `host-entry`'s
+            conduct with no branch of its own. That is what makes
+            `[:> X …]` → `(defhost x X {})` behaviour-preserving, which
+            is the whole theorem of the migration codemod"
+    (testing "an intent vector at an event-SPELLED slot refuses loudly"
+      (try
+        (codec/as-element [:> a-foreign-component {:on-pick [:boom]}])
+        (is false "should have thrown")
+        (catch :default e
+          (let [d (ex-data e)]
+            (is (= :rf.error/hicasso-host-undeclared-callback (:rf.error/id d)))
+            (is (= :on-pick (:position d)))
+            (is (= "[:>]" (:host d)) "the crossing names the form the author wrote")
+            (is (= #{} (:declared d)) "against an empty roster")))))
+    (testing "and so does an event-spelled key-map"
+      (is (= :rf.error/hicasso-host-undeclared-callback
+             (error-id #(codec/as-element [:> a-foreign-component {:on-key-down {"Enter" [:boom]}}])))))
+    (testing "a MARKED h/fn at any slot refuses — rf2-2rtt6.116's ruling,
+              inherited rather than forked. The mark asks the position for
+              a contract and here no position can ever select one"
+      (let [marked (intent/callback (fn [x] [:row/pick x]))]
+        (is (= :rf.error/hicasso-host-unclaimed-callback
+               (error-id #(codec/as-element [:> a-foreign-component {:on-value-change marked}]))))
+        (is (= :rf.error/hicasso-host-unclaimed-callback
+               (error-id #(codec/as-element [:> a-foreign-component {:row-formatter marked}])))
+            "the mark is the trigger, never the on* spelling")))
+    (testing "a PLAIN function crosses by identity — the fence, and the
+              reason React.memo and every downstream bail-out that
+              compares handler identity keep working"
+      (let [f (fn [_])]
+        (is (identical? f (raw-prop :on-value-change f "onValueChange")))))
+    (testing "an intent vector at a NON-event slot is ordinary data"
+      (is (= ["a" "b"] (js->clj (raw-prop :columns ["a" "b"] "columns")))))
+    (testing "`:ref` takes HD-016's rule at this crossing exactly as at the
+              door: a callback ref through, the reserved vector refused"
+      (let [r (fn [_node])]
+        (is (identical? r (raw-prop :ref r "ref"))))
+      (is (= :rf.error/hicasso-ref-vector-reserved
+             (error-id #(codec/as-element [:> a-foreign-component {:ref [::autosize {}]}])))))))
+
+(deftest the-ampersand-law-holds-at-the-escape-before-conversion
+  (testing "HD-023 clause (d): `:&` is merged BEFORE conversion and the
+            conversion that follows is the position's own. Asserted on
+            what the foreign component RECEIVED, not on the hiccup"
+    (let [p (raw-props (codec/as-element
+                         [:> a-foreign-component
+                          {:& {:className "react-name" :selected "caller"}
+                           :selected "owned"}]))]
+      (is (= "react-name" (aget p "className"))
+          "a remainder key crosses under the slot it names")
+      (is (= "owned" (aget p "selected"))
+          "and the owned literal wins, unconditionally")))
+  (testing "the deny is on the canonical SLOT, so a remainder reaches
+            neither structural slot however it is spelled"
+    (doseq [k [:key "key" :x/key]]
+      (is (nil? (el-key (codec/as-element [:> a-foreign-component {:& {k "hostile"}}])))
+          (str "forwarded as " (pr-str k))))
+    (is (nil? (aget (raw-props (codec/as-element [:> a-foreign-component {:& {:ref "hostile"} :ref (fn [_])}]))
+                    "hostile"))))
+  (testing "and the merge is the SAME one — a non-map remainder is the
+            same loud error at this crossing"
+    (is (= :rf.error/hicasso-merge-not-a-map
+           (error-id #(codec/as-element [:> a-foreign-component {:& "nope"}]))))))
+
+(deftest children-lower-eagerly-and-ride-the-outer-element
+  (testing "trailing forms lower here, in the render window of the
+            boundary that wrote the crossing, through `make-element`'s
+            existing three arms — so an intent closure in a child
+            captures the owner's frame-locked dispatch at LOWERING time
+            (the two-frame proof of that is the DOM witness)"
+    (let [one (raw-carrier (codec/as-element [:> a-foreign-component {} [:span "x"]]))]
+      (is (= "span" (.-type (aget one "children")))
+          "one child: an element, not hiccup"))
+    (let [many (raw-carrier (codec/as-element [:> a-foreign-component {} [:span "a"] [:b "c"]]))
+          kids (aget many "children")]
+      (is (array? kids))
+      (is (= ["span" "b"] (mapv #(.-type %) (vec kids))))))
+  (testing "the attribute map is optional, and the indices shift by one
+            from the door's: component at 1, props at 2 when it is a map,
+            children from 3 or from 2"
+    (let [e (codec/as-element [:> a-foreign-component [:span "no props"]])]
+      (is (= "span" (.-type (aget (raw-carrier e) "children"))))
+      (is (= [] (vec (sort (js/Object.keys (raw-props e)))))))
+    (is (some? (codec/as-element [:> a-foreign-component]))
+        "[:> Component] with neither props nor children is legal"))
+  (testing "a lowered intent inside a `[:>]` child is the ordinary
+            frame-locked one — the crossing is transparent to it"
+    (let [!seen (atom [])
+          e     (intent/with-frame (fn [ev] (swap! !seen conj ev))
+                                   (fn [] (codec/as-element
+                                            [:> a-foreign-component {}
+                                             [:button {:on-click [:go]}]])))
+          child (aget (raw-carrier e) "children")]
+      ((aget (.-props child) "onClick") #js {:target #js {}})
+      (is (= [[:go]] @!seen)))))
+
+;; --- Edge 4: the legal Component value -------------------------------------
+;;
+;; THE PINNING ROSTER, and it is not optional. The accepted set is a
+;; REPLICA of what React 19's reconciler mints a fiber for, so a React
+;; upgrade that moved the boundary would have this escape false-refusing
+;; a legal component — the worst failure a hatch can have. These rows
+;; turn that into a red row instead of a silent ship: the accepts assert
+;; that each category crosses, and the refusals assert the id AND the
+;; discriminating reason rather than merely "it threw".
+
+(defn- accepts? [c] (identical? c (raw-component-of (codec/as-element [:> c {}]))))
+
+(deftest every-category-react-mints-a-fiber-for-crosses
+  (testing "functions and classes"
+    (is (accepts? a-foreign-component))
+    (is (accepts? (fn [_]))))
+  (testing "React's built-in `Symbol.for` exotics — the reason a
+            component-keyed weak cache could not have been the mechanism:
+            ES2024 excludes REGISTERED symbols as WeakMap keys by design"
+    (is (accepts? (.-Suspense react)))
+    (is (accepts? (.-Fragment react)))
+    (is (accepts? (.-StrictMode react)))
+    (is (accepts? (.-Profiler react))))
+  (testing "and the `$$typeof`-branded wrapper objects"
+    (is (accepts? (react/memo a-foreign-component)))
+    (is (accepts? (react/lazy (fn [] (js/Promise.resolve #js {:default a-foreign-component})))))
+    (is (accepts? (react/forwardRef (fn [_p _r] nil))))
+    (let [ctx (react/createContext "unset")]
+      (is (accepts? ctx) "a context is a legal type in React 19")
+      (is (accepts? (.-Provider ctx)))
+      (is (accepts? (.-Consumer ctx)))))
+  (testing "`Suspense` and `lazy` in particular are a PAIR — lazy requires
+            a Suspense ancestor, and HD-011 names that pairing as a reason
+            the escape exists, so a roster that took one and not the other
+            would be unsound"
+    (is (some? (codec/as-element [:> (.-Suspense react) {}
+                                  [:> (react/lazy (fn [] (js/Promise.resolve #js {:default a-foreign-component}))) {}]])))))
+
+(deftest a-value-react-would-not-mint-a-fiber-for-is-refused-at-the-crossing
+  (testing "refused HERE, in the owner's render and on the server too,
+            rather than by React. React's own 'Element type is invalid'
+            is minted at fiber creation — behind the gate that is
+            post-adoption and client-only — and it names `typeof type`,
+            so a keyword, map, vector, set or record all read
+            'got: object'"
+    (testing "nil, and the bare form: the broken-import diagnosis"
+      (let [d (ex-data (try (codec/as-element [:> nil {}]) nil (catch :default e e)))]
+        (is (= :rf.error/hicasso-raw-no-component (:rf.error/id d)))
+        (is (= :hand-the-escape-a-real-component (:recovery d))))
+      (is (= :rf.error/hicasso-raw-no-component (error-id #(codec/as-element [:>])))))
+    (testing "a string or a keyword: the GRAMMAR owns tags. Reagent's
+              `[:> \"input\" …]` took its controlled-input wrapper on
+              exactly this path, so accepting one would silently drop
+              caret and IME protection at a site a migrator ports verbatim"
+      (doseq [c ["input" "div" :div]]
+        (let [d (ex-data (try (codec/as-element [:> c {}]) nil (catch :default e e)))]
+          (is (= :rf.error/hicasso-raw-not-a-component (:rf.error/id d)) (str "for " (pr-str c)))
+          (is (re-find #"computed KEYWORD head" (:reason d))
+              "and the message says what to write instead"))))
+    (testing "a defview head, which React WOULD accept — it is fn?-true,
+              so a bare 'is it a function' test mounts the shell raw, the
+              body reads rfProps, gets undefined, and receives nil props"
+      (let [d (ex-data (try (codec/as-element [:> a-view {}]) nil (catch :default e e)))]
+        (is (= :rf.error/hicasso-raw-not-a-component (:rf.error/id d)))
+        (is (= "a defview product" (:shape d)))
+        (is (re-find #"\[my-view" (:reason d)))))
+    (testing "a defhost head — the escape is for what a declaration cannot
+              express, and this one already IS a declaration"
+      (let [d (ex-data (try (codec/as-element [:> a-host {}]) nil (catch :default e e)))]
+        (is (= "a defhost product" (:shape d)))
+        (is (re-find #"\[my-host" (:reason d)))))
+    (testing "a React ELEMENT, which is a legal child and never a type"
+      (let [d (ex-data (try (codec/as-element [:> (codec/as-element [:div]) {}]) nil (catch :default e e)))]
+        (is (= "a React element" (:shape d)))
+        (is (re-find #"legal CHILD" (:reason d)))))
+    (testing "and the ClojureScript shapes React would answer
+              'got: object' for — each NAMED rather than printed, because
+              a foreign or cyclic value would blow `pr-str` inside a
+              diagnostic"
+      (doseq [[c shape] [[{:a 1} "a map"]
+                         [[:a 1] "a vector"]
+                         [#{:a} "a set"]
+                         [(list :a) "a collection"]
+                         [(js/Date.) "a foreign object"]]]
+        (let [d (ex-data (try (codec/as-element [:> c {}]) nil (catch :default e e)))]
+          (is (= :rf.error/hicasso-raw-not-a-component (:rf.error/id d)) (str "for " shape))
+          (is (= shape (:shape d))))))
+    (testing "a non-fn IFn — an r/partial, a multimethod, a keyword used
+              as a lookup — is a WORKING Reagent site that would die here
+              as an opaque object. The refusal steers to wrapping it"
+      (let [d (ex-data (try (codec/as-element [:> (reify IFn (-invoke [_ _] nil)) {}])
+                            nil (catch :default e e)))]
+        (is (= "callable, but not a function" (:shape d)))
+        (is (re-find #"\(fn \[props\]" (:reason d)))))
+    (testing "the shape is in ex-data and the discriminating reason is in
+              the message — one error id is enough because the message
+              carries the difference"
+      (is (re-find #"was handed a map in the Component position"
+                   (ex-message (try (codec/as-element [:> {:a 1} {}]) nil (catch :default e e))))))))
+
+;; ---------------------------------------------------------------------------
 ;; What the codec must NOT be
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
@@ -1014,7 +1014,14 @@
             unchanged"
     (let [e (codec/as-element [:> a-foreign-component {:key "k7" :label "x"}])]
       (is (= "k7" (el-key e)))
-      (is (nil? (aget (raw-carrier e) "key")))
+      ;; `Object.keys` rather than a read of `.key`: React 19 defines a
+      ;; DEV warning getter at that name on any props object it built
+      ;; from a config carrying a key, so reading it would put React's
+      ;; "`key` is not a prop" line in the shared test log — an assertion
+      ;; whose own mechanism is a console warning. The getter is
+      ;; non-enumerable, so this sees the truth without touching it.
+      (is (= ["c" "p"] (vec (sort (js/Object.keys (raw-carrier e)))))
+          "the key is React's on the element and is not a carrier slot")
       (is (= ["label"] (vec (sort (js/Object.keys (raw-props e))))))))
   (testing "a childless crossing does not write `children` onto the props
             the component receives — which is what makes the parity row

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
@@ -373,10 +373,40 @@
                           :reason reason :recovery recovery}
                          extra))))
 
-(defn- require-dispatch [intent]
+(defn- require-dispatch
+  "The frame-locked dispatch this lowering needs, or the loud refusal.
+
+  **The message offers TWO readings, because the runtime cannot tell
+  them apart** (rf2-2rtt6.103). `*dispatch*` being `nil` says only that
+  no render window is binding one; it does not say why, and the two
+  whys want opposite repairs:
+
+  1. The form really was lowered outside any boundary — a declaration,
+     a `defhost` fallback, a module-level `def`. Lower it in a body.
+  2. The form was lowered inside a function some foreign component
+     invokes LATER, after the render window that bound the dispatch has
+     unwound. **A function prop on a `[:>]` crossing is exactly this**:
+     the escape carries no declaration, so no position claims the slot
+     and nothing installs the render wrapper that captures the owner's
+     dispatch and forwards to it. From where the author sits they ARE
+     inside a boundary's render — they wrote the crossing in a body — so
+     a message offering only reading 1 reads as a framework bug.
+
+  Naming `defhost`'s `:callbacks {… :render}` is what makes reading 2
+  actionable: a declared `:render` slot is the position that owns the
+  frame, and declaring it is the whole of the repair."
+  [intent]
   (or *dispatch*
-      (throw (ex-info (str "Intent " (pr-str intent) " was lowered with no ambient frame; "
-                           "event vectors are only legal inside a boundary's render. "
+      (throw (ex-info (str "Intent " (pr-str intent) " was lowered with no ambient frame. "
+                           "Either the form is outside any boundary's render — a "
+                           "declaration, a fallback, a module-level def — in which case "
+                           "lower it inside a body; or it is inside a function a foreign "
+                           "component invokes after that render returned, which is what a "
+                           "function prop on a [:>] crossing is: the escape carries no "
+                           "declaration, so nothing claims the slot and nothing forwards "
+                           "to the owner. Declare the crossing instead — defhost with "
+                           ":callbacks {<the prop> :render} — and the position owns the "
+                           "frame. "
                            "[:rf.error/hicasso-intent-outside-boundary]")
                       {:rf.error/id :rf.error/hicasso-intent-outside-boundary
                        :where       'front.intent/lower-prop


### PR DESCRIPTION
Builds HD-011's raw escape, `[:> Component props & children]`, from
[the synthesized spec](docs/design/hicasso/studio/raw-escape-spec.md) and its
five ruled edges. `rf2-2rtt6.103`.

**The model, in one sentence: `[:>]` is `defhost` with the declaration erased, and
what erasing the declaration costs you is exactly what the declaration carried.**
That is what keeps the escape strictly weaker than the door by construction, which
is the only way "declare what you use twice" has teeth.

## What landed

**Props are the door's walk, not a parallel one.** `raw-element` calls the same
`host-entry` reducing function against an EMPTY declared roster, reading a
module-level `raw-crossing` stand-in for the declaration it does not have. So every
slot at this crossing is unclaimed and the escape inherits the door's conduct with
**no branch of its own**: an intent vector or key-map at an event-spelled slot
refuses, a marked `h/fn` at any slot refuses (`rf2-2rtt6.116`'s ruling, inherited),
a plain function crosses by identity, `:&` merges before conversion per HD-023(d),
`:key` rides the crossing's outer element, `:ref` takes HD-016/HD-022 through the
same `check-ref!`, and the class slot takes its own coercion. The reason this is one
walk rather than two is compositional — if the escape refused what the door accepts,
`[:> X ...]` -> `(defhost x X {})` would stop being behaviour-preserving, and that
rewrite is the whole theorem of `rf2-2rtt6.106`'s codemod.

**SSR is hard `:client-only`, through ONE shared module-level gate** reusing the
snapshot triple `mint-host-gate!` uses with the placeholder fixed at `nil`. Shared
rather than component-keyed is a ruling, not a saving: a component-keyed cache is
the identity-keyed auto-hosting HD-011 rejected wearing a different hat, and it also
cannot be built, because React's built-in wrapper types are `Symbol.for` values and
ES2024 excludes registered symbols as `WeakMap` keys. The carrier is two slots on
the gate's own props (`c`, `p`) — the shape `boundary-element` already uses for
`rfProps` — so a leak of an internal key is unrepresentable rather than merely
witnessed.

**The Component value is refused at the crossing**, in the owner's render and on the
server too. Accepted: functions and classes, React's built-in `Symbol.for` exotics,
`$$typeof`-branded wrapper objects. Refused with a discriminating message: `nil`
(broken-import diagnosis), strings and keywords (the grammar owns tags — Reagent's
`[:> "input" ...]` took the controlled-input wrapper on exactly this path), and
`defview`/`defhost` heads (`fn?`-true, so a bare function test would mount the shell
raw and hand the body `undefined` for `rfProps`).

**The head test costs nothing.** `hiccup-tag?` had exactly one caller and sat after
the `fragment-head?` arm, yet re-asked `(not (fragment-head? head))` — so every
native tag on every page paid the fragment `=` twice. Dropping that provably dead
test pays for `raw-head?` exactly: two `=` and one type predicate before, two `=`
and one type predicate after.

**`:>` was not an error before this.** `hiccup-tag?` accepted any keyword that is not
`:<>`, so `[:> Foo {}]` asked React for an element literally named `<>`. The new arm
precedes it and compares with `=`, never `identical?`; the witness builds the keyword
at runtime, which is what makes that requirement falsifiable rather than merely
stated.

**One diagnostic repair, in `front/intent.cljs`.** `require-dispatch`'s message
offered one reading — "lower it inside a boundary's render" — and at a `[:>]` the
author *is* inside a boundary's render as far as they can see, so it read as a
framework bug. It now offers both readings and names `defhost` with
`:callbacks {... :render}` as the second. Same error id, same recovery, same
behaviour; message text only.

## Operator-overturnable defaults, recorded here so the choice lives in git history

- **SSR: `[:>]` renders NOTHING server-side, and there is no spelling for a
  fallback.** The escape carries no declaration, so it carries no server-safety
  assertion either. A fallback is *policy*, and policy lives on declarations — an
  author who wants a per-site placeholder wraps the escape in a `defhost` that
  carries one, which needs no new escape surface. **The escape must never grow an
  `:ssr` spelling of its own.** Overturning this means giving `[:>]` an inline
  policy, which is the thing the ruling refused.
- **R3 taken as recommended: a `defview` or `defhost` head in Component position is
  refused**, though React would accept both. Removable without touching the
  mechanism — two `cond` arms and two message flavours.
- **Any JS symbol is accepted, not an enumerated exotic roster.** Enumerating would
  false-refuse the next wrapper React ships, and a hatch that refuses a legal
  component is worse than one that passes an illegal value to React's own error.
- **Refused values are NAMED, never printed** (`raw-component-shape`), following
  `key-shape`'s discipline: a foreign or cyclic value would blow `pr-str` inside a
  diagnostic.

## `rf2-2rtt6.115` — verified, not re-landed

R4 asked this PR to carry "a dated scope-note on HD-024's row 3 plus the witness
pinning a marked `h/fn` at an unclaimed door slot". **The record half was discharged
on `main` by PR #7607 on 2026-08-06** — HD-024 carries the dated addendum *and* row 3
carries an inline scope clause, because a reader who reads the table and not the
addendum is how `.115` came to be filed. **The witness half was superseded in the
same tree**: `rf2-2rtt6.116` ruled REFUSE, so a marked `h/fn` at an unclaimed door
slot no longer crosses by identity — the witness R4 asks for is #7607's red refusal
row in `arm1/host_hatch_dom_cljs_test`, and the identity witness that survives is the
plain-function row beside it. Writing R4's original text now would put a sentence in
`decisions.md` that `.116`'s own code falsifies in the same tree. This PR verifies
both and corrects the spec's R4 to the post-`.116` state. `rf2-2rtt6.115` closes
against this PR.

## Records

- **`decisions.md`** — a dated addendum on HD-011 recording the shipped shape, in the
  established dated-amendment pattern. HD-024's row-3 scope note is untouched: it is
  already on `main`.
- **`studio/raw-escape-spec.md`** — marked BUILT, and corrected in the five places
  the merged-PR audits named. #7607's four: the Edge 2 table row (marked `h/fn` now
  refuses), the decisive argument that rejected refusal (the FORK was rejected, not
  the conduct — and the ruling went the way Design A and the minimal design wanted,
  at both crossings), section 7 R1 (answered), and section 7 R4 (the landed
  marked-refusal plus the plain-function identity witness). Plus #7497's: section
  8.3's X2 formula was **wrong for the mechanism this page selects** — a gate is not
  a boundary and has no Hicasso body, so a plain foreign component behind `[:>]` adds
  ZERO body runs, and "boundary count plus crossings" would make a correct
  implementation's witness fail or encode a topology-dependent miscount. X2 stays
  exact and derives its count from the boundary bodies in the fixture. As built, this
  PR adds no `[:>]` to any page that suite drives, so X2 is untouched and green.
- **The guide** — tense flips only; `rf2-2rtt6.109` teaches it fully after merge. All
  13 `[:>]` sites across four pages: 01, 02, 05 (the escape section, the "why
  declare" pointer, and two troubleshooting rows), 11. `08-testing.md` names the
  escape nowhere, so the bead's old `08:44` site does not exist on today's text.

## Witnesses

`front/codec_cljs_test` — the mis-parse regression (including the runtime-built `:>`
keyword); conversion parity with the door on one prop corpus, prop-for-prop; the
carrier never leaking either internal slot; `:key` on the outer element; `:&` before
conversion asserted on what the component received; refs; the door's unclaimed-slot
conduct inherited; the Edge 4 accept roster (functions, classes,
`Suspense`/`Fragment`/`StrictMode`/`Profiler`, `memo`/`lazy`/`forwardRef`/context/
provider/consumer, and the `lazy`-under-`Suspense` pairing) and every refusal row
asserting the id **and** the discriminating shape.

`arm1/raw_escape_dom_cljs_test` (new) — server absence with the component never
invoked; hydration against those bytes with React itself asked, through
`onRecoverableError` plus a console/window capture, whether it found anything to
reconcile; a fresh mount with no placeholder pass; canonical-DOM parity with the
door, byte-equal, with a precondition row so it cannot pass on two empty strings; the
childless crossing handed the door's own props object (no `children: undefined`); and
a child intent landing in the frame that wrote the crossing and in no other, on a
page with a second live frame so "the right frame" is distinguishable from "any
frame". Its docstring names the mutation that reddens each row.

## Quality gates

All foreground, to completion, each redirected to a worktree-local log with the
runner's own exit code echoed — never piped through `tail`/`grep`, whose exit status
would be the filter's.

| Gate | Result | Exit |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | `PASS fast PR spine` — every tier | **0** |
| `npm run test:cljs` (`:node-test`) | Ran 12748 tests, 63988 assertions; 0 failures, 0 errors | **0** |
| `npm run test:browser` (`:browser-test`, real Chromium DOM) | Ran 1111 tests, 6871 assertions; 0 failures, 0 errors | **0** |
| `npm run test:hicasso-compile` | 130 lane namespaces, **0 warnings** | **0** |
| `python scripts/check_doc_slugs.py` | no output | **0** |
| `clj-kondo --lint` (the 4 changed `.cljs` files) | 0 errors, 0 warnings (1 pre-existing `info` on an untouched line) | **0** |

*(6 rows, 3 columns.)*

The `[:>]` DOM rows carry `(mount/browser?)` guards, so `test:cljs` skips them and
`test:browser` is where they actually run. Both were re-run on the final tree after
the last commit.

**A caution about one earlier run, recorded rather than hidden.** A first spine
invocation was killed by a 10-minute harness timeout; its `sh test-fast-pr.sh` child
survived and kept building, and a second invocation's per-namespace isolation sweep
went red on *"the bundle changed on disk during the sweep"* — the gate's own
self-diagnosis for exactly that, since a `:node-test`-family compile unlinks
`out/node-test.js` before it starts. The orphan was killed, the log cleared, and the
spine re-run with nothing else building: **`PASS fast PR spine`, exit 0**. The table
above is the clean run.

**Verified by hand, since nothing gates it.** `mkdocs build --strict` does not cover
`docs/design/**` (`exclude_docs` in `mkdocs.yml`), so it is not the gate for this
tree. `check_doc_slugs.py` validates its link targets and heading anchors and exits
0. Beyond that: one heading changed — `## The escape: [:>] (unbuilt)` ->
`## The escape: [:>]` — and no page links that anchor (the only in-page link in
`05-interop.md` is `#why-declare`, untouched). Every markdown table in every changed
file was checked cell-by-cell against its header: **zero column-count mismatches
across 22 tables in 7 files**, and every `*(N rows, M columns.)*` self-annotation in
`raw-escape-spec.md` is still true after the edits (10x3, 6x3, 7x2, 8x2). No
gitignored `ai/` path is linked from any committed page.

**What CI runs that this does not decide.** `python scripts/check_fast_pr_gap.py
--list` reports 90 required checks with no lane in the spine. The ones this diff
plausibly reaches: **`cljs-browser`** (run locally above, exit 0), **`lint.yml`
clj-kondo** — CI pins 2026.04.15 and this machine has 2025.10.23, so the local pass
proves nothing about the pinned binary — and **`lint.yml` splint** and
**`docs.yml` detect**, which have no local lane at all. Local green is not CI green.

Fences held: the bench lane (`front/codec.cljs`, `front/intent.cljs` and their
witnesses), `docs/design/hicasso/decisions.md`, `docs/design/hicasso/studio/`, and
`docs/design/hicasso/draft-guide/`. **No `spec/*` edits.** Nothing under `.beads/`.
