### PR TITLE
docs(hicasso): route the closed-standard citations, and one pin finding (rf2-sdlw, rf2-iseb)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -731,14 +731,23 @@ adapter *registry*; overruled for the one-declaration-one-identity grain.
 > **Addendum, 2026-08-05 — the bar is PER-AXIS: the mount denominator moved to
 > UIx, the bulk denominator did not (`rf2-hyd50`).** The ruling below states
 > mount and bulk under a single Reagent-denominated number. That is superseded
-> **on the mount axis only**. The operative bar, as the operator-owned standard
-> `rf2-2rtt6.1` carries it:
+> **on the mount axis only**. The bar, as the operator-owned standard
+> `rf2-2rtt6.1` carried it on 2026-08-05:
 >
 > - **Mount** — **≤ 1.10× direct UIx-on-subs**, canonical `M1`,
 >   floor-normalised, on the clock of record (raw `TaskDuration`, script **and**
 >   frame). Reagent-on-subs stays co-instrumented and is **reported beside the
 >   mount row, not gating it**.
 > - **Bulk** — **≤ 1.0× Reagent-on-subs, like-for-like** — unchanged.
+>
+> **Superseded 2026-08-10.** `rf2-2rtt6.1` was closed as superseded by the new
+> governance set. The operative default is now the K1 price-acceptance
+> amendment `rf2-hic-003` (1.25× ceiling vs direct UIx, user-visible budgets);
+> the bulk verdict runs through protocol `rf2-hic-036`, budgets and the shell
+> line through `rf2-hic-006`/`rf2-hic-018` with gates `rf2-hic-089` and
+> `rf2-hic-071`, and the kill rules through
+> [the decision brief](product/decision-brief.md). The two lines above stand as
+> the bar this addendum recorded on 2026-08-05, not as today's gate.
 >
 > **What stands, so the conflict cannot be re-derived.** Everything else in the
 > ruling below: the clock-only ship *number*, browser-only figures, memory

--- a/docs/design/hicasso/hd-002-adjudication.md
+++ b/docs/design/hicasso/hd-002-adjudication.md
@@ -1,7 +1,10 @@
 # HD-002 — the collector adjudication
 
 > **Delegated advisory, operator-overturnable.** The operator-owned standard bead
-> `rf2-2rtt6.1` requires HD-002's four clauses pinned before P1 code. A delegated
+> `rf2-2rtt6.1` required HD-002's four clauses pinned before P1 code; it was
+> superseded and closed on 2026-08-10, and HD-002 adjudication now runs through
+> the kernel witnesses `rf2-hic-010`/`rf2-hic-011`, the design-laws lane, and the
+> substrate adjudication `rf2-hic-018`. A delegated
 > ruling recorded on that bead (mayor, 2026-07-30) makes this a written advisory
 > rather than an operator gate, on the pattern HD-013 already uses for the donor
 > gate: produced by a worker, adversarially reviewed, recorded on the standard
@@ -103,9 +106,11 @@ is not a pass"):
 
 1. **Stop collector work on that arm.** Do not redesign around it quietly. The
    firing is the result.
-2. **Record it** on the arm bead (`rf2-2rtt6.9`) and on the standard bead
-   (`rf2-2rtt6.1`): the construct you reached for, the correctness obligation that
-   demanded it, and the commit SHA where the need became visible.
+2. **Record it** on the arm bead (`rf2-2rtt6.9`) and on the substrate
+   adjudication `rf2-hic-018`, which carries the tripwire clause now that
+   `rf2-2rtt6.1` is superseded and closed (2026-08-10): the construct you
+   reached for, the correctness obligation that demanded it, and the commit SHA
+   where the need became visible.
 3. **The arm continues on grouped.** A fired tripwire kills the *collector tier*,
    not the lean-React arm and not the programme. Grouped is the product default
    and has been dogfooded since P1 start precisely so this is a promotion, not a

--- a/docs/design/hicasso/studio/README.md
+++ b/docs/design/hicasso/studio/README.md
@@ -1,9 +1,13 @@
 # Hicasso — studio
 
 The programme's measured record. Every number Hicasso publishes lands here and
-on its bead; the operator-owned standard bead (`rf2-2rtt6.1`) carries the bar,
-the budgets and the kill criteria, and this tree carries the evidence those
-rulings are made against.
+on its bead; the operator-owned governance set that superseded the standard bead
+`rf2-2rtt6.1` on 2026-08-10 carries the bar, the budgets and the kill criteria —
+K1 price acceptance `rf2-hic-003`, budgets and shell line
+`rf2-hic-006`/`rf2-hic-018` with gates `rf2-hic-089` (early) and `rf2-hic-071`
+(late), bulk verdict protocol `rf2-hic-036`, kill rules in
+[the decision brief](../product/decision-brief.md) — and this tree carries the
+evidence those rulings are made against.
 
 Minted by the first P0 worker per [HD-017](../decisions.md). **The Freehand
 studio at `docs/design/freehand/studio/` is frozen and is never extended** — it

--- a/docs/design/hicasso/studio/a-control-that-differences-the-constant-away.md
+++ b/docs/design/hicasso/studio/a-control-that-differences-the-constant-away.md
@@ -27,7 +27,10 @@ falsification in which every other gate passes
 differencing the constant away also costs the statistic its
 [**sign**](#the-band-is-necessary-and-not-sufficient).
 
-Owner: the operator-owned standard bead `rf2-2rtt6.1`; this page `rf2-7iqb5` and
+Owner: the operator-owned governance set that superseded `rf2-2rtt6.1` on
+2026-08-10 — K1 price acceptance `rf2-hic-003`, budgets and shell line
+`rf2-hic-006`/`rf2-hic-018`, bulk verdict protocol `rf2-hic-036`, kill rules in
+[the decision brief](../product/decision-brief.md); this page `rf2-7iqb5` and
 `rf2-5xrcd`.
 
 ---

--- a/docs/design/hicasso/studio/bulk-broad-re-taken.md
+++ b/docs/design/hicasso/studio/bulk-broad-re-taken.md
@@ -26,7 +26,10 @@ frame-only clock reads that row 4% high and the in-page clock 10% low. One
 instrument, two rows, and it lands on the published value for the row the audit
 independently found robust while landing far from it on the row under question.
 
-Owner: the operator-owned standard bead `rf2-2rtt6.1`; this page `rf2-yd52q`.
+Owner: the operator-owned governance set that superseded `rf2-2rtt6.1` on
+2026-08-10 — K1 price acceptance `rf2-hic-003`, budgets and shell line
+`rf2-hic-006`/`rf2-hic-018`, bulk verdict protocol `rf2-hic-036`, kill rules in
+[the decision brief](../product/decision-brief.md); this page `rf2-yd52q`.
 
 ---
 

--- a/docs/design/hicasso/studio/census-real-clock-rows.md
+++ b/docs/design/hicasso/studio/census-real-clock-rows.md
@@ -10,14 +10,18 @@ floor-normalised, same run, on raw `TaskDuration`** — script AND frame,
 frame-settled, plumb-tared, Reagent-on-subs co-instrumented beside the gate and
 never a second gate.
 
-Bead **`rf2-2rtt6.56`**. The standard is **`rf2-2rtt6.1`**.
+Bead **`rf2-2rtt6.56`**. The standard is the governance set that superseded
+**`rf2-2rtt6.1`** on 2026-08-10 — K1 price acceptance `rf2-hic-003`, budgets and
+shell line `rf2-hic-006`/`rf2-hic-018`, bulk verdict protocol `rf2-hic-036`,
+kill rules in [the decision brief](../product/decision-brief.md).
 
 > **THE CANONICAL MOUNT WITNESS IS M1 AND STAYS M1.** The amendment is
 > explicit that census-page rows **corroborate** the canonical witness and do
 > not silently redefine it. These rows are the diagnostic ladder the roster's
 > pages suggest, and the bar rows stay on their own instrument. Nothing here
 > re-baselines HD-012, and the ruling on any verdict below is the operator's
-> (`rf2-2rtt6.1`), never this page's.
+> ([the decision brief](../product/decision-brief.md) — `rf2-2rtt6.1` was
+> superseded and closed on 2026-08-10), never this page's.
 
 > **RETRACTED, 2026-08-07 (`rf2-2rtt6.62`).** This page previously described
 > the large-template and feed rows as *the same screen at two boundary
@@ -337,8 +341,9 @@ floor-normalised estimand and published as `K1 MISSED, DECISIVELY` —
 [`rf2-emvod` §4.3](rows-re-adjudicated-on-the-corrected-clock.md#43-the-published-m1-row) —
 and it is neither of the readings named above; see the note earlier on this
 page)*, and what these rows corroborate is the **direction**. The ruling on what
-that means for the programme is the operator's (`rf2-2rtt6.1`); this page
-measures.
+that means for the programme is the operator's
+([the decision brief](../product/decision-brief.md) — `rf2-2rtt6.1` was
+superseded and closed on 2026-08-10); this page measures.
 
 ## 2026-08-07 the re-take on the current tree (rf2-jv36i)
 

--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -14,7 +14,10 @@ Two rungs, because the two halves of the claim have to be priced apart.
 | **Rung 2** | plus the **product shell** — one frame-context hook, and **native event-vector lowering** (`:on-click [:hd8/touch i]` lowered by the codec, not by the author) | 2 |
 
 Bead **`rf2-2rtt6.7`**. Decision **[HD-008](../decisions.md)**. The standard is
-**`rf2-2rtt6.1`**.
+the governance set that superseded **`rf2-2rtt6.1`** on 2026-08-10 — K1 price
+acceptance `rf2-hic-003`, budgets and shell line `rf2-hic-006`/`rf2-hic-018`,
+bulk verdict protocol `rf2-hic-036`, kill rules in
+[the decision brief](../product/decision-brief.md).
 
 > **THE STOP/CONTINUE RULING IS NOT ISSUED HERE, AND NOT BY THIS PAGE.**
 > Per HD-013 and HD-014 it is a *delegated advisory* ruling — one adversarial

--- a/docs/design/hicasso/studio/hd8-freehand-codec-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-freehand-codec-donor-arm.md
@@ -18,7 +18,10 @@ the same instrument, in the same runs, on the same witnesses, under the same
 gates.
 
 Bead **`rf2-2rtt6.29`**. Decision **[HD-008](../decisions.md)**. The standard is
-**`rf2-2rtt6.1`**.
+the governance set that superseded **`rf2-2rtt6.1`** on 2026-08-10 — K1 price
+acceptance `rf2-hic-003`, budgets and shell line `rf2-hic-006`/`rf2-hic-018`,
+bulk verdict protocol `rf2-hic-036`, kill rules in
+[the decision brief](../product/decision-brief.md).
 
 > **NO BAR VERDICT IS ISSUED HERE, AND NONE MAY BE READ OUT OF THIS PAGE.**
 > The mount win condition is suspended as a gate pending an operator amendment:
@@ -68,7 +71,8 @@ git rev-parse $A:implementation/freehand/test/re_frame/bench/hicasso/hd8_witness
 **The spine stamp that qualifies the sibling page does not qualify this one.**
 Every column here — including the `donor-r1`, `donor-r2`, `uix`, `reagent` and
 `reagent-slim` columns — was re-taken in these two sweeps, on today's spine
-(`1384ae1285`), on a plan that now has one more arm in it. **Nothing on this page
+blob (`1384ae1285`, the `spine.cljs` blob stamped in the table above), on a plan
+that now has one more arm in it. **Nothing on this page
 is quoted from
 [hd8-composed-donor-arm.md](hd8-composed-donor-arm.md)**, and nothing here amends
 it: adding a fifth or sixth arm changes `k` in the interleaving schedule, so

--- a/docs/design/hicasso/studio/our-walk-against-reagents.md
+++ b/docs/design/hicasso/studio/our-walk-against-reagents.md
@@ -22,8 +22,10 @@ is the answer the P2 fork ruling needs, in the direction nobody had checked.
 > **DIAGNOSTIC, not published.** Every figure here is an in-page
 > `performance.now` over eight whole-page walks per sample. It attributes cost
 > BETWEEN interpreters and BETWEEN stages of one walk. It is **not** the clock
-> of record, no figure here is a gate row, and the mount verdict remains
-> `rf2-2rtt6.1`'s to issue against `census_clock_run.cjs`.
+> of record, no figure here is a gate row, and the mount verdict remains the
+> operator's to issue against `census_clock_run.cjs` — K1 price acceptance
+> `rf2-hic-003` ([the K1 record](../product/k1-price-acceptance.md)), after
+> `rf2-2rtt6.1` was superseded and closed on 2026-08-10.
 
 ## 1. The witness, and why the route-link term cannot reach it
 

--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -7,8 +7,12 @@ bar's rows and the red-zone thresholds a candidate is judged against can be
 read down one column.
 
 Bead **rf2-a4x1o**, re-published under a balanced design by **rf2-6i0i2**. The
-rows are appended to the operator-owned standard bead **rf2-2rtt6.1**; only the
-operator amends the bar, the budgets, the kill criteria or the red-zones.
+rows are appended to the P0 baseline record that superseded the operator-owned
+standard bead **rf2-2rtt6.1** on 2026-08-10 —
+[the evidence baseline](../product/lanes/evidence-baseline.md); only the
+operator amends the bar, the budgets, the kill criteria or the red-zones (K1
+price acceptance `rf2-hic-003`, budget gates `rf2-hic-089`/`rf2-hic-071`, kill
+rules in [the decision brief](../product/decision-brief.md)).
 Nothing here amends any of them.
 
 ## The extent of the mismatch, measured rather than feared

--- a/docs/design/hicasso/studio/p0-reagent-on-subs-baseline.md
+++ b/docs/design/hicasso/studio/p0-reagent-on-subs-baseline.md
@@ -8,9 +8,12 @@ through an `r/cursor`, which is Reagent's own idiom but is a denominator no
 re-frame2 application has. This page supplies the one the bar names, and prices
 the difference between the two.
 
-Bead **rf2-2rtt6.2**. The rows are appended to the operator-owned standard bead
-**rf2-2rtt6.1**; only the operator amends the bar, the budgets, the kill criteria
-or the red-zones.
+Bead **rf2-2rtt6.2**. The rows are appended to the P0 baseline record that
+superseded the operator-owned standard bead **rf2-2rtt6.1** on 2026-08-10 —
+[the evidence baseline](../product/lanes/evidence-baseline.md); only the operator
+amends the bar, the budgets, the kill criteria or the red-zones (K1 price
+acceptance `rf2-hic-003`, budget gates `rf2-hic-089`/`rf2-hic-071`, kill rules in
+[the decision brief](../product/decision-brief.md)).
 
 > **Re-certified on main, 2026-07-31 — the rows below reproduce.** This page was
 > the last P0 arm whose producing SHA was not on main, whose instruments carried

--- a/docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md
+++ b/docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md
@@ -15,8 +15,12 @@ banner below. **Red is not fail** — the ship bar (HD-012: mount AND bulk
 ≤ 1.0× Reagent, like-for-like, clock only) is independent, and a row can clear
 the bar and still be red. That tension is intended.
 
-Bead **rf2-2rtt6.4**. Rows are appended to rf2-2rtt6.1; only the operator amends
-the bar, the budgets, the kill criteria, or these thresholds.
+Bead **rf2-2rtt6.4**. Rows are appended to the P0 baseline record that
+superseded rf2-2rtt6.1 on 2026-08-10 —
+[the evidence baseline](../product/lanes/evidence-baseline.md); only the operator
+amends the bar, the budgets, the kill criteria, or these thresholds (K1 price
+acceptance `rf2-hic-003`, budget gates `rf2-hic-089`/`rf2-hic-071`, kill rules in
+[the decision brief](../product/decision-brief.md)).
 
 > **Superseded on the clock axis only — rf2-a4x1o, PR #7268.** The clock
 > thresholds in the first red-zone table below are superseded *as thresholds* by
@@ -468,7 +472,8 @@ precise wrong number first. They are recorded because the next arm will meet the
     blind under `:advanced` and carries no information in either direction, so
     it decides nothing in either direction. **Exit 0 still means the probe ran
     and its readings are valid — never that the heap is clean.** Rows on this
-    programme stay operator-owned (rf2-2rtt6.1).
+    programme stay operator-owned ([the decision brief](../product/decision-brief.md)
+    — rf2-2rtt6.1 was superseded and closed on 2026-08-10).
 - **The witness set does not match rf2-2rtt6.2's.** That arm's branch (not yet
   merged) uses a 901-element M1 list reading `[:p0/cell i]` and a 51-element M2
   form reading the same sub; this page uses a 1,203-element W1 reading

--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -1,7 +1,9 @@
 # What does a *subscribing* boundary cost in memory, at 1, 3, 7 and 20 reads?
 
 Seat: EVIDENCE SPIKE, EP-0038 Wave 0. Bead `rf2-2rtt6.5`; numbers appended to
-the operator-owned standard `rf2-2rtt6.1`.
+the P0 baseline record that superseded the operator-owned standard
+`rf2-2rtt6.1` on 2026-08-10 —
+[the evidence baseline](../product/lanes/evidence-baseline.md).
 
 **Two measurements live on this page, on two instruments, and they are kept
 apart.** §§1–5 are the donor ladder of `rf2-2rtt6.5`, taken on the freehand
@@ -446,8 +448,10 @@ any candidate that misses it is missing something both donors already have.
 ## 5. What this hands the programme
 
 **The red-zones for this witness family — distinct-query (Q = E), the
-operative upper-envelope family.** Under the delegated ruling on `rf2-2rtt6.1`
-as regime-qualified by the heap-regime ruling (rf2-2rtt6.16), the UIx
+operative upper-envelope family.** Under the delegated ruling recorded on
+`rf2-2rtt6.1` — superseded and closed on 2026-08-10, with red-zones now running
+through budget gates `rf2-hic-089` (early) and `rf2-hic-071` (late) — as
+regime-qualified by the heap-regime ruling (rf2-2rtt6.16), the UIx
 retained-heap figure on this witness *is* the red-zone threshold. Witness stamp
 B = 1,200 · E = 1,200·R · Q = E. **The rows are stated for the tree that ships
 today** (Mike's ruling of 2026-07-31, option (a), on `rf2-e3flf`): a gate

--- a/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
+++ b/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
@@ -77,7 +77,10 @@ the wrong thing, but one label — `taskNet` — denoting two different quantiti
 on two harnesses, and two pages quoting them against each other as though it
 denoted one ([§3](#3-the-three-mount-numbers)).
 
-Owner: the operator-owned standard bead `rf2-2rtt6.1`; this page `rf2-emvod`.
+Owner: the operator-owned governance set that superseded `rf2-2rtt6.1` on
+2026-08-10 — K1 price acceptance `rf2-hic-003`, budgets and shell line
+`rf2-hic-006`/`rf2-hic-018`, bulk verdict protocol `rf2-hic-036`, kill rules in
+[the decision brief](../product/decision-brief.md); this page `rf2-emvod`.
 
 ---
 

--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -1386,7 +1386,7 @@ not offered as a `bulk300` result: `bulk300` is refused.
 | | |
 |---|---|
 | Landed whole-tree anchor | **`a878d71ab9`** — on main, so it resolves. Recovered from the authoring anchor by identical `git patch-id --stable`; every blob that commit contributed is unchanged there |
-| Authoring anchor | `fdff3fd48855e86b34ec88b5ebc07f62903a6c0a` on `worker/clock-0qj9w` — the tree the run executed on. The branch was rebase-merged, so this SHA is on no branch and **will not resolve in a fresh clone**; the landed anchor above is the one to check out, and the blob table below is what pins the instrument |
+| Authoring anchor | `fdff3fd48855e86b34ec88b5ebc07f62903a6c0a` on `worker/clock-0qj9w` — the tree the run executed on. The branch was rebase-merged, so this SHA is on no branch and **will not resolve in a fresh clone**; check out its landed counterpart `a878d71ab9` instead, and the blob table below is what pins the instrument |
 | Runtime | Chromium `HeadlessChrome/147.0.7727.15` (Windows NT 10.0 x64), Playwright 1.59.1, React 19.2.0, node v24.13.0, `hardware-concurrency` 24, `device-memory` 32 |
 | Build | `:hicasso-bench`, `:advanced`, `goog.DEBUG false`, via `--config-merge` only — no build id added, `implementation/shadow-cljs.edn` untouched |
 | Reproduction | `cd implementation && npm ci && node freehand/test/re_frame/bench/hicasso/clock_run.cjs` |

--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -108,7 +108,10 @@ report.
 > [outside cross-check](cross-checked-against-an-outside-instrument.md), which
 > clicks rather than evaluates, needs no restatement either.
 
-Owner: the operator-owned standard bead `rf2-2rtt6.1`; this page `rf2-0qj9w`.
+Owner: the operator-owned governance set that superseded `rf2-2rtt6.1` on
+2026-08-10 — K1 price acceptance `rf2-hic-003`, budgets and shell line
+`rf2-hic-006`/`rf2-hic-018`, bulk verdict protocol `rf2-hic-036`, kill rules in
+[the decision brief](../product/decision-brief.md); this page `rf2-0qj9w`.
 
 ---
 

--- a/docs/design/hicasso/studio/the-cold-read-mount-term.md
+++ b/docs/design/hicasso/studio/the-cold-read-mount-term.md
@@ -12,14 +12,19 @@ cell construction, index write, reaction wiring — **cheapens** the phase the
 profile convicts with behaviour held fixed, and **re-takes** the census clock
 rows at the changed blobs on the clock of record.
 
-Bead **`rf2-6c237`**. The standard is **`rf2-2rtt6.1`** (mount ≤ 1.10× direct
-UIx-on-subs, floor-normalised, same run, raw `TaskDuration`); the before rows
+Bead **`rf2-6c237`**. Adjudicated against the mount gate as **`rf2-2rtt6.1`**
+carried it on 2026-08-02 — mount ≤ 1.10× direct UIx-on-subs, floor-normalised,
+same run, raw `TaskDuration`. That standard was superseded and closed on
+2026-08-10; the operative default is now K1 price acceptance `rf2-hic-003`
+([the K1 record](../product/k1-price-acceptance.md)). The before rows
 are `rf2-y1jkm`'s (`the-interpreter-walk-profiled-and-cheapened.md` §4).
 
 > **THE CANONICAL MOUNT WITNESS IS M1 AND STAYS M1.** These rows corroborate
 > the amendment's line on census-real screens exactly as the walk page's did;
 > nothing here re-baselines the canonical witness, and the ruling on any
-> verdict below is the operator's (`rf2-2rtt6.1`), never this page's.
+> verdict below is the operator's
+> ([the decision brief](../product/decision-brief.md) — `rf2-2rtt6.1` was
+> superseded and closed on 2026-08-10), never this page's.
 
 ## 1. The profile — where 141 cold reads actually pay
 

--- a/docs/design/hicasso/studio/the-in-page-mount-term-decomposed.md
+++ b/docs/design/hicasso/studio/the-in-page-mount-term-decomposed.md
@@ -10,7 +10,10 @@ between the arms (8.254 against 8.246), so the whole `+2.2 ms` lives in the
 decomposes the 6.100 ms, term by term, and then does the same to the twin's
 3.900 so the two are comparable line for line.
 
-Bead **`rf2-409ab`**. The standard is **`rf2-2rtt6.1`**.
+Bead **`rf2-409ab`**. The standard is the governance set that superseded
+**`rf2-2rtt6.1`** on 2026-08-10 — K1 price acceptance `rf2-hic-003`, budgets and
+shell line `rf2-hic-006`/`rf2-hic-018`, bulk verdict protocol `rf2-hic-036`,
+kill rules in [the decision brief](../product/decision-brief.md).
 
 > **DIAGNOSTIC, NOT PUBLISHED.** Every figure here is an **in-page
 > `flushSync` window**, and `rf2-8nqsl` established that such a window
@@ -18,8 +21,9 @@ Bead **`rf2-409ab`**. The standard is **`rf2-2rtt6.1`**.
 > sees only the script half of a mount. That is exactly why it is the right
 > instrument for this question: **the quantity being decomposed IS the script
 > half**. No figure on this page is a gate row, no verdict here re-baselines
-> HD-012, and the ruling on any of it is the operator's (`rf2-2rtt6.1`),
-> never this page's.
+> HD-012, and the ruling on any of it is the operator's
+> ([the decision brief](../product/decision-brief.md) — `rf2-2rtt6.1` was
+> superseded and closed on 2026-08-10), never this page's.
 
 ## 1. The instrument — one door, one window, fifteen arms
 

--- a/docs/design/hicasso/studio/the-route-link-render-term-priced.md
+++ b/docs/design/hicasso/studio/the-route-link-render-term-priced.md
@@ -11,14 +11,19 @@ It is not. Roughly half of it was work the synthesis performed and discarded,
 and **77% of it was not Hicasso's at all** — it was routing's, on a path every
 re-frame2 link surface runs.
 
-Bead **`rf2-cno31`**. The standard is **`rf2-2rtt6.1`** (mount ≤ 1.10× direct
-UIx-on-subs, floor-normalised, same run, raw `TaskDuration`); the before rows
+Bead **`rf2-cno31`**. Adjudicated against the mount gate as **`rf2-2rtt6.1`**
+carried it on 2026-08-02 — mount ≤ 1.10× direct UIx-on-subs, floor-normalised,
+same run, raw `TaskDuration`. That standard was superseded and closed on
+2026-08-10; the operative default is now K1 price acceptance `rf2-hic-003`
+([the K1 record](../product/k1-price-acceptance.md)). The before rows
 are `rf2-6c237`'s ([the cold-read page](the-cold-read-mount-term.md) §6).
 
 > **THE CANONICAL MOUNT WITNESS IS M1 AND STAYS M1.** These rows corroborate
 > the amendment's line on census-real screens exactly as the before rows did;
 > nothing here re-baselines the canonical witness, and the ruling on any verdict
-> below is the operator's (`rf2-2rtt6.1`), never this page's.
+> below is the operator's
+> ([the decision brief](../product/decision-brief.md) — `rf2-2rtt6.1` was
+> superseded and closed on 2026-08-10), never this page's.
 
 ## 1. The profile — where 8.21 µs actually goes
 


### PR DESCRIPTION
Two beads, committed separately so a failure on the second could not strand the first.

## rf2-iseb — the provenance-pin finding at `the-candidates-clock.md:1389`

**The finding.** PR #7734 scoped provenance-pin accompaniment to the table ROW rather than the whole block, which newly exposed the "Authoring anchor" row of §7's provenance table. It cites `fdff3fd48855e86b34ec88b5ebc07f62903a6c0a`, and `git merge-base --is-ancestor` confirms that SHA is an ancestor of no remote ref — STRANDED. The row named no landed SHA of its own; under the old block rule the adjacent "Landed whole-tree anchor" row answered for it, and under the row rule it does not.

**What I did.** This is the census's mechanical repair, not a re-pin by guessing. The landed counterpart already exists and is already asserted on the page: line 1388 records `a878d71ab9`, recovered from the authoring anchor by identical `git patch-id --stable`, and I verified it *is* an ancestor of `origin/main`. So the row now says "check out its landed counterpart `a878d71ab9` instead". One line, one insertion, one deletion. The stranded SHA stays exactly where it is — it is the tree the run executed on, and that is a record.

Sequencing verified before starting: PR #7733 shows `state: MERGED`, `mergedAt: 2026-08-09T17:27:31Z`.

**Where the bead governed over the brief.** The brief's test was "if the cited hash IS an ancestor of `origin/main` … put the landed SHA in that row". That test cannot fire — a hash that is an ancestor is not stranded and never reports. The bead states the workable test, and I followed it: *does a landed counterpart exist, and is it asserted somewhere on the page?* Here it does and it is, so the repair is mechanical.

## rf2-sdlw — routing the closed-standard citations

`rf2-2rtt6.1` is confirmed CLOSED, close reason "Superseded by the new governance set per operator ruling Option A (pointer map in notes)". I read the pointer map from the bead's own notes rather than working from the brief's summary; the notes carry more of it (HD-002 adjudication, the P0 baseline table, deciders), and I routed against the notes.

**Confirmed count: 27 pages, 66 citations.** The mayor's 27 is exact. One page is skipped by fence and 26 were examined citation by citation. No page was sed-ed; every occurrence was read in context and classified before anything was touched.

**The discrimination.** A citation as DATED PROVENANCE ("the mount-gate amendment of 2026-08-02 on `rf2-2rtt6.1`", "transcription on `rf2-2rtt6.1`", "recorded on `rf2-2rtt6.1`" for a ruling already discharged) is a record of where something was written down, it is still true, and rewriting it would erase a dated record. Those stay. A citation as the LIVE STANDARD — an ownership header, "The standard is X", "X owns the bar", "the verdict is X's to issue", "rows are appended to X" — is now wrong and routes.

Note that routing never deletes the token. Every re-pointed sentence still names `rf2-2rtt6.1` as the superseded record and says when it closed, then names what governs today. That is the annotate-never-erase discipline applied to the routing itself: a reader learns both what the page was written against and where the rule now lives.

### Counts

**66 citations: 26 re-pointed, 40 left.** Of the 40 left, 33 are dated provenance left deliberately, 6 are live-standard citations on three pages I could not reach (below), and 1 is on the `rf2-styo` page I skipped unexamined.

| page | total | re-pointed | left |
|---|---:|---:|---:|
| `EP/EP-0038-the-hicasso-view-layer-programme.md` | 1 | 0 | 1 |
| `design/hicasso/decisions.md` | 2 | 1 | 1 |
| `design/hicasso/hd-002-adjudication.md` | 3 | 2 | 1 |
| `design/hicasso/production-server-arm.md` | 1 | 0 | 1 |
| `design/hicasso/studio/README.md` | 2 | 1 | 1 |
| `design/hicasso/studio/a-control-that-differences-the-constant-away.md` | 1 | 1 | 0 |
| `design/hicasso/studio/bulk-broad-re-taken.md` | 1 | 1 | 0 |
| `design/hicasso/studio/census-real-clock-rows.md` | 4 | 3 | 1 |
| `design/hicasso/studio/coldmount-double-build-priced.md` | 3 | 0 | 3 |
| `design/hicasso/studio/cross-checked-against-an-outside-instrument.md` | 1 | 0 | 1 |
| `design/hicasso/studio/hd8-composed-donor-arm.md` | 5 | 1 | 4 |
| `design/hicasso/studio/hd8-freehand-codec-donor-arm.md` | 1 | 1 | 0 |
| `design/hicasso/studio/heap-fan-out-sweep.md` | 1 | 0 | 1 |
| `design/hicasso/studio/our-walk-against-reagents.md` | 3 | 1 | 2 |
| `design/hicasso/studio/p0-converged-witness-set.md` | 9 | 1 | 8 |
| `design/hicasso/studio/p0-ratom-spine-narrow-write.md` | 1 | 0 | 1 |
| `design/hicasso/studio/p0-reagent-on-subs-baseline.md` | 1 | 1 | 0 |
| `design/hicasso/studio/p0-uix-on-subs-frontier-arm.md` | 5 | 2 | 3 |
| `design/hicasso/studio/reads-per-boundary-heap-ladder.md` | 5 | 2 | 3 |
| `design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md` | 1 | 1 | 0 |
| `design/hicasso/studio/ssr-spike-witness.md` | 1 | 0 | 1 |
| `design/hicasso/studio/the-candidates-clock.md` | 1 | 1 | 0 |
| `design/hicasso/studio/the-cold-read-mount-term.md` | 2 | 2 | 0 |
| `design/hicasso/studio/the-in-page-mount-term-decomposed.md` | 2 | 2 | 0 |
| `design/hicasso/studio/the-interpreter-walk-profiled-and-cheapened.md` | 2 | 0 | 2 |
| `design/hicasso/studio/the-route-link-render-term-priced.md` | 2 | 2 | 0 |
| `design/hicasso/validation.md` | 5 | 0 | 5 |
| **TOTAL** | **66** | **26** | **40** |

### Why each judgement went the way it did

**Re-pointed — ownership headers (7).** `a-control-that-differences-the-constant-away.md`, `bulk-broad-re-taken.md`, `rows-re-adjudicated-on-the-corrected-clock.md` and `the-candidates-clock.md` each carried `Owner: the operator-owned standard bead rf2-2rtt6.1`. `studio/README.md` said the bead "carries the bar, the budgets and the kill criteria". These name a closed bead as the governing record, which is the class the bead flags by name. Each now names the governance set: `rf2-hic-003`, `rf2-hic-006`/`rf2-hic-018` with gates `rf2-hic-089`/`rf2-hic-071`, `rf2-hic-036`, and the decision brief for kill rules.

**Re-pointed — "The standard is" headers (6).** `census-real-clock-rows.md`, `hd8-composed-donor-arm.md`, `hd8-freehand-codec-donor-arm.md`, `the-in-page-mount-term-decomposed.md` took the same treatment. But `the-cold-read-mount-term.md` and `the-route-link-render-term-priced.md` stated the gate as a figure — "mount ≤ 1.10× direct UIx-on-subs, floor-normalised, same run, raw `TaskDuration`" — and that figure is what the page actually adjudicated against. Overwriting it with `rf2-hic-003`'s 1.25× ceiling would have silently restated the page's own verdict basis. Those now read "Adjudicated against the mount gate as `rf2-2rtt6.1` carried it on 2026-08-02 — [figure verbatim]. That standard was superseded and closed on 2026-08-10; the operative default is now K1 price acceptance `rf2-hic-003`." The measured record is preserved and the reader is routed.

**Re-pointed — the deciders line (5).** "the ruling on any verdict below is the operator's (`rf2-2rtt6.1`), never this page's", on `census-real-clock-rows.md` (twice), `the-cold-read-mount-term.md`, `the-in-page-mount-term-decomposed.md`, `the-route-link-render-term-priced.md`. The map says deciders are unchanged — the operator — so only the record moved; each now points at the decision brief and notes the closure.

**Re-pointed — "rows are appended to" (4).** `p0-converged-witness-set.md`, `p0-reagent-on-subs-baseline.md`, `p0-uix-on-subs-frontier-arm.md`, `reads-per-boundary-heap-ladder.md` told a reader that rows land on `rf2-2rtt6.1`. That bead is closed and size-locked, so the instruction cannot be followed. The map sends the P0 baseline table to `product/lanes/evidence-baseline.md`, and these now name it.

**Re-pointed — remaining live claims (4).** `coldmount`-style ownership prose on `p0-uix-on-subs-frontier-arm.md:471`; the operative red-zone rule on `reads-per-boundary-heap-ladder.md`; "the mount verdict remains `rf2-2rtt6.1`'s to issue" on `our-walk-against-reagents.md`; and `decisions.md` HD-012, where the 2026-08-05 addendum called `rf2-2rtt6.1` the carrier of "the operative bar". HD-012 keeps its two figure lines verbatim and gains a dated supersession note beneath them.

**Re-pointed — HD-002 (2).** `hd-002-adjudication.md` said the bead "requires HD-002's four clauses pinned before P1 code", and instructed a reader to record a fired tripwire "on the standard bead". Routed to the HD-002 successor specifically, which the map names as kernel witnesses `rf2-hic-010`/`rf2-hic-011` and substrate adjudication `rf2-hic-018` — the map states `rf2-hic-018` carries the tripwire clause, so the recording instruction goes there rather than to the generic set.

**Left — all 5 on `validation.md`.** Confirmed independently: lines 25, 64, 246, 262 and 301 are each a dated ruling or a "recorded on"/"transcription on" locator. The earlier worker's finding holds; all five stay.

**Left — dated provenance elsewhere (28).** The large one is `p0-converged-witness-set.md`, 8 of 9 left. Four are dated rulings (2026-07-31). The rest describe the bead's own state — that it is size-locked, that its hold on quoting `1.2301` is not lifted by that page, and a section explicitly headed "What would have been appended to rf2-2rtt6.1, had it not been size-locked". Those are statements about the record and about the page's own restraint, not quotations of a live rule; rewriting them would erase the restraint they document. Same reasoning left `hd8-composed-donor-arm.md`'s four (all dated 2026-07-31/2026-08-02), `heap-fan-out-sweep.md`, `p0-ratom-spine-narrow-write.md` and `reads-per-boundary-heap-ladder.md`'s "Superseded" sections ("Its rows are on `rf2-2rtt6.1`"), and the two scope-fence records on `production-server-arm.md` and `our-walk-against-reagents.md` that state what a past run did *not* touch.

`EP-0038` line 246 — "Evidence and full text on `rf2-2rtt6.1` (RULING — HD-002 FORK, ERGONOMICS HALF)" — is left because it locates a specific titled ruling whose text is preserved verbatim on that bead. The closure note says the delegated rulings "remain historical record, preserved here", so the pointer is still accurate, and `rf2-hic-003` does not carry that ruling's text.

### Pages I did not reach, and why

Three pages carry pre-existing provenance-pin findings. The pins gate is `--changed-since origin/main`, so it is silent on an untouched page and fires the moment one is edited. Editing these for a citation would have made me either red the gate or invent a re-pin, and the bead is explicit that a human decides rather than a mechanical repair when no landed counterpart exists. I reverted my edits to all three and surface them instead. **6 live-standard citations remain unrouted as a result.**

- **`studio/the-interpreter-walk-profiled-and-cheapened.md` — 2 citations unrouted** (the "The standard is" header and the deciders line). Its `7885a7c148` at §4 is STRANDED and has **no landed counterpart**: the census page records the branch as rebased to `5b51627520`, and that is stranded too. The paragraph's base commits `f57808fb60`/`3bcbaf4323` *are* ancestors, but naming a base would hand a reader a tree that is not the measured tree — precisely what `rf2-owq6p` warns against. This is a genuine unaccompanied authored head and needs a human. Its second finding, `8ccd9f4b41` at §4, *is* mechanically repairable — line 270 already records it landing as `a3ffe8380e`, verified an ancestor — but repairing one does not clear the page.
- **`studio/coldmount-double-build-priced.md` — 3 citations unrouted.** `0b482f385e` is STRANDED with no landed counterpart asserted, and the page says so by design: "The instrument is identified by content hash, not by commit SHA … if that does not resolve, these blobs are what to trust." There is nothing to name.
- **`studio/ssr-spike-witness.md` — 1 citation unrouted** (the deciders line). Five pre-existing findings. Four are mechanically repairable — the page's own producing commit `b557ed71f4` is a verified ancestor asserted at line 9 — but the fifth, `83b865f8`, is not a git object at all; the page itself explains it is the FNV-1a-32 of canonical EDN `[#fn[] {}]`, so it is a digest the checker reads as a pin. Repairing five findings on a page whose in-scope change is one line is outside both beads.

**`studio/cross-checked-against-an-outside-instrument.md` is skipped entirely** per the fence — `rf2-styo` owns it and it needs an operator ruling. It carries 1 `rf2-2rtt6.1` citation, which I did not examine or classify.

### One provenance-pin repair inside the sweep

Touching `hd8-freehand-codec-donor-arm.md` surfaced a pre-existing finding: `1384ae1285` read as an unaccompanied pin because the prose said only "on today's spine". `git cat-file -t` confirms the object is a **blob**, and it is stamped as the `spine.cljs` blob in the table directly above. The prose now says "today's spine blob (`1384ae1285`, the `spine.cljs` blob stamped in the table above)". That is the text becoming accurate about what it cites, not the gate being relaxed — the checker classifies blobs by the words around them, and the words were wrong.

## Quality gates

Run foreground to completion, output redirected to worktree-local logs, exit codes echoed, never piped.

| gate | exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** |

Pins summary on the final tree: `18 files, 225 cited pins (159 landed, 65 stranded, 1 unresolvable)` — "every cited pin is an ancestor of origin/main or shares its block — its table row, when it sits in one — with one."

**Sabotage controls — three, all on pages this PR edits.**

1. *Pins, row accompaniment.* Replaced the landed `a878d71ab9` in `the-candidates-clock.md:1389` with a bogus `deadbeef99`. Exit **1**, two findings, both naming `the-candidates-clock.md:1389`. Restored, exit **0**. (A first attempt that simply removed the accompaniment was an exact revert to `origin/main`, so `--changed-since` correctly reported "no page changed" — a no-op, not a control, which is why it was redone as above.)
2. *Slugs, anchors.* Broke `#61-the-seam-measured-against-load` on `the-candidates-clock.md`. Exit **1**, 12 broken anchors named with line numbers. Restored, exit **0**.
3. *Slugs, link targets.* Broke the new `../product/decision-brief.md` link on `bulk-broad-re-taken.md`. Exit **1**: "BROKEN TARGET: bulk-broad-re-taken.md:32 -> ../product/decision-briefZZZ.md". Restored, exit **0**. This one proves the checker validates the relative links this PR adds.

**Hand-verification, since `mkdocs build --strict` does not cover `docs/design/**`.**

- *Table column counts.* Exactly one added line in this PR contains a pipe: the repaired "Authoring anchor" row. Its parent table is 2-column (`| | |` / `|---|---|`) and the row has 2 cells before and after — the replacement text introduces no `|`. Every other edit is prose, a header, a blockquote or a list item; no other table row is touched.
- *Anchors and links.* 26 new links added: 18 × `../product/decision-brief.md`, 4 × `../product/lanes/evidence-baseline.md`, 3 × `../product/k1-price-acceptance.md`, 1 × `product/decision-brief.md` (from `decisions.md`, one level up). All four targets confirmed present on disk. All are file links without anchor fragments — deliberate, since `k1-price-acceptance.md` is under active change on another PR and an anchor would be the fragile part. No existing anchor was renamed, and no heading text was altered.
- *Router targets exist.* `rf2-hic-003`, `-006`, `-010`, `-011`, `-018`, `-036`, `-070`, `-071`, `-087`, `-089` all resolve via `bd show`. `rf2-hic-003` is CLOSED — it was the bead that drafted the K1 amendment — so where a page needs the operative K1 record rather than the drafting bead, it links `product/k1-price-acceptance.md` alongside.

**Corpus integrity.** The page set is unchanged at 27 before and after; total citations go 66 → 67, the one addition being the supersession note in `decisions.md` naming `rf2-2rtt6.1` as the record that closed. No citation was deleted.

Rebased onto `origin/main` `44581c63dc` after five commits landed mid-run; the rebase was clean and both gates were re-run green on the new base.

## Fence

`docs/**` only. Untouched: `spec/009-Instrumentation.md`, the bench check-standard files, `implementation/hicasso/**`, `implementation/shadow-cljs.edn`, `migration/reagent-to-hicasso/**`, and `docs/design/hicasso/product/k1-price-acceptance.md` (linked to, never edited).

Closes rf2-iseb. Closes rf2-sdlw.
