### PR TITLE
fix(hicasso): the control annotation stops asserting a retired premise (rf2-ejb9h)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -2357,7 +2357,10 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     const all = v.lines.join('\n');
     assert.match(all, /M1 \[mount-regime, rf2-diaud superseding rf2-jcm3p\] STATED/);
     assert.match(all, /NO MAGNITUDE FROM ONE RUN/);
-    assert.match(all, /positive control: FAIL \(ctl-2x 1\.8173x vs 2\.00x\) — expected, and the reason no magnitude/);
+    assert.match(
+      all,
+      /positive control: FAIL \(ctl-2x 1\.8173x vs 2\.00x\) — the regime does not wait on this control/
+    );
     assert.doesNotMatch(all, /the positive control did not see the change/);
   });
 
@@ -2395,6 +2398,65 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     // rf2-diaud's reason and not rf2-jcm3p's: one run, no ensemble.
     assert.match(all, /ENSEMBLE one/);
     assert.match(all, /one run cannot form the interval it is adjudicated against/);
+  });
+
+  // --- AND THE CONTROL ANNOTATION TOO (rf2-ejb9h) ---------------------------
+  //
+  // rf2-vr1hl re-cited the row's own three strings and filed this: two lines
+  // below them, `reportability` annotated the control status of a regime row
+  // that failed its control with " — expected, and the reason no magnitude is
+  // published", and BOTH claims were rf2-jcm3p's. "expected" fell with
+  // rf2-8a746 (`ctl-2x` was never failing — the rule tests per-block band
+  // membership, and all fourteen committed mount row-runs are IN CONTROL under
+  // the v2 class), so no live ruling predicts a failure here. "the reason no
+  // magnitude is published" fell with rf2-diaud, which publishes a magnitude on
+  // M1 and locates this driver's refusal in the ensemble bootstrap instead.
+  //
+  // THE ANNOTATION IS RE-CITED, NEVER DELETED. It exists because the ruling
+  // that made these rows regimes is ABOUT their controls, so a reader must meet
+  // the status rather than infer it. What survives both rulings — and is the
+  // real subject of the fixture's `ctlOk: false` — is that the mount regime
+  // does not WAIT on its control.
+  //
+  // NOTE THAT THIS SUFFIX DOES NOT FIRE ON THE COMMITTED CORPUS: it needs
+  // `ctlOk === false` on a regime row, and every committed mount row-run is in
+  // control. It is reachable only from fixtures like these, which is precisely
+  // why it had to be corrected rather than left — dead prose asserting a
+  // retired premise is read as current the day it finally prints.
+
+  t('the control annotation says what SURVIVED both rulings and predicts nothing', () => {
+    const all = reportability([mountRow({ ctlNote: ' (ctl-2x 1.8173x vs 2.00x)' })]).lines.join('\n');
+    assert.match(
+      all,
+      /positive control: FAIL \(ctl-2x 1\.8173x vs 2\.00x\) — the regime does not wait on this control, so a failure here withholds nothing/,
+      'the independence is what both rulings leave standing, so it is what the annotation states'
+    );
+    // Two-sided, because a pin that asserted only the new sentence would pass
+    // on a line that had merely gained it beside the retired one.
+    assert.doesNotMatch(
+      all,
+      /positive control: FAIL[^\n]*expected/,
+      'rf2-8a746 established ctl-2x was never failing, so no live ruling PREDICTS this failure'
+    );
+    assert.doesNotMatch(
+      all,
+      /the reason no magnitude is published/,
+      'rf2-diaud: M1 publishes a magnitude, and this driver withholds one for the ensemble reason, not a control failure'
+    );
+  });
+
+  t('a regime row whose control PASSED is not annotated at all — the suffix is conditional', () => {
+    const all = reportability([mountRow({ ctlOk: true })]).lines.join('\n');
+    assert.match(all, /positive control: PASS/);
+    assert.doesNotMatch(all, /positive control: PASS[^\n]*withholds nothing/);
+  });
+
+  t('and a regime WITHHELD by its control is not annotated twice', () => {
+    // `keystroke` DOES wait on its controls, so the withholding is already the
+    // subject of the line above and the annotation stays out of it.
+    const all = reportability([respRow({ ctlOk: false })]).lines.join('\n');
+    assert.match(all, /keystroke \[responsiveness-regime, rf2-swwud\] WITHHELD/);
+    assert.doesNotMatch(all, /positive control: FAIL[^\n]*withholds nothing/);
   });
 
   t('the driver CITES the published M1 row and copies no figure out of it', () => {

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
@@ -2284,12 +2284,43 @@ function reportability(rows, opts) {
       // The control status, printed on every regime row whichever way it fell,
       // because the ruling that made these rows regimes is ABOUT their
       // controls and a reader must not have to infer one from the other.
-      // A failure the regime PREDICTS says so; one that withholds the regime is
-      // already explained by the line above and is not annotated twice.
-      const predictedFailure = !r.ctlOk && !g.statementNeedsControl;
+      //
+      // SUPERSEDED (rf2-ejb9h, 2026-08-08), was: 'A failure the regime PREDICTS
+      // says so; one that withholds the regime is already explained by the line
+      // above and is not annotated twice.' Its second clause survives verbatim
+      // below. Its first is rf2-jcm3p's and is retired: NO LIVE RULING PREDICTS
+      // a failure on this row. rf2-8a746 established `ctl-2x` was never failing
+      // — `controlVerdict` tests per-block band membership rather than the mean,
+      // and under the mount class rf2-x7x10 calibrated at v2 all fourteen
+      // committed mount row-runs come back IN CONTROL. What this condition
+      // actually selects is a row whose regime does not WAIT on its control and
+      // whose control nonetheless did not pass, so the row states itself anyway
+      // — which is the independence rf2-jcm3p established and the one part of
+      // its account that both later rulings leave standing. A failure that DOES
+      // withhold the regime is already explained by the line above and is not
+      // annotated twice.
+      // SUPERSEDED (rf2-ejb9h, 2026-08-08), was: `predictedFailure`. The
+      // expression is byte-identical; only the name moved, because a local
+      // asserting a prediction beside a string that denies one is the same lie
+      // one surface in.
+      const statedDespiteFailure = !r.ctlOk && !g.statementNeedsControl;
       lines.push(
         `[clock]     positive control: ${r.ctlOk ? 'PASS' : 'FAIL'}${r.ctlNote || ''}` +
-          (predictedFailure ? ' — expected, and the reason no magnitude is published' : '')
+          // SUPERSEDED (rf2-ejb9h, 2026-08-08), was: ' — expected, and the reason
+          // no magnitude is published'. BOTH of its claims were rf2-jcm3p's and
+          // BOTH are retired. "expected" fell with rf2-8a746, above. "the reason
+          // no magnitude is published" fell with rf2-diaud: M1 publishes a
+          // magnitude, and where THIS DRIVER withholds one the reason is that the
+          // published magnitude is an ensemble estimate whose bootstrap's outer
+          // unit is the RUN — which is exactly what the `why` line printed
+          // directly above this one now says. The annotation is re-cited rather
+          // than deleted, for the reason three paragraphs up: the ruling that
+          // made these rows regimes is about their controls, so a reader must
+          // meet the control's status here and not infer it.
+          (statedDespiteFailure
+            ? ' — the regime does not wait on this control, so a failure here withholds nothing; ' +
+              'what the row publishes and why are the two lines above'
+            : '')
       );
     }
   }
@@ -2776,9 +2807,16 @@ function reportabilitySelfTest() {
   // the name is corrected while the case itself is untouched: what it pins is
   // that the mount regime does not WAIT on its control, which is independent
   // of whether that control passes and is why the fixture sets `ctlOk: false`.
+  //
+  // THE REGEX moved with the annotation it pins (rf2-ejb9h, 2026-08-08), and it
+  // is two-sided for the reason rf2-vr1hl's pins are: asserting only the new
+  // sentence would pass on a line that still carried the retired one beside it.
+  // SUPERSEDED (rf2-ejb9h, 2026-08-08), was:
+  //   /positive control: FAIL.*expected, and the reason no magnitude is published/
   check(
     'the mount regime STATES itself although its control failed — the regime does not wait on that control',
-    m.lines.some((l) => /positive control: FAIL.*expected, and the reason no magnitude is published/.test(l)),
+    m.lines.some((l) => /positive control: FAIL.*the regime does not wait on this control/.test(l)) &&
+      !m.lines.some((l) => /expected, and the reason no magnitude is published/.test(l)),
     m.lines.join(' | ')
   );
 


### PR DESCRIPTION
Third and last link of the supersession chain `rf2-owiis` → `rf2-vr1hl` → `rf2-ejb9h`. `rf2-owiis` swept the driver's prose, `rf2-vr1hl` re-cited the printed REGIME line and its three pins, and each filed what it could not take cleanly. This takes the one thing left: a conditional suffix in `reportability()`, two lines below the strings `rf2-vr1hl` corrected, still asserting two of `rf2-jcm3p`'s retired claims.

## The suffix, before and after

Before:

```
 — expected, and the reason no magnitude is published
```

After:

```
 — the regime does not wait on this control, so a failure here withholds nothing; what the row publishes and why are the two lines above
```

which prints as

```
[clock]     positive control: FAIL (ctl-2x 1.8173x vs 2.00x) — the regime does not wait on this control, so a failure here withholds nothing; what the row publishes and why are the two lines above
```

**Both retired claims were `rf2-jcm3p`'s.**

*"expected"* fell with `rf2-8a746`: `ctl-2x` was never failing, because `controlVerdict` tests per-block band membership rather than the mean. No live ruling predicts a control failure on this row. Verified here rather than assumed — `clock_readjudicate.cjs` over both committed ensembles reports `IN CTRL` on every run and zero `OUT OF CTRL`, so all fourteen committed mount row-runs are in control under the class `rf2-x7x10` calibrated at v2.

*"the reason no magnitude is published"* fell with `rf2-diaud`: M1 publishes a magnitude, and where this driver withholds one the reason is that the published magnitude is an ensemble estimate through a run-preserving bootstrap whose outer unit is the run — which is exactly what the `why` line printed directly above the annotation now says.

What replaces them is the one part of `rf2-jcm3p`'s account both later rulings leave standing, and the real subject of the fixture's `ctlOk: false`: the mount regime does not *wait* on its control.

**Annotated, never erased.** The annotation is re-cited rather than deleted, because the ruling that made these rows regimes is *about* their controls and a reader must meet the status rather than infer it — the comment above it has said so since it was written. Every superseded string is preserved verbatim in a `SUPERSEDED (rf2-ejb9h, 2026-08-08), was: ...` comment beside its replacement, in the idiom #7705 established and #7708 matched.

**It does not fire on the committed corpus**, since the condition needs `ctlOk === false` on a regime row and every committed mount row-run is in control. It is reachable only from fixtures. That is the reason to correct it rather than leave it: dead prose asserting a retired premise is read as current on the day it finally prints.

## Nothing computed or adjudicated changed

`publishesMagnitude`, `statementNeedsControl`, `ROW_REGIME`, `bead`, `publishes` and `why` are untouched — proved by diffing the extracted field lines against the merge base. No threshold, estimand, verdict or exit code moved.

`publishesMagnitude` **remains `false`**, and for `rf2-diaud`'s ensemble reason rather than `rf2-jcm3p`'s: a single run of this capture driver cannot form the interval the published magnitude is adjudicated against. Reading the supersession as licence to flip it would let a one-run capture announce a figure the programme publishes only across an ensemble.

Excluding comments, the driver's entire diff is three things:

- the local `predictedFailure` renamed `statedDespiteFailure`, expression byte-identical — a local asserting a prediction beside a string that denies one is the same lie one surface in;
- the suffix itself;
- the driver's own `--selftest` regex over it.

No figure is quoted anywhere. The published row is cited by path only (`docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md` §4.3), and no doc was touched.

## Red-then-green

Counts established locally against the merge base, not assumed.

| step | `clock_exit_path.test.cjs` | `--selftest` |
| --- | --- | --- |
| baseline on the merge base | 355 passed, exit 0 | ALL ADJUDICATORS OK, exit 0 |
| new suffix, **old** pins | **2/355 failed, exit 1** | **FAILURES: 1, exit 1** |
| both moved | 358 passed, exit 0 | ALL ADJUDICATORS OK, exit 0 |
| reverse: retired suffix restored, **new** pins | **3/358 failed, exit 1** | **FAILURES: 1, exit 1** |
| both sentences on one line | **2/358 failed, exit 1** | **FAILURES: 1, exit 1** |
| restored from HEAD | 358 passed, exit 0 | ALL ADJUDICATORS OK, exit 0 |

The last mutation is the one that earns the negative assertions, and it is why the new pins are two-sided as `rf2-vr1hl`'s are: with **both** sentences printed on the same line, the positive-only pin at `:2360` **passes**. Only the two-sided case and the driver's own self-test catch it. A pin asserting merely that the new sentence is present would green a line that had gained it *beside* the retired one.

The +3 cases are the two-sided annotation case plus two that fence the conditional: a regime row whose control **passed** carries no annotation, and a regime **withheld** by its control is not annotated twice.

## Quality gates

All foreground, to completion, `gate root: C:/Users/miket/code/re-frame2-worktrees/ctlnote-ejb9h`.

| gate | exit |
| --- | --- |
| `node --check clock_run.cjs` | 0 |
| `node --check clock_exit_path.test.cjs` | 0 |
| `node clock_run.cjs --selftest` | 0 — ALL ADJUDICATORS OK |
| `node clock_exit_path.test.cjs` | 0 — 358 passed (355 before) |
| `npm run test:script-helpers` | 0 |
| `sh scripts/test-fast-pr.sh` | 0 — `PASS fast PR spine` |
| `npm run lint:js` (repo root) | 0 |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | 0 — no beads-database paths |

## Residuals

**None in code.** Every remaining `rf2-jcm3p` mention in `clock_run.cjs` is either the mechanism — declaring a regime on the row rather than inferring it from the numbers, which stands — or is explicitly annotated as superseded. A `git grep` for the retired sentences across tracked files returns only this PR's own `SUPERSEDED` comments and negative assertions.

The chain terminates here, and it shrank at every link: prose across many sites → one printed line and three pins → one conditional suffix and one pin. The known doc-half residual (`validation.md` still citing `rf2-t2flm` where `rf2-diaud` is in force) is already tracked as `rf2-sza0w` and is a ruling question, not a sweep.
