### PR TITLE
fix(scripts): a signalled fast-PR run must not outlive its invocation (rf2-ketqy)

### DIFF
--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -564,6 +564,252 @@ if [ "$plan_only" = true ]; then
   exit 0
 fi
 
+# ---------------------------------------------------------------------------
+# ONE LIVE RUN PER TREE — a run that outlives its invocation is REAPED, not
+# inherited (rf2-ketqy).
+#
+# THE OBSERVED DEFECT, twice in one day.  A worker starts this spine in the
+# foreground, the agent harness hits its cap, and the tool call returns — but
+# the run does not stop.  Told the gate "timed out", the worker relaunches it
+# in the same tree, and two live spines then share that tree.  Two kinds of
+# damage follow, both seen on real runs:
+#
+#   1. TWO WRITERS, ONE FILE.  AGENTS.md has every worker redirect this script
+#      to a FIXED path (`> gate-fastpr.log`), so the two runs interleave into
+#      it and produce NUL-riddled output in which no line can be trusted.
+#   2. A SPURIOUS RED IN THE GATE'S OWN ENVIRONMENT CLASS.  The older run's
+#      `npm run test:cljs` unlinks out/node-test.js underneath the younger
+#      run's live per-namespace isolation sweep, which then fails with "the
+#      bundle changed on disk during the sweep" and MODULE_NOT_FOUND.  The
+#      sweep is RIGHT — something did mutate the bundle — but the something is
+#      a dead run, and at the moment a worker meets it that is
+#      indistinguishable from an isolation regression in their own diff.
+#
+# WHY THE REAP RUNS HERE, AT THE START OF THE NEXT RUN, AND NOT ONLY FROM A
+# SIGNAL TRAP.  The obvious remedy is to trap INT/TERM and reap on the way out.
+# One is installed below and it earns its place, but MEASURED — not assumed —
+# it cannot be the whole fix:
+#
+#   * The harness cap does not signal anything.  It BACKGROUNDS the call: the
+#     tool returns while the process tree keeps running.  A probe script with
+#     traps on INT/TERM/HUP/QUIT/EXIT recorded no trap firing at all and its
+#     child went on ticking; this spine, capped mid-run, advanced two more
+#     stages and grew its log by 7.4 KB after the tool call had returned.
+#   * The harness's explicit stop path behaves the same way — it reports
+#     success and the tree keeps running.
+#   * Even when a signal IS delivered, bash defers a trapped signal until the
+#     current FOREGROUND child returns.  Measured: SIGTERM at t+3s to a script
+#     sitting in `bash -c 'sleep 25'` ran the handler at t+25s.  Every
+#     expensive step of this spine is exactly such a child, so a trap-only
+#     remedy would reap minutes after the damage window had opened.
+#
+# The one moment a reap can always run is the start of the NEXT run — which is
+# also the moment it matters, because that is the run whose log and bundle are
+# about to be corrupted.  Both workers who hit this recovered only because they
+# thought to hunt for the orphaned tree by hand; that hunt is what the block
+# below automates.
+#
+# NOT A LOCK.  A second run never waits and never refuses — it clears the dead
+# one and proceeds.  Refusing would be worse than the defect it fixes: the cap
+# fires on most full runs of this spine, so a refusal would block the relaunch
+# every single time.
+# ---------------------------------------------------------------------------
+spine_run_dir="$spine_root/.scratch"
+spine_pidfile="$spine_run_dir/test-fast-pr.run"
+
+# WINDOWS NEEDS A SECOND MECHANISM, and this too was measured rather than
+# assumed.  MSYS `ps` tracks what a shell here spawned, native binaries
+# included — `clojure.exe` and `node.exe` show up with a usable PPID — but
+# NOTHING BENEATH THEM DOES.  Measured on a live `bash -lc "... clojure -M ..."`
+# gate exactly like the ones below: the `java.exe` clojure spawns is absent
+# from `ps -ef` and from `ps`, and `ps -ef` reports the shell as having no
+# children at all.  java is the shadow-cljs compile, i.e. precisely the process
+# that unlinks out/node-test.js, so on Windows the POSIX walk cannot even name
+# the process that has to die.  Windows itself knows the link
+# (Win32_Process.ParentProcessId) and `taskkill /T` walks it: on the same tree
+# it terminated clojure, the java beneath it and java's own child, all three.
+#
+# THE ENV VARS ARE LOAD-BEARING, not decoration.  Git Bash rewrites an argument
+# that looks like a POSIX path, so a bare `taskkill /F /T /PID n` arrives as
+# `taskkill F:/ ...` and dies with "Invalid argument/option - 'F:/'" — which,
+# behind the `>/dev/null 2>&1 || true` this call needs, is a SILENT no-op.
+# `MSYS_NO_PATHCONV=1` is Git-for-Windows' switch and `MSYS2_ARG_CONV_EXCL='*'`
+# is MSYS2's; Cygwin does no such rewriting and ignores both.  Setting the pair
+# is what makes one spelling work on all three.
+#
+# Both arms are guarded, so a host with neither reaps nothing rather than
+# failing the run.
+spine_is_windows=false
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*)
+    if command -v taskkill >/dev/null 2>&1; then
+      spine_is_windows=true
+    fi
+    ;;
+esac
+
+# `ps -ef` is the ONE listing whose PID and PPID sit in the same columns ($2,
+# $3) on Git Bash, macOS and Linux alike.  The tidier spellings are not
+# portable here: MSYS `ps` rejects both `-o` and `-A`, and ships no `pgrep`.
+# No `exit` in any awk program below, deliberately: exiting early would SIGPIPE
+# `ps`, and under this script's `set -o pipefail` that turns a lookup into a
+# failed pipeline and `set -e` would take the whole run down with it.
+spine_child_pids() {
+  { ps -ef 2>/dev/null || true; } |
+    awk -v parent="$1" '$3 == parent && $2 != parent { print $2 }'
+}
+
+spine_descendant_pids() {
+  local kid
+  for kid in $(spine_child_pids "$1"); do
+    spine_descendant_pids "$kid"
+    printf '%s\n' "$kid"
+  done
+}
+
+spine_winpid() {
+  { ps 2>/dev/null || true; } |
+    awk -v pid="$1" '$1 == pid && !seen { print $4; seen = 1 }'
+}
+
+spine_taskkill_tree() {
+  local winpid
+  if [ "$spine_is_windows" != true ]; then
+    return 0
+  fi
+  winpid="$(spine_winpid "$1")"
+  if [ -n "$winpid" ]; then
+    MSYS2_ARG_CONV_EXCL='*' MSYS_NO_PATHCONV=1 \
+      taskkill /F /T /PID "$winpid" >/dev/null 2>&1 || true
+  fi
+  return 0
+}
+
+# Everything BELOW pid, deepest first, TERM then KILL.  Never touches pid.
+spine_kill_descendants() {
+  local root="$1" kid pid pids
+  for kid in $(spine_child_pids "$root"); do
+    spine_taskkill_tree "$kid"
+  done
+  pids="$(spine_descendant_pids "$root")"
+  for pid in $pids; do
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+  if [ -n "$pids" ]; then
+    sleep 1
+    for pid in $pids; do
+      kill -KILL "$pid" 2>/dev/null || true
+    done
+  fi
+  return 0
+}
+
+# Two guards stand between "the recorded pid is alive" and "kill it", because a
+# wrong answer there kills a stranger's process tree.
+#
+# FIRST, the pid must still BE this gate.  Pids are recycled, and `ps -ef`
+# prints the command with its arguments on all three platforms, so the cheapest
+# sound check is to read it back.  If the listing does not name this script the
+# predecessor is not reaped at all — the run degrades to the old behaviour
+# rather than killing something it cannot identify.
+spine_pid_is_this_gate() {
+  local line
+  line="$({ ps -ef 2>/dev/null || true; } |
+    awk -v pid="$1" '$2 == pid && !seen { print; seen = 1 }')"
+  case "$line" in
+    *test-fast-pr*) return 0 ;;
+  esac
+  return 1
+}
+
+# SECOND, it must not be one of OUR ancestors.  `scripts/test-rigorous-local.sh`
+# invokes this spine as a child, so an ancestor pid in the file would be a run
+# killing whatever started it.
+spine_is_own_ancestor() {
+  local target="$1" cur="$$" hops=0
+  while [ -n "$cur" ] && [ "$cur" != 0 ] && [ "$cur" != 1 ] && [ "$hops" -lt 64 ]; do
+    if [ "$cur" = "$target" ]; then
+      return 0
+    fi
+    cur="$({ ps -ef 2>/dev/null || true; } |
+      awk -v pid="$cur" '$2 == pid && !seen { print $3; seen = 1 }')"
+    hops=$((hops + 1))
+  done
+  return 1
+}
+
+spine_release_run() {
+  local held=""
+  if [ -f "$spine_pidfile" ]; then
+    held="$(tr -dc '0-9' < "$spine_pidfile" 2>/dev/null || true)"
+    if [ "$held" = "$$" ]; then
+      rm -f "$spine_pidfile" 2>/dev/null || true
+    fi
+  fi
+  return 0
+}
+
+spine_claim_run() {
+  local prev=""
+  mkdir -p "$spine_run_dir" 2>/dev/null || true
+  if [ -f "$spine_pidfile" ]; then
+    prev="$(tr -dc '0-9' < "$spine_pidfile" 2>/dev/null || true)"
+  fi
+  if [ -n "$prev" ] && [ "$prev" != "$$" ] && kill -0 "$prev" 2>/dev/null &&
+     spine_pid_is_this_gate "$prev" && ! spine_is_own_ancestor "$prev"; then
+    printf 'REAPING A PREVIOUS RUN: pid %s is still live in this tree.\n' "$prev"
+    printf '  It outlived the tool call that started it.  Left alone it would\n'
+    printf '  interleave into this log and mutate out/node-test.js underneath\n'
+    printf '  the isolation sweep, which reads as a regression in your own diff\n'
+    printf '  (rf2-ketqy).  Killing it and its children before starting.\n'
+    spine_taskkill_tree "$prev"
+    spine_kill_descendants "$prev"
+    kill -TERM "$prev" 2>/dev/null || true
+    sleep 1
+    kill -KILL "$prev" 2>/dev/null || true
+    if kill -0 "$prev" 2>/dev/null; then
+      printf '  WARNING: pid %s survived the reap.  Kill it by hand before you\n' "$prev"
+      printf '  trust anything this run reports.\n'
+    else
+      printf '  reaped.\n'
+    fi
+  fi
+  printf '%s\n' "$$" > "$spine_pidfile" 2>/dev/null || true
+  printf 'run pid: %s\n' "$$"
+}
+
+# The trap half of the remedy, for the paths that DO signal: an interactive
+# Ctrl-C, `timeout(1)`, a CI job cancellation, a plain `kill`.  Ctrl-C is where
+# it earns its keep on Windows — SIGINT reaches the foreground process group,
+# so `clojure.exe` dies with the shell while the `java.exe` beneath it does
+# not, and this is what collects that.  The handler clears the traps first, so
+# a second Ctrl-C is not queued behind anything.
+#
+# It deliberately does NOT kill by process group.  Measured here: every child
+# of this script shares the CALLER's process group, so `kill -- -$PGID` would
+# take the harness or terminal that invoked the gate down with it.
+spine_on_signal() {
+  trap - INT TERM HUP QUIT EXIT
+  printf '\n%s received — killing the child processes of this run before exiting (rf2-ketqy)\n' \
+    "$1" >&2
+  spine_kill_descendants "$$"
+  spine_release_run
+  exit "$2"
+}
+
+trap 'spine_on_signal SIGINT 130'  INT
+trap 'spine_on_signal SIGTERM 143' TERM
+trap 'spine_on_signal SIGHUP 129'  HUP
+trap 'spine_on_signal SIGQUIT 131' QUIT
+
+# EXIT does not reap — on a normal or a failing exit every gate has already
+# returned.  It only releases the claim, and it must not disturb the exit
+# status: AGENTS.md has every worker echo this script's `$?` into a file, so
+# the handler runs nothing that can fail and never calls `exit` itself.
+trap 'spine_release_run' EXIT
+
+spine_claim_run
+
 printf '=== fast PR spine: docs=%s jvm=%s node=%s (%s) ===\n' \
   "$run_docs" "$run_jvm" "$run_node" "$plan_reason"
 


### PR DESCRIPTION
A worker starts `scripts/test-fast-pr.sh` in the foreground, the agent harness
hits its cap, and the tool call returns — but the run does not stop. Told the
gate "timed out", the worker relaunches it in the same tree, and two live spines
then share one tree. They interleave into the single fixed log path `AGENTS.md`
tells every worker to redirect to, and the older run's `npm run test:cljs`
unlinks `out/node-test.js` underneath the younger run's per-namespace isolation
sweep, which reds with *"the bundle changed on disk during the sweep"*. That red
is indistinguishable, at the moment a worker meets it, from an isolation
regression in their own diff. It has bitten two workers in one day, and both
recovered only because they thought to go hunting for orphaned process trees.

The fence was `scripts/test-fast-pr.sh`; nothing else is touched.

## Reproduction, BEFORE the fix

Everything below was measured on the unmodified script on Windows / Git Bash.

**1. The harness cap does not signal anything — it BACKGROUNDS the call.** The
spine was started in the foreground and capped at 90s. When the tool call
returned, the run had not been signalled and had not stopped:

```
NOW=06:18:16  (immediately after the tool-timeout return)
log size t0 = 41822
==> retired image-keys self-test
==> retired image keys
  miket 2765110 2765107 sh .../scripts/test-fast-pr.sh --all
  miket 2765525 2765110 python.exe .../check_retired_image_keys.py --verbose

NOW=06:18:31 (15s after the tool call returned)
log size t1 = 49220
==> runtime-subsystem grading drift
==> mkdocs --strict build
```

The run advanced two more stages and grew its log by 7.4 KB **after** the tool
call had returned. A probe script with traps on INT/TERM/HUP/QUIT/EXIT, run the
same way, recorded no trap firing at all while its child went on ticking. The
harness's explicit stop path behaves identically: it reports
`Successfully stopped` and the tree keeps running (parent still writing
heartbeats 12s later, no trap line).

**2. When a signal IS delivered, the children are orphaned.** Same script,
signalled mid-`mkdocs --strict build`:

```
=== spine pid=2775399, stage: ==> mkdocs --strict build
--- children BEFORE the signal ---
   miket 2775888 2775399 python.exe -m mkdocs build --strict
--- sending SIGTERM to 2775399 ---
--- 3s later ---
   SPINE pid 2775399: DEAD
--- orphaned children ---
   miket 2775888       1 python.exe -m mkdocs build --strict     <- PPID now 1
```

**3. A trap alone could not have fixed 2 either.** Bash defers a trapped signal
until the current FOREGROUND child returns. Measured: SIGTERM at t+3s to a
script sitting in `bash -c 'sleep 25'` ran the handler at t+25s — 22 seconds
late. Every expensive step of this spine is exactly such a child.

## Reproduction, AFTER the fix

**1. The case that actually bit.** Run A was started and abandoned exactly as
the cap abandons a run; it stayed live and its log kept growing (6426 → 13569
bytes). A second run was then started in the same tree:

```
gate root: /c/Users/miket/code/re-frame2-worktrees/gatereap-ketqy
REAPING A PREVIOUS RUN: pid 2787241 is still live in this tree.
  It outlived the tool call that started it.  Left alone it would
  interleave into this log and mutate out/node-test.js underneath
  the isolation sweep, which reads as a regression in your own diff
  (rf2-ketqy).  Killing it and its children before starting.
  reaped.
run pid: 2787622
=== fast PR spine: docs=true jvm=true node=true (override (--all)) ===
```

```
=== is A still alive? ===        A (pid 2787241): DEAD
=== surviving descendants? ===   none
=== A's log ===                  29020 bytes, then 29020 bytes 12s later — FROZEN
```

**2. The same thing against the process that causes the spurious red.** Run A2
was taken all the way to `==> JVM implementation/core` so it held a live JVM:

```
=== A2 pid=2815080  stage: ==> JVM implementation/core
  A2 direct child (msys)=2820796  winpid=112516
  its java.exe winpid=108216   <- the test/compile JVM
  can ps -ef see that java?  -> NO — invisible to the POSIX walk
```

A second run reaped it at startup:

```
  A2 pid 2815080: DEAD
  its clojure.exe (msys 2820796): GONE
  its java.exe (winpid 108216, invisible to the POSIX walk): GONE
  A2 log: 51387 -> 51387 bytes over 10s  (FROZEN)
```

That run then went on to complete as the full `--all` gate below, which is also
the demonstration that a run which reaps a predecessor is a clean run.

**3. The signalled case.** Identical experiment to BEFORE-2, signalled mid-
`mkdocs --strict build`:

```
--- sending SIGTERM to 2809009 at 07:29:36 ---
--- handler completed at 07:30:00, 24s after the signal ---
  runner exit code: 143
  trap message: SIGTERM received — killing the child processes of this run before exiting (rf2-ketqy)
  spine pid 2809009: DEAD
  orphaned mkdocs/python?  none — no orphan
  pidfile released
```

The 24s is the measured bash deferral, honestly reported: the handler runs when
the current foreground gate returns. The behaviour still changes in the right
direction — BEFORE, the script died in under a second and left a live orphan;
AFTER, it exits `143` with nothing orphaned.

## Which remedy, and why

The bead sketched **(a) trap and reap** and **(b) a unique log path per
invocation**. This takes (a), with its reap invoked from a second place, and
does not take (b).

**(a) is implemented, and the trap alone is not enough — measured, not
assumed.** Traps do fire under Git Bash (`kill -TERM` produced `TRAP TERM` then
`TRAP EXIT`), so the mechanism is sound, and the trap is installed for the paths
that do signal: an interactive Ctrl-C, `timeout(1)`, a CI job cancellation, a
plain `kill`. But the path that actually bit delivers no signal at all, and even
a delivered signal is deferred behind the running gate. So the same reap is also
invoked at the **start of the next run**, against a predecessor still live in the
same tree — the one moment a reap can always run, and the moment it matters,
because that is the run whose log and bundle are about to be corrupted. It is the
hunt both affected workers performed by hand, automated.

**Two details of the bead's sketch turned out to be wrong on measurement, and are
not what shipped.** First, "kill its own child process group": every child of
this script shares the **caller's** process group, so `kill -- -$PGID` would take
the invoking harness or terminal down with it. The reap walks descendants
instead. Second, on Windows the POSIX walk cannot even name the process that has
to die — see the portability section.

**This is not a lock, and not the lock the bead ruled out.** Nothing was added
around the isolation sweep. A second run never waits and never refuses; it clears
the dead one and proceeds. Refusing would have been worse than the defect: the
cap fires on most full runs of this spine, so a refusal would block the relaunch
every single time.

**(b) was not taken**, for two reasons. It removes only the corrupted-log half,
and the bundle race — the half that produces a red a worker cannot tell from
their own regression — would remain. And it is not implementable inside this
bead's fence anyway: the log path is chosen by the **caller**, not this script
(`AGENTS.md` and `docs/the-mayor-method/dispatch-prompt-template.md` both say
`> gate-fastpr.log`), and both of those files are outside the fence. Reaping the
predecessor closes the log-corruption half by construction instead: the other
writer is dead before this run prints its first gate.

## Portability: Windows, macOS, Linux

Cross-platform per this repo's rule, with the platform-specific parts verified
rather than assumed.

* **The process walk is one POSIX spelling for all three.** `ps -ef` is the only
  listing whose PID and PPID sit in the same columns (`$2`, `$3`) on Git Bash,
  macOS (BSD ps) and Linux (procps). The tidier forms are not available here —
  MSYS `ps` rejects both `-o` and `-A` (`ps: unknown option -- o`) and Git Bash
  ships no `pgrep`. No awk program uses `exit`, deliberately: exiting early would
  SIGPIPE `ps`, and under this script's `set -o pipefail` that would turn a
  lookup into a failed pipeline and `set -e` would take the whole run down.
* **Windows needs a second arm, and it is guarded.** Measured on a live
  `bash -lc "... clojure -M ..."` gate: the `java.exe` beneath it is absent from
  both `ps` and `ps -ef`, and `ps -ef` reports the shell as having *no children
  at all*. Windows knows the link (`Win32_Process.ParentProcessId`), and
  `taskkill /T` walks it — on that tree it terminated clojure, the java beneath
  it and java's own child, all three. The arm is behind
  `uname -s` matching `MINGW*|MSYS*|CYGWIN*` **and** `command -v taskkill`, so
  macOS and Linux never reach it and a Windows host without `taskkill` reaps
  nothing rather than failing the run.
* **The `taskkill` env vars are load-bearing.** This was caught by testing rather
  than by reading: Git Bash rewrites an argument that looks like a POSIX path, so
  a bare `taskkill /F /T /PID n` arrives as `taskkill F:/ ...` and dies with
  `Invalid argument/option - 'F:/'` — which, behind the `>/dev/null 2>&1 || true`
  this call needs, is a **silent no-op**. `MSYS_NO_PATHCONV=1` is
  Git-for-Windows' switch, `MSYS2_ARG_CONV_EXCL='*'` is MSYS2's, and Cygwin does
  no such rewriting and ignores both. With the pair set the same call returns
  `rc=0` and three `SUCCESS:` lines.
* **Bash 3.2 compatible**, like the rest of the file: no `mapfile`, no
  associative arrays, no `${var,,}`.
* **Nothing is written into the tree that git can see.** The pidfile lives at
  `$spine_root/.scratch/test-fast-pr.run`; `.scratch/` is already gitignored
  (`.gitignore:43`, `**/.scratch/`) and `check_readme_inventories.py` skips
  dot-directories, so this leaves no untracked residue to block a
  `git worktree remove`.

**Exit-code semantics are unchanged**, which matters because `AGENTS.md` has
every worker echo this script's `$?` into a file:

| case | before | after |
| --- | --- | --- |
| full `--all` run, green | 0 | 0 |
| `--plan` | 0 | 0 (and it claims nothing, writes no pidfile) |
| `--help` | 0 | 0 |
| unknown flag | 2 | 2 |
| SIGTERM | killed, no code, live orphan | 143, no orphan |

The `EXIT` handler only releases the claim; it runs nothing that can fail and
never calls `exit`, so it cannot disturb the status that triggered it. And
`gate root: <path>` is still the first line of every run — workers are told to
check it. `run pid: <n>` is added as the second line of a real run, which is also
the pid a worker needs if they ever do have to reap one by hand.

## Quality gates

Both runs are `sh scripts/test-fast-pr.sh --all`, foreground to completion,
redirected to a worktree-local log, with the runner's own exit code echoed —
never piped through `tail`/`head`/`grep`.

**BEFORE the edit** — full spine on the unmodified tree:

```
BASELINE_EXIT=0
gate root: /c/Users/miket/code/re-frame2-worktrees/gatereap-ketqy
stages (^==>): 78
PASS fast PR spine
NOT RUN by this spine (2):
```

**AFTER the edit** — full spine on the modified tree:

```
FINAL_EXIT=0
gate root: /c/Users/miket/code/re-frame2-worktrees/gatereap-ketqy
stages (^==>): 79
PASS fast PR spine
NOT RUN by this spine (2):
```

The two stage lists differ by exactly one line, and it is the expected one:

```
54a55
> ==> fast-PR spine tiering self-test
```

That stage is armed precisely because this diff touches the spine's own tree
(rf2-fhdd3) — `--plan` confirms `PLAN-SELFTEST run`, `reason: spine self-change
(every tier)`. Every other stage, the `PASS fast PR spine` line and the
`NOT RUN by this spine (2)` block are identical to the baseline. The JVM
selection is `implementation/core` in both, since the diff touches no artefact
tree.

The spine's own tiering self-test therefore ran as a gate of this PR, which is
what covers the classifier: it drives this script in `--plan` mode against
disposable fixture repos and asserts the whole tier decision. It reported
`37/37 self-test cases passed` inside the run above — a named assertion per
case, not a silent exit 0.

**And it was proved to have teeth on this file rather than assumed to.** With
`scripts/test-fast-pr.sh` removed from its own `is_spine_self_path` surface, the
same self-test goes red and names the two cases that own that behaviour:

```
CLEAN_EXIT=0    37/37 self-test cases passed.
BROKEN_EXIT=1
  FAIL Z  spine-only diff → docs tier armed: expected PLAN docs=true …, got PLAN docs=false …
  FAIL Z1 spine-only diff → the spine's own self-test is armed: expected PLAN-SELFTEST run, got skip
```

The deliberate break was reverted; the tree is clean.

GitHub Actions is in a major outage, so CI has not validated this. The exit
codes above and the reproductions are the record.
