### PR TITLE
fix(hicasso): the ladder aggregator must refuse an absent arm and a NaN (rf2-409ab)

### DIFF
--- a/docs/design/hicasso/studio/the-in-page-mount-term-decomposed.md
+++ b/docs/design/hicasso/studio/the-in-page-mount-term-decomposed.md
@@ -326,6 +326,7 @@ advertisement:
 |---|---|---|
 | a stored aggregate edited (`:deficit 1.9625 → 1.4000` in run A) | REFUSE | **exit 1** — `runA: :deficit stored 1.4 != recomputed 1.9625` |
 | a single raw sample edited (`[0 :bare 2.5] → 9.9`) | REFUSE | **exit 1** — `stored max 5.9 != recomputed 9.9`, and the tmean with it |
+| every raw row for one arm removed, its stored block left (`:noreads` in run A) | REFUSE | **exit 1** — `runA: arm :noreads is ABSENT from the raw rounds`, and the terms built on it as non-finite |
 
 The second mutation is why `:min` and `:max` are checked at all: the trimmed
 mean deliberately discards the extremes, so a corrupted outlier moves neither

--- a/implementation/freehand/test/re_frame/bench/hicasso/inpage_ladder_aggregate.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/inpage_ladder_aggregate.cjs
@@ -10,11 +10,15 @@
 //
 //   node implementation/freehand/test/re_frame/bench/hicasso/inpage_ladder_aggregate.cjs
 //
-// Exit 0  every run's stored aggregates reproduce from its own raw rounds,
-//         its positive control met its own arithmetic, its arm order was
-//         clean, and the ensemble table below is the studio page's.
+// Exit 0  every run presents the whole raw shape this instrument published,
+//         its stored aggregates reproduce from its own raw rounds, no
+//         recomputed figure is non-finite, its positive control met its own
+//         arithmetic, its arm order was clean, and the ensemble table below is
+//         the studio page's.
 // Exit 1  a disagreement, a missing dataset, or a run that recorded a guard
-//         refusal or a failed control.
+//         refusal or a failed control; raw rounds that are not the shape this
+//         instrument published; or any figure that recomputes to a non-finite
+//         number.
 //
 // ## The last two clauses of that promise were never computed (rf2-bml5u)
 //
@@ -41,6 +45,31 @@
 // never run; it is not the place to also change the rule it reconstructs, so
 // it applies the OVERLAP rule the page applied and no other. A tighter
 // prospective policy is that open ruling's to make.
+//
+// ## And it FAILED OPEN on a structural omission (rf2-409ab, audit item 2)
+//
+// A third defect, and the one that matters most for a command whose whole
+// job is to refuse. The audit's own mutation: strip every run-A `:noreads`
+// RAW row and leave its stored summary block untouched. This file exited 0
+// and printed "every published aggregate reproduces" while emitting `NaN`
+// across `h-reads+commit`, `h-memo-fiber`, `reads`, `shell+memo` and
+// `residual`.
+//
+// Two causes compounded, and both are fixed below.
+//
+// **The arm set was DERIVED from whatever rows survived.** `[...new
+// Set(raw.map(x => x.arm))]` cannot report a missing arm, because a wholly
+// absent arm is not a missing arm to it — it is simply not an arm. A verifier
+// that lets the data choose the roster verifies the data against itself. The
+// roster, the round count and the samples-per-cell are now a CONTRACT
+// (`ARMS`/`ROUNDS_PER_RUN`/`SAMPLES_PER_CELL`), measured off all four
+// committed datasets and asserted, not inferred.
+//
+// **Every comparison against a NaN is false.** `Math.abs(stored - NaN) > EPS`
+// is false, so an equality test on a figure that failed to recompute reads as
+// AGREEMENT. Non-finiteness is therefore tested BEFORE the figure is compared,
+// and the refusal names the arms that produced no mean — what was absent,
+// rather than the arithmetic's symptom.
 
 const fs = require('fs');
 const path = require('path');
@@ -63,6 +92,31 @@ const CTL_PREDICTED = 1.9759;
 const CONTROL_SLACK = 0.25;
 // `lane/guard!`'s default, which is the tolerance the page ran at.
 const GUARD_TOLERANCE = 0.1;
+
+// --- THE RAW SHAPE, ASSERTED RATHER THAN DERIVED (rf2-409ab) --------------
+//
+// `inpage_ladder_app.cljs` runs a fixed ladder: 15 arms interleaved within
+// each sample index, 6 rounds, 10 post-warm-up samples per arm per round.
+// Every one of the four committed datasets presents exactly that — 900 raw
+// rows, the same roster, round ids 0–5, 10 samples in all 90 cells — and the
+// figures the studio page publishes are only meaningful over the whole shape.
+// So it is stated here and checked, because the alternative is to read it off
+// the surviving rows, and rows that were removed cannot say they are missing.
+//
+// The 14 ladder arms are exactly the operands `decompose` subtracts, plus the
+// `ctl-2x` positive control.
+const ARMS = [
+  'floor', 'bare',
+  'hicasso', 'local', 'nolink', 'nohiccup', 'nowalk', 'noreads', 'nomemo',
+  'coarse',
+  'uix', 'uixlocal', 'uixnolink', 'uixbare',
+  'ctl-2x',
+];
+const ARM_SET = new Set(ARMS);
+const ROUNDS_PER_RUN = 6;
+const ROUND_IDS = Array.from({ length: ROUNDS_PER_RUN }, (_, i) => i);
+const SAMPLES_PER_CELL = 10;
+const RAW_ROWS = ARMS.length * ROUNDS_PER_RUN * SAMPLES_PER_CELL; // 900
 
 // --- the two EDN shapes this file reads, and nothing more general ---------
 
@@ -245,6 +299,63 @@ function guardSamples(raw) {
   }));
 }
 
+// --- the raw shape, checked against the contract --------------------------
+
+/**
+ * Every way one run's raw rounds can fail to be the shape this instrument
+ * published: a row count that is not 900, an arm or a round id outside the
+ * contract, an arm absent from the run or from a round, and a cell that does
+ * not carry exactly 10 samples (which catches a dropped sample and a
+ * duplicated one alike).
+ *
+ * Driven by `ARMS` x `ROUND_IDS`, never by the surviving rows — that
+ * direction is the whole point. An absent arm is invisible to a roster
+ * derived from the data, and it was exactly the omission that used to exit 0.
+ */
+function shapeProblems(runId, raw) {
+  const problems = [];
+  const n = new Map(); // "round|arm" -> count
+  const strayArms = new Set();
+  const strayRounds = new Set();
+  for (const x of raw) {
+    if (!ARM_SET.has(x.arm)) strayArms.add(x.arm);
+    if (!ROUND_IDS.includes(x.round)) strayRounds.add(x.round);
+    const k = `${x.round}|${x.arm}`;
+    n.set(k, (n.get(k) || 0) + 1);
+  }
+
+  if (raw.length !== RAW_ROWS)
+    problems.push(
+      `run${runId}: raw rounds carry ${raw.length} samples, the contract is ${RAW_ROWS} ` +
+        `(${ARMS.length} arms x ${ROUNDS_PER_RUN} rounds x ${SAMPLES_PER_CELL} samples)`
+    );
+  for (const a of [...strayArms].sort())
+    problems.push(`run${runId}: raw rounds carry :${a}, which is not one of the ${ARMS.length} ladder arms`);
+  for (const r of [...strayRounds].sort((x, y) => x - y))
+    problems.push(`run${runId}: raw rounds carry round ${r}, outside 0–${ROUNDS_PER_RUN - 1}`);
+
+  for (const a of ARMS) {
+    const empty = ROUND_IDS.filter((r) => !n.has(`${r}|${a}`));
+    if (empty.length === ROUNDS_PER_RUN) {
+      problems.push(
+        `run${runId}: arm :${a} is ABSENT from the raw rounds — the roster is a contract, ` +
+          'not whatever survived'
+      );
+      continue;
+    }
+    if (empty.length)
+      problems.push(`run${runId}/${a}: no samples at all in round(s) ${empty.join(', ')}`);
+    for (const r of ROUND_IDS) {
+      const c = n.get(`${r}|${a}`);
+      if (c !== undefined && c !== SAMPLES_PER_CELL)
+        problems.push(
+          `run${runId}/${a}: round ${r} carries ${c} samples, the contract is ${SAMPLES_PER_CELL}`
+        );
+    }
+  }
+  return problems;
+}
+
 // --- one run --------------------------------------------------------------
 
 /**
@@ -260,11 +371,15 @@ function checkRun(runId, text) {
   const storedDec = scalarMap(readMap(text, 'decomposition'));
   const storedRatio = readMap(text, 'ratio-to-floor');
 
-  const arms = [...new Set(raw.map((x) => x.arm))];
+  // BEFORE ANY FIGURE IS COMPARED: is this the run the page took? A shape
+  // failure does not stop the comparisons below — they still run and still
+  // report — but it can no longer be answered by silence.
+  problems.push(...shapeProblems(runId, raw));
+
   const tmean = {};
-  for (const a of arms) {
+  for (const a of ARMS) {
     const xs = raw.filter((x) => x.arm === a).map((x) => x.ms);
-    tmean[a] = trimmedMean(xs);
+    tmean[a] = trimmedMean(xs); // NaN when the arm carries no samples at all
     // The stored per-arm block must reproduce from the same raw samples.
     // `:min` and `:max` are checked too, and they are not decoration: the
     // trimmed mean deliberately discards the extremes, so a corrupted
@@ -280,6 +395,10 @@ function checkRun(runId, text) {
     }
     if (Number(blk[1]) !== xs.length)
       problems.push(`run${runId}/${a}: stored n=${blk[1]}, raw rounds carry ${xs.length}`);
+    // An absent arm has already been named above, and `Math.min` of nothing
+    // is `Infinity` — comparing against that would bury the real finding
+    // under four lines of arithmetic noise.
+    if (xs.length === 0) continue;
     if (Math.abs(Number(blk[2]) - Math.min(...xs)) > EPS)
       problems.push(`run${runId}/${a}: stored min ${blk[2]} != recomputed ${round4(Math.min(...xs))}`);
     if (Math.abs(Number(blk[3]) - Math.max(...xs)) > EPS)
@@ -290,10 +409,25 @@ function checkRun(runId, text) {
       problems.push(`run${runId}/${a}: stored tmean ${blk[5]} != recomputed ${round4(tmean[a])}`);
   }
 
+  // NON-FINITE IS A REFUSAL, NOT A COMPARISON (rf2-409ab). `Math.abs(stored -
+  // NaN) > EPS` is FALSE, so a term that failed to recompute used to read as
+  // agreement and print as `NaN` in a published cell under an exit 0. Test
+  // finiteness first, and name the arms that produced no mean — that is what
+  // was absent; the NaN is only where it surfaced. Every cell of the ensemble
+  // table is one of these terms, so a finite decomposition per run is what
+  // makes the printed table finite.
+  const noMean = ARMS.filter((a) => !Number.isFinite(tmean[a]));
   const dec = decompose(tmean);
   for (const [k, v] of Object.entries(dec)) {
     if (!(k in storedDec)) {
       problems.push(`run${runId}: decomposition has no :${k}`);
+      continue;
+    }
+    if (!Number.isFinite(v)) {
+      problems.push(
+        `run${runId}: :${k} recomputes to ${v}, which is not a finite number` +
+          (noMean.length ? ` — no arm mean recomputed for ${noMean.map((a) => ':' + a).join(', ')}` : '')
+      );
       continue;
     }
     if (Math.abs(storedDec[k] - v) > EPS)
@@ -304,8 +438,15 @@ function checkRun(runId, text) {
   // against what the page stored, and only then adjudicated: a control
   // adjudicated on a number this file could not regenerate would be gating
   // the dataset's own assertion rather than the measurement.
-  const roundIds = [...new Set(raw.map((x) => x.round))].sort((a, b) => a - b);
-  const ratio = perRoundRatio(raw, 'ctl-2x', 'floor', roundIds);
+  // Over the CONTRACT's rounds, not the rounds that happen to be present: a
+  // control averaged over the rounds that survived is a control of nothing.
+  const ratio = perRoundRatio(raw, 'ctl-2x', 'floor', ROUND_IDS);
+  for (const k of ['mean', 'min', 'max'])
+    if (!Number.isFinite(ratio[k]))
+      problems.push(
+        `run${runId}: :ratio-to-floor :ctl-2x :${k} recomputes to ${ratio[k]}, which is not a ` +
+          'finite number — :ctl-2x or :floor is not present in every round'
+      );
   const storedCtl = armBand(storedRatio, 'ctl-2x');
   if (!storedCtl) {
     problems.push(`run${runId}: :ratio-to-floor has no :ctl-2x`);
@@ -425,8 +566,10 @@ function main() {
   console.log(`;;     residual           ${f(mean.deficit - named)}  ${pct(mean.deficit - named)}`);
   console.log(`;;   read shape on our own arm (local - coarse) ${f(mean['h-read-shape'])}  ${pct(mean['h-read-shape'])} of the deficit`);
   console.log(`;;   at MATCHED read shape (coarse - uix)       ${f(mean['matched-shape-gap'])}`);
-  console.log('[inpage-ladder] ok — every published aggregate reproduces from the raw rounds, ' +
-    'its control met its own arithmetic, and its arm order was clean');
+  console.log(`[inpage-ladder] ok — every run presents its whole ${ARMS.length}-arm x ` +
+    `${ROUNDS_PER_RUN}-round x ${SAMPLES_PER_CELL}-sample contract, every published aggregate ` +
+    'reproduces from the raw rounds as a finite number, its control met its own arithmetic, ' +
+    'and its arm order was clean');
   return 0;
 }
 
@@ -438,8 +581,13 @@ module.exports = {
   perRoundRatio,
   controlVerdict,
   guardSamples,
+  shapeProblems,
   checkRun,
   main,
+  ARMS,
+  ROUNDS_PER_RUN,
+  SAMPLES_PER_CELL,
+  RAW_ROWS,
   CTL_PREDICTED,
   CONTROL_SLACK,
   GUARD_TOLERANCE,

--- a/implementation/freehand/test/re_frame/bench/hicasso/inpage_ladder_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/inpage_ladder_exit_path.test.cjs
@@ -235,6 +235,134 @@ test('a REFUSAL can never reach the exit as an empty problem list', () => {
   assert.ok(out.problems.length > 0, 'a refusing guard must contribute at least one problem');
 });
 
+// --- the raw shape, and the NaN that used to pass -------------------------
+//
+// rf2-409ab audit item 2. The command exited 0, printed "every published
+// aggregate reproduces", and emitted `NaN` across five cells — because the
+// arm roster was derived from the rows that survived, and because every
+// comparison against a NaN is false.
+//
+// EVERY FIXTURE BELOW IS BUILT IN-TEST from the tracked dataset text, never
+// asserted about the checkout. That is the CRLF tests' model above and it is
+// deliberate: an earlier version of one of those asserted a fact about git's
+// checkout settings, passed on Windows and failed on Linux CI.
+
+/** Every `[round :arm ms]` row for one arm, gone; the stored block stays. */
+const stripArm = (text, arm) =>
+  text.replace(new RegExp(`\\[\\d+ :${arm} -?[0-9.]+\\] ?`, 'g'), '');
+/** Every row of one round, gone. */
+const stripRound = (text, r) =>
+  text.replace(new RegExp(`\\[${r} :[A-Za-z0-9-]+ -?[0-9.]+\\] ?`, 'g'), '');
+
+test('THE CONTRACT IS THE COMMITTED DATA\'S OWN SHAPE, on all four runs', () => {
+  // The constants are asserted, not derived — so they must be checked against
+  // the data once, here. If a future dataset legitimately changes shape this
+  // goes red and the constants move WITH the measurement; what it forbids is
+  // loosening them to accommodate data that lost rows.
+  assert.strictEqual(agg.ARMS.length, 15);
+  assert.strictEqual(agg.ROUNDS_PER_RUN, 6);
+  assert.strictEqual(agg.SAMPLES_PER_CELL, 10);
+  assert.strictEqual(agg.RAW_ROWS, 900);
+  assert.strictEqual(new Set(agg.ARMS).size, 15, 'the roster carries no duplicate');
+  for (const r of RUNS) {
+    const raw = agg.rounds(agg.readMap(read(r), 'rounds'));
+    assert.strictEqual(raw.length, 900, `run${r}: 900 raw rows`);
+    assert.deepStrictEqual(
+      [...new Set(raw.map((x) => x.arm))].sort(),
+      [...agg.ARMS].sort(),
+      `run${r}: the roster this file asserts must be the roster the run took`
+    );
+    assert.deepStrictEqual(
+      [...new Set(raw.map((x) => x.round))].sort((a, b) => a - b),
+      [0, 1, 2, 3, 4, 5],
+      `run${r}: round ids`
+    );
+    const n = new Map();
+    for (const x of raw) n.set(`${x.round}|${x.arm}`, (n.get(`${x.round}|${x.arm}`) || 0) + 1);
+    assert.strictEqual(n.size, 90, `run${r}: 15 arms x 6 rounds = 90 cells`);
+    assert.deepStrictEqual([...new Set(n.values())], [10], `run${r}: 10 samples in every cell`);
+  }
+});
+
+test('THE FAIL-OPEN: an arm stripped from the raw rounds REFUSES', () => {
+  // The audit's own mutation, verbatim: remove every run-A `:noreads` RAW
+  // row and leave its stored summary block in place. This exited 0.
+  const text = stripArm(read('A'), 'noreads');
+  assert.ok(!/\[\d+ :noreads /.test(text), 'no raw :noreads row survives the mutation');
+  assert.ok(/:noreads \{:n /.test(text), 'and its stored summary block is untouched');
+
+  const out = agg.checkRun('A', text);
+  assert.ok(
+    out.problems.some((p) => /arm :noreads is ABSENT from the raw rounds/.test(p)),
+    `an absent arm must be named as absent; got: ${out.problems.join(' | ')}`
+  );
+  // And the second half of the defect: the terms that went NaN must refuse on
+  // their non-finiteness rather than compare equal to their stored values.
+  for (const term of ['h-reads+commit', 'h-memo-fiber']) {
+    assert.ok(
+      out.problems.some((p) =>
+        p.includes(`:${term} recomputes to NaN, which is not a finite number`)),
+      `:${term} must refuse as non-finite; got: ${out.problems.join(' | ')}`
+    );
+  }
+  assert.ok(
+    out.problems.some((p) => /no arm mean recomputed for :noreads/.test(p)),
+    'and the refusal must name what was absent, not merely that arithmetic failed'
+  );
+});
+
+test('the NaN trap is real — an equality check on one reads as AGREEMENT', () => {
+  // Why finiteness is tested BEFORE the comparison and not by it. This is the
+  // exact expression `checkRun` runs against every stored figure.
+  assert.ok(!(Math.abs(1.2345 - NaN) > agg.EPS), 'NaN comparisons are all false');
+});
+
+test('a whole round missing from the raw rounds REFUSES', () => {
+  const out = agg.checkRun('A', stripRound(read('A'), 4));
+  assert.ok(
+    out.problems.some((p) => /raw rounds carry 750 samples, the contract is 900/.test(p)),
+    `the row count must be checked; got: ${out.problems.slice(0, 3).join(' | ')}`
+  );
+  assert.ok(
+    out.problems.some((p) => /runA\/noreads: no samples at all in round\(s\) 4/.test(p)),
+    'and the empty round must be named per arm'
+  );
+});
+
+test('a cell that is not exactly 10 samples REFUSES — short OR long', () => {
+  const short = agg.checkRun('A', read('A').replace(/\[0 :bare -?[0-9.]+\] /, ''));
+  assert.ok(
+    short.problems.some((p) => /runA\/bare: round 0 carries 9 samples, the contract is 10/.test(p)),
+    `a dropped sample must refuse; got: ${short.problems.slice(0, 3).join(' | ')}`
+  );
+  const long = agg.checkRun('A', read('A').replace(/(\[0 :bare -?[0-9.]+\] )/, '$1$1'));
+  assert.ok(
+    long.problems.some((p) => /runA\/bare: round 0 carries 11 samples, the contract is 10/.test(p)),
+    `a duplicated sample must refuse too; got: ${long.problems.slice(0, 3).join(' | ')}`
+  );
+});
+
+test('an arm outside the roster REFUSES rather than joining it', () => {
+  const out = agg.checkRun('A', read('A').replace('[[0 :nohiccup', '[[0 :bogus 1.0] [0 :nohiccup'));
+  assert.ok(
+    out.problems.some((p) => /raw rounds carry :bogus, which is not one of the 15 ladder arms/.test(p)),
+    `an unknown arm must refuse; got: ${out.problems.slice(0, 3).join(' | ')}`
+  );
+});
+
+test('a control ratio that recomputes non-finite REFUSES', () => {
+  // The per-round ratio is taken over the CONTRACT's six rounds, so a floor
+  // absent from one round makes that round's ratio NaN instead of quietly
+  // averaging the five that survived.
+  const text = read('A').replace(/\[3 :floor -?[0-9.]+\] /g, '');
+  const out = agg.checkRun('A', text);
+  assert.ok(
+    out.problems.some((p) =>
+      /:ratio-to-floor :ctl-2x :mean recomputes to NaN, which is not a finite number/.test(p)),
+    `a non-finite control ratio must refuse; got: ${out.problems.slice(0, 4).join(' | ')}`
+  );
+});
+
 // --- the wiring -----------------------------------------------------------
 
 test('the aggregate is requirable without running, and exits from `main`', () => {


### PR DESCRIPTION
Audit item 2 on **rf2-409ab**. (Item 1, the CRLF portability defect, was already fixed on main by sibling bead rf2-bml5u in `9c30a00ddf` — verified, untouched here.)

`inpage_ladder_aggregate.cjs` is the fail-closed command that recomputes every published aggregate from the committed raw rounds. It could be made to pass while verifying nothing.

## The fail-open, reproduced before the fix

The audit's own mutation, against `origin/main`: strip every run-A `:noreads` **raw** row, leave its stored summary block in place, and run the documented command.

```
raw :noreads rows before=60 after=0
stored :noreads summary block still present: true
...
;;   h-reads+commit              NaN   1.1667   1.1667   1.3896  |      NaN      NaN      NaN
;;   h-memo-fiber                NaN  -0.1146   0.0333  -0.0229  |      NaN      NaN      NaN
...
;;     reads                    NaN  NaN%
;;     shell + memo             NaN  NaN%
;;     residual                 NaN  NaN%
[inpage-ladder] ok — every published aggregate reproduces from the raw rounds, its control met its own arithmetic, and its arm order was clean
EXIT=0        <-- FAIL-OPEN
```

Two causes compounded.

**The arm set was DERIVED from the surviving rows.** `[...new Set(raw.map(x => x.arm))]` cannot report an arm that is wholly absent, because to it that arm is simply not an arm. The per-arm loop therefore never visited `:noreads`, so even the stored-`n` cross-check — which does catch a *short* arm — was never reached. A verifier that lets the data choose the roster verifies the data against itself.

**Every comparison against a NaN is false.** `Math.abs(stored - NaN) > EPS` is `false`, so an equality test on a figure that failed to recompute reads as **agreement**.

## The contract, measured off all four datasets

Verified against the committed data rather than taken from the audit text — identical on runs A/B/C/D:

| | |
|---|---|
| arms | **15** — `floor bare hicasso local nolink nohiccup nowalk noreads nomemo coarse uix uixlocal uixnolink uixbare ctl-2x` |
| rounds | **6** (ids 0–5) |
| samples per arm per round | **10**, in all 90 cells, no cell short or long |
| raw rows | **900** |

The 14 ladder arms are exactly the operands `decompose` subtracts, plus the `ctl-2x` positive control. `ARMS` / `ROUNDS_PER_RUN` / `SAMPLES_PER_CELL` are now stated and checked, not inferred, and a test pins them back against all four datasets so they can only move *with* a measurement — never be loosened to accommodate data that lost rows.

## What now refuses

- a **missing arm** — named as `ABSENT`, with the roster called a contract
- a **missing round**, per arm, and the row count against 900
- a **cell that is not exactly 10 samples** — a dropped sample and a duplicated one alike
- an **arm outside the roster**
- a **non-finite recomputed figure**, tested *before* it is compared, in the decomposition and in the reconstructed control ratio. The refusal names the arms that produced no mean — what was absent — rather than only the arithmetic that surfaced it. Every cell of the printed ensemble is one of these decomposition terms, so a finite decomposition per run is what makes the published table finite.
- the control ratio is now taken over the contract's six rounds rather than over whichever rounds survived, so a floor absent from one round makes that round's ratio NaN instead of quietly averaging the five that remain.

No figure re-measured, re-published or moved. No `src/**` change. No `spec/*` change. `implementation/scripts/lib/edn.cjs` untouched — it is not on this command's path. `test:script-helpers` already wires `inpage_ladder_exit_path.test.cjs`, so `implementation/package.json` needed no change.

## The studio page's refusal table

`docs/design/hicasso/studio/the-in-page-mount-term-decomposed.md` §7's **Proven able to refuse** table exists to enumerate what the verifier provably refuses. It listed two mutations; after this PR the verifier refuses three, and the third is the only one that was a genuine fail-open — so a reader consulting the table would under-count the guarantee. One row added, in the table's existing register and columns:

| mutation | expected | observed |
|---|---|---|
| every raw row for one arm removed, its stored block left (`:noreads` in run A) | REFUSE | **exit 1** — `runA: arm :noreads is ABSENT from the raw rounds`, and the terms built on it as non-finite |

§7 is otherwise untouched — no restructuring, no added narrative, no restatement of the mechanism.

**Column count hand-verified** (the tree's tables are not validated by any gate): all five lines of the table — header, delimiter, and all three rows — carry 4 pipes, i.e. **3 columns**. No cell content contains a literal `|`.

## The witnesses

Seven new cases in `inpage_ladder_exit_path.test.cjs`. **Every fixture is built in-test from the tracked dataset text**, never asserted about the checkout — the model the CRLF tests set after an earlier version of one of those asserted a fact about git's checkout settings, passed on Windows and failed on Linux CI.

Proven to bite: restoring `origin/main`'s aggregator under the new test file reds it at **exit 1, 6/25 failed**. Restored, all 25 pass.

Stated precisely, because not all six are the same finding. Only one is a true fail-open — `THE FAIL-OPEN: an arm stripped from the raw rounds REFUSES` fails on `origin/main` with an **empty problems array**, which is the audit's exit 0 exactly. The other structural mutations (a missing round, a short cell, a stray arm) *did* already refuse on `origin/main`, but incidentally — via the stored-`n` cross-check or `no stored summary for arm bogus` — never naming the structural fault, and never on the one path that mattered. Those cases are pinned so a later refactor cannot quietly drop the shape check and still look green on the incidental cross-check. The remaining two are the contract pin (`ARMS` did not exist on `origin/main`) and the non-finite control ratio.

## Quality gates

All foreground, run to completion, each command's own exit code echoed from a redirected log — never through a pipeline.

| command | result | exit |
|---|---|---|
| `node implementation/freehand/test/re_frame/bench/hicasso/inpage_ladder_aggregate.cjs` (before) | exit 0, ensemble reproduces | **0** |
| `node .../inpage_ladder_exit_path.test.cjs` (before) | 18 passed | **0** |
| `node .../inpage_ladder_aggregate.cjs` (after) | exit 0, ensemble reproduces unchanged; `ship / uix 1.5543`, `deficit 1.8578`, reads 55% / markup 30% / routing 8% / shell+memo 2% / residual 4% — **identical to before**, figure for figure | **0** |
| `node .../inpage_ladder_exit_path.test.cjs` (after) | **25 passed**, 0 failed | **0** |
| `node .../inpage_ladder_exit_path.test.cjs` against `origin/main`'s aggregator | **6/25 failed** — the new witnesses proven to bite | **1** |
| `node .../inpage_ladder_exit_path.test.cjs` (after the doc row) | 25 passed | **0** |
| `node .../inpage_ladder_aggregate.cjs` (after the doc row) | ensemble reproduces | **0** |
| `python scripts/check_doc_slugs.py --verbose` | `scanning 676 markdown files... no broken links.` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | `1 files, 5 cited pins (3 landed, 2 stranded, 0 unresolvable)` · `every cited pin is an ancestor of origin/main or shares its block with one` | **0** |
| `sh scripts/test-fast-pr.sh` | `PASS fast PR spine` — JVM tier `implementation/core` + `implementation/freehand` (1291 tests / 8874 assertions, 0F 0E); node tier CLJS `:node-test` **12,734 tests / 63,868 assertions, 0 failures, 0 errors**; per-ns isolation 17/17 (196 tests / 731 assertions); `test:script-helpers` ran `inpage_ladder_exit_path.test.cjs: 25 passed` inside the spine | **0** |

### The refusals, re-proven through the documented command

Each mutation applied to `runA.edn`, the command run, the dataset restored byte-identical afterwards (verified).

**The audit's mutation — every run-A `:noreads` raw row stripped, stored block kept** — was exit 0, now:

```
EXIT=1
[inpage-ladder] REFUSED — the published aggregates do not reproduce:
  runA: raw rounds carry 840 samples, the contract is 900 (15 arms x 6 rounds x 10 samples)
  runA: arm :noreads is ABSENT from the raw rounds — the roster is a contract, not whatever survived
  runA/noreads: stored n=60, raw rounds carry 0
  runA: :h-reads+commit recomputes to NaN, which is not a finite number — no arm mean recomputed for :noreads
  runA: :h-memo-fiber recomputes to NaN, which is not a finite number — no arm mean recomputed for :noreads
```

**Refusal 1, a stored aggregate edited** (runA `:nohiccup :tmean` 3.3229 → 3.9229) — the bead's first recorded refusal, still refusing:

```
EXIT=1
[inpage-ladder] REFUSED — the published aggregates do not reproduce:
  runA/nohiccup: stored tmean 3.9229 != recomputed 3.3229
```

**Refusal 2, ONE raw sample edited** (`[0 :nohiccup 3.2]` → `99.9`) — the bead's second, and the reason `min`/`max` are checked at all, since a trimmed mean discards the outlier a corruption creates:

```
EXIT=1
[inpage-ladder] REFUSED — the published aggregates do not reproduce:
  runA/nohiccup: stored max 5.8 != recomputed 99.9
  runA/nohiccup: stored p50 3.4 != recomputed 3.45
  runA/nohiccup: stored tmean 3.3229 != recomputed 3.3479
  runA: :h-hiccup-build stored 0.3375 != recomputed 0.3125
  runA: :h-codec-walk stored 0.5813 != recomputed 0.6062
```

None of the three printed an `ok` line, and `runA.edn` was verified byte-identical to its committed content after each. GitHub Actions is in a major outage, so these local exit codes are the evidence.

**The provenance gate saw the page and stayed green, and nothing was re-pinned.** `--changed-since origin/main` selected exactly **1** corpus file — this PR's studio page, the only corpus path it touches — and passed. The two *stranded* pins it reports are pre-existing on that page and are tolerated by the gate's own rule (each shares its block with a landed pin); this PR cites no commit and re-pins nothing, so they were left exactly as found.

A note on how the spine was run: this worktree had no `implementation/node_modules`, so the first spine run reached `CLJS node integration` and failed there with `Cannot find module 'shadow-cljs/cli/runner.js'` — every other tier green. It was re-run with `implementation/node_modules` junctioned to the primary checkout's real tree, which is the exit **0** above; the junction was then removed link-first and the primary checkout's counts re-verified unchanged (101 / 59).

## Not in scope

Audit item 3 (persisting canonical-parity / harvest / arm-order / control verdicts into the datasets themselves, and machine-binding the studio page's §4/§5 cells to generated output) is untouched — it needs a re-publication of the datasets, which this bead's fence explicitly forbids.
