### PR TITLE
fix(hicasso): the workload section must not conclude from a refused ratio (rf2-110be)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/jsfb_compare.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/jsfb_compare.cjs
@@ -60,6 +60,13 @@
 // ratios a sound run produces, so finiteness alone let counter-inverted
 // timing evidence through the gate above (rf2-110be, from #7643's audit).
 //
+// NOR MAY ANYTHING DOWNSTREAM CONCLUDE FROM A CELL THAT PREDICATE REFUSED.
+// The WORKLOAD section states a second finding out of the same numbers, and
+// its only condition used to be that `summary.run1k` existed — so a ratio the
+// table had already thrown out still moved the published mount by a perfectly
+// finite percentage (rf2-110be, from #7675's audit). Every conclusion in
+// `report` now sits behind the decision its evidence was already given.
+//
 // WHAT IT DOES NOT ADJUDICATE, deliberately. The run's own gates — DOM
 // parity, the positive control, page errors, unverified writes — are
 // REPORTED here and decided by `jsfb_ours_run.cjs`, which owns them and
@@ -296,6 +303,7 @@ const fmt = (x, n = 4) => (Number.isFinite(x) ? x.toFixed(n) : 'n/a');
 // row. Our instrument on the benchmark's create-1,000 against our
 // instrument on the M1 mount witness: same instrument, different page.
 const PUBLISHED_M1_MOUNT = 1.2107;
+const WORKLOAD_CELL = cellId('01_run1k', 'rf2-hicasso');
 
 function report(theirs, ours, rows) {
   console.log('');
@@ -333,11 +341,21 @@ function report(theirs, ours, rows) {
 
   console.log('');
   console.log(';; WORKLOAD — one instrument, two pages (the other half of the 2x2)');
-  if (ours && ours.summary && ours.summary.run1k) {
-    const r = ratioOf(ours.summary.run1k, 'rf2-hicasso');
-    console.log(`;;   ours, benchmark create-1,000 rows   ${fmt(r)}`);
-    console.log(`;;   ours, M1 mount (published, rf2-0qj9w) ${fmt(PUBLISHED_M1_MOUNT)}`);
-    console.log(`;;   workload moves the ratio by ${(((r - PUBLISHED_M1_MOUNT) / PUBLISHED_M1_MOUNT) * 100).toFixed(1)}%`);
+  // Both pages are OURS, so it is our side's refusal that governs and not the
+  // row's comparability: the benchmark driver's evidence is not among this
+  // section's premises. The row has already taken that decision over base, arm
+  // and ratio, so this reads it rather than deriving a second one.
+  const w = rows.find((r) => r.cell === WORKLOAD_CELL);
+  const bad = w ? w.oBad : `no \`${WORKLOAD_CELL}\` row was built at all`;
+  console.log(`;;   ours, benchmark create-1,000 rows   ${fmt(w ? w.oRatio : NaN)}`);
+  console.log(`;;   ours, M1 mount (published, rf2-0qj9w) ${fmt(PUBLISHED_M1_MOUNT)}`);
+  // The refused value stays visible; it is the CONCLUSION that is withheld.
+  // Saying so beats printing nothing — a section that simply vanishes reads as
+  // "not applicable" rather than "the evidence was rejected".
+  if (bad) {
+    console.log(`;;   UNMEASURED — ${bad}, so no movement is derived from it`);
+  } else {
+    console.log(`;;   workload moves the ratio by ${(((w.oRatio - PUBLISHED_M1_MOUNT) / PUBLISHED_M1_MOUNT) * 100).toFixed(1)}%`);
   }
 
   // The run's own gates, REPORTED. `jsfb_ours_run.cjs` decides them.

--- a/implementation/freehand/test/re_frame/bench/hicasso/jsfb_compare_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/jsfb_compare_exit_path.test.cjs
@@ -457,6 +457,83 @@ test('THE PROCESS EXIT: an all-negative driver table exits 1 from the shell, not
   assert.doesNotMatch(r.stdout, /VERDICT: 10 of 10 comparable rows agree/, 'ten negative rows are not ten agreements');
 });
 
+// --- AND NOTHING DOWNSTREAM MAY CONCLUDE FROM A CELL THE GATE REFUSED -------
+//
+// The predicate above decides which cells are measured; `report`'s WORKLOAD
+// section then states a SECOND finding — how far our create-1,000 ratio sits
+// from the published M1 mount — and for one release it was not behind that
+// decision. Its only condition was that `summary.run1k` existed, so #7675's
+// merged-PR audit found the refused evidence still speaking: an ours ratio of
+// -1.2 is thrown out of the table by `buildRows` and moves the published
+// 1.2107 by a perfectly finite -199.1% four lines later. A refused
+// measurement that still concludes is worse than one that errors, because the
+// sentence it prints is well formed.
+//
+// `report` prints rather than returns, so these are PROCESS assertions: there
+// is no seam to call. What they pin is one-way — a conclusion may become a
+// suppression, never the reverse — so the measured case is asserted too.
+
+const WORKLOAD_CONCLUSION = /workload moves the ratio by/;
+
+test('THE WORKLOAD CONCLUSION: a refused ours ratio prints UNMEASURED, not a movement', () => {
+  for (const bad of [0, -1.2]) {
+    const f = oursPatched(`wl-ratio-${bad}.json`, 'run1k', OTHERS[0], { ratio: bad });
+    const r = run(['--theirs', theirsDir(`wl-ratio-${bad}`), '--ours', f]);
+    assert.strictEqual(r.status, 1, r.stdout + r.stderr);
+    assert.doesNotMatch(r.stdout, WORKLOAD_CONCLUSION, `ratio ${bad} may not move the published mount by anything`);
+    assert.ok(r.stdout.includes(`UNMEASURED — ratio=${bad}`), r.stdout);
+    // The refused number stays ON THE PAGE. It is the conclusion that goes,
+    // not the evidence: a reader debugging the run needs to see what arrived.
+    assert.match(r.stdout, new RegExp(`ours, benchmark create-1,000 rows\\s+${bad.toFixed(4).replace('-', '-')}`), r.stdout);
+  }
+});
+
+test('THE WORKLOAD CONCLUSION: the audit\'s own -199.1% is not printed', () => {
+  // Named literally, because it is the number the bypass produced and the one
+  // a reader would have quoted.
+  const f = oursPatched('wl-audit.json', 'run1k', OTHERS[0], { ratio: -1.2 });
+  const r = run(['--theirs', theirsDir('wl-audit'), '--ours', f]);
+  assert.doesNotMatch(r.stdout, /-199\.1%/, 'the audit\'s worked example must not survive as a finding');
+});
+
+test('THE WORKLOAD CONCLUSION: a refused ours DURATION suppresses it too, sound ratio or not', () => {
+  // The discriminating case, and the reason this reuses the row's own refusal
+  // rather than testing the ratio a second time: the ratio here is an ordinary
+  // 1.2, so a guard that looked only at the derived number would still print
+  // the movement — which is exactly the defect this bead's first half fixed,
+  // recurring one section further down.
+  for (const [field, bad] of [['base', 0], ['base', -100], ['ms', 0], ['ms', -120]]) {
+    const f = oursPatched(`wl-${field}-${bad}.json`, 'run1k', OTHERS[0], { [field]: bad });
+    const r = run(['--theirs', theirsDir(`wl-${field}-${bad}`), '--ours', f]);
+    assert.strictEqual(r.status, 1, r.stdout + r.stderr);
+    assert.doesNotMatch(r.stdout, WORKLOAD_CONCLUSION, `ours ${field}=${bad} may not yield a movement`);
+    const named = field === 'base' ? `base ms=${bad}` : `${OTHERS[0]} ms=${bad}`;
+    assert.ok(r.stdout.includes(`UNMEASURED — ${named}`), r.stdout);
+  }
+});
+
+test('THE WORKLOAD CONCLUSION: a MEASURED run still states the movement', () => {
+  // The other direction. A section that fell silent on sound evidence would
+  // pass every assertion above and be a worse program than the one repaired.
+  const r = run(['--theirs', theirsDir('wl-ok'), '--ours', oursJson('wl-ok.json')]);
+  assert.strictEqual(r.status, 0, r.stderr);
+  assert.match(r.stdout, /workload moves the ratio by -?\d+\.\d%/);
+  assert.doesNotMatch(r.stdout, /UNMEASURED/, 'a sound ratio is not a refusal');
+});
+
+test('THE WORKLOAD CONCLUSION is OURS-only: a short DRIVER table does not suppress it', () => {
+  // The fence. This section is one instrument across two pages, so the
+  // benchmark driver's evidence is not among its premises — guarding it on the
+  // row's comparability, as the DIRECTION block above rightly does, would
+  // refuse on grounds it never read. Our side's refusal governs; theirs does
+  // not.
+  const dir = theirsDir('wl-short', { skip: [`${OTHERS[0]}_01_run1k`] });
+  const r = run(['--theirs', dir, '--ours', oursJson('wl-short.json')]);
+  assert.strictEqual(r.status, 1, r.stdout + r.stderr);
+  assert.match(r.stderr, /1 of 10 expected cells/);
+  assert.match(r.stdout, WORKLOAD_CONCLUSION, 'ours measured this page; the driver is not its premise');
+});
+
 test('THE PROCESS EXIT: no arguments at all is a refusal, not a green run', () => {
   const r = run([]);
   assert.notStrictEqual(r.status, 0);


### PR DESCRIPTION
Closes rf2-110be (the reopened remainder — the description's measured-cell predicate landed in `abcb34217c`; this is the last note only).

## The bypass

`jsfb_compare.cjs`'s measured-cell predicate rejects non-positive durations, and the DIRECTION section three lines above the WORKLOAD block guards on it correctly:

```js
if (!Number.isFinite(r.diff)) continue; // an unmeasured cell has no direction
```

The WORKLOAD section did not. Its only condition was that `summary.run1k` **existed**, so a ratio `buildRows` had already thrown out still produced a secondary finding four lines later. #7675's worked example, reproduced verbatim here before the change:

```
;; WORKLOAD — one instrument, two pages (the other half of the 2x2)
;;   ours, benchmark create-1,000 rows   -1.2000
;;   ours, M1 mount (published, rf2-0qj9w) 1.2107
;;   workload moves the ratio by -199.1%          <-- from evidence the gate refused
```

A refused measurement that still concludes is worse than one that errors, because the sentence it prints is perfectly well formed.

## The repair

The section now reads the refusal the row **already took** over base, arm and ratio (`row.oBad`) rather than deriving a second one, and prints `UNMEASURED` naming the offending value instead of a movement:

```
;;   ours, benchmark create-1,000 rows   -1.2000
;;   ours, M1 mount (published, rf2-0qj9w) 1.2107
;;   UNMEASURED — ratio=-1.2, so no movement is derived from it
```

The raw numbers stay visible — it is the conclusion that is withheld, not the evidence. It says so rather than falling silent, because a section that simply vanishes reads as "not applicable" rather than "the evidence was rejected".

The sharpest case is not the negative ratio but a refused **duration** behind a sound one: `base ms=-100` under an ordinary `1.2000` ratio previously printed a wholly plausible `-0.9%`. A guard that re-tested only the ratio would still print it; reusing the row's three-value decision is what catches it.

**One deliberate divergence from the DIRECTION guard.** DIRECTION suppresses on `r.diff`, which needs *both* instruments — right, because it compares two. WORKLOAD is one instrument across two pages, so the benchmark driver's evidence is not among its premises and **our** side's refusal governs. A short driver table therefore does *not* suppress it, and a test pins that fence.

## Fence held

- `EXPECTED_CELLS` untouched, still derived from `PAIRS`.
- `verdict`, `buildRows`, `notMeasured`, `positive`, `main` untouched.
- The parity gate untouched.
- The whole edit is inside `report()`, which prints and returns nothing, and which `main` calls *before* `verdict`.

## No exit code changed

Established two ways.

**Structurally**: the diff is confined to `report()` plus one module constant and header prose. `report` returns nothing, mutates nothing (`rows.find` is a read), and `main` returns `verdict({ absent, rows })` — a value it computes independently and after.

**Empirically**: the pre-change comparator was extracted from `HEAD` and both versions were run over one identical 34-fixture matrix spanning all three documented exit codes (0 complete/failing-run-gates; 1 short-theirs, short-ours, all-negative table, zero/negative arm and base medians, zero/negative ours ratio/base/ms, non-finite ratio, dropped run1k; 2 no args, absent dir, dir-is-a-file, empty dir, strangers-only, corrupt result file, absent/unparseable/shapeless ours).

```
34 fixtures compared; 0 exit-code divergence(s)
```

Every one of the 37 pre-existing witness cases also still passes unmodified.

## Red then green

The five new cases were written and run **before** the repair:

```
FAIL  THE WORKLOAD CONCLUSION: a refused ours ratio prints UNMEASURED, not a movement
      ratio 0 may not move the published mount by anything
FAIL  THE WORKLOAD CONCLUSION: the audit's own -199.1% is not printed
      the audit's worked example must not survive as a finding
FAIL  THE WORKLOAD CONCLUSION: a refused ours DURATION suppresses it too, sound ratio or not
      ours base=0 may not yield a movement

jsfb_compare_exit_path.test.cjs: 3/42 failed          <-- exit 1
```

After:

```
jsfb_compare_exit_path.test.cjs: 42 passed            <-- exit 0
```

The two cases that were green in both runs are the one-way fence — "a measured run still states the movement" and "a short driver table does not suppress it" — and they must stay green, or the repair would have turned a conclusion into silence where the evidence was sound.

Witness case count: **37 -> 42**. All fixtures built in-test under `mkdtemp`, in the file's existing idiom; nothing added reads any path in the checkout.

## Quality gates

Every gate run in the foreground to completion, redirected to a worktree-local log, exit code echoed explicitly. Gate root confirmed as `/c/Users/miket/code/re-frame2-worktrees/workloadgate-110be` on each spine invocation.

| gate | exit |
|---|---|
| `node --check` on `jsfb_compare.cjs` | 0 |
| `node --check` on `jsfb_compare_exit_path.test.cjs` | 0 |
| `node .../jsfb_compare_exit_path.test.cjs` (42 passed) | 0 |
| the same suite under **LF** line endings (42 passed) | 0 |
| the same suite under **CRLF** line endings (42 passed) | 0 |
| `npm run test:script-helpers` | 0 |
| `npm run lint:js` (ESLint — a required CI job with no spine lane) | 0 |
| `sh scripts/test-fast-pr.sh` — `PASS fast PR spine` (`docs=false jvm=true node=true`) | 0 |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | 0 — "No beads-database paths in this PR diff." |

Line endings were verified by copying both files out of the tree, normalising each way, and running the suite from there — both green. Note that the suite does **not** itself carry any line-ending handling (no CRLF logic anywhere in it), contrary to the bead's "as that suite already does"; the verification above is what backs the claim.

The spine's JVM tier ran `implementation/core` plus `implementation/freehand` (the artefact this diff touches); its node tier ran the JS harness helpers — including `jsfb_compare_exit_path.test.cjs: 42 passed` — plus CLJS node integration, per-namespace isolation and the hicasso bench-lane compile.

**One aborted first attempt, worth recording rather than hiding.** An earlier invocation of the spine went red in `_changed-surfaces.test.cjs` with 177 failures whose messages were `Command failed: bash -lc ./.github/scripts/report-changed-surfaces.sh …` and `Command failed: git ls-files -s -- scripts/check-beads-pr-boundary.sh` — process-spawn failures under seven concurrent workers on this box, not assertion failures. Established as environmental three ways: the identical classifier invocation succeeds when run directly (exit 0, correct `key=value` output); `node scripts/_changed-surfaces.test.cjs` standalone reports `295 passed`, exit 0; and neither that test nor `git ls-files` reads either changed file. The re-run above is green end to end.

**The benchmark was not run, and no measurement window was disturbed.** Every fixture in this PR is synthetic and built in-test; nothing here spawns Chromium or chromedriver. The bead is explicit that the comparator is rig, and the rig must be stable across any series being compared.

### Relied on CI for

Per `python scripts/check_fast_pr_gap.py --list` (90 required checks the spine does not decide). This diff is two CommonJS files under `implementation/freehand/test/`, so the classifier arms `implementation_jvm`, `cljs_node_test`, `cljs_browser`, `examples_compile`, `cljs_prod` and `freehand_evidence_elision`. Of the required checks with no local lane, the ones that actually reach this surface and are therefore relied on in CI:

- **`eslint`** (`Lint required`) — the only required job that lints `.cjs`. Run locally anyway, exit 0.
- **`jvm-freehand-prod-gate`** and the freehand probes `cljs-freehand-evidence-elision` / `cljs-freehand-reachability` — armed by the `implementation/freehand/**` path, though this diff adds no production surface (both files are test-tree `.cjs`, compiled into nothing).
- **`cljs-browser`**, **`cljs-examples-compile`**, the prod-elision / schemas-boundary / perf-bundle probes, the adapter and UI smokes, `story-xray-browser`, the `tools/*` JVM and MCP-conformance jobs — none of which read either changed file.
- `clj-kondo` / `splint` — no Clojure surface touched; and per `TESTING.md` a locally-run clj-kondo of a different version proves nothing against CI's `2026.04.15` pin.

## Not fixed, reported

Two sibling readings in the same `report()` were examined and deliberately left alone — the bead is explicit that the WORKLOAD block "is the one missed conclusion path, not a request for broader validation":

1. **`OUR RUN'S GATES` asserts from absence.** `ours.parity && ours.parity.identical ? 'IDENTICAL' : 'DIFFERENT'` prints a definite `DIFFERENT` when `parity` is *missing*, not merely when it differs; same shape for `control.pass -> FAIL`. This fails **closed** (absence reads as the pessimistic verdict), so it is the safe direction, and these values are reported here and decided by `jsfb_ours_run.cjs`.
2. **`unverified` sums absence to zero.** `Object.values(ours.summary).reduce((a, s) => a + (s && s.unverified ? s.unverified : 0), 0)` prints `unverified 0` for a JSON that carries no `unverified` field at all — "clean" stated from evidence that is not there. This one does fail **open**, and is the closest genuine sibling of the defect repaired here. Left for the mayor to file and scope; fixing it inside this PR would breach the bead's fence.

The stdout `VERDICT: N of M comparable rows` line was also considered and is **not** a bypass: it names its own denominator and the expected count, and `verdict()` emits the REFUSED lines alongside it.
