### PR TITLE
docs(hicasso): close out the ai/-path references (rf2-lo5r)

### DIFF
--- a/docs/design/hicasso/product/lanes/README.md
+++ b/docs/design/hicasso/product/lanes/README.md
@@ -8,7 +8,7 @@ These documents define the current target for the native interpreted-Hiccup adap
 2. [`../specification.md`](../specification.md) is the normative product target for that selected direction. It owns product verdicts, budgets, capability placement, the public-surface target, and phase order.
 3. [`design-laws.md`](design-laws.md) states the non-negotiable design constraints; [`evidence-baseline.md`](evidence-baseline.md) records what is actually demonstrated and what still needs proof.
 4. The focused specifications below own protocols, risk detail, and acceptance tests only. If one conflicts with either governing document, update it rather than preserving a second verdict or sequence.
-5. The sibling lesson reports and `fable/` material are source corpus. They contribute evidence and ideas but are not normative product documents.
+5. The `lessons-*.md` reports and the `fable/` material are source corpus — operator-local, deliberately not published here, and nothing in this tree substitutes for them. They contribute evidence and ideas but are not normative product documents.
 
 Quantitative claims stay attached to their witness, revision, runtime, substrate, and instrument. Results from different instruments are not presented as one continuous benchmark series.
 

--- a/docs/design/hicasso/product/specification.md
+++ b/docs/design/hicasso/product/specification.md
@@ -491,4 +491,4 @@ Client v0 does not wait for an unused production SSR deployment, but the hydrati
 
 ## Supporting specifications
 
-The complete supporting specification set and its concern-ownership map are maintained in [`codex/README.md`](lanes/README.md). This document does not maintain a second index.
+The complete supporting specification set and its concern-ownership map are maintained in [`lanes/README.md`](lanes/README.md). This document does not maintain a second index.


### PR DESCRIPTION
Closes the defect class opened by rf2-oqe8 and continued through rf2-bmj8 and rf2-28jg: published Hicasso product documents naming paths that exist only in the operator-local source tree, which a fresh clone cannot reach. The mayor enumerated the two remaining points; both are fixed here.

## Point 1 — `specification.md:494`, link text named an unreachable path

The target was already correct. Only the visible text was wrong, and `check_doc_slugs.py` validates targets and anchors, not link text, so no gate caught it.

Before:

```
The complete supporting specification set and its concern-ownership map are maintained in [`codex/README.md`](lanes/README.md). This document does not maintain a second index.
```

After:

```
The complete supporting specification set and its concern-ownership map are maintained in [`lanes/README.md`](lanes/README.md). This document does not maintain a second index.
```

The parenthesised target is byte-identical — the diff touches only the bracketed text. Hand-verified that it still resolves: `docs/design/hicasso/product/` + `lanes/README.md` → `docs/design/hicasso/product/lanes/README.md`, which exists.

## Point 2 — `lanes/README.md:11`, unmarked reference to the unpublished tree

`fable/` and the `lessons-*.md` reports have no published counterpart; rf2-hic-000 deliberately did not publish them, and the `ai/` tree is gitignored.

Before:

```
5. The sibling lesson reports and `fable/` material are source corpus. They contribute evidence and ideas but are not normative product documents.
```

After:

```
5. The `lessons-*.md` reports and the `fable/` material are source corpus — operator-local, deliberately not published here, and nothing in this tree substitutes for them. They contribute evidence and ideas but are not normative product documents.
```

This follows the idiom rf2-28jg established in `decision-brief.md:156` rather than inventing a new phrasing, keeping all three of its moving parts: the material **exists** (so the reference still reads as provenance), it is **deliberately** not published here (so nobody concludes the publication was incomplete), and **nothing here substitutes** for it (which is what actually stops a reader hunting). The original sentence's own work — source corpus, contributes evidence, not normative — is preserved intact.

## Confirming grep — the class is closed

```
$ grep -rn "synth-codex\.md\|\bcodex/\|\bfable/" docs/design/hicasso/product/
```

| Hit | Category |
|---|---|
| `decision-brief.md:133` — `fable/left-field-ideas.md` operator-local mark | **(c)** rf2-28jg, deliberate |
| `decision-brief.md:156` — `fable/` scout corpus operator-local mark | **(c)** rf2-28jg, deliberate |
| `lanes/README.md:11` — `fable/` material, now marked operator-local | **(c)** this PR's fix, deliberate |
| `README.md:3` — `specification.md (= synth-codex.md)`, `lanes/ (= codex/)` gloss | **(a)** name map, deliberate |
| `README.md:23` — `*synth-codex.md` hash | **(b)** source-hash manifest |
| `README.md:24-37` — `*codex/README.md` … `*codex/use-cases.md` hashes (14 lines) | **(b)** source-hash manifest |

Every hit falls in a deliberate category; nothing outside them appears. Category **(b)** is untouched by design — a hash manifest records the hash of the file it was copied *from*, so renaming those entries would break the freshness check the set README's default #7 depends on. The only entry not in the mayor's original three-category enumeration is `lanes/README.md:11`, which is this PR's own fix now carrying the (c) idiom.

### Wider sweep (reported, not fixed — outside the fence)

A broader read-only sweep for `lessons-` / `synth.md` / `ai/` found four further lines, all in `lanes/beads-review.md` (48, 170, 197, 206). These are not instances of the defect class: each discusses the `ai/` tree *as its subject* and already self-marks it as gitignored and unreachable from a worker checkout — e.g. "the gitignored `ai/` tree", "files corrective proposals under gitignored `ai/findings/.../beads/`, which a worker checkout cannot see or land". They are commentary on the publication model, not dangling references a reader would hunt for. Left untouched; flagged for the mayor's judgment.

## Quality gates

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `git fetch --no-tags origin main; python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |

The pins gate reports `2 files, 0 cited pins (0 landed, 0 stranded, 0 unresolvable)` — confirming it opened exactly the two changed files.

`mkdocs build --strict` is not applicable: `mkdocs.yml`'s `exclude_docs` keeps `docs/design/**` out of the site.

### Sabotage controls — run separately on each file

A green exit proves nothing about a file outside the checker's roster, and `specification.md` is large, so each file was proved to be on the roster independently.

**`specification.md`** — broke the anchor at line 37 (`lanes/design-laws.md#native-boundary` → `#rf2-lo5r-sabotage-anchor`):

```
1 broken anchor link(s) found:
  BROKEN ANCHOR: docs\design\hicasso\product\specification.md:37 -> lanes/design-laws.md#rf2-lo5r-sabotage-anchor
```

Exit **1**, naming the file. Restored → exit **0**, diff unchanged.

**`lanes/README.md`** — broke the anchor at line 21 (`design-laws.md#native-boundary` → `#rf2-lo5r-sabotage-anchor`):

```
1 broken anchor link(s) found:
  BROKEN ANCHOR: docs\design\hicasso\product\lanes\README.md:21 -> design-laws.md#rf2-lo5r-sabotage-anchor
```

Exit **1**, naming the file. Restored → exit **0**, diff unchanged.

Final diff after both restores is exactly `2 files changed, 2 insertions(+), 2 deletions(-)`.
