### PR TITLE
fix(hicasso): the census roster's retracted isolation and its write-path verdict (rf2-2rtt6.56, rf2-2rtt6.62)

### DIFF
--- a/docs/design/hicasso/studio/census-real-clock-rows.md
+++ b/docs/design/hicasso/studio/census-real-clock-rows.md
@@ -15,10 +15,19 @@ Bead **`rf2-2rtt6.56`**. The standard is **`rf2-2rtt6.1`**.
 > **THE CANONICAL MOUNT WITNESS IS M1 AND STAYS M1.** The amendment is
 > explicit that census-page rows **corroborate** the canonical witness and do
 > not silently redefine it. These rows are the diagnostic ladder the roster's
-> pages suggest — the same screen at two boundary decompositions, so shell
-> cost and interpreter cost separate on one page — and the bar rows stay on
-> their own instrument. Nothing here re-baselines HD-012, and the ruling on
-> any verdict below is the operator's (`rf2-2rtt6.1`), never this page's.
+> pages suggest, and the bar rows stay on their own instrument. Nothing here
+> re-baselines HD-012, and the ruling on any verdict below is the operator's
+> (`rf2-2rtt6.1`), never this page's.
+
+> **RETRACTED, 2026-08-07 (`rf2-2rtt6.62`).** This page previously described
+> the large-template and feed rows as *the same screen at two boundary
+> decompositions, so shell cost and interpreter cost separate on one page*,
+> and drew conclusions from the difference between them. **That isolation was
+> never established and is withdrawn** — see [What this page does not
+> isolate](#what-this-page-does-not-isolate) below. Every **within-row**
+> measurement stands unchanged: each row's arms mount a canon-gated identical
+> page, so the per-row verdicts, controls and bands below are exactly as
+> measured. What is withdrawn is every **cross-row causal** reading.
 
 ## Provenance
 
@@ -93,6 +102,43 @@ The feed row is therefore the census-real counterpart of the canonical M1
 witness — same decomposition, same read shape, real cards — and the cleanest
 gated pair on this page.
 
+## What this page does not isolate
+
+The three rows are not one screen at three sizes, and only one variable was
+ever meant to move between the first two. In the landed instrument, four move
+together:
+
+| row | cards | elements | per-instance reads | boundaries |
+|---|---|---|---|---|
+| large-template | 69 article cards | 1,202 | 141 | **1** |
+| feed | 300 article cards | 5,129 | 603 | **301** |
+| ordinary | 5 comment cards (a *different screen*) | 51 | 15 | 7 |
+
+`large_template.cljs` seeds `{:articles 69 :tags 10}` and `feed.cljs` seeds
+`{:articles 300 :tags 10}`, through the **same** element arithmetic
+(`19 + 10 + 17·articles`). So the step from the one-boundary row to the
+301-boundary row is simultaneously a step to **4.35× the cards, elements and
+subscription reads**. A shared `card.cljs` and the one-card canonical equality
+gate establish that the two pages are built from **byte-identical markup** —
+that is markup parity, and it is real. It is not matched workload, and no
+timing difference between these two rows can be attributed to boundary
+decomposition rather than to size.
+
+**Consequently, everything below is a within-row claim.** Within a row the
+comparison is sound and unaffected: all arms mount the identical page, proven
+by canonical-DOM equality before any clock is read, so each row's
+hicasso/uix ratio, control, band and verdict are exactly as measured. Between
+rows this page reports the **ordering of measured numbers** and nothing
+causal.
+
+**What would establish it.** Clock both decompositions at one card count — at
+minimum the 69 and 300 rungs. That is a seed change (both shapes already take
+`{:articles n :tags 10}`) plus a session on a quiet box, and it has not been
+run: this repository has published rows taken on a contended box and had to
+retract them, so the matched run waits for a real measurement window rather
+than being estimated from the absolutes already on this page. Until it exists,
+the isolation stays retracted. Tracked on `rf2-2rtt6.62`.
+
 ## What this page refuses, up front
 
 The roster's **write rows** (shape 3's broad commit, shape 4's narrow commit)
@@ -136,10 +182,13 @@ on its own shapes
 cleanly, and it FAILS the amendment's line**: 1.3053× [1.1044 – 1.4660]
 against direct UIx, control PASS, band 6.7%, margin 18.7%. This is the row the
 roster built to price the hiccup interpreter with the boundary shell held at
-one — 1,202 interpreted elements against a compile-time page — and it behaves
-exactly as the restated HD-008 verdict attributes: the deficit lives in the
-interpreter walk, and it concentrates where the interpreter term is largest.
-The caveat is printed on the row itself: the UIx twin reads five coarse
+one — 1,202 interpreted elements against a compile-time page — and its own
+`taskNet` reading puts the whole gap in **script**, which is what the restated
+HD-008 verdict attributes: the deficit lives in the interpreter walk. That
+attribution is within-row and stands. The further claim that it *concentrates
+where the interpreter term is largest* was a cross-row reading and is withdrawn
+(`rf2-2rtt6.62`) — this row is not the feed row with its boundaries rearranged,
+it is a smaller page. The caveat is printed on the row itself: the UIx twin reads five coarse
 subscriptions where the census page reads 141 per-instance, because no
 one-boundary hook surface can spell the census's read shape at all. The row
 prices the whole authoring position, not the codec alone.
@@ -178,15 +227,24 @@ magnitude, per the note above.
 The element-per-boundary scaling argument in the bead — census cards carry
 ~6× more interpreter work per boundary, so the interpreter-attributed deficit
 should scale up — is **refuted in its magnitude prediction and confirmed in
-its attribution**. The gap stays 100% script (taskNet ≈ 1.0), i.e. it *is*
-the interpreter; but on real cards React's own per-element mount work (style,
-layout, commit — identical across arms in the decomposition) grows faster than
-the interpreter term, so the interpreter's *share* shrinks and the ratio
-compresses from M1's ~1.50 readings toward ~1.16–1.22. The candidate's mount
-deficit is workload-dependent, and the synthetic p0 witnesses sit near its
-worst case, not its typical one. Where the shell is held at one and the
-interpreter term is maximal (large-template), the ratio re-expands to
-1.3053× — still well short of what M1 reads.
+its attribution**. The gap stays 100% script (taskNet ≈ 1.0) on every row,
+i.e. it *is* the interpreter: that is a within-row decomposition, measured
+three times, and it stands. The *magnitude* did not grow — the feed row reads
+1.16–1.22× where M1 reads ~1.50 — so the candidate's mount deficit is
+workload-dependent and the synthetic p0 witnesses sit near its worst case
+rather than its typical one.
+
+> **The explanation of *why* it compresses is withdrawn (`rf2-2rtt6.62`).**
+> This paragraph previously argued that React's own per-element mount work
+> grows faster than the interpreter term, so the interpreter's *share*
+> shrinks — and read the large-template row's 1.3053× as that share
+> re-expanding "where the shell is held at one and the interpreter term is
+> maximal". That is a cross-row causal reading, and the rows do not support
+> one: large-template differs from feed in cards, elements and reads as well
+> as in boundaries (see [What this page does not
+> isolate](#what-this-page-does-not-isolate)). The three ratios remain as
+> measured — 1.3053× / 1.1646× / 1.1248× — but which term of the workload
+> moves them is unresolved on this instrument.
 
 Beside the gate: on the one-boundary census page **direct UIx beats stock
 Reagent outright** — uix/reagent 0.8913× [0.7739 – 0.9835], whole range below
@@ -200,7 +258,7 @@ own shapes.
 |---|---|---|
 | P1 | ctl-2x reads below its arithmetic prediction on every row (`rf2-jcm3p`) | **CONFIRMED on large-template** (1.8650 / 1.8879 vs 1.9759) and **on ordinary**, where the additive residual `c` is 0.90 ms on a 1.14 ms tared floor — the constant is most of the signal. **REFUTED on feed** (2.0772 / 2.2450 vs 1.9943): at 10,229 elements the doubled floor costs *more* than the arithmetic — layout 2.06×, style 1.85×, script 2.3× in the decomposition — so the superlinearity of React's own mount at 10k elements outweighs the additive undershoot. Recorded, not smoothed over |
 | P2 | direction only: feed hicasso/uix wholly above 1.10 | **CONFIRMED in direction on the reagent run** (whole range above 1.10); **not resolved on the uix run** (range floor 1.0951). The magnitude *growth* the bead's scaling argument implied did not happen — the deficit shrank instead (see the workload leg above) |
-| P3 | large-template is the largest hicasso/uix of the three rows | **CONFIRMED** — 1.3053 > 1.1646 > 1.1248 |
+| P3 | large-template is the largest hicasso/uix of the three rows | **ORDERING CONFIRMED, REASONING NOT** — 1.3053 > 1.1646 > 1.1248 is what was measured. P3 was registered on the reasoning that the shell is held at one boundary while the interpreter term is maximal; the rows cannot separate that from large-template simply being a different page at a different size (`rf2-2rtt6.62`). The ordering is a fact about three numbers, not evidence for the mechanism that predicted it |
 | P4 | the ordinary row sits near this door's floor; if its control or band cannot hold, it publishes a refusal, not a number | **CONFIRMED** — both runs' ordinary controls FAILED (1.1511 / 1.2964 vs 1.7255 predicted); the row's gated magnitudes are published only as instrument-limited non-results carrying the control's failure |
 
 ## Refusals and instrument limits, with reasons
@@ -236,9 +294,11 @@ census rows corroborating M1:
 
 The corroboration cuts both ways and the page says both halves: the candidate
 clears nothing here (no row passes the amendment's line), **and** M1's ~1.50×
-readings do not transfer to census-real screens, where the measured deficit is
-1.10–1.31× depending on how the same markup is cut into boundaries. That
-second half is a comparison of readings, not of magnitudes: M1 publishes a
-regime rather than a number (`rf2-jcm3p`, 2026-08-06 — see the note above),
-and what these rows corroborate is its **direction**. The ruling on what that
-means for the programme is the operator's (`rf2-2rtt6.1`); this page measures.
+readings do not transfer to census-real screens, where the measured deficit
+across the three rows spans 1.10–1.31×. That span is an observed range over
+three *different pages* — not a function of boundary decomposition, which this
+instrument does not isolate (`rf2-2rtt6.62`). And the second half is a
+comparison of readings, not of magnitudes: M1 publishes a regime rather than a
+number (`rf2-jcm3p`, 2026-08-06 — see the note above), and what these rows
+corroborate is its **direction**. The ruling on what that means for the
+programme is the operator's (`rf2-2rtt6.1`); this page measures.

--- a/docs/design/hicasso/studio/census-real-clock-rows.md
+++ b/docs/design/hicasso/studio/census-real-clock-rows.md
@@ -117,8 +117,10 @@ together:
 `large_template.cljs` seeds `{:articles 69 :tags 10}` and `feed.cljs` seeds
 `{:articles 300 :tags 10}`, through the **same** element arithmetic
 (`19 + 10 + 17·articles`). So the step from the one-boundary row to the
-301-boundary row is simultaneously a step to **4.35× the cards, elements and
-subscription reads**. A shared `card.cljs` and the one-card canonical equality
+301-boundary row is simultaneously a step to **4.35× the cards** — and with
+them 4.27× the elements and 4.28× the subscription reads, the two lagging
+slightly because the 29-element page chrome does not scale. The boundary count
+meanwhile steps by 301×. A shared `card.cljs` and the one-card canonical equality
 gate establish that the two pages are built from **byte-identical markup** —
 that is markup parity, and it is real. It is not matched workload, and no
 timing difference between these two rows can be attributed to boundary

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -280,7 +280,10 @@ for (const { tag, file, mod } of DRIVERS) {
 
   t('the driver exposes its run as `drive` and its decision as `verdict`', () => {
     assert.ok(DRIVE.length > 0, 'the driver must expose its run as `drive`');
-    assert.match(SRC, /module\.exports = \{ summarise, verdict \};/);
+    // `summarise` and `verdict` FIRST and always — a driver may export more
+    // (census_clock_run.cjs adds `destination`, its write-path decision), but
+    // the decision pair is what every test below reaches for.
+    assert.match(SRC, /module\.exports = \{ summarise, verdict\s*[,}]/);
     assert.match(SRC, /require\.main === module/);
     assert.match(SRC, /drive\(\)\.then\(\(code\) => \{\s*if \(code !== 0\) process\.exit\(code\);/);
   });
@@ -346,6 +349,134 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   const band = verdict({ failed: null, rows: [row({ ceilingBreached: true, band: 0.4 })] });
   assert.notStrictEqual(band.code, 0, 'P4 promises a refusal when the band cannot hold');
 });
+
+// --- census_clock_run.cjs: the WRITE path, not just the exit path ------------
+//
+// rf2-2rtt6.56 (merged-PR audit #7379). `verdict` decides what may be QUOTED;
+// `destination` decides what may be WRITTEN. The driver used to write the
+// canonical datasets before the refusal was consulted and under the canonical
+// filenames whatever shape the run had, so a narrowed / --no-build / refused
+// run silently replaced the published evidence. Same fail-open as the exit
+// path, one file over, and checkable the same hermetic way.
+
+{
+  const CENSUS = DRIVERS[1].file;
+  const { destination } = DRIVERS[1].mod;
+  const SRC = fs.readFileSync(CENSUS, 'utf8');
+  const CANON = '/data/censusclock-2rtt6-56';
+  const shape = (over = {}) => ({
+    dataDir: CANON,
+    dataDirOverridden: false,
+    rowsOnly: null,
+    runsOnly: null,
+    noBuild: false,
+    depthPublished: true,
+    ...over,
+  });
+  const t = (what, fn) => test(`census_clock_run.cjs write path: ${what}`, fn);
+
+  t('the published shape, all gates passed, is the ONLY thing that is canonical', () => {
+    const d = destination(shape(), 0);
+    assert.strictEqual(d.canonical, true);
+    assert.strictEqual(d.dir, CANON);
+    assert.strictEqual(d.why, null);
+  });
+
+  // Each condition alone must move the write off the canonical set. These are
+  // the mutation proofs: flip one field, the destination must change.
+  for (const [what, over, code, needle] of [
+    ['a refused verdict', {}, 3, /verdict refused it \(exit 3\)/],
+    ['a partial row set', { rowsOnly: 'feed' }, 0, /PARTIAL row set/],
+    ['a partial run set', { runsOnly: 'uix' }, 0, /PARTIAL run set/],
+    ['--no-build', { noBuild: true }, 0, /--no-build/],
+    ['an overridden depth', { depthPublished: false }, 0, /OVERRIDDEN design depth/],
+  ]) {
+    t(`${what} is NOT canonical, and says why`, () => {
+      const d = destination(shape(over), code);
+      assert.strictEqual(d.canonical, false, `${what} must not be canonical`);
+      assert.notStrictEqual(d.dir, CANON, `${what} must not write the published filenames`);
+      assert.strictEqual(d.dir, `${CANON}.unpublished`);
+      assert.match(d.why, needle);
+      // ... and the same shape WITHOUT that condition is canonical again, so
+      // the test cannot pass by refusing everything.
+      assert.strictEqual(destination(shape(), 0).canonical, true);
+    });
+  }
+
+  t('every condition that fired is named, not just the first', () => {
+    const d = destination(shape({ rowsOnly: 'feed', noBuild: true, depthPublished: false }), 5);
+    assert.strictEqual(d.canonical, false);
+    for (const needle of [/verdict refused it \(exit 5\)/, /PARTIAL row set/, /--no-build/, /OVERRIDDEN design depth/]) {
+      assert.match(d.why, needle);
+    }
+  });
+
+  t('an explicit C56CLOCK_DATA_DIR is honoured as given, and is never canonical', () => {
+    const mine = '/data/censusclock-somebead';
+    const d = destination(shape({ dataDir: mine, dataDirOverridden: true }), 0);
+    assert.strictEqual(d.dir, mine, 'the operator named the destination; do not rewrite it');
+    assert.strictEqual(d.canonical, false, 'an operator-named directory is not the published set');
+    // Even refused, it still lands where the operator said — the refusal is
+    // carried by the exit code and by `canonical`, not by moving the file.
+    assert.strictEqual(destination(shape({ dataDir: mine, dataDirOverridden: true }), 4).dir, mine);
+  });
+
+  // The defect was an ORDERING one: the write happened, and the refusal was
+  // computed afterwards. Pin the order in the source, because that is what
+  // regressed and a behavioural test of a browser driver cannot see it.
+  t('the verdict is computed BEFORE any dataset is written', () => {
+    const v = SRC.indexOf('const v = verdict(summarise(failed, results));');
+    const dst = SRC.indexOf('const dest = destination(runShape(), v.code);');
+    const mk = SRC.indexOf('fs.mkdirSync(dest.dir');
+    assert.ok(v > 0 && dst > 0 && mk > 0, 'the write path no longer has the shape this test pins');
+    assert.ok(v < dst, 'the verdict must be computed before the destination is chosen');
+    assert.ok(dst < mk, 'the destination must be chosen before the directory is created');
+  });
+
+  t('no dataset is written to the raw DATA_DIR downstream of `destination`', () => {
+    // This is how the defect grew: the write named the canonical directory
+    // directly. Every write site must go through the chosen destination.
+    const after = SRC.slice(SRC.indexOf('const dest = destination(runShape(), v.code);'));
+    assert.ok(!/fs\.mkdirSync\(DATA_DIR/.test(after), 'mkdirSync must use the chosen destination');
+    assert.ok(!/path\.join\(DATA_DIR/.test(after), 'the dataset path must use the chosen destination');
+    assert.match(after, /path\.join\(dest\.dir/);
+  });
+
+  t('a dataset records whether it is the published evidence', () => {
+    // A file that travels out of its directory must still say what it is.
+    assert.match(SRC, /canonical: meta\.dest\.canonical/);
+    assert.match(SRC, /notCanonicalWhy: meta\.dest\.why/);
+  });
+
+  t('the dataset is built OUTSIDE `drive`, so recording never looks like deciding', () => {
+    // `datasetFor` names guardRefuse/ceilingBreached to SERIALISE them. Inside
+    // `drive` and downstream of `verdict` that would trip the invariant above
+    // — correctly, since a reader cannot tell a record from a second decision.
+    assert.match(SRC, /^function datasetFor\(rows, meta\) \{/m);
+    const drive = SRC.slice(SRC.indexOf('async function drive('));
+    assert.ok(drive.indexOf('function datasetFor(') === -1, '`datasetFor` must sit above `drive`');
+    assert.match(drive, /const data = datasetFor\(rows, \{ sha, blobs: bl, dest \}\);/);
+  });
+
+  // rf2-2rtt6.62: the counts the retraction turned on must be IN the evidence,
+  // not recoverable only by reading the instrument at the producing commit.
+  t("each row's workload counts are persisted with its numbers", () => {
+    assert.match(SRC, /stamp: STAMP\[r\.rowId\]/);
+    for (const needle of [/cards: '69 article cards'/, /cards: '300 article cards'/, /cards: '5 comment cards/]) {
+      assert.match(SRC, needle);
+    }
+  });
+
+  t('the published depth has ONE definition, shared by the stamp and the write path', () => {
+    assert.match(SRC, /const PUBLISHED_DEPTH = \{ rounds: 6, blocks: 3, warmup: 4, samples: 10 \}/);
+    // The old inline copy must be gone, or the two can drift apart again.
+    assert.ok(
+      !/ROUNDS === 6 && BLOCKS === 3 && WARMUP === 4 && SAMPLES === 10/.test(SRC),
+      'the inline depth predicate is duplicated; use depthIsPublished()'
+    );
+    assert.ok(SRC.split('depthIsPublished()').length - 1 >= 2, 'the one predicate must serve both readers');
+  });
+}
 
 // --- clock_run.cjs: the bar-level adjudication must reach the exit code -------
 //

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_app.cljs
@@ -22,8 +22,9 @@
   (rf2-2rtt6.62, merged-PR audit of #7372/#7379). An earlier wording here
   called shapes 2 and 3 the same screen at two boundary decompositions
   and claimed the pair separates the two costs on one page. Byte-identical
-  cards prove markup parity, not matched workload: the two rows carry 4.35x
-  apart in cards, elements and per-instance reads, so a cross-row timing
+  cards prove markup parity, not matched workload: the two rows stand 4.35x
+  apart in cards (4.27x in elements, 4.28x in reads — the 29-element chrome
+  does not scale) while boundaries step 1 -> 301, so a cross-row timing
   difference confounds decomposition with size and attributes nothing.
   Each row is valid WITHIN itself — every arm mounts the identical page,
   canon-gated before any clock — and that is the whole of what this

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_app.cljs
@@ -14,12 +14,21 @@
 
   ## Three rows, all mounts
 
-  `large-template` (1,202 elements, ONE boundary), `feed` (5,129
-  elements, 301 boundaries — shapes 3 and 4 share this mount), `ordinary`
-  (51 elements, 7 boundaries). Shapes 2 and 3 are the same screen at two
-  boundary decompositions with byte-identical cards, so the pair
-  separates shell cost from interpreter cost on one page — the thing no
-  synthetic witness does.
+  `large-template` (69 cards, 1,202 elements, 141 reads, ONE boundary),
+  `feed` (300 cards, 5,129 elements, 603 reads, 301 boundaries — shapes 3
+  and 4 share this mount), `ordinary` (51 elements, 7 boundaries).
+
+  **THE PAIR DOES NOT ISOLATE SHELL COST FROM INTERPRETER COST**
+  (rf2-2rtt6.62, merged-PR audit of #7372/#7379). An earlier wording here
+  called shapes 2 and 3 "the same screen at two boundary decompositions"
+  and claimed the pair separates the two costs on one page. Byte-identical
+  cards prove markup parity, not matched workload: the two rows carry 4.35x
+  apart in cards, elements and per-instance reads, so a cross-row timing
+  difference confounds decomposition with size and attributes nothing.
+  Each row is valid WITHIN itself — every arm mounts the identical page,
+  canon-gated before any clock — and that is the whole of what this
+  instrument establishes. The isolation is retracted until both
+  decompositions have been clocked at one card count.
 
   ## What this instrument does NOT measure, and why
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_app.cljs
@@ -20,7 +20,7 @@
 
   **THE PAIR DOES NOT ISOLATE SHELL COST FROM INTERPRETER COST**
   (rf2-2rtt6.62, merged-PR audit of #7372/#7379). An earlier wording here
-  called shapes 2 and 3 "the same screen at two boundary decompositions"
+  called shapes 2 and 3 the same screen at two boundary decompositions
   and claimed the pair separates the two costs on one page. Byte-identical
   cards prove markup parity, not matched workload: the two rows carry 4.35x
   apart in cards, elements and per-instance reads, so a cross-row timing

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_arms.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_arms.cljs
@@ -31,7 +31,7 @@
 
   **THEY DIFFER IN HOW MANY CARDS TOO, AND THAT IS NOT AN ISOLATION**
   (rf2-2rtt6.62, from the merged-PR audit of #7372/#7379). An earlier
-  wording of this docstring said the pages "differ in exactly one thing".
+  wording of this docstring said the pages differ in exactly one thing.
   They do not. `large-template` seeds 69 articles and `feed` seeds 300 —
   the same element arithmetic (`19 + 10 + 17·articles`) at 4.35x the
   cards, so elements (1,202 -> 5,129), per-instance reads (141 -> 603)

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_arms.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_arms.cljs
@@ -25,9 +25,25 @@
 
   ## What each substrate can and cannot spell, stated up front
 
-  The three pages differ in exactly one thing — how many boundaries the
-  same markup is cut into — and the substrates do not meet that variable
-  equally. These are findings the rows are FOR, not defects in the arms:
+  The three pages differ in HOW MANY BOUNDARIES the same markup is cut
+  into, and the substrates do not meet that variable equally. These are
+  findings the rows are FOR, not defects in the arms.
+
+  **THEY DIFFER IN HOW MANY CARDS TOO, AND THAT IS NOT AN ISOLATION**
+  (rf2-2rtt6.62, from the merged-PR audit of #7372/#7379). An earlier
+  wording of this docstring said the pages "differ in exactly one thing".
+  They do not. `large-template` seeds 69 articles and `feed` seeds 300 —
+  the same element arithmetic (`19 + 10 + 17·articles`) at 4.35x the
+  cards, so elements (1,202 -> 5,129), per-instance reads (141 -> 603)
+  and boundaries (1 -> 301) all move TOGETHER between those two rows.
+  A shared `card.cljs` and one-card canonical equality establish MARKUP
+  PARITY; they do not hold WORKLOAD constant. Every row below is
+  therefore valid WITHIN itself — its arms mount the identical page —
+  and no cross-row difference may be attributed to boundary
+  decomposition. Matching the decompositions at one card count is a
+  seed change here (both rows already take `{:articles n :tags 10}`)
+  plus a clock session on a quiet box; until that run exists, the
+  isolation is retracted rather than assumed.
 
   - **large-template (1,202 elements, ONE boundary, 141 per-instance
     reads).** The candidate and Reagent read per-instance subscriptions

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
@@ -50,8 +50,10 @@
 // large-template and feed rows were once described as one screen at two
 // boundary decompositions, from which shell cost and interpreter cost
 // separate. They are not: they seed 69 and 300 articles through the SAME
-// element arithmetic, so cards, elements, per-instance reads and
-// boundaries all move together by 4.35x. Shared `card.cljs` and one-card
+// element arithmetic, so cards (4.35x), elements (4.27x) and per-instance
+// reads (4.28x) all move at once, against a 301x step in boundaries — the
+// two middle terms lag only because the 29-element page chrome does not
+// scale with the seed. Shared `card.cljs` and one-card
 // canonical equality buy MARKUP PARITY, not matched workload. What this
 // driver establishes is per row: within a row every arm mounts the
 // identical page (canon-gated before any clock), so hicasso/uix on THAT

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
@@ -37,9 +37,29 @@
 //
 // ## The rows — mounts only, and the write refusal up front
 //
-//   large-template  1,202 elements, ONE boundary   the interpreter row
-//   feed            5,129 elements, 301 boundaries the census M1 counterpart
-//   ordinary           51 elements, 7 boundaries   the small-screen row
+//   large-template   69 article cards  1,202 elements  141 reads    1 boundary
+//   feed            300 article cards  5,129 elements  603 reads  301 boundaries
+//   ordinary          5 comment cards     51 elements   15 reads    7 boundaries
+//
+// `ordinary` is a DIFFERENT SCREEN (the article page's comment column),
+// not the article list at a third size — its cards are not the other two
+// rows' cards and its counts are not on their arithmetic.
+//
+// EVERY ROW IS A WITHIN-ROW COMPARISON, AND NOTHING HERE IS A CROSS-ROW
+// ISOLATION (rf2-2rtt6.62, from the merged-PR audit of #7372/#7379). The
+// large-template and feed rows were once described as one screen at two
+// boundary decompositions, from which shell cost and interpreter cost
+// separate. They are not: they seed 69 and 300 articles through the SAME
+// element arithmetic, so cards, elements, per-instance reads and
+// boundaries all move together by 4.35x. Shared `card.cljs` and one-card
+// canonical equality buy MARKUP PARITY, not matched workload. What this
+// driver establishes is per row: within a row every arm mounts the
+// identical page (canon-gated before any clock), so hicasso/uix on THAT
+// page is adjudicable. Between rows it establishes ordering of measured
+// numbers and nothing causal. Matching the two decompositions at one card
+// count is a seed change in `census_clock_arms.cljs` plus a clock session
+// on a quiet box; the cards column above is printed on every stamp so the
+// confound cannot be re-derived silently.
 //
 // The roster's WRITE rows (shape 3's broad commit, shape 4's narrow
 // commit) are REFUSED by construction on this box, with the recorded
@@ -161,8 +181,14 @@ const BESIDE = {
 // What each arm reads on each row — printed on the stamp, because the
 // substrates do NOT meet the roster's boundary variable equally and a row
 // that hid that would be quoting a comparison it is not making.
+//
+// `cards` is on the stamp for the same reason (rf2-2rtt6.62): it is the
+// term that makes large-template and feed incomparable to each other, and
+// it was the one count the original stamp left off — which is precisely
+// how "the same screen at two boundary decompositions" survived review.
 const STAMP = {
   'large-template': {
+    cards: '69 article cards',
     elements: 1202,
     boundaries: { hicasso: 1, uix: 1, reagent: 1 },
     reads: {
@@ -172,6 +198,7 @@ const STAMP = {
     },
   },
   feed: {
+    cards: '300 article cards',
     elements: 5129,
     boundaries: { hicasso: 301, uix: 301, reagent: 301 },
     reads: {
@@ -181,6 +208,7 @@ const STAMP = {
     },
   },
   ordinary: {
+    cards: '5 comment cards (a DIFFERENT screen — not the article list at a third size)',
     elements: 51,
     boundaries: { hicasso: 7, uix: 7, reagent: 7 },
     reads: {
@@ -581,11 +609,16 @@ function report(out) {
   console.log(
     `;; grain    smallest non-zero per-sample TaskDuration delta ${granularity.length ? granularity[0].toFixed(6) : 'n/a'} ms`
   );
-  console.log(`;; stamp    ${stamp.elements} elements; the census's own screen, mounted at the roster's seed`);
+  console.log(`;; stamp    ${stamp.cards}; ${stamp.elements} elements; the census's own screen, mounted at the roster's seed`);
   for (const arm of ['hicasso', 'uix', 'reagent']) {
     if (!armIds.includes(arm)) continue;
     console.log(`;; stamp    ${arm.padEnd(8)} B=${stamp.boundaries[arm]} · reads: ${stamp.reads[arm]}`);
   }
+  console.log(
+    `;; scope    WITHIN-ROW ONLY — the arms above mount the identical page, so this row's ratios ` +
+      `adjudicate. Rows differ in cards as well as boundaries (rf2-2rtt6.62), so no difference ` +
+      `BETWEEN rows attributes to boundary decomposition.`
+  );
 
   // parity record
   const nonControl = Object.entries(canon).filter(([, c]) => !c.control);

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
@@ -111,6 +111,16 @@
 // also left prediction P4 below ("if its control or band cannot hold, the
 // row publishes a REFUSAL with the reason, not a number") as a promise this
 // file's own exit code did not keep. See the note above `verdict`.
+//
+// ## Where the datasets land
+//
+// The canonical dataset directory holds THE PUBLISHED SHAPE and nothing
+// else. A run that is narrowed (C56CLOCK_ROWS / C56CLOCK_ONLY), taken at an
+// overridden depth, taken `--no-build`, or refused by the verdict above
+// writes to a sibling `.unpublished` directory instead, named on stdout with
+// the reason; an explicit C56CLOCK_DATA_DIR is honoured as given. See the
+// note above `destination` — that routing is rf2-2rtt6.56's half of the same
+// fail-open rf2-rr6do repaired on the exit path.
 
 'use strict';
 
@@ -149,6 +159,17 @@ const GATE_LINE = 1.1; // the amendment's one line: hicasso <= 1.10x direct UIx
 const NO_BUILD = process.argv.includes('--no-build');
 const SKIP_QUIET = process.env.C56CLOCK_SKIP_QUIET === '1';
 
+// The published depth, in ONE place. The provenance stamp and the dataset
+// write path must agree on what "the published shape" is, and two copies of
+// that predicate is how they drift apart.
+const PUBLISHED_DEPTH = { rounds: 6, blocks: 3, warmup: 4, samples: 10 };
+const depthIsPublished = () =>
+  ROUNDS === PUBLISHED_DEPTH.rounds &&
+  BLOCKS === PUBLISHED_DEPTH.blocks &&
+  WARMUP === PUBLISHED_DEPTH.warmup &&
+  SAMPLES === PUBLISHED_DEPTH.samples;
+
+const DATA_DIR_OVERRIDDEN = Boolean((process.env.C56CLOCK_DATA_DIR || '').trim());
 const DATA_DIR =
   process.env.C56CLOCK_DATA_DIR || path.join(__dirname, '..', 'data', 'censusclock-2rtt6-56');
 
@@ -875,6 +896,112 @@ function verdict(summary) {
   return { code, lines };
 }
 
+// WHERE A RUN'S DATASETS MAY BE WRITTEN (rf2-2rtt6.56, merged-PR audit #7379).
+//
+// `verdict` decides what may be QUOTED. This decides what may be WRITTEN, and
+// it is a separate question the driver got wrong in the same direction. The
+// datasets were written under the CANONICAL filenames before the refusal was
+// consulted, whatever shape the run had — so a run narrowed to one row
+// (C56CLOCK_ROWS) or one adapter (C56CLOCK_ONLY), taken with `--no-build`
+// against whatever bundle happened to be on disk, taken at an overridden
+// depth, or one the verdict then REFUSED, silently replaced the published
+// evidence the studio page cites. Nothing announced it: the write had already
+// landed, and the nonzero exit arrived afterwards. rf2-rr6do repaired the exit
+// path; this is the write path, the other half of the same fail-open.
+//
+// THE RULE: the canonical directory holds the PUBLISHED SHAPE and nothing
+// else. Any narrowing, any override, any refusal routes to a sibling
+// `.unpublished` directory, named on stdout with the reason.
+//
+// An explicit C56CLOCK_DATA_DIR is the operator naming their own destination
+// — which is how the sibling `censusclock-*` datasets beside the canonical
+// one were taken. It is honoured as given, and it is never the canonical set.
+//
+// Pure over a flat shape record, for the same reason `verdict` is: the write
+// path is then checkable without a release build and a headless Chromium.
+function destination(shape, code) {
+  const s = shape || {};
+  if (s.dataDirOverridden) {
+    return { dir: s.dataDir, canonical: false, why: 'C56CLOCK_DATA_DIR named this destination' };
+  }
+  const why = [];
+  if (code !== 0) why.push(`the run's own verdict refused it (exit ${code})`);
+  if (s.rowsOnly) why.push(`a PARTIAL row set (C56CLOCK_ROWS=${s.rowsOnly})`);
+  if (s.runsOnly) why.push(`a PARTIAL run set (C56CLOCK_ONLY=${s.runsOnly})`);
+  if (s.noBuild) why.push("--no-build (the bundle on disk is not known to be this tree's)");
+  if (!s.depthPublished) why.push('an OVERRIDDEN design depth');
+  if (!why.length) return { dir: s.dataDir, canonical: true, why: null };
+  return { dir: `${s.dataDir}.unpublished`, canonical: false, why: why.join('; ') };
+}
+
+/**
+ * The compact dataset for one run — the reduced quantities every statistic on
+ * the studio page is a function of, so the page can be recomputed from the
+ * tree.
+ *
+ * Lifted out of `drive` deliberately. Serialising a row means naming its
+ * refusal fields (`guardRefuse`, `ceilingBreached`, …), and `drive` is held to
+ * an invariant that nothing downstream of `verdict` may name one — the check
+ * that stops a second exit path growing back (`../clock_exit_path.test.cjs`).
+ * The write now happens after the verdict, so the serialiser has to live
+ * outside it. Recording is not deciding, and this is where that shows.
+ */
+function datasetFor(rows, meta) {
+  return {
+    bead: 'rf2-2rtt6.56',
+    commit: meta.sha,
+    blobs: meta.blobs,
+    when: new Date().toISOString(),
+    // Whether this file is the published evidence, recorded IN the file — a
+    // dataset that travels out of its directory must still say what it is.
+    canonical: meta.dest.canonical,
+    notCanonicalWhy: meta.dest.why,
+    design: { rounds: ROUNDS, blocks: BLOCKS, warmup: WARMUP, samples: SAMPLES, tolerance: TOLERANCE, controlSlack: CONTROL_SLACK, gateLine: GATE_LINE },
+    clock: 'Performance.getMetrics raw TaskDuration, frame-settled (rAF + setTimeout), plumb-tared',
+    door: 'page.evaluate -> C56CLOCK.sample (every arm, plumb included)',
+    node: process.version,
+    rows: rows.map((r) => ({
+      rowId: r.rowId,
+      armIds: r.armIds,
+      // The row's workload — cards, elements, per-instance reads, boundaries.
+      // Persisted because rf2-2rtt6.62 turned on exactly these counts, and
+      // they were recoverable only by reading the instrument's own source at
+      // the producing commit.
+      stamp: STAMP[r.rowId],
+      canon: r.canon,
+      ctlPredicted: r4(r.ctlPredicted),
+      blocksTask: r.blocksTask,
+      blocksNet: r.blocksNet.map((rd) => rd.map((b) => Object.fromEntries(Object.entries(b).map(([a, xs]) => [a, r4(p50(xs))])))),
+      blocksInPage: r.blocksInPage.map((rd) => rd.map((b) => Object.fromEntries(Object.entries(b).map(([a, xs]) => [a, r4(p50(xs.filter(Number.isFinite)))])))),
+      tally: r.tally,
+      runtime: r.runtime,
+      quiet: r.quiet,
+      windowStart: r.windowStart,
+      adjudication: {
+        ctl: r.adjudication.ctl,
+        cAdditive: r4(r.adjudication.cAdditive),
+        band: Number.isFinite(r.adjudication.assessed.bandStats.band) ? r4(r.adjudication.assessed.bandStats.band) : null,
+        ceilingBreached: r.adjudication.assessed.verdict.ceilingBreached,
+        bars: r.adjudication.bars,
+        verdicts: r.adjudication.verdicts,
+        guardRefuse: r.adjudication.guardRefuse,
+        plumb: r4(r.adjudication.plumb),
+        floorTared: r4(r.adjudication.floorTared),
+      },
+    })),
+  };
+}
+
+/** This process's shape, as `destination` reads it. */
+const runShape = () => ({
+  dataDir: DATA_DIR,
+  dataDirOverridden: DATA_DIR_OVERRIDDEN,
+  rowsOnly: ROWS_ONLY || null,
+  runsOnly: ONLY || null,
+  noBuild: NO_BUILD,
+  depthPublished: depthIsPublished(),
+});
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -906,7 +1033,7 @@ async function drive() {
   console.log(`;;   node        ${process.version}`);
   console.log(
     `;;   design      ${ROUNDS} rounds x ${BLOCKS} blocks x (${WARMUP} warmup + ${SAMPLES} samples) per arm` +
-      `${ROUNDS === 6 && BLOCKS === 3 && WARMUP === 4 && SAMPLES === 10 ? '' : '  *** OVERRIDDEN — NOT THE PUBLISHED SHAPE ***'}`
+      `${depthIsPublished() ? '' : '  *** OVERRIDDEN — NOT THE PUBLISHED SHAPE ***'}`
   );
   console.log(
     `;;   runs        ${RUNS.map((r) => r.id).join(', ')}` +
@@ -967,50 +1094,29 @@ async function drive() {
     server.close();
   }
 
+  // The verdict is computed BEFORE the datasets are written, because where
+  // they may be written depends on it (see `destination`).
+  const v = verdict(summarise(failed, results));
+  const dest = destination(runShape(), v.code);
+
   // compact datasets — the reduced quantities every statistic above is a
   // function of, per run, so the page can be recomputed from the tree.
   if (results.length && !failed) {
-    fs.mkdirSync(DATA_DIR, { recursive: true });
+    if (dest.canonical) {
+      console.log(';; datasets CANONICAL — the published shape, all gates passed');
+    } else {
+      console.log(`;; datasets NOT CANONICAL — ${dest.why}`);
+      console.log(';;          These are working datasets. They are not the published evidence and');
+      console.log(';;          may not be cited as it.');
+    }
+    fs.mkdirSync(dest.dir, { recursive: true });
     for (const runDef of RUNS) {
       const rows = results.filter((r) => r.runId === runDef.id);
       if (!rows.length) continue;
-      const data = {
-        bead: 'rf2-2rtt6.56',
-        commit: sha,
-        blobs: bl,
-        when: new Date().toISOString(),
-        design: { rounds: ROUNDS, blocks: BLOCKS, warmup: WARMUP, samples: SAMPLES, tolerance: TOLERANCE, controlSlack: CONTROL_SLACK, gateLine: GATE_LINE },
-        clock: 'Performance.getMetrics raw TaskDuration, frame-settled (rAF + setTimeout), plumb-tared',
-        door: 'page.evaluate -> C56CLOCK.sample (every arm, plumb included)',
-        node: process.version,
-        rows: rows.map((r) => ({
-          rowId: r.rowId,
-          armIds: r.armIds,
-          canon: r.canon,
-          ctlPredicted: r4(r.ctlPredicted),
-          blocksTask: r.blocksTask,
-          blocksNet: r.blocksNet.map((rd) => rd.map((b) => Object.fromEntries(Object.entries(b).map(([a, xs]) => [a, r4(p50(xs))])))),
-          blocksInPage: r.blocksInPage.map((rd) => rd.map((b) => Object.fromEntries(Object.entries(b).map(([a, xs]) => [a, r4(p50(xs.filter(Number.isFinite)))])))),
-          tally: r.tally,
-          runtime: r.runtime,
-          quiet: r.quiet,
-          windowStart: r.windowStart,
-          adjudication: {
-            ctl: r.adjudication.ctl,
-            cAdditive: r4(r.adjudication.cAdditive),
-            band: Number.isFinite(r.adjudication.assessed.bandStats.band) ? r4(r.adjudication.assessed.bandStats.band) : null,
-            ceilingBreached: r.adjudication.assessed.verdict.ceilingBreached,
-            bars: r.adjudication.bars,
-            verdicts: r.adjudication.verdicts,
-            guardRefuse: r.adjudication.guardRefuse,
-            plumb: r4(r.adjudication.plumb),
-            floorTared: r4(r.adjudication.floorTared),
-          },
-        })),
-      };
-      const f = path.join(DATA_DIR, `${runDef.id}.json`);
+      const data = datasetFor(rows, { sha, blobs: bl, dest });
+      const f = path.join(dest.dir, `${runDef.id}.json`);
       fs.writeFileSync(f, JSON.stringify(data));
-      console.log(`;; dataset  ${f}`);
+      console.log(`;; dataset  ${f}${dest.canonical ? '' : '   (NOT the published evidence)'}`);
     }
   }
 
@@ -1020,7 +1126,6 @@ async function drive() {
   console.log(';;   per-pair adjudications against the recorded line; nothing here amends the');
   console.log(';;   bar, and nothing here re-baselines the canonical M1 witness.');
 
-  const v = verdict(summarise(failed, results));
   for (const line of v.lines) console.error(line);
   if (v.code === 0) {
     console.error('[c56clock] ok — measured, and no arm reads differently for its position in the plan');
@@ -1028,7 +1133,7 @@ async function drive() {
   return v.code;
 }
 
-module.exports = { summarise, verdict };
+module.exports = { summarise, verdict, destination };
 
 if (require.main === module) {
   drive().then((code) => {


### PR DESCRIPTION
Two beads, one edit: the census clock rows claimed an isolation they never had, and the driver's write path did not obey its own verdict.

## `rf2-2rtt6.56` — what was already done, verified not assumed

The bead's fail-open half was repaired by `rf2-rr6do` (PR #7450) and is **verified present in the tree**, not reconstructed. `shapes/census_clock_run.cjs` decides its exit in one pure exported `verdict(summary)` over four independent conditions — `guardRefuse` (exit 2), unverified read-backs (3), band-ceiling breach (4), `ctl.ok` false (5) — with `failed` at 1 and every condition that fires named. Its prediction P4 is therefore kept by the process exit, and `clock_exit_path.test.cjs` carries the explicit test for exactly that.

## The isolation, retracted (`rf2-2rtt6.62`)

The page, the app and the arms all said the large-template and feed rows were *the same screen at two boundary decompositions*, from which shell cost and interpreter cost separate. They are not the same screen. `large_template.cljs` seeds `{:articles 69 :tags 10}`, `feed.cljs` seeds `{:articles 300 :tags 10}`, through the **same** element arithmetic (`19 + 10 + 17·articles`):

| row | cards | elements | reads | boundaries |
|---|---|---|---|---|
| large-template | 69 | 1,202 | 141 | 1 |
| feed | 300 | 5,129 | 603 | 301 |
| ratio | 4.348× | 4.267× | 4.277× | 301× |

A shared `card.cljs` and one-card canonical equality buy markup parity, not matched workload. The audit (#7372, restated #7379) offered two ways out: clock both decompositions at one card count, or retract. **The matched run is a real wall-clock measurement and this box was not quiet — five other workers were live — so this is the retraction.** No timing row was taken and none was estimated from the absolutes already on the page. The bead stays open for that run; matching the seeds is a small change, but it is worthless without a quiet box.

Withdrawn: the header claim; the interpreter-share explanation of why the ratio compresses; the headline's "concentrates where the interpreter term is largest"; P3's reasoning (its *ordering* of three measured numbers is confirmed, the mechanism it was registered on is not); and the closing "depending on how the same markup is cut into boundaries". A new **What this page does not isolate** section states the confound and what would settle it.

**Every within-row result stands unchanged.** Each row's arms mount a canon-gated identical page, so the per-row ratios, controls, bands and verdicts are exactly as measured, and the `taskNet` "the gap is script" decomposition is within-row on all three rows. Only cross-row *causal* readings were withdrawn.

Two factual corrections found while writing that table: the `ordinary` row is a **different screen** (the article page's comment column, 5 comment cards), not the article list at a third size; and `4.35×` is the *cards* ratio only — elements are 4.267× and reads 4.277× because the 29-element chrome does not scale. A page whose subject is four conflated counts cannot round three of them together.

## The write path, made to obey the verdict (`rf2-2rtt6.56`)

`rf2-rr6do` repaired the **exit** path. The **write** path was the other half of the same fail-open, and #7379 named it: datasets were written under the canonical filenames *before* the refusal was consulted, whatever shape the run had. A run narrowed to one row or one adapter, taken `--no-build` against whatever bundle was on disk, taken at an overridden depth, or refused by the verdict, silently replaced the published evidence the studio page cites — with nothing to announce it, because the write had already landed when the nonzero exit arrived.

`destination(shape, code)` is now that decision: pure over a flat shape record, for the same reason `verdict` is — checkable without a release build and a headless Chromium. The canonical directory holds the published shape and nothing else; anything narrowed, overridden or refused routes to a sibling `.unpublished` directory named on stdout with **every** reason that fired. An explicit `C56CLOCK_DATA_DIR` is the operator naming their own destination (how the sibling `censusclock-*` sets were taken), so it is honoured as given and never canonical. Each dataset also records `canonical` and `notCanonicalWhy` **in the file**, so one that travels out of its directory still says what it is.

Two things fell out of moving the verdict above the write:

- **`datasetFor` is lifted out of `drive`.** Serialising a row means naming its refusal fields, and `drive` is held to an invariant that nothing downstream of `verdict` may name one — the check that stops a second exit path growing back. Recording is not deciding, and the extraction is where that shows. That guard is **untouched and still passes**.
- **`PUBLISHED_DEPTH` / `depthIsPublished()`** replace an inline copy of the depth predicate. The provenance stamp and the write path must agree on what the published shape is; two copies is how they drift.

Each row's `stamp` (cards, elements, reads, boundaries) is now persisted with its numbers — `rf2-2rtt6.62` turned on exactly those counts, and they were recoverable only by reading the instrument's source at the producing commit. The driver also prints `cards` and a `WITHIN-ROW ONLY` scope line on every row: the missing cards count is precisely how the claim survived review.

Thirteen new hermetic checks: one mutation proof per condition in both directions, multi-condition naming, the operator override, the ordering pin (verdict → destination → mkdir), and a pin that no write site names the raw `DATA_DIR` downstream of the decision. Two existing assertions were **widened, not weakened**: the exports check now allows a driver to export more than the decision pair.

## Deliberately left

- **The matched-workload measurement** — a contended box, per above.
- **Acceptance item (4), partially.** The compact JSON persists `blocksTask` / `blocksNet` / `blocksInPage` but not the per-metric decomposition. The driver *does* collect `ScriptDuration` / `LayoutDuration` / `RecalcStyleDuration` per sample and drops them at write time, so the page's cited "layout 2.06×, style 1.85×, script 2.3×" cannot be recomputed from the committed datasets. Adding the capture is small, but it only becomes evidence on a **re-run** — the committed datasets would still lack it — so it is measurement-coupled and was left rather than half-done. Worth its own bead beside the matched run.

The page's blob table is unchanged: it records the producing commit, and both pinned blobs were already stale against the tree (`rf2-rr6do` edited the driver after the run), which is the documented convention for that table. `scripts/check_provenance_pins.py` gates commit SHAs, not blob freshness.

## Quality gates

GitHub Actions is in a major outage, so these local exit codes are the only evidence.

| command | result | exit |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | `PASS fast PR spine`, **0 `FAIL` lines**. JVM core 2,233 tests / 11,645 assertions, JVM **freehand** 1,291 tests / 8,874 assertions (the tier that owns these files), per-ns isolation 17/17 standalone, `hicasso bench-lane compile` 129 namespaces / 0 warnings, `mkdocs --strict` built | **0** |
| `npm run test:script-helpers` (owns `clock_exit_path.test.cjs`) | 133 passed in that file; all 21 suites green | **0** |
| `npm run test:hicasso-compile` | 129 lane namespaces, 436 files, **0 warnings** | **0** |
| `python scripts/check_doc_slugs.py` | green (the gate that owns `docs/design/**` links + anchors) | **0** |
| `node --check .../census_clock_run.cjs` | green | **0** |

**On the spine's log, stated plainly.** My first spine attempt hit the harness's 10-minute foreground cap and was killed, but its children kept writing to the same file handle, so the second run's log came back interleaved with the orphan's output — including one `FAIL per-ns test isolation` that belongs to the orphan. Within that run's own output the gate **passed** (`per-ns isolation: all 17 namespace(s) pass standalone (196 tests, 731 assertions)`), the `hicasso bench-lane compile` tier passed (129 namespaces, 0 warnings), and the runner returned **0**. The orphan's red is the gate's own documented bundle race — `MODULE_NOT_FOUND` / "the bundle changed on disk during the sweep", caused by a concurrent `:node-test` build unlinking `out/node-test.js` (rf2-6t03c) — which is exactly what two spines running at once produce. It is an ENVIRONMENT verdict, not an assertion mismatch, and it names no namespace this PR touches. Rather than argue from a polluted log I re-ran the spine clean, single-run, on the final committed tree — **exit 0, zero `FAIL` lines, `PASS fast PR spine`** — and that clean run is the row above. The interleaving is also what made the first log appear to skip the freehand JVM tier; the clean run shows core and freehand both running, which is the coverage that matters here.

`census_clock_run.cjs` has **no `--selftest` flag** — its `guard.selfTest()` / `seamlib.selfTest()` run inside `drive()`, which needs a release build and a headless Chromium (i.e. a measurement). `clock_exit_path.test.cjs` is the equivalent hermetic gate and is the one that owns the decision functions.

`mkdocs build --strict` does not cover `docs/design/**` (excluded by `mkdocs.yml`), so per the repo convention I verified the edited page **by hand**: every table's column count is consistent header/separator/body (the new table is 5 columns throughout; the amended P3 row stays 3), and the one new internal link `#what-this-page-does-not-isolate` resolves to the new `## What this page does not isolate` heading — also confirmed by `check_doc_slugs.py`.

`npm run lint:js` does **not exist** in `implementation/package.json` (that entry in `rf2-rr6do`'s record refers to a different tree); there are no lint scripts there at all.

## Not fixed, reported instead

`docs/design/hicasso/studio/the-clock-behind-the-published-rows.md:137` states the false arithmetic identity **`(U/F) ÷ (R/F) = U/R`, "the floor divides out"** — while the same page says two sentences earlier that each arm is divided by the floor measured in *its own* segment. With per-segment floors the truth is `(U/F_U) ÷ (R/F_R) = (U/R) × (F_R/F_U)`. The page's own measurements refute its own identity: it reads the segment seam at **31.9%** (floor 3.348 ms Reagent vs 4.406 ms UIx), so the dropped term is ~24%. That file is in an open PR (#7633) and a corpus-wide audit of this claim is running, so it is left untouched and routed to that audit.

Checked and **not** instances (both arms genuinely share one floor, so the identity holds): `p0-converged-witness-set.md:923`, `p0_converge_app.cljs:1037`, `jsfb_compare.cjs:24`, `cross-checked-against-an-outside-instrument.md:210,458`, and this PR's own page (its results table carries one `floor abs p50` per row, shared by every arm in that row).
