### PR TITLE
fix(hicasso): the jsfb producer must not record a non-positive taskNet (rf2-iuudn)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/jsfb_ours_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/jsfb_ours_run.cjs
@@ -60,6 +60,21 @@
 // alternate WITHIN each round and the round order flips, so a monotone
 // drift across the run cancels to first order; and a per-round seam figure
 // is published so a reader can see what did not cancel.
+//
+// ## A sample is admitted only if its durations are measurements (rf2-iuudn)
+//
+// `rf2-110be` taught the COMPARATOR that a zero or negative duration is not
+// a measurement — a table of all-negative medians divides out to exactly the
+// positive ratios a sound run produces. The comparator refusing is the last
+// line, not the only one: a value that is not a duration, recorded here,
+// still lands in the JSON this file writes and is still read by everything
+// that is not the comparator. So the refusal is made at the point of
+// measurement too, where it is cheaper.
+//
+// A recorded sample must read strictly positive on both clocks this file
+// publishes. A sample that does not is not averaged, not written, and not
+// silently dropped either — it is COUNTED and the run refuses on the count,
+// alongside the unverified writes it already refuses on.
 
 const fs = require('node:fs');
 
@@ -282,6 +297,36 @@ function deltaOf(a, b) {
   };
 }
 
+// A MEASUREMENT IS FINITE AND STRICTLY POSITIVE (rf2-iuudn).
+//
+// An elapsed time of zero is the absence of a measurement and a negative one
+// is a broken measurement — a counter that went backwards across the delta,
+// or a `DevToolsCommandDuration` that outran the task it is subtracted from.
+// Neither may enter a median.
+const positive = (x) => Number.isFinite(x) && x > 0;
+
+// WHICH DURATIONS ARE ASKED, and — as important — which are not.
+//
+// `taskNet` and `task` are the two clocks this file PUBLISHES: every ratio in
+// the report and every `summary`/`summaryTask` figure in the JSON is a mean of
+// medians of one of them. Both are asked, not just `taskNet`, and rf2-110be
+// says why: it is the derived quantity, `task - devtools`, and a derived
+// number is sound-looking long before its inputs are. A `task` of 0 against a
+// negative `devtools` yields a perfectly positive `taskNet`, which is the
+// wrong-side-blamed failure that bead found on the comparator.
+//
+// `script`, `layout`, `style` and `devtools` are DECOMPOSITION and are
+// deliberately not asked. An operation that recalculates no style honestly
+// reads 0 there — `clear1k` is the obvious candidate — so requiring them
+// positive would refuse sound runs, which is the opposite fault.
+const PUBLISHED = ['taskNet', 'task'];
+
+/** The first published duration in `d` that is not a measurement, or `null`. */
+const notMeasured = (d) => {
+  const bad = PUBLISHED.find((k) => !positive(d[k]));
+  return bad ? `${bad}=${d[bad]}` : null;
+};
+
 // ---------------------------------------------------------------------------
 // Statistics — the lane's, so a figure here is read the way its figures are
 // ---------------------------------------------------------------------------
@@ -315,6 +360,7 @@ async function measureArm(browser, arm, row, roundIdx) {
 
   const out = [];
   let unverified = 0;
+  let nonPositive = 0;
 
   const warmup = row.warmup ?? WARMUP;
   const samples = row.samples ?? SAMPLES;
@@ -338,11 +384,26 @@ async function measureArm(browser, arm, row, roundIdx) {
       }
     }
 
-    if (i >= warmup) out.push(d);
+    // THE RECORDING SITE. A sample enters the medians only if its published
+    // durations are measurements; one that is not is counted and named, and
+    // `main` refuses the run on the count. Counting rather than dropping is
+    // the difference between a gate and a filter: a filter would quietly
+    // publish a figure from a rig that produced impossible numbers.
+    if (i >= warmup) {
+      const bad = notMeasured(d);
+      if (!bad) {
+        out.push(d);
+      } else {
+        nonPositive++;
+        if (nonPositive <= 3) {
+          console.error(`[ours] ${arm} ${row.id} r${roundIdx} sample ${i}: not a measurement, ${bad}`);
+        }
+      }
+    }
   }
 
   await page.close();
-  return { samples: out, unverified, errors };
+  return { samples: out, unverified, nonPositive, errors };
 }
 
 async function main() {
@@ -435,7 +496,7 @@ async function main() {
   const acc = {};
   for (const row of ROWS) {
     acc[row.id] = {};
-    for (const arm of ARMS) acc[row.id][arm] = { rounds: [], unverified: 0, errors: [] };
+    for (const arm of ARMS) acc[row.id][arm] = { rounds: [], unverified: 0, nonPositive: 0, errors: [] };
   }
 
   for (let r = 0; r < ROUNDS; r++) {
@@ -444,11 +505,12 @@ async function main() {
     const order = r % 2 === 0 ? ARMS : [...ARMS].reverse();
     for (const row of ROWS) {
       for (const arm of order) {
-        const { samples, unverified, errors } = await measureArm(browser, arm, row, r);
+        const { samples, unverified, nonPositive, errors } = await measureArm(browser, arm, row, r);
         const a = acc[row.id][arm];
         a.rounds.push(median(samples.map((s) => s.taskNet)));
         (a.roundsTask ||= []).push(median(samples.map((s) => s.task)));
         a.unverified += unverified;
+        a.nonPositive += nonPositive;
         a.errors.push(...errors);
         if (!a.decomp) a.decomp = [];
         a.decomp.push({
@@ -495,7 +557,8 @@ async function main() {
   for (const row of ROWS) {
     const R = acc[row.id][BASE].rounds;
     const unverified = ARMS.reduce((a, x) => a + acc[row.id][x].unverified, 0);
-    summary[row.id] = { base: mean(R), unverified, arms: {} };
+    const nonPositive = ARMS.reduce((a, x) => a + acc[row.id][x].nonPositive, 0);
+    summary[row.id] = { base: mean(R), unverified, nonPositive, arms: {} };
     console.log(`;; ${row.id.padEnd(12)} ${row.jsfb.padEnd(21)} ${BASE.padEnd(13)} ${fmt(mean(R), 3).padStart(8)}     1.0000   —`);
     for (const arm of OTHERS) {
       const H = acc[row.id][arm].rounds;
@@ -552,6 +615,12 @@ async function main() {
   console.log('');
   console.log(';; UNVERIFIED SAMPLES (must be 0 on every row)');
   for (const row of ROWS) console.log(`;;   ${row.id.padEnd(12)} ${summary[row.id].unverified}`);
+
+  // The other way a sample fails to be a sample: it verified the page, and
+  // then read a duration that no elapsed time can produce (rf2-iuudn).
+  console.log('');
+  console.log(';; SAMPLES REFUSED AS NON-MEASUREMENTS — taskNet or task not > 0 (must be 0 on every row)');
+  for (const row of ROWS) console.log(`;;   ${row.id.padEnd(12)} ${summary[row.id].nonPositive}`);
 
   // The positive control, adjudicated against the band registered above.
   console.log('');
@@ -627,7 +696,8 @@ async function main() {
   }
 
   const totalUnverified = Object.values(summary).reduce((a, s) => a + s.unverified, 0);
-  if (!parity.identical || totalUnverified > 0 || pageErrors.length > 0 || !controlPass) {
+  const totalNonPositive = Object.values(summary).reduce((a, s) => a + s.nonPositive, 0);
+  if (!parity.identical || totalUnverified > 0 || pageErrors.length > 0 || !controlPass || totalNonPositive > 0) {
     console.error('[ours] a gate did not clear — see the report above');
     process.exit(1);
   }


### PR DESCRIPTION
Closes rf2-iuudn.

`rf2-110be` gated the **comparator's** measured-cell predicate on strictly positive durations, having shown that a table of all-negative medians divides out to exactly the positive ratios a sound run produces. The **producer** had no such gate. `jsfb_ours_run.cjs`'s recording site was one line:

```js
if (i >= warmup) out.push(d);
```

Every post-warm-up sample entered the medians whatever its durations read. The comparator refusing is the last line, not the only one: a value that is not an elapsed time still lands in the JSON this file writes under `JSFB_OURS_JSON`, is still read by everything that is not the comparator, and still has to be explained later. Refusing at the point of measurement is cheaper than refusing at the point of comparison.

## What changed

A sample is admitted only when both clocks this file **publishes** read finite and strictly positive:

```js
const positive = (x) => Number.isFinite(x) && x > 0;
const PUBLISHED = ['taskNet', 'task'];
const notMeasured = (d) => {
  const bad = PUBLISHED.find((k) => !positive(d[k]));
  return bad ? `${bad}=${d[bad]}` : null;
};
```

**Both, not just `taskNet`** — and rf2-110be is why. `taskNet` is the derived quantity `task - devtools`, and a derived number is sound-looking long before its inputs are. A `task` of `0` against a `devtools` of `-12.5` yields a perfectly positive `taskNet` of `12.5`; a gate on `taskNet` alone admits it and blames the wrong side, which is the failure that bead found on the comparator. `task` is published in its own right too — the whole `rf2-emvod` raw-`TaskDuration` block and `summaryTask` in the JSON are means of medians of it.

**`script`, `layout`, `style` and `devtools` are deliberately NOT asked.** They are decomposition, and an operation that recalculates no style honestly reads `0` there — `clear1k` is the obvious candidate. Requiring them positive would refuse sound runs, which is the opposite fault.

A refused sample is **counted, not silently dropped**: named on stderr (first three per arm/row/round), reported per row next to the unverified writes, carried into `summary` in the JSON, and added to the exit gate. That is the difference between a gate and a filter — a filter would quietly publish a figure from a rig that produced impossible numbers.

Nothing else moves: the parity gate, the exit codes, the arm roster and the pinned benchmark revision `247fafa22c1f2caeb4cad179aa64cf444398cbc7` are untouched. **No benchmark was run** — this is a rig change and the rig must stay stable across any series being compared, which is the same reason tranche 3 left rf2-110be undone mid-window.

## The monotonicity proof

rf2-110be proved its tightening one-way rather than arguing from fixtures, and the same argument holds here in a slightly stronger form, because this change can move a figure and that has to be accounted for.

Let `D` be the number of samples a run refuses.

- **`D = 0`.** Nothing is withheld, so every `out` array is element-for-element what it was, so every median, every `rounds`/`roundsTask` entry, every mean, every ratio, `controlPass`, `parity.identical`, `totalUnverified` and `pageErrors.length` are identical to before. The added disjunct `totalNonPositive > 0` is false. **The exit code is unchanged.**
- **`D > 0`.** Figures may differ, but the added disjunct is true and the run **exits 1** regardless of what any other gate decided.

So for every input, `newExit >= oldExit`: the exit code can only move `0 -> 1` or stay, and **no currently-refusing run can be turned into a pass**. The branch where the published numbers change is exactly the branch where the run is refused, so no figure this repo would publish moves either.

## Quality gates

Run in a worker worktree at `C:/Users/miket/code/re-frame2-worktrees/jsfbprod-iuudn`, foreground, each redirected to a worktree-local log with the runner's own exit code echoed.

| command | result | exit |
| --- | --- | --- |
| `node --check implementation/freehand/test/re_frame/bench/hicasso/jsfb_ours_run.cjs` | parses | **0** |
| `node implementation/freehand/test/re_frame/bench/hicasso/jsfb_compare_exit_path.test.cjs` | `jsfb_compare_exit_path.test.cjs: 37 passed` | **0** |
| `npm run test:script-helpers` (from `implementation/`) | 22 suites green, including `pageerror_exit_path.test.cjs: 91 passed` (which source-scans this driver's page-error collector and its exit wiring), `clock_exit_path.test.cjs: 227 passed`, `jsfb_compare_exit_path.test.cjs: 37 passed`, `lane_cache_wiring 38/38` | **0** |
| `sh scripts/test-fast-pr.sh` | `PASS fast PR spine`. JVM tier: `implementation/core` 2233 tests / 11645 assertions and `implementation/freehand` 1294 tests / 8966 assertions (the artefact this diff touches), 0 failures 0 errors each. Node tier: 12794 tests / 64382 assertions, 0 failures 0 errors. Docs tier not run — surface unchanged | **0** |

The fresh worktree had no `node_modules`; both the repo-root and `implementation/` trees were junctioned at the primary checkout's real ones for the run and the links removed afterwards, with the mayor's canaries re-checked at 101/103 and 59/61.

### Red then green, on the predicate itself

`jsfb_ours_run.cjs` has no witness — unlike its sibling `clock_run.cjs`, which exports its refusal arithmetic under a `require.main === module` guard precisely so a witness can drive the refusals without a headless Chromium (rf2-8bgqq). Giving this driver the same treatment means a new test file plus a `test:script-helpers` entry in `implementation/package.json`, which is outside this bead's fence, so it is filed as follow-up rather than smuggled in here. The bead asks for the monotonicity proof in preference to fixtures and it is above; the predicate was additionally driven directly, lifted verbatim out of the committed source, over fourteen cases:

- **red** on `origin/main` — the driver cannot lift a predicate because there is none; the recording site is the unconditional `out.push(d)` at line 341, so every case below was admitted.
- **green** on this branch — `14/14`, exit 0.

The cases: a sound sample admitted; `taskNet` at `0`, `-3.2`, `NaN`, `Infinity`, `-0` and `undefined` each refused and named; `task = 0` with `devtools = -12.5` refused on `task` even though its `taskNet` is a plausible `12.5`; `task = -1` refused; and `style`, `layout`, `script`, `devtools` at `0` — singly and together — all still **admitted**, which is the half that guards the opposite direction. `positive(1e-9)` is true, so the gate refuses only what no elapsed time can produce.

## Follow-up filed

- **rf2-2ze1h** — `jsfb_ours_run.cjs` has no witness: it requires `playwright` at module top level and calls `main()` unguarded, so nothing can drive its DOM-parity gate, its positive-control adjudication, its unverified-writes count, its page-error funnel, or this predicate. The repair is the shape `clock_run.cjs` and `jsfb_compare.cjs` already use — `module.exports` plus a `require.main === module` guard, a pure `verdict()`, a `jsfb_ours_exit_path.test.cjs`, and a `test:script-helpers` entry.
