### PR TITLE
chore: pin the beads export to LF so it stops churning on Windows (rf2-gsjfr)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -56,3 +56,13 @@ skills/re-frame2-ui/references/ui-context.md text eol=lf
 # (core.autocrlf=true) checkout would CRLF-rewrite them and a reader there
 # would compute a different hash from the one the page names. Pin LF.
 implementation/freehand/test/re_frame/bench/hicasso/data/jsfb-rguy1/*.json text eol=lf
+
+# The beads tracker export (rf2-gsjfr). `bd` rewrites .beads/issues.jsonl with
+# LF endings on every invocation, so an unpinned Windows (core.autocrlf=true)
+# checkout CRLF-rewrites it straight back and the file never settles against
+# what the next export writes. A perpetually-dirty tracker export is the state
+# CLAUDE.md's beads-durability section documents as aborting `git pull` and
+# silently freezing HEAD at a stale base — and the `git checkout -- .beads` that
+# clears it reverts any `bd close` made in the same tick. Pin LF so the
+# checked-out bytes are the bytes `bd` writes.
+.beads/issues.jsonl text eol=lf


### PR DESCRIPTION
Closes rf2-gsjfr.

`bd` rewrites `.beads/issues.jsonl` with LF endings on every invocation, but the
file carried no EOL pin. On a Windows `core.autocrlf=true` checkout git rewrote
it straight back to CRLF, so the tracker export never settled against what the
next `bd` write produced, and every `bd` run emitted `warning: in the working
copy of '.beads/issues.jsonl', LF will be replaced by CRLF the next time Git
touches it`.

That matters more than a stray warning. A perpetually-dirty tracker export is
exactly the state `CLAUDE.md`'s beads-durability section documents as aborting
`git pull` ("local changes would be overwritten") and silently freezing HEAD at
a stale base — and the `git reset` + `git checkout -- .beads` the mayor loop
pays before every pull to clear it is itself the hazard, because a checkout of
this file within a tick of a `bd close` reverts the close. That cost real closes
on 2026-08-07.

One line, beside the pins `.gitattributes` already carries for the same reason
on the git-hook sources (rf2-ujhpf), the playground bundles (rf2-ee38b.22), the
generated manifests (rf2-3nbl5.2, rf2-sofwv) and the retained jsfb evidence
(rf2-rguy1):

```
.beads/issues.jsonl text eol=lf
```

Nothing else changed. `.beads/` contents are untouched: this branch carries no
tracker state.

## Proof

Measured in this worktree, `core.autocrlf=true` confirmed. CR bytes counted
mechanically with `node` reading the file as a buffer — not by eye, and not with
MSYS `grep -c $'\r'`, which has misreported CR counts on this box.

**Before the pin** — `git check-attr text eol -- .beads/issues.jsonl` reported
`text: unspecified`, `eol: unspecified`. Round-trip (`rm` the file, then
`git checkout -- .beads/issues.jsonl`):

```
bytes=14236505  CR=3297  LF=3297      <- CRLF throughout: one CR per row
$ git status --short .beads
(clean — git's clean filter hides the CRLF working copy, so the damage is
 invisible to status and only surfaces as the churn described above)
```

**After the pin** — `git check-attr` now reports `text: set`, `eol: lf`. Same
round-trip, `rm` + `git checkout`:

```
bytes=14233208  CR=0  LF=3297  CRLF-pairs=0
$ git status --short
(clean — whole tree)
```

The byte delta corroborates the count exactly: 14236505 − 14233208 = **3297**,
precisely the CR bytes removed. **CR count: 3297 → 0.**

**A `bd`-shaped write no longer dirties it.** The bead's scope fence forbids
running `bd` on a worker branch, so the same git path `bd` uses was exercised
directly: rewrite the export bytes (bumping mtime so git re-runs the filter
rather than trusting its stat cache), then `git add` the file the way `bd`
auto-stages it.

```
rewrote 14233208 bytes, mtime bumped
$ git add .beads/issues.jsonl
(exit 0, no "LF will be replaced by CRLF" warning)
$ git diff --cached --numstat
(empty — nothing staged)
$ git status --short
(clean)
```

**`--renormalize` produced no `.beads` diff.** `git add --renormalize
.beads/issues.jsonl` was run after applying the pin, as the pin requires; the
index blob was already LF, so the clean filter was a no-op on content and
`git diff --cached --numstat -- .beads/` came back empty. The commit is
`.gitattributes` alone, one file, +10 lines.

## Quality gates

Run from this worktree; each gate's `gate root:` line names
`/c/Users/miket/code/re-frame2-worktrees/eolpin-gsjfr`. Foreground to
completion, never piped.

| Gate | Exit |
| --- | --- |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | **0** — "No beads-database paths in this PR diff." |
| `sh scripts/test-fast-pr.sh` | **0** |
| `npm run lint:js` | **0** |

The boundary gate is the one that matters most here, the change being adjacent
to the beads tree: it confirms no beads-database path rides along on this branch.
It was run twice — once before the spine and once after — and passed both times.

The spine's first run exited 1 on `CLJS node integration` with
`compile-node-test: could not resolve shadow-cljs: Cannot find module
'shadow-cljs/cli/runner.js'`. That was a bare worktree with no `node_modules` at
all, not a defect in this change — a `.gitattributes` line cannot affect module
resolution. The worktree's `node_modules` were junctioned to the primary
checkout's and the **whole spine re-run from scratch to exit 0**; the junctions
were then removed link-first, with the primary checkout's `node_modules` counts
re-verified intact afterwards. Both runs' `gate root:` line named this worktree.

Note the spine log prints `ok … → FAILED` lines from its own negative-test
harness confirming its mutations fail correctly; those are passes.

### Not touched

`origin/main` advanced by one `chore(beads): checkpoint` commit while this was in
flight, so a raw `git diff origin/main` shows a `.beads/issues.jsonl` line that
did not come from here. The PR diff computed from the merge-base is
`.gitattributes` alone, and the boundary gate agrees.
