### PR TITLE
fix(hicasso): the census driver must persist the metrics it collects (rf2-jo60g)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -476,6 +476,128 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     );
     assert.ok(SRC.split('depthIsPublished()').length - 1 >= 2, 'the one predicate must serve both readers');
   });
+
+  // --- rf2-jo60g: the split the driver collects must reach the file ----------
+  //
+  // `deltaOf` has always read ScriptDuration / LayoutDuration /
+  // RecalcStyleDuration per sample, the report has always printed the row's
+  // means, and `datasetFor` dropped all three. So census-real-clock-rows.md's
+  // P1 scoring — "layout 2.06x, style 1.85x, script 2.3x" on the feed row —
+  // was a figure the tree could not reproduce: real when taken, unreachable
+  // afterwards. These tests drive the WRITE, hermetically, on a fixture row.
+  // NO measurement is taken here and none is needed: what regressed is what
+  // the serialiser keeps.
+
+  const { datasetFor, foldDecomposition } = DRIVERS[1].mod;
+  const round4 = (x) => Math.round(x * 10000) / 10000;
+
+  // Four blocks over two rounds, ten samples each. Per-block sums differ so a
+  // fold that read one block, or averaged the blocks' means, cannot pass:
+  // only summing all four gives floor 1.0 / 1.0 / 0.1 ms per sample against
+  // ctl-2x 2.06 / 1.85 / 0.23 — the page's cited ratios, exactly.
+  const DECOMP_BLOCK = (n, layout, style, script) => ({
+    n, task: layout + style + script, taskNet: 0, devtools: 0, script, style, layout, layoutCount: n, inPage: 0,
+  });
+  const FIXTURE_DECOMP = [
+    [
+      { floor: DECOMP_BLOCK(10, 8, 9, 0.8), 'ctl-2x': DECOMP_BLOCK(10, 20, 18, 2.0) },
+      { floor: DECOMP_BLOCK(10, 12, 11, 1.2), 'ctl-2x': DECOMP_BLOCK(10, 21, 19, 2.4) },
+    ],
+    [
+      { floor: DECOMP_BLOCK(10, 9, 10, 1.0), 'ctl-2x': DECOMP_BLOCK(10, 20.4, 18.5, 2.4) },
+      { floor: DECOMP_BLOCK(10, 11, 10, 1.0), 'ctl-2x': DECOMP_BLOCK(10, 21, 18.5, 2.4) },
+    ],
+  ];
+  const CITED = { layout: 2.06, style: 1.85, script: 2.3 };
+
+  const fixtureRow = (over = {}) => ({
+    runId: 'reagent',
+    rowId: 'feed',
+    armIds: ['plumb', 'floor', 'ctl-2x'],
+    canon: { floor: true },
+    ctlPredicted: 1.9943,
+    blocksTask: [[{ floor: [1, 2], 'ctl-2x': [2, 4] }]],
+    blocksNet: [[{ floor: [1, 2], 'ctl-2x': [2, 4] }]],
+    blocksInPage: [[{ floor: [1, 2], 'ctl-2x': [2, 4] }]],
+    blocksDecomp: FIXTURE_DECOMP,
+    tally: { writes: 36, unverified: 0 },
+    runtime: 'fixture',
+    quiet: { ok: true },
+    windowStart: '2026-08-07T00:00:00.000Z',
+    adjudication: {
+      ctl: { ok: true },
+      cAdditive: 0.9,
+      assessed: { bandStats: { band: 0.12 }, verdict: { ceilingBreached: false } },
+      bars: {},
+      verdicts: {},
+      guardRefuse: false,
+      plumb: 0.5,
+      floorTared: 1.14,
+    },
+    ...over,
+  });
+  const META = { sha: 'deadbeef', blobs: {}, dest: { canonical: true, why: null } };
+  const written = () => JSON.parse(JSON.stringify(datasetFor([fixtureRow()], META))).rows[0];
+
+  t('the Script / Layout / RecalcStyle split reaches the written dataset', () => {
+    const row = written();
+    assert.ok(row.blocksDecomp, 'the split was collected and then dropped at write time — that was the defect');
+    // At the same block grain as the arrays beside it, not a row-level lump.
+    assert.strictEqual(row.blocksDecomp.length, FIXTURE_DECOMP.length);
+    assert.strictEqual(row.blocksDecomp[0].length, FIXTURE_DECOMP[0].length);
+    for (const arm of ['floor', 'ctl-2x']) {
+      for (const k of ['n', 'script', 'style', 'layout']) {
+        assert.ok(Number.isFinite(row.blocksDecomp[0][0][arm][k]), `${arm}.${k} must be a number in the file`);
+      }
+    }
+  });
+
+  t("the studio page's cited decomposition is recomputable from the file alone", () => {
+    // The whole point of the bead: read the JSON, fold it, divide, and the
+    // page's three numbers come back out. Nothing here reads the browser.
+    const fold = foldDecomposition(written().blocksDecomp);
+    const mean = (arm, k) => fold[arm][k] / fold[arm].n;
+    for (const [k, cited] of Object.entries(CITED)) {
+      assert.strictEqual(round4(mean('ctl-2x', k) / mean('floor', k)), cited, `${k} must recompute to ${cited}x`);
+    }
+    // ... and the fold is the sum of the stored blocks, so the row the report
+    // prints and the file are the same quantity.
+    assert.strictEqual(fold.floor.n, 40);
+    assert.strictEqual(round4(fold['ctl-2x'].layout), 82.4);
+  });
+
+  t('a row written BEFORE this change fails closed rather than folding to zeros', () => {
+    // This is the state of every census dataset on main when rf2-jo60g was
+    // filed. A fold that answered on it would hand the reader a number for a
+    // split the file never recorded, which is the defect wearing a fix's face.
+    const legacy = written();
+    delete legacy.blocksDecomp;
+    assert.throws(() => foldDecomposition(legacy.blocksDecomp), /NOT recomputable/);
+    assert.throws(() => foldDecomposition([]), /NOT recomputable/);
+  });
+
+  t('every committed census dataset either carries the split or refuses to answer', () => {
+    // Capture backfills nothing: the datasets on disk gain the fields on the
+    // next canonical run, not on this commit. Whatever is there, the rule is
+    // the same — a row with the split folds, a row without it refuses. There
+    // is no third answer, so this stays true across the re-run.
+    const dir = path.join(__dirname, 'data');
+    const files = fs
+      .readdirSync(dir)
+      .filter((d) => d.startsWith('censusclock-'))
+      .flatMap((d) => fs.readdirSync(path.join(dir, d)).filter((f) => f.endsWith('.json')).map((f) => path.join(dir, d, f)));
+    assert.ok(files.length >= 2, 'expected the committed census datasets');
+    for (const f of files) {
+      for (const row of JSON.parse(fs.readFileSync(f, 'utf8')).rows) {
+        if (row.blocksDecomp) {
+          const fold = foldDecomposition(row.blocksDecomp);
+          assert.ok(Object.values(fold).every((a) => a.n > 0), `${f}: a stored split must fold to real counts`);
+        } else {
+          assert.throws(() => foldDecomposition(row.blocksDecomp), /NOT recomputable/, `${f}: must refuse, not answer`);
+        }
+      }
+    }
+  });
 }
 
 // --- clock_run.cjs: the bar-level adjudication must reach the exit code -------

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
@@ -512,15 +512,15 @@ async function runRow(browser, runDef, rowId) {
   const blocksTask = [];
   const blocksNet = [];
   const blocksInPage = [];
+  const blocksDecomp = []; // per block: the renderer's own Script/Layout/Style split
   const samplesTask = []; // arm-order guard, on the clock of record
   const samplesNet = []; // the same guard on the diagnostic clock
-  const decomposition = {};
   const granularity = new Set();
   let position = 0;
   let previous = null;
 
-  const bump = (arm, d, inPage) => {
-    const acc = (decomposition[arm] ||= {
+  const bump = (into, arm, d, inPage) => {
+    const acc = (into[arm] ||= {
       n: 0, task: 0, taskNet: 0, devtools: 0, script: 0, style: 0, layout: 0, layoutCount: 0, inPage: 0,
     });
     acc.n += 1;
@@ -538,10 +538,12 @@ async function runRow(browser, runDef, rowId) {
     const roundTask = [];
     const roundNet = [];
     const roundInPage = [];
+    const roundDecomp = [];
     for (let blk = 0; blk < BLOCKS; blk++) {
       const accT = {};
       const accN = {};
       const accI = {};
+      const accD = {};
       for (const a of armIds) {
         accT[a] = [];
         accN[a] = [];
@@ -565,7 +567,7 @@ async function runRow(browser, runDef, rowId) {
             accT[armId].push(d.task);
             accN[armId].push(d.taskNet);
             accI[armId].push(res.inPageMs);
-            bump(armId, d, res.inPageMs);
+            bump(accD, armId, d, res.inPageMs);
             samplesTask.push({ arm: armId, value: d.task, predecessor: previous, position });
             samplesNet.push({ arm: armId, value: d.taskNet, predecessor: previous, position });
             position += 1;
@@ -576,10 +578,12 @@ async function runRow(browser, runDef, rowId) {
       roundTask.push(accT);
       roundNet.push(accN);
       roundInPage.push(accI);
+      roundDecomp.push(accD);
     }
     blocksTask.push(roundTask);
     blocksNet.push(roundNet);
     blocksInPage.push(roundInPage);
+    blocksDecomp.push(roundDecomp);
   }
 
   const tally = await page.evaluate('window.C56CLOCK.tally()');
@@ -591,10 +595,47 @@ async function runRow(browser, runDef, rowId) {
 
   return {
     runId: runDef.id, rowId, armIds, plan, canon, ctlPredicted,
-    blocksTask, blocksNet, blocksInPage,
-    samplesTask, samplesNet, decomposition, tally, runtime,
+    blocksTask, blocksNet, blocksInPage, blocksDecomp,
+    samplesTask, samplesNet, tally, runtime,
     granularity: [...granularity].sort((a, b) => a - b),
   };
+}
+
+/**
+ * The row's decomposition, folded out of the per-block accumulators — one
+ * `{n, task, taskNet, devtools, script, style, layout, layoutCount, inPage}`
+ * per arm, summed over every block of every round.
+ *
+ * The blocks are what is COLLECTED and what is STORED; this is the only
+ * derived form, so the mean the report prints and the ratio the studio page
+ * quotes are both functions of the dataset rather than of a number that was
+ * true once in a console. Addition is associative, so folding the stored
+ * blocks reproduces the row exactly — `../clock_exit_path.test.cjs` pins that.
+ *
+ * It REFUSES a row that carries no blocks rather than folding to zeros, because
+ * every census dataset written before rf2-jo60g is exactly that row, and a fold
+ * that answered there would hand a reader a NaN — or worse, a plausible number
+ * — for a split those files never recorded.
+ */
+function foldDecomposition(blocksDecomp) {
+  if (!Array.isArray(blocksDecomp) || blocksDecomp.length === 0) {
+    throw new Error(
+      'this row carries no per-block decomposition: it predates rf2-jo60g, so the ' +
+        'Script/Layout/RecalcStyle split is NOT recomputable from it and may not be quoted'
+    );
+  }
+  const out = {};
+  for (const round of blocksDecomp) {
+    for (const blk of round) {
+      for (const [arm, a] of Object.entries(blk)) {
+        const acc = (out[arm] ||= {
+          n: 0, task: 0, taskNet: 0, devtools: 0, script: 0, style: 0, layout: 0, layoutCount: 0, inPage: 0,
+        });
+        for (const k of Object.keys(acc)) acc[k] += a[k] || 0;
+      }
+    }
+  }
+  return out;
 }
 
 // ---------------------------------------------------------------------------
@@ -615,7 +656,8 @@ function perBlock(blocks, f) {
 }
 
 function report(out) {
-  const { runId, rowId, armIds, canon, ctlPredicted, blocksTask, blocksNet, blocksInPage, samplesTask, samplesNet, decomposition, tally, runtime, granularity } = out;
+  const { runId, rowId, armIds, canon, ctlPredicted, blocksTask, blocksNet, blocksInPage, blocksDecomp, samplesTask, samplesNet, tally, runtime, granularity } = out;
+  const decomposition = foldDecomposition(blocksDecomp);
   const stamp = STAMP[rowId];
 
   console.log(`\n;; ==== RUN ${runId} — ROW ${rowId} ====`);
@@ -975,6 +1017,26 @@ function datasetFor(rows, meta) {
       blocksTask: r.blocksTask,
       blocksNet: r.blocksNet.map((rd) => rd.map((b) => Object.fromEntries(Object.entries(b).map(([a, xs]) => [a, r4(p50(xs))])))),
       blocksInPage: r.blocksInPage.map((rd) => rd.map((b) => Object.fromEntries(Object.entries(b).map(([a, xs]) => [a, r4(p50(xs.filter(Number.isFinite)))])))),
+      // THE DECOMPOSITION — the renderer's own Script / RecalcStyle / Layout
+      // split, per block per arm: the block's sums with the `n` that produced
+      // them beside them.
+      //
+      // rf2-jo60g. `deltaOf` has always COLLECTED these three and this function
+      // has always dropped them, so the studio page's cited split on the feed
+      // row — "layout 2.06x, style 1.85x, script 2.3x" — was a figure no
+      // committed dataset could reproduce. Sums and counts at the same block
+      // grain as `blocksTask` are the reduced quantity: `foldDecomposition`
+      // gives the row, dividing by `n` gives the per-sample mean the report
+      // prints, and one arm's mean over another's gives the published ratio.
+      // Persisting it does not backfill the datasets already on main — the
+      // split becomes recomputable from the NEXT canonical run, not this line.
+      blocksDecomp: r.blocksDecomp.map((rd) =>
+        rd.map((b) =>
+          Object.fromEntries(
+            Object.entries(b).map(([a, acc]) => [a, Object.fromEntries(Object.entries(acc).map(([k, v]) => [k, r4(v)]))])
+          )
+        )
+      ),
       tally: r.tally,
       runtime: r.runtime,
       quiet: r.quiet,
@@ -1135,7 +1197,7 @@ async function drive() {
   return v.code;
 }
 
-module.exports = { summarise, verdict, destination };
+module.exports = { summarise, verdict, destination, datasetFor, foldDecomposition };
 
 if (require.main === module) {
   drive().then((code) => {


### PR DESCRIPTION
`shapes/census_clock_run.cjs` reads `ScriptDuration`, `LayoutDuration` and
`RecalcStyleDuration` on every sample (`deltaOf`, ~line 458), prints the row's
per-arm means, and then drops all three when `datasetFor` writes the dataset. So
`census-real-clock-rows.md`'s P1 scoring on the feed row — *"layout 2.06×, style
1.85×, script 2.3×"* — is a figure no committed dataset can reproduce. The
numbers were real when taken; nothing on disk could get back to them.

## Which of the two approved routes, and why

rf2-jo60g records two: **persist the metrics**, or **strike/annotate the
unrecomputable prose** on the studio page. This PR takes **persist**.

The strike is the cheaper *complete* resolution only in the world where the
matched-workload re-run is judged not warranted, and that is the operator's call
on rf2-jv36i's delegated-decision note, not a worker's. The bead's own note is
explicit that the prep half is dispatchable either way — *"persisting per-block
script/layout/style in `datasetFor` … is worker-dispatchable now, no window
needed"* — and it is the half that does not foreclose the other. Striking prose
would; persisting does not. If the operator later strikes the prose anyway, this
change is still the thing that stops the next run producing the same orphan.

## What changed

The row-level `decomposition` accumulator becomes a **per-block** one, at the
same grain as the `blocksTask` / `blocksNet` / `blocksInPage` arrays it now sits
beside, and it is written into the dataset as sums plus the `n` that produced
them — the reduced quantity, not a derived statistic.

The row the report prints is now a fold (`foldDecomposition`) over those stored
blocks rather than a second, separate accumulation. That is the point of doing
it per-block rather than adding a row-level lump: there is **one** collected
quantity, and the console mean, the file, and the page's ratio are all functions
of it. Addition is associative, so the fold reproduces the row exactly.

`foldDecomposition` **refuses** a row that carries no blocks rather than folding
to zeros. Every census dataset on main is exactly that row, and answering there
would hand a reader a plausible number for a split the file never recorded —
the defect wearing a fix's face.

## The re-run is NOT part of this PR

**Capture alone changes nothing today, and that is deliberate.** The four
committed datasets (`censusclock-{2rtt6-56, 6c237, cno31, y1jkm}`) still lack
the fields, so the cited split becomes recomputable on the **next canonical
run** — not on this commit. That re-run is measurement-coupled, it rides the
matched-workload window described on rf2-jo60g and rf2-jv36i, and it **still
awaits a quiet window from the operator**. It is not in this PR.

**No measurement was taken for this PR.** The census driver was never run. The
write path is exercised hermetically on a fixture row, the way the sibling
exit-path tests do.

## Quality gates

All foreground, all to completion, exit codes as printed by the runner itself.

| command | result | exit |
| --- | --- | --- |
| `node --check implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs` | ok | **0** |
| `node --check implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs` | ok | **0** |
| `node implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs` | `137 passed` | **0** |
| `cd implementation && npm run test:script-helpers` | full chain green; `clock_exit_path.test.cjs: 137 passed` | **0** |
| `cd implementation && npm run test:cljs` | `Ran 12776 tests containing 64098 assertions. 0 failures, 0 errors.` | **0** |
| `sh scripts/test-fast-pr.sh` | `PASS fast PR spine`, 61 steps; JVM core `2233 tests / 11645 assertions, 0 failures`; JVM freehand `1291 tests / 8874 assertions, 0 failures`; CLJS node `12776 tests / 64098 assertions, 0 failures` | **0** |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | `No beads-database paths in this PR diff.` | **0** |

**The count is load-bearing, and so is the mutation proof.**

- Baseline: `origin/main`'s copy of `clock_exit_path.test.cjs`, run against this
  branch's driver, gives `133 passed` (exit 0) — so the four new checks are
  additive and the pre-existing 133 still hold under the refactor.
- Mutation: renaming the new field in `datasetFor` (`blocksDecomp` →
  `blocksDecompDROPPED`) turns the suite red — `2/137 failed`, **exit 1**, the
  two failures being *"the split was collected and then dropped at write time"*
  and *"…is NOT recomputable from it…"*. The tests fail without the persistence,
  which is the substance of this bead.

The four new hermetic checks, on a fixture row, no browser and no build:

1. the split reaches the written dataset, at the same block grain as
   `blocksTask` beside it;
2. **the page's cited feed-row figures recompute from the serialised JSON
   alone** — 2.06× / 1.85× / 2.3× come back out. The fixture's per-block sums
   differ deliberately, so a fold that read one block, or averaged the blocks'
   means, cannot pass;
3. a row without the split refuses rather than folding to zeros;
4. every committed census dataset either carries the split or refuses to
   answer — which stays true across the re-run rather than becoming a landmine
   for it.

**One environmental note, stated plainly.** The spine's first invocation exited
**1** on `CLJS node integration` with `could not resolve shadow-cljs: Cannot
find module 'shadow-cljs/cli/runner.js'` — a fresh worktree with no
`implementation/node_modules`, not a regression: the diff is two node `.cjs`
harness files and cannot reach CLJS compilation. `node_modules` was provided and
the whole spine re-run end-to-end to `PASS`, exit **0**; that is the run tabled
above. Both mayor `node_modules` canaries were re-checked after the junction was
removed and are unchanged (101/103 and 59/61).

Not run by this spine, in its own words: documentation gates (surface
unchanged), the JVM artefact suites the diff does not touch, and the browser /
bundle-isolation / perf / Xray / mcp-conformance lanes that are CI-only.
