### PR TITLE
docs(hicasso): the two estimators agree on the rows shown, not universally (rf2-w3yxd)

### DIFF
--- a/docs/design/hicasso/studio/the-clock-behind-the-published-rows.md
+++ b/docs/design/hicasso/studio/the-clock-behind-the-published-rows.md
@@ -189,9 +189,12 @@ second estimator is un-tared rather than un-normalised, so it is not the quantit
 either. That was a run on the box, `rf2-w3yxd` owned it, and **it has been
 taken**: [the 2026-08-07 ensemble](#2026-08-07-the-ensemble-on-the-corrected-clock-and-what-it-refuses-rf2-w3yxd)
 publishes both estimators off its own retained files on all three windows, and
-puts the term this paragraph could not size at **0.6 to 3.9 percentage points**
-on `M1`, `bulk300` and `narrow`. It changes no verdict anywhere, which is the
-same answer the in-page rows gave.
+puts the term this paragraph could not size at **0.5 to 3.9 percentage points**
+across the comparisons it tabulates on `M1`, `bulk300` and `narrow`, changing no
+direction among them — the same answer the in-page rows gave. That bounds those
+comparisons and not the estimator: four comparisons outside the set do cross,
+every one on a row the ensemble refused a magnitude for, and the section names
+them.
 
 This is the mechanism the pure-React controls were never able to catch. A lane
 that certifies its instrument on `ctl-2x` alone is certifying the arm least
@@ -834,14 +837,28 @@ not become answerable or unanswerable with the row's control:
 | `bulk300` · `uix-subs / reagent-subs` | raw `TaskDuration` | 0.8743× [0.8253 – 0.9280] | 0.9036× [0.8701 – 0.9220] | −2.9 pp |
 | `bulk300` · `uix-subs / reagent-subs` | `taskNet` | 1.0267× [0.9127 – 1.1300] | 1.0570× [0.9879 – 1.1517] | −3.0 pp |
 | `narrow` *(k=1)* · `uix-subs / reagent-subs` | raw `TaskDuration` | 0.9520× [0.7351 – 1.0449] | 0.9692× [0.8730 – 1.0374] | −1.7 pp |
-| `narrow` *(k=1)* · `uix-subs / reagent-subs` | `taskNet` | 1.0056× [0.8023 – 1.2199] | 1.0102× [0.9108 – 1.1090] | −1.7 pp |
+| `narrow` *(k=1)* · `uix-subs / reagent-subs` | `taskNet` | 1.0056× [0.8023 – 1.2199] | 1.0102× [0.9108 – 1.1090] | ~~−1.7 pp~~ → **−0.5 pp** |
 
-**So the term §2 could not size is between 0.6 and 3.9 percentage points on
-these rows, and it does not change a verdict anywhere.** The two estimators
-agree on direction on every row and every window, which is the same answer
-[the converged page](p0-converged-witness-set.md#two-estimators-published-together)
-reached for the in-page rows. That is a bound on what the normalisation does to
-a mean — it is not licence to quote a refused row's mean.
+**So the term §2 could not size is between 0.5 and 3.9 percentage points on the
+nine comparisons above, and on none of them does it change a direction** — the
+same answer [the converged page](p0-converged-witness-set.md#two-estimators-published-together)
+reached for its own four in-page rows.
+
+**That is a bound on the comparisons selected here, not a property of the
+estimator.** `clock_readjudicate.cjs` forms the pair for every row, pair and
+window it can, which is forty-two comparisons, and four of them cross.
+`bulk100` · `uix-subs / reagent-subs` reads `1.0072×` normalised against
+`0.9949×` raw on the published clock; `narrow` · `hicasso / reagent-subs` reads
+`0.9659×` against `1.0065×` on `taskNet`; and `keystroke` ·
+`uix-subs / reagent-subs` crosses on both of those windows — `1.0265×` against
+`0.9754×`, and `1.0209×` against `0.9590×`. The gap runs wider outside the table
+too: `5.4 pp` on `narrow` · `hicasso / uix-subs` in-page, `9.8 pp` on `bulk100` ·
+`hicasso / uix-subs`. Every crossing falls on a row the per-row table above
+refused a magnitude for, and none of the eight figures sits more than 4.1 points
+from parity, so no verdict on this page turns on which estimator is read. But
+agreement on the rows chosen is not agreement in general, and this paragraph
+used to claim the latter. That is a bound on what the normalisation does to a
+mean — it is not licence to quote a refused row's mean.
 
 ### What is NOT restated
 


### PR DESCRIPTION
Reopened half of **rf2-w3yxd** — the merged-PR audit of #7671 (2026-08-07, correctness).
The measurement half is done and untouched: the corpus is retained at
`implementation/freehand/test/re_frame/bench/hicasso/data/clock-w3yxd/run{1..6}.json`,
six of six `canonical: true`, readjudicator exit 0.

## What was false

`the-clock-behind-the-published-rows.md`, under the estimator-comparison tables:

> The two estimators **agree on direction on every row and every window**, which is
> the same answer the converged page reached for the in-page rows.

The two tables present **nine** comparisons. `clock_readjudicate.cjs` forms **42**
over the same six datasets, and four of them cross. The claim was true of the nine
and stated of all of them. The `0.6–3.9 pp` range had the same shape.

## Reproduced from the retained corpus

One command, no measurement taken (this is analysis over files already in the tree):

```
cd implementation/freehand
node test/re_frame/bench/hicasso/clock_readjudicate.cjs \
  test/re_frame/bench/hicasso/data/clock-w3yxd/run{1..6}.json
```

Exit **0**. Every figure below is read off that output.

| row · pair | window | floor-normalised | raw quotient | gap |
|---|---|---|---|---|
| `bulk100` · `uix-subs / reagent-subs` | raw `TaskDuration` | 1.0072× | 0.9949× | 1.2 pp — **crosses** |
| `narrow` · `hicasso / reagent-subs` | `taskNet` | 0.9659× | 1.0065× | 4.1 pp — **crosses** |
| `keystroke` · `uix-subs / reagent-subs` | raw `TaskDuration` | 1.0265× | 0.9754× | 5.1 pp — **crosses** |
| `keystroke` · `uix-subs / reagent-subs` | `taskNet` | 1.0209× | 0.9590× | 6.2 pp — **crosses** |
| `narrow` · `hicasso / uix-subs` | in-page | 1.1211× | 1.0673× | 5.4 pp |
| `bulk100` · `hicasso / uix-subs` | in-page | 1.3311× | 1.2334× | 9.8 pp |

The three crossings the audit named all reproduce to four decimal places. A **fourth**
does too, which the audit did not name: the same `keystroke` pair one window over.
`5.4 pp` reproduces, and it is not the widest — `bulk100` · `hicasso / uix-subs`
in-page runs to `9.8 pp`.

Every crossing falls on a row this ensemble **refused a magnitude for** (`bulk100`
0/6, `narrow` 0/6, `keystroke` structurally unadjudicated), and none of the eight
figures is more than 4.1 points from parity. No product verdict moves. The absolute
method conclusion does, and that is what is corrected.

## One gap cell was wrong, and the range depended on it

Recomputing all nine tabulated gaps at full precision, eight reproduce exactly.
The ninth does not:

| cell | published | recomputed |
|---|---|---|
| `narrow` *(k=1)* · `uix-subs / reagent-subs`, `taskNet` | −1.7 pp | **−0.5 pp** |

`1.0056 − 1.0102 = −0.46 pp`. The `−1.7` is the same pair's *published-clock* gap,
one table row up; the readjudicator prints only that one gap per pair, so the
transcription had nothing to check it against. The corrected cell moves the
tabulated range's floor from `0.6` to `0.5`, which is why it is fixed here rather
than filed — the sentence being scoped quotes that range. Recorded with the page's
own strikethrough-arrow convention. **No ratio, band, published row or product
figure is restated.**

## The correction

Both statements of the claim, scoped to what the tables actually present:

- **§2** (the forward reference): range now `0.5 to 3.9 pp` *across the comparisons
  it tabulates*, "changing no direction among them", with a pointer that four
  comparisons outside the set cross.
- **Under the tables**: the conclusion scoped to the nine comparisons; a following
  paragraph names all four crossings with their figures, gives the two out-of-range
  gaps, and states both halves honestly — no verdict on the page turns on which
  estimator is read, but agreement on the rows chosen is not agreement in general.

§4 and the "What is NOT restated" section are untouched.

## The converged page does not overreach — reported, not edited

`p0-converged-witness-set.md:823` reads *"The two estimators agree on the verdict of
every row"*. It sits immediately under its own five-row table, which carries a
per-row `agree?` column showing that verdict for each. "Every row" is bounded by the
table above it, every cell is verified in place, and it makes no claim about an
instrument's whole output. **No correction needed there.** The cross-reference from
this page is re-pointed to "its own four in-page rows" for precision. Not edited —
different surface, possibly another bead's.

## Quality gates

Foreground, to completion, exit code captured explicitly (never piped):

| gate | scope | exit |
|---|---|---|
| `python scripts/check_doc_slugs.py` | anchors + link targets, whole tree | **0** |
| `python scripts/check_doc_slugs.py` (**probe**) | anchor deliberately broken at the edit site | **1** — `…the-clock-behind-the-published-rows.md:844`, reverted, re-run **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | 1 file, 2 cited pins | **0** — 2 landed, 0 stranded, 0 unresolvable |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | no beads-database paths in diff | **0** |
| `node clock_readjudicate.cjs run{1..6}.json` | re-read of the retained corpus | **0** |

`mkdocs build --strict` is **not** nominated and does not apply: `mkdocs.yml`'s
`exclude_docs` keeps `design/hicasso/` out of the site.

**Table column counts, hand-verified** (nothing automated checks them). Both tables
in the touched section are **5 columns** on header, separator and every data row —
the M1 table 5 data rows, the `bulk300`/`narrow` table 4. Counted by pipes per line;
the only table cell changed is the one gap cell above, which does not change the
count.

**No measurement was taken.** Seven other workers are on this box; reading the
retained corpus with the readjudicator is a read.
