### PR TITLE
docs(hicasso): coverage-row classification and SSR/hydration dispositions (rf2-hic-005)

### DIFF
--- a/docs/design/hicasso/product/dispositions.md
+++ b/docs/design/hicasso/product/dispositions.md
@@ -121,48 +121,48 @@ Each row carries both a **target policy** and an **operative disposition**. The 
 default in the [canonical matrix](lanes/react-compatibility-notes.md#public-surface-ssrhydration-matrix) — what the
 surface is expected to become once its behavior is proved. The operative disposition is what the surface is entitled to
 do *today*, and today it is Client-only for every row without exception, because no server witness exists for any
-Hicasso surface yet. The operative column is therefore the upgrade slot: see
-[2.4](#24-the-default-rule-and-how-a-row-is-upgraded).
+Hicasso surface yet. The operative column is therefore the upgrade slot, owned by the per-surface SSR/hydration witness
+bead `rf2-hic-046`: see [2.4](#24-the-default-rule-and-how-a-row-is-upgraded).
 
 ### 2.1 Surface inventory and dispositions
 
 | Id | Public surface | Source | Canonical matrix class | Target policy | Operative disposition (today) |
 |---|---|---|---|---|---|
-| HS-01 | `h/defview` boundary | 4 | `h/defview` with `h/sub` | Render | Client-only — refusal; witness owed |
-| HS-02 | `h/sub` read during a server render | 4 | `h/defview` with `h/sub` | Render | Client-only — refusal; witness owed |
-| HS-03 | `h/handler` and literal intent vectors | 4.1 | Intrinsic/fragment Hiccup | Render | Client-only — refusal; witness owed |
-| HS-04 | Intrinsic element head, including SVG and custom elements | 4 | Intrinsic/fragment Hiccup | Render | Client-only — refusal; witness owed |
-| HS-05 | Fragment head | 4 | Intrinsic/fragment Hiccup | Render | Client-only — refusal; witness owed |
-| HS-06 | Props map and canonical slot naming | 4 | Intrinsic/fragment Hiccup | Render | Client-only — refusal; witness owed |
-| HS-07 | Reserved data vocabulary: event value, checked value, explicit prevention, controlled revision | 4 | Controlled DOM fields | Render | Client-only — refusal; witness owed |
-| HS-08 | Controlled DOM fields as a class (per-control rows in [2.3](#23-per-control-and-dom-conformance-dispositions)) | 4.2 | Controlled DOM fields | Render | Client-only — refusal; witness owed |
-| HS-09 | `h/error-boundary` | 4 | `h/error-boundary` | Render | Client-only — refusal; witness owed |
-| HS-10 | `h/mount!` | 4 | Root/frame provider | Client-only (client root creation; recovery is the server render entry plus `h/hydrate!`) | Client-only — refusal; witness owed |
-| HS-11 | `h/hydrate!` | 4 | Root/frame provider | Client-only (the adoption half of every Render row) | Client-only — refusal; witness owed |
-| HS-12 | `h/render!` | 4 | Root/frame provider | Client-only | Client-only — refusal; witness owed |
-| HS-13 | `h/unmount!` | 4 | Root/frame provider | Client-only | Client-only — refusal; witness owed |
-| HS-14 | Root and frame-provider element, including `identifierPrefix` | 4 | Root/frame provider | Render | Client-only — refusal; witness owed |
-| HS-15 | Attribute-merge helper (public only if a witness needs it) | 4 | Intrinsic/fragment Hiccup | Render | Client-only — refusal; witness owed |
-| HS-16 | `h/defhost` declaration | 4.3 | Declared host | Client-only until the host declaration selects Render | Client-only — refusal; witness owed |
-| HS-17 | Declared ReactNode positions and named content slots | 4.3 | Declared host | Client-only until the host declaration selects Render | Client-only — refusal; witness owed |
-| HS-18 | Render-prop callback lowered through `h/as-element` | 4.3 | Declared host | Client-only until the host declaration selects Render | Client-only — refusal; witness owed |
-| HS-19 | Raw React element head | 4 | Raw React or opaque component | Client-only until classified by an enclosing view or host policy | Client-only — refusal; witness owed |
-| HS-20 | Portal helper | 4.3 | Portal helper | Client-only | Client-only — refusal; witness owed |
-| HS-21 | Outward bridge: a Hicasso view under a native React parent | 4.3 | Root/frame provider and outward bridge | Render | Client-only — refusal; witness owed |
-| HS-22 | `React.lazy` boundary-ABI bridge and Hiccup-aware Suspense host | 7 | Lazy/Suspense/error boundary | Client-only until every server branch and the selected React server API are declared | Client-only — refusal; witness owed |
-| HS-23 | Activity-hosted subtree | 8 | Declared host | Client-only | Client-only — refusal; witness owed |
-| HS-24 | `n/$` intrinsic form | [native surface](lanes/ergonomics-api.md#optional-native-surface) | Intrinsic `n/$` | Render | Client-only — refusal; witness owed |
-| HS-25 | `n/$` component-headed form | [native surface](lanes/ergonomics-api.md#optional-native-surface) | `n/defcomponent` and component-headed `n/$` | Client-only until the component declaration selects Render | Client-only — refusal; witness owed |
-| HS-26 | `n/props` marker | [n/$ grammar](lanes/ergonomics-api.md#provisional-n-grammar) | Intrinsic `n/$` | Render | Client-only — refusal; witness owed |
-| HS-27 | `n/defcomponent` | [native surface](lanes/ergonomics-api.md#optional-native-surface) | `n/defcomponent` | Client-only unless the declaration selects `:render` | Client-only — refusal; witness owed |
-| HS-28 | `n/use-sub` | [native surface](lanes/ergonomics-api.md#optional-native-surface) | `n/defcomponent` | Client-only until its component selects Render | Client-only — refusal; witness owed |
-| HS-29 | `n/use-frame` | [native surface](lanes/ergonomics-api.md#optional-native-surface) | `n/defcomponent` | Client-only until its component selects Render | Client-only — refusal; witness owed |
-| HS-30 | Native ABI helpers: memo, lazy, ref, and both embedding directions | [native surface](lanes/ergonomics-api.md#optional-native-surface) | Memo/lazy/ref helpers | Client-only until the component declaration selects Render | Client-only — refusal; witness owed |
-| HS-31 | Optional forms module | 4.2 | Optional module | Client-only until its module contract selects Render | Client-only — refusal; witness owed |
-| HS-32 | Optional overlay module (popover and modal) | 7 | Optional module | Client-only until its module contract selects Render | Client-only — refusal; witness owed |
-| HS-33 | Optional motion and presence module | 7 | Optional module | Client-only until its module contract selects Render | Client-only — refusal; witness owed |
-| HS-34 | Optional routing-integration module | 7 | Optional module | Client-only until its module contract selects Render | Client-only — refusal; witness owed |
-| HS-35 | Committed-read resource-demand boundary (conditional on its graduating verdict) | 7 | Resource-demand boundary | Client-only until its module contract selects Render | Client-only — refusal; witness owed |
+| HS-01 | `h/defview` boundary | 4 | `h/defview` with `h/sub` | Render | Client-only — refusal until rf2-hic-046 |
+| HS-02 | `h/sub` read during a server render | 4 | `h/defview` with `h/sub` | Render | Client-only — refusal until rf2-hic-046 |
+| HS-03 | `h/handler` and literal intent vectors | 4.1 | Intrinsic/fragment Hiccup | Render | Client-only — refusal until rf2-hic-046 |
+| HS-04 | Intrinsic element head, including SVG and custom elements | 4 | Intrinsic/fragment Hiccup | Render | Client-only — refusal until rf2-hic-046 |
+| HS-05 | Fragment head | 4 | Intrinsic/fragment Hiccup | Render | Client-only — refusal until rf2-hic-046 |
+| HS-06 | Props map and canonical slot naming | 4 | Intrinsic/fragment Hiccup | Render | Client-only — refusal until rf2-hic-046 |
+| HS-07 | Reserved data vocabulary: event value, checked value, explicit prevention, controlled revision | 4 | Controlled DOM fields | Render | Client-only — refusal until rf2-hic-046 |
+| HS-08 | Controlled DOM fields as a class (per-control rows in [2.3](#23-per-control-and-dom-conformance-dispositions)) | 4.2 | Controlled DOM fields | Render | Client-only — refusal until rf2-hic-046 |
+| HS-09 | `h/error-boundary` | 4 | `h/error-boundary` | Render | Client-only — refusal until rf2-hic-046 |
+| HS-10 | `h/mount!` | 4 | Root/frame provider | Client-only (client root creation; recovery is the server render entry plus `h/hydrate!`) | Client-only — refusal until rf2-hic-046 |
+| HS-11 | `h/hydrate!` | 4 | Root/frame provider | Client-only (the adoption half of every Render row) | Client-only — refusal until rf2-hic-046 |
+| HS-12 | `h/render!` | 4 | Root/frame provider | Client-only | Client-only — refusal until rf2-hic-046 |
+| HS-13 | `h/unmount!` | 4 | Root/frame provider | Client-only | Client-only — refusal until rf2-hic-046 |
+| HS-14 | Root and frame-provider element, including `identifierPrefix` | 4 | Root/frame provider | Render | Client-only — refusal until rf2-hic-046 |
+| HS-15 | Attribute-merge helper (public only if a witness needs it) | 4 | Intrinsic/fragment Hiccup | Render | Client-only — refusal until rf2-hic-046 |
+| HS-16 | `h/defhost` declaration | 4.3 | Declared host | Client-only until the host declaration selects Render | Client-only — refusal until rf2-hic-046 |
+| HS-17 | Declared ReactNode positions and named content slots | 4.3 | Declared host | Client-only until the host declaration selects Render | Client-only — refusal until rf2-hic-046 |
+| HS-18 | Render-prop callback lowered through `h/as-element` | 4.3 | Declared host | Client-only until the host declaration selects Render | Client-only — refusal until rf2-hic-046 |
+| HS-19 | Raw React element head | 4 | Raw React or opaque component | Client-only until classified by an enclosing view or host policy | Client-only — refusal until rf2-hic-046 |
+| HS-20 | Portal helper | 4.3 | Portal helper | Client-only | Client-only — refusal until rf2-hic-046 |
+| HS-21 | Outward bridge: a Hicasso view under a native React parent | 4.3 | Root/frame provider and outward bridge | Render | Client-only — refusal until rf2-hic-046 |
+| HS-22 | `React.lazy` boundary-ABI bridge and Hiccup-aware Suspense host | 7 | Lazy/Suspense/error boundary | Client-only until every server branch and the selected React server API are declared | Client-only — refusal until rf2-hic-046 |
+| HS-23 | Activity-hosted subtree | 8 | Declared host | Client-only | Client-only — refusal until rf2-hic-046 |
+| HS-24 | `n/$` intrinsic form | [native surface](lanes/ergonomics-api.md#optional-native-surface) | Intrinsic `n/$` | Render | Client-only — refusal until rf2-hic-046 |
+| HS-25 | `n/$` component-headed form | [native surface](lanes/ergonomics-api.md#optional-native-surface) | `n/defcomponent` and component-headed `n/$` | Client-only until the component declaration selects Render | Client-only — refusal until rf2-hic-046 |
+| HS-26 | `n/props` marker | [n/$ grammar](lanes/ergonomics-api.md#provisional-n-grammar) | Intrinsic `n/$` | Render | Client-only — refusal until rf2-hic-046 |
+| HS-27 | `n/defcomponent` | [native surface](lanes/ergonomics-api.md#optional-native-surface) | `n/defcomponent` | Client-only unless the declaration selects `:render` | Client-only — refusal until rf2-hic-046 |
+| HS-28 | `n/use-sub` | [native surface](lanes/ergonomics-api.md#optional-native-surface) | `n/defcomponent` | Client-only until its component selects Render | Client-only — refusal until rf2-hic-046 |
+| HS-29 | `n/use-frame` | [native surface](lanes/ergonomics-api.md#optional-native-surface) | `n/defcomponent` | Client-only until its component selects Render | Client-only — refusal until rf2-hic-046 |
+| HS-30 | Native ABI helpers: memo, lazy, ref, and both embedding directions | [native surface](lanes/ergonomics-api.md#optional-native-surface) | Memo/lazy/ref helpers | Client-only until the component declaration selects Render | Client-only — refusal until rf2-hic-046 |
+| HS-31 | Optional forms module | 4.2 | Optional module | Client-only until its module contract selects Render | Client-only — refusal until rf2-hic-046 |
+| HS-32 | Optional overlay module (popover and modal) | 7 | Optional module | Client-only until its module contract selects Render | Client-only — refusal until rf2-hic-046 |
+| HS-33 | Optional motion and presence module | 7 | Optional module | Client-only until its module contract selects Render | Client-only — refusal until rf2-hic-046 |
+| HS-34 | Optional routing-integration module | 7 | Optional module | Client-only until its module contract selects Render | Client-only — refusal until rf2-hic-046 |
+| HS-35 | Committed-read resource-demand boundary (conditional on its graduating verdict) | 7 | Resource-demand boundary | Client-only until its module contract selects Render | Client-only — refusal until rf2-hic-046 |
 
 Three notes on the target-policy column, so no reader mistakes a Client-only target for a defect:
 
@@ -203,8 +203,9 @@ as a class for *server rendering*; this table dispositions each control type for
 controlled-field law, across the three supported browser engines.
 
 The roster below is the countable one: every control and DOM conformance case named in
-[specification section 4.2](specification.md#42-controlled-fields) and in the control-conformance programme. No control
-may be silently unsupported, so a row that never acquires a policy is itself a failure.
+[specification section 4.2](specification.md#42-controlled-fields) and in the control-conformance programme, which is
+owned by `rf2-hic-040`. No control may be silently unsupported, so a row that never acquires a policy is itself a
+failure.
 
 | Control or conformance case | Support-or-refusal policy | Witness |
 |---|---|---|
@@ -230,8 +231,8 @@ may be silently unsupported, so a row that never acquires a policy is itself a f
 | Custom elements | Owed | Owed |
 
 Every cell reads Owed because Phase 0 precedes the conformance run. The rows exist now so the run has a fixed roster to
-fill and cannot quietly shrink; the control-conformance owner replaces the cells in place and adds a row only for a
-control case this roster missed.
+fill and cannot quietly shrink; `rf2-hic-040` replaces the cells in place and adds a row only for a control case this
+roster missed.
 
 ### 2.4 The default rule and how a row is upgraded
 
@@ -240,7 +241,8 @@ described as rendering because it plausibly would, because its class default say
 prove it. This is what keeps the Phase 4 witness matrix bounded: the matrix has to close over what is claimed, so
 nothing is claimed before it is shown.
 
-**The upgrade.** One route only. A surface moves from Client-only to Render when a witness proves, for that surface:
+**The upgrade.** One route only, owned by `rf2-hic-046`. A surface moves from Client-only to Render when a witness
+proves, for that surface:
 deterministic server bytes from an immutable request snapshot; matching hydration; deliberate mismatch attributed to
 source; two simultaneous hydrating roots with a stable `identifierPrefix`; and exact cleanup on unmount. Rows that read
 or demand resources additionally prove no duplicate acquisition. The witness id then replaces "witness owed" in the
@@ -258,9 +260,9 @@ those amendments from colliding.
 |---|---|---|
 | [1.1](#11-classification-table) | The coverage-matrix owner | Change a Gap to Claimed only when a bead actually owns the missing proof; never change a Home without a specification change behind it |
 | [1.2](#12-rows-without-a-complete-planned-witness) | The coverage-matrix owner | Remove a bullet when its gap is genuinely owned; add one when a new gap is found |
-| [2.1](#21-surface-inventory-and-dispositions) | The per-surface SSR/hydration witness owner | Rewrite the operative-disposition cell of an existing row; append a row for a surface created after Phase 0 |
-| [2.2](#22-public-surfaces-with-no-server-render-behavior) | The per-surface SSR/hydration witness owner | Append a row for a new non-rendering public surface |
-| [2.3](#23-per-control-and-dom-conformance-dispositions) | The control-conformance owner | Fill the policy and witness cells; append a row for a missed control case |
+| [2.1](#21-surface-inventory-and-dispositions) | Per-surface SSR/hydration witnesses (`rf2-hic-046`) | Rewrite the operative-disposition cell of an existing row; append a row for a surface created after Phase 0 |
+| [2.2](#22-public-surfaces-with-no-server-render-behavior) | Per-surface SSR/hydration witnesses (`rf2-hic-046`) | Append a row for a new non-rendering public surface |
+| [2.3](#23-per-control-and-dom-conformance-dispositions) | Control/DOM conformance (`rf2-hic-040`) | Fill the policy and witness cells; append a row for a missed control case |
 | [2.4](#24-the-default-rule-and-how-a-row-is-upgraded) | Product operator | Change the rule itself |
 
 Two constraints apply to every amendment. **Amend in place; do not restructure.** Two beads in the same wave write into

--- a/docs/design/hicasso/product/dispositions.md
+++ b/docs/design/hicasso/product/dispositions.md
@@ -1,0 +1,271 @@
+# Hicasso dispositions — coverage classification and per-surface server policy
+
+Phase 0 owes two ledgers, and this document is both of them: the classification of every
+[specification section 7](specification.md#7-complete-use-case-coverage) use case into the layer that answers it, and a
+server/hydration disposition for every proposed public surface. The second ledger is owed whether or not the optional
+Node service is ever activated — the [decision brief](decision-brief.md) states the rule as "the server/hydration
+contract is core, per public surface", and [design law Language 8](lanes/design-laws.md#language-and-interop) repeats it.
+
+This document classifies and dispositions. It does not decide policy: the
+[canonical SSR/hydration matrix](lanes/react-compatibility-notes.md#public-surface-ssrhydration-matrix) owns the two
+policies and the witness obligations for each surface class, the specification owns capability placement, and
+[`completeness-audit.md`](lanes/completeness-audit.md) owns the proof suites. What is new here is the per-surface
+accounting: a unique inventory id for every public surface, so that a surface cannot be added, shipped, or forgotten
+without a row.
+
+## How to read this document
+
+Three conventions carry the whole document.
+
+**Every name here is provisional; every id is not.** API spellings freeze at their named witnesses (ordinary surfaces
+after Phase 2, host and native surfaces after Phase 3), and open naming questions live in
+[`naming-ledger.md`](naming-ledger.md). Inventory ids are permanent from the moment they are minted. A renamed surface
+keeps its id; a new surface takes the next free id; ids are never reused and never renumbered.
+
+**Nothing in this document is a claim of evidence.** Phase 0 precedes every witness. The coverage table records where
+each job is answered, not that it has been proved; the surface table records what each surface's server behavior is
+required to become, not what it does. Both tables carry an explicit status column, and both say "unwitnessed" wherever
+that is the truth.
+
+**The default is refusal with recovery.** Where server behavior is not yet proven, the operative disposition is
+Client-only: refuse at the declaration source and name a deterministic fallback. This is what keeps the Phase 4 witness
+matrix bounded. Section [2.4](#24-the-default-rule-and-how-a-row-is-upgraded) states the rule and the only route out of
+it.
+
+## 1. Coverage classification — specification section 7
+
+Each of the twenty rows in [specification section 7](specification.md#7-complete-use-case-coverage) is assigned a
+**primary home** from the five permitted layers — core, optional module, recipe, host escape, didactic refusal — plus the
+additional surfaces that complete the answer and the refusals that bound it. The primary home is where an application
+finds the answer first; the additional-surface column carries the rest.
+
+No row's primary home is a didactic refusal. That is a finding, not an omission: section 7 exists precisely because every
+recurring job has a maintained answer somewhere, so refusals in this table appear as bounds on an answer rather than as
+the answer itself. The refusals that stand alone are catalogued in
+[`completeness-audit.md`](lanes/completeness-audit.md) and
+[design law Economics 5](lanes/design-laws.md#economics-and-scope).
+
+### 1.1 Classification table
+
+| Use case (section 7) | Primary home | Additional surfaces | Refusal or non-goal that bounds it | Planned witness | Source |
+|---|---|---|---|---|---|
+| Ordinary pages, conditional UI, dynamic lists | Core | None | No compiled Hiccup mode, no automatic specialization, no execution-mode flag | Gap — see [1.2](#12-rows-without-a-complete-planned-witness) | 7; [3.3](specification.md#33-dynamic-composition-is-a-feature) |
+| Forms and controlled fields | Core (controlled law and revision) | Optional forms module; forms recipes; buffered-draft helper at its second caller | Buffered drafts, touched/submit-attempt validation and mutation status stay out of the boundary shell | Gap — see [1.2](#12-rows-without-a-complete-planned-witness) | [4.2](specification.md#42-controlled-fields) |
+| Validation and async normalization | Core (derived subscriptions and event data) | Validation-gating and settle-merge recipes | No adapter validation framework | Claimed | [4.2](specification.md#42-controlled-fields); 7 |
+| Routing and navigation | Optional module (routing integration) | Dirty-leave, scroll-restoration and focus-on-route recipes | No router in core; routing stays small | Claimed | 7; [`use-cases.md`](lanes/use-cases.md) |
+| Async resources and mutations | Core (the re-frame2 resource/event model, outside the adapter) | Mutation-status and settle-merge recipes; committed-read resource demand as a gated spike | No automatic fetching or Suspense inferred from reads; no second per-read ledger | Claimed | 7; [`completeness-audit.md`](lanes/completeness-audit.md) |
+| Errors | Core (`h/error-boundary`) | Expected failures remain data | No second exception model | Gap — see [1.2](#12-rows-without-a-complete-planned-witness) | 7; [4](specification.md#4-target-programming-model) |
+| Foreign React ecosystem and native hot work | Host escape (`h/defhost`, raw element, `h/as-element`) | Optional Hicasso-native namespace; library-specific wrappers; optional UIx route; outward bridge | No general React wrapper language, no UIx clone, no host-schema language | Claimed | [4.3](specification.md#43-host-interop); [native-boundary law](lanes/design-laws.md#native-boundary) |
+| Large collections | Core (read topology and keys) | Blessed foreign virtualizer recipe | No keyed-list maintenance machinery before a red bulk verdict | Claimed | [Rung 2](specification.md#rung-2--tune-hicasso-topology); 7 |
+| Imperative SDKs | Host escape (declared host ownership) | Acquire/release recipe | No lifecycle or effect DSL | Claimed | [4.3](specification.md#43-host-interop) |
+| Overlays and focus | Core (native HTML where possible) | Optional popover/modal module on top-layer primitives | No overlay manager in core | Claimed | 7; [Phase 5](specification.md#phase-5--decide-differentiators-and-add-high-value-optional-products) |
+| Motion and high-rate input | Optional module (presence posture) | Native host-local animation and drag state | No animation system in core; high-rate mechanics stay host-private | Gap — see [1.2](#12-rows-without-a-complete-planned-witness) | 7; [6](specification.md#6-performance-contract) |
+| Code splitting | Core (small `React.lazy` boundary-ABI bridge) | Hiccup-aware Suspense/error host | No late-bound view-id registry | Claimed | 7; [`completeness-audit.md`](lanes/completeness-audit.md) |
+| Multiple frames and roots | Core (shared frame context with isolated ownership) | Explicit independent root when isolation requires one | An independent root is an isolation choice, never a performance tier | Claimed | [Rung 5](specification.md#rung-5--native-screen); 7 |
+| Suspense and Activity | Host escape (React-owned lifecycle behind a declared host) | — | No Activity DSL; compatibility only | Claimed | 7; [Activity witness](lanes/react-compatibility-notes.md#activity-lifecycle-witness) |
+| SSR and hydration | Core (per-surface policy — section [2](#2-public-surface-ssrhydration-dispositions) of this document) | Optional Node service for a named caller | No JVM twin, no second renderer, no hydration-free inference | Claimed | 7; [8](specification.md#8-modern-react-compatibility); [Language 8](lanes/design-laws.md#language-and-interop) |
+| Accessibility | Core (semantic Hiccup and native controls) | Structural a11y assertions plus browser focus tests | No accessibility subsystem | Gap — see [1.2](#12-rows-without-a-complete-planned-witness) | 7 |
+| i18n and theming | Recipe (ordinary data, classes, CSS variables, context through hosts) | — | No adapter subsystem; parts registries and tree rewriting deferred | Gap — see [1.2](#12-rows-without-a-complete-planned-witness) | 7; [`use-cases.md`](lanes/use-cases.md) |
+| Testing | Core developer product (the supported test namespace, L0–L4) | Mounted DOM and browser tiers | No shallow renderer, no fake hooks runtime, no retired test renderer | Gap — see [1.2](#12-rows-without-a-complete-planned-witness) | [9](specification.md#9-testing-as-a-product-surface) |
+| Diagnostics | Core developer product (versioned evidence projection) | Xray/Pair causal and heat views | No parallel graph or history system; no production sentinels | Gap — see [1.2](#12-rows-without-a-complete-planned-witness) | [10](specification.md#10-xray-and-runtime-evidence) |
+| Migration | Developer product (reporter and explicit refusal classes) | Shadow DOM/intent comparison; cautious codemod only afterwards | No rewriting codemod before reporter and shadow evidence | Gap — see [1.2](#12-rows-without-a-complete-planned-witness) | 7; [Phase 5](specification.md#phase-5--decide-differentiators-and-add-high-value-optional-products) |
+
+The Source column cites specification sections by number; a bare number is a section of
+[`specification.md`](specification.md).
+
+### 1.2 Rows without a complete planned witness
+
+Nine of the twenty rows above are marked Gap. The distinction that column draws is deliberate and narrow:
+
+- **Claimed** means the programme names a bead that intends to witness the row. It does not mean the witness exists, and
+  it does not mean the bead's acceptance covers the whole row.
+- **Gap** means that even after the programme's final coverage audit completes, the row can still lack the proof
+  section 7 requires — because no bead owns that proof, or because the owning bead's acceptance does not reach it.
+
+The nine gaps and their causes are recorded in the bead-set review's
+[section 1.3](lanes/beads-review.md#13-7-rows-that-can-remain-unwitnessed-when-hic-064-completes), and are reproduced
+here only as a classification input:
+
+- **Ordinary pages, conditional UI, dynamic lists** — one small article flow is named; no Todo flow is, and pagination
+  and runtime-selected content have no owner, so the required Todo and RealWorld-class coverage is not complete.
+- **Forms and controlled fields** — the browser control matrix is owned, but no bead owns the four-field editor and
+  100-cell grid as public-package applications; only their explanatory pages are owned.
+- **Errors** — thrown render and retry are covered; the nested error region that section 7 explicitly requires is not
+  witnessed by any bead.
+- **Motion and high-rate input** — interruption, rapid toggle and teardown are witnessed; the required frame budget is
+  never measured by the owning acceptance.
+- **Accessibility** — focus order and axe are named; keyboard conduct is not, and the virtualizer and overlay clauses
+  reference artifacts that have no ordering edge or later integration run.
+- **i18n and theming** — no bead owns runtime locale and theme-change evidence.
+- **Testing** — the L0 public contract and the L1 codec/intent/native-expansion surface have no owner, so the supported
+  ladder and its positive/sabotage controls at every tier are unproved.
+- **Diagnostics** — loss accounting and production erasure are owned; the core privacy projection has no mandatory
+  witness on the release path.
+- **Migration** — the owning bead permits in-repo Reagent examples as a substitute, which is weaker than the three
+  representative repositories section 7 requires.
+
+Closing a gap is not this document's work. The classification is only honest if it says which rows are answered on paper
+and unproved in fact; making them proved belongs to the beads that own the coverage matrix.
+
+## 2. Public-surface SSR/hydration dispositions
+
+Every proposed public surface — view, read, root, host, escape, native-tier form, and optional module — has a row here
+with a unique inventory id. The two policies are the canonical ones:
+
+- **Render** — produce deterministic React server output from an immutable request frame or snapshot, and support
+  matching hydration.
+- **Client-only** — refuse server use at the declaration source and name an explicit deterministic fallback or recovery.
+  Returning a silent `nil` is not a policy.
+
+Each row carries both a **target policy** and an **operative disposition**. The target policy is the surface class's
+default in the [canonical matrix](lanes/react-compatibility-notes.md#public-surface-ssrhydration-matrix) — what the
+surface is expected to become once its behavior is proved. The operative disposition is what the surface is entitled to
+do *today*, and today it is Client-only for every row without exception, because no server witness exists for any
+Hicasso surface yet. The operative column is therefore the upgrade slot: see
+[2.4](#24-the-default-rule-and-how-a-row-is-upgraded).
+
+### 2.1 Surface inventory and dispositions
+
+| Id | Public surface | Source | Canonical matrix class | Target policy | Operative disposition (today) |
+|---|---|---|---|---|---|
+| HS-01 | `h/defview` boundary | 4 | `h/defview` with `h/sub` | Render | Client-only — refusal; witness owed |
+| HS-02 | `h/sub` read during a server render | 4 | `h/defview` with `h/sub` | Render | Client-only — refusal; witness owed |
+| HS-03 | `h/handler` and literal intent vectors | 4.1 | Intrinsic/fragment Hiccup | Render | Client-only — refusal; witness owed |
+| HS-04 | Intrinsic element head, including SVG and custom elements | 4 | Intrinsic/fragment Hiccup | Render | Client-only — refusal; witness owed |
+| HS-05 | Fragment head | 4 | Intrinsic/fragment Hiccup | Render | Client-only — refusal; witness owed |
+| HS-06 | Props map and canonical slot naming | 4 | Intrinsic/fragment Hiccup | Render | Client-only — refusal; witness owed |
+| HS-07 | Reserved data vocabulary: event value, checked value, explicit prevention, controlled revision | 4 | Controlled DOM fields | Render | Client-only — refusal; witness owed |
+| HS-08 | Controlled DOM fields as a class (per-control rows in [2.3](#23-per-control-and-dom-conformance-dispositions)) | 4.2 | Controlled DOM fields | Render | Client-only — refusal; witness owed |
+| HS-09 | `h/error-boundary` | 4 | `h/error-boundary` | Render | Client-only — refusal; witness owed |
+| HS-10 | `h/mount!` | 4 | Root/frame provider | Client-only (client root creation; recovery is the server render entry plus `h/hydrate!`) | Client-only — refusal; witness owed |
+| HS-11 | `h/hydrate!` | 4 | Root/frame provider | Client-only (the adoption half of every Render row) | Client-only — refusal; witness owed |
+| HS-12 | `h/render!` | 4 | Root/frame provider | Client-only | Client-only — refusal; witness owed |
+| HS-13 | `h/unmount!` | 4 | Root/frame provider | Client-only | Client-only — refusal; witness owed |
+| HS-14 | Root and frame-provider element, including `identifierPrefix` | 4 | Root/frame provider | Render | Client-only — refusal; witness owed |
+| HS-15 | Attribute-merge helper (public only if a witness needs it) | 4 | Intrinsic/fragment Hiccup | Render | Client-only — refusal; witness owed |
+| HS-16 | `h/defhost` declaration | 4.3 | Declared host | Client-only until the host declaration selects Render | Client-only — refusal; witness owed |
+| HS-17 | Declared ReactNode positions and named content slots | 4.3 | Declared host | Client-only until the host declaration selects Render | Client-only — refusal; witness owed |
+| HS-18 | Render-prop callback lowered through `h/as-element` | 4.3 | Declared host | Client-only until the host declaration selects Render | Client-only — refusal; witness owed |
+| HS-19 | Raw React element head | 4 | Raw React or opaque component | Client-only until classified by an enclosing view or host policy | Client-only — refusal; witness owed |
+| HS-20 | Portal helper | 4.3 | Portal helper | Client-only | Client-only — refusal; witness owed |
+| HS-21 | Outward bridge: a Hicasso view under a native React parent | 4.3 | Root/frame provider and outward bridge | Render | Client-only — refusal; witness owed |
+| HS-22 | `React.lazy` boundary-ABI bridge and Hiccup-aware Suspense host | 7 | Lazy/Suspense/error boundary | Client-only until every server branch and the selected React server API are declared | Client-only — refusal; witness owed |
+| HS-23 | Activity-hosted subtree | 8 | Declared host | Client-only | Client-only — refusal; witness owed |
+| HS-24 | `n/$` intrinsic form | [native surface](lanes/ergonomics-api.md#optional-native-surface) | Intrinsic `n/$` | Render | Client-only — refusal; witness owed |
+| HS-25 | `n/$` component-headed form | [native surface](lanes/ergonomics-api.md#optional-native-surface) | `n/defcomponent` and component-headed `n/$` | Client-only until the component declaration selects Render | Client-only — refusal; witness owed |
+| HS-26 | `n/props` marker | [n/$ grammar](lanes/ergonomics-api.md#provisional-n-grammar) | Intrinsic `n/$` | Render | Client-only — refusal; witness owed |
+| HS-27 | `n/defcomponent` | [native surface](lanes/ergonomics-api.md#optional-native-surface) | `n/defcomponent` | Client-only unless the declaration selects `:render` | Client-only — refusal; witness owed |
+| HS-28 | `n/use-sub` | [native surface](lanes/ergonomics-api.md#optional-native-surface) | `n/defcomponent` | Client-only until its component selects Render | Client-only — refusal; witness owed |
+| HS-29 | `n/use-frame` | [native surface](lanes/ergonomics-api.md#optional-native-surface) | `n/defcomponent` | Client-only until its component selects Render | Client-only — refusal; witness owed |
+| HS-30 | Native ABI helpers: memo, lazy, ref, and both embedding directions | [native surface](lanes/ergonomics-api.md#optional-native-surface) | Memo/lazy/ref helpers | Client-only until the component declaration selects Render | Client-only — refusal; witness owed |
+| HS-31 | Optional forms module | 4.2 | Optional module | Client-only until its module contract selects Render | Client-only — refusal; witness owed |
+| HS-32 | Optional overlay module (popover and modal) | 7 | Optional module | Client-only until its module contract selects Render | Client-only — refusal; witness owed |
+| HS-33 | Optional motion and presence module | 7 | Optional module | Client-only until its module contract selects Render | Client-only — refusal; witness owed |
+| HS-34 | Optional routing-integration module | 7 | Optional module | Client-only until its module contract selects Render | Client-only — refusal; witness owed |
+| HS-35 | Committed-read resource-demand boundary (conditional on its graduating verdict) | 7 | Resource-demand boundary | Client-only until its module contract selects Render | Client-only — refusal; witness owed |
+
+Three notes on the target-policy column, so no reader mistakes a Client-only target for a defect:
+
+1. **The root lifecycle functions are Client-only by nature, not by default.** `h/mount!`, `h/hydrate!`, `h/render!` and
+   `h/unmount!` are client entry points; none of them emits server bytes. Their obligation is to refuse a server call at
+   source with the correct recovery, and — for HS-11 — to adopt server bytes with a matching `identifierPrefix` across
+   two simultaneous roots without a process-global adoption window. The Render obligation on the tree they mount belongs
+   to HS-14.
+2. **Client-only-until is a declaration gate, not a rejection.** HS-16 to HS-19 and HS-25 to HS-30 become Render when
+   the host or component declaration selects it and the corresponding witness passes. The default exists so an
+   undeclared foreign or native component cannot silently enlarge the matrix.
+3. **A Client-only row still owes a witness.** The refusal must be shown to fire, at source, with its recovery — an
+   unproved refusal is not a disposition. The
+   [canonical matrix](lanes/react-compatibility-notes.md#public-surface-ssrhydration-matrix) states the required states
+   for both policies.
+
+### 2.2 Public surfaces with no server-render behavior
+
+These are public surfaces of the product but not of the rendered tree, so they carry no Render/Client-only policy. They
+are inventoried anyway, so that "every public surface has a disposition" is a countable claim rather than a claim about
+the surfaces someone remembered.
+
+| Id | Public surface | Source | Disposition |
+|---|---|---|---|
+| HS-36 | Supported test namespace | 9 | Development-only; absent from production and server bundles; proves its own erasure |
+| HS-37 | Xray and Pair evidence projection | 10 | Development-only; versioned, privacy-projected, loss-accounted; no production sentinels |
+| HS-38 | clj-kondo exports and optional dev schemas | [editor ergonomics](lanes/ergonomics-api.md#editor-and-diagnostic-ergonomics) | Development-only; no production cost; no whole-program analysis implied |
+| HS-39 | Bounded Node/React SSR service | [Phase 5](specification.md#phase-5--decide-differentiators-and-add-high-value-optional-products) | Caller-gated deployable service, not a view surface; its operational contract is separate from every surface policy above |
+
+HS-39 is the only genuinely optional part of the server story. Its absence changes nothing in
+[2.1](#21-surface-inventory-and-dispositions): a client-only application still owes every surface a server policy and a
+hydration contract.
+
+### 2.3 Per-control and DOM-conformance dispositions
+
+This section is a distinct axis from [2.1](#21-surface-inventory-and-dispositions). HS-08 dispositions controlled fields
+as a class for *server rendering*; this table dispositions each control type for *support or refusal* under the
+controlled-field law, across the three supported browser engines.
+
+The roster below is the countable one: every control and DOM conformance case named in
+[specification section 4.2](specification.md#42-controlled-fields) and in the control-conformance programme. No control
+may be silently unsupported, so a row that never acquires a policy is itself a failure.
+
+| Control or conformance case | Support-or-refusal policy | Witness |
+|---|---|---|
+| Text input | Owed | Owed |
+| Textarea | Owed | Owed |
+| Checkbox | Owed | Owed |
+| Radio | Owed | Owed |
+| Select (single) | Owed | Owed |
+| Select (multiple) | Owed | Owed |
+| File input | Owed | Owed |
+| Number input | Owed | Owed |
+| Date input | Owed | Owed |
+| Range input | Owed | Owed |
+| Contenteditable | Owed | Owed |
+| Composition and IME | Owed | Owed |
+| Caret and selection preservation | Owed | Owed |
+| Blur after unmount | Owed | Owed |
+| Async normalization | Owed | Owed |
+| Autofill | Owed | Owed |
+| Form reset | Owed | Owed |
+| FormData extraction | Owed | Owed |
+| SVG attributes | Owed | Owed |
+| Custom elements | Owed | Owed |
+
+Every cell reads Owed because Phase 0 precedes the conformance run. The rows exist now so the run has a fixed roster to
+fill and cannot quietly shrink; the control-conformance owner replaces the cells in place and adds a row only for a
+control case this roster missed.
+
+### 2.4 The default rule and how a row is upgraded
+
+**The rule.** Where server behavior is not yet proven, the disposition is refusal with recovery. A surface may not be
+described as rendering because it plausibly would, because its class default says Render, or because a bead intends to
+prove it. This is what keeps the Phase 4 witness matrix bounded: the matrix has to close over what is claimed, so
+nothing is claimed before it is shown.
+
+**The upgrade.** One route only. A surface moves from Client-only to Render when a witness proves, for that surface:
+deterministic server bytes from an immutable request snapshot; matching hydration; deliberate mismatch attributed to
+source; two simultaneous hydrating roots with a stable `identifierPrefix`; and exact cleanup on unmount. Rows that read
+or demand resources additionally prove no duplicate acquisition. The witness id then replaces "witness owed" in the
+operative column and the policy is rewritten to Render.
+
+**The downgrade.** A surface whose witness later fails returns to Client-only in the same edit that reds the witness. A
+row is never left claiming a policy its evidence no longer supports.
+
+## 3. Append protocol and ownership
+
+This file is written once and amended many times, by beads that do not otherwise share a surface. The protocol keeps
+those amendments from colliding.
+
+| Section | Owner after Phase 0 | Permitted amendment |
+|---|---|---|
+| [1.1](#11-classification-table) | The coverage-matrix owner | Change a Gap to Claimed only when a bead actually owns the missing proof; never change a Home without a specification change behind it |
+| [1.2](#12-rows-without-a-complete-planned-witness) | The coverage-matrix owner | Remove a bullet when its gap is genuinely owned; add one when a new gap is found |
+| [2.1](#21-surface-inventory-and-dispositions) | The per-surface SSR/hydration witness owner | Rewrite the operative-disposition cell of an existing row; append a row for a surface created after Phase 0 |
+| [2.2](#22-public-surfaces-with-no-server-render-behavior) | The per-surface SSR/hydration witness owner | Append a row for a new non-rendering public surface |
+| [2.3](#23-per-control-and-dom-conformance-dispositions) | The control-conformance owner | Fill the policy and witness cells; append a row for a missed control case |
+| [2.4](#24-the-default-rule-and-how-a-row-is-upgraded) | Product operator | Change the rule itself |
+
+Two constraints apply to every amendment. **Amend in place; do not restructure.** Two beads in the same wave write into
+sections [2.1](#21-surface-inventory-and-dispositions) and
+[2.3](#23-per-control-and-dom-conformance-dispositions) respectively, and they only stay out of each other's way if both
+append into their named section rather than rewriting the document. **Adding a public surface adds an id.** A surface
+that reaches the facade without a row here has escaped the inventory, and the Phase 4 exit — every inventory id pointing
+at an applicable green row — silently stops meaning anything.


### PR DESCRIPTION
Creates `docs/design/hicasso/product/dispositions.md`, the Phase 0 disposition ledger. One new file; nothing else is touched.

## What it contains

**Section 1 — coverage classification.** All twenty specification section 7 use-case rows, each assigned a primary home from the five permitted layers (core / optional module / recipe / host escape / didactic refusal), plus the additional surfaces that complete the answer, the refusal that bounds it, its planned-witness status, and its specification source. The rows are reproduced in the specification's own order and wording — verified programmatically, see below.

One finding worth flagging: **no section 7 row's primary home is a didactic refusal.** That is not an omission. Section 7 exists because every recurring job has a maintained answer somewhere, so refusals show up as bounds on an answer rather than as the answer. The document says so explicitly rather than leaving a reader to wonder whether the fifth category was forgotten.

**Section 2 — per-surface server policy.** Thirty-five rendered public surfaces (HS-01 to HS-35) and four non-rendering public surfaces (HS-36 to HS-39), each with a permanent inventory id. Ids are never reused or renumbered; a renamed surface keeps its id. Each rendered row separates two things that are easy to conflate:

- **target policy** — the surface class's default in the canonical SSR/hydration matrix, i.e. what the surface is expected to become;
- **operative disposition** — what it is entitled to do today. All 35 rows read `Client-only — refusal until rf2-hic-046`, without exception, because no Hicasso server witness exists yet. No row claims Render, so no Render claim is made without a witness behind it.

The operative column is the upgrade slot, and it names the bead that owns the upgrade rather than saying "witness owed" — an append protocol that says "the relevant owner" is exactly the vagueness the review asked to be replaced with exact files and exact owners. Section 2.3's roster names `rf2-hic-040` the same way. Section 2.4 states the single route out of it (deterministic bytes from an immutable snapshot, matching hydration, mismatch attributed to source, two roots with a stable `identifierPrefix`, exact cleanup; resource-reading rows also prove no duplicate acquisition) and the corresponding downgrade rule.

Three target policies are Client-only *by nature* rather than by default, and the document says why so nobody reads them as defects: the root lifecycle functions never emit server bytes (their obligation is to refuse a server call at source with the right recovery, and for `h/hydrate!` to adopt bytes with a matching `identifierPrefix`), Client-only-until is a declaration gate rather than a rejection, and a Client-only row still owes a witness — an unproved refusal is not a disposition.

## Which section 7 rows are classified as unwitnessed, and why

Nine of the twenty are marked **Gap**; eleven are marked **Claimed**. The distinction is stated in the document and is deliberately narrow: *Claimed* means a bead owns the proof, not that the proof exists; *Gap* means that even after the final coverage audit completes, the row can still lack the proof section 7 requires. **A row is never marked covered because a bead intends to cover it.**

The nine, with the cause in one line each (source: the bead-set review's section 1.3, which is on main):

| Row | Why it is unwitnessed |
|---|---|
| Ordinary pages, conditional UI, dynamic lists | One small article flow is named; no Todo flow is, and pagination and runtime content have no owner, so Todo + RealWorld-class coverage is incomplete |
| Forms and controlled fields | The browser control matrix is owned, but no bead owns the four-field editor and 100-cell grid as public-package applications — only their explanatory pages |
| Errors | Thrown render and retry are covered; the nested error region section 7 explicitly requires is witnessed by nobody |
| Motion and high-rate input | Interruption, rapid toggle and teardown are witnessed; the required frame budget is never measured by the owning acceptance |
| Accessibility | Focus order and axe are named, keyboard conduct is not; the virtualizer and overlay clauses reference artifacts with no ordering edge or later integration run |
| i18n and theming | No bead owns runtime locale and theme-change evidence |
| Testing | The L0 public contract and L1 codec/intent/native-expansion surface have no owner, so the supported ladder and its per-tier sabotage controls are unproved |
| Diagnostics | Loss accounting and erasure are owned; the core privacy projection has no mandatory witness on the release path |
| Migration | The owning bead permits in-repo Reagent examples, weaker than the three representative repositories section 7 requires |

Section 1.2 also says plainly that closing these gaps is not this document's job — the classification is only honest if it names them.

## Structured for the later beads, without doing their work

The review records that two later beads write into this file and neither declares it. The document is therefore sectioned so they append into named sections rather than rewriting it, and section 3 makes the protocol explicit as an owner-per-section table:

- **Control-conformance owner** gets section 2.3, a *different axis* from section 2.1 — HS-08 dispositions controlled fields as a class for server rendering, while 2.3 dispositions each control type for support-or-refusal across the three engines. The roster is pre-seeded with all twenty control and DOM-conformance cases named in specification 4.2 and the conformance programme, every cell reading "Owed", so the run has a fixed roster to fill and cannot quietly shrink. Its policies are not pre-decided here.
- **SSR-witness owner** gets section 2.1: rewrite the operative cell of an existing row, or append a row for a surface created after Phase 0.

Two constraints close section 3: amend in place rather than restructure, and adding a public surface adds an id — otherwise the Phase 4 exit ("every inventory id points at an applicable green row") silently stops meaning anything.

Provisional namespace spellings are deliberately kept out of the inventory (rows read "Optional forms module", not the provisional namespace name) because those names are open rows in the naming ledger. Ids are stable; names are not.

## Quality gates

- `python scripts/check_doc_slugs.py` — **exit code 0** (`no broken links`, 698 markdown files scanned). Run in the foreground to completion, redirected to a log, never piped.
- **Sabotage control on the gate.** An empty log on a passing gate proves nothing on its own, so the gate was re-run with a deliberately broken anchor appended to the new file: **exit 1**. The file was restored and the gate re-run: **exit 0**. The gate demonstrably has teeth on this path.
- `mkdocs build --strict` is **not** nominated: `mkdocs.yml` excludes `docs/design/**`, so it would verify nothing here.

### Hand-verification of anchors and table column counts

Nothing validates tables or rendering in this tree, so both were verified against the real slugifier and by counting, not by eye.

**Anchors — 67 links, 0 failures.** 23 same-file anchor links (all resolving against this file's own 11 rendered heading ids) and 44 cross-file links, every target file confirmed present and every `#anchor` confirmed against the target's slug index built with the same `pymdownx.slugs.slugify(case="lower")` the MkDocs build and the gate use. Anchors were computed from the real index *before* writing, not guessed and fixed afterwards.

**Table column counts — 5 tables, 0 mismatches.** Every row of every table (header, separator and each data row) counted, with pipes inside inline-code spans masked so a pipe in code cannot inflate a count:

| Table | Columns | Data rows |
|---|---|---|
| 1.1 coverage classification | 6 | 20 |
| 2.1 surface inventory | 6 | 35 |
| 2.2 non-rendering surfaces | 4 | 4 |
| 2.3 per-control roster | 3 | 20 |
| 3 append protocol | 3 | 6 |

**Two completeness cross-checks beyond the required ones.** The classification table's first column was compared string-for-string against the specification's section 7 table: 20 rows versus 20, exact match in order, nothing missing and nothing extra. And the inventory ids were checked for uniqueness and contiguity: 39 ids, 39 unique, HS-01 through HS-39 with no gap.

## Notes for sequencing (no action taken — outside this bead's fence)

1. **This file is not indexed anywhere.** `product/README.md` and the `lanes/README.md` ownership map are both outside the fence, so neither mentions `dispositions.md`. A reader arriving at the product directory will not find it from an index. Worth a one-line addition to the ownership map when a bead legitimately owns that file.
2. **The SSR-witness bead's dependency edges.** The review's section 2.2 records that it covers overlapping hydrated roots and the native tier under SSR but depends on neither the root-isolation implementation nor the completed native tier. Section 2.1 hands it HS-14, HS-21 and HS-24 to HS-30, which is exactly that surface area — so the missing edges bear directly on whether those rows can actually be upgraded when it runs.
3. **Section 2.3's roster is a prediction of the conformance programme's scope.** It is drawn from specification 4.2 plus the conformance bead's stated deliverables. If that bead's scope changes, the roster is the thing to reconcile.
