### PR TITLE
feat(hicasso): the Reagent [:>] codemod fixer (rf2-2rtt6.143)

### DIFF
--- a/migration/reagent-to-hicasso/codemod/README.md
+++ b/migration/reagent-to-hicasso/codemod/README.md
@@ -1,0 +1,194 @@
+# The Reagent `[:>]` → Hicasso migration codemod (the fixer)
+
+A source-text tool that reads a consumer's Reagent `.cljs` namespaces and repairs
+the props dialect at every foreign crossing, so that a codebase whose `[:> …]`
+sites are about to be interpreted by Hicasso **keeps behaving the way Reagent
+made it behave**.
+
+It mints no declaration, hoists nothing, and edits no `ns` form. It writes whole
+files through [rewrite-clj](https://github.com/clj-commons/rewrite-clj) — a
+zipper over the node tree, so formatting and comments survive — skips any file
+it cannot parse, and emits a report.
+
+The design is `docs/design/hicasso/studio/reagent-codemod-against-the-landed-escape.md`,
+ratified as `rf2-2rtt6.106`. This artefact implements it as amended by
+`rf2-2rtt6.143`.
+
+## Running it
+
+```bash
+cd migration/reagent-to-hicasso/codemod
+
+clojure -M:run src/                            # scan: report only, touch nothing
+clojure -M:run --rewrite src/                  # dry run: what would change
+clojure -M:run --rewrite --write src/          # apply it
+clojure -M:run --report out.edn src/           # choose where the report goes
+```
+
+The exit code is `0` for any run that completed and `1` only when a file could
+not be read or written. **A migration tool that fails a build because a
+consumer's code needs a human decision is a tool that gets run once.**
+
+## The two laws
+
+**Law 1 — decidability.** A rewrite fires only where the donor's answer and the
+destination's answer are both computable from the source text, and they differ.
+
+**Law 2 — no blanking.** No rewrite introduces a function whose return value
+differs from the value the donor's conversion produced.
+
+A corollary of Law 1 does most of the work: **a prop's spelling may only ever
+make the tool do less.** Where a name-shaped test says "yes", the answer is
+always *skip this rewrite* or *refuse this site* — never *apply this rewrite*.
+That is what keeps the tool away from the failure that killed an earlier design:
+Fluent's `onRender*` family and Ant's `onRow` are event-*spelled* render props,
+so a tool that reads an `on*` name as "this is an event position" and wraps the
+value blanks them silently. Here an event-spelled name can only ever make the
+tool more conservative.
+
+**Silent behaviour change is the only fatal class.** `[:>]` is legal in Hicasso,
+so *leave it as `[:>]`* is a valid output for any site the rewrite cannot make
+behaviour-preserving. A refused site still works; the report is what turns a
+refusal from silence into an instruction.
+
+## What it rewrites
+
+| Id | Matches | Writes | Preserves |
+|---|---|---|---|
+| W1 | `^{:key k}` metadata on a `[:> …]` vector | `:key k` in the props map, minting the map if absent | Reagent's live key; without it the key is inert |
+| W2 | a literal map value, reached from the props map through map values only | the same map with each literal key respelled by Reagent's `cached-prop-name` rule | Reagent's deep camelCasing |
+| W3 | a literal keyword, or a **quoted** symbol, at a prop value | its `name` as a string | Reagent's `(named? x) (name x)` arm |
+| W4 | a literal `(r/partial f a …)` at a prop value | a hygienic `let` capturing the callee and every non-literal argument once, then Reagent's own wrapper | Reagent's `ifn?` wrapper, return and **evaluation time** alike |
+| W5 | `[(r/adapt-react-class X) props & kids]` in head position | `[:> X props & kids]` | Reagent's `NativeWrapper` path is the same `native-element` |
+| W6 | `[:> "tag" props & kids]` with a plain tag string | `[:tag props & kids]` | Reagent's `input-component?` wrapper becomes Hicasso's controlled door |
+
+*(4 columns; 6 body rows.)*
+
+**A bare symbol is never a named value.** `handler` in `{:on-click handler}` is a
+*variable reference*, not a symbol value, and reading it as one would replace a
+live handler with the string `"handler"`. Only a keyword literal and a quoted
+symbol reach W3. Everything arriving through a symbol is invisible to a source
+reader and is reported as `:computed-value`.
+
+**Every output is outside its own rewrite's input language**, so a second run is
+a no-op by construction, and the corpus asserts that byte for byte.
+
+## What it refuses
+
+Refusals are the design's load-bearing half, not its residue. They fall into
+three kinds, and the kind tells you how urgent the line is.
+
+**Undecidable from the source text** — `:computed-props`, `:computed-value`,
+`:computed-nested-key`, `:adapt-def-site`, `:cljc-site`, `:parse-error`.
+
+**Decidable, but the rewrite would itself change behaviour** —
+`:event-carrier-goes-live`, `:key-conflict`, `:string-tag-unparseable`,
+`:normalized-key-collision`, `:css-var-repair`, `:named-ref`, `:amp-key`.
+
+**Decidable, and the destination refuses at runtime** — these are the migration
+blockers, and the site needs a person rather than a rewrite:
+`:intent-needs-a-declaration`, `:dangerous-html`, `:r>-site`, `:f>-site`,
+`:as-element-island`, `:reagent-api-residue`.
+
+## The report
+
+One EDN file, deterministic ordering, written on every run including a clean
+one. It is exhaustive over the sites it touched or refused and carries a count
+of the sites left alone, so "not in the report" is never ambiguous. Every entry
+carries the source form with file, line and column — addressed against the
+**input** file, so a scan and a rewrite of the same tree report the same
+coordinates — and every refusal names the fix in a sentence a person can act on.
+
+It also carries the component name, and **it is the only thing in the system
+that can**: a `[:>]` refusal at runtime prints the constant `"[:>]"` beside an
+empty declared set, because the escape has no name of its own. The report read
+the head.
+
+The suggestions block is labelled as guesses, and its header carries the
+Fluent/Ant counter-example. The tool never synthesizes a `:callbacks` map and
+there is no flag to make it.
+
+## The three amendments
+
+`rf2-2rtt6.143` ratified three corrections to the landed design, and this
+artefact implements the design **as amended**.
+
+**(A) W4 captures at prop-evaluation time.** The design's stated rewrite,
+`(fn [& args] (apply f a … args))`, re-evaluates the callee and every argument
+on *each* callback invocation; Reagent's `make-partial-fn` evaluated them once,
+at construction. So `(r/partial f @snapshot)` stopped being a snapshot and
+`(r/partial f (next-id!))` started minting an id per click. What is written
+instead is a hygienic `let`:
+
+```clojure
+[:> Btn {:on-pick (r/partial handler @cart)}]
+;; =>
+[:> Btn {:on-pick (let [f__rf2 handler a0__rf2 @cart]
+                    (fn [& args__rf2] (apply f__rf2 a0__rf2 args__rf2)))}]
+```
+
+Self-evaluating arguments are inlined rather than bound; symbols are bound,
+because re-reading a var per invocation picks up a redefinition the donor's
+captured value never saw.
+
+**(B) W2 refuses normalized-key collisions.** Reagent's `kv-conv` writes each
+nested-map key under `cached-prop-name`, so `:foo-bar`/`:fooBar`,
+`:class`/`:className` and `:foo-bar`/`"fooBar"` siblings each collapse onto one
+JS property with an iteration-order winner. Respelling both would mint a
+duplicate literal map key or pick a winner the rewrite cannot know. The whole
+map is refused and every colliding source key is named.
+
+**(C) The key slot carries a dedicated report entry.** Excluding `:key` from W3
+is ratified — `:foo` and `"foo"` sibling keys collided under Reagent and are
+distinct under Hicasso, so rewriting would restore a defect. But the cost of
+*not* rewriting is understated as "one remount": React reconciles a changed key
+by unmounting the subtree and mounting a fresh one, **discarding its state**.
+Every key-slot site says so.
+
+## Testing
+
+```bash
+cd migration/reagent-to-hicasso/codemod && clojure -M:test
+```
+
+**The golden-file corpus is the spec.** Each directory under `test/corpus/`
+holds an input namespace, the expected output and the expected report, and every
+case asserts the rewrite byte for byte, the report including its full `:note`
+prose, idempotence, and determinism. Set `RF2_CODEMOD_REGEN=1` to author a new
+case; regenerating is never how one is fixed.
+
+Two suites sit beside it. `amendment_a_test.clj` **executes** W4's output —
+plain `let`/`fn`/`apply`, with no Reagent left in it — and asserts the capture
+semantics directly, running the design's stated shape alongside to show the
+amendment is load-bearing. `shared_rule_test.clj` asserts that the slot rule
+this tool asks is the shared one and not a copy.
+
+## One dependency, deliberately
+
+The tool is otherwise self-contained — it never loads, requires or executes
+re-frame2, so it runs against any Reagent corpus on a bare JVM. The exception is
+`re-frame.bench.hicasso.front.slot`, the `.cljc` carrying the canonical slot
+rule, which is on `:paths`.
+
+That is the whole point of it. The design's own adversarial pass raised "the
+tool reimplements `prop-name`, and nothing pins the two together" and left it
+**unrepaired**: a corpus pins the tool, a DOM suite pins the runtime, and
+nothing pins them equal, with the drift silent in both directions. Extracting
+the rule to one shared file was the only structural answer, and `rf2-ani6y` took
+it. Transcribing it back in here to "remove a dependency" would reproduce, inside
+the tool, the exact defect the tool exists to delete — so a test asserts the rule
+came out of the shared file.
+
+Reagent's *own* key function is a second rule and does live here, in
+`donor.clj` — but written as the shared rule plus its two named deltas (a string
+key is verbatim under the donor; a `--custom-property` is mangled), never as a
+second copy of the camel algorithm.
+
+## Scope
+
+**The hoist is not here.** The declare-what-you-use-twice `defhost` hoist with
+dedupe is demand-gated by the same ratification: it gets built when a real
+migrator reports the manual declarations as the pain.
+
+This is not a general Reagent migrator. It looks at `[:>]` sites and nothing
+else.

--- a/migration/reagent-to-hicasso/codemod/deps.edn
+++ b/migration/reagent-to-hicasso/codemod/deps.edn
@@ -1,0 +1,59 @@
+;; The Reagent `[:>]` → Hicasso migration codemod, FIXER half (rf2-2rtt6.143).
+;;
+;; Designed at
+;;   docs/design/hicasso/studio/reagent-codemod-against-the-landed-escape.md
+;; and built as amended by rf2-2rtt6.143's three ratified acceptance criteria
+;; (W4 captures at prop-evaluation time; W2 refuses normalized-key collisions;
+;; the key slot gets a dedicated report entry).
+;;
+;; Residence and skeleton are cloned from `migration/from-re-frame-v1/codemod/`
+;; per the design's §1 — a standalone JVM artefact that reads consumer SOURCE
+;; TEXT through rewrite-clj and never loads, requires or executes re-frame2.
+;; That keeps it runnable against any Reagent corpus on a bare JVM.
+;;
+;; Programmatic entry points:
+;;   (re-frame.migration.hicasso.codemod/scan-paths   paths)      -> [entry ...]
+;;   (re-frame.migration.hicasso.codemod/rewrite-string s opts)   -> {:source .. :entries ..}
+;;   (re-frame.migration.hicasso.codemod/rewrite-file! path opts) -> {:changed? .. :entries ..}
+{:paths
+ ["src"
+
+  ;; THE ONE EXCEPTION TO "never loads re-frame2", AND IT IS THE WHOLE POINT
+  ;; OF rf2-ani6y.
+  ;;
+  ;; The design's §9.5 charge — "the tool reimplements `prop-name`, and nothing
+  ;; pins the two together" — survived its own adversarial pass UNREPAIRED, and
+  ;; §10.2's third recommendation was the only structural answer: extract the
+  ;; slot rule to `.cljc` so the tool and the door share ONE implementation.
+  ;; rf2-ani6y did exactly that. `front/slot.cljc` names this codemod, by name,
+  ;; as its second consumer.
+  ;;
+  ;; So this path is not a convenience. Dropping it and transcribing
+  ;; `prop-name` into `src/` would re-open §10.3's open question — a corpus
+  ;; pinning the tool, a DOM suite pinning the runtime, and nothing pinning
+  ;; them equal, with the drift silent in both directions. The namespace
+  ;; requires nothing but `clojure.string`, so the JVM cost is one small pure
+  ;; file; `slot_pin_test.clj` asserts we are loading THAT file and not a copy.
+  ;;
+  ;; Note the direction: the bundle-isolation law forbids `implementation/`
+  ;; requiring from `tools/`. This is a `migration/` artefact reading a shared
+  ;; `.cljc` rule out of `implementation/`, which is the direction the rule was
+  ;; extracted to serve.
+  "../../../implementation/freehand/test"]
+
+ :deps {org.clojure/clojure       {:mvn/version "1.12.4"}
+        rewrite-clj/rewrite-clj   {:mvn/version "1.1.49"}}
+
+ :aliases
+ {;; `clojure -M:test` — the golden-file corpus (which IS the spec, per the
+  ;; design's §5), the executable amendment-A semantics pin, and the shared
+  ;; slot-rule pin. Plain cognitect test-runner, matching the sibling
+  ;; artefact, so the test JVM never pulls the implementation build.
+  :test {:extra-paths ["test"]
+         :extra-deps  {io.github.cognitect-labs/test-runner
+                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+         :main-opts   ["-m" "cognitect.test-runner"]}
+
+  ;; `clojure -M:run <path> ...`            — scan, write the report, touch nothing.
+  ;; `clojure -M:run --rewrite <path> ...`  — apply the fixer.
+  :run {:main-opts ["-m" "re-frame.migration.hicasso.codemod"]}}}

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/codemod.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/codemod.clj
@@ -1,0 +1,302 @@
+(ns re-frame.migration.hicasso.codemod
+  "The Reagent `[:>]` → Hicasso migration codemod — the FIXER.
+
+  A source-text tool that reads a consumer's Reagent `.cljs` namespaces and
+  repairs the props dialect at every foreign crossing, so that a codebase
+  whose `[:> …]` sites are about to be interpreted by Hicasso keeps
+  behaving the way Reagent made it behave. It mints no declaration, hoists
+  nothing, and edits no `ns` form. It writes whole files through
+  rewrite-clj, skips any file it cannot parse, and emits a report.
+
+  Designed at
+  `docs/design/hicasso/studio/reagent-codemod-against-the-landed-escape.md`
+  and built as amended by rf2-2rtt6.143. The HOIST — the
+  declare-what-you-use-twice `defhost` hoist with dedupe — is DEMAND-GATED
+  by the same ratification and is deliberately absent.
+
+  ## Two passes over one plan
+
+  The report addresses the INPUT file, so its line and column numbers are
+  the ones a migrator greps for whether they ran a scan or a rewrite. That
+  rules out reading positions off a tree being edited underneath us, so
+  there are two passes:
+
+  * [[analyse]] walks a POSITION-TRACKED zipper over the pristine tree and
+    never edits, so every coordinate it reports is exact.
+  * [[transform]] walks the same pristine tree as pure NODES, bottom-up
+    inside each site, and never asks for a position.
+
+  Both call [[rewrite/plan-site]] on the same nodes with the same context.
+  There is one implementation of every decision and two consumers of it,
+  which is the same discipline `front/slot.cljc` applies to the slot rule
+  one level down."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [re-frame.migration.hicasso.report :as report]
+            [re-frame.migration.hicasso.rewrite :as rw]
+            [rewrite-clj.node :as n]
+            [rewrite-clj.parser :as p]
+            [rewrite-clj.zip :as z])
+  (:gen-class))
+
+;; ---------------------------------------------------------------------------
+;; `:adapt-def-site` (§4.5) — the one class that is about a whole file
+;; ---------------------------------------------------------------------------
+
+(defn- adapt-def?
+  "Is this node `(def Foo (r/adapt-react-class X))`?"
+  [nd ctx]
+  (and (rw/list-node? nd)
+       (= 'def (rw/sexpr-safe (rw/element-at nd 0)))
+       (symbol? (rw/sexpr-safe (rw/element-at nd 1)))
+       (some-> (rw/element-at nd 2) (rw/reagent-call? 'adapt-react-class ctx))))
+
+(defn- hiccup-head-symbol
+  "The head of `[Foo …]` when it is a bare symbol — a call site of a
+  `def`ed adapted class, if that symbol names one."
+  [nd]
+  (when (= :vector (n/tag nd))
+    (let [h (rw/element-at nd 0)]
+      (when (and h (= :token (n/tag h)))
+        (let [s (rw/sexpr-safe h)] (when (symbol? s) s))))))
+
+(defn- adapt-def-entry
+  "`(def Foo (r/adapt-react-class X))` cannot be rewritten by a fixer:
+  rewriting the def changes every call site's conversion regime at once,
+  including call sites in other namespaces this tool may never have been
+  pointed at. The report names the def and the same-file call sites it
+  found, and says plainly that the cross-namespace ones are invisible."
+  [{:keys [sym line col form file]} call-sites]
+  (let [here (sort (get call-sites sym))]
+    {:class  :adapt-def-site
+     :action :refused
+     :file   file
+     :line   line
+     :col    col
+     :form   form
+     :head   (str sym)
+     :detail {:def (str sym) :call-sites-in-this-file (vec here)}
+     :note   (str "`(def " sym " (r/adapt-react-class …))` is left alone, and W5 cannot take it. "
+                  "Rewriting the def would change the conversion regime of EVERY call site at "
+                  "once, and this run found " (count here) " in this file"
+                  (when (seq here) (str " (line" (when (> (count here) 1) "s") " "
+                                        (str/join ", " here) ")"))
+                  ". CALL SITES IN OTHER NAMESPACES ARE INVISIBLE TO THIS TOOL — it only saw the "
+                  "files it was pointed at. Either convert it by hand, or inline the "
+                  "`adapt-react-class` at each call site and re-run so W5 can take them "
+                  "individually.")}))
+
+;; ---------------------------------------------------------------------------
+;; Pass 1 — analyse
+;; ---------------------------------------------------------------------------
+
+(defn- meta-keys-above
+  "The enclosing `^{:key …}` chain, read upward. [[transform]] reads the
+  same chain downward; a chain is order-free for the one thing the plan
+  asks of it (how many keys, and which node)."
+  [loc]
+  (loop [ks [], l loc]
+    (let [p (z/up l)]
+      (if (and p (= :meta (z/tag p)))
+        (recur (if-let [k (rw/meta-key-node (z/node p))] (conj ks k) ks) p)
+        ks))))
+
+(defn analyse
+  "Walk the pristine tree, planning every site and stamping each entry
+  with the file, line, column and source form. Returns
+  `{:entries [...] :suggestions [...] :sites n :left-alone n}`."
+  [source {:keys [file] :as ctx}]
+  (loop [loc      (z/of-string source {:track-position? true})
+         entries  []
+         suggests []
+         defs     []          ; (def Foo (r/adapt-react-class …)) sites
+         calls    {}          ; symbol -> [line …], the same-file call sites
+         sites    0
+         quiet    0]
+    (if (z/end? loc)
+      {:entries    (into entries (map #(adapt-def-entry % calls)) defs)
+       :suggestions suggests
+       :sites      sites
+       :left-alone quiet}
+      (let [nd         (z/node loc)
+            [line col] (z/position loc)
+            form       (fn [] (let [s (z/string loc)]
+                                (if (> (count s) 200) (str (subs s 0 200) " …") s)))
+            kind       (rw/site-kind nd ctx)
+            calls      (if-let [s (hiccup-head-symbol nd)]
+                         (update calls s (fnil conj []) line)
+                         calls)
+            defs       (if (adapt-def? nd ctx)
+                         (conj defs {:sym  (rw/sexpr-safe (rw/element-at nd 1))
+                                     :line line :col col :form (form) :file file})
+                         defs)]
+        (if-not kind
+          (recur (z/next loc) entries suggests defs calls sites quiet)
+          (let [plan (rw/plan-site nd (assoc ctx :meta-keys (meta-keys-above loc)))
+                es   (mapv #(assoc % :file file :line line :col col
+                                   :form (form) :head (:head plan))
+                           (:entries plan))]
+            (recur (z/next loc)
+                   (into entries es)
+                   (cond-> suggests (:suggest plan) (conj (:suggest plan)))
+                   defs calls
+                   (inc sites)
+                   (cond-> quiet (empty? es) inc))))))))
+
+;; ---------------------------------------------------------------------------
+;; Pass 2 — transform
+;; ---------------------------------------------------------------------------
+
+(declare rw-node)
+
+(defn- rw-children [nd ctx]
+  (if (n/inner? nd)
+    (n/replace-children nd (mapv #(rw-node % ctx) (n/children nd)))
+    nd))
+
+(defn- rw-node
+  "Rewrite one node. A site's own plan is applied AFTER its children have
+  been rewritten — so a nested `[:>]` inside a prop value or a child slot
+  is repaired too — but the plan itself is computed from the pristine
+  node, so the report pass and this pass cannot reach different decisions."
+  [nd ctx]
+  (cond
+    (rw/meta-node? nd)
+    (let [[metas inner] (rw/unwrap-metas nd)
+          plan   (rw/plan-site inner (assoc ctx :meta-keys (rw/meta-key-nodes metas)))
+          inner' ((:edit plan) (rw-children inner ctx))]
+      (rw/rebuild-meta-chain nd inner' (boolean (:w1? plan))))
+
+    (rw/site-kind nd ctx)
+    (let [plan (rw/plan-site nd (assoc ctx :meta-keys []))]
+      ((:edit plan) (rw-children nd ctx)))
+
+    :else (rw-children nd ctx)))
+
+(defn transform
+  "Apply the fixer to a source string. Returns the rewritten text."
+  [source ctx]
+  (n/string (rw-node (p/parse-string-all source) ctx)))
+
+;; ---------------------------------------------------------------------------
+;; Public API
+;; ---------------------------------------------------------------------------
+
+(defn- file-context
+  "The per-file context: the Reagent aliases this file's `ns` form binds,
+  and whether the file is `.cljc` (a `[:>]` there is `.cljs`-only at that
+  node, which is `:cljc-site`)."
+  [source file]
+  (let [root (p/parse-string-all source)]
+    (assoc (rw/ns-context root)
+           :file  (some-> file str)
+           :cljc? (boolean (some-> file str (str/ends-with? ".cljc"))))))
+
+(defn scan-string
+  "Analyse a source string. Never edits. Returns the analysis map."
+  ([s] (scan-string s nil))
+  ([s file] (analyse s (file-context s file))))
+
+(defn rewrite-string
+  "Apply the fixer to a source string. Returns
+  `{:source <new-source> :entries [...] :suggestions [...] :sites n :left-alone n}`.
+  The source is unchanged for every site the tool refused."
+  ([s] (rewrite-string s nil))
+  ([s file]
+   (let [ctx (file-context s file)]
+     (assoc (scan-string s file) :source (transform s ctx)))))
+
+(defn- source-file? [^java.io.File f]
+  (and (.isFile f)
+       (let [nm (.getName f)]
+         (or (str/ends-with? nm ".cljs") (str/ends-with? nm ".cljc")))))
+
+(defn- expand-paths [paths]
+  (->> paths
+       (mapcat (fn [p]
+                 (let [f (io/file p)]
+                   (cond (.isDirectory f) (filter source-file? (file-seq f))
+                         (.isFile f)      [f]
+                         :else            []))))
+       distinct
+       (sort-by str)))
+
+(defn- run-file
+  "Analyse (and optionally rewrite) one file, converting any reader failure
+  into a `:parse-error` entry rather than an exception — the design's
+  rule is that the tool skips a file it cannot parse and says so."
+  [f {:keys [rewrite? write?]}]
+  (let [path (str f)]
+    (try
+      (let [orig (slurp f)
+            r    (if rewrite? (rewrite-string orig path) (scan-string orig path))
+            changed? (and rewrite? (not= orig (:source r)))]
+        (when (and write? changed?) (spit f (:source r)))
+        (assoc r :path path :changed? (boolean changed?)))
+      (catch Exception e
+        {:path path :changed? false :sites 0 :left-alone 0 :suggestions []
+         :entries [{:file path :line 0 :col 0 :form "" :head nil
+                    :class :parse-error :action :refused
+                    :detail {:message (.getMessage e)}
+                    :note (str "rewrite-clj could not read this file, so it was left completely "
+                               "untouched. The reader said: " (.getMessage e))}]}))))
+
+(defn run
+  "Scan or rewrite a path set and build the report artefact."
+  [paths {:keys [rewrite? write?] :as opts}]
+  (let [files   (expand-paths paths)
+        results (mapv #(run-file % opts) files)]
+    (report/build
+     {:entries          (vec (mapcat :entries results))
+      :suggestions      (vec (mapcat :suggestions results))
+      :files-scanned    (count files)
+      :files-changed    (count (filter :changed? results))
+      :dry-run?         (and rewrite? (not write?))
+      :sites-total      (reduce + 0 (map #(or (:sites %) 0) results))
+      :sites-left-alone (reduce + 0 (map #(or (:left-alone %) 0) results))})))
+
+(defn scan-paths
+  "Programmatic entry point: every entry across a path set."
+  [paths]
+  (:entries (run paths {})))
+
+(defn rewrite-file!
+  "Apply the fixer to one file. With `{:write? true}` the file is
+  overwritten in place when it changes; otherwise it is a dry run."
+  ([path] (rewrite-file! path {}))
+  ([path opts] (run-file (io/file path) (assoc opts :rewrite? true))))
+
+;; ---------------------------------------------------------------------------
+;; CLI
+;; ---------------------------------------------------------------------------
+
+(def ^:private usage
+  (str "usage: clojure -M:run [--rewrite] [--write] [--report PATH] PATH ...\n"
+       "\n"
+       "  (no flag)        scan: report only, touch nothing\n"
+       "  --rewrite        dry run: show what would change\n"
+       "  --rewrite --write  apply the fixer in place\n"
+       "  --report PATH    where the EDN report goes"
+       " (default: reagent-to-hicasso-report.edn)\n"))
+
+(defn -main
+  [& args]
+  (let [flags    (set (filter #(str/starts-with? % "--") args))
+        report-p (or (second (drop-while #(not= "--report" %) args))
+                     "reagent-to-hicasso-report.edn")
+        paths    (->> args
+                      (remove #(str/starts-with? % "--"))
+                      (remove #(= % report-p)))]
+    (if (empty? paths)
+      (do (print usage) (flush) (System/exit 2))
+      (let [rep (run paths {:rewrite? (contains? flags "--rewrite")
+                            :write?   (contains? flags "--write")})]
+        (report/print-lines (:entries rep))
+        (report/write! rep report-p)
+        (println)
+        (println (pr-str (:summary rep)))
+        (println (str "report: " report-p))
+        ;; Exit 0 for any run that COMPLETED. A migration tool that fails a
+        ;; build because a consumer's code needs a human decision is a tool
+        ;; that gets run once.
+        (System/exit (if (some #(= :parse-error (:class %)) (:entries rep)) 1 0))))))

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/dest.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/dest.clj
@@ -1,0 +1,133 @@
+(ns re-frame.migration.hicasso.dest
+  "**What Hicasso does** — the DESTINATION column of the design's §3 table,
+  and the whole of the design's §6 static-analysis vocabulary.
+
+  ## The vocabulary, and the one term that may authorise a rewrite
+
+  `rf2-2rtt6.103` rejected migration's E2 as fatal: Fluent's `onRender*`
+  family and Ant's `onRow` are event-*spelled* render props, so a design
+  that reads an `on*` name as \"this is an event position\" and wraps the
+  value in a nil-returning event wrapper blanks them silently. The ruling
+  kept the position table alive as **the codemod's static-analysis
+  vocabulary** and nothing more.
+
+  That licence is enforced structurally here rather than promised. Read
+  the last column downward:
+
+  | term | what it is asked | can a \"yes\" ADD a rewrite? |
+  |---|---|---|
+  | [[canonical-slot]] | which React slot does this key emit into? | No — it selects which §3 row applies, and both runtimes compute it identically from the key alone |
+  | [[html-attr-slot?]] | is this slot bound for an HTML attribute? | No — a yes means both runtimes `name` here, so W3 SKIPS |
+  | [[event-prop?]] | will `host-entry` refuse a carrier at this slot? | No — a yes is always a REFUSAL, never a wrap |
+  | literalness (`rewrite`'s own syntactic tests) | can this form's value be read off the text? | Yes — and it is the only term that can |
+
+  Exactly one term can authorise a rewrite and it is the one that asks
+  about syntax rather than about names. Every name-shaped term can only
+  subtract. That is the corollary of the design's Law 1, and it is why
+  this tool cannot reproduce E2's failure even by accident: `onRenderCell`
+  is [[event-prop?]]-true, and an [[event-prop?]]-true answer here does
+  nothing but make the tool MORE conservative at that prop.
+
+  ## What is mirrored, and what is shared
+
+  [[canonical-slot]] is the shared `.cljc` rule itself (rf2-ani6y) — not a
+  mirror, the actual function the codec calls. [[html-attr-slots]] and
+  [[re-event-prop]] ARE mirrors, of `codec/html-attr-slots` and
+  `intent/event-prop?`, because both live in `.cljs` this JVM tool cannot
+  load. Each is one small pure form carrying the symbol it mirrors, which
+  is the design's §9.5 partial mitigation — a convention, and the page is
+  candid that a convention is not a pin."
+  (:require [clojure.string :as str]
+            [re-frame.bench.hicasso.front.slot :as slot]))
+
+(def canonical-slot
+  "**The one slot resolver**, and it is the codec's own. The React prop
+  slot a hiccup attribute key emits into.
+
+  `front.codec/canonical-slot` is `cached-prop-name`, which is a cache
+  over `slot/prop-name`; a cache changes when a lookup is computed and
+  nothing about what it answers, so this alias and the codec's are the
+  same function of the same key."
+  slot/prop-name)
+
+(def key-slot
+  "`raw-element` lifts `(:key props)` — the LITERAL keyword, read off the
+  author's own map before conversion — onto the crossing's outer element.
+  Held as the canonical slot for the report's benefit; W1 mints and reads
+  the literal `:key`, because that is what the codec reads."
+  "key")
+
+(def ref-slot "ref")
+(def class-slot "className")
+
+(def ^:private html-attr-slots
+  "MIRRORS `front.codec/html-attr-slots`. The emitted slots at a foreign
+  crossing whose value is bound for an HTML attribute and therefore has no
+  representation but a string — so the codec keeps `(name v)` there, which
+  is also the donor's answer, which is why W3 skips them.
+
+  Named as SLOTS, not as keys: `:class`, `:className` and `\"class\"` are
+  one position."
+  #{"className" "id" "role"})
+
+(defn html-attr-slot?
+  "Is `slot` one of the HTML-attribute positions? MIRRORS
+  `front.codec/html-attr-slot?`, prefix families included —
+  `slot/prop-name` leaves `aria-*` and `data-*` uncamelCased, so the slot
+  still carries the prefix to test."
+  [slot]
+  (boolean
+   (and (string? slot)
+        (or (contains? html-attr-slots slot)
+            (str/starts-with? slot "data-")
+            (str/starts-with? slot "aria-")))))
+
+(def ^:private re-event-prop
+  "MIRRORS `front.intent/re-event-prop`. `:on-click` (the taught kebab
+  spelling) or `:onClick` (the camel one a migrating author writes). Two
+  shapes, one rule, no roster of DOM event names to maintain."
+  #"^on-[a-z]|^on[A-Z]")
+
+(defn event-prop?
+  "Is `k` an event position? MIRRORS `front.intent/event-prop?`, including
+  its type gate: the function answers false for a symbol, so a prop key
+  spelled `on-click` as a SYMBOL is not an event position and this tool
+  must not refuse there.
+
+  Asked of what `host-entry` will do with our own landed code, not of what
+  a prop means in a library. Where the model says \"this will throw\", the
+  answer is a report line naming `defhost` and `:callbacks` — never a
+  wrap, never a rewrite."
+  [k]
+  (boolean (and (or (keyword? k) (string? k))
+                (re-find re-event-prop (name k)))))
+
+(defn nested-key-name
+  "What `clj->js` emits for a key inside a NESTED map — which is the
+  destination's whole answer there, because `host-prop-value` sends a
+  collection value straight to `clj->js` and its keys keep the spelling
+  the author wrote.
+
+  This is the function W2 has to make agree with [[donor/key-name]]."
+  [k]
+  (cond
+    (keyword? k) (name k)
+    (symbol? k)  (str k)
+    (string? k)  k
+    :else        (pr-str k)))
+
+(defn dangerous-html-key?
+  "Does this key name the `dangerouslySetInnerHTML` slot in any spelling?
+  Compared with the dashes stripped and case folded, because the kebab
+  spelling never reached React's exact name under EITHER runtime — the
+  camel rule answers `dangerouslySetInnerHtml`, with a lowercase `tml` —
+  and the migrator needs telling about the site regardless of which
+  spelling they used.
+
+  The donor DELETED this prop unless it was `UnsafeHTML`-wrapped and
+  Hicasso passes it through, so the migration resurrects it. A decision
+  for a person; never a rewrite (`:dangerous-html`, §5.3)."
+  [k]
+  (and (or (keyword? k) (string? k) (symbol? k))
+       (= "dangerouslysetinnerhtml"
+          (-> (name k) (str/replace "-" "") (str/lower-case)))))

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/donor.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/donor.clj
@@ -1,0 +1,84 @@
+(ns re-frame.migration.hicasso.donor
+  "**What Reagent 2.0.1 does** — the DONOR column of the design's §3 table.
+
+  Every rewrite in
+  `docs/design/hicasso/studio/reagent-codemod-against-the-landed-escape.md`
+  is argued from a proof sketch, and every proof sketch is a claim about
+  this namespace's subject: what Reagent's `convert-prop-value` / `kv-conv`
+  / `cached-prop-name` answer for a given prop. The claims are pinned by an
+  executed suite — `codemod-contract-donor-*` in
+  `implementation/adapters/reagent/test/re_frame/reagent_codemod_contract_donor_cljs_test.cljs`
+  (rf2-d2mwk) — so a Reagent bump that moves any of them goes red with
+  \"codemod\" in the failing test's name.
+
+  ## The key function, and why it is not transcribed
+
+  Reagent's `cached-prop-name` and this repo's
+  [[re-frame.bench.hicasso.front.slot/prop-name]] are the SAME kebab→camel
+  rule with the same three seeded renames and the same `aria`/`data`
+  exemption. They part company in exactly two cells:
+
+  | cell | Reagent's `cached-prop-name` | our `slot/prop-name` |
+  |---|---|---|
+  | a STRING key | verbatim — the cache is only consulted for `named?` keys, so `\"class\"` stays `\"class\"` | the three renames apply to every spelling, so `\"class\"` is `\"className\"` |
+  | a `--custom-property` | mangled: `--brand-color` → `BrandColor` | preserved verbatim |
+
+  So [[key-name]] is written as *the shared rule plus its two named
+  deltas*, never as a second copy of the camel algorithm. That is not
+  tidiness. The design's §9.5 — \"the tool reimplements `prop-name`, and
+  nothing pins the two together\" — survived its own adversarial pass
+  UNREPAIRED, and a transcribed camel rule here would be precisely the
+  second implementation it warns about, drifting silently in both
+  directions. There is one camel rule in this repository and this
+  namespace calls it."
+  (:require [clojure.string :as str]
+            [re-frame.bench.hicasso.front.slot :as slot]))
+
+(defn css-var-name?
+  "Is `n` a CSS custom property? Reagent's `dash-to-prop-name` splits
+  `\"--brand-color\"` into `(\"\" \"\" \"brand\" \"color\")` and the empty
+  leading segments capitalize to nothing, yielding `BrandColor` — a style
+  key nothing reads. Our rule preserves it and React routes it through
+  `setProperty`, so it works.
+
+  Preserving the donor here would mean writing a key that never worked, so
+  the design refuses the cell and reports `:css-var-repair` (§4.2). This
+  predicate exists to DETECT that cell; the mangled answer is never
+  computed, because it is never written."
+  [n]
+  (str/starts-with? n "--"))
+
+(defn key-name
+  "Reagent's `cached-prop-name` answer for a literal map key — the React
+  property name the donor emitted the value under.
+
+  Returns `nil` where the donor's answer is one this tool refuses to
+  preserve (a CSS custom property) or one it cannot model (a key that is
+  neither keyword, symbol nor string — a number, say, which `gobj/set`
+  stringifies). A `nil` means *do not rewrite this key*, never *the key
+  emits nothing*."
+  [k]
+  (cond
+    ;; Delta 1. `cached-prop-name` consults its cache only when the key is
+    ;; `named?`; anything else is handed back untouched, seeded renames
+    ;; included. Pinned by `codemod-contract-donor-w2-nested-map-keys`'s
+    ;; "a STRING key is verbatim" row.
+    (string? k) k
+
+    (or (keyword? k) (symbol? k))
+    (let [n (name k)]
+      ;; Delta 2, detected and refused rather than reproduced.
+      (when-not (css-var-name? n)
+        ;; The cache is keyed on `(name k)`, so a namespaced spelling
+        ;; lands on the same slot as its bare twin — `:x/class` is
+        ;; `className`. Re-keywording `n` reproduces that.
+        (slot/prop-name (keyword n))))
+
+    :else nil))
+
+(defn fixpoint-key?
+  "Is `k` already spelled the way the donor emitted it, so that W2 has
+  nothing to write? True when the destination's `clj->js` answer for the
+  key already equals the donor's `cached-prop-name` answer."
+  [k dest-name]
+  (= dest-name (key-name k)))

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/report.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/report.clj
@@ -1,0 +1,128 @@
+(ns re-frame.migration.hicasso.report
+  "The report (§7), which the design calls the first-class HALF of the tool
+  rather than its residue.
+
+  Six properties make it so, and each is a thing the tool would otherwise
+  be free to do casually.
+
+  1. **It is an artefact, not console output.** One EDN file, deterministic
+     ordering, written on every run including a clean one. The golden
+     corpus asserts it byte-for-byte, so **a change to what the tool SAYS
+     is gated exactly as hard as a change to what it WRITES**. That is the
+     property that makes the other five worth having.
+  2. **It is exhaustive over the sites it touched or refused, and honest
+     about the rest.** The summary carries the count of sites left alone,
+     so \"not in the report\" is never ambiguous.
+  3. **Every entry carries the source form as text, with file, line and
+     column**, addressed against the INPUT file — so a scan and a rewrite
+     of the same tree report the same coordinates.
+  4. **Every refusal names the fix in the migrator's vocabulary.** The
+     `:note` is a sentence a person can act on, not an error code.
+  5. **It carries the component name, and it is the only thing in the
+     system that can.** A `[:>]` refusal at runtime prints
+     `raw-crossing`'s `displayName`, which is the constant `\"[:>]\"`,
+     beside an empty `:declared` set — the runtime cannot say WHICH
+     component refused. The report can, because it read the head.
+  6. **It carries the suggestions block, labelled as guesses.**
+
+  Exit code is 0 for any run that completed, and 1 only when a file could
+  not be read or written. A migration tool that fails a build because a
+  consumer's code needs a human decision is a tool that gets run once."
+  (:require [clojure.java.io :as io]
+            [clojure.pprint :as pp]
+            [clojure.string :as str]))
+
+(def ^:private class-order
+  "Report ordering within one site. Blockers first, then the refusals that
+  need a decision, then the rewrites — so the top of a site's block is the
+  part a migrator must act on."
+  (let [ks [;; §5.3 — the destination refuses at runtime; these need a person
+            :intent-needs-a-declaration :dangerous-html :r>-site :f>-site
+            :as-element-island :reagent-api-residue
+            ;; §5.2 — decidable, but the rewrite would itself change behaviour
+            :event-carrier-goes-live :key-conflict :string-tag-unparseable
+            :normalized-key-collision :css-var-repair :named-ref :amp-key
+            ;; §5.1 — undecidable from the source text
+            :computed-props :computed-value :computed-nested-key
+            :adapt-def-site :cljc-site :parse-error
+            ;; skipped-by-design
+            :key-slot-named-value
+            ;; the rewrites
+            :nested-map-keys :namespaced-named-value :named-value
+            :partial-wrapper :metadata-key
+            :adapt-react-class-head :string-tag-head]]
+    (zipmap ks (range))))
+
+(defn sort-entries
+  "Deterministic ordering: file, then line, then column, then the class
+  order above. Two runs of the tool over the same tree emit byte-identical
+  reports, which is what lets the corpus assert one."
+  [entries]
+  (vec (sort-by (juxt #(str (:file %)) #(or (:line %) 0) #(or (:col %) 0)
+                      #(get class-order (:class %) 999)
+                      #(str (:class %)))
+                entries)))
+
+(def ^:private suggestion-caution
+  (str "GUESSES, NOT A CONTRACT — CHECK EVERY ROW AGAINST THE LIBRARY'S OWN DOCUMENTATION. "
+       "These slots are listed because their NAMES look like event positions or because they "
+       "carry a function, and a name is not a meaning. Fluent's `onRenderCell` and Ant's `onRow` "
+       "are event-SPELLED RENDER PROPS: the caller reads their RETURN VALUE. Declaring one as an "
+       "`:event` contract would hand it a nil-returning wrapper and blank your cell renderer with "
+       "nothing thrown. That failure is why this tool never synthesizes a `:callbacks` map and "
+       "why there is no flag to make it."))
+
+(defn- defhost-sketch
+  "A ready-to-paste declaration for one component. It is TEXT in a report,
+  never a form the tool writes into a file: `:callbacks` synthesis is
+  never mechanical, and the hoist that would mint these is demand-gated
+  and out of scope."
+  [{:keys [head event-slots fn-slots]}]
+  (let [slots (distinct (concat event-slots fn-slots))]
+    (str "(h/defhost " (str/lower-case (or head "component")) " " (or head "Component") "\n"
+         "  {:callbacks {" (str/join "\n               "
+                                     (for [s slots] (str s " :fn"))) "}})")))
+
+(defn build
+  "Assemble the report artefact from the per-file results."
+  [{:keys [entries suggestions files-scanned sites-total sites-left-alone
+           files-changed dry-run?]}]
+  (let [entries (sort-entries entries)
+        by-class (->> entries (group-by :class)
+                      (map (fn [[k v]] [k (count v)]))
+                      (sort-by first)
+                      (into (sorted-map)))]
+    {:tool    "reagent-to-hicasso/codemod (fixer)"
+     :design  "docs/design/hicasso/studio/reagent-codemod-against-the-landed-escape.md"
+     :summary {:files-scanned     files-scanned
+               :files-changed     files-changed
+               :dry-run?          (boolean dry-run?)
+               :sites-total       sites-total
+               :sites-rewritten   (count (into #{} (comp (filter #(= :rewrote (:action %)))
+                                                         (map (juxt :file :line :col)))
+                                               entries))
+               :sites-left-alone  sites-left-alone
+               :entries           (count entries)
+               :by-class          by-class}
+     :entries entries
+     :suggestions
+     (when (seq suggestions)
+       {:caution suggestion-caution
+        :components (vec (for [s (sort-by :head (distinct suggestions))]
+                           (assoc s :defhost (defhost-sketch s))))})}))
+
+(defn write!
+  "Write the report to `path` as EDN. Pretty-printed with a stable key
+  order so a diff of two reports is readable."
+  [report path]
+  (io/make-parents (io/file path))
+  (spit path (with-out-str (pp/pprint report))))
+
+(defn print-lines
+  "The human-facing one-line-per-entry rendering. The EDN artefact is the
+  contract; this is the thing you read while you work."
+  [entries]
+  (doseq [{:keys [file line col class action head]} entries]
+    (println (format "%s:%s:%s  %-26s %-9s %s"
+                     (or file "-") (or line "-") (or col "-")
+                     (name class) (name action) (or head "")))))

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
@@ -100,9 +100,11 @@
                 (recur (conj out k) (rest ks) (inc j))))))))))
 
 (defn- remove-element
-  "Remove the `i`-th semantic child of `node` together with the single
-  whitespace node that preceded it, so a removal does not leave a double
-  space behind."
+  "Remove the `i`-th semantic child of `node` along with ONE adjacent
+  whitespace node, so a removal leaves neither a double space nor a
+  leading one. The preceding space goes when there is one; for the first
+  child — which has nothing before it but the opening delimiter — the
+  FOLLOWING space goes instead."
   [node i]
   (let [kept (loop [out [], ks (n/children node), j 0]
                (if (empty? ks)
@@ -111,10 +113,15 @@
                    (if (n/whitespace-or-comment? k)
                      (recur (conj out k) (rest ks) j)
                      (if (= j i)
-                       (recur (if (and (seq out) (n/whitespace-or-comment? (peek out)))
-                                (pop out)
-                                out)
-                              (rest ks) (inc j))
+                       (if (and (seq out) (n/whitespace-or-comment? (peek out)))
+                         (recur (pop out) (rest ks) (inc j))
+                         ;; nothing to drop behind us: drop the space ahead
+                         (let [ks' (rest ks)]
+                           (recur out
+                                  (if (and (seq ks') (n/whitespace-or-comment? (first ks')))
+                                    (rest ks')
+                                    ks')
+                                  (inc j))))
                        (recur (conj out k) (rest ks) (inc j)))))))]
     (n/replace-children node kept)))
 
@@ -146,6 +153,33 @@
          (or (keyword? v) (string? v) (number? v) (boolean? v)
              (nil? v) (char? v) (instance? java.util.regex.Pattern v)))))
 
+(defn- literal-named-value
+  "The keyword or symbol this prop value **is**, or `nil`.
+
+  A bare symbol token is a VARIABLE REFERENCE, not a symbol value:
+  `handler` names whatever `handler` is bound to, and at a prop that is
+  overwhelmingly a function. Only a keyword literal and a QUOTED symbol
+  are named values the donor's `(name x)` arm ever saw.
+
+  This distinction is the difference between W3 and a catastrophe.
+  Reading a bare symbol as a symbol value rewrites `{:on-click handler}`
+  to `{:on-click \"handler\"}` — a live handler replaced by a string,
+  silently, which is precisely the fatal class this whole tool exists to
+  delete. Everything reached through a symbol is invisible to a source
+  reader and falls to `:computed-value` (§4.4's \"scope, stated
+  honestly\")."
+  [v]
+  (cond
+    (and (tag= v :token) (keyword? (sexpr-safe v)))
+    (sexpr-safe v)
+
+    (tag= v :quote)
+    (let [inner (element-at v 0)]
+      (when (and inner (tag= inner :token) (symbol? (sexpr-safe inner)))
+        (sexpr-safe inner)))
+
+    :else nil))
+
 (defn- fn-literal?
   "Is this form SYNTACTICALLY a function — `(fn …)`, `(fn* …)`, `#(…)`,
   or a `let` whose body ends in one (which is W4's own output shape)?
@@ -163,6 +197,19 @@
               (or (contains? '#{fn fn* clojure.core/fn} s)
                   (and (= 'let s)
                        (some-> (last (elements node)) fn-literal?))))))))
+
+(defn- read-off-the-text?
+  "Can this prop value's crossing be decided from the text alone? True for
+  a non-symbol token, a literal collection, a quoted form, a reader
+  literal such as `#js {…}`, and a function literal. False for a bare
+  symbol and for any call — those are `:computed-value`, which is exactly
+  what §4.4 says of \"anything arriving through a symbol\"."
+  [v]
+  (boolean
+   (or (and (tag= v :token) (not (symbol? (sexpr-safe v))))
+       (map-node? v) (vector-node? v) (tag= v :set)
+       (tag= v :quote) (tag= v :reader-macro)
+       (fn-literal? v))))
 
 ;; ---------------------------------------------------------------------------
 ;; The `^{:key k}` wrapper (W1's other half)
@@ -634,9 +681,9 @@
                               "deliberately whether you want that.")))
 
          ;; ---- §5.2 `:named-ref` ----------------------------------------------
-         (and (= dest/ref-slot slot)
-              (tag= v :token)
-              (let [vv (sexpr-safe v)] (or (keyword? vv) (symbol? vv))))
+         ;; A bare symbol at `:ref` is a CALLBACK ref and is fine; only a
+         ;; keyword or quoted symbol made the donor produce a string ref.
+         (and (= dest/ref-slot slot) (literal-named-value v))
          (add acc (entry :named-ref :refused {:prop ktext :value (str/trim (n/string v))}
                          (str "Reagent's `(name …)` here produced a STRING REF, which React 19 "
                               "removed and now throws on — so preserving Reagent would restore a "
@@ -687,9 +734,8 @@
            acc)
 
          ;; ---- W3 (§4.3), amended by (C) ---------------------------------------
-         (and (tag= v :token)
-              (let [vv (sexpr-safe v)] (or (keyword? vv) (symbol? vv))))
-         (let [vv (sexpr-safe v)]
+         (literal-named-value v)
+         (let [vv (literal-named-value v)]
            (cond
              ;; W6 landed this site on a NATIVE tag, whose Hicasso walk carries
              ;; the `(name v)` arm itself — so W3 is a fixpoint here and firing
@@ -721,9 +767,7 @@
   [props-node ctx]
   (let [unread (->> (pairs props-node)
                     (remove (fn [[_ v _]]
-                              (or (tag= v :token) (map-node? v) (vector-node? v)
-                                  (fn-literal? v)
-                                  (tag= v :quote)
+                              (or (read-off-the-text? v)
                                   ;; W4 read this one and rewrote it; a tool that
                                   ;; reports its own rewrite as undecidable is
                                   ;; crying wolf.

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
@@ -1,0 +1,967 @@
+(ns re-frame.migration.hicasso.rewrite
+  "The six rewrites (§4) and the refusal set (§5), as pure functions over
+  rewrite-clj NODES.
+
+  ## Two laws, and one corollary that does most of the work
+
+  **Law 1 — decidability.** A rewrite fires only where the donor's answer
+  and the destination's answer are both computable from the source text,
+  and they differ.
+
+  **Law 2 — no blanking.** No rewrite introduces a function whose return
+  value differs from the value the donor's conversion produced.
+
+  **Corollary.** A prop's spelling may only ever make the tool do LESS.
+  Where a name-shaped test says \"yes\", the answer is always *skip this
+  rewrite* or *refuse this site* — never *apply this rewrite*. See
+  [[re-frame.migration.hicasso.dest]], where the vocabulary is enumerated
+  with that enforcement in its last column.
+
+  **Silent behaviour change is the only fatal class.** `[:>]` is legal in
+  Hicasso, so \"leave it as `[:>]`\" is a valid output for any site the
+  rewrite cannot make behaviour-preserving. A refused site still works;
+  the report is what turns a refusal from silence into an instruction.
+
+  ## How a site is planned, and why it is planned exactly once
+
+  [[plan-site]] is a pure function from a site node (plus a context) to
+  `{:entries [...] :edit (fn [node] node')}`. The report pass and the
+  rewrite pass each call it, on the same node with the same context, and
+  therefore reach the same decision — there is no separate \"apply\"
+  implementation to drift from the analysis. `:edit` is written to operate
+  STRUCTURALLY on whatever node it is handed, so the rewrite pass may hand
+  it a node whose nested sites have already been rewritten.
+
+  ## The three amendments (rf2-2rtt6.143), which CORRECT the landed design
+
+  **(A)** W4 captures at prop-evaluation time — [[w4-plan]].
+  **(B)** W2 refuses normalized-key collisions — [[injective-keys]].
+  **(C)** The key slot gets a dedicated report entry — [[w3-entry]]."
+  (:require [clojure.string :as str]
+            [re-frame.migration.hicasso.dest :as dest]
+            [re-frame.migration.hicasso.donor :as donor]
+            [rewrite-clj.node :as n]
+            [rewrite-clj.parser :as p]))
+
+;; ---------------------------------------------------------------------------
+;; Node helpers
+;; ---------------------------------------------------------------------------
+
+(defn sexpr-safe
+  "The node's value, or `::unreadable` for a node no reader can answer —
+  a reader conditional, an unresolved auto-resolved keyword, a tagged
+  literal. `::unreadable` is never equal to anything the tool tests for,
+  so an unreadable node simply fails every literalness test, which is the
+  conservative direction."
+  [node]
+  (try (n/sexpr node) (catch Exception _ ::unreadable)))
+
+(defn elements
+  "The node's semantic children — whitespace, newlines and comments
+  removed. Indices into this vector are what [[replace-element]] and
+  [[insert-element]] address, so formatting survives every edit."
+  [node]
+  (if (n/inner? node)
+    (vec (remove n/whitespace-or-comment? (n/children node)))
+    []))
+
+(defn element-at [node i] (get (elements node) i))
+
+(defn- replace-element
+  "Replace the `i`-th semantic child of `node`, leaving every whitespace
+  and comment node exactly where the author put it."
+  [node i new-child]
+  (loop [out [], ks (n/children node), j 0]
+    (if (empty? ks)
+      (n/replace-children node out)
+      (let [k (first ks)]
+        (if (n/whitespace-or-comment? k)
+          (recur (conj out k) (rest ks) j)
+          (recur (conj out (if (= j i) new-child k)) (rest ks) (inc j)))))))
+
+(defn- insert-element
+  "Insert `new-child` so that it becomes the `i`-th semantic child,
+  separated by one space. Appended at the end when `i` is past the last
+  semantic child — which is the `[:> C]` case W1 mints into."
+  [node i new-child]
+  (let [total (count (elements node))]
+    (if (>= i total)
+      (n/replace-children node (concat (n/children node)
+                                       (when (pos? total) [(n/spaces 1)])
+                                       [new-child]))
+      (loop [out [], ks (n/children node), j 0]
+        (if (empty? ks)
+          (n/replace-children node out)
+          (let [k (first ks)]
+            (if (n/whitespace-or-comment? k)
+              (recur (conj out k) (rest ks) j)
+              (if (= j i)
+                (n/replace-children node (concat out [new-child (n/spaces 1)] ks))
+                (recur (conj out k) (rest ks) (inc j))))))))))
+
+(defn- remove-element
+  "Remove the `i`-th semantic child of `node` together with the single
+  whitespace node that preceded it, so a removal does not leave a double
+  space behind."
+  [node i]
+  (let [kept (loop [out [], ks (n/children node), j 0]
+               (if (empty? ks)
+                 out
+                 (let [k (first ks)]
+                   (if (n/whitespace-or-comment? k)
+                     (recur (conj out k) (rest ks) j)
+                     (if (= j i)
+                       (recur (if (and (seq out) (n/whitespace-or-comment? (peek out)))
+                                (pop out)
+                                out)
+                              (rest ks) (inc j))
+                       (recur (conj out k) (rest ks) (inc j)))))))]
+    (n/replace-children node kept)))
+
+(defn- tag= [node t] (and node (= t (n/tag node))))
+
+(defn- map-node? [node] (tag= node :map))
+(defn- vector-node? [node] (tag= node :vector))
+(defn list-node? [node] (tag= node :list))
+
+(defn pairs
+  "A literal map node as `[[key-node value-node index] ...]`, where index
+  is the KEY's position among the node's semantic children. A map with an
+  odd number of semantic children is malformed source; it yields the
+  pairs it can and drops the dangling key."
+  [node]
+  (let [els (elements node)]
+    (vec (for [i (range 0 (dec (count els)) 2)]
+           [(nth els i) (nth els (inc i)) i]))))
+
+(defn- self-evaluating?
+  "Is this form's value fixed by its own text, with no evaluation to
+  observe? Keywords, strings, numbers, booleans, `nil`, characters and
+  regexes. Deliberately NOT symbols: re-reading a var on each callback
+  invocation is observable under redefinition, which is the whole subject
+  of amendment (A)."
+  [node]
+  (and (tag= node :token)
+       (let [v (sexpr-safe node)]
+         (or (keyword? v) (string? v) (number? v) (boolean? v)
+             (nil? v) (char? v) (instance? java.util.regex.Pattern v)))))
+
+(defn- fn-literal?
+  "Is this form SYNTACTICALLY a function — `(fn …)`, `(fn* …)`, `#(…)`,
+  or a `let` whose body ends in one (which is W4's own output shape)?
+
+  Used only to keep a value OUT of the `:computed-value` report: the three
+  things a computed value may silently be are a keyword, a nested map and
+  a non-fn `IFn`, and a function literal is provably none of them. A tool
+  that flags the code it just wrote as undecidable is crying wolf."
+  [node]
+  (boolean
+   (or (tag= node :fn)
+       (and (list-node? node)
+            (let [h (element-at node 0)
+                  s (and h (sexpr-safe h))]
+              (or (contains? '#{fn fn* clojure.core/fn} s)
+                  (and (= 'let s)
+                       (some-> (last (elements node)) fn-literal?))))))))
+
+;; ---------------------------------------------------------------------------
+;; The `^{:key k}` wrapper (W1's other half)
+;; ---------------------------------------------------------------------------
+;;
+;; W1's edit spans two nodes: the key moves OUT of the metadata map and INTO
+;; the props map. The props half is [[plan-site]]'s `:edit`; this half is the
+;; caller's, because a metadata map is the site vector's PARENT and a plan
+;; cannot reach upward. Both halves fire on the one condition — `plan-site`'s
+;; `:w1?` — so they cannot disagree.
+
+(defn meta-node? [nd] (tag= nd :meta))
+
+(defn unwrap-metas
+  "Walk down a chain of `:meta` nodes. Returns `[meta-nodes innermost]`.
+
+  A chain rather than a single node because `^:foo ^{:key k} [:> …]` is
+  legal and Reagent's `(meta argv)` reads the merge of all of them."
+  [nd]
+  (loop [ms [], cur nd]
+    (if (meta-node? cur)
+      (recur (conj ms cur) (element-at cur 1))
+      [ms cur])))
+
+(defn meta-key-node
+  "The `:key` VALUE node inside one meta node's map, if it carries one.
+  Non-map metadata — `^:foo`, `^String` — never carries a key."
+  [mnode]
+  (let [mv (element-at mnode 0)]
+    (when (map-node? mv)
+      (some (fn [[k v _]] (when (= :key (sexpr-safe k)) v)) (pairs mv)))))
+
+(defn meta-key-nodes
+  "Every `:key` value node across a meta chain. More than one is a
+  `:key-conflict`; [[plan-site]] decides that, not this."
+  [metas]
+  (vec (keep meta-key-node metas)))
+
+(defn- drop-key-entry
+  "Remove the `:key` entry from one meta node's map. When the map is left
+  empty the whole `^{}` wrapper goes with it, because an empty metadata
+  map is noise the author never wrote."
+  [mnode]
+  (let [mv (element-at mnode 0)
+        i  (some (fn [[k _ idx]] (when (= :key (sexpr-safe k)) idx)) (pairs mv))]
+    (if (nil? i)
+      mnode
+      (let [mv' (-> mv (remove-element (inc i)) (remove-element i))]
+        (if (empty? (elements mv'))
+          (element-at mnode 1)
+          (replace-element mnode 0 mv'))))))
+
+(defn rebuild-meta-chain
+  "Rebuild a meta chain around `inner'`, dropping the `:key` entry from
+  whichever meta carries it when `strip?`."
+  [nd inner' strip?]
+  (if (meta-node? nd)
+    (let [child (rebuild-meta-chain (element-at nd 1) inner' strip?)
+          nd'   (replace-element nd 1 child)]
+      (if strip? (drop-key-entry nd') nd'))
+    inner'))
+
+;; ---------------------------------------------------------------------------
+;; Reagent alias resolution
+;; ---------------------------------------------------------------------------
+
+(def ^:private reagent-namespaces
+  '#{reagent.core reagent.dom reagent.dom.client reagent.ratom})
+
+(defn ns-context
+  "Read a file's `ns` form and answer which symbols name Reagent's API.
+
+  Returns `{:aliases #{r reagent} :referred #{partial …}}`. Alias
+  resolution is what makes W4 and W5 legal at all: the only non-fn `IFn`
+  and the only `adapt-react-class` a source reader can RECOGNISE is a
+  literal call through a symbol this map resolves. A bare `partial` is
+  `clojure.core/partial` — which IS a function, so the donor never wrapped
+  it — unless the `ns` form referred Reagent's, so the referred set is
+  read rather than assumed."
+  [root-node]
+  (let [ns-form (->> (elements root-node)
+                     (filter #(and (list-node? %)
+                                   (= 'ns (sexpr-safe (element-at % 0)))))
+                     first)
+        form    (some-> ns-form sexpr-safe)
+        reqs    (when (seq? form)
+                  (->> form
+                       (filter #(and (seq? %) (contains? #{:require :require-macros} (first %))))
+                       (mapcat rest)))]
+    (reduce
+     (fn [acc spec]
+       (let [spec (if (symbol? spec) [spec] spec)]
+         (if (and (sequential? spec) (contains? reagent-namespaces (first spec)))
+           (let [opts (apply hash-map (rest spec))]
+             (cond-> (update acc :aliases conj (first spec))
+               (:as opts)    (update :aliases conj (:as opts))
+               (:refer opts) (update :referred into (:refer opts))))
+           acc)))
+     {:aliases #{} :referred #{}}
+     reqs)))
+
+(defn reagent-call?
+  "Is `node` a literal call to Reagent's `sym`, through an alias this
+  file's `ns` form actually binds?"
+  [node sym {:keys [aliases referred]}]
+  (and (list-node? node)
+       (let [h (sexpr-safe (element-at node 0))]
+         (and (symbol? h)
+              (= (name h) (name sym))
+              (if-let [q (namespace h)]
+                (contains? aliases (symbol q))
+                (contains? referred sym))))))
+
+(defn- subtree-has-reagent-call?
+  [node sym ctx]
+  (boolean
+   (or (reagent-call? node sym ctx)
+       (and (n/inner? node)
+            (some #(subtree-has-reagent-call? % sym ctx) (n/children node))))))
+
+;; ---------------------------------------------------------------------------
+;; Site detection
+;; ---------------------------------------------------------------------------
+
+(defn- head-keyword [node]
+  (when (vector-node? node)
+    (let [h (element-at node 0)]
+      (when (tag= h :token) (sexpr-safe h)))))
+
+(defn site-kind
+  "Which kind of site is this node, if any?
+
+  `:raw`   — `[:> C …]`, the tool's whole subject.
+  `:adapt` — `[(r/adapt-react-class X) …]`, W5's inline head.
+  `:r>`    — `[:r> C …]`, ported by hand (§5.3).
+  `:f>`    — `[:f> C …]`, ported by hand (§5.3)."
+  [node ctx]
+  (when (vector-node? node)
+    (case (head-keyword node)
+      :> :raw
+      :r> :r>
+      :f> :f>
+      (when (reagent-call? (element-at node 0) 'adapt-react-class ctx) :adapt))))
+
+(defn- head-text
+  "The component name for the report — the one thing in the system that
+  can carry it. A `[:>]` refusal at RUNTIME prints `raw-crossing`'s
+  `displayName`, which is the constant `\"[:>]\"`, so the runtime cannot
+  say which component refused. The report can, because it read the head."
+  [node kind]
+  (let [h (case kind
+            :adapt (element-at (element-at node 0) 1)
+            (element-at node 1))]
+    (some-> h n/string str/trim)))
+
+(defn- props-index [kind] (if (= :adapt kind) 1 2))
+
+(defn- child-literal?
+  "Is this form OBVIOUSLY a hiccup child rather than a props map? A
+  string, a number, a boolean, `nil` or a nested hiccup vector. Anything
+  else that is not a literal map is `:computed-props` — the tool could not
+  tell props from a child, and says so."
+  [node]
+  (or (vector-node? node)
+      (and (tag= node :token)
+           (let [v (sexpr-safe node)]
+             (or (string? v) (number? v) (boolean? v) (nil? v))))))
+
+;; ---------------------------------------------------------------------------
+;; The report entry
+;; ---------------------------------------------------------------------------
+
+(defn- entry [class action detail note]
+  {:class class :action action :detail detail :note note})
+
+;; ---------------------------------------------------------------------------
+;; W2 — nested map keys (§4.2), amended by (B)
+;; ---------------------------------------------------------------------------
+
+(defn injective-keys
+  "**AMENDMENT (B).** Are this literal map's keys injective under the
+  DONOR's key function?
+
+  Reagent's `kv-conv` writes each nested-map key under
+  `cached-prop-name`, so `:foo-bar`/`:fooBar`, `:class`/`:className` and
+  `:foo-bar`/`\"fooBar\"` siblings each collapse onto ONE JS property with
+  an iteration-order winner. (The donor suite pins exactly this at the top
+  level: `codemod-contract-donor-the-whole-corpus` asserts a sixteen-prop
+  corpus emits FIFTEEN slots, and that `\"which of the two survives is
+  reduce-kv order … so the pin is that exactly one does\"`.)
+
+  Respelling both sources is therefore not available. Writing both
+  normalized names mints a DUPLICATE literal map key — which is not even
+  readable Clojure — and writing one picks a winner the rewrite cannot
+  know. So the whole map is refused and every colliding source key is
+  named.
+
+  Returns `nil` when injective, else a sorted vector of the colliding
+  source keys' texts, grouped by the normalized name they collapse onto.
+
+  CSS custom properties are excluded from the check because [[donor/key-name]]
+  answers `nil` for them: they are refused individually and never
+  respelled, so they cannot be half of a minted duplicate."
+  [map-node]
+  (let [named (->> (pairs map-node)
+                   (keep (fn [[k _ _]]
+                           (let [kv (sexpr-safe k)
+                                 dn (donor/key-name kv)]
+                             (when dn [dn (str/trim (n/string k))])))))
+        clashes (->> (group-by first named)
+                     (filter (fn [[_ v]] (> (count v) 1)))
+                     (sort-by first))]
+    (when (seq clashes)
+      (vec (for [[slot ks] clashes]
+             {:slot slot :keys (vec (sort (map second ks)))})))))
+
+(defn- respell-key
+  "The key node W2 writes, or nil when the key is already a fixpoint or is
+  one the tool refuses. Preserves the KIND the author wrote — a keyword
+  stays a keyword, a symbol stays a symbol — because `clj->js` reads
+  keywords by `name` and symbols by `str`, and only the same kind
+  reproduces the donor's emitted name."
+  [key-node]
+  (let [kv (sexpr-safe key-node)
+        dn (donor/key-name kv)]
+    (when (and dn (not= dn (dest/nested-key-name kv)))
+      (cond
+        (keyword? kv) (n/token-node (keyword dn))
+        (symbol? kv)  (n/token-node (symbol dn))
+        :else         nil))))
+
+(declare w2-map-plan)
+
+(defn- w2-map-plan
+  "Plan the rewrite of ONE literal map value, recursively.
+
+  Returns `{:edit fn :entries [...] :changed? bool}`. Recursion walks map
+  values THROUGH MAPS ONLY and stops at the first non-map collection,
+  because that is exactly where the donor stopped: Reagent recurses via
+  the `map?` arm, and a map inside a vector, list or set is reached by the
+  `coll?` arm, which is `clj->js` and does not camelCase. It never
+  descends into a `#js {…}` node, which both runtimes pass through
+  untouched."
+  [map-node path]
+  (let [collisions (injective-keys map-node)]
+    (if collisions
+      ;; (B): refuse the WHOLE map, naming every colliding source key.
+      {:edit identity
+       :changed? false
+       :entries [(entry :normalized-key-collision :refused
+                        {:path path :collisions collisions}
+                        (str "Reagent wrote each of these keys under `cached-prop-name`, so the "
+                             "siblings named here COLLAPSED onto one JS property and an "
+                             "iteration-order winner decided which value the library saw. "
+                             "Respelling them would either mint a duplicate map key or silently "
+                             "pick a winner this tool cannot know was the one that won. The map "
+                             "is left exactly as written: decide which key you meant, delete the "
+                             "other, and re-run."))]}
+      (let [ps (pairs map-node)]
+        (reduce
+         (fn [acc [k v i]]
+           (let [kv    (sexpr-safe k)
+                 kpath (conj path (str/trim (n/string k)))
+                 ;; the key
+                 acc   (cond
+                         (and (or (keyword? kv) (symbol? kv)) (donor/css-var-name? (name kv)))
+                         (update acc :entries conj
+                                 (entry :css-var-repair :refused
+                                        {:path kpath}
+                                        (str "Reagent's `dash-to-prop-name` mangled this CSS custom "
+                                             "property into a style key nothing reads, so the "
+                                             "declaration never took effect. Hicasso preserves it and "
+                                             "React routes a `--`-prefixed key through `setProperty`. "
+                                             "The key is left alone and THE SITE STARTS WORKING — "
+                                             "check that the style it now applies is the one you "
+                                             "want.")))
+
+                         (not (or (keyword? kv) (symbol? kv) (string? kv)))
+                         (update acc :entries conj
+                                 (entry :computed-nested-key :refused
+                                        {:path kpath}
+                                        (str "This map key is not a literal keyword, symbol or "
+                                             "string, so the tool cannot compute what Reagent spelled "
+                                             "it as. It keeps the spelling you wrote, and the "
+                                             "collision check above could not see it either.")))
+
+                         :else
+                         (if-let [nk (respell-key k)]
+                           (-> acc
+                               (update :edit (fn [f] (fn [nd] (replace-element (f nd) i nk))))
+                               (assoc :changed? true)
+                               (update :respelled conj [(str/trim (n/string k))
+                                                        (str/trim (n/string nk))]))
+                           acc))
+                 ;; the value, when it is itself a literal map
+                 acc   (if (map-node? v)
+                         (let [sub (w2-map-plan v kpath)]
+                           (cond-> (update acc :entries into (:entries sub))
+                             (:changed? sub)
+                             (-> (update :edit (fn [f] (fn [nd]
+                                                         (let [nd (f nd)]
+                                                           (replace-element nd (inc i)
+                                                                            ((:edit sub) (element-at nd (inc i))))))))
+                                 (assoc :changed? true))
+                             (seq (:respelled sub))
+                             (update :respelled into (:respelled sub))))
+                         acc)]
+             acc))
+         {:edit identity :entries [] :changed? false :respelled []}
+         ps)))))
+
+(defn- w2-entry
+  "W2's own report line — **the loudest the tool emits** (§9.1), and the
+  reason it must be is that W2 moves a latent conversion into visible
+  source text and hands the author a rake."
+  [path respelled]
+  (entry :nested-map-keys :rewrote
+         {:path path :respelled (vec (sort respelled))}
+         (str "Reagent camelCased these nested keys on the way across; Hicasso does not, so the "
+              "spelling is now written into your source where the library will actually read it. "
+              "IF A KEY HERE IS DATA RATHER THAN A LIBRARY OPTION, THIS REWRITE IS THE MOMENT TO "
+              "NOTICE — tidying it back to the spelling you originally wrote will silently change "
+              "what the library receives.")))
+
+;; ---------------------------------------------------------------------------
+;; W3 — named prop values (§4.3), amended by (C)
+;; ---------------------------------------------------------------------------
+
+(defn- w3-entry
+  "The report line for a literal keyword or symbol prop value.
+
+  **AMENDMENT (C)** is the `key`-slot arm. The exclusion itself is
+  ratified — `:foo` and `\"foo\"` sibling keys COLLIDED under Reagent and
+  are DISTINCT under Hicasso, so rewriting would restore the defect
+  rf2-vrvv9 removed — but §5.4 priced it as \"one remount\", and a remount
+  is not free: React reconciles a changed key by UNMOUNTING the old
+  subtree and mounting a new one, which discards its state."
+  [kind kw prop]
+  (case kind
+    :key-slot
+    (entry :key-slot-named-value :skipped
+           {:prop prop :value (str kw)}
+           (str "NOT REWRITTEN, DELIBERATELY, AND IT COSTS YOU SOMETHING. Reagent converted this "
+                "key like any prop and React received \"" (name kw) "\"; Hicasso lifts it raw and "
+                "React coerces it to \"" (str kw) "\". Writing \"" (name kw) "\" here would restore a "
+                "defect: two sibling elements keyed `" (str kw) "` and `\"" (name kw) "\"` collided "
+                "under Reagent and are distinct under Hicasso. The cost of leaving it is that the "
+                "key CHANGES at the migration, so on the first render after it React treats this "
+                "element as a new one — it unmounts the existing subtree and mounts a fresh one, "
+                "DISCARDING ITS STATE (uncontrolled input values, scroll position, component "
+                "state). It is a one-time cost and the key is stable thereafter."))
+
+    :namespaced
+    (entry :namespaced-named-value :rewrote
+           {:prop prop :was (str kw) :now (name kw)}
+           (str "Preserved exactly, and the preservation bakes in a collision. Reagent answered "
+                "`(name " (str kw) ")`, so `" (str kw) "` and any other namespace's `" (name kw)
+                "` reached the library as ONE string. Hicasso keeps the namespace, which is what "
+                "rf2-vrvv9 changed it to do. Writing the string preserves your current behaviour; "
+                "if the namespace was carrying meaning, this is where it was already being lost."))
+
+    (entry :named-value :rewrote
+           {:prop prop :was (str kw) :now (name kw)}
+           (str "Reagent named every keyword and symbol prop value; Hicasso keeps them whole "
+                "except at HTML-attribute slots. The string is a fixpoint on both walks."))))
+
+;; ---------------------------------------------------------------------------
+;; W4 — the non-fn IFn literal (§4.4), amended by (A)
+;; ---------------------------------------------------------------------------
+
+(def ^:private w4-callee 'f__rf2)
+(def ^:private w4-rest   'args__rf2)
+
+(defn- w4-binding [i] (symbol (str "a" i "__rf2")))
+
+(defn w4-plan
+  "**AMENDMENT (A).** Rewrite a literal `(r/partial f a …)` prop value.
+
+  The landed design's stated shape is `(fn [& args] (apply f a … args))`,
+  and it is wrong in a way that only shows up at runtime: it re-evaluates
+  the callee and every argument form on EACH callback invocation, where
+  Reagent's `make-partial-fn` evaluated them ONCE, at construction. So
+  `(r/partial f @snapshot)` stopped being a snapshot, and
+  `(r/partial f (next-id!))` started minting a new id per click.
+
+  The shape written here is therefore a hygienic `let` that captures the
+  callee and every non-literal argument **once, left to right, before the
+  wrapper is minted**:
+
+      (r/partial handler @cart (log! :x))
+        =>
+      (let [f__rf2 handler, a0__rf2 @cart, a1__rf2 (log! :x)]
+        (fn [& args__rf2] (apply f__rf2 a0__rf2 a1__rf2 args__rf2)))
+
+  Self-evaluating arguments — keywords, strings, numbers, booleans, `nil`
+  — are inlined at their original positions rather than bound, because
+  their evaluation has nothing to observe and a binding for one is pure
+  noise. Symbols ARE bound: re-reading a var on each invocation picks up a
+  redefinition the donor's captured value would not have seen.
+
+  The `__rf2` suffix is what makes the binding hygienic, and the names are
+  FIXED rather than gensym'd so the golden corpus can assert output
+  byte-for-byte.
+
+  Law 2 holds by transcription: the wrapper is `apply`, so whatever `f`
+  returned before it returns now. That is why W4 cannot blank a render
+  prop even at a prop that IS a render prop."
+  [call-node]
+  (let [els    (elements call-node)
+        callee (second els)
+        args   (drop 2 els)]
+    (when callee
+      (let [numbered (map-indexed (fn [i a] [i a (self-evaluating? a)]) args)
+            bound    (remove (fn [[_ _ lit?]] lit?) numbered)
+            binds    (str/join " " (cons (str w4-callee " " (str/trim (n/string callee)))
+                                         (for [[i a _] bound]
+                                           (str (w4-binding i) " " (str/trim (n/string a))))))
+            applied  (str/join " " (for [[i a lit?] numbered]
+                                     (if lit? (str/trim (n/string a)) (str (w4-binding i)))))
+            body     (str "(fn [& " w4-rest "] (apply " w4-callee
+                          (when (seq applied) (str " " applied))
+                          " " w4-rest "))")]
+        {:node    (p/parse-string (str "(let [" binds "] " body ")"))
+         :captured (vec (for [[_ a _] bound] (str/trim (n/string a))))}))))
+
+;; ---------------------------------------------------------------------------
+;; The props walk
+;; ---------------------------------------------------------------------------
+
+(defn- meta-key-note []
+  (str "Reagent read a `^{:key …}` on the vector AFTER converting the props, so a metadata key "
+       "BEAT a props `:key`. Hicasso's `raw-element` reads `(:key props)` and contains no `(meta …)` "
+       "read at all, so this key would have gone dead at the migration with no diagnostic from "
+       "either Hicasso or React beyond React's own parent-deduped warning. Moved into the props "
+       "map, where the destination reads it."))
+
+(defn- plan-props
+  "Walk the props map: W2, W3, W4 and every prop-level refusal. Returns
+  `{:edit fn :entries [...] :suggest {...}}`, where `:edit` maps the props
+  map node to its rewritten self."
+  [props-node {:keys [native? w6-candidate?] :as ctx}]
+  (reduce
+   (fn [acc [k v i]]
+     (let [kv    (sexpr-safe k)
+           ktext (str/trim (n/string k))
+           slot  (when (or (keyword? kv) (symbol? kv) (string? kv)) (dest/canonical-slot kv))
+           event? (dest/event-prop? kv)
+           vi    (inc i)
+           add   (fn [a e] (update a :entries conj e))
+           edit  (fn [a new-v]
+                   (update a :edit (fn [f] (fn [nd] (replace-element (f nd) vi new-v)))))]
+       (cond
+         ;; ---- §5.2 `:amp-key` -------------------------------------------------
+         (= :& kv)
+         (add acc (entry :amp-key :refused {:prop ktext}
+                         (str "Reagent emitted a prop LITERALLY NAMED \"&\"; Hicasso reads `:&` as "
+                              "its one attribute merge, folding the map into this element's own "
+                              "attributes under the owned-literal law. Two unrelated meanings for "
+                              "one literal and your intent is unrecoverable from the text — decide "
+                              "which you meant.")))
+
+         ;; ---- §5.3 `:dangerous-html` -----------------------------------------
+         (dest/dangerous-html-key? kv)
+         (add acc (entry :dangerous-html :refused {:prop ktext}
+                         (str "MIGRATION BLOCKER. Reagent's `convert-props` DELETED this prop "
+                              "unless its value was an `UnsafeHTML` instance, so under Reagent it "
+                              "very likely did nothing at all. Hicasso passes it through, so the "
+                              "migration RESURRECTS it and the HTML starts being injected. Decide "
+                              "deliberately whether you want that.")))
+
+         ;; ---- §5.2 `:named-ref` ----------------------------------------------
+         (and (= dest/ref-slot slot)
+              (tag= v :token)
+              (let [vv (sexpr-safe v)] (or (keyword? vv) (symbol? vv))))
+         (add acc (entry :named-ref :refused {:prop ktext :value (str/trim (n/string v))}
+                         (str "Reagent's `(name …)` here produced a STRING REF, which React 19 "
+                              "removed and now throws on — so preserving Reagent would restore a "
+                              "crash. Replace it with a callback ref (a function taking the node) "
+                              "or a `useRef`-style handle.")))
+
+         ;; ---- carriers at event-spelled slots (§5.2 / §5.3) -------------------
+         (and event? (or (vector-node? v) (map-node? v)))
+         (add acc
+              (if w6-candidate?
+                (entry :event-carrier-goes-live :refused
+                       {:prop ktext :value (str/trim (n/string v))}
+                       (str "REWRITE REFUSED, AND THIS IS THE DESIGN'S ONE GENUINELY FATAL CLASS. "
+                            "Under Reagent this was INERT — `convert-prop-value` asks `coll?` "
+                            "before `ifn?`, so it crossed as an array and the handler never fired. "
+                            "At a native Hicasso tag the same form is LOWERED into a live "
+                            "dispatch, so rewriting the head to a native tag would turn a handler "
+                            "that never fired into one that does. The head is left as `[:>]`. "
+                            "Decide whether this handler was ever meant to run."))
+                (entry :intent-needs-a-declaration :refused
+                       {:prop ktext :value (str/trim (n/string v))}
+                       (str "MIGRATION BLOCKER, and the one place Hicasso refuses something "
+                            "Reagent accepted. `host-entry` refuses an intent vector or key-map at "
+                            "an event-spelled prop the declaration does not name, and a `[:>]` "
+                            "crossing declares nothing — so this site will THROW at render. Know "
+                            "first that it never fired under Reagent either: it crossed as an "
+                            "inert array. Either declare the crossing with `defhost` and name "
+                            "this prop in `:callbacks`, or hand it a plain function."))))
+
+         ;; ---- W4 (§4.4), amended by (A) ---------------------------------------
+         (reagent-call? v 'partial ctx)
+         (if-let [{:keys [node captured]} (w4-plan v)]
+           (-> (edit acc node)
+               (add (entry :partial-wrapper :rewrote
+                           {:prop ktext
+                            :was (str/trim (n/string v))
+                            :now (str/trim (n/string node))
+                            :captured captured}
+                           (str "Reagent's `convert-prop-value` ends with an `ifn?` arm that "
+                                "wrapped a `PartialFn` in `(fn [& args] (apply x args))`. Hicasso "
+                                "has no such arm, so the object would have crossed opaque and this "
+                                "handler would have stopped firing with nothing thrown. The "
+                                "wrapper is Reagent's own, transcribed — return-transparent, so "
+                                "whatever it returned before it returns now. The `let` is not "
+                                "decoration: `r/partial` evaluated the callee and every argument "
+                                "ONCE when the prop was built, and the `let` is what keeps that "
+                                "true instead of re-evaluating them on every invocation."))))
+           acc)
+
+         ;; ---- W3 (§4.3), amended by (C) ---------------------------------------
+         (and (tag= v :token)
+              (let [vv (sexpr-safe v)] (or (keyword? vv) (symbol? vv))))
+         (let [vv (sexpr-safe v)]
+           (cond
+             ;; W6 landed this site on a NATIVE tag, whose Hicasso walk carries
+             ;; the `(name v)` arm itself — so W3 is a fixpoint here and firing
+             ;; it would only grow the diff (§4.6).
+             native? acc
+             ;; both runtimes `name` here — a fixpoint, and skipping keeps the diff small
+             (dest/html-attr-slot? slot) acc
+             ;; the class slot: `class-names` names it on the Hicasso side, in every spelling
+             (= dest/class-slot slot) acc
+             ;; (C) — ratified exclusion, now with its own report entry
+             (= dest/key-slot slot) (add acc (w3-entry :key-slot vv ktext))
+             :else
+             (-> (edit acc (n/string-node (name vv)))
+                 (add (w3-entry (if (namespace vv) :namespaced :plain) vv ktext)))))
+
+         :else acc)))
+
+   {:edit identity :entries []}
+   (pairs props-node)))
+
+;; ---------------------------------------------------------------------------
+;; The site plan
+;; ---------------------------------------------------------------------------
+
+(defn- computed-value-entry
+  "ONE entry per site naming every prop whose value the tool could not
+  read, rather than one entry per prop — a per-prop line for a class this
+  common is noise that teaches migrators to skim the report."
+  [props-node ctx]
+  (let [unread (->> (pairs props-node)
+                    (remove (fn [[_ v _]]
+                              (or (tag= v :token) (map-node? v) (vector-node? v)
+                                  (fn-literal? v)
+                                  (tag= v :quote)
+                                  ;; W4 read this one and rewrote it; a tool that
+                                  ;; reports its own rewrite as undecidable is
+                                  ;; crying wolf.
+                                  (reagent-call? v 'partial ctx))))
+                    (mapv (fn [[k _ _]] (str/trim (n/string k)))))]
+    (when (seq unread)
+      (entry :computed-value :refused {:props unread}
+             (str "These prop values are computed, so the tool cannot see what crosses. Three "
+                  "things a computed value may silently be, each of which diverges: a KEYWORD or "
+                  "symbol (Reagent named it, Hicasso keeps it whole), a NESTED MAP (Reagent "
+                  "camelCased its keys, Hicasso does not), or a non-fn `IFn` such as an "
+                  "`r/partial` reached through a symbol (Reagent wrapped it, Hicasso passes it "
+                  "opaque and the handler stops firing). Check each by hand.")))))
+
+(defn- suggestions
+  "The per-component suggestion block (§7.6), LABELLED AS GUESSES. The
+  tool suggests a declaration and never writes one: `:callbacks` synthesis
+  is never mechanical."
+  [head props-node]
+  (when props-node
+    (let [ps (pairs props-node)
+          ev (->> ps (keep (fn [[k _ _]] (let [kv (sexpr-safe k)]
+                                           (when (dest/event-prop? kv) (str/trim (n/string k))))))
+                  sort vec)
+          fns (->> ps (keep (fn [[k v _]] (when (fn-literal? v) (str/trim (n/string k)))))
+                   sort vec)]
+      (when (or (seq ev) (seq fns))
+        {:head head :event-slots ev :fn-slots fns}))))
+
+(defn plan-site
+  "Plan one site. Pure, and called by both passes — see this namespace's
+  docstring."
+  [node ctx]
+  (let [kind (site-kind node ctx)
+        head (head-text node kind)
+        base {:head head :entries [] :edit identity :suggest nil}]
+    (case kind
+      (:r> :f>)
+      (assoc base :entries
+             [(entry (if (= :r> kind) :r>-site :f>-site) :refused {}
+                     (str "Port this by hand. Hicasso reads `" (name (head-keyword node))
+                          "` as an ordinary tag keyword and renders an unknown element — nothing "
+                          "throws, nothing warns, and the component never mounts."))])
+
+      (:raw :adapt)
+      (let [pidx     (props-index kind)
+            slot     (element-at node pidx)
+            props    (when (map-node? slot) slot)
+            computed? (and slot (not props) (not (child-literal? slot)))
+            head-node (element-at node 1)
+            head-str  (when (and (= :raw kind) (tag= head-node :token)) (sexpr-safe head-node))
+            plain-tag? (and (string? head-str)
+                            (re-matches #"[A-Za-z][A-Za-z0-9-]*" head-str))
+            ;; W6 fires only when the head is a plain tag string AND no prop
+            ;; would go live at a native destination.
+            carrier?  (and props
+                           (some (fn [[k v _]]
+                                   (and (dest/event-prop? (sexpr-safe k))
+                                        (or (vector-node? v) (map-node? v))))
+                                 (pairs props)))
+            w6-cand?  (and (= :raw kind) plain-tag?)
+            w6?       (and w6-cand? (not carrier?))
+            ctx       (assoc ctx :w6-candidate? w6-cand? :native? w6?)
+
+            ;; ---- the props walk -------------------------------------------
+            ;; Always walked, even at a W6 site: the head repair must not
+            ;; suppress a refusal. `:native?` is what suppresses the two
+            ;; rewrites that are fixpoints at a native tag; W1, W4 and every
+            ;; refusal class still fire there (§4.6).
+            pp        (when props (plan-props props ctx))
+            ;; W2 runs per nested literal map value, under the props walk
+            w2        (when (and props (not w6?))
+                        (reduce (fn [acc [k v i]]
+                                  (if (map-node? v)
+                                    (let [sub (w2-map-plan v [(str/trim (n/string k))])]
+                                      (cond-> (update acc :entries into (:entries sub))
+                                        (:changed? sub)
+                                        (-> (update :edit (fn [f] (fn [nd]
+                                                                    (let [nd (f nd)]
+                                                                      (replace-element nd (inc i)
+                                                                                       ((:edit sub) (element-at nd (inc i))))))))
+                                            (update :entries conj (w2-entry (str/trim (n/string k))
+                                                                            (:respelled sub))))))
+                                    acc))
+                                {:edit identity :entries []}
+                                (pairs props)))
+
+            ;; ---- W1 ---------------------------------------------------------
+            meta-keys (:meta-keys ctx)
+            props-key (when props
+                        (some (fn [[k _ _]] (when (= :key (sexpr-safe k)) k)) (pairs props)))
+            w1?       (and (= 1 (count meta-keys)) (not props-key) (or props (not computed?)))
+            w1-clash? (and (seq meta-keys) (or (> (count meta-keys) 1) props-key))
+            w1-blocked? (and (= 1 (count meta-keys)) (not props-key) computed?)
+
+            entries (cond-> []
+                      computed?
+                      (conj (entry :computed-props :refused
+                                   {:slot (str/trim (n/string slot))}
+                                   (str "The slot after the head is neither a literal map nor "
+                                        "obviously a child, so the tool could not tell props from "
+                                        "a child and left the whole site alone. Every prop-level "
+                                        "repair is unavailable here — check this site by hand.")))
+
+                      w1-clash?
+                      (conj (entry :key-conflict :refused {}
+                                   (str "Both a `^{:key …}` and a props `:key` are present. "
+                                        "Reagent's metadata key WON, because `native-element` sets "
+                                        "it after `convert-props` has run — so preserving your "
+                                        "current behaviour would mean OVERWRITING the `:key` you "
+                                        "wrote in the map, and an overwrite is a decision. Delete "
+                                        "whichever one is dead and re-run.")))
+
+                      w1-blocked?
+                      (conj (entry :computed-props :refused {}
+                                   (str "A `^{:key …}` needs a props map to move into and the "
+                                        "props slot is computed, so the key cannot be relocated. "
+                                        "It will go DEAD at the migration — move it by hand.")))
+
+                      (:cljc? ctx)
+                      (conj (entry :cljc-site :refused {}
+                                   (str "This crossing is in a `.cljc` file. `[:>]` is a "
+                                        "ClojureScript-only node — the JVM side of this file has "
+                                        "no React to cross into — so check that this branch is "
+                                        "reader-conditioned to `:cljs`.")))
+
+                      (and props (subtree-has-reagent-call? props 'as-element ctx))
+                      (conj (entry :as-element-island :refused {}
+                                   (str "An `r/as-element` inside a callback body at this site. "
+                                        "Port it by hand: the closure runs when the library calls "
+                                        "it, OUTSIDE the owner's render window, so swapping "
+                                        "Reagent's lowering for Hicasso's is not a text "
+                                        "substitution.")))
+
+                      (and props (some #(subtree-has-reagent-call? props % ctx)
+                                       '[atom cursor track reaction create-class with-let]))
+                      (conj (entry :reagent-api-residue :refused {}
+                                   (str "Reagent API — `r/atom`, `r/cursor`, `r/track`, a form-2 or "
+                                        "form-3 shape — inside this site. That is outside this "
+                                        "tool's fence entirely; it is named here so you are not "
+                                        "surprised by it later."))))
+
+            cv      (when props (computed-value-entry props ctx))
+            entries (cond-> entries cv (conj cv))
+
+            ;; ---- heads ------------------------------------------------------
+            head-entries
+            (cond
+              (= :adapt kind)
+              [(entry :adapt-react-class-head :rewrote {:head head}
+                      (str "`vec-to-elem` sent a `NativeWrapper` head and a `[:> C …]` head to the "
+                           "SAME `native-element`, with the props slot at a different index — two "
+                           "spellings of one path. Respelled as `[:> …]`, which is the form "
+                           "Hicasso accepts; left alone it is a head Hicasso answers with "
+                           "`:rf.error/hicasso-bad-head`."))]
+
+              w6?
+              [(entry :string-tag-head :rewrote {:head head-str}
+                      (str "Under Reagent `[:> \"" head-str "\" …]` took the controlled-input "
+                           "wrapper when the tag was `input` or `textarea`, because "
+                           "`input-component?` matches on exactly this path. Under Hicasso a "
+                           "string head is REFUSED at the crossing. Rewritten to `[:" head-str
+                           " …]`, which lands the site on Hicasso's own controlled door — the "
+                           "taught form. Reagent's deep camelCasing and its `(name …)` arm are "
+                           "both present at a native tag, so the prop rewrites are fixpoints here "
+                           "and are deliberately not applied."))]
+
+              (and (= :raw kind) (string? head-str) (not plain-tag?))
+              [(entry :string-tag-unparseable :refused {:head head-str}
+                      (str "This string head was ALREADY BROKEN under Reagent: the `:>` path never "
+                           "parsed the `#`/`.` shorthand, so `createElement(\"" head-str "\")` "
+                           "asked React for an element that does not exist. Rewriting it to a "
+                           "native tag would PARSE the shorthand and the site would start "
+                           "behaving differently, so it is left for you."))]
+
+              (and (= :raw kind) (string? head-str) plain-tag? carrier?)
+              []                       ; the carrier entry above already explains the refusal
+
+              :else [])
+
+            entries (into entries head-entries)
+            entries (into entries (:entries pp))
+            entries (into entries (:entries w2))
+
+            ;; ---- the edit ---------------------------------------------------
+            key-node  (first meta-keys)
+            props-edit (apply comp (keep :edit [w2 pp]))
+            edit
+            (fn [nd]
+              (let [;; 1. The head repair, which is the only edit that moves
+                    ;;    the props slot. `pidx*` is where the props map sits
+                    ;;    once the head is settled.
+                    [nd pidx*]
+                    (cond
+                      ;; W5 — `[(r/adapt-react-class X) props …]` → `[:> X props …]`.
+                      ;; `nd` inside the second form is still the ORIGINAL node,
+                      ;; so element 0 is the adapt call the component is read out of.
+                      (= :adapt kind)
+                      [(-> nd
+                           (replace-element 0 (n/token-node :>))
+                           (insert-element 1 (element-at (element-at nd 0) 1)))
+                       2]
+
+                      ;; W6 — `[:> "input" props …]` → `[:input props …]`.
+                      ;; The `:>` head becomes the tag and the string goes away,
+                      ;; so the props slot moves down one.
+                      w6?
+                      [(-> nd
+                           (replace-element 0 (n/token-node (keyword head-str)))
+                           (remove-element 1))
+                       1]
+
+                      :else [nd 2])
+
+                    ;; 2. The props rewrites, applied in place.
+                    nd (if props (replace-element nd pidx* (props-edit (element-at nd pidx*))) nd)]
+
+                ;; 3. W1 — mint the props map, or extend the one that is there.
+                (if w1?
+                  (if props
+                    (replace-element nd pidx*
+                                     (let [m (element-at nd pidx*)]
+                                       (n/replace-children
+                                        m (concat (n/children m)
+                                                  (when (seq (elements m)) [(n/spaces 1)])
+                                                  [(n/token-node :key) (n/spaces 1) key-node]))))
+                    (insert-element nd pidx*
+                                    (n/map-node [(n/token-node :key) (n/spaces 1) key-node])))
+                  nd)))]
+
+        (assoc base
+               :kind kind
+               :w1? w1?
+               :entries (cond-> entries
+                          w1? (conj (entry :metadata-key :rewrote
+                                           {:key (str/trim (n/string key-node))}
+                                           (meta-key-note))))
+               :suggest (suggestions head props)
+               :edit edit))
+
+      base)))

--- a/migration/reagent-to-hicasso/codemod/test/corpus/cljc-site/expected-report.edn
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/cljc-site/expected-report.edn
@@ -1,0 +1,16 @@
+[{:line 8,
+  :col 3,
+  :class :cljc-site,
+  :action :refused,
+  :head "Btn",
+  :detail {},
+  :note
+  "This crossing is in a `.cljc` file. `[:>]` is a ClojureScript-only node — the JVM side of this file has no React to cross into — so check that this branch is reader-conditioned to `:cljs`."}
+ {:line 8,
+  :col 3,
+  :class :named-value,
+  :action :rewrote,
+  :head "Btn",
+  :detail {:prop ":variant", :was ":contained", :now "contained"},
+  :note
+  "Reagent named every keyword and symbol prop value; Hicasso keeps them whole except at HTML-attribute slots. The string is a fixpoint on both walks."}]

--- a/migration/reagent-to-hicasso/codemod/test/corpus/cljc-site/expected.cljc
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/cljc-site/expected.cljc
@@ -1,0 +1,8 @@
+(ns app.shared
+  "§5.1 `:cljc-site` — a `[:>]` inside a `.cljc` file. The crossing is
+  ClojureScript-only at that node: the JVM side of this file has no React
+  to cross into."
+  (:require [reagent.core :as r]))
+
+(defn a-crossing-in-shared-source []
+  [:> Btn {:variant "contained"}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/cljc-site/input.cljc
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/cljc-site/input.cljc
@@ -1,0 +1,8 @@
+(ns app.shared
+  "§5.1 `:cljc-site` — a `[:>]` inside a `.cljc` file. The crossing is
+  ClojureScript-only at that node: the JVM side of this file has no React
+  to cross into."
+  (:require [reagent.core :as r]))
+
+(defn a-crossing-in-shared-source []
+  [:> Btn {:variant :contained}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/preserved-and-clean/expected-report.edn
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/preserved-and-clean/expected-report.edn
@@ -1,0 +1,8 @@
+[{:line 22,
+  :col 3,
+  :class :computed-value,
+  :action :refused,
+  :head "Btn",
+  :detail {:props [":on-click"]},
+  :note
+  "These prop values are computed, so the tool cannot see what crosses. Three things a computed value may silently be, each of which diverges: a KEYWORD or symbol (Reagent named it, Hicasso keeps it whole), a NESTED MAP (Reagent camelCased its keys, Hicasso does not), or a non-fn `IFn` such as an `r/partial` reached through a symbol (Reagent wrapped it, Hicasso passes it opaque and the handler stops firing). Check each by hand."}]

--- a/migration/reagent-to-hicasso/codemod/test/corpus/preserved-and-clean/expected.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/preserved-and-clean/expected.cljs
@@ -1,0 +1,28 @@
+(ns app.clean
+  "§5.4 — divergences the tool deliberately does NOT repair, each because
+  Hicasso is better than the donor or the difference is invisible. The
+  report is written on a clean run too, so \"not in the report\" is never
+  ambiguous."
+  (:require [reagent.core :as r]))
+
+(defn a-class-collection-under-any-spelling []
+  ;; Reagent read the literal `:class` key only, so this reached React as
+  ;; a `clj->js` array and the DOM wrote it "a,b". Hicasso coerces and
+  ;; composes at the slot in every spelling.
+  [:> Btn {:className ["a" "b"]}])
+
+(defn a-nested-class-collection []
+  ;; Reagent's `class-names` does not recurse; Hicasso's does.
+  [:> Btn {:class ["a" ["b" "c"]]}])
+
+(defn a-literal-nil-at-the-props-slot []
+  [:> Btn nil "child"])
+
+(defn scalars-and-functions-cross-unchanged []
+  [:> Btn {:label "due date" :count 7 :open true :on-click handler}])
+
+(defn a-js-literal-is-passed-through-by-both []
+  [:> Btn {:opts #js {:first-name "a"}}])
+
+(defn no-props-and-no-children []
+  [:> Btn])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/preserved-and-clean/input.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/preserved-and-clean/input.cljs
@@ -1,0 +1,28 @@
+(ns app.clean
+  "§5.4 — divergences the tool deliberately does NOT repair, each because
+  Hicasso is better than the donor or the difference is invisible. The
+  report is written on a clean run too, so \"not in the report\" is never
+  ambiguous."
+  (:require [reagent.core :as r]))
+
+(defn a-class-collection-under-any-spelling []
+  ;; Reagent read the literal `:class` key only, so this reached React as
+  ;; a `clj->js` array and the DOM wrote it "a,b". Hicasso coerces and
+  ;; composes at the slot in every spelling.
+  [:> Btn {:className ["a" "b"]}])
+
+(defn a-nested-class-collection []
+  ;; Reagent's `class-names` does not recurse; Hicasso's does.
+  [:> Btn {:class ["a" ["b" "c"]]}])
+
+(defn a-literal-nil-at-the-props-slot []
+  [:> Btn nil "child"])
+
+(defn scalars-and-functions-cross-unchanged []
+  [:> Btn {:label "due date" :count 7 :open true :on-click handler}])
+
+(defn a-js-literal-is-passed-through-by-both []
+  [:> Btn {:opts #js {:first-name "a"}}])
+
+(defn no-props-and-no-children []
+  [:> Btn])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/refusals-that-need-a-person/expected-report.edn
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/refusals-that-need-a-person/expected-report.edn
@@ -1,0 +1,88 @@
+[{:line 9,
+  :col 3,
+  :class :intent-needs-a-declaration,
+  :action :refused,
+  :head "C",
+  :detail {:prop ":on-click", :value "[:save!]"},
+  :note
+  "MIGRATION BLOCKER, and the one place Hicasso refuses something Reagent accepted. `host-entry` refuses an intent vector or key-map at an event-spelled prop the declaration does not name, and a `[:>]` crossing declares nothing — so this site will THROW at render. Know first that it never fired under Reagent either: it crossed as an inert array. Either declare the crossing with `defhost` and name this prop in `:callbacks`, or hand it a plain function."}
+ {:line 12,
+  :col 3,
+  :class :intent-needs-a-declaration,
+  :action :refused,
+  :head "C",
+  :detail {:prop ":on-key-down", :value "{\"Enter\" [:save!]}"},
+  :note
+  "MIGRATION BLOCKER, and the one place Hicasso refuses something Reagent accepted. `host-entry` refuses an intent vector or key-map at an event-spelled prop the declaration does not name, and a `[:>]` crossing declares nothing — so this site will THROW at render. Know first that it never fired under Reagent either: it crossed as an inert array. Either declare the crossing with `defhost` and name this prop in `:callbacks`, or hand it a plain function."}
+ {:line 15,
+  :col 3,
+  :class :dangerous-html,
+  :action :refused,
+  :head "C",
+  :detail {:prop ":dangerouslySetInnerHTML"},
+  :note
+  "MIGRATION BLOCKER. Reagent's `convert-props` DELETED this prop unless its value was an `UnsafeHTML` instance, so under Reagent it very likely did nothing at all. Hicasso passes it through, so the migration RESURRECTS it and the HTML starts being injected. Decide deliberately whether you want that."}
+ {:line 18,
+  :col 3,
+  :class :amp-key,
+  :action :refused,
+  :head "C",
+  :detail {:prop ":&"},
+  :note
+  "Reagent emitted a prop LITERALLY NAMED \"&\"; Hicasso reads `:&` as its one attribute merge, folding the map into this element's own attributes under the owned-literal law. Two unrelated meanings for one literal and your intent is unrecoverable from the text — decide which you meant."}
+ {:line 21,
+  :col 3,
+  :class :as-element-island,
+  :action :refused,
+  :head "Grid",
+  :detail {},
+  :note
+  "An `r/as-element` inside a callback body at this site. Port it by hand: the closure runs when the library calls it, OUTSIDE the owner's render window, so swapping Reagent's lowering for Hicasso's is not a text substitution."}
+ {:line 24,
+  :col 3,
+  :class :reagent-api-residue,
+  :action :refused,
+  :head "C",
+  :detail {},
+  :note
+  "Reagent API — `r/atom`, `r/cursor`, `r/track`, a form-2 or form-3 shape — inside this site. That is outside this tool's fence entirely; it is named here so you are not surprised by it later."}
+ {:line 24,
+  :col 3,
+  :class :computed-value,
+  :action :refused,
+  :head "C",
+  :detail {:props [":value"]},
+  :note
+  "These prop values are computed, so the tool cannot see what crosses. Three things a computed value may silently be, each of which diverges: a KEYWORD or symbol (Reagent named it, Hicasso keeps it whole), a NESTED MAP (Reagent camelCased its keys, Hicasso does not), or a non-fn `IFn` such as an `r/partial` reached through a symbol (Reagent wrapped it, Hicasso passes it opaque and the handler stops firing). Check each by hand."}
+ {:line 27,
+  :col 3,
+  :class :computed-props,
+  :action :refused,
+  :head "C",
+  :detail {:slot "(merge base extra)"},
+  :note
+  "The slot after the head is neither a literal map nor obviously a child, so the tool could not tell props from a child and left the whole site alone. Every prop-level repair is unavailable here — check this site by hand."}
+ {:line 30,
+  :col 3,
+  :class :computed-value,
+  :action :refused,
+  :head "C",
+  :detail {:props [":variant" ":other"]},
+  :note
+  "These prop values are computed, so the tool cannot see what crosses. Three things a computed value may silently be, each of which diverges: a KEYWORD or symbol (Reagent named it, Hicasso keeps it whole), a NESTED MAP (Reagent camelCased its keys, Hicasso does not), or a non-fn `IFn` such as an `r/partial` reached through a symbol (Reagent wrapped it, Hicasso passes it opaque and the handler stops firing). Check each by hand."}
+ {:line 33,
+  :col 3,
+  :class :r>-site,
+  :action :refused,
+  :head "C",
+  :detail {},
+  :note
+  "Port this by hand. Hicasso reads `r>` as an ordinary tag keyword and renders an unknown element — nothing throws, nothing warns, and the component never mounts."}
+ {:line 36,
+  :col 3,
+  :class :f>-site,
+  :action :refused,
+  :head "C",
+  :detail {},
+  :note
+  "Port this by hand. Hicasso reads `f>` as an ordinary tag keyword and renders an unknown element — nothing throws, nothing warns, and the component never mounts."}]

--- a/migration/reagent-to-hicasso/codemod/test/corpus/refusals-that-need-a-person/expected.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/refusals-that-need-a-person/expected.cljs
@@ -1,0 +1,36 @@
+(ns app.refusals
+  "The refusal set (design §5). A refused site still WORKS — `[:>]` is
+  legal, so leaving it alone is a valid output — and the report is what
+  turns a refusal from silence into an instruction."
+  (:require [reagent.core :as r]))
+
+(defn an-intent-vector-at-an-event-slot []
+  ;; Silently dead under Reagent; throws at render under Hicasso.
+  [:> C {:on-click [:save!]}])
+
+(defn a-key-map-at-an-event-slot []
+  [:> C {:on-key-down {"Enter" [:save!]}}])
+
+(defn dangerously-set-inner-html-is-resurrected []
+  [:> C {:dangerouslySetInnerHTML {:__html markup}}])
+
+(defn the-ampersand-key []
+  [:> C {:& {:a 1}}])
+
+(defn an-as-element-island []
+  [:> Grid {:on-render-cell (fn [row] (r/as-element [:span (:name row)]))}])
+
+(defn reagent-api-residue []
+  [:> C {:value @(r/atom 1)}])
+
+(defn a-computed-props-slot []
+  [:> C (merge base extra) "kid"])
+
+(defn a-computed-prop-value []
+  [:> C {:variant (pick-variant x) :other (compute y)}])
+
+(defn the-r-arrow-site []
+  [:r> C {:a 1}])
+
+(defn the-f-arrow-site []
+  [:f> C {:a 1}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/refusals-that-need-a-person/input.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/refusals-that-need-a-person/input.cljs
@@ -1,0 +1,36 @@
+(ns app.refusals
+  "The refusal set (design §5). A refused site still WORKS — `[:>]` is
+  legal, so leaving it alone is a valid output — and the report is what
+  turns a refusal from silence into an instruction."
+  (:require [reagent.core :as r]))
+
+(defn an-intent-vector-at-an-event-slot []
+  ;; Silently dead under Reagent; throws at render under Hicasso.
+  [:> C {:on-click [:save!]}])
+
+(defn a-key-map-at-an-event-slot []
+  [:> C {:on-key-down {"Enter" [:save!]}}])
+
+(defn dangerously-set-inner-html-is-resurrected []
+  [:> C {:dangerouslySetInnerHTML {:__html markup}}])
+
+(defn the-ampersand-key []
+  [:> C {:& {:a 1}}])
+
+(defn an-as-element-island []
+  [:> Grid {:on-render-cell (fn [row] (r/as-element [:span (:name row)]))}])
+
+(defn reagent-api-residue []
+  [:> C {:value @(r/atom 1)}])
+
+(defn a-computed-props-slot []
+  [:> C (merge base extra) "kid"])
+
+(defn a-computed-prop-value []
+  [:> C {:variant (pick-variant x) :other (compute y)}])
+
+(defn the-r-arrow-site []
+  [:r> C {:a 1}])
+
+(defn the-f-arrow-site []
+  [:f> C {:a 1}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w1-metadata-key/expected-report.edn
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w1-metadata-key/expected-report.edn
@@ -1,0 +1,72 @@
+[{:line 10,
+  :col 23,
+  :class :computed-value,
+  :action :refused,
+  :head "Row",
+  :detail {:props [":label"]},
+  :note
+  "These prop values are computed, so the tool cannot see what crosses. Three things a computed value may silently be, each of which diverges: a KEYWORD or symbol (Reagent named it, Hicasso keeps it whole), a NESTED MAP (Reagent camelCased its keys, Hicasso does not), or a non-fn `IFn` such as an `r/partial` reached through a symbol (Reagent wrapped it, Hicasso passes it opaque and the handler stops firing). Check each by hand."}
+ {:line 10,
+  :col 23,
+  :class :metadata-key,
+  :action :rewrote,
+  :head "Row",
+  :detail {:key "(:id row)"},
+  :note
+  "Reagent read a `^{:key …}` on the vector AFTER converting the props, so a metadata key BEAT a props `:key`. Hicasso's `raw-element` reads `(:key props)` and contains no `(meta …)` read at all, so this key would have gone dead at the migration with no diagnostic from either Hicasso or React beyond React's own parent-deduped warning. Moved into the props map, where the destination reads it."}
+ {:line 14,
+  :col 23,
+  :class :metadata-key,
+  :action :rewrote,
+  :head "Row",
+  :detail {:key "(:id row)"},
+  :note
+  "Reagent read a `^{:key …}` on the vector AFTER converting the props, so a metadata key BEAT a props `:key`. Hicasso's `raw-element` reads `(:key props)` and contains no `(meta …)` read at all, so this key would have gone dead at the migration with no diagnostic from either Hicasso or React beyond React's own parent-deduped warning. Moved into the props map, where the destination reads it."}
+ {:line 18,
+  :col 23,
+  :class :metadata-key,
+  :action :rewrote,
+  :head "Row",
+  :detail {:key "(:id row)"},
+  :note
+  "Reagent read a `^{:key …}` on the vector AFTER converting the props, so a metadata key BEAT a props `:key`. Hicasso's `raw-element` reads `(:key props)` and contains no `(meta …)` read at all, so this key would have gone dead at the migration with no diagnostic from either Hicasso or React beyond React's own parent-deduped warning. Moved into the props map, where the destination reads it."}
+ {:line 21,
+  :col 22,
+  :class :metadata-key,
+  :action :rewrote,
+  :head "Row",
+  :detail {:key "1"},
+  :note
+  "Reagent read a `^{:key …}` on the vector AFTER converting the props, so a metadata key BEAT a props `:key`. Hicasso's `raw-element` reads `(:key props)` and contains no `(meta …)` read at all, so this key would have gone dead at the migration with no diagnostic from either Hicasso or React beyond React's own parent-deduped warning. Moved into the props map, where the destination reads it."}
+ {:line 26,
+  :col 21,
+  :class :key-conflict,
+  :action :refused,
+  :head "Row",
+  :detail {},
+  :note
+  "Both a `^{:key …}` and a props `:key` are present. Reagent's metadata key WON, because `native-element` sets it after `convert-props` has run — so preserving your current behaviour would mean OVERWRITING the `:key` you wrote in the map, and an overwrite is a decision. Delete whichever one is dead and re-run."}
+ {:line 26,
+  :col 21,
+  :class :computed-value,
+  :action :refused,
+  :head "Row",
+  :detail {:props [":key"]},
+  :note
+  "These prop values are computed, so the tool cannot see what crosses. Three things a computed value may silently be, each of which diverges: a KEYWORD or symbol (Reagent named it, Hicasso keeps it whole), a NESTED MAP (Reagent camelCased its keys, Hicasso does not), or a non-fn `IFn` such as an `r/partial` reached through a symbol (Reagent wrapped it, Hicasso passes it opaque and the handler stops firing). Check each by hand."}
+ {:line 29,
+  :col 13,
+  :class :computed-props,
+  :action :refused,
+  :head "Row",
+  :detail {:slot "(merge base extra)"},
+  :note
+  "The slot after the head is neither a literal map nor obviously a child, so the tool could not tell props from a child and left the whole site alone. Every prop-level repair is unavailable here — check this site by hand."}
+ {:line 29,
+  :col 13,
+  :class :computed-props,
+  :action :refused,
+  :head "Row",
+  :detail {},
+  :note
+  "A `^{:key …}` needs a props map to move into and the props slot is computed, so the key cannot be relocated. It will go DEAD at the migration — move it by hand."}]

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w1-metadata-key/expected.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w1-metadata-key/expected.cljs
@@ -1,0 +1,29 @@
+(ns app.w1
+  "W1 — the metadata key (design §4.1). `grep` for `(meta ` across the
+  codec returns nothing, so a migrated seq of keyed crossings loses every
+  key at every build with no diagnostic. This is the highest-value
+  rewrite in the design."
+  (:require [reagent.core :as r]))
+
+(defn extends-an-existing-props-map []
+  (for [row rows]
+    [:> Row {:label (:label row) :key (:id row)}]))
+
+(defn mints-a-props-map-when-there-is-none []
+  (for [row rows]
+    [:> Row {:key (:id row)}]))
+
+(defn mints-one-in-front-of-children []
+  (for [row rows]
+    [:> Row {:key (:id row)} "just a child"]))
+
+(defn keeps-other-metadata []
+  ^{:tag "x"} [:> Row {:a 1 :key 1}])
+
+(defn refuses-a-conflict []
+  ;; Reagent's metadata key WON here, so relocating it would have to
+  ;; overwrite the props `:key` the author wrote. That is a decision.
+  ^{:key (:id row)} [:> Row {:key (:fallback row)}])
+
+(defn refuses-when-the-props-slot-is-computed []
+  ^{:key 1} [:> Row (merge base extra)])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w1-metadata-key/input.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w1-metadata-key/input.cljs
@@ -1,0 +1,29 @@
+(ns app.w1
+  "W1 — the metadata key (design §4.1). `grep` for `(meta ` across the
+  codec returns nothing, so a migrated seq of keyed crossings loses every
+  key at every build with no diagnostic. This is the highest-value
+  rewrite in the design."
+  (:require [reagent.core :as r]))
+
+(defn extends-an-existing-props-map []
+  (for [row rows]
+    ^{:key (:id row)} [:> Row {:label (:label row)}]))
+
+(defn mints-a-props-map-when-there-is-none []
+  (for [row rows]
+    ^{:key (:id row)} [:> Row]))
+
+(defn mints-one-in-front-of-children []
+  (for [row rows]
+    ^{:key (:id row)} [:> Row "just a child"]))
+
+(defn keeps-other-metadata []
+  ^{:key 1 :tag "x"} [:> Row {:a 1}])
+
+(defn refuses-a-conflict []
+  ;; Reagent's metadata key WON here, so relocating it would have to
+  ;; overwrite the props `:key` the author wrote. That is a decision.
+  ^{:key (:id row)} [:> Row {:key (:fallback row)}])
+
+(defn refuses-when-the-props-slot-is-computed []
+  ^{:key 1} [:> Row (merge base extra)])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w2-nested-map-keys/expected-report.edn
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w2-nested-map-keys/expected-report.edn
@@ -1,0 +1,74 @@
+[{:line 9,
+  :col 3,
+  :class :nested-map-keys,
+  :action :rewrote,
+  :head "Chart",
+  :detail
+  {:path ":options",
+   :respelled
+   [[":first-name" ":firstName"] [":page-size" ":pageSize"]]},
+  :note
+  "Reagent camelCased these nested keys on the way across; Hicasso does not, so the spelling is now written into your source where the library will actually read it. IF A KEY HERE IS DATA RATHER THAN A LIBRARY OPTION, THIS REWRITE IS THE MOMENT TO NOTICE — tidying it back to the spelling you originally wrote will silently change what the library receives."}
+ {:line 12,
+  :col 3,
+  :class :nested-map-keys,
+  :action :rewrote,
+  :head "Chart",
+  :detail
+  {:path ":cfg",
+   :respelled
+   [[":charset" ":charSet"]
+    [":class" ":className"]
+    [":for" ":htmlFor"]]},
+  :note
+  "Reagent camelCased these nested keys on the way across; Hicasso does not, so the spelling is now written into your source where the library will actually read it. IF A KEY HERE IS DATA RATHER THAN A LIBRARY OPTION, THIS REWRITE IS THE MOMENT TO NOTICE — tidying it back to the spelling you originally wrote will silently change what the library receives."}
+ {:line 15,
+  :col 3,
+  :class :nested-map-keys,
+  :action :rewrote,
+  :head "Chart",
+  :detail {:path ":cfg", :respelled [[":other-key" ":otherKey"]]},
+  :note
+  "Reagent camelCased these nested keys on the way across; Hicasso does not, so the spelling is now written into your source where the library will actually read it. IF A KEY HERE IS DATA RATHER THAN A LIBRARY OPTION, THIS REWRITE IS THE MOMENT TO NOTICE — tidying it back to the spelling you originally wrote will silently change what the library receives."}
+ {:line 21,
+  :col 3,
+  :class :nested-map-keys,
+  :action :rewrote,
+  :head "Chart",
+  :detail
+  {:path ":outer",
+   :respelled [[":deep-key" ":deepKey"] [":inner-map" ":innerMap"]]},
+  :note
+  "Reagent camelCased these nested keys on the way across; Hicasso does not, so the spelling is now written into your source where the library will actually read it. IF A KEY HERE IS DATA RATHER THAN A LIBRARY OPTION, THIS REWRITE IS THE MOMENT TO NOTICE — tidying it back to the spelling you originally wrote will silently change what the library receives."}
+ {:line 29,
+  :col 3,
+  :class :css-var-repair,
+  :action :refused,
+  :head "Chart",
+  :detail {:path [":style" ":--brand-color"]},
+  :note
+  "Reagent's `dash-to-prop-name` mangled this CSS custom property into a style key nothing reads, so the declaration never took effect. Hicasso preserves it and React routes a `--`-prefixed key through `setProperty`. The key is left alone and THE SITE STARTS WORKING — check that the style it now applies is the one you want."}
+ {:line 29,
+  :col 3,
+  :class :nested-map-keys,
+  :action :rewrote,
+  :head "Chart",
+  :detail {:path ":style", :respelled [[":font-size" ":fontSize"]]},
+  :note
+  "Reagent camelCased these nested keys on the way across; Hicasso does not, so the spelling is now written into your source where the library will actually read it. IF A KEY HERE IS DATA RATHER THAN A LIBRARY OPTION, THIS REWRITE IS THE MOMENT TO NOTICE — tidying it back to the spelling you originally wrote will silently change what the library receives."}
+ {:line 32,
+  :col 3,
+  :class :computed-nested-key,
+  :action :refused,
+  :head "Chart",
+  :detail {:path [":cfg" "(key-for x)"]},
+  :note
+  "This map key is not a literal keyword, symbol or string, so the tool cannot compute what Reagent spelled it as. It keeps the spelling you wrote, and the collision check above could not see it either."}
+ {:line 32,
+  :col 3,
+  :class :nested-map-keys,
+  :action :rewrote,
+  :head "Chart",
+  :detail {:path ":cfg", :respelled [[":page-size" ":pageSize"]]},
+  :note
+  "Reagent camelCased these nested keys on the way across; Hicasso does not, so the spelling is now written into your source where the library will actually read it. IF A KEY HERE IS DATA RATHER THAN A LIBRARY OPTION, THIS REWRITE IS THE MOMENT TO NOTICE — tidying it back to the spelling you originally wrote will silently change what the library receives."}]

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w2-nested-map-keys/expected.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w2-nested-map-keys/expected.cljs
@@ -1,0 +1,32 @@
+(ns app.w2
+  "W2 — nested map keys (design §4.2). Reagent's `convert-prop-value`
+  recurses through the `map?` arm, respelling every key with
+  `cached-prop-name`; Hicasso sends the same map to `clj->js`, whose keys
+  keep the spelling the author wrote."
+  (:require [reagent.core :as r]))
+
+(defn the-kebab-to-camel-rule []
+  [:> Chart {:options {:pageSize 10 :firstName "a"}}])
+
+(defn the-three-seeded-renames []
+  [:> Chart {:cfg {:className "c" :htmlFor "f" :charSet "utf-8"}}])
+
+(defn aria-and-data-are-exempt []
+  [:> Chart {:cfg {:aria-label "x" :data-kind "y" :otherKey "z"}}])
+
+(defn a-string-key-is-already-a-fixpoint []
+  [:> Chart {:cfg {"first-name" 1}}])
+
+(defn the-recursion-walks-through-maps []
+  [:> Chart {:outer {:innerMap {:deepKey 1}}}])
+
+(defn the-recursion-stops-at-the-first-non-map-collection []
+  ;; Reagent reached these maps by the `coll?` arm, which is `clj->js`
+  ;; and does not camelCase. So neither does W2.
+  [:> Chart {:menu-items [{:day-of-week 1}] :tags #{{:other-key 2}}}])
+
+(defn a-css-custom-property-is-repaired-not-preserved []
+  [:> Chart {:style {:--brand-color "red" :fontSize 12}}])
+
+(defn a-computed-nested-key-keeps-its-spelling []
+  [:> Chart {:cfg {(key-for x) 1 :pageSize 2}}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w2-nested-map-keys/input.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w2-nested-map-keys/input.cljs
@@ -1,0 +1,32 @@
+(ns app.w2
+  "W2 — nested map keys (design §4.2). Reagent's `convert-prop-value`
+  recurses through the `map?` arm, respelling every key with
+  `cached-prop-name`; Hicasso sends the same map to `clj->js`, whose keys
+  keep the spelling the author wrote."
+  (:require [reagent.core :as r]))
+
+(defn the-kebab-to-camel-rule []
+  [:> Chart {:options {:page-size 10 :first-name "a"}}])
+
+(defn the-three-seeded-renames []
+  [:> Chart {:cfg {:class "c" :for "f" :charset "utf-8"}}])
+
+(defn aria-and-data-are-exempt []
+  [:> Chart {:cfg {:aria-label "x" :data-kind "y" :other-key "z"}}])
+
+(defn a-string-key-is-already-a-fixpoint []
+  [:> Chart {:cfg {"first-name" 1}}])
+
+(defn the-recursion-walks-through-maps []
+  [:> Chart {:outer {:inner-map {:deep-key 1}}}])
+
+(defn the-recursion-stops-at-the-first-non-map-collection []
+  ;; Reagent reached these maps by the `coll?` arm, which is `clj->js`
+  ;; and does not camelCase. So neither does W2.
+  [:> Chart {:menu-items [{:day-of-week 1}] :tags #{{:other-key 2}}}])
+
+(defn a-css-custom-property-is-repaired-not-preserved []
+  [:> Chart {:style {:--brand-color "red" :font-size 12}}])
+
+(defn a-computed-nested-key-keeps-its-spelling []
+  [:> Chart {:cfg {(key-for x) 1 :page-size 2}}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w2-normalized-key-collisions/expected-report.edn
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w2-normalized-key-collisions/expected-report.edn
@@ -1,0 +1,56 @@
+[{:line 13,
+  :col 3,
+  :class :normalized-key-collision,
+  :action :refused,
+  :head "C",
+  :detail
+  {:path [":opts"],
+   :collisions [{:slot "fooBar", :keys [":foo-bar" ":fooBar"]}]},
+  :note
+  "Reagent wrote each of these keys under `cached-prop-name`, so the siblings named here COLLAPSED onto one JS property and an iteration-order winner decided which value the library saw. Respelling them would either mint a duplicate map key or silently pick a winner this tool cannot know was the one that won. The map is left exactly as written: decide which key you meant, delete the other, and re-run."}
+ {:line 16,
+  :col 3,
+  :class :normalized-key-collision,
+  :action :refused,
+  :head "C",
+  :detail
+  {:path [":opts"],
+   :collisions [{:slot "className", :keys [":class" ":className"]}]},
+  :note
+  "Reagent wrote each of these keys under `cached-prop-name`, so the siblings named here COLLAPSED onto one JS property and an iteration-order winner decided which value the library saw. Respelling them would either mint a duplicate map key or silently pick a winner this tool cannot know was the one that won. The map is left exactly as written: decide which key you meant, delete the other, and re-run."}
+ {:line 19,
+  :col 3,
+  :class :normalized-key-collision,
+  :action :refused,
+  :head "C",
+  :detail
+  {:path [":opts"],
+   :collisions [{:slot "fooBar", :keys ["\"fooBar\"" ":foo-bar"]}]},
+  :note
+  "Reagent wrote each of these keys under `cached-prop-name`, so the siblings named here COLLAPSED onto one JS property and an iteration-order winner decided which value the library saw. Respelling them would either mint a duplicate map key or silently pick a winner this tool cannot know was the one that won. The map is left exactly as written: decide which key you meant, delete the other, and re-run."}
+ {:line 24,
+  :col 3,
+  :class :normalized-key-collision,
+  :action :refused,
+  :head "C",
+  :detail
+  {:path [":opts"],
+   :collisions [{:slot "fooBar", :keys [":foo-bar" ":fooBar"]}]},
+  :note
+  "Reagent wrote each of these keys under `cached-prop-name`, so the siblings named here COLLAPSED onto one JS property and an iteration-order winner decided which value the library saw. Respelling them would either mint a duplicate map key or silently pick a winner this tool cannot know was the one that won. The map is left exactly as written: decide which key you meant, delete the other, and re-run."}
+ {:line 27,
+  :col 3,
+  :class :nested-map-keys,
+  :action :rewrote,
+  :head "C",
+  :detail {:path ":opts", :respelled [[":page-size" ":pageSize"]]},
+  :note
+  "Reagent camelCased these nested keys on the way across; Hicasso does not, so the spelling is now written into your source where the library will actually read it. IF A KEY HERE IS DATA RATHER THAN A LIBRARY OPTION, THIS REWRITE IS THE MOMENT TO NOTICE — tidying it back to the spelling you originally wrote will silently change what the library receives."}
+ {:line 27,
+  :col 3,
+  :class :nested-map-keys,
+  :action :rewrote,
+  :head "C",
+  :detail {:path ":other", :respelled [[":first-name" ":firstName"]]},
+  :note
+  "Reagent camelCased these nested keys on the way across; Hicasso does not, so the spelling is now written into your source where the library will actually read it. IF A KEY HERE IS DATA RATHER THAN A LIBRARY OPTION, THIS REWRITE IS THE MOMENT TO NOTICE — tidying it back to the spelling you originally wrote will silently change what the library receives."}]

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w2-normalized-key-collisions/expected.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w2-normalized-key-collisions/expected.cljs
@@ -1,0 +1,27 @@
+(ns app.w2-collisions
+  "AMENDMENT (B) — W2 must refuse normalized-key collisions.
+
+  Reagent's `kv-conv` writes each nested-map key under
+  `cached-prop-name`, so these siblings each collapse onto ONE JS
+  property with an iteration-order winner. Respelling both sources would
+  either mint a duplicate literal map key — which is not even readable
+  Clojure — or pick a winner the rewrite cannot know was the one that
+  won. The whole map is refused, and every colliding source key named."
+  (:require [reagent.core :as r]))
+
+(defn an-ordinary-camel-case-collision []
+  [:> C {:opts {:foo-bar 1 :fooBar 2}}])
+
+(defn a-seeded-rename-collision []
+  [:> C {:opts {:class "a" :className "b"}}])
+
+(defn a-keyword-string-collision []
+  [:> C {:opts {:foo-bar 1 "fooBar" 2}}])
+
+(defn the-refusal-is-of-the-whole-map []
+  ;; `:page-size` is rewritable and is NOT rewritten: a partial rewrite of
+  ;; a map whose emitted shape is already ambiguous is worse than none.
+  [:> C {:opts {:foo-bar 1 :fooBar 2 :page-size 10}}])
+
+(defn a-non-colliding-sibling-map-still-rewrites []
+  [:> C {:opts {:pageSize 10} :other {:firstName "a"}}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w2-normalized-key-collisions/input.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w2-normalized-key-collisions/input.cljs
@@ -1,0 +1,27 @@
+(ns app.w2-collisions
+  "AMENDMENT (B) — W2 must refuse normalized-key collisions.
+
+  Reagent's `kv-conv` writes each nested-map key under
+  `cached-prop-name`, so these siblings each collapse onto ONE JS
+  property with an iteration-order winner. Respelling both sources would
+  either mint a duplicate literal map key — which is not even readable
+  Clojure — or pick a winner the rewrite cannot know was the one that
+  won. The whole map is refused, and every colliding source key named."
+  (:require [reagent.core :as r]))
+
+(defn an-ordinary-camel-case-collision []
+  [:> C {:opts {:foo-bar 1 :fooBar 2}}])
+
+(defn a-seeded-rename-collision []
+  [:> C {:opts {:class "a" :className "b"}}])
+
+(defn a-keyword-string-collision []
+  [:> C {:opts {:foo-bar 1 "fooBar" 2}}])
+
+(defn the-refusal-is-of-the-whole-map []
+  ;; `:page-size` is rewritable and is NOT rewritten: a partial rewrite of
+  ;; a map whose emitted shape is already ambiguous is worse than none.
+  [:> C {:opts {:foo-bar 1 :fooBar 2 :page-size 10}}])
+
+(defn a-non-colliding-sibling-map-still-rewrites []
+  [:> C {:opts {:page-size 10} :other {:first-name "a"}}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w3-named-values/expected-report.edn
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w3-named-values/expected-report.edn
@@ -1,0 +1,48 @@
+[{:line 9,
+  :col 3,
+  :class :named-value,
+  :action :rewrote,
+  :head "Btn",
+  :detail {:prop ":variant", :was ":contained", :now "contained"},
+  :note
+  "Reagent named every keyword and symbol prop value; Hicasso keeps them whole except at HTML-attribute slots. The string is a fixpoint on both walks."}
+ {:line 13,
+  :col 3,
+  :class :named-value,
+  :action :rewrote,
+  :head "Btn",
+  :detail {:prop ":variant", :was "my-sym", :now "my-sym"},
+  :note
+  "Reagent named every keyword and symbol prop value; Hicasso keeps them whole except at HTML-attribute slots. The string is a fixpoint on both walks."}
+ {:line 21,
+  :col 3,
+  :class :computed-value,
+  :action :refused,
+  :head "Btn",
+  :detail {:props [":variant" ":on-click"]},
+  :note
+  "These prop values are computed, so the tool cannot see what crosses. Three things a computed value may silently be, each of which diverges: a KEYWORD or symbol (Reagent named it, Hicasso keeps it whole), a NESTED MAP (Reagent camelCased its keys, Hicasso does not), or a non-fn `IFn` such as an `r/partial` reached through a symbol (Reagent wrapped it, Hicasso passes it opaque and the handler stops firing). Check each by hand."}
+ {:line 24,
+  :col 3,
+  :class :namespaced-named-value,
+  :action :rewrote,
+  :head "Provider",
+  :detail {:prop ":theme", :was ":theme/dark", :now "dark"},
+  :note
+  "Preserved exactly, and the preservation bakes in a collision. Reagent answered `(name :theme/dark)`, so `:theme/dark` and any other namespace's `dark` reached the library as ONE string. Hicasso keeps the namespace, which is what rf2-vrvv9 changed it to do. Writing the string preserves your current behaviour; if the namespace was carrying meaning, this is where it was already being lost."}
+ {:line 34,
+  :col 3,
+  :class :named-ref,
+  :action :refused,
+  :head "Btn",
+  :detail {:prop ":ref", :value ":my-ref"},
+  :note
+  "Reagent's `(name …)` here produced a STRING REF, which React 19 removed and now throws on — so preserving Reagent would restore a crash. Replace it with a callback ref (a function taking the node) or a `useRef`-style handle."}
+ {:line 37,
+  :col 3,
+  :class :key-slot-named-value,
+  :action :skipped,
+  :head "Row",
+  :detail {:prop ":key", :value ":foo"},
+  :note
+  "NOT REWRITTEN, DELIBERATELY, AND IT COSTS YOU SOMETHING. Reagent converted this key like any prop and React received \"foo\"; Hicasso lifts it raw and React coerces it to \":foo\". Writing \"foo\" here would restore a defect: two sibling elements keyed `:foo` and `\"foo\"` collided under Reagent and are distinct under Hicasso. The cost of leaving it is that the key CHANGES at the migration, so on the first render after it React treats this element as a new one — it unmounts the existing subtree and mounts a fresh one, DISCARDING ITS STATE (uncontrolled input values, scroll position, component state). It is a one-time cost and the key is stable thereafter."}]

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w3-named-values/expected.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w3-named-values/expected.cljs
@@ -1,0 +1,37 @@
+(ns app.w3
+  "W3 — named prop values (design §4.3), and AMENDMENT (C) at the key
+  slot. Reagent answered `(name x)` for any keyword or symbol at every
+  prop; Hicasso keeps the named value whole except at HTML-attribute
+  slots (the rf2-vrvv9 narrowing)."
+  (:require [reagent.core :as r]))
+
+(defn a-plain-keyword-value []
+  [:> Btn {:variant "contained"} "Save"])
+
+(defn a-quoted-symbol-takes-the-same-arm []
+  ;; `named?` is keyword-or-symbol, so the donor answered `(name x)` here too.
+  [:> Btn {:variant "my-sym"}])
+
+(defn a-BARE-symbol-is-a-variable-and-is-NEVER-rewritten []
+  ;; THE DISTINCTION THAT KEEPS THIS TOOL HONEST. `handler` is a variable
+  ;; reference, not a symbol value — reading it as one would write
+  ;; `{:on-click "handler"}` and replace a live handler with a string,
+  ;; silently. Everything reached through a symbol is invisible to a
+  ;; source reader and falls to `:computed-value` (§4.4).
+  [:> Btn {:variant chosen-variant :on-click handler}])
+
+(defn a-namespaced-keyword-preserves-a-collision []
+  [:> Provider {:theme "dark"}])
+
+(defn the-html-attribute-slots-are-fixpoints []
+  [:> Btn {:className :wide :id :greeting :role :dialog
+           :aria-label :close :data-kind :row}])
+
+(defn the-class-slot-in-any-spelling []
+  [:> Btn {:class :theme/dark}])
+
+(defn the-ref-slot-is-reported-never-written []
+  [:> Btn {:ref :my-ref}])
+
+(defn the-key-slot-is-excluded-and-reported []
+  [:> Row {:key :foo}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w3-named-values/input.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w3-named-values/input.cljs
@@ -1,0 +1,37 @@
+(ns app.w3
+  "W3 — named prop values (design §4.3), and AMENDMENT (C) at the key
+  slot. Reagent answered `(name x)` for any keyword or symbol at every
+  prop; Hicasso keeps the named value whole except at HTML-attribute
+  slots (the rf2-vrvv9 narrowing)."
+  (:require [reagent.core :as r]))
+
+(defn a-plain-keyword-value []
+  [:> Btn {:variant :contained} "Save"])
+
+(defn a-quoted-symbol-takes-the-same-arm []
+  ;; `named?` is keyword-or-symbol, so the donor answered `(name x)` here too.
+  [:> Btn {:variant 'my-sym}])
+
+(defn a-BARE-symbol-is-a-variable-and-is-NEVER-rewritten []
+  ;; THE DISTINCTION THAT KEEPS THIS TOOL HONEST. `handler` is a variable
+  ;; reference, not a symbol value — reading it as one would write
+  ;; `{:on-click "handler"}` and replace a live handler with a string,
+  ;; silently. Everything reached through a symbol is invisible to a
+  ;; source reader and falls to `:computed-value` (§4.4).
+  [:> Btn {:variant chosen-variant :on-click handler}])
+
+(defn a-namespaced-keyword-preserves-a-collision []
+  [:> Provider {:theme :theme/dark}])
+
+(defn the-html-attribute-slots-are-fixpoints []
+  [:> Btn {:className :wide :id :greeting :role :dialog
+           :aria-label :close :data-kind :row}])
+
+(defn the-class-slot-in-any-spelling []
+  [:> Btn {:class :theme/dark}])
+
+(defn the-ref-slot-is-reported-never-written []
+  [:> Btn {:ref :my-ref}])
+
+(defn the-key-slot-is-excluded-and-reported []
+  [:> Row {:key :foo}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w4-partial-capture/expected-report.edn
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w4-partial-capture/expected-report.edn
@@ -1,0 +1,68 @@
+[{:line 18,
+  :col 3,
+  :class :partial-wrapper,
+  :action :rewrote,
+  :head "Btn",
+  :detail
+  {:prop ":on-pick",
+   :was "(r/partial handler @cart)",
+   :now
+   "(let [f__rf2 handler a0__rf2 @cart] (fn [& args__rf2] (apply f__rf2 a0__rf2 args__rf2)))",
+   :captured ["@cart"]},
+  :note
+  "Reagent's `convert-prop-value` ends with an `ifn?` arm that wrapped a `PartialFn` in `(fn [& args] (apply x args))`. Hicasso has no such arm, so the object would have crossed opaque and this handler would have stopped firing with nothing thrown. The wrapper is Reagent's own, transcribed — return-transparent, so whatever it returned before it returns now. The `let` is not decoration: `r/partial` evaluated the callee and every argument ONCE when the prop was built, and the `let` is what keeps that true instead of re-evaluating them on every invocation."}
+ {:line 23,
+  :col 3,
+  :class :partial-wrapper,
+  :action :rewrote,
+  :head "Btn",
+  :detail
+  {:prop ":on-pick",
+   :was "(r/partial (make-handler!) (next-id!) (log! \"x\"))",
+   :now
+   "(let [f__rf2 (make-handler!) a0__rf2 (next-id!) a1__rf2 (log! \"x\")] (fn [& args__rf2] (apply f__rf2 a0__rf2 a1__rf2 args__rf2)))",
+   :captured ["(next-id!)" "(log! \"x\")"]},
+  :note
+  "Reagent's `convert-prop-value` ends with an `ifn?` arm that wrapped a `PartialFn` in `(fn [& args] (apply x args))`. Hicasso has no such arm, so the object would have crossed opaque and this handler would have stopped firing with nothing thrown. The wrapper is Reagent's own, transcribed — return-transparent, so whatever it returned before it returns now. The `let` is not decoration: `r/partial` evaluated the callee and every argument ONCE when the prop was built, and the `let` is what keeps that true instead of re-evaluating them on every invocation."}
+ {:line 26,
+  :col 3,
+  :class :partial-wrapper,
+  :action :rewrote,
+  :head "Btn",
+  :detail
+  {:prop ":on-pick",
+   :was "(r/partial handler :id 7 \"s\")",
+   :now
+   "(let [f__rf2 handler] (fn [& args__rf2] (apply f__rf2 :id 7 \"s\" args__rf2)))",
+   :captured []},
+  :note
+  "Reagent's `convert-prop-value` ends with an `ifn?` arm that wrapped a `PartialFn` in `(fn [& args] (apply x args))`. Hicasso has no such arm, so the object would have crossed opaque and this handler would have stopped firing with nothing thrown. The wrapper is Reagent's own, transcribed — return-transparent, so whatever it returned before it returns now. The `let` is not decoration: `r/partial` evaluated the callee and every argument ONCE when the prop was built, and the `let` is what keeps that true instead of re-evaluating them on every invocation."}
+ {:line 29,
+  :col 3,
+  :class :partial-wrapper,
+  :action :rewrote,
+  :head "Btn",
+  :detail
+  {:prop ":on-pick",
+   :was "(r/partial handler)",
+   :now
+   "(let [f__rf2 handler] (fn [& args__rf2] (apply f__rf2 args__rf2)))",
+   :captured []},
+  :note
+  "Reagent's `convert-prop-value` ends with an `ifn?` arm that wrapped a `PartialFn` in `(fn [& args] (apply x args))`. Hicasso has no such arm, so the object would have crossed opaque and this handler would have stopped firing with nothing thrown. The wrapper is Reagent's own, transcribed — return-transparent, so whatever it returned before it returns now. The `let` is not decoration: `r/partial` evaluated the callee and every argument ONCE when the prop was built, and the `let` is what keeps that true instead of re-evaluating them on every invocation."}
+ {:line 33,
+  :col 3,
+  :class :computed-value,
+  :action :refused,
+  :head "Btn",
+  :detail {:props [":on-pick"]},
+  :note
+  "These prop values are computed, so the tool cannot see what crosses. Three things a computed value may silently be, each of which diverges: a KEYWORD or symbol (Reagent named it, Hicasso keeps it whole), a NESTED MAP (Reagent camelCased its keys, Hicasso does not), or a non-fn `IFn` such as an `r/partial` reached through a symbol (Reagent wrapped it, Hicasso passes it opaque and the handler stops firing). Check each by hand."}
+ {:line 37,
+  :col 3,
+  :class :computed-value,
+  :action :refused,
+  :head "Btn",
+  :detail {:props [":on-pick"]},
+  :note
+  "These prop values are computed, so the tool cannot see what crosses. Three things a computed value may silently be, each of which diverges: a KEYWORD or symbol (Reagent named it, Hicasso keeps it whole), a NESTED MAP (Reagent camelCased its keys, Hicasso does not), or a non-fn `IFn` such as an `r/partial` reached through a symbol (Reagent wrapped it, Hicasso passes it opaque and the handler stops firing). Check each by hand."}]

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w4-partial-capture/expected.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w4-partial-capture/expected.cljs
@@ -1,0 +1,37 @@
+(ns app.w4
+  "W4 — the non-fn `IFn` literal (design §4.4), as corrected by
+  AMENDMENT (A).
+
+  Reagent's `convert-prop-value` ends with an `ifn?` arm returning
+  `(fn [& args] (apply x args))`, and `r/partial` builds a `PartialFn`
+  deftype that reaches it. Hicasso has no such arm, so the object crosses
+  opaque and a working handler stops firing with nothing thrown.
+
+  The design's stated rewrite re-evaluates the callee and every argument
+  on EACH invocation. `make-partial-fn` evaluated them ONCE, at
+  construction. The first two sites below are the witnesses."
+  (:require [reagent.core :as r]))
+
+(defn a-dereferenced-snapshot []
+  ;; @cart must be read ONCE, when the prop is built — not on every click,
+  ;; which would silently turn a snapshot into a live read.
+  [:> Btn {:on-pick (let [f__rf2 handler a0__rf2 @cart] (fn [& args__rf2] (apply f__rf2 a0__rf2 args__rf2)))}])
+
+(defn effect-count-and-ordering []
+  ;; Each of these ran exactly once, left to right, when the prop was
+  ;; built. The wrapper must not re-run them per invocation.
+  [:> Btn {:on-pick (let [f__rf2 (make-handler!) a0__rf2 (next-id!) a1__rf2 (log! "x")] (fn [& args__rf2] (apply f__rf2 a0__rf2 a1__rf2 args__rf2)))}])
+
+(defn literals-are-inlined-not-bound []
+  [:> Btn {:on-pick (let [f__rf2 handler] (fn [& args__rf2] (apply f__rf2 :id 7 "s" args__rf2)))}])
+
+(defn a-symbol-callee-with-no-arguments []
+  [:> Btn {:on-pick (let [f__rf2 handler] (fn [& args__rf2] (apply f__rf2 args__rf2)))}])
+
+(defn a-plain-function-is-not-wrapped []
+  ;; `js-val?` catches a function first, so the donor never wrapped one.
+  [:> Btn {:on-pick handler}])
+
+(defn clojure-cores-partial-is-not-reagents []
+  ;; `(partial f a)` IS a function, so the donor did not wrap it either.
+  [:> Btn {:on-pick (partial handler 1)}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w4-partial-capture/input.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w4-partial-capture/input.cljs
@@ -1,0 +1,37 @@
+(ns app.w4
+  "W4 — the non-fn `IFn` literal (design §4.4), as corrected by
+  AMENDMENT (A).
+
+  Reagent's `convert-prop-value` ends with an `ifn?` arm returning
+  `(fn [& args] (apply x args))`, and `r/partial` builds a `PartialFn`
+  deftype that reaches it. Hicasso has no such arm, so the object crosses
+  opaque and a working handler stops firing with nothing thrown.
+
+  The design's stated rewrite re-evaluates the callee and every argument
+  on EACH invocation. `make-partial-fn` evaluated them ONCE, at
+  construction. The first two sites below are the witnesses."
+  (:require [reagent.core :as r]))
+
+(defn a-dereferenced-snapshot []
+  ;; @cart must be read ONCE, when the prop is built — not on every click,
+  ;; which would silently turn a snapshot into a live read.
+  [:> Btn {:on-pick (r/partial handler @cart)}])
+
+(defn effect-count-and-ordering []
+  ;; Each of these ran exactly once, left to right, when the prop was
+  ;; built. The wrapper must not re-run them per invocation.
+  [:> Btn {:on-pick (r/partial (make-handler!) (next-id!) (log! "x"))}])
+
+(defn literals-are-inlined-not-bound []
+  [:> Btn {:on-pick (r/partial handler :id 7 "s")}])
+
+(defn a-symbol-callee-with-no-arguments []
+  [:> Btn {:on-pick (r/partial handler)}])
+
+(defn a-plain-function-is-not-wrapped []
+  ;; `js-val?` catches a function first, so the donor never wrapped one.
+  [:> Btn {:on-pick handler}])
+
+(defn clojure-cores-partial-is-not-reagents []
+  ;; `(partial f a)` IS a function, so the donor did not wrap it either.
+  [:> Btn {:on-pick (partial handler 1)}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w5-adapt-react-class/expected-report.edn
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w5-adapt-react-class/expected-report.edn
@@ -1,0 +1,32 @@
+[{:line 9,
+  :col 3,
+  :class :adapt-react-class-head,
+  :action :rewrote,
+  :head "Foo",
+  :detail {:head "Foo"},
+  :note
+  "`vec-to-elem` sent a `NativeWrapper` head and a `[:> C …]` head to the SAME `native-element`, with the props slot at a different index — two spellings of one path. Respelled as `[:> …]`, which is the form Hicasso accepts; left alone it is a head Hicasso answers with `:rf.error/hicasso-bad-head`."}
+ {:line 9,
+  :col 3,
+  :class :named-value,
+  :action :rewrote,
+  :head "Foo",
+  :detail {:prop ":variant", :was ":big", :now "big"},
+  :note
+  "Reagent named every keyword and symbol prop value; Hicasso keeps them whole except at HTML-attribute slots. The string is a fixpoint on both walks."}
+ {:line 12,
+  :col 3,
+  :class :adapt-react-class-head,
+  :action :rewrote,
+  :head "Foo",
+  :detail {:head "Foo"},
+  :note
+  "`vec-to-elem` sent a `NativeWrapper` head and a `[:> C …]` head to the SAME `native-element`, with the props slot at a different index — two spellings of one path. Respelled as `[:> …]`, which is the form Hicasso accepts; left alone it is a head Hicasso answers with `:rf.error/hicasso-bad-head`."}
+ {:line 17,
+  :col 1,
+  :class :adapt-def-site,
+  :action :refused,
+  :head "Adapted",
+  :detail {:def "Adapted", :call-sites-in-this-file [20]},
+  :note
+  "`(def Adapted (r/adapt-react-class …))` is left alone, and W5 cannot take it. Rewriting the def would change the conversion regime of EVERY call site at once, and this run found 1 in this file (line 20). CALL SITES IN OTHER NAMESPACES ARE INVISIBLE TO THIS TOOL — it only saw the files it was pointed at. Either convert it by hand, or inline the `adapt-react-class` at each call site and re-run so W5 can take them individually."}]

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w5-adapt-react-class/expected.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w5-adapt-react-class/expected.cljs
@@ -1,0 +1,20 @@
+(ns app.w5
+  "W5 — the inline `adapt-react-class` head (design §4.5). `vec-to-elem`
+  sends a `NativeWrapper` head and a `[:> C …]` head to the SAME
+  `native-element`, with the props slot at a different index — two
+  spellings of one path."
+  (:require [reagent.core :as r]))
+
+(defn the-inline-head []
+  [:> Foo {:variant "big"} "kid"])
+
+(defn the-inline-head-with-no-props []
+  [:> Foo "kid"])
+
+;; A def site cannot be rewritten by a fixer: rewriting the def changes
+;; every call site's conversion regime at once, including call sites in
+;; namespaces this tool was never pointed at.
+(def Adapted (r/adapt-react-class Bar))
+
+(defn a-call-site-of-the-def []
+  [Adapted {:variant :big}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w5-adapt-react-class/input.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w5-adapt-react-class/input.cljs
@@ -1,0 +1,20 @@
+(ns app.w5
+  "W5 — the inline `adapt-react-class` head (design §4.5). `vec-to-elem`
+  sends a `NativeWrapper` head and a `[:> C …]` head to the SAME
+  `native-element`, with the props slot at a different index — two
+  spellings of one path."
+  (:require [reagent.core :as r]))
+
+(defn the-inline-head []
+  [(r/adapt-react-class Foo) {:variant :big} "kid"])
+
+(defn the-inline-head-with-no-props []
+  [(r/adapt-react-class Foo) "kid"])
+
+;; A def site cannot be rewritten by a fixer: rewriting the def changes
+;; every call site's conversion regime at once, including call sites in
+;; namespaces this tool was never pointed at.
+(def Adapted (r/adapt-react-class Bar))
+
+(defn a-call-site-of-the-def []
+  [Adapted {:variant :big}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w6-string-tag-head/expected-report.edn
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w6-string-tag-head/expected-report.edn
@@ -1,0 +1,69 @@
+[{:line 8,
+  :col 3,
+  :class :computed-value,
+  :action :refused,
+  :head "\"input\"",
+  :detail {:props [":value" ":on-change"]},
+  :note
+  "These prop values are computed, so the tool cannot see what crosses. Three things a computed value may silently be, each of which diverges: a KEYWORD or symbol (Reagent named it, Hicasso keeps it whole), a NESTED MAP (Reagent camelCased its keys, Hicasso does not), or a non-fn `IFn` such as an `r/partial` reached through a symbol (Reagent wrapped it, Hicasso passes it opaque and the handler stops firing). Check each by hand."}
+ {:line 8,
+  :col 3,
+  :class :string-tag-head,
+  :action :rewrote,
+  :head "\"input\"",
+  :detail {:head "input"},
+  :note
+  "Under Reagent `[:> \"input\" …]` took the controlled-input wrapper when the tag was `input` or `textarea`, because `input-component?` matches on exactly this path. Under Hicasso a string head is REFUSED at the crossing. Rewritten to `[:input …]`, which lands the site on Hicasso's own controlled door — the taught form. Reagent's deep camelCasing and its `(name …)` arm are both present at a native tag, so the prop rewrites are fixpoints here and are deliberately not applied."}
+ {:line 11,
+  :col 3,
+  :class :string-tag-head,
+  :action :rewrote,
+  :head "\"div\"",
+  :detail {:head "div"},
+  :note
+  "Under Reagent `[:> \"div\" …]` took the controlled-input wrapper when the tag was `input` or `textarea`, because `input-component?` matches on exactly this path. Under Hicasso a string head is REFUSED at the crossing. Rewritten to `[:div …]`, which lands the site on Hicasso's own controlled door — the taught form. Reagent's deep camelCasing and its `(name …)` arm are both present at a native tag, so the prop rewrites are fixpoints here and are deliberately not applied."}
+ {:line 16,
+  :col 3,
+  :class :string-tag-unparseable,
+  :action :refused,
+  :head "\"div#id\"",
+  :detail {:head "div#id"},
+  :note
+  "This string head was ALREADY BROKEN under Reagent: the `:>` path never parsed the `#`/`.` shorthand, so `createElement(\"div#id\")` asked React for an element that does not exist. Rewriting it to a native tag would PARSE the shorthand and the site would start behaving differently, so it is left for you."}
+ {:line 21,
+  :col 3,
+  :class :event-carrier-goes-live,
+  :action :refused,
+  :head "\"button\"",
+  :detail {:prop ":on-click", :value "[:boom]"},
+  :note
+  "REWRITE REFUSED, AND THIS IS THE DESIGN'S ONE GENUINELY FATAL CLASS. Under Reagent this was INERT — `convert-prop-value` asks `coll?` before `ifn?`, so it crossed as an array and the handler never fired. At a native Hicasso tag the same form is LOWERED into a live dispatch, so rewriting the head to a native tag would turn a handler that never fired into one that does. The head is left as `[:>]`. Decide whether this handler was ever meant to run."}
+ {:line 24,
+  :col 13,
+  :class :string-tag-head,
+  :action :rewrote,
+  :head "\"input\"",
+  :detail {:head "input"},
+  :note
+  "Under Reagent `[:> \"input\" …]` took the controlled-input wrapper when the tag was `input` or `textarea`, because `input-component?` matches on exactly this path. Under Hicasso a string head is REFUSED at the crossing. Rewritten to `[:input …]`, which lands the site on Hicasso's own controlled door — the taught form. Reagent's deep camelCasing and its `(name …)` arm are both present at a native tag, so the prop rewrites are fixpoints here and are deliberately not applied."}
+ {:line 24,
+  :col 13,
+  :class :partial-wrapper,
+  :action :rewrote,
+  :head "\"input\"",
+  :detail
+  {:prop ":on-change",
+   :was "(r/partial handler @cart)",
+   :now
+   "(let [f__rf2 handler a0__rf2 @cart] (fn [& args__rf2] (apply f__rf2 a0__rf2 args__rf2)))",
+   :captured ["@cart"]},
+  :note
+  "Reagent's `convert-prop-value` ends with an `ifn?` arm that wrapped a `PartialFn` in `(fn [& args] (apply x args))`. Hicasso has no such arm, so the object would have crossed opaque and this handler would have stopped firing with nothing thrown. The wrapper is Reagent's own, transcribed — return-transparent, so whatever it returned before it returns now. The `let` is not decoration: `r/partial` evaluated the callee and every argument ONCE when the prop was built, and the `let` is what keeps that true instead of re-evaluating them on every invocation."}
+ {:line 24,
+  :col 13,
+  :class :metadata-key,
+  :action :rewrote,
+  :head "\"input\"",
+  :detail {:key "1"},
+  :note
+  "Reagent read a `^{:key …}` on the vector AFTER converting the props, so a metadata key BEAT a props `:key`. Hicasso's `raw-element` reads `(:key props)` and contains no `(meta …)` read at all, so this key would have gone dead at the migration with no diagnostic from either Hicasso or React beyond React's own parent-deduped warning. Moved into the props map, where the destination reads it."}]

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w6-string-tag-head/expected.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w6-string-tag-head/expected.cljs
@@ -1,0 +1,24 @@
+(ns app.w6
+  "W6 — the string tag head (design §4.6). Under Reagent a string head at
+  `input` or `textarea` took the controlled-input wrapper; under Hicasso
+  a string head is refused at the crossing."
+  (:require [reagent.core :as r]))
+
+(defn a-controlled-input []
+  [:input {:value v :on-change f}])
+
+(defn an-ordinary-tag []
+  [:div {:class-name "wide"} "text"])
+
+(defn the-shorthand-was-already-broken []
+  ;; The `:>` path never parsed the shorthand, so this asked React for an
+  ;; element that does not exist. Rewriting it would make it start working.
+  [:> "div#id" {}])
+
+(defn a-carrier-would-go-live-at-a-native-tag []
+  ;; INERT under Reagent (`coll?` precedes `ifn?`), LOWERED at a native
+  ;; Hicasso tag. The design's one genuinely fatal class, so the head stays.
+  [:> "button" {:on-click [:boom]} "Go"])
+
+(defn w1-and-w4-still-apply-at-a-native-destination []
+  [:input {:on-change (let [f__rf2 handler a0__rf2 @cart] (fn [& args__rf2] (apply f__rf2 a0__rf2 args__rf2))) :key 1}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/w6-string-tag-head/input.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/w6-string-tag-head/input.cljs
@@ -1,0 +1,24 @@
+(ns app.w6
+  "W6 — the string tag head (design §4.6). Under Reagent a string head at
+  `input` or `textarea` took the controlled-input wrapper; under Hicasso
+  a string head is refused at the crossing."
+  (:require [reagent.core :as r]))
+
+(defn a-controlled-input []
+  [:> "input" {:value v :on-change f}])
+
+(defn an-ordinary-tag []
+  [:> "div" {:class-name "wide"} "text"])
+
+(defn the-shorthand-was-already-broken []
+  ;; The `:>` path never parsed the shorthand, so this asked React for an
+  ;; element that does not exist. Rewriting it would make it start working.
+  [:> "div#id" {}])
+
+(defn a-carrier-would-go-live-at-a-native-tag []
+  ;; INERT under Reagent (`coll?` precedes `ifn?`), LOWERED at a native
+  ;; Hicasso tag. The design's one genuinely fatal class, so the head stays.
+  [:> "button" {:on-click [:boom]} "Go"])
+
+(defn w1-and-w4-still-apply-at-a-native-destination []
+  ^{:key 1} [:> "input" {:on-change (r/partial handler @cart)}])

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/amendment_a_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/amendment_a_test.clj
@@ -1,0 +1,164 @@
+(ns re-frame.migration.hicasso.amendment-a-test
+  "**AMENDMENT (A), pinned by EXECUTION rather than by text.**
+
+  The golden corpus pins text and only text, and the design is candid
+  about why (§9.7): the corpus is a JVM harness over source text while the
+  destination is a browser runtime, so a corpus case cannot render.
+
+  W4 is the one rewrite where that limit bites, because its correction is
+  entirely about **when** something is evaluated. A text assertion can
+  confirm the `let` was written; it cannot confirm the `let` does what a
+  `let` is here to do. But W4's OUTPUT is plain Clojure — `let`, `fn`,
+  `apply`, with no `r/partial` left in it — so this JVM can `eval` it and
+  ask the runtime question directly.
+
+  The callee and argument forms below are ordinary vars in this
+  namespace, so the emitted text resolves against them exactly as a
+  consumer's would resolve against theirs.
+
+  Each test runs the emitted wrapper AND the design's stated wrapper on
+  the same inputs. The second assertion in each pair is what makes the
+  first mean something: it shows the landed design's shape actually
+  diverges here, so the amendment is load-bearing rather than defensive."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.migration.hicasso.rewrite :as rw]
+            [rewrite-clj.node :as n]
+            [rewrite-clj.parser :as p]))
+
+;; ---------------------------------------------------------------------------
+;; The rig — plain vars, so the emitted source resolves naturally
+;; ---------------------------------------------------------------------------
+
+(def cart (atom :v1))
+(defn handler [snapshot & _] snapshot)
+
+(def effects (atom []))
+(defn make-handler! [] (swap! effects conj :make) (fn [& args] (vec args)))
+(defn next-id!     [] (swap! effects conj :next) 7)
+(defn log!         [_] (swap! effects conj :log) :logged)
+
+(defn pair [a b] [a b])
+(defn all-args [& xs] (vec xs))
+
+(defn- eval-here
+  "Evaluate an emitted form with this namespace's vars in scope."
+  [form]
+  (binding [*ns* (find-ns 're-frame.migration.hicasso.amendment-a-test)]
+    (eval form)))
+
+(defn- emitted
+  "Run W4 over a literal `(r/partial …)` call; return `[wrapper text]`."
+  [src]
+  (let [node (:node (rw/w4-plan (p/parse-string src)))]
+    [(eval-here (n/sexpr node)) (n/string node)]))
+
+(defn- naive
+  "The design's stated rewrite, `(fn [& args] (apply f a … args))`, built
+  from the same call — the shape amendment (A) replaced."
+  [src]
+  (let [els  (rw/elements (p/parse-string src))
+        body (str/join " " (map n/string (rest els)))]
+    (eval-here (read-string (str "(fn [& args] (apply " body " args))")))))
+
+;; ---------------------------------------------------------------------------
+;; Witness 1 — the dereferenced snapshot
+;; ---------------------------------------------------------------------------
+
+(def ^:private snapshot-src "(r/partial handler @cart)")
+
+(deftest a-dereferenced-argument-is-a-snapshot-not-a-live-read
+  (testing "`(r/partial handler @cart)` read `@cart` ONCE, when the prop
+            was built. `make-partial-fn` stored the evaluated arguments in
+            a `PartialFn`; nothing re-read them per invocation."
+    (reset! cart :v1)
+    (let [[wrapper _] (emitted snapshot-src)]
+      (is (= :v1 (wrapper)) "the snapshot taken at construction")
+      (reset! cart :v2)
+      (is (= :v1 (wrapper))
+          "STILL the snapshot: the deref sits in the `let`, so changing the
+           atom afterwards cannot reach through the wrapper")
+      (is (= :v1 (wrapper)) "and it stays put across further invocations")))
+
+  (testing "the design's stated shape diverges here, which is why the
+            amendment exists"
+    (reset! cart :v1)
+    (let [w (naive snapshot-src)]
+      (is (= :v1 (w)))
+      (reset! cart :v2)
+      (is (= :v2 (w))
+          "the naive wrapper re-derefs on every invocation, silently
+           turning a snapshot into a live read — the exact class of change
+           this tool exists to delete"))))
+
+;; ---------------------------------------------------------------------------
+;; Witness 2 — effect count and ordering
+;; ---------------------------------------------------------------------------
+
+(def ^:private effectful-src "(r/partial (make-handler!) (next-id!) (log! \"x\"))")
+
+(deftest every-argument-is-evaluated-once-left-to-right-at-construction
+  (testing "the callee and both arguments run EXACTLY ONCE, in source
+            order, when the prop is built"
+    (reset! effects [])
+    (let [[wrapper _] (emitted effectful-src)]
+      (is (= [:make :next :log] @effects)
+          "left to right, at prop-evaluation time — before the wrapper is
+           minted, which is what `make-partial-fn` did")
+      (wrapper) (wrapper) (wrapper)
+      (is (= [:make :next :log] @effects)
+          "and NOT AGAIN: three invocations added no effects")))
+
+  (testing "the design's stated shape re-runs all three per invocation"
+    (reset! effects [])
+    (let [w (naive effectful-src)]
+      (is (= [] @effects) "nothing has run yet — the first divergence")
+      (w)
+      (is (= [:make :next :log] @effects))
+      (w)
+      (is (= [:make :next :log :make :next :log] @effects)
+          "a second click ran every effect a second time: a `next-id!`
+           that minted one id per prop now mints one per click"))))
+
+;; ---------------------------------------------------------------------------
+;; Law 2 — return transparency
+;; ---------------------------------------------------------------------------
+
+(deftest the-wrapper-is-return-transparent
+  (testing "whatever `f` returned before, it returns now (design Law 2).
+            This is why W4 cannot blank a render prop even at a prop that
+            IS a render prop — a `(r/partial render-cell ctx)` at Fluent's
+            `onRenderCell` keeps returning its element."
+    (let [[wrapper _] (emitted "(r/partial pair 1)")]
+      (is (= [1 2] (wrapper 2)))))
+
+  (testing "bound arguments come first and invocation arguments after, in
+            that order — `apply f a … args`"
+    (let [[wrapper _] (emitted "(r/partial all-args :a :b)")]
+      (is (= [:a :b 1 2] (wrapper 1 2))))))
+
+;; ---------------------------------------------------------------------------
+;; The written shape
+;; ---------------------------------------------------------------------------
+
+(deftest the-emitted-shape-is-hygienic-and-minimal
+  (testing "self-evaluating arguments are INLINED, not bound: their
+            evaluation has nothing to observe and a binding for one is
+            pure noise"
+    (let [[_ text] (emitted "(r/partial handler :id 7 \"s\")")]
+      (is (= "(let [f__rf2 handler] (fn [& args__rf2] (apply f__rf2 :id 7 \"s\" args__rf2)))"
+             text))))
+
+  (testing "a SYMBOL callee is bound even though it looks atomic:
+            re-reading a var on each invocation picks up a redefinition
+            the donor's captured value would never have seen"
+    (let [[_ text] (emitted "(r/partial handler)")]
+      (is (= "(let [f__rf2 handler] (fn [& args__rf2] (apply f__rf2 args__rf2)))" text))))
+
+  (testing "every argument that is not self-evaluating is bound, in source
+            order, and every binding carries the `__rf2` suffix that makes
+            the `let` hygienic against the forms it captures"
+    (let [[_ text] (emitted "(r/partial (make-handler!) (next-id!) (log! \"x\"))")]
+      (is (= (str "(let [f__rf2 (make-handler!) a0__rf2 (next-id!) a1__rf2 (log! \"x\")] "
+                  "(fn [& args__rf2] (apply f__rf2 a0__rf2 a1__rf2 args__rf2)))")
+             text)))))

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/corpus_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/corpus_test.clj
@@ -1,0 +1,105 @@
+(ns re-frame.migration.hicasso.corpus-test
+  "**THE GOLDEN-FILE CORPUS IS THE SPEC** (design §5).
+
+  Each case is a directory under `test/corpus/`:
+
+      <case>/input.cljs           the consumer namespace, as written under Reagent
+      <case>/expected.cljs        what the fixer writes
+      <case>/expected-report.edn  what the fixer says
+
+  and every case asserts four things:
+
+  1. the rewrite — `input` transforms to `expected`, BYTE FOR BYTE, so a
+     change in whitespace, comment placement or key order fails;
+  2. the report — the entries over `input` equal `expected-report`,
+     `:note` prose included, so **a change to what the tool SAYS is gated
+     exactly as hard as a change to what it WRITES** (§7.1);
+  3. **idempotence** — running the fixer on `expected` returns `expected`
+     unchanged, which is §4.7's claim that every output is outside its own
+     rewrite's input language;
+  4. determinism — a second analysis of `input` reports identically.
+
+  The report is compared as DATA read back from EDN rather than as
+  characters. The claim being gated is what the tool says, and every field
+  including the full `:note` participates in that comparison; pinning the
+  pretty-printer's line breaks as well would red the corpus on a Clojure
+  upgrade that changed nothing about the tool. The rewritten SOURCE is
+  compared as characters, because there formatting is the whole point.
+
+  Set `RF2_CODEMOD_REGEN=1` to rewrite the expectation files from the
+  tool's current behaviour. Regenerating is how a case is authored; it is
+  never how one is fixed."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.pprint :as pp]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.migration.hicasso.codemod :as cm]))
+
+(def ^:private corpus-root (io/file "test" "corpus"))
+
+(def ^:private regen? (= "1" (System/getenv "RF2_CODEMOD_REGEN")))
+
+(defn- cases []
+  (->> (.listFiles corpus-root)
+       (filter #(.isDirectory ^java.io.File %))
+       (sort-by #(.getName ^java.io.File %))))
+
+(defn- input-file [dir]
+  (first (filter #(str/starts-with? (.getName ^java.io.File %) "input.")
+                 (.listFiles ^java.io.File dir))))
+
+(defn- report-shape
+  "The comparable shape of a report: the entries, with the transient
+  `:form` excerpt dropped (it is the input text, already asserted by the
+  input file itself) and everything the tool DECIDED kept."
+  [entries]
+  (mapv #(select-keys % [:line :col :class :action :head :detail :note]) entries))
+
+(defn- read-edn [f] (edn/read-string (slurp f)))
+
+(defn- write-edn! [f data]
+  (spit f (with-out-str (pp/pprint data))))
+
+(deftest corpus-is-not-empty
+  (testing "a corpus that silently found no cases would pass every
+            assertion below and mean nothing"
+    (is (<= 8 (count (cases)))
+        "the corpus must cover every rewrite, every preserve class and
+         every report class — see this namespace's docstring")))
+
+(deftest ^:corpus golden-corpus
+  (doseq [dir (cases)]
+    (let [name*    (.getName ^java.io.File dir)
+          in-f     (input-file dir)
+          exp-f    (io/file dir (str "expected" (subs (.getName ^java.io.File in-f)
+                                                      (str/index-of (.getName ^java.io.File in-f) "."))))
+          rep-f    (io/file dir "expected-report.edn")
+          src      (slurp in-f)
+          path     (str "src/app/" (.getName ^java.io.File in-f))
+          result   (cm/rewrite-string src path)
+          entries  (report-shape (:entries result))]
+
+      (when regen?
+        (spit exp-f (:source result))
+        (write-edn! rep-f entries))
+
+      (testing (str name* " — the rewrite")
+        (is (.exists exp-f) (str "missing " exp-f))
+        (is (= (slurp exp-f) (:source result))
+            (str name* ": the fixer wrote something other than expected.cljs")))
+
+      (testing (str name* " — the report")
+        (is (.exists rep-f) (str "missing " rep-f))
+        (is (= (read-edn rep-f) entries)
+            (str name* ": the fixer SAID something other than expected-report.edn")))
+
+      (testing (str name* " — idempotence (§4.7): a second run is a no-op")
+        (let [again (cm/rewrite-string (:source result) path)]
+          (is (= (:source result) (:source again))
+              (str name* ": running the fixer on its own output changed it, so some "
+                   "output is still inside its own rewrite's input language"))))
+
+      (testing (str name* " — determinism")
+        (is (= entries (report-shape (:entries (cm/rewrite-string src path))))
+            (str name* ": two analyses of one input disagreed"))))))

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/shared_rule_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/shared_rule_test.clj
@@ -1,0 +1,184 @@
+(ns re-frame.migration.hicasso.shared-rule-test
+  "The two conversion tables, pinned where this tool can reach them.
+
+  ## Why the first test matters more than it looks
+
+  The design's §9.5 charge — *\"the tool reimplements `prop-name`, and
+  nothing pins the two together\"* — survived its own adversarial pass
+  UNREPAIRED, and §10.3 named it the open question the page could not
+  close: a corpus pins the tool, a DOM suite pins the runtime, and nothing
+  pins them equal, with the drift silent in both directions.
+
+  §10.2's third recommendation was the only structural answer, and
+  rf2-ani6y took it: the slot rule moved to `front/slot.cljc`, the one
+  file both hosts can load. This tool therefore does not *mirror*
+  `prop-name` — it CALLS it. [[the-slot-rule-is-the-shared-one]] is what
+  keeps that true, by asserting the function came out of the shared file
+  rather than out of this artefact's own tree. Copy the rule in here to
+  \"remove a dependency\" and that test goes red, which is the whole
+  point.
+
+  ## What is still mirrored, and honestly labelled
+
+  `codec/html-attr-slots` and `intent/event-prop?` live in `.cljs` this
+  JVM cannot load, so [[re-frame.migration.hicasso.dest]] carries small
+  transcriptions of both. Those are conventions, not pins, and the design
+  says so. The rows below assert the transcription's behaviour so a
+  reader can diff two short tables by eye.
+
+  ## The donor's two deltas
+
+  Reagent's `cached-prop-name` and our `slot/prop-name` are one rule apart
+  from two cells. Each row below cites the executed donor witness that
+  pins it — `codemod-contract-donor-*` in
+  `implementation/adapters/reagent/test/re_frame/reagent_codemod_contract_donor_cljs_test.cljs`
+  (rf2-d2mwk)."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.bench.hicasso.front.slot :as slot]
+            [re-frame.migration.hicasso.dest :as dest]
+            [re-frame.migration.hicasso.donor :as donor]
+            [re-frame.migration.hicasso.rewrite :as rw]
+            [rewrite-clj.parser :as p]))
+
+;; ---------------------------------------------------------------------------
+;; There is no second copy
+;; ---------------------------------------------------------------------------
+
+(deftest the-slot-rule-is-the-shared-one
+  (testing "the tool's slot resolver IS `slot/prop-name`, by identity —
+            not a transcription of it"
+    (is (identical? dest/canonical-slot slot/prop-name)))
+
+  (testing "and it is loaded from the SHARED `.cljc`, not from a copy
+            inside this artefact. rf2-ani6y extracted that file precisely
+            so the tool and the door cannot hold two answers; a copy in
+            `src/` would satisfy every other test in this suite and
+            silently re-open the design's §10.3."
+    (let [url (io/resource "re_frame/bench/hicasso/front/slot.cljc")
+          path (some-> url .getPath (str/replace "\\" "/"))]
+      (is (some? url) "the shared slot rule is on the classpath")
+      (is (str/includes? path "implementation/freehand/test/re_frame/bench/hicasso/front/slot.cljc")
+          (str "the slot rule must come from the shared implementation file; it came from "
+               path))
+      (is (not (str/includes? path "/migration/reagent-to-hicasso/"))
+          "a copy of the slot rule has appeared inside the codemod's own tree"))))
+
+;; ---------------------------------------------------------------------------
+;; The donor's key function, and its two deltas from the shared rule
+;; ---------------------------------------------------------------------------
+
+(deftest the-donor-key-rule
+  (testing "kebab→camel, which is `dash-to-prop-name`
+            (donor witness: codemod-contract-donor-w2-nested-map-keys)"
+    (is (= "pageSize"  (donor/key-name :page-size)))
+    (is (= "firstName" (donor/key-name :first-name)))
+    (is (= "otherKey"  (donor/key-name :other-key))))
+
+  (testing "the three seeded renames, which hold for every spelling of the
+            same attribute because the cache is keyed on `(name k)`"
+    (is (= "className" (donor/key-name :class)))
+    (is (= "htmlFor"   (donor/key-name :for)))
+    (is (= "charSet"   (donor/key-name :charset)))
+    (is (= "className" (donor/key-name :x/class))))
+
+  (testing "`aria` and `data` are exempt"
+    (is (= "aria-label" (donor/key-name :aria-label)))
+    (is (= "data-kind"  (donor/key-name :data-kind))))
+
+  (testing "symbols take the same arm — `named?` is keyword-or-symbol"
+    (is (= "pageSize" (donor/key-name 'page-size))))
+
+  (testing "DELTA 1 — a STRING key is verbatim under the donor, seeded
+            renames included, where our own rule applies them to every
+            spelling. This is the cell that makes a transcription of
+            `prop-name` wrong for W2's purposes."
+    (is (= "first-name" (donor/key-name "first-name")))
+    (is (= "class"      (donor/key-name "class")))
+    (is (= "className"  (slot/prop-name "class"))
+        "the shared rule's answer for the same key, for contrast"))
+
+  (testing "DELTA 2 — a CSS custom property is DETECTED and refused, never
+            reproduced. Reagent mangled `--brand-color` into `BrandColor`,
+            a style key nothing reads; preserving that would mean writing
+            a key that never worked."
+    (is (donor/css-var-name? "--brand-color"))
+    (is (nil? (donor/key-name :--brand-color)))
+    (is (= "--brand-color" (slot/prop-name :--brand-color))
+        "our rule preserves it, and React routes it through `setProperty`"))
+
+  (testing "everywhere else the two rules agree, which is why `key-name`
+            delegates rather than transcribes"
+    (doseq [k [:page-size :first-name :other-key :class :for :charset
+               :aria-label :data-kind :onClick :on-click]]
+      (is (= (slot/prop-name k) (donor/key-name k))
+          (str "the two rules should agree at " k)))))
+
+;; ---------------------------------------------------------------------------
+;; The destination vocabulary (mirrors, labelled as such)
+;; ---------------------------------------------------------------------------
+
+(deftest the-destination-vocabulary
+  (testing "`html-attr-slot?` mirrors the codec's, prefix families included"
+    (is (every? dest/html-attr-slot? ["className" "id" "role" "data-kind" "aria-label"]))
+    (is (not-any? dest/html-attr-slot? ["variant" "theme" "key" "ref" "onClick"])))
+
+  (testing "`event-prop?` mirrors `intent/event-prop?`, INCLUDING its type
+            gate — a prop key spelled `on-click` as a SYMBOL is not an
+            event position, so the tool must not refuse there"
+    (is (dest/event-prop? :on-click))
+    (is (dest/event-prop? :onClick))
+    (is (dest/event-prop? "on-click"))
+    (is (not (dest/event-prop? 'on-click)) "symbols answer false")
+    (is (not (dest/event-prop? :once)) "`on` followed by a lowercase letter is not `on-`")
+    (is (not (dest/event-prop? :online))))
+
+  (testing "a nested map key's destination name is `clj->js`'s answer,
+            which is what W2 has to make agree with the donor"
+    (is (= "page-size" (dest/nested-key-name :page-size)))
+    (is (= "x/page-size" (dest/nested-key-name 'x/page-size)))
+    (is (= "first-name" (dest/nested-key-name "first-name"))))
+
+  (testing "`dangerouslySetInnerHTML` is recognised in any spelling,
+            because the kebab one never reached React's exact name under
+            either runtime and the migrator needs telling regardless"
+    (is (dest/dangerous-html-key? :dangerouslySetInnerHTML))
+    (is (dest/dangerous-html-key? :dangerously-set-inner-html))
+    (is (dest/dangerous-html-key? "dangerouslySetInnerHTML"))
+    (is (not (dest/dangerous-html-key? :dangerous)))))
+
+;; ---------------------------------------------------------------------------
+;; Amendment (B), at the unit
+;; ---------------------------------------------------------------------------
+
+(defn- collisions [src] (rw/injective-keys (p/parse-string src)))
+
+(deftest amendment-b-injectivity
+  (testing "an ordinary camel-case collision"
+    (is (= [{:slot "fooBar" :keys [":foo-bar" ":fooBar"]}]
+           (collisions "{:foo-bar 1 :fooBar 2}"))))
+
+  (testing "a seeded-rename collision"
+    (is (= [{:slot "className" :keys [":class" ":className"]}]
+           (collisions "{:class \"a\" :className \"b\"}"))))
+
+  (testing "a keyword/string collision — the donor takes the string
+            verbatim and camelCases the keyword onto the same name"
+    (is (= [{:slot "fooBar" :keys ["\"fooBar\"" ":foo-bar"]}]
+           (collisions "{:foo-bar 1 \"fooBar\" 2}"))))
+
+  (testing "three sources onto one slot are all named, not just the pair"
+    (is (= [{:slot "fooBar" :keys ["\"fooBar\"" ":foo-bar" ":fooBar"]}]
+           (collisions "{:foo-bar 1 :fooBar 2 \"fooBar\" 3}"))))
+
+  (testing "an injective map is not refused"
+    (is (nil? (collisions "{:page-size 10 :first-name \"a\"}")))
+    (is (nil? (collisions "{:aria-label 1 :data-kind 2}")))
+    (is (nil? (collisions "{\"first-name\" 1 :first-name 2}"))
+        "the donor takes the string verbatim, so these are two DIFFERENT
+         slots — `first-name` and `firstName` — and neither collides"))
+
+  (testing "a CSS custom property cannot be half of a minted duplicate,
+            because it is never respelled"
+    (is (nil? (collisions "{:--brand-color \"red\" :font-size 12}")))))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ site_dir: site
 exclude_docs: |
   tools/playground/
   migration/from-re-frame-v1/codemod/
+  migration/reagent-to-hicasso/codemod/
   design/freehand/
   design/hicasso/
 


### PR DESCRIPTION
Implements the fixer half of the ratified `[:>]` migration codemod design
(`docs/design/hicasso/studio/reagent-codemod-against-the-landed-escape.md`,
`rf2-2rtt6.106`), **as amended** by this bead's three ratified acceptance
criteria. The hoist is demand-gated by the same ratification and is absent.

## Residence, and the one dependency

`migration/reagent-to-hicasso/codemod/`, cloned from the
`migration/from-re-frame-v1/codemod/` skeleton the design's §1 names: a
standalone JVM artefact reading source text through **rewrite-clj 1.1.49**,
which the repo already depends on. No new dependency was added, and the tool
never loads, requires or executes re-frame2 — so it runs against any Reagent
corpus on a bare JVM.

There is exactly one exception, and it is the point rather than a convenience:
`re-frame.bench.hicasso.front.slot` is on `:paths`. The design's §9.5 charge —
*"the tool reimplements `prop-name`, and nothing pins the two together"* —
survived its own adversarial pass **unrepaired**, and §10.3 named it the open
question the page could not close. §10.2's third recommendation was the only
structural answer and `rf2-ani6y` took it; `slot.cljc`'s own docstring names
this codemod as its second consumer. Transcribing the rule back into `src/`
would reproduce, inside the tool, the exact defect the tool exists to delete, so
`shared_rule_test.clj` asserts by identity **and by loaded resource path** that
we are calling the shared file. Note the direction: the bundle-isolation law
forbids `implementation/` requiring from `tools/`; this is `migration/` reading
a shared `.cljc` rule out of `implementation/`.

Reagent's *own* key function is a genuinely different rule and does live here,
in `donor.clj` — but written as the shared rule plus its two named deltas (a
string key is verbatim under the donor; a `--custom-property` is mangled), never
as a second copy of the camel algorithm.

## The three amendments

**(A) W4 captures at prop-evaluation time.** The design's stated shape,
`(fn [& args] (apply f a … args))`, re-evaluates the callee and every argument
on *each* invocation where `make-partial-fn` evaluated them once at
construction. What is written is a hygienic `let` capturing the callee and every
non-literal argument once, left to right, before the wrapper is minted:

```clojure
[:> Btn {:on-pick (r/partial handler @cart)}]
;; =>
[:> Btn {:on-pick (let [f__rf2 handler a0__rf2 @cart]
                    (fn [& args__rf2] (apply f__rf2 a0__rf2 args__rf2)))}]
```

Self-evaluating arguments are inlined rather than bound; symbols are bound,
because re-reading a var per invocation picks up a redefinition the donor's
captured value never saw. Names are fixed rather than gensym'd so the corpus can
assert output byte for byte.

*Witness pins* — `amendment_a_test.clj`, and these **execute** rather than
assert text. The corpus pins text and only text (§9.7: a JVM harness, a browser
destination), and W4 is the one rewrite whose correction is entirely about
*when* something runs. Its output is plain `let`/`fn`/`apply` with no Reagent in
it, so the JVM evals it directly:

- `a-dereferenced-argument-is-a-snapshot-not-a-live-read` — `@cart` is read
  once; mutating the atom afterwards cannot reach through the wrapper.
- `every-argument-is-evaluated-once-left-to-right-at-construction` — the three
  effects fire once, in order, before the wrapper exists; three invocations add
  none.

Each runs the **design's stated shape alongside** and asserts it diverges (the
naive deref goes live; the naive effects re-run per call). That is what makes
the amendment load-bearing rather than defensive.

**(B) W2 refuses normalized-key collisions.** Before rewriting any nested
literal map, `injective-keys` requires the donor-normalized names to be
injective; a collision refuses the **whole** map with a report line naming every
colliding source key, grouped by the slot they collapse onto. The premise is
already pinned donor-side: `codemod-contract-donor-the-whole-corpus` asserts a
sixteen-prop corpus emits **fifteen** slots and that "the pin is that exactly
one" of `:class`/`:className` survives.

*Witness pins* — corpus case `w2-normalized-key-collisions` (an ordinary
camel-case collision, a seeded rename, a keyword/string collision, a whole-map
refusal that declines to partially rewrite an injective sibling key, and a
non-colliding sibling map that still rewrites) plus unit rows in
`shared_rule_test.clj/amendment-b-injectivity`, including the three-way case and
the `"first-name"`/`:first-name` pair that is **not** a collision because the
donor takes a string verbatim.

**(C) Key-slot report entry.** The exclusion is ratified; the entry names the
counter-cost the design understated. Not "one remount": React reconciles a
changed key by unmounting the subtree and mounting a fresh one, **discarding its
state** — uncontrolled input values, scroll position, component state.

*Witness pin* — corpus case `w3-named-values`, class `:key-slot-named-value`,
action `:skipped`, with the state-loss sentence in its `:note`.

## The golden-file corpus

Ten cases under `test/corpus/`, each an input namespace plus expected output and
expected report: `w1-metadata-key`, `w2-nested-map-keys`,
`w2-normalized-key-collisions`, `w3-named-values`, `w4-partial-capture`,
`w5-adapt-react-class`, `w6-string-tag-head`, `refusals-that-need-a-person`,
`preserved-and-clean`, `cljc-site`. Between them they cover all six rewrites,
every §5.4 preserve class, and every report class.

The report is asserted **including its full `:note` prose**, so a change to what
the tool *says* is gated exactly as hard as a change to what it *writes* (§7.1).
Source output is compared as characters; the report is compared as data read
back from EDN — every field participates, but the pretty-printer's line breaks
do not, so a Clojure upgrade cannot red the corpus without the tool changing.

**Idempotence.** Every output is outside its own rewrite's input language: W1
leaves no metadata key, `cached-prop-name` is idempotent, a string is not a
keyword, a `let` is not an `r/partial` call, the head is `:>` rather than an
`adapt-react-class` call, and a W6 site is no longer a `[:>]` site at all. Every
case asserts it by running the fixer on its own output and requiring the result
byte-identical, and a determinism row asserts two analyses of one input agree.

## Two fatal-class bugs the corpus caught

Recorded because the corpus earning its keep on day one is the argument for it.

1. **A bare symbol was read as a symbol value.** W3 rewrote
   `{:on-click handler}` to `{:on-click "handler"}` — a live handler replaced by
   a string, silently. rewrite-clj hands back *syntax*: a symbol token is a
   variable reference, and only a keyword literal or a **quoted** symbol is a
   named value the donor's `(name x)` arm ever saw. Everything reached through a
   symbol now falls to `:computed-value`, which is what §4.4 says of it. The
   same misreading was refusing a perfectly good callback ref as `:named-ref`.
2. Removing the first entry of a metadata map left `^{ :tag "x"}`.

## Quality gates

Every gate run in the foreground to completion, exit code captured directly.

| Gate | Exit |
|---|---|
| `clojure -M:test` in `migration/reagent-to-hicasso/codemod` — 10 tests, 129 assertions | **0** |
| `python scripts/check_doc_slugs.py` | **0** |
| `python -m mkdocs build --strict` (with `migration/` staged into `docs/` as `docs.yml` does) | **0** |
| `python scripts/check_readme_links.py --ci` | **0** |
| `python scripts/check_test_lane_bijection.py --repo-root .` | **0** |
| `python scripts/check_jvm_lane_rosters.py` | **0** |

**A required check this run does not cover, and it needs sequencing.** The new
artefact is on **no CI lane** — `migration/**` triggers only `docs.yml`, which
never compiles Clojure. This matches the sibling exactly (nothing in CI or any
local roster runs `migration/from-re-frame-v1/codemod` either), but it means the
corpus-as-spec currently runs nowhere but a developer's terminal, which is at
odds with §10.1's insistence on executed evidence.

I verified empirically that the fix cannot be made from inside this PR's fence:
adding the artefact to `scripts/test-jvm-tools.sh` makes
`check_jvm_lane_rosters.py` fail R1 —

```
R1 migration/reagent-to-hicasso/codemod: on scripts/test-jvm-tools.sh, but no
.github/workflows/test.yml job runs `clojure -M:test` there
```

— and `.github/workflows/*` is hot-zone. The remedy is one roster line plus one
`test.yml` job, both trivial; I left it for the mayor to sequence rather than
take a hot-zone file another wave may be holding.

## Fence

`migration/reagent-to-hicasso/codemod/**` (all new) plus one line in
`mkdocs.yml`'s `exclude_docs`, which the sibling codemod already needs for the
same reason. `implementation/shadow-cljs.edn` and `implementation/deps.edn` were
not touched; neither was `docs/design/hicasso/product/**`.

## Standing rider

The bead's rider — the door-side `codemod-contract-*` rows as the only executed
evidence — is **already discharged on the donor side**: `rf2-d2mwk` landed
eleven `codemod-contract-donor-*` deftests (PR #7661) pinning Reagent 2.0.1's
answer for every proof sketch W1–W6 rest on. This PR consumes them: `donor.clj`
cites them by name and `shared_rule_test.clj` echoes their rows on the JVM. The
Hicasso half is `conversion-parity-with-the-door-on-one-prop-corpus`, which
§10.1 notes does not carry "codemod" in its name; renaming or aliasing it is the
one-line door-side change that remains.
