### PR TITLE
docs(hicasso): name the published file in three lane authority lines (rf2-bmj8)

### DIFF
--- a/docs/design/hicasso/product/lanes/completeness-audit.md
+++ b/docs/design/hicasso/product/lanes/completeness-audit.md
@@ -1,6 +1,6 @@
 # Coverage proof suites
 
-[`../synth-codex.md`](../specification.md#7-complete-use-case-coverage) owns capability placement, phase deliverables, and release policy. This file owns the concrete proof suites: the finite witnesses and artifacts that demonstrate coverage. It does not maintain a second roadmap or paraphrase phase outcomes.
+[`../specification.md`](../specification.md#7-complete-use-case-coverage) owns capability placement, phase deliverables, and release policy. This file owns the concrete proof suites: the finite witnesses and artifacts that demonstrate coverage. It does not maintain a second roadmap or paraphrase phase outcomes.
 
 ## Canonical suites
 

--- a/docs/design/hicasso/product/lanes/delivery-programme.md
+++ b/docs/design/hicasso/product/lanes/delivery-programme.md
@@ -1,6 +1,6 @@
 # Delivery dependency and exit index
 
-[`../synth-codex.md`](../specification.md#12-action-programme) owns phase order, scope, and product decisions. This index exposes dependencies and exits without creating a second roadmap.
+[`../specification.md`](../specification.md#12-action-programme) owns phase order, scope, and product decisions. This index exposes dependencies and exits without creating a second roadmap.
 
 | Phase | Depends on | Canonical evidence | Exit signal |
 |---|---|---|---|

--- a/docs/design/hicasso/product/lanes/left-field-ideas.md
+++ b/docs/design/hicasso/product/lanes/left-field-ideas.md
@@ -1,6 +1,6 @@
 # Left-field ideas
 
-[`../synth-codex.md`](../specification.md#11-innovation-portfolio) owns portfolio status and delivery order. This file defines the deciding protocols and kill conditions.
+[`../specification.md`](../specification.md#11-innovation-portfolio) owns portfolio status and delivery order. This file defines the deciding protocols and kill conditions.
 
 ## Product workflow
 


### PR DESCRIPTION
Three lane files opened line 3 — the authority sentence a worker reads to learn which document governs its surface — with link **text** reading `../synth-codex.md`. That file does not exist in the published tree: it is the `ai/` tree's local-only original, and `ai/` is gitignored, so in a fresh clone the reader cannot find it at all and goes hunting.

The link **targets** were already correct and resolve into `../specification.md` with a working anchor, which is why no gate catches this — `check_doc_slugs.py` validates targets and anchors, not whether the visible text names a real file.

Same defect class as the one just repaired in `lanes/README.md` under rf2-oqe8.

## The three lines

**`docs/design/hicasso/product/lanes/completeness-audit.md:3`**

before
```
[`../synth-codex.md`](../specification.md#7-complete-use-case-coverage) owns capability placement, phase deliverables, and release policy. This file owns the concrete proof suites: the finite witnesses and artifacts that demonstrate coverage. It does not maintain a second roadmap or paraphrase phase outcomes.
```
after
```
[`../specification.md`](../specification.md#7-complete-use-case-coverage) owns capability placement, phase deliverables, and release policy. This file owns the concrete proof suites: the finite witnesses and artifacts that demonstrate coverage. It does not maintain a second roadmap or paraphrase phase outcomes.
```

**`docs/design/hicasso/product/lanes/left-field-ideas.md:3`**

before
```
[`../synth-codex.md`](../specification.md#11-innovation-portfolio) owns portfolio status and delivery order. This file defines the deciding protocols and kill conditions.
```
after
```
[`../specification.md`](../specification.md#11-innovation-portfolio) owns portfolio status and delivery order. This file defines the deciding protocols and kill conditions.
```

**`docs/design/hicasso/product/lanes/delivery-programme.md:3`**

before
```
[`../synth-codex.md`](../specification.md#12-action-programme) owns phase order, scope, and product decisions. This index exposes dependencies and exits without creating a second roadmap.
```
after
```
[`../specification.md`](../specification.md#12-action-programme) owns phase order, scope, and product decisions. This index exposes dependencies and exits without creating a second roadmap.
```

## Targets and anchors unchanged

Every target and anchor is **byte-identical**; only the visible link text changed. The whole diff is 3 files, 3 insertions, 3 deletions, and each changed line differs from its predecessor solely inside the bracketed text span. Nothing else in these files was touched — not the surrounding sentence, not the ordering, not the headings.

Hand-verified that all three still resolve after the edit. `docs/design/hicasso/product/specification.md` exists, `../specification.md` resolves from `lanes/`, and each anchor matches a real heading in it:

| Anchor | Heading in `specification.md` |
|---|---|
| `#7-complete-use-case-coverage` | `## 7. Complete use-case coverage` (line 268) |
| `#11-innovation-portfolio` | `## 11. Innovation portfolio` (line 349) |
| `#12-action-programme` | `## 12. Action programme` (line 367) |

The visible text now names a file that genuinely exists at the path the text states.

## Further occurrences — found, reported, left alone

Fenced to the three files above; the string was not swept. A report-only search over `docs/` surfaced four other occurrences, all left untouched:

- `product/README.md:3` — the `specification.md (= synth-codex.md)` file-map gloss. Deliberate: it maps the published name to the original for a reader who knows the `ai/` tree. Left alone.
- `product/README.md:23` — the rf2-hic-000 source-hash manifest line (`… *synth-codex.md`). A freshness check. Left alone.
- `product/decision-brief.md:7` and `product/decision-brief.md:156` — **not covered by either known exemption**, so flagging them for the mayor rather than acting. These are prose references (not links), and they name a whole family of `ai/`-tree originals rather than just this one: line 7 says "Its sibling `synth-codex.md` is the detailed product specification … maintained with the `codex/` lanes … indexed by `codex/README.md`", and line 156 cites `synth-codex.md`, "the `codex/` specification set", `codex/evidence-baseline.md`, `codex/corpus-insights.md`, `fable/` and `fable/dispositions.md`. In the published tree those are `specification.md` and `lanes/`. Same defect class as this PR, but wider than a text swap and plausibly deliberate in the way `README.md`'s gloss is — it wants a judgement call, not a drive-by. Out of fence, untouched.

## Quality gates

| Gate | Exit code |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `git fetch --no-tags origin main; python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |

Both run in the foreground to completion, redirected to worktree-local logs, never piped through `tail`/`head`/`grep`. The pins gate confirms it saw this change: `check_provenance_pins: 3 files, 0 cited pins (0 landed, 0 stranded, 0 unresolvable)` / `every cited pin is an ancestor of origin/main or shares its block with one`.

`mkdocs build --strict` is **not applicable** — `mkdocs.yml`'s `exclude_docs` keeps `docs/design/**` out of the site.

**Sabotage control** (proving these files are inside the slug checker's roster, so the green above means something):

1. Broke one anchor in `lanes/completeness-audit.md`, changing `#7-complete-use-case-coverage` to `#7-sabotage-control-no-such-anchor`.
2. Re-ran `check_doc_slugs.py` → **exit 1**, naming the file and line:
   ```
   1 broken anchor link(s) found:

     BROKEN ANCHOR: docs\design\hicasso\product\lanes\completeness-audit.md:3 -> ../specification.md#7-sabotage-control-no-such-anchor
         (target: docs\design\hicasso\product\specification.md)
   ```
3. Restored the anchor and re-ran → **exit 0**, with the diff back to exactly the three intended lines.

Closes rf2-bmj8.
