### PR TITLE
bench(hicasso): the outside instrument's parity pass, actually run (rf2-rguy1)

### DIFF
--- a/docs/design/hicasso/studio/cross-checked-against-an-outside-instrument.md
+++ b/docs/design/hicasso/studio/cross-checked-against-an-outside-instrument.md
@@ -3,7 +3,7 @@
 **The mount row survives and the bulk-broad win does not.** Running
 [krausest/js-framework-benchmark](https://github.com/krausest/js-framework-benchmark)'s
 own driver over three re-frame2 arms — Reagent-on-subs, UIx-on-subs and Hicasso
-Arm 1, sharing one model and building byte-identical DOM — an instrument this
+Arm 1, sharing one model and building canonically identical DOM — an instrument this
 programme did not write reads the candidate's mount at **1.1756× Reagent**
 against **1.2789×** from our own clock on the same app, the same operation and
 the same DOM — an **8.8%** instrument gap with a named mechanism, and that
@@ -166,12 +166,37 @@ arms draw the identical id sequence and the identical labels, and therefore buil
 **canonically identical DOM: 216,066 bytes on all three**, attribute names
 sorted.
 
-That last gate is worth a sentence because it first came back red. Reagent
-serialises `type, id, class` and UIx serialises `class, type, id` — same
-elements, same attributes, same values, same length, different write order.
-Attribute order is not part of the DOM, so the gate now sorts attribute names, as
-this lane's own DOM gate does, and reports the raw lengths beside the canonical
-ones.
+That last gate is worth more than a sentence, because for five days this page
+claimed it on a run that never took it (`rf2-rguy1`, corrected 2026-08-07).
+
+It first came back red. Reagent serialises `type, id, class` and UIx serialises
+`class, type, id` — same elements, same attributes, same values, same length,
+different write order. Attribute order is not part of the DOM, so the gate was
+changed to sort attribute names, as this lane's own DOM gate does, and to report
+the raw lengths beside the canonical ones.
+
+**The published run predates that change and therefore failed the gate it is
+quoted as passing.** The preserved `ours3.json` records `parity.identical:
+false`, its `firstDiff` is exactly the `#run` button's attribute permutation, and
+the sorting commit `f6cb3584fb` was authored at 00:09:42 — after that run ended
+at 00:06:59. The evidence settles it without reference to any clock: `ours3.json`
+carries no `rawLens` key at all, and `rawLens` is *introduced by* `f6cb3584fb`,
+whose parent contains no occurrence of it. A file written by the sorting
+instrument always has that key, so `ours3.json` was not written by it.
+
+What made the error easy to miss is that the three `lens` values were already
+equal — **216,066 on all three arms, in the failing run**. Equal length is
+precisely what a permutation of one element's attributes produces, so the triple
+that was read as proof of identity was consistent with the gate being red.
+
+**The gate has now actually been run, and it clears.** Re-taken 2026-08-07 on the
+landed harness against the three published bundles — byte-for-byte the same
+bundles, verified by their SHA-256 digests in [§6](#6-provenance) — it reports
+`IDENTICAL`, `firstDiff: null`, canonical lengths `216,066` on all three arms and
+raw `innerHTML` lengths of `216,066` on all three as well. That last pair is the
+point the original gate could not make: the raw lengths match while the raw bytes
+do not, which is the attribute-order difference stated as a measurement rather
+than as an argument.
 
 ---
 
@@ -247,9 +272,14 @@ Ratios against `rf2-reagent`, the denominator HD-012 names. Every figure below
 comes from one run of each instrument on a quiet box, at the blobs in
 [§6](#6-provenance).
 
-**Gates on our run: canonical DOM identical (216,066 B, three arms). 0
-unverified of 1,000 writes. 0 page errors. Positive control FAILED — see
-[§5](#5-the-control-failed-and-here-is-what-that-does-and-does-not-touch).**
+**Gates on our run: 0 unverified of 1,000 writes. 0 page errors. Positive control
+FAILED — see
+[§5](#5-the-control-failed-and-here-is-what-that-does-and-does-not-touch). The
+DOM gate was RED on this run and is not claimed for it** — the arms do build
+canonically identical DOM (216,066 B, three arms), but that was demonstrated by
+the 2026-08-07 re-take on the landed harness, not by the run these figures come
+from ([§1.3](#13-the-one-deliberate-deviation-and-why-it-strengthens-the-comparison),
+[§6](#6-provenance)).
 
 ### 3.1 The candidate — `hicasso / reagent`
 
@@ -468,6 +498,19 @@ closing it.
 
 The band is not widened after the fact. It is recorded as failed.
 
+**And the control is not stable across runs, which the 2026-08-07 re-take
+exposed** (`rf2-rguy1`). That run — same box, same bundles, same instrument on
+this gate — measured `rf2-reagent` **14.638×**, `rf2-hicasso` **12.883×** and
+`rf2-uix` **14.367×**, so two arms failed the `8 – 13×` band and **one passed
+it**. The verdict for an arm therefore flipped between two runs of the same
+experiment. The figures above are not restated on the strength of one re-take and
+the re-take's are not published in their place; what is recorded is that this
+control decides arm-level pass/fail near its own boundary and is not reproducible
+there. A control that cannot repeat its own verdict is weaker than a failed one,
+because a failure at least says something definite. The repair already named
+above — hold page size fixed and double the changed set — is the one this
+strengthens the case for.
+
 ---
 
 ## 6. Provenance
@@ -483,8 +526,9 @@ The band is not widened after the fact. It is recorded as failed.
 | Build | `:hicasso-bench`, `:advanced`, `goog.DEBUG false`, via `--config-merge` only — no build id added, `implementation/shadow-cljs.edn` untouched |
 | Bundles | `rf2-reagent` `300a273bd20d44fcc9a6ef6718a2366faf73d691b2a2122c43003d4fc0ce8ac6` · `rf2-hicasso` `1cc9fef3bca6a6a85602361f807ff95d8338ffefba0dcad9ed04dc8ff343814f` · `rf2-uix` `4594e3f11222a16e7ef47f3fb7c6827854ff3cd9e3fa4ea07682482adea1abc1` |
 | Their run | started 2026-08-01 23:55:03 AUSEST, ended 00:00:55, **exit 0**, driver's own PlausibilityCheck `successful run` |
-| Our run | started 2026-08-02 00:01:09 AUSEST, ended 00:06:59, **exit 1** — scoped to the positive control ([§5](#5-the-control-failed-and-here-is-what-that-does-and-does-not-touch)); DOM parity, unverified writes and page errors all cleared |
-| Box | verified quiet before each run — 8 consecutive `LoadPercentage` samples below 30% |
+| Our run | started 2026-08-02 00:01:09 AUSEST, ended 00:06:59, **exit 1**. Unverified writes and page errors cleared; the positive control failed ([§5](#5-the-control-failed-and-here-is-what-that-does-and-does-not-touch)) and **so did the DOM parity gate** — `parity.identical: false`. The earlier claim that parity cleared here is **withdrawn** (`rf2-rguy1`, 2026-08-07): this run predates the attribute-sorting gate, so the gate it is quoted as passing did not yet exist ([§1.3](#13-the-one-deliberate-deviation-and-why-it-strengthens-the-comparison)) |
+| Our DOM-parity re-take | started 2026-08-07 18:33:08 AUSEST, ended 18:39:47, **exit 1** — scoped to the positive control alone. **DOM parity IDENTICAL**, `firstDiff: null`, canonical and raw lengths `216,066` on all three arms; 0 unverified of 1,000 writes; 0 page errors. Landed harness at `851961adc6`, whose `jsfb_ours_run.cjs` differs from the pinned blob below only in `rf2-emvod`'s raw-`TaskDuration` reporting and `JSFB_ONLY` — the canonicalisation and the exit gate are byte-identical, so this is the same instrument on the parity question. Run against the three bundles below, digests re-verified before the run. **This re-take establishes the DOM gate only**; the ratios on this page are unchanged and remain those of the 2026-08-02 run |
+| Box | 2026-08-02 runs: verified quiet before each — 8 consecutive `LoadPercentage` samples below 30%. **That counter is now known to be unreliable on this box** — it has read 93% while the true utilisation was 11% — so the 2026-08-07 re-take used `\Processor(_Total)\% Processor Time` and `\System\Processor Queue Length` instead: 8.9–17.1% before, 11.6–21.9% mid-run, 9.3–19.5% after, with **processor queue length 0 on every sample except one reading of 1 taken after the run had finished** |
 
 The instrument, by blob rather than by SHA, because a SHA does not survive a
 rebase:


### PR DESCRIPTION
Item 1 of `rf2-rguy1`. Items 2 and 3 landed in #7643; this is the measurement that remained.

The page claimed a canonical-DOM parity pass that had never been taken. It has now been taken, and it clears — but the run that clears it is not the run the page's figures come from, and the page now says so.

## What the evidence shows

**The published run failed the gate it was quoted as passing.** Three independent lines, and the third does not depend on a clock:

1. The preserved `ours3.json` records `parity.identical: false`, with `firstDiff` at byte 187 on the `#run` button — Reagent's `type, id, class` against UIx's `class, type, id`.
2. That run ended 2026-08-02 00:06:59. The attribute-sorting gate `f6cb3584fb` ("the parity gate compares pages, not serialisers") was *authored* at 00:09:42 and committed at 00:53:50.
3. `ours3.json`'s `parity` object has keys exactly `identical, lens, firstDiff` — **no `rawLens`**. `rawLens` is introduced *by* `f6cb3584fb` (`git show f6cb3584fb^:…/jsfb_ours_run.cjs | grep -c rawLens` → `0`), and the sorting instrument writes it unconditionally. A file without that key cannot have been written by that instrument.

**Why it was easy to miss.** The three `lens` values in the failing run were already equal — `216,066` on all three arms — and the page published that triple as proof of identity. Equal length is exactly what a permutation of one element's attributes produces, so the evidence quoted was consistent with the gate being red.

## The re-take

Run against **the three published bundles byte-for-byte**, not a rebuild: the surviving clone's arm bundles were re-hashed before the run and match the published SHA-256 digests exactly (`300a273b…`, `1cc9fef3…`, `4594e3f1…`), so the parity question is isolated from five days of implementation drift. The benchmark clone is at the pinned `247fafa22c1f2caeb4cad179aa64cf444398cbc7`. `JSFB_ROUNDS=5`, as published.

```
;; DOM PARITY (canonical, attribute names sorted): IDENTICAL
;;   canonical lengths {"rf2-reagent":216066,"rf2-hicasso":216066,"rf2-uix":216066}
;;   raw innerHTML     {"rf2-reagent":216066,"rf2-hicasso":216066,"rf2-uix":216066}
```

`parity.identical: true`, `firstDiff: null`. Runner exit **1**, held **solely** by the positive control; unverified writes 0, page errors 0.

**The harness is the same instrument on this question.** HEAD's `jsfb_ours_run.cjs` blob (`64c37b1873`) differs from the page's pinned blob (`8f4c8c7657`) only in `rf2-emvod`'s raw-`TaskDuration` reporting and the `JSFB_ONLY` narrowing. The canonicalisation block and the exit gate are byte-identical — md5 `9a9ffabcb0cb19afd8f6303c83eff215` on both — so this is not a rig change.

**Ratios on this page are unchanged.** This re-take establishes the DOM gate only.

## A second finding: the positive control cannot repeat its own verdict

Not asked for, and reported rather than dropped. The re-take's control measured `rf2-reagent` **14.638×**, `rf2-hicasso` **12.883×**, `rf2-uix` **14.367×** — two arms outside the registered `8 – 13×` band and **one inside it**, where the published run put all three outside. An arm's pass/fail verdict flipped between two runs of the same experiment on the same box against the same bundles.

Neither set of figures is restated on the strength of one re-take. What is recorded in §5 is that this control decides arm-level pass/fail near its own boundary and is not reproducible there — which is weaker than a clean failure, because a failure at least says something definite. It strengthens the case for the repair §5 already names: hold page size fixed and double the changed set.

## Quality gates

All foreground, logs redirected outside the repo, each runner's own exit code echoed.

| command | exit |
|---|---|
| `sh scripts/assert-worker-worktree.sh` | **0** — `WORKTREE_ROOT=/c/Users/miket/code/re-frame2-worktrees/window-jsfb` |
| `node freehand/test/re_frame/bench/hicasso/jsfb_build.cjs --dest <scratchpad>` | **2** — correctly refused a dest that is not a benchmark clone; no rebuild was needed or used |
| `JSFB_ROUNDS=5 JSFB_OURS_JSON=… node freehand/test/re_frame/bench/hicasso/jsfb_ours_run.cjs` | **1** — DOM parity IDENTICAL, 0 unverified, 0 page errors; exit held solely by the positive control |
| `node freehand/test/re_frame/bench/hicasso/jsfb_compare.cjs --theirs <clone>/webdriver-ts/results --ours …` | **0** — `6 of 10 comparable rows agree within 15% (10 expected)`; denominator held at 10 |
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_doc_slugs.py` *(deliberate broken anchor at the exact edit site)* | **1** — `BROKEN ANCHOR: …:281 -> #13-this-anchor-does-not-exist-probe`; reverted, re-run **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | **0** |
| table column-count check (hand gate; `mkdocs --strict` does not cover `docs/design`) | **0** — 12 tables, 0 mismatches; probed with an injected 3-cell row → **1**, reverted → **0** |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | **0** — no beads-database paths |

`mkdocs build --strict` is **not** nominated: `exclude_docs` keeps `design/` out of the site. Anchors and table column counts were verified by hand, and both hand checks were probed rather than trusted.

### Box

Real counters, not `Win32_Processor.LoadPercentage` — which has read 93% on this box while true utilisation was 11%.

| when | `% Processor Time` | `Processor Queue Length` |
|---|---|---|
| before | 17.1 / 8.9 / 15.5 / 11.5 | 0 / 0 / 0 / 0 |
| before run (2nd) | 11.7 / 17.8 / 16.3 / 20.1 | 0 / 0 / 0 / 0 |
| mid-run | 21.9 / 20.1 / 20.3 / 11.6 | 0 / 0 / 0 / 0 |
| after | 18.3 / 19.5 / 9.3 / 12.8 | 0 / 0 / 0 / **1** |

**One excursion, reported rather than dropped**: a single queue-length reading of `1` in the final after-run sample, taken after the measurement had completed. No sample during the run exceeded 0.

## Bearing on whether the bulk rows are measurable at all

Flagged because it is outside this bead's acceptance and bears on `rf2-8a746`, which found the three-point control refused **42 of 42** bulk-class runs.

This instrument is not a difference-of-differences — it takes a direct ratio against `rf2-reagent` — and on it **the bulk rows are the best-behaved rows in the matrix, not the worst.**

Run-to-run reproducibility, published 2026-08-02 against this re-take, same box and same bundles:

| row | class | `hicasso/reagent` drift | `uix/reagent` drift |
|---|---|---:|---:|
| `replace1k` replace all | **bulk** | **+1.7%** | **−2.4%** |
| `swaprows` swap | **bulk** | +17.0% | +7.8% |
| `run1k` create 1,000 | mount | +11.5% | +1.5% |
| `update10th` partial update | **narrow** | −6.3% | **+32.9%** |
| `clear1k` clear | bulk-ish | +4.3% | −1.3% |
| `create10k` | control | −1.0% | +4.0% |

And cross-instrument agreement within the re-take, ours against the benchmark's own driver: `replace all` agrees on **both** arms (11.9%, 14.3%) and `swap rows` agrees on **both** (0.8%, 4.4%), while the mount row disagrees on both (21.3%, 24.6%) and the narrow row disagrees on the donor (21.3%).

So the two bulk rows are simultaneously the most reproducible across two runs of our instrument and the most agreed-upon between two independent instruments, while the *narrow* row is the least reproducible of all. That is the opposite of the ordering the three-point construction implies.

The honest reading is bounded: this is one app with trivial state, `swaprows` drifted 17% on one arm, and two runs are not an ensemble. It does not establish that our bulk rows are fine. What it does establish is that **a bulk row on this workload is measurable to a couple of percent by an instrument that takes a direct ratio** — so `rf2-8a746`'s 42-of-42 refusal is evidence about the difference-of-differences construction rather than about bulk operations being inherently unmeasurable. Whether that carries to the census witnesses is a separate question and is not claimed here.

## Fence

`rf2-7iqb5`, `rf2-yd52q` and `rf2-ph85f` untouched. `chrome_run.cjs`, `clock_run.cjs` and the census drivers untouched; the `frame-inclusive` guard untouched. No `spec/*`. No file overlap with #7672 or #7637 (verified with `gh pr diff --name-only`). No pin was re-pinned — the corrections accompany.

**Not done, deliberately**: the merged-PR audit on this bead asks the comparator to require strictly positive durations and ratios before a cell counts as measured. That is a real finding and it is left open. Changing the comparator during a measurement window would alter the rig between the published run and this one, which the window's standing rule forbids; it wants its own bead.

Evidence preserved beside the originals, outside the repository and uncommitted, at `%LOCALAPPDATA%\Temp\jsfb-rguy1\` as `ours4.json` and `bench4.log`.
