### PR TITLE
bench(p0): a small-witness allocation arm sized to the masking bound (rf2-2rtt6.138)

### DIFF
--- a/implementation/core/test/re_frame/bench/p0_heap.cljs
+++ b/implementation/core/test/re_frame/bench/p0_heap.cljs
@@ -153,6 +153,22 @@
    :unmount-one (fn [handle]
                   (react-dom/flushSync (fn [] (.unmount (:root handle)))))})
 
+(defn- grid-floor-arm
+  "The `grid` family's floor over `cells` boundaries per root — no
+  subscription, no hook, nothing on the page that a write can re-render.
+
+  CONSTRUCTED rather than tabled, and that is the allocation row's doing
+  (rf2-2rtt6.138). The ladder's arms are now sized by their driver so that
+  a whole measured window fits under the masking bound, and a floor left
+  at the published 300 would be the calibrator for a page the row never
+  mounted: its `B/boundary/write` column would divide the write's own cost
+  by a boundary count its own DOM did not have. At `cells` = [[per-root]]
+  it is the arm the table used to hold, to the byte."
+  [cells]
+  (assoc (react-root-arm (fn [_] (floor/u-grid (vec (repeat cells 0))))
+                         ".cell" cells)
+         :segment nil :keys-expected 0))
+
 (def arm-table
   "`arm-id -> {:segment :selector :expected :keys-expected :mount-one
   :unmount-one}`.
@@ -161,6 +177,10 @@
   with it before taking the baseline of the pair. A floor arm names the
   segment it is being measured IN, because the floor is the calibrator and
   has to be read on both sides of the seam.
+
+  `:grid/floor` is NOT here: it is sized with whatever ladder it is
+  calibrating, so it is built by [[grid-floor-arm]] in [[arm-for]] beside
+  the arms it is differenced against.
 
   `:keys-expected` is **Q**, and it is written down here rather than
   derived, because the published arms are exactly the ones whose Q the
@@ -183,11 +203,6 @@
    (assoc (uix-root-arm (fn [_] (ux/w1-root arms/frame-id rows-per-root))
                         ".row" rows-per-root)
           :segment :uix-subs :keys-expected rows-per-root)
-
-   :grid/floor
-   (assoc (react-root-arm (fn [_] (floor/u-grid (vec (repeat per-root 0))))
-                          ".cell" per-root)
-          :segment nil :keys-expected 0)
 
    :grid/reagent
    (assoc (reagent-root-arm (fn [_] (rg/u-root arms/frame-id)) ".cell" per-root)
@@ -244,23 +259,49 @@
 ;; boundary carrying `data-i` and the one-character text `0`, because
 ;; every `:p0/fan` value is 0 and a sum of zeros is zero — so the floor
 ;; subtraction stays honest as R grows.
+;;
+;; ## The page is a PARAMETER, and the allocation row is why (rf2-2rtt6.138)
+;;
+;; The retention rows hold B fixed at the published 1,200 and nothing here
+;; needed to move. The allocation row cannot: its instrument is accurate
+;; only while no collection falls inside the measured window, and one warm
+;; write of 1,200 boundaries allocates 1.2–1.7 MB, two to three times the
+;; ~600 KB at which the first fall appears. The row's own masking bound
+;; (`p0_run.cjs` `ALLOC_MASK_BUDGET_B`) refuses a window that large rather
+;; than publishing what it reads, because the reading degrades ALWAYS
+;; DOWNWARD and under-reading allocation is the direction that manufactures
+;; HD-002's predicted flat-at-zero.
+;;
+;; The repair is to shrink the measured UNIT, not the window: the quantity
+;; is per BOUNDARY, so a page of a few dozen boundaries puts a many-write
+;; window under the threshold and leaves the averaging a fit needs. B was
+;; unreachable through the driver's env surface — `P0_ROOTS=1` floors it at
+;; the compile-time [[per-root]] — which is exactly why the small-witness
+;; arm is this parameter and not a flag.
 
 (defn- lad-arm
   "One rung of the ladder: `reads` DISTINCT subscription reads on each of
-  the same `.cell` boundaries the `grid` family holds, drawn from `q`
-  unique query keys — and at Q = E the driver states `q` as `B·reads`."
-  [substrate reads q]
+  `cells` boundaries per root, drawn from `q` unique query keys — and at
+  Q = E the driver states `q` as `B·reads`.
+
+  `cells` is the measured unit and the driver owns it: the retention rows
+  pass [[per-root]] and read the published page, the allocation row passes
+  the size its masking bound admits. Nothing else about the rung moves
+  with it — the same substrates, the same key rule, the same DOM one
+  `span.cell` at a time."
+  [substrate cells reads q]
   (let [reads   (long reads)
+        cells   (long cells)
         base    (case substrate
                   :reagent (reagent-root-arm
-                             (fn [r] (rg/lad-root arms/frame-id (* r per-root) per-root reads))
-                             ".cell" per-root)
+                             (fn [r] (rg/lad-root arms/frame-id (* r cells) cells reads))
+                             ".cell" cells)
                   :uix     (uix-root-arm
-                             (fn [r] (ux/lad-root arms/frame-id (* r per-root) per-root reads))
-                             ".cell" per-root)
+                             (fn [r] (ux/lad-root arms/frame-id (* r cells) cells reads))
+                             ".cell" cells)
                   :hicasso (hicasso-root-arm
-                             (fn [r] (hic/lad-grid (* r per-root) per-root reads))
-                             ".cell" per-root))]
+                             (fn [r] (hic/lad-grid (* r cells) cells reads))
+                             ".cell" cells))]
     (assoc base
            ;; The candidate reads through `re-frame.subs` and the
            ;; substrate's single internal frame context, so it needs
@@ -286,18 +327,26 @@
            :keys-expected (if (zero? reads) 0 (long q)))))
 
 (defn- arm-for
-  "Resolve `arm-id` to an arm map. `:fan/*` and `:lad/*` are
-  parameterised by `opts` (`{:reads r :keys q}`); everything else is the
-  published table."
+  "Resolve `arm-id` to an arm map. `:fan/*`, `:lad/*` and `:grid/floor`
+  are parameterised by `opts` (`{:reads r :keys q :cells n}`); everything
+  else is the published table.
+
+  `:cells` is boundaries per root, and it moves the LADDER family and the
+  floor that calibrates it together — the two arms a row differences
+  against each other must be the same page or the difference is not one.
+  Absent, it is [[per-root]], which is what every retention row passes and
+  what the published table was written in. The fan family does not take
+  it: its sweep moves Q against a fixed page and has no reason to."
   [arm-id opts]
-  (or (get arm-table arm-id)
-      (case arm-id
-        :fan/reagent (fan-arm :reagent (:reads opts) (:keys opts))
-        :fan/uix     (fan-arm :uix     (:reads opts) (:keys opts))
-        :lad/reagent (lad-arm :reagent (:reads opts) (:keys opts))
-        :lad/uix     (lad-arm :uix     (:reads opts) (:keys opts))
-        :lad/hicasso (lad-arm :hicasso (:reads opts) (:keys opts))
-        nil)))
+  (let [cells (long (or (:cells opts) per-root))]
+    (case arm-id
+      :grid/floor  (grid-floor-arm cells)
+      :fan/reagent (fan-arm :reagent (:reads opts) (:keys opts))
+      :fan/uix     (fan-arm :uix     (:reads opts) (:keys opts))
+      :lad/reagent (lad-arm :reagent cells (:reads opts) (:keys opts))
+      :lad/uix     (lad-arm :uix     cells (:reads opts) (:keys opts))
+      :lad/hicasso (lad-arm :hicasso cells (:reads opts) (:keys opts))
+      (get arm-table arm-id))))
 
 ;; ---------------------------------------------------------------------------
 ;; Segment preparation — always OUTSIDE the baseline read

--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -47,6 +47,10 @@ const {
   allocSteps,
   allocMaskableWindows,
   ALLOC_MASK_BUDGET_B,
+  ladderPlan,
+  allocArmSizing,
+  allocMaxWrites,
+  ALLOC_ARM,
 } = require('./p0_run.cjs');
 
 const tests = [];
@@ -448,7 +452,7 @@ test('the driver exits on THIS function and does not re-derive the budget', () =
   has(/const maskable = allocMaskableWindows\(out\.alloc\);/, 'the alloc gate calls it');
   has(/if \(maskable\.length > 0\) \{/, 'and its result is what pushes a failure');
   has(
-    /module\.exports = \{\s*ladderStructuralFailures,\s*allocSteps,\s*allocMaskableWindows,\s*ALLOC_MASK_BUDGET_B,\s*\};/,
+    /module\.exports = \{\s*ladderStructuralFailures,\s*allocSteps,\s*allocMaskableWindows,\s*ALLOC_MASK_BUDGET_B,\s*ladderPlan,\s*allocArmSizing,\s*allocMaxWrites,\s*ALLOC_ARM,\s*\};/,
     'so this file can drive it'
   );
 });
@@ -463,6 +467,223 @@ test('the budget is DERIVED from the measured threshold and has no dial on it', 
     'a gate with an env dial on it is a gate that gets dialled off'
   );
   has(/if \(out\.alloc\.fallsInMeasuredWindows > 0\) \{/, 'and the falling-step gate still exits');
+});
+
+// ===========================================================================
+// THE SMALL-WITNESS ARM — rf2-2rtt6.138
+// ===========================================================================
+//
+// WHAT THIS PINS, AND WHY IT IS PINNED HERE. The allocation row's published
+// witness is outside its own instrument's range: one warm write of 1,200
+// boundaries allocates 1.2-1.7 MB against a ~600 KB fall threshold, and the
+// masking bound above refuses a window that size rather than publishing what
+// it reads. The repair is a smaller PAGE — the row's quantity is per
+// BOUNDARY, so a few dozen of them put a many-write window under the
+// threshold with the averaging a fit needs still in it.
+//
+// A SIZE IS A CLAIM AND HAS TO BE CHECKABLE. `allocArmSizing` is the
+// arithmetic that chose the page, as a pure function of the bound, so the
+// claim "this arm fits" is a thing this file can adjudicate on every PR
+// rather than something the next opt-in run discovers. `--only alloc` needs
+// a release build and a headless Chromium and is in no gate; an arm that
+// drifted out of range would otherwise be found by a measurement, which is
+// the expensive way to find it and the way rf2-2rtt6.76 already found it
+// once.
+//
+// NOTHING HERE MEASURES ANYTHING, and the arm these tests describe HAS NEVER
+// BEEN RUN. Every window below is a synthetic sample stream from `stream`
+// above, built from the sizing's own prediction — which is exactly what
+// makes the check hermetic and exactly what stops it being evidence about
+// the substrate.
+
+// The window a page of `boundaries` produces at `writes`, as `alloc-window!`
+// would have sampled it if every leg allocated the predicted `B.c`. Built
+// from the SIZING, so the two cannot disagree: if the prediction is wrong
+// about the bound, `allocSteps` says so on the sizing's own numbers.
+const predictedStream = (sizing) =>
+  stream(Array.from({ length: sizing.writes }, () => sizing.predictedMaxStep));
+
+test('THE BOUND IS THE SIZING — (W+1).B.c is what the arithmetic computes', () => {
+  const s = allocArmSizing({ writes: 6, roots: 4, cells: 6, bytesPerBoundaryWrite: 1000 });
+  assert.strictEqual(s.boundaries, 24, 'B is roots x cells');
+  assert.strictEqual(s.predictedMaxStep, 24000, 'the largest single step is ONE write, B.c');
+  assert.strictEqual(s.predictedRise, 144000, 'and rise is W of them');
+  assert.strictEqual(s.predictedWindowB, 168000, '(W+1).B.c — the bound\'s left-hand side');
+  assert.strictEqual(s.headroom, ALLOC_MASK_BUDGET_B - 168000);
+  assert.ok(s.admissible);
+});
+
+test('THE SHIPPED ARM is a few dozen boundaries and is inside the bound', () => {
+  // The numbers the driver ships with. A `P0_ALLOC_CELLS` / `P0_ALLOC_WRITES`
+  // / `P0_ROOTS` in the environment moves them, and this failing under one is
+  // a TRUE signal — the run's arm would not be the shipped arm.
+  assert.strictEqual(ALLOC_ARM.cells, 6, 'cells per root');
+  assert.strictEqual(ALLOC_ARM.roots, 4, 'P0_ROOTS');
+  assert.strictEqual(ALLOC_ARM.boundaries, 24, 'a few dozen boundaries, as the bead asked');
+  assert.strictEqual(ALLOC_ARM.writes, 6, 'and a MANY-write window, which is the averaging');
+  assert.strictEqual(ALLOC_ARM.bytesPerBoundaryWrite, 1655, 'the top of the measured range');
+  assert.strictEqual(ALLOC_ARM.predictedWindowB, 278040, '(6+1) x 24 x 1655');
+  assert.strictEqual(ALLOC_ARM.headroom, 21960, 'under the 300000 B budget');
+  assert.ok(ALLOC_ARM.admissible);
+});
+
+test('the shipped arm takes EVERY write the bound admits at its page', () => {
+  // A window smaller than the bound allows is averaging thrown away, and the
+  // whole reason the page shrank was to buy that averaging back.
+  assert.strictEqual(ALLOC_ARM.writes, allocMaxWrites(ALLOC_ARM.boundaries));
+});
+
+test('THE PUBLISHED WITNESS is refused by the same arithmetic — the reason the arm exists', () => {
+  const published = allocArmSizing({ writes: ALLOC_ARM.writes, roots: 4, cells: 300 });
+  assert.strictEqual(published.boundaries, 1200);
+  assert.strictEqual(published.predictedWindowB, 7 * 1200 * 1655);
+  assert.ok(!published.admissible, '1,200 boundaries cannot be certified at any useful window');
+  assert.ok(published.headroom < 0);
+  assert.strictEqual(allocMaxWrites(1200), -1, 'not even a one-write window fits at that page');
+});
+
+test('the predicted window PASSES the real gate, and the published one does not', () => {
+  // The sizing and `allocSteps` are two expressions of one bound, so they are
+  // driven against each other rather than each asserted alone.
+  const arm = allocSteps(predictedStream(ALLOC_ARM));
+  assert.strictEqual(arm.rise, ALLOC_ARM.predictedRise);
+  assert.strictEqual(arm.maxStep, ALLOC_ARM.predictedMaxStep);
+  assert.strictEqual(arm.headroom, ALLOC_ARM.headroom);
+  assert.strictEqual(arm.maskable, false, 'the arm the driver ships is inside the budget');
+  assert.strictEqual(arm.falls, 0);
+
+  const published = allocArmSizing({ writes: ALLOC_ARM.writes, roots: 4, cells: 300 });
+  const big = allocSteps(predictedStream(published));
+  assert.strictEqual(big.headroom, published.headroom);
+  assert.ok(big.maskable, 'and the 1,200-boundary page is not');
+});
+
+test('a MIS-SIZED arm is refused — one boundary over the bound is over it', () => {
+  // `maxBoundaries` is the largest page the window admits, so the page one
+  // root wider than it must refuse. A sizing rule that named a limit it did
+  // not enforce would have adjudicated nothing.
+  const fits = allocArmSizing({ writes: 6, roots: 1, cells: ALLOC_ARM.maxBoundaries });
+  assert.strictEqual(fits.boundaries, 25);
+  assert.ok(fits.admissible, 'exactly at the limit is inside it');
+  const over = allocArmSizing({ writes: 6, roots: 1, cells: ALLOC_ARM.maxBoundaries + 1 });
+  assert.ok(!over.admissible, 'and one boundary more is not');
+  assert.ok(allocSteps(predictedStream(over)).maskable, 'the real gate agrees');
+});
+
+test('`allocMaxWrites` inverts the bound exactly — one write more refuses', () => {
+  for (const boundaries of [4, 12, 24, 25, 60]) {
+    const w = allocMaxWrites(boundaries);
+    assert.ok(w >= 1, `${boundaries} boundaries must admit a window at all`);
+    assert.ok(
+      allocArmSizing({ writes: w, roots: 1, cells: boundaries }).admissible,
+      `${boundaries} boundaries at ${w} writes must fit`
+    );
+    assert.ok(
+      !allocArmSizing({ writes: w + 1, roots: 1, cells: boundaries }).admissible,
+      `${boundaries} boundaries at ${w + 1} writes must not`
+    );
+  }
+});
+
+test('a window with no work in it, and a page with no boundaries, are NOT admissible', () => {
+  // Both sail under the budget on zero bytes, and neither has a per-boundary
+  // quantity to publish. A bound that admitted them would be admitting
+  // nothing measured at all.
+  assert.ok(!allocArmSizing({ writes: 0, roots: 4, cells: 6 }).admissible);
+  assert.ok(!allocArmSizing({ writes: 6, roots: 4, cells: 0 }).admissible);
+  assert.ok(!allocArmSizing({ writes: 0, roots: 0, cells: 0 }).admissible);
+});
+
+test('the sizing cannot buy headroom by shrinking the WINDOW alone', () => {
+  // The direction the bead ruled out: the 300-boundary one-write config whose
+  // fall count was zero across 88 windows is still refused by the bound, so
+  // it was never certified. Shrinking the unit is what works.
+  const oneWrite = allocArmSizing({ writes: 1, roots: 1, cells: 300 });
+  assert.ok(!oneWrite.admissible, 'B=300 at one write is still over budget');
+  assert.ok(oneWrite.predictedWindowB > ALLOC_MASK_BUDGET_B);
+  const smallUnit = allocArmSizing({ writes: 6, roots: 4, cells: 6 });
+  assert.ok(smallUnit.admissible, 'and a smaller UNIT carries six writes of averaging');
+});
+
+// --- the plan the page is mounted from -------------------------------------
+
+test('`ladderPlan` states the page on every arm, floor included', () => {
+  const plan = ladderPlan({ list: 300, grid: 6 }, 4);
+  assert.strictEqual(plan.length, 2, 'one per segment');
+  for (const { arms } of plan) {
+    assert.strictEqual(arms.length, 11, 'a floor plus 5 rungs x 2 substrates');
+    for (const a of arms) {
+      assert.strictEqual(a.opts.cells, 6, `${a.key} must state the page it mounts`);
+      assert.strictEqual(a.boundaries, 24, `${a.key} must agree with roots x cells`);
+    }
+  }
+  const floor = plan[0].arms[0];
+  assert.strictEqual(floor.arm, 'grid/floor');
+  assert.strictEqual(floor.opts.cells, 6, 'the calibrator is read on the SAME page as the arms');
+});
+
+test('the plan the small arm mounts is the ladder plan, at a smaller page', () => {
+  // Same arms, same rungs, same keys rule — Q = E on every rung. A second
+  // plan shape would make the small witness a second instrument, which is the
+  // one thing this arm may not be.
+  const small = ladderPlan({ list: 300, grid: 6 }, 4);
+  const published = ladderPlan({ list: 300, grid: 300 }, 4);
+  assert.deepStrictEqual(
+    small.map((s) => s.arms.map((a) => a.key)),
+    published.map((s) => s.arms.map((a) => a.key)),
+    'the same arms under the same keys'
+  );
+  for (const [i, seg] of small.entries()) {
+    for (const [j, a] of seg.arms.entries()) {
+      const p = published[i].arms[j];
+      assert.strictEqual(a.rung, p.rung);
+      assert.strictEqual(a.reads, p.reads);
+      if (a.rung === 'floor') {
+        // The calibrator reads nothing and holds no key on either page.
+        assert.strictEqual(a.keys, undefined);
+        assert.strictEqual(p.keys, undefined);
+        continue;
+      }
+      // Q = E at every rung on both pages: keys is B x R and nothing else.
+      assert.strictEqual(a.keys, a.boundaries * a.reads);
+      assert.strictEqual(p.keys, p.boundaries * p.reads);
+    }
+  }
+});
+
+test('the RETENTION ladder is not moved by any of this', () => {
+  // It reads at the published 1,200 and its instrument has no such ceiling.
+  const published = ladderPlan({ list: 300, grid: 300 }, 4);
+  for (const { arms } of published) {
+    for (const a of arms) {
+      assert.strictEqual(a.boundaries, 1200);
+      assert.strictEqual(a.opts.cells, 300);
+    }
+  }
+  assert.strictEqual(published[0].arms.find((a) => a.rung === 'R20').keys, 24000);
+});
+
+// --- the wiring, so this pin cannot drift off the thing that refuses -------
+
+test('the driver REFUSES a mis-sized arm before it launches a browser', () => {
+  has(/if \(!ALLOC_ARM\.admissible\) \{/, 'the sizing refusal is an exit, not a warning');
+  has(
+    /the allocation arm is configured outside the masking bound before anything is /,
+    'and it says so before a byte is measured'
+  );
+  has(/SHRINK THE MEASURED UNIT, DO NOT WIDEN THE BUDGET/, 'naming the repair, not the dial');
+});
+
+test('the window is DERIVED from the bound and the arm from the measured cost', () => {
+  has(
+    /const ALLOC_WRITES = Number\(\s*process\.env\.P0_ALLOC_WRITES \|\| allocMaxWrites\(ROOTS \* ALLOC_CELLS\)\s*\);/,
+    'the window must be what the page admits, not a number typed beside it'
+  );
+  has(/const ALLOC_B_PER_BOUNDARY_WRITE = 1655;/, 'the top of the MEASURED range sizes the arm');
+  has(/const ALLOC_MIN_WRITES = 6;/, 'and a window is sized to hold averaging');
+  // The bound itself is still the untouched one, with no dial of its own.
+  has(/const ALLOC_MASK_BUDGET_B = ALLOC_FALL_THRESHOLD_B \/ 2;/, 'unchanged by this arm');
+  has(/const ALLOC_FALL_THRESHOLD_B = 600000;/, 'and so is the measured threshold under it');
 });
 
 let failed = 0;

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -268,11 +268,24 @@ const LADDER_SUBSTRATES = {
   'uix-subs': ['uix', 'hicasso'],
 };
 
+// `perRoot.grid` is the PAGE, and the plan states it on every arm rather
+// than letting the page's own compile-time default stand in for it. The
+// retention row passes what `window.P0H.boundariesPerRoot` answers and the
+// plan is the one it has always been; the allocation row passes the small
+// witness its masking bound admits (rf2-2rtt6.138), and the floor moves with
+// the arms because a calibrator read on a different page is not one.
 function ladderPlan(perRoot, roots) {
-  const B = roots * perRoot.grid;
+  const cells = perRoot.grid;
+  const B = roots * cells;
   return Object.keys(LADDER_SUBSTRATES).map((segment) => {
     const arms = [
-      { arm: 'grid/floor', key: `${segment}|grid/floor`, boundaries: B, opts: null, rung: 'floor' },
+      {
+        arm: 'grid/floor',
+        key: `${segment}|grid/floor`,
+        boundaries: B,
+        opts: { cells },
+        rung: 'floor',
+      },
     ];
     for (const sub of LADDER_SUBSTRATES[segment]) {
       for (const R of LADDER_RUNGS) {
@@ -280,7 +293,7 @@ function ladderPlan(perRoot, roots) {
           arm: `lad/${sub}`,
           key: `${segment}|lad/${sub}#R${R}`,
           boundaries: B,
-          opts: { reads: R, keys: B * R },
+          opts: { reads: R, keys: B * R, cells },
           rung: `R${R}`,
           reads: R,
           keys: B * R,
@@ -966,7 +979,10 @@ async function ladderRow(chromium) {
 // entire claim this row has to establish before any arm is quoted, and it
 // is the check `b8-alloc` was built around after the sampling profiler
 // produced a wrong table on this surface.
-const ALLOC_WRITES = Number(process.env.P0_ALLOC_WRITES || 30);
+// `ALLOC_WRITES` — how many warm writes one measured window holds — is
+// NOT here. It is an answer to the masking bound rather than a number
+// chosen beside it, so it is derived below `ALLOC_MASK_BUDGET_B` together
+// with the arm it has to fit around (rf2-2rtt6.138).
 const ALLOC_ROUNDS = Number(process.env.P0_ALLOC_ROUNDS || 6);
 const ALLOC_WARMUPS = Number(process.env.P0_ALLOC_WARMUPS || 3);
 // 8 B a double, so 1,000 doubles is a predicted 8,000 B of garbage per
@@ -1064,6 +1080,132 @@ const ALLOC_FALL_THRESHOLD_B = 600000;
 // that says why.
 const ALLOC_MASK_BUDGET_B = ALLOC_FALL_THRESHOLD_B / 2;
 
+// ---------------------------------------------------------------------------
+// THE SMALL-WITNESS ARM (rf2-2rtt6.138) — the page sized TO the bound above
+// ---------------------------------------------------------------------------
+//
+// The published witness is outside this instrument's range and the row is
+// right to refuse it. One warm write of the 1,200-boundary page allocates
+// 1.2-1.7 MB, two to three times the ~600 KB at which the first collection
+// appears; the 2026-08-07 quiet-box run put 36 falling steps inside 44
+// windows and a quiet box moved neither figure, because it was never
+// contention. It is the arm's SCALE against a fixed threshold.
+//
+// So the repair is the one the bead named: shrink the measured UNIT, not the
+// window. The quantity this row publishes is per BOUNDARY, so a page of a few
+// dozen boundaries puts a MANY-WRITE window under the threshold and leaves
+// the averaging a fit needs — where the other direction, one write on the
+// 300-boundary page, cleared the fall count and produced four fits at r2
+// 0.75 / 0.28 / 0.94 / 0.31 out of windows the bound above cannot certify
+// anyway (326-993 KB of rise+maxStep).
+//
+// THE ARITHMETIC, and every term in it is either measured or derived:
+//
+//   c   bytes one warm write allocates per mounted boundary. MEASURED, on
+//       the candidate arm, in that same quiet-box run: 544-1655 B across its
+//       rungs. The TOP of the range sizes the arm, because a page sized off
+//       the bottom would be refused rather than published.
+//   W   writes in one window. A window of one has no averaging in it, so the
+//       arm is sized to hold at least `ALLOC_MIN_WRITES` of them and then
+//       takes every further write the bound still admits.
+//   B   boundaries on the page, = P0_ROOTS x cells-per-root.
+//
+//   rise ~ W.B.c and the largest single step is one write, ~B.c, so the
+//   bound `rise + maxStep <= ALLOC_MASK_BUDGET_B` reads
+//
+//       (W + 1).B.c  <=  ALLOC_MASK_BUDGET_B
+//
+//   and the two ways round it are the two knobs:
+//
+//       B  <=  budget / ((W + 1).c)        the page a window admits
+//       W  <=  budget / (B.c)  -  1        the window a page admits
+//
+// At the shipped constants that is 6 cells x 4 roots = 24 boundaries and 6
+// writes: 24 x 1,655 = 39,720 B a write, 278,040 B of rise+maxStep, 21,960 B
+// of headroom under the budget. The same page at the published 1,200
+// boundaries predicts 13.9 MB and the row would refuse it — which is the
+// whole reason this arm exists.
+//
+// WHAT THE ARITHMETIC DOES NOT MODEL, stated rather than glossed. `c` is
+// per-boundary, and `:p0/write-all` also rebuilds a 300-element vector and
+// drives the whole event pipeline whether one boundary is mounted or 1,200.
+// That fixed per-write cost is in every window and in no term above, and no
+// run on this rig has recorded it on its own — the floor arm measures it
+// directly and its figure has never been published. So the prediction below
+// is a SIZING aid and not a certificate: what certifies a window is
+// `allocSteps` reading the window's own samples, on the run, against the
+// same budget. The prediction is here so a configuration that cannot
+// possibly pass is refused before a measurement is spent on it, not so that
+// one which passes it may be trusted.
+const ALLOC_B_PER_BOUNDARY_WRITE = 1655;
+
+// The averaging floor. Six is the config the quiet-box run took the
+// published witness in, and the smallest window the bead's own re-costing
+// table carries; below two there is no averaging in a window at all.
+const ALLOC_MIN_WRITES = 6;
+
+// Boundaries per root — the MEASURED UNIT, and the reason this arm is a code
+// change rather than a flag. `fx/cells-n` is compile-time, so `P0_ROOTS=1`
+// floored B at 300 through the env surface and no window on any page that
+// size can be certified. `p0-heap/arm-for` now takes it as `:cells`, so the
+// driver states the page and the dial exists for a measurement window that
+// wants to walk B — the bound below adjudicates whatever it is set to.
+const ALLOC_CELLS = Number(
+  process.env.P0_ALLOC_CELLS ||
+    Math.max(
+      1,
+      Math.floor(
+        ALLOC_MASK_BUDGET_B / ((ALLOC_MIN_WRITES + 1) * ROOTS * ALLOC_B_PER_BOUNDARY_WRITE)
+      )
+    )
+);
+
+// The largest window a page of `boundaries` admits, from the bound and
+// nothing else. `- 1` is `maxStep`: the bound charges one extra write's
+// worth for the leg a collection could have hidden in.
+function allocMaxWrites(boundaries) {
+  return Math.floor(ALLOC_MASK_BUDGET_B / (boundaries * ALLOC_B_PER_BOUNDARY_WRITE)) - 1;
+}
+
+const ALLOC_WRITES = Number(
+  process.env.P0_ALLOC_WRITES || allocMaxWrites(ROOTS * ALLOC_CELLS)
+);
+
+// The sizing, as a PURE FUNCTION of the config and the bound — the same
+// shape and for the same reason as `allocSteps` and `allocMaskableWindows`:
+// it needs neither a release build nor a Chromium, so it is pinned on every
+// PR by `p0_ladder_structural.test.cjs` instead of waiting for the next
+// opt-in run of this driver to notice that an arm drifted out of range.
+//
+// Nothing here measures anything. `predictedWindowB` is `(W + 1).B.c`, the
+// left-hand side of the bound, and `admissible` is the bound itself.
+function allocArmSizing({ writes, roots, cells, bytesPerBoundaryWrite = ALLOC_B_PER_BOUNDARY_WRITE }) {
+  const boundaries = roots * cells;
+  const predictedMaxStep = boundaries * bytesPerBoundaryWrite;
+  const predictedRise = writes * predictedMaxStep;
+  const predictedWindowB = predictedRise + predictedMaxStep;
+  const headroom = ALLOC_MASK_BUDGET_B - predictedWindowB;
+  return {
+    cells,
+    roots,
+    boundaries,
+    writes,
+    bytesPerBoundaryWrite,
+    predictedRise,
+    predictedMaxStep,
+    predictedWindowB,
+    headroom,
+    // A window with no work in it measures nothing, and a page with no
+    // boundaries on it has no per-boundary quantity to publish. Both would
+    // otherwise sail under the budget on zero bytes.
+    admissible: writes >= 1 && boundaries >= 1 && headroom >= 0,
+    maxWrites: allocMaxWrites(boundaries),
+    maxBoundaries: Math.floor(ALLOC_MASK_BUDGET_B / ((writes + 1) * bytesPerBoundaryWrite)),
+  };
+}
+
+const ALLOC_ARM = allocArmSizing({ writes: ALLOC_WRITES, roots: ROOTS, cells: ALLOC_CELLS });
+
 // Rising and falling steps, accumulated separately, from one window's raw
 // samples. The samples are `[s0, pre0, post0, pre1, post1, ...]`, so the
 // work legs are the (pre -> post) steps and the gaps between iterations
@@ -1128,6 +1270,24 @@ function allocMaskableWindows(row) {
 }
 
 async function allocRow(chromium) {
+  // THE SIZING REFUSAL, before a browser is launched and a byte is measured.
+  // The bound decides what may be published; this decides what is worth
+  // measuring at all, and it exists because the alternative is a twenty
+  // minute run whose every window the bound then refuses — which is exactly
+  // what the 2026-08-07 quiet-box run spent. It is a PREDICTION and not a
+  // certificate: passing it licenses nothing, and `allocSteps` still reads
+  // every window's own samples against the same budget on the way through.
+  if (!ALLOC_ARM.admissible) {
+    throw new Error(
+      `the allocation arm is configured outside the masking bound before anything is ` +
+        `measured: ${ALLOC_ARM.boundaries} boundaries (${ROOTS} roots x ${ALLOC_CELLS} cells) ` +
+        `x ${ALLOC_ARM.writes} writes predicts ${ALLOC_ARM.predictedWindowB} B of rise+maxStep ` +
+        `at the measured ${ALLOC_ARM.bytesPerBoundaryWrite} B/boundary/write, against the ` +
+        `${ALLOC_MASK_BUDGET_B} B budget. SHRINK THE MEASURED UNIT, DO NOT WIDEN THE BUDGET: ` +
+        `this page admits at most ${ALLOC_ARM.maxWrites} writes (P0_ALLOC_WRITES), and this ` +
+        `window at most ${ALLOC_ARM.maxBoundaries} boundaries (P0_ROOTS x P0_ALLOC_CELLS)`
+    );
+  }
   const { browser, page, watch } = await newPage(chromium, '?mode=heap');
   await watch.race('window.P0_READY === true || window.P0_ERROR', {
     timeoutMs: 180000,
@@ -1152,8 +1312,14 @@ async function allocRow(chromium) {
     throw new Error('the ladder-fit self-test FAILED — no allocation slope may be priced');
   }
 
-  const perRoot = await page.evaluate(() => window.P0H.boundariesPerRoot);
-  const B = ROOTS * perRoot.grid;
+  // The page's own `boundariesPerRoot` is the PUBLISHED size and this row
+  // does not measure it: `grid` is overridden with the small witness, so the
+  // plan, the floor and every rung mount the same few dozen boundaries. The
+  // published figure rides along in the record, because a reader has to be
+  // able to see which page this row is NOT the 1,200-boundary one.
+  const published = await page.evaluate(() => window.P0H.boundariesPerRoot);
+  const perRoot = { ...published, grid: ALLOC_CELLS };
+  const B = ALLOC_ARM.boundaries;
   const plan = ladderPlan(perRoot, ROOTS);
   const { gc, read } = await makeReaders(page);
 
@@ -1312,6 +1478,8 @@ async function allocRow(chromium) {
     bead: 'rf2-2rtt6.76',
     roots: ROOTS,
     perRoot,
+    publishedPerRoot: published,
+    arm: ALLOC_ARM,
     boundaries: B,
     writes: ALLOC_WRITES,
     warmups: ALLOC_WARMUPS,
@@ -1345,6 +1513,49 @@ function summariseAlloc(row, maskable) {
   );
   console.log(';; The arm stays MOUNTED across the window: this is what a standing page');
   console.log(';; allocates when it is written to, not what a mount costs.');
+
+  // THE ARM'S SIZE, AND THE ARITHMETIC THAT CHOSE IT (rf2-2rtt6.138). Printed
+  // beside the figures rather than left in a source comment, because the one
+  // question a reader of this table has to be able to answer is which page it
+  // was taken on — the published 1,200-boundary witness is outside this
+  // instrument's range and its refusal is what put this arm here.
+  const a = row.arm;
+  const publishedB = row.roots * row.publishedPerRoot.grid;
+  const publishedWindow = allocArmSizing({
+    writes: a.writes,
+    roots: row.roots,
+    cells: row.publishedPerRoot.grid,
+  });
+  console.log(';;');
+  console.log(';; ==== THE SMALL-WITNESS ARM (rf2-2rtt6.138) ====');
+  console.log(
+    `;;   ${a.cells} cells x ${a.roots} roots = ${a.boundaries} boundaries, ${a.writes} writes a ` +
+      'window. The measured unit is the BOUNDARY, so shrinking'
+  );
+  console.log(
+    ';;   the PAGE is what puts a many-write window under the fall threshold — not shrinking the'
+  );
+  console.log(';;   window, which is the direction that leaves a fit with nothing to average.');
+  console.log(
+    `;;   PREDICTED (W+1).B.c at the measured ${a.bytesPerBoundaryWrite} B/boundary/write: ` +
+      `${n0(a.predictedRise)} B rise + ${n0(a.predictedMaxStep)} B largest step = ` +
+      `${n0(a.predictedWindowB)} B,`
+  );
+  console.log(
+    `;;   against the ${ALLOC_MASK_BUDGET_B} B masking budget — headroom ${n0(a.headroom)} B. ` +
+      `The published ${publishedB}-boundary witness`
+  );
+  console.log(
+    `;;   predicts ${n0(publishedWindow.predictedWindowB)} B on the same window, and the row ` +
+      'would refuse it. That refusal is why this arm exists.'
+  );
+  console.log(
+    ';;   A PREDICTION, NOT A CERTIFICATE: what certifies a window is the bound read off that'
+  );
+  console.log(
+    ";;   window's OWN samples, below. The fixed per-write cost of `:p0/write-all` is in every"
+  );
+  console.log(';;   window here and in no term of the prediction.');
 
   // --- the controls, adjudicated ----------------------------------------
   console.log(';;');
@@ -1979,6 +2190,10 @@ module.exports = {
   allocSteps,
   allocMaskableWindows,
   ALLOC_MASK_BUDGET_B,
+  ladderPlan,
+  allocArmSizing,
+  allocMaxWrites,
+  ALLOC_ARM,
 };
 
 if (require.main === module) (async () => {

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -1150,15 +1150,10 @@ const ALLOC_MIN_WRITES = 6;
 // size can be certified. `p0-heap/arm-for` now takes it as `:cells`, so the
 // driver states the page and the dial exists for a measurement window that
 // wants to walk B — the bound below adjudicates whatever it is set to.
-const ALLOC_CELLS = Number(
-  process.env.P0_ALLOC_CELLS ||
-    Math.max(
-      1,
-      Math.floor(
-        ALLOC_MASK_BUDGET_B / ((ALLOC_MIN_WRITES + 1) * ROOTS * ALLOC_B_PER_BOUNDARY_WRITE)
-      )
-    )
-);
+// MUTATION (rf2-2rtt6.138, temporary): a deliberately MIS-SIZED arm — ten
+// times the page the bound admits, with the window typed beside it instead
+// of derived from it. Reverted in the next commit.
+const ALLOC_CELLS = Number(process.env.P0_ALLOC_CELLS || 60);
 
 // The largest window a page of `boundaries` admits, from the bound and
 // nothing else. `- 1` is `maxStep`: the bound charges one extra write's
@@ -1167,9 +1162,7 @@ function allocMaxWrites(boundaries) {
   return Math.floor(ALLOC_MASK_BUDGET_B / (boundaries * ALLOC_B_PER_BOUNDARY_WRITE)) - 1;
 }
 
-const ALLOC_WRITES = Number(
-  process.env.P0_ALLOC_WRITES || allocMaxWrites(ROOTS * ALLOC_CELLS)
-);
+const ALLOC_WRITES = Number(process.env.P0_ALLOC_WRITES || 6);
 
 // The sizing, as a PURE FUNCTION of the config and the bound — the same
 // shape and for the same reason as `allocSteps` and `allocMaskableWindows`:

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -1150,10 +1150,15 @@ const ALLOC_MIN_WRITES = 6;
 // size can be certified. `p0-heap/arm-for` now takes it as `:cells`, so the
 // driver states the page and the dial exists for a measurement window that
 // wants to walk B — the bound below adjudicates whatever it is set to.
-// MUTATION (rf2-2rtt6.138, temporary): a deliberately MIS-SIZED arm — ten
-// times the page the bound admits, with the window typed beside it instead
-// of derived from it. Reverted in the next commit.
-const ALLOC_CELLS = Number(process.env.P0_ALLOC_CELLS || 60);
+const ALLOC_CELLS = Number(
+  process.env.P0_ALLOC_CELLS ||
+    Math.max(
+      1,
+      Math.floor(
+        ALLOC_MASK_BUDGET_B / ((ALLOC_MIN_WRITES + 1) * ROOTS * ALLOC_B_PER_BOUNDARY_WRITE)
+      )
+    )
+);
 
 // The largest window a page of `boundaries` admits, from the bound and
 // nothing else. `- 1` is `maxStep`: the bound charges one extra write's
@@ -1162,7 +1167,9 @@ function allocMaxWrites(boundaries) {
   return Math.floor(ALLOC_MASK_BUDGET_B / (boundaries * ALLOC_B_PER_BOUNDARY_WRITE)) - 1;
 }
 
-const ALLOC_WRITES = Number(process.env.P0_ALLOC_WRITES || 6);
+const ALLOC_WRITES = Number(
+  process.env.P0_ALLOC_WRITES || allocMaxWrites(ROOTS * ALLOC_CELLS)
+);
 
 // The sizing, as a PURE FUNCTION of the config and the bound — the same
 // shape and for the same reason as `allocSteps` and `allocMaskableWindows`:

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -1054,7 +1054,7 @@ const ALLOC_FALL_THRESHOLD_B = 600000;
 //     built on it has to take the conservative side.
 //   - The halved figure, ~300 KB, is a whisker above the largest window
 //     this instrument has a CORROBORATED clean reading for: the D=1,000
-//     control at the default 30 writes is 240 KB of cumulative garbage and
+//     control at 30 writes is 240 KB of cumulative garbage and
 //     reads 8.13 B/double against a predicted 8. A window that under-read
 //     would not hit its prediction, so the control is positive evidence of
 //     no collection at that scale — which a fall count of zero, on its own,
@@ -1142,6 +1142,14 @@ const ALLOC_B_PER_BOUNDARY_WRITE = 1655;
 // The averaging floor. Six is the config the quiet-box run took the
 // published witness in, and the smallest window the bead's own re-costing
 // table carries; below two there is no averaging in a window at all.
+//
+// It moves the CONTROLS too, and that is checked rather than assumed: the
+// same quiet-box run read 8.13 and 8.20 B/double direct and 8.08
+// differential against a predicted 8 at exactly this window, so the claim
+// the controls exist to establish — that transient garbage is visible to
+// this counter at all — has been corroborated here as well as at the 30
+// writes `ALLOC_MASK_BUDGET_B` cites. A smaller control window is also a
+// further-under-budget one, which is the safe direction.
 const ALLOC_MIN_WRITES = 6;
 
 // Boundaries per root — the MEASURED UNIT, and the reason this arm is a code


### PR DESCRIPTION
The P0 allocation row's published witness is outside its own instrument's range,
and rf2-n6w7o's masking bound is what says so rather than merely suspecting it.
One warm write of the 1,200-boundary page allocates 1.2–1.7 MB against a
measured ~600 KB fall threshold; the 2026-08-07 quiet-box run put 36 falling
steps inside 44 windows and a quiet box moved neither figure, because it was
never contention — it is the arm's SCALE against a fixed threshold.

This is the repair the bead named: shrink the measured **unit**, not the window.
The row's quantity is per BOUNDARY, so a page of a few dozen boundaries puts a
many-write window under the threshold with the averaging a fit needs still in
it. The other direction — one write on the 300-boundary page — is the one the
bound has already refused at 326–993 KB of `rise + maxStep`, so its zero fall
count across 88 windows was never a certificate.

## THE ARM HAS NEVER BEEN EXECUTED, AND IS UNVALIDATED UNTIL A MEASUREMENT WINDOW RUNS IT

No measurement was taken. Five other workers were on this box, so any allocation
row taken now would be invalid by construction — worse than useless, because it
would look like a number. Nothing in this PR is evidence about a substrate.
Every window below is a synthetic sample stream built in-test from stated
per-leg allocations; every figure is a PREDICTION from constants already
recorded on the bead.

What remains for the measurement half, on a quiet box:

```
P0_ALLOC_ROUNDS=… node implementation/core/test/re_frame/bench/p0_run.cjs --only alloc
```

with `P0_ALLOC_CELLS` / `P0_ALLOC_WRITES` left at their derived defaults. Until
that runs, this arm is a shape, not a reading — and the row's own gates
(`falls`, the masking bound, the control verdict, the warm-write read-back) are
what will decide whether it may publish anything at all.

## The sizing arithmetic, derived from the constants in this checkout

Every term is either measured or derived; none is chosen by taste.

| term | value | where it comes from |
|---|---|---|
| `ALLOC_FALL_THRESHOLD_B` | 600,000 B | measured, unchanged, untouched |
| `ALLOC_MASK_BUDGET_B` | 300,000 B | `ALLOC_FALL_THRESHOLD_B / 2`, unchanged, untouched |
| `c` | 1,655 B/boundary/write | the TOP of the 544–1,655 range the quiet-box run measured on the candidate arm (rf2-2rtt6.138's note) |
| `ALLOC_MIN_WRITES` | 6 | the averaging floor: the config the quiet-box run took, and the smallest window the bead's re-costing table carries |
| `ROOTS` | 4 | `P0_ROOTS`, unchanged |

The bound is `rise + maxStep <= 300,000`. A window of `W` writes over `B`
boundaries has `rise ≈ W·B·c`, and its largest single step is one write, `≈ B·c`
— so the bound reads

```
(W + 1) · B · c  <=  ALLOC_MASK_BUDGET_B
```

and inverts two ways, which are the two knobs:

```
B  <=  budget / ((W + 1)·c)        the page a window admits
W  <=  budget / (B·c)  −  1        the window a page admits
```

**The page**, at the averaging floor:

```
cells <= 300,000 / ((6 + 1) · 4 · 1,655) = 300,000 / 46,340 = 6.47  ->  6 cells/root
B = 4 roots × 6 cells = 24 boundaries
```

**The window**, at that page:

```
W <= floor(300,000 / (24 · 1,655)) − 1 = floor(7.5528) − 1 = 6 writes
```

**The prediction**, which is what the arm is sized against:

```
maxStep  = 24 × 1,655            =  39,720 B
rise     =  6 × 39,720           = 238,320 B
rise + maxStep                   = 278,040 B
headroom = 300,000 − 278,040     =  21,960 B
```

**Derived B: 24 boundaries at 6 writes.** The largest page the bound admits at
that window is 25 — one small correction to the brief and to the bead's
re-costing note, which both say "B ≤ 26": `300,000 / (7 · 1,655) = 25.9`, so the
exact integer bound is **25**, not 26. The arm sits one boundary inside it.

For contrast, computed by the same function:

- the published 1,200-boundary witness at the same window predicts
  `7 × 1,200 × 1,655 = 13,902,000 B` — 46× the budget, and `allocMaxWrites(1200)`
  returns **−1**: not even a one-write window fits at that page;
- the B=300 one-write config predicts `2 × 300 × 1,655 = 993,000 B` — refused,
  exactly as the bead's re-costing said.

### What the arithmetic does NOT model, stated rather than glossed

`c` is per-boundary. `:p0/write-all` also rebuilds a 300-element vector and
drives the whole event pipeline whether one boundary is mounted or 1,200, and
that fixed per-write cost is in every window and in no term above. No run on
this rig has ever recorded it on its own (the floor arm measures it directly and
its figure has never been published). So the prediction is a **sizing aid, not a
certificate**: what certifies a window is `allocSteps` reading that window's own
samples against the same budget, on the run. The pre-flight exists so that a
configuration which cannot possibly pass is refused before twenty minutes are
spent on it — not so that one which passes it may be trusted.

Two observations the measurement half should carry, both arithmetic over figures
already on the bead and neither a reason to hold this arm:

1. At B=24 the unmodelled fixed per-write cost is divided by 24 rather than by
   1,200, so it is ~50× larger in the `B/boundary/write` column. It is
   rung-independent, so it lands in the intercept and not in the slope — but its
   *variance* reaches the fit, and larger B is strictly better for that. B=24 at
   6 writes is ~7× better on this term than B=4 at 30 writes would be, which is
   why the page is sized first and the window second.
2. The premise the bead asked to be costed — that averaging is what the
   non-monotone rungs lacked — is still not established by anything here. This
   arm buys back six writes of averaging inside a certified window. Whether that
   resolves r² 0.75 / 0.28 / 0.94 / 0.31 or leaves them is exactly what the
   measurement window will answer, and it is a live possibility that it does not.

## What changed

- **`p0_heap.cljs`** — `arm-for` now takes `:cells` (boundaries per root) and
  threads it through the ladder family and the `grid/floor` that calibrates it,
  so the two arms a row differences against each other are always the same page.
  Absent, `:cells` is the compile-time `per-root` and every retention row is the
  arm it has always been, to the byte. `fx/cells-n` being compile-time is
  precisely why this is a code change and not a flag: `P0_ROOTS=1` floored B at
  300 through the env surface.
- **`p0_run.cjs`** — `ladderPlan` states the page on every arm; the allocation
  row derives its page from the bound and its window from the page, records the
  sizing in the raw output, prints it beside the table, and **refuses** a
  configuration the bound could not certify before it launches a browser.
- **`p0_ladder_structural.test.cjs`** — 27 → 41 tests.

It is a rung, not an instrument: same collector, same three controls, same
falling-step gate, same masking bound, same fit rule, same `Q = E` key rule,
same arms under the same keys, same serialisation. No estimator, no counter and
no parallel code path was added. **No gate or threshold was touched** —
`ALLOC_FALL_THRESHOLD_B`, `ALLOC_MASK_BUDGET_B`, the falling-step exit and the
0.98 r² floor are all unchanged, and three of the new tests pin them as such.

### One published default did move, and it is called out rather than buried

`P0_ALLOC_WRITES` no longer defaults to a literal 30; it defaults to
`allocMaxWrites(ROOTS × ALLOC_CELLS)`, which is 6 at the shipped page. A literal
30 was never admissible for any arm on this row — 30 writes of the 1,200-boundary
page is ~60 MB in one window — and 6 is the config the quiet-box run actually
took. Two consequences, both handled:

- `ALLOC_MASK_BUDGET_B`'s comment said the D=1,000 control runs "at the default
  30 writes". With the default derived, the word *default* was false, so it is
  dropped (`993b015523`). The measurement it cites is unchanged and still
  corroborates the budget; the constant, its derivation and what it refuses are
  untouched.
- The window carries the CONTROLS too. The same quiet-box run read 8.13 and 8.20
  B/double direct and 8.08 differential against a predicted 8 at exactly this
  window, so the claim the controls exist to establish is corroborated here as
  well as at 30 writes — and a smaller control window is a further-under-budget
  one, which is the safe direction. That is recorded beside `ALLOC_MIN_WRITES`.

## Mutation proof

The new pins are proved on BEHAVIOUR, against a deliberately mis-sized arm —
ten times the page the bound admits (60 cells × 4 roots = 240 boundaries), with
the window typed beside it instead of derived from it.

- **`3f31fd2743`** — the mutation. `p0_ladder_structural.test.cjs: 4/41 failed`,
  runner exit **1**:
  - `THE SHIPPED ARM is a few dozen boundaries and is inside the bound` — `60 !== 6`
  - `the shipped arm takes EVERY write the bound admits at its page` — `6 !== -1`
  - `the predicted window PASSES the real gate…` — `maskable: true !== false`
  - `the window is DERIVED from the bound…` — the source pin on the derivation
- **`a5710c7315`** — the revert, byte-identical to the pre-mutation
  `5c989ce9ec`. `41 passed`, exit **0**.

The third failure is the load-bearing one: `rise`, `maxStep` and `headroom` all
match the sizing's own prediction to the byte and the assertions before it pass
— the arithmetic is right and the *arm* is wrong, which is the direction a pin
has to be able to fail in.

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/smallarm-2rtt6-138`, in the
foreground, to completion. No gate was piped through `tail`/`head`/`grep`; each
was redirected to a bead-prefixed log and the runner's own exit code echoed.

| gate | exit | note |
|---|---|---|
| `node --check` on `p0_run.cjs` | 0 | |
| `node --check` on `p0_ladder_structural.test.cjs` | 0 | |
| `node …/p0_ladder_structural.test.cjs` (baseline, at `origin/main`) | 0 | **27 passed** |
| `node …/p0_ladder_structural.test.cjs` (mutation) | 1 | **4/41 failed** |
| `node …/p0_ladder_structural.test.cjs` (final) | 0 | **41 passed** |
| `npm run test:script-helpers` | 0 | includes the 41 above; re-run at `993b015523` |
| `npm run test:cljs` | 0 | 12,794 tests / 64,382 assertions, 0 failures, 0 errors |
| `sh scripts/test-fast-pr.sh` | 0 | `PASS fast PR spine` — JVM `implementation/core` tier + node tier + repo-wide static checks. **Run twice**: once at `a5710c7315` and again in full at `993b015523`, the comment repair. |
| `clj-kondo --lint …/p0_heap.cljs` | 0 | 0 errors, 0 warnings |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | 0 | "No beads-database paths in this PR diff." |
| `python scripts/check_fast_pr_gap.py --list` | 0 | 90 required checks the spine does not run |
| `shadow-cljs release hicasso-bench` (`p0-app/-main`) | 0 | `Build completed. (183 files, 128 compiled, 0 warnings, 28.49s)` |

The bench compile is here because **nothing else compiles `p0_heap.cljs`**: the
`:node-test` build discovers namespaces by a `cljs-test$` regexp, which
`re-frame.bench.p0-heap` does not match, and `--only alloc` is opt-in and in no
CI gate. Compiling the bundle is not a measurement — it produces no figure — and
without it the CLJS edit would ship with clj-kondo as its only check.

### What the local spine does not decide

`check_fast_pr_gap.py --list` names 90 required checks; the ones this diff can
plausibly reach are:

- **`clj-kondo`** (lint.yml). CI pins **2026.04.15**; the local binary here is
  **v2025.10.23**, and the gap script's own note says a pass from a
  differently-versioned binary proves nothing. Read the red in CI.
- **`splint`** and **`eslint`** (lint.yml) — two `.cjs` files and one `.cljs`
  file changed and neither linter runs in the spine.
- **`beads-pr-boundary`** (test.yml) — the job form of the check run above,
  plus `scripts/git-hooks/test-pre-commit.sh`, which the spine does not run.
- **`CLJS (shadow-cljs :node-test)`** as a *job* — `npm run test:cljs` ran here,
  but the job also carries `npm run test:ui-isolation`, which did not.

Nothing in this diff reaches the browser gates, the MCP conformance lanes, the
docs build or the API-manifest projections: no spec, doc, skill or public-API
surface is touched, and `implementation/core/test/re_frame/bench/` is not on any
production build's classpath.

## The bead stays OPEN

rf2-2rtt6.138 is the BUILD half only. The measurement half is unfinished and the
mayor tracks it. The bead carries a note recording what was built, what the
sizing predicts, and that nothing has been executed.
