### PR TITLE
fix(hicasso): the census rig's run-rejection rate, measured (rf2-y0pkh)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -889,6 +889,222 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   });
 }
 
+// --- rf2-y0pkh: the census run-rejection rule's false-refusal rate, MEASURED --
+//
+// rf2-8a746 retired the all-blocks strict rule on the HICASSO CLOCK, and the
+// `^18` grep that ruling mandated also landed here — on a different
+// instrument, with a different driver, its own datasets, and a control whose
+// prediction is the row's own element arithmetic rather than a page doubling.
+// The ruling rejects retiring a control merely because it shares a shape with
+// one that failed, so the rule was MEASURED here before being decided on.
+// `1 - p^n` is a property of the rule and not of the clock, so only `p`
+// decides it — and this rig's `p` is not that rig's. The rule is RETAINED.
+//
+// Everything below recomputes from the committed datasets through the
+// driver's OWN `controlBlocks` and `controlVerdict`. That `controlVerdict` is
+// exported here where the clock's deliberately is not, and the asymmetry is
+// the point: on the clock it was retired and now decides nothing, so a test
+// able to reach it would be a reader able to reach it; here its `ok` is still
+// the decision, reaching `summarise` -> `verdict` -> exit 5. A rule a test
+// cannot drive is not a checked rule however exactly it is quoted.
+
+{
+  const { controlBlocks, controlVerdict } = DRIVERS[1].mod;
+  const CSRC = fs.readFileSync(DRIVERS[1].file, 'utf8');
+  const t = (what, fn) => test(`census run-rejection rate: ${what}`, fn);
+
+  // The corpus the rates are stated over, and the rates themselves. Stated as
+  // literals so that a new dataset, or an arithmetic change, reds this file
+  // rather than silently ageing the driver's comment into a false claim.
+  const CORPUS = { datasets: 5, rowRuns: 30, blocks: 540, n: 18, slack: 0.25 };
+  const RATES = {
+    'large-template': { rowRuns: 10, blocks: 180, inBand: 178, passed: 8, falseRefusalPct: '18.2' },
+    feed: { rowRuns: 10, blocks: 180, inBand: 175, passed: 7, falseRefusalPct: '39.8' },
+    ordinary: { rowRuns: 10, blocks: 180, inBand: 56, passed: 0, falseRefusalPct: '100.0' },
+  };
+
+  const med = (xs) => {
+    const v = [...xs].sort((a, b) => a - b);
+    return v.length % 2 ? v[(v.length - 1) / 2] : (v[v.length / 2 - 1] + v[v.length / 2]) / 2;
+  };
+  const choose = (n, k) => {
+    let x = 1;
+    for (let i = 0; i < k; i++) x = (x * (n - i)) / (i + 1);
+    return x;
+  };
+  const binom = (n, k, p) => choose(n, k) * p ** k * (1 - p) ** (n - k);
+  /** Exact two-sided p-value for k of n at probability p — no normal approximation at n=10. */
+  const exactTwoSided = (n, k, p) => {
+    const ceiling = binom(n, k, p) * (1 + 1e-7);
+    let s = 0;
+    for (let i = 0; i <= n; i++) if (binom(n, i, p) <= ceiling) s += binom(n, i, p);
+    return s;
+  };
+
+  /** Every committed census row-run, its statistic recomputed by the driver's own arithmetic. */
+  const corpus = () => {
+    const dir = path.join(__dirname, 'data');
+    return fs
+      .readdirSync(dir)
+      .filter((d) => d.startsWith('censusclock-'))
+      .sort()
+      .flatMap((d) =>
+        fs
+          .readdirSync(path.join(dir, d))
+          .filter((f) => f.endsWith('.json'))
+          .sort()
+          .flatMap((f) => {
+            const data = JSON.parse(fs.readFileSync(path.join(dir, d, f), 'utf8'));
+            return data.rows.map((r) => {
+              const per = controlBlocks(r.blocksTask);
+              return {
+                where: `${d}/${f} ${r.rowId}`,
+                rowId: r.rowId,
+                slack: data.design.controlSlack,
+                stored: r.adjudication.ctl,
+                // The band the run ACTUALLY adjudicated on, read back rather
+                // than re-derived: the run held the page's raw `ctlPredicted`
+                // and the dataset stores `r4` of it, so a re-derived edge can
+                // differ by one unit in the last stored place. Counting on the
+                // stored band measures the rate the runs experienced.
+                band: r.adjudication.ctl.band,
+                per,
+                verdict: controlVerdict(r.ctlPredicted, per, data.design.controlSlack),
+              };
+            });
+          })
+      );
+  };
+
+  t('the corpus the rates are stated over is the corpus on disk', () => {
+    const all = corpus();
+    const datasets = new Set(all.map((r) => r.where.split('/')[0]));
+    assert.strictEqual(datasets.size, CORPUS.datasets, 'a new censusclock-* dataset means the stated rates need recounting');
+    assert.strictEqual(all.length, CORPUS.rowRuns);
+    for (const r of all) {
+      assert.strictEqual(r.per.length, CORPUS.n, `${r.where}: n is the design's 6 rounds x 3 blocks`);
+      assert.strictEqual(r.slack, CORPUS.slack, `${r.where}: the tolerance band must be the one the rates were measured at`);
+    }
+    assert.strictEqual(
+      all.reduce((a, r) => a + r.per.length, 0),
+      CORPUS.blocks
+    );
+    // A per-row rate pools blocks across row-runs, which only means something
+    // if every row-run of that row was judged against the same band.
+    for (const rowId of Object.keys(RATES)) {
+      const bands = new Set(all.filter((r) => r.rowId === rowId).map((r) => r.band.join(':')));
+      assert.strictEqual(bands.size, 1, `${rowId}: its row-runs must share one band — ${[...bands].join(' / ')}`);
+    }
+  });
+
+  t('the live arithmetic and the stored verdicts are the same quantity', () => {
+    // Without this the rate would be a rate about the datasets rather than
+    // about the rule: a statistic recomputed differently from the one the
+    // driver adjudicated on would measure the recomputation.
+    for (const r of corpus()) {
+      assert.deepStrictEqual(r.verdict.perBlock, r.stored.perBlock, `${r.where}: recomputed blocks must match the stored ones`);
+      assert.strictEqual(r.verdict.ok, r.stored.ok, `${r.where}: same strict verdict`);
+      // The one place the two can legitimately differ, and by exactly one unit
+      // in the last stored place: `datasetFor` writes `r4(ctlPredicted)` while
+      // the run adjudicated on the page's raw value. Bounded rather than
+      // deep-equalled, because a wider drift would mean the band moved.
+      for (const i of [0, 1]) {
+        assert.ok(
+          Math.abs(r.verdict.band[i] - r.stored.band[i]) <= 1e-4 + Number.EPSILON,
+          `${r.where}: band edge ${i} drifted beyond the stored grain (${r.verdict.band[i]} vs ${r.stored.band[i]})`
+        );
+      }
+      assert.strictEqual(
+        r.per.every((x) => x >= r.band[0] && x <= r.band[1]),
+        r.stored.ok,
+        `${r.where}: the stored band and the stored verdict must agree`
+      );
+    }
+  });
+
+  t('the measured rate, per row — and it is survivable where the control meets its premise', () => {
+    const all = corpus();
+    for (const [rowId, want] of Object.entries(RATES)) {
+      const rows = all.filter((r) => r.rowId === rowId);
+      const blocks = rows.flatMap((r) => r.per);
+      const [lo, hi] = rows[0].band;
+      const inBand = blocks.filter((x) => x >= lo && x <= hi).length;
+      const passed = rows.filter((r) => r.verdict.ok).length;
+      assert.strictEqual(rows.length, want.rowRuns, `${rowId}: row-runs`);
+      assert.strictEqual(blocks.length, want.blocks, `${rowId}: blocks`);
+      assert.strictEqual(inBand, want.inBand, `${rowId}: per-block in band`);
+      assert.strictEqual(passed, want.passed, `${rowId}: runs the strict rule passed`);
+      const p = inBand / blocks.length;
+      assert.strictEqual(((1 - p ** CORPUS.n) * 100).toFixed(1), want.falseRefusalPct, `${rowId}: 1 - p^${CORPUS.n}`);
+    }
+    // The claim that decides the bead: on the two rows carrying the gated pair
+    // the rule costs 18-40% of runs, against the 90.5% empirical per-run false
+    // refusal that retired the clock's. A rate a run survives is not a defect.
+    assert.ok(Number(RATES['large-template'].falseRefusalPct) < 90.5);
+    assert.ok(Number(RATES.feed.falseRefusalPct) < 90.5);
+  });
+
+  t('the arithmetic and the empirical rate AGREE, so p^n is the right model here', () => {
+    // The bead asks whether `1 - p^n` predicts what the corpus actually did.
+    // Per row it does; POOLED it does not, and that disagreement is a fact
+    // about pooling a mis-centred row with two well-centred ones, not about
+    // the rule. Both halves are pinned so neither can be quoted alone.
+    const all = corpus();
+    for (const rowId of Object.keys(RATES)) {
+      const rows = all.filter((r) => r.rowId === rowId);
+      const blocks = rows.flatMap((r) => r.per);
+      const [lo, hi] = rows[0].band;
+      const p = blocks.filter((x) => x >= lo && x <= hi).length / blocks.length;
+      const pv = exactTwoSided(rows.length, rows.filter((r) => r.verdict.ok).length, p ** CORPUS.n);
+      assert.ok(pv > 0.05, `${rowId}: observed pass count is not what p^${CORPUS.n} predicts (exact two-sided p = ${pv.toFixed(3)})`);
+    }
+    const pooled = all.flatMap((r) => r.per.map((x) => ({ x, band: r.band })));
+    const p = pooled.filter((o) => o.x >= o.band[0] && o.x <= o.band[1]).length / pooled.length;
+    assert.strictEqual((p * 100).toFixed(1), '75.7', 'the pooled in-band fraction');
+    assert.strictEqual(((1 - p ** CORPUS.n) * 100).toFixed(1), '99.3', 'which predicts near-total refusal');
+    assert.strictEqual(all.filter((r) => r.verdict.ok).length, 15, 'against 15 of 30 observed — pooling is the wrong statistic, not the rule');
+  });
+
+  t('the ordinary row refuses on its CENTRE, and no relaxation of this rule reaches it', () => {
+    // The load-bearing assertion. `ordinary` is 0 of 10, and a reader who saw
+    // only that number would blame the rule the way rf2-8a746's clock evidence
+    // invites. It is the centre: the block median sits BELOW the band's own
+    // lower edge, so every run would refuse under any per-block count.
+    const rows = corpus().filter((r) => r.rowId === 'ordinary');
+    const [lo, hi] = rows[0].band;
+    const centre = med(rows.flatMap((r) => r.per));
+    assert.ok(centre < lo, `the ordinary centre ${centre.toFixed(4)}x must sit below the band's lower edge ${lo}`);
+    for (const k of [0, 1, 2, 3]) {
+      const passed = rows.filter((r) => r.per.filter((x) => x < lo || x > hi).length <= k).length;
+      assert.strictEqual(passed, 0, `allowing ${k} out-of-band blocks must still pass 0 of 10 — the rule is not the binding constraint`);
+    }
+    // And the two rows whose centre IS inside the band recover immediately, so
+    // the rule is doing real work exactly where it is not the constraint.
+    for (const rowId of ['large-template', 'feed']) {
+      const rs = corpus().filter((r) => r.rowId === rowId);
+      const [l, h] = rs[0].band;
+      assert.ok(med(rs.flatMap((r) => r.per)) > l, `${rowId}: its centre is inside the band`);
+      assert.strictEqual(rs.filter((r) => r.per.filter((x) => x < l || x > h).length <= 2).length, 10, `${rowId}: recovers within two blocks`);
+    }
+  });
+
+  t('the retained rule states its measured rates where the grep lands', () => {
+    // rf2-8a746's criterion 4 in the form this instrument needs it: the label
+    // a `^18`-semantics grep hits must say the rule was measured and kept, or
+    // the next grep re-files rf2-y0pkh. That is how this bead came to exist.
+    assert.match(CSRC, /rule: 'strict — EVERY block inside the band \(rf2-y0pkh: measured and retained\)'/);
+    for (const [rowId, want] of Object.entries(RATES)) {
+      assert.ok(CSRC.includes(`${want.inBand}/${want.blocks}`), `the comment states ${rowId}'s per-block count`);
+    }
+    assert.match(CSRC, /90\.5%/, "and the clock's retired rate it is measured against");
+    assert.match(CSRC, /rf2-pzqy8/, "the ordinary row's centre is handed on by bead id, not left as a shape");
+    // The rates are rates AT A SLACK. Widening the band would change every one
+    // of them, so the constant they were measured at is pinned beside them —
+    // otherwise the limits could move and the stated rates would quietly lie.
+    assert.match(CSRC, /const CONTROL_SLACK = 0\.25;/, 'the tolerance the rates were measured at');
+  });
+}
+
 // --- hd8_clock_run.cjs: the WRITE path, not just the exit path ---------------
 //
 // rf2-2rtt6.31, the write-before-refuse ruling. The same fail-open as the block

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
@@ -77,7 +77,13 @@
 //     double, so the prediction is the row's own element arithmetic
 //     (1.9759 / 1.9944 / 1.7255), not a flat 2.00 — the page computes it
 //     and this driver prints predicted vs measured, adjudicated STRICT
-//     (every block inside +/-25%). rf2-jcm3p records the mount-row
+//     (every block inside +/-25%). THAT STRICT RULE IS THE ONE rf2-8a746
+//     RETIRED ON THE CLOCK, and rf2-y0pkh measured it here before deciding:
+//     it costs 18.2% and 39.8% per-run false refusal on large-template and
+//     feed against the clock's 90.5%, so it is RETAINED — the arithmetic
+//     and the reasons are above `controlVerdict`. The `ordinary` row
+//     refuses 10 of 10 for a different reason (its centre, not the rule)
+//     and is rf2-pzqy8's. rf2-jcm3p records the mount-row
 //     undershoot (1.8173x against 2.00 over seven runs): an additive
 //     per-sample constant survives the tare in `(PW + c)/(W + c)`, and no
 //     changed-set control can reach a mount. So this control certifies
@@ -264,6 +270,50 @@ function band(xs) {
   };
 }
 
+/**
+ * The run-rejection rule: EVERY block inside the tolerance band.
+ *
+ * rf2-8a746 RETIRED this rule on the hicasso clock, and rf2-y0pkh asked
+ * whether it should be retired here too. It should not, and the reason is a
+ * measurement rather than a shape. `1 - p^n` on a per-block in-band rate `p`
+ * is a property of the RULE and not of the clock, so what decides the answer
+ * is `p` — and this rig's `p` is not that rig's.
+ *
+ * MEASURED over the 30 committed row-runs (540 blocks) in
+ * `../data/censusclock-{2rtt6-56,6c237,cno31,jv36i,y1jkm}` — five sessions at
+ * five commits — at this design's n = 18 blocks per row-run:
+ *
+ *     row              per-block in band    1 - p^18    runs passed
+ *     large-template   178/180 = 98.9%        18.2%       8 of 10
+ *     feed             175/180 = 97.2%        39.8%       7 of 10
+ *     ordinary          56/180 = 31.1%       100.0%       0 of 10
+ *
+ * On the two rows that carry the gated pair the arithmetic and the empirical
+ * rate agree (exact binomial two-sided p = 1.000 and 0.749), and 18–40% is a
+ * rate a run survives — against the 90.5% empirical per-run false refusal
+ * that retired the clock's. THE RULE IS RETAINED HERE ON MEASURED GROUNDS.
+ *
+ * The rig does not inherit the clock's ill-conditioning because this control
+ * is ALREADY LEVEL-DENOMINATED, which is the class rf2-8a746's ruling
+ * endorses: the tared floor reads 10.72 / 41.00 ms with a between-block SD of
+ * 2.55 / 8.82, i.e. 4.20 / 4.65 sigma from zero, against the retired ctl3
+ * denominator's 2.09. Block IQR is 7.7% of the centre on both rows.
+ *
+ * `ordinary` refuses 10 of 10 and THIS RULE IS NOT WHY. Its block median is
+ * 1.2264x against a predicted 1.7255x — 71.1% of P, and 5.2% BELOW the band's
+ * lower edge of 1.2941 — so the centre sits outside the band the rule
+ * enforces, and relaxing the rule cannot reach it: allowing up to three
+ * out-of-band blocks per run still passes 0 of 10. That is a mis-specified
+ * CENTRE, the same defect class rf2-8a746 diagnosed on ctl3, and it is
+ * rf2-pzqy8's to rule on — together with the fact that this row's failure
+ * refuses the whole RUN (`verdict` below) where prediction P4 promised a
+ * refusal of the ROW. Retiring a rule that is not the binding constraint
+ * would loosen a control on the two rows where it is doing real work.
+ *
+ * Every figure above recomputes from the committed datasets and is pinned by
+ * `../clock_exit_path.test.cjs`, which drives `controlBlocks` and this
+ * function rather than a copy of their arithmetic.
+ */
 function controlVerdict(predicted, per, slack) {
   const lo = predicted * (1 - slack);
   const hi = predicted * (1 + slack);
@@ -274,7 +324,7 @@ function controlVerdict(predicted, per, slack) {
     measured: b,
     perBlock: per.map(r4),
     ok: per.every((x) => x >= lo && x <= hi),
-    rule: 'strict — EVERY block inside the band',
+    rule: 'strict — EVERY block inside the band (rf2-y0pkh: measured and retained)',
   };
 }
 
@@ -762,6 +812,19 @@ function perBlock(blocks, f) {
   return out;
 }
 
+/**
+ * The control's per-block statistic — tared ctl-2x over tared floor, one per
+ * (round, block), which is what `controlVerdict` adjudicates and what a row's
+ * `adjudication.ctl.perBlock` records.
+ *
+ * Exported so a witness can drive the REAL arithmetic over a committed
+ * dataset rather than a copy of it (rf2-y0pkh). `report` used to spell this
+ * inline, and a rate measured against a reimplementation would be a rate
+ * about the reimplementation.
+ */
+const controlBlocks = (blocksTask) =>
+  perBlock(blocksTask, (r, b) => taredCell(blocksTask, r, b, CTL) / taredCell(blocksTask, r, b, FLOOR));
+
 function report(out) {
   const { runId, rowId, armIds, canon, ctlPredicted, blocksTask, blocksNet, blocksInPage, blocksDecomp, samplesTask, samplesNet, tally, runtime, granularity } = out;
   const decomposition = foldDecomposition(blocksDecomp, { armIds, rounds: ROUNDS, blocks: BLOCKS });
@@ -834,7 +897,7 @@ function report(out) {
   }
 
   // the control — predicted from the row's own element arithmetic
-  const ctlPer = perBlock(blocksTask, (r, b) => taredCell(blocksTask, r, b, CTL) / taredCell(blocksTask, r, b, FLOOR));
+  const ctlPer = controlBlocks(blocksTask);
   const ctl = controlVerdict(ctlPredicted, ctlPer, CONTROL_SLACK);
   const floorTared = p50(perBlock(blocksTask, (r, b) => taredCell(blocksTask, r, b, FLOOR)));
   const c = additiveConstant(floorTared, ctl.measured.mean, ctlPredicted);
@@ -1315,7 +1378,7 @@ async function drive() {
   return v.code;
 }
 
-module.exports = { summarise, verdict, destination, datasetFor, foldDecomposition };
+module.exports = { summarise, verdict, destination, datasetFor, foldDecomposition, controlBlocks, controlVerdict };
 
 if (require.main === module) {
   drive().then((code) => {


### PR DESCRIPTION
rf2-8a746 retired the all-blocks strict run-rejection rule **on the hicasso clock**, and the `^18`-semantics grep that ruling mandated also landed on `shapes/census_clock_run.cjs`. rf2-y0pkh asked whether it should be retired here too. **It should not**, and the reason is a measurement rather than a shape — `1 - p^n` is a property of the rule and not of the clock, so only `p` decides it, and this rig's `p` is not that rig's.

**No measurement was taken.** No census driver, no clock driver, no quiet window. Everything below is arithmetic over the committed `data/censusclock-*` datasets.

## What was measured

Thirty committed row-runs — five sessions at five commits (`2rtt6-56`, `6c237`, `cno31`, `jv36i`, `y1jkm`) × two adapter runs × three rows — 540 blocks, at this design's **n = 18** blocks per row-run.

| row | per-block in band (`p`) | `1 − p¹⁸` | runs passed | exact binomial two-sided p |
|---|---|---|---|---|
| large-template | 178/180 = **98.9%** | **18.2%** | 8 of 10 | 1.000 |
| feed | 175/180 = **97.2%** | **39.8%** | 7 of 10 | 0.749 |
| ordinary | 56/180 = **31.1%** | **100.0%** | 0 of 10 | 1.000 |

**The arithmetic and the empirical rate agree, per row.** Pooled they do not — pooled `p` is 75.7%, which predicts 99.3% refusal against 15 of 30 observed — and that disagreement is a fact about pooling a mis-centred row with two well-centred ones, not about the rule. Both halves are pinned so neither can be quoted alone.

## The verdict: the rule is RETAINED

On the two rows that carry the gated pair the rule costs 18.2% and 39.8% per-run false refusal, against the **90.5%** empirical rate that retired the clock's, and the rig produces passing runs. The rig does not inherit the clock's ill-conditioning because **this control is already level-denominated**, which is the class rf2-8a746's ruling endorses: the tared floor reads 10.72 / 41.00 ms with a between-block SD of 2.55 / 8.82 — **4.20 / 4.65 sigma from zero** against the retired ctl3 denominator's 2.09. Block IQR is 7.7% of the centre on both rows.

The clock's frozen limits are **not** imported. Applying a standard seeded from `clock_run.cjs`'s ctl-2x/floor medians on a 300-boundary page to a rig whose prediction comes from each row's own element arithmetic would re-commit the exact mis-specification the ruling retires.

## The one thing the measurement did find, and it is not the rule

`ordinary` refuses 10 of 10 **on its centre**. Its block median is 1.2264x against a predicted 1.7255x — 71.1% of P, and **5.2% below the band's lower edge** of 1.2941. Relaxing the run rule cannot reach it: allowing up to three out-of-band blocks per run still passes 0 of 10. That is a mis-specified centre, the same defect class rf2-8a746 diagnosed on ctl3, and because `verdict`'s `ctlFailed` condition is run-wide it also means **no full-shape census run can be canonical** while it stands — driven on the real exported functions, a run with large-template and feed clean and ordinary's control failed returns exit 5 and routes every dataset to `.unpublished`. Filed as **rf2-pzqy8** with both candidate directions and the note that the choice is a ruling, not an implementation. Nothing here acts on it.

## What changed

- `shapes/census_clock_run.cjs` — the rule's measured rates, its retention and its reasons stated above `controlVerdict`, which is where the `^18` grep lands; the label now reads `strict — EVERY block inside the band (rf2-y0pkh: measured and retained)` so the next grep does not re-file this bead. `controlBlocks` is lifted out of `report` (it was spelled inline) and exported beside `controlVerdict`, so the witness drives the driver's own arithmetic rather than a copy — a rate measured against a reimplementation would be a rate about the reimplementation. `controlVerdict` is exported here where the clock's deliberately is not, and the asymmetry is the point: on the clock it was retired and decides nothing, here its `ok` still reaches `summarise` → `verdict` → exit 5.
- `clock_exit_path.test.cjs` — six new cases in the census section, recomputing every figure above from the committed datasets. No behaviour, no threshold and no gate is changed.

## Mutation proof

| mutation | result |
|---|---|
| widen the control band, `CONTROL_SLACK` 0.25 → 0.40 | **RED** 1/279 — `the retained rule states its measured rates where the grep lands` |
| the retained rule loses its `rf2-y0pkh` cite | **RED** 1/279 — same case |
| a stated per-row rate is wrong (feed 175 → 174) | **RED** 2/279 — `the measured rate, per row` + the grep case |
| the ordinary centre is claimed to be inside the band | **RED** 1/279 — `the ordinary row refuses on its CENTRE` |
| reverted | **GREEN** 279 passed |

## Quality gates

All foreground to completion in `C:/Users/miket/code/re-frame2-worktrees/censusrule-y0pkh`; the spine's `gate root:` line names that worktree.

| gate | exit |
|---|---|
| `node --check` on both changed `.cjs` | 0 |
| `node freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs` | 0 — **273 → 279 passed** (six new) |
| `npm run test:script-helpers` | 0 |
| `sh scripts/test-fast-pr.sh` | 0 — `PASS fast PR spine` |
| `npm run lint:js` (repo root) | 0 |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | 0 — no beads-database paths in the diff |

The spine log's fourteen `FAILED` lines are its negative-test harnesses passing; the verdict is the echoed exit code.
