### PR TITLE
refactor(hicasso): split the runtime into owned modules (rf2-hic-009)

### DIFF
--- a/implementation/hicasso/frozen-sources.edn
+++ b/implementation/hicasso/frozen-sources.edn
@@ -37,6 +37,36 @@
 ;; every other, and `:whole-file?` false is what says the package file is not
 ;; expected to be a rename-only image of it.
 
+;; ## The first retirement: `arm1/runtime.cljs` (rf2-hic-009)
+;;
+;; The header above names the moment this file starts shedding rows, and
+;; rf2-hic-009 is it. That bead carved the copied 2,120-line runtime into six
+;; owned modules so Wave B's file fences are real files:
+;;
+;;   impl/collector.cljs   the render context, the cell table, the commit, the
+;;                         two read tiers, the read-set entries, the generation
+;;                         fence, the two shells and the two mint doors
+;;   impl/generation.cljs  the flush generation, the registry epoch, commit-basis
+;;   impl/frames.cljs      the two frame-locked memo tables and their invalidation
+;;   impl/roots.cljs       the hydration adoption window
+;;   impl/evidence.cljs    the dev-only sink seam
+;;   impl/inventory.cljs   the retention census, declared and measured
+;;
+;; There is no longer a package file that is `arm1/runtime.cljs` moved, so its
+;; row is RETIRED rather than re-pinned — the third of the header's three
+;; responses, and the one it names for exactly this bead. The consequence is
+;; stated rather than hidden: **the bench tree's `arm1/runtime.cljs` is no
+;; longer digest-pinned by anything.** It goes on running under
+;; `:hicasso-bench`, and a fix landing there is now a fix somebody has to port
+;; by reading, not by being told.
+;;
+;; Three rows SURVIVE with `:whole-file? false` newly on them —
+;; `arm1/mount.cljs`, `arm1/boundary.cljs` and `arm1/presence.cljs`. Each
+;; imported `arm1.runtime` and now imports the module that answers for the vars
+;; it used, so each differs from its donor by its `:require` block and by the
+;; prose that named the old namespace. Their donors stay pinned, which is the
+;; half of the row that still earns its keep.
+
 {:donor-root "implementation/freehand/test/re_frame/bench/hicasso"
 
  ;; The namespace rename the copy applied, in full. A reference to a bench
@@ -68,6 +98,9 @@
   re-frame.bench.hicasso.front.route-link re-frame.hicasso.impl.route-link
   re-frame.bench.hicasso.front.slot       re-frame.hicasso.impl.slot
   re-frame.bench.hicasso.front.state      re-frame.hicasso.impl.state
+  ;; RETIRED as a single target by rf2-hic-009 — the package side is now
+  ;; impl.{collector,generation,frames,roots,evidence,inventory}. Kept in the
+  ;; table because the table records what the COPY did, and the copy did this.
   re-frame.bench.hicasso.arm1.runtime     re-frame.hicasso.impl.runtime
   re-frame.bench.hicasso.arm1.boundary    re-frame.hicasso.impl.boundary
   re-frame.bench.hicasso.arm1.mount       re-frame.hicasso.impl.mount
@@ -118,26 +151,29 @@
    :ns      re-frame.hicasso.impl.state
    :lines   309
    :sha256  "d9c7561fc8a6a7bc717f3695b5321f050b7900c5b5d0eae78a9a71b26bca52dd"}
-  {:bench   "arm1/runtime.cljs"
-   :package "src/re_frame/hicasso/impl/runtime.cljs"
-   :ns      re-frame.hicasso.impl.runtime
-   :lines   2120
-   :sha256  "b363e260c8374755d125c832decc52bba8296ee58e4b6196ba4a4fbec09b4484"}
-  {:bench   "arm1/boundary.cljs"
-   :package "src/re_frame/hicasso/impl/boundary.cljs"
-   :ns      re-frame.hicasso.impl.boundary
-   :lines   214
-   :sha256  "09642a5c9893ac8e6acafb1718f9931aae4300c139f2bfb3b8d38b5adcef71a6"}
-  {:bench   "arm1/mount.cljs"
-   :package "src/re_frame/hicasso/impl/mount.cljs"
-   :ns      re-frame.hicasso.impl.mount
-   :lines   345
-   :sha256  "32c8085956a7b840f3b637a4345f833ec170197dfc1a9d8484357552fcb0977c"}
-  {:bench   "arm1/presence.cljs"
-   :package "src/re_frame/hicasso/impl/presence_react.cljs"
-   :ns      re-frame.hicasso.impl.presence-react
-   :lines   169
-   :sha256  "cc957212578406aa61b00f8b0bb513c28d5c02581c93a3bcf1f69492ac2b0ae1"}
+  {:bench       "arm1/boundary.cljs"
+   :package     "src/re_frame/hicasso/impl/boundary.cljs"
+   :ns          re-frame.hicasso.impl.boundary
+   :lines       214
+   ;; rf2-hic-009 re-pointed its `arm1.runtime` import at impl.collector.
+   :whole-file? false
+   :sha256      "09642a5c9893ac8e6acafb1718f9931aae4300c139f2bfb3b8d38b5adcef71a6"}
+  {:bench       "arm1/mount.cljs"
+   :package     "src/re_frame/hicasso/impl/mount.cljs"
+   :ns          re-frame.hicasso.impl.mount
+   :lines       345
+   ;; rf2-hic-009 re-pointed its `arm1.runtime` import at impl.collector and
+   ;; impl.roots.
+   :whole-file? false
+   :sha256      "32c8085956a7b840f3b637a4345f833ec170197dfc1a9d8484357552fcb0977c"}
+  {:bench       "arm1/presence.cljs"
+   :package     "src/re_frame/hicasso/impl/presence_react.cljs"
+   :ns          re-frame.hicasso.impl.presence-react
+   :lines       169
+   ;; rf2-hic-009 re-pointed its `arm1.runtime` import at impl.collector and
+   ;; impl.roots.
+   :whole-file? false
+   :sha256      "cc957212578406aa61b00f8b0bb513c28d5c02581c93a3bcf1f69492ac2b0ae1"}
   {:bench       "arm1/lang.clj"
    :package     "src/re_frame/hicasso.cljc"
    :ns          re-frame.hicasso

--- a/implementation/hicasso/src/re_frame/hicasso.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso.cljc
@@ -45,11 +45,11 @@
   with no keyword changing value."
   #?(:cljs
      (:require [re-frame.hicasso.impl.boundary :as impl-boundary]
+               [re-frame.hicasso.impl.collector :as impl-collector]
                [re-frame.hicasso.impl.intent :as impl-intent]
                [re-frame.hicasso.impl.mount :as impl-mount]
                [re-frame.hicasso.impl.presence-react :as impl-presence-react]
                [re-frame.hicasso.impl.route-link :as impl-route-link]
-               [re-frame.hicasso.impl.runtime :as impl-runtime]
                [re-frame.hicasso.impl.state :as impl-state]))
   #?(:cljs (:require-macros [re-frame.hicasso :refer [defview defhost hfn]])))
 
@@ -82,7 +82,7 @@
            view-name (str (ns-name *ns*) "/" sym)
            body-name (symbol (str sym "-body"))]
        `(def ~(if doc (vary-meta sym assoc :doc doc) sym)
-          (re-frame.hicasso.impl.runtime/mint-view!
+          (re-frame.hicasso.impl.collector/mint-view!
             ~view-name
             (fn ~body-name ~argv ~@body))))))
 
@@ -192,14 +192,14 @@
   from anywhere inside a body, including inside a `when`, a `for` or an
   inlined helper. The edge is recorded where the read happens, so a branch
   not taken contributes no edge.
-  [[re-frame.hicasso.impl.runtime/sub]]."}
-       sub impl-runtime/sub)
+  [[re-frame.hicasso.impl.collector/sub]]."}
+       sub impl-collector/sub)
 
      (def ^{:doc "**Grouped — the control.** One fixed site takes the whole
   query collection and returns the snapshot the body destructures, so a
   boundary's edge set is a function of its declaration rather than of its
-  control flow. [[re-frame.hicasso.impl.runtime/use-subs]]."}
-       use-subs impl-runtime/use-subs)
+  control flow. [[re-frame.hicasso.impl.collector/use-subs]]."}
+       use-subs impl-collector/use-subs)
 
      (def ^{:doc "`h/frame` in the authoring surface — the frame id KEYWORD
   of the boundary currently rendering, for the handful of core doors that

--- a/implementation/hicasso/src/re_frame/hicasso/impl/boundary.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/boundary.cljs
@@ -64,7 +64,7 @@
   boundary reports from one lifecycle rather than three.
 
   The frame reaches the class through `contextType` — the substrate's one
-  internal React context, the same object `runtime/shell` reads with
+  internal React context, the same object `collector/shell` reads with
   `useContext` — so `:on-error`'s intent lands in the frame the boundary
   was mounted under rather than in whatever happened to be ambient when
   the throw arrived.
@@ -95,7 +95,7 @@
   has [[frame-of]] through `contextType`. So there is no new hook and no
   new accessor — only HD-020(a)'s rule applied where the lowering
   actually happens rather than where the hiccup was written, with
-  `runtime/frame-dispatch`'s memoised frame-locked dispatch so a child
+  `collector/frame-dispatch`'s memoised frame-locked dispatch so a child
   here lowers *identically* to one written in the parent's body and
   nothing is allocated per render.
 
@@ -116,8 +116,8 @@
   throws lands in the browser's error channel, not here. That is React's
   boundary, not this arm's, and the arm inherits it exactly."
   (:require [re-frame.adapter.context :as adapter-context]
-            [re-frame.hicasso.impl.runtime :as rt]
             [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.collector :as collector]
             [re-frame.hicasso.impl.intent :as intent]
             ["react" :as react]))
 
@@ -143,7 +143,7 @@
   (let [on-error (:on-error (props-of this))]
     (cond
       (vector? on-error) (when-some [frame-kw (frame-of this)]
-                           (rt/dispatch! frame-kw (conj on-error error)))
+                           (collector/dispatch! frame-kw (conj on-error error)))
       (fn? on-error)     (on-error error)
       :else              nil))
   nil)
@@ -206,7 +206,7 @@
                 ;; binding is unconditional so the branch does not exist, and
                 ;; an intent written under a frameless boundary still lands on
                 ;; the existing loud error naming the intent.
-                (intent/with-frame frame-kw (when frame-kw (rt/frame-dispatch frame-kw))
+                (intent/with-frame frame-kw (when frame-kw (collector/frame-dispatch frame-kw))
                   (fn []
                     (if (some? error)
                       (codec/as-element (if (fn? fallback) (fallback error) fallback))

--- a/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
@@ -1,5 +1,6 @@
-(ns re-frame.hicasso.impl.runtime
-  "HICASSO ARM 1 — LEAN-REACT. The runtime skeleton (rf2-2rtt6.9).
+(ns re-frame.hicasso.impl.collector
+  "HICASSO — THE COLLECTOR. The runtime's heart (rf2-2rtt6.9,
+  rf2-hic-009).
 
   A boundary is a real React function component minted by `defview`
   (`re-frame.hicasso`). React owns identity,
@@ -9,8 +10,38 @@
   *how* a boundary's body reaches subscription values, and *the fence*
   that keeps one render pass on one commit.
 
-  Residence: the bench/test tree, off every production source path
-  (HD-017). Nothing under `implementation/*/src` requires this.
+  ## The five siblings, and why the grouping is what it is (rf2-hic-009)
+
+  rf2-hic-001 copied the measured prototype's `arm1/runtime.cljs` here
+  whole; rf2-hic-009 carved it into owned modules so that Wave B's file
+  fences are real files. What stayed is what could not be separated:
+
+  | module | what it owns |
+  |---|---|
+  | **this one** | the render context, the cell table, the commit, the two read tiers, the read-set entries, the generation fence, the two shells and the two mint doors |
+  | [[re-frame.hicasso.impl.generation]] | the flush generation, the registry epoch and `commit-basis` |
+  | [[re-frame.hicasso.impl.frames]] | the two frame-locked memo tables and their invalidation |
+  | [[re-frame.hicasso.impl.roots]] | the hydration adoption window |
+  | [[re-frame.hicasso.impl.evidence]] | the dev-only sink seam |
+  | [[re-frame.hicasso.impl.inventory]] | what the runtime RETAINS: the declared census and the measured one |
+
+  The grouping above is a dependency fact, not a taste. The render
+  context, the commit and the shells are one strongly-connected
+  component: `flush!` has to know whether a body is running (it must not
+  call React's `onStoreChange` from inside somebody's render), which is a
+  read of [[rstate]]; [[with-commit]] is `flush!`'s window; [[dispatch!]]
+  is `with-commit` applied to a frame's `:dispatch-sync`;
+  [[frame-dispatch]] is `dispatch!` memoised per frame; and [[run-once]]
+  — which owns `rstate` — binds `frame-dispatch` for the body's dynamic
+  extent. Cut that chain anywhere and the two halves require each other.
+  So the chain is one namespace, and what left are the parts with an edge
+  in one direction only.
+
+  Residence: `implementation/hicasso/src`, the package's own source root.
+  No production build requires it — Hicasso is bundle-isolated and
+  EXPERIMENTAL — and nothing here reaches the benchmark tree the copy
+  came from, which `implementation/hicasso/scripts/check_freeze.py`
+  enforces.
 
   ## The shell, and the ≤2-hook budget (HD-020)
 
@@ -43,7 +74,7 @@
     commits registers nothing.
   - `getSnapshot` also lives on the entry and returns the **sum of the
     set's epochs**, where a key nothing holds yet contributes the
-    [[commit-basis]] rather than nothing (see *the render→commit gap*
+    [[re-frame.hicasso.impl.generation/commit-basis]] rather than nothing (see *the render→commit gap*
     below). Every term only ever increases, so the sum is monotone:
     `Object.is` on one number is a correct change test, and React's own
     \"getSnapshot should be cached\" rule is satisfied without a memo.
@@ -247,18 +278,18 @@
   subscription at commit; this arm may not (HD-002), so it needs
   something else there.
 
-  Both windows are judged against one number, [[commit-basis]]:
+  Both windows are judged against one number, [[re-frame.hicasso.impl.generation/commit-basis]]:
 
       commit-basis(frame) = this runtime's flush generation
                           + that frame's own physical-install epoch
                           + this runtime's registry epoch
 
-  [[generation]] counts flushes. `frame-commit-epoch` is the substrate's
+  [[re-frame.hicasso.impl.generation/generation]] counts flushes. `frame-commit-epoch` is the substrate's
   own counter, bumped once per physical frame-state install at both
   write chokepoints, and Spec 006's observation port already uses it for
   exactly this question — *did the frame's durable state move in the
   render→commit gap?* — because it answers without watching anything.
-  [[registry-epoch]] counts `:sub` registrations, which are neither a
+  [[re-frame.hicasso.impl.generation/registry-epoch]] counts `:sub` registrations, which are neither a
   flush nor an install, so a `reg-sub` in the gap would otherwise move no
   term at all (rf2-2rtt6.50). The second term is what the runtime was
   missing, and it is why the basis is not just the generation:
@@ -317,11 +348,11 @@
   For a boundary inside the render→commit gap there is no cell, so there
   is no dead reference — the commit acquires against whatever is live
   *then*, and one extra render is exactly the repair. rf2-2rtt6.50 closes
-  the registry half of that, with the [[registry-epoch]] term of the
+  the registry half of that, with the [[re-frame.hicasso.impl.generation/registry-epoch]] term of the
   basis; because a held key contributes a frozen stamp and only a staged
   key reads the basis live, the term reaches the gap and costs the
   mounted case nothing. The `:node-key` half stays open and is stated in
-  [[commit-basis]] — the basis TIES across a reincarnation, so no
+  [[re-frame.hicasso.impl.generation/commit-basis]] — the basis TIES across a reincarnation, so no
   arithmetic over these terms could report it.
 
   What each transition does to a *held* cell, and what the arm hears when
@@ -344,7 +375,7 @@
   registered. It costs no React hook and no per-boundary object.
 
   The gap half rides the same hook, one line earlier, as a `vswap!` on
-  [[registry-epoch]] — so the arm reads a registry count it keeps itself
+  [[re-frame.hicasso.impl.generation/registry-epoch]] — so the arm reads a registry count it keeps itself
   and `observation/registry-epoch*` stays `^:private`. **What
   rf2-2rtt6.44 rejected is still rejected**: that was a registry term in
   every key's *live* contribution to [[make-snapshot]], which moves every
@@ -366,8 +397,11 @@
   hole, or writes the DOM."
   (:require [re-frame.adapter.context :as adapter-context]
             [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.evidence :as evidence]
+            [re-frame.hicasso.impl.frames :as frames]
+            [re-frame.hicasso.impl.generation :as generation]
             [re-frame.hicasso.impl.intent :as intent]
-            [re-frame.core :as rf]
+            [re-frame.hicasso.impl.roots :as roots]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.live-frame :as live-frame]
@@ -431,111 +465,42 @@
   (some? (.-frame rstate)))
 
 ;; ---------------------------------------------------------------------------
-;; The adoption window (rf2-2rtt6.84)
+;; The ambient dispatch a body binds — the memo table is
+;; `re-frame.hicasso.impl.frames`'s; the closure in it is this file's,
+;; because it is `dispatch!` partially applied
 ;; ---------------------------------------------------------------------------
-
-(def ^:private ^js adoption
-  "Is this page's tree being ADOPTED from server-rendered HTML right now?
-
-  Opened by [[re-frame.hicasso.impl.mount/hydrate-root!]] before it
-  calls `hydrateRoot`, and closed by that root's closer component from a
-  passive effect on the hydration commit — the spine's own pattern
-  (`re-frame.substrate.spine/adoption-window-closer`), whose whole point
-  is that a passive effect runs strictly AFTER the commit and therefore
-  cannot close the window early.
-
-  **Module-level, like every other slot in this arm.** `rstate`, the
-  scratch and the cell table are one-per-page too. A page hydrates once,
-  at boot, so one window is the shape the case has; a second hydrating
-  root opened while the first window is still open would share it, and
-  that limit is stated rather than engineered around. The spine keeps its
-  flag root-local because it hands the flag to its closer as a prop —
-  doing the same here would put a prop or a context read on
-  `arm1.presence`, which is a cost this arm has no case for.
-
-  A boolean and nothing else: it selects **adoption behaviour** in a
-  renderer that still has exactly one render mode (the charter's
-  one-mode law). Nothing branches on it but presence's born-present
-  seeding."
-  #js {"open" false})
-
-(defn adopting?
-  "Is a hydration adoption in flight?
-
-  False on every ordinary client mount, and false again the moment the
-  adopted root's closer commits. A server render entry opens the same
-  window around its own `renderToString`, so the two halves of an SSR
-  route answer this identically — which is what stops the client's first
-  pass from rendering something the server did not."
-  []
-  (.-open adoption))
-
-(defn open-adoption-window!
-  "Declare the renders that follow to be adopting server-rendered DOM."
-  []
-  (set! (.-open adoption) true)
-  nil)
-
-(defn close-adoption-window!
-  "Close the window. The closer component's passive effect calls this,
-  and so does [[reset-runtime!]] — a fixture that throws mid-hydration
-  must not leave the page permanently adopting."
-  []
-  (set! (.-open adoption) false)
-  nil)
-
-;; ---------------------------------------------------------------------------
-;; Frame-locked ops, resolved once per frame and not once per boundary
-;; ---------------------------------------------------------------------------
-
-(defonce ^:private !frame-ops (atom {}))
-(defonce ^:private !frame-dispatch (atom {}))
 
 (declare dispatch!)
-
-(defn frame-ops
-  "The frame-locked op bundle for `frame-kw` — `rf/capture-frame`'s
-  `{:frame :dispatch :dispatch-sync :subscribe}` — memoised per frame.
-
-  HD-020(a) has each boundary read the frame *once* from the substrate's
-  single internal context; it does not ask each boundary to rebuild the
-  bundle. `capture-frame` pins a frame incarnation and is not free, so
-  the shell's cost here is one map lookup per render and no allocation."
-  [frame-kw]
-  (or (get @!frame-ops frame-kw)
-      (let [ops (rf/capture-frame frame-kw)]
-        (swap! !frame-ops assoc frame-kw ops)
-        ops)))
 
 (defn frame-dispatch
   "The ambient dispatch a boundary binds for its render's dynamic extent
   (HD-020(a)), memoised per frame so binding it allocates nothing.
 
   **Public because a boundary shell is not the only thing that lowers
-  hiccup** (rf2-2rtt6.66). `arm1.presence` renders retained children
-  inside its OWN React render, after the parent body's dynamic extent has
-  unwound, so it must re-bind the ambient frame before it hands them to
-  the codec — and the dispatch it binds has to be *this* one. Handing it
-  a private route of its own (a fresh `(fn [e] (dispatch! frame-kw e))`
-  per render) would allocate a closure per presence render and would make
-  \"a presence child lowers exactly as it would in the parent's body\" an
-  approximation rather than an identity. Nothing new is exported: the
-  memo, the `capture-frame` pin and the [[with-commit]] batching are the
-  ones `run-once` already binds, and [[frame-ops]] beside it has been
-  public for the same reason."
-  [frame-kw]
-  (or (get @!frame-dispatch frame-kw)
-      (let [f (fn dispatch-for-frame [event] (dispatch! frame-kw event))]
-        (swap! !frame-dispatch assoc frame-kw f)
-        f)))
+  hiccup** (rf2-2rtt6.66). `impl.presence-react` renders retained
+  children inside its OWN React render, after the parent body's dynamic
+  extent has unwound, so it must re-bind the ambient frame before it
+  hands them to the codec — and the dispatch it binds has to be *this*
+  one. Handing it a private route of its own (a fresh
+  `(fn [e] (dispatch! frame-kw e))` per render) would allocate a closure
+  per presence render and would make \"a presence child lowers exactly as
+  it would in the parent's body\" an approximation rather than an
+  identity. Nothing new is exported: the memo, the `capture-frame` pin
+  and the [[with-commit]] batching are the ones `run-once` already binds,
+  and [[re-frame.hicasso.impl.frames/frame-ops]] beside it has been
+  public for the same reason.
 
-(defn forget-frame-ops!
-  "Drop the memoised bundles. A destroyed and re-created frame is a new
-  incarnation, and a captured bundle is pinned to the old one."
-  ([] (reset! !frame-ops {}) (reset! !frame-dispatch {}) nil)
-  ([frame-kw] (swap! !frame-ops dissoc frame-kw)
-              (swap! !frame-dispatch dissoc frame-kw)
-              nil))
+  **The table it memoises into is
+  [[re-frame.hicasso.impl.frames/!frame-dispatch]]**, because
+  `forget-frame-ops!` has to empty it in the same act it empties the op
+  bundles; the closure is minted here because it is [[dispatch!]]
+  partially applied, and `dispatch!` is [[with-commit]] partially
+  applied."
+  [frame-kw]
+  (or (get @frames/!frame-dispatch frame-kw)
+      (let [f (fn dispatch-for-frame [event] (dispatch! frame-kw event))]
+        (swap! frames/!frame-dispatch assoc frame-kw f)
+        f)))
 
 ;; ---------------------------------------------------------------------------
 ;; THE CELL TABLE — one cell per unique (frame, query), shared by every
@@ -587,12 +552,13 @@
 ;; table actually sees, a `.push` and an `.indexOf` beat a persistent set
 ;; and retain one object rather than a container per membership.
 
-(defonce ^:private !cells (atom {}))
+;; `!cells` is public so `re-frame.hicasso.impl.inventory` can count what
+;; the table retains without this file growing a reader per instrument.
+;; It is the collector's to WRITE, and every writer is in this file.
+(defonce !cells (atom {}))
 (defonce ^:private !dirty (volatile! #{}))
 (defonce ^:private !batching (volatile! false))
-(defonce ^:private !generation (volatile! 0))
 (defonce ^:private !deferred (volatile! #{}))
-(defonce ^:private !registry-epoch (volatile! 0))
 
 (def ^:private cell-watch-key
   "**One constant keyword for every cell's value-change watch** — not a
@@ -615,85 +581,6 @@
   paid for. The counter goes with it: a global that numbered something
   that never needed a number."
   ::cell-watch)
-
-(defn generation
-  "The commit generation. Bumped once per flush that moved something."
-  []
-  @!generation)
-
-(defn registry-epoch
-  "**The arm's own count of `:sub` registrations** — first-time and
-  replacement alike — and the third term of [[commit-basis]].
-
-  It is the arm's rather than the substrate's on purpose.
-  `observation/registry-epoch*` counts exactly this and is `^:private`;
-  the arm already installs a registration hook for [[first-registration!]],
-  so the counter is a `vswap!` on a hook that runs anyway rather than a
-  new public reader on a production namespace. Monotone, like both other
-  terms."
-  []
-  @!registry-epoch)
-
-(defn commit-basis
-  "**The number both invariant-5 windows are judged against** — this
-  runtime's flush [[generation]], plus `frame`'s own physical-install
-  epoch (`re-frame.frame/frame-commit-epoch`, the substrate's
-  observation-port evidence counter, bumped once per frame-state install
-  at both write chokepoints), plus the arm's [[registry-epoch]].
-
-  The generation alone cannot carry it, and the reason is structural
-  rather than a matter of degree: the generation moves only through
-  `mark-dirty!`, whose only caller is the value-change watch
-  [[acquire-cell!]] installs **at commit**, so a key nothing holds yet
-  can move without moving it. The frame's install epoch has no such
-  dependency — it is a counter read, not a watch — which is exactly why
-  Spec 006's observation port uses it to ask whether durable state moved
-  in the render→commit gap. And neither of them is a registry write, so
-  the third term is what carries a `reg-sub` landing in that gap.
-
-  All three terms are monotone within a frame incarnation, so the basis
-  is, and so is any sum of bases and cell epochs. Deliberately
-  install-counting rather than `=`-counting: a value-equal install still
-  advances it, which costs at most one redundant re-render and cannot
-  cost a missed one. Pure read; allocates nothing.
-
-  ## Why the registry term costs the mounted case nothing (rf2-2rtt6.50)
-
-  This is the term rf2-2rtt6.44 costed and declined, and **it is not the
-  thing that was declined.** What that costing priced was a registry term
-  in every key's *live* contribution to [[make-snapshot]] — which would
-  have moved every mounted boundary's number on every `reg-sub` in the
-  application, and bought a re-render that read straight back through a
-  dead cell. This term is in the basis, and the basis is read live by
-  exactly one branch of that sum: **a key no cell holds yet**. A held key
-  contributes its cell's *frozen* stamp, which no registration touches.
-
-  So the reach of the term is precisely the set of keys inside a
-  render→commit gap, which is the set of keys that have the defect. A
-  mounted boundary holds a reference to every key it reads, so it has no
-  staged term at all and an unrelated `reg-sub` moves its snapshot by
-  zero — `a-first-registration-of-an-id-no-cell-holds-disturbs-nothing`
-  asserts exactly that, and it is unchanged by this term, which is the
-  cleanest available proof that the two options are different options.
-
-  Conservative in the safe direction and only there, exactly as the
-  install term already is: a boundary mounting as an *unrelated* module
-  registers its subs re-renders once for nothing. A MISSED move would be
-  the P0, and adding a monotone term to a monotone sum cannot cause one.
-
-  Still silent on one axis, and permanently so: a same-id frame
-  reincarnation RESTARTS `frame-commit-epoch` at 0 (measured: A's epoch
-  and B's are both 1, so the basis TIES across the reincarnation), which
-  is the case the observation port needs its `:node-key` field for. That
-  axis is not this number's to carry, and rf2-2rtt6.44 settled why: the
-  transition leaves the cell holding a reaction that can no longer answer
-  for its key, so a moved number would only buy a re-render that read
-  back through the same dead reference. [[invalidate-cell!]] carries the
-  *held*-cell half of all three axes; this term carries the *staged* half
-  of the registry one, where there is no dead reference to read back
-  through because the commit acquires against the live registration."
-  [frame-kw]
-  (+ @!generation (frame/frame-commit-epoch frame-kw) @!registry-epoch))
 
 (declare flush!)
 
@@ -867,8 +754,8 @@
 
   **It is the held-cell half of the axis, and only that half.** A
   boundary inside the render→commit gap has no cell for the id, so this
-  scan reaches nothing on its behalf; the [[registry-epoch]] term of
-  [[commit-basis]] carries that half instead. rf2-2rtt6.50."
+  scan reaches nothing on its behalf; the [[re-frame.hicasso.impl.generation/registry-epoch]] term of
+  [[re-frame.hicasso.impl.generation/commit-basis]] carries that half instead. rf2-2rtt6.50."
   [{:keys [kind id was]}]
   (when (and (= :sub kind) (nil? was))
     ;; `first`, not `(nth … 0)`: a registrar hook's throw is SWALLOWED by
@@ -887,7 +774,7 @@
   "The arm's whole listening post on the registry, and the two halves of
   the registry axis in one place because they are one event.
 
-  **Bump then scan.** [[registry-epoch]] counts every `:sub` registration,
+  **Bump then scan.** [[re-frame.hicasso.impl.generation/registry-epoch]] counts every `:sub` registration,
   first-time or replacement, because both are the same defect in the
   render→commit gap: the body read one computation and the commit
   acquires against another, and neither the flush generation nor the
@@ -902,7 +789,7 @@
   read against."
   [{:keys [kind] :as registration}]
   (when (= :sub kind)
-    (vswap! !registry-epoch inc)
+    (generation/bump-registry-epoch!)
     (first-registration! registration))
   nil)
 
@@ -948,7 +835,7 @@
                                      ;; different one, and React's
                                      ;; post-subscribe re-check corrects
                                      ;; the boundary. rf2-2rtt6.42.
-                                     "epoch"    (commit-basis frame-kw)
+                                     "epoch"    (generation/commit-basis frame-kw)
                                      ;; The key's reverse edge AND its
                                      ;; reference count, in one array —
                                      ;; see the section header.
@@ -1004,47 +891,12 @@
   nil)
 
 ;; ---------------------------------------------------------------------------
-;; The evidence sink seam (HD-005)
-;; ---------------------------------------------------------------------------
-;;
-;; Two lines — a holder and a setter — so dev tooling can attach to the
-;; dependency edges later with no redesign. It moved here from the retired
-;; `front.sub-index` unchanged in shape: the `:edges-changed` and `:commit`
-;; events keep their keys, so anything written against the seam attaches to
-;; the fused table without being rewritten.
-;;
-;; Detached cost is one deref and one nil test at each of the two tap
-;; points, and **that is a literal count, which it only is because the nil
-;; test is the outermost form at each tap point**: nothing the sink would
-;; have been handed gets built when there is no sink. A third line used to
-;; own that check — a private `evidence!` the tap points called with the
-;; event already constructed — and the indirection is what hid the cost,
-;; charging the detached path one event map per boundary per commit and one
-;; per commit, garbage the moment it was made and so invisible to a
-;; retained-heap ladder (rf2-e3i6y). Factoring the guard back out restores
-;; the claim's falsity, which is why it reads as duplication and stays.
-;;
-;; Fusing the index in moved one more allocation behind the guard
-;; (rf2-dabt3): [[flush!]]'s `(into #{} (map .-subKey) dirty)` used to be
-;; built unconditionally because the index's `commit!` took sub-keys, and
-;; the cells were mapped straight back. The dirty set is now taken off the
-;; cells in hand, so that set is evidence-only and is built only when a
-;; sink is listening.
-;;
-;; **No evidence subsystem ships**: no manifest, no registry, no buffering,
-;; and the sink is nil until something sets it.
-
-(defonce ^:private !evidence-sink (atom nil))
-
-(defn set-evidence-sink!
-  "Attach (or with nil, detach) the evidence sink."
-  [f]
-  (reset! !evidence-sink f)
-  nil)
-
-;; ---------------------------------------------------------------------------
 ;; The commit — the only door through which a write becomes re-render work
 ;; ---------------------------------------------------------------------------
+;;
+;; The two evidence tap points below read `evidence/!evidence-sink` as the
+;; OUTERMOST form of their guard, and never through a reader fn. That is
+;; the seam's whole cost claim; `re-frame.hicasso.impl.evidence` states it.
 
 (defn- notify! [registrations]
   (doseq [^js r registrations]
@@ -1075,16 +927,16 @@
   (let [dirty @!dirty]
     (when (seq dirty)
       (vreset! !dirty #{})
-      (vswap! !generation inc)
+      (generation/bump-generation!)
       ;; Re-STAMP rather than increment, so a cell's epoch is always a
       ;; `commit-basis` reading and never drifts into a private
       ;; numbering the staged term could not be compared against. It
       ;; still strictly increases: the generation was just bumped and
       ;; the frame's install epoch never falls, so the new stamp is
       ;; above the one this cell last carried.
-      (doseq [^js c dirty] (set! (.-epoch c) (commit-basis (.-frameKw c))))
+      (doseq [^js c dirty] (set! (.-epoch c) (generation/commit-basis (.-frameKw c))))
       (let [boundaries (dirty-readers dirty)]
-        (when-some [sink @!evidence-sink]
+        (when-some [sink @evidence/!evidence-sink]
           (sink {:event            :commit
                  :dirty-subs       (into #{} (map (fn [^js c] (.-subKey c))) dirty)
                  :dirty-boundaries boundaries}))
@@ -1117,7 +969,7 @@
   event, for an intent) and the store notification runs before that turn
   ends, so React commits the echo in the same turn."
   [frame-kw event]
-  (with-commit (fn [] ((:dispatch-sync (frame-ops frame-kw)) event)))
+  (with-commit (fn [] ((:dispatch-sync (frames/frame-ops frame-kw)) event)))
   nil)
 
 ;; ---------------------------------------------------------------------------
@@ -1179,7 +1031,7 @@
 
   Within one body run all cold reads observe one snapshot, which is the
   fence's own invariant stated smaller; a commit landing mid-body moves
-  the [[commit-basis]] and [[render-body]] re-runs the body against the
+  the [[re-frame.hicasso.impl.generation/commit-basis]] and [[render-body]] re-runs the body against the
   newer one, fresh box included. The values a probe computes are what
   the sub-cache reaction would have answered against the same committed
   state — `compute-sub` and the reactive path share the input grammar,
@@ -1238,7 +1090,7 @@
   [query-v]
   (when (nil? (.-frame rstate))
     (fail! :rf.error/hicasso-sub-outside-render
-           're-frame.hicasso.impl.runtime/read-key!
+           're-frame.hicasso.impl.collector/read-key!
            (str "A subscription read " (pr-str query-v)
                 " happened outside a boundary render. `sub` and `use-subs` "
                 "are legal only inside a defview body; `subscribe-once` is "
@@ -1289,7 +1141,7 @@
 ;; zero-allocation detection of the unchanged case
 ;; ---------------------------------------------------------------------------
 
-(defonce ^:private !entries
+(defonce !entries
   ;; read-sequence hash -> vector of entries. See [[scratch-bucket-key]]
   ;; for why the key is a hash of the WHOLE sequence and not, as it once
   ;; was, the first sub-key.
@@ -1345,7 +1197,7 @@
                (if (seq left) (assoc m bucket-key left) (dissoc m bucket-key)))))
     nil))
 
-(def ^:private entry-reap-horizon-ms
+(def entry-reap-horizon-ms
   "The provisional-entry reaper's delay: **4 ms, not 0** (rf2-2rtt6.84).
 
   ## What the 0 raced
@@ -1445,7 +1297,7 @@
 
 (defn- make-snapshot
   "React's `getSnapshot`: the sum of the set's epochs, where a key **no
-  cell holds yet** contributes its frame's current [[commit-basis]]
+  cell holds yet** contributes its frame's current [[re-frame.hicasso.impl.generation/commit-basis]]
   instead of nothing. Monotone, so `Object.is` on it is a correct change
   test; cached on the entry, so a render allocates no closure for it.
 
@@ -1453,7 +1305,7 @@
   contributes `basis@render` while the boundary renders and, once the
   commit has created its cell, `basis@commit` — the same number when
   nothing moved in between and a different one when something did. It is
-  a *live* [[commit-basis]] read, which is why the basis's registry term
+  a *live* [[re-frame.hicasso.impl.generation/commit-basis]] read, which is why the basis's registry term
   reaches a `reg-sub` in the gap (rf2-2rtt6.50) and why a held key —
   whose contribution is the cell's frozen stamp — is untouched by one.
   React re-reads this closure immediately after `subscribe` returns
@@ -1481,7 +1333,7 @@
             (recur (inc i)
                    (if-some [^js c (get cells k)]
                      (+ acc (.-epoch c))
-                     (+ acc (commit-basis (nth k 0)))))))))))
+                     (+ acc (generation/commit-basis (nth k 0)))))))))))
 
 (defn- make-subscribe
   "React's `subscribe`, as a pure function of the read set.
@@ -1518,7 +1370,7 @@
           ^js reg #js {"reads" reads "notify" on-store-change}
           cells (mapv (fn [sub-key] (acquire-cell! sub-key reg)) reads)]
       (unchecked-set reg "cells" cells)
-      (when-some [sink @!evidence-sink]
+      (when-some [sink @evidence/!evidence-sink]
         (when (seq reads)
           (sink {:event :edges-changed :boundary reg :added reads :dropped #{}})))
       (set! (.-refs entry) (inc (.-refs entry)))
@@ -1592,7 +1444,7 @@
   "Run a boundary body under the generation fence and return its element;
   [[last-reads]] carries the read-set entry.
 
-  The fence is the loop: capture the [[commit-basis]], run the body, and
+  The fence is the loop: capture the [[re-frame.hicasso.impl.generation/commit-basis]], run the body, and
   if a commit landed while it ran, run it again against the newer
   commit. All of a pass's reads therefore observe one commit —
   invariant-5 preservation as one comparison per boundary, not one deref
@@ -1606,10 +1458,10 @@
   moves for that write, so the basis does. rf2-2rtt6.42."
   [frame-kw body-fn props]
   (loop [attempt 0]
-    (let [before  (commit-basis frame-kw)
+    (let [before  (generation/commit-basis frame-kw)
           element (run-once frame-kw body-fn props)]
       (cond
-        (= before (commit-basis frame-kw))
+        (= before (generation/commit-basis frame-kw))
         (do (set! (.-entry rstate) (entry-for)) element)
 
         (< attempt max-fence-retries)
@@ -1617,13 +1469,13 @@
 
         :else
         (fail! :rf.error/hicasso-generation-fence-exhausted
-               're-frame.hicasso.impl.runtime/render-body
+               're-frame.hicasso.impl.collector/render-body
                (str "A boundary body observed a new commit on each of "
                     (inc max-fence-retries) " consecutive runs. A body that "
                     "writes on every render cannot be fenced; move the write "
                     "out of the render.")
                :move-the-write-out-of-the-render
-               {:frame frame-kw :generation (generation)})))))
+               {:frame frame-kw :generation (generation/generation)})))))
 
 (defn last-reads
   "The read-set entry the most recent [[render-body]] resolved."
@@ -1703,7 +1555,7 @@
 (defn- resolve-frame! [frame-kw]
   (if (or (nil? frame-kw) (= adapter-context/no-provider-sentinel frame-kw))
     (fail! :rf.error/no-frame-context
-           're-frame.hicasso.impl.runtime/shell
+           're-frame.hicasso.impl.collector/shell
            (str "A Hicasso boundary rendered with no frame in scope. Mount the "
                 "tree under a frame boundary — `arm1.mount/root!` installs one.")
            :mount-under-a-frame
@@ -1751,7 +1603,7 @@
 (defn- resolve-frame-prop! [frame-kw]
   (if (nil? frame-kw)
     (fail! :rf.error/no-frame-prop
-           're-frame.hicasso.impl.runtime/frame-prop-shell
+           're-frame.hicasso.impl.collector/frame-prop-shell
            (str "A frame-fed Hicasso boundary rendered with no frame in its "
                 "props. Every boundary element below the root is minted by an "
                 "ancestor body, which carries the frame; the root and any "
@@ -1843,7 +1695,7 @@
   carrying a custom comparator stays a `MemoComponent` rather than
   collapsing to React's `SimpleMemoComponent`, so React keeps a wrapper
   fiber above the component's own. That is React's retention rather than
-  this arm's, and it is recorded in [[retained-inventory]] under
+  this arm's, and it is recorded in [[re-frame.hicasso.impl.inventory/retained-inventory]] under
   `:react/memo-fiber` instead of being left for a heap ladder to
   discover.
 
@@ -1945,165 +1797,19 @@
       (codec/mark-frame-prop! (codec/mark-boundary! component)))))
 
 ;; ---------------------------------------------------------------------------
-;; Retained inventory — honest accounting, not a claimed absence
+;; Teardown — the one door that empties every module
 ;; ---------------------------------------------------------------------------
-
-(defn retained-inventory
-  "Every boundary-exclusive token this arm retains, enumerated rather than
-  asserted (architecture.md, Arm 1). `:shared` names what is emphatically
-  *not* per boundary, because that is the half a heap ladder reads wrong
-  if nobody writes it down.
-
-  **The classification is the ladder's input, so where a token sits is a
-  measurement and not a filing convenience (rf2-2rtt6.46).** The read-set
-  entry sat under `:shared` and does not belong there: an entry is shared
-  only between boundaries whose read SEQUENCES are identical, and the
-  shape the per-read heap ladder is taken on (rf2-2rtt6.34) is the
-  distinct-query one — every row reading its own key, so every row a read
-  sequence of its own and an entry of its own. Filed as `:shared` it
-  under-counted per-boundary retention by one entry per boundary, on
-  exactly the rung being measured, in the direction that flatters this
-  arm. Filed here it over-counts in the coincident-sequence case, which
-  is the direction a candidate's own instrument should err in."
-  []
-  {:per-boundary
-   [{:token :registration
-     :what  "one JS object: the read set (shared with its entry, never copied — and since rf2-dabt3 this IS the forward edge, so no map holds a second copy of it), React's onStoreChange, and the acquired cell vector"}
-    {:token :cell/reader-membership
-     :what  "one slot in each read key's cell-local reader list — the key's reverse edge and this boundary's reference to the key's cell, which are ONE membership since rf2-dabt3. It replaces the retired index's :index/b->subs entry, its :index/sub->bs membership, and the singleton reader SET the second map retained per key at fan-out 1"}
-    {:token :react/use-sync-external-store
-     :what  "React's own hook cell for the one subscription hook"}
-    {:token :react/use-context
-     :what  "React's own hook cell for the frame hook, plus the fiber's context dependency record — held by the CONTEXT-fed shell only. The frame-fed variant ([[mint-frame-prop-view!]]) does NOT hold it: its frame arrives as the element prop `rfFrame`, which costs one slot in every boundary element's props object instead. A ladder reading this table for that variant must subtract this token and add that slot (rf2-2rtt6.39, priced on rf2-2rtt6.72)"}
-    {:token :react/memo-fiber
-     :what  "one EXTRA React fiber — `mint-view!`'s props-equality bail-out is a `React.memo` carrying a comparator, and a memo with a custom comparator stays a MemoComponent rather than collapsing into React's SimpleMemoComponent, so React holds a wrapper fiber above the component's own (rf2-2rtt6.52)"}
-    {:token :read-set-entry
-     :what  "one key array, key SET, subscribe and getSnapshot per distinct read SEQUENCE — shared ONLY with boundaries whose sequence is identical, so on the distinct-query rung the ladder is taken on there is one per boundary"}]
-   :shared
-   [{:token :key-cell
-     :what  "one cell + one sub-cache reaction + one reader ARRAY per unique (frame, query), however many boundaries read it — the array is the one container the fusion retains, in place of a persistent map entry AND a persistent set per key"}
-    {:token :scratch
-     :what  "ONE module-level array for the whole runtime, reset by overwrite; its capacity is the high-water read count"}
-    {:token :frame-ops
-     :what  "one capture-frame bundle and one ambient dispatch per frame"}
-    {:token :codec-cache
-     :what  "the codec's tag and prop caches, per distinct literal in the build"}]
-   :absent
-   [{:token :use-ref   :what "no useRef anywhere in the shell (HD-020(b))"}
-    {:token :use-state :what "no per-instance render-phase state of any kind IN THE SHELL. The one useState on an Arm 1 page belongs to `front.controlled`'s composition shadow and is a controlled TEXT ELEMENT's, one per field — never a boundary's, and priced per field on `shapes/hook_budget_dom_cljs_test` (rf2-digtt)"}
-    {:token :view-cell :what "no per-boundary object graph, reaction, watcher or scheduler"}
-    {:token :candidate-ledger
-     :what  "one scratch buffer, never two; nothing keyed by render, attempt, lane or generation; no per-read object; no commit-phase deref"}]})
-
-(defn cell-reaction
-  "The subscription `sub-key`'s cell currently derives through, or nil —
-  either because nothing holds the key, or because the substrate disposed
-  the reaction and [[invalidate-cell!]] dropped the reference.
-
-  A witness reader, and the one the rf2-2rtt6.44 rows need: the failure
-  they pin is what a HELD container answers after its disposal, so they
-  have to be able to hold it."
-  [sub-key]
-  (some-> ^js (get @!cells sub-key) (.-reaction)))
-
-(defn cell-readers
-  "The registrations currently reading `sub-key` — the cell's own reader
-  list, which is the whole of the fused table's reverse edge.
-
-  A witness reader, answered as a vector so a caller cannot mutate the
-  live list. It replaces the retired index's `readers-of`, and it is what
-  the reader-counting rows assert against."
-  [sub-key]
-  (if-some [^js c (get @!cells sub-key)]
-    (vec (.-readers c))
-    []))
-
-(defn boundary-reads
-  "The sub-key set `reg` reads — the fused table's `edges-of`.
-
-  It is a field read rather than a lookup, and that is the point: the
-  forward edge was always on the registration (`.-reads`, the read-set
-  entry's own key set, shared by reference), which is why retiring the
-  index cost no structure (rf2-dabt3)."
-  [^js reg]
-  (.-reads reg))
-
-(defn stats
-  "What the witnesses read: live cells, live boundaries, cached read-set
-  entries, the generation, and the codec caches.
-
-  `:cell-refs` and `:edges` are **one number**, counted once, because one
-  reader slot is both the reference and the edge — the fusion, stated in
-  the instrument rather than argued in a docstring. `:boundaries` counts
-  the distinct registrations holding at least one such slot; a boundary
-  whose body read nothing retains nothing in this table, so it is
-  correctly absent (its read-set entry is still counted by `:entries`)."
-  []
-  (let [cells       @!cells
-        memberships (reduce-kv (fn [acc _ ^js c] (+ acc (alength (.-readers c)))) 0 cells)
-        boundaries  (reduce-kv (fn [acc _ ^js c] (into acc (.-readers c))) #{} cells)]
-    {:cells      (count cells)
-     :cell-refs  memberships
-     :edges      memberships
-     :boundaries (count boundaries)
-     :entries    (reduce + 0 (map (fn [[_ v]] (count v)) @!entries))
-     :generation (generation)
-     :frames     (count @!frame-ops)
-     :codec      (codec/cache-sizes)}))
-
-(defn entry-buckets
-  "The read-set entry cache's bucket occupancy — `{:buckets n :max-bucket
-  m}`, where `:max-bucket` is the number of entries a lookup compares
-  against in the worst case.
-
-  The scan's cost is `:max-bucket`, and the point of hashing the whole
-  read sequence is that it stays put while the number of live boundaries
-  grows. Computed on demand from the cache, so nothing on the hot path
-  counts anything. rf2-2rtt6.46."
-  []
-  (let [sizes (map (fn [[_ v]] (count v)) @!entries)]
-    {:buckets (count sizes) :max-bucket (reduce max 0 sizes)}))
-
-(defn residue
-  "What must be zero after a clean teardown. `:cell-refs` is the standing
-  zero-leaked-subscription-ref-counts assertion; `:boundaries` and
-  `:edges` are the dependency edges' half of it — now read off the same
-  memberships, which is why a leak cannot show in one and hide in the
-  other."
-  []
-  (select-keys (stats) [:cells :cell-refs :boundaries :edges :entries]))
-
-(defn quiesced!
-  "A promise that resolves once every reaper armed before this call has
-  run — **the runtime's own settling point, and the only honest place to
-  take a [[residue]] BASELINE**.
-
-  One macrotask is not that point. [[entry-reap-horizon-ms]] is
-  deliberately outside a bare `setTimeout 0`, so a residue read one
-  macrotask after an unclaimed render still counts entries the runtime
-  is about to drop. A baseline taken there is a state the runtime never
-  returns to, and an instrument gating on residue EQUALITY against it
-  throws on the first arm whose row outlives the horizon — which is
-  exactly what rf2-981nt was: `read_profile_app`'s phase B baselined six
-  entries at ~0 ms and found five thereafter, every run, byte-identical.
-
-  Exported so a caller settles against the runtime's own horizon rather
-  than against a copy of it, because the copy is what drifted. Nothing
-  here becomes a contract: [[entry-reap-horizon-ms]] stays a margin no
-  caller may rely on, and this promise says only *wait for me*, never
-  *here is my number*."
-  []
-  (js/Promise.
-    (fn [resolve]
-      ;; Strictly past the horizon, so a timer armed here expires after
-      ;; every reaper armed before it — the cell reapers (0 ms) included.
-      (js/setTimeout (fn [] (resolve nil)) (inc entry-reap-horizon-ms)))))
 
 (defn reset-runtime!
   "Drop every cell, every edge, every cached entry and every frame bundle.
   The root-teardown and test-fixture door; disposing each cell releases
   its sub-cache reference, so this is the leak check's reset rather than
-  a way to hide one."
+  a way to hide one.
+
+  It lives here because the collector holds most of what it drops, and it
+  calls each sibling's own door for the rest — a module that owns state
+  owns the act of emptying it, so this fn cannot silently miss a slot
+  somebody adds elsewhere."
   []
   (doseq [[_ cell] @!cells] (dispose-cell! cell))
   (reset! !cells {})
@@ -2111,14 +1817,13 @@
   (vreset! !dirty #{})
   (vreset! !deferred #{})
   (vreset! !batching false)
-  (vreset! !generation 0)
-  (vreset! !registry-epoch 0)
+  (generation/reset-basis!)
   (set! (.-entry rstate) nil)
   (set! (.-frame rstate) nil)
   (set! (.-probe rstate) nil)
   (set! (.-length scratch) 0)
   ;; A fixture that threw mid-hydration must not leave the page adopting.
   ;; `bodyRuns` is deliberately NOT reset here — see [[body-runs]].
-  (close-adoption-window!)
-  (forget-frame-ops!)
+  (roots/close-adoption-window!)
+  (frames/forget-frame-ops!)
   nil)

--- a/implementation/hicasso/src/re_frame/hicasso/impl/evidence.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/evidence.cljs
@@ -1,0 +1,62 @@
+(ns re-frame.hicasso.impl.evidence
+  "THE EVIDENCE SINK SEAM (HD-005) — a holder and a setter, and
+  deliberately nothing else (rf2-hic-009).
+
+  It is its own namespace because it is the one part of the runtime whose
+  correctness is a claim about what the DETACHED path costs. That claim
+  is falsifiable only while the seam stays two lines: the moment
+  something here builds, buffers, registers or projects, the guard at
+  each tap point stops being the outermost form and the cost stops being
+  countable. Giving the seam a file of its own is what makes an addition
+  to it visible as an addition.
+
+  The tap points are the collector's, not this file's, and they read
+  [[!evidence-sink]] directly rather than through a door here — see the
+  cost note below, which is the reason there is no `evidence!` function
+  to call.
+
+  **rf2-hic-023 owns this file**: the versioned, adapter-neutral evidence
+  projection Xray consumes attaches here.
+
+  ## The cost note, moved with the seam
+
+  It moved to the runtime from the retired `front.sub-index` unchanged in
+  shape: the `:edges-changed` and `:commit` events keep their keys, so
+  anything written against the seam attaches to the fused table without
+  being rewritten.
+
+  Detached cost is one deref and one nil test at each of the two tap
+  points, and **that is a literal count, which it only is because the nil
+  test is the outermost form at each tap point**: nothing the sink would
+  have been handed gets built when there is no sink. A third line used to
+  own that check — a private `evidence!` the tap points called with the
+  event already constructed — and the indirection is what hid the cost,
+  charging the detached path one event map per boundary per commit and
+  one per commit, garbage the moment it was made and so invisible to a
+  retained-heap ladder (rf2-e3i6y). Factoring the guard back out restores
+  the claim's falsity, which is why it reads as duplication and stays,
+  and why [[!evidence-sink]] is reachable as the atom rather than behind
+  a reader fn: a reader would reintroduce a call on the path whose whole
+  claim is that it performs a deref and a nil test.
+
+  Fusing the index in moved one more allocation behind the guard
+  (rf2-dabt3): the collector's `flush!` used to build
+  `(into #{} (map .-subKey) dirty)` unconditionally because the index's
+  `commit!` took sub-keys, and the cells were mapped straight back. The
+  dirty set is now taken off the cells in hand, so that set is
+  evidence-only and is built only when a sink is listening.
+
+  **No evidence subsystem ships**: no manifest, no registry, no
+  buffering, and the sink is nil until something sets it.")
+
+;; The attached sink, or nil. Read at each tap point as the outermost form
+;; of the guard — see the ns docstring for why that is the whole design and
+;; not an optimisation. A comment rather than a docstring because
+;; `defonce` takes none.
+(defonce !evidence-sink (atom nil))
+
+(defn set-evidence-sink!
+  "Attach (or with nil, detach) the evidence sink."
+  [f]
+  (reset! !evidence-sink f)
+  nil)

--- a/implementation/hicasso/src/re_frame/hicasso/impl/frames.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/frames.cljs
@@ -1,0 +1,61 @@
+(ns re-frame.hicasso.impl.frames
+  "FRAME-LOCKED OPS — resolved once per frame and not once per boundary
+  (rf2-hic-009).
+
+  Two memo tables, keyed by frame keyword, and the one door that empties
+  them. HD-020(a) has each boundary read the frame *once* from the
+  substrate's single internal context; it does not ask each boundary to
+  rebuild the bundle, and `capture-frame` pins a frame incarnation and is
+  not free.
+
+  ## Why this is an ownership boundary and not a filing convenience
+
+  **Every entry in both tables is pinned to a frame INCARNATION**, and
+  nothing in either table can tell that its incarnation died. That is the
+  whole of rf2-hic-013's problem — a destroyed-and-recreated frame with
+  the same public id must not be reachable through a handle minted
+  against the previous one — and [[forget-frame-ops!]] is the whole of
+  today's answer to it: a blunt, caller-driven invalidation with no
+  notion of *which* incarnation a memoised bundle belongs to. Putting the
+  two tables and their invalidation in one small file is what makes that
+  answer legible, and makes replacing it a change to one file.
+
+  ## What lives here, and the one thing that does not
+
+  [[!frame-dispatch]] is the arm's ambient-dispatch memo, but the closure
+  it caches is minted by `re-frame.hicasso.impl.collector/frame-dispatch`
+  — because that closure is a partial application of the collector's
+  commit door (`dispatch!` → `with-commit`), and a namespace cycle is the
+  alternative. The TABLE is here because [[forget-frame-ops!]] must empty
+  it in the same act it empties the op bundles: they are pinned to the
+  same incarnation, and an invalidation that cleared one of them would
+  leave a live route into a dead frame. So both tables are public, and
+  their only writer outside this file is that one memo-miss branch."
+  (:require [re-frame.core :as rf]))
+
+(defonce !frame-ops (atom {}))
+(defonce !frame-dispatch (atom {}))
+
+(defn frame-ops
+  "The frame-locked op bundle for `frame-kw` — `rf/capture-frame`'s
+  `{:frame :dispatch :dispatch-sync :subscribe}` — memoised per frame.
+
+  HD-020(a) has each boundary read the frame *once* from the substrate's
+  single internal context; it does not ask each boundary to rebuild the
+  bundle. `capture-frame` pins a frame incarnation and is not free, so
+  the shell's cost here is one map lookup per render and no allocation."
+  [frame-kw]
+  (or (get @!frame-ops frame-kw)
+      (let [ops (rf/capture-frame frame-kw)]
+        (swap! !frame-ops assoc frame-kw ops)
+        ops)))
+
+(defn forget-frame-ops!
+  "Drop the memoised bundles. A destroyed and re-created frame is a new
+  incarnation, and a captured bundle is pinned to the old one.
+
+  It clears BOTH tables in one act, which is why they sit in one file."
+  ([] (reset! !frame-ops {}) (reset! !frame-dispatch {}) nil)
+  ([frame-kw] (swap! !frame-ops dissoc frame-kw)
+              (swap! !frame-dispatch dissoc frame-kw)
+              nil))

--- a/implementation/hicasso/src/re_frame/hicasso/impl/generation.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/generation.cljs
@@ -1,0 +1,138 @@
+(ns re-frame.hicasso.impl.generation
+  "THE COMMIT BASIS — the three monotone numbers invariant 5 is judged
+  against, and the only doors that advance them (rf2-hic-009).
+
+  Everything here is a counter and a read of a counter. That is the
+  ownership boundary: the collector *consults* the basis on four hot
+  paths and *advances* it on two, and a number whose increment can be
+  written from anywhere is a number nobody can reason about. Both
+  volatiles are private and both bumps are named, so
+  `git grep bump-generation!` is the complete list of writers.
+
+  The basis is deliberately arithmetic over three independent terms
+  rather than one counter, because each term sees a movement the other
+  two are structurally blind to. [[commit-basis]] says which, and why the
+  fourth axis — a same-id frame reincarnation — is not carryable here at
+  all.
+
+  **The HMR contract lands on this file** (rf2-hic-015). A reload
+  re-registers `:sub` handlers, which is exactly what [[registry-epoch]]
+  counts and exactly what the collector's cell-invalidation repair rides;
+  a reload that must promise identity, focus and state across a save has
+  to say what it does to these three numbers."
+  (:require [re-frame.frame :as frame]))
+
+(defonce ^:private !generation (volatile! 0))
+(defonce ^:private !registry-epoch (volatile! 0))
+
+(defn generation
+  "The commit generation. Bumped once per flush that moved something."
+  []
+  @!generation)
+
+(defn bump-generation!
+  "Advance the flush generation. The collector's `flush!` is the only
+  caller, and it calls it exactly once per flush that found a dirty cell
+  — which is what makes [[generation]] a count of *commits that moved
+  something* rather than of flush attempts."
+  []
+  (vswap! !generation inc)
+  nil)
+
+(defn registry-epoch
+  "**The arm's own count of `:sub` registrations** — first-time and
+  replacement alike — and the third term of [[commit-basis]].
+
+  It is the arm's rather than the substrate's on purpose.
+  `observation/registry-epoch*` counts exactly this and is `^:private`;
+  the arm already installs a registration hook for
+  [[re-frame.hicasso.impl.collector/first-registration!]], so the counter
+  is a `vswap!` on a hook that runs anyway rather than a new public
+  reader on a production namespace. Monotone, like both other terms."
+  []
+  @!registry-epoch)
+
+(defn bump-registry-epoch!
+  "Advance the registry epoch. Called from the collector's single
+  registration hook, BEFORE that hook scans the cells — a render racing
+  the scan must not see an epoch from before the registration it is about
+  to read against. See
+  [[re-frame.hicasso.impl.collector/sub-registered!]], which is where the
+  ordering is stated and enforced."
+  []
+  (vswap! !registry-epoch inc)
+  nil)
+
+(defn commit-basis
+  "**The number both invariant-5 windows are judged against** — this
+  runtime's flush [[generation]], plus `frame`'s own physical-install
+  epoch (`re-frame.frame/frame-commit-epoch`, the substrate's
+  observation-port evidence counter, bumped once per frame-state install
+  at both write chokepoints), plus the arm's [[registry-epoch]].
+
+  The generation alone cannot carry it, and the reason is structural
+  rather than a matter of degree: the generation moves only through
+  `mark-dirty!`, whose only caller is the value-change watch
+  [[re-frame.hicasso.impl.collector/acquire-cell!]] installs **at
+  commit**, so a key nothing holds yet can move without moving it. The
+  frame's install epoch has no such dependency — it is a counter read,
+  not a watch — which is exactly why Spec 006's observation port uses it
+  to ask whether durable state moved in the render→commit gap. And
+  neither of them is a registry write, so the third term is what carries
+  a `reg-sub` landing in that gap.
+
+  All three terms are monotone within a frame incarnation, so the basis
+  is, and so is any sum of bases and cell epochs. Deliberately
+  install-counting rather than `=`-counting: a value-equal install still
+  advances it, which costs at most one redundant re-render and cannot
+  cost a missed one. Pure read; allocates nothing.
+
+  ## Why the registry term costs the mounted case nothing (rf2-2rtt6.50)
+
+  This is the term rf2-2rtt6.44 costed and declined, and **it is not the
+  thing that was declined.** What that costing priced was a registry term
+  in every key's *live* contribution to
+  [[re-frame.hicasso.impl.collector/make-snapshot]] — which would have
+  moved every mounted boundary's number on every `reg-sub` in the
+  application, and bought a re-render that read straight back through a
+  dead cell. This term is in the basis, and the basis is read live by
+  exactly one branch of that sum: **a key no cell holds yet**. A held key
+  contributes its cell's *frozen* stamp, which no registration touches.
+
+  So the reach of the term is precisely the set of keys inside a
+  render→commit gap, which is the set of keys that have the defect. A
+  mounted boundary holds a reference to every key it reads, so it has no
+  staged term at all and an unrelated `reg-sub` moves its snapshot by
+  zero — `a-first-registration-of-an-id-no-cell-holds-disturbs-nothing`
+  asserts exactly that, and it is unchanged by this term, which is the
+  cleanest available proof that the two options are different options.
+
+  Conservative in the safe direction and only there, exactly as the
+  install term already is: a boundary mounting as an *unrelated* module
+  registers its subs re-renders once for nothing. A MISSED move would be
+  the P0, and adding a monotone term to a monotone sum cannot cause one.
+
+  Still silent on one axis, and permanently so: a same-id frame
+  reincarnation RESTARTS `frame-commit-epoch` at 0 (measured: A's epoch
+  and B's are both 1, so the basis TIES across the reincarnation), which
+  is the case the observation port needs its `:node-key` field for. That
+  axis is not this number's to carry, and rf2-2rtt6.44 settled why: the
+  transition leaves the cell holding a reaction that can no longer answer
+  for its key, so a moved number would only buy a re-render that read
+  back through the same dead reference.
+  [[re-frame.hicasso.impl.collector/invalidate-cell!]] carries the
+  *held*-cell half of all three axes; this term carries the *staged* half
+  of the registry one, where there is no dead reference to read back
+  through because the commit acquires against the live registration."
+  [frame-kw]
+  (+ @!generation (frame/frame-commit-epoch frame-kw) @!registry-epoch))
+
+(defn reset-basis!
+  "Zero both terms this namespace owns. The teardown half, called by
+  [[re-frame.hicasso.impl.collector/reset-runtime!]] and by nothing else
+  — the frame's install epoch is the substrate's and is not this door's
+  to touch."
+  []
+  (vreset! !generation 0)
+  (vreset! !registry-epoch 0)
+  nil)

--- a/implementation/hicasso/src/re_frame/hicasso/impl/inventory.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/inventory.cljs
@@ -1,0 +1,178 @@
+(ns re-frame.hicasso.impl.inventory
+  "WHAT THE RUNTIME RETAINS — the declared census and the measured one,
+  in one file so they can be read against each other (rf2-hic-009).
+
+  [[retained-inventory]] is the DECLARATION: every boundary-exclusive
+  token this arm holds, enumerated rather than asserted, plus the tokens
+  that are emphatically shared and the ones that are absent. [[stats]],
+  [[entry-buckets]] and [[residue]] are the MEASUREMENT, read off the
+  live tables. A heap ladder is only as honest as the agreement between
+  those two, and the agreement is only checkable while they sit side by
+  side — which is the whole reason this is a namespace rather than a tail
+  on the collector.
+
+  Nothing here writes. Every fn is a pure read of state another module
+  owns, which is why the collector exposes `!cells`, `!entries` and its
+  reap horizon, and `re-frame.hicasso.impl.frames` its op table: an
+  instrument that had to be granted a reader fn per number would grow the
+  owning file every time somebody wanted to count something new.
+
+  [[quiesced!]] is here rather than beside the reapers it waits on
+  because its only purpose is to make a [[residue]] BASELINE honest, and
+  a settling point separated from the thing it settles for is a settling
+  point that drifts — which is exactly what rf2-981nt was."
+  (:require [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.frames :as frames]
+            [re-frame.hicasso.impl.generation :as generation]))
+
+(defn retained-inventory
+  "Every boundary-exclusive token this arm retains, enumerated rather than
+  asserted (architecture.md, Arm 1). `:shared` names what is emphatically
+  *not* per boundary, because that is the half a heap ladder reads wrong
+  if nobody writes it down.
+
+  **The classification is the ladder's input, so where a token sits is a
+  measurement and not a filing convenience (rf2-2rtt6.46).** The read-set
+  entry sat under `:shared` and does not belong there: an entry is shared
+  only between boundaries whose read SEQUENCES are identical, and the
+  shape the per-read heap ladder is taken on (rf2-2rtt6.34) is the
+  distinct-query one — every row reading its own key, so every row a read
+  sequence of its own and an entry of its own. Filed as `:shared` it
+  under-counted per-boundary retention by one entry per boundary, on
+  exactly the rung being measured, in the direction that flatters this
+  arm. Filed here it over-counts in the coincident-sequence case, which
+  is the direction a candidate's own instrument should err in."
+  []
+  {:per-boundary
+   [{:token :registration
+     :what  "one JS object: the read set (shared with its entry, never copied — and since rf2-dabt3 this IS the forward edge, so no map holds a second copy of it), React's onStoreChange, and the acquired cell vector"}
+    {:token :cell/reader-membership
+     :what  "one slot in each read key's cell-local reader list — the key's reverse edge and this boundary's reference to the key's cell, which are ONE membership since rf2-dabt3. It replaces the retired index's :index/b->subs entry, its :index/sub->bs membership, and the singleton reader SET the second map retained per key at fan-out 1"}
+    {:token :react/use-sync-external-store
+     :what  "React's own hook cell for the one subscription hook"}
+    {:token :react/use-context
+     :what  "React's own hook cell for the frame hook, plus the fiber's context dependency record — held by the CONTEXT-fed shell only. The frame-fed variant ([[re-frame.hicasso.impl.collector/mint-frame-prop-view!]]) does NOT hold it: its frame arrives as the element prop `rfFrame`, which costs one slot in every boundary element's props object instead. A ladder reading this table for that variant must subtract this token and add that slot (rf2-2rtt6.39, priced on rf2-2rtt6.72)"}
+    {:token :react/memo-fiber
+     :what  "one EXTRA React fiber — `mint-view!`'s props-equality bail-out is a `React.memo` carrying a comparator, and a memo with a custom comparator stays a MemoComponent rather than collapsing into React's SimpleMemoComponent, so React holds a wrapper fiber above the component's own (rf2-2rtt6.52)"}
+    {:token :read-set-entry
+     :what  "one key array, key SET, subscribe and getSnapshot per distinct read SEQUENCE — shared ONLY with boundaries whose sequence is identical, so on the distinct-query rung the ladder is taken on there is one per boundary"}]
+   :shared
+   [{:token :key-cell
+     :what  "one cell + one sub-cache reaction + one reader ARRAY per unique (frame, query), however many boundaries read it — the array is the one container the fusion retains, in place of a persistent map entry AND a persistent set per key"}
+    {:token :scratch
+     :what  "ONE module-level array for the whole runtime, reset by overwrite; its capacity is the high-water read count"}
+    {:token :frame-ops
+     :what  "one capture-frame bundle and one ambient dispatch per frame"}
+    {:token :codec-cache
+     :what  "the codec's tag and prop caches, per distinct literal in the build"}]
+   :absent
+   [{:token :use-ref   :what "no useRef anywhere in the shell (HD-020(b))"}
+    {:token :use-state :what "no per-instance render-phase state of any kind IN THE SHELL. The one useState on an Arm 1 page belongs to `front.controlled`'s composition shadow and is a controlled TEXT ELEMENT's, one per field — never a boundary's, and priced per field on `shapes/hook_budget_dom_cljs_test` (rf2-digtt)"}
+    {:token :view-cell :what "no per-boundary object graph, reaction, watcher or scheduler"}
+    {:token :candidate-ledger
+     :what  "one scratch buffer, never two; nothing keyed by render, attempt, lane or generation; no per-read object; no commit-phase deref"}]})
+
+(defn cell-reaction
+  "The subscription `sub-key`'s cell currently derives through, or nil —
+  either because nothing holds the key, or because the substrate disposed
+  the reaction and [[re-frame.hicasso.impl.collector/invalidate-cell!]] dropped the reference.
+
+  A witness reader, and the one the rf2-2rtt6.44 rows need: the failure
+  they pin is what a HELD container answers after its disposal, so they
+  have to be able to hold it."
+  [sub-key]
+  (some-> ^js (get @collector/!cells sub-key) (.-reaction)))
+
+(defn cell-readers
+  "The registrations currently reading `sub-key` — the cell's own reader
+  list, which is the whole of the fused table's reverse edge.
+
+  A witness reader, answered as a vector so a caller cannot mutate the
+  live list. It replaces the retired index's `readers-of`, and it is what
+  the reader-counting rows assert against."
+  [sub-key]
+  (if-some [^js c (get @collector/!cells sub-key)]
+    (vec (.-readers c))
+    []))
+
+(defn boundary-reads
+  "The sub-key set `reg` reads — the fused table's `edges-of`.
+
+  It is a field read rather than a lookup, and that is the point: the
+  forward edge was always on the registration (`.-reads`, the read-set
+  entry's own key set, shared by reference), which is why retiring the
+  index cost no structure (rf2-dabt3)."
+  [^js reg]
+  (.-reads reg))
+
+(defn stats
+  "What the witnesses read: live cells, live boundaries, cached read-set
+  entries, the generation, and the codec caches.
+
+  `:cell-refs` and `:edges` are **one number**, counted once, because one
+  reader slot is both the reference and the edge — the fusion, stated in
+  the instrument rather than argued in a docstring. `:boundaries` counts
+  the distinct registrations holding at least one such slot; a boundary
+  whose body read nothing retains nothing in this table, so it is
+  correctly absent (its read-set entry is still counted by `:entries`)."
+  []
+  (let [cells       @collector/!cells
+        memberships (reduce-kv (fn [acc _ ^js c] (+ acc (alength (.-readers c)))) 0 cells)
+        boundaries  (reduce-kv (fn [acc _ ^js c] (into acc (.-readers c))) #{} cells)]
+    {:cells      (count cells)
+     :cell-refs  memberships
+     :edges      memberships
+     :boundaries (count boundaries)
+     :entries    (reduce + 0 (map (fn [[_ v]] (count v)) @collector/!entries))
+     :generation (generation/generation)
+     :frames     (count @frames/!frame-ops)
+     :codec      (codec/cache-sizes)}))
+
+(defn entry-buckets
+  "The read-set entry cache's bucket occupancy — `{:buckets n :max-bucket
+  m}`, where `:max-bucket` is the number of entries a lookup compares
+  against in the worst case.
+
+  The scan's cost is `:max-bucket`, and the point of hashing the whole
+  read sequence is that it stays put while the number of live boundaries
+  grows. Computed on demand from the cache, so nothing on the hot path
+  counts anything. rf2-2rtt6.46."
+  []
+  (let [sizes (map (fn [[_ v]] (count v)) @collector/!entries)]
+    {:buckets (count sizes) :max-bucket (reduce max 0 sizes)}))
+
+(defn residue
+  "What must be zero after a clean teardown. `:cell-refs` is the standing
+  zero-leaked-subscription-ref-counts assertion; `:boundaries` and
+  `:edges` are the dependency edges' half of it — now read off the same
+  memberships, which is why a leak cannot show in one and hide in the
+  other."
+  []
+  (select-keys (stats) [:cells :cell-refs :boundaries :edges :entries]))
+
+(defn quiesced!
+  "A promise that resolves once every reaper armed before this call has
+  run — **the runtime's own settling point, and the only honest place to
+  take a [[residue]] BASELINE**.
+
+  One macrotask is not that point. [[re-frame.hicasso.impl.collector/entry-reap-horizon-ms]] is
+  deliberately outside a bare `setTimeout 0`, so a residue read one
+  macrotask after an unclaimed render still counts entries the runtime
+  is about to drop. A baseline taken there is a state the runtime never
+  returns to, and an instrument gating on residue EQUALITY against it
+  throws on the first arm whose row outlives the horizon — which is
+  exactly what rf2-981nt was: `read_profile_app`'s phase B baselined six
+  entries at ~0 ms and found five thereafter, every run, byte-identical.
+
+  Exported so a caller settles against the runtime's own horizon rather
+  than against a copy of it, because the copy is what drifted. Nothing
+  here becomes a contract: [[re-frame.hicasso.impl.collector/entry-reap-horizon-ms]] stays a margin no
+  caller may rely on, and this promise says only *wait for me*, never
+  *here is my number*."
+  []
+  (js/Promise.
+    (fn [resolve]
+      ;; Strictly past the horizon, so a timer armed here expires after
+      ;; every reaper armed before it — the cell reapers (0 ms) included.
+      (js/setTimeout (fn [] (resolve nil)) (inc collector/entry-reap-horizon-ms)))))

--- a/implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs
@@ -31,8 +31,9 @@
   door returns before the tree is adopted, and a witness for it waits for
   the closer instead of for a flush."
   (:require [re-frame.adapter.context :as adapter-context]
-            [re-frame.hicasso.impl.runtime :as rt]
             [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.roots :as roots]
             [re-frame.interop :as interop]
             [re-frame.trace :as trace]
             ["react" :as react]
@@ -75,7 +76,7 @@
   An ordinary root gets no wrapper at all, which keeps the tree the whole
   bench lane measures exactly what it was — no extra fiber, no extra
   passive effect, and nothing new in
-  `re-frame.hicasso.impl.runtime/retained-inventory`."
+  `re-frame.hicasso.impl.inventory/retained-inventory`."
   [handle hiccup]
   (let [app (provider (:frame handle)
                       (codec/root-element (:frame handle) hiccup))]
@@ -121,11 +122,11 @@
   adds nothing for `hydrateRoot` to match and cannot itself mismatch.
 
   Public because that is what makes adoption OBSERVABLE without a probe:
-  `(rt/adopting?)` answering false is this effect having run, which is
+  `(roots/adopting?)` answering false is this effect having run, which is
   the completion signal a witness waits on in place of the `flushSync`
   [[hydrate-root!]] refuses to perform."
   [_props]
-  (react/useEffect (fn close-window [] (rt/close-adoption-window!) js/undefined)
+  (react/useEffect (fn close-window [] (roots/close-adoption-window!) js/undefined)
                    #js [])
   nil)
 
@@ -134,7 +135,7 @@
 ;; happens not to enforce. Both emit the same `(x["displayName"] = ...)`,
 ;; and it is the STRING key that keeps the property off Closure's renamer
 ;; under `:advanced` — the reason the arm's other stamps
-;; (`runtime/mint-view!`, `codec/memoize-boundary!`) are spelled this way.
+;; (`collector/mint-view!`, `codec/memoize-boundary!`) are spelled this way.
 (unchecked-set adoption-window-closer "displayName" "hicasso/adoption-window-closer")
 
 ;; ---------------------------------------------------------------------------
@@ -196,7 +197,7 @@
   "The `onRecoverableError` a hydrating root installs. **The callback
   itself, not a builder** — the spine builds one per root because its
   adoption window is root-local; this arm's window is module-level
-  (`runtime/adopting?`, and the reason is stated there), so there is
+  (`roots/adopting?`, and the reason is stated there), so there is
   nothing to close over.
 
   Emits the framework diagnostic ONLY while the adoption window is open,
@@ -211,7 +212,7 @@
   across the window boundary rather than a copy of it — the spine's own
   reason for publishing `native-hydration-reporter`."
   [error _error-info]
-  (when (rt/adopting?)
+  (when (roots/adopting?)
     (emit-hydration-mismatch! error))
   (report-recoverable-default! error))
 
@@ -281,7 +282,7 @@
   the adopted tree down and rebuilds it. [[tree]] is the one place that
   decision is made and `:hydrated?` is what it reads."
   [container frame-kw hiccup]
-  (rt/open-adoption-window!)
+  (roots/open-adoption-window!)
   (let [handle  {:frame frame-kw :container container :hydrated? true}
         element (tree handle hiccup)
         opts    (hydrate-root-options)]
@@ -319,15 +320,15 @@
   **Not the door a residue assertion takes** — see [[unmount!]]."
   [handle]
   (unmount! handle)
-  (rt/reset-runtime!)
+  (collector/reset-runtime!)
   nil)
 
 (defn dispatch!
   "Dispatch through the arm's synchronous door and commit the echo. The
   witness door; an intent written in a view reaches
-  `runtime/dispatch!` on its own."
+  `collector/dispatch!` on its own."
   [handle event]
-  (rt/dispatch! (:frame handle) event)
+  (collector/dispatch! (:frame handle) event)
   (settle!)
   nil)
 

--- a/implementation/hicasso/src/re_frame/hicasso/impl/presence_react.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/presence_react.cljs
@@ -9,7 +9,7 @@
   **Three React hooks — `useContext`, `useState` and `useEffect` — in
   THIS component.** The ≤2-hook budget HD-020(b) polices is the *boundary
   shell's*, and this is not a boundary shell: it reads no subscription,
-  mounts no registration and takes no cell. `runtime/shell` is untouched
+  mounts no registration and takes no cell. `collector/shell` is untouched
   and the dispatcher-level ledger still counts exactly two there.
 
   The two lifecycle hooks are legitimate under HD-003's placement rule
@@ -39,9 +39,9 @@
   the control an exiting toast wants.
 
   The frame is therefore resolved once, from the substrate's single
-  internal context — the same object `runtime/shell` reads and
+  internal context — the same object `collector/shell` reads and
   `arm1.boundary` takes through `contextType` — and re-bound around the
-  one `as-element` call below, with `runtime/frame-dispatch`'s memoised
+  one `as-element` call below, with `collector/frame-dispatch`'s memoised
   frame-locked dispatch. That is HD-020(a)'s rule applied where the
   lowering actually happens rather than where the hiccup was written.
 
@@ -71,14 +71,15 @@
 
   A hydrating tree's children are already on the screen, so they start
   `:present` rather than `:mounting` — the machine's own `settle`,
-  applied one render earlier, gated on `runtime/adopting?`. It costs no
+  applied one render earlier, gated on `roots/adopting?`. It costs no
   hook, changes no transform, and is scoped to the adoption window; see
   the comment at the binding below."
   (:require [re-frame.adapter.context :as adapter-context]
-            [re-frame.hicasso.impl.runtime :as rt]
             [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.collector :as collector]
             [re-frame.hicasso.impl.intent :as intent]
             [re-frame.hicasso.impl.presence :as presence]
+            [re-frame.hicasso.impl.roots :as roots]
             ["react" :as react]))
 
 (defn- now [] (js/Date.now))
@@ -118,7 +119,7 @@
         ;; HTML and the client's first pass agree by construction; that
         ;; agreement is the whole reason the flag is read here in the
         ;; RENDER rather than in the effect below.
-        next       (if (rt/adopting?) (presence/settle stepped) stepped)]
+        next       (if (roots/adopting?) (presence/settle stepped) stepped)]
     ;; Adjusting state while rendering — React's own answer to "a value
     ;; derived from props that must persist". `step` is idempotent, so the
     ;; equality test converges rather than looping.
@@ -146,7 +147,7 @@
     ;; the tray — the binding is unconditional so the branch does not
     ;; exist, and an intent written under a frameless tray still lands on
     ;; the existing loud error naming the intent.
-    (intent/with-frame frame-kw (when frame-kw (rt/frame-dispatch frame-kw))
+    (intent/with-frame frame-kw (when frame-kw (collector/frame-dispatch frame-kw))
       (fn [] (codec/as-element (into [:<>] (presence/render next)))))))
 
 (def presence
@@ -155,7 +156,7 @@
   `::h/unmounting` attribute overrides while it is in that phase.
 
       [presence {:timeout-ms 300}
-       (for [t (rt/sub [:toasts/visible])]
+       (for [t (collector/sub [:toasts/visible])]
          [:div.toast {:key (:id t)
                       ::h/unmounting {:class \"toast toast--exit\"
                                       :inert true :aria-hidden true}}

--- a/implementation/hicasso/src/re_frame/hicasso/impl/roots.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/roots.cljs
@@ -1,0 +1,74 @@
+(ns re-frame.hicasso.impl.roots
+  "THE HYDRATION ADOPTION WINDOW (rf2-2rtt6.84) — one boolean, and the
+  three doors that move it (rf2-hic-009).
+
+  The window is what tells a render *whether the DOM it is about to
+  produce is already on the screen*. `re-frame.hicasso.impl.mount` opens
+  it around `hydrateRoot` and the root's closer component shuts it on the
+  hydration commit; `re-frame.hicasso.impl.presence-react` is the one
+  reader, and it reads it during a RENDER.
+
+  It is its own namespace because the flag is **module-level and the
+  runtime is multi-root**, and those two facts are in tension. Today that
+  tension is stated rather than engineered around (see [[adoption]]);
+  rf2-hic-012 is the bead that has to resolve it, by making adoption
+  root-scoped. A boundary drawn here means that bead edits one small file
+  whose entire contents are the thing it is changing, rather than
+  thirty lines inside two thousand — and means the reviewer of that
+  change can see the whole of the before at once.
+
+  The root LIFECYCLE proper — `root!`, `hydrate-root!`, `render!`,
+  `unmount!`, `release!` — lives in `re-frame.hicasso.impl.mount`, which
+  the copy brought over as its own file and which rf2-hic-009 therefore
+  did not carve. The two files together are rf2-hic-012's surface.")
+
+(def ^:private ^js adoption
+  "Is this page's tree being ADOPTED from server-rendered HTML right now?
+
+  Opened by [[re-frame.hicasso.impl.mount/hydrate-root!]] before it
+  calls `hydrateRoot`, and closed by that root's closer component from a
+  passive effect on the hydration commit — the spine's own pattern
+  (`re-frame.substrate.spine/adoption-window-closer`), whose whole point
+  is that a passive effect runs strictly AFTER the commit and therefore
+  cannot close the window early.
+
+  **Module-level, like every other slot in this arm.** The collector's
+  `rstate`, its scratch and its cell table are one-per-page too. A page
+  hydrates once, at boot, so one window is the shape the case has; a
+  second hydrating root opened while the first window is still open would
+  share it, and that limit is stated rather than engineered around. The
+  spine keeps its flag root-local because it hands the flag to its closer
+  as a prop — doing the same here would put a prop or a context read on
+  `impl.presence-react`, which is a cost this arm has no case for.
+
+  A boolean and nothing else: it selects **adoption behaviour** in a
+  renderer that still has exactly one render mode (the charter's
+  one-mode law). Nothing branches on it but presence's born-present
+  seeding."
+  #js {"open" false})
+
+(defn adopting?
+  "Is a hydration adoption in flight?
+
+  False on every ordinary client mount, and false again the moment the
+  adopted root's closer commits. A server render entry opens the same
+  window around its own `renderToString`, so the two halves of an SSR
+  route answer this identically — which is what stops the client's first
+  pass from rendering something the server did not."
+  []
+  (.-open adoption))
+
+(defn open-adoption-window!
+  "Declare the renders that follow to be adopting server-rendered DOM."
+  []
+  (set! (.-open adoption) true)
+  nil)
+
+(defn close-adoption-window!
+  "Close the window. The closer component's passive effect calls this,
+  and so does [[re-frame.hicasso.impl.collector/reset-runtime!]] — a
+  fixture that throws mid-hydration must not leave the page permanently
+  adopting."
+  []
+  (set! (.-open adoption) false)
+  nil)

--- a/implementation/hicasso/test/re_frame/hicasso/smoke_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/smoke_cljs_test.cljs
@@ -27,7 +27,7 @@
   the same machinery are the bench tree's `*_dom_cljs_test` suites.
 
   The three harness namespaces reached below the door (`impl.mount`'s
-  provider, `impl.codec`'s root element, `impl.runtime`'s reset) are the
+  provider, `impl.codec`'s root element, `impl.collector`'s reset) are the
   server-render harness, not authoring surface. Mounting is
   [[re-frame.hicasso/root!]]'s job and needs a DOM; wiring a consumer app
   and an SSR entry to the package is rf2-hic-008's."
@@ -37,8 +37,9 @@
             [re-frame.core :as rf]
             [re-frame.hicasso :as h]
             [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.inventory :as inventory]
             [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.runtime :as runtime]
             [re-frame.test-support :as test-support]
             ["react-dom/server" :as react-dom-server]))
 
@@ -59,7 +60,7 @@
   (test-support/make-reset-runtime-fixture
     {:adapter       uix-adapter/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (runtime/reset-runtime!))}))
+     :init-fn       (fn [] (collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The consumer's whole source file
@@ -116,3 +117,22 @@
     (let [markup (html [greeting-line {:tag "greet"}])]
       (is (re-find #"HELLO" markup))
       (is (nil? (re-find #">hello<" markup))))))
+
+(deftest the-module-graph-loads-and-a-server-render-acquires-nothing
+  ;; rf2-hic-009 split the copied runtime into six owned modules, and
+  ;; `impl.inventory` is the one nothing else requires — its readers reach
+  ;; ACROSS the split, into the collector's tables, the frame memo and the
+  ;; generation counters. Requiring it here is what puts it on the build at
+  ;; all; asserting through it is what says those reaches resolve.
+  ;;
+  ;; The property asserted is the simplest true statement about the render
+  ;; phase: `renderToString` runs bodies and never commits — React calls
+  ;; `getServerSnapshot`, never `subscribe` — so the runtime acquires no
+  ;; cell, takes no reference and records no edge. The real
+  ;; commit-owns/abandonment witnesses are rf2-hic-010's; this one only has
+  ;; to fail when the module graph is wrong.
+  (testing "a render that never commits leaves the retention tables empty"
+    (seeded! "hello")
+    (html [greeting-line {:tag "greet"}])
+    (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0}
+           (dissoc (inventory/residue) :entries)))))


### PR DESCRIPTION
Closes rf2-hic-009.

The copy `rf2-hic-001` landed brought `arm1/runtime.cljs` over whole: 2,120
lines holding the collector, the commit, the cell table, the two read tiers,
the read-set entries, the generation fence, the two shells, the frame-op
memos, the adoption window, the evidence seam and the retention census. One
file cannot host six parallel Wave-B kernel lanes. This carves it into six.

**Moves only.** No public name changed, no behaviour changed, and the roster
diff below is the proof rather than the claim.

## The module boundaries, and why each is an ownership boundary

The bead's fence map is the requirement; what follows is why each line is a
boundary of *ownership* and not one of file size.

| module | vars | what it owns | Wave-B owner |
|---|---|---|---|
| `impl/collector.cljs` | 57 | the render context, the cell table, the commit, the two read tiers, the read-set entries, the generation fence, the two shells, the two mint doors | 010 then 011 then 014 then 018, **one at a time** |
| `impl/generation.cljs` | 8 | the flush generation, the registry epoch, `commit-basis`, and the three doors that move them | 015 |
| `impl/frames.cljs` | 4 | the two frame-locked memo tables and their one invalidation | 013 |
| `impl/roots.cljs` | 4 | the hydration adoption window | 012 (with `impl/mount.cljs`) |
| `impl/evidence.cljs` | 2 | the dev-only sink seam | 023 |
| `impl/inventory.cljs` | 8 | what the runtime RETAINS: the declared census and the measured one | none |

- **`generation.cljs`** owns two volatiles and nothing else. Both are private
  and both bumps are named, so `git grep bump-generation!` is the complete
  list of writers - which is the property a counter needs and a counter
  living beside 2,000 lines of its readers cannot have. It is 015's because
  an HMR save re-registers `:sub` handlers, and the registry epoch is what
  counts them.
- **`frames.cljs`** exists because *every entry in both memo tables is pinned
  to a frame incarnation and nothing in either table can tell that its
  incarnation died*. That is 013's whole problem, and `forget-frame-ops!` is
  the whole of today's answer to it. Replacing that answer is now a change to
  one 61-line file.
- **`roots.cljs`** holds one boolean. That is the point: the flag is
  module-level and the runtime is multi-root, and 012's entire job is to
  resolve that tension. A bead whose file *is* the thing it changes can be
  reviewed against the whole of the before.
- **`evidence.cljs`** is two lines of code and a long note, because the
  seam's correctness is a claim about what the DETACHED path costs, and that
  claim stays falsifiable only while the seam stays two lines. Giving it a
  file makes an addition to it visible as an addition. Its atom is read
  directly at both tap points - a reader fn would reintroduce the call the
  cost claim denies (rf2-e3i6y).
- **`inventory.cljs`** puts the declared census next to the measured one. A
  heap ladder is only as honest as the agreement between those two, and the
  agreement is only checkable while they sit side by side.

## What did NOT split, and the dependency proof

`rstate`, `run-once`, `flush!`, `with-commit`, `dispatch!` and
`frame-dispatch` are one namespace because they *must* be:

- `flush!` must know whether a body is running (an `onStoreChange` fired from
  inside somebody's render is a render-phase update on another component), so
  `flush!` is in `rstate`'s module or above it;
- `with-commit` is `flush!`'s window, `dispatch!` is `with-commit` applied to
  a frame's `:dispatch-sync`, `frame-dispatch` is `dispatch!` memoised - so
  each is in the previous one's module or above it;
- `run-once` binds `frame-dispatch` for the body's dynamic extent, and
  `run-once` owns `rstate`.

Chaining those forces `frame-dispatch`, `dispatch!`, `with-commit`, `flush!`
and `rstate` into one module. So `dispatch!` and `frame-dispatch` stay in the
collector and `frames.cljs` owns the memo TABLES, with `frame-dispatch`
writing into `frames/!frame-dispatch` on a miss - because
`forget-frame-ops!` must empty both tables in one act. The bead's own text
supports this: hic-013's Depends line already reads "shares the
collector/frame-routing file", so it is already sequenced behind hic-010 for
any collector touch, and `frames.cljs` is its primary fence.

Likewise, `roots.cljs` takes only the adoption window: the bead's Surface
line scopes this work to "mechanical file split of the copied
runtime.cljs", and the root LIFECYCLE (`root!`, `hydrate-root!`, `render!`,
`unmount!`, `release!`) already lives in its own `impl/mount.cljs`, which the
copy brought over separately. hic-012's fence is those two files together -
which its own Surface line anticipates ("root-lifecycle/hydration files").

## Before/after namespace map

`re-frame.hicasso.impl.runtime` is gone. Every var it held now lives at:

| was | now |
|---|---|
| `runtime/{sub,use-subs,read-key!,cold-read!}` | `collector/...` |
| `runtime/{flush!,with-commit,dispatch!,frame-dispatch}` | `collector/...` |
| `runtime/{acquire-cell!,release-cell!,wire-cell!,invalidate-cell!,...}` | `collector/...` |
| `runtime/{entry-for,make-subscribe,make-snapshot,commit-boundary!,...}` | `collector/...` |
| `runtime/{run-once,render-body,last-reads,body-runs,...}` | `collector/...` |
| `runtime/{shell,frame-prop-shell,mint-view!,mint-frame-prop-view!}` | `collector/...` |
| `runtime/reset-runtime!` | `collector/reset-runtime!` |
| `runtime/{generation,registry-epoch,commit-basis}` | `generation/...` |
| `runtime/{frame-ops,forget-frame-ops!}` | `frames/...` |
| `runtime/{adopting?,open-adoption-window!,close-adoption-window!}` | `roots/...` |
| `runtime/set-evidence-sink!` | `evidence/set-evidence-sink!` |
| `runtime/{retained-inventory,stats,residue,entry-buckets,quiesced!,cell-reaction,cell-readers,boundary-reads}` | `inventory/...` |

Consumers re-pointed: `impl/boundary.cljs`, `impl/mount.cljs`,
`impl/presence_react.cljs`, the public door `re_frame/hicasso.cljc`, and the
package smoke test.

## The roster diff - moves only, and how it was established

The bead's FENCE CORRECTION note asks for this so a dropped form cannot hide
behind a green partial suite. It is not an eyeball count.

**Method, so a reviewer can re-run it.** Every top-level definition form was
extracted by regex from two sources and the name sets compared:

- the OLD side: `git show HEAD~1:.../impl/runtime.cljs` — the file as it stood
  before this commit, read from git rather than from the working tree so the
  comparison cannot be contaminated by an edit in flight;
- the NEW side: the six module files on disk, concatenated.

The regex anchors on column 0 (`^\((def[a-z-]*)\s+(\^\S+\s+)*(\S+)`), so it
catches `def`, `defn`, `defn-` and `defonce` alike, skips any leading
`^:private` / `^js` metadata, and cannot match a nested form or a form inside
a docstring. Three set operations were then printed — old minus new, new minus
old, and a duplicate check across modules:

```
ORIGINAL runtime.cljs vars: 80
  collector.cljs: 57   generation.cljs: 8   frames.cljs: 4
  roots.cljs:      4   evidence.cljs:   2   inventory.cljs: 8
  TOTAL: 83

MISSING (in old, in no module): []
ADDED   (in a module, not in old): ['bump-generation!', 'bump-registry-epoch!', 'reset-basis!']
DUPLICATED across modules: []
```

**Nothing was dropped and nothing was duplicated.** The three additions are
the line a careless reader will mistake for a semantic change, so each is
named here with the exact expression it wraps. All three exist for one
reason: `generation.cljs` keeps both volatiles `^:private`, so a namespace
that owns a counter owns its mutation instead of exporting a volatile for
other files to `vswap!`.

| new var | the expression it names | where that expression used to sit |
|---|---|---|
| `bump-generation!` | `(vswap! !generation inc)` | inline in `flush!` |
| `bump-registry-epoch!` | `(vswap! !registry-epoch inc)` | inline in `sub-registered!` |
| `reset-basis!` | `(vreset! !generation 0)` and `(vreset! !registry-epoch 0)` | the two adjacent lines inline in `reset-runtime!` |

Each call site now reads as one call where it read as one form before, in the
same position and the same order. In particular `sub-registered!`'s
bump-BEFORE-scan ordering — which its docstring calls out as deliberate,
because a render racing the scan must not see a pre-registration epoch — is
preserved literally, and `sub-registered!` is still one function. Only the
counter's storage moved.

## Explicit confirmations

- **No public name changed.** `h/fn` (`hfn`), `h/frame` (`hframe`),
  `defview`, `defhost`, `root!`, `release!`, `sub`, `use-subs`, `boundary`,
  `presence`, `reg-state`, `route-link` are byte-identical in
  `re_frame/hicasso.cljc`; only the alias they resolve through changed
  (`impl-runtime` to `impl-collector`). rf2-84w6's open ruling is untouched.
- **No behaviour changed.** Every moved form is verbatim. Six private vars
  became public so a sibling module can READ state it does not own
  (`collector/{!cells,!entries,entry-reap-horizon-ms}`,
  `frames/{!frame-ops,!frame-dispatch}`, `evidence/!evidence-sink`); each is
  documented at its definition with the module that reads it.
- **The one payload consequence of the move, stated rather than buried:** the
  four `fail!` `:where` symbols now name `re-frame.hicasso.impl.collector`
  instead of `...impl.runtime`, because `:where` is defined as the emit site
  and the emit site moved. Keeping the old spelling would name a namespace
  that no longer exists. See the follow-up below.
- **Docstrings** moved with their forms. Cross-module wikilinks were
  re-pointed to their new fully-qualified targets. Prose provenance
  references into the frozen bench tree (`front.codec/...`,
  `arm1/...-cljs-test`) were left verbatim, per `frozen-sources.edn`'s stated
  policy. One correction was made where the surrounding docstring had to be
  rewritten anyway: `frame-dispatch` said `arm1.presence`, which is a renamed
  file, not provenance. A package-wide prose sweep is a separate,
  non-mechanical job and was not attempted.
- **One ns-docstring sentence was corrected rather than carried:** the copy
  brought over "Residence: the bench/test tree, off every production source
  path (HD-017). Nothing under `implementation/*/src` requires this", which
  is false of a file that now lives at `implementation/hicasso/src`.

## The freeze manifest anticipated this bead

Worth being plain about, because the change to `frozen-sources.edn` could be
misread as working around a gate. It is the opposite: **the manifest was
written expecting this bead, and names the response by bead id.**

Its header lists three things a red row can mean, and the third is:

> the fix landed in the PACKAGE and the bench tree is now the stale copy —
> that is expected and permanent from the moment rf2-hic-009 starts carving
> the runtime into owned modules, and the honest response is to retire the
> row rather than to re-pin it

`check_freeze.py`'s own SUNSET note says the same thing again: *"rf2-hic-009
carves the runtime into owned modules, and from the first such split the
package is deliberately ahead of the bench tree — at that point the divergent
rows are retired rather than re-pinned."* Deleting `impl/runtime.cljs` trips
the gate's package-file-exists check, so the manifest had to move with the
split, and retiring is the move both documents prescribe. So:

- `arm1/runtime.cljs`'s row is **retired**, with a new header section
  recording the six-way carve and stating the cost plainly rather than
  hiding it: the bench tree's `arm1/runtime.cljs` is no longer digest-pinned
  by anything, so a fix landing there is now one somebody has to port by
  reading.
- `arm1/{mount,boundary,presence}.cljs` keep their rows and gain
  `:whole-file? false` — their donors stay pinned, but their package files
  now differ by a re-pointed `:require` block.
- The `:renames` table keeps its `arm1.runtime` line, annotated: the table
  records what the COPY did, and the copy did that.

Nothing under `implementation/freehand/test/re_frame/bench/hicasso/**` was
touched, and the bench lane still compiles clean (137 namespaces, 0 warnings
— see the gate table).

## Follow-up, not in this PR

**`spec/009-Instrumentation.md` is now stale in four places, and it is
hot-zone.** Lines 2515, 2556, 2557 and 2558 record `:where` and "Emitted by"
as `re-frame.hicasso.impl.runtime/{shell, read-key!, render-body,
frame-prop-shell}`; all four now read `re-frame.hicasso.impl.collector/...`.
Not edited here — `spec/009` is fenced hot-zone this wave, and the mayor is
sequencing it.

This does **not** red the keyword-catalogue drift gate: CHECK A and CHECK C
key on the `:rf.error/*` ids, which are unchanged and still emitted from the
package. It is documentation drift only, and the fix is four token
replacements.

**A second, smaller finding.** The changed-surface classifier
(`.github/scripts/report-changed-surfaces.sh`) does not recognise
`implementation/hicasso/**`: a diff confined to the package classifies as
"conservative fallback (unknown surface)" and runs the COMPLETE spine. That
errs safe, so it is not urgent, but the package has no named tier of its own
— and relatedly, the shadow-cljs build `:node-test-hicasso` (the package's
own CLJS suite) is still reachable only by hand, wired to no npm script and
no spine step. `test:hicasso-freeze` and `test:hicasso-compile` ARE wired.
That wiring is rf2-hic-016's, not this bead's.

No semantic change was found to be necessary, so none was made and none was
deferred.

## Quality gates

Every gate below was run to completion and its exit code read directly — no
gate piped through `tail`/`head`/`grep`, so no pipeline could report a red run
as green.

**Note on where these were run.** This PR was merged while its spine run was
still in flight, and the worktree was reaped underneath it — so the first
spine attempt died of having its checkout deleted, not of anything in the
diff. The spine was therefore re-run **against `origin/main` with this change
already merged in** (`2676149f52`), in a fresh worktree, which is the stronger
check: it verifies the merged result rather than the pre-merge branch.

| gate | command | exit |
|---|---|---|
| **Complete fast-PR spine** (`--all`, every tier) | `sh scripts/test-fast-pr.sh --all` | **0** — `PASS fast PR spine` |
| Hicasso freeze gate (FROZEN + SEALED) + self-test | `npm run test:hicasso-freeze` (also run standalone) | **0** — 11 rows match the bench tree; no package file imports it |
| Hicasso bench-lane compile (the frozen donor tree) | `npm run test:hicasso-compile` | **0** — 137 lane namespaces, 444 files, **0 warnings** |
| Hicasso package compile | `node scripts/compile-node-test.cjs node-test-hicasso out/node-test-hicasso.js` | **0** — 167 files, 166 compiled, **0 warnings** |
| Hicasso package suite (smoke + new module-graph test) | `node out/node-test-hicasso.js` | **0** — 2 tests, 5 assertions, 0 failures/errors |
| CLJS node integration | inside the spine (`test:cljs`) | **0** — 2,233 tests, 11,645 assertions, 0 failures/errors |
| Per-namespace isolation | inside the spine | **0** — 17 namespaces pass standalone (196 tests, 731 assertions) |
| JVM tier (`implementation/core`) | inside the spine | **0** |
| JS harness helpers / script policy / script helpers | inside the spine | **0** |
| Var/namespace roster diff (moves-only proof) | method documented above | **0 missing, 0 duplicated, 3 named additions** |

The first package-compile attempt raised one `:undeclared-var` warning
(`collector/!generation` — a `vswap!` I had missed re-pointing). It was fixed
before commit and every run since is 0 warnings. Recorded because a
warning-clean rerun is only evidence if the first run is disclosed.

**Checks this local run cannot decide** — the spine names 90 required CI
checks it does not run, and the relevant ones here are: the browser/DOM
lanes, bundle-isolation, prod-elision, perf-bundle, the adapter and UI
smokes, the Xray feature matrix, mcp-conformance, the tool JVM suites, and
`clj-kondo` (CI pins 2026.04.15; a differently-versioned local binary proves
nothing). CI owns those.
