### PR TITLE
fix(hicasso): the clock's consumers require complete evidence before pooling (rf2-8a746)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_check_standard.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_check_standard.cjs
@@ -127,6 +127,28 @@
 // applied to a hold-out record: the arithmetic that produced it is driven over
 // the committed corpus by `clock_exit_path.test.cjs`, which has the datasets;
 // the fixtures here stay synthetic and check the record's SHAPE and its claims.
+//
+// ## v4 — THE EVIDENCE CARDINALITY IS PART OF THE STANDARD (rf2-8a746,
+// merged-PR audit #7698, 2026-08-10)
+//
+// Retiring the all-blocks rule (v1) retired a PER-BLOCK VERDICT, and this
+// module then read that retirement as licence to accept ANY number of blocks:
+// a one-element list at the frozen centre came back `ok: true` with `n: 1` and
+// `robustScale: 0`, and a committed six-round row truncated to one round still
+// passed on its three surviving segment blocks. That confuses retiring
+// all-blocks-in-band with allowing blocks to be ABSENT. The frozen limits are
+// statistics OF the declared design — a location band of run MEDIANS over 18
+// blocks, a dispersion limit of 18-block robust scales — so a smaller or
+// larger block set is not the quantity the limits were calibrated on, and
+// certifying it "in control" asserts against it a value never measured on it,
+// which is the exact mis-specification this whole standard exists to retire.
+//
+// So `checkStandard` — the direct helper both consumers share — now carries an
+// EXPECTED-N CONTRACT: exactly `STANDARD.evidence.expectedBlocks` finite
+// readings (18, from the declared 6-round x 3-segment design, stated once in
+// the JSON), refused otherwise with observed and expected counts. It is a
+// completeness rule on the evidence, not a per-block verdict: no block's own
+// VALUE rejects anything, so the v1 retirement stands untouched.
 
 'use strict';
 
@@ -232,6 +254,23 @@ function checkStandard(perBlockRatios, rowId) {
       xs.length === 0
         ? 'no blocks — an empty block set is an absent reading, not a run in control'
         : `${xs.length - finite.length} of ${xs.length} blocks are not finite readings of a level ratio`;
+    return base;
+  }
+  // THE EXPECTED-N CONTRACT (rf2-8a746, merged-PR audit #7698). The frozen
+  // limits are statistics of the declared 6-round x 3-segment design — a
+  // location band of run medians over 18 blocks, a dispersion limit of
+  // 18-block robust scales — so a run is judged only when it carries EXACTLY
+  // that many readings. Before this check, a one-element list at the frozen
+  // centre certified with `n: 1` and `robustScale: 0`. This is a completeness
+  // rule and not a per-block verdict: no block's VALUE rejects anything here,
+  // so the v1 all-blocks retirement stands.
+  const expected = STANDARD.evidence.expectedBlocks;
+  if (finite.length !== expected) {
+    base.why =
+      `${finite.length} block(s) observed where the frozen standard's ${STANDARD.evidence.design.rounds}-round x ` +
+      `${STANDARD.evidence.design.segments}-segment design requires exactly ${expected} — ` +
+      `${finite.length < expected ? 'a MISSING round or block' : 'an EXTRA round or block'} is an incomplete or ` +
+      'foreign evidence set, and limits calibrated on the full design certify nothing about it (rf2-8a746, audit #7698)';
     return base;
   }
 
@@ -515,6 +554,55 @@ function checkStandardSelfTest() {
   check('an EMPTY block set is not a pass', !checkStandard([], BULK).ok && /empty block set/.test(checkStandard([], BULK).why));
   check('and a block that is not a finite reading refuses the run', !checkStandard([...blocksAt(2, 17, 0.05), NaN], BULK).ok);
   check('a missing block set is absent, not clean', !checkStandard(undefined, BULK).ok && !checkStandard(null, BULK).ok);
+
+  // 6b. THE EVIDENCE CARDINALITY (rf2-8a746, merged-PR audit #7698). The
+  //     audit's own demonstration comes first: ONE block sitting dead on the
+  //     frozen centre used to certify with `n: 1` and `robustScale: 0`,
+  //     because a single reading trivially has no dispersion and is its own
+  //     median. The refusal must carry observed and expected counts, and it
+  //     must be the CARDINALITY refusing — not the block's value, which is
+  //     deliberately unimpeachable here.
+  const oneBlock = checkStandard(blocksAt(2, 1), BULK);
+  check(
+    'THE AUDIT WITNESS: one block at the frozen centre is REFUSED for incompleteness, never certified with n: 1',
+    !oneBlock.ok && /1 block\(s\) observed/.test(oneBlock.why || '') && /exactly 18/.test(oneBlock.why || ''),
+    oneBlock.why
+  );
+  const oneRound = checkStandard(blocksAt(2, 3, 0.02), BULK);
+  check(
+    'a row TRUNCATED to one round — three segment blocks of the six-round design — is refused with the counts',
+    !oneRound.ok && /3 block\(s\) observed/.test(oneRound.why || '') && /MISSING round/.test(oneRound.why || ''),
+    oneRound.why
+  );
+  check(
+    'a single MISSING round (15 of 18) refuses, and a single EXTRA round (21 of 18) refuses too',
+    !checkStandard(blocksAt(2, 15, 0.02), BULK).ok &&
+      /15 block\(s\) observed/.test(checkStandard(blocksAt(2, 15, 0.02), BULK).why || '') &&
+      !checkStandard(blocksAt(2, 21, 0.02), BULK).ok &&
+      /EXTRA round/.test(checkStandard(blocksAt(2, 21, 0.02), BULK).why || '')
+  );
+  check(
+    'the boundary is exact: 17 refuses, 18 certifies, 19 refuses — on the same healthy world',
+    !checkStandard(blocksAt(2, 17, 0.02), BULK).ok &&
+      checkStandard(blocksAt(2, 18, 0.02), BULK).ok &&
+      !checkStandard(blocksAt(2, 19, 0.02), BULK).ok
+  );
+  check(
+    'the cardinality contract holds on EVERY calibrated class, not the first one written',
+    !checkStandard(blocksAtIn(mount, 2, 1), MOUNT).ok && /exactly 18/.test(checkStandard(blocksAtIn(mount, 2, 1), MOUNT).why || '')
+  );
+  check(
+    "the expected count is the JSON's, derived from the declared design rather than written twice",
+    STANDARD.evidence.expectedBlocks === 18 &&
+      STANDARD.evidence.design.rounds * STANDARD.evidence.design.segments === STANDARD.evidence.expectedBlocks &&
+      /rf2-8a746/.test(STANDARD.evidence.ruling),
+    JSON.stringify(STANDARD.evidence.design)
+  );
+  check(
+    'and the completeness refusal is NOT the retired per-block rule returning: an in-band count still decides nothing',
+    oneRound.location === null && oneRound.tolerance === null,
+    'a cardinality refusal happens before location, dispersion or the reported band are computed'
+  );
 
   // 7. THE STANDARD IS DATA AND SAYS WHICH DATA IT IS. A verdict that did not
   //    carry its version could not be re-read after a recalibration — and v2

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_check_standard.json
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_check_standard.json
@@ -1,6 +1,6 @@
 {
   "id": "hicasso-clock/ctl-2x-level",
-  "version": 3,
+  "version": 4,
   "ruling": "rf2-8a746",
   "frozen": "2026-08-07",
   "amendments": [
@@ -17,6 +17,13 @@
       "ruling": "rf2-c1974",
       "what": "The limits are VALIDATED OUT OF SAMPLE, to the strongest independence this corpus supports — a SESSION-level hold-out. Each class's limits are re-derived from ONE ensemble and the OTHER is judged against them, both ways, and each provenance.independence field now carries what that measured in place of v1 and v2's honest admission that it had never been measured. Bulk passes both ways; the MOUNT DIRECTIONS DISAGREE, and that is recorded as the finding rather than averaged away.",
       "touches": "the two provenance.independence fields, a new provenance.holdOut record on each class, and one recalibrateOn entry naming the residual. NO NUMBER THAT DECIDES ANYTHING MOVED: every centre, location limit, dispersion limit, tolerance band and error rate is byte-identical to v2, and no hard refusal is involved. Nothing was widened to make a hold-out pass — the fence rf2-c1974 was raised under."
+    },
+    {
+      "version": 4,
+      "date": "2026-08-10",
+      "ruling": "rf2-8a746",
+      "what": "The consumer boundary requires the frozen design's EVIDENCE CARDINALITY before it computes anything. Merged-PR audit #7698 found checkStandard certifying a one-element ratio list at the frozen centre (ok: true with n: 1 and robustScale: 0) and checkStandardFor accepting a row truncated to one round — three segment blocks judged by limits calibrated on eighteen. Retiring the per-block unanimity rule (v1) never meant allowing blocks to be ABSENT: a location limit derived from 18-block run medians says nothing about the median of a 3-block subset of one. The new top-level `evidence` field states the expected count once — 18 blocks, from the declared 6-round x 3-segment design — and every consumer refuses a missing or extra round/block with observed and expected counts in the refusal.",
+      "touches": "adds the top-level `evidence` field and this amendment entry only. Every centre, location limit, dispersion limit, tolerance band and error rate is byte-identical to v3; no hard refusal (read-back, canonical-DOM, page-error, arm-order, quiet-box, band-ceiling) is involved; the location/dispersion run-rejection rule is unchanged — a run now simply has to be COMPLETE before that rule is consulted."
     }
   ],
   "what": "The level-denominated check standard for the Hicasso clock (clock_run.cjs). The measured quantity is the ctl-2x arm's TARED TaskDuration over the floor's TARED TaskDuration, in the same round of the same segment — one per block, 18 per row-run. Both terms are LEVELS, so the ~0.4 ms of estimator error each arm's p50 carries is 9% of a ~4.5 ms denominator rather than 48% of a 1.2 ms difference. It replaces the three-point difference-of-differences control, which rf2-8a746 retired as a gate.",
@@ -28,6 +35,13 @@
   },
   "runRejection": "a run is IN CONTROL when its block median lies inside the frozen location limits AND its robust scale is at or under the frozen dispersion limit. Nothing per-block rejects a run: the retired rule required all 18 blocks inside a tolerance band, and 0.835^18 = 3.9% is why a control that fully met its premise still passed only 4 of 42 runs.",
   "toleranceBandIsNotTheRule": "The per-block tolerance band below is REPORTED and decides nothing. rf2-8a746 ruled that the tolerance band and the run-rejection rule get distinct, calibrated error rates; these are they.",
+  "evidence": {
+    "ruling": "rf2-8a746",
+    "audit": "merged-PR audit #7698 (2026-08-09)",
+    "design": { "rounds": 6, "segments": 3 },
+    "expectedBlocks": 18,
+    "rule": "a run's block list must carry EXACTLY expectedBlocks finite readings — one (round, segment) pair per block of the declared 6-round x 3-segment design — before location or dispersion is computed. A missing or extra round/block refuses with observed and expected counts: retiring the per-block unanimity rule never meant allowing blocks to be absent, and a location limit calibrated on 18-block run medians says nothing about the median of a smaller or larger set. This is a COMPLETENESS requirement on the evidence, not a per-block verdict — no block's own value rejects anything here."
+  },
   "classes": {
     "bulk": {
       "rows": ["bulk300", "bulk100", "narrow"],

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -3881,7 +3881,10 @@ function fixtureRoundsTask(over) {
     // The fixture is only worth its name if it refuses where a run is
     // actually adjudicated, so it is driven through `reportable` on a record
     // shaped as `clock_run.cjs` writes one.
-    const CANON = { canonical: true, notCanonicalWhy: null, design: { tare: true } };
+    // `rounds` is here because the consumer now checks the raw readings against
+    // the file's own declared design (rf2-8a746, audit #7698) — a design that
+    // does not declare its round count refuses, absent is not clean.
+    const CANON = { canonical: true, notCanonicalWhy: null, design: { rounds: 6, tare: true } };
     const ADJ = { unadjudicated: false, why: 'clears' };
     const row = (rt) => ({
       rowId: 'bulk300', pageErrors: [], guardRefuse: false, guardRefuseTask: false, parityOk: true,
@@ -3989,7 +3992,10 @@ function fixtureRoundsTask(over) {
   });
 
   t('criterion 1: and behaviourally — flipping the three-point record changes no verdict', () => {
-    const CANON = { canonical: true, notCanonicalWhy: null, design: { tare: true } };
+    // `rounds` is here because the consumer now checks the raw readings against
+    // the file's own declared design (rf2-8a746, audit #7698) — a design that
+    // does not declare its round count refuses, absent is not clean.
+    const CANON = { canonical: true, notCanonicalWhy: null, design: { rounds: 6, tare: true } };
     const ADJ = { unadjudicated: false, why: 'clears' };
     const base = {
       rowId: 'bulk300', pageErrors: [], guardRefuse: false, guardRefuseTask: false, parityOk: true,
@@ -4506,10 +4512,13 @@ function fixtureRoundsTask(over) {
     // instance and putting it back, which is also the shape of this PR's own
     // mutation proof.
     const before = JSON.stringify(STANDARD.classes.mount);
+    // A FULL 18-block reading list (rf2-8a746 audit #7698 gave the helper an
+    // expected-N contract), so the only thing refusing below is the class.
+    const MREADS = Array.from({ length: 6 }, () => [1.79, 1.8, 1.81]).flat();
     let v;
     try {
       STANDARD.classes.mount.calibrated = false;
-      v = checkStandard([1.79, 1.8, 1.81], 'M1');
+      v = checkStandard(MREADS, 'M1');
     } finally {
       STANDARD.classes.mount.calibrated = true;
     }
@@ -4518,7 +4527,7 @@ function fixtureRoundsTask(over) {
     assert.strictEqual(v.location, null, 'and it refuses on the CLASS, before any reading is judged');
     assert.match(v.why, /NOT CALIBRATED/);
     assert.strictEqual(JSON.stringify(STANDARD.classes.mount), before, 'the fixture must leave the standard as it found it');
-    assert.strictEqual(checkStandard([1.79, 1.8, 1.81], 'M1').ok, true, 'and the class certifies again afterwards');
+    assert.strictEqual(checkStandard(MREADS, 'M1').ok, true, 'and the class certifies again afterwards');
   });
 }
 
@@ -4751,7 +4760,10 @@ function fixtureRoundsTask(over) {
   // --- 6. THE VERSION, THE AMENDMENT AND THE RESIDUAL -----------------------
 
   t('v3 is an amendment with its own entry, and the earlier admissions are replaced by measurements', () => {
-    assert.strictEqual(STANDARD.version, 3, 'replacing an independence claim is a version bump — a stored verdict must stay re-readable');
+    // The version has moved on since (v4, rf2-8a746 audit #7698), so the pin is
+    // on the amendment that records THIS change rather than on the head number
+    // — the same reading the rf2-x7x10 block gives its own v2.
+    assert.ok(STANDARD.version >= 3, 'replacing an independence claim is a version bump — a stored verdict must stay re-readable');
     const a = STANDARD.amendments.find((x) => x.ruling === 'rf2-c1974');
     assert.ok(a, 'the amendment log must carry this change');
     assert.strictEqual(a.version, 3);
@@ -5421,6 +5433,266 @@ function fixtureRoundsTask(over) {
       for (const bead of ['rf2-vp0j7', 'rf2-vh0e3']) {
         assert.ok(new RegExp(bead).test(src), `${path.basename(f)} must cite ${bead}`);
       }
+    }
+  });
+}
+
+// ============================================================================
+// rf2-8a746, MERGED-PR AUDITS #7698 AND #7700 — EVIDENCE COMPLETENESS AT THE
+// CONSUMER BOUNDARY
+// ============================================================================
+//
+// Two audits of this ruling's own merged PRs found the same seam open twice:
+// ELIGIBILITY was decided on the serialised verdicts while the RAW EVIDENCE
+// behind them could be missing, and each consumer quietly worked with whatever
+// survived.
+//
+//   #7698  `checkStandard` certified a ONE-ELEMENT ratio list at the frozen
+//          centre (`ok: true`, `n: 1`, `robustScale: 0`), and
+//          `checkStandardFor` accepted a committed six-round row TRUNCATED to
+//          one round — three segment blocks judged by limits that are
+//          statistics of the 18-block design. Retiring the all-blocks rule
+//          never meant allowing blocks to be ABSENT.
+//   #7700  `passIdx.map(pairedLogRatios).filter(Boolean)` dropped a reportable
+//          run whose raw pair readings were unusable, and `effectInterval`
+//          filtered again — blanking ONE reading of ONE run still published
+//          "an interval over 7 reportable run(s)" where 8 had cleared every
+//          gate, with nothing anywhere saying evidence was lost.
+//
+// The witnesses below are the audits' own demonstrations, driven against the
+// committed clock-emvod corpus where both defects were shown live, plus the
+// fence that nothing adjudicative moved: the frozen limits are byte-identical
+// (pinned to the last place by the rf2-x7x10 and rf2-c1974 blocks above) and
+// both committed ensembles still read COMPLETE and still exit 0 (pinned by the
+// corpus cases above). What changed is only that an INCOMPLETE evidence set
+// now refuses, by name, instead of shrinking silently.
+{
+  const { STANDARD, checkStandard } = require('./clock_check_standard.cjs');
+  const {
+    checkStandardFor, pairedLogRatios, effectInterval, reportable, refusals,
+  } = require('./clock_readjudicate.cjs');
+  const { reportability } = require('./clock_run.cjs');
+  const t = (what, fn) => test(`rf2-8a746 audits #7698/#7700: ${what}`, fn);
+  const RJ = path.join(__dirname, 'clock_readjudicate.cjs');
+  const ROWS_WITH_STANDARD = ['bulk300', 'bulk100', 'narrow', 'M1'];
+  const PAIRS_ALL = ['hicasso / reagent-subs', 'hicasso / uix-subs', 'uix-subs / reagent-subs'];
+
+  const corpus = (dir) => {
+    const d = path.join(__dirname, 'data', dir);
+    if (!fs.existsSync(d)) return null;
+    return fs.readdirSync(d).sort().map((f) => ({
+      file: path.join(d, f),
+      name: f,
+      data: JSON.parse(fs.readFileSync(path.join(d, f), 'utf8')),
+    }));
+  };
+
+  // --- #7698: THE DIRECT HELPER'S EXPECTED-N CONTRACT -----------------------
+
+  t('WITNESS (one block): a one-element list at the frozen centre is REFUSED, never certified with n: 1', () => {
+    // The audit's exact demonstration: the single reading sits DEAD ON the
+    // frozen centre, so only the cardinality can be what refuses it.
+    for (const [rowId, klass] of [['bulk300', STANDARD.classes.bulk], ['M1', STANDARD.classes.mount]]) {
+      const v = checkStandard([klass.centre], rowId);
+      assert.strictEqual(v.ok, false, `${rowId}: one block must not certify`);
+      assert.match(v.why, /1 block\(s\) observed/, `${rowId}: the refusal carries the observed count`);
+      assert.match(v.why, /exactly 18/, `${rowId}: and the expected count`);
+      assert.strictEqual(v.location, null, `${rowId}: refused BEFORE location was computed`);
+      assert.strictEqual(v.dispersion, null, `${rowId}: and before dispersion`);
+    }
+  });
+
+  t('missing and extra blocks refuse in both directions, and the boundary is exact at 18', () => {
+    const at = (n) => Array.from({ length: n }, () => STANDARD.classes.bulk.centre);
+    for (const n of [2, 3, 15, 17]) {
+      const v = checkStandard(at(n), 'bulk300');
+      assert.strictEqual(v.ok, false, `${n} blocks must refuse`);
+      assert.match(v.why, new RegExp(`${n} block\\(s\\) observed`), `${n}: observed count in the message`);
+      assert.match(v.why, /MISSING round/, `${n}: named as the missing direction`);
+    }
+    for (const n of [19, 21, 36]) {
+      const v = checkStandard(at(n), 'bulk300');
+      assert.strictEqual(v.ok, false, `${n} blocks must refuse`);
+      assert.match(v.why, /EXTRA round/, `${n}: named as the extra direction`);
+    }
+    assert.strictEqual(checkStandard(at(18), 'bulk300').ok, true, '18 at the centre still certifies — the contract is exact, not a floor');
+  });
+
+  t('the expected count is the STANDARD\'s own field, tied to the declared 6-round x 3-segment design', () => {
+    assert.strictEqual(STANDARD.evidence.expectedBlocks, 18);
+    assert.strictEqual(
+      STANDARD.evidence.design.rounds * STANDARD.evidence.design.segments,
+      STANDARD.evidence.expectedBlocks,
+      'the count is the design\'s arithmetic, stated once'
+    );
+    assert.strictEqual(STANDARD.evidence.ruling, 'rf2-8a746');
+    assert.strictEqual(STANDARD.version, 4, 'requiring completeness is a consumer-contract change — a version bump with its own amendment');
+    const a = STANDARD.amendments.find((x) => x.version === 4);
+    assert.ok(a && a.ruling === 'rf2-8a746' && /#7698/.test(a.what), 'the amendment names the audit');
+    assert.match(a.touches, /byte-identical to v3/, 'and swears the frozen numbers did not move');
+  });
+
+  // --- #7698: THE TRUNCATED-ROUND WITNESS, ON THE COMMITTED CORPUS ----------
+
+  t('WITNESS (truncated round, committed corpus): every row cut to one round is REFUSED — none still passes', () => {
+    // The audit's finding was that "several rows still pass the standard"
+    // after truncation. The count of survivors must now be ZERO, over every
+    // dataset of the ensemble the audit demonstrated on and every row that
+    // has a standard.
+    const c = corpus('clock-emvod');
+    if (!c) return; // datasets are retained, not required to build
+    let checked = 0;
+    let passed = 0;
+    for (const { data } of c) {
+      for (const rowId of ROWS_WITH_STANDARD) {
+        const row = data.rows.find((r) => r.rowId === rowId);
+        if (!row) continue;
+        const cut = { ...row, roundsTask: row.roundsTask.slice(0, 1) };
+        const v = checkStandardFor(cut, data);
+        checked += 1;
+        if (v.ok) passed += 1;
+        assert.match(v.why || '', /1 round\(s\) of TaskDuration readings/, `${rowId}: observed rounds in the message`);
+        assert.match(v.why || '', /declared design of 6/, `${rowId}: expected rounds in the message`);
+        // and the refusal reaches the POOLING decision: the run leaves the
+        // reportable subset for a stated cause — no pool.
+        assert.strictEqual(reportable(cut, data), false, `${rowId}: a truncated run may not be pooled`);
+        assert.ok(refusals(cut, data).some((w) => /TRUNCATED or PADDED/.test(w)), `${rowId}: and the refusal names itself`);
+      }
+    }
+    assert.strictEqual(checked, 32, 'four rows with a standard over eight committed datasets');
+    assert.strictEqual(passed, 0, `${passed} truncated row(s) still certified — the audit defect is back`);
+  });
+
+  t('a record whose OWN declared design is short cannot smuggle a smaller count past the boundary', () => {
+    // Internal consistency alone would wave this through: one round declared,
+    // one round present. The expected-N contract is the standard's, so the
+    // three consistent blocks still refuse with both counts named.
+    const c = corpus('clock-emvod');
+    if (!c) return;
+    const { data } = c[0];
+    const row = data.rows.find((r) => r.rowId === 'bulk300');
+    const cut = { ...row, roundsTask: row.roundsTask.slice(0, 1) };
+    const v = checkStandardFor(cut, { ...data, design: { ...data.design, rounds: 1 } });
+    assert.strictEqual(v.ok, false);
+    assert.match(v.why, /3 block\(s\) observed/);
+    assert.match(v.why, /exactly 18/);
+    // and a design that declares NO round count is absent, not clean
+    const noRounds = checkStandardFor(row, { ...data, design: { tare: data.design.tare } });
+    assert.strictEqual(noRounds.ok, false);
+    assert.match(noRounds.why, /declares no round count/);
+  });
+
+  t('and a truncation refusal is a NONZERO exit in the driver\'s own seat', () => {
+    // `clock_run.cjs` reads `checkStandard.ok` into `ctlOk`, and
+    // `reportability` is the one pure function its exit code comes from — so
+    // the cardinality refusal reaching it as `ctlOk: false` is what makes a
+    // truncated run red rather than quietly unreportable.
+    const rows = [{ rowId: 'bulk300', ctlOk: false, ctlNote: ' (check standard hicasso-clock/ctl-2x-level v4: 3 block(s) observed where the frozen standard\'s 6-round x 3-segment design requires exactly 18)', adjudicable: true }];
+    const v = reportability(rows);
+    assert.strictEqual(v.code, 1, 'a run the standard refused must not exit 0');
+  });
+
+  // --- #7700: THE INTERVAL CONSUMER REFUSES, NEVER FILTERS ------------------
+
+  t('effectInterval REJECTS an invalid member rather than filtering it, citing the ruling', () => {
+    const good = Array(6).fill(Math.log(1.2));
+    assert.throws(() => effectInterval([good, null]), /rf2-8a746/, 'a null member is refused, not dropped');
+    assert.throws(() => effectInterval([good, []]), /never filtered into a smaller unstated subset/, 'an empty member too');
+    assert.throws(() => effectInterval([good, [Math.log(1.2), NaN]]), /merged-PR audit #7700/, 'and a member with a non-finite entry');
+    const iv = effectInterval([good, good, good]);
+    assert.ok(iv && iv.runs === 3, 'a complete pool still forms its interval');
+    assert.strictEqual(effectInterval([]), null, 'an EMPTY pool is no interval, not a refusal — nothing was pooled and nothing was lost');
+    assert.strictEqual(effectInterval(undefined), null);
+  });
+
+  t('WITNESS (mutation, committed corpus): blanking one raw reading is caught, named, and exits 4', () => {
+    // Audit #7700's live witness, end to end: blank ONLY run1's
+    // `roundsTask[0].hicasso.hicasso` on M1. Every serialised gate verdict is
+    // untouched, so eligibility is UNCHANGED — which is exactly what made the
+    // old behaviour silent — and the raw evidence behind the hicasso pairs is
+    // gone.
+    const c = corpus('clock-emvod');
+    if (!c) return;
+    const mutated = JSON.parse(JSON.stringify(c[0].data));
+    const m1 = mutated.rows.find((r) => r.rowId === 'M1');
+    m1.roundsTask[0].hicasso.hicasso = [];
+    // eligibility survives the mutation — the defect's precondition, asserted
+    assert.strictEqual(reportable(m1, mutated), true, 'the run still clears every gate — evidence loss is NOT an eligibility question');
+    assert.strictEqual(pairedLogRatios(m1, 'hicasso / uix-subs', mutated), null, 'and the estimand refuses to form');
+    assert.strictEqual(pairedLogRatios(m1, 'hicasso / reagent-subs', mutated), null);
+    assert.ok(Array.isArray(pairedLogRatios(m1, 'uix-subs / reagent-subs', mutated)), 'the unblanked pair still forms');
+
+    // through the PROGRAM, which is where the audit found the silent subset:
+    // the same ensemble with run1 mutated, spawned from disk.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hic-8a746-'));
+    try {
+      const files = c.map(({ name, data }, i) => {
+        const p = path.join(tmp, name);
+        fs.writeFileSync(p, JSON.stringify(i === 0 ? mutated : data));
+        return p;
+      });
+      const r = cp.spawnSync(process.execPath, [RJ, ...files], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+      const out = `${r.stdout}${r.stderr}`;
+      assert.strictEqual(r.status, 4, `the program must exit 4 on raw evidence lost after eligibility — got ${r.status}: ${out.slice(-1500)}`);
+      assert.match(out, /RAW EVIDENCE LOST AFTER ELIGIBILITY/, 'the loss is announced where the interval would have printed');
+      assert.match(out, /run1\.json: row M1, pair `hicasso \/ uix-subs`/, 'the exit roster names the file and the pair');
+      assert.match(out, /run1\.json: row M1, pair `hicasso \/ reagent-subs`/, 'both hicasso pairs of the blanked segment');
+      // THE AUDIT'S OWN SENTENCE, scoped to the row it demonstrated on: the M1
+      // block must not publish "an interval over 7 reportable run(s)" where 8
+      // cleared the gates. (`narrow` legitimately pools 7 of 8 on this
+      // ensemble — ONE run refused BY A GATE, with its reason printed in the
+      // refusal table — which is the stated-subset path and exactly the
+      // distinction this witness exists to draw.)
+      const m1Block = out.slice(out.indexOf(';; ======== ROW M1'), out.indexOf(';; ======== ROW bulk300'));
+      assert.ok(m1Block.length > 0, 'the M1 block must be printed');
+      assert.ok(!/over 7 reportable run\(s\)/.test(m1Block), 'no M1 interval claims 7 reportable runs where 8 cleared the gates — the silent subset is dead');
+      assert.match(m1Block, /INCOMPLETE — 1 of 8 reportable run\(s\) yield no raw quotient/, 'and the raw-quotient diagnostic states its loss instead of shrinking');
+      assert.match(out, /EXIT 4 — 2 reportable run\/pair\(s\) LOST RAW EVIDENCE/, 'and the exit block counts the losses');
+      // the unaffected pair still pools all 8 — suppression is per pair, not
+      // a blanket refusal of the ensemble — and the intact donor pair is
+      // nowhere in the loss roster
+      assert.match(m1Block, /over 8 reportable run\(s\)/, 'the intact M1 pair keeps its full pool');
+      assert.ok(!/run1\.json: row M1, pair `uix-subs \/ reagent-subs`/.test(out), 'the intact pair is not named as lost');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  t('the committed corpus itself is COMPLETE under the new boundary — nothing eligible was lost', () => {
+    // The fence, API-level: on both ensembles, every reportable run of every
+    // row yields its declared round count of paired ratios on every pair, so
+    // the pool the program forms is exactly the reportable set and the
+    // program's exit stays 0 (the corpus spawn cases above pin that).
+    for (const dir of ['clock-emvod', 'clock-w3yxd']) {
+      const c = corpus(dir);
+      if (!c) return;
+      const rowIds = [...new Set(c.flatMap(({ data }) => data.rows.map((r) => r.rowId)))].filter((id) => ROWS_WITH_STANDARD.includes(id));
+      for (const rowId of rowIds) {
+        const pooled = c
+          .map(({ file, data }) => ({ file, data, row: data.rows.find((r) => r.rowId === rowId) }))
+          .filter((x) => x.row && reportable(x.row, x.data));
+        assert.ok(pooled.length > 0, `${dir}/${rowId}: the corpus must still pool`);
+        for (const pair of PAIRS_ALL) {
+          for (const { file, data, row } of pooled) {
+            const ratios = pairedLogRatios(row, pair, data);
+            assert.ok(Array.isArray(ratios), `${dir}/${rowId}/${pair}: ${path.basename(file)} must yield ratios`);
+            assert.strictEqual(ratios.length, data.design.rounds, `${dir}/${rowId}/${pair}: ${path.basename(file)} must yield its declared round count`);
+          }
+        }
+      }
+    }
+  });
+
+  t('the ruling and both audits are cited at every changed seat', () => {
+    for (const [name, res] of [
+      ['clock_check_standard.json', /#7698/],
+      ['clock_check_standard.cjs', /audit #7698/],
+      ['clock_readjudicate.cjs', /audit #7700/],
+      ['clock_run.cjs', /#7698/],
+    ]) {
+      const src = fs.readFileSync(path.join(__dirname, name), 'utf8');
+      assert.ok(res.test(src), `${name} must cite the audit that changed it`);
+      assert.ok(/rf2-8a746/.test(src), `${name} must cite the ruling`);
     }
   });
 }

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
@@ -210,6 +210,40 @@
 // veto was never what was holding it. That is a fact about this corpus and not
 // a property of the rule, so `clock_exit_path.test.cjs` drives it in both
 // directions — and if it ever stops being true, the failure is the finding.
+//
+// ## AND THE EVIDENCE ITSELF IS COMPLETE, OR THE CONSUMER REFUSES (rf2-8a746,
+// merged-PR audits #7698 and #7700, 2026-08-10)
+//
+// Two audits of this ruling's own merged PRs found the same boundary open in
+// two places: eligibility was being decided on the serialised verdicts while
+// the RAW EVIDENCE behind them could be missing, and each consumer quietly
+// worked with whatever survived.
+//
+//   * #7698 — THE CHECK-STANDARD PATH. `checkStandardFor` asked only that
+//     `roundsTask` be non-empty, so a committed six-round row truncated to ONE
+//     round handed its three surviving segment blocks to a standard whose
+//     limits are statistics of the 18-block design — and passed. The boundary
+//     now refuses a record whose raw rounds disagree with its own declared
+//     `design.rounds` (observed and expected named), and `checkStandard`
+//     itself carries the expected-N contract (`STANDARD.evidence`, 18 blocks
+//     from the declared 6-round x 3-segment design), so a consistent-but-
+//     off-design count refuses too, before location or dispersion is computed.
+//
+//   * #7700 — THE INTERVAL PATH. `passIdx.map(pairedLogRatios).filter(Boolean)`
+//     dropped a reportable run whose raw pair readings were unusable, and
+//     `effectInterval` filtered again, so blanking one reading of one run
+//     still published "an interval over 7 reportable run(s)" where 8 had
+//     cleared every gate. The pool now forms only when every reportable run
+//     yields its declared round count of ratios (`ivRuns.length ===
+//     passIdx.length`); a loss suppresses the WHOLE interval with the file and
+//     pair named, `effectInterval` throws on an invalid member rather than
+//     shrinking the pool, and the program exits 4 — eligibility without its
+//     raw evidence is an integrity fault, not a quiet omission.
+//
+// NOTHING ADJUDICATIVE MOVED: the frozen centres and limits, the row-scoped
+// publication rules, the four-part 2026-08-07 ruling and every hard refusal
+// are byte-for-byte the rules above; both committed ensembles still read
+// complete and still exit 0.
 
 'use strict';
 
@@ -336,6 +370,33 @@ function checkStandardFor(row, dataset) {
     return {
       ok: false,
       why: 'no raw per-sample TaskDuration readings — the check standard is applied to the readings themselves, so a record that did not store them cannot be shown to have been in control',
+    };
+  }
+  // THE ROUND CARDINALITY, AGAINST THE FILE'S OWN DECLARED DESIGN (rf2-8a746,
+  // merged-PR audit #7698). Non-empty was never the contract: the audit
+  // truncated a committed six-round row to ONE round and this boundary handed
+  // its three surviving segment blocks to the standard, which certified them.
+  // A record whose raw rounds disagree with its own `design.rounds` is a
+  // truncated or padded record, and a design that does not declare a round
+  // count cannot be shown complete — absent is not clean. The 18-block
+  // contract itself is `checkStandard`'s (`STANDARD.evidence`), which refuses
+  // any consistent-but-off-design count with observed/expected; this seat
+  // refuses the file-level disagreement with both numbers named.
+  if (!Number.isFinite(d.design.rounds)) {
+    return {
+      ok: false,
+      why:
+        'the design record declares no round count — the check standard compares the raw readings against the ' +
+        'declared design, and a record that does not say how many rounds it took cannot be shown complete (rf2-8a746, audit #7698)',
+    };
+  }
+  if (r.roundsTask.length !== d.design.rounds) {
+    return {
+      ok: false,
+      why:
+        `the raw readings are TRUNCATED or PADDED — ${r.roundsTask.length} round(s) of TaskDuration readings against ` +
+        `the file's own declared design of ${d.design.rounds}, so this is a subset (or superset) of the run, not the run, ` +
+        'and a run judged on part of its declared evidence has not been judged (rf2-8a746, audit #7698)',
     };
   }
   const xs = [];
@@ -655,10 +716,33 @@ function counterpartLogRatios(row, pair, dataset) {
  * `runs` is `[[logRatio per round]]`. The point estimate is the mean over runs
  * of each run's mean, which is the balanced-design estimator the bootstrap is
  * the distribution of.
+ *
+ * AND IT REJECTS AN INVALID MEMBER RATHER THAN FILTERING IT (rf2-8a746,
+ * merged-PR audit #7700). This function used to `filter` out any member that
+ * was not a non-empty array, which made it the second half of a silent-subset
+ * defect: the caller's `.filter(Boolean)` dropped a reportable run whose raw
+ * pair readings were unusable, this filter would have dropped it again, and
+ * the output then called the survivors "reportable run(s)" — concealing that
+ * evidence was lost AFTER eligibility was decided. Completeness is the
+ * caller's to prove BEFORE pooling (every reportable run present, every run
+ * carrying its declared round count); handing this function an invalid member
+ * is therefore a caller bug, and it throws rather than shrinking the pool.
+ * An EMPTY pool stays `null` — nothing was pooled and nothing was lost.
  */
 function effectInterval(runs) {
-  const usable = (runs || []).filter((r) => Array.isArray(r) && r.length > 0);
-  if (usable.length === 0) return null;
+  const rs = Array.isArray(runs) ? runs : [];
+  if (rs.length === 0) return null;
+  const invalid = rs
+    .map((r, i) => (Array.isArray(r) && r.length > 0 && r.every(Number.isFinite) ? -1 : i))
+    .filter((i) => i >= 0);
+  if (invalid.length) {
+    throw new Error(
+      `effectInterval: member(s) ${invalid.join(', ')} of ${rs.length} carry no usable paired log-ratios — an invalid ` +
+        'member is REFUSED, never filtered into a smaller unstated subset; completeness is the caller\'s to prove ' +
+        'before pooling (rf2-8a746, merged-PR audit #7700)'
+    );
+  }
+  const usable = rs;
   const point = mean(usable.map(mean));
   const rnd = mulberry32(EFFECT.seed);
   const draws = [];
@@ -1112,6 +1196,13 @@ function main(argv) {
     for (const { file, data } of ineligible) console.log(`;; !!   ${file}: ${CANONICAL_GATE.why(data)}`);
   }
 
+  // RAW EVIDENCE LOST AFTER ELIGIBILITY (rf2-8a746, merged-PR audit #7700):
+  // every (file, row, pair) whose reportable run yielded no usable raw pair
+  // readings. Filled per pair below; drives EXIT 4 at the foot, because a
+  // record that grants eligibility while lacking the raw evidence behind it is
+  // an integrity fault a script must not exit 0 over.
+  const rawEvidenceLoss = [];
+
   for (const rowId of rowIds) {
     const runs = datasets
       .map(({ file, data }) => ({ file, data, row: data.rows.find((r) => r.rowId === rowId) }))
@@ -1214,11 +1305,20 @@ function main(argv) {
       const erN = ens(rawNet);
       const erI = ens(rawInPage);
       if (erT.n > 0) {
+        // A REPORTABLE RUN THAT YIELDS NO QUOTIENT IS SAID, NOT SHRUNK AWAY
+        // (rf2-8a746, audit #7700). This diagnostic used to filter a NaN out
+        // and still print "reportable subset" over the survivors — the same
+        // unstated-subset shape as the interval defect, one table up. The
+        // count is now stated against the reportable count whenever they part.
         const rawPass = passIdx.map((i) => rawTask[i]).filter(Number.isFinite);
+        const rawIncomplete =
+          rawPass.length && rawPass.length < passIdx.length
+            ? ` (INCOMPLETE — ${passIdx.length - rawPass.length} of ${passIdx.length} reportable run(s) yield no raw quotient; see the interval refusal below)`
+            : '';
         console.log(
           `;;     RAW quotient (neither floor) raw TaskDuration ${fmt(erT.mean)}x  [${fmt(erT.min)} – ${fmt(erT.max)}]  n=${erT.n}` +
             (rawPass.length
-              ? `   reportable subset ${fmt(ens(rawPass).mean)}x n=${rawPass.length}`
+              ? `   reportable subset ${fmt(ens(rawPass).mean)}x n=${rawPass.length}${rawIncomplete}`
               : '   reportable subset: NONE')
         );
         console.log(
@@ -1281,20 +1381,75 @@ function main(argv) {
       // heading with its own complete figure. Nothing here may be read across
       // the two lines.
       const rule = publicationRule(rowId);
-      const ivRuns = passIdx.map((i) => pairedLogRatios(runs[i].row, pair, runs[i].data)).filter(Boolean);
-      const iv = effectInterval(ivRuns);
+      // EVERY REPORTABLE RUN MUST YIELD ITS READINGS, OR THE INTERVAL IS
+      // SUPPRESSED (rf2-8a746, merged-PR audit #7700). This line used to read
+      // `passIdx.map(pairedLogRatios).filter(Boolean)`: a reportable run whose
+      // raw pair readings were absent or unusable was silently dropped, and
+      // the output then called the survivors "reportable run(s)" — an interval
+      // over 7 runs where 8 had cleared every gate, with nothing anywhere
+      // saying evidence was lost AFTER eligibility was decided. Eligibility is
+      // `reportable`'s to grant and only a NAMED refusal may shrink the pool,
+      // so each member is checked for usable ratios AND for its own declared
+      // round count, the pool forms only when `ivRuns.length === passIdx.length`,
+      // and a loss suppresses the whole interval with the file and pair named
+      // — never a smaller unstated subset. The loss also fails the program
+      // (exit 4 below): a record that grants eligibility while lacking the raw
+      // evidence behind it is an integrity fault, not a quiet omission.
+      const ivMembers = passIdx.map((i) => ({
+        file: runs[i].file,
+        declaredRounds: runs[i].data && runs[i].data.design ? runs[i].data.design.rounds : NaN,
+        ratios: pairedLogRatios(runs[i].row, pair, runs[i].data),
+      }));
+      const ivLost = ivMembers.filter(
+        (m) =>
+          !Array.isArray(m.ratios) ||
+          m.ratios.length === 0 ||
+          !(Number.isFinite(m.declaredRounds) && m.ratios.length === m.declaredRounds)
+      );
+      const ivRuns = ivLost.length === 0 ? ivMembers.map((m) => m.ratios) : [];
+      const iv = ivLost.length === 0 && ivRuns.length === passIdx.length ? effectInterval(ivRuns) : null;
       const bands = passIdx
         .map((i) => runs[i].row.seamTask && runs[i].row.seamTask.band)
         .filter((b) => Number.isFinite(b))
         .map((b) => b * 100);
       const noise = bands.length ? Math.max(...bands) : NaN;
-      const ev = effectVerdict(iv, rowId, pair, { widestSameRunBandPct: noise });
+      const ev = ivLost.length
+        ? {
+            publishes: false,
+            verdict: 'RAW EVIDENCE LOST AFTER ELIGIBILITY — the interval is SUPPRESSED, not formed over an unstated subset',
+            why:
+              `${ivLost.length} of ${passIdx.length} reportable run(s) carry no usable raw pair readings for \`${pair}\` ` +
+              `(${ivLost.map((m) => shortName(m.file)).join(', ')}) — refused by name rather than filtered ` +
+              '(rf2-8a746, merged-PR audit #7700)',
+          }
+        : effectVerdict(iv, rowId, pair, { widestSameRunBandPct: noise });
+      if (ivLost.length) {
+        rawEvidenceLoss.push(...ivLost.map((m) => ({ file: m.file, rowId, pair })));
+      }
       console.log(
         `;;     EFFECT-SIZE INTERVAL (${EFFECT.bead}, row-class estimand and threshold ${EFFECT.thresholdsRuling}) — ` +
           `${rule ? rule.estimandSays : 'no estimand of record for this row class'}; ${EFFECT.method}`
       );
       if (rule) {
         console.log(`;;       GOVERNING RECORD  ${rule.governingRecord}`);
+      }
+      if (ivLost.length) {
+        // THE LOSS, NAMED PER FILE AND PER PAIR (rf2-8a746, audit #7700) — a
+        // run that leaves the pool leaves it for a stated cause, or it is
+        // indistinguishable from one that was selected away.
+        console.log(
+          `;;       RAW EVIDENCE LOST AFTER ELIGIBILITY — no interval is formed on this pair, and the whole pool is ` +
+            `withheld rather than a subset pooled (rf2-8a746, merged-PR audit #7700):`
+        );
+        for (const m of ivLost) {
+          console.log(
+            `;;         ${m.file} is REPORTABLE and ` +
+              (!Array.isArray(m.ratios) || m.ratios.length === 0
+                ? `carries no usable raw readings for \`${pair}\``
+                : `yields ${m.ratios.length} paired round(s) for \`${pair}\` against its own declared design of ${m.declaredRounds}`) +
+              ' — eligibility without its raw evidence is an integrity fault in the record, and this program exits nonzero on it'
+          );
+        }
       }
       if (iv) {
         console.log(
@@ -1329,17 +1484,29 @@ function main(argv) {
                 `are added.`)
         );
         // THE OTHER ESTIMAND, COMPLETE AND LABELLED — never a headline, and
-        // never a bound to be read beside the point above.
-        const cIv = effectInterval(passIdx.map((i) => counterpartLogRatios(runs[i].row, pair, runs[i].data)).filter(Boolean));
+        // never a bound to be read beside the point above. COMPLETE is checked
+        // the same way as the headline's (rf2-8a746, audit #7700): the old
+        // `.filter(Boolean)` here would have printed "over the same runs" over
+        // a silently smaller set, so a member that yields no ratios suppresses
+        // the diagnostic with the loss stated instead.
+        const cMembers = passIdx.map((i) => counterpartLogRatios(runs[i].row, pair, runs[i].data));
+        const cLost = cMembers.filter((m) => !Array.isArray(m) || m.length === 0).length;
+        const cIv = cLost === 0 ? effectInterval(cMembers) : null;
         if (cIv) {
           console.log(
             `;;       DIAGNOSTIC, NEVER THE HEADLINE — the ${rule && rule.estimand === 'floorNormalised' ? 'unfloored LEVEL' : 'floor-normalised'} ` +
               `estimand reads ${fmt(cIv.point)}x [${fmt(cIv.lo)} – ${fmt(cIv.hi)}] over the same runs. It is a ` +
               `DIFFERENT quantity, so no figure on this line may be quoted beside a figure on the line above.`
           );
+        } else if (cLost) {
+          console.log(
+            `;;       [the counterpart estimand is SUPPRESSED — ${cLost} of ${passIdx.length} reportable run(s) yield no ` +
+              `usable readings for it, and a diagnostic pooled over an unstated subset would be the defect one line up ` +
+              `(rf2-8a746, audit #7700)]`
+          );
         }
-      } else {
-        console.log(`;;       no interval — ${passIdx.length} run(s) cleared every gate and none carried usable paired readings`);
+      } else if (!ivLost.length) {
+        console.log(`;;       no interval — no reportable run cleared the gates on this row, so there is nothing to pool`);
       }
       console.log(`;;       VERDICT ${ev.verdict} — ${ev.why}`);
       if (!ev.publishes) {
@@ -1546,6 +1713,15 @@ function main(argv) {
   // says so in the one place a script can be believed. Everything is printed
   // either way — a refusal is about what may be QUOTED, never about throwing a
   // measurement away (`rf2-2rtt6.31`).
+  if (rawEvidenceLoss.length) {
+    console.log('');
+    console.log(
+      `;; EXIT 4 — ${rawEvidenceLoss.length} reportable run/pair(s) LOST RAW EVIDENCE after eligibility was decided ` +
+        '(rf2-8a746, merged-PR audit #7700). Every affected interval above is SUPPRESSED rather than formed over an ' +
+        'unstated subset, and no figure on those pairs may be quoted:'
+    );
+    for (const l of rawEvidenceLoss) console.log(`;;   ${l.file}: row ${l.rowId}, pair \`${l.pair}\``);
+  }
   if (ineligible.length) {
     console.log('');
     console.log(
@@ -1554,6 +1730,7 @@ function main(argv) {
     );
     return 3;
   }
+  if (rawEvidenceLoss.length) return 4;
   return 0;
 }
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
@@ -1762,6 +1762,15 @@ function report(out) {
   // rule is the run's own location and dispersion — never "every block inside
   // a band", which is the rule rf2-8a746 retired with the three-point control
   // for a separate reason: `0.835^18 = 3.9%`.
+  //
+  // AND THE HELPER CARRIES AN EXPECTED-N CONTRACT (rf2-8a746, merged-PR audit
+  // #7698): exactly `STANDARD.evidence.expectedBlocks` finite readings — 18,
+  // from the declared 6-round x 3-segment design — or it refuses with observed
+  // and expected counts. At the published depth this list is 3 segments x
+  // `ROUNDS` rounds = 18 by construction; an `HCLOCK_ROUNDS` override now
+  // refuses here as well as in `depthPublished`, which is the correct
+  // fail-closed reading — limits calibrated on the full design certify nothing
+  // about a shorter run.
   const checkStandard = ctl2xBlocks ? checkstd.checkStandard(ctl2xBlocks, rowId) : null;
   if (checkStandard) {
     console.log(`;; ---- CHECK STANDARD: is this run IN CONTROL? (rf2-8a746) ----`);


### PR DESCRIPTION
## What this enforces (rf2-8a746, operator ruling 2026-08-10, Option A at P3)

Both bounded acceptances from the merged-PR audits of this ruling's own PRs, in one PR, per the ruling.

### A. Check-standard cardinality (audit #7698)

The check-standard consumer now requires exactly the frozen standard's expected evidence cardinality — 18 blocks — from one explicit field, `STANDARD.evidence` (`clock_check_standard.json` v4), tied to the declared 6-round x 3-segment design (`design.rounds * design.segments === expectedBlocks`), before computing location or dispersion:

- `checkStandard` (the direct helper both consumers share) carries the expected-N contract itself: a missing or extra round/block refuses with **observed and expected counts** in the message. The audit's demonstrated defect — a one-element list at the frozen centre returning `ok: true, n: 1, robustScale: 0` — now refuses before location is computed.
- `checkStandardFor` (the boundary over a dataset) additionally refuses a record whose raw `roundsTask` length disagrees with its own declared `design.rounds` (both numbers named), and a design that declares no round count — absent is not clean. A record whose own declared design is short cannot smuggle a smaller count past the standard's expected-N either.
- The driver's call site (`clock_run.cjs`) inherits the contract through the shared helper; an `HCLOCK_ROUNDS` override now refuses at the standard as well as at `depthPublished`, which is the fail-closed direction.

### B. Interval-consumer completeness (audit #7700)

A reportable run whose raw pair readings are absent or unusable can no longer be silently filtered into a smaller unstated subset:

- The pool forms only when every reportable run yields ratios and each member carries its declared per-run round cardinality — `ivRuns.length === passIdx.length` is required before pooling.
- A loss **suppresses the entire interval** and prints the refusal naming each file and the pair; the verdict is `RAW EVIDENCE LOST AFTER ELIGIBILITY` and the program exits **4** (new exit code, distinct from the existing 3) — eligibility without its raw evidence is an integrity fault.
- `effectInterval` now **rejects (throws, citing rf2-8a746 / audit #7700) rather than filters** an invalid member; an empty pool remains `null` (nothing pooled, nothing lost).
- The counterpart-estimand diagnostic and the raw-quotient diagnostic state their loss instead of shrinking silently (the raw-quotient line annotates `INCOMPLETE — N of M reportable run(s) yield no raw quotient`).

## Witnesses (all driven against the committed clock-emvod corpus where the audits demonstrated the defects)

- **One-block witness** (`checkStandard`): a single reading dead on the frozen centre refuses with observed/expected, on both calibrated classes, before location/dispersion — plus boundary-exactness (17/18/19) and missing/extra directions, in the module's own selftest and in `clock_exit_path.test.cjs`.
- **Truncated-round witness** (`checkStandardFor` + `reportable`/`refusals`): every committed emvod row with a standard, truncated to one round — 32 of 32 refuse, 0 still certify (the audit had found several passing); the refusal reaches the no-pool decision and the driver's nonzero seat (`reportability` code 1).
- **Mutation witness** (the program end to end): blanking only run1's `roundsTask[0].hicasso.hicasso` leaves the run reportable (the defect's precondition, asserted), and the spawned `clock_readjudicate.cjs` over the 8-file ensemble now exits **4**, names `run1.json` and both hicasso pairs in the loss roster, publishes no M1 interval "over 7 reportable run(s)", and keeps the intact donor pair's full 8-run pool — suppression is per pair.
- **Corpus completeness fence**: on both committed ensembles every reportable run yields its declared round count of ratios on every pair, and both ensembles still exit 0 (existing corpus spawn tests unchanged and green).

## Anchors and retained rules unchanged

- The empirical centres, frozen location/dispersion limits, tolerance bands and error rates are **byte-identical** — the v4 amendment states it and the existing rf2-x7x10/rf2-c1974 fence tests still pin every number to the last place.
- The row-scoped publication rules (`PUBLICATION`, gatedPairs, thresholds, estimands), the four-part 2026-08-07 ruling, all hard refusals (read-back, canonical-DOM, page-error, arm-order, quiet-box, band-ceiling), and the retained strict rule (keystroke's 50 ms sensitivity floor) are untouched; no schema framework was added.
- `clock_check_standard.json` moves v3 -> v4 by its own amendment discipline; the only structural additions are the `evidence` field and the amendment entry.

## Gates (all foreground, to completion)

- `node clock_check_standard.cjs --selftest` — 41 checks, 0 failed
- `node clock_exit_path.test.cjs` — 368 passed
- `node clock_witness.test.cjs` — 9/9
- `node clock_run.cjs --selftest` — ALL ADJUDICATORS OK
- `npm run test:script-helpers` — full chain green (last suite reached and passed)

Closes rf2-8a746.