### PR TITLE
test(hicasso): controlled input across Firefox and WebKit (rf2-hic-016)

### DIFF
--- a/implementation/hicasso/testbed/hicasso_testbed/core.cljs
+++ b/implementation/hicasso/testbed/hicasso_testbed/core.cljs
@@ -86,6 +86,10 @@
     :revision typed
     :form-b   typed
     :digits   (if (re-matches #"[0-9]*" typed) typed old)
+    ;; Refusing, like `digits`, and deliberately: the unmount row needs the
+    ;; field to be showing a draft the MODEL NEVER TOOK, or "no stranded
+    ;; draft after a remount" is satisfied by the model having accepted it.
+    :mountable (if (re-matches #"[0-9]*" typed) typed old)
     :empty    old
     :grouped  (group-digits typed)
     :upper    (str/upper-case typed)
@@ -103,7 +107,7 @@
    :revision "keep"
    :form-a   "FORM"
    :form-b   "form"
-   :mountable ""})
+   :mountable "9"})
 
 ;; ---------------------------------------------------------------------------
 ;; Events and subscriptions — an ordinary re-frame2 app, nothing else

--- a/implementation/hicasso/testbed/hicasso_testbed/core.cljs
+++ b/implementation/hicasso/testbed/hicasso_testbed/core.cljs
@@ -1,0 +1,255 @@
+(ns hicasso-testbed.core
+  "THE CONTROLLED-INPUT TESTBED — the surface invariant I15 is driven
+  against in three engines (rf2-hic-016).
+
+  Every field below is an ORDINARY Hicasso field: a `:value` off a
+  subscription and an intent vector at `:on-input`, written exactly as
+  authoring.md tells a consumer to write one. There is no probe, no ref,
+  no escape hatch and no test-only prop on any of them — which is the
+  point. A testbed that reached past the authoring surface to make its
+  assertions pass would be measuring the reach rather than the runtime.
+
+  ## What is here, and why each field exists
+
+  I15 says an interpreted controlled field converges within the turn that
+  edited it, echoes only committed state, and preserves caret, selection
+  and in-flight composition across that echo; that a rejected or
+  normalised value echoes as the COMMITTED one; and that reset is an
+  explicit revision preserving element identity. Those are properties of
+  the relationship between a field and its model, so the fields differ
+  only in the MODEL POLICY behind them — one field per policy, so a red
+  row names its policy:
+
+  | field | policy | what it can prove that the others cannot |
+  |---|---|---|
+  | `plain` | takes what is typed | the accepted keystroke SURVIVES — the converge's own trap (`converge-to!`'s docstring), where writing the handler's stale closure value back would wipe the character just typed |
+  | `digits` | refuses any value containing a non-digit; the model does not move | rejection echoes the COMMITTED value in-turn, rather than the field silently keeping what was typed |
+  | `empty` | refuses everything; the model is `\"\"` forever | owned `:value` wins by PRESENCE, not truthiness — `\"\"` is falsy, and a truthiness test here would leave the field uncontrolled and the typed character on screen |
+  | `grouped` | digits only, comma-grouped in threes | caret preservation where the normalisation CHANGES THE LENGTH, which is the only case that distinguishes offset-from-the-end from an absolute position |
+  | `upper` | upper-cases | caret preservation at a length the normalisation preserves, so a caret failure cannot hide behind a length change |
+  | `notes` (`<textarea>`) | collapses whitespace runs | the same law on the other convergeable tag |
+  | `revision` | takes what is typed | `::h/revision` re-baselines the field to the model, on the SAME DOM node |
+  | `flag` (checkbox) | toggles | the owned `::h/checked` pair, whose `false` is likewise a presence rather than a truth |
+
+  `form-a` / `form-b` sit in a real `<form>` with a real reset button,
+  because `form.reset()` returns a control to its `defaultValue` — and
+  `defaultValue` is precisely the per-instance record
+  `re-frame.hicasso.impl.controlled/last-rendered` reads. A form reset is
+  therefore the one ordinary browser action that touches the converge's
+  own bookkeeping, and rf2-hic-016 records its conduct (the full
+  conformance matrix is hic-040's).
+
+  `mountable` is rendered behind a flag so the driver can unmount a field
+  mid-composition: the carve-out's shadow is one `useState` on a fiber and
+  cannot outlive it, and \"cannot strand\" is worth witnessing rather than
+  reasoning about.
+
+  ## The harness door
+
+  One `window.__RF2_HIC_TB__`, and it reads the model only. The DOM is the
+  driver's to read through Playwright; what the driver cannot see from
+  outside is what the STORE holds, and \"echoes only committed state\" is
+  a claim about both halves. Nothing here mutates anything the app could
+  not reach through an ordinary dispatch."
+  (:require [clojure.string :as str]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]))
+
+(def ^:private frame-id ::testbed)
+
+;; ---------------------------------------------------------------------------
+;; The model policies — one function, the whole of the difference between
+;; the fields
+;; ---------------------------------------------------------------------------
+
+(defn- group-digits
+  "`\"12345\"` -> `\"12,345\"`. Length-changing by construction, which is
+  what makes the caret row on this field a real one."
+  [s]
+  (let [digits (str/replace s #"[^0-9]" "")]
+    (if (<= (count digits) 3)
+      digits
+      (->> (reverse digits)
+           (partition-all 3)
+           (map (comp str/join reverse))
+           reverse
+           (str/join ",")))))
+
+(defn- apply-policy
+  "`old` is the COMMITTED value and `typed` is what the field now shows.
+  A policy that returns `old` is a refusal; one that returns something
+  else is a normalisation; one that returns `typed` accepts."
+  [field old typed]
+  (case field
+    :plain    typed
+    :revision typed
+    :form-b   typed
+    :digits   (if (re-matches #"[0-9]*" typed) typed old)
+    :empty    old
+    :grouped  (group-digits typed)
+    :upper    (str/upper-case typed)
+    :form-a   (str/upper-case typed)
+    :notes    (str/replace typed #"\s{2,}" " ")
+    typed))
+
+(def ^:private seed
+  {:plain    "abc"
+   :digits   "123"
+   :empty    ""
+   :grouped  "1,234"
+   :upper    "ABC"
+   :notes    "one two"
+   :revision "keep"
+   :form-a   "FORM"
+   :form-b   "form"
+   :mountable ""})
+
+;; ---------------------------------------------------------------------------
+;; Events and subscriptions — an ordinary re-frame2 app, nothing else
+;; ---------------------------------------------------------------------------
+
+(rf/reg-sub :tb/field (fn [db [_ field]] (get-in db [:fields field] "")))
+(rf/reg-sub :tb/flag (fn [db _] (:flag db)))
+(rf/reg-sub :tb/revision (fn [db _] (:revision db)))
+(rf/reg-sub :tb/mounted? (fn [db _] (:mounted? db)))
+
+(rf/reg-event :tb/seed
+  (fn [_ _] {:db {:fields seed :flag false :revision 0 :mounted? true}}))
+
+(rf/reg-event :tb/edit
+  (fn [{:keys [db]} [_ field typed]]
+    {:db (assoc-in db [:fields field]
+                   (apply-policy field (get-in db [:fields field] "") typed))}))
+
+(rf/reg-event :tb/toggle-flag
+  (fn [{:keys [db]} [_ checked]] {:db (assoc db :flag (boolean checked))}))
+
+;; The reset trigger, and the ONLY thing that fires it: an explicit caller
+;; revision change, never a value comparison. HD-019's reset law.
+(rf/reg-event :tb/bump-revision
+  (fn [{:keys [db]} _] {:db (update db :revision inc)}))
+
+;; An OUT-OF-BAND correction — a write that no keystroke caused, which is
+;; the path `converge!` is deliberately not on (rf2-n3dxw). The driver uses
+;; it to record what a range selection does across such a write.
+(rf/reg-event :tb/correct
+  (fn [{:keys [db]} [_ field value]] {:db (assoc-in db [:fields field] value)}))
+
+(rf/reg-event :tb/toggle-mounted
+  (fn [{:keys [db]} _] {:db (update db :mounted? not)}))
+
+(rf/reg-event :tb/noop (fn [{:keys [db]} _] {:db db}))
+
+;; ---------------------------------------------------------------------------
+;; The views — every field written the way authoring.md writes one
+;; ---------------------------------------------------------------------------
+
+(h/defview text-field
+  "One controlled `<input>`. `:value` off the subscription, an intent
+  vector at `:on-input`, and nothing else."
+  [{:keys [field]}]
+  (let [id (name field)]
+    [:input {:data-testid id
+             :id          id
+             :type        "text"
+             :value       (h/sub [:tb/field field])
+             :on-input    [:tb/edit field ::h/value]}]))
+
+(h/defview notes-field
+  "The same law on the other convergeable tag."
+  [_]
+  [:textarea {:data-testid "notes"
+              :id          "notes"
+              :value       (h/sub [:tb/field :notes])
+              :on-input    [:tb/edit :notes ::h/value]}])
+
+(h/defview revision-field
+  "The reset trigger, carried as the author carries it: one `::h/revision`
+  on the element's own attribute map. It is never an attribute, and the
+  field is otherwise an ordinary controlled field."
+  [_]
+  [:input {:data-testid   "revision"
+           :id            "revision"
+           :type          "text"
+           ::h/revision   (h/sub [:tb/revision])
+           :value         (h/sub [:tb/field :revision])
+           :on-input      [:tb/edit :revision ::h/value]}])
+
+(h/defview flag-box
+  "The owned `::h/checked` pair. `false` is a presence here, not a
+  falsehood."
+  [_]
+  [:input {:data-testid "flag"
+           :id          "flag"
+           :type        "checkbox"
+           :checked     (h/sub [:tb/flag])
+           :on-change   [:tb/toggle-flag ::h/checked]}])
+
+(h/defview reset-form
+  "A real form with a real reset button, so `form.reset()` is the
+  browser's own and not a simulation of it."
+  [_]
+  [:form {:data-testid "form" :id "form" :on-submit [:tb/noop]}
+   [:input {:data-testid "form-a"
+            :id          "form-a"
+            :type        "text"
+            :value       (h/sub [:tb/field :form-a])
+            :on-input    [:tb/edit :form-a ::h/value]}]
+   [:input {:data-testid "form-b"
+            :id          "form-b"
+            :type        "text"
+            :value       (h/sub [:tb/field :form-b])
+            :on-input    [:tb/edit :form-b ::h/value]}]
+   [:button {:data-testid "form-reset" :type "reset"} "reset"]])
+
+(h/defview mountable-field
+  "Rendered behind a flag, so the driver can take the fiber away from
+  under a live composition."
+  [_]
+  (if (h/sub [:tb/mounted?])
+    [:input {:data-testid "mountable"
+             :id          "mountable"
+             :type        "text"
+             :value       (h/sub [:tb/field :mountable])
+             :on-input    [:tb/edit :mountable ::h/value]}]
+    [:p {:data-testid "mountable-gone"} "unmounted"]))
+
+(h/defview app
+  [_]
+  [:main {:data-testid "hicasso-controlled-testbed"}
+   [:h1 "Hicasso controlled-input testbed"]
+   [text-field {:field :plain}]
+   [text-field {:field :digits}]
+   [text-field {:field :empty}]
+   [text-field {:field :grouped}]
+   [text-field {:field :upper}]
+   [notes-field {}]
+   [revision-field {}]
+   [flag-box {}]
+   [reset-form {}]
+   [mountable-field {}]
+   [:button {:data-testid "bump-revision" :on-click [:tb/bump-revision]} "bump"]
+   [:button {:data-testid "toggle-mounted" :on-click [:tb/toggle-mounted]} "toggle"]
+   [:button {:data-testid "correct-upper" :on-click [:tb/correct :upper "ZZZZZZ"]}
+    "correct upper"]])
+
+;; ---------------------------------------------------------------------------
+;; The harness door — the model, and only the model
+;; ---------------------------------------------------------------------------
+
+(defn- model-json
+  []
+  (let [db (rf/app-db-value frame-id)]
+    (js/JSON.stringify
+     (clj->js {:fields   (:fields db)
+               :flag     (:flag db)
+               :revision (:revision db)}))))
+
+(defn ^:export init
+  []
+  (rf/init! uix-adapter/adapter)
+  (rf/make-frame {:id frame-id :initial-events [[:tb/seed]]})
+  (h/root! (js/document.getElementById "app") frame-id [app {}])
+  (unchecked-set js/window "__RF2_HIC_TB__" #js {:model model-json})
+  nil)

--- a/implementation/hicasso/testbed/index.html
+++ b/implementation/hicasso/testbed/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: Hicasso controlled input</title>
+  <style>
+    body { margin: 0; font-family: sans-serif; padding: 2em; }
+    input, textarea { display: block; margin: 0.4em 0; font-size: 1em; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/implementation/hicasso/testbed/spec.cjs
+++ b/implementation/hicasso/testbed/spec.cjs
@@ -162,8 +162,14 @@ class Witness {
 
 // I15 — "converge within the turn that edited them" and "echo only
 // committed state". Read on the line after the dispatch, before the task
-// yields: a runtime that converged a frame later would still show the
-// draft here.
+// yields.
+//
+// These rows are the invariant as stated, and each one's expectation was
+// flipped to confirm it is wired to a real reading. They do NOT attribute
+// the conduct to this runtime, and the runner's `## Coverage` block says
+// why it was measured rather than argued: React's own end-of-event restore
+// corrects any value the converge got wrong, in the same discrete event.
+// The rows that isolate this runtime are the caret rows below.
 async function sameTurnConvergence(page, w) {
   const grouped = await page.evaluate(() =>
     // "1,234" with the caret at the end; the user types "5".

--- a/implementation/hicasso/testbed/spec.cjs
+++ b/implementation/hicasso/testbed/spec.cjs
@@ -1,0 +1,528 @@
+'use strict';
+
+/*
+ * THE CONTROLLED-INPUT WITNESSES — invariant I15, in three real engines
+ * (rf2-hic-016).
+ *
+ * `serve-and-run-hicasso-controlled-testbed.cjs` compiles the testbed,
+ * serves it, and runs everything below once per engine in Chromium,
+ * Firefox and WebKit. The spec asserts what must hold in every engine and
+ * RECORDS what differs; the runner compares the recorded rows across
+ * engines and reds on an unexplained divergence.
+ *
+ * ## Why the witnesses are driven from page script rather than the keyboard
+ *
+ * Both, in fact — and the split is the point.
+ *
+ * `page.keyboard` produces the browser's own trusted key and input events,
+ * which is the only way to be sure the field is really being typed into.
+ * But a Playwright keystroke resolves a round-trip later, so the value read
+ * after it is the value at QUIESCENCE, and I15's first clause is about the
+ * TURN: a runtime that converged one animation frame late (UIx's port of
+ * Reagent's workaround does exactly that) passes every quiescent
+ * assertion. The only place a same-turn claim can be witnessed is inside
+ * the dispatching task, so the convergence rows dispatch the event
+ * themselves and read the field on the next line, before the task yields.
+ *
+ * Those dispatched events are not fakes of the DOM: `nativeSet` writes
+ * through `HTMLInputElement.prototype`'s own `value` setter, which is what
+ * a keystroke does and what React's value tracker is watching, so React's
+ * ChangeEventPlugin banks a restore target exactly as it does for a real
+ * key. Assigning `el.value` instead would go through the tracker's patched
+ * setter, React would conclude nothing changed, and the whole
+ * end-of-event restore this invariant is about would never run — a test
+ * that passed by never reaching the mechanism.
+ *
+ * The caret rows then re-witness the same fields with `page.keyboard`, so
+ * no caret claim rests on a dispatched event alone.
+ *
+ * ## Composition
+ *
+ * `Input.imeSetComposition` is a CDP method and CDP is Chromium's protocol,
+ * so the repo's existing real-IME harness
+ * (`freehand/test/re_frame/bench/hicasso/ime_run.cjs`) states its scope as
+ * Chromium only. This gate needs the carve-out witnessed on WebKit and
+ * Firefox, where no such protocol exists, so composition here is the event
+ * SEQUENCE a composition produces — `compositionstart`, `beforeinput` and
+ * `input` carrying `isComposing`, `compositionend` — dispatched at the real
+ * node, through real React, into the real shadow component.
+ *
+ * What that reaches and what it does not is stated rather than glossed:
+ * it reaches `composing-input?`'s reading of the native event, the shadow
+ * that holds the draft, and React's own end-of-event restore finding
+ * nothing to write — every mechanism the carve-out is made of. It does not
+ * reach the browser's composition RANGE, so the abort signature the CDP
+ * harness detects (a value write killing an exchange without a
+ * `compositionend`) stays Chromium-only and stays that harness's. See the
+ * `## Coverage` block in the runner.
+ */
+
+// Everything the page needs, installed before the app's own script runs.
+// Kept as one string so the runner can hand it to `page.addInitScript`
+// unchanged in every engine.
+const PAGE_HELPERS = `
+window.__TB__ = (function () {
+  function el(id) {
+    var n = document.querySelector('[data-testid="' + id + '"]');
+    if (!n) throw new Error('no element with data-testid=' + id);
+    return n;
+  }
+  // The browser's own value setter, which is the one React's value tracker
+  // is watching. See the spec header.
+  function nativeSet(node, v) {
+    var proto = node.tagName === 'TEXTAREA'
+      ? HTMLTextAreaElement.prototype
+      : HTMLInputElement.prototype;
+    Object.getOwnPropertyDescriptor(proto, 'value').set.call(node, v);
+  }
+  function fire(node, type, init) {
+    node.dispatchEvent(new InputEvent(type, Object.assign(
+      { bubbles: true, cancelable: type === 'beforeinput', composed: true }, init)));
+  }
+  function composition(node, type, data) {
+    node.dispatchEvent(new CompositionEvent(type, {
+      bubbles: true, composed: true, data: data == null ? '' : data,
+    }));
+  }
+  // One edit, delivered as a keystroke delivers it: the field already
+  // shows what the user left behind, the caret is where they left it, and
+  // the event goes out. Returns what the field shows on the very next
+  // line — inside the same task, which is what "same turn" means.
+  function edit(id, next, caret, opts) {
+    var node = el(id);
+    var o = opts || {};
+    node.focus();
+    nativeSet(node, next);
+    node.setSelectionRange(caret, caret);
+    if (o.beforeinput !== false) {
+      fire(node, 'beforeinput', { inputType: o.inputType || 'insertText', data: o.data || null });
+    }
+    fire(node, 'input', {
+      inputType: o.inputType || 'insertText',
+      data: o.data || null,
+      isComposing: !!o.isComposing,
+    });
+    return read(id);
+  }
+  function read(id) {
+    var node = el(id);
+    return {
+      value: node.value,
+      start: node.selectionStart,
+      end: node.selectionEnd,
+      direction: node.selectionDirection,
+      active: document.activeElement === node,
+    };
+  }
+  function model() { return JSON.parse(window.__RF2_HIC_TB__.model()); }
+  return {
+    el: el, nativeSet: nativeSet, fire: fire, composition: composition,
+    edit: edit, read: read, model: model,
+  };
+})();
+`;
+
+// ---------------------------------------------------------------------------
+// Assertion vocabulary — every failure names the engine, the field and the
+// property, because a row that reds in one engine only is the finding.
+// ---------------------------------------------------------------------------
+
+class Witness {
+  constructor(engine) {
+    this.engine = engine;
+    this.checks = 0;
+    this.recorded = {};
+  }
+
+  eq(actual, expected, what) {
+    this.checks += 1;
+    if (actual !== expected) {
+      throw new Error(
+        `[${this.engine}] ${what}: expected ${JSON.stringify(expected)}, ` +
+        `got ${JSON.stringify(actual)}`);
+    }
+  }
+
+  // A row whose conduct is MEASURED rather than required. The runner
+  // compares these across engines and reds on a divergence no narrowing
+  // names, so recording is not a way of not asserting.
+  record(key, value) {
+    this.recorded[key] = value;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The witnesses
+// ---------------------------------------------------------------------------
+
+// I15 — "converge within the turn that edited them" and "echo only
+// committed state". Read on the line after the dispatch, before the task
+// yields: a runtime that converged a frame later would still show the
+// draft here.
+async function sameTurnConvergence(page, w) {
+  const grouped = await page.evaluate(() =>
+    // "1,234" with the caret at the end; the user types "5".
+    window.__TB__.edit('grouped', '1,2345', 6, { data: '5' }));
+  w.eq(grouped.value, '12,345', 'grouped normalises within the edit turn');
+
+  const plain = await page.evaluate(() =>
+    window.__TB__.edit('plain', 'abcd', 4, { data: 'd' }));
+  // The converge's own trap: hand `converge-to!` the handler's stale
+  // closure value instead of the element's record and this row shows
+  // "abc" — the accepted keystroke wiped off the screen.
+  w.eq(plain.value, 'abcd', 'an accepted keystroke survives the converge');
+
+  const digits = await page.evaluate(() =>
+    window.__TB__.edit('digits', '123x', 4, { data: 'x' }));
+  w.eq(digits.value, '123', 'a refused edit echoes the committed value in-turn');
+
+  // Owned `:value` wins by PRESENCE, not truthiness. This field's model is
+  // "" forever; a runtime that read `value` for truth would call the
+  // element uncontrolled and leave the typed character on screen.
+  const empty = await page.evaluate(() =>
+    window.__TB__.edit('empty', 'x', 1, { data: 'x' }));
+  w.eq(empty.value, '', 'an empty owned value is present, not falsy');
+
+  const model = await page.evaluate(() => window.__TB__.model());
+  w.eq(model.fields.grouped, '12,345', 'the store holds the normalised value');
+  w.eq(model.fields.plain, 'abcd', 'the store took the accepted keystroke');
+  w.eq(model.fields.digits, '123', 'the store did not move on a refusal');
+  w.eq(model.fields.empty, '', 'the store did not move on the empty field');
+}
+
+// I15 — "preserve caret across that echo". The caret is the property that
+// separates this runtime from plain React, which converges in the same
+// discrete event and throws the caret to the end of the control. Every row
+// here therefore edits in the MIDDLE of the string; a row that typed at the
+// end would pass under either conduct.
+async function caretAcrossTheEcho(page, w) {
+  // Length-CHANGING normalisation — the only case that distinguishes an
+  // offset from the end of the string from an absolute position.
+  // "1,2|34" + "9" -> field "1,2934" caret 4 -> model "12,934", caret 4.
+  const grouped = await page.evaluate(() =>
+    window.__TB__.edit('grouped', '1,2934', 4, { data: '9' }));
+  w.eq(grouped.value, '12,934', 'grouped regrouped around the inserted digit');
+  w.eq(grouped.start, 4, 'the caret sits after the digit just typed, not at the end');
+
+  // Length-PRESERVING normalisation, so a caret failure cannot hide behind
+  // a change of length. "A|BC" + "x" -> "AxBC" caret 2 -> "AXBC", caret 2.
+  const upper = await page.evaluate(() =>
+    window.__TB__.edit('upper', 'AxBC', 2, { data: 'x' }));
+  w.eq(upper.value, 'AXBC', 'upper normalised the inserted character');
+  w.eq(upper.start, 2, 'the caret survived a same-length normalisation');
+
+  // On a REFUSAL. "1|23" + "x" -> field "1x23" caret 2 -> model "123";
+  // the offset from the end is 2, so the caret lands at 1 — where the
+  // refused character would have gone.
+  const digits = await page.evaluate(() =>
+    window.__TB__.edit('digits', '1x23', 2, { data: 'x' }));
+  w.eq(digits.value, '123', 'the refusal echoed');
+  w.eq(digits.start, 1, 'the caret survived the refusal');
+
+  // The other convergeable tag. "one| two" + " " -> "one  two" caret 4 ->
+  // collapsed to "one two", offset from the end 4, caret 3.
+  const notes = await page.evaluate(() =>
+    window.__TB__.edit('notes', 'one  two', 4, { data: ' ' }));
+  w.eq(notes.value, 'one two', 'the textarea normalised');
+  w.eq(notes.start, 3, 'the caret survived on a textarea');
+
+  // Every converge leaves a CARET rather than a range — `converge-to!`
+  // restores one offset, which is the whole of rf2-n3dxw's honest limit.
+  w.eq(grouped.start === grouped.end, true, 'the converge leaves a collapsed caret');
+}
+
+// The same claim again, this time with the browser's own trusted key
+// events, so no caret row rests on a dispatched event alone. Read at
+// quiescence — a keystroke cannot be read inside its own turn from here —
+// which is exactly why the rows above exist beside these.
+async function caretUnderRealTyping(page, w) {
+  const field = page.locator('[data-testid="upper"]');
+  await field.click();
+  // Put the caret between "A" and "X" of the "AXBC" the rows above left.
+  await page.evaluate(() => window.__TB__.el('upper').setSelectionRange(1, 1));
+  await page.keyboard.type('q');
+  const after = await page.evaluate(() => window.__TB__.read('upper'));
+  w.eq(after.value, 'AQXBC', 'a real keystroke normalised');
+  w.eq(after.start, 2, 'a real keystroke left the caret after the character typed');
+
+  const groupedField = page.locator('[data-testid="grouped"]');
+  await groupedField.click();
+  await page.evaluate(() => window.__TB__.el('grouped').setSelectionRange(4, 4));
+  await page.keyboard.type('7');
+  const grouped = await page.evaluate(() => window.__TB__.read('grouped'));
+  // "12,9|34" + "7" -> digits "129734" -> "129,734"; the offset from the
+  // end was 2, so the caret is at 5, immediately after the 7.
+  w.eq(grouped.value, '129,734', 'a real keystroke regrouped');
+  w.eq(grouped.start, 5, 'a real keystroke kept the caret off the end');
+}
+
+// I15 — "preserve selection". A keystroke collapses a selection by itself,
+// so the only place the question is live is an OUT-OF-BAND write: a model
+// correction no keystroke caused, which `converge!` is deliberately not on
+// (rf2-n3dxw). What survives there is React's own selection restore, and
+// what it does is measured per engine rather than assumed.
+async function selectionAcrossAnOutOfBandWrite(page, w) {
+  const observed = await page.evaluate(() => {
+    const node = window.__TB__.el('upper');
+    node.focus();
+    node.setSelectionRange(1, 3, 'backward');
+    const before = window.__TB__.read('upper');
+    // A programmatic click never moves focus, so the field under
+    // observation keeps it and React's restore is in scope.
+    window.__TB__.el('correct-upper').click();
+    return { before, after: window.__TB__.read('upper') };
+  });
+  w.eq(observed.before.end - observed.before.start, 2, 'a range was selected to begin with');
+  w.eq(observed.after.value, 'ZZZZZZ', 'the out-of-band correction reached the field');
+  w.eq(observed.after.active, true, 'the field still holds focus across the correction');
+  w.record('selection-across-out-of-band-write', {
+    start: observed.after.start,
+    end: observed.after.end,
+    direction: observed.after.direction,
+    collapsed: observed.after.start === observed.after.end,
+  });
+}
+
+// I15 — "preserve in-flight composition". The carve-out (rf2-digtt): while
+// a composition is live nothing writes the field, and the model's refusal
+// lands whole and visible at `compositionend`. Driven on the REFUSING
+// field, which is the case the CDP harness measured plain React destroying.
+async function compositionSafety(page, w) {
+  const run = await page.evaluate(() => {
+    const node = window.__TB__.el('digits');
+    node.focus();
+    const seen = [];
+    const log = (t) => seen.push(t);
+    node.addEventListener('compositionstart', () => log('start'));
+    node.addEventListener('compositionend', () => log('end'));
+
+    window.__TB__.composition(node, 'compositionstart', '');
+    const started = window.__TB__.read('digits').value;
+
+    // First composing update. Read on the next line: if the converge ran
+    // here the field would already show the model's refusal.
+    const draft1 = window.__TB__.edit('digits', '123あ', 4, {
+      isComposing: true, inputType: 'insertCompositionText', data: 'あ',
+    });
+
+    const draft2 = window.__TB__.edit('digits', '123あい', 5, {
+      isComposing: true, inputType: 'insertCompositionText', data: 'あい',
+    });
+
+    const midModel = window.__TB__.model().fields.digits;
+
+    window.__TB__.composition(node, 'compositionend', 'あい');
+    const ended = window.__TB__.read('digits');
+
+    return {
+      started, draft1, draft2, midModel, ended, seen,
+      startCount: seen.filter((t) => t === 'start').length,
+      endCount: seen.filter((t) => t === 'end').length,
+    };
+  });
+
+  w.eq(run.draft1.value, '123あ', 'the first composing update survives in the field');
+  w.eq(run.draft2.value, '123あい', 'the second composing update survives too');
+  w.eq(run.midModel, '123', 'the refusing model never moved during the exchange');
+  // The exchange was not destroyed: one start, one end. A value write
+  // landing mid-composition is what mints a second `compositionstart` in
+  // the CDP harness, and a synthetic exchange can at least witness that
+  // this runtime wrote nothing.
+  w.eq(run.startCount, 1, 'exactly one compositionstart');
+  w.eq(run.endCount, 1, 'exactly one compositionend');
+  // And the refusal lands whole, at the close, visibly.
+  w.eq(run.ended.value, '123', 'the refusal lands at compositionend');
+
+  const model = await page.evaluate(() => window.__TB__.model());
+  w.eq(model.fields.digits, '123', 'the store still holds the committed value');
+}
+
+// The carve-out's safety rider: every path out of a composition releases
+// the shadow, so a field cannot be stranded showing a draft the model never
+// agreed to. `compositionend` is witnessed above; these are the other two
+// that do not go through it.
+async function compositionReleaseEdges(page, w) {
+  // Blur — the composition the browser abandoned with the focus.
+  const blurred = await page.evaluate(() => {
+    const node = window.__TB__.el('digits');
+    node.focus();
+    window.__TB__.composition(node, 'compositionstart', '');
+    window.__TB__.edit('digits', '123あ', 4, {
+      isComposing: true, inputType: 'insertCompositionText', data: 'あ',
+    });
+    const held = window.__TB__.read('digits').value;
+    node.blur();
+    return { held, after: window.__TB__.read('digits').value };
+  });
+  w.eq(blurred.held, '123あ', 'the draft was held before the blur');
+  w.eq(blurred.after, '123', 'blur releases the shadow and the model re-asserts');
+
+  // A NON-COMPOSING change — the path that recovers an exchange some other
+  // write aborted silently, since the abort itself fires nothing.
+  const recovered = await page.evaluate(() => {
+    const node = window.__TB__.el('digits');
+    node.focus();
+    window.__TB__.composition(node, 'compositionstart', '');
+    window.__TB__.edit('digits', '123あ', 4, {
+      isComposing: true, inputType: 'insertCompositionText', data: 'あ',
+    });
+    const held = window.__TB__.read('digits').value;
+    // No compositionend: just an ordinary keystroke.
+    const plain = window.__TB__.edit('digits', '1234', 4, { data: '4' });
+    return { held, plain };
+  });
+  w.eq(recovered.held, '123あ', 'the draft was held');
+  w.eq(recovered.plain.value, '1234', 'a non-composing change releases and converges');
+
+  // Unmount — the shadow is one `useState` on a fiber and cannot outlive
+  // it. There is no registry and no node property to strand.
+  const unmounted = await page.evaluate(() => {
+    const node = window.__TB__.el('mountable');
+    node.focus();
+    window.__TB__.composition(node, 'compositionstart', '');
+    window.__TB__.edit('mountable', 'draft', 5, {
+      isComposing: true, inputType: 'insertCompositionText', data: 'draft',
+    });
+    window.__TB__.el('toggle-mounted').click();
+    const gone = !!document.querySelector('[data-testid="mountable-gone"]');
+    window.__TB__.el('toggle-mounted').click();
+    return { gone, back: window.__TB__.read('mountable').value };
+  });
+  w.eq(unmounted.gone, true, 'the field unmounted mid-composition');
+  w.eq(unmounted.back, '', 'the remounted field shows the model, not a stranded draft');
+}
+
+// I15 — "reset is an explicit revision that preserves element identity".
+// The divergence is created the way a password manager creates one: a value
+// write with no event, which no handler sees and no commit is scheduled for.
+async function revisionResetPreservesIdentity(page, w) {
+  const observed = await page.evaluate(async () => {
+    const node = window.__TB__.el('revision');
+    node.__tbMark = 'M1';
+    window.__TB__.nativeSet(node, 'drifted');
+    const drifted = window.__TB__.read('revision').value;
+    // A turn passes with no revision change: the draft must survive it,
+    // or the row below would be measuring an incidental commit.
+    await new Promise((r) => setTimeout(r, 50));
+    const survived = window.__TB__.read('revision').value;
+    const modelBefore = window.__TB__.model();
+
+    window.__TB__.el('bump-revision').click();
+    const after = window.__TB__.read('revision');
+    const same = window.__TB__.el('revision');
+    return {
+      drifted, survived, modelBefore, after,
+      mark: same.__tbMark,
+      identical: same === node,
+      revision: window.__TB__.model().revision,
+    };
+  });
+  w.eq(observed.drifted, 'drifted', 'the eventless write reached the field');
+  w.eq(observed.survived, 'drifted', 'and survived a turn — nothing else reset it');
+  w.eq(observed.modelBefore.fields.revision, 'keep', 'the store never saw the draft');
+  w.eq(observed.after.value, 'keep', 'the revision bump re-baselined the field to the model');
+  w.eq(observed.revision, 1, 'exactly one revision advance');
+  w.eq(observed.mark, 'M1', 'the DOM node survived the reset — no remount');
+  w.eq(observed.identical, true, 'and it is the same node the document still holds');
+}
+
+// The owned `::h/checked` pair, whose `false` is a presence rather than a
+// truth. Read inside the click's own turn.
+async function ownedCheckedPair(page, w) {
+  const toggled = await page.evaluate(() => {
+    const node = window.__TB__.el('flag');
+    const before = { dom: node.checked, model: window.__TB__.model().flag };
+    node.click();
+    const on = { dom: node.checked, model: window.__TB__.model().flag };
+    node.click();
+    const off = { dom: node.checked, model: window.__TB__.model().flag };
+    return { before, on, off };
+  });
+  w.eq(toggled.before.dom, false, 'the checkbox starts unchecked');
+  w.eq(toggled.before.model, false, 'and so does its model');
+  w.eq(toggled.on.dom, true, 'the DOM followed the click');
+  w.eq(toggled.on.model, true, 'and the store did too, in the same turn');
+  w.eq(toggled.off.dom, false, 'and back — an owned false is a presence');
+  w.eq(toggled.off.model, false, 'with the store agreeing');
+}
+
+// RECORDED, not gated (the conformance matrix is hic-040). A form reset
+// returns a control to its `defaultValue`, and `defaultValue` is exactly
+// the per-instance record `controlled/last-rendered` reads — so a reset is
+// the one ordinary browser action that touches the converge's own
+// bookkeeping. Autofill has no cross-engine drive (Chromium's is a CDP
+// method and needs a profile), so the eventless write below is recorded as
+// its PROXY and named as one.
+async function formResetAndFillProxy(page, w) {
+  const reset = await page.evaluate(() => {
+    const a = window.__TB__.el('form-a');
+    window.__TB__.edit('form-a', 'FORMx', 5, { data: 'x' });
+    const typed = window.__TB__.read('form-a').value;
+    const defaultBefore = a.defaultValue;
+    window.__TB__.el('form-reset').click();
+    return {
+      typed,
+      defaultBefore,
+      afterValue: window.__TB__.read('form-a').value,
+      afterDefault: a.defaultValue,
+      model: window.__TB__.model().fields['form-a'],
+    };
+  });
+  w.eq(reset.typed, 'FORMX', 'the form field normalised like any other');
+  w.record('form-reset', {
+    'default-value-mirrors-the-model': reset.defaultBefore === reset.typed,
+    'value-after-reset': reset.afterValue,
+    'model-after-reset': reset.model,
+    'reset-is-visually-inert': reset.afterValue === reset.model,
+  });
+
+  const fill = await page.evaluate(async () => {
+    const b = window.__TB__.el('form-b');
+    // (1) a fill that dispatches an input event, which is what most
+    // password managers do — indistinguishable from a keystroke.
+    const withEvent = window.__TB__.edit('form-b', 'filled', 6, { inputType: 'insertReplacementText' });
+    // (2) a fill that dispatches nothing, which is the pathological one.
+    window.__TB__.nativeSet(b, 'silent');
+    await new Promise((r) => setTimeout(r, 50));
+    const silent = window.__TB__.read('form-b').value;
+    window.__TB__.el('form-reset').click();
+    return {
+      withEvent: withEvent.value,
+      withEventModel: window.__TB__.model().fields['form-b'],
+      silent,
+      afterReset: window.__TB__.read('form-b').value,
+    };
+  });
+  w.eq(fill.withEvent, 'filled', 'a fill carrying an input event converges like a keystroke');
+  w.eq(fill.withEventModel, 'filled', 'and reaches the store');
+  w.record('fill-proxy', {
+    'eventless-fill-leaves-a-draft': fill.silent === 'silent',
+    'form-reset-clears-the-eventless-draft': fill.afterReset === fill.withEventModel,
+    'value-after-reset': fill.afterReset,
+  });
+}
+
+// ---------------------------------------------------------------------------
+
+module.exports = {
+  name: 'Hicasso controlled input (I15) — three engines',
+  url: '/index.html',
+  pageHelpers: PAGE_HELPERS,
+
+  // Every row that must hold in every engine, in order. The runner reports
+  // the check count and refuses a run that banked too few, so a section
+  // that silently stopped running cannot pass as green.
+  run: async (page, ctx) => {
+    const w = new Witness(ctx.engine);
+    await sameTurnConvergence(page, w);
+    await caretAcrossTheEcho(page, w);
+    await caretUnderRealTyping(page, w);
+    await selectionAcrossAnOutOfBandWrite(page, w);
+    await compositionSafety(page, w);
+    await compositionReleaseEdges(page, w);
+    await revisionResetPreservesIdentity(page, w);
+    await ownedCheckedPair(page, w);
+    await formResetAndFillProxy(page, w);
+    return { checks: w.checks, recorded: w.recorded };
+  },
+};

--- a/implementation/hicasso/testbed/spec.cjs
+++ b/implementation/hicasso/testbed/spec.cjs
@@ -115,9 +115,14 @@ window.__TB__ = (function () {
     };
   }
   function model() { return JSON.parse(window.__RF2_HIC_TB__.model()); }
+  // Let a concurrent root's sync lane land. A keystroke does not need this
+  // — \`converge!\` spends a \`flushSync\` so the echo is inside the turn —
+  // but an ordinary click spends none, so anything driven by a button is
+  // read on the next task rather than the next line.
+  function settle() { return new Promise(function (r) { setTimeout(r, 0); }); }
   return {
     el: el, nativeSet: nativeSet, fire: fire, composition: composition,
-    edit: edit, read: read, model: model,
+    edit: edit, read: read, model: model, settle: settle,
   };
 })();
 `;
@@ -262,7 +267,7 @@ async function caretUnderRealTyping(page, w) {
 // (rf2-n3dxw). What survives there is React's own selection restore, and
 // what it does is measured per engine rather than assumed.
 async function selectionAcrossAnOutOfBandWrite(page, w) {
-  const observed = await page.evaluate(() => {
+  const observed = await page.evaluate(async () => {
     const node = window.__TB__.el('upper');
     node.focus();
     node.setSelectionRange(1, 3, 'backward');
@@ -270,8 +275,18 @@ async function selectionAcrossAnOutOfBandWrite(page, w) {
     // A programmatic click never moves focus, so the field under
     // observation keeps it and React's restore is in scope.
     window.__TB__.el('correct-upper').click();
-    return { before, after: window.__TB__.read('upper') };
+    // Read on the next task, NOT the next line, and the difference is the
+    // whole of why an out-of-band write is a different path. A concurrent
+    // root flushes a discrete update's sync lane in a microtask; the
+    // keystroke rows above are inside the turn only because `converge!`
+    // spends a `flushSync` to put them there, and no `flushSync` is
+    // spent here because there is no caret to save.
+    const immediate = window.__TB__.read('upper');
+    await new Promise((r) => setTimeout(r, 0));
+    return { before, immediate, after: window.__TB__.read('upper') };
   });
+  w.record('out-of-band-write-lands-in-the-same-task',
+    observed.immediate.value === 'ZZZZZZ');
   w.eq(observed.before.end - observed.before.start, 2, 'a range was selected to begin with');
   w.eq(observed.after.value, 'ZZZZZZ', 'the out-of-band correction reached the field');
   w.eq(observed.after.active, true, 'the field still holds focus across the correction');
@@ -343,7 +358,7 @@ async function compositionSafety(page, w) {
 // that do not go through it.
 async function compositionReleaseEdges(page, w) {
   // Blur — the composition the browser abandoned with the focus.
-  const blurred = await page.evaluate(() => {
+  const blurred = await page.evaluate(async () => {
     const node = window.__TB__.el('digits');
     node.focus();
     window.__TB__.composition(node, 'compositionstart', '');
@@ -351,7 +366,11 @@ async function compositionReleaseEdges(page, w) {
       isComposing: true, inputType: 'insertCompositionText', data: 'あ',
     });
     const held = window.__TB__.read('digits').value;
+    // A blurred field has no caret worth restoring, so the release spends
+    // no `flushSync` and the model re-asserts on the next task rather than
+    // this line — the deliberate asymmetry `shadowed-props` states.
     node.blur();
+    await window.__TB__.settle();
     return { held, after: window.__TB__.read('digits').value };
   });
   w.eq(blurred.held, '123あ', 'the draft was held before the blur');
@@ -376,20 +395,28 @@ async function compositionReleaseEdges(page, w) {
 
   // Unmount — the shadow is one `useState` on a fiber and cannot outlive
   // it. There is no registry and no node property to strand.
-  const unmounted = await page.evaluate(() => {
+  const unmounted = await page.evaluate(async () => {
     const node = window.__TB__.el('mountable');
     node.focus();
     window.__TB__.composition(node, 'compositionstart', '');
-    window.__TB__.edit('mountable', 'draft', 5, {
-      isComposing: true, inputType: 'insertCompositionText', data: 'draft',
+    // A REFUSING field, so the draft in the element is one the model never
+    // took — without that the row below would pass on a model that had
+    // simply accepted the composition.
+    const draft = window.__TB__.edit('mountable', '9あ', 2, {
+      isComposing: true, inputType: 'insertCompositionText', data: 'あ',
     });
+    const midModel = window.__TB__.model().fields.mountable;
     window.__TB__.el('toggle-mounted').click();
+    await window.__TB__.settle();
     const gone = !!document.querySelector('[data-testid="mountable-gone"]');
     window.__TB__.el('toggle-mounted').click();
-    return { gone, back: window.__TB__.read('mountable').value };
+    await window.__TB__.settle();
+    return { draft: draft.value, midModel, gone, back: window.__TB__.read('mountable').value };
   });
+  w.eq(unmounted.draft, '9あ', 'the field held a draft the model had refused');
+  w.eq(unmounted.midModel, '9', 'and the model really had refused it');
   w.eq(unmounted.gone, true, 'the field unmounted mid-composition');
-  w.eq(unmounted.back, '', 'the remounted field shows the model, not a stranded draft');
+  w.eq(unmounted.back, '9', 'the remounted field shows the model, not a stranded draft');
 }
 
 // I15 — "reset is an explicit revision that preserves element identity".
@@ -408,6 +435,7 @@ async function revisionResetPreservesIdentity(page, w) {
     const modelBefore = window.__TB__.model();
 
     window.__TB__.el('bump-revision').click();
+    await window.__TB__.settle();
     const after = window.__TB__.read('revision');
     const same = window.__TB__.el('revision');
     return {
@@ -429,12 +457,14 @@ async function revisionResetPreservesIdentity(page, w) {
 // The owned `::h/checked` pair, whose `false` is a presence rather than a
 // truth. Read inside the click's own turn.
 async function ownedCheckedPair(page, w) {
-  const toggled = await page.evaluate(() => {
+  const toggled = await page.evaluate(async () => {
     const node = window.__TB__.el('flag');
     const before = { dom: node.checked, model: window.__TB__.model().flag };
     node.click();
+    await window.__TB__.settle();
     const on = { dom: node.checked, model: window.__TB__.model().flag };
     node.click();
+    await window.__TB__.settle();
     const off = { dom: node.checked, model: window.__TB__.model().flag };
     return { before, on, off };
   });
@@ -454,12 +484,13 @@ async function ownedCheckedPair(page, w) {
 // method and needs a profile), so the eventless write below is recorded as
 // its PROXY and named as one.
 async function formResetAndFillProxy(page, w) {
-  const reset = await page.evaluate(() => {
+  const reset = await page.evaluate(async () => {
     const a = window.__TB__.el('form-a');
     window.__TB__.edit('form-a', 'FORMx', 5, { data: 'x' });
     const typed = window.__TB__.read('form-a').value;
     const defaultBefore = a.defaultValue;
     window.__TB__.el('form-reset').click();
+    await window.__TB__.settle();
     return {
       typed,
       defaultBefore,
@@ -486,6 +517,7 @@ async function formResetAndFillProxy(page, w) {
     await new Promise((r) => setTimeout(r, 50));
     const silent = window.__TB__.read('form-b').value;
     window.__TB__.el('form-reset').click();
+    await window.__TB__.settle();
     return {
       withEvent: withEvent.value,
       withEventModel: window.__TB__.model().fields['form-b'],

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -64,6 +64,7 @@
     "test:reagent-slim:smoke": "node scripts/serve-and-run-reagent-slim-smoke.cjs",
     "test:adapter-smokes": "node adapters/scripts/serve-and-run-adapter-smokes.cjs",
     "test:testbed-tenant-switcher": "node scripts/serve-and-run-tenant-switcher-testbed.cjs",
+    "test:hicasso-controlled": "node scripts/serve-and-run-hicasso-controlled-testbed.cjs",
     "dev:example": "node ../examples/scripts/serve-example.cjs",
     "story:build": "node scripts/story-build.cjs",
     "test:story-feature-load": "node ../examples/scripts/serve-and-run-story-feature-load-tests.cjs",

--- a/implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs
+++ b/implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs
@@ -90,10 +90,10 @@ const ENGINES = ONLY
   : ALL_ENGINES;
 
 // The check floor (the discipline `ime_run.cjs` carries): a run that
-// asserted almost nothing must not exit 0. A full engine banks 43 checks;
-// 40 refuses a section that silently stopped running while leaving a little
-// room for a row to be retired.
-const MIN_CHECKS_PER_ENGINE = 40;
+// asserted almost nothing must not exit 0. A full engine banks 55 checks;
+// 50 refuses a section that silently stopped running — the smallest of the
+// nine is 6 rows — while leaving room for a row to be retired.
+const MIN_CHECKS_PER_ENGINE = 50;
 
 // ---------------------------------------------------------------------------
 // Cross-engine narrowings — every RECORDED row that is allowed to differ,

--- a/implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs
+++ b/implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs
@@ -1,0 +1,384 @@
+#!/usr/bin/env node
+'use strict';
+
+/*
+ * THE HICASSO CONTROLLED-INPUT GATE — invariant I15 in three real engines
+ * (rf2-hic-016).
+ *
+ *   node implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs
+ *   npm run test:hicasso-controlled          (from implementation/)
+ *
+ * Compiles the `:hicasso/testbed` build, serves it, and runs
+ * `implementation/hicasso/testbed/spec.cjs` once per engine in Chromium,
+ * Firefox and WebKit.
+ *
+ * ## Why this is not an entry in the adapter-smoke manifest
+ *
+ * That runner is ONE engine over N specs; this surface is ONE spec over N
+ * engines, and the engines are the contract rather than a detail of how it
+ * is run. Widening the shared runner would have put three browser launches
+ * behind every adapter smoke to serve one caller. The reagent-slim and
+ * tenant-switcher testbeds set the precedent for a surface that carries its
+ * own orchestrator, and `run-ui-g8.cjs` sets it for a correctness gate that
+ * drives more than one engine.
+ *
+ * ## The three engines, and why each is mandatory
+ *
+ * Chromium is where every controlled-input claim in this repo was
+ * previously witnessed — `run-ui-g8.cjs` adds WebKit for re-frame.ui, and
+ * `bench/hicasso/ime_run.cjs` states its own scope as Chromium-only because
+ * `Input.imeSetComposition` is a CDP method. Nothing had ever driven
+ * Hicasso's element-path converge outside Chromium, and the mechanism is
+ * made of exactly the things engines differ on: caret and selection
+ * restoration, composition event carriage, and the order in which a
+ * discrete event's work is flushed. Firefox is the third because it is the
+ * one major engine the repo had never launched at all.
+ *
+ * ## Two verdicts, kept apart
+ *
+ * REQUIRED rows are the spec's own assertions; a throw in any engine fails
+ * the gate. RECORDED rows are conduct the spec measures without demanding
+ * — and they are not a way of not asserting, because this runner COMPARES
+ * them across engines and fails on a divergence that no entry in
+ * `NARROWINGS` names, with its engines and its reason. An engine that
+ * quietly starts behaving differently is therefore a red gate rather than a
+ * silently-updated record.
+ *
+ * The comparator and the check floor both carry mutation teeth that run
+ * before any browser launches: a gate whose own verdict logic cannot fail
+ * is worse than a gate that is red.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const playwright = require('playwright');
+const {
+  createHarnessCleanup,
+  resolveServePort,
+  startLocalHttpServer,
+} = require('./lib/local-browser-harness.cjs');
+const { enforcePolicy, DEFAULT_OUT_ROOT } = require('./_path-policy.cjs');
+
+const IMPL_ROOT = path.resolve(__dirname, '..');
+const BUILD_ID = 'hicasso/testbed';
+const ROOT = enforcePolicy(
+  'HICASSO_TESTBED_ROOT',
+  path.join(IMPL_ROOT, 'out', 'hicasso-testbed'),
+  { allowedRoots: [DEFAULT_OUT_ROOT] },
+);
+const HTML_SRC = path.join(IMPL_ROOT, 'hicasso', 'testbed', 'index.html');
+const SPEC = require(path.join(IMPL_ROOT, 'hicasso', 'testbed', 'spec.cjs'));
+
+const DEFAULT_PORT = 8065;
+const READY_TIMEOUT_MS = 30000;
+const SPEC_TIMEOUT_MS = parseInt(process.env.HICASSO_TESTBED_SPEC_TIMEOUT_MS || '90000', 10);
+// The navigation's own ceiling, named so a CI log cannot read it as the
+// spec budget above. `'commit'` rather than `'load'`: the page's own script
+// is an un-optimized dev bundle that mounts the app, and everything after
+// the navigation auto-waits on the execution context anyway.
+const NAV_WAIT_UNTIL = 'commit';
+const NAV_TIMEOUT_MS = 60000;
+
+// Chromium, Firefox and WebKit. `HICASSO_TESTBED_ENGINES` narrows the set
+// for local iteration; the floor below is prorated so a partial run stays
+// honest about being one.
+const ALL_ENGINES = ['chromium', 'firefox', 'webkit'];
+const ONLY = (process.env.HICASSO_TESTBED_ENGINES || '').trim();
+const ENGINES = ONLY
+  ? ALL_ENGINES.filter((e) => ONLY.split(',').map((s) => s.trim()).includes(e))
+  : ALL_ENGINES;
+
+// The check floor (the discipline `ime_run.cjs` carries): a run that
+// asserted almost nothing must not exit 0. A full engine banks 43 checks;
+// 40 refuses a section that silently stopped running while leaving a little
+// room for a row to be retired.
+const MIN_CHECKS_PER_ENGINE = 40;
+
+// ---------------------------------------------------------------------------
+// Cross-engine narrowings — every RECORDED row that is allowed to differ,
+// with the engines it differs on and why. An entry here is a claim about
+// the world; an unlisted divergence is a red gate.
+// ---------------------------------------------------------------------------
+
+const NARROWINGS = [
+  // Populated only by a divergence this gate actually measured. An empty
+  // list is the honest starting state: nothing is excused in advance.
+];
+
+function narrowingFor(row) {
+  return NARROWINGS.find((n) => n.row === row) || null;
+}
+
+/**
+ * Compare the RECORDED rows across engines. Returns a list of problems —
+ * empty when every row either agrees everywhere or is covered by a
+ * narrowing that names the engines it saw.
+ */
+function divergenceReport(perEngine, narrowings = NARROWINGS) {
+  const problems = [];
+  const engines = Object.keys(perEngine);
+  if (engines.length < 2) return problems;
+  const rows = new Set();
+  for (const e of engines) for (const r of Object.keys(perEngine[e])) rows.add(r);
+
+  for (const row of rows) {
+    const byValue = new Map();
+    for (const e of engines) {
+      const key = JSON.stringify(perEngine[e][row]);
+      if (!byValue.has(key)) byValue.set(key, []);
+      byValue.get(key).push(e);
+    }
+    if (byValue.size === 1) continue;
+    const narrowing = narrowings.find((n) => n.row === row);
+    const groups = [...byValue.entries()]
+      .map(([value, es]) => `${es.join('+')}: ${value}`)
+      .join('  |  ');
+    if (!narrowing) {
+      problems.push(
+        `RECORDED row "${row}" diverges across engines and no NARROWINGS ` +
+        `entry names it — ${groups}. Either the runtime should agree here ` +
+        `(fix it) or the divergence is real (add a narrowing with its ` +
+        `engines and reason, and carry it to the hic-005 table).`);
+      continue;
+    }
+    const seen = engines.filter((e) => JSON.stringify(perEngine[e][row]) !== JSON.stringify(perEngine[engines[0]][row]));
+    const unexpected = seen.filter((e) => !narrowing.engines.includes(e));
+    if (unexpected.length > 0) {
+      problems.push(
+        `RECORDED row "${row}" has a narrowing for ${narrowing.engines.join('+')}, ` +
+        `but ${unexpected.join('+')} also diverged — ${groups}.`);
+    }
+  }
+  return problems;
+}
+
+// ---------------------------------------------------------------------------
+// Mutation teeth — the gate's own verdict logic, proven able to fail before
+// a single browser is launched.
+// ---------------------------------------------------------------------------
+
+function runMutationTeeth() {
+  const teeth = [];
+  const bite = (name, fn) => {
+    if (!fn()) throw new Error(`MUTATION TOOTH DID NOT BITE: ${name}`);
+    teeth.push(name);
+  };
+
+  bite('agreement across engines raises nothing', () =>
+    divergenceReport({
+      chromium: { row: { a: 1 } }, firefox: { row: { a: 1 } }, webkit: { row: { a: 1 } },
+    }, []).length === 0);
+
+  bite('an unnarrowed divergence is a problem', () =>
+    divergenceReport({
+      chromium: { row: { a: 1 } }, firefox: { row: { a: 2 } }, webkit: { row: { a: 1 } },
+    }, []).length === 1);
+
+  bite('a narrowing that names the engine excuses it', () =>
+    divergenceReport({
+      chromium: { row: { a: 1 } }, firefox: { row: { a: 2 } },
+    }, [{ row: 'row', engines: ['firefox'], why: 'tooth' }]).length === 0);
+
+  bite('a narrowing that names the WRONG engine does not', () =>
+    divergenceReport({
+      chromium: { row: { a: 1 } }, firefox: { row: { a: 2 } },
+    }, [{ row: 'row', engines: ['webkit'], why: 'tooth' }]).length === 1);
+
+  bite('a single engine cannot diverge from itself', () =>
+    divergenceReport({ chromium: { row: { a: 1 } } }, []).length === 0);
+
+  bite('the check floor refuses a run that asserted almost nothing', () =>
+    belowFloor({ checks: 3 }) === true && belowFloor({ checks: MIN_CHECKS_PER_ENGINE }) === false);
+
+  return teeth;
+}
+
+function belowFloor(result) {
+  return result.checks < MIN_CHECKS_PER_ENGINE;
+}
+
+// ---------------------------------------------------------------------------
+// Build and serve
+// ---------------------------------------------------------------------------
+
+function compile() {
+  const runner = require.resolve('shadow-cljs/cli/runner.js', { paths: [IMPL_ROOT] });
+  console.log(`> shadow-cljs compile ${BUILD_ID}`);
+  const result = spawnSync(process.execPath, [runner, 'compile', BUILD_ID], {
+    cwd: IMPL_ROOT, env: process.env, shell: false, stdio: 'inherit',
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`shadow-cljs compile ${BUILD_ID} exited ${result.status}`);
+  }
+}
+
+function stageHtml() {
+  fs.mkdirSync(ROOT, { recursive: true });
+  fs.copyFileSync(HTML_SRC, path.join(ROOT, 'index.html'));
+}
+
+// ---------------------------------------------------------------------------
+// One engine
+// ---------------------------------------------------------------------------
+
+async function driveEngine(engine, baseUrl) {
+  const browserType = playwright[engine];
+  if (!browserType) throw new Error(`unknown engine ${engine}`);
+  const browser = await browserType.launch({ headless: true });
+  // Page errors live in a DEDICATED array and flip the verdict, even when
+  // every assertion otherwise passed.
+  const pageErrors = [];
+  const lines = [];
+  const log = (s) => lines.push(s);
+  let passed = false;
+  let result = null;
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    page.on('console', (msg) => log(`[${engine}:${msg.type()}] ${msg.text()}`));
+    page.on('pageerror', (err) => {
+      pageErrors.push(err);
+      log(`[${engine}:pageerror] ${err.message}`);
+      if (err.stack) log(err.stack);
+    });
+    // The spec's page-side vocabulary, in place before the app's own script
+    // runs so nothing races the mount.
+    await page.addInitScript(SPEC.pageHelpers);
+
+    const url = SPEC.url.startsWith('http') ? SPEC.url : baseUrl + SPEC.url;
+    log(`\n=== ${SPEC.name} — ${engine} ===`);
+    try {
+      await page.goto(url, { waitUntil: NAV_WAIT_UNTIL, timeout: NAV_TIMEOUT_MS });
+    } catch (err) {
+      throw new Error(
+        `[${engine}] NAVIGATION FAILED — the page.goto ceiling fired ` +
+        `(waitUntil: '${NAV_WAIT_UNTIL}', timeout: ${NAV_TIMEOUT_MS}ms), which ` +
+        `is NOT the ${SPEC_TIMEOUT_MS}ms spec budget that would have followed ` +
+        `it. No witness ran, so nothing about the runtime has been observed. ` +
+        `An unbuilt bundle or a dead server fails here at any size. ` +
+        `Underlying: ${err.message}`);
+    }
+    // The app must be up before the first witness touches a field.
+    await page.waitForSelector('[data-testid="hicasso-controlled-testbed"]',
+      { timeout: SPEC_TIMEOUT_MS });
+
+    result = await withTimeout(SPEC.run(page, { engine }), SPEC_TIMEOUT_MS,
+      `${SPEC.name} (${engine})`);
+
+    if (pageErrors.length > 0) {
+      throw new Error(
+        `[${engine}] page emitted ${pageErrors.length} uncaught error(s); ` +
+        `first: ${pageErrors[0].message}`);
+    }
+    if (belowFloor(result)) {
+      throw new Error(
+        `[${engine}] banked only ${result.checks} checks, floor is ` +
+        `${MIN_CHECKS_PER_ENGINE} — a section stopped running.`);
+    }
+    passed = true;
+  } catch (err) {
+    log(`FAIL ${SPEC.name} (${engine}): ${err && err.message ? err.message : err}`);
+    if (err && err.stack) log(err.stack);
+  } finally {
+    await browser.close();
+  }
+  if (!passed) for (const ln of lines) console.log(ln);
+  console.log(passed
+    ? `PASS  ${engine} — ${result.checks} checks`
+    : `FAIL  ${engine}`);
+  return { passed, result };
+}
+
+function withTimeout(promise, ms, label) {
+  let timer;
+  return Promise.race([
+    promise.finally(() => clearTimeout(timer)),
+    new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`${label} exceeded ${ms}ms`)), ms);
+    }),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const cleanup = createHarnessCleanup();
+  cleanup.installSignalHandlers();
+  let tearingDown = false;
+
+  if (ENGINES.length === 0) {
+    console.error(`HICASSO_TESTBED_ENGINES=${ONLY} selects no engine; ` +
+      `known: ${ALL_ENGINES.join(', ')}`);
+    return 1;
+  }
+
+  try {
+    const teeth = runMutationTeeth();
+    console.log(`> verdict logic teeth bit: ${teeth.length}`);
+
+    compile();
+    stageHtml();
+
+    const port = await resolveServePort(
+      Number(process.env.HICASSO_TESTBED_PORT) || DEFAULT_PORT,
+      { onFallback: (p, f) => console.log(`> port ${p} busy, serving on ${f}`) },
+    );
+    const httpServerBin = require.resolve('http-server/bin/http-server', { paths: [IMPL_ROOT] });
+    const server = await startLocalHttpServer({
+      cleanup,
+      httpServerBin,
+      root: ROOT,
+      port,
+      cwd: IMPL_ROOT,
+      readyTimeoutMs: READY_TIMEOUT_MS,
+      suppressExitDiagnostic: () => tearingDown,
+    });
+    if (!server.ready) {
+      console.error('the testbed server did not prove owned readiness');
+      return 1;
+    }
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    const recorded = {};
+    let failures = 0;
+    for (const engine of ENGINES) {
+      const { passed, result } = await driveEngine(engine, baseUrl);
+      if (!passed) failures += 1;
+      else recorded[engine] = result.recorded;
+    }
+    if (failures > 0) {
+      console.error(`\n${failures} of ${ENGINES.length} engine(s) failed.`);
+      return 1;
+    }
+
+    console.log('\n--- RECORDED conduct (measured, not required) ---');
+    for (const engine of ENGINES) {
+      console.log(`  [${engine}] ${JSON.stringify(recorded[engine])}`);
+    }
+    const problems = divergenceReport(recorded);
+    if (problems.length > 0) {
+      console.error('\nCROSS-ENGINE DIVERGENCE:');
+      for (const p of problems) console.error(`  - ${p}`);
+      return 1;
+    }
+    for (const n of NARROWINGS) {
+      console.log(`  narrowing: ${n.row} on ${n.engines.join('+')} — ${n.why}`);
+    }
+    console.log(`\nHICASSO CONTROLLED-INPUT PASS (${ENGINES.join(' + ')})`);
+    return 0;
+  } finally {
+    tearingDown = true;
+    await cleanup.cleanup();
+  }
+}
+
+module.exports = { divergenceReport, runMutationTeeth, belowFloor, NARROWINGS };
+
+if (require.main === module) {
+  main().then((code) => process.exit(code)).catch((error) => {
+    console.error(error.stack || String(error));
+    process.exit(1);
+  });
+}

--- a/implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs
+++ b/implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs
@@ -47,6 +47,84 @@
  * The comparator and the check floor both carry mutation teeth that run
  * before any browser launches: a gate whose own verdict logic cannot fail
  * is worse than a gate that is red.
+ *
+ * ## Coverage — what these witnesses reach, and what they do not
+ *
+ * I15's clauses, and where each is proven:
+ *
+ * | clause | witnessed | isolates THIS runtime? |
+ * |---|---|---|
+ * | converge within the edit turn | yes, read inside the dispatching task | no — see below |
+ * | echo only committed state | yes, DOM and store both read | no — see below |
+ * | rejection / normalisation echo the committed value | yes, one field per policy | no — see below |
+ * | caret preserved across the echo | yes, mid-string edits, dispatched AND real-keyboard | YES |
+ * | in-flight composition preserved | yes, on a REFUSING field, plus blur / non-composing / unmount releases | YES |
+ * | reset is an explicit revision | yes, structurally — removing the revision read leaves the draft in place | YES |
+ * | reset preserves element identity | yes, an expando survives the bump; a `:key` bump destroys it | YES |
+ * | owned slots win by presence, not truthiness | partly — `value: ""` and `checked: false` are both proven live | no |
+ * | a forwarded attribute cannot replace an owned one | NO — see below |
+ *
+ * ### Why only some rows isolate this runtime, and how that was established
+ *
+ * Measured, not assumed. Three deliberate regressions were driven through
+ * the whole matrix — the converge deferred a task (the UIx-port conduct),
+ * the caret restored to the end of the string (plain React's conduct), and
+ * `converge-to!` handed the pre-flush record (the stale-value trap the
+ * namespace docstring names) — and ALL THREE were caught by the CARET rows
+ * and by nothing else. The value rows stayed green under every one of them.
+ *
+ * The reason is React's own end-of-event restore. `updateInput` assigns
+ * `element.value` whenever the DOM disagrees with the committed value, in
+ * the same discrete event, so any value-level misconduct of the converge is
+ * corrected before the next line runs. What React cannot undo is the caret:
+ * its own restore assigns the value, and assigning moves the cursor to the
+ * end. So in a real browser the caret is the only observable that separates
+ * this runtime from the two it was built to beat — which is exactly why
+ * this gate is a browser gate, and why the caret rows edit in the MIDDLE of
+ * the string.
+ *
+ * The value rows are still worth their place: they are the invariant as
+ * stated, and their negative controls (an expectation flipped per row) all
+ * bite. They just do not, on their own, attribute the conduct.
+ *
+ * ### Out of reach here, and where it lives instead
+ *
+ * - **A real IME.** `Input.imeSetComposition` is CDP, so real composition
+ *   ranges are Chromium-only and stay with `bench/hicasso/ime_run.cjs`.
+ *   The abort SIGNATURE that harness detects — a value write killing an
+ *   exchange with no `compositionend` — cannot be reproduced from page
+ *   script in any engine, so it is not claimed here.
+ * - **Autofill.** No cross-engine drive exists (Chromium's needs CDP and a
+ *   profile). The spec records the two shapes it CAN drive — a fill that
+ *   dispatches an input event, and one that dispatches nothing — and names
+ *   them a proxy. The conformance matrix is hic-040's.
+ * - **Owned-vs-forwarded attribute merge.** There is no public merge
+ *   surface on the door today, so a testbed asserting it would be
+ *   measuring its own helper. The presence-not-truthiness HALF is proven
+ *   (a `value: ""` field is controlled and converges; a `checked: false`
+ *   box tracks its model); the forwarding half is not, and is not claimed.
+ *
+ * ### What the three engines actually said
+ *
+ * Nothing diverged. Every RECORDED row is byte-identical in Chromium,
+ * Firefox and WebKit, so `NARROWINGS` is empty and no per-control
+ * refusal policy is owed to the hic-005 table from this bead. Three
+ * conducts worth carrying forward, all three-engine unanimous:
+ *
+ *   1. An out-of-band model write lands on the NEXT TASK, not the same
+ *      one. A keystroke is inside its turn only because `converge!` buys
+ *      that with a `flushSync`; a button buys none, and a concurrent root
+ *      flushes its sync lane in a microtask.
+ *   2. A RANGE selection does not survive an out-of-band write: it
+ *      collapses to a caret at the end of the new value. That is
+ *      rf2-n3dxw's stated limit, now measured in three engines rather
+ *      than one, and it is React's restore doing it rather than this
+ *      runtime.
+ *   3. `form.reset()` is VISUALLY INERT on a converged field, because
+ *      `defaultValue` — the record `controlled/last-rendered` reads — is
+ *      already the model. The one ordinary browser action that touches
+ *      the converge's own bookkeeping agrees with it in all three
+ *      engines, which is a direct check on that dependency.
  */
 
 const fs = require('fs');

--- a/implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs
+++ b/implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs
@@ -184,10 +184,6 @@ const NARROWINGS = [
   // list is the honest starting state: nothing is excused in advance.
 ];
 
-function narrowingFor(row) {
-  return NARROWINGS.find((n) => n.row === row) || null;
-}
-
 /**
  * Compare the RECORDED rows across engines. Returns a list of problems —
  * empty when every row either agrees everywhere or is covered by a

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -157,6 +157,16 @@
                 ;; re-frame.hicasso.*.
                 "hicasso/src"
                 "hicasso/test"
+                ;; rf2-hic-016 — the controlled-input testbed. A standalone
+                ;; app under hicasso/testbed/ whose fields are the §4.2
+                ;; policy family (accept / refuse / normalise / reset), and
+                ;; the only surface the three-engine controlled-input gate
+                ;; drives. Source path here so the :hicasso/testbed build's
+                ;; init-fn resolves; the gate is
+                ;; scripts/serve-and-run-hicasso-controlled-testbed.cjs,
+                ;; which compiles, serves and drives it in Chromium,
+                ;; Firefox and WebKit.
+                "hicasso/testbed"
                 ;; The build-time reader for committed `spec/` data
                 ;; (day8/re-frame2-spec-resource). Both macros named under
                 ;; the `../spec` root below go through it, and it is on
@@ -2726,6 +2736,22 @@
    :asset-path "."
    :modules    {:main {:init-fn ui-testbed.core/init}}
    :devtools   {:preloads [re-frame2-pair.runtime]}}
+
+  ;; rf2-hic-016 — the Hicasso controlled-input testbed. NOT in the shared
+  ;; adapter-smoke manifest and deliberately so: that runner is one engine
+  ;; (Chromium) over N specs, and this surface's whole contract is the
+  ;; SAME spec over three engines. It therefore carries its own
+  ;; orchestrator, scripts/serve-and-run-hicasso-controlled-testbed.cjs —
+  ;; the reagent-slim / tenant-switcher precedent — which compiles this
+  ;; build, serves it, and drives Chromium, Firefox and WebKit in turn.
+  ;; No :dev-http entry: the gate serves from http-server on a resolved
+  ;; port like every other browser gate, and nothing here is a
+  ;; `shadow-cljs watch` surface.
+  :hicasso/testbed
+  {:target     :browser
+   :output-dir "out/hicasso-testbed"
+   :asset-path "."
+   :modules    {:main {:init-fn hicasso-testbed.core/init}}}
 
   ;; rf2-xsgu8a — per-adapter CLIENT-RUNTIME smoke for the day8/reagent-slim
   ;; substrate. Same minimal-counter shape as the Reagent/UIx

--- a/scripts/check_gate_scheduling.py
+++ b/scripts/check_gate_scheduling.py
@@ -243,8 +243,26 @@ DISPOSITIONS: dict[str, dict] = {
                "DOES yield a verdict, which is why that one is scheduled "
                "(freehand-bench.yml) and pinned into the local rigorous sweep",
     },
-    # NO DECLARED HOLES REMAIN (rf2-a9oic, closed out by rf2-v4o7e).  All four
-    # this checker found on arrival now have homes: `test:perf-bundle` went
+    "test:hicasso-controlled": {
+        "kind": "unscheduled",
+        "bead": "rf2-hic-016",
+        "why": "the Hicasso controlled-input gate — "
+               "scripts/serve-and-run-hicasso-controlled-testbed.cjs, driving "
+               "implementation/hicasso/testbed/spec.cjs across Chromium, Firefox "
+               "and WebKit. A real gate: a non-zero exit is a verdict about the "
+               "tree, so `not-a-gate` would be a lie and `covered-by` has nothing "
+               "true to point at (no other gate launches Firefox at all). It runs "
+               "nowhere yet because the PR that added it was fenced out of "
+               ".github/workflows/** — rf2-8a6s held that surface — so the job, "
+               "its classifier arm and the matching _changed-surfaces.test.cjs "
+               "rows are a separate change, sequenced after that bead. Declared "
+               "rather than silently unrun",
+    },
+    # ONE DECLARED HOLE REMAINS (`test:hicasso-controlled`, rf2-hic-016, above);
+    # it is a scheduling change deliberately deferred to a PR allowed to touch
+    # the workflows, not a gate without a home.
+    #
+    # The four this checker found on arrival all have homes: `test:perf-bundle` went
     # per-PR as `cljs-perf-bundle` (rf2-eegpw / #7530), `test:ui-warm-watch` +
     # `test:cljs-perf-emit-nightly` went into the nightly browser/bundle sweep,
     # and `test:schemas-bundle` went per-PR as `cljs-schemas-bundle`.  Their


### PR DESCRIPTION
Closes the browser half of the controlled-field law for `rf2-hic-016`: invariant **I15** driven against real Chromium, real Firefox and real WebKit, on a new testbed at `implementation/hicasso/testbed/`.

**55 checks per engine, all three green, and every RECORDED row is byte-identical across the three engines** — so `NARROWINGS` in the runner is empty and this bead owes the hic-005 table no per-control refusal policy. There was no browser-specific divergence to fix in `controlled.cljs` or to narrow.

## The finding that matters most

Three deliberate regressions were driven through the whole matrix — the converge deferred one task (the UIx-port conduct), the caret restored to the end of the string (plain React's conduct), and `converge-to!` handed the pre-flush record (the stale-value trap the namespace docstring names). **All three were caught by the CARET rows and by nothing else. The value rows stayed green under every one of them.**

The reason is React's own end-of-event restore. `updateInput` assigns `element.value` whenever the DOM disagrees with the committed value, inside the same discrete event — so any value-level misconduct of the converge is corrected before the next line runs. What React cannot undo is the caret: its own restore assigns the value, and assigning moves the cursor to the end.

**So in a real browser the caret is the only observable that separates this runtime from plain React.** That is why this is a browser gate rather than a unit test, and why every caret row edits in the *middle* of the string. A later reader who deletes the caret rows as "redundant with the value rows" would silently gut the suite: the value rows would stay green while the runtime regressed to React's conduct. The same paragraph is in the runner's `## Coverage` block so it cannot be lost with this PR description.

## I15 coverage — what is proven, and what is not

| I15 clause | witnessed | isolates this runtime? |
|---|---|---|
| converge within the edit turn | yes — read inside the dispatching task | no (React's restore also delivers it) |
| echo only committed state | yes — DOM and store both read | no |
| rejection / normalisation echo the committed value | yes — one field per policy | no |
| caret preserved across the echo | yes — mid-string edits, dispatched **and** real-keyboard | **yes** |
| in-flight composition preserved | yes — on a *refusing* field, plus blur / non-composing / unmount releases | **yes** |
| reset is an explicit revision | yes — structurally | **yes** |
| reset preserves element identity | yes — expando survives the bump | **yes** |
| owned slots win by presence, not truthiness | partly — `value: ""` and `checked: false` both proven live | no |
| a forwarded attribute cannot replace an owned one | **no** | — |

### Not covered, stated plainly

- **A real IME.** `Input.imeSetComposition` is CDP and CDP is Chromium's protocol, which is why `bench/hicasso/ime_run.cjs` scopes itself to Chromium. This gate needed the carve-out witnessed on WebKit and Firefox, so composition here is the event *sequence* a composition produces — `compositionstart`, `beforeinput`/`input` carrying `isComposing`, `compositionend` — dispatched at the real node, through real React, into the real shadow component. That reaches `composing-input?`'s reading of the native event, the shadow holding the draft, and React's restore finding nothing to write. It does **not** reach the browser's composition range, so the abort signature that harness detects (a value write killing an exchange with no `compositionend`) stays Chromium-only and is not claimed here.
- **Autofill.** No cross-engine drive exists. The two shapes that *can* be driven are recorded and named a proxy: a fill that dispatches an input event (indistinguishable from a keystroke) and one that dispatches nothing (leaves a draft the model never saw). Full matrix is hic-040.
- **Owned-vs-forwarded attribute merge.** There is no public merge surface on the door today, so a testbed asserting it would be measuring its own helper. The presence-not-truthiness *half* is proven; the forwarding half is not claimed.

Note on `value: ""`: it proves the field is controlled with a falsy owned value, but it cannot separate this runtime from React, because at `""` there is no caret to lose. Said so rather than letting the row imply more.

## Three unanimous cross-engine conducts, now recorded

1. An out-of-band model write lands on the **next task**, not the same one. A keystroke is inside its turn only because `converge!` buys that with a `flushSync`; a button buys none, and a concurrent root flushes its sync lane in a microtask.
2. A **range selection does not survive** an out-of-band write — it collapses to a caret at the end of the new value (`{start: 6, end: 6, direction: "forward"}`). That is rf2-n3dxw's stated limit, now measured in three engines rather than argued in one, and it is React's restore doing it rather than this runtime.
3. **`form.reset()` is visually inert** on a converged field, because `defaultValue` — the record `controlled/last-rendered` reads — already *is* the model. The one ordinary browser action that touches the converge's own bookkeeping agrees with it in all three engines, which is a direct check on that dependency.

## Negative controls — eleven, all bite

Nothing below is committed; each was applied, run, observed red, and reverted. Four are implementation regressions in `controlled.cljs`, two are structural changes to the testbed, five are expectation flips.

| # | control | scope | observed failure |
|---|---|---|---|
| 1 | **`composing-input?` → `false`** (the bead's required sabotage) | impl | `the first composing update survives in the field: expected "123あ", got "123"` — **red in WebKit**, and in Chromium and Firefox identically |
| 2 | caret restored to end of string | impl | `the caret sits after the digit just typed, not at the end: expected 4, got 6` — all three engines |
| 3 | `converge!` deferred one task | impl | same caret row, `expected 4, got 6` — all three engines |
| 4 | `converge-to!` handed the pre-flush record | impl | same caret row, `expected 4, got 6` — all three engines |
| 5 | revision read replaced by a constant | testbed (structural) | `the revision bump re-baselined the field to the model: expected "keep", got "drifted"` |
| 6 | `:key` derived from the revision (forces remount) | testbed (structural) | `the DOM node survived the reset — no remount: expected "M1", got undefined` |
| 7 | accepted-keystroke expectation flipped | expectation | `expected "abc", got "abcd"` |
| 8 | empty-owned-value expectation flipped | expectation | `expected "x", got ""` |
| 9 | compositionend-refusal expectation flipped | expectation | `expected "123あい", got "123"` |
| 10 | blur-release / no-stranded-draft expectations flipped | expectation | `expected "123あ", got "123"`; `expected "9あ", got "9"` |
| 11 | checked-pair and form-normalisation expectations flipped | expectation | `expected false, got true`; `expected "FORMx", got "FORMX"` |

Controls 2–4 are the evidence for the central finding above: three different regressions, one row catching all of them.

The gate also carries **six in-process mutation teeth** that run before any browser launches, so the divergence comparator and the check floor cannot themselves be vacuous (an unnarrowed divergence must raise; a narrowing naming the wrong engine must not excuse; the floor must refuse a short run).

## The exact `shadow-cljs.edn` edit

Two additions, nothing reordered, reformatted or tidied. **No `:dev-http` entry and no port were needed** — the gate serves from `http-server` on a resolved port like every other browser gate, so the hot-zone footprint is smaller than the brief allowed for.

A source path, immediately after the existing `"hicasso/test"`:

```clojure
"hicasso/testbed"
```

And a build id, modelled on `:ui-g8` (the other correctness gate) rather than on the adapter testbeds — hence no `:devtools` preload:

```clojure
:hicasso/testbed
{:target     :browser
 :output-dir "out/hicasso-testbed"
 :asset-path "."
 :modules    {:main {:init-fn hicasso-testbed.core/init}}}
```

Both carry a comment naming the bead and the gate.

## Browsers: local vs CI

| engine | run locally | in CI |
|---|---|---|
| Chromium | yes — 55 checks | not yet scheduled |
| Firefox | yes — 55 checks | not yet scheduled |
| WebKit | yes — 55 checks | not yet scheduled |

All three ran **locally, foreground, to completion**. Firefox had never been launched anywhere in this repo before; installing it required the pinned CLI (`node node_modules/playwright/cli.js install firefox`) — an `npx playwright install` resolves a newer Playwright, fetches the wrong revision, and prunes the pinned WebKit out of the shared cache. Worth knowing before the CI step is written.

**Nothing is scheduled in CI yet, and that is deliberate rather than overlooked.** This PR was fenced out of `.github/workflows/**` (held by `rf2-8a6s`), so the job, its classifier arm in `report-changed-surfaces.sh`, and the matching `_changed-surfaces.test.cjs` rows are a separate change. Rather than let the gate go silently unrun, `test:hicasso-controlled` is declared in `scripts/check_gate_scheduling.py` as a known hole with its bead:

```
"test:hicasso-controlled": {"kind": "unscheduled", "bead": "rf2-hic-016", ...}
```

`not-a-gate` would have been a lie (a non-zero exit is a verdict about the tree) and `covered-by` had nothing true to point at — no other gate in the repo launches Firefox at all. **A follow-up bead is owed for the CI wiring, sequenced after `rf2-8a6s` merges.**

## Quality gates

| gate | exit | notes |
|---|---|---|
| `npm run test:hicasso-controlled` (Chromium + Firefox + WebKit) | **0** | 55 checks per engine; 6 mutation teeth bit; no cross-engine divergence |
| `npm run lint:js` (ESLint, repo root) | **0** | re-run after the dead-code fix below |
| `sh scripts/test-fast-pr.sh` | **0** | full spine, run to completion; exit code read directly, not through a pipeline |
| `shadow-cljs compile hicasso/testbed` | **0** | 159 files, 0 warnings |
| `python implementation/hicasso/scripts/check_freeze.py` | **0** | 12 frozen rows match; no package file imports the bench tree |
| `python scripts/check_gate_scheduling.py` | **0** | 41 gate commands, 34 scheduled, 7 declared |

ESLint initially red on this PR: `'narrowingFor' is defined but never used`. It was a lookup helper for the narrowing table — and since **nothing diverged across the three engines**, `NARROWINGS` is empty and the helper had nothing to look up. `divergenceReport` already does its own lookup inline. Deleted rather than silenced with a disable comment: an unused narrowing helper is speculative machinery for a case that does not exist. Green after the fix, and the three-engine gate re-run at exit **0**, 55 checks per engine, unchanged.

Worth recording for the next bead: `lint:js` lives in the **repo-root** `package.json`, not `implementation/`, and needs the root `node_modules`. It is not in the gate list this bead was dispatched with, which is how a first-`.cjs` PR reached CI red.

## Scope

Touched: `implementation/hicasso/testbed/**` (new), `implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs` (new), `implementation/shadow-cljs.edn` (two additions), `implementation/package.json` (one script), `scripts/check_gate_scheduling.py` (one disposition).

Not touched: `implementation/hicasso/src/**` (rf2-hic-009 owns the module split in flight — the four implementation negative controls were applied locally and reverted, and appear in no commit), `implementation/hicasso/resources/clj-kondo.exports/**`, `.github/workflows/**`, the frozen bench tree. No public name renamed.

The bead names `controlled.cljs` as part of this surface; the dispatch brief fenced it off. Moot in the event, since nothing diverged and no fix was owed — but flagging it, because had an engine diverged the two would have been in direct conflict.

