### PR TITLE
docs(hicasso): the decision brief names published paths, and marks its local-only sources (rf2-28jg)

### DIFF
--- a/docs/design/hicasso/product/decision-brief.md
+++ b/docs/design/hicasso/product/decision-brief.md
@@ -2,9 +2,9 @@
 
 **The goal**: **Hicasso is the base** — an interpreted-hiccup view layer with clean ways to drop down to very efficient React for the hot parts of an app (1–2% of the code; often 0%). Good-enough performance. Excellent programming ergonomics: minimal, clean code; excellent testing; excellent Xray diagnostics. Complete coverage of the use-cases. The end state is an excellent **native re-frame2 adaptor that is better than the other adaptors** — more ergonomic, more complete.
 
-This document is the decision-grade analysis, review, and plan. It owns the forensic scoreboard, the selected-direction record, the scoped price amendment, the K3 disposition, the sitting agenda, and the kill rules—the same split `codex/README.md` states.
+This document is the decision-grade analysis, review, and plan. It owns the forensic scoreboard, the selected-direction record, the scoped price amendment, the K3 disposition, the sitting agenda, and the kill rules—the same split `lanes/README.md` states.
 
-Its sibling `synth-codex.md` is the detailed **product specification**: facade, budgets, coverage matrix, phase exits. It is maintained with the `codex/` lanes as a living normative spec set, indexed by `codex/README.md`. This page deliberately does not restate API spellings, budget tables, or coverage rows. The two are designed to be read together. History and evidence live in companion files; neither page retells them.
+Its sibling `specification.md` is the detailed **product specification**: facade, budgets, coverage matrix, phase exits. It is maintained with the `lanes/` documents as a living normative spec set, indexed by `lanes/README.md`. This page deliberately does not restate API spellings, budget tables, or coverage rows. The two are designed to be read together. History and evidence live in companion files; neither page retells them.
 
 ---
 
@@ -92,7 +92,7 @@ The biggest gaps sit on high-traffic jobs: forms, overlays on the native top lay
 
 The strategic differentiator among the gaps is **demand-driven resource ownership**: a committed `sub` that reads a resource may also declare demand — unmount or parameter change releases it; debounce, supersession, refresh-with-data, and cancellation remain explicit policies. Its fences are hard (reuse committed read membership; abandoned renders acquire nothing; no second per-read ledger — the failed-ledger mechanism class must not reappear here) and a typeahead witness decides whether it graduates.
 
-**Trust: the one blocker class.** The trust register in `codex/adversarial-risks.md` holds eleven risks. Eight belong to the kernel: module-global ownership including the shared hydration adoption window; same-id reincarnation dispatch; speculative-render leakage and false abandonment tests; the unstated ambient-read extent; controlled-input portability; HMR identity; callback retirement; and hydration isolation.
+**Trust: the one blocker class.** The trust register in `lanes/adversarial-risks.md` holds eleven risks. Eight belong to the kernel: module-global ownership including the shared hydration adoption window; same-id reincarnation dispatch; speculative-render leakage and false abandonment tests; the unstated ambient-read extent; controlled-input portability; HMR identity; callback retirement; and hydration isolation.
 
 Three belong to the native tier: native-language leakage (`n/$` never rewrites interpreted Hiccup), boundary-ABI drift across the three authoring routes, and native-tier rent (zero native runtime in interpreted-only bundles). “Better than the other adaptors” begins at “as trustworthy as them.”
 
@@ -130,14 +130,14 @@ Plus the working loop (reproduce → attribute with Xray → tune topology → t
 
 Comparative bands follow: an initial mount ceiling of 1.25x direct UIx; tuned broad updates at ≤1.25x the best relevant adapter, with 1.25–1.5x a warning and >1.5x forcing island analysis or reclassification; and native islands within 5% or 1 ms of the same component mounted directly through its chosen React route. Hicasso-native is co-instrumented against handwritten React and UIx. The same-instrument regression gate is 5%; an escape earns its keep at ≥20%, ≥2 ms, or by flipping a user-visible budget. Native-code percentage is **an observed census, never a quota**. Budgets ratify on named hardware before optimization; thresholds never widen to turn a row green.
 
-**The ideas ledger** (full designs in `fable/left-field-ideas.md` and `codex/left-field-ideas.md`):
+**The ideas ledger** (full designs in `lanes/left-field-ideas.md`, and in its operator-local source `fable/left-field-ideas.md`, which is not published in this tree):
 
 - *Adopt*: complaint catalogue, cause-aware hot advisor, direct React output with the Hicasso-owned native tier (`n/$` and companions; gates in Part II).
 - *Spike with deciding rules*: committed-read resource demand; pull-shaped reads; schema-driven generators; counterfactual topology advice; capability receipts; replayable view capsules after L2; MCP-queryable runtime and migration shadowing through existing tools; shared read-set notification groups after a census.
 - *Watch*: a read-free shell as a read-nothing optimization, not a heap fix; codec shape planning only when classification/lowering exceeds 10% of hot-boundary self time; intent replay through Story; keyed-list maintenance only after a red bulk verdict; a future React store seam.
 - *Reject*: compiler/JIT modes, second renderers, worker view runtimes, signals replacement, universal callback cells, and hydration-free inference.
 
-Every spike must retain the detailed fence and deciding witness in `codex/left-field-ideas.md`; this ledger is not permission to build an open-ended experiment.
+Every spike must retain the detailed fence and deciding witness in `lanes/left-field-ideas.md`; this ledger is not permission to build an open-ended experiment.
 
 **First moves now**: the reincarnation-dispatch witness; the `hicasso.test` extraction; the installable package spine; the hot-view advisor; the forms field recipe; the first lint checks; and at the sitting — the K3 disposition and the amendment that names the accepted mount price.
 
@@ -153,4 +153,4 @@ The residual governance is the amendment's reconsideration trigger. The plan is 
 
 ## Sources
 
-`synth-codex.md` (the product specification; §6 budgets, §7 coverage, §9 testing, §13 done) and the `codex/` specification set. Product evidence and rationale: `codex/evidence-baseline.md` and `codex/corpus-insights.md`. Source corpus: `fable/` and the three `lessons-*.md`; the current status of every scout idea is `fable/dispositions.md`. Normative implementation record: `docs/design/hicasso/` and the governance beads (K1: rf2-diaud / PR #7704; bulk gating: rf2-vp0j7; SSR: rf2-2rtt6.88).
+`specification.md` (the product specification; §6 budgets, §7 coverage, §9 testing, §13 done) and the `lanes/` specification set. Product evidence and rationale: `lanes/evidence-baseline.md` and `lanes/corpus-insights.md`. Source corpus — operator-local, deliberately not published here, and nothing in this tree substitutes for it: the `fable/` scout corpus, its three `lessons-*.md` files, and `fable/dispositions.md`, which carries the current status of every scout idea (a different ledger from this directory's `dispositions.md`). Normative implementation record: `docs/design/hicasso/` and the governance beads (K1: rf2-diaud / PR #7704; bulk gating: rf2-vp0j7; SSR: rf2-2rtt6.88).


### PR DESCRIPTION
`docs/design/hicasso/product/decision-brief.md` is the first document every bead brief in this set opens, and its prose navigated the reader to `ai/`-tree paths that do not exist in the published tree. The `ai/` tree is gitignored, so in a fresh clone those names cannot be reached at all — which makes this rf2-hic-000's own surface line ("no ai/ paths appear in anything a worker must read") unmet, not a cosmetic nit.

The bead named lines 7 and 156. Both matched the description exactly and were fixed. Reading the whole file turned up **four more lines of the same class** — 5, 95, 133 and 140 — all fixed here, all inside the one fenced file.

## Before and after, line by line

**Line 5**
- before: `…the sitting agenda, and the kill rules—the same split `codex/README.md` states.`
- after: `…the sitting agenda, and the kill rules—the same split `lanes/README.md` states.`

**Line 7**
- before: ``Its sibling `synth-codex.md` is the detailed **product specification**: … It is maintained with the `codex/` lanes as a living normative spec set, indexed by `codex/README.md`.``
- after: ``Its sibling `specification.md` is the detailed **product specification**: … It is maintained with the `lanes/` documents as a living normative spec set, indexed by `lanes/README.md`.``
- ("the `codex/` lanes" became "the `lanes/` documents" rather than the tautological "the `lanes/` lanes".)

**Line 95** — found by reading the file, not named on the bead
- before: ``The trust register in `codex/adversarial-risks.md` holds eleven risks.``
- after: ``The trust register in `lanes/adversarial-risks.md` holds eleven risks.``
- (`lanes/adversarial-risks.md` is present in the published tree.)

**Line 133** — found by reading the file; carries one of the unpublished references
- before: ``**The ideas ledger** (full designs in `fable/left-field-ideas.md` and `codex/left-field-ideas.md`):``
- after: ``**The ideas ledger** (full designs in `lanes/left-field-ideas.md`, and in its operator-local source `fable/left-field-ideas.md`, which is not published in this tree):``

**Line 140** — found by reading the file
- before: ``Every spike must retain the detailed fence and deciding witness in `codex/left-field-ideas.md`;``
- after: ``Every spike must retain the detailed fence and deciding witness in `lanes/left-field-ideas.md`;``

**Line 156 (Sources)**
- before: ``` `synth-codex.md` (the product specification; §6 budgets, §7 coverage, §9 testing, §13 done) and the `codex/` specification set. Product evidence and rationale: `codex/evidence-baseline.md` and `codex/corpus-insights.md`. Source corpus: `fable/` and the three `lessons-*.md`; the current status of every scout idea is `fable/dispositions.md`. Normative implementation record: … ```
- after: ``` `specification.md` (the product specification; §6 budgets, §7 coverage, §9 testing, §13 done) and the `lanes/` specification set. Product evidence and rationale: `lanes/evidence-baseline.md` and `lanes/corpus-insights.md`. Source corpus — operator-local, deliberately not published here, and nothing in this tree substitutes for it: the `fable/` scout corpus, its three `lessons-*.md` files, and `fable/dispositions.md`, which carries the current status of every scout idea (a different ledger from this directory's `dispositions.md`). Normative implementation record: … ```

The trailing "Normative implementation record" clause is unchanged; the governance bead ids and PR number are untouched.

## The three local-only references, and why they are worded this way

The ruling on the bead is (a) for all three: mark them explicitly as local-only sources not present in this tree. Nothing is published and no reference is dropped, because the references carry real provenance — where the material came from — and this repo's habit is to state what a record does not cover rather than to go silent.

The wording target was a reader in a fresh clone who must understand *immediately* that the material is absent, rather than going hunting. Three choices follow from that:

1. **"operator-local" says whose tree it is**, so the reader knows the material exists somewhere and is not lost — the reference is provenance, not a dead link.
2. **"deliberately not published here" forecloses the bug report.** Without "deliberately" a reader reasonably concludes the publication was incomplete and files an issue or goes looking through history.
3. **"nothing in this tree substitutes for it"** is the sentence that actually stops the hunt. It is the difference between "this file is elsewhere" and "do not go looking for a stand-in".

One extra guard on line 156, which is not in the bead but follows from the same reasoning: this directory contains a published `dispositions.md` sitting three files away from the reference to `fable/dispositions.md`. They are entirely different documents — the published one is Phase 0's coverage-classification and per-surface server-policy ledger; the `fable/` one is the scout-idea status ledger. A reader told only "`fable/dispositions.md` is not here" would very likely substitute the neighbour. Hence the parenthetical "(a different ledger from this directory's `dispositions.md`)". This is the mis-substitution the fix exists to prevent, so it is worth the clause.

Line 133 uses the shorter form ("its operator-local source … which is not published in this tree") because the sentence already names the published `lanes/left-field-ideas.md` beside it — the reader has somewhere to go, so the marking only has to prevent the second hunt.

## Occurrences found elsewhere — reported, not fixed

Inside the fence: the four extra lines above (5, 95, 133, 140), all fixed.

Outside the fence, left alone as instructed:

- `product/README.md:3` — the `specification.md (= synth-codex.md)` / `lanes/ (= codex/)` file map. **Deliberate and correct**: it maps published names to originals for a reader who knows the `ai/` tree, which is the reverse of this defect.
- `product/README.md:23-37` — the rf2-hic-000 source-hash manifest. **Deliberate**: a freshness check against the source files.
- **`product/specification.md:494`** — ``The complete supporting specification set … maintained in [`codex/README.md`](lanes/README.md).`` The link *target* is correct (`lanes/README.md`) but the visible link *text* still reads `codex/README.md`, so a reader is shown an unreachable name. Same defect class as this bead, in a document that is also in the worker reading set. It is not a broken link, so no gate catches it. **Reported for a follow-up bead — not touched here.**
- **`product/lanes/README.md:11`** — ``The sibling lesson reports and `fable/` material are source corpus.`` An unmarked reference to the unpublished `fable/` tree and the `lessons-*.md` reports, of exactly the class this bead rules on. **Reported — not touched here.**
- `docs/EP/EP-0024-unified-frame-identity-and-lifecycle.md:176-178` — three `ai/findings/API-review/codex/*.md` paths. Different bead set and different tree entirely; noted only so the sweep is complete.

## Hand verification

- **Anchors**: this change touches no heading and introduces no link. The file contains **zero** markdown links before and after (`grep -c '](' ` returns 0), so no anchor exists in it to break. All six edits are inline code spans in prose.
- **Tables**: the file has two tables (the placement table at lines 19-24, three columns; the scoreboard at lines 38-49, two columns). **Neither is touched** by this change — every edited line is prose. Column counts are therefore unchanged, and were re-read to confirm: 3 columns throughout the first, 2 throughout the second.
- **Renamed targets exist**: `specification.md`, `lanes/README.md`, `lanes/adversarial-risks.md`, `lanes/evidence-baseline.md`, `lanes/corpus-insights.md`, `lanes/left-field-ideas.md` all verified present in the working tree.
- **`mkdocs build --strict` is not applicable** — `mkdocs.yml`'s `exclude_docs` keeps `docs/design/**` out of the site.

## Quality gates

| Gate | Exit code |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `git fetch --no-tags origin main; python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |

The pins gate reported `1 files, 0 cited pins (0 landed, 0 stranded, 0 unresolvable)` — it opened this file, and the change cites no pins (no hex-looking tokens were introduced; the only dates and ids in the edited text are bead ids and a PR number carried over unchanged).

**Sabotage control.** Necessary here for a reason worth stating: because the file contains no markdown links at all, a green slug-gate exit on its own proves nothing about roster membership. Appending one line with a deliberately broken target *and* a deliberately broken anchor:

```
[sabotage target](no-such-file-here.md) and [sabotage anchor](specification.md#no-such-anchor-here)
```

produced **exit 1**, naming the file on both check paths:

```
BROKEN TARGET: docs\design\hicasso\product\decision-brief.md:158 -> no-such-file-here.md
BROKEN ANCHOR: docs\design\hicasso\product\decision-brief.md:158 -> specification.md#no-such-anchor-here
```

The line was then removed and the gate re-run: **exit 0**. `git diff --stat` after restore shows `1 file changed, 6 insertions(+), 6 deletions(-)` — the sabotage left no residue.

Closes rf2-28jg.
