### PR TITLE
fix(bench): the allocation preflight enforces the averaging floor (rf2-2rtt6.142)

### DIFF
--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -36,6 +36,7 @@
 // Wired into implementation/package.json via `test:script-helpers`.
 
 const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 
@@ -50,6 +51,7 @@ const {
   ladderPlan,
   allocArmSizing,
   allocMaxWrites,
+  ALLOC_MIN_WRITES,
   ALLOC_ARM,
 } = require('./p0_run.cjs');
 
@@ -452,7 +454,7 @@ test('the driver exits on THIS function and does not re-derive the budget', () =
   has(/const maskable = allocMaskableWindows\(out\.alloc\);/, 'the alloc gate calls it');
   has(/if \(maskable\.length > 0\) \{/, 'and its result is what pushes a failure');
   has(
-    /module\.exports = \{\s*ladderStructuralFailures,\s*allocSteps,\s*allocMaskableWindows,\s*ALLOC_MASK_BUDGET_B,\s*ladderPlan,\s*allocArmSizing,\s*allocMaxWrites,\s*ALLOC_ARM,\s*\};/,
+    /module\.exports = \{\s*ladderStructuralFailures,\s*allocSteps,\s*allocMaskableWindows,\s*ALLOC_MASK_BUDGET_B,\s*ladderPlan,\s*allocArmSizing,\s*allocMaxWrites,\s*ALLOC_MIN_WRITES,\s*ALLOC_ARM,\s*\};/,
     'so this file can drive it'
   );
 });
@@ -570,16 +572,20 @@ test('a MIS-SIZED arm is refused — one boundary over the bound is over it', ()
   assert.ok(allocSteps(predictedStream(over)).maskable, 'the real gate agrees');
 });
 
-test('`allocMaxWrites` inverts the bound exactly — one write more refuses', () => {
+test('`allocMaxWrites` inverts the BOUND exactly — one write more is over budget', () => {
+  // Driven on `headroom`, which is the bound's own term, and not on
+  // `admissible`, which is the whole preflight verdict: at 60 boundaries the
+  // bound admits only 2 writes, and the averaging floor refuses that page
+  // whatever the budget thinks of it (rf2-2rtt6.142, below).
   for (const boundaries of [4, 12, 24, 25, 60]) {
     const w = allocMaxWrites(boundaries);
     assert.ok(w >= 1, `${boundaries} boundaries must admit a window at all`);
     assert.ok(
-      allocArmSizing({ writes: w, roots: 1, cells: boundaries }).admissible,
-      `${boundaries} boundaries at ${w} writes must fit`
+      allocArmSizing({ writes: w, roots: 1, cells: boundaries }).headroom >= 0,
+      `${boundaries} boundaries at ${w} writes must fit the budget`
     );
     assert.ok(
-      !allocArmSizing({ writes: w + 1, roots: 1, cells: boundaries }).admissible,
+      allocArmSizing({ writes: w + 1, roots: 1, cells: boundaries }).headroom < 0,
       `${boundaries} boundaries at ${w + 1} writes must not`
     );
   }
@@ -603,6 +609,171 @@ test('the sizing cannot buy headroom by shrinking the WINDOW alone', () => {
   assert.ok(oneWrite.predictedWindowB > ALLOC_MASK_BUDGET_B);
   const smallUnit = allocArmSizing({ writes: 6, roots: 4, cells: 6 });
   assert.ok(smallUnit.admissible, 'and a smaller UNIT carries six writes of averaging');
+});
+
+// ===========================================================================
+// THE AVERAGING FLOOR IS ENFORCED, NOT MERELY DERIVED FROM — rf2-2rtt6.142
+// ===========================================================================
+//
+// THE DEFECT THIS PINS. `ALLOC_MIN_WRITES` sized the default page and then
+// adjudicated nothing: the preflight's verdict was `writes >= 1 && boundaries
+// >= 1 && headroom >= 0`, so every window from one write upwards was licensed
+// however little averaging was left in it. Two routes reached that state
+// through the shipped env surface, and the merged-PR audit of #7688 derived
+// both without launching a browser:
+//
+//   P0_ROOTS=50          the DEFAULT derivation, which floors `cells` at 1 and
+//                        lands on 50 boundaries — a page that admits 2 writes
+//   P0_ALLOC_WRITES=1    the shipped 24-boundary page, window set by hand
+//
+// Both are far under the masking budget, which is precisely why the bound
+// could not catch them: the budget is an upper limit on a window's SIZE and
+// has nothing to say about how few writes are averaged inside it.
+//
+// WHY THE FLOOR EXISTS, so it is not weakened by accident. A one-write window
+// has no averaging in it, and at one write per window all four ladder fits
+// came back under the 0.98 r2 floor — 0.75 / 0.28 / 0.94 / 0.31. The row
+// already assumes the averaging; this is the preflight being made to enforce
+// what the row assumes.
+//
+// NOTHING HERE MEASURES ANYTHING. The two env routes are re-derived in a
+// child `node` that requires the driver and prints `ALLOC_ARM` — the module
+// constants are read at require time, so an env route can only be pinned from
+// outside the process. No build, no browser, no page.
+
+// The driver's own `ALLOC_ARM`, as a fresh process with `env` set derives it.
+// This is the shipped derivation and not a re-statement of it, which is the
+// whole point: the routes below are configuration, and configuration is read
+// exactly once, at require.
+function armUnderEnv(env) {
+  const r = spawnSync(
+    process.execPath,
+    ['-e', 'process.stdout.write(JSON.stringify(require(process.argv[1]).ALLOC_ARM))', DRIVER],
+    { env: { ...process.env, ...env }, encoding: 'utf8' }
+  );
+  assert.strictEqual(r.status, 0, `requiring the driver must not throw: ${r.stderr}`);
+  return JSON.parse(r.stdout);
+}
+
+test('ROUTE 1 — the large-root DEFAULT that cannot fit six writes is refused', () => {
+  // `P0_ROOTS=50` needs no other flag: the `ALLOC_CELLS` default floors at one
+  // cell per root, so the page it derives is 50 boundaries and the window that
+  // page admits is 2 — below the floor, and inside the budget, which is how it
+  // reached a publication path at all.
+  const arm = armUnderEnv({ P0_ROOTS: '50', P0_ALLOC_CELLS: '', P0_ALLOC_WRITES: '' });
+  assert.strictEqual(arm.cells, 1, 'the default floors at one cell per root');
+  assert.strictEqual(arm.boundaries, 50);
+  assert.strictEqual(arm.writes, 2, 'and 50 boundaries admit only a two-write window');
+  assert.ok(arm.headroom >= 0, 'the masking bound is content — it never saw this');
+  assert.ok(!arm.admissible, 'the averaging floor is what refuses it');
+  assert.ok(
+    arm.refusals.some((r) => r.includes('averaging floor')),
+    `the refusal must name the floor: ${JSON.stringify(arm.refusals)}`
+  );
+});
+
+test('ROUTE 2 — an explicit one-write window on the shipped page is refused', () => {
+  const arm = armUnderEnv({ P0_ALLOC_WRITES: '1' });
+  assert.strictEqual(arm.boundaries, 24, 'the shipped page, unchanged');
+  assert.strictEqual(arm.writes, 1);
+  assert.ok(arm.headroom >= 0, 'and far under the budget, which is why it got through');
+  assert.ok(!arm.admissible);
+  assert.ok(arm.refusals.some((r) => r.includes('averaging floor')));
+});
+
+test('THE CONTROL — the shipped six-write arm is still admitted, so this is not vacuous', () => {
+  // A gate that refused everything would pass the two cases above and have
+  // adjudicated nothing. The arm the driver actually ships must go through.
+  const arm = armUnderEnv({});
+  assert.strictEqual(arm.boundaries, 24);
+  assert.strictEqual(arm.writes, ALLOC_MIN_WRITES, 'exactly at the floor');
+  assert.deepStrictEqual(arm.refusals, []);
+  assert.ok(arm.admissible);
+});
+
+test('the refusal names SHRINKING THE PAGE and never shrinking the window', () => {
+  // The one direction that must not be advised. A below-floor arm whose page
+  // admits fewer than six writes has no window repair at all: telling the
+  // operator "this page admits at most 2 writes" is telling them to configure
+  // the very shape being refused.
+  const arm = armUnderEnv({ P0_ROOTS: '50', P0_ALLOC_CELLS: '', P0_ALLOC_WRITES: '' });
+  const floor = arm.refusals.find((r) => r.includes('averaging floor'));
+  assert.match(floor, /P0_ROOTS/);
+  assert.match(floor, /P0_ALLOC_CELLS/);
+  assert.match(floor, /at most 25 boundaries/, 'the largest page that carries the floor');
+  assert.doesNotMatch(
+    floor,
+    /admits at most 2 writes \(P0_ALLOC_WRITES\)/,
+    'the window is not the knob when the window is what is wrong'
+  );
+});
+
+test('the floor follows ALLOC_MIN_WRITES rather than a number typed beside it', () => {
+  // If a later ruling moves the averaging floor, the preflight moves with it.
+  assert.ok(ALLOC_MIN_WRITES >= 1, 'a floor below one write would not be a floor');
+  const page = { roots: 1, cells: 4 }; // 4 boundaries: admits 44 writes, budget-wise
+  for (let w = 0; w < ALLOC_MIN_WRITES; w++) {
+    const s = allocArmSizing({ writes: w, ...page });
+    assert.ok(s.headroom >= 0, `w=${w} is inside the budget`);
+    assert.ok(!s.admissible, `w=${w} is below the floor and must refuse`);
+  }
+  const atFloor = allocArmSizing({ writes: ALLOC_MIN_WRITES, ...page });
+  assert.ok(atFloor.admissible, 'and exactly at the floor is admitted');
+});
+
+test('THE CHANGE ONLY EVER REFUSES MORE — admissible is a subset of the old bound', () => {
+  // The old predicate, verbatim: `writes >= 1 && boundaries >= 1 && headroom
+  // >= 0`. Enforcing the floor may only turn an admitted shape into a refused
+  // one, never the reverse, and that is checked exhaustively over the grid
+  // rather than argued.
+  let admitted = 0;
+  let newlyRefused = 0;
+  for (let writes = 0; writes <= 40; writes++) {
+    for (let cells = 0; cells <= 40; cells++) {
+      for (const roots of [0, 1, 4, 50]) {
+        const s = allocArmSizing({ writes, roots, cells });
+        const wasAdmissible = writes >= 1 && s.boundaries >= 1 && s.headroom >= 0;
+        if (s.admissible) {
+          admitted++;
+          assert.ok(wasAdmissible, `newly admissible at W=${writes} B=${s.boundaries}`);
+        } else if (wasAdmissible) {
+          newlyRefused++;
+          assert.ok(writes < ALLOC_MIN_WRITES, 'and only ever for want of averaging');
+        }
+      }
+    }
+  }
+  assert.ok(admitted > 0, 'the sweep must still admit something');
+  assert.ok(newlyRefused > 0, 'and must have refused something, or it changed nothing');
+});
+
+test('a refused arm says WHY, one reason per thing wrong with it', () => {
+  // Both wrong at once: 300 boundaries at one write is over the budget AND
+  // under the floor, and an operator who fixed only the one they were told
+  // about would come back to the other.
+  const both = allocArmSizing({ writes: 1, roots: 1, cells: 300 });
+  assert.strictEqual(both.refusals.length, 2, JSON.stringify(both.refusals));
+  assert.ok(both.refusals.some((r) => r.includes('averaging floor')));
+  assert.ok(both.refusals.some((r) => r.includes('masking budget')));
+  // A page with nothing on it has no per-boundary quantity, and none of the
+  // other terms mean anything: one reason, and it is that one.
+  const empty = allocArmSizing({ writes: 6, roots: 4, cells: 0 });
+  assert.strictEqual(empty.refusals.length, 1);
+  assert.match(empty.refusals[0], /no per-boundary quantity/);
+});
+
+test('`floorBoundaries` is the largest page that carries the averaging floor', () => {
+  const s = allocArmSizing({ writes: 6, roots: 4, cells: 6 });
+  assert.strictEqual(s.floorBoundaries, 25, '300000 / ((6+1) x 1655)');
+  assert.ok(
+    allocMaxWrites(s.floorBoundaries) >= ALLOC_MIN_WRITES,
+    'a page that size admits the floor'
+  );
+  assert.ok(
+    allocMaxWrites(s.floorBoundaries + 1) < ALLOC_MIN_WRITES,
+    'and one boundary more does not'
+  );
+  assert.ok(ALLOC_ARM.boundaries <= s.floorBoundaries, 'the shipped page is inside it');
 });
 
 // --- the plan the page is mounted from -------------------------------------
@@ -668,10 +839,25 @@ test('the RETENTION ladder is not moved by any of this', () => {
 test('the driver REFUSES a mis-sized arm before it launches a browser', () => {
   has(/if \(!ALLOC_ARM\.admissible\) \{/, 'the sizing refusal is an exit, not a warning');
   has(
-    /the allocation arm is configured outside the masking bound before anything is /,
+    /the allocation arm is refused by its own preflight before anything is measured/,
     'and it says so before a byte is measured'
   );
   has(/SHRINK THE MEASURED UNIT, DO NOT WIDEN THE BUDGET/, 'naming the repair, not the dial');
+  has(
+    /ALLOC_ARM\.refusals/,
+    'and the exit prints the reasons rather than one undifferentiated verdict'
+  );
+});
+
+test('the averaging floor is ENFORCED in the sizing, not merely derived from', () => {
+  // rf2-2rtt6.142. `ALLOC_MIN_WRITES` sized the default page and adjudicated
+  // nothing; the verdict admitted any window from one write up.
+  has(/if \(writes < ALLOC_MIN_WRITES\) \{/, 'the floor is a refusal in the sizing itself');
+  has(/admissible: refusals\.length === 0,/, 'and the verdict is the reasons, not a conjunction');
+  lacks(
+    /admissible: writes >= 1 && boundaries >= 1 && headroom >= 0,/,
+    'the old verdict licensed exactly the low-averaging shape the row rules out'
+  );
 });
 
 test('the window is DERIVED from the bound and the arm from the measured cost', () => {

--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -678,7 +678,12 @@ test('ROUTE 2 — an explicit one-write window on the shipped page is refused', 
   assert.strictEqual(arm.writes, 1);
   assert.ok(arm.headroom >= 0, 'and far under the budget, which is why it got through');
   assert.ok(!arm.admissible);
-  assert.ok(arm.refusals.some((r) => r.includes('averaging floor')));
+  const floor = arm.refusals.find((r) => r.includes('averaging floor'));
+  assert.ok(floor, JSON.stringify(arm.refusals));
+  // The page here is fine — it carries six writes — so the WINDOW is the knob
+  // and the refusal must say so rather than send the operator at the page.
+  assert.match(floor, /RAISE P0_ALLOC_WRITES to at least 6/);
+  assert.doesNotMatch(floor, /SHRINK THE PAGE/);
 });
 
 test('THE CONTROL — the shipped six-write arm is still admitted, so this is not vacuous', () => {
@@ -698,13 +703,13 @@ test('the refusal names SHRINKING THE PAGE and never shrinking the window', () =
   // the very shape being refused.
   const arm = armUnderEnv({ P0_ROOTS: '50', P0_ALLOC_CELLS: '', P0_ALLOC_WRITES: '' });
   const floor = arm.refusals.find((r) => r.includes('averaging floor'));
-  assert.match(floor, /P0_ROOTS/);
-  assert.match(floor, /P0_ALLOC_CELLS/);
+  assert.match(floor, /SHRINK THE PAGE/);
+  assert.match(floor, /P0_ROOTS \/ P0_ALLOC_CELLS/);
   assert.match(floor, /at most 25 boundaries/, 'the largest page that carries the floor');
   assert.doesNotMatch(
     floor,
-    /admits at most 2 writes \(P0_ALLOC_WRITES\)/,
-    'the window is not the knob when the window is what is wrong'
+    /P0_ALLOC_WRITES/,
+    'a page that cannot carry the floor must not have its window named at all'
   );
 });
 

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -1107,7 +1107,10 @@ const ALLOC_MASK_BUDGET_B = ALLOC_FALL_THRESHOLD_B / 2;
 //       the bottom would be refused rather than published.
 //   W   writes in one window. A window of one has no averaging in it, so the
 //       arm is sized to hold at least `ALLOC_MIN_WRITES` of them and then
-//       takes every further write the bound still admits.
+//       takes every further write the bound still admits — and the preflight
+//       REFUSES a window under that floor however it was configured, which
+//       the bound below cannot do for it (a small window is a small window,
+//       and the budget is a ceiling on size).
 //   B   boundaries on the page, = P0_ROOTS x cells-per-root.
 //
 //   rise ~ W.B.c and the largest single step is one write, ~B.c, so the
@@ -1150,6 +1153,18 @@ const ALLOC_B_PER_BOUNDARY_WRITE = 1655;
 // this counter at all — has been corroborated here as well as at the 30
 // writes `ALLOC_MASK_BUDGET_B` cites. A smaller control window is also a
 // further-under-budget one, which is the safe direction.
+//
+// IT IS A FLOOR AND NOT ONLY A DEFAULT (rf2-2rtt6.142). It sized the page
+// below and adjudicated nothing, so the preflight admitted any window from
+// one write up: `P0_ROOTS=50` derives a 50-boundary page whose largest legal
+// window is two writes, and `P0_ALLOC_WRITES=1` sets a one-write window on
+// the shipped page. Both sit far under the masking budget — that budget is a
+// ceiling on a window's SIZE and has nothing to say about how few writes are
+// averaged inside it — so both reached every publication path. One write is
+// exactly the configuration whose four fits came back at r² 0.75 / 0.28 /
+// 0.94 / 0.31, against the 0.98 floor this row publishes under.
+// `allocArmSizing` now refuses below this number rather than only deriving
+// from it.
 const ALLOC_MIN_WRITES = 6;
 
 // Boundaries per root — the MEASURED UNIT, and the reason this arm is a code
@@ -1186,13 +1201,82 @@ const ALLOC_WRITES = Number(
 // opt-in run of this driver to notice that an arm drifted out of range.
 //
 // Nothing here measures anything. `predictedWindowB` is `(W + 1).B.c`, the
-// left-hand side of the bound, and `admissible` is the bound itself.
+// left-hand side of the bound.
+//
+// `refusals` IS THE VERDICT, one entry per thing wrong with the arm, and
+// `admissible` is just "none of them" (rf2-2rtt6.142). One boolean was not
+// enough because the two ways an arm can be wrong want OPPOSITE repairs: a
+// window over the masking budget is repaired by shrinking it, and a window
+// under the averaging floor is repaired by shrinking the PAGE so a bigger one
+// fits. An arm can be both at once, and a refusal that named only the budget
+// would send an operator to `P0_ALLOC_WRITES` — i.e. to configure the very
+// shape being refused.
 function allocArmSizing({ writes, roots, cells, bytesPerBoundaryWrite = ALLOC_B_PER_BOUNDARY_WRITE }) {
   const boundaries = roots * cells;
   const predictedMaxStep = boundaries * bytesPerBoundaryWrite;
   const predictedRise = writes * predictedMaxStep;
   const predictedWindowB = predictedRise + predictedMaxStep;
   const headroom = ALLOC_MASK_BUDGET_B - predictedWindowB;
+  const maxWrites = allocMaxWrites(boundaries);
+  const maxBoundaries = Math.floor(ALLOC_MASK_BUDGET_B / ((writes + 1) * bytesPerBoundaryWrite));
+  // The largest page that still carries the averaging floor: `maxBoundaries`
+  // read at `ALLOC_MIN_WRITES` instead of at whatever this window happens to
+  // be. It is the number a below-floor arm has to be shrunk TO, so it is
+  // computed here rather than left for the reader to invert.
+  const floorBoundaries = Math.floor(
+    ALLOC_MASK_BUDGET_B / ((ALLOC_MIN_WRITES + 1) * bytesPerBoundaryWrite)
+  );
+
+  const refusals = [];
+  if (boundaries < 1) {
+    // No per-boundary quantity to publish, and none of the terms below mean
+    // anything on an empty page — it would otherwise sail under the budget on
+    // zero bytes.
+    refusals.push(
+      `a page of ${boundaries} boundaries (${roots} roots x ${cells} cells) has no ` +
+        `per-boundary quantity to publish: RAISE P0_ROOTS or P0_ALLOC_CELLS`
+    );
+  } else {
+    if (writes < ALLOC_MIN_WRITES) {
+      // Two different arms land here and they want opposite repairs. If the
+      // page still admits the floor then the window alone was set too small
+      // and the window is the knob. If it does not, the window is not the
+      // knob at all — and naming what such a page DOES admit would be naming
+      // a below-floor window, i.e. advising the shape being refused. So that
+      // branch names only the page.
+      const repair =
+        maxWrites >= ALLOC_MIN_WRITES
+          ? `This page admits ${maxWrites} writes: RAISE P0_ALLOC_WRITES to at least ` +
+            `${ALLOC_MIN_WRITES}, or unset it and take the window the page derives`
+          : `${boundaries} boundaries cannot carry a ${ALLOC_MIN_WRITES}-write window under ` +
+            `the ${ALLOC_MASK_BUDGET_B} B masking budget, so the WINDOW IS NOT THE KNOB: ` +
+            `SHRINK THE PAGE — lower P0_ROOTS / P0_ALLOC_CELLS to at most ` +
+            `${floorBoundaries} boundaries`;
+      refusals.push(
+        `a window of ${writes} write(s) is under the ${ALLOC_MIN_WRITES}-write averaging floor ` +
+          `(ALLOC_MIN_WRITES) and has too little in it to average: at one write per window this ` +
+          `row's four fits came back at r² 0.75 / 0.28 / 0.94 / 0.31, under its 0.98 floor. ` +
+          repair
+      );
+    }
+    if (headroom < 0) {
+      // Naming `maxWrites` here is only a repair while the page can still
+      // carry the floor; below it the window is not the knob, and saying so
+      // would advise exactly the shape the refusal above exists to stop.
+      const windowKnob =
+        maxWrites >= ALLOC_MIN_WRITES
+          ? `, and this page at most ${maxWrites} writes (P0_ALLOC_WRITES)`
+          : '';
+      refusals.push(
+        `${boundaries} boundaries x ${writes} writes predicts ${predictedWindowB} B of ` +
+          `rise+maxStep at the measured ${bytesPerBoundaryWrite} B/boundary/write, against the ` +
+          `${ALLOC_MASK_BUDGET_B} B masking budget. ` +
+          `SHRINK THE MEASURED UNIT, DO NOT WIDEN THE BUDGET: this window admits at most ` +
+          `${maxBoundaries} boundaries (P0_ROOTS x P0_ALLOC_CELLS)${windowKnob}`
+      );
+    }
+  }
+
   return {
     cells,
     roots,
@@ -1203,12 +1287,11 @@ function allocArmSizing({ writes, roots, cells, bytesPerBoundaryWrite = ALLOC_B_
     predictedMaxStep,
     predictedWindowB,
     headroom,
-    // A window with no work in it measures nothing, and a page with no
-    // boundaries on it has no per-boundary quantity to publish. Both would
-    // otherwise sail under the budget on zero bytes.
-    admissible: writes >= 1 && boundaries >= 1 && headroom >= 0,
-    maxWrites: allocMaxWrites(boundaries),
-    maxBoundaries: Math.floor(ALLOC_MASK_BUDGET_B / ((writes + 1) * bytesPerBoundaryWrite)),
+    refusals,
+    admissible: refusals.length === 0,
+    maxWrites,
+    maxBoundaries,
+    floorBoundaries,
   };
 }
 
@@ -1285,15 +1368,18 @@ async function allocRow(chromium) {
   // what the 2026-08-07 quiet-box run spent. It is a PREDICTION and not a
   // certificate: passing it licenses nothing, and `allocSteps` still reads
   // every window's own samples against the same budget on the way through.
+  //
+  // The averaging floor is the half that `allocSteps` can NEVER catch up on
+  // (rf2-2rtt6.142). A window under `ALLOC_MIN_WRITES` is not over the budget
+  // — it is comfortably under it — so nothing downstream refuses it, and the
+  // r² floor sees only a fit it has no averaging to make. This is the one
+  // gate that can say so, and it says so here.
   if (!ALLOC_ARM.admissible) {
     throw new Error(
-      `the allocation arm is configured outside the masking bound before anything is ` +
-        `measured: ${ALLOC_ARM.boundaries} boundaries (${ROOTS} roots x ${ALLOC_CELLS} cells) ` +
-        `x ${ALLOC_ARM.writes} writes predicts ${ALLOC_ARM.predictedWindowB} B of rise+maxStep ` +
-        `at the measured ${ALLOC_ARM.bytesPerBoundaryWrite} B/boundary/write, against the ` +
-        `${ALLOC_MASK_BUDGET_B} B budget. SHRINK THE MEASURED UNIT, DO NOT WIDEN THE BUDGET: ` +
-        `this page admits at most ${ALLOC_ARM.maxWrites} writes (P0_ALLOC_WRITES), and this ` +
-        `window at most ${ALLOC_ARM.maxBoundaries} boundaries (P0_ROOTS x P0_ALLOC_CELLS)`
+      `the allocation arm is refused by its own preflight before anything is measured — ` +
+        `${ALLOC_ARM.boundaries} boundaries (${ROOTS} roots x ${ALLOC_CELLS} cells) x ` +
+        `${ALLOC_ARM.writes} writes:\n` +
+        ALLOC_ARM.refusals.map((r) => `  - ${r}`).join('\n')
     );
   }
   const { browser, page, watch } = await newPage(chromium, '?mode=heap');
@@ -2201,6 +2287,7 @@ module.exports = {
   ladderPlan,
   allocArmSizing,
   allocMaxWrites,
+  ALLOC_MIN_WRITES,
   ALLOC_ARM,
 };
 


### PR DESCRIPTION
Closes rf2-2rtt6.142.

`ALLOC_MIN_WRITES = 6` is the allocation row's averaging floor, and until this
PR it **derived the default page and adjudicated nothing**. The preflight's
verdict was

```js
admissible: writes >= 1 && boundaries >= 1 && headroom >= 0,
```

which licenses every window from one write up. The masking budget cannot cover
for it: the budget is a ceiling on a window's **size**, and a window with too
few writes in it is comfortably *under* that ceiling. Nothing downstream
refuses such a window either — `allocSteps` reads the same budget, and the
0.98 r² floor sees only a fit it has no averaging to make.

## The two routes, reproduced

Both are pure derivations of the shipped env surface. No browser, no build, no
measurement — `require` the driver with an env set and read `ALLOC_ARM`.

**Before** (origin/main @ 4c5101ee3a):

| route | derives | admissible |
|---|---|---|
| `P0_ROOTS=50` | `{cells: 1, boundaries: 50, writes: 2, headroom: 51750}` | **true** |
| `P0_ALLOC_WRITES=1` | `{cells: 6, boundaries: 24, writes: 1, headroom: 220560}` | **true** |
| shipped defaults | `{cells: 6, boundaries: 24, writes: 6, headroom: 21960}` | true |

Route 1 needs no flag beyond the root count: the `ALLOC_CELLS` default floors
at one cell per root, so a large `P0_ROOTS` derives a page whose largest legal
window is below the floor. Both routes sail past every publication path, and a
one-write window is exactly the configuration whose four fits came back at
r² 0.75 / 0.28 / 0.94 / 0.31.

**After**:

| route | admissible | refusal |
|---|---|---|
| `P0_ROOTS=50` | **false** | `a window of 2 write(s) is under the 6-write averaging floor (ALLOC_MIN_WRITES) … 50 boundaries cannot carry a 6-write window under the 300000 B masking budget, so the WINDOW IS NOT THE KNOB: SHRINK THE PAGE — lower P0_ROOTS / P0_ALLOC_CELLS to at most 25 boundaries` |
| `P0_ALLOC_WRITES=1` | **false** | `a window of 1 write(s) is under the 6-write averaging floor (ALLOC_MIN_WRITES) … This page admits 6 writes: RAISE P0_ALLOC_WRITES to at least 6, or unset it and take the window the page derives` |
| shipped defaults | true | — |

## The shape of the repair

`allocArmSizing` now returns `refusals`, one entry per thing wrong with the
arm, and `admissible` is "none of them".

One boolean was not enough, because **the two ways an arm can be wrong want
opposite repairs**, and an arm can be both at once. Over the masking budget →
shrink the window. Under the averaging floor → raise the window if the page
still carries six, shrink the **page** if it cannot. A refusal that named only
the budget would have told the operator "this page admits at most 2 writes",
i.e. sent them to configure the very shape being refused — so the below-floor
branch on a page that cannot carry six names no window count at all.

`floorBoundaries` (= `maxBoundaries` read at `ALLOC_MIN_WRITES`) is the number
such an arm has to be shrunk *to*, so it is computed rather than left for the
reader to invert.

## Nothing previously refused became admissible

Stated, and established two ways.

1. **Exhaustively, in the test.** `THE CHANGE ONLY EVER REFUSES MORE —
   admissible is a subset of the old bound` sweeps W ∈ 0..40 × cells ∈ 0..40 ×
   roots ∈ {0, 1, 4, 50} — 6,724 shapes — and asserts for every one that
   `admissible ⟹ (writes >= 1 && boundaries >= 1 && headroom >= 0)`, the old
   predicate verbatim. It also asserts the sweep admits something (not
   vacuous), refuses something (not a no-op), and that every newly-refused
   shape is refused *only* for `writes < ALLOC_MIN_WRITES`.

2. **Structurally.** The refusal list is the old predicate's terms negated and
   unchanged, plus one new term. `boundaries < 1` and `headroom < 0` are
   verbatim; `writes < 1` is subsumed by `writes < ALLOC_MIN_WRITES` (6 ≥ 1,
   pinned by an assertion). Nothing was loosened, and no threshold moved.

**Deliberately untouched**: `ALLOC_FALL_THRESHOLD_B`, `ALLOC_MASK_BUDGET_B`,
the falling-step exit, the r² floor, `allocMaxWrites`, the `ALLOC_CELLS` /
`ALLOC_WRITES` derivations. The masking bound's soundness is under separate
live dispute (rf2-2rtt6.141) and is **not** cited as justification for anything
here — this change only ever refuses more, so it is safe whichever way that
ruling lands.

**No measurement was taken.** The allocation row was not run, no window was
opened, no number is published. Every case above is a derivation.

## The red-then-green proof

Committed in that order, so the refusal can be seen to refuse.

| commit | | `p0_ladder_structural.test.cjs` |
|---|---|---|
| origin/main | baseline | 41 passed, exit 0 |
| 53f43ecbe6 | tests only, driver untouched | **11/50 failed, exit 1** |
| 5a6479c8e3 | + the preflight change | **50 passed, exit 0** |

The 11 red: both reproduced routes, the six-write control (no `refusals` field
existed), the "shrink the page" wording, the floor-follows-the-constant check,
the subset sweep, the one-reason-per-fault check, `floorBoundaries`, and three
source-wiring pins.

One pre-existing test moved with the change — the one asserting that
`allocMaxWrites` inverts the bound exactly. It now drives on `headroom`, the
bound's own term, instead of on `admissible`, the whole preflight verdict. Its
60-boundary case admits only 2 writes, which the averaging floor now correctly
refuses; asserting on `headroom` states what that test was always about, and
states it more exactly.

## A note on sequencing

The bead carries a priority note added by rf2-2rtt6.138's measurement window:
sequence after rf2-2rtt6.139 and .140 are ruled on, since .140 measured that no
page of one boundary or more certifies the R=20 rung at six writes, so the
six-write floor may not survive as the right constraint. **Both are still
open**, and this PR was written anyway on the judgement that it is robust to
either ruling: the enforcement is written against `ALLOC_MIN_WRITES` and never
against `6`, so if a ruling moves the floor the preflight and its tests move
with it. The defect — a floor that adjudicates nothing — is wrong at any value.
Flagging it here so the reviewer can hold the PR if they disagree.

## Quality gates

All run foreground to completion from the worktree
`C:/Users/miket/code/re-frame2-worktrees/preflight-142`, each gate's
`gate root:` line checked against it.

| gate | exit |
|---|---|
| `node --check implementation/core/test/re_frame/bench/p0_run.cjs` | 0 |
| `node --check implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs` | 0 |
| `node implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs` | 0 — 50 passed (41 before) |
| `npm run test:script-helpers` (from `implementation/`) | 0 |
| `sh scripts/test-fast-pr.sh` | 0 — `gate root: /c/Users/miket/code/re-frame2-worktrees/preflight-142` |
| `npm run lint:js` (from repo root) | 0 |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | 0 — "No beads-database paths in this PR diff." |
