### PR TITLE
docs(hicasso): the checkpoint-correction ledger and closure rule (rf2-hic-073)

### DIFF
--- a/docs/design/hicasso/product/correction-ledger.md
+++ b/docs/design/hicasso/product/correction-ledger.md
@@ -1,0 +1,73 @@
+# Correction ledger — every checkpoint finding, and what it takes to close one
+
+**Rule**: a checkpoint that finds a miss files a real `bd` issue and appends a row here. The row does not close when the fix merges — it closes when the affected checkpoint protocol section has been **re-run against the landed fix** and the result is written into the row. The final audit (rf2-hic-064) reads this file: zero unresolved correctness or coverage rows, or the audit returns a non-release verdict.
+
+This is the enforcement home the set review names as missing — see [`lanes/beads-review.md`](lanes/beads-review.md#6-checkpoint-design) items 1, 2 and 6, the obligations left homeless in [§7](lanes/beads-review.md#7-risks-kill-rules-and-budgets-without-an-enforcement-home), and blocker 3 of its [verdict](lanes/beads-review.md#verdict): *"corrective beads, dormant pilots, and the donor-surface disposition have no closure path into a later release decision."*
+
+## Severity
+
+| Severity | What it means | Effect on the release verdict |
+|---|---|---|
+| `correctness` | Shipped behaviour is, or may be, wrong: a witness that avoids its risk row's named scenario, a sabotage control that fails to redden, a claim the artefacts contradict. | Blocks. |
+| `coverage` | An obligation has no accountable witness at all: a §13 bullet, a use-case row, a budget line with no gate, a population that was never counted. | Blocks. |
+| `quality` | Behaviour holds but the shape is poor: naming, error text, docs, machinery grown past its witness. | Does not block. Must be dispositioned — fixed, filed forward with a named owner, or explicitly accepted — before rf2-hic-064 signs. |
+
+## Status, and why `resolved` is not `closed`
+
+| Status | Meaning |
+|---|---|
+| `open` | Filed. No fix has landed. |
+| `resolved` | The corrective bead's PR is merged to `main`. The finding is **still unresolved for gating purposes**. |
+| `closed` | The affected protocol section was re-run after the fix landed, it passed, and the evidence is in the row. |
+
+For the rf2-hic-064 gate, *unresolved* means **any status other than `closed`**. A `resolved` row fails the gate exactly as an `open` one does. Nothing else in the programme distinguishes "we fixed it" from "we checked that we fixed it"; that distinction is this file's job.
+
+## The closure rule
+
+Filing a fix is not evidence that the miss is fixed, and neither is merging it. A row moves to `closed` only when all three hold:
+
+1. the corrective bead's PR is merged to `main`;
+2. **the protocol section that produced the finding is re-run** against that `main` — the section as written, not a narrower test authored by whoever wrote the fix;
+3. the re-run passes, and its evidence — date, section, commit, what was run, the result — is written into the row's Closure evidence cell.
+
+Who re-runs it depends on cost. **Trivial** (re-read one fixture, re-run one sabotage control, re-count one roster): the fixing worker does it inside the corrective PR and quotes the result. **Non-trivial** (a clean-checkout suite, a fresh reviewer, the physical reference profile, a whole sabotage family): the checkpoint files a **closure bead** depending on the corrective bead, and the ledger row names it. A closure bead is small and mechanical — re-run one named section, write one cell.
+
+Rows are never deleted. A finding that proves mistaken is `closed` with `withdrawn — <reason>` as its evidence, so the audit can see it was considered rather than lost.
+
+## The ledger
+
+Checkpoints append rows. Corrective workers flip `open` → `resolved` and cite the merged PR. The closure re-run flips `resolved` → `closed`.
+
+| Checkpoint | Protocol section | Finding | bd id | Severity | Status | Closure evidence |
+|---|---|---|---|---|---|---|
+
+*No rows yet — the first checkpoint (rf2-hic-019) has not run.*
+
+## Worked example (dry run)
+
+Illustrative only; `rf2-hic-9001` and `rf2-hic-9002` are not filed issues. rf2-hic-019 §2 Correctness re-runs the eight sabotage controls and finds the callback-identity control still passes with the sabotage applied — the witness never reaches the retained-host path.
+
+| Step | What happens | Status | Closure evidence |
+|---|---|---|---|
+| 1. File | rf2-hic-019 runs `bd create` for `rf2-hic-9001` (surface fence and acceptance in its description) and appends the row. | `open` | — |
+| 2. Fix | The corrective worker rewrites the witness so the sabotage reddens; its PR merges to `main`. | `resolved` | PR merged; re-run outstanding |
+| 3. Closure re-run | Re-running all eight controls from a clean checkout is non-trivial, so rf2-hic-019 had filed closure bead `rf2-hic-9002` depending on `rf2-hic-9001`. It re-runs §2 Correctness against `main`. | `resolved` | re-run in progress (rf2-hic-9002) |
+| 4. Close | All eight controls redden. The result goes into the row. | `closed` | 2026-09-02 · §2 re-run on `main`@`abc1234` via rf2-hic-9002 · 8/8 controls reddened |
+
+Between steps 2 and 3 the fix is on `main` and `rf2-hic-9001` is closed in the tracker, yet the ledger row still reads `resolved` and rf2-hic-064 would return a non-release verdict on it. That interval is the mechanism, not an inconvenience.
+
+## Deferred items and the release decision
+
+Some obligations cannot close before the final audit runs. They are not corrections, and they must not vanish into a green tick. Each gets a row here naming the bead that will close it and which verdict it gates.
+
+rf2-hic-064 emits two verdicts separately: *implementation audit complete* (achievable without pilots) and *product definition of done*. A deferred item may leave the first green while holding the second red. What it may not do is go unmentioned.
+
+| Item | Owner bead | State | Gates | Closure path |
+|---|---|---|---|---|
+| Pilot applications — two, each shipping a substantial screen unaided | rf2-hic-063 | Operator-activated; blocks nothing in the engineering line | *product definition of done* — red until both pilots ship | The operator nominates; rf2-hic-063 records the friction log; every friction entry is a docs or API defect filed as its own bead. The release decision re-reads this row. |
+| Sitting outcomes — the K1 amendment and K3 disposition records | rf2-hic-085 | Dormant until 2026-08-27 | *product definition of done*; any amendment re-pins rf2-hic-071's budget gates | rf2-hic-085 records the ruling and files consequence beads. A changed ceiling reopens each affected budget line as a `coverage` row above. |
+| Donor-surface disposition | rf2-hic-062 | In rf2-hic-064's dependency set | *implementation audit complete* | Every experimental tree carries archive / remove / keep-as-evidence. `keep-as-evidence` is **not terminal**: it earns a row here naming the later decision it defers to, so the audit reports standing donor state instead of absorbing it. |
+
+## Where the checkpoints read this
+
+rf2-hic-019, rf2-hic-026, rf2-hic-038, rf2-hic-048 and rf2-hic-064 each carry the closure paragraph in their protocol: findings become real `bd` issues, the ids land here, and a landed fix closes only by re-running the affected protocol section. rf2-hic-064's green definition names this file directly — every §13 bullet green **and** zero unresolved correctness or coverage rows, or the audit says non-release and enumerates the misses.

--- a/docs/design/hicasso/product/correction-ledger.md
+++ b/docs/design/hicasso/product/correction-ledger.md
@@ -45,14 +45,14 @@ Checkpoints append rows. Corrective workers flip `open` → `resolved` and cite 
 
 ## Worked example (dry run)
 
-Illustrative only; `rf2-hic-9001` and `rf2-hic-9002` are not filed issues. rf2-hic-019 §2 Correctness re-runs the eight sabotage controls and finds the callback-identity control still passes with the sabotage applied — the witness never reaches the retained-host path.
+Illustrative only; `rf2-hic-9001` and `rf2-hic-9002` are not filed issues, and `<commit-sha>` below stands in for the SHA a real row would carry. rf2-hic-019 §2 Correctness re-runs the eight sabotage controls and finds the callback-identity control still passes with the sabotage applied — the witness never reaches the retained-host path.
 
 | Step | What happens | Status | Closure evidence |
 |---|---|---|---|
 | 1. File | rf2-hic-019 runs `bd create` for `rf2-hic-9001` (surface fence and acceptance in its description) and appends the row. | `open` | — |
 | 2. Fix | The corrective worker rewrites the witness so the sabotage reddens; its PR merges to `main`. | `resolved` | PR merged; re-run outstanding |
 | 3. Closure re-run | Re-running all eight controls from a clean checkout is non-trivial, so rf2-hic-019 had filed closure bead `rf2-hic-9002` depending on `rf2-hic-9001`. It re-runs §2 Correctness against `main`. | `resolved` | re-run in progress (rf2-hic-9002) |
-| 4. Close | All eight controls redden. The result goes into the row. | `closed` | 2026-09-02 · §2 re-run on `main`@`abc1234` via rf2-hic-9002 · 8/8 controls reddened |
+| 4. Close | All eight controls redden. The result goes into the row. | `closed` | 2026-09-02 · §2 re-run on `main`@`<commit-sha>` via rf2-hic-9002 · 8/8 controls reddened |
 
 Between steps 2 and 3 the fix is on `main` and `rf2-hic-9001` is closed in the tracker, yet the ledger row still reads `resolved` and rf2-hic-064 would return a non-release verdict on it. That interval is the mechanism, not an inconvenience.
 


### PR DESCRIPTION
Closes rf2-hic-073.

Corrections have to close, not just get filed. This adds the mechanism the checkpoints and the final audit use.

## What landed

**Created — `docs/design/hicasso/product/correction-ledger.md`** (the only file in this PR). One page:

- **Severity** — `correctness` and `coverage` block the release verdict; `quality` does not, but must be dispositioned before rf2-hic-064 signs.
- **Status** — `open` → `resolved` → `closed`, with `resolved` (fix merged, re-run outstanding) explicitly still failing the gate.
- **The closure rule** — three conditions, and the trivial/non-trivial split that decides whether the re-run happens inside the corrective PR or in a small closure bead. Rows are never deleted; a mistaken finding closes as `withdrawn — <reason>`.
- **The ledger table** — 7 columns, empty, because no checkpoint has run yet.
- **A dry-run row** walking the full lifecycle (file → resolve → closure re-run → closed) with illustrative ids `rf2-hic-9001` / `rf2-hic-9002`, which are deliberately outside the real 000–085 range and are not filed issues.
- **Deferred items and the release decision** — the rf2-hic-063 pilots, the rf2-hic-085 sitting outcomes, and the rf2-hic-062 donor-surface disposition, each with the bead that closes it and which verdict it gates.

## Existing files touched: none

The bead's second surface is "a paragraph in each checkpoint's protocol (via the published set)". Those protocols are **not** in the published set — `checkpoint` appears zero times across `specification.md`, `decision-brief.md` and every `lanes/` file except the review itself. Each checkpoint's `## Review protocol` lives in its bead description, and rf2-hic-019 already forward-referenced "the hic-073 rule" there. So the paragraph went where the checkpoints actually read it, as a note on each of the five checkpoint beads:

- **rf2-hic-019, rf2-hic-026, rf2-hic-038, rf2-hic-048** — identical filer paragraph, headed `CLOSURE RULE (rf2-hic-073) — this paragraph is part of this checkpoint's protocol.` It states that every miss becomes a real bd issue via `bd create` and a ledger row carrying severity, protocol section and status; that a row does not close when the corrective PR merges but only when the protocol section that produced the finding is re-run against the landed fix with the evidence written into the row; the trivial/non-trivial split for who performs that re-run; that rows are never deleted; and that rf2-hic-064 gates on zero unresolved correctness/coverage rows, where unresolved means any status other than `closed`.
- **rf2-hic-064** — the consumer variant. Same filing terms, plus: reading the ledger is a gate step, quality rows must each be dispositioned, and the deferred-items table is walked row by row and reported against the two verdicts this audit already emits separately (*implementation audit complete* vs *product definition of done*). Its existing green definition already names the hic-073 ledger, so this paragraph elaborates it rather than changing it.

Nothing in the file fence was touched. `invariants.md`, `k1-price-acceptance.md`, `requirements-mine.md`, `dispositions.md`, `resource-demand-criteria.md`, `specification.md`, `decision-brief.md`, `naming-ledger.md` and `lanes/**` are all unmodified — `git show --stat` on this branch lists exactly one path.

## How this answers review blocker 3

Blocker 3: *"The 'final' checkpoint can complete with definition-of-done bullets still red; corrective beads, dormant pilots, and the donor-surface disposition have no closure path into a later release decision."* Three limbs, three answers:

1. **Corrective beads.** The `resolved` ≠ `closed` distinction is the whole device. A merged fix moves a row to `resolved`, and rf2-hic-064 still returns a non-release verdict on it. Only a re-run of the protocol section that produced the finding — the section as written, not a narrower test by the fix's own author — moves it to `closed`. This is §6 item 6 of the review ("Filing a fix is not evidence that the miss is fixed") given a status value that a gate can read, and §6 items 1 and 2 given a home.
2. **Dormant pilots.** rf2-hic-063 gets a deferred row naming the operator activation, the friction log, and the verdict it holds red. The audit cannot complete without reporting it, and the later release decision re-reads that row instead of rediscovering the debt.
3. **Donor-surface disposition.** rf2-hic-062's `keep-as-evidence` marker is declared non-terminal: it earns a ledger row naming the later decision it defers to, so standing donor state is reported rather than absorbed into a green tick. rf2-hic-085's sitting outcomes get the same treatment, since an amendment there re-pins rf2-hic-071's budget gates and reopens the affected lines as `coverage` rows.

The two-verdict split rf2-hic-064 already carries is what makes this non-blocking: deferred rows can leave *implementation audit complete* green while holding *product definition of done* red. What they cannot do is go unmentioned.

## Quality gates

| Gate | Command | Exit code |
|---|---|---|
| Doc slugs | `python scripts/check_doc_slugs.py` | **0** |
| Provenance pins | `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |

**Provenance pins was red, and this is what it caught.** The worked-example row cited `` `abc1234` `` as the commit its dry-run closure re-run was taken on. That is a 7-character hex run in a code span with no digest vocabulary on its line, which is exactly the shape of a real pin, so the checker read it as one and refused — correctly, since it resolves to no commit in any clone. The token was never a citation; it was a stand-in inside an example that is illustrative from its first sentence. It now reads `` `<commit-sha>` ``, which no reader and no checker can mistake for a SHA, and the section's opening sentence names it alongside the illustrative `rf2-hic-9001` / `rf2-hic-9002` ids. The checker was not touched and no exception was added — the gate's verdict was right.

`mkdocs build --strict` is not nominated: `mkdocs.yml`'s `exclude_docs` keeps `docs/design/**` out of the site, so it would verify nothing here.

**The green was positive-controlled.** An exit 0 from this gate is worth nothing unless the gate opened the file, so I broke one anchor deliberately (`#6-checkpoint-design` → `#6-checkpoint-design-BOGUS`) and re-ran it: exit **1**, `BROKEN ANCHOR: docs\design\hicasso\product\correction-ledger.md:5`. Restored, re-ran, exit **0**. The gate is reading this file. (`docs` is in its `DEFAULT_ROOTS`; `design` is not in `EXCLUDE_DIR_NAMES`.)

**Anchors — hand-verified, 3 of 3.** All three are cross-file links from line 5 into `lanes/beads-review.md`, and each target heading was read in that file:

| Link | Target heading | Line in target |
|---|---|---|
| `lanes/beads-review.md#6-checkpoint-design` | `## 6. Checkpoint design` | 200 |
| `lanes/beads-review.md#7-risks-kill-rules-and-budgets-without-an-enforcement-home` | `## 7. Risks, kill rules, and budgets without an enforcement home` | 221 |
| `lanes/beads-review.md#verdict` | `## Verdict` | 3 |

Slugs were computed with the same `pymdownx.slugs.slugify(case="lower")` the gate and MkDocs use, not guessed. There are no same-file anchor links and no links into any fenced file.

**Table column counts — hand-verified, 5 of 5 tables internally consistent** (header, separator and every data row agree, per table):

| Table | Line | Columns | Rows |
|---|---|---|---|
| Severity | 9 | 3 | 3 data |
| Status | 17 | 2 | 3 data |
| The ledger | 41 | 7 | 0 data (header + separator only — no checkpoint has run) |
| Worked example | 50 | 4 | 4 data |
| Deferred items | 65 | 5 | 3 data |

Nothing validates tables or rendering in `docs/design/**`, so these counts were checked directly against the pipe-delimited cells rather than inferred.

## Risk noticed

rf2-hic-064's existing green definition and this ledger now state the same gate in two places. They agree today — I wrote the ledger's wording to match the bead's — but if either is edited alone they drift, and the drift would be silent because no gate reads bead text. The ledger is the normative statement; the bead paragraph should be treated as a pointer to it.

