### PR TITLE
fix(hicasso): phase B baselines past the reap horizon, not before it (rf2-981nt)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -2069,6 +2069,32 @@
   []
   (select-keys (stats) [:cells :cell-refs :boundaries :edges :entries]))
 
+(defn quiesced!
+  "A promise that resolves once every reaper armed before this call has
+  run — **the runtime's own settling point, and the only honest place to
+  take a [[residue]] BASELINE**.
+
+  One macrotask is not that point. [[entry-reap-horizon-ms]] is
+  deliberately outside a bare `setTimeout 0`, so a residue read one
+  macrotask after an unclaimed render still counts entries the runtime
+  is about to drop. A baseline taken there is a state the runtime never
+  returns to, and an instrument gating on residue EQUALITY against it
+  throws on the first arm whose row outlives the horizon — which is
+  exactly what rf2-981nt was: `read_profile_app`'s phase B baselined six
+  entries at ~0 ms and found five thereafter, every run, byte-identical.
+
+  Exported so a caller settles against the runtime's own horizon rather
+  than against a copy of it, because the copy is what drifted. Nothing
+  here becomes a contract: [[entry-reap-horizon-ms]] stays a margin no
+  caller may rely on, and this promise says only *wait for me*, never
+  *here is my number*."
+  []
+  (js/Promise.
+    (fn [resolve]
+      ;; Strictly past the horizon, so a timer armed here expires after
+      ;; every reaper armed before it — the cell reapers (0 ms) included.
+      (js/setTimeout (fn [] (resolve nil)) (inc entry-reap-horizon-ms)))))
+
 (defn reset-runtime!
   "Drop every cell, every edge, every cached entry and every frame bundle.
   The root-teardown and test-fixture door; disposing each cell releases

--- a/implementation/freehand/test/re_frame/bench/hicasso/read_profile_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/read_profile_app.cljs
@@ -94,7 +94,10 @@
   Every phase-B delta is quoted as `c-local - variant`, a floor on the
   phase (the stubs are not free). Teardown runs outside every window;
   a settle and a residue equality gate (runtime counters AND each probe
-  frame's sub-cache emptiness) sit between samples.
+  frame's sub-cache emptiness) sit between samples. That settle is
+  [[residue-settle!]] — the runtime's own quiescence point rather than a
+  bare macrotask, and its docstring says why the difference is the
+  difference between phase B reaching a number and not (rf2-981nt).
 
   **`c-noactivate` should read at the noise floor ON THIS HOST, and that is
   the point of quoting it** (rf2-lzpfj). This app installs the UIx adapter,
@@ -513,6 +516,45 @@
 (def ^:private b-sampling {:warmup 2 :samples 6})
 (def ^:private b-rounds 4)
 
+(defn residue-settle!
+  "**The one point behind which every phase-B residue reading is taken** —
+  the baseline, the between-sample gate, and the final zero.
+
+  It is [[rt/quiesced!]] and not [[lane/settle!]], and the difference is
+  the whole of rf2-981nt. `settle!` yields ONE macrotask, which is the
+  right point for a substrate that queues its disposals there and the
+  wrong one for a runtime that arms its entry reaper at a horizon
+  deliberately OUTSIDE a bare `setTimeout 0` (rf2-2rtt6.84, so an
+  unclaimed entry survives long enough for `hydrateRoot`'s passive
+  subscribe to claim it). Phase B's setup harvests one unclaimed entry
+  per commit frame; baselined a macrotask later they are all still
+  cached, and they are gone by the first sampled arm. The gate compares
+  by equality — correctly, it is a count of live references — so it saw
+  six entries and then five and threw, every run.
+
+  So the baseline moves to where the runtime has actually settled. That
+  is the better instrument on its own terms: a baseline that holds
+  because the runtime has quiesced is evidence, where one that holds
+  because nothing has had time to happen yet is a coincidence with a
+  four-millisecond shelf life.
+
+  The arms are unaffected. A reaped entry is dropped from the runtime's
+  entry CACHE, not destroyed — the object survives in the closure phase B
+  holds — and [[rt/commit-boundary!]] reads the entry, never the cache,
+  so the `commit` arm acquires the same 141 cells through the same seam
+  either way.
+
+  **Named rather than spelled out three times**, because this defect was
+  invisible for exactly as long as the concept was unnamed: three
+  `lane/settle!` calls look like three ordinary yields, and there was
+  nowhere for the reason to live. Public because
+  `read-profile-baseline-cljs-test` drives THIS fn — a witness that
+  called `rt/quiesced!` itself would go green however this instrument
+  settled, which is the vacuous test that let the horizon move under a
+  faithful rig in the first place."
+  []
+  (rt/quiesced!))
+
 (defn- probe-caches-empty? []
   (every? (fn [f] (zero? (count @(:sub-cache (frame/frame f)))))
           commit-frames))
@@ -520,9 +562,9 @@
 (defn- rounds-async!
   "The reflecting-schedule sampler, promise-chained: every sample index
   visits every arm in [[lane/slot-order]]'s order; warm-up samples are
-  taken and discarded; between samples the arm's teardowns run, one
-  macrotask settles, and the residue gate must answer clean. Mirrors
-  `lane/rounds!`, which cannot yield."
+  taken and discarded; between samples the arm's teardowns run, the
+  runtime settles behind [[residue-settle!]], and the residue gate must
+  answer clean. Mirrors `lane/rounds!`, which cannot yield."
   [arms {:keys [warmup samples]} rounds' baseline]
   (let [k    (count arms)
         coll (lane/sample-collector)
@@ -539,7 +581,7 @@
                   teardowns (run)
                   ms        (- (lane/now-ms) t0)]
               (doseq [t teardowns] (t))
-              (-> (lane/settle!)
+              (-> (residue-settle!)
                   (.then
                     (fn [_]
                       (let [now (rt/residue)]
@@ -686,7 +728,7 @@
                                             commit-frames)
                               sets    (into {} (map (fn [f] [f (rt/reads-of (get entries f))])) commit-frames)
                               fss     (into {} (map (fn [f] [f (frame/frame-state-value f)])) commit-frames)]
-                          (-> (lane/settle!)
+                          (-> (residue-settle!)
                               (.then (fn [_]
                                        (let [baseline (rt/residue)]
                                          (rounds-async! (phase-b-arms entries sets fss roster)
@@ -728,8 +770,15 @@
                                       (doseq [[k v] micro]
                                         (js/console.log (str ";;   " (name k) ": " (fmt v 1) " ns"))))
                                     ;; ---- Teardown: release the warm hold, verify.
+                                    ;; Behind [[residue-settle!]] like every
+                                    ;; other residue reading: releasing the warm
+                                    ;; boundary arms the warm entry's reaper, and
+                                    ;; a bare macrotask lands in front of it — so
+                                    ;; the "nothing survives" gate below would
+                                    ;; have failed on `:entries 1` for the same
+                                    ;; reason the baseline failed on six.
                                     (warm-release)
-                                    (lane/settle!))))
+                                    (residue-settle!))))
                               (.then
                                 (fn [_]
                                   (let [res (rt/residue)]

--- a/implementation/freehand/test/re_frame/bench/hicasso/read_profile_baseline_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/read_profile_baseline_cljs_test.cljs
@@ -1,0 +1,173 @@
+(ns re-frame.bench.hicasso.read-profile-baseline-cljs-test
+  "PHASE B'S RESIDUE BASELINE IS THE STATE THE RUNTIME SETTLES TO —
+  pinned (rf2-981nt).
+
+  `read_profile_app`'s phase B gates every sample on residue EQUALITY
+  against a baseline read once, at setup. The gate is right and the
+  equality is right: these are counts of live references and a tolerance
+  on them would only make room for the fault. What was wrong was WHERE
+  the baseline was read.
+
+  Phase B's setup harvests one unclaimed read-set entry per commit frame
+  — minted by a render, `refs` still zero, reaper armed. `arm1/runtime`
+  arms that reaper at [[rt/quiesced!]]'s horizon, which rf2-2rtt6.84 moved
+  from 0 ms to 4 ms so an entry survives long enough for `hydrateRoot`'s
+  passive subscribe to claim it. A baseline read one bare macrotask later
+  therefore counts every one of those entries, and by the first sampled
+  arm they are gone. Six, then five, byte-identical on both attempts of
+  the granted quiet-box run, and no phase-B number at all.
+
+  ## Why this file, and why it would have caught the move
+
+  Both published phase-B runs predate the horizon change, so the studio
+  page records a residue gate that had never once fired. A gate that
+  never fires looks exactly like a gate that passes — which is the whole
+  reason the 0 -> 4 move could land under a faithful instrument without
+  anything going red.
+
+  The rows below drive `read-profile-app/residue-settle!` itself rather
+  than the runtime primitive underneath it, and that is deliberate: a
+  witness that called [[rt/quiesced!]] directly would stay green however
+  the instrument settled, which is precisely the vacuum this file exists
+  to fill. Put the instrument back on a bare macrotask and both rows go
+  red; move the horizon again and they stay green, because the settle
+  point is derived from the runtime's own number instead of copying it.
+
+  ## Shape
+
+  Four frames, one body run each through the same [[rt/render-body]] door
+  phase B's setup uses, and the same [[rt/commit-boundary!]] seam its
+  `commit` arm rides. Nothing here is timed and no number is published —
+  the claim is about reachability, not cost."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.read-profile-app :as app]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     ;; The map shape, because a reap horizon is not observable inside
+     ;; one synchronous test body — every row here is `async`.
+     :async?  true
+     :init-fn (fn [] (rt/reset-runtime!))}))
+
+(def ^:private commit-frames
+  "Phase B's four identically-seeded frames, in miniature."
+  [::b1 ::b2 ::b3 ::b4])
+
+(defn- seeded! []
+  (rt/reset-runtime!)
+  (doseq [f commit-frames] (dogfood/make-frame! f 3))
+  nil)
+
+(defn- harvest!
+  "Phase B's setup: one body run per frame through the runtime's own
+  door, and the read-set entry that run minted read back off
+  [[rt/last-reads]]. Every entry comes back UNCLAIMED — `refs` zero,
+  reaper armed — which is the state the real setup leaves behind and the
+  state the baseline is taken in."
+  []
+  (mapv (fn [f]
+          (rt/render-body f
+                          (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
+                                   (str (rt/sub [:dogfood/remaining]))])
+                          {})
+          (rt/last-reads))
+        commit-frames))
+
+(defn- commit-arm!
+  "Phase B's `commit` arm and its teardown: the shipping commit half
+  through the seam React occupies, for every harvested entry, released
+  again outside any window."
+  [entries]
+  (let [stops (mapv (fn [e] (rt/commit-boundary! e (fn [] nil))) entries)]
+    (doseq [stop stops] (stop))
+    nil))
+
+;; ===========================================================================
+;; 1 — the baseline is the state the runtime settles to
+;; ===========================================================================
+
+(deftest the-phase-b-baseline-is-the-state-the-runtime-settles-to
+  (async done
+    (seeded!)
+    (harvest!)
+    (testing "the reading `residue-settle!` puts the baseline behind is the
+             reading the runtime settles to on its own. Read it a bare
+             macrotask earlier and it counts four cached entries the
+             reapers are about to drop — a baseline the run can never
+             return to, and the six-against-five the gate threw on"
+      (let [!baseline (volatile! nil)]
+        (-> (app/residue-settle!)
+            (.then (fn [_] (vreset! !baseline (rt/residue)) (rt/quiesced!)))
+            (.then (fn [_]
+                     (is (= @!baseline (rt/residue))
+                         "the baseline is a fixed point of the runtime's own
+                          settling, so every later sample can reach it")
+                     (is (zero? (:entries @!baseline))
+                         "and it is the post-reap state: four unclaimed
+                          entries, none of them cached by the time the
+                          baseline is taken")
+                     (rt/reset-runtime!)
+                     (done))))))))
+
+;; ===========================================================================
+;; 2 — the mechanism, stated positively
+;; ===========================================================================
+
+(deftest one-bare-macrotask-lands-in-front-of-the-reap-horizon
+  (async done
+    (seeded!)
+    (harvest!)
+    (testing "why row 1 is not free: one `lane/settle!` after the render
+             every unclaimed entry is STILL cached — that survival is the
+             hydration margin rf2-2rtt6.84 bought, and it is what makes a
+             residue reading taken there disagree with one taken after the
+             runtime has quiesced"
+      (-> (lane/settle!)
+          (.then (fn [_]
+                   (is (= (count commit-frames) (:entries (rt/residue)))
+                       "a bare macrotask is inside the horizon: every
+                        harvested entry is still in the cache")
+                   (app/residue-settle!)))
+          (.then (fn [_]
+                   (is (zero? (:entries (rt/residue)))
+                       "past it they are gone — two readings, two answers,
+                        and only the second is a baseline")
+                   (rt/reset-runtime!)
+                   (done)))))))
+
+;; ===========================================================================
+;; 3 — and the gate itself holds across the `commit` arm
+;; ===========================================================================
+
+(deftest the-residue-gate-holds-across-the-commit-arm
+  (async done
+    (seeded!)
+    (let [entries   (harvest!)
+          !baseline (volatile! nil)]
+      (testing "the assertion `rounds-async!` runs between samples, end to
+               end: baseline, one `commit` arm with its teardown, and the
+               reading a row's worth of time later. The real run takes
+               hundreds of samples over eight arms, so only its very first
+               reading can fall inside the horizon at all — `rt/quiesced!`
+               behind the instrument's own settle is the shortest honest
+               stand-in for that, and it is what makes this row decide the
+               gate rather than race it"
+        (-> (app/residue-settle!)
+            (.then (fn [_]
+                     (vreset! !baseline (rt/residue))
+                     (commit-arm! entries)
+                     (app/residue-settle!)))
+            (.then (fn [_] (rt/quiesced!)))
+            (.then (fn [_]
+                     (is (= @!baseline (rt/residue))
+                         "the commit half acquired 4 x 2 cells and gave
+                          every one of them back, and the entry cache is
+                          where the baseline left it")
+                     (rt/reset-runtime!)
+                     (done))))))))


### PR DESCRIPTION
`read_profile_app`'s phase B could not reach a number. Two granted quiet-box
attempts produced the identical refusal, exit 1 both times:

```
phase-B residue after commit — expected {:cells 141, :cell-refs 141, :boundaries 1,
:edges 141, :entries 6}, found {... :entries 5}
```

Phase B's setup harvests one **unclaimed** read-set entry per commit frame —
minted by a render, `refs` still zero, reaper armed. `arm1/runtime` arms that
reaper at `entry-reap-horizon-ms`, which rf2-2rtt6.84 (`337b2c2fb4`) moved from
0 ms to 4 ms so an entry survives long enough for `hydrateRoot`'s passive
subscribe to claim it. `lane/settle!` is ONE macrotask, so the baseline was read
strictly *inside* that horizon and counted all six live entries; the reapers
fired during the first sampled arm and the gate — comparing by equality, as it
must — saw five and threw.

It had never fired before because at horizon 0 the reaper's `setTimeout` was
armed *before* `settle!`'s and drained first, so every residue read saw the same
post-reap state. Both published phase-B runs (`cb41ee537b`, `0c0ff21f0d`)
predate `337b2c2fb4`, which is why the studio page records a residue gate that
had never once fired.

## The repair

**The gate is not widened and the 4 ms is not reverted.** The gate was reporting
a real disagreement: the baseline phase B computed was no longer reachable under
the runtime its arms measure. So the baseline moves to where the runtime has
actually settled.

- **`arm1/runtime.cljs` gains `quiesced!`** — a promise resolving strictly past
  `entry-reap-horizon-ms`, so a caller settles against the runtime's own horizon
  instead of a copy of it. The copy is what drifted, and this file already
  carries that lesson once (rf2-6wh9o, on `cell-watch-key`). Nothing becomes a
  contract: the horizon stays a margin no caller may rely on, and the promise
  says only *wait for me*, never *here is my number*.
- **`read_profile_app.cljs` names the concept it never had** — `residue-settle!`,
  the one point behind which the baseline, the between-sample gate and the final
  zero are all read. The defect was invisible for exactly as long as the concept
  was unnamed: three `lane/settle!` calls look like three ordinary yields, and
  there was nowhere for the reason to live.
- **The final zero had the same latent defect.** Releasing the warm hold arms
  that entry's reaper too, and a bare macrotask lands in front of it — the
  "nothing survives" gate would have failed on `:entries 1` for the same reason
  the baseline failed on six. It is behind the same settle point now.

### Why the settle point and not the other site

The bead offered two homes: settle past the horizon before baselining, or hold
the harvested entries' `refs` above zero for the row's duration. **The second
was rejected because it cannot be done without changing what the `commit` arm
measures.** The only honest way to raise an entry's `refs` is to commit a
boundary on it — which pre-acquires all 141 cells per frame, so the sampled
`commit` arm would then be acquiring *existing* cells rather than minting them,
and the arm's whole subject (cell construction, reaction wiring, reader
membership) evaporates. The alternative — a runtime mutator that pokes `refs`
for no reason but this instrument — would bend the runtime to accommodate the
rig, which is backwards.

The settle point costs the measurement nothing. A reaped entry is dropped from
the runtime's entry *cache*, not destroyed — the object survives in the closure
phase B holds — and `rt/commit-boundary!` reads the entry, never the cache, so
the arm acquires the same 141 cells through the same seam either way. And a
baseline that holds *because the runtime has quiesced* is evidence, where one
that holds because nothing has had time to happen yet is a coincidence with a
four-millisecond shelf life.

### The witness

`read_profile_baseline_cljs_test.cljs` — three rows, driving
`read-profile-app/residue-settle!` **itself** rather than the runtime primitive
underneath it. That is the load-bearing choice: a witness that called
`rt/quiesced!` directly would stay green however the instrument settled, which
is precisely the vacuum that let the horizon move under a faithful rig with
nothing going red.

1. `the-phase-b-baseline-is-the-state-the-runtime-settles-to`
2. `one-bare-macrotask-lands-in-front-of-the-reap-horizon` (the mechanism)
3. `the-residue-gate-holds-across-the-commit-arm` (the assertion `rounds-async!`
   actually runs, end to end)

**Red-then-green proof.** With `residue-settle!`'s body reverted to
`(lane/settle!)` — i.e. the protocol exactly as it stands on `main`, everything
else unchanged — `npm run test:cljs` exits **1** with **3 failures**:

```
FAIL in (the-phase-b-baseline-is-the-state-the-runtime-settles-to)
expected: (= (deref !baseline) (rt/residue))
  actual: (not (= {:cells 0, :cell-refs 0, :boundaries 0, :edges 0, :entries 4}
                  {:cells 0, :cell-refs 0, :boundaries 0, :edges 0, :entries 0}))

FAIL in (the-phase-b-baseline-is-the-state-the-runtime-settles-to)
expected: (zero? (:entries (deref !baseline)))
  actual: (not (zero? 4))

FAIL in (the-residue-gate-holds-across-the-commit-arm)
expected: (= (deref !baseline) (rt/residue))
  actual: (not (= {:cells 0, :cell-refs 0, :boundaries 0, :edges 0, :entries 4}
                  {:cells 0, :cell-refs 0, :boundaries 0, :edges 0, :entries 0}))

Ran 12797 tests containing 64387 assertions.
3 failures, 0 errors.
```

That is the instrument's six-against-five in miniature. With the repair in
place: `0 failures, 0 errors`, exit 0. Had these rows existed before
`337b2c2fb4`, the 0 → 4 ms move would have turned them red; they now hold at any
horizon, because the settle point is derived from the runtime's own number
rather than copying it.

**No measurement was taken.** No quiet window was opened, no number published,
no absolute re-taken — five other workers are on this box and any wall-clock row
taken today is invalid by construction. The deliverable is that phase B can
*reach* a number again. rf2-d360z is now unblocked.

## Quality gates

Every gate run in the foreground to completion, output redirected to a
worktree-local log (never piped — a pipeline's exit status is its last
command's), with the runner's own exit code echoed. Every gate script printed
`gate root: /c/Users/miket/code/re-frame2-worktrees/phaseb-981nt` — this
worktree.

| gate | command | exit | result |
|---|---|---|---|
| Hicasso bench-lane compile | `npm run test:hicasso-compile` (from `implementation/`) | **0** | 137 lane namespaces, 444 files, 443 compiled, **0 warnings** |
| CLJS node-test | `npm run test:cljs` (from `implementation/`) | **0** | **12797 tests, 64387 assertions, 0 failures, 0 errors** |
| CLJS node-test, repair reverted (red proof) | same, `residue-settle!` → `(lane/settle!)` | **1** | 12797 tests, 64387 assertions, **3 failures**, 0 errors |
| Fast-PR spine | `sh scripts/test-fast-pr.sh` | **0** | 61 stages, classified `docs=false jvm=true node=true` |
| clj-kondo | `clj-kondo --fail-level error --lint` over the three changed files | **0** | **errors 0, warnings 0** (one pre-existing `info` on an untouched line) |
| Beads PR boundary | `sh scripts/check-beads-pr-boundary.sh origin/main` | **0** | "No beads-database paths in this PR diff." |

**clj-kondo version.** Local binary is `v2025.10.23`; CI pins `2026.04.15`. The
spine says plainly that a pass from a differently-versioned local binary proves
nothing, so the kondo verdict here is indicative and **CI's `clj-kondo` job
decides it**.

**Relied on CI** (from `python scripts/check_fast_pr_gap.py --list`; none of
these is decided by the local spine):

- `cljs-browser` — the `*_dom_cljs_test` lane. `arm1/runtime.cljs` is required by
  `hydrate_dom_cljs_test`, `dogfood_dom_cljs_test` and others; the change there
  is purely additive (one new public fn, nothing existing touched), but CI
  decides.
- The `CLJS (shadow-cljs :node-test)` job's extra step, `npm run test:ui-isolation`.
- `jvm-freehand` and `jvm-freehand-prod-gate` — CLJS-only files with no JVM reach.
- The `cljs_prod`-armed probes that `implementation/freehand/**` triggers:
  `cljs-freehand-evidence-elision`, `cljs-freehand-reachability`, `cljs-elision`,
  `cljs-perf-bundle`, `cljs-browser-prod-elision`,
  `cljs-browser-schemas-boundary-prod`. All three files are bench-lane test
  sources, not require-reachable from any release entry.
- `Lint required` → `clj-kondo` (at the pin), `splint`, `eslint`, `api-manifest`.
- `beads-pr-boundary`'s own self-test step (`scripts/git-hooks/test-pre-commit.sh`).

Closes rf2-981nt. Unblocks rf2-d360z.
