### PR TITLE
docs(hicasso): the seam is controlled for, not cancelled by algebra (rf2-es04f, rf2-s6qg4)

### DIFF
--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -1084,13 +1084,42 @@ spreads of 30–45% are ordinary here — this ladder saw 45% in one round of an
 *observation* and not the *load attribution*; the pooled statistic is the one
 §6 quoted and the one this ladder moved a box under without shifting.
 
-The two pages also reach cancellation by different routes, and conflating them
+~~The two pages also reach cancellation by different routes, and conflating them
 would overstate both. The audit's `(U/F) ÷ (R/F) = U/R` is **algebra**, and it
 is exact only where both legs are divided by the *same* floor — the converged
 witness, whose arms share one segment. Here the three segments have three
 different floors, so nothing cancels algebraically; what makes it cancel is the
 measured fact that the perturbation is multiplicative. Same conclusion, and only
-one of the two is free.
+one of the two is free.~~
+
+**WITHDRAWN — the contrast was drawn wrongly on both sides (2026-08-07,
+`rf2-es04f`).** The audit has since withdrawn the identity itself.
+`(U/F) ÷ (R/F) = U/R` holds only where the two `F`s are the *same reading*;
+where each arm is normalised against the floor measured in its own segment the
+identity is `(U/F_U) ÷ (R/F_R) = (U/R) × (F_R/F_U)`, and the floor is not the arm
+that cancels but the arm that contributes a second term
+([the clock behind the published rows §2](the-clock-behind-the-published-rows.md#2-why-the-floor-normalisation-does-not-protect-the-ratio)).
+
+So the exception carved out above is empty. **The converged witness's published
+red zone crosses two segments**, and
+[its own page](p0-converged-witness-set.md#two-estimators-published-together)
+says so outright — *"every threshold above divides one floor-normalised ratio by
+another, so the two segments' floors enter it"* — which is why it publishes a
+floor-free estimator beside every threshold and reports the two together. What
+*does* cancel there is its
+[reactive leg](p0-converged-witness-set.md#the-reactive-leg-from-a-second-author-rf2-2rtt621),
+formed inside one segment of one round from two Reagent arms against a single
+floor reading. One reading, so the algebra is exact — that is the shape the
+sentence above was reaching for, and it is not the shape of a cross-segment row,
+here or there.
+
+And the second route is gone with it: cancellation *"by the measured fact that
+the perturbation is multiplicative"* is precisely what the re-take withdrew a few
+paragraphs up. **Nothing on this page cancels the seam.** What survives is
+weaker: the seam does not track load and does not belong to the segment, so it is
+*controlled for* rather than divided out, and
+[§6.2](#62-what-replaces-it-the-band-a-magnitude-must-clear)'s band — which
+measures what fails to cancel — is what a magnitude is adjudicated against.
 
 ### 6.2 What replaces it: the band a magnitude must clear
 

--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -188,14 +188,22 @@ in one segment would each pay for the other's writes.
 The floor runs in all three: it holds no re-frame state, reads no subscription
 and is untouched by which adapter is installed. Every figure is a ratio to the
 floor measured in **that round of that segment**, so a cross-segment figure is a
-ratio of two floor-normalised ratios with the seam cancelled. That is a weaker
-interleaving than one segment's, and this page says so rather than describing it
-as though it were sample-level. **That the seam cancels is now measured rather
-than asserted** ([§6.1](#61-the-seam-measured-against-load)): the perturbation a
-busy box applies is multiplicative, and a multiplicative perturbation cancels
-exactly. Every row publishes the seam, the null of the seam's own statistic, an
-orthogonal decomposition of where the floor's variation lives, and the **band** a
-magnitude must clear to be one.
+ratio of two floor-normalised ratios ~~with the seam cancelled~~ — **and the two
+floors are two readings, not one, so the seam does not divide out**:
+`(H/F_H) ÷ (R/F_R) = (H/R) × (F_R/F_H)`, and the second term is the seam. That is
+a weaker interleaving than one segment's, and this page says so rather than
+describing it as though it were sample-level. ~~**That the seam cancels is now
+measured rather than asserted**: the perturbation a busy box applies is
+multiplicative, and a multiplicative perturbation cancels exactly.~~
+*(2026-08-07, `rf2-s6qg4`: **withdrawn** —
+[§6.1](#61-the-seam-measured-against-load)'s own banner records the re-take that
+refuted multiplicativity.)* What §6.1 leaves standing is weaker, and is what this
+design actually rests on: **the seam does not track load and is not attributable
+to the segment**, so it is *controlled for* rather than cancelled. Nor is it
+nominal — this page's own seams reach 22–34% on runs 3 and 4. Every row
+publishes the seam, the null of the seam's own statistic, an orthogonal
+decomposition of where the floor's variation lives, and the **band** a magnitude
+must clear to be one.
 
 - **Witness**: the `M1` page — 300 sub-reading boundaries, 901 elements, one
   `[:p0/cell i]` read per boundary. Identical markup on all three substrates,
@@ -895,10 +903,18 @@ earns its place. It refused.
    the *same* floor — identical work, no substrate — read 3.147 / 2.437 /
    2.349 ms across the three segments on run 3's `bulk300`, a **34% spread**,
    against 23% and 22% on the other two bulk rows. The *inference* does not.
-   Floor-normalisation cancels a multiplicative seam and not an additive one,
+   ~~Floor-normalisation cancels a multiplicative seam and not an additive one,
    and [§6.1](#61-the-seam-measured-against-load) measures which this is: it is
-   multiplicative, it cancels exactly, and the seam is not attributable to the
-   segment at all. **The rows are still refused, on grounds 1 and 2 and on the
+   multiplicative, it cancels exactly,~~ *(2026-08-07, `rf2-s6qg4`: the
+   multiplicativity clause is **withdrawn** — §6.1's own banner records the
+   re-take that refuted it, and a seam of this size does not divide out of a
+   cross-segment ratio.)* **The withdrawal stands on its other leg**, which is
+   the one that was never about cancellation:
+   [§6.1](#61-the-seam-measured-against-load)'s relabelling null puts the
+   variation on the **round**, so the seam is not attributable to the
+   segment at all — a spread between three segments' floors is not a property of
+   the segments being compared, and this ground read it as one.
+   **The rows are still refused, on grounds 1 and 2 and on the
    band `rf2-cvvb7` put in this ground's place** — which refuses them on a
    quantity that was measured rather than assumed. A ground is withdrawn here
    because it was shown wrong, which is the only reason a refusal may drop one.
@@ -1377,8 +1393,11 @@ inputs are gone; the durable path starts at the re-run and not before it.
   turns `validation.md`'s assumed *"a margin under 5% is instrument-limited"*
   into a figure each run measures for itself.
 - **One of this page's own refusal grounds was wrong, and a load ladder found
-  it.** The seam does not track load, is not attributable to the segment, and is
-  multiplicative — so it cancels, exactly. The ground is withdrawn and the
+  it.** The seam does not track load and is not attributable to the segment —
+  ~~and is multiplicative, so it cancels, exactly~~ *(2026-08-07, `rf2-s6qg4`:
+  that third clause is **withdrawn**; see
+  [§6.1](#61-the-seam-measured-against-load). The seam is controlled for, not
+  cancelled.)*. The ground is withdrawn and the
   measurement that withdrew it is published beside it. The general lesson is
   cheap and reusable: a max-over-min of three noisy block medians has a long
   right tail, and quoting one without its null invites a reader to treat 6% as a


### PR DESCRIPTION
`docs/design/hicasso/studio/the-candidates-clock.md` asserted, in four places,
that floor-normalisation cancels the segment seam. Its own §6.1 banner has
marked that WITHDRAWN since `rf2-ymi6j`, and the driver carries the withdrawal
at `clock_run.cjs:110` and `:1183`. Only the prose was stale — and it
contradicted itself on the same page.

Two claim shapes are in play and they fail differently:

- **algebra, false**: `(U/F) ÷ (R/F) = U/R` is exact only where the two `F`s are
  the *same reading*. Where each arm is normalised against the floor measured in
  its own segment the identity is `(U/F_U) ÷ (R/F_R) = (U/R) × (F_R/F_U)`. The
  floor is not the arm that cancels; it is the arm that contributes a second
  term. `the-clock-behind-the-published-rows.md` §2 already carries this.
- **empirical, withdrawn**: that floor-normalisation removes a segment-common
  *multiplicative* perturbation. Pure multiplicativity predicts `ctl-2x / floor`
  = 2.00 with no variance; nineteen fresh runs read 1.7138 [1.6228 – 1.8417].
  `the-band-re-calibrated.md` §6 is titled "Multiplicativity is withdrawn".

**No published figure moves.** This page publishes no cross-segment magnitude —
every row is a regime and `ctl-2x` fails — so there is no number for the second
term to corrupt. This is a documentation repair, and nothing here restates,
recomputes or shifts a measured value.

Struck through rather than deleted, per the 2026-08-06 annotate-never-erase
ruling, matching the treatment #7632 gave line 1198.

## The four sites

**`rf2-s6qg4` — three sites** (commit `61b8442`)

1. **§3, the method paragraph.** Was: *"a cross-segment figure is a ratio of two
   floor-normalised ratios with the seam cancelled … the perturbation a busy box
   applies is multiplicative, and a multiplicative perturbation cancels
   exactly."* Now states the two-term identity, strikes the multiplicativity
   clause, and puts in its place what §6.1 actually leaves standing — the seam
   does not track load and is not attributable to the segment, so it is
   *controlled for* rather than cancelled. Notes that the term is not nominal,
   citing this page's own 22–34% seams on runs 3 and 4.
2. **§6, ground 3's explanation.** The *"§6.1 measures which this is: it is
   multiplicative, it cancels exactly"* reason is struck. **Ground 3's
   WITHDRAWAL is unchanged** — it stands on its other leg, the relabelling null
   that puts the variation on the round. Only the reason moves; the rows stay
   refused on grounds 1 and 2 and on the band.
3. **§8, the handoff.** *"…and is multiplicative — so it cancels, exactly"*
   struck; the first two clauses kept verbatim.

**`rf2-es04f` — §6.1's cancellation contrast** (commit `884a9b8`)

The paragraph re-stated the audit's identity as sound somewhere, carved out an
exception for "the converged witness, whose arms share one segment", and closed
by attributing cancellation here to measured multiplicativity. All three fail:

- The identity is corrected to the two-term form, pointing at the audit's own §2
  where the correction landed.
- **The exception is empty**: the converged witness's *published red zone*
  crosses two segments, and `p0-converged-witness-set.md` says so outright at its
  "Two estimators, published together" section, publishing a floor-free
  estimator beside every threshold. That page is cited, not re-derived, and not
  edited.
- The distinction matters and is drawn explicitly: that page's **reactive leg**
  *is* genuinely single-segment — two Reagent arms against one floor reading —
  so it does cancel exactly, and this repair says so rather than condemning it.
  It is named as the shape the original sentence was reaching for.
- **The paragraph's conclusion is not preserved.** `rf2-es04f`'s description
  says the conclusion "is unaffected and should stand"; a note on the bead
  corrects that — the conclusion is itself withdrawn by `rf2-ymi6j` and by this
  page's own §6.1 banner. Following the description literally would have fixed
  the algebra and left a withdrawn conclusion standing as the page's answer.
  It does not: the paragraph now ends on what survives — control, and the band
  as the gate.

## Quality gates

Each run in the foreground to completion in the worker worktree
`C:/Users/miket/code/re-frame2-worktrees/candclock-es04f`, output redirected to a
log rather than piped, exit code read from the runner itself.

| command | result | exit |
|---|---|---:|
| `python scripts/check_doc_slugs.py --verbose` | `scanning 678 markdown files... no broken links.` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | `1 files, 5 cited pins (4 landed, 1 stranded, 0 unresolvable)` — *every cited pin is an ancestor of `origin/main` or shares its block with one* | **0** |
| `sh scripts/test-fast-pr.sh` | `PASS fast PR spine`; documentation tier armed (`documentation surface changed → running link/anchor/status gates`) | **0** |

**Gate selection proven, not assumed.** `check_doc_slugs.py` is silent on
success, so a deliberate broken anchor was appended to the target file and the
checker re-run: **exit 1**, naming
`docs/design/hicasso/studio/the-candidates-clock.md:1449 ->
#this-anchor-does-not-exist-rf2-es04f-probe`. The probe was reverted with
`git checkout --` and the checker re-run to **exit 0**. The gate does select
this file.

**Provenance: accompanied, never re-pinned.** The one stranded pin is
pre-existing and passes because it shares its block with a landed counterpart —
the checker's own ancestry test, not a subject match. This diff introduces **no
pins at all**: grepping every added line for a 7–40 character hex token returns
empty, so nothing was pinned or re-pinned.

**Hand-verification, because `mkdocs build --strict` does not cover
`docs/design/**`** (`mkdocs.yml`'s `exclude_docs` keeps this tree off the site,
so it is not the gate for this edit):

- **Table column counts**: unchanged **by construction**. The diff touches no
  table line — grepping every added and removed line for a leading `|` returns
  empty. The three-column segment table immediately above site 1 is untouched.
- **Heading anchors**: no heading was added, removed or reworded — the same grep
  for a leading `#` on any changed line returns empty — so every inbound anchor
  to this page still resolves.
- **The five anchors introduced** were each checked by hand against their target
  heading, in addition to the checker's pass:
  `#61-the-seam-measured-against-load` → `### 6.1 The seam, measured against
  load`; `#62-what-replaces-it-the-band-a-magnitude-must-clear` → `### 6.2 What
  replaces it: the band a magnitude must clear`;
  `the-clock-behind-the-published-rows.md#2-why-the-floor-normalisation-does-not-protect-the-ratio`
  → `## 2. Why the floor normalisation does not protect the ratio` (:123);
  `p0-converged-witness-set.md#two-estimators-published-together` → `### Two
  estimators, published together` (:804);
  `p0-converged-witness-set.md#the-reactive-leg-from-a-second-author-rf2-2rtt621`
  → `## The reactive leg, from a second author (rf2-2rtt6.21)` (:910).
- **Strikethrough rendering**: the multi-line `~~…~~` spans are
  paragraph-internal with no blank line inside, the same construction already
  used on this page at the §6.1 banner and in the §7 handoff list.

## Scope

One file: `docs/design/hicasso/studio/the-candidates-clock.md`. No `spec/`, no
code, no other studio page — `p0-converged-witness-set.md` and
`the-clock-behind-the-published-rows.md` are cited and left alone. Sequenced
behind #7632, which merged before this branch was cut.
