### PR TITLE
fix(hicasso): retire the three-point gate for a calibrated check standard (rf2-8a746)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_app.cljs
@@ -243,14 +243,40 @@
    :unmount  (fn [root] (.unmount root))})
 
 ;; ---------------------------------------------------------------------------
-;; THE THREE-POINT CONTROL — the one that differences the constant away
+;; THE THREE-POINT STATISTIC — DIAGNOSTIC, NON-GATING (rf2-8a746)
 ;; ---------------------------------------------------------------------------
 
 (def ^:private ctl3-dirty
-  "The dirty-set sizes of the three-point control's arms, at FIXED page
+  "The dirty-set sizes of the three-point statistic's arms, at FIXED page
   size. The floor supplies a fourth point at 300 for free, because a floor
   sample rewrites every one of its cells with a value that is fresh on
   every operation.
+
+  ## IT IS NO LONGER A CONTROL, AND THE ARMS STAY (rf2-8a746)
+
+  These arms fed a difference-of-differences CONTROL that gated every bulk
+  row. It refused 42 of 42 bulk row-runs across two independent quiet-box
+  ensembles, and the 2026-08-07 ruling retired it as a gate — not re-sited,
+  not re-tried. The diagnosis is arithmetic and both halves are
+  independently fatal: the prediction `(2D - eps)/(D - eps)` holds only if
+  `T` is affine in `d` and it is not, so the statistic's true centre sits
+  2.6% ABOVE the value at which it refuses; and `T(D) - T(eps)` is ~1.25 ms
+  carrying ~0.6 ms of dispersion, about 2 sigma from zero, which is the
+  classic Fieller ratio problem. Re-siting at 100/200/300 fixes the centre
+  and halves the denominator. Both available sitings fail; the conditioning
+  arithmetic says any siting must.
+
+  WHAT GATES A BULK ROW NOW is a level-denominated, empirically calibrated,
+  versioned CHECK STANDARD on `ctl-2x / floor` —
+  `clock_check_standard.json`, applied by `clock_check_standard.cjs`.
+
+  WHY THE ARMS ARE STILL BUILT. The same statistic on `LayoutDuration` over
+  the identical blocks is healthy — 1.9681/1.9801, flat marginals, no
+  negative difference in 756 blocks — which localises the failure to the
+  non-affine non-layout clock rather than to the quotient machinery, and
+  makes the pair a live diagnostic of the PAGE's dirty-set shape. The
+  driver prints it labelled non-gating. Removing the arms would delete the
+  only reading this instrument has of that shape.
 
   ## Why the control this replaces cannot be repaired by widening it
 
@@ -318,15 +344,21 @@
   three-point statistic reading 2.14x on the layout counter — so the
   workload's LAYOUT half is affine and something else is not.
 
-  The mechanism is PAINT, and it saturates. A commit that dirties cells
+  WHAT IS ESTABLISHED, AND WHAT IS ONLY INFERRED (rf2-8a746). Established,
+  on both committed ensembles: the concave term is in the NON-LAYOUT half,
+  it collapses 7.1 -> 1.8 µs per dirty cell, and it saturates below
+  d = 100. That is enough to kill the control, because it is not a constant
+  — it is a saturating function of the very axis the statistic varies, and
+  no amount of differencing removes one.
+
+  WHICH non-layout work it is remains UNSETTLED and must not be published
+  as settled. Paint damage-region clipping at the viewport is consistent
+  with the shape and with layout staying linear — a commit dirtying cells
   0..d-1 damages a region that grows with `d` only until it covers the
-  VIEWPORT; past that, the extra dirty rows are off-screen, they are laid
-  out but never painted. The viewport holds a few tens of rows, so paint
-  is still growing at d = 1 and has stopped by d = 100, which is exactly
-  the shape in the table. It is a property of the page and the window,
-  not of the instrument, and no amount of differencing removes it because
-  it is not a constant — it is a saturating function of the very axis the
-  control varies.
+  viewport, and the viewport holds a few tens of rows — but these datasets
+  carry Task, Script, Layout and DevTools and NO paint counter, so nothing
+  here measures paint. rf2-8a746 carries this as residual uncertainty: no
+  published row may state paint causation.
 
   RECORDED AS A REFUTATION. The driver prints the marginal cost per dirty
   cell over each interval on every row, so the shape above is re-measured
@@ -479,14 +511,16 @@
    (floor-mount-arm :ctl-2x (* 2 v/cells-n) 2)])
 
 (defn- ctl3-arms
-  "The three-point control's arms, and they exist on BULK ROWS ONLY.
+  "The three-point statistic's arms, and they exist on BULK ROWS ONLY.
+
+  THEY GATE NOTHING (rf2-8a746) — see [[ctl3-dirty]]. What they feed is a
+  printed diagnostic of the page's dirty-set shape.
 
   A mount row's operation IS the mount, so it has no standing page to
   write a changed set into and no changed-set axis to be linear in. Its
-  control stays `ctl-2x` and stays known to undershoot — recorded on the
-  bead rather than papered over here, because the row this instrument
-  blocks is a bulk row and an arm invented for a mount row would be an
-  arm nothing had asked for.
+  check standard is `ctl-2x / floor`, whose empirical centre differs by row
+  class (1.72x on bulk, 1.80x on the mount) and whose mount class rf2-8a746
+  deliberately left UNCALIBRATED for rf2-t2flm's concurrent ruling.
 
   The arms come out in ascending dirty count, so a reader of the
   marginal-cost table reads it in the order the cells rise."

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_check_standard.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_check_standard.cjs
@@ -1,0 +1,387 @@
+#!/usr/bin/env node
+// THE CHECK STANDARD FOR THE HICASSO CLOCK (rf2-8a746).
+//
+//   node freehand/test/re_frame/bench/hicasso/clock_check_standard.cjs --selftest
+//
+// ## What this replaces, and why the replacement is a LEVEL
+//
+// rf2-8a746 retired the three-point difference-of-differences control as a
+// gate on this instrument — not re-sited, retired — on two independently
+// fatal grounds, both arithmetic:
+//
+//   * THE PREDICTION WAS MIS-DERIVED. `(d2-d0)/(d1-d0) = 2.0101` is the
+//     expectation only if `T` is affine in the dirty set. On the published
+//     TaskDuration clock it is not: marginal cost falls 12.6 -> 6.8-7.2 µs
+//     per cell across `[1,100]` / `[100,200]`, so the statistic's true centre
+//     is 1.546-1.578 and sits 2.6% ABOVE the 1.5076 edge at which it refuses.
+//   * THE ESTIMATOR WAS ILL-CONDITIONED. `den = T(100) - T(1)` is 1.23-1.25 ms
+//     carrying 0.60-0.67 ms of dispersion — 1.85-2.09 sigma from zero, with
+//     `corr(T(1), T(100)) ~ 0.4`. That is the classic Fieller ratio problem
+//     (Franz, arXiv:0710.2024): differencing away the additive constant also
+//     throws away the pedestal that made each arm's own estimator error look
+//     small, and those errors are independent between arms so they ADD.
+//
+// Re-siting at 100/200/300 fixes the centre (1.9975/2.0777) and halves the
+// denominator: in-band blocks FALL from 47% to 33%. Both available sitings
+// fail and the conditioning arithmetic says any siting must. So the axis
+// changes rather than the points: this standard's denominator is the floor's
+// WHOLE TARED READING, ~4.5 ms, which carries the same ~0.4 ms of estimator
+// error — 9% relative rather than 48%.
+//
+// ## And why its centre is measured rather than predicted
+//
+// `ctl-2x` builds exactly twice the floor's page, so its arithmetic prediction
+// is 2.00x. It does not read 2.00x, on any row, in any configuration, on
+// either clock, and the reason is the same non-affinity: page-doubling has a
+// component that does not scale. Asserting a theoretical value against a
+// non-affine clock is precisely the mistake being retired, so `clock_check_
+// standard.json` freezes what this instrument WAS MEASURED TO READ — centre,
+// location limits and dispersion limit — with its provenance, its error rates
+// and the conditions that force a recalibration beside it (NIST e-Handbook
+// 2.3.5's check-standard doctrine).
+//
+// ## The all-blocks rule went with it, and it was a SEPARATE defect
+//
+// The retired run-rejection rule was "every one of the 18 blocks inside the
+// tolerance band". Its arithmetic is `p^18`: the premise-MEETING layout
+// statistic has 83.5% of blocks in band and still passes 4 of 42 runs, because
+// `0.835^18 = 3.9%`. Swapping controls while keeping "every block" would not
+// have unblocked anything. So the tolerance band and the run-rejection rule
+// are now two different things with two different, stated error rates — see
+// `errorRates` in the JSON, and `checkStandard` below, which reports the band
+// and rejects on neither block count nor block extremes.
+//
+// ## Why it is its own module
+//
+// `clock_run.cjs` applies it to a run it just measured and `clock_
+// readjudicate.cjs` applies it to a dataset off disk. Two copies of the
+// arithmetic would be two adjudicators, which is the fault this lane's exit
+// path was rebuilt to remove, so there is one function and both require it.
+// The JSON beside it is data on purpose: recalibrating is editing that file
+// and bumping its version, never editing this one.
+
+'use strict';
+
+const STANDARD = require('./clock_check_standard.json');
+
+const r4 = (x) => (Number.isFinite(x) ? Math.round(x * 10000) / 10000 : NaN);
+
+function p50(xs) {
+  const v = [...xs].sort((a, b) => a - b);
+  if (v.length === 0) return NaN;
+  return v.length % 2 ? v[(v.length - 1) / 2] : (v[v.length / 2 - 1] + v[v.length / 2]) / 2;
+}
+
+/** Linear-interpolated quantile, the definition `robustScale` is stated on. */
+function quantile(xs, q) {
+  const v = [...xs].sort((a, b) => a - b);
+  if (v.length === 0) return NaN;
+  const h = (v.length - 1) * q;
+  const lo = Math.floor(h);
+  const hi = Math.ceil(h);
+  return v[lo] + (v[hi] - v[lo]) * (h - lo);
+}
+
+/**
+ * THE RUN'S DISPERSION, ROBUSTLY. `IQR / 1.349` is the normal-consistent scale
+ * estimator, so its number is comparable with a standard deviation while not
+ * being movable by one wild block — which matters here for the same reason
+ * rf2-8bgqq moved the headline to the median: a rule that a single extreme
+ * block can trip is the all-blocks rule wearing a summary statistic's clothes.
+ */
+function robustScale(xs) {
+  return (quantile(xs, 0.75) - quantile(xs, 0.25)) / 1.349;
+}
+
+/** Which class of the standard adjudicates a row — declared, never inferred. */
+function classOf(rowId) {
+  for (const [name, klass] of Object.entries(STANDARD.classes)) {
+    if ((klass.rows || []).includes(rowId)) return name;
+  }
+  return null;
+}
+
+/**
+ * IS THIS RUN IN CONTROL? — the whole verdict, over one row-run's per-block
+ * `ctl-2x / floor` level ratios.
+ *
+ * FAIL CLOSED AT EVERY SEAT, in this lane's standing sense: a row with no
+ * blocks, a block that is not a finite reading, a row whose class has no
+ * standard, and a class that has not been calibrated are each a REFUSAL and
+ * never a pass. An uncalibrated class is the one worth spelling out — it does
+ * not mean "no opinion", it means nothing has ever established what this
+ * instrument reads on that class, and a certificate nobody calibrated is not
+ * a certificate.
+ *
+ * `why` is `null` for a pass and the refusal's own sentence otherwise, in the
+ * idiom `clock_readjudicate.cjs`'s `GATES` are written in, so a caller prints
+ * a reason rather than a boolean.
+ */
+function checkStandard(perBlockRatios, rowId) {
+  const klassName = classOf(rowId);
+  const klass = klassName ? STANDARD.classes[klassName] : null;
+  const xs = Array.isArray(perBlockRatios) ? perBlockRatios : [];
+  const finite = xs.filter(Number.isFinite);
+  const base = {
+    standard: { id: STANDARD.id, version: STANDARD.version, ruling: STANDARD.ruling },
+    rowId: rowId || null,
+    rowClass: klassName,
+    calibrated: !!(klass && klass.calibrated),
+    rule: STANDARD.runRejection,
+    measured: {
+      n: xs.length,
+      finite: finite.length,
+      p50: r4(p50(finite)),
+      mean: finite.length ? r4(finite.reduce((a, b) => a + b, 0) / finite.length) : NaN,
+      min: finite.length ? r4(Math.min(...finite)) : NaN,
+      max: finite.length ? r4(Math.max(...finite)) : NaN,
+      scale: r4(robustScale(finite)),
+    },
+    location: null,
+    dispersion: null,
+    tolerance: null,
+    errorRates: klass ? klass.errorRates || null : null,
+    ok: false,
+    why: null,
+  };
+
+  if (!klassName) {
+    base.why =
+      `row \`${rowId}\` has no class in the check standard — ` +
+      (STANDARD.noStandard.rows.includes(rowId) ? STANDARD.noStandard.why : 'no proportional control arm adjudicates it');
+    return base;
+  }
+  if (!klass.calibrated) {
+    base.why = `the \`${klassName}\` class of the check standard is NOT CALIBRATED — ${klass.why}`;
+    return base;
+  }
+  if (finite.length === 0 || finite.length !== xs.length) {
+    base.why =
+      xs.length === 0
+        ? 'no blocks — an empty block set is an absent reading, not a run in control'
+        : `${xs.length - finite.length} of ${xs.length} blocks are not finite readings of a level ratio`;
+    return base;
+  }
+
+  const [lo, hi] = klass.location.limits;
+  const centre = klass.centre;
+  const scale = robustScale(finite);
+  const median = p50(finite);
+  const [tlo, thi] = klass.tolerance.band;
+  const inBand = finite.filter((x) => x >= tlo && x <= thi).length;
+
+  base.location = {
+    statistic: STANDARD.statistics.location,
+    centre,
+    limits: [lo, hi],
+    measured: r4(median),
+    ok: median >= lo && median <= hi,
+  };
+  base.dispersion = {
+    statistic: STANDARD.statistics.dispersion,
+    limit: klass.dispersion.limit,
+    measured: r4(scale),
+    ok: scale <= klass.dispersion.limit,
+  };
+  // REPORTED AND NOT A RULE (rf2-8a746). It is printed because a reader wants
+  // to see where the blocks fell; nothing below reads `inBand` into `ok`.
+  base.tolerance = {
+    band: [tlo, thi],
+    inBand,
+    of: finite.length,
+    fraction: r4(inBand / finite.length),
+    gating: false,
+  };
+  base.ok = base.location.ok && base.dispersion.ok;
+  base.why = base.ok
+    ? null
+    : [
+        base.location.ok
+          ? null
+          : `the run's block median ${r4(median)}x is outside the frozen location limits ` +
+            `[${lo} – ${hi}] about an empirical centre of ${centre}x`,
+        base.dispersion.ok
+          ? null
+          : `the run's robust scale ${r4(scale)} exceeds the frozen dispersion limit ${klass.dispersion.limit} ` +
+            `— the box could not reproduce identical work block to block`,
+      ]
+        .filter(Boolean)
+        .join('; ');
+  return base;
+}
+
+/** The one line a report prints for a check-standard verdict. */
+function formatCheckStandard(v) {
+  if (!v) return [];
+  const head =
+    `;;   ${v.ok ? 'IN CONTROL' : 'REFUSED   '} check standard \`${v.standard.id}\` v${v.standard.version} ` +
+    `[${v.rowClass || 'no class'}${v.calibrated ? '' : ', UNCALIBRATED'}] (${v.standard.ruling})`;
+  const lines = [head];
+  if (v.location && v.dispersion) {
+    lines.push(
+      `;;     location  ${v.location.measured}x median of ${v.measured.finite} blocks against ` +
+        `[${v.location.limits[0]} – ${v.location.limits[1]}] about an EMPIRICAL centre ${v.location.centre}x ` +
+        `— ${v.location.ok ? 'inside' : 'OUTSIDE'}`
+    );
+    lines.push(
+      `;;     dispersion ${v.dispersion.measured} robust scale (IQR/1.349) against a limit of ` +
+        `${v.dispersion.limit} — ${v.dispersion.ok ? 'inside' : 'OVER'}`
+    );
+    lines.push(
+      `;;     tolerance ${v.tolerance.inBand} of ${v.tolerance.of} blocks inside [${v.tolerance.band[0]} – ` +
+        `${v.tolerance.band[1]}] — REPORTED, and it decides nothing: the retired rule required all of them, ` +
+        `and 0.835^18 = 3.9% is why a control meeting its own premise passed 4 of 42 runs`
+    );
+  }
+  if (v.why) lines.push(`;;     why      ${v.why}`);
+  return lines;
+}
+
+/**
+ * THE STANDARD'S OWN FIXTURES, in the idiom every other adjudicator on this
+ * lane is held to: the refusals stated as cases rather than as prose, run
+ * before a browser opens and driven by `clock_exit_path.test.cjs` in CI.
+ *
+ * THE SABOTAGE CASE IS THE ONE THAT MATTERS (rf2-8a746 acceptance criterion
+ * 2). `HCLOCK_CTL3_SABOTAGE` makes the THREE-POINT control's top arm render
+ * fewer cells than it declares, and it is the fixture form of that knob —
+ * an arm that does not do what it declares — pointed at the standard's own
+ * arm instead: `ctl-2x` declares the floor's page doubled and builds 140 of
+ * its 300 boundaries. A standard nobody has seen refuse is a standard of
+ * unmeasured sensitivity, and this lane has found that defect nine times.
+ *
+ * Every world here is synthetic and pure. No measurement is taken, no window
+ * is opened, and the numbers are chosen to sit on the frozen limits rather
+ * than the limits chosen to admit the numbers.
+ */
+function checkStandardSelfTest() {
+  const checks = [];
+  const check = (name, ok, detail) => checks.push({ name, ok: !!ok, detail: detail || '' });
+  const BULK = 'bulk300';
+  const bulk = STANDARD.classes.bulk;
+
+  // A block world in the shape the instrument actually has: a floor sample is
+  // `W + c`, where `W` is the page-proportional work and `c` is the part that
+  // does not scale with the page. `ctl-2x` builds `P` times the page, so it
+  // reads `P*W + c` and the block ratio is `(P*W + c)/(W + c)`.
+  const W = 3.0;
+  const C = 1.1628; // c/W = 0.3876, which puts the doubling arm on the frozen centre
+  const blocksAt = (P, n, jitter) =>
+    Array.from({ length: n || 18 }, (_, i) => {
+      const j = jitter ? jitter * (i % 2 === 0 ? 1 : -1) * (1 + (i % 3) / 3) : 0;
+      return (P * W + C + j) / (W + C);
+    });
+
+  // 1. THE HEALTHY WORLD PASSES, and it comes first in weight: every refusal
+  //    below is worth nothing against a standard that refuses everything.
+  const healthy = checkStandard(blocksAt(2, 18, 0.05), BULK);
+  check(
+    'a doubling arm on the frozen centre is IN CONTROL',
+    healthy.ok && healthy.why === null && Math.abs(healthy.location.measured - bulk.centre) < 0.01,
+    JSON.stringify(healthy.location)
+  );
+
+  // 2. THE SABOTAGE, which is the fixture form of `HCLOCK_CTL3_SABOTAGE`
+  //    aimed at this standard's own arm: `ctl-2x` declares twice the floor's
+  //    300 boundaries and renders 140 of them. Every other gate on the run
+  //    passes and this is the only one that can see it.
+  const sabotaged = checkStandard(blocksAt(140 / 300, 18, 0.05), BULK);
+  check(
+    'THE SABOTAGE: an arm rendering 140 of the 300 boundaries it declares doubled REFUSES',
+    !sabotaged.ok && !sabotaged.location.ok && /outside the frozen location limits/.test(sabotaged.why || ''),
+    `${sabotaged.location && sabotaged.location.measured}x — ${sabotaged.why}`
+  );
+  check(
+    'and the sabotage refusal is the LOCATION rule, not a dispersion accident',
+    sabotaged.dispersion.ok === true,
+    JSON.stringify(sabotaged.dispersion)
+  );
+  // The knob's other direction: an arm that OVERBUILDS is equally a sabotage,
+  // and a one-sided standard would wave it through.
+  const over = checkStandard(blocksAt(3, 18, 0.05), BULK);
+  check('an arm building THREE times the page it declares doubled REFUSES too', !over.ok && !over.location.ok);
+
+  // 3. THE DISPERSION HALF, which is the run-rejection rule's other term. A
+  //    box that could not reproduce identical work block to block is refused
+  //    on the same centre — this world's median sits dead on it.
+  const noisy = checkStandard(blocksAt(2, 18, 1.4), BULK);
+  check(
+    'a run whose blocks scatter past the frozen dispersion limit REFUSES on the same centre',
+    !noisy.ok && noisy.location.ok && !noisy.dispersion.ok,
+    `median ${noisy.location.measured}x, scale ${noisy.dispersion.measured}`
+  );
+
+  // 4. THE DEFECT THIS STANDARD REPAIRS, asserted rather than described. The
+  //    retired rule refused a run for ONE out-of-band block. A world with a
+  //    healthy median, a scale inside the limit and two blocks outside the
+  //    tolerance band is exactly that run, and it must now PASS while the
+  //    band still REPORTS the two.
+  const twoOut = blocksAt(2, 18, 0.05);
+  twoOut[0] = 1.28; // just under the reported band's lower edge
+  twoOut[1] = 2.19; // just over its upper edge
+  const survives = checkStandard(twoOut, BULK);
+  check(
+    'THE RETIRED RULE, INVERTED: two out-of-band blocks no longer refuse a run whose median and scale hold',
+    survives.ok && survives.tolerance.inBand === 16 && survives.tolerance.of === 18 && survives.tolerance.gating === false,
+    JSON.stringify(survives.tolerance)
+  );
+  check(
+    'and the tolerance band is REPORTED rather than read into the verdict',
+    survives.tolerance.fraction < 1 && survives.ok === true,
+    JSON.stringify(survives.tolerance)
+  );
+
+  // 5. FAIL CLOSED, at each seat.
+  const uncal = checkStandard(blocksAt(2), 'M1');
+  check(
+    'an UNCALIBRATED class refuses rather than abstains, and hands the mount to rf2-t2flm by id',
+    !uncal.ok && uncal.calibrated === false && /rf2-t2flm/.test(uncal.why || ''),
+    uncal.why
+  );
+  const noClass = checkStandard(blocksAt(2), 'keystroke');
+  check(
+    'a row with no proportional control arm cannot be certified in control',
+    !noClass.ok && noClass.rowClass === null && /fixed 50 ms/.test(noClass.why || ''),
+    noClass.why
+  );
+  check(
+    'an unknown row is refused too — a class is granted by calibration, never by default',
+    !checkStandard(blocksAt(2), 'a-row-nobody-has-calibrated').ok
+  );
+  check('an EMPTY block set is not a pass', !checkStandard([], BULK).ok && /empty block set/.test(checkStandard([], BULK).why));
+  check('and a block that is not a finite reading refuses the run', !checkStandard([...blocksAt(2, 17, 0.05), NaN], BULK).ok);
+  check('a missing block set is absent, not clean', !checkStandard(undefined, BULK).ok && !checkStandard(null, BULK).ok);
+
+  // 6. THE STANDARD IS DATA AND SAYS WHICH DATA IT IS. A verdict that did not
+  //    carry its version could not be re-read after a recalibration.
+  check(
+    'every verdict carries the standard it was taken against, by id and version',
+    healthy.standard.id === STANDARD.id &&
+      healthy.standard.version === STANDARD.version &&
+      healthy.standard.ruling === 'rf2-8a746' &&
+      Number.isInteger(STANDARD.version)
+  );
+  check(
+    'the frozen limits are the JSON\'s, never a literal here',
+    healthy.location.limits[0] === bulk.location.limits[0] &&
+      healthy.location.limits[1] === bulk.location.limits[1] &&
+      healthy.dispersion.limit === bulk.dispersion.limit &&
+      healthy.location.centre === bulk.centre
+  );
+  check(
+    'and the limits bracket the centre rather than sitting to one side of it',
+    bulk.location.limits[0] < bulk.centre && bulk.centre < bulk.location.limits[1]
+  );
+
+  return { checks };
+}
+
+module.exports = { STANDARD, checkStandard, checkStandardSelfTest, formatCheckStandard, classOf, robustScale, quantile };
+
+if (require.main === module) {
+  const { checks } = checkStandardSelfTest();
+  for (const c of checks) console.error(`[check-standard] ${c.ok ? 'ok  ' : 'FAIL'}  ${c.name}${c.detail ? `  — ${c.detail}` : ''}`);
+  const bad = checks.filter((c) => !c.ok);
+  console.error(`[check-standard] ${checks.length} checks, ${bad.length} failed`);
+  if (bad.length) process.exit(1);
+}

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_check_standard.json
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_check_standard.json
@@ -38,7 +38,8 @@
     "mount": {
       "rows": ["M1"],
       "calibrated": false,
-      "why": "rf2-8a746 calibrated the BULK class only, from the 42 bulk row-runs it names. The mount half of the instrument question is rf2-t2flm's ruling, and one finding is handed to it by id: ctl-2x's true centre is empirical and differs by row class — 1.72x on bulk against 1.80x on the mount — so a mount decision function must state its expectation empirically too. Until that ruling lands this class FAILS CLOSED: an uncalibrated class cannot certify that a run was in control. M1 publishes DIRECTION and never a magnitude by rf2-jcm3p, so nothing turns on it.",
+      "why": "rf2-8a746 calibrated the BULK class only and hands the mount decision function to rf2-t2flm, so nothing has established what this instrument reads on a mount and no run of one can be certified in control",
+      "rationale": "The 42 row-runs rf2-8a746 names are bulk. The mount half of the instrument question is rf2-t2flm's ruling, concurrent and separate, and one finding is handed to it by id: ctl-2x's true centre is EMPIRICAL and differs by row class — 1.72x on bulk against 1.80x on the mount — so a mount decision function must state its expectation empirically too rather than assert 2.00x. Until that ruling lands this class fails closed, which costs nothing: M1 publishes DIRECTION and never a magnitude by rf2-jcm3p, so no magnitude is being withheld.",
       "observed": {
         "rowRuns": 14,
         "runMedianCentre": 1.7956,
@@ -52,7 +53,8 @@
   },
   "noStandard": {
     "rows": ["keystroke"],
-    "why": "this row's control burns a fixed 50 ms rather than doubling the page, so control/floor reads (F+50)/F and moves with F. It is a sensitivity control and not a check standard, and rf2-swwud adjudicates the row by Event Timing. A row with no proportional control arm cannot be certified in control by this standard, and the verdict says so rather than passing."
+    "why": "this row's control burns a fixed 50 ms rather than doubling the page, so control/floor reads (F+50)/F and moves with F — a sensitivity control and not a check standard, with rf2-swwud adjudicating the row by Event Timing instead",
+    "rationale": "A row with no proportional control arm cannot be certified in control by this standard, and the verdict says so rather than passing. Its own fixed-work control is untouched by rf2-8a746 and still refuses on its own terms in clock_run.cjs."
   },
   "recalibrateOn": [
     "any Chromium version change — the counters and the compositor are the instrument",

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_check_standard.json
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_check_standard.json
@@ -1,0 +1,64 @@
+{
+  "id": "hicasso-clock/ctl-2x-level",
+  "version": 1,
+  "ruling": "rf2-8a746",
+  "frozen": "2026-08-07",
+  "what": "The level-denominated check standard for the Hicasso clock (clock_run.cjs). The measured quantity is the ctl-2x arm's TARED TaskDuration over the floor's TARED TaskDuration, in the same round of the same segment — one per block, 18 per row-run. Both terms are LEVELS, so the ~0.4 ms of estimator error each arm's p50 carries is 9% of a ~4.5 ms denominator rather than 48% of a 1.2 ms difference. It replaces the three-point difference-of-differences control, which rf2-8a746 retired as a gate.",
+  "notAPrediction": "The expected centre is EMPIRICAL, not theoretical. ctl-2x builds exactly twice the floor's page and the arithmetic prediction is 2.00x, but TaskDuration is not affine in the page either, and asserting a theoretical value against a non-affine clock is the exact mistake rf2-8a746 retired. What is frozen below is what this instrument, on this page, through this door, was MEASURED to read.",
+  "statistics": {
+    "block": "one (round, segment) pair — tared(ctl-2x) / tared(floor)",
+    "location": "the run's MEDIAN over its blocks (rf2-8bgqq: a ratio's headline is its median)",
+    "dispersion": "the run's robust scale over its blocks, IQR / 1.349 — the normal-consistent estimator, so it is comparable with an SD without inheriting one wild block"
+  },
+  "runRejection": "a run is IN CONTROL when its block median lies inside the frozen location limits AND its robust scale is at or under the frozen dispersion limit. Nothing per-block rejects a run: the retired rule required all 18 blocks inside a tolerance band, and 0.835^18 = 3.9% is why a control that fully met its premise still passed only 4 of 42 runs.",
+  "toleranceBandIsNotTheRule": "The per-block tolerance band below is REPORTED and decides nothing. rf2-8a746 ruled that the tolerance band and the run-rejection rule get distinct, calibrated error rates; these are they.",
+  "classes": {
+    "bulk": {
+      "rows": ["bulk300", "bulk100", "narrow"],
+      "calibrated": true,
+      "centre": 1.7207,
+      "location": { "limits": [1.5509, 1.8905], "derivation": "centre +/- 3 x between-run SD 0.0566" },
+      "dispersion": { "limit": 0.568, "derivation": "exp(mu + 3 sigma) of the 42 log robust scales, mu = -1.6757, sigma = 0.37 — a lognormal upper 3 sigma on a positive skewed quantity, 35% above the widest of the 42 observed draws rather than at it" },
+      "tolerance": { "slack": 0.25, "band": [1.2905, 2.1509], "reported": true },
+      "errorRates": {
+        "runRejectionNominal": "0.4% per run — location 0.27% (two-sided 3 sigma, normal) plus dispersion 0.13% (one-sided 3 sigma, lognormal)",
+        "runRejectionEmpirical": "0 of 42 committed row-runs refused",
+        "toleranceBandPerBlock": "8.2% of blocks fall outside the reported band (694 of 756 inside)",
+        "retiredRuleForComparison": "the retired rule — every block inside a +/-25% band about the theoretical 2.00x — put 626 of 756 blocks (82.8%) inside and passed 4 of 42 runs, a 90.5% empirical per-run false refusal. Re-centring that band on the empirical 1.7207 raises the pooled in-band fraction to 91.8% and still passes only 10 of 42, because 0.918^18 = 21.4%. The centre and the all-blocks rule are two separate defects and this standard repairs both."
+      },
+      "provenance": {
+        "rowRuns": 42,
+        "datasets": ["data/clock-emvod/run1-8.json", "data/clock-w3yxd/run1-6.json"],
+        "chromium": "147.0.7727.15",
+        "design": "6 rounds x (4 warmup + 10 samples), tare on, 3 segments",
+        "observed": { "runMedianCentre": 1.7207, "runMedianRange": [1.596, 1.8288], "betweenRunSD": 0.0566, "robustScaleP50": 0.1922, "robustScaleMax": 0.4211 },
+        "independence": "NOT INDEPENDENT OF ITS OWN BASELINE, and said here rather than left to be discovered. v1 is seeded from the same 42 row-runs it is quoted against, so 0-of-42 is a consistency check and not a false-refusal measurement. NIST e-Handbook 2.3.5's doctrine is that the limits come from a baseline the standard is not afterwards judged on; the next recalibration must take one."
+      }
+    },
+    "mount": {
+      "rows": ["M1"],
+      "calibrated": false,
+      "why": "rf2-8a746 calibrated the BULK class only, from the 42 bulk row-runs it names. The mount half of the instrument question is rf2-t2flm's ruling, and one finding is handed to it by id: ctl-2x's true centre is empirical and differs by row class — 1.72x on bulk against 1.80x on the mount — so a mount decision function must state its expectation empirically too. Until that ruling lands this class FAILS CLOSED: an uncalibrated class cannot certify that a run was in control. M1 publishes DIRECTION and never a magnitude by rf2-jcm3p, so nothing turns on it.",
+      "observed": {
+        "rowRuns": 14,
+        "runMedianCentre": 1.7956,
+        "runMedianRange": [1.7489, 1.8978],
+        "betweenRunSD": 0.0397,
+        "robustScaleP50": 0.12,
+        "robustScaleRange": [0.041, 0.2863],
+        "note": "evidence for rf2-t2flm, not limits. Nothing reads these."
+      }
+    }
+  },
+  "noStandard": {
+    "rows": ["keystroke"],
+    "why": "this row's control burns a fixed 50 ms rather than doubling the page, so control/floor reads (F+50)/F and moves with F. It is a sensitivity control and not a check standard, and rf2-swwud adjudicates the row by Event Timing. A row with no proportional control arm cannot be certified in control by this standard, and the verdict says so rather than passing."
+  },
+  "recalibrateOn": [
+    "any Chromium version change — the counters and the compositor are the instrument",
+    "any change to the harness: the door an arm goes through, the tare arm, the settle, the sample or round counts",
+    "any change to the floor's page — cell count, boundary count, the shape of a cell",
+    "any change to the published clock (the counter the rows are stated on)",
+    "and the recalibration takes a FRESH baseline: re-deriving limits from the runs they will judge is how a check standard stops being one"
+  ]
+}

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -1180,7 +1180,7 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
       );
       // ...and the run refuses anyway. A verdict that read the summary would
       // pass here, and that is the whole failure this test exists to catch.
-      assert.strictEqual(heavy.ok, false, 'one out-of-band block must still refuse the run');
+      assert.strictEqual(heavy.premiseMet, false, 'one out-of-band block must still break the premise');
       assert.strictEqual(heavy.sign.ok, true, 'refused by the BAND, not swept up by the sign gate');
       assert.strictEqual(heavy.perRound.filter((x) => x > 10).length, 1, 'exactly one wild block');
     });
@@ -1197,7 +1197,7 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
 
     t('rf2-8bgqq: on a healthy run the median IS the mean, so no untailed run moved', () => {
       const clean = ctl3Verdict(synth((d) => A * d + C), plan, 0.25);
-      assert.strictEqual(clean.ok, true);
+      assert.strictEqual(clean.premiseMet, true);
       assert.strictEqual(clean.measured.p50, clean.measured.mean);
       assert.strictEqual(clean.measured.p50, 2.0101);
     });
@@ -1215,9 +1215,9 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
         'an unreadable arm': synth((d) => (d === 100 ? NaN : A * d + C)),
       };
       for (const [name, rounds] of Object.entries(refusing)) {
-        assert.strictEqual(ctl3Verdict(rounds, plan, 0.25).ok, false, `${name} must still refuse`);
+        assert.strictEqual(ctl3Verdict(rounds, plan, 0.25).premiseMet, false, `${name} must still break the premise`);
       }
-      assert.strictEqual(ctl3Verdict([], plan, 0.25).ok, false, 'and an empty block set is not a pass');
+      assert.strictEqual(ctl3Verdict([], plan, 0.25).premiseMet, false, 'and an empty block set is not a premise met');
     });
   }
 
@@ -1273,7 +1273,7 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   t('HCLOCK_CTL3_SABOTAGE still declares the run a falsification', () => {
     const v = reportability([clockRow({ ctlOk: false })], { sabotage: 140 });
     assert.strictEqual(v.code, 1);
-    assert.match(v.lines[1], /HCLOCK_CTL3_SABOTAGE=140 WAS SET/);
+    assert.match(v.lines[0], /HCLOCK_CTL3_SABOTAGE=140 WAS SET/);
   });
 
   t('neither verdict masks the other — a row failing both is refused for both', () => {
@@ -1626,6 +1626,50 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   });
 }
 
+// --- A RUN'S RAW READINGS, AS A FIXTURE (rf2-8a746) --------------------------
+//
+// The check standard is applied to the READINGS rather than read back off a
+// stored boolean — a check standard is versioned data a reader applies, and
+// re-applying a recalibrated standard to a retained dataset is the whole point
+// of freezing it as data. So every fixture that must clear the gate below has
+// to carry readings, and this builds them in the shape `clock_run.cjs` writes:
+// `roundsTask[round][segment][arm]`, ten samples an arm.
+//
+// The numbers are the instrument's own model — a floor sample is `W + c` where
+// `c` is the part that does not scale with the page, and `ctl-2x` builds twice
+// the page so it reads `2W + c`. `W = 3.0` and `c = 1.1628` put the block ratio
+// dead on the frozen empirical centre, 1.7207x. The jitter is deterministic and
+// small, so the run has a real dispersion without being anywhere near the
+// frozen limit: a fixture that passed only because it had none would not be
+// exercising the dispersion term at all.
+const FIXTURE_SEGMENTS = ['reagent-subs', 'uix-subs', 'hicasso'];
+function fixtureRoundsTask(over) {
+  const o = over || {};
+  const W = o.W === undefined ? 3.0 : o.W;
+  const C = 1.1628;
+  const TARE = 0.7;
+  const scale = o.ctlScale === undefined ? 2 : o.ctlScale; // what ctl-2x actually builds
+  const ten = (x) => Array.from({ length: 10 }, (_, k) => x + (k % 3) * 0.01);
+  const rounds = [];
+  for (let r = 0; r < 6; r++) {
+    const per = {};
+    for (let i = 0; i < FIXTURE_SEGMENTS.length; i++) {
+      const seg = FIXTURE_SEGMENTS[i];
+      const j = 0.02 * ((r + i) % 4) - 0.03;
+      per[seg] = {
+        plumb: ten(TARE),
+        floor: ten(W + C + TARE + j),
+        'ctl-2x': ten(scale * W + C + TARE + j),
+        // the segment's own substrate arm, which is what the paired level
+        // ratio is formed from
+        [seg]: ten(5.0 + i * 0.1 + j),
+      };
+    }
+    rounds.push(per);
+  }
+  return rounds;
+}
+
 // --- clock_readjudicate.cjs: the SAME term, on the persisted datasets --------
 //
 // rf2-y7mw7's second place. The driver adjudicates one run; the readjudicator
@@ -1651,12 +1695,21 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   // THE FILE'S OWN TWO-TIER VERDICT (rf2-2rtt6.31), as `datasetFor` writes it.
   // Every predicate here is handed one, because a row cannot vouch for the
   // file it came from and this filter's first gate is that it does not try.
-  const CANON = { canonical: true, notCanonicalWhy: null };
+  // `design` is here because a ROW gate now receives the envelope too
+  // (rf2-8a746): whether the readings are tared decides what a level ratio
+  // taken from them means, and the check standard refuses a record that does
+  // not say.
+  const CANON = { canonical: true, notCanonicalWhy: null, design: { rounds: 6, warmup: 4, samples: 10, tare: true } };
   // A dataset row as a two-tier `clock_run.cjs` writes it, reduced to the
   // fields this predicate reads — every whole-run verdict the driver exits on,
   // each at its passing value.
+  //
+  // `bulk300` rather than `M1` (rf2-8a746): the check standard's mount class is
+  // deliberately UNCALIBRATED — the mount decision function is rf2-t2flm's —
+  // so an `M1` row can never be reportable and a roster fixture built on one
+  // would be asserting against a gate that is closed for an unrelated reason.
   const dsRow = (bars, over) => ({
-    rowId: 'M1',
+    rowId: 'bulk300',
     pageErrors: [],
     guardRefuse: false,
     guardRefuseTask: false,
@@ -1665,8 +1718,9 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     kbWitness: null,
     tally: { writes: 1008, unverified: 0 },
     ctl3: null,
-    ctlOk: true,
-    ctlTask: { ok: true },
+    ctlOk: null,
+    ctlTask: { measured: { mean: 1.9 }, inBand: 18, of: 18 },
+    roundsTask: fixtureRoundsTask(),
     etVerdict: null,
     seam: { verdict: { ceilingBreached: false } },
     seamTask: { ceilingBreached: false, rows: bars },
@@ -1739,9 +1793,14 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
 
   t('the OTHER two terms are unchanged — adjudication was ADDED, never substituted', () => {
     const bars = { 'h / r': ADJ, 'h / u': ADJ };
-    // A failed control still excludes a fully adjudicated run ...
-    assert.strictEqual(reportable(dsRow(bars, { ctlTask: { ok: false } }), CANON), false);
-    assert.strictEqual(reportable(dsRow(bars, { ctlTask: null }), CANON), false);
+    // A failed control still excludes a fully adjudicated run — and it is the
+    // CHECK STANDARD's refusal now (rf2-8a746), read off the run's own
+    // readings rather than off a stored `ctlTask.ok`.
+    assert.strictEqual(
+      reportable(dsRow(bars, { roundsTask: fixtureRoundsTask({ ctlScale: 140 / 300 }) }), CANON),
+      false
+    );
+    assert.strictEqual(reportable(dsRow(bars, { roundsTask: [] }), CANON), false);
     // ... and so does either ceiling, which fires before any control.
     assert.strictEqual(
       reportable(dsRow(bars, { seam: { verdict: { ceilingBreached: true } } }), CANON),
@@ -1851,11 +1910,17 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
       absent: /no published-clock band verdict/,
     },
     {
-      id: 'control',
-      row: { ctl3: { ok: false, measured: { mean: 1.2 } } },
-      failed: /THREE-POINT control FAILED/,
-      erase: { row: 'ctl3' },
-      absent: /no three-point-control record/,
+      // THE SABOTAGE, ON THE CONSUMER SIDE (rf2-8a746). `ctlScale: 140/300` is
+      // the fixture form of an arm that declares the floor's page doubled and
+      // builds 140 of its 300 boundaries — the run's block median collapses to
+      // 0.6156x and the frozen location limits refuse it. The ERASURE case is
+      // the readings themselves: a record that did not store them cannot be
+      // shown to have been in control.
+      id: 'check-standard',
+      row: { roundsTask: fixtureRoundsTask({ ctlScale: 140 / 300 }) },
+      failed: /outside the frozen location limits/,
+      erase: { row: 'roundsTask' },
+      absent: /no raw per-sample TaskDuration readings/,
     },
     {
       id: 'event-timing',
@@ -1923,10 +1988,10 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   });
 
   t('EVERY reason is reported, not the first — a run that failed four gates says four', () => {
-    const why = refusals(dsRow(BARS, { guardRefuse: true, parityOk: false, ctlTask: { ok: false } }), {
-      canonical: false,
-      notCanonicalWhy: 'a PARTIAL row set',
-    });
+    const why = refusals(
+      dsRow(BARS, { guardRefuse: true, parityOk: false, roundsTask: fixtureRoundsTask({ ctlScale: 140 / 300 }) }),
+      { canonical: false, notCanonicalWhy: 'a PARTIAL row set', design: { tare: true } }
+    );
     assert.strictEqual(why.length, 4, JSON.stringify(why));
   });
 
@@ -2006,7 +2071,7 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   });
 
   t('requiring the readjudicator does not RUN it, which is what made this reachable', () => {
-    assert.match(RJSRC, /module\.exports = \{ GATES, adjudicated, refusals, reportable, responsivenessRegime \};/);
+    assert.match(RJSRC, /^  GATES, adjudicated, refusals, reportable, responsivenessRegime,$/m);
     assert.match(RJSRC, /if \(require\.main === module\) \{/);
     assert.match(RJSRC, /main\(process\.argv\.slice\(2\)\)/);
   });
@@ -2222,7 +2287,11 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     out: {
       rowId: 'bulk300',
       rounds: [],
-      roundsTask: [],
+      // THE READINGS THE CHECK STANDARD IS APPLIED TO (rf2-8a746). This used
+      // to be `[]`, which was fine while every gate read a stored boolean; the
+      // standard is applied to the readings, so a serialiser that dropped them
+      // would produce a record no reader could certify.
+      roundsTask: fixtureRoundsTask(),
       roundsLayout: [],
       inPageRounds: [],
       granularity: [0.146],
@@ -2246,11 +2315,12 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
       seam: { band: 0.06, verdict: { ceilingBreached: false } },
       seamTask: { band: 0.05, ceilingBreached: false, rows: BARS },
       tally: { writes: 1008, unverified: 0 },
-      ctlVerdict: { ok: true },
+      ctlVerdict: { measured: { mean: 1.9 }, inBand: 18, of: 18, allInBand: true, gating: false },
       ctl3: null,
       ctl3Net: null,
       ctl3Layout: null,
       ctl3Parity: null,
+      checkStandard: { ok: true, standard: { id: 'hicasso-clock/ctl-2x-level', version: 1 }, why: null },
       constants: null,
       guardVerdict: { refuse: false },
       guardVerdictTask: { refuse: false },
@@ -2321,7 +2391,11 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     unverified: (rec) => delete rec.rows[0].tally,
     'ceiling-net': (rec) => delete rec.rows[0].seam,
     'ceiling-task': (rec) => delete rec.rows[0].seamTask.ceilingBreached,
-    control: (rec) => delete rec.rows[0].ctl3,
+    // THE PRODUCER FIELD FOR THE CHECK STANDARD IS THE READINGS (rf2-8a746),
+    // not the driver's stored verdict — the standard is versioned data a
+    // reader applies, so what the serialiser must not lose is what it is
+    // applied to.
+    'check-standard': (rec) => delete rec.rows[0].roundsTask,
     'event-timing': (rec) => delete rec.rows[0].etVerdict,
     adjudication: (rec) => delete rec.rows[0].seamTask.rows,
   };
@@ -2338,7 +2412,9 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
 
   for (const g of GATES) {
     t(`gate \`${g.id}\`: the record SATISFIES it, and erasing the field REFUSES again`, () => {
-      const ask = (rec) => (g.scope === 'dataset' ? g.why(rec) : g.why(rec.rows[0]));
+      // A ROW GATE RECEIVES THE ENVELOPE TOO (rf2-8a746) — the design it was
+      // taken under decides what its readings mean.
+      const ask = (rec) => (g.scope === 'dataset' ? g.why(rec) : g.why(rec.rows[0], rec));
       const green = produce();
       assert.strictEqual(ask(green), null, `the serialiser must write what \`${g.id}\` reads`);
 
@@ -2709,6 +2785,433 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     assert.strictEqual(code(label).length, 1, 'a printed label is code, and must be searched');
     assert.match(code(label)[0][1], /frame-inclusive/);
     assert.deepStrictEqual(code(prose), [], 'a whole-line comment is prose, and must not be');
+  });
+}
+
+// --- rf2-8a746: THE CHECK STANDARD, AND WHAT MAY PUBLISH A MAGNITUDE ---------
+//
+// The 2026-08-07 ruling retired two rules at once and they are separate
+// defects, so they get separate pins.
+//
+//   THE THREE-POINT CONTROL, retired as a GATE — not re-sited. Its prediction
+//   is mis-derived on a clock that is not affine in the dirty set and its
+//   denominator sits ~2 sigma from zero, which is the Fieller ratio problem;
+//   it refused 42 of 42 bulk row-runs across two independent quiet-box
+//   ensembles. It still prints, labelled non-gating.
+//
+//   THE ALL-BLOCKS STRICT RULE, retired WITH it and for its own reason: the
+//   arithmetic is `p^18`, so a control fully MEETING its premise passes 4 of
+//   42 runs at an 83.5% per-block rate. Swapping controls while keeping "every
+//   block" would not have unblocked anything.
+//
+// What replaced them: a level-denominated, empirically calibrated, VERSIONED
+// check standard as the gate, and a run-preserving effect-size interval as the
+// publication rule. Both are pinned here, and the interval is pinned as a
+// PROCEDURE — the corpus case below asserts that a verdict is well formed and
+// that the 42 committed row-runs publish no magnitude, which is the ruling's
+// own fence, not a preferred answer.
+{
+  const {
+    STANDARD, checkStandard, checkStandardSelfTest, classOf,
+  } = require('./clock_check_standard.cjs');
+  const {
+    checkStandardFor, pairedLogRatios, effectInterval, effectVerdict, EFFECT, reportable, refusals,
+  } = require('./clock_readjudicate.cjs');
+  const CLOCKSRC = fs.readFileSync(path.join(__dirname, 'clock_run.cjs'), 'utf8');
+  const RJSRC2 = fs.readFileSync(path.join(__dirname, 'clock_readjudicate.cjs'), 'utf8');
+  const t = (what, fn) => test(`rf2-8a746: ${what}`, fn);
+  const BULK = 'bulk300';
+
+  // The same synthetic world the standard's own fixtures use: a floor sample
+  // is `W + c`, `ctl-2x` builds `P` times the page, so a block reads
+  // `(P*W + c)/(W + c)`.
+  const W = 3.0;
+  const C = 1.1628;
+  const blocksAt = (P, jitter) =>
+    Array.from({ length: 18 }, (_, i) => (P * W + C + (jitter || 0) * (i % 2 ? -1 : 1) * (1 + (i % 3) / 3)) / (W + C));
+
+  // --- 1. THE STANDARD IS DATA, AND IT SAYS WHICH DATA ----------------------
+
+  t("the standard's own fixtures pass, every case — a standard nobody has seen refuse is not one", () => {
+    const { checks } = checkStandardSelfTest();
+    assert.ok(checks.length >= 10, `expected the standard's fixtures, got ${checks.length}`);
+    const bad = checks.filter((c) => !c.ok);
+    assert.deepStrictEqual(bad.map((c) => `${c.name}: ${c.detail}`), []);
+  });
+
+  t('the check standard lands as DATA — versioned, with a frozen centre and frozen limits', () => {
+    // Criterion 2's first half. The point of freezing it as data is that
+    // recalibrating is editing a file and bumping a version, so the version
+    // has to be a real number and the limits have to live in the JSON rather
+    // than in the code that reads it.
+    assert.ok(Number.isInteger(STANDARD.version) && STANDARD.version >= 1, JSON.stringify(STANDARD.version));
+    assert.strictEqual(STANDARD.ruling, 'rf2-8a746');
+    const bulk = STANDARD.classes.bulk;
+    assert.strictEqual(bulk.calibrated, true);
+    assert.strictEqual(typeof bulk.centre, 'number');
+    assert.strictEqual(bulk.location.limits.length, 2);
+    assert.ok(bulk.location.limits[0] < bulk.centre && bulk.centre < bulk.location.limits[1], 'the limits must bracket the centre');
+    assert.strictEqual(typeof bulk.dispersion.limit, 'number');
+    assert.ok(bulk.dispersion.limit > 0);
+    // and the file, not the reader, is where they live
+    const v = checkStandard(blocksAt(2, 0.05), BULK);
+    assert.deepStrictEqual(v.location.limits, bulk.location.limits);
+    assert.strictEqual(v.dispersion.limit, bulk.dispersion.limit);
+    assert.strictEqual(v.location.centre, bulk.centre);
+    // the JSON carries the source code no literal here duplicates
+    assert.ok(
+      !new RegExp(String(bulk.centre)).test(require('node:fs').readFileSync(path.join(__dirname, 'clock_check_standard.cjs'), 'utf8')),
+      'the frozen centre must not also be a literal in the module that reads it'
+    );
+  });
+
+  t('the centre is EMPIRICAL and the standard says so — 2.00x is arithmetic, not a reading', () => {
+    // The ruling's own reason for not reusing ctl-2x's literal prediction:
+    // asserting a theoretical value against a non-affine clock is the mistake
+    // being retired.
+    assert.ok(Math.abs(STANDARD.classes.bulk.centre - 2.0) > 0.2, 'the frozen centre is nowhere near 2.00x');
+    assert.match(STANDARD.notAPrediction, /EMPIRICAL/);
+    assert.ok(Array.isArray(STANDARD.recalibrateOn) && STANDARD.recalibrateOn.length >= 3, 'a check standard states when it must be recalibrated');
+    const prov = STANDARD.classes.bulk.provenance;
+    assert.strictEqual(prov.rowRuns, 42);
+    assert.deepStrictEqual(prov.datasets, ['data/clock-emvod/run1-8.json', 'data/clock-w3yxd/run1-6.json']);
+    assert.match(prov.independence, /NOT INDEPENDENT/, 'v1 is seeded from the runs it is quoted against, and must say so');
+  });
+
+  // --- 2. THE SABOTAGE FIXTURE (criterion 2) --------------------------------
+
+  t('THE SABOTAGE: an arm building 140 of the 300 boundaries it declares doubled is REFUSED', () => {
+    const healthy = checkStandard(blocksAt(2, 0.05), BULK);
+    assert.strictEqual(healthy.ok, true, 'the healthy world must pass, or every refusal below proves nothing');
+    const sabotaged = checkStandard(blocksAt(140 / 300, 0.05), BULK);
+    assert.strictEqual(sabotaged.ok, false);
+    assert.strictEqual(sabotaged.location.ok, false, 'refused on LOCATION');
+    assert.strictEqual(sabotaged.dispersion.ok, true, 'and not swept up by the dispersion term');
+    assert.match(sabotaged.why, /outside the frozen location limits/);
+  });
+
+  t('and the sabotage reaches the consumer — a dataset carrying it may not be pooled', () => {
+    // The fixture is only worth its name if it refuses where a run is
+    // actually adjudicated, so it is driven through `reportable` on a record
+    // shaped as `clock_run.cjs` writes one.
+    const CANON = { canonical: true, notCanonicalWhy: null, design: { tare: true } };
+    const ADJ = { unadjudicated: false, why: 'clears' };
+    const row = (rt) => ({
+      rowId: 'bulk300', pageErrors: [], guardRefuse: false, guardRefuseTask: false, parityOk: true,
+      ctl3Parity: null, kbWitness: null, tally: { writes: 10, unverified: 0 }, etVerdict: null,
+      roundsTask: rt, seam: { verdict: { ceilingBreached: false } },
+      seamTask: { ceilingBreached: false, band: 0.2, rows: { 'hicasso / reagent-subs': ADJ } },
+    });
+    assert.strictEqual(reportable(row(fixtureRoundsTask()), CANON), true, 'the clean record must still pool');
+    const bad = row(fixtureRoundsTask({ ctlScale: 140 / 300 }));
+    assert.strictEqual(reportable(bad, CANON), false);
+    assert.ok(refusals(bad, CANON).some((w) => /outside the frozen location limits/.test(w)), JSON.stringify(refusals(bad, CANON)));
+  });
+
+  t('the DISPERSION term refuses on its own — a box that could not reproduce its own work', () => {
+    const noisy = checkStandard(blocksAt(2, 1.4), BULK);
+    assert.strictEqual(noisy.ok, false);
+    assert.strictEqual(noisy.location.ok, true, 'the centre is untouched — this is the other term');
+    assert.strictEqual(noisy.dispersion.ok, false);
+    assert.match(noisy.why, /robust scale .* exceeds the frozen dispersion limit/);
+  });
+
+  // --- 3. THE ALL-BLOCKS RULE IS GONE, EVERYWHERE ON THIS INSTRUMENT --------
+
+  t('criterion 4: no verdict on this instrument is "every block inside the band" any more', () => {
+    const clockMod = require('./clock_run.cjs');
+    const { ctl3Verdict } = clockMod;
+    // `controlVerdict` is not exported, and that is the point: it describes a
+    // band, it takes no decision, and a test able to reach it would be a
+    // reader able to reach it.
+    assert.ok(!('controlVerdict' in clockMod), 'a description is not part of the decision surface');
+    // The three-point statistic no longer offers an `ok` to read ...
+    const D = [1, 100, 200];
+    const plan = ['ctl-d1', 'ctl-d100', 'ctl-d200'].map((id, i) => ({ id, dirty: D[i], ctl3: true, ctl3Witness: false, cells: 300 }));
+    const rs = [];
+    for (let r = 0; r < 3; r++) {
+      const per = {};
+      for (const seg of FIXTURE_SEGMENTS) {
+        per[seg] = { 'ctl-d1': [3.506], 'ctl-d100': [4.1], 'ctl-d200': [4.694], floor: [5.3], plumb: [0.7] };
+      }
+      rs.push(per);
+    }
+    const v = ctl3Verdict(rs, plan, 0.25);
+    assert.ok(!('ok' in v), 'a retired gate may not keep a field called `ok` — that is how one grows back');
+    assert.strictEqual(v.gating, false);
+    assert.strictEqual(typeof v.premiseMet, 'boolean');
+    assert.strictEqual(typeof v.allInBand, 'boolean', 'the retired rule survives as a DESCRIPTION, named for what it is');
+    assert.match(v.rule, /DIAGNOSTIC \/ NON-GATING \(rf2-8a746\)/);
+  });
+
+  t('criterion 4: the ^18 semantics are gone from both programs, and the survivor says why', () => {
+    // Grepped rather than reasoned about, because the ruling asks for the
+    // SEMANTICS to be gone rather than one call site. The one `strict — EVERY`
+    // left in the driver is `keystroke`'s fixed-work sensitivity floor, which
+    // is a one-sided threshold with a 10 ms margin on a 50 ms burn and carries
+    // no `p^n` at all; it is annotated in place, and rf2-swwud's regime
+    // depends on it.
+    const survivors = CLOCKSRC.split('\n')
+      .map((line, i) => [i + 1, line])
+      .filter(([, line]) => /strict — EVERY/.test(line));
+    assert.deepStrictEqual(
+      survivors.map(([, l]) => l.trim()),
+      ["rule: 'strict — EVERY segment-round (a one-sided sensitivity floor, not a tolerance band)',"],
+      'the only surviving every-block rule is the 50 ms sensitivity floor'
+    );
+    assert.match(CLOCKSRC, /THIS ONE KEEPS ITS EVERY-BLOCK RULE, and the reason is worth stating/);
+    assert.ok(!/strict — EVERY/.test(RJSRC2), 'and the readjudicator carries none at all');
+  });
+
+  t('criterion 4: the replacement states its error rates in the code comment', () => {
+    // Both of them, distinctly — the ruling's own term is that the tolerance
+    // band and the run-rejection rule get DIFFERENT calibrated rates.
+    const rates = STANDARD.classes.bulk.errorRates;
+    assert.match(rates.runRejectionNominal, /0\.4% per run/);
+    assert.match(rates.runRejectionEmpirical, /0 of 42/);
+    assert.match(rates.toleranceBandPerBlock, /8\.2% of blocks/);
+    assert.match(rates.retiredRuleForComparison, /4 of 42/);
+    assert.match(rates.retiredRuleForComparison, /0\.918\^18/);
+    assert.match(CLOCKSRC, /`0\.835\^18 = 3\.9%`/, 'the driver states the retired rule\'s arithmetic where it was removed');
+    assert.match(RJSRC2, /0\.835\^18 = 3\.9%/);
+  });
+
+  t('criterion 4: a run with out-of-band blocks now PASSES if its location and dispersion hold', () => {
+    // The inversion, which is the whole unblocking: the retired rule refused
+    // this run and the calibrated one does not, while the band still REPORTS
+    // the blocks it refused for.
+    const xs = blocksAt(2, 0.05);
+    xs[0] = 1.28;
+    xs[1] = 2.19;
+    const v = checkStandard(xs, BULK);
+    assert.strictEqual(v.ok, true);
+    assert.ok(v.tolerance.inBand < v.tolerance.of, 'blocks the retired rule would have refused for');
+    assert.strictEqual(v.tolerance.gating, false);
+  });
+
+  // --- 4. NO VERDICT PATH CONSULTS THE THREE-POINT STATISTIC (criterion 1) --
+
+  t('criterion 1: neither program reads the three-point statistic into a decision', () => {
+    // Source-level, because the strongest form of "it does not gate" is that
+    // the name a gate would read does not exist. `ctl3Parity` stays — it is a
+    // canonical-DOM refusal about whether the control's own arms built one
+    // page, which rf2-8a746 leaves in the UNCHANGED list.
+    assert.ok(!/ctl3\.ok|ctl3Layout\.ok|ctl3Net\.ok/.test(CLOCKSRC.replace(/^\s*\/\/.*$/gm, '')), 'the driver reads no ctl3 verdict');
+    assert.ok(!/r\.ctl3\b(?!Parity)/.test(RJSRC2.replace(/^\s*\/\/.*$/gm, '')), 'the readjudicator reads no ctl3 field but parity');
+    assert.match(CLOCKSRC, /const ctlBad = \(o\) => !\(o\.verdict\.checkStandard && o\.verdict\.checkStandard\.ok\);/);
+  });
+
+  t('criterion 1: and behaviourally — flipping the three-point record changes no verdict', () => {
+    const CANON = { canonical: true, notCanonicalWhy: null, design: { tare: true } };
+    const ADJ = { unadjudicated: false, why: 'clears' };
+    const base = {
+      rowId: 'bulk300', pageErrors: [], guardRefuse: false, guardRefuseTask: false, parityOk: true,
+      ctl3Parity: null, kbWitness: null, tally: { writes: 10, unverified: 0 }, etVerdict: null,
+      roundsTask: fixtureRoundsTask(), seam: { verdict: { ceilingBreached: false } },
+      seamTask: { ceilingBreached: false, band: 0.2, rows: { 'hicasso / reagent-subs': ADJ } },
+    };
+    const failing = { premiseMet: false, measured: { p50: 1.2 }, ok: false };
+    const passing = { premiseMet: true, measured: { p50: 2.01 }, ok: true };
+    assert.strictEqual(reportable({ ...base, ctl3: failing }, CANON), true, 'a failing three-point record refuses nothing');
+    assert.strictEqual(reportable({ ...base, ctl3: passing }, CANON), true);
+    assert.strictEqual(reportable({ ...base, ctl3: null }, CANON), true);
+    // and it cannot rescue a run the standard refused, either
+    const sab = { ...base, roundsTask: fixtureRoundsTask({ ctlScale: 140 / 300 }) };
+    assert.strictEqual(reportable({ ...sab, ctl3: passing }, CANON), false, 'nor may it vouch for one');
+  });
+
+  t('criterion 1: the printout is relabelled DIAGNOSTIC / NON-GATING and no re-siting code landed', () => {
+    assert.match(CLOCKSRC, /THREE-POINT STATISTIC \[DIAGNOSTIC, NON-GATING — rf2-8a746\]/);
+    assert.match(CLOCKSRC, /RETIRED {2}this statistic refuses nothing/);
+    // No re-siting: the ruling says the points are not to be moved, so the
+    // page's declared dirty counts are still the only source of the
+    // prediction and no alternative siting is computed anywhere.
+    assert.ok(!/100\s*\/\s*200\s*\/\s*300|resite|reSite/i.test(CLOCKSRC.replace(/^\s*\/\/.*$/gm, '')), 'no re-siting code');
+  });
+
+  t('the falsification knob survived the retirement — it refuses on its own now', () => {
+    // The coupling that retiring a gate would have silently broken: the knob
+    // used to refuse THROUGH the three-point control.
+    const { reportability } = require('./clock_run.cjs');
+    const clean = [{ rowId: 'bulk300', ctlOk: true, ctlNote: '', adjudicable: true }];
+    assert.strictEqual(reportability(clean).code, 0, 'the same rows without the knob exit 0');
+    const v = reportability(clean, { sabotage: 140 });
+    assert.strictEqual(v.code, 1, 'a falsification run may not exit 0 however clean its gates');
+    assert.match(v.lines[0], /HCLOCK_CTL3_SABOTAGE=140 WAS SET/);
+    assert.strictEqual(v.lines[v.lines.length - 1], '[clock] REPORTABLE: none.');
+  });
+
+  // --- 5. THE PUBLICATION RULE (criterion 3) --------------------------------
+
+  t('criterion 3: the interval is run-preserving — outer RUNS resampled before inner ROUNDS', () => {
+    // The load-bearing property, asserted rather than described. Five runs
+    // whose ROUNDS are identical within a run and whose runs differ: all the
+    // variance is BETWEEN runs, so a bootstrap that pooled the 30 rounds and
+    // ignored the run structure would return an interval roughly sqrt(30/5)
+    // times too narrow. The hierarchical one must see the whole of it.
+    const consts = [0.9, 0.95, 1.0, 1.05, 1.1].map(Math.log);
+    const runs = consts.map((c) => Array(6).fill(c));
+    const iv = effectInterval(runs);
+    assert.strictEqual(iv.runs, 5);
+    const width = iv.hi - iv.lo;
+    assert.ok(width > 0.05, `a between-run spread of 20% must reach the interval, got width ${width}`);
+    // ... and the inner resample is real too: with rounds that differ inside a
+    // run and runs that do not, the interval is still non-degenerate.
+    const inner = Array.from({ length: 5 }, () => [0.9, 0.95, 1.0, 1.05, 1.1, 1.0].map(Math.log));
+    assert.ok(effectInterval(inner).hi - effectInterval(inner).lo > 0, 'inner resampling must contribute');
+    // and identical runs of identical rounds collapse to a point
+    const flat = Array.from({ length: 5 }, () => Array(6).fill(Math.log(1.2)));
+    const fv = effectInterval(flat);
+    assert.ok(Math.abs(fv.hi - fv.lo) < 1e-9 && Math.abs(fv.point - 1.2) < 1e-9, 'no variance, no interval width');
+  });
+
+  t('criterion 3: the interval is REPRODUCIBLE — a seeded bootstrap, stated in the output', () => {
+    const runs = [0.9, 0.95, 1.0, 1.05, 1.1].map((c) => Array(6).fill(Math.log(c)));
+    assert.deepStrictEqual(effectInterval(runs), effectInterval(runs), 'two runs of the same program agree to the last place');
+    assert.strictEqual(EFFECT.seed, 20260807);
+    assert.match(EFFECT.method, /Kalibera & Jones 2013/);
+    assert.match(EFFECT.method, /outer RUNS resampled before inner ROUNDS/);
+  });
+
+  t('criterion 3: the WHOLE interval must clear the threshold, and the effect must clear the band', () => {
+    // Both conditions and neither alone, driven at the boundary in each
+    // direction. A lower ratio is faster: these are times.
+    const below = { runs: 8, rounds: [6], point: 0.6, lo: 0.55, hi: 0.65, draws: 1, seed: 1 };
+    assert.strictEqual(effectVerdict(below, 10).publishes, true, 'wholly below 1.0 and a 40% effect over a 10% band');
+    assert.match(effectVerdict(below, 10).verdict, /MAGNITUDE PUBLISHABLE/);
+    assert.strictEqual(effectVerdict(below, 50).publishes, false, 'the same interval inside a 50% band publishes nothing');
+    assert.match(effectVerdict(below, 50).why, /an effect inside the band is a difference this instrument cannot resolve/);
+    const straddles = { runs: 8, rounds: [6], point: 0.99, lo: 0.9, hi: 1.05, draws: 1, seed: 1 };
+    assert.strictEqual(effectVerdict(straddles, 1).publishes, false, 'an interval containing parity publishes nothing');
+    assert.match(effectVerdict(straddles, 1).verdict, /INSTRUMENT-LIMITED/);
+    const kill = { runs: 8, rounds: [6], point: 1.9, lo: 1.7, hi: 2.1, draws: 1, seed: 1 };
+    assert.strictEqual(effectVerdict(kill, 10).publishes, true);
+    assert.match(effectVerdict(kill, 10).verdict, /ARCHITECTURE-KILL/);
+    const nearKill = { runs: 8, rounds: [6], point: 1.5, lo: 1.4, hi: 1.6, draws: 1, seed: 1 };
+    assert.strictEqual(effectVerdict(nearKill, 10).publishes, false, 'an interval straddling 1.5 is not a kill');
+    // an unrecorded band is not a clear band
+    assert.strictEqual(effectVerdict(below, NaN).publishes, false, 'no band recorded is not a band cleared');
+    // and two runs are not an ensemble
+    assert.strictEqual(effectVerdict({ ...below, runs: 2 }, 1).publishes, false);
+    assert.match(effectVerdict({ ...below, runs: 2 }, 1).why, /is not an ensemble/);
+    assert.strictEqual(effectVerdict(null, 1).publishes, false, 'no interval is not a pass');
+  });
+
+  // --- 6. AND OVER THE COMMITTED 42-RUN CORPUS ------------------------------
+  //
+  // THE TEST PINS THE PROCEDURE, NOT THE ANSWER. What is asserted is that
+  // every pair of every bulk row comes back with a WELL-FORMED verdict
+  // carrying its own reason, and that none of them publishes a magnitude —
+  // which is rf2-8a746's own fence rather than a preferred result: the 42
+  // committed row-runs are calibration and diagnostic evidence and are NOT
+  // retroactively promoted. If the procedure ever published from them this
+  // test fails, and that failure is the finding.
+
+  const CORPORA = [
+    { dir: 'clock-emvod', runs: 8 },
+    { dir: 'clock-w3yxd', runs: 6 },
+  ];
+  const BULK_ROWS = ['bulk300', 'bulk100', 'narrow'];
+  const PAIRS_8a746 = ['hicasso / reagent-subs', 'hicasso / uix-subs', 'uix-subs / reagent-subs'];
+
+  t('the committed corpus is 42 bulk row-runs, and every one is IN CONTROL under the standard', () => {
+    let n = 0;
+    let inControl = 0;
+    for (const { dir } of CORPORA) {
+      const d = path.join(__dirname, 'data', dir);
+      if (!fs.existsSync(d)) return; // datasets are retained, not required to build
+      for (const f of fs.readdirSync(d)) {
+        const data = JSON.parse(fs.readFileSync(path.join(d, f), 'utf8'));
+        for (const row of data.rows.filter((r) => BULK_ROWS.includes(r.rowId))) {
+          n += 1;
+          if (checkStandardFor(row, data).ok) inControl += 1;
+        }
+      }
+    }
+    assert.strictEqual(n, 42, 'the corpus rf2-8a746 calibrated from');
+    // The consistency check the standard's own provenance calls NOT
+    // INDEPENDENT: v1 was seeded from these medians, so 42 of 42 is what it
+    // must say, and a drift here means the limits and the corpus have parted.
+    assert.strictEqual(inControl, 42, `the frozen limits must still admit their own baseline — got ${inControl}`);
+  });
+
+  t('criterion 3: every pair of every bulk row gets a stated verdict over the committed corpus', () => {
+    for (const { dir } of CORPORA) {
+      const d = path.join(__dirname, 'data', dir);
+      if (!fs.existsSync(d)) return;
+      const datasets = fs.readdirSync(d).map((f) => JSON.parse(fs.readFileSync(path.join(d, f), 'utf8')));
+      for (const rowId of BULK_ROWS) {
+        const rows = datasets.map((data) => ({ data, row: data.rows.find((r) => r.rowId === rowId) })).filter((x) => x.row);
+        const pooled = rows.filter(({ row, data }) => reportable(row, data));
+        for (const pair of PAIRS_8a746) {
+          const iv = effectInterval(pooled.map(({ row }) => pairedLogRatios(row, pair)).filter(Boolean));
+          const bands = pooled.map(({ row }) => row.seamTask.band).filter(Number.isFinite).map((b) => b * 100);
+          const ev = effectVerdict(iv, bands.length ? Math.max(...bands) : NaN);
+          assert.ok(typeof ev.why === 'string' && ev.why.length > 0, `${dir}/${rowId}/${pair}: a verdict must carry its reason`);
+          assert.ok(
+            /^(INSTRUMENT-LIMITED|MAGNITUDE PUBLISHABLE|ARCHITECTURE-KILL)/.test(ev.verdict),
+            `${dir}/${rowId}/${pair}: unrecognised verdict ${ev.verdict}`
+          );
+          assert.ok(iv, `${dir}/${rowId}/${pair}: the corpus must yield an interval to adjudicate`);
+          assert.ok(iv.lo <= iv.point && iv.point <= iv.hi, `${dir}/${rowId}/${pair}: the point must lie inside its own interval`);
+          assert.strictEqual(
+            ev.publishes,
+            false,
+            `${dir}/${rowId}/${pair} PUBLISHED a magnitude from the committed corpus — rf2-8a746 rules those 42 ` +
+              `row-runs calibration and diagnostic evidence, never retroactively promoted. Verdict: ${ev.verdict} — ${ev.why}`
+          );
+        }
+      }
+    }
+  });
+
+  t('and the program itself exits 0 over both committed ensembles, publishing no magnitude', () => {
+    const RJ = path.join(__dirname, 'clock_readjudicate.cjs');
+    for (const { dir } of CORPORA) {
+      const d = path.join(__dirname, 'data', dir);
+      if (!fs.existsSync(d)) return;
+      const files = fs.readdirSync(d).map((f) => path.join(d, f));
+      const r = cp.spawnSync(process.execPath, [RJ, ...files], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+      const out = `${r.stdout}${r.stderr}`;
+      assert.strictEqual(r.status, 0, `${dir}: ${out.slice(-2000)}`);
+      assert.ok(/EFFECT-SIZE INTERVAL \(rf2-8a746\)/.test(out), `${dir}: the interval must be printed`);
+      assert.ok(!/VERDICT MAGNITUDE PUBLISHABLE|VERDICT ARCHITECTURE-KILL/.test(out), `${dir}: no magnitude may be published from the corpus`);
+      assert.ok(/pooled means below are DIAGNOSTICS/.test(out), `${dir}: the pooled means must be labelled`);
+    }
+  });
+
+  // --- 7. CRITERION 5: EVERYTHING CITES THE RULING --------------------------
+
+  t('criterion 5: the ruling is cited by bead id in every surface it changed', () => {
+    for (const [name, src] of [
+      ['clock_run.cjs', CLOCKSRC],
+      ['clock_readjudicate.cjs', RJSRC2],
+      ['clock_check_standard.cjs', fs.readFileSync(path.join(__dirname, 'clock_check_standard.cjs'), 'utf8')],
+      ['clock_check_standard.json', fs.readFileSync(path.join(__dirname, 'clock_check_standard.json'), 'utf8')],
+      ['clock_app.cljs', fs.readFileSync(path.join(__dirname, 'clock_app.cljs'), 'utf8')],
+    ]) {
+      assert.ok(/rf2-8a746/.test(src), `${name} must cite the ruling that changed it`);
+    }
+    assert.strictEqual(classOf('bulk300'), 'bulk');
+    assert.strictEqual(classOf('M1'), 'mount');
+    assert.strictEqual(classOf('keystroke'), null);
+  });
+
+  t('the residual uncertainty is carried: no surface states paint causation', () => {
+    // rf2-8a746 carries it explicitly — "non-layout and saturating below
+    // d=100" is established; that PAINT causes the concavity is not, because
+    // the datasets have no paint counter.
+    for (const [name, src] of [
+      ['clock_run.cjs', CLOCKSRC],
+      ['clock_readjudicate.cjs', RJSRC2],
+      ['clock_app.cljs', fs.readFileSync(path.join(__dirname, 'clock_app.cljs'), 'utf8')],
+    ]) {
+      const claims = src
+        .split('\n')
+        .map((line, i) => [i + 1, line])
+        .filter(([, l]) => /mechanism is PAINT|paint is what|caused by paint|because paint/i.test(l));
+      assert.deepStrictEqual(claims.map(([n, l]) => `${name}:${n}: ${l.trim()}`), [], 'paint causation is an inference, not a finding');
+    }
   });
 }
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
@@ -78,9 +78,41 @@
 // better explanation and the repair is a control that DIFFERENCES the
 // constant away rather than one that changes what is doubled.
 
+// ## WHAT ADJUDICATES A ROW, AND WHAT PUBLISHES ONE (rf2-8a746)
+//
+// The 2026-08-07 ruling replaced both halves of this program's verdict and
+// they are separate things.
+//
+//   THE GATE is a level-denominated, empirically calibrated, versioned CHECK
+//   STANDARD — `clock_check_standard.json`, applied by `clock_check_
+//   standard.cjs`, which this file and `clock_run.cjs` both require so there
+//   is one seat and not two. It replaced the three-point difference-of-
+//   differences control, which refused 42 of 42 bulk row-runs across two
+//   independent quiet-box ensembles because its prediction is mis-derived on
+//   a clock that is not affine in the dirty set AND its denominator sits ~2
+//   sigma from zero. It also replaced the all-blocks strict rule, which was a
+//   SEPARATE defect: `0.835^18 = 3.9%`, so a control fully meeting its premise
+//   passed 4 of 42 runs.
+//
+//   THE PUBLICATION RULE is an EFFECT-SIZE CONFIDENCE INTERVAL on the quantity
+//   the product claim actually asserts — the paired same-round Hicasso/donor
+//   LEVEL ratio at fixed witness and fixed K — computed by a run-preserving
+//   hierarchical bootstrap (Kalibera & Jones 2013: resample outer RUNS before
+//   inner ROUNDS). A magnitude publishes only when the WHOLE interval lies on
+//   the required side of 1.0, and the effect clears the same-run noise band.
+//   Otherwise the row publishes INSTRUMENT-LIMITED and never a magnitude.
+//
+// Every pooled mean this program prints is therefore a DIAGNOSTIC beneath that
+// verdict, and the 42 committed row-runs remain calibration evidence: they are
+// not retroactively promoted to published magnitudes by anything here.
+
 'use strict';
 
 const fs = require('node:fs');
+
+// ONE SEAT FOR THE GATE'S ARITHMETIC (rf2-8a746) — see `clock_run.cjs`, which
+// requires the same module. Two copies would be two adjudicators.
+const checkstd = require('./clock_check_standard.cjs');
 
 const fmt = (x, n = 4) => (Number.isFinite(x) ? x.toFixed(n) : 'n/a');
 const mean = (xs) => xs.reduce((a, b) => a + b, 0) / xs.length;
@@ -89,6 +121,16 @@ function p50(xs) {
   const v = [...xs].sort((a, b) => a - b);
   if (v.length === 0) return NaN;
   return v.length % 2 ? v[(v.length - 1) / 2] : (v[v.length / 2 - 1] + v[v.length / 2]) / 2;
+}
+
+/** Linear-interpolated quantile — the percentile-interval definition below. */
+function quantile(xs, q) {
+  const v = [...xs].sort((a, b) => a - b);
+  if (v.length === 0) return NaN;
+  const h = (v.length - 1) * q;
+  const lo = Math.floor(h);
+  const hi = Math.ceil(h);
+  return v[lo] + (v[hi] - v[lo]) * (h - lo);
 }
 
 /** mean / min / max over the runs of the ensemble — never a bare mean. */
@@ -148,6 +190,235 @@ function rawCrossSegment(rounds, pair) {
 }
 
 /**
+ * THE CHECK STANDARD, RE-APPLIED TO THE RUN'S OWN READINGS (rf2-8a746).
+ *
+ * RECOMPUTED, NOT READ BACK, and this is the one gate in the roster below that
+ * is — so the reason has to be here rather than inferred. Every other gate
+ * mirrors a verdict `clock_run.cjs` TOOK, and a taken verdict can be lost in a
+ * file, which is why absent is not clean. A check standard is not that kind of
+ * thing. It is versioned DATA that a READER applies, and applying today's
+ * standard to a dataset taken before it existed is the entire point of
+ * freezing limits as data instead of as a stored boolean: recalibrate, bump
+ * the version, and every retained run can be re-adjudicated without re-running
+ * the box. `clock_run.cjs` stores its own verdict beside the readings anyway,
+ * carrying the standard's id and version, so a reader can see which standard a
+ * run was taken under; nothing here reads it, because a run adjudicated under
+ * v1 and re-read under v2 must come back with v2's answer.
+ *
+ * FAIL CLOSED, at each seat: no design record, no raw readings, a missing arm,
+ * a block that is not a finite reading, a row whose class has no standard, and
+ * a class nobody has calibrated are each a REFUSAL.
+ */
+function checkStandardFor(row, dataset) {
+  const r = row || {};
+  const d = dataset || {};
+  // THE CLASS DECIDES BEFORE THE READINGS DO. A row whose class is
+  // uncalibrated cannot be certified in control however clean its blocks are,
+  // and asking for readings first would report the wrong refusal.
+  const klass = checkstd.classOf(r.rowId);
+  if (!klass || !checkstd.STANDARD.classes[klass].calibrated) return checkstd.checkStandard([], r.rowId);
+  if (!d.design || typeof d.design.tare !== 'boolean') {
+    return {
+      ok: false,
+      why: 'no design record — whether these readings are tared was not serialised, and a level ratio taken with the wrong tare is not that ratio',
+    };
+  }
+  if (!Array.isArray(r.roundsTask) || r.roundsTask.length === 0) {
+    return {
+      ok: false,
+      why: 'no raw per-sample TaskDuration readings — the check standard is applied to the readings themselves, so a record that did not store them cannot be shown to have been in control',
+    };
+  }
+  const xs = [];
+  for (const seg of SEGMENTS) {
+    for (const round of r.roundsTask) {
+      const s = round && round[seg];
+      const c = s && s['ctl-2x'];
+      const f = s && s.floor;
+      const t = s && s.plumb;
+      if (!Array.isArray(c) || !Array.isArray(f) || (d.design.tare && !Array.isArray(t))) {
+        return {
+          ok: false,
+          why: `the check standard's arms are not all in the record — segment \`${seg}\` is missing ctl-2x, floor or the tare`,
+        };
+      }
+      xs.push((p50(c) - (d.design.tare ? p50(t) : 0)) / (p50(f) - (d.design.tare ? p50(t) : 0)));
+    }
+  }
+  return checkstd.checkStandard(xs, r.rowId);
+}
+
+/**
+ * THE PUBLICATION RULE (rf2-8a746), and it is deliberately small.
+ *
+ * `bar` is the claim's threshold and `architectureKill` the other side of it.
+ * `draws` and `seed` are here rather than inline because a published interval
+ * a reader cannot reproduce is the fault this whole program exists to fix: the
+ * bootstrap is seeded, so running this file twice over the same datasets
+ * yields the same interval to the last place.
+ *
+ * `minRuns` is the lane's own standing sentence — two runs are not an ensemble
+ * — as arithmetic. A run-preserving bootstrap resamples OUTER units, and with
+ * one or two of them the outer distribution is essentially the observed runs
+ * themselves, so the interval understates by construction. Below the floor the
+ * row publishes INSTRUMENT-LIMITED rather than a narrow interval.
+ */
+const EFFECT = {
+  bead: 'rf2-8a746',
+  draws: 4000,
+  seed: 20260807,
+  alpha: 0.05,
+  bar: 1.0,
+  architectureKill: 1.5,
+  minRuns: 3,
+  method: 'paired log-ratios; hierarchical percentile bootstrap, outer RUNS resampled before inner ROUNDS (Kalibera & Jones 2013)',
+};
+
+/** A small deterministic PRNG, so a published interval is reproducible. */
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function next() {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * ONE RUN'S PAIRED LOG-RATIOS, one per round — the quantity the product claim
+ * asserts, at fixed witness and fixed K.
+ *
+ * PAIRED AND SAME-ROUND, which is what makes it the right quantity: both arms
+ * are read in the same round of the same run, so whatever that round's box was
+ * doing is common to the pair. LEVEL over LEVEL, touching neither floor, for
+ * the reason the check standard is level-denominated — the floors are two
+ * different values and dividing by them injects a second term. And LOGS,
+ * because a ratio's sampling distribution is skewed and its log's is not, so
+ * the arithmetic is done where the mean is a summary.
+ *
+ * Returns `null` for a row that carries no usable readings, which is a
+ * refusal to state an interval rather than an interval over nothing.
+ */
+function pairedLogRatios(row, pair) {
+  const [num, den] = pair.split(' / ');
+  const out = [];
+  for (const round of (row && row.roundsTask) || []) {
+    const n = round && round[num] && round[num][num];
+    const d = round && round[den] && round[den][den];
+    if (!Array.isArray(n) || !Array.isArray(d) || n.length === 0 || d.length === 0) return null;
+    const q = p50(n) / p50(d);
+    if (!Number.isFinite(q) || q <= 0) return null;
+    out.push(Math.log(q));
+  }
+  return out.length ? out : null;
+}
+
+/**
+ * THE EFFECT-SIZE INTERVAL — a hierarchical percentile bootstrap that
+ * PRESERVES THE RUN (rf2-8a746, Kalibera & Jones 2013).
+ *
+ * Runs are the outer unit and rounds the inner one, and the order matters: a
+ * bootstrap that pooled every round of every run and resampled that pool would
+ * treat two rounds of one run as independent of each other, which they are
+ * not — a run is a box state, a browser process and a bundle — and would
+ * return an interval far too narrow. So each draw resamples RUNS with
+ * replacement first and then, within each drawn run, its ROUNDS.
+ *
+ * `runs` is `[[logRatio per round]]`. The point estimate is the mean over runs
+ * of each run's mean, which is the balanced-design estimator the bootstrap is
+ * the distribution of.
+ */
+function effectInterval(runs) {
+  const usable = (runs || []).filter((r) => Array.isArray(r) && r.length > 0);
+  if (usable.length === 0) return null;
+  const point = mean(usable.map(mean));
+  const rnd = mulberry32(EFFECT.seed);
+  const draws = [];
+  for (let b = 0; b < EFFECT.draws; b++) {
+    const outer = [];
+    for (let i = 0; i < usable.length; i++) {
+      const run = usable[Math.floor(rnd() * usable.length)];
+      const inner = [];
+      for (let j = 0; j < run.length; j++) inner.push(run[Math.floor(rnd() * run.length)]);
+      outer.push(mean(inner));
+    }
+    draws.push(mean(outer));
+  }
+  return {
+    runs: usable.length,
+    rounds: usable.map((r) => r.length),
+    point: Math.exp(point),
+    lo: Math.exp(quantile(draws, EFFECT.alpha / 2)),
+    hi: Math.exp(quantile(draws, 1 - EFFECT.alpha / 2)),
+    draws: EFFECT.draws,
+    seed: EFFECT.seed,
+    method: EFFECT.method,
+  };
+}
+
+/**
+ * MAY THIS ROW PUBLISH A MAGNITUDE? (rf2-8a746)
+ *
+ * Both conditions, and neither on its own. THE WHOLE INTERVAL must lie on one
+ * side of the threshold — an interval straddling it is a row that has not
+ * measured a direction, and quoting its point estimate is quoting the middle
+ * of a range that contains parity. AND THE EFFECT MUST CLEAR THE SAME-RUN
+ * NOISE BAND, because a confidence interval narrows with runs while the band
+ * says what a single run of this instrument can resolve at all: an effect
+ * inside the band is a difference the instrument cannot see in one sitting,
+ * however many sittings are pooled.
+ *
+ * `noiseBandPct` is the WIDEST band among the runs pooled — a claim must clear
+ * the noisiest run it is drawn from, which is the fail-closed direction and
+ * the same direction this program's other asymmetries take.
+ *
+ * A LOWER RATIO IS FASTER: these are times. So the ship claim is the whole
+ * interval BELOW 1.0 and the architecture-kill is the whole interval ABOVE
+ * 1.5.
+ */
+function effectVerdict(iv, noiseBandPct) {
+  if (!iv) return { publishes: false, verdict: 'INSTRUMENT-LIMITED', why: 'no usable paired readings in any pooled run — no interval was formed' };
+  if (iv.runs < EFFECT.minRuns) {
+    return {
+      publishes: false,
+      verdict: 'INSTRUMENT-LIMITED',
+      why:
+        `${iv.runs} pooled run(s) is not an ensemble — a run-preserving interval resamples OUTER units, and ` +
+        `below ${EFFECT.minRuns} the outer distribution is the observed runs themselves and the interval understates`,
+    };
+  }
+  const effectPct = Math.abs(iv.point - 1) * 100;
+  const clearsNoise = Number.isFinite(noiseBandPct) && effectPct > noiseBandPct;
+  const below = iv.hi < EFFECT.bar;
+  const above = iv.lo > EFFECT.architectureKill;
+  if (!below && !above) {
+    return {
+      publishes: false,
+      verdict: 'INSTRUMENT-LIMITED',
+      why:
+        `the interval [${fmt(iv.lo)} – ${fmt(iv.hi)}] does not lie wholly on one side of the ${EFFECT.bar} bar ` +
+        `or the ${EFFECT.architectureKill} architecture-kill threshold`,
+    };
+  }
+  if (!clearsNoise) {
+    return {
+      publishes: false,
+      verdict: 'INSTRUMENT-LIMITED',
+      why:
+        `the effect is ${fmt(effectPct, 1)}% and the widest same-run noise band among the pooled runs is ` +
+        `${Number.isFinite(noiseBandPct) ? fmt(noiseBandPct, 1) + '%' : 'not recorded'} — an effect inside the band ` +
+        `is a difference this instrument cannot resolve in one sitting, however many sittings are pooled`,
+    };
+  }
+  return {
+    publishes: true,
+    verdict: below ? 'MAGNITUDE PUBLISHABLE — the whole interval is below the 1.0 bar' : 'ARCHITECTURE-KILL — the whole interval is above 1.5',
+    why: `the interval [${fmt(iv.lo)} – ${fmt(iv.hi)}] clears the threshold and the ${fmt(effectPct, 1)}% effect clears the ${fmt(noiseBandPct, 1)}% same-run band`,
+  };
+}
+
+/**
  * IS EVERY BAR THIS RUN PUBLISHED ON THIS ROW ADJUDICATED?
  *
  * rf2-y7mw7's term, and the one this file was missing entirely: a row whose
@@ -198,7 +469,11 @@ function adjudicated(row) {
  * the handful someone remembered to write a case for.
  *
  * Each entry's `why` returns `null` for a pass and the refusal's own sentence
- * otherwise. `scope` says what it is handed: the dataset envelope, or one row.
+ * otherwise. `scope` says what it is PRIMARILY handed — the dataset envelope,
+ * or one row — and a row gate receives the envelope as a second argument,
+ * because the envelope carries the design a reading has to be interpreted
+ * under (`rf2-8a746`: whether the readings are tared decides what a level
+ * ratio taken from them means). Most row gates ignore it.
  */
 const GATES = [
   // --- the file's own two-tier verdict, before anything in it is read ------
@@ -309,24 +584,23 @@ const GATES = [
           ? "the run's own reproducibility band exceeds the ceiling on the published clock"
           : null,
   },
-  // THE CONTROL, MIRRORING `ctlBad` RATHER THAN RE-DECIDING IT. A row that has
-  // a three-point control is gated on it and `ctl-2x` is a reported diagnostic
-  // (rf2-7iqb5, rf2-5xrcd); a row that has none — `M1`, `keystroke` — is gated
-  // on `ctl-2x`, and on BOTH clocks, because the row is stated on one of them
-  // and was adjudicated on the other.
+  // THE CHECK STANDARD (rf2-8a746). It replaced two rules at once and the old
+  // gate's shape is worth recording, because a reader of an old dataset will
+  // meet it: this seat used to ask `ctl3.ok` on a bulk row and `ctlOk` /
+  // `ctlTask.ok` — the +/-25% band about a THEORETICAL 2.00x, every block —
+  // everywhere else. The three-point control read 0 of 42 bulk row-runs in
+  // band, on a mis-derived prediction and a denominator ~2 sigma from zero;
+  // and the all-blocks rule was a separate defect that would have refused just
+  // as hard behind any control, `0.835^18 = 3.9%`.
+  //
+  // The replacement is level over level, against an EMPIRICAL centre frozen
+  // with its provenance, with a run-rejection rule made of the run's own
+  // location and dispersion at stated error rates. The refusal is the
+  // standard's own sentence, so a reader is told which of the two terms went.
   {
-    id: 'control',
+    id: 'check-standard',
     scope: 'row',
-    why: (r) => {
-      if (!('ctl3' in r)) return 'no three-point-control record — which control gates this row was not serialised';
-      if (r.ctl3) return r.ctl3.ok === true ? null : 'the THREE-POINT control FAILED';
-      if (r.ctlOk !== true) return r.ctlOk === false ? 'ctl-2x FAILED on taskNet' : 'no ctl-2x verdict on taskNet';
-      return r.ctlTask && r.ctlTask.ok === true
-        ? null
-        : r.ctlTask
-          ? 'ctl-2x FAILED on the published clock'
-          : 'no ctl-2x verdict on the published clock';
-    },
+    why: (r, d) => checkStandardFor(r, d).why || null,
   },
   {
     id: 'event-timing',
@@ -375,7 +649,7 @@ function refusals(row, dataset) {
     } else if (!r) {
       why.push(`no row to read \`${g.id}\` from`);
     } else {
-      const w = g.why(r);
+      const w = g.why(r, d);
       if (w) why.push(w);
     }
   }
@@ -512,19 +786,26 @@ function main(argv) {
     console.log(`;; ======== ROW ${rowId} — ${runs.length} runs ========`);
 
     // --- gates, per run -------------------------------------------------------
-    console.log(';; run  guard(net/task)  ctl-2x task   ctlPASS  band(task)  band(net)  floor abs ms');
-    for (const { file, row } of runs) {
+    // THE COLUMN THAT DECIDES IS THE CHECK STANDARD'S (rf2-8a746), and the
+    // `ctl-2x` mean beside it is the raw reading it is taken from rather than
+    // a second verdict. The old `ctlPASS` column read `ctlTask.ok` — the
+    // all-blocks band about a theoretical 2.00x — and that rule no longer
+    // exists to be printed.
+    console.log(';; run  guard(net/task)  ctl-2x task  ctl2x/floor  STANDARD  band(task)  band(net)  floor abs ms');
+    for (const { file, data, row } of runs) {
       const floorAbs = p50(
         SEGMENTS.map((s) => {
           const d = row.decomposition[`${s}/floor`];
           return d ? d.task / d.n : NaN;
         }).filter(Number.isFinite)
       );
+      const cs = checkStandardFor(row, data);
       console.log(
         `;;  ${shortName(file).padEnd(6)} ${(row.guardRefuse ? 'REFUSE' : 'ok').padEnd(7)}` +
           `${(row.guardRefuseTask ? 'REFUSE' : 'ok').padEnd(8)}` +
-          `${row.ctlTask ? fmt(row.ctlTask.measured.mean, 3).padStart(10) : '       n/a'}` +
-          `${row.ctlTask ? (row.ctlTask.ok ? '   PASS' : '   FAIL') : '    n/a'}` +
+          `${row.ctlTask ? fmt(row.ctlTask.measured.mean, 3).padStart(9) : '      n/a'}` +
+          `${cs.location ? fmt(cs.location.measured, 3).padStart(13) : '          n/a'}` +
+          `${(cs.ok ? 'IN CTRL' : 'REFUSED').padStart(10)}` +
           `${row.bandTask === null || row.bandTask === undefined ? '       n/a' : (fmt(row.bandTask * 100, 1) + '%').padStart(10)}` +
           `${row.seam && row.seam.band !== null ? (fmt(row.seam.band * 100, 1) + '%').padStart(11) : '        n/a'}` +
           `${fmt(floorAbs, 3).padStart(13)}`
@@ -565,6 +846,15 @@ function main(argv) {
       const ei = ens(inPage);
       console.log('');
       console.log(`;;   PAIR ${pair}`);
+      // EVERY POOLED MEAN BELOW IS A DIAGNOSTIC (rf2-8a746). "reportable
+      // subset" means the runs that cleared every gate, which is a statement
+      // about eligibility and never about publication: what publishes a
+      // magnitude is the EFFECT-SIZE INTERVAL at the foot of this block, and a
+      // subset mean quoted above it would be exactly the un-adjudicated
+      // magnitude the ruling forbids.
+      console.log(
+        `;;     [pooled means below are DIAGNOSTICS — the interval at the foot of this block is what publishes]`
+      );
       console.log(
         `;;     raw TaskDuration (PUBLISHED)  ${fmt(e.mean)}x  [${fmt(e.min)} – ${fmt(e.max)}]  n=${e.n}` +
           (taskPass.length
@@ -630,8 +920,8 @@ function main(argv) {
           ? `BAND CEILING BREACHED — whole run refused before any control is consulted`
           : barUnadjudicated
             ? 'UNADJUDICATED — no proportional control on this row'
-            : !(row.ctlTask && row.ctlTask.ok)
-              ? `control FAILED — no magnitude reportable`
+            : !checkStandardFor(row, runs[i].data).ok
+              ? `check standard REFUSED — the run was not shown to be in control`
               : margin > bandPct
                 ? `clears its ${fmt(bandPct, 1)}% band`
                 : `INSIDE the band — instrument-limited`;
@@ -641,6 +931,45 @@ function main(argv) {
             ` ${(fmt(margin, 1) + '%').padStart(7)}   ${verdict}`
         );
       });
+
+      // --- THE EFFECT-SIZE INTERVAL, and the only thing here that publishes --
+      //
+      // rf2-8a746's fourth part. The rows above describe; this decides. It is
+      // computed over the REPORTABLE runs only — a run refused by any gate is
+      // not evidence about the page — and it is stated whichever way it falls,
+      // because a rule that only prints when it likes the answer is not one.
+      const ivRuns = passIdx.map((i) => pairedLogRatios(runs[i].row, pair)).filter(Boolean);
+      const iv = effectInterval(ivRuns);
+      const bands = passIdx
+        .map((i) => runs[i].row.seamTask && runs[i].row.seamTask.band)
+        .filter((b) => Number.isFinite(b))
+        .map((b) => b * 100);
+      const noise = bands.length ? Math.max(...bands) : NaN;
+      const ev = effectVerdict(iv, noise);
+      console.log(
+        `;;     EFFECT-SIZE INTERVAL (${EFFECT.bead}) — paired same-round LEVEL ratio at fixed witness and ` +
+          `fixed K, neither floor; ${EFFECT.method}`
+      );
+      if (iv) {
+        console.log(
+          `;;       point ${fmt(iv.point)}x   ${fmt((1 - EFFECT.alpha) * 100, 0)}% CI [${fmt(iv.lo)} – ${fmt(iv.hi)}]   ` +
+            `over ${iv.runs} reportable run(s) x ${iv.rounds[0]} rounds, ${iv.draws} draws, seed ${iv.seed}`
+        );
+        console.log(
+          `;;       effect |1 - point| ${fmt(Math.abs(iv.point - 1) * 100, 1)}%   widest same-run band among the ` +
+            `pooled runs ${Number.isFinite(noise) ? fmt(noise, 1) + '%' : 'n/a'}   ` +
+            `thresholds: bar ${EFFECT.bar} (whole interval below), architecture-kill ${EFFECT.architectureKill} (whole interval above)`
+        );
+      } else {
+        console.log(`;;       no interval — ${passIdx.length} run(s) cleared every gate and none carried usable paired readings`);
+      }
+      console.log(`;;       VERDICT ${ev.verdict} — ${ev.why}`);
+      if (!ev.publishes) {
+        console.log(
+          `;;       so this row publishes INSTRUMENT-LIMITED on this pair and NEVER a magnitude, and no mean ` +
+            `printed above may be quoted as one (${EFFECT.bead}).`
+        );
+      }
     }
 
     // --- the responsiveness regime, per run (rf2-swwud) -----------------------
@@ -860,7 +1189,16 @@ function shortName(f) {
 // DECISIONS a test must be able to drive. The raw estimator decides nothing —
 // it is a second description of a row printed beside the first — so exporting
 // it would widen a guard to accommodate a reporting helper.
-module.exports = { GATES, adjudicated, refusals, reportable, responsivenessRegime };
+//
+// rf2-8a746 adds four names and every one of them is a decision: the gate a
+// row now turns on, the quantity the product claim asserts, the interval over
+// it, and the rule that says whether that interval may publish. `EFFECT` is
+// exported with them because a test that could not read the seed could not
+// pin the procedure.
+module.exports = {
+  GATES, adjudicated, refusals, reportable, responsivenessRegime,
+  checkStandardFor, pairedLogRatios, effectInterval, effectVerdict, EFFECT,
+};
 
 // Requiring this file must not run it: `clock_exit_path.test.cjs` drives the
 // two predicates above directly, which it cannot do if the module body reads

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
@@ -163,6 +163,10 @@ const { shadowBuild } = require('./lane_build.cjs');
 const guard = require('../../freehand/bench/order_guard.cjs');
 const seamlib = require('./seam.cjs');
 const kbwitness = require('./clock_witness.cjs');
+// THE GATE ON A BULK ROW (rf2-8a746). One module, required by this driver and
+// by `clock_readjudicate.cjs`, because two copies of an adjudicator's
+// arithmetic are two adjudicators.
+const checkstd = require('./clock_check_standard.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
 
@@ -340,32 +344,106 @@ function band(xs) {
 }
 
 /**
- * A positive control is a STATED prediction against a measured range, and
- * the STRICT rule is used: every round must sit inside the band.
- * `lane/control-verdict`'s overlap rule is documented in its own docstring
- * as the lane's known defect (rf2-egdaq) — a control whose worst round is
- * wrong has caught something, and letting a good round vouch for a bad one
- * is how an instrument stops being one. Nothing here is already published
- * under the weaker rule, so there is nothing to re-adjudicate.
+ * A STATED prediction against a measured range — AND NO LONGER A VERDICT
+ * (rf2-8a746).
+ *
+ * It used to carry `ok`, computed by the STRICT rule: every block inside the
+ * band, one bad block refuses the run. That rule is retired everywhere on this
+ * instrument, and it is worth being precise about why, because the reasoning
+ * that put it here was sound and is not what failed.
+ *
+ * The rule was chosen against `lane/control-verdict`'s overlap defect
+ * (rf2-egdaq): a control whose worst block is wrong HAS caught something, and
+ * letting a good block vouch for a bad one is how an instrument stops being
+ * one. True, and it says nothing about how many blocks a run has. THE
+ * ARITHMETIC IS `p^n`. A control that fully MEETS its premise — the same
+ * three-point statistic on `LayoutDuration`, whose centre is right, whose
+ * conditioning is healthy and whose sign gate never fired in 756 blocks — puts
+ * 83.5% of blocks inside the band and passes 4 of 42 runs, because
+ * `0.835^18 = 3.9%`. `ctl-2x` shows the identical pathology: 626 of 756 in
+ * band, 4 of 42 strict. At n = 18 the rule is not strict, it is a lottery, and
+ * a run-rejection rule with a 90% false-refusal rate cannot adjudicate
+ * anything.
+ *
+ * So a tolerance band and a run-rejection rule are two different things with
+ * two different, separately calibrated error rates — the band is REPORTED
+ * here, and `clock_check_standard.cjs` owns the rejection. `allInBand` is kept
+ * because it is a true and useful description of where a run's blocks fell,
+ * and it is named for what it is rather than for a decision it no longer
+ * takes: nothing in this driver's exit path reads it.
  */
 function controlVerdict(predicted, perRound, slack) {
   const lo = predicted * (1 - slack);
   const hi = predicted * (1 + slack);
   const b = band(perRound);
-  const ok = perRound.every((x) => x >= lo && x <= hi);
+  const inBand = perRound.filter((x) => x >= lo && x <= hi).length;
   return {
     predicted: r4(predicted),
     band: [r4(lo), r4(hi)],
     measured: b,
     perRound: perRound.map(r4),
-    ok,
-    rule: 'strict — EVERY round inside the band',
+    inBand,
+    of: perRound.length,
+    // THE RETIRED RULE, kept as a DESCRIPTION and never read as a verdict
+    // (rf2-8a746). A reader comparing an old dataset with a new one needs the
+    // number the old rule turned on; a gate reading it would be that rule
+    // growing back.
+    allInBand: perRound.length > 0 && inBand === perRound.length,
+    gating: false,
+    rule:
+      'DESCRIPTION, NOT A VERDICT (rf2-8a746) — the band is reported per block and the run-rejection ' +
+      'rule is the check standard\'s; the retired "every block inside the band" is kept as `allInBand`',
   };
 }
 
 // ---------------------------------------------------------------------------
-// THE THREE-POINT CONTROL — a difference of differences (rf2-7iqb5, rf2-5xrcd)
+// THE THREE-POINT CONTROL — RETIRED AS A GATE, KEPT AS A DIAGNOSTIC (rf2-8a746)
 // ---------------------------------------------------------------------------
+//
+// IT GATES NOTHING. rf2-8a746 retired this statistic as a gate on this
+// instrument — not re-sited, not re-tried — after it refused 42 of 42 bulk
+// row-runs across two independent quiet-box ensembles with every hard refusal
+// clean throughout. The diagnosis is arithmetic and both halves are
+// independently fatal:
+//
+//   * THE PREDICTION IS MIS-DERIVED FOR THE POINTS CHOSEN. `(d2-d0)/(d1-d0)`
+//     is the expectation only if `T` is affine in `d`. On the published
+//     TaskDuration clock it is not — marginal cost 12.6 -> 6.8-7.2 µs per
+//     dirty cell across `[1,100]` / `[100,200]` — so the statistic's true
+//     centre is 1.546-1.578 and sits 2.6% ABOVE the 1.5076 edge at which it
+//     refuses. The knee is below `d = 100` and the eps arm straddles it.
+//   * THE ESTIMATOR IS ILL-CONDITIONED, and this alone would refuse. `den =
+//     T(100) - T(1)` is 1.23-1.25 ms carrying 0.60-0.67 ms of dispersion,
+//     1.85-2.09 sigma from zero, with `corr(T(1), T(100)) ~ 0.4` — the classic
+//     Fieller ratio problem (Franz, arXiv:0710.2024). The invariance argument
+//     below is TRUE OF THE LEVEL; what destroys the control is the error in
+//     each arm's ESTIMATE of that level, which is independent between arms and
+//     therefore ADDS under differencing.
+//
+// Re-siting at 100/200/300 fixes the centre (1.9975/2.0777) and HALVES the
+// denominator — in-band blocks fall 47% -> 33%. Both available sitings fail
+// and the conditioning arithmetic says any siting must, so there is no third
+// siting to try and no re-siting code here.
+//
+// WHAT IT STILL EARNS ITS PLACE FOR. Its internal control `ctl3Layout` — the
+// same statistic on `LayoutDuration` over the IDENTICAL blocks and samples —
+// is healthy: 1.9681/1.9801, marginals flat at 5.4 -> 5.1 µs per cell, all 756
+// numerators and denominators positive. That localises the failure to the
+// non-affine NON-LAYOUT clock rather than to the quotient machinery, and it
+// makes the pair a live diagnostic of the page's dirty-set shape. So it is
+// still computed, still printed and still refused nothing — every printout
+// below says so, and `clock_check_standard.cjs` is what a bulk row is gated
+// on now.
+//
+// WHAT IS ESTABLISHED ABOUT THE CONCAVE RESIDUAL, AND WHAT IS NOT. The
+// non-layout half collapses 7.1 -> 1.8 µs per cell and saturates below
+// `d = 100`; that is measured on both ensembles. That PAINT specifically
+// causes it is NOT established — the datasets carry Task/Script/Layout/
+// DevTools and no paint counter — and rf2-8a746 carries that as residual
+// uncertainty. No published row may state paint causation.
+//
+// The construction's own reasoning is kept below, because a control removed
+// with its argument deleted is indistinguishable from one nobody understood.
 //
 // `ctl-2x` is the floor at twice the boundaries against the floor, predicted
 // 2.00x. Over rf2-emvod's seven runs it read 1.8173x on the MOUNT row and
@@ -568,10 +646,21 @@ function ctl3Verdict(rounds, plan, slack) {
   const marg = (k) => band(blocks.map((b) => b.marginalUs[k]).filter(Number.isFinite));
   return {
     ...v,
-    ok: v.ok && sign.ok,
+    // NOT `ok` (rf2-8a746). This statistic gates nothing, and a field called
+    // `ok` on a retired gate is exactly how one grows back: `ctlBad` used to
+    // read it, `clock_readjudicate.cjs`'s `control` gate used to read it, and
+    // neither can now because the name it read is gone. `premiseMet` says
+    // what the boolean actually means — the statistic sat where its own
+    // premise says it should, on a run whose blocks all rose with `d` — which
+    // is a true and useful DESCRIPTION of the page's dirty-set shape and is
+    // not a certificate that the instrument was in control.
+    premiseMet: v.allInBand && sign.ok,
+    gating: false,
     rule:
-      'strict — EVERY block inside the band, AND every block\'s numerator and denominator ' +
-      'finite and strictly positive',
+      'DIAGNOSTIC / NON-GATING (rf2-8a746) — `premiseMet` is EVERY block inside the band AND every ' +
+      "block's numerator and denominator finite and strictly positive. It refuses nothing: the " +
+      'prediction is mis-derived on a non-affine clock and the estimator is ill-conditioned, so the ' +
+      "bulk gate is `clock_check_standard.cjs`'s",
     sign,
     arms: { eps: a0, d: a1, twoD: a2, witness: wArm },
     dirty: { [a0]: d0, [a1]: d1, [a2]: d2 },
@@ -603,11 +692,20 @@ function ctl3Verdict(rounds, plan, slack) {
 }
 
 /**
- * The adjudicator's own self-test, run before the browser opens and fatal if
- * it fails — the pattern `order_guard.cjs` and `seam.cjs` already hold this
- * driver to. A control is only worth its verdict if its arithmetic has been
- * shown to REFUSE something, and these cases are the refusals stated as
- * fixtures rather than as prose.
+ * The DIAGNOSTIC's own self-test, run before the browser opens and fatal if it
+ * fails — the pattern `order_guard.cjs` and `seam.cjs` already hold this driver
+ * to.
+ *
+ * IT IS NO LONGER A GATE'S FIXTURE SET (rf2-8a746), and the fixtures are kept
+ * anyway. Their subject was the statistic's DISCRIMINATING POWER — a
+ * superlinear page, an arm that does not do what it declares, a denominator
+ * that has gone to noise, one bad block among nine, a page on which more dirty
+ * work reads FASTER at exactly the predicted ratio — and that is exactly what
+ * a diagnostic of the page's dirty-set shape has to have. What changed is what
+ * the boolean is CALLED and what reads it: `premiseMet`, and nothing in the
+ * exit path. Deleting them along with the gate would have thrown away the only
+ * evidence that this statistic can tell two pages apart, on the day it became
+ * the thing whose whole job is telling two pages apart.
  */
 function ctl3SelfTest() {
   const D = [1, 100, 200];
@@ -640,7 +738,7 @@ function ctl3SelfTest() {
   // unit in the last place it can carry.
   const exact = (x) => Math.abs(x - r4(predicted)) < 5e-5;
   const lin = ctl3Verdict(synth((d) => A * d + C), plan, CONTROL_SLACK);
-  checks.push({ name: 'linear + large additive constant PASSES', ok: lin.ok && exact(lin.measured.mean) });
+  checks.push({ name: 'linear + large additive constant MEETS THE PREMISE', ok: lin.premiseMet && exact(lin.measured.mean) });
 
   // 2. THE SAME WORLD THROUGH A DOUBLING CONTROL. The claim is not that
   //    `ctl-2x` fails some band on one value — with realistic numbers it
@@ -663,13 +761,13 @@ function ctl3SelfTest() {
   // 3. A MULTIPLICATIVE block perturbation — ambient load, which rf2-cvvb7
   //    measured to be exactly this shape — must also cancel.
   const mult = ctl3Verdict(synth((d, r, i) => (1 + 0.35 * r + 0.2 * i) * (A * d + C)), plan, CONTROL_SLACK);
-  checks.push({ name: 'multiplicative block perturbation PASSES', ok: mult.ok && exact(mult.measured.mean) });
+  checks.push({ name: 'multiplicative block perturbation MEETS THE PREMISE', ok: mult.premiseMet && exact(mult.measured.mean) });
 
   // 4. SUPERLINEAR work must REFUSE. If the page's cost per dirty cell grows
   //    with the dirty set, the row's own premise is wrong and the control is
   //    the thing that says so.
   const sup = ctl3Verdict(synth((d) => (A * Math.pow(d, 2)) / 300 + C), plan, CONTROL_SLACK);
-  checks.push({ name: 'superlinear work (d^2) REFUSES', ok: !sup.ok });
+  checks.push({ name: 'superlinear work (d^2) reads OUT OF PREMISE', ok: !sup.premiseMet });
 
   // 4b. THE CONTROL'S SENSITIVITY, DERIVED AND ASSERTED RATHER THAN HOPED
   //     FOR. With equally spaced points the statistic is exactly
@@ -685,10 +783,10 @@ function ctl3SelfTest() {
   checks.push({
     name: 'the statistic is exactly 1 + upper/lower marginal, so the band is |Δ₂/Δ₁ - 1| <= 50%',
     ok:
-      controlVerdict(2, [1 + 0.5], CONTROL_SLACK).ok &&
-      controlVerdict(2, [1 + 1.5], CONTROL_SLACK).ok &&
-      !controlVerdict(2, [1 + 0.49], CONTROL_SLACK).ok &&
-      !controlVerdict(2, [1 + 1.51], CONTROL_SLACK).ok,
+      controlVerdict(2, [1 + 0.5], CONTROL_SLACK).allInBand &&
+      controlVerdict(2, [1 + 1.5], CONTROL_SLACK).allInBand &&
+      !controlVerdict(2, [1 + 0.49], CONTROL_SLACK).allInBand &&
+      !controlVerdict(2, [1 + 1.51], CONTROL_SLACK).allInBand,
   });
 
   //     A PURE POWER LAW `d^k` is the sharp way to state that. At
@@ -703,17 +801,17 @@ function ctl3SelfTest() {
   //     finding rather than a shrug.
   const kOf = (k) => (Math.pow(200, k) - 1) / (Math.pow(100, k) - 1);
   checks.push({
-    name: 'sensitivity, asserted: refuses a power law below k~0.55 and above k~1.33 (1:2:3 spacing could do neither below)',
+    name: 'sensitivity, asserted: reads a power law below k~0.55 and above k~1.33 out of band (1:2:3 spacing could do neither below)',
     ok:
       Math.abs(kOf(1) - predicted) < 1e-9 &&
-      controlVerdict(predicted, [kOf(0.65)], CONTROL_SLACK).ok &&
-      !controlVerdict(predicted, [kOf(0.45)], CONTROL_SLACK).ok &&
-      controlVerdict(predicted, [kOf(1.25)], CONTROL_SLACK).ok &&
-      !controlVerdict(predicted, [kOf(1.4)], CONTROL_SLACK).ok &&
+      controlVerdict(predicted, [kOf(0.65)], CONTROL_SLACK).allInBand &&
+      !controlVerdict(predicted, [kOf(0.45)], CONTROL_SLACK).allInBand &&
+      controlVerdict(predicted, [kOf(1.25)], CONTROL_SLACK).allInBand &&
+      !controlVerdict(predicted, [kOf(1.4)], CONTROL_SLACK).allInBand &&
       // and the equally-spaced alternative genuinely cannot: its floor is
       // 1.585, which is inside the band for every sublinear exponent.
       [0.05, 0.3, 0.6, 0.9].every((k) =>
-        controlVerdict(2, [(Math.pow(3, k) - 1) / (Math.pow(2, k) - 1)], CONTROL_SLACK).ok
+        controlVerdict(2, [(Math.pow(3, k) - 1) / (Math.pow(2, k) - 1)], CONTROL_SLACK).allInBand
       ),
   });
 
@@ -722,7 +820,7 @@ function ctl3SelfTest() {
   //    still declaring 200, every other gate passes, and the control is the
   //    only one that can see it.
   const sab = ctl3Verdict(synth((d) => A * (d === 200 ? 140 : d) + C), plan, CONTROL_SLACK);
-  checks.push({ name: 'an arm dirtying 140 while declaring 200 REFUSES', ok: !sab.ok });
+  checks.push({ name: 'an arm dirtying 140 while declaring 200 reads OUT OF PREMISE', ok: !sab.premiseMet });
 
   // 6. A DEAD DENOMINATOR must REFUSE rather than read as a pass. This
   //    statistic's characteristic failure is not a wrong number, it is a
@@ -732,8 +830,8 @@ function ctl3SelfTest() {
   //    this, and it has to come out as a refusal.
   const dead = ctl3Verdict(synth(() => C), plan, CONTROL_SLACK);
   checks.push({
-    name: 'a workload with NO dirty-set signal REFUSES (degenerate denominator is not a pass)',
-    ok: !dead.ok && !Number.isFinite(dead.measured.mean),
+    name: 'a workload with NO dirty-set signal reads OUT OF PREMISE (a degenerate denominator is not agreement)',
+    ok: !dead.premiseMet && !Number.isFinite(dead.measured.mean),
   });
   // 6b. THE STRICT RULE IS PER BLOCK. Eight clean blocks must not vouch for
   //     a ninth that is wrong — that is `lane/control-verdict`'s recorded
@@ -746,8 +844,8 @@ function ctl3SelfTest() {
     plan, CONTROL_SLACK
   );
   checks.push({
-    name: 'ONE nonlinear block out of nine REFUSES (eight good blocks do not vouch for it)',
-    ok: !oneBad.ok && oneBad.perRound.length === 9 &&
+    name: 'ONE nonlinear block out of nine breaks the premise (eight good blocks do not vouch for it)',
+    ok: !oneBad.premiseMet && oneBad.perRound.length === 9 &&
       oneBad.perRound.filter((x) => Math.abs(x - predicted) < 0.01).length === 8,
   });
 
@@ -765,7 +863,7 @@ function ctl3SelfTest() {
       Math.abs(lin.predicted - r4(199 / 99)) < 1e-9 &&
       Math.abs(widerV.predicted - r4(180 / 80)) < 1e-9 &&
       Math.abs(widerV.measured.mean - r4(180 / 80)) < 5e-5 &&
-      widerV.ok,
+      widerV.premiseMet,
   });
 
   // 8. `additiveConstant` inverts a doubling control exactly, and reproduces
@@ -791,16 +889,16 @@ function ctl3SelfTest() {
   const decreasing = ctl3Verdict(synth((d) => 10 - A * d), plan, CONTROL_SLACK);
   const bandOnlyOnDecreasing = controlVerdict(predicted, decreasing.perRound, CONTROL_SLACK);
   checks.push({
-    name: 'a DECREASING linear page (more dirty work reads FASTER) REFUSES — though the band alone admits it',
+    name: 'a DECREASING linear page (more dirty work reads FASTER) breaks the premise — though the band alone admits it',
     ok:
       // the band alone admits it, and admits it exactly: this is the defect,
       // asserted rather than described.
-      bandOnlyOnDecreasing.ok &&
+      bandOnlyOnDecreasing.allInBand &&
       exact(decreasing.measured.mean) &&
       // both differences are negative, which is the thing the ratio hid
       decreasing.blocks.every((b) => b.num < 0 && b.den < 0) &&
       // and the shipped rule refuses every one of the nine blocks
-      !decreasing.ok &&
+      !decreasing.premiseMet &&
       !decreasing.sign.ok &&
       decreasing.sign.bad === 9 &&
       decreasing.sign.of === 9,
@@ -823,21 +921,21 @@ function ctl3SelfTest() {
   const zeroDen = ctl3Verdict(synth(at({ 1: 5.0, 100: 5.0, 200: 6.2 })), plan, CONTROL_SLACK);
   const nanArm = ctl3Verdict(synth((d) => (d === 100 ? NaN : A * d + C)), plan, CONTROL_SLACK);
   checks.push({
-    name: 'sign-degenerate blocks REFUSE: negative numerator, negative denominator, either exactly zero, or unreadable',
+    name: 'sign-degenerate blocks break the premise: negative numerator, negative denominator, either exactly zero, or unreadable',
     ok:
       // numerator negative, denominator positive: T rises then falls back
       // below T(eps). The ratio is finite and NEGATIVE.
-      !negNum.ok && negNum.sign.bad === 9 && negNum.blocks.every((b) => b.num < 0 && b.den > 0) &&
+      !negNum.premiseMet && negNum.sign.bad === 9 && negNum.blocks.every((b) => b.num < 0 && b.den > 0) &&
       // denominator negative, numerator negative-but-larger: a finite ratio
       // INSIDE the band, which is the sign-inverted defect in another shape.
-      !negDen.ok && negDen.sign.bad === 9 &&
+      !negDen.premiseMet && negDen.sign.bad === 9 &&
       Math.abs(negDen.measured.mean - r4(0.6 / 0.3)) < 5e-5 &&
       // numerator exactly zero: T(2D) indistinguishable from T(eps)
-      !zeroNum.ok && zeroNum.sign.bad === 9 && zeroNum.blocks.every((b) => b.num === 0) &&
+      !zeroNum.premiseMet && zeroNum.sign.bad === 9 && zeroNum.blocks.every((b) => b.num === 0) &&
       // denominator exactly zero: the ratio is not a number at all
-      !zeroDen.ok && zeroDen.sign.bad === 9 && zeroDen.blocks.every((b) => b.den === 0) &&
+      !zeroDen.premiseMet && zeroDen.sign.bad === 9 && zeroDen.blocks.every((b) => b.den === 0) &&
       // an arm that read nothing at all
-      !nanArm.ok && nanArm.sign.bad === 9,
+      !nanArm.premiseMet && nanArm.sign.bad === 9,
   });
 
   // 9c. AND THE GATE IS NOT A BLANKET REFUSAL. A rule that fails closed is
@@ -849,17 +947,17 @@ function ctl3SelfTest() {
   //     not read as a control holding.
   const noBlocks = ctl3Verdict([], plan, CONTROL_SLACK);
   checks.push({
-    name: 'the sign gate does not refuse a healthy world, and an EMPTY block set is not a pass',
+    name: 'the sign check does not condemn a healthy world, and an EMPTY block set is not a premise met',
     ok:
-      lin.ok && lin.sign.ok && lin.sign.bad === 0 &&
-      mult.ok && mult.sign.ok &&
-      widerV.ok && widerV.sign.ok &&
+      lin.premiseMet && lin.sign.ok && lin.sign.bad === 0 &&
+      mult.premiseMet && mult.sign.ok &&
+      widerV.premiseMet && widerV.sign.ok &&
       // and the refusals above are still refusals FOR THEIR OWN REASON: the
       // superlinear and sabotage worlds rise monotonically and are refused
       // by the band, not swept up by the new rule.
-      sup.sign.ok && !sup.ok &&
-      sab.sign.ok && !sab.ok &&
-      !noBlocks.ok && noBlocks.sign.of === 0,
+      sup.sign.ok && !sup.premiseMet &&
+      sab.sign.ok && !sab.premiseMet &&
+      !noBlocks.premiseMet && noBlocks.sign.of === 0,
   });
 
   // 10. THE SUMMARY MAY NOT LAUNDER A REFUSAL (rf2-8bgqq). The run figure is
@@ -887,10 +985,10 @@ function ctl3SelfTest() {
     CONTROL_SLACK
   );
   checks.push({
-    name: 'ONE near-zero-denominator block still REFUSES the run, though the MEDIAN lands dead on the prediction',
+    name: 'ONE near-zero-denominator block still breaks the premise, though the MEDIAN lands dead on the prediction',
     ok:
       // the run refuses — this is the whole point of the fixture
-      !heavy.ok &&
+      !heavy.premiseMet &&
       // and it refuses on the BAND, not swept up by the sign gate: every
       // difference here is a finite positive reading
       heavy.sign.ok && heavy.sign.bad === 0 &&
@@ -1642,15 +1740,32 @@ function report(out) {
   // has `ctl-50ms` — so reaching for one outside this branch reads an
   // undefined arm and dies mid-row. Which is what it did, and what the
   // keystroke smoke was run to find.
-  const ctlTask = hasProportionalControl
-    ? controlVerdict(2.0, SEGMENTS.flatMap((seg) => ratioToFloor(roundsTask, seg, 'ctl-2x')), CONTROL_SLACK)
+  const ctl2xBlocks = hasProportionalControl
+    ? SEGMENTS.flatMap((seg) => ratioToFloor(roundsTask, seg, 'ctl-2x'))
     : null;
+  const ctlTask = ctl2xBlocks ? controlVerdict(2.0, ctl2xBlocks, CONTROL_SLACK) : null;
   if (ctlTask) {
     console.log(
-      `;;   CONTROL on this clock: ${ctlTask.ok ? 'PASS' : 'FAIL'} ${ctlTask.measured.mean}x ` +
-        `[${ctlTask.measured.min} – ${ctlTask.measured.max}] against 2.00x +/-${CONTROL_SLACK * 100}%, ` +
-        `${ctlTask.rule}`
+      `;;   ctl-2x on this clock: ${ctlTask.measured.mean}x ` +
+        `[${ctlTask.measured.min} – ${ctlTask.measured.max}] against the ARITHMETIC 2.00x, ` +
+        `${ctlTask.inBand} of ${ctlTask.of} blocks inside +/-${CONTROL_SLACK * 100}% — ` +
+        `a DESCRIPTION and not the verdict (rf2-8a746): 2.00x is what doubling the page predicts and ` +
+        `not what this clock reads, and the gate is the check standard below`
     );
+  }
+
+  // --- THE CHECK STANDARD, which is what a row is gated on (rf2-8a746) -------
+  //
+  // Level over level, in the same block: the `ctl-2x` arm's tared reading over
+  // the floor's. The centre it is judged against is EMPIRICAL and frozen in
+  // `clock_check_standard.json` with its provenance, and the run-rejection
+  // rule is the run's own location and dispersion — never "every block inside
+  // a band", which is the rule rf2-8a746 retired with the three-point control
+  // for a separate reason: `0.835^18 = 3.9%`.
+  const checkStandard = ctl2xBlocks ? checkstd.checkStandard(ctl2xBlocks, rowId) : null;
+  if (checkStandard) {
+    console.log(`;; ---- CHECK STANDARD: is this run IN CONTROL? (rf2-8a746) ----`);
+    for (const line of checkstd.formatCheckStandard(checkStandard)) console.log(line);
   }
 
   // --- where the time goes --------------------------------------------------
@@ -1706,21 +1821,35 @@ function report(out) {
   // --- the positive control -------------------------------------------------
   let ctlVerdict = null;
   if (rowId !== 'keystroke') {
+    // ON THE SUPERSEDED CLOCK, AND A DIAGNOSTIC ON BOTH COUNTS (rf2-8a746).
+    // `taskNet` is not what the rows are stated on, and 2.00x is not what
+    // this instrument reads on either clock. Kept and printed because a
+    // reader comparing an old dataset with a new one needs the number the
+    // old rule turned on; the check standard above is what decides.
     const per = SEGMENTS.flatMap((seg) => ratioToFloor(rounds, seg, 'ctl-2x'));
     ctlVerdict = controlVerdict(2.0, per, CONTROL_SLACK);
     console.log(
-      `;; ---- POSITIVE CONTROL: ctl-2x builds exactly twice the page, so the prediction is 2.00x ----`
+      `;; ---- ctl-2x ON THE SUPERSEDED taskNet CLOCK — a diagnostic, never the verdict (rf2-8a746) ----`
     );
     console.log(
-      `;;   ${ctlVerdict.ok ? 'PASS' : 'FAIL'}  predicted ${ctlVerdict.predicted}x, band ` +
-        `[${ctlVerdict.band[0]} – ${ctlVerdict.band[1]}], measured ${ctlVerdict.measured.mean}x ` +
-        `[${ctlVerdict.measured.min} – ${ctlVerdict.measured.max}] over ${per.length} segment-rounds ` +
-        `(${ctlVerdict.rule})`
+      `;;   measured ${ctlVerdict.measured.mean}x [${ctlVerdict.measured.min} – ${ctlVerdict.measured.max}] ` +
+        `over ${per.length} blocks, ${ctlVerdict.inBand} of ${ctlVerdict.of} inside the arithmetic band ` +
+        `[${ctlVerdict.band[0]} – ${ctlVerdict.band[1]}] (${ctlVerdict.rule})`
     );
   } else {
     // A DIFFERENCE, so the tare cancels in it whether or not it is
     // subtracted — which is why this control is stated in milliseconds
     // rather than as a ratio.
+    //
+    // THIS ONE KEEPS ITS EVERY-BLOCK RULE, and the reason is worth stating
+    // where a `grep` for the retired rule will land (rf2-8a746). What was
+    // retired is a TOLERANCE BAND around a predicted centre applied to all 18
+    // blocks, whose arithmetic is `p^18` on a per-block pass rate below 1.
+    // This is not one: it is a one-sided sensitivity floor with a 10 ms margin
+    // on a 50 ms burn, so its per-block pass rate is 1 and there is no `p^n`
+    // to compound. Retiring it would loosen a control rf2-8a746 leaves
+    // untouched — rf2-swwud's responsiveness regime is WITHHELD when its
+    // fixed-work control does not move, and this is that control.
     const ctlTask = SEGMENTS.flatMap((seg) =>
       rounds.map((r) => p50(r[seg]['ctl-50ms']) - p50(r[seg][FLOOR]))
     );
@@ -1729,7 +1858,7 @@ function report(out) {
       predicted: `>= ${CTL_BUSY_MS - 10} ms of extra main-thread task time`,
       measured: b,
       ok: ctlTask.every((x) => x >= CTL_BUSY_MS - 10),
-      rule: 'strict — EVERY segment-round',
+      rule: 'strict — EVERY segment-round (a one-sided sensitivity floor, not a tolerance band)',
     };
     console.log(`;; ---- POSITIVE CONTROL: ctl-50ms burns 50 ms inside its own handler ----`);
     console.log(
@@ -1787,7 +1916,7 @@ function report(out) {
     );
   }
 
-  // --- THE THREE-POINT CONTROL ----------------------------------------------
+  // --- THE THREE-POINT STATISTIC — DIAGNOSTIC, NON-GATING (rf2-8a746) --------
   const ctl3 = ctl3Verdict(roundsTask, armPlan, CONTROL_SLACK);
   const ctl3Net = ctl3 ? ctl3Verdict(rounds, armPlan, CONTROL_SLACK) : null;
   const ctl3Layout = ctl3 ? ctl3Verdict(roundsLayout, armPlan, CONTROL_SLACK) : null;
@@ -1810,8 +1939,16 @@ function report(out) {
     const d = ctl3.dirty;
     const cells = (armPlan.find((a) => a.ctl3) || {}).cells;
     console.log(
-      `;; ---- THREE-POINT CONTROL: dirty ${Object.values(d).join(' / ')} of ${cells} boundaries, FIXED ` +
-        `page size — the floor's own page, so the canonical-DOM gate CHECKS these arms ----`
+      `;; ---- THREE-POINT STATISTIC [DIAGNOSTIC, NON-GATING — rf2-8a746]: dirty ` +
+        `${Object.values(d).join(' / ')} of ${cells} boundaries, FIXED page size — the floor's own page, ` +
+        `so the canonical-DOM gate CHECKS these arms ----`
+    );
+    console.log(
+      `;;   RETIRED  this statistic refuses nothing. It read 0 of 42 bulk row-runs in band across two ` +
+        `independent quiet-box ensembles, and rf2-8a746 retired it as a gate — not re-sited — because the ` +
+        `prediction is mis-derived on a clock that is not affine in the dirty set AND the denominator is ` +
+        `~2 sigma from zero. What it is now is a reading of the PAGE's dirty-set shape, published beside ` +
+        `its own internal control on LayoutDuration. The gate is the check standard above.`
     );
     console.log(
       `;;   parity   ${ctl3Parity.arms} control arms across ${SEGMENTS.length} segments, canonical DOM ` +
@@ -1890,27 +2027,29 @@ function report(out) {
       constants.orderAsPredicted = usable ? ordered : null;
       constants.orderUsable = usable;
     }
-    // THE SAME STATISTIC ON THE LAYOUT COUNTER ALONE. This is the line that
-    // decides whether a refusal is about the INSTRUMENT or about the
-    // WORKLOAD, and it is the question a three-point control cannot answer
-    // by itself. `LayoutDuration` is the part of a commit that must scale
-    // with the dirty set — d dirty rows, d relayouts — while paint does not
-    // once the damage region covers the viewport. If the control refuses on
-    // `task` and PASSES on `layout`, the arithmetic is sound and the page's
-    // cost simply is not affine in the dirty set; if it refuses on both,
-    // the fault is upstream of the workload.
+    // THE SAME STATISTIC ON THE LAYOUT COUNTER ALONE — and it is why the
+    // three-point statistic is still printed at all (rf2-8a746). It says
+    // whether the disagreement is about the INSTRUMENT or about the PAGE.
+    // `LayoutDuration` is the part of a commit that must scale with the dirty
+    // set — d dirty rows, d relayouts. Over both committed ensembles it reads
+    // 1.9681/1.9801 with flat marginals and never a negative difference in 756
+    // blocks, while the same arithmetic on `task` reads 1.569/1.575. The
+    // arithmetic, the door, the tare and the aggregation are therefore sound
+    // and the PAGE is not affine in the dirty set on the non-layout half.
     if (ctl3Layout) {
       console.log(
-        `;;   MECHANISM the same statistic on LayoutDuration alone: ${ctl3Layout.ok ? 'PASS' : 'FAIL'} ` +
+        `;;   MECHANISM the same statistic on LayoutDuration alone: ` +
           `${ctl3Layout.measured.p50.toFixed(4)}x median [${ctl3Layout.measured.min.toFixed(4)} – ` +
           `${ctl3Layout.measured.max.toFixed(4)}], marginal ${ctl3Layout.marginal.lower.mean.toFixed(3)} then ` +
           `${ctl3Layout.marginal.upper.mean.toFixed(3)} µs per dirty cell — a ` +
-          `${margGap(ctl3Layout.marginal).toFixed(1)}% disagreement against ${margGap(m).toFixed(1)}% on task`
+          `${margGap(ctl3Layout.marginal).toFixed(1)}% disagreement against ${margGap(m).toFixed(1)}% on task` +
+          `${ctl3Layout.premiseMet ? ' (premise met on layout)' : ''}`
       );
       console.log(
-        `;;            layout is the half of a commit that MUST scale with the dirty set; paint is the half ` +
-          `that stops scaling once the damage region covers the viewport. A control that holds on layout and ` +
-          `refuses on task is reporting the PAGE, not the clock.`
+        `;;            layout is the half of a commit that MUST scale with the dirty set, and it does. What ` +
+          `does not is in the NON-LAYOUT half: 7.1 -> 1.8 µs per cell, saturating below d=100, reproduced on ` +
+          `both ensembles. WHICH non-layout work is NOT established — these datasets carry Task, Script, ` +
+          `Layout and DevTools and no paint counter — so no row may state paint causation (rf2-8a746).`
       );
     }
     // THE SIGN, BEFORE THE NUMBER. The quotient is unchanged when both
@@ -1925,8 +2064,8 @@ function report(out) {
         .map((b) => `${b.seg} r${b.round} num ${b.num} ms / den ${b.den} ms`)
         .join('; ');
       console.log(
-        `;;   SIGN     REFUSED ${ctl3.sign.bad} of ${ctl3.sign.of} blocks — a numerator or denominator ` +
-          `that is not finite and strictly positive is not a reading of a rising cost` +
+        `;;   SIGN     ${ctl3.sign.bad} of ${ctl3.sign.of} blocks break the premise — a numerator or ` +
+          `denominator that is not finite and strictly positive is not a reading of a rising cost` +
           (eg ? `: ${eg}` : ` (no blocks at all)`)
       );
       console.log(
@@ -1936,42 +2075,47 @@ function report(out) {
       );
     }
     // THE RUN FIGURE IS THE MEDIAN, and the denominator stands beside it
-    // (rf2-8bgqq). The verdict on this line is unchanged — it is
-    // `ctl3.ok`, every block against the band plus every sign — and only the
-    // NUMBER describing the run has moved. It had to: a mean over 18 blocks of
-    // a quotient this close to a zero denominator is a summary of whichever
-    // block came nearest, and it reported two ensembles of the same experiment
-    // as 1.6045x and 86.05x when their block medians were 1.569 and 1.575.
-    // The mean is still printed, one line down, where it can be read as the
-    // tail-detector it actually is rather than as the headline.
+    // (rf2-8bgqq). A mean over 18 blocks of a quotient this close to a zero
+    // denominator is a summary of whichever block came nearest, and it
+    // reported two ensembles of the same experiment as 1.6045x and 86.05x
+    // when their block medians were 1.569 and 1.575. The mean is still
+    // printed, one line down, where it can be read as the tail-detector it
+    // actually is rather than as the headline.
+    //
+    // AND NEITHER NUMBER DECIDES ANYTHING NOW (rf2-8a746): `premiseMet`
+    // describes where the blocks fell, the row is gated on the check
+    // standard, and the label below says PREMISE rather than PASS so nobody
+    // reads a certificate off a diagnostic.
     console.log(
-      `;;   ${ctl3.ok ? 'PASS' : 'FAIL'}     measured ${ctl3.measured.p50.toFixed(4)}x MEDIAN of ` +
+      `;;   PREMISE ${ctl3.premiseMet ? 'MET    ' : 'NOT MET'} measured ${ctl3.measured.p50.toFixed(4)}x MEDIAN of ` +
         `${ctl3.perRound.length} blocks [${ctl3.measured.min.toFixed(4)} – ${ctl3.measured.max.toFixed(4)}] ` +
-        `against band [${ctl3.band[0]} – ${ctl3.band[1]}] (${ctl3.rule}), on a denominator of ` +
-        `${ctl3.signal.denMs.p50.toFixed(4)} ms [${ctl3.signal.denMs.min.toFixed(4)} – ` +
-        `${ctl3.signal.denMs.max.toFixed(4)}]`
+        `against band [${ctl3.band[0]} – ${ctl3.band[1]}], ${ctl3.inBand} of ${ctl3.of} blocks inside, ` +
+        `on a denominator of ${ctl3.signal.denMs.p50.toFixed(4)} ms ` +
+        `[${ctl3.signal.denMs.min.toFixed(4)} – ${ctl3.signal.denMs.max.toFixed(4)}] — ${ctl3.rule}`
     );
     console.log(
       `;;            the block MEAN is ${ctl3.measured.mean.toFixed(4)}x and is NOT the run figure: this ` +
         `statistic is a quotient whose denominator sits ~2 sigma from zero, so one near-zero block moves a ` +
         `mean by a factor of fifty and moves the median not at all. A mean far from the median above is a ` +
-        `reading about the DENOMINATOR, not about the page. Neither number decides anything — the verdict ` +
-        `is the strict per-block rule, and it is stated on the line above.`
+        `reading about the DENOMINATOR, not about the page.`
     );
     console.log(`;;   per-block ${ctl3.perRound.join(', ')}`);
     if (ctl3Net) {
       console.log(
-        `;;   the same statistic on the superseded taskNet clock: ${ctl3Net.ok ? 'PASS' : 'FAIL'} ` +
-          `${ctl3Net.measured.p50.toFixed(4)}x median — reported as a diagnostic, never as the verdict`
+        `;;   the same statistic on the superseded taskNet clock: ` +
+          `${ctl3Net.measured.p50.toFixed(4)}x median — a diagnostic of a diagnostic`
       );
     }
-    // SIDE BY SIDE with the control it replaces, on the SAME samples. The
-    // claim is not that the new control is kinder; it is that the old one was
-    // reading a quantity it could not correct for.
-    if (ctlTask) {
+    // SIDE BY SIDE with the standard that now gates the row, on the SAME
+    // samples and the same blocks. The two are printed together because the
+    // whole content of rf2-8a746 is which DENOMINATOR a control may have: a
+    // level carrying ~0.4 ms of estimator error on ~4.5 ms, against a
+    // difference carrying the same ~0.4 ms on 1.2 ms.
+    if (ctlTask && checkStandard) {
       console.log(
-        `;;   vs ctl-2x on the SAME samples: ${ctlTask.ok ? 'PASS' : 'FAIL'} ${ctlTask.measured.mean}x ` +
-          `against 2.00x — the gap is c/(W + c), and it is the same samples, the same blocks, one clock`
+        `;;   vs the check standard on the SAME samples: ${checkStandard.ok ? 'IN CONTROL' : 'REFUSED'} at ` +
+          `${checkStandard.location ? checkStandard.location.measured : 'n/a'}x median ctl-2x/floor — a LEVEL ` +
+          `over a LEVEL, 9% relative estimator error against this statistic's 48%`
       );
     }
   }
@@ -1991,7 +2135,7 @@ function report(out) {
 
   return {
     bar, inPageBar, barTask, ctlTask, bandTask, ctlVerdict, etVerdict, kbVerdict, guardVerdict: v,
-    guardVerdictTask: vTask, ctl3, ctl3Net, ctl3Layout, ctl3Parity, constants, sabotage,
+    guardVerdictTask: vTask, ctl3, ctl3Net, ctl3Layout, ctl3Parity, constants, sabotage, checkStandard,
     seamTask: {
       band: Number.isFinite(assessedTask.bandStats.band) ? r4(assessedTask.bandStats.band) : null,
       ceilingBreached: assessedTask.verdict.ceilingBreached,
@@ -2046,21 +2190,30 @@ function reportability(rows, opts) {
   const regimeRows = list.filter((r) => !regimeOf(r).publishesMagnitude);
   const ctlFailed = magnitudeRows.filter((r) => !r.ctlOk);
   const unadjudicated = magnitudeRows.filter((r) => !r.adjudicable);
-  const passed = magnitudeRows.filter((r) => r.ctlOk && r.adjudicable).map((r) => r.rowId);
+  const passed = sabotage ? [] : magnitudeRows.filter((r) => r.ctlOk && r.adjudicable).map((r) => r.rowId);
   const lines = [];
+  // THE FALSIFICATION KNOB REFUSES ON ITS OWN (rf2-8a746). It used to refuse
+  // through the three-point control — set the knob, the control's top arm
+  // renders fewer cells than it declares, the control fails, the run exits 1 —
+  // and that is exactly the coupling that retiring the control would have
+  // silently disarmed. A knob whose refusal depends on a gate that no longer
+  // gates is a knob that stopped working the day the gate did, and nothing
+  // would have said so. So the knob is its own refusal now, ahead of every
+  // control, and no row of a falsification run may be announced REPORTABLE.
+  if (sabotage) {
+    lines.push(
+      `[clock] FAILED: HCLOCK_CTL3_SABOTAGE=${sabotage} WAS SET — the three-point statistic's arms rendered ` +
+        `${sabotage} cells while declaring 200. This run is a FALSIFICATION and not a measurement of anything, ` +
+        `whatever every gate on it says. (rf2-8a746: the knob refuses on its own, because the control it used ` +
+        `to refuse through no longer gates.)`
+    );
+  }
   if (ctlFailed.length > 0) {
     lines.push(
       `[clock] FAILED: the positive control did not see the change its own arithmetic predicts on: ` +
         `${ctlFailed.map((r) => `${r.rowId}${r.ctlNote || ''}`).join(', ')}. ` +
         `No MAGNITUDE from those rows is reportable.`
     );
-    if (sabotage) {
-      lines.push(
-        `[clock] HCLOCK_CTL3_SABOTAGE=${sabotage} WAS SET: the control's arms rendered ${sabotage} cells ` +
-          `while declaring 200. This refusal is the DEMONSTRATION that the control can fail, and this run is not ` +
-          `a measurement of anything.`
-      );
-    }
   }
   // AND A ROW MAY HAVE A BAR IT CANNOT ADJUDICATE (rf2-y7mw7). This is a
   // different claim from the control's and it used to reach nothing: the
@@ -2130,7 +2283,7 @@ function reportability(rows, opts) {
       );
     }
   }
-  if (ctlFailed.length === 0 && unadjudicated.length === 0 && regimeRows.length === 0) {
+  if (!sabotage && ctlFailed.length === 0 && unadjudicated.length === 0 && regimeRows.length === 0) {
     return { code: 0, lines };
   }
   lines.push(
@@ -2346,7 +2499,9 @@ function reportabilitySelfTest() {
   // THE CONTROL GATE IS UNCHANGED, which is the other half of the repair: the
   // bar-level verdict was ADDED to the exit code, not substituted for the
   // row-level one.
-  const ctl = reportability([row({ ctlOk: false, ctlNote: ' (three-point 1.2134x vs 2.0101x)' })]);
+  const ctl = reportability([
+    row({ ctlOk: false, ctlNote: ' (check standard hicasso-clock/ctl-2x-level v1: median 0.6156x is outside [1.5509 – 1.8905])' }),
+  ]);
   check(
     'a failed positive control still refuses, alone, exactly as before',
     ctl.code === 1 && /the positive control did not see the change/.test(ctl.lines[0] || ''),
@@ -2357,6 +2512,19 @@ function reportabilitySelfTest() {
     'the falsification knob still says the run was a falsification',
     sab.code === 1 && sab.lines.some((l) => l.includes('HCLOCK_CTL3_SABOTAGE=140')),
     sab.lines.join(' | ')
+  );
+  // AND IT REFUSES ON ITS OWN NOW (rf2-8a746). The knob perturbs the arms of a
+  // statistic that no longer gates, so a run in which every gate PASSES is
+  // exactly the case that used to be impossible and is now the one that
+  // matters: without this the retirement would have disarmed the falsification
+  // knob and nothing would have said so.
+  const sabClean = reportability([row({}), row({ rowId: 'bulk300' })], { sabotage: 140 });
+  check(
+    'THE KNOB REFUSES A RUN WHOSE EVERY GATE PASSED — the retirement did not disarm it',
+    sabClean.code === 1 &&
+      /HCLOCK_CTL3_SABOTAGE=140 WAS SET/.test(sabClean.lines[0] || '') &&
+      sabClean.lines[sabClean.lines.length - 1] === '[clock] REPORTABLE: none.',
+    sabClean.lines.join(' | ')
   );
 
   const both = reportability([row({ rowId: 'keystroke', ctlOk: false, adjudicable: false, unadjudicatedWhy: KEYSTROKE_WHY })]);
@@ -2674,8 +2842,14 @@ function datasetFor(outcomes, meta) {
       seam: o.verdict.seam,
       seamTask: o.verdict.seamTask,
       tally: o.verdict.tally,
-      ctlOk: o.verdict.ctlVerdict ? o.verdict.ctlVerdict.ok : null,
-      // THE THREE-POINT CONTROL, whole — its per-block readings, the
+      // `null` ON EVERY ROW BUT `keystroke` NOW (rf2-8a746). This field was
+      // the taskNet ctl-2x all-blocks verdict, and that rule is retired: on a
+      // row with a proportional control `ctlVerdict` is a DESCRIPTION carrying
+      // no `ok`, and `null` here says the run took no such verdict rather than
+      // inventing one. `keystroke`'s fixed-work sensitivity floor keeps its
+      // boolean, because that control is untouched.
+      ctlOk: o.verdict.ctlVerdict && typeof o.verdict.ctlVerdict.ok === 'boolean' ? o.verdict.ctlVerdict.ok : null,
+      // THE THREE-POINT STATISTIC, whole — its per-block readings, the
       // absolutes each difference was taken from, the fitted line and
       // the constant it recovers. `armPlan` is the page's DECLARED
       // plan and `sabotage` is what the 2D arm actually rendered, so a
@@ -2684,6 +2858,14 @@ function datasetFor(outcomes, meta) {
       ctl3: o.verdict.ctl3,
       ctl3Net: o.verdict.ctl3Net,
       ctl3Layout: o.verdict.ctl3Layout,
+      // THE GATE THE ROW ACTUALLY TURNED ON (rf2-8a746), with the standard's
+      // own id and version in it, so a reader can tell a run adjudicated
+      // against v1 from one adjudicated against a recalibrated v2. It is
+      // RECORDED here and RECOMPUTED by `clock_readjudicate.cjs` — a check
+      // standard is versioned data applied by the reader, and re-applying a
+      // new standard to an old dataset is the whole point of freezing it as
+      // data rather than as a stored boolean.
+      checkStandard: o.verdict.checkStandard,
       roundsLayout: o.out.roundsLayout,
       ctl3Parity: o.verdict.ctl3Parity,
       constants: o.verdict.constants,
@@ -2740,14 +2922,30 @@ async function main() {
   // nine, and a page on which more dirty work reads FASTER at exactly the
   // predicted ratio — stated as fixtures, plus the case that shows the
   // doubling control failing on a world the three-point one passes.
+  // THE CHECK STANDARD FIRST, because it is the one that gates a row
+  // (rf2-8a746). Its fixtures are the refusals a standard is only worth its
+  // certificate for having been seen to make — the sabotage above all, an arm
+  // that does not build what it declares.
+  const cst = checkstd.checkStandardSelfTest();
+  const badCst = cst.checks.filter((c) => !c.ok);
+  for (const c of cst.checks) console.error(`[clock] check-standard   ${c.ok ? 'ok  ' : 'FAIL'}  ${c.name}`);
+  if (badCst.length > 0) {
+    console.error(`[clock] the check standard's own self-test FAILED: ${badCst.map((c) => c.name).join(', ')}`);
+    process.exit(1);
+  }
+  console.error(
+    `[clock] check standard self-test: ${cst.checks.length} checks, all ok ` +
+      `(${checkstd.STANDARD.id} v${checkstd.STANDARD.version})`
+  );
+
   const c3st = ctl3SelfTest();
   const badCtl3 = c3st.checks.filter((c) => !c.ok);
   for (const c of c3st.checks) console.error(`[clock] ctl3 self-test  ${c.ok ? 'ok  ' : 'FAIL'}  ${c.name}`);
   if (badCtl3.length > 0) {
-    console.error(`[clock] the three-point control's own self-test FAILED: ${badCtl3.map((c) => c.name).join(', ')}`);
+    console.error(`[clock] the three-point diagnostic's own self-test FAILED: ${badCtl3.map((c) => c.name).join(', ')}`);
     process.exit(1);
   }
-  console.error(`[clock] three-point control self-test: ${c3st.checks.length} checks, all ok`);
+  console.error(`[clock] three-point DIAGNOSTIC self-test: ${c3st.checks.length} checks, all ok (gates nothing — rf2-8a746)`);
 
   // The keystroke witness's fixtures run on EVERY invocation, not only under
   // `--selftest`, for the three-point control's reason: they are cheap, they
@@ -3023,43 +3221,29 @@ async function main() {
     process.exit(1);
   }
 
-  // THE CONTROL IS ADJUDICATED ON THE PUBLISHED CLOCK TOO. `ctlVerdict` is
-  // the `taskNet` verdict and was the only one this gate consulted; the row
-  // is now stated on raw `TaskDuration`, so its control has to hold there.
-  // In practice the two agree to within 2% — `rf2-yd52q` measured that — so
-  // this is a gate that should almost never change an answer, and one that
-  // would be indefensible to leave out for exactly that reason.
-  // THE THREE-POINT CONTROL IS THE GATE ON A BULK ROW, and `ctl-2x` is
-  // demoted to a reported diagnostic on those rows rather than deleted
-  // (rf2-7iqb5, rf2-5xrcd).
+  // THE ROW IS GATED ON THE CHECK STANDARD (rf2-8a746), and on nothing else
+  // that this file used to consult.
   //
-  // Demotion and not removal, because the two disagree for a REASON that is
-  // itself measured here — `ctl-2x` reads `(2W + c)/(W + c)` and the run
-  // prints the `c` that explains the gap — and a control removed the moment
-  // it started failing is indistinguishable from a control tuned until it
-  // passed. `ctl-2x` also still supplies the band, which needs a pair whose
-  // true ratio is a property of the page and does NOT need that ratio to be
-  // 2.00; nothing about the band moves in this change, deliberately, because
-  // moving the band in the same change that repairs the control would make
-  // the repair unfalsifiable.
+  // WHAT WAS HERE AND IS GONE. This predicate read `ctl3.ok` on a bulk row and
+  // `ctlVerdict.ok || ctlTask.ok` — the ±25% band about a theoretical 2.00x,
+  // every block — everywhere else. Both are retired. The three-point statistic
+  // refused 42 of 42 bulk row-runs on a mis-derived prediction and an
+  // ill-conditioned estimator, and the all-blocks rule is a separate defect
+  // whose arithmetic is `p^18`: a control fully MEETING its premise passes 4 of
+  // 42 runs at an 83.5% per-block rate. Neither name exists to be read now —
+  // `ctl3` carries `premiseMet` and `controlVerdict` carries `allInBand`.
   //
-  // A row that HAS no three-point control — `M1`, whose operation is the
-  // mount, and `keystroke` — is gated exactly as before.
-  const ctlBad = (o) =>
-    o.verdict.ctl3
-      ? !o.verdict.ctl3.ok
-      : !o.verdict.ctlVerdict.ok || (o.verdict.ctlTask && !o.verdict.ctlTask.ok);
-  const demoted = outcomes.filter(
-    (o) => o.verdict.ctl3 && o.verdict.ctl3.ok && (!o.verdict.ctlVerdict.ok || (o.verdict.ctlTask && !o.verdict.ctlTask.ok))
-  );
-  for (const o of demoted) {
-    console.error(
-      `[clock] ${o.out.rowId}: ctl-2x FAILED at ${o.verdict.ctlTask ? o.verdict.ctlTask.measured.mean : '?'}x and the ` +
-        `THREE-POINT control PASSED at ${o.verdict.ctl3.measured.p50.toFixed(4)}x median on the same samples. ` +
-        `The row is gated on the three-point control. c(2x) = ` +
-        `${o.verdict.constants ? o.verdict.constants.c2x.mean.toFixed(4) : '?'} ms is the reported reason they differ.`
-    );
-  }
+  // WHAT IS HERE INSTEAD. `checkStandard`, whose denominator is a LEVEL, whose
+  // expected centre is EMPIRICAL and frozen with its provenance, and whose
+  // run-rejection rule is the run's own location and dispersion at stated
+  // error rates (0.4% nominal per run, 0 of 42 empirical, against the retired
+  // rule's 90.5%). A row it cannot certify — `keystroke`, which has no
+  // proportional control arm, and `M1`, whose class rf2-8a746 deliberately
+  // left uncalibrated for rf2-t2flm — FAILS CLOSED and says which.
+  //
+  // The Event-Timing witness still refuses beside it, unchanged: the two make
+  // different claims and a row can fail both.
+  const ctlBad = (o) => !(o.verdict.checkStandard && o.verdict.checkStandard.ok);
   // THE DECISION HAS ONE SEAT (`reportability`, above). Nothing below reads a
   // refusal on its own: the summary is built, the function decides, its lines
   // are printed and its code is the exit code.
@@ -3077,13 +3261,13 @@ async function main() {
         regime: rowRegime(o.out.rowId),
         ctlOk: !(ctlBad(o) || (o.verdict.etVerdict && !o.verdict.etVerdict.ok)),
         // THE PARENTHETICAL A REFUSAL CARRIES, and therefore the one sentence
-        // most likely to be quoted out of the log — so it reports the MEDIAN
-        // and names its denominator in milliseconds (rf2-8bgqq). It describes
-        // the refusal; `ctlOk` above decides it, from `ctl3.ok`.
-        ctlNote: o.verdict.ctl3
-          ? ` (three-point ${o.verdict.ctl3.measured.p50.toFixed(4)}x median vs ` +
-            `${o.verdict.ctl3.predicted}x, on a ${o.verdict.ctl3.signal.denMs.p50.toFixed(4)} ms denominator)`
-          : '',
+        // most likely to be quoted out of the log — so it is the CHECK
+        // STANDARD's own refusal, in its own words (rf2-8a746). It describes
+        // the refusal; `ctlOk` above decides it, from `checkStandard.ok`.
+        ctlNote: o.verdict.checkStandard
+          ? ` (check standard ${o.verdict.checkStandard.standard.id} v${o.verdict.checkStandard.standard.version}: ` +
+            `${o.verdict.checkStandard.why || 'in control'})`
+          : ' (no check standard on this row — a run with no proportional control arm cannot be certified in control)',
         // THE BAR-LEVEL RULE HAS ONE SEAT TOO (`rowAdjudication`, above), for
         // the reason the run-level one does: a rule written out here is a rule
         // no test can drive.
@@ -3103,9 +3287,12 @@ module.exports = {
   rowRegime,
   ROW_REGIME,
   reportabilitySelfTest,
-  // The three-point control's own arithmetic and its fixture set, exported so
-  // the witness can drive the REFUSALS directly rather than through a headless
+  // The three-point DIAGNOSTIC's arithmetic and its fixture set, exported so
+  // the witness can drive them directly rather than through a headless
   // Chromium (rf2-8bgqq) — the same reason `reportability` is exported above.
+  // It decides nothing (rf2-8a746); `clock_check_standard.cjs` is the gate,
+  // and it is required by both this driver and the readjudicator rather than
+  // re-exported here, so there is one module and not two ways to reach it.
   ctl3Verdict,
   ctl3SelfTest,
   publication,


### PR DESCRIPTION
Executes the DELEGATED DECISION on **rf2-8a746** (2026-08-07 11:38). One bounded protocol change in the driver and the readjudicator; no new measurement was taken and no quiet box was consumed. Everything below is arithmetic over the committed corpus.

## What changed, against the four parts of the ruling

**(1) The three-point difference-of-differences control is RETIRED AS A GATE.** Not re-sited, not re-tried — there is no re-siting code in the diff and a test asserts there is none. Its `ok` field is gone, so no gate has a name to read: it carries `premiseMet` and `gating: false`, and every printout is relabelled `THREE-POINT STATISTIC [DIAGNOSTIC, NON-GATING — rf2-8a746]`. It still prints, because `ctl3Layout` is healthy (1.9681/1.9801 on identical blocks, flat marginals, 756 of 756 differences positive) and that makes the pair a live reading of the page's dirty-set shape.

**(2) The all-18-blocks strict rule is retired with it, everywhere on this instrument.** `controlVerdict` no longer returns `ok` at all — it returns `inBand`, `of` and `allInBand`, named for the description they are. A grep-driven test pins that the only surviving `strict — EVERY` on this instrument is `keystroke`'s fixed-work sensitivity floor, and the code says why in place: that is a one-sided threshold with a 10 ms margin on a 50 ms burn, so its per-block pass rate is 1 and there is no `p^n` to compound; retiring it would loosen a control the ruling leaves untouched and would unconditionally state rf2-swwud's regime.

**(3) The replacement is a level-denominated, empirically calibrated, versioned check standard.** It lands as data — `clock_check_standard.json`, v1 — applied by `clock_check_standard.cjs`, which the driver and the readjudicator both require so there is one seat and not two.

**(4) The product claim is adjudicated on the quantity it asserts.** The readjudicator now computes, per row and per pair, the paired same-round Hicasso/donor **level** ratio at fixed witness and fixed K, as an effect-size confidence interval from a run-preserving hierarchical bootstrap (paired log-ratios; outer RUNS resampled before inner ROUNDS, Kalibera & Jones 2013; 4000 draws, seed 20260807 so the interval is reproducible). A magnitude publishes only when the whole interval lies on the required side of 1.0 / 1.5 **and** the effect clears the same-run noise band; otherwise the row publishes INSTRUMENT-LIMITED and never a magnitude, and the pooled means above it are labelled diagnostics.

## The check standard, and where its numbers come from

Recomputed from the 42 committed row-runs (`clock-emvod` run1-8, `clock-w3yxd` run1-6) and they reproduce the ruling's seed exactly: run-median centre **1.7207x** (ruling: 1.721), range **1.5960 – 1.8288** (1.596 – 1.829), between-run SD **0.0566** (0.057).

| | frozen | derivation |
|---|---|---|
| location statistic | run median of 18 blocks | rf2-8bgqq — a ratio's headline is its median |
| location limits | `[1.5509, 1.8905]` | centre ± 3 × between-run SD |
| dispersion statistic | robust scale, IQR / 1.349 | normal-consistent, not movable by one wild block |
| dispersion limit | `0.568` | `exp(mu + 3 sigma)` of the 42 log scales — 35% above the widest observed draw, not *at* it |
| tolerance band | `[1.2905, 2.1509]` | ±25% about the empirical centre — **REPORTED, gating nothing** |

**Distinct, calibrated error rates**, as the ruling requires:

* run-rejection rule: **0.4% nominal per run** (location 0.27% two-sided 3σ, dispersion 0.13% one-sided lognormal 3σ); **0 of 42 empirical**.
* per-block tolerance band: **8.2% of blocks fall outside** (694/756 inside). It decides nothing.
* the retired rule, for comparison: 626/756 blocks (82.8%) inside a ±25% band about the theoretical 2.00x, **4 of 42 runs passing — a 90.5% per-run false refusal**. Re-centring that band on the empirical 1.7207 lifts the pooled in-band fraction to 91.8% and still passes only **10 of 42**, because `0.918^18 = 21.4%`. That is the ruling's point as arithmetic: the wrong centre and the all-blocks rule are two separate defects and this repairs both.

The standard records its own limitation: v1 is seeded from the very 42 row-runs it is quoted against, so 0-of-42 is a consistency check and not a false-refusal measurement. `recalibrateOn` names the conditions (browser, harness, page, clock) and requires a fresh baseline next time — NIST e-Handbook 2.3.5.

**The mount class is deliberately left UNCALIBRATED and fails closed**, handing the mount decision function to **rf2-t2flm** by id, with the observed M1 figures (14 row-runs, centre 1.7956, SD 0.0397) recorded as evidence for that ruling and read by nothing. This does not withhold a magnitude: M1 publishes DIRECTION only, by rf2-jcm3p.

## What the readjudicator now says about the committed corpus

**Every pair of every bulk row on both ensembles publishes INSTRUMENT-LIMITED. No magnitude is published from the 42 committed row-runs.** Both programs exit 0.

All 42 bulk row-runs are IN CONTROL under the check standard. The rows are then limited for two different, stated reasons:

* on `hicasso / reagent-subs` and `hicasso / uix-subs` for most rows, because the interval straddles the 1.0 bar — e.g. emvod bulk300 `hicasso / reagent-subs` point 0.9922x, CI `[0.9529 – 1.0385]` over 8 runs; emvod bulk100 `hicasso / uix-subs` point 1.1067x, CI `[1.0521 – 1.1618]`;
* on the intervals that *do* lie wholly on one side, because the effect does not clear the same-run noise band — emvod bulk300 `uix-subs / reagent-subs` point 0.8699x, CI `[0.8327 – 0.9031]`, a 13.0% effect against a 28.4% widest same-run band; w3yxd bulk300 the same pair, 9.6% against 15.5%.

M1 is refused ahead of any interval by the uncalibrated mount class; `keystroke` by having no proportional control arm at all, beside its existing refusals.

## Quality gates

Every gate run in the foreground to completion from the worker worktree, never piped through `tail`/`head`/`grep`; each long gate's `gate root:` verified as `/c/Users/miket/code/re-frame2-worktrees/ctl3retire-8a746`.

| gate | exit |
|---|---|
| `node --check` on `clock_run.cjs`, `clock_readjudicate.cjs`, `clock_check_standard.cjs`, `clock_exit_path.test.cjs` | 0 |
| `node clock_check_standard.cjs` (16 fixtures) | 0 |
| `node clock_readjudicate.cjs data/clock-emvod/run*.json` | 0 (was 0 before the change) |
| `node clock_readjudicate.cjs data/clock-w3yxd/run*.json` | 0 (was 0 before the change) |
| `node clock_exit_path.test.cjs` | 0 — **273 passed** (251 before; 22 new) |
| `npm run test:script-helpers` | 0 |
| `sh scripts/test-fast-pr.sh` | 0 |
| `npm run lint:js` (repo root) | 0 |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | 0 — "No beads-database paths in this PR diff." |

## Mutation proofs

Each mutation applied to the shipped implementation, the suite run, then reverted and re-run. Counts are `clock_exit_path.test.cjs`.

**Criterion 2 — the sabotage fixture.** Widened the frozen bulk location limits from `[1.5509, 1.8905]` to `[0.4, 3.0]`, so an arm rendering 140 of the 300 boundaries it declares doubled (block median 0.6156x) would pass:

* **RED: 7 of 273 failed** — `the standard's own fixtures pass, every case`; `THE SABOTAGE: an arm building 140 of the 300 boundaries it declares doubled is REFUSED`; `and the sabotage reaches the consumer — a dataset carrying it may not be pooled`; `gate check-standard: a FAILED verdict removes the run from the subset`; `the OTHER two terms are unchanged`; `EVERY reason is reported, not the first`; `criterion 1: and behaviourally — flipping the three-point record changes no verdict`.
* **GREEN on revert: 273 passed**, file byte-identical to the committed one.

**Criterion 3 — the verdict rule.** Three separate mutations of `clock_readjudicate.cjs`:

| mutation | red | green on revert |
|---|---|---|
| whole-interval → point estimate (`iv.hi < bar` / `iv.lo > kill` become `iv.point`) | **1 of 273** — `criterion 3: the WHOLE interval must clear the threshold, and the effect must clear the band` | 273 passed |
| noise-band clause removed (`clearsNoise = true`) | **3 of 273** — the boundary test, `every pair of every bulk row gets a stated verdict over the committed corpus`, and `the program itself exits 0 over both committed ensembles, publishing no magnitude` | 273 passed |
| run-preserving order removed (pool all rounds, resample the pool) | **1 of 273** — `criterion 3: the interval is run-preserving — outer RUNS resampled before inner ROUNDS` | 273 passed |

The corpus test is red under the noise-band mutation because without that clause two pairs would publish a magnitude from the 42 committed row-runs — which is exactly the fence the test exists to hold.

## Hard refusals: none loosened

Read-back, canonical-DOM, page-error, arm-order, quiet-box and band-ceiling are untouched, and the roster tests that drive each one still pass unchanged. `ctl3-parity` stays in the gate roster — it is a canonical-DOM refusal about whether the control's own arms built one page, which the ruling leaves in the UNCHANGED list. The band ceiling still removes emvod narrow run1 and w3yxd bulk300 run5/run6 and bulk100 run1/run2 from the pooled set, before any control is consulted.

Two things were made **stricter**, both deliberately:

* **the falsification knob now refuses on its own.** `HCLOCK_CTL3_SABOTAGE` used to refuse *through* the three-point control, so retiring that control would have silently disarmed it and nothing would have said so. A falsification run now refuses whatever every gate says, and a test drives the case that used to be impossible — every gate passing, knob set, exit 1, `REPORTABLE: none`.
* **the readjudicator's mount rows are refused** by the uncalibrated class rather than by a `ctl-2x`-vs-2.00 verdict that passed 4 of 8. A consumer stricter than its producer can withhold a magnitude the driver would have allowed, never publish one it refused — which is this file's own standing asymmetry.

## The 42 committed row-runs, and what was not claimed

No row is published from them. They are calibration and diagnostic evidence, exactly as the ruling states, and the corpus test asserts `publishes === false` on every pair of every bulk row for that reason — if the procedure ever published from them the test fails, and that failure is the finding rather than something to tune away.

**No surface states paint causation.** `clock_app.cljs` said flatly "The mechanism is PAINT, and it saturates"; that paragraph is rewritten to the established form — the concave term is in the NON-LAYOUT half, collapses 7.1 → 1.8 µs per dirty cell, and saturates below `d = 100`, all measured on both ensembles — with viewport clipping labelled as the inference it is, because these datasets carry Task/Script/Layout/DevTools and no paint counter. A test greps all three surfaces for causal paint claims and fails on any.

## Scope boundary, stated rather than assumed

`grep` for the `^18` semantics also finds `shapes/census_clock_run.cjs:277`, `'strict — EVERY block inside the band'`. **It is deliberately not changed.** That is a different instrument: a different driver, different rows, its own datasets under `data/censusclock-*`, and a control whose prediction comes from the row's own element arithmetic rather than from a page doubling. Applying this standard's frozen limits — seeded from `clock_run.cjs`'s `ctl-2x/floor` — to it would re-commit the exact mis-specification rf2-8a746 retires. It needs its own calibration and its own ruling; filed as **rf2-y0pkh**, which asks for the census rig's own per-block rate to be computed over its retained datasets first — a rule with a defensible false-refusal rate is not a defect.
