### PR TITLE
fix(xray): activate the reaction before watching it, and correct the comment that caused this (rf2-lynzk)

### DIFF
--- a/tools/xray/spec/016-Auxiliary-Panels.md
+++ b/tools/xray/spec/016-Auxiliary-Panels.md
@@ -675,11 +675,29 @@ nil and `(add-watch nil …)` would throw; the frame-presence guard
 makes the early call safe and the watcher lands on first frame
 registration. Detached on flip-off.
 
+**Activation (rf2-lynzk).** The install MUST put the subscription on the
+substrate's push path — `re-frame.interop/activate-derived-value!` — as
+its FIRST act, before the baseline seed and before `add-watch`. A
+subscription is **not** already live the instant `subscribe` returns.
+On the ratom family (Reagent, reagent-slim) a subscription IS a bare
+`reagent.ratom/Reaction`, built deliberately without `:auto-run`, and a
+Reaction learns its sources ONLY through `deref-capture`; a plain deref
+taken outside `*ratom-context*` runs the body raw and leaves the
+reaction watching nothing. The `add-watch` then records a callback that
+cannot fire, and auto-open-on-error never fires at all — silently, and
+only on those adapters, while this section promises the behaviour
+unconditionally. `:rf.xray/issues-ribbon` is a SIGNAL with no rendered
+consumer (see [`018-Event-Spine.md` §5.4](./018-Event-Spine.md)), so no
+component render supplies the capture context that hides this defect
+elsewhere. The op is a no-op on adapters already push-based from birth
+and idempotent on an already-activated reaction. Same law, same fix
+order (activate → seed → watch) as the framework's own observation port.
+
 **Baseline seeding (rf2-8i1tg3).** The edge-detector's baseline count
 MUST be seeded from the reaction's value AT INSTALL TIME, before
-`add-watch` — a reaction is already live the instant `subscribe`
-returns (e.g. a re-install after a focus-nav that already landed on an
-issue-carrying epoch), so `add-watch` only fires on the NEXT change.
+`add-watch` — the reaction may already hold issues that predate the
+install (e.g. a re-install after a focus-nav that already landed on an
+issue-carrying epoch), and `add-watch` only fires on the NEXT change.
 Leaving the baseline at its cold-start default of zero misclassifies
 that pre-existing non-empty state as the empty→non-empty edge on the
 first subsequent change, spuriously auto-opening Xray for an epoch the

--- a/tools/xray/src/day8/re_frame2_xray/settings/effects.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/effects.cljs
@@ -68,6 +68,7 @@
   (:require [goog.object :as gobj]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.theme.tokens :as tokens]))
 
@@ -617,16 +618,43 @@
                            ;; would revert a hidden overlay to inline. See
                            ;; `reopen-preserving-surface!`'s docstring.
                            (reopen-preserving-surface!))))]
+        ;; ACTIVATE, then seed, then watch — and the activation is the
+        ;; whole fix for rf2-lynzk (the same defect shape as rf2-8cnxg,
+        ;; repaired in `re-frame.substrate.observation/build-node-handle!`
+        ;; — see its comment for the canonical statement of this order).
+        ;;
+        ;; This call used to be absent, on the stated premise that "a
+        ;; reagent/re-frame reaction is already live the instant
+        ;; `subscribe` returns". That premise is FALSE on the ratom
+        ;; family, and silently so. Under those adapters the subscription
+        ;; IS a bare `reagent.ratom/Reaction`, built deliberately WITHOUT
+        ;; `:auto-run`, and a Reaction learns its sources ONLY through
+        ;; `deref-capture`. The plain `@reaction` below is taken outside
+        ;; `*ratom-context*`, so it runs the body raw and leaves
+        ;; `watching` nil — the node is in nobody's watcher set, the
+        ;; `add-watch` records a callback that can never fire, and
+        ;; auto-open-on-error never fires at all. Watchable, watched,
+        ;; silent. A Reagent COMPONENT never hits this because its render
+        ;; IS the capture context; `:rf.xray/issues-ribbon` is a SIGNAL
+        ;; with no rendered consumer anywhere (panels.cljs §Issues), so
+        ;; nothing but this call supplies one.
+        ;;
+        ;; `interop/activate-derived-value!` is the substrate's own "put
+        ;; this derived value on your push path" op: a no-op on hosts that
+        ;; are push-based from birth (the React-hook spine — UIx, Helix,
+        ;; re-frame.ui, Freehand) and on plain-atom, and idempotent on an
+        ;; already-capturing reaction. It runs FIRST so the seed below
+        ;; reads a settled node.
+        (interop/activate-derived-value! reaction)
         ;; Seed the baseline from the reaction's CURRENT value before
-        ;; `add-watch` — a reagent/re-frame reaction is already live the
-        ;; instant `subscribe` returns (it may have run against issues
-        ;; that predate this install, e.g. re-install after a focus nav
-        ;; that already landed on an issue-carrying epoch). `add-watch`
-        ;; only fires on the NEXT change, so leaving `last-issue-count`
-        ;; at its `defonce` 0 misclassifies that pre-existing non-empty
-        ;; state as the empty->non-empty edge on the first subsequent
-        ;; change, spuriously auto-opening Xray. Seeding here makes the
-        ;; watcher's edge detection start from the true "now", matching
+        ;; `add-watch` — the reaction may hold issues that predate this
+        ;; install (e.g. re-install after a focus nav that already landed
+        ;; on an issue-carrying epoch). `add-watch` only fires on the NEXT
+        ;; change, so leaving `last-issue-count` at its `defonce` 0
+        ;; misclassifies that pre-existing non-empty state as the
+        ;; empty->non-empty edge on the first subsequent change,
+        ;; spuriously auto-opening Xray. Seeding here makes the watcher's
+        ;; edge detection start from the true "now", matching
         ;; xray/016-Auxiliary-Panels §Auto-open-on-error (first
         ;; empty->non-empty only).
         (reset! last-issue-count (count (:issues @reaction)))

--- a/tools/xray/test/day8/re_frame2_xray/settings/auto_open_watcher_activates_ratom_node_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/auto_open_watcher_activates_ratom_node_cljs_test.cljs
@@ -1,0 +1,175 @@
+(ns day8.re-frame2-xray.settings.auto-open-watcher-activates-ratom-node-cljs-test
+  "rf2-lynzk — `install-auto-open-watcher!` puts its `:rf.xray/issues-ribbon`
+  subscription on the substrate's PUSH path ITSELF, so auto-open-on-error
+  actually fires on the ratom family.
+
+  THE DEFECT THIS PINS. The installer did `subscribe` → plain deref →
+  `add-watch`, on the stated premise that \"a reagent/re-frame reaction is
+  already live the instant `subscribe` returns\". On the ratom family that is
+  false, and silently so: the subscription IS a bare Reaction, built WITHOUT
+  `:auto-run`, and a Reaction learns its sources only through `deref-capture`.
+  A plain deref taken outside `*ratom-context*` runs the body raw and leaves
+  `watching` nil — the node is in nobody's watcher set, so the installed
+  `add-watch` records a callback that CANNOT fire. Xray never auto-opened on
+  the first error under Reagent / reagent-slim, and nothing said so.
+
+  WHY NO SUITE SAW IT. `:rf.xray/issues-ribbon` is a SIGNAL, never a rendered
+  value (`panels.cljs` §Issues: there is no Issues tab), so no component render
+  ever supplies it a capture context — the one thing that hides this defect
+  everywhere else. The sibling suite (`settings.effects-cljs-test`) runs the
+  headless plain-atom adapter, whose derived subscriptions are not `IWatchable`
+  at all, and drives the watch fn DIRECTLY. Calling the watch fn by hand is
+  precisely what cannot see this: everything looks correct until a CHANGE has
+  to propagate.
+
+  So this file installs a ratom-family adapter (reagent-slim — the adapter
+  Xray's own `deps.edn` declares) and drives the whole production path: the
+  real `install-auto-open-watcher!`, the real `add-watch` on the real reaction,
+  and a real app-db write that must reach it.
+
+  Node, no DOM: the claim is about the notification channel, not about a
+  render. Template: `re-frame.observation-port-activates-ratom-node-cljs-test`,
+  the same proof for the observation port (rf2-8cnxg)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent2.ratom :as ratom]
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
+            [re-frame.core :as rf]
+            [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.settings.effects :as effects]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(use-fixtures :each
+  ;; A RATOM-family adapter, deliberately — the plain-atom default the rest of
+  ;; the Xray suite uses is exactly the substrate on which this defect is
+  ;; invisible. `:runtime` clears the persisted settings so the
+  ;; `:auto-open-on-error?` flips below start from the shipped default.
+  (xray-test-support/make-xray-runtime-fixture
+    {:adapter    reagent-slim-adapter/adapter
+     :tier       :runtime
+     :post-reset (fn [] (effects/detach-auto-open-watcher!))}))
+
+;; ---- the issues feed, driven through app-db ------------------------------
+;;
+;; `:rf.xray/issues-ribbon` joins `:rf.xray/focus` against
+;; `:rf.xray/epoch-history` and projects the focused epoch's `:trace-events`
+;; into the issue subset. `:rf.xray/sync-epoch-history` writes the history
+;; slot AND focuses the head epoch, so one dispatch is a complete, ordinary
+;; app-db write of the kind the production feed makes.
+
+(defn- quiet-epoch
+  "An epoch whose trace carries no issue — the ribbon reads `:issues []`."
+  [epoch-id]
+  {:epoch-id     epoch-id
+   :trace-events [{:id 0 :time 0 :op-type :rf.event :operation :app/anything}]})
+
+(defn- error-epoch
+  "An epoch carrying one `:error` trace event — the ribbon reads one issue."
+  [epoch-id]
+  {:epoch-id     epoch-id
+   :trace-events [{:id        1
+                   :time      0
+                   :op-type   :error
+                   :operation :rf.error/handler-exception
+                   :tags      {:reason "boom"}}]})
+
+(defn- sync-history! [history]
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/sync-epoch-history history])))
+
+(defn- setup! []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray}))
+
+;; ---- the mount surface the watcher reopens through -----------------------
+
+(defn- with-hidden-shell-exports
+  "Stand the browser API exports the preload installs, with `status`
+  reporting a HIDDEN shell (the auto-open precondition) and each reopen
+  export recording its own name. Calls `(f invoked-atom)`."
+  [f]
+  (let [invoked     (atom [])
+        had-window? (exists? js/globalThis.window)
+        record      (fn [nm] (fn [] (swap! invoked conj nm) nil))]
+    (when-not had-window?
+      (set! (.-window js/globalThis) #js {}))
+    (let [win js/globalThis.window]
+      (set! (.-day8 win)
+            #js {"re_frame2_xray"
+                 #js {"open_BANG_"         (record "open_BANG_")
+                      "open_overlay_BANG_" (record "open_overlay_BANG_")
+                      "toggle_BANG_"       (record "toggle_BANG_")
+                      "status"             (fn [] #js {"visible?" false})}})
+      (try
+        (f invoked)
+        (finally
+          (js-delete win "day8")
+          (when-not had-window?
+            (js-delete js/globalThis "window")))))))
+
+(defn- install-watcher! []
+  (effects/detach-auto-open-watcher!)
+  (effects/install-auto-open-watcher!)
+  ;; The reaction the installer actually watched — the object under test.
+  @@#'effects/auto-open-watcher)
+
+;; ===========================================================================
+
+(deftest auto-open-on-error-fires-through-the-real-watch-on-a-ratom-substrate
+  (testing "the installed watcher hears a real app-db write: on the
+            empty → non-empty issue edge, with the toggle on and the shell
+            hidden, Xray reopens. Before rf2-lynzk the watch was held on a
+            node that could not notify, so this never happened at all"
+    (setup!)
+    (config/update-setting! :general :auto-open-on-error? true)
+    ;; Baseline — a focused epoch that carries NO issues, so the installer
+    ;; seeds `last-issue-count` at 0 and the next write is a genuine edge.
+    (sync-history! [(quiet-epoch 1)])
+    (with-hidden-shell-exports
+      (fn [invoked]
+        (let [reaction (install-watcher!)]
+          (is (some? reaction)
+              "precondition — the watcher installed and holds the reaction")
+          (is (satisfies? IWatchable reaction)
+              "precondition — the node IS watchable, so a silent channel here
+               is the installer's fault and not the host's")
+          (is (some? (.-watching reaction))
+              "the install ACTIVATED the node: it is subscribed to its
+               sources. Before rf2-lynzk this was nil — watchable, watched,
+               and unable to notify")
+          (is (empty? @invoked)
+              "activation itself reopened nothing")
+
+          ;; The edge, driven the way production drives it.
+          (sync-history! [(quiet-epoch 1) (error-epoch 2)])
+          (ratom/flush!)
+
+          (is (= ["toggle_BANG_"] @invoked)
+              "the write reached the watch and Xray reopened — through the
+               surface-preserving `toggle!` route (rf2-kggzi4), once")
+
+          ;; …and the edge is still an EDGE on the now-live channel.
+          (sync-history! [(quiet-epoch 1) (error-epoch 2) (error-epoch 3)])
+          (ratom/flush!)
+
+          (is (= ["toggle_BANG_"] @invoked)
+              "a second, non-empty → non-empty push is not the edge: the
+               live channel did not reopen again"))))))
+
+(deftest the-toggle-still-gates-the-now-live-channel
+  (testing "activation puts the node on the push path; it must not make the
+            reopen unconditional. With `:auto-open-on-error?` OFF the same
+            write reaches the same live watch and nothing opens"
+    (setup!)
+    (config/update-setting! :general :auto-open-on-error? false)
+    (sync-history! [(quiet-epoch 1)])
+    (with-hidden-shell-exports
+      (fn [invoked]
+        (let [reaction (install-watcher!)]
+          (is (some? (.-watching reaction))
+              "precondition — the channel is live, so the silence below is a
+               gate and not a dead watch")
+          (sync-history! [(quiet-epoch 1) (error-epoch 2)])
+          (ratom/flush!)
+          (is (empty? @invoked)
+              "toggle off → no reopen, even on the edge"))))))

--- a/tools/xray/test/day8/re_frame2_xray/settings/effects_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/effects_cljs_test.cljs
@@ -217,11 +217,14 @@
 ;; We unit-test that helper's routing directly (mirroring how
 ;; mount_cljs_test's `toggle!-*` suite unit-tests the mount layer's own
 ;; surface preservation): the auto-open GATE — the empty→non-empty edge +
-;; toggle-on + hidden — is covered by the watcher tests above. Note the
-;; full `install-auto-open-watcher!` `add-watch` path can't be driven
-;; under this suite's headless plain-atom adapter (its derived
-;; subscriptions reify `IDeref`/`IDisposable` only, not `IWatchable`);
-;; that reactive glue is exercised in the browser suites.
+;; toggle-on + hidden — is covered by the watcher tests above. The full
+;; `install-auto-open-watcher!` `add-watch` path can't be driven under THIS
+;; suite's headless plain-atom adapter (its derived subscriptions reify
+;; `IDeref`/`IDisposable` only, not `IWatchable`), and the claim that "the
+;; browser suites exercise that reactive glue" was false — no suite did, which
+;; is how rf2-lynzk (the missing `activate-derived-value!`) survived. It is now
+;; pinned on a ratom-family adapter, in this same directory:
+;; `settings.auto-open-watcher-activates-ratom-node-cljs-test`.
 
 (defn- with-recording-mount-exports
   "Install a stub `window.day8.re_frame2_xray` whose mount exports each


### PR DESCRIPTION
Fourth occurrence of the rf2-8cnxg defect shape. `install-auto-open-watcher!`
did `subscribe` → plain deref → `add-watch`, with **no activation**.

Under the ratom family (Reagent, reagent-slim) a subscription **is** a bare
`reagent.ratom/Reaction`, built deliberately without `:auto-run`, and a
Reaction learns its sources only through `deref-capture`. The plain deref is
taken outside `*ratom-context*`, so it runs the body raw and leaves `watching`
nil — the node is in nobody's watcher set, the `add-watch` records a callback
that can never fire, and **auto-open-on-error never fires at all**. Watchable,
watched, silent. `:rf.xray/issues-ribbon` is a SIGNAL with no rendered consumer
anywhere (`panels.cljs` §Issues), so no component render ever supplies the
capture context that hides this defect elsewhere.

The fix is one call, in the order `re-frame.substrate.observation/build-node-handle!`
states as the whole fix for rf2-8cnxg (`observation.cljc:1959-1982` — verified,
ACTIVATE → watch → observe):

```clojure
(interop/activate-derived-value! reaction)      ; <- added
(reset! last-issue-count (count (:issues @reaction)))
(add-watch reaction ::auto-open-on-error watch-fn)
```

`re-frame.interop` is already required by six other `tools/xray/src` namespaces;
the edge runs tools → implementation, which is the permitted direction (nothing
under `implementation/` requires `tools/`; the bundle-isolation gate below
confirms it).

### The false comment

The comment at the old `:621` stated the premise the bug was written from,
verbatim: *"a reagent/re-frame reaction is already live the instant `subscribe`
returns"*. It is replaced with the actual law — a Reaction learns its sources
only through `deref-capture` and must be activated first — so the next reader is
not re-taught the falsehood. The baseline-seeding rationale is kept, re-justified
on the ground that actually holds (the reaction may hold issues that predate the
install).

### `tools/xray/spec/*` — UPDATED

`016-Auxiliary-Panels.md` §Auto-open-on-error semantics carried the same false
sentence NORMATIVELY, inside **Baseline seeding (rf2-8i1tg3)**. A new
**Activation (rf2-lynzk)** paragraph states the requirement and its order; the
seeding paragraph's justification is corrected. No behavioural promise changed —
the spec already promised auto-open unconditionally; the code was the
non-conformant party.

Anchors/links: the one added link (`./018-Event-Spine.md`, no fragment) matches
the file's five existing references to that document, and `tools/*/spec` is in
`scripts/check_doc_slugs.py`'s roots, which the fast-PR spine runs. No tables
touched.

### The test

`tools/xray/test/day8/re_frame2_xray/settings/auto_open_watcher_activates_ratom_node_cljs_test.cljs`
installs the **reagent-slim** adapter (the ratom-family adapter Xray's own
`deps.edn` declares) and drives the whole production path: the real
`install-auto-open-watcher!`, its real `add-watch` on the real reaction, and a
real app-db write (`:rf.xray/sync-epoch-history`) that must reach it. Modelled on
`re-frame.observation-port-activates-ratom-node-cljs-test`.

The sibling suite's deferral comment — "that reactive glue is exercised in the
browser suites" — was false; no suite carried it, which is how this survived.
That comment now points at this file.

#### Red then green (demonstrated, not asserted)

Same bundle, same runner, only the one call removed:

| | command | exit | result |
|---|---|---|---|
| WITHOUT the fix | `node out/node-test.js --test=day8.re-frame2-xray.settings.auto-open-watcher-activates-ratom-node-cljs-test` | **1** | 2 tests / 8 assertions, **4 failures** |
| WITH the fix | same | **0** | 2 tests / 8 assertions, **0 failures** |

The load-bearing red assertion is not the white-box one — it is
`expected: (= ["toggle_BANG_"] @invoked) / actual: (not (= ["toggle_BANG_"] []))`:
the error landed, the watch was installed, and Xray did not reopen.

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/xrayact-lynzk`, foreground, each
redirected to a worktree-local log with the runner's own exit code echoed.

| gate | command | exit | result |
|---|---|---|---|
| xray CLJS (focused, WITH fix) | `node out/node-test.js --test=…auto-open-watcher-activates-ratom-node-cljs-test` | 0 | 2 tests, 8 assertions, 0 failures |
| xray CLJS (focused, WITHOUT fix) | same, activation removed | 1 | 4 failures — the red demonstration |
| full CLJS node-test | `npm run test:cljs` | 0 | **12750 tests, 63996 assertions, 0 failures, 0 errors** |
| xray artefact JVM | `cd tools/xray && clojure -M:test` | 0 | **1272 tests, 5919 assertions, 0 failures, 0 errors** |
| bundle isolation | `npm run test:bundle-isolation` | 0 | PASS ×4 — 23 artefacts, 39 sentinels absent, 39 positive-control sentinels present |
| fast-PR spine | `sh scripts/test-fast-pr.sh` | 0 | **PASS fast PR spine** — static/drift checks, docs tier (`mkdocs build --strict`, doc-slug/anchor validators), node tier (12750 tests / 63996 assertions / 0 failures + per-ns isolation gate) |

Spine tiering note: it reported `implementation_jvm surface unchanged → skipping
JVM artefact suites` — correct, this diff touches only `tools/`. The xray
artefact's own JVM suite was therefore run explicitly (row above).

Closes rf2-lynzk.
