### PR TITLE
fix(hicasso): the driver prints the published row, not the retired regime (rf2-vr1hl)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -2289,6 +2289,17 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   // anything. rf2-y7mw7 had just made `HCLOCK_ONLY=keystroke` exit 1, and a
   // "relabelling" that let it exit 0 again would be that repair undone under
   // a nicer name. Every case below asserts the code as well as the sentence.
+  //
+  // THE MOUNT HALF IS SUPERSEDED AND THE MECHANISM IS NOT. Declaring a regime
+  // on the row rather than inferring it from the numbers is rf2-jcm3p's, and it
+  // stands. What that regime MEANS on `M1` does not: rf2-8a746 removed its
+  // ground (`ctl-2x` was never failing — the rule tests per-block band
+  // membership) and rf2-t2flm, then rf2-diaud, took its position (`M1` publishes
+  // a magnitude; K1 MISSED, DECISIVELY). The row still refuses HERE, for
+  // rf2-diaud's reason instead — the published magnitude is an ensemble
+  // estimate and one run cannot form it. The bracket the cases below pin was
+  // re-cited by rf2-vr1hl, jointly with the driver, because a print and its pin
+  // move together or one of them is a lie.
 
   const mountRow = (over) => clockRow({ rowId: 'M1', regime: 'mount-regime', ctlOk: false, ...over });
   const respRow = (over) =>
@@ -2344,10 +2355,60 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   t('the M1 refusal now states a REGIME rather than a control that went wrong', () => {
     const v = reportability([mountRow({ ctlNote: ' (ctl-2x 1.8173x vs 2.00x)' })]);
     const all = v.lines.join('\n');
-    assert.match(all, /M1 \[mount-regime, rf2-jcm3p\] STATED/);
-    assert.match(all, /DIRECTION ONLY/);
+    assert.match(all, /M1 \[mount-regime, rf2-diaud superseding rf2-jcm3p\] STATED/);
+    assert.match(all, /NO MAGNITUDE FROM ONE RUN/);
     assert.match(all, /positive control: FAIL \(ctl-2x 1\.8173x vs 2\.00x\) — expected, and the reason no magnitude/);
     assert.doesNotMatch(all, /the positive control did not see the change/);
+  });
+
+  // --- THE BRACKET CITES THE RULING IN FORCE (rf2-vr1hl) --------------------
+  //
+  // rf2-owiis swept this driver's PROSE off rf2-jcm3p's superseded position and
+  // could not take the LOG, because the log was pinned here and this file was
+  // held by another bead. So for a day the source said one thing and the run
+  // printed another. These three cases are the pins that make the log's half
+  // true, and they are deliberately two-sided: naming the ruling in force is
+  // half of it, and NOT printing the retired sentence is the other half. A pin
+  // that only asserts the new string would pass on a line carrying both.
+
+  t('the printed bracket names the ruling IN FORCE and keeps the superseded citation beside it', () => {
+    const all = reportability([mountRow()]).lines.join('\n');
+    // rf2-diaud is what governs the row; rf2-jcm3p is retained rather than
+    // dropped, because annotate-never-erase reaches a log line too.
+    assert.match(all, /\[mount-regime, rf2-diaud superseding rf2-jcm3p\]/);
+    assert.doesNotMatch(
+      all,
+      /\[mount-regime, rf2-jcm3p\]/,
+      'the bracket must not name the superseded ruling alone — that is the state rf2-vr1hl retired'
+    );
+  });
+
+  t('and the retired regime-only sentence is GONE from the log, not merely joined', () => {
+    const all = reportability([mountRow()]).lines.join('\n');
+    assert.doesNotMatch(all, /DIRECTION ONLY/, "rf2-t2flm and rf2-diaud gave M1 a magnitude — it publishes no 'DIRECTION ONLY'");
+    assert.doesNotMatch(
+      all,
+      /the control status is the published reason/,
+      "rf2-8a746 established ctl-2x was never failing, so its status is the published reason for nothing"
+    );
+    // and what replaced it says why THIS DRIVER still refuses, which is
+    // rf2-diaud's reason and not rf2-jcm3p's: one run, no ensemble.
+    assert.match(all, /ENSEMBLE one/);
+    assert.match(all, /one run cannot form the interval it is adjudicated against/);
+  });
+
+  t('the driver CITES the published M1 row and copies no figure out of it', () => {
+    const all = reportability([mountRow()]).lines.join('\n');
+    assert.match(all, /K1 MISSED, DECISIVELY/, 'the verdict in force is quoted');
+    assert.match(all, /rows-re-adjudicated-on-the-corrected-clock\.md sec 4\.3/, 'and the row it comes from is named by path');
+    // THE DISCIPLINE THIS PINS. §4.3 says of itself that every figure in it is
+    // quoted from nowhere else, and a figure with two homes has two futures:
+    // this driver would be the second home, and it is not the file that
+    // computes them. `clock_readjudicate.cjs` is. So the point and both bounds
+    // of both ensembles must appear nowhere in this driver's source.
+    for (const fig of ['1.1718', '1.1263', '1.2190', '1.1976', '1.1504', '1.2468']) {
+      assert.ok(!SRC.includes(fig), `clock_run.cjs must cite the published M1 row, never restate its figures — found ${fig}`);
+    }
   });
 
   // --- MUTATION, BOTH DIRECTIONS -------------------------------------------
@@ -2380,10 +2441,12 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   });
 
   t('a mount regime is NOT withheld by a failing control — the two regimes differ deliberately', () => {
-    // rf2-jcm3p's premise IS that ctl-2x fails, so a mount regime that waited
-    // on it could never be stated at all.
+    // rf2-jcm3p's premise WAS that ctl-2x fails, so a mount regime that waited
+    // on it could never be stated at all. rf2-8a746 removed the premise and
+    // rf2-diaud the position; the independence survives both, which is why the
+    // fixture still sets `ctlOk: false` and the row still STATES itself.
     const v = reportability([mountRow()]);
-    assert.match(v.lines.join('\n'), /M1 \[mount-regime, rf2-jcm3p\] STATED/);
+    assert.match(v.lines.join('\n'), /M1 \[mount-regime, rf2-diaud superseding rf2-jcm3p\] STATED/);
     assert.doesNotMatch(v.lines.join('\n'), /M1 .* WITHHELD/);
   });
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
@@ -2452,15 +2452,25 @@ function rowAdjudication(bars) {
  * licence to flip this flag would let a one-run capture announce a figure the
  * programme publishes only across an ensemble.
  *
- * WHAT THE LOG STILL SAYS, stated here because a comment nobody reads is not a
- * correction. The printed line remains `M1 [mount-regime, rf2-jcm3p] STATED —
- * DIRECTION ONLY ...`: both halves are pinned in `clock_exit_path.test.cjs`,
- * which a concurrent bead holds, so re-citing the LOG is a coordinated change
- * across two files and is filed as rf2-vr1hl rather than forced here. This
- * sweep changed no value, no threshold, no verdict, no roster entry and no
- * string this driver prints about a run. One `--selftest` CASE NAME was
- * corrected, in the fixtures below, because it asserted the premise rf2-8a746
- * retired; the case it names is unchanged and still passes.
+ * AND THE LOG SAYS IT TOO (rf2-vr1hl, 2026-08-08), because a comment nobody
+ * reads is not a correction. The printed line used to read `M1 [mount-regime,
+ * rf2-jcm3p] STATED — DIRECTION ONLY ...`, and both halves of it were pinned in
+ * `clock_exit_path.test.cjs`, so re-citing the LOG was a coordinated change
+ * across two files that rf2-owiis's sweep could not take alone. It reads now
+ *
+ *   `M1 [mount-regime, rf2-diaud superseding rf2-jcm3p] STATED — NO MAGNITUDE
+ *   FROM ONE RUN — ...`
+ *
+ * with the superseded citation kept in the bracket rather than dropped, and the
+ * three strings that compose it — `bead`, `publishes`, `why` — preserved
+ * verbatim beside their replacements below. NOTHING COMPUTED MOVED WITH THEM:
+ * `publishesMagnitude`, `statementNeedsControl` and `ROW_REGIME` are untouched,
+ * this run's exit code is what it was, and no threshold, estimand or verdict is
+ * this driver's to hold. The verdict in the new string is QUOTED from the row
+ * cited in it; the figures are not copied here, for the reason two paragraphs
+ * up. (rf2-owiis's own sweep moved no printed string at all; the one thing it
+ * did touch below is a `--selftest` CASE NAME that asserted the premise
+ * rf2-8a746 retired, and the case it names is unchanged and still passes.)
  *
  * A REGIME ROW REFUSES THE RUN, and that is not a change of temperature. This
  * run publishes no magnitude from it — by ruling rather than by accident — so
@@ -2476,28 +2486,49 @@ function rowAdjudication(bars) {
  */
 const REGIMES = {
   magnitude: { publishesMagnitude: true },
-  // EVERY STRING IN THIS ENTRY IS rf2-jcm3p's, AND rf2-jcm3p IS SUPERSEDED ON
-  // THIS ROW — the block above sets out by what, and rf2-vr1hl carries the
-  // re-citation of the printed line, which is pinned in
-  // `clock_exit_path.test.cjs` and therefore not this file's to take alone.
-  // The strings stay byte-identical: they are the record of the ruling this
-  // driver refused under, and rf2-owiis's sweep was of the prose around them.
+  // THIS ENTRY'S PRINTED STRINGS WERE rf2-jcm3p's UNTIL rf2-vr1hl, AND
+  // rf2-jcm3p IS SUPERSEDED ON THIS ROW — the block above sets out by what.
+  // The three strings the log prints are re-cited to the ruling in force; they
+  // are preserved verbatim immediately beside each one, because annotate-never-
+  // erase applies to a log line as much as to a figure, and because what this
+  // driver refused under is part of the record. Nothing else in the entry moved.
   'mount-regime': {
     // Still `false`, and now for rf2-diaud's reason rather than rf2-jcm3p's: a
     // single run cannot form the ensemble bootstrap the published M1 magnitude
     // is an estimate from. See the block above before changing this.
     publishesMagnitude: false,
-    bead: 'rf2-jcm3p',
-    // The statement is about DIRECTION, and direction does not turn on a
-    // control whose status is itself the published finding. (rf2-8a746: that
-    // status is not a FAILURE — the rule tests per-block band membership — but
-    // the regime's independence from it is what let the row state itself at
-    // all, and it is unaffected by the correction.)
+    // The bracket names the ruling IN FORCE and keeps the superseded citation
+    // beside it, so a reader of the log meets both without a git history.
+    // SUPERSEDED (rf2-vr1hl, 2026-08-08), was: 'rf2-jcm3p'
+    bead: 'rf2-diaud superseding rf2-jcm3p',
+    // The statement does not turn on a control whose status is itself part of
+    // the finding. (rf2-8a746: that status is not a FAILURE — the rule tests
+    // per-block band membership — but the regime's independence from it is what
+    // let the row state itself at all, and it is unaffected by the correction.)
     statementNeedsControl: false,
-    publishes: 'DIRECTION ONLY — hicasso mounts materially slower than both adapters; no magnitude',
+    // SUPERSEDED (rf2-vr1hl, 2026-08-08), was: 'DIRECTION ONLY — hicasso mounts
+    // materially slower than both adapters; no magnitude'. rf2-t2flm and then
+    // rf2-diaud gave the row a magnitude, so DIRECTION ONLY is no longer what
+    // it publishes; what this DRIVER can build from one run is what changed.
+    // The verdict is quoted; the figures are not, and must not be — they live
+    // in the cited row and are printed by `clock_readjudicate.cjs`.
+    publishes:
+      'NO MAGNITUDE FROM ONE RUN — M1 publishes a magnitude, but an ENSEMBLE one, and its verdict is ' +
+      'K1 MISSED, DECISIVELY (docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md sec 4.3)',
+    // SUPERSEDED (rf2-vr1hl, 2026-08-08), was: 'ctl-2x undershoots 2.00x by the
+    // additive constant c ~ 1.04 ms and no changed-set control can reach a
+    // mount, so the control status is the published reason rather than a fault
+    // of this run'. Its first two clauses survive rf2-8a746 intact and are in
+    // the preserved roster entry above; its last clause is the one sentence
+    // that ruling killed — the control was never failing, so its status cannot
+    // be the published reason for anything. Moved with `publishes` rather than
+    // after it: this is the same printed statement's second line, and a bracket
+    // citing rf2-diaud above a reason citing rf2-jcm3p's dead premise would
+    // pin the lie the re-citation exists to remove.
     why:
-      'ctl-2x undershoots 2.00x by the additive constant c ~ 1.04 ms and no changed-set control ' +
-      'can reach a mount, so the control status is the published reason rather than a fault of this run',
+      'the published M1 magnitude is a floor-normalised leg ratio through a run-preserving bootstrap ' +
+      'whose OUTER unit is the RUN, so one run cannot form the interval it is adjudicated against; ' +
+      'clock_readjudicate.cjs forms it over a committed corpus, and this driver contributes one run to that corpus',
   },
   'responsiveness-regime': {
     publishesMagnitude: false,
@@ -2716,12 +2747,13 @@ function reportabilitySelfTest() {
   // the ones showing a regime row REFUSES — the temperature of the exit did
   // not change, only the sentence.
   //
-  // THESE CASES PIN A SENTENCE rf2-jcm3p WROTE AND LATER RULINGS SUPERSEDED,
-  // and they still pin it on purpose. What they are for is that the regimes
-  // did not soften the exit code, and that holds whichever ruling the printed
-  // bracket names; changing the sentence is rf2-vr1hl's, jointly with
-  // `clock_exit_path.test.cjs`. The supersession itself is set out beside
-  // `REGIMES` above.
+  // THESE CASES USED TO PIN A SENTENCE rf2-jcm3p WROTE AND LATER RULINGS
+  // SUPERSEDED. rf2-vr1hl re-cited it, here and in `clock_exit_path.test.cjs`
+  // together, which is why it had to be one bead: the print and its pins move
+  // in one change or the suite goes red on a true string. What the cases are
+  // FOR did not move with the sentence — that the regimes did not soften the
+  // exit code, which holds whichever ruling the printed bracket names. The
+  // supersession itself is set out beside `REGIMES` above.
   const mount = (over) => row({ rowId: 'M1', regime: 'mount-regime', ctlOk: false, ...over });
   const resp = (over) =>
     row({ rowId: 'keystroke', regime: 'responsiveness-regime', adjudicable: false, unadjudicatedWhy: KEYSTROKE_WHY, ...over });
@@ -2735,7 +2767,7 @@ function reportabilitySelfTest() {
   check(
     'and it is refused as a REGIME rather than as a control that went wrong',
     m.lines.some((l) => /REGIME: these rows publish a regime and never a magnitude/.test(l)) &&
-      m.lines.some((l) => /M1 \[mount-regime, rf2-jcm3p\] STATED/.test(l)) &&
+      m.lines.some((l) => /M1 \[mount-regime, rf2-diaud superseding rf2-jcm3p\] STATED/.test(l)) &&
       !m.lines.some((l) => /the positive control did not see the change/.test(l)),
     m.lines.join(' | ')
   );


### PR DESCRIPTION
`rf2-owiis` (#7705) swept `clock_run.cjs`'s **prose** off `rf2-jcm3p`'s superseded
regime-only position, and could not take the **log**: both halves of the printed
line were pinned in `clock_exit_path.test.cjs`, which `worker/bulkgate-vp0j7`
held at the time. So for a day the source said one thing and the run printed
another. This is the other half — the print and its pins, moved together,
because changing the print alone reds the suite and changing the pins alone pins
a lie.

## The printed line

**Before**

```
[clock]   M1 [mount-regime, rf2-jcm3p] STATED — DIRECTION ONLY — hicasso mounts materially slower than both adapters; no magnitude
[clock]     ctl-2x undershoots 2.00x by the additive constant c ~ 1.04 ms and no changed-set control can reach a mount, so the control status is the published reason rather than a fault of this run
```

**After**

```
[clock]   M1 [mount-regime, rf2-diaud superseding rf2-jcm3p] STATED — NO MAGNITUDE FROM ONE RUN — M1 publishes a magnitude, but an ENSEMBLE one, and its verdict is K1 MISSED, DECISIVELY (docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md sec 4.3)
[clock]     the published M1 magnitude is a floor-normalised leg ratio through a run-preserving bootstrap whose OUTER unit is the RUN, so one run cannot form the interval it is adjudicated against; clock_readjudicate.cjs forms it over a committed corpus, and this driver contributes one run to that corpus
```

The bracket names the ruling **in force** and keeps `rf2-jcm3p` beside it rather
than dropping it — annotate-never-erase reaches a log line as much as a figure.
All three superseded strings are preserved verbatim in `SUPERSEDED (rf2-vr1hl,
2026-08-08), was: …` comments beside their replacements, in the idiom #7705
established in this file.

## The verdict is cited; the figures are not

The verdict `K1 MISSED, DECISIVELY` and the row's path were read off **merged
main**, §4.3 of `docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md`.
It matched what the bead recorded — **no discrepancy**. The intervals behind it
(`1.1718× [1.1263 – 1.2190]` n=8 and `1.1976× [1.1504 – 1.2468]` n=6) are
deliberately **not** copied into the driver: §4.3 says of itself that every
figure in it is quoted from nowhere else, and a figure with two homes has two
futures. A new case asserts it, scanning `clock_run.cjs`'s source for the point
and both bounds of both ensembles.

## Three fields moved, not two

The bead's shape named `REGIMES['mount-regime'].bead` and `.publishes`. A third
moved with them, and the reason is stated rather than buried: `.why` is the
**second line of the same printed statement**, and it ended
*"…so the control status is the published reason rather than a fault of this
run"* — a restatement of `THE FAILING CONTROL IS THE PUBLISHED REASON`, the one
sentence `rf2-owiis` named as dead under `rf2-8a746`. Leaving it would have put
`rf2-jcm3p`'s retired premise one line under a bracket citing `rf2-diaud`. Its
first two clauses survive intact and are in the preserved roster entry above it.

## Nothing computed or adjudicated changed

No threshold, estimand, verdict or published figure is this driver's to hold,
and none moved. `publishesMagnitude`, `statementNeedsControl` and `ROW_REGIME`
are untouched, and the exit code is what it was. Excluding comments, the driver's
whole diff is four lines: the three strings and the driver's own `--selftest`
regex over them.

**`publishesMagnitude` remains `false`, for `rf2-diaud`'s reason and not
`rf2-jcm3p`'s.** The published magnitude is a floor-normalised leg ratio through
a run-preserving bootstrap whose **outer unit is the run**, over eight runs and
six, so no single run of this capture driver can form the interval it would be
adjudicated against. Reading the supersession as licence to flip the flag would
let a one-run capture announce a figure the programme publishes only across an
ensemble. The source says so in terms, twice.

## Red-then-green

`clock_exit_path.test.cjs` was **352 passed** on `origin/main`.

| step | result |
|---|---|
| baseline, before any edit | **352 passed**, exit 0 |
| new print, **old pins** (driver edited, test file untouched) | **2/352 failed**, exit 1 — `:2347` and `:2386` both on `/M1 \[mount-regime, rf2-jcm3p\] STATED/` |
| both moved | **355 passed**, exit 0 |
| reverse mutation: `bead` + `publishes` reverted to `rf2-jcm3p`, **new pins** | **6/355 failed**, exit 1 — every new pin fires, plus the driver's own self-test |
| restored from `HEAD` | **355 passed**, exit 0 |

`+3` cases: the bracket names the ruling in force *and* no longer names the
superseded one alone; the retired sentence is **gone** rather than merely joined
(`DIRECTION ONLY`, `the control status is the published reason`); and the driver
cites the published row while copying no figure out of it. Each is two-sided —
a pin that only asserted the new string would pass on a line carrying both.

## Quality gates

All run foreground to completion from `/c/Users/miket/code/re-frame2-worktrees/regimeline-vr1hl`, none piped through `tail`/`head`/`grep` for its verdict.

| gate | exit |
|---|---|
| `node --check clock_run.cjs` | 0 |
| `node --check clock_exit_path.test.cjs` | 0 |
| `node clock_run.cjs --selftest` | 0 — `ALL ADJUDICATORS OK` |
| `node clock_exit_path.test.cjs` | 0 — **355 passed** (was 352) |
| `npm run test:script-helpers` | 0 |
| `sh scripts/test-fast-pr.sh` | 0 — `PASS fast PR spine`, `gate root: /c/Users/miket/code/re-frame2-worktrees/regimeline-vr1hl` |
| `npm run lint:js` (repo root) | 0 |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | 0 — no beads-database paths |

The spine's `ok … → FAILED` lines are its negative-test harnesses passing; the
verdict is `PASS fast PR spine` and the echoed exit code.

**No measurement was taken.** No window was consumed, and no dataset was read or
written.

## One residual, filed rather than taken

`rf2-ejb9h` (P3). `reportability()` annotates a regime row's failed control with
`— expected, and the reason no magnitude is published`. Both claims are
`rf2-jcm3p`'s and both are retired — `rf2-8a746` established the control was
never failing, and the reason this driver publishes no magnitude is `rf2-diaud`'s
ensemble one. It is one surface further out than this bead's fence: it lives in
the decision function rather than the roster, it is generic over regime rows, and
it does not fire on the committed corpus (all 14 mount row-runs are `IN CONTROL`
under the v2 mount class). Its two pins and the shape of the fix are on the bead.
