### PR TITLE
docs(hicasso): one owner for the layer classification, and honest lane link text (rf2-3amd, rf2-oqe8)

### DIFF
--- a/docs/design/hicasso/product/dispositions.md
+++ b/docs/design/hicasso/product/dispositions.md
@@ -39,6 +39,9 @@ Each of the twenty rows in [specification section 7](specification.md#7-complete
 additional surfaces that complete the answer and the refusals that bound it. The primary home is where an application
 finds the answer first; the additional-surface column carries the rest.
 
+This table is the normative record of that classification. [`requirements-mine.md`](requirements-mine.md) repeats each
+job's layer in its Home column so that a ledger row reads on its own, and this table governs wherever the two disagree.
+
 No row's primary home is a didactic refusal. That is a finding, not an omission: section 7 exists precisely because every
 recurring job has a maintained answer somewhere, so refusals in this table appear as bounds on an answer rather than as
 the answer itself. The refusals that stand alone are catalogued in

--- a/docs/design/hicasso/product/lanes/README.md
+++ b/docs/design/hicasso/product/lanes/README.md
@@ -4,8 +4,8 @@ These documents define the current target for the native interpreted-Hiccup adap
 
 ## Authority
 
-1. [`../synth.md`](../decision-brief.md) is the decision instrument. It owns the forensic scoreboard, selected-direction record, scoped-amendment adjudication, K3 disposition, sitting agenda, and kill rules.
-2. [`../synth-codex.md`](../specification.md) is the normative product target for that selected direction. It owns product verdicts, budgets, capability placement, the public-surface target, and phase order.
+1. [`../decision-brief.md`](../decision-brief.md) is the decision instrument. It owns the forensic scoreboard, selected-direction record, scoped-amendment adjudication, K3 disposition, sitting agenda, and kill rules.
+2. [`../specification.md`](../specification.md) is the normative product target for that selected direction. It owns product verdicts, budgets, capability placement, the public-surface target, and phase order.
 3. [`design-laws.md`](design-laws.md) states the non-negotiable design constraints; [`evidence-baseline.md`](evidence-baseline.md) records what is actually demonstrated and what still needs proof.
 4. The focused specifications below own protocols, risk detail, and acceptance tests only. If one conflicts with either governing document, update it rather than preserving a second verdict or sequence.
 5. The sibling lesson reports and `fable/` material are source corpus. They contribute evidence and ideas but are not normative product documents.
@@ -17,7 +17,7 @@ Quantitative claims stay attached to their witness, revision, runtime, substrate
 | Concern | Canonical owner |
 |---|---|
 | Current measurements and their admissibility | [`evidence-baseline.md`](evidence-baseline.md) |
-| Product budgets, capability placement, portfolio status, and phase deliverables | [`../synth-codex.md`](../specification.md) |
+| Product budgets, capability placement, portfolio status, and phase deliverables | [`../specification.md`](../specification.md) |
 | Native-tier semantic laws | [`design-laws.md#native-boundary`](design-laws.md#native-boundary) |
 | Native authoring grammar and examples | [`ergonomics-api.md#optional-native-surface`](ergonomics-api.md#optional-native-surface) |
 | Native-tier acceptance checklist and performance protocols | [`hot-path-architecture.md#canonical-native-tier-acceptance-checklist`](hot-path-architecture.md#canonical-native-tier-acceptance-checklist) |

--- a/docs/design/hicasso/product/requirements-mine.md
+++ b/docs/design/hicasso/product/requirements-mine.md
@@ -21,6 +21,8 @@ A witness cell always names the proof, not just its status: a reader should be a
 
 ## The ledger
 
+The Home column is repeated here so that a row reads on its own. The layer classification itself is owned by [`dispositions.md` §1.1](dispositions.md#11-classification-table), which governs wherever the two disagree.
+
 | Job | Observed frequency | Failure modes | Home | Owner | Executable witness |
 |---|---|---|---|---|---|
 | Ordinary pages, conditional UI, dynamic lists | 231 reads across 85 files; ~140 `reg-view` across 38 files; 48 `for` with 35 `^{:key}`; 52 reads (23%) parameterised | Stale read surviving commit; a read escaping the synchronous extent through a callback, promise or timer; key identity unstable across re-render; attribution lost through a plain helper. P5 argues the answer is plain Hiccup, not a layout DSL | Core: Hiccup, helpers, ambient reads, keyed boundaries. No escape | rf2-hic-010, rf2-hic-011 | Commit-basis fence exists — `implementation/freehand/test/re_frame/bench/hicasso/generation_fence_coverage_cljs_test.cljs`. Todo and RealWorld-class flow on the public API only: owed by rf2-hic-025, extended by rf2-hic-074 |


### PR DESCRIPTION
Two small product-doc corrections in the hicasso set, worked in order and committed separately.

## rf2-oqe8 — lanes/README.md link text names files that do not exist

`docs/design/hicasso/product/lanes/README.md` rendered link text reading `../synth.md` and `../synth-codex.md`. Those are the operator-local working-set originals under the gitignored `ai/` tree; neither exists in the published set, so in a fresh clone a reader cannot find them at all. The link *targets* were already correct, which is why nothing caught it: `check_doc_slugs.py` validates targets and anchors, not whether the visible text names a real file.

Changed the visible text to the published filenames. Targets, ordering and the map's structure are untouched.

**One line beyond the bead's wording, flagged deliberately.** The bead names lines 7-8 (the Authority list). The identical defect also sat on line 20, an ownership-map row reading `` `../synth-codex.md` `` -> `../specification.md`. It is the same two-word text defect in the same fenced file, and leaving it would have half-served the bead's own rationale — the ownership map is precisely the part a worker reads to find which document governs a surface. A link-text correction is not a restructure of the map, and line 20 is **not** one of the five rows added by PR #7719 (that PR added lines 29-33; verified against `b326ca09d1`). Those five rows are untouched.

**Belongs to someone else — not fixed here, outside the fence.** The same stale-text defect appears in three more lane files, each rendering `` `../synth-codex.md` `` over a correct `../specification.md` target:

- `lanes/completeness-audit.md:3`
- `lanes/left-field-ideas.md:3`
- `lanes/delivery-programme.md:3`

Separately, `product/README.md:3` glosses the mapping deliberately ("decision-brief.md (= synth.md)") and lines 22-23 are rf2-hic-000's source-hash manifest naming the originals — both look intentional and should not be swept. Worth one follow-up bead for the three lane files.

## rf2-3amd — one owner for the layer classification

`requirements-mine.md`'s Home column and `dispositions.md`'s primary-home column assign the same twenty specification section 7 jobs to the same five layers, with nothing stating which governs. The two files have different owners and different update triggers — the mine grows as jobs are discovered, while `dispositions.md` is appended to by `rf2-hic-040` and `rf2-hic-046` as control and SSR rows land — so the first divergence would be silent and a reader hitting it could not tell which page was stale.

**`dispositions.md` section 1.1 is now the normative record.** The reasoning, from what each document is for rather than which is longer:

1. **It is the classification ledger by charter.** Its opening line reads "Phase 0 owes two ledgers, and this document is both of them", the first being exactly this classification. `requirements-mine.md` is chartered as an evidence ledger — frequency, failure modes, accountable bead, executable witness — in which the layer is context, not the subject.
2. **It already has an ownership protocol for the table; the mine has none for its column.** `dispositions.md` section 3 names an owner for section 1.1 and constrains the amendment: "never change a Home without a specification change behind it." Nothing comparable governs the mine's Home column, so naming the mine normative would have meant inventing a protocol rather than recognising one.
3. **It classifies with the apparatus adjudication needs.** Section 1.1 separates primary home from additional surfaces, from the refusal that bounds the row, and from the specification section the assignment derives from — six columns. The mine fuses home, additional surfaces and refusal into one prose cell ("Core: Hiccup, helpers, ambient reads, keyed boundaries. No escape"), which reads well and adjudicates badly.
4. **The mine already defers upward on the row list.** Its maintenance rule 4 says rows belong to section 7 and change only when the specification does. Deferring on the layer too is consistent with how it already positions itself.

Both columns stay — each page needs the layer visible to be readable. The change is one sentence in each file: `dispositions.md` claims the classification and cites the mine as the place it is repeated; `requirements-mine.md` names `dispositions.md` section 1.1 as the owner and says it governs on disagreement. No new precedence mechanism, no sync script, no check — per the set review's remedy at `lanes/beads-review.md` section 2.4, one consolidation owner rather than concurrent authorities.

Five inserted lines total, no deletions.

## Quality gates

Both gates run in the foreground to completion, unpiped, redirected to worktree-local logs, after each bead's commit and again on the complete branch.

| Gate | Exit code |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |

The pins gate reports `3 files, 0 cited pins (0 landed, 0 stranded, 0 unresolvable)`. No dates or hex-like tokens were introduced by either bead.

`mkdocs build --strict` is not applicable: `mkdocs.yml`'s `exclude_docs` keeps `docs/design/**` out of the site, so it would verify nothing here.

**Sabotage controls.** Run to prove a green exit means the files are actually on the checker's roster, not merely absent from it. Both controls were restored and re-verified green; the final diff is pure additions with zero deletions, which is itself proof no sabotage text survived.

| Control | Result |
|---|---|
| Broke the `design-laws.md#native-boundary` anchor in `lanes/README.md` | exit **1** — `BROKEN ANCHOR: ...lanes\README.md:21` |
| Broke the anchor added to `requirements-mine.md` | exit **1** — `BROKEN ANCHOR: ...requirements-mine.md:24 -> dispositions.md#11-sabotage-no-such-anchor` |
| Broke the file target added to `dispositions.md` | exit **1** — `BROKEN TARGET: ...dispositions.md:42 -> requirements-mine-sabotage.md` |
| All three restored | exit **0** |

All three edited files are therefore confirmed on the roster, and both links added by rf2-3amd are confirmed to be validated by the checker rather than merely unexamined.

**Hand-verified anchors** (nothing in this tree validates rendering, and the pre-existing `sabotage` string at `dispositions.md:104` is legitimate prose, not control residue):

- `dispositions.md#11-classification-table` -> heading `### 1.1 Classification table` at `dispositions.md:51`. Slug matches the file's own internal usage of the same anchor at lines 261 and 264.
- `requirements-mine.md` -> file exists, same directory.
- `../decision-brief.md` and `../specification.md` -> both exist at `docs/design/hicasso/product/`, confirmed by direct file test.

**Hand-verified table column counts.** Every table touched or adjacent to an edit, counted per line:

| Table | Lines | Data rows | Cells per line |
|---|---|---|---|
| `lanes/README.md` ownership map (row edited) | 17 | 15 | 2, uniform |
| `dispositions.md` 1.1 classification table (sentence added above it) | 22 | 20 | 6, uniform |
| `requirements-mine.md` ledger (sentence added above it) | 22 | 20 | 6, uniform |

No table row was added, removed or re-shaped by either bead; the rf2-oqe8 change rewrote link text inside one existing cell, and rf2-3amd added prose only. The two 20-row counts agreeing is also the direct confirmation of the duplication rf2-3amd describes: both files classify the same twenty jobs.
