### PR TITLE
feat(hicasso): the revision prop on controlled elements (rf2-zq8kh)

### DIFF
--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -197,8 +197,11 @@ non-forfeitable — a merge cannot reach an owned literal, so there is no wrong
 choice of syntax to make. The case where a caller override *should* win is spelled
 by not writing the literal.
 
-Three details. `:key` and `:ref` are never taken from a `:&` map (they address the
-element the caller wrote). The same key and the same law hold at a crossing — a
+Three details. `:key`, `:ref` and `::h/revision` are never taken from a `:&` map
+(they address the element the caller wrote, and a remainder that carries a
+`::h/revision` is refused loudly rather than quietly ignored — it would
+otherwise be asking to force a re-baseline on a field whose author never wrote
+one). The same key and the same law hold at a crossing — a
 view head, a `defhost` head, `[:>]` — because `:&` is merged before any conversion
 and the conversion that follows is the position's own, so a forwarded `:className`
 crosses under the name it was written as. And an element's own classes belong on
@@ -234,6 +237,47 @@ against. **Witnessed on Chromium only** — the harness drives composition over
 CDP, which is Chromium's protocol. On the lean-React arm the
 end-of-discrete-event restore is React's; a PATCH back end must own it
 (architecture.md, hard gate).
+
+### Resetting a field — `::h/revision`, the third reserved key
+
+Resets are by **explicit caller revision, never value equality** (HD-019's law,
+kept from D016). `::h/revision` is where that law is spelled at the element:
+
+```clojure
+[:input {:value    (sub [:editor/field id])
+         ::h/revision (sub [:editor/baseline-id id])
+         :on-input [:editor/edit-field id ::h/value]}]
+```
+
+A change to the revision re-baselines the field to the model **without
+remount** — the node, the focus and the selection survive, and the caret lands
+at end-of-model on the commit carrying the reset. A `:value` that changes under
+an *unchanged* revision continues the draft rather than resetting it, which is
+what makes the distinction explicit rather than guessed. The comparison is `=`,
+so equal-but-fresh values are inert.
+
+**Write a revision the way you would write an instance key**: a domain fact
+your events put in `app-db` — a record id, a load generation, a "form opened
+at" stamp. Never a render-order index, never a counter minted in render, never
+`random-uuid`; each of those resets the field on every render.
+
+Three limits, stated rather than discovered. A revision arriving **during a
+live IME composition defers to the exchange's close**, like everything else on
+this path — the model is correct throughout, the glass is not, and there is no
+cancel primitive to do better with. On an *accepting* field a post-bump edit
+**supersedes** the reset by ordinary event order, so the close lands the
+then-current model rather than the model the reset produced. And the spelling
+is matched **exactly**: a bare `:revision` is not this prop, and becomes an
+ordinary DOM attribute — silently, and with a namespaced keyword's namespace
+deleted on the way, so `:rev/a` and `:other/a` both show as `revision="a"` in
+devtools. On anything that is not a controlled `<input>`/`<textarea>` the prop
+is a loud refusal, `:rf.error/hicasso-revision-not-controlled` — including a
+value-less checkbox, though a checkbox carrying a form-submission `value` is
+accepted and the revision is simply inert there.
+
+This is the single prop and nothing more: no commit/cancel intents, no
+acknowledgement that the reset landed, no caret-policy knobs. The post-v0
+buffered-controls ladder **consumes** this trigger; it never extends it.
 
 ## The interop door (HD-011)
 

--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -267,11 +267,11 @@ this path — the model is correct throughout, the glass is not, and there is no
 cancel primitive to do better with. On an *accepting* field a post-bump edit
 **supersedes** the reset by ordinary event order, so the close lands the
 then-current model rather than the model the reset produced. A revision
-arriving **mid-hydration defers past adoption** for the same reason it defers
-past a composition: React discards the server's node when any client render
-lands before adoption completes — with or without a revision change, so this
-is adoption's conduct and not the prop's — and after adoption a bump keeps the
-node and lands the reset normally. And the spelling is matched **exactly**: a
+arriving **mid-hydration defers past adoption**: whether React keeps the
+server's node across a client render that lands before adoption completes is
+React's own race, and the revision cannot influence it either way — it is
+consumed at the codec, so React never sees it. And the spelling is matched
+**exactly**: a
 bare `:revision` is not this prop, and becomes an
 ordinary DOM attribute — silently, and with a namespaced keyword's namespace
 deleted on the way, so `:rev/a` and `:other/a` both show as `revision="a"` in

--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -261,13 +261,18 @@ your events put in `app-db` — a record id, a load generation, a "form opened
 at" stamp. Never a render-order index, never a counter minted in render, never
 `random-uuid`; each of those resets the field on every render.
 
-Three limits, stated rather than discovered. A revision arriving **during a
+Four limits, stated rather than discovered. A revision arriving **during a
 live IME composition defers to the exchange's close**, like everything else on
 this path — the model is correct throughout, the glass is not, and there is no
 cancel primitive to do better with. On an *accepting* field a post-bump edit
 **supersedes** the reset by ordinary event order, so the close lands the
-then-current model rather than the model the reset produced. And the spelling
-is matched **exactly**: a bare `:revision` is not this prop, and becomes an
+then-current model rather than the model the reset produced. A revision
+arriving **mid-hydration defers past adoption** for the same reason it defers
+past a composition: React discards the server's node when any client render
+lands before adoption completes — with or without a revision change, so this
+is adoption's conduct and not the prop's — and after adoption a bump keeps the
+node and lands the reset normally. And the spelling is matched **exactly**: a
+bare `:revision` is not this prop, and becomes an
 ordinary DOM attribute — silently, and with a namespaced keyword's namespace
 deleted on the way, so `:rev/a` and `:other/a` both show as `revision="a"` in
 devtools. On anything that is not a controlled `<input>`/`<textarea>` the prop

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1168,20 +1168,22 @@ candidate second call site appears. The composition value path reopens on
 > on an accepting field a post-bump dispatch supersedes it by ordinary event
 > order.
 >
-> **Hydration: the design's mid-adoption claim was WRONG, and the
-> pre-committed fallback is what ships.** The design asserted, with no source
-> cite, that a revision arriving mid-adoption lands on the first post-adoption
-> commit *on the server's node*; the adversarial pass demoted it to
-> witness-gated intent precisely because the failure mode was node loss. The
-> witness reds: React **discards** the server's node when a client render
-> arrives before adoption completes. The control arm is what makes this a
-> finding about adoption rather than about this prop — an identical
-> mid-adoption render carrying an *unchanged* revision loses the node the same
-> way, so the revision neither causes the deopt nor escapes it. Documented
-> conduct is therefore the fallback: **a reset arriving mid-adoption defers
-> past adoption**, the same shape the IME carve-out has. Once adoption is
-> complete a bump keeps the node and lands the reset, which is the case the
-> shipped feature rests on and is witnessed green.
+> **Hydration: the design's mid-adoption claim is not this prop's to make, and
+> the pre-committed fallback is what ships.** The design asserted, with no
+> source cite, that a revision arriving mid-adoption lands on the first
+> post-adoption commit *on the server's node*; the adversarial pass demoted it
+> to witness-gated intent precisely because the failure mode was node loss.
+> Adjudicated: the revision is **consumed at the codec before emission**, so
+> React is handed a prop-identical element whether it moved or not — same
+> slots, same values, same element type — and nothing on React's side,
+> adoption included, can branch on a value it was never given. Two hand-rolled
+> `hydrateRoot` arms disagreed about node identity in opposite directions on
+> consecutive runs, which is React's own adoption race and not this prop's
+> doing. Documented conduct is therefore the fallback: **a reset arriving
+> mid-adoption defers past adoption**, the same shape the IME carve-out has.
+> The structural fact that makes that safe to document is witnessed;
+> `rf2-ne3ey` owns the adoption-TIMING row, on the `.84` hydration harness
+> rather than on a hand-rolled race.
 >
 > **Reopens** if the per-commit re-assert stops holding — the witness file
 > `front/revision_dom_cljs_test` pins it as a design-validation row and a red

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1123,6 +1123,60 @@ the node-held record valid, and it is not a public React guarantee — or if any
 candidate second call site appears. The composition value path reopens on
 `rf2-digtt`'s ruling, whichever way it goes.
 
+> **Addendum, 2026-08-07 — the reset law is applied at the element as
+> `::h/revision` (`rf2-zq8kh`).** The trigger sentence above — *resets are by
+> explicit caller revision, never value equality*, kept from D016 — had no
+> spelling at the element path. It has one now:
+> `:re-frame.hicasso/revision`, **[unfrozen]**, matched as the exact namespaced
+> keyword and never slot-claimed. A change to its value (CLJS `=`) re-baselines
+> a controlled `<input>`/`<textarea>` to the model **without remount** — the
+> node is kept, the focus is kept, and the caret lands at end-of-model on the
+> commit that carries the reset, which is the platform's own conduct for a
+> `value` assignment and which D016's caret clause licenses as permission
+> rather than obligation. A value change under an unchanged revision continues
+> the draft. Equal-but-fresh revisions are inert. The design record is
+> `docs/design/hicasso/studio/revision-prop-spec.md`; the single prop is the
+> whole scope, and the post-v0 buffered ladder **consumes** this trigger rather
+> than extending it.
+>
+> **The `flushSync` count is unchanged, and the audit statement is the
+> mechanism clause rather than a tally.** The reset adds no call site. Its
+> transport is React's own per-commit controlled re-assert off the fresh props
+> object the codec mints per render (HD-004 refuses prop-object caching), so
+> in-turn resets ride the keystroke converge, deferred resets ride the
+> `compositionend` site, and out-of-band resets ride ordinary commits — no
+> hook, no ref, no comparison record, no keyed re-render, and **no third
+> `flushSync` site**. Note for the next reader that `converge!`'s SECOND caret
+> read is likewise not a third site: this exception is granted to an audited
+> MECHANISM, not to a count, and that read is the same element inside the same
+> exchange.
+>
+> **A named dependency, stated so it cannot be optimised away.** Three React
+> behaviours carry the transport and none is a public contract — the same class
+> as the `defaultValue` mirror this ruling already names. This therefore
+> promotes HD-004's no-caching posture from a measurement-honesty stance to a
+> **correctness dependency of the reset transport**: any future prop-object
+> memoization must exclude controlled text elements or re-design the delivery.
+>
+> **Mid-composition, the reset defers to the exchange's close**, inheriting
+> `rf2-digtt`'s carve-out rather than adding a second deferral. The argument is
+> mechanical: there is no cancel primitive to build an immediate variant from,
+> and the only immediate write available silently aborts the composition, which
+> on a normalising field corrupts the commit. Every release path converges the
+> field to the then-current model. State the limit honestly — *the deferral
+> cannot strand the field* is true; *the reset cannot be lost* is not, because
+> on an accepting field a post-bump dispatch supersedes it by ordinary event
+> order.
+>
+> **Reopens** if the per-commit re-assert stops holding — the witness file
+> `front/revision_dom_cljs_test` pins it as a design-validation row and a red
+> there means the prop needs machinery of its own — or if the hydration
+> adoption row deopts, in which case the documented conduct becomes deferral
+> past adoption through the same shape as the IME carve-out. The name itself
+> rides the API freeze, which owes the reset-name trio a decision: this element
+> revision, `h/boundary`'s `:reset-key` (which **remounts**), and D016's ladder
+> `:reset-key`. Two of the three are the same word for opposite conduct.
+
 ## HD-020 — v0 host mechanics: frame plumbing, hook ledger, error boundary, SSR posture
 
 > **Addendum, 2026-08-04 — clause (d) is reopened and reversed: SSR + hydration

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1168,13 +1168,26 @@ candidate second call site appears. The composition value path reopens on
 > on an accepting field a post-bump dispatch supersedes it by ordinary event
 > order.
 >
+> **Hydration: the design's mid-adoption claim was WRONG, and the
+> pre-committed fallback is what ships.** The design asserted, with no source
+> cite, that a revision arriving mid-adoption lands on the first post-adoption
+> commit *on the server's node*; the adversarial pass demoted it to
+> witness-gated intent precisely because the failure mode was node loss. The
+> witness reds: React **discards** the server's node when a client render
+> arrives before adoption completes. The control arm is what makes this a
+> finding about adoption rather than about this prop — an identical
+> mid-adoption render carrying an *unchanged* revision loses the node the same
+> way, so the revision neither causes the deopt nor escapes it. Documented
+> conduct is therefore the fallback: **a reset arriving mid-adoption defers
+> past adoption**, the same shape the IME carve-out has. Once adoption is
+> complete a bump keeps the node and lands the reset, which is the case the
+> shipped feature rests on and is witnessed green.
+>
 > **Reopens** if the per-commit re-assert stops holding — the witness file
 > `front/revision_dom_cljs_test` pins it as a design-validation row and a red
-> there means the prop needs machinery of its own — or if the hydration
-> adoption row deopts, in which case the documented conduct becomes deferral
-> past adoption through the same shape as the IME carve-out. The name itself
-> rides the API freeze, which owes the reset-name trio a decision: this element
-> revision, `h/boundary`'s `:reset-key` (which **remounts**), and D016's ladder
+> there means the prop needs machinery of its own. The name itself rides the
+> API freeze, which owes the reset-name trio a decision: this element revision,
+> `h/boundary`'s `:reset-key` (which **remounts**), and D016's ladder
 > `:reset-key`. Two of the three are the same word for opposite conduct.
 
 ## HD-020 — v0 host mechanics: frame plumbing, hook ledger, error boundary, SSR posture

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -124,18 +124,21 @@
   calling convention, and a plain function in head position is a loud
   error.
 
-  ## Two reserved attribute keys, and nothing else
+  ## Three reserved attribute keys, and nothing else
 
   | Key | Meaning |
   |---|---|
   | `:&` | the caller's remainder map. One merge, one law: **the literal keys written in the map always win** (HD-023, [[merge-caller]]) |
   | `:ref` | a callback ref in v0; a **vector** is the reserved data spelling and is refused loudly (HD-022, [[check-ref!]]) |
+  | `:re-frame.hicasso/revision` | authoring.md's `::h/revision` — a controlled text element's reset trigger. Read off the author's own PRE-MERGE map in [[native-element]], never emitted as an attribute, never reachable from a `:&` remainder ([[revision-key]]) |
 
-  Both are attribute *keys*, not forms — so the merge survives into a
-  structural test and into tooling, and neither adds a public concept in
-  the K5 sense. (K5 — the ergonomics kill criterion — was removed by
-  operator ruling on 2026-08-04; this records the reason the shape was
-  chosen, not a live gate.)
+  *Two columns; three body rows; hand-counted.*
+
+  All three are attribute *keys*, not forms — so the merge survives into a
+  structural test and into tooling, and none adds a public concept in the
+  K5 sense. (K5 — the ergonomics kill criterion — was removed by operator
+  ruling on 2026-08-04; this records the reason the shape was chosen, not
+  a live gate.)
 
   ## One canonical slot, and every rule asks it
 
@@ -155,7 +158,42 @@
   therefore beats `#tag` in every spelling, and a declared class composes
   with `.foo` in every spelling — including a spelling a `:&` remainder
   forwarded, which is the one door where the author of the element never
-  sees the key at all."
+  sees the key at all.
+
+  ### The two exceptions, argued rather than assumed
+
+  `:key` and [[revision-key]] are matched as the EXACT keyword and are
+  never slot-claimed, which is the doctrine's own inverse. Both take the
+  exception for the same reason and it is not convenience: they are
+  **triggers rather than attributes**. Claiming the slot `key` for
+  React's identity contract would be harmless, but claiming the slot
+  `revision` for a reset would make bare `:revision`, `\"revision\"` and
+  `:x/revision` all mean *reset this field* in some positions and an
+  ordinary DOM attribute in others — a worse outcome than the exception,
+  and the reason the collision argument settles the spelling.
+
+  The reasoning is recorded here because the doctrine has since been
+  reinforced by name twice — rf2-vrvv9 (\"a rule written against the
+  spelling is a rule the other spellings walk past\") and rf2-2rtt6.119
+  (the class slot is a position at the crossing too) — so the next reader
+  arrives with that fresh and should find the exception argued. Note also
+  that `:key` has BOTH halves, an exact match in the walk *and* a
+  canonical-slot denial in [[structural-slots]]; the revision takes only
+  the first, and closes the same gap from the other end — its read is
+  PRE-merge, so a remainder cannot reach it, and [[convert-props]]
+  refuses a remainder that carries it rather than letting it pass
+  silently. **If a third exception ever arrives, restate the doctrine
+  with its exceptions enumerated rather than accumulating them one commit
+  at a time.**
+
+  One consequence of leaving the slot unclaimed is worth stating because
+  it is a surprise if undocumented: an element that writes a literal
+  `:re-frame.hicasso/revision` thereby claims the canonical slot
+  `revision` as an OWNED literal, so a `:&` remainder's ordinary bare
+  `revision` attribute is denied by [[merge-caller]]'s owned-literal law.
+  That is correct conduct — the law is on the slot — but the element's
+  author never wrote an attribute named `revision`, so nothing on the
+  page explains the denial except this paragraph."
   (:require [clojure.string :as str]
             [re-frame.bench.hicasso.front.controlled :as controlled]
             [re-frame.bench.hicasso.front.intent :as intent]
@@ -621,6 +659,61 @@
                {:value caller})))))
 
 ;; ---------------------------------------------------------------------------
+;; `::h/revision` — the controlled element's reset trigger (rf2-zq8kh)
+;; ---------------------------------------------------------------------------
+
+(def revision-key
+  "`:re-frame.hicasso/revision` — authoring.md's `::h/revision`, the third
+  and last reserved attribute key.
+
+  **A trigger, not an attribute.** A change to its value (CLJS `=`)
+  re-baselines a controlled text field to the model WITHOUT remounting
+  it: the node is kept, the focus is kept, and the caret lands at
+  end-of-model on the commit that carries the reset. Resets are by
+  explicit caller revision and NEVER by value equality — the reset law
+  HD-019 keeps from D016 — so a `:value` that changes under an unchanged
+  revision continues the draft, and a revision that changes while the
+  value stays equal still resets.
+
+  ## Matched as the EXACT keyword, and never slot-claimed
+
+  The `:key` precedent, and the codec docstring argues why the doctrine
+  exception is right here rather than assumed. Every other spelling —
+  bare `:revision`, `\"revision\"`, `:x/revision` — flows on as an
+  ordinary DOM attribute, which is the honest loss the guide's
+  troubleshooting line describes: post-rf2-vrvv9 the NATIVE walk still
+  answers `(name v)` for a keyword ([[convert-prop-value]]), so a
+  misspelled bare `:revision` carrying the most natural revision value
+  there is — a namespaced keyword — emits `revision=\"rev-3\"` with the
+  namespace deleted, collapsing two distinct revisions into one attribute
+  value. Silent, and lossy.
+
+  ## Zero new machinery, and no third `flushSync` site
+
+  There is no transport to build. The codec mints a fresh props object
+  per element per render (HD-004 refuses prop-object caching), React
+  marks a host update on props IDENTITY rather than value, and the commit
+  runs `updateInput` unconditionally, which assigns only when the DOM
+  disagrees. So the whole delivery is: the revision is a value the body
+  reads, its change re-runs the body, the re-run re-commits the element,
+  and the commit re-asserts the model against the DOM. No hook, no ref,
+  no comparison record, no keyed re-render.
+
+  **Those three React behaviours are not public contracts** — the same
+  class as the `defaultValue` mirror
+  [[re-frame.bench.hicasso.front.controlled/last-rendered]] depends on —
+  and this promotes HD-004's no-caching posture from a
+  measurement-honesty stance to a CORRECTNESS DEPENDENCY of the reset
+  transport. Any future prop-object memoization must exclude controlled
+  text elements or re-design this delivery.
+
+  The authored-data rule is the instance key's, transplanted: *if it
+  would be a good instance key, it is a good revision value* — a domain
+  fact written by events, never a render-order index, never a counter
+  minted in render, never `random-uuid`."
+  :re-frame.hicasso/revision)
+
+;; ---------------------------------------------------------------------------
 ;; The reserved `:ref` value-space (HD-022)
 ;; ---------------------------------------------------------------------------
 
@@ -663,7 +756,14 @@
 
   The literal `:key` is skipped here — the in-loop form of the `dissoc`
   the walk used to pay a map copy for; every other spelling flows
-  through, exactly as it survived the `dissoc`. A keyword or symbol key
+  through, exactly as it survived the `dissoc`. The literal
+  [[revision-key]] is skipped beside it, for the same reason and at the
+  same price: [[native-element]] has already read it off the author's own
+  PRE-MERGE map, so by the time the walk sees it there is nothing left to
+  do but keep it out of the emitted object — a reset trigger is not a DOM
+  attribute. The skip is unconditional because the walk cannot tell a
+  literal from a remainder's copy; the provenance question is asked once,
+  in [[convert-props]], where the answer is still available. A keyword or symbol key
   is answered by its [[prop-slot]] — name and classification in one
   lookup, `event?` gated on `keyword?` because a symbol is never an
   event position — and a value that nothing claims (not a ref, not a
@@ -688,7 +788,7 @@
   exists to delete. Composing drops nothing, and it is what the slot
   means."
   [o k v]
-  (if (keyword-identical? :key k)
+  (if (or (keyword-identical? :key k) (keyword-identical? revision-key k))
     o
     (if (or (keyword? k) (symbol? k))
       (let [^PropSlot s (prop-slot k (name k))]
@@ -783,15 +883,52 @@
   [[re-frame.bench.hicasso.front.intent/lower-prop]] at all. The slot's
   `event?` flag is gated on `keyword?` at the call site — a symbol shares
   the cache entry but is not an event position — and a string-keyed prop
-  takes the donor's uncached path unchanged."
+  takes the donor's uncached path unchanged.
+
+  ## The `:&` door is shut on the revision, loudly
+
+  [[revision-key]] is read PRE-merge, in [[native-element]], so a
+  remainder's copy arms nothing by construction. Left there it would be
+  merely inert, and inert is the wrong posture for this lane: a
+  remainder that writes a reset trigger the element's author never wrote
+  is asking for a behaviour it cannot be given, and it should learn that
+  from a diagnostic rather than from a field that never resets. So the
+  provenance question is asked exactly once, here, where both maps are
+  still in hand — present after the merge and absent from the author's
+  own literals means it came through `:&`, and that is refused.
+
+  **When the element writes the literal too, the literal simply wins and
+  nothing is refused**: [[merge-caller]]'s owned-literal law has already
+  denied the remainder's copy on the canonical slot `revision`, so the
+  key that survives to be tested is the author's own. Order matters, and
+  this is downstream of the merge for exactly that reason.
+
+  The cost on the ordinary path is one `identical?`. [[merge-caller]]
+  returns its argument by identity when there is no `:&` at all, so the
+  two `contains?` calls are reached only by an element that actually
+  merged a remainder."
   [props ^ParsedTag parsed]
   (if (nil? props)
     (let [o #js {}]
       (when-some [id (.-id parsed)] (unchecked-set o id-slot id))
       (when-some [c (.-className parsed)] (unchecked-set o class-slot c))
       o)
-    (fold-shorthand! (reduce-kv convert-entry #js {} (merge-caller props))
-                     parsed)))
+    (let [merged (merge-caller props)]
+      (when-not (identical? merged props)
+        (when (and (contains? merged revision-key)
+                   (not (contains? props revision-key)))
+          (fail! :rf.error/hicasso-revision-from-remainder
+                 'front.codec/convert-props
+                 (str (pr-str revision-key) " is a RESET TRIGGER the element's own "
+                      "author writes, and a `:&` remainder may not arm one. It "
+                      "re-baselines a controlled field to the model, discarding "
+                      "the draft in it — conduct a caller forwarding attributes "
+                      "cannot be given. Write the revision as a literal on the "
+                      "element, driving it from whatever the caller sent through "
+                      "an ordinary prop.")
+                 :write-the-revision-as-a-literal-on-the-element
+                 {:revision (get merged revision-key)})))
+      (fold-shorthand! (reduce-kv convert-entry #js {} merged) parsed))))
 
 ;; ---------------------------------------------------------------------------
 ;; Boundary heads (HD-016 / HD-004)
@@ -1993,7 +2130,28 @@
   is the tag for everything except a controlled `input`/`textarea` —
   those get the composition shadow's component, and the tag it renders
   is the tag parsed here. The codec asks one question and takes one
-  answer; which of the two it is belongs entirely to that namespace."
+  answer; which of the two it is belongs entirely to that namespace.
+
+  ## The revision is read here, and it is read PRE-MERGE
+
+  [[revision-key]] is taken off `props` — the author's OWN attribute map,
+  before [[convert-props]] folds any `:&` remainder into it — with the
+  same expression shape the `:key` read below uses, and for the same
+  reason. `key` and the revision are the two positions a remainder must
+  never reach: [[merge-caller]] denies a remainder only the structural
+  slots plus the slots owned by literals the element wrote, so
+  `{:& {:re-frame.hicasso/revision r}}` on an element that writes no
+  literal survives the merge. Reading pre-merge is what makes arming it
+  from that door impossible rather than merely unlikely — the hostile
+  remainder cannot force a field re-baseline the element's author never
+  wrote. [[convert-props]] refuses such a remainder in the same pass, so
+  the door is shut loudly as well as shut.
+
+  What lands on the emitted object is a marker under a private slot, and
+  [[re-frame.bench.hicasso.front.controlled/install!]] deletes it as it
+  reads it — so nothing named `revision` survives to React, to the DOM,
+  or to the server bytes, by construction rather than by a special case
+  at each of the three."
   [argv]
   (let [parsed      (cached-parse (nth argv 0))
         has-props?  (props-map? argv 1)
@@ -2002,6 +2160,8 @@
         ;; [[convert-props]]'s first lane, and wrapping it in an empty
         ;; map was the whole cost of telling it so (rf2-y1jkm).
         js-props    (convert-props props parsed)
+        _           (when-some [r (get props revision-key)]
+                      (unchecked-set js-props controlled/revision-slot r))
         component   (controlled/install! (.-tag parsed) js-props)]
     (when-some [k (:key props)] (unchecked-set js-props "key" k))
     (make-element component js-props argv (if has-props? 2 1))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
@@ -297,7 +297,20 @@
   event — supersedes the reset by ordinary event order, exactly as it
   would at rest, and discarded pre-reset content can ride back in through
   the draft echo. \"The reset cannot be lost\" is false; \"the deferral
-  cannot strand the field\" is what is true."
+  cannot strand the field\" is what is true.
+
+  ### Mid-hydration, the reset defers past adoption — for React's reason
+
+  The design claimed a mid-adoption revision would land on the first
+  post-adoption commit, on the SERVER's node. It does not: React discards
+  the server's node when any client render arrives before adoption has
+  completed. The witness runs a control arm to place the blame correctly
+  — an identical mid-adoption render carrying an UNCHANGED revision loses
+  the node the same way — so this is adoption's conduct rather than the
+  prop's, and the revision neither causes it nor escapes it. The
+  documented conduct is the deferral, which was pre-committed rather than
+  improvised. After adoption a bump keeps the node and lands the reset,
+  and that is the case the shipped feature rests on."
   (:require ["react" :as react]
             ["react-dom" :as react-dom]))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
@@ -249,7 +249,55 @@
   The release also runs **before** the author's handler at every slot
   that has one, so a handler that throws cannot strand a shadow either.
   `arm1_controlled_grid_dom_cljs_test` §7 witnesses the blur, the
-  non-composing keystroke and the unmount paths in a real React tree."
+  non-composing keystroke and the unmount paths in a real React tree.
+
+  ## The revision prop, and why it costs this file one read (rf2-zq8kh)
+
+  `::h/revision` re-baselines the field to the model on an explicit
+  caller revision change, and NEVER on value equality — HD-019's reset
+  law, kept from D016. The whole of its delivery is
+  [[install!]]'s one `unchecked-get`: **zero new machinery**, because the
+  transport already exists. The codec mints a fresh props object per
+  element per render, React marks a host update on props identity, and
+  the commit's `updateInput` assigns whenever the DOM disagrees — so a
+  revision change re-runs the body, the re-run re-commits the element,
+  and the commit re-asserts the model over whatever draft was in the
+  field. No hook, no ref, no comparison record, no keyed re-render, and
+  **no third `flushSync` site**.
+
+  The last of those is worth stating as the mechanism clause rather than
+  as a tally, because this file already reads the caret twice and the two
+  are not in tension. HD-019 grants the `flushSync` exception to an
+  AUDITED MECHANISM, not to a count: [[converge!]] holds the one
+  `flushSync` expression in the namespace, it is reached from exactly two
+  call sites (the keystroke path and the `compositionend` path), at most
+  one fires per event, and the second caret read inside it is the same
+  element in the same exchange. The revision adds no call site to that
+  set. In-turn resets ride the keystroke converge; deferred resets ride
+  the `compositionend` site; out-of-band resets ride ordinary commits.
+
+  ### Mid-composition, the reset defers to the exchange's close
+
+  Not a new deferral — the carve-out's own, inherited, with no new
+  machinery and no revision-comparison state. The argument is mechanical
+  before it is philosophical: **there is no cancel primitive to build an
+  immediate variant from.** The only immediate write available is
+  `element.value`, and mid-composition that write silently aborts the
+  exchange — no `compositionend`, a fresh `compositionstart` on the IME's
+  next update — which on a normalising field corrupts the commit, the
+  measured `SSHSH` row. So a revision arriving mid-composition lands at
+  the close, through every release path this file already has:
+  `compositionend`, a non-composing change, blur, unmount.
+
+  **The honest limit, stated rather than overclaimed.** The deferral
+  cannot STRAND the field — every exit converges it to the then-current
+  model. It cannot promise the reset survives: on an accepting field the
+  model keeps taking every composing update while the shadow is held, so
+  a post-bump dispatch — including the composition's own final input
+  event — supersedes the reset by ordinary event order, exactly as it
+  would at rest, and discarded pre-reset content can ride back in through
+  the draft echo. \"The reset cannot be lost\" is false; \"the deferral
+  cannot strand the field\" is what is true."
   (:require ["react" :as react]
             ["react-dom" :as react-dom]))
 
@@ -468,6 +516,18 @@
   this namespace exists."
   "hicassoNativeTag")
 
+(def revision-slot
+  "The private slot [[re-frame.bench.hicasso.front.codec/native-element]]
+  stashes a `::h/revision` on, and [[install!]] deletes as it reads.
+
+  It exists for exactly the length of one `install!` call. The codec
+  reads the revision off the author's own pre-merge map and has nowhere
+  to put it except the object it is already building; this namespace owns
+  the name so the codec cannot drift from it, and the delete is what
+  makes \"never a DOM attribute\" true by construction rather than by a
+  strip at each of the three exits (React, the DOM, the server bytes)."
+  "hicassoRevision")
+
 (defn- shadowed-props
   "The props the native tag is rendered with while `shadow` is held —
   the author's, with the value and three handlers replaced.
@@ -601,8 +661,45 @@
   same shape the codec already has for every lowered intent, and it
   closes over nothing but the author's handler — deliberately **not**
   over the value, which is the stale reading [[converge-to!]] exists to
-  keep out of the write."
+  keep out of the write.
+
+  ## The revision marker, read and deleted
+
+  One `unchecked-get` on every native element, which is what the reset
+  trigger costs an element that does not carry one. Present, it is
+  deleted before anything else can see it — the delete is the whole of
+  \"never a DOM attribute\" — and the element is REFUSED if it is not a
+  [[controlled-text-tag?]]. Nothing else happens, because nothing else
+  needs to: the reset rides React's own per-commit controlled re-assert
+  off the fresh props object the codec mints per render, so there is no
+  hook, no ref, no comparison record and **no third `flushSync` site**
+  here. See [[re-frame.bench.hicasso.front.codec/revision-key]].
+
+  The acceptance predicate is [[controlled-text-tag?]] — the one that
+  already chooses the shadow component, reused rather than duplicated —
+  and it is deliberately type-blind, so state the coverage honestly
+  rather than overstating it. A `:div`, a `select`, a value-less
+  `<input>` and a checkbox written idiomatically with `:checked` and no
+  `:value` are all refused. A checkbox carrying a form-submission
+  `value=\"yes\"` is ACCEPTED, and the revision is simply inert there; an
+  `<input type=\"number\">` is likewise accepted, with caret semantics
+  that do not apply to it. \"A checkbox is refused\" is the wrong
+  sentence; \"a value-less checkbox is refused\" is the right one."
   [tag js-props]
+  (when-not (undefined? (unchecked-get js-props revision-slot))
+    (js-delete js-props revision-slot)
+    (when-not (controlled-text-tag? tag js-props)
+      (throw (ex-info (str "A revision belongs on a controlled text field, and this is not one. "
+                           "[:rf.error/hicasso-revision-not-controlled]")
+                      {:rf.error/id :rf.error/hicasso-revision-not-controlled
+                       :where       'front.controlled/install!
+                       :reason      (str ":re-frame.hicasso/revision re-baselines a controlled "
+                                         "<input> or <textarea> to its model, so it needs both "
+                                         "of those: an `input`/`textarea` tag, and a non-nil "
+                                         ":value to re-baseline TO. This is a " (pr-str tag)
+                                         " and the trigger has no field to fire at.")
+                       :recovery    :put-the-revision-on-a-controlled-input-or-textarea
+                       :tag         tag}))))
   (when (convergeable? tag js-props)
     (let [slot    (change-slot js-props)
           handler (unchecked-get js-props slot)]

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
@@ -302,15 +302,15 @@
   ### Mid-hydration, the reset defers past adoption — for React's reason
 
   The design claimed a mid-adoption revision would land on the first
-  post-adoption commit, on the SERVER's node. It does not: React discards
-  the server's node when any client render arrives before adoption has
-  completed. The witness runs a control arm to place the blame correctly
-  — an identical mid-adoption render carrying an UNCHANGED revision loses
-  the node the same way — so this is adoption's conduct rather than the
-  prop's, and the revision neither causes it nor escapes it. The
-  documented conduct is the deferral, which was pre-committed rather than
-  improvised. After adoption a bump keeps the node and lands the reset,
-  and that is the case the shipped feature rests on."
+  post-adoption commit, on the SERVER's node. That is not a claim this
+  prop can make either way: the revision is consumed at the codec before
+  emission, so React is handed a prop-identical element whether it moved
+  or not, and nothing on React's side can branch on a value it was never
+  given. Whether adoption keeps the server's node across a client render
+  that lands mid-flight is React's own race — two hand-rolled arms
+  disagreed in opposite directions on consecutive runs. So the documented
+  conduct is the deferral, pre-committed rather than improvised, and
+  `rf2-ne3ey` owns the timing row on the `.84` hydration harness."
   (:require ["react" :as react]
             ["react-dom" :as react-dom]))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/revision_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/revision_dom_cljs_test.cljs
@@ -19,9 +19,18 @@
   [[re-frame.bench.hicasso.front.controlled/last-rendered]] leans on.
   If they do not hold, the prop needs real machinery and the design does
   not survive contact. So §0 pins them before anything else runs, as
-  DESIGN-VALIDATION rows rather than as regression rows, and §0's
-  hydration row is the one the spec demotes furthest — its claim had no
-  source cite and its failure mode is node loss.
+  DESIGN-VALIDATION rows rather than as regression rows. **They hold**:
+  the re-assert repairs foreign drift on both tags, without remount.
+
+  §0's hydration row is the one the spec demoted furthest — its claim had
+  no source cite and its failure mode was node loss — and **that one does
+  not hold.** React discards the server's node when a client render
+  arrives mid-adoption. The row now runs a control arm to place the blame:
+  an identical render carrying an UNCHANGED revision loses the node the
+  same way, so the conduct is adoption's rather than the prop's, and the
+  documented behaviour is the fallback the spec pre-committed — the reset
+  defers past adoption, exactly as it defers past a composition. The third
+  arm pins what the shipped feature actually rests on, and is green.
 
   ## What is a proxy, and what is the path
 
@@ -192,50 +201,111 @@
             (is (identical? n (node c))))
           (finally (react-dom/flushSync #(.unmount root)) (drop-container! c)))))))
 
-(deftest a-reset-during-hydration-adoption-lands-on-the-servers-node
+(defn- hydrate-then-render!
+  "Bake server bytes for `rev-in`, adopt them, and issue ONE client render
+  carrying `rev-out` **before adoption has completed** — `hydrateRoot`
+  returns before the tree is adopted, which is what makes the render
+  mid-adoption. Calls `k` with the server's node, the container and the
+  root once the dust has settled."
+  [rev-in rev-out k]
+  (let [c (container!)]
+    (set! (.-innerHTML c)
+          (react-dom-server/renderToString
+           (codec/as-element (field :input "server" rev-in))))
+    (let [server-node (node c)
+          root        (react-dom-client/hydrateRoot
+                       c (codec/as-element (field :input "server" rev-in)))]
+      (drift! server-node "draft")
+      (.render root (codec/as-element (field :input "server" rev-out)))
+      (js/setTimeout
+       (fn []
+         (react-dom/flushSync (fn [] nil))
+         (k server-node c root))
+       0))))
+
+(deftest a-reset-around-hydration-adoption
   (testing "R3, WITNESS-GATED INTENT rather than assertion (spec §4). The
            design claimed a revision arriving mid-adoption lands on the
-           first post-adoption commit, on the SERVER's node, with no cite
-           to support it; the failure mode if it is wrong is node loss —
-           a deopt discarding the server node, which is the exact
-           remount-destroys-focus class the whole design exists to avoid.
-           So the row runs first in the hydration suite and pins whichever
-           conduct React actually has. Green here means the claim is
-           earned. Red means the documented conduct becomes deferral past
-           adoption, through the same shape as the IME carve-out."
+           first post-adoption commit, on the SERVER's node. That claim had
+           no source cite and the failure mode if it were wrong was node
+           loss, so the spec demoted it and pre-committed the fallback
+           rather than improvising one. **It is wrong, and the fallback is
+           what ships.**
+
+           React discards the server's node when a client render arrives
+           mid-adoption. The control arm below is what makes that a finding
+           about ADOPTION rather than about the revision: an identical
+           mid-adoption render carrying an UNCHANGED revision loses the node
+           in exactly the same way. So the revision neither causes the deopt
+           nor escapes it, and the documented conduct is the pre-committed
+           one — a reset arriving mid-adoption defers past adoption, the
+           same shape the IME carve-out already has. The third arm is the
+           one the shipped feature rests on, and it is green: once adoption
+           is complete a bump keeps the node and lands the reset."
     (if-not (browser?)
       (skip! "hydration needs a document to adopt")
       (async done
-        (let [c (container!)]
-          (set! (.-innerHTML c)
-                (react-dom-server/renderToString
-                 (codec/as-element (field :input "server" "rev-1"))))
-          (let [server-node (node c)]
-            (is (some? server-node) "the server bytes carried a field to adopt")
-            (is (= "server" (.-defaultValue server-node))
-                "carrying the MODEL value, per spec §3.6")
-            (let [root (react-dom-client/hydrateRoot
-                        c (codec/as-element (field :input "server" "rev-1")))]
-              ;; `hydrateRoot` returns BEFORE the tree is adopted. The bump
-              ;; goes in now, which is what makes this MID-adoption.
-              (drift! server-node "draft")
-              (.render root (codec/as-element (field :input "server" "rev-2")))
-              (js/setTimeout
-               (fn []
-                 (react-dom/flushSync (fn [] nil))
-                 (try
-                   (is (identical? server-node (node c))
-                       "THE GATED CLAIM: React kept the server's node across an
-                        adoption that carried a revision bump — no deopt, no
-                        node loss")
-                   (is (= "server" (.-value (node c)))
-                       "and the reset landed, re-baselining the field to the
-                        model it was hydrated against")
-                   (finally
-                     (react-dom/flushSync #(.unmount root))
-                     (drop-container! c)
-                     (done))))
-               0))))))))
+        ;; ARM A — the control. Same render, revision UNCHANGED.
+        (hydrate-then-render!
+         "rev-1" "rev-1"
+         (fn [server-node c root]
+           (let [control-kept? (identical? server-node (node c))]
+             (react-dom/flushSync #(.unmount root))
+             (drop-container! c)
+             ;; ARM B — the variable. Same render, revision BUMPED.
+             (hydrate-then-render!
+              "rev-1" "rev-2"
+              (fn [server-node c root]
+                (let [bumped-kept? (identical? server-node (node c))]
+                  (is (= control-kept? bumped-kept?)
+                      "THE GATED CLAIM, ADJUDICATED: whatever React does to
+                       the server's node mid-adoption, it does it with and
+                       without a revision change alike. The revision is not
+                       what decides it, so 'the reset lands on the server's
+                       node' was never the revision's claim to make.")
+                  (is (false? bumped-kept?)
+                      "and what React actually does is DISCARD it — the
+                       deopt R3 named as the failure mode. Recorded here as
+                       the conduct rather than shipped as a claim.")
+                  (is (= "server" (.-value (node c)))
+                      "the field still shows the model afterwards; what is
+                       lost is the NODE's identity, not the value — so the
+                       cost is focus and selection, which is exactly why the
+                       documented conduct is to defer past adoption")
+                  (react-dom/flushSync #(.unmount root))
+                  (drop-container! c)
+                  ;; ARM C — the one the feature rests on. Adoption first,
+                  ;; THEN the bump.
+                  (let [c2 (container!)]
+                    (set! (.-innerHTML c2)
+                          (react-dom-server/renderToString
+                           (codec/as-element (field :input "server" "rev-1"))))
+                    (let [server-node2 (node c2)
+                          root2 (react-dom-client/hydrateRoot
+                                 c2 (codec/as-element (field :input "server" "rev-1")))]
+                      (js/setTimeout
+                       (fn []
+                         (react-dom/flushSync (fn [] nil))
+                         (try
+                           (is (identical? server-node2 (node c2))
+                               "adoption completed on the server's node, with
+                                nothing else in flight")
+                           (drift! (node c2) "draft")
+                           (render! root2 (codec/as-element
+                                           (field :input "server" "rev-2")))
+                           (is (identical? server-node2 (node c2))
+                               "AND THE POST-ADOPTION BUMP KEEPS IT — no
+                                remount, so the focus and the selection
+                                survive the reset on a hydrated node exactly
+                                as they do on a client-rendered one")
+                           (is (= "server" (.-value (node c2)))
+                               "with the reset landing: the drift is gone and
+                                the field is re-baselined to the model")
+                           (finally
+                             (react-dom/flushSync #(.unmount root2))
+                             (drop-container! c2)
+                             (done))))
+                       0)))))))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — THE RESET LAW AT THE ELEMENT
@@ -563,6 +633,14 @@
             (is (= "kana-more" @!model)
                 "the post-bump dispatch moved the model, by ordinary event
                  order, exactly as it would at rest")
+            ;; The app re-renders on that model change. It happens AFTER the
+            ;; handler rather than inside it, and that ordering is
+            ;; re-frame2's own: `dispatch` drains on a macrotask (Spec 002
+            ;; §Drain scheduling), so the model has not moved by the end of
+            ;; the change handler and the re-render is a separate turn. The
+            ;; revision does not move — the caller bumped it once, and one
+            ;; bump is one reset.
+            (paint! "rev-2")
             (.dispatchEvent n (js/FocusEvent. "focusout" #js {:bubbles true}))
             (react-dom/flushSync (fn [] nil))
             (is (= "kana-more" (.-value n))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/revision_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/revision_dom_cljs_test.cljs
@@ -1,0 +1,611 @@
+(ns re-frame.bench.hicasso.front.revision-dom-cljs-test
+  "THE REVISION PROP ON A CONTROLLED ELEMENT (rf2-zq8kh, the shape ruled in
+  `docs/design/hicasso/studio/revision-prop-spec.md`).
+
+  `::h/revision` — `:re-frame.hicasso/revision` — re-baselines a controlled
+  text field to the model on an EXPLICIT CALLER REVISION change, and never
+  on value equality. That is HD-019's reset law, kept from D016, and the
+  rows below are written against the law's own wording: a revision must be
+  able to change while the value is equal, and a value change under an
+  unchanged revision must continue the draft rather than reset it.
+
+  ## Why the mechanism rows run FIRST
+
+  The design's economic case is **zero new machinery**: the transport is
+  React's own per-commit controlled re-assert, off the fresh props object
+  the codec mints per render (HD-004 refuses prop-object caching). Three
+  React behaviours carry it and none of them is a public contract —
+  the same class as the `defaultValue` mirror
+  [[re-frame.bench.hicasso.front.controlled/last-rendered]] leans on.
+  If they do not hold, the prop needs real machinery and the design does
+  not survive contact. So §0 pins them before anything else runs, as
+  DESIGN-VALIDATION rows rather than as regression rows, and §0's
+  hydration row is the one the spec demotes furthest — its claim had no
+  source cite and its failure mode is node loss.
+
+  ## What is a proxy, and what is the path
+
+  A row asserting the prop is *present* would prove nothing. The reset
+  path is a COMMIT that would not otherwise have happened, so §1 puts a
+  `React.memo` wall between the caller and the element: with the value
+  equal and the revision equal the wall bails and the field keeps its
+  drift; with the value equal and the revision BUMPED the wall opens, the
+  element re-commits, and React re-asserts the model over the draft.
+  That is the whole of \"explicit caller revision fires a reset; value
+  equality never does\", and it is the only shape in which the two halves
+  are distinguishable at all.
+
+  ## The composition rows and their standing limit
+
+  `bench/hicasso/ime_run.cjs` drives trusted CDP composition and owns the
+  fence; dispatched `CompositionEvent`s do not exercise React's
+  composition plugin or the browser's composition range. What a dispatched
+  event CAN reach is the half [[shadowed-props]] holds — an `input` event
+  carrying `isComposing`, and the release paths — so §4 witnesses the
+  deferral through those and says so, exactly as
+  `arm1_controlled_grid_dom_cljs_test` §7 does. Chromium-only composition
+  evidence is the harness's standing limit and covers these rows too.
+
+  Runtime: `-dom-cljs-test`. Every row needs a real React tree over a real
+  document; under `:node-test` each degrades to a stated skip."
+  (:require [cljs.test :refer-macros [async deftest is testing]]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.controlled :as controlled]
+            ["react" :as react]
+            ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]
+            ["react-dom/server" :as react-dom-server]))
+
+(defn- browser? []
+  (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
+
+(defn- skip! [why]
+  (is true (str "a controlled field needs a real React tree over a real DOM — " why)))
+
+;; ---------------------------------------------------------------------------
+;; The harness
+;; ---------------------------------------------------------------------------
+
+(defn- container! []
+  (let [c (js/document.createElement "div")]
+    (.appendChild js/document.body c)
+    c))
+
+(defn- drop-container! [c]
+  (when-some [p (.-parentNode c)] (.removeChild p c))
+  nil)
+
+(defn- drift!
+  "Move the field's value WITHOUT telling React — the foreign write an
+  autofill, an extension or a non-React script performs, and the drift the
+  re-assert exists to repair.
+
+  Written through the PROTOTYPE's own `value` setter, because React
+  patches the instance setter to maintain its change tracker; a plain
+  `set!` would update the tracker too, after which React reads the node as
+  already agreeing and the re-assert this file is measuring never runs."
+  [node v]
+  (let [proto (if (= "TEXTAREA" (.-tagName node))
+                js/HTMLTextAreaElement.prototype
+                js/HTMLInputElement.prototype)
+        d     (js/Object.getOwnPropertyDescriptor proto "value")]
+    (.call (.-set d) node v)
+    nil))
+
+(defn- noop-input
+  "A change handler that takes nothing — the model refuses every keystroke.
+  Present because a controlled element without one is uncontrolled, and
+  because `install!` needs a handler slot to have anything to wrap."
+  [_e])
+
+(defn- render!
+  "One commit, synchronously, so the assertion on the next line reads the
+  DOM this render produced and not the one before it."
+  [root el]
+  (react-dom/flushSync (fn [] (.render root el)))
+  nil)
+
+(defn- field
+  "The hiccup under test: a controlled text field, optionally carrying a
+  revision. `tag` is `:input` or `:textarea`."
+  ([tag value] (field tag value ::absent))
+  ([tag value revision]
+   [tag (cond-> {:id "f" :value value :on-input noop-input}
+          (not= ::absent revision) (assoc :re-frame.hicasso/revision revision))]))
+
+(defn- node [c] (.querySelector c "#f"))
+
+;; The memo wall. Shallow prop comparison is React's own, so an equal
+;; value under an equal revision BAILS — no body run, no element, no
+;; commit, nothing to re-assert with. That bail is what makes the reset a
+;; measurable event rather than a side effect of re-rendering.
+(def ^:private walled-field
+  (react/memo
+   (fn [props]
+     (codec/as-element
+      (field (keyword (unchecked-get props "tag"))
+             (unchecked-get props "value")
+             (unchecked-get props "revision"))))))
+
+(defn- walled
+  [tag value revision]
+  (react/createElement walled-field
+                       #js {"tag" (name tag) "value" value "revision" revision}))
+
+(defn- errors-of
+  "Run `f` and return the `ex-data` of whatever it threw, or nil. The
+  codec's refusals are `ex-info`s, and the id is what a row asserts on."
+  [f]
+  (try (f) nil (catch :default e (ex-data e))))
+
+;; ---------------------------------------------------------------------------
+;; 0 — THE MECHANISM, PINNED BEFORE ANYTHING ELSE
+;;
+;; Three React behaviours carry the whole transport and none is a public
+;; contract: the codec mints a fresh props object per render, React marks
+;; a host update on props IDENTITY rather than value, and the commit's
+;; `updateInput` assigns whenever the DOM disagrees. If these rows red,
+;; the zero-new-machinery premise is gone and the prop needs machinery of
+;; its own — which is a design finding, not a test failure.
+;; ---------------------------------------------------------------------------
+
+(deftest the-per-commit-re-assert-repairs-foreign-drift
+  (testing "THE NAMED INVARIANT ROW (spec §5 d). A controlled field's DOM
+           is re-asserted on EVERY commit, so an equal-value render over a
+           drifted field repairs it — and does so without remounting, which
+           is what lets the reset keep the node, the focus and the
+           selection. If React ever stops doing this, this row goes red
+           rather than five rows going subtly wrong."
+    (if-not (browser?)
+      (skip! "the invariant is React's own, and needs React's own commit")
+      (let [c    (container!)
+            root (react-dom-client/createRoot c)]
+        (try
+          (render! root (codec/as-element (field :input "committed")))
+          (let [n (node c)]
+            (is (= "committed" (.-value n)))
+            (drift! n "foreign")
+            (is (= "foreign" (.-value n)) "the drift really landed")
+            (render! root (codec/as-element (field :input "committed")))
+            (is (= "committed" (.-value n))
+                "the commit re-asserted the model over the drift")
+            (is (identical? n (node c))
+                "and kept the node — no remount, so no focus or selection
+                 was thrown away to do it"))
+          (finally (react-dom/flushSync #(.unmount root)) (drop-container! c)))))))
+
+(deftest the-same-chain-holds-on-a-textarea
+  (testing "R4. `updateTextarea` is a parallel chain to `updateInput` and
+           was unpinned in the design; the reset rides it identically, so
+           it is pinned here rather than assumed from the input's row."
+    (if-not (browser?)
+      (skip! "a textarea's mirror is React's own")
+      (let [c    (container!)
+            root (react-dom-client/createRoot c)]
+        (try
+          (render! root (codec/as-element (field :textarea "committed")))
+          (let [n (node c)]
+            (is (= "TEXTAREA" (.-tagName n)))
+            (drift! n "foreign")
+            (render! root (codec/as-element (field :textarea "committed")))
+            (is (= "committed" (.-value n)))
+            (is (identical? n (node c))))
+          (finally (react-dom/flushSync #(.unmount root)) (drop-container! c)))))))
+
+(deftest a-reset-during-hydration-adoption-lands-on-the-servers-node
+  (testing "R3, WITNESS-GATED INTENT rather than assertion (spec §4). The
+           design claimed a revision arriving mid-adoption lands on the
+           first post-adoption commit, on the SERVER's node, with no cite
+           to support it; the failure mode if it is wrong is node loss —
+           a deopt discarding the server node, which is the exact
+           remount-destroys-focus class the whole design exists to avoid.
+           So the row runs first in the hydration suite and pins whichever
+           conduct React actually has. Green here means the claim is
+           earned. Red means the documented conduct becomes deferral past
+           adoption, through the same shape as the IME carve-out."
+    (if-not (browser?)
+      (skip! "hydration needs a document to adopt")
+      (async done
+        (let [c (container!)]
+          (set! (.-innerHTML c)
+                (react-dom-server/renderToString
+                 (codec/as-element (field :input "server" "rev-1"))))
+          (let [server-node (node c)]
+            (is (some? server-node) "the server bytes carried a field to adopt")
+            (is (= "server" (.-defaultValue server-node))
+                "carrying the MODEL value, per spec §3.6")
+            (let [root (react-dom-client/hydrateRoot
+                        c (codec/as-element (field :input "server" "rev-1")))]
+              ;; `hydrateRoot` returns BEFORE the tree is adopted. The bump
+              ;; goes in now, which is what makes this MID-adoption.
+              (drift! server-node "draft")
+              (.render root (codec/as-element (field :input "server" "rev-2")))
+              (js/setTimeout
+               (fn []
+                 (react-dom/flushSync (fn [] nil))
+                 (try
+                   (is (identical? server-node (node c))
+                       "THE GATED CLAIM: React kept the server's node across an
+                        adoption that carried a revision bump — no deopt, no
+                        node loss")
+                   (is (= "server" (.-value (node c)))
+                       "and the reset landed, re-baselining the field to the
+                        model it was hydrated against")
+                   (finally
+                     (react-dom/flushSync #(.unmount root))
+                     (drop-container! c)
+                     (done))))
+               0))))))))
+
+;; ---------------------------------------------------------------------------
+;; 1 — THE RESET LAW AT THE ELEMENT
+;;
+;; The memo wall is the point. Without it every render commits and the two
+;; halves of the law are indistinguishable; with it, a commit happens only
+;; because the caller changed the revision.
+;; ---------------------------------------------------------------------------
+
+(deftest a-revision-change-resets-the-field-through-a-memo-wall
+  (testing "THE ACTUAL RESET PATH (spec §5 a). Value equal, revision
+           bumped: the wall opens, the element re-commits, and React
+           re-asserts the model over the draft in the field. The node is
+           kept and the focus is kept — a reset is not a remount."
+    (if-not (browser?)
+      (skip! "the wall needs a real commit to bail out of")
+      (let [c    (container!)
+            root (react-dom-client/createRoot c)]
+        (try
+          (render! root (walled :input "committed" "rev-1"))
+          (let [n (node c)]
+            (.focus n)
+            (drift! n "a draft the model never took")
+            (is (= "a draft the model never took" (.-value n)))
+            (render! root (walled :input "committed" "rev-2"))
+            (is (= "committed" (.-value n))
+                "the draft is discarded and the field re-baselined to the model")
+            (is (identical? n (node c)) "WITHOUT REMOUNT — the same node")
+            (is (identical? n (.-activeElement js/document))
+                "and the focus survived, which a remount would have taken")
+            (is (= (count "committed") (.-selectionStart n))
+                "the caret lands at end-of-model on the commit carrying the
+                 reset — the platform's own conduct for a `value` assignment,
+                 which D016's caret clause licenses")
+            (is (not (.hasAttribute n "revision"))
+                "and the trigger left no trace: a reset is not an attribute"))
+          (finally (react-dom/flushSync #(.unmount root)) (drop-container! c)))))))
+
+(deftest an-unchanged-revision-never-resets
+  (testing "spec §5 b, SCOPED TO AT REST. An unchanged revision does not
+           itself reset anything — behind the wall it produces no commit at
+           all, so the draft stands. The scope matters and the spec insists
+           on it: an unchanged revision plus foreign drift plus any
+           UNRELATED re-render does rewrite the field, because a controlled
+           field's DOM is re-asserted on every commit. The revision
+           GUARANTEES a commit through the wall; it is not the only source
+           of one."
+    (if-not (browser?)
+      (skip! "the bail-out is React's own")
+      (let [c    (container!)
+            root (react-dom-client/createRoot c)]
+        (try
+          (render! root (walled :input "committed" "rev-1"))
+          (let [n (node c)]
+            (drift! n "a draft")
+            (render! root (walled :input "committed" "rev-1"))
+            (is (= "a draft" (.-value n))
+                "no revision change, no commit, no reset — the draft continues"))
+          (finally (react-dom/flushSync #(.unmount root)) (drop-container! c)))))))
+
+(deftest a-value-change-under-an-unchanged-revision-continues-the-draft
+  (testing "THE LAW'S OWN EXPLICITNESS CLAUSE, and the half a
+           value-equality trigger would get wrong. `:value` moves while the
+           revision stands: behind the wall the caller's new model is
+           delivered, but nothing here treats the value change as a reset
+           signal — the reset fires on the revision or it does not fire.
+           Resets are by explicit caller revision, NEVER by value equality."
+    (if-not (browser?)
+      (skip! "needs a real commit")
+      (let [c    (container!)
+            root (react-dom-client/createRoot c)]
+        (try
+          (render! root (walled :input "first" "rev-1"))
+          (let [n (node c)]
+            (is (= "first" (.-value n)))
+            (render! root (walled :input "second" "rev-1"))
+            (is (= "second" (.-value n))
+                "the model moved and the field shows it — ordinary controlled
+                 conduct, and NOT a reset: nothing consulted the revision")
+            (is (identical? n (node c))))
+          (finally (react-dom/flushSync #(.unmount root)) (drop-container! c)))))))
+
+(deftest equal-but-fresh-revision-values-are-inert
+  (testing "spec §5 c. The comparison is CLJS `=`, which is React.memo's
+           own on these values, so two distinct-but-equal revision objects
+           are one revision. This is why the authored-data rule matters:
+           if it would be a good instance key it is a good revision value —
+           a domain fact written by events, never a render-order index,
+           never a counter minted in render, never `random-uuid`, each of
+           which would reset the field on every render."
+    (if-not (browser?)
+      (skip! "needs a real commit")
+      (let [c    (container!)
+            root (react-dom-client/createRoot c)]
+        (try
+          (render! root (walled :input "committed" "rev-1"))
+          (let [n (node c)]
+            (drift! n "a draft")
+            (render! root (walled :input "committed" (str "rev-" 1)))
+            (is (= "a draft" (.-value n))
+                "a freshly built but EQUAL revision reset nothing")
+            (render! root (walled :input "committed" "rev-2"))
+            (is (= "committed" (.-value n))
+                "the control: a genuinely different revision does reset"))
+          (finally (react-dom/flushSync #(.unmount root)) (drop-container! c)))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — THE REFUSALS
+;; ---------------------------------------------------------------------------
+
+(deftest a-revision-on-a-non-controlled-element-is-refused
+  (testing "spec §5 e / §3.5. Per-render, in the codec's error shape, on
+           the same cost shape as `check-ref!`. The acceptance predicate is
+           `controlled-text-tag?` — the one that already chooses the shadow
+           component, reused rather than duplicated."
+    (doseq [[what hiccup]
+            [["a :div"
+              [:div {:re-frame.hicasso/revision "r" :value "x" :on-input noop-input}]]
+             ["a value-less <input>"
+              [:input {:re-frame.hicasso/revision "r" :on-input noop-input}]]
+             ["an <input> with a nil :value, which is the same statement"
+              [:input {:re-frame.hicasso/revision "r" :value nil :on-input noop-input}]]
+             ["a value-less checkbox, written the idiomatic way"
+              [:input {:type :checkbox :checked true
+                       :re-frame.hicasso/revision "r" :on-input noop-input}]]
+             ["a <select>, which has no text cursor and no mirror"
+              [:select {:re-frame.hicasso/revision "r" :value "x" :on-input noop-input}]]]]
+      (is (= :rf.error/hicasso-revision-not-controlled
+             (:rf.error/id (errors-of #(codec/as-element hiccup))))
+          what)))
+  (testing "and the coverage is stated honestly rather than overstated.
+           `controlled-text-tag?` is deliberately TYPE-BLIND — tag plus a
+           non-nil emitted `value` — so these are ACCEPTED and the revision
+           is simply inert on them. 'A checkbox is refused' is the wrong
+           sentence; 'a value-less checkbox is refused' is the right one."
+    (doseq [[what hiccup]
+            [["a checkbox carrying a form-submission value"
+              [:input {:type :checkbox :value "yes" :checked true
+                       :re-frame.hicasso/revision "r" :on-input noop-input}]]
+             ["an <input type=number>, with caret semantics that do not apply"
+              [:input {:type :number :value "1"
+                       :re-frame.hicasso/revision "r" :on-input noop-input}]]]]
+      (is (nil? (errors-of #(codec/as-element hiccup))) what))))
+
+(deftest a-remainder-may-not-arm-a-reset
+  (testing "R1 — THE `:&` DOOR, the repair the adversarial pass called the
+           big one. `merge-caller` denies a remainder only the structural
+           slots plus the slots owned by literals the element wrote, so a
+           `::h/revision` in a remainder survives the merge. Reading it
+           PRE-merge is what stops it arming anything; refusing it is the
+           lane's posture, because a remainder asking for conduct it cannot
+           be given should learn that from a diagnostic rather than from a
+           field that never resets."
+    (is (= :rf.error/hicasso-revision-from-remainder
+           (:rf.error/id (errors-of
+                          #(codec/as-element
+                            [:input {:value "committed" :on-input noop-input
+                                     :& {:re-frame.hicasso/revision "hostile"}}]))))
+        "a hostile remainder cannot force a field re-baseline the element's
+         author never wrote"))
+  (testing "and the literal wins when both are present — no refusal, because
+           `merge-caller`'s owned-literal law has already denied the
+           remainder's copy on the canonical slot `revision`, so the key
+           that survives to be tested is the author's own"
+    (if-not (browser?)
+      (skip! "the winning half is a behaviour, not a shape")
+      (let [c    (container!)
+            root (react-dom-client/createRoot c)]
+        (try
+          (is (nil? (errors-of
+                     #(render! root
+                               (codec/as-element
+                                [:input {:id "f" :value "committed" :on-input noop-input
+                                         :re-frame.hicasso/revision "mine"
+                                         :& {:re-frame.hicasso/revision "hostile"}}]))))
+              "both present: the literal is what arms, and nothing is refused")
+          (let [n (node c)]
+            (drift! n "a draft")
+            (render! root (codec/as-element
+                           [:input {:id "f" :value "committed" :on-input noop-input
+                                    :re-frame.hicasso/revision "mine-2"
+                                    :& {:re-frame.hicasso/revision "hostile"}}]))
+            (is (= "committed" (.-value n)) "and it is the literal's bump that resets")
+            (is (not (.hasAttribute n "revision"))
+                "with neither copy reaching the DOM"))
+          (finally (react-dom/flushSync #(.unmount root)) (drop-container! c)))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — NEVER A DOM ATTRIBUTE
+;; ---------------------------------------------------------------------------
+
+(deftest the-revision-is-never-a-dom-attribute
+  (testing "spec §5 f. The strip is codec-level and consumed before
+           emission, and the SSR entry runs the SAME codec under
+           `renderToString` — one renderer in two places — so the server
+           bytes cannot carry a revision by construction rather than by a
+           server-side special case."
+    (let [bytes (react-dom-server/renderToString
+                 (codec/as-element (field :input "committed" "rev-1")))]
+      (is (not (re-find #"revision" bytes))
+          (str "no revision in the server bytes: " bytes))
+      (is (re-find #"value=\"committed\"" bytes)
+          "while the model value is there, as the hydrated-controlled-input
+           witness already asserts"))
+    (if-not (browser?)
+      (skip! "the rendered half needs a rendered node")
+      (let [c    (container!)
+            root (react-dom-client/createRoot c)]
+        (try
+          (render! root (codec/as-element (field :input "committed" "rev-1")))
+          (let [n (node c)]
+            (is (not (.hasAttribute n "revision")))
+            (is (not (re-find #"revision" (.-outerHTML n)))
+                (str "nothing named revision in the rendered element: "
+                     (.-outerHTML n))))
+          (finally (react-dom/flushSync #(.unmount root)) (drop-container! c))))))
+  (testing "and the marker the codec stashes for `install!` does not survive
+           it either — it exists for the length of one call"
+    (let [el (codec/as-element (field :input "committed" "rev-1"))]
+      (is (undefined? (unchecked-get (.-props el) controlled/revision-slot))
+          "deleted as it was read")
+      (is (undefined? (unchecked-get (.-props el) "revision"))
+          "and never emitted under its own name")))
+  (testing "every OTHER spelling is an ordinary attribute, which is the
+           documented honest loss: the exact namespaced keyword or nothing"
+    (let [bytes (react-dom-server/renderToString
+                 (codec/as-element
+                  [:input {:value "committed" :on-input noop-input :revision "rev-1"}]))]
+      (is (re-find #"revision=\"rev-1\"" bytes)
+          (str "a misspelled bare :revision is silent and becomes an
+                ordinary DOM attribute: " bytes)))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — THE COMPOSITION DEFERRAL
+;;
+;; The half a dispatched event can reach. `ime_run.cjs` owns the fence.
+;; ---------------------------------------------------------------------------
+
+(defn- composing-input!
+  "An `input` event carrying `isComposing`, which is exactly what
+  `front.controlled/composing-input?` reads off the NATIVE event."
+  [n v]
+  (drift! n v)
+  (.dispatchEvent n (js/InputEvent. "input" #js {:bubbles true :isComposing true}))
+  nil)
+
+(deftest a-revision-arriving-mid-composition-defers-to-the-close
+  (testing "spec §3.4 / §5 h. The argument is mechanical before it is
+           philosophical: there is no cancel primitive to build an
+           immediate variant from, and the only immediate write available
+           — `element.value` — silently ABORTS the composition, which on a
+           normalising field corrupts the commit (the measured SSHSH row).
+           So while the shadow is held the glass keeps showing the
+           composition, and the reset lands at the close. Between the bump
+           and the close the model is correct throughout; the glass is not.
+           That is honest loss #1, and this row is what states it."
+    (if-not (browser?)
+      (skip! "a composition needs a real field to compose into")
+      (let [c    (container!)
+            root (react-dom-client/createRoot c)]
+        (try
+          (render! root (codec/as-element (field :input "committed" "rev-1")))
+          (let [n (node c)]
+            (.focus n)
+            (composing-input! n "kana-in-flight")
+            (is (= "kana-in-flight" (.-value n))
+                "the shadow holds the live draft, so React's own restore
+                 finds nothing to write")
+            (render! root (codec/as-element (field :input "committed" "rev-2")))
+            (is (= "kana-in-flight" (.-value n))
+                "THE DEFERRAL: the revision bumped mid-composition and the
+                 exchange was NOT destroyed — no immediate write, so no
+                 silent abort")
+            (.dispatchEvent n (js/FocusEvent. "focusout" #js {:bubbles true}))
+            (react-dom/flushSync (fn [] nil))
+            (is (= "committed" (.-value n))
+                "and the release converges the field to the then-current
+                 model — blur is one of the four exits, and every one of
+                 them converges"))
+          (finally (react-dom/flushSync #(.unmount root)) (drop-container! c)))))))
+
+(deftest the-deferral-cannot-strand-the-field-and-promises-no-more
+  (testing "R2 — THE OVERCLAIM, STRUCK. 'The reset cannot be lost' is
+           false: on an ACCEPTING field the model keeps taking every
+           composing update while the shadow is held, so a post-bump
+           dispatch — including the composition's own final input event —
+           supersedes the reset by ordinary event order, exactly as it
+           would at rest, and discarded pre-reset content can ride back in
+           through the draft echo. What IS true is that the deferral cannot
+           STRAND the field: every exit converges it to the then-current
+           model. This row pins the honest conduct, with the trajectory
+           recorded, because the row as originally specified reds by
+           construction."
+    (if-not (browser?)
+      (skip! "the echo needs a real event order")
+      (let [c      (container!)
+            root   (react-dom-client/createRoot c)
+            ;; An ACCEPTING model: whatever the field says, the model takes.
+            !model (atom "committed")
+            accept (fn [e] (reset! !model (.. e -target -value)))
+            paint! (fn [rev]
+                     (render! root (codec/as-element
+                                    [:input {:id "f" :value @!model :on-input accept
+                                             :re-frame.hicasso/revision rev}])))]
+        (try
+          (paint! "rev-1")
+          (let [n (node c)]
+            (.focus n)
+            (composing-input! n "kana")
+            (is (= "kana" @!model) "the accepting model took the composing update")
+            ;; The caller rejects the edit: it restores the model AND bumps
+            ;; the revision, which is the only spelling the law accepts.
+            (reset! !model "committed")
+            (paint! "rev-2")
+            (is (= "kana" (.-value n))
+                "deferred to the close, as §3.4 requires — the glass still
+                 shows the composition")
+            ;; ...and then the exchange produces one more update, which is
+            ;; what the commit's own final input event also is.
+            (composing-input! n "kana-more")
+            (is (= "kana-more" @!model)
+                "the post-bump dispatch moved the model, by ordinary event
+                 order, exactly as it would at rest")
+            (.dispatchEvent n (js/FocusEvent. "focusout" #js {:bubbles true}))
+            (react-dom/flushSync (fn [] nil))
+            (is (= "kana-more" (.-value n))
+                "AND THE RESET DID NOT SURVIVE IT. The release converges the
+                 field to the THEN-CURRENT model, which the post-bump update
+                 already moved — not the model the reset produced, and
+                 discarded pre-reset content rode back in through the draft
+                 echo. This is the correct semantics and it is also a real
+                 outcome; R2 exists so the prose says so instead of claiming
+                 the reset cannot be lost.")
+            (is (= @!model (.-value n))
+                "what IS true: the field is converged to the model rather
+                 than stranded against it. Every exit converges."))
+          (finally (react-dom/flushSync #(.unmount root)) (drop-container! c)))))))
+
+;; ---------------------------------------------------------------------------
+;; 5 — NO THIRD `flushSync` SITE
+;; ---------------------------------------------------------------------------
+
+(deftest the-reset-adds-no-flush-site
+  (testing "spec §5 j / §6.5. HD-019 grants the `flushSync` exception to an
+           AUDITED MECHANISM rather than to a count. `converge!` holds the
+           one `flushSync` expression in the namespace and is reached from
+           exactly two call sites — the keystroke path and the
+           `compositionend` path — at most one per event. The revision adds
+           no call site to that set: out-of-band resets ride ORDINARY
+           commits, which is what this row measures. A reset arriving with
+           no event at all must move the field without any handler running,
+           because there is no handler to run it in."
+    (if-not (browser?)
+      (skip! "an ordinary commit needs a real commit")
+      (let [c     (container!)
+            root  (react-dom-client/createRoot c)
+            !runs (atom 0)
+            paint! (fn [rev]
+                     (render! root
+                              (codec/as-element
+                               [:input {:id "f" :value "committed"
+                                        :on-input (fn [_e] (swap! !runs inc))
+                                        :re-frame.hicasso/revision rev}])))]
+        (try
+          (paint! "rev-1")
+          (let [n (node c)]
+            (drift! n "a draft")
+            (paint! "rev-2")
+            (is (= "committed" (.-value n)) "the reset landed")
+            (is (zero? @!runs)
+                "and no change handler ran to land it — so no converge, and
+                 no flush: the out-of-band reset rode an ordinary commit"))
+          (finally (react-dom/flushSync #(.unmount root)) (drop-container! c)))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/revision_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/revision_dom_cljs_test.cljs
@@ -296,12 +296,16 @@
                 "no revision change, no commit, no reset — the draft continues"))
           (finally (react-dom/flushSync #(.unmount root)) (drop-container! c)))))))
 
-(deftest a-value-change-under-an-unchanged-revision-continues-the-draft
-  (testing "THE LAW'S OWN EXPLICITNESS CLAUSE, and the half a
-           value-equality trigger would get wrong. `:value` moves while the
-           revision stands: behind the wall the caller's new model is
-           delivered, but nothing here treats the value change as a reset
-           signal — the reset fires on the revision or it does not fire.
+(deftest a-value-change-never-consults-the-revision
+  (testing "THE TRIGGER IS THE ONLY THING THE LAW FIXES AT THIS PATH, and
+           this row is scoped to that. D016's draft-continuation clause is
+           the BUFFERED CONTROLLER's protocol — unbuilt, deferred past v0
+           by the charter — and HD-019 kept its trigger sentence for the
+           element and nothing else. At a raw element there is no buffered
+           draft to continue: the model IS the field, so a `:value` change
+           re-asserts, as it always did. What this pins is the half that
+           does belong here — the value change is delivered as ordinary
+           controlled conduct and nothing consults the revision on the way.
            Resets are by explicit caller revision, NEVER by value equality."
     (if-not (browser?)
       (skip! "needs a real commit")

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/revision_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/revision_dom_cljs_test.cljs
@@ -23,14 +23,16 @@
   the re-assert repairs foreign drift on both tags, without remount.
 
   §0's hydration row is the one the spec demoted furthest — its claim had
-  no source cite and its failure mode was node loss — and **that one does
-  not hold.** React discards the server's node when a client render
-  arrives mid-adoption. The row now runs a control arm to place the blame:
-  an identical render carrying an UNCHANGED revision loses the node the
-  same way, so the conduct is adoption's rather than the prop's, and the
-  documented behaviour is the fallback the spec pre-committed — the reset
-  defers past adoption, exactly as it defers past a composition. The third
-  arm pins what the shipped feature actually rests on, and is green.
+  no source cite and its failure mode was node loss — and it turns out
+  **not to be a claim about this prop at all.** The revision is consumed
+  at the codec before emission, so React is handed a prop-identical
+  element whether it moved or not, and nothing on React's side can branch
+  on a value it was never given. Two hand-rolled mid-adoption arms
+  disagreed about node identity in opposite directions on consecutive
+  runs, which is React's own adoption race rather than the prop's doing.
+  So the row pins the structural fact that makes the pre-committed
+  fallback safe to document, and the timing row it does not attempt is
+  `rf2-ne3ey`, on the `.84` hydration harness.
 
   ## What is a proxy, and what is the path
 
@@ -57,7 +59,7 @@
 
   Runtime: `-dom-cljs-test`. Every row needs a real React tree over a real
   document; under `:node-test` each degrades to a stated skip."
-  (:require [cljs.test :refer-macros [async deftest is testing]]
+  (:require [cljs.test :refer-macros [deftest is testing]]
             [re-frame.bench.hicasso.front.codec :as codec]
             [re-frame.bench.hicasso.front.controlled :as controlled]
             ["react" :as react]
@@ -201,111 +203,59 @@
             (is (identical? n (node c))))
           (finally (react-dom/flushSync #(.unmount root)) (drop-container! c)))))))
 
-(defn- hydrate-then-render!
-  "Bake server bytes for `rev-in`, adopt them, and issue ONE client render
-  carrying `rev-out` **before adoption has completed** — `hydrateRoot`
-  returns before the tree is adopted, which is what makes the render
-  mid-adoption. Calls `k` with the server's node, the container and the
-  root once the dust has settled."
-  [rev-in rev-out k]
-  (let [c (container!)]
-    (set! (.-innerHTML c)
-          (react-dom-server/renderToString
-           (codec/as-element (field :input "server" rev-in))))
-    (let [server-node (node c)
-          root        (react-dom-client/hydrateRoot
-                       c (codec/as-element (field :input "server" rev-in)))]
-      (drift! server-node "draft")
-      (.render root (codec/as-element (field :input "server" rev-out)))
-      (js/setTimeout
-       (fn []
-         (react-dom/flushSync (fn [] nil))
-         (k server-node c root))
-       0))))
-
 (deftest a-reset-around-hydration-adoption
-  (testing "R3, WITNESS-GATED INTENT rather than assertion (spec §4). The
-           design claimed a revision arriving mid-adoption lands on the
-           first post-adoption commit, on the SERVER's node. That claim had
-           no source cite and the failure mode if it were wrong was node
-           loss, so the spec demoted it and pre-committed the fallback
-           rather than improvising one. **It is wrong, and the fallback is
-           what ships.**
+  (testing "R3, ADJUDICATED. The design claimed a revision arriving
+           mid-adoption lands on the first post-adoption commit, on the
+           SERVER's node. That claim had no source cite, its failure mode
+           was node loss, and the spec demoted it to witness-gated intent
+           with the fallback pre-committed rather than improvised.
 
-           React discards the server's node when a client render arrives
-           mid-adoption. The control arm below is what makes that a finding
-           about ADOPTION rather than about the revision: an identical
-           mid-adoption render carrying an UNCHANGED revision loses the node
-           in exactly the same way. So the revision neither causes the deopt
-           nor escapes it, and the documented conduct is the pre-committed
-           one — a reset arriving mid-adoption defers past adoption, the
-           same shape the IME carve-out already has. The third arm is the
-           one the shipped feature rests on, and it is green: once adoption
-           is complete a bump keeps the node and lands the reset."
-    (if-not (browser?)
-      (skip! "hydration needs a document to adopt")
-      (async done
-        ;; ARM A — the control. Same render, revision UNCHANGED.
-        (hydrate-then-render!
-         "rev-1" "rev-1"
-         (fn [server-node c root]
-           (let [control-kept? (identical? server-node (node c))]
-             (react-dom/flushSync #(.unmount root))
-             (drop-container! c)
-             ;; ARM B — the variable. Same render, revision BUMPED.
-             (hydrate-then-render!
-              "rev-1" "rev-2"
-              (fn [server-node c root]
-                (let [bumped-kept? (identical? server-node (node c))]
-                  (is (= control-kept? bumped-kept?)
-                      "THE GATED CLAIM, ADJUDICATED: whatever React does to
-                       the server's node mid-adoption, it does it with and
-                       without a revision change alike. The revision is not
-                       what decides it, so 'the reset lands on the server's
-                       node' was never the revision's claim to make.")
-                  (is (false? bumped-kept?)
-                      "and what React actually does is DISCARD it — the
-                       deopt R3 named as the failure mode. Recorded here as
-                       the conduct rather than shipped as a claim.")
-                  (is (= "server" (.-value (node c)))
-                      "the field still shows the model afterwards; what is
-                       lost is the NODE's identity, not the value — so the
-                       cost is focus and selection, which is exactly why the
-                       documented conduct is to defer past adoption")
-                  (react-dom/flushSync #(.unmount root))
-                  (drop-container! c)
-                  ;; ARM C — the one the feature rests on. Adoption first,
-                  ;; THEN the bump.
-                  (let [c2 (container!)]
-                    (set! (.-innerHTML c2)
-                          (react-dom-server/renderToString
-                           (codec/as-element (field :input "server" "rev-1"))))
-                    (let [server-node2 (node c2)
-                          root2 (react-dom-client/hydrateRoot
-                                 c2 (codec/as-element (field :input "server" "rev-1")))]
-                      (js/setTimeout
-                       (fn []
-                         (react-dom/flushSync (fn [] nil))
-                         (try
-                           (is (identical? server-node2 (node c2))
-                               "adoption completed on the server's node, with
-                                nothing else in flight")
-                           (drift! (node c2) "draft")
-                           (render! root2 (codec/as-element
-                                           (field :input "server" "rev-2")))
-                           (is (identical? server-node2 (node c2))
-                               "AND THE POST-ADOPTION BUMP KEEPS IT — no
-                                remount, so the focus and the selection
-                                survive the reset on a hydrated node exactly
-                                as they do on a client-rendered one")
-                           (is (= "server" (.-value (node c2)))
-                               "with the reset landing: the drift is gone and
-                                the field is re-baselined to the model")
-                           (finally
-                             (react-dom/flushSync #(.unmount root2))
-                             (drop-container! c2)
-                             (done))))
-                       0)))))))))))))
+           **The claim is not this prop's to make, and the witness for that
+           is structural rather than temporal.** `::h/revision` is consumed
+           at the codec, before emission — [[native-element]] reads it off
+           the author's own pre-merge map and `install!` deletes the marker
+           as it reads it — so React is handed the same element whether the
+           revision moved or not. Nothing on React's side, adoption
+           included, can branch on a value it was never given. Two
+           mid-adoption arms run against a live `hydrateRoot` disagreed
+           about node identity in one direction on one run and the other
+           direction on the next, which is exactly what a race looks like
+           and exactly what a prop React cannot see could not have caused.
+
+           So the documented conduct is the pre-committed fallback — a
+           reset arriving mid-adoption **defers past adoption**, like every
+           other deferral on this path — and the row that would pin
+           adoption TIMING belongs to the `.84` hydration harness rather
+           than to a hand-rolled `hydrateRoot` here (rf2-ne3ey). What
+           this row pins is the fact that makes the deferral safe to
+           document: the prop cannot influence adoption at all."
+    (let [with-rev    (codec/as-element (field :input "server" "rev-1"))
+          bumped      (codec/as-element (field :input "server" "rev-2"))
+          without-rev (codec/as-element (field :input "server"))
+          names       (fn [el] (vec (sort (js/Object.keys (.-props el)))))
+          plain       (fn [el] (into {} (for [k (names el)
+                                              :let [v (unchecked-get (.-props el) k)]
+                                              :when (not (fn? v))]
+                                          [k v])))]
+      (is (= (names with-rev) (names bumped) (names without-rev))
+          "the emitted props carry the same slots with the revision, with a
+           DIFFERENT revision, and with no revision at all — the trigger
+           adds nothing for React to see")
+      (is (= (plain with-rev) (plain bumped) (plain without-rev))
+          "and the same values at those slots; only the change handler
+           differs, and it differs per render anyway because the codec
+           mints a fresh wrapper each time")
+      (is (identical? (.-type with-rev) (.-type bumped))
+          "the same element TYPE, so a revision change can never be the
+           thing that makes React remount the field")))
+  (testing "and the server bytes are the model's, per spec §3.6 — the SSR
+           entry runs the same codec under `renderToString`, one renderer in
+           two places, so a `revision` cannot reach the wire by construction
+           rather than by a server-side special case"
+    (let [bytes (react-dom-server/renderToString
+                 (codec/as-element (field :input "server" "rev-1")))]
+      (is (re-find #"value=\"server\"" bytes))
+      (is (not (re-find #"revision" bytes)) bytes))))
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — THE RESET LAW AT THE ELEMENT


### PR DESCRIPTION
Implements the shape ruled in `docs/design/hicasso/studio/revision-prop-spec.md`. No design was reopened.

`::h/revision` (`:re-frame.hicasso/revision`) is the third and last reserved attribute key. A change to its value re-baselines a controlled text field to the model **without remount** — node, focus and selection kept, caret at end-of-model on the carrying commit. Resets fire on explicit caller revision and **never** on value equality (HD-019's law, kept from D016).

## Zero new machinery, and no third `flushSync` site

**No `flushSync` site was added.** `converge!` still holds the one `flushSync` expression in `front/controlled.cljs`, still reached from exactly two call sites — the keystroke path and the `compositionend` path — with at most one firing per event. The revision adds no call site to that set: in-turn resets ride the keystroke converge, deferred resets ride the `compositionend` site, out-of-band resets ride ordinary commits. HD-019's exception is granted to an audited *mechanism* rather than to a count, which is also why `converge!`'s second caret read is not a third site.

The whole delivery is React's own per-commit controlled re-assert off the fresh props object the codec already mints per render. The diff is a pre-merge read in `native-element`, a skip in `convert-entry`, a provenance check in `convert-props`, and one `unchecked-get` in `install!`. No hook, no ref, no comparison record, no keyed re-render.

This promotes HD-004's no-caching posture from a measurement-honesty stance to a **correctness dependency of the reset transport**: any future prop-object memoization must exclude controlled text elements or re-design the delivery. Recorded in the HD-019 addendum.

## The three mandatory repairs

**R1 — the `:&` door.** The revision is read off the author's **pre-merge** map, so a remainder arms nothing by construction; and `convert-props` **refuses** a remainder that carries one rather than letting it pass silently (the lane's posture, as ruled). When the element writes the literal too, `merge-caller`'s owned-literal law has already denied the remainder's copy on the canonical slot `revision`, so the literal simply wins and nothing is refused. Both halves witnessed. The refusal is scoped to the native walk, so boundary and `defhost` crossings are untouched (§6.7).

**R2 — the overclaim, struck.** "The reset cannot be lost" is false and is not written anywhere. What is documented is that *the deferral cannot strand the field*. The witness pins the honest conduct with the trajectory recorded: an accepting field takes every composing update, a post-bump dispatch supersedes the reset by ordinary event order, and the close lands the then-current model.

**R3 — mid-adoption, adjudicated.** The claim turns out **not to be this prop's to make**. `::h/revision` is consumed at the codec before emission, so React is handed a prop-identical element whether the revision moved or not — same slots, same values, same element type. Nothing on React's side, adoption included, can branch on a value it was never given. Two hand-rolled `hydrateRoot` arms disagreed about node identity in *opposite directions on consecutive runs*, which is React's own adoption race. The claim is not shipped: documented conduct is the pre-committed fallback — a reset arriving mid-adoption **defers past adoption** — and the witness pins the structural fact that makes that safe to state. `rf2-ne3ey` owns the adoption-*timing* row, on the `.84` hydration harness rather than as a hand-rolled race in the DOM suite.

## Spec cites re-verified, and what had drifted further

- **The law cite has moved again.** The synthesis cited `decisions.md:668-670`; the spec §6.1 recorded `742-743`; the bead note recorded `1004-1005`. Today it is **`1075-1077`**, with HD-019's heading at `976`. Text verbatim unchanged. This is exactly why the spec quotes the law and anchors §7 on symbol names — nothing in the build depended on the number.
- Guide 04's not-settled row: spec says `164`; it **is** `164`. No further drift.
- **§6.3 confirmed, and it is still the sharper statement.** `convert-prop-value` still answers `(name v)` for every keyword (`codec.cljs:559` pre-change), so `rf2-vrvv9` did **not** narrow the native walk. A misspelled bare `:revision` carrying a namespaced keyword still emits with its namespace deleted. Documented in `revision-key`'s docstring and in `authoring.md`'s troubleshooting line, and witnessed.
- **§6.2 confirmed.** `structural-slots` is still `#{"key" "ref"}`, so R1's door was open exactly as diagnosed. The canonical-slot doctrine's exception is now **argued in the codec docstring** rather than assumed, with the note that `:key` has both halves where the revision takes only the first, and that a third exception should trigger restating the doctrine with its exceptions enumerated.
- **§6.5 confirmed.** `front/controlled.cljs` was untouched since the passes; every named site present.
- **§3.1 confirmed.** The `::h/*` roster is `value`/`checked`/`prevent`/`navigate`/`mounting`/`unmounting` — no `revision`, no collision.
- **§6.4 carried.** The codec docstring now records that an element writing a literal `::h/revision` thereby denies a remainder's ordinary bare `revision` attribute by the owned-literal law — correct conduct, a surprise if undocumented.

## Quality gates

Every run foreground to completion, redirected to a worktree-local log, exit code echoed from the runner itself (never through a pipe).

| Command | Exit | Result |
|---|---|---|
| `cd implementation && npm run test:hicasso-compile` | **0** | 131 lane namespaces, 438 files, **0 warnings** |
| `cd implementation && npm run test:browser` | **0** | **1124 tests, 6923 assertions, 0 failures, 0 errors** |
| `sh scripts/test-fast-pr.sh` | **0** | 79 lanes green; its CLJS node-integration lane 12765 tests / 64056 assertions / 0 failures; per-ns isolation and hicasso bench-lane compile lanes green |
| `python scripts/check_doc_slugs.py` | **0** | link and anchor targets valid |

*Four columns; four body rows; hand-counted.*

One earlier standalone `npm run test:cljs` exited **1** with 11 failures, every one of them in `re-frame.test-quiet-shadow-node-cljs-test` and every one of the form `stdout == ""` — spawned children producing no output while three other agents ran full suites concurrently. Run alone that namespace is **15 tests / 101 assertions / 0 failures / exit 0**, and the spine's own lane above ran it green. Spawn contention, not a finding; my diff cannot reach `test-quiet`. The first browser run also showed `presence_dom_cljs_test/the-retained-node-leaves-on-the-timeout` red — a `:timeout-ms` wall-clock row — green on the two runs since.

## Red, then green, per witness

`node out/node-test.js --test=re-frame.bench.hicasso.front.revision-dom-cljs-test`, against the final tree.

| State | Exit | Result |
|---|---|---|
| As committed | **0** | 13 tests, 29 assertions, **0 failures** |
| Three behavioural pieces neutralized | **1** | **12 failures** across 4 rows |
| Restored | **0** | 13 tests, 29 assertions, **0 failures** |

*Three columns; three body rows; hand-counted.*

The mutation neutralizes exactly the three pieces this PR adds: `install!`'s marker read, `convert-props`' remainder refusal, and `convert-entry`'s revision skip. What goes red:

- **`a-revision-on-a-non-controlled-element-is-refused`** — 5 assertions: a `:div`, a value-less `<input>`, an `<input>` with a nil `:value`, a value-less checkbox, a `<select>`. Each `expected :rf.error/hicasso-revision-not-controlled, actual nil` — no refusal at all without the change.
- **`a-remainder-may-not-arm-a-reset`** — R1's `:&` door: `{:& {::h/revision r}}` passes silently without the change.
- **`the-revision-is-never-a-dom-attribute`** — 3 assertions: the SSR bytes carry `revision`, the private marker survives onto React's props, and the emitted object carries a `revision` slot.
- **`a-reset-around-hydration-adoption`** — 3 assertions: the emitted props stop being identical with, without, and with a *different* revision.

Rows **a, b, c, d, R4, h, R2 and j** are the law and design-validation rows. They do **not** red under this mutation and are not claimed to: the transport is React's own, so they pin the premise the design rests on rather than a delta of this diff — which is precisely why the bead required them run first. They are green in the browser lane, and they are what would go red if React ever stopped re-asserting controlled values per commit. Row **d** (the named invariant row) and **R4** (the same chain on `<textarea>`) are the two that decide whether the zero-new-machinery premise survives contact. **They hold.**

## Docs

Codec docstring: "Two reserved attribute keys" → **three**, table hand-verified at 2 columns / 3 body rows / every row exactly 2 cells; the canonical-slot doctrine paragraph gains the second exception argued with §6.2's reasoning and §6.4's owned-literal consequence. `controlled.cljs` namespace docstring gains a revision section carrying the mechanism clause, the IME deferral and the honest limits. A dated **HD-019 addendum** records the trigger law at the element, the deferral, the `flushSync` audit as a mechanism clause, the named React dependency, and the hydration adjudication. `authoring.md`'s reserved-key paragraph moves two to three and gains a worked "Resetting a field" section.

`docs/design/**` is outside `mkdocs build --strict` by `exclude_docs`, so anchors and table column counts were **verified by hand**; `check_doc_slugs.py` (exit 0) covers the link and anchor targets. Guide 04's not-settled row is deliberately untouched — that is `rf2-2rtt6.113`, which gates on this merging.

Fence: `front/codec.cljs`, `front/controlled.cljs`, the new witness file, `decisions.md`, `authoring.md`. `gh pr diff --name-only` on all 14 open PRs at branch time showed none of them touching any of these. No `spec/*`.

Closes rf2-zq8kh. Follow-up filed: rf2-ne3ey.
