### PR TITLE
perf(hicasso): close the remaining walk-value allocation leak (rf2-y1jkm)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_app.cljs
@@ -48,7 +48,7 @@
   |---------------|----------|----------------|
   | `ship-lazy`   | lazy     | the mount-billed walk: interpretation PLUS the body's lazy card/sub work |
   | `ship`        | realized | the shipping walk alone |
-  | `local`       | realized | the faithful in-namespace copy — the ablation baseline, validated against `ship` |
+  | `local`       | realized | the in-namespace copy — the ablation baseline, and the in-process A/B's OLD arm |
   | `no-create`   | realized | `local` with `react/createElement` swapped for a two-field object mint |
   | `no-props`    | realized | `local` emitting `#js {}` per element — the whole prop pipeline removed |
   | `no-lower`    | realized | `local` with intent lowering stubbed (vectors/maps at any position -> nil, cheaply) |
@@ -83,6 +83,20 @@
   foreign one compares call conventions as much as phases, and that
   confound was only ever caught by keeping all arms local and checking
   the copy against the shipping fn explicitly.
+
+  ## What `local` is frozen against (the PR #7383 audit)
+
+  `local` is also the OLD arm of the in-process A/B, so the two paths
+  the rf2-y1jkm candidate cheapened are held at their pre-candidate
+  shape here rather than reached for in the codec:
+  [[local-prop-cache]]/[[local-prop-name]] for the prop NAME, and
+  [[local-convert-prop-value]] for the prop VALUE. A baseline that calls
+  a helper the candidate changed absorbs the candidate and undersells
+  it, which is what the merged-PR audit found at `walk-value`. What is
+  deliberately NOT frozen, and why, is on
+  [[local-convert-prop-value]]'s own docstring; both freezes are pinned
+  by `walk_profile_baseline_cljs_test`, which fails if either arm
+  re-enters the shipping helper.
 
   Every phase delta is quoted as `local - variant`, so a positive number
   is the phase's cost. The stubs are not free (an object mint, a pair of
@@ -289,8 +303,10 @@
     (if (or (vector? v) (map? v)) nil v)
     (intent/lower-prop k v)))
 
+(declare local-convert-prop-value)
+
 (defn- walk-value [mode v]
-  (if (identical? mode M-NO-VALUE) v (codec/convert-prop-value v)))
+  (if (identical? mode M-NO-VALUE) v (local-convert-prop-value v)))
 
 (def ^:private id-slot "id")
 (def ^:private class-slot "className")
@@ -328,6 +344,8 @@
 ;; the `local` arm stays the pre-optimisation walk even after the codec's
 ;; own cache changes shape. Without this the ablation baseline silently
 ;; absorbs half the candidate and the in-process A/B undersells it.
+;; [[local-convert-prop-value]] below is the other half of the same
+;; freeze; `walk_profile_baseline_cljs_test` pins both.
 (def ^:private local-prop-cache
   (doto #js {}
     (unchecked-set "class" "className")
@@ -347,6 +365,53 @@
           (let [converted (codec/prop-name k)]
             (unchecked-set local-prop-cache n converted)
             converted))))))
+
+(defn- local-nested-map->js
+  "The donor's `nested-map->js`, on the frozen name lookup and the frozen
+  converter — `:style` and its kin."
+  [m]
+  (reduce-kv (fn [o k v] (unchecked-set o (local-prop-name k) (local-convert-prop-value v)) o)
+             #js {}
+             m))
+
+(defn local-convert-prop-value
+  "The donor's `convert-prop-value` **in the branch order the codec
+  shipped when this bead opened** — before the candidate's `string?`
+  fast lane (rf2-y1jkm).
+
+  Frozen here for the reason [[local-prop-cache]] is: `local` is the
+  ablation baseline AND the in-process A/B's old arm, and an old arm
+  that calls the candidate's own converter absorbs the candidate and
+  undersells it. PR #7383's audit named this exact site — the `local`
+  walk reached straight into `codec/convert-prop-value`, which that same
+  PR changed, so the quoted old-vs-new figure was measured against a
+  baseline the candidate had already reached into.
+
+  The answer is unchanged for every input; only the order of the tests
+  is. `walk_profile_baseline_cljs_test` asserts both halves of that —
+  that this agrees with the shipping converter value for value, and that
+  the baseline arm never enters the shipping one.
+
+  ## What is NOT frozen, and why
+
+  `merge-shorthand` and the map-copying `dissoc` the candidate also
+  replaced were **deleted** from the codec by rf2-2rtt6.36, so there is
+  no shipping shape left to copy and rf2-2rtt6.70 re-pointed
+  [[walk-convert-props]] at the lanes that ship. `codec/cached-parse`
+  likewise keeps the candidate's cheaper reserved-name check, because
+  the `parse-raw` benefit line prices the TAG CACHE and needs both its
+  arms on one parse implementation. So `local` is the pre-optimisation
+  walk in its prop-VALUE and prop-NAME paths, which is what the audit
+  asked for, and not a frozen copy of the whole pre-PR codec — which is
+  also why the reported `local/ship` line reads as an A/B ratio rather
+  than as a fidelity check near 1.0."
+  [v]
+  (cond
+    (fn? v)                       v
+    (map? v)                      (local-nested-map->js v)
+    (or (keyword? v) (symbol? v)) (name v)
+    (coll? v)                     (clj->js v)
+    :else                         v))
 
 (defn- walk-convert-props
   "The shipping `convert-props`' two lanes, with the phase switches.
@@ -450,6 +515,13 @@
     (keyword? x)     (name x)
     (symbol? x)      (name x)
     :else            x))
+
+(defn walk-arm
+  "Run the local walk at `mode` over hiccup `h`. The arms table reaches
+  [[walk-el]] directly; this exists so the witness set can run an arm
+  from outside the namespace without the modes leaking any further."
+  [mode h]
+  (walk-el mode h))
 
 ;; ---------------------------------------------------------------------------
 ;; The census

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_baseline_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_baseline_cljs_test.cljs
@@ -1,0 +1,157 @@
+(ns re-frame.bench.hicasso.walk-profile-baseline-cljs-test
+  "THE ABLATION BASELINE IS THE *OLD* WALK — pinned (rf2-y1jkm).
+
+  `walk_profile_app`'s `local` arm is two things at once: the ablation
+  baseline every phase delta is subtracted from, and the OLD arm of the
+  in-process A/B that priced the rf2-y1jkm codec candidate. The second
+  role is the fragile one. Every helper the candidate cheapened that the
+  baseline still reaches for in `front.codec` is a piece of the
+  candidate the baseline has already absorbed, and the A/B then quotes a
+  reduction smaller than the one it took — silently, with no arm going
+  red, because both numbers still look plausible.
+
+  That is not hypothetical here: it is what the merged-PR #7383 audit
+  found. `walk-value` called `codec/convert-prop-value`, and that same
+  PR reordered `convert-prop-value`'s branches. The prop-NAME half was
+  frozen locally in the PR itself (`local-prop-cache`); the prop-VALUE
+  half was not, and this file exists because the fix for that is exactly
+  the kind of thing a later refactor re-breaks by reaching for the
+  obvious `codec/` name.
+
+  ## What is asserted, and why in this shape
+
+  1. The frozen converter answers what the shipping one answers, value
+     for value and identity for identity. Only the ORDER of the tests
+     differs, so a freeze that changed an answer would be a bug in the
+     instrument rather than a baseline.
+  2. The baseline arm never ENTERS the shipping helpers. There is no
+     output that distinguishes `string?`-first from `fn?`-first — both
+     converters are total and agree everywhere — so the only honest
+     witness counts entries rather than compares results. Each count is
+     paired with a CONTROL that drives the shipping walk through the
+     same probe, so a zero can never be read off a probe that was never
+     live.
+
+  Reverting `walk-value` to `codec/convert-prop-value` fails (2) and
+  leaves (1) green, which is the whole point: (1) is why the freeze is
+  safe, (2) is why the freeze is there.
+
+  ## Deliberately not asserted
+
+  `codec/cached-parse` keeps the candidate's cheaper reserved-name check
+  in the baseline. That residue is deliberate and reasoned on
+  `walk-profile-app/local-convert-prop-value`'s docstring — the
+  `parse-raw` benefit line prices the tag cache and needs both its arms
+  on one parse implementation — so a test here would only re-litigate
+  it, and would go red the day someone freezes it properly."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.walk-profile-app :as app]))
+
+(use-fixtures :each {:before (fn [] (codec/reset-caches!))})
+
+;; ---------------------------------------------------------------------------
+;; Fixtures
+;; ---------------------------------------------------------------------------
+
+(def ^:private keyword-keyed
+  "Census-shaped markup: keyword-keyed attribute maps, string values, a
+  propless element (the short-circuit lane), a nested `:style` map (the
+  converter's recursive branch) and a literal `:key`."
+  [:div.home-page
+   [:div.banner
+    [:h1.logo-font "conduit"]]
+   [:a.nav-link {:href "#" :data-testid "your-feed-tab" :class "active"}
+    "Your Feed"]
+   [:div.tag-list {:data-testid "tag-list" :style {:background-color "red"}}
+    [:a.tag-pill.tag-default {:key "clj" :href "#" :data-testid "tag-clj"} "clj"]]])
+
+(def ^:private string-keyed
+  "A string-keyed attribute map — the one spelling that reaches
+  `codec/cached-prop-name` on the SHIPPING side, so the control for the
+  prop-name probe has something to count."
+  [:div {"data-testid" "string-keyed" "aria-label" "x"}])
+
+(defn- probe
+  "Run `thunk` with `v` installed over the shipping var `restore` names,
+  counting entries. Answers the count."
+  [install! restore! thunk]
+  (let [n (atom 0)]
+    (install! n)
+    (try (thunk) (finally (restore!)))
+    @n))
+
+;; ---------------------------------------------------------------------------
+;; 1. The freeze is behaviour-preserving
+;; ---------------------------------------------------------------------------
+
+(deftest the-frozen-converter-answers-what-the-shipping-one-answers
+  (testing "the classes the codec answers BY IDENTITY, answered by identity"
+    (let [f      (fn [_] nil)
+          obj    #js {:a 1}
+          arr    (array 1 2)]
+      (doseq [v ["href" f obj arr 42 nil true false]]
+        (is (identical? v (app/local-convert-prop-value v))
+            (str "frozen converter must pass " (pr-str v) " through by identity"))
+        (is (identical? (codec/convert-prop-value v)
+                        (app/local-convert-prop-value v))
+            (str "frozen and shipping must agree by identity on " (pr-str v))))))
+
+  (testing "the classes the codec CONVERTS, converted the same way"
+    (doseq [v [:active
+               'sym
+               {:background-color "red" :z-index 3}
+               {:outer {:font-weight "bold"}}
+               ["a" "b"]
+               #{"a"}
+               [:conduit/show-your-feed]]]
+      (is (= (js->clj (codec/convert-prop-value v))
+             (js->clj (app/local-convert-prop-value v)))
+          (str "frozen and shipping must agree on " (pr-str v)))))
+
+  (testing "a nested map camelCases its keys, through the frozen name lookup"
+    (is (= {"backgroundColor" "red"}
+           (js->clj (app/local-convert-prop-value {:background-color "red"})))))
+
+  (testing "the two are DISTINCT functions — a freeze that aliased the
+            shipping var would satisfy every assertion above"
+    (is (not (identical? codec/convert-prop-value app/local-convert-prop-value)))))
+
+;; ---------------------------------------------------------------------------
+;; 2. The baseline arm does not enter the shipping helpers
+;; ---------------------------------------------------------------------------
+
+(deftest the-baseline-arm-never-enters-the-shipping-value-converter
+  (let [real codec/convert-prop-value
+        install! (fn [n] (set! codec/convert-prop-value
+                               (fn [v] (swap! n inc) (real v))))
+        restore! (fn [] (set! codec/convert-prop-value real))]
+
+    (testing "CONTROL — the shipping walk does enter it, so the probe is live"
+      (is (pos? (probe install! restore! #(codec/as-element keyword-keyed)))
+          "the shipping walk must reach convert-prop-value on this fixture"))
+
+    (testing "the local arm converts every value through its OWN frozen copy"
+      (is (zero? (probe install! restore! #(app/walk-arm app/M-FULL keyword-keyed)))
+          (str "the `local` arm is the in-process A/B's OLD arm; entering the "
+               "shipping converter absorbs the rf2-y1jkm candidate into the "
+               "baseline it is measured against (merged-PR #7383 audit)")))
+
+    (testing "and so does the no-value ablation, which converts nothing at all"
+      (is (zero? (probe install! restore! #(app/walk-arm app/M-NO-VALUE keyword-keyed)))))))
+
+(deftest the-baseline-arm-never-enters-the-shipping-prop-name-cache
+  (let [real codec/cached-prop-name
+        install! (fn [n] (set! codec/cached-prop-name
+                               (fn [k] (swap! n inc) (real k))))
+        restore! (fn [] (set! codec/cached-prop-name real))]
+
+    (testing "CONTROL — the shipping walk does enter it on a string-keyed map"
+      (is (pos? (probe install! restore! #(codec/as-element string-keyed)))
+          "the shipping walk must reach cached-prop-name on this fixture"))
+
+    (testing "the local arm names every prop through local-prop-name"
+      (is (zero? (probe install! restore! #(app/walk-arm app/M-FULL keyword-keyed)))
+          "keyword-keyed props must take the frozen string-valued cache")
+      (is (zero? (probe install! restore! #(app/walk-arm app/M-FULL string-keyed)))
+          "string-keyed props must take the frozen path too"))))


### PR DESCRIPTION
Closes the second half of the merged-PR #7383 audit finding on `rf2-y1jkm`
(acceptance criterion 1). No production code changes; the whole diff is the
bench lane's own instrument.

## What was leaking

`walk_profile_app`'s `local` arm is two things at once: the ablation baseline
every phase delta is subtracted from, and the OLD arm of the in-process A/B
that priced the rf2-y1jkm codec candidate. The second role is the fragile one
— every helper the candidate cheapened that the baseline still reaches for in
`front.codec` is a piece of the candidate the baseline has already absorbed,
and the A/B then quotes a reduction smaller than the one it took, silently,
with nothing going red.

The audit found exactly that: `walk-value` called `codec/convert-prop-value`,
and `ddc17c1066` — the candidate itself — reordered `convert-prop-value` to
ask `string?` first. The prop-NAME half of the same leak was frozen in that
PR (`local-prop-cache` / `local-prop-name`, verified still frozen and still
byte-equal to the pre-PR `cached-prop-name`); the prop-VALUE half was not.

Before: `(if (identical? mode M-NO-VALUE) v (codec/convert-prop-value v))`
After:  `(if (identical? mode M-NO-VALUE) v (local-convert-prop-value v))`

`local-convert-prop-value` is the donor's converter in the branch order the
codec shipped when this bead opened, with its own `local-nested-map->js` on
the frozen name lookup so the recursive `:style` branch cannot leak either.
The answer is unchanged for every input; only the order of the tests is.

### What is deliberately NOT frozen

Stated on the new fn's docstring rather than left for the next reader to
rediscover:

- `merge-shorthand` and the map-copying `dissoc` the candidate also replaced
  were **deleted** from the codec by rf2-2rtt6.36, and rf2-2rtt6.70 re-pointed
  the prop arms at the lanes that ship. There is no shipping shape left to
  copy, so those two are gone from the A/B by construction.
- `codec/cached-parse` keeps the candidate's cheaper reserved-name check,
  because the `parse-raw` benefit line prices the TAG CACHE and needs both of
  its arms on one parse implementation.

So `local` is the pre-optimisation walk in its prop-VALUE and prop-NAME paths
— which is what the audit asked for — and not a frozen copy of the whole
pre-PR codec. The namespace docstring now says so, and says that the reported
`local/ship` line therefore reads as an A/B ratio rather than as a fidelity
check near 1.0.

## The witness

`walk_profile_baseline_cljs_test` (new, 3 tests / 31 assertions, runs under
`npm run test:cljs`).

There is **no output** that distinguishes `string?`-first from `fn?`-first —
both converters are total and agree everywhere — so comparing results could
never witness this. The test therefore does two different things:

1. Asserts the freeze is behaviour-preserving: the frozen converter agrees
   with the shipping one value for value and identity for identity, across
   both the pass-through classes and the converted ones, including nested
   maps; plus an explicit `(not (identical? ...))` so a "freeze" that merely
   aliased the shipping var could not satisfy the rest.
2. **Counts entries** into the shipping helpers while an arm runs, and
   asserts zero. Every zero is paired with a CONTROL that drives the
   *shipping* walk through the same live probe, so a zero can never be read
   off a probe that was never installed.

## The witness goes red — demonstrated

`walk-value` was reverted to `codec/convert-prop-value`, recompiled
(`node scripts/compile-node-test.cjs node-test out/node-test.js`, exit **0**),
and the witness re-run:

```
node out/node-test.js --test=re-frame.bench.hicasso.walk-profile-baseline-cljs-test
```

exit **1**, `Ran 3 tests containing 31 assertions. 2 failures, 0 errors.`

```
FAIL in (the-baseline-arm-never-enters-the-shipping-value-converter)
  actual: (not (zero? 8))
FAIL in (the-baseline-arm-never-enters-the-shipping-prop-name-cache)
  actual: (not (zero? 1))
```

Both counts are informative. The 8 is the leak itself — eight prop values on
the fixture converted by the candidate's own converter inside the baseline
arm. The 1 is the *nested* leak: the shipping `convert-prop-value` reaches
`nested-map->js`, which reaches `codec/cached-prop-name`, so reverting the
value freeze silently punctures the already-landed name freeze too. That is
the second reason the frozen converter carries its own `local-nested-map->js`.

The fix was then restored (`git checkout HEAD -- …`), recompiled and re-run:
exit **0**, `0 failures, 0 errors`.

## Quality gates

Run from this worktree (`C:/Users/miket/code/re-frame2-worktrees/walkvalue-y1jkm`),
foreground, redirected to a log with the runner's own exit code echoed — never
piped, so no pipeline exit status can mask a red. GitHub Actions is in a major
outage, so these local exit codes are the evidence.

| gate | command | result | exit |
|---|---|---|---|
| hicasso bench-lane compile | `npm run test:hicasso-compile` | 130 lane namespaces, 437 files, **0 warnings** | **0** |
| CLJS suite (owns the witness) | `npm run test:cljs` | 12,737 tests / 63,899 assertions, **0 failures, 0 errors** | **0** |
| witness, focused | `node out/node-test.js --test=re-frame.bench.hicasso.walk-profile-baseline-cljs-test` | 3 tests / 31 assertions, **0 failures** | **0** |
| witness, focused, fix REVERTED | same, after reverting `walk-value` | 3 tests / 31 assertions, **2 failures** | **1** |
| fast-PR spine | `sh scripts/test-fast-pr.sh` | 61 stages, `PASS fast PR spine`; JVM core 2,233/11,645, JVM freehand 1,291/8,874, CLJS 12,737/63,899, per-ns isolation all 17 standalone | **0** |
| clj-kondo (2 changed files) | `clj-kondo --fail-level error --lint <the two files>` | **errors: 0, warnings: 0** | **0** |

The compile gate printed `config: …/walkvalue-y1jkm/implementation/shadow-cljs.edn`
and the spine printed `gate root: /c/Users/miket/code/re-frame2-worktrees/walkvalue-y1jkm`
— both this worktree, not the mayor checkout.

The full CLJS suite was run twice (once before the red demonstration, once
after restoring), green both times, so the bundle the final green came off is
the code in this PR.

Two caveats stated rather than buried:

- **The spine was run twice, and only the SECOND run is quoted.** A first
  invocation hit the harness's 10-minute foreground cap and was signalled, but
  its process tree survived on Windows and kept writing to the same log as the
  relaunch — two writers, one file, interleaved bytes, and a spurious
  `per-ns test isolation` red of the gate's own documented ENVIRONMENT class
  ("the bundle changed on disk during the sweep", `MODULE_NOT_FOUND`), because
  the orphan's `npm run test:cljs` was unlinking `out/node-test.js` underneath
  the live sweep (rf2-6t03c). The orphans were killed, the log deleted, and the
  spine re-run once from clean. The quoted run is that one: single writer,
  zero NUL bytes in the log, `per-ns isolation: all 17 namespace(s) pass
  standalone`. None of it was a finding about this diff.
- **clj-kondo here is v2025.10.23; CI pins 2026.04.15.** Versions disagree
  about which findings are errors, so treat the local green as indicative, not
  as the `Lint required` context.

## No timing was taken

Deliberately. Five other workers share this box, so any wall-clock row taken
now would be invalid by construction, and an allocation/identity leak is
pinnable without a clock — which is what the witness above does.

`bench:freehand-browser` is schedule-only and is not a PR gate, so nothing in
CI would have caught this lane regressing either.

## What stays open on rf2-y1jkm

Acceptance criteria 2 and 3 need the quiet box and are NOT in this PR:

2. Re-run the interleaved diagnostic profile with the baseline now clean, and
   publish corrected old/new and phase figures.
3. Correct the studio page and the bead close record, preserving the unchanged
   clock-of-record results and their verdicts.

The clock-of-record rows (`census_clock_run.cjs`, `data/censusclock-y1jkm/`)
are untouched and unaffected — the bias the audit found was conservative and
local to the in-process diagnostic.
