### PR TITLE
docs(hicasso): the K1 row records the ruling (rf2-sza0w)

### DIFF
--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -1508,8 +1508,18 @@ inputs are gone; the durable path starts at the re-run and not before it.
   denominator on 2026-08-05 to `≤ 1.10×` direct UIx-on-subs — and on the amended
   denominator the published row's verdict is `K1 MISSED, DECISIVELY`
   ([§4.3](rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row),
-  2026-08-08, `rf2-diaud`). Whether the criterion's remaining condition, **after
-  two serious runtime iterations**, is met is a ruling this page does not make)*
+  2026-08-08, `rf2-diaud`). ~~Whether the criterion's remaining condition, **after
+  two serious runtime iterations**, is met is a ruling this page does not make~~
+  — **that ruling has since been made elsewhere: the operator ruled the
+  two-iterations conjunct MET on 2026-08-10 (`rf2-sza0w`), so both conjuncts
+  stand and K1 is TRIPPED.** Its *stop or narrow* consequence is superseded by
+  the selection of Hicasso plus the scoped price-acceptance amendment — the
+  operative default, [`rf2-hic-003`](../product/k1-price-acceptance.md) — making
+  the outcome a formalized **narrow-and-price, not a stop**; that record's
+  `1.25×` ceiling is ratified at the 2026-08-27 sitting and colours no result
+  before then, and the published miss above is not recoloured by it. The kill
+  table carries the same record and is where the criterion lives:
+  [`validation.md`](../validation.md#kill-criteria-any-tripping--stop-or-narrow-adapters-only-is-success))*
   — but no longer a range that straddles parity, and the direction
   has never once come back the other way.
 - **The deficit's location is measured, not inferred.** The candidate pays

--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -662,7 +662,7 @@ comparison this section schedules was originally written as
 
 | # | Kill if |
 |---|---|
-| K1 | Mount above the amended mount gate (1.10× direct UIx on the clock of record) after two serious runtime iterations |
+| K1 | Mount above the amended mount gate (1.10× direct UIx on the clock of record) after two serious runtime iterations — **TRIPPED, ruled 2026-08-10 (`rf2-sza0w`)**: the gate half is measured **MISSED, DECISIVELY** (`rf2-diaud`, PR #7704 — figures at [§4.3](studio/rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row)), and the two-serious-runtime-iterations conjunct is **ruled MET** that date. The criterion text above is as registered and the `1.10×` gate is untouched; what is superseded is the **consequence** — a formalized narrow-and-price, not a stop. See the note directly below |
 | K2 | Bulk (≥ ~100 boundaries, one commit) > 1.5× Reagent view work after those iterations |
 | K3 | Per-boundary heap worse than Reagent with no paper path to the floor |
 | K4 | Controlled text fails same-tick echo / IME on Chromium and WebKit for a simple form |
@@ -670,6 +670,37 @@ comparison this section schedules was originally written as
 | K7 | Six weeks (HD-014) with no path that is both preferable and ≤ Reagent on K1–K2 |
 
 Red gates shrink scope; they never expand features.
+
+**K1 IS TRIPPED — operator ruling, 2026-08-10 (`rf2-sza0w`).** Both conjuncts now
+stand, and the row above records it. **The gate half is measured MISSED,
+DECISIVELY**: `rf2-diaud` (PR #7704) published the `M1` mount row on K1's own
+floor-normalised estimand and adjudicated it against K1's own `1.10×` threshold,
+and on both retained ensembles the whole interval sits above the gate on the
+losing side. The figures, the co-instrumented Reagent-on-subs pairs and the
+residual-uncertainty caveats are at
+[§4.3](studio/rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row)
+and are **not** duplicated here. **The two-serious-runtime-iterations conjunct is
+ruled MET** as of this date, on the basis the operator gave: `rf2-nld4g` closed
+with no admissible attack clearing the bar, and the interpreter was exonerated at
+`0.9636×` stock Reagent, locating the deficit outside it.
+
+**The consequence is superseded — the outcome is a formalized narrow-and-price,
+not a stop.** This section's heading names *stop or narrow* as what a tripping
+criterion asks, and that remains the general rule; for K1 it is superseded by the
+operator's [selection of Hicasso](product/decision-brief.md) together with the
+scoped price-acceptance amendment, the **operative default**, whose record is
+[`product/k1-price-acceptance.md`](product/k1-price-acceptance.md) (`rf2-hic-003`):
+a [`1.25×` product ceiling](product/k1-price-acceptance.md#5-the-proposed-ceiling)
+read by a frozen comparison rule, carrying this very ruling as the first of its
+[reconsideration triggers](product/k1-price-acceptance.md#71-reopen-conditions).
+That ceiling is **proposed, not operative** — it is ratified at the 2026-08-27
+sitting and may mark no result green before then, and **the published miss is not
+recoloured by any of this**. **Nothing in the criterion moved:** the row's text is
+as registered, the `1.10×` gate is untouched, and K2, K3, K4, K6 and K7 are
+unaffected. The sitting's K1 line is this annotated row plus ratification of the
+amendment; no tripped-criterion surprise remains. The clock page's
+[§8](studio/the-candidates-clock.md#8-what-this-hands-the-programme) carries the
+same record.
 
 **K1's denominator was amended — mount-gate amendment 2026-08-02, consistency
 edit 2026-08-05 (`rf2-hyd50`).** Its row read, verbatim: `Mount > Reagent on the


### PR DESCRIPTION
Transcribes the operator ruling of 2026-08-10 02:59 AUSEST (Mike, in session; Option A on all three questions) into the kill-criteria table, and brings the clock page's section 8 into agreement with it.

The kill table was the one page in the tree that did not know its own criterion had fired. To a fresh reader it said "nothing has happened here".

## The row, before and after

**Before** (`docs/design/hicasso/validation.md:665`):

```text
| K1 | Mount above the amended mount gate (1.10× direct UIx on the clock of record) after two serious runtime iterations |
```

**After:**

```text
| K1 | Mount above the amended mount gate (1.10× direct UIx on the clock of record) after two serious runtime iterations — **TRIPPED, ruled 2026-08-10 (`rf2-sza0w`)**: the gate half is measured **MISSED, DECISIVELY** (`rf2-diaud`, PR #7704 — figures at [§4.3](studio/rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row)), and the two-serious-runtime-iterations conjunct is **ruled MET** that date. The criterion text above is as registered and the `1.10×` gate is untouched; what is superseded is the **consequence** — a formalized narrow-and-price, not a stop. See the note directly below |
```

The row carries the verdict and the pointers; the reasoning goes in a dated note beneath the table, which is how this section already handles the denominator amendment and the K5 removal. The note is placed first among the notes because this file's own banner idiom is newest-first.

## The ruling's three facts, and where each is recorded

| Fact | Recorded |
|---|---|
| Gate half measured **MISSED, DECISIVELY** — `rf2-diaud`, PR #7704, figures at `rows-re-adjudicated-on-the-corrected-clock.md` §4.3 | K1 row cell; first paragraph of the new note (`validation.md:674-685`); clock page §8 |
| Two-iterations conjunct **ruled MET**, dated 2026-08-10, with the operator's stated basis (`rf2-nld4g` closed with no admissible attack clearing the bar; interpreter exonerated at `0.9636×` stock Reagent, locating the deficit outside it) | K1 row cell; end of the note's first paragraph; clock page §8 |
| Consequence "stop or narrow" **superseded** by the selection of Hicasso plus the scoped price amendment — `rf2-hic-003`, operative default, `1.25×` product ceiling, reconsideration trigger — a formalized narrow-and-price, not a stop | Second paragraph of the note (`validation.md:687-703`), linking the amendment record, its §5 ceiling and its §7.1 reopen conditions; clock page §8 |

## Consistency between the two pages

Section 8 of `docs/design/hicasso/studio/the-candidates-clock.md` ended its K1 clause with "Whether the criterion's remaining condition, **after two serious runtime iterations**, is met is a ruling this page does not make". True when written, stale now. That sentence is **struck and kept in full**, followed by the ruling. Both pages now carry the 2026-08-10 date and link to each other.

## Nothing erased, no threshold moved

The diff is 44 insertions against 3 deletions, and each deleted line is reproduced verbatim in its replacement:

- The K1 criterion text is the **exact character-for-character prefix** of the new cell (verified programmatically), with the annotation appended after an em dash. The `1.10×` threshold is untouched.
- The clock page's superseded sentence is preserved verbatim inside `~~ ~~`.
- The section heading is deliberately **not** edited. Its "stop or narrow" remains the general rule and still governs K2–K7; the note says in terms that the supersession is K1-specific. Editing the heading would both erase and change an anchor.
- The `1.25×` ceiling is described as **proposed and inoperative until the 2026-08-27 sitting**, matching `k1-price-acceptance.md`'s own status line, and the note states explicitly that the published miss is not recoloured.

The verbatim freeze of the K1 row at `product/k1-price-acceptance.md:12` is untouched and remains accurate: it froze the criterion "as it stands at drafting", and the criterion has not moved — only an annotation was appended.

## Found and reported, not fixed

Outside the two-file fence, so left alone:

1. **`product/k1-price-acceptance.md` is now stale on the trigger half.** Its §2.2 ("The trigger half: undecided"), its §6 record row ("Trigger half: **undecided**, open operator ruling `rf2-sza0w`") and its §7.1 first reopen condition all describe the ruling this PR transcribes as still open. §7.1 says a ruling that K1 has tripped "changes what 'stop or narrow' asks of the programme, and the accepted price must be reconsidered in that light" — **this ruling fires that record's own reconsideration trigger.** Worth a follow-up bead before the 2026-08-25 packet freeze.
2. **The retired `> Reagent` K1 trigger is fully handled.** A sweep of every tracked page under `docs/design/hicasso/**` found only two occurrences, both already correct: clock page §8 (struck and annotated) and `validation.md`'s deliberate historical quote in the denominator-amendment note. No page asserts it live.
3. **`rf2-2rtt6.1` is cited as the live governance standard on roughly fifteen pages** (for example `studio/README.md:4`, `decisions.md:735`, `studio/cross-checked-against-an-outside-instrument.md:66`, and the per-page "The standard is `rf2-2rtt6.1`" / "Owner: the operator-owned standard bead" headers). `validation.md` is clean on this axis — its five citations are all dated provenance and none sits near the kill table. Within this PR's fence, `studio/the-candidates-clock.md:111` carries one such ownership header. It is left as-is deliberately: it is one instance of a uniform corpus-wide pattern, and re-pointing a single page would leave it inconsistent with the other fourteen. This wants one sweep bead using the pointer map in `rf2-2rtt6.1`'s notes, not a partial fix here. This PR cites `rf2-hic-003` directly and never routes through the closed bead.

## Quality gates

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |

Both run in the foreground to completion, redirected to worktree-local logs, never piped. The pins gate reported `2 files, 11 cited pins (9 landed, 1 stranded, 1 unresolvable)` and passed — no new hex token was introduced; `PR #7704` is a four-digit run, below the checker's seven-character floor, and already appears in three tracked pages. All dates are ISO.

**Sabotage control.** A green exit proves nothing about a file outside the checker's roster, so one anchor was broken in **each** of the two files. The checker returned **exit 1** naming both by path and line:

```text
BROKEN ANCHOR: docs\design\hicasso\studio\the-candidates-clock.md:1522 -> ../validation.md#kill-criteria-SABOTAGE-CANARY-NOT-A-REAL-ANCHOR
BROKEN ANCHOR: docs\design\hicasso\validation.md:681 -> studio/rows-re-adjudicated-on-the-corrected-clock.md#43-SABOTAGE-CANARY-NOT-A-REAL-ANCHOR
```

Both restored, canary residue grep empty, re-run **exit 0**.

**Counts, hand-verified.** The kill-criteria table is **2 columns on all 8 rows** (header, separator, K1, K2, K3, K4, K6, K7) — unchanged, and no `|` was introduced into any cell. Every anchor cited was computed against `pymdownx.slugs.slugify(case="lower")`, the exact function `mkdocs.yml` configures, before being written: `#43-the-published-m1-row`, `#8-what-this-hands-the-programme`, `#5-the-proposed-ceiling`, `#71-reopen-conditions`, and `#kill-criteria-any-tripping--stop-or-narrow-adapters-only-is-success` (note the double dash, from the elided `=`).

`mkdocs build --strict` is not applicable — `mkdocs.yml`'s `exclude_docs` keeps `docs/design/**` out of the site.
