### PR TITLE
fix(method,hicasso): the sixth shape in the roster, and a heavy-tailed ratio reported honestly (rf2-mm77e, rf2-8bgqq)

### DIFF
--- a/docs/the-mayor-method/README.md
+++ b/docs/the-mayor-method/README.md
@@ -234,8 +234,8 @@ Different lenses find different issues.
 ## Standing prompts
 
 The cron prompts I register with the scheduler are defined in
-[`bootstrap.md`](bootstrap.md). Four `/loop` blocks: bead dispatch,
-clustering review, worktree hygiene, and PR merge. Each
+[`bootstrap.md`](bootstrap.md). Five `/loop` blocks: bead dispatch,
+clustering review, worktree hygiene, PR merge, and posture reread. Each
 carries its own operating manual inline (short-circuit rules,
 phase-transition behaviour, `--admin` discipline, the Windows-worktree
 merge trap recovery sequence). Register them once with your local
@@ -256,8 +256,9 @@ is running:
 
 - [`dispatch-prompt-template.md`](dispatch-prompt-template.md) — the
   canonical worker-prompt shapes (solo / cluster / audit /
-  cluster-reviewer / CI-fix) and the worktree-boundary block that must
-  go into every editing dispatch verbatim.
+  cluster-reviewer / CI-fix / measurement window) and the
+  worktree-boundary block that must go into every editing dispatch
+  verbatim.
 - [`bootstrap.md`](bootstrap.md) — re-read on cadence; it carries
   the five `/loop` blocks the mayor registers with its scheduler,
   each with its own inline operating manual.

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -832,7 +832,10 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
 
 {
   const CLOCK = path.join(__dirname, 'clock_run.cjs');
-  const { reportability, rowAdjudication, rowRegime, ROW_REGIME, reportabilitySelfTest } = require('./clock_run.cjs');
+  const {
+    reportability, rowAdjudication, rowRegime, ROW_REGIME, reportabilitySelfTest,
+    ctl3Verdict, ctl3SelfTest,
+  } = require('./clock_run.cjs');
   const SRC = fs.readFileSync(CLOCK, 'utf8');
   const t = (what, fn) => test(`clock_run.cjs: ${what}`, fn);
   const KEYSTROKE_WHY = "UNADJUDICATED — this row's control burns a fixed 50 ms rather than doubling the page";
@@ -849,6 +852,114 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     const bad = checks.filter((c) => !c.ok);
     assert.deepStrictEqual(bad, [], bad.map((c) => `${c.name}: ${c.detail}`).join('\n'));
   });
+
+  // --- the three-point control's own fixtures, likewise --------------------
+  //
+  // The driver runs these before the browser opens and dies if one fails, but
+  // that path needs an `:advanced` build to reach. Driving them here puts the
+  // control's refusals in the fast spine, where a change to how a run
+  // DESCRIBES itself gets checked against what it DECIDES.
+
+  t("the three-point control's own self-test passes, every case", () => {
+    const { checks } = ctl3SelfTest();
+    assert.ok(checks.length >= 10, `expected the control's fixtures, got ${checks.length}`);
+    const bad = checks.filter((c) => !c.ok);
+    assert.deepStrictEqual(bad.map((c) => c.name), [], 'the control must still refuse everything it refused');
+  });
+
+  // --- rf2-8bgqq: the run figure is a summary, never a verdict --------------
+  //
+  // The headline moved from the block MEAN to the block MEDIAN, because a mean
+  // over a quotient whose denominator sits ~2 sigma from zero summarises
+  // whichever block came nearest to it: rf2-8a746's two ensembles were read as
+  // DISAGREEING at 1.6045x and 86.05x when their block medians were 1.569 and
+  // 1.575 and they agreed to within 2% on every structural quantity.
+  //
+  // A robuster headline is worth nothing if it is also a softer gate, and the
+  // median is precisely the statistic that shrugs off the one wild block. So
+  // the load-bearing assertion is not that the number improved — it is that a
+  // run which refused before refuses after, ON A RUN BUILT SO THE NEW HEADLINE
+  // LOOKS PERFECT: eight clean blocks and one whose denominator has collapsed,
+  // median dead on the prediction and inside the band, verdict still FAIL.
+  {
+    const SEG = ['reagent-subs', 'uix-subs', 'hicasso'];
+    const D = [1, 100, 200];
+    const plan = ['ctl-d1', 'ctl-d100', 'ctl-d200'].map((id, i) => ({
+      id, dirty: D[i], ctl3: true, ctl3Witness: false, cells: 300,
+    }));
+    const A = 0.006;
+    const C = 3.5;
+    const synth = (f) => {
+      const rs = [];
+      for (let r = 0; r < 3; r++) {
+        const per = {};
+        for (let i = 0; i < SEG.length; i++) {
+          per[SEG[i]] = {
+            'ctl-d1': [f(1, r, i)], 'ctl-d100': [f(100, r, i)], 'ctl-d200': [f(200, r, i)],
+            floor: [f(300, r, i)], plumb: [0.7],
+          };
+        }
+        rs.push(per);
+      }
+      return rs;
+    };
+    // One block of nine with a denominator collapsed to 0.02 ms; the rest
+    // linear and exact. Both differences stay positive, so the sign gate is
+    // clean and the refusal is the band's, exactly as on the real runs.
+    const heavy = ctl3Verdict(
+      synth((d, r, i) => (r === 0 && i === 0 ? { 1: 5.0, 100: 5.02, 200: 7.0 }[d] : A * d + C)),
+      plan,
+      0.25
+    );
+
+    t('rf2-8bgqq: a refusal STAYS a refusal though the new headline lands dead on the prediction', () => {
+      assert.strictEqual(heavy.measured.p50, 2.0101, 'the median is the prediction, to four places');
+      assert.ok(
+        heavy.measured.p50 >= heavy.band[0] && heavy.measured.p50 <= heavy.band[1],
+        `the new headline must be INSIDE the band [${heavy.band}] for this test to mean anything`
+      );
+      // ...and the run refuses anyway. A verdict that read the summary would
+      // pass here, and that is the whole failure this test exists to catch.
+      assert.strictEqual(heavy.ok, false, 'one out-of-band block must still refuse the run');
+      assert.strictEqual(heavy.sign.ok, true, 'refused by the BAND, not swept up by the sign gate');
+      assert.strictEqual(heavy.perRound.filter((x) => x > 10).length, 1, 'exactly one wild block');
+    });
+
+    t('rf2-8bgqq: the mean it replaced was off by a factor of six, from that one block', () => {
+      assert.strictEqual(heavy.measured.mean, 12.8979);
+      assert.ok(heavy.measured.mean > heavy.band[1], 'the OLD headline was outside the band it is quoted against');
+    });
+
+    t('rf2-8bgqq: the denominator is surfaced in ms, which is where the collapse is visible', () => {
+      assert.strictEqual(heavy.signal.denMs.p50, 0.594, 'the healthy denominator');
+      assert.strictEqual(heavy.signal.denMs.min, 0.02, 'and the collapsed one, which the ratio alone cannot show');
+    });
+
+    t('rf2-8bgqq: on a healthy run the median IS the mean, so no untailed run moved', () => {
+      const clean = ctl3Verdict(synth((d) => A * d + C), plan, 0.25);
+      assert.strictEqual(clean.ok, true);
+      assert.strictEqual(clean.measured.p50, clean.measured.mean);
+      assert.strictEqual(clean.measured.p50, 2.0101);
+    });
+
+    t('rf2-8bgqq: every refusing world in the fixture set still refuses', () => {
+      // The summary changed; the refusals may not. Each of these is a world
+      // the control is built to reject, driven through the same entry point.
+      const at = (m) => (d) => (d in m ? m[d] : 0);
+      const refusing = {
+        'decreasing (more dirty work reads FASTER)': synth((d) => 10 - A * d),
+        'superlinear': synth((d) => (A * Math.pow(d, 2)) / 300 + C),
+        'a dead page': synth(() => C),
+        'negative denominator': synth(at({ 1: 5.0, 100: 4.7, 200: 4.4 })),
+        'zero denominator': synth(at({ 1: 5.0, 100: 5.0, 200: 6.2 })),
+        'an unreadable arm': synth((d) => (d === 100 ? NaN : A * d + C)),
+      };
+      for (const [name, rounds] of Object.entries(refusing)) {
+        assert.strictEqual(ctl3Verdict(rounds, plan, 0.25).ok, false, `${name} must still refuse`);
+      }
+      assert.strictEqual(ctl3Verdict([], plan, 0.25).ok, false, 'and an empty block set is not a pass');
+    });
+  }
 
   // --- the defect itself, driven here as well as in the driver -------------
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
@@ -308,8 +308,35 @@ function summarise(xs) {
   return { n: v.length, min: v[0], p50: p50(v), max: v[v.length - 1] };
 }
 
+/**
+ * A BAND CARRIES ITS MEDIAN AS WELL AS ITS MEAN, and for a RATIO the median is
+ * the one to read (rf2-8bgqq). A sample mean summarises a quantity whose tail
+ * is thin. The three-point control's statistic is a quotient whose denominator
+ * `T(d1) - T(d0)` is measured at 1.249 ms against a block-to-block dispersion
+ * of 0.599 ms — 2.09 sigma from zero — so 2.5% of blocks land with
+ * `|den| < 0.2 ms` and the ratio is heavy-tailed by construction. Over 18
+ * blocks ONE such block moved a run's headline from ~1.6x to 86x, and that is
+ * not a rounding complaint: rf2-8a746's ensembles were read as DISAGREEING
+ * about the shape of the same experiment when at block level they agree to
+ * within 2% on every structural quantity (statistic p50 1.52-1.62, in-band
+ * 42-49%, den p50 1.19-1.29 ms). The medians were 1.569 and 1.575.
+ *
+ * Both are kept and both are printed. The mean is not wrong about the sample,
+ * it is simply not a summary of this one, and a reader shown only the median
+ * could not see the tail that the pair together makes obvious.
+ *
+ * NOTHING HERE IS A VERDICT. `p50` is an added field on a summary object; no
+ * gate, band, slack, sign check or prediction reads it — `controlVerdict`'s
+ * `ok` is `perRound.every(...)` over the RAW per-block ratios and is untouched
+ * by how they are later described.
+ */
 function band(xs) {
-  return { mean: r4(xs.reduce((a, b) => a + b, 0) / xs.length), min: r4(Math.min(...xs)), max: r4(Math.max(...xs)) };
+  return {
+    mean: r4(xs.reduce((a, b) => a + b, 0) / xs.length),
+    p50: r4(p50(xs)),
+    min: r4(Math.min(...xs)),
+    max: r4(Math.max(...xs)),
+  };
 }
 
 /**
@@ -833,6 +860,53 @@ function ctl3SelfTest() {
       sup.sign.ok && !sup.ok &&
       sab.sign.ok && !sab.ok &&
       !noBlocks.ok && noBlocks.sign.of === 0,
+  });
+
+  // 10. THE SUMMARY MAY NOT LAUNDER A REFUSAL (rf2-8bgqq). The run figure is
+  //     now the block MEDIAN, because a mean over a quotient whose denominator
+  //     sits ~2 sigma from zero is a summary of whichever block came nearest —
+  //     rf2-8a746's two ensembles were read as DISAGREEING at 1.6045x and
+  //     86.05x when their block medians were 1.569 and 1.575.
+  //
+  //     A more robust HEADLINE is worth nothing if it is also a softer GATE,
+  //     and the failure mode is specific enough to name: a median is exactly
+  //     the statistic that shrugs off the one wild block, so wiring it into
+  //     the verdict would turn "one block out of band" into a pass. This
+  //     fixture is that run — eight clean blocks and one whose denominator has
+  //     collapsed to 0.02 ms — and it is built so the median lands DEAD ON the
+  //     prediction, inside the band, while the run must still REFUSE.
+  //
+  //     It also pins the route: this run is refused by the BAND, with its sign
+  //     check clean, because both differences are positive. A near-zero
+  //     denominator is not a sign defect — it is a real reading of a signal
+  //     that has gone into the noise, which is precisely why the ratio needed
+  //     its denominator printed in milliseconds beside it.
+  const heavy = ctl3Verdict(
+    synth((d, r, i) => (r === 0 && i === 0 ? { 1: 5.0, 100: 5.02, 200: 7.0 }[d] || 5.0 : A * d + C)),
+    plan,
+    CONTROL_SLACK
+  );
+  checks.push({
+    name: 'ONE near-zero-denominator block still REFUSES the run, though the MEDIAN lands dead on the prediction',
+    ok:
+      // the run refuses — this is the whole point of the fixture
+      !heavy.ok &&
+      // and it refuses on the BAND, not swept up by the sign gate: every
+      // difference here is a finite positive reading
+      heavy.sign.ok && heavy.sign.bad === 0 &&
+      // the median is the prediction, to the last place `band` can carry,
+      // and sits INSIDE the band — so a verdict reading it would have passed
+      exact(heavy.measured.p50) &&
+      heavy.measured.p50 >= heavy.band[0] && heavy.measured.p50 <= heavy.band[1] &&
+      // while the mean it replaced is off by a factor of six, from one block
+      heavy.measured.mean > 10 &&
+      // the denominator is what moved, and the summary now says so: its
+      // median is the healthy 0.594 ms, its minimum the collapsed one
+      Math.abs(heavy.signal.denMs.p50 - r4(A * 99 * 1000) / 1000) < 5e-4 &&
+      heavy.signal.denMs.min < 0.05 &&
+      // and on a HEALTHY world the median is the mean, so this change is
+      // invisible to every run that was not heavy-tailed to begin with
+      exact(lin.measured.p50) && lin.measured.p50 === lin.measured.mean,
   });
 
   return { checks };
@@ -1828,7 +1902,7 @@ function report(out) {
     if (ctl3Layout) {
       console.log(
         `;;   MECHANISM the same statistic on LayoutDuration alone: ${ctl3Layout.ok ? 'PASS' : 'FAIL'} ` +
-          `${ctl3Layout.measured.mean.toFixed(4)}x [${ctl3Layout.measured.min.toFixed(4)} – ` +
+          `${ctl3Layout.measured.p50.toFixed(4)}x median [${ctl3Layout.measured.min.toFixed(4)} – ` +
           `${ctl3Layout.measured.max.toFixed(4)}], marginal ${ctl3Layout.marginal.lower.mean.toFixed(3)} then ` +
           `${ctl3Layout.marginal.upper.mean.toFixed(3)} µs per dirty cell — a ` +
           `${margGap(ctl3Layout.marginal).toFixed(1)}% disagreement against ${margGap(m).toFixed(1)}% on task`
@@ -1861,16 +1935,34 @@ function report(out) {
           `a necessary condition, never a sufficient one.`
       );
     }
+    // THE RUN FIGURE IS THE MEDIAN, and the denominator stands beside it
+    // (rf2-8bgqq). The verdict on this line is unchanged — it is
+    // `ctl3.ok`, every block against the band plus every sign — and only the
+    // NUMBER describing the run has moved. It had to: a mean over 18 blocks of
+    // a quotient this close to a zero denominator is a summary of whichever
+    // block came nearest, and it reported two ensembles of the same experiment
+    // as 1.6045x and 86.05x when their block medians were 1.569 and 1.575.
+    // The mean is still printed, one line down, where it can be read as the
+    // tail-detector it actually is rather than as the headline.
     console.log(
-      `;;   ${ctl3.ok ? 'PASS' : 'FAIL'}     measured ${ctl3.measured.mean.toFixed(4)}x ` +
-        `[${ctl3.measured.min.toFixed(4)} – ${ctl3.measured.max.toFixed(4)}] against band ` +
-        `[${ctl3.band[0]} – ${ctl3.band[1]}] over ${ctl3.perRound.length} blocks (${ctl3.rule})`
+      `;;   ${ctl3.ok ? 'PASS' : 'FAIL'}     measured ${ctl3.measured.p50.toFixed(4)}x MEDIAN of ` +
+        `${ctl3.perRound.length} blocks [${ctl3.measured.min.toFixed(4)} – ${ctl3.measured.max.toFixed(4)}] ` +
+        `against band [${ctl3.band[0]} – ${ctl3.band[1]}] (${ctl3.rule}), on a denominator of ` +
+        `${ctl3.signal.denMs.p50.toFixed(4)} ms [${ctl3.signal.denMs.min.toFixed(4)} – ` +
+        `${ctl3.signal.denMs.max.toFixed(4)}]`
+    );
+    console.log(
+      `;;            the block MEAN is ${ctl3.measured.mean.toFixed(4)}x and is NOT the run figure: this ` +
+        `statistic is a quotient whose denominator sits ~2 sigma from zero, so one near-zero block moves a ` +
+        `mean by a factor of fifty and moves the median not at all. A mean far from the median above is a ` +
+        `reading about the DENOMINATOR, not about the page. Neither number decides anything — the verdict ` +
+        `is the strict per-block rule, and it is stated on the line above.`
     );
     console.log(`;;   per-block ${ctl3.perRound.join(', ')}`);
     if (ctl3Net) {
       console.log(
         `;;   the same statistic on the superseded taskNet clock: ${ctl3Net.ok ? 'PASS' : 'FAIL'} ` +
-          `${ctl3Net.measured.mean.toFixed(4)}x — reported as a diagnostic, never as the verdict`
+          `${ctl3Net.measured.p50.toFixed(4)}x median — reported as a diagnostic, never as the verdict`
       );
     }
     // SIDE BY SIDE with the control it replaces, on the SAME samples. The
@@ -2963,7 +3055,7 @@ async function main() {
   for (const o of demoted) {
     console.error(
       `[clock] ${o.out.rowId}: ctl-2x FAILED at ${o.verdict.ctlTask ? o.verdict.ctlTask.measured.mean : '?'}x and the ` +
-        `THREE-POINT control PASSED at ${o.verdict.ctl3.measured.mean.toFixed(4)}x on the same samples. ` +
+        `THREE-POINT control PASSED at ${o.verdict.ctl3.measured.p50.toFixed(4)}x median on the same samples. ` +
         `The row is gated on the three-point control. c(2x) = ` +
         `${o.verdict.constants ? o.verdict.constants.c2x.mean.toFixed(4) : '?'} ms is the reported reason they differ.`
     );
@@ -2984,8 +3076,13 @@ async function main() {
         // one on the strength of its own numbers.
         regime: rowRegime(o.out.rowId),
         ctlOk: !(ctlBad(o) || (o.verdict.etVerdict && !o.verdict.etVerdict.ok)),
+        // THE PARENTHETICAL A REFUSAL CARRIES, and therefore the one sentence
+        // most likely to be quoted out of the log — so it reports the MEDIAN
+        // and names its denominator in milliseconds (rf2-8bgqq). It describes
+        // the refusal; `ctlOk` above decides it, from `ctl3.ok`.
         ctlNote: o.verdict.ctl3
-          ? ` (three-point ${o.verdict.ctl3.measured.mean.toFixed(4)}x vs ${o.verdict.ctl3.predicted}x)`
+          ? ` (three-point ${o.verdict.ctl3.measured.p50.toFixed(4)}x median vs ` +
+            `${o.verdict.ctl3.predicted}x, on a ${o.verdict.ctl3.signal.denMs.p50.toFixed(4)} ms denominator)`
           : '',
         // THE BAR-LEVEL RULE HAS ONE SEAT TOO (`rowAdjudication`, above), for
         // the reason the run-level one does: a rule written out here is a rule
@@ -3006,6 +3103,11 @@ module.exports = {
   rowRegime,
   ROW_REGIME,
   reportabilitySelfTest,
+  // The three-point control's own arithmetic and its fixture set, exported so
+  // the witness can drive the REFUSALS directly rather than through a headless
+  // Chromium (rf2-8bgqq) — the same reason `reportability` is exported above.
+  ctl3Verdict,
+  ctl3SelfTest,
   publication,
   datasetFor,
   PUBLISHED_DEPTH,


### PR DESCRIPTION
Two small, disjoint fixes. Ordered commits: `rf2-mm77e` (docs, one line) then `rf2-8bgqq` (the driver's summary).

---

## rf2-mm77e — the sixth shape in the roster

PR #7672 added **Shape 6 — Measurement window** to `dispatch-prompt-template.md`, but `README.md` sat outside that PR's fence. Its pointer at the template enumerated five shapes, so the first file a fresh mayor reads undercounted its own contents.

`docs/the-mayor-method/README.md:258` now reads `solo / cluster / audit / cluster-reviewer / CI-fix / measurement window`. The label is taken from the shape's own heading in the template, not invented.

**How many roster sites exist: one.** Swept the repo (tracked files, `.beads` excluded) for `cluster-reviewer`, `CI-fix`, `Shape 6`, `measurement window`, `solo / cluster`, `five shapes`, `worker-prompt shapes`. Findings:

- `docs/the-mayor-method/README.md:258` — the only enumeration of the shape roster. Fixed.
- `.claude/commands/mayor-dispatch.md:13` — already names Shape 6 explicitly; landed in #7672. Correct, untouched.
- `dispatch-prompt-template.md:322` — "three or four exemplary dispatches per project (a solo, a cluster, an audit, a CI-fix)". That is an example set with its own stated count, not a roster. Deliberately untouched.

**One adjacent miscount, same file, same class, found while verifying the roster.** The standing-prompts paragraph said "Four `/loop` blocks" and named four, while `bootstrap.md` registers five and this file's own next-but-one bullet already said "the five `/loop` blocks" — the file contradicted itself two paragraphs apart. The missing one is the 60m posture reread. Fixed in the same commit; it is inside the bead's fenced file and is the same defect the bead is about.

---

## rf2-8bgqq — a heavy-tailed ratio reported honestly

The three-point control's statistic is a quotient whose denominator `T(d1) - T(d0)` is measured at 1.249 ms against a block-to-block dispersion of 0.599 ms — 2.09 sigma from zero. 2.5% of blocks land with `|den| < 0.2 ms`, so the ratio is heavy-tailed by construction and over 18 blocks **one** such block moves a run's headline by a factor of fifty.

That is why `rf2-8a746`'s two quiet-box ensembles were recorded as *disagreeing about the shape of the same experiment* — "low and tight, mean 1.6045" against runs "ranging to 86.05x" and "113.87x" — when at block level they agree to within 2% on every structural quantity (statistic p50 1.52–1.62, in-band 42–49%, den p50 1.19–1.29 ms, same rate in both ensembles on all three rows). Their block medians were 1.569 and 1.575.

### What the summary now reports

`band()` carries `p50` beside `mean`, and the three-point control's five summary sites lead with the **median**:

| site | what it now says |
| --- | --- |
| the `PASS`/`FAIL` headline | median over N blocks, against the band, **on a denominator of X ms** |
| `MECHANISM` (LayoutDuration) | median |
| the superseded-`taskNet` diagnostic | median |
| the `ctl-2x` demotion notice | median |
| `ctlNote` — the parenthetical a refusal carries into the published row | median **and** the denominator in ms |

The headline and the `ctlNote` now name the denominator in milliseconds. `signal.denMs` was already computed and serialised, and `ctl3Verdict`'s own docstring already said *"the only way to see [a denominator shrinking to noise] happening is to look at it in milliseconds"* — the line a reader acts on simply did not carry it.

### What it no longer claims

That the mean of these blocks summarises the run. **The mean is still printed**, one line down, labelled as the tail-detector it actually is: a mean far from the median is now readable as a statement about the *denominator* rather than about the page. Nothing is hidden; one number stopped being the headline.

### Out of scope, and untouched

The band, the slack, the strict every-block rule, the sign gate, the prediction — and `ctl-2x`, whose denominator is a level and whose blocks are tight. The bead says so explicitly, and leaving `ctl-2x` reporting its mean is where the scope line falls.

**No verdict reads `p50`.** `controlVerdict`'s `ok` is `perRound.every(...)` over the raw per-block ratios; `ctl3`'s is that **and** `sign.ok`; `ctlBad` reads `ctl3.ok` alone. `p50` is an added field on a summary object.

### Proof that a refusing run still refuses

This is the load-bearing test, not the cosmetic improvement. A more robust *headline* is worth nothing if it is also a softer *gate*, and a median is precisely the statistic that shrugs off the one wild block — so the fixture is built so the **new headline looks perfect** and the run must refuse anyway.

Eight clean blocks and one whose denominator has collapsed to 0.02 ms:

```
  ok (VERDICT)      : false          <-- still refuses
  sign.ok / bad     : true / 0       <-- refused by the BAND, not the sign gate
  band              : [1.5076, 2.5126]
  OLD headline mean : 12.8979
  NEW headline p50  : 2.0101         (inside band: true)
  denMs p50/min/max : 0.594 / 0.02 / 0.594
  per-block         : 100, 2.0101, 2.0101, 2.0101, 2.0101, 2.0101, 2.0101, 2.0101, 2.0101
```

The new headline is the prediction to four places and sits dead inside the band. **A verdict that read the summary would pass this run. It refuses.**

Three further guards ship with it: on a healthy world `p50` is byte-identical to `mean` (so no untailed run moved); every refusing world in the fixture set — decreasing, superlinear, dead page, negative denominator, zero denominator, unreadable arm, empty block set — is re-driven and still refuses; and the driver's own `ctl3SelfTest` is now driven from the witness, where it runs in the fast spine instead of needing an `:advanced` build and a headless Chromium.

**And the strongest single statement: the 221 pre-existing witness tests were run unmodified against the patched driver and all 221 pass.** Nothing about what this driver decides moved.

`ctl3Verdict` and `ctl3SelfTest` are exported so the witness can drive the refusals directly — the same reason `reportability` is exported.

---

## Quality gates

All foreground, never piped, each redirected to a worktree-local log with the runner's own exit code echoed.

| # | command | exit | result |
| --- | --- | --- | --- |
| 1 | `python -m mkdocs build --strict` | **0** | `Documentation built in 25.98 seconds` |
| 2 | `python scripts/check_doc_slugs.py --verbose` | **0** | `scanning 678 markdown files... no broken links.` |
| 3 | `node implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs` | **0** | **227 passed**, 0 failed (221 before, **+6**) |
| 4 | `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` |
| 5 | `sh scripts/check-beads-pr-boundary.sh origin/main` | **0** | `No beads-database paths in this PR diff.` |
| 6 | `ctl3SelfTest()` (driver's own fixtures, fatal at startup) | **0** | **15/15 ok** (14 before, **+1**) |

Legs inside gate 4:

| leg | count |
| --- | --- |
| JVM `implementation/core` | 2233 tests / 11645 assertions |
| JVM `implementation/freehand` | 1294 tests / 8966 assertions |
| CLJS node integration | 12794 tests / 64382 assertions |
| `clock_exit_path.test.cjs` | 227 passed |
| `mkdocs --strict build` | pass (gate 1 again, inside the spine) |

### Coverage probes — a silent gate proves nothing

`check_doc_slugs.py` is silent on success **and masks fenced blocks**, so its coverage of the edit site was probed rather than assumed. A broken link injected at `docs/the-mayor-method/README.md:258` — my exact edit site, outside any fence:

```
SLUGS_PROBE_EXIT=1
  BROKEN TARGET: docs\the-mayor-method\README.md:258 -> no-such-file-rf2mm77e.md
```

Probe removed, gate back to exit 0, `git status` clean. `docs/the-mayor-method/` is mkdocs-covered — `exclude_docs` lists `tools/playground/`, `migration/.../codemod/`, `design/freehand/`, `design/hicasso/`, not this tree.

**Baseline probe for the driver change:** the *original* witness (from `origin/main`) was run against the *patched* driver → `clock_exit_path.test.cjs: 221 passed`, exit 0. That is the number quoted above, and it is what rules out a regression hiding behind new tests.

### Fence

Diff is exactly `docs/the-mayor-method/README.md`, `implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs`, and its witness `clock_exit_path.test.cjs`. `chrome_run.cjs`, the census drivers and `clock_readjudicate.cjs` are untouched. No diff line carries the `frame-inclusive` adjective anywhere, comment or otherwise (verified by grep over the diff); the PR #7667 guard is untouched and passes.

Closes rf2-mm77e, rf2-8bgqq.
