### PR TITLE
docs(hicasso): the price record states its reconsideration condition is met (rf2-hr9s)

### DIFF
--- a/docs/design/hicasso/product/k1-price-acceptance.md
+++ b/docs/design/hicasso/product/k1-price-acceptance.md
@@ -2,7 +2,7 @@
 
 **Status: PROPOSED. Not operative.** This is the scoped amendment instrument prepared in Phase 0 and held for the sitting of **2026-08-27**, where **Mike Thompson, acting as re-frame2 product operator, is the decider**. Nothing on this page is in force until he ratifies it. Until then the registered `1.10x` K1 gate remains the only adjudicated mount line, the proposed `1.25x` ceiling may not mark any result green, and rejection at the sitting leaves the registered gate and its consequences in force. The [primary performance contract](specification.md#6-performance-contract) owns the proposed ceiling and the sitting rule; the [evidence baseline](lanes/evidence-baseline.md#k1-price-proposal) records the same pending status; the [decision brief](decision-brief.md) owns the selection this record is the honest bill for.
 
-Three things this record deliberately does not do. It does not recolour the measured result: the miss in §2 is quoted as published, and no threshold anywhere in this tree widens to accommodate it. It does not decide whether the K1 *kill criterion* has tripped — that criterion is a conjunction and only one half is adjudicated. And it does not waive the red read-free boundary-shell row, which the performance contract keeps as a separate prospective disposition that this sitting does not pre-authorize.
+Three things this record deliberately does not do. It does not recolour the measured result: the miss in §2 is quoted as published, and no threshold anywhere in this tree widens to accommodate it. It does not decide whether the K1 *kill criterion* has tripped — at drafting that conjunction had only one half adjudicated, and the operator has since ruled the other half MET (2026-08-10, `rf2-sza0w`), so this record carries the trip in §2.2 rather than deciding it; what the trip asks of the accepted price is §7.1's first reopen condition, now fired, with the answer owed by the decider and pending. And it does not waive the red read-free boundary-shell row, which the performance contract keeps as a separate prospective disposition that this sitting does not pre-authorize.
 
 ## 1. The frozen registered criterion
 
@@ -31,11 +31,17 @@ Both intervals lie entirely above the gate on the losing side, so the mount prem
 
 The figures, the co-instrumented Reagent-on-subs pairs, the labelled unfloored diagnostic, and the residual-uncertainty caveats live at [§4.3 of the corrected-clock re-adjudication](../studio/rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row) and are quoted from nowhere else. Those caveats travel with the row into this record: eight and six outer runs are thin ensembles, the mount check standard was calibrated on the same fourteen runs it then judges, and both ensembles record the same Chromium build. The [evidence baseline](lanes/evidence-baseline.md#pinned-economic-evidence) owns the pinned values.
 
-### 2.2 The trigger half: undecided
+### 2.2 The trigger half: ruled MET on 2026-08-10
 
-Whether the candidate has had **two serious runtime iterations** is a programme judgement rather than a measurement, and no document in this tree decides it. It is an open operator ruling, tracked as `rf2-sza0w`, which also owes what K1's "stop or narrow" consequence would mean in practice were the condition found met.
+**Ruled MET, 2026-08-10 (`rf2-sza0w`).** The operator ruled that the candidate has had **two serious runtime iterations**, on the basis the [validation register](../validation.md#kill-criteria-any-tripping--stop-or-narrow-adapters-only-is-success) records: `rf2-nld4g` closed with no admissible attack clearing the bar, and the interpreter was exonerated at `0.9636x` stock Reagent, locating the deficit outside it. Both conjuncts therefore stand and **K1 is TRIPPED**. The criterion text is as registered, the `1.10x` gate is untouched, and the published miss in §2.1 is not recoloured by the ruling: what the trip supersedes is K1's *stop or narrow* consequence, which the selection of Hicasso together with this scoped record make a formalized narrow-and-price rather than a stop. The [clock page §8](../studio/the-candidates-clock.md#8-what-this-hands-the-programme) carries the same record.
 
-This record neither decides that question nor depends on its answer. What it prices is the measured mount premium in §2.1 — a fact independent of whether the kill criterion is later ruled to have tripped.
+**What the ruling asks of this record, and what is still owed.** What this record prices is the measurement in §2.1, and that fact never depended on the ruling. The record's *standing* does: the ruling is the first of [§7.1](#71-reopen-conditions)'s reopen conditions, and firing it returns this record to the decider. **Whether the accepted price stands or changes, having been reconsidered in that light, is an open operator question and it is pending.** It is not decided here, in either direction, and nothing on this page may be read as deciding it.
+
+Kept rather than erased — the reading this section carried at drafting, superseded on 2026-08-10:
+
+> **2.2 The trigger half: undecided.** Whether the candidate has had **two serious runtime iterations** is a programme judgement rather than a measurement, and no document in this tree decides it. It is an open operator ruling, tracked as `rf2-sza0w`, which also owes what K1's "stop or narrow" consequence would mean in practice were the condition found met.
+>
+> This record neither decides that question nor depends on its answer. What it prices is the measured mount premium in §2.1 — a fact independent of whether the kill criterion is later ruled to have tripped.
 
 ## 3. What the premium buys
 
@@ -97,7 +103,7 @@ The fields any governance change owes under the [measurement posture](lanes/evid
 | Field | Value |
 |---|---|
 | Frozen registered criterion | The K1 row quoted verbatim in §1 — mount above `1.10x` direct UIx on the clock of record, after two serious runtime iterations |
-| Adjudicated status of that criterion | Gate half: **MISSED, DECISIVELY** (`rf2-diaud` / PR #7704), §2.1. Trigger half: **undecided**, open operator ruling `rf2-sza0w`, §2.2 |
+| Adjudicated status of that criterion | Gate half: **MISSED, DECISIVELY** (`rf2-diaud` / PR #7704), §2.1. Trigger half: **ruled MET on 2026-08-10** (`rf2-sza0w`), §2.2 — this field read *undecided, open operator ruling* at drafting. Both conjuncts stand, so **K1 is TRIPPED**; the criterion text and its `1.10x` gate are untouched, and the published miss is not recoloured |
 | Purchased use cases | The read-capability jobs of §3.2, at their census weights |
 | Accepted ceiling | `1.25x` cold mount versus equivalent direct UIx on the agreed representative witness — **proposed**, inoperative until ratified. A future row is read against it only by the comparison rule frozen in §5.1 |
 | Native escape | The five-rung gradient of §4, gated on the canonical native-tier acceptance checklist |
@@ -105,7 +111,7 @@ The fields any governance change owes under the [measurement posture](lanes/evid
 | Decider | Mike Thompson, acting as re-frame2 product operator |
 | Evidence owner | [`lanes/evidence-baseline.md`](lanes/evidence-baseline.md#pinned-economic-evidence) for the pinned values; [corrected-clock §4.3](../studio/rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row) for the published figures and their labels |
 | Effective revision | *(left blank — the sitting fills this on ratification)* |
-| Reopen conditions | §7.1 |
+| Reopen conditions | §7.1. Its first condition **fired on 2026-08-10** with the ruling above; the reconsideration of the accepted price that it calls for is **the decider's, and pending** |
 | Revert condition | §7.2 |
 
 ## 7. Reopen and revert
@@ -115,6 +121,7 @@ The fields any governance change owes under the [measurement posture](lanes/evid
 Any of these returns this record to the decider, whether or not it has been ratified:
 
 - `rf2-sza0w` rules on the two-serious-runtime-iterations conjunct. A ruling that K1 has tripped changes what "stop or narrow" asks of the programme, and the accepted price must be reconsidered in that light.
+    - **FIRED — 2026-08-10.** `rf2-sza0w` ruled the conjunct MET; both conjuncts stand and K1 is TRIPPED (§2.2). This condition is therefore satisfied on its own terms, and the record is returned to the decider. **Whether the accepted price stands or changes, having been reconsidered in that light, is an open operator question and it is pending** — it is not answered here, in either direction. No figure moved when the ruling landed: §5's proposed `1.25x` reads exactly as drafted **because the reconsideration has not been made**, not because it was made and came back unchanged. Until the decider answers, nothing discharges this reopen, and no evidence row may cite the record as though something had.
 - A new clean clock-of-record acceptance row is published on the mount estimand.
 - A named lever plausibly worth the registered `45.7–49.4%` threshold of the measured deficit appears, or the compiler / render-phase / witness-set fences change explicitly. These are the baseline's own reopen conditions for the bounded irreducibility conclusion, and they reopen the price with it.
 - The comparative budgets are ratified against named reference hardware and the representative witness changes as a result.
@@ -148,12 +155,13 @@ On lapse the registered `1.10x` gate and its consequences resume immediately as 
 
 ## 9. Amendments to this record
 
-This record is **proposed**, so it is not yet frozen: the commit that carries it into the sitting is what freezes it, and until then amendment is exactly the window a prospective instrument reserves. Amendments are prospective and never silent — each one is recorded below with its reason, in the manner the sibling [resource-demand criteria](resource-demand-criteria.md#amendment-rule) uses, and none may widen a threshold, recolour the published verdict, or settle a question this record deliberately holds open. After ratification the effective revision governs and `rf2-hic-085`, which owns that field, is the only route to a change.
+This record is **proposed**, so it is not yet frozen: the commit that carries it into the sitting is what freezes it, and until then amendment is exactly the window a prospective instrument reserves. Amendments are prospective and never silent — each one is recorded below with its reason, in the manner the sibling [resource-demand criteria](resource-demand-criteria.md#amendment-rule) uses, and none may widen a threshold, recolour the published verdict, or settle a question this record deliberately holds open. After ratification the effective revision governs and `rf2-hic-085`, which owns that field, is the only route to a change. A **back-fill is not an amendment** — the rule `rf2-mcwm` established for that same sibling record: recording a fact decided elsewhere touches no threshold, verdict or rule, so it does not re-freeze this one. Back-fills are logged in the same table and marked as such, because the discipline this record keeps is that no change to it is silent, not that only amendments are written down.
 
 | Date | Bead | Amendment | Thresholds and verdicts touched |
 |---|---|---|---|
 | 2026-08-09 | `rf2-hic-003` | Made the lapse terms executable, on a merged-PR audit of the drafting PR. §5.1 freezes the prospective rule for reading a future canonical K1 row against the ceiling; §7.2 names the two ambient-read witnesses and the native-tier checklist with their exact owners, and records that two of the three are unwitnessed. | None. The registered `1.10x` gate, the proposed `1.25x` ceiling, the published `rf2-diaud` miss and the undecided `rf2-sza0w` conjunct all stand exactly as drafted. |
 | 2026-08-09 | `rf2-hic-003` | Named the ordinary-application owners, on a merged-PR audit of the amendment above. That row read "no bead owes it yet", which was already stale when it merged: `rf2-hic-025` and `rf2-hic-074` own this proof jointly and are now cited in §7.2. The witness itself is unchanged and still does not exist. | None. No witness was added, no status was promoted, and the sentence that lapse fires on a red result rather than on a missing one is unchanged. |
+| 2026-08-10 | `rf2-hr9s` | **A back-fill, not an amendment.** The operator's K1 ruling of 2026-08-10 (`rf2-sza0w`) is recorded where this record was silent about it: §2.2 now reads *ruled MET* and keeps its drafting text verbatim beneath, the §6 adjudicated-status and reopen-condition rows follow it, §7.1's first condition is marked **fired**, and the preamble's "only one half is adjudicated" is dated to drafting. Nothing here decides what the fired condition asks. | None. The registered `1.10x` gate, the proposed `1.25x` ceiling, the frozen §5.1 comparison rule and the published `rf2-diaud` miss are untouched, and no criterion changed, so the record does not re-freeze. Whether the reconsidered price stands or changes is the decider's, is unanswered in either direction, and is now recorded as pending rather than left silent. |
 
 ## Sources
 


### PR DESCRIPTION
`docs/design/hicasso/product/k1-price-acceptance.md` states in its own §7.1 that a ruling on the two-serious-runtime-iterations conjunct requires the accepted price to be reconsidered. The operator made that ruling on 2026-08-10 (`rf2-sza0w`) — PR #7733 landed it in `validation.md`'s K1 row and in `studio/the-candidates-clock.md` §8 — and this record was silent about it, reading in three places as though the conjunct were still undecided. A reader at the sitting would have concluded the price stands unreconsidered when the record's own rule says otherwise.

This PR records the fact. It does **not** decide what the fired condition asks; that is the operator's, and it is written down as pending.

## The three sections, before and after

**§2.2** — heading and body.

- Before: `### 2.2 The trigger half: undecided` … "Whether the candidate has had **two serious runtime iterations** is a programme judgement rather than a measurement, and no document in this tree decides it. It is an open operator ruling, tracked as `rf2-sza0w` …" / "This record neither decides that question nor depends on its answer."
- After: `### 2.2 The trigger half: ruled MET on 2026-08-10`, opening "**Ruled MET, 2026-08-10 (`rf2-sza0w`).**" with the basis `validation.md` records (`rf2-nld4g` closed with no admissible attack clearing the bar; the interpreter exonerated at `0.9636x` stock Reagent), "Both conjuncts therefore stand and **K1 is TRIPPED**", the criterion text and `1.10x` gate untouched, the published miss not recoloured, the *stop or narrow* consequence superseded by a formalized narrow-and-price, and a cross-reference to the clock page §8. Both drafting paragraphs are **kept verbatim** beneath, as a blockquote headed "Kept rather than erased — the reading this section carried at drafting, superseded on 2026-08-10".

**§6, the record table** — two cells.

- Adjudicated status — before: "Gate half: **MISSED, DECISIVELY** (`rf2-diaud` / PR #7704), §2.1. Trigger half: **undecided**, open operator ruling `rf2-sza0w`, §2.2". After: "… Trigger half: **ruled MET on 2026-08-10** (`rf2-sza0w`), §2.2 — this field read *undecided, open operator ruling* at drafting. Both conjuncts stand, so **K1 is TRIPPED**; the criterion text and its `1.10x` gate are untouched, and the published miss is not recoloured".
- Reopen conditions — before: "§7.1". After: "§7.1. Its first condition **fired on 2026-08-10** with the ruling above; the reconsideration of the accepted price that it calls for is **the decider's, and pending**". A reader consulting this field for "has anything fired?" now gets the answer there.

**§7.1** — the first reopen condition is preserved verbatim and annotated with a nested, dated **FIRED — 2026-08-10** entry.

## The open operator question, in the words used

Recorded in §2.2 and §7.1 as:

> **Whether the accepted price stands or changes, having been reconsidered in that light, is an open operator question and it is pending** — it is not answered here, in either direction.

§7.1 adds the sentence that closes off the reading this bead most needed to prevent:

> No figure moved when the ruling landed: §5's proposed `1.25x` reads exactly as drafted **because the reconsideration has not been made**, not because it was made and came back unchanged. Until the decider answers, nothing discharges this reopen, and no evidence row may cite the record as though something had.

§6's reopen row and the preamble carry the same "pending" in shorter form. Nothing on the page leans either way.

## §9: a back-fill, not an amendment

By the file's own §9 definition an amendment changes a rule; this changes none. `rf2-mcwm` established the distinction in the sibling `resource-demand-criteria.md` ("recording provenance touches no criterion, so it does not re-freeze the file"), and it applies here: no threshold, verdict, criterion or comparison rule moved. So the record does **not** re-freeze.

It is still logged, because this file's discipline is that no change to it is silent. §9 gains one sentence stating that back-fills are not amendments, do not re-freeze the record, and are logged in the same table marked as such; and the ledger gains a dated `rf2-hr9s` row that opens "**A back-fill, not an amendment.**" and records "None" in the thresholds-and-verdicts column.

## One fourth section, flagged

The bead names three stale places. A fourth would have contradicted them: the preamble's "It does not decide whether the K1 *kill criterion* has tripped — that criterion is a conjunction and only one half is adjudicated". Left alone, the front page would have said one half was adjudicated three paragraphs above §2.2 saying both are. The clause is now dated to drafting — "at drafting that conjunction had only one half adjudicated, and the operator has since ruled the other half MET (2026-08-10, `rf2-sza0w`), so this record carries the trip in §2.2 rather than deciding it" — which preserves the original fact and keeps the sentence's "does not do" force. Called out here because it is outside the bead's enumerated three.

## Untouched, confirmed

The proposed `1.25x` ceiling (§5) and the §1 frozen registered-criterion block are byte-identical to `origin/main` — neither appears in the diff. The §5.1 comparison rule, the §7.2 lapse terms and witness table, the `1.10x` gate, the published `rf2-diaud` figures and the blank effective-revision field are all unchanged. The two 2026-08-09 ledger rows are left as written: they are dated records of what was true when those amendments landed, and rewriting them would erase history rather than annotate it.

## Reported, not fixed

Nothing in this file cites the closed `rf2-2rtt6.1` (`rf2-sdlw`'s surface), and no other out-of-scope defect was found. One observation for the record: `validation.md` already describes this record as "carrying this very ruling as the first of its reconsideration triggers", so the two pages now interlock rather than merely coexist.

## Quality gates

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |

Both run in the foreground to completion, redirected to worktree-local logs, never piped. The pins gate reports "1 files, 0 cited pins (0 landed, 0 stranded, 0 unresolvable)" — the known trap on this exact file (an unseparated digit run read as a commit pin) is avoided: every date is ISO with hyphens, and no bare 7+ digit run or hex-looking token was introduced. Noted that this gate fails open per-block, so its green is not proof a hash is right; no hash was touched.

**Sabotage control.** `#71-reopen-conditions` in §2.2 was broken to `#71-reopen-conditions-SABOTAGE`; `check_doc_slugs.py` exited **1** with `BROKEN ANCHOR: docs\design\hicasso\product\k1-price-acceptance.md:38 -> #71-reopen-conditions-SABOTAGE`, naming this file. Restored, re-run, exit **0**.

**Hand-verified.** Every link introduced resolves: `../validation.md#kill-criteria-any-tripping--stop-or-narrow-adapters-only-is-success`, `../studio/the-candidates-clock.md#8-what-this-hands-the-programme`, the intra-file `#71-reopen-conditions`, and `resource-demand-criteria.md#amendment-rule`. The §2.2 heading change retires the anchor `#22-the-trigger-half-undecided`; a repo-wide `git grep` finds **0** inbound links to it, and only two documents link into this file at all (`validation.md`, to §5 and §7.1 — both intact).

**Table column counts**, every row in the file: §2.1 ensembles 4/4/4/4; §3.2 purchased jobs 3 × 6 rows; §4 ladder 3 × 7 rows; **§6 record 2 cells × 13 rows** including both edited cells; §7.2 witnesses 4 × 5 rows; **§9 ledger 4 cells × 5 rows** including the new one. No cell text introduces a stray pipe.

Closes rf2-hr9s.
