### PR TITLE
docs(hicasso): index the published product records (rf2-pxk7)

### DIFF
--- a/docs/design/hicasso/product/README.md
+++ b/docs/design/hicasso/product/README.md
@@ -4,6 +4,18 @@ Published from the operator-local working set by rf2-hic-000. This is the worker
 
 The naming ledger (naming-ledger.md) is live and appended-to by beads; see rf2-hic-065.
 
+## Records
+
+Standalone ledgers and decision records kept beside the snapshot. Each states in its own opening what it owns and which document governs it.
+
+- [`invariants.md`](invariants.md) — one page to check a change against: every invariant the product commits to, every capability and the rent it pays, and the provisional `h` and `n` facades. Wholly transcribed from the governing documents, so where a row and its owner disagree the owner governs and the row is the defect.
+- [`dispositions.md`](dispositions.md) — the two ledgers Phase 0 owes: which layer answers each [specification §7](specification.md#7-complete-use-case-coverage) use case, and the server/hydration disposition of every proposed public surface. It mints the permanent inventory id each surface carries, so no surface can be added, shipped or forgotten without a row.
+- [`requirements-mine.md`](requirements-mine.md) — one row per recurring application job: how often the corpus actually does it, how it fails, where the answer lives, who is accountable, and the executable artefact that would prove it. Frequency is what justifies syntax and standing cost.
+- [`naming-ledger.md`](naming-ledger.md) — every naming question any bead finds, consolidated in one place so that nobody renames mid-flow. Recommendations apply as defaults immediately; the operator's sitting overrides rows asynchronously.
+- [`resource-demand-criteria.md`](resource-demand-criteria.md) — the adopt-or-stop criteria for demand-driven resource ownership, frozen before the typeahead witness produced any data. The default verdict is STOP and amendment is prospective only, so read it before reading any resource-demand result.
+- [`k1-price-acceptance.md`](k1-price-acceptance.md) — the scoped amendment instrument for the K1 mount gate: what the measured mount premium buys, and what ratification would and would not carry. PROPOSED and not operative — the registered gate stands until the sitting ratifies it.
+- [`correction-ledger.md`](correction-ledger.md) — every checkpoint finding and what it takes to close one. A row does not close when the fix merges, only when the protocol section that produced the finding has been re-run against the landed fix; the final audit reads this file.
+
 ## Source hashes at publication
 
 ```

--- a/docs/design/hicasso/product/lanes/README.md
+++ b/docs/design/hicasso/product/lanes/README.md
@@ -26,6 +26,11 @@ Quantitative claims stay attached to their witness, revision, runtime, substrate
 | Phase dependencies and exit signals | [`delivery-programme.md`](delivery-programme.md) |
 | Candidate-idea protocols and kill criteria | [`left-field-ideas.md`](left-field-ideas.md) |
 | Corpus-derived rationale and cautions | [`corpus-insights.md`](corpus-insights.md) |
+| Use-case coverage classification and per-surface server/hydration dispositions | [`../dispositions.md`](../dispositions.md) |
+| Per-job corpus evidence: frequency, failure modes, and the witness each recurring job owes | [`../requirements-mine.md`](../requirements-mine.md) |
+| Open naming questions and their consolidation | [`../naming-ledger.md`](../naming-ledger.md) |
+| Pre-registered adopt/stop criteria for demand-driven resource ownership | [`../resource-demand-criteria.md`](../resource-demand-criteria.md) |
+| Checkpoint findings and their closure into the release verdict | [`../correction-ledger.md`](../correction-ledger.md) |
 
 ## Product documents
 


### PR DESCRIPTION
`docs/design/hicasso/product/README.md` was seeded by rf2-hic-000 and indexed none of the records published since. Verified against `origin/main` before the change: `invariants.md`, `dispositions.md`, `requirements-mine.md`, `resource-demand-criteria.md`, `k1-price-acceptance.md` and `correction-ledger.md` all scored zero hits. Every one was reachable only by someone who already knew its path.

This is the single consolidation owner for that fix, per the remedy the set review records at [`lanes/beads-review.md` section 2.4](https://github.com/day8/re-frame2/blob/main/docs/design/hicasso/product/lanes/beads-review.md) — one owner rather than six concurrent edits to a shared Markdown file.

## What was added

A `## Records` section in `product/README.md`, placed after the existing prose and **before** the source-hash block, listing each standalone record with what it is for. Every description was written from the record's own opening, not inferred from its filename.

Seven entries, not six. `naming-ledger.md` is also a standalone record in this directory, and an index that silently skipped one file would be worse than no index. It is mentioned in the existing prose but was absent from any list.

One correction to the dispatch framing worth recording: the brief and the bead both describe the six as records "published since" the seed, which is true of those six — but `git log --diff-filter=A` shows `naming-ledger.md` was added in the **same commit as README.md itself** (`ae77d063e9`), so it belongs to the rf2-hic-000 publication rather than after it. The section is therefore titled plainly `## Records` and divides by kind (standalone ledgers and decision records) rather than by date, so it makes no false claim about when anything landed.

## lanes/README.md — yes, it needed a change

The rf2-hic-005 worker's report that the ownership map "is also silent" is correct, and in two rows it is worse than silent: it gives an *incomplete* answer that misroutes a reader. `Public-surface SSR/hydration policy and witness matrix → react-compatibility-notes.md` is still right about the policy, but a sibling file now mints the per-surface inventory ids, so a reader asking "which surfaces exist and what is each one's disposition" is sent to the wrong page. `Candidate-idea protocols and kill criteria → left-field-ideas.md` is incomplete in the same way now that the flagship candidate's criteria are pre-registered elsewhere.

Five rows added, one per record that makes a genuine ownership claim in its own text. The map already reaches outside `lanes/` (it cites `../specification.md`), so parent-directory owners are not a new pattern here.

**Two records were deliberately left out**, and the omissions are the substance of the judgement:

- `invariants.md` owns nothing. Its own opening states "Nothing here is new… Where a row and its owner disagree the owner governs and the row is the defect." Listing it as a canonical owner would contradict the document.
- `k1-price-acceptance.md` is `PROPOSED. Not operative.` The Authority section of `lanes/README.md` already assigns scoped-amendment adjudication to the decision brief, so an ownership row would create a competing claim.

No existing row was edited or reordered. The new rows are worded so none collides with a concern an existing row already claims.

## rf2-hic-000's source hashes are untouched

Both changes are **pure additions**: `git diff --numstat` reports `12  0` and `5  0` — twelve and five insertions, **zero deletions in either file**. Nothing in the hash block was touched, reordered or tidied, and the zero-deletion count is the proof rather than an assertion.

## Quality gates

| Gate | Command | Exit |
|---|---|---|
| Doc slugs | `python scripts/check_doc_slugs.py` | **0** |
| Provenance pins | `git fetch --no-tags origin main; python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |

Both run in the foreground to completion, redirected to worktree-local logs, never piped. The pins gate reported `2 files, 0 cited pins (0 landed, 0 stranded, 0 unresolvable)` — it saw both changed files, and the additions introduce no hex tokens.

`mkdocs build --strict` is not applicable: `mkdocs.yml` excludes `docs/design/**`, so it would verify nothing here.

### Sabotage control — the checker demonstrably sees both files

A green exit proves nothing if a file is outside the checker's roster, so both files were proven in-roster rather than assumed. One broken **anchor** was injected into `product/README.md` and one broken **target** into `lanes/README.md`, simultaneously:

```
SABOTAGE_EXIT=1
  BROKEN TARGET: docs\design\hicasso\product\lanes\README.md:33 -> ../correction-ledger-SABOTAGE.md
  BROKEN ANCHOR: docs\design\hicasso\product\README.md:12 -> specification.md#7-complete-use-case-coverage-SABOTAGE
```

Exit 1, naming both files by path and catching both link classes. Restored, re-run, exit 0.

### Hand-verification counts

Nothing in this tree validates tables or rendering, so these were checked by hand.

**Links — 13 added, all verified, 0 broken.**

- `product/README.md`: 8 links across 7 bullets — 7 same-directory file targets (`invariants.md`, `dispositions.md`, `requirements-mine.md`, `naming-ledger.md`, `resource-demand-criteria.md`, `k1-price-acceptance.md`, `correction-ledger.md`), each confirmed present via `git ls-files`, plus 1 anchored link.
- `lanes/README.md`: 5 links, all `../` file targets, 0 anchors.

**Anchors — 1 written, 1 verified.** `specification.md#7-complete-use-case-coverage` resolves to the heading `## 7. Complete use-case coverage` at `specification.md:268`, and the identical anchor is already used in four other pages in this corpus. Anchors were deliberately kept to that one: in an index, and in an ownership map where the whole document is the owner, a link to the file is the correct target and a sub-section anchor would understate it.

**Tables — 1 touched, 2 columns, 15 data rows, all consistent.**

- `product/README.md` adds **no table**; the `## Records` section is a bullet list, matching the house style of `lanes/README.md`'s own "Product documents" list.
- `lanes/README.md`'s ownership map: header `| Concern | Canonical owner |` and separator `|---|---|` are both 2 columns. Every row was counted programmatically — 10 pre-existing data rows and 5 new ones, **15 of 15 at exactly 2 cells**, no row over- or under-filled.

## Scope

Only the two files named above were changed. None of the six records, `decision-brief.md`, `specification.md`, `naming-ledger.md` or any lane was edited. `resource-demand-criteria.md` has a worker in flight (rf2-mcwm) back-filling a commit hash; it is linked here and otherwise untouched.

Closes rf2-pxk7.
