### PR TITLE
fix(hicasso): the clock standard's limits, validated out of sample (rf2-c1974)

### DIFF
--- a/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
+++ b/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
@@ -481,10 +481,25 @@ different one, and it is about the *limits* rather than the runs: v2 is seeded
 from the same 14 row-runs it is quoted against, so `14 of 14` is a **consistency
 check and not a false-refusal measurement** (`0.4%` nominal per run, from a
 two-sided 3σ location term and a one-sided 3σ dispersion term). A check standard
-earns its name on a baseline it is not afterwards judged on, and this one has
-not had that yet; the JSON's `provenance.independence` says so where a
-recalibrator will read it, and on this class 14 runs is thin for fixing the
-dispersion term's σ.
+earns its name on a baseline it is not afterwards judged on, and at the time of
+writing this one had not had that; the JSON's `provenance.independence` said so
+where a recalibrator will read it, and on this class 14 runs is thin for fixing
+the dispersion term's σ.
+
+*(2026-08-08, `rf2-c1974`: **the hold-out has since been taken, and on this class
+it came back split.** v3 of the standard replaces the admission above with a
+measurement. Limits fitted on `clock-emvod`'s 8 mount row-runs admit all 6 of
+`clock-w3yxd`; limits fitted on `clock-w3yxd`'s 6 **refuse 4 of `clock-emvod`'s
+8**, every refusal on location and none on dispersion. The cause is not a large
+shift between the sittings — their centres are 1.81% apart, *less* than the bulk
+rows' 2.44% — but `clock-w3yxd`'s own tightness: a between-run SD of `0.0113`
+against `clock-emvod`'s `0.0486`, so a ±3σ budget only `0.0678` wide, which the
+offset alone all but fills. **The limits quoted above are not the failing ones** —
+they pool both sittings, carry the between-session term in their `0.0397` SD, and
+still admit all 14. What the split impeaches is *single-sitting* calibration on
+this class, now a named recalibration trigger. And note what the hold-out is: it
+crosses a **sitting**, same day and same tree, ~90 minutes apart. Commit-level
+independence has still never been measured on this instrument.)*
 
 **For comparison, the retired rule's arithmetic on this row**, since it is what
 the struck labels quoted: every block inside `2.00× ± 25%` put 240 of 252 blocks

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_check_standard.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_check_standard.cjs
@@ -87,10 +87,46 @@
 // reader with the datasets can run the readjudicator and get the row back — and
 // what the row then says is the readjudicator's to state, not this file's.
 //
+// ## v3 — THE LIMITS, VALIDATED OUT OF SAMPLE (rf2-c1974, 2026-08-08)
+//
+// `rf2-8a746` part 3 asks for limits frozen from an INDEPENDENT baseline, and
+// v1 and v2 both said in their own `provenance.independence` fields that they
+// did not have one: seeded from the runs they were quoted against, so `0 of 42`
+// and `14 of 14` were consistency checks and not false-refusal measurements.
+// That was honest and it was also a gap, because the moment a NEW run is judged
+// in control the verdict rests on limits nobody has tested out of sample.
+//
+// WHAT THIS CORPUS CAN SUPPORT, AND WHAT IT CANNOT. `rf2-pzqy8`'s census
+// standard held out a genuinely later COMMIT — its corpus spans five days and a
+// code change. This one does not: every run in both clock ensembles carries a
+// `when` of 2026-08-07 and the two ensembles start 87 minutes apart, on the
+// evidence one tree. So the strongest hold-out available here is by SITTING —
+// derive each class's limits from ONE ensemble, judge the OTHER against them —
+// and the JSON claims exactly that and no more. It crosses a coffee break, not
+// a commit, and the residual is written into `recalibrateOn` as the next
+// ensemble's job rather than left to read as if the criterion were discharged.
+//
+// BOTH WAYS, because one direction's answer depends on which ensemble happened
+// to be picked. On BULK they agree and every held-out row-run is in control, 42
+// of 42. ON MOUNT THEY DISAGREE, and that is the finding: `clock-emvod`'s 8 runs
+// give limits that admit all 6 of `clock-w3yxd`, while `clock-w3yxd`'s 6 give
+// limits that refuse 4 of `clock-emvod`'s 8 — every refusal on LOCATION, none on
+// dispersion. The cause is not a large between-session shift (the centres are
+// 1.81% apart, less than bulk's 2.44%) but the w3yxd sitting's own tightness: a
+// between-run SD under a quarter of emvod's, so a +/-3 sigma budget too narrow
+// to contain the offset. NOTHING WAS WIDENED TO REPAIR IT — the fence this bead
+// was raised under — and nothing needed to be: the shipped limits pool both
+// sittings, so they already carry the between-session component and admit all
+// 14. What the failure impeaches is SINGLE-SITTING CALIBRATION on that class,
+// which is why `recalibrateOn` now names it.
+//
 // Every number above is in the JSON, once. Neither centre is written here, and
 // the fixtures below derive their worlds from the classes' own frozen values
 // for the same reason: a fixture carrying a copy of a limit is a second
-// calibration waiting to drift from the first.
+// calibration waiting to drift from the first. The hold-out is the same rule
+// applied to a hold-out record: the arithmetic that produced it is driven over
+// the committed corpus by `clock_exit_path.test.cjs`, which has the datasets;
+// the fixtures here stay synthetic and check the record's SHAPE and its claims.
 
 'use strict';
 
@@ -511,7 +547,107 @@ function checkStandardSelfTest() {
     'every calibrated class states its provenance and its error rates — a limit with no baseline is an assertion',
     Object.entries(STANDARD.classes)
       .filter(([, k]) => k.calibrated)
-      .every(([, k]) => k.provenance && k.provenance.rowRuns > 0 && /NOT INDEPENDENT/.test(k.provenance.independence || '') && k.errorRates)
+      .every(([, k]) => k.provenance && k.provenance.rowRuns > 0 && k.provenance.independence && k.errorRates)
+  );
+
+  // 8. THE INDEPENDENCE CLAIM IS A MEASUREMENT (rf2-c1974), and the fixtures
+  //    that hold it to that are here rather than only in the corpus test,
+  //    because the corpus is retained and not required to build. What is
+  //    checked here is the RECORD — its shape, its arithmetic against itself,
+  //    and that it claims no more than a session-level hold-out. The numbers
+  //    themselves are re-derived from the committed datasets by
+  //    `clock_exit_path.test.cjs`, which is where the data lives.
+  const calibrated = Object.entries(STANDARD.classes).filter(([, k]) => k.calibrated);
+  check(
+    'every calibrated class carries an out-of-sample hold-out, taken BOTH WAYS',
+    calibrated.every(([, k]) => {
+      const h = k.provenance.holdOut;
+      if (!h || !Array.isArray(h.directions) || h.directions.length !== 2) return false;
+      const bases = h.directions.map((d) => d.baseline).sort();
+      const held = h.directions.map((d) => d.heldOut).sort();
+      // each ensemble serves once as baseline and once as the held-out set —
+      // a "both ways" that reused one baseline would be one direction twice
+      return bases[0] !== bases[1] && JSON.stringify(bases) === JSON.stringify(held);
+    }),
+    calibrated.map(([n, k]) => `${n}:${(k.provenance.holdOut && k.provenance.holdOut.directions || []).length}`).join(' ')
+  );
+  check(
+    'the two baselines PARTITION the class\'s corpus — a hold-out that judged a run it was fitted on is not one',
+    calibrated.every(([, k]) => {
+      const h = k.provenance.holdOut;
+      const sum = h.directions.reduce((a, d) => a + d.baselineRowRuns, 0);
+      return sum === k.provenance.rowRuns && h.directions.every((d) => d.baselineRowRuns + d.heldOutRowRuns === k.provenance.rowRuns);
+    }),
+    calibrated.map(([n, k]) => `${n}: ${k.provenance.holdOut.directions.map((d) => d.baselineRowRuns).join('+')} of ${k.provenance.rowRuns}`).join('; ')
+  );
+  check(
+    'the claim is SESSION-LEVEL and says why it is not commit-level — the weaker claim, made in the file rather than in a PR body',
+    calibrated.every(([, k]) => /SESSION[- ]LEVEL/i.test(k.provenance.holdOut.level) && /does not split by commit/.test(k.provenance.holdOut.whyNotCommitLevel)) &&
+      calibrated.every(([, k]) => /SESSION LEVEL/i.test(k.provenance.independence)),
+    calibrated.map(([n, k]) => `${n}: ${k.provenance.holdOut.level.slice(0, 40)}`).join(' | ')
+  );
+  check(
+    'and the residual is the STANDARD\'s to state: commit-level independence is named as what the next ensemble is for',
+    STANDARD.recalibrateOn.some((r) => /COMMIT-LEVEL INDEPENDENCE HAS NEVER BEEN MEASURED/.test(r)),
+    STANDARD.recalibrateOn.length + ' recalibration triggers'
+  );
+  check(
+    '`agree` is the arithmetic and not an opinion — true exactly when every direction admitted every held-out run',
+    calibrated.every(([, k]) => {
+      const h = k.provenance.holdOut;
+      const allIn = h.directions.every((d) => d.inControl === d.heldOutRowRuns);
+      const totIn = h.directions.reduce((a, d) => a + d.inControl, 0);
+      const totOf = h.directions.reduce((a, d) => a + d.heldOutRowRuns, 0);
+      return h.agree === allIn && h.heldOutInControl === `${totIn} of ${totOf}`;
+    }),
+    calibrated.map(([n, k]) => `${n}: agree=${k.provenance.holdOut.agree} ${k.provenance.holdOut.heldOutInControl}`).join('; ')
+  );
+  check(
+    'a DISAGREEING class states the disagreement and names every refused run and its term — not averaged into a summary',
+    calibrated
+      .filter(([, k]) => k.provenance.holdOut.agree === false)
+      .every(([, k]) => {
+        const h = k.provenance.holdOut;
+        const refused = h.directions.flatMap((d) => d.refused || []);
+        return (
+          typeof h.disagreement === 'string' &&
+          h.disagreement.length > 0 &&
+          refused.length > 0 &&
+          refused.every((r) => r.run && Number.isFinite(r.median) && r.term) &&
+          h.directions.every((d) => (d.refused || []).length === d.heldOutRowRuns - d.inControl)
+        );
+      }),
+    calibrated.filter(([, k]) => k.provenance.holdOut.agree === false).map(([n]) => n).join(',') || 'no class disagreed'
+  );
+  check(
+    'THE FENCE: no hold-out fit became a shipped limit — the frozen limits are still the POOLED ones',
+    calibrated.every(([, k]) =>
+      k.provenance.holdOut.directions.every(
+        (d) =>
+          d.centre !== k.centre &&
+          d.limits[0] !== k.location.limits[0] &&
+          d.limits[1] !== k.location.limits[1] &&
+          d.dispersionLimit !== k.dispersion.limit
+      )
+    ),
+    'a shipped limit equal to a single-ensemble fit would mean the standard had been refitted to make a hold-out pass'
+  );
+  check(
+    'and the pooled limits are not simply the widest available — pooling carried the between-session term, it did not widen',
+    calibrated.every(([, k]) => {
+      const width = k.location.limits[1] - k.location.limits[0];
+      const widths = k.provenance.holdOut.directions.map((d) => d.limits[1] - d.limits[0]);
+      return width < Math.max(...widths) && width > Math.min(...widths);
+    }),
+    calibrated
+      .map(([n, k]) => `${n}: pooled ${r4(k.location.limits[1] - k.location.limits[0])} against [${k.provenance.holdOut.directions.map((d) => r4(d.limits[1] - d.limits[0])).join(', ')}]`)
+      .join('; ')
+  );
+  check(
+    'every hold-out direction\'s limits bracket its own derived centre, exactly as the shipped ones do',
+    calibrated.every(([, k]) =>
+      k.provenance.holdOut.directions.every((d) => d.limits[0] < d.centre && d.centre < d.limits[1] && d.betweenRunSD > 0 && d.dispersionLimit > 0)
+    )
   );
 
   return { checks };

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_check_standard.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_check_standard.cjs
@@ -558,33 +558,45 @@ function checkStandardSelfTest() {
   //    themselves are re-derived from the committed datasets by
   //    `clock_exit_path.test.cjs`, which is where the data lives.
   const calibrated = Object.entries(STANDARD.classes).filter(([, k]) => k.calibrated);
+  // A MISSING RECORD MUST FAIL THE CHECK, NOT THROW PAST IT. Every reader below
+  // goes through `HO`, so a class with no hold-out — the pre-v3 shape — reports
+  // as a red fixture with its name and its detail, which is what the mutation
+  // proof reads. A fixture that crashes on the mutation it exists to catch
+  // tells you only that something broke.
+  const HO = (k) => (k.provenance && k.provenance.holdOut) || {};
+  const DIRS = (k) => (Array.isArray(HO(k).directions) ? HO(k).directions : []);
   check(
     'every calibrated class carries an out-of-sample hold-out, taken BOTH WAYS',
     calibrated.every(([, k]) => {
-      const h = k.provenance.holdOut;
-      if (!h || !Array.isArray(h.directions) || h.directions.length !== 2) return false;
-      const bases = h.directions.map((d) => d.baseline).sort();
-      const held = h.directions.map((d) => d.heldOut).sort();
+      const dirs = DIRS(k);
+      if (dirs.length !== 2) return false;
+      const bases = dirs.map((d) => d.baseline).sort();
+      const held = dirs.map((d) => d.heldOut).sort();
       // each ensemble serves once as baseline and once as the held-out set —
       // a "both ways" that reused one baseline would be one direction twice
       return bases[0] !== bases[1] && JSON.stringify(bases) === JSON.stringify(held);
     }),
-    calibrated.map(([n, k]) => `${n}:${(k.provenance.holdOut && k.provenance.holdOut.directions || []).length}`).join(' ')
+    calibrated.map(([n, k]) => `${n}:${DIRS(k).length}`).join(' ')
   );
   check(
     'the two baselines PARTITION the class\'s corpus — a hold-out that judged a run it was fitted on is not one',
     calibrated.every(([, k]) => {
-      const h = k.provenance.holdOut;
-      const sum = h.directions.reduce((a, d) => a + d.baselineRowRuns, 0);
-      return sum === k.provenance.rowRuns && h.directions.every((d) => d.baselineRowRuns + d.heldOutRowRuns === k.provenance.rowRuns);
+      const dirs = DIRS(k);
+      if (!dirs.length) return false;
+      const sum = dirs.reduce((a, d) => a + d.baselineRowRuns, 0);
+      return sum === k.provenance.rowRuns && dirs.every((d) => d.baselineRowRuns + d.heldOutRowRuns === k.provenance.rowRuns);
     }),
-    calibrated.map(([n, k]) => `${n}: ${k.provenance.holdOut.directions.map((d) => d.baselineRowRuns).join('+')} of ${k.provenance.rowRuns}`).join('; ')
+    calibrated.map(([n, k]) => `${n}: ${DIRS(k).map((d) => d.baselineRowRuns).join('+') || 'none'} of ${k.provenance.rowRuns}`).join('; ')
   );
   check(
     'the claim is SESSION-LEVEL and says why it is not commit-level — the weaker claim, made in the file rather than in a PR body',
-    calibrated.every(([, k]) => /SESSION[- ]LEVEL/i.test(k.provenance.holdOut.level) && /does not split by commit/.test(k.provenance.holdOut.whyNotCommitLevel)) &&
-      calibrated.every(([, k]) => /SESSION LEVEL/i.test(k.provenance.independence)),
-    calibrated.map(([n, k]) => `${n}: ${k.provenance.holdOut.level.slice(0, 40)}`).join(' | ')
+    calibrated.every(
+      ([, k]) =>
+        /SESSION[- ]LEVEL/i.test(HO(k).level || '') &&
+        /does not split by commit/.test(HO(k).whyNotCommitLevel || '') &&
+        /SESSION LEVEL/i.test(k.provenance.independence || '')
+    ),
+    calibrated.map(([n, k]) => `${n}: ${(HO(k).level || 'NO HOLD-OUT').slice(0, 40)}`).join(' | ')
   );
   check(
     'and the residual is the STANDARD\'s to state: commit-level independence is named as what the next ensemble is for',
@@ -594,35 +606,35 @@ function checkStandardSelfTest() {
   check(
     '`agree` is the arithmetic and not an opinion — true exactly when every direction admitted every held-out run',
     calibrated.every(([, k]) => {
-      const h = k.provenance.holdOut;
-      const allIn = h.directions.every((d) => d.inControl === d.heldOutRowRuns);
-      const totIn = h.directions.reduce((a, d) => a + d.inControl, 0);
-      const totOf = h.directions.reduce((a, d) => a + d.heldOutRowRuns, 0);
-      return h.agree === allIn && h.heldOutInControl === `${totIn} of ${totOf}`;
+      const dirs = DIRS(k);
+      if (!dirs.length) return false;
+      const allIn = dirs.every((d) => d.inControl === d.heldOutRowRuns);
+      const totIn = dirs.reduce((a, d) => a + d.inControl, 0);
+      const totOf = dirs.reduce((a, d) => a + d.heldOutRowRuns, 0);
+      return HO(k).agree === allIn && HO(k).heldOutInControl === `${totIn} of ${totOf}`;
     }),
-    calibrated.map(([n, k]) => `${n}: agree=${k.provenance.holdOut.agree} ${k.provenance.holdOut.heldOutInControl}`).join('; ')
+    calibrated.map(([n, k]) => `${n}: agree=${HO(k).agree} ${HO(k).heldOutInControl}`).join('; ')
   );
   check(
     'a DISAGREEING class states the disagreement and names every refused run and its term — not averaged into a summary',
     calibrated
-      .filter(([, k]) => k.provenance.holdOut.agree === false)
+      .filter(([, k]) => HO(k).agree === false)
       .every(([, k]) => {
-        const h = k.provenance.holdOut;
-        const refused = h.directions.flatMap((d) => d.refused || []);
+        const refused = DIRS(k).flatMap((d) => d.refused || []);
         return (
-          typeof h.disagreement === 'string' &&
-          h.disagreement.length > 0 &&
+          typeof HO(k).disagreement === 'string' &&
+          HO(k).disagreement.length > 0 &&
           refused.length > 0 &&
           refused.every((r) => r.run && Number.isFinite(r.median) && r.term) &&
-          h.directions.every((d) => (d.refused || []).length === d.heldOutRowRuns - d.inControl)
+          DIRS(k).every((d) => (d.refused || []).length === d.heldOutRowRuns - d.inControl)
         );
       }),
-    calibrated.filter(([, k]) => k.provenance.holdOut.agree === false).map(([n]) => n).join(',') || 'no class disagreed'
+    calibrated.filter(([, k]) => HO(k).agree === false).map(([n]) => n).join(',') || 'no class disagreed'
   );
   check(
     'THE FENCE: no hold-out fit became a shipped limit — the frozen limits are still the POOLED ones',
     calibrated.every(([, k]) =>
-      k.provenance.holdOut.directions.every(
+      DIRS(k).every(
         (d) =>
           d.centre !== k.centre &&
           d.limits[0] !== k.location.limits[0] &&
@@ -635,19 +647,18 @@ function checkStandardSelfTest() {
   check(
     'and the pooled limits are not simply the widest available — pooling carried the between-session term, it did not widen',
     calibrated.every(([, k]) => {
+      const widths = DIRS(k).map((d) => d.limits[1] - d.limits[0]);
+      if (!widths.length) return false;
       const width = k.location.limits[1] - k.location.limits[0];
-      const widths = k.provenance.holdOut.directions.map((d) => d.limits[1] - d.limits[0]);
       return width < Math.max(...widths) && width > Math.min(...widths);
     }),
     calibrated
-      .map(([n, k]) => `${n}: pooled ${r4(k.location.limits[1] - k.location.limits[0])} against [${k.provenance.holdOut.directions.map((d) => r4(d.limits[1] - d.limits[0])).join(', ')}]`)
+      .map(([n, k]) => `${n}: pooled ${r4(k.location.limits[1] - k.location.limits[0])} against [${DIRS(k).map((d) => r4(d.limits[1] - d.limits[0])).join(', ') || 'none'}]`)
       .join('; ')
   );
   check(
     'every hold-out direction\'s limits bracket its own derived centre, exactly as the shipped ones do',
-    calibrated.every(([, k]) =>
-      k.provenance.holdOut.directions.every((d) => d.limits[0] < d.centre && d.centre < d.limits[1] && d.betweenRunSD > 0 && d.dispersionLimit > 0)
-    )
+    calibrated.every(([, k]) => DIRS(k).length > 0 && DIRS(k).every((d) => d.limits[0] < d.centre && d.centre < d.limits[1] && d.betweenRunSD > 0 && d.dispersionLimit > 0))
   );
 
   return { checks };

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_check_standard.json
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_check_standard.json
@@ -1,6 +1,6 @@
 {
   "id": "hicasso-clock/ctl-2x-level",
-  "version": 2,
+  "version": 3,
   "ruling": "rf2-8a746",
   "frozen": "2026-08-07",
   "amendments": [
@@ -10,6 +10,13 @@
       "ruling": "rf2-x7x10",
       "what": "The MOUNT class is calibrated, from its own 14 committed row-runs, in the same derivation the bulk class was frozen under. v1 left it uncalibrated and failing closed; see classes.mount.amendedFrom for what that cost and for the superseded ruling v1's rationale cited.",
       "touches": "the mount class only. The bulk class's centre, limits, dispersion and error rates are byte-identical to v1, and no hard refusal (read-back, canonical-DOM, page-error, arm-order, quiet-box, band-ceiling) is involved either way."
+    },
+    {
+      "version": 3,
+      "date": "2026-08-08",
+      "ruling": "rf2-c1974",
+      "what": "The limits are VALIDATED OUT OF SAMPLE, to the strongest independence this corpus supports — a SESSION-level hold-out. Each class's limits are re-derived from ONE ensemble and the OTHER is judged against them, both ways, and each provenance.independence field now carries what that measured in place of v1 and v2's honest admission that it had never been measured. Bulk passes both ways; the MOUNT DIRECTIONS DISAGREE, and that is recorded as the finding rather than averaged away.",
+      "touches": "the two provenance.independence fields, a new provenance.holdOut record on each class, and one recalibrateOn entry naming the residual. NO NUMBER THAT DECIDES ANYTHING MOVED: every centre, location limit, dispersion limit, tolerance band and error rate is byte-identical to v2, and no hard refusal is involved. Nothing was widened to make a hold-out pass — the fence rf2-c1974 was raised under."
     }
   ],
   "what": "The level-denominated check standard for the Hicasso clock (clock_run.cjs). The measured quantity is the ctl-2x arm's TARED TaskDuration over the floor's TARED TaskDuration, in the same round of the same segment — one per block, 18 per row-run. Both terms are LEVELS, so the ~0.4 ms of estimator error each arm's p50 carries is 9% of a ~4.5 ms denominator rather than 48% of a 1.2 ms difference. It replaces the three-point difference-of-differences control, which rf2-8a746 retired as a gate.",
@@ -41,7 +48,30 @@
         "chromium": "147.0.7727.15",
         "design": "6 rounds x (4 warmup + 10 samples), tare on, 3 segments",
         "observed": { "runMedianCentre": 1.7207, "runMedianRange": [1.596, 1.8288], "betweenRunSD": 0.0566, "robustScaleP50": 0.1922, "robustScaleMax": 0.4211 },
-        "independence": "NOT INDEPENDENT OF ITS OWN BASELINE, and said here rather than left to be discovered. v1 is seeded from the same 42 row-runs it is quoted against, so 0-of-42 is a consistency check and not a false-refusal measurement. NIST e-Handbook 2.3.5's doctrine is that the limits come from a baseline the standard is not afterwards judged on; the next recalibration must take one."
+        "independence": "VALIDATED OUT OF SAMPLE AT SESSION LEVEL, both ways, and every held-out row-run came back in control (rf2-c1974). v1 said plainly that it was seeded from the same 42 row-runs it was quoted against, so 0-of-42 was a consistency check; that admission was correct and is replaced here by a measurement rather than deleted. Derive from clock-emvod's 24 row-runs and clock-w3yxd's 18 are ALL IN CONTROL; derive from clock-w3yxd's 18 and clock-emvod's 24 are ALL IN CONTROL. 42 of 42 held-out judgements, on limits fitted without the run being judged, and the two directions AGREE — which is the reassurance a single direction could not give, because it would have depended on which ensemble happened to be picked. See holdOut for the derived limits and the margins, and recalibrateOn for what this still does NOT establish.",
+        "holdOut": {
+          "ruling": "rf2-c1974",
+          "level": "SESSION-LEVEL, same day, same tree — and that is the ceiling this corpus supports, not a choice",
+          "whyNotCommitLevel": "the corpus does not split by commit. Every run in both ensembles carries a `when` of 2026-08-07 and the two ensembles start 87 minutes apart — clock-emvod/run1 at 05:37:29Z, clock-w3yxd/run1 at 07:04:47Z — on the evidence one tree. A hold-out across them therefore crosses a SITTING and not a commit, which is real and is the dominant practical failure mode for a check standard, but it is weaker than the census standard's hold-out (rf2-pzqy8) which crossed five days and a code change.",
+          "derivation": "each direction re-derives the class's own frozen recipe on ONE ensemble alone — centre = median of that ensemble's run medians, location = centre +/- 3 x its between-run SD, dispersion = exp(mu + 3 sigma) of its log robust scales — and judges every row-run of the other against it. The two baselines partition the 42: 24 + 18.",
+          "directions": [
+            {
+              "baseline": "clock-emvod", "baselineRowRuns": 24,
+              "centre": 1.7298, "betweenRunSD": 0.0592, "limits": [1.5521, 1.9075], "dispersionLimit": 0.5879,
+              "heldOut": "clock-w3yxd", "heldOutRowRuns": 18, "inControl": 18, "refused": [],
+              "tightestMargin": 0.0635, "note": "the held-out medians span [1.6157, 1.7954] and the widest held-out robust scale is 0.3779 against a limit of 0.5879 — location is the term with the smaller headroom here, as it is everywhere on this instrument"
+            },
+            {
+              "baseline": "clock-w3yxd", "baselineRowRuns": 18,
+              "centre": 1.6886, "betweenRunSD": 0.0492, "limits": [1.5411, 1.8361], "dispersionLimit": 0.5443,
+              "heldOut": "clock-emvod", "heldOutRowRuns": 24, "inControl": 24, "refused": [],
+              "tightestMargin": 0.0073, "note": "AND IT IS CLOSE, which is worth saying rather than rounding off: emvod's widest run reads 1.8288x against this direction's ceiling of 1.8361, clear by 0.0073 — 2.5% of the limits' own width. It passes on the numbers and it does not pass comfortably."
+            }
+          ],
+          "agree": true,
+          "heldOutInControl": "42 of 42",
+          "betweenSessionOffset": "the two sittings' centres are 0.0412 apart (1.7298x against 1.6886x, 2.44%), which is 0.70 of emvod's own between-run SD and 0.84 of w3yxd's. On this class the between-session shift is small against the within-session scatter, which is exactly why both directions hold."
+        }
       }
     },
     "mount": {
@@ -67,7 +97,38 @@
         "design": "6 rounds x (4 warmup + 10 samples), tare on, 3 segments",
         "observed": { "runMedianCentre": 1.7956, "runMedianRange": [1.7489, 1.8978], "betweenRunSD": 0.0397, "robustScaleP50": 0.12, "robustScaleRange": [0.041, 0.2863] },
         "notCopiedFromBULK": "and this is the point of the class existing at all. The bulk class reads 1.7207x and the mount reads 1.7956x on the identical statistic through the identical door — 4.4% apart, which is 1.9 of the mount's own between-run SDs. Importing bulk's [1.5509, 1.8905] here would have asserted against the mount a value never measured on it, which is the mis-specification rf2-8a746 retired, one row class over. rf2-8a746 saw this and handed the finding forward by id: ctl-2x's true centre is EMPIRICAL and differs by row class.",
-        "independence": "NOT INDEPENDENT OF ITS OWN BASELINE, on the bulk class's own terms and on a smaller baseline. v2 is seeded from the same 14 M1 row-runs it is quoted against, so 14 of 14 is a consistency check and not a false-refusal measurement. NIST e-Handbook 2.3.5's doctrine is that the limits come from a baseline the standard is not afterwards judged on; the next recalibration must take one, and on this class it wants more than 14 runs — 14 is what fixes sigma for the dispersion term, and it is thin."
+        "independence": "MEASURED OUT OF SAMPLE AT SESSION LEVEL, AND ONE DIRECTION FAILED — which is this class's finding, not a defect to be tuned away (rf2-c1974). v2 said plainly that it was seeded from the same 14 M1 row-runs it was quoted against, so 14 of 14 was a consistency check; that admission was correct and is replaced here by a measurement rather than deleted. Derive from clock-emvod's 8 row-runs and all 6 of clock-w3yxd are IN CONTROL. Derive from clock-w3yxd's 6 and 4 of clock-emvod's 8 are REFUSED — every one on LOCATION, none on dispersion. THE DIRECTIONS DISAGREE, and the reason is not a large between-session shift: see holdOut.disagreement. WHAT IT DOES AND DOES NOT IMPEACH: not the shipped limits, which are fitted on both sittings pooled and admit all 14; it impeaches SINGLE-SITTING CALIBRATION on this class, which is a live risk because 14 runs is thin and the temptation at the next recalibration will be to take one sitting's worth. See recalibrateOn.",
+        "holdOut": {
+          "ruling": "rf2-c1974",
+          "level": "SESSION-LEVEL, same day, same tree — and that is the ceiling this corpus supports, not a choice",
+          "whyNotCommitLevel": "the corpus does not split by commit. Every run in both ensembles carries a `when` of 2026-08-07 and the two ensembles start 87 minutes apart — clock-emvod/run1 at 05:37:29Z, clock-w3yxd/run1 at 07:04:47Z — on the evidence one tree. A hold-out across them therefore crosses a SITTING and not a commit.",
+          "derivation": "each direction re-derives the class's own frozen recipe on ONE ensemble alone — centre = median of that ensemble's run medians, location = centre +/- 3 x its between-run SD, dispersion = exp(mu + 3 sigma) of its log robust scales — and judges every row-run of the other against it. The two baselines partition the 14: 8 + 6.",
+          "directions": [
+            {
+              "baseline": "clock-emvod", "baselineRowRuns": 8,
+              "centre": 1.8133, "betweenRunSD": 0.0486, "limits": [1.6674, 1.9591], "dispersionLimit": 0.3983,
+              "heldOut": "clock-w3yxd", "heldOutRowRuns": 6, "inControl": 6, "refused": [],
+              "tightestMargin": 0.1039, "note": "the held-out medians span [1.7713, 1.8014] — a 0.0300 span inside a 0.2916-wide limit — and the widest held-out robust scale is 0.2863 against a limit of 0.3983"
+            },
+            {
+              "baseline": "clock-w3yxd", "baselineRowRuns": 6,
+              "centre": 1.781, "betweenRunSD": 0.0113, "limits": [1.7471, 1.8149], "dispersionLimit": 0.6763,
+              "heldOut": "clock-emvod", "heldOutRowRuns": 8, "inControl": 4,
+              "refused": [
+                { "run": "clock-emvod/run3", "median": 1.8978, "term": "location", "over": 0.0828 },
+                { "run": "clock-emvod/run4", "median": 1.8475, "term": "location", "over": 0.0325 },
+                { "run": "clock-emvod/run2", "median": 1.8412, "term": "location", "over": 0.0263 },
+                { "run": "clock-emvod/run6", "median": 1.8176, "term": "location", "over": 0.0027 }
+              ],
+              "tightestMargin": -0.0828,
+              "note": "4 of 8 refused, every one on LOCATION and not one on dispersion — so this is a statement about where the sittings sit, not about how noisy either was"
+            }
+          ],
+          "agree": false,
+          "heldOutInControl": "10 of 14",
+          "betweenSessionOffset": "the two sittings' centres are 0.0322 apart (1.8133x against 1.7810x, 1.81%) — SMALLER in absolute terms than bulk's 0.0412, where both directions held. The offset is not what breaks this class.",
+          "disagreement": "WHAT BREAKS IT IS THE w3yxd SITTING'S OWN REPRODUCIBILITY. Its six mount medians span 0.0300 and give a between-run SD of 0.0113, under a quarter of emvod's 0.0486, so its +/- 3 SD budget is only 0.0678 wide and the between-session offset alone consumes 2.85 of the 3 sigma. Fitted the other way the budget is 0.2916 wide and the same offset consumes 0.66 sigma, so it costs nothing. THE ASYMMETRY IS THE MEASUREMENT: a single sitting can be reproducible enough to fit limits this instrument will not meet ninety minutes later, and six runs is far too few to tell a genuinely tight instrument from a lucky sitting. NOTE WHERE THE SHIPPED LIMITS SIT: v2 pools both sittings, so its between-run SD of 0.0397 already carries the between-session component and its limits are 0.2382 wide — narrower than the emvod-derived 0.2916 and 3.5x wider than the w3yxd-derived 0.0678. Pooling is what makes them survivable; it is not a widening, and none was applied here."
+        }
       },
       "amendedFrom": {
         "version": 1,
@@ -88,6 +149,8 @@
     "any change to the harness: the door an arm goes through, the tare arm, the settle, the sample or round counts",
     "any change to the floor's page — cell count, boundary count, the shape of a cell",
     "any change to the published clock (the counter the rows are stated on)",
-    "and the recalibration takes a FRESH baseline: re-deriving limits from the runs they will judge is how a check standard stops being one"
+    "and the recalibration takes a FRESH baseline: re-deriving limits from the runs they will judge is how a check standard stops being one",
+    "THE RESIDUAL, AND THE NEXT RECALIBRATION'S JOB (rf2-c1974). The independence this standard has is SESSION-LEVEL and no further: both ensembles were taken on 2026-08-07, about ninety minutes apart, on one tree, so the hold-out crosses a sitting and not a commit. COMMIT-LEVEL INDEPENDENCE HAS NEVER BEEN MEASURED ON THIS INSTRUMENT, and taking it is what the next ensemble is for — a baseline and a hold-out on different trees, which is what rf2-8a746 part 3 asks for and what rf2-pzqy8's census standard already has. Until then no run judged in control here has been judged by limits validated across a code change.",
+    "and on the MOUNT class specifically, the next baseline spans MORE THAN ONE SITTING and more than 14 runs. rf2-c1974 measured what a single-sitting mount baseline does: fitted on clock-w3yxd's 6 runs it refuses 4 of clock-emvod's 8, all on location. A sitting can be reproducible enough to fit limits the instrument will not meet an hour and a half later."
   ]
 }

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_check_standard.json
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_check_standard.json
@@ -108,7 +108,7 @@
               "baseline": "clock-emvod", "baselineRowRuns": 8,
               "centre": 1.8133, "betweenRunSD": 0.0486, "limits": [1.6674, 1.9591], "dispersionLimit": 0.3983,
               "heldOut": "clock-w3yxd", "heldOutRowRuns": 6, "inControl": 6, "refused": [],
-              "tightestMargin": 0.1039, "note": "the held-out medians span [1.7713, 1.8014] — a 0.0300 span inside a 0.2916-wide limit — and the widest held-out robust scale is 0.2863 against a limit of 0.3983"
+              "tightestMargin": 0.1039, "note": "the held-out medians span [1.7713, 1.8014] — a 0.0300 span inside a 0.2917-wide limit — and the widest held-out robust scale is 0.2863 against a limit of 0.3983"
             },
             {
               "baseline": "clock-w3yxd", "baselineRowRuns": 6,
@@ -127,7 +127,7 @@
           "agree": false,
           "heldOutInControl": "10 of 14",
           "betweenSessionOffset": "the two sittings' centres are 0.0322 apart (1.8133x against 1.7810x, 1.81%) — SMALLER in absolute terms than bulk's 0.0412, where both directions held. The offset is not what breaks this class.",
-          "disagreement": "WHAT BREAKS IT IS THE w3yxd SITTING'S OWN REPRODUCIBILITY. Its six mount medians span 0.0300 and give a between-run SD of 0.0113, under a quarter of emvod's 0.0486, so its +/- 3 SD budget is only 0.0678 wide and the between-session offset alone consumes 2.85 of the 3 sigma. Fitted the other way the budget is 0.2916 wide and the same offset consumes 0.66 sigma, so it costs nothing. THE ASYMMETRY IS THE MEASUREMENT: a single sitting can be reproducible enough to fit limits this instrument will not meet ninety minutes later, and six runs is far too few to tell a genuinely tight instrument from a lucky sitting. NOTE WHERE THE SHIPPED LIMITS SIT: v2 pools both sittings, so its between-run SD of 0.0397 already carries the between-session component and its limits are 0.2382 wide — narrower than the emvod-derived 0.2916 and 3.5x wider than the w3yxd-derived 0.0678. Pooling is what makes them survivable; it is not a widening, and none was applied here."
+          "disagreement": "WHAT BREAKS IT IS THE w3yxd SITTING'S OWN REPRODUCIBILITY. Its six mount medians span 0.0300 and give a between-run SD of 0.0113, under a quarter of emvod's 0.0486, so its +/- 3 SD budget is only 0.0678 wide and the between-session offset alone consumes 2.85 of the 3 sigma. Fitted the other way the budget is 0.2917 wide and the same offset consumes 0.66 sigma, so it costs nothing. THE ASYMMETRY IS THE MEASUREMENT: a single sitting can be reproducible enough to fit limits this instrument will not meet ninety minutes later, and six runs is far too few to tell a genuinely tight instrument from a lucky sitting. NOTE WHERE THE SHIPPED LIMITS SIT: v2 pools both sittings, so its between-run SD of 0.0397 already carries the between-session component and its limits are 0.2382 wide — narrower than the emvod-derived 0.2917 and 3.5x wider than the w3yxd-derived 0.0678. Pooling is what makes them survivable; it is not a widening, and none was applied here."
         }
       },
       "amendedFrom": {

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -3734,7 +3734,10 @@ function fixtureRoundsTask(over) {
     const prov = STANDARD.classes.bulk.provenance;
     assert.strictEqual(prov.rowRuns, 42);
     assert.deepStrictEqual(prov.datasets, ['data/clock-emvod/run1-8.json', 'data/clock-w3yxd/run1-6.json']);
-    assert.match(prov.independence, /NOT INDEPENDENT/, 'v1 is seeded from the runs it is quoted against, and must say so');
+    // v1 said it was seeded from the runs it was quoted against; v3 replaced
+    // that admission with the measurement it was waiting for (rf2-c1974).
+    assert.match(prov.independence, /SESSION LEVEL/i, 'the independence field states the level actually achieved');
+    assert.ok(prov.holdOut, 'and carries the hold-out it was measured by');
   });
 
   // --- 2. THE SABOTAGE FIXTURE (criterion 2) --------------------------------
@@ -4117,7 +4120,11 @@ function fixtureRoundsTask(over) {
   // --- 1. THE CLASS IS DATA, LIKE THE OTHER ONE -----------------------------
 
   t('the mount class lands as DATA — calibrated, with its own frozen centre and limits', () => {
-    assert.strictEqual(STANDARD.version, 2, 'calibrating a class is a version bump, or a stored verdict cannot be re-read');
+    // Calibrating a class is a version bump, or a stored verdict cannot be
+    // re-read. The version has moved on since (v3, rf2-c1974), so the pin is on
+    // the amendment that records THIS change rather than on the head number.
+    assert.ok(STANDARD.version >= 2, `expected at least v2, got ${STANDARD.version}`);
+    assert.strictEqual((STANDARD.amendments.find((a) => a.ruling === 'rf2-x7x10') || {}).version, 2);
     assert.strictEqual(mount.calibrated, true);
     assert.deepStrictEqual(mount.rows, ['M1']);
     assert.strictEqual(classOf('M1'), 'mount');
@@ -4132,13 +4139,17 @@ function fixtureRoundsTask(over) {
     );
   });
 
-  t('the mount centre is EMPIRICAL, with its provenance and its non-independence stated', () => {
+  t('the mount centre is EMPIRICAL, with its provenance and the independence it has stated', () => {
     assert.ok(Math.abs(mount.centre - 2.0) > 0.15, 'the frozen centre is not the arithmetic 2.00x');
     const prov = mount.provenance;
     assert.strictEqual(prov.rowRuns, 14);
     assert.strictEqual(prov.calibratedBy, 'rf2-x7x10');
     assert.deepStrictEqual(prov.datasets, ['data/clock-emvod/run1-8.json', 'data/clock-w3yxd/run1-6.json']);
-    assert.match(prov.independence, /NOT INDEPENDENT/, 'v2 is seeded from the runs it is quoted against, and must say so');
+    // v2 said it was seeded from the runs it was quoted against; v3 replaced
+    // that admission with the measurement it was waiting for (rf2-c1974), and
+    // on this class the measurement came back split — see the rf2-c1974 block.
+    assert.match(prov.independence, /SESSION LEVEL/i, 'the independence field states the level actually achieved');
+    assert.ok(prov.holdOut, 'and carries the hold-out it was measured by');
     // the derivation is the bulk class's, restated on this class's numbers
     assert.match(mount.location.derivation, /3 x between-run SD/);
     assert.match(mount.dispersion.derivation, /exp\(mu \+ 3 sigma\)/);
@@ -4345,6 +4356,271 @@ function fixtureRoundsTask(over) {
     assert.match(v.why, /NOT CALIBRATED/);
     assert.strictEqual(JSON.stringify(STANDARD.classes.mount), before, 'the fixture must leave the standard as it found it');
     assert.strictEqual(checkStandard([1.79, 1.8, 1.81], 'M1').ok, true, 'and the class certifies again afterwards');
+  });
+}
+
+// ============================================================================
+// rf2-c1974 — THE LIMITS, VALIDATED OUT OF SAMPLE
+// ============================================================================
+//
+// rf2-8a746 part 3 asks for limits frozen from an INDEPENDENT baseline. v1 and
+// v2 both said, in their own `provenance.independence` fields, that they did not
+// have one — seeded from the runs they were quoted against, so `0 of 42` and
+// `14 of 14` were CONSISTENCY CHECKS and not false-refusal measurements. To
+// their credit they said it rather than leaving it to be found; but the moment
+// a NEW run is judged in control the verdict rests on limits nobody has tested
+// out of sample.
+//
+// WHAT THIS CORPUS SUPPORTS, AND THE CLAIM IS DELIBERATELY THE WEAKER ONE.
+// rf2-pzqy8's census standard held out a later COMMIT: its corpus spans five
+// days and a code change. This one cannot — every run in both clock ensembles
+// carries a `when` of 2026-08-07 and the ensembles start 87 minutes apart, on
+// the evidence one tree — so the strongest hold-out here is by SITTING. That is
+// real, and it is the dominant practical failure mode for a check standard, but
+// it crosses a coffee break rather than a commit. The first case below checks
+// that premise against the datasets rather than taking it on trust.
+//
+// BOTH WAYS, because a one-directional answer depends on which ensemble
+// happened to be picked. BULK agrees, 42 of 42 held-out row-runs in control.
+// MOUNT DISAGREES — and the disagreement is the finding, so it is pinned here
+// as a measurement rather than smoothed into an average.
+//
+// AND NOTHING WAS WIDENED. The fence rf2-c1974 was raised under is that a
+// hold-out failure is an answer, not a tuning signal; the last cases assert
+// that every shipped limit is still v2's, to the last place.
+{
+  const { STANDARD } = require('./clock_check_standard.cjs');
+  const { checkStandardFor } = require('./clock_readjudicate.cjs');
+  const t = (what, fn) => test(`rf2-c1974: ${what}`, fn);
+  const bulk = STANDARD.classes.bulk;
+  const mount = STANDARD.classes.mount;
+  const ENSEMBLES = ['clock-emvod', 'clock-w3yxd'];
+
+  const r4 = (x) => Math.round(x * 10000) / 10000;
+  const p50 = (xs) => {
+    const v = [...xs].sort((a, b) => a - b);
+    return v.length % 2 ? v[(v.length - 1) / 2] : (v[v.length / 2 - 1] + v[v.length / 2]) / 2;
+  };
+  const mean = (xs) => xs.reduce((a, b) => a + b, 0) / xs.length;
+  const sd = (xs) => {
+    const m = mean(xs);
+    return Math.sqrt(xs.reduce((a, b) => a + (b - m) * (b - m), 0) / (xs.length - 1));
+  };
+
+  /**
+   * Every committed row-run of one class, per ensemble, ADJUDICATED BY THE LIVE
+   * ADJUDICATOR rather than by a copy of its arithmetic: `checkStandardFor` is
+   * what the readjudicator applies to a dataset off disk, so a witness built on
+   * it cannot pass while the thing it describes has changed. Returns `null`
+   * when the corpus is absent — the datasets are retained, not required to
+   * build.
+   */
+  const readClass = (klassName) => {
+    const rows = STANDARD.classes[klassName].rows;
+    const out = {};
+    for (const dir of ENSEMBLES) {
+      const d = path.join(__dirname, 'data', dir);
+      if (!fs.existsSync(d)) return null;
+      out[dir] = [];
+      for (const f of fs.readdirSync(d).sort()) {
+        const data = JSON.parse(fs.readFileSync(path.join(d, f), 'utf8'));
+        for (const row of data.rows.filter((r) => rows.includes(r.rowId))) {
+          const v = checkStandardFor(row, data);
+          out[dir].push({ run: `${dir}/${f.replace(/\.json$/, '')}`, rowId: row.rowId, median: v.location.measured, scale: v.dispersion.measured });
+        }
+      }
+    }
+    return out;
+  };
+
+  /** The class's own frozen recipe, applied to ONE ensemble alone. */
+  const deriveFrom = (runs) => {
+    const meds = runs.map((r) => r.median);
+    const logs = runs.map((r) => Math.log(r.scale));
+    const centre = p50(meds);
+    const s = sd(meds);
+    return { n: runs.length, centre, sd: s, limits: [centre - 3 * s, centre + 3 * s], dispersionLimit: Math.exp(mean(logs) + 3 * sd(logs)) };
+  };
+
+  // --- 1. THE PREMISE OF THE WEAKER CLAIM, CHECKED AGAINST THE DATA ---------
+
+  t('the corpus does NOT split by commit — one day, ~90 minutes apart, so the hold-out is by SITTING', () => {
+    // The reason the claim is session-level rather than commit-level. It is
+    // asserted from the datasets because a standard that overstated its own
+    // independence would be the exact defect rf2-c1974 was raised on, one
+    // level up.
+    const firsts = {};
+    for (const dir of ENSEMBLES) {
+      const d = path.join(__dirname, 'data', dir);
+      if (!fs.existsSync(d)) return;
+      const whens = fs.readdirSync(d).sort().map((f) => JSON.parse(fs.readFileSync(path.join(d, f), 'utf8')).when);
+      assert.ok(whens.every((w) => /^2026-08-07T/.test(w)), `${dir}: every run must be the same day for the claim to be what it says — ${JSON.stringify(whens)}`);
+      firsts[dir] = Math.min(...whens.map((w) => Date.parse(w)));
+    }
+    const gapMinutes = Math.abs(firsts['clock-w3yxd'] - firsts['clock-emvod']) / 60000;
+    assert.ok(gapMinutes > 30 && gapMinutes < 180, `the two ensembles must be separate sittings of the same day — ${r4(gapMinutes)} minutes apart`);
+    for (const k of [bulk, mount]) {
+      assert.match(k.provenance.holdOut.level, /SESSION-LEVEL/, 'and the file must claim exactly that');
+      assert.match(k.provenance.holdOut.whyNotCommitLevel, /does not split by commit/);
+    }
+  });
+
+  // --- 2. THE HOLD-OUT IS RECOMPUTABLE FROM THE COMMITTED DATASETS ---------
+
+  t('every hold-out number in the standard is re-derived from the corpus — both classes, both directions', () => {
+    for (const [name, klass] of [['bulk', bulk], ['mount', mount]]) {
+      const data = readClass(name);
+      if (!data) return;
+      assert.strictEqual(
+        Object.values(data).reduce((a, v) => a + v.length, 0),
+        klass.provenance.rowRuns,
+        `${name}: the corpus must be the ${klass.provenance.rowRuns} row-runs the class was calibrated from`
+      );
+      for (const dir of klass.provenance.holdOut.directions) {
+        const d = deriveFrom(data[dir.baseline]);
+        const held = data[dir.heldOut];
+        assert.strictEqual(d.n, dir.baselineRowRuns, `${name}/${dir.baseline}: baseline size`);
+        assert.strictEqual(held.length, dir.heldOutRowRuns, `${name}/${dir.heldOut}: held-out size`);
+        assert.strictEqual(r4(d.centre), dir.centre, `${name}/${dir.baseline}: derived centre`);
+        assert.strictEqual(r4(d.sd), dir.betweenRunSD, `${name}/${dir.baseline}: derived between-run SD`);
+        // THE LIMITS AND THE DISPERSION TERM ARE PINNED TO WITHIN HALF A PLACE
+        // rather than to the last one, and the reason is arithmetic and not
+        // slack: the adjudicator reports a run's median and scale ROUNDED to
+        // four places, so a statistic taken over the reported numbers can
+        // differ from one taken over the raw ones in the fourth. Any refit
+        // moves these by orders of magnitude more than 1e-3.
+        assert.ok(Math.abs(d.limits[0] - dir.limits[0]) < 1e-3 && Math.abs(d.limits[1] - dir.limits[1]) < 1e-3,
+          `${name}/${dir.baseline}: derived limits [${r4(d.limits[0])}, ${r4(d.limits[1])}] against recorded ${JSON.stringify(dir.limits)}`);
+        assert.ok(Math.abs(d.dispersionLimit - dir.dispersionLimit) < 1e-3,
+          `${name}/${dir.baseline}: derived dispersion ${r4(d.dispersionLimit)} against recorded ${dir.dispersionLimit}`);
+        // and the verdict itself: every held-out run judged by limits fitted
+        // without it, against the limits the file records.
+        const verdicts = held.map((r) => ({ ...r, ok: r.median >= dir.limits[0] && r.median <= dir.limits[1] && r.scale <= dir.dispersionLimit }));
+        assert.strictEqual(verdicts.filter((v) => v.ok).length, dir.inControl, `${name}/${dir.baseline} -> ${dir.heldOut}: in-control count`);
+        assert.deepStrictEqual(
+          verdicts.filter((v) => !v.ok).map((v) => v.run).sort(),
+          (dir.refused || []).map((r) => r.run).sort(),
+          `${name}/${dir.baseline} -> ${dir.heldOut}: the refused runs must be the ones the file names`
+        );
+        for (const r of dir.refused || []) {
+          const v = verdicts.find((x) => x.run === r.run);
+          assert.strictEqual(v.median, r.median, `${r.run}: recorded median`);
+          assert.strictEqual(r.term, v.scale <= dir.dispersionLimit ? 'location' : 'dispersion', `${r.run}: recorded term`);
+        }
+      }
+    }
+  });
+
+  // --- 3. BULK: BOTH DIRECTIONS AGREE ---------------------------------------
+
+  t('BULK: limits fitted on one sitting admit every row-run of the other, BOTH WAYS — 42 of 42', () => {
+    const h = bulk.provenance.holdOut;
+    assert.strictEqual(h.agree, true);
+    assert.strictEqual(h.heldOutInControl, '42 of 42');
+    assert.deepStrictEqual(h.directions.map((d) => `${d.baseline}->${d.heldOut} ${d.inControl}/${d.heldOutRowRuns}`), [
+      'clock-emvod->clock-w3yxd 18/18',
+      'clock-w3yxd->clock-emvod 24/24',
+    ]);
+    // and the file does not oversell it: the closer direction passes by 0.0073
+    // on a limits width of 0.2949, which the note says out loud.
+    const tight = Math.min(...h.directions.map((d) => d.tightestMargin));
+    assert.ok(tight > 0 && tight < 0.02, `the tightest held-out margin is ${tight}`);
+    assert.match(h.directions.find((d) => d.tightestMargin === tight).note, /does not pass comfortably/);
+  });
+
+  // --- 4. MOUNT: THE DIRECTIONS DISAGREE, AND THAT IS THE FINDING -----------
+
+  t('MOUNT: one direction admits all 6, the other REFUSES 4 of 8 — the disagreement is recorded, not averaged', () => {
+    const h = mount.provenance.holdOut;
+    assert.strictEqual(h.agree, false, 'a class whose directions disagree may not report as if they agreed');
+    assert.strictEqual(h.heldOutInControl, '10 of 14');
+    const emvodBased = h.directions.find((d) => d.baseline === 'clock-emvod');
+    const w3yxdBased = h.directions.find((d) => d.baseline === 'clock-w3yxd');
+    assert.strictEqual(emvodBased.inControl, emvodBased.heldOutRowRuns, 'the 8-run baseline admits the whole other sitting');
+    assert.strictEqual(w3yxdBased.inControl, 4);
+    assert.strictEqual(w3yxdBased.refused.length, 4);
+    // EVERY refusal is LOCATION. That is what makes this a statement about
+    // where the two sittings sit rather than about how noisy either was, and
+    // it is the difference between a finding and a flaky instrument.
+    assert.ok(w3yxdBased.refused.every((r) => r.term === 'location'), JSON.stringify(w3yxdBased.refused));
+    // and the cause is stated: not a large shift, but a baseline too tight to
+    // contain a small one.
+    assert.ok(
+      Math.abs(emvodBased.centre - w3yxdBased.centre) < Math.abs(bulk.provenance.holdOut.directions[0].centre - bulk.provenance.holdOut.directions[1].centre),
+      'the mount sittings are CLOSER than the bulk sittings, which is why the cause cannot be the offset alone'
+    );
+    assert.ok(w3yxdBased.betweenRunSD * 4 < emvodBased.betweenRunSD, 'the failing baseline is the tighter one, by more than 4x');
+    assert.match(h.disagreement, /REPRODUCIBILITY/);
+    assert.match(h.disagreement, /single sitting/i);
+  });
+
+  // --- 5. THE FENCE: NOTHING WAS WIDENED TO MAKE A HOLD-OUT PASS ------------
+
+  t('THE FENCE: not one shipped limit moved — v2\'s frozen numbers, to the last place', () => {
+    // The bulk half of this is already pinned by the rf2-x7x10 block; the mount
+    // half is pinned here, because the mount is the class whose hold-out
+    // failed and therefore the one a tuning hand would have reached for.
+    assert.strictEqual(mount.centre, 1.7956);
+    assert.deepStrictEqual(mount.location.limits, [1.6765, 1.9147]);
+    assert.strictEqual(mount.dispersion.limit, 0.577);
+    assert.deepStrictEqual(mount.tolerance.band, [1.3467, 2.2445]);
+    assert.strictEqual(bulk.centre, 1.7207);
+    assert.deepStrictEqual(bulk.location.limits, [1.5509, 1.8905]);
+    assert.strictEqual(bulk.dispersion.limit, 0.568);
+    // and the shipped limits are the POOLED fit rather than either single-
+    // sitting one — narrower than the widest available, which is what a
+    // widening would have produced.
+    for (const k of [bulk, mount]) {
+      const width = k.location.limits[1] - k.location.limits[0];
+      const widths = k.provenance.holdOut.directions.map((d) => d.limits[1] - d.limits[0]);
+      assert.ok(width < Math.max(...widths), `${JSON.stringify(k.rows)}: pooled width ${r4(width)} against ${widths.map(r4)}`);
+    }
+    // the standard still admits its own baseline, both classes, unchanged
+    for (const [name, klass] of [['bulk', bulk], ['mount', mount]]) {
+      const data = readClass(name);
+      if (!data) return;
+      const all = ENSEMBLES.flatMap((d) => data[d]);
+      const inControl = all.filter((r) => r.median >= klass.location.limits[0] && r.median <= klass.location.limits[1] && r.scale <= klass.dispersion.limit);
+      assert.strictEqual(inControl.length, klass.provenance.rowRuns, `${name}: the shipped limits must still admit all ${klass.provenance.rowRuns}`);
+    }
+  });
+
+  // --- 6. THE VERSION, THE AMENDMENT AND THE RESIDUAL -----------------------
+
+  t('v3 is an amendment with its own entry, and the earlier admissions are replaced by measurements', () => {
+    assert.strictEqual(STANDARD.version, 3, 'replacing an independence claim is a version bump — a stored verdict must stay re-readable');
+    const a = STANDARD.amendments.find((x) => x.ruling === 'rf2-c1974');
+    assert.ok(a, 'the amendment log must carry this change');
+    assert.strictEqual(a.version, 3);
+    assert.match(a.what, /OUT OF SAMPLE/);
+    assert.match(a.touches, /byte-identical to v2/);
+    // the honest admission is GONE as a live claim, on both classes, because it
+    // has been answered — not because it was inconvenient.
+    for (const k of [bulk, mount]) {
+      assert.ok(!/NOT INDEPENDENT OF ITS OWN BASELINE/.test(k.provenance.independence), 'the admission is replaced by the measurement that answers it');
+      assert.match(k.provenance.independence, /rf2-c1974/);
+      assert.match(k.provenance.independence, /SESSION LEVEL/i);
+    }
+  });
+
+  t('THE RESIDUAL: commit-level independence is named as the recalibration trigger, not implied to be done', () => {
+    // The half of rf2-8a746 part 3 this work does NOT discharge. Left unstated,
+    // a reader meeting `provenance.independence` would take "validated out of
+    // sample" for the whole criterion.
+    const triggers = STANDARD.recalibrateOn;
+    const residual = triggers.find((r) => /COMMIT-LEVEL INDEPENDENCE HAS NEVER BEEN MEASURED/.test(r));
+    assert.ok(residual, `the standard must name what it still lacks — ${JSON.stringify(triggers)}`);
+    assert.match(residual, /different trees/);
+    assert.match(residual, /rf2-8a746 part 3/);
+    // and the mount's own residual, which is narrower and sharper: its next
+    // baseline may not be a single sitting.
+    assert.ok(triggers.some((r) => /MOUNT class specifically/.test(r) && /more than 14 runs/.test(r)), JSON.stringify(triggers));
+  });
+
+  t('the ruling is cited by bead id in every surface it changed', () => {
+    for (const file of ['clock_check_standard.json', 'clock_check_standard.cjs']) {
+      assert.ok(/rf2-c1974/.test(fs.readFileSync(path.join(__dirname, file), 'utf8')), `${file} must cite the ruling that changed it`);
+    }
   });
 }
 


### PR DESCRIPTION
`rf2-8a746` part 3 asks for run-level location and dispersion limits frozen from an **independent baseline**. `clock_check_standard.json` v1 and v2 both disclosed, in their own `provenance.independence` fields, that they did not have one — seeded from the same row-runs they were quoted against, so *0 of 42* and *14 of 14* were **consistency checks, not false-refusal measurements**. That was honest, and it was still a gap: the moment a new run is judged in control, the verdict rests on limits nobody has tested out of sample.

This replaces both admissions with a measurement. **No measurement was taken** — this is arithmetic over the retained corpus (`data/clock-emvod/run1-8`, `data/clock-w3yxd/run1-6`) plus a versioned data edit.

## What this corpus can support, and what it cannot

`rf2-pzqy8`'s census standard held out a genuinely later **commit**: its corpus spans five days and a code change. This one cannot. Checked against the datasets rather than assumed: every run in **both** clock ensembles carries a `when` of `2026-08-07`, and the ensembles start **87 minutes apart** — `clock-emvod/run1` at `05:37:29Z`, `clock-w3yxd/run1` at `07:04:47Z` — on the evidence one tree.

So the independence achieved here is **session-level, same day, same tree**, and the file claims exactly that and no more. It tests whether limits fitted to one sitting admit runs from a different sitting ninety minutes later, which is real and is the dominant practical failure mode for a check standard — but it crosses a coffee break, not a commit. **Commit-level independence has never been measured on this instrument**, and it is recorded as the standard's stated recalibration trigger rather than implied to be discharged.

## The hold-out, both ways

Each class's limits are re-derived from **one** ensemble in the class's own frozen recipe — centre = median of that ensemble's run medians, location = centre ± 3 × its between-run SD, dispersion = `exp(mu + 3 sigma)` of its log robust scales — and every row-run of the **other** ensemble is judged against them. Both directions, so the answer does not depend on which ensemble happened to be picked.

### BULK — the directions agree, 42 of 42 held out in control

| baseline | n | centre | between-run SD | location limits | dispersion | held out | in control |
|---|---|---|---|---|---|---|---|
| `clock-emvod` | 24 | 1.7298 | 0.0592 | [1.5521, 1.9075] | 0.5879 | `clock-w3yxd` (18) | **18 of 18** |
| `clock-w3yxd` | 18 | 1.6886 | 0.0492 | [1.5411, 1.8361] | 0.5443 | `clock-emvod` (24) | **24 of 24** |

The two sittings' centres are 0.0412 apart (2.44%) — 0.70 of emvod's own between-run SD, 0.84 of w3yxd's — so the between-session shift is small against the within-session scatter and both directions hold. **It is not comfortable in one of them and the file says so**: emvod's widest run reads `1.8288x` against w3yxd's derived ceiling of `1.8361`, clear by `0.0073`, which is 2.5% of that direction's limits width.

### MOUNT — the directions DISAGREE, and that is the finding

| baseline | n | centre | between-run SD | location limits | dispersion | held out | in control |
|---|---|---|---|---|---|---|---|
| `clock-emvod` | 8 | 1.8133 | 0.0486 | [1.6674, 1.9591] | 0.3983 | `clock-w3yxd` (6) | **6 of 6** |
| `clock-w3yxd` | 6 | 1.7810 | 0.0113 | [1.7471, 1.8149] | 0.6763 | `clock-emvod` (8) | **4 of 8** |

The four refusals are `clock-emvod/run3` (1.8978), `/run4` (1.8475), `/run2` (1.8412) and `/run6` (1.8176) — **every one on LOCATION, not one on dispersion**, so this is a statement about where the two sittings sit rather than about how noisy either was.

**The cause is not a large between-session shift.** The mount centres are 0.0322 apart (1.81%) — *smaller* in absolute terms than bulk's 0.0412, where both directions held. What differs is the `clock-w3yxd` sitting's own reproducibility: its six mount medians span `0.0300` and give a between-run SD of `0.0113`, under a quarter of emvod's `0.0486`. Its ±3σ budget is therefore only `0.0678` wide, and the between-session offset alone consumes 2.85 of the 3 σ. Fitted the other way the budget is `0.2917` wide and the same offset costs 0.66 σ.

**The shipped limits are not the failing ones.** v2 pools both sittings, so its between-run SD of `0.0397` already carries the between-session component; its limits are `0.2382` wide — narrower than the emvod-derived `0.2917` and 3.5× wider than the w3yxd-derived `0.0678` — and all 14 row-runs are inside. What the split impeaches is **single-sitting calibration** on that class, which is a live risk because 14 runs is thin and the temptation at the next recalibration is to take one sitting's worth. That is now a named recalibration trigger on the standard, alongside the commit-level residual.

## No limit moved

The fence this bead was raised under is that a hold-out failure is an answer, not a tuning signal. Every centre, location limit, dispersion limit, tolerance band and error rate is **byte-identical to v2**, on both classes, pinned literally in `clock_exit_path.test.cjs`. Nothing was widened, no hard refusal is involved, the retired ctl3 gate and the all-blocks rule are untouched, and the census standard is not touched. The readjudicator's output over both ensembles is byte-identical before and after.

What changed is the two `independence` fields, a new `provenance.holdOut` record per class carrying the derived limits and the named refusals, one amendment entry (v2 → v3), and two `recalibrateOn` entries naming the residual.

Files: `clock_check_standard.json`, `clock_check_standard.cjs` (header + nine new fixtures), `clock_exit_path.test.cjs` (eight new witnesses; three existing `NOT INDEPENDENT` assertions updated to the claim that replaces it). One more, outside the bead's stated surface and flagged here for that reason: `docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md` asserted "the JSON's `provenance.independence` says so" about a claim this PR removes, so it carries a one-paragraph annotation in its own `*(date, bead: …)*` idiom rather than being left factually wrong.

## Quality gates

Foreground, to completion, in the worker worktree `C:/Users/miket/code/re-frame2-worktrees/holdout-c1974`, rebased onto `origin/main` `7b56349f59`. Every gate's `gate root:` names that worktree.

| gate | result |
|---|---|
| `node --check clock_check_standard.cjs` | exit 0 |
| `node --check clock_exit_path.test.cjs` | exit 0 |
| `node clock_check_standard.cjs` | exit 0 — **25 → 34 checks**, 0 failed |
| `node clock_readjudicate.cjs data/clock-emvod/run{1..8}.json` | exit 0 — output **byte-identical** to `origin/main`'s (0-line diff) |
| `node clock_readjudicate.cjs data/clock-w3yxd/run{1..6}.json` | exit 0 — output **byte-identical** to `origin/main`'s (0-line diff) |
| `node clock_exit_path.test.cjs` | exit 0 — **321 → 329 passed** (baseline measured by checking out `origin/main`'s three files and running them) |
| `npm run test:script-helpers` | exit 0 |
| `sh scripts/test-fast-pr.sh` | exit 0 — `PASS fast PR spine` (docs=true jvm=true node=true) |
| `npm run lint:js` (repo root) | exit 0 |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | exit 0 — "No beads-database paths in this PR diff." |

The readjudicator prints the standard's verdict as an IN/OUT column rather than its version string, which is why a v2 → v3 bump leaves its output unchanged; the version travels in the stored verdict, and every published figure is still reproduced exactly.

`docs/design/hicasso/**` is excluded from `mkdocs build --strict` by `mkdocs.yml`'s `exclude_docs`, so that is not the gate for this edit. `scripts/check_doc_slugs.py` runs in the spine. The doc change adds **no links, no headings and no tables** — it is one annotated paragraph in the existing `*(date, bead: …)*` idiom — and anchors and table column counts were checked by hand accordingly: nothing was added or removed.

## Mutation proof

Every witness shown red against the thing it exists to catch, then green on the final tree (329 passed / 34 checks).

| mutation | exit-path reds | self-test reds |
|---|---|---|
| the **pre-v3 standard** (`origin/main`'s JSON + module) under the new witnesses | **10** | — (old module) |
| only the **pre-v3 JSON**, under the new module and witnesses | **11** | **7** |
| claim the mount directions **agreed** (`agree: true`) | 2 | 1 |
| **widen** the mount's shipped limits to the emvod-derived fit, so the failing hold-out would pass | 2 | 2 |
| **drop the residual** `recalibrateOn` entry | 2 | 1 |
| **fold the hold-out** — both directions baselined on the same ensemble | 4 | 1 |
| **average the disagreement away** — drop the mount's named refusals | 3 | 1 |
| **overstate the independence** — claim commit level | 5 | 1 |

The first two rows are the one the bead asks for: the new witnesses are red against the old self-seeded numbers and green against the measurement that replaces them.

## What this does not close

`rf2-8a746` part 3 is **partly** discharged. Session-level independence is now measured, both ways, on both classes. Commit-level independence needs a future ensemble taken on a different tree, and until it exists no run judged in control by this standard has been judged by limits validated across a code change. That sentence is in `recalibrateOn`, not only here.

Closes rf2-c1974.
