### PR TITLE
docs(hicasso): teach the Reagent [:>] codemod (rf2-2rtt6.112)

### DIFF
--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -445,19 +445,143 @@ which is the composition intended — but a `:render` return still crosses
 unconverted, so today the subtree has to be written where children lower
 ([Not settled yet](#not-settled-yet)).
 
+### The codemod
+
+Arriving from Reagent is the direction that needs a tool. Your `[:> …]` sites
+already work — `[:>]` is legal here — but Reagent *converted* their props on the
+way across and Hicasso does not, so a site can keep rendering while quietly
+meaning something else. The codemod repairs that dialect in place, wherever the
+repair is decidable from the source text.
+
+```bash
+cd migration/reagent-to-hicasso/codemod
+
+clojure -M:run src/                     # scan: report only, touch nothing
+clojure -M:run --rewrite src/           # dry run: what would change
+clojure -M:run --rewrite --write src/   # apply it
+clojure -M:run --report out.edn src/    # choose where the report goes
+```
+
+Files or directories in, `.cljs` and `.cljc`; a rewritten tree and one EDN
+report out (`reagent-to-hicasso-report.edn` by default). It writes whole files
+through rewrite-clj, so formatting, comments and line endings all survive — a
+CRLF file comes back CRLF. Exit is `0` for any run that completed and `1` only
+when a file could not be read or written, because a migration tool that fails
+your build over a decision only you can make is a tool you run once.
+
+**Scan first, read the report, then rewrite.** Both passes address the *input*
+file, so a coordinate in the report is the one you grep for either way. And
+every output is outside its own rewrite's input language, so a second run
+changes nothing — asserted byte for byte, in both line-ending conventions.
+
+#### What it rewrites
+
+| | At | Written | Preserving |
+|---|---|---|---|
+| W1 | `^{:key k}` on the vector | `:key k` inside the props map | Reagent read the metadata key *after* converting props, so it beat a props `:key`. Hicasso reads `(:key props)` and never looks at metadata, so left alone the key goes dead |
+| W2 | a literal map reached from the props map through map values | the same map, its literal keys respelled | Reagent camelCased *nested* keys ([No deep conversion](#defaults)); Hicasso does not. Top-level prop names need nothing — both sides camelCase those |
+| W3 | a keyword, or a **quoted** symbol, at a prop value | its `name`, as a string | Reagent's `(name x)` arm. A namespaced keyword loses its namespace here, exactly as it already did |
+| W4 | `(r/partial f a …)` at a prop value | a `let` capture, then Reagent's own wrapper | Reagent's `ifn?` wrapper — its return *and* its evaluation time |
+| W5 | `[(r/adapt-react-class X) …]` | `[:> X …]` | The same `native-element` path, spelled the way Hicasso accepts. Left alone it is a head Hicasso refuses |
+| W6 | `[:> "tag" …]` with a plain tag string | `[:tag …]` | Reagent's controlled-input wrapper becomes [Hicasso's controlled door](04-controlled-inputs.md) |
+
+**A bare symbol is never a named value.** `handler` in `{:on-click handler}` is a
+variable reference, and reading it as a symbol value would replace a live
+handler with the string `"handler"`. Only a literal keyword and a quoted symbol
+reach W3; anything arriving through a symbol is reported instead of guessed at.
+
+**W4's `let` is the part to read twice**, because the obvious rewrite is wrong.
+`r/partial` evaluated its callee and every argument **once**, when the prop was
+built. A bare `(fn [& args] (apply f a … args))` re-evaluates them on each call,
+so `@snapshot` stops being a snapshot and `(next-id!)` mints a fresh id per
+click:
+
+```clojure
+[:> Btn {:on-pick (r/partial handler @cart)}]
+;; =>
+[:> Btn {:on-pick (let [f__rf2 handler a0__rf2 @cart]
+                    (fn [& args__rf2] (apply f__rf2 a0__rf2 args__rf2)))}]
+```
+
+Self-evaluating arguments are inlined rather than bound. The names are
+deterministic rather than gensym'd, so what lands in your diff is a name you can
+read — and they are checked against every symbol the site spells, so if one
+would collide the whole family bumps together (`f__rf2__1`, `a0__rf2__1`,
+`args__rf2__1`) until it is fresh. `let` binds sequentially, so a shadowed
+binding would otherwise reach every later initializer in the same form.
+
+#### What it refuses
+
+**Silent behaviour change is the only fatal class.** Everything the tool cannot
+rewrite behaviour-preservingly is *reported* rather than guessed at. `[:>]` is
+legal, so leaving a site exactly as written is a valid outcome — a refused site
+still works, and the report is what turns the refusal from silence into an
+instruction. **The report is as much the product as the rewrite is.** It is
+written on a clean run too and carries the count of sites left untouched, so
+*not in the report* is never ambiguous.
+
+Refusals come in three kinds, and the kind tells you how urgent the line is.
+
+| Kind | Classes | What it means |
+|---|---|---|
+| Undecidable from the source text | `:computed-props`, `:computed-value`, `:computed-nested-key`, `:adapt-def-site`, `:cljc-site`, `:parse-error` | The tool cannot see what crosses. A computed value may be a keyword, a nested map, or an `r/partial` reached through a symbol, and each of those diverges differently |
+| Decidable, but the rewrite would itself change behaviour | `:event-carrier-goes-live`, `:key-conflict`, `:string-tag-unparseable`, `:normalized-key-collision`, `:css-var-repair`, `:named-ref`, `:amp-key` | Several are places Reagent was already broken and the move *repairs* them. Check that the behaviour you are about to start getting is the one you want |
+| Decidable, and Hicasso refuses at runtime | `:intent-needs-a-declaration`, `:dangerous-html`, `:r>-site`, `:f>-site`, `:as-element-island`, `:reagent-api-residue` | Migration blockers. These need a person before the page runs |
+
+Three are worth knowing before you read your first report.
+
+**An intent vector at a `[:>]` prop is a blocker.** It is the one thing Hicasso
+refuses that Reagent accepted ([Every prop is unclaimed](#every-prop-is-unclaimed)),
+and the site throws at render. Know first that it never fired under Reagent
+either — it crossed as an inert array — so what the site needs is a decision
+about what it was for: a `defhost` naming that prop in `:callbacks`, or a plain
+function.
+
+**Colliding nested keys refuse the whole map.** Reagent wrote `:foo-bar` and
+`:fooBar` to the same JS property, with an iteration-order winner. Respelling
+both would mint a duplicate map key or silently pick a winner the tool cannot
+know was the one that won, so W2 stands down for that map — including the keys
+in it that *were* rewritable, because a partial rewrite of an already-ambiguous
+map is worse than none — and the report names every colliding source key. Delete
+the one you did not mean and re-run.
+
+**The `:key` slot is reported, never rewritten.** Reagent converted a key like
+any other prop, so sibling `:foo` and `"foo"` keys collided; Hicasso lifts the
+key raw and they are distinct. Rewriting would restore that defect, so the tool
+leaves the slot alone — and says what leaving it costs, because the key
+*changes* at the migration, and React reconciles a changed key by unmounting the
+subtree and mounting a fresh one, discarding its state. One-time, and stable
+after.
+
+The report also lists candidate callback slots as a **suggestions** block, and
+it is labelled as guesses because that is what it is: Fluent's `onRenderCell`
+and Ant's `onRow` are event-*spelled* render props whose *return value* the
+caller reads, so declaring one as an `:event` would blank your cell renderer
+with nothing thrown. You choose the contract. The tool never synthesizes a
+`:callbacks` map and there is no flag to make it.
+
+Full reference, including every refusal class and the corpus that pins them:
+[`migration/reagent-to-hicasso/codemod/`](../../../../migration/reagent-to-hicasso/codemod/README.md).
+
 ### Migrating off it
 
 A hand migration from Reagent is three moves per namespace: collect `[:> X …]`,
 emit `defhost`, rewrite call sites. `[:> X props]` → `(defhost x X {})` is
 behaviour-preserving by construction, because the escape's prop walk *is* the
 door's with an empty roster — whatever is ruled at the door, the escape does the
-same thing. A codemod is planned and not built.
+same thing.
+
+**That hoist is by hand.** The codemod mints no declaration, hoists nothing and
+edits no `ns` form: it repairs the sites you have and leaves them `[:>]`.
+Building the hoist is demand-gated — it happens when a migrator reports the
+hand-written declarations as the pain, rather than the crossings themselves.
 
 ## Troubleshooting
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | Prop arrives as `on-change` and the library ignores it | Nested keys expected camelCase; deep conversion is not offered | Convert the nested map yourself before it crosses |
+| A prop that worked under Reagent behaves differently after the move | Reagent converted prop values and nested keys on the way across; Hicasso does not, so the site renders and quietly means something else | Run [the codemod](#the-codemod) — it repairs the decidable cases and reports the rest |
 | The library ignored a keyword prop value | A keyword crosses a host prop unchanged; only HTML-attribute names stringify | Write the string at the call site — `"compact"`, or `(name :compact)` |
 | Hiccup passed *in a prop* renders as its own tag name and text | Only children lower; a prop value crosses as data, so `[:h2 "Tasks"]` arrives as the array `["h2" "Tasks"]` — silently, with no error | Pass the subtree as a child where the library takes one; at a prop there is nothing to reach for yet |
 | React refuses an object as a child, from a `:render` body | The body returned hiccup; a `:render` return crosses unconverted | Return a string, or keep the subtree on the Hicasso side of the crossing |
@@ -589,7 +713,7 @@ path. Nothing in the reserved vector will rescue that later.
 | Turning hiccup into an element at a prop or a `:render` return | **Open, and a real gap.** The mechanism exists inside the codec; nothing on the taught `h/` roster reaches it, so today the answer is to write the subtree where children lower — or to write it twice |
 | Declarable conversion defaults on `defhost` | Open — `:callbacks` and `:ssr` are the two options today |
 | A provider whose *value* is client-only | Open, and named rather than solved. `:ssr :render` renders the component server-side, but the value it carries is computed in the caller's body — so a `window`-derived value has no server story and the host stays `:client-only` |
-| Migration codemod | Planned, unbuilt |
+| Migration codemod | The dialect **fixer** is built — [The codemod](#the-codemod). The `defhost` **hoist** is demand-gated and unbuilt: it gets written when the hand-written declarations are what a migrator reports as the pain |
 | When `{:ref [id config]}` lands, and what registers an id | Reserved, not designed |
 | Which React version the product pins | Not pinned by the product; cleanup-returning refs need React 19; this repo currently pins 19.2 |
 | Embedding Hicasso inside a React-primary app | Named as a use case; no API designed |


### PR DESCRIPTION
Guide 05-interop said the Reagent `[:>]` migration codemod was "planned, unbuilt" in two places. It landed as `rf2-2rtt6.143` (PR #7746, `8e379e2375`) at `migration/reagent-to-hicasso/codemod/`, so both claims were false. This teaches what actually shipped.

Bead: `rf2-2rtt6.112`.

## What I documented, and where

One file: `docs/design/hicasso/draft-guide/05-interop.md` (+126 / -2).

**New `### The codemod`**, placed under `## The escape: [:>]` and *before* `### Migrating off it` — arriving from Reagent comes before leaving `[:>]`:

- **Invocation.** The four CLI shapes (scan / `--rewrite` dry run / `--rewrite --write` / `--report`), files-or-directories in for `.cljs` and `.cljc`, a rewritten tree plus one EDN report out, the default report path, and the exit-code contract (`0` for any run that completed, `1` only on read/write failure).
- **What it rewrites.** W1-W6 in a 4-column table, each row naming the Reagent behaviour being preserved; the bare-symbol rule; and a worked W4 example with the collision bump.
- **What it refuses.** The governing principle first — silent behaviour change is the only fatal class, `[:>]` is legal so leaving a site alone is a valid outcome, a refused site still works — then the three refusal kinds with their full class lists, then the three a migrator meets first (the intent-vector blocker, the nested-key collision, the `:key` slot).
- **Idempotence**, stated where it is useful (right after "scan first, then rewrite") rather than as a bullet.
- **The report is as much the product as the rewrite is** — written on a clean run, carrying the left-alone count, so *not in the report* is never ambiguous.

**`### Migrating off it`** keeps the three-move hand hoist unchanged and gains one paragraph: the codemod mints no declaration, hoists nothing, edits no `ns` form, and the hoist is *demand-gated* rather than pending.

**`## Not settled yet`** — the `Migration codemod` row now splits fixer (built, linked) from hoist (demand-gated, unbuilt) instead of saying "Planned, unbuilt".

**`## Troubleshooting`** — one new row routing "a prop that worked under Reagent behaves differently after the move" to the tool.

## Re-scoped to the fixer, per the bead

The bead's own note of 2026-08-09 14:20 says this bead **as written documents the HOISTER, not the fixer** ("the declare-what-you-use-twice `defhost` hoist with dedupe"), that the hoist is demand-gated and may never become writable, and that "whoever takes this bead must re-scope it to the fixer and state in the PR body that the hoist remains unbuilt and demand-gated". I did that. The bead governs over the dispatch brief; here they agreed.

The bead's line references (`:164`, `:286`) are stale — the page has grown since. The two "planned, unbuilt" strings were at `:454` and `:592`.

## How I verified each behavioural claim

I read the shipped source and the golden corpus rather than the design record, because the design was amended three times and the corpus is the spec.

| Claim | Verified against |
|---|---|
| CLI shapes, flags, default report path | `codemod.clj` `-main` / `usage` (`src/re_frame/migration/hicasso/codemod.clj:310-339`) |
| Paths accept files or directories, `.cljs` + `.cljc` | `source-file?` / `expand-paths`, same file |
| Exit `0` completed / `1` unreadable-or-unwritable | `-main`'s `System/exit` on any `:parse-error`; `run-file` wraps both `slurp` and `spit` in the `try` |
| Scan and rewrite report the same coordinates | Two-pass design: `analyse` walks a position-tracked zipper over the pristine tree, `transform` walks it as nodes; both call `rewrite/plan-site` |
| W1-W6 behaviour and what each preserves | Every `test/corpus/w*/` triple (`input` / `expected` / `expected-report.edn`), read in full |
| W4 generated names are `f__rf2` / `a0__rf2` / `args__rf2`, callee always bound, self-evaluating args inlined | `corpus/w4-partial-capture/expected.cljs`, all four sites |
| W4 family-wide collision bump to `__1`, `__2` | `test/.../amendment_a_test.clj` (the corpus is generation 0 only; the bump is asserted by execution there) |
| W2 refuses a colliding map **whole**, including its rewritable keys, and names every colliding source key | `corpus/w2-normalized-key-collisions/` — input and expected are byte-identical at the four colliding sites; `:detail {:path … :collisions [{:slot … :keys […]}]}` |
| Top-level prop names are never respelled by W2 | `corpus/w2-nested-map-keys/expected.cljs` — only keys *inside* nested maps change |
| `:key` slot reported, never rewritten, and a changed key discards React state | `corpus/w3-named-values/expected-report.edn` line 37 — the corpus's only `:action :skipped`, and the only place the unmount/remount cost is stated |
| The three refusal kinds and their exact class membership | `report.clj`'s `class-order`, which groups them into 5.3 / 5.2 / 5.1 |
| Report written on a clean run; left-alone count | `corpus/preserved-and-clean/expected-report.edn` (six untouched sites, one entry) and `report/build`'s `:sites-left-alone` |
| Suggestions labelled as guesses; Fluent/Ant counter-example; no synthesis flag | `report.clj` `suggestion-caution` |
| CRLF preserved; majority rule; no newline invented | `crlf-source?` / `with-newlines-of` in `codemod.clj`, and all eight assertions in `newlines_test.clj` |
| Idempotence in **both** conventions | `newlines_test.clj` `a-second-run-is-a-no-op-in-both-conventions`, plus the corpus's own idempotence assertion |

## What the design record has that the shipped tool does not

**The hoister.** `docs/design/hicasso/studio/reagent-codemod-against-the-landed-escape.md` section 8 puts hoister-vs-fixer to the operator; only the fixer was built, and the hoist is demand-gated by the same ratification. I avoided implying it is coming by:

- never using future tense for it — the new text says the hoist "is by hand", not "is not yet automated";
- stating the gate itself ("it happens when a migrator reports the hand-written declarations as the pain") so a reader knows it is conditional, not scheduled;
- making the `Not settled yet` row name both halves separately rather than leaving one "codemod" entry a reader would read as one tool;
- keeping `### Migrating off it`'s hand recipe intact, since that recipe *is* the hoist and is still the answer.

Also deliberately not documented: `:action` / `:class` / `:detail` as a report **schema**. The corpus pins it byte-for-byte, so publishing it in the guide would make a prose page a second spec for a surface that already has one.

## Two observations about the tool — not fixed here, per the brief

Neither is touched by this PR (I did not edit the codemod, its README, or its corpus).

1. **The suggestions block emits a contract keyword the guide does not teach.** `report.clj`'s `defhost-sketch` writes `(str s " :fn")`, producing `{:callbacks {:on-pick :fn}}`. The three taught contracts are `:event`, `:handler` and `:render`; `:fn` is not one of them and appears nowhere else in the guide or the freehand witnesses. A migrator pasting the sketch would be refused at mint. I documented the suggestions block honestly — candidate slots, labelled guesses, *you* choose the contract — without quoting the sketch. Worth a follow-up bead.
2. **`docs/design/hicasso/authoring.md:304`** still describes the codemod as "collect `[:> X …]` sites, emit the defhost block, rewrite call sites", which is the hoist. That is an authoring record rather than user documentation and is outside this bead's named scope, so I left it; flagging it as stale.

## `migration/from-re-frame-v1/README.md` — checked, and my recommendation is no line yet

The bead asks me to check whether it should mention the codemod, notes it is HOT-ZONE, and says to report rather than batch. **I did not edit it.**

It mentions Hicasso **zero** times (`grep -c` returns 0). It is the v1-to-v2 *core API* migration guide — event registrars, coeffects, interceptors, frames — on a different axis from the view layer. Hicasso is still EXPERIMENTAL with no `implementation/hicasso/` package, and this guide page carries a **Draft** banner with `[unfrozen]` names. Pointing the v1 guide at a tool for a substrate that has not shipped would date faster than it helps.

The natural home when it does land is a `migration/reagent-to-hicasso/README.md` index (that directory currently holds only `codemod/`) — a separate bead, not this one. Mayor's call either way.

## Digest-pinned code blocks: not involved

`samples_coverage_jvm_test.clj` pins fenced blocks under `docs/core/freehand/` only — `(def ^:private guide-dir "docs/core/freehand")`. This file is `docs/design/hicasso/draft-guide/`, so the two fenced blocks I added (one `bash`, one `clojure`) are **not** digest-pinned and this stays a one-file change.

## Quality gates

`mkdocs build --strict` is **not** the gate for this file and was not run: `mkdocs.yml`'s `exclude_docs` lists `design/hicasso/`, so the whole tree is outside the site build. `scripts/check_doc_slugs.py` is what validates it, and it does — proven below, not assumed.

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** (`1 files, 0 cited pins`) |
| Sabotage control: same slug gate, one anchor deliberately broken | **1** |

Each gate was run alone, in the foreground, with its exit code captured to its own file — no filter appended to a gate's command line.

**Sabotage control.** A clean `check_doc_slugs.py` run prints nothing at all, so exit 0 alone does not prove the file was inspected. I changed `[The codemod](#the-codemod)` to a non-existent anchor and re-ran: exit **1**, output `BROKEN ANCHOR: docs\design\hicasso\draft-guide\05-interop.md:716 -> #the-codemod-DELIBERATELY-BROKEN`. Restored, re-ran, exit **0**. The gate reads this file and resolves the anchors I added.

**Hand-verified, since nothing validates tables or rendering under the `docs/design` tree:**

- **Table column counts.** Every table in the file parsed with a pipe-counter that ignores pipes inside backticks: 8 tables, **0 ragged**. The two I added are 4 cols x 6 body rows (W1-W6) and 3 cols x 3 body rows (refusal kinds); Troubleshooting went 15 to 16 body rows at 3 cols; `Not settled yet` unchanged at 2 cols x 7 rows, one cell edited.
- **Every link target.** `#the-codemod`, `#defaults`, `#every-prop-is-unclaimed` and `#not-settled-yet` resolve (the slug gate covers these). `04-controlled-inputs.md` exists. The out-of-`docs/` reference `../../../../migration/reagent-to-hicasso/codemod/README.md` resolves to the real file — verified by `ls` through the literal relative path, since four levels up from `draft-guide/` is the repo root.
- **Table-annotation convention.** The `*(N columns; N body rows.)*` footnote is a `studio/` convention; no `draft-guide/` page uses it, so I hand-counted instead of introducing it here.
