### PR TITLE
docs(hicasso): the published set carries its own refresh contract (rf2-hic-000)

### DIFF
--- a/docs/design/hicasso/product/README.md
+++ b/docs/design/hicasso/product/README.md
@@ -1,6 +1,6 @@
 # Published normative set (snapshot)
 
-Published from the operator-local working set by rf2-hic-000. This is the worker-facing snapshot; the refresh rule and the living-home question are recorded in the bead-set README (default #7). File map: decision-brief.md (= synth.md), specification.md (= synth-codex.md), lanes/ (= codex/).
+Published from the operator-local working set by rf2-hic-000. This is the worker-facing snapshot; the refresh rule and the living-home question are stated below, under [Refresh contract](#refresh-contract). File map: decision-brief.md (= synth.md), specification.md (= synth-codex.md), lanes/ (= codex/).
 
 The naming ledger (naming-ledger.md) is live and appended-to by beads; see rf2-hic-065.
 
@@ -36,3 +36,15 @@ a25e603d1f8aabb6ca6b5709ff61abd95864c702adc329de9a7df17bcffc2c2e *codex/react-co
 f479a12c5edc15f02a334616cc9c7d5b9e2588196fc87e3e97afa96d13f2aba5 *codex/testing-xray.md
 5904203883eae79c1b972e07c9ac7ca88228c0a0593c45480f61afd102a4da6f *codex/use-cases.md
 ```
+
+## Refresh contract
+
+The rule this snapshot lives under is stated here, in the tracked tree, so that a clean worktree checkout can read it. The operator-local bead-set README records the same default; it is not published, and nothing below depends on being able to open it.
+
+**The originals remain the working set.** These documents are written and revised under `ai/`, in the operator's sessions. This directory holds copies of them. Do not edit a document here: the next publication overwrites it, and the operator who owns the original never sees the change.
+
+**Refresh on material source change.** When a source changes in a way a reader could act on differently — a verdict, a budget, a facade spelling, a phase exit, an added lane — republish the affected files and update their digests above in the same change. Wording and typo repairs owe no republication.
+
+**What makes a stale snapshot fail loudly.** The digests above are recorded under the *source* file names, so the comparison runs source-against-manifest rather than copy-against-copy. Before filing a bead or dispatching a worker from the operator-local set, re-digest the sources being filed from and compare them with the list above. Equal means this snapshot says what the filer is reading. Unequal means it is stale for exactly the files that differ, and those are republished before the bead is filed or the brief goes out. That is the whole mechanism, and it needs no checker and no extra step in anyone's workflow: filing and dispatch are the only two moments at which a stale copy can mislead someone, so they are the only two moments the comparison has to happen.
+
+**Moving the living home into this tree permanently is an operator and Codex decision.** It is not a worker's to take, and not a side effect of a refresh. Until it is taken, this directory is a snapshot and the rule above stands.


### PR DESCRIPTION
Discharges the **MERGED-PR AUDIT #7711** note on rf2-hic-000. The published files and their recorded source hashes were already complete and fresh; what was missing was the worker-visible refresh contract. `docs/design/hicasso/product/README.md` line 3 pointed at the operator-local bead-set README ("default #7") — a file no clean worker checkout can open — so the rule governing this snapshot was unreadable from the tree that snapshot exists to serve.

One file changed, 13 insertions and 1 deletion.

## The text added

Line 3's pointer clause now resolves in-tree:

> This is the worker-facing snapshot; the refresh rule and the living-home question are stated below, under [Refresh contract](#refresh-contract).

And a new closing section, placed directly after the manifest it describes:

> ## Refresh contract
>
> The rule this snapshot lives under is stated here, in the tracked tree, so that a clean worktree checkout can read it. The operator-local bead-set README records the same default; it is not published, and nothing below depends on being able to open it.
>
> **The originals remain the working set.** These documents are written and revised under `ai/`, in the operator's sessions. This directory holds copies of them. Do not edit a document here: the next publication overwrites it, and the operator who owns the original never sees the change.
>
> **Refresh on material source change.** When a source changes in a way a reader could act on differently — a verdict, a budget, a facade spelling, a phase exit, an added lane — republish the affected files and update their digests above in the same change. Wording and typo repairs owe no republication.
>
> **What makes a stale snapshot fail loudly.** The digests above are recorded under the *source* file names, so the comparison runs source-against-manifest rather than copy-against-copy. Before filing a bead or dispatching a worker from the operator-local set, re-digest the sources being filed from and compare them with the list above. Equal means this snapshot says what the filer is reading. Unequal means it is stale for exactly the files that differ, and those are republished before the bead is filed or the brief goes out. That is the whole mechanism, and it needs no checker and no extra step in anyone's workflow: filing and dispatch are the only two moments at which a stale copy can mislead someone, so they are the only two moments the comparison has to happen.
>
> **Moving the living home into this tree permanently is an operator and Codex decision.** It is not a worker's to take, and not a side effect of a refresh. Until it is taken, this directory is a snapshot and the rule above stands.

## How this discharges the #7711 note, clause by clause

| The note asks for | Where it is met |
|---|---|
| "does not carry the required worker-visible refresh contract" — put the actual bounded rule in the tracked README | The whole `## Refresh contract` section is in the tracked file. Nothing in it depends on reading an untracked path. |
| "It points to the gitignored bead-set README ('default #7'), which a clean worker checkout cannot read" | The line-3 pointer now targets the in-file section. The set README is still acknowledged as the origin of the default, but explicitly as operator-local and explicitly not load-bearing — the same treatment `decision-brief.md` gives the `fable/` corpus. |
| "refresh on material source change" | The **Refresh on material source change** paragraph, with the test stated as *could a reader act on it differently* and examples of both sides, so the rule can be applied without a ruling. |
| "while ai originals remain the working set" | The **originals remain the working set** paragraph, including the consequence that makes it stick: an edit made to a copy is overwritten by the next publication and never reaches the operator. |
| "any permanent living-home move owned by the operator + Codex decision" | The closing paragraph, stated as a negative too — not a worker's to take, and not a side effect of a refresh. |
| "state the filing/dispatch comparison point that makes a stale snapshot fail loudly" | The **What makes a stale snapshot fail loudly** paragraph names what is compared (a fresh digest of the sources being filed from), against what (the manifest list), when (before filing a bead or dispatching a worker), and what each outcome means. |
| "no new governance machinery is needed" | Nothing was added but prose. No checker, no workflow, no CI job, no process step. The section says so in as many words, and explains why filing and dispatch are sufficient coverage: they are the only moments a stale copy can mislead anyone. |

## The hash manifest and the line-3 gloss are untouched

Confirmed by the diff: `git diff | grep -E "^[+-][0-9a-f]{64} "` returns **0** lines. The manifest at lines 22–37 keeps its SOURCE names (`synth.md`, `synth-codex.md`, `codex/*.md`), its hashes, its order and its formatting — a hash manifest records the hash of the file it was copied *from*, and the new section explains that property rather than altering it. The `specification.md (= synth-codex.md)` gloss on line 3 is preserved verbatim; only the refresh-rule clause in that sentence changed.

## The other two audit notes on rf2-hic-000, verified before being left alone

- **#7721** (decision-brief.md:7 and :156) — discharged. PR #7722 is MERGED. In this branch's tree, decision-brief.md:7 reads "Its sibling `specification.md` … indexed by `lanes/README.md`", and the Sources paragraph names `specification.md`, `lanes/evidence-baseline.md` and `lanes/corpus-insights.md`, with the `fable/` corpus marked operator-local and deliberately unpublished. No action taken.
- **#7722** (specification.md:494 and lanes/README.md:11) — owned by PR #7723, which is OPEN and touches exactly those two files, one line each. Both defects are therefore still visible in `main` (specification.md:494 still displays the `codex/README.md` label over the correct `lanes/README.md` target; lanes/README.md:11 still calls the lesson reports and `fable/` material sibling source corpus without marking them operator-local). **Deliberately not fixed here** — #7723 owns them and a collision would cost more than the delay.

## Quality gates

Run foreground, to completion, unpiped, from `C:/Users/miket/code/re-frame2-worktrees/refresh-hic000`.

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |

The pins gate reported `1 files, 0 cited pins (0 landed, 0 stranded, 0 unresolvable)` — it did read this file, and classified every 64-character token in the manifest as a document digest rather than a commit pin, as its length rule intends. The new prose introduces no hex token at all, so there is nothing in it that could be misread as a pin.

**Sabotage control.** A green exit on a docs file proves nothing unless the checker's roster actually includes it, so the new anchor was broken deliberately: `(#refresh-contract)` became `(#refresh-contract-does-not-exist)`. `check_doc_slugs.py` then exited **1** and named the file — `BROKEN ANCHOR: docs\design\hicasso\product\README.md:3 -> #refresh-contract-does-not-exist`. The anchor was restored and both gates re-run: slugs **0**, pins **0**.

**By hand**, since nothing gates rendering in `docs/design/**`: the one new link target `#refresh-contract` resolves to the new `## Refresh contract` heading in the same file (and the sabotage above proves the checker agrees). The section adds no table, so there are no column counts to check; the pre-existing tables in this file were not touched. `mkdocs build --strict` is not applicable — `mkdocs.yml`'s `exclude_docs` keeps `docs/design/**` out of the site.

## Scope

`docs/design/hicasso/product/README.md` only. Not touched: `specification.md` and `lanes/README.md` (PR #7723), `invariants.md` (rf2-hic-002), `k1-price-acceptance.md` (rf2-hic-003).

rf2-hic-000 is **left open on purpose**. The merged-PR audit hook owns this bead's lifecycle and has reopened it three times; the mayor decides after this merges.
