### PR TITLE
bench(hicasso): the heap-family rows, measured on a granted quiet box (rf2-2rtt6.138, rf2-d360z)

### DIFF
--- a/docs/design/hicasso/studio/the-cold-read-mount-term.md
+++ b/docs/design/hicasso/studio/the-cold-read-mount-term.md
@@ -45,7 +45,9 @@ figure.
 plus the three chrome keys — every one a **single-source layer-1 sub**
 (`:input-kind :db`, no `:<-` chain, no shared parents).
 
-**The render half** (before, commit `cb41ee537b`; ms per 141-read pass, p50
+**The render half** (before, commit `cb41ee537b` — authored, and rebase-merged,
+so it resolves in no fresh clone; it landed on main as **`12e50c5b36`**, which
+recovers the measured read path in full (Provenance); ms per 141-read pass, p50
 over 60 samples; µs per read in brackets):
 
 | arm | what one pass is | p50 ms [min–max] | µs/read |
@@ -275,7 +277,9 @@ builds only.
 
 The instrument's `local` arm is deliberately the FROZEN pre-change path, so
 the re-run at the landed commit is a before/after in one process (commit
-`0c0ff21f0d`, exit 0, guard clean on every arm of both phases, control
+`0c0ff21f0d` — authored on the same rebase-merged branch as §1's, and it landed
+on main as **`aeab4bbd0d`**, which recovers the measured read path in full
+(Provenance); exit 0, guard clean on every arm of both phases, control
 predicted 1.100 measured 1.113 [0.987–1.825] PASS):
 
 | arm | ms per 141-read pass, p50 [min–max] | µs/read |
@@ -340,9 +344,12 @@ hash form with the reason stated at the assertion.
 
 ## 6. The clock of record — the re-take, and what page it measured
 
-**Before** (`rf2-y1jkm`, commit `8ccd9f4b41`, 2026-08-02T08:31Z, this box):
+**Before** (`rf2-y1jkm`, commit `8ccd9f4b41`, 2026-08-02T08:31Z, this box; the
+authored head resolves in no fresh clone, and its landed counterpart
+**`a3ffe8380e`** recovers the patch but **not this tree** — see Provenance):
 the last rows on the **pre-migration** page — hand-written anchors, no
-routing term. **After** (this run, commit `ac09504d74`, windows
+routing term. **After** (this run, commit `ac09504d74`, landed on main as
+**`fd01c070a7`**, windows
 2026-08-02T11:45:12Z – 11:49:12Z (`uix`) and – 11:54:01Z (`reagent`), exit
 `0`, both runs to completion, arm-order guard reportable on every row,
 quiet-box gate QUIET on attempt 1 or 2 everywhere): the first rows on the
@@ -446,6 +453,22 @@ the y1jkm row's blobs are exactly the two this page describes:
 | `…/arm1/lang.clj` · `…/lane.cljs` · `core …/substrate/spine.cljs` | `0151ddafb4…` · `0642815dc2…` · `ad7b19d9d8…` |
 
 Compact datasets: `implementation/freehand/test/re_frame/bench/hicasso/data/censusclock-6c237/`.
+
+**The other commits this page pins.** Three of its runs were taken before the
+published one, at authored heads on branches this repo rebase-merged, so none
+of the three is in a fresh clone; each is accompanied below by the SHA a reader
+can actually check out. Every mapping holds three independent ways — same
+subject and author date, the commit's own contributed blobs identical, and
+identical `git patch-id --stable` — and each was separated from its neighbours
+on main, because a patch-id alone can match a commit's parent and once did
+(rf2-rguy1). Recovering the patch is not the same as recovering the tree, so
+the last column says which was recovered.
+
+| authored (the tree measured) | landed on main | what the landed SHA recovers |
+|---|---|---|
+| `cb41ee537b` — §1's two halves | `12e50c5b36` | the patch **and** the measured tree. Six sources differ across the pair; the only one the profiled build compiles at all is the controlled-input mechanism, whose whole delta there is a docstring. Everything this profile times is byte-identical |
+| `0c0ff21f0d` — §4's A/B, authored on the same branch | `aeab4bbd0d` | the same, across the same six-source gap |
+| `8ccd9f4b41` — §6's *before* rows (`rf2-y1jkm`'s) | `a3ffe8380e` | **the patch only.** The y1jkm branch was rebased over the rf2-2rtt6.54 migration on its way to main, so at `a3ffe8380e` the arm-1 runtime and the `card`, `model`, `ordinary` and `route_link` sources are already post-migration. The tree those rows were measured on is reachable from no ref — which is §5's finding from the other side, and exactly why they are labelled pre-migration |
 
 ## 7. How this composes with the pending memo wrapper (#7375)
 

--- a/docs/design/hicasso/studio/the-cold-read-mount-term.md
+++ b/docs/design/hicasso/studio/the-cold-read-mount-term.md
@@ -45,10 +45,11 @@ figure.
 plus the three chrome keys — every one a **single-source layer-1 sub**
 (`:input-kind :db`, no `:<-` chain, no shared parents).
 
-**The render half** (before, commit `cb41ee537b` — authored, and rebase-merged,
-so it resolves in no fresh clone; it landed on main as **`12e50c5b36`**, which
-recovers the measured read path in full (Provenance); ms per 141-read pass, p50
-over 60 samples; µs per read in brackets):
+**The render half** (before, commit `cb41ee537b`; ms per 141-read pass, p50
+over 60 samples; µs per read in brackets). `cb41ee537b` is an authored head
+this repo's rebase-merge stranded, so it is in no fresh clone; **it landed on
+main as `12e50c5b36`**, which recovers the measured read path in full
+(Provenance), and that is the SHA to check these rows against:
 
 | arm | what one pass is | p50 ms [min–max] | µs/read |
 |---|---|---|---|
@@ -277,10 +278,11 @@ builds only.
 
 The instrument's `local` arm is deliberately the FROZEN pre-change path, so
 the re-run at the landed commit is a before/after in one process (commit
-`0c0ff21f0d` — authored on the same rebase-merged branch as §1's, and it landed
-on main as **`aeab4bbd0d`**, which recovers the measured read path in full
-(Provenance); exit 0, guard clean on every arm of both phases, control
-predicted 1.100 measured 1.113 [0.987–1.825] PASS):
+`0c0ff21f0d`, exit 0, guard clean on every arm of both phases, control
+predicted 1.100 measured 1.113 [0.987–1.825] PASS). `0c0ff21f0d` is an authored
+head on the same rebase-merged branch as §1's; **it landed on main as
+`aeab4bbd0d`**, which recovers the measured read path in full (Provenance), and
+that is the SHA to check these rows against:
 
 | arm | ms per 141-read pass, p50 [min–max] | µs/read |
 |---|---|---|
@@ -349,10 +351,10 @@ authored head resolves in no fresh clone, and its landed counterpart
 **`a3ffe8380e`** recovers the patch but **not this tree** — see Provenance):
 the last rows on the **pre-migration** page — hand-written anchors, no
 routing term. **After** (this run, commit `ac09504d74`, landed on main as
-**`fd01c070a7`**, windows
-2026-08-02T11:45:12Z – 11:49:12Z (`uix`) and – 11:54:01Z (`reagent`), exit
-`0`, both runs to completion, arm-order guard reportable on every row,
-quiet-box gate QUIET on attempt 1 or 2 everywhere): the first rows on the
+**`fd01c070a7`**, windows 2026-08-02T11:45:12Z – 11:49:12Z (`uix`)
+and – 11:54:01Z (`reagent`), exit `0`, both runs to completion, arm-order
+guard reportable on every row, quiet-box gate QUIET on attempt 1 or 2
+everywhere): the first rows on the
 **post-migration** page, whose 207 anchors are `route-link` calls through
 routing's `link-model`. The before/after pair therefore carries THREE
 deltas at once — the rf2-6c237 probe (an improvement, priced in-process at

--- a/docs/design/hicasso/studio/the-cold-read-mount-term.md
+++ b/docs/design/hicasso/studio/the-cold-read-mount-term.md
@@ -92,6 +92,44 @@ and settled between samples behind a residue equality gate that never fired):
 > once again *structurally* identical to the seam it prices, which warrants
 > the `c-*` ablations better than a clock agreement on its own ever did.
 
+> **THE QUIET-BOX RE-TAKE WAS ATTEMPTED AND REFUSED — the figures above stand
+> unchanged, still as upper bounds** (`rf2-d360z`, 2026-08-07, `abcb34217c`,
+> Processor Queue Length 0 before the attempt). `read_profile_app` reaches
+> phase A and stops: **both attempts threw at the phase-B residue gate, on the
+> `commit` arm, with the identical counts** — baseline
+> `{:cells 141 :cell-refs 141 :boundaries 1 :edges 141 :entries 6}` against a
+> measured `:entries 5`. Runner exit `1` both times; nothing from phase B was
+> produced, let alone published.
+>
+> **The cause is not the box and not this instrument.** `rf2-2rtt6.84`
+> (`337b2c2fb4`, 2026-08-04) moved `arm1/runtime.cljs`'s
+> `entry-reap-horizon-ms` from **0 to 4** so the entry reaper could not beat
+> React back to its own passive flush on a `hydrateRoot`. `lane/settle!` is
+> one macrotask — a bare `setTimeout 0` — and 4 ms is strictly outside it, so
+> the two no longer interleave the way the gate's baseline assumes. Phase B's
+> setup harvests four read-set entries through `rt/render-body`, each minted
+> with `refs` 0 and each arming a reaper at +4 ms; the baseline `rt/residue` is
+> read after ONE settle, at ~0 ms, so it counts all six entries. The reapers
+> then fire during the first sampled arm, `commit` is the only arm that raises
+> `refs` at all, and any entry whose reaper lands while `refs` is 0 is evicted.
+> The gate compares by EQUALITY and refuses. **Both published phase-B runs
+> (`cb41ee537b`, `0c0ff21f0d`, both 2026-08-02) predate that change**, which is
+> exactly why §1 could record a residue gate that never fired.
+>
+> **The gate is right and was not touched.** What it is telling us is that the
+> baseline phase B hands it is no longer reachable — an instrument-versus-
+> runtime disagreement, filed as `rf2-981nt`, not something to widen.
+>
+> **And the prize was under the grid in any case, which the refusal does not
+> change.** 141 mints at the micro table's nearest anchor of 53 ns is
+> **0.0075 ms/commit against a 0.025 ms quantum — under a third of one grid
+> step**, and the two absolutes this page already carries (0.8875 here, 0.7625
+> in §4) sit **5 quanta apart** across two runs taken an hour apart at
+> different commits. The drift is smaller than the instrument's resolution and
+> far smaller than its run-to-run dispersion, so no re-take on this clock could
+> have attributed a difference to `rf2-aqgr2`/`rf2-6wh9o` even had phase B run.
+> A quiet box does not fix that.
+
 Micro table, over the page's own roster (ns/op): `subscribe-once` 5,284;
 `compute-sub` 1,170; the raw handler invoke 227; `registrar/lookup` 67;
 `frame-state-value` 266; the `call-with-frame-resolution` wrap 206; the
@@ -265,7 +303,11 @@ decomposition as before (reaction build + cache insert 51.9%, index write
 designed: the durable wiring, amortised over the mount. That re-read is
 `0c0ff21f0d`'s and carries §1's staleness for the same reason — the per-cell
 keyword mint was still on both arms — so it is an upper bound and its shares
-lower bounds, by the same about-one-quantum term.
+lower bounds, by the same about-one-quantum term. **`rf2-d360z`'s quiet-box
+re-take of this figure was attempted on 2026-08-07 at `abcb34217c` and
+refused twice at the phase-B residue gate before producing a number** — same
+cause, same evidence, stated in full under §1's table. 0.7625 and its
+51.9 / 5.6 / 3.7% shares therefore stand exactly as they are.
 
 ## 5. The parity gap the re-take tripped over — found, bisected, repaired
 

--- a/docs/design/hicasso/studio/the-survival-metrics-allocation-half.md
+++ b/docs/design/hicasso/studio/the-survival-metrics-allocation-half.md
@@ -48,6 +48,12 @@ the cheaper mistake is the one that never ships.
 - **The instrument has a hard ceiling and the published witness is outside
   it.** At B = 1,200 boundaries, 32 collections fell inside 44 measured
   windows and the row refused on that alone.
+- **Re-taken 2026-08-07 on a granted quiet box and it refuses identically**
+  — 36 falls across 44 windows, controls passing at 8.13 / 8.20 / 8.08
+  B/double. The one thing that moved is the Reagent-segment read-back, now
+  clean at 0 of 44 since `rf2-2kshh` landed. Detail, and why the
+  small-witness arm was not built in that window, are under
+  [The published witness is outside the instrument's range](#the-published-witness-is-outside-the-instruments-range).
 
 ## What the metric is, and why the reads ladder does not answer it
 
@@ -311,6 +317,77 @@ A warm re-render of 1,200 boundaries allocates 1.2–1.7 MB, two to three
 times the ~600 KB fall threshold **in a single write**. There is no window
 size that fixes this, because one write is the atom.
 
+### Re-taken on a granted quiet box, and it refuses on the same gate
+
+`rf2-2rtt6.138` was dispatched to build the small-witness arm that clause (4)
+of [What this hands the programme](#what-this-hands-the-programme) describes.
+Before building anything it re-ran the published witness unchanged, at
+`abcb34217c`, on a box granted quiet for the purpose — Processor Queue Length
+**0** on every sample before the run, 29–42% of 24 logical cores. The verdict
+is the same verdict:
+
+- **36 falling steps across 44 measured windows** (2026-08-07), against the
+  32 across 44 this section already records. Runner exit `1`.
+- **The controls pass, and pass better**: idle window 32 B/iteration
+  [32–32]; D=1,000 → 8.13 B/double [8,096–8,165 B]; D=400 → 8.20 B/double
+  [3,280–3,280 B]; **differential 8.08 B/double** against a predicted 8. All
+  three fit self-tests (A, B, C) ok.
+- **A quiet box does not move the ceiling.** It was never a contention
+  problem; it is the arm's scale against a ~600 KB threshold, exactly as
+  this section says.
+
+**One thing did change, and it is good news.** This is the first allocation
+run since `rf2-2kshh` landed, and the warm-write read-back is now clean:
+**0 unverified across all 44 windows**, where `rf2-2rtt6.137` recorded 16
+failures on the Reagent segment's `lad/hicasso` arm. That arm now reads
+544–1,655 B/boundary/write instead of sitting on the floor's ~20. The deaf
+arm is fixed and the Reagent segment is being exercised again.
+
+**None of this run's arm figures are quotable and none are reproduced here**
+— 36 falls means every one is an under-estimate the run cannot bound. They
+are worth one sentence only as a warning: the candidate's fitted slopes came
+in at 36–55 B/read against donors at 289–610, which reads as *candidate minus
+donor of −234 and −574 B/read*. That is HD-002's predicted answer arriving in
+the exact shape a systematically under-reading instrument manufactures, from
+a run whose own gate says it under-read. It is recorded so nobody mistakes it
+for a result later, and it is why `rf2-n6w7o` (below) has to land first.
+
+### Why the small-witness arm was not built in that window
+
+Two structural reasons, neither of them about the box or about effort:
+
+1. **The audit precondition is unmet.** The merged-PR audit of #7644 found
+   the collector refusal **fail-open**: `allocSteps` calls a collection only
+   on a negative adjacent `usedJSHeapSize` delta, so a GC inside one sampled
+   leg whose in-leg allocation equals or exceeds the reclaimed bytes leaves
+   `post ≥ pre`, `falls` at zero, and the vanished bytes out of `rise`. It
+   required an independent in-window collection witness that net growth
+   cannot mask — or a comparably rigorous bound that the window cannot
+   collect — plus the masked-GC case pinned in the allocation-row structural
+   tests, **before** any small-witness fit publishes. Confirmed still unmet
+   by reading: `cdpBracket` is recorded on every arm and control and appears
+   in no failure path, and `p0_ladder_structural.test.cjs` carries no
+   allocation coverage at all. Filed as **`rf2-n6w7o`**, which now blocks
+   `rf2-2rtt6.138`.
+2. **The arm is a new rung, and the window forbade one.** `per-root` is the
+   compile-time `fx/cells-n` = 300, so `P0_ROOTS=1` floors B at 300 and a
+   few-dozen-boundary arm cannot be reached through the rig's env surface at
+   all — it is a `p0_heap.cljs` edit, exactly as (4) says. A rung added
+   between runs of a series makes the series two instruments, so it was not
+   added mid-measurement.
+
+**And the premise deserves a look before anyone builds it.** (4) argues a
+many-write window "restores the averaging a fit needs". The in-range witness
+did not fail for want of averaging: its four fits came back 0.75 / 0.28 /
+0.94 / 0.31 against a 0.98 floor and its rungs are **non-monotone**, and
+averaging does not make a non-monotone sequence linear. This run's own
+candidate fits say the same thing from the other side — r² 0.97538 on the
+Reagent segment and 0.84451 on the UIx one, both refused, while both donors
+fit cleanly at 0.99730 and 0.99446. The donors are lines; the candidate is
+not a line at this scale. Whether that is noise the smaller unit will resolve
+or a real non-linearity is itself unmeasured, and the small-witness arm
+should be costed against that question rather than assumed to answer it.
+
 ## What this hands the programme
 
 1. **The rig has an allocation instrument it did not have**, gated on its
@@ -323,10 +400,10 @@ size that fixes this, because one write is the atom.
 3. **Two blockers stand between here and the metric**, and neither is about
    effort:
    - the candidate does not re-render under the Reagent adapter on this
-     bench, so half the witness is not being exercised at all. This one is
-     now **diagnosed and has a one-line repair in flight** (`rf2-2kshh`);
-     until it lands, a Reagent-segment re-take is blocked, and the rows it
-     produced are struck from this page rather than standing as a refusal;
+     bench, so half the witness is not being exercised at all. **This one is
+     now DISCHARGED** — `rf2-2kshh` landed and the 2026-08-07 re-take reads
+     0 unverified across all 44 windows (see above); the rows it originally
+     produced stay struck rather than standing as a refusal;
    - at any witness the instrument can see, a single-write window is too
      noisy to fit, and at any window large enough to average, the collector
      is inside it.
@@ -335,7 +412,10 @@ size that fixes this, because one write is the atom.
    dozen boundaries would put a many-write window under the fall threshold
    and restore the averaging a fit needs. That is a new arm on this row
    rather than a new instrument, and it is the shape the next attempt
-   should take.
+   should take. **It is `rf2-2rtt6.138`, it is now blocked on `rf2-n6w7o`,
+   and its premise about averaging is questioned above on the strength of
+   the 2026-08-07 re-take** — settle the fail-open first, then cost the arm
+   against whether the candidate's ladder is noisy or genuinely non-monotone.
 5. **Nothing in [validation.md](../validation.md) moves.** The survival
    metric's allocation half is exactly as unwitnessed as it was, and no
    gate line, budget or verdict anywhere in the corpus is restated on the

--- a/docs/design/hicasso/studio/the-survival-metrics-allocation-half.md
+++ b/docs/design/hicasso/studio/the-survival-metrics-allocation-half.md
@@ -432,7 +432,19 @@ does not survive a rebase, and this corpus has been bitten by that before.
 | `p0_heap.cljs` | `5c83cc2a653812cfbddc7c7c76ae022ebe6f870c` |
 | `p0_arms.cljs` | `5be2024f326c4a3debd17f9f5c791c171468eeb4` |
 
-All three live under `implementation/core/test/re_frame/bench/`. Measured
+All three live under `implementation/core/test/re_frame/bench/`.
+
+> **The 2026-08-07 re-take is accompanied by these same three pins, not by
+> new ones.** It ran at `abcb34217c`, where `p0_run.cjs`, `p0_heap.cljs` and
+> `p0_arms.cljs` are **byte-identical** to the blobs above — so the move from
+> 32 falls to 36 cannot be an instrument change, and the controls' agreement
+> across the two runs is a like-for-like agreement. What moved *under* the
+> instrument is the arm: `arm1/runtime.cljs` is
+> `9f0e341c2deffffc5b4dc32cbcf6ad00f2a5c924` at that commit, carrying
+> `rf2-2kshh` (`9d01cd171e`), which is why the Reagent-segment read-back is
+> clean where this page's own run recorded 16 failures.
+
+Measured
 at authored head `d31fdb5a069b5b5ff5541ff2878f60278dd61e7a` on branch
 `worker/heapslope-2rtt6-76`, which branched from the landed commit
 `6dbf37998dcccf21f6ec7316887410beaa09dbc4` on main — that one resolves in


### PR DESCRIPTION
Tranche 4 of the granted quiet-box measurement window: the two heap-family beads whose rigs do **not** use the three-point control `rf2-8a746` found structurally unusable.

**Both refused. Neither refusal is about the box, and each was refused by a gate that was written before the run.** No published figure is restated anywhere in this PR. The diff is two studio pages; no `spec/`, no instrument edited, no gate widened.

Measured at `abcb34217c` (`origin/main` at dispatch). Worktree `C:/Users/miket/code/re-frame2-worktrees/window-heap`, guard printed `WORKTREE_ROOT=/c/Users/miket/code/re-frame2-worktrees/window-heap`.

## Box counters

`Get-Counter` on `\Processor(_Total)\% Processor Time` and `\System\Processor Queue Length` — never `Win32_Processor.LoadPercentage`. 24 logical cores.

| when | % Processor Time | Processor Queue Length |
|---|---|---|
| before `rf2-d360z` attempt 1 | 16.3 / 12.4 / 10.9 / 10.3 | 0 / 0 / 0 / 0 |
| **excursion, between attempts** | **82.5 / 87.6 / 85.7 / 95.8 then 99.6 / 99.4 / 98.5 / 98.7 / 92.3** | **1 / 0 / 1 / 31 then 6 / 9 / 4 / 16 / 0** |
| before `rf2-d360z` attempt 2 | 18.0 / 23.3 / 16.7 / 24.7 / 15.3 / 22.8 / 14.9 / 11.4 | 0 / 0 / 2 / 0 / 0 / 0 / 0 / 0 |
| before the `rf2-2rtt6.138` alloc run | 33.7 / 42.3 / 31.7 / 36.1 / 29.3 | 0 / 1 / 1 / 0 / 0 |
| after the series | 22.5 / 17.1 / 25.7 / 21.9 / 21.8 | 0 / 0 / 0 / 1 / 0 |

**The excursion is reported rather than dropped.** It sat between two runs (~21:20–21:22 AUSEST), not inside one. A 5 s per-process CPU-delta sweep taken during it attributed under 3 of 120 available CPU-seconds to any process — consistent with the tail of the preceding run's own Chromium/JVM teardown — and it resolved on its own before the next run began. Every measured window in this PR opened with Processor Queue Length 0.

---

## rf2-d360z — read_profile phase B: REFUSED, twice, before producing a number

**Ran:** `HICASSO_INIT_FN=re-frame.bench.hicasso.read-profile-app/-main` through the lane's generic `run.cjs`, twice. **Runner exit `1` both times.**

**Refused by:** the phase-B residue equality gate, on the first sampled arm (`commit`), byte-identical on both attempts:

```
expected {:cells 141, :cell-refs 141, :boundaries 1, :edges 141, :entries 6}
found    {:cells 141, :cell-refs 141, :boundaries 1, :edges 141, :entries 5}
```

**Controls, predicted vs measured** — phase A completed cleanly both times and its controls passed:

| attempt | arm-order guard | positive control predicted | measured |
|---|---|---|---|
| 1 | VERDICT: reportable | 1.225× | 1.219× [1.038–1.675] — PASS |
| 2 | VERDICT: reportable | 1.000× | 1.038× [0.888–1.675] — PASS |

Phase A's figures were **recorded and not published**: this bead does not ask for them and the run exited 1.

**Cause, read out of the code rather than inferred.** `rf2-2rtt6.84` (`337b2c2fb4`, 2026-08-04) moved `arm1/runtime.cljs`'s `entry-reap-horizon-ms` from **0 to 4** so the entry reaper could not beat React back to its own passive flush on a `hydrateRoot`. `lane/settle!` is one macrotask — a bare `setTimeout 0` — and 4 ms is strictly outside it. Phase-B setup harvests four read-set entries through `rt/render-body`, each minted with `refs` 0 and each arming a reaper at +4 ms; the baseline `rt/residue` is read after ONE settle, at ~0 ms, and therefore counts all six. The reapers fire during the first sampled arm; `commit` is the only arm that raises `refs` at all; an entry whose reaper lands while `refs` is 0 is evicted. The gate compares by equality, sees 5 against 6, and throws. **Both published phase-B runs (`cb41ee537b`, `0c0ff21f0d`, both 2026-08-02) predate that change** — which is exactly why the page could record a residue gate that never fired.

**The gate is right and was not touched, and the 4 ms was not reverted.** Filed as `rf2-981nt`. The bead's closing premise — *"the only thing missing is a run"* — no longer holds: the instrument is faithful, the runtime moved under it.

**Was the effect resolvable against the instrument's own dispersion? No — and independently of the gate.** 141 keyword mints at the micro table's nearest anchor of 53 ns is **0.0075 ms/commit against a 0.025 ms grid — under a third of one quantum**, not "about one". The page's two absolutes (0.8875 §1, 0.7625 §4) sit **5 quanta apart** across two runs an hour apart at different commits. The signal is below the instrument's resolution and far below its run-to-run dispersion, so no re-take on this clock could have attributed a difference to `rf2-aqgr2`/`rf2-6wh9o` even had phase B run. Recorded on the page as such.

**Nothing restated.** 0.8875 / 0.8625 in §1 and 0.7625 with its 51.9 / 5.6 / 3.7% shares in §4 stand exactly as they were.

---

## rf2-2rtt6.138 — the allocation ladder: REFUSED, and the arm was not built

**Ran, once, the published witness unchanged:**

```
P0_ALLOC_ROUNDS=2 P0_ALLOC_WRITES=6 P0_ALLOC_WARMUPS=2 \
  node implementation/core/test/re_frame/bench/p0_run.cjs --only alloc
```

**Runner exit `1`.**

**Every control, predicted vs measured — all pass, and pass better than `rf2-2rtt6.76`'s:**

| control | predicted | measured | reading |
|---|---|---|---|
| idle window (sampler's own footprint) | — | 32 B/iteration [32–32] | — |
| D = 1,000 doubles, dropped | 8,000 B | 8,130 B [8,096–8,165] | **8.13 B/double** |
| D = 400 doubles, dropped | 3,200 B | 3,280 B [3,280–3,280] | **8.20 B/double** |
| differential (D=1,000 less D=400) | 8 B/double | — | **8.08 B/double** |
| fit self-test A (exact line recovered) | slope 900 / intercept 400 / r² 1.0 | as predicted | **ok** |
| fit self-test B (quadratic refused by the r² floor) | r² 0.9646 | r² 0.96464 | **ok** |
| fit self-test C (absurd R=0 rung moves nothing) | slope 900, intercept 400 | unchanged | **ok** |

VERDICT: **OK — transient garbage IS visible to this counter.**

**Refused by:** the falling-step gate — **36 collections inside 44 measured windows**, against the 32 across 44 the page already records. A quiet box does not move that ceiling; it was never contention, it is the arm's scale against a measured ~600 KB threshold.

**One thing did move, and it is good news.** First allocation run since `rf2-2kshh` landed: the warm-write read-back is **0 unverified across all 44 windows**, where `rf2-2rtt6.137` recorded 16 failures on the Reagent segment's `lad/hicasso` arm, which now reads 544–1,655 B/boundary/write instead of sitting on the floor's ~20. The page's clause (3) first blocker is marked discharged.

**No arm figure is published, and one is recorded as a warning.** With 36 falls every figure under-reads by an amount the run cannot bound. The shape they took: candidate slopes 36–55 B/read against donors at 289–610, i.e. candidate-minus-donor of **−234 and −574 B/read** — HD-002's predicted flat-at-zero arriving in precisely the shape a systematically under-reading instrument manufactures, out of a run whose own gate says it under-read. Recorded so nobody mistakes it for a result later.

**Was the effect resolvable? Not at this scale, and the row says so from both sides.** The candidate's fits refused at **r² 0.97538** (reagent-subs) and **0.84451** (uix-subs) against the 0.98 floor, while **both donors fit cleanly at 0.99730 and 0.99446**. The donors are lines; the candidate is not.

### Why the small-witness arm was not built

Two structural reasons, neither about the box or about effort:

1. **The audit precondition on the bead is unmet** — confirmed by reading, not assumed. `allocSteps` is the only collector detector and it is a sign test on adjacent in-page deltas, so a GC masked by in-leg growth leaves `falls` at zero. `cdpBracket` is recorded on every arm and control and appears in **no** failure path. `p0_ladder_structural.test.cjs` has **zero** allocation coverage across its 288 lines, so there is no allocation-row structural test in which to pin the masked-GC case. Filed as **`rf2-n6w7o`**, added as a blocking dependency on `rf2-2rtt6.138`.
2. **It is a new rung, and this window forbade adding one mid-series.** `per-root` is the compile-time `fx/cells-n` = 300, so `P0_ROOTS=1` floors B at 300 and a few-dozen-boundary arm is unreachable through the rig's env surface — it is a `p0_heap.cljs` edit, exactly as the bead says. A rung added between runs makes the series two instruments.

**And the arm's premise is now questioned on the page rather than assumed.** The bead argues a many-write window "restores the averaging a fit needs". The in-range witness did not fail for want of averaging — 0.75 / 0.28 / 0.94 / 0.31 against a 0.98 floor with **non-monotone** rungs — and averaging does not linearise a non-monotone sequence. Whether that is noise a smaller unit resolves or a real non-linearity is unmeasured, and the arm should be costed against that question rather than assumed to answer it.

---

## Provenance — accompanied, never re-pinned

`p0_run.cjs` `44d106b3c2…`, `p0_heap.cljs` `5c83cc2a65…` and `p0_arms.cljs` `5be2024f32…` at `abcb34217c` are **byte-identical** to the three blobs the allocation page already pins, so the re-take rides those pins rather than minting new ones — and that is what makes 32 falls against 36 a like-for-like comparison. What moved *under* the instrument is the arm: `arm1/runtime.cljs` is `9f0e341c2d…`, carrying `rf2-2kshh` (`9d01cd171e`). Stated as an accompaniment in the page's Provenance section; nothing existing was rewritten.

## CI repair — the four stranded heads on `the-cold-read-mount-term.md`

The `docs` workflow was red on **Provenance pins**: `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` exited `1` with *4 findings*, reported as `2 files, 20 cited pins (10 landed, 0 stranded, 10 unresolvable)`. **Docs required** was only that check's rollup and needed nothing of its own.

The pins are **pre-existing** — main's copy of the page already carries them — but the gate is changed-page-scoped, so touching the page pulled its whole pin set into scope, and clearing it is this branch's job. Each of the four sat **alone in its block** with no SHA a fresh clone could resolve, which is exactly the accompaniment rule (`rf2-owq6p`): within one block, if any cited pin is not an ancestor of `origin/main`, some other pin in that same block must be.

**Accompanied, never re-pinned.** The authored head stays in place as the tree that was measured; the landed counterpart is named beside it, in the same block. Nothing was deleted or rewritten.

### Per-SHA ancestry — the property CI actually checks

`git merge-base --is-ancestor <sha> origin/main`. All four originals **resolve in this clone and in the mayor's**, so a local `check_provenance_pins` run proves nothing on its own about CI; the question is ancestry, not resolvability.

| SHA | cited at | ancestor of `origin/main` | role |
|---|---|---|---|
| `cb41ee537b` | §1 render/commit halves | **NO** — authored head, `worker/readopt-6c237` | measured tree, retained |
| `12e50c5b36` | §1, and the new Provenance table | **YES** | landed counterpart, added |
| `0c0ff21f0d` | §4 in-process A/B | **NO** — authored head, same branch | measured tree, retained |
| `aeab4bbd0d` | §4, and the new Provenance table | **YES** | landed counterpart, added |
| `8ccd9f4b41` | §6 *before* rows | **NO** — authored head, `rf2-y1jkm`'s branch | measured tree, retained |
| `a3ffe8380e` | §6, and the new Provenance table | **YES** | landed counterpart, added |
| `ac09504d74` | §6 *after* rows | **NO** — authored head, `worker/readopt-6c237` | measured tree, retained |
| `fd01c070a7` | §6 (already in the Provenance table) | **YES** | landed counterpart, added to §6's block |

### How each mapping was established — three ways, and the patch-id trap avoided

`rf2-rguy1` recorded a false justification derived from `git patch-id --stable` alone: on `19a3710bc9` the identical patch-id belonged to `f6cb3584fb`, which is `2f5af3db42`'s **parent**. So patch-id is corroboration here, never the derivation. Each mapping holds on all of:

1. **Same subject and same author date** (the rebase rewrites the commit date, never the author date). All four pairs match to the second.
2. **Parent-chain isomorphism** — `cb41ee537b → 0c0ff21f0d → ac09504d74` on the branch maps onto `12e50c5b36 → aeab4bbd0d → fd01c070a7` on main, parent for parent; `8ccd9f4b41`'s parent `25d4c410d9` maps onto `a3ffe8380e`'s parent `ddc17c1066`, same subject and author date again.
3. **The commit's OWN contributed blobs identical** — `git diff-tree -r <sha>^ <sha>`, not whole trees (whole trees differ for every rebased pair; `rf2-owq6p` names that as the mistake). Identical on all four pairs.
4. **Patch-id, corroborating only**, and checked against neighbours: the eight commits' `git patch-id --stable` values are pairwise distinct, so no mapping rests on a collision with a parent.

**All four resolved. None recorded as unresolvable.** One is honest about what it recovers:

- `cb41ee537b → 12e50c5b36` and `0c0ff21f0d → aeab4bbd0d` recover the **patch and the measured tree**. Six sources differ across each pair; the only one the profiled build compiles at all is `front/controlled.cljs` (reached through `front/codec.cljs`), and its entire delta there is a docstring. `read_profile_app.cljs`, `arm1/runtime.cljs`, `shapes/model.cljs`, `shapes/card.cljs` and `front/codec.cljs` are byte-identical between authored and landed trees.
- `ac09504d74 → fd01c070a7` recovers the patch with every contributed blob unchanged — the page's Provenance table already said so; this only puts `fd01c070a7` inside §6's block, where the rule needs it.
- `8ccd9f4b41 → a3ffe8380e` recovers **the patch only, and the page now says so.** The `rf2-y1jkm` branch was rebased over the `rf2-2rtt6.54` migration on its way to main, so at `a3ffe8380e` the arm-1 runtime and the `card`, `model`, `ordinary` and `route_link` sources are already post-migration. The measured tree is on no ref. That is `rf2-owq6p`'s annotate-rather-than-re-pin case, and it is the same fact §5 states from the other side.

**No measurement was taken and no figure moved.** Verified mechanically: every decimal figure and unit-bearing number on the page, bead ids excluded — **209 occurrences, 163 distinct — none lost, none gained** against the page at `56fbaba3e4`.

## Quality gates

Foreground, never piped; redirected to a worktree-local log with the runner's own exit code echoed.

| command | exit |
|---|---|
| `sh scripts/assert-worker-worktree.sh` | `0` — `WORKTREE_ROOT=/c/Users/miket/code/re-frame2-worktrees/window-heap` |
| `python scripts/check_doc_slugs.py` (after the `the-cold-read-mount-term.md` edit) | `0` |
| `python scripts/check_doc_slugs.py` (after the `the-survival-metrics-allocation-half.md` edits) | `0` |
| `python scripts/check_doc_slugs.py` (after the provenance accompaniment) | `0` |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | `0` — "No beads-database paths in this PR diff." |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` (**the failing gate**) | before: `1` — 4 findings. after: **`0`** — `2 files, 33 cited pins (18 landed, 15 stranded, 0 unresolvable)` |
| the same check, **CI-simulated** (every stranded head forced to UNRESOLVABLE, as a fresh clone sees them) | **`0`** — `18 landed, 0 stranded, 15 unresolvable` |
| `python scripts/check_doc_slugs.py` (after the provenance-pin repair) | `0` |
| `sh scripts/check-beads-pr-boundary.sh origin/main` (re-run after the repair) | `0` |
| `node …/hicasso/run.cjs` (read_profile, ×2) | `1`, `1` — **the refusal, and the deliverable** |
| `node …/bench/p0_run.cjs --only alloc` | `1` — **the refusal, and the deliverable** |

**`check_doc_slugs.py` was probed at each exact edit site rather than trusted for being silent.** It masks fenced blocks and does not scan `implementation/` at all, so a broken relative link and a broken anchor were injected into each of the two edited paragraphs in turn; the gate failed `1` and named the injected line (`the-cold-read-mount-term.md:121`, `the-survival-metrics-allocation-half.md:320`) both times, and passed `0` again after each revert. Residue greps for the probe strings return 0.

**Hand-verified, because nothing validates it.** The measurement tranche added no table rows. The provenance-pin repair adds **one** table, in `the-cold-read-mount-term.md`'s Provenance section: **3 columns**, header + delimiter + 3 data rows, no pipe inside any cell. Counted by hand across the whole page: **9 tables, 0 column-count mismatches** — and the counter was probed with an injected 2-cell row, which it reported as a mismatch on that exact table before the revert. Both earlier anchor links (`#what-this-hands-the-programme`, `#the-published-witness-is-outside-the-instruments-range`) still resolve; the repair adds no link.

**`check_doc_slugs.py` was probed again at the new edit site.** A broken anchor was injected into the new Provenance paragraph: the gate failed `1` naming `the-cold-read-mount-term.md:465` and its target file, and passed `0` after the revert. `git status` clean afterwards, no probe residue.

`mkdocs build --strict` is **not** nominated: `mkdocs.yml`'s `exclude_docs` keeps `design/` out of the site, so it would not cover either edited file.

## Fence

Diff is `docs/design/hicasso/studio/the-cold-read-mount-term.md` and `docs/design/hicasso/studio/the-survival-metrics-allocation-half.md`. No `spec/`. No instrument file edited — `read_profile_app.cljs`, `p0_run.cjs`, `p0_heap.cljs` and `p0_arms.cljs` are untouched. Nothing in `chrome_run.cjs`, `clock_run.cjs`, `clock_readjudicate.cjs`, the census drivers or `jsfb_*`. The string `frame-inclusive` appears nowhere in the diff. PR #7637's three files (`p0-uix-on-subs-frontier-arm.md`, `p0_floor.cljs`, `p0_converge_app.cljs`) are untouched — verified with `gh pr diff 7637 --name-only` before starting.

## Beads

`rf2-d360z` and `rf2-2rtt6.138` are both **left OPEN** — neither measurement happened. Two new beads carry the blockers: **`rf2-981nt`** (the reaper/settle disagreement that stops phase B reaching a number) and **`rf2-n6w7o`** (the allocation row's masked-GC fail-open, now a blocking dependency of `rf2-2rtt6.138`).

