### PR TITLE
fix(docs): reagent-slim's Form-3 recipe must own its subscription per mount (rf2-iogzk)

### DIFF
--- a/implementation/adapters/reagent-slim/FORM-3.md
+++ b/implementation/adapters/reagent-slim/FORM-3.md
@@ -373,7 +373,11 @@ Three variations worth knowing:
   `activate!` runs that body once through `deref-capture`, so the first run is
   both the seed and the subscription to the sources, and every later change
   re-runs it on the ordinary batched drain (`reagent2.ratom/flush!`, which the
-  commit boundary performs) rather than inline inside the `app-db` write. Hold
+  commit boundary performs) rather than inline inside the `app-db` write. Write
+  the widget as though the feed lands on the following commit; the adapter's
+  `:flush-render!` happens to perform that drain itself, so under `dispatch-sync`
+  the widget is already current when the call returns, but do not build on it.
+  Hold
   the owner per mount and tear down in that order at unmount —
   `reagent2.ratom/dispose!` the owner **first**, then balance the acquire with
   frame-first `(rf/unsubscribe frame query-v)` — so the owner is gone before the

--- a/implementation/adapters/reagent-slim/FORM-3.md
+++ b/implementation/adapters/reagent-slim/FORM-3.md
@@ -237,8 +237,9 @@ deriving the value in render (pure, no state needed):
     [:div derived]))
 ```
 
-If memoisation is needed, wrap `compute` in `memoize` or a
-`(reagent2.core/track compute props)` track.
+If memoisation is needed, wrap `compute` in `memoize`, or move the derivation
+into a `reg-sub` and deref that in render. `reagent2.core/track` is **not**
+shipped — a cached derived value is what a sub already is.
 
 ---
 
@@ -355,16 +356,40 @@ Three variations worth knowing:
   captured `:subscribe` inside `:reagent-render`, never in a lifecycle callback
   (reactive reads have no owner there, and the scope has already unwound). The
   one disciplined exception is a rare imperative widget re-fed as a sub's value
-  changes from a hook rather than React's render commit: it captures the frame's
-  `:subscribe` in the outer callable, `add-watch`es the reaction under a
-  **per-mount** watch key (never a constant — equal `(frame, query-v)`
-  subscriptions share **one** cached reaction, so a constant key clobbers a
-  sibling instance's watch), and balances the acquire with frame-first
-  `(rf/unsubscribe frame query-v)` at unmount. That is the *only* lifecycle use
-  of the captured `:subscribe`; see
+  changes from a hook rather than React's render commit. It captures the frame's
+  `:subscribe` in the outer callable, acquires the reaction in
+  `:component-did-mount`, and — the step that is easy to miss — **owns** it there
+  with a per-mount reactive owner, because a subscription is not live merely for
+  having been handed to you. On this adapter a subscription *is* a bare
+  `reagent2.ratom/Reaction`, built deliberately without `:auto-run`, and a
+  Reaction learns its sources only through `deref-capture`; a deref taken in a
+  lifecycle hook runs the body raw and leaves `watching` nil, so the node ends up
+  in no watcher set. An `add-watch` on it is therefore a **trap** rather than a
+  shortcut — the watch is registered against a node that can never fire, so the
+  widget is fed once at mount and is deaf for the rest of its life, silently and
+  with no error. The owner is what supplies the missing capture, and reagent-slim
+  spells it with its own reactive primitives:
+  `(reagent2.ratom/activate! (reagent2.ratom/make-reaction (fn [] (feed! @!widget @reaction))))`.
+  `activate!` runs that body once through `deref-capture`, so the first run is
+  both the seed and the subscription to the sources, and every later change
+  re-runs it on the ordinary batched drain (`reagent2.ratom/flush!`, which the
+  commit boundary performs) rather than inline inside the `app-db` write. Hold
+  the owner per mount and tear down in that order at unmount —
+  `reagent2.ratom/dispose!` the owner **first**, then balance the acquire with
+  frame-first `(rf/unsubscribe frame query-v)` — so the owner is gone before the
+  cache slot is released and no feed can run against a destroyed widget. Equal
+  `(frame, query-v)` subscriptions share **one** cached reaction, but each mount
+  holds its own owner, so two instances are independent by construction: there is
+  nothing to key and no sibling watch to clobber. That is the *only* lifecycle
+  use of the captured `:subscribe`; see
   [`guided-handlers-state.md`](../../../skills/re-frame-migration/references/guided-handlers-state.md)
-  §M-11 for the copy-pasteable form. It does not weaken the default: ordinary
-  reactive reads still belong in `:reagent-render`, not a hook.
+  §M-11 for the fully worked form — take its **structure**, not its ops. M-11 is
+  written for the stock-Reagent adapter and reaches for `reagent.core/track!`,
+  which `reagent2.core` deliberately does not ship (see
+  [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md)); `activate!` + `make-reaction` +
+  `dispose!` is the reagent-slim spelling of the same ownership. It does not
+  weaken the default: ordinary reactive reads still belong in `:reagent-render`,
+  not a hook.
 
   **Capture-once is a locked handle — safe only when the mount's frame is
   invariant.** `(rf/capture-frame)` locks to the **one** frame that is live when

--- a/implementation/adapters/reagent-slim/FORM-3.md
+++ b/implementation/adapters/reagent-slim/FORM-3.md
@@ -377,8 +377,7 @@ Three variations worth knowing:
   the widget as though the feed lands on the following commit; the adapter's
   `:flush-render!` happens to perform that drain itself, so under `dispatch-sync`
   the widget is already current when the call returns, but do not build on it.
-  Hold
-  the owner per mount and tear down in that order at unmount —
+  Hold the owner per mount and tear down in that order at unmount —
   `reagent2.ratom/dispose!` the owner **first**, then balance the acquire with
   frame-first `(rf/unsubscribe frame query-v)` — so the owner is gone before the
   cache slot is released and no feed can run against a destroyed widget. Equal


### PR DESCRIPTION
Closes rf2-iogzk. Follow-up to rf2-ynved (PR #7664), whose fence covered five doc
surfaces + the drift gate + the test, and left this sixth one standing.

## What was wrong

`implementation/adapters/reagent-slim/FORM-3.md` still taught the **retired**
shape as the disciplined exception:

> it captures the frame's `:subscribe` in the outer callable, `add-watch`es the
> reaction under a **per-mount** watch key (never a constant …), and balances the
> acquire with frame-first `(rf/unsubscribe frame query-v)` at unmount. … see
> `guided-handlers-state.md` §M-11 for the copy-pasteable form.

Verified still present on `origin/main` before editing, and in no open PR
(`gh pr diff --name-only` across #7666, #7665, #7637 — none touches this file).

Two defects, both user-visible:

1. **The taught shape cannot work.** On this adapter a subscription *is* a bare
   `reagent2.ratom/Reaction` built without `:auto-run`
   (`re_frame/adapter/reagent_slim.cljs:37` → `ratom/make-reaction`), and a
   Reaction learns its sources only through `deref-capture`. A deref taken in a
   lifecycle hook runs the body raw and leaves `watching` nil, so the node is in
   no watcher set and the `add-watch` is registered against something that can
   never fire — the widget is fed once at mount and deaf thereafter, silently.
   This is rf2-8cnxg's symptom, in a published copy-pasteable recipe.
2. **The cross-reference was broken by #7664.** It pointed at §M-11 "for the
   copy-pasteable form", and that form is now explicitly stock-Reagent-only —
   it uses `reagent.core/track!`, which `reagent2.core` deliberately does not
   ship. A reagent-slim reader following the pointer hits an unavailable op.

## The ruling this needed, and how it was resolved

The bead flagged that this is **not** a mechanical copy of #7664: rf2-ynved's
ruling item 9 says reagent-slim deliberately omits `track!` / `with-let`, so
FORM-3.md must either declare the imperative branch unsupported here, or
document an adapter-specific owner.

**reagent-slim already has the primitive.** No surface widening, no invented
`track!`, nothing added to `reagent2.core`:

- `reagent2.ratom/activate!` — a **public** Var of the slim rewrite, documented
  in `IMPL-SPEC.md` §2.3 as "Added beyond stock: `activate!` — see §3.2. Stock
  reaches the same operation through `IRunnable`'s `run`, which this rewrite does
  not ship." Its docstring (`reagent2/ratom.cljs:483`) names rf2-8cnxg directly:
  "Put `rx` on the PUSH path by running its body through `deref-capture`, so it
  subscribes to the sources it reads." Idempotent and total; explicitly *not*
  `:auto-run true`.
- `reagent2.ratom/make-reaction` and `reagent2.ratom/dispose!` — both public
  (`IMPL-SPEC.md` §2.3 table; `dispose!` is the `IDisposable` protocol fn).
- `spec/006-ReactiveSubstrate.md:209` already names this pairing: "the ratom
  family alone publishes it, Reagent over `reagent.ratom/run` and reagent-slim
  over its own `activate!`".

So the reagent-slim owner is
`(reagent2.ratom/activate! (reagent2.ratom/make-reaction (fn [] …)))`, torn down
with `reagent2.ratom/dispose!`. That is `track!` decomposed, and it carries the
same three properties the operator's ruling wanted from `track!`: the eager first
run is both the seed and the `deref-capture`; each mount gets a distinct owner,
so there are **no watch keys at all**; and it has a lifetime handle to dispose.

Verified in the kernel that re-feeding actually happens: a source change reaches
`_handle-change`, which (with `auto-run` nil) calls `rea-enqueue`; `flush!` then
calls `._queued-run`, which calls `._run this true` → `_try-capture` →
`deref-capture f this`, so the body **and its side effect** re-run.

**No facade export was added.** `re-frame.core` is untouched, and
`interop/activate-derived-value!` stays internal per the rf2-ynved ruling. The
op this recipe names is the *adapter's own* public reactive primitive — the same
class of thing as `reagent.core/track!` in the stock recipe, which the ruling
explicitly accepted ("using another stock public Reagent op crosses no new
boundary").

## Before / after

- **Deleted:** the `add-watch` sentence and the whole per-mount-watch-key
  parenthetical (moot — each mount owns its own reactive owner, so there is
  nothing to key and no sibling to clobber).
- **Added:** acquire in `:component-did-mount` → **own** with a per-mount
  `activate!`-ed reaction → at unmount `dispose!` the owner **first**, then
  frame-first `(rf/unsubscribe frame query-v)`. Plus the mechanism, so the doc
  explains rather than asserts.
- **Repointed:** §M-11 is now cited for its **structure, not its ops**, with an
  explicit note that it is written for stock Reagent and that `reagent2.core`
  does not ship `track!`.
- **Timing stated honestly.** The re-feed rides the ordinary batched
  `reagent2.ratom/flush!` drain, not an inline callback inside the `app-db`
  write. Checked against slim rather than assumed from stock: the adapter's
  `:flush-render!` is `rdc/flush-render!`, which wraps `(f)` + `batching/flush!`
  in `flushSync`, and `batching/flush!` calls `(ratom/flush!)` first — so under
  `dispatch-sync` the widget *is* already current when the call returns. The doc
  says so and says not to build on it, mirroring what §M-11 now does for stock.
- **Second stale reference in the same file, also fixed:** the memoisation note
  at §3 recommended `(reagent2.core/track compute props)`. `track` is on the
  slim rewrite's not-shipped list (`IMPL-SPEC.md` §2.2), so the call would fail
  to compile. It now points at `memoize` or a `reg-sub`.

## Tree-wide re-grep for other survivors

Swept `add-watch`, `watch key` / `watch-key` / `gensym`, and
`imperative-subscription` / `imperative widget` / `M-11` across all tracked
markdown. **No seventh site.** The five surfaces #7664 moved are all repaired
(`guided-handlers-state.md`, `spec/Pattern-StatefulComponents.md` ×2,
`skills/re-frame2/patterns/stateful-components.md`,
`implementation/adapters/reagent/README.md`), and every remaining `add-watch`
mention is either the substrate's own listener contract (`spec/006`,
`IMPL-SPEC.md` §2.1) or an internal site already repaired via
`activate-derived-value!` (`observation.cljc`, `machines/timer.cljc`,
`tools/xray` + `016-Auxiliary-Panels.md` — rf2-8cnxg / rf2-wmpte / rf2-lynzk).
`implementation/adapters/reagent-slim/README.md` carries no imperative-branch
prose at all.

Out-of-fence and **not** touched, reported per the brief:
`implementation/adapters/reagent/test/re_frame/schema_reject_notification_cljs_test.cljs:19-22`
still says "a Reagent **1.x** Reaction" while the pinned substrate is Reagent
2.0.1 (the bead's SECONDARY note; the law is unchanged, only the phrasing is
stale).

## Quality gates

All foreground, output redirected to a log, exit code echoed from the runner
itself (never through a pipeline).

| command | exit | result |
|---|---|---|
| `python scripts/check_skill_migration_contract_drift.py` | **0** | silent on success — the FORM3-* rules ACCEPT this edit |
| `python scripts/check_skill_migration_contract_drift.py --self-test` | **0** | `self-test: all cases passed.` |
| `python scripts/check_doc_slugs.py --verbose` | **0** | `scanning 678 markdown files... no broken links.` |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | **0** | `No beads-database paths in this PR diff.` |
| `sh scripts/test-fast-pr.sh` | **0** | full spine green — `docs=true jvm=true node=true`, including `mkdocs build --strict`, JVM `implementation/core`, JVM `implementation/adapters/reagent-slim`, the JS harness arms and CLJS node integration |

### The FORM3-* drift gate's verdict

`check_skill_migration_contract_drift.py` scans this file by name
(`FORM3_MD`, line 231) and rf2-ynved added **Rule 5c**
(`form3_reactive_owner_problems`) to enforce the repaired shape. It passes.

Worth stating explicitly, because it shaped the edit: Rule 5c keys on **fenced
code** carrying `(rf/capture-frame)` + `:component-did-mount` + `(rf/unsubscribe …)`,
and its owner regex (`FORM3_REACTIVE_OWNER_RE`) matches only
`r/track!` / `ratom/run!` spellings. FORM-3.md's treatment of this exception has
always been **prose** that delegates to §M-11 for the worked form, and this PR
keeps it that way — so the fix stays inside its fence and does not need the gate
widened for the slim spelling. Had I added a slim-spelled fenced example here,
Rule 5c would have reported `FORM3-REACTIVE-OWNER-MISSING`; that is the gate
correctly saying `track!` is canonical *for the one canonical fenced example*,
which lives in `guided-handlers-state.md`. Flagging it as a known follow-up if
the operator ever wants a fenced reagent-slim recipe: the gate script would need
to learn the `activate!` spelling, and the gate is outside this fence.

### `check_doc_slugs.py` does not cover this file — proven, not assumed

The brief asked for a selection probe outside any fence. I appended
`[probe](./NO-SUCH-FILE-iogzk.md)` (bare prose, no fence) to FORM-3.md and re-ran
the checker: **exit 0, link not reported.** The reason is in
`_iter_markdown` — `DEFAULT_ROOTS` is `docs`, `spec`, `skills`, `migration`
plus `tools/*/spec`, so **nothing under `implementation/` is scanned at all**.
The probe was reverted immediately (`git checkout --`).

So: this gate is green but **vacuous for this file**, and `mkdocs build --strict`
does not cover `implementation/` either. Both links in the edited passage were
therefore verified by hand:
`../../../skills/re-frame-migration/references/guided-handlers-state.md` ✓ and
the new sibling `DESIGN-RATIONALE.md` ✓. Note also that fenced content is not
link-validated anywhere by this gate even in the trees it does cover — though it
is moot here, since this change adds no fenced block.

### Getting to that spine result took three runs — both earlier failures were environmental

Recorded so the next worker on this surface does not re-diagnose them.

1. A foreground `test-fast-pr.sh` was killed at a 10-minute harness cap
   (exit 143 / SIGTERM) and reported 45 `changed-surfaces` failures, all shaped
   `Command failed: bash -lc …` / `Command failed: git ls-files …` — child
   processes dying with the process group, not real failures. Both commands run
   clean by hand, and the arm passes in isolation: `npm run test:script-helpers`
   exit **0** (38 tests, 0 fail), `npm run test:script-policy` exit **0**.
2. The first uninterrupted run then exited **1** at `CLJS node integration` with
   `could not resolve shadow-cljs: Cannot find module 'shadow-cljs/cli/runner.js'`
   — a fresh worker worktree has no `implementation/node_modules`. Note the trap
   for anyone assuming a markdown edit skips this: the surface classifier is
   path-prefix based, so `implementation/adapters/reagent-slim/FORM-3.md` arms
   `cljs_node_test`, `cljs_browser`, `cljs_prod`, `implementation_jvm`,
   `reagent_slim_bundle`, `adapter_diagnostic`, `examples_compile` and
   `playground` on content it cannot possibly affect.

The junction to the mayor's `node_modules` was created for run 3 and removed with
`cmd /c rmdir` immediately afterwards, per `CLAUDE.md`; the mayor's real
`node_modules` was re-counted before and after and is unchanged at 101 entries.
Both trees are clean with no untracked residue.
