### PR TITLE
docs(hicasso): the comparison count is derived, and the census split is labelled unrecomputable (rf2-w3yxd, rf2-jo60g)

### DIFF
--- a/docs/design/hicasso/studio/census-real-clock-rows.md
+++ b/docs/design/hicasso/studio/census-real-clock-rows.md
@@ -267,7 +267,7 @@ own shapes.
 
 | | registered | outcome |
 |---|---|---|
-| P1 | ctl-2x reads below its arithmetic prediction on every row (`rf2-jcm3p`) | **CONFIRMED on large-template** (1.8650 / 1.8879 vs 1.9759) and **on ordinary**, where the additive residual `c` is 0.90 ms on a 1.14 ms tared floor — the constant is most of the signal. **REFUTED on feed** (2.0772 / 2.2450 vs 1.9943): at 10,229 elements the doubled floor costs *more* than the arithmetic — layout 2.06×, style 1.85×, script 2.3× in the decomposition — so the superlinearity of React's own mount at 10k elements outweighs the additive undershoot. Recorded, not smoothed over |
+| P1 | ctl-2x reads below its arithmetic prediction on every row (`rf2-jcm3p`) | **CONFIRMED on large-template** (1.8650 / 1.8879 vs 1.9759) and **on ordinary**, where the additive residual `c` is 0.90 ms on a 1.14 ms tared floor — the constant is most of the signal. **REFUTED on feed** (2.0772 / 2.2450 vs 1.9943): at 10,229 elements the doubled floor costs *more* than the arithmetic — layout 2.06×, style 1.85×, script 2.3× in the decomposition, **a dated 2026-08-02 observation that is not recomputable from any committed dataset** ([why](#refusals-and-instrument-limits-with-reasons)) — so the superlinearity of React's own mount at 10k elements outweighs the additive undershoot. Recorded, not smoothed over |
 | P2 | direction only: feed hicasso/uix wholly above 1.10 | **CONFIRMED in direction on the reagent run** (whole range above 1.10); **not resolved on the uix run** (range floor 1.0951). The magnitude *growth* the bead's scaling argument implied did not happen — the deficit shrank instead (see the workload leg above) |
 | P3 | large-template is the largest hicasso/uix of the three rows | **ORDERING CONFIRMED, REASONING NOT** — 1.3053 > 1.1646 > 1.1248 is what was measured. P3 was registered on the reasoning that the shell is held at one boundary while the interpreter term is maximal; the rows cannot separate that from large-template simply being a different page at a different size (`rf2-2rtt6.62`). The ordering is a fact about three numbers, not evidence for the mechanism that predicted it |
 | P4 | the ordinary row sits near this door's floor; if its control or band cannot hold, it publishes a refusal, not a number | **CONFIRMED** — both runs' ordinary controls FAILED (1.1511 / 1.2964 vs 1.7255 predicted); the row's gated magnitudes are published only as instrument-limited non-results carrying the control's failure |
@@ -290,6 +290,17 @@ own shapes.
   in the driver header and above.
 - The mount control cannot certify exactness, only page-proportional signal
   (`rf2-jcm3p`); the additive residual `c` is printed per row.
+- **P1's feed decomposition — `layout 2.06×`, `style 1.85×`, `script 2.3×` — is
+  a dated 2026-08-02 observation and is not recomputable from any committed
+  dataset** (`rf2-jo60g`). The driver collected the three durations per sample
+  and then dropped them when it wrote the dataset, so nothing on disk carries
+  them and no file here can reproduce them; they were real when taken and they
+  stand as read rather than as restatable. **This is a labelling correction and
+  not a withdrawal.** PR #7666 landed the per-block
+  `Script`/`RecalcStyle`/`Layout` persistence and PR #7681 made
+  `foldDecomposition` refuse partial evidence instead of zeroing it, so the
+  split becomes recomputable on the next canonical census run — whenever one is
+  taken for its own reasons.
 
 ## The verdict, as the bead states it
 

--- a/docs/design/hicasso/studio/the-clock-behind-the-published-rows.md
+++ b/docs/design/hicasso/studio/the-clock-behind-the-published-rows.md
@@ -846,7 +846,8 @@ reached for its own four in-page rows.
 
 **That is a bound on the comparisons selected here, not a property of the
 estimator.** `clock_readjudicate.cjs` forms the pair for every row, pair and
-window it can, which is forty-two comparisons, and four of them cross.
+window it can — five row blocks × three `PAIRS` × three estimator windows, so
+~~forty-two~~ **forty-five** comparisons — and four of them cross.
 `bulk100` · `uix-subs / reagent-subs` reads `1.0072×` normalised against
 `0.9949×` raw on the published clock; `narrow` · `hicasso / reagent-subs` reads
 `0.9659×` against `1.0065×` on `taskNet`; and `keystroke` ·
@@ -859,6 +860,14 @@ from parity, so no verdict on this page turns on which estimator is read. But
 agreement on the rows chosen is not agreement in general, and this paragraph
 used to claim the latter. That is a bound on what the normalisation does to a
 mean — it is not licence to quote a refused row's mean.
+
+*(2026-08-08, `rf2-w3yxd`: the count above read **forty-two** until the
+merged-PR audit of #7680 recounted it — the earlier pass counted comparisons off
+the reader's output instead of deriving them from the block structure, which is
+why it is now written as the product it is. All fifteen `PAIR` blocks carry a
+RAW quotient, so both estimators are present for every pair. Nothing else here
+moves: the nine tabulated comparisons, the four crossings, the corrected
+`−0.5 pp` cell and the 0.5–3.9 pp range all reproduce.)*
 
 ### What is NOT restated
 


### PR DESCRIPTION
Two small, exact corrections to the Hicasso studio record, on different pages. Both
are annotate-never-erase. No measurement was taken, no driver was run, and no figure
is restated.

## `rf2-w3yxd` — forty-two becomes forty-five

`docs/design/hicasso/studio/the-clock-behind-the-published-rows.md`

The merged-PR audit of #7680 reopened this bead for one counting error. The
retained-reader output is **five row blocks × three `PAIRS` × three estimator
windows = forty-five comparisons**, and all fifteen `PAIR` blocks carry a RAW
quotient, which confirms both estimators are present for every pair. The landed
page said forty-two.

The number is now written as **the product it is** rather than transcribed, for the
same reason `EXPECTED_CELLS` is derived from `PAIRS` in the jsfb comparator rather
than typed — the earlier pass counted comparisons off the reader's output, which is
how it came to be wrong. The block structure is verified against
`clock_readjudicate.cjs`: `PAIRS` has three entries (`clock_readjudicate.cjs:101`),
the per-pair block prints three windows (raw `TaskDuration`, `taskNet`, in-page),
and the page's own per-row table carries five rows.

Struck-and-replaced by the page's own convention, with a dated parenthetical
recording where forty-two came from so it is not reintroduced.

**Nothing else was touched, and nothing re-adjudicated.** The audit is explicit that
the scoped nine-table claim, the four crossing examples, the corrected `−0.5 pp`
cell, the 0.5–3.9 pp range and the product verdict all reproduce and remain sound.

## `rf2-jo60g` — the census split is labelled unrecomputable

`docs/design/hicasso/studio/census-real-clock-rows.md`

The mayor ruled the **strike route, not the re-run**. `rf2-jv36i` made the re-run
conditional on the boundary-decomposition term being P2-relevant; the measurement
lane has been stood down for the P2 sitting, which settles the conditional.

P1's cited feed decomposition — `layout 2.06×`, `style 1.85×`, `script 2.3×` — is
not recomputable from any committed dataset: the driver collected the three
durations per sample and dropped them when it wrote the dataset, so nothing on disk
carries them.

Annotate, never erase. The figures stay visible as the dated 2026-08-02
observations they are, marked in place in the P1 cell and given their reason as a
bullet in **Refusals and instrument limits, with reasons** — the page's own home for
this class of statement.

**A labelling correction, not a withdrawal, and it forecloses nothing.** PR #7666
landed the per-block `Script`/`RecalcStyle`/`Layout` persistence and PR #7681 made
`foldDecomposition` refuse partial evidence instead of zeroing it, so the split
becomes recomputable on the next canonical census run, whenever one is taken for its
own reasons.

## Quality gates

`mkdocs build --strict` is **not** nominated and does not apply: `mkdocs.yml`'s
`exclude_docs` keeps `design/hicasso/` out of the site. Every gate below was run in
the foreground, to completion, unpiped, with its own exit code read directly.

| gate | exit |
|---|---:|
| `python scripts/check_doc_slugs.py` | `0` |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | `0` |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | `0` |

**Doc-slug gate probed at both edit sites, as required.** Breaking the anchor at the
`the-clock-behind-the-published-rows.md` edit site gave **exit 1**, naming
`docs/design/hicasso/studio/the-clock-behind-the-published-rows.md:844` and the
broken target; reverted, **exit 0**. Breaking the anchor this PR *adds* at the
census edit site gave **exit 1**, naming
`docs/design/hicasso/studio/census-real-clock-rows.md:270`; reverted, **exit 0**. So
the gate is live over both files rather than merely silent.

**Provenance gate fired and passed, and it was read rather than assumed.** Verbose
output: `2 files, 12 cited pins (10 landed, 2 stranded, 0 unresolvable)` —
`every cited pin is an ancestor of origin/main or shares its block with one`. The
two stranded authored SHAs already carry a landed counterpart in the same block, so
`rf2-owq6p`'s accompaniment remedy is already satisfied on these pages and **no pin
was added, deleted or re-pinned**.

**Tables and anchors hand-verified.**

- `census-real-clock-rows.md`, *Predictions, registered before any clock, scored* —
  the one table this PR edits a cell of. Header `3` cells, delimiter `3`, and rows
  P1/P2/P3/P4 `3` each: **six lines, all three columns**. The added text introduces
  no `|`, so the cell count is unchanged.
- New anchor `#refusals-and-instrument-limits-with-reasons` resolves to the existing
  `## Refusals and instrument limits, with reasons` heading on the same page —
  confirmed by the probe above, which is the only way this link could have been
  wrong.
- `the-clock-behind-the-published-rows.md` — **no table was touched**; both edits
  are prose in the *Two estimators, published together* section, and the two tables
  in that section are byte-unchanged. The neighbouring
  `#two-estimators-published-together` link was verified live by the probe.

Commits are ordered smallest-first. Do not merge on my account — `rf2-w3yxd` and
`rf2-jo60g` are closed against this PR by cross-reference.
