### PR TITLE
test(hicasso): the mid-adoption revision row on the .84 harness (rf2-ne3ey)

### DIFF
--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -267,10 +267,13 @@ this path — the model is correct throughout, the glass is not, and there is no
 cancel primitive to do better with. On an *accepting* field a post-bump edit
 **supersedes** the reset by ordinary event order, so the close lands the
 then-current model rather than the model the reset produced. A revision
-arriving **mid-hydration defers past adoption**: whether React keeps the
-server's node across a client render that lands before adoption completes is
-React's own race, and the revision cannot influence it either way — it is
-consumed at the codec, so React never sees it. And the spelling is matched
+arriving **while the page is still hydrating is absorbed rather than
+deferred**: the adoption render takes it as the field's first revision, so
+no reset fires and a draft typed into the server-rendered field survives —
+send the revision again after adoption if you need it discarded. The node is
+never at risk (the revision is consumed at the codec, so React never sees
+it), and the next revision change does reset the field on the server's own
+node without remount. And the spelling is matched
 **exactly**: a
 bare `:revision` is not this prop, and becomes an
 ordinary DOM attribute — silently, and with a namespaced keyword's namespace

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1179,11 +1179,27 @@ candidate second call site appears. The composition value path reopens on
 > adoption included, can branch on a value it was never given. Two hand-rolled
 > `hydrateRoot` arms disagreed about node identity in opposite directions on
 > consecutive runs, which is React's own adoption race and not this prop's
-> doing. Documented conduct is therefore the fallback: **a reset arriving
-> mid-adoption defers past adoption**, the same shape the IME carve-out has.
-> The structural fact that makes that safe to document is witnessed;
-> `rf2-ne3ey` owns the adoption-TIMING row, on the `.84` hydration harness
-> rather than on a hand-rolled race.
+> doing. Documented conduct is therefore the fallback, pending the timing row.
+>
+> **Amended by rf2-ne3ey, which ran that timing row on the `.84` hydration
+> harness — the conduct is ABSORPTION, not deferral.** `hydrate-root!`
+> returns before the tree is adopted, so "mid-adoption" is a fact rather than
+> a wait and a synchronous dispatch on the next line cannot be raced; ten
+> consecutive runs gave one answer. A mid-adoption revision reaches no
+> committed boundary — this arm acquires at COMMIT, and the adoption commit
+> is the first one — so it notifies nothing, and the already-scheduled
+> adoption render reads it as the field's FIRST revision, a change with no
+> predecessor to be a change from. Hydration is a mount rather than an
+> update, so the per-commit re-assert that carries the whole reset never
+> runs. Measured: the server's node survives, React reports on neither
+> channel, one body runs, and the draft is still in the field. *"Lands on the
+> first post-adoption commit"* is therefore false in both halves — there is
+> no post-adoption commit, and the adoption commit does not re-assert — and
+> *"defers past adoption"* overstates it, because nothing lands later either.
+> What survives of R3 is the NODE claim, and the row pins it: the next
+> revision change after the window shuts resets the field on the server's own
+> node, without remount. The field is never stranded; the reset is the
+> caller's to send again. `arm1/hydrate_dom_cljs_test` §6.
 >
 > **Reopens** if the per-commit re-assert stops holding — the witness file
 > `front/revision_dom_cljs_test` pins it as a design-validation row and a red

--- a/docs/design/hicasso/studio/revision-prop-spec.md
+++ b/docs/design/hicasso/studio/revision-prop-spec.md
@@ -229,6 +229,14 @@ pre-committed rather than improvised: if React deopts, the documented conduct
 becomes that the reset defers past adoption through the same deferral shape as IME,
 and the row pins that instead. **Never ship the claim unpinned.**
 
+*Outcome (rf2-ne3ey, on the `.84` hydration harness).* Neither the claim nor the
+pre-committed fallback: the conduct is **absorption**. A mid-adoption revision
+notifies no committed boundary, so the adoption render reads it as the field's
+first revision and nothing fires; the server's node survives, and the draft
+survives with it. The next revision change after the window shuts does reset the
+field, on the server's own node. Pinned by `arm1/hydrate_dom_cljs_test` §6; the
+ruling record is amended at HD-019's addendum in `decisions.md`.
+
 ---
 
 ## 5 · Witnesses

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/hydrate_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/hydrate_dom_cljs_test.cljs
@@ -85,13 +85,18 @@
 (rf/reg-sub :hyd/row (fn [db [_ i]] (get-in db [:rows i] "")))
 (rf/reg-sub :hyd/toasts (fn [db _] (:toasts db)))
 (rf/reg-sub :hyd/field (fn [db _] (:field db)))
+(rf/reg-sub :hyd/revision (fn [db _] (:revision db)))
 
 (rf/reg-event :hyd/seed
   (fn [_ _]
-    {:db {:title  "hydrated"
-          :rows   {0 "alpha" 1 "beta" 2 "gamma"}
-          :toasts [{:id 1 :message "Saved"}]
-          :field  "abc"}}))
+    {:db {:title    "hydrated"
+          :rows     {0 "alpha" 1 "beta" 2 "gamma"}
+          :toasts   [{:id 1 :message "Saved"}]
+          :field    "abc"
+          :revision "rev-1"}}))
+
+(rf/reg-event :hyd/set-revision
+  (fn [{:keys [db]} [_ r]] {:db (assoc db :revision r)}))
 
 (rf/reg-event :hyd/set-row
   (fn [{:keys [db]} [_ i v]] {:db (assoc-in db [:rows i] v)}))
@@ -180,6 +185,31 @@
   [:input#hyd-field.field {:type     "text"
                            :value    (rt/sub [:hyd/field])
                            :on-input [:hyd/set-field :re-frame.hicasso/value]}])
+
+(defview revision-field-screen
+  "[[field-screen]] carrying `::h/revision` off a subscription — the shape
+  §6 needs, and the only difference is that the reset trigger is a value
+  the model owns rather than a literal."
+  [_]
+  [:input#hyd-field.field {:type     "text"
+                           :value    (rt/sub [:hyd/field])
+                           :re-frame.hicasso/revision (rt/sub [:hyd/revision])
+                           :on-input [:hyd/set-field :re-frame.hicasso/value]}])
+
+(defn- drift!
+  "Move the field's value WITHOUT telling React — what a user typing into
+  server-rendered HTML before the bundle arrived leaves behind, and the
+  draft a reset exists to discard.
+
+  Written through the PROTOTYPE's `value` setter because React patches the
+  instance setter to maintain its change tracker; a plain `set!` would
+  update the tracker too, after which React reads the node as already
+  agreeing and no re-assert runs. Same reason, same shape as
+  `front/revision_dom_cljs_test`'s own."
+  [node v]
+  (let [d (js/Object.getOwnPropertyDescriptor js/HTMLInputElement.prototype "value")]
+    (.call (.-set d) node v)
+    nil))
 
 ;; ---------------------------------------------------------------------------
 ;; The fixture doors
@@ -467,3 +497,127 @@
                             "and every row is still the SERVER'S node — the
                              render did not remount the adopted tree"))
                       (finally (mount/release! handle) (done))))))))))))
+
+;; ===========================================================================
+;; 6 — HD-019's OTHER rider: a `::h/revision` arriving mid-adoption
+;;
+;; R3 of `studio/revision-prop-spec.md`, adjudicated on this harness
+;; (rf2-ne3ey). The design claimed a revision arriving during adoption
+;; lands on the first post-adoption commit, on the SERVER's node. R3
+;; demoted that to witness-gated intent with the fallback pre-committed;
+;; rf2-zq8kh settled the STRUCTURAL half — the revision is consumed at the
+;; codec, so React is handed a prop-identical element whether it moved or
+;; not (`front/revision_dom_cljs_test`) — and left the TIMING half here,
+;; because two hand-rolled `hydrateRoot` arms disagreed about node identity
+;; in opposite directions on consecutive runs.
+;;
+;; **The row below is not a re-run of that race, because `mid-adoption` is
+;; a fact here rather than a wait.** `hydrate-root!` refuses to `flushSync`,
+;; so it returns before the tree is adopted and `(rt/adopting?)` is TRUE on
+;; the line after — asserted, exactly as §1 asserts it. The dispatch is
+;; synchronous in that same turn, so no timer, no retry loop and no
+;; tolerance stands between the two: nothing can interleave and there is
+;; nothing to settle. It goes through `rt/dispatch!` rather than
+;; `mount/dispatch!` deliberately — the latter's `settle!` is a `flushSync`,
+;; and flushing React mid-adoption would manufacture the very schedule this
+;; door exists to refuse.
+;;
+;; **The verdict: the revision is ABSORBED, not deferred, and the adoption
+;; never notices it.** The write reaches no committed boundary — this arm
+;; acquires at COMMIT, and the adoption commit is the first one — so it
+;; notifies nothing, and the already-scheduled adoption render simply reads
+;; the new revision as its FIRST revision. A change with no predecessor to
+;; be a change from fires nothing; and React's hydration is a mount rather
+;; than an update, so the per-commit `updateInput` re-assert that carries
+;; the whole reset never runs. One body ran, the server's node survived,
+;; React reported nothing, and the draft the user typed into the server HTML
+;; is still in the field.
+;;
+;; So "lands on the first post-adoption commit" is false in both halves:
+;; there is no post-adoption commit to land on, and the adoption commit does
+;; not re-assert. What survives of the claim is the NODE, and the closing
+;; arm pins it — the next revision change after the window shuts resets the
+;; field on the server's own node, without remount. The field is never
+;; stranded; the reset is simply the caller's to send again.
+;; ===========================================================================
+
+(deftest a-revision-arriving-mid-adoption-is-absorbed-by-the-adoption
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (do
+        (fresh!)
+        (let [html (server-html! [revision-field-screen {}])]
+          (is (re-find #"value=\"abc\"" html)
+              "the server emitted the model as an attribute")
+          (is (not (re-find #"revision" html))
+              (str "and no revision — the strip is codec-level, so the wire
+                    cannot carry one: " html))
+          (let [container (stamp-server-nodes! (server-dom! html))
+                before    (.querySelector container "#hyd-field")]
+            (is (server-node? before))
+            (drift! before "a draft the model never took")
+            (is (= "a draft the model never took" (.-value before))
+                "the draft really landed, and it landed BEFORE any JS adopted
+                 the page — which is the only way a hydrated field can be
+                 carrying one at all")
+            (rt/reset-body-runs!)
+            (let [{:keys [captured close!]} (open-console-capture!)
+                  handle (mount/hydrate-root! container frame-id
+                                              [revision-field-screen {}])]
+              (is (true? (rt/adopting?))
+                  "**the window is OPEN**, so the dispatch on the next line is
+                   mid-adoption by construction rather than by timing")
+              (rt/dispatch! frame-id [:hyd/set-revision "rev-2"])
+              (-> (adopted!)
+                  (.then
+                    (fn [ok]
+                      (close!)
+                      (try
+                        (is (true? ok) "the closer's passive effect ran")
+                        (is (= "rev-2" @(rf/subscribe [:hyd/revision]
+                                                      {:frame frame-id}))
+                            "and the mid-adoption write really landed in the
+                             model — what follows measures an ABSORBED
+                             revision, not a dispatch that went nowhere")
+                        (is (= [] @captured)
+                            (str "React reported nothing on either channel: "
+                                 (pr-str @captured)))
+                        (let [after (.querySelector container "#hyd-field")]
+                          (is (identical? before after)
+                              "**the server's node survived.** A revision React
+                               was never given cannot make it deopt to a client
+                               render")
+                          (is (server-node? after)
+                              "and the stamp says so — an expando cannot
+                               survive re-serialisation")
+                          (is (= "a draft the model never took" (.-value after))
+                              "**THE RESET DID NOT LAND.** Hydration is a mount,
+                               not an update, so the per-commit re-assert that
+                               carries the whole reset never ran — the draft is
+                               exactly where the user left it")
+                          (is (= "abc" (controlled/last-rendered after))
+                              "while the mirror is the MODEL's, so the field is
+                               one ordinary commit away from converging"))
+                        (is (= 1 (rt/body-runs))
+                            (str "one boundary, ONE body run across the whole "
+                                 "adoption — the mid-adoption revision produced "
+                                 "no render of its own, which is what ABSORBED "
+                                 "means; read " (rt/body-runs)))
+                        (testing "**and the field is not stranded.** The next
+                                 revision change after the window shuts resets
+                                 it, on the SERVER's own node — the half of
+                                 R3's claim that does survive"
+                          (rt/reset-body-runs!)
+                          (mount/dispatch! handle [:hyd/set-revision "rev-3"])
+                          (let [after (.querySelector container "#hyd-field")]
+                            (is (= "abc" (.-value after))
+                                "the draft is discarded and the field
+                                 re-baselined to the model")
+                            (is (identical? before after)
+                                "WITHOUT REMOUNT — still the server's own node")
+                            (is (server-node? after))
+                            (is (= 1 (rt/body-runs))
+                                (str "on one ordinary commit; read "
+                                     (rt/body-runs)))))
+                        (finally (mount/release! handle) (done)))))))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
@@ -299,18 +299,33 @@
   the draft echo. \"The reset cannot be lost\" is false; \"the deferral
   cannot strand the field\" is what is true.
 
-  ### Mid-hydration, the reset defers past adoption — for React's reason
+  ### Mid-hydration, the reset is ABSORBED by the adoption — measured
 
   The design claimed a mid-adoption revision would land on the first
   post-adoption commit, on the SERVER's node. That is not a claim this
   prop can make either way: the revision is consumed at the codec before
   emission, so React is handed a prop-identical element whether it moved
   or not, and nothing on React's side can branch on a value it was never
-  given. Whether adoption keeps the server's node across a client render
-  that lands mid-flight is React's own race — two hand-rolled arms
-  disagreed in opposite directions on consecutive runs. So the documented
-  conduct is the deferral, pre-committed rather than improvised, and
-  `rf2-ne3ey` owns the timing row on the `.84` hydration harness."
+  given.
+
+  What does happen was then measured (rf2-ne3ey) on the `.84` hydration
+  harness rather than on a hand-rolled `hydrateRoot`, because two
+  hand-rolled arms disagreed about node identity in opposite directions on
+  consecutive runs: `arm1/hydrate_dom_cljs_test` §6, where *mid-adoption*
+  is a fact rather than a wait — `hydrate-root!` returns before the tree
+  is adopted, so a synchronous dispatch on the next line cannot be raced,
+  and ten consecutive runs gave one answer.
+
+  **The revision is ABSORBED, not deferred.** The write reaches no
+  committed boundary, so it notifies nothing and the already-scheduled
+  adoption render simply reads it as the field's FIRST revision — a change
+  with no predecessor to be a change from. And hydration is a MOUNT rather
+  than an update, so the per-commit re-assert that carries the whole reset
+  never runs. Measured: the server's node survives, React reports on
+  neither channel, one body runs, and the draft is still in the field
+  afterwards. The next revision change after the window shuts does reset
+  it, on the server's own node and without remount — so the field is never
+  stranded, but the reset is the caller's to send again."
   (:require ["react" :as react]
             ["react-dom" :as react-dom]))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/revision_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/revision_dom_cljs_test.cljs
@@ -30,9 +30,11 @@
   on a value it was never given. Two hand-rolled mid-adoption arms
   disagreed about node identity in opposite directions on consecutive
   runs, which is React's own adoption race rather than the prop's doing.
-  So the row pins the structural fact that makes the pre-committed
-  fallback safe to document, and the timing row it does not attempt is
-  `rf2-ne3ey`, on the `.84` hydration harness.
+  So the row pins the structural fact, and the timing row it does not
+  attempt is `arm1/hydrate_dom_cljs_test` §6, on the `.84` hydration
+  harness (rf2-ne3ey) — which measured the conduct as ABSORPTION rather
+  than deferral: the adoption render reads the new revision as the
+  field's FIRST, so the reset never fires and the draft survives.
 
   ## What is a proxy, and what is the path
 
@@ -222,13 +224,14 @@
            direction on the next, which is exactly what a race looks like
            and exactly what a prop React cannot see could not have caused.
 
-           So the documented conduct is the pre-committed fallback — a
-           reset arriving mid-adoption **defers past adoption**, like every
-           other deferral on this path — and the row that would pin
-           adoption TIMING belongs to the `.84` hydration harness rather
-           than to a hand-rolled `hydrateRoot` here (rf2-ne3ey). What
-           this row pins is the fact that makes the deferral safe to
-           document: the prop cannot influence adoption at all."
+           So the row that pins adoption TIMING belongs to the `.84`
+           hydration harness rather than to a hand-rolled `hydrateRoot`
+           here, and it is `arm1/hydrate_dom_cljs_test` §6 (rf2-ne3ey): it
+           measured ABSORPTION rather than the pre-committed deferral —
+           the adoption render reads the mid-adoption revision as the
+           field's first, so no reset ever fires and the draft survives.
+           What THIS row pins is the fact underneath that: the prop cannot
+           influence adoption at all."
     (let [with-rev    (codec/as-element (field :input "server" "rev-1"))
           bumped      (codec/as-element (field :input "server" "rev-2"))
           without-rev (codec/as-element (field :input "server"))


### PR DESCRIPTION
Closes rf2-ne3ey.

## What this pins

R3 of `docs/design/hicasso/studio/revision-prop-spec.md` demoted the design's
mid-adoption claim — *"a revision arriving during hydration adoption lands on
the first post-adoption commit, on the SERVER's node"* — to witness-gated
intent, with the fallback pre-committed. rf2-zq8kh settled the **structural**
half (the revision is consumed at the codec, so React is handed a
prop-identical element whether it moved or not) and left the **timing** half
open, because two hand-rolled `hydrateRoot` arms disagreed about node identity
in opposite directions on consecutive runs.

This is that timing row, on the `.84` hydration harness:
`arm1/hydrate_dom_cljs_test` §6.

**It cannot flake, and the reason is structural rather than a tolerance.**
`mid-adoption` is a fact here, not a wait: `mount/hydrate-root!` refuses to
`flushSync`, so it returns before the tree is adopted and `(rt/adopting?)` is
TRUE on the line after — asserted, exactly as §1 asserts it. The dispatch is
synchronous in that same turn, so nothing can interleave and there is nothing
to settle. No `setTimeout`, no retry loop, no tolerance, no change to
`entry-reap-horizon-ms`, no change to `hydration_support.cljs`. The row uses
`adopted!` and the server-node predicates exactly as they stand. It goes
through `rt/dispatch!` rather than `mount/dispatch!` deliberately — the
latter's `settle!` is a `flushSync`, and flushing React mid-adoption would
manufacture the very schedule this door exists to refuse.

## The verdict: ABSORPTION, not deferral

Measured, ten consecutive runs, one answer:

- the server's node **survives** — `identical?` to the pre-hydration node, and
  still carrying the expando stamp;
- React reports on **neither** channel;
- **one** body ran across the whole adoption — the mid-adoption write produced
  no render of its own;
- **the reset did not land**: the draft typed into the server-rendered field
  before the bundle arrived is still in the field, while the `defaultValue`
  mirror is the model's;
- and the field is **not stranded** — the next revision change after the
  window shuts resets it to the model, on the server's own node, without
  remount, on one ordinary commit.

The mechanism, which is why it is deterministic: the write reaches **no
committed boundary** (this arm acquires at COMMIT, and the adoption commit is
the first one), so it notifies nothing, and the already-scheduled adoption
render simply reads the new revision as the field's **first** revision — a
change with no predecessor to be a change from. And hydration is a **mount**
rather than an update, so the per-commit `updateInput` re-assert that carries
the whole reset never runs.

The row is self-contrasting rather than one-sided: the *same* dispatch,
mid-adoption and then post-adoption, produces opposite outcomes in the same
tree. That is what makes it able to answer FALSE. The row also asserts the
mid-adoption write really landed in the model, so it is measuring an absorbed
revision rather than a dispatch that went nowhere.

## What that corrects in the tracked records

*"Lands on the first post-adoption commit"* is false in both halves — there is
no post-adoption commit, and the adoption commit does not re-assert. But the
pre-committed fallback, *"the reset defers past adoption"*, **overstates it
too**: nothing lands later either. What survives of R3 is the NODE claim, and
the row pins it.

Four records carried the superseded sentence and are corrected here:

- `docs/design/hicasso/decisions.md` — HD-019's addendum, amended in place with
  the measurement and the mechanism (this is the ruling record);
- `docs/design/hicasso/authoring.md` — the authoring limit now tells the author
  the actionable thing: a revision arriving while the page is still hydrating
  is absorbed, the draft survives, send it again after adoption;
- `docs/design/hicasso/studio/revision-prop-spec.md` — R3 gets its outcome, so
  a reader of the spec is not left working from a superseded fallback;
- `front/controlled.cljs` and `front/revision_dom_cljs_test.cljs` — the
  prose that pointed at an open bead now names the shipped witness.

## Quality gates

Every gate run in the FOREGROUND to completion, redirected to a worktree-local
bead-prefixed log, exit code echoed explicitly. Every script printed
`gate root: /c/Users/miket/code/re-frame2-worktrees/hydrarev-ne3ey`.

| gate | exit | result |
|---|---|---|
| `npm run test:browser` (**the lane that runs this row**) | **0** | Ran 1129 tests containing 6962 assertions. 0 failures, 0 errors. |
| the row's namespace, **10 consecutive runs** | **0 ×10** | **10/10 pass** — 7 tests containing 55 assertions, 0 failures, 0 errors, identical every run |
| `npm run test:cljs` | **0** | Ran 12795 tests containing 64389 assertions. 0 failures, 0 errors. |
| `npm run test:hicasso-compile` | **0** | 136 lane namespaces compiled, zero warnings |
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` (docs + JVM + node tiers all armed; JVM core 2233/11645, JVM freehand 1294/8966) |
| `clj-kondo` over the three changed namespaces | **0** | errors: 0, warnings: 0 |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | **0** | `No beads-database paths in this PR diff.` |

The repeat-run measurement used a narrowed `:browser-test` compile
(`--config-merge {:ns-regexp "hydrate-dom-cljs-test$"}`) so each run exercises
this file alone; the full lane above then ran the unnarrowed build.

**clj-kondo version caveat**, stated because the gap map insists on it: the
local binary is **v2025.10.23** and CI pins **2026.04.15**. A local pass on a
different version proves less than a CI pass; the diff adds no new construct
beyond ordinary `deftest`/`is`/`async` already used throughout this file.

**Relied on CI for** (per `python scripts/check_fast_pr_gap.py --list`, exit 0):
`cljs-browser` is the one required job that decides this diff, and it is the
one run locally above — green. Otherwise: the `lint.yml` jobs (`clj-kondo` on
the pin, `splint`, `eslint`, `api-manifest`), the four `*-prod-gate` JVM lanes,
and the `jvm-freehand` donor-boundary `git grep` step (this diff adds no
`re-frame.ui` reference). Everything else in the 90 is surface-gated away from
this diff.

**`docs/design/**` is deliberately outside `mkdocs build --strict`**, so it is
not the gate for those three files. `scripts/check_doc_slugs.py` — the `docs
corpus anchor validator` step of the spine — did run and passed. Per the
standing rule the worker hand-verifies what nothing validates: **these edits
add no headings, no links and no tables** (verified against the diff), so there
are no anchors and no column counts to check; the changed prose is inside
existing paragraphs and one blockquote.

## Fences honoured

`arm1/runtime.cljs` was **read only, never edited** (`worker/phaseb-981nt` owns
it), and `entry-reap-horizon-ms` is **untouched** — the row waits on `adopted!`,
which already stands on that horizon. `hydration_support.cljs` needed no change
at all. No `git stash` at any point.
