### PR TITLE
fix(hicasso): arm1 must activate its Reaction before watching it (rf2-2kshh)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/ratom_activation_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/ratom_activation_cljs_test.cljs
@@ -1,0 +1,239 @@
+(ns re-frame.bench.hicasso.arm1.ratom-activation-cljs-test
+  "**ARM 1 UNDER THE STOCK REAGENT ADAPTER** — a committed cell is on the
+  substrate's push path, so a write after the mount is re-render work
+  (rf2-2kshh).
+
+  THE DEFECT THIS PINS. `runtime/wire-cell!` is the whole of a cell's
+  attachment to the substrate, and it used to perform three acts:
+  subscribe, deref once for the baseline, `add-watch`. Under the ratom
+  family that is a channel that cannot fire. A subscription there IS a
+  bare `reagent.ratom/Reaction`, built deliberately without `:auto-run`,
+  and a Reaction learns its sources only through `deref-capture`: the
+  baseline deref is taken outside `*ratom-context*`, so it runs the body
+  raw and leaves `watching` nil. The reaction is then absent from
+  app-db's watcher set, the `add-watch` above never fires,
+  `runtime/mark-dirty!` never fires — that watch is its only caller —
+  `flush!` finds an empty dirty set, and React is handed nothing. **The
+  arm painted once at mount and was deaf from that instant.**
+
+  It is the identical defect the observation port carried as rf2-8cnxg
+  and repaired at `re-frame.substrate.observation/build-node-handle!`
+  (\"ACTIVATE, then watch, then observe — and the order is the whole
+  fix\"). Arm 1's runtime is a second consumer of the same channel that
+  never received the call. The port's own unit arms are
+  `re-frame.observation-port-activates-ratom-node-cljs-test`, whose
+  docstring already names and excludes the cheap wrong diagnosis: **even
+  `reagent.core/flush` moves nothing** when the node never captured.
+
+  WHY IT WENT UNCAUGHT FOR SO LONG. Every other suite in this arm
+  installs the **UIx** adapter, whose React-hook spine wires one watch
+  per source at construction and is push-based from birth — the activate
+  op is a routed no-op there and the channel works without it. The
+  Hicasso clock bench likewise gives the candidate its own UIx segment
+  on purpose. rf2-2rtt6.76's P0 allocation row was the first time in the
+  programme a write was driven at lad/hicasso with the *Reagent* adapter
+  installed, and the arm read flat at the FLOOR's figure — an arm with
+  no subscription at all reads the same, because both re-render never.
+
+  WHAT EACH ARM IS FOR. The first is the bead's own smallest
+  reproduction, taken through the arm's real seam rather than by hand:
+  render a body, commit it at [[re-frame.bench.hicasso.arm1.runtime/commit-boundary!]]
+  — the same `subscribe` closure `useSyncExternalStore` calls — write,
+  drain, and count the notifications React would have received. The rest
+  are the adversarial half, because \"make it notify\" has cheap wrong
+  answers a movement-only test rates green: a chatty channel that fires
+  on writes that moved nothing, and an attachment that works at birth
+  but not on the rebuild `invalidate-cell!` performs.
+
+  No DOM and no React: the claim is about the notification channel, and
+  the mounted counterpart where a real page repaints is
+  `re-frame.bench.hicasso.arm1.ratom-activation-dom-cljs-test`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [reagent.core :as r]
+            [reagent.ratom :as ratom]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       reagent-adapter/adapter
+     :ambient-frame nil
+     ;; The rebuild claim rides a macrotask — `invalidate-cell!` defers
+     ;; the re-attachment on purpose — so the map shape, with `async`.
+     :async?        true
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::arm1-ratom-activation)
+
+(defn- register! []
+  (rf/reg-sub :hic/n (fn [db _] (:n db)))
+  (rf/reg-event :hic/set-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
+  (rf/reg-event :hic/set-other (fn [{:keys [db]} [_ v]] {:db (assoc db :other v)})))
+
+(defn- fresh!
+  ([] (fresh! 1))
+  ([n]
+   (rt/reset-runtime!)
+   (register!)
+   (rf/make-frame {:id frame-id :initial-events [[:hic/set-n n]]})
+   frame-id))
+
+(defn- key-of [query] [frame-id query])
+
+;; White-box, and only ever COROBORATING: `watching` is the Reagent field
+;; that says "this reaction is subscribed to its sources". Read alone it
+;; would go vacuously nil against any object that is not a Reaction, so
+;; every row that consults it also asserts the behaviour it explains.
+;; `^clj` because it is a deftype field rather than a JS property.
+(defn- capturing? [rx] (some? (.-watching ^clj rx)))
+
+(defn- mounted!
+  "A boundary at the seam React occupies: render the body, commit its
+  reads, and hand back the notification counter and the release. The
+  same shape `arm1/runtime-cljs-test` uses, under a different adapter."
+  [body-fn]
+  (rt/render-body frame-id body-fn {})
+  (let [entry (rt/last-reads)
+        hits  (volatile! 0)]
+    {:entry    entry
+     :hits     hits
+     :release! (rt/commit-boundary! entry (fn [] (vswap! hits inc)))}))
+
+(defn- write!
+  "The arm's synchronous door, then Reagent's own drain.
+
+  `reagent.core/flush` is the drain the P0 bench performs for this
+  segment (inside one `flushSync`), and it is what turns an ACTIVATED
+  reaction's enqueued recompute into the `notify-w` that reaches the
+  cell's watch. It is deliberately the only thing added here: the bead's
+  falsified hypothesis was that the bench's drain was at fault, and a
+  reaction that never captured is not enqueued by anything, so this call
+  moves precisely nothing until [[wire-cell!]] activates."
+  [event]
+  (rt/dispatch! frame-id event)
+  (r/flush)
+  nil)
+
+(def ^:private !last-read
+  "What the body's `sub` read on its most recent run — so a row can assert
+  the boundary reads the MOVED value back through the cell it holds, and
+  not merely that it was pinged."
+  (atom ::never))
+
+(defn- readout-body [_]
+  (let [n (rt/sub [:hic/n])]
+    (reset! !last-read n)
+    [:span (str n)]))
+
+;; ===========================================================================
+;; the bead's reproduction: a committed cell is on the push path
+;; ===========================================================================
+
+(deftest a-committed-cell-notifies-its-boundary-under-the-reagent-adapter
+  (testing "rf2-2kshh's exact reproduction. One boundary, one query, the
+            REAGENT adapter installed: the commit must leave the cell's
+            reaction CAPTURING, so a later write reaches React's own
+            `onStoreChange`. Before the fix the cell held a watch on a
+            reaction that could not fire and the count stayed at zero
+            for the life of the mount"
+    (fresh! 1)
+    (let [b  (mounted! readout-body)
+          rx (rt/cell-reaction (key-of [:hic/n]))]
+      (try
+        (is (some? rx)
+            "precondition — the commit built a cell and it holds a reaction")
+        (is (satisfies? ratom/IRunnable rx)
+            "precondition — under this adapter a subscription IS a bare
+             Reagent Reaction, so a silent channel here is the arm's fault
+             and not the host's")
+        (is (capturing? rx)
+            "the commit ACTIVATED it: the reaction is subscribed to its
+             sources. Before the fix this was nil — watchable, watched,
+             and unable to notify")
+        (is (zero? @(:hits b))
+            "and the activation itself fanned nothing at the boundary — it
+             runs BEFORE the watch, so there is no priming notification")
+
+        (write! [:hic/set-n 2])
+        (is (= 1 @(:hits b))
+            "THE MEASUREMENT THAT WAS ZERO: the write became re-render
+             work. This is the whole of the arm's dirty channel — the
+             cell's watch is `mark-dirty!`'s only caller")
+
+        (testing "…and the channel stays armed rather than firing once
+                  and lapsing"
+          (write! [:hic/set-n 3])
+          (is (= 2 @(:hits b))))
+
+        (testing "…and the boundary reads the moved value back through the
+                  cell it holds, so the notification is not a bare ping"
+          (reset! !last-read ::never)
+          (rt/render-body frame-id readout-body {})
+          (is (= 3 @!last-read)
+              "the re-render the notification bought read 3 — a WARM read,
+               straight off the cell's reaction"))
+        (finally
+          ((:release! b)))))))
+
+;; ===========================================================================
+;; the adversarial half — activation must not make the channel chatty
+;; ===========================================================================
+
+(deftest a-write-that-moved-nothing-notifies-no-boundary
+  (testing "the cheap wrong answer a movement-only test would rate green:
+            a channel that fires on every write. An equal re-write and a
+            write to a key the sub never reads must both stay silent"
+    (fresh! 7)
+    (let [b (mounted! readout-body)]
+      (try
+        (write! [:hic/set-n 7])
+        (is (zero? @(:hits b))
+            "an equal re-write moved nothing, so nothing was fanned")
+
+        (write! [:hic/set-other :noise])
+        (is (zero? @(:hits b))
+            "…and neither did a write to an unrelated app-db key")
+
+        (testing "positive control — the two silences above are silences,
+                  not a dead channel that would make this row vacuous"
+          (write! [:hic/set-n 8])
+          (is (= 1 @(:hits b))))
+        (finally
+          ((:release! b)))))))
+
+;; ===========================================================================
+;; the rebuild path — one insertion has to cover both callers
+;; ===========================================================================
+
+(deftest a-rebuilt-cell-is-activated-too
+  (testing "`wire-cell!` is called from `acquire-cell!` at birth and again
+            from `invalidate-cell!`'s deferred rebuild, so a re-registered
+            query must come back on the push path rather than silently
+            deaf. A `reg-sub` replacement evicts the sub-cache entry and
+            disposes the reaction; the rebuild lands on a macrotask"
+    (fresh! 1)
+    (let [b (mounted! readout-body)]
+      (write! [:hic/set-n 2])
+      (is (= 1 @(:hits b)) "precondition — the original attachment notifies")
+      ;; The replacement. Same query id, a different computation.
+      (rf/reg-sub :hic/n (fn [db _] (* 10 (:n db))))
+      (async done
+        (js/setTimeout
+          (fn []
+            (try
+              (let [rx     (rt/cell-reaction (key-of [:hic/n]))
+                    before @(:hits b)]
+                (is (some? rx) "the rebuild re-subscribed")
+                (is (capturing? rx)
+                    "and ACTIVATED the replacement — the second caller of
+                     `wire-cell!` gets the same repair as the first")
+                (write! [:hic/set-n 3])
+                (is (= (inc before) @(:hits b))
+                    "a write after the re-registration still becomes
+                     re-render work: the rebuilt attachment notifies, once"))
+              (finally
+                ((:release! b))
+                (done))))
+          0)))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/ratom_activation_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/ratom_activation_dom_cljs_test.cljs
@@ -1,0 +1,200 @@
+(ns re-frame.bench.hicasso.arm1.ratom-activation-dom-cljs-test
+  "**ARM 1, MOUNTED UNDER THE STOCK REAGENT ADAPTER**, repaints when its
+  subscription moves (rf2-2kshh).
+
+  The mounted counterpart to
+  `re-frame.bench.hicasso.arm1.ratom-activation-cljs-test`, which proves
+  the notification channel itself. This one proves the outcome the P0
+  allocation row measured and could not get: a real React root, a real
+  DOM press, and a readout that moves.
+
+  THE REPRODUCTION. rf2-2rtt6.137 drove `:p0/write-all` at lad/hicasso on
+  the reagent-subs segment and read the arm's DOM back. It was stale by
+  exactly the number of writes the window had driven — every write since
+  mount, on every rung, in every round — and its allocation column sat
+  flat on the FLOOR's figure, which is what an arm with no subscription
+  at all reads. `runtime/wire-cell!` never called
+  `interop/activate-derived-value!`, so the cell's watch sat on a
+  `reagent.ratom/Reaction` that had never captured its sources and could
+  not fire. The arm painted once at mount and was deaf thereafter.
+
+  WHY IT MOUNTS RATHER THAN DRIVING THE SEAM BY HAND. A hand-driven read
+  goes through the cell's reaction whatever the notification channel did
+  — `Reaction`'s non-reactive `-deref` re-runs the body raw — so a
+  scenario that renders on demand reads CURRENT values and stays green
+  straight through this bug. Only a repaint the DOM shows can tell a live
+  channel from a dead one. That is also why the drain here is the
+  segment's own (`reagent.core/flush`, then the empty `flushSync` that
+  lets an already-scheduled sync-lane notification commit): the bead's
+  falsified hypothesis was that the drain was at fault, and this file
+  performs that very drain — it moves nothing at all until the cell is
+  activated.
+
+  Every other DOM suite in this arm installs the **UIx** adapter, whose
+  React-hook spine is push-based from birth and for which the activate op
+  is a routed no-op. This file is the arm's only mounted witness under a
+  ratom host, which is the whole reason the defect survived here after
+  being repaired in the shipping observation port (rf2-8cnxg).
+
+  `-dom-cljs-test`, so `:browser-test` runs it against a real React DOM;
+  under `:node-test` every DOM claim degrades to a stated skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent.core :as r]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       reagent-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::arm1-ratom-activation-dom)
+
+;; ---------------------------------------------------------------------------
+;; The page — one reader, one committed press site
+;; ---------------------------------------------------------------------------
+
+(defview readout
+  "The boundary under test. Its `sub` read is an ordinary ambient-collector
+  read, so the mounted occurrence repaints only if the commit's cell is
+  actually notified."
+  [_]
+  [:output#readout (str (rt/sub [:hic/n]))])
+
+(defview bump
+  "A committed `:on-click` site — the operator's press, driven for real."
+  [_]
+  [:button#bump {:on-click [:hic/bump]} "+"])
+
+(defview page [_]
+  [:div#page [readout {}] [bump {}]])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- skip! [why]
+  (is true (str "a repaint claim needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (lane/leave-act-environment!)
+  (rt/reset-runtime!)
+  (rf/reg-sub :hic/n (fn [db _] (:n db)))
+  (rf/reg-event :hic/bump (fn [{:keys [db]} _] {:db (update db :n inc)}))
+  (rf/reg-event :hic/set-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
+  (rf/reg-event :hic/set-other (fn [{:keys [db]} [_ v]] {:db (assoc db :other v)}))
+  (rf/make-frame {:id frame-id :initial-events [[:hic/set-n 0]]})
+  (rt/reset-body-runs!)
+  frame-id)
+
+(defn- settle!
+  "The reagent-subs segment's drain, in two lines rather than one.
+
+  `reagent.core/flush` runs the reactions a write enqueued, which is what
+  turns an activated node's recompute into the `notify-w` the cell's watch
+  rides; `mount/settle!` is the empty `flushSync` that lets the sync-lane
+  `onStoreChange` that raised commit. The bench spells the pair as
+  `(flushSync (fn [] (r/flush)))`, which is the same two acts in one
+  call."
+  []
+  (r/flush)
+  (mount/settle!)
+  nil)
+
+(defn- write! [handle event]
+  (rt/dispatch! (:frame handle) event)
+  (settle!))
+
+(defn- press! [handle]
+  (.click (.querySelector (:container handle) "#bump"))
+  (settle!))
+
+(defn- readout-text [handle]
+  (some-> (.querySelector (:container handle) "#readout") .-textContent))
+
+;; ===========================================================================
+;; 1 — the bead's reproduction, as a gate
+;; ===========================================================================
+
+(deftest a-mounted-boundary-repaints-under-the-reagent-adapter
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [page {}])]
+        (try
+          (is (= "0" (readout-text handle))
+              "the first render read the seeded value — it always did; the
+               bug was never the mount")
+          (write! handle [:hic/bump])
+          (is (= 1 (:n (rf/app-db-value frame-id)))
+              "precondition — the dispatch LANDS. app-db moved, and it moved
+               before the fix too")
+          (is (= "1" (readout-text handle))
+              "THE READING THAT WAS STALE: the mounted arm repainted from
+               the write. Before the fix this stayed at its first render
+               forever, which is why the P0 row read the FLOOR's allocation
+               figure — an arm that never re-renders allocates nothing per
+               read")
+          (write! handle [:hic/bump])
+          (is (= "2" (readout-text handle))
+              "0 → 1 → 2: the channel stays armed rather than firing once")
+          (finally
+            (mount/release! handle)))))))
+
+;; ===========================================================================
+;; 2 — a real press, which is what the operator drives
+;; ===========================================================================
+
+(deftest a-real-press-repaints-the-mounted-boundary
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [page {}])]
+        (try
+          (is (= "0" (readout-text handle)))
+          (press! handle)
+          (is (= 1 (:n (rf/app-db-value frame-id)))
+              "the committed `:on-click` dispatched into the bound frame")
+          (is (= "1" (readout-text handle))
+              "and the sibling reader repainted off the same movement — the
+               whole round trip a page performs, with nothing hand-driven")
+          (finally
+            (mount/release! handle)))))))
+
+;; ===========================================================================
+;; 3 — the adversarial companion: activation must not make it chatty
+;; ===========================================================================
+
+(deftest a-write-that-moved-nothing-repaints-no-boundary
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [page {}])]
+        (try
+          (is (= "0" (readout-text handle)))
+          (rt/reset-body-runs!)
+          (write! handle [:hic/set-n 0])
+          (is (zero? (rt/body-runs))
+              "an equal re-write moved nothing, so no body re-ran")
+          (write! handle [:hic/set-other :noise])
+          (is (zero? (rt/body-runs))
+              "…and neither did a write to a key this sub never reads")
+          (is (= "0" (readout-text handle))
+              "the DOM is untouched by either write")
+
+          (testing "positive control — the silences above are silences, not
+                    a dead channel that would make this whole row vacuous"
+            (write! handle [:hic/set-n 6])
+            (is (pos? (rt/body-runs)))
+            (is (= "6" (readout-text handle))))
+          (finally
+            (mount/release! handle)))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -720,11 +720,29 @@
 (declare invalidate-cell!)
 
 (defn- wire-cell!
-  "Give `cell` a live subscription: subscribe, establish the baseline,
-  arm the value-change watch, and arm the **disposal** hook. The whole of
-  a cell's attachment to the substrate, in one place, because it is
+  "Give `cell` a live subscription: subscribe, **activate**, establish the
+  baseline, arm the value-change watch, and arm the **disposal** hook. The
+  whole of a cell's attachment to the substrate, in one place, because it is
   performed twice — once when the cell is born and once when the
   substrate disposes the reaction out from under it.
+
+  **Activation comes first, and it is not optional** (rf2-2kshh; the same
+  defect the observation port carried as rf2-8cnxg, and repaired at
+  `substrate/observation.cljc` — \"ACTIVATE, then watch, then observe\").
+  A subscription under the ratom family IS a bare `reagent.ratom/Reaction`,
+  built deliberately without `:auto-run`, and a Reaction learns its sources
+  only through `deref-capture`: a plain deref taken outside `*ratom-context*`
+  runs the body raw and leaves `watching` nil. The reaction is then not in
+  app-db's watcher set, so the watch below never fires, [[mark-dirty!]] never
+  fires — that watch is its only caller — and no write after the mount ever
+  becomes re-render work. Measured: the arm painted once and was deaf
+  thereafter. `interop/activate-derived-value!` is the substrate's own op for
+  this and is a routed no-op on the React-hook spine, which wires one watch
+  per source at construction.
+
+  It runs BEFORE the watch so the activating run cannot fan a priming
+  notification, and before the baseline deref so that deref reads a settled
+  node — the activation left it clean, so the baseline recomputes nothing.
 
   The disposal hook is the arm's counterpart to the two axes
   `commit-basis` cannot see (rf2-2rtt6.44), and it is deliberately an
@@ -740,6 +758,8 @@
         reaction (subs/subscribe query-v {:frame frame-kw})]
     (set! (.-reaction cell) reaction)
     (when (some? reaction)
+      ;; On the substrate's PUSH path, before anything observes or watches it.
+      (interop/activate-derived-value! reaction)
       ;; ONE baseline deref, before the watch — see `acquire-cell!`.
       @reaction
       (add-watch reaction cell-watch-key


### PR DESCRIPTION
Closes rf2-2kshh. Diagnosed read-only on rf2-2rtt6.137; this PR is the repair plus the two regression suites that bead asked for.

## The defect

`arm1/runtime.cljs`'s `wire-cell!` is the whole of a cell's attachment to the substrate — subscribe, deref once for the baseline, `add-watch`, arm the disposal hook. Under the ratom family that is a channel that cannot fire. A subscription there **is** a bare `reagent.ratom/Reaction` (`spine.cljs` builds it with `make-reaction` and deliberately not `:auto-run`), and a Reaction learns its sources only through `deref-capture`. The baseline deref is taken outside `*ratom-context*`, so it runs the body raw and leaves `watching` nil. The reaction is then absent from app-db's watcher set → the `add-watch` never fires → `mark-dirty!` never fires (that watch is its only caller) → `flush!` finds an empty dirty set → React is handed nothing. **The arm painted once at mount and was deaf thereafter.**

This is rf2-8cnxg in a second consumer that never got the fix. The shipping observation port carried the identical defect and repaired it at `substrate/observation.cljc` — *"ACTIVATE, then watch, then observe — and the order is the whole fix."*

## The fix

One line in `wire-cell!`:

```clojure
 (when (some? reaction)
+  ;; On the substrate's PUSH path, before anything observes or watches it.
+  (interop/activate-derived-value! reaction)
   ;; ONE baseline deref, before the watch — see `acquire-cell!`.
   @reaction
   (add-watch reaction cell-watch-key ...)
```

`re-frame.interop` was already required as `interop`. `wire-cell!` is the single attachment point — called from `acquire-cell!` at birth and from `invalidate-cell!`'s deferred rebuild — so one insertion covers both paths, and a test arm pins the rebuild half.

**Ordering, verified against `observation.cljc` rather than assumed.** That site's order is `activate-derived-value!` → `add-watch` → baseline observe, and the load-bearing part is stated there in prose: activation runs *before* the watch so the activating recompute cannot fan a priming notification, and before the baseline observe so the observe reads a settled node. Both properties are preserved here. Arm 1 keeps its own deref-then-watch order after the activation, which it documents at `acquire-cell!` (it uses the notification itself as the dirty signal, so it needs a real baseline rather than `unset`); that ordering is now inert either way, because `deref-capture` clears `dirty?`, so the baseline deref recomputes and notifies nothing. The "activation fans nothing at the boundary" assertion in the node suite pins exactly this.

**UIx is unaffected.** `interop/activate-derived-value!` routes through the `:adapter/activate-derived-value!` late-bind hook, which is published by the ratom family alone. The React-hook spine (UIx, Helix, re-frame.ui, Freehand) wires one watch per source at construction and is push-based from birth, so it publishes no hook and the routed chain-bottom returns nil — the call is a no-op there. Every pre-existing arm1 suite installs the UIx adapter and all of them are unchanged and green.

## The tests

Both live beside the arm they test, in `implementation/freehand/test/re_frame/bench/hicasso/arm1/`:

- **`ratom_activation_cljs_test.cljs`** (node, no DOM) — the notification channel itself. Renders a body, commits it at `runtime/commit-boundary!` (the same `subscribe` closure `useSyncExternalStore` calls), writes, drains with `reagent.core/flush`, and counts what React would have received. Plus the adversarial arms: a write that moved nothing and a write to an unread key must fan nothing (with a positive control so the silences are silences), and `invalidate-cell!`'s rebuild must be activated too.
- **`ratom_activation_dom_cljs_test.cljs`** (`-dom-cljs-test`, so `:browser-test` runs it) — the mounted counterpart. A real React root via `arm1/mount`, a real DOM press on a committed `:on-click`, a readout that moves 0 → 1 → 2, and the same no-movement companion.

**Note on placement — a deliberate deviation from the bead.** rf2-2rtt6.137 suggested the reagent adapter's test tree, beside the two rf2-8cnxg port suites. They are here instead, because the DOM counterpart needs `arm1/mount`, `arm1/lane` and the `arm1/lang` `defview` macro, and routing a shipped adapter's test tree through the bench candidate's private harness is the wrong coupling direction. The precedent is local: `arm1/runtime_cljs_test.cljs` already installs `re-frame.adapter.uix`, and the hicasso bench tree already requires `re-frame.adapter.reagent` and `reagent.core` in several places. Both new docstrings cross-reference the port suites by name.

## Red-then-green demonstration

The one line was reverted, both suites re-run, then the line was restored and both re-run. The working tree afterwards is byte-identical to the commit.

### Node suite — `re-frame.bench.hicasso.arm1.ratom-activation-cljs-test`

RED (line commented out), `node out/node-test.js --test=...` → **exit 1**, `Ran 6 tests containing 17 assertions. 7 failures, 0 errors.`

```
FAIL a-committed-cell-notifies-its-boundary-under-the-reagent-adapter
  expected: (capturing? rx)
    actual: (not (capturing? #object[reagent.ratom.Reaction {:val 1}]))
  expected: (= 1 @(:hits b))
    actual: (not (= 1 0))
  expected: (= 2 @(:hits b))
    actual: (not (= 2 0))
FAIL a-write-that-moved-nothing-notifies-no-boundary   ; the positive control
  expected: (= 1 @(:hits b))
    actual: (not (= 1 0))
FAIL a-rebuilt-cell-is-activated-too
  expected: (capturing? rx)
    actual: (not (capturing? #object[reagent.ratom.Reaction {:val 20}]))
  expected: (= (inc before) @(:hits b))
    actual: (not (= 2 1))
```

The failure is the diagnosis, printed: the object *is* a `reagent.ratom.Reaction`, it holds a live value, it is watched — and `watching` is nil, so the notification count never leaves 0. The two adversarial silence arms pass vacuously without the fix, which is precisely what their positive control exists to catch, and that control is one of the seven failures.

GREEN (line restored) → **exit 0**, `Ran 6 tests containing 17 assertions. 0 failures, 0 errors.`

### DOM suite — `re-frame.bench.hicasso.arm1.ratom-activation-dom-cljs-test`

RED, `node scripts/serve-and-run-browser-tests.cjs` → **exit 1**, `Ran 1114 tests containing 6884 assertions. 5 failures, 0 errors.` **All five failures were the new file's**; nothing else in the lane moved.

```
FAIL a-mounted-boundary-repaints-under-the-reagent-adapter
  expected: (= "1" (readout-text handle))   actual: (not (= "1" "0"))
  expected: (= "2" (readout-text handle))   actual: (not (= "2" "0"))
FAIL a-real-press-repaints-the-mounted-boundary
  expected: (= "1" (readout-text handle))   actual: (not (= "1" "0"))
FAIL a-write-that-moved-nothing-repaints-no-boundary   ; the positive control
  expected: (pos? (rt/body-runs))           actual: (not (pos? 0))
  expected: (= "6" (readout-text handle))   actual: (not (= "6" "0"))
```

That is rf2-2rtt6.137's published symptom reproduced exactly: the readout is frozen at the value it painted at mount, through every write, and `body-runs` is 0 — no body re-ran at all. It is also why that row's allocation column sat flat on the FLOOR's figure: an arm that never re-renders allocates nothing per read.

GREEN (line restored) → **exit 0**, `Ran 1114 tests containing 6884 assertions. 0 failures, 0 errors.` Identical test and assertion counts to the RED run, so the same namespaces ran in both.

## Quality gates

All foreground, none piped, each exit code read from the runner itself.

| # | Command (cwd) | Result | Exit |
|---|---|---|---|
| 1 | `node scripts/compile-node-test.cjs node-test out/node-test.js` (`implementation/`) | `Build completed. (2164 files, 2163 compiled, 0 warnings, 107.02s)` | **0** |
| 2 | `node out/node-test.js --test=re-frame.bench.hicasso.arm1.ratom-activation-cljs-test,re-frame.bench.hicasso.arm1.ratom-activation-dom-cljs-test` | `Ran 6 tests containing 17 assertions. 0 failures, 0 errors.` | **0** |
| 3 | *(RED control)* same two commands with the fix reverted | compile `0`; run `Ran 6 tests containing 17 assertions. 7 failures, 0 errors.` | **1** |
| 4 | `./node_modules/.bin/shadow-cljs compile browser-test` *(RED control)* | `Build completed. (1122 files, 1121 compiled, 0 warnings, 100.11s)` | **0** |
| 5 | `node scripts/serve-and-run-browser-tests.cjs` *(RED control)* | `Ran 1114 tests containing 6884 assertions. 5 failures, 0 errors.` — all five the new file's | **1** |
| 6 | `./node_modules/.bin/shadow-cljs compile browser-test` | `Build completed. (1122 files, 49 compiled, 0 warnings, 69.89s)` | **0** |
| 7 | `node scripts/serve-and-run-browser-tests.cjs` | `Ran 1114 tests containing 6884 assertions. 0 failures, 0 errors.` | **0** |
| 8 | `npm run test:cljs` | `Ran 12754 tests containing 64005 assertions. 0 failures, 0 errors.` | **0** |
| 9 | `npm run test:hicasso-compile` | `Build completed. (439 files, 438 compiled, 0 warnings, 48.97s)` — `ok — 132 lane namespaces compiled with zero warnings` | **0** |
| 10 | `sh scripts/test-fast-pr.sh` (repo root) | `PASS fast PR spine` — every tier green: static gates in full (lockstep, skill/MCP drift, retired-spelling, thrown-error, keyword-catalogue, test-lane bijection `1808 test-defining files, 46 lanes`, JVM roster bijection, gate-scheduling, CI reproduce-commands, README link/inventory, adapter-disposition, all self-tests); JVM `implementation/core` `Ran 2233 tests containing 11645 assertions. 0 failures, 0 errors.`; JVM `implementation/freehand` `Ran 1291 tests containing 8874 assertions. 0 failures, 0 errors.`; JS harness helpers; CLJS node integration `Ran 12754 tests containing 64005 assertions. 0 failures, 0 errors.`; per-ns isolation `all 17 namespace(s) pass standalone (196 tests, 731 assertions)`; hicasso bench-lane compile `132 lane namespaces compiled with zero warnings` | **0** |

CI is healthy again, so the full check set should run on this PR; the local exit codes above are the independent record.

## Scope

Three files, all under `implementation/freehand/test/re_frame/bench/hicasso/arm1/`: the one-line fix in `runtime.cljs` (plus its docstring), and the two new suites. No `spec/` change, no bench-driver change — per rf2-2rtt6.137, nothing in `p0_run.cjs` / `p0_heap.cljs` / `p0_arms.cljs` needs to move.

PR #7644's Reagent-segment lad/hicasso rows are knock-on from this bug and are **not** touched here; routing that is the operator's call.

## A cost-model note, stated not fixed

`freehand/test/re_frame/bench/hicasso/read_profile_app.cljs:405-424` hand-transcribes `wire-cell!`'s shape as a retained-heap cost model — `subs/subscribe`, `@r`, `add-watch`, `add-on-dispose!`, with the `C-NOSUB` / `C-NOWATCH` / `C-NOREADERS` ablations hanging off it. Adding activation makes that rig model a shape the runtime no longer has.

**No published figure moves.** That app installs the UIx adapter (`rf/init! uix-adapter/adapter`, line 576), and `activate-derived-value!` is a routed no-op on the React-hook spine, so the omitted call prices exactly zero there.

**But the capture run does belong in the priced shape**, for two reasons. Structurally, the rig's whole claim is that it transcribes `wire-cell!`; a transcription that has silently diverged is the thing the rf2-2rtt6.32 call-convention discipline exists to prevent. Numerically, it would matter the moment the rig is pointed at a ratom host: `deref-capture` retains a `watching` array per reaction and adds an entry to each source's watcher set, which is per-key retained heap the model would understate — and it is not purely additive either, since the capture run *replaces* the raw `(f)` the baseline deref would otherwise perform. Left alone here: it is outside this bead's fence and wants its own bead.
