### PR TITLE
bench(p0): a boundary-proportional write and an observed-collection witness (rf2-2rtt6.140)

### DIFF
--- a/docs/design/hicasso/studio/the-survival-metrics-allocation-half.md
+++ b/docs/design/hicasso/studio/the-survival-metrics-allocation-half.md
@@ -10,6 +10,34 @@ series was taken. The refusal is reported here in full rather than
 withdrawn, because the programme has retracted a published row before and
 the cheaper mistake is the one that never ships.
 
+> **SUPERSEDED-NOT-COMPARABLE, 2026-08-08 17:12 AUSEST.** The instrument
+> these rows were taken on no longer exists. `rf2-2rtt6.140`'s implementation
+> landed the two artefacts
+> [the allocation instrument's rework](../allocation-instrument-rework.md)
+> designs: a **boundary-proportional write** (`:p0/write-page`, which
+> rebuilds the grid at the width the mounted page reads, where
+> `:p0/write-all` rebuilt 300 cells whatever was mounted) and an
+> **observed-collection witness** (a window is certified by whether its work
+> legs look like repetitions of one work unit, not by
+> `(W+1)·perWrite ≤ ALLOC_MASK_BUDGET_B`, which is retired).
+>
+> **So no `s(R)`, floor figure or ladder row below may be differenced against
+> anything measured after that change**, and none may be quoted as a property
+> of the new instrument. They remain valid as exactly what they are: the
+> record of the write that was, and the evidence base the rework was designed
+> from. **Every figure and every table on this page stands** — this note
+> annotates and erases nothing.
+>
+> The one figure that keeps its full force across the change is **`F_old`**,
+> the 24,108 / 24,730 B per write the floor arm read on 2026-08-08. Validity
+> witness V1 re-measures it as its own control, and an agreement at B = 24 is
+> what licenses comparing the two writes at all.
+>
+> The three instrument blob pins below are pins on the **old** instrument.
+> The new one carries its own. **V1–V3 have not run**: `rf2-2rtt6.140`
+> criterion 5 freezes every allocation window until they are green, and no
+> window has been granted.
+
 ## The answer, first
 
 - **The allocation half of HD-002's survival metric is still unwitnessed**,
@@ -399,6 +427,14 @@ or a real non-linearity is itself unmeasured, and the small-witness arm
 should be costed against that question rather than assumed to answer it.
 
 ## The small-witness arm, measured
+
+> **Superseded-not-comparable** (see the note at the head of this page). This
+> section and [the fixed per-write cost](#the-fixed-per-write-cost-measured-for-the-first-time)
+> below were taken with `:p0/write-all` on a 24-boundary page, and
+> `rf2-2rtt6.140` replaced that write with `:p0/write-page`. Nothing measured
+> under the new write may be differenced against these rows. `F_old` — the
+> 24,108 / 24,730 B per write — is the exception, and V1 re-measures it as
+> the control that licenses the comparison.
 
 The arm clause (4) asks for was built by `rf2-2rtt6.138` (PR #7688) and had
 never been executed. It was executed once, on 2026-08-08, on a box granted

--- a/implementation/core/test/re_frame/bench/p0_arms.cljs
+++ b/implementation/core/test/re_frame/bench/p0_arms.cljs
@@ -137,17 +137,25 @@
   `make-frame` and a seeding dispatch would price frame construction on
   whichever arm happened to own it.
 
+  `grid-width` is how many `:cells` the frame is seeded with, and it is an
+  ARGUMENT rather than an ambient volatile (rf2-2rtt6.140): a width set
+  after seeding would be a page whose sub graph and whose db disagree, and
+  a parameter that is never ambient cannot be set in the wrong order. It
+  defaults to `fx/cells-n`, so the clock rows and the retention rows —
+  which pass nothing — seed the published page to the byte.
+
   A teardown that throws STOPS the instrument and names the phase — see
   [[teardown!]]."
-  [{:keys [adapter]}]
-  (teardown! "destroy-frame!" #(rf/destroy-frame! frame-id))
-  (when (rf/current-adapter)
-    (teardown! "destroy-adapter!" #(rf/destroy-adapter!)))
-  (rf/init! adapter)
-  (fx/register!)
-  (rf/make-frame {:id frame-id :initial-events [[:p0/seed]]})
-  (reset! captured (rf/capture-frame frame-id))
-  nil)
+  ([segment] (enter-segment! segment fx/cells-n))
+  ([{:keys [adapter]} grid-width]
+   (teardown! "destroy-frame!" #(rf/destroy-frame! frame-id))
+   (when (rf/current-adapter)
+     (teardown! "destroy-adapter!" #(rf/destroy-adapter!)))
+   (rf/init! adapter)
+   (fx/register!)
+   (rf/make-frame {:id frame-id :initial-events [[:p0/seed (long grid-width)]]})
+   (reset! captured (rf/capture-frame frame-id))
+   nil))
 
 (defn- dispatch-sync! [ev]
   ((:dispatch-sync @captured) ev))
@@ -163,6 +171,25 @@
   the one the clock and heap rows measured."
   [v]
   (dispatch-sync! [:p0/write-all v])
+  nil)
+
+(defn write-page!
+  "The BOUNDARY-PROPORTIONAL write, as a public door beside [[write-all!]]
+  (rf2-2rtt6.140).
+
+  Same [[dispatch-sync!]], same event pipeline, same signal graph — the
+  allocation row's warm re-render still has to be the write a real
+  application pays for. What differs is that `:p0/write-page` rebuilds
+  `:cells` at the width the mounted page actually reads, where
+  `:p0/write-all` rebuilds `fx/cells-n` of them whatever is mounted. That
+  fixed cost measured 24.4 KB per write on this rig — 57% of the retired
+  masking budget before a single boundary had been measured — and it does
+  not shrink when the page does.
+
+  The clock and bulk rows keep driving [[write-all!]]: their rows are
+  published and their write stays byte-identical."
+  [v]
+  (dispatch-sync! [:p0/write-page v])
   nil)
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/core/test/re_frame/bench/p0_fixture.cljc
+++ b/implementation/core/test/re_frame/bench/p0_fixture.cljc
@@ -151,12 +151,26 @@
 
 (defn seed-db
   "The app-db every arm starts from. One map, so the two adapter segments
-  cannot begin from different data."
-  []
-  {:rows   (mapv row-value (range w1-rows))
-   :fields (mapv (fn [i] {:value (field-value i) :error (field-error i)})
-                 (range w3-fields))
-   :cells  (vec (repeat cells-n 0))})
+  cannot begin from different data.
+
+  `grid-width` is how many cells `:cells` holds, and it is A PROPERTY OF THE
+  SEEDED DB rather than a compile-time constant baked into three places
+  (rf2-2rtt6.140). [[cells-n]] is the default, so every caller that passes
+  nothing gets the published page to the byte — the clock rows, the bulk
+  rows, the fan-out sweep and the retention ladder all do.
+
+  The allocation row is the one caller that states it, because
+  `:p0/write-all` rebuilds 300 cells whether one boundary is mounted or
+  1,200 and that fixed cost is the thing that made the ladder
+  uncertifiable at any page size. There is nowhere for the width to drift
+  to: [[fan-key]]'s modulus is Q, and `:p0/fan` folds into whatever grid
+  the db it is handed actually holds."
+  ([] (seed-db cells-n))
+  ([grid-width]
+   {:rows   (mapv row-value (range w1-rows))
+    :fields (mapv (fn [i] {:value (field-value i) :error (field-error i)})
+                  (range w3-fields))
+    :cells  (vec (repeat grid-width 0))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The registrations
@@ -176,8 +190,18 @@
   ;; grid answers and every rung of the sweep renders identical DOM. A rung
   ;; whose text differed with Q would be moving the floor it is differenced
   ;; against while claiming to move only the cache.
-  (rf/reg-sub :p0/fan   (fn [db [_ i]] (get-in db [:cells (mod i cells-n)])))
-  (rf/reg-event :p0/seed (fn [_ _] {:db (seed-db)}))
+  ;;
+  ;; The modulus is READ OFF THE DB rather than off `cells-n`
+  ;; (rf2-2rtt6.140), so the grid width lives in exactly one place — the
+  ;; seeded db — and cannot drift against the width a write rebuilds. It is
+  ;; a field read on a `PersistentVector`: O(1), allocating nothing and
+  ;; retaining nothing, which is why the retention rows that publish
+  ;; retained bytes are not moved by it.
+  (rf/reg-sub :p0/fan   (fn [db [_ i]] (get-in db [:cells (mod i (count (:cells db)))])))
+  ;; The width rides on the event, so a frame's `:initial-events` states the
+  ;; page it is seeding and nothing ambient has to be set in the right order
+  ;; beforehand. Absent, it is the published [[cells-n]].
+  (rf/reg-event :p0/seed (fn [_ [_ grid-width]] {:db (seed-db (or grid-width cells-n))}))
   ;; The two BULK writes, as ordinary re-frame events. Both arms drive
   ;; their bulk row through `dispatch-sync` on these, because in re-frame2
   ;; the commit IS the write clock and an arm that reached past it — a
@@ -186,6 +210,30 @@
   ;; for on every write. The floor arm has neither and says so.
   (rf/reg-event :p0/write-all
     (fn [{:keys [db]} [_ v]] {:db (assoc db :cells (vec (repeat cells-n v)))}))
+  ;; THE BOUNDARY-PROPORTIONAL WRITE (rf2-2rtt6.140). Byte-for-byte the same
+  ;; event through the same pipeline as `:p0/write-all` — an ordinary
+  ;; re-frame event with an ordinary `:db` effect, dispatched synchronously —
+  ;; differing in ONE term: the width of the vector rebuilt inside the
+  ;; handler is the db's own, not the compile-time 300.
+  ;;
+  ;; THE EQUIVALENCE ARGUMENT, because a cheaper write that measures
+  ;; something else is worse than no write. Every mounted key `[:p0/fan k]`
+  ;; folds into `db[:cells]` under `(mod k width)` and this replaces every
+  ;; slot with a new value, so every one of the E = B·R edges sees a changed
+  ;; value and the INVALIDATION SET IS IDENTICAL: the same R subs recompute,
+  ;; the same R changed values reach each boundary, the same re-render and
+  ;; commit follow. A boundary's text is the sum of its R reads, so at a page
+  ;; written to `v` it is `(str (* R v))` under either write and the DOM
+  ;; read-back, the canonical-DOM comparison and the floor subtraction are
+  ;; all unchanged. B, E, Q and the key rule are untouched.
+  ;;
+  ;; The old write ALSO changed data no boundary read — on the 24-boundary
+  ;; page 276 of the 300 rebuilt cells were read by nothing at all — and that
+  ;; is the whole of the difference. It is machinery on both sides of the
+  ;; floor subtraction. `:p0/write-all` is left exactly as it is: its rows
+  ;; are published and it stays byte-identical.
+  (rf/reg-event :p0/write-page
+    (fn [{:keys [db]} [_ v]] {:db (assoc db :cells (vec (repeat (count (:cells db)) v)))}))
   (rf/reg-event :p0/write-one
     (fn [{:keys [db]} [_ i v]] {:db (update db :cells assoc i v)}))
   nil)

--- a/implementation/core/test/re_frame/bench/p0_heap.cljs
+++ b/implementation/core/test/re_frame/bench/p0_heap.cljs
@@ -158,8 +158,7 @@
   subscription, no hook, nothing on the page that a write can re-render.
 
   CONSTRUCTED rather than tabled, and that is the allocation row's doing
-  (rf2-2rtt6.138). The ladder's arms are now sized by their driver so that
-  a whole measured window fits under the masking bound, and a floor left
+  (rf2-2rtt6.138). The ladder's arms are sized by their driver, and a floor left
   at the published 300 would be the calibrator for a page the row never
   mounted: its `B/boundary/write` column would divide the write's own cost
   by a boundary count its own DOM did not have. At `cells` = [[per-root]]
@@ -266,18 +265,22 @@
 ;; needed to move. The allocation row cannot: its instrument is accurate
 ;; only while no collection falls inside the measured window, and one warm
 ;; write of 1,200 boundaries allocates 1.2–1.7 MB, two to three times the
-;; ~600 KB at which the first fall appears. The row's own masking bound
-;; (`p0_run.cjs` `ALLOC_MASK_BUDGET_B`) refuses a window that large rather
-;; than publishing what it reads, because the reading degrades ALWAYS
-;; DOWNWARD and under-reading allocation is the direction that manufactures
+;; ~600 KB at which the first fall appears — so the reading degrades ALWAYS
+;; DOWNWARD, and under-reading allocation is the direction that manufactures
 ;; HD-002's predicted flat-at-zero.
 ;;
 ;; The repair is to shrink the measured UNIT, not the window: the quantity
-;; is per BOUNDARY, so a page of a few dozen boundaries puts a many-write
-;; window under the threshold and leaves the averaging a fit needs. B was
-;; unreachable through the driver's env surface — `P0_ROOTS=1` floors it at
-;; the compile-time [[per-root]] — which is exactly why the small-witness
-;; arm is this parameter and not a flag.
+;; is per BOUNDARY, so a page of a few dozen boundaries leaves the averaging
+;; a fit needs. B was unreachable through the driver's env surface —
+;; `P0_ROOTS=1` floors it at the compile-time [[per-root]] — which is exactly
+;; why the small-witness arm is this parameter and not a flag.
+;;
+;; AND IT IS ONLY HALF THE REPAIR (rf2-2rtt6.140). Shrinking the page did not
+;; shrink the write: `:p0/write-all` rebuilds 300 cells whatever is mounted,
+;; a fixed F ~ 24.4 KB per write that at B=24 was 57% of the whole allowance
+;; before a boundary had been measured. `:p0/write-page` makes that term
+;; proportional to the page too, and `p0_run.cjs`'s certification is now read
+;; off the window's own legs rather than predicted from a constant.
 
 (defn- lad-arm
   "One rung of the ladder: `reads` DISTINCT subscription reads on each of
@@ -286,7 +289,7 @@
 
   `cells` is the measured unit and the driver owns it: the retention rows
   pass [[per-root]] and read the published page, the allocation row passes
-  the size its masking bound admits. Nothing else about the rung moves
+  the page its operator stated. Nothing else about the rung moves
   with it — the same substrates, the same key rule, the same DOM one
   `span.cell` at a time."
   [substrate cells reads q]
@@ -353,25 +356,33 @@
 ;; ---------------------------------------------------------------------------
 
 (defn prepare!
-  "Install the adapter `segment-id` names and stand the frame back up.
+  "Install the adapter `segment-id` names and stand the frame back up,
+  seeded at `grid-width` cells.
 
   Called by the driver BEFORE its baseline read, so the adapter swap's own
   residue is in the baseline and not in the arm's retained delta. Passing
   a segment that is already installed still re-seeds, so the two branches
-  cost the same."
-  [segment-id]
-  ;; The Hicasso runtime memoises `capture-frame` per frame id, and
-  ;; `enter-segment!` destroys and re-creates `:p0/frame` — a bundle
-  ;; captured before the swap is pinned to a dead incarnation. Resetting
-  ;; here rather than after an arm is deliberate: `prepare!` runs OUTSIDE
-  ;; every measured window and before the baseline read, so the reset's
-  ;; own residue lands in the baseline, and no arm's teardown is ever
-  ;; forced — which is what leaves the survival metric something to
-  ;; measure (rf2-2rtt6.34).
-  (hic-rt/reset-runtime!)
-  (let [segment (first (filter #(= segment-id (:id %)) arms/segments))]
-    (when segment (arms/enter-segment! segment)))
-  true)
+  cost the same.
+
+  `grid-width` defaults to [[per-root]] — the published 300 — so the
+  retention rows and the fan-out sweep, which pass nothing, seed the page
+  they always did. The allocation row states B, because its write rebuilds
+  the grid and a grid wider than the mounted page is machinery no boundary
+  reads (rf2-2rtt6.140)."
+  ([segment-id] (prepare! segment-id per-root))
+  ([segment-id grid-width]
+   ;; The Hicasso runtime memoises `capture-frame` per frame id, and
+   ;; `enter-segment!` destroys and re-creates `:p0/frame` — a bundle
+   ;; captured before the swap is pinned to a dead incarnation. Resetting
+   ;; here rather than after an arm is deliberate: `prepare!` runs OUTSIDE
+   ;; every measured window and before the baseline read, so the reset's
+   ;; own residue lands in the baseline, and no arm's teardown is ever
+   ;; forced — which is what leaves the survival metric something to
+   ;; measure (rf2-2rtt6.34).
+   (hic-rt/reset-runtime!)
+   (let [segment (first (filter #(= segment-id (:id %)) arms/segments))]
+     (when segment (arms/enter-segment! segment (long grid-width))))
+   true))
 
 ;; ---------------------------------------------------------------------------
 ;; Holding, and letting go
@@ -984,8 +995,8 @@
 ;; The written value, MONOTONE FOR THE LIFE OF THE PAGE rather than
 ;; restarting at 1 in every window.
 ;;
-;; It restarted, and the row read a constant. `:p0/write-all` writes
-;; `(vec (repeat cells-n v))`, so writing the value that is already there
+;; It restarted, and the row read a constant. A `:p0/write-*` event writes
+;; `(vec (repeat width v))`, so writing the value that is already there
 ;; produces an EQUAL app-db, no subscription changes, and React re-renders
 ;; nothing — while the read-back still passed, because the warm-up pass had
 ;; already put the expected text in the DOM. Every arm then reads the write
@@ -1044,10 +1055,13 @@
   leg boundary, and answer the raw samples.
 
   `kind` is `\"write\"` — a warm bulk re-render of the arm that is ALREADY
-  MOUNTED, through the same `:p0/write-all` event the bulk clock arms
-  drive — or `\"control\"` (a dropped `.slice` of predicted size) or
-  `\"idle\"` (nothing at all, which prices the sampler's own footprint as
-  a constant sitting inside every other figure).
+  MOUNTED, through the `:p0/write-page` event (rf2-2rtt6.140), which is
+  the same `dispatch-sync` through the same pipeline and signal graph as
+  the bulk clock arms' `:p0/write-all` and differs only in rebuilding the
+  grid at the mounted page's own width — or `\"control\"` (a dropped
+  `.slice` of predicted size) or `\"idle\"` (nothing at all, which prices
+  the sampler's own footprint as a constant sitting inside every other
+  figure).
 
   `drain` is `\"reagent\"` for Reagent's own documented synchronous render
   drain, and anything else for the empty `flushSync` a
@@ -1068,7 +1082,7 @@
       (aset buf (inc (* 2 i)) (mem))
       (cond
         write? (do (vswap! alloc-tick inc)
-                   (arms/write-all! @alloc-tick)
+                   (arms/write-page! @alloc-tick)
                    (if reagent?
                      (react-dom/flushSync (fn [] (r/flush)))
                      (react-dom/flushSync (fn [] nil))))
@@ -1097,7 +1111,9 @@
   decides when a reading is taken."
   []
   (set! (.-P0H js/window)
-        #js {:prepare        (fn [seg] (prepare! (when seg (keyword seg))))
+        #js {:prepare        (fn [seg grid-width]
+                               (prepare! (when seg (keyword seg))
+                                         (if (some? grid-width) (long grid-width) per-root)))
              :mount          (fn [arm k opts] (mount! arm k opts))
              :release        (fn [] (release!*) true)
              :control        (fn [n] (control! n))

--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -47,7 +47,9 @@ const {
   ladderStructuralFailures,
   allocSteps,
   allocMaskableWindows,
+  allocRefusedWindows,
   ALLOC_MASK_BUDGET_B,
+  ALLOC_LEG_TOLERANCE,
   ladderPlan,
   allocArmSizing,
   allocMaxWrites,
@@ -875,6 +877,140 @@ test('the window is DERIVED from the bound and the arm from the measured cost', 
   // The bound itself is still the untouched one, with no dial of its own.
   has(/const ALLOC_MASK_BUDGET_B = ALLOC_FALL_THRESHOLD_B \/ 2;/, 'unchanged by this arm');
   has(/const ALLOC_FALL_THRESHOLD_B = 600000;/, 'and so is the measured threshold under it');
+});
+
+// ===========================================================================
+// VALIDITY WITNESS V4 — THE PINNED PROBES (rf2-2rtt6.140, criterion 3)
+// ===========================================================================
+//
+// The merged-PR audit of #7682 wrote two executable probes and the old bound
+// ADMITTED both, at `headroom = 0`, with true allocations of 300 KB and
+// 600 KB. That is what retired the bound: it was not too loose, its premises
+// did not support it. `ALLOC_FALL_THRESHOLD_B` is an UPPER bound on where the
+// first collection runs where safety needs a LOWER one, and a masked leg's
+// true allocation is not bounded by the observed `maxStep`, which sees only
+// NET positive deltas.
+//
+// THE REPLACEMENT IS AN OBSERVATION, NOT ANOTHER MODEL. The legs of a window
+// are W repetitions of ONE work unit, so absent a collection they should be
+// alike. A leg materially BELOW its cohort is a leg something removed bytes
+// from, and nothing in the work unit removes bytes — the collector does. A
+// leg ABOVE its cohort is not evidence of a collection but is evidence that
+// the one-work-unit premise has failed in this window, so refusing is correct
+// rather than merely conservative.
+//
+// HERMETIC, exactly as the pins above: every window here is a synthetic
+// sample stream from `stream`, and NOTHING IN THIS FILE HAS EVER BEEN RUN
+// AGAINST A REAL PAGE.
+
+// The two audit probes, as the fixtures `stream` builds them. Each has its
+// offending leg at EXACTLY ZERO against a strictly positive cohort median,
+// which is what makes the refusal independent of the calibration.
+const PROBE_A = () => stream([60000, 60000, 60000, 60000, 60000], [0, 0, 0, 0, 60000]);
+const PROBE_B = () =>
+  stream([50000, 50000, 50000, 50000, 50000, 350000], [0, 0, 0, 0, 0, 350000]);
+
+test('V4 PROBE A — 300 KB of true allocation, admitted by the retired bound, is REFUSED', () => {
+  const s = allocSteps(PROBE_A());
+  // The old admission, reproduced AS FACT rather than described. These three
+  // are what the retired bound saw, and it let the window through on them.
+  assert.strictEqual(s.falls, 0, 'the sign test saw nothing — the fifth leg netted to zero');
+  assert.strictEqual(s.rise, 240000, 'and `rise` under-reads the true 300000 by the whole leg');
+  assert.strictEqual(s.maxStep, 60000);
+  // The new verdict, which names the leg.
+  assert.strictEqual(s.certified, false, 'the leg witness must refuse what the bound admitted');
+  assert.strictEqual(s.legMedian, 60000, 'four legs at 60000 and one at 0');
+  assert.deepStrictEqual(s.legs, [60000, 60000, 60000, 60000, 0]);
+  assert.strictEqual(s.refusals.length, 1, JSON.stringify(s.refusals));
+  assert.match(s.refusals[0], /leg 5 of 5/, 'the refusal must NAME the leg');
+  assert.match(s.refusals[0], /0 B against a cohort median of 60000 B/);
+});
+
+test('V4 PROBE B — 600 KB of true allocation, admitted by the retired bound, is REFUSED', () => {
+  const s = allocSteps(PROBE_B());
+  assert.strictEqual(s.falls, 0);
+  assert.strictEqual(s.rise, 250000, 'the sixth leg allocated 350000 and lost all of it');
+  assert.strictEqual(s.maxStep, 50000);
+  assert.strictEqual(s.certified, false);
+  assert.strictEqual(s.legMedian, 50000);
+  assert.deepStrictEqual(s.legs, [50000, 50000, 50000, 50000, 50000, 0]);
+  assert.strictEqual(s.refusals.length, 1, JSON.stringify(s.refusals));
+  assert.match(s.refusals[0], /leg 6 of 6/);
+});
+
+test('V4 — the net-growth masking case is refused on the LEG grounds', () => {
+  // The fixture this file has carried since rf2-n6w7o, re-pointed. It used to
+  // refuse for being over the budget; it now refuses because its third leg
+  // reads zero against a cohort of 200 KB, which is the observation rather
+  // than the arithmetic.
+  const s = allocSteps(stream([200000, 200000, 200000, 200000], [0, 0, 200000, 0]));
+  assert.strictEqual(s.falls, 0, 'the sign test is blind here — that IS the defect');
+  assert.strictEqual(s.rise, 600000, 'rise under-reads the true 800000 by the reclaimed 200000');
+  assert.strictEqual(s.certified, false);
+  assert.deepStrictEqual(s.legs, [200000, 200000, 0, 200000]);
+  assert.strictEqual(s.legMedian, 200000);
+  assert.match(s.refusals[0], /leg 3 of 4/);
+});
+
+test('V4 τ-INDEPENDENCE — both probes are refused for EVERY tolerance below 1', () => {
+  // The property that stops a later re-calibration silently re-admitting
+  // them. In both probes the offending leg reads exactly zero against a
+  // strictly positive median, so |0 − m| = m > τ·m for every τ < 1 — the
+  // refusal is a fact about the fixtures, not about the constant.
+  const taus = [0, 0.001, 0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.99, 0.999];
+  for (const tau of taus) {
+    for (const [name, probe] of [['A', PROBE_A], ['B', PROBE_B]]) {
+      const s = allocSteps(probe(), tau);
+      assert.strictEqual(s.certified, false, `probe ${name} must refuse at τ=${tau}`);
+    }
+    // And the sweep must not be vacuous: a clean cohort certifies at every
+    // one of the same tolerances, so what refuses the probes is the leg that
+    // deviates and not a gate that refuses everything.
+    assert.strictEqual(
+      allocSteps(stream([20000, 20000, 20000, 20000]), tau).certified,
+      true,
+      `a clean window must still certify at τ=${tau}`
+    );
+  }
+});
+
+test('V4 NOT VACUOUS — the clean small window and the idle window both certify', () => {
+  const clean = allocSteps(stream([20000, 20000, 20000, 20000]));
+  assert.strictEqual(clean.certified, true, 'four alike legs are one work unit repeated');
+  assert.deepStrictEqual(clean.refusals, []);
+  assert.strictEqual(clean.legMedian, 20000);
+  assert.strictEqual(clean.legWorstDeviation, 0);
+
+  // An idle window is homogeneous AT ZERO. `τ·0` is 0 and every leg deviates
+  // from the median by 0, which is not MORE than 0 — so it certifies, and it
+  // has to, because the idle control is one of the three the row takes.
+  const idle = allocSteps(stream([0, 0, 0]));
+  assert.strictEqual(idle.certified, true);
+  assert.strictEqual(idle.legMedian, 0);
+  assert.deepStrictEqual(idle.legs, [0, 0, 0]);
+  // A relative deviation from a zero median is not a number, and the field
+  // says so rather than reporting a fabricated 0 or an Infinity.
+  assert.strictEqual(idle.legWorstDeviation, null);
+});
+
+test('THE MANDATORY PAGE — an unstated P0_ALLOC_CELLS is refused BY NAME', () => {
+  // rf2-2rtt6.139 retired `ALLOC_B_PER_BOUNDARY_WRITE` as a sizing input and
+  // forbade substituting a replacement constant. With no sizing model there
+  // is no honest default page, so the page becomes MANDATORY — which also
+  // makes an accidental publication run impossible while criterion 5's
+  // measurement freeze is in force.
+  const arm = armUnderEnv({ P0_ALLOC_CELLS: '', P0_ALLOC_WRITES: '' });
+  assert.strictEqual(arm.admissible, false, 'an unstated page cannot be derived');
+  const page = arm.refusals.find((r) => r.includes('P0_ALLOC_CELLS'));
+  assert.ok(page, JSON.stringify(arm.refusals));
+  assert.match(page, /rf2-2rtt6\.139/, 'and it names what would make a default honest');
+  // A stated page derives an admissible arm, so the refusal is the missing
+  // page and not a preflight that refuses everything.
+  const stated = armUnderEnv({ P0_ALLOC_CELLS: '6', P0_ALLOC_WRITES: '' });
+  assert.strictEqual(stated.cells, 6);
+  assert.strictEqual(stated.boundaries, 24);
+  assert.deepStrictEqual(stated.refusals, []);
+  assert.ok(stated.admissible);
 });
 
 let failed = 0;

--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 'use strict';
 // THE LADDER'S STRUCTURAL WITNESS — what the counts must be, and at R=0
-// especially. rf2-xzg3b. AND THE ALLOCATION ROW'S MASKING WITNESS —
-// rf2-n6w7o, at the foot of this file.
+// especially. rf2-xzg3b. AND THE ALLOCATION ROW'S OBSERVED-COLLECTION
+// WITNESS — rf2-2rtt6.140, at the foot of this file, which retired
+// rf2-n6w7o's masking budget rather than widening it.
 //
 //     node core/test/re_frame/bench/p0_ladder_structural.test.cjs
 //
@@ -46,15 +47,12 @@ const DRIVER = path.join(__dirname, 'p0_run.cjs');
 const {
   ladderStructuralFailures,
   allocSteps,
-  allocMaskableWindows,
   allocRefusedWindows,
-  ALLOC_MASK_BUDGET_B,
   ALLOC_LEG_TOLERANCE,
+  ALLOC_FALL_THRESHOLD_B,
   ladderPlan,
   allocArmSizing,
-  allocMaxWrites,
   ALLOC_MIN_WRITES,
-  ALLOC_ARM,
 } = require('./p0_run.cjs');
 
 const tests = [];
@@ -286,7 +284,7 @@ test('the printed legend states the R=0 zero rather than the old flat `boundarie
 });
 
 // ===========================================================================
-// THE ALLOCATION ROW'S MASKING WITNESS — rf2-n6w7o
+// THE ALLOCATION ROW'S OBSERVED-COLLECTION WITNESS — rf2-2rtt6.140
 // ===========================================================================
 //
 // THE DEFECT THIS PINS. `allocSteps` detects a collection by the SIGN of an
@@ -298,9 +296,22 @@ test('the printed legend states the R=0 zero rather than the old flat `boundarie
 // allocation is the direction that manufactures HD-002's predicted
 // flat-at-zero, so it is the one direction this row may not fail in.
 //
-// Until rf2-n6w7o there was no allocation coverage in this file at all, and a
-// sample stream with a fully masked collection in it passed `allocSteps`
-// silently with nothing anywhere to notice. The pin below is that stream.
+// WHAT USED TO GUARD IT, AND WHY IT IS GONE. rf2-n6w7o charged
+// `rise + maxStep <= ALLOC_FALL_THRESHOLD_B / 2` and argued that a window
+// inside that budget could contain no collection at all. The merged-PR audit
+// of #7682 refuted both premises — the threshold is an UPPER bound on where
+// the first collection runs where safety needs a LOWER one, and `maxStep`
+// bounds nothing about a masked leg because it sees only NET positive deltas
+// — and wrote two executable probes the bound ADMITTED, at `headroom = 0`,
+// with true allocations of 300 KB and 600 KB. rf2-2rtt6.141 accepted both
+// objections and named this witness as the replacement; rf2-2rtt6.140's
+// criterion 4 sanctions the retirement explicitly and states that replacing
+// is not widening.
+//
+// WHAT REPLACED IT reads the window's own samples: the legs of a window are
+// W repetitions of ONE work unit, so REFUSE the window if any leg deviates
+// from the cohort MEDIAN by more than τ·m. The two probes are pinned at the
+// foot of this file, refused, and refused INDEPENDENTLY OF τ.
 //
 // HERMETIC BY CONSTRUCTION. Nothing here measures anything. `stream` builds
 // the sample buffer `p0-heap/alloc-window!` would have filled, from stated
@@ -332,57 +343,114 @@ test('THE DEFECT — a collection fully masked by net growth is REFUSED', () => 
   assert.strictEqual(s.falls, 0, 'the sign test is blind here — that IS the defect');
   assert.strictEqual(s.fall, 0, 'and nothing was netted, so `fall` is silent too');
   assert.strictEqual(s.rise, 600000, 'rise under-reads the true 800000 by the reclaimed 200000');
-  assert.ok(s.maskable, 'the masking witness must refuse it where the sign test cannot');
-  assert.ok(s.headroom < 0, `headroom must be negative, was ${s.headroom}`);
+  // The witness refuses it where the sign test cannot — and on the LEG, which
+  // is an observation about this window rather than an argument about its
+  // size. The third leg read 0 B against a cohort of 200 KB.
+  assert.strictEqual(s.certified, false, 'the leg witness must refuse it');
+  assert.deepStrictEqual(s.legs, [200000, 200000, 0, 200000]);
+  assert.strictEqual(s.legMedian, 200000);
+  assert.strictEqual(s.legWorstDeviation, -1, 'the masked leg is 100% below its cohort');
+  assert.strictEqual(s.refusals.length, 1, JSON.stringify(s.refusals));
+  assert.match(s.refusals[0], /leg 3 of 4/);
 });
 
-test('the budget is the measured fall threshold HALVED, and pinned at its value', () => {
-  // Pinned as a NUMBER on purpose. Widening this constant is the one repair
-  // that would retro-admit every window it was introduced to refuse, so a
-  // change to it has to come through this line and say so.
-  assert.strictEqual(ALLOC_MASK_BUDGET_B, 300000, 'ALLOC_FALL_THRESHOLD_B (600000) / 2');
+test('the tolerance is CALIBRATED, pinned, and has no dial on it', () => {
+  // The pin that replaces `the budget is the measured fall threshold HALVED`.
+  // τ decides whether a measurement may be PUBLISHED, and a gate with a dial
+  // on it is a gate that gets dialled — `ALLOC_MASK_BUDGET_B`'s reasoning,
+  // unchanged and inherited.
+  assert.strictEqual(typeof ALLOC_LEG_TOLERANCE, 'number');
+  assert.ok(ALLOC_LEG_TOLERANCE > 0, 'a tolerance of zero would refuse every real window');
+  assert.ok(
+    ALLOC_LEG_TOLERANCE < 1,
+    'at τ >= 1 a leg reading ZERO against a positive cohort is admitted, which is exactly ' +
+      'the shape both audit probes have'
+  );
+  // It is UNCALIBRATED until V3 runs, and the source has to say so rather
+  // than letting a placeholder pass for a measured constant.
+  has(/const ALLOC_LEG_TOLERANCE = /, 'named, and typed once');
+  has(/THIS VALUE IS AN UNCALIBRATED PLACEHOLDER/, 'and marked as not yet measured');
+  has(/VALIDITY WITNESS V3/, 'naming what would calibrate it');
+  lacks(
+    /P0_ALLOC_TOLERANCE|P0_ALLOC_TAU|P0_ALLOC_LEG|P0_ALLOC_MASK|P0_ALLOC_HEADROOM|P0_ALLOC_BUDGET/,
+    'a gate with an env dial on it is a gate that gets dialled off'
+  );
+  // And the driver reads the module constant at every measurement site: the
+  // `tolerance` parameter exists for the τ sweep below and for nothing else.
+  has(/const s = allocSteps\(w\.samples\);/, 'the control windows take the shipped τ');
+  has(/const s = allocSteps\(win\.samples\);/, 'and so do the arm windows');
+});
+
+test('the retired masking budget is GONE, not widened', () => {
+  // rf2-2rtt6.140 criterion 4, as a fact about the source rather than a
+  // sentence in a brief. Retaining the bound belt-and-braces was considered
+  // and rejected on arithmetic: at the composed operating point a window is
+  // ~630 KB of rise+maxStep, so a retained bound would refuse every window
+  // the witness certifies and the package would deliver nothing.
+  lacks(/const ALLOC_MASK_BUDGET_B/, 'the budget constant is deleted');
+  lacks(/const ALLOC_B_PER_BOUNDARY_WRITE/, 'and the sizing constant with it');
+  lacks(/function allocMaxWrites/, 'and the inversion that only existed to serve it');
+  // The measured threshold STAYS, at its measured value, and gates nothing.
+  has(/const ALLOC_FALL_THRESHOLD_B = 600000;/, 'not loosened — recorded');
+  assert.strictEqual(ALLOC_FALL_THRESHOLD_B, 600000);
+  has(/RECORDED, gates nothing/, 'and the summary says which it is');
 });
 
 test('the gate is not vacuous — a small clean window passes it', () => {
-  // Four writes of 20 KB. 100 KB of rise-plus-largest-step against a 300 KB
-  // budget: nowhere near the threshold at which a collection can fire, which
-  // is the shape rf2-2rtt6.138's small-witness arm has to have.
+  // Four writes of 20 KB. Four alike legs are four repetitions of one work
+  // unit, which is what the witness is looking for.
   const s = allocSteps(stream([20000, 20000, 20000, 20000]));
   assert.strictEqual(s.falls, 0);
   assert.strictEqual(s.rise, 80000);
   assert.strictEqual(s.maxStep, 20000);
-  assert.strictEqual(s.headroom, ALLOC_MASK_BUDGET_B - 100000);
-  assert.strictEqual(s.maskable, false);
+  assert.strictEqual(s.certified, true);
+  assert.deepStrictEqual(s.refusals, []);
+  assert.strictEqual(s.legMedian, 20000);
+  assert.strictEqual(s.legWorstDeviation, 0);
 });
 
-test('the boundary is exact — at budget passes, one byte over refuses', () => {
-  const at = allocSteps(stream([50000, 50000, 50000, 50000, 50000]));
-  assert.strictEqual(at.rise + at.maxStep, ALLOC_MASK_BUDGET_B);
-  assert.strictEqual(at.headroom, 0);
-  assert.strictEqual(at.maskable, false, 'exactly at budget is still inside it');
-  const over = allocSteps(stream([50000, 50000, 50000, 50000, 50000, 1]));
-  assert.strictEqual(over.rise + over.maxStep, ALLOC_MASK_BUDGET_B + 1);
-  assert.strictEqual(over.headroom, -1);
-  assert.ok(over.maskable);
+test('the boundary is exact — at τ passes, one byte past refuses', () => {
+  // The replacement for `at budget passes, one byte over refuses`. Five legs
+  // whose median is 20000, with the first sitting exactly τ·m high: admitted.
+  // One byte further: refused. Both directions, because the rule is two-sided
+  // and a one-sided check would have adjudicated half of it.
+  const m = 20000;
+  const edge = Math.round(ALLOC_LEG_TOLERANCE * m);
+  for (const sign of [1, -1]) {
+    const at = allocSteps(stream([m + sign * edge, m, m, m, m]));
+    assert.strictEqual(at.legMedian, m, `sign ${sign}: the median is the cohort, not the outlier`);
+    assert.strictEqual(at.certified, true, `sign ${sign}: exactly at τ is inside it`);
+    const past = allocSteps(stream([m + sign * (edge + 1), m, m, m, m]));
+    assert.strictEqual(past.legMedian, m);
+    assert.strictEqual(past.certified, false, `sign ${sign}: one byte past τ is not`);
+    assert.strictEqual(past.refusals.length, 1);
+    assert.match(past.refusals[0], /leg 1 of 5/);
+  }
 });
 
-test('NET GROWTH CANNOT DEFEAT IT — masking only moves a window toward refusal', () => {
-  // The same four legs, once with the third leg's collection masked and once
-  // without it. Masking REMOVES bytes from `rise`, so the masked window is
-  // the one with MORE headroom — and it is still refused, because the
-  // allocation that had to happen before the collector could fire is counted
-  // in full, in the legs before it, where no masking is possible.
+test('A MASKED LEG READS BELOW ITS COHORT, and that is what refuses', () => {
+  // The replacement for `NET GROWTH CANNOT DEFEAT IT`, which argued about the
+  // budget. The same four legs, once with the third leg's collection masked
+  // and once without. Masking REMOVES bytes from `rise`, so the masked window
+  // is the one that looks SMALLER — and the retired bound could only ever be
+  // flattered by that. The leg witness reads the opposite way round: removing
+  // bytes from one leg is precisely what makes it unlike its cohort.
   const legs = [200000, 200000, 200000, 200000];
   const masked = allocSteps(stream(legs, [0, 0, 200000, 0]));
   const clean = allocSteps(stream(legs));
   assert.ok(masked.rise < clean.rise, 'masking removes bytes from the rising sum');
-  assert.ok(masked.headroom > clean.headroom, 'so it can only flatter the headroom');
-  assert.ok(masked.maskable && clean.maskable, 'and both are over budget regardless');
+  assert.strictEqual(clean.certified, true, 'the unmasked window is four alike legs');
+  assert.strictEqual(masked.certified, false, 'and masking is what refuses the other');
+  assert.ok(
+    masked.legWorstDeviation < 0,
+    'the offending leg is BELOW its cohort, never above — that is the signature'
+  );
 });
 
 test('THE FALLS GATE IS UNTOUCHED — a visible collection still counts as one', () => {
-  // The half that works. rf2-n6w7o is discharged by ADDING a refusal, never
-  // by widening this one: every window it admits today it must still admit.
+  // The half that works. rf2-n6w7o was discharged by ADDING a refusal and
+  // rf2-2rtt6.140 replaces only what rf2-n6w7o added: every window this gate
+  // refuses today it refuses after.
   const s = allocSteps(stream([20000, 20000], [0, 40000]));
   assert.strictEqual(s.falls, 1, 'a net-negative leg is still a falling step');
   assert.strictEqual(s.fall, 20000, 'the second leg allocated 20000 and lost 40000');
@@ -391,18 +459,45 @@ test('THE FALLS GATE IS UNTOUCHED — a visible collection still counts as one',
 });
 
 test('`maxStep` is the largest single rising step, not the mean or the last', () => {
+  // It survives as a reported DIAGNOSTIC. Nothing certifies on it any more —
+  // it was the term the audit showed bounds nothing about a masked leg — but
+  // it is still the right answer to the question it asks.
   const s = allocSteps(stream([1000, 7000, 3000]));
   assert.strictEqual(s.rise, 11000);
   assert.strictEqual(s.maxStep, 7000);
   assert.strictEqual(s.endpoints, 11000);
 });
 
-test('an idle window is neither maskable nor a fall', () => {
+test('an idle window is homogeneous at zero, and certifies', () => {
+  // The idle control prices the sampler's own footprint and is one of the
+  // three windows every round takes, so a witness that refused it would refuse
+  // the row's own instrument. `τ·0` is 0 and no leg deviates from 0 by more
+  // than 0.
   const s = allocSteps(stream([0, 0, 0]));
   assert.strictEqual(s.rise, 0);
   assert.strictEqual(s.falls, 0);
   assert.strictEqual(s.maxStep, 0);
-  assert.strictEqual(s.maskable, false);
+  assert.strictEqual(s.certified, true);
+  assert.strictEqual(s.legMedian, 0);
+  assert.deepStrictEqual(s.legs, [0, 0, 0]);
+  // But it is not a free pass: a window whose legs disagree is refused at a
+  // zero median too, which is the case a ratio test would have divided by
+  // zero on.
+  const lumpy = allocSteps(stream([0, 100, 0]));
+  assert.strictEqual(lumpy.legMedian, 0);
+  assert.strictEqual(lumpy.certified, false, 'one leg doing work and two doing none is not one unit');
+});
+
+test('LEGS AND GAPS are read apart, and only the legs are adjudicated', () => {
+  // `[s0, pre0, post0, pre1, post1, ...]`: the legs are `post - pre` and the
+  // gaps are `pre - post`, where nothing happens but a loop increment and two
+  // array stores. `rise` walks BOTH, as it always did. The witness reads only
+  // the legs — and nothing allocates in a gap, so a collection there cannot be
+  // masked at all: it lands as a negative step and the falls gate takes it.
+  const s = allocSteps(stream([1000, 2000, 3000]));
+  assert.deepStrictEqual(s.legs, [1000, 2000, 3000], 'one leg per iteration');
+  assert.deepStrictEqual(s.gaps, [0, 0, 0], 'and nothing happens between them');
+  assert.strictEqual(s.rise, 6000, 'rise is unchanged by the split');
 });
 
 // --- the row-level witness the driver actually exits on --------------------
@@ -424,27 +519,27 @@ const MASKED = stream([200000, 200000, 200000, 200000], [0, 0, 200000, 0]);
 
 test('a row of small clean windows is not a failure', () => {
   assert.deepStrictEqual(
-    allocMaskableWindows(allocRowWith({ 'reagent-subs|lad/hicasso#R7': SMALL })),
+    allocRefusedWindows(allocRowWith({ 'reagent-subs|lad/hicasso#R7': SMALL })),
     []
   );
 });
 
 test('a row with no rounds at all is not a failure', () => {
-  assert.deepStrictEqual(allocMaskableWindows({ perRound: [] }), []);
+  assert.deepStrictEqual(allocRefusedWindows({ perRound: [] }), []);
 });
 
-test('every over-budget window is named, on every round, with its overshoot', () => {
-  const fails = allocMaskableWindows(
+test('every REFUSED window is named, on every round, with its reason', () => {
+  const fails = allocRefusedWindows(
     allocRowWith({
       'reagent-subs|lad/hicasso#R7': MASKED,
       'reagent-subs|lad/reagent#R7': SMALL,
     })
   );
-  assert.strictEqual(fails.length, 2, 'one per round, and only the over-budget arm');
+  assert.strictEqual(fails.length, 2, 'one per round, and only the refused arm');
   for (const f of fails) {
     assert.match(f, /lad\/hicasso#R7/);
-    assert.match(f, /rise 600000 B \+ largest step 200000 B/);
-    assert.match(f, /500000 B over the 300000 B masking budget/);
+    assert.match(f, /leg 3 of 4 read 0 B against a cohort median of 200000 B/);
+    assert.match(f, /leg BELOW its cohort/, 'and it says what a low leg means');
   }
   assert.ok(fails.some((f) => f.startsWith('round 1 ')));
   assert.ok(fails.some((f) => f.startsWith('round 2 ')));
@@ -452,194 +547,41 @@ test('every over-budget window is named, on every round, with its overshoot', ()
 
 // --- the wiring, so this pin cannot drift off the thing that exits ---------
 
-test('the driver exits on THIS function and does not re-derive the budget', () => {
-  has(/const maskable = allocMaskableWindows\(out\.alloc\);/, 'the alloc gate calls it');
-  has(/if \(maskable\.length > 0\) \{/, 'and its result is what pushes a failure');
+test('the driver exits on THIS function and does not re-derive the verdict', () => {
+  has(/const refusedWindows = allocRefusedWindows\(out\.alloc\);/, 'the alloc gate calls it');
+  has(/if \(refusedWindows\.length > 0\) \{/, 'and its result is what pushes a failure');
+  has(/DO NOT WIDEN THE TOLERANCE/, 'naming the repair, not the dial');
   has(
-    /module\.exports = \{\s*ladderStructuralFailures,\s*allocSteps,\s*allocMaskableWindows,\s*ALLOC_MASK_BUDGET_B,\s*ladderPlan,\s*allocArmSizing,\s*allocMaxWrites,\s*ALLOC_MIN_WRITES,\s*ALLOC_ARM,\s*\};/,
+    /module\.exports = \{\s*ladderStructuralFailures,\s*allocSteps,\s*allocRefusedWindows,\s*ALLOC_LEG_TOLERANCE,\s*ALLOC_FALL_THRESHOLD_B,\s*ladderPlan,\s*allocArmSizing,\s*ALLOC_MIN_WRITES,\s*ALLOC_ARM,\s*\};/,
     'so this file can drive it'
-  );
-});
-
-test('the budget is DERIVED from the measured threshold and has no dial on it', () => {
-  has(
-    /const ALLOC_MASK_BUDGET_B = ALLOC_FALL_THRESHOLD_B \/ 2;/,
-    'the budget must follow the measured threshold, not be typed beside it'
-  );
-  lacks(
-    /P0_ALLOC_MASK|P0_ALLOC_HEADROOM|P0_ALLOC_BUDGET/,
-    'a gate with an env dial on it is a gate that gets dialled off'
   );
   has(/if \(out\.alloc\.fallsInMeasuredWindows > 0\) \{/, 'and the falling-step gate still exits');
 });
 
 // ===========================================================================
-// THE SMALL-WITNESS ARM — rf2-2rtt6.138
+// THE PAGE IS STATED, AND THE AVERAGING FLOOR IS ENFORCED — rf2-2rtt6.139/.142
 // ===========================================================================
 //
-// WHAT THIS PINS, AND WHY IT IS PINNED HERE. The allocation row's published
-// witness is outside its own instrument's range: one warm write of 1,200
-// boundaries allocates 1.2-1.7 MB against a ~600 KB fall threshold, and the
-// masking bound above refuses a window that size rather than publishing what
-// it reads. The repair is a smaller PAGE — the row's quantity is per
-// BOUNDARY, so a few dozen of them put a many-write window under the
-// threshold with the averaging a fit needs still in it.
+// WHAT THE PREFLIGHT IS FOR, now that it predicts nothing. rf2-2rtt6.139
+// retired `ALLOC_B_PER_BOUNDARY_WRITE = 1655` as a sizing input — it was read
+// off the 2026-08-07 run, which itself refused at 36 falling steps across 44
+// windows, and that run's own refusal text declares every figure from such a
+// window an under-estimate — and ruled that NO REPLACEMENT CONSTANT MAY BE
+// SUBSTITUTED. Its interim posture: the preflight refuses only on grounds it
+// can defend without a sizing model. Two survive.
 //
-// A SIZE IS A CLAIM AND HAS TO BE CHECKABLE. `allocArmSizing` is the
-// arithmetic that chose the page, as a pure function of the bound, so the
-// claim "this arm fits" is a thing this file can adjudicate on every PR
-// rather than something the next opt-in run discovers. `--only alloc` needs
-// a release build and a headless Chromium and is in no gate; an arm that
-// drifted out of range would otherwise be found by a measurement, which is
-// the expensive way to find it and the way rf2-2rtt6.76 already found it
-// once.
+//   THE PAGE IS MANDATORY. With no sizing model there is no honest default,
+//   so an unstated `P0_ALLOC_CELLS` is refused by name. It has the additional
+//   virtue of making an accidental publication run impossible while
+//   rf2-2rtt6.140 criterion 5's measurement freeze is in force.
 //
-// NOTHING HERE MEASURES ANYTHING, and the arm these tests describe HAS NEVER
-// BEEN RUN. Every window below is a synthetic sample stream from `stream`
-// above, built from the sizing's own prediction — which is exactly what
-// makes the check hermetic and exactly what stops it being evidence about
-// the substrate.
-
-// The window a page of `boundaries` produces at `writes`, as `alloc-window!`
-// would have sampled it if every leg allocated the predicted `B.c`. Built
-// from the SIZING, so the two cannot disagree: if the prediction is wrong
-// about the bound, `allocSteps` says so on the sizing's own numbers.
-const predictedStream = (sizing) =>
-  stream(Array.from({ length: sizing.writes }, () => sizing.predictedMaxStep));
-
-test('THE BOUND IS THE SIZING — (W+1).B.c is what the arithmetic computes', () => {
-  const s = allocArmSizing({ writes: 6, roots: 4, cells: 6, bytesPerBoundaryWrite: 1000 });
-  assert.strictEqual(s.boundaries, 24, 'B is roots x cells');
-  assert.strictEqual(s.predictedMaxStep, 24000, 'the largest single step is ONE write, B.c');
-  assert.strictEqual(s.predictedRise, 144000, 'and rise is W of them');
-  assert.strictEqual(s.predictedWindowB, 168000, '(W+1).B.c — the bound\'s left-hand side');
-  assert.strictEqual(s.headroom, ALLOC_MASK_BUDGET_B - 168000);
-  assert.ok(s.admissible);
-});
-
-test('THE SHIPPED ARM is a few dozen boundaries and is inside the bound', () => {
-  // The numbers the driver ships with. A `P0_ALLOC_CELLS` / `P0_ALLOC_WRITES`
-  // / `P0_ROOTS` in the environment moves them, and this failing under one is
-  // a TRUE signal — the run's arm would not be the shipped arm.
-  assert.strictEqual(ALLOC_ARM.cells, 6, 'cells per root');
-  assert.strictEqual(ALLOC_ARM.roots, 4, 'P0_ROOTS');
-  assert.strictEqual(ALLOC_ARM.boundaries, 24, 'a few dozen boundaries, as the bead asked');
-  assert.strictEqual(ALLOC_ARM.writes, 6, 'and a MANY-write window, which is the averaging');
-  assert.strictEqual(ALLOC_ARM.bytesPerBoundaryWrite, 1655, 'the top of the measured range');
-  assert.strictEqual(ALLOC_ARM.predictedWindowB, 278040, '(6+1) x 24 x 1655');
-  assert.strictEqual(ALLOC_ARM.headroom, 21960, 'under the 300000 B budget');
-  assert.ok(ALLOC_ARM.admissible);
-});
-
-test('the shipped arm takes EVERY write the bound admits at its page', () => {
-  // A window smaller than the bound allows is averaging thrown away, and the
-  // whole reason the page shrank was to buy that averaging back.
-  assert.strictEqual(ALLOC_ARM.writes, allocMaxWrites(ALLOC_ARM.boundaries));
-});
-
-test('THE PUBLISHED WITNESS is refused by the same arithmetic — the reason the arm exists', () => {
-  const published = allocArmSizing({ writes: ALLOC_ARM.writes, roots: 4, cells: 300 });
-  assert.strictEqual(published.boundaries, 1200);
-  assert.strictEqual(published.predictedWindowB, 7 * 1200 * 1655);
-  assert.ok(!published.admissible, '1,200 boundaries cannot be certified at any useful window');
-  assert.ok(published.headroom < 0);
-  assert.strictEqual(allocMaxWrites(1200), -1, 'not even a one-write window fits at that page');
-});
-
-test('the predicted window PASSES the real gate, and the published one does not', () => {
-  // The sizing and `allocSteps` are two expressions of one bound, so they are
-  // driven against each other rather than each asserted alone.
-  const arm = allocSteps(predictedStream(ALLOC_ARM));
-  assert.strictEqual(arm.rise, ALLOC_ARM.predictedRise);
-  assert.strictEqual(arm.maxStep, ALLOC_ARM.predictedMaxStep);
-  assert.strictEqual(arm.headroom, ALLOC_ARM.headroom);
-  assert.strictEqual(arm.maskable, false, 'the arm the driver ships is inside the budget');
-  assert.strictEqual(arm.falls, 0);
-
-  const published = allocArmSizing({ writes: ALLOC_ARM.writes, roots: 4, cells: 300 });
-  const big = allocSteps(predictedStream(published));
-  assert.strictEqual(big.headroom, published.headroom);
-  assert.ok(big.maskable, 'and the 1,200-boundary page is not');
-});
-
-test('a MIS-SIZED arm is refused — one boundary over the bound is over it', () => {
-  // `maxBoundaries` is the largest page the window admits, so the page one
-  // root wider than it must refuse. A sizing rule that named a limit it did
-  // not enforce would have adjudicated nothing.
-  const fits = allocArmSizing({ writes: 6, roots: 1, cells: ALLOC_ARM.maxBoundaries });
-  assert.strictEqual(fits.boundaries, 25);
-  assert.ok(fits.admissible, 'exactly at the limit is inside it');
-  const over = allocArmSizing({ writes: 6, roots: 1, cells: ALLOC_ARM.maxBoundaries + 1 });
-  assert.ok(!over.admissible, 'and one boundary more is not');
-  assert.ok(allocSteps(predictedStream(over)).maskable, 'the real gate agrees');
-});
-
-test('`allocMaxWrites` inverts the BOUND exactly — one write more is over budget', () => {
-  // Driven on `headroom`, which is the bound's own term, and not on
-  // `admissible`, which is the whole preflight verdict: at 60 boundaries the
-  // bound admits only 2 writes, and the averaging floor refuses that page
-  // whatever the budget thinks of it (rf2-2rtt6.142, below).
-  for (const boundaries of [4, 12, 24, 25, 60]) {
-    const w = allocMaxWrites(boundaries);
-    assert.ok(w >= 1, `${boundaries} boundaries must admit a window at all`);
-    assert.ok(
-      allocArmSizing({ writes: w, roots: 1, cells: boundaries }).headroom >= 0,
-      `${boundaries} boundaries at ${w} writes must fit the budget`
-    );
-    assert.ok(
-      allocArmSizing({ writes: w + 1, roots: 1, cells: boundaries }).headroom < 0,
-      `${boundaries} boundaries at ${w + 1} writes must not`
-    );
-  }
-});
-
-test('a window with no work in it, and a page with no boundaries, are NOT admissible', () => {
-  // Both sail under the budget on zero bytes, and neither has a per-boundary
-  // quantity to publish. A bound that admitted them would be admitting
-  // nothing measured at all.
-  assert.ok(!allocArmSizing({ writes: 0, roots: 4, cells: 6 }).admissible);
-  assert.ok(!allocArmSizing({ writes: 6, roots: 4, cells: 0 }).admissible);
-  assert.ok(!allocArmSizing({ writes: 0, roots: 0, cells: 0 }).admissible);
-});
-
-test('the sizing cannot buy headroom by shrinking the WINDOW alone', () => {
-  // The direction the bead ruled out: the 300-boundary one-write config whose
-  // fall count was zero across 88 windows is still refused by the bound, so
-  // it was never certified. Shrinking the unit is what works.
-  const oneWrite = allocArmSizing({ writes: 1, roots: 1, cells: 300 });
-  assert.ok(!oneWrite.admissible, 'B=300 at one write is still over budget');
-  assert.ok(oneWrite.predictedWindowB > ALLOC_MASK_BUDGET_B);
-  const smallUnit = allocArmSizing({ writes: 6, roots: 4, cells: 6 });
-  assert.ok(smallUnit.admissible, 'and a smaller UNIT carries six writes of averaging');
-});
-
-// ===========================================================================
-// THE AVERAGING FLOOR IS ENFORCED, NOT MERELY DERIVED FROM — rf2-2rtt6.142
-// ===========================================================================
+//   THE AVERAGING FLOOR STAYS (rf2-2rtt6.142). It is not a budget question:
+//   a one-write window has no averaging in it whatever certifies the window,
+//   and at one write per window all four ladder fits came back under the 0.98
+//   r² floor — 0.75 / 0.28 / 0.94 / 0.31.
 //
-// THE DEFECT THIS PINS. `ALLOC_MIN_WRITES` sized the default page and then
-// adjudicated nothing: the preflight's verdict was `writes >= 1 && boundaries
-// >= 1 && headroom >= 0`, so every window from one write upwards was licensed
-// however little averaging was left in it. Two routes reached that state
-// through the shipped env surface, and the merged-PR audit of #7688 derived
-// both without launching a browser:
-//
-//   P0_ROOTS=50          the DEFAULT derivation, which floors `cells` at 1 and
-//                        lands on 50 boundaries — a page that admits 2 writes
-//   P0_ALLOC_WRITES=1    the shipped 24-boundary page, window set by hand
-//
-// Both are far under the masking budget, which is precisely why the bound
-// could not catch them: the budget is an upper limit on a window's SIZE and
-// has nothing to say about how few writes are averaged inside it.
-//
-// WHY THE FLOOR EXISTS, so it is not weakened by accident. A one-write window
-// has no averaging in it, and at one write per window all four ladder fits
-// came back under the 0.98 r2 floor — 0.75 / 0.28 / 0.94 / 0.31. The row
-// already assumes the averaging; this is the preflight being made to enforce
-// what the row assumes.
-//
-// NOTHING HERE MEASURES ANYTHING. The two env routes are re-derived in a
-// child `node` that requires the driver and prints `ALLOC_ARM` — the module
+// NOTHING HERE MEASURES ANYTHING. The env routes are re-derived in a child
+// `node` that requires the driver and prints `ALLOC_ARM` — the module
 // constants are read at require time, so an env route can only be pinned from
 // outside the process. No build, no browser, no page.
 
@@ -657,130 +599,138 @@ function armUnderEnv(env) {
   return JSON.parse(r.stdout);
 }
 
-test('ROUTE 1 — the large-root DEFAULT that cannot fit six writes is refused', () => {
-  // `P0_ROOTS=50` needs no other flag: the `ALLOC_CELLS` default floors at one
-  // cell per root, so the page it derives is 50 boundaries and the window that
-  // page admits is 2 — below the floor, and inside the budget, which is how it
-  // reached a publication path at all.
+test('ROUTE 1 — the large-root DEFAULT is gone, and an unstated page refuses', () => {
+  // `P0_ROOTS=50` used to derive a 50-boundary page carrying a two-write
+  // window — below the floor, inside the budget, and therefore on a
+  // publication path. There is no derivation left to do it: the page is
+  // stated or the run refuses.
   const arm = armUnderEnv({ P0_ROOTS: '50', P0_ALLOC_CELLS: '', P0_ALLOC_WRITES: '' });
-  assert.strictEqual(arm.cells, 1, 'the default floors at one cell per root');
-  assert.strictEqual(arm.boundaries, 50);
-  assert.strictEqual(arm.writes, 2, 'and 50 boundaries admit only a two-write window');
-  assert.ok(arm.headroom >= 0, 'the masking bound is content — it never saw this');
-  assert.ok(!arm.admissible, 'the averaging floor is what refuses it');
+  assert.strictEqual(arm.cells, null, 'no default is derived from the retired constant');
+  assert.strictEqual(arm.boundaries, null, 'so there is no page to report');
+  assert.ok(!arm.admissible);
   assert.ok(
-    arm.refusals.some((r) => r.includes('averaging floor')),
-    `the refusal must name the floor: ${JSON.stringify(arm.refusals)}`
+    arm.refusals.some((r) => r.includes('STATE P0_ALLOC_CELLS')),
+    `the refusal must name the page: ${JSON.stringify(arm.refusals)}`
   );
+  // And the window is the floor, not something inverted out of a bound that
+  // no longer exists.
+  assert.strictEqual(arm.writes, ALLOC_MIN_WRITES);
 });
 
-test('ROUTE 2 — an explicit one-write window on the shipped page is refused', () => {
-  const arm = armUnderEnv({ P0_ALLOC_WRITES: '1' });
-  assert.strictEqual(arm.boundaries, 24, 'the shipped page, unchanged');
+test('ROUTE 2 — an explicit one-write window on a stated page is refused', () => {
+  // rf2-2rtt6.142's pin, which must stay green. The floor is enforced against
+  // `ALLOC_MIN_WRITES` and never against the literal 6, so a ruling that moves
+  // the floor moves this with it.
+  const arm = armUnderEnv({ P0_ALLOC_CELLS: '6', P0_ALLOC_WRITES: '1' });
+  assert.strictEqual(arm.boundaries, 24, 'a stated page, unchanged');
   assert.strictEqual(arm.writes, 1);
-  assert.ok(arm.headroom >= 0, 'and far under the budget, which is why it got through');
   assert.ok(!arm.admissible);
   const floor = arm.refusals.find((r) => r.includes('averaging floor'));
   assert.ok(floor, JSON.stringify(arm.refusals));
-  // The page here is fine — it carries six writes — so the WINDOW is the knob
-  // and the refusal must say so rather than send the operator at the page.
   assert.match(floor, /RAISE P0_ALLOC_WRITES to at least 6/);
-  assert.doesNotMatch(floor, /SHRINK THE PAGE/);
 });
 
-test('THE CONTROL — the shipped six-write arm is still admitted, so this is not vacuous', () => {
-  // A gate that refused everything would pass the two cases above and have
-  // adjudicated nothing. The arm the driver actually ships must go through.
-  const arm = armUnderEnv({});
+test('THE CONTROL — a stated page at the floor is admitted, so this is not vacuous', () => {
+  // A gate that refused everything would pass both cases above and have
+  // adjudicated nothing.
+  const arm = armUnderEnv({ P0_ALLOC_CELLS: '6', P0_ALLOC_WRITES: '' });
+  assert.strictEqual(arm.cells, 6);
   assert.strictEqual(arm.boundaries, 24);
-  assert.strictEqual(arm.writes, ALLOC_MIN_WRITES, 'exactly at the floor');
+  assert.strictEqual(arm.writes, ALLOC_MIN_WRITES, 'the window defaults to the floor');
   assert.deepStrictEqual(arm.refusals, []);
   assert.ok(arm.admissible);
 });
 
-test('the refusal names SHRINKING THE PAGE and never shrinking the window', () => {
-  // The one direction that must not be advised. A below-floor arm whose page
-  // admits fewer than six writes has no window repair at all: telling the
-  // operator "this page admits at most 2 writes" is telling them to configure
-  // the very shape being refused.
-  const arm = armUnderEnv({ P0_ROOTS: '50', P0_ALLOC_CELLS: '', P0_ALLOC_WRITES: '' });
+test('the refusal names THE WINDOW, and never a page it cannot size', () => {
+  // AMENDED from `the refusal names SHRINKING THE PAGE and never shrinking the
+  // window`. That message BRANCHED on whether the page could carry six writes,
+  // and the branch was computed from the budget; with the budget retired its
+  // trigger no longer exists and the refusal collapses to one arm.
+  //
+  // NOT A REGRESSION, and the property rf2-2rtt6.142's mayor adjudication
+  // endorsed is what has to survive: never advise the operator to configure
+  // the very shape being refused. It survives because the collapsed message
+  // names NO PAGE AT ALL — with no page-size model there is nothing to name.
+  const arm = armUnderEnv({ P0_ALLOC_CELLS: '6', P0_ALLOC_WRITES: '1' });
   const floor = arm.refusals.find((r) => r.includes('averaging floor'));
-  assert.match(floor, /SHRINK THE PAGE/);
-  assert.match(floor, /P0_ROOTS \/ P0_ALLOC_CELLS/);
-  assert.match(floor, /at most 25 boundaries/, 'the largest page that carries the floor');
-  assert.doesNotMatch(
-    floor,
-    /P0_ALLOC_WRITES/,
-    'a page that cannot carry the floor must not have its window named at all'
-  );
+  assert.match(floor, /RAISE P0_ALLOC_WRITES/, 'the window is the knob it names');
+  assert.doesNotMatch(floor, /SHRINK THE PAGE/, 'and it may not name a page it cannot size');
+  assert.doesNotMatch(floor, /boundaries/, 'nor any boundary count');
+  assert.doesNotMatch(floor, /masking budget/, 'the budget is retired and may not be cited');
 });
 
 test('the floor follows ALLOC_MIN_WRITES rather than a number typed beside it', () => {
   // If a later ruling moves the averaging floor, the preflight moves with it.
   assert.ok(ALLOC_MIN_WRITES >= 1, 'a floor below one write would not be a floor');
-  const page = { roots: 1, cells: 4 }; // 4 boundaries: admits 44 writes, budget-wise
+  const page = { roots: 1, cells: 4 };
   for (let w = 0; w < ALLOC_MIN_WRITES; w++) {
     const s = allocArmSizing({ writes: w, ...page });
-    assert.ok(s.headroom >= 0, `w=${w} is inside the budget`);
     assert.ok(!s.admissible, `w=${w} is below the floor and must refuse`);
+    assert.ok(s.refusals.some((r) => r.includes('averaging floor')));
   }
   const atFloor = allocArmSizing({ writes: ALLOC_MIN_WRITES, ...page });
   assert.ok(atFloor.admissible, 'and exactly at the floor is admitted');
 });
 
-test('THE CHANGE ONLY EVER REFUSES MORE — admissible is a subset of the old bound', () => {
-  // The old predicate, verbatim: `writes >= 1 && boundaries >= 1 && headroom
-  // >= 0`. Enforcing the floor may only turn an admitted shape into a refused
-  // one, never the reverse, and that is checked exhaustively over the grid
-  // rather than argued.
+test('a refused arm says WHY, one reason per thing wrong with it', () => {
+  // Both wrong at once: no page stated AND one write. An operator who fixed
+  // only the one they were told about would come back to the other, so the two
+  // checks are independent rather than nested.
+  const both = allocArmSizing({ writes: 1, roots: 4, cells: null });
+  assert.strictEqual(both.refusals.length, 2, JSON.stringify(both.refusals));
+  assert.ok(both.refusals.some((r) => r.includes('STATE P0_ALLOC_CELLS')));
+  assert.ok(both.refusals.some((r) => r.includes('averaging floor')));
+  // A page STATED as zero is a different fault from a page not stated, and
+  // they say so differently: one is a page with nothing on it, the other is a
+  // missing configuration.
+  const empty = allocArmSizing({ writes: 6, roots: 4, cells: 0 });
+  assert.strictEqual(empty.refusals.length, 1);
+  assert.match(empty.refusals[0], /no per-boundary quantity/);
+  assert.doesNotMatch(empty.refusals[0], /STATE P0_ALLOC_CELLS/);
+});
+
+test('a window with no work in it, and a page with no boundaries, are NOT admissible', () => {
+  // Neither has a per-boundary quantity to publish, and a preflight that
+  // admitted them would be admitting nothing measured at all.
+  assert.ok(!allocArmSizing({ writes: 0, roots: 4, cells: 6 }).admissible);
+  assert.ok(!allocArmSizing({ writes: 6, roots: 4, cells: 0 }).admissible);
+  assert.ok(!allocArmSizing({ writes: 0, roots: 0, cells: 0 }).admissible);
+});
+
+test('THE CHANGE ONLY EVER REFUSES MORE than rf2-2rtt6.142 shipped', () => {
+  // The property this package had to preserve, checked exhaustively over the
+  // grid rather than argued. rf2-2rtt6.142's shipped predicate was
+  // `boundaries >= 1 && writes >= ALLOC_MIN_WRITES && headroom >= 0`; the
+  // budget term is retired, so the surviving predicate is the first two. An
+  // admitted arm must therefore have satisfied BOTH surviving terms — which
+  // is the statement that nothing became newly admissible for any reason
+  // other than the budget's removal, and the budget's removal is criterion 4.
   let admitted = 0;
   let newlyRefused = 0;
   for (let writes = 0; writes <= 40; writes++) {
     for (let cells = 0; cells <= 40; cells++) {
       for (const roots of [0, 1, 4, 50]) {
         const s = allocArmSizing({ writes, roots, cells });
-        const wasAdmissible = writes >= 1 && s.boundaries >= 1 && s.headroom >= 0;
+        const survivingTerms = s.boundaries >= 1 && writes >= ALLOC_MIN_WRITES;
         if (s.admissible) {
           admitted++;
-          assert.ok(wasAdmissible, `newly admissible at W=${writes} B=${s.boundaries}`);
-        } else if (wasAdmissible) {
+          assert.ok(survivingTerms, `newly admissible at W=${writes} B=${s.boundaries}`);
+        } else if (survivingTerms) {
           newlyRefused++;
-          assert.ok(writes < ALLOC_MIN_WRITES, 'and only ever for want of averaging');
         }
       }
     }
   }
   assert.ok(admitted > 0, 'the sweep must still admit something');
-  assert.ok(newlyRefused > 0, 'and must have refused something, or it changed nothing');
-});
-
-test('a refused arm says WHY, one reason per thing wrong with it', () => {
-  // Both wrong at once: 300 boundaries at one write is over the budget AND
-  // under the floor, and an operator who fixed only the one they were told
-  // about would come back to the other.
-  const both = allocArmSizing({ writes: 1, roots: 1, cells: 300 });
-  assert.strictEqual(both.refusals.length, 2, JSON.stringify(both.refusals));
-  assert.ok(both.refusals.some((r) => r.includes('averaging floor')));
-  assert.ok(both.refusals.some((r) => r.includes('masking budget')));
-  // A page with nothing on it has no per-boundary quantity, and none of the
-  // other terms mean anything: one reason, and it is that one.
-  const empty = allocArmSizing({ writes: 6, roots: 4, cells: 0 });
-  assert.strictEqual(empty.refusals.length, 1);
-  assert.match(empty.refusals[0], /no per-boundary quantity/);
-});
-
-test('`floorBoundaries` is the largest page that carries the averaging floor', () => {
-  const s = allocArmSizing({ writes: 6, roots: 4, cells: 6 });
-  assert.strictEqual(s.floorBoundaries, 25, '300000 / ((6+1) x 1655)');
-  assert.ok(
-    allocMaxWrites(s.floorBoundaries) >= ALLOC_MIN_WRITES,
-    'a page that size admits the floor'
+  assert.strictEqual(
+    newlyRefused,
+    0,
+    'and a stated page at or above the floor is admitted, so the preflight adds no new refusal ' +
+      'beyond the mandatory page'
   );
-  assert.ok(
-    allocMaxWrites(s.floorBoundaries + 1) < ALLOC_MIN_WRITES,
-    'and one boundary more does not'
-  );
-  assert.ok(ALLOC_ARM.boundaries <= s.floorBoundaries, 'the shipped page is inside it');
+  // The one genuinely NEW refusal is the unstated page, and it refuses a
+  // configuration that used to be admitted — the direction criterion 4 allows.
+  assert.ok(!allocArmSizing({ writes: 6, roots: 4, cells: null }).admissible);
 });
 
 // --- the plan the page is mounted from -------------------------------------
@@ -839,17 +789,65 @@ test('the RETENTION ladder is not moved by any of this', () => {
     }
   }
   assert.strictEqual(published[0].arms.find((a) => a.rung === 'R20').keys, 24000);
+
+  // STRENGTHENED (rf2-2rtt6.140). The retention rows publish RETAINED bytes,
+  // and the write half must not move them: they still drive `:p0/write-all`
+  // at the published width, `prepare!` still defaults to `per-root`, and only
+  // the allocation window drives `write-page!`. Read off the sources, because
+  // a driver that silently swapped the write would leave every published
+  // retention figure describing a page it was not taken on.
+  const HEAP = fs.readFileSync(path.join(__dirname, 'p0_heap.cljs'), 'utf8');
+  const ARMS = fs.readFileSync(path.join(__dirname, 'p0_arms.cljs'), 'utf8');
+  const FIXTURE = fs.readFileSync(path.join(__dirname, 'p0_fixture.cljc'), 'utf8');
+  assert.match(HEAP, /\(arms\/write-page! @alloc-tick\)/, 'the alloc window drives write-page!');
+  assert.doesNotMatch(HEAP, /\(arms\/write-all! /, 'and never write-all!');
+  assert.match(
+    HEAP,
+    /\(\[segment-id\] \(prepare! segment-id per-root\)\)/,
+    'and an unstated width is the published page'
+  );
+  assert.match(ARMS, /\(dispatch-sync! \[:p0\/write-all v\]\)/, 'the public door is untouched');
+  assert.match(ARMS, /\(dispatch-sync! \[:p0\/write-page v\]\)/, 'and the new one sits beside it');
+  assert.match(
+    FIXTURE,
+    /\(rf\/reg-event :p0\/write-all\s+\(fn \[\{:keys \[db\]\} \[_ v\]\] \{:db \(assoc db :cells \(vec \(repeat cells-n v\)\)\)\}\)\)/,
+    '`:p0/write-all` is byte-identical, literal `cells-n` and all'
+  );
+  assert.match(
+    FIXTURE,
+    /\(vec \(repeat \(count \(:cells db\)\) v\)\)/,
+    'and `:p0/write-page` rebuilds at the db\'s own width'
+  );
+  assert.match(
+    FIXTURE,
+    /\(mod i \(count \(:cells db\)\)\)/,
+    "`:p0/fan`'s modulus is read off the db, so the width cannot live in two places"
+  );
+});
+
+test('the clock and bulk rows are not moved either', () => {
+  // The other half of the same property. `p0_app.cljs` drives the clock rows
+  // and must still call `enter-segment!` with no width — the arity that seeds
+  // the published grid to the byte.
+  const APP = fs.readFileSync(path.join(__dirname, 'p0_app.cljs'), 'utf8');
+  assert.match(APP, /\(arms\/enter-segment! segment\)/, 'the clock rows pass no width');
+  assert.doesNotMatch(APP, /:p0\/write-page/, 'and no clock row drives the new write');
+  const ARMS = fs.readFileSync(path.join(__dirname, 'p0_arms.cljs'), 'utf8');
+  assert.match(
+    ARMS,
+    /\(\[segment\] \(enter-segment! segment fx\/cells-n\)\)/,
+    'because the default arity IS the published width'
+  );
 });
 
 // --- the wiring, so this pin cannot drift off the thing that refuses -------
 
-test('the driver REFUSES a mis-sized arm before it launches a browser', () => {
-  has(/if \(!ALLOC_ARM\.admissible\) \{/, 'the sizing refusal is an exit, not a warning');
+test('the driver REFUSES a mis-configured arm before it launches a browser', () => {
+  has(/if \(!ALLOC_ARM\.admissible\) \{/, 'the preflight refusal is an exit, not a warning');
   has(
     /the allocation arm is refused by its own preflight before anything is measured/,
     'and it says so before a byte is measured'
   );
-  has(/SHRINK THE MEASURED UNIT, DO NOT WIDEN THE BUDGET/, 'naming the repair, not the dial');
   has(
     /ALLOC_ARM\.refusals/,
     'and the exit prints the reasons rather than one undifferentiated verdict'
@@ -857,8 +855,9 @@ test('the driver REFUSES a mis-sized arm before it launches a browser', () => {
 });
 
 test('the averaging floor is ENFORCED in the sizing, not merely derived from', () => {
-  // rf2-2rtt6.142. `ALLOC_MIN_WRITES` sized the default page and adjudicated
-  // nothing; the verdict admitted any window from one write up.
+  // rf2-2rtt6.142, unchanged by this package. `ALLOC_MIN_WRITES` sized the
+  // default page and adjudicated nothing; the verdict admitted any window from
+  // one write up.
   has(/if \(writes < ALLOC_MIN_WRITES\) \{/, 'the floor is a refusal in the sizing itself');
   has(/admissible: refusals\.length === 0,/, 'and the verdict is the reasons, not a conjunction');
   lacks(
@@ -867,16 +866,19 @@ test('the averaging floor is ENFORCED in the sizing, not merely derived from', (
   );
 });
 
-test('the window is DERIVED from the bound and the arm from the measured cost', () => {
+test('the window is the FLOOR and the page is STATED — neither is derived', () => {
+  // Replaces `the window is DERIVED from the bound and the arm from the
+  // measured cost`. Both derivations were the retired constant's arithmetic.
   has(
-    /const ALLOC_WRITES = Number\(\s*process\.env\.P0_ALLOC_WRITES \|\| allocMaxWrites\(ROOTS \* ALLOC_CELLS\)\s*\);/,
-    'the window must be what the page admits, not a number typed beside it'
+    /const ALLOC_WRITES = Number\(process\.env\.P0_ALLOC_WRITES \|\| ALLOC_MIN_WRITES\);/,
+    'the window follows the averaging floor, not an inverted bound'
   );
-  has(/const ALLOC_B_PER_BOUNDARY_WRITE = 1655;/, 'the top of the MEASURED range sizes the arm');
   has(/const ALLOC_MIN_WRITES = 6;/, 'and a window is sized to hold averaging');
-  // The bound itself is still the untouched one, with no dial of its own.
-  has(/const ALLOC_MASK_BUDGET_B = ALLOC_FALL_THRESHOLD_B \/ 2;/, 'unchanged by this arm');
-  has(/const ALLOC_FALL_THRESHOLD_B = 600000;/, 'and so is the measured threshold under it');
+  has(
+    /process\.env\.P0_ALLOC_CELLS === undefined \|\| process\.env\.P0_ALLOC_CELLS === ''/,
+    'the page is stated or it is not derivable'
+  );
+  lacks(/const ALLOC_CELLS = Number\(\s*process\.env\.P0_ALLOC_CELLS \|\|/, 'never defaulted');
 });
 
 // ===========================================================================

--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -488,6 +488,33 @@ test('an idle window is homogeneous at zero, and certifies', () => {
   assert.strictEqual(lumpy.certified, false, 'one leg doing work and two doing none is not one unit');
 });
 
+test('THE CERTIFICATE IS TIGHT — an admitted window under-reads by at most 2τ', () => {
+  // What an admitted window is certified to BE, checked rather than asserted.
+  // UNDER THE COHORT PREMISE — that absent a collection each leg's true
+  // allocation lies within τ of the true median — a leg can sit τ·m high on
+  // its own merits and still be admitted after losing a further τ·m. So the
+  // guarantee is `rise under-reads by at most 2τ`, and this is the exact
+  // worst case: leg 1 is τ·m HIGH, loses 2τ·m, and reads τ·m LOW.
+  const m = 1000;
+  const hi = m * (1 + ALLOC_LEG_TOLERANCE);
+  const lost = 2 * ALLOC_LEG_TOLERANCE * m;
+  const at = allocSteps(stream([hi, m, m, m, m], [lost, 0, 0, 0, 0]));
+  assert.strictEqual(at.falls, 0, 'a masked leg turns no step negative — that IS the fault');
+  assert.strictEqual(at.legs[0], m * (1 - ALLOC_LEG_TOLERANCE), 'and reads exactly τ·m low');
+  assert.strictEqual(at.legMedian, m);
+  assert.strictEqual(at.certified, true, 'admitted, at the very edge of the tolerance');
+  // The under-read that bought that admission is exactly 2τ of the median,
+  // and no more: one byte further and the window refuses.
+  assert.strictEqual(lost, 2 * ALLOC_LEG_TOLERANCE * at.legMedian);
+  const past = allocSteps(stream([hi, m, m, m, m], [lost + 1, 0, 0, 0, 0]));
+  assert.strictEqual(past.certified, false, 'so 2τ is a BOUND and not an approximation');
+  // And the whole-window statement the summary prints: `rise` under-reads the
+  // true allocation by at most 2τ. Here the true allocation is 5,250 B and
+  // `rise` reads 4,750 B — a 9.5% under-read against a 50% ceiling.
+  const trueAlloc = hi + 4 * m;
+  assert.ok((trueAlloc - at.rise) / trueAlloc <= 2 * ALLOC_LEG_TOLERANCE);
+});
+
 test('LEGS AND GAPS are read apart, and only the legs are adjudicated', () => {
   // `[s0, pre0, post0, pre1, post1, ...]`: the legs are `post - pre` and the
   // gaps are `pre - post`, where nothing happens but a loop increment and two

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -980,9 +980,8 @@ async function ladderRow(chromium) {
 // is the check `b8-alloc` was built around after the sampling profiler
 // produced a wrong table on this surface.
 // `ALLOC_WRITES` — how many warm writes one measured window holds — is
-// NOT here. It is an answer to the masking bound rather than a number
-// chosen beside it, so it is derived below `ALLOC_MASK_BUDGET_B` together
-// with the arm it has to fit around (rf2-2rtt6.138).
+// NOT here. It is the averaging floor, and it is stated below beside the
+// floor it follows (rf2-2rtt6.140).
 const ALLOC_ROUNDS = Number(process.env.P0_ALLOC_ROUNDS || 6);
 const ALLOC_WARMUPS = Number(process.env.P0_ALLOC_WARMUPS || 3);
 // 8 B a double, so 1,000 doubles is a predicted 8,000 B of garbage per
@@ -1003,144 +1002,165 @@ const ALLOC_D2 = Number(process.env.P0_ALLOC_D2 || 400);
 const ALLOC_CONTROL_SLACK = Number(process.env.P0_ALLOC_CONTROL_SLACK || 0.75);
 // The threshold, MEASURED rather than assumed: the standalone probes put
 // the first falling step at roughly 600 KB of cumulative garbage in a
-// window, on both kinds of garbage and at every semi-space size tried. It
-// is recorded here because it is what decides whether a given arm is
-// measurable by this instrument at all, and a warm re-render of 1,200
-// boundaries is two to three times over it in ONE write.
+// window, on both kinds of garbage and at every semi-space size tried.
+//
+// IT GATES NOTHING (rf2-2rtt6.140). It is a RECORDED FACT ABOUT THIS RIG,
+// quoted in the summary because a window's `rise` as a fraction of it is a
+// useful thing for a reader to see, and it is NOT loosened — it stays at
+// the figure the probes read. What it may not do is certify a window: it is
+// an UPPER bound on where the first collection runs, and the safety
+// argument the retired masking budget built on it needed a LOWER one.
 const ALLOC_FALL_THRESHOLD_B = 600000;
 
-// THE MASKING BUDGET — what makes a masked collection UNREACHABLE rather
-// than merely unlikely (rf2-n6w7o).
+// THE OBSERVED-COLLECTION WITNESS — a certificate read off the window's own
+// samples (rf2-2rtt6.140, replacing rf2-n6w7o's masking budget).
 //
-// `allocSteps` below detects a collection by the SIGN of an adjacent step,
-// and a sign test is blind in exactly one direction. Where V8 collects
-// inside a leg that ALSO allocates at least as much as the collection
-// reclaimed, the observed step is >= 0: `falls` stays 0, the reclaimed
-// bytes are simply missing from `rise`, and the row prints a window that
-// looks clean and reads LOW. Under-reading allocation is the direction that
-// manufactures HD-002's predicted flat-at-zero, so it is the one direction
-// this row may not be able to fail in — and until this constant existed it
-// was the direction with no gate on it at all.
+// THE FAULT IT ADDRESSES IS UNCHANGED. `allocSteps` below detects a
+// collection by the SIGN of an adjacent step, and a sign test is blind in
+// exactly one direction. Where V8 collects inside a leg that ALSO allocates
+// at least as much as the collection reclaimed, the observed step is >= 0:
+// `falls` stays 0, the reclaimed bytes are simply missing from `rise`, and
+// the row prints a window that looks clean and reads LOW. Under-reading
+// allocation is the direction that manufactures HD-002's predicted
+// flat-at-zero, so it is the one direction this row may not be able to fail
+// in.
 //
-// THE REPAIR IS ARITHMETIC, NOT A SECOND DETECTOR, and it rests on one
-// property of the fault: MASKING CANNOT PRECEDE THE FIRST COLLECTION. Every
-// leg before it runs with no collector in it, so `rise` counts those legs
-// EXACTLY. And the first collection does not fire until roughly
-// `ALLOC_FALL_THRESHOLD_B` of cumulative garbage has built up since the
-// forced GC the driver takes on the window's near side. So if a collection
-// fired in leg k, writing A_k for that leg's own allocation:
+// WHY THE ARITHMETIC THAT USED TO GUARD IT IS RETIRED. The old bound charged
+// `rise + maxStep <= ALLOC_FALL_THRESHOLD_B / 2` and rested on two premises
+// the merged-PR audit of #7682 refuted and rf2-2rtt6.141 accepted:
 //
-//     rise  >=  (every leg before k)  >=  ALLOC_FALL_THRESHOLD_B - A_k
+//   - `ALLOC_FALL_THRESHOLD_B` is where the first VISIBLE fall appeared. A
+//     masked one would not have shown, so it is an UPPER bound on where the
+//     first collection runs — and the safety argument needs a LOWER one.
+//     Halving an upper bound does not produce a lower one.
+//   - `maxStep` was taken as a bound on a masked leg's true allocation, but
+//     `maxStep` sees only NET positive deltas, which is precisely what a
+//     masked leg does not produce.
 //
-// The legs are n repetitions of ONE work unit and every earlier leg is
-// counted exactly, so A_k is bounded by the largest rising step the window
-// shows. Contrapositive, and it is the gate:
+// The audit wrote two executable probes and the bound ADMITTED both, at
+// `headroom = 0`, with true allocations of 300 KB and 600 KB. Retiring is
+// therefore not widening: the mechanism did not do the job it named. It is
+// route (b) of rf2-2rtt6.140's ruling, which sanctions exactly this
+// replacement. Both probes are pinned in `p0_ladder_structural.test.cjs`.
 //
-//     rise + maxStep  <=  budget   =>   NO collection ran, masked or not.
+// THE REPLACEMENT ASKS THE DATA A QUESTION INSTEAD OF ASSERTING A MODEL.
+// The legs of one window are W repetitions of ONE work unit — the same
+// event, the same page, the same drain — so absent a collection they should
+// be alike. Let `m` be the MEDIAN of the window's work legs:
 //
-// Note which way net growth pushes here, because it is the whole point.
-// Masking REMOVES bytes from `rise`, so it can only move a window further
-// under budget — but the allocation that had to happen first, to give the
-// collector a reason to run, is already counted in full in the legs before
-// it, where no masking is possible. Growth cannot defeat this gate the way
-// it defeats the sign test. It can only make a window fail it sooner.
+//     REFUSE the window if any leg deviates from `m` by more than τ·m.
 //
-// THE BUDGET IS THE MEASURED THRESHOLD HALVED, and both halves of that are
-// stated rather than assumed:
+// Two-sided, on purpose, and the median rather than the mean because the
+// first leg of a window is the one most likely to sit high.
 //
-//   - `ALLOC_FALL_THRESHOLD_B` is where the first VISIBLE fall appeared in
-//     the standalone probes. A masked one would not have shown, so it is an
-//     UPPER bound on where the first collection actually runs, and a gate
-//     built on it has to take the conservative side.
-//   - The halved figure, ~300 KB, is a whisker above the largest window
-//     this instrument has a CORROBORATED clean reading for: the D=1,000
-//     control at 30 writes is 240 KB of cumulative garbage and
-//     reads 8.13 B/double against a predicted 8. A window that under-read
-//     would not hit its prediction, so the control is positive evidence of
-//     no collection at that scale — which a fall count of zero, on its own,
-//     is not.
+//   - A leg BELOW its cohort is a leg something removed bytes from. Nothing
+//     in the work unit removes bytes; the collector does. That is the
+//     observation, and it is why a masked leg — which under-reads by
+//     construction — is exactly what this rule catches.
+//   - A leg ABOVE its cohort is not evidence of a collection, but it is
+//     evidence that the one-work-unit premise the whole witness rests on has
+//     failed in this window. Refusing is then correct rather than merely
+//     conservative, and refusal is the safe reading either way.
 //
-// Deliberately not an env knob. Every other `P0_ALLOC_*` constant sizes the
-// measurement; this one decides whether a measurement may be PUBLISHED, and
-// a gate with a dial on it is a gate that gets dialled. Widening it would
-// retro-admit every window it exists to refuse.
+// WHAT AN ADMITTED WINDOW IS CERTIFIED TO BE, stated exactly, because a
+// witness that oversells itself is worse than none. Under the cohort premise
+// — that absent a collection each leg's true allocation lies within τ of `m`
+// — a leg can sit τ·m high on its own merits and still be admitted after
+// losing a further τ·m. So the certificate reads:
 //
-// WHAT IT DOES NOT CLOSE, stated because a bound that oversells itself is
-// worse than no bound. A window in which EVERY leg is masked — a collection
-// in each one, each reclaiming at least that leg's allocation, the heap
-// flat while megabytes pass through it — defeats both terms. `falls`
-// catches such a window the moment one collection overshoots; `maxStep`
-// catches it the moment one leg runs unmasked; nothing here catches it if
-// neither ever happens, and closing it properly would need a per-leg
-// allocation counter V8 does not expose in-page. It is also UNREACHABLE for
-// the arm this bound exists to license: an arm whose warm write allocates a
-// few KB cannot cross the threshold inside a single leg at all, so there is
-// no leg for a first collection to hide in. That is the shape
-// rf2-2rtt6.138's small-witness arm has to have, and this is the arithmetic
-// that says why.
-const ALLOC_MASK_BUDGET_B = ALLOC_FALL_THRESHOLD_B / 2;
+//     this window's `rise` under-reads its true allocation by at most 2τ,
+//     and here is the worst leg deviation actually observed.
+//
+// That is a weaker claim than "no collection ran" and a far stronger one
+// than the old bound could support, because it is CHECKABLE FROM THE WINDOW
+// ITSELF rather than from a premise about where V8 first collects. And it is
+// the right shape for this row: a bounded under-read with the bound printed
+// beside the figure is the guarantee the row needs.
+//
+// WHAT IT DOES NOT CLOSE. A window in which EVERY leg is masked by a similar
+// amount is homogeneous and passes. rf2-n6w7o already named that hole as
+// unreachable in-page — closing it needs a per-leg allocation counter V8
+// does not expose. Three things stand against it, none of them a proof: the
+// falls gate takes it the moment one collection overshoots; this gate takes
+// it the moment one leg runs unmasked; and the controls in the same round
+// would read low against their own 8 B/double prediction if the collector
+// were running that hard. Masking smaller than τ·m in a single leg is
+// invisible BY CONSTRUCTION — that is what the 2τ statement is for. It is a
+// bounded under-read, not a silent one.
+//
+// NOTHING ALLOCATES IN A GAP, so a collection between iterations cannot be
+// masked at all: it lands as a negative step and the untouched falls gate
+// takes it. `gaps` is recorded as a diagnostic and stays inside `rise`.
+//
+// τ IS NOT AN ENV KNOB, for `ALLOC_MASK_BUDGET_B`'s reason unchanged: every
+// other `P0_ALLOC_*` constant sizes the measurement, and this one decides
+// whether a measurement may be PUBLISHED. A gate with a dial on it is a gate
+// that gets dialled.
+//
+// >>> THIS VALUE IS AN UNCALIBRATED PLACEHOLDER. <<<
+//
+// rf2-2rtt6.141 carried an acceptance criterion into this package from the
+// audit's closing line — *a witness whose own reliability is unmeasured is a
+// second thing to distrust* — so τ is not chosen by taste. It is to be
+// calibrated by VALIDITY WITNESS V3 on windows that are INDEPENDENTLY
+// CORROBORATED CLEAN: a dropped `.slice` of D doubles costs a PREDICTED 8D
+// bytes, and a control that hit its prediction is positive evidence of no
+// collection in a way a zero fall count is not. The two control sizes
+// bracket the arms' own magnitude (D=1,000 is 8 KB a leg, D=400 is 3.2 KB),
+// so the natural spread is measured at the scale it is applied at. V3 sets τ
+// to a stated multiple of the observed worst deviation, records the observed
+// figure and the margin here, and this line stops saying PLACEHOLDER.
+//
+// V3 HAS NOT RUN — rf2-2rtt6.140 criterion 5 freezes every allocation window
+// until V1-V4 are green — so the figure below is a conservative stand-in and
+// no window may be published on it. Conservative in the direction that
+// matters: τ is a tolerance, so a SMALLER τ refuses MORE, and 0.25 refuses
+// strictly more than any larger value V3 might land on. Nothing in the
+// pinned probes depends on it: their offending legs read exactly zero
+// against a strictly positive median, so they refuse for every τ < 1, and
+// that property is itself a test.
+const ALLOC_LEG_TOLERANCE = 0.25;
 
 // ---------------------------------------------------------------------------
-// THE SMALL-WITNESS ARM (rf2-2rtt6.138) — the page sized TO the bound above
+// THE PAGE — MANDATORY, because no honest default survives (rf2-2rtt6.139)
 // ---------------------------------------------------------------------------
 //
-// The published witness is outside this instrument's range and the row is
-// right to refuse it. One warm write of the 1,200-boundary page allocates
-// 1.2-1.7 MB, two to three times the ~600 KB at which the first collection
-// appears; the 2026-08-07 quiet-box run put 36 falling steps inside 44
-// windows and a quiet box moved neither figure, because it was never
-// contention. It is the arm's SCALE against a fixed threshold.
+// `ALLOC_B_PER_BOUNDARY_WRITE = 1655` sized the whole allocation arm and is
+// RETIRED, effective rf2-2rtt6.139's ruling. Its stated provenance was the
+// 2026-08-07 quiet-box run — and that run REFUSED, at 36 falling steps
+// across 44 windows, whose own refusal text declares every figure from such
+// a window an under-estimate. Sizing off a lower bound licenses a page too
+// LARGE, and the 2026-08-08 window found exactly that: 3,731-23,192 B per
+// boundary per write measured at B=24 against the 1,655 the arm was sized
+// with, 2.3x to 14x.
 //
-// So the repair is the one the bead named: shrink the measured UNIT, not the
-// window. The quantity this row publishes is per BOUNDARY, so a page of a few
-// dozen boundaries puts a MANY-WRITE window under the threshold and leaves
-// the averaging a fit needs — where the other direction, one write on the
-// 300-boundary page, cleared the fall count and produced four fits at r2
-// 0.75 / 0.28 / 0.94 / 0.31 out of windows the bound above cannot certify
-// anyway (326-993 KB of rise+maxStep).
+// AND NO REPLACEMENT CONSTANT MAY BE SUBSTITUTED, because the old one
+// silently mixed two terms that run then separated: a FIXED per-write cost
+// F ~ 24.4 KB that does not scale with B (the floor arm reads it directly:
+// 24,108 B/write on reagent-subs, 24,730 on uix-subs) and a genuine
+// per-boundary term s(R) that does, and that swings 5x across the HD-002
+// ladder (2,031-4,067 B/bnd/write at R=1 up to 6,800-22,174 at R=20). A
+// scale-free `c` models neither and is valid only at the page it was
+// measured on.
 //
-// THE ARITHMETIC, and every term in it is either measured or derived:
+// SO THE PAGE IS STATED, NEVER DERIVED. With no sizing model there is no
+// honest default, and inventing a literal would be substituting the number
+// rf2-2rtt6.139 forbids. An unstated `P0_ALLOC_CELLS` is refused BY NAME in
+// `allocArmSizing` below — which has the additional virtue of making an
+// accidental publication run impossible while rf2-2rtt6.140 criterion 5's
+// measurement freeze is in force. `rf2-2rtt6.139` re-derives sizing PER RUNG
+// from V1's floor data and V2's per-rung signal, and may restore a derived
+// default on those grounds; this package derives none.
 //
-//   c   bytes one warm write allocates per mounted boundary. MEASURED, on
-//       the candidate arm, in that same quiet-box run: 544-1655 B across its
-//       rungs. The TOP of the range sizes the arm, because a page sized off
-//       the bottom would be refused rather than published.
-//   W   writes in one window. A window of one has no averaging in it, so the
-//       arm is sized to hold at least `ALLOC_MIN_WRITES` of them and then
-//       takes every further write the bound still admits — and the preflight
-//       REFUSES a window under that floor however it was configured, which
-//       the bound below cannot do for it (a small window is a small window,
-//       and the budget is a ceiling on size).
-//   B   boundaries on the page, = P0_ROOTS x cells-per-root.
-//
-//   rise ~ W.B.c and the largest single step is one write, ~B.c, so the
-//   bound `rise + maxStep <= ALLOC_MASK_BUDGET_B` reads
-//
-//       (W + 1).B.c  <=  ALLOC_MASK_BUDGET_B
-//
-//   and the two ways round it are the two knobs:
-//
-//       B  <=  budget / ((W + 1).c)        the page a window admits
-//       W  <=  budget / (B.c)  -  1        the window a page admits
-//
-// At the shipped constants that is 6 cells x 4 roots = 24 boundaries and 6
-// writes: 24 x 1,655 = 39,720 B a write, 278,040 B of rise+maxStep, 21,960 B
-// of headroom under the budget. The same page at the published 1,200
-// boundaries predicts 13.9 MB and the row would refuse it — which is the
-// whole reason this arm exists.
-//
-// WHAT THE ARITHMETIC DOES NOT MODEL, stated rather than glossed. `c` is
-// per-boundary, and `:p0/write-all` also rebuilds a 300-element vector and
-// drives the whole event pipeline whether one boundary is mounted or 1,200.
-// That fixed per-write cost is in every window and in no term above, and no
-// run on this rig has recorded it on its own — the floor arm measures it
-// directly and its figure has never been published. So the prediction below
-// is a SIZING aid and not a certificate: what certifies a window is
-// `allocSteps` reading the window's own samples, on the run, against the
-// same budget. The prediction is here so a configuration that cannot
-// possibly pass is refused before a measurement is spent on it, not so that
-// one which passes it may be trusted.
-const ALLOC_B_PER_BOUNDARY_WRITE = 1655;
+// Boundaries per root, and the reason it is a parameter at all: `fx/cells-n`
+// is compile-time, so `P0_ROOTS=1` floored B at 300 through the env surface.
+// `p0-heap/arm-for` takes it as `:cells`, so the driver states the page.
+// `null` — the env var unset or empty — is the unstated case, and it is a
+// refusal rather than a default.
+const ALLOC_CELLS =
+  process.env.P0_ALLOC_CELLS === undefined || process.env.P0_ALLOC_CELLS === ''
+    ? null
+    : Number(process.env.P0_ALLOC_CELLS);
 
 // The averaging floor. Six is the config the quiet-box run took the
 // published witness in, and the smallest window the bead's own re-costing
@@ -1151,165 +1171,126 @@ const ALLOC_B_PER_BOUNDARY_WRITE = 1655;
 // differential against a predicted 8 at exactly this window, so the claim
 // the controls exist to establish — that transient garbage is visible to
 // this counter at all — has been corroborated here as well as at the 30
-// writes `ALLOC_MASK_BUDGET_B` cites. A smaller control window is also a
-// further-under-budget one, which is the safe direction.
+// writes the retired masking budget cited.
 //
 // IT IS A FLOOR AND NOT ONLY A DEFAULT (rf2-2rtt6.142). It sized the page
-// below and adjudicated nothing, so the preflight admitted any window from
-// one write up: `P0_ROOTS=50` derives a 50-boundary page whose largest legal
-// window is two writes, and `P0_ALLOC_WRITES=1` sets a one-write window on
-// the shipped page. Both sit far under the masking budget — that budget is a
-// ceiling on a window's SIZE and has nothing to say about how few writes are
-// averaged inside it — so both reached every publication path. One write is
+// and adjudicated nothing, so the preflight admitted any window from one
+// write up: `P0_ROOTS=50` derived a 50-boundary page whose largest legal
+// window was two writes, and `P0_ALLOC_WRITES=1` set a one-write window on
+// the shipped page. Both sat far under the masking budget — that budget was
+// a ceiling on a window's SIZE and had nothing to say about how few writes
+// are averaged inside it — so both reached every publication path. The same
+// is true of the leg witness that replaced it, and for the same reason: it
+// asks whether the legs are alike, not how many there are. One write is
 // exactly the configuration whose four fits came back at r² 0.75 / 0.28 /
 // 0.94 / 0.31, against the 0.98 floor this row publishes under.
-// `allocArmSizing` now refuses below this number rather than only deriving
-// from it.
+// `allocArmSizing` refuses below this number rather than only deriving from
+// it, and rf2-2rtt6.140 leaves that untouched: the averaging floor is not a
+// budget question. A one-write window has no averaging in it whatever
+// certifies the window.
 const ALLOC_MIN_WRITES = 6;
 
-// Boundaries per root — the MEASURED UNIT, and the reason this arm is a code
-// change rather than a flag. `fx/cells-n` is compile-time, so `P0_ROOTS=1`
-// floored B at 300 through the env surface and no window on any page that
-// size can be certified. `p0-heap/arm-for` now takes it as `:cells`, so the
-// driver states the page and the dial exists for a measurement window that
-// wants to walk B — the bound below adjudicates whatever it is set to.
-const ALLOC_CELLS = Number(
-  process.env.P0_ALLOC_CELLS ||
-    Math.max(
-      1,
-      Math.floor(
-        ALLOC_MASK_BUDGET_B / ((ALLOC_MIN_WRITES + 1) * ROOTS * ALLOC_B_PER_BOUNDARY_WRITE)
-      )
-    )
-);
+// The window, which is now the averaging floor and nothing else. It used to
+// be inverted out of the masking budget — `budget / (B.c) - 1` — and with
+// the budget retired there is no bound left to invert. Taking MORE writes
+// than the floor is a measurement configuration's business, not a default's.
+const ALLOC_WRITES = Number(process.env.P0_ALLOC_WRITES || ALLOC_MIN_WRITES);
 
-// The largest window a page of `boundaries` admits, from the bound and
-// nothing else. `- 1` is `maxStep`: the bound charges one extra write's
-// worth for the leg a collection could have hidden in.
-function allocMaxWrites(boundaries) {
-  return Math.floor(ALLOC_MASK_BUDGET_B / (boundaries * ALLOC_B_PER_BOUNDARY_WRITE)) - 1;
-}
-
-const ALLOC_WRITES = Number(
-  process.env.P0_ALLOC_WRITES || allocMaxWrites(ROOTS * ALLOC_CELLS)
-);
-
-// The sizing, as a PURE FUNCTION of the config and the bound — the same
-// shape and for the same reason as `allocSteps` and `allocMaskableWindows`:
-// it needs neither a release build nor a Chromium, so it is pinned on every
-// PR by `p0_ladder_structural.test.cjs` instead of waiting for the next
-// opt-in run of this driver to notice that an arm drifted out of range.
+// The sizing, as a PURE FUNCTION of the config — the same shape and for the
+// same reason as `allocSteps` and `allocRefusedWindows`: it needs neither a
+// release build nor a Chromium, so it is pinned on every PR by
+// `p0_ladder_structural.test.cjs` instead of waiting for the next opt-in run
+// of this driver to notice that an arm drifted.
 //
-// Nothing here measures anything. `predictedWindowB` is `(W + 1).B.c`, the
-// left-hand side of the bound.
+// NOTHING HERE PREDICTS A WINDOW'S SIZE ANY MORE. `predictedWindowB`,
+// `headroom`, `maxBoundaries` and `floorBoundaries` went with the budget and
+// with `ALLOC_B_PER_BOUNDARY_WRITE`, because every one of them was that
+// constant's arithmetic wearing a different name. What is left refuses only
+// on grounds it can defend WITHOUT a sizing model — rf2-2rtt6.139's interim
+// posture, stated on that bead: a window spent on a page that then refuses
+// is acceptable; a gatekeeper enforcing a model the data contradicts is not.
 //
 // `refusals` IS THE VERDICT, one entry per thing wrong with the arm, and
 // `admissible` is just "none of them" (rf2-2rtt6.142). One boolean was not
-// enough because the two ways an arm can be wrong want OPPOSITE repairs: a
-// window over the masking budget is repaired by shrinking it, and a window
-// under the averaging floor is repaired by shrinking the PAGE so a bigger one
-// fits. An arm can be both at once, and a refusal that named only the budget
-// would send an operator to `P0_ALLOC_WRITES` — i.e. to configure the very
-// shape being refused.
-function allocArmSizing({ writes, roots, cells, bytesPerBoundaryWrite = ALLOC_B_PER_BOUNDARY_WRITE }) {
-  const boundaries = roots * cells;
-  const predictedMaxStep = boundaries * bytesPerBoundaryWrite;
-  const predictedRise = writes * predictedMaxStep;
-  const predictedWindowB = predictedRise + predictedMaxStep;
-  const headroom = ALLOC_MASK_BUDGET_B - predictedWindowB;
-  const maxWrites = allocMaxWrites(boundaries);
-  const maxBoundaries = Math.floor(ALLOC_MASK_BUDGET_B / ((writes + 1) * bytesPerBoundaryWrite));
-  // The largest page that still carries the averaging floor: `maxBoundaries`
-  // read at `ALLOC_MIN_WRITES` instead of at whatever this window happens to
-  // be. It is the number a below-floor arm has to be shrunk TO, so it is
-  // computed here rather than left for the reader to invert.
-  const floorBoundaries = Math.floor(
-    ALLOC_MASK_BUDGET_B / ((ALLOC_MIN_WRITES + 1) * bytesPerBoundaryWrite)
-  );
+// enough because the ways an arm can be wrong want different repairs, and an
+// arm can be wrong in more than one at once.
+function allocArmSizing({ writes, roots, cells }) {
+  // `null`/`undefined` is the page NOT STATED, which is distinct from a page
+  // stated as zero: one is a missing configuration and the other is a page
+  // with nothing on it. They refuse for different reasons and say so.
+  const stated = cells !== null && cells !== undefined;
+  const boundaries = stated ? roots * cells : null;
 
   const refusals = [];
-  if (boundaries < 1) {
-    // No per-boundary quantity to publish, and none of the terms below mean
-    // anything on an empty page — it would otherwise sail under the budget on
-    // zero bytes.
+  if (!stated) {
+    refusals.push(
+      `the allocation row's page is not derivable until rf2-2rtt6.139 re-derives sizing from ` +
+        `the new instrument's own floor data: STATE P0_ALLOC_CELLS (boundaries per root; the ` +
+        `page is P0_ROOTS x P0_ALLOC_CELLS). ALLOC_B_PER_BOUNDARY_WRITE was retired because it ` +
+        `was read off a run that itself refused, and no replacement constant may be substituted`
+    );
+  } else if (boundaries < 1) {
+    // No per-boundary quantity to publish. It would otherwise sail through on
+    // zero bytes, which is admitting nothing measured at all.
     refusals.push(
       `a page of ${boundaries} boundaries (${roots} roots x ${cells} cells) has no ` +
         `per-boundary quantity to publish: RAISE P0_ROOTS or P0_ALLOC_CELLS`
     );
-  } else {
-    if (writes < ALLOC_MIN_WRITES) {
-      // Two different arms land here and they want opposite repairs. If the
-      // page still admits the floor then the window alone was set too small
-      // and the window is the knob. If it does not, the window is not the
-      // knob at all — and naming what such a page DOES admit would be naming
-      // a below-floor window, i.e. advising the shape being refused. So that
-      // branch names only the page.
-      const repair =
-        maxWrites >= ALLOC_MIN_WRITES
-          ? `This page admits ${maxWrites} writes: RAISE P0_ALLOC_WRITES to at least ` +
-            `${ALLOC_MIN_WRITES}, or unset it and take the window the page derives`
-          : `${boundaries} boundaries cannot carry a ${ALLOC_MIN_WRITES}-write window under ` +
-            `the ${ALLOC_MASK_BUDGET_B} B masking budget, so the WINDOW IS NOT THE KNOB: ` +
-            `SHRINK THE PAGE — lower P0_ROOTS / P0_ALLOC_CELLS to at most ` +
-            `${floorBoundaries} boundaries`;
-      refusals.push(
-        `a window of ${writes} write(s) is under the ${ALLOC_MIN_WRITES}-write averaging floor ` +
-          `(ALLOC_MIN_WRITES) and has too little in it to average: at one write per window this ` +
-          `row's four fits came back at r² 0.75 / 0.28 / 0.94 / 0.31, under its 0.98 floor. ` +
-          repair
-      );
-    }
-    if (headroom < 0) {
-      // Naming `maxWrites` here is only a repair while the page can still
-      // carry the floor; below it the window is not the knob, and saying so
-      // would advise exactly the shape the refusal above exists to stop.
-      const windowKnob =
-        maxWrites >= ALLOC_MIN_WRITES
-          ? `, and this page at most ${maxWrites} writes (P0_ALLOC_WRITES)`
-          : '';
-      refusals.push(
-        `${boundaries} boundaries x ${writes} writes predicts ${predictedWindowB} B of ` +
-          `rise+maxStep at the measured ${bytesPerBoundaryWrite} B/boundary/write, against the ` +
-          `${ALLOC_MASK_BUDGET_B} B masking budget. ` +
-          `SHRINK THE MEASURED UNIT, DO NOT WIDEN THE BUDGET: this window admits at most ` +
-          `${maxBoundaries} boundaries (P0_ROOTS x P0_ALLOC_CELLS)${windowKnob}`
-      );
-    }
+  }
+  // Independent of the page, and deliberately so: with no page-size model
+  // there is nothing to say about what a given page admits, so this refusal
+  // no longer branches on one. rf2-2rtt6.142's endorsed property — never
+  // advise the operator to configure the very shape being refused — survives
+  // the collapse intact, because the collapsed message names no shape at all.
+  if (writes < ALLOC_MIN_WRITES) {
+    refusals.push(
+      `a window of ${writes} write(s) is under the ${ALLOC_MIN_WRITES}-write averaging floor ` +
+        `(ALLOC_MIN_WRITES) and has too little in it to average: at one write per window this ` +
+        `row's four fits came back at r² 0.75 / 0.28 / 0.94 / 0.31, under its 0.98 floor. ` +
+        `RAISE P0_ALLOC_WRITES to at least ${ALLOC_MIN_WRITES}, or unset it and take the floor`
+    );
   }
 
   return {
-    cells,
+    cells: stated ? cells : null,
     roots,
     boundaries,
     writes,
-    bytesPerBoundaryWrite,
-    predictedRise,
-    predictedMaxStep,
-    predictedWindowB,
-    headroom,
     refusals,
     admissible: refusals.length === 0,
-    maxWrites,
-    maxBoundaries,
-    floorBoundaries,
   };
 }
 
 const ALLOC_ARM = allocArmSizing({ writes: ALLOC_WRITES, roots: ROOTS, cells: ALLOC_CELLS });
 
+// The median of a window's work legs. The MEDIAN and not the mean, because
+// the first leg of a window is the one most likely to sit high and a mean
+// would let it drag the cohort toward whichever leg is the outlier.
+function median(xs) {
+  if (xs.length === 0) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = s.length >> 1;
+  return s.length % 2 === 1 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
 // Rising and falling steps, accumulated separately, from one window's raw
-// samples. The samples are `[s0, pre0, post0, pre1, post1, ...]`, so the
-// work legs are the (pre -> post) steps and the gaps between iterations
-// are the (post -> pre) steps; both are walked, because a collection can
-// fall in either.
+// samples — AND the leg cohort the certificate is read off.
 //
-// `maxStep`, `headroom` and `maskable` are the masking witness above:
-// `headroom` is the budget less what a collection would have had to hide
-// behind to go unseen, and `maskable` says the window is large enough to
-// have hidden one WHATEVER `falls` reports. The two gates are independent
-// and both are exits — a fall is a collection this counter saw, a maskable
-// window is one it could not have.
-function allocSteps(samples) {
+// The samples are `[s0, pre0, post0, pre1, post1, ...]`, so leg `k` is
+// `post_k - pre_k` (one per write, the work) and gap `k` is
+// `pre_k - post_{k-1}` (`pre0 - s0` for the first), where nothing happens
+// but a loop increment and two array stores. `rise` / `fall` / `falls` /
+// `maxStep` walk EVERY step exactly as they always did, because a collection
+// can fall in either kind — and note the property a gap has for free:
+// nothing allocates in a gap, so a collection there cannot be masked. It
+// lands as a negative step and the untouched falls gate takes it.
+//
+// `certified` is `refusals.length === 0`, mirroring `allocArmSizing` since
+// rf2-2rtt6.142 — one verdict shape across the preflight and the window
+// gate. `tolerance` is a parameter so the pinned probes can be swept across
+// τ; the driver never passes it, so the shipped gate is the module constant
+// and there is no dial anywhere on the measurement path.
+function allocSteps(samples, tolerance = ALLOC_LEG_TOLERANCE) {
   let rise = 0;
   let fall = 0;
   let falls = 0;
@@ -1324,61 +1305,100 @@ function allocSteps(samples) {
       falls++;
     }
   }
-  const headroom = ALLOC_MASK_BUDGET_B - (rise + maxStep);
+
+  const w = (samples.length - 1) >> 1;
+  const legs = [];
+  const gaps = [];
+  for (let k = 0; k < w; k++) {
+    gaps.push(samples[2 * k + 1] - samples[2 * k]);
+    legs.push(samples[2 * k + 2] - samples[2 * k + 1]);
+  }
+
+  const legMedian = median(legs);
+  // Stated in BYTES rather than as a ratio, so the rule is well defined at a
+  // zero median: an idle window is homogeneous at zero, every leg deviates
+  // from it by 0, and 0 is not MORE than 0 — so it certifies, which it has
+  // to, because the idle control is one of the three windows the row takes.
+  const allowed = tolerance * legMedian;
+  const refusals = [];
+  let worst = 0;
+  for (const [k, leg] of legs.entries()) {
+    const dev = leg - legMedian;
+    if (Math.abs(dev) > Math.abs(worst)) worst = dev;
+    if (Math.abs(dev) <= allowed) continue;
+    const why =
+      dev < 0
+        ? 'a leg BELOW its cohort is a leg something removed bytes from, and nothing in the ' +
+          'work unit removes bytes — the collector does'
+        : 'a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has ' +
+          'failed in this window, so refusing is correct rather than merely conservative';
+    refusals.push(
+      `leg ${k + 1} of ${w} read ${leg} B against a cohort median of ${legMedian} B ` +
+        `(${dev > 0 ? '+' : ''}${dev} B` +
+        (legMedian > 0 ? `, ${((dev / legMedian) * 100).toFixed(1)}%` : '') +
+        `), past the ±${(tolerance * 100).toFixed(0)}% leg tolerance (±${allowed} B): ${why}`
+    );
+  }
+
   return {
     rise,
     fall,
     falls,
     maxStep,
-    headroom,
-    maskable: headroom < 0,
     endpoints: samples[samples.length - 1] - samples[0],
+    legs,
+    gaps,
+    legMedian,
+    // Signed and RELATIVE, so it is comparable across windows of different
+    // magnitudes — and `null` at a zero median, because a relative deviation
+    // from zero is not a number and reporting a fabricated 0 would say the
+    // window was homogeneous when it may not have been.
+    legWorstDeviation: legMedian > 0 ? worst / legMedian : null,
+    legTolerance: tolerance,
+    refusals,
+    certified: refusals.length === 0,
   };
 }
 
-// The masking witness over a whole collected row, as a PURE FUNCTION of it
-// — the same shape and for the same reason as `ladderStructuralFailures`
-// below: it needs neither a release build nor a Chromium to adjudicate, so
-// it can be pinned on every PR by `p0_ladder_structural.test.cjs` instead of
-// waiting for the next opt-in run of this driver to notice.
+// The witness over a whole collected row, as a PURE FUNCTION of it — the
+// same shape and for the same reason as `ladderStructuralFailures` below: it
+// needs neither a release build nor a Chromium to adjudicate, so it can be
+// pinned on every PR by `p0_ladder_structural.test.cjs` instead of waiting
+// for the next opt-in run of this driver to notice.
 //
 // ARM WINDOWS ONLY, exactly as the falling-step gate counts only those. The
 // arms are what gets published; the controls adjudicate the arithmetic, and
 // a masked control would read LOW against its own 8 B/double prediction and
 // refuse through `controlVerdict` — the safe direction, already gated.
-function allocMaskableWindows(row) {
+//
+// EVERY REFUSED WINDOW IS NAMED WITH ITS REASON, on every round, because a
+// count of refusals tells an operator nothing about which leg misbehaved.
+function allocRefusedWindows(row) {
   const out = [];
   for (const r of row.perRound || []) {
     for (const [key, a] of Object.entries(r.arms || {})) {
-      if (!a.maskable) continue;
-      out.push(
-        `round ${r.round} ${key}: rise ${a.rise} B + largest step ${a.maxStep} B is ` +
-          `${-a.headroom} B over the ${ALLOC_MASK_BUDGET_B} B masking budget`
-      );
+      if (a.certified) continue;
+      for (const reason of a.refusals || []) out.push(`round ${r.round} ${key}: ${reason}`);
     }
   }
   return out;
 }
 
 async function allocRow(chromium) {
-  // THE SIZING REFUSAL, before a browser is launched and a byte is measured.
-  // The bound decides what may be published; this decides what is worth
-  // measuring at all, and it exists because the alternative is a twenty
-  // minute run whose every window the bound then refuses — which is exactly
-  // what the 2026-08-07 quiet-box run spent. It is a PREDICTION and not a
-  // certificate: passing it licenses nothing, and `allocSteps` still reads
-  // every window's own samples against the same budget on the way through.
+  // THE PREFLIGHT REFUSAL, before a browser is launched and a byte is
+  // measured. It refuses only on grounds it can defend WITHOUT a sizing model
+  // — rf2-2rtt6.139's interim posture — which is now two: an unstated page,
+  // and a window under the averaging floor.
   //
-  // The averaging floor is the half that `allocSteps` can NEVER catch up on
-  // (rf2-2rtt6.142). A window under `ALLOC_MIN_WRITES` is not over the budget
-  // — it is comfortably under it — so nothing downstream refuses it, and the
-  // r² floor sees only a fit it has no averaging to make. This is the one
-  // gate that can say so, and it says so here.
+  // The averaging floor is the half `allocSteps` can NEVER catch up on
+  // (rf2-2rtt6.142). A window under `ALLOC_MIN_WRITES` is not heterogeneous,
+  // so nothing downstream refuses it, and the r² floor sees only a fit it has
+  // no averaging to make. This is the one gate that can say so.
   if (!ALLOC_ARM.admissible) {
     throw new Error(
       `the allocation arm is refused by its own preflight before anything is measured — ` +
-        `${ALLOC_ARM.boundaries} boundaries (${ROOTS} roots x ${ALLOC_CELLS} cells) x ` +
-        `${ALLOC_ARM.writes} writes:\n` +
+        `${ALLOC_ARM.boundaries === null ? 'no page stated' : `${ALLOC_ARM.boundaries} boundaries ` +
+          `(${ROOTS} roots x ${ALLOC_CELLS} cells)`} x ${ALLOC_ARM.writes} writes:\n` +
         ALLOC_ARM.refusals.map((r) => `  - ${r}`).join('\n')
     );
   }
@@ -1464,7 +1484,19 @@ async function allocRow(chromium) {
     // --- the arms, in the order this round's parity dictates ------------
     const segs = round % 2 === 0 ? plan : [...plan].slice().reverse();
     for (const { segment, arms } of segs) {
-      await page.evaluate((s) => window.P0H.prepare(s), segment);
+      // THE GRID WIDTH IS B, AND IT IS SEEDED WITH THE FRAME (rf2-2rtt6.140).
+      // `:p0/write-page` rebuilds `:cells` at the width the mounted page
+      // actually reads — one cell per boundary — so the write's own machinery
+      // is O(mounted page) instead of the flat 300-element rebuild
+      // `:p0/write-all` performs whether one boundary is mounted or 1,200. On
+      // the 24-boundary page this row last ran, 276 of those 300 rebuilt cells
+      // were read by nothing at all.
+      //
+      // Passed here rather than set ambiently: the width has to be seeded
+      // BEFORE `make-frame`, and a parameter that is never ambient cannot be
+      // set in the wrong order relative to seeding. Every OTHER row passes
+      // nothing and seeds at `fx/cells-n`, so no published figure moves.
+      await page.evaluate(([s, gw]) => window.P0H.prepare(s, gw), [segment, B]);
       const drain = segment === 'reagent-subs' ? 'reagent' : 'react';
       const order = await page.evaluate(
         ([n, r]) => window.P0H.slotOrder(n, r),
@@ -1581,20 +1613,21 @@ async function allocRow(chromium) {
     preciseMemory: precise,
     controlDoubles: { d1: ALLOC_D, d2: ALLOC_D2 },
     controlSlack: ALLOC_CONTROL_SLACK,
+    write: ':p0/write-page — the grid is rebuilt at the width the mounted page reads',
     instrument:
       'in-page performance.memory.usedJSHeapSize sampled at every leg boundary, ' +
       'rising steps accumulated separately from falling ones; --enable-precise-memory-info. ' +
-      'A falling step is a collection this counter SAW; a window over the masking budget is ' +
-      'one it could not have seen, and both refuse',
+      'A falling step is a collection this counter SAW; a leg that deviates from its cohort ' +
+      'median by more than the leg tolerance is a work unit that is not one, and both refuse',
     fallThresholdB: ALLOC_FALL_THRESHOLD_B,
-    maskBudgetB: ALLOC_MASK_BUDGET_B,
+    legTolerance: ALLOC_LEG_TOLERANCE,
     verification: { unverified, detail: unverifiedDetail },
     perRound: rounds,
     allocFits: fits,
   };
 }
 
-function summariseAlloc(row, maskable) {
+function summariseAlloc(row, refused) {
   const B = row.boundaries;
   console.log('\n;; ==== P0 STEADY-STATE ALLOCATION — WARM 1/3/7/20 READS (rf2-2rtt6.76) ====');
   console.log(
@@ -1608,48 +1641,36 @@ function summariseAlloc(row, maskable) {
   console.log(';; The arm stays MOUNTED across the window: this is what a standing page');
   console.log(';; allocates when it is written to, not what a mount costs.');
 
-  // THE ARM'S SIZE, AND THE ARITHMETIC THAT CHOSE IT (rf2-2rtt6.138). Printed
-  // beside the figures rather than left in a source comment, because the one
-  // question a reader of this table has to be able to answer is which page it
-  // was taken on — the published 1,200-boundary witness is outside this
-  // instrument's range and its refusal is what put this arm here.
+  // THE ARM'S SIZE, AND WHERE IT CAME FROM (rf2-2rtt6.140). Printed beside the
+  // figures rather than left in a source comment, because the one question a
+  // reader of this table has to be able to answer is which page it was taken
+  // on — the published 1,200-boundary witness is outside this instrument's
+  // range and its refusal is what put this arm here.
   const a = row.arm;
   const publishedB = row.roots * row.publishedPerRoot.grid;
-  const publishedWindow = allocArmSizing({
-    writes: a.writes,
-    roots: row.roots,
-    cells: row.publishedPerRoot.grid,
-  });
   console.log(';;');
-  console.log(';; ==== THE SMALL-WITNESS ARM (rf2-2rtt6.138) ====');
+  console.log(';; ==== THE PAGE, AND THE WRITE (rf2-2rtt6.140) ====');
   console.log(
     `;;   ${a.cells} cells x ${a.roots} roots = ${a.boundaries} boundaries, ${a.writes} writes a ` +
-      'window. The measured unit is the BOUNDARY, so shrinking'
+      `window. STATED, never derived: rf2-2rtt6.139`
   );
   console.log(
-    ';;   the PAGE is what puts a many-write window under the fall threshold — not shrinking the'
-  );
-  console.log(';;   window, which is the direction that leaves a fit with nothing to average.');
-  console.log(
-    `;;   PREDICTED (W+1).B.c at the measured ${a.bytesPerBoundaryWrite} B/boundary/write: ` +
-      `${n0(a.predictedRise)} B rise + ${n0(a.predictedMaxStep)} B largest step = ` +
-      `${n0(a.predictedWindowB)} B,`
+    ';;   retired the sizing constant as read off a run that itself refused, and no replacement'
   );
   console.log(
-    `;;   against the ${ALLOC_MASK_BUDGET_B} B masking budget — headroom ${n0(a.headroom)} B. ` +
-      `The published ${publishedB}-boundary witness`
+    `;;   may be substituted, so P0_ALLOC_CELLS is mandatory. The published ${publishedB}-boundary`
+  );
+  console.log(';;   witness is what this row is NOT.');
+  console.log(
+    `;;   THE WRITE IS \`:p0/write-page\`, which rebuilds the grid at ${B} cells — one per mounted`
   );
   console.log(
-    `;;   predicts ${n0(publishedWindow.predictedWindowB)} B on the same window, and the row ` +
-      'would refuse it. That refusal is why this arm exists.'
+    ";;   boundary. `:p0/write-all` rebuilt 300 whatever was mounted, and that fixed cost was"
   );
   console.log(
-    ';;   A PREDICTION, NOT A CERTIFICATE: what certifies a window is the bound read off that'
+    ';;   57% of the retired budget before a single boundary had been measured. The clock and'
   );
-  console.log(
-    ";;   window's OWN samples, below. The fixed per-write cost of `:p0/write-all` is in every"
-  );
-  console.log(';;   window here and in no term of the prediction.');
+  console.log(';;   bulk rows still drive `:p0/write-all`, unchanged, at the published width.');
 
   // --- the controls, adjudicated ----------------------------------------
   console.log(';;');
@@ -1700,10 +1721,21 @@ function summariseAlloc(row, maskable) {
   );
   const wins = row.perRound.reduce((a, r) => a + Object.keys(r.arms).length, 0);
   console.log(';;');
+  // A RECORDED FACT, GATING NOTHING (rf2-2rtt6.140). It is an UPPER bound on
+  // where the first collection runs and the retired masking budget needed a
+  // LOWER one; it stays at its measured value and is printed because a
+  // window's rise as a fraction of it is a useful thing for a reader to see.
+  const risesSeen = row.perRound.flatMap((r) => Object.values(r.arms).map((x) => x.rise));
   console.log(
-    `;;   measured fall threshold: ~${row.fallThresholdB} B of cumulative garbage per window. ` +
-      'Enlarging the young generation does NOT move it (128 MB and 512 MB tried).'
+    `;;   measured fall threshold: ~${row.fallThresholdB} B of cumulative garbage per window ` +
+      '(RECORDED, gates nothing). Enlarging the young generation does NOT move it.'
   );
+  if (risesSeen.length) {
+    console.log(
+      `;;   largest arm-window rise seen: ${n0(Math.max(...risesSeen))} B = ` +
+        `${((Math.max(...risesSeen) / row.fallThresholdB) * 100).toFixed(0)}% of that threshold`
+    );
+  }
   console.log(
     `;;   collections seen inside arm windows: ${falls} falling steps across ${wins} windows ` +
       '(a fall is EXCLUDED from the rising sum, never netted against it)'
@@ -1720,28 +1752,36 @@ function summariseAlloc(row, maskable) {
   // predicted answer is zero.
   row.fallsInMeasuredWindows = falls;
 
-  // THE MASKING WITNESS (rf2-n6w7o), which is the fall gate's blind side and
-  // a SECOND exit, not a softening of the first. A collection that runs
-  // inside a leg allocating at least as much as it reclaims never turns a
-  // step negative, so the line above reports 0 and the window under-reads
-  // with nothing to say so. See ALLOC_MASK_BUDGET_B for the arithmetic that
-  // makes that case unreachable below the budget rather than merely
-  // improbable.
-  const headrooms = row.perRound.flatMap((r) => Object.values(r.arms).map((x) => x.headroom));
-  row.maskableWindows = maskable.length;
+  // THE OBSERVED-COLLECTION WITNESS (rf2-2rtt6.140), which is the fall gate's
+  // blind side and a SECOND exit, not a softening of the first. A collection
+  // that runs inside a leg allocating at least as much as it reclaims never
+  // turns a step negative, so the line above reports 0 and the window
+  // under-reads with nothing to say so. This one reads the window's own legs
+  // and asks whether they look like repetitions of one work unit.
+  const deviations = row.perRound.flatMap((r) =>
+    Object.values(r.arms)
+      .map((x) => x.legWorstDeviation)
+      .filter((x) => typeof x === 'number')
+  );
+  row.refusedWindows = refused.length;
   console.log(
-    `;;   masking budget: ${ALLOC_MASK_BUDGET_B} B per window (the measured fall threshold, ` +
-      'HALVED) on rise PLUS the largest single step. At or under it no collection can have'
+    `;;   leg tolerance τ = ${(row.legTolerance * 100).toFixed(0)}% of the window's own leg ` +
+      'MEDIAN, two-sided. The legs of a window are W repetitions of ONE'
   );
   console.log(
-    ';;   run at all, masked or otherwise; above it a collection can hide behind the window\'s ' +
-      'own growth and `falls` = 0 stops meaning the reading is clean'
+    ';;   work unit, so a leg below its cohort is a leg something removed bytes from and a leg'
   );
   console.log(
-    `;;   windows over budget: ${maskable.length} of ${wins}` +
-      (headrooms.length ? `  (tightest headroom ${n0(Math.min(...headrooms))} B)` : '')
+    ';;   above it is a window whose one-work-unit premise failed. An ADMITTED window under-reads'
   );
-  for (const m of maskable) console.log(`;;   MASKABLE ${m}`);
+  console.log(`;;   its true allocation by AT MOST 2τ = ${(row.legTolerance * 200).toFixed(0)}%.`);
+  console.log(
+    `;;   windows refused: ${refused.length} of ${wins}` +
+      (deviations.length
+        ? `  (worst leg deviation observed ${(Math.max(...deviations.map(Math.abs)) * 100).toFixed(1)}%)`
+        : '')
+  );
+  for (const m of refused) console.log(`;;   REFUSED ${m}`);
 
   console.log(
     `;;   verification: ${row.verification.unverified} unverified ` +
@@ -2282,11 +2322,11 @@ function summariseFanout(row) {
 module.exports = {
   ladderStructuralFailures,
   allocSteps,
-  allocMaskableWindows,
-  ALLOC_MASK_BUDGET_B,
+  allocRefusedWindows,
+  ALLOC_LEG_TOLERANCE,
+  ALLOC_FALL_THRESHOLD_B,
   ladderPlan,
   allocArmSizing,
-  allocMaxWrites,
   ALLOC_MIN_WRITES,
   ALLOC_ARM,
 };
@@ -2419,8 +2459,8 @@ if (require.main === module) (async () => {
     if (wantAlloc) {
       console.error('[p0] steady-state allocation row ...');
       out.alloc = await allocRow(chromium);
-      const maskable = allocMaskableWindows(out.alloc);
-      summariseAlloc(out.alloc, maskable);
+      const refusedWindows = allocRefusedWindows(out.alloc);
+      summariseAlloc(out.alloc, refusedWindows);
       if (out.alloc.verification.unverified > 0) {
         failures.push(
           `alloc: ${out.alloc.verification.unverified} unverified — ` +
@@ -2448,23 +2488,22 @@ if (require.main === module) (async () => {
             'refuses is the arms\' scale, not the method'
         );
       }
-      // AND ITS BLIND SIDE (rf2-n6w7o). The gate above sees a collection
-      // only when it turns a step negative. One that runs inside a leg
-      // allocating at least as much as it reclaimed turns nothing negative,
-      // so that gate reports a clean window while the reclaimed bytes are
-      // missing from `rise`. This one refuses any window merely LARGE ENOUGH
-      // for that to have happened, which is a bound rather than a detector —
-      // see ALLOC_MASK_BUDGET_B. It is additional to the falling-step gate
-      // and replaces none of it.
-      if (maskable.length > 0) {
+      // AND ITS BLIND SIDE (rf2-2rtt6.140, superseding rf2-n6w7o). The gate
+      // above sees a collection only when it turns a step negative. One that
+      // runs inside a leg allocating at least as much as it reclaimed turns
+      // nothing negative, so that gate reports a clean window while the
+      // reclaimed bytes are missing from `rise`. This one reads the window's
+      // OWN legs — W repetitions of one work unit — and refuses the window
+      // where one of them does not look like the others. It is additional to
+      // the falling-step gate and replaces none of it.
+      if (refusedWindows.length > 0) {
         failures.push(
-          `alloc: ${maskable.length} windows over the ${ALLOC_MASK_BUDGET_B} B masking ` +
-            'budget — at that scale a collection can run inside a leg that allocates at least as ' +
-            'much as it reclaims, so no step goes negative, the falling-step gate above reports a ' +
-            'clean window, and the reclaimed bytes are missing from `rise` with nothing to say ' +
-            'so. Every figure from such a window is an UNDER-estimate of unknown size, and ' +
-            'under-reading is the direction that manufactures HD-002\'s flat-at-zero. SHRINK THE ' +
-            `MEASURED UNIT, DO NOT WIDEN THE BUDGET. First: ${maskable[0]}`
+          `alloc: ${refusedWindows.length} windows have a work leg that deviates from its own ` +
+            'cohort median by more than the leg tolerance. A leg BELOW its cohort is a leg ' +
+            'something removed bytes from and nothing in the work unit removes bytes; a leg ' +
+            'ABOVE it is a window whose ONE WORK UNIT premise failed. Either way the window ' +
+            "under-reads by an unknown amount, and under-reading manufactures HD-002's " +
+            `flat-at-zero. DO NOT WIDEN THE TOLERANCE. First: ${refusedWindows[0]}`
         );
       }
     }

--- a/implementation/core/test/re_frame/bench/p0_write_page_cljs_test.cljs
+++ b/implementation/core/test/re_frame/bench/p0_write_page_cljs_test.cljs
@@ -49,22 +49,35 @@
 
 (def ^:private frame-id :p0.wp/frame)
 
+;; THE IMAGE IS SCOPED TO THE FIXTURE'S OWN NAMESPACE, and it has to be.
+;; `:p0/cell` is registered THREE times across this repo — here in
+;; `p0-fixture`, and again in `hicasso/clock_views` and
+;; `hicasso/p0_reagent_views`, each with its own implementation. The p0
+;; release builds put exactly one of those namespaces on the classpath, so
+;; the collision is unreachable there; the consolidated `:node-test` build
+;; loads all three, and image assembly correctly refuses to let selection
+;; order decide which one a frame runs (`:rf.error/image-duplicate-id`).
+;;
+;; So this suite says which it means. That is the error's own first remedy
+;; and it is the right one: a bench fixture suite asserting the fixture's
+;; contract should be running the fixture's registrations and no one else's.
+(def ^:private fixture-image
+  (rf/image {:id :p0.wp/app :select-ns {:include ["re-frame.bench.p0-fixture"]}}))
+
 (defn- frame-at
   "Stand a frame up seeded at `width` cells, with `q` unique fan keys —
   the same two moves `p0-arms/enter-segment!` and `p0-heap/mount!` make,
-  in the same order (the key space is set BEFORE the page reads it).
-
-  The whole-db sub is this suite's own and exists so the assertions can
-  read `:cells` directly; nothing in the fixture registers one, and the
-  arms deliberately do not — a whole-db read would re-render every
-  boundary on every write and make the NARROW row unmeasurable."
+  in the same order (the key space is set BEFORE the page reads it)."
   [width q]
   (fx/register!)
-  (rf/reg-sub :p0.wp/db (fn [db _] db))
   (fx/set-fan-keys! q)
-  (rf/make-frame {:id frame-id :initial-events [[:p0/seed width]]}))
+  (rf/make-frame {:id frame-id :images [fixture-image] :initial-events [[:p0/seed width]]}))
 
-(defn- db [] (rf/subscribe-once [:p0.wp/db] {:frame frame-id}))
+;; Read straight off the frame rather than through a whole-db subscription:
+;; the fixture deliberately registers none, because a whole-db read would
+;; re-render every boundary on every write and make the NARROW row
+;; unmeasurable by construction.
+(defn- db [] (rf/app-db-value frame-id))
 
 (defn- fan [k] (rf/subscribe-once [:p0/fan k] {:frame frame-id}))
 

--- a/implementation/core/test/re_frame/bench/p0_write_page_cljs_test.cljs
+++ b/implementation/core/test/re_frame/bench/p0_write_page_cljs_test.cljs
@@ -1,0 +1,195 @@
+(ns re-frame.bench.p0-write-page-cljs-test
+  "rf2-2rtt6.140 — the BOUNDARY-PROPORTIONAL WRITE, adjudicated hermetically.
+
+  `:p0/write-page` exists because `:p0/write-all` rebuilds a 300-element
+  vector and drives the whole event pipeline whether one boundary is
+  mounted or 1,200. On this rig that fixed cost measured F ~ 24.4 KB per
+  write (24,108 B on `reagent-subs`, 24,730 on `uix-subs`) and it does not
+  shrink when the page does — which is what made the allocation ladder
+  uncertifiable at any page size.
+
+  WHY A CLJS SUITE AND NOT THE ALLOCATION ROW. The allocation row is an
+  `:advanced` release build driven by hand behind an opt-in flag, in no
+  gate at all, and rf2-2rtt6.140's criterion 5 freezes it until its
+  validity witnesses are green. So the write's CONTRACT — as opposed to
+  its cost — has to be checkable without a browser, on every PR. That is
+  what this suite is: no DOM, no adapter beyond the plain atom, no
+  measurement.
+
+  WHAT IT PINS is the equivalence argument's checkable half. The claim the
+  ladder makes is about steady-state allocation per boundary per warm
+  read, so the stimulus has one job: for every mounted boundary it must
+  invalidate all R of its subscriptions and deliver R CHANGED values.
+
+    - the seeded grid is the width the caller stated, not `fx/cells-n`;
+    - `:p0/fan` folds every key into THAT grid, so the key space and the
+      db cannot disagree about how wide the page is;
+    - one `:p0/write-page` changes EVERY key a mounted page reads, which
+      is the invalidation set being identical rather than merely similar;
+    - a boundary's rendered text stays `(str (* R v))`, which is what
+      leaves the DOM read-back and the canonical-DOM gate unchanged;
+    - and `:p0/write-all` is untouched, at the published 300, because the
+      clock and bulk rows publish figures taken with it.
+
+  NOTHING HERE MEASURES ANYTHING. The cost claim — that the fixed residue
+  is no longer dominant — is validity witness V1's, and V1 needs a quiet
+  box that criterion 5 has not granted.
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up via
+  `:ns-regexp \"cljs-test$\"`; `core/test` is already on that build's
+  source paths."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.bench.p0-fixture :as fx]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private frame-id :p0.wp/frame)
+
+(defn- frame-at
+  "Stand a frame up seeded at `width` cells, with `q` unique fan keys —
+  the same two moves `p0-arms/enter-segment!` and `p0-heap/mount!` make,
+  in the same order (the key space is set BEFORE the page reads it).
+
+  The whole-db sub is this suite's own and exists so the assertions can
+  read `:cells` directly; nothing in the fixture registers one, and the
+  arms deliberately do not — a whole-db read would re-render every
+  boundary on every write and make the NARROW row unmeasurable."
+  [width q]
+  (fx/register!)
+  (rf/reg-sub :p0.wp/db (fn [db _] db))
+  (fx/set-fan-keys! q)
+  (rf/make-frame {:id frame-id :initial-events [[:p0/seed width]]}))
+
+(defn- db [] (rf/subscribe-once [:p0.wp/db] {:frame frame-id}))
+
+(defn- fan [k] (rf/subscribe-once [:p0/fan k] {:frame frame-id}))
+
+;; ---------------------------------------------------------------------------
+;; The grid width is a property of the SEEDED DB
+;; ---------------------------------------------------------------------------
+
+(deftest the-seeded-grid-is-the-width-the-caller-stated
+  (testing "rf2-2rtt6.140 — `seed-db` takes the width and `:p0/seed` carries
+            it, so the page a frame is standing on is stated at the one place
+            the frame is stood up. The brief's V2 configuration is B=4, and
+            this is that page."
+    (frame-at 4 1)
+    (is (= 4 (count (:cells (db)))) "four cells, one per mounted boundary")
+    (is (= [0 0 0 0] (:cells (db))) "seeded to zero, as the published grid is")
+    ;; The other two seeded surfaces are untouched by the width — a width
+    ;; parameter that quietly resized the list or the form would make the
+    ;; mount rows incomparable across the change.
+    (is (= fx/w1-rows (count (:rows (db)))))
+    (is (= fx/w3-fields (count (:fields (db)))))))
+
+(deftest an-unstated-width-is-the-published-page-to-the-byte
+  (testing "every caller that passes nothing — the clock rows, the bulk rows,
+            the fan-out sweep, the retention ladder — gets `fx/cells-n`. No
+            published figure may move on the strength of this change."
+    (is (= fx/cells-n (count (:cells (fx/seed-db)))))
+    (is (= (fx/seed-db) (fx/seed-db fx/cells-n))
+        "the default arity is the stated one at the published width")))
+
+;; ---------------------------------------------------------------------------
+;; The invalidation set is IDENTICAL — the crux of the equivalence argument
+;; ---------------------------------------------------------------------------
+
+(deftest write-page-rebuilds-at-the-db-s-own-width
+  (testing "the handler reads its width off the db it is handed, so there is
+            no second place for the width to live and drift."
+    (frame-at 4 1)
+    (rf/dispatch-sync [:p0/write-page 7] {:frame frame-id})
+    (is (= [7 7 7 7] (:cells (db))) "four cells wide, every one of them changed")
+    (rf/dispatch-sync [:p0/write-page 9] {:frame frame-id})
+    (is (= [9 9 9 9] (:cells (db))) "and it is still four wide on the next write")))
+
+(deftest every-key-a-mounted-page-reads-sees-a-changed-value
+  (testing "THE EQUIVALENCE ARGUMENT'S CHECKABLE HALF. The ladder mounts at
+            Q = E, so B boundaries x R reads is B·R distinct `:p0/fan` keys,
+            and `(n·R + j) mod Q` is the identity over 0 … B·R−1. Each folds
+            into the grid under `(mod k width)`. One `:p0/write-page` must
+            move EVERY one of them — that is the invalidation set being
+            identical to `:p0/write-all`'s, not merely similar to it."
+    (let [b 4, r 20, q (* b r), width b]
+      (frame-at width q)
+      (is (every? zero? (map fan (range q))) "the seeded page answers 0 everywhere")
+      (rf/dispatch-sync [:p0/write-page 3] {:frame frame-id})
+      (is (= width (count (:cells (db)))) "the write did not resize the grid")
+      (is (every? #(= 3 %) (map fan (range q)))
+          "all 80 edges of the B=4, R=20 rung see the new value")
+      ;; And the keys the ladder actually mounts, through the same rule the
+      ;; arms use rather than through a restatement of it.
+      (is (every? #(= 3 %)
+                  (for [n (range b), j (range r)] (fan (fx/fan-key n r j))))
+          "read through `fx/fan-key`, which is what the arms read through"))))
+
+(deftest the-rendered-text-is-unchanged-so-the-read-back-gate-is
+  (testing "a boundary's text is the sum of its R reads, so at a page written
+            to `v` it is `R·v` under EITHER write. That is what leaves the DOM
+            read-back, the canonical-DOM comparison and the floor subtraction
+            unchanged — the driver states its expectation as `String(R * tick)`
+            and this is the arithmetic behind it."
+    (let [b 4, r 7, q (* b r)]
+      (frame-at b q)
+      (rf/dispatch-sync [:p0/write-page 5] {:frame frame-id})
+      (doseq [n (range b)]
+        (is (= (* r 5) (reduce + (map #(fan (fx/fan-key n r %)) (range r))))
+            (str "boundary " n " renders R·v"))))))
+
+(deftest two-keys-folding-onto-one-slot-is-not-new
+  (testing "`:p0/fan` has folded `mod cells-n` since rf2-5prok, and at B=24,
+            R=20 the published page already folds 480 keys onto 300 slots. What
+            changes is only WHICH grid they fold into, and folding does not
+            cost a key its invalidation: distinct keys sharing a slot all see
+            the write."
+    (frame-at 4 480)
+    (rf/dispatch-sync [:p0/write-page 2] {:frame frame-id})
+    (is (= [2 2 2 2] (:cells (db))))
+    (is (every? #(= 2 %) (map fan (range 480)))
+        "480 distinct query keys over a 4-cell grid, every one of them changed")))
+
+;; ---------------------------------------------------------------------------
+;; `:p0/write-all` is BYTE-IDENTICAL, because its rows are published
+;; ---------------------------------------------------------------------------
+
+(deftest write-all-still-rebuilds-the-published-grid-whatever-is-mounted
+  (testing "rf2-2rtt6.140 leaves `:p0/write-all` exactly as it is, literal
+            `cells-n` and all: it is the bulk clock row's write, its rows are
+            published, and it stays byte-identical. On a 4-cell page it
+            therefore RESIZES the grid back to 300 — which is precisely the
+            cost the allocation row stopped paying, made visible."
+    (frame-at 4 1)
+    (is (= 4 (count (:cells (db)))))
+    (rf/dispatch-sync [:p0/write-all 1] {:frame frame-id})
+    (is (= fx/cells-n (count (:cells (db))))
+        "300 cells rebuilt on a page that reads four of them")
+    (is (every? #(= 1 %) (:cells (db))))))
+
+(deftest write-all-and-write-page-agree-at-the-published-width
+  (testing "the two writes are the SAME WRITE at the page `:p0/write-all` was
+            written for. A difference here would mean the new event is not a
+            width-parameterised form of the old one but a second thing."
+    (frame-at fx/cells-n 300)
+    (rf/dispatch-sync [:p0/write-all 4] {:frame frame-id})
+    (let [after-all (:cells (db))]
+      (rf/dispatch-sync [:p0/seed fx/cells-n] {:frame frame-id})
+      (rf/dispatch-sync [:p0/write-page 4] {:frame frame-id})
+      (is (= after-all (:cells (db)))
+          "identical `:cells` at width 300, so the difference is the width alone"))))
+
+;; ---------------------------------------------------------------------------
+;; `:p0/write-one` — the point write, unmoved
+;; ---------------------------------------------------------------------------
+
+(deftest the-narrow-write-is-untouched
+  (testing "the NARROW row's write changes one slot and must keep changing
+            exactly one, whatever the grid width is. HD-002's law is stated
+            about the CHANGE, so the narrow row and the bulk row have to stay
+            different sizes of change."
+    (frame-at 4 4)
+    (rf/dispatch-sync [:p0/write-one 2 8] {:frame frame-id})
+    (is (= [0 0 8 0] (:cells (db))) "one slot moved, three did not")))


### PR DESCRIPTION
Implements criteria 2, 3 and 4 of `rf2-2rtt6.140`, to the design settled in
[`docs/design/hicasso/allocation-instrument-rework.md`](https://github.com/day8/re-frame2/blob/main/docs/design/hicasso/allocation-instrument-rework.md)
(criterion 1, merged as #7697). **The bead stays OPEN**: criterion 5's
measurement freeze stands and the validity witnesses remain.

## NEITHER ARTEFACT HAS BEEN EXECUTED AGAINST A REAL PAGE

Stated first, because it is the shape of the deliverable and not a caveat on
it. **No allocation window was opened. No ladder row was taken. No quiet box
was requested.** The measurement lane is stood down and criterion 5 forbids
any window until the validity witnesses are green, so **`:p0/write-page` has
never written to a mounted page and the leg witness has never read a real
sample stream.** Both are proven **structurally only** — 50 hermetic pins in
`p0_ladder_structural.test.cjs` and 9 hermetic CLJS suites, every window in
them a synthetic sample buffer and every frame a plain-atom test frame.

**V1** (the floor at B ∈ {4, 24, 96} under both writes), **V2** (the
equivalence cross-check) and **V3** (calibrating τ) all await a measurement
window. **V4 — the pinned probes — is discharged here**, because it is pure
test and needs no browser. `ALLOC_LEG_TOLERANCE` is consequently an
**uncalibrated placeholder**, marked as such in the source, and no window may
be published on it.

## What landed

**THE WRITE (criterion 2).** `:p0/write-page` rebuilds `:cells` at the width
the mounted page actually reads. The grid width becomes a **property of the
seeded app-db** — `seed-db` takes it, `:p0/seed` carries it as an event
argument, `enter-segment!` and `p0-heap/prepare!` thread it from the driver —
and `:p0/fan`'s modulus reads `(count (:cells db))`, so the width **cannot
live in two places and drift**. `:p0/write-all` is left **byte-identical**,
literal `cells-n` and all; the clock, bulk, fan-out and retention rows keep
driving it at the published 300, and a structural pin reads that off the
sources rather than trusting it.

The equivalence argument is preserved rather than re-derived: same
`dispatch-sync` through the same pipeline and signal graph; every one of the
`E = B·R` edges sees a changed value so the invalidation set is identical;
rendered text stays `(str (* R v))` so the read-back and canonical-DOM gates
are unchanged; `B`, `E`, `Q` and the key rule untouched. On the 24-boundary
page 276 of the 300 rebuilt cells were read by nothing.

**THE WITNESS (criterion 3).** `(W+1)·perWrite <= ALLOC_MASK_BUDGET_B` is
**retired** and replaced by a rule read off the window's own samples: the work
legs are W repetitions of one work unit, so refuse if any leg deviates from
the cohort **median** by more than `τ·m`. `allocSteps` grows `legs`, `gaps`,
`legMedian`, `legWorstDeviation`, `refusals` and `certified` — mirroring
`allocArmSizing`'s verdict shape since `rf2-2rtt6.142`, so there is one
verdict shape across the preflight and the window gate. `rise`, `fall`,
`falls`, `maxStep` and `endpoints` keep their definitions exactly, so no
published total changes meaning. `allocMaskableWindows` becomes
`allocRefusedWindows` and names every refused window with its reason.

**CONSTRAINT SEMANTICS (criterion 4).** The budget is **retired, not
widened** — replacement is route (b) itself. `ALLOC_FALL_THRESHOLD_B` stays at
its measured 600,000 B and **gates nothing** (the summary now prints the
largest arm-window rise as a percentage of it). **R = 20 stays.**
**`ALLOC_MIN_WRITES = 6` stays a floor.** **The falls gate and the r² floor
are untouched.** `ALLOC_B_PER_BOUNDARY_WRITE`, `allocMaxWrites`,
`predictedWindowB`, `headroom`, `maxBoundaries`, `floorBoundaries` and
`maskable` go with the budget, because every one of them was that constant's
arithmetic under a different name.

**THE `.139` SEAM.** `P0_ALLOC_CELLS` becomes **mandatory** — no honest
default exists without a sizing model, and a mandatory page makes an
accidental publication run impossible while criterion 5's freeze holds. No
sizing constant is derived here; that is `.139`'s, sequenced behind V1.

**CRITERION 6** (see *What this dispatch got wrong*, below).
`the-survival-metrics-allocation-half.md` is **annotated, never erased**: a
dated supersession note at the head and at the small-witness section, every
figure and every table standing, and `F_old` named as the one figure that
keeps its full force because V1 re-measures it as the control that licenses
the comparison at all.

## The mutation proofs

**Red-then-green, in two commits**, as `rf2-n6w7o` and `rf2-2rtt6.142` both
did. Commit `059d4fb` adds the six new pins against the unrepaired driver;
commit `72d4eaa` is the repair.

| pin | red at `059d4fb` | green at `72d4eaa` |
|---|---|---|
| V4 probe A — 300 KB true, admitted at headroom 0 | `certified` was `undefined` | refused, naming leg 5 of 5 |
| V4 probe B — 600 KB true, admitted at headroom 0 | `certified` was `undefined` | refused, naming leg 6 of 6 |
| the net-growth masking case, on leg grounds | `certified` was `undefined` | refused, naming leg 3 of 4 |
| τ-independence across `τ ∈ [0, 1)` | `certified` was `undefined` | refused at every τ |
| not vacuous — clean and idle both certify | `certified` was `undefined` | both certify |
| mandatory `P0_ALLOC_CELLS` | **`true !== false`** — the driver derived a default page | refused by name |

Verbatim from the red run: `p0_ladder_structural.test.cjs: 6/56 failed`. The
mandatory-page pin is the one that failed on a *value* rather than an absent
field, which is the sharper red: the shipped preflight really did derive and
admit an arm with no page stated.

**Structural test counts: 50 → 49 → 50.** The brief's disposition retires more
than it adds; the certificate pin below is the one addition beyond it.

## How I established that nothing loosened

Three separate arguments, because "nothing loosened" means three different
things once the budget is retired by criterion 4.

**1. The falls gate never admits where it refused.** Exhaustive over 17,496
synthetic window shapes (3 legs × 9 magnitudes each × a reclaim on each leg ×
6 reclaim sizes), driven against the **shipped module**: `0` violations. Every
window with a falling step is still refused.

**2. The preflight only ever refuses more.** Exhaustive over
`W ∈ 0..40 × cells ∈ 0..40 × roots ∈ {0,1,4,50}` (4,200 admitted): every
admitted arm satisfies both surviving `rf2-2rtt6.142` terms
(`boundaries >= 1 && writes >= ALLOC_MIN_WRITES`), and **`0`** arms satisfying
those terms are refused. The one genuinely new refusal is the unstated page,
which refuses a configuration that used to be admitted — the permitted
direction.

**3. The window gate is a replacement, so subset is the wrong test — and I
say so rather than claiming otherwise.** Retiring the budget necessarily
admits windows the budget refused; the brief's own arithmetic *requires* it
(a ~630 KB window must be admittable, or the package delivers nothing), and
the disposition retires `THE CHANGE ONLY EVER REFUSES MORE` for exactly this
reason — "it compares against a bound that no longer exists". In the sweep,
**36 of 17,496** shapes moved from refused to admitted, and **all 36 are over
the retired 300,000 B budget** — i.e. every one is the sanctioned direction,
and none is a masked window slipping through. What replaces the subset claim:

- **Both audit probes moved from admitted to refused.** Measured against the
  shipped module: probe A and probe B each sat at `headroom = 0` under the old
  bound — admitted — with true allocations of 300 KB and 600 KB, and both are
  now refused.
- **98.1% of masked windows in the sweep (4,527 of 4,617) are refused** by the
  leg rule. The remainder are the bounded under-read the certificate names.
- **The 2τ certificate holds, and holds tight.** Swept over 20,096 windows
  *inside the cohort premise* — the certificate's own stated antecedent, that
  absent a collection each leg's true allocation lies within τ of the true
  median: worst per-leg masked reclamation **50.00%** of the median against a
  `2τ` ceiling of 50%, worst whole-window under-read 10.00%. The worst case is
  exactly the shape the brief predicts — a leg sitting `τ·m` high on its own
  merits, losing `2τ·m`, reading `τ·m` low, admitted at the very edge — and
  **one byte further refuses**. That case is now pinned
  (`THE CERTIFICATE IS TIGHT`), so `2τ` is a bound rather than an
  approximation. Outside the premise the certificate says nothing and the
  brief says so; that is the homogeneous-masking hole `rf2-n6w7o` already
  named unreachable in-page.

## The disposition table

All 36 rows applied as written; the buckets total 36.

**KEPT** (18): the falls-gate pin verbatim; `maxStep`, which survives as a
reported diagnostic; the masking defect, the not-vacuous window, the idle
window, the clean row, the empty row, the row-level naming (renamed), and the
driver-exit wiring, all re-pointed at the leg verdict; `ladderPlan`, the
small-arm plan, the driver's pre-browser refusal, the enforced averaging
floor, `ROUTE 2` (green and unchanged), `THE CONTROL` at an explicitly stated
page, the `ALLOC_MIN_WRITES` floor, the one-reason-per-fault refusal, and the
empty-page/empty-window refusal.

**KEPT and STRENGTHENED** (1): the retention ladder now also asserts, off the
CLJS sources, that the retention rows still drive `:p0/write-all` at the
published width and that `prepare!`'s default arity is `per-root`.

**AMENDED** (1): the refusal names the window and never a page it cannot size
— the branch was budget-derived, its trigger is gone, and the endorsed
property survives because the collapsed message names no shape at all.

**REPLACED** (2): the exact boundary is now at τ, checked in both directions
because the rule is two-sided; and `NET GROWTH CANNOT DEFEAT IT` becomes
`A MASKED LEG READS BELOW ITS COHORT`.

**RE-POINTED** (1): `ROUTE 1` at the mandatory-page refusal.

**RETIRED** (13), of which two (`the budget is the measured fall threshold
HALVED` and `the budget is DERIVED … and has no dial on it`) collapse into one
replacement pin, `the tolerance is CALIBRATED, pinned, and has no dial on it`.

**I disagreed with none of it.** Four additions beyond the table, each closing
something it left implicit: `the retired masking budget is GONE, not widened`
(criterion 4 as a fact about the source rather than a sentence in a brief),
`LEGS AND GAPS are read apart`, `the clock and bulk rows are not moved
either`, and `THE CERTIFICATE IS TIGHT`.

**One discrepancy, reported not resolved:** the brief and the bead both say
"37 rows"; the table as written has **36**. I dispositioned all 36 and nothing
appears to be missing — I read it as a miscount in the prose, not a lost row.

## New, beyond the table

`implementation/core/test/re_frame/bench/p0_write_page_cljs_test.cljs` — nine
hermetic CLJS deftests, no browser, no DOM, plain-atom adapter. They pin the
seeded width, the default width (so no published figure moves), that one
`:p0/write-page` changes **every** key a `B=4, R=20` page reads (all 80 edges,
read through `fx/fan-key` itself rather than a restatement of it), that a
boundary's text stays `R·v`, that 480 keys folding onto a 4-cell grid all see
the write, that `:p0/write-all` still resizes to 300 on a 4-cell page, that
the two writes agree exactly at the published width, and that `:p0/write-one`
still moves one slot.

**A real pre-existing collision surfaced in the process** and is worth
flagging: `:p0/cell` is registered in **three** namespaces — `p0_fixture`,
`hicasso/clock_views` and `hicasso/p0_reagent_views` — each with its own
implementation. The p0 release builds carry one of those namespaces, so the
collision is unreachable there; the consolidated `:node-test` build loads all
three and image assembly correctly refuses to let selection order decide
(`:rf.error/image-duplicate-id`). The suite is scoped with
`:select-ns {:include ["re-frame.bench.p0-fixture"]}` — the error's own first
remedy, and the right one for a suite asserting that fixture's contract.

## Quality gates

All foreground, to completion, never piped through `tail`/`head`/`grep`.
Every gate ran from `WORKTREE_ROOT=/c/Users/miket/code/re-frame2-worktrees/allocbuild-140`
(`sh scripts/assert-worker-worktree.sh` → `OK: worker worktree guard passed.`).

| gate | exit | result |
|---|---|---|
| `node --check` on both changed `.cjs` | 0 | clean |
| `node …/p0_ladder_structural.test.cjs` | 0 | **50 passed** (baseline 50; 49 after the disposition, 50 with the certificate pin) |
| `npm run test:script-helpers` (from `implementation/`) | 0 | all suites green, incl. the 50 above |
| `npm run test:cljs` (from `implementation/`) | 0 | **12,812 tests, 64,426 assertions, 0 failures, 0 errors** |
| `sh scripts/test-fast-pr.sh` | 0 | full spine green |
| `npm run lint:js` (repo root) | 0 | eslint clean |
| `python scripts/check_doc_slugs.py` | 0 | the studio-page annotation's anchors resolve |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | 0 | `No beads-database paths in this PR diff.` |

**One flake, diagnosed and not papered over.** The first `test-fast-pr.sh` run
exited 1 at `CLJS node integration` on
`aborted par-compile, … still waiting for …`, cascading across namespaces
unrelated to this change and naming different ones on each attempt.
`scripts/compile-node-test.cjs`'s own header documents this signature exactly:
`par-compile-one`'s 60s `:par-timeout` "seen under box load", self-healing
because shadow-cljs's per-namespace cache is keyed by source hash. It
reproduced once and then cleared on a re-run (`test:cljs` exit 0, same counts),
and the full spine re-run went green end to end. Recorded because a swallowed
root error is worth naming, not because it is this change's.

`mkdocs build --strict` runs inside the spine and passed, but per `CLAUDE.md`
it does **not** cover `docs/design/**` — `exclude_docs` keeps that tree off the
site. `check_doc_slugs.py` validates the tree's link targets and heading
anchors and is green. The studio-page edit adds **no** tables and two
blockquotes; its one same-file anchor
(`#the-fixed-per-write-cost-measured-for-the-first-time`) resolves, verified by
hand and by the validator.

## Also recorded

`rf2-2rtt6.142` is CLOSED and this changes its shipped behaviour: its refusal
text branched on whether the page could carry six writes, that branch was
computed from the budget, and with the budget retired the trigger no longer
exists. The refusal collapses to one arm. Not a regression — with no
page-size model there is no admissible-page figure to name — and the endorsed
property survives because the collapsed message names no shape at all. Its
`ROUTE 2` pin is unchanged and green; its `ROUTE 1` pin is re-pointed at the
mandatory page. A note goes on that bead.

## What this dispatch got wrong

Recorded because the bead governs, then the brief, then the dispatch.

- **The dispatch said criterion 6 remains outstanding.** The bead's criterion 6
  says the studio page annotates "once the new write lands", and the brief says
  "the implementation PR adds a dated note to that page". The new write lands
  here, so the annotation rides here. Done, per bead-then-brief.
- **The dispatch said 37 disposition rows.** So does the brief's prose. The
  table has 36. All 36 are dispositioned.
- **The bead's "a `p0_arms.cljs` / `p0_heap.cljs` question"** is superseded by
  the brief's own correction, which `rf2-2rtt6.142`'s forward note repeats: the
  registration is in `p0_fixture.cljc`. All four files moved, as the dispatch
  correctly anticipated.
- **The dispatch's "50 passed after #7693 — establish the real number
  yourself"** was right to hedge and right on the number: baseline 50.
