### PR TITLE
fix(hicasso): a zero or negative duration is not a measurement (rf2-110be)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/jsfb_compare.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/jsfb_compare.cjs
@@ -54,6 +54,12 @@
 //   2  the comparison could not run at all: an input was not named, is not
 //      present, or will not parse. Named, with the path.
 //
+// And a cell counts as measured only when the DURATIONS UNDER IT are
+// measurements: finite and STRICTLY POSITIVE on both sides — base, arm and
+// ratio. A table of all-negative medians divides out to exactly the positive
+// ratios a sound run produces, so finiteness alone let counter-inverted
+// timing evidence through the gate above (rf2-110be, from #7643's audit).
+//
 // WHAT IT DOES NOT ADJUDICATE, deliberately. The run's own gates — DOM
 // parity, the positive control, page errors, unverified writes — are
 // REPORTED here and decided by `jsfb_ours_run.cjs`, which owns them and
@@ -187,6 +193,21 @@ function readOurs(file) {
 
 const ratioOf = (o, arm) => (o && o.arms && o.arms[arm] ? o.arms[arm].ratio : NaN);
 
+// A MEASUREMENT IS FINITE AND STRICTLY POSITIVE (rf2-110be).
+//
+// The predicate below used to be "the derived difference is finite", and a
+// difference is finite long before the durations under it are real. An
+// elapsed time of zero is the absence of a measurement and a negative one is
+// a broken measurement, so neither may enter the measured set — and neither
+// may a ratio built out of them.
+const positive = (x) => Number.isFinite(x) && x > 0;
+
+/** The first named value on one side that is not a measurement, or `null`. */
+const notMeasured = (named) => {
+  const bad = named.find(([, v]) => !positive(v));
+  return bad ? `${bad[0]}=${bad[1]}` : null;
+};
+
 /** One row per (benchmark, arm), whether or not either instrument measured it. */
 function buildRows(theirs, ours) {
   const rows = [];
@@ -194,19 +215,27 @@ function buildRows(theirs, ours) {
     const t = theirs[p.bench];
     const tBase = t && t[BASE] && t[BASE].total ? t[BASE].total.median : NaN;
     const o = ours && ours.summary ? ours.summary[p.ours] : null;
+    const oBase = o ? o.base : NaN;
 
     for (const arm of OTHERS) {
       const tArm = t && t[arm] && t[arm].total ? t[arm].total.median : NaN;
       const tRatio = tArm / tBase;
+      const oArm = o && o.arms && o.arms[arm] ? o.arms[arm] : null;
+      const oMs = oArm ? oArm.ms : NaN;
       const oRatio = ratioOf(o, arm);
+
+      // Both sides must have MEASURED, and the durations say whether they did:
+      // -100 ms over -120 ms is a tidy 1.2 that no reading produced.
+      const tBad = notMeasured([[`${BASE} median`, tBase], [`${arm} median`, tArm], ['ratio', tRatio]]);
+      const oBad = notMeasured([['base ms', oBase], [`${arm} ms`, oMs], ['ratio', oRatio]]);
 
       let agree = '';
       let diff = NaN;
-      if (Number.isFinite(tRatio) && Number.isFinite(oRatio)) {
+      if (!tBad && !oBad) {
         diff = Math.abs(tRatio - oRatio) / Math.min(tRatio, oRatio);
         agree = diff <= AGREEMENT_BAND ? 'YES' : 'NO';
       }
-      rows.push({ cell: cellId(p.bench, arm), bench: p.bench, ourId: p.ours, label: p.label, expected: p.theirs, arm, tArm, tRatio, oRatio, diff, agree });
+      rows.push({ cell: cellId(p.bench, arm), bench: p.bench, ourId: p.ours, label: p.label, expected: p.theirs, arm, tArm, tRatio, oRatio, diff, agree, tBad, oBad });
     }
   }
   return rows;
@@ -242,10 +271,12 @@ function verdict({ absent = [], rows = [] } = {}) {
     for (const cell of missing) {
       const r = rows.find((x) => x.cell === cell);
       let why;
+      // The offending value is NAMED. Absence prints `NaN`; the positivity
+      // cases print the number that is not a duration.
       if (!r) why = 'no row was built for it at all';
-      else if (!Number.isFinite(r.tRatio) && !Number.isFinite(r.oRatio)) why = 'NEITHER instrument measured it';
-      else if (!Number.isFinite(r.tRatio)) why = "the benchmark driver's results carry no usable median for this cell";
-      else why = "our run's JSON carries no usable ratio for this cell";
+      else if (r.tBad && r.oBad) why = `NEITHER instrument measured it (theirs ${r.tBad}; ours ${r.oBad})`;
+      else if (r.tBad) why = `the benchmark driver's results carry no usable median for this cell (${r.tBad})`;
+      else why = `our run's JSON carries no usable ratio for this cell (${r.oBad})`;
       lines.push(`[compare]   ${cell}: ${why}`);
     }
     lines.push(
@@ -292,7 +323,7 @@ function report(theirs, ours, rows) {
   console.log('');
   console.log(';; DIRECTION — does each instrument put the arm on the same side of parity?');
   for (const r of rows) {
-    if (!Number.isFinite(r.tRatio) || !Number.isFinite(r.oRatio)) continue;
+    if (!Number.isFinite(r.diff)) continue; // an unmeasured cell has no direction
     const tSide = r.tRatio > 1 ? 'slower' : 'faster';
     const oSide = r.oRatio > 1 ? 'slower' : 'faster';
     console.log(

--- a/implementation/freehand/test/re_frame/bench/hicasso/jsfb_compare_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/jsfb_compare_exit_path.test.cjs
@@ -69,19 +69,22 @@ const resultFile = (framework, benchmark, median) => ({
   values: { total: { min: median, max: median, median, mean: median, stddev: 0, values: [median] } },
 });
 
+// Arms differ so the ratios are finite and not all exactly 1.0.
+const DEFAULT_MEDIAN = (arm) => (arm === BASE ? 100 : arm === OTHERS[0] ? 120 : 90);
+
 /**
  * A complete results directory: every benchmark the driver runs, every arm.
  * `skip` drops named `framework_benchmark` files so a SHORT run can be built.
+ * `median(arm, bench)` supplies the duration, so a table can be built whose
+ * shape is complete and whose numbers are not measurements.
  */
-function theirsDir(name, { skip = [], corrupt = null } = {}) {
+function theirsDir(name, { skip = [], corrupt = null, median = DEFAULT_MEDIAN } = {}) {
   const dir = scratch(name);
   for (const p of PAIRS.filter((x) => x.theirs)) {
     for (const arm of [BASE, ...OTHERS]) {
       const file = `${arm}_${p.bench}.json`;
       if (skip.includes(`${arm}_${p.bench}`)) continue;
-      // Arms differ so the ratios are finite and not all exactly 1.0.
-      const median = arm === BASE ? 100 : arm === OTHERS[0] ? 120 : 90;
-      fs.writeFileSync(path.join(dir, file), JSON.stringify(resultFile(arm, p.bench, median)));
+      fs.writeFileSync(path.join(dir, file), JSON.stringify(resultFile(arm, p.bench, median(arm, p.bench))));
     }
   }
   if (corrupt) fs.writeFileSync(path.join(dir, corrupt), '{ this is not json');
@@ -103,6 +106,20 @@ function oursJson(name, { drop = [], over = {} } = {}) {
     file,
     JSON.stringify({ provenance: { rounds: 5 }, parity: { identical: true }, summary, control: { pass: true }, pageErrors: 0, ...over })
   );
+  return file;
+}
+
+/**
+ * Our run's JSON with one cell's own numbers overwritten — the style the
+ * non-finite-ratio case below already uses, factored out because the
+ * positivity cases need `base` and `ms` as well as `ratio`.
+ */
+function oursPatched(name, ourId, arm, patch) {
+  const j = JSON.parse(fs.readFileSync(oursJson(`${name}.src`), 'utf8'));
+  if ('base' in patch) j.summary[ourId].base = patch.base;
+  for (const k of ['ms', 'ratio']) if (k in patch) j.summary[ourId].arms[arm][k] = patch[k];
+  const file = path.join(TMP, name);
+  fs.writeFileSync(file, JSON.stringify(j));
   return file;
 }
 
@@ -258,6 +275,102 @@ test('a ratio present but NOT FINITE is missing evidence, not a measured cell', 
   });
 });
 
+// --- A ZERO OR NEGATIVE DURATION IS NOT A MEASUREMENT (rf2-110be) -----------
+//
+// The half of the fail-open class the repair above left standing. "Measured"
+// meant "the derived difference is finite", and a difference is finite long
+// before the durations under it are real. #7643's merged-PR audit built the
+// case: a COMPLETE ten-cell table whose driver medians are all NEGATIVE
+// (-100 ms base, -120/-90 ms arms) divides out to exactly the positive
+// 1.2/0.9 ratios a sound run produces, matches our ratios, and exited 0 with
+// YES on every row. Counter-inverted or malformed timing evidence walked
+// through the fail-closed gate the rest of this file pins.
+//
+// The tightening is one-way by construction — the predicate gained
+// conjuncts and lost none — so no input that was refused before is measured
+// now. The green cases at the top of this file are the witness for that
+// direction; these are the witness for the other.
+
+const NEGATE = (arm, bench) => -DEFAULT_MEDIAN(arm, bench);
+
+test("THE AUDIT'S FIXTURE: an all-negative driver table is not a measured run", () => {
+  const v = verdict(evidence(theirsDir('neg-all', { median: NEGATE }), oursJson('neg-all.json')));
+  assert.notStrictEqual(v.code, 0, 'negative durations divide out to sound-looking ratios');
+  assert.strictEqual(v.code, 1, 'the comparison RAN; what it read is not measurement');
+  const all = v.lines.join('\n');
+  assert.match(all, /10 of 10 expected cells were not measured by both instruments/);
+  assert.ok(
+    all.includes(`01_run1k / ${OTHERS[0]}: the benchmark driver's results carry no usable median for this cell (${BASE} median=-100)`),
+    all
+  );
+});
+
+test('a negative table reports agreement on NO row — the cells, not just the verdict', () => {
+  const { rows } = evidence(theirsDir('neg-rows', { median: NEGATE }), oursJson('neg-rows.json'));
+  assert.deepStrictEqual(rows.filter((r) => r.agree === 'YES').map((r) => r.cell), [], 'no negative row may agree');
+  assert.deepStrictEqual(rows.filter((r) => Number.isFinite(r.diff)).map((r) => r.cell), [], 'and none may be comparable');
+});
+
+test('ONE arm median of zero or negative refuses that cell alone, naming the value', () => {
+  for (const bad of [0, -120]) {
+    const median = (arm, bench) => (arm === OTHERS[0] && bench === '01_run1k' ? bad : DEFAULT_MEDIAN(arm));
+    const v = verdict(evidence(theirsDir(`arm-${bad}`, { median }), oursJson(`arm-${bad}.json`)));
+    assert.strictEqual(v.code, 1, `arm median ${bad} must refuse`);
+    const all = v.lines.join('\n');
+    assert.match(all, /1 of 10 expected cells/);
+    assert.ok(
+      all.includes(`01_run1k / ${OTHERS[0]}: the benchmark driver's results carry no usable median for this cell (${OTHERS[0]} median=${bad})`),
+      all
+    );
+    assert.doesNotMatch(all, /02_replace1k/, 'the sound rows of the same table must not be blamed');
+  }
+});
+
+test('a zero or negative DENOMINATOR takes every cell of that benchmark with it', () => {
+  // A negative base against positive arms is the sharper half: it yields a
+  // NEGATIVE ratio, whose distance from ours divided by that same negative
+  // minimum came out negative — and a negative distance is inside any band.
+  for (const bad of [0, -100]) {
+    const median = (arm, bench) => (arm === BASE && bench === '02_replace1k' ? bad : DEFAULT_MEDIAN(arm));
+    const v = verdict(evidence(theirsDir(`base-${bad}`, { median }), oursJson(`base-${bad}.json`)));
+    assert.strictEqual(v.code, 1, `base median ${bad} must refuse`);
+    const all = v.lines.join('\n');
+    assert.match(all, /2 of 10 expected cells/);
+    for (const arm of OTHERS) {
+      assert.ok(
+        all.includes(`02_replace1k / ${arm}: the benchmark driver's results carry no usable median for this cell (${BASE} median=${bad})`),
+        all
+      );
+    }
+  }
+});
+
+test('an OURS ratio of zero or negative is not a measurement, however finite', () => {
+  for (const bad of [0, -1.2]) {
+    const f = oursPatched(`ours-ratio-${bad}.json`, 'run1k', OTHERS[0], { ratio: bad });
+    const v = verdict(evidence(theirsDir(`ours-ratio-${bad}`), f));
+    assert.strictEqual(v.code, 1, `ours ratio ${bad} must refuse`);
+    const all = v.lines.join('\n');
+    assert.match(all, /1 of 10 expected cells/);
+    assert.ok(all.includes(`01_run1k / ${OTHERS[0]}: our run's JSON carries no usable ratio for this cell (ratio=${bad})`), all);
+  }
+});
+
+test('an OURS base or arm duration of zero or negative refuses even behind a sound ratio', () => {
+  // The ratio these sit under is a perfectly ordinary 1.2. Reading only the
+  // derived number is exactly how the durations went unexamined.
+  for (const [field, bad] of [['base', 0], ['base', -100], ['ms', 0], ['ms', -120]]) {
+    const f = oursPatched(`ours-${field}-${bad}.json`, 'run1k', OTHERS[0], { [field]: bad });
+    const v = verdict(evidence(theirsDir(`ours-${field}-${bad}`), f));
+    assert.strictEqual(v.code, 1, `ours ${field} ${bad} must refuse`);
+    const all = v.lines.join('\n');
+    // `base` is the row's denominator, so it takes both arms; `ms` is one arm's.
+    assert.match(all, new RegExp(`${field === 'base' ? 2 : 1} of 10 expected cells`));
+    const named = field === 'base' ? `base ms=${bad}` : `${OTHERS[0]} ms=${bad}`;
+    assert.ok(all.includes(`01_run1k / ${OTHERS[0]}: our run's JSON carries no usable ratio for this cell (${named})`), all);
+  }
+});
+
 // --- THE EXPECTED COUNT, derived rather than typed --------------------------
 
 test('EXPECTED_CELLS is the ten the audit counted, and it is DERIVED from PAIRS', () => {
@@ -335,6 +448,13 @@ test('THE PROCESS EXIT: short evidence exits 1 and names the missing cells', () 
   assert.strictEqual(r.status, 1, r.stderr);
   assert.match(r.stderr, /1 of 10 expected cells were not measured/);
   assert.match(r.stderr, /03_update10th1k_x16 \/ rf2-uix/);
+});
+
+test('THE PROCESS EXIT: an all-negative driver table exits 1 from the shell, not 0', () => {
+  const r = run(['--theirs', theirsDir('e2e-neg', { median: NEGATE }), '--ours', oursJson('e2e-neg.json')]);
+  assert.strictEqual(r.status, 1, r.stdout + r.stderr);
+  assert.match(r.stderr, /10 of 10 expected cells were not measured/);
+  assert.doesNotMatch(r.stdout, /VERDICT: 10 of 10 comparable rows agree/, 'ten negative rows are not ten agreements');
 });
 
 test('THE PROCESS EXIT: no arguments at all is a refusal, not a green run', () => {


### PR DESCRIPTION
Closes rf2-110be.

The jsfb comparator equated "measured" with a **finite derived difference**, and a difference is finite long before the durations under it are real. #7643's merged-PR audit built the case, and rf2-rguy1's tranche-3 worker deliberately left the repair open rather than change the rig mid-measurement-window. There is no measurement running, so it is dispatchable now.

## The defect, reproduced

A **complete** ten-cell fixture whose driver medians are all negative — `-100` ms base, `-120`/`-90` ms arms — divides out to exactly the positive `1.2`/`0.9` ratios a sound run produces. Against the landed comparator that table printed

```
;; create 1,000 rows            rf2-hicasso      -120.0         1.2000       1.2000     0.0%   YES
;;                              rf2-uix           -90.0         0.9000       0.9500     5.6%   YES
...
;; VERDICT: 10 of 10 comparable rows agree within 15% (10 expected)
```

and exited **0**. Counter-inverted timing evidence walked straight through the fail-closed gate `jsfb_compare_exit_path.test.cjs` exists to pin — the remaining half of the class that PR fixed when it stopped the comparator exiting 0 over a missing results directory and silently rewriting its own denominator.

Two narrower fail-opens rode the same predicate:

- a **negative denominator** against positive arms yields a negative `tRatio`, whose distance from ours divided by that same negative minimum came out **negative** — and a negative distance is inside any band, so it read `YES`;
- a **negative `ours` ratio** did the same thing from the other side;
- our `base` / `ms` durations were never examined at all, only the ratio derived from them.

## The change

Confined to the **measured-cell predicate** in `buildRows`. A cell enters the measured set only when both sides' base, arm and ratio are finite **and strictly positive**:

```js
const positive = (x) => Number.isFinite(x) && x > 0;
```

The refusal `verdict` already prints now **names the offending value** — `(rf2-reagent median=-100)`, `(base ms=0)`, `(rf2-hicasso ms=-120)` — instead of stopping at "no usable median". That also fixes a mis-attribution the old branch had: an arm median of `0` left `tRatio` finite, so the diagnostic blamed *our* side for the driver's bad cell.

Nothing else moved, per the bead's fence:

- **`EXPECTED_CELLS` stays derived from `PAIRS`** — untouched, still `PAIRS.filter(p => p.theirs).flatMap(...)`, so a new row still raises the bar by itself;
- the **fail-closed exit codes** are untouched: `2` (absent), `1` (short), `0` (complete), and the `absent` path is byte-identical;
- the **parity gate** is still reported here and decided by `jsfb_ours_run.cjs` — one seat per decision;
- `clock_run.cjs`, `chrome_run.cjs`, `clock_readjudicate.cjs` and the census drivers are not touched, and no diff line carries `frame-inclusive` (the adjective appears nowhere in either file).

## No refusal was turned into a pass

**Stated explicitly, and it is a proof rather than a hope.** The predicate gained conjuncts and lost none, and `positive(x) ⟹ Number.isFinite(x)`. So the new condition implies the old one, the measured set can only *shrink*, `missing` can only *grow*, and the exit code can therefore only move `0 → 1` or stay put — never `1 → 0` or `2 → 0`. The `absent` branch that owns code `2` was not edited at all. The green cases at the top of the witness (complete evidence exits 0; the complete fixture fills every expected cell) are the standing check in that direction, and they stayed green throughout.

## The new cases, red before and green after

Seven cases added to `jsfb_compare_exit_path.test.cjs` in the existing style — **every fixture built in-test under `mkdtemp`**, nothing asserted about the checkout. The suite goes 30 → 37.

BEFORE the comparator change, with only the tests added:

```
$ node implementation/freehand/test/re_frame/bench/hicasso/jsfb_compare_exit_path.test.cjs
FAIL  THE AUDIT'S FIXTURE: an all-negative driver table is not a measured run
FAIL  a negative table reports agreement on NO row — the cells, not just the verdict
FAIL  ONE arm median of zero or negative refuses that cell alone, naming the value
FAIL  a zero or negative DENOMINATOR takes every cell of that benchmark with it
FAIL  an OURS ratio of zero or negative is not a measurement, however finite
FAIL  an OURS base or arm duration of zero or negative refuses even behind a sound ratio
FAIL  THE PROCESS EXIT: an all-negative driver table exits 1 from the shell, not 0
jsfb_compare_exit_path.test.cjs: 7/37 failed
exit 1
```

AFTER:

```
$ node implementation/freehand/test/re_frame/bench/hicasso/jsfb_compare_exit_path.test.cjs
jsfb_compare_exit_path.test.cjs: 37 passed
exit 0
```

The `THE PROCESS EXIT` case drives the real binary through `spawnSync` and asserts the **process** status, because that is the observable the bead is about.

## Quality gates

All foreground, run to completion, exit codes echoed from the runner itself.

| # | command | result | exit |
|---|---------|--------|------|
| 1 | `node implementation/freehand/test/re_frame/bench/hicasso/jsfb_compare_exit_path.test.cjs` — **before** the predicate change | `7/37 failed` (the seven new cases) | **1** |
| 2 | `node --check implementation/freehand/test/re_frame/bench/hicasso/jsfb_compare.cjs` | clean parse | **0** |
| 3 | `node implementation/freehand/test/re_frame/bench/hicasso/jsfb_compare_exit_path.test.cjs` — **after** | `37 passed` | **0** |
| 4 | same suite over a **CRLF** copy of both files (383 + 533 CRLF lines, 0 bare LF, built in a scratch dir) | `37 passed` | **0** |
| 5 | `npm run test:script-helpers` (from `implementation/`) | whole chain green; `jsfb_compare_exit_path.test.cjs: 37 passed`, `clock_exit_path.test.cjs: 227 passed`, `inpage_ladder_exit_path.test.cjs: 25 passed`, `heap_control_exit_path.test.cjs: 33 passed` | **0** |
| 6 | `sh scripts/test-fast-pr.sh` | `PASS fast PR spine` | **0** |
| 7 | `sh scripts/check-beads-pr-boundary.sh origin/main` | `No beads-database paths in this PR diff.` | **0** |

Gate 6 detail — the spine classified `docs=false jvm=true node=true`, ran 61 stages and reported:

- JVM tier: `implementation/core` + `implementation/freehand` (the artefacts the diff touches);
- `[:node-test] Build completed. (2173 files, 2172 compiled, 0 warnings, 70.51s)`;
- CLJS lanes `Ran 2233 tests containing 11645 assertions. 0 failures, 0 errors.` and `Ran 1294 tests containing 8966 assertions. 0 failures, 0 errors.`;
- `per-ns isolation: all 17 namespace(s) pass standalone (196 tests, 731 assertions in total).`;
- `hicasso bench-lane compile` over all 136 lane namespaces.

**No measurement was taken and no benchmark was run.** This is a rig change; the rig has to be stable across any series being compared, which is exactly why it was held back during tranche 3.

Docs tier not nominated: the diff touches no documentation surface, and the spine's classifier says so (`documentation gates: skip`).
