### PR TITLE
fix(scripts): the provenance-pins gate scopes accompaniment to a table row (rf2-xlsh)

### DIFF
--- a/docs/design/hicasso/studio/the-in-page-mount-term-decomposed.md
+++ b/docs/design/hicasso/studio/the-in-page-mount-term-decomposed.md
@@ -116,7 +116,7 @@ measurement failure — see §5.
 | **Guard** | arm-order guard, tolerance 10%, by predecessor **and** by phase — **no refusal on any arm of any of the four runs** |
 | **Parity** | 14 of 15 arms canonical-DOM byte-identical to the candidate's page, all four runs; `ctl-2x` exempt by construction |
 | **Read-back** | harvest gate fatal unless the real page mounts 1,202 elements and resolves exactly 3 + 2 × 69 = 141 distinct reads — **passed on all four runs** |
-| **Windows** | announced on `rf2-409ab` before opening. Run A closed `2026-08-03 05:28:12 AUSEST`, runs B/C/D `05:29:17 – 05:32:13`. **Run A was taken from the working file that commit `b8e6da6681` then recorded unchanged**, so its blob is the producing commit's; B, C and D ran at the commit |
+| **Windows** | announced on `rf2-409ab` before opening. Run A closed `2026-08-03 05:28:12 AUSEST`, runs B/C/D `05:29:17 – 05:32:13`. **Run A was taken from the working file that commit `b8e6da6681` — landed on main as `4866dfa90c`, the row above — then recorded unchanged**, so its blob is the producing commit's; B, C and D ran at the commit |
 | **Quiet box** | **FAILED, and recorded rather than hidden** — see §8 |
 | **Exit codes** | four publication runs, **all exit `0`**; aggregator exit `0`; two deliberate mutations of the dataset each exit `1` (§7) |
 

--- a/scripts/check_provenance_pins.py
+++ b/scripts/check_provenance_pins.py
@@ -21,6 +21,20 @@ heads; what it may not do is leave the reader with no resolvable anchor at all.
 Concretely: within one block, if any cited pin is not an ancestor of
 `origin/main`, then some other pin in that same block must be.
 
+A TABLE ROW IS A BLOCK OF ITS OWN, because the paragraph-sized scope was a
+fail-open (rf2-xlsh).  A record table is one unbroken run of non-blank lines, so
+every row in it shared a single scope and any one landed hash answered for all
+of them — a wrong pin in the operative row went unreported as long as some other
+row cited something that had landed.  That is precisely backwards from where the
+risk lives: on a pre-registration page the hash that matters most is the one in
+the table, beside a landed one, so the guard was blind in the field whose
+wrongness costs most.  Accompaniment is therefore scoped to the row that makes
+the claim.  A row ends where the NEXT row begins and not at the newline, because
+this corpus wraps a long cell across source lines and the anchor rescuing a head
+is routinely on the continuation.  Prose is untouched — a paragraph remains one
+scope, which is what keeps the census's repaired "authored at X … it landed on
+main as Y" sentences passing.
+
 FAILURE DIRECTION — this gate fails toward REFUSAL, never toward silence, and
 one asymmetry forces it.  The stranded pins are precisely the objects a fresh
 clone does NOT have, so from inside any checkout "git has never heard of this
@@ -106,7 +120,8 @@ Usage:
     python scripts/check_provenance_pins.py --self-test [--verbose]
 
 Exit codes:
-    0  every cited pin is landed or shares its block with a landed one
+    0  every cited pin is landed or shares its block — its table row, when it
+       sits in one — with a landed one
     1  findings — a human decides each; this tool never re-pins
     2  the check could not run (absent corpus, unresolvable baseline, bad ref).
        Never 0: a gate that cannot run must not report success for work it
@@ -196,11 +211,18 @@ _UNFILLED_ANCHOR = re.compile(r"\(\s*filled on merge", re.I)
 
 _FENCE = re.compile(r"^\s*(?:```|~~~)")
 
+# The start of a table row, which is where one accompaniment scope ends and the
+# next begins.  Deliberately only the OPENING pipe: a continuation line carries
+# no pipe of its own, so it stays with the row it belongs to.
+_TABLE_ROW = re.compile(r"^\s*\|")
+
 
 class Citation(NamedTuple):
     path: str
     line: int
-    block: int
+    # The scope accompaniment is judged in: a paragraph, or a single table row.
+    # Not called `block` any more because a table is one block and many scopes.
+    scope: int
     token: str
     reason: str  # why it was read as a pin rather than a digest
 
@@ -365,10 +387,10 @@ def scan_file(
     citations: List[Citation] = []
     anchors: List[Finding] = []
     in_fence = False
-    block = 0
+    scope = 0
     for i, line in enumerate(lines):
         if not line.strip():
-            block += 1
+            scope += 1
             continue
         if _FENCE.match(line):
             in_fence = not in_fence
@@ -377,6 +399,12 @@ def scan_file(
             # Fenced blocks are reproduction commands.  Their SHAs are
             # arguments to an example, not the page's own provenance.
             continue
+        if _TABLE_ROW.match(_strip_quote(line)):
+            # A row makes its own claim, so it may accompany only itself
+            # (rf2-xlsh).  The scope opens here and runs to the next row rather
+            # than to the newline, because a wrapped cell continues on lines
+            # that open no pipe and the anchor is often down there.
+            scope += 1
         if _UNFILLED_ANCHOR.search(line):
             anchors.append(
                 Finding(
@@ -392,7 +420,7 @@ def scan_file(
             for token in _split_span(match.group(1), max_id_len):
                 verdict = classify(lines, i, match.start(), match.end())
                 if verdict.is_pin:
-                    citations.append(Citation(path, i + 1, block, token, verdict.reason))
+                    citations.append(Citation(path, i + 1, scope, token, verdict.reason))
         # Then the same line with its code spans blanked out, so a token cannot
         # be read twice, and with the default reading switched off.
         for match in _BARE_PROSE_HEX.finditer(_mask_code_spans(line)):
@@ -402,7 +430,7 @@ def scan_file(
             verdict = classify(lines, i, match.start(), match.end())
             if verdict.is_pin and verdict.spoken:
                 citations.append(
-                    Citation(path, i + 1, block, token, verdict.reason + ", uncoded")
+                    Citation(path, i + 1, scope, token, verdict.reason + ", uncoded")
                 )
     return citations, anchors
 
@@ -475,20 +503,26 @@ class Git:
 
 
 def evaluate(citations: Iterable[Citation], git: Git) -> List[Finding]:
-    """Apply the accompaniment rule, one block at a time.
+    """Apply the accompaniment rule, one scope at a time.
 
-    A block is a maximal run of consecutive non-blank lines, which makes a
-    markdown table one block and a prose paragraph one block — the two shapes
-    this corpus writes provenance in.  That is the scope in which a reader
-    actually finds the fallback: the census's repairs all put the landed SHA in
-    the same table cell or the same sentence as the head it rescues.
+    A scope is a prose paragraph, or a SINGLE TABLE ROW — not the whole table.
+    Those are the two shapes this corpus writes provenance in, and they are the
+    scope in which a reader actually finds the fallback: the census's repairs
+    all put the landed SHA in the same table cell or the same sentence as the
+    head it rescues, never merely somewhere in the same table.
+
+    Scoping the table by row is what closes rf2-xlsh.  A table is one unbroken
+    run of non-blank lines, so judging it whole let any single landed hash
+    answer for every row around it, and a wrong pin in the operative row went
+    unreported — on the pages this guards, that row is the one that matters
+    most.  A row accompanies itself and nothing else.
     """
-    per_block: Dict[Tuple[str, int], List[Citation]] = {}
+    per_scope: Dict[Tuple[str, int], List[Citation]] = {}
     for c in citations:
-        per_block.setdefault((c.path, c.block), []).append(c)
+        per_scope.setdefault((c.path, c.scope), []).append(c)
 
     findings: List[Finding] = []
-    for (_path, _block), group in sorted(per_block.items()):
+    for (_path, _scope), group in sorted(per_scope.items()):
         statuses = {c.token: git.status(c.token) for c in group}
         landed = sorted({t for t, s in statuses.items() if s == "LANDED"})
         if landed:
@@ -608,13 +642,15 @@ def check(
         if verbose:
             stream.write(
                 "check_provenance_pins: every cited pin is an ancestor of %s or "
-                "shares its block with one.\n" % BASELINE_REF
+                "shares its block — its table row, when it sits in one — with "
+                "one.\n" % BASELINE_REF
             )
         return 0
 
     stream.write(
         "\ncheck_provenance_pins: %d finding(s). Every cited authored head must "
-        "be accompanied, in its own block, by a SHA that is an ancestor of %s.\n"
+        "be accompanied, in its own block — its own table ROW, when it sits in "
+        "a table — by a SHA that is an ancestor of %s.\n"
         "This tool does NOT re-pin: recovering the landed SHA restores the patch "
         "and not necessarily the measured tree, so a human decides each one "
         "(see rf2-owq6p).\n\n" % (len(findings), BASELINE_REF)
@@ -830,6 +866,44 @@ _RULE_CASES: List[Tuple[str, List[str], Dict[str, str], List[str]]] = [
     (
         "a bare landed id accompanies the stranded head beside it",
         ["Authored at aaaaaaaaaa on worker/x; it landed on main as bbbbbbbbbb."],
+        {"aaaaaaaaaa": "STRANDED", "bbbbbbbbbb": "LANDED"},
+        [],
+    ),
+    # THE ROW SCOPE (rf2-xlsh).  The first case is the fail-open itself: a
+    # record table cited the operative pin in one row and a landed hash in
+    # another, and per-paragraph accompaniment let the neighbour answer for it,
+    # so a wrong hash in the field whose wrongness costs most went unreported.
+    (
+        "a landed hash in a SIBLING ROW does not rescue the row beside it",
+        [
+            "| Original freeze | `bbbbbbbbbb`, registering all seven criteria |",
+            "| Pre-registration commit | `aaaaaaaaaa` — this is the hash to cite |",
+        ],
+        {"aaaaaaaaaa": "STRANDED", "bbbbbbbbbb": "LANDED"},
+        ["aaaaaaaaaa"],
+    ),
+    # The counterweight, and the reason a row is not simply one line: this
+    # corpus wraps a long cell across source lines, and the anchor that rescues
+    # the head is routinely on the continuation.  `aaaa` is accompanied from the
+    # second line of its OWN row; `cccc`, a row down, is not.
+    (
+        "a cell wrapped across source lines is still one row",
+        [
+            "| Producing commit | `aaaaaaaaaa` on `worker/x` — authored, and",
+            "rebase-merged. It landed on main as **`bbbbbbbbbb`**. |",
+            "| Orphan row | `cccccccccc` |",
+        ],
+        {"aaaaaaaaaa": "STRANDED", "bbbbbbbbbb": "LANDED", "cccccccccc": "STRANDED"},
+        ["cccccccccc"],
+    ),
+    # Prose is untouched by the row scope — the shape the census's repairs put
+    # the anchor in, which must keep passing.
+    (
+        "a paragraph is still one scope after the table split",
+        [
+            "Authored at `aaaaaaaaaa` on `worker/x`, before the rebase; the",
+            "same patch landed on main as `bbbbbbbbbb`.",
+        ],
         {"aaaaaaaaaa": "STRANDED", "bbbbbbbbbb": "LANDED"},
         [],
     ),


### PR DESCRIPTION
Closes rf2-xlsh.

## The mechanism, before and after

**Before.** Accompaniment was judged per BLOCK, where a block is a maximal run of consecutive non-blank lines. A markdown table is one such run, so every row of a record table shared a single scope, and any one landed hash answered for all of them. A cited pin that is not an ancestor of `origin/main` therefore went unreported whenever a landed hash happened to sit in a neighbouring row.

That is backwards from where the risk lives. On a pre-registration page the hash that matters most is the one in the table, beside a landed one — so the guard was blind in exactly the field whose wrongness costs most. It caught the same bad hash only where it also appeared alone in prose.

**After.** A table row is its own accompaniment scope; a row accompanies only itself. A row ends where the next row begins rather than at the newline, because this corpus wraps a long cell across source lines and the anchor rescuing a head is routinely on the continuation. Prose is untouched — a paragraph remains one scope, which is what keeps the census's repaired "authored at X … it landed on main as Y" sentences passing.

`Citation.block` becomes `Citation.scope`: a table is one block and many scopes, so the old name would now be a lie.

### Why this shape, and not the one first ruled

The first ruling was option (b) — keep per-block accompaniment, additionally flag any token that resolves to no commit at all. Measurement showed (b) is the wrong shape, and the ruling was revised to (c). Recorded here so the reasoning is not lost.

"Resolves to no commit" is a property of the local object store, not of the citation. Same corpus, same 346 citations:

| checkout | landed | stranded | unresolvable |
|---|---|---|---|
| local dev (PR heads fetched over time) | 238 | 100 | 8 |
| fresh clone, main only | 238 | 0 | 108 |
| fresh clone + all branches + tags (exact `fetch-depth: 0` CI shape) | 238 | 0 | 108 |

STRANDED is empty in CI, because a commit that is not an ancestor of main is not reachable from main and merged worker branches are deleted. Consequences, all measured in the CI-shaped clone:

- **(b) degenerates into (a) in CI.** Today 18 findings / 10 pages; (b) → 108 / 28; (a) → 108 / 28 — identical. (b) was chosen expressly to avoid (a)'s noise, and its stated justification ("adds no false positives on pages that deliberately cite historical or superseded commits") inverts: in CI those historical citations *are* the unresolvable tokens.
- **(b) does not catch the bead's own probe in a dev checkout.** Prototyped correctly, the reproduction still exited 0 — the probe resolves locally, so it stays STRANDED and stays shielded.
- **(b) widens the existing false-positive class.** Both prior refusals (`20260807`, `abc1234`) are unresolvable tokens; (b) would report them additionally whenever a landed hash shares their block.

(c) costs 23 findings / 13 pages against today's 18 / 10, and "is an ancestor of `origin/main`" is checkout-invariant, so its verdict does not depend on what happens to be fetched.

Option (d) — require that a token the writer *calls* landed actually be an ancestor, leaving "authored at X on worker/y" alone — was weighed and rejected as more machinery for the same outcome: it needs new `_COMMIT_WORDS` vocabulary. It is recorded on the bead.

## The four proofs

### 1. Reproduce the fail-open on the current code

`92cd524aeeb0132f51f8e3376e313d7819f8813c` (a PR head; `merge-base --is-ancestor` against `origin/main` exits 1) substituted for the operative `afbb58febc` at line 19 of `docs/design/hicasso/product/resource-demand-criteria.md` — the `| Pre-registration commit | … this is the hash to cite |` row, shielded by the landed `c8b8de6d28` one row above. Gate at `origin/main`:

```
PROOF1_OLD_EXIT=0
check_provenance_pins: 2 files, 11 cited pins (8 landed, 3 stranded, 0 unresolvable)
check_provenance_pins: every cited pin is an ancestor of origin/main or shares its block with one.
```

Exit 0. A wrong hash in the operative field passes.

### 2. The fix catches it

Same substitution, this branch:

```
PROOF2_NEW_EXIT=1
check_provenance_pins: 2 files, 11 cited pins (8 landed, 3 stranded, 0 unresolvable)

check_provenance_pins: 1 finding(s). Every cited authored head must be accompanied, in its own block — its own table ROW, when it sits in a table — by a SHA that is an ancestor of origin/main.
This tool does NOT re-pin: recovering the landed SHA restores the patch and not necessarily the measured tree, so a human decides each one (see rf2-owq6p).

  docs/design/hicasso/product/resource-demand-criteria.md:19  92cd524aeeb0132f51f8e3376e313d7819f8813c [STRANDED]
      authored head — resolves here but is an ancestor of no remote ref, so it is absent from a fresh clone
```

### 3. No regression

Blocking gate over this PR's actual diff, probe reverted:

```
PROOF3_CHANGED_SINCE_EXIT=0
check_provenance_pins: 1 files, 6 cited pins (4 landed, 2 stranded, 0 unresolvable)
check_provenance_pins: every cited pin is an ancestor of origin/main or shares its block — its table row, when it sits in one — with one.
```

Full-corpus audit, old code versus new on the same tree: 18 findings → 23. **No finding reported before this change goes unreported after it** — the set difference in that direction is empty. The five newly reported are the measured cost of the row scope and are itemised below.

### 4. The existing refusals still fire

The two false-positive shapes that cost fix-worker round trips — an unseparated digit run beside a commit word, and a placeholder — under the new code:

```
PROOF4_NEW_EXIT=1
  docs/design/hicasso/studio/zz-probe-refusal.md:3  20260807 [UNRESOLVABLE]
      … (commit word 'Authored' nearest on the left, uncoded)
  docs/design/hicasso/studio/zz-probe-refusal.md:5  abc1234 [UNRESOLVABLE]
      … (commit word 'commit' nearest on the left)
```

Fail-toward-refusal posture intact. No ignore or exception mechanism was added, and no reported token became unreported.

## The five newly exposed findings

One repaired, three surfaced for a human, one blocked by an in-flight PR.

**REPAIRED — `studio/the-in-page-mount-term-decomposed.md:119`, `b8e6da6681` (STRANDED).** Row 108 of the same table already asserts and patch-id-verifies the pairing: the producing commit "landed on main as `4866dfa90c` (same patch — identical `git patch-id --stable`)". `4866dfa90c` is an ancestor of `origin/main`. Naming it in the row that cites the head is the census's own repair and invents nothing. The page is now clean.

**SURFACED, needs a human — `studio/cross-checked-against-an-outside-instrument.md`, three findings.** Not edited, because one of the three cannot be repaired without a ruling and a partial edit would red this PR's own gate.

- `:541` `19a3710bc9604684ddbc7b2b72ec901dcc0f0ea7` (STRANDED) and `3680992949a6eec842ba033ae50f3a9a34af7884` (STRANDED). Repairable in principle: row 540 already asserts, and says it verified by identical `git patch-id --stable`, that `f6cb3584fb` (LANDED) is what `19a3710bc9…` became. Naming it in row 541 would be the same mechanical repair as above.
- `:544` `247fafa22c1f2caeb4cad179aa64cf444398cbc7` (UNRESOLVABLE). **Not a citation defect and not repairable.** The row cites a commit in `krausest/js-framework-benchmark`, and says so itself: "That SHA belongs to the benchmark's repository, not to this one, so it resolves there and nowhere else." No SHA of this repository belongs in that row. The gate reads "at commit `X`" and classifies it as a local pin, which it cannot know is false. A ruling is needed on whether the checker should learn a foreign-repository context, or the page be annotated some other way. Repairing `:541` alone would leave this one live, so the page is left untouched.

**BLOCKED — `studio/the-candidates-clock.md:1389`, `fdff3fd48855e86b34ec88b5ebc07f62903a6c0a` (STRANDED).** This is the file PR #7733 (rf2-sza0w) is editing. There is no `docs/design/hicasso/the-candidates-clock.md`; `studio/` is the only one, and #7733's changed-file list confirms it. Left untouched, to be sequenced after #7733 merges.

None of the three blocks this PR: the blocking gate is `--changed-since`, and this PR does not touch those pages. They become live for whoever next edits them.

## No probe residue

```
 .../studio/the-in-page-mount-term-decomposed.md    |   2 +-
 scripts/check_provenance_pins.py                   | 110 +++++++++++++++++----
 2 files changed, 93 insertions(+), 19 deletions(-)
```

Every probe reverted; `git status --porcelain` is empty apart from these two tracked files. The scratch clone used for the CI-shape measurement, the temporary copy of the old checker, and the refusal probe page were all deleted.

## Quality gates

| Gate | Exit |
|---|---|
| `python scripts/check_provenance_pins.py --self-test --verbose` | **0** — all 36 passed (33 pre-existing + 3 new) |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |
| `python scripts/check_doc_slugs.py` | **0** |
| `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine` |

`scripts/test-fast-pr.sh` does cover this script — lines 1191-1205 run both the self-test and the changed-pages gate — so it was run in full rather than relied on from CI. `mkdocs build --strict` is not the gate for this change: `mkdocs.yml`'s `exclude_docs` keeps `docs/design/**` out of the site. `check_doc_slugs.py`, which does validate that tree's link targets and heading anchors, is green. The one documentation edit adds no link and no heading and changes no table column count — it inserts a clause inside an existing cell of an existing row.

Three self-test cases pin the new behaviour: a landed hash in a sibling row does not rescue the row beside it; a cell wrapped across source lines is still one row; and a paragraph is still one scope after the table split.
