### PR TITLE
fix(hicasso): the bulk bar gates the pair it names, and the band veto retires (rf2-vp0j7, rf2-vh0e3)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -3935,23 +3935,26 @@ function fixtureRoundsTask(over) {
     assert.match(EFFECT.method, /outer RUNS resampled before inner ROUNDS/);
   });
 
-  t('criterion 3: the WHOLE interval must clear the threshold, and the effect must clear the band', () => {
-    // Both conditions and neither alone, driven at the boundary in each
-    // direction. A lower ratio is faster: these are times.
+  t('criterion 3: the WHOLE interval must clear the threshold', () => {
+    // Driven at the boundary in each direction. A lower ratio is faster: these
+    // are times.
     //
-    // AMENDED BY rf2-diaud: the verdict is asked for a ROW and a PAIR rather
-    // than a bare limit, because the threshold belongs to the row class beside
-    // the estimand it was derived for. `bulk300` is the bulk class, whose path
-    // rf2-diaud (b) leaves unchanged — including its band veto, retained on
-    // this class alone pending rf2-vh0e3 — so every assertion below still
-    // reads exactly as rf2-8a746 froze it.
+    // AMENDED TWICE, AND THE SECOND CONDITION IS GONE. rf2-diaud asks the
+    // verdict for a ROW and a PAIR rather than for a bare limit, because the
+    // threshold belongs to the row class beside the estimand it was derived
+    // for — and `hicasso / reagent-subs` is the pair validation.md's bulk bar
+    // actually names (rf2-vp0j7). rf2-8a746's rule ALSO required the effect to
+    // exceed the widest same-run band; rf2-diaud (c) and rf2-vh0e3 retired that
+    // from publication authority on every class, so it no longer reaches this
+    // verdict. Asserted below rather than assumed.
     const P = 'hicasso / reagent-subs';
     const ev = (iv, bandPct) => effectVerdict(iv, BULK, P, { widestSameRunBandPct: bandPct });
     const below = { runs: 8, rounds: [6], point: 0.6, lo: 0.55, hi: 0.65, draws: 1, seed: 1 };
-    assert.strictEqual(ev(below, 10).publishes, true, 'wholly below 1.0 and a 40% effect over a 10% band');
+    assert.strictEqual(ev(below, 10).publishes, true, 'wholly below 1.0');
     assert.match(ev(below, 10).verdict, /MAGNITUDE PUBLISHABLE/);
-    assert.strictEqual(ev(below, 50).publishes, false, 'the same interval inside a 50% band publishes nothing');
-    assert.match(ev(below, 50).why, /the widest same-run noise band among the pooled runs/);
+    for (const b of [50, 99, 0.1, NaN, undefined]) {
+      assert.strictEqual(ev(below, b).publishes, true, `the retired band veto must not reach the bulk verdict either: ${b}`);
+    }
     const straddles = { runs: 8, rounds: [6], point: 0.99, lo: 0.9, hi: 1.05, draws: 1, seed: 1 };
     assert.strictEqual(ev(straddles, 1).publishes, false, 'an interval containing parity publishes nothing');
     assert.match(ev(straddles, 1).verdict, /INSTRUMENT-LIMITED/);
@@ -3960,8 +3963,6 @@ function fixtureRoundsTask(over) {
     assert.match(ev(kill, 10).verdict, /ARCHITECTURE-KILL/);
     const nearKill = { runs: 8, rounds: [6], point: 1.5, lo: 1.4, hi: 1.6, draws: 1, seed: 1 };
     assert.strictEqual(ev(nearKill, 10).publishes, false, 'an interval straddling 1.5 is not a kill');
-    // an unrecorded band is not a clear band
-    assert.strictEqual(ev(below, NaN).publishes, false, 'no band recorded is not a band cleared');
     // and two runs are not an ensemble
     assert.strictEqual(ev({ ...below, runs: 2 }, 1).publishes, false);
     assert.match(ev({ ...below, runs: 2 }, 1).why, /is not an ensemble/);
@@ -4019,8 +4020,12 @@ function fixtureRoundsTask(over) {
           const bands = pooled.map(({ row }) => row.seamTask.band).filter(Number.isFinite).map((b) => b * 100);
           const ev = effectVerdict(iv, rowId, pair, { widestSameRunBandPct: bands.length ? Math.max(...bands) : NaN });
           assert.ok(typeof ev.why === 'string' && ev.why.length > 0, `${dir}/${rowId}/${pair}: a verdict must carry its reason`);
+          // CO-INSTRUMENTED joins the roster under rf2-vp0j7: bulk's bar names
+          // `hicasso / reagent-subs`, so the other two pairs are reported and
+          // not adjudicated. The fence below is unchanged and is what matters
+          // here — an un-adjudicated pair publishes nothing either.
           assert.ok(
-            /^(INSTRUMENT-LIMITED|MAGNITUDE PUBLISHABLE|ARCHITECTURE-KILL)/.test(ev.verdict),
+            /^(INSTRUMENT-LIMITED|MAGNITUDE PUBLISHABLE|ARCHITECTURE-KILL|CO-INSTRUMENTED)/.test(ev.verdict),
             `${dir}/${rowId}/${pair}: unrecognised verdict ${ev.verdict}`
           );
           assert.ok(iv, `${dir}/${rowId}/${pair}: the corpus must yield an interval to adjudicate`);
@@ -4925,36 +4930,20 @@ function fixtureRoundsTask(over) {
     assert.ok(GATE_IDS.includes('ceiling-task') && GATE_IDS.includes('ceiling-net'), 'the run-eligibility ceilings stay');
   });
 
-  t('MUTATION: the veto is RETAINED on bulk, and rf2-vh0e3 is what that costs', () => {
-    // The collision this repair surfaced and did not decide. rf2-diaud (b)
-    // says bulk's path is unchanged; rf2-diaud (c) retires the veto. On the
-    // committed corpus they cannot both hold: retiring it on bulk promotes two
-    // DONOR-AGAINST-DONOR pairs out of the 42-run corpus rf2-8a746 fenced.
-    // Both directions are driven here so the operator's choice is one line and
-    // its price is a number.
-    const PAIR = 'uix-subs / reagent-subs';
-    const c = corpus('clock-emvod');
-    if (!c) return;
-    for (const rowId of ['bulk300', 'bulk100']) {
-      const pooled = c
-        .map(({ data }) => ({ data, row: data.rows.find((r) => r.rowId === rowId) }))
-        .filter((x) => x.row && reportable(x.row, x.data));
-      const iv = effectInterval(pooled.map(({ row, data }) => pairedLogRatios(row, PAIR, data)).filter(Boolean));
-      const widest = Math.max(...pooled.map(({ row }) => row.seamTask.band * 100));
-      assert.ok(iv.hi < 1.0, `${rowId}: the whole interval is below the bar, so only the veto is holding it`);
-      const held = effectVerdict(iv, rowId, PAIR, { widestSameRunBandPct: widest });
-      assert.strictEqual(held.publishes, false, `${rowId}: retained, so no magnitude leaves the corpus`);
-      assert.match(held.why, /rf2-vh0e3/, 'and the refusal names the ruling it waits on');
-      const before = PUBLICATION.bulk.crossRunBandVeto;
-      let mutated;
-      try {
-        PUBLICATION.bulk.crossRunBandVeto = false;
-        mutated = effectVerdict(iv, rowId, PAIR, { widestSameRunBandPct: widest });
-      } finally {
-        PUBLICATION.bulk.crossRunBandVeto = before;
-      }
-      assert.strictEqual(mutated.publishes, true, `${rowId}: retiring it here WOULD publish — that is rf2-vh0e3's cost`);
-      assert.strictEqual(PUBLICATION.bulk.crossRunBandVeto, true, 'the fixture must leave the table as it found it');
+  t('criterion (c): the retirement ended up GENERAL, and every class says so as data', () => {
+    // As this repair shipped it, (c) was mount-only: (b) said "bulk's path
+    // unchanged", and retiring the veto on bulk promoted DONOR-AGAINST-DONOR
+    // pairs out of the 42-run corpus rf2-8a746 fenced. rf2-vh0e3 ruled that
+    // the collision dissolves once bulk gates the pair its own bar names —
+    // an un-adjudicated pair has no verdict for a retirement to promote it
+    // into. What belongs HERE is only that criterion (c) came out general,
+    // which is what its own three reasons say; the corpus mechanics, and the
+    // two-way mutation on the field, are pinned in the rf2-vp0j7/rf2-vh0e3
+    // block at the foot of this file.
+    const classes = Object.keys(PUBLICATION);
+    assert.deepStrictEqual(classes.sort(), ['bulk', 'mount'], 'every publication class is covered by this assertion');
+    for (const klass of classes) {
+      assert.strictEqual(PUBLICATION[klass].crossRunBandVeto, false, `${klass}: the cross-run maximum vetoes nothing`);
     }
   });
 
@@ -5039,6 +5028,274 @@ function fixtureRoundsTask(over) {
       path.join(STUDIO, 'rows-re-adjudicated-on-the-corrected-clock.md'),
     ]) {
       assert.ok(/rf2-diaud/.test(fs.readFileSync(f, 'utf8')), `${path.basename(f)} must cite the ruling that changed it`);
+    }
+  });
+}
+
+// --- rf2-vp0j7 / rf2-vh0e3: BULK GATES THE PAIR ITS BAR NAMES ----------------
+//
+// ONE CHANGE, NOT TWO, and the interlock is the whole content of the block.
+//
+// rf2-vp0j7 is a scope defect. `validation.md:17` states the bulk ship bar as
+// "<= 1.0x Reagent-on-subs, LIKE-FOR-LIKE, both sides reading re-frame2
+// subscriptions" — ONE comparison, exactly as `:15-16` state the mount's
+// against direct UIx-on-subs. The rule adjudicated all three pairs of a bulk
+// row against it, holding `hicasso / uix-subs` and `uix-subs / reagent-subs` to
+// a threshold written for a different question. That is the error `rf2-diaud`
+// fixed one class up, where it would otherwise have printed MOUNT SHIP BAR MET
+// on a donor-against-donor pair.
+//
+// rf2-vh0e3 is the collision it was masking. `rf2-diaud` (c) retires the
+// cross-run max-band second veto and gives three general reasons; (b) of the
+// same ruling says "bulk's path unchanged". Those could not both hold, because
+// retiring the veto on `bulk` promoted pairs of the 42-run corpus `rf2-8a746`
+// fenced. EVERY ONE OF THOSE PAIRS IS `uix-subs / reagent-subs` — donor against
+// donor — so once `gatedPairs` lands they are not adjudicated at all and there
+// is no verdict for the retirement to promote them into. The collision
+// dissolves rather than being decided, and `rf2-8a746`'s "not retroactively
+// promoted to published magnitudes" is honoured without a control statistic
+// standing in for a scope guard nobody designed it to be.
+//
+// THE LOAD-BEARING CHECK IS THAT THE GATED PAIR DOES NOT MOVE. If retiring the
+// veto flipped `hicasso / reagent-subs`, the ruling's premise would be wrong
+// and the fence would be breached. It does not: on all six row-ensemble
+// combinations that pair straddles `1.0` and is refused by the WHOLE-INTERVAL
+// rule, which sits ahead of the veto and is untouched by it. That is a fact
+// about this corpus and not a property of the rule, so it is driven here — and
+// if it ever stops being true, the failure is the finding.
+{
+  const {
+    pairedLogRatios, effectInterval, effectVerdict, reportable, PUBLICATION, publicationRule,
+  } = require('./clock_readjudicate.cjs');
+  const t = (what, fn) => test(`rf2-vp0j7/rf2-vh0e3: ${what}`, fn);
+  const GATED = 'hicasso / reagent-subs';
+  const UNGATED = ['hicasso / uix-subs', 'uix-subs / reagent-subs'];
+  const BULK_ROWS = ['bulk300', 'bulk100', 'narrow'];
+  const CORPORA = ['clock-emvod', 'clock-w3yxd'];
+
+  const corpus = (dir) => {
+    const d = path.join(__dirname, 'data', dir);
+    if (!fs.existsSync(d)) return null;
+    return fs.readdirSync(d).map((f) => ({ file: path.join(d, f), data: JSON.parse(fs.readFileSync(path.join(d, f), 'utf8')) }));
+  };
+
+  /** One bulk row of one ensemble, as the publication path sees it: interval + widest band. */
+  const bulkPooled = (dir, rowId, pair) => {
+    const c = corpus(dir);
+    if (!c) return null;
+    const pooled = c
+      .map(({ data }) => ({ data, row: data.rows.find((r) => r.rowId === rowId) }))
+      .filter((x) => x.row && reportable(x.row, x.data));
+    const bands = pooled.map(({ row }) => row.seamTask && row.seamTask.band).filter(Number.isFinite).map((b) => b * 100);
+    return {
+      iv: effectInterval(pooled.map(({ row, data }) => pairedLogRatios(row, pair, data)).filter(Boolean)),
+      band: bands.length ? Math.max(...bands) : NaN,
+    };
+  };
+
+  // --- 1. rf2-vp0j7: A NON-GATED BULK PAIR REPORTS, AND ADJUDICATES NOTHING --
+
+  t('a non-gated bulk pair keeps its interval and loses only the VERDICT', () => {
+    // `validation.md`'s "co-instrumented and reported beside" language is why
+    // the interval survives. What the pair stops carrying is a ship/kill
+    // verdict against a bar stated for another comparison — the output is not
+    // deleted, it is un-adjudicated.
+    let seen = 0;
+    for (const dir of CORPORA) {
+      for (const rowId of BULK_ROWS) {
+        for (const pair of UNGATED) {
+          const p = bulkPooled(dir, rowId, pair);
+          if (!p) return;
+          assert.ok(p.iv, `${dir}/${rowId}/${pair}: the interval must still be formed`);
+          assert.ok(p.iv.lo <= p.iv.point && p.iv.point <= p.iv.hi, `${dir}/${rowId}/${pair}: and be well formed`);
+          const ev = effectVerdict(p.iv, rowId, pair, { widestSameRunBandPct: p.band });
+          assert.match(ev.verdict, /^CO-INSTRUMENTED/, `${dir}/${rowId}/${pair}: ${ev.verdict}`);
+          assert.strictEqual(ev.publishes, false, `${dir}/${rowId}/${pair}: a pair nobody gates cannot ship`);
+          assert.match(ev.why, /hicasso \/ reagent-subs/, 'the refusal must name the pair the bar does gate');
+          seen += 1;
+        }
+      }
+    }
+    assert.strictEqual(seen, 12, 'two ungated pairs of three bulk rows over two ensembles');
+  });
+
+  t("and it says so in the tool's own output, beside its own interval", () => {
+    // Read off stdout rather than asserted through the API, because "reported
+    // beside" is a claim about what a reader SEES.
+    const RJ = path.join(__dirname, 'clock_readjudicate.cjs');
+    for (const dir of CORPORA) {
+      const c = corpus(dir);
+      if (!c) return;
+      const r = cp.spawnSync(process.execPath, [RJ, ...c.map((x) => x.file)], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+      const out = `${r.stdout}${r.stderr}`;
+      assert.strictEqual(r.status, 0, `${dir}: ${out.slice(-2000)}`);
+      for (const rowId of BULK_ROWS) {
+        const at = out.indexOf(`;; ======== ROW ${rowId} `);
+        const next = out.indexOf(';; ======== ROW ', at + 1);
+        const rowBlock = out.slice(at, next < 0 ? undefined : next);
+        for (const pair of UNGATED) {
+          const from = rowBlock.indexOf(`;;   PAIR ${pair}`);
+          assert.ok(from >= 0, `${dir}/${rowId}: the ${pair} block must still be printed`);
+          const ends = [`;;   PAIR `, `;; ======== `].map((m) => rowBlock.indexOf(m, from + 1)).filter((i) => i > 0);
+          const block = rowBlock.slice(from, ends.length ? Math.min(...ends) : undefined);
+          assert.ok(/point .*95% CI \[/.test(block), `${dir}/${rowId}/${pair}: the interval must still print`);
+          assert.ok(/VERDICT CO-INSTRUMENTED/.test(block), `${dir}/${rowId}/${pair}: and carry no ship/kill verdict`);
+        }
+      }
+    }
+  });
+
+  // --- 2. rf2-vp0j7: THE GATED PAIR IS THE ONLY ONE THAT ADJUDICATES --------
+
+  t('the gated bulk pair still adjudicates, and is still INSTRUMENT-LIMITED on this corpus', () => {
+    // The fence. `hicasso / reagent-subs` is what `validation.md`'s bulk bar
+    // names, so it keeps its verdict — and that verdict is unchanged: on all
+    // six row-ensemble combinations the interval STRADDLES 1.0 and is refused
+    // by the whole-interval rule, which is the first condition and not the
+    // retired second one. The reason is asserted, not just the outcome,
+    // because "refused by the band" and "refused by the interval" answer the
+    // rf2-vh0e3 question differently.
+    assert.deepStrictEqual(publicationRule('bulk300').gatedPairs, [GATED], "bulk gates the pair validation.md:17 names");
+    let seen = 0;
+    for (const dir of CORPORA) {
+      for (const rowId of BULK_ROWS) {
+        const p = bulkPooled(dir, rowId, GATED);
+        if (!p) return;
+        assert.ok(p.iv.lo < 1.0 && p.iv.hi > 1.0, `${dir}/${rowId}: the gated interval must straddle the bar — [${p.iv.lo} – ${p.iv.hi}]`);
+        const ev = effectVerdict(p.iv, rowId, GATED, { widestSameRunBandPct: p.band });
+        assert.strictEqual(ev.publishes, false, `${dir}/${rowId}: ${ev.verdict}`);
+        assert.match(ev.verdict, /^INSTRUMENT-LIMITED/, `${dir}/${rowId}: a gated pair gets a threshold verdict, not a scope one`);
+        assert.match(ev.why, /does not lie wholly on one side of the 1 bar/, `${dir}/${rowId}: refused by the INTERVAL, not the band`);
+        seen += 1;
+      }
+    }
+    assert.strictEqual(seen, 6, 'three bulk rows over two ensembles');
+  });
+
+  t('MUTATION: the band veto is retired on bulk, and the gated pair does not move either way', () => {
+    // rf2-vh0e3's load-bearing check, driven in BOTH directions. Retiring the
+    // veto is what the ruling does; that the one adjudicated bulk pair returns
+    // a BYTE-IDENTICAL verdict with the veto forced back on is what makes the
+    // retirement safe to make — the whole-interval rule refuses it first, so
+    // the veto was never what was holding it.
+    assert.strictEqual(PUBLICATION.bulk.crossRunBandVeto, false, 'the entry says so as data');
+    for (const dir of CORPORA) {
+      for (const rowId of BULK_ROWS) {
+        const p = bulkPooled(dir, rowId, GATED);
+        if (!p) return;
+        const shipped = effectVerdict(p.iv, rowId, GATED, { widestSameRunBandPct: p.band });
+        const before = PUBLICATION.bulk.crossRunBandVeto;
+        let mutated;
+        try {
+          PUBLICATION.bulk.crossRunBandVeto = true;
+          mutated = effectVerdict(p.iv, rowId, GATED, { widestSameRunBandPct: p.band });
+        } finally {
+          PUBLICATION.bulk.crossRunBandVeto = before;
+        }
+        assert.deepStrictEqual(mutated, shipped, `${dir}/${rowId}: the veto must not reach the gated pair in either position`);
+        assert.strictEqual(PUBLICATION.bulk.crossRunBandVeto, false, 'the fixture must leave the table as it found it');
+      }
+    }
+  });
+
+  t('MUTATION: and the retired veto still REFUSES when it is switched back on', () => {
+    // The other direction, on a synthetic interval, because the corpus cannot
+    // show it: no bulk pair that is adjudicated ever reaches the veto. The
+    // refusal branch is kept live so the ruling is one line to overturn, and a
+    // branch nobody drives is a branch nobody can trust.
+    const iv = { runs: 8, rounds: [6], point: 0.9, lo: 0.85, hi: 0.95, draws: 1, seed: 1 };
+    const ev = () => effectVerdict(iv, 'bulk300', GATED, { widestSameRunBandPct: 40 });
+    assert.strictEqual(ev().publishes, true, 'retired: a 10% effect inside a 40% band publishes on the interval alone');
+    assert.match(ev().verdict, /MAGNITUDE PUBLISHABLE/);
+    const before = PUBLICATION.bulk.crossRunBandVeto;
+    let mutated;
+    try {
+      PUBLICATION.bulk.crossRunBandVeto = true;
+      mutated = ev();
+    } finally {
+      PUBLICATION.bulk.crossRunBandVeto = before;
+    }
+    assert.strictEqual(mutated.publishes, false, 'reinstated: the same interval is refused, or the mutation proves nothing');
+    assert.match(mutated.why, /the widest same-run noise band among the pooled runs/);
+    assert.strictEqual(PUBLICATION.bulk.crossRunBandVeto, false, 'the fixture must leave the table as it found it');
+    assert.strictEqual(ev().publishes, true, 'and the retirement holds again');
+  });
+
+  // --- 3. rf2-8a746's FENCE: NOTHING IS PROMOTED OUT OF THE 42-RUN CORPUS ----
+
+  t('nothing is promoted out of the 42-run corpus — no bulk pair publishes, on either ensemble', () => {
+    let seen = 0;
+    for (const dir of CORPORA) {
+      for (const rowId of BULK_ROWS) {
+        for (const pair of [GATED, ...UNGATED]) {
+          const p = bulkPooled(dir, rowId, pair);
+          if (!p) return;
+          const ev = effectVerdict(p.iv, rowId, pair, { widestSameRunBandPct: p.band });
+          assert.strictEqual(
+            ev.publishes,
+            false,
+            `${dir}/${rowId}/${pair} PUBLISHED a magnitude — rf2-8a746 rules the 42 committed row-runs calibration ` +
+              `and diagnostic evidence, NEVER retroactively promoted, and rf2-vh0e3 turns on that sentence still ` +
+              `holding. Verdict: ${ev.verdict} — ${ev.why}`
+          );
+          seen += 1;
+        }
+      }
+    }
+    assert.strictEqual(seen, 18, 'three pairs of three bulk rows over two ensembles');
+  });
+
+  t('MUTATION: and gatedPairs is WHY — without it the donor-against-donor pairs would publish', () => {
+    // rf2-vh0e3's cost, priced. These are the pairs the band veto was
+    // incidentally masking: `uix-subs / reagent-subs` is UIx-on-subs against
+    // Reagent-on-subs, whose whole interval sits below 1.0, and publishing a
+    // magnitude on it would assert that a DONOR meets the CANDIDATE's bulk
+    // ship bar. Scoping the rule is what stops that; the veto only ever hid it.
+    const PAIR = 'uix-subs / reagent-subs';
+    const would = [];
+    for (const dir of CORPORA) {
+      for (const rowId of BULK_ROWS) {
+        const p = bulkPooled(dir, rowId, PAIR);
+        if (!p) return;
+        const before = PUBLICATION.bulk.gatedPairs;
+        let mutated;
+        try {
+          PUBLICATION.bulk.gatedPairs = null;
+          mutated = effectVerdict(p.iv, rowId, PAIR, { widestSameRunBandPct: p.band });
+        } finally {
+          PUBLICATION.bulk.gatedPairs = before;
+        }
+        assert.deepStrictEqual(PUBLICATION.bulk.gatedPairs, [GATED], 'the fixture must leave the table as it found it');
+        if (mutated.publishes) would.push(`${dir}/${rowId}`);
+      }
+    }
+    // THE COUNT IS THE MEASUREMENT, and it is three rather than the two both
+    // beads record: rf2-vh0e3 named `clock-emvod`'s `bulk300` and `bulk100`,
+    // and `clock-w3yxd`'s `bulk300` is a third with the same shape (effect
+    // 9.6% against a 15.5% band, whole interval [0.8740 – 0.9373]). It was not
+    // measured because the mutation that found the other two read one ensemble.
+    // The ruling is unaffected — all three are donor against donor — but the
+    // number on the beads is wrong and this is where that is recorded.
+    assert.deepStrictEqual(
+      would,
+      ['clock-emvod/bulk300', 'clock-emvod/bulk100', 'clock-w3yxd/bulk300'],
+      'the pairs gatedPairs is holding back — if this list changes, the corpus has moved and rf2-vh0e3 needs re-reading'
+    );
+    // and every one of them is refused as UNADJUDICATED rather than as refused
+    for (const dir of CORPORA) {
+      for (const rowId of BULK_ROWS) {
+        const p = bulkPooled(dir, rowId, PAIR);
+        assert.match(effectVerdict(p.iv, rowId, PAIR, { widestSameRunBandPct: p.band }).verdict, /^CO-INSTRUMENTED/);
+      }
+    }
+  });
+
+  t('the rulings are cited by bead id in every surface they changed', () => {
+    for (const f of [path.join(__dirname, 'clock_readjudicate.cjs'), path.join(__dirname, 'clock_exit_path.test.cjs')]) {
+      const src = fs.readFileSync(f, 'utf8');
+      for (const bead of ['rf2-vp0j7', 'rf2-vh0e3']) {
+        assert.ok(new RegExp(bead).test(src), `${path.basename(f)} must cite ${bead}`);
+      }
     }
   });
 }

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
@@ -181,25 +181,35 @@
 // retaining the veto flips `M1` to INSTRUMENT-LIMITED (the widest same-run bands
 // are 22.34% and 18.29%) even though the row-specific interval clears `1.10x`.
 //
-// THE RETIREMENT IS SCOPED TO THE MOUNT CLASS, AND THAT IS A FINDING RATHER
-// THAN A HEDGE (rf2-vh0e3). Criterion (c) retires the veto; criterion (b) of
-// the same ruling says BULK'S PATH IS UNCHANGED. On the committed corpus those
-// two cannot both be satisfied globally, and the implementation is how that
-// became visible: retiring the veto on `bulk` as well promotes TWO pairs of the
-// 42-run corpus to published magnitudes — `bulk300` and `bulk100` on
-// `uix-subs / reagent-subs`, at [0.8327 – 0.9031] and [0.8870 – 0.9675]. Both
-// are DONOR AGAINST DONOR, a comparison that answers no ship question, and
-// `rf2-8a746` says in terms that the 42 committed row-runs "remain
-// calibration/diagnostic evidence and are NOT retroactively promoted to
-// published magnitudes". `rf2-diaud` amends that ruling for the row it is
-// about; it does not overturn that sentence, and no implementation may.
+// ## AND THE RETIREMENT IS GENERAL, ONCE BULK GATES THE PAIR ITS BAR NAMES
+// (rf2-vh0e3, rf2-vp0j7)
 //
-// So the veto is retired where the ruling states its consequence — the mount —
-// and retained on `bulk`, which is what "bulk's path unchanged" says in the one
-// place the two criteria disagree. It is NOT quietly re-added to make a verdict
-// look safer: on the mount row, the row this ruling is about, it is gone, and
-// `M1` publishes because its own interval clears its own gate. `rf2-vh0e3`
-// carries the collision to the operator with both consequences priced.
+// It did not start there. Criterion (c) retires the veto and criterion (b) of
+// the same ruling says BULK'S PATH IS UNCHANGED, and on the committed corpus
+// those two could not both hold: retiring the veto on `bulk` promoted pairs of
+// the 42-run corpus `rf2-8a746` fenced. So it was retired on the mount, where
+// the ruling states its consequence, and RETAINED on `bulk` pending a ruling.
+//
+// THE COLLISION DISSOLVED RATHER THAN BEING DECIDED, and the mechanism is the
+// `gatedPairs` field in `PUBLICATION` below. EVERY pair the veto was holding is
+// `uix-subs / reagent-subs` — UIx-on-subs against Reagent-on-subs, DONOR
+// AGAINST DONOR, which answers no question `validation.md`'s bulk bar asks.
+// That bar reads "<= 1.0x Reagent-on-subs, like-for-like", naming ONE
+// comparison exactly as the mount's names one, so `bulk` gates
+// `hicasso / reagent-subs` and reports the other two beside it. A pair nobody
+// adjudicates has no verdict for a retirement to promote it into, so
+// `rf2-8a746`'s "remain calibration/diagnostic evidence and are NOT
+// retroactively promoted to published magnitudes" is honoured in full — and
+// honoured by scoping the rule rather than by leaving a control statistic
+// standing in for a scope guard it was never designed to be.
+//
+// THE ONE BULK PAIR THAT IS ADJUDICATED DOES NOT MOVE, which is what makes the
+// retirement safe to make rather than merely arguable: on all six row-ensemble
+// combinations `hicasso / reagent-subs` STRADDLES 1.0 and is refused by the
+// whole-interval rule, which sits ahead of the veto and is untouched by it. The
+// veto was never what was holding it. That is a fact about this corpus and not
+// a property of the rule, so `clock_exit_path.test.cjs` drives it in both
+// directions — and if it ever stops being true, the failure is the finding.
 
 'use strict';
 
@@ -405,19 +415,22 @@ const PUBLICATION = {
     estimandSays: 'paired same-round LEVEL ratio at fixed witness and fixed K, touching neither floor',
     bar: 1.0,
     architectureKill: 1.5,
-    // UNCHANGED BY rf2-diaud, deliberately and by name: the ruling adopts
-    // row-specific thresholds and leaves bulk's path exactly as `rf2-8a746`
-    // froze it, including that every pair of a bulk row adjudicates. (The bulk
-    // bar's own pair is `hicasso / reagent-subs`; that the rule speaks to all
-    // three is a pre-existing looseness this ruling did not reach — rf2-vp0j7.)
-    gatedPairs: null,
-    // THE CROSS-RUN MAX-BAND SECOND VETO, RETAINED HERE AND NOWHERE ELSE, under
-    // criterion (b) and against criterion (c) — see the header, and rf2-vh0e3
-    // for the ruling this waits on. Retiring it here promotes `bulk300` and
-    // `bulk100` on `uix-subs / reagent-subs` out of the 42-run corpus that
-    // `rf2-8a746` fenced, on a donor-against-donor comparison that answers no
-    // ship question. One field, so overturning it is one line.
-    crossRunBandVeto: true,
+    // THE BAR GATES THE PAIR IT NAMES (rf2-vp0j7). `validation.md:17` states it
+    // as "<= 1.0x Reagent-on-subs, LIKE-FOR-LIKE, both sides reading re-frame2
+    // subscriptions" — ONE comparison, exactly as `:15-16` state the mount's
+    // against direct UIx-on-subs. Adjudicating `hicasso / uix-subs` or
+    // `uix-subs / reagent-subs` against it holds a pair to a threshold written
+    // for a different question, which is the error rf2-diaud fixed one class
+    // up. They keep their intervals and lose only the verdict.
+    gatedPairs: ['hicasso / reagent-subs'],
+    // AND THE CROSS-RUN MAX-BAND SECOND VETO IS RETIRED HERE TOO (rf2-vh0e3) —
+    // which the line above is what made possible. Every pair the veto was
+    // holding is donor against donor, so once they are no longer adjudicated
+    // there is no verdict left for its retirement to promote them into, and
+    // `rf2-8a746`'s 42-run fence stands without a control statistic doing a
+    // scope guard's work. One field, so overturning it is still one line, and
+    // `adjudicate` below still carries the refusal it would fire.
+    crossRunBandVeto: false,
     adjudicate(iv, diagnostics) {
       const below = iv.hi < this.bar;
       const above = iv.lo > this.architectureKill;
@@ -439,8 +452,8 @@ const PUBLICATION = {
           why:
             `the effect is ${fmt(effectPct, 1)}% and the widest same-run noise band among the pooled runs is ` +
             `${Number.isFinite(bandPct) ? fmt(bandPct, 1) + '%' : 'not recorded'} — rf2-8a746's second veto, ` +
-            'RETAINED on this class alone because rf2-diaud (b) leaves bulk\'s path unchanged while rf2-diaud (c) ' +
-            'retires the veto; the collision is rf2-vh0e3 and it is the operator\'s',
+            'RETIRED from publication authority by rf2-diaud (c) and rf2-vh0e3, and reachable now only by setting ' +
+            'this class\'s crossRunBandVeto back to true',
         };
       }
       return {
@@ -689,15 +702,23 @@ function effectInterval(runs) {
  * ABOVE 1.5, while the mount ships at or under K1's 1.10x and trips K1 wholly
  * above it.
  *
- * THE SECOND VETO IS RETIRED ON THE MOUNT (rf2-diaud (c)) and the band arrives
- * as a `diagnostics` bag rather than as a bare limit, because on every class but
- * `bulk` that is all it is. The widest same-run band is a control statistic for
- * a different estimand, it belongs to one run while the effect is pooled over
- * all of them, and it gets HARDER to clear as runs are added. The 35% band
- * ceiling still refuses a run outright in `GATES`, and the same-run bands still
- * print beside every verdict. `bulk` alone still consults it, under criterion
- * (b)'s "bulk's path unchanged" and pending rf2-vh0e3 — the entry says so by
- * name in its own `crossRunBandVeto` field.
+ * AND WHICH PAIR, WHICH IS NOT THE SAME QUESTION (rf2-diaud, rf2-vp0j7). A
+ * class's bar is stated against ONE comparison — the mount's against direct
+ * UIx-on-subs, bulk's against Reagent-on-subs like-for-like — so `gatedPairs`
+ * names it and the others are reported beside it with no verdict at all. They
+ * lose the adjudication, never the interval.
+ *
+ * THE SECOND VETO IS RETIRED ON EVERY CLASS (rf2-diaud (c), rf2-vh0e3) and the
+ * band arrives as a `diagnostics` bag rather than as a bare limit, because that
+ * is now all it is. The widest same-run band is a control statistic for a
+ * different estimand, it belongs to one run while the effect is pooled over all
+ * of them, and it gets HARDER to clear as runs are added. The 35% band ceiling
+ * still refuses a run outright in `GATES`, and the same-run bands still print
+ * beside every verdict. `bulk` consulted it for one ruling's length and no
+ * longer does: retiring it there promoted nothing once `gatedPairs` stopped the
+ * donor-against-donor pairs being adjudicated at all. Each entry still says
+ * which it is, by name, in its own `crossRunBandVeto` field, because that is
+ * the one line an operator overturns.
  */
 function effectVerdict(iv, rowId, pair, diagnostics) {
   const rule = publicationRule(rowId);
@@ -716,8 +737,8 @@ function effectVerdict(iv, rowId, pair, diagnostics) {
       verdict: 'CO-INSTRUMENTED — reported beside the gated pair, not gating it',
       why:
         `this row's gate is stated on ${rule.gatedPairs.join(', ')}; \`${pair}\` is measured on the same estimand ` +
-        'and printed beside it, and holding it to a threshold defined for another comparison is the error this ' +
-        'ruling retires (rf2-diaud)',
+        'and printed beside it, and holding it to a threshold defined for another comparison is the error these ' +
+        'rulings retire (rf2-diaud on the mount, rf2-vp0j7 on bulk)',
     };
   }
   if (!iv) return { publishes: false, verdict: 'INSTRUMENT-LIMITED', why: 'no usable paired readings in any pooled run — no interval was formed' };
@@ -1289,22 +1310,23 @@ function main(argv) {
                 ? `thresholds: bar ${rule.bar} (whole interval below), architecture-kill ${rule.architectureKill} (whole interval above)`
                 : 'no threshold — this row class has no governing record')
         );
-        // SENSITIVITY DIAGNOSTIC, AND ON EVERY CLASS BUT `bulk` THAT IS ALL IT
-        // IS (rf2-diaud (c)). The 35% ceiling above already refused any run
-        // whose band breached it; what the ruling retires is the cross-run
-        // MAXIMUM as a second gate on publication. Which classes it still gates
-        // is printed rather than inferred, because the asymmetry is a live
-        // ruling (rf2-vh0e3) and a reader must not have to read the table.
+        // SENSITIVITY DIAGNOSTIC, AND ON EVERY CLASS THAT IS NOW ALL IT IS
+        // (rf2-diaud (c), rf2-vh0e3). The 35% ceiling above already refused any
+        // run whose band breached it; what the rulings retire is the cross-run
+        // MAXIMUM as a second gate on publication. Whether it still gates is
+        // printed rather than inferred, because the retirement is operator-
+        // overturnable in one field and a reader must not have to read the
+        // table to see which way that field is set.
         console.log(
           `;;       SENSITIVITY DIAGNOSTIC — same-run reproducibility bands among the pooled runs, widest ` +
             `${Number.isFinite(noise) ? fmt(noise, 1) + '%' : 'n/a'}. ` +
             (rule && rule.crossRunBandVeto
-              ? `On this row class it ALSO still vetoes publication — rf2-8a746's second condition, retained under ` +
-                `${EFFECT.thresholdsRuling} (b) "bulk's path unchanged" while (c) retires it elsewhere; the ` +
-                `collision is rf2-vh0e3 and it is the operator's.`
+              ? `On this row class it ALSO vetoes publication — rf2-8a746's second condition, REINSTATED against ` +
+                `${EFFECT.thresholdsRuling} (c) and rf2-vh0e3 by this class's own crossRunBandVeto field.`
               : `It DECIDES NOTHING here: the 35% ceiling refuses a run in the gates above, and the cross-run ` +
-                `maximum was retired from publication authority (${EFFECT.thresholdsRuling}) — it is not an ` +
-                `interval for this effect, it belongs to one run, and it grows harder to clear as runs are added.`)
+                `maximum was retired from publication authority (${EFFECT.thresholdsRuling} (c), rf2-vh0e3) — it ` +
+                `is not an interval for this effect, it belongs to one run, and it grows harder to clear as runs ` +
+                `are added.`)
         );
         // THE OTHER ESTIMAND, COMPLETE AND LABELLED — never a headline, and
         // never a bound to be read beside the point above.


### PR DESCRIPTION
**One change, not two: the second's resolution is the first's fix.** Closes rf2-vp0j7 and rf2-vh0e3, both ruled 2026-08-08 (delegated, operator-overturnable).

The code is what the previous worker left room for — one field gains a value, one boolean flips:

```js
bulk: {
  gatedPairs: ['hicasso / reagent-subs'],   // was null
  crossRunBandVeto: false,                  // was true
```

Everything else is the comment record catching up, plus tests.

## What the two rulings say, and why they land together

**rf2-vp0j7 is a scope defect.** `validation.md:17` states the bulk ship bar as *"≤ 1.0× Reagent-on-subs, **like-for-like**, both sides reading re-frame2 subscriptions"* — one comparison, exactly as `:15-16` state the mount's against direct UIx-on-subs. The rule adjudicated **all three** pairs of a bulk row against it, holding `hicasso / uix-subs` and `uix-subs / reagent-subs` to a threshold written for a different question. That is the error `rf2-diaud` fixed one class up, where it would otherwise have printed **MOUNT SHIP BAR MET** on a pair whose interval is [0.9179 – 1.0228]. The non-gated pairs keep their intervals and lose only the *verdict*, which is what `validation.md`'s "co-instrumented and reported beside" language requires.

**rf2-vh0e3 is the collision that scoping was masking.** `rf2-diaud` (c) retires the cross-run max-band second veto for three reasons that are general — it is not an interval for the claimed effect, it borrows a control statistic from another estimand, and it grows harder to clear merely by adding runs — while (b) of the same ruling says *"bulk's path unchanged"*. Both could not hold, because retiring the veto on bulk promoted pairs out of the 42-run corpus `rf2-8a746` fenced. **Every one of those pairs is `uix-subs / reagent-subs` — donor against donor.** Once `gatedPairs` lands they are not adjudicated at all, so there is no verdict for the retirement to promote them into. The collision dissolves rather than being decided, and `rf2-8a746`'s *"remain calibration/diagnostic evidence and are NOT retroactively promoted to published magnitudes"* is honoured by scoping the rule rather than by leaving a control statistic doing a scope guard's work.

## The load-bearing check: `hicasso / reagent-subs` did not flip

On **all six** row-ensemble combinations the gated pair straddles 1.0 and is refused by the **whole-interval rule**, which sits ahead of the veto and is untouched by it. The veto was never what was holding it. Every gated verdict below is byte-identical to `origin/main`'s.

| ensemble | row | gated pair `hicasso / reagent-subs` | verdict |
|---|---|---|---|
| `clock-emvod` | `bulk300` | 0.9922× [0.9529 – 1.0385] n=8 | INSTRUMENT-LIMITED |
| `clock-emvod` | `bulk100` | 1.0247× [0.9837 – 1.0643] n=8 | INSTRUMENT-LIMITED |
| `clock-emvod` | `narrow` | 1.0243× [0.9528 – 1.1207] n=7 | INSTRUMENT-LIMITED |
| `clock-w3yxd` | `bulk300` | 1.0313× [0.9755 – 1.0967] n=4 | INSTRUMENT-LIMITED |
| `clock-w3yxd` | `bulk100` | 1.0381× [0.9704 – 1.1115] n=4 | INSTRUMENT-LIMITED |
| `clock-w3yxd` | `narrow` | 0.9771× [0.9028 – 1.0443] n=6 | INSTRUMENT-LIMITED |

**No pair was promoted out of the 42-run corpus.** `grep -c "MAGNITUDE PUBLISHABLE\|ARCHITECTURE-KILL"` over both ensembles' full output returns **0** and **0**. The three bulk rows of both ensembles publish no magnitude on any of their three pairs, before this change and after it.

## A correction to both beads: it is THREE pairs, not two

Both beads record that retiring the veto on bulk without `gatedPairs` would promote **two** pairs — `clock-emvod`'s `bulk300` [0.8327 – 0.9031] and `bulk100` [0.8870 – 0.9675]. Measured over both ensembles it is **three**: `clock-w3yxd`'s `bulk300` on the same pair, [0.8740 – 0.9373], effect 9.6% against a 15.5% band, is a third with exactly the same shape. The mutation that found the other two read one ensemble.

**The ruling is unaffected** — all three are `uix-subs / reagent-subs`, donor against donor, and all three are un-adjudicated after `gatedPairs` — but the count on the beads is wrong, so the list is pinned in the test with a note saying where it came from and that a change to it means the corpus has moved.

## What is deliberately untouched

Mount's rule; the 35% band ceiling as a **run-eligibility** guard in `GATES`; same-run band **diagnostics**, which still print beside every verdict; `clock_check_standard.*`; every hard refusal. **No measurement was taken** — no window, no driver. Everything here is arithmetic over the committed `data/clock-emvod/` and `data/clock-w3yxd/`.

The `crossRunBandVeto` refusal branch stays live in `adjudicate`, so the ruling remains one line to overturn, and the printer still states which way the field is set rather than making a reader infer it.

## Quality gates

Every gate run foreground to completion in `C:/Users/miket/code/re-frame2-worktrees/bulkgate-vp0j7`; the spine's `gate root:` line names that worktree.

| gate | exit |
|---|---|
| `node --check clock_readjudicate.cjs` | **0** |
| `node --check clock_exit_path.test.cjs` | **0** |
| `node clock_exit_path.test.cjs` | **0** — `352 passed` (was 344, **+8**) |
| `node clock_readjudicate.cjs data/clock-emvod/*.json` | **0** |
| `node clock_readjudicate.cjs data/clock-w3yxd/*.json` | **0** |
| `npm run test:script-helpers` | **0** |
| `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine` |
| `npm run lint:js` | **0** |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | **0** — no beads-database paths in the diff |

### Red then green

The three pins were written first and run against unmodified `origin/main`. `6/352 failed`, exit 1:

```
FAIL  rf2-vp0j7/rf2-vh0e3: a non-gated bulk pair keeps its interval and loses only the VERDICT
      clock-emvod/bulk300/hicasso / uix-subs: INSTRUMENT-LIMITED
FAIL  rf2-vp0j7/rf2-vh0e3: and it says so in the tool's own output, beside its own interval
      clock-emvod/bulk300/hicasso / uix-subs: and carry no ship/kill verdict
FAIL  rf2-vp0j7/rf2-vh0e3: the gated bulk pair still adjudicates, and is still INSTRUMENT-LIMITED on this corpus
      bulk gates the pair validation.md:17 names
      + null   - [ 'hicasso / reagent-subs' ]
FAIL  rf2-vp0j7/rf2-vh0e3: MUTATION: the band veto is retired on bulk, and the gated pair does not move either way
      the entry says so as data — true !== false
FAIL  rf2-vp0j7/rf2-vh0e3: MUTATION: and the retired veto still REFUSES when it is switched back on
      retired: a 10% effect inside a 40% band publishes on the interval alone — false !== true
FAIL  rf2-vp0j7/rf2-vh0e3: MUTATION: and gatedPairs is WHY — without it the donor-against-donor pairs would publish
      the fixture must leave the table as it found it
      + null   - [ 'hicasso / reagent-subs' ]

clock_exit_path.test.cjs: 6/352 failed
```

After the flip: `clock_exit_path.test.cjs: 352 passed`, exit 0.

**Pin 1 — a non-gated bulk pair reports its interval and carries no ship/kill verdict.** Red as `INSTRUMENT-LIMITED`; green as `CO-INSTRUMENTED` across 12 combinations (2 ungated pairs × 3 rows × 2 ensembles), asserted both through `effectVerdict` and off the tool's own stdout, where the `point … 95% CI [ … ]` line must still print beside it.

**Pin 2 — the gated bulk pair still adjudicates, and still returns INSTRUMENT-LIMITED.** Red on `gatedPairs === null`; green over 6 combinations, asserting the *reason* and not just the outcome — `does not lie wholly on one side of the 1 bar`, i.e. refused by the interval and not by the band. Paired with a two-way mutation: with `crossRunBandVeto` forced back to `true` the gated verdict is `deepStrictEqual` to the shipped one, restored in a `finally`.

**Pin 3 — the `rf2-8a746` fence holds.** The invariant assertion (18 combinations, none publishes) is green **before and after**, which is what a fence must be — it never had a red state to show, and a fence that flipped would be the finding. What is red-then-green is the *mechanism*: mutating `gatedPairs` back to `null` and finding that the three donor-vs-donor pairs **would** publish. Before the change that mutation is a no-op; after it, it prices exactly what `gatedPairs` is holding back.

**The previous worker's two-way `crossRunBandVeto` mutation is kept working in both directions**, in its new polarity: retired, a synthetic sub-1.0 interval inside a 40% band publishes; reinstated, the same interval is refused and the `why` names the band; restored in a `finally` and re-asserted.

### The `docs/design/hicasso/studio` page needed no edit

Its band-veto section sits inside the M1 supersession block and says the veto is *"retired here"*, which was true and remains true. It makes no claim about bulk's pair scope. `mkdocs build --strict` excludes `docs/design/**` in any case, and nothing in that tree changed.
