### PR TITLE
fix(scripts): the pins gate's left-context stops at a table-row start (rf2-xlsh)

### DIFF
--- a/scripts/check_provenance_pins.py
+++ b/scripts/check_provenance_pins.py
@@ -61,7 +61,11 @@ roster of known digests (which rots) and never by asking git (see above):
     "landed on main as `x`" and "authored at `x` on `worker/…`" say pin.
     Nearest rather than any-match, because a sentence about a commit routinely
     ends by naming a blob and vice versa, and the word beside the token is the
-    one describing it.  A FILE PATH in a code span counts as a digest word: "|
+    one describing it.  That reach STOPS AT THE START OF THE TOKEN'S OWN ROW,
+    which is the other half of rf2-xlsh: a "| Blob hash | … |" row above
+    otherwise repaints the row below it as a digest, no citation is created,
+    and the row scope below never gets to adjudicate what was never extracted.
+    A FILE PATH in a code span counts as a digest word: "|
     `lane.cljs` | `x` |" and "`front/codec.cljs` is `x`" are how a blob is
     written when no noun is spare.  A branch is not a path — `worker/x` and
     `origin/main` carry no extension — so they stay commit words.
@@ -180,8 +184,8 @@ _BARE_PROSE_HEX = re.compile(
 _SPAN_SPLIT = re.compile(r"[=/:,\s]+")
 
 # Left-context vocabulary.  These decide what the WRITER said the token is, and
-# they are read only from the token's own line, so a neighbouring sentence
-# cannot repaint it.
+# they are read no further back than the claim the token stands in — its own
+# paragraph, or its own table row — so a neighbouring ROW cannot repaint it.
 _DIGEST_WORDS = re.compile(
     r"blob|digest|sha-?256|fnv|checksum|hash", re.I
 )
@@ -315,7 +319,7 @@ _RIGHT_APPOSITION = 14
 
 def _left_context(lines: Sequence[str], index: int, span_start: int) -> str:
     """The token's left context: everything before it on its own line, plus up
-    to two whole lines above.
+    to two whole lines above, STOPPING AT THE START OF ITS OWN TABLE ROW.
 
     It has to cross lines: this corpus hard-wraps at about eighty columns, so
     the word describing a token routinely sits on the line above it, and a run
@@ -323,18 +327,38 @@ def _left_context(lines: Sequence[str], index: int, span_start: int) -> str:
     stops at a blank line, because that is a different block and a different
     claim.
 
+    IT STOPS AT A PRIOR ROW FOR THE SAME REASON, and not stopping there was the
+    second half of rf2-xlsh.  Scoping accompaniment by row fixed adjudication
+    but left EXTRACTION reading whatever the rows above happened to say, so a
+    "| Blob hash | … |" row one line up repainted the next row's token as a
+    digest and no citation was created at all — `evaluate` never saw it, and the
+    row scope it could not see had nothing to enforce.  A digest word describes
+    the cell it stands in; the row below makes its own claim.  So the context
+    may reach the line that OPENS the token's row — the corpus wraps a long cell
+    across source lines and the word describing the token is routinely up
+    there — and it may not reach past it.
+
     WHOLE lines, never a character slice.  Cutting the context mid-line can cut
     a code span in half, after which the surviving backtick re-pairs with the
     wrong partner and the file path that would have identified the token as a
     blob stops being visible — which is how the first cut of this function
     reported a column of blob hashes as unresolvable pins.
     """
-    parts = [_strip_quote(lines[index][:span_start])]
+    own = _strip_quote(lines[index][:span_start])
+    if _TABLE_ROW.match(_strip_quote(lines[index])):
+        # The token's own line opens the row, so everything above it is a
+        # previous row's claim.
+        return own
+    parts = [own]
     i = index - 1
     taken = 0
     while taken < _LEFT_LINES and i >= 0 and lines[i].strip():
         parts.append(_strip_quote(lines[i]))
         taken += 1
+        if _TABLE_ROW.match(_strip_quote(lines[i])):
+            # That line opened the row this token wrapped out of; the row ends
+            # here going up.
+            break
         i -= 1
     return " ".join(reversed(parts))
 
@@ -799,6 +823,36 @@ _EXTRACTION_CASES: List[Tuple[str, List[str], List[str]]] = [
         ],
         [],
     ),
+    # THE SIBLING DIGEST (rf2-xlsh, second half).  Scoping accompaniment by row
+    # guards adjudication; this guards EXTRACTION, which ran first and so ran
+    # unguarded.  The digest word in the row above used to reach down and
+    # repaint the row below, and a token classified as a digest is never a
+    # citation, so `evaluate` was handed nothing and the operative pin failed
+    # open with the row scope already in place.  Both rows are asserted: the
+    # digest must stay a digest, and the pin beside it must be seen.
+    (
+        "a digest word in the row above does not repaint the next row",
+        [
+            "| Field | Value |",
+            "|---|---|",
+            "| Blob hash | `bbbbbbbbbb` |",
+            "| Original freeze | `aaaaaaaaaa` |",
+        ],
+        ["aaaaaaaaaa"],
+    ),
+    # The counterweight, and the reason the boundary is the row START and not
+    # the newline: a long cell wraps across source lines, and the word
+    # describing the token is up on the line that opened the row.  `0642815dc2`
+    # has no vocabulary of its own, so it is a digest only if the context still
+    # reaches its own row's first line — cut that and it defaults to a pin.
+    (
+        "a wrapped cell still reads the word that opened its own row",
+        [
+            "| Instrument blob | `0304f489bb`, and the follow-up",
+            "`0642815dc2` for the same lane |",
+        ],
+        [],
+    ),
 ]
 
 # (label, lines, {token: status}, expected finding tokens)
@@ -895,6 +949,20 @@ _RULE_CASES: List[Tuple[str, List[str], Dict[str, str], List[str]]] = [
         ],
         {"aaaaaaaaaa": "STRANDED", "bbbbbbbbbb": "LANDED", "cccccccccc": "STRANDED"},
         ["cccccccccc"],
+    ),
+    # THE SIBLING DIGEST, end to end.  The row scope alone left this at exit 0:
+    # the `Blob hash` row above repainted `aaaaaaaaaa` as a digest during
+    # extraction, so there was no citation for the row scope to adjudicate and
+    # the operative pin failed open.  An empty expectation here would be a pass
+    # for the wrong reason, so the finding is the assertion.
+    (
+        "a digest row above neither repaints nor rescues the row beside it",
+        [
+            "| Blob hash | `bbbbbbbbbb` |",
+            "| Original freeze | `aaaaaaaaaa` |",
+        ],
+        {"aaaaaaaaaa": "STRANDED", "bbbbbbbbbb": "LANDED"},
+        ["aaaaaaaaaa"],
     ),
     # Prose is untouched by the row scope — the shape the census's repairs put
     # the anchor in, which must keep passing.


### PR DESCRIPTION
Closes the second half of rf2-xlsh, reopened by the merged-PR audit on #7734. **Do not close the bead — the audit hook owns it.**

## The mechanism

PR #7734 gave `Citation` a `scope` so a table row accompanies only itself. That guards **adjudication**. The leak was upstream, in **extraction**.

**Before.** `_left_context` walked back two nonblank source lines unconditionally, with no notion of a row:

```python
i = index - 1
taken = 0
while taken < _LEFT_LINES and i >= 0 and lines[i].strip():
    parts.append(_strip_quote(lines[i]))
    taken += 1
    i -= 1
```

A record table is one unbroken run of nonblank lines, so a `| Blob hash | … |` row one line up landed in the next row's left context. Nearest-word-wins then read `hash` and called the row below a digest. A token classified as a digest is never a citation, so `evaluate` was handed nothing at all — and the row scope it could not see had nothing to enforce. Exit 0. A wrong operative commit still failed open.

**After.** The context stops at the start of the token's own row. If the token's line *opens* a row, the row starts there and nothing above it is read. If the token's line is a continuation, the walk may reach the line that opened the row — this corpus wraps a long cell across source lines and the word describing the token is routinely up there — and stops on including it.

A digest word describes the cell it stands in; the row below makes its own claim. Prose is untouched, so the census's repaired "authored at X … it landed on main as Y" sentences keep passing.

## Proof 1 — reproduced on unmodified main

Worktree at `7cf6b78f9d` (= `origin/main`), the audit's exact fixture, both shapes:

```
FIXTURE: audit fixture, neutral header
  citations: 0 -> []
  findings : 0 -> []
FIXTURE: audit fixture, bare rows
  citations: 0 -> []
  findings : 0 -> []
```

Zero citations. The gate never saw the stranded hash.

## Proof 2 — the fix catches it

Same fixtures, same harness, after the change:

```
FIXTURE: audit fixture, neutral header
  citation line=4 scope=4 token=aaaaaaaaaa reason=unclassified — read as a pin (fail toward refusal)
  citations=1 findings=1 -> ['aaaaaaaaaa']
FIXTURE: audit fixture, bare rows
  citation line=2 scope=2 token=aaaaaaaaaa reason=unclassified — read as a pin (fail toward refusal)
  citations=1 findings=1 -> ['aaaaaaaaaa']
```

The stranded token is extracted and reported. `bbbbbbbbbb` in the `Blob hash` row above is still correctly a digest and still not a citation — the row keeps its own classification, it just stops exporting it downward.

## Proof 3 — no regression

Self-tests: **36 passed before, 39 passed after** (3 added, none changed or removed). Both runs exit 0.

Full-corpus audit run, before and after:

| | files | cited pins | landed | stranded | unresolvable | findings |
|---|---|---|---|---|---|---|
| before | 85 | 347 | 240 | 100 | 7 | **20** |
| after | 85 | 354 | 244 | 102 | 8 | **20** |

Set difference on the finding lines (`path:line token [STATUS]`), not a spot check:

```
only-before: [0 lines]
only-after:  [0 lines]
identical:   YES
```

Bit for bit identical. Nothing reported before goes unreported now, and no page gains a finding. The 20 land on the same 10 pages as before:

```
      2 docs/design/hicasso/production-server-arm.md
      1 docs/design/hicasso/studio/coldmount-double-build-priced.md
      1 docs/design/hicasso/studio/controlled-input-two-implementations.md
      3 docs/design/hicasso/studio/cross-checked-against-an-outside-instrument.md
      2 docs/design/hicasso/studio/heap-fan-out-sweep.md
      1 docs/design/hicasso/studio/p0-ratom-spine-narrow-write.md
      1 docs/design/hicasso/studio/raw-escape-design-b-correctness.md
      5 docs/design/hicasso/studio/ssr-spike-witness.md
      2 docs/design/hicasso/studio/the-interpreter-walk-profiled-and-cheapened.md
      2 docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
```

Extraction does surface 7 more citations (347 → 354). **Every one of them is accompanied inside its own row**, which is why the finding set does not move — those rows were already carrying their own landed anchor and were being classified as digests only because of a neighbour. No corpus repair is implied by this change, and none was made. rf2-styo and rf2-iseb keep their pages.

## Proof 4 — the two cases the remedy told me not to break

Both are named self-tests, both pass, and both are discriminating rather than incidental.

**Wrapped continuations.** The pre-existing rule case `a cell wrapped across source lines is still one row` covers the *scope* half. The *extraction* half had no coverage, so this PR adds it — `a wrapped cell still reads the word that opened its own row`:

```
| Instrument blob | `0304f489bb`, and the follow-up
`0642815dc2` for the same lane |
```

`0642815dc2` carries no vocabulary of its own, there is no digest word in its right apposition, and `_table_header_is_digest` declines immediately because the continuation line opens no pipe. It is a digest **only** if the context still reaches the line that opened its row. Cut the boundary at the newline instead of the row start and this token defaults to a pin — the test goes red. That is the counterweight doing real work.

**Digest-header classification.** `blob table header covers a row whose own cell is bare prose` and `a blockquoted blob table is still a blob table` both pass. Worth noting *why* they now pass: before this change they were being carried by the header line leaking into the left context, and they are now decided by `_table_header_is_digest`, the mechanism actually written for them. `a non-digest table header leaves its rows as pins` confirms the header check has not become a blanket. Also passing unchanged: `blob table row keyed by a path is not a pin`, `right apposition survives a blockquote prefix`.

## Fail-toward-refusal, preserved

The gate correctly refused twice on tokens that merely looked like SHAs. Both still fire, and I added the two table-row shapes because those are the shapes this change touches:

```
bootstrap RNG seed in a code span    citations=1 findings=['20260807']
placeholder in a code span           citations=1 findings=['abc1234']
seed inside a table row              citations=1 findings=['20260807']
placeholder inside a table row       citations=1 findings=['abc1234']
```

No ignore or exemption mechanism was added, no current report was weakened, and the unresolvable/stranded/unclassified defaults are untouched.

## No probe residue

```
 scripts/check_provenance_pins.py | 78 +++++++++++++++++++++++++++++++++++++---
 1 file changed, 73 insertions(+), 5 deletions(-)
```

One file: the script plus its self-tests. Every probe ran through a stdin heredoc against the imported module, so no fixture file was ever written to the tree. Working tree is clean at HEAD.

## Quality gates

All foreground, to completion, unpiped, redirected to worktree-local gitignored logs.

| gate | exit |
|---|---|
| `python scripts/check_provenance_pins.py --self-test --verbose` | **0** — `all 39 self-tests passed.` |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** — `no page under docs/design/hicasso changed since origin/main.` |
| `python scripts/check_doc_slugs.py` | **0** |
| `sh scripts/test-fast-pr.sh` | **0** |

The spine covers this script directly — `==> provenance pin self-test` and `==> provenance pins on changed pages` both appear in its log, so a regression here would have reddened the whole spine.
