### PR TITLE
docs(hicasso): guide 04 teaches the revision prop (rf2-2rtt6.113)

### DIFF
--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -81,7 +81,57 @@ Force a field back to a value with an **explicit revision** from the caller —
 form reset, revert, server normalisation — not by comparing the incoming value
 to a target. Value-equality reset is how a user who legitimately types that
 value gets yanked mid-edit, and how a same-value reassertion becomes invisible.
-The prop that carries the revision is still unnamed; see **Not settled yet**.
+
+`::h/revision` **[unfrozen]** is where that law is spelled at the element. It
+reads like any other value, beside `:value`:
+
+```clojure
+(defview revertable-field [{:keys [id]}]
+  [:input {:type        :text
+           :value       (sub [:editor/field id])
+           ::h/revision (sub [:editor/baseline id])
+           :on-input    [:editor/edit-field id ::h/value]}])
+```
+
+The revert event does both halves — restore the value **and** move the
+revision. A `[:button {:on-click [:editor/revert id]} "Revert"]` fires it:
+
+```clojure
+(rf/reg-event :editor/revert
+  (fn [{:keys [db]} [_ id]]
+    {:db (-> db
+             (assoc-in [:editor :fields id] (get-in db [:editor :saved id]))
+             (update-in [:editor :baselines id] inc))}))   ;; the revision moves
+```
+
+**Only a revision change resets.** A `:value` that moves under an unchanged
+revision is ordinary controlled conduct: the field shows it, and nothing
+consulted the revision on the way. The comparison is `=`, so equal-but-fresh
+revision values are inert.
+
+**A reset is not a remount.** What goes is the draft in the field. What stays is
+the node itself, and the focus on it — the caret lands at end-of-model on the
+commit carrying the reset, which is the platform's own conduct for a `value`
+assignment. Contrast `h/boundary`'s `:reset-key`, which *does* remount ([When a
+view throws](09-when-a-view-throws.md)): same idea, opposite conduct on the node.
+
+**Write a revision the way you would write an instance key** — a domain fact
+your events put in app-db: a record id, a load generation, a "form opened at"
+stamp. Never a render-order index, never a counter minted in render, never
+`random-uuid`; each of those resets the field on every render.
+
+The prop is refused loudly on anything that is not controlled text — a `:div`, a
+`select`, an input with no `:value`, a value-less checkbox — as
+`:rf.error/hicasso-revision-not-controlled`. It is never taken from a `:&`
+remainder either, so a caller cannot force a re-baseline on a field whose author
+never wrote one. And it never reaches the DOM as an attribute, client or server.
+
+This is the single prop and nothing more: no commit/cancel intents, no
+acknowledgement that the reset landed, no caret-policy knobs. The
+draft-and-commit ladder under **Not settled yet** *consumes* this trigger rather
+than extending it. The ruled shape is in [the adjudicated
+spec](../studio/revision-prop-spec.md); the two cases where a reset cannot land
+immediately are under [Advanced](#advanced).
 
 ## Troubleshooting
 
@@ -92,7 +142,9 @@ The prop that carries the revision is still unnamed; see **Not settled yet**.
 | Enter commits half-typed text mid-composition | A hand-written key handler that bypasses the intent path | Use the data key-map; the composition check lives there |
 | Composition dies when the model refuses mid-draft | A value write during composition (browser treats that as abort) | Not this runtime on controlled text: composition is left alone until `compositionend` |
 | An IME commit lands stale text, then corrects itself | Something async sat between keystroke and commit, so `compositionend` reconciled the field against a model the deferred write had not reached yet | Keep the controlled write synchronous. The composition survives either way — only what it commits is late |
-| Typing the "reset" value clears the field | Reset keyed on value equality somewhere | Reset on an explicit revision |
+| Typing the "reset" value clears the field | Reset keyed on value equality somewhere | Move `::h/revision`; a value comparison is not a reset |
+| The field resets on every render | A revision minted in render — `random-uuid`, a render-order index, a counter the body increments | Read a revision your *events* wrote into app-db |
+| The field never resets, and devtools shows a `revision="…"` attribute on it | A bare `:revision`. The match is the exact namespaced keyword, so every other spelling flows through as an ordinary attribute — silently, and with a namespaced value's namespace deleted on the way, so two distinct revisions can collapse to one | Write `::h/revision` |
 | Focus lost after validation fails | Something remounted the node | Do not remount to reset — that is exactly what destroys focus |
 
 ## When not to control an input
@@ -157,11 +209,37 @@ Scope: controlled **text** entry (same path as the rest of this page).
 Composition behaviour is proven on Chromium; a WebKit IME misbehave is a bug
 report, not a documented limit.
 
+### A reset that cannot land immediately
+
+Two cases, both deferrals, and both limits rather than bugs.
+
+**Mid-composition.** A revision change that arrives while an IME composition is
+running lands at the exchange's close — `compositionend`, blur, unmount, or the
+next non-composing input — for the same reason nothing else writes the field
+there: the only immediate write available is `element.value`, and
+mid-composition that silently aborts the composition. The model is correct
+throughout; the glass is not.
+
+The deferral does not promise the reset *survives*, and the honest version
+matters here. On an accepting field the model keeps taking every composing
+update while the reset is pending, so a post-bump edit — including the
+composition's own final input event — supersedes the reset by ordinary event
+order, exactly as it would at rest. What does hold is that the field is never
+stranded: every exit converges it to the then-current model.
+
+**Mid-hydration.** A revision that arrives before adoption completes defers past
+adoption. The revision cannot influence adoption either way — it is consumed
+before the element is emitted, so React is handed the same element whether the
+revision moved or not. What adoption does with a client render that lands
+mid-flight is React's own affair and is **not pinned yet**; the deferral is the
+documented conduct until it is.
+
 ## Not settled yet
 
 | Question | Status |
 |---|---|
-| The revision prop's spelling on a controlled element | Reset law fixed; the attribute name is still open |
-| A buffered / draft-and-commit input ladder | Not in the first ship of same-tick echo + caret preservation |
+| `::h/revision`'s spelling | The prop exists and the reset law is fixed; the name is **[unfrozen]**, and the freeze faces it alongside the other reset-ish names |
+| What adoption does with a reset that lands mid-hydration | Deferring past adoption is the documented conduct; the timing itself is not pinned |
+| A buffered / draft-and-commit input ladder | Not in the first ship of same-tick echo + caret preservation. It *consumes* `::h/revision`'s trigger; the single prop is not the ladder |
 | A controls kit that owns drafts and revisions | Not first ship — a draft is app-db state you write yourself |
 | Whether `:on-input` or `:on-change` is the taught attribute | Both work; the runtime takes whichever runs last. Current screens use `:on-input` for text and `:on-change` for checkboxes |


### PR DESCRIPTION
Closes rf2-2rtt6.113.

`::h/revision` landed under `rf2-zq8kh` (PR #7655, merged 2026-08-07T01:38:38Z),
which was this bead's precondition. Verified on `main` before writing:
`front/codec.cljs` carries the `:re-frame.hicasso/revision` row and its
pre-merge read, `front/controlled.cljs` carries `revision-slot` and the
`:rf.error/hicasso-revision-not-controlled` refusal, and
`front/revision_dom_cljs_test.cljs` is the witness the prose is written against.

Guide 04's reset section stopped pointing at an unnamed prop and now teaches the
real one. **The load-bearing thing is the fixed reset law**: a reset fires on an
explicit caller revision change and never on value equality. An author who
believes equality triggers it writes code that silently does nothing, so that is
the sentence the section leads with and the worked example demonstrates.

## What changed

`docs/design/hicasso/draft-guide/04-controlled-inputs.md`, one file.

**§Resets are by revision, not by value** — the law framing is kept verbatim and
the "still unnamed; see Not settled yet" sentence is gone. Added: the spelling
with its **[unfrozen]** marker; one worked example in two halves (the field
reading `::h/revision` beside `:value`, and the revert event that moves *both*
the value and the revision, because the value alone says nothing); what only a
revision change does and what a `:value` change under an unchanged revision does
not; what a reset discards (the draft) and what survives (the node, the focus,
caret at end-of-model, no remount) with the contrast against `h/boundary`'s
`:reset-key`, which *does* remount; the instance-key rule for revision values;
the refusals on a non-controlled element and on a `:&` remainder; and the ladder
boundary — the single prop is not the ladder.

The revert example uses the **intent-vector** form (`:on-click [:editor/revert
id]`, `:on-input [… ::h/value]`) rather than a closure calling `rf/dispatch`,
per the spec's §6.6 note about the ambient-find withdrawal.

**§Advanced → "A reset that cannot land immediately"** — the two deferrals, set
beside the IME section that already explains why they exist. The
mid-composition row is stated with R2's honest limit rather than the struck
overclaim: a post-bump edit supersedes the reset by ordinary event order; what
holds is that the field is never stranded, because every exit converges it to
the then-current model.

**The hydration note claims exactly what PR #7655 witnessed and no more.** The
revision is consumed before emission, so it cannot influence adoption either
way; deferring past adoption is the documented conduct; and what adoption itself
does with a client render landing mid-flight is **not pinned yet**. No timing
behaviour is taught. `rf2-ne3ey` owns that row on the `.84` hydration harness.

**§Troubleshooting** — two rows added for the failures an author cannot diagnose
from the symptom: a revision minted in render (resets every render), and a bare
`:revision`, which flows through as an ordinary DOM attribute silently and with
a namespaced value's namespace deleted, so two distinct revisions collapse to
one. The existing "typing the reset value clears the field" row now names the
prop in its fix.

**§Not settled yet** — the spelling row resolves (the prop exists, the law is
fixed, the *name* is [unfrozen] pending the freeze's reset-name sitting) and the
hydration-timing row replaces it as the honest open question. The ladder row
restates the boundary.

Controlled inputs are not re-taught, nothing is restructured, and the ruled
shape is linked (`../studio/revision-prop-spec.md`) rather than duplicated.

## Quality gates

Foreground, unpiped, each redirected to a worktree-local log with the runner's
own exit code echoed.

| Command | Result | Exit |
|---|---|---|
| `python scripts/check_doc_slugs.py --verbose` | `scanning 678 markdown files... no broken links.` | **0** |
| `sh scripts/test-fast-pr.sh` | full spine green | **0** |

*Three columns; two body rows; hand-counted.*

**Selection proved, at the exact site edited.** `check_doc_slugs.py` is silent on
success, so both new links were deliberately broken *in place* — the cross-tree
target `../studio/revision-prop-spec.md` and the same-file anchor `#advanced`,
both at the end of the reset section — and the checker fired:

```
1 broken target file(s) found:
  BROKEN TARGET: docs\design\hicasso\draft-guide\04-controlled-inputs.md:133 -> ../studio/revision-prop-spec-PROBE.md
1 broken anchor link(s) found:
  BROKEN ANCHOR: docs\design\hicasso\draft-guide\04-controlled-inputs.md:134 -> #advanced-PROBE
      (target: docs\design\hicasso\draft-guide\04-controlled-inputs.md)
```

exit **1**, naming this file and both lines. Probe reverted; the gate re-run
clean at exit 0. The probe sits in prose because every link this PR adds is in
prose — the checker masks fenced blocks, and the two fenced blocks added here
contain no links, so there is nothing inside a fence for it to have skipped.

`mkdocs build --strict` is **not** nominated: `mkdocs.yml`'s `exclude_docs`
keeps `design/hicasso/` out of the site, so it would verify nothing here.

**Hand-verification, since nothing gates it.**

- *Anchors.* `#advanced` resolves to this file's `## Advanced`. `09-when-a-view-throws.md`
  and `../studio/revision-prop-spec.md` are target-only links; both files exist
  on `main`. The new `### A reset that cannot land immediately` sits under
  `## Advanced` and duplicates no existing heading in the file.
- *Tables.* Troubleshooting: 3 columns in the header, 3 in the separator, **9
  body rows** each with 3 cells (was 7). Not settled yet: 2 columns in the
  header, 2 in the separator, **5 body rows** each with 2 cells (was 4). Counted
  cell-by-cell with fenced blocks masked; no row carries a `|` inside a cell.
- *Digest pinning does not apply.* `samples_coverage_jvm_test.clj`'s `guide-dir`
  is `"docs/core/freehand"` (line 86), not this tree. The only other repo
  reference to `draft-guide/` is a prose comment in `codec_cljs_test.cljs:788`.
  Checked before adding the two fenced blocks; the fast-PR spine's exit 0
  confirms it.

Docs-only, one file. No `spec/`, no code, no studio page.
