### PR TITLE
refactor(hicasso): one slot rule, shared by the codec and the JVM tool (rf2-ani6y)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_views.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_views.cljs
@@ -64,7 +64,7 @@
 
   React's `onChange` fires on the native `input` event, and Hicasso's
   `:on-change` lowers to the same prop: `intent/lower-prop` claims every
-  `^on-` position and `codec/prop-name` camelCases it to `onChange`. Same
+  `^on-` position and `slot/prop-name` camelCases it to `onChange`. Same
   prop, same event, same handler.
 
   ## The keystroke floor holds its draft in React, and it is NOT a lower

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -373,12 +373,14 @@
 (def ^:private prop-cache
   ;; The three seeded entries are the RULE, not memos of one — they are
   ;; the rename table inside
-  ;; [[re-frame.bench.hicasso.front.slot/prop-name]], pre-warmed, and
-  ;; `slot-cljs-test`'s corpus asserts the seed against the rule on both
-  ;; hosts so a re-spelled seed cannot outlive it. None is reserved, an
-  ;; event position, or the ref
-  ;; slot; `class` IS the class slot, which is the whole reason the rule
-  ;; is stated on the emitted name rather than on the key.
+  ;; [[re-frame.bench.hicasso.front.slot/prop-name]], pre-warmed. They
+  ;; are the one place this file could still answer a slot the shared
+  ;; rule would not, so `codec-cljs-test` asks these very keys of
+  ;; `cached-prop-name` against `slot-cljs-test`'s corpus and a
+  ;; re-spelled seed cannot outlive the ask. None is reserved, an event
+  ;; position, or the ref slot; `class` IS the class slot, which is the
+  ;; whole reason the rule is stated on the emitted name rather than on
+  ;; the key.
   (doto (empty-cache)
     (unchecked-set "class" (->PropSlot "className" false false false true))
     (unchecked-set "for" (->PropSlot "htmlFor" false false false false))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -152,6 +152,14 @@
   written against the raw key is a rule that `\"key\"`, `:x/ref` and
   `:onInput` walk straight past.
 
+  **The rule itself is not in this file** (rf2-ani6y). It is
+  [[re-frame.bench.hicasso.front.slot/prop-name]], in `.cljc`, because
+  the `[:>]` migration codemod decides the same slots on the JVM and a
+  reimplementation there would be the codemod's own defect class turned
+  inward: a divergence nothing pins, failing silently. What stays here is
+  the CACHING of its answers — [[cached-prop-name]] and [[PropSlot]] —
+  which is emission work and has no JVM consumer.
+
   The tag's `#id`/`.class` shorthand answers the same question one step
   further on: it is folded onto the **emitted object**, where the slot is
   not resolved at all because it already *is* the slot. An explicit id
@@ -197,6 +205,7 @@
   (:require [clojure.string :as str]
             [re-frame.bench.hicasso.front.controlled :as controlled]
             [re-frame.bench.hicasso.front.intent :as intent]
+            [re-frame.bench.hicasso.front.slot :as slot]
             ["react" :as react]))
 
 (declare as-element)
@@ -312,41 +321,12 @@
 ;; Prop names and their cache
 ;; ---------------------------------------------------------------------------
 
-(def ^:private dont-camel-case
-  "`aria-*` and `data-*` are HTML attribute names in React too, and
-  camelCasing them would break them."
-  #{"aria" "data"})
-
-(defn- capitalize [s]
-  (if (< (count s) 2) (str/upper-case s) (str (str/upper-case (subs s 0 1)) (subs s 1))))
-
-(def ^:private react-renames
-  "The three attribute names React spells differently from HTML. They are
-  the RULE rather than a memo of one, so they hold for every spelling of
-  the same attribute: `:class`, `:className`, `\"class\"` and `:x/class`
-  all name the one slot React calls `className`."
-  {"class" "className" "for" "htmlFor" "charset" "charSet"})
-
-(defn prop-name
-  "The React prop name for a hiccup prop key — which, because it is the
-  name the codec emits the value under, is that key's CANONICAL SLOT.
-  `:on-click` → `\"onClick\"`; `:aria-label` and `:data-index` pass
-  through; a `--custom-property` is preserved verbatim; a string is
-  already a React name and is taken verbatim apart from the three renames
-  above.
-
-  **A pure function of the key**, which is what [[canonical-slot]] rests
-  on. A slot that depended on what the build happened to have converted
-  earlier would make the owned-literal law depend on render order."
-  [k]
-  (let [n (name k)]
-    (or (react-renames n)
-        (if (or (string? k) (str/starts-with? n "--"))
-          n
-          (let [[start & parts] (str/split n #"-")]
-            (if (dont-camel-case start)
-              n
-              (apply str start (map capitalize parts))))))))
+;; The slot rule itself is NOT here. It is
+;; [[re-frame.bench.hicasso.front.slot/prop-name]], in `.cljc`, because
+;; the `[:>]` migration codemod has to ask the same question on the JVM
+;; and a tool that reimplemented it would reproduce — inside the tool —
+;; the silent divergence the codemod exists to delete (rf2-ani6y). Only
+;; the CACHING of its answers is codec work, and that is what follows.
 
 (deftype PropSlot [js-name reserved? event? ref? class?]
   ;; What the prop cache holds for one prop literal (rf2-y1jkm): the React
@@ -373,7 +353,7 @@
   "The [[PropSlot]] for a keyword or symbol prop literal whose name is
   `n`. Every field a pure function of the literal, per the deftype note."
   [k n]
-  (let [js-name (prop-name k)]
+  (let [js-name (slot/prop-name k)]
     (->PropSlot js-name
                 (reserved-name? js-name)
                 ;; asked of the NAME, not of `k` — a symbol shares the
@@ -391,8 +371,12 @@
                 (identical? "className" js-name))))
 
 (def ^:private prop-cache
-  ;; The three seeded entries are the RULE, not memos of one — see
-  ;; [[react-renames]]. None is reserved, an event position, or the ref
+  ;; The three seeded entries are the RULE, not memos of one — they are
+  ;; the rename table inside
+  ;; [[re-frame.bench.hicasso.front.slot/prop-name]], pre-warmed, and
+  ;; `slot-cljs-test`'s corpus asserts the seed against the rule on both
+  ;; hosts so a re-spelled seed cannot outlive it. None is reserved, an
+  ;; event position, or the ref
   ;; slot; `class` IS the class slot, which is the whole reason the rule
   ;; is stated on the emitted name rather than on the key.
   (doto (empty-cache)
@@ -419,11 +403,12 @@
       hit)))
 
 (defn cached-prop-name
-  "[[prop-name]] behind the codec-work cache (HD-004).
+  "[[re-frame.bench.hicasso.front.slot/prop-name]] behind the codec-work
+  cache (HD-004).
 
   **Only a keyword or a symbol is cached**, which is the donor's shape and
-  is load-bearing here. The cache is keyed by `(name k)` while
-  [[prop-name]] answers a STRING differently from the keyword of the same
+  is load-bearing here. The cache is keyed by `(name k)` while the rule
+  answers a STRING differently from the keyword of the same
   name — a string is already a React name, so `\"on-input\"` stays
   `\"on-input\"` where `:on-input` becomes `\"onInput\"`. Sharing one cache
   entry between them lets either poison the other: the first
@@ -435,7 +420,7 @@
   dependence the owned-literal law exists to remove."
   [k]
   (if-not (or (keyword? k) (symbol? k))
-    (if (string? k) (prop-name k) k)
+    (if (string? k) (slot/prop-name k) k)
     (let [^PropSlot s (prop-slot k (name k))]
       (.-js-name s))))
 
@@ -2219,7 +2204,8 @@
   as SLOTS rather than as keys — `:class`, `:className` and `\"class\"`
   are one position ([[canonical-slot]]), and a rule written against the
   spelling is a rule the other spellings walk past. The `data-*` /
-  `aria-*` families join them by prefix; [[prop-name]] leaves those two
+  `aria-*` families join them by prefix;
+  [[re-frame.bench.hicasso.front.slot/prop-name]] leaves those two
   uncamelCased, so the slot still carries the prefix to test.
 
   The roster is this repo's own, not a guess: the `reagent-slim` adapter

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -370,21 +370,29 @@
                 ;; overwriting the other.
                 (identical? "className" js-name))))
 
-(def ^:private prop-cache
-  ;; The three seeded entries are the RULE, not memos of one — they are
-  ;; the rename table inside
-  ;; [[re-frame.bench.hicasso.front.slot/prop-name]], pre-warmed. They
-  ;; are the one place this file could still answer a slot the shared
-  ;; rule would not, so `codec-cljs-test` asks these very keys of
-  ;; `cached-prop-name` against `slot-cljs-test`'s corpus and a
-  ;; re-spelled seed cannot outlive the ask. None is reserved, an event
-  ;; position, or the ref slot; `class` IS the class slot, which is the
-  ;; whole reason the rule is stated on the emitted name rather than on
-  ;; the key.
-  (doto (empty-cache)
-    (unchecked-set "class" (->PropSlot "className" false false false true))
-    (unchecked-set "for" (->PropSlot "htmlFor" false false false false))
-    (unchecked-set "charset" (->PropSlot "charSet" false false false false))))
+(defn- seed-prop-cache!
+  "Pre-warm `cache` with the three React renames, and return it.
+
+  **The seeded entries are the RULE, not memos of one** — so each slot
+  name is ASKED of [[re-frame.bench.hicasso.front.slot/prop-name]]
+  rather than written out again here (rf2-ani6y). A hand-spelled seed is
+  the one place this file could still answer a slot the shared rule
+  would not, which is this bead's own defect class one level in; and the
+  seed was written out TWICE, here and in [[reset-caches!]], so a drift
+  had two chances and the suites' `:each` fixture made the second copy
+  the live one. There is one copy now, and it cannot disagree with the
+  rule because it does not restate it.
+
+  None of the three is reserved, an event position, or the ref slot;
+  `class` IS the class slot, which is the whole reason the rule is
+  stated on the emitted name rather than on the key."
+  [cache]
+  (doto cache
+    (unchecked-set "class" (->PropSlot (slot/prop-name :class) false false false true))
+    (unchecked-set "for" (->PropSlot (slot/prop-name :for) false false false false))
+    (unchecked-set "charset" (->PropSlot (slot/prop-name :charset) false false false false))))
+
+(def ^:private prop-cache (seed-prop-cache! (empty-cache)))
 
 (defn- prop-slot
   "The [[PropSlot]] for keyword/symbol `k` with name `n` — the caller has
@@ -2953,11 +2961,12 @@
 
 (defn reset-caches!
   "Empty both codec caches. The prop cache keeps its three seeded entries,
-  because those are the rule and not a memo of one."
+  because those are the rule and not a memo of one — and it re-seeds
+  through [[seed-prop-cache!]], the same one the `def` uses, so a
+  suite's `:each` fixture cannot leave the cache holding a different
+  spelling from a cold build's (rf2-ani6y)."
   []
   (doseq [k (js/Object.keys tag-cache)] (js-delete tag-cache k))
   (doseq [k (js/Object.keys prop-cache)] (js-delete prop-cache k))
-  (unchecked-set prop-cache "class" (->PropSlot "className" false false false true))
-  (unchecked-set prop-cache "for" (->PropSlot "htmlFor" false false false false))
-  (unchecked-set prop-cache "charset" (->PropSlot "charSet" false false false false))
+  (seed-prop-cache! prop-cache)
   nil)

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
@@ -10,6 +10,8 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.bench.hicasso.front.codec :as codec]
             [re-frame.bench.hicasso.front.intent :as intent]
+            [re-frame.bench.hicasso.front.slot :as slot]
+            [re-frame.bench.hicasso.front.slot-cljs-test :as slot-test]
             ["react" :as react]))
 
 (use-fixtures :each {:before (fn [] (codec/reset-caches!))})
@@ -106,21 +108,42 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest prop-names-follow-the-donors-kebab-to-camel-rule
-  (is (= "onClick" (codec/prop-name :on-click)))
-  (is (= "tabIndex" (codec/prop-name :tab-index)))
+  (is (= "onClick" (slot/prop-name :on-click)))
+  (is (= "tabIndex" (slot/prop-name :tab-index)))
   (is (= "className" (codec/cached-prop-name :class)))
   (is (= "htmlFor" (codec/cached-prop-name :for)))
   (is (= "charSet" (codec/cached-prop-name :charset)))
   (testing "aria and data are HTML attribute names in React too"
-    (is (= "aria-label" (codec/prop-name :aria-label)))
-    (is (= "data-index" (codec/prop-name :data-index))))
+    (is (= "aria-label" (slot/prop-name :aria-label)))
+    (is (= "data-index" (slot/prop-name :data-index))))
   (testing "a CSS custom property is preserved verbatim"
-    (is (= "--gap" (codec/prop-name :--gap))))
+    (is (= "--gap" (slot/prop-name :--gap))))
   (testing "the three seeded entries are the rule, not a memo of one"
     (is (= 3 (:props (codec/cache-sizes))))
     (codec/cached-prop-name :on-click)
     (codec/cached-prop-name :on-click)
     (is (= 4 (:props (codec/cache-sizes))))))
+
+(deftest the-codecs-cached-slot-is-the-shared-rules-answer
+  (testing "THE OTHER HALF OF THE EQUIVALENCE PIN (rf2-ani6y). The rule
+            lives in `.cljc` so the JVM codemod and this runtime share one
+            implementation, and `slot-cljs-test` runs its corpus on both
+            hosts. That pins the RULE. What it cannot see is this codec
+            putting something else in front of the rule — a
+            hand-written seed in `prop-cache`, a cache keyed so two
+            spellings share one entry, a re-introduced local copy — each
+            of which would answer a slot the codemod would never predict.
+            So the codec's own doors are asked the same corpus: whatever
+            the rule answers, `cached-prop-name` and `canonical-slot`
+            answer, for every spelling the codec accepts."
+    (doseq [[k expected] slot-test/corpus]
+      (is (= expected (codec/cached-prop-name k) (codec/canonical-slot k))
+          (str "codec slot for " (pr-str k)))))
+  (testing "and again warm, because the first ask is the one that writes
+            the cache and the second is the one that reads it"
+    (doseq [[k expected] slot-test/corpus]
+      (is (= expected (codec/cached-prop-name k))
+          (str "warm codec slot for " (pr-str k))))))
 
 (deftest the-slot-is-a-pure-function-of-the-key-and-a-string-cannot-poison-it
   (testing "a string prop name is already a React name and is taken verbatim,

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/slot.cljc
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/slot.cljc
@@ -1,0 +1,109 @@
+(ns re-frame.bench.hicasso.front.slot
+  "THE CANONICAL SLOT RULE — one implementation, two hosts (rf2-ani6y).
+
+  A hiccup prop key is written in one of four spellings — a keyword, a
+  string, a symbol or a namespaced keyword — in kebab or in camel, and
+  every one of them is emitted under ONE React name. [[prop-name]] is
+  the function that decides which. It is the whole of the rule and it is
+  the whole of this namespace.
+
+  ## Why it is `.cljc` rather than a `defn` inside the codec
+
+  [[re-frame.bench.hicasso.front.codec]] is `.cljs`, because emission is
+  `React.createElement`. The slot rule is not: it is a pure function from
+  a name to a name, and it has a **second consumer that cannot run in
+  CLJS at all** — the `[:>]` migration codemod, which reads a Reagent
+  namespace on the JVM and must decide, statically, which slot each prop
+  it rewrites will land in.
+
+  A tool that reimplements the rule is the exact defect the codemod
+  exists to delete, reproduced inside the tool: a corpus pins the tool, a
+  DOM suite pins the runtime, and **nothing pins them equal**. When they
+  drift the failure is silent — the tool rewrites a prop one way, the
+  runtime reads it another, and the author's source now says something
+  the framework does not do. No comment, checklist or restating test
+  inside the tool's own tree closes that; a convention is not a pin.
+
+  So the rule moved to the one file both hosts can load, and the codec
+  calls it like anybody else. There is no second copy to keep honest.
+
+  ## What pins the two hosts equal
+
+  `re-frame.bench.hicasso.front.slot-cljs-test` is a **`.cljc` suite**,
+  and this repo's lane bijection (`scripts/check_test_lane_bijection.py`
+  rule B2) requires such a file to be selected by a CLJS lane as well as
+  the JVM one. So the same corpus of authored keys, with the same
+  expected slots, is asserted by `npm run test:cljs` AND by
+  `clojure -M:test` in `implementation/freehand`. One table, one
+  implementation, two runtimes — and a divergence has nowhere left to
+  hide, because there is no second implementation to hold a second
+  answer.
+
+  That matters more than it looks, because the primitives below are not
+  host-identical for free. `str/upper-case` is `.toUpperCase()` on both,
+  but the JVM's takes the platform's DEFAULT LOCALE — on a Turkish-locale
+  JVM `\"i\"` upper-cases to `\"İ\"` and `:aria-index` would slot
+  differently from the browser's answer. `str/split`'s trailing-empty
+  handling is a second such seam. Neither is guarded here by a
+  reader conditional, and deliberately: a guard would be a guess about
+  which host is right. The cross-host suite makes the disagreement LOUD
+  instead, on the host that has it.
+
+  ## What is NOT here
+
+  The caches, the [[re-frame.bench.hicasso.front.codec/PropSlot]]
+  classifications, the prototype-poisoning guard and every walk are
+  emission concerns and stay in the codec. This namespace holds the pure
+  rule and its two vocabularies, and requires nothing but
+  `clojure.string`."
+  (:require [clojure.string :as str]))
+
+(def ^:private dont-camel-case
+  "`aria-*` and `data-*` are HTML attribute names in React too, and
+  camelCasing them would break them."
+  #{"aria" "data"})
+
+(defn- capitalize
+  "Upper-case the first character and leave the rest ALONE.
+
+  Deliberately not `clojure.string/capitalize`, which lower-cases the
+  tail: `:on-Click` would become `onClick` under either, but an author
+  who wrote `:view-Box` means `viewBox` and `str/capitalize` would hand
+  React `Viewbox`."
+  [s]
+  (if (< (count s) 2)
+    (str/upper-case s)
+    (str (str/upper-case (subs s 0 1)) (subs s 1))))
+
+(def ^:private react-renames
+  "The three attribute names React spells differently from HTML. They are
+  the RULE rather than a memo of one, so they hold for every spelling of
+  the same attribute: `:class`, `:className`, `\"class\"` and `:x/class`
+  all name the one slot React calls `className`."
+  {"class" "className" "for" "htmlFor" "charset" "charSet"})
+
+(defn prop-name
+  "The React prop name for a hiccup prop key — which, because it is the
+  name the codec emits the value under, is that key's CANONICAL SLOT.
+  `:on-click` → `\"onClick\"`; `:aria-label` and `:data-index` pass
+  through; a `--custom-property` is preserved verbatim; a string is
+  already a React name and is taken verbatim apart from the three renames
+  above.
+
+  **A pure function of the key**, which is what
+  [[re-frame.bench.hicasso.front.codec/canonical-slot]] rests on. A slot
+  that depended on what the build happened to have converted earlier
+  would make the owned-literal law depend on render order.
+
+  It is also the function the `[:>]` migration codemod asks on the JVM,
+  which is why it lives here rather than in the codec — see this
+  namespace's docstring."
+  [k]
+  (let [n (name k)]
+    (or (react-renames n)
+        (if (or (string? k) (str/starts-with? n "--"))
+          n
+          (let [[start & parts] (str/split n #"-")]
+            (if (dont-camel-case start)
+              n
+              (apply str start (map capitalize parts))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/slot_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/slot_cljs_test.cljc
@@ -1,0 +1,140 @@
+(ns re-frame.bench.hicasso.front.slot-cljs-test
+  "THE EQUIVALENCE PIN for the canonical slot rule (rf2-ani6y).
+
+  This file is `.cljc` on purpose, and that is the whole mechanism. The
+  repo's lane bijection (`scripts/check_test_lane_bijection.py` rule B2)
+  requires a `.cljc` suite under a CLJS-owned test root to be selected by
+  a CLJS lane as well as the JVM one, so [[corpus]] below is asserted
+  twice against ONE implementation: once by `npm run test:cljs` in Node
+  and once by `clojure -M:test` on the JVM, in
+  `implementation/freehand`.
+
+  ## What it would catch
+
+  The rule has exactly one definition
+  ([[re-frame.bench.hicasso.front.slot/prop-name]]), so the interesting
+  failure is not \"someone edited one copy\". It is the two ways one
+  definition can still answer two things:
+
+  1. **A reader conditional.** `#?(:clj … :cljs …)` inside the rule, or
+     inside anything it calls, splits it silently — the file still reads
+     as one implementation and the two hosts stop agreeing. Whichever
+     host the conditional favours stays green; the other goes red here,
+     naming the key.
+  2. **A host-differing primitive.** `str/upper-case` is
+     `.toUpperCase()` on both hosts, but the JVM's consults the platform
+     DEFAULT LOCALE — on a Turkish-locale JVM `\"i\"` upper-cases to
+     `\"İ\"`, so `:aria-index`, `:on-input` and every other key whose
+     camel hump lands on an `i` would slot differently from the
+     browser's answer. `str/split`'s trailing-empty handling is a second
+     such seam. Nothing here guards against either, deliberately: a
+     guard would be a guess about which host is right. This suite makes
+     the disagreement loud on the host that has it.
+
+  And the codec's own agreement — that its CACHE still answers what the
+  rule answers, seeded entries included — is asserted against this same
+  corpus in `codec-cljs-test`, which is CLJS-only because the caches
+  are."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [re-frame.bench.hicasso.front.slot :as slot]))
+
+(def corpus
+  "Authored prop key → the canonical React slot it emits into.
+
+  ONE table, read by both hosts and by the codec's cache suite. Every
+  branch of the rule is represented, and every spelling the codec accepts
+  appears at least once — because a rule written against the spelling is
+  a rule the other spellings walk past, and a corpus that only carries
+  bare kebab keywords could not tell."
+  {;; the three React renames — the RULE, so they hold for every spelling
+   :class          "className"
+   :className      "className"
+   "class"         "className"
+   :x/class        "className"
+   'class          "className"
+   :for            "htmlFor"
+   "for"           "htmlFor"
+   :x/for          "htmlFor"
+   :charset        "charSet"
+   'charset        "charSet"
+
+   ;; kebab → camel
+   :on-click       "onClick"
+   :tab-index      "tabIndex"
+   :on-mouse-enter "onMouseEnter"
+   :default-value  "defaultValue"
+   :a-b-c          "aBC"
+   'on-click       "onClick"
+   :x/on-click     "onClick"
+
+   ;; a hump the author already wrote survives — this is why the rule
+   ;; carries its own `capitalize` rather than `str/capitalize`, which
+   ;; would lower-case the tail and hand React `Viewbox`
+   :view-Box       "viewBox"
+   :on-Click       "onClick"
+
+   ;; nothing to camelCase
+   :x              "x"
+   :onInput        "onInput"
+   :viewBox        "viewBox"
+   :id             "id"
+   :ref            "ref"
+   :key            "key"
+
+   ;; aria/data are HTML attribute names in React too
+   :aria-label     "aria-label"
+   :aria-hidden    "aria-hidden"
+   :data-index     "data-index"
+   :data-testid    "data-testid"
+   'aria-label     "aria-label"
+   :x/data-index   "data-index"
+
+   ;; a CSS custom property is preserved verbatim
+   :--gap          "--gap"
+   :--my-custom-x  "--my-custom-x"
+
+   ;; a string is already a React name and is taken verbatim, apart from
+   ;; the three renames above — so `"on-input"` and `:on-input` are
+   ;; DIFFERENT slots
+   "on-input"      "on-input"
+   :on-input       "onInput"
+   "onInput"       "onInput"
+   "data-x"        "data-x"
+   "--gap"         "--gap"
+   "aria-label"    "aria-label"
+
+   ;; the prototype-poisoning names are the codec's problem, not the
+   ;; rule's; the rule answers them like any other name
+   :__proto__      "__proto__"
+   :constructor    "constructor"})
+
+(deftest the-slot-rule-answers-the-corpus
+  (doseq [[k expected] corpus]
+    (is (= expected (slot/prop-name k))
+        (str "slot for " (pr-str k)))))
+
+(deftest the-slot-rule-is-a-pure-function-of-the-key
+  (testing "the same key answers the same slot however often it is asked,
+            on a rule that holds no state at all — the codec's caches are
+            an accelerant over this, never a source of a different answer"
+    (doseq [[k expected] corpus]
+      (is (= expected (slot/prop-name k) (slot/prop-name k))
+          (str "repeated for " (pr-str k))))))
+
+(deftest every-branch-of-the-rule-is-represented
+  (testing "a corpus that lost a branch would go on passing while the
+            branch it stopped covering diverged between the hosts, so the
+            branches are counted rather than assumed"
+    (let [slots (into #{} (map val) corpus)]
+      (is (contains? slots "className") "the rename table")
+      (is (contains? slots "onClick") "kebab → camel")
+      (is (contains? slots "aria-label") "the aria exemption")
+      (is (contains? slots "data-index") "the data exemption")
+      (is (contains? slots "--gap") "the custom-property passthrough")
+      (is (contains? slots "on-input") "a string, taken verbatim"))
+    (let [ks (set (keys corpus))]
+      (is (some string? ks) "a string spelling")
+      (is (some symbol? ks) "a symbol spelling")
+      (is (some #(and (keyword? %) (namespace %)) ks) "a namespaced spelling")
+      (is (some #(and (keyword? %) (not (namespace %))) ks) "a bare keyword"))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_app.cljs
@@ -125,6 +125,7 @@
             [re-frame.bench.hicasso.front.codec :as codec]
             [re-frame.bench.hicasso.front.controlled :as controlled]
             [re-frame.bench.hicasso.front.intent :as intent]
+            [re-frame.bench.hicasso.front.slot :as slot]
             [re-frame.bench.hicasso.lane :as lane]
             [re-frame.bench.hicasso.shapes.card :as card]
             [re-frame.bench.hicasso.shapes.large-template :as lt]
@@ -346,6 +347,11 @@
 ;; absorbs half the candidate and the in-process A/B undersells it.
 ;; [[local-convert-prop-value]] below is the other half of the same
 ;; freeze; `walk_profile_baseline_cljs_test` pins both.
+;;
+;; What is frozen is the CACHE, never the rule. The name each arm
+;; computes on a miss is [[re-frame.bench.hicasso.front.slot/prop-name]]
+;; on both sides — freezing that too would make the A/B price a
+;; difference in answers rather than a difference in lookups.
 (def ^:private local-prop-cache
   (doto #js {}
     (unchecked-set "class" "className")
@@ -356,13 +362,13 @@
 
 (defn- local-prop-name [k]
   (if-not (or (keyword? k) (symbol? k))
-    (if (string? k) (codec/prop-name k) k)
+    (if (string? k) (slot/prop-name k) k)
     (let [n (name k)]
       (if (reserved-names n)
-        (codec/prop-name k)
+        (slot/prop-name k)
         (if (.call local-has-own local-prop-cache n)
           (unchecked-get local-prop-cache n)
-          (let [converted (codec/prop-name k)]
+          (let [converted (slot/prop-name k)]
             (unchecked-set local-prop-cache n converted)
             converted))))))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
@@ -72,6 +72,7 @@
             [re-frame.bench.hicasso.front.codec :as codec]
             [re-frame.bench.hicasso.front.controlled :as controlled]
             [re-frame.bench.hicasso.front.intent :as intent]
+            [re-frame.bench.hicasso.front.slot :as slot]
             [re-frame.bench.hicasso.lane :as lane]
             [re-frame.bench.hicasso.shapes.large-template :as lt]
             [re-frame.bench.hicasso.walk-profile-app :as wp]
@@ -367,7 +368,7 @@
   "All three arms cache the same value shape the codec caches, so the
   rows price the LOOKUP and not two different payloads."
   [k n]
-  (codec/->PropSlot (codec/prop-name k) (reserved-name? n) false false false))
+  (codec/->PropSlot (slot/prop-name k) (reserved-name? n) false false false))
 
 (defn- guarded-lookup
   "The shipping lookup shape, written here so every arm is local."


### PR DESCRIPTION
Closes rf2-ani6y.

The `[:>]` migration codemod (rf2-2rtt6.106) has to decide prop-name slots **on the JVM**. The codec that decides them at runtime was `.cljs`, so the tool would have reimplemented `prop-name` — and while the corpus pins the tool and the door's suite pins the runtime, **nothing pinned them equal**. That is the codemod's own defect class reproduced inside the codemod: a silent divergence where the tool rewrites a prop one way, the runtime reads it another, and the author's source now says something the framework does not do. Every remedy available inside the codemod's own tree is a convention, and conventions do not pin.

This lands before the fixer, so the fixer is built against a rule it consumes rather than one it copies.

## How self-contained the rule proved to be

**Fully.** `prop-name` moved whole, and it dragged nothing:

| moved to `front/slot.cljc` | why it could move |
|---|---|
| `prop-name` | the rule itself — a pure function from a name to a name |
| `react-renames` | a 3-entry map literal |
| `dont-camel-case` | a 2-entry set literal |
| `capitalize` | `subs` / `count` / `str/upper-case`; deliberately not `str/capitalize`, which lower-cases the tail |

*(2 columns; 4 body rows; hand-counted.)*

The new namespace requires `clojure.string` and nothing else. No cache, no `PropSlot`, no prototype guard, no walk came with it — those are emission concerns with no JVM consumer, and they stayed. So there was no judgement call about where to cut and no partial extraction to report.

`re-frame.freehand.rules/react-prop-name` was checked and is **not** the same rule (a react-dom `possibleStandardNames` table for the Freehand compiler, where this is the donor's kebab→camel rule for the Hicasso codec). They are deliberately different and were left alone.

## The equivalence test, and what it would catch

`front/slot_cljs_test.cljc` is **`.cljc`**, and that is the mechanism rather than a detail. This repo's lane bijection (`scripts/check_test_lane_bijection.py` rule B2) requires a `.cljc` suite under a CLJS-owned test root to be selected by a CLJS lane as well as the JVM one — so its `corpus` (41 authored keys → expected slots, covering every branch and every spelling the codec accepts) is asserted against one implementation **on both hosts**: by `npm run test:cljs` in Node and by `clojure -M:test` in `implementation/freehand`.

With one implementation the interesting failure is not "someone edited one copy". It is the two ways one definition can still answer two things, and the suite catches both:

1. **A reader conditional** inside the rule or anything it calls — the file still reads as one implementation while the hosts stop agreeing.
2. **A host-differing primitive.** `str/upper-case` is `.toUpperCase()` on both, but the JVM's takes the platform DEFAULT LOCALE — on a Turkish-locale JVM `"i"` upper-cases to `"İ"` and every key whose camel hump lands on an `i` would slot differently from the browser's. `str/split`'s trailing-empty handling is a second such seam. Neither is guarded, deliberately: a guard would be a guess about which host is right. The suite makes the disagreement loud on the host that has it.

A second pin covers what that one cannot see — this codec putting something *in front of* the rule. `codec_cljs_test`'s `the-codecs-cached-slot-is-the-shared-rules-answer` asks `cached-prop-name` and `canonical-slot` the same corpus, cold and warm.

### Red, then green — both halves

**Cross-host pin.** Made `dont-camel-case` `#?(:clj #{"aria"} :cljs #{"aria" "data"})` — a tool that camelCases `data-*` where the runtime does not, which is exactly the divergence class:

```
clojure -M:test -n re-frame.bench.hicasso.front.slot-cljs-test
  Ran 3 tests containing 92 assertions.  6 failures, 0 errors.   exit 1
  actual: (not (= "data-index" "dataIndex"))
  actual: (not (= "data-testid" "dataTestid"))
```

Restored (`git diff` empty), re-ran: `3 tests / 92 assertions, 0 failures, 0 errors`, **exit 0**.

**Codec pin.** Re-introduced a local rule inside `mint-slot` that camelCases `data-*` — the regression of putting the rule back in the codec:

```
node out/node-test.js --test=...codec-cljs-test,...slot-cljs-test
  Ran 70 tests containing 630 assertions.  9 failures, 0 errors.   exit 1
  FAIL in (the-codecs-cached-slot-is-the-shared-rules-answer)  codec_cljs_test.cljs:140  (cold)
  FAIL in (the-codecs-cached-slot-is-the-shared-rules-answer)  codec_cljs_test.cljs:145  (warm)
```

Six of the nine are the new test naming the divergent keys; the other three are pre-existing codec tests. `slot-cljs-test` stayed green throughout — correct, and the point: the rule was untouched, so the rule-level pin does not fire and the codec-level one does. Restored, re-ran: `73 tests / 661 assertions, 0 failures, 0 errors`, **exit 0**.

## Two things the extraction found

**Three call sites outside the codec asked `codec/prop-name`** — two in `walk_profile_app`'s frozen baseline arm, one in `walk_vs_reagent_app/mint-slot`, plus a `clock_views` docstring. CLJS answers a removed var with an `:undeclared-var` **warning** and `undefined` at runtime, so the build stayed at exit 0 and `walk_profile_baseline_cljs_test` reported seven errors instead. All three now call the shared rule, which is the right answer rather than a repair: what `walk_profile_app` deliberately freezes is the **cache shape**, never the name rule — freezing the rule too would make the in-process A/B price a difference in answers rather than a difference in lookups. The comment says so now.

**The three cache seeds were hand-typed, twice** — in the `prop-cache` `def` and again in `reset-caches!`. That is this bead's defect class one level in: a place inside the codec that can answer a slot the shared rule would not. It was also unreachable from the suites, because their `:each` fixture calls `reset-caches!`, so a drift in the `def` copy would never execute (measured: drifting it left the suite green). Both now go through one `seed-prop-cache!` that **asks `slot/prop-name`** for each name instead of restating it, so a seed can no longer disagree with the rule — it no longer says anything the rule does not. Flagged explicitly as the one change beyond the extraction itself; it deletes a duplicate rather than adding a mechanism, but it is a judgement call and easy to back out.

## Nothing else moved

Five files, all under `implementation/freehand/test/re_frame/bench/hicasso/`. No `spec/*`, no `shadow-cljs.edn`, no `deps.edn`, no workflow, no docs. No behaviour change: every slot answered before is answered identically now, which is what the corpus and the unchanged codec suite assert.

## Quality gates

Foreground, never piped; each redirected to a worktree-local log with the runner's own exit code echoed separately.

| # | Command | Result | Exit |
|---|---|---|---|
| 1 | `clojure -M:test` (`implementation/freehand`, JVM) | 1294 tests / 8966 assertions, 0 failures, 0 errors | **0** |
| 2 | `clojure -M:test -n re-frame.bench.hicasso.front.slot-cljs-test` (JVM half of the `.cljc`) | 3 tests / 92 assertions, 0 failures, 0 errors | **0** |
| 3 | `npm run test:cljs` (`:node-test`, Node half) | 2171 files compiled **0 warnings**; 12780 tests / 64272 assertions | **0** |
| 4 | `node out/node-test.js --test=`codec + slot + walk-profile-baseline | 73 tests / 661 assertions, 0 failures, 0 errors | **0** |
| 5 | `npm run test:freehand` (`:node-test-freehand`) | 488 files, 0 warnings; 1406 tests / 7786 assertions | **0** |
| 6 | `npm run test:browser` (`:browser-test`, arm1 DOM incl. the door) | 1124 files compiled **0 warnings**; 1128 tests / 6945 assertions | **0** |
| 7 | `npm run test:hicasso-compile` (bench lane, `:advanced`) | 136 lane namespaces, 443 files, **zero warnings** | **0** |
| 8 | `sh scripts/test-fast-pr.sh` (full spine) | `PASS fast PR spine` — JVM core 2233/11645, JVM freehand 1294/8966, CLJS node 12780/64272, per-ns isolation, bundle-isolation, hicasso bench-lane compile, all static/drift checks; docs tier correctly skipped (no doc surface touched) | **0** |

*(4 columns; 8 body rows; hand-counted.)*

**Both platforms compile.** The `.cljc` is loaded and executed on the JVM by gates 1–2 and in JavaScript by gates 3–6; gate 7 additionally compiles the whole hicasso lane under `:advanced` with `goog.DEBUG false`.

The three `:undeclared-var` warnings that the first `test:cljs` run surfaced (the missed call sites above) are gone — every compile after the fix reports **0 warnings**, on four separate builds.

No orphan build child was left behind: process table checked for high-CPU `node`/`java` between runs, and the isolation sweep inside the spine ran clean.
