### PR TITLE
fix(hicasso): the decomposition fold checks the row's shape, not block one (rf2-e1tko)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -527,22 +527,37 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   const DECOMP_BLOCK = (n, layout, style, script) => ({
     n, task: layout + style + script, taskNet: 0, devtools: 0, script, style, layout, layoutCount: n, inPage: 0,
   });
+  // The plan names plumb too and the collector bumps every arm in it, so a
+  // faithful block carries plumb — laying nothing out and reading zeros, as it
+  // does in the committed data. rf2-e1tko made this load-bearing: completeness
+  // is measured against the row's DECLARED roster, so a fixture that omitted
+  // plumb from every block would itself be the truncation under test.
+  const DECOMP_PLUMB = () => ({
+    n: 10, task: 0.5, taskNet: 0, devtools: 0, script: 0.5, style: 0, layout: 0, layoutCount: 0, inPage: 0,
+  });
   const FIXTURE_DECOMP = [
     [
-      { floor: DECOMP_BLOCK(10, 8, 9, 0.8), 'ctl-2x': DECOMP_BLOCK(10, 20, 18, 2.0) },
-      { floor: DECOMP_BLOCK(10, 12, 11, 1.2), 'ctl-2x': DECOMP_BLOCK(10, 21, 19, 2.4) },
+      { plumb: DECOMP_PLUMB(), floor: DECOMP_BLOCK(10, 8, 9, 0.8), 'ctl-2x': DECOMP_BLOCK(10, 20, 18, 2.0) },
+      { plumb: DECOMP_PLUMB(), floor: DECOMP_BLOCK(10, 12, 11, 1.2), 'ctl-2x': DECOMP_BLOCK(10, 21, 19, 2.4) },
     ],
     [
-      { floor: DECOMP_BLOCK(10, 9, 10, 1.0), 'ctl-2x': DECOMP_BLOCK(10, 20.4, 18.5, 2.4) },
-      { floor: DECOMP_BLOCK(10, 11, 10, 1.0), 'ctl-2x': DECOMP_BLOCK(10, 21, 18.5, 2.4) },
+      { plumb: DECOMP_PLUMB(), floor: DECOMP_BLOCK(10, 9, 10, 1.0), 'ctl-2x': DECOMP_BLOCK(10, 20.4, 18.5, 2.4) },
+      { plumb: DECOMP_PLUMB(), floor: DECOMP_BLOCK(10, 11, 10, 1.0), 'ctl-2x': DECOMP_BLOCK(10, 21, 18.5, 2.4) },
     ],
   ];
   const CITED = { layout: 2.06, style: 1.85, script: 2.3 };
 
+  // What the row DECLARES itself to be: the arms its plan named and the
+  // dimensions its design ran. Both travel beside the split rather than out of
+  // it — `report` reads them from the row and the run's design, a reader of a
+  // written dataset from `row.armIds` and `data.design` — which is the whole
+  // point: evidence cannot be its own completeness check (rf2-e1tko).
+  const DECLARED = { armIds: ['plumb', 'floor', 'ctl-2x'], rounds: 2, blocks: 2 };
+
   const fixtureRow = (over = {}) => ({
     runId: 'reagent',
     rowId: 'feed',
-    armIds: ['plumb', 'floor', 'ctl-2x'],
+    armIds: DECLARED.armIds,
     canon: { floor: true },
     ctlPredicted: 1.9943,
     blocksTask: [[{ floor: [1, 2], 'ctl-2x': [2, 4] }]],
@@ -584,7 +599,7 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   t("the studio page's cited decomposition is recomputable from the file alone", () => {
     // The whole point of the bead: read the JSON, fold it, divide, and the
     // page's three numbers come back out. Nothing here reads the browser.
-    const fold = foldDecomposition(written().blocksDecomp);
+    const fold = foldDecomposition(written().blocksDecomp, DECLARED);
     const mean = (arm, k) => fold[arm][k] / fold[arm].n;
     for (const [k, cited] of Object.entries(CITED)) {
       assert.strictEqual(round4(mean('ctl-2x', k) / mean('floor', k)), cited, `${k} must recompute to ${cited}x`);
@@ -601,29 +616,42 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     // split the file never recorded, which is the defect wearing a fix's face.
     const legacy = written();
     delete legacy.blocksDecomp;
-    assert.throws(() => foldDecomposition(legacy.blocksDecomp), /NOT recomputable/);
-    assert.throws(() => foldDecomposition([]), /NOT recomputable/);
+    assert.throws(() => foldDecomposition(legacy.blocksDecomp, DECLARED), /NOT recomputable/);
+    assert.throws(() => foldDecomposition([], DECLARED), /NOT recomputable/);
   });
 
-  t('every committed census dataset either carries the split or refuses to answer', () => {
-    // Capture backfills nothing: the datasets on disk gain the fields on the
-    // next canonical run, not on this commit. Whatever is there, the rule is
-    // the same — a row with the split folds, a row without it refuses. There
-    // is no third answer, so this stays true across the re-run.
+  // Every committed census row, paired with the declared shape its own file
+  // carries. `row.armIds` and `data.design` are serialised independently of
+  // `blocksDecomp`, so reading them back measures the split against something
+  // other than itself — which is the whole of rf2-e1tko in one line.
+  const committedRows = () => {
     const dir = path.join(__dirname, 'data');
     const files = fs
       .readdirSync(dir)
       .filter((d) => d.startsWith('censusclock-'))
       .flatMap((d) => fs.readdirSync(path.join(dir, d)).filter((f) => f.endsWith('.json')).map((f) => path.join(dir, d, f)));
     assert.ok(files.length >= 2, 'expected the committed census datasets');
-    for (const f of files) {
-      for (const row of JSON.parse(fs.readFileSync(f, 'utf8')).rows) {
-        if (row.blocksDecomp) {
-          const fold = foldDecomposition(row.blocksDecomp);
-          assert.ok(Object.values(fold).every((a) => a.n > 0), `${f}: a stored split must fold to real counts`);
-        } else {
-          assert.throws(() => foldDecomposition(row.blocksDecomp), /NOT recomputable/, `${f}: must refuse, not answer`);
-        }
+    return files.flatMap((f) => {
+      const data = JSON.parse(fs.readFileSync(f, 'utf8'));
+      return data.rows.map((row) => ({
+        f,
+        row,
+        declared: { armIds: row.armIds, rounds: data.design.rounds, blocks: data.design.blocks },
+      }));
+    });
+  };
+
+  t('every committed census dataset either carries the split or refuses to answer', () => {
+    // Capture backfills nothing: the datasets on disk gain the fields on the
+    // next canonical run, not on this commit. Whatever is there, the rule is
+    // the same — a row with the split folds, a row without it refuses. There
+    // is no third answer, so this stays true across the re-run.
+    for (const { f, row, declared } of committedRows()) {
+      if (row.blocksDecomp) {
+        const fold = foldDecomposition(row.blocksDecomp, declared);
+        assert.ok(Object.values(fold).every((a) => a.n > 0), `${f}: a stored split must fold to real counts`);
+      } else {
+        assert.throws(() => foldDecomposition(row.blocksDecomp, declared), /NOT recomputable/, `${f}: must refuse, not answer`);
       }
     }
   });
@@ -658,11 +686,11 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     r.adjudication.ctl = { ok: true, measured: { mean: 1.9943 } };
     return r;
   };
-  const driveOn = (blocksDecomp) => {
+  const driveOn = (blocksDecomp, declared = DECLARED) => {
     const results = [];
     let failed = null;
     try {
-      foldDecomposition(blocksDecomp); // `report`'s first act on the row
+      foldDecomposition(blocksDecomp, declared); // `report`'s first act on the row
       results.push(summarisable()); // reached only if the fold ANSWERED
     } catch (e) {
       failed = e.message;
@@ -680,7 +708,13 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     // Each pin is one link of the chain the witnesses below assume. Newlines
     // are normalised because this tree is checked out with CRLF on Windows.
     const src = SRC.replace(/\r\n/g, '\n');
-    assert.match(src, /function report\(out\) \{\n {2}const \{[^}]*blocksDecomp[^}]*\} = out;\n {2}const decomposition = foldDecomposition\(blocksDecomp\);/);
+    // The second argument is pinned with the first: rf2-e1tko turns on WHERE
+    // the declared shape comes from, and `{ armIds, rounds: ROUNDS, blocks:
+    // BLOCKS }` is the row's plan and the run's design — never the blocks.
+    assert.match(
+      src,
+      /function report\(out\) \{\n {2}const \{[^}]*armIds[^}]*blocksDecomp[^}]*\} = out;\n {2}const decomposition = foldDecomposition\(blocksDecomp, \{ armIds, rounds: ROUNDS, blocks: BLOCKS \}\);/
+    );
     const drive = src.slice(src.indexOf('async function drive('));
     assert.match(drive, /const out = await runRow\(browser, runDef, rowId\);\n\s*const adj = report\(out\);\n\s*results\.push\(/);
     assert.match(drive, /\} catch \(e\) \{\n\s*failed = e\.message;/);
@@ -706,6 +740,21 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     assert.match(fold, /for \(const k of DECOMP_FIELDS\) acc\[k\] \+= a\[k\];/);
   });
 
+  t('the fold measures completeness against the DECLARED shape, never against block 1', () => {
+    // rf2-e1tko, and the reason it is a source pin as well as a witness: every
+    // state below is one the pre-repair fold ACCEPTED, and a rewrite that
+    // re-derived the roster from the evidence could go on rejecting them for
+    // some other reason while the anchor quietly returned. `roster`, the old
+    // block-1 variable, and the message that named it are both gone.
+    const fold = SRC.slice(SRC.indexOf('function foldDecomposition('), SRC.indexOf('function taredCell('));
+    assert.match(fold, /function foldDecomposition\(blocksDecomp, declared\)/);
+    assert.match(fold, /const expected = Array\.isArray\(shape\.armIds\) \? shape\.armIds\.slice\(\)\.sort\(\) : \[\];/);
+    assert.match(fold, /blocksDecomp\.length !== shape\.rounds/, 'the row must carry the rounds it declares');
+    assert.match(fold, /round\.length !== shape\.blocks/, 'each round must carry the blocks the row declares');
+    assert.match(fold, /for \(const arm of expected\)/, 'the per-field checks must run over the declared roster');
+    assert.ok(!/round 0, block 0 carries/.test(fold), 'block 1 is not the authority on what a whole row carries');
+  });
+
   t('the collector, the serialiser and the fold agree on ONE field list', () => {
     // Three readers over one constant; the split was dropped in the first place
     // because a field could be collected and then not be required anywhere.
@@ -723,12 +772,20 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     return c;
   };
 
-  // [what it is, the evidence, the phrase the refusal must carry, the side it must name]
+  // [what it is, the evidence, the phrase the refusal must carry, the side it
+  //  must name, and the shape the row DECLARES itself to be]
+  //
+  // The declared shape defaults to the fixture's own. The four degenerate
+  // arrays below are single-round, single-block by construction, so each is
+  // measured against a shape that matches its dimensions — otherwise the row
+  // count would refuse them first and the structural fault they stand for would
+  // never be reached.
+  const ONE = { armIds: DECLARED.armIds, rounds: 1, blocks: 1 };
   const PARTIAL = [
-    ['an outer array whose round has no blocks', [[]], 'carries no blocks', 'round 0'],
-    ['a round whose block has no arms', [[{}]], 'carries no arms', 'round 0, block 0'],
-    ['a round that is not an array at all', [null], 'carries no blocks', 'round 0'],
-    ['a block that is not a block of arms', [[[]]], 'is not a block of arms', 'round 0, block 0'],
+    ['an outer array whose round has no blocks', [[]], 'carries no blocks', 'round 0', ONE],
+    ['a round whose block has no arms', [[{}]], 'carries no arms', 'round 0, block 0', ONE],
+    ['a round that is not an array at all', [null], 'carries no blocks', 'round 0', ONE],
+    ['a block that is not a block of arms', [[[]]], 'is not a block of arms', 'round 0, block 0', ONE],
     ['a block that LOST an arm the other blocks carry', mutate((c) => delete c[1][0]['ctl-2x']), 'missing ctl-2x', 'round 1, block 0'],
     ['a block that grew an arm the row never planned', mutate((c) => (c[1][1].bogus = DECOMP_BLOCK(10, 1, 1, 1))), 'unexpected bogus', 'round 1, block 1'],
     ['an arm with no accumulator at all', mutate((c) => (c[0][0].floor = null)), 'carries no accumulator (null)', 'arm "floor"'],
@@ -740,10 +797,34 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     ['a negative renderer count', mutate((c) => (c[0][1].floor.layoutCount = -1)), 'field "layoutCount" is -1', 'round 0, block 1, arm "floor"'],
   ];
 
-  for (const [what, blocks, needle, side] of PARTIAL) {
+  // --- rf2-e1tko, merged-PR audit #7681: TRUNCATED evidence must refuse too ---
+  //
+  // The three shapes the audit drove through the landed fold and watched it
+  // ACCEPT — each returning internally consistent survivors and a perfectly
+  // plausible aggregate, which is the whole danger. They passed because
+  // completeness was measured against the first surviving block, and block 1
+  // cannot report a round dropped after it, a sibling block that was never
+  // stored, or an arm it has lost itself. The third is the sharp one: uniform
+  // loss walks straight past a block-to-block roster check, so the check written
+  // to catch a lost arm was blind to an arm lost everywhere. The row's declared
+  // shape sees all three, which is why it is now the anchor.
+  const TRUNCATED = [
+    ['a row whose FINAL ROUND was dropped', mutate((c) => c.pop()), 'carries 1 round where the row declares 2', "the row's shape"],
+    ['a round that LOST a block', mutate((c) => c[1].splice(0, 1)), 'carries 1 block where the row declares 2', 'round 1'],
+    [
+      'an arm removed from EVERY block, which block-to-block agreement cannot see',
+      mutate((c) => {
+        for (const rd of c) for (const b of rd) delete b['ctl-2x'];
+      }),
+      'missing ctl-2x',
+      'round 0, block 0',
+    ],
+  ];
+
+  for (const [what, blocks, needle, side, declared = DECLARED] of PARTIAL.concat(TRUNCATED)) {
     t(`${what} is refused, and the refusal names it`, () => {
-      assert.throws(() => foldDecomposition(blocks), /not valid evidence/, 'this state must not fold');
-      const d = driveOn(blocks);
+      assert.throws(() => foldDecomposition(blocks, declared), /not valid evidence/, 'this state must not fold');
+      const d = driveOn(blocks, declared);
       assert.notStrictEqual(d.code, 0, 'a refused row must reach a NON-ZERO driver outcome');
       assert.strictEqual(d.wrote, false, 'a refused row must not be written at all');
       assert.strictEqual(d.canonical, false, 'and the destination must not be the published set');
@@ -764,32 +845,47 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     const stripped = mutate((c) => {
       for (const k of ['task', 'taskNet', 'devtools', 'script', 'layoutCount', 'inPage']) delete c[0][0]['ctl-2x'][k];
     });
-    assert.throws(() => foldDecomposition(stripped), /not valid evidence/);
+    assert.throws(() => foldDecomposition(stripped, DECLARED), /not valid evidence/);
     const nulled = mutate((c) => (c[0][0]['ctl-2x'].script = null));
-    assert.throws(() => foldDecomposition(nulled), /field "script" is null/);
+    assert.throws(() => foldDecomposition(nulled, DECLARED), /field "script" is null/);
     assert.strictEqual(driveOn(nulled).code, 1, 'the run must exit non-zero, not publish a script ratio of 0');
   });
 
-  t("a stored split must agree with the row's own arm roster", () => {
-    // The blocks and `armIds` are serialised independently, so their agreement
-    // is a real check on the file rather than a restatement of it — and it is
-    // the one case block-to-block consistency alone cannot see: an arm absent
-    // from EVERY block folds to a roster the file's own header contradicts.
-    const dir = path.join(__dirname, 'data');
-    const files = fs
-      .readdirSync(dir)
-      .filter((d) => d.startsWith('censusclock-'))
-      .flatMap((d) => fs.readdirSync(path.join(dir, d)).filter((f) => f.endsWith('.json')).map((f) => path.join(dir, d, f)));
-    for (const f of files) {
-      for (const row of JSON.parse(fs.readFileSync(f, 'utf8')).rows) {
-        if (!row.blocksDecomp) continue;
-        assert.deepStrictEqual(
-          Object.keys(foldDecomposition(row.blocksDecomp)).sort(),
-          row.armIds.slice().sort(),
-          `${f} / ${row.rowId}: the stored split covers a different arm set than the row claims`
-        );
-      }
+  t('a fold offered no declared shape refuses rather than anchoring to the evidence', () => {
+    // The fence around rf2-e1tko. A shape argument that could be omitted, or
+    // quietly filled in from block 1, would be the defect with an extra
+    // parameter — so the whole evidence, folded with nothing to measure it
+    // against, must refuse exactly as a truncated row does.
+    for (const bad of [undefined, {}, { armIds: [], rounds: 2, blocks: 2 }, { armIds: DECLARED.armIds, rounds: 0, blocks: 2 }]) {
+      assert.throws(() => foldDecomposition(FIXTURE_DECOMP, bad), /DECLARED shape/, `${JSON.stringify(bad)} must not fold`);
     }
+    // `null` rather than `undefined`, which `driveOn`'s own default would fill.
+    const d = driveOn(FIXTURE_DECOMP, null);
+    assert.notStrictEqual(d.code, 0);
+    assert.strictEqual(d.wrote, false);
+    assert.strictEqual(d.canonical, false);
+  });
+
+  t("a stored split must match the row's own declared shape, dimensions included", () => {
+    // The counterweight to the tightening above: a rule that refuses a dropped
+    // round, a lost block and a uniformly-missing arm must still accept the real
+    // thing unchanged, or it is over-tight rather than fail-closed. `armIds` and
+    // `design` are serialised independently of `blocksDecomp`, so this measures
+    // the file against its own header rather than restating it.
+    let checked = 0;
+    for (const { f, row, declared } of committedRows()) {
+      if (!row.blocksDecomp) continue;
+      const where = `${f} / ${row.rowId}`;
+      assert.strictEqual(row.blocksDecomp.length, declared.rounds, `${where}: stored rounds must be the declared depth`);
+      for (const rd of row.blocksDecomp) assert.strictEqual(rd.length, declared.blocks, `${where}: stored blocks must be the declared width`);
+      assert.deepStrictEqual(
+        Object.keys(foldDecomposition(row.blocksDecomp, declared)).sort(),
+        declared.armIds.slice().sort(),
+        `${where}: the stored split covers a different arm set than the row claims`
+      );
+      checked += 1;
+    }
+    assert.ok(checked >= 3, 'expected the committed rows that carry the split');
   });
 }
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
@@ -635,8 +635,6 @@ async function runRow(browser, runDef, rowId) {
  * the repair is to REQUIRE the shape rather than to default it:
  *
  *   - every round carries at least one block, and every block at least one arm;
- *   - every block carries the same arm roster as the row's first block, so a
- *     block that dropped an arm cannot be summed against blocks that kept it;
  *   - every arm carries every one of `DECOMP_FIELDS`, each a FINITE number —
  *     absent, `null`, `undefined` and `NaN` are refusals, not zeros;
  *   - `n` is positive (a block that took no samples is not evidence) and
@@ -646,12 +644,40 @@ async function runRow(browser, runDef, rowId) {
  * out and reads 0, and `taskNet` subtracts the devtools window so it may read
  * below zero. The refusal names the round, the block, the arm and the field, so
  * a reader can go to the offending side of the ratio and see what is wrong.
+ *
+ * AND IT MEASURES COMPLETENESS AGAINST THE ROW'S DECLARED SHAPE, not against
+ * the evidence itself (merged-PR audit #7681, rf2-e1tko). That landing required
+ * "the same arm roster as the row's FIRST BLOCK" and counted no rounds or
+ * blocks at all, so the evidence certified itself: a row with its final round
+ * removed, a row with one block removed, and a row with an arm removed from
+ * EVERY block were all accepted, each folding to internally consistent
+ * survivors and a plausible aggregate. The third is the sharp one — a roster
+ * read off block 1 cannot see an arm that block 1 has also lost, so uniform
+ * loss walks straight past the check written to catch it.
+ *
+ * So `declared` is REQUIRED, and it is the row's own account of itself: the
+ * `armIds` its plan named and the `rounds` x `blocks` its design ran. Both are
+ * carried beside the split rather than derived from it — `report` reads them
+ * from the row and the run's design, a reader of a written dataset from
+ * `row.armIds` and `data.design`. Passing the stored blocks back in under a new
+ * name would be this defect with extra steps, so a caller that offers no
+ * declared shape gets a refusal rather than a fold.
  */
-function foldDecomposition(blocksDecomp) {
+function foldDecomposition(blocksDecomp, declared) {
   if (!Array.isArray(blocksDecomp) || blocksDecomp.length === 0) {
     throw new Error(
       'this row carries no per-block decomposition: it predates rf2-jo60g, so the ' +
         'Script/Layout/RecalcStyle split is NOT recomputable from it and may not be quoted'
+    );
+  }
+  const shape = declared || {};
+  const expected = Array.isArray(shape.armIds) ? shape.armIds.slice().sort() : [];
+  if (expected.length === 0 || !(shape.rounds > 0) || !(shape.blocks > 0)) {
+    throw new Error(
+      "foldDecomposition needs the row's DECLARED shape — {armIds, rounds, blocks} — to measure " +
+        'completeness against. Anchoring to the stored blocks instead lets a truncated row certify ' +
+        'itself: that is what accepted a removed round, a removed block, and an arm removed from ' +
+        'every block (rf2-e1tko).'
     );
   }
   const describe = (v) =>
@@ -669,34 +695,38 @@ function foldDecomposition(blocksDecomp) {
     );
   };
 
-  let roster = null; // the arms of round 0, block 0 — every block must carry them
+  // "5 rounds are stored where the row declares 6 — 1 missing", in one voice for
+  // both dimensions, because a reader wants the same sentence either way.
+  const counted = (stored, want, unit) =>
+    `carries ${stored} ${unit}${stored === 1 ? '' : 's'} where the row declares ${want} — ` +
+    `${Math.abs(want - stored)} ${stored < want ? 'missing' : 'unexpected'}`;
+
+  if (blocksDecomp.length !== shape.rounds) refuse("the row's shape", counted(blocksDecomp.length, shape.rounds, 'round'));
+
   const out = {};
   for (let r = 0; r < blocksDecomp.length; r++) {
     const round = blocksDecomp[r];
     if (!Array.isArray(round) || round.length === 0) {
       refuse(`round ${r}`, `carries no blocks (${describe(round)})`);
     }
+    if (round.length !== shape.blocks) refuse(`round ${r}`, counted(round.length, shape.blocks, 'block'));
     for (let b = 0; b < round.length; b++) {
       const blk = round[b];
       const at = `round ${r}, block ${b}`;
       if (!blk || typeof blk !== 'object' || Array.isArray(blk)) refuse(at, `is not a block of arms (${describe(blk)})`);
       const here = Object.keys(blk).sort();
       if (here.length === 0) refuse(at, 'carries no arms — an empty block measured nothing');
-      if (roster === null) {
-        roster = here;
-      } else {
-        const missing = roster.filter((a) => !here.includes(a));
-        const extra = here.filter((a) => !roster.includes(a));
-        if (missing.length || extra.length) {
-          refuse(
-            at,
-            `carries arms [${here.join(', ')}] where round 0, block 0 carries [${roster.join(', ')}]` +
-              `${missing.length ? ` — missing ${missing.join(', ')}` : ''}` +
-              `${extra.length ? ` — unexpected ${extra.join(', ')}` : ''}`
-          );
-        }
+      const missing = expected.filter((a) => !here.includes(a));
+      const extra = here.filter((a) => !expected.includes(a));
+      if (missing.length || extra.length) {
+        refuse(
+          at,
+          `carries arms [${here.join(', ')}] where the row declares [${expected.join(', ')}]` +
+            `${missing.length ? ` — missing ${missing.join(', ')}` : ''}` +
+            `${extra.length ? ` — unexpected ${extra.join(', ')}` : ''}`
+        );
       }
-      for (const arm of roster) {
+      for (const arm of expected) {
         const a = blk[arm];
         const side = `${at}, arm "${arm}"`;
         if (!a || typeof a !== 'object' || Array.isArray(a)) refuse(side, `carries no accumulator (${describe(a)})`);
@@ -734,7 +764,7 @@ function perBlock(blocks, f) {
 
 function report(out) {
   const { runId, rowId, armIds, canon, ctlPredicted, blocksTask, blocksNet, blocksInPage, blocksDecomp, samplesTask, samplesNet, tally, runtime, granularity } = out;
-  const decomposition = foldDecomposition(blocksDecomp);
+  const decomposition = foldDecomposition(blocksDecomp, { armIds, rounds: ROUNDS, blocks: BLOCKS });
   const stamp = STAMP[rowId];
 
   console.log(`\n;; ==== RUN ${runId} — ROW ${rowId} ====`);


### PR DESCRIPTION
Closes rf2-e1tko. The finding is the merged-PR audit of #7681, recorded on rf2-jo60g and adjudicated by the mayor on 2026-08-08 10:45 AUSEST: that bead's ruling settled the doc half and said the code half was done, and the audit sitting above it had already named one remaining code gap.

## The defect

`foldDecomposition` measured completeness against the evidence rather than against the shape the row declares. Its own docstring named the anchor — *"every block carries the same arm roster as **the row's first block**"* — and it counted no rounds and no blocks at all. So a truncated row certified itself. Three shapes passed that must not, each folding to internally consistent survivors and a perfectly plausible aggregate:

1. the final round removed;
2. one block removed from a round;
3. an arm removed from **every** block.

The third is the sharp one. A roster read off block 1 cannot see an arm block 1 has also lost, so uniform loss walks straight past the check written to catch a lost arm.

Reproduced on `origin/main` before anything was changed, as a pure derivation over the committed `censusclock-jv36i/uix.json` (declared 6 rounds x 3 blocks; `armIds` includes `uix`). No browser, no measurement, no census run — the module is requirable under its `require.main` guard.

```
-- whole evidence (control) --
ACCEPTED  untouched  -> arms [ctl-2x, floor, hicasso, plumb, uix] n={...:180}

-- the three shapes --
ACCEPTED  1. the FINAL ROUND removed          -> arms [ctl-2x, floor, hicasso, plumb, uix] n={...:150}
ACCEPTED  2. one BLOCK removed from round 2   -> arms [ctl-2x, floor, hicasso, plumb, uix] n={...:170}
ACCEPTED  3. "uix" removed from EVERY block   -> arms [ctl-2x, floor, hicasso, plumb]      n={...:180}
```

This is the exact mechanism that made the cited `layout 2.06x / style 1.85x / script 2.3x` split unrecomputable in the first place: evidence that looked complete and was not. The fold is the last thing standing between a truncated dataset and a published ratio.

## The repair

Completeness is now measured against the **row's declared shape** — the `armIds` its plan named and the `rounds` x `blocks` its design ran — and never against whatever block 1 happens to contain.

**Where the declared shape comes from, since inventing one would have been the defect with extra steps.** Both terms already exist beside the split and are serialised independently of it. `report` reads the row's own `armIds` off `out` and the run's design off `ROUNDS` / `BLOCKS`; a reader of a written dataset takes `row.armIds` and `data.design`. Nothing new is stored and no new source of truth is created.

The argument is required. A fold offered nothing to measure against refuses rather than falling back to the blocks — an optional shape, or one quietly filled in from block 1, would leave the defect reachable behind a parameter.

Refusals name what is missing, in the idiom PR #7681 landed an hour earlier in this same function (`refuse(where, what)`, one voice, the offending side named):

```
... not valid evidence — the row's shape: carries 5 rounds where the row declares 6 — 1 missing
... not valid evidence — round 1: carries 2 blocks where the row declares 3 — 1 missing
... not valid evidence — round 0, block 0: carries arms [ctl-2x, floor, hicasso, plumb]
    where the row declares [ctl-2x, floor, hicasso, plumb, uix] — missing uix
```

**No schema validator, per the ruling.** The change is one required argument, two count comparisons, and one roster comparison that moved its anchor. No new layer, no new abstraction, no framework. The no-blocks refusal, the per-field present-and-finite checks, `n > 0` and `layoutCount >= 0` are untouched.

## Nothing previously refused became acceptable

Established three ways.

**By construction.** Every check the diff adds is a new refusal. The only check that *changed* is the roster one, and the declared anchor strictly contains the old block-1 anchor: if every block equals the declared roster then every block equals every other block, so any row the old rule refused on roster grounds the new rule refuses too. The per-field loop still runs over exactly the arms each block carries, because block keys are now required to equal the declared roster.

**By the suite.** All thirteen pre-existing refusal witnesses from PR #7681 are green unchanged, each still refusing with the same phrase and naming the same side. Nothing was loosened and no assertion was relaxed.

**By differential.** 20,000 randomly generated nested structures (half whole by construction, half freely damaged) crossed with 27 declared shapes = 540,000 pairs, each judged by `origin/main`'s fold and by this one:

```
structures 20000 (old refused 9798, old accepted 10202); pairs 540000
pairs the OLD accepted and the NEW refuses (the repair): 270573
pairs both accept: 4881
pairs where the OLD fold refused and the NEW one accepted: 0
```

Zero. And the 4,881 both-accept pairs show the new rule is not vacuously refusing everything.

## Witnesses: 246 -> 251, each red before and green after

Every fixture is built in-test. There is no committed dataset for any negative case, no browser, and no measurement.

Three new refusal witnesses, one per shape, each driven through `drive`'s own composition on the real exported functions to a **non-zero driver outcome with `wrote === false` and `destination().canonical === false`** — the acceptance the bead names:

- `a row whose FINAL ROUND was dropped`
- `a round that LOST a block`
- `an arm removed from EVERY block, which block-to-block agreement cannot see`

Plus `a fold offered no declared shape refuses rather than anchoring to the evidence`, and a source pin holding the anchor itself (`the fold measures completeness against the DECLARED shape, never against block 1`), because a rewrite could go on rejecting the three shapes for some other reason while the block-1 anchor quietly returned.

**RED BEFORE / GREEN AFTER.** With `origin/main`'s `census_clock_run.cjs` restored under this PR's test file, `6/251 failed`, exit 1 — the three shapes (`Missing expected exception: this state must not fold`), the no-declared-shape witness, and the two source pins:

```
FAIL  ... the reconstruction above IS `drive`'s composition, and stays that way
FAIL  ... the fold measures completeness against the DECLARED shape, never against block 1
FAIL  ... a row whose FINAL ROUND was dropped is refused, and the refusal names it
FAIL  ... a round that LOST a block is refused, and the refusal names it
FAIL  ... an arm removed from EVERY block, which block-to-block agreement cannot see is refused, ...
FAIL  ... a fold offered no declared shape refuses rather than anchoring to the evidence
clock_exit_path.test.cjs: 6/251 failed
```

Restoring this PR's fold: `251 passed`, exit 0.

**The load-bearing case is preserved.** `the studio page's cited decomposition is recomputable from the file alone` still recomputes `2.06x / 1.85x / 2.3x` from serialised JSON alone, with per-block sums that differ so a fold reading one block cannot pass. Its fixture gained `plumb` in every block — the plan names plumb and the collector bumps every arm in it, so a faithful fixture carries it; a fixture that omitted plumb from every block would itself be shape 3.

**Real evidence is still accepted unchanged.** `censusclock-jv36i` (all six rows across both files) folds exactly as before: stored 6 x 3 against a declared 6 x 3, rosters identical to `armIds`. The committed-dataset witness now checks stored dimensions against `data.design` as well as the roster, so it would catch an over-tight rule against the real thing.

**Two pre-existing tests changed, both because the composition they pin changed.** The `report` source pin now pins the second argument as well as the first — `foldDecomposition(blocksDecomp, { armIds, rounds: ROUNDS, blocks: BLOCKS })` — which is precisely the pin that holds the declared shape to the row's plan and the run's design rather than to the blocks. And `a stored split must agree with the row's own arm roster` became `a stored split must match the row's own declared shape, dimensions included`: the roster agreement it asserted from outside is now the fold's own rule, so it earns its place by checking the dimensions too.

## Quality gates

Foreground, to completion, never piped. Each gate's `gate root:` was checked against this worktree. Exit codes as reported by the runner:

| gate | exit |
| --- | --- |
| `node --check` on `shapes/census_clock_run.cjs` | 0 |
| `node --check` on `clock_exit_path.test.cjs` | 0 |
| `node .../clock_exit_path.test.cjs` — baseline on `origin/main` | 0 (**246 passed**) |
| `node .../clock_exit_path.test.cjs` — this branch | 0 (**251 passed**) |
| `node .../clock_exit_path.test.cjs` — mutation proof, main's fold restored | 1 (**6/251 failed**) |
| `npm run test:script-helpers` (from `implementation/`) | 0 |
| `sh scripts/test-fast-pr.sh` | 0 (`PASS fast PR spine`) |
| `npm run lint:js` (from repo root) | 0 |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | 0 (`No beads-database paths in this PR diff.`) |

`sh scripts/test-fast-pr.sh` printed `gate root: /c/Users/miket/code/re-frame2-worktrees/foldshape-e1tko`. A fresh worktree had no `node_modules`; junctions to the mayor checkout's real ones were provided for the gates and the **links** removed as the last act before reporting. Mayor canaries re-verified unchanged afterwards: `node_modules` 59, `implementation/node_modules` 101, `tools/mcp-conformance/node_modules` 92.

**No measurement was taken.** The census driver was never run and no figure was restated, recomputed or republished. The measurement lane is stood down for the P2 sitting; every case here is synthetic.

## What this does not claim

The split still becomes recomputable on the next canonical census run, whenever one is taken for its own reasons. This PR does not produce one and does not change what any dataset on disk contains. It changes what the fold will accept when that run happens.
