### PR TITLE
docs(hicasso): publish the normative product set for workers (rf2-hic-000)

### DIFF
--- a/docs/design/hicasso/product/README.md
+++ b/docs/design/hicasso/product/README.md
@@ -1,0 +1,26 @@
+# Published normative set (snapshot)
+
+Published from the operator-local working set by rf2-hic-000. This is the worker-facing snapshot; the refresh rule and the living-home question are recorded in the bead-set README (default #7). File map: decision-brief.md (= synth.md), specification.md (= synth-codex.md), lanes/ (= codex/).
+
+The naming ledger (naming-ledger.md) is live and appended-to by beads; see rf2-hic-065.
+
+## Source hashes at publication
+
+```
+d4f4b73de25d7d16db204b3475fb73c368433b7fcce2d16d1981e7de49c380a1 *synth.md
+22016a0f24a3876e669f143854504d16016aad8a8f6c8e7e07fc6e576a1740e9 *synth-codex.md
+5aada8dc5adfff72d8078912dff1bbd30de4e6caae471e21a0a9e9e45994625a *codex/README.md
+eedfc83cdf53246bd7c9effcf062d410e574c0c4603c8bff6cbce914917c2c7d *codex/adversarial-risks.md
+212b41dc4bffa3004e1220260554b543ec36a3b5b44120ff460682d3a717daeb *codex/beads-review.md
+11c7d5b4b346feeb7bae9c1403969c956d36a5662bc7a243b3832ccf20ba28c8 *codex/completeness-audit.md
+81bcabd307c3cc6703e093f1e11c1048057ada8a8d0d11a1eab8d3a1cbc7a80e *codex/corpus-insights.md
+18eb61ffcfec460b883ca75ca3c220adf8fa41eef01899285739f2bb0d2f5289 *codex/delivery-programme.md
+b2b1d5f8fe254b2c2042e9fb24cdca86e8cb799181a39e8194095a6f9195b053 *codex/design-laws.md
+4ced536fd23726d7dca081baf0171d5fc32d0bb5e35d0e0c6f7e9f652ae58ed8 *codex/ergonomics-api.md
+1224b468ddd2e71777bb182cff6f9864891f11678dfbc87d8c9c506a5b64d8e6 *codex/evidence-baseline.md
+cae0d4bf4c1041b350837bf8ed143be763fff88b9685375b528788d26ec770dd *codex/hot-path-architecture.md
+0bea850ebd1f1dc7da42ab693030a135e309e9a368fb728f3f50ca4836bb2abe *codex/left-field-ideas.md
+a25e603d1f8aabb6ca6b5709ff61abd95864c702adc329de9a7df17bcffc2c2e *codex/react-compatibility-notes.md
+f479a12c5edc15f02a334616cc9c7d5b9e2588196fc87e3e97afa96d13f2aba5 *codex/testing-xray.md
+5904203883eae79c1b972e07c9ac7ca88228c0a0593c45480f61afd102a4da6f *codex/use-cases.md
+```

--- a/docs/design/hicasso/product/decision-brief.md
+++ b/docs/design/hicasso/product/decision-brief.md
@@ -1,0 +1,156 @@
+# Hicasso: the native adaptor — analysis, review, and plan
+
+**The goal**: **Hicasso is the base** — an interpreted-hiccup view layer with clean ways to drop down to very efficient React for the hot parts of an app (1–2% of the code; often 0%). Good-enough performance. Excellent programming ergonomics: minimal, clean code; excellent testing; excellent Xray diagnostics. Complete coverage of the use-cases. The end state is an excellent **native re-frame2 adaptor that is better than the other adaptors** — more ergonomic, more complete.
+
+This document is the decision-grade analysis, review, and plan. It owns the forensic scoreboard, the selected-direction record, the scoped price amendment, the K3 disposition, the sitting agenda, and the kill rules—the same split `codex/README.md` states.
+
+Its sibling `synth-codex.md` is the detailed **product specification**: facade, budgets, coverage matrix, phase exits. It is maintained with the `codex/` lanes as a living normative spec set, indexed by `codex/README.md`. This page deliberately does not restate API spellings, budget tables, or coverage rows. The two are designed to be read together. History and evidence live in companion files; neither page retells them.
+
+---
+
+## Part I — Analysis: what everything rests on
+
+**1. Capability pays rent — standing per-boundary machinery is the design's mortal enemy.** A facility used by few boundaries must never add standing cost to all boundaries; optional modules are zero reachable production code when absent; the do-nothing boundary is measured whenever the shell changes. The rule is unconditional, and its evidence is mortal: two prior runtimes died of fixed per-boundary cost (a 2,430 B do-nothing wrapper; an O(reads) observation ledger) — different runtimes on different instruments, so a *mechanism-class hypothesis* rather than one pooled result, but the strongest failure signal in the record.
+
+**2. The hot path is authored, not compiled** — a visible gradient of explicit choices, never a `:fast` flag or a second execution mode. Compilation does not rescue runtime costs: a compiled tier moved a 27.78x deficit only to 24.83x, a perfect markup compiler lands *on* the UIx twin, and the registered bounded conclusion stands — on the named large-template mount evidence, no identified admissible lever clears the 45.7–49.4% threshold of the measured deficit (reopen conditions are named in the baseline).
+
+**3. Where the semantics live is the real architecture axis.** Four coherent placements exist, each with a price owner:
+
+| Placement | Buys | Price owner |
+|---|---|---|
+| Data IR + analyzer + two emitters | Static knowledge, portable structure | Grammar, compiler, parity corpus, boundary machinery — the re-frame.ui/Freehand bill |
+| **Interpreted data as real React components** | Ordinary Clojure composition, one client semantics, the React ecosystem | Runtime read collection, a small shell, codec work, Node for full SSR |
+| Own renderer / whole-state renderer | A chance to change bulk/heap economics at the root | DOM semantics, invalidation topology, React as islands |
+| Thin adapter over UIx | Minimal machinery, mature hooks | No ambient reads in loops/helpers; a weaker data language |
+
+Hicasso is the second row, chosen with eyes open; the fourth row stays alive as the permanent comparator and fallback.
+
+**4. The mount premium is priced, and the amendment is its record.** The canonical K1 record—one estimator producing point and interval together; rf2-diaud / PR #7704—stands at **1.1718x [1.1263–1.2190]** and **1.1976x [1.1504–1.2468]** versus direct UIx, both intervals above the original 1.10x gate: **K1 is missed, decisively**, and remains a miss.
+
+About 70% of that premium is read-count *capability*: ambient `sub` in loops and helpers declares fine reads a hook twin cannot spell; per read, Hicasso is cheaper; read-matched pages run near parity. The dogfood verdict prefers the capability, and the selection is made. The **prospective, scoped amendment** is the selection's honest record — the accepted price, the use-cases it buys, the escape route, and the reconsideration trigger — drafted in Phase 0 and ratified at the sitting; the original result is never recoloured and no threshold widens.
+
+Bulk is gated on the Reagent pair only, unresolved and instrument-limited. Heap keeps **three scoreboards, no denominator substitution**: viability against the best shipped path (Reagent, the governed K3 row); architecture progress against the UIx parent (~29% better, reported beside); and author preference (the verdict). None replaces another.
+
+**5. Semantics live in React, so the server renders with React.** The server/hydration contract is **core, per public surface**: every view, host, root, and escape either renders deterministically with React server bytes or refuses at its source with recovery — only the deployable Node *service* is optional and caller-gated. The Node sidecar is ruled; one emitter; no JVM twin ever. And **numbers never pool across instruments** — every claim carries its witness, commit, substrate, and instrument.
+
+**The scoreboard** (records cited in Sources):
+
+| Axis | Where it stands |
+|---|---|
+| Mount (K1) | **Missed decisively**: 1.1718x / 1.1976x vs direct UIx, canonical, both intervals above 1.10x — the priced capability premium |
+| Bulk (K2) | Gated on the Reagent pair only (ruled); all gated intervals straddle 1.0 — unresolved, instrument-limited |
+| Per-read heap (K3) | Misses the governed Reagent row (~1.4x); beats the UIx parent by ~29% — both reported, disposition owed explicitly |
+| Boundary shell (R=0) | **1,103 B / 1,097 B on the pinned segments — above the registered 1 KB paper-fail line**; a live pressure, owned by the Phase 1 substrate adjudication |
+| Warm allocation | No fitted series clears the instrument's quality floor — no claim publishable yet |
+| Teardown | Zero retained bytes and objects on the pinned heap arms — the proven invariant |
+| Interpreter walk | Faster than stock Reagent — interpretation itself is solved |
+| Controlled input | Strong in Chromium; WebKit matrix open (K4) |
+| SSR | Core per-surface server/hydration contract owed; the Node spike is proven on its fixtures; the deployable service waits for its named caller |
+| Correctness isolation | Eleven-risk register open — eight kernel rows plus three native-tier rows; the blocker class |
+
+---
+
+## Part II — Review: Hicasso against the goal
+
+**"Better" is ordered, and a lower priority cannot buy a failure in a higher one**: correctness → ergonomics → coverage → testing & diagnosis → performance → product readiness. The product has five surfaces, of which only the interpreted core is unavoidable: the interpreted core (small fixed shell; cost follows actual reads and markup), the React bridge (a core capability, paid only at the crossing), the native hot path (paid by the selected region; absent when unused), optional libraries (zero production code when absent), and developer products (erased from production).
+
+**The use-case compass steers everything.** Hicasso exists for ordinary data-heavy forms, lists, routes, and conditional UI; dynamic reads whose natural spelling is helpers, branches, and loops; event-data-first authoring; controlled fields under the centralized law; React libraries through the declared door; and incremental Reagent migration. These jobs are the census-grounded majority: 231 reads across 85 files, ~97% pure-data handler sites, 77 controlled fields, 106 route links, and zero view-local cells. They justify the premium.
+
+It must still prove bulk collections, multi-root isolation, WebKit input, a complete application, and a serious vendor integration; Phases 1 and 4 exist for those jobs. Generic local state, controller runtimes, overlay managers, layout primitives, and form frameworks stay out of core until demand repeats. That is the anti-cathedral fence: universalizing rare jobs killed the predecessor. Rarity in one repository is not proof that a job does not matter, so the fitness harness remains the standing acceptance corpus.
+
+**The interpreted base: strong and settled.** Hiccup as data, intents as data, ambient reads at point of use; the interpreter outruns stock Reagent; the dogfood screen reads 47 lines against UIx's 72 with the IME law centralized where hand-rolled code gets it wrong. Nothing in the plan touches the language. State keeps **named pressure valves** rather than one brittle rule: domain and workflow state in re-frame; drafts and control state in concern-named or optional modules; host-private geometry, focus, and imperative handles inside ordinary React hosts; no generic second store, ever.
+
+**The drop-down: the trap door is native React, not any particular library.** UIx is the proven, ergonomic CLJS route to native React and the standing comparator, but it is not the contract and not necessarily the absolute floor. The ladder reads: **native React, with Hicasso-native and UIx as supported authoring routes**.
+
+Raw escapes, `defhost`, and a shared frame context already make mixed subtrees feasible without a second state owner. What is missing is the **gradient** in Part III. Its most valuable unbuilt rung is direct React output from a Hicasso boundary: keep the frame, reads, memo, and lifecycle, but skip Hiccup lowering for the returned React element. The advisor must name the hot 1–2%, and the product must teach the routes between “ordinary” and “island.”
+
+**The native tier ships in the same artifact.** An application should not acquire UIx merely to optimize one hot region. Hicasso therefore carries a small surface in a separate namespace, provisionally `re-frame.hicasso.native` as `n`. The namespace makes the semantic boundary visible and contains only:
+
+- `n/$`, compiling one explicit element expression directly to React construction;
+- `n/defcomponent`, defining a stable native component with display name, source, HMR, and one props/children ABI;
+- `n/use-sub` and `n/use-frame`, joining the installed frame through shared native hooks;
+- same-root bridges in both directions; and
+- ABI-preserving helpers for memo, lazy loading, and refs.
+
+Ordinary hooks come directly from React. Clojure-friendly wrappers appear only when real island code proves repeated ceremony; Hicasso does not pre-emptively clone UIx's utility library. UIx remains supported for applications already using it or whose native region grows into substantial React-first work.
+
+The boundary is **two explicit languages, absolute and visible**: `[...]` is always interpreted Hiccup and `n/$` is always compiled native React. This does not revive macro optimization of later-interpreted Hiccup. Native props take native callbacks with no intent lowering. Controlled-input repair, structural testing, and tree diagnostics stop at the boundary. Xray still names and times it and observes reads through `n/use-sub`, while the inner React tree remains honestly opaque. Foreign libraries still normally enter through `defhost`.
+
+The tier is real only after parity against **both UIx and handwritten React**: equivalent DOM, keys, refs, hydration, SVG, custom elements, dynamic props, and children; stable HMR and component identity; zero native runtime in bundles that never require the namespace; and performance inside the native-island parity budget.
+
+**Ergonomics: a real win, with the facade needing curation, not growth.** The honest losses versus UIx (compile-time shape checking; event-in-hand) are recoverable as lint and the one explicit handler form. The prototype-to-product disposition (spec §3.7) prunes rather than adds: `h/fn` becomes `h/handler` with one invariant meaning; `:&` leaves the grammar for a pure merge helper; `h/reg-state` leaves the adaptor core; `subscribe-once` goes internal; presence and route-link move to their optional homes; `h/as-element` and the outward bridge (a native React parent rendering a Hicasso view under the shared frame) are the two genuinely missing conversions. Names stay provisional until their witnesses pass.
+
+**Testing: the unshipped superpower, now with a shape.** The layered ladder (spec §9): L0 pure functions → L1 pure data/property tests → L2 a *restricted semantic-tree assertion harness* for registered hook-free bodies (an assertion model with honest opacity — hosts, hooks, and raw React are opaque by design, missing fixtures refuse) → L3 mounted React DOM → L4 real browsers. The bench-private machinery (canonical-DOM compare, intent-script driver) becomes the supported kit; schema-driven generative testing runs as a bounded spike; every important gate carries a sabotage control.
+
+**Diagnostics: measured but dark, with the laws already learned.** The causal lens is *event → subscriptions → values → boundaries → bodies → commit → paint*. Every link has an explicit evidence seam; unavailable facts are `unknown`, `opaque`, or `uncorrelated`, never authoritative empties. Schemas are versioned, loss is accounted for, and the machinery erases from production.
+
+The differentiator is the **cause-aware hot-view advisor**. It ranks views by time, frequency, read churn, and fan-out; classifies pressure as computation, topology, lowering, React, or layout; and recommends native extraction only when that addresses the measured owner. It chooses the smallest route among direct `n/$`, a named Hicasso-native component, UIx, and a foreign host. The complaint catalogue—stable diagnostic ids with recovery ladders—is the cheapest proven asset to adopt. Current Xray consumes the Freehand tooling tier, while `re-frame.ui.tool` survives only in fixtures, so the glass builds on the live tier.
+
+**Completeness: named gaps under one coverage rule.** Every recurring job gets a maintained answer at a named layer: core default, optional module, recipe, host escape, or didactic refusal with recovery. The full matrix is spec §7.
+
+The biggest gaps sit on high-traffic jobs: forms, overlays on the native top layer, the testing kit, the glass, async resource demand, code splitting, and modern-React conduct. The forms answer begins with a buffered-draft field that removes five hand-rolled trap classes. For code splitting, current Hicasso mints React functions and has **no** late-bound view-id registry; a small `React.lazy` boundary-ABI bridge is the default over existing fact, while a registry would be new work needing its own justification. The release matrix covers Activity hide/reveal, the internal `useSyncExternalStore` seam, and hydration from React server bytes.
+
+The strategic differentiator among the gaps is **demand-driven resource ownership**: a committed `sub` that reads a resource may also declare demand — unmount or parameter change releases it; debounce, supersession, refresh-with-data, and cancellation remain explicit policies. Its fences are hard (reuse committed read membership; abandoned renders acquire nothing; no second per-read ledger — the failed-ledger mechanism class must not reappear here) and a typeahead witness decides whether it graduates.
+
+**Trust: the one blocker class.** The trust register in `codex/adversarial-risks.md` holds eleven risks. Eight belong to the kernel: module-global ownership including the shared hydration adoption window; same-id reincarnation dispatch; speculative-render leakage and false abandonment tests; the unstated ambient-read extent; controlled-input portability; HMR identity; callback retirement; and hydration isolation.
+
+Three belong to the native tier: native-language leakage (`n/$` never rewrites interpreted Hiccup), boundary-ABI drift across the three authoring routes, and native-tier rent (zero native runtime in interpreted-only bundles). “Better than the other adaptors” begins at “as trustworthy as them.”
+
+---
+
+## Part III — The plan
+
+Phases with exits (delivery in vertical slices — testing and Xray land *with* the behavior they explain, never in a polish phase). This is a **map of future work, not a case for a verdict**: sequencing follows dependency, proof obligation, and named callers. Two standing rules govern scope: most of the programme's value — the kit, the lint, the glass laws, the recipes, the requirements corpus — holds even if the amendment's reconsideration trigger ever fires; and speculative surfaces wait for their named caller.
+
+**Phase 0 — freeze and product spine**. Freeze semantic expansion. One-page invariant/capability ledger and the provisional facade; the core/optional/host/recipe/refusal classification for every coverage row; ratified budgets on named reference hardware; an installable `implementation/hicasso` package a clean consumer can compile, hot-reload, and production-build; a server/hydration disposition for every proposed public surface (owed regardless of whether the Node service is ever activated); stable error shape with source coordinates. Exit: a minimal app runs on public namespaces; no option selects an execution mode.
+
+**Phase 1 — the trustworthy kernel** *(blocking)*. Close the eight kernel rows of the eleven-risk trust register; the three native-tier rows close with Phase 3's adoption gates. Apply the gate rule—published populations, sabotage mutations, residue before reset—to render-probes/commit-owns; abandonment and retry under concurrent roots; multi-root and frame isolation; same-id reincarnation dispatch; Activity and Suspense; HMR; controlled input across Chromium, Firefox, and WebKit; and every mutable global.
+
+The **substrate adjudication** explicitly chooses the under-collector subscription substrate using correctness, retained cost, clock, teardown, and migration evidence rather than an inherited default. It also freezes the two-hook boundary ceiling before the runtime ABI stabilizes. Exit: zero stale reads, cross-frame operations, tears, or residue.
+
+**Phase 2 — one lovable vertical slice**. A small complete flow (routing, keyed list, edit, async mutation, controlled fields, errors) on the proposed API only — shipped together with the L0–L3 testing facade, the first versioned evidence projection, the Xray mounted/read/intent/explain-render views, the complaint catalogue, the first lint checks, and production-erasure proof. Exit: the app has no artificial boundaries; the ordinary facade freezes from this evidence.
+
+**Phase 3 — the hot path made excellent**. The five-rung gradient, delivered and taught:
+
+1. *Ordinary Hicasso* — the default.
+2. *Tune topology* — boundary placement, keys, and read shape (fine row reads for sparse updates; a coarse view-model for cheap mount and bulk; chunked/windowed reads; virtualization when the DOM shouldn't exist in full). Xray shows boundary count, reads, fan-out, churn.
+3. *Direct React output* — a `defview` returns a React element, authored with `n/$`; frame, reads, memo, and lifecycle stay; hiccup lowering is skipped for that result. The narrowest escape, for when lowering is the measured owner.
+4. *Named native island* — hooks, vendors, drag/animation, hot collections as a native component (`n/defcomponent` with `react` hooks, or UIx); same root, same frame, `n/use-frame`/`n/use-sub`; explicit crossing contract.
+5. *Native screen* — an intrinsically React-first screen authored natively (Hicasso-native or UIx) under the single installed adaptor; an independent root remains an isolation choice only.
+
+Plus the working loop (reproduce → attribute with Xray → tune topology → try direct output → isolate an island → re-verify parity and budget; the escape stays only if it clears its declared threshold), the cause-aware advisor, the completed `defhost`/portal/outward-bridge contracts, the native tier delivered against its Part II adoption gates, and the bounded experiment set (direct-return delta; topology tournament; retaining-host callback identity; one causal Xray slice; outward-bridge parity; the native-tier three-way parity — `n/$` vs UIx vs handwritten React) — with **no open-ended benchmark programme after it**. Exit: a measured hot boundary moves to native React without a second root or state owner and is diagnosed from the same Xray surface.
+
+**Phase 4 — close the coverage matrix**. Every spec §7 row points to running evidence, an installable module, a tested recipe, or an explicit non-goal with a React escape — including pagination, code splitting through the lazy boundary bridge, navigation focus/scroll and prefetch across hover/focus/touch, accessibility assertions, autofill/reset/FormData, all named control types, the typeahead resource-demand witness, the published per-keystroke mechanics for the editor and grid (state writes → recomputations → boundary runs → commit → visible echo; a witness that doubles as teaching documentation), React server bytes and hydration proven across every public surface, and a second screen with a serious vendor component.
+
+**Phase 5 — optional products, in priority order**. Decide the committed-read resource-demand spike from the Phase 4 typeahead witness — an explicit adopt or stop, first, because it gates the shape of the async-resource recipes below; forms (recipes, then the buffered-draft helper at its second consumer); popover + modal on native top-layer primitives; presence/motion posture and the focus intent; routing and async-resource recipes (settle-merge, mutation status, dirty-nav guard); migration reporter → shadow comparison (the dual-render canonical-DOM/intent diff as a consumer verifier) → only then cautious codemod transforms; the Node SSR service when a named caller activates it; the left-field spikes that meet their deciding rules.
+
+**Phase 6 — adoption and release**. Versioned artifacts, compatibility matrix, upgrade policy, cookbook, performance method, escape criteria; **one taught native story** — the experimental donor surfaces and their docs explicitly dispositioned so users never face three overlapping view models; two pilot applications shipping substantial screens without framework-author intervention. The definition of done is spec §13.
+
+**The performance contract** *(detail in spec §6)* starts with user-visible budgets: controlled echo within one frame; discrete interactions to paint in 50 ms p95; broad operations in 100 ms p95; narrow work scaling with changed rows; and zero teardown residue.
+
+Comparative bands follow: an initial mount ceiling of 1.25x direct UIx; tuned broad updates at ≤1.25x the best relevant adapter, with 1.25–1.5x a warning and >1.5x forcing island analysis or reclassification; and native islands within 5% or 1 ms of the same component mounted directly through its chosen React route. Hicasso-native is co-instrumented against handwritten React and UIx. The same-instrument regression gate is 5%; an escape earns its keep at ≥20%, ≥2 ms, or by flipping a user-visible budget. Native-code percentage is **an observed census, never a quota**. Budgets ratify on named hardware before optimization; thresholds never widen to turn a row green.
+
+**The ideas ledger** (full designs in `fable/left-field-ideas.md` and `codex/left-field-ideas.md`):
+
+- *Adopt*: complaint catalogue, cause-aware hot advisor, direct React output with the Hicasso-owned native tier (`n/$` and companions; gates in Part II).
+- *Spike with deciding rules*: committed-read resource demand; pull-shaped reads; schema-driven generators; counterfactual topology advice; capability receipts; replayable view capsules after L2; MCP-queryable runtime and migration shadowing through existing tools; shared read-set notification groups after a census.
+- *Watch*: a read-free shell as a read-nothing optimization, not a heap fix; codec shape planning only when classification/lowering exceeds 10% of hot-boundary self time; intent replay through Story; keyed-list maintenance only after a red bulk verdict; a future React store seam.
+- *Reject*: compiler/JIT modes, second renderers, worker view runtimes, signals replacement, universal callback cells, and hydration-free inference.
+
+Every spike must retain the detailed fence and deciding witness in `codex/left-field-ideas.md`; this ledger is not permission to build an open-ended experiment.
+
+**First moves now**: the reincarnation-dispatch witness; the `hicasso.test` extraction; the installable package spine; the hot-view advisor; the forms field recipe; the first lint checks; and at the sitting — the K3 disposition and the amendment that names the accepted mount price.
+
+**Kill rules**: no compiler or dual mode for the hiccup language (`n/$` is a visibly distinct second language, never a second mode of `[...]`), no ViewCell-class graph, no second emitter, for any gate. Bulk above its kill line after the allowed iterations stops or narrows. Standing cost without a paying use-case is refused. Tools without daily consumers build no retained machinery. Thresholds never widen.
+
+---
+
+## The sitting (2026-08-27) and this document
+
+The direction is selected, so the sitting is a **recording and dispositioning session, not a go/no-go**. Its business is to ratify the price-acceptance amendment as the formal record of the decisive K1 miss: frozen original criterion, purchased use-cases, escape route, and reconsideration trigger. The held instrument is exactly this. It also takes the K3 disposition and assigns the open proof obligations—correctness, bulk, WebKit, and application witnesses—as execution risks inside the selected direction, each with an owner and a phase.
+
+The residual governance is the amendment's reconsideration trigger. The plan is robust under it: the kit, lint, glass laws, recipes, and requirements corpus retain their value regardless.
+
+## Sources
+
+`synth-codex.md` (the product specification; §6 budgets, §7 coverage, §9 testing, §13 done) and the `codex/` specification set. Product evidence and rationale: `codex/evidence-baseline.md` and `codex/corpus-insights.md`. Source corpus: `fable/` and the three `lessons-*.md`; the current status of every scout idea is `fable/dispositions.md`. Normative implementation record: `docs/design/hicasso/` and the governance beads (K1: rf2-diaud / PR #7704; bulk gating: rf2-vp0j7; SSR: rf2-2rtt6.88).

--- a/docs/design/hicasso/product/lanes/README.md
+++ b/docs/design/hicasso/product/lanes/README.md
@@ -1,0 +1,51 @@
+# Hicasso product specification set
+
+These documents define the current target for the native interpreted-Hiccup adapter and are organized by enduring product concern.
+
+## Authority
+
+1. [`../synth.md`](../decision-brief.md) is the decision instrument. It owns the forensic scoreboard, selected-direction record, scoped-amendment adjudication, K3 disposition, sitting agenda, and kill rules.
+2. [`../synth-codex.md`](../specification.md) is the normative product target for that selected direction. It owns product verdicts, budgets, capability placement, the public-surface target, and phase order.
+3. [`design-laws.md`](design-laws.md) states the non-negotiable design constraints; [`evidence-baseline.md`](evidence-baseline.md) records what is actually demonstrated and what still needs proof.
+4. The focused specifications below own protocols, risk detail, and acceptance tests only. If one conflicts with either governing document, update it rather than preserving a second verdict or sequence.
+5. The sibling lesson reports and `fable/` material are source corpus. They contribute evidence and ideas but are not normative product documents.
+
+Quantitative claims stay attached to their witness, revision, runtime, substrate, and instrument. Results from different instruments are not presented as one continuous benchmark series.
+
+## Ownership map
+
+| Concern | Canonical owner |
+|---|---|
+| Current measurements and their admissibility | [`evidence-baseline.md`](evidence-baseline.md) |
+| Product budgets, capability placement, portfolio status, and phase deliverables | [`../synth-codex.md`](../specification.md) |
+| Native-tier semantic laws | [`design-laws.md#native-boundary`](design-laws.md#native-boundary) |
+| Native authoring grammar and examples | [`ergonomics-api.md#optional-native-surface`](ergonomics-api.md#optional-native-surface) |
+| Native-tier acceptance checklist and performance protocols | [`hot-path-architecture.md#canonical-native-tier-acceptance-checklist`](hot-path-architecture.md#canonical-native-tier-acceptance-checklist) |
+| Public-surface SSR/hydration policy and witness matrix | [`react-compatibility-notes.md#public-surface-ssrhydration-matrix`](react-compatibility-notes.md#public-surface-ssrhydration-matrix) |
+| Concrete product proof suites | [`completeness-audit.md`](completeness-audit.md) |
+| Phase dependencies and exit signals | [`delivery-programme.md`](delivery-programme.md) |
+| Candidate-idea protocols and kill criteria | [`left-field-ideas.md`](left-field-ideas.md) |
+| Corpus-derived rationale and cautions | [`corpus-insights.md`](corpus-insights.md) |
+
+## Product documents
+
+- [`design-laws.md`](design-laws.md) — React, ownership, state, language, interop, scope, and evidence laws.
+- [`evidence-baseline.md`](evidence-baseline.md) — implemented capabilities, demonstrated value, measured economics, and open proof obligations.
+- [`corpus-insights.md`](corpus-insights.md) — durable rationale and deciding cautions distilled from the wider corpus; it does not own portfolio membership or status.
+- [`ergonomics-api.md`](ergonomics-api.md) — small public language, the native-form grammar and examples, interop, failure ergonomics, and facade discipline.
+- [`hot-path-architecture.md`](hot-path-architecture.md) — topology tuning, the canonical native-tier acceptance checklist, budgets, and deciding experiments.
+- [`testing-xray.md`](testing-xray.md) — tiered testing, evidence schema, causal questions, privacy, and release witnesses.
+- [`completeness-audit.md`](completeness-audit.md) — concrete proof suites and coverage witnesses, independent of roadmap prose.
+- [`use-cases.md`](use-cases.md) — motivating jobs, adversarial cases, ownership, and required witnesses.
+- [`adversarial-risks.md`](adversarial-risks.md) — kernel, native-surface, programme, and evidence risk/contract/witness/remedy registers.
+- [`react-compatibility-notes.md`](react-compatibility-notes.md) — React obligations and the canonical public-surface SSR/hydration matrix.
+- [`left-field-ideas.md`](left-field-ideas.md) — bounded innovation portfolio with validation and kill criteria.
+- [`delivery-programme.md`](delivery-programme.md) — dependency and exit index keyed exactly to the primary Phases 0–6.
+
+## Maintenance rules
+
+- State current facts, decisions, requirements, unknowns, and next actions directly.
+- Replace superseded claims in place; do not append dated review narratives or fold logs.
+- Preserve provenance in the source corpus, not in this normative set.
+- Keep proposed features conditional until their witness and kill criteria are explicit.
+- Remove obsolete documents once their durable content is represented in the living specification.

--- a/docs/design/hicasso/product/lanes/adversarial-risks.md
+++ b/docs/design/hicasso/product/lanes/adversarial-risks.md
@@ -1,0 +1,43 @@
+# Hicasso adversarial risk register
+
+A missing witness is not a confirmed defect. Each risk has a required contract, a deciding witness, and a remedy if the witness is red.
+
+## Phase 1 kernel risks
+
+| Risk | Required contract | Deciding witness | Remedy if red |
+|---|---|---|---|
+| Frame reincarnation and cached operations | Every delayed operation targets the intended frame incarnation; a reused public id cannot revive an old handle | Mount, dispatch, destroy, recreate the same id, then dispatch both current and retained callbacks | Key operation bundles by incarnation or evict them exactly on destruction |
+| Process-global ownership | Independent roots and SSR requests cannot reset, adopt, dirty, or release one another's state | Overlapping hydration, independent root release, concurrent request frames and root-unmount failure | Move each mutable owner to root/adapter/request scope |
+| Speculative render leakage | Render probes only; the selected commit owns reads and evidence; abandoned attempts leave zero residue | Suspense/transition abort, changed reads, delayed commit, error retry and residue census before any global reset | Make commit identity authoritative and replace time-based/reaper assumptions |
+| Ambient-read extent | `sub` works only during direct synchronous execution of the active body; every deferred crossing refuses with source and recovery | Nested helper, branch, loop, render prop, event, promise, timer, lazy sequence and module escape matrix | Use an explicit collector stack/token for supported nesting and fail closed elsewhere |
+| Controlled-input portability | Echo, rejection, normalization, composition, selection and revision remain correct across supported React/browser versions | WebKit/Firefox native composition and `beforeinput`, range/direction, autofill, reset, blur, unmount and upgrade matrix | Own the last committed model value or narrow/refuse a control whose platform contract cannot be made stable |
+| HMR identity | Reload either preserves the stated identity/focus/state contract or promises a clean, diagnosable subtree remount | Focused/uncontrolled input, child hook state, active host, frame routing and cleanup through reload | Use the smallest stable shell justified by the witness or document/lint the remount contract |
+| Callback identity and retirement | Retained handlers route to the correct frame and become harmless after retirement; ordinary code pays no universal proxy cost | Memoized foreign child retaining callbacks through rerender, unmount and same-id frame replacement | Add a localized host-edge stable-event primitive only when required |
+| Hydration isolation | Adoption and mismatch attribution are root-scoped; simultaneous roots cannot cross-contaminate | Two overlapping hydrated roots with independent complaints and teardown | Root-scope adoption/evidence state and fail closed on ambiguous ownership |
+
+These eight risks block the trustworthy-kernel exit. Native-surface risks enter only when Phase 3 introduces that optional surface.
+
+## Phase 3 native-surface risks
+
+| Risk | Required contract | Deciding witness | Remedy if red |
+|---|---|---|---|
+| Native-language leakage | Clauses 2–3 of the [native-boundary law](design-laws.md#native-boundary) | Native-form grammar row of the [canonical checklist](hot-path-architecture.md#canonical-native-tier-acceptance-checklist) | Refuse ambiguous mixing with a source-located recovery; keep the namespaces and syntax visibly distinct |
+| Native boundary ABI drift | Clause 5 of the native-boundary law | Component-ABI, same-root and server rows of the canonical checklist | Shrink the one ABI and remove helpers that cannot prove parity |
+| Optional native-tier rent | Clause 6 of the native-boundary law | Dependency-and-rent row of the canonical checklist | Split the namespace/module boundary until tree shaking is deterministic; refuse universal helper state |
+| Hook-semantics fork | Clause 4 of the native-boundary law | Frame-and-store-lifecycle row of the canonical checklist | Factor and reuse the shared React seams before publishing the namespace; do not maintain a Hicasso-specific copy |
+
+## Programme and evidence risks
+
+| Risk | Required contract | Deciding witness | Remedy if red |
+|---|---|---|---|
+| Instrument self-flattery | An instrument qualifies before product data publishes; controls detect the named failure class and the estimator/population are pinned | Sabotage the clock, floor, population and masking assumptions and observe a refusal rather than a result | Withdraw the row, fix the instrument, and rerun without carrying forward its previous number |
+| Comparator mismatch | Controls are tuned and behavior/read topology is equal, or every deliberate capability difference is stated beside the ratio | Canonical DOM, intent, read-shape and host-crossing audit before clock/heap comparison | Rebuild the control or reframe the claim as a priced capability comparison |
+| Equality substitution | Each gate names authored-data, semantic-tree, DOM, intent, server-byte, hydration, commit or paint equality without treating one as another | Adjacent-text hydration sabotage and an L2-vs-mounted lifecycle counterexample | Replace the oracle with the platform-authoritative equality; keep the weaker result under its honest name |
+| Experimental residue becomes architecture | One taught public story; no primary product/tool path relies on re-frame.ui or Freehand after Hicasso evidence is live | Dependency graph, namespace/doc census, production sentinels and Xray/Story/Pair consumer audit | Migrate consumers first, retain only named compatibility fixtures, then archive or remove the donor surface |
+
+## Gate construction
+
+- Publish the exercised population and inspect residue before fixture-global reset.
+- Include a sabotage mutation that makes each correctness gate red.
+- Keep source evidence, revision/substrate, inference and overturning observation traceable.
+- Treat a precedent, census absence, descendant measurement or co-instrumented pair as context, never as a current gated result.

--- a/docs/design/hicasso/product/lanes/beads-review.md
+++ b/docs/design/hicasso/product/lanes/beads-review.md
@@ -1,0 +1,251 @@
+# Review of the proposed Hicasso implementation bead set
+
+## Verdict
+
+Do not file the set unchanged. The decomposition has a strong spine: it follows the product phases, gives correctness work real adversarial witnesses, keeps optional products caller-shaped, and usually distinguishes evidence from implementation. The current set nevertheless has four filing blockers:
+
+1. The live bead briefs disagree with the current normative specification at load-bearing API and SSR points.
+2. The dependency graph does not enforce several dependencies stated by the briefs, and its broad source fences permit concurrent edits to the same files.
+3. The “final” checkpoint can complete with definition-of-done bullets still red; corrective beads, dormant pilots, and the donor-surface disposition have no closure path into a later release decision.
+4. The new naming tail directly violates the governing execution requirement. The README says, “No bead waits on an operator ruling,” while `hic-065` says, “This is the set's one deliberate operator gate,” and `hic-066`, documentation, artifacts, and the final audit wait behind it.
+
+The reviewed live snapshot contains **60 bead documents plus the README**, not the 57 in the review request. `hic-065` and `hic-066`, plus related edits to the README and several existing beads, arrived during this review and are included here.
+
+## 1. Coverage against the programme
+
+Most Phase 0–6 capabilities have at least a plausible owner. The following obligations have no complete accountable bead, or are placed so that the phase checkpoint can pass without them.
+
+### 1.1 Phase deliverables and definition-of-done gaps
+
+| Programme obligation | Apparent owner | Gap |
+|---|---|---|
+| Record the actual K1 sitting outcome and effective revision | `hic-003` | `hic-003` only drafts the proposal and deliberately leaves the effective revision blank. No non-blocking bead records ratification or rejection and its consequences after the sitting. |
+| Explicit K3 disposition preserving the Reagent, UIx-parent, and author-preference scoreboards | `hic-006`, `hic-018` | Neither brief owns the three-scoreboard K3 instrument. `hic-006` transcribes budgets; `hic-018` chooses the substrate. The Phase 0 K3 deliverable has no record owner. |
+| Freeze the byte-exact shell line before measuring or disposing it | `hic-006`, `hic-018` | Both repeat ambiguous `1 KB`. `hic-006` says “R=0 ≈ 1.1 KB vs the registered 1 KB paper-fail line”; `hic-018` says the substrate “either brings R=0 under 1 KB.” Neither freezes 1,000 B versus 1,024 B as required by the specification. |
+| Close all eight Phase 1 kernel-risk rows | `hic-019` | Callback identity and retirement is assigned to `hic-036`, after the kernel checkpoint. `hic-019` nevertheless requires every kernel row to be green. `hic-013` covers reincarnation, not the risk row's memoized retaining-host population and ordinary-path cost question. |
+| Ship the complete L0–L3 testing facade in Phase 2 | `hic-020` | Despite its title, its deliverables specify L2, L3, and comparison helpers. There is no explicit L0 public contract or L1 codec/intent/native-expansion surface and acceptance suite. |
+| Implement the current native grammar and ABI | `hic-030` | The brief omits `n/props`, the raw-JavaScript props-object ABI, canonical-slot collision refusal, and `n/defcomponent`'s server declaration. It says “dynamic props take the runtime path with identical results,” but the normative grammar requires the explicit `(n/props expression)` marker so a dynamic React element cannot be misclassified as props. It also says “the spec lacks” an example; the current spec contains one. |
+| One virtualizer and one imperative SDK witness before the Phase 3 exit | `hic-047` | The bead is in Phase 4 and is not a predecessor of `hic-038`; the Phase 3 checkpoint can pass without a deliverable that Phase 3 explicitly lists. |
+| Extend the product application with pagination and runtime content | — | No bead names pagination or runtime-selected content. The Phase 4 beads are separate witnesses; none owns the required integrated application extension. |
+| A public-package four-field editor and 100-cell grid witness | `hic-045` | Its fence is documentation plus “the two witness pages.” It does not own the applications or tests, so it can publish numbers from the frozen bench prototypes without proving that the installable package expresses the §13 controlled-grid witness through public surfaces. |
+| Qualified bulk release gate at every named operation and size | `hic-036` | The tournament exists, but `hic-048` neither depends on it nor audits it. Phase 4 can close without the bulk/economic suite that its exit requires. |
+| Counterfactual topology advice | — | The primary innovation portfolio says **Spike**; no bead owns its blinded calibration protocol. |
+| Capability receipts | — | The primary portfolio says **Spike**; no bead owns its perturbation/privacy deciding protocol. |
+| Replayable view capsules after L2 | — | The primary portfolio says **Spike after L2**; no bead owns the one-shot, commit-owned, redacted experiment. |
+| Shared read-set notification-group census and conditional spike | — | The portfolio says **Census, then spike**; no bead owns either stage. |
+| Keep the requirements mine current as witnesses and public names land | `hic-004` | `hic-004` seeds the ledger and says rows update, but no consolidation bead owns those updates. The final audit can inspect a permanently “owed by hic-NNN” snapshot. |
+| Move every live Xray/Story/Pair consumer to the adapter-neutral provider before donor disposition | `hic-023`, `hic-062` | `hic-023` covers Xray/Pair consumption; `hic-062` records what remains. No bead inventories and migrates **Story** consumers or proves that all primary tool paths have left donor surfaces. |
+| Xray privacy projection as a release contract | `hic-023`, `hic-059` | `hic-023` specifies loss and erasure but not the privacy projector. `hic-059` tests privacy only for an optional MCP spike and is not on the final-audit path. |
+| Enforce the user-visible, regression, and escape-benefit budgets | `hic-006`, `hic-033`, `hic-036`, `hic-045` | No bead owns the 50 ms p95/100 ms p99 discrete-interaction gate, the 100 ms p95 broad-operation gate, the 5% same-instrument regression gate, or the rule that an escape stays only after recovering 20%, 2 ms, or a failed budget. Transcribing them into `budgets.md` is not enforcement. |
+| Report native-code share as a census, never a quota | — | The performance contract requires the post-implementation census; no bead produces it. |
+| Prove warm allocation carries no product claim until its instrument qualifies | — | No final docs/release scan owns the explicit non-claim. This matters because §13 permits release without an allocation series but forbids an unsupported allocation claim. |
+| Close checkpoint corrections before a release recommendation | — | Checkpoints file proposed corrections, but no bead resolves their roster or reruns the affected checkpoint. `hic-064` does not require zero unresolved corrective beads. |
+
+Conditional follow-up work is acceptable where the programme itself is conditional: `hic-050` may file a resource implementation bead, `hic-055` may file a codemod bead, `hic-056` correctly remains caller-gated, and `hic-063` remains pilot-gated. Any activated or graduated work still needs to be inserted into the naming, documentation, erasure, compatibility, and final-audit dependency rosters; the current graph has no such dynamic-tail rule.
+
+### 1.2 Beads without specification grounding
+
+- `hic-000` is execution infrastructure rather than a product deliverable. It is justified by the gitignored `ai/` tree and worker-worktree model, so it should remain, preferably as a generated publication/synchronization step.
+- `hic-019`, `hic-026`, `hic-038`, `hic-048`, and `hic-064` are not product features but are grounded in the requested independent-checkpoint design.
+- The purpose of `hic-065` and `hic-066`—settling provisional names—is grounded. Their **single late operator gate and repo-wide delayed rename strategy is not**. It replaces the specification's Phase 2 ordinary-surface and Phase 3 host/native freeze schedule, contradicts the explicit ungated-flow requirement, and is not executable by a context-free background worker.
+- Every other bead has a recognizable grounding in Part III, §12, §7, §11, or a named risk/checkpoint obligation.
+
+### 1.3 §7 rows that can remain unwitnessed when `hic-064` completes
+
+There is no defined meaning of “`hic-064` passes.” Its output is a report plus corrective beads; it can close successfully after reporting red bullets. Even if “passes” is interpreted as completing the current protocol, these rows can still lack their specified proof:
+
+| §7 row | Remaining witness gap |
+|---|---|
+| Ordinary pages, conditional UI, dynamic lists | `hic-025` is one small article flow. No Todo flow is named, and pagination/runtime content have no bead, so the required Todo and RealWorld-class coverage is not demonstrably complete. |
+| Forms and controlled fields | Browser controls are covered, but no bead owns the public-package four-field editor and 100-cell grid applications; `hic-045` owns only their explanatory pages. |
+| Errors | Load/error/retry paths exist, but no bead explicitly witnesses a nested error region, one of §7's required proofs. |
+| Motion and high-rate input | `hic-053` witnesses interruption, rapid toggle, and teardown, but its acceptance never measures the required frame budget. |
+| Accessibility | `hic-043` names focus order and axe, but does not explicitly witness keyboard conduct. Its virtualizer and overlay clauses say “with hic-047's” and “with hic-052's when it lands” without dependencies or a later integration run. |
+| i18n and theming | No bead owns runtime locale and theme-change evidence. |
+| Testing | The L0/L1 hole in `hic-020` leaves the full supported ladder and positive/sabotage controls at every tier unproved. |
+| Diagnostics | Loss and erasure are present; the core privacy projection has no mandatory witness. |
+| Migration | `hic-055` permits “the in-repo Reagent examples if externals are unavailable,” which is weaker than the required three representative repositories. |
+
+The remaining §7 rows have at least a claimed bead-level witness, although several are endangered by the dependency and file-fence defects below.
+
+## 2. Dependency correctness
+
+### 2.1 The graph and the briefs disagree mechanically
+
+The README says its graph is authoritative, but it does not encode the briefs' own dependency declarations consistently.
+
+- `hic-001`–`hic-005` each say `Depends: —`, while the README has `hic000 --> hic001 & ... & hic005` and says no worker can resolve its reading set before `hic-000`. The bead metadata must name `hic-000`; otherwise the filed issue and graph tell different stories.
+- Seven stated edges are absent from the README graph: `019→026`, `030→036`, `023→037`, `030→041`, `020→043`, `006→045`, and `005→046`. For example, `hic-026` says `Depends: hic-025, hic-019`, but the graph contains only `hic025 --> hic026`; `hic-041` says `Depends: hic-035, hic-030`, but the graph contains only `hic035 --> hic041`.
+- The README adds direct `hic-001` edges to `hic-011`, `hic-013`, `hic-014`, and `hic-017`, while their briefs name narrower predecessors; conversely, `hic-025` names `hic-001` directly while the graph supplies it only transitively through `007/020`. These do not alter reachability, but the drift makes automated filing unverifiable.
+- `hic-000` acceptance still checks references only through “hic-001…hic-064,” omitting the newly added `hic-065` and `hic-066`.
+
+Generate the filed graph from one machine-readable dependency roster and validate each Markdown `Depends` line against it; do not hand-maintain both forms across 60 files.
+
+### 2.2 Missing semantic or build edges
+
+These are not optional ordering preferences: the dependent brief either names the predecessor's artifact or mutates its surface.
+
+| Required ordering | Evidence in the dependent brief |
+|---|---|
+| `011→014` and `013→014` | `hic-014` says its surface runs “after hic-010/011 merge” and that retained intents obey “the hic-013 incarnation rule,” yet it formally depends only on `hic-010`. |
+| `010/011→018` | `hic-018` says it will “reuse hic-010/011 witnesses” and “coordinate with hic-010” on collector wiring. Coordination is not a dependency or fence. |
+| `007→021` | `hic-021` says “hic-007 lands the shape; this catalogues it,” but the README gives it only `hic-001`. |
+| `007,020,023→024` | `hic-024` says it “strengthens as 007/020/023 land” while promising sentinels in all of their surfaces. Run first, it can green on an incomplete sentinel roster; edit them itself, it violates their fences. |
+| `021,022,023,024→026` | `hic-026` requires “all landed (hic-020…024)” but depends only on `hic-025` and `hic-019`. |
+| `007,015→030` | `hic-030` promises the `hic-007` source/error shape and documented HMR conduct but does not wait for either contract. |
+| `013,023→031` | `hic-031` says `n/use-frame` “obeys the hic-013 incarnation rule” and acceptance asserts Xray through “hic-023's projection,” yet depends only on `hic-030`. |
+| `007,013→035` | `hic-035` exposes new refusals and says retained callbacks follow `hic-013`; neither predecessor is listed. |
+| `016→040` | `hic-040` says “hic-016 established the browser rig” but formally depends on `hic-025`. Replace the false application dependency with the browser-rig dependency. |
+| `032→041` | `hic-041` says marker/props ABI are preserved using “hic-032 helpers,” but does not depend on `hic-032`. |
+| `012,034→046` | `hic-046` includes overlapping hydrated roots and “the native tier (`n/` components under SSR)” but waits on neither the root-isolation implementation nor the completed native tier. |
+| `036→048` | Phase 4 exit requires qualified bulk/economic evidence, but the coverage checkpoint waits only on `040…047`. |
+| split `043` into core helpers and post-integration checks | `hic-043` needs virtualizer and overlay artifacts while `hic-047` and `hic-052` say they use its helpers. Adding edges in either direction creates a conceptual cycle. Land the helpers first; run separate virtualizer/overlay keyboard-focus witnesses after those products. |
+| pre-registration bead `→044→050` | `hic-044` records data “against the pre-registered criteria in hic-050,” while `hic-050` depends on `hic-044` and claims criteria are stated “before reading the hic-044 report.” A commit made after the report exists is not pre-registration. |
+| `042,050→054` | `hic-054` is “shaped by hic-050's verdict” and implements the guard on “hic-042's wiring point,” but formally depends only on `hic-025`. |
+| `021,024,025→059` | `hic-059` exposes complaints, diagnoses a “real slice-app bug,” and asserts production erasure unchanged, but waits only for `hic-023`. |
+| `026,038,050` and every graduating public-surface bead `→065` | `hic-065` says it uses checkpoint findings and covers every public name, yet does not wait for either freeze/checkpoint, the resource verdict, or any public surface created by a successful `057`–`059` spike or conditional follow-up. |
+| `066→062`, then serialize its docs sweep with `060` | `hic-066` renames “any docs already written”; `hic-062` concurrently edits docs/nav/READMEs and does not depend on final names. |
+| `021,050→060` | Troubleshooting requires the complaint catalogue and async docs must reflect the resource verdict. Neither is currently on the docs bead's dependency path. |
+| `023,038,060→062` (`066` is then transitive through `060`) | `hic-062` decides live-tool residue and the taught native story but waits only on `hic-026`; it can run before the live evidence provider, native contract, final names, and new documentation. |
+| `050,062→064` | The final protocol requires the resource verdict and donor independence, but the final graph includes neither owner. |
+| `057,058,059→064`, plus conditional `056/063→064` when activated | Phase 5's selected spikes otherwise float outside the release tail. An activated server or pilot bead can also finish after an audit that purports to report its current release status. These edges need not gate ordinary implementation: activation should insert them into the audit roster. |
+
+If `hic-050`, `hic-055`, `hic-056`, or a spike files or activates consequential work, that work must be inserted before naming, docs, erasure revalidation, compatibility, and the final audit. If pilots activate, their result must precede the release recommendation. “File a follow-up” is not enough unless the graph has a dynamic-tail rule.
+
+### 2.3 False or avoidable serialization
+
+- The largest false edge is `hic-065` itself: an unbounded human wait on the only path to final names, docs, artifacts, and audit. It violates the required ungated design.
+- `hic-040` does not use the slice app; its own surface is the control testbed. Waiting on `hic-025` delays a browser lane that should follow `hic-016` directly.
+- `hic-047` can prove a foreign virtualizer and imperative SDK through `defhost` after `hic-035`; requiring the full native three-way parity bead `hic-034` is unnecessary unless the chosen witness explicitly uses the Hicasso-native route.
+- The README's direct `hic-001` edges to beads already behind `hic-010` or `hic-012` are redundant. They do not lengthen the current path but should be removed so one graph means one thing.
+
+### 2.4 File-fence collisions the graph does not prevent
+
+The current prototype matters here. `hic-001` is a mechanical copy and does not split the 2,000-line `arm1/runtime.cljs`; that file currently contains adoption, frame operations, generation/HMR, the evidence sink, collector, commit, shells, and retained inventory. The proposed labels do not create separate files.
+
+| Shared mutating surface | Concurrent beads |
+|---|---|
+| Copied `runtime.cljs` | `hic-010`, `011`, `013`, `014`, `015`, `018`, and the projection hooks in `023`; `017` may also repair globals there. `hic-010` says the others “sequence behind it,” but the graph makes `011`, `013`, and `014` siblings and leaves `018`/`023` independent. |
+| Copied `front/codec.cljs` | `hic-007` generalizes `fail!`; `hic-033` changes boundary result handling; `hic-035` changes the host path; `hic-040` allows support-policy fixes “in the codec.” Their fences name sections, not files, and the graph permits overlap. |
+| `product/invariants.md` | `hic-002` creates it; `hic-011`, `013`, `015`, and `018` each promise to add/freeze text there but do not declare the file in their surface. Several run concurrently. |
+| `product/dispositions.md` | `hic-005` creates it; `hic-040` writes per-control rows and `hic-046` upgrades SSR rows in the same wave. |
+| `product/budgets.md` | `hic-006` creates it; `hic-033`, `hic-036`, and `hic-045` all publish results or update rows and can overlap. |
+| `product/naming-ledger.md` | `hic-000` seeds it; `hic-026` and `hic-038` append findings on independent branches; `hic-065` depends on neither. |
+| Routing integration files | `hic-042` creates the wiring point and `hic-054` consumes/extends it without an edge. |
+| User-facing docs/nav/READMEs | `hic-060`, `hic-062`, and repo-wide `hic-066` have overlapping sweeps; only `060` is ordered after `066`. |
+
+Replace “coordinate,” “when it lands,” “if not already,” and “where a gap is found” with exact files plus graph edges. For the shared ledgers, prefer per-bead evidence fragments and one consolidation owner rather than concurrent edits to a central Markdown file.
+
+## 3. Parallelism and critical path
+
+The current longest release path is approximately:
+
+`000 → 001 → 030 → 031 → 032 → 034 → 047 → 048 → 065 → 066 → 060 → 064`
+
+The single largest throughput limiter is now **hic-065**, because its duration is external and unbounded. Remove that gate. Among autonomous beads, **hic-001** is the dominant fan-out bottleneck: one L-sized PR blocks all 16 Wave-B jobs and several later lanes. The README also schedules “up to 16 workers” despite the available eight-worker ceiling; it needs an eight-slot priority order, not merely a wide wave.
+
+Concrete changes:
+
+1. Make naming ungated. Apply recommended defaults automatically, permit asynchronous operator overrides before release, and keep the ledger as evidence—not as a dependency on a sitting. Prefer ordinary-name settlement after the slice evidence and native-name settlement after native evidence so there is no repo-wide Phase 6 rename.
+2. Split `hic-001` into package/source extraction plus a compiling public facade, test migration, and tiny-consumer/HMR/release wiring. Only the first minimal compiling package should block source/test workers; keep the hot-zone wiring in one owner.
+3. Either split `runtime.cljs` into owned modules before Wave B, or let Phase 1 workers land test-only witnesses in parallel and serialize red-path fixes through one runtime owner. The current “parallel fixes to sections of one file” plan is not viable.
+4. Split `hic-020` into L0–L2 pure kit and L3 mounted kit behind a tiny shared contract.
+5. Split `hic-035` into host declarations/ReactNode/render-prop ABI and portal/server-policy work, with exact source files.
+6. Split `hic-036` into the 48-cell topology tournament and the retaining-host callback verdict. The former is a release-economics programme; the latter is a focused semantic experiment.
+7. Split `hic-047` into virtualizer and imperative-SDK beads and run them in parallel after the shared host seam.
+8. Split `hic-060` by reference/cookbook, troubleshooting, and performance/escape documentation, followed by one nav/link integration bead.
+9. `hic-057` cannot be both an M bead and “one week equivalent.” Reduce it to a two-hour bounded pilot or classify it as a larger research task outside the small-bead claim.
+
+With eight slots, prioritize the runtime critical chain, the testing kit, package diagnostics, and the native ABI foundation; queue optional docs and spikes behind those rather than presenting a theoretical 16-worker wave.
+
+## 4. Bead quality as context-free worker briefs
+
+The sample below spans every phase and more than the requested eight beads.
+
+| Bead | Assessment |
+|---|---|
+| `hic-001` | Objective package/consumer checks, but not small: runtime copy, namespace migration, metadata, hot-zone builds, app, HMR, production release, and all existing tests are one L bead. “Move/point the existing CLJS test suites” also leaves copy versus relocation underdetermined. |
+| `hic-006` | Good provenance requirements, but “make ... budgets ratified” gives a background worker authority the specification assigns to the product operator. It also carries ambiguous `1 KB` and does not name the K3 record. |
+| `hic-010` | One of the best briefs: real abandonment populations, residue before reset, and a leak mutation that must red are objectively checkable. Its only material defect is the non-exclusive “runtime collector file” fence. |
+| `hic-019` | Strong three-lens review and real-path warning. Its surface says it files corrective proposals under gitignored `ai/findings/.../beads/`, which a worker checkout cannot see or land. Re-running only two sabotages also cannot validate eight newly introduced gate families. |
+| `hic-020` | Honest opacity and no fake hooks are excellent. “`implementation/hicasso/test-kit/` or equivalent” is not an unambiguous fence, and the advertised L0–L3 scope omits L0/L1 deliverables. |
+| `hic-024` | Excellent fail-closed positive-control and sentinel sabotage. It is scheduled before the surfaces whose sentinels it must inventory, making an otherwise strong acceptance test vacuously incomplete. |
+| `hic-030` | A plausible-but-wrong PR is likely: “dynamic props take the runtime path” can produce an unmarked dynamic-map grammar, while the current contract requires `n/props`; server policy and raw-JS ABI are absent. “The spec lacks” an example is a direct stale-corpus marker. |
+| `hic-034` | Strong three-way comparator, equality typing, and bundle positive control. Its acceptance says “island band met **or the miss published un-softened**.” Publication is not a pass: the canonical checklist says a red row blocks the native namespace until fixed or the surface shrinks. |
+| `hic-036` | Populations and operations are concrete, but two large experiments are bundled and there is no sabotage/eligibility control for either instrument. “No open-ended benchmark programme follows” does not enforce the bulk kill line or escape-benefit threshold. |
+| `hic-040` | The browser/control roster is objective. “Sabotage one policy” is underspecified: a worker could alter a table rather than the runtime behavior. The fence permits unplanned codec edits and conflicts with `hic-046` on the disposition table. |
+| `hic-044` / `hic-050` | The witness and adopt/stop separation is good. The pre-registration claim is impossible under the graph: the criteria-owning bead starts only after the report exists. This is exactly the instrument-self-flattery failure the corpus warns about. |
+| `hic-046` | “Every facade surface” makes coverage countable, which is good. It inherits stale taxonomy—“the three `defhost` `:ssr` policies”—where the canonical matrix has two policies, Render and Client-only, with deterministic fallback/recovery inside Client-only. It also lacks native/root dependencies. |
+| `hic-055` | Determinism plus a seeded shadow difference are meaningful controls. The fallback “in-repo Reagent examples if externals are unavailable” permits a pass that does not satisfy the three-repository proof. |
+| `hic-060` | “Examples are the witness code, not invented” is a strong rule. Five substantial documents in one L bead are not a small deliverable, and “an outsider can” is not checkable without a named fresh-reader protocol. |
+| `hic-064` | Good fresh-checkout, fresh-reader, random-complaint, and anti-cathedral ideas. It does not define a green acceptance state, omits several exact §13 lines, samples only one sabotage per domain, and can complete while pilots, donor disposition, resource verdict, or corrective beads remain open. |
+| `hic-065` | The public-surface census is valuable, but a grep needs a seeded omitted-export positive control. More fundamentally, “one operator sitting” is neither autonomous nor ungated, and its graph omits several evidence/public-surface predecessors. |
+| `hic-066` | The rename grep and full suite are checkable. A repo-wide mechanical sweep over source, tests, examples, recipes, and docs is the opposite of an isolated file fence and creates the largest late merge-conflict surface in the programme. |
+
+## 5. The defaults taken
+
+The README now contains eight defaults, not six.
+
+| Default | Assessment | Recommendation |
+|---|---|---|
+| 1. New package; bench tree frozen to Phase 6 | The package location is right. Keeping a second live source tree for six phases invites evidence/code drift, and “frozen” has no mechanical guard. | Freeze with a hash manifest immediately. After `hic-006` re-pins package baselines, retain cited fixtures/data plus the source revision, not a second editable runtime. Add a no-import/no-mutation gate. |
+| 2. Kebab props through shared `slot/prop-name`; camelCase legal | Keep, with constraints. Literal CLJS maps get ergonomic zero-runtime lowering; raw JS objects remain the true dynamic fast path. The current bead is incomplete. | Require `n/props` for dynamic operands; pass raw JS objects by identity; convert dynamic CLJS maps shallowly and explicitly; strings/raw JS names stay exact; refuse normalized-slot collisions, namespaced-key ambiguity, `:children`, and Hiccup semantics. Macro/runtime conversion must share one total rule and parity corpus, not necessarily call the existing Hiccup helper blindly for every key kind. |
+| 3. Operator Windows machine + GitHub CI runner class | A “runner class” is not a sufficiently pinned hardware identity for distributional budget ratification, and neither choice guarantees the named low-/mid-tier product profiles. | Use a pinned physical/calibrated low-tier and mid-tier profile for product budgets. Use hosted CI for correctness, eligibility controls, and same-run relative drift unless its observed hardware/runtime identity is recorded and accepted for that estimand. |
+| 4. Criteria decide resource demand; async veto | The authority model fits an ungated programme, but the implementation violates its own pre-registration. | Split criteria registration before `hic-044`; run the witness; let `hic-050` apply the frozen rule. Default to STOP on ambiguity, file ADOPT implementation separately, and insert that bead into naming/docs/erasure/audit automatically. |
+| 5. No Node SSR caller; service dormant | Correct. It preserves the core React-server/hydration contract without building unused operations. | Keep. Add a final caller-census statement so “none” is an observed state, not a forgotten dormant bead. |
+| 6. Proceed without pilots | Correct for keeping implementation work moving; incorrect for a green §13/release claim. | Keep the engineering line ungated, but make the final release decision explicitly red until `hic-063` supplies two pilots. Distinguish “implementation audit complete” from “product definition of done.” |
+| 7. Tracked snapshot; `ai/` remains living home | This already produced drift: current bead prose references a missing §3.7, omits `n/props`, and uses old SSR taxonomy. “Refresh on material change” has no owner or mechanical definition. | Prefer one tracked living normative home. If dual homes remain temporarily, generate the snapshot, record source hashes, and fail a freshness check before filing or dispatch. |
+| 8. One end-of-line naming ruling and rename sweep | Reject under the stated requirements. It creates the only human gate, delays docs/artifacts/audit, invalidates evidence/docs late, and cannot account for dynamically graduated features. | Apply recommended names as defaults without waiting. Keep a ledger and permit asynchronous overrides. If late consolidation remains useful, make it an autonomous consistency check, not a sitting dependency. |
+
+## 6. Checkpoint design
+
+The five checkpoints are placed at sensible product boundaries, and the explicit completeness/correctness/quality lenses are better than one generic “review” bead. They are not yet independent or strong enough for this corpus.
+
+| Checkpoint | Problem |
+|---|---|
+| `hic-019` kernel | Correct boundary and good real-path emphasis. It cannot file its proposed `ai/` documents from a worker checkout, samples only two sabotages across eight risk families, and is guaranteed to find the late callback-identity row missing. |
+| `hic-026` slice | Correct moment to review authoring evidence. It also writes the facade freeze, so the reviewer is performing a governance mutation rather than only auditing and filing corrections. It may start before `021…024`, despite requiring them. |
+| `hic-038` native | Correct adoption boundary, but its abbreviated completeness list is weaker than the canonical eight-row native checklist. It does not independently sabotage dependency/rent, frame/store lifecycle, HMR residue, or server refusal. “Contracts freeze here” again combines audit and governance. |
+| `hic-048` coverage | Row-by-row and surface-by-surface walks are good. It omits the bulk/economic exit, runs before optional products that some rows name, and re-runs only one control and one SSR sabotage. |
+| `hic-064` final | It is an audit producer, not a final green gate. Its completeness paraphrase omits the exact shell disposition, qualified bulk populations, warm-allocation non-claim, donor dependency, and pilots as a required green condition. One fresh run on one profile does not establish every ratified distributional budget. |
+
+Strengthen all five without halting the implementation line:
+
+1. Checkpoints create real `bd` issues, not ignored Markdown proposals, and record the resulting ids in the tracked report.
+2. Maintain a checkpoint-correction ledger with open/resolved status. The final audit requires zero unresolved correctness/coverage corrections or reports a non-release verdict.
+3. Separate freeze/ruling records from independent review workers. The reviewer reports evidence; a small deterministic follow-up applies a pre-resolved default.
+4. Give every gate a roster/population count, positive control, targeted negative mutation, restore proof, and runner-root check. A checkpoint mechanically verifies those records rather than sampling a few and assuming the rest.
+5. Add explicit budget-line reconciliation: registered line, current value, status, authority, and any prospective disposition. This catches silently normalized threshold breaches.
+6. When corrective beads land, rerun the affected checkpoint protocol or a small closure bead. Filing a fix is not evidence that the miss is fixed.
+
+## 7. Risks, kill rules, and budgets without an enforcement home
+
+| Obligation | Current partial home | Missing enforcement |
+|---|---|---|
+| Callback identity/retirement kernel risk | `hic-013`, `hic-036` | The risk is not closed before the Phase 1 checkpoint and no ordinary-cost verdict is in `hic-019`'s dependency set. |
+| Instrument self-flattery risk | `hic-006`, measurement beads | The `044/050` order defeats pre-registration; `033`, `036`, and `045` do not each name an eligibility sabotage before publishing product data. |
+| Experimental residue risk | `hic-023`, `hic-062` | No mandatory Story/Pair/Xray consumer census and migration proof; `hic-062` is absent from the final graph. |
+| Registered shell budget | `hic-006`, `hic-018` | No byte-exact line freeze; no checkpoint line item that prevents ambiguous `1 KB` from being silently carried. |
+| K3 scoreboards and per-read regression | `hic-006`, `hic-018` | No explicit three-scoreboard decision record and no 10% same-witness enforcement owner. |
+| User-visible 50/100 ms budgets | `hic-045` partially | No representative discrete/broad interaction gate over the slice/vendor applications. |
+| Same-instrument 5% regression | — | No baseline comparison gate or disposition owner. |
+| Escape keeps its place only at 20%, 2 ms, or budget recovery | `hic-033`, `hic-036`, `hic-037` | Results are published, but no acceptance removes an escape that misses. |
+| Bulk kill rule | `hic-036` | The brief publishes any result and says only that the programme ends. It does not stop/narrow after the allowed iterations or define those iterations. `hic-048` does not inspect it. |
+| Warm-allocation non-claim | — | No release/doc scan forbids an allocation claim before instrument qualification. |
+| Native-code percentage census | — | No post-implementation census bead. |
+| Standing-cost/no-paying-use-case kill rule | Optional beads, `hic-034` | Individual optional products have reachability checks, but there is no final aggregate over all Phase 5/graduated modules and no boundary-shell comparison after they land. |
+| No ViewCell-class graph or second emitter | Design docs only | No final architecture/dependency census checks that resource/pull/generator/tooling work did not introduce either rejected mechanism. |
+| Tools without a real consumer build no retained machinery | `hic-023`, `hic-059` | No consumer/retention decision is attached to every new tool feature, and the final audit does not enumerate retained tooling state. |
+
+## Ranked top 10 changes before filing
+
+1. **Remove the `hic-065` operator gate.** Preserve the ledger, apply recommended defaults automatically, and eliminate the late human wait and mass-rename funnel.
+2. **Synchronize every brief with the current normative set.** Fix `n/props`/raw-JS/server ABI in `hic-030`, the two-policy SSR model in `hic-035`/`046`, the missing §3.7 references, the native roster in `hic-000`, and every stale “spec lacks” claim.
+3. **Generate one dependency manifest and validate it against all `Depends` fields.** Add the missing build/semantic edges and dynamic-tail rule before creating real beads.
+4. **Resolve the Wave-B runtime and shared-ledger fence collisions.** Split owned modules or separate parallel witnesses from serialized fixes; never rely on “coordinate.”
+5. **Make resource-demand pre-registration real.** Freeze criteria before `hic-044`, then apply them in `hic-050`; thread any ADOPT bead through naming, erasure, docs, compatibility, and audit.
+6. **Give the final programme a real closure model.** Track checkpoint corrections, rerun affected audits, require `hic-050` and `hic-062`, and separate an ungated implementation audit from a pilot-dependent release decision.
+7. **Fill the uncovered programme/use-case witnesses.** Add pagination/runtime content, i18n/theme change, nested errors, public editor/grid, motion frame budget, keyboard/accessibility integration, Xray privacy, and three-repository migration evidence.
+8. **Add the missing performance governance.** Own K3, freeze the byte-exact shell line, enforce user-visible/regression/escape/bulk rules, prohibit unsupported allocation claims, and publish the native-share census.
+9. **Split the oversized critical beads.** At minimum split `001`, `020`, `035`, `036`, `047`, `057`, `060`, and—if it survives—`066`; publish an eight-worker priority schedule.
+10. **Eliminate the dual-source and frozen-twin drift hazards.** Make the tracked normative set generated/hash-checked, mechanically freeze the bench tree, and retire the duplicate runtime after package baselines are re-pinned while retaining cited evidence and provenance.

--- a/docs/design/hicasso/product/lanes/completeness-audit.md
+++ b/docs/design/hicasso/product/lanes/completeness-audit.md
@@ -1,0 +1,65 @@
+# Coverage proof suites
+
+[`../synth-codex.md`](../specification.md#7-complete-use-case-coverage) owns capability placement, phase deliverables, and release policy. This file owns the concrete proof suites: the finite witnesses and artifacts that demonstrate coverage. It does not maintain a second roadmap or paraphrase phase outcomes.
+
+## Canonical suites
+
+| Suite | Scope | Green evidence |
+|---|---|---|
+| Package and facade | Standalone artifact, public namespaces, root lifecycle, HMR, production build, one facade and optional reachability | Clean consumer builds without benchmark-tree imports; dependency and sentinel tests prove production erasure |
+| Governance and instruments | Proposed product budgets, K1 proposal, red boundary shell, K3 scoreboards, reference hardware, estimands, controls and refusal rules | Product budgets are ratified by the named decider; K1 is ratified or rejected at its sitting; shell meets its byte-exact line or has its own prospective disposition; K3 denominators remain separate; sabotaged instruments refuse |
+| Reactive kernel | Commit-owned dynamic reads, real abandonment, multiple roots, same-id reincarnation, HMR, Activity/Suspense, substrate and exact cleanup | Mutation/sabotage suite reports zero stale reads, tears, cross-frame operations or residue across the exercised population |
+| Control and browser | Text/textarea, checkbox/radio/select, file, number/date/range, contenteditable, composition, revision, normalization, caret/selection, autofill and reset/FormData | Chromium, Firefox and WebKit DOM/browser suite with same-turn echo, published mechanics and deliberate failure controls |
+| Ordinary application | Routes, keyed lists, article edit, async mutation, errors, reset, pagination, accessibility, code splitting and multiple frames | Todo and RealWorld-class flows use only public surfaces and contain no artificial boundary introduced for the harness |
+| Testing and Xray | L0–L4 facade, restricted semantic assertions, mounted DOM, browser truth, evidence schema, causal projection, privacy/loss and erasure | Supported test namespace and one mutation-proved causal trace; opaque/unknown/loss states remain honest; production sentinels absent |
+| Host and native interop | ReactNode positions, providers, compound components, render props, refs, portals, outward embedding, virtualizer and imperative SDK | Every row of the [canonical native-tier checklist](hot-path-architecture.md#canonical-native-tier-acceptance-checklist) plus host ownership/cleanup witnesses is green |
+| SSR and hydration | Every public surface inventory id, its Render or Client-only policy, and the common hydration/refusal states | Every id points to a green row in the [canonical SSR/hydration matrix](react-compatibility-notes.md#public-surface-ssrhydration-matrix) |
+| Bulk and economics | Sparse, broad replacement, reorder and controlled edit at 100, 300 and 1,000 items; retained shell/read heap and teardown | Qualified topology-tournament results meet ratified user-visible/comparative budgets and scaling shape; the boundary shell meets its operative line or named disposition; teardown is zero |
+| Optional products | Resource-demand verdict, forms, overlays, presence, routing/resource recipes, migration and caller-gated Node service | Each product has a named consumer, deciding witness, kill condition and zero unused reachability; Node additionally proves request isolation, termination and caller latency |
+| Adoption and migration | Install, development, diagnostics, production build, upgrade, donor-tool disposition and real pilot use | Two independent pilot applications ship substantial screens without bespoke support; no primary tool/product path depends on an experimental donor surface |
+
+Warm-allocation evidence is deliberately absent from the release suites until its instrument qualifies. No allocation claim ships in the meantime; retained heap, shell, teardown, bulk, and user-visible budgets remain mandatory.
+
+## Concrete witness fixtures
+
+### Ordinary application
+
+- Todo and RealWorld-class flows with dynamic reads, event data, routing, mutation state, errors and controlled editing.
+- A four-field editor and 100-cell grid with published per-keystroke state-write, recomputation, boundary-run, commit and visible-echo mechanics.
+- A typeahead resource witness covering debounce, supersession, refresh-with-data, cancellation and abandoned render.
+
+### React and host ownership
+
+- A compound library with provider, named ReactNode slots and a render prop lowered only through the explicit conversion.
+- A blessed virtualizer preserving keyboard access, focus and selection.
+- An imperative editor/map/chart with balanced acquire/release under StrictMode, remount, retry and thrown render.
+
+### Browser and platform
+
+- Chromium, Firefox and WebKit control/IME behavior; structural accessibility assertions plus browser focus and axe checks.
+- Lazy load, fallback, error, retry and HMR through the Hicasso boundary-ABI bridge.
+- The complete public-surface SSR/hydration inventory, including deliberate mismatch and overlapping-root witnesses.
+
+### Bulk and economic
+
+- Fine, coarse, chunked/windowed and native-virtualized topology arms over the same data, DOM/intent behavior and operation script.
+- Sparse update, broad replacement, reorder and controlled edit at every registered size, with instrument eligibility decided before product data publishes.
+- Read-free shell, retained reads and teardown measured on the named substrate segments; no per-read average hides the shell.
+
+### Adoption and migration
+
+- One migration-shadow witness compares canonical DOM and intent behavior before any rewriting codemod is trusted.
+- Two real pilot applications exercise installation, hot reload, diagnostics, production build and upgrade without framework-author intervention.
+
+## Boundary facts
+
+- Hicasso mints React functions; it has no late-bound view-id registry. Code splitting uses a small `React.lazy` adapter for the private boundary props ABI, declared outside render and composed with Suspense/error handling.
+- Read-free does not imply hydration-free. Zero-hydration islands require a separate island/root architecture.
+- A full server or JVM renderer is a second implementation. The semantic assertion harness remains intentionally restricted and React server bytes remain authoritative.
+- Progressive Suspense SSR requires React streaming APIs. A `renderToString` proof supports only a non-streaming first product.
+- Hicasso-specific User Timing does not replace adapter-neutral lifecycle/read/source evidence.
+- Native semantics and rent are governed only by the [native-boundary design law](design-laws.md#native-boundary); this proof lane applies its canonical checklist without restating it.
+
+## Explicit refusals
+
+No compiled Hiccup mode, automatic hot promotion, deep conversion inside arbitrary host data, unmarked JavaScript heads, automatic fetching/Suspense from reads, fake Hooks runtime, generic local state/effect/ref DSL, UIx clone, RSC/Flight ownership, or core design system.

--- a/docs/design/hicasso/product/lanes/corpus-insights.md
+++ b/docs/design/hicasso/product/lanes/corpus-insights.md
@@ -1,0 +1,81 @@
+# Corpus-derived product insights
+
+These are the useful product implications distilled from the wider Hicasso/re-frame2 view corpus. The primary specification owns decisions and ordering; this document preserves rationale and deciding cautions.
+
+## Requirements are mined, not imagined
+
+Maintain a requirements mine with application job, observed frequency, failure modes, intended home, owner and executable witness. Frequent ordinary jobs can justify syntax. Rare but critical jobs normally justify a strong host seam or optional module. Absence from a census argues against universal syntax and standing cost; it does not make the job unimportant.
+
+The revision-pinned census baseline contains 231 reads across 85 files, about 97% of 183 handler sites one value placeholder from data, 77 controlled fields, 106 route links, zero view-local reactive cells, and one ref site. It supports reads, data intents, controlled fields, keys/lists and routing as the high-frequency spine.
+
+React-library interop and SSR/hydration correctness remain core completeness obligations despite lower census frequency because they preserve ecosystem reach and constrain every public boundary. Forms, overlays, imperative SDK wrappers, the deployable Node service and migration tooling keep their cost localized. Corpus absence remains evidence against universal syntax, not evidence of irrelevance.
+
+## What transfers and what does not
+
+| Corpus asset | Hicasso disposition |
+|---|---|
+| Fitness harness, frequency census, canonical-DOM and intent witnesses | Keep as the living requirements mine and acceptance corpus |
+| Hiccup/data intents, one component form, explicit state addresses | Keep as the ordinary authoring spine |
+| Render-probes/commit-owns and the tear check | Keep the correctness guarantee; do not keep the ViewCell or observation ledger that first carried it |
+| Stable complaint ids and the versioned S6 evidence shape | Reuse behind the adapter-neutral Hicasso provider, with a named consumer and production erasure |
+| JVM structural tree and dual-emitter parity corpus | Reuse compatible assertion data/helpers only for restricted L2 tests; React server bytes remain SSR/hydration authority |
+| Analyzer, compiled Hiccup tier and static manifest | Do not revive; recover bounded syntax facts with lint and use an explicit native React form only at a visible escape boundary |
+| UIx adapter and `$`/component ergonomics | Keep UIx supported and as a tuned comparator; Hicasso's narrow native route removes it as a mandatory hot-path dependency |
+
+This is guarantee/mechanism separation: a predecessor can teach a law without donating the object graph that implemented it.
+
+## The performance premium must buy a product capability
+
+The representative mount difference is largely associated with a richer read topology that hook-shaped code cannot express directly. Judge the product on the value of local reads plus user-visible budgets, not on the fiction that every comparator expresses the same page.
+
+That paid-for read declaration suggests the flagship extension: committed resource demand. A committed read can acquire demand; unmount or parameter change releases it; debounce, supersession, refresh and cancellation are explicit policy. Abandoned render acquires nothing and no second ledger appears. A typeahead witness decides adoption.
+
+## Evidence is a designed product
+
+Instrument eligibility precedes every product row because an invalid clock, control, allocation method, estimand, or population can flatter or obscure a candidate. Name the estimand and population, use a tuned behaviorally equal control, state which failure class each control detects, pin the estimator before candidate data opens, and sabotage the instrument so it demonstrably refuses. Invalid evidence produces no fallback ratio.
+
+Equality is similarly typed. Authored data, semantic assertion trees, canonical DOM, intent streams, React server bytes, hydrated behavior, commits, and paint are different claims. The platform-authoritative layer decides its own contract; normalized structure never stands in for hydration bytes, and render timing never stands in for commit.
+
+## Centralized laws are an ergonomic feature
+
+Controlled value echo, caret/selection, IME, revision reset, owned-prop collision, memoization and explicit prevention remove defect classes that direct React authors otherwise reproduce. Centralization is justified when the law is subtle, common and testable; it does not justify a general behavior DSL.
+
+## State needs pressure valves, not a second model
+
+Durable and application-visible state belongs at explicit re-frame2 addresses. Concern-named libraries may package draft/revision transitions. High-rate geometry, motion, composition or vendor mechanics may remain inside a native host when they are not application facts. DOM-owned state is declared. This keeps one state system without routing every animation frame through app-db.
+
+## The trapdoor targets React, not a wrapper library
+
+Maximum-performance and ecosystem compatibility are contracts with native React. UIx is a proven ergonomic CLJS route and a permanent comparator, but requiring it for a rare hot island would make an optional optimization acquire a second library and API.
+
+A narrowly scoped Hicasso-native namespace can own direct element construction, stable native component identity, shared-frame read hooks, and boundary-ABI helpers without becoming another component framework. The semantic split stays visible: Hiccup is always interpreted; explicit native forms always use React semantics. Three-way evidence against handwritten React and UIx decides whether the convenience surface earns its place.
+
+## Completeness is layered
+
+- Core owns view/read/event/control/root/error, exact React host-boundary laws, and SSR/hydration behavior for every public surface.
+- Optional libraries own forms, overlays, presence and activated resource features; the deployable Node/React SSR service is optional infrastructure over the core server/hydration contract.
+- Recipes cover routing conduct, mutation correlation, virtualization, imperative ownership, styling, i18n and navigation focus.
+- Tooling owns lint, semantic assertions, Xray/Pair, migration and generative checks.
+- Native React owns hook-intensive/vendor/high-rate surfaces; Hicasso-native, UIx, and raw React are supported authoring routes.
+
+Every layer has a witness and an unused-cost rule. One facade is taught; live Xray/Story/Pair consumers migrate to the adapter-neutral Hicasso evidence provider, then obsolete re-frame.ui/Freehand surfaces and documentation are archived or removed before release. Named compatibility fixtures may remain isolated.
+
+## Innovation rationale
+
+The [primary portfolio](../specification.md#11-innovation-portfolio) alone owns idea membership and status; [`left-field-ideas.md`](left-field-ideas.md) owns candidate protocols and kill criteria. The corpus contributes four durable decision rules rather than a second portfolio:
+
+- Diagnose the owner before automating a remedy. Computation, read topology, lowering, React reconciliation and layout require different responses; heat alone does not justify native extraction.
+- New read or resource shapes must beat the smallest hand-written topology on both ergonomics and cost without recreating a per-leaf ownership ledger.
+- Developer products extend the existing complaint and Xray/Pair evidence schema, prove a real human or machine consumer, preserve privacy/loss semantics and erase from production.
+- Forms, overlays, migration and other application products begin as recipes or bounded witnesses. They become optional APIs only after repeated consumers justify maintenance and prove zero standing core cost.
+
+## Guardrails on attractive but unsound ideas
+
+- A read-free declaration may skip part of the shell; it does not imply hydration-free output.
+- One pull subscription may merely relocate traversal, equality and broad invalidation.
+- Compile-time rewriting of Hiccup can disappear from the browser while still imposing a large language/test/parity tax. An explicitly native element macro is acceptable only because it defines a separate, visibly native form rather than another Hiccup mode.
+- A full headless/JVM renderer is a second semantic implementation; the supported assertion model remains partial.
+- User Timing describes render attempts, not committed occurrence identity.
+- Deep Hiccup conversion inside arbitrary host data corrupts foreign ABIs; ReactNode positions must be declared.
+- Submit-only automatic prevention creates position/value-dependent behavior; prevention stays explicit.
+- Generic adapter-local state, compiler/JIT modes, automatic hot promotion, signals replacement and universal callback cells remain out.

--- a/docs/design/hicasso/product/lanes/delivery-programme.md
+++ b/docs/design/hicasso/product/lanes/delivery-programme.md
@@ -1,0 +1,23 @@
+# Delivery dependency and exit index
+
+[`../synth-codex.md`](../specification.md#12-action-programme) owns phase order, scope, and product decisions. This index exposes dependencies and exits without creating a second roadmap.
+
+| Phase | Depends on | Canonical evidence | Exit signal |
+|---|---|---|---|
+| 0 — product spine | Selected Hicasso direction | Package/facade and governance/instrument suites in the [proof matrix](completeness-audit.md#canonical-suites) | A clean consumer runs a minimal public-API view; the product budget set is ratified; K1 is ratified or rejected by the named decider; the red shell has an operative remediation gate; K3 denominators remain distinct; every proposed surface has an inventory id and server policy |
+| 1 — trustworthy kernel | Phase 0 package, laws and governance | Reactive-kernel and control/browser suites | Sabotage-tested zero stale reads, tears, cross-frame operations or residue; the shell meets its byte-exact line or carries a separate prospective disposition before ABI freeze |
+| 2 — lovable vertical slice | Phase 1 trustworthy kernel | Ordinary-application and testing/Xray suites | The public workflow contains no artificial boundary or internal import, the evidence provider erases from production, and the ordinary facade can freeze from application evidence |
+| 3 — native hot path | Phase 1 kernel and Phase 2 ordinary facade | Host/native suite and the [canonical native-tier checklist](hot-path-architecture.md#canonical-native-tier-acceptance-checklist) | The checklist is green and a measured boundary moves to native React with declared gain and the same root, frame, state owner and diagnostic surface |
+| 4 — coverage closure | Phases 2–3 public seams | Browser/platform, SSR/hydration and bulk/economic suites | Every coverage row has maintained evidence or an explicit owned disposition; every public-surface inventory id and required bulk population is green |
+| 5 — optional products | Phase 4 evidence and a named caller per feature | Optional-products suite | Each admitted product meets its deciding witness and unused-cost rule; the Node service additionally meets its caller's isolation, termination and latency contract |
+| 6 — adoption and release | Stable Phases 0–5 surfaces | Adoption/migration suite | Two pilots install, ship, diagnose and upgrade without bespoke support; no primary path depends on donor surfaces; no critical API changes across the release candidate |
+
+## Cross-cutting release gates
+
+- Testing and Xray ship with the behavior they prove; neither is deferred to a polish stage.
+- Correctness, cleanup, scaling shape and production erasure are deterministic blockers.
+- Clock and heap claims use the evidence protocol and thresholds owned by the primary performance contract.
+- A new core surface needs a job, owner, witness, unused-cost result and comparison with the smallest equivalent direct-React, Hicasso-native, or established-library control.
+- Optional namespaces need a named consumer, explicit kill condition and bundle-reachability proof.
+- A native escape remains only when it preserves behavior and ownership and clears its declared benefit threshold.
+- Phase exits use public-package witnesses, never benchmark-tree-only demonstrations.

--- a/docs/design/hicasso/product/lanes/design-laws.md
+++ b/docs/design/hicasso/product/lanes/design-laws.md
@@ -1,0 +1,63 @@
+# Hicasso design laws
+
+These laws define the product and constrain every implementation choice.
+
+## React and ownership
+
+1. Render is speculative and owns nothing durable.
+2. The selected commit acquires exactly its current read/host ownership; disconnect releases it.
+3. A render/commit tear is detected and corrected before visible paint.
+4. React owns component identity, hooks, refs, effects, context, errors, concurrency, Suspense, Activity, hydration, commit and DOM reconciliation.
+5. Hicasso has one interpreted Hiccup semantics and one React implementation. Native work crosses the explicit [native-boundary law](#native-boundary); it is not another Hiccup mode.
+
+## State and reactivity
+
+1. re-frame2 is the application-state owner.
+2. Subscriptions are the only adapter reactive source and the re-frame2 state commit is the application write clock. React commit owns UI read/host attachment; it is not a second application write clock.
+3. Application-visible ephemera has an explicit re-frame2 address. High-rate host-private mechanics may remain inside a native host; DOM-owned state is an explicit interop contract.
+4. `sub` is legal during direct synchronous execution of the active Hicasso body, including ordinary helpers, branches and loops. Deferred crossings refuse.
+5. Dynamic reads are reconciled from the selected render without a general per-boundary dependency ledger.
+6. The two-hook boundary shell is a ceiling. Optional capabilities add no universal hook or ownership graph.
+7. Demand-driven resources may reuse committed read membership; they cannot acquire during abandoned render or create a second read ledger.
+
+## Language and interop
+
+1. Hiccup and ordinary intent are data; executable host behavior uses explicit functions.
+2. A `defview` is always a boundary and an ordinary `defn` is always inline composition.
+3. One props map, stable keys, value-equality memoization and explicit controlled revision are the default laws.
+4. Prevention is explicit and uniform. The same handler form never changes meaning by position.
+5. Foreign React positions are declared by their real ABI: event, ReactNode/slot, render callback, ref, children and server policy. Arbitrary host data is not deeply converted.
+6. Unsupported behavior fails with a stable id, source, path/position, offending value and recovery.
+7. Applications get one obvious facade; optional namespaces are separately reachable and erase when absent.
+8. React-library interop and SSR/hydration correctness are core contracts. Every public surface renders deterministically on the server or refuses with recovery and has explicit hydration behavior; only the deployable Node service is optional.
+
+## Native boundary
+
+This section is the canonical owner of the native-tier laws. Other documents classify surfaces, sequence work, or define witnesses; they link here rather than restating these laws.
+
+1. Native React is the performance and ecosystem contract. Hicasso-native, UIx, and raw React/JavaScript are supported authoring routes; UIx is a comparator and optional toolkit, never a Hicasso dependency.
+2. `[...]` always means interpreted Hiccup. `n/$` compiles only its own explicit native form and never analyzes or rewrites a `defview` body.
+3. Native props, callbacks, children, keys, refs, hooks, control behavior, and errors follow React semantics. The native authoring surface may normalize only top-level prop-name spelling; Hicasso intent lowering, controlled-field repair, structural inspection, and tree diagnostics stop at the boundary.
+4. Native work remains under the same React root, re-frame2 frame context, and application-state owner. `n/use-sub` and `n/use-frame` reuse the substrate-neutral React spine and existing direct-React frame hook; they neither import UIx nor fork frame, store, teardown, or error semantics.
+5. Element construction, `n/defcomponent`, memo, lazy loading, refs, and both embedding directions share one props/children ABI. There is no separate “ergonomic” and “fast” ABI.
+6. The native namespace is separately reachable. An interpreted-only production dependency graph and bundle contain neither native-tier runtime nor UIx code.
+7. Xray may name and time the native boundary and observe reads made through supported native hooks. The inner React tree is otherwise explicitly opaque.
+
+## Economics and scope
+
+1. Standing cost is measured before feature-rich behavior. The do-nothing and read-free boundary are permanent controls.
+2. Capability pays rent where it is used. A rare facility does not burden every boundary.
+3. A core proposal needs a repeated job or centralized defect class, a paying witness, and a better result than the smallest equivalent direct-React, Hicasso-native, or established-library control.
+4. Optional modules need a named consumer and zero reachability when unused. Recipes become APIs only after repeated application code proves the need.
+5. No compiler/AOT mode for Hiccup, second renderer, custom React renderer, automatic specialization, signals replacement, universal callback cells or generic local-state/effect DSL. A macro for an explicitly native element form does not create an alternate Hiccup mode.
+
+## Evidence and tools
+
+1. Every claim names its witness, runtime, substrate, instrument, estimand and population.
+2. Semantic tree, canonical DOM, intent stream, React server bytes, hydrated behavior, commit and paint are distinct equalities.
+3. A gate carries a positive/sabotage control and refuses to publish when its own validity checks fail.
+4. Deterministic correctness/scaling/erasure gates block changes; distributional clock and heap budgets use pinned evidence runs.
+5. Tool evidence is versioned, privacy-projected, loss-accounted and absent from production.
+6. Unknown, opaque, capped and uncorrelated are first-class results. Timing proximity never fabricates causality or commit.
+7. A tool builds retained machinery only for a named consumer; Xray and Pair share one projection rather than duplicating evidence systems.
+8. Prefer a source-located, runtime-checked declaration with loud failure before purchasing static analysis; add proof only for facts a declaration cannot establish.

--- a/docs/design/hicasso/product/lanes/ergonomics-api.md
+++ b/docs/design/hicasso/product/lanes/ergonomics-api.md
@@ -1,0 +1,119 @@
+# Hicasso public language and ergonomics
+
+## Recommendation
+
+Converge on a deliberately small language. Freeze laws first and names only after application/host witnesses. Hicasso should feel like Hiccup plus re-frame2, not like a second React component system. The common path is data; ordinary Clojure functions provide composition; explicit functions and native React components cover the places where executable behavior is real. A small optional Hicasso-native namespace makes the exceptional native path self-contained without cloning UIx. React-library interop and SSR/hydration correctness are core product contracts, while UIx, library-specific wrappers, and the deployable Node service remain optional.
+
+## Proposed core surface
+
+- `h/defview`: defines a React/re-frame boundary. It is used as a Hiccup head and refuses a direct Clojure call with a source-located recovery.
+- `h/sub`: reads at the point of use during the direct synchronous execution of the active boundary. Branches, loops, and ordinary `defn` helpers are legal; deferred reads refuse.
+- `h/handler`: captures the current frame, runs later, dispatches a returned event vector, and ignores `nil`. Its meaning does not vary by prop position.
+- Literal event vectors: the default event representation.
+- `h/defhost`: names and documents a foreign React ABI, ReactNode positions, and server policy once.
+- `h/as-element`: explicitly converts Hiccup returned through a foreign render-prop or slot callback.
+- Attribute merge: a pure owned-wins recipe/helper, public only if an application witness needs it.
+- `h/mount!`, `h/hydrate!`, `h/render!`, and `h/unmount!`: the root lifecycle.
+- Server/hydration contract: every public view and host produces deterministic React server behavior or a source-located refusal, then hydrates with root-scoped identity, errors, adoption, and cleanup.
+- `h/error-boundary`: a minimal error-region primitive.
+
+The grammar needs only the fragment head, the raw React element head, one props map, and a very small reserved-data vocabulary: value extraction, checked extraction, explicit prevention, and controlled-value revision.
+
+Applications get one obvious `h` facade; optional capabilities use named namespaces with bundle-reachability proofs. A new surface earns core status only when a living use-case ledger shows repeated use or a centralized defect class and the smallest direct-React, Hicasso-native, or established-library alternative is materially worse.
+
+## Optional native surface
+
+The same artifact exposes a separately reachable namespace, provisionally `re-frame.hicasso.native` (`n`). The [canonical native-boundary laws](design-laws.md#native-boundary) govern its semantics, dependency isolation, ABI, and opacity; the [canonical acceptance checklist](hot-path-architecture.md#canonical-native-tier-acceptance-checklist) owns its release proof.
+
+| Surface | Contract |
+|---|---|
+| `n/$` | Macro-expand an explicit native element form to direct React construction; native props, callbacks, children, keys, and refs apply, with no Hicasso intent or controlled-field lowering |
+| `n/props` | Mark a dynamic ClojureScript map or JavaScript object as the props operand of `n/$`; the marker itself emits no wrapper |
+| `n/defcomponent` | Define a stable native function component with source/display metadata, HMR behavior, one props/children ABI, and an explicit server policy that defaults to Client-only |
+| `n/use-sub` | Read re-frame2 state through the substrate-neutral native React hook in the current frame; do not wrap or import UIx |
+| `n/use-frame` | Reuse the existing direct-React frame hook for native component work |
+| ABI helpers | Preserve component identity and the boundary marker through memo, lazy loading, refs, and the two same-root embedding directions |
+
+Ordinary React hooks are used directly. Clojure-friendly wrappers are added only when real island code demonstrates repeated ceremony.
+
+### Provisional `n/$` grammar
+
+The authoring shape is deliberately small:
+
+```clojure
+(n/$ head)
+(n/$ head child*)
+(n/$ head literal-props child*)
+(n/$ head (n/props dynamic-props) child*)
+```
+
+- An unqualified keyword head such as `:div` names an intrinsic React element. A string head names an intrinsic or custom element verbatim. Any other head expression must evaluate to a native React component. Selector shorthand such as `:div.card#main` is not in the v0 native grammar; spell class and id as props.
+- The macro treats only `nil`, a literal ClojureScript map, a `#js` object literal, or the explicit `(n/props expression)` marker as the props operand. Every other trailing form is a child. This syntactic rule avoids misclassifying a dynamic React element—which is itself a JavaScript object—as props.
+- A JavaScript props object passes by identity. A ClojureScript map is converted shallowly: literal keys are lowered by the macro and a dynamic map inside `n/props` uses the separately reachable native helper. The `n/props` marker emits no component or wrapper.
+- ClojureScript-map prop names use the same canonical top-level React slot-name rule as the Hicasso codec: kebab spellings become React camelCase, `:class`/`:for` use the React names, and `data-*`/`aria-*` remain hyphenated. Existing camelCase keywords are fixpoints and string keys pass verbatim. A raw JavaScript object already uses exact React property names and is not renamed. Macro and runtime map conversion share one `.cljc` rule plus parity fixtures; they may not carry copied algorithms.
+- Prop values pass by identity. There is no intent lowering, class collection merge, style-map conversion, keyword-value conversion, controlled-field repair, or deep conversion. Use a JavaScript object where a native API expects one, including React style objects and CSS custom properties.
+- Children are trailing ReactNode values. Nested elements use nested `n/$`; Hiccup vectors are not interpreted. Collections must already be valid React children, normally a JavaScript array or iterable. `:children` in the props map is refused so there is one child channel.
+- `:key` and `:ref` use the ordinary React slots. Two source keys that normalize to the same slot refuse rather than acquire an order-dependent winner.
+
+The provisional `n/defcomponent` ABI is one raw JavaScript props object; React children are available at `.-children`. A declaration map before the argument vector carries the server policy, provisionally `{:server :render}` or `{:server :client-only}`; omission means Client-only. The macro supplies stable top-level component identity, source/display metadata, and HMR conduct, but does not allocate a Clojure map merely to destructure props. A later compile-time destructuring convenience may be considered before the Phase 3 ABI freeze only if it expands to the same object ABI and materially improves real island code.
+
+```clojure
+(ns app.hot-row
+  (:require [re-frame.hicasso.native :as n]))
+
+(n/defcomponent hot-row
+  {:server :render}
+  [^js props]
+  (let [row-id (.-rowId props)
+        label  (n/use-sub [:row/label row-id])]
+    (n/$ :button
+         {:class       "hot-row"
+          :data-row-id row-id
+          :on-click    (.-onOpen props)}
+         label)))
+
+(n/$ hot-row
+     {:row-id row-id
+      :on-open (fn [_event] (open-row! row-id))})
+```
+
+Here the macro emits the canonical `className`, `data-row-id`, `onClick`, `rowId`, and `onOpen` slots. The callback remains a native function; an event vector in `:on-click` is an error, not Hicasso intent syntax.
+
+## Authoring laws
+
+1. A `defview` is always a boundary; an ordinary `defn` is always inline composition.
+2. A body is pure and may run, retry, or be abandoned. Render owns nothing.
+3. `sub` is ambient only during the active synchronous body. A helper may donate reads to that boundary; a callback, promise, timer, or lazy escape may not.
+4. React owns keys, refs, hooks, effects, errors, concurrency, hydration, and component identity.
+5. Event vectors are data. `h/handler` is the one explicit event-producing function form. Ordinary `fn` values retain ordinary JavaScript callback semantics.
+6. Controlled fields use app-db, the synchronous controlled-input door, and an explicit revision for identity-preserving reset.
+7. Owned control attributes beat forwarded attributes by presence, not truthiness.
+8. Host props use an honest ABI: normalize documented HTML-like slots, pass other values by identity, and require explicit `clj->js` for JavaScript option objects.
+9. No public option selects an execution mode. Native construction is explicit at the form or component boundary and never changes the meaning of Hiccup.
+
+State ownership is explicit: durable and application-visible ephemera live at addressed re-frame2 locations; high-rate host-private mechanics may live inside a native host; DOM-owned state is an explicit interop choice. No hidden ratom-like tier appears.
+
+## Surface boundaries and exclusions
+
+- Prevention is explicit everywhere; there is no submit-only auto-prevention.
+- Callback contracts use literal intents, `h/handler`, and ordinary functions rather than a positional taxonomy.
+- Attribute forwarding uses an owned-wins pure merge recipe; a public helper exists only if repeated code warrants it.
+- Keep key maps restricted to keyboard event props.
+- Validate React refs instead of reserving an unproven vector-ref syntax.
+- Presence, forms, routing integration, and overlays live in optional namespaces or recipes; a generic local-state facility is outside the product.
+- Do not expose the codec or internal `rfProps` ABI as the outward bridge.
+- Do not grow the native namespace into a second component framework, hook library, styling system, or host-schema language.
+
+## Interop contract
+
+`defhost` is the named seam for a foreign component, provider, compound component, retained callback, or server policy. Declared ReactNode props and named content slots lower Hiccup under the captured frame; dev schema/lint validates their positions without deep-converting arbitrary data. A one-off raw element remains available, but repeated or hot use should acquire a name and tests. Render props return Hiccup only through `h/as-element`; otherwise values cross by identity.
+
+Add a thin outward bridge for a native React parent—authored with `n/defcomponent`, UIx, or JavaScript/TypeScript—to render a minted Hicasso view under an existing frame provider. It must retain the memo wrapper, frame isolation, key identity, hydration behavior, and teardown law without creating another root.
+
+## Editor and diagnostic ergonomics
+
+The defining macros capture file, line, and column. Every refusal carries a stable error id, view, source, tree path or host-prop position, offending value, expected shape, and concrete recovery. Publish clj-kondo exports for the syntactic facts that can be checked honestly; optional dev schemas may validate declared view args and host/control props without shipping a general validation framework or production cost. Do not imply whole-program analysis.
+
+## Acceptance examples
+
+The frozen ordinary surface must express a Todo flow, article editor, controlled grid, foreign date picker with a render prop, and virtualized list. Direct `defview` calls, deferred reads, malformed intents, opaque host assertions, native/Hiccup semantic mixing, and unsafe SSR policies fail didactically. Native-island completeness is decided only by the canonical hot-path checklist rather than a second paraphrased gate here.

--- a/docs/design/hicasso/product/lanes/evidence-baseline.md
+++ b/docs/design/hicasso/product/lanes/evidence-baseline.md
@@ -1,0 +1,86 @@
+# Hicasso evidence baseline
+
+This baseline records the current product facts that constrain implementation. Quantitative rows remain pinned to their named witnesses and instruments; they are not universal adapter ratios.
+
+## Product state
+
+- Hicasso is the selected native adapter design.
+- The proposed `1.25x` K1 product ceiling is not operative. Phase 0 prepares its scoped record for operator ratification at the 2026-08-27 sitting; the registered `1.10x` gate remains the only adjudicated line until then.
+- The implementation remains under the benchmark tree rather than an installable `implementation/hicasso` package.
+- Public names are provisional until the ordinary application and host/hot-path witnesses pass.
+- The interpreted React-function-component path is the ordinary product path. An explicitly native element/component surface is the local escape; compiled Hiccup, own-renderer and second-emitter paths are outside the design.
+- React-library interop and SSR/hydration correctness are core product obligations; UIx, library-specific wrappers, and the deployable Node service are optional.
+
+## Demonstrated value
+
+- Ambient reads work through synchronous helpers, branches and variable-length loops.
+- Event vectors and the controlled-input/revision laws are implemented.
+- A [mutation-proved dogfood screen](../../studio/the-dogfood-preference-case.md) reaches the same canonical DOM and 15-intent behavior through a 17-step script in 47 counted lines versus UIx's 72, with eight data event positions versus eight closures.
+- The [revision-pinned requirements census](../../charter.md) records 231 reads across 85 files, about 97% of 183 handler sites one value placeholder from data, 77 controlled fields, 106 route links, zero view-local reactive cells, and one ref site.
+- Controlled input demonstrates same-turn convergence, caret repair, revision reset and live composition behavior in Chromium.
+- Hicasso and UIx can share the same frame provider in one React root.
+- A Hicasso boundary can return an existing React element, enabling a narrow direct-output comparison without another runtime mode.
+
+The proposed Hicasso-native namespace is not demonstrated value yet. It remains a Phase 3 product hypothesis until every row of the [canonical native-tier checklist](hot-path-architecture.md#canonical-native-tier-acceptance-checklist) passes.
+
+## Pinned economic evidence
+
+| Axis | Current baseline | Evidence anchor | Product implication |
+|---|---|---|---|
+| Cold mount | `1.1718x [1.1263–1.2190]`, n=8; `1.1976x [1.1504–1.2468]`, n=6 against direct UIx-on-subs on the final K1 estimator | [`rf2-diaud`; `clock-emvod` / `clock-w3yxd`](../../studio/rows-re-adjudicated-on-the-corrected-clock.md) | The registered `1.10x` gate is missed; `1.25x` is only a proposed scoped amendment pending its named ratification |
+| Interpreted lowering | At or below stock Reagent on the measured walk rows | [`rf2-2rtt6.63`](../../studio/our-walk-against-reagents.md) | Do not assume Hiccup interpretation is the dominant pressure |
+| Narrow update | Workload-specific parity/win evidence | [Corrected-clock rows](../../studio/rows-re-adjudicated-on-the-corrected-clock.md) | Require changed-work scaling; make no universal “narrow is faster” claim |
+| Broad update | Governed Hicasso/Reagent intervals remain instrument-limited; no general magnitude | [`rf2-vp0j7` evidence lineage](../../studio/bulk-broad-re-taken.md) | Do not optimize from a refused or non-governed comparator |
+| Boundary shell | Current pinned `R=0` shells are `1,103 B` on the Reagent segment and `1,097 B` on the UIx segment, above the registered `1 KB` paper-fail line under either 1,000 B or 1,024 B | [Current heap ladder](../../studio/reads-per-boundary-heap-ladder.md) | The row is red; freeze the byte-exact line, then remediate it or require a separate prospective operator disposition before ABI freeze |
+| Retained reads | Hicasso `1,278 B/read` versus Reagent `947 B/read`; Hicasso `2,115 B/read` versus UIx `2,980 B/read` | [Current heap ladder](../../studio/reads-per-boundary-heap-ladder.md) | Choose the under-collector substrate explicitly; keep governed shipped-path viability, parent-relative architecture progress, and author preference as separate scoreboards |
+| Warm allocation | No fitted series clears the registered quality floor | [Allocation survival metric](../../studio/the-survival-metrics-allocation-half.md) and [instrument contract](../../allocation-instrument-rework.md) | Publish no allocation claim yet |
+| Teardown | Zero retained bytes and objects on the pinned heap arms | [Current heap ladder](../../studio/reads-per-boundary-heap-ladder.md) | Preserve as an absolute invariant |
+| SSR/hydration | Node/React spike produces deterministic hydratable fixtures | [SSR spike witness](../../studio/ssr-spike-witness.md) | Product service, isolation and operations remain to build |
+
+The heap result has three non-substitutable scoreboards: governed viability against Reagent, architecture progress against the UIx parent, and author preference from the dogfood witness. None is a replacement denominator for another.
+
+On the named large-template mount evidence, no identified admissible lever clears the registered threshold of `45.7–49.4%` of the measured deficit. Reopen that bounded conclusion only for a new clean clock-of-record acceptance row, a named lever plausibly worth the threshold, or an explicit change to the compiler/render-phase/witness-set fences. It does not claim that every workload or future implementation is irreducible.
+
+## Current economic status
+
+### K1 price proposal
+
+The baseline remains a decisive miss against the registered K1 gate. The [primary performance contract](../specification.md#6-performance-contract) owns the proposed ceiling, named decider, sitting, effective-revision, reopen and revert rules. Its status is pending; no evidence row may use the proposal to mark K1 green.
+
+### Read-free boundary shell
+
+The current result is red against the `1 KB` paper-fail line under either byte interpretation. The primary performance contract owns the exact-line freeze, remediation path and any later prospective disposition. No acceptance exists, the K1 decision does not waive this row, and a percentage regression allowance cannot make it green.
+
+### Bulk, retained heap, and allocation
+
+Representative bulk evidence remains unresolved while the comparator is instrument-limited; the primary performance contract owns its release-gate population and budgets. Retained heap, boundary shell and teardown remain independent. Warm allocation has no publishable claim and is not itself a release blocker.
+
+## Open proof obligations
+
+- Root-scope every mutable runtime owner, including hydration adoption and dirty/read structures.
+- Prove same-public-id frame reincarnation and delayed callback routing.
+- Exercise genuine React abandonment, retry, Suspense and Activity hide/reveal.
+- State and enforce the exact synchronous read extent.
+- Complete Chromium, Firefox and WebKit control/DOM matrices.
+- Define HMR identity/preservation honestly.
+- Prove retaining-host callback identity and retirement.
+- Adjudicate the underlying subscription substrate before ABI freeze.
+- Publish editor/grid per-keystroke mechanics and qualified bulk evidence; publish warm-allocation evidence only if its instrument qualifies and a product claim is sought.
+- Complete the core server/hydration contract independently of deployment demand; turn the Node spike into a bounded service only for a named caller.
+- Complete every row of the canonical native-tier checklist; partial element, hook, server, dependency or performance parity is not a substitute.
+- Move live Xray/Story/Pair consumers to the adapter-neutral Hicasso evidence provider before disposing of experimental donor tool surfaces.
+
+## Measurement posture
+
+- Preserve comparator, witness, hardware, browser, commit, substrate, fan-out regime, raw samples and estimator.
+- Never pool numbers from different programmes or instruments.
+- A repeated mechanism class across different runtimes is a design hypothesis, not pooled empirical evidence.
+- Compare against a tuned control and prove behavioral equality before comparing cost; native-surface claims retain both handwritten React and UIx controls.
+- Keep a permanent status-quo/null arm in comparative product decisions.
+- Measure the do-nothing boundary before any universal feature.
+- Attribute shared framework cost separately from adapter-owned cost on the shipping host.
+- Use deterministic blockers for correctness, residue, scaling shape and production erasure; adjudicate distributions in pinned interleaved runs.
+- Drift-sensitive browser comparisons carry a same-run interleaved floor/control; they do not import a floor from another run.
+- Production-erasure tests use unique sentinels plus a reachable positive-control sentinel, never a public-name grep alone.
+- Keep failed or refused measurements visible as absence of evidence, not a flattering zero.
+- Governance changes are prospective and record the frozen registered criterion, decider, effective revision, reopen conditions and revert trigger.

--- a/docs/design/hicasso/product/lanes/hot-path-architecture.md
+++ b/docs/design/hicasso/product/lanes/hot-path-architecture.md
@@ -1,0 +1,103 @@
+# Hot-path architecture
+
+## Principle
+
+Hicasso remains one interpreted Hiccup language. Native React is the explicit local boundary, not a compiler tier or hidden fast mode. Hicasso supplies a small optional native namespace so an application can cross that boundary without acquiring UIx; UIx and raw React/JavaScript remain supported peer routes. Zero to two percent native code is a plausible outcome to measure, never a quota: a small amount of source can dominate the application's work.
+
+## The performance ladder
+
+### 1. Ordinary Hicasso
+
+Use interpreted Hiccup, ambient reads, data intents, controlled-input semantics, structural tests, and full diagnostics. Start every feature here.
+
+### 2. Tune topology without changing language
+
+Place boundaries around independently changing or expensive regions; inline helpers that always travel with the parent; stabilize keys and props; choose fine, coarse, chunked, or visible-window subscriptions to match the workload; virtualize genuinely large collections. Do not split per element mechanically because each boundary retains a React fiber, memo wrapper, and Hicasso shell.
+
+### 3. Return a direct React element
+
+A Hicasso `defview` can return an existing React element, normally built with `n/$` and equally able to come from UIx or raw React. This retains the same frame, Hicasso subscription shell, props ABI, and component identity while skipping Hiccup lowering for that boundary. It is the narrowest useful escape for a measured codec/markup hotspot.
+
+The returned subtree follows native React rules: Hicasso intent lowering, controlled-field normalization, key diagnostics, and structural inspection do not apply. Use native props and callbacks. Keep hooks in a separately defined native component rather than making hook order depend on a Hicasso body's data paths.
+
+### 4. Use a named native React island
+
+Use a top-level native component behind the named host seam for a virtualizer, editor, animation surface, canvas/WebGL coordinator, retained vendor widget, or hook-intensive hot collection. The default self-contained route is `n/defcomponent` with `n/use-frame` and `n/use-sub`; UIx is an optional mature route, and JavaScript/TypeScript uses the host bridge. Each remains under the same React root and shared re-frame2 frame context. It is not a second store or adapter root.
+
+One-off raw elements are for migration and genuinely one-off interop; they should not be sold as a performance tier. Repeated hot crossings become a named host or native island with an explicit server policy and contract tests.
+
+### 5. Choose a native screen only when the screen is React-shaped
+
+An intrinsically React-first surface may implement its view tree with the Hicasso-native namespace, UIx, or raw React/JavaScript under the single installed Hicasso adapter, root, and shared frame contract. This is a local view-implementation choice, not another adapter or Hicasso mode. A substantial React-first surface may reasonably choose UIx instead of expanding Hicasso's deliberately narrow native facade.
+
+## Owned native surface and semantic fence
+
+The [native-boundary law](design-laws.md#native-boundary) is the single semantic owner, and the [public-language lane](ergonomics-api.md#optional-native-surface) owns the surface and `n/$` grammar. This lane owns only the performance workflow, implementation implications, and acceptance evidence.
+
+The implementation must factor the substrate-neutral React spine and direct-React frame hook before publishing the namespace if the existing seams cannot be consumed without UIx. Macro source, tests, build behavior, and error quality count as product cost even when the expansion adds no browser runtime. No macro rewrites interpreted Hiccup; only an explicit `n/$` native form expands to direct React construction.
+
+## Canonical native-tier acceptance checklist
+
+This is the only release checklist for the native tier. Other documents link here instead of maintaining variant gate lists.
+
+| Area | Required result | Deciding evidence |
+|---|---|---|
+| Native-form grammar | The provisional `n/$` grammar handles omitted and literal props, explicit `n/props` dynamic maps/objects, dynamic React-element children, trailing and nested children, keyword/string/component heads, keys and refs, SVG and custom elements, canonical-slot collisions, and source-located refusal of Hiccup/intent semantics | Macro-expansion fixtures plus client DOM and React server witnesses against handwritten `createElement` |
+| Component ABI and identity | One raw-JavaScript props/children ABI survives `n/defcomponent`, memo, lazy loading, ref forwarding, CLJS/JavaScript component heads, display/source metadata and HMR; there is no parallel fast ABI | One matched component exercised through every wrapper and one HMR replacement cycle |
+| Frame and store lifecycle | `n/use-sub` and `n/use-frame` use the shared substrate implementation across no-provider failure, two frames, frame replacement, StrictMode, retry/abandonment, Suspense, Activity hide/reveal, unmount and exact cleanup | Matched Hicasso-native and UIx consumers plus a dependency check proving no UIx import |
+| Same-root interop | Hicasso-native, UIx and raw React parents can render Hicasso, and Hicasso can render each native route, without another root, frame or state owner | Both embedding directions across two frames, retained callbacks, provider/compound components, errors and teardown |
+| Server and hydration | Every native surface satisfies its row and declared policy in the canonical SSR/hydration matrix, including server bytes or source refusal, matching hydration, mismatch attribution and multiple roots | [`react-compatibility-notes.md`](react-compatibility-notes.md#public-surface-ssrhydration-matrix) |
+| Dependency and rent | Interpreted-only dependency graphs and production bundles contain neither native-tier runtime nor UIx; native bundles contain no UIx unless the application imports it | Dependency-graph assertions and unique production sentinels with reachable positive controls |
+| Diagnostics | Xray names and times the boundary, reports supported-hook reads, labels the inner tree opaque and adds no production evidence machinery | One causal trace with an opaque foreign subtree and production-erasure proof |
+| Performance | Equivalent Hicasso-native, handwritten-React and UIx components share behavior, read shape, DOM and instrument; the Hicasso-native route meets the ratified island parity budget, and each retained escape meets the benefit threshold | Interleaved three-way client and server runs with the instrument controls from the primary performance contract |
+
+A red row blocks publication of the native namespace. The remedy is to fix or shrink the surface; no row is waived by success on another row.
+
+## Read-topology guidance
+
+- Fine row reads trade mount/heap for sparse invalidation.
+- A coarse view-model read trades sparse precision for cheap mount and bulk replacement.
+- Chunked or visible-window reads are the useful middle for large mixed workloads.
+- Large oscillating read sets are suspect because whole-set reconciliation can become proportional to the current read count.
+- A pull-shaped subscription is worth a bounded experiment if it can give one invalidation unit and one retained read while preserving a declarative, colocated query. It must not grow a per-leaf ledger.
+
+Xray should expose boundary count, reads per boundary, fan-out, and read-set churn so this is observable rather than folklore.
+
+## Boundary substrate and hook budget
+
+The normal shell already spends its two hooks on frame context and the external-store bridge. Optional facilities cannot add another hook to every boundary. The underlying collector can currently ride materially different subscription substrates; select that substrate before the ABI freezes using correctness, retained heap, clock, teardown, and migration evidence. It is an architectural choice, not an inherited implementation detail.
+
+## Budget protocol
+
+The primary [performance contract](../specification.md#6-performance-contract) owns every numeric threshold; the [evidence baseline](evidence-baseline.md) owns measured facts. Hot-path decisions apply them as follows:
+
+- Calibrate on named low- and mid-tier hardware in Chromium, Firefox, and WebKit.
+- Compare the same behavior, read shape, host crossing and DOM result, or state every deliberate capability difference.
+- Attribute body, lowering, React, commit and paint pressure before selecting a remedy.
+- Require topology changes and native islands to preserve DOM/intent, focus/selection, frame, hydration and cleanup contracts.
+- Keep an escape only when it clears the primary's benefit threshold; otherwise remove it.
+- Use deterministic blockers for correctness, scaling, residue and production erasure; distributional clocks/heaps use pinned interleaved runs with explicit estimands, populations and sabotage controls.
+- Refuse a verdict from an unhealthy instrument and keep comparator, witness, hardware, revision and confidence attached.
+
+## Xray-guided workflow
+
+1. Name a slow interaction and reproduce it with a stable script.
+2. Correlate event, changed reads, invalidated boundaries, body work, commit, and paint.
+3. Tune read and boundary topology first.
+4. If codec work dominates, compare direct React output in the same boundary.
+5. If hooks, reconciliation, vendor behavior, or high-rate local work dominate, isolate a named native component and choose Hicasso-native, UIx, or raw React according to its needs.
+6. Run behavioral parity, focus/selection, frame routing, SSR/hydration, cleanup, and performance scripts.
+7. Keep the escape only if it clears a declared budget.
+
+## Decisive experiments
+
+- Run the canonical native-tier acceptance checklist as one controlled publication protocol rather than separate partial parity programmes.
+- Direct-return delta: identical body, reads, data, and DOM with Hiccup output versus direct native React output.
+- Topology tournament: fine, coarse, chunked/windowed, and native-virtualized tables at 100, 300, and 1,000 rows across sparse, bulk, reorder, and controlled-edit operations.
+- Host identity: generated intent, stable handler, and native island against a memoized retaining host, including delayed callbacks and frame replacement.
+- Collector substrate: like-for-like correctness, clock, retained heap, teardown, and migration comparison before runtime ABI freeze.
+- One complete causal Xray slice with mutation-tested links and production erasure.
+
+## Explicit refusals
+
+No `:fast` flag, compiler fork, automatic promotion, profiling-dependent semantics, per-boundary callback-cell table, second state owner, or performance claim based only on render timing. Keep context-based frame propagation unless a materially larger measured result justifies weakening native-island composition.

--- a/docs/design/hicasso/product/lanes/left-field-ideas.md
+++ b/docs/design/hicasso/product/lanes/left-field-ideas.md
@@ -1,0 +1,73 @@
+# Left-field ideas
+
+[`../synth-codex.md`](../specification.md#11-innovation-portfolio) owns portfolio status and delivery order. This file defines the deciding protocols and kill conditions.
+
+## Product workflow
+
+Close the loop around the chosen architecture:
+
+`observe a real occurrence -> attribute the pressure -> recommend the smallest remedy -> optionally extract one same-root native island -> prove parity and improvement`
+
+This makes rare native React an actual product workflow. Most more radical runtime ideas recreate the standing dependency graph, scheduler, or second semantics that Hicasso is designed to avoid.
+
+## Workflow protocol details
+
+### Xray diagnosis plus manual same-root extraction
+
+Do more than sort render durations. Classify whether pressure comes from application computation, read topology, Hiccup/prop lowering, React reconciliation, or DOM/layout. Native extraction is recommended only for the classes it can improve. The scaffold chooses the smallest credible route—direct `n/$`, a named Hicasso-native component, UIx, or a foreign host—and includes frame-aware reads, host declaration where needed, source/performance identity, DOM/intent parity, lifecycle tests and before/after evidence.
+
+The native component remains in the same React tree and consumes the shared frame through public `n/use-frame`/`n/use-sub`, the equivalent UIx hooks, or the raw host bridge. UIx remains optional. Reject an extraction that needs another root/state owner, loses boundary-level diagnostics, or does not materially improve the named interaction.
+
+### React-concurrency compatibility seam
+
+Keep `useSyncExternalStore` behind an internal bridge and continuously test transitions, Suspense, Activity, hydration and frame retargeting. Do not invent a transition-tagged intent system or async store that React's public contract cannot support.
+
+## Experiment protocols
+
+### Capability receipts
+
+Report mechanical attempt facts rather than pretend to allocate cost: self time, body/fence runs, read calls, unique reads, cache hit, codec nodes/props/foreign/intents. Distinguish attempts from commits; omit raw queries, values and text by default; prove attached-only allocation and production erasure. Kill the idea if instrumentation changes rankings or requires production retention.
+
+### Counterfactual topology advice
+
+Use committed, redacted read edges and event windows to show membership savings, set stability, co-change frequency and likely coarse/fine/chunked trade-offs. Calibrate blindly against real implementations under correlated and independent changes. Retain a factual worksheet if outcome prediction is unreliable.
+
+### Pull-shaped reads
+
+Compare one declarative pull subscription with fine reads and a hand-written coarse view-model on the same form/list witness under correlated and independent churn. A pull is one invalidation unit; it cannot build a per-leaf dependency ledger. Graduate only if it approaches the coarse arm's clock/heap while materially preserving the local declaration ergonomics, with no independent-churn regression that makes the hand-coarse answer plainly better.
+
+### Schema-driven state and intent generation
+
+After the semantic assertion harness exists, derive bounded generators from the repository's registered schemas. Generate valid app-db states and intent sequences, assert domain invariants, stable complaints, keyed/accessible structure and renderability, and require useful shrinking. Run the first spike on the ordinary product witness. Graduate only if it finds a real defect or refusal gap that the hand-written corpus missed; otherwise retain the schemas and hand witnesses without a generator product.
+
+### AI-pair runtime queries
+
+Expose the smallest read-only questions through the existing Xray/Pair projection: mounted views, current reads, recent approved intents, complaints, source/DOM ownership and explain-render. Add no second graph or history buffer, apply the existing privacy projector, and return explicit loss/opacity. The deciding witness is a real diagnosis completed materially faster than source/log inspection. Protocol transport, including MCP, is an edge adapter over the versioned evidence schema rather than a new runtime subsystem.
+
+### Migration shadowing
+
+Mount the Reagent reference and Hicasso candidate against isolated copies of the same seeded frame, drive the same intent script, and compare canonical DOM plus intent streams at checkpoints. A mutation must make the comparison fail at the correct node or intent. Graduate when a representative real view can be set up in under ten minutes and the report distinguishes mechanical differences from explicit migration refusals.
+
+### Replayable view capsules
+
+After the restricted semantic harness exists, allow one-shot capture of a committed view's ordered read values, approved props, intents, semantic expectation, build identity and opacity/redaction record. Finalize only the render token whose layout effect commits. Never continuously retain raw values or snapshot all app-db. A capsule is a regression seed, not semantic proof.
+
+### Shared read-set notification groups
+
+Identical `(frame, ordered-read-set)` boundaries may be able to share cell membership and fan notification out, reducing approximately `B x R` memberships toward `R + B`. Census first. Benchmark singleton, shared and distinct-query populations, then stress retry, set replacement, notification cleanup, HMR, reincarnation and multiple roots. Stop if fewer than roughly 10% of real memberships coalesce or the common case regresses.
+
+### Codec shape planning
+
+Only profile-trigger this if classification/lowering exceeds 10% of hot-boundary self time. Require a meaningful codec-slice and whole-boundary improvement with bounded cache growth; current caches and the JavaScript engine may already capture the available win.
+
+### Read-free shell declaration
+
+Census real boundaries before implementation. A declaration may skip only the read/external-store portion that can be proven absent; it is not a K3 per-read lever, compiler mode, or hydration-free island. Development must execute a loud source-located guard if the body reads, and the optimized boundary must preserve props, context, component identity, HMR, SSR/hydration and intentional remount behavior. Graduate only when the population and whole-application saving are material and the do-nothing/read-free controls remain green.
+
+## Guardrails and rejects
+
+- A pull query may move traversal/equality/allocation rather than remove work; compare correlated and independent-churn cases and forbid a per-leaf ledger.
+- React `<Profiler>` is an explicitly perturbing deep-diagnostic mode, not a wrapper around every boundary.
+- Read-free does not mean hydration-free.
+- Admit no native helper outside the [native-boundary law](design-laws.md#native-boundary) and provisional public grammar unless a named witness justifies changing those owners and the canonical checklist is updated first.
+- Reject signals/Adapton as a replacement reactive graph, compiled/JIT bodies, automatic observed-read-free specialization, worker/WASM interpretation, global element memoization, and a new generic causal/MCP subsystem parallel to Xray/Pair.

--- a/docs/design/hicasso/product/lanes/react-compatibility-notes.md
+++ b/docs/design/hicasso/product/lanes/react-compatibility-notes.md
@@ -1,0 +1,90 @@
+# React compatibility contract
+
+These are core compatibility obligations for Hicasso, not reasons to reproduce React APIs in Hicasso. React-library interop and SSR/hydration correctness apply whether or not an application deploys the optional Node service. Recheck them against the supported React version at each release.
+
+## Native boundary contract
+
+The [native-boundary design law](design-laws.md#native-boundary) owns semantics and dependency rules. This lane owns only how those surfaces participate in React server rendering, hydration, Activity, external stores, errors, and supported-version tests. The [canonical native-tier checklist](hot-path-architecture.md#canonical-native-tier-acceptance-checklist) joins the resulting matrix to the rest of the publication evidence.
+
+## Public-surface SSR/hydration matrix
+
+This is the canonical matrix for the core server/hydration contract. Phase 0 assigns every proposed public surface a unique inventory id and one of two v0 policies:
+
+- **Render**: produce deterministic React server output from an immutable request frame/snapshot and support matching hydration.
+- **Client-only**: refuse server use at the declaration source and name an explicit deterministic fallback or recovery. Returning silent `nil` is not a policy.
+
+Built-in Hicasso data surfaces default to Render. Opaque foreign components, portals, browser-only code, and unclassified native component heads default to Client-only until a declaration and witness earn Render. This default keeps the initial matrix bounded without weakening the requirement that every surface has a disposition.
+
+| Surface class | v0 default | Required server witness | Required hydration or refusal witness |
+|---|---|---|---|
+| Intrinsic/fragment Hiccup | Render | Deterministic HTML/SVG bytes, adjacent text, escaped content and stable prop naming | Matching hydrate, deliberate mismatch attribution, unmount cleanup |
+| `h/defview` with `h/sub` | Render | Immutable request frame/snapshot, dynamic and conditional reads, no cross-request state | Matching state/snapshot, no duplicate acquisition, two roots, teardown |
+| Controlled DOM fields | Render | Value/checked/selection-relevant attributes for every supported control type | Echo, revision, autofill/reset, composition and mismatch repair without lost input |
+| `h/error-boundary` | Render | Successful child output and a thrown server render routed through React's server error channel; React [does not make client error boundaries catch server rendering errors](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) | Matching hydrate plus caught, uncaught and recoverable client errors attributed to source |
+| Root/frame provider and outward bridge | Render | Stable frame identity and request isolation without a process-global adoption window | Matching `identifierPrefix`, two overlapping roots, frame isolation and exact cleanup |
+| Declared `h/defhost`, ReactNode slots, render props and `h/as-element` | Client-only until the host declaration selects Render | For Render: provider/slot/callback output, errors and all declared ReactNode positions | For Render: matching slot/callback hydration; otherwise source refusal plus deterministic fallback and client activation |
+| Portal helper | Client-only | Source refusal with the target and recovery named; an explicit server fallback if the caller supplies one; [`createPortal`](https://react.dev/reference/react-dom/createPortal) requires an existing DOM target | Client mount, target change, event propagation, focus restore and cleanup; no hydration claim for absent portal bytes |
+| Raw React element or opaque JavaScript/UIx component | Client-only until classified by an enclosing view/host policy | For Render: exact component revision, deterministic bytes and error attribution | For Render: matching hydrate and cleanup; otherwise enclosing-boundary refusal/fallback |
+| Intrinsic `n/$` form | Render | Macro/client/server prop-name parity, children, keys, refs, SVG and custom elements | Matching hydrate, mismatch attribution and component identity |
+| `n/defcomponent`, component-headed `n/$`, memo/lazy/ref helpers | Client-only until the component declaration selects Render | For Render: one ABI through every helper, native-hook server snapshot and deterministic bytes | For Render: matching hydrate, HMR/identity and cleanup; otherwise source refusal/fallback |
+| Lazy/Suspense/error boundary | Client-only until all server branches and the selected React server API are declared | For Render: resolved, pending, fallback and error behavior on the chosen non-streaming or streaming API | Matching resolved/fallback hydration, retry, error attribution and no hidden client remount |
+| Optional module or resource-demand boundary | Client-only until its module contract selects Render | For Render: allowlisted request state, deterministic pending/data/error output and no render-time acquisition | Matching hydrate, no duplicate demand/fetch, supersession and release on teardown |
+
+Every Render row runs the common hydration states: matching content, deliberate mismatch with source attribution, two simultaneous roots with stable `identifierPrefix`, and unmount cleanup. Rows that read or demand resources also prove no duplicate acquisition. Every Client-only row proves source-located refusal, deterministic fallback/recovery, and client activation without pretending that omitted server bytes were hydrated. Phase 4 closes only when every Phase 0 inventory id points to the applicable green row; adding a public surface adds an inventory id and cannot silently enlarge an untracked matrix.
+
+## Activity lifecycle witness
+
+React 19.2's [`<Activity>`](https://react.dev/reference/react/Activity) hides a subtree while retaining its UI state. When hidden, React cleans up effects and active subscriptions; hidden children may still render at lower priority, and effects/subscriptions are recreated on reveal.
+
+Hicasso therefore needs a real Activity matrix:
+
+- hide releases committed subscription ownership without destroying re-frame state;
+- hidden work does not publish speculative read sets;
+- reveal reacquires the current read set and corrects before visible paint;
+- conditional reads changed while hidden do not resurrect stale membership;
+- intents retained before hide obey the documented callback/frame-incarnation rule;
+- Xray distinguishes hidden-retained, visible-connected, and unmounted rather than collapsing them.
+
+Activity should be used through native React construction—Hicasso-native, UIx, or a `defhost` declaration. Hicasso needs compatibility, not an Activity DSL.
+
+## External-store transitions have a real ceiling
+
+React's [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore) documentation states that external-store mutations cannot be marked as non-blocking Transition updates. React may restart a transition as blocking when the snapshot changes, and it discourages suspending from values read from an external store because an update can replace visible content with a Suspense fallback.
+
+Consequences:
+
+- do not advertise re-frame commits as transition-aware or non-blocking;
+- test that Hicasso remains tear-free under `startTransition`, but document the blocking fallback honestly;
+- do not make `sub`-driven `lazy`/promise selection the default resource-loading pattern;
+- prefer route/resource preparation, explicit pending state, preloading, or a native React Suspense island when that UX is required;
+- reconsider external-store concurrency only when a stable API belongs to a supported React release; it is not a product dependency.
+
+## Hydration is a root-level diagnostic contract
+
+[`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot) requires matching server/client content, supports `identifierPrefix` for multiple roots, and exposes `onCaughtError`, `onUncaughtError`, and `onRecoverableError` with component stacks.
+
+The Hicasso root and Xray design should therefore include:
+
+- stable, matching `identifierPrefix` across server and client;
+- per-root attribution for caught, uncaught, and recoverable errors;
+- no process-global hydration adoption window;
+- mismatch reports joined to Hicasso view identity/source and host policy;
+- multiple simultaneous hydrated roots as a required witness.
+
+## Server rendering should hide topology behind one product contract
+
+React documents [`renderToString`](https://react.dev/reference/react-dom/server/renderToString) as non-streaming with limited Suspense support, and recommends [`renderToPipeableStream`](https://react.dev/reference/react-dom/server/renderToPipeableStream) for Node streaming.
+
+The first Hicasso server product can remain bounded and non-streaming if that meets its caller, but the JVM↔Node protocol should not bake “one complete string” into every layer. Keep entrypoint, immutable allowlisted state snapshot, build identity, error attribution, cancellation, and response framing separable so a later streaming caller does not require a second rendering semantics. Start with one in-flight render per isolate, bounded concurrency, timeout plus hard termination, and a pre-registered latency envelope from the activating caller; relax isolation only after a dedicated witness.
+
+## Testing must not depend on React's retired test renderer
+
+React has [deprecated `react-test-renderer`](https://react.dev/warnings/react-test-renderer). Hicasso's headless tests should remain pure tests of authored Hiccup, read resolution, intent data, and codec rules; host truth belongs in mounted DOM/browser tests using React's supported `act` path. There should be no shallow renderer or fake hooks runtime.
+
+## Effect Events are not a stable-callback primitive
+
+[`useEffectEvent`](https://react.dev/reference/react/useEffectEvent) is for callbacks called only from effects; its returned function intentionally changes identity and may not be passed to components. It is useful inside native React host components, whether Hicasso-native, UIx, or handwritten, not as a replacement for Hicasso intent callbacks or a universal stable-event proxy.
+
+## Experimental features stay at the host edge
+
+[`<ViewTransition>`](https://react.dev/reference/react/ViewTransition) remains Canary/Experimental. Hicasso should prove that a hosted ViewTransition can contain Hicasso children without ownership or controlled-input breakage, but should not expose a core wrapper until the API is stable and repeated application demand exists.

--- a/docs/design/hicasso/product/lanes/testing-xray.md
+++ b/docs/design/hicasso/product/lanes/testing-xray.md
@@ -1,0 +1,77 @@
+# Testing and Xray product contract
+
+## Recommendation
+
+Testing and diagnostics are product surfaces, not documentation afterthoughts. Ship a supported `re-frame.hicasso.test` namespace and a dev-only adapter-neutral evidence provider. Do not expose the raw internal sink or invent evidence the interpreted runtime cannot know.
+
+## Testing ladder
+
+| Tier | Scope | Correct tool |
+|---|---|---|
+| L0 | event handlers, subscriptions, state transitions | pure CLJ/CLJS tests |
+| L1 | codecs, intents, controlled-field/presence laws, native-form expansion and ABI helpers | pure data/property and macro-expansion tests |
+| L2 | hook-free Hicasso bodies and owned Hicasso children | restricted semantic-tree harness |
+| L3 | React lifecycle, hooks, context, refs, foreign hosts and native components | mounted React DOM tests |
+| L4 | IME, caret, focus, hydration, layout, performance | Chromium, Firefox, and WebKit witnesses |
+
+The L2 harness is not a JVM renderer or alternate execution semantics. It invokes the stored view body under a discardable subscription resolver and returns a versioned semantic tree with small `find`, `attrs`, `text`, and `intents` helpers.
+
+Before defining another schema, audit the existing versioned structural-tree and Spec-011 assertion utilities and reuse compatible data/helpers only; do not inherit another renderer, SSR authority, or simulated React lifecycle. Hooks, `n/$` results, native components, and raw/foreign hosts are opaque and refuse with a pointer to L3. Missing fixtures refuse; they are never replaced with fake React dispatchers.
+
+The mounted facade should provide isolated-frame `mount!`, `hydrate!`, `render!`, `dispatch-and-settle!`, `settle!`, `unmount!`, and `assert-clean!`. It should interoperate with Testing Library and user-event instead of introducing another selector language. Cleanup unmounts, waits for Hicasso quiescence, compares residue with the pre-mount baseline, and only then resets.
+
+Every witness names the equality it proves. Authored-data equality, semantic assertion-tree equality, canonical DOM, intent streams, React server bytes, and hydrated browser behavior are distinct claims. A normalized tree is never a proxy for hydration-wire parity, and L2 never claims React lifecycle parity.
+
+## Required browser and lifecycle witnesses
+
+- StrictMode, retry, suspension, and genuinely abandoned renders.
+- Conditional and changing read sets, keyed identity, and multiple roots/frames.
+- Controlled input echo, rejection, normalization, revision reset, selection, and real IME composition.
+- Context, refs, errors, foreign hooks, retained callbacks, HMR, and same-id frame replacement.
+- The [canonical native-tier checklist](hot-path-architecture.md#canonical-native-tier-acceptance-checklist), using L1 expansion/property tests plus L3/L4 React and browser witnesses; this lane supplies test mechanisms but does not redefine checklist membership.
+- Server bytes, hydration, adjacent text, `useId` prefixes, recoverable mismatch reporting, and two hydrating roots.
+- React Activity hide/reveal: subscriptions and effects stop while hidden, then re-establish correctly on reveal.
+- Exact post-quiescence residue rather than reset-masked cleanliness.
+
+## Evidence contract
+
+Xray and the AI pair consume the same versioned projection. Every envelope states schema, producer, read operation, scope, basis, completeness, and loss. Unknown is never encoded as an empty collection.
+
+Useful basis/loss states include:
+
+- `:opaque` / `:no-static-analysis` for facts an interpreted body cannot enumerate ahead of execution;
+- `:host-opaque` for raw React internals;
+- `:cap` for retention-window loss;
+- `:uncorrelated` when an event-to-render relationship cannot be established.
+
+Project current registrations from state Hicasso already retains and use the existing trace ring for history. Do not add a universal accumulator, universal occurrence identity, or second history buffer merely to make a panel look complete. A named operation such as mount/unmount correlation or capsule capture may allocate bounded, commit-owned identity. Production returns nil and contains no evidence, schema, or source sentinels.
+
+Preserve the live Xray consumer contract while replacing producer semantics behind the adapter-neutral schema. Move every primary Xray/Story/Pair consumer off the experimental re-frame.ui/Freehand producer before those donor surfaces are disposed; fixture-only integrations may remain as named compatibility evidence, not an architecture foundation.
+
+## Questions Xray must answer
+
+1. What Hicasso views ran or committed in this epoch?
+2. Which changed subscriptions intersected the current reads?
+3. Did props, context, a read-set change, or a host boundary trigger the work?
+4. Where are read fan-out, read-set churn, render storms, retries, and abandoned work concentrated?
+5. Is time in the body, Hiccup lowering, React commit, layout, or paint?
+6. Which boundary is a credible topology-tuning or native-island candidate, and is direct `n/$`, a named Hicasso-native component, UIx, or a foreign host the smallest fitting route?
+7. What is unknown, capped, opaque, or uncorrelated?
+
+Render timing is not commit evidence. Correlate event, subscription recomputation, boundary invalidation, body run, commit, and paint when the instruments support it; label every missing link. Xray owns bounded retention. React DevTools and browser performance tools remain the authority for React commits and paint.
+
+Deterministic gates block ordinary changes. Distributional performance evidence uses pinned interleaved runs. Each instrument states its estimand and exercised population, carries a positive/sabotage control, and refuses to publish when its validity check fails.
+
+Instrument qualification precedes the product row. The qualification states the failure class each control can detect, pins the estimator before candidate data is opened, and proves the population is non-empty. A benchmark implementation and its eligibility check land together; an invalid instrument produces no flattering fallback number.
+
+Production-erasure tests use unique sentinels and a reachable positive-control sentinel. Drift-sensitive browser measurements carry an interleaved same-run floor/control.
+
+## Failure and privacy contract
+
+Every testing refusal is structured and source-located. Query results never leave the process unless an explicitly authorized consumer requests them, and query arguments pass through the existing privacy projector. Sink failures are contained. Performance collection is independently gated and off by default.
+
+Optional modules contribute evidence only while installed and used. Forms, overlays, presence, resources, and native islands may add their own bounded projections—for example draft ownership, active top-layer region, transition posture, resource demand, or native read edges—but none adds a universal accumulator to ordinary Hicasso.
+
+## Acceptance
+
+Release requires positive and sabotaged negative controls for semantic trees and intents; dispatch-to-settled-DOM; lifecycle abandonment; cleanup residue; controlled-input browsers; the canonical SSR/hydration matrix; the canonical native-tier checklist; schema mismatch; cap/opaque/uncorrelated displays; privacy redaction; byte-equivalent Xray/Pair projections; and production erasure.

--- a/docs/design/hicasso/product/lanes/use-cases.md
+++ b/docs/design/hicasso/product/lanes/use-cases.md
@@ -1,0 +1,26 @@
+# Motivating use cases
+
+| Job | Design pressure | Hicasso consequence |
+|---|---|---|
+| Ordinary forms, lists, branches, and keyed collections | Closed compiled grammars impose extraction and syntax cliffs; ordinary Clojure composition is valuable. | Preserve one interpreted mode, helpers, loops, and ambient reads. |
+| Dynamic and conditional reads | Compile-indexed sites give attribution but cannot express the desired authoring model. | Keep read-anywhere during direct synchronous boundary execution; solve collection safely at runtime. |
+| Controlled input and IME | This defect-prone behavior needs a narrow framework law. | Keep the centralized door, but require Chromium, Firefox, and WebKit plus broader control/hydration coverage and published per-keystroke mechanics. |
+| Ephemeral and host-private state | One application state needs pressure valves for drafts, revisions, composition, geometry, observers, and imperative handles. | Keep domain/workflow state in re-frame; put reusable control state in concern-named libraries and host-private facts in native React hosts. Do not add a generic Hicasso local-state DSL. |
+| React libraries and compound components | Access to the React ecosystem and same-root hot path is a core adapter requirement; a large host algebra is not. | Complete the core host/outward bridge with real vendors and apply the [native-boundary law](design-laws.md#native-boundary) plus its single acceptance checklist. |
+| Imperative SDKs | Ownership route and cleanup proof matter more than a neutral lifecycle DSL. | Use an ordinary Hicasso-native, UIx, or raw-React host component; publish recipes and adversarial cleanup tests first. |
+| Routing | A late-bound plain route-link works without reactive-boundary machinery. | Keep routing small and test browser behavior plus SSR output. |
+| Async resources and typeahead | Mounted demand is promising, but lifecycle machinery can create a second dependency ledger. | Spike only after root/commit ownership is sound; reuse committed read membership or kill the idea. |
+| Theming and parts | Tokens, CSS variables, root scope, and ordinary composition cover most needs. | Defer parts registries/tree rewriting until a component-library caller proves them necessary. |
+| Errors | React error regions are sufficient; expected failures remain data. | Ship a minimal wrapper, not a second exception model. |
+| SSR and hydration | Full React semantics imply a core React server/hydration contract; JVM structural equality is not wire equality. | Inventory every public surface under the [canonical SSR/hydration matrix](react-compatibility-notes.md#public-surface-ssrhydration-matrix). A bounded Node/React service starts only for a named caller; no JVM twin. |
+| Tooling and inspection | Committed/runtime evidence and static possibility are different facts. | Start with bounded lint and pure current-state projections for a named consumer. |
+| Large/bulk UI | Fixed per-boundary machinery can fail product economics; the current broad comparator is instrument-limited. | Qualified sparse/broad/reorder/edit evidence, retained heap, the boundary-shell disposition, abandonment and teardown are release gates. Warm allocation is not: publish no allocation claim until its fitted-series instrument qualifies. |
+| Reagent migration | Real conversions contain non-mechanical cases. | Build a reporter/linter and explicit refusal guidance before a rewriting codemod. |
+
+## Evidence scope
+
+The Hicasso census strongly supports data intents, controlled fields, loops/keys, route links, and read-at-point-of-use. It weakly represents refs, portals, foreign observers, and complex React integrations; rarity in one repository is not proof those jobs do not matter.
+
+Keep the census alive as a requirements mine: job, observed frequency, failure classes, home, owner, and executable witness. Frequency can justify syntax; a rare critical job normally earns a first-class escape or optional module. Every core proposal is compared with the smallest equivalent direct-React, Hicasso-native, or established-library control before it earns universal cost.
+
+The current dogfood screen is strong preference evidence for one ordinary list/form workload, not external adoption evidence. A full RealWorld-style application and one serious vendor integration are the next useful witnesses.

--- a/docs/design/hicasso/product/naming-ledger.md
+++ b/docs/design/hicasso/product/naming-ledger.md
@@ -1,0 +1,23 @@
+# Naming ledger — every naming question, one consolidation point
+
+**Rule**: nobody renames mid-flow; prototype names are used consistently everywhere; every naming question found by any bead is appended here as a row. The consolidation bead (rf2-hic-065) publishes the complete packet; its recommendations apply as defaults immediately; the operator's single sitting overrides rows asynchronously and rf2-hic-066 re-runs the sweep as a diff.
+
+| # | Current name | Candidate(s) | Recommendation | Status |
+|---|---|---|---|---|
+| 1 | `h/fn` | `h/handler` | `h/handler` (one invariant meaning; spec §4) | open |
+| 2 | `:&` merge key | remove; pure owned-wins merge helper/recipe | remove from grammar (spec §4 disposition) | open |
+| 3 | `h/reg-state` | remove from adaptor core; reconsider in forms | remove from core | open |
+| 4 | `subscribe-once` | internal/advanced | internal until a caller proves `sub` inadequate | open |
+| 5 | presence namespace | optional motion namespace name | `re-frame.hicasso.motion` (provisional) | open |
+| 6 | route-link home | routing-integration namespace name | `re-frame.hicasso.routing` (provisional) | open |
+| 7 | `n/$` | keep | keep (ruled surface) | open |
+| 8 | `n/props` | keep | keep (normative grammar) | open |
+| 9 | `n/defcomponent` | keep | keep | open |
+| 10 | `n/use-sub` / `n/use-frame` | keep | keep | open |
+| 11 | `h/as-element` | keep | keep | open |
+| 12 | `h/error-boundary` | keep | keep | open |
+| 13 | root lifecycle | `mount!` `hydrate!` `render!` `unmount!` | keep the four | open |
+| 14 | package/artifact name | `implementation/hicasso`, artifact name TBD | `re-frame.hicasso` (provisional) | open |
+| 15 | test-kit namespace | `re-frame.hicasso.test` | keep | open |
+| 16 | forms module ns | `re-frame.hicasso.forms` | provisional | open |
+| 17 | overlay module ns | `re-frame.hicasso.overlay` | provisional | open |

--- a/docs/design/hicasso/product/specification.md
+++ b/docs/design/hicasso/product/specification.md
@@ -1,0 +1,494 @@
+# Hicasso: native re-frame2 adapter
+
+## Product analysis, design review, and action specification
+
+Hicasso is the selected native re-frame2 view adapter. Its default is interpreted Hiccup with ambient re-frame2 reads, data-first events, React-correct controlled fields, and ordinary Clojure composition. When a measured part of an application needs native React performance or semantics, that part drops through an explicit React boundary while retaining the same root, frame context, and state owner. Hicasso supplies a small optional native namespace for this purpose; UIx and raw React/JavaScript components remain supported alternative authoring routes rather than required dependencies.
+
+This living product specification defines what Hicasso should become, how it is judged, and the work required to ship it. The companion [decision brief](decision-brief.md) owns the forensic scoreboard, the selected-direction record, the scoped amendment, the K3 disposition, and the kill rules; this document assumes that direction and turns it into a product contract.
+
+> **Decision:** Hicasso is the selected product direction; Phase 0 prepares its measured capability price for explicit ratification without treating the registered gate as passed or silently reopening adapter selection.  
+> **Current state:** the implementation is a benchmark prototype, not an installable product.  
+> **Authority of this document:** normative product target, proposed budgets, and action specification; the decision brief owns selected-direction and sitting decisions, while the evidence baseline owns adjudicated measurements. API spellings remain provisional until their named witnesses pass.
+
+The intended outcome is not “the fastest adapter on every synthetic row.” It is the best overall re-frame2 adapter:
+
+- the least ceremony for ordinary application code;
+- correct under modern React and browser behavior;
+- complete across real SPA use cases;
+- unusually easy to test and diagnose;
+- fast enough by declared user-visible and comparative budgets;
+- able to recover direct React performance in the exceptional hot regions;
+- installable, documented, supportable, and safe to adopt.
+
+The expected native-React share may be 0%, 1%, or 2% of source in a typical application. That is an observed outcome, never a quota. A small amount of source may perform most of the work.
+
+## 1. Product shape
+
+Hicasso has five cooperating surfaces. Only the interpreted core is unavoidable. The React bridge and SSR/hydration contracts are core product capabilities, but their runtime cost is paid only when an application crosses or exercises them.
+
+| Surface | Purpose | Cost rule |
+|---|---|---|
+| Interpreted core | Views, reads, Hiccup lowering, event intents, controlled fields, roots, SSR/hydration semantics | Small fixed boundary shell; variable cost follows actual reads and markup |
+| React bridge | Declared hosts, raw elements, providers, refs, render props, outward embedding, server policies | Paid only at the crossing |
+| Native hot path | Direct React output or a named native island, authored through Hicasso's optional native namespace, UIx, or raw React/JavaScript | Paid only by the selected region; absent when the namespace is unused |
+| Optional libraries | Forms, overlays, presence, routing integration, deployable Node/React SSR service | Zero reachable production code when absent |
+| Developer products | Testing, Xray, lint, migration, AI-readable evidence | Development-only; erased from production |
+
+The core is not a general React wrapper language, component library, local-state framework, compiler, or renderer. React-specific work stays React-specific, application state remains in re-frame2, and the adapter owns only the semantics that remove repeated defects or ceremony. The exact native-tier semantic contract has one owner: the [native-boundary design law](lanes/design-laws.md#native-boundary).
+
+React-library interop and SSR/hydration correctness are core product goals. Every public view, host, root, resource boundary, and native escape needs defined server and hydration behavior or a source-located refusal. “Optional SSR” refers only to the deployable Node service and its operational machinery; a client-only application does not ship that service.
+
+## 2. What “better” means
+
+The priorities are ordered. A lower item cannot buy a failure in a higher one.
+
+1. **Correctness.** No stale reads, cross-frame dispatch, leaked ownership, hydration corruption, lost input, or speculative-render side effects.
+2. **Ergonomics.** The ordinary screen is Hiccup, local reads, and event data. Helpers are ordinary functions. Special forms are rare and stable.
+3. **Coverage.** Every motivating use case has a clean default, a supported optional module, a named React escape, or a didactic refusal with recovery.
+4. **Testing and diagnosis.** Most application logic is cheap to test as data; React and browser laws use real React and real browsers; Xray explains work without pretending to know unavailable facts.
+5. **Performance.** Ordinary interactions meet user-visible budgets. Comparative regressions are bounded. A local native island can recover the exceptional case.
+6. **Product readiness.** A clean consumer can install, compile, hot-reload, production-build, test, diagnose, upgrade, and remove the adapter without benchmark-tree knowledge.
+
+The current [evidence baseline](lanes/evidence-baseline.md) supports the direction but does not yet constitute a product release:
+
+- The canonical representative cold-mount row decisively misses the registered `1.10x` K1 gate. The [pinned evidence](lanes/evidence-baseline.md#pinned-economic-evidence) owns the point estimates, intervals, sample counts, witness, and estimator context. The product implication is a priced capability decision, not a retrospective pass; much of the difference is the witness's richer read topology rather than Hiccup walking alone.
+- On the proved-same dogfood screen, Hicasso expressed the same DOM and intent behavior in 47 lines versus UIx's 72, with eight event positions as data rather than eight closures and no threaded subscription values. The centralized IME law prevents a defect present in naïve direct-React handling.
+- Hicasso's per-read retained cost is below its UIx parent on the measured row, but the read-free boundary shell is red against its registered paper-fail line and is a Phase 1 remediation gate; the three K3 scoreboards remain non-substitutable.
+- Interpreted lowering is not the dominant general defect; read topology, boundary count, React work, and host behavior often matter more.
+- Controlled input behavior is strong in Chromium, but Firefox, WebKit, multi-root, abandonment, reincarnation, HMR, and React lifecycle matrices remain release work.
+- The collector can currently sit over materially different underlying subscription substrates; that choice changes retained cost enough that it must be adjudicated before the runtime ABI freezes.
+- The shared re-frame2 frame context already makes mixed Hicasso/native-React subtrees feasible without a second state system; UIx is one demonstrated producer of those native components.
+
+Performance evidence always names the witness, comparator, hardware, browser, commit, instrument, and confidence. Numbers from different instruments do not silently pool.
+
+### 2.1 Use-case compass
+
+Maintain a living requirements mine: application job, observed frequency, failure modes, intended home, and executable witness. Frequent ordinary jobs justify syntax; rare but critical jobs justify an excellent host escape or optional module. Absence from a census is evidence against universal syntax and standing cost, not evidence that the job is unimportant.
+
+A feature enters core only when it removes repeated ceremony or a centralized defect class, has at least one paying witness, adds no unexplained standing boundary cost, and beats the smallest equivalent direct-React, Hicasso-native, or established-library alternative. Optional modules need a named consumer and zero reachability when absent. Recipes graduate to APIs only after repetition demonstrates that prose is inadequate.
+
+## 3. Architecture laws
+
+### 3.1 One language and one state owner
+
+There is one ordinary Hicasso semantics: interpreted Hiccup. There is no `:fast` flag, compiled body, alternate renderer, automatic specialization, or profile-dependent meaning. The explicit native language is governed by the [native-boundary design law](lanes/design-laws.md#native-boundary); it never changes the meaning of Hiccup.
+
+Application state has one owner: re-frame2. A host may use local React state for host-private motion, focus, transient editing mechanics, or vendor integration, but not as an invisible duplicate of application state.
+
+The pressure valves are named. Durable or application-visible state—including drafts that affect validation, navigation, replay, or collaboration—uses an explicit re-frame2 address, normally through an optional forms/application pattern. High-frequency state that exists only to operate a native widget may remain inside that host and is diagnostic-opaque by contract. DOM-owned uncontrolled state is an explicit interop choice, never a hidden substitute for application state. No ratom-like second model is introduced.
+
+### 3.2 React owns React facts
+
+React owns component identity, hooks, refs, effects, errors, context, concurrency, Suspense, Activity, hydration, and commit. Hicasso uses React's public contracts rather than simulating them.
+
+Render is speculative. It may retry or disappear. Render probes reads but acquires no durable ownership and publishes no committed evidence. Commit reconciles the selected read set. Abandoned renders leave no subscriptions or diagnostic records. Teardown is exact and testable.
+
+### 3.3 Dynamic composition is a feature
+
+Reads may occur in branches, loops, and ordinary synchronous helpers. Runtime-selected Hiccup and Clojure data transformations remain legal. This is a deliberate ergonomic advantage, not a temporary lack of compiler analysis.
+
+The boundary is equally clear: a read deferred through a callback, promise, timer, lazy sequence, or other escaped extent refuses with source and recovery. Hicasso must never guess which render owns a deferred read.
+
+### 3.4 Capability pays rent
+
+A facility used by few boundaries must not add standing machinery to all boundaries. Optional libraries and the native namespace are separately reachable and absent from a production bundle that does not use them. Diagnostics project facts already retained by the runtime before they ask for more retention. Stable callback machinery, read ledgers, static manifests, and lifecycle histories require a measured caller before they exist.
+
+The ordinary boundary's context plus external-store hooks consume the current two-hook budget. Optional capabilities may not add hooks to every boundary. Freeing or replacing one requires its own correctness and whole-shell measurement; a feature cannot quietly spend a third hook.
+
+Measure the do-nothing and read-free boundary whenever the shell changes. Standing cost is the first budget; Hiccup lowering is the second.
+
+The native tier must satisfy the shared-substrate and zero-rent clauses of the [native-boundary design law](lanes/design-laws.md#native-boundary). The [canonical native-tier checklist](lanes/hot-path-architecture.md#canonical-native-tier-acceptance-checklist) decides whether those clauses are proved; no paraphrased local checklist can waive them.
+
+### 3.5 Data by default, functions when the contract is executable
+
+Markup and ordinary event intent are data. An explicit handler form covers value-first or calculated events. Ordinary functions cross host boundaries unchanged when a JavaScript API genuinely expects executable behavior. Position must not silently change the meaning of the same function form.
+
+### 3.6 Loud, stable failure
+
+Every refusal has a stable error id, source coordinate, view, frame where relevant, tree path or host-prop position, offending value, expected shape, and actionable recovery. Unknown diagnostic information is labelled unknown, opaque, capped, or uncorrelated; it is never rendered as an authoritative empty result.
+
+## 4. Target programming model
+
+These names are a provisional facade. Phase 0 freezes the laws and classifications; ordinary names freeze after the Phase 2 application witness, and host/hot-path names after Phase 3. The public model should be no larger than this without a witnessed need.
+
+| Surface | Contract |
+|---|---|
+| `h/defview` | Define a React/re-frame boundary; use it as a Hiccup head; direct Clojure invocation refuses |
+| `h/sub` | Return a subscription value during the direct synchronous body; legal in branches, loops, and ordinary helpers |
+| `h/handler` | Capture the current frame; run later; dispatch a returned event vector; ignore `nil` |
+| `h/defhost` | Declare a foreign React ABI, ReactNode-valued positions, and server policy once |
+| `h/as-element` | Explicitly lower Hiccup returned through a render prop or foreign callback |
+| attribute merge | Pure owned-wins helper or recipe for forwarded attributes; public only if a witness needs it |
+| root lifecycle | `mount!`, `hydrate!`, `render!`, and `unmount!` with idempotent handles |
+| server/hydration contract | A Render or Client-only policy for every inventory id under the canonical matrix; root-scoped identity, errors, adoption, and cleanup |
+| error region | A minimal `h/error-boundary` surface |
+
+The separately imported `re-frame.hicasso.native` namespace, conventionally aliased `n`, is the self-contained hot-path surface. Its complete provisional grammar and example live in the [public-language specification](lanes/ergonomics-api.md#optional-native-surface):
+
+| Surface | Contract |
+|---|---|
+| `n/$` | Compile one explicit element form to direct React construction; apply native React props and callback semantics, never Hicasso intent or control lowering |
+| `n/props` | Disambiguate a dynamic map or JavaScript object as the props operand without adding a React wrapper |
+| `n/defcomponent` | Define a top-level native function component with stable identity, source/HMR metadata, one props/children ABI, and an explicit server policy that defaults to Client-only |
+| `n/use-sub` | Read re-frame2 state through a native React hook under the current Hicasso frame |
+| `n/use-frame` | Obtain frame-locked operations from that same context |
+| native ABI helpers | Preserve the component contract through memoization, lazy loading, refs, and outward/inward embedding where raw React would otherwise erase the marker |
+
+React hooks remain React's surface and may be called directly inside `n/defcomponent`; Hicasso adds wrappers only after repeated native-island code proves material value. Phase 3 freezes the grammar and ABI only when every row of the canonical native-tier checklist passes.
+
+The interpreted grammar needs a fragment, raw React element escape, one props map, and a small reserved-data vocabulary: event value, checked value, explicit prevention, and controlled-value revision. Existing `rf/current-frame-id` and `rf/capture-frame` remain the frame doors; Hicasso should not duplicate them. Applications get one obvious `h` facade, with optional capabilities in clearly named namespaces and no alias sprawl; the facade and each optional namespace have bundle-reachability proofs.
+
+A typical view stays unsurprising:
+
+```clojure
+(h/defview article-row [{:keys [article-id]}]
+  (let [title (h/sub [:article/title article-id])
+        saving? (h/sub [:article/saving? article-id])]
+    [:article
+     [:h2 title]
+     [:button {:disabled saving?
+               :on-click [:article/delete article-id]}
+      "Delete"]]))
+```
+
+Ordinary `defn` helpers inline into their caller and donate any synchronous reads to the active boundary. A `defview` always creates identity and reactivity; it never changes into an inline function because it was called differently. Keys live in props, bodies are pure and re-runnable, and default prop equality follows the project's value-equality doctrine without mode flags.
+
+### 4.1 Events
+
+Literal vectors are the common path. Explicit prevention is uniform rather than special-cased for submit. `h/handler` has one meaning everywhere; ordinary `fn` is reserved for real callbacks, render props, and imperative APIs. Generated intent callbacks may be fresh per render. A narrow stable-event primitive is admitted only if a realistic retaining host demonstrates a material problem and the solution is safe across abandonment, frame reincarnation, and teardown.
+
+Keyboard maps apply only to keyboard props and must make IME composition behavior explicit. The framework should not hide the DOM event when a host API genuinely requires it; that is the function escape.
+
+### 4.2 Controlled fields
+
+Controlled inputs are a framework law because the defect class is too subtle and common to repeat in applications. The contract includes same-turn convergence, committed echo, rejection/normalization, caret and selection preservation, composition safety, and identity-preserving reset through an explicit revision.
+
+Forwarded attributes cannot replace owned value, checked, handler, key, or revision slots. Text, textarea, checkbox, radio, select, file input, contenteditable, blur-after-unmount, and async normalization each receive an explicit support or refusal policy.
+
+Buffered drafts, touched/submit-attempt validation, and mutation status belong in an optional forms layer or recipe, not the boundary shell.
+
+### 4.3 Host interop
+
+`defhost` is the primary seam for foreign components, providers, compound components, refs, callbacks retained by vendors, render props, and server policy. A host declaration identifies ReactNode-valued props such as a Suspense fallback or named content slot so Hiccup is lowered under the captured frame without deep-converting arbitrary data maps. Dev schemas and lint validate declared slots and prop positions; runtime conversion remains honest: normalize documented HTML-like slots, pass values by identity, and require explicit `clj->js` for JavaScript option objects.
+
+An ordinary render callback returns Hiccup only through `h/as-element`; this makes the conversion visible without a general callback taxonomy. Component and host definitions are minted at top level, never during render. Literal owned props win collisions by presence. Imperative integrations receive an idempotent acquire/release recipe and adversarial StrictMode/remount tests. A tiny optional portal helper lowers Hiccup into `createPortal`, preserves frame/context, documents React-tree event bubbling and target-change identity, and has an explicit client/server policy.
+
+Add a thin outward bridge so a native React parent—whether authored with `n/defcomponent`, UIx, or JavaScript—can render a minted Hicasso view under the existing frame provider without another root or exposure of the internal codec/`rfProps` ABI.
+
+## 5. Native React hot path
+
+The hot path is a gradient of explicit choices, all visible to tests and Xray.
+
+### Rung 1 — ordinary Hicasso
+
+Start here. Use interpreted Hiccup, local reads, event data, controlled semantics, structural tests, and full diagnostics.
+
+### Rung 2 — tune Hicasso topology
+
+Move boundaries around independently changing or expensive regions, inline helpers that always travel with their parent, stabilize keys and props, and select a read topology that fits the workload:
+
+- fine row reads for sparse independent updates;
+- a coarse view-model read for cheap mount and bulk replacement;
+- chunked or visible-window reads for large mixed workloads;
+- virtualization for collections whose DOM should not exist in full.
+
+Large oscillating read sets are suspect because whole-set reconciliation can become proportional to the current read count. Xray must show boundary count, reads per boundary, fan-out, and read-set churn.
+
+### Rung 3 — direct React output from a Hicasso boundary
+
+A `defview` may return an existing React element, normally constructed with `n/$` and equally able to come from UIx or raw React. The boundary keeps its frame, Hicasso reads, props, memo wrapper, and lifecycle but skips Hiccup lowering for that result. This is the narrowest escape when measurement says the codec/markup walk is material.
+
+Native React semantics begin inside the returned element. Hicasso event lowering, controlled-field normalization, structural assertions, and key diagnostics do not inspect it. Use native React props and callbacks. Hooks do not belong in the dynamically composed `defview` body; hook-intensive behavior belongs in a separately defined native component so hook order cannot depend on Hicasso data paths.
+
+### Rung 4 — named native React island
+
+A virtualizer, editor, drag/animation surface, canvas/WebGL coordinator, retained vendor widget, or hot hook-intensive collection becomes a named native component. The default self-contained route is `n/defcomponent` with `n/use-sub` and `n/use-frame`; UIx is an optional mature route, and a JavaScript/TypeScript component enters through the host bridge. Every route stays inside the same React root and shared re-frame2 frame context.
+
+The crossing has an explicit prop, child, callback, error, cleanup, diagnostics, and SSR contract. The native boundary is visible to Xray; its internal React subtree is opaque unless its re-frame reads pass through the supported native hooks. Repeated raw escapes graduate to a named host or island. A one-off raw element remains useful for migration and truly one-off interop, but it is not advertised as the performance tier.
+
+### Rung 5 — native screen
+
+An intrinsically React-first screen may implement its view tree with the Hicasso-native namespace, UIx, or JavaScript/TypeScript React under the single installed Hicasso adapter and shared frame provider. No second adapter, root, or state owner is installed for speed. A substantial React-first application may reasonably choose UIx rather than asking Hicasso's deliberately narrow native surface to grow into a second component framework. Phase 3 must prove subscription behavior, frame isolation, and cleanup parity across the mixed tree; an independent root remains an isolation choice only.
+
+### The working loop
+
+1. Reproduce a named slow interaction with a stable script.
+2. Use Xray to correlate event, changed reads, invalidated boundaries, body work, commit, and paint.
+3. Tune read and boundary topology.
+4. Compare direct React output if lowering dominates.
+5. Isolate a named native component if hooks, vendor behavior, reconciliation, or high-rate local work dominates; choose Hicasso-native, UIx, or raw React according to the component's actual needs.
+6. Re-run DOM/intent parity, focus/selection, frame routing, SSR/hydration, cleanup, and performance checks.
+7. Keep the escape only if it clears its declared benefit threshold.
+
+Diagnostics may recommend a boundary and scaffold a comparison. They never rewrite code or switch execution semantics at runtime.
+
+## 6. Performance contract
+
+“Good enough” is a product contract, not a euphemism. Unless already registered, the initial budgets below are proposals until Mike Thompson, acting as re-frame2 product operator, ratifies them against named low- and mid-tier reference hardware in Phase 0. The K1 ceiling has the additional sitting rule below.
+
+The registered `1.10x` K1 gate is a decisive miss, not a pass; the exact record is fixed in the [evidence baseline](lanes/evidence-baseline.md#pinned-economic-evidence) and decision brief. The `1.25x` cold-mount ceiling below is a **proposal**, not an operative budget. Phase 0 prepares the scoped price-acceptance record for the 2026-08-27 sitting, where the re-frame2 product operator, Mike Thompson, is the decider. Until ratification, the registered criterion remains the only adjudicated K1 line and `1.25x` cannot mark a result green.
+
+The proposed record names the frozen registered criterion, purchased use cases, accepted ceiling, native escape, effective revision, evidence owner, reopen conditions, and revert condition. It lapses if the purchased ambient-read capability or the native escape fails its named witness, if the canonical K1 row exceeds the accepted ceiling, or if the witness/estimator changes materially without re-ratification. Rejection at the sitting leaves the registered gate and its consequences in force.
+
+The registered read-free boundary-shell paper-fail budget remains `1 KB` retained per boundary on each canonical segment. Phase 0 must freeze its byte-exact interpretation before the next product run; the current pinned row is red under either 1,000 B or 1,024 B, and the [baseline owns its values and evidence](lanes/evidence-baseline.md#pinned-economic-evidence). Phase 1 first attempts remediation through the collector-substrate adjudication.
+
+If Phase 1 cannot meet the frozen line without breaking a higher-order law, a separate prospective re-registration or scoped acceptance—decided by the same product operator before the runtime ABI freezes—must name the reason, ceiling, effective revision, reopen conditions, and revert trigger. The K1 sitting does not pre-authorize that later decision, and a relative regression allowance cannot recolour the red shell row.
+
+Deterministic correctness, residue, scaling-shape, and production-erasure gates block ordinary changes. Noisy clock/heap distributions are adjudicated in pinned, interleaved evidence runs rather than converted into flaky PR thresholds. Every instrument states its estimand and exercised population, includes a positive control or sabotage that can make it fail, and refuses to publish when its own quality checks fail.
+
+### Absolute correctness and user-visible budgets
+
+- Controlled updates are correct in the same turn and visibly echoed within one 60 Hz frame at p95.
+- Ordinary discrete interactions reach next paint within 50 ms p95 and 100 ms p99.
+- Broad application operations complete within 100 ms p95 unless explicitly classified as background work.
+- Dragging and animation remain inside their frame budget, normally by keeping high-rate mechanics local to a native host.
+- Narrow-update body work scales with changed rows rather than all mounted rows.
+- Teardown residue is zero after quiescence.
+
+For the four-field editor and controlled grid, publish the mechanical per-keystroke path: state writes, subscription recomputations, boundary runs, write amplification, commit, and visible echo. This is explanatory product documentation as well as a performance witness.
+
+### Comparative and regression budgets
+
+- The pinned ordinary-Hicasso benchmark does not regress more than 5% on the same witness and instrument.
+- Subject to the named ratification above, cold mount has an initial ceiling of 1.25x equivalent direct UIx on the agreed representative witness. Read topology and capability differences remain reported alongside the ratio.
+- After topology tuning, representative broad updates target no worse than 1.25x the best relevant supported adapter. A sustained result beyond 1.5x triggers local-island analysis rather than a global redesign.
+- The read-free boundary shell meets the frozen byte-exact `1 KB` line or carries the separately ratified disposition described above. It is not governed by a “baseline plus 10%” rule.
+- Per-read retained cost is governed by the three-scoreboard K3 disposition and also may not regress more than 10% on the same pinned witness. Retained cost stays linear in boundaries/reads and teardown leaves no residue.
+- A native island should be within 5% or 1 ms of the same component mounted directly through its chosen React route, excluding the single explicit crossing. The Hicasso-native surface is co-instrumented against both handwritten React construction and UIx so the convenience layer cannot define its own floor.
+- An escape earns its added complexity by recovering at least 20%, saving at least 2 ms p95, or converting a failed user-visible budget into a pass.
+
+Once the comparative budgets are ratified, disposition is explicit. A same-instrument baseline regression blocks the change until the benchmark owner validates the instrument and the adapter owner fixes or reverts it. A 1.25–1.5x comparative result is a warning band: attribute the cause, make one bounded topology pass, and test a local island where appropriate. Above 1.5x, or on any user-visible miss, that scenario cannot graduate as ordinary Hicasso until it is fixed or deliberately classified as a native-host use case. An island that misses its parity or benefit threshold is simplified or removed; thresholds do not widen to keep it.
+
+Representative bulk behavior is a release gate. The topology tournament must publish qualified, behaviorally matched sparse, broad-replace, reorder, and controlled-edit rows at 100, 300, and 1,000 items, meet the ratified user-visible and comparative budgets, and preserve the declared scaling shape. The current instrument-limited broad row is therefore an open obligation, not a waiver. Warm-allocation evidence is not a release gate: no allocation claim publishes until a fitted series clears the registered quality floor. Retained heap, boundary shell, teardown, and bulk behavior remain required independently.
+
+The native-code percentage is reported as a source/component census after implementation; it is never enforced. Diagnostic and profiling sentinels must be absent from default production bundles.
+
+The bounded experiment set is the [canonical native-tier checklist](lanes/hot-path-architecture.md#canonical-native-tier-acceptance-checklist), direct-return delta, fine/coarse/chunked/native topology tournament, retaining-host callback identity, one mutation-proved causal Xray slice, and outward-bridge performance/lifecycle. Exact protocols live in the [hot-path lane](lanes/hot-path-architecture.md); no open-ended benchmark programme follows them.
+
+## 7. Complete use-case coverage
+
+Completeness does not mean every feature belongs in core. It means every recurring application job has a maintained answer and a clear ownership layer.
+
+| Use case | Default answer | Additional surface or escape | Required proof |
+|---|---|---|---|
+| Ordinary pages, conditional UI, dynamic lists | Hiccup, helpers, ambient reads, keyed boundaries | None | Todo and RealWorld-class flows |
+| Forms and controlled fields | Core controlled law and revision | Forms recipes; buffered-draft helper after a second caller | Four-field editor, 100-cell grid, Chromium/Firefox/WebKit IME |
+| Validation and async normalization | Derived subscriptions and event data | Validation-gating and settle-merge recipes | Late result cannot clobber newer edits |
+| Routing and navigation | Routing integration namespace | Dirty-leave, scroll restoration, focus-on-route recipes | Deep link, back/forward, pending mutation |
+| Async resources and mutations | re-frame2 resource/event model | Mutation status/settle-merge recipes; committed-read resource demand as the flagship experiment | Typeahead, cancellation, supersession, rollback |
+| Errors | Minimal error region | Expected failures stay data | Thrown render, retry, nested region |
+| Foreign React ecosystem and native hot work | Core React bridge: `defhost`, raw element, `h/as-element`; optional Hicasso-native namespace | Library-specific wrappers, optional UIx route and outward bridge | Compound library, native hot row, render prop, provider, portal |
+| Large collections | Suitable read topology and keys | Blessed foreign virtualizer recipe | 10K-row behavior, focus and accessibility |
+| Imperative SDKs | Declared host ownership | Acquire/release recipe | StrictMode, remount, throw, cleanup |
+| Overlays and focus | Native HTML where possible | Optional popover/modal module on top-layer primitives | Nesting, dismissal, focus restore, zero idle listeners |
+| Motion and high-rate input | Presence posture | Native host-local animation/drag state | Interrupted transition and frame budget |
+| Code splitting | Route/module boundary | Small `React.lazy` bridge for Hicasso's boundary ABI; Hiccup-aware Suspense/error host | Load, fallback, error, retry, HMR |
+| Multiple frames and roots | Shared frame context with isolated ownership | Explicit independent root only when needed | Same public id reincarnation, two roots, teardown |
+| Suspense and Activity | React-owned lifecycle | Declared host boundary when necessary | Suspend/retry; hide/reveal releases and reacquires reads |
+| SSR and hydration | Every public-surface inventory id follows the canonical Render or Client-only policy | Optional Node service for a named caller; its operational contract remains separate from surface semantics | Every inventory id is green in the [canonical SSR/hydration matrix](lanes/react-compatibility-notes.md#public-surface-ssrhydration-matrix) |
+| Accessibility | Semantic Hiccup and native controls | Structural a11y assertions plus browser focus tests | Names, roles, keyboard, virtualized/overlay focus |
+| i18n and theming | Ordinary data, classes, CSS variables, context through hosts | Recipes; no adapter subsystem | Runtime locale/theme change |
+| Testing | Pure data and supported semantic harness | Mounted DOM and browser tiers | Positive and sabotage controls at every tier |
+| Diagnostics | Versioned current-state evidence | Xray/Pair causal and heat views | Loss states, privacy, production erasure |
+| Migration | Reporter and explicit refusal classes | Shadow DOM/intent comparison; cautious codemod later | Three representative repositories |
+
+The strategic differentiator is demand-driven resource ownership: a committed `sub` that reads a resource may also declare demand; unmount or parameter change releases it; debounce, supersession, refresh-with-data, and cancellation remain explicit policies. The spike must reuse committed read membership, execute nothing for abandoned renders, and add no second per-read ledger. A typeahead witness decides whether it graduates.
+
+The initial optional-library priorities are forms and overlays because they remove repeated high-risk application code. Layout primitives, a generic component-library platform, generic state helpers, and a lifecycle/effect DSL stay out until repeated external demand demonstrates that recipes and hosts are inadequate.
+
+## 8. Modern React compatibility
+
+React compatibility is a release matrix, not a one-time claim. Keep `useSyncExternalStore` behind an internal seam because React makes external-store updates synchronous and limits their Transition/Suspense behavior ([reference](https://react.dev/reference/react/useSyncExternalStore)).
+
+React 19.2 Activity must release active subscriptions while hidden and restore them safely on reveal ([reference](https://react.dev/reference/react/Activity)). Hydration uses React server bytes, recoverable-error reporting, matching `identifierPrefix`, and root isolation ([reference](https://react.dev/reference/react-dom/client/hydrateRoot)). Streaming stays behind the server abstraction ([server APIs](https://react.dev/reference/react-dom/server)).
+
+The supported-version matrix covers StrictMode, retry/abandonment, Suspense, Activity, errors, HMR, multiple roots, controls, and production erasure. The separate [public-surface SSR/hydration matrix](lanes/react-compatibility-notes.md#public-surface-ssrhydration-matrix) owns server policy and hydration states. Lazy components are declared outside render and use a small boundary-ABI adapter. Tests use pure data, mounted DOM, and browsers—not deprecated test-renderer/shallow foundations ([warning](https://react.dev/warnings/react-test-renderer)). Experimental React APIs remain at native host edges.
+
+## 9. Testing as a product surface
+
+Ship a supported `re-frame.hicasso.test` namespace with a deliberately layered contract.
+
+| Tier | What it proves | Mechanism |
+|---|---|---|
+| L0 | subscriptions, handlers, state transitions | Pure CLJ/CLJS functions |
+| L1 | codecs, intents, control/revision, optional-module laws, native-form expansion and boundary-ABI helpers | Pure data, property, and macro-expansion tests |
+| L2 | Registered hook-free Hicasso bodies | Restricted semantic-tree assertion harness with injected read fixtures |
+| L3 | React lifecycle, context, hooks, refs, errors, hosts | Mounted React DOM and Testing Library/user-event |
+| L4 | IME, caret, focus, layout, hydration, performance | Chromium, Firefox, and WebKit |
+
+L2 is an assertion model, not a renderer or React-parity oracle. It invokes a registered hook-free body under a discardable resolver and expands only registered hook-free Hicasso children. Hosts, raw React, hooks, identity, lifecycle, Suspense, and errors are opaque/L3; missing fixtures and escaped reads refuse.
+
+The mounted facade provides isolated-frame mount, hydrate, rerender, dispatch-and-settle, settle, unmount, and assert-clean. Cleanup waits for quiescence and compares residue with the pre-mount baseline before reset.
+
+Every important gate has a negative or sabotage control so an accidentally empty population cannot pass. Apply the canonical native-tier checklist around native extraction, add migration-shadow tests for Reagent conversions, and run a bounded schema-driven generative spike for state/intent sequences.
+
+Every differential witness names the equality it proves: authored data, semantic assertion tree, canonical DOM, intent stream, React server bytes, or hydrated browser behavior. Normalized structure cannot stand in for React's hydration wire format, and a semantic snapshot cannot claim lifecycle parity.
+
+## 10. Xray and runtime evidence
+
+Xray should answer questions developers actually ask:
+
+1. What can current evidence prove about mounted, hidden, suspended, or recently committed work?
+2. Why did this boundary run or commit, which reads changed, and what is their fan-out?
+3. Did props, context, reads, retries, abandonment, errors, or a host cause the work?
+4. Is pressure in computation, read topology, Hiccup lowering, React, or layout/paint, and what remedy is credible?
+5. What information is unavailable, capped, host-opaque, or uncorrelated?
+
+The causal lens follows:
+
+`event -> subscriptions recomputed -> values changed -> boundaries notified -> bodies run -> React commit -> paint`
+
+Each link needs an explicit evidence seam. Timing proximity never proves commit, paint, hidden, or suspended state; a render measure may be retry, throw, StrictMode duplicate, or abandoned work. Use existing trace history, pure current-state projections, separate commit evidence, and `unknown`/`opaque`/`uncorrelated` for unsupported links. Xray owns bounded retention.
+
+Every envelope carries schema, producer, operation, scope, basis, completeness, and loss. Xray and Pair consume the same privacy-projected schema; sink failures are contained and production contains no evidence/source sentinels.
+
+Emit the standard adapter-neutral fields that can be proved: view, frame, source, current reads, known cause, attempt outcome, commit/rendered event, and unmount. Stable occurrence identity requires a commit-owned identifier. User Timing is complementary.
+
+The differentiating feature is a hot-view advisor that ranks time/frequency/read churn/fan-out, then classifies computation, topology, lowering, React, or layout pressure. It recommends native extraction only when it addresses the measured owner, selects the smallest credible route—direct `n/$`, a named Hicasso-native component, UIx, or a foreign React host—and otherwise points to computation, topology, boundary, or virtualization work.
+
+## 11. Innovation portfolio
+
+Novelty enters only through a small deciding experiment. The detailed designs and privacy/kill rules are in [the left-field lane](lanes/left-field-ideas.md).
+
+| Idea | Status | Deciding rule |
+|---|---|---|
+| Complaint catalogue and cause-aware hot advisor | Adopt | Stable recovery guidance and cause-directed optimization are part of the core developer workflow; no automatic promotion |
+| Counterfactual topology advice | Spike | Retain only if blinded calibration predicts useful coarse/fine/chunked choices |
+| Capability receipts | Spike | Mechanical attempt facts only; stop if instrumentation changes rankings or exposes values |
+| Replayable view capsules | Spike after L2 | One-shot, commit-owned, redacted; stop if representative views are mostly opaque |
+| Pull-shaped reads | Spike | Must beat hand-coarse ergonomics/cost without a per-leaf ledger or independent-churn regression |
+| Schema-driven generators | Spike | Graduate only if they find real defects/refusal gaps and shrink usefully |
+| AI-pair queries and migration shadowing | Extend existing tools | Reuse Xray/Pair and canonical DOM/intent evidence; create no parallel graph/history system |
+| Shared read-set notification groups | Census, then spike | Proceed only for material identical-set fan-out with no singleton/cleanup regression |
+| Codec shape planning | Watch | Profile-trigger only when classification/lowering exceeds 10% of hot-boundary self time; require whole-boundary gain and bounded cache growth |
+| Read-free shell, intent replay, keyed-list maintenance, future React store seam | Watch | Each waits for its named population, owner, or failing budget |
+| Compiler/JIT mode, second renderer, worker view runtime, signals replacement, universal callback cells, hydration-free inference | Reject | Second semantics/state, standing cost, or unsupported inference |
+
+## 12. Action programme
+
+The programme proceeds in vertical slices. Testing and Xray land with the behavior they explain; they are not deferred to a polish phase.
+
+### Phase 0 — freeze the invariants and establish the product spine
+
+Deliver:
+
+- a one-page invariant/capability ledger and provisional facade;
+- the [K1 price-acceptance proposal specified in section 6](#6-performance-contract), drafted for the named sitting and made operative only if its named decider ratifies it;
+- the section 6 read-free-shell disposition, including the frozen byte-exact `1 KB` line and Phase 1 remediation gate;
+- an explicit K3 disposition that preserves the governed Reagent viability row, the UIx-parent architecture row, and author preference as three non-substitutable scoreboards;
+- the living requirements mine, with every surface mapped to a job, home, owner, and witness;
+- the core/optional/host/recipe/refusal classification for every use case in section 7;
+- a unique inventory entry and server/hydration policy for every proposed public surface under the [canonical SSR/hydration matrix](lanes/react-compatibility-notes.md#public-surface-ssrhydration-matrix), independent of whether the Node service is activated;
+- ratified performance budgets, estimands/control standards, named reference hardware, and an instrument-eligibility rule that must pass before a product row can publish;
+- an installable `implementation/hicasso` package, public namespaces, metadata, tiny app, production build, and HMR path;
+- one public facade, optional-namespace reachability checks, and no benchmark-only aliases;
+- stable error shape and source-coordinate capture in `defview`/`defhost`.
+
+Exit when a clean consumer can compile and run a minimal view without benchmark-tree imports, no provisional option selects an execution mode, the sitting has ratified or rejected the K1 proposal with consequences recorded, and the shell breach has an operative remediation gate rather than a relative-baseline waiver. Exact names are not frozen ahead of the application witnesses.
+
+### Phase 1 — make the reactive kernel trustworthy
+
+Deliver and sabotage-test:
+
+- render-probes/commit-owns behavior;
+- conditional and changing reads;
+- abandonment, retry, unmount, and rollback;
+- multiple roots and frame isolation;
+- same-public-id frame reincarnation and delayed callbacks;
+- Activity hide/reveal and Suspense behavior;
+- HMR generation and cleanup;
+- controlled input across Chromium, Firefox, and WebKit;
+- an explicit choice of the under-collector subscription substrate, using correctness, retained cost, clock, teardown, and migration evidence rather than an inherited default;
+- read-free shell evidence at or below the operative byte-exact `1 KB` line on both canonical segments, or a separate prospective operator disposition completed before runtime ABI freeze;
+- exact residue after quiescence;
+- root-scoping or explicit justification for every mutable global.
+
+Exit at zero stale reads, cross-frame operations, tears, or residual ownership and only when the shell meets its frozen line or carries its separate prospective disposition. Correctness failures are blockers, not performance trade-offs.
+
+### Phase 2 — ship one lovable vertical slice
+
+Build a small but complete application flow using only the proposed API: routing, keyed list, article edit, async mutation, controlled fields, errors, and reset. In the same slice, ship:
+
+- the L0–L3 testing facade;
+- the first versioned evidence projection;
+- Xray mounted/read/intent/explain-render views;
+- the complaint catalogue;
+- the first bounded clj-kondo checks;
+- production-erasure proof.
+
+Exit when the application code contains no artificial boundaries or internal imports and its core behavior is readable without browser-test ceremony. Freeze the ordinary authoring facade from this evidence.
+
+### Phase 3 — make the native hot path excellent
+
+Deliver:
+
+- direct React output contract and delta benchmark;
+- the optional `re-frame.hicasso.native` namespace implementing the [provisional grammar](lanes/ergonomics-api.md#provisional-n-grammar) and passing every row of the [canonical native-tier acceptance checklist](lanes/hot-path-architecture.md#canonical-native-tier-acceptance-checklist);
+- completed `defhost` callback, ReactNode prop, children, provider, render-prop, ref, error, and SSR contracts, plus the optional portal helper;
+- outward Hicasso-under-native-React bridge, exercised from Hicasso-native, UIx, and raw React parents;
+- topology tournament and host-identity experiment;
+- one causal Xray interaction and hot-view advisor;
+- one virtualizer and one imperative SDK witness.
+
+Exit when the canonical native-tier checklist is green and a measured hot boundary can move to native React, meet the island budget, and remain diagnosable from the same Xray surface. Freeze the host, outward-bridge, and hot-path facade from those witnesses.
+
+### Phase 4 — close the application coverage matrix
+
+Extend the product application and witness suite to cover pagination, runtime content, code splitting through the explicit lazy-boundary bridge, lazy/error fallbacks, navigation prefetch across hover/focus/touch, navigation focus, multiple frames, retained callbacks, provider/compound components, accessibility, SVG/custom-element attributes, autofill/form reset/FormData, all named control types, the complete countable SSR/hydration matrix, and a typeahead resource-demand witness. Publish the editor/grid per-keystroke mechanics and the qualified bulk topology tournament. Add a second screen with a serious vendor component.
+
+Exit when every row in section 7 points to running evidence, an installable optional module, a tested recipe, or an explicit non-goal with a React escape, and when the canonical SSR/hydration and bulk/economic suites are green.
+
+### Phase 5 — decide differentiators and add high-value optional products
+
+In priority order:
+
+1. decide the committed-read resource-demand spike from the typeahead witness;
+2. forms recipes and a buffered-draft helper after its second consumer;
+3. anchored popover and modal on native top-layer primitives;
+4. presence/motion posture and focus intent;
+5. routing and async-resource recipes;
+6. migration reporter, shadow comparison, and only then safe codemod transforms;
+7. deliver the bounded Node/React SSR service contract when a named caller activates it, using immutable request snapshots, allowlisted state, build identity, bounded isolate concurrency, hard termination, and a pre-registered caller latency envelope;
+8. selected left-field spikes that meet their decision criteria.
+
+Each optional namespace proves zero reachable production code when absent. No optional feature changes the boundary shell.
+
+### Phase 6 — adoption and release
+
+Publish versioned artifacts, compatibility matrix, upgrade policy, API reference, cookbook, troubleshooting guide, performance method, and escape criteria.
+
+Make Hicasso the one taught interpreted-Hiccup native story and archive or remove the obsolete re-frame.ui/Freehand public APIs and documentation so users do not face overlapping data-view models. UIx remains the supported React-first adapter and optional native authoring route.
+
+Move every live Xray/Story/Pair consumer onto the adapter-neutral Hicasso evidence provider before disposing of the experimental donor tool surfaces. Fixtures may retain explicit compatibility coverage, but production and primary tooling may not retain a hidden dependency.
+
+Recruit two real pilot applications and migrate at least one substantial screen in each.
+
+Exit when both pilots can install, develop, test, diagnose, production-build, and upgrade without framework-author intervention, and no critical public API changes across one release candidate.
+
+## 13. Definition of done
+
+Hicasso is ready to be the native re-frame2 adapter when all of the following are true:
+
+- The package is independent of the benchmark tree and has a documented compatibility/release policy.
+- The language is small, internally coherent, source-located, and has no execution-mode switch.
+- The collector substrate and two-hook shell are explicit, measured choices; optional capabilities add no universal hook or ownership graph.
+- The full correctness matrix passes with sabotage controls and exact cleanup.
+- The representative app, controlled grid, compound host, virtualizer, and imperative SDK use only public surfaces.
+- React-library interop is a core contract: providers, compound components, ReactNode slots, render props, refs, errors, lazy boundaries, outward embedding, and same-root native islands pass their ownership tests.
+- Every inventoried public surface passes its policy row in the [canonical SSR/hydration matrix](lanes/react-compatibility-notes.md#public-surface-ssrhydration-matrix) even when the optional Node service is not deployed.
+- Ordinary performance meets the ratified user-visible, regression, mount, update, and heap budgets.
+- The read-free boundary shell meets the operative byte-exact `1 KB` line or has a separately ratified, prospective operator disposition; a relative regression budget cannot substitute for it.
+- Qualified bulk evidence covers the named sparse, broad, reorder, and controlled-edit populations and meets the ratified budgets. Warm allocation is not a release blocker and carries no product claim unless its instrument qualifies.
+- Every row of the [canonical native-tier acceptance checklist](lanes/hot-path-architecture.md#canonical-native-tier-acceptance-checklist) passes; no partial parity result substitutes for that checklist.
+- The testing ladder is supported, with honest opacity boundaries and browser coverage for browser laws.
+- Xray explains current reads and causal work, accounts for loss, guides hot extraction, respects privacy, and erases from production.
+- Every motivating use case is assigned to core, optional module, recipe, host escape, or explicit non-goal.
+- The requirements mine and per-keystroke mechanics are current, and the demand-driven resource spike has an explicit adopt/stop verdict.
+- Two pilot applications ship substantial screens without bespoke support.
+- No primary documentation, production path, or live developer-tool consumer depends on the experimental re-frame.ui or Freehand public surfaces; any retained compatibility fixture is named and isolated.
+
+Client v0 does not wait for an unused production SSR deployment, but the hydration contract and React-server compatibility tests are mandatory. The bounded Node service ships when a named caller exists.
+
+## Supporting specifications
+
+The complete supporting specification set and its concern-ownership map are maintained in [`codex/README.md`](lanes/README.md). This document does not maintain a second index.


### PR DESCRIPTION
Executes rf2-hic-000: snapshot of the decision brief, the specification, and all lanes into docs/design/hicasso/product/ so worker worktrees can read the normative set (the ai/ originals are local-only). Includes link fixes for the new home, the seeded naming ledger, and source hashes in product/README.md.

Anchors and table column counts verified by hand; scripts/check_doc_slugs.py green (the only gate for docs/design/**).