### PR TITLE
fix(machines): the timer must activate its delay Reaction before watching it (rf2-wmpte)

### DIFF
--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -36,6 +36,7 @@
   already emitted `:rf.machine.timer/skipped-on-server` in place of
   /scheduled."
   (:require [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.machines.paths :as paths]
             [re-frame.machines.reply :as m-reply]
@@ -661,6 +662,37 @@
                     ;; `add-watch` failed, so the author needs a signal the
                     ;; dynamic-delay subscription is not actually wired up.
                     (try
+                      ;; ACTIVATE, then watch — the order is the whole fix for
+                      ;; rf2-wmpte, and it mirrors
+                      ;; `re-frame.substrate.observation/build-node-handle!`
+                      ;; (rf2-8cnxg / rf2-jt8vz).
+                      ;;
+                      ;; `resolve-delay-ms`'s "subscribe to keep the reaction
+                      ;; live" is FALSE on the ratom family, and silently so. A
+                      ;; `reagent.ratom/Reaction` learns its sources ONLY through
+                      ;; `deref-capture`; the plain `deref` `resolve-delay-ms`
+                      ;; takes runs outside `*ratom-context*` with no `auto-run`,
+                      ;; so it runs the body raw and leaves `watching` nil. The
+                      ;; node is then in no source's watcher set: `_handle-change`
+                      ;; is never called, `_queued-run` short-circuits on
+                      ;; `(some? watching)`, and the `add-watch` below RECORDS a
+                      ;; callback that can never fire. The first arming resolved
+                      ;; correctly and the dynamic delay then never re-resolved
+                      ;; for the rest of the arming's life — no trace, no error.
+                      ;;
+                      ;; A Reagent COMPONENT never hits this because its render
+                      ;; IS the capture context; a timer is not a component, so
+                      ;; nothing but this call supplies one. It runs BEFORE
+                      ;; `add-watch` so activation's own first recompute cannot
+                      ;; fan a priming change at this watcher. Total and
+                      ;; idempotent: the React-hook spine (UIx / Helix /
+                      ;; re-frame.ui / Freehand) is push-based from birth and
+                      ;; publishes no hook, so the routed chain-bottom returns
+                      ;; nil; plain-atom / JVM derived values have no capture
+                      ;; step. A throw here lands on the same
+                      ;; `:recovery :static-delay` signal as a failed
+                      ;; `add-watch` — both mean the dynamic delay is not wired.
+                      (interop/activate-derived-value! reaction)
                       (add-watch reaction watch-key
                                  (fn [_ _ old-v new-v]
                                    (on-sub-changed! frame-id parent-id invoke-id

--- a/implementation/machines/test/re_frame/after_dynamic_delay_reresolve_ratom_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/after_dynamic_delay_reresolve_ratom_cljs_test.cljs
@@ -1,0 +1,173 @@
+(ns re-frame.after-dynamic-delay-reresolve-ratom-cljs-test
+  "rf2-wmpte — a machine's `:after [sub-vec]` dynamic delay RE-RESOLVES on the
+  ratom family, driven by nothing but the timer's own wiring.
+
+  THE DEFECT THIS PINS. `re-frame.machines.timer` resolved a sub-vec delay by
+  `subs/subscribe` → plain `@reaction` → `add-watch`, on the stated premise
+  that the subscribe \"keeps the reaction live\". On the ratom family that is
+  false, and silently so: a subscription IS a bare `reagent.ratom/Reaction`,
+  built deliberately WITHOUT `:auto-run`, and a Reaction learns its sources
+  only through `deref-capture`. The plain deref runs outside `*ratom-context*`,
+  so it runs the body raw and leaves `watching` nil — the node sits in no
+  source's watcher set, `_handle-change` is never called, `_queued-run`
+  short-circuits on `(some? watching)`, and even `reagent.core/flush` moves
+  nothing. The `add-watch` RECORDED a callback that could not fire.
+
+  Observably: the first arming resolved correctly and the delay then never
+  re-resolved for the rest of that arming's life. No trace, no error. Spec 005
+  §Delayed `:after` transitions and `docs/api/re-frame.machines.md` promise the
+  re-resolution unconditionally. The fix is the observation port's
+  (`re-frame.substrate.observation/build-node-handle!`, rf2-8cnxg): ACTIVATE,
+  then watch.
+
+  WHY NO SUITE SAW IT — the untested-combination axis. Every CLJS timer suite
+  that drives a dynamic delay installs plain-atom and, KNOWING a plain-atom
+  derived value does not push, `with-redefs`es a plain controllable atom in
+  place of the reaction (`after_fire_reap_cljs_test.cljc` says so in its own
+  header). A plain atom always notifies: the substitution that makes those
+  tests deterministic is the substitution that makes them blind. So this file
+  stubs the HOST CLOCK and nothing else — `subs/subscribe` is the real one and
+  the reaction under the watch is the real cached subscription node, because
+  the stand-in is precisely what hid the bug.
+
+  CLJS-only (the ratom family is CLJS); the `-cljs-test` ns suffix enrols it in
+  the consolidated `:node-test` build. No DOM and no React are needed — the
+  claim is about a notification channel, not a render."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent.ratom :as ratom]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.core :as rf]
+            [re-frame.interop :as interop]
+            ;; Loading `re-frame.machines` installs the machines-artefact
+            ;; late-bind hooks (`reg-machine`, `reset-timers!`); under a
+            ;; single-ns run nothing else pulls it in.
+            [re-frame.machines]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.machines.timer :as timer]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter reagent-adapter/adapter})
+  mtest/trace-capture-fixture)
+
+(defn- live-entry
+  "The `:rf/default` frame's single live `:after` timer entry, or nil."
+  []
+  (first (vals (get @timer/after-timers :rf/default {}))))
+
+;; White-box, and only ever CORROBORATING: `watching` is the Reagent field that
+;; says \"this reaction is subscribed to its sources\". Read against anything
+;; that is not a Reaction it would go vacuously nil, so every arm that consults
+;; it also asserts the behaviour it is there to explain.
+(defn- capturing? [rx]
+  (some? (.-watching rx)))
+
+(defn- register-dynamic-delay-machine! []
+  (rf/reg-event :dyn/set-ms (fn [{:keys [db]} [_ ms]] {:db (assoc db :ms ms)}))
+  (rf/reg-event :dyn/set-other (fn [{:keys [db]} [_ v]] {:db (assoc db :other v)}))
+  (rf/reg-sub :dyn/ms (fn [db _] (:ms db)))
+  (rf/reg-machine :dyn/timer
+                  {:initial :idle
+                   :data    {}
+                   :states  {:idle    {:on {:go :running}}
+                             :running {:after {[:dyn/ms] :expired}}
+                             :expired {}}}))
+
+;; ===========================================================================
+;; the regression
+;; ===========================================================================
+
+(deftest dynamic-after-delay-re-resolves-when-the-delay-sub-moves
+  (testing "a machine armed on `:after {[:dyn/ms] …}` cancels and re-arms at
+            the NEW duration every time the delay subscription moves — with a
+            REAL subscription node under the watch, on the Reagent adapter"
+    (register-dynamic-delay-machine!)
+    (rf/dispatch-sync [:dyn/set-ms 5000])
+    (let [arms (atom [])]
+      ;; The HOST CLOCK is the only thing stubbed: record each arm's duration
+      ;; and hand back an opaque sentinel instead of a real setTimeout handle.
+      ;; `managed-timer/cancel!` swallows throws, so the sentinel is safe on
+      ;; the cancellation path.
+      (with-redefs [interop/schedule-after!
+                    (fn [_thunk ms] (swap! arms conj ms) (js-obj "rf-fake-handle" ms))]
+
+        (rf/dispatch-sync [:dyn/timer [:go]])
+        (is (= :running (mtest/machine-state :dyn/timer))
+            "precondition — entered the `:after`-bearing state")
+        (is (= [5000] @arms)
+            "precondition — armed once, at the delay sub's current value")
+        (is (= 5000 (:resolved-ms (live-entry)))
+            "precondition — the registry entry records that resolution")
+
+        (let [rx (:reaction (live-entry))]
+          (is (some? rx) "precondition — a sub-vec delay holds a reaction")
+          (is (satisfies? IWatchable rx)
+              "precondition — the node IS watchable, so a silent channel here
+               is the timer's fault and not the host's")
+          (is (capturing? rx)
+              "the timer ACTIVATED the delay node before watching it: it is
+               subscribed to its sources. Before rf2-wmpte this was nil —
+               watchable, watched, and unable to notify"))
+
+        ;; ---- the movement the whole bead is about ------------------------
+        (rf/dispatch-sync [:dyn/set-ms 9000])
+        (ratom/flush!)
+
+        (is (= [5000 9000] @arms)
+            "THE REGRESSION — the delay sub moved, so the timer cancelled and
+             re-armed at the new duration. Before the fix this stayed [5000]:
+             the watch was recorded on a node that could never fire")
+        (is (= 9000 (:resolved-ms (live-entry)))
+            "…and the live registry entry carries the re-resolved duration")
+        (is (some #(= :on-resolution (:reason (:tags %)))
+                  (mtest/events-of :rf.machine.timer/cancelled))
+            "the cancellation was traced with `:reason :on-resolution` — the
+             re-resolution path ran, not some other cancel")
+
+        ;; ---- and again, because the re-arm builds a FRESH node ------------
+        ;; `on-sub-changed!` cancels (dropping the held subscription ref-count,
+        ;; which disposes the reaction) before rescheduling, so the second
+        ;; arming subscribes anew. The activation must therefore happen at
+        ;; EVERY arming, not once at birth.
+        (let [rx2 (:reaction (live-entry))]
+          (is (capturing? rx2)
+              "the RE-ARMED node is on the push path too — activation lives on
+               the arming path, so it covers the reschedule as well as birth"))
+
+        (rf/dispatch-sync [:dyn/set-ms 12000])
+        (ratom/flush!)
+
+        (is (= [5000 9000 12000] @arms)
+            "a second move re-resolves as well — one activated arming does not
+             buy the next one's channel")
+        (is (= 12000 (:resolved-ms (live-entry))))))))
+
+;; ===========================================================================
+;; the negative control — activation must not make the channel chatty
+;; ===========================================================================
+
+(deftest a-write-that-does-not-move-the-delay-does-not-re-arm
+  (testing "activation puts the node on the push path; it must not turn every
+            app-db write into a cancel-and-reschedule"
+    (register-dynamic-delay-machine!)
+    (rf/dispatch-sync [:dyn/set-ms 5000])
+    (let [arms (atom [])]
+      (with-redefs [interop/schedule-after!
+                    (fn [_thunk ms] (swap! arms conj ms) (js-obj "rf-fake-handle" ms))]
+        (rf/dispatch-sync [:dyn/timer [:go]])
+        (is (= [5000] @arms) "precondition — one arming")
+
+        (rf/dispatch-sync [:dyn/set-ms 5000])
+        (ratom/flush!)
+        (is (= [5000] @arms)
+            "an equal re-write moved nothing, so nothing re-armed")
+
+        (rf/dispatch-sync [:dyn/set-other :anything])
+        (ratom/flush!)
+        (is (= [5000] @arms)
+            "a write to a key this delay sub does not read moved nothing")
+
+        (testing "positive control — the channel really is armed, so the two
+                  silences above are silences and not a dead watch"
+          (rf/dispatch-sync [:dyn/set-ms 7000])
+          (ratom/flush!)
+          (is (= [5000 7000] @arms)))))))


### PR DESCRIPTION
Closes rf2-wmpte. The third occurrence of the rf2-8cnxg defect shape, after the
observation port (rf2-8cnxg / rf2-jt8vz) and hicasso Arm 1 (rf2-2kshh).

## The defect

`re-frame.machines.timer` resolved a sub-vector `:after` delay by
`subs/subscribe` → plain `@reaction` → `add-watch`, on the premise its own
comment stated: *"subscribe to keep the reaction live"*. On the ratom family
that premise is false, and silently so. A subscription **is** a bare
`reagent.ratom/Reaction`, built deliberately without `:auto-run`, and a Reaction
learns its sources only through `deref-capture`. The deref `resolve-delay-ms`
takes runs outside `*ratom-context*`, so it runs the body raw and leaves
`watching` nil — the node sits in no source's watcher set, `_handle-change` is
never called, `_queued-run` short-circuits on `(some? watching)`, and the
`add-watch` records a callback that cannot fire.

Observably: a machine's `:after [sub-vec]` dynamic delay armed its **first**
resolution correctly and then never re-resolved for the rest of that arming's
life. No trace, no error. Spec 005 §Delayed `:after` transitions and
`docs/api/re-frame.machines.md` promise the re-resolution unconditionally.
Correct already on the React-hook spine (UIx / Helix / re-frame.ui / Freehand),
which is push-based from birth; loud on plain-atom, where `add-watch` throws and
the existing `:rf.error/machine-after-watch-failed` / `:recovery :static-delay`
path fires. The ratom family was the only substrate where it was silently wrong.

## The fix — one call plus a require

`implementation/machines/src/re_frame/machines/timer.cljc`: add
`[re-frame.interop :as interop]` to the ns requires, and call
`(interop/activate-derived-value! reaction)` immediately **before** the
`add-watch` in `schedule-after-timer!`, inside the existing `try`. Total and
idempotent: the React-hook spine publishes no hook so the routed chain-bottom
returns nil, and the ratom impls no-op on an already-capturing Reaction. A throw
lands on the same `:recovery :static-delay` signal a failed `add-watch` already
had — both mean the same thing, the dynamic delay is not wired.

**Ordering, checked against the canonical site rather than assumed.**
`re-frame.substrate.observation/build-node-handle!`
(`implementation/core/src/re_frame/substrate/observation.cljc:1959-1990`) states
the rule as *"ACTIVATE, then watch, then observe — and the order is the whole fix
for rf2-8cnxg"*, and gives two reasons: activate **before** `add-watch` so
activation's own first recompute cannot fan a priming notification at the
handle, and before the baseline observe so the observe reads a settled node.

The timer's structure forces the deref earlier than the watch — `resolve-delay-ms`
must return the resolved ms so `managed-timer/arm!` can arm the host clock, and
only the surviving publish attempt installs the watch. The load-bearing half of
the rule is preserved exactly: activation runs strictly before `add-watch`, so
the watch is installed on a node that is already capturing and cannot receive a
priming change. The baseline read is a raw run of the same pure subscription body
and returns the same value the activation's capture run does — the red run below
shows it: the reverted reaction reads `{:val 5000}`, the correct value, with
`watching` nil. Nothing needs a second call site: `schedule-after-timer!` is the
only place a watch is attached, and `on-sub-changed!` re-enters it, so one
insertion covers birth **and** every reschedule. The added test asserts that
second property directly.

`spec/*` unchanged: no normative surface moves — Spec 005 already promises this
behaviour, the implementation now delivers it.

## The test

New: `implementation/machines/test/re_frame/after_dynamic_delay_reresolve_ratom_cljs_test.cljs`
(CLJS-only; the `-cljs-test` ns suffix enrols it in the consolidated `:node-test`
build — no DOM and no React, the claim is about a notification channel).

**Why no suite saw this.** Every existing CLJS timer suite that drives a dynamic
delay installs plain-atom and, knowing a plain-atom derived value does not push,
`with-redefs`es a plain controllable atom in place of the reaction —
`after_fire_reap_cljs_test.cljc:16-19` says so in its own header. A plain atom
always notifies: the substitution that makes those tests deterministic is the
substitution that makes them blind. And `machines_after_cljs_test.cljs`'s
sub-delay arm asserts only the **first** `:scheduled` trace, which was always
correct. So this file stubs the **host clock** and nothing else — `subs/subscribe`
is the real one and the node under the watch is the real cached subscription.

Two arms:

- `dynamic-after-delay-re-resolves-when-the-delay-sub-moves` — arm on
  `:after {[:dyn/ms] :expired}` at 5000, move the sub to 9000, then to 12000;
  assert each move cancels and re-arms at the new duration, that the live
  `after-timers` entry carries the re-resolved `:resolved-ms`, and that the
  cancellation is traced `:reason :on-resolution`. Because `on-sub-changed!`
  cancels (dropping the ref-count, disposing the reaction) before rescheduling,
  the second move exercises a **fresh** reaction — which is what proves the
  activation belongs on the arming path and not at birth. A corroborating
  white-box `capturing?` read backs each behavioural claim.
- `a-write-that-does-not-move-the-delay-does-not-re-arm` — the negative control.
  Activation must not make the channel chatty: an equal re-write and a write to
  a key the delay sub does not read must re-arm nothing, with a positive control
  behind them so the two silences are silences and not a dead watch.

## Red, then green

Reverting the single `(interop/activate-derived-value! reaction)` line (the test
file untouched) and re-running `npm run test:cljs`:

```
Ran 12750 tests containing 64004 assertions.
8 failures, 0 errors.          exit 1
```

All 8 failures are in the new namespace; **nothing else in the 12750-test suite
moved**. The four that carry the diagnosis:

```
FAIL (…:106) expected: (capturing? rx)
     actual: (not (capturing? #object[reagent.ratom.Reaction {:val 5000}]))
```
— the node holds the right value from the raw deref and is subscribed to nothing.

```
FAIL (…:115) expected: (= [5000 9000] @arms)
     actual: (not (= [5000 9000] [5000]))
FAIL (…:119) expected: (= 9000 (:resolved-ms (live-entry)))
     actual: (not (= 9000 5000))
FAIL (…:121) expected: (some … (mtest/events-of :rf.machine.timer/cancelled))
     actual: (not (some #object[Function] []))
```
— the delay moved, the timer did not: no re-arm, the entry keeps the stale
duration, and not a single cancellation trace was emitted. Exactly the silent
failure the bead describes.

Restoring the line and re-running gives `0 failures, 0 errors`, exit 0 (below).

## Quality gates

All run foreground to completion from the worker worktree
`C:/Users/miket/code/re-frame2-worktrees/timeract-wmpte`, output redirected to a
worktree-local log, exit code echoed from the runner itself (never a pipeline).

| Command | Result | Exit |
|---|---|---|
| `cd implementation && npm run test:cljs` (fix in place) | build 2163 files / 0 warnings; **Ran 12750 tests, 64004 assertions — 0 failures, 0 errors** | **0** |
| `cd implementation && npm run test:cljs` (fix reverted — red demo) | **Ran 12750 tests, 64004 assertions — 8 failures, 0 errors**, all in the new ns | **1** |
| `cd implementation/machines && clojure -M:test` | **Ran 1202 tests, 4188 assertions — 0 failures, 0 errors** | **0** |
| `sh scripts/test-fast-pr.sh` (fix restored) | `PASS fast PR spine` — JVM core 2233 tests / 11645 assertions 0F0E; JVM machines 1202 / 4188 0F0E; CLJS node integration **12750 / 64004 0F0E**; per-ns test isolation sweep ok; all repo-wide static/drift checks + self-tests pass | **0** |

The spine's own PASS line names what it did not run: the documentation tier
(surface unchanged), the JVM artefact suites the diff does not touch, and the
browser / prod-elision / bundle-isolation / perf / adapter-smoke / Xray-matrix /
mcp-conformance / tool-JVM lanes (CI only). This change touches one
implementation file and adds one CLJS test file, so none of those surfaces moves.
