### PR TITLE
docs(hicasso): the ladder's crossover is one model, stated (rf2-2rtt6.34)

### DIFF
--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -893,7 +893,7 @@ is a second model and this page does not quote it as a result; it is named
 here so that 1.43 is read as one model's output inside a measured bracket,
 and not as a quantity known to two significant figures.
 
-**The archetype is past the crossing under any of them, and by direct
+**The archetype is past the crossing under either model, and by direct
 measurement.** The census's seven-read archetype reads **16,457 B against
 20,799 B, a 4,341 B/boundary saving** — 5.2 MB across 1,200 boundaries —
 with no model standing between that row and its reading. Against Reagent

--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -861,20 +861,55 @@ reactions it holds — and the bracket is wide: 1,363 to 2,272 B/read.
 
 ### The crossover, and where the archetype falls
 
-Against the UIx spine the candidate pays a fixed 913 B more at the shell
-and saves 708 B on every read, so it is behind at one read and ahead from
-two:
+Against the UIx spine the candidate pays a large fixed cost at the boundary
+and saves **708 B on every read**, so it starts behind and ends ahead.
+*Where* it crosses depends on which fixed term the arithmetic uses, and
+this page states **one model: the two fitted lines**, whose own intercepts
+are the only fixed terms that belong to them.
 
 ```
-crossover  =  (1,134 − 220) / (2,981 − 2,272)  =  R = 1.29 reads
+fitted lines   UIx      y =   161 + 2,981·R
+               Hicasso  y = 1,175 + 2,272·R
+
+crossover   =  (1,175 − 161) / (2,981 − 2,272)  =  R = 1.43 reads
+               MODEL-INFERRED — no R = 2 rung was measured
 ```
 
-Measured, not only fitted: at R = 1 the candidate is **1.173×** UIx and at
-R = 3 it is **0.883×**. The census's seven-read archetype sits well past
-the crossing — **16,457 B against 20,799 B, a 4,341 B/boundary saving**,
-5.2 MB across 1,200 boundaries. Against Reagent there is no crossover at
-all: the candidate is worse at every rung, and the ratio only *improves*
-with reads (1.764× → 1.466×) because the shell amortises.
+**Direct observation brackets the crossing; it does not locate it.** The
+candidate is behind at R = 1 — **1.173×** UIx — and ahead at R = 3 —
+**0.883×** — in all six rounds, both directly measured. The crossing
+therefore lies somewhere in (1, 3). That bracket is the evidence. The 1.43
+is what the model says inside it, and **anything this page or anything
+downstream reads as the candidate being ahead at R = 2 is model-inferred**,
+because no R = 2 rung exists on this ladder.
+
+**Why the model's answer sits low in its own bracket, stated rather than
+smoothed.** Both arms cost more on their first read than on their marginal
+one — UIx 3,067 against 2,981, the candidate 2,721 against 2,272 — so a
+line fitted over the reactive rungs under-predicts R = 1 on both, by 145 B
+and 408 B. Anchoring instead on the *measured* R = 1 pair and applying the
+−708 B/read after the first read would put the crossing near R = 1.8. That
+is a second model and this page does not quote it as a result; it is named
+here so that 1.43 is read as one model's output inside a measured bracket,
+and not as a quantity known to two significant figures.
+
+**The archetype is past the crossing under any of them, and by direct
+measurement.** The census's seven-read archetype reads **16,457 B against
+20,799 B, a 4,341 B/boundary saving** — 5.2 MB across 1,200 boundaries —
+with no model standing between that row and its reading. Against Reagent
+there is no crossover at all: the candidate is worse at every rung, and the
+ratio only *improves* with reads (1.764× → 1.466×) because the shell
+amortises.
+
+**What this row published before, and why it was withdrawn
+(`rf2-2rtt6.34`).** It read `(1,134 − 220) / (2,981 − 2,272) = R = 1.29
+reads`, dividing the **measured** R = 0 shell difference by the **fitted**
+marginal-slope difference. The fit excludes R = 0 by rule — that exclusion
+is the whole point of [the fitted lines](#the-fitted-lines) — so those two
+quantities belong to no single line, and 1.29 was neither the fitted
+crossing nor an observation of one. Nothing measured moved; the arithmetic
+did. The withdrawn value is left visible here rather than erased, because
+it was quoted downstream.
 
 ### The survival metric, in objects and not only in bytes
 
@@ -1437,9 +1472,21 @@ published — nothing here touches them. The candidate's live numbers move:
 | the design's win (UIx seg., donor − candidate) | −708 B/read (0.7624×) | **−692 B/read** (0.7679×, a 23.2% margin) |
 | the design's bill (Reagent seg., candidate − donor) | +415 B/read (1.4379×) | **+499 B/read** (1.5264×) |
 | the bracket a shipped Hicasso sits in | 1,363 – 2,272 B/read | **1,447 – 2,289 B/read** |
-| crossover against the UIx spine | R = 1.29 reads | **R = 1.32 reads** |
+| crossover against the UIx spine *(model-inferred)* | R = 1.43 reads, fitted lines | **not restated** — the bisection publishes slopes, not intercepts |
 | the grouped tier's ~2,000 B line | cleared on the Reagent substrate only | unchanged in kind: 1,447 < 2,000 < 2,289 |
 | seven-read archetype vs UIx, B = 1,200 | 4,341 B/boundary saved | **4,230 B/boundary** saved (16,572 vs 20,802, measured R = 7; ≈5.1 MB across 1,200) |
+
+**The crossover row was corrected, not re-measured (`rf2-2rtt6.34`).** Both
+of its cells previously carried the hybrid arithmetic — 1.29 as published,
+restated as 1.32 on run 4's slopes — which divides a *measured* R = 0 shell
+difference by a *fitted* slope difference and so belongs to neither line.
+[§6's crossover](#the-crossover-and-where-the-archetype-falls) now states
+the fitted-line model alone, and run 4's counterpart cannot be restated in
+that model, because the bisection above publishes marginal slopes and no
+fitted intercepts. What the row's reading actually rests on is the direct
+bracket, and no arithmetic here touches it: the candidate is behind at the
+measured R = 1 and ahead at the measured R = 3, and **R = 2 was never
+measured on any tree on this page.**
 
 The verdict's shape survives — the axis is still won against UIx by nearly
 five times the instrument-limited floor, and 943/948 B is still not beaten
@@ -1591,9 +1638,11 @@ wobble does not read as a change in the bill.
 unchanged: the axis is won against UIx — now by more than five times the
 instrument-limited floor — and lost to Reagent's `deref`-capture. What
 moved is the size of the loss, by 22%. The crossover against the UIx
-spine is deliberately **not** restated: rf2-2rtt6.34 is reopened on which
-model this page states it in, and a fifth number computed a sixth way is
-the opposite of what that bead asks for.
+spine is still **not** restated here, and now for a settled reason rather
+than a pending one: `rf2-2rtt6.34` has since fixed the page's model to
+[the fitted lines](#the-crossover-and-where-the-archetype-falls), this
+section publishes marginal slopes and no fitted intercepts, and a fifth
+number computed a sixth way was never what that bead asked for.
 
 #### Provenance
 


### PR DESCRIPTION
Closes `rf2-2rtt6.34` — the bounded publication-correctness fix the PR #7337
chronological audit reopened it for. **Docs only, one file, no measurement, no
harness expansion, no R = 2 rung.**

## The defect

Section 6 computed the crossover against the UIx spine as

```
(1,134 − 220) / (2,981 − 2,272)  =  R = 1.29 reads
```

which divides the **measured R = 0 shell** difference by the **fitted marginal
slope** difference. The fit excludes R = 0 by rule — that exclusion is the whole
point of the fitted-lines subsection, and the fit rule's own self-test enforces
it — so those two quantities belong to no single line. 1.29 was neither the
fitted-line crossing nor an observation of one. The same hybrid was carried into
the rf2-2rtt6.60 re-take row as `1.29 → 1.32`.

## The model chosen, and why

**The fitted lines**, labelled MODEL-INFERRED:

```
UIx      y =   161 + 2,981·R
Hicasso  y = 1,175 + 2,272·R

crossover  =  (1,175 − 161) / (2,981 − 2,272)  =  R = 1.43 reads
```

Chosen over the R = 1-anchored arithmetic (`1 + (3,855 − 3,287) / 709 ≈ 1.8`)
because each line's own intercept is the fixed term that belongs to it, so the
crossing is a property of two published objects rather than a mixture; because
the page already publishes both intercepts and both slopes, so a reader can
re-derive it from the page without new arithmetic; and because it is the model
the bead's acceptance names.

The R = 1-anchored alternative is **named in the page but not quoted as a
result**, with its cause stated — both arms cost more on their first read than
on their marginal one (UIx 3,067 vs 2,981; candidate 2,721 vs 2,272), so a fit
over the reactive rungs under-predicts R = 1 by 145 B and 408 B respectively.
That is there so 1.43 reads as one model's output inside a measured bracket
rather than as a quantity known to two significant figures — and so the next
reader does not re-derive 1.8 and conclude the page is wrong.

## What the direct evidence is now kept separate as

The candidate is behind at the measured **R = 1** (1.173× UIx) and ahead at the
measured **R = 3** (0.883×), in all six rounds. The crossing therefore lies in
**(1, 3)** — that bracket is the evidence; 1.43 is the inference inside it.
**No R = 2 rung exists on this ladder**, and the page now says so explicitly
wherever the candidate could be read as ahead there. The old text said "behind
at one read and ahead from two"; that R = 2 claim is now labelled as
model-inferred rather than stated as observed. The seven-read archetype's
4,341 B/boundary saving is untouched — it is a directly measured rung with no
model between it and its reading.

## Annotate, never erase

Per the page's own idiom, the withdrawn 1.29 is left visible with its equation
and the reason it was withdrawn, because it was quoted downstream. The re-take
row's second cell reads **not restated**: run 4's counterpart cannot be computed
in the adopted model, because the bisection publishes marginal slopes and no
fitted intercepts. The later rf2-aqgr2 subsection, which had deferred its
crossover pending this bead, now records the settled reason instead of a pending
one.

## Scope

Untouched: every measured row, every donor gate, all four shells, the structural
witness, the fits themselves, and the §§1–4 Reagent↔UIx crossover statements at
`:170` / `:598`. Those last two were checked and are **not** the same defect —
"below one read" is a bracket claim directly supported by the R = 1 rows
(UIx ≈3,038 B against Reagent 1,562 B), not a point value from mixed terms.
Nothing measured moved; the arithmetic did.

## Quality gates

All foreground, never piped, each redirected to a worktree-local log; the exit
code below is the runner's own.

| command | result | exit |
|---|---|---:|
| `python scripts/check_doc_slugs.py --verbose` | `scanning 678 markdown files... no broken links.` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | `1 files, 59 cited pins (48 landed, 11 stranded, 0 unresolvable)` — every cited pin is an ancestor of `origin/main` or shares its block with one | **0** |
| `sh scripts/test-fast-pr.sh` | `fast PR spine: docs=true jvm=false node=false (classified)`, full spine green | **0** |

Both doc gates were re-run after the final wording commit: exit **0** and **0**.

**Selection proof for `check_doc_slugs.py`** (it is silent on success, so a green
run alone proves nothing about whether it looked at this file). A deliberate
break was injected into this page's `](#the-fitted-lines)` link:

```
BROKEN ANCHOR: docs\design\hicasso\studio\reads-per-boundary-heap-ladder.md:908
    -> #the-fitted-lines-DELIBERATELY-BROKEN
```

exit **1**, then reverted — `git status` clean, and the clean re-run is exit 0
above.

**No provenance re-pinning was done.** The gate passed as-is: the page's 11
stranded authored heads are all accompanied by a landed pin in their own block,
which is the accompaniment PR #7626 established. This PR adds no SHA-shaped
token of any kind, so no head could be stranded by it.

### Hand-verification, since `mkdocs build --strict` does not cover `docs/design/**`

`mkdocs.yml`'s `exclude_docs` keeps this tree out of the site, so the following
was verified by hand rather than by a build.

- **Table column counts.** All **52** tables on the page were parsed and every
  one of their **312** rows compared against its own header: **0 mismatches**.
  Only one table row was edited (the re-take restatement row), and it is 3 cells
  against a 3-column header, unchanged in width.
- **Anchors.** The diff introduces two links, `#the-fitted-lines` and
  `#the-crossover-and-where-the-archetype-falls`. Both targets exist as `###`
  headings on this page (`### The fitted lines`, `### The crossover, and where
  the archetype falls`); neither heading's text was changed by this PR, so no
  existing inbound link moved. `check_doc_slugs.py` validates both, and the
  injected-break run above proves it is actually reading this file.
- **Fenced blocks.** The one code fence added is plain text (the two fitted line
  equations and the crossover), opened and closed; fence pairing across the page
  was walked when counting tables and the parser never ended inside a fence.
- **No other crossover statement.** Post-edit, `crossover` occurs at `:170`,
  `:598`, `:862`, `:874`, `:900`, `:1475` (the re-take row), `:1479`, `:1483`,
  `:1640` and `:1643`. The three sites in scope — §6's equation, the re-take row
  and the rf2-aqgr2 deferral — are reconciled to the one model; the two §§1–4
  ones are a different comparator pair, addressed under Scope. No other page in
  `docs/` or `spec/` mentions this crossover — grepped.
