### PR TITLE
fix(hicasso,scripts): a docstring's phantom witness, and backticks in the --help heredoc (rf2-xhbv4, rf2-x2brm)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
@@ -433,12 +433,21 @@ function ctl3Verdict(rounds, plan, slack) {
   const [a0, a1, a2] = arms;
   const [d0, d1, d2] = arms.map((a) => dirty[a]);
   // The witness would be a fourth point BELOW the control's range, and it is
-  // never a term in the statistic: it exists to re-measure, every run, the
-  // saturating paint term that refuted the first build of this control.
-  // NO SHIPPED ARM DECLARES ITSELF ONE — `clock-app/ctl3-arms` emits the
-  // three control points and nothing else — so `wArm` is null on every run
-  // and the witness column of the regime table reads null. Read here rather
-  // than deleted because the page can declare one without the driver
+  // never a term in the statistic: its job was to re-measure the saturating
+  // paint term that refuted the first build of this control.
+  //
+  // IT WAS BUILT AND THEN RETIRED, not planned-and-never-landed — and which
+  // of those it is decides how far this control is corroborated.
+  // `ctl3-witness-dirty` (one dirty cell, arm `:ctl-b-witness`) shipped with
+  // the eps=1 rebuild in 46f1db73c2 and went out in 04638c42e1 with the
+  // 3,000-cell page it measured, when the run reverted to the ruled 300-cell
+  // construction. Only the page's `:ctl3Witness` emission outlived it, so NO
+  // SHIPPED ARM DECLARES ITSELF ONE — `clock-app/ctl3-arms` emits the three
+  // control points and nothing else — and `wArm` is null on every run.
+  //
+  // The paint-saturation account is therefore INHERITED from that retired
+  // run rather than re-measured on this one. Read here rather than deleted
+  // because the page can declare a witness again without the driver
   // changing; a reader of a null witness column is reading its absence.
   const wArm = witness.length ? witness[0].id : null;
   const wD = witness.length ? witness[0].dirty : null;
@@ -519,7 +528,8 @@ function ctl3Verdict(rounds, plan, slack) {
     blocks,
     // THE REGIME TABLE. The two intervals inside the control must agree;
     // the witness interval below it is where the first build of this
-    // control was refuted, and it is re-measured rather than inherited.
+    // control was refuted. With the witness arm retired it is null, so
+    // that refutation is inherited rather than re-measured.
     marginal: {
       witness: wD !== null ? marg(`${wD}-${d0}`) : null,
       lower: marg(`${d0}-${d1}`),
@@ -1736,9 +1746,10 @@ function report(out) {
     );
     // THE REGIME TABLE — the reason the epsilon point is not one cell.
     // The control's two intervals must agree with each other (that is the
-    // statistic restated); the witness interval below them is expected NOT
-    // to, and an agreement there would refute the paint-saturation account
-    // that put the control where it is.
+    // statistic restated). The witness interval below them was expected NOT
+    // to, and an agreement there would have refuted the paint-saturation
+    // account that put the control where it is — but its arm is retired, so
+    // only the control's own two intervals are printed here.
     const m = ctl3.marginal;
     // NB not `disagree` — that name is the canonical-DOM gate's, above.
     const margGap = (x) => (Math.abs(x.upper.mean - x.lower.mean) / ((x.upper.mean + x.lower.mean) / 2)) * 100;

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -175,7 +175,7 @@ touches documentation content.  The cheap static/drift checks always run.
 
 Within the JVM tier the spine runs implementation/core plus the suite of every
 artefact whose own tree the diff touched, selected against the roster in
-scripts/test-jvm-implementation.sh.  `--plan` prints that selection.
+scripts/test-jvm-implementation.sh.  --plan prints that selection.
 
 Flags:
   --all, -a     run the COMPLETE spine regardless of classification


### PR DESCRIPTION
Two small, disjoint fixes from the same small-misc cluster. Neither file is in any other open PR.

## rf2-xhbv4 — the ctl3 witness was RETIRED, not never built

`ctl3Verdict`'s witness resolves to `null` on every run. The bead asks which kind of absence that is, because "the witness was dropped" and "the witness was never built" say different things about how far the control is corroborated.

**Determination: it was built, it ran, and it was retired.** Established from history, not inferred — `git log -S "ctl3-witness?" -- implementation/freehand/` returns exactly two commits:

| commit | date | direction |
|---|---|---|
| `46f1db73c2` | 2026-08-02 | **ADDED** `ctl3-witness-dirty` — one dirty cell on the control's own 3,000-cell page, arm `:ctl-b-witness`, carrying `:ctl3? false :ctl3-witness? true` — with the eps=1 rebuild |
| `04638c42e1` | 2026-08-02 | **REMOVED** it, when the 3,000-cell rescue was abandoned as worse-conditioned than the build it was meant to rescue and the run reverted to the ruled 300-cell construction |

The witness went out with the page it measured. What outlived it is the plumbing: `clock_app.cljs:960` still emits `:ctl3Witness`, the driver still carries `wArm`/`wD` and a witness column, and the captured runs under `data/clock-0qj9w/` record `"ctl3Witness": false` throughout. That is why `wArm` is null every run while the machinery still looks live.

Note that the dangling `see clock-app/ctl3-witness-dirty` pointer the bead names was **already struck by PR #7634** — the same PR whose worker filed this bead — and replaced with an accurate "no shipped arm declares itself one" note. What #7634 could not settle, and this PR does, is *which* absence it is. The consequence is now stated where it is read: the paint-saturation account that put the control above the knee is **inherited** from that retired run rather than re-measured on this one.

Two further comments asserting a live re-measurement are corrected to match what the code actually does — the regime table's "it is re-measured rather than inherited", and the report's "the witness interval below them is expected NOT to".

**Comment-only.** No statistic, threshold, or control point changes; verified mechanically (see gates).

## rf2-x2brm — backticks in the unquoted `--help` heredoc

The usage block is `cat <<EOF` with an **unquoted** delimiter, so command substitution runs inside it. One markdown-style backtick pair around `--plan` was being executed.

Per the bead, quoting the delimiter is the **wrong** fix — line 168 genuinely wants `$(basename "$0")` to expand. The backticks are dropped instead, which also matches the block's own house style: every other flag it names, in both the Usage line and the Flags list, is bare.

### `--help` before

```
gate root: /c/Users/miket/code/re-frame2-worktrees/smallmisc-xhbv4
scripts/test-fast-pr.sh: line 164: --plan: command not found
fast PR pre-checkin spine (rf2-r6x1t)
...
Within the JVM tier the spine runs implementation/core plus the suite of every
artefact whose own tree the diff touched, selected against the roster in
scripts/test-jvm-implementation.sh.   prints that selection.
```

### `--help` after

```
gate root: /c/Users/miket/code/re-frame2-worktrees/smallmisc-xhbv4
fast PR pre-checkin spine (rf2-r6x1t)
...
Within the JVM tier the spine runs implementation/core plus the suite of every
artefact whose own tree the diff touched, selected against the roster in
scripts/test-jvm-implementation.sh.  --plan prints that selection.
```

### Full diff of the rendered output

```
2d1
< scripts/test-fast-pr.sh: line 164: --plan: command not found
16c15
< scripts/test-jvm-implementation.sh.   prints that selection.
---
> scripts/test-jvm-implementation.sh.  --plan prints that selection.
```

Two symptoms, one cause: the stderr line, and a sentence whose subject had been replaced by the command's empty output. Everything else is byte-identical, and `$(basename "$0")` still expands (the Usage line still reads `test-fast-pr.sh [--all] ...`).

The gate-reaper added by **PR #7642** (trap on INT/TERM/HUP/QUIT plus a reap at the start of the next run, lines 589–809) was read first and is untouched — this is a one-line change inside the usage text at line 178.

## Quality gates

I am editing the gate runner itself, so the full spine was run to completion **before and after** the edit, foreground, unpiped, redirected to a worktree-local log with the runner's own exit code echoed.

| gate | command | result | exit |
|---|---|---|---|
| full spine, BEFORE any edit | `sh scripts/test-fast-pr.sh --all` | **78 stages**, `PASS fast PR spine` | **0** |
| full spine, AFTER both edits | `sh scripts/test-fast-pr.sh --all` | **80 stages**, `PASS fast PR spine` | **0** |
| syntax | `node --check clock_run.cjs` | clean | **0** |
| exit-path test | `node clock_run.cjs --selftest` | `ALL ADJUDICATORS OK` (22 ctl3 checks) | **0** |
| exit-path test | `node clock_witness.test.cjs` | 9/9 checks passed | **0** |
| help path | `sh scripts/test-fast-pr.sh --help` | usage text, no stderr | **0** |
| help path | `sh scripts/test-fast-pr.sh -h` | usage text | **0** |
| plan path | `sh scripts/test-fast-pr.sh --plan` | tier decision printed | **0** |
| unknown flag | `sh scripts/test-fast-pr.sh --bogus` | `unknown flag: --bogus` | **2** |
| first line of a run | `sh scripts/test-fast-pr.sh --plan \| head -1` | `gate root: …` | — |

### On the stage count: 78 → 80

The count moved, and it moved for the designed reason rather than a regression. The two added stages are exactly the two surfaces this PR touches, and the stage sequence is otherwise identical (`diff` of the `==>` headers shows only these two insertions):

```
> ==> fast-PR spine tiering self-test
> ==> JVM implementation/freehand
```

`--plan` confirms the cause. Baseline read `spine self-test: skip (spine unchanged)` / `reason: no changes (static checks only)`. With this diff applied it reads:

```
  spine self-test:     run
  reason:              spine self-change (every tier)
  JVM artefact suites: implementation/core implementation/freehand
```

That is `rf2-fhdd3`'s rule working: `scripts/test-fast-pr.sh` is on the spine's own surface so changing it arms the tiering self-test, and the JVM tier is `implementation/core` **plus the artefacts the diff touched**, so touching `implementation/freehand/` arms freehand. `--all` forces the tiers on but does not widen the per-artefact selection, which is why the baseline run legitimately had neither.

Both new stages are green: the tiering self-test passed 37 checks, and `JVM implementation/freehand` ran **1291 tests / 8874 assertions, 0 failures, 0 errors**.

The two footer counts are unchanged across both runs — `NOT RUN by this spine (2)` and `REQUIRED CHECKS THIS SPINE DOES NOT RUN (90)`.

Closes rf2-xhbv4. Closes rf2-x2brm.
