### PR TITLE
fix(hicasso): the clock driver must serialize every verdict its readjudicator gates on (rf2-e87sk)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -1202,10 +1202,20 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
 
   t('the driver exposes its decision and does not drive itself on require', () => {
     assert.ok(MAIN.length > 0, 'the driver must expose its run as `main`');
-    assert.match(
-      SRC,
-      /module\.exports = \{ reportability, rowAdjudication, rowRegime, ROW_REGIME, reportabilitySelfTest \};/
-    );
+    // The decision's four seats, plus the write path's two (rf2-e87sk) — a
+    // serialiser nothing can require is a serialiser nothing can drive.
+    for (const name of [
+      'reportability',
+      'rowAdjudication',
+      'rowRegime',
+      'ROW_REGIME',
+      'reportabilitySelfTest',
+      'publication',
+      'datasetFor',
+      'PUBLISHED_DEPTH',
+    ]) {
+      assert.match(SRC, new RegExp(`module\\.exports = \\{[^}]*\\b${name}\\b`), `\`${name}\` must be exported`);
+    }
     assert.match(SRC, /if \(require\.main === module\) \{\s*main\(\);/);
   });
 
@@ -1794,6 +1804,255 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     assert.match(RJSRC, /It does not select runs\./);
     const body = RJSRC.slice(RJSRC.indexOf('function main(argv)'));
     assert.match(body, /runs\.forEach\(\(\{ file, row \}, i\) => \{/);
+  });
+}
+
+// --- THE PRODUCER HALF: clock_run.cjs must WRITE every verdict it is gated on
+//
+// rf2-e87sk, the other half of rf2-emvod. The roster above refuses on ABSENT
+// as well as on failed, which is right — a gate that passes when its evidence
+// is missing is the fail-open this lane keeps finding — and four of its
+// thirteen gates named verdicts `clock_run.cjs` COMPUTED, PRINTED and EXITED
+// ON and then did not store: `canonical`, `pageErrors`, `parityOk` and
+// `etVerdict`. So no dataset in the tree could be reportable on those axes,
+// and a measurement window would have produced correctly-unreportable
+// evidence.
+//
+// THE TWO CLAIMS THIS BLOCK MAKES, and they pull against each other, which is
+// the point:
+//
+//   1. A dataset the CURRENT serialiser writes satisfies every one of the
+//      thirteen gates. Without this the repair could be "the field is there
+//      somewhere" rather than "the consumer accepts it".
+//   2. Erase any one of those fields from that same freshly written record and
+//      its gate refuses again. Without this the repair could have been made by
+//      loosening the gate, which is the fail-open wearing the fix's clothes.
+//
+// Both are driven over `GATES` rather than over a hand-written list, so a gate
+// added to the roster with no producer field fails the first assertion instead
+// of shipping as a gate no dataset can satisfy — the exact fault this bead is.
+
+{
+  const { datasetFor, publication, PUBLISHED_DEPTH } = require('./clock_run.cjs');
+  const { GATES, refusals, reportable } = require('./clock_readjudicate.cjs');
+  const RJ = path.join(__dirname, 'clock_readjudicate.cjs');
+  const t = (what, fn) => test(`clock_run.cjs -> clock_readjudicate.cjs: ${what}`, fn);
+
+  const ADJ = { unadjudicated: false, band: 0.21, why: 'margin 34.8% clears the band 21.4%' };
+  const BARS = { 'hicasso / reagent-subs': ADJ };
+
+  /**
+   * ONE OUTCOME AS `runRow` AND `report` HAND IT TO THE WRITE PATH, at every
+   * gate's passing value. Hermetic on purpose: reaching the real thing needs
+   * an `:advanced` build and a headless Chromium, and no measurement window is
+   * spent on a serialisation test.
+   */
+  const outcome = (outOver, verdictOver) => ({
+    out: {
+      rowId: 'bulk300',
+      rounds: [],
+      roundsTask: [],
+      roundsLayout: [],
+      inPageRounds: [],
+      granularity: [0.146],
+      decomposition: {
+        'reagent-subs/plumb': { n: 60, task: 36, taskNet: 12, devtools: 24, script: 0.06, layout: 5 },
+        'reagent-subs/floor': { n: 60, task: 360, taskNet: 280, devtools: 80, script: 0.06, layout: 40 },
+        'reagent-subs/reagent-subs': { n: 60, task: 600, taskNet: 280, devtools: 320, script: 0.06, layout: 60 },
+        'hicasso/hicasso': { n: 60, task: 780, taskNet: 320, devtools: 460, script: 0.06, layout: 70 },
+      },
+      // THE FOUR, at the producer's own internal names.
+      pageErrors: [],
+      armPlan: { 'ctl-3pt-2d': 200 },
+      sabotage: null,
+      sentKeys: null,
+      eventTiming: null,
+      census: null,
+      kbShape: null,
+      ...outOver,
+    },
+    verdict: {
+      seam: { band: 0.06, verdict: { ceilingBreached: false } },
+      seamTask: { band: 0.05, ceilingBreached: false, rows: BARS },
+      tally: { writes: 1008, unverified: 0 },
+      ctlVerdict: { ok: true },
+      ctl3: null,
+      ctl3Net: null,
+      ctl3Layout: null,
+      ctl3Parity: null,
+      constants: null,
+      guardVerdict: { refuse: false },
+      guardVerdictTask: { refuse: false },
+      parityOk: true,
+      bar: { 'hicasso / reagent-subs': { tared: { mean: 1.1 } } },
+      inPageBar: { 'hicasso / reagent-subs': { mean: 1.2 } },
+      barTask: { 'hicasso / reagent-subs': { mean: 1.3, min: 1.2, max: 1.4 } },
+      ctlTask: { ok: true, measured: { mean: 1.9 } },
+      bandTask: 0.05,
+      etVerdict: null,
+      kbVerdict: null,
+      ...verdictOver,
+    },
+  });
+
+  /** What the driver would write for a full-shape run of that outcome. */
+  const produce = (outOver, verdictOver) =>
+    datasetFor([outcome(outOver, verdictOver)], {
+      chromium: '147.0.0.0',
+      publication: publication({ depthPublished: true, tare: true }),
+    });
+
+  // --- 1. THE FOUR, BY NAME ------------------------------------------------
+
+  t('rf2-e87sk: the four verdicts no dataset could carry are in the record', () => {
+    const rec = produce();
+    assert.strictEqual(rec.canonical, true, 'the file must state whether it is the published evidence set');
+    assert.ok('notCanonicalWhy' in rec, 'and carry the reason seat even when there is no reason');
+    assert.deepStrictEqual(rec.rows[0].pageErrors, [], 'whether the page threw must be IN the file');
+    assert.strictEqual(rec.rows[0].parityOk, true, 'and whether the arms built the same page');
+    assert.ok('etVerdict' in rec.rows[0], 'and the Event-Timing verdict, `null` included — null is a verdict');
+  });
+
+  t('each of the four is COPIED off the verdict, never defaulted to a passing value', () => {
+    // A serialiser that wrote `pageErrors: []` unconditionally would satisfy
+    // the gate on a run that threw, which is the fail-open one layer down.
+    const rec = produce(
+      { pageErrors: ['TypeError: undefined is not a function'] },
+      { parityOk: false, etVerdict: { ok: false, predicted: 1, measured: 3 } }
+    );
+    assert.deepStrictEqual(rec.rows[0].pageErrors, ['TypeError: undefined is not a function']);
+    assert.strictEqual(rec.rows[0].parityOk, false);
+    assert.deepStrictEqual(rec.rows[0].etVerdict, { ok: false, predicted: 1, measured: 3 });
+    assert.strictEqual(reportable(rec.rows[0], rec), false, 'and a record carrying them is refused');
+    for (const want of [
+      /the page THREW during the run/,
+      /canonical-DOM gate found arms building DIFFERENT PAGES/,
+      /Event-Timing witness REFUSED/,
+    ]) {
+      assert.ok(refusals(rec.rows[0], rec).some((w) => want.test(w)), `no refusal matched ${want}`);
+    }
+  });
+
+  // --- 2. EVERY GATE, SATISFIED THEN ERASED --------------------------------
+  //
+  // The eraser is per gate rather than per field name because two gates read
+  // one object (`seamTask` carries both the task ceiling and the bar set), and
+  // a table keyed by field could not say which of them a deletion tests.
+
+  const ERASE = {
+    canonical: (rec) => delete rec.canonical,
+    'page-errors': (rec) => delete rec.rows[0].pageErrors,
+    'guard-net': (rec) => delete rec.rows[0].guardRefuse,
+    'guard-task': (rec) => delete rec.rows[0].guardRefuseTask,
+    'canonical-dom': (rec) => delete rec.rows[0].parityOk,
+    'ctl3-parity': (rec) => delete rec.rows[0].ctl3Parity,
+    'keystroke-witness': (rec) => delete rec.rows[0].kbWitness,
+    unverified: (rec) => delete rec.rows[0].tally,
+    'ceiling-net': (rec) => delete rec.rows[0].seam,
+    'ceiling-task': (rec) => delete rec.rows[0].seamTask.ceilingBreached,
+    control: (rec) => delete rec.rows[0].ctl3,
+    'event-timing': (rec) => delete rec.rows[0].etVerdict,
+    adjudication: (rec) => delete rec.rows[0].seamTask.rows,
+  };
+
+  t('every gate in the roster has a producer field — a gate no dataset can satisfy is this bead', () => {
+    assert.deepStrictEqual(GATES.map((g) => g.id), Object.keys(ERASE), 'GATES and the erasures must agree, in order');
+  });
+
+  t('THE WHOLE ROSTER IS SATISFIABLE by a freshly written dataset — all thirteen', () => {
+    const rec = produce();
+    assert.deepStrictEqual(refusals(rec.rows[0], rec), [], 'a full-shape clean run must clear every gate');
+    assert.strictEqual(reportable(rec.rows[0], rec), true);
+  });
+
+  for (const g of GATES) {
+    t(`gate \`${g.id}\`: the record SATISFIES it, and erasing the field REFUSES again`, () => {
+      const ask = (rec) => (g.scope === 'dataset' ? g.why(rec) : g.why(rec.rows[0]));
+      const green = produce();
+      assert.strictEqual(ask(green), null, `the serialiser must write what \`${g.id}\` reads`);
+
+      const red = produce();
+      ERASE[g.id](red);
+      const why = ask(red);
+      assert.ok(
+        typeof why === 'string' && why.length > 0,
+        `erasing \`${g.id}\`'s field must refuse — absent is not clean, and a fix that made it clean ` +
+          `would be the fail-open this gate exists to prevent`
+      );
+      assert.strictEqual(reportable(red.rows[0], red), false, 'and the run may not be pooled into the published mean');
+    });
+  }
+
+  // --- 3. AND THE PROGRAM A READER ACTUALLY RUNS ---------------------------
+
+  t('THE COMMAND accepts a freshly written dataset and pools it — end to end, on a file', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rf2-e87sk-'));
+    const f = path.join(dir, 'run1.json');
+    fs.writeFileSync(f, JSON.stringify(produce()));
+    const r = cp.spawnSync(process.execPath, [RJ, f], { encoding: 'utf8' });
+    fs.rmSync(dir, { recursive: true, force: true });
+    const out = `${r.stdout}${r.stderr}`;
+    assert.strictEqual(r.status, 0, out);
+    assert.match(out, /reportable subset 1\.3000x n=1/);
+    assert.match(out, /— reportable: every gate this dataset serialises is clean/);
+  });
+
+  // --- 4. THE SHAPE VERDICT ------------------------------------------------
+  //
+  // `publication` answers "is this file the published evidence set", and the
+  // one thing it must never do is answer yes by default. Every narrowing gets
+  // a case and each names itself, because a refusal without a reason is
+  // indistinguishable from a run that was selected away.
+
+  const full = { rowsOnly: null, noBuild: false, depthPublished: true, tare: true, sabotage: null };
+
+  t('a full-shape run IS canonical — the verdict is not vacuous', () => {
+    assert.deepStrictEqual(publication(full), { canonical: true, why: null });
+  });
+
+  t('the published depth is the design every table on this lane was taken at', () => {
+    assert.deepStrictEqual(PUBLISHED_DEPTH, { rounds: 6, warmup: 4, samples: 10 });
+  });
+
+  for (const [what, over, why] of [
+    ['a PARTIAL row set', { rowsOnly: 'keystroke' }, /a PARTIAL row set \(HCLOCK_ONLY=keystroke\)/],
+    ['--no-build', { noBuild: true }, /--no-build/],
+    ['an overridden depth', { depthPublished: false }, /an OVERRIDDEN design depth/],
+    ['the tare off', { tare: false }, /the tare DISABLED \(HCLOCK_TARE=off\)/],
+    ['a falsification run', { sabotage: 140 }, /a FALSIFICATION run \(HCLOCK_CTL3_SABOTAGE=140\)/],
+  ]) {
+    t(`${what} is NOT the published evidence set, and the file says why`, () => {
+      const p = publication({ ...full, ...over });
+      assert.strictEqual(p.canonical, false);
+      assert.match(p.why, why);
+      // and the consumer refuses it by that same sentence.
+      const rec = { ...produce(), canonical: p.canonical, notCanonicalWhy: p.why };
+      assert.strictEqual(reportable(rec.rows[0], rec), false);
+      assert.ok(refusals(rec.rows[0], rec).some((w) => /NOT the published evidence set/.test(w)));
+    });
+  }
+
+  t('an absent shape record is NOT canonical either — the producer fails closed too', () => {
+    assert.strictEqual(publication(undefined).canonical, false);
+    assert.match(publication({}).why, /an OVERRIDDEN design depth/);
+  });
+
+  t('every narrowing is named at once, not the first — the same rule the refusals follow', () => {
+    const p = publication({ rowsOnly: 'M1', noBuild: true, depthPublished: false, tare: false, sabotage: 140 });
+    assert.strictEqual(p.why.split('; ').length, 5, p.why);
+  });
+
+  // --- 5. THE WIRING, so none of the above is decorative -------------------
+
+  t('the driver writes what `datasetFor` returns, and derives the shape from its own knobs', () => {
+    const SRC = fs.readFileSync(path.join(__dirname, 'clock_run.cjs'), 'utf8');
+    const MAIN = SRC.slice(SRC.indexOf('async function main()'), SRC.indexOf('\nmodule.exports'));
+    assert.match(MAIN, /const pub = publication\(runShape\(\)\);/);
+    assert.match(MAIN, /datasetFor\(outcomes, \{ chromium: version, publication: pub \}\)/);
+    // The serialiser lives OUTSIDE `main` — it names refusal fields, and
+    // inside `main` those names are both invariant-breaking and undrivable.
+    assert.ok(!/pageErrors: o\.out\.pageErrors/.test(MAIN), 'the serialiser must not have grown back inside `main`');
+    assert.match(SRC.slice(0, SRC.indexOf('async function main()')), /function datasetFor\(outcomes, meta\) \{/);
   });
 }
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
@@ -46,16 +46,18 @@
 // the published mean. `GATES` below is that exit path, read back off the
 // serialised record, fail-closed at every seat: **absent is not clean.**
 //
-// THREE OF THE DRIVER'S FATAL CHECKS ARE NOT SERIALISED YET, and they are
-// named here rather than skipped, because skipping one is how this file came
-// to need repairing twice. `clock_run.cjs` computes `pageErrors`, `parityOk`
-// (the canonical-DOM gate) and `etVerdict` (Event Timing) and exits 1 on each,
-// but stores none of them, so no dataset in the tree today can satisfy this
-// filter — which is the correct fail-closed reading of an INCOMPLETE record
-// and not a defect in it. The producer half adopts the family policy when
-// `clock_run.cjs` is next touched (`rf2-2rtt6.31`, "record once, converge on
-// touch"); the field names below are its own internal names so that adoption
-// is one line per verdict.
+// THREE OF THE DRIVER'S FATAL CHECKS WERE NOT SERIALISED WHEN THIS ROSTER WAS
+// WRITTEN, and they were named here rather than skipped, because skipping one
+// is how this file came to need repairing twice. `clock_run.cjs` computed
+// `pageErrors`, `parityOk` (the canonical-DOM gate) and `etVerdict` (Event
+// Timing) and exited 1 on each while storing none of them, so no dataset in
+// the tree could satisfy this filter — the correct fail-closed reading of an
+// INCOMPLETE record, and not a defect in it. Naming them at the driver's OWN
+// internal field names is what made the producer half one line per verdict,
+// and `rf2-e87sk` wrote those lines: `clock_run.cjs`'s `datasetFor` stores all
+// three now, and its `publication` writes the two-tier `canonical` verdict
+// beside them. Datasets taken before that repair still fail these gates, which
+// is exactly what an incomplete record should do.
 //
 // ## THE ADDITIVE RESIDUAL, and why it is computed here
 //

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
@@ -2466,6 +2466,180 @@ function reportabilitySelfTest() {
 
 // ---------------------------------------------------------------------------
 
+/**
+ * THE DESIGN DEPTH EVERY PUBLISHED TABLE ON THIS LANE WAS TAKEN AT. The knobs
+ * exist so a reader can probe the instrument cheaply; a probe is not the
+ * published shape, and `publication` below is where that distinction is made.
+ */
+const PUBLISHED_DEPTH = { rounds: 6, warmup: 4, samples: 10 };
+
+/**
+ * IS THIS FILE THE PUBLISHED EVIDENCE SET? (rf2-2rtt6.31, rf2-e87sk)
+ *
+ * The family's two-tier write policy splits CAPTURE from PUBLICATION: every
+ * completed measurement is preserved, and only a run of the full published
+ * shape is eligible published evidence. A dataset says which it is IN THE
+ * FILE, because the directory a file was found in is exactly what it loses
+ * when it is copied — and `clock_readjudicate.cjs`'s first gate refuses a file
+ * that does not say, because absent is not a pass.
+ *
+ * WHAT THIS ANSWERS, AND WHAT IT DELIBERATELY DOES NOT. This is the SHAPE
+ * verdict: was the run the published design, over every row, against a bundle
+ * built from this tree, with no falsification knob set and the tare on? It is
+ * NOT the run's own verdict. Every gate this driver exits on is serialised per
+ * row by `datasetFor` below and re-adjudicated by the readjudicator's twelve
+ * ROW gates, so folding them in here would be a second seat deciding what one
+ * seat already decides — the fault this driver's exit path was rebuilt to
+ * remove. Shape here, run there; the two together are the filter.
+ *
+ * Pure over a flat record, for the reason `reportability` is: the write path
+ * is then checkable without a release build and a headless Chromium.
+ */
+function publication(shape) {
+  const s = shape || {};
+  const why = [];
+  if (s.rowsOnly) why.push(`a PARTIAL row set (HCLOCK_ONLY=${s.rowsOnly})`);
+  if (s.noBuild) why.push("--no-build (the bundle on disk is not known to be this tree's)");
+  if (!s.depthPublished) why.push('an OVERRIDDEN design depth');
+  if (!s.tare) why.push('the tare DISABLED (HCLOCK_TARE=off)');
+  if (s.sabotage) why.push(`a FALSIFICATION run (HCLOCK_CTL3_SABOTAGE=${s.sabotage})`);
+  return why.length === 0 ? { canonical: true, why: null } : { canonical: false, why: why.join('; ') };
+}
+
+/** This process's own shape, in the flat form `publication` reads. */
+function runShape() {
+  return {
+    rowsOnly: ONLY || null,
+    noBuild: NO_BUILD,
+    depthPublished:
+      ROUNDS === PUBLISHED_DEPTH.rounds && WARMUP === PUBLISHED_DEPTH.warmup && SAMPLES === PUBLISHED_DEPTH.samples,
+    tare: TARE,
+    sabotage: CTL3_SABOTAGE,
+  };
+}
+
+/**
+ * THE RUN'S DATASET — the raw readings, and EVERY verdict this driver exits
+ * on, so a reader holding the file can re-adjudicate the run instead of
+ * trusting it.
+ *
+ * LIFTED OUT OF `main`, in `shapes/census_clock_run.cjs`'s idiom and for its
+ * reason. Serialising a row means naming its refusal fields — `pageErrors`,
+ * `guardRefuse`, `parityOk`, `ceilingBreached` — and `main` is held to an
+ * invariant that nothing downstream of the decision may name one
+ * (`clock_exit_path.test.cjs`, the check that stops a second exit path growing
+ * back). A serialiser inside `main` is also a serialiser no test can drive,
+ * because reaching it needs an `:advanced` build and a headless Chromium.
+ * Recording is not deciding, and this is where that shows: every field below
+ * is COPIED off the object the report printed, never recomputed.
+ *
+ * rf2-e87sk IS THE FOUR FIELDS THAT WERE MISSING. `clock_readjudicate.cjs`
+ * carries thirteen gates in this driver's own order, each read off the
+ * serialised record and each fail-closed on ABSENT as well as on failed. Four
+ * of them — `canonical`, `pageErrors`, `parityOk`, `etVerdict` — named
+ * verdicts this driver computed, printed and exited on, and then did not
+ * store. The consumer was right to refuse and no dataset in the tree could be
+ * reportable on those axes: an incomplete record read correctly, not a defect
+ * in the reader. They are stored now, and the erasure cases in
+ * `clock_exit_path.test.cjs` hold each gate closed against their loss.
+ */
+function datasetFor(outcomes, meta) {
+  const pub = (meta && meta.publication) || {};
+  return {
+    label: process.env.HCLOCK_LABEL || null,
+    load: process.env.HCLOCK_LOAD === undefined ? null : Number(process.env.HCLOCK_LOAD),
+    chromium: meta && meta.chromium,
+    node: process.version,
+    when: new Date().toISOString(),
+    // WHETHER THIS FILE IS THE PUBLISHED EVIDENCE, recorded IN the file — a
+    // dataset that travels out of its directory must still say what it is.
+    canonical: pub.canonical,
+    notCanonicalWhy: pub.why,
+    design: { rounds: ROUNDS, warmup: WARMUP, samples: SAMPLES, tare: TARE, segments: SEGMENTS },
+    rows: outcomes.map((o) => ({
+      rowId: o.out.rowId,
+      // Raw per-sample task-time readings, [round][segment][arm].
+      // Everything the seam decomposition needs is derived from
+      // these; the segment's POSITION in a round is
+      // `(SEGMENTS.indexOf(seg) - round) mod 3` by construction.
+      rounds: o.out.rounds,
+      // THE PUBLISHED CLOCK'S OWN RAW READINGS, and the in-page
+      // window's, on the same samples. Only `rounds` (taskNet) was
+      // ever written, so a dataset from this driver could not
+      // recompute the figure the page actually quotes — which is the
+      // durable-evidence gap `rf2-cvvb7`'s merged-PR audit recorded
+      // against the seam study. All three windows are here now, so
+      // every table in `the-candidates-clock.md` is reproducible from
+      // the file without re-running the box.
+      roundsTask: o.out.roundsTask,
+      inPageRounds: o.out.inPageRounds,
+      decomposition: o.out.decomposition,
+      granularity: o.out.granularity,
+      // DID THE PAGE THROW? The driver exits 1 on a non-empty list and stored
+      // none of it, so every figure a reader recomputed from an older dataset
+      // was taken on a page that may already have thrown (rf2-e87sk).
+      pageErrors: o.out.pageErrors,
+      seam: o.verdict.seam,
+      seamTask: o.verdict.seamTask,
+      tally: o.verdict.tally,
+      ctlOk: o.verdict.ctlVerdict ? o.verdict.ctlVerdict.ok : null,
+      // THE THREE-POINT CONTROL, whole — its per-block readings, the
+      // absolutes each difference was taken from, the fitted line and
+      // the constant it recovers. `armPlan` is the page's DECLARED
+      // plan and `sabotage` is what the 2D arm actually rendered, so a
+      // dataset carries the evidence that a falsification run was a
+      // falsification run rather than a measurement.
+      ctl3: o.verdict.ctl3,
+      ctl3Net: o.verdict.ctl3Net,
+      ctl3Layout: o.verdict.ctl3Layout,
+      roundsLayout: o.out.roundsLayout,
+      ctl3Parity: o.verdict.ctl3Parity,
+      constants: o.verdict.constants,
+      armPlan: o.out.armPlan,
+      sabotage: o.out.sabotage,
+      guardRefuse: o.verdict.guardVerdict.refuse,
+      guardRefuseTask: o.verdict.guardVerdictTask.refuse,
+      // DID THE ARMS BUILD THE SAME PAGE? The canonical-DOM gate — a ratio
+      // between two different pages is not a ratio, the driver exits 1 on it,
+      // and it too went unstored (rf2-e87sk).
+      parityOk: o.verdict.parityOk,
+      bar: o.verdict.bar,
+      inPageBar: o.verdict.inPageBar,
+      ctl: o.verdict.ctlVerdict,
+      barTask: o.verdict.barTask,
+      ctlTask: o.verdict.ctlTask,
+      bandTask: o.verdict.bandTask,
+      // THE EVENT-TIMING WITNESS'S VERDICT, which adjudicates the
+      // responsiveness regime (rf2-swwud) and reaches the exit code through
+      // `ctlOk` in the summary below. `null` on every row that has no
+      // keystroke, which is a verdict — the field is present and says so.
+      etVerdict: o.verdict.etVerdict,
+      // THE KEYSTROKE ROW'S RAW ACCOUNTING. `sentKeys` is what the
+      // driver pressed, `eventTiming` is what the browser reported and
+      // `census` is what recomputed — so the published records, the
+      // censored count and the localisation can all be recomputed from
+      // the file without re-running the box, which is what the seam
+      // study's merged-PR audit asked of every row here.
+      sentKeys: o.out.sentKeys,
+      eventTiming: o.out.eventTiming,
+      census: o.out.census,
+      kbShape: o.out.kbShape,
+      kbWitness: o.verdict.kbVerdict
+        ? {
+            ok: o.verdict.kbVerdict.ok,
+            faults: o.verdict.kbVerdict.faults,
+            totals: o.verdict.kbVerdict.totals,
+            perArm: o.verdict.kbVerdict.perArm,
+            records: o.verdict.kbVerdict.records,
+            censored: o.verdict.kbVerdict.censored,
+          }
+        : null,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+
 async function main() {
   // THE ADJUDICATORS' SELF-TESTS, and they run before anything is built or
   // launched. `ctl3SelfTest` is the one that matters for this driver's new
@@ -2614,89 +2788,20 @@ async function main() {
   }
 
   if (JSON_OUT) {
+    // THE SHAPE VERDICT, announced as well as stored. A run that narrowed the
+    // design or skipped the build still writes its file — capture is not
+    // publication — but nothing downstream should have to infer which it was
+    // from the path the operator chose.
+    const pub = publication(runShape());
     fs.mkdirSync(path.dirname(path.resolve(JSON_OUT)), { recursive: true });
     fs.writeFileSync(
       path.resolve(JSON_OUT),
-      JSON.stringify(
-        {
-          label: process.env.HCLOCK_LABEL || null,
-          load: process.env.HCLOCK_LOAD === undefined ? null : Number(process.env.HCLOCK_LOAD),
-          chromium: version,
-          node: process.version,
-          when: new Date().toISOString(),
-          design: { rounds: ROUNDS, warmup: WARMUP, samples: SAMPLES, tare: TARE, segments: SEGMENTS },
-          rows: outcomes.map((o) => ({
-            rowId: o.out.rowId,
-            // Raw per-sample task-time readings, [round][segment][arm].
-            // Everything the seam decomposition needs is derived from
-            // these; the segment's POSITION in a round is
-            // `(SEGMENTS.indexOf(seg) - round) mod 3` by construction.
-            rounds: o.out.rounds,
-            // THE PUBLISHED CLOCK'S OWN RAW READINGS, and the in-page
-            // window's, on the same samples. Only `rounds` (taskNet) was
-            // ever written, so a dataset from this driver could not
-            // recompute the figure the page actually quotes — which is the
-            // durable-evidence gap `rf2-cvvb7`'s merged-PR audit recorded
-            // against the seam study. All three windows are here now, so
-            // every table in `the-candidates-clock.md` is reproducible from
-            // the file without re-running the box.
-            roundsTask: o.out.roundsTask,
-            inPageRounds: o.out.inPageRounds,
-            decomposition: o.out.decomposition,
-            granularity: o.out.granularity,
-            seam: o.verdict.seam,
-            seamTask: o.verdict.seamTask,
-            tally: o.verdict.tally,
-            ctlOk: o.verdict.ctlVerdict ? o.verdict.ctlVerdict.ok : null,
-            // THE THREE-POINT CONTROL, whole — its per-block readings, the
-            // absolutes each difference was taken from, the fitted line and
-            // the constant it recovers. `armPlan` is the page's DECLARED
-            // plan and `sabotage` is what the 2D arm actually rendered, so a
-            // dataset carries the evidence that a falsification run was a
-            // falsification run rather than a measurement.
-            ctl3: o.verdict.ctl3,
-            ctl3Net: o.verdict.ctl3Net,
-            ctl3Layout: o.verdict.ctl3Layout,
-            roundsLayout: o.out.roundsLayout,
-            ctl3Parity: o.verdict.ctl3Parity,
-            constants: o.verdict.constants,
-            armPlan: o.out.armPlan,
-            sabotage: o.out.sabotage,
-            guardRefuse: o.verdict.guardVerdict.refuse,
-            guardRefuseTask: o.verdict.guardVerdictTask.refuse,
-            bar: o.verdict.bar,
-            inPageBar: o.verdict.inPageBar,
-            ctl: o.verdict.ctlVerdict,
-            barTask: o.verdict.barTask,
-            ctlTask: o.verdict.ctlTask,
-            bandTask: o.verdict.bandTask,
-            // THE KEYSTROKE ROW'S RAW ACCOUNTING. `sentKeys` is what the
-            // driver pressed, `eventTiming` is what the browser reported and
-            // `census` is what recomputed — so the published records, the
-            // censored count and the localisation can all be recomputed from
-            // the file without re-running the box, which is what the seam
-            // study's merged-PR audit asked of every row here.
-            sentKeys: o.out.sentKeys,
-            eventTiming: o.out.eventTiming,
-            census: o.out.census,
-            kbShape: o.out.kbShape,
-            kbWitness: o.verdict.kbVerdict
-              ? {
-                  ok: o.verdict.kbVerdict.ok,
-                  faults: o.verdict.kbVerdict.faults,
-                  totals: o.verdict.kbVerdict.totals,
-                  perArm: o.verdict.kbVerdict.perArm,
-                  records: o.verdict.kbVerdict.records,
-                  censored: o.verdict.kbVerdict.censored,
-                }
-              : null,
-          })),
-        },
-        null,
-        1
-      )
+      JSON.stringify(datasetFor(outcomes, { chromium: version, publication: pub }), null, 1)
     );
-    console.error(`[clock] raw readings -> ${path.resolve(JSON_OUT)}`);
+    console.error(
+      `[clock] raw readings -> ${path.resolve(JSON_OUT)}` +
+        (pub.canonical ? '' : `   (NOT the published evidence set — ${pub.why})`)
+    );
   }
 
   const errored = outcomes.filter((o) => o.out.pageErrors.length > 0);
@@ -2895,7 +3000,16 @@ async function main() {
   console.error('[clock] ok');
 }
 
-module.exports = { reportability, rowAdjudication, rowRegime, ROW_REGIME, reportabilitySelfTest };
+module.exports = {
+  reportability,
+  rowAdjudication,
+  rowRegime,
+  ROW_REGIME,
+  reportabilitySelfTest,
+  publication,
+  datasetFor,
+  PUBLISHED_DEPTH,
+};
 
 if (require.main === module) {
   main();


### PR DESCRIPTION
`clock_readjudicate.cjs` carries thirteen gates in `clock_run.cjs`'s own order,
each read off the serialised record and each refusing on **ABSENT** as well as
on failed. Four of them named verdicts the driver **computed, printed and
exited 1 on** and then did not store, so no dataset in the tree could ever be
reportable on those axes — an incomplete record read correctly, not a defect in
the reader. This is the producer half (`rf2-emvod` built the consumer half in
#7662 and put this explicitly out of its fence).

## The four verdicts, and where each is now written

| gate | field | written by |
| --- | --- | --- |
| `canonical` | `canonical` + `notCanonicalWhy` (dataset envelope) | `publication(runShape())`, then `datasetFor` |
| `page-errors` | `rows[].pageErrors` | `datasetFor`, copied from `o.out.pageErrors` |
| `canonical-dom` | `rows[].parityOk` | `datasetFor`, copied from `o.verdict.parityOk` |
| `event-timing` | `rows[].etVerdict` | `datasetFor`, copied from `o.verdict.etVerdict` |

**All thirteen gates are now satisfiable by a freshly written dataset** — driven
in the test over `GATES` itself, not over a hand-written list, so a gate added
to the roster with no producer field fails there instead of shipping as a gate
no dataset can satisfy.

### Two structural notes

**The serialiser moved out of `main` into a pure `datasetFor`**, in
`shapes/census_clock_run.cjs`'s idiom and for its stated reason: serialising a
row means naming its refusal fields, `main` is held to an invariant that nothing
downstream of the decision may read one, and a serialiser inside `main` is one
no test can drive (reaching it needs an `:advanced` build and a headless
Chromium). The write itself stays exactly where it was — before the fatal
checks — so a refused run still writes its file. Capture is not publication.

**`publication()` is the SHAPE verdict, deliberately not the run's own.** It
refuses a partial row set, `--no-build`, an overridden design depth, `TARE=off`
and `HCLOCK_CTL3_SABOTAGE`, each named. It does **not** fold in the run's
per-row refusals, because the readjudicator's twelve row gates re-adjudicate
every one of those off this same record; folding them in would be a second seat
deciding what one seat already decides.

## The absent-field refusal, red then green

The repair must not quietly turn "absent" into "pass" — that would convert a
correct fail-closed gate into the exact fail-open it was built to prevent. Three
independent demonstrations:

**1. The new tests are red against the pre-change producer.** `git checkout
origin/main -- clock_run.cjs`, then the witness:

```
node implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
  -> clock_exit_path.test.cjs: 28/221 failed          exit 1
```

**2. Each gate is satisfied by the produced record and refuses when its field is
erased from that same record.** One case per gate, generated from `GATES`:

```
gate `canonical`:      the record SATISFIES it, and erasing the field REFUSES again
gate `page-errors`:    the record SATISFIES it, and erasing the field REFUSES again
gate `canonical-dom`:  the record SATISFIES it, and erasing the field REFUSES again
gate `event-timing`:   the record SATISFIES it, and erasing the field REFUSES again
   ... and the other nine
```

**3. Those erasure cases are not vacuous — a mutation proof.** Each of the four
gates' absent-branch was temporarily rewritten to return `null` (pass) and the
suite re-run. Every one was caught, by the new case *and* by `rf2-emvod`'s
existing absent case:

```
=== MUTATED gate `canonical` to PASS on absent -> test exit 1
   FAIL  clock_readjudicate.cjs: gate `canonical`: an ABSENT verdict removes it too — absent is not clean
   FAIL  clock_readjudicate.cjs: a row cannot vouch for the file it came from — no envelope is a refusal
   FAIL  clock_run.cjs -> clock_readjudicate.cjs: gate `canonical`: the record SATISFIES it, and erasing the field REFUSES again

=== MUTATED gate `page-errors` to PASS on absent -> test exit 1
   FAIL  clock_readjudicate.cjs: gate `page-errors`: an ABSENT verdict removes it too — absent is not clean
   FAIL  clock_run.cjs -> clock_readjudicate.cjs: gate `page-errors`: the record SATISFIES it, and erasing the field REFUSES again

=== MUTATED gate `canonical-dom` to PASS on absent -> test exit 1
   FAIL  clock_readjudicate.cjs: gate `canonical-dom`: an ABSENT verdict removes it too — absent is not clean
   FAIL  clock_run.cjs -> clock_readjudicate.cjs: gate `canonical-dom`: the record SATISFIES it, and erasing the field REFUSES again

=== MUTATED gate `event-timing` to PASS on absent -> test exit 1
   FAIL  clock_readjudicate.cjs: gate `event-timing`: an ABSENT verdict removes it too — absent is not clean
   FAIL  clock_run.cjs -> clock_readjudicate.cjs: gate `event-timing`: the record SATISFIES it, and erasing the field REFUSES again

ALL FOUR MUTATIONS WERE CAUGHT
```

The mutation was reverted; the mutating script is a scratchpad throwaway and is
not in this diff.

Also proved: `datasetFor` **copies** each of the four rather than defaulting to a
passing value — a serialiser that wrote `pageErrors: []` unconditionally would
satisfy the gate on a run that threw. A record built from a throwing,
parity-failing, Event-Timing-refusing outcome carries all three faults and is
refused by name.

## NO MEASUREMENT WAS TAKEN

No benchmark run, no browser, no build of the bench lane. The write path is
exercised hermetically through the pure `datasetFor`, as
`clock_exit_path.test.cjs` already does for every other adjudicator on this
lane. The quiet window is untouched and is the operator's to spend.

No published figure, range or verdict is changed by this PR.

## Quality gates

All foreground, never piped, redirected to a worktree-local log; the exit code
below is the runner's own.

| command | result | exit |
| --- | --- | --- |
| `node --check implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs` | ok | **0** |
| `node --check implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs` | ok | **0** |
| `node --check implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs` | ok | **0** |
| `node …/clock_exit_path.test.cjs` **against `origin/main`'s producer** | `28/221 failed` | **1** (the red) |
| `node …/clock_exit_path.test.cjs` | `221 passed` (28 new cases) | **0** |
| mutation proof, four gates loosened one at a time | `ALL FOUR MUTATIONS WERE CAUGHT` | **0** |
| `npm run test:script-helpers` (from `implementation/`) | all suites pass; `clock_exit_path.test.cjs: 221 passed` | **0** |
| `sh scripts/test-fast-pr.sh` | `PASS fast PR spine` — CLJS `:node-test` build completed (2173 files, 0 warnings), `hicasso-compile` ok (136 lane namespaces, 0 warnings) | **0** |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | `No beads-database paths in this PR diff.` | **0** |

The `frame-inclusive` label guard (#7667) is in `clock_exit_path.test.cjs` and is
green — no line of this diff carries the adjective, and the guard is untouched.
`chrome_run.cjs` is not touched and remains outside the roster.

## Fence

`clock_run.cjs` and its witness `clock_exit_path.test.cjs`. No `spec/*`. Verified
free of every open PR before starting (`gh pr diff 7637 --name-only` was the only
open PR and touches none of these paths).

**One deliberate step just outside the stated fence**, disclosed: a
**comment-only** correction to `clock_readjudicate.cjs`'s header, which stated
that the driver "stores none of them, so no dataset in the tree today can
satisfy this filter". That was true when the roster was written and is false as
of this PR. No code, no gate, no behaviour changed — `git diff` on that file is
twelve comment lines.
