### PR TITLE
fix(hicasso): M1 publishes from K1's own estimand, point and interval together (rf2-diaud)

### DIFF
--- a/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
+++ b/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
@@ -343,7 +343,7 @@ ensemble was taken at, so it is filed rather than done here.
 > ```
 >
 > through the same run-preserving bootstrap — outer runs resampled before inner
-> rounds, 4,000 draws, fixed seed `20260807`.
+> rounds, 4,000 draws, at the fixed bootstrap seed 20260807.
 >
 > **And the threshold is the mount's own.** `rf2-8a746`'s whole-interval
 > discipline is retained with no exceptions, but `1.0` and `1.5` are the *bulk*

--- a/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
+++ b/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
@@ -322,6 +322,142 @@ ensemble was taken at, so it is filed rather than done here.
 
 ### 4.3 The published M1 row
 
+> **RULED AND PUBLISHED 2026-08-08 (`rf2-diaud`). THIS BLOCK IS THE LIVE ROW;
+> everything below it is the record of how it got here.** The magnitudes held by
+> the `rf2-x7x10` block that follows are **unheld** — and restated, because the
+> ruling found that they could not have published as they stood.
+>
+> **The defect was not a wrong number. It was two estimators in one figure.**
+> `validation.md` defines canonical `M1` as **floor-normalised** on the clock of
+> record; the effect-size interval was computed on the **level ratio that
+> touches neither floor**. Both are correct arithmetic and they are not the same
+> quantity. The publication proposed below spliced floor-normalised *points*
+> onto unfloored geometric *intervals*, and a point and an interval must
+> describe the same estimand. **No spliced figure ever publishes.**
+>
+> **So the tool now computes K1's own estimand and takes the point and the
+> interval from that one estimator.** Per round, per segment, tared:
+>
+> ```
+> ((H − plumbH) / (floorH − plumbH)) ÷ ((U − plumbU) / (floorU − plumbU))
+> ```
+>
+> through the same run-preserving bootstrap — outer runs resampled before inner
+> rounds, 4,000 draws, fixed seed `20260807`.
+>
+> **And the threshold is the mount's own.** `rf2-8a746`'s whole-interval
+> discipline is retained with no exceptions, but `1.0` and `1.5` are the *bulk*
+> row's bar and architecture-kill. `M1`'s decision threshold is **K1's `1.10×`
+> against direct UIx-on-subs**: ship only when the whole interval sits at or
+> below it, trip K1 only when the whole interval sits above it, otherwise
+> instrument-limited.
+>
+> #### The published row — K1 is MISSED, decisively
+>
+> | ensemble | outer runs | `hicasso / uix-subs`, floor-normalised | verdict against K1's `1.10×` |
+> |---|---:|---|---|
+> | `clock-emvod` | 8 | **1.1718×** [1.1263 – 1.2190] | whole interval above — **K1 MISSED** |
+> | `clock-w3yxd` | 6 | **1.1976×** [1.1504 – 1.2468] | whole interval above — **K1 MISSED** |
+>
+> Both intervals lie entirely above `1.10×` on the losing side, so the mount
+> premium is a **magnitude and not a direction**: the candidate mounts at
+> roughly **1.17 – 1.20× direct UIx-on-subs**, and K1's gate is missed on two
+> independently launched ensembles.
+>
+> #### Reagent-on-subs, co-instrumented and gating nothing
+>
+> `validation.md` states K1's gate against **direct UIx-on-subs** and says in
+> terms that Reagent-on-subs is *"co-instrumented and reported beside the mount
+> row, not gating it"*. These are the same estimand and the same bootstrap; they
+> adjudicate no threshold, and the tool labels them `CO-INSTRUMENTED` rather
+> than giving them a verdict.
+>
+> | pair | `clock-emvod` *(n=8)* | `clock-w3yxd` *(n=6)* |
+> |---|---|---|
+> | `hicasso / reagent-subs` | 1.1326× [1.0775 – 1.1955] | 1.1282× [1.0217 – 1.2301] |
+> | `uix-subs / reagent-subs` | 0.9665× [0.9179 – 1.0228] | 0.9420× [0.8517 – 1.0294] |
+>
+> #### The unfloored level ratio, kept as a labelled diagnostic
+>
+> It is a **different quantity** from the row above and never the headline. It
+> is printed because the two estimators agreeing on a row's direction is what
+> bounds what the floor normalisation is doing — and because the figures below
+> are the ones the superseded proposal drew its intervals from, so they are
+> where a reader checks the splice for themselves. **No figure in this table may
+> be quoted beside a figure in the tables above.**
+>
+> | pair | `clock-emvod` *(n=8)* | `clock-w3yxd` *(n=6)* |
+> |---|---|---|
+> | `hicasso / uix-subs` | 1.1679× [1.1259 – 1.2096] | 1.1621× [1.1209 – 1.2090] |
+> | `hicasso / reagent-subs` | 1.1142× [1.0238 – 1.1988] | 1.1151× [1.0314 – 1.1955] |
+> | `uix-subs / reagent-subs` | 0.9540× [0.8835 – 1.0139] | 0.9596× [0.8962 – 1.0209] |
+>
+> Every pair moves the same way on both estimators, and on the gated pair the
+> whole interval sits above `1.10×` under **either** — so the verdict does not
+> turn on the choice. What turned on it was the *citable figure*, which is why
+> the repair was owed before publication and not after.
+>
+> #### The cross-run max-band second veto is retired from publication authority
+>
+> `rf2-8a746`'s rule carried a second condition: the effect had to exceed the
+> **widest same-run reproducibility band** among the pooled runs. It is retired
+> here — not because it was inconvenient, but because it is not an interval for
+> the claimed effect, it borrows a control statistic belonging to *one* run of
+> *one* ensemble, and it grows **harder** to clear merely by adding runs.
+>
+> The corpus makes the objection concrete, and this is an argument the ruling
+> did not have. On `clock-emvod` the effect is 17.2% against a widest band of
+> **22.34%** — the retired condition **refuses**. On `clock-w3yxd` it is 19.8%
+> against **18.29%** — the retired condition **admits**. Two ensembles measuring
+> the same effect to within 2.6 pp are sent to *opposite verdicts* by it.
+>
+> **What is not retired:** the **35% band ceiling** remains a run-eligibility
+> guard that refuses a whole run before any interval is formed, and the same-run
+> bands are printed beside every verdict as sensitivity diagnostics.
+>
+> #### Residual uncertainty this row carries, and it is not optional
+>
+> - **Eight and six outer runs only.** The bootstrap resamples runs as the outer
+>   unit, and eight and six are thin ensembles for an outer distribution.
+> - **The mount check standard is not independent of this row.** Its limits were
+>   **calibrated on these same 14 runs** rather than on a separate baseline, so
+>   `14 of 14 in control` is a consistency check and not a false-refusal
+>   measurement. A check standard earns its name on a baseline it is not
+>   afterwards judged on, and this one has not had that yet.
+> - **Both ensembles record the same Chromium**, `147.0.7727.15`. They are
+>   independent of each other in launch, box state and session — not in browser
+>   build. A browser-level effect would appear in both and be invisible to the
+>   replication.
+>
+> #### What replication this row actually claims
+>
+> **Two independently launched ensembles, whole-ensemble figures, overlapping
+> intervals.** That is the whole of it, and it is the ruling's own wording. The
+> published points sit **2.58 pp** apart (1.1718× against 1.1976×), the two
+> intervals overlap over `[1.1504 – 1.2190]`, and each contains the other's
+> point. No selection stands behind either figure: `14 of 14` runs are in
+> control, so the reportable subset is the whole ensemble in both cases.
+>
+> The section below used to rest weight on a much tighter agreement between the
+> two ensembles on this pair. **That claim is withdrawn** (`rf2-diaud` part 3):
+> it was a property of the *selection* those figures were means over and not of
+> the measurement, and it disappears the moment the selection does. It is
+> withdrawn rather than restated, because a corroboration that survives only
+> under a selection is not corroboration.
+>
+> **Reproduce it.** Every figure in this block is arithmetic over the committed
+> corpus, printed by the canonical tool and quoted from nowhere else:
+>
+> ```bash
+> node freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs \
+>   freehand/test/re_frame/bench/hicasso/data/clock-emvod/run*.json
+> # exit 0 — ROW M1, PAIR hicasso / uix-subs:
+> #   point 1.1718x  95% CI [1.1263 – 1.2190]  over 8 reportable run(s)
+> #   VERDICT K1 MISSED, DECISIVELY — the whole interval is above the 1.1x mount gate
+> ```
+>
+> **No measurement was taken for any of this**, and no window was consumed.
+
 > **RE-ADJUDICATED 2026-08-08 UNDER A CALIBRATED MOUNT CLASS (`rf2-x7x10`), AND
 > THE CONDITIONING LABEL BELOW IS SUPERSEDED.** Nothing in this section is
 > erased and no figure in it was found wrong. What changed is the *rule* the
@@ -365,17 +501,24 @@ ensemble was taken at, so it is filed rather than done here.
 > headline.
 >
 > **And one claim below does not survive the change of subset.** The section
-> rests weight on the two ensembles "agreeing to **0.11 percentage points**" on
-> the UIx pair. That agreement was a property of the *selected* subsets:
-> unselected, the two ensembles sit **2.6 pp** apart (1.1798 against 1.2057).
-> The Reagent pair moves the other way — 3.0 pp apart on the subsets, **0.6 pp**
-> apart unselected. Neither direction was chosen; both are what removing a
-> selection on a control does, and the honest reading is that the selection was
-> making the UIx replication look tighter than it is and the Reagent
-> replication looser.
+> rested weight on the two ensembles agreeing to about a tenth of a percentage
+> point on the UIx pair. That agreement was a property of the *selected*
+> subsets: unselected, the two ensembles sit **2.6 pp** apart (1.1798 against
+> 1.2057). The Reagent pair moves the other way — 3.0 pp apart on the subsets,
+> **0.6 pp** apart unselected. Neither direction was chosen; both are what
+> removing a selection on a control does, and the honest reading is that the
+> selection was making the UIx replication look tighter than it is and the
+> Reagent replication looser. **The claim is retired everywhere on this page**
+> (`rf2-diaud` part 3), and the sentence that asserted it is gone rather than
+> struck: a corroboration figure left legible in strikethrough is still a figure
+> a reader can lift.
 >
 > **`rf2-8a746`'s publication rule now reaches this row, and it refuses a
-> magnitude.** It could not reach it before: with no run eligible, no interval
+> magnitude.** *(**Superseded 2026-08-08 by `rf2-diaud`** — see the block at the
+> head of this section. The refusal below is correct for the rule as it stood
+> and for the estimand it was computed on; the ruling replaced both. The table
+> that follows survives as the **labelled diagnostic** it is quoted as up
+> there.)* It could not reach it before: with no run eligible, no interval
 > was formed. With all 14 eligible the run-preserving effect-size interval
 > (paired same-round level ratios, outer runs resampled before inner rounds,
 > 4000 draws, at the fixed bootstrap seed 20260807) computes, and on **every
@@ -402,6 +545,15 @@ ensemble was taken at, so it is filed rather than done here.
 > disagree, and which governs is a **ruling** rather than a worker's call — the
 > same reason §7.2 stopped rather than published. Recorded, not decided.
 >
+> **THE RULING CAME (2026-08-08, `rf2-diaud`), AND THE HOLD IS LIFTED.** It went
+> further than the collision it was asked about: the whole-interval discipline
+> is kept but its threshold is **row-class-specific**, and the row is
+> re-computed on **K1's own floor-normalised estimand** rather than published
+> from the level-ratio interval quoted above. The magnitudes below are therefore
+> **superseded rather than restored** — the live row is at the head of this
+> section. Which is why holding rather than withdrawing was right: a withdrawal
+> would have thrown away the row that a corrected estimator went on to publish.
+>
 > **No measurement was taken for any of this.** Every figure in this block is
 > arithmetic over the committed 42-run corpus, reproduced by the command in
 > [§7.2](#72-the-re-take-that-was-taken-and-what-it-refuses) over each
@@ -421,8 +573,12 @@ not hold. It is published on the two retained quiet-box ensembles,
 | `clock-emvod` | **1.1837×** *(n=4)* | 1.1798× [1.1346 – 1.2347] *(n=8)* | 1.1561× *(n=4)* |
 | `clock-w3yxd` | **1.1848×** *(n=3)* | 1.2057× [1.1731 – 1.2390] *(n=6)* | 1.1537× *(n=3)* |
 
-Two independently launched ensembles agreeing to **0.11 percentage points** on
-the programme's floor-normalised `TaskDuration` estimator. The **raw quotient —
+Two independently launched ensembles on the programme's floor-normalised
+`TaskDuration` estimator. **The corroboration claim that stood here — that the
+two ensembles agreed to about a tenth of a percentage point — is RETIRED**
+(2026-08-08, `rf2-diaud` part 3): it was a property of the *selected subsets*
+rather than of the measurement, and unselected the two sit 2.6 pp apart. The
+honest replication statement is at the head of this section. The **raw quotient —
 the direct arm-to-arm comparison touching neither floor — reads `~1.155×`**, and
 it is stated here beside the headline rather than behind it: on the reportable
 subsets the two estimators differ by **2.8 pp** (`clock-emvod`) and **3.1 pp**
@@ -439,9 +595,12 @@ point.**
 | `clock-emvod` | **1.1402×** *(n=4)* | 1.1429× [1.0723 – 1.2640] *(n=8)* | 1.1545× *(n=4)* |
 | `clock-w3yxd` | **1.1100×** *(n=3)* | 1.1492× [1.0492 – 1.3339] *(n=6)* | 1.0969× *(n=3)* |
 
-The replication is **looser** on this pair — 3.0 pp apart floor-normalised and
-5.8 pp raw, against 0.11 pp on the UIx pair — so the two estimates are published
-side by side and **a single pooled figure is refused**. Averaging them would
+The replication was read as **looser** on this pair — 3.0 pp apart
+floor-normalised and 5.8 pp raw — so the two estimates are published side by
+side and **a single pooled figure is refused**. *(The comparison this sentence
+drew against the UIx pair is retired with the claim it rested on — `rf2-diaud`
+part 3. On the whole ensembles the ordering reverses: the Reagent pair is the
+**tighter** replication of the two.)* Averaging them would
 manufacture a precision the data does not carry, and the honest statement is that
 the candidate is above Reagent-on-subs on mount by something in the low tens of
 percent, measured twice, at two values.

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -3938,25 +3938,34 @@ function fixtureRoundsTask(over) {
   t('criterion 3: the WHOLE interval must clear the threshold, and the effect must clear the band', () => {
     // Both conditions and neither alone, driven at the boundary in each
     // direction. A lower ratio is faster: these are times.
+    //
+    // AMENDED BY rf2-diaud: the verdict is asked for a ROW and a PAIR rather
+    // than a bare limit, because the threshold belongs to the row class beside
+    // the estimand it was derived for. `bulk300` is the bulk class, whose path
+    // rf2-diaud (b) leaves unchanged — including its band veto, retained on
+    // this class alone pending rf2-vh0e3 — so every assertion below still
+    // reads exactly as rf2-8a746 froze it.
+    const P = 'hicasso / reagent-subs';
+    const ev = (iv, bandPct) => effectVerdict(iv, BULK, P, { widestSameRunBandPct: bandPct });
     const below = { runs: 8, rounds: [6], point: 0.6, lo: 0.55, hi: 0.65, draws: 1, seed: 1 };
-    assert.strictEqual(effectVerdict(below, 10).publishes, true, 'wholly below 1.0 and a 40% effect over a 10% band');
-    assert.match(effectVerdict(below, 10).verdict, /MAGNITUDE PUBLISHABLE/);
-    assert.strictEqual(effectVerdict(below, 50).publishes, false, 'the same interval inside a 50% band publishes nothing');
-    assert.match(effectVerdict(below, 50).why, /an effect inside the band is a difference this instrument cannot resolve/);
+    assert.strictEqual(ev(below, 10).publishes, true, 'wholly below 1.0 and a 40% effect over a 10% band');
+    assert.match(ev(below, 10).verdict, /MAGNITUDE PUBLISHABLE/);
+    assert.strictEqual(ev(below, 50).publishes, false, 'the same interval inside a 50% band publishes nothing');
+    assert.match(ev(below, 50).why, /the widest same-run noise band among the pooled runs/);
     const straddles = { runs: 8, rounds: [6], point: 0.99, lo: 0.9, hi: 1.05, draws: 1, seed: 1 };
-    assert.strictEqual(effectVerdict(straddles, 1).publishes, false, 'an interval containing parity publishes nothing');
-    assert.match(effectVerdict(straddles, 1).verdict, /INSTRUMENT-LIMITED/);
+    assert.strictEqual(ev(straddles, 1).publishes, false, 'an interval containing parity publishes nothing');
+    assert.match(ev(straddles, 1).verdict, /INSTRUMENT-LIMITED/);
     const kill = { runs: 8, rounds: [6], point: 1.9, lo: 1.7, hi: 2.1, draws: 1, seed: 1 };
-    assert.strictEqual(effectVerdict(kill, 10).publishes, true);
-    assert.match(effectVerdict(kill, 10).verdict, /ARCHITECTURE-KILL/);
+    assert.strictEqual(ev(kill, 10).publishes, true);
+    assert.match(ev(kill, 10).verdict, /ARCHITECTURE-KILL/);
     const nearKill = { runs: 8, rounds: [6], point: 1.5, lo: 1.4, hi: 1.6, draws: 1, seed: 1 };
-    assert.strictEqual(effectVerdict(nearKill, 10).publishes, false, 'an interval straddling 1.5 is not a kill');
+    assert.strictEqual(ev(nearKill, 10).publishes, false, 'an interval straddling 1.5 is not a kill');
     // an unrecorded band is not a clear band
-    assert.strictEqual(effectVerdict(below, NaN).publishes, false, 'no band recorded is not a band cleared');
+    assert.strictEqual(ev(below, NaN).publishes, false, 'no band recorded is not a band cleared');
     // and two runs are not an ensemble
-    assert.strictEqual(effectVerdict({ ...below, runs: 2 }, 1).publishes, false);
-    assert.match(effectVerdict({ ...below, runs: 2 }, 1).why, /is not an ensemble/);
-    assert.strictEqual(effectVerdict(null, 1).publishes, false, 'no interval is not a pass');
+    assert.strictEqual(ev({ ...below, runs: 2 }, 1).publishes, false);
+    assert.match(ev({ ...below, runs: 2 }, 1).why, /is not an ensemble/);
+    assert.strictEqual(ev(null, 1).publishes, false, 'no interval is not a pass');
   });
 
   // --- 6. AND OVER THE COMMITTED 42-RUN CORPUS ------------------------------
@@ -4006,9 +4015,9 @@ function fixtureRoundsTask(over) {
         const rows = datasets.map((data) => ({ data, row: data.rows.find((r) => r.rowId === rowId) })).filter((x) => x.row);
         const pooled = rows.filter(({ row, data }) => reportable(row, data));
         for (const pair of PAIRS_8a746) {
-          const iv = effectInterval(pooled.map(({ row }) => pairedLogRatios(row, pair)).filter(Boolean));
+          const iv = effectInterval(pooled.map(({ row, data }) => pairedLogRatios(row, pair, data)).filter(Boolean));
           const bands = pooled.map(({ row }) => row.seamTask.band).filter(Number.isFinite).map((b) => b * 100);
-          const ev = effectVerdict(iv, bands.length ? Math.max(...bands) : NaN);
+          const ev = effectVerdict(iv, rowId, pair, { widestSameRunBandPct: bands.length ? Math.max(...bands) : NaN });
           assert.ok(typeof ev.why === 'string' && ev.why.length > 0, `${dir}/${rowId}/${pair}: a verdict must carry its reason`);
           assert.ok(
             /^(INSTRUMENT-LIMITED|MAGNITUDE PUBLISHABLE|ARCHITECTURE-KILL)/.test(ev.verdict),
@@ -4027,7 +4036,15 @@ function fixtureRoundsTask(over) {
     }
   });
 
-  t('and the program itself exits 0 over both committed ensembles, publishing no magnitude', () => {
+  t('and the program itself exits 0 over both committed ensembles, publishing no BULK magnitude', () => {
+    // SCOPED TO THE BULK BLOCKS BY rf2-diaud, and the scoping is the fence
+    // rather than a relaxation of it. This assertion used to read the whole
+    // output because the whole output was bulk's answer; the mount row now
+    // publishes under its own ruling, so a whole-output grep would pin M1's
+    // verdict here by accident — in the block whose entire subject is that the
+    // 42 BULK row-runs are calibration evidence and are never retroactively
+    // promoted. The M1 verdict is pinned where it belongs, in the rf2-diaud
+    // block at the foot of this file.
     const RJ = path.join(__dirname, 'clock_readjudicate.cjs');
     for (const { dir } of CORPORA) {
       const d = path.join(__dirname, 'data', dir);
@@ -4036,8 +4053,17 @@ function fixtureRoundsTask(over) {
       const r = cp.spawnSync(process.execPath, [RJ, ...files], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
       const out = `${r.stdout}${r.stderr}`;
       assert.strictEqual(r.status, 0, `${dir}: ${out.slice(-2000)}`);
-      assert.ok(/EFFECT-SIZE INTERVAL \(rf2-8a746\)/.test(out), `${dir}: the interval must be printed`);
-      assert.ok(!/VERDICT MAGNITUDE PUBLISHABLE|VERDICT ARCHITECTURE-KILL/.test(out), `${dir}: no magnitude may be published from the corpus`);
+      assert.ok(/EFFECT-SIZE INTERVAL \(rf2-8a746, row-class estimand and threshold rf2-diaud\)/.test(out), `${dir}: the interval must be printed`);
+      for (const rowId of BULK_ROWS) {
+        const at = out.indexOf(`;; ======== ROW ${rowId} `);
+        assert.ok(at >= 0, `${dir}: the ${rowId} block must be printed`);
+        const next = out.indexOf(';; ======== ROW ', at + 1);
+        const block = out.slice(at, next < 0 ? undefined : next);
+        assert.ok(
+          !/VERDICT MAGNITUDE PUBLISHABLE|VERDICT ARCHITECTURE-KILL/.test(block),
+          `${dir}/${rowId}: no magnitude may be published from the committed corpus`
+        );
+      }
       assert.ok(/pooled means below are DIAGNOSTICS/.test(out), `${dir}: the pooled means must be labelled`);
     }
   });
@@ -4252,28 +4278,35 @@ function fixtureRoundsTask(over) {
       const rows = c.map(({ data }) => ({ data, row: data.rows.find((r) => r.rowId === 'M1') })).filter((x) => x.row);
       const pooled = rows.filter(({ row, data }) => reportable(row, data));
       for (const pair of M1_PAIRS) {
-        const iv = effectInterval(pooled.map(({ row }) => pairedLogRatios(row, pair)).filter(Boolean));
-        const bands = pooled.map(({ row }) => row.seamTask.band).filter(Number.isFinite).map((b) => b * 100);
-        const ev = effectVerdict(iv, bands.length ? Math.max(...bands) : NaN);
+        const iv = effectInterval(pooled.map(({ row, data }) => pairedLogRatios(row, pair, data)).filter(Boolean));
+        const ev = effectVerdict(iv, 'M1', pair);
         assert.ok(iv, `${dir}/M1/${pair}: the corpus must now yield an interval to adjudicate`);
         assert.ok(iv.lo <= iv.point && iv.point <= iv.hi, `${dir}/M1/${pair}: the point must lie inside its own interval`);
         assert.ok(typeof ev.why === 'string' && ev.why.length > 0, `${dir}/M1/${pair}: a verdict must carry its reason`);
         assert.ok(
-          /^(INSTRUMENT-LIMITED|MAGNITUDE PUBLISHABLE|ARCHITECTURE-KILL)/.test(ev.verdict),
+          /^(INSTRUMENT-LIMITED|MAGNITUDE PUBLISHABLE|ARCHITECTURE-KILL|K1 MISSED|MOUNT SHIP BAR MET|CO-INSTRUMENTED)/.test(ev.verdict),
           `${dir}/M1/${pair}: unrecognised verdict ${ev.verdict}`
         );
-        // PINNED AS THE RULING'S FENCE, NOT AS A PREFERRED ANSWER, exactly as
-        // the bulk corpus case above is. These 14 row-runs are calibration
-        // evidence; promoting them to a published magnitude is a RULING —
-        // rf2-t2flm's magnitude and rf2-8a746's whole-interval rule currently
-        // disagree on this row — and no code here may do it silently. If this
-        // ever flips, the failure IS the finding.
+        // THE PIN FLIPPED, AND IT FLIPPED BY RULING (rf2-diaud, 2026-08-08).
+        //
+        // It used to read `publishes === false` on every pair, with a message
+        // saying that a flip is a ruling to be made and not a test to be
+        // updated. That was right, the ruling was made, and this is what it
+        // says: `M1` is adjudicated against K1's `1.10x` mount gate rather than
+        // against bulk's `1.0`/`1.5`, on K1's OWN floor-normalised estimand,
+        // and on the gated pair the whole interval sits above the gate. The
+        // magnitude is published — as a MISS, which is the honest direction.
+        //
+        // The other two pairs publish nothing, and not because they are noisy:
+        // `validation.md` states K1's gate against DIRECT UIx-on-subs and says
+        // in terms that Reagent-on-subs does not gate this row.
+        const gated = pair === 'hicasso / uix-subs';
         assert.strictEqual(
           ev.publishes,
-          false,
-          `${dir}/M1/${pair} PUBLISHED a magnitude from the committed corpus. That is a ruling to be made, not a ` +
-            `test to be updated: rf2-t2flm publishes a magnitude on this row and rf2-8a746 part 4 publishes one only ` +
-            `on a whole interval clearing the 1.0 bar or the 1.5 kill threshold. Verdict: ${ev.verdict} — ${ev.why}`
+          gated,
+          `${dir}/M1/${pair}: expected publishes === ${gated} under rf2-diaud — the gated pair trips K1 on a whole ` +
+            `interval above 1.10x, the co-instrumented pairs are reported beside it and gate nothing. ` +
+            `Verdict: ${ev.verdict} — ${ev.why}`
         );
       }
     }
@@ -4292,7 +4325,7 @@ function fixtureRoundsTask(over) {
       assert.ok(!/reportable subset: NONE/.test(m1), `${dir}: the M1 row must have a reportable subset — that is the defect rf2-x7x10 repairs`);
       assert.ok(new RegExp(`reportable subset [0-9.]+x n=${runs}`).test(m1), `${dir}: the subset must pool all ${runs} runs`);
       assert.ok(!/the `mount` class of the check standard is NOT CALIBRATED/.test(m1), `${dir}: the mount class is calibrated now`);
-      assert.ok(/EFFECT-SIZE INTERVAL \(rf2-8a746\)/.test(m1), `${dir}: the interval must be printed on M1 too`);
+      assert.ok(/EFFECT-SIZE INTERVAL \(rf2-8a746, row-class estimand and threshold rf2-diaud\)/.test(m1), `${dir}: the interval must be printed on M1 too`);
     }
   });
 
@@ -4620,6 +4653,369 @@ function fixtureRoundsTask(over) {
   t('the ruling is cited by bead id in every surface it changed', () => {
     for (const file of ['clock_check_standard.json', 'clock_check_standard.cjs']) {
       assert.ok(/rf2-c1974/.test(fs.readFileSync(path.join(__dirname, file), 'utf8')), `${file} must cite the ruling that changed it`);
+    }
+  });
+}
+
+// --- rf2-diaud: A POINT AND AN INTERVAL MUST DESCRIBE THE SAME ESTIMAND ------
+//
+// The defect this block pins is not a wrong number. Every figure `rf2-t2flm`
+// and `rf2-x7x10` published was correctly computed. The fault was that the
+// POINT and the INTERVAL came from two different estimators: `validation.md`
+// defines canonical `M1` as FLOOR-NORMALISED on the clock of record, while the
+// interval was computed on the level ratio that touches neither floor. The
+// proposed publication spliced floor-normalised points onto unfloored geometric
+// intervals — two correct figures making one incorrect claim.
+//
+// So the block below proves three things, and the third is the one that lasts:
+// that the tool computes K1's own estimand; that the row-specific threshold is
+// what adjudicates it; and that NO FIGURE CAN BE SPLICED, because the estimand
+// is bound to the threshold in one table entry and neither can be supplied by a
+// caller.
+{
+  const {
+    pairedLogRatios, counterpartLogRatios, effectInterval, effectVerdict,
+    reportable, PUBLICATION, publicationRule,
+  } = require('./clock_readjudicate.cjs');
+  const t = (what, fn) => test(`rf2-diaud: ${what}`, fn);
+  const GATED = 'hicasso / uix-subs';
+  const M1_PAIRS = ['hicasso / reagent-subs', GATED, 'uix-subs / reagent-subs'];
+  const STUDIO = path.join(__dirname, '..', '..', '..', '..', '..', '..', 'docs', 'design', 'hicasso', 'studio');
+
+  /** The ruling's expected outcome, to 4 places — the tool's, not the note's. */
+  const EXPECTED = {
+    'clock-emvod': { runs: 8, point: '1.1718', lo: '1.1263', hi: '1.2190', widestBand: 22.34 },
+    'clock-w3yxd': { runs: 6, point: '1.1976', lo: '1.1504', hi: '1.2468', widestBand: 18.29 },
+  };
+
+  const corpus = (dir) => {
+    const d = path.join(__dirname, 'data', dir);
+    if (!fs.existsSync(d)) return null;
+    return fs.readdirSync(d).map((f) => ({ file: path.join(d, f), data: JSON.parse(fs.readFileSync(path.join(d, f), 'utf8')) }));
+  };
+
+  /** Every reportable M1 run of an ensemble, as the publication path sees them. */
+  const pooledM1 = (dir) => {
+    const c = corpus(dir);
+    if (!c) return null;
+    return c
+      .map(({ data }) => ({ data, row: data.rows.find((r) => r.rowId === 'M1') }))
+      .filter((x) => x.row && reportable(x.row, x.data));
+  };
+
+  const m1Interval = (dir, pair) => {
+    const pooled = pooledM1(dir);
+    return pooled && effectInterval(pooled.map(({ row, data }) => pairedLogRatios(row, pair, data)).filter(Boolean));
+  };
+
+  // --- 1. CRITERION (a): THE TOOL COMPUTES K1's OWN ESTIMAND ----------------
+
+  t("criterion (a): the mount estimand IS validation.md's canonical M1, and the driver's own bar proves it", () => {
+    // The estimator is computed from `roundsTask` — the raw per-sample
+    // readings — and not read back from a stored summary. `clock_run.cjs`'s
+    // `crossSegment` computed the same quantity at capture time and stored it
+    // in `barTask[pair].perRound`, so the two agreeing to the last place is a
+    // WITNESS that this file implements the driver's own definition rather
+    // than an assumption that it does. If they ever part, one of them has
+    // silently changed what canonical `M1` means.
+    let checked = 0;
+    for (const dir of Object.keys(EXPECTED)) {
+      const c = corpus(dir);
+      if (!c) return;
+      for (const { data } of c) {
+        const row = data.rows.find((r) => r.rowId === 'M1');
+        for (const pair of M1_PAIRS) {
+          const mine = pairedLogRatios(row, pair, data).map((x) => Math.exp(x).toFixed(4));
+          const driver = row.barTask[pair].perRound.map((x) => x.toFixed(4));
+          assert.deepStrictEqual(mine, driver, `${dir}/M1/${pair}: the estimand and the driver's own bar must agree`);
+          checked += 1;
+        }
+      }
+    }
+    assert.strictEqual(checked, 42, 'three pairs over fourteen committed mount row-runs');
+  });
+
+  t('criterion (a): it is FLOOR-NORMALISED, so it is NOT the level ratio — and the difference is measurable', () => {
+    // The whole defect in one assertion. If these two agreed, the splice would
+    // have been harmless and there would have been nothing to repair.
+    for (const dir of Object.keys(EXPECTED)) {
+      const pooled = pooledM1(dir);
+      if (!pooled) return;
+      const floored = effectInterval(pooled.map(({ row, data }) => pairedLogRatios(row, GATED, data)));
+      const level = effectInterval(pooled.map(({ row, data }) => counterpartLogRatios(row, GATED, data)));
+      assert.ok(floored && level);
+      assert.notStrictEqual(floored.point.toFixed(4), level.point.toFixed(4), `${dir}: the two estimands must differ`);
+      assert.notStrictEqual(floored.lo.toFixed(4), level.lo.toFixed(4));
+      assert.notStrictEqual(floored.hi.toFixed(4), level.hi.toFixed(4));
+    }
+  });
+
+  t('criterion (a): the estimand refuses a record that did not serialise its tare', () => {
+    // Fail-closed at the same seat `checkStandardFor` is: whether the readings
+    // are tared decides what a floor-normalised ratio taken from them MEANS.
+    const c = corpus('clock-emvod');
+    if (!c) return;
+    const { data } = c[0];
+    const row = data.rows.find((r) => r.rowId === 'M1');
+    assert.ok(pairedLogRatios(row, GATED, data), 'the design record is present and the estimand forms');
+    assert.strictEqual(pairedLogRatios(row, GATED, { ...data, design: undefined }), null, 'no design record, no estimand');
+    assert.strictEqual(
+      pairedLogRatios(row, GATED, { ...data, design: { ...data.design, tare: 'yes' } }),
+      null,
+      'a tare that is not a boolean has not been serialised'
+    );
+    assert.strictEqual(pairedLogRatios(row, GATED, undefined), null, 'and the dataset is not optional on this class');
+  });
+
+  // --- 2. CRITERION (b): THE THRESHOLD IS THE ROW CLASS'S -------------------
+
+  t('criterion (b): the estimand and the threshold live in ONE entry, so they cannot drift apart', () => {
+    const mount = publicationRule('M1');
+    const bulk = publicationRule('bulk300');
+    assert.strictEqual(mount.estimand, 'floorNormalised');
+    assert.strictEqual(mount.gate, 1.1);
+    assert.match(mount.governingRecord, /validation\.md:14\/:286/);
+    assert.match(mount.governingRecord, /FLOOR-NORMALISED/);
+    assert.strictEqual(bulk.estimand, 'level');
+    assert.strictEqual(bulk.bar, 1.0);
+    assert.strictEqual(bulk.architectureKill, 1.5);
+    assert.strictEqual(publicationRule('keystroke'), null, 'a row with no class has no rule, and publishes nothing');
+    assert.strictEqual(effectVerdict(null, 'keystroke', GATED).publishes, false);
+    assert.match(effectVerdict(null, 'keystroke', GATED).verdict, /NO PUBLICATION RULE/);
+  });
+
+  t("criterion (b): the mount rule's boundary, driven in both directions at 1.10x", () => {
+    const iv = (lo, hi) => ({ runs: 8, rounds: [6], point: (lo + hi) / 2, lo, hi, draws: 1, seed: 1 });
+    // ship: the WHOLE interval at or below the gate
+    assert.strictEqual(effectVerdict(iv(1.0, 1.1), 'M1', GATED).publishes, true, '1.10 exactly is at the gate, so it ships');
+    assert.match(effectVerdict(iv(1.0, 1.1), 'M1', GATED).verdict, /MOUNT SHIP BAR MET/);
+    assert.strictEqual(effectVerdict(iv(1.0, 1.1001), 'M1', GATED).publishes, false, 'a hair above and it no longer ships');
+    // trip: the WHOLE interval strictly above the gate
+    assert.strictEqual(effectVerdict(iv(1.1001, 1.3), 'M1', GATED).publishes, true);
+    assert.match(effectVerdict(iv(1.1001, 1.3), 'M1', GATED).verdict, /K1 MISSED, DECISIVELY/);
+    assert.strictEqual(effectVerdict(iv(1.1, 1.3), 'M1', GATED).publishes, false, 'a lower bound AT the gate is not above it');
+    // and the middle is instrument-limited, which is the discipline retained
+    assert.match(effectVerdict(iv(1.05, 1.2), 'M1', GATED).verdict, /INSTRUMENT-LIMITED/);
+    assert.match(effectVerdict(iv(1.05, 1.2), 'M1', GATED).why, /straddles K1's 1\.1x mount gate/);
+    // two runs are still not an ensemble, on any class
+    assert.strictEqual(effectVerdict({ ...iv(1.2, 1.3), runs: 2 }, 'M1', GATED).publishes, false);
+  });
+
+  t("MUTATION: adjudicate M1's own interval against BULK's thresholds and it stops publishing", () => {
+    // The pre-ruling behaviour, reproduced deliberately. `1.0`/`1.5` are the
+    // bulk row's lines; an interval at ~1.17x clears neither, which is exactly
+    // why rf2-8a746's rule returned INSTRUMENT-LIMITED on a row whose own gate
+    // it clears decisively. This is the mutation that proves the row-specific
+    // threshold is load-bearing rather than decorative.
+    for (const dir of Object.keys(EXPECTED)) {
+      const iv = m1Interval(dir, GATED);
+      if (!iv) return;
+      assert.strictEqual(effectVerdict(iv, 'M1', GATED).publishes, true, `${dir}: on its own gate it publishes`);
+      const asBulk = effectVerdict(iv, 'bulk300', 'hicasso / reagent-subs', { widestSameRunBandPct: 1 });
+      assert.strictEqual(asBulk.publishes, false, `${dir}: on bulk's thresholds the same interval publishes nothing`);
+      assert.match(asBulk.why, /does not lie wholly on one side of the 1 bar/);
+    }
+  });
+
+  t('MUTATION: without gatedPairs the mount rule would claim the SHIP BAR on a donor-against-donor pair', () => {
+    // `validation.md` states K1's gate against DIRECT UIx-on-subs and says in
+    // terms that Reagent-on-subs does not gate this row. Without that scoping
+    // the rule reads `uix-subs / reagent-subs` — UIx against Reagent, a
+    // comparison K1 does not ask — and, because that interval sits under
+    // 1.10x, announces that the MOUNT SHIP BAR IS MET. Proved by removing the
+    // scoping and putting it back.
+    const iv = m1Interval('clock-emvod', 'uix-subs / reagent-subs');
+    if (!iv) return;
+    assert.ok(iv.hi < 1.1, 'the donor pair does sit under the gate, which is what makes the mutation dangerous');
+    assert.strictEqual(effectVerdict(iv, 'M1', 'uix-subs / reagent-subs').publishes, false);
+    assert.match(effectVerdict(iv, 'M1', 'uix-subs / reagent-subs').verdict, /CO-INSTRUMENTED/);
+    const before = PUBLICATION.mount.gatedPairs;
+    let mutated;
+    try {
+      PUBLICATION.mount.gatedPairs = null;
+      mutated = effectVerdict(iv, 'M1', 'uix-subs / reagent-subs');
+    } finally {
+      PUBLICATION.mount.gatedPairs = before;
+    }
+    assert.strictEqual(mutated.publishes, true, 'the mutation must actually change the answer, or it proves nothing');
+    assert.match(mutated.verdict, /MOUNT SHIP BAR MET/);
+    assert.deepStrictEqual(PUBLICATION.mount.gatedPairs, before, 'the fixture must leave the table as it found it');
+    assert.strictEqual(effectVerdict(iv, 'M1', 'uix-subs / reagent-subs').publishes, false, 'and the scoping holds again');
+  });
+
+  t('MUTATION: swapping the mount estimand changes the published figure, which is the splice', () => {
+    // Both estimators are correct arithmetic. Which one the row publishes on is
+    // the RULING, and it is one field. Flipping it here and reading the figure
+    // back is the closest this file can get to committing the original fault on
+    // purpose and watching the test catch it.
+    const pooled = pooledM1('clock-emvod');
+    if (!pooled) return;
+    const floored = m1Interval('clock-emvod', GATED);
+    const before = PUBLICATION.mount.estimand;
+    let mutated;
+    try {
+      PUBLICATION.mount.estimand = 'level';
+      mutated = effectInterval(pooled.map(({ row, data }) => pairedLogRatios(row, GATED, data)).filter(Boolean));
+    } finally {
+      PUBLICATION.mount.estimand = before;
+    }
+    assert.strictEqual(floored.point.toFixed(4), EXPECTED['clock-emvod'].point);
+    assert.strictEqual(mutated.point.toFixed(4), '1.1679', "the level estimand's own point, for the record");
+    assert.strictEqual(mutated.lo.toFixed(4), '1.1259');
+    assert.strictEqual(mutated.hi.toFixed(4), '1.2096');
+    assert.strictEqual(PUBLICATION.mount.estimand, before, 'the fixture must leave the table as it found it');
+    assert.strictEqual(m1Interval('clock-emvod', GATED).point.toFixed(4), EXPECTED['clock-emvod'].point);
+  });
+
+  // --- 3. CRITERION (c): THE CROSS-RUN MAX-BAND SECOND VETO -----------------
+
+  t('criterion (c): the retirement is LOAD-BEARING, and the veto SPLITS the two ensembles', () => {
+    // Stated as arithmetic rather than asserted, because a retirement that
+    // changed no outcome would not need a ruling. What the corpus actually
+    // shows is stronger than "it would have refused", and it is recorded here
+    // because it is an argument the ruling did not have:
+    //
+    //   clock-emvod  effect 17.2% against a widest same-run band of 22.34% —
+    //                the retired veto REFUSES.
+    //   clock-w3yxd  effect 19.8% against 18.29% — the retired veto ADMITS.
+    //
+    // Two independently launched ensembles measuring the same effect to within
+    // 2.6 pp, and the retired condition sends them to OPPOSITE verdicts —
+    // because it compares the effect to a control statistic belonging to one
+    // run of one ensemble rather than to any interval for the effect. That is
+    // criterion (c)'s three objections showing up as a disagreement.
+    const relation = {};
+    for (const [dir, want] of Object.entries(EXPECTED)) {
+      const pooled = pooledM1(dir);
+      if (!pooled) return;
+      const iv = m1Interval(dir, GATED);
+      const widest = Math.max(...pooled.map(({ row }) => row.seamTask.band * 100));
+      assert.strictEqual(widest.toFixed(2), want.widestBand.toFixed(2), `${dir}: the widest same-run band`);
+      relation[dir] = Math.abs(iv.point - 1) * 100 > widest ? 'admits' : 'refuses';
+      // and none of it reaches the verdict, which is the retirement itself
+      assert.strictEqual(effectVerdict(iv, 'M1', GATED, { widestSameRunBandPct: widest }).publishes, true, `${dir}: publishes regardless`);
+    }
+    assert.deepStrictEqual(
+      relation,
+      { 'clock-emvod': 'refuses', 'clock-w3yxd': 'admits' },
+      'the retired veto must still split the ensembles — if it stops doing so, this argument has changed and the note above is stale'
+    );
+    assert.strictEqual(PUBLICATION.mount.crossRunBandVeto, false, 'and the mount entry says so as data');
+  });
+
+  t('criterion (c): the band is a SENSITIVITY DIAGNOSTIC on the mount — no band at all changes nothing', () => {
+    const iv = m1Interval('clock-emvod', GATED);
+    if (!iv) return;
+    for (const d of [undefined, {}, { widestSameRunBandPct: NaN }, { widestSameRunBandPct: 0.1 }, { widestSameRunBandPct: 99 }]) {
+      assert.strictEqual(effectVerdict(iv, 'M1', GATED, d).publishes, true, `the band must not reach the mount verdict: ${JSON.stringify(d)}`);
+    }
+    // and the 35% CEILING is untouched — it is a GATE, not a veto, and it
+    // still refuses a whole run before any interval is formed.
+    const GATE_IDS = require('./clock_readjudicate.cjs').GATES.map((g) => g.id);
+    assert.ok(GATE_IDS.includes('ceiling-task') && GATE_IDS.includes('ceiling-net'), 'the run-eligibility ceilings stay');
+  });
+
+  t('MUTATION: the veto is RETAINED on bulk, and rf2-vh0e3 is what that costs', () => {
+    // The collision this repair surfaced and did not decide. rf2-diaud (b)
+    // says bulk's path is unchanged; rf2-diaud (c) retires the veto. On the
+    // committed corpus they cannot both hold: retiring it on bulk promotes two
+    // DONOR-AGAINST-DONOR pairs out of the 42-run corpus rf2-8a746 fenced.
+    // Both directions are driven here so the operator's choice is one line and
+    // its price is a number.
+    const PAIR = 'uix-subs / reagent-subs';
+    const c = corpus('clock-emvod');
+    if (!c) return;
+    for (const rowId of ['bulk300', 'bulk100']) {
+      const pooled = c
+        .map(({ data }) => ({ data, row: data.rows.find((r) => r.rowId === rowId) }))
+        .filter((x) => x.row && reportable(x.row, x.data));
+      const iv = effectInterval(pooled.map(({ row, data }) => pairedLogRatios(row, PAIR, data)).filter(Boolean));
+      const widest = Math.max(...pooled.map(({ row }) => row.seamTask.band * 100));
+      assert.ok(iv.hi < 1.0, `${rowId}: the whole interval is below the bar, so only the veto is holding it`);
+      const held = effectVerdict(iv, rowId, PAIR, { widestSameRunBandPct: widest });
+      assert.strictEqual(held.publishes, false, `${rowId}: retained, so no magnitude leaves the corpus`);
+      assert.match(held.why, /rf2-vh0e3/, 'and the refusal names the ruling it waits on');
+      const before = PUBLICATION.bulk.crossRunBandVeto;
+      let mutated;
+      try {
+        PUBLICATION.bulk.crossRunBandVeto = false;
+        mutated = effectVerdict(iv, rowId, PAIR, { widestSameRunBandPct: widest });
+      } finally {
+        PUBLICATION.bulk.crossRunBandVeto = before;
+      }
+      assert.strictEqual(mutated.publishes, true, `${rowId}: retiring it here WOULD publish — that is rf2-vh0e3's cost`);
+      assert.strictEqual(PUBLICATION.bulk.crossRunBandVeto, true, 'the fixture must leave the table as it found it');
+    }
+  });
+
+  // --- 4. CRITERION (e): M1 PUBLISHES FROM THE CANONICAL TOOL'S OUTPUT ------
+
+  t('criterion (e): the figures come out of clock_readjudicate.cjs itself, on both ensembles', () => {
+    // NOT from the ruling note and not from any replay. The tool is spawned,
+    // its M1 block is read, and the point and BOTH bounds are asserted off the
+    // one printed line — which is the only way a splice cannot survive: a
+    // figure read from one line of one estimator's output has no second line
+    // to borrow a bound from.
+    const RJ = path.join(__dirname, 'clock_readjudicate.cjs');
+    for (const [dir, want] of Object.entries(EXPECTED)) {
+      const c = corpus(dir);
+      if (!c) return;
+      const r = cp.spawnSync(process.execPath, [RJ, ...c.map((x) => x.file)], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+      const out = `${r.stdout}${r.stderr}`;
+      assert.strictEqual(r.status, 0, `${dir}: ${out.slice(-2000)}`);
+      const m1 = out.slice(out.indexOf(';; ======== ROW M1'), out.indexOf(';; ======== ROW bulk300'));
+      const block = m1.slice(m1.indexOf(`;;   PAIR ${GATED}`), m1.indexOf(';;   PAIR uix-subs / reagent-subs'));
+      const line = block.split('\n').find((l) => /^;;\s+point /.test(l));
+      assert.ok(line, `${dir}: the gated pair must print a point and an interval`);
+      assert.ok(
+        new RegExp(`point ${want.point}x\\s+95% CI \\[${want.lo} – ${want.hi}\\]\\s+over ${want.runs} reportable run\\(s\\)`).test(line),
+        `${dir}: expected ${want.point}x [${want.lo} – ${want.hi}] n=${want.runs}, got: ${line.trim()}`
+      );
+      assert.match(line, /POINT AND INTERVAL FROM THE ONE ESTIMATOR, never spliced/);
+      assert.ok(/FLOOR-NORMALISED leg ratio/.test(block), `${dir}: the estimand must be named on the line that publishes`);
+      assert.ok(/VERDICT K1 MISSED, DECISIVELY/.test(block), `${dir}: the gated pair trips K1`);
+      // the unfloored table survives as a LABELLED DIAGNOSTIC, never a headline
+      assert.ok(/DIAGNOSTIC, NEVER THE HEADLINE — the unfloored LEVEL estimand reads/.test(block), `${dir}: the level estimand is kept and labelled`);
+      // and the co-instrumented pairs publish nothing
+      assert.ok(/VERDICT CO-INSTRUMENTED/.test(m1.slice(m1.indexOf(';;   PAIR uix-subs / reagent-subs'))), `${dir}: donor-vs-donor gates nothing`);
+    }
+  });
+
+  // --- 5. CRITERION (f) AND PART (3): WHAT THE PUBLISHED ROW MUST CARRY -----
+
+  t('criterion (f): the published row carries its residual-uncertainty caveats', () => {
+    const src = fs.readFileSync(path.join(STUDIO, 'rows-re-adjudicated-on-the-corrected-clock.md'), 'utf8');
+    for (const [what, re] of [
+      ['8 and 6 outer runs only', /8 and 6 outer runs/],
+      ['the limits were calibrated on these same 14 runs', /calibrated on these same 14 runs/],
+      ['both ensembles record the same Chromium', /same Chromium/],
+    ]) {
+      assert.match(src, re, `the published M1 row must carry the caveat: ${what}`);
+    }
+  });
+
+  t('part (3): the 0.11pp agreement sentence is retired everywhere', () => {
+    // It was a property of the SELECTION and not of the measurement — the
+    // whole-ensemble means sit 2.59 pp apart. Struck rather than argued with,
+    // because a corroboration claim that survives only under a selection is not
+    // corroboration. The honest statement replaces it.
+    for (const f of fs.readdirSync(STUDIO).filter((x) => x.endsWith('.md'))) {
+      const src = fs.readFileSync(path.join(STUDIO, f), 'utf8');
+      assert.ok(!/0\.11 percentage points/.test(src), `${f} still claims the 0.11 pp agreement`);
+      assert.ok(!/0\.11 pp/.test(src), `${f} still claims the 0.11 pp agreement`);
+    }
+    const src = fs.readFileSync(path.join(STUDIO, 'rows-re-adjudicated-on-the-corrected-clock.md'), 'utf8');
+    assert.match(src, /2\.59 (?:pp|percentage points)/, 'and the honest distance replaces it');
+    assert.match(src, /two independently launched ensembles/i);
+  });
+
+  t('the ruling is cited by bead id in every surface it changed', () => {
+    for (const f of [
+      path.join(__dirname, 'clock_readjudicate.cjs'),
+      path.join(__dirname, 'clock_exit_path.test.cjs'),
+      path.join(STUDIO, 'rows-re-adjudicated-on-the-corrected-clock.md'),
+    ]) {
+      assert.ok(/rf2-diaud/.test(fs.readFileSync(f, 'utf8')), `${path.basename(f)} must cite the ruling that changed it`);
     }
   });
 }

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -4682,6 +4682,16 @@ function fixtureRoundsTask(over) {
   const M1_PAIRS = ['hicasso / reagent-subs', GATED, 'uix-subs / reagent-subs'];
   const STUDIO = path.join(__dirname, '..', '..', '..', '..', '..', '..', 'docs', 'design', 'hicasso', 'studio');
 
+  /**
+   * A page's prose with its line wrapping and blockquote markers removed, so a
+   * sentence can be asserted as a SENTENCE. Markdown wraps at 80 columns and
+   * prefixes quoted blocks with `> `, and a phrase that happens to straddle a
+   * line break is still the phrase — a test that missed it would be pinning the
+   * fill, not the claim.
+   */
+  const prose = (file) =>
+    fs.readFileSync(path.join(STUDIO, file), 'utf8').replace(/\r?\n>?[ \t]*/g, ' ').replace(/[ \t]+/g, ' ');
+
   /** The ruling's expected outcome, to 4 places — the tool's, not the note's. */
   const EXPECTED = {
     'clock-emvod': { runs: 8, point: '1.1718', lo: '1.1263', hi: '1.2190', widestBand: 22.34 },
@@ -4984,9 +4994,9 @@ function fixtureRoundsTask(over) {
   // --- 5. CRITERION (f) AND PART (3): WHAT THE PUBLISHED ROW MUST CARRY -----
 
   t('criterion (f): the published row carries its residual-uncertainty caveats', () => {
-    const src = fs.readFileSync(path.join(STUDIO, 'rows-re-adjudicated-on-the-corrected-clock.md'), 'utf8');
+    const src = prose('rows-re-adjudicated-on-the-corrected-clock.md');
     for (const [what, re] of [
-      ['8 and 6 outer runs only', /8 and 6 outer runs/],
+      ['eight and six outer runs only', /[Ee]ight and six outer runs only/],
       ['the limits were calibrated on these same 14 runs', /calibrated on these same 14 runs/],
       ['both ensembles record the same Chromium', /same Chromium/],
     ]) {
@@ -5000,13 +5010,26 @@ function fixtureRoundsTask(over) {
     // because a corroboration claim that survives only under a selection is not
     // corroboration. The honest statement replaces it.
     for (const f of fs.readdirSync(STUDIO).filter((x) => x.endsWith('.md'))) {
-      const src = fs.readFileSync(path.join(STUDIO, f), 'utf8');
+      const src = prose(f);
       assert.ok(!/0\.11 percentage points/.test(src), `${f} still claims the 0.11 pp agreement`);
       assert.ok(!/0\.11 pp/.test(src), `${f} still claims the 0.11 pp agreement`);
     }
-    const src = fs.readFileSync(path.join(STUDIO, 'rows-re-adjudicated-on-the-corrected-clock.md'), 'utf8');
-    assert.match(src, /2\.59 (?:pp|percentage points)/, 'and the honest distance replaces it');
+    const src = prose('rows-re-adjudicated-on-the-corrected-clock.md');
+    // THE HONEST DISTANCE IS COMPUTED, NOT QUOTED, and it is 2.58 pp rather
+    // than the ruling's 2.59. Both are right about different summaries of the
+    // same estimand: 2.59 pp is the gap between the whole-ensemble ARITHMETIC
+    // means of the per-round bar (1.1798 / 1.2057), which is what the ruling
+    // had in front of it; 2.58 pp is the gap between the figures this row now
+    // PUBLISHES (1.1718 / 1.1976), which are the bootstrap's balanced
+    // mean-of-logs. Criterion (e) says the tool's output is the record, so the
+    // page states the distance between its own published points and says which
+    // summary that is — quoting 2.59 beside them would be a splice one order
+    // smaller than the one this ruling exists to retire.
+    const gap = ((1.1976 - 1.1718) * 100).toFixed(2);
+    assert.strictEqual(gap, '2.58');
+    assert.match(src, new RegExp(`\\*\\*${gap} pp\\*\\*`), 'the distance between the PUBLISHED points, computed here');
     assert.match(src, /two independently launched ensembles/i);
+    assert.match(src, /overlapping intervals/i);
   });
 
   t('the ruling is cited by bead id in every surface it changed', () => {

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
@@ -123,12 +123,83 @@
 // row adjudicates again. WHAT IT THEN SAYS IS NOT THIS FILE'S TO ARRANGE: all
 // 14 come back in control, so the reportable subset is the whole ensemble, and
 // the publication rule above — reaching `M1` for the first time, because an
-// interval needs a reportable run to be formed from — returns INSTRUMENT-LIMITED
-// on every pair. The intervals sit wholly above 1.0 and clear neither the ship
-// bar below nor the architecture-kill above. That is the rule doing its job on
-// a row it had never been applied to, and the tension it creates with
-// `rf2-t2flm`'s published magnitude is a RULING, recorded on the studio page
-// and not resolved by any code here.
+// interval needs a reportable run to be formed from — returned INSTRUMENT-LIMITED
+// on every pair. That is the rule doing its job on a row it had never been
+// applied to, and the tension it created with `rf2-t2flm`'s published magnitude
+// was a RULING, recorded on the studio page and not resolved by any code here.
+//
+// ## THE ESTIMAND AND THE THRESHOLD ARE BOTH ROW-CLASS-SPECIFIC (rf2-diaud)
+//
+// That ruling landed on 2026-08-08, and it found the collision narrower than it
+// looked AND a deeper fault underneath it. Both halves are implemented here.
+//
+//   THE THRESHOLD. `rf2-8a746`'s whole-interval discipline is RETAINED, with no
+//   exceptions and no named exemptions, but its thresholds are the BULK ROW'S:
+//   `1.0` is `validation.md`'s bulk ship bar and `1.5` its architecture-kill.
+//   Asking `M1` to clear them asks a question its governing record does not
+//   define — the mount's decision threshold is `K1`'s `1.10x` against direct
+//   UIx-on-subs — and importing one row's limit onto another is the exact class
+//   of error `rf2-8a746` exists to retire. So each row class is adjudicated
+//   against the threshold of the question it answers.
+//
+//   THE ESTIMAND, WHICH IS THE DEEPER FAULT. A point and an interval must
+//   describe the SAME quantity, and here they did not. `validation.md:14`/`:286`
+//   define canonical `M1` as FLOOR-NORMALISED on the clock of record; the
+//   interval was computed on the level ratio, which by its own comment touches
+//   neither floor. The proposed publication spliced floor-normalised POINTS
+//   (1.1798x / 1.2057x) onto unfloored geometric INTERVALS. NO SPLICED FIGURE
+//   EVER PUBLISHES. A threshold is defined for an estimand, so making the
+//   threshold row-specific without making the ESTIMAND row-specific would have
+//   left the same fault one layer down.
+//
+// `PUBLICATION` below is therefore one table with one row per class, carrying
+// the governing record, the estimand and the threshold TOGETHER, because they
+// are not three independent choices — the record names the quantity and the
+// quantity is what the threshold is a value of.
+//
+// ## AND THE CROSS-RUN MAX-BAND SECOND VETO IS RETIRED (rf2-diaud (c))
+//
+// `rf2-8a746`'s rule carried a second condition: the effect had to exceed the
+// WIDEST same-run reproducibility band among the pooled runs. Three things are
+// wrong with it as a publication gate, and none of them is wrong with the band
+// itself.
+//
+//   * It is not an interval for the claimed effect. It is a control statistic
+//     for a different estimand — the run's own reproducibility across rounds —
+//     and comparing an effect to it asserts against one quantity a value
+//     derived for another.
+//   * It borrows across runs. The widest band belongs to ONE run; the effect is
+//     pooled over all of them, and a pooled estimate does not inherit the
+//     noisiest member's resolution.
+//   * It grows HARDER to clear by adding runs, which no evidence rule may do.
+//
+// What stays is everything that was doing real work: the 35% band CEILING
+// remains a run-eligibility guard in `GATES` above, refusing a whole run before
+// any interval is formed, and the same-run bands are printed as SENSITIVITY
+// DIAGNOSTICS beside every verdict. Only the cross-run maximum stops vetoing.
+// This is operator-overturnable and the consequence is stated on the ruling:
+// retaining the veto flips `M1` to INSTRUMENT-LIMITED (the widest same-run bands
+// are 22.34% and 18.29%) even though the row-specific interval clears `1.10x`.
+//
+// THE RETIREMENT IS SCOPED TO THE MOUNT CLASS, AND THAT IS A FINDING RATHER
+// THAN A HEDGE (rf2-vh0e3). Criterion (c) retires the veto; criterion (b) of
+// the same ruling says BULK'S PATH IS UNCHANGED. On the committed corpus those
+// two cannot both be satisfied globally, and the implementation is how that
+// became visible: retiring the veto on `bulk` as well promotes TWO pairs of the
+// 42-run corpus to published magnitudes — `bulk300` and `bulk100` on
+// `uix-subs / reagent-subs`, at [0.8327 – 0.9031] and [0.8870 – 0.9675]. Both
+// are DONOR AGAINST DONOR, a comparison that answers no ship question, and
+// `rf2-8a746` says in terms that the 42 committed row-runs "remain
+// calibration/diagnostic evidence and are NOT retroactively promoted to
+// published magnitudes". `rf2-diaud` amends that ruling for the row it is
+// about; it does not overturn that sentence, and no implementation may.
+//
+// So the veto is retired where the ruling states its consequence — the mount —
+// and retained on `bulk`, which is what "bulk's path unchanged" says in the one
+// place the two criteria disagree. It is NOT quietly re-added to make a verdict
+// look safer: on the mount row, the row this ruling is about, it is gone, and
+// `M1` publishes because its own interval clears its own gate. `rf2-vh0e3`
+// carries the collision to the operator with both consequences priced.
 
 'use strict';
 
@@ -277,9 +348,8 @@ function checkStandardFor(row, dataset) {
 }
 
 /**
- * THE PUBLICATION RULE (rf2-8a746), and it is deliberately small.
+ * THE BOOTSTRAP, which is common to every row class (rf2-8a746).
  *
- * `bar` is the claim's threshold and `architectureKill` the other side of it.
  * `draws` and `seed` are here rather than inline because a published interval
  * a reader cannot reproduce is the fault this whole program exists to fix: the
  * bootstrap is seeded, so running this file twice over the same datasets
@@ -290,17 +360,152 @@ function checkStandardFor(row, dataset) {
  * one or two of them the outer distribution is essentially the observed runs
  * themselves, so the interval understates by construction. Below the floor the
  * row publishes INSTRUMENT-LIMITED rather than a narrow interval.
+ *
+ * THE THRESHOLDS ARE NOT HERE ANY MORE (rf2-diaud). They moved into
+ * `PUBLICATION` below, one entry per row class, because `1.0` and `1.5` are the
+ * BULK row's lines and a threshold only means anything beside the estimand it
+ * was derived for.
  */
 const EFFECT = {
   bead: 'rf2-8a746',
+  thresholdsRuling: 'rf2-diaud',
   draws: 4000,
   seed: 20260807,
   alpha: 0.05,
-  bar: 1.0,
-  architectureKill: 1.5,
   minRuns: 3,
   method: 'paired log-ratios; hierarchical percentile bootstrap, outer RUNS resampled before inner ROUNDS (Kalibera & Jones 2013)',
 };
+
+/**
+ * ONE RULE PER ROW CLASS: ITS RECORD, ITS ESTIMAND, ITS THRESHOLD (rf2-diaud).
+ *
+ * Keyed by the CHECK STANDARD'S class (`clock_check_standard.cjs`'s `classOf`),
+ * so a row is adjudicated by the same classification that decides whether its
+ * run was in control. Two class tables would be two answers to "what kind of
+ * row is this".
+ *
+ * THE THREE FIELDS ARE ONE DECISION. `governingRecord` names the document that
+ * defines the claim; `estimand` is the quantity that document defines; the
+ * threshold is a value OF that quantity. Splitting them is how a point from one
+ * estimator came to be published beside an interval from another.
+ *
+ * A ROW CLASS NOBODY HAS ENTERED HERE PUBLISHES NOTHING. `keystroke` has no
+ * class and therefore no governing record, no estimand of record and no
+ * threshold; adjudicating it against bulk's `1.0`/`1.5` would import a limit
+ * derived for a different question, which is the whole error being retired. Its
+ * interval is still computed and printed as a description of the row.
+ */
+const PUBLICATION = {
+  bulk: {
+    ruling: 'rf2-8a746',
+    governingRecord:
+      "validation.md's bulk ship bar — <= 1.0x Reagent-on-subs, like-for-like, both sides reading re-frame2 " +
+      'subscriptions, on the witness shapes; K2 architecture-kill at 1.5x',
+    estimand: 'level',
+    estimandSays: 'paired same-round LEVEL ratio at fixed witness and fixed K, touching neither floor',
+    bar: 1.0,
+    architectureKill: 1.5,
+    // UNCHANGED BY rf2-diaud, deliberately and by name: the ruling adopts
+    // row-specific thresholds and leaves bulk's path exactly as `rf2-8a746`
+    // froze it, including that every pair of a bulk row adjudicates. (The bulk
+    // bar's own pair is `hicasso / reagent-subs`; that the rule speaks to all
+    // three is a pre-existing looseness this ruling did not reach — rf2-vp0j7.)
+    gatedPairs: null,
+    // THE CROSS-RUN MAX-BAND SECOND VETO, RETAINED HERE AND NOWHERE ELSE, under
+    // criterion (b) and against criterion (c) — see the header, and rf2-vh0e3
+    // for the ruling this waits on. Retiring it here promotes `bulk300` and
+    // `bulk100` on `uix-subs / reagent-subs` out of the 42-run corpus that
+    // `rf2-8a746` fenced, on a donor-against-donor comparison that answers no
+    // ship question. One field, so overturning it is one line.
+    crossRunBandVeto: true,
+    adjudicate(iv, diagnostics) {
+      const below = iv.hi < this.bar;
+      const above = iv.lo > this.architectureKill;
+      if (!below && !above) {
+        return {
+          publishes: false,
+          verdict: 'INSTRUMENT-LIMITED',
+          why:
+            `the interval [${fmt(iv.lo)} – ${fmt(iv.hi)}] does not lie wholly on one side of the ${this.bar} bar ` +
+            `or the ${this.architectureKill} architecture-kill threshold`,
+        };
+      }
+      const bandPct = (diagnostics || {}).widestSameRunBandPct;
+      const effectPct = Math.abs(iv.point - 1) * 100;
+      if (this.crossRunBandVeto && !(Number.isFinite(bandPct) && effectPct > bandPct)) {
+        return {
+          publishes: false,
+          verdict: 'INSTRUMENT-LIMITED',
+          why:
+            `the effect is ${fmt(effectPct, 1)}% and the widest same-run noise band among the pooled runs is ` +
+            `${Number.isFinite(bandPct) ? fmt(bandPct, 1) + '%' : 'not recorded'} — rf2-8a746's second veto, ` +
+            'RETAINED on this class alone because rf2-diaud (b) leaves bulk\'s path unchanged while rf2-diaud (c) ' +
+            'retires the veto; the collision is rf2-vh0e3 and it is the operator\'s',
+        };
+      }
+      return {
+        publishes: true,
+        verdict: below
+          ? 'MAGNITUDE PUBLISHABLE — the whole interval is below the 1.0 bar'
+          : 'ARCHITECTURE-KILL — the whole interval is above 1.5',
+        why: `the interval [${fmt(iv.lo)} – ${fmt(iv.hi)}] lies wholly on one side of its own threshold`,
+      };
+    },
+  },
+  mount: {
+    ruling: 'rf2-diaud',
+    governingRecord:
+      "validation.md:14/:286 — canonical M1, FLOOR-NORMALISED, on the clock of record's raw TaskDuration; " +
+      "K1's mount gate is <= 1.10x direct UIx-on-subs, with Reagent-on-subs co-instrumented and reported " +
+      'beside the row rather than gating it',
+    estimand: 'floorNormalised',
+    estimandSays:
+      'per-round TARED, FLOOR-NORMALISED leg ratio ((H - plumbH)/(floorH - plumbH)) / ((U - plumbU)/(floorU - plumbU)), ' +
+      'same round, same segment for each leg',
+    gate: 1.1,
+    // K1's gate is stated against DIRECT UIx-on-subs and validation.md says in
+    // terms that Reagent-on-subs does NOT gate this row. So the other two pairs
+    // get the same estimand and the same interval — and no gate verdict, because
+    // a threshold defined for one comparison says nothing about another.
+    gatedPairs: ['hicasso / uix-subs'],
+    // RETIRED HERE, which is where rf2-diaud (c) states its consequence. The
+    // widest same-run bands on this row are 22.34% and 18.29%, so retaining it
+    // would refuse a 17.2% effect whose whole interval clears K1's line — an
+    // effect measured against a control statistic for a different estimand.
+    crossRunBandVeto: false,
+    adjudicate(iv) {
+      if (iv.hi <= this.gate) {
+        return {
+          publishes: true,
+          verdict: `MOUNT SHIP BAR MET — the whole interval is at or below the ${this.gate}x mount gate`,
+          why: `the interval [${fmt(iv.lo)} – ${fmt(iv.hi)}] sits wholly at or under K1's ${this.gate}x line`,
+        };
+      }
+      if (iv.lo > this.gate) {
+        return {
+          publishes: true,
+          verdict: `K1 MISSED, DECISIVELY — the whole interval is above the ${this.gate}x mount gate`,
+          why:
+            `the interval [${fmt(iv.lo)} – ${fmt(iv.hi)}] sits wholly above K1's ${this.gate}x line, so the mount ` +
+            'premium is a magnitude and not a direction',
+        };
+      }
+      return {
+        publishes: false,
+        verdict: 'INSTRUMENT-LIMITED',
+        why:
+          `the interval [${fmt(iv.lo)} – ${fmt(iv.hi)}] straddles K1's ${this.gate}x mount gate — the row has not ` +
+          'measured which side of the gate it is on',
+      };
+    },
+  },
+};
+
+/** The publication rule for a row id, or `null` for a class with no record. */
+function publicationRule(rowId) {
+  const klass = checkstd.classOf(rowId);
+  return (klass && PUBLICATION[klass]) || null;
+}
 
 /** A small deterministic PRNG, so a published interval is reproducible. */
 function mulberry32(seed) {
@@ -314,8 +519,7 @@ function mulberry32(seed) {
 }
 
 /**
- * ONE RUN'S PAIRED LOG-RATIOS, one per round — the quantity the product claim
- * asserts, at fixed witness and fixed K.
+ * BULK'S ESTIMAND — ONE RUN'S PAIRED LEVEL LOG-RATIOS, one per round.
  *
  * PAIRED AND SAME-ROUND, which is what makes it the right quantity: both arms
  * are read in the same round of the same run, so whatever that round's box was
@@ -328,7 +532,7 @@ function mulberry32(seed) {
  * Returns `null` for a row that carries no usable readings, which is a
  * refusal to state an interval rather than an interval over nothing.
  */
-function pairedLogRatios(row, pair) {
+function levelLogRatios(row, pair) {
   const [num, den] = pair.split(' / ');
   const out = [];
   for (const round of (row && row.roundsTask) || []) {
@@ -340,6 +544,88 @@ function pairedLogRatios(row, pair) {
     out.push(Math.log(q));
   }
   return out.length ? out : null;
+}
+
+/**
+ * THE MOUNT'S ESTIMAND — K1's OWN QUANTITY, COMPUTED HERE (rf2-diaud (a)).
+ *
+ * `validation.md:14`/`:286` define canonical `M1` as FLOOR-NORMALISED on the
+ * clock of record, so K1's `1.10x` gate is a value of THIS quantity and of no
+ * other. Per round, per segment:
+ *
+ *     ((H - plumbH) / (floorH - plumbH)) / ((U - plumbU) / (floorU - plumbU))
+ *
+ * Each leg divides an arm's tared reading by the floor measured in ITS OWN
+ * segment of THAT round, and the two legs are then taken against each other —
+ * which is why the bar is a DOUBLE ratio and why the two floors do not divide
+ * out. That second term is the whole difference from the level estimand above,
+ * and it is a property of the claim rather than of this program: `K1` is stated
+ * against the floor, so the floor is in the estimator.
+ *
+ * COMPUTED FROM THE RAW READINGS, not read back from `barTask.perRound`. The
+ * driver stores its own per-round bar and a reader could quote it, but the
+ * point of a re-adjudicator is that a published figure is recomputable from
+ * `roundsTask` by a fresh clone; the two agreeing to the last place is a
+ * witness this file's test carries, not an assumption it makes.
+ *
+ * FAIL-CLOSED ON THE TARE, for the reason `checkStandardFor` is: whether the
+ * readings are tared decides what a floor-normalised ratio taken from them
+ * MEANS, and a record that did not serialise its design cannot say. `plumb` is
+ * subtracted from all four terms when the design says tare, and from none when
+ * it says otherwise — never from some.
+ */
+function floorNormalisedLogRatios(row, pair, dataset) {
+  const d = dataset || {};
+  if (!d.design || typeof d.design.tare !== 'boolean') return null;
+  const [num, den] = pair.split(' / ');
+  const leg = (round, seg) => {
+    const s = round && round[seg];
+    if (!s) return NaN;
+    const arm = s[seg];
+    const floor = s.floor;
+    const plumb = s.plumb;
+    if (!Array.isArray(arm) || !Array.isArray(floor) || arm.length === 0 || floor.length === 0) return NaN;
+    if (d.design.tare && (!Array.isArray(plumb) || plumb.length === 0)) return NaN;
+    const t = d.design.tare ? p50(plumb) : 0;
+    return (p50(arm) - t) / (p50(floor) - t);
+  };
+  const out = [];
+  for (const round of (row && row.roundsTask) || []) {
+    const q = leg(round, num) / leg(round, den);
+    if (!Number.isFinite(q) || q <= 0) return null;
+    out.push(Math.log(q));
+  }
+  return out.length ? out : null;
+}
+
+/**
+ * THE ROW'S OWN ESTIMAND, and the only entry point the publication path uses.
+ *
+ * Dispatches on the row's class through `PUBLICATION`, so the quantity an
+ * interval is formed on and the threshold it is judged against are read from
+ * the same entry and cannot drift apart. A class with no entry falls to the
+ * level estimand — a description of the row that publishes nothing, which is
+ * what `effectVerdict` says of it.
+ */
+function pairedLogRatios(row, pair, dataset) {
+  const rule = publicationRule(row && row.rowId);
+  return rule && rule.estimand === 'floorNormalised'
+    ? floorNormalisedLogRatios(row, pair, dataset)
+    : levelLogRatios(row, pair);
+}
+
+/**
+ * THE OTHER ESTIMAND, PRINTED AS A LABELLED DIAGNOSTIC AND NEVER AS A HEADLINE
+ * (rf2-diaud). Whichever quantity a row publishes on, the other one is stated
+ * beside it with its OWN point and its OWN interval — never a bound from one
+ * next to a point from the other. Two complete figures cannot be spliced; a
+ * bound and a point can, and were.
+ */
+function counterpartLogRatios(row, pair, dataset) {
+  const rule = publicationRule(row && row.rowId);
+  return rule && rule.estimand === 'floorNormalised'
+    ? levelLogRatios(row, pair)
+    : floorNormalisedLogRatios(row, pair, dataset);
 }
 
 /**
@@ -386,26 +672,54 @@ function effectInterval(runs) {
 }
 
 /**
- * MAY THIS ROW PUBLISH A MAGNITUDE? (rf2-8a746)
+ * MAY THIS ROW PUBLISH A MAGNITUDE ON THIS PAIR? (rf2-8a746, amended rf2-diaud)
  *
- * Both conditions, and neither on its own. THE WHOLE INTERVAL must lie on one
- * side of the threshold — an interval straddling it is a row that has not
- * measured a direction, and quoting its point estimate is quoting the middle
- * of a range that contains parity. AND THE EFFECT MUST CLEAR THE SAME-RUN
- * NOISE BAND, because a confidence interval narrows with runs while the band
- * says what a single run of this instrument can resolve at all: an effect
- * inside the band is a difference the instrument cannot see in one sitting,
- * however many sittings are pooled.
+ * THE WHOLE INTERVAL must lie on one side of the threshold — an interval
+ * straddling it is a row that has not measured which side of the line it is on,
+ * and quoting its point estimate is quoting the middle of a range that contains
+ * the answer and its opposite. That discipline is `rf2-8a746`'s and is retained
+ * here unchanged, with no exceptions and no named exemptions.
  *
- * `noiseBandPct` is the WIDEST band among the runs pooled — a claim must clear
- * the noisiest run it is drawn from, which is the fail-closed direction and
- * the same direction this program's other asymmetries take.
+ * WHICH THRESHOLD, AND OF WHAT QUANTITY, IS THE ROW'S CLASS TO SAY (rf2-diaud).
+ * `rowId` rather than a bare number, because the caller must not be able to
+ * hand this function a limit: the limit belongs to `PUBLICATION[class]` beside
+ * the estimand it was derived for, and the interval must have been formed on
+ * that same estimand by `pairedLogRatios`. A LOWER RATIO IS FASTER — these are
+ * times — so bulk ships on the whole interval BELOW 1.0 and architecture-kills
+ * ABOVE 1.5, while the mount ships at or under K1's 1.10x and trips K1 wholly
+ * above it.
  *
- * A LOWER RATIO IS FASTER: these are times. So the ship claim is the whole
- * interval BELOW 1.0 and the architecture-kill is the whole interval ABOVE
- * 1.5.
+ * THE SECOND VETO IS RETIRED ON THE MOUNT (rf2-diaud (c)) and the band arrives
+ * as a `diagnostics` bag rather than as a bare limit, because on every class but
+ * `bulk` that is all it is. The widest same-run band is a control statistic for
+ * a different estimand, it belongs to one run while the effect is pooled over
+ * all of them, and it gets HARDER to clear as runs are added. The 35% band
+ * ceiling still refuses a run outright in `GATES`, and the same-run bands still
+ * print beside every verdict. `bulk` alone still consults it, under criterion
+ * (b)'s "bulk's path unchanged" and pending rf2-vh0e3 — the entry says so by
+ * name in its own `crossRunBandVeto` field.
  */
-function effectVerdict(iv, noiseBandPct) {
+function effectVerdict(iv, rowId, pair, diagnostics) {
+  const rule = publicationRule(rowId);
+  if (!rule) {
+    return {
+      publishes: false,
+      verdict: 'NO PUBLICATION RULE — this row has no class, so no governing record, no estimand of record and no threshold',
+      why:
+        `\`${rowId}\` is in none of PUBLICATION's classes, and adjudicating it against another class's threshold ` +
+        'would assert a limit derived for a different question (rf2-diaud)',
+    };
+  }
+  if (rule.gatedPairs && !rule.gatedPairs.includes(pair)) {
+    return {
+      publishes: false,
+      verdict: 'CO-INSTRUMENTED — reported beside the gated pair, not gating it',
+      why:
+        `this row's gate is stated on ${rule.gatedPairs.join(', ')}; \`${pair}\` is measured on the same estimand ` +
+        'and printed beside it, and holding it to a threshold defined for another comparison is the error this ' +
+        'ruling retires (rf2-diaud)',
+    };
+  }
   if (!iv) return { publishes: false, verdict: 'INSTRUMENT-LIMITED', why: 'no usable paired readings in any pooled run — no interval was formed' };
   if (iv.runs < EFFECT.minRuns) {
     return {
@@ -416,34 +730,7 @@ function effectVerdict(iv, noiseBandPct) {
         `below ${EFFECT.minRuns} the outer distribution is the observed runs themselves and the interval understates`,
     };
   }
-  const effectPct = Math.abs(iv.point - 1) * 100;
-  const clearsNoise = Number.isFinite(noiseBandPct) && effectPct > noiseBandPct;
-  const below = iv.hi < EFFECT.bar;
-  const above = iv.lo > EFFECT.architectureKill;
-  if (!below && !above) {
-    return {
-      publishes: false,
-      verdict: 'INSTRUMENT-LIMITED',
-      why:
-        `the interval [${fmt(iv.lo)} – ${fmt(iv.hi)}] does not lie wholly on one side of the ${EFFECT.bar} bar ` +
-        `or the ${EFFECT.architectureKill} architecture-kill threshold`,
-    };
-  }
-  if (!clearsNoise) {
-    return {
-      publishes: false,
-      verdict: 'INSTRUMENT-LIMITED',
-      why:
-        `the effect is ${fmt(effectPct, 1)}% and the widest same-run noise band among the pooled runs is ` +
-        `${Number.isFinite(noiseBandPct) ? fmt(noiseBandPct, 1) + '%' : 'not recorded'} — an effect inside the band ` +
-        `is a difference this instrument cannot resolve in one sitting, however many sittings are pooled`,
-    };
-  }
-  return {
-    publishes: true,
-    verdict: below ? 'MAGNITUDE PUBLISHABLE — the whole interval is below the 1.0 bar' : 'ARCHITECTURE-KILL — the whole interval is above 1.5',
-    why: `the interval [${fmt(iv.lo)} – ${fmt(iv.hi)}] clears the threshold and the ${fmt(effectPct, 1)}% effect clears the ${fmt(noiseBandPct, 1)}% same-run band`,
-  };
+  return rule.adjudicate(iv, diagnostics || {});
 }
 
 /**
@@ -966,36 +1253,77 @@ function main(argv) {
       // computed over the REPORTABLE runs only — a run refused by any gate is
       // not evidence about the page — and it is stated whichever way it falls,
       // because a rule that only prints when it likes the answer is not one.
-      const ivRuns = passIdx.map((i) => pairedLogRatios(runs[i].row, pair)).filter(Boolean);
+      //
+      // AND IT IS ONE ESTIMATOR END TO END (rf2-diaud). The point and both
+      // bounds below come from the SAME `pairedLogRatios`, which is the row
+      // class's own estimand; the other estimand is printed under its own
+      // heading with its own complete figure. Nothing here may be read across
+      // the two lines.
+      const rule = publicationRule(rowId);
+      const ivRuns = passIdx.map((i) => pairedLogRatios(runs[i].row, pair, runs[i].data)).filter(Boolean);
       const iv = effectInterval(ivRuns);
       const bands = passIdx
         .map((i) => runs[i].row.seamTask && runs[i].row.seamTask.band)
         .filter((b) => Number.isFinite(b))
         .map((b) => b * 100);
       const noise = bands.length ? Math.max(...bands) : NaN;
-      const ev = effectVerdict(iv, noise);
+      const ev = effectVerdict(iv, rowId, pair, { widestSameRunBandPct: noise });
       console.log(
-        `;;     EFFECT-SIZE INTERVAL (${EFFECT.bead}) — paired same-round LEVEL ratio at fixed witness and ` +
-          `fixed K, neither floor; ${EFFECT.method}`
+        `;;     EFFECT-SIZE INTERVAL (${EFFECT.bead}, row-class estimand and threshold ${EFFECT.thresholdsRuling}) — ` +
+          `${rule ? rule.estimandSays : 'no estimand of record for this row class'}; ${EFFECT.method}`
       );
+      if (rule) {
+        console.log(`;;       GOVERNING RECORD  ${rule.governingRecord}`);
+      }
       if (iv) {
         console.log(
           `;;       point ${fmt(iv.point)}x   ${fmt((1 - EFFECT.alpha) * 100, 0)}% CI [${fmt(iv.lo)} – ${fmt(iv.hi)}]   ` +
-            `over ${iv.runs} reportable run(s) x ${iv.rounds[0]} rounds, ${iv.draws} draws, seed ${iv.seed}`
+            `over ${iv.runs} reportable run(s) x ${iv.rounds[0]} rounds, ${iv.draws} draws, seed ${iv.seed}` +
+            `  — POINT AND INTERVAL FROM THE ONE ESTIMATOR, never spliced (${EFFECT.thresholdsRuling})`
         );
         console.log(
-          `;;       effect |1 - point| ${fmt(Math.abs(iv.point - 1) * 100, 1)}%   widest same-run band among the ` +
-            `pooled runs ${Number.isFinite(noise) ? fmt(noise, 1) + '%' : 'n/a'}   ` +
-            `thresholds: bar ${EFFECT.bar} (whole interval below), architecture-kill ${EFFECT.architectureKill} (whole interval above)`
+          `;;       effect |1 - point| ${fmt(Math.abs(iv.point - 1) * 100, 1)}%   ` +
+            (rule && rule.gate
+              ? `threshold: ${rule.gate} (ship at or below the whole interval, trip wholly above)`
+              : rule
+                ? `thresholds: bar ${rule.bar} (whole interval below), architecture-kill ${rule.architectureKill} (whole interval above)`
+                : 'no threshold — this row class has no governing record')
         );
+        // SENSITIVITY DIAGNOSTIC, AND ON EVERY CLASS BUT `bulk` THAT IS ALL IT
+        // IS (rf2-diaud (c)). The 35% ceiling above already refused any run
+        // whose band breached it; what the ruling retires is the cross-run
+        // MAXIMUM as a second gate on publication. Which classes it still gates
+        // is printed rather than inferred, because the asymmetry is a live
+        // ruling (rf2-vh0e3) and a reader must not have to read the table.
+        console.log(
+          `;;       SENSITIVITY DIAGNOSTIC — same-run reproducibility bands among the pooled runs, widest ` +
+            `${Number.isFinite(noise) ? fmt(noise, 1) + '%' : 'n/a'}. ` +
+            (rule && rule.crossRunBandVeto
+              ? `On this row class it ALSO still vetoes publication — rf2-8a746's second condition, retained under ` +
+                `${EFFECT.thresholdsRuling} (b) "bulk's path unchanged" while (c) retires it elsewhere; the ` +
+                `collision is rf2-vh0e3 and it is the operator's.`
+              : `It DECIDES NOTHING here: the 35% ceiling refuses a run in the gates above, and the cross-run ` +
+                `maximum was retired from publication authority (${EFFECT.thresholdsRuling}) — it is not an ` +
+                `interval for this effect, it belongs to one run, and it grows harder to clear as runs are added.`)
+        );
+        // THE OTHER ESTIMAND, COMPLETE AND LABELLED — never a headline, and
+        // never a bound to be read beside the point above.
+        const cIv = effectInterval(passIdx.map((i) => counterpartLogRatios(runs[i].row, pair, runs[i].data)).filter(Boolean));
+        if (cIv) {
+          console.log(
+            `;;       DIAGNOSTIC, NEVER THE HEADLINE — the ${rule && rule.estimand === 'floorNormalised' ? 'unfloored LEVEL' : 'floor-normalised'} ` +
+              `estimand reads ${fmt(cIv.point)}x [${fmt(cIv.lo)} – ${fmt(cIv.hi)}] over the same runs. It is a ` +
+              `DIFFERENT quantity, so no figure on this line may be quoted beside a figure on the line above.`
+          );
+        }
       } else {
         console.log(`;;       no interval — ${passIdx.length} run(s) cleared every gate and none carried usable paired readings`);
       }
       console.log(`;;       VERDICT ${ev.verdict} — ${ev.why}`);
       if (!ev.publishes) {
         console.log(
-          `;;       so this row publishes INSTRUMENT-LIMITED on this pair and NEVER a magnitude, and no mean ` +
-            `printed above may be quoted as one (${EFFECT.bead}).`
+          `;;       so this row publishes NO MAGNITUDE on this pair, and no mean printed above may be quoted as ` +
+            `one (${EFFECT.bead}, ${EFFECT.thresholdsRuling}).`
         );
       }
     }
@@ -1223,9 +1551,20 @@ function shortName(f) {
 // it, and the rule that says whether that interval may publish. `EFFECT` is
 // exported with them because a test that could not read the seed could not
 // pin the procedure.
+//
+// rf2-diaud adds `PUBLICATION` and `counterpartLogRatios`, and both are
+// decisions rather than helpers. `PUBLICATION` is where a row class's governing
+// record, estimand and threshold are bound together — the binding IS the
+// ruling, so a test has to be able to read it. `counterpartLogRatios` is the
+// rule that the estimand NOT being published is stated complete beside the one
+// that is; a test drives it to prove no bound of one can reach a point of the
+// other. The two per-class estimators stay unexported: which one applies is
+// `PUBLICATION`'s to say, and a caller able to pick would be a second
+// adjudicator.
 module.exports = {
   GATES, adjudicated, refusals, reportable, responsivenessRegime,
-  checkStandardFor, pairedLogRatios, effectInterval, effectVerdict, EFFECT,
+  checkStandardFor, pairedLogRatios, counterpartLogRatios, effectInterval, effectVerdict,
+  EFFECT, PUBLICATION, publicationRule,
 };
 
 // Requiring this file must not run it: `clock_exit_path.test.cjs` drives the


### PR DESCRIPTION
Implements the 2026-08-08 delegated decision on `rf2-diaud`, criteria (a)–(f) plus part (3).

## The defect

The point and the interval described **different estimands**. `validation.md:14`/`:286` define canonical `M1` as **floor-normalised** on the clock of record; `pairedLogRatios` said of itself, in its own comment, *"LEVEL over LEVEL, touching neither floor"*. The proposed publication spliced floor-normalised **points** (1.1798× / 1.2057×) onto unfloored geometric **intervals**. Both halves were correct arithmetic; together they were not a figure.

**No figure in this PR is spliced.** Every published point and both its bounds come from one call to one estimator, over one set of runs. The tool prints that claim on the line itself (`POINT AND INTERVAL FROM THE ONE ESTIMATOR, never spliced`), and the other estimand is printed **complete** — its own point, its own bounds — under `DIAGNOSTIC, NEVER THE HEADLINE`, so there is no bound anywhere for a point to be read beside.

## What changed

`clock_readjudicate.cjs` gains a `PUBLICATION` table with one entry per check-standard row class, binding **governing record + estimand + threshold** together — they are not three independent choices, and splitting them is how the splice happened.

| class | estimand | threshold | gated pair |
|---|---|---|---|
| `mount` | per-round tared, floor-normalised leg ratio | K1's `1.10×` — ship at or below, trip above | `hicasso / uix-subs` |
| `bulk` | level ratio, neither floor (**unchanged**) | `1.0` bar / `1.5` architecture-kill (**unchanged**) | every pair (**unchanged**) |

- **(a)** The mount estimand is `((H − plumbH)/(floorH − plumbH)) / ((U − plumbU)/(floorU − plumbU))`, computed from the raw `roundsTask` readings and run through the **existing** run-preserving bootstrap (outer runs, then inner rounds; 4,000 draws; seed 20260807). A test witnesses that it reproduces the driver's own `barTask[pair].perRound` to the last place across all 42 mount row-run pairs — so this is `clock_run.cjs`'s definition, not a second one.
- **(b)** Thresholds are row-class-specific; the whole-interval discipline is retained with no exceptions. **Bulk's path is byte-identical in behaviour.**
- **(c)** The cross-run max-band second veto is retired from publication authority **on the mount**. The 35% band ceiling stays as the run-eligibility guard in `GATES`; same-run bands print as sensitivity diagnostics. **It was not quietly re-added** — see the collision below for where it was retained and why.
- **(d)** The `clock_exit_path.test.cjs` pin flips deliberately, citing this ruling.
- **(e)** Every figure below is quoted from the canonical tool's own stdout.
- **(f)** The published row carries all three caveats: 8 and 6 outer runs only; the mount limits were calibrated on these same 14 runs rather than an independent baseline; both ensembles record the same Chromium (`147.0.7727.15`).
- **Part (3)**: the 0.11 pp agreement claim is retired everywhere on the page, and a test greps the whole studio tree for it.

## The verdict — M1 publishes

`hicasso / uix-subs`, floor-normalised, verbatim from `clock_readjudicate.cjs`:

```
;;   PAIR hicasso / uix-subs
;;     EFFECT-SIZE INTERVAL (rf2-8a746, row-class estimand and threshold rf2-diaud) — per-round TARED, FLOOR-NORMALISED leg ratio ((H - plumbH)/(floorH - plumbH)) / ((U - plumbU)/(floorU - plumbU)), same round, same segment for each leg; paired log-ratios; hierarchical percentile bootstrap, outer RUNS resampled before inner ROUNDS (Kalibera & Jones 2013)
;;       GOVERNING RECORD  validation.md:14/:286 — canonical M1, FLOOR-NORMALISED, on the clock of record's raw TaskDuration; K1's mount gate is <= 1.10x direct UIx-on-subs, with Reagent-on-subs co-instrumented and reported beside the row rather than gating it
;;       point 1.1718x   95% CI [1.1263 – 1.2190]   over 8 reportable run(s) x 6 rounds, 4000 draws, seed 20260807  — POINT AND INTERVAL FROM THE ONE ESTIMATOR, never spliced (rf2-diaud)
;;       effect |1 - point| 17.2%   threshold: 1.1 (ship at or below the whole interval, trip wholly above)
;;       SENSITIVITY DIAGNOSTIC — same-run reproducibility bands among the pooled runs, widest 22.3%. It DECIDES NOTHING here: the 35% ceiling refuses a run in the gates above, and the cross-run maximum was retired from publication authority (rf2-diaud) — it is not an interval for this effect, it belongs to one run, and it grows harder to clear as runs are added.
;;       DIAGNOSTIC, NEVER THE HEADLINE — the unfloored LEVEL estimand reads 1.1679x [1.1259 – 1.2096] over the same runs. It is a DIFFERENT quantity, so no figure on this line may be quoted beside a figure on the line above.
;;       VERDICT K1 MISSED, DECISIVELY — the whole interval is above the 1.1x mount gate — the interval [1.1263 – 1.2190] sits wholly above K1's 1.1x line, so the mount premium is a magnitude and not a direction
```

and on `clock-w3yxd`:

```
;;       point 1.1976x   95% CI [1.1504 – 1.2468]   over 6 reportable run(s) x 6 rounds, 4000 draws, seed 20260807  — POINT AND INTERVAL FROM THE ONE ESTIMATOR, never spliced (rf2-diaud)
;;       DIAGNOSTIC, NEVER THE HEADLINE — the unfloored LEVEL estimand reads 1.1621x [1.1209 – 1.2090] over the same runs. It is a DIFFERENT quantity, so no figure on this line may be quoted beside a figure on the line above.
;;       VERDICT K1 MISSED, DECISIVELY — the whole interval is above the 1.1x mount gate — the interval [1.1504 – 1.2468] sits wholly above K1's 1.1x line, so the mount premium is a magnitude and not a direction
```

**Both reproduce part (5)'s diagnostic replays exactly, to four places.** Nothing was reconciled toward them; the implementation was written first and the agreement is the result.

The other two `M1` pairs publish `CO-INSTRUMENTED — reported beside the gated pair, not gating it`, because `validation.md` states K1's gate against **direct UIx-on-subs** and says in terms that Reagent-on-subs does not gate this row.

## Mutation coverage, both directions

Every decision is driven in both directions, each mutation restored in a `finally` and re-asserted afterwards:

| mutation | without it | with it |
|---|---|---|
| the threshold class | `M1`'s own interval on bulk's `1.0`/`1.5` gives `INSTRUMENT-LIMITED` | on K1's `1.10×` it publishes |
| `gatedPairs` on `mount` | `uix-subs / reagent-subs` (interval `[0.9179 – 1.0228]`) announces `MOUNT SHIP BAR MET` | `CO-INSTRUMENTED`, publishes nothing |
| `estimand` on `mount` | the level estimand's own figure, 1.1679× [1.1259 – 1.2096] | 1.1718× [1.1263 – 1.2190] |
| `crossRunBandVeto` on `bulk` | `bulk300` / `bulk100` publish out of the 42-run corpus | `INSTRUMENT-LIMITED`, naming `rf2-vh0e3` |

The mount gate's boundary is driven on both sides at `1.10` exactly: `hi = 1.10` ships, `hi = 1.1001` does not; `lo = 1.1001` trips K1, `lo = 1.10` does not; the middle is `INSTRUMENT-LIMITED`.

## Two findings the ruling did not have

**1. Criteria (b) and (c) collide on the bulk rows — `rf2-vh0e3` (P2, RULING NEEDED).** Retiring the veto globally promotes **two pairs out of the 42-run corpus** that `rf2-8a746` explicitly fenced: `bulk300` `[0.8327 – 0.9031]` and `bulk100` `[0.8870 – 0.9675]`, both on `uix-subs / reagent-subs` — **donor against donor**, a comparison that answers no ship question. So the veto is retired on the `mount`, where the ruling states its consequence, and **retained on `bulk`**, which is what "bulk's path unchanged" says in the one place the two criteria disagree. It is one named field with a comment and a two-way mutation test, so overturning it is one line. `rf2-vh0e3` carries all three options priced.

**2. The retired veto sends the two ensembles to opposite verdicts.** `clock-emvod`: effect 17.2% against a widest same-run band of 22.34% — the retired condition **refuses**. `clock-w3yxd`: 19.8% against 18.29% — it **admits**. Two ensembles measuring the same effect to within 2.6 pp, split by a statistic belonging to one run of one of them. That is criterion (c)'s three objections showing up as a disagreement, and it is now pinned by a test.

Also filed: **`rf2-vp0j7`** (P3) — bulk's rule adjudicates all three pairs while `validation.md`'s bulk bar names only `hicasso / reagent-subs`. Deliberately not changed here, per criterion (b).

## One departure from the ruling's arithmetic, stated rather than reconciled

Part (3) gives the whole-ensemble distance as **2.59 pp** (1.1798× vs 1.2057×). Those are the **arithmetic** whole-ensemble means of the per-round bar. The figures this row now **publishes** are the bootstrap's balanced mean-of-logs, 1.1718× and 1.1976×, which sit **2.58 pp** apart. The page states 2.58 pp and says which summary it is; quoting 2.59 beside the published points would be a splice one order smaller than the one this ruling exists to retire. Criterion (e) governs.

## Quality gates

All foreground, to completion, `gate root: /c/Users/miket/code/re-frame2-worktrees/m1publish-diaud`.

| gate | exit |
|---|---|
| `node --check clock_readjudicate.cjs` | 0 |
| `node --check clock_exit_path.test.cjs` | 0 |
| `node clock_exit_path.test.cjs` | 0 — **344 passed** (321 baseline + 8 from #7703 + 15 new here) |
| `clock_readjudicate.cjs` over `clock-emvod/run*.json` | 0 |
| `clock_readjudicate.cjs` over `clock-w3yxd/run*.json` | 0 |
| `npm run test:script-helpers` | 0 |
| `sh scripts/test-fast-pr.sh` | 0 — `PASS fast PR spine` |
| `npm run lint:js` | 0 |
| `python scripts/check_doc_slugs.py` | 0 — **probe-verified** |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | 0 |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | 0 |

**Slug gate probe:** a deliberate `[probe](does-not-exist-rf2-diaud.md#nope)` appended to the changed page made the gate exit **1** with `BROKEN TARGET`; removing it returned exit **0**. The gate does see this file.

**Tables hand-verified:** `mkdocs build --strict` excludes `docs/design/**`, so all 22 tables on the changed page were checked rectangular by cell count against their header and separator rows — 0 ragged. The three tables this PR adds are 4, 3 and 3 columns wide.

## Collision handling — #7703 landed, and this branch is rebased on top of it

`worker/holdout-c1974` (#7703) merged after this branch was first pushed, and it touches both `clock_exit_path.test.cjs` and this studio page. Rebased onto current `origin/main`; the predicted conflict appeared exactly where predicted and was resolved as stated — **by keeping both blocks**.

- **The test file** conflicted at the append point: both blocks end with a test named *"the ruling is cited by bead id in every surface it changed"*, so git aligned their trailing `}` / `});` / `}`. Resolved by taking **both blocks complete**, in order, each with its own closing lines. **#7703's block is preserved byte-for-byte** — 15,425 characters, all 8 of its cases — verified by diffing that slice against `origin/main`. No case was dropped from either side, and the two adjoin rather than contradict: its cases are about the check standard's out-of-sample limits, mine are about which estimand and threshold publish a row.
- **The page rebased clean**, as reported — its hunk is at line 484, mine span 324–445. #7703's `provenance.independence` annotation is intact in full, including its rewrite of *"at the time of writing this one had not had that"*, its split hold-out result (`refuse 4 of clock-emvod`, between-run SD `0.0113`) and its commit-level-independence residual.
- `clock_check_standard.json` / `.cjs` remain untouched by this PR.

**#7703 bumped the check standard to v3, and the figures do not move.** All 14 `M1` runs are still `IN CONTROL` under v3, so the pooled sets are unchanged at n=8 and n=6 and both published intervals reproduce to the last place: 1.1718× [1.1263 – 1.2190] and 1.1976× [1.1504 – 1.2468], `K1 MISSED, DECISIVELY`. Test count is the clean union, 344 = 321 + 8 + 15.
