### PR TITLE
fix(bench): the check standard requires its declared evidence cardinality (rf2-pzqy8)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -1801,6 +1801,14 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   // its EIGHTEEN-block twin green in the same test, so neither can pass by
   // refusing everything.
   //
+  // SCOPE, for anyone rebasing the clock-side instrument onto this file: these
+  // witnesses are the CENSUS rig's (`shapes/census_clock_run.cjs`), and the
+  // rule they pin is a cardinality PRECONDITION on the calibrated limits in
+  // `shapes/census_check_standard.json`. It is NOT the per-block all-blocks
+  // rule, and its 18 is the census design's 6 x 3 — never the `p^18` exponent
+  // in that rule's false-refusal arithmetic. See the note above
+  // `EXPECTED_READINGS` in the driver for why the two are orthogonal.
+  //
   // NO MEASUREMENT IS TAKEN. Cardinality and arithmetic over fixture blocks.
 
   for (const [what, n] of [['ONE BLOCK', 1], ['SEVENTEEN BLOCKS', 17]]) {

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -1807,6 +1807,8 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     t(`${what} at the frozen centre REFUSES the row, and publishes nothing from it`, () => {
       const row = resultRow('ordinary', { blocks: n });
       const ctl = row.adjudication.ctl;
+      /** The full published shape, with the two complete rows beside this one. */
+      const beside = (ordinary) => ['large-template', 'feed'].map((id) => resultRow(id)).concat(ordinary);
 
       // 1. THE STANDARD REFUSED IT, ON THE COUNT, BEFORE COMPUTING A STATISTIC.
       assert.strictEqual(ctl.standard.ok, false, `${n} blocks must not be adjudicated in control`);
@@ -1833,7 +1835,7 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
       assert.match(ctl.adjudicator, /calibrated check standard/);
 
       // 3. THE NONZERO EXIT PATH.
-      const rows = ['large-template', 'feed'].map((id) => resultRow(id)).concat(row);
+      const rows = beside(row);
       const v = verdict(summarise(null, rows));
       assert.strictEqual(v.code, 5, 'a row whose control does not hold exits 5');
       assert.match(v.lines[0], /uix\/ordinary/);
@@ -1849,11 +1851,11 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
       for (const id of ['large-template', 'feed']) {
         assert.strictEqual(byId[id].canonical, true, `${id} must stay citable — the refusal's scope is the ROW`);
       }
-      // ... and the whole-evidence run publishes every row, so step 4 is not
-      // passing by refusing the world.
-      const clean = written(['large-template', 'feed'].map((id) => resultRow(id)).concat(resultRow('ordinary', { blocks: EXPECTED })));
-      assert.deepStrictEqual(clean.rowsRefused, []);
-      assert.strictEqual(verdict(summarise(null, ['large-template', 'feed'].map((id) => resultRow(id)).concat(resultRow('ordinary', { blocks: EXPECTED })))).code, 0);
+      // ... and the same run carrying WHOLE evidence publishes every row and
+      // exits 0, so neither step 3 nor step 4 passes by refusing the world.
+      const wholeRun = beside(resultRow('ordinary', { blocks: EXPECTED }));
+      assert.deepStrictEqual(written(wholeRun).rowsRefused, []);
+      assert.strictEqual(verdict(summarise(null, wholeRun)).code, 0);
     });
   }
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -1512,9 +1512,30 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
 
 {
   const CENSUS = DRIVERS[1].mod;
-  const { summarise, summariseRow, verdict, destination, datasetFor, rowPublication } = CENSUS;
+  const {
+    summarise, summariseRow, verdict, destination, datasetFor, rowPublication,
+    controlBlocks, controlAdjudication, checkStandardVerdict, CHECK_STANDARD: STD,
+  } = CENSUS;
   const CSRC = fs.readFileSync(DRIVERS[1].file, 'utf8');
   const t = (what, fn) => test(`census refusal scope: ${what}`, fn);
+
+  const ORD = STD.rows.ordinary;
+  const EXPECTED = STD.evidence.rounds * STD.evidence.blocks;
+
+  /**
+   * A capture of exactly `n` control blocks, every block reading the frozen
+   * CENTRE — the most favourable evidence this standard has, so anything that
+   * refuses it can only be refusing the COUNT. Laid out in rounds of
+   * `evidence.blocks`, the way a capture truncated part-way actually arrives.
+   */
+  const centreBlocks = (n) => {
+    const rounds = [];
+    for (let i = 0; i < n; i += STD.evidence.blocks) {
+      const width = Math.min(STD.evidence.blocks, n - i);
+      rounds.push(Array.from({ length: width }, () => ({ plumb: [0], floor: [1], 'ctl-2x': [ORD.centre] })));
+    }
+    return rounds;
+  };
 
   const CANON = '/data/censusclock-2rtt6-56';
   const shape = (over = {}) => ({
@@ -1531,35 +1552,54 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
 
   const DECOMP = () => ({ n: 10, task: 3, taskNet: 2, devtools: 1, script: 0.5, style: 0.4, layout: 0.6, layoutCount: 10, inPage: 1 });
 
-  /** One row as `drive` collects it, with its four gates settable one at a time. */
-  const resultRow = (rowId, gates = {}) => ({
-    runId: 'uix',
-    rowId,
-    armIds: ['plumb', 'floor', 'ctl-2x'],
-    canon: { floor: { hash: 'a', bytes: 10, control: true } },
-    ctlPredicted: 1.7255,
-    blocksTask: [[{ plumb: [0.7], floor: [2, 2.1], 'ctl-2x': [3, 3.1] }]],
-    blocksNet: [[{ floor: [1, 2], 'ctl-2x': [2, 4] }]],
-    blocksInPage: [[{ floor: [1, 2], 'ctl-2x': [2, 4] }]],
-    blocksDecomp: [[{ plumb: DECOMP(), floor: DECOMP(), 'ctl-2x': DECOMP() }]],
-    tally: { writes: 36, unverified: gates.unverified || 0 },
-    runtime: 'fixture',
-    quiet: { ok: true },
-    windowStart: '2026-08-08T00:00:00.000Z',
-    adjudication: {
-      ctl: { ok: gates.ctlOk !== false, measured: { mean: gates.ctlMeasured || 1.9943 } },
-      cAdditive: 0.96,
-      assessed: {
-        bandStats: { band: gates.band === undefined ? 0.12 : gates.band },
-        verdict: { ceilingBreached: gates.ceilingBreached === true },
+  /**
+   * One row as `drive` collects it, with its four gates settable one at a time.
+   *
+   * A `blocks` gate is the fifth, and it is different in kind: instead of
+   * handing the row a stated control verdict it hands it a real capture of that
+   * many blocks and adjudicates it through the driver's OWN
+   * `controlAdjudication`, so a witness can drive the evidence-cardinality
+   * precondition end to end rather than assert a hand-set answer (rf2-pzqy8).
+   */
+  const resultRow = (rowId, gates = {}) => {
+    const ctlPredicted = 1.7255;
+    const blocksTask =
+      gates.blocks === undefined
+        ? [[{ plumb: [0.7], floor: [2, 2.1], 'ctl-2x': [3, 3.1] }]]
+        : centreBlocks(gates.blocks);
+    const ctl =
+      gates.blocks === undefined
+        ? { ok: gates.ctlOk !== false, measured: { mean: gates.ctlMeasured || 1.9943 } }
+        : controlAdjudication(rowId, ctlPredicted, controlBlocks(blocksTask), ORD.tolerance.slack);
+    return {
+      runId: 'uix',
+      rowId,
+      armIds: ['plumb', 'floor', 'ctl-2x'],
+      canon: { floor: { hash: 'a', bytes: 10, control: true } },
+      ctlPredicted,
+      blocksTask,
+      blocksNet: [[{ floor: [1, 2], 'ctl-2x': [2, 4] }]],
+      blocksInPage: [[{ floor: [1, 2], 'ctl-2x': [2, 4] }]],
+      blocksDecomp: [[{ plumb: DECOMP(), floor: DECOMP(), 'ctl-2x': DECOMP() }]],
+      tally: { writes: 36, unverified: gates.unverified || 0 },
+      runtime: 'fixture',
+      quiet: { ok: true },
+      windowStart: '2026-08-08T00:00:00.000Z',
+      adjudication: {
+        ctl,
+        cAdditive: 0.96,
+        assessed: {
+          bandStats: { band: gates.band === undefined ? 0.12 : gates.band },
+          verdict: { ceilingBreached: gates.ceilingBreached === true },
+        },
+        bars: {},
+        verdicts: {},
+        guardRefuse: gates.guardRefuse === true,
+        plumb: 0.7683,
+        floorTared: 1.4076,
       },
-      bars: {},
-      verdicts: {},
-      guardRefuse: gates.guardRefuse === true,
-      plumb: 0.7683,
-      floorTared: 1.4076,
-    },
-  });
+    };
+  };
 
   /** The full published shape: the three rows, in the order the driver takes them. */
   const fullShape = (gatesByRow = {}) =>
@@ -1741,6 +1781,105 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     const note = CSRC.slice(CSRC.indexOf('// WHERE A RUN\'S DATASETS MAY BE WRITTEN'), CSRC.indexOf('function destination('));
     assert.match(note, /`clock_run\.cjs`'s `publication\(shape\)` has read shape and nothing else/);
     assert.match(note, /A refusal is evidence/);
+  });
+
+  // --- rf2-pzqy8: the standard requires its DECLARED EVIDENCE CARDINALITY ----
+  //
+  // MERGED-PR AUDIT #7701. The calibrated standard's limits are statistics OF
+  // 18-block row-runs, but `checkStandardVerdict` accepted any non-empty
+  // all-finite array and never compared its length against the design. On the
+  // landed helper `checkStandardVerdict('ordinary', [1.2308])` reported `n: 1`,
+  // `scale: 0`, location ok, dispersion ok and final `ok: true` — and because
+  // `controlAdjudication` makes the standard THE adjudicator on a calibrated
+  // row, one block at the centre made the row citable as in control while the
+  // strict rule was failing it. Truncated capture evidence could publish.
+  //
+  // The two witnesses are the audit's own: a ONE-BLOCK row-run and a
+  // SEVENTEEN-BLOCK one. Each is driven through the driver's real
+  // `controlBlocks` and `controlAdjudication` and out through BOTH consumers of
+  // that verdict — the nonzero exit and the row publication — and each asserts
+  // its EIGHTEEN-block twin green in the same test, so neither can pass by
+  // refusing everything.
+  //
+  // NO MEASUREMENT IS TAKEN. Cardinality and arithmetic over fixture blocks.
+
+  for (const [what, n] of [['ONE BLOCK', 1], ['SEVENTEEN BLOCKS', 17]]) {
+    t(`${what} at the frozen centre REFUSES the row, and publishes nothing from it`, () => {
+      const row = resultRow('ordinary', { blocks: n });
+      const ctl = row.adjudication.ctl;
+
+      // 1. THE STANDARD REFUSED IT, ON THE COUNT, BEFORE COMPUTING A STATISTIC.
+      assert.strictEqual(ctl.standard.ok, false, `${n} blocks must not be adjudicated in control`);
+      assert.strictEqual(ctl.standard.measured.n, n, 'the observed count is reported');
+      assert.strictEqual(ctl.standard.measured.expected, EXPECTED, 'and so is the expected one');
+      assert.strictEqual(ctl.standard.measured.finite, n, 'every block here IS a finite reading');
+      assert.strictEqual(ctl.standard.location, null, 'no location statistic may be computed on partial evidence');
+      assert.strictEqual(ctl.standard.dispersion, null, 'nor a dispersion one');
+      assert.match(ctl.standard.why, new RegExp(`^${n} finite blocks where this standard's evidence is ${EXPECTED} `));
+      assert.match(ctl.standard.why, new RegExp(`${EXPECTED - n} MISSING`));
+
+      // ... and it is the COUNT and nothing else: the same blocks at the same
+      // centre, eighteen of them, are in control.
+      const whole = resultRow('ordinary', { blocks: EXPECTED }).adjudication.ctl;
+      assert.strictEqual(whole.standard.ok, true, 'the eighteen-block twin must PASS, or this witness is vacuous');
+      assert.strictEqual(whole.standard.location.ok, true);
+      assert.strictEqual(whole.standard.dispersion.ok, true);
+      assert.strictEqual(whole.ok, true);
+
+      // 2. `controlAdjudication` CARRIES THE REFUSAL — this is the seat the
+      //    audit found, where a passing standard overrode a failing strict rule.
+      assert.strictEqual(ctl.ok, false, 'the standard adjudicates a calibrated row, so the row does not hold');
+      assert.strictEqual(ctl.strictOk, false, 'the strict rule was failing all along; it must not be what saves this');
+      assert.match(ctl.adjudicator, /calibrated check standard/);
+
+      // 3. THE NONZERO EXIT PATH.
+      const rows = ['large-template', 'feed'].map((id) => resultRow(id)).concat(row);
+      const v = verdict(summarise(null, rows));
+      assert.strictEqual(v.code, 5, 'a row whose control does not hold exits 5');
+      assert.match(v.lines[0], /uix\/ordinary/);
+      assert.doesNotMatch(v.lines[0], /large-template|feed/, 'a clean row must not be blamed');
+
+      // 4. THE ROW-PUBLICATION PATH — refused at the ROW's scope, the two
+      //    complete rows still citable, per the fence this bead may not move.
+      const data = written(rows);
+      assert.deepStrictEqual(data.rowsRefused, ['ordinary']);
+      const byId = Object.fromEntries(data.rows.map((r) => [r.rowId, r]));
+      assert.strictEqual(byId.ordinary.canonical, false);
+      assert.match(byId.ordinary.notCanonicalWhy, /POSITIVE CONTROL did not hold/);
+      for (const id of ['large-template', 'feed']) {
+        assert.strictEqual(byId[id].canonical, true, `${id} must stay citable — the refusal's scope is the ROW`);
+      }
+      // ... and the whole-evidence run publishes every row, so step 4 is not
+      // passing by refusing the world.
+      const clean = written(['large-template', 'feed'].map((id) => resultRow(id)).concat(resultRow('ordinary', { blocks: EXPECTED })));
+      assert.deepStrictEqual(clean.rowsRefused, []);
+      assert.strictEqual(verdict(summarise(null, ['large-template', 'feed'].map((id) => resultRow(id)).concat(resultRow('ordinary', { blocks: EXPECTED })))).code, 0);
+    });
+  }
+
+  t('EXTRA blocks refuse too, and the refusal counts them', () => {
+    // The precondition is EXACTLY the declared evidence, not a floor. A row-run
+    // deeper than the design is not the run these limits were calibrated on
+    // either, and a standard that adjudicates any depth has an unmeasured rate.
+    const v = checkStandardVerdict('ordinary', controlBlocks(centreBlocks(EXPECTED + 1)));
+    assert.strictEqual(v.ok, false);
+    assert.strictEqual(v.measured.n, EXPECTED + 1);
+    assert.strictEqual(v.measured.expected, EXPECTED);
+    assert.match(v.why, /1 EXTRA/);
+    assert.strictEqual(v.location, null);
+  });
+
+  t('the expected count is the STANDARD\'s design field, not a literal in the driver', () => {
+    // One field, one place. `18` is nowhere in the driver's code: it is
+    // `evidence.rounds x evidence.blocks`, so re-deepening the design is
+    // editing the JSON exactly as moving a limit is — and `recalibrateOn`
+    // already says a change to the round or block counts is a recalibration.
+    assert.deepStrictEqual([STD.evidence.rounds, STD.evidence.blocks], [6, 3]);
+    assert.strictEqual(EXPECTED, 18, 'the published design is 6 rounds x 3 blocks');
+    const CODE = CSRC.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+    assert.match(CODE, /CHECK_STANDARD\.evidence\.rounds \* CHECK_STANDARD\.evidence\.blocks/);
+    assert.ok(!/=\s*18\b/.test(CODE), 'the expected count must not be assigned as a literal in the driver');
+    assert.match(STD.recalibrateOn.join(' '), /the sample or round counts/);
   });
 }
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_check_standard.json
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_check_standard.json
@@ -10,7 +10,13 @@
     "location": "the row-run's MEDIAN over its 18 blocks (rf2-8bgqq: a ratio's headline is its median)",
     "dispersion": "the row-run's robust scale over those blocks, IQR / 1.349 — the normal-consistent estimator, comparable with an SD without inheriting one wild block"
   },
-  "runRejection": "a row-run is IN CONTROL when its block median lies inside the frozen location limits AND its robust scale is at or under the frozen dispersion limit. Nothing per-block rejects it.",
+  "evidence": {
+    "rounds": 6,
+    "blocks": 3,
+    "why": "THE CARDINALITY THIS STANDARD'S LIMITS DESCRIBE, and a PRECONDITION rather than a description (rf2-pzqy8). Every limit below is a statistic OF row-runs of exactly 6 x 3 = 18 blocks: the between-run SD the location limits are three of, and the lognormal fit the dispersion limit is the upper 3 sigma of, are both taken over 18-block row-runs. A median over fewer blocks has a different sampling distribution, so judging it against these limits judges a different quantity — and at n = 1 it is not a judgement at all, because the robust scale of one reading is 0 and the dispersion rule cannot fail. `checkStandardVerdict` therefore refuses a row-run that does not carry exactly this many finite readings, with the observed and expected counts, BEFORE computing either statistic. `recalibrateOn` already makes a change to the round or block counts a recalibration; this is that requirement made enforceable rather than trusted.",
+    "expectedReadings": "rounds x blocks — derived in the driver, never spelled there, so re-deepening the design is editing this file like every other limit"
+  },
+  "runRejection": "a row-run is IN CONTROL when it carries exactly the evidence above AND its block median lies inside the frozen location limits AND its robust scale is at or under the frozen dispersion limit. Nothing per-block rejects it.",
   "toleranceBandIsNotTheRule": "The per-block tolerance band below is REPORTED and decides nothing on a row this standard calibrates. It is the same +/-25% band the strict rule uses, re-centred on the empirical centre, and it is printed because a reader wants to see where the blocks fell.",
   "whyNotTheAllBlocksRule": "Because on THIS row it is `p^18` and nothing else. Re-centred on the empirical centre the ordinary row's per-block in-band fraction rises from 31.1% to 90.0%, and the all-blocks rule would still pass only 3 of 10 row-runs, because 0.90^18 = 15%. That is rf2-8a746's arithmetic exactly. THE RULE IS NOT TOUCHED WHERE rf2-y0pkh MEASURED AND RETAINED IT: on `large-template` and `feed` it costs 18.2% and 39.8% per-run false refusal and it remains those rows' adjudicator, unchanged. `ordinary` is the row rf2-y0pkh explicitly held out of that retention.",
   "rows": {

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
@@ -176,10 +176,23 @@ const seamlib = require('../seam.cjs');
 // is editing that file and bumping its `version`; nothing here holds a limit.
 const CHECK_STANDARD = require('./census_check_standard.json');
 
-// The evidence that standard's limits are statistics OF, taken from its own
-// `evidence` design field and multiplied out in ONE place, so no `18` is
-// spelled anywhere in this driver — re-deepening the design is editing that
-// file, exactly like moving a limit is (rf2-pzqy8).
+// THE CENSUS RIG'S EVIDENCE CARDINALITY (rf2-pzqy8) — how MANY control blocks
+// this instrument's calibrated standard requires before it will adjudicate a
+// row-run. Taken from that standard's own `evidence` design field and
+// multiplied out in ONE place, so no `18` is spelled anywhere in this driver:
+// re-deepening the design is editing that file, exactly like moving a limit.
+//
+// THIS IS NOT THE ALL-BLOCKS RULE, and the two must never be conflated. The
+// strict per-block unanimity rule — `controlVerdict` below, "EVERY block
+// inside the band" — is about WHERE each block falls, and its cost is the
+// `p^n` arithmetic rf2-8a746 reasoned about on the hicasso clock. This is
+// about HOW MANY blocks exist at all, and it is a precondition of the
+// calibrated standard that REPLACED unanimity as the `ordinary` row's
+// adjudicator. Retiring unanimity and requiring the whole evidence are
+// orthogonal, and on this rig they ALREADY coexist — which is the proof that
+// they are two rules and not one. A reader arriving from the clock-side
+// instrument should read this `18` as the census design's 6 x 3, never as the
+// `p^18` exponent in that rule's false-refusal arithmetic.
 const EXPECTED_READINGS = CHECK_STANDARD.evidence.rounds * CHECK_STANDARD.evidence.blocks;
 
 const IMPL = path.resolve(__dirname, '../../../../../..');

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
@@ -176,6 +176,12 @@ const seamlib = require('../seam.cjs');
 // is editing that file and bumping its `version`; nothing here holds a limit.
 const CHECK_STANDARD = require('./census_check_standard.json');
 
+// The evidence that standard's limits are statistics OF, taken from its own
+// `evidence` design field and multiplied out in ONE place, so no `18` is
+// spelled anywhere in this driver — re-deepening the design is editing that
+// file, exactly like moving a limit is (rf2-pzqy8).
+const EXPECTED_READINGS = CHECK_STANDARD.evidence.rounds * CHECK_STANDARD.evidence.blocks;
+
 const IMPL = path.resolve(__dirname, '../../../../../..');
 const REPO = path.resolve(IMPL, '..');
 
@@ -423,12 +429,27 @@ function controlVerdict(predicted, per, slack) {
  * TOUCHED WHERE rf2-y0pkh MEASURED AND RETAINED IT — on the two rows above
  * it is still the adjudicator, with the same band and the same wording.
  *
- * FAIL CLOSED AT EVERY SEAT: a row-run with no blocks, a block that is not a
- * finite reading, and a row the standard declares `calibrated: false` are
- * each a REFUSAL and never a pass. A row that appears in NEITHER list is a
- * fault and THROWS — the standard is complete over the roster by
- * construction, so a row it has never heard of may not be adjudicated by it
- * or waved past it.
+ * ## And the evidence has to be all there
+ *
+ * The limits are statistics OF 18-block row-runs — the between-run SD the
+ * location limits are three of, and the lognormal fit the dispersion limit
+ * caps, are both taken over row-runs of exactly `evidence.rounds x
+ * evidence.blocks`. So that count is a PRECONDITION and not a description.
+ * Truncated capture evidence judged against these limits is a different
+ * quantity judged against the wrong sampling distribution, and at `n = 1` it
+ * is not a judgement at all: the robust scale of one reading is 0, so the
+ * dispersion rule cannot fail, and a single block sitting at the centre
+ * reported `ok: true` with `n: 1` — which `controlAdjudication` then made the
+ * gate verdict, citing a row as in control on one block. MISSING OR EXTRA
+ * BLOCKS REFUSE, with the observed and the expected count, BEFORE either
+ * statistic is computed.
+ *
+ * FAIL CLOSED AT EVERY SEAT: a row-run with no blocks, one with fewer or more
+ * than the declared evidence, a block that is not a finite reading, and a row
+ * the standard declares `calibrated: false` are each a REFUSAL and never a
+ * pass. A row that appears in NEITHER list is a fault and THROWS — the
+ * standard is complete over the roster by construction, so a row it has never
+ * heard of may not be adjudicated by it or waved past it.
  */
 function checkStandardVerdict(rowId, per) {
   const spec = CHECK_STANDARD.rows[rowId];
@@ -451,6 +472,7 @@ function checkStandardVerdict(rowId, per) {
     measured: {
       n: xs.length,
       finite: finite.length,
+      expected: EXPECTED_READINGS,
       p50: r4(p50(finite)),
       scale: r4(robustScale(finite)),
     },
@@ -466,11 +488,24 @@ function checkStandardVerdict(rowId, per) {
     out.why = `the \`${rowId}\` row of the check standard is NOT CALIBRATED — ${spec.why || 'nothing has established what this instrument reads on it'}`;
     return out;
   }
-  if (finite.length === 0 || finite.length !== xs.length) {
+  if (finite.length !== xs.length) {
+    out.why = `${xs.length - finite.length} of ${xs.length} blocks are not finite readings of a level ratio`;
+    return out;
+  }
+  // THE CARDINALITY PRECONDITION, before either statistic exists to be read.
+  if (finite.length !== EXPECTED_READINGS) {
+    const short = EXPECTED_READINGS - finite.length;
     out.why =
-      xs.length === 0
-        ? 'no blocks — an empty block set is an absent reading, not a row-run in control'
-        : `${xs.length - finite.length} of ${xs.length} blocks are not finite readings of a level ratio`;
+      `${finite.length} finite blocks where this standard's evidence is ${EXPECTED_READINGS} ` +
+      `(${CHECK_STANDARD.evidence.rounds} rounds x ${CHECK_STANDARD.evidence.blocks} blocks) — ` +
+      (finite.length === 0
+        ? 'no blocks at all, and an empty block set is an absent reading, not a row-run in control'
+        : short > 0
+          ? `${short} MISSING. These limits are the location and dispersion OF ${EXPECTED_READINGS}-block ` +
+            'row-runs, so a statistic over truncated evidence is a different quantity judged against the ' +
+            'wrong sampling distribution'
+          : `${-short} EXTRA. A row-run deeper than the declared design is not the run these limits were ` +
+            'calibrated on either, and a standard that adjudicates any depth has an unmeasured rate');
     return out;
   }
 


### PR DESCRIPTION
Closes rf2-pzqy8. Operator ruling 2026-08-10 03:05 AUSEST: Option A — the bounded acceptance in the merged-PR-audit note — ratified and released for dispatch.

## The gap

`checkStandardVerdict` validated that its block list was non-empty and all-finite, and never compared its length against the design its limits were calibrated on. Measured on the pre-change driver:

```
OLD n=1  ok=true  measured={"n":1,"finite":1,"p50":1.2308,"scale":0}   loc.ok=true disp.ok=true why=null
OLD n=17 ok=true  measured={"n":17,"finite":17,"p50":1.2308,"scale":0} loc.ok=true disp.ok=true why=null
```

One block at the frozen centre passed both rules — the robust scale of a single reading is `0`, so the dispersion limit cannot fail. Because `controlAdjudication` makes the standard THE adjudicator on a calibrated row, that verdict overrode a *failing* strict rule and made the `ordinary` row citable as in control on one block. Truncated capture evidence could publish.

## The expected-count source, and why

The standard's own file, as one design field:

```json
"evidence": { "rounds": 6, "blocks": 3, "why": "..." }
```

and the driver multiplies it out exactly once:

```js
const EXPECTED_READINGS = CHECK_STANDARD.evidence.rounds * CHECK_STANDARD.evidence.blocks;
```

`18` is spelled nowhere in the driver's code. The count belongs in the JSON rather than in the driver's `PUBLISHED_DEPTH` because it is a property of *the limits*, not of the run: the between-run SD the location limits are three of, and the lognormal fit the dispersion limit caps, are both statistics **of 18-block row-runs**. A run launched at `C56CLOCK_ROUNDS=3` must still be refused by a standard calibrated at six, and reading the driver's live depth would have accepted it. `recalibrateOn` already said a change to the round or block counts is a recalibration; this makes that enforceable rather than trusted.

`version` is deliberately **not** bumped: no limit, centre or band moved, and bumping would falsely signal the re-baseline that fence A still requires.

## The rejection, with observed and expected counts

```
NEW n=1  ok=false measured={"n":1,"finite":1,"expected":18,...}  location=null dispersion=null
   why: 1 finite blocks where this standard's evidence is 18 (6 rounds x 3 blocks) - 17 MISSING. These
        limits are the location and dispersion OF 18-block row-runs, so a statistic over truncated
        evidence is a different quantity judged against the wrong sampling distribution

NEW n=17 ok=false ... - 1 MISSING. ...
NEW n=18 ok=true  measured={"n":18,"finite":18,"expected":18,...}   <- unchanged
NEW n=19 ok=false ... - 1 EXTRA. A row-run deeper than the declared design is not the run these limits
        were calibrated on either, and a standard that adjudicates any depth has an unmeasured rate
```

Both counts are also machine-readable on the verdict as `measured.n` and `measured.expected`. `location` and `dispersion` are `null` on a refusal — the precondition runs *before* either statistic is computed, which is the assertion the witnesses pin.

## The two witnesses

`census refusal scope: ONE BLOCK / SEVENTEEN BLOCKS at the frozen centre REFUSES the row, and publishes nothing from it`. Every block reads the frozen centre — the most favourable evidence the standard has — so only the count can be refusing them. Each is built as a real capture, laid out in rounds of three the way a truncated capture arrives, and driven through the driver's own `controlBlocks` then `controlAdjudication` then `summariseRow`, and out through both consumers of that verdict:

1. the standard refuses on the count, with `location`/`dispersion` null;
2. `controlAdjudication` carries the refusal (`ok:false`, `strictOk:false`) — the exact seat the audit found;
3. the **nonzero exit path**: `verdict(...).code === 5`, naming `uix/ordinary` and blaming neither clean row;
4. the **row-publication path**: `rowsRefused === ['ordinary']`, ordinary `canonical:false`, `large-template` and `feed` still citable.

Each test also asserts its **eighteen-block twin** green — `ok:true`, `rowsRefused: []`, exit 0 — so neither witness can pass by refusing everything.

Before/after: the new tests run against the reverted driver (JSON held new, since the old code ignores the added field) —

```
FAIL  census refusal scope: ONE BLOCK ...        1 blocks must not be adjudicated in control : true !== false
FAIL  census refusal scope: SEVENTEEN BLOCKS ... 17 blocks must not be adjudicated in control : true !== false
FAIL  census refusal scope: EXTRA blocks refuse too ...
FAIL  census refusal scope: the expected count is the STANDARD's design field ...
clock_exit_path.test.cjs: 4/362 failed
```

— and against the new driver, all pass. No other test in the file changed behaviour.

## Preserved, explicitly

- **The empirical centre and the limits.** The JSON diff is the new `evidence` block plus one clause in `runRejection`. Everything under `rows{}` is byte-identical: centre `1.2308`, location `[1.0412, 1.4204]`, dispersion `0.3422`, tolerance `[0.9231, 1.5385]`, prediction `1.7255`. No threshold widened, nothing re-centred.
- **The row-scoped publication.** Untouched, and now additionally exercised by both witnesses at step 4.
- **The strict rule on the other rows.** `large-template` and `feed` are in `notInThisStandard`, so `checkStandardVerdict` returns `null` for them *before* the cardinality gate — they keep the strict all-blocks rule with no count precondition. Their existing 8-of-10 and 7-of-10 pins pass unchanged.
- **All ten committed `ordinary` row-runs still pass** (180 blocks / 10 runs = 18 each), so the corpus, the derivations and the hold-out measurement are unaffected.

## The four ratification fences — none touched

1. **v1 stays diagnostic-grade.** `version` unchanged at 1; no re-baseline claimed or implied.
2. **No ordinary-row magnitude publishes.** Untouched; this change only ever makes a row *less* citable.
3. **The element-count read-back stays a hard row gate.** Untouched — that is the `unverified`/`writes` gate, a different seat.
4. **The rescue path stands.** Untouched; nothing here forecloses a finer door or a fresh baseline.

This bead added a cardinality precondition and nothing else.

## Overlap with PR #7738

PR #7738 (`rf2-8a746`, "the clock's consumers require complete evidence before pooling") merged as `44581c63dc` while this branch was in flight. **This branch is rebased onto it**, and the reconciliation was empty: git applied all three commits with no conflict.

**Only `implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs` is shared.** #7738 also touches `clock_check_standard.{cjs,json}`, `clock_readjudicate.cjs` and `clock_run.cjs`, none of which this branch goes near; this branch also touches `shapes/census_clock_run.cjs` and `shapes/census_check_standard.json`, neither of which #7738 goes near. Inside the shared file their hunks all sit at line 3881 and below; mine are confined to the `census refusal scope:` block at 1512–1880. Nothing overlapped textually.

**The two rules are siblings, not rivals, and the next reader of that test file needs to tell them apart:**

| | #7738 (rf2-8a746) | this PR (rf2-pzqy8) |
|---|---|---|
| instrument | the hicasso **clock** | the **census** rig |
| surface | `clock_readjudicate.cjs`, `clock_check_standard.json` | `shapes/census_clock_run.cjs`, `shapes/census_check_standard.json` |
| the rule | complete evidence before **pooling**; the per-block unanimity rule retired on that instrument | an evidence-**cardinality** precondition on the calibrated standard |
| the 18 | where it appears, the `p^18` exponent in false-refusal arithmetic | the census design's `6 x 3`, from `evidence.rounds x evidence.blocks` |

Retiring per-block unanimity is about **where** each block falls; this precondition is about **how many** blocks exist. They are orthogonal, and there is proof already shipped: on the census rig unanimity was *already* retired for the `ordinary` row — the calibrated standard replaced it as adjudicator in #7701 — and this PR adds cardinality *to that replacement*. The two therefore coexist in the same file today. After the rebase the shared test file runs 372 tests: my 362 and their 10, all green together.

Both sites a later reader will land on now say this in the code: the note above `EXPECTED_READINGS` in the driver, and a `SCOPE` note at the head of the witness section in the shared test file.

## Quality gates

Run in this worktree (`C:/Users/miket/code/re-frame2-worktrees/cardinality-pzqy8`), foreground, to completion, unpiped. **All of the following were re-run after the rebase onto `44581c63dc`.**

| gate | exit |
|---|---|
| `node freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs` — the owning file, **372 passed** | **0** |
| `npm run test:script-helpers` — the suite that owns it (7 exit-path suites + script helpers) | **0** |
| `npm run test:script-policy` — path/surface/policy classifiers | **0** |
| `sh scripts/test-fast-pr.sh` — full spine: JVM `implementation/core` + JVM `implementation/freehand` + `test:cljs` + hicasso bench-lane compile (137 namespaces, 0 warnings) + static/drift checks | **0** |

**Not covered locally**, as the spine itself reports: documentation gates (surface unchanged), the JVM artefact suites the diff does not touch, and the CI-only lanes — browser, prod-elision/bundle-isolation/perf, adapter probes and smokes, Xray feature matrix, mcp-conformance, tool JVM suites. `scripts/check_fast_pr_gap.py` counts 90 required checks no local run decides; the three required contexts (`All required checks passed`, `Lint required`, `Docs required`) are CI's.

**No benchmark and no measurement window was run.** This bead is cardinality and arithmetic over committed data and fixture blocks; the witnesses take no clock.
