### PR TITLE
fix(hicasso): the HD-008 driver must consult its verdict before its destination (rf2-2rtt6.31)

### DIFF
--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -220,7 +220,7 @@ So the re-take is two measurements, deliberately separate:
 
 | | |
 |---|---|
-| **Producing commit** | `16ddf3e30772ceff170f28ffe466247b0a84341b` on `worker/hd8retake-2rtt6-31` — both measurements, one tree. The landed SHA is the merge's to mint |
+| **Producing commit** | `16ddf3e30772ceff170f28ffe466247b0a84341b` on `worker/hd8retake-2rtt6-31` — both measurements, one tree. That head is the authored one; this repo rebase-merges, so it is reachable from no ref and a fresh clone does not have it. It landed on main as `1ac48c4a0be1fed3338fbb504f5b023af6d1524d` (PR #7378), which is the resolvable whole-tree anchor to check this page against. The rebase minted a new commit, not a new tree for what is stamped here: every one of the six instrument blobs below is byte-identical at both heads |
 | **Spine** | blob `ad7b19d9d8957e7a1872e58f9b18ace8acdc4841` — post-`.13`/`.25`, and **further moved since this page's stamp** (latest spine-touching commit `0c7c5bfb0d`, the `.25` reap-horizon race statement). The pre-landing blob this page's original rows read is `befd8469d932…`, above |
 | **Clock of record** | CDP `Performance.getMetrics` raw `TaskDuration`, settled to the next frame (`requestAnimationFrame` → `setTimeout 0`), tared by a `plumb` arm measured in the same block. `taskNet` and the in-page `flushSync` window are recorded on the **same samples** as diagnostics |
 | **The door** | every arm, tare included: `page.evaluate → HD8CLOCK.sample` — one door, so its cost is common-mode and subtracted. Through this door `taskNet` is FRAME-ONLY (`DevToolsCommandDuration` carries the arm's own script, `rf2-emvod`) and is never a verdict here |

--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -154,7 +154,9 @@ anything quotable against the bar.
 **Why both columns, and what each one is actually good for.** A producing SHA is
 rewritten by rebase *and* by merge. Every authored SHA in the middle column above
 is now unreachable — `d46ede4f`, `b943c7ed` and `d3f1c2ff` are on no branch, so a
-reader handed one of them can check out nothing and run nothing. That is what the
+reader handed one of them can check out nothing and run nothing. Each landed on
+main as `172244521e`, `c7e4c70ac0` and `0cba8181a7` respectively, established by
+`git patch-id --stable` rather than by matching subjects. That is what the
 landed column is for, and it is the **whole-tree anchor**: the bundle these
 figures came off depends on `re-frame.core`, on the three adapters, on
 `deps.edn`, `package-lock.json` and the React version, and only a commit pins all
@@ -178,9 +180,9 @@ the superseded unbatched ranges are kept rather than deleted; `rf2-9zysg`
 batched ten writes under one clock and left every other window alone, so no
 other row moved. Before that:
 
-At `d46ede4f` the `reagent-slim` write rows read *78 of 78*
+At `d46ede4f` (landed `172244521e`) the `reagent-slim` write rows read *78 of 78*
 unverified and their figures were withheld. `rf2-z3vlz` diagnosed why and
-`rf2-b69lw` repaired it; `b943c7ed` is that repair, and the `reagent-slim`
+`rf2-b69lw` repaired it; `b943c7ed` (landed `c7e4c70ac0`) is that repair, and the `reagent-slim`
 write rows below are its. **No other row was replaced.** The repair changes the
 write window for arms on a **microtask-scheduled** substrate and leaves every
 other arm's window byte-for-byte as it was, so the rows taken at `d46ede4f`
@@ -385,7 +387,7 @@ all twelve rows; exit `0`. The plan is the current 7-arm plan (`donor-fh` rides
 per `rf2-2rtt6.29`), so ranges are compared with the published 4/5/5-arm rows
 as *the same comparison on a fresh take*, not figure-for-figure.
 
-Mount, published above → re-taken at `16ddf3e307`, in-page instrument:
+Mount, published above → re-taken at `16ddf3e307` (landed `1ac48c4a0b`), in-page instrument:
 
 | run | comparison | published *(pre-landing spine)* | **re-taken (current tree)** |
 |---|---|---|---|
@@ -608,14 +610,14 @@ the same reason — a denominator pinned at one quantum was rounded **up**, and 
 floor rounded up understates every ratio taken against it.
 
 <details><summary><b>Superseded — the same row on the unbatched window</b>
-(`d46ede4f`, and `b943c7ed` for <code>reagent-slim</code>)</summary>
+(`d46ede4f`, landed `172244521e`; and `b943c7ed` for <code>reagent-slim</code>)</summary>
 
 Within-run, `uix` run: `donor-r1 / uix` 0.909 – 1.200, `donor-r2 / uix`
 0.960 – 1.200, `donor-r2 / donor-r1` 1.000 – 1.167 — all *indistinguishable*.
 
 Cross-run, floor-normalised: `donor-r1` 5.000 – 8.000 and `donor-r2`
 5.000 – 8.000 against `reagent` 3.000 – 5.000 and `reagent-slim` 2.667 – 6.000.
-An independent slim-only replication at `f5bd4b49` read 3.000 – 5.500. Absolute
+An independent slim-only replication at `f5bd4b49` (landed `85cb1dd5c2`) read 3.000 – 5.500. Absolute
 p50s: `reagent-slim` 0.40 – 0.60 ms, floor 0.10 – 0.15 ms. **0 unverified of
 78.**
 
@@ -665,12 +667,12 @@ five times, which is exactly what the batch bought and exactly what this row
 never got.
 
 <details><summary><b>Withheld — the cross-run figures this row used to publish</b>
-(`d46ede4f`, and <code>b943c7ed</code> for <code>reagent-slim</code>)</summary>
+(`d46ede4f`, landed `172244521e`; and <code>b943c7ed</code> for <code>reagent-slim</code>)</summary>
 
 Cross-run, floor-normalised: `donor-r1` 7.750 – 11.000 and `donor-r2`
 8.250 – 11.750 against `reagent` 8.750 – 17.000 and `reagent-slim`
-11.000 – 13.667. The independent slim-only replication at `f5bd4b49` read
-9.500 – 13.000.
+11.000 – 13.667. The independent slim-only replication at `f5bd4b49` (landed
+`85cb1dd5c2`) read 9.500 – 13.000.
 
 **None of these may be quoted as a magnitude.** They are kept for the same
 reason the narrow row's superseded band is: a measurement the instrument later
@@ -733,13 +735,13 @@ split **30 / 30** across its two possible predecessors, which is the local
 `slot-order` override working.
 
 **DOM read-back — 0 unverified of 1,248**, which is every write the driver
-executed across the three runs at `b943c7ed` (`0 of 960` counting only the timed
+executed across the three runs at `b943c7ed` (landed `c7e4c70ac0`; `0 of 960` counting only the timed
 post-warmup samples). **On the batched re-take the narrow rows carry ten writes per
 sample, so the same three runs execute 0 unverified of 6,864** — `0 of 780` on
 each of the eight narrow arm-columns, plus the bulk rows' `0 of 78` each. The
 denominator grew with the batch; the numerator did not.
 
-At `d46ede4f` the same counts read **156 of 1,248** and **120 of 960**,
+At `d46ede4f` (landed `172244521e`) the same counts read **156 of 1,248** and **120 of 960**,
 every one of them the `reagent-slim` arm, and its write figures were suppressed
 rather than published. *An earlier version of this page reported that as "156
 unverified of 936", which is not a like-for-like denominator and is corrected
@@ -1013,8 +1015,8 @@ returned `:not-owed` on every `uix` and `reagent` write row and
 ten of its windows, both at `k = 10` and at `k = 1` — so ~~the ratios above stand
 exactly as published~~ **the ratios stood exactly as published on the instrument
 of that day**, now with the bound checked rather than asserted. A full sweep at
-the three-state repair (authored `79de836f35`; the landed SHA is the merge's to
-mint) answered the same, exit `0`: `:not-owed` on all four
+the three-state repair (authored `79de836f35`, landed on main as `50ce76d85f`)
+answered the same, exit `0`: `:not-owed` on all four
 `uix`/`reagent` write rows, `:below-resolution` on both `slim` rows with every
 aggregate window at `0.0`, every read-back `0` unverified, and every slim write
 range overlapping the published one — the repair moves gate logic and table
@@ -1064,7 +1066,7 @@ wherever a sub-quantum per-item cost is asserted negligible across a batch.
 reappears there and wants the same treatment.
 
 **Reproduction check — NOT a republication.** The re-take ran all three
-adapters, so the rows published at `d46ede4f` were measured again by a driver
+adapters, so the rows published at `d46ede4f` (landed `172244521e`) were measured again by a driver
 carrying the change. Every one of them reproduced: on the mount rows, which are
 the well-resolved ones, `donor-r1 / uix` in the `uix` run read `1.150 – 1.233`
 against the published `1.149 – 1.230`. On the write rows five of the six

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -281,7 +281,7 @@ for (const { tag, file, mod } of DRIVERS) {
   t('the driver exposes its run as `drive` and its decision as `verdict`', () => {
     assert.ok(DRIVE.length > 0, 'the driver must expose its run as `drive`');
     // `summarise` and `verdict` FIRST and always — a driver may export more
-    // (census_clock_run.cjs adds `destination`, its write-path decision), but
+    // (both clock drivers add `destination`, their write-path decision), but
     // the decision pair is what every test below reaches for.
     assert.match(SRC, /module\.exports = \{ summarise, verdict\s*[,}]/);
     assert.match(SRC, /require\.main === module/);
@@ -475,6 +475,201 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
       'the inline depth predicate is duplicated; use depthIsPublished()'
     );
     assert.ok(SRC.split('depthIsPublished()').length - 1 >= 2, 'the one predicate must serve both readers');
+  });
+}
+
+// --- hd8_clock_run.cjs: the WRITE path, not just the exit path ---------------
+//
+// rf2-2rtt6.31, the write-before-refuse ruling. The same fail-open as the block
+// above, on the sibling driver that never received the repair: the dataset
+// writes preceded `verdict`, so a control-refused re-run silently replaced
+// data/hd8clock-2rtt6-31/{uix,reagent,slim}.json — the very files the studio
+// page recomputes from, and whose committed rows fail the control on five of
+// six. The ruling is TWO-TIER: no completed measurement is ever discarded, but
+// only a gate-passing full-shape run gets the published names. Capture is not
+// publication.
+//
+// hd8's `destination` is census's rule with ONE condition absent — census can
+// narrow its rows (C56CLOCK_ROWS), hd8 cannot — and the last check below pins
+// that deviation so a row knob cannot be added without the routing following.
+
+{
+  const HD8 = DRIVERS[0].file;
+  const { destination } = DRIVERS[0].mod;
+  const SRC = fs.readFileSync(HD8, 'utf8');
+  const CANON = '/data/hd8clock-2rtt6-31';
+  const shape = (over = {}) => ({
+    dataDir: CANON,
+    dataDirOverridden: false,
+    runsOnly: null,
+    noBuild: false,
+    depthPublished: true,
+    ...over,
+  });
+  const t = (what, fn) => test(`hd8_clock_run.cjs write path: ${what}`, fn);
+
+  t('the published shape, all gates passed, is the ONLY thing that is canonical', () => {
+    const d = destination(shape(), 0);
+    assert.strictEqual(d.canonical, true);
+    assert.strictEqual(d.dir, CANON);
+    assert.strictEqual(d.why, null);
+  });
+
+  // Each condition alone must move the write off the canonical set. These are
+  // the mutation proofs: flip one field, the destination must change.
+  for (const [what, over, code, needle] of [
+    ['a refused verdict', {}, 5, /verdict refused it \(exit 5\)/],
+    ['a partial run set', { runsOnly: 'uix' }, 0, /PARTIAL run set \(HD8CLOCK_ONLY=uix\)/],
+    ['--no-build', { noBuild: true }, 0, /--no-build/],
+    ['an overridden depth', { depthPublished: false }, 0, /OVERRIDDEN design depth/],
+  ]) {
+    t(`${what} is NOT canonical, and says why`, () => {
+      const d = destination(shape(over), code);
+      assert.strictEqual(d.canonical, false, `${what} must not be canonical`);
+      assert.notStrictEqual(d.dir, CANON, `${what} must not write the published filenames`);
+      assert.strictEqual(d.dir, `${CANON}.unpublished`);
+      assert.match(d.why, needle);
+      // ... and the same shape WITHOUT that condition is canonical again, so
+      // the test cannot pass by refusing everything.
+      assert.strictEqual(destination(shape(), 0).canonical, true);
+    });
+  }
+
+  // The failure that actually bit: five of the six committed rows failed the
+  // positive control (exit 5). Under the old driver that re-run overwrote the
+  // cited evidence in place; it must now land beside it, and still land.
+  t('EVERY refusal code this driver can return routes off the canonical set', () => {
+    for (const code of [1, 2, 3, 4, 5]) {
+      const d = destination(shape(), code);
+      assert.strictEqual(d.canonical, false, `exit ${code} must not write the published evidence`);
+      assert.strictEqual(d.dir, `${CANON}.unpublished`);
+      assert.match(d.why, new RegExp(`verdict refused it \\(exit ${code}\\)`));
+    }
+  });
+
+  // The preservation half of the ruling: rr6do's "no refusal suppresses
+  // output" stands. A refusal moves the write, it never cancels it — the
+  // refused rows were the DIAGNOSTIC evidence that exposed the control
+  // failure, and discarding them would lose exactly the interesting data.
+  t('a refused run still HAS a destination — the measurement is never discarded', () => {
+    const d = destination(shape(), 5);
+    assert.ok(d.dir && d.dir.length > 0, 'a refused run must still be written somewhere');
+    assert.notStrictEqual(d.dir, null);
+    assert.match(SRC, /No refusal suppresses output, and none ever discards a completed/);
+    assert.match(SRC, /Capture is not publication\./);
+  });
+
+  t('every condition that fired is named, not just the first', () => {
+    const d = destination(shape({ runsOnly: 'uix', noBuild: true, depthPublished: false }), 5);
+    assert.strictEqual(d.canonical, false);
+    for (const needle of [/verdict refused it \(exit 5\)/, /PARTIAL run set/, /--no-build/, /OVERRIDDEN design depth/]) {
+      assert.match(d.why, needle);
+    }
+  });
+
+  t('an explicit HD8CLOCK_DATA_DIR is honoured as given, and is never canonical', () => {
+    const mine = '/data/hd8clock-somebead';
+    const d = destination(shape({ dataDir: mine, dataDirOverridden: true }), 0);
+    assert.strictEqual(d.dir, mine, 'the operator named the destination; do not rewrite it');
+    assert.strictEqual(d.canonical, false, 'an operator-named directory is not the published set');
+    // Even refused, it still lands where the operator said — the refusal is
+    // carried by the exit code and by `canonical`, not by moving the file.
+    assert.strictEqual(destination(shape({ dataDir: mine, dataDirOverridden: true }), 4).dir, mine);
+  });
+
+  // The defect was an ORDERING one: the write happened, and the refusal was
+  // computed afterwards. Pin the order in the source, because that is what
+  // regressed and a behavioural test of a browser driver cannot see it.
+  const ORDER = (src) => {
+    const v = src.indexOf('const v = verdict(summarise(failed, results));');
+    const dst = src.indexOf('const dest = destination(runShape(), v.code);');
+    const mk = src.indexOf('fs.mkdirSync(dest.dir');
+    return { v, dst, mk, ok: v > 0 && dst > 0 && mk > 0 && v < dst && dst < mk };
+  };
+
+  t('the verdict is computed BEFORE any dataset is written', () => {
+    const o = ORDER(SRC);
+    assert.ok(o.v > 0 && o.dst > 0 && o.mk > 0, 'the write path no longer has the shape this test pins');
+    assert.ok(o.v < o.dst, 'the verdict must be computed before the destination is chosen');
+    assert.ok(o.dst < o.mk, 'the destination must be chosen before the directory is created');
+    assert.ok(o.ok);
+  });
+
+  // ... and the same check must REFUSE the defect. A guard that only ever
+  // reports "ok" on the one source it is pointed at proves nothing; this
+  // hoists `destination` above `verdict` in a copy of the real text and
+  // requires the guard to catch it. This is the regression, reconstructed.
+  t('that ordering check REFUSES a destination consulted before the verdict', () => {
+    const V = 'const v = verdict(summarise(failed, results));';
+    const D = 'const dest = destination(runShape(), v.code);';
+    // Swap the two statements in place, whatever the line endings are.
+    const HOLE = '<<swap>>';
+    const mutant = SRC.replace(V, HOLE).replace(D, V).replace(HOLE, D);
+    assert.notStrictEqual(mutant, SRC, 'the mutation must actually change the source');
+    assert.strictEqual(ORDER(mutant).ok, false, 'the guard must refuse a write decided before the verdict');
+    // and the pre-repair shape — no `destination` at all — is refused too.
+    assert.strictEqual(ORDER(SRC.replace(D, '')).ok, false, 'a driver with no destination step must not pass');
+  });
+
+  t('no dataset is written to the raw DATA_DIR downstream of `destination`', () => {
+    // This is how the defect grew: the write named the canonical directory
+    // directly. Every write site must go through the chosen destination.
+    const after = SRC.slice(SRC.indexOf('const dest = destination(runShape(), v.code);'));
+    assert.ok(!/fs\.mkdirSync\(DATA_DIR/.test(after), 'mkdirSync must use the chosen destination');
+    assert.ok(!/path\.join\(DATA_DIR/.test(after), 'the dataset path must use the chosen destination');
+    assert.match(after, /path\.join\(dest\.dir/);
+  });
+
+  t('a dataset records whether it is the published evidence', () => {
+    // A file that travels out of its directory must still say what it is, and
+    // a consumer that finds no `canonical` field has not found a pass.
+    assert.match(SRC, /canonical: meta\.dest\.canonical/);
+    assert.match(SRC, /notCanonicalWhy: meta\.dest\.why/);
+  });
+
+  t('the dataset is built OUTSIDE `drive`, so recording never looks like deciding', () => {
+    // `datasetFor` names guardRefuse/ceilingBreached to SERIALISE them. Inside
+    // `drive` and downstream of `verdict` that would trip the invariant above
+    // — correctly, since a reader cannot tell a record from a second decision.
+    assert.match(SRC, /^function datasetFor\(rows, meta\) \{/m);
+    const drive = SRC.slice(SRC.indexOf('async function drive('));
+    assert.ok(drive.indexOf('function datasetFor(') === -1, '`datasetFor` must sit above `drive`');
+    assert.match(drive, /const data = datasetFor\(rows, \{ sha, blobs: bl, dest \}\);/);
+  });
+
+  t('the published depth has ONE definition, shared by the stamp and the write path', () => {
+    assert.match(SRC, /const PUBLISHED_DEPTH = \{ rounds: 6, blocks: 3, warmup: 4, samples: 10 \}/);
+    // The old inline copy must be gone, or the two can drift apart again.
+    assert.ok(
+      !/ROUNDS === 6 && BLOCKS === 3 && WARMUP === 4 && SAMPLES === 10/.test(SRC),
+      'the inline depth predicate is duplicated; use depthIsPublished()'
+    );
+    assert.ok(SRC.split('depthIsPublished()').length - 1 >= 2, 'the one predicate must serve both readers');
+  });
+
+  t("the header states the two-tier rule, so the file's own record is not the old one", () => {
+    const header = SRC.slice(0, SRC.indexOf("'use strict'"));
+    assert.match(header, /## Where the datasets land/);
+    assert.match(header, /`\.unpublished`/);
+    assert.match(header, /HD8CLOCK_DATA_DIR is honoured as given/);
+    // The canonical-filename half of the pre-ruling intent must be gone.
+    assert.ok(
+      !/the datasets are\r?\n\/\/ written before this is consulted/.test(SRC),
+      'the pre-ruling "written before this is consulted" intent must not survive'
+    );
+  });
+
+  // hd8 deviates from census by ONE condition, and only because it has no row
+  // knob. If a row knob is ever added, this fails and the routing must follow
+  // — the deviation is pinned to its reason, not left as an omission.
+  t('the absent PARTIAL-ROW condition is pinned to its reason: hd8 has no row knob', () => {
+    assert.ok(!/HD8CLOCK_ROWS/.test(SRC), 'a row knob exists; `destination` must name a PARTIAL row set');
+    assert.match(SRC, /^const ROWS = \['mount-M', 'mount-U'\];\r?$/m);
+    assert.match(SRC, /no partial-row shape to\r?\n\/\/ name/);
+    // Census, which DOES have the knob, still names it — the two files carry
+    // one rule, not two.
+    const census = fs.readFileSync(DRIVERS[1].file, 'utf8');
+    assert.match(census, /a PARTIAL row set \(C56CLOCK_ROWS=/);
   });
 }
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_clock_run.cjs
@@ -80,6 +80,17 @@
 // 3, 4 and 5 are rf2-rr6do's repair: all three were computed, printed and
 // written into the dataset, and none of them reached the exit. See the note
 // above `verdict` below.
+//
+// ## Where the datasets land
+//
+// The canonical dataset directory holds THE PUBLISHED SHAPE and nothing
+// else. A run that is narrowed (HD8CLOCK_ONLY), taken at an overridden
+// depth, taken `--no-build`, or refused by the verdict above writes to a
+// sibling `.unpublished` directory instead, named on stdout with the reason;
+// an explicit HD8CLOCK_DATA_DIR is honoured as given. See the note above
+// `destination` — that routing is rf2-2rtt6.31's half of the same fail-open
+// rf2-rr6do repaired on the exit path, and the rule census_clock_run.cjs
+// (rf2-2rtt6.56) already carries one file over.
 
 'use strict';
 
@@ -126,9 +137,20 @@ const GATE_LINE = 1.1; // the amendment's one line: donor <= 1.10x direct UIx
 const NO_BUILD = process.argv.includes('--no-build');
 const SKIP_QUIET = process.env.HD8CLOCK_SKIP_QUIET === '1';
 
+// The published depth, in ONE place. The provenance stamp and the dataset
+// write path must agree on what "the published shape" is, and two copies of
+// that predicate is how they drift apart.
+const PUBLISHED_DEPTH = { rounds: 6, blocks: 3, warmup: 4, samples: 10 };
+const depthIsPublished = () =>
+  ROUNDS === PUBLISHED_DEPTH.rounds &&
+  BLOCKS === PUBLISHED_DEPTH.blocks &&
+  WARMUP === PUBLISHED_DEPTH.warmup &&
+  SAMPLES === PUBLISHED_DEPTH.samples;
+
 // Where the run's compact datasets go. Named per run id below; the page's
 // provenance points here, because a published study a reader cannot
 // recompute from the landed tree is rf2-cvvb7's recorded fault.
+const DATA_DIR_OVERRIDDEN = Boolean((process.env.HD8CLOCK_DATA_DIR || '').trim());
 const DATA_DIR =
   process.env.HD8CLOCK_DATA_DIR || path.join(__dirname, 'data', 'hd8clock-2rtt6-31');
 
@@ -717,9 +739,17 @@ function report(out) {
 // arm-order guard refused still exits 2 — so nothing that used to refuse now
 // refuses differently.
 //
-// No refusal suppresses output: the tables are printed and the datasets are
-// written before this is consulted. A refusal is about what may be QUOTED,
-// not about throwing the measurement away.
+// No refusal suppresses output, and none ever discards a completed
+// measurement: the tables are printed and the datasets are written whatever
+// this returns. A refusal is about what may be QUOTED, not about throwing
+// the measurement away.
+//
+// What a refusal DOES decide is where the datasets land (rf2-2rtt6.31). The
+// canonical directory is the PUBLISHED EVIDENCE SET, not "the last file this
+// driver wrote", so a refused run is written to a `.unpublished` sibling and
+// stamped `canonical: false` in the file rather than replacing the rows the
+// studio page cites. Capture is not publication. See `destination` below —
+// which is why this verdict is now computed BEFORE the write, not after it.
 
 /** The flat record the exit is decided on: one entry per row actually taken. */
 function summarise(failed, results) {
@@ -798,6 +828,116 @@ function verdict(summary) {
 }
 
 // ---------------------------------------------------------------------------
+// Where a run's datasets may be written
+// ---------------------------------------------------------------------------
+
+// WHERE A RUN'S DATASETS MAY BE WRITTEN (rf2-2rtt6.31, the write-before-refuse
+// ruling; census_clock_run.cjs / rf2-2rtt6.56 carries the same rule).
+//
+// `verdict` decides what may be QUOTED. This decides what may be WRITTEN, and
+// it is a separate question this driver got wrong in the same direction its
+// sibling did. The datasets were written under the CANONICAL filenames before
+// the refusal was consulted, whatever shape the run had — so a run narrowed to
+// one adapter (HD8CLOCK_ONLY), taken with `--no-build` against whatever bundle
+// happened to be on disk, taken at an overridden depth, or one the verdict then
+// REFUSED, silently replaced the published evidence the studio page cites.
+// Nothing announced it: the write had already landed, and the nonzero exit
+// arrived afterwards. rf2-rr6do repaired the exit path; this is the write path,
+// the other half of the same fail-open.
+//
+// THE RULE: the canonical directory holds the PUBLISHED SHAPE and nothing
+// else. Any narrowing, any override, any refusal routes to a sibling
+// `.unpublished` directory, named on stdout with the reason. No completed
+// measurement is ever discarded — it simply does not get the published names.
+//
+// An explicit HD8CLOCK_DATA_DIR is the operator naming their own destination.
+// It is honoured as given, and it is never the canonical set.
+//
+// This is census's `destination` with ONE condition absent: census names a
+// PARTIAL ROW SET because C56CLOCK_ROWS can narrow its rows. This driver's
+// ROWS is a fixed pair with no such knob, so there is no partial-row shape to
+// name and a `rowsOnly` that could only ever be null would be a dead reason.
+// Every other condition, and the routing, is the same rule verbatim.
+//
+// Pure over a flat shape record, for the same reason `verdict` is: the write
+// path is then checkable without a release build and a headless Chromium.
+function destination(shape, code) {
+  const s = shape || {};
+  if (s.dataDirOverridden) {
+    return { dir: s.dataDir, canonical: false, why: 'HD8CLOCK_DATA_DIR named this destination' };
+  }
+  const why = [];
+  if (code !== 0) why.push(`the run's own verdict refused it (exit ${code})`);
+  if (s.runsOnly) why.push(`a PARTIAL run set (HD8CLOCK_ONLY=${s.runsOnly})`);
+  if (s.noBuild) why.push("--no-build (the bundle on disk is not known to be this tree's)");
+  if (!s.depthPublished) why.push('an OVERRIDDEN design depth');
+  if (!why.length) return { dir: s.dataDir, canonical: true, why: null };
+  return { dir: `${s.dataDir}.unpublished`, canonical: false, why: why.join('; ') };
+}
+
+/**
+ * The compact dataset for one run — the reduced quantities every statistic on
+ * the studio page is a function of, so the page can be recomputed from the
+ * tree.
+ *
+ * Lifted out of `drive` deliberately. Serialising a row means naming its
+ * refusal fields (`guardRefuse`, `ceilingBreached`, …), and `drive` is held to
+ * an invariant that nothing downstream of `verdict` may name one — the check
+ * that stops a second exit path growing back (`clock_exit_path.test.cjs`).
+ * The write now happens after the verdict, so the serialiser has to live
+ * outside it. Recording is not deciding, and this is where that shows.
+ */
+function datasetFor(rows, meta) {
+  return {
+    bead: 'rf2-2rtt6.31',
+    commit: meta.sha,
+    blobs: meta.blobs,
+    when: new Date().toISOString(),
+    // Whether this file is the published evidence, recorded IN the file — a
+    // dataset that travels out of its directory must still say what it is.
+    // A consumer that finds no `canonical` field has not found a pass.
+    canonical: meta.dest.canonical,
+    notCanonicalWhy: meta.dest.why,
+    design: { rounds: ROUNDS, blocks: BLOCKS, warmup: WARMUP, samples: SAMPLES, tolerance: TOLERANCE, controlSlack: CONTROL_SLACK, gateLine: GATE_LINE },
+    clock: 'Performance.getMetrics raw TaskDuration, frame-settled (rAF + setTimeout), plumb-tared',
+    door: 'page.evaluate -> HD8CLOCK.sample (every arm, plumb included)',
+    node: process.version,
+    rows: rows.map((r) => ({
+      rowId: r.rowId,
+      armIds: r.armIds,
+      canon: r.canon,
+      blocksTask: r.blocksTask,
+      blocksNet: r.blocksNet.map((rd) => rd.map((b) => Object.fromEntries(Object.entries(b).map(([a, xs]) => [a, r4(p50(xs))])))),
+      blocksInPage: r.blocksInPage.map((rd) => rd.map((b) => Object.fromEntries(Object.entries(b).map(([a, xs]) => [a, r4(p50(xs.filter(Number.isFinite)))])))),
+      tally: r.tally,
+      runtime: r.runtime,
+      quiet: r.quiet,
+      windowStart: r.windowStart,
+      adjudication: {
+        ctl: r.adjudication.ctl,
+        cAdditive: r4(r.adjudication.cAdditive),
+        band: Number.isFinite(r.adjudication.assessed.bandStats.band) ? r4(r.adjudication.assessed.bandStats.band) : null,
+        ceilingBreached: r.adjudication.assessed.verdict.ceilingBreached,
+        bars: r.adjudication.bars,
+        verdicts: r.adjudication.verdicts,
+        guardRefuse: r.adjudication.guardRefuse,
+        plumb: r4(r.adjudication.plumb),
+        floorTared: r4(r.adjudication.floorTared),
+      },
+    })),
+  };
+}
+
+/** This process's shape, as `destination` reads it. */
+const runShape = () => ({
+  dataDir: DATA_DIR,
+  dataDirOverridden: DATA_DIR_OVERRIDDEN,
+  runsOnly: ONLY || null,
+  noBuild: NO_BUILD,
+  depthPublished: depthIsPublished(),
+});
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -828,7 +968,7 @@ async function drive() {
   console.log(`;;   node        ${process.version}`);
   console.log(
     `;;   design      ${ROUNDS} rounds x ${BLOCKS} blocks x (${WARMUP} warmup + ${SAMPLES} samples) per arm` +
-      `${ROUNDS === 6 && BLOCKS === 3 && WARMUP === 4 && SAMPLES === 10 ? '' : '  *** OVERRIDDEN — NOT THE PUBLISHED SHAPE ***'}`
+      `${depthIsPublished() ? '' : '  *** OVERRIDDEN — NOT THE PUBLISHED SHAPE ***'}`
   );
   console.log(`;;   runs        ${RUNS.map((r) => r.id).join(', ')}${ONLY ? `  (HD8CLOCK_ONLY=${ONLY} — PARTIAL, not the published shape)` : ''}`);
   console.log(`;;   guard tol   ${TOLERANCE} on raw TaskDuration (HD-008's stated mount choice)`);
@@ -875,49 +1015,29 @@ async function drive() {
     server.close();
   }
 
+  // The verdict is computed BEFORE the datasets are written, because where
+  // they may be written depends on it (see `destination`).
+  const v = verdict(summarise(failed, results));
+  const dest = destination(runShape(), v.code);
+
   // compact datasets — the reduced quantities every statistic above is a
   // function of, per run, so the page can be recomputed from the tree.
   if (results.length && !failed) {
-    fs.mkdirSync(DATA_DIR, { recursive: true });
+    if (dest.canonical) {
+      console.log(';; datasets CANONICAL — the published shape, all gates passed');
+    } else {
+      console.log(`;; datasets NOT CANONICAL — ${dest.why}`);
+      console.log(';;          These are working datasets. They are not the published evidence and');
+      console.log(';;          may not be cited as it.');
+    }
+    fs.mkdirSync(dest.dir, { recursive: true });
     for (const runDef of RUNS) {
       const rows = results.filter((r) => r.runId === runDef.id);
       if (!rows.length) continue;
-      const data = {
-        bead: 'rf2-2rtt6.31',
-        commit: sha,
-        blobs: bl,
-        when: new Date().toISOString(),
-        design: { rounds: ROUNDS, blocks: BLOCKS, warmup: WARMUP, samples: SAMPLES, tolerance: TOLERANCE, controlSlack: CONTROL_SLACK, gateLine: GATE_LINE },
-        clock: 'Performance.getMetrics raw TaskDuration, frame-settled (rAF + setTimeout), plumb-tared',
-        door: 'page.evaluate -> HD8CLOCK.sample (every arm, plumb included)',
-        node: process.version,
-        rows: rows.map((r) => ({
-          rowId: r.rowId,
-          armIds: r.armIds,
-          canon: r.canon,
-          blocksTask: r.blocksTask,
-          blocksNet: r.blocksNet.map((rd) => rd.map((b) => Object.fromEntries(Object.entries(b).map(([a, xs]) => [a, r4(p50(xs))])))),
-          blocksInPage: r.blocksInPage.map((rd) => rd.map((b) => Object.fromEntries(Object.entries(b).map(([a, xs]) => [a, r4(p50(xs.filter(Number.isFinite)))])))),
-          tally: r.tally,
-          runtime: r.runtime,
-          quiet: r.quiet,
-          windowStart: r.windowStart,
-          adjudication: {
-            ctl: r.adjudication.ctl,
-            cAdditive: r4(r.adjudication.cAdditive),
-            band: Number.isFinite(r.adjudication.assessed.bandStats.band) ? r4(r.adjudication.assessed.bandStats.band) : null,
-            ceilingBreached: r.adjudication.assessed.verdict.ceilingBreached,
-            bars: r.adjudication.bars,
-            verdicts: r.adjudication.verdicts,
-            guardRefuse: r.adjudication.guardRefuse,
-            plumb: r4(r.adjudication.plumb),
-            floorTared: r4(r.adjudication.floorTared),
-          },
-        })),
-      };
-      const f = path.join(DATA_DIR, `${runDef.id}.json`);
+      const data = datasetFor(rows, { sha, blobs: bl, dest });
+      const f = path.join(dest.dir, `${runDef.id}.json`);
       fs.writeFileSync(f, JSON.stringify(data));
-      console.log(`;; dataset  ${f}`);
+      console.log(`;; dataset  ${f}${dest.canonical ? '' : '   (NOT the published evidence)'}`);
     }
   }
 
@@ -926,7 +1046,6 @@ async function drive() {
   console.log(';;   operator\'s to overturn (rf2-2rtt6.1). This driver prints measurements and');
   console.log(';;   per-pair adjudications against the recorded line; nothing here amends the bar.');
 
-  const v = verdict(summarise(failed, results));
   for (const line of v.lines) console.error(line);
   if (v.code === 0) {
     console.error('[hd8clock] ok — measured, and no arm reads differently for its position in the plan');
@@ -934,7 +1053,7 @@ async function drive() {
   return v.code;
 }
 
-module.exports = { summarise, verdict };
+module.exports = { summarise, verdict, destination };
 
 if (require.main === module) {
   drive().then((code) => {


### PR DESCRIPTION
`hd8_clock_run.cjs` wrote its datasets under the canonical filenames **before**
it consulted its own refusal. So a control-refused re-run silently replaced
`data/hd8clock-2rtt6-31/{uix,reagent,slim}.json` — the very files the studio
page recomputes from, and whose committed rows fail the positive control on
five of six. Nothing announced it: the write had already landed, and the
nonzero exit arrived afterwards.

This applies the two-tier ruling recorded on `rf2-2rtt6.31`: **preserve every
completed measurement; promote only a gate-passing, full-published-shape run to
the canonical evidence set.** Capture is not publication.

Both contradicting records survive in part. `rf2-rr6do`'s landed intent — *"no
refusal suppresses output … a refusal is about what may be QUOTED, not about
throwing the measurement away"* — keeps its preservation half: nothing is ever
discarded. Its canonical-filename half falls: refused output is still written,
just never under the published evidence set's names.

## Mirroring census

`destination(shape, code)` is copied from `census_clock_run.cjs` (PR #7639,
`rf2-2rtt6.56`) rather than reinvented — same pure-function-over-a-flat-shape
form, same `.unpublished` sibling, same "honoured as given, never canonical"
treatment of an operator-named directory, same `canonical:` / `notCanonicalWhy:`
fields serialised **in** the dataset. A shared helper was not extracted: the two
drivers sit in different directories, `census_clock_run.cjs` is outside this
bead's fence, and the ruling explicitly permits copying the pattern.

**One deliberate deviation.** Census names a *PARTIAL row set* because
`C56CLOCK_ROWS` can narrow its rows. This driver's `ROWS` is a fixed pair with
no such knob, so that reason would be dead code and is omitted. The deviation is
pinned by a check that fails the moment an `HD8CLOCK_ROWS` knob appears, so the
routing must follow if one is ever added.

Two supporting changes came with it, both mirroring census:

- `datasetFor` is **lifted out of `drive`**. Serialising a row means naming
  `guardRefuse` / `ceilingBreached`, and `drive` is held to an invariant that
  nothing downstream of `verdict` may name a refusal — the check that stops a
  second exit path growing back. Moving the write *after* the verdict is exactly
  what would have tripped it, so recording had to leave the deciding function.
  That pre-existing guard passes unchanged, now covering the whole write path.
- `PUBLISHED_DEPTH` / `depthIsPublished()` replace the inline depth predicate,
  so the provenance stamp and the write path cannot drift apart.

## The refusal, demonstrated

`destination` routing, exercised directly (this is the hermetic block, not prose):

```
clean full-shape run, exit 0                   -> CANONICAL   data/hd8clock-2rtt6-31
control-refused run (exit 5) — the real case   -> unpublished data/hd8clock-2rtt6-31.unpublished
                                                  why: the run's own verdict refused it (exit 5)
arm-order guard refused (exit 2)               -> unpublished data/hd8clock-2rtt6-31.unpublished
                                                  why: the run's own verdict refused it (exit 2)
narrowed HD8CLOCK_ONLY=uix, exit 0             -> unpublished data/hd8clock-2rtt6-31.unpublished
                                                  why: a PARTIAL run set (HD8CLOCK_ONLY=uix)
--no-build, exit 0                             -> unpublished data/hd8clock-2rtt6-31.unpublished
                                                  why: --no-build (the bundle on disk is not known to be this tree's)
overridden depth, exit 0                       -> unpublished data/hd8clock-2rtt6-31.unpublished
                                                  why: an OVERRIDDEN design depth
operator-named HD8CLOCK_DATA_DIR, exit 0       -> unpublished /tmp/mine
                                                  why: HD8CLOCK_DATA_DIR named this destination
refused AND narrowed AND --no-build            -> unpublished data/hd8clock-2rtt6-31.unpublished
                                                  why: the run's own verdict refused it (exit 5); a PARTIAL run set
                                                       (HD8CLOCK_ONLY=uix); --no-build (…)
```

Every one of the five exit codes this driver can return (1–5) routes off the
canonical set, and every condition that fired is named — not just the first.

**And the ordering guard is shown refusing.** A guard that only ever reports
"ok" on the one source it is pointed at proves nothing, so one check reconstructs
the regression: it hoists `destination` above `verdict` in a copy of the real
source and requires the guard to reject it, and separately requires it to reject
a driver with no `destination` step at all. A policy that cannot be shown to
refuse is not a policy.

## Check count against census

**17 new hermetic checks**, `clock_exit_path.test.cjs` going **133 → 150**.
Census's equivalent write-path block carries 13 for `rf2-2rtt6.56` (plus one
later `rf2-2rtt6.62` check). The 17 are the 13 mirrored, plus four this driver
earned: all-five-exit-codes-route, the preservation half (a refused run still
*has* a destination), the header stating the two-tier rule, and the
absent-row-knob deviation pinned to its reason.

Standing datasets under `data/hd8clock-2rtt6-31/` are **not** rewritten — they
are the cited evidence base for the audit record, and under fail-closed reading
their missing `canonical` field already marks them non-canonical.

## Provenance (#7462 audit item 1)

The stamp had drifted from the cited line 218 to **line 223**. `hd8-composed-donor-arm.md`
said *"The landed SHA is the merge's to mint"*; it is now minted:
`1ac48c4a0be1fed3338fbb504f5b023af6d1524d` (PR #7378), which **is** an ancestor
of `origin/main`. The authored/producing head `16ddf3e3077…` is retained — it is
the true provenance of the run, and it is reachable from no ref.

The two heads' `git patch-id --stable` values differ (`5c7a940…` vs `308dcde…`),
as expected for a rebase-merge that reshaped the branch, so the anchor is
**established by tree content, not by patch-id and not by subject**: all six
instrument blobs the page pins are byte-identical at both heads —
`hd8_clock_app.cljs e2469a0e`, `hd8_clock_run.cjs ba79e38e`, `hd8_rows.cljs
b34cf52b`, `hd8_witnesses.cljs 8669cc71`, `lane.cljs 0642815d`, and
`substrate/spine.cljs ad7b19d9`. That is the page's own stated anchoring method.

**The gate then required more than the one stamp.** Editing this page arms the
scoped provenance gate on it, and it carried **16 pre-existing findings** across
11 blocks — untouched by, and unrelated to, the stamp above. Each is now
accompanied in its own block by a resolvable landed SHA, every one established
by `git patch-id --stable` (subjects corroborate but did not decide):

| authored (stranded) | landed on `main` |
|---|---|
| `d46ede4f` | `172244521e` |
| `b943c7ed` | `c7e4c70ac0` |
| `d3f1c2ff` | `0cba8181a7` |
| `f5bd4b49` | `85cb1dd5c2` |
| `79de836f35` | `50ce76d85f` |
| `16ddf3e307` | `1ac48c4a0b` |

No measurement, range, verdict or exit code on the page is amended; only anchors
are added. `check_doc_slugs.py` masks fenced blocks and is silent on success, so
the page's structure was **hand-verified** at every edit site: `<details>` 2/2,
`<summary>` 2/2, `<code>` 3/3 balanced, and all tables checked for consistent
column counts (0 ragged).

## Quality gates

All foreground, never piped, each redirected to a worktree-local log with the
runner's own exit code echoed.

| gate | command | result | exit |
|---|---|---|---|
| exit-path test owning `hd8_clock_run.cjs` | `node freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs` | **150 passed** (133 on `origin/main`; +17) | **0** |
| doc slugs | `python scripts/check_doc_slugs.py --verbose` | 678 markdown files, no broken links | **0** |
| provenance pins | `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | 42 cited pins — 22 landed, 20 stranded, 0 unresolvable; every pin accompanied | **0** |
| CLJS node integration | `cd implementation && npm run test:cljs` | 12,776 tests / 64,098 assertions, 0 failures, 0 errors | **0** |
| fast-PR spine | `sh scripts/test-fast-pr.sh` | 0 FAIL steps; full docs+JVM+JS+CLJS tier green (`clock_exit_path.test.cjs: 150 passed` inside it) | **0** |

**On the spine's first run** (`FASTPR_EXIT=1`): exactly one step failed —
`CLJS node integration`, with `could not resolve shadow-cljs: Cannot find module
'shadow-cljs/cli/runner.js'`. That is the worker worktree having no
`implementation/node_modules`, not a regression: this diff contains no CLJS at
all (one `.cjs` driver, one `.cjs` test, one `.md`). Every other step passed,
including `provenance pins on changed pages` and the exit-path suite at 150.
The `node_modules` junction was then created against the mayor checkout's real
tree, the step re-run in isolation (exit 0, above), and the whole spine re-run —
the row above. The junction is removed as the last act of this task; the mayor's
`node_modules` canaries were verified before and after (`101`/`103` for
`implementation/`, `59`/`61` for the root).

Baseline for comparison: on `origin/main` the provenance gate reported
`no page under docs/design/hicasso changed since origin/main` (exit 0,
vacuous — nothing was armed). Against the pre-edit page it reported the same
16 findings this PR clears.

**Not implemented, deliberately.** The ruling lists unique per-refusal
subdirectories (timestamp/sha) as *recommended, not gating*. Census does not do
it, and the instruction here was to mirror census rather than invent a third
shape, so it is left out rather than gold-plated.

## Note for the `rf2-emvod` half

`rf2-emvod` implements the consumer side of this same rule on its own driver
(the reportable filter enforcing the serialised gates). This PR is the producer
half and touches neither `clock_run.cjs` nor anything in emvod's fence. The two
agree on the contract: a dataset carries `canonical` and `notCanonicalWhy`
in-file, and **a missing `canonical` field is not a pass**.

Closes the write-before-refuse acceptance criteria on `rf2-2rtt6.31`.
