### PR TITLE
docs(hicasso): back-fill the pre-registration commit hash (rf2-mcwm)

### DIFF
--- a/docs/design/hicasso/product/resource-demand-criteria.md
+++ b/docs/design/hicasso/product/resource-demand-criteria.md
@@ -15,9 +15,11 @@ Nothing here was measured. Every line below is derived from the [specification](
 | Applied by | `rf2-hic-050`, mechanically |
 | Default verdict | STOP. ADOPT requires every criterion met on published, re-checkable evidence |
 | Amendment | Prospective only — see [Amendment rule](#amendment-rule) |
-| Pre-registration commit | `TO BE FILLED AFTER MERGE` |
+| Pre-registration commit | `c8b8de6d28` |
 
-**The commit hash is a deliverable of this file and must be back-filled once it merges.** It is the pre-registration proof: `rf2-hic-044` records its instrumentation against these criteria by citing it, and `rf2-hic-050` cites it again when it applies them. A verdict that cannot cite a criteria commit predating the report has not been pre-registered, whatever the dates claim.
+**That commit is the pre-registration proof**, back-filled by `rf2-mcwm` once the merge minted it. `rf2-hic-044` records its instrumentation against these criteria by citing it, and `rf2-hic-050` cites it again when it applies them. A verdict that cannot cite a criteria commit predating the report has not been pre-registered, whatever the dates claim.
+
+**Post-freeze edits, recorded here rather than made silently.** Two landed after that commit and before `rf2-hic-044` began, which is the window the [amendment rule](#amendment-rule) reserves: the row above was back-filled, and C2's closing sentence was corrected. That sentence had let unregistered defect classes count toward C2's threshold, contradicting the same criterion's statement that its classes are fixed in advance so no flattering class can be invented after the fact. Unregistered classes are still reported; they no longer count unless registered prospectively. No threshold moved, and nothing else changed.
 
 ## What is being decided
 
@@ -60,7 +62,7 @@ These are the pre-registered candidates, fixed here so that no flattering class 
 
 Each class the report claims carries three things: the mechanism, a reachability demonstration on the witness — a mutation that makes the hand-written answer actually exhibit the defect, so an accidentally unreachable class cannot pass — and a statement of whether demand makes the class unreachable *by construction* or merely easier to avoid.
 
-STOP unless at least two classes are killed by construction, at least one of them producing a wrong user-visible result or residue that survives teardown. "Easier to avoid" is never killed: a class whose only remedy is developer discipline or a documented step is exactly what a recipe is for, and `rf2-hic-054` already owns that answer. Unregistered classes may be added and count normally, but each carries the same reachability demonstration or is inadmissible.
+STOP unless at least two classes are killed by construction, at least one of them producing a wrong user-visible result or residue that survives teardown. "Easier to avoid" is never killed: a class whose only remedy is developer discipline or a documented step is exactly what a recipe is for, and `rf2-hic-054` already owns that answer. An unregistered class may still be reported, and carries the same reachability demonstration or is inadmissible; but it does not count toward this threshold unless it was added to the table above prospectively, under the [amendment rule](#amendment-rule), before the `rf2-hic-044` report exists. Otherwise the threshold could be met with classes chosen after the data, which is exactly what fixing the table in advance exists to prevent.
 
 ### C3 — Zero acquisition on abandoned renders
 


### PR DESCRIPTION
Back-fills the pre-registration hash that `docs/design/hicasso/product/resource-demand-criteria.md` demands of itself, and repairs the C2 contradiction the merged-PR audit recorded on rf2-mcwm. `rf2-hic-044` is blocked on this; a pre-registration whose proof is a placeholder proves nothing.

## The hash

`c8b8de6d28` (full: `c8b8de6d28c270e667650cdc4b0f6b24da23cce6`).

Determined from git, not from the dispatch brief:

```
$ git log --oneline --follow -- docs/design/hicasso/product/resource-demand-criteria.md
c8b8de6d28 docs(hicasso): pre-register the resource-demand criteria (rf2-hic-039)

$ git merge-base --is-ancestor c8b8de6d28 origin/main && echo yes
yes
```

`--follow` attributes the file to exactly one commit, so there was no choice to make between "the introducing commit" and "the merge": PR #7715 rebase-merged, and `c8b8de6d28` is both. The record asks for "this file's pre-registration commit" (record row, and step 1 of the verdict procedure), which is that object. It is an ancestor of `origin/main`, so it resolves in a fresh clone.

## No criterion changed

C1, C3, C4, C5, C6, C7 are untouched. No threshold moved: C2 still requires two classes killed by construction, at least one producing a wrong user-visible result or surviving residue. The three-class OWNERSHIP/POLICY/DOMAIN table, the six-class defect table, the at-a-glance table, the amendment rule, the verdict procedure, the consequences and the reopen conditions are all byte-identical.

## The C2 repair

Per the merged-PR audit note on rf2-mcwm. C2 fixed its six defect classes in advance "so that no flattering class can be invented after the fact", then closed by saying unregistered classes "may be added and count normally" — which let the two-class threshold be satisfied entirely with classes chosen after the data, defeating the pre-registration the rest of the document exists to establish. Unregistered classes may still be reported, with the same reachability demonstration; they now count toward the threshold only if registered prospectively under the amendment rule before the `rf2-hic-044` report exists.

Because the record is frozen and this text differs from the cited proof commit, the change is stated in the document rather than left for a reader to find by diffing. Both edits land before `rf2-hic-044` begins — the window the amendment rule reserves — and no data exists yet for either to be fitted to.

## Quality gates

| Gate | Command | Exit |
|---|---|---|
| Doc slugs | `python scripts/check_doc_slugs.py` | **0** |
| Provenance pins | `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |

Both run in the foreground to completion, unpiped, redirected to worktree-local logs.

The pins gate is the load-bearing one here, since this PR adds a real SHA to a corpus page. It reports `1 files, 1 cited pins (1 landed, 0 stranded, 0 unresolvable)` — the new token is positively classified as a commit (the row label supplies the "commit" vocabulary word) and positively shown to be an ancestor of `origin/main`, so the accompaniment rule is satisfied by the pin itself rather than by a neighbour. The `TO BE FILLED AFTER MERGE` placeholder is also gone, which was the shape that gate's unfilled-anchor tooth exists to catch.

Hand-verified, since nothing automated covers them:

- **Anchors** — the file's three in-page links (`#amendment-rule`, at the record row, the new post-freeze note, and the repaired C2 sentence) all resolve to the `## Amendment rule` heading. Two of the three are new.
- **Table column counts** — four tables, each internally uniform: the pre-registration record 2-wide across 10 rows (the edited row included), the ceremony-class table 3-wide across 5, the defect-class table 3-wide across 8, the at-a-glance table 3-wide across 9. Only one cell in one table changed.

`mkdocs build --strict` is not the gate for this tree: `mkdocs.yml`'s `exclude_docs` keeps `design/` out of the site.

Closes rf2-mcwm. Unblocks rf2-hic-044.
