### PR TITLE
fix(hicasso): the decomposition fold refuses partial evidence instead of zeroing it (rf2-jo60g)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -627,6 +627,170 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
       }
     }
   });
+
+  // --- rf2-jo60g, merged-PR audit #7666: PARTIAL evidence must refuse too ----
+  //
+  // The landing above closed the ABSENT case and left the partial one open. It
+  // checked the outer array and nothing inside it, then summed with
+  // `acc[k] += a[k] || 0` — so `foldDecomposition([[]])` and
+  // `foldDecomposition([[{}]])` each answered `{}`, and an arm that had lost
+  // `task`/`script`/`layoutCount`, or carried an explicit `null`, folded with
+  // every missing field synthesised as zero. A half-written or truncated
+  // dataset therefore became a plausible Script/Layout/RecalcStyle ratio
+  // instead of the refusal this bead promises, which is the fail-open the
+  // whole bead exists to close, one level down from where it was closed.
+  //
+  // Every fixture below is built HERE. The committed datasets cannot witness
+  // these states — they either carry a whole split or none — and a negative
+  // case that needs a file to be wrong on disk is not a test anyone can run.
+
+  const { summarise, verdict } = DRIVERS[1].mod;
+
+  // `drive`'s own composition, on the real exported functions: `report` folds
+  // BEFORE anything else it does, inside the try; a throw sets `failed`, so the
+  // row never reaches `results`; `verdict` reads `failed`; and the dataset write
+  // is gated on `results.length && !failed`. A refusal that throws where nothing
+  // catches is not the same as a driver that exits non-zero — this drives the
+  // second. The source pins below hold the reconstruction to the shape it
+  // stands for, so it cannot drift away from the driver while still passing.
+  const summarisable = () => {
+    const r = fixtureRow();
+    r.adjudication.ctl = { ok: true, measured: { mean: 1.9943 } };
+    return r;
+  };
+  const driveOn = (blocksDecomp) => {
+    const results = [];
+    let failed = null;
+    try {
+      foldDecomposition(blocksDecomp); // `report`'s first act on the row
+      results.push(summarisable()); // reached only if the fold ANSWERED
+    } catch (e) {
+      failed = e.message;
+    }
+    const v = verdict(summarise(failed, results));
+    return {
+      code: v.code,
+      wrote: Boolean(results.length && !failed),
+      canonical: destination(shape(), v.code).canonical,
+      why: failed || '',
+    };
+  };
+
+  t("the reconstruction above IS `drive`'s composition, and stays that way", () => {
+    // Each pin is one link of the chain the witnesses below assume. Newlines
+    // are normalised because this tree is checked out with CRLF on Windows.
+    const src = SRC.replace(/\r\n/g, '\n');
+    assert.match(src, /function report\(out\) \{\n {2}const \{[^}]*blocksDecomp[^}]*\} = out;\n {2}const decomposition = foldDecomposition\(blocksDecomp\);/);
+    const drive = src.slice(src.indexOf('async function drive('));
+    assert.match(drive, /const out = await runRow\(browser, runDef, rowId\);\n\s*const adj = report\(out\);\n\s*results\.push\(/);
+    assert.match(drive, /\} catch \(e\) \{\n\s*failed = e\.message;/);
+    assert.match(drive, /if \(results\.length && !failed\) \{/);
+  });
+
+  // The green case first, so nothing below is vacuously red: the valid fixture
+  // folds, the row is kept, and the run writes to the canonical set.
+  t('the fold ANSWERS on whole evidence — the gate is not vacuous', () => {
+    const d = driveOn(FIXTURE_DECOMP);
+    assert.strictEqual(d.code, 0, 'a complete decomposition must fold, not refuse');
+    assert.strictEqual(d.wrote, true);
+    assert.strictEqual(d.canonical, true);
+  });
+
+  t('the fold sums the stored fields and DEFAULTS nothing', () => {
+    // `acc[k] += a[k] || 0` is the defect itself. Pinned in the source because
+    // a rewrite of the loop could reintroduce it while every witness below
+    // still described a state the new loop happened to reject some other way.
+    const fold = SRC.slice(SRC.indexOf('function foldDecomposition('), SRC.indexOf('function taredCell('));
+    assert.ok(fold.length > 0, 'the fold no longer has the shape this test pins');
+    assert.ok(!/\|\| 0/.test(fold), 'a missing or null metric must REFUSE, not become zero');
+    assert.match(fold, /for \(const k of DECOMP_FIELDS\) acc\[k\] \+= a\[k\];/);
+  });
+
+  t('the collector, the serialiser and the fold agree on ONE field list', () => {
+    // Three readers over one constant; the split was dropped in the first place
+    // because a field could be collected and then not be required anywhere.
+    assert.match(SRC, /^const DECOMP_FIELDS = \['n', 'task', 'taskNet', 'devtools', 'script', 'style', 'layout', 'layoutCount', 'inPage'\];$/m);
+    assert.match(SRC, /const acc = \(into\[arm\] \|\|= zeroDecomp\(\)\);/, 'the collector must build the one shape');
+    assert.match(SRC, /const acc = \(out\[arm\] \|\|= zeroDecomp\(\)\);/, 'the fold must build the one shape');
+  });
+
+  // JSON.stringify cannot carry NaN or undefined, so the mutations are applied
+  // AFTER the clone — the states below are what a truncated write, a partial
+  // in-memory row, or a corrupt read actually looks like.
+  const mutate = (fn) => {
+    const c = JSON.parse(JSON.stringify(FIXTURE_DECOMP));
+    fn(c);
+    return c;
+  };
+
+  // [what it is, the evidence, the phrase the refusal must carry, the side it must name]
+  const PARTIAL = [
+    ['an outer array whose round has no blocks', [[]], 'carries no blocks', 'round 0'],
+    ['a round whose block has no arms', [[{}]], 'carries no arms', 'round 0, block 0'],
+    ['a round that is not an array at all', [null], 'carries no blocks', 'round 0'],
+    ['a block that is not a block of arms', [[[]]], 'is not a block of arms', 'round 0, block 0'],
+    ['a block that LOST an arm the other blocks carry', mutate((c) => delete c[1][0]['ctl-2x']), 'missing ctl-2x', 'round 1, block 0'],
+    ['a block that grew an arm the row never planned', mutate((c) => (c[1][1].bogus = DECOMP_BLOCK(10, 1, 1, 1))), 'unexpected bogus', 'round 1, block 1'],
+    ['an arm with no accumulator at all', mutate((c) => (c[0][0].floor = null)), 'carries no accumulator (null)', 'arm "floor"'],
+    ['an arm MISSING a metric', mutate((c) => delete c[0][1]['ctl-2x'].script), 'field "script" is absent', 'round 0, block 1, arm "ctl-2x"'],
+    ['an arm whose metric is explicitly null', mutate((c) => (c[0][0].floor.layout = null)), 'field "layout" is null', 'round 0, block 0, arm "floor"'],
+    ['an arm whose metric is NaN', mutate((c) => (c[1][1]['ctl-2x'].style = NaN)), 'field "style" is NaN', 'round 1, block 1, arm "ctl-2x"'],
+    ['an arm whose metric is a string', mutate((c) => (c[0][0]['ctl-2x'].task = '20')), 'field "task" is a string', 'arm "ctl-2x"'],
+    ['a block that took no samples', mutate((c) => (c[1][0].floor.n = 0)), 'field "n" is 0', 'round 1, block 0, arm "floor"'],
+    ['a negative renderer count', mutate((c) => (c[0][1].floor.layoutCount = -1)), 'field "layoutCount" is -1', 'round 0, block 1, arm "floor"'],
+  ];
+
+  for (const [what, blocks, needle, side] of PARTIAL) {
+    t(`${what} is refused, and the refusal names it`, () => {
+      assert.throws(() => foldDecomposition(blocks), /not valid evidence/, 'this state must not fold');
+      const d = driveOn(blocks);
+      assert.notStrictEqual(d.code, 0, 'a refused row must reach a NON-ZERO driver outcome');
+      assert.strictEqual(d.wrote, false, 'a refused row must not be written at all');
+      assert.strictEqual(d.canonical, false, 'and the destination must not be the published set');
+      // Naming the offending side is the diagnostic that earns its place: it
+      // fires only on evidence that is already invalid, and it tells the reader
+      // which side of the ratio to go and look at.
+      assert.ok(d.why.includes(needle), `the refusal must say "${needle}" — it said: ${d.why}`);
+      assert.ok(d.why.includes(side), `the refusal must name ${side} — it said: ${d.why}`);
+    });
+  }
+
+  t('a partial arm can no longer be synthesised into a plausible ratio', () => {
+    // The audit's own probe, verbatim: an arm lacking task/taskNet/devtools/
+    // script/layoutCount/inPage used to fold with all six read as zero, and an
+    // explicit `null` script used to fold as `script: 0`. Both would have made
+    // the studio page's cited split reproducible from evidence that never held
+    // it — a wrong number with a fold's authority behind it.
+    const stripped = mutate((c) => {
+      for (const k of ['task', 'taskNet', 'devtools', 'script', 'layoutCount', 'inPage']) delete c[0][0]['ctl-2x'][k];
+    });
+    assert.throws(() => foldDecomposition(stripped), /not valid evidence/);
+    const nulled = mutate((c) => (c[0][0]['ctl-2x'].script = null));
+    assert.throws(() => foldDecomposition(nulled), /field "script" is null/);
+    assert.strictEqual(driveOn(nulled).code, 1, 'the run must exit non-zero, not publish a script ratio of 0');
+  });
+
+  t("a stored split must agree with the row's own arm roster", () => {
+    // The blocks and `armIds` are serialised independently, so their agreement
+    // is a real check on the file rather than a restatement of it — and it is
+    // the one case block-to-block consistency alone cannot see: an arm absent
+    // from EVERY block folds to a roster the file's own header contradicts.
+    const dir = path.join(__dirname, 'data');
+    const files = fs
+      .readdirSync(dir)
+      .filter((d) => d.startsWith('censusclock-'))
+      .flatMap((d) => fs.readdirSync(path.join(dir, d)).filter((f) => f.endsWith('.json')).map((f) => path.join(dir, d, f)));
+    for (const f of files) {
+      for (const row of JSON.parse(fs.readFileSync(f, 'utf8')).rows) {
+        if (!row.blocksDecomp) continue;
+        assert.deepStrictEqual(
+          Object.keys(foldDecomposition(row.blocksDecomp)).sort(),
+          row.armIds.slice().sort(),
+          `${f} / ${row.rowId}: the stored split covers a different arm set than the row claims`
+        );
+      }
+    }
+  });
 }
 
 // --- hd8_clock_run.cjs: the WRITE path, not just the exit path ---------------

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
@@ -464,6 +464,16 @@ function deltaOf(a, b) {
   };
 }
 
+/**
+ * The nine quantities ONE block's decomposition accumulator carries, named
+ * once. `bump` creates them at collection, `datasetFor` serialises them, and
+ * `foldDecomposition` both sums them and requires exactly these — three
+ * readers over one list, so a field cannot be collected and then silently not
+ * be required, which is how the split came to be dropped in the first place.
+ */
+const DECOMP_FIELDS = ['n', 'task', 'taskNet', 'devtools', 'script', 'style', 'layout', 'layoutCount', 'inPage'];
+const zeroDecomp = () => Object.fromEntries(DECOMP_FIELDS.map((k) => [k, 0]));
+
 // ---------------------------------------------------------------------------
 // One row of one run
 // ---------------------------------------------------------------------------
@@ -521,9 +531,7 @@ async function runRow(browser, runDef, rowId) {
   let previous = null;
 
   const bump = (into, arm, d, inPage) => {
-    const acc = (into[arm] ||= {
-      n: 0, task: 0, taskNet: 0, devtools: 0, script: 0, style: 0, layout: 0, layoutCount: 0, inPage: 0,
-    });
+    const acc = (into[arm] ||= zeroDecomp());
     acc.n += 1;
     acc.task += d.task;
     acc.taskNet += d.taskNet;
@@ -617,6 +625,27 @@ async function runRow(browser, runDef, rowId) {
  * every census dataset written before rf2-jo60g is exactly that row, and a fold
  * that answered there would hand a reader a NaN — or worse, a plausible number
  * — for a split those files never recorded.
+ *
+ * AND IT REFUSES A PARTIAL ONE (merged-PR audit #7666). The first landing
+ * checked only the OUTER array and then summed with `acc[k] += a[k] || 0`, so
+ * `[[]]` and `[[{}]]` both answered `{}`, and a missing, null or NaN metric was
+ * silently synthesised as zero. An arm that had lost half its fields therefore
+ * folded to a plausible ratio instead of a refusal — the same fail-open one
+ * level down, and the one this bead exists to close. `|| 0` is the defect, so
+ * the repair is to REQUIRE the shape rather than to default it:
+ *
+ *   - every round carries at least one block, and every block at least one arm;
+ *   - every block carries the same arm roster as the row's first block, so a
+ *     block that dropped an arm cannot be summed against blocks that kept it;
+ *   - every arm carries every one of `DECOMP_FIELDS`, each a FINITE number —
+ *     absent, `null`, `undefined` and `NaN` are refusals, not zeros;
+ *   - `n` is positive (a block that took no samples is not evidence) and
+ *     `layoutCount` is non-negative (it tallies a monotone renderer counter).
+ *
+ * Durations are only required to be finite: `plumb` legitimately lays nothing
+ * out and reads 0, and `taskNet` subtracts the devtools window so it may read
+ * below zero. The refusal names the round, the block, the arm and the field, so
+ * a reader can go to the offending side of the ratio and see what is wrong.
  */
 function foldDecomposition(blocksDecomp) {
   if (!Array.isArray(blocksDecomp) || blocksDecomp.length === 0) {
@@ -625,14 +654,61 @@ function foldDecomposition(blocksDecomp) {
         'Script/Layout/RecalcStyle split is NOT recomputable from it and may not be quoted'
     );
   }
+  const describe = (v) =>
+    v === undefined ? 'absent'
+      : v === null ? 'null'
+        : typeof v === 'number' ? (Number.isNaN(v) ? 'NaN' : String(v))
+          : Array.isArray(v) ? 'an array'
+            : `a ${typeof v}`;
+  const refuse = (where, what) => {
+    throw new Error(
+      `this row's per-block decomposition is not valid evidence — ${where}: ${what}. ` +
+        'A partial or corrupt split is refused rather than folded: defaulting it to zero ' +
+        'would publish a plausible Script/Layout/RecalcStyle ratio for numbers the run ' +
+        'never recorded (rf2-jo60g).'
+    );
+  };
+
+  let roster = null; // the arms of round 0, block 0 — every block must carry them
   const out = {};
-  for (const round of blocksDecomp) {
-    for (const blk of round) {
-      for (const [arm, a] of Object.entries(blk)) {
-        const acc = (out[arm] ||= {
-          n: 0, task: 0, taskNet: 0, devtools: 0, script: 0, style: 0, layout: 0, layoutCount: 0, inPage: 0,
-        });
-        for (const k of Object.keys(acc)) acc[k] += a[k] || 0;
+  for (let r = 0; r < blocksDecomp.length; r++) {
+    const round = blocksDecomp[r];
+    if (!Array.isArray(round) || round.length === 0) {
+      refuse(`round ${r}`, `carries no blocks (${describe(round)})`);
+    }
+    for (let b = 0; b < round.length; b++) {
+      const blk = round[b];
+      const at = `round ${r}, block ${b}`;
+      if (!blk || typeof blk !== 'object' || Array.isArray(blk)) refuse(at, `is not a block of arms (${describe(blk)})`);
+      const here = Object.keys(blk).sort();
+      if (here.length === 0) refuse(at, 'carries no arms — an empty block measured nothing');
+      if (roster === null) {
+        roster = here;
+      } else {
+        const missing = roster.filter((a) => !here.includes(a));
+        const extra = here.filter((a) => !roster.includes(a));
+        if (missing.length || extra.length) {
+          refuse(
+            at,
+            `carries arms [${here.join(', ')}] where round 0, block 0 carries [${roster.join(', ')}]` +
+              `${missing.length ? ` — missing ${missing.join(', ')}` : ''}` +
+              `${extra.length ? ` — unexpected ${extra.join(', ')}` : ''}`
+          );
+        }
+      }
+      for (const arm of roster) {
+        const a = blk[arm];
+        const side = `${at}, arm "${arm}"`;
+        if (!a || typeof a !== 'object' || Array.isArray(a)) refuse(side, `carries no accumulator (${describe(a)})`);
+        for (const k of DECOMP_FIELDS) {
+          if (typeof a[k] !== 'number' || !Number.isFinite(a[k])) {
+            refuse(side, `field "${k}" is ${describe(a[k])}, not a finite number`);
+          }
+        }
+        if (!(a.n > 0)) refuse(side, `field "n" is ${a.n} — a block that took no samples is not evidence`);
+        if (a.layoutCount < 0) refuse(side, `field "layoutCount" is ${a.layoutCount} — a count cannot be negative`);
+        const acc = (out[arm] ||= zeroDecomp());
+        for (const k of DECOMP_FIELDS) acc[k] += a[k];
       }
     }
   }


### PR DESCRIPTION
Closes the CORRECTNESS half that the merged-PR audit of #7666 reopened on rf2-jo60g. The re-run half stays open — see the last section.

## The defect

`foldDecomposition` checked only its OUTER array and then summed with `acc[k] += a[k] || 0`. So:

- `foldDecomposition([[]])` and `foldDecomposition([[{}]])` each returned `{}`;
- a missing, `null` or `NaN` metric was silently synthesised as zero.

A live probe on the landed function accepted a partial arm lacking `task`/`taskNet`/`devtools`/`script`/`layoutCount`/`inPage` with all six read as 0, and an explicit `null` script as `script: 0`. Partial or corrupt persisted evidence therefore became a plausible Script/Layout/RecalcStyle ratio instead of the required non-zero refusal — the same fail-open class the bead exists to close, one level down from where it was closed. The committed-dataset test branched only on the truthiness of `row.blocksDecomp`, so it could not see this third state.

## The repair

`|| 0` is the defect, so the fold now REQUIRES the shape rather than defaulting it. Bounded inside the existing fold/write path — no validator abstraction, no schema library, no new layer:

- every round carries at least one block, and every block at least one arm;
- every block carries the same arm roster (as a set — insertion order genuinely varies with the guard schedule) as the row's first block, so a block that dropped an arm cannot be summed against blocks that kept it;
- every arm carries every one of `DECOMP_FIELDS` as a **finite number** — absent, `null`, `undefined`, `NaN` and non-numbers are refusals, not zeros;
- `n` is positive (a block that took no samples is not evidence) and `layoutCount` is non-negative (it tallies a monotone renderer counter).

Durations are required to be finite and nothing more, deliberately: `plumb` legitimately lays nothing out and reads `layout: 0, style: 0, layoutCount: 0` in the real committed data, and `taskNet` subtracts the devtools window so it may read below zero. Constraining them further would refuse valid runs.

The refusal names the round, the block, the arm and the field — a diagnostic that earns its place because it fires only on evidence that is already invalid, and it sends the reader to the offending side of the ratio:

```
this row's per-block decomposition is not valid evidence — round 0, block 1, arm "ctl-2x":
field "script" is absent, not a finite number. A partial or corrupt split is refused rather
than folded: defaulting it to zero would publish a plausible Script/Layout/RecalcStyle ratio
for numbers the run never recorded (rf2-jo60g).
```

`DECOMP_FIELDS` is now one constant shared by the collector (`bump`), the fold and the validation, replacing two hand-written copies of the nine-field shape. A field that is collected can no longer quietly not be required — which is exactly how the split came to be dropped in the first place.

Both pre-existing refusals are preserved untouched: a row with no blocks still throws the `NOT recomputable` message (every census dataset on main predating the split is that row), and the test that recomputes the page's cited 2.06x/1.85x/2.3x from serialised JSON alone, with per-block sums that differ so a fold reading one block cannot pass, is unchanged and still green.

## The witnesses

Nineteen new checks in `clock_exit_path.test.cjs`, **every fixture built in-test** — the committed datasets cannot witness these states (they carry a whole split or none), and a negative case that needs a file to be wrong on disk is not a test anyone can run.

Each of the states the audit named — `[[]]`, `[[{}]]`, an absent arm, a missing metric, `null`, `NaN` — plus a non-array round, a non-object block, a missing accumulator, a string metric, `n === 0`, a negative count, is asserted to **reach a non-zero driver outcome, not merely to throw**. A refusal that throws where nothing catches is not a driver that exits non-zero, and the bead asks for the latter. Each witness drives `drive`'s own composition on the real exported functions — the fold runs where `report` runs it, a throw sets `failed`, the row never reaches `results`, `verdict` reads `failed`, and the write is gated on `results.length && !failed` — and asserts exit code non-zero, `wrote === false`, and `destination(...).canonical === false`. Four source pins hold that reconstruction to the driver's actual shape so it cannot drift away while still passing.

A green control runs first (a whole fixture folds, is kept, and writes canonical), so the gate is not vacuously red. A further source pin keeps `|| 0` from returning under a rewritten loop.

## Verified against real evidence

`censusclock-jv36i` — the matched-workload re-take taken on a granted quiet box (landed in `623c9341af`, after this bead's 03:46 comment) — is the first committed dataset carrying `blocksDecomp`, and the stricter validation **accepts it unchanged**: 6 rounds x 3 blocks, a consistent 5- or 6-arm roster per row, all nine fields finite, `n = 10`, `plumb` reading zeros. That is the strongest available evidence the new checks are tight rather than over-tight. One added check asserts the stored split's arm set equals the row's independently-serialised `armIds` — the one case block-to-block consistency alone cannot see.

No pre-existing test needed to change, and no pre-existing assertion was loosened.

## Quality gates

Foreground, to completion, each redirected to a worktree-local log with the runner's own exit code echoed explicitly (never piped through `tail`/`grep`, whose exit status is the last stage's).

| gate | exit | result |
|---|---|---|
| `node --check shapes/census_clock_run.cjs` | **0** | |
| `node --check clock_exit_path.test.cjs` | **0** | |
| `node clock_exit_path.test.cjs` | **0** | **246 passed** (baseline 227 at the branch point `31099a515d`, so +19) |
| `npm run test:script-helpers` (from `implementation/`) | **0** | all 23 helper suites green |
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`, 61 steps |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | **0** | `No beads-database paths in this PR diff` |

The worktree had no `implementation/node_modules`; a junction to the primary checkout's was provided before the spine ran, and **the link (never its target) was removed afterwards**. The primary checkout's canaries are unchanged: `node_modules` 59/63, `implementation/node_modules` 101/105, `tools/mcp-conformance/node_modules` 92/96.

### Mutation proof

A validator nobody has seen refuse is the defect restated, so each half was reverted in turn and the witnesses shown going red.

| mutation | result |
|---|---|
| delete the finite-field check and restore `acc[k] += a[k] \|\| 0` | **6/246 failed, exit 1** — the missing / `null` / `NaN` / string metric witnesses, the partial-arm probe, and the `\|\| 0` source pin |
| delete the nonempty-round and nonempty-roster checks | **3/246 failed, exit 1** — the `[[]]`, `[[{}]]` and non-array-round witnesses |
| neutralise the block-to-block arm-roster check | **2/246 failed, exit 1** — the lost-arm and unexpected-arm witnesses |

The lost-arm case is instructive: with the roster check gone it is still caught by the accumulator check one line down, but with a message naming the wrong fault, and the witness asserts the message — so defence-in-depth does not let a deleted check pass silently.

Reverted and re-verified green (246 passed, exit 0) between each mutation and after the last.

### Relying on CI for

`python scripts/check_fast_pr_gap.py --list` reports 90 required checks the local spine does not decide. The diff is two `.cjs` files under `implementation/freehand/test/re_frame/bench/hicasso/` — no CLJS source, no spec, no docs, no workflow, no `deps.edn` — so most are surface-gated and skip. Named explicitly: `beads-pr-boundary` (run locally against `origin/main`, exit 0), the `Lint required` context (`detect`, `eslint`; `clj-kondo` pins 2026.04.15 in CI and a differently-versioned local binary proves nothing), the `Docs required` context (`detect` — no documentation surface touched), and `JVM freehand (clojure -M:test)` / `CLJS (shadow-cljs :node-test)` as they run in CI's environment.

## Still open, and deliberately not this PR

**The re-run half of rf2-jo60g stays OPEN.** It is measurement-coupled, rides the matched-workload window, and is the operator's call on rf2-jv36i. **No measurement was taken for this PR and the census driver was never run.** Everything above is hermetic: pure functions, in-test fixtures, and one read of already-committed JSON.
