### PR TITLE
fix(hicasso): a missing unverified count is a refusal, not a zero (rf2-0fixc)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/jsfb_compare.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/jsfb_compare.cjs
@@ -72,7 +72,9 @@
 // REPORTED here and decided by `jsfb_ours_run.cjs`, which owns them and
 // exits on them. Two programs deciding one verdict is the defect
 // `clock_exit_path.test.cjs` exists to pin, and this file is not going to
-// grow a second seat for it.
+// grow a second seat for it. But reporting a gate is not licence to invent
+// one: an unverified-writes count the JSON does not carry is now printed as
+// UNSTATED rather than defaulted into a clean total (rf2-0fixc).
 
 const fs = require('node:fs');
 const path = require('node:path');
@@ -365,8 +367,20 @@ function report(theirs, ours, rows) {
     console.log(`;;   DOM parity        ${ours.parity && ours.parity.identical ? 'IDENTICAL' : 'DIFFERENT'}`);
     console.log(`;;   positive control  ${ours.control && ours.control.pass ? 'PASS' : 'FAIL'}`);
     console.log(`;;   page errors       ${ours.pageErrors}`);
-    const unv = Object.values(ours.summary).reduce((a, s) => a + (s && s.unverified ? s.unverified : 0), 0);
-    console.log(`;;   unverified        ${unv}`);
+    // A COUNT THAT IS NOT THERE IS NOT A ZERO (rf2-0fixc). This fold defaulted
+    // a missing `unverified` to 0, so an entry that never recorded the field
+    // read exactly like one that recorded it as 0 having verified every write.
+    // The field is REQUIRED, and the benchmarks lacking it are named instead of
+    // summed away. UNSTATED rather than UNMEASURED because nobody measures this
+    // one: the rig counts it, and the fault is that it did not say so.
+    const unstated = Object.entries(ours.summary).filter(([, s]) => !s || !Number.isFinite(s.unverified));
+    if (unstated.length > 0) {
+      console.log(
+        `;;   unverified        UNSTATED — no \`unverified\` count under ${unstated.map(([k]) => k).join(', ')}, so no total is derived`
+      );
+    } else {
+      console.log(`;;   unverified        ${Object.values(ours.summary).reduce((a, s) => a + s.unverified, 0)}`);
+    }
   }
 
   console.log('');

--- a/implementation/freehand/test/re_frame/bench/hicasso/jsfb_compare_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/jsfb_compare_exit_path.test.cjs
@@ -123,6 +123,22 @@ function oursPatched(name, ourId, arm, patch) {
   return file;
 }
 
+/**
+ * Our run's JSON with named benchmarks' `unverified` counts overwritten — or
+ * DELETED where the count is `undefined`, which is the fixture the absent-field
+ * case needs and which `JSON.stringify` will not write any other way.
+ */
+function oursUnverified(name, counts) {
+  const j = JSON.parse(fs.readFileSync(oursJson(`${name}.src`), 'utf8'));
+  for (const [ourId, n] of Object.entries(counts)) {
+    if (n === undefined) delete j.summary[ourId].unverified;
+    else j.summary[ourId].unverified = n;
+  }
+  const file = path.join(TMP, name);
+  fs.writeFileSync(file, JSON.stringify(j));
+  return file;
+}
+
 /** The evidence bundle the decision is taken over. */
 function evidence(dir, oursFile) {
   const t = readTheirs(dir);
@@ -532,6 +548,71 @@ test('THE WORKLOAD CONCLUSION is OURS-only: a short DRIVER table does not suppre
   assert.strictEqual(r.status, 1, r.stdout + r.stderr);
   assert.match(r.stderr, /1 of 10 expected cells/);
   assert.match(r.stdout, WORKLOAD_CONCLUSION, 'ours measured this page; the driver is not its premise');
+});
+
+// --- AND A COUNT THAT IS NOT THERE IS NOT A ZERO (rf2-0fixc) ----------------
+//
+// The same fail-open shape, one section further down. `OUR RUN'S GATES` folded
+// the per-benchmark unverified-write counts with `s.unverified ? s.unverified
+// : 0`, so a summary entry carrying NO `unverified` field at all contributed 0
+// — indistinguishable from one carrying `unverified: 0` that genuinely
+// verified every write. A JSON from a rig that never recorded the field, or
+// from a version that dropped it, therefore printed a clean `unverified 0`,
+// and the one line a reader consults to decide whether the writes were checked
+// answered out of evidence that is not there.
+//
+// The two lines ABOVE it have the same shape and are NOT this defect: a
+// missing `parity` object prints DIFFERENT and a missing `control` prints
+// FAIL, which is the safe direction. This one printed the clean value.
+//
+// `report` prints rather than returns, so these are PROCESS assertions. What
+// they pin is one-way — a stated total may become a refusal, never the reverse
+// — so the stated case is asserted too. And so is the exit code: this line is
+// REPORTED here and decided by `jsfb_ours_run.cjs`, so a refusal in it must
+// leave the comparator's own verdict exactly where it was.
+
+const UNVERIFIED_TOTAL = /;;\s+unverified\s+\d/;
+
+test('THE UNVERIFIED COUNT: a summary entry with no `unverified` field refuses, naming it', () => {
+  const f = oursUnverified('unv-missing.json', { run1k: undefined });
+  const r = run(['--theirs', theirsDir('unv-missing'), '--ours', f]);
+  assert.doesNotMatch(r.stdout, UNVERIFIED_TOTAL, 'a count nobody recorded may not print as a number');
+  assert.ok(r.stdout.includes('UNSTATED — no `unverified` count under run1k, so no total is derived'), r.stdout);
+  // Reported, not decided: an otherwise complete run still exits 0.
+  assert.strictEqual(r.status, 0, r.stderr);
+});
+
+test('THE UNVERIFIED COUNT: every benchmark lacking the field is named, not just the first', () => {
+  const f = oursUnverified('unv-two.json', { replace1k: undefined, swaprows: undefined });
+  const r = run(['--theirs', theirsDir('unv-two'), '--ours', f]);
+  assert.doesNotMatch(r.stdout, UNVERIFIED_TOTAL);
+  assert.ok(r.stdout.includes('UNSTATED — no `unverified` count under replace1k, swaprows'), r.stdout);
+});
+
+test('THE UNVERIFIED COUNT: a field present but NOT A NUMBER is no count either', () => {
+  // `null` is what a JSON round-trip of `NaN` leaves behind and `'n/a'` is what
+  // a rig writes when it declines to answer. The old fold took the first as 0
+  // and concatenated the second onto the running total as text.
+  // Indexed rather than named, as the non-finite-ratio case above is: `'n/a'`
+  // carries a separator and cannot be part of a fixture's file name.
+  [null, 'n/a'].forEach((bad, i) => {
+    const f = oursUnverified(`unv-bad-${i}.json`, { run1k: bad });
+    const r = run(['--theirs', theirsDir(`unv-bad-${i}`), '--ours', f]);
+    assert.doesNotMatch(r.stdout, UNVERIFIED_TOTAL, `unverified=${String(bad)} must not print a total`);
+    assert.ok(r.stdout.includes('UNSTATED — no `unverified` count under run1k'), r.stdout);
+  });
+});
+
+test('THE UNVERIFIED COUNT: a run that states every count still prints the SUM', () => {
+  // The other direction. A line that fell silent on stated counts would pass
+  // every assertion above and be a worse program than the one repaired — and
+  // the total must still be the sum, not merely something that is not a
+  // refusal.
+  const f = oursUnverified('unv-ok.json', { run1k: 2, clear1k: 3 });
+  const r = run(['--theirs', theirsDir('unv-ok'), '--ours', f]);
+  assert.strictEqual(r.status, 0, r.stderr);
+  assert.match(r.stdout, /;;\s+unverified\s+5\b/, r.stdout);
+  assert.doesNotMatch(r.stdout, /UNSTATED/, 'a stated count is not a refusal');
 });
 
 test('THE PROCESS EXIT: no arguments at all is a refusal, not a green run', () => {


### PR DESCRIPTION
Closes rf2-0fixc. The closest genuine sibling of the WORKLOAD bypass PR #7687 closed, found by that PR's worker and left unfixed there because fixing it inside would have breached its fence.

## What was wrong

`report`'s `OUR RUN'S GATES` block folded the per-benchmark unverified-write counts with

```js
const unv = Object.values(ours.summary).reduce((a, s) => a + (s && s.unverified ? s.unverified : 0), 0);
```

and printed the total on the next line as the run's unverified-writes gate. A summary entry carrying **no `unverified` field at all contributed 0** — indistinguishable from one that carried `unverified: 0` having genuinely verified every write. So a JSON from a rig that never recorded the field, or from a version that dropped it, printed a clean `unverified 0`, and the one line a reader consults to decide whether the writes were checked answered out of evidence that is not there.

Reproduced verbatim against the landed file before the change. Against an `--ours` JSON whose `run1k` entry has no `unverified` key, HEAD's comparator prints:

```
;; OUR RUN'S GATES (decided by jsfb_ours_run.cjs; reported here)
;;   DOM parity        IDENTICAL
;;   positive control  PASS
;;   page errors       0
;;   unverified        0
```

This **fails OPEN**, which is what makes it worth repairing rather than noting: absence of evidence rendered as evidence of absence.

## The repair

The field is REQUIRED rather than defaulted. An entry lacking it — or carrying something that is not a finite number — makes the line refuse and **name every benchmark that did not state one**:

```
;;   unverified        UNSTATED — no `unverified` count under run1k, so no total is derived
;;   unverified        UNSTATED — no `unverified` count under replace1k, swaprows, so no total is derived
```

and a run that states them all still prints the **sum** (counts of 2 and 3 print `5`, not merely "not a refusal").

`UNSTATED` rather than the file's existing `UNMEASURED` because nobody *measures* this one — the rig counts it, and the fault is that it did not say so. The refusal keeps the established idiom otherwise: all-caps token, em-dash, the named cause, `so no <conclusion> is derived`, exactly as #7687's `UNMEASURED — <bad value>, so no movement is derived from it` four lines above.

`Number.isFinite` is the predicate, so `null` (what a JSON round-trip of `NaN` leaves behind) and `'n/a'` refuse too. The old fold took the first as `0` and *concatenated* the second onto the running total as text.

## The neighbour at the line above is deliberately untouched

`ours.parity && ours.parity.identical ? 'IDENTICAL' : 'DIFFERENT'` has the same shape, and so does `control.pass`. They are **not** this defect: a missing object prints `DIFFERENT` and `FAIL`, which is the safe direction — they fail **closed**. Changing them for symmetry would be gold-plating, so they are left exactly as they are.

## No exit code changed

Established two ways, the same pattern #7687 used.

**Structurally.** The whole edit is inside `report`, which prints and returns nothing; `main` calls it before `verdict`, and it mutates neither `theirs`, `ours` nor `rows`. `verdict`, `buildRows`, `notMeasured`, `positive`, `main` and the parity gate are untouched, and `EXPECTED_CELLS` stays derived from `PAIRS`.

**Empirically.** The pre-change comparator was extracted from HEAD (`git show`, verified byte-identical) and both versions were spawned over one identical **42-fixture** matrix spanning all three documented exit codes — including nine fixtures on the surface this repair actually reads (field absent from one / two / every benchmark, `null`, `'n/a'`, stated non-zero counts, a `null` summary entry outright, and the absent field combined with short and with negative evidence):

```
42 fixtures compared; 0 exit-code divergence(s); codes observed: 0, 1, 2
```

A refusal stayed a refusal: this change only turns a printed number into a refusal, never the reverse.

## Proved red, then green

Four cases added to `jsfb_compare_exit_path.test.cjs` in its existing in-test `mkdtemp` idiom (one new fixture helper, `oursUnverified`, which sets counts or deletes them — `JSON.stringify` will not write an absent field any other way). They are PROCESS assertions, because `report` prints rather than returns and there is no seam to call.

Witness count **42 → 46**.

With the **final** test file run against HEAD's comparator, out of tree:

```
FAIL  THE UNVERIFIED COUNT: a summary entry with no `unverified` field refuses, naming it
FAIL  THE UNVERIFIED COUNT: every benchmark lacking the field is named, not just the first
FAIL  THE UNVERIFIED COUNT: a field present but NOT A NUMBER is no count either
jsfb_compare_exit_path.test.cjs: 3/46 failed          (exit 1)
```

After the change:

```
jsfb_compare_exit_path.test.cjs: 46 passed            (exit 0)
```

The fourth new case — **a run that states every count still prints the SUM** — is green in both runs *by design*. It is the one-way fence: a repair that turned this line silent, or that stopped summing, would pass every other assertion above and be a worse program than the one repaired. The first case also asserts `status === 0`, pinning that a refusal in a REPORTED line leaves the comparator's own verdict where it was.

## Line endings

The suite carries **no line-ending handling of any kind**, and this change does not need any: every new assertion is a single-line `includes` or a newline-agnostic regex over spawned stdout, and `console.log` writes `\n` on every platform. Verified anyway, out of tree rather than by adding machinery to the suite — copies of both files normalised each way and run from there:

| fixture | `jsfb_compare.cjs` | test file | result |
| --- | --- | --- | --- |
| LF | 415 bare LF, 0 CRLF | 691 bare LF, 0 CRLF | 46 passed, exit 0 |
| CRLF | 415 CRLF, 0 bare LF | 691 CRLF, 0 bare LF | 46 passed, exit 0 |

(Counted with `node`, not `grep` — MSYS `grep -c $'\r'` reports the same count for both files on this box and cannot be trusted for it.)

## The benchmark was not run

No measurement window was disturbed. Every fixture is synthetic and built in-test; every decision was reached through the module's `require.main` guard and its exports.

## Not fixed, reported

One sibling in the same fold, left alone because this bead's fence is explicit — "require the field rather than defaulting it", and "do NOT grow a schema validator":

- **A negative count cancels a positive one.** `unverified: -5` in one entry against `unverified: 5` in another still totals `0`. That is present-but-wrong evidence rather than absent evidence, which makes it rf2-110be's class (a value that is not a measurement) rather than this bead's, and rf2-110be deliberately scoped itself to durations and ratios. Worth a follow-up bead for the mayor to scope; the one-line guard would be `s.unverified >= 0`, but adding it here would have changed this repair from "require the field" into "validate the field".

## Quality gates

Every gate run in the foreground to completion, in `C:/Users/miket/code/re-frame2-worktrees/unverified-0fixc`, redirected to a bead-prefixed log rather than piped, with the runner's own exit code echoed.

| gate | exit | result |
| --- | --- | --- |
| `node --check jsfb_compare.cjs` | 0 | — |
| `node --check jsfb_compare_exit_path.test.cjs` | 0 | — |
| `node jsfb_compare_exit_path.test.cjs` | 0 | 46 passed (was 42) |
| `node jsfb_ours_exit_path.test.cjs` | 0 | 41 passed, unchanged |
| exit-code equivalence matrix (pre vs post) | 0 | 42 fixtures, 0 divergences, codes 0/1/2 |
| the suite under LF, out of tree | 0 | 46 passed |
| the suite under CRLF, out of tree | 0 | 46 passed |
| `npm run test:script-helpers` (from `implementation/`) | 0 | every suite green, `jsfb_compare_exit_path` 46 / `jsfb_ours_exit_path` 41 among them |
| `npm run lint:js` (from repo root) | 0 | ESLint clean (a required CI job with no spine lane) |
| `sh scripts/test-fast-pr.sh` | 0 | `PASS fast PR spine`, docs=false jvm=true node=true |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | 0 | "No beads-database paths in this PR diff." |

The PR diff is exactly the two files named above; `.beads/` is untouched.
