### PR TITLE
test(hicasso): witness W7 — the [:>] value-first door dispatches through a plain closure (rf2-zllp8)

### DIFF
--- a/docs/design/hicasso/studio/hframe-design.md
+++ b/docs/design/hicasso/studio/hframe-design.md
@@ -217,7 +217,7 @@ Nine rows, re-grounded on the post-`rf2-2rtt6.122` tree.
 | W4 | Inside a `defhost` `:render` callback invocation → answers the **supplying** boundary's frame, not the invoker's | the `rf2-2rtt6.74` owner rule |
 | W5 | Not a tracked read: a body reading `(h/frame)` alone registers zero edges; adding it to a reading body changes no read set; the hook ledger still counts 2 (and 1 on the frame-prop shell) | |
 | W6 | StrictMode double-invoke: same value both runs, no additive effect | |
-| W7 | The `[:>]` value-first door dispatches through a plain closure over the capture | pairs with the `rf2-2rtt6.103` dev-warning row. **NOT BUILT** — the raw escape is unbuilt, so there is no door to drive; see §8a and `rf2-zllp8` |
+| W7 | The `[:>]` value-first door dispatches through a plain closure over the capture | **BUILT** once `rf2-2rtt6.103` shipped the escape — `rf2-zllp8`; see §8a |
 | W8 | SSR: the server body answers the per-request id; render-twice stays byte-identical while the id stays out of markup, and goes red when a witness deliberately renders it | |
 | W9 | An event-time read is not silently wrong: `(h/frame)` inside a `reg-event` handler body raises | the router binds core scope, not the arm's |
 
@@ -268,14 +268,33 @@ in exactly one place in the new work — nowhere. The carry rows pin *"the same 
 an ambient read gets"*, taken live from a sibling row, so `rf2-k0rbk`'s rename
 touches the one pre-existing anchor rather than five new sites.
 
-**W7 could not be built, and it is not a shortfall.** The row needs the `[:>]`
-value-first door; `front/codec.cljs` says at the site that the raw escape *"stays
-unbuilt here, deliberately"*, so a witness would have had to mint its own
-`[:>]`-shaped thing and would then be witnessing the test's construction.
-Filed as `rf2-zllp8` against whichever bead ships the escape. Everything W7
-depends on is pinned elsewhere — the composition firing after the extent unwinds,
-and `(h/frame)` answering the supplying boundary inside a render callback, which
-is the closest live analogue of a foreign value-first invoker.
+**W7 could not be built when this record was first written, and that was not a
+shortfall.** The row needs the `[:>]` value-first door, and `front/codec.cljs`
+said at the site that the raw escape *"stays unbuilt here, deliberately"* — so a
+witness would have had to mint its own `[:>]`-shaped thing and would then be
+witnessing the test's construction. It was filed as `rf2-zllp8` against whichever
+bead shipped the escape.
+
+**`rf2-2rtt6.103` shipped it, and W7 is now built** — the last row of
+`arm1/hframe_dom_cljs_test`, `the-escapes-value-first-door-dispatches-through-a-plain-closure-over-the-capture`
+(`rf2-zllp8`). ONE reusable view is mounted under two frames and writes a `[:>]`
+crossing whose callback prop is a plain closure over `(rf/capture-frame
+(h/frame))`; a foreign component keeps that closure and calls it from a DOM
+handler of its own, from a macrotask, after every render extent has unwound. Both
+crossings are clicked, deliberately: a capture that resolved one frame for both
+would toggle that one frame twice and leave the pair reading `false`/`false`,
+which one click alone would not catch.
+
+**One correction to the row's own note.** It said W7 *"pairs with the
+`rf2-2rtt6.103` dev-warning row"*, and what shipped is not a dev warning — it is
+a pair of hard refusals. `[:>]` carries no declaration, so `raw-crossing`'s
+roster is empty by construction, and an intent vector at an event-spelled prop is
+`:rf.error/hicasso-host-undeclared-callback` while a marked `h/fn` at any prop is
+`:rf.error/hicasso-host-unclaimed-callback`. That strengthens W7 rather than
+changing it: the plain closure is not the recommended spelling among two, it is
+the only one the door admits. Both refusals are asserted live at the top of the
+row, so the premise is measured rather than cited — if the escape ever grows a
+contract at a callback slot, W7 goes red before it mounts anything.
 
 **One new finding, pinned but not endorsed.** The refusal withdraws the ambient
 find and never the carrying — so an enclosing `rf/with-frame` still answers
@@ -297,8 +316,10 @@ to sequence with `rf2-k0rbk`.
 **The guide half is still owed.** §10's guide bullet was fenced out of the
 implementation PR — a rename was landing in `draft-guide/` at the time — so the
 fx-first troubleshooting row, the contract-force sentence, and the `[:>]`
-dev-warning's "plain closure" spelling have not been written. The last of those
-is blocked on `[:>]` in any case (`rf2-zllp8`).
+"plain closure" spelling have not been written. The last of those is no longer
+blocked — the escape shipped with `rf2-2rtt6.103` and W7 pins the mechanism — but
+it was fenced out of `rf2-zllp8` for the same reason it was fenced out of
+`rf2-841vn`: live work in `draft-guide/`. It stays owed.
 
 ---
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/hframe_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/hframe_dom_cljs_test.cljs
@@ -25,6 +25,30 @@
      would be a finding rather than a price.
   4. **StrictMode's double-invoke is not additive** (W6) — the same value
      on both runs, and no second edge, entry or registration.
+  5. **The `[:>]` value-first door dispatches through a plain closure
+     over the capture** (W7, rf2-zllp8). The escape carries no
+     declaration, so its callback roster is EMPTY by construction and
+     both spellings that would otherwise carry the frame for the author
+     refuse at the prop — an intent vector is
+     `:rf.error/hicasso-host-undeclared-callback` and an `h/fn` is
+     `:rf.error/hicasso-host-unclaimed-callback`. What crosses is an
+     ordinary function, by identity, and an ordinary function carries no
+     frame. This is the edge `h/frame` names in its own docstring as the
+     one it exists for: *\"a value-first callback on a foreign
+     component\"*.
+
+  ## The mutation witness for W7
+
+  Lock both captures to one frame — `(rf/capture-frame frame-a)` in
+  place of `(rf/capture-frame (h/frame))` in
+  [[escape-picker]] — and
+  [[the-escapes-value-first-door-dispatches-through-a-plain-closure-over-the-capture]]
+  goes red on the second click, which toggles the first frame back off
+  and leaves the pair reading `false`/`false`. That is why the row
+  clicks BOTH crossings: one click alone is green under a capture that
+  resolved one frame for both. Give the escape's roster a contract at
+  `:on-pick` and the premise rows go red before anything mounts; hand
+  the crossing a marked `h/fn` that survives, and the second one does.
 
   Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
   React DOM; under `:node-test` every claim degrades to a stated skip."
@@ -291,3 +315,144 @@
               (is (= 1 boundaries))
               (is (= 1 edges) "the one real read, counted once")))
           (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; W7 — the `[:>]` value-first door, and the plain closure over the capture
+;; ---------------------------------------------------------------------------
+;;
+;; W2 proves the composition survives a macrotask. This row proves it is
+;; the ONLY thing that can serve the crossing HD-011 made the escape for.
+;; `[:>]` is `defhost` with the declaration erased, and a declaration is
+;; what a callback contract lives on — so `raw-crossing`'s roster is
+;; empty by construction and every slot at this crossing is UNCLAIMED.
+;; The consequence is not a nuance, it is the whole row: the two
+;; spellings that carry a frame FOR the author are both refused here, and
+;; what remains is a plain function, which carries nothing. The frame has
+;; to be put into it by hand, in the body, where it is knowable.
+
+(def ^:private !built
+  "The closure each mounted instance BUILT, keyed by the frame its body
+  read. The other half of [[!handed]]: two atoms rather than one because
+  the claim that the door is *value-first* is a claim that these are the
+  same object."
+  (atom {}))
+
+(def ^:private !handed
+  "The `onPick` prop each instance of the foreign component was HANDED,
+  keyed by the label it was given — which is the frame its writing
+  boundary read. An instance that never crossed leaves this empty, so
+  neither the identity row nor the dispatch rows below can pass
+  vacuously."
+  (atom {}))
+
+(defn- foreign-picker
+  "A stand-in for the component an author reaches for `[:>]` to mount: it
+  is handed a callback prop, KEEPS it, and calls it from a DOM handler of
+  its own — so the invoker is foreign code running long after our render
+  returned, rather than the test reaching into a stash.
+
+  Written with `react/createElement` on purpose. A library component is
+  not ours and does not lower through this codec, and a fixture that went
+  through the codec would witness our own walk a second time instead of
+  the crossing."
+  [^js props]
+  (let [on-pick (.-onPick props)]
+    (swap! !handed assoc (.-label props) on-pick)
+    (react/createElement "button"
+      #js {:className "pick" :onClick (fn [_e] (on-pick))}
+      "pick")))
+
+(defview escape-picker
+  "[[reusable]]'s body at the foreign edge: ONE view, mounted under N
+  frames, that does not know its own frame id — and now has to hand a
+  dispatching closure to a caller it does not control.
+
+  `(rf/capture-frame (h/frame))` is the whole answer, and each half is
+  load-bearing. `h/frame` supplies the id a reusable view cannot name;
+  `capture-frame`'s 1-arity never consults the ambient resolver, so the
+  handle it returns is still good when the foreign component calls back."
+  [{:keys [id]}]
+  (let [f (intent/hframe)
+        d (rf/capture-frame f)
+        on-pick (fn [] ((:dispatch-sync d) [:dogfood/toggle id]))]
+    (swap! !built assoc (str f) on-pick)
+    [:span.row {:data-frame (str f)
+                :data-done  (str (rt/sub [:dogfood/done? id]))}
+     [:> foreign-picker {:label (str f) :on-pick on-pick}]]))
+
+(defn- refusal-id [f]
+  (try (f) ::did-not-throw (catch :default e (:rf.error/id (ex-data e)))))
+
+(defn- done-attr [handle]
+  (some-> (.querySelector (:container handle) ".row") (.getAttribute "data-done")))
+
+(defn- pick! [handle]
+  (.click (.querySelector (:container handle) ".pick"))
+  (mount/settle!)
+  nil)
+
+(deftest the-escapes-value-first-door-dispatches-through-a-plain-closure-over-the-capture
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (async done
+      (frames!)
+      (reset! !built {})
+      (reset! !handed {})
+
+      (testing "THE PREMISE, asserted rather than cited. `[:>]` is a
+                value-first door: its roster is empty by construction, so
+                the two spellings that would carry the frame for the
+                author both refuse at this very prop. That is what leaves
+                the plain closure as the only door rather than one option
+                of two — and if the escape ever grew a contract here, this
+                row goes red before the mount and the rest of W7 stops
+                being the answer to a real question"
+        (is (= :rf.error/hicasso-host-undeclared-callback
+               (refusal-id #(codec/as-element
+                              [:> foreign-picker {:on-pick [:dogfood/toggle 0]}])))
+            "an intent vector at an event-spelled slot")
+        (is (= :rf.error/hicasso-host-unclaimed-callback
+               (refusal-id #(codec/as-element
+                              [:> foreign-picker
+                               {:on-pick (intent/callback (fn [] [:dogfood/toggle 0]))}])))
+            "and a marked h/fn, which asks the position for a contract no
+             position here can ever select"))
+
+      (let [a (mount/root! (mount/fresh-container!) frame-a [escape-picker {:id 0}])
+            b (mount/root! (mount/fresh-container!) frame-b [escape-picker {:id 0}])]
+        (is (= #{(str frame-a) (str frame-b)} (set (keys @!handed)))
+            (str "two mounts of ONE view crossed under two different frames; got "
+                 (pr-str (keys @!handed))))
+        (testing "and what crossed is the body's own function, by
+                  IDENTITY — no wrapper of ours stands between the author
+                  and the library, which is what *value-first* names and
+                  what keeps React.memo and every handler-identity
+                  bail-out working through the escape"
+          (doseq [f [frame-a frame-b]]
+            (is (identical? (get @!built (str f)) (get @!handed (str f))) (str f))))
+
+        ;; A real macrotask, then the FOREIGN component's own click
+        ;; handler: by the time either closure runs, no render extent is
+        ;; live and there is no ambient frame anywhere to resolve.
+        (js/setTimeout
+          (fn []
+            (try
+              (is (nil? intent/*frame*)
+                  "precondition: no render extent is live inside the timeout")
+              (pick! a)
+              (is (= "true" (done-attr a))
+                  "the closure the first crossing handed the foreign
+                   component dispatched into the frame that wrote it")
+              (is (= "false" (done-attr b))
+                  "and nothing reached the other frame")
+              (pick! b)
+              (is (= ["true" "true"] [(done-attr a) (done-attr b)])
+                  "and the second crossing's closure into ITS own frame. A
+                   capture that had resolved one frame for both would have
+                   toggled that one frame twice and left this pair reading
+                   false/false — which is why BOTH crossings are clicked")
+              (finally
+                (mount/release! a)
+                (mount/release! b)
+                (done))))
+          0)))))


### PR DESCRIPTION
`rf2-841vn` built the ruled `h/frame` design's witnesses W1–W6 and W8–W11 and
could not build W7. The reason was structural rather than a shortfall: the row
needs the `[:>]` value-first door, and `front/codec.cljs` said at the site that
the raw escape *"stays unbuilt here, deliberately"*, so a witness would have had
to mint its own `[:>]`-shaped thing and would then have been witnessing the
test's construction.

`rf2-2rtt6.103` shipped the escape — PR #7635, **MERGED** at `382611ef0b`,
2026-08-06T23:01:27Z. So the row is buildable, and this builds it.

## What W7 asserts

`[:>]` is `defhost` with the declaration erased, and a declaration is what a
callback contract lives on. `raw-crossing`'s roster is therefore empty by
construction and every slot at this crossing is UNCLAIMED — which is not a
nuance but the whole row. The two spellings that carry a frame *for* the author
are both refused here, and what remains is a plain function, which carries
nothing. The frame has to be put into it by hand, in the body, where it is
knowable.

`the-escapes-value-first-door-dispatches-through-a-plain-closure-over-the-capture`,
in `arm1/hframe_dom_cljs_test`, in four movements:

1. **The premise, asserted rather than cited.** An intent vector at an
   event-spelled prop is `:rf.error/hicasso-host-undeclared-callback`; a marked
   `h/fn` at that prop is `:rf.error/hicasso-host-unclaimed-callback`. Both are
   driven live against the row's own fixture component. If the escape ever grows
   a contract at a callback slot, W7 goes red before it mounts anything and stops
   claiming to answer a question that no longer exists.
2. **The crossing, under two frames.** ONE reusable view — it does not know its
   own frame id, which is why neither `with-frame` nor a `{:frame …}` opt can
   serve it — writes `[:> foreign-picker {:label … :on-pick <closure>}]`, where
   the closure is built over `(rf/capture-frame (h/frame))`. Mounted under two
   frames, the two instances must key the stash by two different frames or the
   row is red on the count.
3. **Value-first means identity.** What the foreign component received is the
   very function the body built, `identical?`, at both frames. No wrapper of ours
   stands between the author and the library — which is what keeps `React.memo`
   and every handler-identity bail-out working through the escape.
4. **The dispatch, from foreign code, after the extent unwinds.** The foreign
   component KEEPS its callback prop and calls it from a DOM handler of its own.
   From inside a `setTimeout` — with `intent/*frame*` asserted `nil` first, so
   there is no ambient frame anywhere to resolve — the row clicks the first
   crossing (its frame moves, the sibling does not), then the second (both now
   moved).

Clicking BOTH is deliberate and is what gives the row its teeth: `:dogfood/toggle`
is an involution, so a capture that resolved one frame for both would toggle that
one frame twice and leave the pair reading `false`/`false`. One click alone is
green under that break.

`arm1/raw_escape_dom_cljs_test`'s row 4 already pins the neighbouring claim — an
intent in a `[:>]` **child** lowers in the writing boundary's render window. W7 is
the **prop** path, where no intent is admissible at all.

## One correction the shipped shape forces

The W7 row's own note said it *"pairs with the `rf2-2rtt6.103` dev-warning row"*.
What shipped is not a dev warning; it is a pair of hard refusals. That
**strengthens** W7 rather than changing it — the plain closure is not the
recommended spelling among two, it is the only one the door admits — and it is
recorded on `hframe-design.md` §8a rather than quietly absorbed.

**No change was made to `[:>]` to make W7 pass.** `front/codec.cljs` is untouched.

## Design record

`docs/design/hicasso/studio/hframe-design.md` carried W7's not-built status in two
places (the §8 table row and a dedicated §8a paragraph). Both are trued up, and
§10's "guide half is still owed" note is corrected: the `[:>]` *plain closure*
guide spelling is no longer blocked on the escape, but it stays owed — it was
fenced out of this PR for the same reason it was fenced out of `rf2-841vn`, live
work in `draft-guide/`. §8's table is unchanged at 3 columns across header,
separator and all nine rows (verified by hand, per the `docs/design/**` rule); no
markdown links were added.

## Quality gates

Every gate run in the foreground, to completion, never piped, redirected to a
worktree-local log, with the runner's own exit code echoed.

| Gate | Command | Result | Exit |
|---|---|---|---|
| hicasso bench-lane compile | `cd implementation && npm run test:hicasso-compile` | 130 lane namespaces, 0 warnings | **0** |
| DOM suite owning the W-series (focused) | `npx shadow-cljs compile browser-test --config-merge '{:ns-regexp "^re-frame[.]bench[.]hicasso[.]arm1[.](hframe\|raw-escape)-dom-cljs-test$" …}'` then `node scripts/serve-and-run-browser-tests.cjs --root out/browser-test-w7 --port 8031` | Ran 11 tests containing 53 assertions. 0 failures, 0 errors. | **0** |
| full browser DOM lane | `cd implementation && npm run test:browser` | Ran 1112 tests containing 6880 assertions. 0 failures, 0 errors. | **0** |
| fast-PR spine | `sh scripts/test-fast-pr.sh` | 79 steps, `PASS fast PR spine` — run twice, both green | **0**, **0** |

The focused browser build used `--config-merge` rather than a new build id, for
the reason `compile_gate.cjs` states: a new id is a hot-zone edit to
`implementation/shadow-cljs.edn`. `implementation/shadow-cljs.edn` is untouched,
and the poisoned `browser-test` cache entry was cleared before the full lane ran.

The spine was run twice for an honest reason rather than a superstitious one. The
first run was launched against this exact commit with a clean tree and completed
`PASS fast PR spine` at exit 0 — but a second run had been started before that
one's completion was observable, so the two overlapped for part of their length.
The second run finished uncontended, also 79 steps, also `PASS fast PR spine`,
also exit 0. Both are reported rather than the convenient one.

### The witness goes red

A witness that cannot be shown to go red proves nothing. The mutation is the one
the file's own docstring names: lock both captures to one frame —
`(rf/capture-frame frame-a)` in place of `(rf/capture-frame (h/frame))` in
`escape-picker` — leaving everything else, including `h/frame` itself, in place.

```
FAIL in (the-escapes-value-first-door-dispatches-through-a-plain-closure-over-the-capture)
        (re_frame/bench/hicasso/arm1/hframe_dom_cljs_test.cljs:449:19)
and the second crossing's closure into ITS own frame. A
capture that had resolved one frame for both would have
toggled that one frame twice and left this pair reading
false/false — which is why BOTH crossings are clicked
expected: (= ["true" "true"] [(done-attr a) (done-attr b)])
  actual: (not (= ["true" "true"] ["false" "false"]))

Ran 11 tests containing 53 assertions.
1 failures, 0 errors.
```

Runner exit **1**. Note what stays green under that break — the two refusal rows,
the two-frames-two-keys count, and the identity rows all still pass, because the
labels still come from `h/frame` and only the capture was locked. That is exactly
why the row clicks both crossings rather than one.

Reverted, recompiled, re-ran: `Ran 11 tests containing 53 assertions. 0 failures,
0 errors.` — runner exit **0**.

GitHub Actions is in a major outage with webhooks throttled, so these local exit
codes are the record.

Closes `rf2-zllp8`.
