### PR TITLE
fix(hicasso): a skip-quiet run must not land canonical (rf2-azopg)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -371,6 +371,7 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     runsOnly: null,
     noBuild: false,
     depthPublished: true,
+    skipQuiet: false,
     ...over,
   });
   const t = (what, fn) => test(`census_clock_run.cjs write path: ${what}`, fn);
@@ -390,6 +391,13 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     ['a partial run set', { runsOnly: 'uix' }, 0, /PARTIAL run set/],
     ['--no-build', { noBuild: true }, 0, /--no-build/],
     ['an overridden depth', { depthPublished: false }, 0, /OVERRIDDEN design depth/],
+    // rf2-azopg. C56CLOCK_SKIP_QUIET=1 made `quietGate` return ok:true and
+    // print "NOT the published shape", and then nothing carried that fact to
+    // the write decision — so a run whose samples were never checked against a
+    // quiet box could occupy the canonical directory, indistinguishable from
+    // one taken in a granted window. This is the probe that found it: the
+    // published shape in every other respect, exit 0, quiet gate skipped.
+    ['a SKIPPED quiet gate', { skipQuiet: true }, 0, /SKIPPED quiet gate \(C56CLOCK_SKIP_QUIET=1\)/],
   ]) {
     t(`${what} is NOT canonical, and says why`, () => {
       const d = destination(shape(over), code);
@@ -404,11 +412,30 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   }
 
   t('every condition that fired is named, not just the first', () => {
-    const d = destination(shape({ rowsOnly: 'feed', noBuild: true, depthPublished: false }), 5);
+    const d = destination(shape({ rowsOnly: 'feed', noBuild: true, depthPublished: false, skipQuiet: true }), 5);
     assert.strictEqual(d.canonical, false);
-    for (const needle of [/verdict refused it \(exit 5\)/, /PARTIAL row set/, /--no-build/, /OVERRIDDEN design depth/]) {
+    for (const needle of [/verdict refused it \(exit 5\)/, /PARTIAL row set/, /--no-build/, /OVERRIDDEN design depth/, /SKIPPED quiet gate/]) {
       assert.match(d.why, needle);
     }
+  });
+
+  // rf2-azopg, the other half. `destination` is pure over a shape RECORD; the
+  // one caller that builds the real shape is `runShape`, and it is not
+  // exported. So a `destination` that reads `skipQuiet` correctly still fails
+  // open if `runShape` never puts it there — which is precisely how the defect
+  // survived: the flag existed, printed "NOT the published shape", and never
+  // reached the write decision. Pin the wiring in the source, the same way the
+  // ordering pins below do, because no test of the export can see it.
+  t('runShape carries the skip-quiet fact into the write decision', () => {
+    assert.match(SRC, /const SKIP_QUIET = process\.env\.C56CLOCK_SKIP_QUIET === '1';/);
+    const from = SRC.indexOf('const runShape = () => ({');
+    assert.ok(from > 0, 'runShape no longer has the shape this test pins');
+    const body = SRC.slice(from, SRC.indexOf('});', from));
+    assert.match(
+      body,
+      /skipQuiet: SKIP_QUIET,/,
+      'runShape must carry skipQuiet, or a skipped quiet gate can still write the canonical set'
+    );
   });
 
   t('an explicit C56CLOCK_DATA_DIR is honoured as given, and is never canonical', () => {

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
@@ -118,11 +118,12 @@
 //
 // The canonical dataset directory holds THE PUBLISHED SHAPE and nothing
 // else. A run that is narrowed (C56CLOCK_ROWS / C56CLOCK_ONLY), taken at an
-// overridden depth, taken `--no-build`, or refused by the verdict above
-// writes to a sibling `.unpublished` directory instead, named on stdout with
-// the reason; an explicit C56CLOCK_DATA_DIR is honoured as given. See the
-// note above `destination` — that routing is rf2-2rtt6.56's half of the same
-// fail-open rf2-rr6do repaired on the exit path.
+// overridden depth, taken `--no-build`, taken with the quiet gate skipped
+// (C56CLOCK_SKIP_QUIET), or refused by the verdict above writes to a sibling
+// `.unpublished` directory instead, named on stdout with the reason; an
+// explicit C56CLOCK_DATA_DIR is honoured as given. See the note above
+// `destination` — that routing is rf2-2rtt6.56's half of the same fail-open
+// rf2-rr6do repaired on the exit path.
 
 'use strict';
 
@@ -912,8 +913,14 @@ function verdict(summary) {
 // path; this is the write path, the other half of the same fail-open.
 //
 // THE RULE: the canonical directory holds the PUBLISHED SHAPE and nothing
-// else. Any narrowing, any override, any refusal routes to a sibling
-// `.unpublished` directory, named on stdout with the reason.
+// else. Any narrowing, any override, any skipped gate, any refusal routes to
+// a sibling `.unpublished` directory, named on stdout with the reason.
+//
+// rf2-azopg added the skipped gate to that list, and it is the sharpest case:
+// C56CLOCK_SKIP_QUIET=1 already PRINTED "NOT the published shape", but the
+// fact never reached here, so a run taken on a contended box could occupy the
+// canonical set and read back as if it had been taken in a granted window.
+// That is the one distinction the whole quiet-box discipline exists to keep.
 //
 // An explicit C56CLOCK_DATA_DIR is the operator naming their own destination
 // — which is how the sibling `censusclock-*` datasets beside the canonical
@@ -932,6 +939,7 @@ function destination(shape, code) {
   if (s.runsOnly) why.push(`a PARTIAL run set (C56CLOCK_ONLY=${s.runsOnly})`);
   if (s.noBuild) why.push("--no-build (the bundle on disk is not known to be this tree's)");
   if (!s.depthPublished) why.push('an OVERRIDDEN design depth');
+  if (s.skipQuiet) why.push('a SKIPPED quiet gate (C56CLOCK_SKIP_QUIET=1)');
   if (!why.length) return { dir: s.dataDir, canonical: true, why: null };
   return { dir: `${s.dataDir}.unpublished`, canonical: false, why: why.join('; ') };
 }
@@ -1002,6 +1010,10 @@ const runShape = () => ({
   runsOnly: ONLY || null,
   noBuild: NO_BUILD,
   depthPublished: depthIsPublished(),
+  // The quiet gate PRINTS that a skipped run is not the published shape
+  // (`quietGate`); until rf2-azopg nothing carried that fact here, so the
+  // write decision never saw it. Printing a caveat is not enforcing one.
+  skipQuiet: SKIP_QUIET,
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes rf2-azopg.

`C56CLOCK_SKIP_QUIET=1` made `quietGate` return `ok:true` and print that the run is **NOT the published shape** — and then nothing carried that fact to the write decision. `runShape` did not include the flag and `destination` never tested it, so a skip-quiet run could occupy the canonical dataset directory and read back as if it had been taken in a granted window.

That is the exact distinction the quiet-box discipline exists to preserve: canonical datasets are what the published rows are recomputed from, so a figure taken on a contended box became indistinguishable from one taken in a granted window. Printing a caveat is not enforcing one.

**This is quiet-box INSTRUMENT PREP.** Per the rf2-jv36i delegated decision, no census quiet-box window is requested from the operator until this lands — it decides whether that window's output can be trusted. **No measurement was taken by this PR.**

## The defect, before and after

Probe of the exported `destination`, published shape in every other respect, exit 0:

```
BEFORE  skipQuiet:true  -> {"dir":"/data/censusclock-2rtt6-56","canonical":true,"why":null}

AFTER   skipQuiet:true  -> {"dir":"/data/censusclock-2rtt6-56.unpublished","canonical":false,
                            "why":"a SKIPPED quiet gate (C56CLOCK_SKIP_QUIET=1)"}
AFTER   skipQuiet:false -> {"dir":"/data/censusclock-2rtt6-56","canonical":true,"why":null}
```

The before-row reproduces the bead's probe verbatim. The second after-row is the negative control: the fix routes the skipped gate, not everything.

## The fix

Fails closed in the shape `destination` already uses — no second idiom:

- `runShape` carries `skipQuiet: SKIP_QUIET`;
- `destination` adds `a SKIPPED quiet gate (C56CLOCK_SKIP_QUIET=1)` to the `why` list, so the run routes to the sibling `.unpublished` directory and `datasetFor` stamps `canonical:false` / `notCanonicalWhy` **in the file** — a dataset that travels out of its directory still says what it is.

Two prose sites that enumerate the routing conditions were updated with it, so the file's own description of the rule stays true.

**No dataset files were touched.** The diff is two files: the driver and its exit-path test.

## The mutation test

The test was written **first** and run against the unfixed driver, so it is demonstrated to detect the fail-open rather than merely to agree with the fix. Fixtures are built in-test — nothing is asserted about the checkout's datasets, so it is platform-independent.

Both halves are pinned **independently**, because the export can only see one of them. `destination` is pure over a shape *record*; the one caller that builds the real shape is `runShape`, which is not exported — so a correct `destination` still fails open if `runShape` never puts the flag there. That is precisely how the defect survived.

| mutation | runner exit | failures |
|---|---|---|
| both halves absent (pre-fix tree) | 1 | **3**/135 |
| `destination` arm removed only | 1 | **2**/135 |
| `runShape` wiring removed only | 1 | **1**/135 |
| fixed | 0 | **0**/135 (135 passed) |

The new case joins the existing per-condition loop, which also re-asserts that the unmutated shape is still canonical — so the test cannot pass by refusing everything. The `runShape` pin is a source pin, matching the file's existing convention for wiring no test of the export can reach (`canonical: meta.dest.canonical`, the verdict/write ordering pins).

## Quality gates

All foreground, to completion, never piped; each log redirected and the runner's own exit code echoed.

| command | result | exit |
|---|---|---|
| `node freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs` (pre-fix, expected red) | 3/135 failed | **1** |
| `node freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs` (post-fix) | 135 passed | **0** |
| `npm run test:script-helpers` (the suite owning this driver test — 24 runners) | all passed, `clock_exit_path.test.cjs: 135 passed` | **0** |
| `sh scripts/test-fast-pr.sh` | JVM tiers green (2233 + 1291 tests, 0 failures); **run invalidated** — see below | n/a |
| `node .../clock_exit_path.test.cjs` re-run on merged `origin/main` in a clean worktree | 135 passed | **0** |

### Note on the fast-PR spine run

The local spine run was **invalidated by an environment event, not by this change**: this PR was merged while the spine was still running, and the hygiene loop reaped the worker worktree underneath it. Its `node_modules` disappeared mid-run, and the CLJS `:node-test` tier then reported 5 failures in `re-frame.test-quiet-shadow-node-cljs-test`, every one of them a spawned-subprocess `Error: Cannot find module 'react'`.

That diagnosis is confirmed three ways: the two JVM tiers that had already completed were green; CI's own **CLJS (shadow-cljs :node-test)** job passed here in 12m39s; and the merged tree was re-verified afterwards in a clean worktree (table row above, exit 0). This PR's diff is two `.cjs` bench-driver files, which no CLJS build compiles or requires.

CI on this PR: **50 pass, 36 skipping, 0 failures.**
