### PR TITLE
docs(hicasso): re-freeze the pre-registration at its landed amendment revision (rf2-mcwm)

### DIFF
--- a/docs/design/hicasso/product/resource-demand-criteria.md
+++ b/docs/design/hicasso/product/resource-demand-criteria.md
@@ -15,11 +15,14 @@ Nothing here was measured. Every line below is derived from the [specification](
 | Applied by | `rf2-hic-050`, mechanically |
 | Default verdict | STOP. ADOPT requires every criterion met on published, re-checkable evidence |
 | Amendment | Prospective only — see [Amendment rule](#amendment-rule) |
-| Pre-registration commit | `c8b8de6d28` |
+| Original freeze | `c8b8de6d28`, registering all seven criteria |
+| Pre-registration commit | `afbb58febc`, the effective revision after C2's amendment — this is the hash to cite |
 
-**That commit is the pre-registration proof**, back-filled by `rf2-mcwm` once the merge minted it. `rf2-hic-044` records its instrumentation against these criteria by citing it, and `rf2-hic-050` cites it again when it applies them. A verdict that cannot cite a criteria commit predating the report has not been pre-registered, whatever the dates claim.
+**The effective revision is the pre-registration proof.** `rf2-hic-044` records its instrumentation against these criteria by citing `afbb58febc`, and `rf2-hic-050` cites it again when it applies them, because that is the revision carrying the criteria text they actually apply. The original freeze `c8b8de6d28` remains the provenance of C1 and C3–C7, which have not changed a byte since it; only C2 was amended, and only prospectively. A verdict that cannot cite a criteria commit predating the report has not been pre-registered, whatever the dates claim.
 
-**Post-freeze edits, recorded here rather than made silently.** Two landed after that commit and before `rf2-hic-044` began, which is the window the [amendment rule](#amendment-rule) reserves: the row above was back-filled, and C2's closing sentence was corrected. That sentence had let unregistered defect classes count toward C2's threshold, contradicting the same criterion's statement that its classes are fixed in advance so no flattering class can be invented after the fact. Unregistered classes are still reported; they no longer count unless registered prospectively. No threshold moved, and nothing else changed.
+**Post-freeze edits, recorded here rather than made silently.** Two landed after the original freeze and before `rf2-hic-044` began, which is the window the [amendment rule](#amendment-rule) reserves, and both landed as `afbb58febc4e0a28e67a2a172bb604f0570472b5`: the commit row was back-filled, and C2's closing sentence was corrected. That sentence had let unregistered defect classes count toward C2's threshold, contradicting the same criterion's statement that its classes are fixed in advance so no flattering class can be invented after the fact. Unregistered classes are still reported; they no longer count unless registered prospectively. No threshold moved, and nothing else changed. C2's correction is a prospective amendment, so the file re-froze there, and the rows above now name that revision.
+
+**A back-fill is not an amendment.** Those rows were themselves written afterwards, by `rf2-mcwm`, because no commit can contain its own hash — the same reason the original freeze could not carry `c8b8de6d28`. Recording provenance touches no criterion, so it does not re-freeze the file: the effective revision stays `afbb58febc`, whose criteria text is byte-for-byte the text below. Only a change to a criterion moves it.
 
 ## What is being decided
 


### PR DESCRIPTION
Discharges the MERGED-PR AUDIT #7718 obligation on `rf2-mcwm`. The record named `c8b8de6d28` as its pre-registration commit, but C2 was amended after that commit — the C2 text at `c8b8de6d28` still carries the superseded "may be added and count normally" sentence. A witness citing `c8b8de6d28` would be citing rules it is not operating under. The file's own amendment rule says an amendment re-freezes the file at a new commit and that hash is what `rf2-hic-044` and `rf2-hic-050` cite, so the landed amendment revision is now recorded as the operative one.

Only `docs/design/hicasso/product/resource-demand-criteria.md` is touched.

## The landed hash, and the evidence it is the landed revision

The operative revision is **`afbb58febc4e0a28e67a2a172bb604f0570472b5`**. It was verified from git in this worktree, not taken from the audit note.

It is the most recent of exactly two commits ever to touch the file:

```
$ git log --oneline --follow -- docs/design/hicasso/product/resource-demand-criteria.md
afbb58febc docs(hicasso): back-fill the pre-registration commit hash (rf2-mcwm)
c8b8de6d28 docs(hicasso): pre-register the resource-demand criteria (rf2-hic-039)
```

It is an ancestor of `origin/main`, and the PR head is not — this repo rebase-merges, so the two are different objects:

```
$ git merge-base --is-ancestor afbb58febc4e0a28e67a2a172bb604f0570472b5 origin/main
afbb58f ancestor-of-origin/main exit=0
$ git merge-base --is-ancestor 92cd524aeeb0132f51f8e3376e313d7819f8813c origin/main
92cd524 ancestor-of-origin/main exit=1

$ git cat-file -t 92cd524aeeb0132f51f8e3376e313d7819f8813c
commit                       # the PR head exists locally, but is reachable from no remote ref

$ git branch -r --contains afbb58febc4e0a28e67a2a172bb604f0570472b5
  origin/HEAD -> origin/main
  origin/main
```

This agrees with the audit note on both hashes. Nothing had to be reconciled.

## How both revisions stay legible

The record table now carries two rows instead of one, following the document's own amendment-rule vocabulary:

```
| Original freeze | `c8b8de6d28`, registering all seven criteria |
| Pre-registration commit | `afbb58febc`, the effective revision after C2's amendment — this is the hash to cite |
```

The operative hash deliberately keeps the label `Pre-registration commit`, the name downstream already knows. That means the Verdict procedure's step 1 — "Cite this file's pre-registration commit" — now resolves to the right object with no edit, and no instruction in `rf2-hic-044` or `rf2-hic-050` has to change. The original freeze sits above it as the provenance of C1 and C3–C7.

The existing post-freeze note was extended rather than replaced, so there is one format and not two: it now names the revision those two edits landed as, and states that C2's correction is the prospective amendment the file re-froze at.

One addition closes a regress the audit's fix would otherwise reopen. No commit can contain its own hash, so writing `afbb58febc` into the file necessarily makes a newer commit — which is precisely how the record went stale the first time. A short paragraph, **"A back-fill is not an amendment"**, fixes the rule: recording provenance touches no criterion and does not re-freeze the file, so the effective revision stays `afbb58febc`. Without it the file would need re-freezing forever, one commit behind itself.

## C1 and C3–C7 are byte-identical

No criterion changed. Extracting the whole `### C1` → `## The criteria at a glance` span at each revision and hashing it:

```
3c51b1a37b96d0d23ae7fedf9c9c0f4dfcd72bc6465f9de5fe652debea2d2b4c  at c8b8de6d28 (original freeze)
1c35446d7a8eb083fea6d20ad52f58ae4433c20a21026193b870d7e8025865a5  at afbb58febc (effective revision)
1c35446d7a8eb083fea6d20ad52f58ae4433c20a21026193b870d7e8025865a5  this branch
```

The criteria block on this branch is byte-identical to `afbb58febc` — this PR changes no criterion text at all, which is what lets the file claim the effective revision is unmoved. Diffed against the original freeze, the sole difference in the whole C1–C7 span is C2's already-merged closing sentence; C1 and C3–C7 are byte-identical across all three revisions.

C2's content was not revisited. Thresholds are untouched.

## Quality gates

Both run in the foreground to completion, unpiped.

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |

Full pins-gate output:

```
check_provenance_pins: 1 files, 5 cited pins (5 landed, 0 stranded, 0 unresolvable)
check_provenance_pins: every cited pin is an ancestor of origin/main or shares its block with one.
```

Every cited pin is landed. The count rises from 1 to 5 because the record now cites two revisions and names each where it is load-bearing.

**Sabotage control (slugs).** Broke the `#amendment-rule` anchor in the record table; the gate failed as it should:

```
1 broken anchor link(s) found:
  BROKEN ANCHOR: docs\design\hicasso\product\resource-demand-criteria.md:17 -> #amendment-rule-DELIBERATELY-BROKEN
```

exit 1, naming this file. Restored, re-ran, exit 0.

**Sabotage control (pins).** Since this PR writes a real SHA into a page the pins gate inspects, the gate was also proved able to fail on the specific mistake in question: substituting the PR head `92cd524aee…` for the landed hash.

```
check_provenance_pins: 1 files, 5 cited pins (2 landed, 3 stranded, 0 unresolvable)
  docs/design/hicasso/product/resource-demand-criteria.md:23  92cd524aeeb0132f51f8e3376e313d7819f8813c [STRANDED]
      authored head — resolves here but is an ancestor of no remote ref, so it is absent from a fresh clone
```

exit 1. Worth recording precisely: only one of the three stranded occurrences was reported, because the two in the table row share a block with the landed `c8b8de6d28` and the gate enforces accompaniment per block rather than "every SHA on main". So the gate would have caught the PR-head error here, but it is the prose citation that catches it, not the table. Restored, re-ran, exit 0.

`rf2-mcwm` is left OPEN — the audit hook owns its lifecycle.
