### PR TITLE
fix(hicasso): make the corrected-clock re-adjudication reproducible from committed data (rf2-emvod)

### DIFF
--- a/docs/design/hicasso/studio/a-control-that-differences-the-constant-away.md
+++ b/docs/design/hicasso/studio/a-control-that-differences-the-constant-away.md
@@ -393,3 +393,17 @@ Every figure on this page is recomputable from the dataset the run writes when
 `inPageRounds` per block, the control's per-block terms and marginals, the page's
 **declared** plan, and what the 2D arm actually rendered when the falsification
 knob was on.
+
+**That sentence is about the FORMAT, and this page's own datasets were not
+retained** *(2026-08-07, `rf2-emvod`, recorded rather than repaired)*. Nothing
+tracked in the tree holds the run behind §2's constants, §3's marginal-cost and
+`LayoutDuration` tables, §5's noise figures or §6's sabotage result, so the two
+commands above take a **new** run at this instrument rather than recomputing
+*this* one, and the falsification is re-performed rather than re-read. Re-taking
+them is a measurement and not a repair; none was taken to write this note, and
+no figure above is restated. The retention contract that would close it — a run
+of the full published shape writing under a canonical name, a refused or partial
+one writing the same serialised shape beside it, and both saying which they are
+in the file — is `rf2-2rtt6.31`'s two-tier policy, which `clock_run.cjs` adopts
+when it is next touched. Its reading end is already armed: see
+[the corrected-clock page's §7.1](rows-re-adjudicated-on-the-corrected-clock.md#71-what-this-page-cannot-regenerate).

--- a/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
+++ b/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
@@ -74,6 +74,15 @@ tables below. It does not select runs — every dataset handed to it appears, an
 the reportable subset is shown *beside* the whole ensemble rather than instead
 of it.
 
+**The subset that program draws is now the driver's whole exit path, and it
+fails closed** *(2026-08-07, `rf2-emvod`)*. It asked for the positive control
+and the two ceilings and nothing else, while printing four further verdicts it
+then ignored; and the driver writes its dataset *before* its own fatal checks
+run, so a run the page threw on was a well-formed file that reached the
+published mean. What that repair does and does not reach — including the
+datasets this page's own tables were computed from, which **were never
+retained** — is [§7.1](#71-what-this-page-cannot-regenerate).
+
 ---
 
 ## 2. The door
@@ -438,6 +447,75 @@ git rev-parse <candidate>:$P   # must print 84aa25d93b65ee55f3d28d339d57720e3a50
 cd implementation && npm ci
 node freehand/test/re_frame/bench/hicasso/clock_run.cjs           # one run, all five rows
 node freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs out/run*.json
+```
+
+### 7.1 What this page cannot regenerate
+
+**The seven datasets were not retained, and the command above is therefore not
+a reproduction** *(2026-08-07, `rf2-emvod`, recorded rather than repaired)*.
+`out/run*.json` names files that existed only in the author's working tree; the
+merge landed no Hicasso dataset at all. So a fresh clone cannot recompute
+`1.3737×`, its range, the 7/3/2/4 reportable counts, the controls, the bands,
+the absolutes, the door spreads or [§4.2](#42-ctl-2x-undershoots-on-the-mount-row-too-and-that-changes-its-diagnosis)'s
+additive-residual table. **Every table on this page is unreproducible from the
+tree, and that is stated here rather than left to be discovered.** Re-taking the
+ensemble is a *measurement*, not a repair, and none was taken to write this
+section: no figure above has been restated, widened or recomputed.
+
+This is [`rf2-cvvb7`'s recorded gap](the-candidates-clock.md#71-the-seam-study-rf2-cvvb7)
+landing on the very page that quotes it — which is the reason the repair below
+is in the *instrument* rather than in this prose. A page can only promise
+reproducibility; a program can refuse to pretend.
+
+**What the tree enforces now.** `clock_readjudicate.cjs`'s reportable subset is
+the driver's own exit path, read back off the serialised record, fail-closed at
+every seat — a verdict that is missing, null or silent has not been passed, it
+has been lost. Its first gate is [`rf2-2rtt6.31`'s two-tier write
+policy](hd8-composed-donor-arm.md) seen from the reading end: a dataset records
+`canonical` and `notCanonicalWhy` **in the file**, and a missing `canonical`
+field is not a pass. Nothing is selected away — every run stays in every table
+with its own magnitude beside it and its refusals named — and the program exits
+`3` over evidence it may not publish from.
+
+| gate | what refuses the run | serialised today |
+|---|---|---|
+| `canonical` | the file does not say it is the published evidence set | **no** — the producer half is `clock_run.cjs`'s to add |
+| `page-errors` | Chromium threw during the run | **no** |
+| `guard-net`, `guard-task` | the arm-order guard refused, on either clock | yes |
+| `canonical-dom` | the arms built different pages | **no** |
+| `ctl3-parity` | the three-point control's own arms built different pages | yes |
+| `keystroke-witness` | the per-keystroke accounting does not close | yes |
+| `unverified` | a window whose value never reached the page | yes |
+| `ceiling-net`, `ceiling-task` | the reproducibility band exceeds its ceiling | yes |
+| `control` | the three-point control failed, or `ctl-2x` on either clock | yes |
+| `event-timing` | the Event-Timing witness refused | **no** |
+| `adjudication` | a published bar carries no band | yes |
+
+The four unserialised verdicts are named at the driver's own internal field
+names, so no dataset in the tree satisfies the filter today — the correct
+fail-closed reading of an *incomplete* record, and not a defect in it.
+`clock_run.cjs` adopts the family policy when it is next touched — "record
+once, converge on touch" — and because the names above are its own, that
+adoption is one line per verdict.
+
+**The one command, and what it does on the datasets that were kept:**
+
+```bash
+cd implementation
+node freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs \
+  freehand/test/re_frame/bench/hicasso/data/clock-0qj9w/run1.json \
+  freehand/test/re_frame/bench/hicasso/data/clock-0qj9w/run2.json
+# exit 3 — neither file carries a `canonical` verdict, both are printed in
+#          full, and no reportable subset is drawn from either
+```
+
+Its refusals are fixtures rather than an assertion — one deliberate corruption
+*and* one deliberate erasure per gate, plus the whole program run over a file
+in both directions:
+
+```bash
+cd implementation
+node freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
 ```
 
 The cross-check probe in [§2.1](#21-what-the-correction-therefore-does-not-reach)

--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -369,7 +369,7 @@ transcribed.
 | Box at close | occupancy **1.37%**, same process counts, 32.4 GB free |
 | Occupancy method | summed per-process CPU-time deltas over a 10 s wall interval, divided by core count. **Not** `Win32_Processor.LoadPercentage`, which read 24% and 45% on this same idle box |
 | Driver exit code | **1** — the positive control on `M1` |
-| Retained dataset | `implementation/freehand/test/re_frame/bench/hicasso/data/clock-0qj9w/run1.json`, re-adjudicable with `clock_readjudicate.cjs` |
+| Retained dataset | `implementation/freehand/test/re_frame/bench/hicasso/data/clock-0qj9w/run1.json`, re-adjudicable with `clock_readjudicate.cjs` — which prints every table and **exits 3**, because the file predates `rf2-2rtt6.31`'s two-tier contract and carries no in-file `canonical` verdict *(2026-08-07, `rf2-emvod`)* |
 
 **One refusal fired, and it is `M1`'s positive control.** `ctl-2x` measured
 **1.8443×** [1.3837 – 2.4233] on raw `TaskDuration` against 2.00× ±25% under the
@@ -443,7 +443,7 @@ might have dissolved.
 | Box at close | occupancy **3.12%**, 534 processes, 28.8 GB free |
 | Occupancy method | summed per-process CPU-time deltas over a 6 s wall interval, divided by core count. **Not** `Win32_Processor.LoadPercentage` |
 | Driver exit code | **1** — the positive control on `M1`, again |
-| Retained dataset | `implementation/freehand/test/re_frame/bench/hicasso/data/clock-0qj9w/run2.json`, re-adjudicable with `clock_readjudicate.cjs` |
+| Retained dataset | `implementation/freehand/test/re_frame/bench/hicasso/data/clock-0qj9w/run2.json`, re-adjudicable with `clock_readjudicate.cjs` — which prints every table and **exits 3**, because the file predates `rf2-2rtt6.31`'s two-tier contract and carries no in-file `canonical` verdict *(2026-08-07, `rf2-emvod`)* |
 
 **`M1`'s positive control refused again, and it refused from the other side.**
 `ctl-2x` measured **1.8567×** [1.6562 – 2.6112] against 2.00× ±25% under the

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -82,7 +82,9 @@
 // Wired into implementation/package.json via `test:script-helpers`.
 
 const assert = require('node:assert');
+const cp = require('node:child_process');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 // Requiring a driver must NOT drive it: the `require.main === module` guard
@@ -916,16 +918,31 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
 
 {
   const RJ = path.join(__dirname, 'clock_readjudicate.cjs');
-  const { adjudicated, reportable, responsivenessRegime } = require('./clock_readjudicate.cjs');
+  const { GATES, adjudicated, refusals, reportable, responsivenessRegime } = require('./clock_readjudicate.cjs');
   const RJSRC = fs.readFileSync(RJ, 'utf8');
   const t = (what, fn) => test(`clock_readjudicate.cjs: ${what}`, fn);
   const ADJ = { unadjudicated: false, band: 0.21, why: 'margin 34.8% clears the band 21.4%' };
   const UNADJ = { unadjudicated: true, band: null, why: 'UNADJUDICATED — no proportional control on this row' };
-  // A dataset row as `clock_run.cjs` writes it, reduced to the fields this
-  // predicate reads.
+  // THE FILE'S OWN TWO-TIER VERDICT (rf2-2rtt6.31), as `datasetFor` writes it.
+  // Every predicate here is handed one, because a row cannot vouch for the
+  // file it came from and this filter's first gate is that it does not try.
+  const CANON = { canonical: true, notCanonicalWhy: null };
+  // A dataset row as a two-tier `clock_run.cjs` writes it, reduced to the
+  // fields this predicate reads — every whole-run verdict the driver exits on,
+  // each at its passing value.
   const dsRow = (bars, over) => ({
     rowId: 'M1',
+    pageErrors: [],
+    guardRefuse: false,
+    guardRefuseTask: false,
+    parityOk: true,
+    ctl3Parity: null,
+    kbWitness: null,
+    tally: { writes: 1008, unverified: 0 },
+    ctl3: null,
+    ctlOk: true,
     ctlTask: { ok: true },
+    etVerdict: null,
     seam: { verdict: { ceilingBreached: false } },
     seamTask: { ceilingBreached: false, rows: bars },
     ...over,
@@ -934,13 +951,13 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   t('THE REMAINDER: one unadjudicated bar keeps the whole run OUT of the subset', () => {
     const row = dsRow({ 'h / r': ADJ, 'h / u': UNADJ, 'u / r': ADJ });
     assert.strictEqual(adjudicated(row), false, 'two adjudicated bars may not carry a third with no band');
-    assert.strictEqual(reportable(row), false, 'and the run may not be pooled into the published mean');
+    assert.strictEqual(reportable(row, CANON), false, 'and the run may not be pooled into the published mean');
   });
 
   t('a run whose every bar carries a band IS pooled — the predicate is not vacuous', () => {
     const row = dsRow({ 'h / r': ADJ, 'h / u': ADJ, 'u / r': ADJ });
     assert.strictEqual(adjudicated(row), true);
-    assert.strictEqual(reportable(row), true, 'a clean run must still reach the reportable subset');
+    assert.strictEqual(reportable(row, CANON), true, 'a clean run must still reach the reportable subset');
   });
 
   t('a run whose every bar is UNADJUDICATED is still out — the term was tightened, not swapped', () => {
@@ -951,7 +968,7 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     assert.strictEqual(adjudicated(dsRow({})), false, 'an empty bar set is absent, not clean');
     assert.strictEqual(adjudicated({ rowId: 'M1' }), false, 'a row with no seamTask at all is absent, not clean');
     assert.strictEqual(adjudicated(undefined), false);
-    assert.strictEqual(reportable(undefined), false);
+    assert.strictEqual(reportable(undefined, CANON), false);
   });
 
   // --- AND THE FIELD, which #7550's merged-PR audit found still open here ---
@@ -966,7 +983,7 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   t('THE FIELD: a bar with no `unadjudicated` field keeps the run OUT of the subset', () => {
     const row = dsRow({ 'h / r': ADJ, 'h / u': {} });
     assert.strictEqual(adjudicated(row), false, 'a bar carrying no verdict has not been adjudicated');
-    assert.strictEqual(reportable(row), false, 'and a lost verdict may not reach the published mean');
+    assert.strictEqual(reportable(row, CANON), false, 'and a lost verdict may not reach the published mean');
   });
 
   t('a dataset whose every bar is fieldless is out, and it used to be IN', () => {
@@ -974,7 +991,7 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     // passing control and no ceiling breach `reportable` returned true too.
     const row = dsRow({ 'h / r': {}, 'h / u': {} });
     assert.strictEqual(adjudicated(row), false);
-    assert.strictEqual(reportable(row), false);
+    assert.strictEqual(reportable(row, CANON), false);
   });
 
   t('a bar stored as null or undefined is out rather than a crash', () => {
@@ -983,7 +1000,7 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     // rather than one that declines to publish from it.
     for (const missing of [null, undefined]) {
       assert.strictEqual(adjudicated(dsRow({ 'h / r': ADJ, 'h / u': missing })), false, `bar=${String(missing)}`);
-      assert.strictEqual(reportable(dsRow({ 'h / r': ADJ, 'h / u': missing })), false, `bar=${String(missing)}`);
+      assert.strictEqual(reportable(dsRow({ 'h / r': ADJ, 'h / u': missing }), CANON), false, `bar=${String(missing)}`);
     }
   });
 
@@ -992,36 +1009,286 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     // false and no run would ever be published again.
     const row = dsRow({ 'h / r': { unadjudicated: false }, 'h / u': { unadjudicated: false, band: 0.2 } });
     assert.strictEqual(adjudicated(row), true);
-    assert.strictEqual(reportable(row), true);
+    assert.strictEqual(reportable(row, CANON), true);
   });
 
   t('the OTHER two terms are unchanged — adjudication was ADDED, never substituted', () => {
     const bars = { 'h / r': ADJ, 'h / u': ADJ };
     // A failed control still excludes a fully adjudicated run ...
-    assert.strictEqual(reportable(dsRow(bars, { ctlTask: { ok: false } })), false);
-    assert.strictEqual(reportable(dsRow(bars, { ctlTask: null })), false);
+    assert.strictEqual(reportable(dsRow(bars, { ctlTask: { ok: false } }), CANON), false);
+    assert.strictEqual(reportable(dsRow(bars, { ctlTask: null }), CANON), false);
     // ... and so does either ceiling, which fires before any control.
     assert.strictEqual(
-      reportable(dsRow(bars, { seam: { verdict: { ceilingBreached: true } } })),
+      reportable(dsRow(bars, { seam: { verdict: { ceilingBreached: true } } }), CANON),
       false,
       'a breached net-band ceiling still excludes the run'
     );
     assert.strictEqual(
-      reportable(dsRow(bars, { seamTask: { ceilingBreached: true, rows: bars } })),
+      reportable(dsRow(bars, { seamTask: { ceilingBreached: true, rows: bars } }), CANON),
       false,
       'a breached task-band ceiling still excludes the run'
     );
   });
 
+  // --- EVERY GATE THE DRIVER EXITS ON, ENFORCED HERE TOO (rf2-emvod) --------
+  //
+  // #7365's merged-PR audit: the subset asked for `ctlTask.ok` and the two
+  // ceilings and nothing else, while the very same program PRINTED
+  // `guardRefuse`, `guardRefuseTask`, the legacy-clock `ctlOk` and
+  // `tally.unverified` in the gate table two lines above the pooled mean. And
+  // `clock_run.cjs` writes its dataset BEFORE its fatal checks run, so a run
+  // Chromium threw on, or whose arms built different pages, is a well-formed
+  // file that reached the published mean. The filter is now the driver's own
+  // exit path read back off the record, plus rf2-2rtt6.31's two-tier clause:
+  // a file that does not say it is the published evidence set is not.
+  //
+  // DRIVEN OVER THE ROSTER, not over a hand-written list, so a gate added to
+  // `GATES` without a case here fails the first assertion rather than shipping
+  // as a gate nothing has ever seen refuse.
+
+  const del = (o, k) => {
+    const c = { ...o };
+    delete c[k];
+    return c;
+  };
+  const BARS = { 'h / r': ADJ, 'h / u': ADJ };
+  // One deliberate corruption per gate, and one deliberate ERASURE per gate:
+  // `failed` and `absent` are different faults and both must refuse.
+  const CASES = [
+    {
+      id: 'canonical',
+      data: { canonical: false, notCanonicalWhy: "the run's own verdict refused it (exit 5)" },
+      failed: /NOT the published evidence set — the run's own verdict refused it \(exit 5\)/,
+      erase: { data: 'canonical' },
+      absent: /carries no `canonical` verdict/,
+    },
+    {
+      id: 'page-errors',
+      row: { pageErrors: ['TypeError: undefined is not a function'] },
+      failed: /the page THREW during the run: TypeError/,
+      erase: { row: 'pageErrors' },
+      absent: /no `pageErrors` record/,
+    },
+    {
+      id: 'guard-net',
+      row: { guardRefuse: true },
+      failed: /arm-order guard REFUSED this row on taskNet/,
+      erase: { row: 'guardRefuse' },
+      absent: /no arm-order guard verdict on taskNet/,
+    },
+    {
+      id: 'guard-task',
+      row: { guardRefuseTask: true },
+      failed: /arm-order guard REFUSED this row on the published clock/,
+      erase: { row: 'guardRefuseTask' },
+      absent: /no arm-order guard verdict on the published clock/,
+    },
+    {
+      id: 'canonical-dom',
+      row: { parityOk: false },
+      failed: /canonical-DOM gate found arms building DIFFERENT PAGES/,
+      erase: { row: 'parityOk' },
+      absent: /no canonical-DOM verdict was serialised/,
+    },
+    {
+      id: 'ctl3-parity',
+      row: { ctl3Parity: { ok: false } },
+      failed: /three-point control's own arms built DIFFERENT PAGES/,
+      erase: { row: 'ctl3Parity' },
+      absent: /no three-point-control parity record/,
+    },
+    {
+      id: 'keystroke-witness',
+      row: { kbWitness: { ok: false, faults: [{ code: 'ORPHAN', why: 'an entry belongs to no key pressed' }] } },
+      failed: /per-keystroke witness REFUSED/,
+      erase: { row: 'kbWitness' },
+      absent: /no per-keystroke witness record/,
+    },
+    {
+      id: 'unverified',
+      row: { tally: { writes: 1008, unverified: 4 } },
+      failed: /4 unverified operation\(s\) of 1008/,
+      erase: { row: 'tally' },
+      absent: /no write-verification tally/,
+    },
+    {
+      id: 'ceiling-net',
+      row: { seam: { verdict: { ceilingBreached: true } } },
+      failed: /frame-only reproducibility band exceeds the ceiling/,
+      erase: { row: 'seam' },
+      absent: /no frame-only band verdict/,
+    },
+    {
+      id: 'ceiling-task',
+      row: { seamTask: { ceilingBreached: true, rows: BARS } },
+      failed: /band exceeds the ceiling on the published clock/,
+      erase: { row: 'seamTask' },
+      absent: /no published-clock band verdict/,
+    },
+    {
+      id: 'control',
+      row: { ctl3: { ok: false, measured: { mean: 1.2 } } },
+      failed: /THREE-POINT control FAILED/,
+      erase: { row: 'ctl3' },
+      absent: /no three-point-control record/,
+    },
+    {
+      id: 'event-timing',
+      row: { etVerdict: { ok: false } },
+      failed: /Event-Timing witness REFUSED/,
+      erase: { row: 'etVerdict' },
+      absent: /no Event-Timing verdict was serialised/,
+    },
+    {
+      id: 'adjudication',
+      bars: { 'h / r': ADJ, 'h / u': UNADJ },
+      failed: /carries no adjudication verdict/,
+      erase: { bars: true },
+      absent: /carries no adjudication verdict/,
+    },
+  ];
+
+  t('every gate in the roster has a case — an unexercised gate is not a gate', () => {
+    assert.deepStrictEqual(
+      GATES.map((g) => g.id),
+      CASES.map((c) => c.id),
+      'GATES and the corruption cases must agree, in order'
+    );
+  });
+
+  t('a fully compliant run IS reportable — the roster is not vacuous', () => {
+    // Every assertion below would pass against a predicate that always said
+    // false, so this one comes first in weight if not in order.
+    assert.strictEqual(reportable(dsRow(BARS), CANON), true);
+    assert.deepStrictEqual(refusals(dsRow(BARS), CANON), []);
+  });
+
+  for (const c of CASES) {
+    t(`gate \`${c.id}\`: a FAILED verdict removes the run from the subset, and names itself`, () => {
+      const row = dsRow(c.bars || BARS, c.row || {});
+      const data = { ...CANON, ...(c.data || {}) };
+      const why = refusals(row, data);
+      assert.ok(
+        why.some((w) => c.failed.test(w)),
+        `no refusal matched ${c.failed} — got ${JSON.stringify(why)}`
+      );
+      assert.strictEqual(reportable(row, data), false);
+    });
+
+    t(`gate \`${c.id}\`: an ABSENT verdict removes it too — absent is not clean`, () => {
+      let row = dsRow(c.erase.bars ? {} : c.bars || BARS, c.row ? {} : {});
+      if (c.erase.row) row = del(row, c.erase.row);
+      let data = { ...CANON };
+      if (c.erase.data) data = del(data, c.erase.data);
+      const why = refusals(row, data);
+      assert.ok(
+        why.some((w) => c.absent.test(w)),
+        `no refusal matched ${c.absent} — got ${JSON.stringify(why)}`
+      );
+      assert.strictEqual(reportable(row, data), false);
+    });
+  }
+
+  t('a row cannot vouch for the file it came from — no envelope is a refusal', () => {
+    // The two-tier contract's consumer clause. A dataset that travelled out of
+    // its directory, or a caller that forgot to pass the envelope, must not be
+    // able to publish on the strength of the row alone.
+    assert.strictEqual(reportable(dsRow(BARS)), false);
+    assert.ok(refusals(dsRow(BARS)).some((w) => /carries no `canonical` verdict/.test(w)));
+  });
+
+  t('EVERY reason is reported, not the first — a run that failed four gates says four', () => {
+    const why = refusals(dsRow(BARS, { guardRefuse: true, parityOk: false, ctlTask: { ok: false } }), {
+      canonical: false,
+      notCanonicalWhy: 'a PARTIAL row set',
+    });
+    assert.strictEqual(why.length, 4, JSON.stringify(why));
+  });
+
+  // --- AND THE WHOLE PROGRAM, END TO END, ON A FILE -------------------------
+  //
+  // The predicates above are pure and the program is what a reader actually
+  // runs, so the refusal is demonstrated where it is claimed: over a dataset on
+  // disk, by exit code. Both directions, because a checker nobody has seen say
+  // yes is as useless as one nobody has seen say no.
+
+  const fixture = (over) => ({
+    label: 'fixture',
+    chromium: '147.0.0.0',
+    node: process.version,
+    when: '2026-08-07T00:00:00.000Z',
+    design: { rounds: 6, warmup: 4, samples: 10, tare: true },
+    canonical: true,
+    notCanonicalWhy: null,
+    ...over,
+    rows: [
+      {
+        ...dsRow({ 'hicasso / reagent-subs': ADJ }),
+        granularity: [0.146],
+        inPageRounds: [],
+        decomposition: {
+          'reagent-subs/plumb': { n: 60, task: 36, taskNet: 12, devtools: 24, script: 0.06, layout: 5 },
+          'reagent-subs/floor': { n: 60, task: 360, taskNet: 280, devtools: 80, script: 0.06, layout: 40 },
+          'reagent-subs/reagent-subs': { n: 60, task: 600, taskNet: 280, devtools: 320, script: 0.06, layout: 60 },
+          'hicasso/hicasso': { n: 60, task: 780, taskNet: 320, devtools: 460, script: 0.06, layout: 70 },
+        },
+        ctlTask: { ok: true, measured: { mean: 1.9 } },
+        seam: { band: 0.06, verdict: { ceilingBreached: false } },
+        seamTask: { ceilingBreached: false, band: 0.05, rows: { 'hicasso / reagent-subs': ADJ } },
+        bandTask: 0.05,
+        bar: { 'hicasso / reagent-subs': { tared: { mean: 1.1 } } },
+        inPageBar: { 'hicasso / reagent-subs': { mean: 1.2 } },
+        barTask: { 'hicasso / reagent-subs': { mean: 1.3, min: 1.2, max: 1.4 } },
+      },
+    ],
+  });
+
+  const runProgram = (data) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rf2-emvod-'));
+    const f = path.join(dir, 'run1.json');
+    fs.writeFileSync(f, JSON.stringify(data));
+    const r = cp.spawnSync(process.execPath, [RJ, f], { encoding: 'utf8' });
+    fs.rmSync(dir, { recursive: true, force: true });
+    return { code: r.status, out: `${r.stdout}${r.stderr}` };
+  };
+
+  t('THE COMMAND: a compliant dataset regenerates its aggregate and exits 0', () => {
+    const { code, out } = runProgram(fixture());
+    assert.strictEqual(code, 0, out);
+    assert.match(out, /reportable subset 1\.3000x n=1/);
+    assert.match(out, /— reportable: every gate this dataset serialises is clean/);
+  });
+
+  t('THE COMMAND: a non-canonical dataset exits 3 and is still printed in full', () => {
+    const { code, out } = runProgram(fixture({ canonical: false, notCanonicalWhy: '--no-build' }));
+    assert.strictEqual(code, 3, out);
+    assert.match(out, /NOT ELIGIBLE PUBLISHED EVIDENCE/);
+    assert.match(out, /reportable subset: NONE/);
+    // RETAINED, not erased: the run is still in the per-run table with its own
+    // magnitude beside it. A refusal is about what may be QUOTED.
+    assert.match(out, /;;\s+run1\s+1\.2000\s+1\.1000\s+1\.3000/);
+    assert.match(out, /EXIT 3 — 1 of 1 dataset\(s\) are not eligible published evidence/);
+  });
+
+  t('THE COMMAND: a gate failure inside a canonical dataset empties the subset, not the table', () => {
+    const bad = fixture();
+    bad.rows[0].tally = { writes: 1008, unverified: 4 };
+    const { code, out } = runProgram(bad);
+    assert.strictEqual(code, 0, 'the FILE is still eligible evidence — it is the RUN that is refused');
+    assert.match(out, /reportable subset: NONE/);
+    assert.match(out, /4 unverified operation\(s\) of 1008/);
+    assert.match(out, /;;\s+run1\s+1\.2000\s+1\.1000\s+1\.3000/);
+  });
+
   t('requiring the readjudicator does not RUN it, which is what made this reachable', () => {
-    assert.match(RJSRC, /module\.exports = \{ adjudicated, reportable, responsivenessRegime \};/);
+    assert.match(RJSRC, /module\.exports = \{ GATES, adjudicated, refusals, reportable, responsivenessRegime \};/);
     assert.match(RJSRC, /if \(require\.main === module\) \{/);
     assert.match(RJSRC, /main\(process\.argv\.slice\(2\)\)/);
   });
 
   t('the subset is chosen by `reportable` alone, not by a second predicate inline', () => {
     const body = RJSRC.slice(RJSRC.indexOf('function main(argv)'));
-    assert.match(body, /runs\.map\(\(\{ row \}, i\) => \(reportable\(row\) \? i : -1\)\)/);
+    assert.match(body, /runs\.map\(\(\{ row, data \}, i\) => \(reportable\(row, data\) \? i : -1\)\)/);
     assert.ok(
       !/\.some\(\(n\) => !bars\[n\]\.unadjudicated\)/.test(RJSRC),
       'the loose `some` rule must not survive anywhere in this file'

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
@@ -25,6 +25,38 @@
 // result is the fault this whole lane is built to avoid, and an analysis
 // script is the easiest possible place to commit it silently.
 //
+// ## THE CONSUMER HALF OF THE TWO-TIER WRITE POLICY (`rf2-2rtt6.31`)
+//
+// The family's ruling of 2026-08-07 splits CAPTURE from PUBLICATION. Every
+// completed measurement is preserved; only a gate-passing run of the full
+// published shape is eligible published evidence, and a dataset says which it
+// is IN THE FILE — `canonical` and `notCanonicalWhy`, exactly as
+// `shapes/census_clock_run.cjs`'s `datasetFor` writes them. The ruling's
+// consumer clause is one sentence: **a missing `canonical` field is not a
+// pass.** A reader that inferred eligibility from the directory a file was
+// found in would be trusting the one thing a file loses when it is copied.
+//
+// This program is that consumer, and `rf2-emvod`'s merged-PR audit (#7365)
+// recorded it failing open in the other direction as well: the subset asked
+// only for `ctlTask.ok` and the two ceilings, so it PRINTED `guardRefuse`,
+// `guardRefuseTask`, the legacy-clock `ctlOk` and `tally.unverified` and then
+// pooled the run anyway. The driver writes its dataset BEFORE its own fatal
+// checks run, so a run that Chromium threw on, whose arms built different
+// pages, or whose arm-order guard refused, is a well-formed file that reached
+// the published mean. `GATES` below is that exit path, read back off the
+// serialised record, fail-closed at every seat: **absent is not clean.**
+//
+// THREE OF THE DRIVER'S FATAL CHECKS ARE NOT SERIALISED YET, and they are
+// named here rather than skipped, because skipping one is how this file came
+// to need repairing twice. `clock_run.cjs` computes `pageErrors`, `parityOk`
+// (the canonical-DOM gate) and `etVerdict` (Event Timing) and exits 1 on each,
+// but stores none of them, so no dataset in the tree today can satisfy this
+// filter — which is the correct fail-closed reading of an INCOMPLETE record
+// and not a defect in it. The producer half adopts the family policy when
+// `clock_run.cjs` is next touched (`rf2-2rtt6.31`, "record once, converge on
+// touch"); the field names below are its own internal names so that adoption
+// is one line per verdict.
+//
 // ## THE ADDITIVE RESIDUAL, and why it is computed here
 //
 // `ctl-2x` builds exactly twice the floor's page and reads 1.68-1.86x rather
@@ -106,26 +138,198 @@ function adjudicated(row) {
 }
 
 /**
- * MAY THIS RUN'S MAGNITUDE ON THIS ROW BE POOLED INTO THE REPORTABLE SUBSET?
+ * EVERY GATE A RUN MUST CLEAR BEFORE ITS MAGNITUDE MAY BE POOLED, in the order
+ * `clock_run.cjs` applies them, each read off the serialised record and each
+ * FAIL-CLOSED: a verdict that is missing, null or silent has not been passed,
+ * it has been lost.
  *
- * Its control held, its band stayed under the ceiling — the ceiling is a
- * whole-run refusal that fires before any control is consulted, so a run that
- * breached it contributes no magnitude even if its control passed — AND every
- * bar it published carries a band.
+ * Stated as data rather than as a boolean expression for two reasons. The
+ * refusal has to be NAMED — a run dropped from the subset without a reason is
+ * indistinguishable from a run that was selected away — and a roster can be
+ * quantified over, so `clock_exit_path.test.cjs` drives every gate rather than
+ * the handful someone remembered to write a case for.
+ *
+ * Each entry's `why` returns `null` for a pass and the refusal's own sentence
+ * otherwise. `scope` says what it is handed: the dataset envelope, or one row.
+ */
+const GATES = [
+  // --- the file's own two-tier verdict, before anything in it is read ------
+  {
+    id: 'canonical',
+    scope: 'dataset',
+    why: (d) =>
+      d.canonical === true
+        ? null
+        : d.notCanonicalWhy
+          ? `NOT the published evidence set — ${d.notCanonicalWhy}`
+          : 'the file carries no `canonical` verdict, so it has never been shown to be the published ' +
+            'evidence set — absent is not a pass (rf2-2rtt6.31)',
+  },
+  // --- the driver's fatal checks, in its own order -------------------------
+  {
+    id: 'page-errors',
+    scope: 'row',
+    why: (r) =>
+      !Array.isArray(r.pageErrors)
+        ? 'no `pageErrors` record — whether the page threw was not serialised'
+        : r.pageErrors.length
+          ? `the page THREW during the run: ${r.pageErrors.join(' | ')}`
+          : null,
+  },
+  {
+    id: 'guard-net',
+    scope: 'row',
+    why: (r) =>
+      r.guardRefuse === false
+        ? null
+        : r.guardRefuse === true
+          ? 'the arm-order guard REFUSED this row on taskNet'
+          : 'no arm-order guard verdict on taskNet',
+  },
+  {
+    id: 'guard-task',
+    scope: 'row',
+    why: (r) =>
+      r.guardRefuseTask === false
+        ? null
+        : r.guardRefuseTask === true
+          ? 'the arm-order guard REFUSED this row on the published clock'
+          : 'no arm-order guard verdict on the published clock',
+  },
+  {
+    id: 'canonical-dom',
+    scope: 'row',
+    why: (r) =>
+      r.parityOk === true
+        ? null
+        : r.parityOk === false
+          ? 'the canonical-DOM gate found arms building DIFFERENT PAGES — a ratio between two pages is not a ratio'
+          : 'no canonical-DOM verdict was serialised',
+  },
+  {
+    id: 'ctl3-parity',
+    scope: 'row',
+    why: (r) =>
+      !('ctl3Parity' in r)
+        ? "no three-point-control parity record — whether the control's own arms agreed was not serialised"
+        : r.ctl3Parity === null || r.ctl3Parity.ok === true
+          ? null
+          : "the three-point control's own arms built DIFFERENT PAGES",
+  },
+  {
+    id: 'keystroke-witness',
+    scope: 'row',
+    why: (r) =>
+      !('kbWitness' in r)
+        ? "no per-keystroke witness record — whether the row's n counts anything was not serialised"
+        : r.kbWitness === null || r.kbWitness.ok === true
+          ? null
+          : 'the per-keystroke witness REFUSED — its accounting does not close',
+  },
+  {
+    id: 'unverified',
+    scope: 'row',
+    why: (r) =>
+      !r.tally || !Number.isFinite(r.tally.unverified)
+        ? 'no write-verification tally'
+        : r.tally.unverified > 0
+          ? `${r.tally.unverified} unverified operation(s) of ${r.tally.writes} — a window whose value never reached the page`
+          : null,
+  },
+  // THE CEILINGS FIRE BEFORE ANY CONTROL IS CONSULTED, and this file refuses
+  // on BOTH while the driver (rf2-ymi6j) refuses only on the published clock's
+  // and reports the frame-only one. The asymmetry is deliberate and it is the
+  // safe direction: a consumer stricter than its producer can withhold a
+  // magnitude the driver would have allowed, never publish one it refused.
+  {
+    id: 'ceiling-net',
+    scope: 'row',
+    why: (r) =>
+      !r.seam || !r.seam.verdict || typeof r.seam.verdict.ceilingBreached !== 'boolean'
+        ? 'no frame-only band verdict'
+        : r.seam.verdict.ceilingBreached
+          ? "the run's own frame-only reproducibility band exceeds the ceiling"
+          : null,
+  },
+  {
+    id: 'ceiling-task',
+    scope: 'row',
+    why: (r) =>
+      !r.seamTask || typeof r.seamTask.ceilingBreached !== 'boolean'
+        ? 'no published-clock band verdict'
+        : r.seamTask.ceilingBreached
+          ? "the run's own reproducibility band exceeds the ceiling on the published clock"
+          : null,
+  },
+  // THE CONTROL, MIRRORING `ctlBad` RATHER THAN RE-DECIDING IT. A row that has
+  // a three-point control is gated on it and `ctl-2x` is a reported diagnostic
+  // (rf2-7iqb5, rf2-5xrcd); a row that has none — `M1`, `keystroke` — is gated
+  // on `ctl-2x`, and on BOTH clocks, because the row is stated on one of them
+  // and was adjudicated on the other.
+  {
+    id: 'control',
+    scope: 'row',
+    why: (r) => {
+      if (!('ctl3' in r)) return 'no three-point-control record — which control gates this row was not serialised';
+      if (r.ctl3) return r.ctl3.ok === true ? null : 'the THREE-POINT control FAILED';
+      if (r.ctlOk !== true) return r.ctlOk === false ? 'ctl-2x FAILED on taskNet' : 'no ctl-2x verdict on taskNet';
+      return r.ctlTask && r.ctlTask.ok === true
+        ? null
+        : r.ctlTask
+          ? 'ctl-2x FAILED on the published clock'
+          : 'no ctl-2x verdict on the published clock';
+    },
+  },
+  {
+    id: 'event-timing',
+    scope: 'row',
+    why: (r) =>
+      !('etVerdict' in r)
+        ? 'no Event-Timing verdict was serialised'
+        : r.etVerdict === null || r.etVerdict.ok === true
+          ? null
+          : 'the Event-Timing witness REFUSED',
+  },
+  {
+    id: 'adjudication',
+    scope: 'row',
+    why: (r) => (adjudicated(r) ? null : 'a bar this run published carries no adjudication verdict'),
+  },
+];
+
+/**
+ * WHY THIS RUN MAY NOT BE POOLED — every reason, never the first one.
+ *
+ * All of them, because a reader deciding whether to re-take a run needs to know
+ * that four gates failed rather than that one did, and because a filter that
+ * short-circuits reports the cheapest fault rather than the interesting one.
  *
  * This selects nothing away from the TABLE. Every dataset handed to this
- * program appears in the per-run table whatever this returns; the subset is
- * printed beside the whole ensemble and never instead of it.
+ * program appears in the per-run listing whatever this returns, with these
+ * reasons printed beside it; the subset is shown beside the whole ensemble and
+ * never instead of it.
  */
-function reportable(row) {
-  return !!(
-    row &&
-    row.ctlTask &&
-    row.ctlTask.ok &&
-    !(row.seam && row.seam.verdict && row.seam.verdict.ceilingBreached) &&
-    !(row.seamTask && row.seamTask.ceilingBreached) &&
-    adjudicated(row)
-  );
+function refusals(row, dataset) {
+  const d = dataset || {};
+  const r = row || null;
+  const why = [];
+  for (const g of GATES) {
+    if (g.scope === 'dataset') {
+      const w = g.why(d);
+      if (w) why.push(w);
+    } else if (!r) {
+      why.push(`no row to read \`${g.id}\` from`);
+    } else {
+      const w = g.why(r);
+      if (w) why.push(w);
+    }
+  }
+  return why;
+}
+
+/** MAY THIS RUN'S MAGNITUDE ON THIS ROW BE POOLED INTO THE REPORTABLE SUBSET? */
+function reportable(row, dataset) {
+  return refusals(row, dataset).length === 0;
 }
 
 /**
@@ -230,9 +434,22 @@ function main(argv) {
     );
   }
 
+  // THE FILE'S OWN VERDICT, ANNOUNCED BEFORE ANY TABLE. A dataset that does
+  // not say it is the published evidence set is still read, still tabled and
+  // still printed in full — capture is preserved — but it may not contribute a
+  // magnitude, and the reader is told that at the top rather than left to
+  // notice an empty subset at the bottom.
+  const ineligible = datasets.filter(({ data }) => !!GATES[0].why(data));
+  if (ineligible.length) {
+    console.log('');
+    console.log(';; !! NOT ELIGIBLE PUBLISHED EVIDENCE — every table below is printed, and none of it');
+    console.log(';; !! may be quoted as a magnitude. This program exits nonzero for that reason.');
+    for (const { file, data } of ineligible) console.log(`;; !!   ${file}: ${GATES[0].why(data)}`);
+  }
+
   for (const rowId of rowIds) {
     const runs = datasets
-      .map(({ file, data }) => ({ file, row: data.rows.find((r) => r.rowId === rowId) }))
+      .map(({ file, data }) => ({ file, data, row: data.rows.find((r) => r.rowId === rowId) }))
       .filter((x) => x.row);
     if (runs.length === 0) continue;
 
@@ -259,6 +476,20 @@ function main(argv) {
       );
     }
 
+    // --- WHY EACH REFUSED RUN IS REFUSED --------------------------------------
+    //
+    // The audit's own term: reject an incomplete or failed dataset in the
+    // reportable ACCOUNTING while still displaying it in the full ensemble.
+    // Every reason, named, per run — so a run that leaves the subset leaves it
+    // for a stated cause and can be told from one that was selected away.
+    console.log(';; run    REFUSED FROM THE REPORTABLE SUBSET (and retained in every table here)');
+    for (const { file, data, row } of runs) {
+      const why = refusals(row, data);
+      console.log(
+        `;;  ${shortName(file).padEnd(6)} ${why.length ? why.join('; ') : '— reportable: every gate this dataset serialises is clean'}`
+      );
+    }
+
     // --- the three clocks, per pair -------------------------------------------
     for (const pair of PAIRS) {
       const inPage = runs.map(({ row }) => (row.inPageBar && row.inPageBar[pair] ? row.inPageBar[pair].mean : NaN));
@@ -271,7 +502,7 @@ function main(argv) {
       // test. rf2-y7mw7's third term landed here wrong, and it took a merged-PR
       // audit rather than a gate to find it, precisely because nothing could
       // reach it.
-      const passIdx = runs.map(({ row }, i) => (reportable(row) ? i : -1)).filter((i) => i >= 0);
+      const passIdx = runs.map(({ row, data }, i) => (reportable(row, data) ? i : -1)).filter((i) => i >= 0);
       const taskPass = passIdx.map((i) => task[i]);
 
       const e = ens(task);
@@ -282,8 +513,8 @@ function main(argv) {
       console.log(
         `;;     raw TaskDuration (PUBLISHED)  ${fmt(e.mean)}x  [${fmt(e.min)} – ${fmt(e.max)}]  n=${e.n}` +
           (taskPass.length
-            ? `   control-passing subset ${fmt(ens(taskPass).mean)}x n=${taskPass.length}`
-            : '   control-passing subset: NONE')
+            ? `   reportable subset ${fmt(ens(taskPass).mean)}x n=${taskPass.length}`
+            : '   reportable subset: NONE')
       );
       console.log(`;;     taskNet (frame-only, superseded) ${fmt(en.mean)}x  [${fmt(en.min)} – ${fmt(en.max)}]`);
       console.log(`;;     in-page performance.now()        ${fmt(ei.mean)}x  [${fmt(ei.min)} – ${fmt(ei.max)}]`);
@@ -519,6 +750,20 @@ function main(argv) {
     );
   }
 
+  // FAIL-CLOSED, AND THE EXIT CODE IS WHERE THAT LANDS. `rf2-cvvb7`'s recorded
+  // gap was a study nobody could recompute; the repair is not just that a
+  // program exists but that running it over evidence it may not publish from
+  // says so in the one place a script can be believed. Everything is printed
+  // either way — a refusal is about what may be QUOTED, never about throwing a
+  // measurement away (`rf2-2rtt6.31`).
+  if (ineligible.length) {
+    console.log('');
+    console.log(
+      `;; EXIT 3 — ${ineligible.length} of ${datasets.length} dataset(s) are not eligible published evidence. ` +
+        'No reportable subset above was drawn from them, and no figure here may be quoted as a magnitude.'
+    );
+    return 3;
+  }
   return 0;
 }
 
@@ -527,7 +772,7 @@ function shortName(f) {
   return m ? m[1] : f;
 }
 
-module.exports = { adjudicated, reportable, responsivenessRegime };
+module.exports = { GATES, adjudicated, refusals, reportable, responsivenessRegime };
 
 // Requiring this file must not run it: `clock_exit_path.test.cjs` drives the
 // two predicates above directly, which it cannot do if the module body reads

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
@@ -298,6 +298,13 @@ const GATES = [
 ];
 
 /**
+ * THE FILE-LEVEL GATE, BY NAME. `main` announces a dataset's own verdict ahead
+ * of every table and carries it into the exit code, and reaching it by array
+ * position would make that announcement depend on the roster's order.
+ */
+const CANONICAL_GATE = GATES.find((g) => g.id === 'canonical');
+
+/**
  * WHY THIS RUN MAY NOT BE POOLED — every reason, never the first one.
  *
  * All of them, because a reader deciding whether to re-take a run needs to know
@@ -439,12 +446,12 @@ function main(argv) {
   // still printed in full — capture is preserved — but it may not contribute a
   // magnitude, and the reader is told that at the top rather than left to
   // notice an empty subset at the bottom.
-  const ineligible = datasets.filter(({ data }) => !!GATES[0].why(data));
+  const ineligible = datasets.filter(({ data }) => !!CANONICAL_GATE.why(data));
   if (ineligible.length) {
     console.log('');
     console.log(';; !! NOT ELIGIBLE PUBLISHED EVIDENCE — every table below is printed, and none of it');
     console.log(';; !! may be quoted as a magnitude. This program exits nonzero for that reason.');
-    for (const { file, data } of ineligible) console.log(`;; !!   ${file}: ${GATES[0].why(data)}`);
+    for (const { file, data } of ineligible) console.log(`;; !!   ${file}: ${CANONICAL_GATE.why(data)}`);
   }
 
   for (const rowId of rowIds) {


### PR DESCRIPTION
**NO MEASUREMENT WAS TAKEN.** Nothing here re-runs the box, and no published
magnitude, range, count, band, control, absolute or door spread is restated,
widened or recomputed. This is the evidence *path*, not the evidence.

`rf2-emvod`'s two reopen items, worked bottom-up from the bead and against
`rf2-2rtt6.31`'s 2026-08-07 two-tier ruling.

## What this does

**1. The reportable filter is now the driver's whole exit path, fail-closed.**
#7365's audit found the ensemble's subset asking for `ctlTask.ok` and the two
ceilings and nothing else, while the same program printed `guardRefuse`,
`guardRefuseTask`, the legacy-clock `ctlOk` and `tally.unverified` two lines
above the pooled mean. And `clock_run.cjs` writes its dataset *before* its own
fatal checks run, so a run Chromium threw on, or whose arms built different
pages, is a well-formed file that reached the published mean.

`clock_readjudicate.cjs` now carries `GATES` — a roster of thirteen, in the
driver's own order, each read off the serialised record and each fail-closed:
a verdict that is missing, null or silent has not been passed, it has been
lost. `refusals(row, dataset)` returns **every** reason rather than the first;
`reportable` is that list being empty.

**Nothing is selected away from the table.** Every run stays in every listing
with its own magnitude beside it and a new per-run line naming its refusals.
The refusal is about what may be **quoted**.

**2. How it agrees with `rf2-2rtt6.31`'s producer half.** The ruling's consumer
clause is one sentence — *a missing `canonical` field is not a pass* — and it
is the roster's **first gate**, read from the in-file `canonical` /
`notCanonicalWhy` that `shapes/census_clock_run.cjs`'s `datasetFor` writes,
never from the directory a file was found in. `destination()` decides
eligibility on the producing side; this decides it on the reading side, off the
same two fields, and the two halves touch nothing but those fields.
`hd8_clock_run.cjs` is untouched — it is the `rf2-2rtt6.31` worker's.

**3. The seven datasets were never retained, and the page now says so.** The
merge landed no Hicasso dataset for this ensemble; `out/run*.json` named files
that existed only in the author's working tree. New §7.1 states plainly that
`1.3737×`, its range, the 7/3/2/4 reportable counts, the controls, bands,
absolutes, door spreads and the additive-residual table are **unreproducible
from the tree**, carries the gate roster and which verdicts the driver
serialises today, and gives the fail-closed command over the datasets that
*were* kept. #7367's page gets the same treatment: its closing "every figure is
recomputable from the dataset the run writes" is true of the **format** and
was reading as a reproduction claim it does not make.

## What I left, and why

**Landing the seven datasets, and #7367's, requires a fresh measurement.** They
do not exist — not in the tree, not in git history, not on disk. Re-taking them
is a measurement, this dispatch takes none, and a competing draw taken after
reading the published result is a selection opportunity besides. Recorded on
both pages rather than silently left.

**"Serialize every required verdict" is the producer half, in
`clock_run.cjs`** — held by another live worker and out of fence. Four of the
thirteen gates (`canonical`, `page-errors`, `canonical-dom`, `event-timing`)
therefore cannot be satisfied by any dataset in the tree today. That is the
correct fail-closed reading of an **incomplete** record, not a defect in it,
and it is named at the driver's own internal field names so the adoption is one
line per verdict when `clock_run.cjs` is next touched ("record once, converge
on touch").

## The refusal demonstration

A verifier nobody has seen refuse is not a verifier. Both halves, both
directions.

**Roster-driven fixtures** — one deliberate *corruption* and one deliberate
*erasure* per gate, plus a first assertion that `GATES` and the case list agree
in order, so a gate added without a case fails rather than shipping unexercised.
Plus the whole program spawned over a file on disk: compliant dataset → exit 0
with the aggregate regenerated; non-canonical dataset → **exit 3** with the run
still printed in full; a gate failure *inside* a canonical dataset → exit 0
(the file is still evidence, the run is refused) with the subset empty and the
run retained.

**Shown red, then green.** `reportable` was reverted in place to the pre-repair
predicate:

```
$ node freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs   # DELIBERATELY CORRUPTED
clock_exit_path.test.cjs: 24/166 failed          exit 1
```

Twenty-four failures naming `canonical`, `page-errors`, `guard-net`,
`guard-task`, `canonical-dom`, `ctl3-parity`, `keystroke-witness`,
`unverified`, `control`, `event-timing` and the absent-is-not-clean case of
`ceiling-net`. The corruption was reverted:

```
$ node freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
clock_exit_path.test.cjs: 166 passed             exit 0
```

**And the command itself, over the two committed datasets:**

```
$ node freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs \
    freehand/test/re_frame/bench/hicasso/data/clock-0qj9w/run*.json
;; !! NOT ELIGIBLE PUBLISHED EVIDENCE — every table below is printed, and none of it
;; !! may be quoted as a magnitude. This program exits nonzero for that reason.
…
;; EXIT 3 — 2 of 2 dataset(s) are not eligible published evidence.
                                                 exit 3
```

## Quality gates

Foreground, never piped, each redirected to a worktree-local log; the exit code
below is the runner's own.

| command | result | exit |
|---|---|---|
| `node freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs` | **166 passed** (was 135 on `origin/main` — 31 new) | **0** |
| `node freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs` *(filter deliberately corrupted)* | **24/166 failed** — the refusal demonstration | **1** |
| `cd implementation && npm run test:script-helpers` | the lane that owns the changed code — 38 + 166 + 30 + 25 + 33 + 14 + 19 passed | **0** |
| `npm run lint:js` *(repo ESLint gate, root `npm ci` first)* | clean | **0** |
| `python scripts/check_doc_slugs.py --verbose` | 678 files, no broken links | **0** |
| `python scripts/check_doc_slugs.py --verbose` *(probe planted at the edit site)* | `BROKEN ANCHOR: …rows-re-adjudicated-on-the-corrected-clock.md:84` | **1** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | 2 files, 2 cited pins (1 landed, 1 stranded, accompanied) | **0** |
| `sh scripts/test-fast-pr.sh` | `PASS fast PR spine` (log line 1588) | **0** |

`check_doc_slugs.py` is silent on success and masks fenced blocks, so its
selection is proven rather than assumed: `[§7.1](#71-what-this-page-cannot-regenerate)`
was broken on purpose at my actual edit site, the checker named
`rows-re-adjudicated-on-the-corrected-clock.md:84`, and the probe was reverted.

**Provenance: accompanied, never re-pinned.** No pin on either page is changed.
My §8 paragraph pulled `a-control-that-differences-the-constant-away.md`'s
existing block into the changed set; its stranded `ef30c639…` and landed
`93ad80f097` were re-verified as the same patch by `git patch-id --stable`
(both `c23c153fa9c9a4961ca54904631e1dca580f294e`), and `93ad80f097` is an
ancestor of `origin/main`. The `clock_readjudicate.cjs` blob pin on
`rows-re-adjudicated…md` is **left alone on purpose**: it names the blob that
*produced* the tables, which is still true, and re-pinning it to the repaired
file would make the page claim tables it never computed.

`docs/design/**` is outside `mkdocs build --strict`, so both pages' anchors and
table column counts were checked by hand: every link target resolves (verified
by the slug gate above), and the new gate table is 3 columns in its header,
separator and all eleven rows.

**Post-merge note.** Rebasing onto a later `main` (which added a census block to `clock_exit_path.test.cjs` in `769277f64b`, `rf2-azopg`) applies cleanly: **168 passed**, exit **0**, and the fail-closed command over the two committed `clock-0qj9w` datasets still exits **3**.
