### PR TITLE
docs(hicasso): teach the [:>] escape, and narrow the entity-key warning's claim (rf2-2rtt6.109, rf2-y7zql)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -882,9 +882,13 @@ read that lands in the calling boundary's window.
 > coverage would be a silent-inconsistency factory. Against all of that, the
 > ceremony saved is roughly a dozen characters per list site. The dominating
 > repair the pass identified — a dev warning on a **non-primitive `:key` value**,
-> closing the same hazard in the explicit spelling at zero concept cost — is
-> designed but **not landed** (`rf2-2rtt6.104`), and this verdict deliberately
-> does not lean on it.
+> closing the same hazard in the explicit spelling at zero concept cost — has
+> since **landed** (`rf2-2rtt6.104`), and its classification is total over every
+> value React must coerce rather than over collections alone. React's own
+> duplicate-key warning covers the collision half and only that half, so the
+> distinct-but-unstable key — a `js/Date`, a JS array, a CLJS map — is this
+> warning's alone. The verdict predates the repair and deliberately does not
+> lean on it.
 >
 > **Corpus correction, binding on any record of this ruling.** The decisive
 > framing is **not** "wrong at two-thirds" — that ratio belongs to the v1-idiom

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -292,7 +292,7 @@ the collector mechanics.
 | Index thrash, subscriptions constantly re-created | Query args not *value*-stable (timestamp, real sort-order change, or JS/fn identity) | Make the args equal under `=` between renders; allocation of equal persistent values is fine |
 | A body's side effect fires twice | StrictMode double-invoke | Bodies are pure; move the effect out |
 | `:rf.warning/hicasso-missing-key` names a view and a child head | A seq of boundary children has no `:key` — absent, or an expression that computed `nil` | Put a `:key` in each member's props map. A Reagent `^{:key}` on the form is not read |
-| `:rf.warning/hicasso-entity-key`, and a row remounts when you edit it | `:key` holds a collection, which React coerces to a string — the key moves with the content | Key on a stable identifier: `{:key (:id todo)}` |
+| `:rf.warning/hicasso-entity-key`, and a row remounts when you edit it | `:key` holds a value React has to coerce. The classification is total: strings, numbers, keywords, uuids and symbols pass; a collection, a foreign object, a `js/Date`, a JS array, a boolean or a function is named. A content-derived coercion moves with the content, and React itself says nothing — distinct keys never collide, so its duplicate-key warning never fires | Key on a stable identifier: `{:key (:id todo)}` |
 
 ## When not to use a boundary
 

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -52,7 +52,7 @@ Putting a raw JS component in the tree breaks three things at once:
 
 `defhost` quarantines the require in one `.cljs` host namespace and leaves the rest
 of the view tree as data. Friction once; free at every use site. The Reagent
-`[:> …]` escape is built and explicitly secondary — covered briefly below.
+`[:> …]` escape is built and explicitly secondary — [covered below](#the-escape-).
 
 ## Defaults
 
@@ -218,40 +218,194 @@ side, to the value never changing.
 
 ## The escape: `[:>]`
 
-`[:> Component props & children]` is the secondary form for cases a static
-declaration cannot express. It uses the same foreign path as `defhost` with the
-same default conversions, and it accepts the costs in
-[Why declare](#why-declare).
+`[:> Component props & children]` is the secondary form, for the cases a static
+declaration cannot express: the component is **selected at runtime**, it is a
+`memo` or `lazy` value, it **arrives from a render prop**, an **ecosystem
+provider** hands it to you, or the site is a **one-off migration** you have no
+intention of keeping. It takes the same foreign path as `defhost` with the same
+default conversions, and it accepts the costs in [Why declare](#why-declare).
 
-Reach for it when the component is selected at runtime, is a `memo`/`lazy`
-value, arrives from a render prop, or is a one-off migration site.
-**Declare what you use twice.** First use, escape if faster; second use, `defhost`.
+**Declare what you use twice.** First use, escape if that is faster; second use,
+`defhost`. That is not a style preference. The escape is strictly weaker than the
+door by construction, and every remedy in this section is the same word.
 
 ```clojure
-[:> Chart {:series data} [:span.legend "revenue"]]
+;; the component is chosen by data, so there is nothing to declare
+(def widgets {:chart Chart :table Table :map MapView})
+
+(defview panel [{:keys [kind]}]
+  [:> (get widgets kind) {:series (sub [:panel/series kind])}
+   [:span.legend "revenue"]])
 ```
 
-**It is `defhost` with the declaration erased, and what erasing the declaration
-costs you is exactly what the declaration carried.** No crossing name for your
-tools; no `:callbacks`, so every prop here is unclaimed and an intent vector at
-an `on*` slot or an `h/fn` anywhere is a loud refusal; no `:ssr` policy, so a
-`[:>]` renders **nothing** server-side and there is no spelling to change that
-— wrap it in a `defhost` if you want a placeholder there. The JS require lands
-in the view namespace rather than a `.cljc`-quarantined host one, which is the
-cost you meet first: not "my structural test cannot match a node", but "my test
-namespace will not load."
+One gate serves every `[:>]` on the page and its type is constant, so moving
+`kind` keeps that gate's own fiber and remounts only the subtree beneath it —
+the right grain when the component is the thing that changed.
 
-The Component position takes what React accepts as an element type — a function
-or class component, one of React's built-in wrappers, a `memo` / `lazy` /
-`forwardRef` / context value. A tag string, a keyword, a `defview` head and a
-`defhost` head are all refused, each naming the spelling to write instead.
+**It is `defhost` with the declaration erased, and what erasing the declaration
+costs you is exactly what the declaration carried.**
+
+| What a declaration carries | `defhost` | `[:>]` |
+|---|---|---|
+| A crossing name for your tools | authored, on the crossing's `displayName` | one constant, `"[:>]"` |
+| `:callbacks` contracts | exact, per slot | none — every prop is unclaimed |
+| An `:ssr` policy | `:client-only`, `{:fallback …}` or `:render` | fixed `:client-only`, and unspellable |
+| An early site for refusals | the component, the options and the contracts, checked once at the declaration | nothing to check early — every refusal fires at the crossing |
+| A `.cljc` quarantine for the JS require | one host namespace | the require lands in the view namespace |
+
+Every remedy for every row is `defhost`. That is the design rather than a
+coincidence, and the rest of this section is those rows in detail.
+
+### Every prop is unclaimed
+
+`:callbacks` is what turns a prop into a *position*. The escape has none, so
+every prop at a `[:>]` is unclaimed — and the conduct is exactly the door's for
+an undeclared slot, through the same code, not a second rule:
+
+| Written at a `[:>]` prop | What happens |
+|---|---|
+| An intent vector or key-map at an `on*`-spelled slot | **Refused** — `:rf.error/hicasso-host-undeclared-callback`. A contract is never inferred from a name, and the alternative is `clj->js` shipping your intent to the library as an inert array |
+| An intent vector or key-map anywhere else | Data, through the position's own conversion, like any other collection |
+| An `h/fn`, at any slot | **Refused** — `:rf.error/hicasso-host-unclaimed-callback`. The marked form *asks* the position for a contract, and there is no position here to answer |
+| A plain function | Crosses by identity and runs. It never asked for anything, so nothing is left unanswered — memoisation on callback identity keeps working |
+| `:ref` | The crossing's own check: a callback ref crosses untouched, the reserved vector is refused |
+| `:key` | React's, on the crossing's element, exactly as at a `defhost` |
+
+Both refusals name `defhost`'s `:callbacks` as the recovery, and at the escape
+that means writing the declaration you do not have. **The refusals are the
+point.** An `h/fn` that crossed unclaimed would be called by the library, would
+return an intent, and the library would discard the return — a handler that does
+nothing, in production, with no diagnostic anywhere.
+
+### On the server, nothing
+
+A `[:>]` is hard `:client-only` and there is no spelling for anything else. The
+server emits nothing at the crossing, hydration's first client pass emits
+nothing, and the component appears once adoption completes. Those are not two
+facts kept in step: React reads the same snapshot for the server render and for
+hydration's first pass, so server-absent and first-pass-absent cannot disagree
+and no mismatch is possible. A fresh client-only mount never consults the server
+snapshot at all, so it renders the component immediately with no placeholder
+flash.
+
+**"Nothing" includes the children.** If the crossing is a transparent wrapper —
+an ecosystem provider is the case you will meet — every descendant leaves the
+response with it, silently, because the server HTML and the first client pass
+agree by construction. Answering that is `{:ssr :render}`'s job at the door
+([Server-side rendering](10-server-side-rendering.md#render--when-the-region-has-to-be-in-the-response)),
+and the escape has nothing to assert it with.
+
+A per-site *placeholder* is still reachable with no new escape surface, by
+putting the policy back on a declaration:
+
+```clojure
+(h/defhost skeleton-slot (fn [p] (.-children p)) {:ssr {:fallback [:div.skeleton]}})
+
+;; then at any site, dynamic head included:
+[skeleton-slot {} [:> (get widgets kind) {:series data}]]
+```
+
+Say precisely what that buys: a placeholder, not server-rendered content. The
+wrapper cannot borrow `{:ssr :render}`, because the thing it wraps is a `[:>]`,
+which carries no declaration to assert server-safety with.
+
+### The Component position
+
+The slot takes what React accepts as an element type — a function or class
+component, one of React's built-in wrappers (`Fragment`, `Suspense`,
+`StrictMode`, `Profiler`, …), and a `memo` / `lazy` / `forwardRef` / context
+value. Everything else is refused **at the crossing, in the owner's render and
+on the server too**, with your stack pointing at the line you wrote.
+
+That refusal is Hicasso's rather than React's on purpose. React's own *Element
+type is invalid* is minted at fiber creation, which behind the adoption gate is
+post-adoption and client-only — never on the server, never at first paint — and
+it names `typeof type`, so a keyword, a map, a vector and a record all read
+*"got: object"*, naming nothing you wrote.
+
+| What you wrote | Why it is refused |
+|---|---|
+| `nil`, or `[:>]` with nothing after it | Its own id, `:rf.error/hicasso-raw-no-component`, and the door's diagnosis: an import that resolved nothing — `:default` against a library with no default export |
+| A string or a keyword | The grammar owns tags. Write the tag, or a computed **keyword** head for a runtime one, which keeps the parse and the controlled-input door that `[:> "input" …]` would silently drop |
+| A `defview` head | A head in its own right: write `[my-view …]`. Mounted raw it would read its props slot, get `undefined`, and receive `nil` props — silently |
+| A `defhost` head | Also a head: `[my-host …]`. The escape is for what a declaration cannot express, and this one already is a declaration |
+| A React **element** | An element is a legal child, never a type. Put it in child position, or hand `[:>]` the component it was built from |
+
+Each carries its own recovery sentence; everything but the `nil` case shares
+`:rf.error/hicasso-raw-not-a-component`, with the shape in `ex-data`.
 
 **Bare-head auto-hosting stays illegal.** `[DatePicker {…}]` with a raw JS
-component in head position is not a shortcut. One sentinel, not two ways to
-smuggle JS into the tree.
+component in head position is not a shortcut, and it is not going to become one.
+One sentinel, not two ways to smuggle JS into the tree.
+
+### Reduced structural identity, exactly
+
+Four statements, and the useful one is first.
+
+**The DOM is not reduced at all.** A `[:>]` and a `defhost` on the same component
+with the same props produce the same DOM in every phase — nothing before
+adoption, the component's own markup after — because the gate contributes no node
+of its own. Anything asserting on rendered markup sees no difference between the
+two forms.
+
+**The hiccup lane is reduced at exactly one slot.** `[:> C {…}]` is an ordinary
+vector: `:>` is a plain keyword and `=` compares it structurally. The one
+reduction is that slot 1 holds a JS value compared by *identity*, so
+`(= [:> C {:a 1}] [:> C {:a 1}])` is true and the same props under a different
+component are not equal. Everything else in the vector is total. That is the
+whole of the phrase.
+
+**The fiber carries a constant name.** `displayName` is the literal `"[:>]"`, and
+no name is derived from the component — deliberately. React resolves a type's
+name as `displayName || name || null`, Closure renames `.name` under `:advanced`,
+and foreign production bundles routinely ship without a `displayName`, so a
+derived name would be *build-dependent*: it would look authored and would not be.
+`defhost` has no such problem because its name is data you wrote. Little is lost
+in the tree anyway, because the component's own fiber sits directly beneath the
+gate and React names it there: a `defhost` reads `<my.ns/date-picker>` →
+`<DatePicker>`, and the escape reads `<[:>]>` → `<DatePicker>`.
+
+**And the loss you meet first is none of the above.** It is the `.cljc`
+quarantine. `defhost` puts the JS require in one host namespace; `[:>]` names the
+component at the call site, so the require lands in the *view* namespace and that
+namespace stops loading on the JVM. The symptom is not "my structural test cannot
+match a node" — it is "my test namespace will not load." Today that is close to
+the whole cost, because the
+[headless structural render](08-testing.md#full-headless-render-not-built) does
+not exist yet, and the foreign region is out of its scope for both forms in any
+case. When it lands, a declared crossing has a name to project and a `[:>]` node
+has none.
+
+### Children lower where you wrote them
+
+Children of a `[:>]` lower **eagerly, inside the render window of the boundary
+that wrote the crossing**, along the same path a `defhost`'s children take. That
+is what makes intents in them work: a child's intent closure captures the owner's
+frame-locked dispatch at lowering time, so it fires into the right frame however
+much later the foreign component renders it — inside a portal, in a virtualised
+window, in a `Suspense` fallback. A Hicasso boundary *beneath* a crossing gets its
+frame from React context, which ignores the JS call stack, so a foreign component
+in the middle is transparent.
+
+A **function prop on the crossing itself** is the other case, and the one worth
+knowing. It gets no wrapper, because no position claimed it, so a body that lowers
+an intent there runs with no ambient frame and raises
+`:rf.error/hicasso-intent-outside-boundary` at the library's call — loud and late,
+never silently inert. The message offers both readings, because from where you sit
+you *are* inside a boundary's render (you wrote the crossing in a body), and it
+names the repair: `defhost` with `:callbacks {<the prop> :render}` is the position
+that owns the frame. A `[:>]` written inside a *declared* `:render` body inherits
+that position's frame, which is the composition intended — but a `:render` return
+still crosses unconverted, so today the subtree has to be written where children
+lower ([Not settled yet](#not-settled-yet)).
+
+### Migrating off it
 
 A hand migration from Reagent is three moves per namespace: collect `[:> X …]`,
-emit `defhost`, rewrite call sites. A codemod is planned and not built.
+emit `defhost`, rewrite call sites. `[:> X props]` → `(defhost x X {})` is
+behaviour-preserving by construction, because the escape's prop walk *is* the
+door's with an empty roster — whatever is ruled at the door, the escape does the
+same thing. A codemod is planned and not built.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Two beads, one PR, ordered smallest first. Both edit the Hicasso draft guide and
`decisions.md`; nothing else is touched.

## `rf2-y7zql` — two stale claims about the minted entity-key warning

**`draft-guide/02-views-and-reads.md:295`** said the warning fires when `:key`
"holds a collection". Narrow, not wrong: since `rf2-2rtt6.104` the
classification is **total** — strings, numbers, keywords, uuids and symbols
pass, and everything else is named, foreign objects, `js/Date`, JS arrays,
booleans and functions included. A reader with a `js/Date` key concluded they
were outside the guard when they were exactly inside it, and that is the silent
case. Line 95 was already correct and is untouched; this is the one-line
narrowing the bead asked for.

The row now also carries the distinction that keeps it from overclaiming in the
other direction: React's duplicate-key warning fires on **collision only**.
`createElement` runs `key = '' + config.key`, so by the time react-dom's
`warnOnInvalidKey` reaches its `if ("string" !== typeof key) break` guard the key
is already a string and the check applies — two colliding `[object Object]` keys
do get React's warning. A distinct-but-unstable key collides with nothing and
React never speaks.

**`decisions.md`** (HD-009's 2026-08-05 addendum) still called the warning
"designed but **not landed**". It landed. The clause now records that, states the
totality, names where React's own warning does and does not overlap, and keeps
the verdict's own point — it predates the repair and deliberately does not lean
on it.

**The classifier is untouched.** It is correct as landed.

## `rf2-2rtt6.109` — teach the `[:>]` escape fully

The gate on this bead is discharged: PR #7635 is MERGED (`gh pr view 7635 --json
state` reads `MERGED`, merge commit `382611ef0b`), and `raw-element`, `raw-gate`,
`raw-component` and `raw-crossing` are all on `main` in
`implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs`. Noted on
the bead.

Written against that code rather than against `studio/raw-escape-spec.md`, and
they differ in one place worth stating: the shipped `raw-component` narrows
**keywords** as well as strings, and additionally refuses `defview` heads,
`defhost` heads, React elements and `ifn?`-but-not-`fn` values, each with its own
recovery sentence. The guide teaches what shipped.

The spine is unchanged and deliberately so — `[:>]` is the **secondary** form,
`defhost` remains the taught policy-bearing one, and *declare what you use twice*
now says why that is not a style preference: the escape is strictly weaker than
the door by construction, and every remedy in the section is the same word. The
job here is to make the honest hatch usable, not to advertise it.

The section grows from four paragraphs to a five-row trade table plus six short
subsections:

- **Every prop is unclaimed** — the door's undeclared-slot conduct through the
  same code, so an intent at an `on*` slot
  (`:rf.error/hicasso-host-undeclared-callback`) and an `h/fn` anywhere
  (`:rf.error/hicasso-host-unclaimed-callback`) are refusals, and why those
  refusals are the point.
- **On the server, nothing** — hard `:client-only` through one shared gate,
  server-absent and first-pass-absent being one fact React chooses rather than
  two kept in step, "nothing" including the children, and the placeholder recipe
  that puts the policy back on a declaration with a precise statement of what it
  buys (a placeholder, not server-rendered content).
- **The Component position** — the accepted roster, the five refusals in a table,
  and why they fire at the crossing in the owner's render rather than at React's
  fiber creation (post-adoption, client-only, and `typeof type` names nothing the
  author wrote).
- **Reduced structural identity, exactly** — the four statements: the DOM is not
  reduced at all, the hiccup lane is reduced at exactly one slot, the fiber's
  constant `"[:>]"` name is deliberate (a derived name would be build-dependent
  under Closure renaming), and the loss met first is the `.cljc` quarantine, with
  the honest note that the headless structural render does not exist yet.
- **Children lower where you wrote them** — eager lowering inside the writing
  boundary's render window, so a child's intent fires into the right frame however
  much later the component renders it; and a function prop on the crossing itself
  getting no wrapper, raising `:rf.error/hicasso-intent-outside-boundary` with the
  two-reading message and the `defhost … :callbacks {… :render}` repair.
- **Migrating off it** — the three moves, and why `[:> X props]` →
  `(defhost x X {})` is behaviour-preserving.

One worked example, the runtime-selected component: the first named use case, and
the one the shared gate's constant type is the right grain for. The
render-prop-supplied case is named in the use-case list and its current limit
stated in the children section rather than shown, because a `:render` return still
crosses unconverted — an open row in *Not settled yet*, and it would have been a
worked example that does not work.

Also: the "covered briefly below" pointer in *Why declare* now links the section,
which is no longer brief. Swept `[:>` across the whole draft guide — every
remaining mention already reads in the built tense from #7635's true-up.

## Quality gates

Run from the worktree root, foreground to completion, each redirected to a
worktree-local log with the runner's own exit code echoed. No pipelines — nothing
went through `tail`/`head`/`grep`.

| Command | Exit | Result |
|---|---|---|
| `python scripts/check_doc_slugs.py` (after `rf2-y7zql`) | **0** | silent success |
| `python scripts/check_doc_slugs.py` (after `rf2-2rtt6.109`) | **0** | silent success |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** | `3 files, 1 cited pins (1 landed, 0 stranded, 0 unresolvable)`; every cited pin is an ancestor of `origin/main`. Nothing re-pinned, nothing to accompany |
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` (837-line log; test-lane bijection 1806 files / 46 lanes, JVM roster to CI bijection 31 artefacts, 0 baselined) |

`mkdocs build --strict` is **not** nominated and would prove nothing here:
`mkdocs.yml`'s `exclude_docs` keeps `design/` out of the site entirely.

**`check_doc_slugs.py` is silent on success, so it was proved to select these
files.** A deliberate broken anchor was appended to each changed file and the run
re-executed: **exit 1**, naming
`docs\design\hicasso\decisions.md:2071 -> #no-such-anchor-zzz-decisions` and
`docs\design\hicasso\draft-guide\02-views-and-reads.md:340 -> #no-such-anchor-zzz-y7zql`;
and on a second probe covering the escape section's own file,
`docs\design\hicasso\draft-guide\05-interop.md:550 -> #no-such-anchor-zzz-interop`
plus a cross-file `05-interop.md:551 -> 08-testing.md#no-such-heading-zzz`. Both
same-file and cross-file anchors are therefore checked in this tree. Every probe
was reverted and the checker re-run to **exit 0**; the diff contains none of them.

### Hand-verification

**Heading anchors.** Six new headings in `05-interop.md`, slugified with the same
`pymdownx.slugs.slugify(case="lower")` the checker imports per `mkdocs.yml`:
`every-prop-is-unclaimed`, `on-the-server-nothing`, `the-component-position`,
`reduced-structural-identity-exactly`, `children-lower-where-you-wrote-them`,
`migrating-off-it`. Enumerated all 22 headings on the page and confirmed **zero
duplicate slugs**. Three new links were checked by hand and by the gate:
`#the-escape-` (same page), `08-testing.md#full-headless-render-not-built`, and
`10-server-side-rendering.md#render--when-the-region-has-to-be-in-the-response`.
No heading text was renamed, so no inbound link anywhere in `docs/` was
invalidated — the only inbound anchors into this page are
`decisions.md:1274 -> #the-reserved-vector-and-the-gap-it-does-not-close` and
`02-views-and-reads.md:156 -> #memo-and-hosted-components`, both untouched.

**Table column counts.** Every pipe table in all three changed files was parsed
and every row's cell count compared against its header (splitting only on pipes
outside backticks, since several cells carry code spans). All uniform:

- `05-interop.md` — 6 tables. Three are new: the declaration-carries table
  (**3 columns**, 5 rows), the unclaimed-prop table (**2 columns**, 6 rows), and
  the Component-position refusal table (**2 columns**, 5 rows). The three
  pre-existing tables (2 / 3 / 2 columns) are unchanged, including the 14-row
  troubleshooting table whose two `[:>]` rows still agree with the new prose.
- `02-views-and-reads.md` — 3 tables. The edited row sits in the troubleshooting
  table under `| Symptom | What went wrong | Fix |`, **3 columns**, and the
  rewritten cell introduces no pipe characters.
- `decisions.md` — 3 tables, none touched; the edit is prose inside a blockquote.

**CI note.** GitHub Actions is in a major outage with webhooks throttled, so this
PR may receive no checks at all. The local exit codes above are the record.
