### PR TITLE
docs(hicasso): the regime statement is superseded on the remaining pages (rf2-ih772)

### DIFF
--- a/docs/design/hicasso/studio/bulk-broad-re-taken.md
+++ b/docs/design/hicasso/studio/bulk-broad-re-taken.md
@@ -243,13 +243,18 @@ corrected clock is not a clock that flattens everything toward 1.0: in the same
 eight runs it puts `hicasso / reagent-subs` on `M1` at **1.4896×**
 [1.3488 – 1.5989], a reading far from parity that clears every run's band. It
 reproduces a published parity row to two parts in a thousand and simultaneously
-separates a large deficit elsewhere. **What that `M1` reading is NOT is a
-published magnitude** — `rf2-jcm3p` ruled on 2026-08-06 that `M1` mount states a
-**REGIME** and not an adjudicated magnitude, because its own `ctl-2x` fails
+separates a large deficit elsewhere. **What that `M1` reading is NOT is the
+published magnitude** — ~~`rf2-jcm3p` ruled on 2026-08-06 that `M1` mount states
+a **REGIME** and not an adjudicated magnitude, because its own `ctl-2x` fails
 (1.8173× against a predicted 2.00×, the additive constant `c ≈ 1.04 ms`
 explaining the undershoot); `1.4896×` remains visible here as a historical
 observation *stated under a failing `ctl-2x`; withdrawn as a magnitude
-2026-08-06*. **The check above is unaffected**, because it turns on this clock
+2026-08-06*.~~ *(Superseded 2026-08-07, `rf2-t2flm`: the row does publish a
+magnitude, drawn from the two retained quiet-box ensembles and conditionally
+labelled —
+[`rf2-emvod` §4.3](rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row).
+`1.4896×` is not it, and stays here as what these eight runs read on
+2026-08-01.)* **The check above is unaffected**, because it turns on this clock
 discriminating a far-from-parity reading from a parity one — a direction and a
 band, not a number.
 
@@ -513,9 +518,16 @@ commits is the check.
 - **The candidate's own mount deficit is worse than published**, at `1.4896×`
   Reagent-on-subs on the corrected clock against `1.2107×` on the frame-only
   one. Recorded here because it is in these runs; adjudicating it is
-  `rf2-emvod`'s, not this page's. **That adjudication has since happened, and
+  `rf2-emvod`'s, not this page's. ~~**That adjudication has since happened, and
   it publishes no magnitude**: `rf2-jcm3p` restated `M1` mount as a **REGIME**
   on 2026-08-06 — materially slower than both adapters, every corroborated
   reading above the amended `≤ 1.10×` UIx gate, `≤ 1.10×` not demonstrated —
   because the row's `ctl-2x` fails. `1.4896×` above is a reading stated under
-  that failing control, not a published magnitude.
+  that failing control, not a published magnitude.~~ **That adjudication has
+  since happened twice, and it publishes a magnitude** *(2026-08-07,
+  `rf2-t2flm`, superseding the 2026-08-06 regime statement struck above —
+  `rf2-jcm3p` read `ctl-2x`'s mean against `2.00×` where the implemented rule
+  tests per-block band membership)*: the row and its conditional labels are at
+  [`rf2-emvod` §4.3](rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row).
+  `1.4896×` above is this ensemble's own reading and stays as such; it is not
+  the published figure.

--- a/docs/design/hicasso/studio/census-real-clock-rows.md
+++ b/docs/design/hicasso/studio/census-real-clock-rows.md
@@ -201,7 +201,16 @@ The operator's open question: does the candidate's p0 mount deficit —
 `1.5001×` vs UIx / `1.4896×` vs Reagent on the M1 witness (`rf2-yd52q`) —
 reproduce on census-real screens?
 
-> **THOSE TWO M1 FIGURES ARE NO LONGER PUBLISHED MAGNITUDES (`rf2-jcm3p`,
+> **THOSE TWO M1 FIGURES ARE STILL NOT THE PUBLISHED MAGNITUDE, BUT THERE IS
+> ONE AGAIN (`rf2-t2flm`, ruled 2026-08-07).** M1 mount publishes `~1.184×`
+> against direct UIx-on-subs, conditionally labelled, drawn from two retained
+> quiet-box ensembles — [`rf2-emvod`
+> §4.3](rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row)
+> carries the figures and the labels, and this page does not restate them.
+> `1.5001×` and `1.4896×` stay visible here as what the programme read on
+> 2026-08-01, on a heavier load regime than the published row is drawn from.
+>
+> ~~**THOSE TWO M1 FIGURES ARE NO LONGER PUBLISHED MAGNITUDES (`rf2-jcm3p`,
 > ruled 2026-08-06).** M1 mount is stated as a **REGIME**, not an adjudicated
 > magnitude: hicasso mounts materially slower than both adapters — every
 > corroborated reading sits above the amended `≤ 1.10×` UIx gate — direction
@@ -209,14 +218,14 @@ reproduce on census-real screens?
 > benchmark), and **`≤ 1.10×` has NOT been demonstrated**. The row's positive
 > control fails (`ctl-2x` 1.8173× against a predicted 2.00×, explained by the
 > additive constant `c ≈ 1.04 ms`), so no magnitude is published
-> ([the clock page's §4](the-candidates-clock.md#4-the-mount-row--a-regime-not-a-magnitude)).
-> `1.5001×` and `1.4896×` stay visible here as historical observations
-> *stated under a failing `ctl-2x`; withdrawn as magnitudes 2026-08-06*.
-> **The rows measured on THIS page are untouched by that ruling** — they carry
-> their own controls, adjudicated per row above — and this page is one of the
-> three legs corroborating the regime's direction. What changes below is that
-> M1 is compared against as a set of *readings*, never as a published
-> magnitude.
+> ([the clock page's §4](the-candidates-clock.md#4-the-mount-row--a-regime-not-a-magnitude)).~~
+> *(Superseded 2026-08-07 — the implemented rule tests per-block band
+> membership rather than the mean, and seven of fourteen runs pass it.)*
+>
+> **The rows measured on THIS page are untouched by either ruling** — they
+> carry their own controls, adjudicated per row above — and this page remains
+> one of the three legs corroborating the direction. What holds below is that
+> M1 is compared against as a set of *readings*, never as the published figure.
 
 **At M1's readings, no.** On the census feed — 301 boundaries of 17-element
 cards, the read shape M1's 3-element rows share — the same gated ratio reads
@@ -300,10 +309,16 @@ readings do not transfer to census-real screens, where the measured deficit
 across the three rows spans 1.10–1.31×. That span is an observed range over
 three *different pages* — not a function of boundary decomposition, which this
 instrument does not isolate (`rf2-2rtt6.62`). And the second half is a
-comparison of readings, not of magnitudes: M1 publishes a regime rather than a
-number (`rf2-jcm3p`, 2026-08-06 — see the note above), and what these rows
-corroborate is its **direction**. The ruling on what that means for the
-programme is the operator's (`rf2-2rtt6.1`); this page measures.
+comparison of readings, not of magnitudes: ~~M1 publishes a regime rather than a
+number (`rf2-jcm3p`, 2026-08-06 — see the note above)~~ **the `~1.50×` readings
+compared here are not M1's published figure** *(2026-08-07, `rf2-t2flm`: M1 does
+publish a magnitude, conditionally labelled and drawn from the two retained
+ensembles —
+[`rf2-emvod` §4.3](rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row) —
+and it is neither of the readings named above; see the note earlier on this
+page)*, and what these rows corroborate is the **direction**. The ruling on what
+that means for the programme is the operator's (`rf2-2rtt6.1`); this page
+measures.
 
 ## 2026-08-07 the re-take on the current tree (rf2-jv36i)
 

--- a/docs/design/hicasso/studio/cross-checked-against-an-outside-instrument.md
+++ b/docs/design/hicasso/studio/cross-checked-against-an-outside-instrument.md
@@ -21,7 +21,15 @@ as corroborating rather than equal to it within 20%. What survives — and it is
 the stronger claim — is that an outside driver and ours agree to 8.8% on one app
 on one clock, so the deficit is not a harness artefact.
 
-> **THAT `1.4896×` IS A READING, NOT A PUBLISHED MAGNITUDE (`rf2-jcm3p`, ruled
+> **THAT `1.4896×` IS A READING, AND THE PUBLISHED MAGNITUDE IS ELSEWHERE
+> (`rf2-t2flm`, ruled 2026-08-07).** `M1` mount publishes `~1.184×` against
+> direct UIx-on-subs, conditionally labelled and drawn from two retained
+> quiet-box ensembles; the figures and their labels are at [`rf2-emvod`
+> §4.3](rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row)
+> and are not restated here. `1.4896×` stays visible wherever it appears below
+> as what the corrected clock read on 2026-08-01.
+>
+> ~~**THAT `1.4896×` IS A READING, NOT A PUBLISHED MAGNITUDE (`rf2-jcm3p`, ruled
 > 2026-08-06).** `M1` mount is stated as a **REGIME**: hicasso mounts materially
 > slower than both adapters — every corroborated reading sits above the amended
 > `≤ 1.10×` UIx gate — direction triple-corroborated (worst-case witnesses,
@@ -29,12 +37,13 @@ on one clock, so the deficit is not a harness artefact.
 > demonstrated**. The row's positive control fails (`ctl-2x` 1.8173× against a
 > predicted 2.00×, explained by the additive constant `c ≈ 1.04 ms`), so no
 > magnitude is published
-> ([the clock page's §4](the-candidates-clock.md#4-the-mount-row--a-regime-not-a-magnitude)).
-> `1.4896×` stays visible wherever it appears below as a historical observation
-> *stated under a failing `ctl-2x`; withdrawn as a magnitude 2026-08-06*.
-> **This page's OWN figures are untouched by that ruling** — §0 establishes they
-> are script-and-frame on an unaffected harness — and the corroboration above is
-> a direction, which is exactly what the regime publishes.
+> ([the clock page's §4](the-candidates-clock.md#4-the-mount-row--a-regime-not-a-magnitude)).~~
+> *(Superseded 2026-08-07: the implemented control rule tests per-block band
+> membership rather than the mean, and seven of fourteen runs pass it.)*
+>
+> **This page's OWN figures are untouched by either ruling** — §0 establishes
+> they are script-and-frame on an unaffected harness — and the corroboration
+> above is a direction, which both rulings agree this benchmark supplies.
 
 The bulk number is the one that matters most, because it is the **third** reading
 of that row taken past the `flushSync` boundary and the third to refuse the win:
@@ -339,8 +348,9 @@ of our harness.**
 > on this page is a script-and-frame reading and none of them is restated.**
 >
 > The decomposition is. Against the M1 witness re-taken on the corrected clock
-> — `1.4896×`, a reading and **not a published magnitude** (`rf2-jcm3p`,
-> 2026-08-06; see the note at the top of this page) — the two legs are
+> — `1.4896×`, a reading and **not the published magnitude** (~~`rf2-jcm3p`,
+> 2026-08-06~~ `rf2-t2flm`, 2026-08-07; see the note at the top of this
+> page) — the two legs are
 > **workload** (`1.4896 → 1.2789`, our
 > instrument throughout) and **instrument 8.8%** (`1.2789 → 1.1756`, the same
 > app throughout). *That these two compound to the whole gap is arithmetic
@@ -622,10 +632,16 @@ comparable to the public leaderboard** — which is not what it is for.
   ([§3.3](#33-the-mount-row-three-ways)). On a clock that sees the whole
   operation the programme's own witness reads **1.4896×**, so the deficit is
   worse than published rather than corroborated at 20%. **What this page hands
-  the programme on that row is a DIRECTION, not a number**: `rf2-jcm3p` restated
-  `M1` mount as a **regime** on 2026-08-06 — its `ctl-2x` fails, so no mount
-  magnitude is published — and named this benchmark as one of the three legs
-  corroborating that direction.
+  the programme on that row is a DIRECTION, and the number is stated
+  elsewhere**: ~~`rf2-jcm3p` restated `M1` mount as a **regime** on 2026-08-06 —
+  its `ctl-2x` fails, so no mount magnitude is published — and named this
+  benchmark as one of the three legs corroborating that direction.~~
+  *(Superseded 2026-08-07, `rf2-t2flm`: `M1` publishes a magnitude again,
+  conditionally labelled, at
+  [`rf2-emvod` §4.3](rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row).
+  What is unchanged is this page's part in it — an outside driver corroborating
+  the direction, one of three legs, and no figure of this page's restated by
+  either ruling.)*
 - **The bulk-broad win is refused by a third instrument.** `UIx / Reagent` reads
   0.9740 on the benchmark's `replace all rows` and 1.1419 on `swap rows`, against
   a published 0.6291. No instrument that has looked past the `flushSync`

--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -523,7 +523,7 @@ be expected to buy the same pair of refusals.
 
 ## 4. The mount row — a REGIME, not a magnitude
 
-> ## THE ROW PUBLISHES A MAGNITUDE AGAIN, AND THIS SECTION'S TITLE IS SUPERSEDED (`rf2-t2flm`, ruled 2026-08-07)
+> ## THE ROW PUBLISHES A MAGNITUDE AGAIN — THIS SECTION'S TITLE IS SUPERSEDED AND KEPT (`rf2-t2flm`, ruled 2026-08-07)
 >
 > **The regime-only statement below is superseded.** `M1` publishes `~1.184×`
 > against direct UIx-on-subs, conditionally labelled, on the two retained
@@ -531,8 +531,7 @@ be expected to buy the same pair of refusals.
 > labels every one of them must carry are at
 > [`rf2-emvod` §4.3](rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row),
 > and they are **not** duplicated here: two copies of a published row is how a
-> record starts disagreeing with itself, which is the failure this sweep exists
-> to repair.
+> record starts disagreeing with itself.
 >
 > **What fell was the ground, not a measurement.** `rf2-jcm3p` read `ctl-2x`'s
 > *mean* against `2.00×` and called that categorical failure. The implemented

--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -7,11 +7,18 @@ holds the operation's own script as well as the frame it causes, above the ship
 bar's `≤ 1.0×` and above
 [the restated M1 red zone](../validation.md#the-clock-gates-restated-on-the-post-25-tree)
 of `1.0150×`, with an interval that does not straddle 1.0. **That figure is a
-historical observation and not a published magnitude**: the row's positive
+historical observation and not the published magnitude**: ~~the row's positive
 control fails, so [§4](#4-the-mount-row--a-regime-not-a-magnitude) states the
 mount as a **regime** — *Hicasso mounts materially slower than both adapters,
-and `≤ 1.10×` has not been demonstrated* — rather than as a number.
-*(2026-08-06, `rf2-jcm3p`: this called `1.4896×` ~~the figure of record~~ and
+and `≤ 1.10×` has not been demonstrated* — rather than as a number.~~
+**Superseded 2026-08-07 (`rf2-t2flm`): the row publishes a magnitude again**,
+`~1.184×` against direct UIx-on-subs and conditionally labelled. The figures and
+the labels they must carry are at
+[`rf2-emvod` §4.3](rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row)
+and are not restated here. `1.4896×` remains what this programme read on
+2026-08-01, on a heavier load regime than the published row is drawn from.
+*(2026-08-06, `rf2-jcm3p` — **the withdrawal, since superseded**: this called
+`1.4896×` ~~the figure of record~~ and
 the mount ~~the only row of five whose positive control passed~~, and read the
 deficit as ~~established and not merely indicated~~. The control that carries
 this figure — `rf2-emvod`'s seven-run ensemble — reads `ctl-2x` at `1.8173×`
@@ -68,9 +75,13 @@ report.
 > [1.3488 – 1.5989] against the **1.2107×** below, and `hicasso / uix-subs` at
 > **1.5001×** against **1.1865×**. The candidate's mount deficit is *materially
 > worse* than ~~this page publishes~~ this page read before the correction, not
-> better. *(2026-08-06, `rf2-jcm3p`: neither mount figure is a published
+> better. *(2026-08-06, `rf2-jcm3p`: ~~neither mount figure is a published
 > magnitude any longer — both are stated under a failing `ctl-2x`, and
-> [§4](#4-the-mount-row--a-regime-not-a-magnitude) states the row as a regime.)*
+> [§4](#4-the-mount-row--a-regime-not-a-magnitude) states the row as a regime.~~
+> **Superseded 2026-08-07, `rf2-t2flm`**: the row publishes a magnitude again,
+> and it is neither of the two figures above — see
+> [`rf2-emvod` §4.3](rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row).
+> Both stay here as dated readings of the corrected clock.)*
 > `ctl-2x` is untouched — it reads
 > 1.69–1.83× the floor on both clocks — so [§6](#6-the-three-rows-this-page-refuses)'s
 > refusals stand unchanged.
@@ -512,7 +523,38 @@ be expected to buy the same pair of refusals.
 
 ## 4. The mount row — a REGIME, not a magnitude
 
+> ## THE ROW PUBLISHES A MAGNITUDE AGAIN, AND THIS SECTION'S TITLE IS SUPERSEDED (`rf2-t2flm`, ruled 2026-08-07)
+>
+> **The regime-only statement below is superseded.** `M1` publishes `~1.184×`
+> against direct UIx-on-subs, conditionally labelled, on the two retained
+> quiet-box ensembles. The figures, the estimators they are drawn on and the
+> labels every one of them must carry are at
+> [`rf2-emvod` §4.3](rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row),
+> and they are **not** duplicated here: two copies of a published row is how a
+> record starts disagreeing with itself, which is the failure this sweep exists
+> to repair.
+>
+> **What fell was the ground, not a measurement.** `rf2-jcm3p` read `ctl-2x`'s
+> *mean* against `2.00×` and called that categorical failure. The implemented
+> rule never asked the mean to equal `2.00×` — `controlVerdict` tests per-block
+> band membership, committed 2026-08-01, before either retained ensemble was
+> captured — and **seven of fourteen runs pass it on both clocks**. So no new
+> window was taken and nothing here was re-measured; a rule already in the tree
+> was read correctly for the first time.
+>
+> **This section keeps its title and its anchor.** `#4-the-mount-row--a-regime-not-a-magnitude`
+> is cited from five other pages, including the re-adjudication that carries the
+> published row, and an anchor is part of how this record is addressed. Renaming
+> it would strand those citations to spare a reader one line of reading; the
+> banner does that job instead.
+>
+> **The withdrawal below stays in full**, because the reasoning it records is
+> the reason the premise was worth re-examining.
+
 > ## THE MOUNT MAGNITUDE IS WITHDRAWN AND THE ROW IS RESTATED AS A REGIME (`rf2-jcm3p`, ruled 2026-08-06)
+>
+> ***Superseded 2026-08-07 by `rf2-t2flm` — see the banner immediately above.
+> Kept in full and unedited below.***
 >
 > **`1.4896×` [1.3488 – 1.5989] against Reagent-on-subs and `1.5001×` against
 > UIx-on-subs are withdrawn as MAGNITUDES.** The strict rule that refuses the
@@ -599,8 +641,8 @@ The bar arithmetic — two floor-normalised ratios, one against the other:
 
 | row | measured | range | disposition |
 |---|---:|---|---|
-| ~~**`hicasso / reagent-subs`**~~ | ~~1.2107×~~ | [0.9756 – 1.7208] | ~~**SUPERSEDED — frame-only.**~~ **REGIME, no magnitude** *(2026-08-06, `rf2-jcm3p`)*. Read **1.4896×** [1.3488 – 1.5989] on the corrected clock and **1.3737×** [1.3289 – 1.4331] on `rf2-emvod`'s heavier-regime ensemble — both above the `≤ 1.0×` win condition and the `1.0150×` red zone, neither straddling 1.0, **both stated under a failing `ctl-2x` and therefore historical observations rather than published magnitudes** |
-| ~~**`hicasso / uix-subs`**~~ | ~~1.1865×~~ | [0.9753 – 1.3722] | ~~**SUPERSEDED.**~~ **REGIME, no magnitude** *(2026-08-06, `rf2-jcm3p`)*. Read **1.5001×** on the corrected clock and **1.4656×** [1.3819 – 1.5088] on `rf2-emvod`'s ensemble; neither straddles 1.0, and both are stated under the same failing control |
+| ~~**`hicasso / reagent-subs`**~~ | ~~1.2107×~~ | [0.9756 – 1.7208] | ~~**SUPERSEDED — frame-only.**~~ ~~**REGIME, no magnitude** *(2026-08-06, `rf2-jcm3p`)*~~ **A MAGNITUDE AGAIN, CONDITIONALLY LABELLED** *(2026-08-07, `rf2-t2flm` — [§4.3](rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row))*. Read **1.4896×** [1.3488 – 1.5989] on the corrected clock and **1.3737×** [1.3289 – 1.4331] on `rf2-emvod`'s heavier-regime ensemble — both above the `≤ 1.0×` win condition and the `1.0150×` red zone, neither straddling 1.0, **both dated historical observations, and neither is the published figure** |
+| ~~**`hicasso / uix-subs`**~~ | ~~1.1865×~~ | [0.9753 – 1.3722] | ~~**SUPERSEDED.**~~ ~~**REGIME, no magnitude** *(2026-08-06, `rf2-jcm3p`)*~~ **A MAGNITUDE AGAIN, CONDITIONALLY LABELLED** *(2026-08-07, `rf2-t2flm` — [§4.3](rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row))*. Read **1.5001×** on the corrected clock and **1.4656×** [1.3819 – 1.5088] on `rf2-emvod`'s ensemble; neither straddles 1.0, and both are dated readings rather than the published figure |
 
 **What that means against the gates.** The P1 win condition is *mount ≤ 1.0×
 Reagent-on-subs, same run and same instrument*, and the restated M1 red zone is
@@ -608,12 +650,18 @@ Reagent-on-subs, same run and same instrument*, and the restated M1 red zone is
 candidate's point estimate is above both, in this run and in the four before it.
 ~~**On the clock of record the deficit is established**: `1.4896×`
 [1.3488 – 1.5989] does not straddle 1.0, and `rf2-emvod`'s independent ensemble
-agrees in direction at `1.3737×` [1.3289 – 1.4331].~~ **The deficit's DIRECTION
+agrees in direction at `1.3737×` [1.3289 – 1.4331].~~ ~~**The deficit's DIRECTION
 is established and its SIZE is not published** *(2026-08-06, `rf2-jcm3p`: an
 interval that misses 1.0 establishes a magnitude only against a control that can
 adjudicate it, and this row's cannot — see the banner above. What the readings
 jointly establish is the regime: above the `≤ 1.10×` UIx gate on every
-corroborated reading, with `≤ 1.10×` not demonstrated.)* ~~Its range straddles
+corroborated reading, with `≤ 1.10×` not demonstrated.)*~~ **Both the direction
+and a size are published, the size conditionally** *(2026-08-07, `rf2-t2flm`:
+this row's control can adjudicate it after all — the rule tests per-block band
+membership, not the mean — so the deficit has a magnitude again, at
+[§4.3](rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row)
+and under the labels stated there. Neither figure struck above is that
+magnitude.)* ~~Its range straddles
 1.0, so at n = 6 the deficit is not *established*~~ — that was the frame-only
 reading's hedge and it is spent. What still holds either way is
 validation.md's own rule that *a margin under 5% is instrument-limited rather
@@ -660,9 +708,13 @@ On the substrate arms the two windows differ by a factor of three to nine and �
 the part that matters — **by a different factor per arm**. It is not a scale
 error that cancels in a ratio: on M1 the in-page window puts
 `hicasso / reagent` at 1.56× where `taskNet` reads 1.21×, and raw
-`TaskDuration` — the clock that holds both halves — reads **1.4896×** (a
+`TaskDuration` — the clock that holds both halves — reads **1.4896×** (~~a
 reading under a failing `ctl-2x`; the row publishes no magnitude —
-[§4](#4-the-mount-row--a-regime-not-a-magnitude)).
+[§4](#4-the-mount-row--a-regime-not-a-magnitude)~~ a dated reading, and not the
+published magnitude, which is at
+[§4.3](rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row) —
+*2026-08-07, `rf2-t2flm`*). What this table is doing is comparing **windows**,
+and that comparison is unaffected either way.
 
 > **THE SEPARATION IS REAL AND THIS MECHANISM STATEMENT IS WRONG (`rf2-yd52q`,
 > measured by `rf2-emvod`).** The `+300–610%` above is not one window
@@ -1210,7 +1262,7 @@ readings; the **magnitudes** are superseded row by row on
 
 | run 5 row *(all figures `taskNet`)* | margin from 1.0 | against | verdict |
 |---|---:|---|---|
-| `M1`, `hicasso / reagent-subs` ~~1.2107~~ | 21.1% | its own band, ≤ 11.7% | **clears the band** — ~~published, as it was; the magnitude is now **1.4896×**~~ **and still publishes no magnitude** *(2026-08-06, `rf2-jcm3p`)*. The corrected clock read **1.4896×** [1.3488 – 1.5989] on this row, under a failing `ctl-2x`; clearing the band is not clearing the control, and [§4](#4-the-mount-row--a-regime-not-a-magnitude) states the row as a regime |
+| `M1`, `hicasso / reagent-subs` ~~1.2107~~ | 21.1% | its own band, ≤ 11.7% | **clears the band** — ~~published, as it was; the magnitude is now **1.4896×**~~ ~~**and still publishes no magnitude** *(2026-08-06, `rf2-jcm3p`)*. The corrected clock read **1.4896×** [1.3488 – 1.5989] on this row, under a failing `ctl-2x`; clearing the band is not clearing the control, and [§4](#4-the-mount-row--a-regime-not-a-magnitude) states the row as a regime~~ **and publishes a magnitude again, conditionally labelled** *(2026-08-07, `rf2-t2flm` — [§4.3](rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row))*. The corrected clock read **1.4896×** [1.3488 – 1.5989] on this row, which stays a dated observation; the published figure is drawn from the two retained ensembles and stated at §4.3 |
 | `bulk300` ~~1.0100~~ | 1.0% | smaller than every band ever measured here | instrument-limited — refused, as it was; **1.1494×** corrected |
 | `bulk100` ~~0.9902~~ | 1.0% | the same | instrument-limited — refused, as it was; **1.1089×** corrected, a sign change |
 | `narrow` 1.0369 | 3.7% | the same | instrument-limited — refused, as it was; **1.0236×** corrected |
@@ -1392,15 +1444,16 @@ inputs are gone; the durable path starts at the re-run and not before it.
 ## 8. What this hands the programme
 
 - **The candidate has clock rows.** It did not before.
-- **On mount it is materially slower than Reagent-on-subs — a REGIME, and not a
-  magnitude** *(2026-08-06, `rf2-jcm3p`;
-  [§4](#4-the-mount-row--a-regime-not-a-magnitude))*. ~~On mount it is 1.4896×
+- **On mount it is materially slower than Reagent-on-subs, and the row publishes
+  a magnitude** *(2026-08-07, `rf2-t2flm`;
+  [§4.3](rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row))* —
+  ~~a REGIME, and not a magnitude *(2026-08-06, `rf2-jcm3p`;
+  [§4](#4-the-mount-row--a-regime-not-a-magnitude))*~~. ~~On mount it is 1.4896×
   Reagent-on-subs on the clock of record [1.3488 – 1.5989], against a `≤ 1.0×`
   win condition and a `1.0150×` red zone.~~ That reading stands as a historical
-  observation *stated under a failing `ctl-2x`*: it sits above the `≤ 1.0×` win
-  condition and the `1.0150×` red zone, as does every other corroborated
-  reading, and `≤ 1.10×` has not been demonstrated — but the row publishes no
-  number.
+  observation: it sits above the `≤ 1.0×` win condition and the `1.0150×` red
+  zone, as does every other corroborated reading. What the row now publishes,
+  with the conditional labels it must carry, is stated at §4.3 and not here.
   This page's own `1.21×` is the frame-only reading of the same row, above
   parity in all five of its runs; the correction moved the figure *up*. Still
   not a clear K1 kill — K1 asks for `> Reagent` *after two serious runtime

--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -18,9 +18,9 @@ the labels they must carry are at
 and are not restated here. `1.4896×` remains what this programme read on
 2026-08-01, on a heavier load regime than the published row is drawn from.
 *(2026-08-06, `rf2-jcm3p` — **the withdrawal, since superseded**: this called
-`1.4896×` ~~the figure of record~~ and
-the mount ~~the only row of five whose positive control passed~~, and read the
-deficit as ~~established and not merely indicated~~. The control that carries
+`1.4896×` ~~the figure of record~~ and the mount ~~the only row of five whose
+positive control passed~~, and read the deficit as ~~established and not merely
+indicated~~. The control that carries
 this figure — `rf2-emvod`'s seven-run ensemble — reads `ctl-2x` at `1.8173×`
 against a predicted `2.00×`, and two re-takes on verifiably idle boxes
 reproduced the miss. The strict rule that refuses the three bulk rows in

--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -396,6 +396,27 @@ and the two instrument repairs a refusing control forced:
 > agree to 0.3%. Full re-adjudication:
 > [the corrected clock's page](studio/rows-re-adjudicated-on-the-corrected-clock.md).
 
+> **Amended again, 2026-08-07 — the `M1` mount row publishes a MAGNITUDE once
+> more, conditionally labelled (`rf2-t2flm`).** The withdrawal recorded below is
+> **superseded**, and not because anything was re-measured: `rf2-jcm3p` read
+> `ctl-2x`'s *mean* against `2.00×` and called that categorical failure, where
+> the implemented rule tests per-block band membership — a rule committed
+> 2026-08-01, before either retained ensemble was captured — and seven of
+> fourteen runs pass it on both clocks. The row publishes `~1.184×` against
+> direct UIx-on-subs on the two retained quiet-box ensembles, with two
+> ensemble-specific estimates against Reagent-on-subs and no pooled point. The
+> figures, the estimators and the labels each one must carry are stated at
+> [`rf2-emvod` §4.3](studio/rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row)
+> and are **not** duplicated here. **K1 is untouched by the change** — the gate
+> is `≤ 1.10×` direct UIx, and the published row sits above it, as does every
+> whole-ensemble run mean behind it. `1.4896×` and `1.5001×` stay visible below
+> as dated historical observations; neither is the published figure. Delegated
+> ruling, operator-overturnable.
+
+> ***Superseded 2026-08-07 by `rf2-t2flm` — see the banner immediately above.
+> Kept in full because the reasoning is why the premise was worth
+> re-examining.***
+>
 > **Amended, 2026-08-06 — the `M1` mount row publishes a REGIME, not a
 > magnitude (`rf2-jcm3p`).** The figure the note above substitutes in is itself
 > **withdrawn as a magnitude**: `1.4896×` [1.3488 – 1.5989] against
@@ -419,7 +440,7 @@ and the two instrument repairs a refusing control forced:
 
 | row | candidate | disposition |
 |---|---|---|
-| **M1 mount** | ~~1.2107× Reagent-on-subs~~ *(frame-only)* → ~~**1.4896×** [1.3488 – 1.5989] on script-and-frame~~ **REGIME, no magnitude** *(2026-08-06, `rf2-jcm3p`)* — reads `1.4896×` [1.3488 – 1.5989] on script-and-frame, **stated under a failing `ctl-2x` and therefore a historical observation rather than a published magnitude** | above the `≤ 1.0×` win condition and above the `1.0150×` red zone on either clock, and above the amended `≤ 1.10×` UIx gate on every corroborated reading — **the direction is what publishes; the size is not** (`rf2-jcm3p`). The frame-only range straddled 1.0 so a deficit was not *established* at n = 6; the corrected clock's interval does **not** straddle it, and the deficit is larger — but an interval missing 1.0 establishes a *magnitude* only against a control that can adjudicate it, and this row's cannot. The deficit is the runtime hiccup **codec**, not the spine: the candidate pays +1.06 ms over its own floor where `uix-subs` — same spine, same adapter, same 300 reads, byte-identical DOM — pays +0.38 ms |
+| **M1 mount** | ~~1.2107× Reagent-on-subs~~ *(frame-only)* → ~~**1.4896×** [1.3488 – 1.5989] on script-and-frame~~ → ~~**REGIME, no magnitude** *(2026-08-06, `rf2-jcm3p`)*~~ **A MAGNITUDE AGAIN, CONDITIONALLY LABELLED** *(2026-08-07, `rf2-t2flm` — [§4.3](studio/rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row))*; `1.4896×` [1.3488 – 1.5989] on script-and-frame remains a dated 2026-08-01 reading and is **not** the published figure | above the `≤ 1.0×` win condition and above the `1.0150×` red zone on either clock, and above the amended `≤ 1.10×` UIx gate on every corroborated reading — ~~**the direction is what publishes; the size is not** (`rf2-jcm3p`)~~ **the direction and a conditionally-labelled size both publish** (`rf2-t2flm`, §4.3). The frame-only range straddled 1.0 so a deficit was not *established* at n = 6; the corrected clock's interval does **not** straddle it, and the deficit is larger. ~~But an interval missing 1.0 establishes a *magnitude* only against a control that can adjudicate it, and this row's cannot.~~ *(This row's control can adjudicate it — the rule tests per-block band membership, and 7 of 14 runs pass.)* The deficit is the runtime hiccup **codec**, not the spine: the candidate pays +1.06 ms over its own floor where `uix-subs` — same spine, same adapter, same 300 reads, byte-identical DOM — pays +0.38 ms |
 | **per-keystroke** | one frame, as are both donors | Event Timing puts every arm at its 16 ms reporting floor; the finer clock reads 2.0–2.3 ms of main-thread work inside a 16.7 ms budget. Indistinguishable, and a pass for all three |
 | bulk K=100/300, narrow | **refused** | the doubling control failed the strict rule in every run, and the rows move more between runs (0.87 → 1.38 on one) than the effect they report. The page names three repairs, one of which is that `ctl-2x` is mis-specified for an *update* row — it doubles the page, and on an update the work does not follow |
 
@@ -428,8 +449,11 @@ samples, an in-page `performance.now()` window and `taskNet` **split** a
 substrate arm 300–610% apart, **and by a different factor per arm** — on M1 the
 in-page window puts the candidate at 1.56× Reagent where `taskNet` reads 1.21×
 and the clock holding both halves reads 1.4896× (three *readings* of one row on
-three clocks — none of them a published magnitude since `rf2-jcm3p`, above; the
-finding here is the split between them, which the withdrawal does not touch). It
+three clocks — none of them ~~a published magnitude since `rf2-jcm3p`, above~~
+**the published magnitude, which is at
+[§4.3](studio/rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row)**
+*(2026-08-07, `rf2-t2flm`)*; the finding here is the split between them, which
+neither ruling touches). It
 is not a scale error that cancels in a ratio. The pure-React control arms differ
 by only 6–13%, which is
 how a lane that checks only its controls in-page would never see it — and,
@@ -457,7 +481,7 @@ ours.
 
 | row | outside instrument | our published figure | disposition |
 |---|---|---|---|
-| **candidate mount** | `1.1756×` on create-1,000 | ~~`1.2107×`~~ `1.4896×` on M1 — **no longer a published figure**, the row states a regime *(2026-08-06, `rf2-jcm3p`)* | **corroborated in direction, which is what now publishes** (`rf2-emvod`; `rf2-jcm3p` for the regime). `1.2107×` is a frame-**only** figure and the outside instrument's is script-and-frame, so "1.18–1.28" compared unlike things. On one clock the gap is **workload (~7–17%)** plus an **instrument-window 8.8%** with a named mechanism — and the leg that was previously invisible, the clock definition, is eliminated rather than estimated. The mount deficit is not a harness artefact and is **larger on our own witness** than this row read |
+| **candidate mount** | `1.1756×` on create-1,000 | ~~`1.2107×`~~ `1.4896×` on M1 — ~~**no longer a published figure**, the row states a regime *(2026-08-06, `rf2-jcm3p`)*~~ **not the published figure, which is at [§4.3](studio/rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row)** *(2026-08-07, `rf2-t2flm`)* | **corroborated in direction** (`rf2-emvod`), and the direction is what an outside instrument on a different app can supply. `1.2107×` is a frame-**only** figure and the outside instrument's is script-and-frame, so "1.18–1.28" compared unlike things. On one clock the gap is **workload (~7–17%)** plus an **instrument-window 8.8%** with a named mechanism — and the leg that was previously invisible, the clock definition, is eliminated rather than estimated. The mount deficit is not a harness artefact and is **larger on our own witness** than this row read |
 | **donor bulk broad** | `0.9740×` on replace-all, `1.1419×` on swap | ~~`0.6291×`~~ **withdrawn** | **refused a third time, and now [re-taken](studio/bulk-broad-re-taken.md).** No instrument that sees the whole operation reproduces the 37% win; the re-take reads `0.8602×`, keeps the direction and publishes no magnitude. It expected parity and did not find it either — the row is a real but much smaller win, at the edge of the instrument's resolution |
 | candidate bulk | `1.6216×` theirs / `1.4260×` ours on replace-all | **refused** by the clock page | the candidate's **worst** row, agreed by both instruments and materially worse than its mount |
 | candidate narrow | `0.7203×` theirs / `0.7583×` ours on partial-update | **refused** by the clock page | a **win** — 24–28% faster than Reagent-on-subs. UIx wins it slightly harder |


### PR DESCRIPTION
`rf2-t2flm` superseded `rf2-jcm3p`'s regime-only statement on 2026-08-07 and PR #7678 published
the M1 row at `docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md`
[§4.3](https://github.com/day8/re-frame2/blob/main/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row).
That PR annotated the two pages the ruling named plus the studio README. **Five more pages still
asserted the withdrawn claim and now contradicted the published row.** This is the sweep.

Nothing is measured, recomputed or re-derived here. No figure is restated beyond the published
headline `~1.184×`, always with its conditional label and always beside a link to §4.3 — the same
shape PR #7678 used on `the-clock-behind-the-published-rows.md`, and for the same reason it gave:
two copies of a published row is how a record starts disagreeing with itself.

### Annotate, never erase

Every superseded sentence is struck rather than deleted, the supersession is dated
(2026-08-07) and attributed (`rf2-t2flm`), and `1.4896×`, `1.3737×`, `1.5001×` and `1.4656×`
all remain visible as dated historical observations. Where a page carried a whole banner
asserting the withdrawn claim, a dated superseding banner goes **above** it and the old one is
marked superseded in place and kept in full — the reasoning it records is why the premise was
worth re-examining.

### Per-page sites swept

Site counts were taken as `git grep -c jcm3p` at the merge base and checked against the bead's
own counts. All match.

| page | `jcm3p` sites at base | asserting the withdrawn claim | annotated |
|---|---:|---:|---:|
| `studio/the-candidates-clock.md` | 8 | 8 | 8 |
| `studio/bulk-broad-re-taken.md` | 2 | 2 | 2 |
| `studio/census-real-clock-rows.md` | 4 | 2 | 2 |
| `studio/cross-checked-against-an-outside-instrument.md` | 3 | 3 | 3 |
| `validation.md` | 4 | 4 | 4 |

**`census-real-clock-rows.md` — two references deliberately untouched.** Its predictions table
row *"ctl-2x reads below its arithmetic prediction on every row (`rf2-jcm3p`)"* and its note that
*"the mount control cannot certify exactness, only page-proportional signal (`rf2-jcm3p`)"* cite
`rf2-jcm3p`'s **mechanism** finding, not its regime statement. Both survive the premise correction
intact — the correction is that the implemented rule tests per-block band membership rather than
the mean, which is if anything what the second of those two already said.

**One site with no `jcm3p` token was also swept**: `the-candidates-clock.md` §4.1 read
*"the row publishes no magnitude — §4"* in a parenthetical, which asserts the withdrawn claim
without naming the bead. It is annotated with the rest.

### The heading-anchor decision

`the-candidates-clock.md` carries two headings asserting the withdrawn claim — the section
heading `## 4. The mount row — a REGIME, not a magnitude` and, beneath it, the blockquoted banner
`> ## THE MOUNT MAGNITUDE IS WITHDRAWN AND THE ROW IS RESTATED AS A REGIME`.

**Both are kept, and annotated beneath.** The evidence:

```
git grep -n "the-candidates-clock.md#4-the-mount-row--a-regime-not-a-magnitude" -- docs/
```

returns **13 inbound links across 6 files** — 5 self-links inside `the-candidates-clock.md`, plus
`bulk-broad-re-taken.md:290`, `census-real-clock-rows.md:212`,
`cross-checked-against-an-outside-instrument.md:32`, `validation.md:417`, and
**`rows-re-adjudicated-on-the-corrected-clock.md:43`**.

That last one settles it. It is a page **outside this bead's write surface** — it is the page PR
#7678 landed hours ago and the page that carries the published row this sweep points at. Renaming
the heading would require editing it, expanding this diff into the surface of a just-merged PR to
spare a reader one line of reading. An anchor is also part of how this record is addressed: four
other studio pages and `validation.md` cite `#4-...` as a stable citation target, and the tree's
own discipline is to annotate history rather than re-address it.

So the section keeps its title and its slug, and a dated banner immediately below the heading
says the title is superseded and why it is kept. The banner says this in the page itself, so a
reader meeting the heading cold is corrected in the next line rather than left to infer it.
`check_doc_slugs.py` exits 0, which is the proof the 13 links still resolve.

The blockquoted banner is kept for the same reason plus one more: `git grep` for any link to its
slug returns **empty**, so renaming it would strand nothing — but its text is part of the record
the tree exists to keep, and the page's own idiom (the frame-only banner above §1, the Event
Timing banner in §5) is stacked dated banners rather than rewritten ones. It gains a
`***Superseded 2026-08-07 by rf2-t2flm***` line at its head and is otherwise untouched.

## Quality gates

Every gate run in the foreground to completion, redirected to a worktree-local log, exit code
echoed explicitly. No gate piped through `tail`/`head`/`grep`.

| gate | command | exit |
|---|---|---:|
| doc slugs | `python scripts/check_doc_slugs.py` | **0** |
| doc slugs — **probe** | same, with one anchor deliberately broken | **1** |
| doc slugs — after revert | `python scripts/check_doc_slugs.py` | **0** |
| provenance pins | `python scripts/check_provenance_pins.py --changed-since origin/main` | **0** |
| beads PR boundary | `sh scripts/check-beads-pr-boundary.sh origin/main` | **0** |

**`mkdocs build --strict` is NOT nominated** — `mkdocs.yml`'s `exclude_docs` keeps
`design/hicasso/` out of the site, so it would exit 0 having read none of these files.

**The slug gate was probe-verified**, as it is the gate that matters most here: the whole diff is
cross-page links. Breaking one anchor at an edit site of mine (`validation.md`, the §4.3 link in
the new banner) produced `1 broken anchor link(s) found` naming
`docs\design\hicasso\validation.md:409` and the bad slug, exit **1**. Reverted; exit **0**.

**The provenance gate did not fire** — exit 0, empty output. Nothing was re-pinned, and no
authored SHA was touched or deleted.

### Hand-verified by eye, because nothing automates it

**Table column counts. 64 tables across the five pages, all rectangular; 4 of them touched.**

| table | columns | data rows |
|---|---:|---:|
| `the-candidates-clock.md` — the bar-arithmetic table (both M1 rows edited) | 4 | 2 |
| `the-candidates-clock.md` — the run-5 band table (M1 row edited) | 4 | 4 |
| `validation.md` — the row/candidate/disposition table (M1 mount row edited) | 3 | 3 |
| `validation.md` — the outside-instrument table (candidate mount row edited) | 4 | 4 |

One apparent ragged table on `cross-checked-against-an-outside-instrument.md:295` and `:306` was
run down and is a **counting artefact, not a defect**: those headers carry escaped pipes, which
are content rather than delimiters. Honouring the escape, both are 7 columns throughout. Neither
is touched by this diff.

**Strikethrough and emphasis balance.** Every `~~` pair closes within its own block, and the five
pages render to **0 literal `~~`** with 43 / 2 / 2 / 12 / 13 `<del>` elements respectively — so
every strike this diff adds is a strike, not stray text on the page.

### Left alone deliberately

- **No figure looked wrong.** Nothing was found that needed reporting and could not be swept.
- **`studio/hd8-composed-donor-arm.md:312`** carries the sixth `rf2-jcm3p` reference in the tree —
  *"no changed-set control can reach a mount (`rf2-jcm3p`)"*. That is the mechanism claim, it
  survives the correction, and the page is outside this bead's write surface. Not touched, and
  flagged here so the next sweep does not re-open it.
- **The epic `rf2-2rtt6` sitting-prep K1 line** is still the mayor's, per `rf2-t2flm`'s own
  outstanding note. `validation.md`'s K1 sentence is stated as untouched by the change — the gate
  is still `≤ 1.10×` direct UIx — rather than restated.

Closes `rf2-ih772`. This also clears the last surviving item of `rf2-emvod`
(`the-candidates-clock.md`'s M1 sites), which the mayor closes after this merges.
