### PR TITLE
fix(bench): the allocation row cannot be masked by net growth (rf2-n6w7o)

### DIFF
--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -260,7 +260,7 @@ const lacks = (re, why) => assert.ok(!re.test(SRC), `p0_run.cjs: must no longer 
 test('the driver exits on THIS function and does not re-derive the counts', () => {
   has(/const structural = ladderStructuralFailures\(out\.ladder\);/, 'the ladder gate calls it');
   has(/if \(structural\.length > 0\) \{/, 'and its result is what pushes a failure');
-  has(/module\.exports = \{ ladderStructuralFailures \};/, 'so this file can drive it');
+  has(/module\.exports = \{\s*ladderStructuralFailures,/, 'so this file can drive it');
   has(/if \(require\.main === module\)/, 'and requiring the driver must not drive it');
 });
 

--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 // THE LADDER'S STRUCTURAL WITNESS — what the counts must be, and at R=0
-// especially. rf2-xzg3b.
+// especially. rf2-xzg3b. AND THE ALLOCATION ROW'S MASKING WITNESS —
+// rf2-n6w7o, at the foot of this file.
 //
 //     node core/test/re_frame/bench/p0_ladder_structural.test.cjs
 //
@@ -41,7 +42,12 @@ const path = require('node:path');
 const DRIVER = path.join(__dirname, 'p0_run.cjs');
 // Requiring the driver must NOT drive it: it builds, serves and launches a
 // browser. The `require.main === module` guard is part of what is under test.
-const { ladderStructuralFailures } = require('./p0_run.cjs');
+const {
+  ladderStructuralFailures,
+  allocSteps,
+  allocMaskableWindows,
+  ALLOC_MASK_BUDGET_B,
+} = require('./p0_run.cjs');
 
 const tests = [];
 const test = (name, fn) => tests.push([name, fn]);
@@ -269,6 +275,194 @@ test('the printed legend states the R=0 zero rather than the old flat `boundarie
   has(/boundaries = B \(0 at R=0\)/, 'the printed legend must qualify it');
   lacks(/boundaries = B ·/, 'the unqualified printed legend');
   lacks(/one registration per boundary, R-independent/, 'the stale source legend');
+});
+
+// ===========================================================================
+// THE ALLOCATION ROW'S MASKING WITNESS — rf2-n6w7o
+// ===========================================================================
+//
+// THE DEFECT THIS PINS. `allocSteps` detects a collection by the SIGN of an
+// adjacent step in `usedJSHeapSize`. A sign test is blind in exactly one
+// direction: where V8 collects inside a leg that also allocates at least as
+// much as the collection reclaimed, the observed step is >= 0, `falls` stays
+// 0, and the reclaimed bytes are simply missing from `rise`. The row then
+// prints a window that looks clean and reads LOW — and under-reading
+// allocation is the direction that manufactures HD-002's predicted
+// flat-at-zero, so it is the one direction this row may not fail in.
+//
+// Until rf2-n6w7o there was no allocation coverage in this file at all, and a
+// sample stream with a fully masked collection in it passed `allocSteps`
+// silently with nothing anywhere to notice. The pin below is that stream.
+//
+// HERMETIC BY CONSTRUCTION. Nothing here measures anything. `stream` builds
+// the sample buffer `p0-heap/alloc-window!` would have filled, from stated
+// per-leg allocations and stated reclaims, so the masked case is a fixture
+// rather than something that has to be provoked out of a real collector.
+
+// `[s0, pre0, post0, pre1, post1, ...]` — the shape `alloc-window!` fills:
+// one sample before the window, then a pair around every iteration. `legs[i]`
+// is the TRUE allocation of work leg i; `reclaim[i]` is what a collection
+// took back inside that same leg, which is what the sign test cannot see.
+// The gaps between iterations do nothing, as they do in the real window.
+function stream(legs, reclaim = []) {
+  let h = 10000000;
+  const out = [h];
+  legs.forEach((a, i) => {
+    out.push(h);
+    h += a - (reclaim[i] || 0);
+    out.push(h);
+  });
+  return out;
+}
+
+test('THE DEFECT — a collection fully masked by net growth is REFUSED', () => {
+  // Four warm writes of 200 KB each. A collection runs inside the third and
+  // reclaims exactly what that leg allocated, so the step is 0 and the sign
+  // test sees nothing at all. 200 KB of real allocation has vanished from
+  // `rise`, and the window would have been published as clean.
+  const s = allocSteps(stream([200000, 200000, 200000, 200000], [0, 0, 200000, 0]));
+  assert.strictEqual(s.falls, 0, 'the sign test is blind here — that IS the defect');
+  assert.strictEqual(s.fall, 0, 'and nothing was netted, so `fall` is silent too');
+  assert.strictEqual(s.rise, 600000, 'rise under-reads the true 800000 by the reclaimed 200000');
+  assert.ok(s.maskable, 'the masking witness must refuse it where the sign test cannot');
+  assert.ok(s.headroom < 0, `headroom must be negative, was ${s.headroom}`);
+});
+
+test('the budget is the measured fall threshold HALVED, and pinned at its value', () => {
+  // Pinned as a NUMBER on purpose. Widening this constant is the one repair
+  // that would retro-admit every window it was introduced to refuse, so a
+  // change to it has to come through this line and say so.
+  assert.strictEqual(ALLOC_MASK_BUDGET_B, 300000, 'ALLOC_FALL_THRESHOLD_B (600000) / 2');
+});
+
+test('the gate is not vacuous — a small clean window passes it', () => {
+  // Four writes of 20 KB. 100 KB of rise-plus-largest-step against a 300 KB
+  // budget: nowhere near the threshold at which a collection can fire, which
+  // is the shape rf2-2rtt6.138's small-witness arm has to have.
+  const s = allocSteps(stream([20000, 20000, 20000, 20000]));
+  assert.strictEqual(s.falls, 0);
+  assert.strictEqual(s.rise, 80000);
+  assert.strictEqual(s.maxStep, 20000);
+  assert.strictEqual(s.headroom, ALLOC_MASK_BUDGET_B - 100000);
+  assert.strictEqual(s.maskable, false);
+});
+
+test('the boundary is exact — at budget passes, one byte over refuses', () => {
+  const at = allocSteps(stream([50000, 50000, 50000, 50000, 50000]));
+  assert.strictEqual(at.rise + at.maxStep, ALLOC_MASK_BUDGET_B);
+  assert.strictEqual(at.headroom, 0);
+  assert.strictEqual(at.maskable, false, 'exactly at budget is still inside it');
+  const over = allocSteps(stream([50000, 50000, 50000, 50000, 50000, 1]));
+  assert.strictEqual(over.rise + over.maxStep, ALLOC_MASK_BUDGET_B + 1);
+  assert.strictEqual(over.headroom, -1);
+  assert.ok(over.maskable);
+});
+
+test('NET GROWTH CANNOT DEFEAT IT — masking only moves a window toward refusal', () => {
+  // The same four legs, once with the third leg's collection masked and once
+  // without it. Masking REMOVES bytes from `rise`, so the masked window is
+  // the one with MORE headroom — and it is still refused, because the
+  // allocation that had to happen before the collector could fire is counted
+  // in full, in the legs before it, where no masking is possible.
+  const legs = [200000, 200000, 200000, 200000];
+  const masked = allocSteps(stream(legs, [0, 0, 200000, 0]));
+  const clean = allocSteps(stream(legs));
+  assert.ok(masked.rise < clean.rise, 'masking removes bytes from the rising sum');
+  assert.ok(masked.headroom > clean.headroom, 'so it can only flatter the headroom');
+  assert.ok(masked.maskable && clean.maskable, 'and both are over budget regardless');
+});
+
+test('THE FALLS GATE IS UNTOUCHED — a visible collection still counts as one', () => {
+  // The half that works. rf2-n6w7o is discharged by ADDING a refusal, never
+  // by widening this one: every window it admits today it must still admit.
+  const s = allocSteps(stream([20000, 20000], [0, 40000]));
+  assert.strictEqual(s.falls, 1, 'a net-negative leg is still a falling step');
+  assert.strictEqual(s.fall, 20000, 'the second leg allocated 20000 and lost 40000');
+  assert.strictEqual(s.rise, 20000, 'a fall is EXCLUDED from the rising sum, never netted');
+  assert.strictEqual(s.endpoints, 0, 'and the endpoints alone would have said nothing happened');
+});
+
+test('`maxStep` is the largest single rising step, not the mean or the last', () => {
+  const s = allocSteps(stream([1000, 7000, 3000]));
+  assert.strictEqual(s.rise, 11000);
+  assert.strictEqual(s.maxStep, 7000);
+  assert.strictEqual(s.endpoints, 11000);
+});
+
+test('an idle window is neither maskable nor a fall', () => {
+  const s = allocSteps(stream([0, 0, 0]));
+  assert.strictEqual(s.rise, 0);
+  assert.strictEqual(s.falls, 0);
+  assert.strictEqual(s.maxStep, 0);
+  assert.strictEqual(s.maskable, false);
+});
+
+// --- the row-level witness the driver actually exits on --------------------
+
+const allocRowWith = (windows, rounds = 2) => ({
+  perRound: Array.from({ length: rounds }, (_, i) => ({
+    round: i + 1,
+    arms: Object.fromEntries(
+      Object.entries(windows).map(([key, legs]) => [
+        key,
+        { segment: 'reagent-subs', arm: 'lad/hicasso', reads: 7, ...allocSteps(legs) },
+      ])
+    ),
+  })),
+});
+
+const SMALL = stream([20000, 20000, 20000, 20000]);
+const MASKED = stream([200000, 200000, 200000, 200000], [0, 0, 200000, 0]);
+
+test('a row of small clean windows is not a failure', () => {
+  assert.deepStrictEqual(
+    allocMaskableWindows(allocRowWith({ 'reagent-subs|lad/hicasso#R7': SMALL })),
+    []
+  );
+});
+
+test('a row with no rounds at all is not a failure', () => {
+  assert.deepStrictEqual(allocMaskableWindows({ perRound: [] }), []);
+});
+
+test('every over-budget window is named, on every round, with its overshoot', () => {
+  const fails = allocMaskableWindows(
+    allocRowWith({
+      'reagent-subs|lad/hicasso#R7': MASKED,
+      'reagent-subs|lad/reagent#R7': SMALL,
+    })
+  );
+  assert.strictEqual(fails.length, 2, 'one per round, and only the over-budget arm');
+  for (const f of fails) {
+    assert.match(f, /lad\/hicasso#R7/);
+    assert.match(f, /rise 600000 B \+ largest step 200000 B/);
+    assert.match(f, /500000 B over the 300000 B masking budget/);
+  }
+  assert.ok(fails.some((f) => f.startsWith('round 1 ')));
+  assert.ok(fails.some((f) => f.startsWith('round 2 ')));
+});
+
+// --- the wiring, so this pin cannot drift off the thing that exits ---------
+
+test('the driver exits on THIS function and does not re-derive the budget', () => {
+  has(/const maskable = allocMaskableWindows\(out\.alloc\);/, 'the alloc gate calls it');
+  has(/if \(maskable\.length > 0\) \{/, 'and its result is what pushes a failure');
+  has(
+    /module\.exports = \{\s*ladderStructuralFailures,\s*allocSteps,\s*allocMaskableWindows,\s*ALLOC_MASK_BUDGET_B,\s*\};/,
+    'so this file can drive it'
+  );
+});
+
+test('the budget is DERIVED from the measured threshold and has no dial on it', () => {
+  has(
+    /const ALLOC_MASK_BUDGET_B = ALLOC_FALL_THRESHOLD_B \/ 2;/,
+    'the budget must follow the measured threshold, not be typed beside it'
+  );
+  lacks(
+    /P0_ALLOC_MASK|P0_ALLOC_HEADROOM|P0_ALLOC_BUDGET/,
+    'a gate with an env dial on it is a gate that gets dialled off'
+  );
+  has(/if \(out\.alloc\.fallsInMeasuredWindows > 0\) \{/, 'and the falling-step gate still exits');
 });
 
 let failed = 0;

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -1321,8 +1321,11 @@ async function allocRow(chromium) {
     controlSlack: ALLOC_CONTROL_SLACK,
     instrument:
       'in-page performance.memory.usedJSHeapSize sampled at every leg boundary, ' +
-      'rising steps accumulated separately from falling ones; --enable-precise-memory-info',
+      'rising steps accumulated separately from falling ones; --enable-precise-memory-info. ' +
+      'A falling step is a collection this counter SAW; a window over the masking budget is ' +
+      'one it could not have seen, and both refuse',
     fallThresholdB: ALLOC_FALL_THRESHOLD_B,
+    maskBudgetB: ALLOC_MASK_BUDGET_B,
     verification: { unverified, detail: unverifiedDetail },
     perRound: rounds,
     allocFits: fits,

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -993,29 +993,138 @@ const ALLOC_CONTROL_SLACK = Number(process.env.P0_ALLOC_CONTROL_SLACK || 0.75);
 // boundaries is two to three times over it in ONE write.
 const ALLOC_FALL_THRESHOLD_B = 600000;
 
+// THE MASKING BUDGET — what makes a masked collection UNREACHABLE rather
+// than merely unlikely (rf2-n6w7o).
+//
+// `allocSteps` below detects a collection by the SIGN of an adjacent step,
+// and a sign test is blind in exactly one direction. Where V8 collects
+// inside a leg that ALSO allocates at least as much as the collection
+// reclaimed, the observed step is >= 0: `falls` stays 0, the reclaimed
+// bytes are simply missing from `rise`, and the row prints a window that
+// looks clean and reads LOW. Under-reading allocation is the direction that
+// manufactures HD-002's predicted flat-at-zero, so it is the one direction
+// this row may not be able to fail in — and until this constant existed it
+// was the direction with no gate on it at all.
+//
+// THE REPAIR IS ARITHMETIC, NOT A SECOND DETECTOR, and it rests on one
+// property of the fault: MASKING CANNOT PRECEDE THE FIRST COLLECTION. Every
+// leg before it runs with no collector in it, so `rise` counts those legs
+// EXACTLY. And the first collection does not fire until roughly
+// `ALLOC_FALL_THRESHOLD_B` of cumulative garbage has built up since the
+// forced GC the driver takes on the window's near side. So if a collection
+// fired in leg k, writing A_k for that leg's own allocation:
+//
+//     rise  >=  (every leg before k)  >=  ALLOC_FALL_THRESHOLD_B - A_k
+//
+// The legs are n repetitions of ONE work unit and every earlier leg is
+// counted exactly, so A_k is bounded by the largest rising step the window
+// shows. Contrapositive, and it is the gate:
+//
+//     rise + maxStep  <=  budget   =>   NO collection ran, masked or not.
+//
+// Note which way net growth pushes here, because it is the whole point.
+// Masking REMOVES bytes from `rise`, so it can only move a window further
+// under budget — but the allocation that had to happen first, to give the
+// collector a reason to run, is already counted in full in the legs before
+// it, where no masking is possible. Growth cannot defeat this gate the way
+// it defeats the sign test. It can only make a window fail it sooner.
+//
+// THE BUDGET IS THE MEASURED THRESHOLD HALVED, and both halves of that are
+// stated rather than assumed:
+//
+//   - `ALLOC_FALL_THRESHOLD_B` is where the first VISIBLE fall appeared in
+//     the standalone probes. A masked one would not have shown, so it is an
+//     UPPER bound on where the first collection actually runs, and a gate
+//     built on it has to take the conservative side.
+//   - The halved figure, ~300 KB, is a whisker above the largest window
+//     this instrument has a CORROBORATED clean reading for: the D=1,000
+//     control at the default 30 writes is 240 KB of cumulative garbage and
+//     reads 8.13 B/double against a predicted 8. A window that under-read
+//     would not hit its prediction, so the control is positive evidence of
+//     no collection at that scale — which a fall count of zero, on its own,
+//     is not.
+//
+// Deliberately not an env knob. Every other `P0_ALLOC_*` constant sizes the
+// measurement; this one decides whether a measurement may be PUBLISHED, and
+// a gate with a dial on it is a gate that gets dialled. Widening it would
+// retro-admit every window it exists to refuse.
+//
+// WHAT IT DOES NOT CLOSE, stated because a bound that oversells itself is
+// worse than no bound. A window in which EVERY leg is masked — a collection
+// in each one, each reclaiming at least that leg's allocation, the heap
+// flat while megabytes pass through it — defeats both terms. `falls`
+// catches such a window the moment one collection overshoots; `maxStep`
+// catches it the moment one leg runs unmasked; nothing here catches it if
+// neither ever happens, and closing it properly would need a per-leg
+// allocation counter V8 does not expose in-page. It is also UNREACHABLE for
+// the arm this bound exists to license: an arm whose warm write allocates a
+// few KB cannot cross the threshold inside a single leg at all, so there is
+// no leg for a first collection to hide in. That is the shape
+// rf2-2rtt6.138's small-witness arm has to have, and this is the arithmetic
+// that says why.
+const ALLOC_MASK_BUDGET_B = ALLOC_FALL_THRESHOLD_B / 2;
+
 // Rising and falling steps, accumulated separately, from one window's raw
 // samples. The samples are `[s0, pre0, post0, pre1, post1, ...]`, so the
 // work legs are the (pre -> post) steps and the gaps between iterations
 // are the (post -> pre) steps; both are walked, because a collection can
 // fall in either.
+//
+// `maxStep`, `headroom` and `maskable` are the masking witness above:
+// `headroom` is the budget less what a collection would have had to hide
+// behind to go unseen, and `maskable` says the window is large enough to
+// have hidden one WHATEVER `falls` reports. The two gates are independent
+// and both are exits — a fall is a collection this counter saw, a maskable
+// window is one it could not have.
 function allocSteps(samples) {
   let rise = 0;
   let fall = 0;
   let falls = 0;
+  let maxStep = 0;
   for (let i = 1; i < samples.length; i++) {
     const d = samples[i] - samples[i - 1];
-    if (d > 0) rise += d;
-    else if (d < 0) {
+    if (d > 0) {
+      rise += d;
+      if (d > maxStep) maxStep = d;
+    } else if (d < 0) {
       fall += -d;
       falls++;
     }
   }
+  const headroom = ALLOC_MASK_BUDGET_B - (rise + maxStep);
   return {
     rise,
     fall,
     falls,
+    maxStep,
+    headroom,
+    maskable: headroom < 0,
     endpoints: samples[samples.length - 1] - samples[0],
   };
+}
+
+// The masking witness over a whole collected row, as a PURE FUNCTION of it
+// — the same shape and for the same reason as `ladderStructuralFailures`
+// below: it needs neither a release build nor a Chromium to adjudicate, so
+// it can be pinned on every PR by `p0_ladder_structural.test.cjs` instead of
+// waiting for the next opt-in run of this driver to notice.
+//
+// ARM WINDOWS ONLY, exactly as the falling-step gate counts only those. The
+// arms are what gets published; the controls adjudicate the arithmetic, and
+// a masked control would read LOW against its own 8 B/double prediction and
+// refuse through `controlVerdict` — the safe direction, already gated.
+function allocMaskableWindows(row) {
+  const out = [];
+  for (const r of row.perRound || []) {
+    for (const [key, a] of Object.entries(r.arms || {})) {
+      if (!a.maskable) continue;
+      out.push(
+        `round ${r.round} ${key}: rise ${a.rise} B + largest step ${a.maxStep} B is ` +
+          `${-a.headroom} B over the ${ALLOC_MASK_BUDGET_B} B masking budget`
+      );
+    }
+  }
+  return out;
 }
 
 async function allocRow(chromium) {
@@ -1220,7 +1329,7 @@ async function allocRow(chromium) {
   };
 }
 
-function summariseAlloc(row) {
+function summariseAlloc(row, maskable) {
   const B = row.boundaries;
   console.log('\n;; ==== P0 STEADY-STATE ALLOCATION — WARM 1/3/7/20 READS (rf2-2rtt6.76) ====');
   console.log(
@@ -1302,6 +1411,30 @@ function summariseAlloc(row) {
   // that fault, which is the direction that flatters a candidate whose
   // predicted answer is zero.
   row.fallsInMeasuredWindows = falls;
+
+  // THE MASKING WITNESS (rf2-n6w7o), which is the fall gate's blind side and
+  // a SECOND exit, not a softening of the first. A collection that runs
+  // inside a leg allocating at least as much as it reclaims never turns a
+  // step negative, so the line above reports 0 and the window under-reads
+  // with nothing to say so. See ALLOC_MASK_BUDGET_B for the arithmetic that
+  // makes that case unreachable below the budget rather than merely
+  // improbable.
+  const headrooms = row.perRound.flatMap((r) => Object.values(r.arms).map((x) => x.headroom));
+  row.maskableWindows = maskable.length;
+  console.log(
+    `;;   masking budget: ${ALLOC_MASK_BUDGET_B} B per window (the measured fall threshold, ` +
+      'HALVED) on rise PLUS the largest single step. Below it no collection can have run at'
+  );
+  console.log(
+    ';;   all, masked or otherwise; at or above it a collection can hide behind the window\'s ' +
+      'own growth and `falls` = 0 stops meaning the reading is clean'
+  );
+  console.log(
+    `;;   windows over budget: ${maskable.length} of ${wins}` +
+      (headrooms.length ? `  (tightest headroom ${n0(Math.min(...headrooms))} B)` : '')
+  );
+  for (const m of maskable) console.log(`;;   MASKABLE ${m}`);
+
   console.log(
     `;;   verification: ${row.verification.unverified} unverified ` +
       '(mount read-backs AND the warm-write read-back)'
@@ -1838,7 +1971,12 @@ function summariseFanout(row) {
 // is how the R=0 expectation sat stale from rf2-dabt3 until rf2-zei9w ran
 // the driver; the unit pin is what stops the next such drift being found
 // by the next measurement instead of by CI.
-module.exports = { ladderStructuralFailures, allocSteps };
+module.exports = {
+  ladderStructuralFailures,
+  allocSteps,
+  allocMaskableWindows,
+  ALLOC_MASK_BUDGET_B,
+};
 
 if (require.main === module) (async () => {
   build();
@@ -1968,7 +2106,8 @@ if (require.main === module) (async () => {
     if (wantAlloc) {
       console.error('[p0] steady-state allocation row ...');
       out.alloc = await allocRow(chromium);
-      summariseAlloc(out.alloc);
+      const maskable = allocMaskableWindows(out.alloc);
+      summariseAlloc(out.alloc, maskable);
       if (out.alloc.verification.unverified > 0) {
         failures.push(
           `alloc: ${out.alloc.verification.unverified} unverified — ` +
@@ -1994,6 +2133,25 @@ if (require.main === module) (async () => {
             'is the direction that manufactures the flat-at-zero answer HD-002 predicts, so no ' +
             'slope here is quotable. The controls above still adjudicate the arithmetic; what ' +
             'refuses is the arms\' scale, not the method'
+        );
+      }
+      // AND ITS BLIND SIDE (rf2-n6w7o). The gate above sees a collection
+      // only when it turns a step negative. One that runs inside a leg
+      // allocating at least as much as it reclaimed turns nothing negative,
+      // so that gate reports a clean window while the reclaimed bytes are
+      // missing from `rise`. This one refuses any window merely LARGE ENOUGH
+      // for that to have happened, which is a bound rather than a detector —
+      // see ALLOC_MASK_BUDGET_B. It is additional to the falling-step gate
+      // and replaces none of it.
+      if (maskable.length > 0) {
+        failures.push(
+          `alloc: ${maskable.length} windows at or over the ${ALLOC_MASK_BUDGET_B} B masking ` +
+            'budget — at that scale a collection can run inside a leg that allocates at least as ' +
+            'much as it reclaims, so no step goes negative, the falling-step gate above reports a ' +
+            'clean window, and the reclaimed bytes are missing from `rise` with nothing to say ' +
+            'so. Every figure from such a window is an UNDER-estimate of unknown size, and ' +
+            'under-reading is the direction that manufactures HD-002\'s flat-at-zero. SHRINK THE ' +
+            `MEASURED UNIT, DO NOT WIDEN THE BUDGET. First: ${maskable[0]}`
         );
       }
     }

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -1838,7 +1838,7 @@ function summariseFanout(row) {
 // is how the R=0 expectation sat stale from rf2-dabt3 until rf2-zei9w ran
 // the driver; the unit pin is what stops the next such drift being found
 // by the next measurement instead of by CI.
-module.exports = { ladderStructuralFailures };
+module.exports = { ladderStructuralFailures, allocSteps };
 
 if (require.main === module) (async () => {
   build();

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -1426,10 +1426,10 @@ function summariseAlloc(row, maskable) {
   row.maskableWindows = maskable.length;
   console.log(
     `;;   masking budget: ${ALLOC_MASK_BUDGET_B} B per window (the measured fall threshold, ` +
-      'HALVED) on rise PLUS the largest single step. Below it no collection can have run at'
+      'HALVED) on rise PLUS the largest single step. At or under it no collection can have'
   );
   console.log(
-    ';;   all, masked or otherwise; at or above it a collection can hide behind the window\'s ' +
+    ';;   run at all, masked or otherwise; above it a collection can hide behind the window\'s ' +
       'own growth and `falls` = 0 stops meaning the reading is clean'
   );
   console.log(
@@ -2148,7 +2148,7 @@ if (require.main === module) (async () => {
       // and replaces none of it.
       if (maskable.length > 0) {
         failures.push(
-          `alloc: ${maskable.length} windows at or over the ${ALLOC_MASK_BUDGET_B} B masking ` +
+          `alloc: ${maskable.length} windows over the ${ALLOC_MASK_BUDGET_B} B masking ` +
             'budget — at that scale a collection can run inside a leg that allocates at least as ' +
             'much as it reclaims, so no step goes negative, the falling-step gate above reports a ' +
             'clean window, and the reclaimed bytes are missing from `rise` with nothing to say ' +


### PR DESCRIPTION
Closes rf2-n6w7o, which BLOCKS rf2-2rtt6.138.

## The defect

`allocSteps` was the allocation row's only collector detector, and it is a sign test on
adjacent in-page `usedJSHeapSize` deltas. Where V8 collects inside a leg that **also
allocates at least as much as the collection reclaimed**, the step never goes negative:
`falls` stays 0, the reclaimed bytes are missing from `rise`, and the row publishes a
window that looks clean and reads LOW.

Under-reading allocation is the direction that manufactures HD-002's predicted
flat-at-zero, so it is the one direction this row may not be able to fail in. And
`p0_ladder_structural.test.cjs` had no allocation coverage at all — a sample stream with a
fully masked collection in it passed silently, with nothing anywhere to notice.

## Route taken: (b), the bound — enforced as a refusal

The audit admitted either (a) an independent in-window witness or refusal, or (b) a
comparably rigorous bound. **(b), and it needed no new measurement**, so (a) was not
reached for.

Why (a) was rejected: every in-page collection witness available to this rig —
`WeakRef`/`FinalizationRegistry` liveness, or promoting `cdpBracket` into a failure path —
would itself have to be validated empirically before the row could lean on it, and no
measurement taken on a shared box is valid. A witness whose own reliability is unmeasured
is not better than the sign test; it is a second thing to distrust. The bound needs
nothing but arithmetic over figures already recorded.

**The bound** rests on one property of the fault: **masking cannot precede the first
collection.** Every leg before it runs with no collector in it, so `rise` counts those legs
*exactly*. And the collector does not fire until roughly `ALLOC_FALL_THRESHOLD_B` of
cumulative garbage has built up since the driver's forced GC on the window's near side. So
if a collection fired in leg k, writing `A_k` for that leg's own allocation:

```
rise  >=  (every leg before k)  >=  ALLOC_FALL_THRESHOLD_B - A_k
```

The legs are n repetitions of ONE work unit and every earlier leg is counted exactly, so
`A_k` is bounded by the largest rising step the window shows. Contrapositive, and it is the
gate:

```
rise + maxStep <= budget   =>   NO collection ran, masked or otherwise.
```

**Net growth cannot defeat it.** Masking only *removes* bytes from `rise`, which moves a
window further under budget — but the allocation that gave the collector its reason to run
is already counted, in full, in the legs before it where no masking is possible. Growth
cannot hide from this gate the way it hides from the sign test; it can only make a window
fail sooner. That is pinned as its own test (`NET GROWTH CANNOT DEFEAT IT`).

**The budget is the MEASURED threshold halved**, and both halves are stated in the header
rather than asserted:

- `ALLOC_FALL_THRESHOLD_B` (600 KB) is where the first **visible** fall appeared in the
  standalone probes. A masked one would not have shown, so it is an *upper* bound on where
  collection actually starts, and a gate built on it must take the conservative side.
- The halved figure, 300 KB, sits just above the largest window this instrument has a
  **corroborated** clean reading for: the D=1,000 control at the default 30 writes is
  240 KB of cumulative garbage and reads 8.13 B/double against a predicted 8. A window that
  under-read would not hit its prediction, so the control is positive evidence of no
  collection at that scale — which a fall count of zero, on its own, is not.

Deliberately **not** an env knob (pinned by a `lacks` assertion): every other `P0_ALLOC_*`
constant sizes the measurement, this one decides whether a measurement may be *published*,
and widening it would retro-admit every window it exists to refuse.

**The falling-step gate is untouched.** This is a second, independent exit beside it — a
falling step is a collection the counter *saw*, a window over budget is one it could not
have seen. `THE FALLS GATE IS UNTOUCHED` pins that half, and it was green before this
change as well as after. `cdpBracket` is likewise untouched and still appears in no failure
path.

**What the bound does not close**, stated in the header because a bound that oversells
itself is worse than none: a window in which *every* leg is masked defeats both terms.
`falls` catches such a window the moment one collection overshoots, `maxStep` the moment one
leg runs unmasked, and nothing here catches it if neither happens — that would need a
per-leg allocation counter V8 does not expose in-page. It is also unreachable for the arm
this bound exists to license, whose warm write is too small to cross the threshold inside a
single leg at all.

## What the bound says about rf2-2rtt6.138 (arithmetic only — no measurement taken)

Using the per-boundary-per-write figures **already recorded** on rf2-2rtt6.138's 2026-08-07
note (the candidate arm reads **544–1655 B/boundary/write**), against the gate
`(W+1) · B · c <= 300,000` for a W-write window:

| configuration | rise + maxStep | verdict |
|---|---|---|
| published witness, B=1200, 6 writes | 4.57–13.9 MB | REFUSED (the falls gate already refused it) |
| **the B=300 one-write config** | **326–993 KB** | **REFUSED — and this one showed 0 falls across 88 windows** |

That second row is the finding. The B=300 single-write configuration was treated as the
in-range witness because its fall count was zero; the bound says it was never certified,
across the whole measured range of `c`. rf2-2rtt6.138's note recorded its rungs as
non-monotone with r² of 0.75 / 0.28 / 0.94 / 0.31 and left the cause open — "whether that is
noise a smaller unit resolves or a real non-linearity is unmeasured". There is now a stated
reason to suspect the instrument rather than the substrate there. The bound does not say
that reading was wrong, only that it was never certified.

And the target size for the small-witness arm, which the bound makes computable:

| writes per window | B at c=1655 (pessimistic) | B at c=544 (optimistic) |
|---|---|---|
| 2 | <= 60 | <= 184 |
| 6 | <= 26 | <= 79 |

"A few dozen boundaries" — exactly the shape rf2-2rtt6.138's description proposed, now with
a number on it. This does **not** remove that bead's other blocker: `fx/cells-n` = 300 is
compile-time, so B is floored at 300 through the env surface and the arm still needs the
`p0_heap.cljs` rung the bead already names.

## Mutation proof

Done in two commits so the red is on the record.

`1f71231e6c` adds the pin against the **unrepaired** detector, with `allocSteps` exported
but otherwise untouched, so the pin fails on **behaviour** rather than on a missing symbol:

```
FAIL  THE DEFECT — a collection fully masked by net growth is REFUSED
      the masking witness must refuse it where the sign test cannot
p0_ladder_structural.test.cjs: 13/27 failed          runner exit 1
```

Inside `THE DEFECT`, the assertions **before** the failing one all passed: `falls === 0`,
`fall === 0`, `rise === 600000`. The current detector reports a clean window on a stream
that hid a 200 KB collection, and under-reports by exactly that 200 KB. Only
`assert.ok(s.maskable)` refuses.

`1408de6b9d` lands the repair: **27 passed, runner exit 0**.

The fixture is hermetic — `stream(legs, reclaim)` builds the sample buffer
`p0-heap/alloc-window!` would have filled, from stated per-leg allocations and stated
reclaims. Nothing is measured to produce it.

Coverage added: the masked case; the budget pinned as a number; a non-vacuous small-window
pass; the boundary either side (at budget passes, one byte over refuses); net growth's
direction; the falls gate unchanged; `maxStep` semantics; the idle window; and the
row-level `allocMaskableWindows` walk including its wiring into the driver's exit path.

## Quality gates

Every gate run in the foreground to completion, redirected to a worktree-local log (never
piped — a pipeline's exit status is its last command's), with the runner's own exit code
echoed explicitly.

| gate | result | exit |
|---|---|---|
| `node --check implementation/core/test/re_frame/bench/p0_run.cjs` | ok | **0** |
| `node --check implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs` | ok | **0** |
| `node …/p0_ladder_structural.test.cjs` — **baseline, before any change** | 14 passed | **0** |
| `node …/p0_ladder_structural.test.cjs` — **mutation proof vs unrepaired `allocSteps`** | **13/27 failed** | **1** |
| `node …/p0_ladder_structural.test.cjs` — **after the repair** | **27 passed** | **0** |
| `npm run test:script-helpers` (from `implementation/`) | every suite green; `p0_ladder_structural.test.cjs: 27 passed` | **0** |
| `sh scripts/test-fast-pr.sh` | `PASS fast PR spine` (incl. JVM core 2233 tests / 11645 assertions 0F 0E, `test:cljs`, and `p0_ladder_structural.test.cjs: 27 passed` inside `test:script-helpers`) | **0** |
| `sh scripts/check-beads-pr-boundary.sh main` | `No beads-database paths in this PR diff.` | **0** |

Structural-test count: **14 before, 27 after** (+13).

### Relying on CI for

`python scripts/check_fast_pr_gap.py --list` reports 90 required checks the local spine does
not decide. The diff is two `.cjs` files under `implementation/core/test/re_frame/bench/`,
so the ones that actually reach this surface, and which I am relying on CI for, are:

- **`eslint`** (lint.yml, `npm run lint:js`) — the repo-root lint manifest has no
  `node_modules` in a worker worktree. The gate is bug-class only (`no-undef`,
  `no-unused-vars`, `no-unreachable`, …) with no formatter; both files pass `node --check`
  and introduce no free or dead identifiers. No `eslint-disable` directive is added —
  `git grep -nE "(/\*|//) *eslint-(disable|enable)"` over this bench directory is empty.
- **`beads-pr-boundary`** (test.yml) — run locally against `main` and green, but CI resolves
  the branch point itself.
- **`Repo invariant checks`** (test.yml) — no skill, MCP, catalogue or namespace surface is
  touched.

No CLJS-browser, JVM-artefact, bundle-isolation or docs gate is reached: `p0_heap.cljs` is
**unchanged** (the bound needed no new page-side reading), no spec or docs file is touched,
and `--only alloc` is opt-in and in no gate — which is precisely why the witness is pinned
as a pure function under `test:script-helpers` rather than left to the next run of the
driver to discover.
