### PR TITLE
docs(hicasso): the [:>] crossing's closure must capture the frame (rf2-mfj1t)

### DIFF
--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -267,7 +267,7 @@ an undeclared slot, through the same code, not a second rule:
 | An intent vector or key-map at an `on*`-spelled slot | **Refused** — `:rf.error/hicasso-host-undeclared-callback`. A contract is never inferred from a name, and the alternative is `clj->js` shipping your intent to the library as an inert array |
 | An intent vector or key-map anywhere else | Data, through the position's own conversion, like any other collection |
 | An `h/fn`, at any slot | **Refused** — `:rf.error/hicasso-host-unclaimed-callback`. The marked form *asks* the position for a contract, and there is no position here to answer |
-| A plain function | Crosses by identity and runs. It never asked for anything, so nothing is left unanswered — memoisation on callback identity keeps working |
+| A plain function | Crosses by identity and runs. It never asked for anything, so nothing is left unanswered — memoisation on callback identity keeps working. It also carries no frame, so a dispatching one has to [carry its own](#the-closure-has-to-carry-the-frame) |
 | `:ref` | The crossing's own check: a callback ref crosses untouched, the reserved vector is refused |
 | `:key` | React's, on the crossing's element, exactly as at a `defhost` |
 
@@ -276,6 +276,49 @@ that means writing the declaration you do not have. **The refusals are the
 point.** An `h/fn` that crossed unclaimed would be called by the library, would
 return an intent, and the library would discard the return — a handler that does
 nothing, in production, with no diagnostic anywhere.
+
+### The closure has to carry the frame
+
+The two refusals above are the two spellings that carry a frame *for* you, so
+what is left is the plain function — and a plain function carries no frame. The
+library keeps it and calls it later, from its own DOM handler or a timer, by
+which time the render that built it has unwound and there is no ambient frame
+anywhere to find. `(fn [value] (rf/dispatch [:row/picked value]))` at a `[:>]`
+prop is a handler that runs and then refuses, with `:rf.error/no-frame-context`
+at the library's call.
+
+Async work *you* own does not have this problem and does not belong here: an fx
+handler already receives the frame id in its context and `:dispatch-later` says
+the delay as data. What survives that move is this case and only this case — a
+dispatching closure handed to a caller you do not control. Read the frame during
+the render, where it is knowable, and let the closure close over the carry:
+
+```clojure
+;; cf. implementation/freehand/test/re_frame/bench/hicasso/arm1/
+;;     hframe_dom_cljs_test.cljs — the witness mounts one such view under two
+;;     frames and clicks both crossings from the component's own DOM handler.
+(defview picker-row [{:keys [id component]}]   ;; component chosen at runtime
+  (let [{:keys [dispatch]} (rf/capture-frame (h/frame))]   ;; h/frame is [unfrozen]
+    [:> component
+     {:label   id
+      ;; unclaimed and value-first, so a plain closure is the only door —
+      ;; and this one carries the frame its own render read
+      :on-pick (fn [value] (dispatch [:row/picked id value]))}]))
+```
+
+**Each half is load-bearing.** `(h/frame)` answers the frame the boundary is
+rendering under, which is the id a *reusable* view cannot name — the whole reason
+it is mounted under several. Core's `rf/capture-frame` takes that id and, in this
+one-argument form, never consults the ambient resolver, so the handle it returns
+is still good after the render extent has unwound. The bare `(rf/capture-frame)`
+the adapters spell is not the shorter way to write this: ambient frame lookup is
+what a Hicasso body withdraws, so it refuses there for the same reason an ambient
+`rf/dispatch` does
+([Events as data](03-events-as-data.md#callbacks-carry-their-frame)).
+
+`defhost` is still the remedy for the two rows above — a declared `:event` slot
+builds this closure for you and you write the intent. This is what you write
+until you have one.
 
 ### On the server, nothing
 
@@ -394,10 +437,13 @@ an intent there runs with no ambient frame and raises
 never silently inert. The message offers both readings, because from where you sit
 you *are* inside a boundary's render (you wrote the crossing in a body), and it
 names the repair: `defhost` with `:callbacks {<the prop> :render}` is the position
-that owns the frame. A `[:>]` written inside a *declared* `:render` body inherits
-that position's frame, which is the composition intended — but a `:render` return
-still crosses unconverted, so today the subtree has to be written where children
-lower ([Not settled yet](#not-settled-yet)).
+that owns the frame. If what that body wanted was to *dispatch* rather than lower,
+the repair keeps the escape:
+[the closure carries the frame itself](#the-closure-has-to-carry-the-frame). A
+`[:>]` written inside a *declared* `:render` body inherits that position's frame,
+which is the composition intended — but a `:render` return still crosses
+unconverted, so today the subtree has to be written where children lower
+([Not settled yet](#not-settled-yet)).
 
 ### Migrating off it
 
@@ -417,6 +463,7 @@ same thing. A codemod is planned and not built.
 | React refuses an object as a child, from a `:render` body | The body returned hiccup; a `:render` return crosses unconverted | Return a string, or keep the subtree on the Hicasso side of the crossing |
 | `:rf.error/hicasso-intent-at-a-non-event-contract` | Slot is `:handler` or `:render`; neither dispatches | Declare `:event`, or write an `h/fn` for the real work |
 | `:rf.error/hicasso-intent-needs-the-event` | Vector spelling needs the DOM event at arg one; library put something else there | Use `h/fn` — full argument list, library order |
+| A `[:>]` callback runs, then refuses with `:rf.error/no-frame-context` | A plain function crosses by identity and carries no frame; by the time the library calls it the render has unwound | Build `(rf/capture-frame (h/frame))` in the body and close over it |
 | Namespace won't load on the JVM | A JS require reached a `.cljc` file | Quarantine the require in a `.cljs` host ns |
 | Structural test can't match a node | A `[:>]` node has reduced structural identity — slot 1 holds a JS value compared by identity, and the crossing's fiber is named `[:>]` rather than by the component | Prefer `defhost`, or assert around the node |
 | A `[:>]` region is missing from the server HTML | `[:>]` is hard `:client-only` — no declaration, so no `:ssr` policy and no spelling for one | Declare it with `defhost` and choose `:ssr`, or wrap the escape in a host that carries a `{:fallback …}` |


### PR DESCRIPTION
Closes rf2-mfj1t.

PR #7645 taught the `[:>]` escape fully — the model, the named use cases,
declare-what-you-use-twice, the unclaimed-prop refusals, SSR conduct, the
Component roster, reduced structural identity, eager children lowering, the
migration equivalence. What it did not teach is what has to be **inside** the
function-prop it names as the only admissible spelling. `grep -c capture-frame`
over that diff returns 0, and 05-interop had no `capture-frame` and no `h/frame`
anywhere on the page before this change.

That is the silently-dead-handler class the escape's refusals exist to delete,
one level along. An author who reads the section, obeys it, and writes
`(fn [value] (rf/dispatch [:row/picked value]))` at a `[:>]` callback prop gets a
handler that runs and then refuses.

### What lands

A new `### The closure has to carry the frame` under `## The escape: [:>]`,
between `### Every prop is unclaimed` and `### On the server, nothing` — beside
the unclaimed-prop table whose last row is where the reader learns the plain
function is the door. One worked example, and the reasoning the example needs:

- **Why the plain closure is the only door rather than one option of two.** The
  two spellings that carry a frame *for* the author are both refused at this very
  prop, because `[:>]` carries no declaration and a callback contract lives on a
  declaration — so the roster is empty by construction. What crosses is an
  ordinary function, and an ordinary function carries no frame.
- **The composition**, built in the body and closed over:
  `(rf/capture-frame (h/frame))`.
- **Why each half is load-bearing.** `(h/frame)` supplies the id a *reusable*
  view cannot name; `capture-frame`'s one-argument form never consults the
  ambient resolver, so the handle is still good after the render extent has
  unwound. The bare `(rf/capture-frame)` the adapters spell refuses in a Hicasso
  body, for the same reason an ambient `rf/dispatch` does.
- **`:fx` first**, per the `h/frame` design record's standing rule for every
  guide row that puts `h/frame` on the page: async work the author owns goes
  through the event layer, and what survives that move is this case and only this
  case.

Plus three pointers rather than three repetitions: the plain-function row in the
unclaimed table now says it carries no frame and links here; the function-prop
paragraph in `### Children lower where you wrote them` named only the
`defhost` + `:callbacks {… :render}` repair, which is unavailable to someone who
is at the escape precisely because they cannot declare — it now also names the
repair that keeps the escape; and one Troubleshooting row.

`h/frame`'s own documentation is not duplicated — the section links to
`03-events-as-data.md#callbacks-carry-their-frame` for the body-discipline half.

### Prose over a witnessed contract

Not a synthesis. The mechanism is pinned live by the W7 row that merged in
PR #7649 (rf2-zllp8):
`arm1/hframe_dom_cljs_test.cljs`,
`the-escapes-value-first-door-dispatches-through-a-plain-closure-over-the-capture`.
It asserts the premise rather than citing it — an intent vector at an
event-spelled prop is `:rf.error/hicasso-host-undeclared-callback`, a marked
`h/fn` is `:rf.error/hicasso-host-unclaimed-callback` — then mounts one reusable
view under two frames, checks `intent/*frame*` is nil inside a `setTimeout`, and
clicks both crossings from the foreign component's own DOM handler. The example
in the guide is that row's `escape-picker`, written for an author. The witness is
cited in the code fence.

## Quality gates

`docs/design/**` is outside `mkdocs build --strict` (`mkdocs.yml`'s
`exclude_docs` keeps `design/` off the site), so it is **not** nominated here.
`scripts/check_doc_slugs.py` is the gate that does apply, and it runs in the
fast-PR spine and in `docs.yml`.

| Command | Result | Exit |
|---|---|---|
| `python scripts/check_doc_slugs.py --verbose` | `scanning 678 markdown files... no broken links.` | **0** |
| `python scripts/check_doc_slugs.py --verbose` *(with a deliberately broken anchor — selection proof)* | `1 broken anchor link(s) found: BROKEN ANCHOR: docs\design\hicasso\draft-guide\05-interop.md:270 -> #the-closure-has-to-carry-the-frame-XX` | **1** |
| `python scripts/check_doc_slugs.py --verbose` *(after reverting the injection)* | `no broken links.` | **0** |
| `sh scripts/test-fast-pr.sh` | `=== fast PR spine: docs=true jvm=false node=false (classified) ===` … `PASS fast PR spine` | **0** |

Both gates run in the foreground, unpiped, redirected to a worktree-local log;
the exit codes above are the runners' own.

**Selection is proven, not assumed.** `check_doc_slugs.py` is silent on success,
so a green run alone does not show the new file was examined. Renaming the new
intra-page target to `#the-closure-has-to-carry-the-frame-XX` made it fail with
exit 1 naming `05-interop.md:270`; the injection was then reverted and the gate
returned to exit 0.

### Hand-verification (what no gate covers)

- **Anchors, by hand.** Three links added. Two intra-page to
  `#the-closure-has-to-carry-the-frame`, which is the GitHub/mkdocs slug of the
  new `### The closure has to carry the frame`; one cross-page to
  `03-events-as-data.md#callbacks-carry-their-frame`, whose `## Callbacks carry
  their frame` heading is at line 230 of that file. All three resolve under
  `check_doc_slugs.py`, and the deliberate break above shows that result is real.
  No existing anchor was renamed, so nothing linking into this page can have
  broken.
- **Table column counts, by hand.** All six tables in `05-interop.md` were parsed
  row by row and every row in each table has the same cell count. The two tables
  this PR touches: the unclaimed-prop table stays **2 columns across 8 rows**
  (one existing row extended, none added), and Troubleshooting stays **3 columns
  across 17 rows** (one row added, matching `Symptom | What went wrong | Fix`).
  No pipe characters were introduced inside a cell.
- **Digest-pinning does not apply here.** The guide's fenced-block hashing lives
  in `implementation/freehand/test/re_frame/freehand/guide/samples_coverage_jvm_test.clj`,
  whose `guide-dir` is `"docs/core/freehand"` — not
  `docs/design/hicasso/draft-guide/`. Nothing in the repo references
  `hicasso/draft-guide` from a test, script or workflow, so the one new fenced
  block needs no roster row and this stays a one-file change.

Fence honoured: `docs/design/hicasso/draft-guide/05-interop.md` only. No `spec/`,
no code, no studio page.
