### PR TITLE
fix(reagent-slim): dispatch-sync does not flush, and the recipe must not promise it does (rf2-iogzk)

### DIFF
--- a/implementation/adapters/reagent-slim/FORM-3.md
+++ b/implementation/adapters/reagent-slim/FORM-3.md
@@ -374,9 +374,12 @@ Three variations worth knowing:
   both the seed and the subscription to the sources, and every later change
   re-runs it on the ordinary batched drain (`reagent2.ratom/flush!`, which the
   commit boundary performs) rather than inline inside the `app-db` write. Write
-  the widget as though the feed lands on the following commit; the adapter's
-  `:flush-render!` happens to perform that drain itself, so under `dispatch-sync`
-  the widget is already current when the call returns, but do not build on it.
+  the widget as though the feed lands on the following commit, because it does:
+  a source change only enqueues the owner for the next microtask drain, and
+  `dispatch-sync` returns before that drain has run. A caller that must see the
+  widget settled before it looks — a test, or a headless Tool-Pair step — wraps
+  the dispatch in the adapter's `:flush-render!`, which drains the reaction
+  queue and commits inside a single `flushSync` boundary.
   Hold the owner per mount and tear down in that order at unmount —
   `reagent2.ratom/dispose!` the owner **first**, then balance the acquire with
   frame-first `(rf/unsubscribe frame query-v)` — so the owner is gone before the

--- a/implementation/adapters/reagent/test/re_frame/schema_reject_notification_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/schema_reject_notification_cljs_test.cljs
@@ -16,9 +16,9 @@
   assert-schema-rejection-zero-sub-notifications`.
 
   The observer is an `r/track!` auto-runner — the SAME activation path
-  a mounted Reagent view uses (a bare `add-watch` on a Reagent 1.x
-  Reaction never activates it headlessly, so it would vacuously see
-  nothing on ANY commit).
+  a mounted Reagent view uses (a bare `add-watch` on a Reagent Reaction
+  never activates it headlessly, so it would vacuously see nothing on
+  ANY commit).
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]


### PR DESCRIPTION
Closes rf2-iogzk.

## The false timing promise

`FORM-3.md`'s imperative-widget owner recipe ended with a reassurance that
the repository's own test disproves:

> the adapter's `:flush-render!` happens to perform that drain itself, so under
> `dispatch-sync` the widget is already current when the call returns, but do
> not build on it.

`dispatch-sync` does not call `:flush-render!`. A source change on an
`activate!`-owned reaction reaches `_handle-change`, which — because
`activate!` deliberately leaves `:auto-run` nil — takes the `rea-enqueue`
branch (`reagent2/ratom.cljs:326-331`), and `rea-enqueue` asks the installed
scheduler for a **microtask** drain (`:177-183`). That drain runs after
`dispatch-sync` has returned. `reagent_slim_flush_render_dom_cljs_test.cljs`
states and proves the same thing for the render half: dispatching without a
manual flush "only enqueues the dependent component for the next
microtask-turn re-render, so the committed DOM still reads the OLD value",
and it is the explicit `flush!` on the next line that commits it.

The sentence already carried the correct instruction — *write the widget as
though the feed lands on the following commit* — and then undercut it. The
reassurance is **deleted rather than qualified**: a caveat attached to a false
statement is still a false statement, and "do not build on it" is not a defence
against a reader who will. What replaces it says why the next-commit rule holds
and names the one supported way to settle the widget synchronously, wrapping
the dispatch in the adapter's `:flush-render!`.

The `activate!` / `make-reaction` / `dispose!` ownership recipe that PR #7669
landed is correct and is **untouched** — the `add-watch` trap wording, the
adapter-specific owner, and the per-mount teardown ordering all stand.

## The stale substrate version

`schema_reject_notification_cljs_test.cljs`'s docstring said "a bare
`add-watch` on a Reagent **1.x** Reaction never activates it headlessly". The
claim is right and the law is unchanged; only the version was stale. The pinned
substrate is **Reagent 2.0.1** (`implementation/adapters/reagent/deps.edn:15`,
the artefact that owns the stock-Reagent dep). The version qualifier is
**dropped** rather than renumbered: the law holds on every Reagent version, so
naming one only sets up the next rot. Docstring only — no logic, no assertion,
no fixture touched.

## Ruling on teeth for the prose (bead item 3): declined

Every token-level rule that would have caught the old sentence — `dispatch-sync`
co-occurring with `:flush-render!`, or with a settled-on-return claim — fires
just as readily on the **replacement**, which mentions both correctly; the
difference between the false version and the true one is semantic, not lexical,
and Rule 5c's power comes precisely from keying on stable *code* tokens that
carry meaning on their own. The alternative, pinning the paragraph's wording as
a prose anchor, would detect *change* rather than *falsehood* and would fire on
innocent rewording — nag-diagnostics, not a drift gate. Rule 5c is left exactly
as it is.

## Quality gates

Every gate run in the foreground to completion, output redirected to a
worktree-local log (never piped — a pipeline's exit status is its last
command's), exit code captured explicitly. Every gate script's first line read
`gate root: /c/Users/miket/code/re-frame2-worktrees/slimform3-iogzk`.

| Gate | Result | Exit |
|---|---|---|
| `npm run test:cljs` (from `implementation/`) | 12794 tests, 64382 assertions, 0 failures, 0 errors | **0** |
| `sh scripts/test-fast-pr.sh` | `PASS fast PR spine` — always-on static/drift block, docs tier (`mkdocs build --strict` + 9 doc checkers), JVM tier (`implementation/core` + `implementation/adapters/reagent` + `implementation/adapters/reagent-slim`), node tier (`:node-test`, JS harness self-tests, 17-namespace isolation gate, hicasso compile gate) | **0** |
| `clj-kondo --lint …/schema_reject_notification_cljs_test.cljs` | 0 errors, 0 warnings | **0** |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | "No beads-database paths in this PR diff." | **0** |
| `python scripts/check_skill_migration_contract_drift.py` (Rules 5 / 5b / 5c + retarget invariance — the one gate that **does** read `FORM-3.md`) | clean | **0** |

`clj-kondo` caveat: the local binary is v2025.10.23; CI pins 2026.04.15, and the
versions can disagree about which findings are errors. CI's `clj-kondo` job is
authoritative. The change is a docstring string, so the exposure is nil.

### Gates that do NOT cover `FORM-3.md` — hand-verified instead

`implementation/adapters/reagent-slim/FORM-3.md` lives under `implementation/`,
and **neither documentation gate reaches it**:

- `mkdocs build --strict` — `mkdocs.yml` sets `docs_dir: docs`, so nothing
  outside `docs/` is in the site at all.
- `scripts/check_doc_slugs.py` — its `DEFAULT_ROOTS` are `docs`, `spec`,
  `skills`, `migration`, plus `tools/*/spec`. `implementation/` is not a root.

Nominating either would have been a green that verified nothing — the same
fail-open shape this bead is about. Hand-verified instead:

- **Links** — 5 distinct relative targets, all resolve from the file's own
  directory: `../../../skills/re-frame-migration/references/guided-handlers-state.md`,
  `DESIGN-RATIONALE.md`, `IMPL-SPEC.md`,
  `../../../skills/reagent-migration/references/catalog-judgment.md`,
  `../../../spec/004-Views.md`. No anchor fragments, so nothing to slug-check.
- **Tables** — 4 tables, each internally uniform: line 17 (2 columns; header +
  separator + 7 body rows), line 49 (3 columns; + 4 body rows), line 622
  (2 columns; + 6 body rows), line 653 (3 columns; + 6 body rows). The diff
  touches no table and no link.

### Relying on CI for

From `python scripts/check_fast_pr_gap.py --list` (90 required checks the spine
does not decide). The ones this diff's surface actually reaches:

- `cljs-reagent-slim-bundle-isolation` (`reagent_slim_bundle` gate — the Slim
  adapter tree changed)
- `adapter_diagnostic`'s lanes, notably `jvm-reagent-slim` and
  `jvm-adapters-test-react`
- `clj-kondo` and `splint` under `Lint required`, at CI's pinned versions
- `tools-playground`, if the `playground` path filter admits a `.md`. It cannot
  drift the bundle either way: `scripts/playground-sci-input-digest.mjs` scopes
  reagent-slim to `src` and `deps.edn` only.

No measurement was taken — six other workers share this box.
