### PR TITLE
fix(hicasso): the ordinary row's centre is empirical, and a refused row no longer refuses the run (rf2-pzqy8)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -1118,6 +1118,632 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   });
 }
 
+// --- rf2-pzqy8, half one: the ordinary row's CENTRE, re-specified empirically -
+//
+// rf2-y0pkh measured the census rig's run-rejection rule and RETAINED it, and
+// found the one thing the rule is not: `ordinary` refused 10 of 10 on its
+// CENTRE. Its block median is 1.2308x against an element-arithmetic prediction
+// of 1.7255x — 71.3% of P, and 5.2% below the strict band's own lower edge —
+// so no relaxation of the block count reaches it. That is the class rf2-8a746
+// diagnosed on ctl3, whose true centre sat 2.6% ABOVE its refusal edge where
+// this sits below, and its ruling's part 3 is the repair: a level-denominated,
+// EMPIRICALLY CALIBRATED, versioned check standard.
+//
+// EVERYTHING BELOW RECOMPUTES FROM THE COMMITTED DATASETS through the driver's
+// own `controlBlocks`, `checkStandardVerdict` and `controlAdjudication`. The
+// frozen limits are read out of `shapes/census_check_standard.json` and never
+// written here, so a recalibration moves the file and these witnesses follow
+// it; what they pin is that the numbers in the file are the numbers its own
+// `derivation` strings claim, taken over the corpus the file names.
+//
+// NO MEASUREMENT IS TAKEN. No census driver, no window.
+
+{
+  const CENSUS = DRIVERS[1].mod;
+  const { controlBlocks, controlAdjudication, checkStandardVerdict, CHECK_STANDARD: STD, robustScale } = CENSUS;
+  const CSRC = fs.readFileSync(DRIVERS[1].file, 'utf8');
+  const t = (what, fn) => test(`census check standard: ${what}`, fn);
+
+  const ORD = STD.rows.ordinary;
+  const p50 = (xs) => {
+    const v = [...xs].sort((a, b) => a - b);
+    return v.length % 2 ? v[(v.length - 1) / 2] : (v[v.length / 2 - 1] + v[v.length / 2]) / 2;
+  };
+  const mean = (xs) => xs.reduce((a, b) => a + b, 0) / xs.length;
+  const sd = (xs) => Math.sqrt(xs.reduce((a, b) => a + (b - mean(xs)) ** 2, 0) / (xs.length - 1));
+  const r4 = (x) => Math.round(x * 10000) / 10000;
+
+  /** Every committed census row-run, adjudicated by the driver's real functions. */
+  const corpus = () => {
+    const dir = path.join(__dirname, 'data');
+    return fs
+      .readdirSync(dir)
+      .filter((d) => d.startsWith('censusclock-'))
+      .sort()
+      .flatMap((d) =>
+        fs
+          .readdirSync(path.join(dir, d))
+          .filter((f) => f.endsWith('.json'))
+          .sort()
+          .flatMap((f) => {
+            const data = JSON.parse(fs.readFileSync(path.join(dir, d, f), 'utf8'));
+            return data.rows.map((r) => {
+              const per = controlBlocks(r.blocksTask);
+              return {
+                set: d,
+                where: `${d}/${f}`,
+                rowId: r.rowId,
+                per,
+                adj: controlAdjudication(r.rowId, r.ctlPredicted, per, data.design.controlSlack),
+                stored: r.adjudication.ctl,
+              };
+            });
+          })
+      );
+  };
+  const ordinaries = () => corpus().filter((r) => r.rowId === 'ordinary');
+  const setsOf = (which) => (ORD.provenance[which].datasets || []).map((d) => path.basename(d));
+
+  // --- the standard is complete over the roster, and says which rows it holds -
+
+  t('every row this driver takes is either calibrated or declared OUT, by name', () => {
+    const roster = CSRC.match(/const ALL_ROWS = \[([^\]]*)\]/)[1].split(',').map((s) => s.trim().replace(/'/g, ''));
+    assert.deepStrictEqual(roster, ['large-template', 'feed', 'ordinary'], "the driver's roster is not what this test assumes");
+    for (const rowId of roster) {
+      const held = Object.keys(STD.rows).includes(rowId);
+      const out = STD.notInThisStandard.rows.includes(rowId);
+      assert.ok(held !== out, `${rowId} must be in exactly one of \`rows\` and \`notInThisStandard\``);
+    }
+  });
+
+  t('a row the standard has never heard of THROWS rather than being waved past', () => {
+    // Fail closed at the seat that decides WHETHER a row has a standard. A row
+    // silently returning `null` here would be adjudicated by the strict rule
+    // on nobody's decision, which is how a roster and a standard drift apart.
+    assert.throws(
+      () => checkStandardVerdict('a-row-nobody-calibrated', [1.2, 1.25]),
+      /is in neither `rows` nor `notInThisStandard`/
+    );
+    assert.throws(() => checkStandardVerdict('a-row-nobody-calibrated', [1.2]), /rf2-pzqy8/);
+  });
+
+  t('the two sibling rows are declared out and get NO standard, by name', () => {
+    for (const rowId of ['large-template', 'feed']) {
+      assert.strictEqual(checkStandardVerdict(rowId, [1.9, 2.0]), null, `${rowId} must have no standard`);
+    }
+    assert.match(STD.notInThisStandard.why, /MEETS its own element-arithmetic prediction/);
+    assert.match(STD.notInThisStandard.adjudicatedBy, /controlVerdict/);
+  });
+
+  // --- the frozen numbers are the numbers their own derivations claim --------
+
+  t('the CENTRE recomputes from the baseline the file names, and is not a literal in the code', () => {
+    // The load-bearing check on half one. The file says the centre is the
+    // median of its baseline row-runs' block medians; this recomputes exactly
+    // that, from the datasets the file names, through the driver's own
+    // `controlBlocks`. A centre typed into the JSON by hand would red here.
+    const base = ordinaries().filter((r) => setsOf('baseline').includes(r.set));
+    assert.strictEqual(base.length, ORD.provenance.baseline.rowRuns, 'the baseline is the row-runs the file declares');
+    assert.strictEqual(
+      base.reduce((a, r) => a + r.per.length, 0),
+      ORD.provenance.baseline.blocks
+    );
+    const meds = base.map((r) => p50(r.per));
+    assert.strictEqual(r4(p50(meds)), ORD.centre, 'the frozen centre is the baseline run medians\' median');
+    assert.strictEqual(r4(p50(meds)), ORD.provenance.baseline.observed.runMedianCentre);
+    assert.strictEqual(r4(mean(meds)), ORD.provenance.baseline.observed.runMedianMean);
+    assert.deepStrictEqual([r4(Math.min(...meds)), r4(Math.max(...meds))], ORD.provenance.baseline.observed.runMedianRange);
+    assert.strictEqual(r4(sd(meds)), ORD.provenance.baseline.observed.betweenRunSD);
+  });
+
+  t('NO LIMIT IS SPELLED IN THE DRIVER — recalibrating edits the JSON, never the code', () => {
+    // The prose above `checkStandardVerdict` quotes the centre, because a
+    // reader landing on the control needs the finding; the CODE must not,
+    // because a limit in two places is a limit that can be moved in one.
+    const CODE = CSRC.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+    assert.ok(CODE.includes('const spec = CHECK_STANDARD.rows[rowId];'), 'the comment stripper removed the code as well');
+    for (const [what, n] of [
+      ['the centre', ORD.centre],
+      ['a location limit', ORD.location.limits[0]],
+      ['a location limit', ORD.location.limits[1]],
+      ['the dispersion limit', ORD.dispersion.limit],
+    ]) {
+      assert.ok(!CODE.includes(String(n)), `${what} (${n}) is a literal in the driver's code`);
+    }
+    for (const read of ['spec.location.limits', 'spec.dispersion.limit', 'spec.centre', 'spec.tolerance.band']) {
+      assert.ok(CODE.includes(read), `the driver must read ${read} from the file`);
+    }
+  });
+
+  t('the LOCATION limits are centre +/- 3 x the between-run SD the file states', () => {
+    // Derived from the PUBLISHED figures rather than from full precision, in
+    // clock_check_standard.json's idiom — its own 1.7207 +/- 3 x 0.0566
+    // reproduces [1.5509, 1.8905] exactly — so a reader with the file alone
+    // can check the arithmetic without re-running the corpus.
+    const s = ORD.provenance.baseline.observed.betweenRunSD;
+    assert.match(ORD.location.derivation, /centre \+\/- 3 x between-run SD 0\.0632/);
+    assert.deepStrictEqual(ORD.location.limits, [r4(ORD.centre - 3 * s), r4(ORD.centre + 3 * s)]);
+    assert.ok(ORD.location.limits[0] < ORD.centre && ORD.centre < ORD.location.limits[1], 'the limits must bracket the centre');
+  });
+
+  t('the DISPERSION limit is the lognormal upper 3 sigma of the baseline robust scales', () => {
+    const base = ordinaries().filter((r) => setsOf('baseline').includes(r.set));
+    const scales = base.map((r) => robustScale(r.per));
+    const logs = scales.map(Math.log);
+    const mu = mean(logs);
+    const sigma = sd(logs);
+    assert.strictEqual(Number(mu.toFixed(4)), -2.104, 'the stated mu');
+    assert.strictEqual(Number(sigma.toFixed(4)), 0.3439, 'the stated sigma');
+    assert.strictEqual(r4(Math.exp(mu + 3 * sigma)), ORD.dispersion.limit);
+    assert.strictEqual(r4(p50(scales)), ORD.provenance.baseline.observed.robustScaleP50);
+    assert.strictEqual(r4(Math.max(...scales)), ORD.provenance.baseline.observed.robustScaleMax);
+    // ABOVE the widest observed draw rather than at it — a limit sitting on
+    // its own worst baseline draw refuses the next one by construction.
+    assert.ok(ORD.dispersion.limit > ORD.provenance.baseline.observed.robustScaleMax);
+    assert.match(ORD.dispersion.derivation, /44% above the widest of the 8 observed draws/);
+    assert.strictEqual(Math.round((ORD.dispersion.limit / ORD.provenance.baseline.observed.robustScaleMax - 1) * 100), 44);
+  });
+
+  // --- INDEPENDENCE, which is what makes it a check standard ----------------
+
+  t('the baseline and the HOLD-OUT are disjoint, and together they are the corpus', () => {
+    // rf2-8a746's v1 said in its own `independence` field that its limits were
+    // seeded from the 42 runs it was quoted against, so 0-of-42 was a
+    // consistency check and not a false-refusal measurement. This corpus is
+    // five sessions at five commits and therefore SPLITS, which is the one
+    // thing v1 could not do — NIST e-Handbook 2.3.5's doctrine kept rather
+    // than merely cited.
+    const base = setsOf('baseline');
+    const hold = setsOf('holdOut');
+    assert.strictEqual(base.length, 4);
+    assert.strictEqual(hold.length, 1);
+    for (const d of hold) assert.ok(!base.includes(d), `${d} may not be in both`);
+    const all = [...new Set(ordinaries().map((r) => r.set))].sort();
+    assert.deepStrictEqual(all, [...base, ...hold].sort(), 'a new censusclock-* dataset means the standard needs recalibrating');
+  });
+
+  t('the HOLD-OUT row-runs are IN CONTROL against limits derived WITHOUT them', () => {
+    // The false-refusal measurement, small but real: two row-runs taken five
+    // days after the last baseline session, at a different commit, judged by
+    // limits that never saw them.
+    const hold = ordinaries().filter((r) => setsOf('holdOut').includes(r.set));
+    assert.strictEqual(hold.length, ORD.provenance.holdOut.rowRuns);
+    assert.deepStrictEqual(hold.map((r) => r4(p50(r.per))), ORD.provenance.holdOut.observed.runMedians);
+    assert.deepStrictEqual(hold.map((r) => r4(robustScale(r.per))), ORD.provenance.holdOut.observed.robustScales);
+    for (const r of hold) {
+      assert.strictEqual(r.adj.standard.ok, true, `${r.where}: the hold-out must be in control`);
+      assert.strictEqual(r.adj.standard.location.ok, true);
+      assert.strictEqual(r.adj.standard.dispersion.ok, true);
+    }
+    assert.match(ORD.provenance.independence, /INDEPENDENT OF THE RUNS THEY ARE FIRST JUDGED ON/);
+    assert.match(ORD.errorRates.runRejectionHoldOut, /0 of 2 HOLD-OUT row-runs refused/);
+  });
+
+  // --- what the repair actually changed, and what it deliberately did not ----
+
+  t('the CENTRE was the defect: the same blocks refuse against 1.7255 and hold against 1.2308', () => {
+    const rows = ordinaries();
+    assert.strictEqual(rows.length, 10);
+    // The strict rule's OWN answer about the element arithmetic is untouched —
+    // still 0 of 10 — so nothing here widened a band to make a row pass.
+    assert.strictEqual(rows.filter((r) => r.adj.strictOk).length, 0, 'the strict rule about 1.7255 still refuses every row-run');
+    for (const r of rows) assert.strictEqual(r.adj.strictOk, r.stored.ok, `${r.where}: the strict answer must be what the run recorded`);
+    // And the calibrated standard holds every one of them.
+    assert.strictEqual(rows.filter((r) => r.adj.ok).length, 10, 'the empirical centre holds all ten committed row-runs');
+    assert.strictEqual(ORD.prediction, 1.7255);
+    assert.ok(ORD.centre < ORD.prediction, 'the empirical centre is BELOW the prediction — that is the whole finding');
+    assert.match(ORD.errorRates.retiredCentreForComparison, /56 of 180 blocks \(31\.1%\) inside/);
+    assert.match(ORD.errorRates.retiredCentreForComparison, /passed 0 of 10 row-runs/);
+  });
+
+  t('and the ADJUDICATOR is named on the row, so nobody has to infer which rule decided', () => {
+    for (const r of corpus()) {
+      if (r.rowId === 'ordinary') {
+        assert.ok(r.adj.standard, 'ordinary must carry a standard verdict');
+        assert.strictEqual(r.adj.ok, r.adj.standard.ok, 'a calibrated row is adjudicated by its standard');
+        assert.match(r.adj.adjudicator, /calibrated check standard `census-clock\/ctl-2x-level` v1 \(rf2-pzqy8\)/);
+      } else {
+        assert.strictEqual(r.adj.standard, null, `${r.rowId} must carry no standard`);
+        assert.strictEqual(r.adj.ok, r.adj.strictOk, 'a row with no standard is adjudicated by the strict rule');
+        assert.match(r.adj.adjudicator, /strict all-blocks rule/);
+      }
+    }
+  });
+
+  t('THE SIBLING ROWS ARE UNTOUCHED — rf2-y0pkh measured and retained the rule where it works', () => {
+    // The fence, asserted rather than promised. Their pass counts are the ones
+    // rf2-y0pkh measured three hours before this bead, and the rule that
+    // produced them is the same function with the same wording.
+    for (const [rowId, passed] of [['large-template', 8], ['feed', 7]]) {
+      const rows = corpus().filter((r) => r.rowId === rowId);
+      assert.strictEqual(rows.length, 10);
+      assert.strictEqual(rows.filter((r) => r.adj.ok).length, passed, `${rowId}: still ${passed} of 10`);
+      assert.strictEqual(rows.filter((r) => r.adj.strictOk).length, passed, `${rowId}: and the strict rule is what decided it`);
+      for (const r of rows) assert.strictEqual(r.adj.ok, r.stored.ok, `${r.where}: unchanged from what the run recorded`);
+    }
+    assert.match(CSRC, /rule: 'strict — EVERY block inside the band \(rf2-y0pkh: measured and retained\)'/);
+  });
+
+  t('the tolerance band is REPORTED on a calibrated row, and the all-blocks rule is why', () => {
+    // The other half of the diagnosis, and the reason re-centring ALONE is not
+    // the repair: about the empirical centre 90.0% of blocks are in band and
+    // `0.90^18 = 15%`, so the all-blocks rule would still pass 3 of 10. That is
+    // rf2-8a746's `p^n` arithmetic on this rig, at this n.
+    const rows = ordinaries();
+    const blocks = rows.flatMap((r) => r.per);
+    const [lo, hi] = ORD.tolerance.band;
+    assert.deepStrictEqual(ORD.tolerance.band, [r4(ORD.centre * (1 - ORD.tolerance.slack)), r4(ORD.centre * (1 + ORD.tolerance.slack))]);
+    const inBand = blocks.filter((x) => x >= lo && x <= hi).length;
+    assert.strictEqual(blocks.length, 180);
+    assert.strictEqual(inBand, 162, '90.0% of blocks in band about the empirical centre');
+    assert.strictEqual(((inBand / blocks.length) * 100).toFixed(1), '90.0');
+    assert.strictEqual(rows.filter((r) => r.per.every((x) => x >= lo && x <= hi)).length, 3, 'the all-blocks rule would pass 3 of 10');
+    assert.strictEqual((((inBand / blocks.length) ** 18) * 100).toFixed(0), '15', '0.90^18');
+    // ... and nothing reads it into the verdict.
+    for (const r of rows) {
+      assert.strictEqual(r.adj.standard.tolerance.gating, false);
+      assert.strictEqual(r.adj.standard.tolerance.of, 18);
+    }
+    assert.match(STD.whyNotTheAllBlocksRule, /0\.90\^18 = 15%/);
+    assert.match(STD.runRejection, /Nothing per-block rejects it/);
+  });
+
+  // --- what this standard can and cannot catch, stated as arithmetic ---------
+
+  t('the SENSITIVITY the file states is the sensitivity the frozen limits have', () => {
+    // A standard nobody has seen refuse is a standard of unmeasured
+    // sensitivity. This one refuses an arm that does not double at all and an
+    // arm that triples — and ADMITS the 140-of-300 sabotage rf2-8a746 proved
+    // its own standard against, because only 31.8% of this row's reading is
+    // page-proportional. That is prediction P4 restated as a number, and the
+    // file says so rather than leaving it to be discovered.
+    const k = 0.3181; // the page-proportional share, from the model in the file
+    const c = 0.6819;
+    assert.match(ORD.sensitivity.model, new RegExp(`R = ${k} \\* P_eff \\+ ${c}`));
+    assert.strictEqual(r4(k + c), 1, 'the two shares are one reading');
+    const reads = (pEff) => r4(k * pEff + c);
+    const admits = (R) => R >= ORD.location.limits[0] && R <= ORD.location.limits[1];
+    const pEffFor = (R) => r4((R - c) / k);
+    assert.match(
+      ORD.sensitivity.admits,
+      new RegExp(`P_eff in \\[${pEffFor(ORD.location.limits[0])}, ${pEffFor(ORD.location.limits[1])}\\]`)
+    );
+    // the declared doubling reads the frozen centre — the model and the
+    // corpus are the same instrument, which is what makes the rest of this
+    // arithmetic a statement about the row rather than about an analogy
+    assert.strictEqual(reads(ORD.prediction), ORD.centre, 'a declared doubling must read the frozen centre');
+    // CATCHES
+    assert.strictEqual(reads(1), 1, 'an arm that does not double reads 1.0000x');
+    assert.ok(!admits(reads(1)), 'and is REFUSED');
+    assert.strictEqual(reads(1 + 2 * (ORD.prediction - 1)), 1.4616);
+    assert.ok(!admits(reads(1 + 2 * (ORD.prediction - 1))), 'a TRIPLING is REFUSED');
+    assert.match(ORD.sensitivity.catches, /reads 1\.0000x and is REFUSED/);
+    assert.match(ORD.sensitivity.catches, /reads 1\.4616x and is REFUSED/);
+    // MISSES, and says so
+    const sabotage = reads(1 + (ORD.prediction - 1) * (140 / 300));
+    assert.strictEqual(sabotage, 1.1077);
+    assert.ok(admits(sabotage), 'the 140-of-300 sabotage is ADMITTED on this row');
+    assert.match(ORD.sensitivity.misses, /would read 1\.1077x on THIS row and be ADMITTED/);
+    assert.match(ORD.sensitivity.misses, /prediction P4 restated as a number/);
+  });
+
+  // --- fail closed at every seat --------------------------------------------
+
+  t('an empty, a partial, or a non-finite block set REFUSES rather than passing', () => {
+    assert.strictEqual(checkStandardVerdict('ordinary', []).ok, false);
+    assert.match(checkStandardVerdict('ordinary', []).why, /empty block set/);
+    assert.strictEqual(checkStandardVerdict('ordinary', undefined).ok, false);
+    assert.strictEqual(checkStandardVerdict('ordinary', null).ok, false);
+    const withNaN = [...Array.from({ length: 17 }, () => ORD.centre), NaN];
+    assert.strictEqual(checkStandardVerdict('ordinary', withNaN).ok, false);
+    assert.match(checkStandardVerdict('ordinary', withNaN).why, /not finite readings of a level ratio/);
+    // ... while the healthy world passes, so none of the above is vacuous.
+    assert.strictEqual(checkStandardVerdict('ordinary', Array.from({ length: 18 }, () => ORD.centre)).ok, true);
+  });
+
+  t('a row-run OUTSIDE either frozen limit refuses, and the refusal says which', () => {
+    const flat = (x) => Array.from({ length: 18 }, () => x);
+    const low = checkStandardVerdict('ordinary', flat(ORD.location.limits[0] - 0.01));
+    assert.strictEqual(low.ok, false);
+    assert.strictEqual(low.location.ok, false);
+    assert.strictEqual(low.dispersion.ok, true, 'a flat world has no dispersion — this must be the LOCATION rule');
+    assert.match(low.why, /outside the frozen location limits/);
+    const high = checkStandardVerdict('ordinary', flat(ORD.location.limits[1] + 0.01));
+    assert.strictEqual(high.ok, false, 'the limits are two-sided — an arm that OVERBUILDS is equally a fault');
+    // a world whose median sits dead on the centre and whose blocks scatter
+    const noisy = Array.from({ length: 18 }, (_, i) => ORD.centre + (i % 2 ? 1 : -1) * 0.9);
+    const n = checkStandardVerdict('ordinary', noisy);
+    assert.strictEqual(n.location.ok, true, 'the median is still the centre');
+    assert.strictEqual(n.dispersion.ok, false);
+    assert.strictEqual(n.ok, false);
+    assert.match(n.why, /exceeds the frozen dispersion limit/);
+  });
+
+  t('every verdict carries the standard it was taken against, by id and version', () => {
+    const v = checkStandardVerdict('ordinary', Array.from({ length: 18 }, () => ORD.centre));
+    assert.strictEqual(v.standard.id, STD.id);
+    assert.strictEqual(v.standard.version, STD.version);
+    assert.strictEqual(v.standard.bead, 'rf2-pzqy8');
+    assert.ok(Number.isInteger(STD.version), 'a version that is not an integer cannot be bumped');
+    assert.deepStrictEqual(v.location.limits, ORD.location.limits, 'the frozen limits are the JSON\'s, never a literal');
+    assert.strictEqual(v.location.centre, ORD.centre);
+    assert.strictEqual(v.dispersion.limit, ORD.dispersion.limit);
+    assert.ok(STD.recalibrateOn.length >= 4, 'a standard with no recalibration conditions is a constant');
+    assert.ok(STD.recalibrateOn.some((s) => /FRESH baseline/.test(s)));
+  });
+
+  t('the driver cites the bead and the standard where a reader of the control lands', () => {
+    assert.match(CSRC, /require\('\.\/census_check_standard\.json'\)/);
+    assert.match(CSRC, /rf2-pzqy8/);
+    // The finding itself, above `checkStandardVerdict`, where a reader of the
+    // control lands — the measured centre and the prediction it is not.
+    const note = CSRC.slice(CSRC.indexOf('THE CALIBRATED CHECK STANDARD, applied to one row-run'), CSRC.indexOf('function checkStandardVerdict('));
+    assert.ok(note.length > 0, 'the standard no longer carries the note this test pins');
+    assert.match(note, /1\.2308x/);
+    assert.match(note, /1\.7255x/);
+    assert.match(note, /mis-specified CENTRE/);
+    assert.match(note, /rf2-8a746/, 'and the ruling whose idiom this is');
+    assert.match(note, /rf2-y0pkh/, 'and the measurement it stands on');
+  });
+}
+
+// --- rf2-pzqy8, half two: a REFUSED ROW no longer refuses the RUN -----------
+//
+// The higher-leverage half, and it is a SCOPE defect rather than an arithmetic
+// one. `census_clock_run.cjs`'s prediction P4, registered before any clock,
+// says: "the ORDINARY row (51 elements) sits near this door's own floor; if
+// its control or band cannot hold, the ROW publishes a REFUSAL with the
+// reason, not a number." The implementation refused the RUN — `verdict`'s
+// `ctlFailed` exits 5 and `destination` then read that exit code and sent the
+// whole run's datasets to `.unpublished`, including the `large-template` and
+// `feed` rows that had passed every gate they have.
+//
+// Over the five committed sessions the ordinary row failed on both adapters
+// every time, so NO FULL-SHAPE CENSUS RUN COULD EVER BE CANONICAL — which is
+// why the mayor's 2026-08-07 ruling on rf2-jo60g specified work nobody could
+// have done, and why this half is the precondition for any future
+// recomputable census claim.
+//
+// THE REFUSAL IS NOT WEAKENED, IT IS PUT AT ITS OWN SCOPE. The exit code still
+// refuses the run and still names every offending row; each row now carries
+// its own `canonical` and `notCanonicalWhy`; the file indexes them; and the
+// directory is chosen by the run's SHAPE alone, which is what
+// `clock_run.cjs`'s `publication(shape)` has read all along.
+
+{
+  const CENSUS = DRIVERS[1].mod;
+  const { summarise, summariseRow, verdict, destination, datasetFor, rowPublication } = CENSUS;
+  const CSRC = fs.readFileSync(DRIVERS[1].file, 'utf8');
+  const t = (what, fn) => test(`census refusal scope: ${what}`, fn);
+
+  const CANON = '/data/censusclock-2rtt6-56';
+  const shape = (over = {}) => ({
+    dataDir: CANON,
+    dataDirOverridden: false,
+    rowsOnly: null,
+    runsOnly: null,
+    noBuild: false,
+    depthPublished: true,
+    skipQuiet: false,
+    ...over,
+  });
+  const PUBLISHED = () => destination(shape());
+
+  const DECOMP = () => ({ n: 10, task: 3, taskNet: 2, devtools: 1, script: 0.5, style: 0.4, layout: 0.6, layoutCount: 10, inPage: 1 });
+
+  /** One row as `drive` collects it, with its four gates settable one at a time. */
+  const resultRow = (rowId, gates = {}) => ({
+    runId: 'uix',
+    rowId,
+    armIds: ['plumb', 'floor', 'ctl-2x'],
+    canon: { floor: { hash: 'a', bytes: 10, control: true } },
+    ctlPredicted: 1.7255,
+    blocksTask: [[{ plumb: [0.7], floor: [2, 2.1], 'ctl-2x': [3, 3.1] }]],
+    blocksNet: [[{ floor: [1, 2], 'ctl-2x': [2, 4] }]],
+    blocksInPage: [[{ floor: [1, 2], 'ctl-2x': [2, 4] }]],
+    blocksDecomp: [[{ plumb: DECOMP(), floor: DECOMP(), 'ctl-2x': DECOMP() }]],
+    tally: { writes: 36, unverified: gates.unverified || 0 },
+    runtime: 'fixture',
+    quiet: { ok: true },
+    windowStart: '2026-08-08T00:00:00.000Z',
+    adjudication: {
+      ctl: { ok: gates.ctlOk !== false, measured: { mean: gates.ctlMeasured || 1.9943 } },
+      cAdditive: 0.96,
+      assessed: {
+        bandStats: { band: gates.band === undefined ? 0.12 : gates.band },
+        verdict: { ceilingBreached: gates.ceilingBreached === true },
+      },
+      bars: {},
+      verdicts: {},
+      guardRefuse: gates.guardRefuse === true,
+      plumb: 0.7683,
+      floorTared: 1.4076,
+    },
+  });
+
+  /** The full published shape: the three rows, in the order the driver takes them. */
+  const fullShape = (gatesByRow = {}) =>
+    ['large-template', 'feed', 'ordinary'].map((id) => resultRow(id, gatesByRow[id] || {}));
+  const META = (dest) => ({ sha: 'deadbeef', blobs: {}, dest });
+  const written = (rows, dest = PUBLISHED()) => JSON.parse(JSON.stringify(datasetFor(rows, META(dest))));
+
+  // --- the green case first, so nothing below is vacuously red ---------------
+
+  t('a full-shape run with every gate held is canonical, and every row is citable', () => {
+    const data = written(fullShape());
+    assert.strictEqual(data.canonical, true);
+    assert.strictEqual(data.notCanonicalWhy, null);
+    assert.deepStrictEqual(data.rowsRefused, []);
+    for (const row of data.rows) {
+      assert.strictEqual(row.canonical, true, `${row.rowId} must be citable`);
+      assert.strictEqual(row.notCanonicalWhy, null);
+    }
+    assert.strictEqual(verdict(summarise(null, fullShape())).code, 0);
+  });
+
+  // --- THE ONE THIS BEAD EXISTS FOR -----------------------------------------
+
+  t('ORDINARY REFUSED, THE OTHER TWO CLEAN: the two stay canonical and the run still refuses', () => {
+    // The state every one of the five committed sessions was in, on both
+    // adapters. Before rf2-pzqy8 this produced exit 5, dir
+    // `censusclock-2rtt6-56.unpublished`, and `canonical: false` over the
+    // whole file — the two rows that passed every gate discarded with the one
+    // that did not.
+    const rows = fullShape({ ordinary: { ctlOk: false, ctlMeasured: 1.2264 } });
+    const v = verdict(summarise(null, rows));
+
+    // 1. THE RUN STILL REFUSES. A run in which a row refused is not a clean
+    //    run; it is a run with a refused row, and the exit says so.
+    assert.strictEqual(v.code, 5, 'the run-level refusal is NOT weakened into nothing');
+    assert.strictEqual(v.lines.length, 1);
+    assert.match(v.lines[0], /uix\/ordinary \(measured 1\.2264x\)/);
+    assert.doesNotMatch(v.lines[0], /large-template|feed/, 'a clean row must not be blamed');
+    assert.match(v.lines[0], /the scope is the ROW \(rf2-pzqy8\)/);
+
+    // 2. THE FILE STAYS IN THE PUBLISHED SET, because the run's SHAPE is the
+    //    published one and a gate refusal is not a fact about the shape.
+    const dest = PUBLISHED();
+    assert.strictEqual(dest.dir, CANON, 'a refused ROW must not move the RUN off the canonical set');
+    assert.strictEqual(dest.canonical, true);
+
+    // 3. AND THE ROWS CARRY THE REFUSAL AT ITS OWN SCOPE.
+    const data = written(rows, dest);
+    assert.deepStrictEqual(data.rowsRefused, ['ordinary'], 'the file indexes exactly the row that refused');
+    const byId = Object.fromEntries(data.rows.map((r) => [r.rowId, r]));
+    for (const id of ['large-template', 'feed']) {
+      assert.strictEqual(byId[id].canonical, true, `${id} passed every gate and must remain canonical`);
+      assert.strictEqual(byId[id].notCanonicalWhy, null);
+    }
+    assert.strictEqual(byId.ordinary.canonical, false);
+    assert.match(byId.ordinary.notCanonicalWhy, /POSITIVE CONTROL did not hold \(measured 1\.2264x\)/);
+    assert.match(byId.ordinary.notCanonicalWhy, /prediction P4 promises the row publishes/);
+    // ... and the row's numbers are still in the file. A refusal is evidence;
+    // throwing the measurement away was never the refusal.
+    assert.ok(byId.ordinary.blocksTask, 'the refused row is recorded, not deleted');
+  });
+
+  t('the whole point, stated as a counterfactual: nothing citable used to survive this run', () => {
+    // If the write decision ever folds a gate refusal back in, this is the
+    // assertion that reds. `destination` takes ONE argument now — the shape —
+    // and a second one would have to come from somewhere.
+    assert.strictEqual(destination.length, 1, '`destination` must read the run SHAPE and nothing else');
+    const rows = fullShape({ ordinary: { ctlOk: false } });
+    const citable = written(rows).rows.filter((r) => r.canonical).map((r) => r.rowId);
+    assert.deepStrictEqual(citable, ['large-template', 'feed'], 'a full-shape run must be able to publish SOME row');
+  });
+
+  // --- each gate alone, at the row's scope ----------------------------------
+
+  for (const [what, gates, needle] of [
+    ['the ARM-ORDER GUARD', { guardRefuse: true }, /ARM-ORDER GUARD refused it/],
+    ['UNVERIFIED read-backs', { unverified: 4 }, /4 of 36 operations are UNVERIFIED/],
+    ['a BREACHED band ceiling', { ceilingBreached: true, band: 0.412 }, /band 41\.2% exceeds seam\.cjs's 35% ceiling/],
+    ['a FAILED positive control', { ctlOk: false, ctlMeasured: 1.2264 }, /POSITIVE CONTROL did not hold/],
+  ]) {
+    t(`${what} refuses THAT row and no other`, () => {
+      const data = written(fullShape({ feed: gates }));
+      assert.deepStrictEqual(data.rowsRefused, ['feed']);
+      const byId = Object.fromEntries(data.rows.map((r) => [r.rowId, r]));
+      assert.strictEqual(byId.feed.canonical, false);
+      assert.match(byId.feed.notCanonicalWhy, needle);
+      for (const id of ['large-template', 'ordinary']) {
+        assert.strictEqual(byId[id].canonical, true, `${id} must be untouched by ${what}`);
+      }
+      // ... and the run still refuses, so this cannot pass by going quiet.
+      assert.notStrictEqual(verdict(summarise(null, fullShape({ feed: gates }))).code, 0);
+      // ... and the same run WITHOUT that gate publishes every row, so it
+      // cannot pass by refusing everything either.
+      assert.deepStrictEqual(written(fullShape()).rowsRefused, []);
+    });
+  }
+
+  t('several gates on one row name every one of them', () => {
+    const data = written(fullShape({ ordinary: { ctlOk: false, ceilingBreached: true, band: 0.5, unverified: 2, guardRefuse: true } }));
+    const why = data.rows.find((r) => r.rowId === 'ordinary').notCanonicalWhy;
+    for (const needle of [/ARM-ORDER GUARD/, /UNVERIFIED/, /band 50\.0% exceeds/, /POSITIVE CONTROL/]) {
+      assert.match(why, needle);
+    }
+  });
+
+  // --- a row inherits the run's shape ---------------------------------------
+
+  t('NO row of a run that is not the published shape is citable, whatever its own gates did', () => {
+    // The composition that keeps the two scopes from drifting apart: the row's
+    // own gates are necessary and the run's shape is necessary, and neither is
+    // sufficient. A `--no-build` run whose every gate held publishes nothing.
+    const dest = destination(shape({ noBuild: true }));
+    assert.strictEqual(dest.canonical, false);
+    const data = written(fullShape(), dest);
+    assert.strictEqual(data.canonical, false);
+    assert.match(data.notCanonicalWhy, /--no-build/);
+    assert.deepStrictEqual(data.rowsRefused, ['large-template', 'feed', 'ordinary']);
+    for (const row of data.rows) {
+      assert.strictEqual(row.canonical, false);
+      assert.match(row.notCanonicalWhy, /the run itself is not the published evidence: --no-build/);
+    }
+  });
+
+  t('and the run-shape reason comes FIRST, so a reader sees the disqualifying fact first', () => {
+    const dest = destination(shape({ skipQuiet: true }));
+    const p = rowPublication(summariseRow(resultRow('ordinary', { ctlOk: false })), dest);
+    assert.strictEqual(p.canonical, false);
+    assert.match(p.why, /^the run itself is not the published evidence: a SKIPPED quiet gate/);
+    assert.match(p.why, /POSITIVE CONTROL did not hold/, 'and the row-level reason is still named');
+  });
+
+  // --- fail closed ----------------------------------------------------------
+
+  t('an absent row and an absent destination are each a REFUSAL, never a pass', () => {
+    assert.strictEqual(rowPublication(undefined, PUBLISHED()).canonical, false);
+    assert.match(rowPublication(undefined, PUBLISHED()).why, /an absent row is not a citable one/);
+    assert.strictEqual(rowPublication(null, PUBLISHED()).canonical, false);
+    const clean = summariseRow(resultRow('feed'));
+    assert.strictEqual(rowPublication(clean, undefined).canonical, false);
+    assert.match(rowPublication(clean, undefined).why, /no destination was decided for this run/);
+    // ... and the same row with a decided, published destination IS citable.
+    assert.strictEqual(rowPublication(clean, PUBLISHED()).canonical, true);
+    assert.strictEqual(rowPublication(clean, PUBLISHED()).why, null);
+  });
+
+  // --- the wiring: ONE mapper, so the two scopes cannot disagree -------------
+
+  t('the write path and the exit path read the SAME four refusal fields', () => {
+    // The fault this replaces was two readings of one fact. `summarise` and
+    // `rowPublication` now share `summariseRow`, so a row the exit refuses and
+    // a row the file marks refused are the same row by construction — and a
+    // renamed accessor breaks both at once instead of one silently.
+    // Newlines are normalised because this tree is checked out with CRLF.
+    const src = CSRC.replace(/\r\n/g, '\n');
+    assert.match(src, /^const summariseRow = \(r\) => \(\{/m);
+    assert.match(src, /function summarise\(failed, results\) \{\n\s*return \{ failed: failed \|\| null, rows: \(results \|\| \[\]\)\.map\(summariseRow\) \};/);
+    assert.match(src, /const publication = \(r\) => rowPublication\(summariseRow\(r\), meta\.dest\);/);
+    // and the summary the exit takes is built by that mapper
+    const s = summarise(null, [resultRow('ordinary', { ctlOk: false, ctlMeasured: 1.2264 })]);
+    assert.deepStrictEqual(s.rows[0], {
+      id: 'uix/ordinary',
+      guardRefuse: false,
+      unverified: 0,
+      writes: 36,
+      ctlOk: false,
+      ctlMeasured: 1.2264,
+      ceilingBreached: false,
+      band: 0.12,
+    });
+  });
+
+  t('the header says the scope, in the instrument\'s own words', () => {
+    const header = CSRC.slice(0, CSRC.indexOf("'use strict'"));
+    assert.match(header, /the ROW publishes a REFUSAL with the reason, not a number/);
+    assert.match(header, /A NONZERO EXIT IS A RUN-LEVEL FACT AND STAYS ONE/);
+    assert.match(header, /full-shape census run could ever be canonical/i);
+    assert.match(header, /rf2-pzqy8/);
+    // The write-path note must name both scopes and the idiom it follows.
+    const note = CSRC.slice(CSRC.indexOf('// WHERE A RUN\'S DATASETS MAY BE WRITTEN'), CSRC.indexOf('function destination('));
+    assert.match(note, /`clock_run\.cjs`'s `publication\(shape\)` has read shape and nothing else/);
+    assert.match(note, /A refusal is evidence/);
+  });
+}
+
 // --- hd8_clock_run.cjs: the WRITE path, not just the exit path ---------------
 //
 // rf2-2rtt6.31, the write-before-refuse ruling. The same fail-open as the block

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -378,8 +378,8 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   });
   const t = (what, fn) => test(`census_clock_run.cjs write path: ${what}`, fn);
 
-  t('the published shape, all gates passed, is the ONLY thing that is canonical', () => {
-    const d = destination(shape(), 0);
+  t('the published shape is the ONLY thing that is canonical', () => {
+    const d = destination(shape());
     assert.strictEqual(d.canonical, true);
     assert.strictEqual(d.dir, CANON);
     assert.strictEqual(d.why, null);
@@ -387,36 +387,41 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
 
   // Each condition alone must move the write off the canonical set. These are
   // the mutation proofs: flip one field, the destination must change.
-  for (const [what, over, code, needle] of [
-    ['a refused verdict', {}, 3, /verdict refused it \(exit 3\)/],
-    ['a partial row set', { rowsOnly: 'feed' }, 0, /PARTIAL row set/],
-    ['a partial run set', { runsOnly: 'uix' }, 0, /PARTIAL run set/],
-    ['--no-build', { noBuild: true }, 0, /--no-build/],
-    ['an overridden depth', { depthPublished: false }, 0, /OVERRIDDEN design depth/],
+  //
+  // EVERY ONE OF THEM IS A FACT ABOUT THE RUN'S SHAPE, and after rf2-pzqy8
+  // that is the whole of this list — a refused VERDICT used to be on it and
+  // is not, because a gate refusal belongs to one row and is recorded there
+  // (`rowPublication`, below). `clock_run.cjs`'s `publication(shape)` has
+  // read shape and nothing else all along; this is now that same rule.
+  for (const [what, over, needle] of [
+    ['a partial row set', { rowsOnly: 'feed' }, /PARTIAL row set/],
+    ['a partial run set', { runsOnly: 'uix' }, /PARTIAL run set/],
+    ['--no-build', { noBuild: true }, /--no-build/],
+    ['an overridden depth', { depthPublished: false }, /OVERRIDDEN design depth/],
     // rf2-azopg. C56CLOCK_SKIP_QUIET=1 made `quietGate` return ok:true and
     // print "NOT the published shape", and then nothing carried that fact to
     // the write decision — so a run whose samples were never checked against a
     // quiet box could occupy the canonical directory, indistinguishable from
     // one taken in a granted window. This is the probe that found it: the
     // published shape in every other respect, exit 0, quiet gate skipped.
-    ['a SKIPPED quiet gate', { skipQuiet: true }, 0, /SKIPPED quiet gate \(C56CLOCK_SKIP_QUIET=1\)/],
+    ['a SKIPPED quiet gate', { skipQuiet: true }, /SKIPPED quiet gate \(C56CLOCK_SKIP_QUIET=1\)/],
   ]) {
     t(`${what} is NOT canonical, and says why`, () => {
-      const d = destination(shape(over), code);
+      const d = destination(shape(over));
       assert.strictEqual(d.canonical, false, `${what} must not be canonical`);
       assert.notStrictEqual(d.dir, CANON, `${what} must not write the published filenames`);
       assert.strictEqual(d.dir, `${CANON}.unpublished`);
       assert.match(d.why, needle);
       // ... and the same shape WITHOUT that condition is canonical again, so
       // the test cannot pass by refusing everything.
-      assert.strictEqual(destination(shape(), 0).canonical, true);
+      assert.strictEqual(destination(shape()).canonical, true);
     });
   }
 
   t('every condition that fired is named, not just the first', () => {
-    const d = destination(shape({ rowsOnly: 'feed', noBuild: true, depthPublished: false, skipQuiet: true }), 5);
+    const d = destination(shape({ rowsOnly: 'feed', noBuild: true, depthPublished: false, skipQuiet: true }));
     assert.strictEqual(d.canonical, false);
-    for (const needle of [/verdict refused it \(exit 5\)/, /PARTIAL row set/, /--no-build/, /OVERRIDDEN design depth/, /SKIPPED quiet gate/]) {
+    for (const needle of [/PARTIAL row set/, /--no-build/, /OVERRIDDEN design depth/, /SKIPPED quiet gate/]) {
       assert.match(d.why, needle);
     }
   });
@@ -442,12 +447,13 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
 
   t('an explicit C56CLOCK_DATA_DIR is honoured as given, and is never canonical', () => {
     const mine = '/data/censusclock-somebead';
-    const d = destination(shape({ dataDir: mine, dataDirOverridden: true }), 0);
+    const d = destination(shape({ dataDir: mine, dataDirOverridden: true }));
     assert.strictEqual(d.dir, mine, 'the operator named the destination; do not rewrite it');
     assert.strictEqual(d.canonical, false, 'an operator-named directory is not the published set');
-    // Even refused, it still lands where the operator said — the refusal is
-    // carried by the exit code and by `canonical`, not by moving the file.
-    assert.strictEqual(destination(shape({ dataDir: mine, dataDirOverridden: true }), 4).dir, mine);
+    // It still lands where the operator said whatever else the run was — the
+    // refusal is carried by the exit code and by `canonical`, never by moving
+    // the file out from under the name the operator gave it.
+    assert.strictEqual(destination(shape({ dataDir: mine, dataDirOverridden: true, skipQuiet: true })).dir, mine);
   });
 
   // The defect was an ORDERING one: the write happened, and the refusal was
@@ -455,7 +461,7 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   // regressed and a behavioural test of a browser driver cannot see it.
   t('the verdict is computed BEFORE any dataset is written', () => {
     const v = SRC.indexOf('const v = verdict(summarise(failed, results));');
-    const dst = SRC.indexOf('const dest = destination(runShape(), v.code);');
+    const dst = SRC.indexOf('const dest = destination(runShape());');
     const mk = SRC.indexOf('fs.mkdirSync(dest.dir');
     assert.ok(v > 0 && dst > 0 && mk > 0, 'the write path no longer has the shape this test pins');
     assert.ok(v < dst, 'the verdict must be computed before the destination is chosen');
@@ -465,7 +471,7 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   t('no dataset is written to the raw DATA_DIR downstream of `destination`', () => {
     // This is how the defect grew: the write named the canonical directory
     // directly. Every write site must go through the chosen destination.
-    const after = SRC.slice(SRC.indexOf('const dest = destination(runShape(), v.code);'));
+    const after = SRC.slice(SRC.indexOf('const dest = destination(runShape());'));
     assert.ok(!/fs\.mkdirSync\(DATA_DIR/.test(after), 'mkdirSync must use the chosen destination');
     assert.ok(!/path\.join\(DATA_DIR/.test(after), 'the dataset path must use the chosen destination');
     assert.match(after, /path\.join\(dest\.dir/);
@@ -569,7 +575,12 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     quiet: { ok: true },
     windowStart: '2026-08-07T00:00:00.000Z',
     adjudication: {
-      ctl: { ok: true },
+      // The whole `ctl` record a real row carries, `measured` included:
+      // `datasetFor` now decides each row's own publication through the same
+      // `summariseRow` mapper `summarise` uses, so a fixture missing a field
+      // the mapper reads would be testing a row no run can produce
+      // (rf2-pzqy8).
+      ctl: { ok: true, measured: { mean: 1.9943 } },
       cAdditive: 0.9,
       assessed: { bandStats: { band: 0.12 }, verdict: { ceilingBreached: false } },
       bars: {},
@@ -681,25 +692,27 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   // catches is not the same as a driver that exits non-zero — this drives the
   // second. The source pins below hold the reconstruction to the shape it
   // stands for, so it cannot drift away from the driver while still passing.
-  const summarisable = () => {
-    const r = fixtureRow();
-    r.adjudication.ctl = { ok: true, measured: { mean: 1.9943 } };
-    return r;
-  };
   const driveOn = (blocksDecomp, declared = DECLARED) => {
     const results = [];
     let failed = null;
     try {
       foldDecomposition(blocksDecomp, declared); // `report`'s first act on the row
-      results.push(summarisable()); // reached only if the fold ANSWERED
+      results.push(fixtureRow()); // reached only if the fold ANSWERED
     } catch (e) {
       failed = e.message;
     }
     const v = verdict(summarise(failed, results));
+    const wrote = Boolean(results.length && !failed);
     return {
       code: v.code,
-      wrote: Boolean(results.length && !failed),
-      canonical: destination(shape(), v.code).canonical,
+      wrote,
+      // WHAT THIS RUN PUBLISHED, which is the question every witness below
+      // asks. `destination` reads the run's SHAPE and nothing else after
+      // rf2-pzqy8, so what keeps a refused fold out of the published set is
+      // not a routing decision — it is that `report` threw, `failed` was set,
+      // and `drive`'s `if (results.length && !failed)` never reached a write
+      // at all. Nothing is published because nothing was written.
+      canonical: wrote && destination(shape()).canonical,
       why: failed || '',
     };
   };

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_check_standard.json
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_check_standard.json
@@ -32,7 +32,7 @@
         "runRejectionBaseline": "0 of 8 baseline row-runs refused — a consistency check, since the limits are seeded from them",
         "runRejectionHoldOut": "0 of 2 HOLD-OUT row-runs refused — and this one is a false-refusal measurement, because the limits were derived without them",
         "toleranceBandPerBlock": "10.0% of blocks fall outside the reported band (162 of 180 inside; 136 of 144 on the baseline alone)",
-        "retiredCentreForComparison": "the element-arithmetic centre 1.7255 put 56 of 180 blocks (31.1%) inside its +/-25% band and passed 0 of 10 row-runs. rf2-y0pkh measured that no relaxation of the block count reaches it — allowing one, two or three out-of-band blocks per row-run still passes 0 of 10 — because the row's centre sat 5.2% BELOW that band's lower edge of 1.2941. The centre was the defect, and this file is the repair."
+        "retiredCentreForComparison": "the element-arithmetic centre 1.7255 put 56 of 180 blocks (31.1%) inside its +/-25% band and passed 0 of 10 row-runs. rf2-y0pkh measured that no relaxation of the block count reaches it — allowing one, two or three out-of-band blocks per row-run still passes 0 of 10 — because the row's centre sat BELOW that band's lower edge of 1.2941 rather than inside it, its pooled block median of 1.2264 by 5.2% and the baseline centre frozen above by 4.9%. The centre was the defect, and this file is the repair."
       },
       "sensitivity": {
         "what": "WHAT THIS STANDARD CAN AND CANNOT CATCH, stated rather than left to be discovered. A standard nobody has seen refuse is a standard of unmeasured sensitivity, and this lane has found that defect nine times.",

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_check_standard.json
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_check_standard.json
@@ -19,7 +19,7 @@
       "prediction": 1.7255,
       "centre": 1.2308,
       "location": {
-        "limits": [1.0411, 1.4204],
+        "limits": [1.0412, 1.4204],
         "derivation": "centre +/- 3 x between-run SD 0.0632, over the 8 BASELINE row-runs"
       },
       "dispersion": {
@@ -37,8 +37,8 @@
       "sensitivity": {
         "what": "WHAT THIS STANDARD CAN AND CANNOT CATCH, stated rather than left to be discovered. A standard nobody has seen refuse is a standard of unmeasured sensitivity, and this lane has found that defect nine times.",
         "model": "R = 0.3181 * P_eff + 0.6819 — the row's reading as a function of the work its control arm actually builds, fitted from the baseline's own additive residual (c / floorTared p50 = 0.6819, so only 31.8% of this row's reading is page-proportional)",
-        "admits": "the location limits admit control arms building P_eff in [1.1293, 2.3217] against a declared 1.7255 — that is, an arm doing between 17.8% and 182.2% of the declared EXTRA work",
-        "catches": "an arm that does not double at all reads 1.0000x and is REFUSED; an arm building a TRIPLING reads 1.4615x and is REFUSED",
+        "admits": "the location limits admit control arms building P_eff in [1.1295, 2.3216] against a declared 1.7255 — that is, an arm doing between 17.8% and 182.2% of the declared EXTRA work",
+        "catches": "an arm that does not double at all reads 1.0000x and is REFUSED; an arm building a TRIPLING reads 1.4616x and is REFUSED",
         "misses": "an arm rendering 140 of the 300 boundaries it declares — the sabotage rf2-8a746 proved its own standard against — would read 1.1077x on THIS row and be ADMITTED. That is not a hole in the rule; it is prediction P4 restated as a number. 51 elements through this door leaves too little page-proportional signal for a control to resolve a half-built arm, and any row-level claim taken here carries that resolution."
       },
       "provenance": {

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_check_standard.json
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_check_standard.json
@@ -1,0 +1,92 @@
+{
+  "id": "census-clock/ctl-2x-level",
+  "version": 1,
+  "bead": "rf2-pzqy8",
+  "frozen": "2026-08-08",
+  "what": "The calibrated check standard for the census-real clock rows (shapes/census_clock_run.cjs). The measured quantity is the ctl-2x arm's TARED TaskDuration over the floor's TARED TaskDuration, in the same block — `controlBlocks`, one per (round, block), 18 per row-run. Both terms are LEVELS, which is the class rf2-8a746's ruling endorses; rf2-y0pkh measured this rig's denominators at 4.20 / 4.65 / 3.33 sigma from zero against the retired ctl3 denominator's 2.09. This standard does not replace that statistic. It replaces the CENTRE one row was judged against.",
+  "notAPrediction": "The expected centre is EMPIRICAL. `ctl-2x` builds twice the row's cards and the page computes the row's own element arithmetic as the prediction — 1.9759 / 1.9943 / 1.7255. On the two large rows the instrument reads that prediction (93.3% and 101.0% of it) and the prediction stands. On the `ordinary` row it does not: 51 elements is small enough that the per-sample work which does NOT scale with the page dominates the reading, so `R = (P*W + c)/(W + c)` sits far below `P` with no defect anywhere in the arithmetic. Asserting a theoretical value against a reading the constant dominates is the mistake rf2-8a746 retired on ctl3, and what is frozen below is what this instrument, on this page, through this door, WAS MEASURED to read.",
+  "statistics": {
+    "block": "one (round, block) pair — tared(ctl-2x) / tared(floor), the driver's own `controlBlocks`",
+    "location": "the row-run's MEDIAN over its 18 blocks (rf2-8bgqq: a ratio's headline is its median)",
+    "dispersion": "the row-run's robust scale over those blocks, IQR / 1.349 — the normal-consistent estimator, comparable with an SD without inheriting one wild block"
+  },
+  "runRejection": "a row-run is IN CONTROL when its block median lies inside the frozen location limits AND its robust scale is at or under the frozen dispersion limit. Nothing per-block rejects it.",
+  "toleranceBandIsNotTheRule": "The per-block tolerance band below is REPORTED and decides nothing on a row this standard calibrates. It is the same +/-25% band the strict rule uses, re-centred on the empirical centre, and it is printed because a reader wants to see where the blocks fell.",
+  "whyNotTheAllBlocksRule": "Because on THIS row it is `p^18` and nothing else. Re-centred on the empirical centre the ordinary row's per-block in-band fraction rises from 31.1% to 90.0%, and the all-blocks rule would still pass only 3 of 10 row-runs, because 0.90^18 = 15%. That is rf2-8a746's arithmetic exactly. THE RULE IS NOT TOUCHED WHERE rf2-y0pkh MEASURED AND RETAINED IT: on `large-template` and `feed` it costs 18.2% and 39.8% per-run false refusal and it remains those rows' adjudicator, unchanged. `ordinary` is the row rf2-y0pkh explicitly held out of that retention.",
+  "rows": {
+    "ordinary": {
+      "calibrated": true,
+      "prediction": 1.7255,
+      "centre": 1.2308,
+      "location": {
+        "limits": [1.0411, 1.4204],
+        "derivation": "centre +/- 3 x between-run SD 0.0632, over the 8 BASELINE row-runs"
+      },
+      "dispersion": {
+        "limit": 0.3422,
+        "derivation": "exp(mu + 3 sigma) of the 8 baseline log robust scales, mu = -2.1040, sigma = 0.3439 — a lognormal upper 3 sigma on a positive skewed quantity, 44% above the widest of the 8 observed draws rather than at it"
+      },
+      "tolerance": { "slack": 0.25, "band": [0.9231, 1.5385], "reported": true },
+      "errorRates": {
+        "runRejectionNominal": "0.4% per row-run — location 0.27% (two-sided 3 sigma, normal) plus dispersion 0.13% (one-sided 3 sigma, lognormal)",
+        "runRejectionBaseline": "0 of 8 baseline row-runs refused — a consistency check, since the limits are seeded from them",
+        "runRejectionHoldOut": "0 of 2 HOLD-OUT row-runs refused — and this one is a false-refusal measurement, because the limits were derived without them",
+        "toleranceBandPerBlock": "10.0% of blocks fall outside the reported band (162 of 180 inside; 136 of 144 on the baseline alone)",
+        "retiredCentreForComparison": "the element-arithmetic centre 1.7255 put 56 of 180 blocks (31.1%) inside its +/-25% band and passed 0 of 10 row-runs. rf2-y0pkh measured that no relaxation of the block count reaches it — allowing one, two or three out-of-band blocks per row-run still passes 0 of 10 — because the row's centre sat 5.2% BELOW that band's lower edge of 1.2941. The centre was the defect, and this file is the repair."
+      },
+      "sensitivity": {
+        "what": "WHAT THIS STANDARD CAN AND CANNOT CATCH, stated rather than left to be discovered. A standard nobody has seen refuse is a standard of unmeasured sensitivity, and this lane has found that defect nine times.",
+        "model": "R = 0.3181 * P_eff + 0.6819 — the row's reading as a function of the work its control arm actually builds, fitted from the baseline's own additive residual (c / floorTared p50 = 0.6819, so only 31.8% of this row's reading is page-proportional)",
+        "admits": "the location limits admit control arms building P_eff in [1.1293, 2.3217] against a declared 1.7255 — that is, an arm doing between 17.8% and 182.2% of the declared EXTRA work",
+        "catches": "an arm that does not double at all reads 1.0000x and is REFUSED; an arm building a TRIPLING reads 1.4615x and is REFUSED",
+        "misses": "an arm rendering 140 of the 300 boundaries it declares — the sabotage rf2-8a746 proved its own standard against — would read 1.1077x on THIS row and be ADMITTED. That is not a hole in the rule; it is prediction P4 restated as a number. 51 elements through this door leaves too little page-proportional signal for a control to resolve a half-built arm, and any row-level claim taken here carries that resolution."
+      },
+      "provenance": {
+        "baseline": {
+          "rowRuns": 8,
+          "blocks": 144,
+          "sessions": 4,
+          "datasets": [
+            "../data/censusclock-2rtt6-56",
+            "../data/censusclock-y1jkm",
+            "../data/censusclock-6c237",
+            "../data/censusclock-cno31"
+          ],
+          "taken": "2026-08-02, at four commits (7885a7c148, 8ccd9f4b41, ac09504d74, 08344cb500)",
+          "observed": {
+            "runMedianCentre": 1.2308,
+            "runMedianMean": 1.2193,
+            "runMedianRange": [1.1333, 1.3133],
+            "betweenRunSD": 0.0632,
+            "robustScaleP50": 0.1108,
+            "robustScaleMax": 0.2381
+          }
+        },
+        "holdOut": {
+          "rowRuns": 2,
+          "blocks": 36,
+          "datasets": ["../data/censusclock-jv36i"],
+          "taken": "2026-08-07, at commit 752b8069be — a different session on a different day, five days after the last baseline session",
+          "observed": { "runMedians": [1.1605, 1.1878], "robustScales": [0.165, 0.1985] },
+          "verdict": "both IN CONTROL against limits derived without them"
+        },
+        "independence": "THE LIMITS ARE INDEPENDENT OF THE RUNS THEY ARE FIRST JUDGED ON, and that is the difference from clock_check_standard.json v1, which said in its own `independence` field that it was not. NIST e-Handbook 2.3.5's doctrine is that the limits come from a baseline the standard is not afterwards judged on; the corpus here is five sessions at five commits, so it splits: the four 2026-08-02 sessions are the baseline and the 2026-08-07 session is held out. 0 of 2 hold-out refusals is a small false-refusal measurement rather than no measurement at all. It is small — two row-runs cannot bound a 0.4% nominal rate — and the next recalibration should take a fresh baseline rather than fold the hold-out in.",
+        "chromium": "147.0.7727.15 (one version across all five sessions)",
+        "design": "6 rounds x 3 blocks x (4 warmup + 10 samples), plumb tare on, controlSlack 0.25"
+      }
+    }
+  },
+  "notInThisStandard": {
+    "rows": ["large-template", "feed"],
+    "why": "their control MEETS its own element-arithmetic prediction — run-median centres 1.8433 and 2.0146 against predictions 1.9759 and 1.9943, i.e. 93.3% and 101.0% of P — and rf2-y0pkh measured the strict all-blocks rule on them at 18.2% and 39.8% per-run false refusal and RETAINED it on those grounds",
+    "adjudicatedBy": "`controlVerdict` in shapes/census_clock_run.cjs — the strict all-blocks rule about the row's own element arithmetic, untouched by rf2-pzqy8",
+    "rationale": "Calibrating a standard for a row whose prediction the instrument already meets would replace a working control with a seeded one, and rf2-8a746 rejects retiring a control merely because it shares a shape with one that failed. Absence from this file is a positive statement about those rows, not an omission — a row in NEITHER list is a fault, and the driver refuses to adjudicate one."
+  },
+  "recalibrateOn": [
+    "any Chromium version change — the counters and the compositor are the instrument",
+    "any change to the harness: the door an arm goes through, the plumb tare, the settle, the sample or round counts",
+    "any change to the `ordinary` page — its 5 comment cards, its 51 elements, its 7 boundaries, the shape of a card",
+    "any change to the published clock (the counter the rows are stated on)",
+    "and the recalibration takes a FRESH baseline: re-deriving limits from the runs they will judge is how a check standard stops being one"
+  ]
+}

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
@@ -396,15 +396,17 @@ function controlVerdict(predicted, per, slack) {
  * would replace a working control with a copied one.
  *
  * `ordinary` is the row that does not. It reads 1.2308x against a predicted
- * 1.7255x — 71.3% of P and 5.2% BELOW the strict band's own lower edge — so
- * every one of its ten committed row-runs refused, and rf2-y0pkh measured
- * that no relaxation of the block count reaches it (0, 1, 2 or 3 out-of-band
- * blocks allowed: 0 of 10 either way). The arithmetic is not wrong anywhere;
- * the row is small. `R = (P*W + c)/(W + c)`, and at 51 elements the tared
- * floor is 1.41 ms of which `c = 0.96 ms` — 68% — does not scale with the
- * page, so the reading sits far below `P` by construction. That is a
- * mis-specified CENTRE, the class rf2-8a746 diagnosed on ctl3 (whose true
- * centre sat 2.6% ABOVE its refusal edge where this sits 5.2% below), and
+ * 1.7255x — 71.3% of P, and BELOW the strict band's own lower edge of 1.2941
+ * rather than inside it — so every one of its ten committed row-runs refused,
+ * and rf2-y0pkh measured that no relaxation of the block count reaches it
+ * (0, 1, 2 or 3 out-of-band blocks allowed: 0 of 10 either way, its pooled
+ * block median 1.2264 sitting 5.2% under that edge). The arithmetic is not
+ * wrong anywhere; the row is small. `R = (P*W + c)/(W + c)`, and at 51
+ * elements the tared floor is 1.41 ms of which `c = 0.96 ms` — 68% — does
+ * not scale with the page, so the reading sits far below `P` by
+ * construction. That is a mis-specified CENTRE, the class rf2-8a746
+ * diagnosed on ctl3 (whose true centre sat 2.6% ABOVE its refusal edge
+ * where this row's sits below its own), and
  * its ruling's part 3 is the repair: a level-denominated, EMPIRICALLY
  * CALIBRATED, versioned standard rather than a theoretical value asserted
  * against a reading it does not describe.

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
@@ -80,15 +80,27 @@
 //     (every block inside +/-25%). THAT STRICT RULE IS THE ONE rf2-8a746
 //     RETIRED ON THE CLOCK, and rf2-y0pkh measured it here before deciding:
 //     it costs 18.2% and 39.8% per-run false refusal on large-template and
-//     feed against the clock's 90.5%, so it is RETAINED — the arithmetic
-//     and the reasons are above `controlVerdict`. The `ordinary` row
-//     refuses 10 of 10 for a different reason (its centre, not the rule)
-//     and is rf2-pzqy8's. rf2-jcm3p records the mount-row
-//     undershoot (1.8173x against 2.00 over seven runs): an additive
-//     per-sample constant survives the tare in `(PW + c)/(W + c)`, and no
-//     changed-set control can reach a mount. So this control certifies
-//     page-proportional SIGNAL and bounds the additive residual (printed
-//     as c); it cannot certify exactness.
+//     feed against the clock's 90.5%, so it is RETAINED on those two rows,
+//     unchanged — the arithmetic and the reasons are above `controlVerdict`.
+//     rf2-jcm3p records the mount-row undershoot (1.8173x against 2.00 over
+//     seven runs): an additive per-sample constant survives the tare in
+//     `(PW + c)/(W + c)`, and no changed-set control can reach a mount. So
+//     this control certifies page-proportional SIGNAL and bounds the
+//     additive residual (printed as c); it cannot certify exactness.
+//   * THE CHECK STANDARD, on the `ordinary` row only — `census_check_
+//     standard.json`, v1, rf2-pzqy8. That row's element arithmetic is the
+//     one prediction this instrument does NOT meet: it reads 1.2308x
+//     against a predicted 1.7255x, because at 51 elements the per-sample
+//     work that does not scale with the page is 68% of the reading, so
+//     `(PW + c)/(W + c)` sits far below `P` with no defect anywhere. That
+//     is a mis-specified CENTRE, the class rf2-8a746 diagnosed on ctl3, and
+//     the repair is that ruling's part 3: a level-denominated, EMPIRICALLY
+//     CALIBRATED, versioned standard whose location and dispersion limits
+//     are frozen from a baseline it is not afterwards judged on. Where it
+//     calibrates a row it is the adjudicator and the strict band above is
+//     REPORTED; where it does not, it says so by name and the strict rule
+//     decides. It is data on purpose: recalibrating edits the JSON and
+//     bumps its version, never this file.
 //   * THE BAND — seam.cjs's `ctl-2x / floor` per-block statistic, ceiling
 //     35% on raw TaskDuration (rf2-ymi6j). A run whose band breaches has
 //     NO reportable magnitude; a gated ratio whose margin to the 1.10
@@ -120,16 +132,33 @@
 // row publishes a REFUSAL with the reason, not a number") as a promise this
 // file's own exit code did not keep. See the note above `verdict`.
 //
-// ## Where the datasets land
+// A NONZERO EXIT IS A RUN-LEVEL FACT AND STAYS ONE. 2, 3, 4 and 5 each mean
+// "a row in this run refused" and never "every row did", so the exit refuses
+// the RUN while the refusal itself belongs to the row that earned it — which
+// is what the section below is about.
+//
+// ## Where the datasets land, and WHICH ROWS IN THEM MAY BE CITED
 //
 // The canonical dataset directory holds THE PUBLISHED SHAPE and nothing
 // else. A run that is narrowed (C56CLOCK_ROWS / C56CLOCK_ONLY), taken at an
-// overridden depth, taken `--no-build`, taken with the quiet gate skipped
-// (C56CLOCK_SKIP_QUIET), or refused by the verdict above writes to a sibling
-// `.unpublished` directory instead, named on stdout with the reason; an
-// explicit C56CLOCK_DATA_DIR is honoured as given. See the note above
-// `destination` — that routing is rf2-2rtt6.56's half of the same fail-open
-// rf2-rr6do repaired on the exit path.
+// overridden depth, taken `--no-build`, or taken with the quiet gate skipped
+// (C56CLOCK_SKIP_QUIET) writes to a sibling `.unpublished` directory
+// instead, named on stdout with the reason; an explicit C56CLOCK_DATA_DIR is
+// honoured as given. See the note above `destination` — that routing is
+// rf2-2rtt6.56's half of the same fail-open rf2-rr6do repaired on the exit
+// path.
+//
+// EVERY ONE OF THOSE IS A FACT ABOUT THE RUN'S SHAPE. A gate refusal is not:
+// it is a fact about ONE ROW, and P4 below says so in the instrument's own
+// words — "the ROW publishes a REFUSAL with the reason, not a number". Until
+// rf2-pzqy8 the refusal moved the whole run's file, so one refused row sent
+// the rows that had passed every gate to `.unpublished` with it, and no
+// full-shape census run could ever be canonical. Each row now carries its
+// own `canonical` and `notCanonicalWhy` (see `rowPublication`), the file
+// indexes them in `rowsRefused`, and a refused row travels beside the
+// canonical ones with its reason attached. The run-level refusal is
+// untouched: it is still the process exit, and `verdict` still names every
+// offending row.
 
 'use strict';
 
@@ -142,6 +171,10 @@ const { navigate, NAV_TIMEOUT_MS } = require('../../../freehand/bench/navigate.c
 const { resetLaneBuildCache } = require('../../../freehand/bench/lane_cache.cjs');
 const guard = require('../../../freehand/bench/order_guard.cjs');
 const seamlib = require('../seam.cjs');
+
+// THE CALIBRATED CHECK STANDARD (rf2-pzqy8) — data, never code. Recalibrating
+// is editing that file and bumping its `version`; nothing here holds a limit.
+const CHECK_STANDARD = require('./census_check_standard.json');
 
 const IMPL = path.resolve(__dirname, '../../../../../..');
 const REPO = path.resolve(IMPL, '..');
@@ -270,6 +303,26 @@ function band(xs) {
   };
 }
 
+/** Linear-interpolated quantile, the definition `robustScale` is stated on. */
+function quantile(xs, q) {
+  const v = [...xs].sort((a, b) => a - b);
+  if (v.length === 0) return NaN;
+  const h = (v.length - 1) * q;
+  const lo = Math.floor(h);
+  const hi = Math.ceil(h);
+  return v[lo] + (v[hi] - v[lo]) * (h - lo);
+}
+
+/**
+ * A ROW-RUN'S DISPERSION, ROBUSTLY. `IQR / 1.349` is the normal-consistent
+ * scale estimator, so its number is comparable with a standard deviation
+ * while not being movable by one wild block — which matters for the same
+ * reason rf2-8bgqq moved a ratio's headline to its median: a run rule that a
+ * single extreme block can trip is the all-blocks rule wearing a summary
+ * statistic's clothes.
+ */
+const robustScale = (xs) => (quantile(xs, 0.75) - quantile(xs, 0.25)) / 1.349;
+
 /**
  * The run-rejection rule: EVERY block inside the tolerance band.
  *
@@ -326,6 +379,195 @@ function controlVerdict(predicted, per, slack) {
     ok: per.every((x) => x >= lo && x <= hi),
     rule: 'strict — EVERY block inside the band (rf2-y0pkh: measured and retained)',
   };
+}
+
+/**
+ * THE CALIBRATED CHECK STANDARD, applied to one row-run (rf2-pzqy8) — or
+ * `null` when `census_check_standard.json` does not calibrate that row.
+ *
+ * ## Why one row has a standard and two do not
+ *
+ * `ctl-2x` builds twice the row's cards and the page states the row's own
+ * element arithmetic as the prediction. On `large-template` and `feed` the
+ * instrument MEETS it — run-median centres 1.8433 and 2.0146 against 1.9759
+ * and 1.9943 — and rf2-y0pkh measured the strict rule on those two rows at
+ * 18.2% and 39.8% per-run false refusal and retained it. Nothing there needs
+ * repairing, and seeding a standard for a row whose prediction already holds
+ * would replace a working control with a copied one.
+ *
+ * `ordinary` is the row that does not. It reads 1.2308x against a predicted
+ * 1.7255x — 71.3% of P and 5.2% BELOW the strict band's own lower edge — so
+ * every one of its ten committed row-runs refused, and rf2-y0pkh measured
+ * that no relaxation of the block count reaches it (0, 1, 2 or 3 out-of-band
+ * blocks allowed: 0 of 10 either way). The arithmetic is not wrong anywhere;
+ * the row is small. `R = (P*W + c)/(W + c)`, and at 51 elements the tared
+ * floor is 1.41 ms of which `c = 0.96 ms` — 68% — does not scale with the
+ * page, so the reading sits far below `P` by construction. That is a
+ * mis-specified CENTRE, the class rf2-8a746 diagnosed on ctl3 (whose true
+ * centre sat 2.6% ABOVE its refusal edge where this sits 5.2% below), and
+ * its ruling's part 3 is the repair: a level-denominated, EMPIRICALLY
+ * CALIBRATED, versioned standard rather than a theoretical value asserted
+ * against a reading it does not describe.
+ *
+ * ## And why its run rule is location + dispersion
+ *
+ * Because re-centring alone does not reach it either. About the empirical
+ * centre the per-block in-band fraction rises from 31.1% to 90.0% and the
+ * all-blocks rule would still pass only 3 of 10, because `0.90^18 = 15%` —
+ * rf2-8a746's `p^n` arithmetic, on this rig, at this n. So on a calibrated
+ * row the tolerance band is REPORTED and the run rule is the standard's:
+ * the row-run's block median inside frozen location limits AND its robust
+ * scale at or under a frozen dispersion limit. THE STRICT RULE IS NOT
+ * TOUCHED WHERE rf2-y0pkh MEASURED AND RETAINED IT — on the two rows above
+ * it is still the adjudicator, with the same band and the same wording.
+ *
+ * FAIL CLOSED AT EVERY SEAT: a row-run with no blocks, a block that is not a
+ * finite reading, and a row the standard declares `calibrated: false` are
+ * each a REFUSAL and never a pass. A row that appears in NEITHER list is a
+ * fault and THROWS — the standard is complete over the roster by
+ * construction, so a row it has never heard of may not be adjudicated by it
+ * or waved past it.
+ */
+function checkStandardVerdict(rowId, per) {
+  const spec = CHECK_STANDARD.rows[rowId];
+  if (!spec) {
+    if ((CHECK_STANDARD.notInThisStandard.rows || []).includes(rowId)) return null;
+    throw new Error(
+      `row \`${rowId}\` is in neither \`rows\` nor \`notInThisStandard\` of ${CHECK_STANDARD.id} ` +
+        `v${CHECK_STANDARD.version} — a row this standard has never heard of can be neither adjudicated ` +
+        `by it nor waved past it (${CHECK_STANDARD.bead})`
+    );
+  }
+
+  const xs = Array.isArray(per) ? per : [];
+  const finite = xs.filter(Number.isFinite);
+  const out = {
+    standard: { id: CHECK_STANDARD.id, version: CHECK_STANDARD.version, bead: CHECK_STANDARD.bead },
+    rowId,
+    calibrated: spec.calibrated === true,
+    rule: CHECK_STANDARD.runRejection,
+    measured: {
+      n: xs.length,
+      finite: finite.length,
+      p50: r4(p50(finite)),
+      scale: r4(robustScale(finite)),
+    },
+    location: null,
+    dispersion: null,
+    tolerance: null,
+    errorRates: spec.errorRates || null,
+    ok: false,
+    why: null,
+  };
+
+  if (!out.calibrated) {
+    out.why = `the \`${rowId}\` row of the check standard is NOT CALIBRATED — ${spec.why || 'nothing has established what this instrument reads on it'}`;
+    return out;
+  }
+  if (finite.length === 0 || finite.length !== xs.length) {
+    out.why =
+      xs.length === 0
+        ? 'no blocks — an empty block set is an absent reading, not a row-run in control'
+        : `${xs.length - finite.length} of ${xs.length} blocks are not finite readings of a level ratio`;
+    return out;
+  }
+
+  const [lo, hi] = spec.location.limits;
+  const median = p50(finite);
+  const scale = robustScale(finite);
+  const [tlo, thi] = spec.tolerance.band;
+  const inBand = finite.filter((x) => x >= tlo && x <= thi).length;
+
+  out.location = {
+    statistic: CHECK_STANDARD.statistics.location,
+    centre: spec.centre,
+    limits: [lo, hi],
+    measured: r4(median),
+    ok: median >= lo && median <= hi,
+  };
+  out.dispersion = {
+    statistic: CHECK_STANDARD.statistics.dispersion,
+    limit: spec.dispersion.limit,
+    measured: r4(scale),
+    ok: scale <= spec.dispersion.limit,
+  };
+  // REPORTED AND NOT A RULE. It is printed because a reader wants to see
+  // where the blocks fell; nothing below reads `inBand` into `ok`.
+  out.tolerance = {
+    band: [tlo, thi],
+    inBand,
+    of: finite.length,
+    fraction: r4(inBand / finite.length),
+    gating: false,
+  };
+  out.ok = out.location.ok && out.dispersion.ok;
+  out.why = out.ok
+    ? null
+    : [
+        out.location.ok
+          ? null
+          : `the row-run's block median ${r4(median)}x is outside the frozen location limits ` +
+            `[${lo} – ${hi}] about an EMPIRICAL centre of ${spec.centre}x`,
+        out.dispersion.ok
+          ? null
+          : `the row-run's robust scale ${r4(scale)} exceeds the frozen dispersion limit ${spec.dispersion.limit} ` +
+            `— the box could not reproduce identical work block to block`,
+      ]
+        .filter(Boolean)
+        .join('; ');
+  return out;
+}
+
+/**
+ * THE ROW'S CONTROL VERDICT, and the one field a gate may read.
+ *
+ * Both adjudicators are computed and both are recorded, so a reader can see
+ * the mis-specification rather than take its repair on trust: `strictOk` is
+ * the all-blocks rule's own answer about the row's element arithmetic, and
+ * `standard` is the calibrated standard's, or `null` where the row has none.
+ * `ok` is whichever of the two ADJUDICATES the row, and `adjudicator` names
+ * it. One field, one gate, one seat — `summarise` reads `ok` and nothing
+ * else, exactly as it did before rf2-pzqy8.
+ */
+function controlAdjudication(rowId, predicted, per, slack) {
+  const strict = controlVerdict(predicted, per, slack);
+  const standard = checkStandardVerdict(rowId, per);
+  return {
+    ...strict,
+    strictOk: strict.ok,
+    standard,
+    adjudicator: standard
+      ? `the calibrated check standard \`${standard.standard.id}\` v${standard.standard.version} (${standard.standard.bead}); the band above is REPORTED`
+      : 'the strict all-blocks rule above, about the row\'s own element arithmetic (rf2-y0pkh: measured and retained)',
+    ok: standard ? standard.ok : strict.ok,
+  };
+}
+
+/** The lines a report prints for a check-standard verdict; none when there is no standard. */
+function formatCheckStandard(v) {
+  if (!v) return [];
+  const lines = [
+    `;;   ${v.ok ? 'IN CONTROL' : 'REFUSED   '} check standard \`${v.standard.id}\` v${v.standard.version} ` +
+      `[${v.rowId}${v.calibrated ? '' : ', UNCALIBRATED'}] (${v.standard.bead})`,
+  ];
+  if (v.location && v.dispersion) {
+    lines.push(
+      `;;     location   ${v.location.measured}x median of ${v.measured.finite} blocks against ` +
+        `[${v.location.limits[0]} – ${v.location.limits[1]}] about an EMPIRICAL centre ${v.location.centre}x ` +
+        `— ${v.location.ok ? 'inside' : 'OUTSIDE'}`
+    );
+    lines.push(
+      `;;     dispersion ${v.dispersion.measured} robust scale (IQR/1.349) against a limit of ` +
+        `${v.dispersion.limit} — ${v.dispersion.ok ? 'inside' : 'OVER'}`
+    );
+    lines.push(
+      `;;     tolerance  ${v.tolerance.inBand} of ${v.tolerance.of} blocks inside [${v.tolerance.band[0]} – ` +
+        `${v.tolerance.band[1]}] — REPORTED, and it decides nothing: about this centre the all-blocks rule ` +
+        `would pass 3 of 10 row-runs, because 0.90^18 = 15%`
+    );
+  }
+  if (v.why) lines.push(`;;     why        ${v.why}`);
+  return lines;
 }
 
 /**
@@ -898,14 +1140,17 @@ function report(out) {
 
   // the control — predicted from the row's own element arithmetic
   const ctlPer = controlBlocks(blocksTask);
-  const ctl = controlVerdict(ctlPredicted, ctlPer, CONTROL_SLACK);
+  const ctl = controlAdjudication(rowId, ctlPredicted, ctlPer, CONTROL_SLACK);
   const floorTared = p50(perBlock(blocksTask, (r, b) => taredCell(blocksTask, r, b, FLOOR)));
   const c = additiveConstant(floorTared, ctl.measured.mean, ctlPredicted);
   console.log(`;; ---- POSITIVE CONTROL: ctl-2x doubles the row's cards; prediction ${fmt(ctlPredicted)}x (element arithmetic, chrome does not double) ----`);
   console.log(
-    `;;   ${ctl.ok ? 'PASS' : 'FAIL'}  measured ${fmt(ctl.measured.mean)}x [${fmt(ctl.measured.min)} – ${fmt(ctl.measured.max)}] ` +
-      `against [${fmt(ctl.band[0], 2)} – ${fmt(ctl.band[1], 2)}] (${ctl.rule})`
+    `;;   ${ctl.strictOk ? 'PASS' : 'FAIL'}  measured ${fmt(ctl.measured.mean)}x [${fmt(ctl.measured.min)} – ${fmt(ctl.measured.max)}] ` +
+      `against [${fmt(ctl.band[0], 2)} – ${fmt(ctl.band[1], 2)}] (${ctl.rule})` +
+      (ctl.standard ? '   [REPORTED — this row is adjudicated by the check standard below]' : '')
   );
+  for (const line of formatCheckStandard(ctl.standard)) console.log(line);
+  console.log(`;;   ADJUDICATED BY ${ctl.adjudicator} — ${ctl.ok ? 'the control HOLDS' : 'the control DOES NOT HOLD'}`);
   console.log(
     `;;   rf2-jcm3p's recorded mount undershoot expected: additive residual c = ` +
       `${fmt(c, 3)} ms on a tared floor of ${fmt(floorTared, 3)} ms. This control certifies ` +
@@ -1034,21 +1279,29 @@ function report(out) {
 // written before this is consulted. A refusal is about what may be QUOTED,
 // not about throwing the measurement away.
 
+/**
+ * ONE ROW, in the flat shape every decision below is taken on.
+ *
+ * Lifted out of `summarise` because the WRITE path needs the same four
+ * refusal fields the EXIT path does, and reading them twice off two
+ * different accessor paths is how a second adjudicator grows (rf2-pzqy8).
+ * One mapper, so `verdict` and `rowPublication` can never disagree about
+ * what refused a row.
+ */
+const summariseRow = (r) => ({
+  id: `${r.runId}/${r.rowId}`,
+  guardRefuse: r.adjudication.guardRefuse,
+  unverified: r.tally.unverified,
+  writes: r.tally.writes,
+  ctlOk: r.adjudication.ctl.ok,
+  ctlMeasured: r.adjudication.ctl.measured.mean,
+  ceilingBreached: r.adjudication.assessed.verdict.ceilingBreached,
+  band: r.adjudication.assessed.bandStats.band,
+});
+
 /** The flat record the exit is decided on: one entry per row actually taken. */
 function summarise(failed, results) {
-  return {
-    failed: failed || null,
-    rows: (results || []).map((r) => ({
-      id: `${r.runId}/${r.rowId}`,
-      guardRefuse: r.adjudication.guardRefuse,
-      unverified: r.tally.unverified,
-      writes: r.tally.writes,
-      ctlOk: r.adjudication.ctl.ok,
-      ctlMeasured: r.adjudication.ctl.measured.mean,
-      ceilingBreached: r.adjudication.assessed.verdict.ceilingBreached,
-      band: r.adjudication.assessed.bandStats.band,
-    })),
-  };
+  return { failed: failed || null, rows: (results || []).map(summariseRow) };
 }
 
 function verdict(summary) {
@@ -1092,7 +1345,9 @@ function verdict(summary) {
       '[c56clock] REFUSED — the positive control did not see the change its own arithmetic ' +
         'predicts (rf2-rr6do; this is prediction P4 kept) on: ' +
         ctlFailed.map((r) => `${r.id} (measured ${Number(r.ctlMeasured).toFixed(4)}x)`).join(', ') +
-        '. No MAGNITUDE from those rows is reportable.'
+        '. No MAGNITUDE from those rows is reportable — and the scope is the ROW (rf2-pzqy8): every ' +
+        'row above that passed every gate stays canonical in the same file, which is P4 kept at the ' +
+        'scope P4 states it.'
     );
   }
 
@@ -1124,8 +1379,29 @@ function verdict(summary) {
 // path; this is the write path, the other half of the same fail-open.
 //
 // THE RULE: the canonical directory holds the PUBLISHED SHAPE and nothing
-// else. Any narrowing, any override, any skipped gate, any refusal routes to
-// a sibling `.unpublished` directory, named on stdout with the reason.
+// else. Any narrowing, any override, any skipped gate routes to a sibling
+// `.unpublished` directory, named on stdout with the reason.
+//
+// AND EVERY ONE OF THOSE IS A PROPERTY OF THE RUN, which is the correction
+// rf2-pzqy8 makes. A gate refusal is a property of ONE ROW, and this function
+// used to read the whole verdict's exit code and move the file for it — so a
+// run whose `ordinary` row missed its control sent `large-template` and
+// `feed` to `.unpublished` too, having passed every gate they have. Over the
+// five committed sessions that was every session, on both adapters, so NO
+// FULL-SHAPE CENSUS RUN COULD EVER BE CANONICAL and the studio page's
+// recomputable claims had no canonical set to be recomputed from.
+//
+// The refusal is not weakened, it is put at its own scope. The exit code
+// still refuses the run and `verdict` still names every offending row; each
+// row now carries its own `canonical` and `notCanonicalWhy` (`rowPublication`
+// below) and the file indexes them in `rowsRefused`. A canonical file may
+// therefore hold a REFUSED row beside citable ones — which is not a hole but
+// prediction P4 in the driver's own words: "the ROW publishes a REFUSAL with
+// the reason, not a number". A refusal is evidence; discarding the rows
+// beside it was the fault.
+//
+// `clock_run.cjs`'s `publication(shape)` has read shape and nothing else all
+// along. This is that function's rule, on this driver.
 //
 // rf2-azopg added the skipped gate to that list, and it is the sharpest case:
 // C56CLOCK_SKIP_QUIET=1 already PRINTED "NOT the published shape", but the
@@ -1139,13 +1415,12 @@ function verdict(summary) {
 //
 // Pure over a flat shape record, for the same reason `verdict` is: the write
 // path is then checkable without a release build and a headless Chromium.
-function destination(shape, code) {
+function destination(shape) {
   const s = shape || {};
   if (s.dataDirOverridden) {
     return { dir: s.dataDir, canonical: false, why: 'C56CLOCK_DATA_DIR named this destination' };
   }
   const why = [];
-  if (code !== 0) why.push(`the run's own verdict refused it (exit ${code})`);
   if (s.rowsOnly) why.push(`a PARTIAL row set (C56CLOCK_ROWS=${s.rowsOnly})`);
   if (s.runsOnly) why.push(`a PARTIAL run set (C56CLOCK_ONLY=${s.runsOnly})`);
   if (s.noBuild) why.push("--no-build (the bundle on disk is not known to be this tree's)");
@@ -1153,6 +1428,57 @@ function destination(shape, code) {
   if (s.skipQuiet) why.push('a SKIPPED quiet gate (C56CLOCK_SKIP_QUIET=1)');
   if (!why.length) return { dir: s.dataDir, canonical: true, why: null };
   return { dir: `${s.dataDir}.unpublished`, canonical: false, why: why.join('; ') };
+}
+
+/**
+ * WHETHER ONE ROW MAY BE CITED (rf2-pzqy8) — `destination`'s decision at the
+ * scope prediction P4 states it at, over the same flat row `verdict` refuses
+ * on, so the two can never disagree about what refused it.
+ *
+ * TWO GROUNDS, and they compose. A row INHERITS the run's shape: nothing
+ * taken at an overridden depth or on an unchecked box is citable whatever its
+ * own gates did. On top of that it carries its OWN four gates — the arm-order
+ * guard, unverified read-backs, a reproducibility band over seam.cjs's
+ * ceiling, and a positive control that did not hold. Every one of those is
+ * already per-row in `verdict`'s own lines, which name the rows they refuse;
+ * the write path is where that scope used to be thrown away.
+ *
+ * FAIL CLOSED: an absent row record is refused rather than waved through, and
+ * an absent destination is treated as an unpublished one — a row whose run's
+ * shape nobody established is not a citable row.
+ */
+function rowPublication(row, dest) {
+  const r = row || {};
+  const d = dest || { canonical: false, why: 'no destination was decided for this run' };
+  const pct = (x) => (Number.isFinite(x) ? `${(x * 100).toFixed(1)}%` : 'n/a');
+  const why = [];
+  if (!row) why.push('no row record — an absent row is not a citable one');
+  if (!d.canonical) why.push(`the run itself is not the published evidence: ${d.why}`);
+  if (r.guardRefuse) {
+    why.push(
+      'the ARM-ORDER GUARD refused it — a figure that depends on where in the plan it was measured ' +
+        'may not be reported as measured'
+    );
+  }
+  if (r.unverified > 0) {
+    why.push(
+      `${r.unverified} of ${r.writes} operations are UNVERIFIED (rf2-rr6do) — a window whose value ` +
+        'never reached the page is not a measurement of that page'
+    );
+  }
+  if (r.ceilingBreached) {
+    why.push(
+      `its reproducibility band ${pct(r.band)} exceeds seam.cjs's ${(seamlib.BAND_CEILING * 100).toFixed(0)}% ` +
+        'ceiling (rf2-ymi6j) — the box could not reproduce identical work, so no magnitude is reportable'
+    );
+  }
+  if (row && !r.ctlOk) {
+    why.push(
+      `its POSITIVE CONTROL did not hold (measured ${Number(r.ctlMeasured).toFixed(4)}x) — this is the ` +
+        'REFUSAL prediction P4 promises the row publishes, with the reason, in place of a number'
+    );
+  }
+  return why.length ? { canonical: false, why: why.join('; ') } : { canonical: true, why: null };
 }
 
 /**
@@ -1168,21 +1494,34 @@ function destination(shape, code) {
  * outside it. Recording is not deciding, and this is where that shows.
  */
 function datasetFor(rows, meta) {
+  const publication = (r) => rowPublication(summariseRow(r), meta.dest);
   return {
     bead: 'rf2-2rtt6.56',
     commit: meta.sha,
     blobs: meta.blobs,
     when: new Date().toISOString(),
-    // Whether this file is the published evidence, recorded IN the file — a
+    // Whether this file is THE PUBLISHED SHAPE, recorded IN the file — a
     // dataset that travels out of its directory must still say what it is.
+    // It is a fact about the RUN: its depth, its row set, its build, its
+    // quiet gate. Whether a given ROW in it may be cited is on the row.
     canonical: meta.dest.canonical,
     notCanonicalWhy: meta.dest.why,
+    // ... and the rows that may NOT be, indexed at the top of the file so a
+    // reader who checks only the header cannot cite one by missing it
+    // (rf2-pzqy8). Empty on a run every row of which passed every gate.
+    rowsRefused: rows.filter((r) => !publication(r).canonical).map((r) => r.rowId),
     design: { rounds: ROUNDS, blocks: BLOCKS, warmup: WARMUP, samples: SAMPLES, tolerance: TOLERANCE, controlSlack: CONTROL_SLACK, gateLine: GATE_LINE },
     clock: 'Performance.getMetrics raw TaskDuration, frame-settled (rAF + setTimeout), plumb-tared',
     door: 'page.evaluate -> C56CLOCK.sample (every arm, plumb included)',
     node: process.version,
     rows: rows.map((r) => ({
       rowId: r.rowId,
+      // WHETHER THIS ROW MAY BE CITED, and why not when it may not — the
+      // refusal at prediction P4's own scope (rf2-pzqy8). A row that refused
+      // travels here beside the rows that did not, rather than taking them
+      // to `.unpublished` with it.
+      canonical: publication(r).canonical,
+      notCanonicalWhy: publication(r).why,
       armIds: r.armIds,
       // The row's workload — cards, elements, per-instance reads, boundaries.
       // Persisted because rf2-2rtt6.62 turned on exactly these counts, and
@@ -1342,13 +1681,13 @@ async function drive() {
   // The verdict is computed BEFORE the datasets are written, because where
   // they may be written depends on it (see `destination`).
   const v = verdict(summarise(failed, results));
-  const dest = destination(runShape(), v.code);
+  const dest = destination(runShape());
 
   // compact datasets — the reduced quantities every statistic above is a
   // function of, per run, so the page can be recomputed from the tree.
   if (results.length && !failed) {
     if (dest.canonical) {
-      console.log(';; datasets CANONICAL — the published shape, all gates passed');
+      console.log(';; datasets CANONICAL — the published shape; each row states whether it may be cited');
     } else {
       console.log(`;; datasets NOT CANONICAL — ${dest.why}`);
       console.log(';;          These are working datasets. They are not the published evidence and');
@@ -1361,7 +1700,12 @@ async function drive() {
       const data = datasetFor(rows, { sha, blobs: bl, dest });
       const f = path.join(dest.dir, `${runDef.id}.json`);
       fs.writeFileSync(f, JSON.stringify(data));
-      console.log(`;; dataset  ${f}${dest.canonical ? '' : '   (NOT the published evidence)'}`);
+      console.log(
+        `;; dataset  ${f}${dest.canonical ? '' : '   (NOT the published evidence)'}` +
+          (data.rowsRefused.length
+            ? `   — rows that may NOT be cited: ${data.rowsRefused.join(', ')} (each carries its own reason)`
+            : '   — every row citable')
+      );
     }
   }
 
@@ -1378,7 +1722,10 @@ async function drive() {
   return v.code;
 }
 
-module.exports = { summarise, verdict, destination, datasetFor, foldDecomposition, controlBlocks, controlVerdict };
+// rf2-pzqy8 adds the last six: the empirical centre, and the refusal at the
+// row's own scope. `summarise` and `verdict` stay FIRST, which the shared
+// wiring pin in `../clock_exit_path.test.cjs` reads.
+module.exports = { summarise, verdict, destination, datasetFor, foldDecomposition, controlBlocks, controlVerdict, CHECK_STANDARD, checkStandardVerdict, controlAdjudication, robustScale, summariseRow, rowPublication };
 
 if (require.main === module) {
   drive().then((code) => {


### PR DESCRIPTION
Two bounded changes to the census-real clock rig, both in `shapes/`, neither touching another instrument. NO MEASUREMENT WAS TAKEN — no census driver, no clock driver, no quiet box. Everything below is arithmetic over the committed `data/censusclock-*` datasets, driven through the driver's own exported functions.

## Half one — the ordinary row's centre is EMPIRICAL

`ordinary` refused 10 of 10 committed row-runs, and rf2-y0pkh measured that the run-rejection rule is not why: the row reads **1.2308x against an element-arithmetic prediction of 1.7255x** — 71.3% of P, and *below* the strict band's own lower edge of 1.2941 rather than inside it, so allowing one, two or three out-of-band blocks still passes 0 of 10. (rf2-y0pkh's 5.2% is that gap measured on the pooled block median 1.2264; the baseline-only centre frozen below sits 4.9% under the same edge. Both are stated where they are used.) The arithmetic is not wrong anywhere — the row is small. `R = (P·W + c)/(W + c)`, and at 51 elements the tared floor is 1.41 ms of which **c = 0.96 ms (68%) does not scale with the page**, so the reading sits far below `P` by construction. That is a mis-specified CENTRE, the class rf2-8a746 diagnosed on ctl3 — whose true centre sat *above* its refusal edge where this row's sits *below* its own — and its ruling's part 3 is the repair.

**`shapes/census_check_standard.json` v1** — level-denominated, versioned as data, in `clock_check_standard.json`'s idiom. The clock's frozen limits were NOT imported: that rig measures a different quantity on a 300-boundary page, and asserting its 1.7207x centre here would re-commit the mis-specification being retired.

| | frozen | derivation |
|---|---|---|
| centre | 1.2308 | the MEDIAN of the 8 baseline row-runs' block medians (rf2-8bgqq: a ratio's headline is its median) |
| location | [1.0412, 1.4204] | centre ± 3 × between-run SD 0.0632 |
| dispersion | ≤ 0.3422 | `exp(mu + 3 sigma)` of the 8 baseline log robust scales, mu = −2.1040, sigma = 0.3439 — 44% above the widest observed draw, not at it |
| tolerance | [0.9231, 1.5385] | centre ± 25%, REPORTED, decides nothing |

**The baseline is independent of the runs it is first judged on**, which is where this improves on `clock_check_standard.json` v1 rather than repeating it — v1's own `independence` field says its limits were seeded from the 42 row-runs it was quoted against, so 0-of-42 was a consistency check and not a false-refusal measurement. This corpus is five sessions at five commits, so it splits: the **four 2026-08-02 sessions are the baseline** (8 row-runs, 144 blocks) and the **2026-08-07 session `censusclock-jv36i` is held out** (2 row-runs, 36 blocks, a different commit five days later). Both hold-out row-runs are IN CONTROL against limits derived without them. That is a small false-refusal measurement — two row-runs cannot bound a 0.4% nominal rate — and the file says so and requires a fresh baseline at the next recalibration.

**Why the run rule is location + dispersion and not the block count.** Re-centring ALONE does not reach it: about the empirical centre the per-block in-band fraction rises from 31.1% to 90.0% and the all-blocks rule would still pass only 3 of 10, because `0.90^18 = 15%`. That is rf2-8a746's `p^n` arithmetic on this rig at this n, and it is the reason the tolerance band is reported and the standard's own rule decides.

**The all-blocks strict rule is UNTOUCHED where rf2-y0pkh measured and retained it.** `controlVerdict` is unchanged, wording included; `large-template` and `feed` are declared out of the standard by name (their centres are 93.3% and 101.0% of their predictions) and still pass 8 of 10 and 7 of 10 on the same rule. No band was widened, and the strict rule's own answer about 1.7255 is still 0 of 10 — the row now holds because the CENTRE moved to what the instrument reads, and both answers are recorded side by side (`strictOk`, `standard`, `adjudicator`).

**The standard states what it cannot catch.** `R = 0.3181·P_eff + 0.6819`: the frozen limits admit control arms building `P_eff ∈ [1.1295, 2.3216]` against a declared 1.7255 — 17.8% to 182.2% of the declared extra work. An arm that does not double at all reads 1.0000x and is REFUSED; a tripling reads 1.4616x and is REFUSED; the 140-of-300 sabotage rf2-8a746 proved its own standard against would read **1.1077x on this row and be ADMITTED**. That is not a hole in the rule, it is prediction P4 restated as a number, and it is in the file rather than left to be discovered.

**Does the ordinary row now pass? Yes** — all 10 committed row-runs are in control, including the 2 independent hold-outs. The fence held either way: nothing was widened to get there.

## Half two — a refused ROW no longer refuses the RUN

P4, registered before any clock: *"the ORDINARY row (51 elements) sits near this door's own floor; if its control or band cannot hold, **the row publishes a REFUSAL with the reason, not a number**."* The scope is the row. `verdict`'s `ctlFailed` exits 5 run-wide, and `destination` then read that exit code and sent **the whole run's datasets** — `large-template` and `feed` included, having passed every gate they have — to the `.unpublished` sibling. Over the five committed sessions the ordinary row failed on both adapters every time, so **no full-shape census run could ever be canonical**.

The repair is a scope split, not a loosening:

- **`destination(shape)` reads the run's SHAPE and nothing else** — narrowing, `--no-build`, an overridden depth, a skipped quiet gate, an operator-named directory. This is exactly what `clock_run.cjs`'s `publication(shape)` has read all along; the census driver was the one that folded a gate verdict in.
- **Each row carries its own `canonical` / `notCanonicalWhy`** (`rowPublication`), composed from the run's shape AND the row's own four gates — arm-order guard, unverified read-backs, a breached band ceiling, a control that did not hold. A row inherits the run: nothing in a non-published-shape file is citable whatever its gates did.
- **The file indexes them in `rowsRefused`**, so a reader who checks only the header cannot cite a refused row by missing it.
- **One mapper.** `summariseRow` is lifted out of `summarise` and used by both `verdict` and `rowPublication`, so the exit path and the write path cannot disagree about what refused a row.
- **The run-level refusal is untouched.** The exit code still refuses (2/3/4/5), `verdict` still names every offending row, and the header now says so: *"A NONZERO EXIT IS A RUN-LEVEL FACT AND STAYS ONE."*

### What a full-shape run now produces when `ordinary` refuses

Exit 5, one refusal line naming `uix/ordinary` and no other row, and the datasets written to the **canonical** directory — because the run's shape is the published one. Inside the file: `canonical: true`, `rowsRefused: ["ordinary"]`, `large-template` and `feed` each `canonical: true, notCanonicalWhy: null`, and `ordinary` `canonical: false` with the reason attached and its numbers still recorded. A refusal is evidence; discarding the rows beside it was the fault.

Counterfactual over the ten committed run-files, on the gate verdicts they carry: **6 now have all three rows citable and 4 have one refused row beside two citable ones — against 0 files with any citable row before.** (`censusclock-jv36i` is separately non-canonical for a provenance reason — `C56CLOCK_DATA_DIR named this destination` — which this PR does not touch.)

## Quality gates

Every gate run from the worker worktree `C:/Users/miket/code/re-frame2-worktrees/censuscentre-pzqy8`, foreground to completion, after rebasing onto current `origin/main` (`f09af5e6d2`).

| gate | result |
|---|---|
| `node --check` on `shapes/census_clock_run.cjs` | exit 0 |
| `node --check` on `clock_exit_path.test.cjs` | exit 0 |
| `census_check_standard.json` parses | ok |
| `node freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs` | **291 → 321 passed**, exit 0 (baseline measured on `origin/main` by checking its two files out and running them) |
| `npm run test:script-helpers` | exit 0 |
| `sh scripts/test-fast-pr.sh` | `PASS fast PR spine`, exit 0 |
| `npm run lint:js` (repo root) | exit 0 |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | `No beads-database paths in this PR diff.`, exit 0 |

The spine's `ok … → FAILED` lines are its negative-test harnesses passing; the verdict is the echoed exit code.

## Mutation proofs

Each mutation applied to the final tree, the suite run, the file restored. All eight go red, and the tree is green either side of every one.

**Half one — the centre**

| mutation | result |
|---|---|
| the frozen centre moved back to the retired prediction `1.7255` | 7 of 321 red |
| the location limits widened to ±25% of the centre | 2 of 321 red |
| the HOLD-OUT session folded into the baseline | 3 of 321 red |
| the 140-of-300 sabotage claimed as CAUGHT rather than admitted | 1 of 321 red |

**Half two — the scope**

| mutation | result |
|---|---|
| the OLD run-wide routing restored (`destination(shape, code)`, `if (code !== 0) …`) | **19 of 321 red**, including *"ORDINARY REFUSED, THE OTHER TWO CLEAN"* and the counterfactual witness |
| the row's own control gate dropped from `rowPublication` | 5 of 321 red |
| the per-row `canonical` decision replaced by a constant `true` | 7 of 321 red |
| the RUN-LEVEL refusal removed (`verdict`'s `ctlFailed` clause) | 7 of 321 red |

The last one is the fence in both directions: weakening the run-level refusal into nothing is as red as restoring the run-wide routing.

## Files

- `implementation/freehand/test/re_frame/bench/hicasso/shapes/census_check_standard.json` (new, 92 lines)
- `implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs`
- `implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs`

Nothing in `clock_run.cjs`, `clock_check_standard.*`, `clock_readjudicate.cjs` or the studio pages is touched.

Closes rf2-pzqy8. Related: rf2-y0pkh (the measurement), rf2-8a746 (the ruling and the clock-side check standard this mirrors), rf2-2rtt6.56 (the driver), rf2-jo60g (the ruling whose scope this makes reachable).
