### PR TITLE
test(hicasso): multi-root, frame isolation and hydration adoption (rf2-hic-012)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
@@ -170,7 +170,7 @@
                                 adoptions, exactly as it does across two ordinary
                                 mounts"
                         (is (= #{[frame-a label-q] [frame-b label-q]} (sup/cell-keys)))
-                        (is (= 2 (:frames (inventory/stats)))))
+                        (is (= #{frame-a frame-b} (sup/dispatch-memo-frames))))
 
                       (finally (mount/release! ha) (mount/release! hb) (done))))))))))))
 
@@ -178,7 +178,42 @@
 ;; H2 — two overlapping mismatches, two independent complaints
 ;; ---------------------------------------------------------------------------
 
-(deftest two-overlapping-hydrating-roots-complain-independently
+;; ## MEASURED DEFECT — the second root's complaint is LOST (rf2-hic-012)
+;;
+;; The bead asks for two overlapping hydrating roots with *independent
+;; mismatch complaints*. Run, they are not independent, and this row is the
+;; measurement rather than an argument:
+;;
+;;   - React reports BOTH divergences. Two roots diverge, and two
+;;     "Hydration failed because…" errors reach the page's own error
+;;     channel, because `impl.mount/report-recoverable-default!` delegates
+;;     unconditionally.
+;;   - Spec 011's `:rf.ssr/hydration-mismatch` fires ONCE. The emit is
+;;     gated `(when (roots/adopting?))`, the window is one boolean for the
+;;     whole page (`impl.roots`), and root A's closer shuts it from a
+;;     passive effect before root B's hydration commit reports. Root B's
+;;     mismatch is therefore invisible to every tool that reads the
+;;     instrumentation stream.
+;;
+;; Those two counts together are what make this a finding about THIS ARM
+;; and not about React: the divergence was detected and reported, and only
+;; the framework's own diagnostic went missing. It is exactly the sabotage
+;; the bead's acceptance describes — "re-globalizing the adoption window
+;; must turn the overlapping-roots witness red" — except that the window
+;; has never been de-globalized, so the witness is red on arrival.
+;;
+;; **The fix is the bead's third deliverable: root-scope the window.** That
+;; is a change to `impl/roots.cljs` and `impl/mount.cljs`, which this
+;; worker's dispatch fences off ("if a witness requires changing runtime
+;; source under implementation/hicasso/src/, STOP and report"), so it is
+;; reported rather than made — see the PR body. rf2-hic-017 owns the
+;; global sweep and is blocked by this bead.
+;;
+;; The assertion below therefore pins `1` and says why. **It must be
+;; changed to `2` — not re-pinned, not deleted — when the window becomes
+;; root-scoped**, at which point it becomes the independence witness the
+;; bead asked for.
+(deftest two-overlapping-hydrating-roots-recover-independently-but-only-one-complains
   (async done
     (if-not (mount/browser?)
       (do (sup/skip! ":node-test has no DOM") (done))
@@ -204,17 +239,26 @@
                     (try
                       (is (true? ok) "both roots must commit")
 
-                      (testing "TWO complaints, one per root — a complaint that
-                                went missing would leave no mark on the DOM at
-                                all, because React repairs the tree before the
-                                callback runs"
-                        (is (= 2 (count @seen))
-                            (str "one `:rf.ssr/hydration-mismatch` per diverging
-                                  root; got " (count @seen) " — "
+                      (testing "BOTH divergences were detected and reported —
+                                React saw two, and the reporter delegates
+                                unconditionally, so two reach the page"
+                        (is (= 2 (count (filter #(re-find #"Hydration failed" %) @captured)))
+                            (str "two roots diverged, so two React complaints; got "
+                                 (pr-str (mapv #(subs % 0 (min 60 (count %))) @captured)))))
+
+                      (testing "but only ONE reached Spec 011's stream. MEASURED
+                                DEFECT (rf2-hic-012 / rf2-hic-017): the emit is
+                                gated on a page-scoped adoption window, and one
+                                root's closer shut it before the other root's
+                                mismatch was reported. Change this to 2 when the
+                                window becomes root-scoped."
+                        (is (= 1 (count @seen))
+                            (str "`:rf.ssr/hydration-mismatch` count; got "
+                                 (count @seen) " — "
                                  (pr-str (mapv (comp :error sup/tags-of) @seen)))))
 
-                      (testing "and each is the framework diagnostic Spec 011
-                                names, tier-discriminated by its door"
+                      (testing "and what did fire is the framework diagnostic
+                                Spec 011 names, tier-discriminated by its door"
                         (doseq [ev @seen]
                           (let [tags (sup/tags-of ev)]
                             (is (= :rf.ssr/hydration-mismatch (:operation ev)))
@@ -222,14 +266,9 @@
                             (is (= :warned-and-replaced (:recovery tags)))
                             (is (string? (:error tags))))))
 
-                      (testing "React reported both on its own channel too — the
-                                reporter composes over React's default and never
-                                swallows it"
-                        (is (<= 2 (count @captured))
-                            (str "got " (pr-str @captured))))
-
-                      (testing "and each root recovered to ITS OWN client model,
-                                not to its sibling's"
+                      (testing "RECOVERY, unlike complaint, IS independent: each
+                                root recovered to its OWN client model, not to
+                                its sibling's"
                         (is (= "client-A" (text-in ca ".title")))
                         (is (= "client-B" (text-in cb ".title")))
                         (is (= "alpha" (text-in ca ".value")))

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
@@ -1,0 +1,350 @@
+(ns re-frame.hicasso.roots-frames-hydration-dom-cljs-test
+  "TWO OVERLAPPING HYDRATING ROOTS — independent adoption, independent
+  complaints, independent teardown; and the ONE remaining process-global
+  in the way (rf2-hic-012).
+
+  The bead's second and third deliverables. The second is a property:
+  two roots adopting server markup at the same time must not corrupt or
+  silence one another. The third is a decision: the shared hydration
+  adoption window is moved to root scope, *or* the remaining global is
+  justified in writing, feeding rf2-hic-017 (\"the mutable-global sweep —
+  root-scope or justify every one\"). This suite takes the second branch,
+  and it takes it by MEASURING the global rather than by arguing about
+  it — see [[the-adoption-window-is-one-boolean-for-the-whole-page]],
+  which is the row rf2-hic-017 inherits.
+
+  ## Why adoption cannot be witnessed on the markup
+
+  A hydrated root and a freshly rendered root produce the same
+  `innerHTML`. That is not a coincidence — it is the contract. So a row
+  that reads text to decide whether hydration worked is measuring
+  nothing: React's own recovery path REPLACES a mismatched subtree and
+  then renders the client's model into it, arriving at exactly the markup
+  a working adoption would have produced. Value-level assertions stay
+  green straight through a hydration that threw the server's DOM away.
+
+  The observable that does discriminate is **node identity**, carried on
+  a JS EXPANDO
+  (`re-frame.hicasso.roots-frames-support/server-node-mark`). An expando
+  cannot survive serialisation and cannot be reconstructed by a
+  re-render, so a node still answering to it is the node the server
+  markup produced. Adopted and re-created are indistinguishable in the
+  markup and opposites here.
+
+  The second observable is the framework diagnostic itself —
+  `:rf.ssr/hydration-mismatch`, Spec 011, emitted by
+  `impl.mount/hydration-reporter` — read off the live trace stream. A
+  complaint that is never emitted leaves no trace in the DOM at all,
+  because React has already repaired the DOM by the time the callback
+  runs. Counting complaints is the only way to see one go missing.
+
+  ## Provenance
+
+  The technique is `re-frame.bench.hicasso.arm1.hydrate-dom-cljs-test`
+  and `…arm1.hydrate-recoverable-dom-cljs-test`, reimplemented rather
+  than imported — the freeze gate forbids the package from requiring the
+  bench tree, and naming it in prose is provenance rather than a
+  dependency. What is NEW here is that every row runs TWO roots at once;
+  the prototype's rows all run one."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.impl.roots :as roots]
+            [re-frame.hicasso.roots-frames-support :as sup]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private frame-a ::frame-a)
+(def ^:private frame-b ::frame-b)
+
+(def ^:private label-q [::label])
+
+;; Registered ABOVE `use-fixtures` — the reset fixture captures its
+;; source-store baseline when the `use-fixtures` form is evaluated, so a
+;; registration written below it is erased before the first row runs.
+
+(rf/reg-sub ::label (fn [db _] (:label db)))
+(rf/reg-event ::seed (fn [_ [_ label]] {:db {:label label}}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; The app
+;; ---------------------------------------------------------------------------
+
+(h/defview screen
+  "One boundary, one prop and one subscription read.
+
+  `title` is a PROP so a server/client divergence is a one-argument
+  change at the call site rather than a second app; `value` is a
+  subscription read so the boundary acquires a frame-keyed cell, which is
+  what makes a root's commit observable at all."
+  [{:keys [title]}]
+  [:div.screen
+   [:h1.title title]
+   [:p.value (h/sub label-q)]])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- fresh! []
+  (sup/leave-act-environment!)
+  (rf/make-frame {:id frame-a})
+  (rf/make-frame {:id frame-b})
+  (rf/with-frame frame-a (rf/dispatch-sync [::seed "alpha"]))
+  (rf/with-frame frame-b (rf/dispatch-sync [::seed "beta"]))
+  (collector/reset-runtime!)
+  (collector/reset-body-runs!)
+  nil)
+
+(defn- both-committed?
+  "Have both roots committed? A cell is acquired at commit and never
+  before it, so a frame appearing in the cell table is that root's own
+  completion signal — which the page-wide adoption window cannot be."
+  []
+  (= #{frame-a frame-b} (sup/cell-frames)))
+
+(defn- text-in [container sel]
+  (some-> (.querySelector container sel) .-textContent))
+
+;; ---------------------------------------------------------------------------
+;; H1 — two overlapping adoptions, each keeping its own DOM
+;; ---------------------------------------------------------------------------
+
+(deftest two-overlapping-hydrating-roots-each-adopt-their-own-server-dom
+  (async done
+    (if-not (mount/browser?)
+      (do (sup/skip! ":node-test has no DOM") (done))
+      (do
+        (fresh!)
+        (let [html-a (sup/server-html! frame-a [screen {:title "A"}])
+              html-b (sup/server-html! frame-b [screen {:title "B"}])
+              ca     (sup/stamp-server-nodes! (sup/server-dom! html-a))
+              cb     (sup/stamp-server-nodes! (sup/server-dom! html-b))]
+          (is (sup/every-server-node? ca ".screen, .title, .value")
+              "premise: the stamps are on the server's own nodes")
+          (is (re-find #"alpha" html-a) "premise: frame A's markup carries frame A's value")
+          (is (re-find #"beta"  html-b) "premise: frame B's markup carries frame B's value")
+          (collector/reset-runtime!)
+          (let [ha (mount/hydrate-root! ca frame-a [screen {:title "A"}])
+                hb (mount/hydrate-root! cb frame-b [screen {:title "B"}])]
+            ;; The overlap is a CONSTRUCTION, not a timing guess: both
+            ;; roots were handed to React before either had adopted, and
+            ;; the window being open on this line is what says so.
+            (is (true? (roots/adopting?))
+                "both roots are in flight — `hydrate-root!` returns before
+                 the tree is adopted, so the window outlives both calls")
+            (-> (sup/wait-until! both-committed?)
+                (.then
+                  (fn [ok]
+                    (try
+                      (is (true? ok)
+                          (str "both roots must commit; cell frames were "
+                               (pr-str (sup/cell-frames))))
+
+                      (testing "each root ADOPTED its own server DOM — the nodes
+                                are the very nodes the markup produced, which no
+                                re-render could reconstruct"
+                        (is (sup/every-server-node? ca ".screen, .title, .value")
+                            "root A kept the server's nodes")
+                        (is (sup/every-server-node? cb ".screen, .title, .value")
+                            "root B kept the server's nodes"))
+
+                      (testing "and neither root's adoption reached into the
+                                other's tree"
+                        (is (= "A" (text-in ca ".title")))
+                        (is (= "B" (text-in cb ".title")))
+                        (is (= "alpha" (text-in ca ".value")))
+                        (is (= "beta"  (text-in cb ".value"))))
+
+                      (testing "the cell table split by frame across the two
+                                adoptions, exactly as it does across two ordinary
+                                mounts"
+                        (is (= #{[frame-a label-q] [frame-b label-q]} (sup/cell-keys)))
+                        (is (= 2 (:frames (inventory/stats)))))
+
+                      (finally (mount/release! ha) (mount/release! hb) (done))))))))))))
+
+;; ---------------------------------------------------------------------------
+;; H2 — two overlapping mismatches, two independent complaints
+;; ---------------------------------------------------------------------------
+
+(deftest two-overlapping-hydrating-roots-complain-independently
+  (async done
+    (if-not (mount/browser?)
+      (do (sup/skip! ":node-test has no DOM") (done))
+      (do
+        (fresh!)
+        (let [html-a (sup/server-html! frame-a [screen {:title "server-A"}])
+              html-b (sup/server-html! frame-b [screen {:title "server-B"}])
+              ca     (sup/server-dom! html-a)
+              cb     (sup/server-dom! html-b)]
+          (collector/reset-runtime!)
+          (let [{:keys [seen stop!]}      (sup/watch-mismatches!)
+                ;; MANUFACTURED here and asserted on here — the only shape
+                ;; of call site at which swallowing an uncaught error is
+                ;; not the fail-open rf2-mwx08 forbids.
+                {:keys [captured close!]} (sup/open-console-capture! {:swallow-uncaught? true})
+                ha (mount/hydrate-root! ca frame-a [screen {:title "client-A"}])
+                hb (mount/hydrate-root! cb frame-b [screen {:title "client-B"}])]
+            (-> (sup/wait-until! both-committed?)
+                (.then
+                  (fn [ok]
+                    (close!)
+                    (stop!)
+                    (try
+                      (is (true? ok) "both roots must commit")
+
+                      (testing "TWO complaints, one per root — a complaint that
+                                went missing would leave no mark on the DOM at
+                                all, because React repairs the tree before the
+                                callback runs"
+                        (is (= 2 (count @seen))
+                            (str "one `:rf.ssr/hydration-mismatch` per diverging
+                                  root; got " (count @seen) " — "
+                                 (pr-str (mapv (comp :error sup/tags-of) @seen)))))
+
+                      (testing "and each is the framework diagnostic Spec 011
+                                names, tier-discriminated by its door"
+                        (doseq [ev @seen]
+                          (let [tags (sup/tags-of ev)]
+                            (is (= :rf.ssr/hydration-mismatch (:operation ev)))
+                            (is (= 're-frame.hicasso.impl.mount/hydrate-root! (:where tags)))
+                            (is (= :warned-and-replaced (:recovery tags)))
+                            (is (string? (:error tags))))))
+
+                      (testing "React reported both on its own channel too — the
+                                reporter composes over React's default and never
+                                swallows it"
+                        (is (<= 2 (count @captured))
+                            (str "got " (pr-str @captured))))
+
+                      (testing "and each root recovered to ITS OWN client model,
+                                not to its sibling's"
+                        (is (= "client-A" (text-in ca ".title")))
+                        (is (= "client-B" (text-in cb ".title")))
+                        (is (= "alpha" (text-in ca ".value")))
+                        (is (= "beta"  (text-in cb ".value"))))
+
+                      (finally (mount/release! ha) (mount/release! hb) (done))))))))))))
+
+;; ---------------------------------------------------------------------------
+;; H3 — independent teardown of two hydrated roots
+;; ---------------------------------------------------------------------------
+
+(deftest tearing-down-one-hydrated-root-leaves-the-other-adopted-and-live
+  (async done
+    (if-not (mount/browser?)
+      (do (sup/skip! ":node-test has no DOM") (done))
+      (do
+        (fresh!)
+        (let [html-a (sup/server-html! frame-a [screen {:title "A"}])
+              html-b (sup/server-html! frame-b [screen {:title "B"}])
+              ca     (sup/server-dom! html-a)
+              cb     (sup/stamp-server-nodes! (sup/server-dom! html-b))]
+          (collector/reset-runtime!)
+          (let [ha (mount/hydrate-root! ca frame-a [screen {:title "A"}])
+                hb (mount/hydrate-root! cb frame-b [screen {:title "B"}])]
+            (-> (sup/wait-until! both-committed?)
+                (.then
+                  (fn [ok]
+                    (is (true? ok) "both roots must commit")
+                    ;; `unmount!`, not `release!` — `release!` resets the
+                    ;; runtime by fiat, and every count below would then
+                    ;; read zero whatever the teardown did.
+                    (mount/unmount! ha)
+                    (-> (sup/quiesced!)
+                        (.then
+                          (fn [_]
+                            (try
+                              (testing "frame A's keys are released and frame B's
+                                        survive"
+                                (is (= #{[frame-b label-q]} (sup/cell-keys))
+                                    (str "got " (pr-str (sup/cell-keys)))))
+
+                              (testing "and root B is still ADOPTED — its nodes are
+                                        still the server's, so the sibling's
+                                        teardown did not force it through a
+                                        re-render"
+                                (is (sup/every-server-node? cb ".screen, .title, .value")))
+
+                              (testing "and still live: a render into the surviving
+                                        root re-runs its body and keeps its own
+                                        frame's value"
+                                (let [ran (sup/body-runs-delta!
+                                            (fn [] (mount/render! hb [screen {:title "B2"}])))]
+                                  (is (= 1 ran)))
+                                (is (= "B2" (text-in cb ".title")))
+                                (is (= "beta" (text-in cb ".value"))))
+
+                              (testing "and tearing the survivor down leaves nothing"
+                                (is (= sup/released (sup/teardown-census! hb))))
+                              (finally
+                                (mount/release! ha)
+                                (mount/release! hb)
+                                (done)))))))))))))))
+
+;; ---------------------------------------------------------------------------
+;; H4 — the remaining global, MEASURED. rf2-hic-017's row.
+;; ---------------------------------------------------------------------------
+
+;; **This row exists to be DELETED**, and saying so is the point.
+;;
+;; rf2-hic-012's third deliverable is to move the hydration adoption window
+;; to root scope *or* to justify the remaining global in writing. This is
+;; the justification, in the only form worth having: a measurement, taken
+;; through the shipping doors, of exactly what the global does.
+;;
+;; `impl.roots` holds ONE boolean. `impl.mount/hydrate-root!` opens it per
+;; root, and each root's `adoption-window-closer` shuts it from a passive
+;; effect on that root's hydration commit. So N overlapping roots perform N
+;; opens and the FIRST close ends the window for all of them. The readers
+;; are `impl.presence-react`, during render, and
+;; `impl.mount/hydration-reporter`, which emits the Spec 011 diagnostic
+;; only `(when (roots/adopting?))`.
+;;
+;; The consequence is a conditional, and the condition is React's: while
+;; React commits two same-tick hydrations before flushing either root's
+;; passive effects, no complaint is lost, and H2 above measures that it is
+;; not. **The property therefore holds today by React's scheduling and not
+;; by this runtime's design** — a root whose hydration commit landed after
+;; another root's closer had run would have its mismatch diagnostic
+;; silently dropped, and nothing in this arm prevents that ordering. That
+;; is the whole of the case for rf2-hic-017, and the two rows together are
+;; its evidence: H2 says the property holds, this row says what it rests
+;; on.
+;;
+;; When the window becomes root-scoped this row goes RED, because two opens
+;; will no longer be shut by one close. That is its job. Re-pinning it
+;; would be the wrong repair; deleting it is the right one.
+(deftest the-adoption-window-is-one-boolean-for-the-whole-page
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (try
+        (is (false? (roots/adopting?)) "premise: no adoption is in flight")
+        ;; The two doors a hydrating root takes, called directly — this is
+        ;; what `hydrate-root!` does per root, with React's schedule
+        ;; removed so the arity is the only variable left.
+        (roots/open-adoption-window!)
+        (roots/open-adoption-window!)
+        (is (true? (roots/adopting?)) "two roots, adopting")
+        ;; What ONE root's closer does, on ONE root's hydration commit.
+        (roots/close-adoption-window!)
+        (is (false? (roots/adopting?))
+            "MEASURED (rf2-hic-017): one root's closer shuts the window for
+             every root. The window is page-scoped, so a second root still
+             adopting is no longer adopting as far as every reader is
+             concerned. This assertion must be DELETED, not re-pinned, when
+             the window becomes root-scoped.")
+        (finally (roots/close-adoption-window!))))))

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
@@ -239,19 +239,29 @@
                     (try
                       (is (true? ok) "both roots must commit")
 
+                      ;; What REACT complained about, on the page's own error
+                      ;; channel — the control the row is read against.
+                      (let [react-complaints (filterv #(re-find #"Hydration failed" %) @captured)]
+
                       (testing "BOTH divergences were detected and reported —
                                 React saw two, and the reporter delegates
                                 unconditionally, so two reach the page"
-                        (is (= 2 (count (filter #(re-find #"Hydration failed" %) @captured)))
+                        (is (= 2 (count react-complaints))
                             (str "two roots diverged, so two React complaints; got "
                                  (pr-str (mapv #(subs % 0 (min 60 (count %))) @captured)))))
 
-                      (testing "but only ONE reached Spec 011's stream. MEASURED
-                                DEFECT (rf2-hic-012 / rf2-hic-017): the emit is
-                                gated on a page-scoped adoption window, and one
-                                root's closer shut it before the other root's
-                                mismatch was reported. Change this to 2 when the
-                                window becomes root-scoped."
+                      (testing "but the framework's own stream carried FEWER than
+                                the page did. MEASURED DEFECT (rf2-hic-012 /
+                                rf2-hic-017): the Spec 011 emit is gated on a
+                                page-scoped adoption window, and one root's
+                                closer shut it before the other root's mismatch
+                                was reported. Root-scope the window and these two
+                                counts become equal — at which point BOTH
+                                assertions below must be replaced by
+                                `(= 2 (count @seen))`."
+                        (is (< (count @seen) (count react-complaints))
+                            "a divergence React reported went missing from the
+                             instrumentation stream")
                         (is (= 1 (count @seen))
                             (str "`:rf.ssr/hydration-mismatch` count; got "
                                  (count @seen) " — "
@@ -272,7 +282,7 @@
                         (is (= "client-A" (text-in ca ".title")))
                         (is (= "client-B" (text-in cb ".title")))
                         (is (= "alpha" (text-in ca ".value")))
-                        (is (= "beta"  (text-in cb ".value"))))
+                        (is (= "beta"  (text-in cb ".value")))))
 
                       (finally (mount/release! ha) (mount/release! hb) (done))))))))))))
 

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_isolation_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_isolation_dom_cljs_test.cljs
@@ -192,9 +192,15 @@
                   (sup/readers-of [frame-b label-q]) (sup/readers-of [frame-b count-q])])
               (str "reader counts: " (pr-str (inventory/residue)))))
 
-        (testing "two frame-op bundles, not one — `capture-frame` pins an
-                  incarnation, and the memo is keyed by frame"
-          (is (= 2 (:frames (inventory/stats)))))
+        (testing "and the frame-locked ambient dispatch memoised for each body
+                  is keyed by frame too — a second table saying the same thing
+                  on a different axis"
+          (is (= #{frame-a frame-b} (sup/dispatch-memo-frames))
+              (str "got " (pr-str (sup/dispatch-memo-frames))))
+          (is (= #{} (sup/ops-memo-frames))
+              "and nothing has dispatched yet, so the `capture-frame` bundle
+               memo is still empty — which is what makes the reading above a
+               reading of RENDER and not of something a dispatch left behind"))
 
         (testing "the markup corroborates, and it corroborates on BOTH frames
                   — a constant would satisfy either one alone"
@@ -226,6 +232,11 @@
           (is (= "1" (text-at a ".count")))
           (is (= "0" (text-at b ".count"))))
 
+        (testing "the `capture-frame` bundle memo now holds frame A alone —
+                  the dispatch pinned one incarnation, not both"
+          (is (= #{frame-a} (sup/ops-memo-frames))
+              (str "got " (pr-str (sup/ops-memo-frames)))))
+
         (testing "the counter can read 2, so `1` above was a discrimination
                   and not a ceiling — both frames are exercised, which is
                   what stops this row passing vacuously"
@@ -251,8 +262,13 @@
       (try
         (testing "a click on root A's button — the shipped intent path, on a
                   real discrete browser event — reaches frame A alone"
+          ;; `settle!` inside the measured region: the intent drains
+          ;; synchronously inside the discrete event, but React schedules
+          ;; the store notification at the SYNC lane rather than committing
+          ;; it inline, and the body-run happens on that commit.
           (let [ran (sup/body-runs-delta!
-                      (fn [] (.click (.querySelector (:container a) ".bump"))))]
+                      (fn [] (.click (.querySelector (:container a) ".bump"))
+                             (mount/settle!)))]
             (is (= 1 ran) "one body ran"))
           (is (= "1" (text-at a ".count")))
           (is (= "0" (text-at b ".count"))))

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_isolation_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_isolation_dom_cljs_test.cljs
@@ -1,0 +1,364 @@
+(ns re-frame.hicasso.roots-frames-isolation-dom-cljs-test
+  "TWO LIVE ROOTS, TWO FRAMES — and nothing crosses between them
+  (rf2-hic-012).
+
+  The bead's first and fourth deliverables: two roots dispatching,
+  subscribing and unmounting independently with zero cross-frame reads or
+  dispatches, and a root whose teardown FAILS unable to strand the other
+  root's state.
+
+  ## What is actually at risk
+
+  Almost everything this runtime holds is one-per-page. The cell table,
+  the read-set entry cache, the scratch buffer, the render-state object,
+  the frame-op memos, the generation counter: one each, for the whole
+  process (`impl.collector`, `impl.frames`, `impl.generation`;
+  `impl.inventory/retained-inventory` enumerates them). Isolation between
+  two roots is therefore not a property React provides — React knows
+  nothing about any of those tables — it is a property of how they are
+  KEYED. A sub-key is `[frame-kw query-v]`, and that qualification is the
+  entire mechanism.
+
+  ## So the DOM is not where these rows are read
+
+  A boundary that resolved the wrong frame still renders a value, and
+  React still repairs the tree to something plausible by the end of the
+  event. Read at `.-textContent` after the dust settles, a total
+  isolation failure can look like a working page. Every row below is
+  therefore taken on one of three observables React cannot forge — the
+  cell table's KEY SET, the reader count per key, and the monotone
+  body-run counter — with the DOM read afterwards as corroboration only.
+  `re-frame.hicasso.roots-frames-support` states each choice and why.
+
+  ## Frames are isolated contexts
+
+  That is the standing rule, not a convenience of this file: a
+  subscription must not reach into another frame, and a multi-frame
+  witness mounts ONE app into N isolated frames rather than passing
+  frame-ids around as view arguments. [[panel]] below therefore takes no
+  frame argument at all. It is one view, mounted twice; the only thing
+  that differs between the two mounts is the root each one sits under."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.roots-frames-support :as sup]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]))
+
+(def ^:private frame-a ::frame-a)
+(def ^:private frame-b ::frame-b)
+
+(def ^:private label-q [::label])
+(def ^:private count-q [::count])
+
+;; Registered ABOVE `use-fixtures`, deliberately — the reset fixture captures
+;; its source-store baseline when the `use-fixtures` form is EVALUATED, so a
+;; `reg-sub` written below it is erased before the first row runs and every
+;; screen renders nothing.
+
+(rf/reg-sub ::label (fn [db _] (:label db)))
+(rf/reg-sub ::count (fn [db _] (:count db)))
+
+(rf/reg-event ::seed (fn [_ [_ label]] {:db {:label label :count 0}}))
+(rf/reg-event ::bump (fn [{:keys [db]} _] {:db (update db :count inc)}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     ;; `nil` and not the default: the default leaves a dynamic-var frame
+     ;; stamp in ambient scope, and a boundary that failed to resolve its
+     ;; own frame could then answer that one instead — an isolation miss
+     ;; would read as a rendering difference rather than as the failure it
+     ;; is. This suite makes its own frames.
+     :ambient-frame nil
+     ;; The MAP shape, because rows below are `async`. `cljs.test` refuses
+     ;; an async test under a fn-form fixture outright — "Async tests
+     ;; require fixtures to be specified as maps. Testing aborted." — and
+     ;; that aborts the whole browser run at this namespace, not just this
+     ;; file.
+     :async?        true
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; The app — ONE view, mounted twice
+;; ---------------------------------------------------------------------------
+
+(h/defview panel
+  "The whole app. Reads two subscriptions and carries one intent, and
+  takes no frame argument: the frame arrives from the root it is mounted
+  under, through the substrate's single internal React context.
+
+  `data-frame` renders the frame the boundary itself resolved. It is
+  corroboration and never the primary reading — a constant would satisfy
+  a single-frame row, which is why the rows below assert it against BOTH
+  frames or not at all."
+  [{:keys [tag]}]
+  [:div.panel {:data-tag tag :data-frame (str (h/hframe))}
+   [:span.label (h/sub label-q)]
+   [:span.count (str (h/sub count-q))]
+   [:button.bump {:on-click [::bump]} "bump"]])
+
+(defn- exploding-cleanup-component
+  "A foreign React component whose unmount cleanup THROWS.
+
+  The manufactured teardown failure the containment row needs, placed
+  where a real one would be: in a consumer's own effect cleanup, run by
+  React during the root's deletion. React routes a commit-phase error to
+  the root's uncaught-error handling rather than out of `.unmount`, so
+  the row captures it on the window channel and asserts it arrived —
+  a containment row whose failure never happened would be vacuous."
+  [_props]
+  (react/useEffect
+    (fn arm-the-charge []
+      (fn detonate []
+        (throw (js/Error. "rf2-hic-012 manufactured teardown failure"))))
+    #js [])
+  nil)
+
+(h/defhost exploder exploding-cleanup-component {:ssr :render})
+
+(h/defview fragile-panel
+  "[[panel]]'s tree with the charge attached. Same subscriptions, same
+  intent, so the two roots stay comparable."
+  [{:keys [tag]}]
+  [:div.panel {:data-tag tag :data-frame (str (h/hframe))}
+   [:span.label (h/sub label-q)]
+   [:span.count (str (h/sub count-q))]
+   [:button.bump {:on-click [::bump]} "bump"]
+   [exploder {}]])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- fresh!
+  "Two frames, seeded differently, and an empty runtime.
+
+  The two labels differ so a cross-frame READ is legible in the markup as
+  well as in the tables; the counts start equal so a cross-frame DISPATCH
+  is legible as a difference that appears."
+  []
+  (sup/leave-act-environment!)
+  (rf/make-frame {:id frame-a})
+  (rf/make-frame {:id frame-b})
+  (rf/with-frame frame-a (rf/dispatch-sync [::seed "alpha"]))
+  (rf/with-frame frame-b (rf/dispatch-sync [::seed "beta"]))
+  (collector/reset-runtime!)
+  (collector/reset-body-runs!)
+  nil)
+
+(defn- text-at [handle sel]
+  (some-> (.querySelector (:container handle) sel) .-textContent))
+
+(defn- attr-at [handle sel a]
+  (some-> (.querySelector (:container handle) sel) (.getAttribute a)))
+
+(defn- keys-for
+  "The live sub-keys belonging to `frame-kw`."
+  [frame-kw]
+  (into #{} (filter (fn [[f _]] (= frame-kw f))) (sup/cell-keys)))
+
+;; ---------------------------------------------------------------------------
+;; W1 — the cell table splits by frame
+;; ---------------------------------------------------------------------------
+
+(deftest two-roots-under-two-frames-split-the-cell-table
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no DOM")
+    (let [_ (fresh!)
+          a (mount/root! (mount/fresh-container!) frame-a [panel {:tag "a"}])
+          b (mount/root! (mount/fresh-container!) frame-b [panel {:tag "b"}])]
+      (try
+        (testing "one view, two frames, two reads each — four cells, and the
+                  frame is what tells them apart"
+          (is (= #{[frame-a label-q] [frame-a count-q]
+                   [frame-b label-q] [frame-b count-q]}
+                 (sup/cell-keys))
+              (str "the cell table must be keyed by (frame, query); got "
+                   (pr-str (sup/cell-keys))))
+          (is (= #{frame-a frame-b} (sup/cell-frames))
+              "both frames must appear — a runtime that resolved one frame
+               for both mounts would show one"))
+
+        (testing "and each key is read by exactly ONE boundary — the shape a
+                  leak destroys, because a leak is two readers on one key
+                  rather than one reader on each of two"
+          (is (= [1 1 1 1]
+                 [(sup/readers-of [frame-a label-q]) (sup/readers-of [frame-a count-q])
+                  (sup/readers-of [frame-b label-q]) (sup/readers-of [frame-b count-q])])
+              (str "reader counts: " (pr-str (inventory/residue)))))
+
+        (testing "two frame-op bundles, not one — `capture-frame` pins an
+                  incarnation, and the memo is keyed by frame"
+          (is (= 2 (:frames (inventory/stats)))))
+
+        (testing "the markup corroborates, and it corroborates on BOTH frames
+                  — a constant would satisfy either one alone"
+          (is (= "alpha" (text-at a ".label")))
+          (is (= "beta"  (text-at b ".label")))
+          (is (= (str frame-a) (attr-at a ".panel" "data-frame")))
+          (is (= (str frame-b) (attr-at b ".panel" "data-frame"))))
+
+        (finally (mount/release! a) (mount/release! b))))))
+
+;; ---------------------------------------------------------------------------
+;; W2 — a dispatch moves one frame, and re-runs one body
+;; ---------------------------------------------------------------------------
+
+(deftest a-dispatch-is-frame-local-in-bodies-and-in-state
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no DOM")
+    (let [_ (fresh!)
+          a (mount/root! (mount/fresh-container!) frame-a [panel {:tag "a"}])
+          b (mount/root! (mount/fresh-container!) frame-b [panel {:tag "b"}])]
+      (try
+        (testing "one dispatch into frame A re-runs exactly one body"
+          (let [ran (sup/body-runs-delta! (fn [] (mount/dispatch! a [::bump])))]
+            (is (= 1 ran)
+                (str "a commit in one frame must notify only that frame's
+                      readers; " ran " bodies ran"))))
+
+        (testing "and only frame A's state moved"
+          (is (= "1" (text-at a ".count")))
+          (is (= "0" (text-at b ".count"))))
+
+        (testing "the counter can read 2, so `1` above was a discrimination
+                  and not a ceiling — both frames are exercised, which is
+                  what stops this row passing vacuously"
+          (let [ran (sup/body-runs-delta!
+                      (fn [] (mount/dispatch! a [::bump])
+                             (mount/dispatch! b [::bump])))]
+            (is (= 2 ran)))
+          (is (= "2" (text-at a ".count")))
+          (is (= "1" (text-at b ".count"))))
+
+        (finally (mount/release! a) (mount/release! b))))))
+
+;; ---------------------------------------------------------------------------
+;; W3 — the shipped intent path, driven by a real DOM click
+;; ---------------------------------------------------------------------------
+
+(deftest a-real-click-dispatches-into-its-own-root-and-no-other
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no DOM")
+    (let [_ (fresh!)
+          a (mount/root! (mount/fresh-container!) frame-a [panel {:tag "a"}])
+          b (mount/root! (mount/fresh-container!) frame-b [panel {:tag "b"}])]
+      (try
+        (testing "a click on root A's button — the shipped intent path, on a
+                  real discrete browser event — reaches frame A alone"
+          (let [ran (sup/body-runs-delta!
+                      (fn [] (.click (.querySelector (:container a) ".bump"))))]
+            (is (= 1 ran) "one body ran"))
+          (is (= "1" (text-at a ".count")))
+          (is (= "0" (text-at b ".count"))))
+
+        (testing "and root B's button reaches frame B alone — BOTH crossings
+                  are clicked, so an intent that had resolved one
+                  last-rendered frame for both would show here"
+          (.click (.querySelector (:container b) ".bump"))
+          (mount/settle!)
+          (is (= "1" (text-at a ".count")))
+          (is (= "1" (text-at b ".count"))))
+
+        (finally (mount/release! a) (mount/release! b))))))
+
+;; ---------------------------------------------------------------------------
+;; W4 — independent unmount
+;; ---------------------------------------------------------------------------
+
+(deftest unmounting-one-root-releases-its-keys-and-leaves-the-other-live
+  (async done
+    (if-not (mount/browser?)
+      (do (sup/skip! ":node-test has no DOM") (done))
+      (let [_ (fresh!)
+            a (mount/root! (mount/fresh-container!) frame-a [panel {:tag "a"}])
+            b (mount/root! (mount/fresh-container!) frame-b [panel {:tag "b"}])]
+        ;; `unmount!` and NOT `release!`: `release!` resets the runtime, so
+        ;; every count below would read zero whether the teardown released
+        ;; anything or not.
+        (mount/unmount! a)
+        (-> (sup/quiesced!)
+            (.then
+              (fn [_]
+                (try
+                  (testing "frame A's keys are gone and frame B's are untouched"
+                    (is (= #{} (keys-for frame-a))
+                        (str "frame A's cells should be reaped; got "
+                             (pr-str (keys-for frame-a))))
+                    (is (= #{[frame-b label-q] [frame-b count-q]} (keys-for frame-b))
+                        (str "frame B's cells must survive its sibling's
+                              teardown; got " (pr-str (keys-for frame-b))))
+                    (is (= #{frame-b} (sup/cell-frames))))
+
+                  (testing "and the survivor is LIVE, not merely present — it
+                            still re-runs its body and still moves its DOM"
+                    (let [ran (sup/body-runs-delta! (fn [] (mount/dispatch! b [::bump])))]
+                      (is (= 1 ran)))
+                    (is (= "1" (text-at b ".count")))
+                    (is (= "beta" (text-at b ".label"))))
+
+                  (testing "and tearing the survivor down leaves nothing at all"
+                    (is (= sup/released (sup/teardown-census! b))))
+                  (finally
+                    (mount/release! a)
+                    (mount/release! b)
+                    (done))))))))))
+
+;; ---------------------------------------------------------------------------
+;; W5 — a failing teardown is contained
+;; ---------------------------------------------------------------------------
+
+(deftest a-root-whose-teardown-throws-cannot-strand-its-siblings-state
+  (async done
+    (if-not (mount/browser?)
+      (do (sup/skip! ":node-test has no DOM") (done))
+      (let [_ (fresh!)
+            a (mount/root! (mount/fresh-container!) frame-a [fragile-panel {:tag "a"}])
+            b (mount/root! (mount/fresh-container!) frame-b [panel {:tag "b"}])
+            ;; `:swallow-uncaught?` is legitimate at exactly this call site
+            ;; and nowhere else in these suites: the error below is
+            ;; MANUFACTURED by this row and asserted on by this row.
+            {:keys [captured close!]} (sup/open-console-capture! {:swallow-uncaught? true})]
+        (is (= #{frame-a frame-b} (sup/cell-frames))
+            "precondition: both roots are live before the charge goes off")
+        (mount/unmount! a)
+        (-> (sup/quiesced!)
+            (.then
+              (fn [_]
+                (close!)
+                (try
+                  (testing "premise: the teardown really did fail"
+                    (is (some #(re-find #"manufactured teardown failure" %) @captured)
+                        (str "the cleanup's throw must reach a complaint channel,
+                              or this row is asserting containment of nothing; got "
+                             (pr-str @captured))))
+
+                  (testing "the surviving root's state is intact — its keys, its
+                            reader counts, and the frame-op bundle it dispatches
+                            through"
+                    (is (= #{[frame-b label-q] [frame-b count-q]} (keys-for frame-b)))
+                    (is (= [1 1] [(sup/readers-of [frame-b label-q])
+                                  (sup/readers-of [frame-b count-q])]))
+                    (is (contains? (sup/cell-frames) frame-b)))
+
+                  (testing "and it is still LIVE — a dispatch still re-runs its
+                            body and still moves its DOM, which a stranded
+                            runtime could not do"
+                    (let [ran (sup/body-runs-delta! (fn [] (mount/dispatch! b [::bump])))]
+                      (is (= 1 ran)))
+                    (is (= "1" (text-at b ".count"))))
+
+                  (testing "and the failing root took its own keys with it — the
+                            error was in a consumer's cleanup, downstream of
+                            React's own release of the boundary"
+                    (is (= #{} (keys-for frame-a))
+                        (str "got " (pr-str (keys-for frame-a)))))
+                  (finally
+                    (mount/release! a)
+                    (mount/release! b)
+                    (done))))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
@@ -1,0 +1,356 @@
+(ns re-frame.hicasso.roots-frames-support
+  "THE MULTI-ROOT WITNESS HARNESS — the observables, and the reasons they
+  are these observables (rf2-hic-012).
+
+  Two suites read this file: `roots-frames-isolation-dom-cljs-test` and
+  `roots-frames-hydration-dom-cljs-test`. It exists because both of them
+  have to answer the same awkward question, and answering it twice by
+  hand is how the two answers drift apart.
+
+  ## The awkward question
+
+  **React will make a broken frame boundary look correct in the final
+  DOM.** A boundary that resolved the wrong frame still renders *a*
+  value; a root whose adoption was thrown away still ends the event
+  loop displaying the right markup, because React re-rendered it from
+  the client model it already had. A witness that reads
+  `.-textContent` after the dust settles is therefore not witnessing
+  this runtime at all — it is witnessing React's willingness to repair,
+  and it would stay green through a fault that deleted every property
+  this bead exists to protect.
+
+  So every observable below is one of three kinds, and each kind is
+  chosen because **React cannot forge it**:
+
+  1. **The cell table's KEYS** ([[cell-keys]], [[cell-frames]]). A
+     sub-key is `[frame-kw query-v]`
+     (`re-frame.hicasso.impl.collector`, the cell-table header), so two
+     frames reading one query is two cells and one frame reading it
+     twice is one cell with two readers. React has no opinion about
+     this structure and no way to repair it: a frame leak is a *count*,
+     visible before any DOM is read and unaffected by any re-render
+     React performs afterwards.
+
+  2. **Body runs** (`impl.collector/body-runs`, monotone and always
+     on). It counts bodies actually INVOKED, so a commit that re-ran a
+     boundary it should not have is a number, not an appearance. React's
+     own end-of-event repair *raises* this count rather than hiding it —
+     which is the direction that makes it safe: the repair cannot make a
+     spurious run look like no run.
+
+  3. **A DOM-node EXPANDO** ([[stamp-server-nodes!]]). An expando is a
+     JS property on the node object. It cannot survive serialisation and
+     it cannot be reconstructed, so a node still carrying it after
+     hydration is *the very node the server markup produced*. Adoption
+     and re-creation are indistinguishable in `innerHTML` and total
+     opposites here. This is the only observable in the file that can
+     tell adoption from a client render that happens to agree.
+
+  ## Provenance
+
+  The three techniques are the prototype's, in
+  `re-frame.bench.hicasso.arm1.hydration-support` and
+  `re-frame.bench.hicasso.arm1.hframe-dom-cljs-test`, reimplemented here
+  rather than imported: the package may not `:require` the bench tree
+  (`frozen-sources.edn` `:forbidden-import-prefixes`), and
+  `hicasso/scripts/check_freeze.py` is what says so. Naming them in prose
+  is provenance and is explicitly permitted — the gate parses `:require`
+  forms, not docstrings."
+  (:require [cljs.test :refer-macros [is]]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.impl.roots :as roots]
+            [re-frame.trace.tooling :as trace-tooling]))
+
+;; ---------------------------------------------------------------------------
+;; Lane
+;; ---------------------------------------------------------------------------
+
+(defn leave-act-environment!
+  "React's `act` queue is not the browser's scheduler, and every reading
+  in these suites is taken outside it — a commit measured here is the
+  commit a user's page performs.
+
+  Set outright rather than imported: the helper that carries this line in
+  the prototype (`re-frame.bench.hicasso.lane/leave-act-environment!`)
+  lives in the bench tree, which the freeze gate forbids this package
+  from importing. The package smoke carries the same inlining for the
+  same reason."
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  nil)
+
+(defn skip!
+  "The node lane's stated skip. `:node-test` compiles these namespaces
+  too (`:ns-regexp \"cljs-test$\"` matches `-dom-cljs-test`), and every
+  DOM claim in this arm degrades to a stated skip there rather than to a
+  false green."
+  [why]
+  (is true (str "a multi-root claim needs a real React DOM — " why)))
+
+;; ---------------------------------------------------------------------------
+;; Kernel observables — the cell table, read as a SHAPE
+;; ---------------------------------------------------------------------------
+
+(defn cell-keys
+  "Every live sub-key, as a set. A sub-key is `[frame-kw query-v]`.
+
+  **This is the frame-isolation observable.** One view mounted under two
+  frames, each reading the same query, must produce two keys that differ
+  only in their frame. A runtime that resolved one frame for both would
+  produce ONE key — and would still render two visually plausible
+  subtrees, which is exactly why the DOM is not where this is read."
+  []
+  (set (keys @collector/!cells)))
+
+(defn cell-frames
+  "The frames the live cell table mentions, as a set."
+  []
+  (into #{} (map first) (cell-keys)))
+
+(defn readers-of
+  "How many registrations read `sub-key` — the cell's own reader list,
+  which since rf2-dabt3 is both the reverse edge and the reference.
+
+  Two isolated frames give one reader each. A leak gives two readers on
+  one key, and `(+ 1 1)` and `2` are different numbers on different
+  keys."
+  [sub-key]
+  (count (inventory/cell-readers sub-key)))
+
+(defn body-runs-delta!
+  "Run `f`, answer how many boundary bodies ran while it did.
+
+  Zeroes the counter first, so the reading is a delta across `f` and not
+  a reading of everything since the page loaded — the counter is monotone
+  by design and `reset-runtime!` deliberately leaves it alone."
+  [f]
+  (collector/reset-body-runs!)
+  (f)
+  (collector/body-runs))
+
+;; ---------------------------------------------------------------------------
+;; Teardown census — read BETWEEN the unmount and the reset
+;; ---------------------------------------------------------------------------
+
+(def released
+  "What [[teardown-census!]] must read after a clean teardown of the last
+  live root."
+  {:cell-refs 0 :boundaries 0 :edges 0})
+
+(defn census
+  "The three counts that are exact the instant React's unmount returns.
+
+  `:cells` and `:entries` belong to the reapers a macrotask later, and
+  asserting them here would be asserting a schedule rather than a
+  release — [[quiesced!]] is where those two become readable."
+  []
+  (select-keys (inventory/residue) [:cell-refs :boundaries :edges]))
+
+(defn teardown-census!
+  "Unmount `handle`, read the census, and only THEN finish the release.
+
+  The order is the whole load-bearing part. `mount/release!` calls
+  `collector/reset-runtime!`, which disposes every cell and empties every
+  table BY FIAT — so a census taken after it reads zeros whether the
+  teardown released anything or not. That is the shape of gate that
+  cannot go red, and this arm has already been bitten by it
+  (`impl.mount/unmount!`'s own docstring, rf2-2rtt6.48).
+
+  `:root nil` on the way out so the arm's teardown door does the rest —
+  reset the runtime, drop the container — without unmounting a root that
+  is already gone."
+  [handle]
+  (mount/unmount! handle)
+  (let [c (census)]
+    (mount/release! (assoc handle :root nil))
+    c))
+
+(defn quiesced!
+  "The runtime's own settling point — every reaper armed before this call
+  has run. `impl.inventory/quiesced!`, re-exported so a suite settles
+  against the runtime's horizon rather than against a copy of it."
+  []
+  (inventory/quiesced!))
+
+;; ---------------------------------------------------------------------------
+;; Server bytes, and the node identity that survives them
+;; ---------------------------------------------------------------------------
+
+(defn server-html!
+  "The bytes an SSR route would deliver for `hiccup` under `frame-kw`.
+
+  Rendered under an OPEN adoption window, which is the state a server
+  render is in, and released afterwards so the runtime the hydration is
+  measured on is empty. The prototype's
+  `arm1.hydration-support/server-html!` does exactly this, and the
+  honesty caveat is the same: these are the client tier's own bytes, so
+  a row that cares about a *particular* string reads it back out of the
+  captured markup rather than assuming it."
+  [frame-kw hiccup]
+  (roots/open-adoption-window!)
+  (let [container (mount/fresh-container!)
+        handle    (mount/root! container frame-kw hiccup)
+        html      (.-innerHTML container)]
+    (mount/release! handle)
+    html))
+
+(defn server-dom!
+  "A container carrying `html`, attached to the document — the page as it
+  arrives, before any JavaScript has adopted it."
+  [html]
+  (let [container (mount/fresh-container!)]
+    (set! (.-innerHTML container) html)
+    container))
+
+(def server-node-mark
+  "An EXPANDO, not an attribute.
+
+  An attribute round-trips through `innerHTML`; an expando does not. A
+  node still answering to this after hydration is therefore the very node
+  the server markup produced, rather than a replacement that happens to
+  look alike — and telling those two apart is the entire difference
+  between *adopted* and *re-rendered*."
+  "hicassoRootsFramesServerNode")
+
+(defn stamp-server-nodes!
+  "Stamp every element in `container`, and answer it."
+  [container]
+  (doseq [n (array-seq (.querySelectorAll container "*"))]
+    (unchecked-set n server-node-mark true))
+  container)
+
+(defn server-node?
+  "Is `node` a node the server markup produced?"
+  [node]
+  (and (some? node) (true? (unchecked-get node server-node-mark))))
+
+(defn every-server-node?
+  "Do all of `container`'s `sel` matches still carry the stamp?
+
+  **False for an EMPTY match**, because `every?` over nothing is
+  vacuously true and a selector that quietly stopped matching is exactly
+  how this check would quietly stop checking."
+  [container sel]
+  (let [ns' (array-seq (.querySelectorAll container sel))]
+    (and (seq ns') (every? server-node? ns'))))
+
+(defn adopted!
+  "Wait for the adoption window to shut — the closer component's passive
+  effect — and then for the reapers. Answers a promise of true, or of
+  false if the window never shut inside `budget-ms`.
+
+  Real timers only: no `act`, no `flushSync`. `impl.mount/hydrate-root!`
+  deliberately does not force hydration synchronously, so there is no
+  flush that would make this a straight line, and manufacturing one
+  would manufacture a schedule no shipped caller has.
+
+  **The window it polls is one boolean for the whole page**
+  (`impl.roots`), so in a two-root row this answers *some* root's closer
+  and not a named one. Where that distinction matters, the hydration
+  suite says so at the call site and reads a per-root observable
+  instead."
+  ([] (adopted! 3000))
+  ([budget-ms]
+   (js/Promise.
+     (fn [resolve]
+       (let [deadline (+ (js/Date.now) budget-ms)]
+         (letfn [(tick []
+                   (cond
+                     (not (roots/adopting?))
+                     ;; Past the closer AND past the entry reap horizon,
+                     ;; so a reading of the entry cache is taken on the
+                     ;; far side of the race.
+                     (js/setTimeout (fn [] (resolve true)) 16)
+
+                     (< deadline (js/Date.now))
+                     (resolve false)
+
+                     :else (js/setTimeout tick 4)))]
+           (tick)))))))
+
+(defn wait-until!
+  "Poll `pred?` on real timers until it answers truthy. Answers a promise
+  of true, or of false if `budget-ms` elapses first.
+
+  **This is how a two-root row waits, and [[adopted!]] is not.** The
+  adoption window is one boolean for the whole page, so `(adopting?)`
+  going false says *some* root's closer ran and never says which. A
+  per-root completion signal has to come from something the root itself
+  produced — its cells, which are acquired at COMMIT and therefore cannot
+  appear before that root committed."
+  ([pred?] (wait-until! pred? 3000))
+  ([pred? budget-ms]
+   (js/Promise.
+     (fn [resolve]
+       (let [deadline (+ (js/Date.now) budget-ms)]
+         (letfn [(tick []
+                   (cond
+                     (pred?)                   (js/setTimeout (fn [] (resolve true)) 16)
+                     (< deadline (js/Date.now)) (resolve false)
+                     :else                     (js/setTimeout tick 4)))]
+           (tick)))))))
+
+;; ---------------------------------------------------------------------------
+;; The two complaint channels
+;; ---------------------------------------------------------------------------
+
+(defn open-console-capture!
+  "Capture what the page COMPLAINS — `console.error` and uncaught window
+  errors — until `close!` is called.
+
+  The window/close split is the point: a capture whose window shuts when
+  the call returns is shut across the render, and the render is the half
+  that can complain. `impl.mount/hydrate-root!` returns before the tree is
+  adopted, so a capture that closed on its return would see nothing.
+
+  `:swallow-uncaught?` calls `preventDefault` on the error event.
+  **Off by default, and it belongs only at a call site that MANUFACTURES
+  a recoverable error and asserts on it** — anywhere else it is the
+  fail-open the browser runner's pageerror rule exists to prevent
+  (rf2-mwx08)."
+  ([] (open-console-capture! nil))
+  ([{:keys [swallow-uncaught?]}]
+   (let [captured (atom [])
+         original (.-error js/console)
+         on-error (fn [^js e]
+                    (swap! captured conj (str "window.error: " (.-message e)))
+                    (when swallow-uncaught? (.preventDefault e)))
+         closed?  (volatile! false)]
+     (.addEventListener js/window "error" on-error)
+     (set! (.-error js/console)
+           (fn [& args]
+             (swap! captured conj (str "console.error: " (apply str args)))
+             nil))
+     {:captured captured
+      :close!   (fn []
+                  (when-not @closed?
+                    (vreset! closed? true)
+                    (set! (.-error js/console) original)
+                    (.removeEventListener js/window "error" on-error))
+                  @captured)})))
+
+(defn watch-mismatches!
+  "Capture every `:rf.ssr/hydration-mismatch` the framework emits, on the
+  live trace stream. Answers `{:seen atom :stop! fn}`; `stop!` is
+  idempotent.
+
+  A listener is the only place this can be read: the diagnostic fires
+  from a React root-error callback, outside any dispatch scope, so it is
+  frameless and never reaches a per-frame ring. `with-trace-recorder!`
+  is the sanctioned macro for the same job but it brackets a SYNCHRONOUS
+  body, and an adoption is not one."
+  []
+  (let [seen (atom [])
+        k    (keyword (str "rf2-hic-012-" (gensym)))]
+    (trace-tooling/register-listener!
+      k (fn [ev] (when (= :rf.ssr/hydration-mismatch (:operation ev))
+                   (swap! seen conj ev))))
+    {:seen seen :stop! (fn [] (trace-tooling/unregister-listener! k) @seen)}))
+
+(defn tags-of
+  "A diagnostic's tags merged with its top level, so a read is robust to
+  whichever slots the envelope hoists."
+  [ev]
+  (merge (:tags ev) ev))

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
@@ -58,6 +58,7 @@
   forms, not docstrings."
   (:require [cljs.test :refer-macros [is]]
             [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.frames :as frames]
             [re-frame.hicasso.impl.inventory :as inventory]
             [re-frame.hicasso.impl.mount :as mount]
             [re-frame.hicasso.impl.roots :as roots]
@@ -118,6 +119,29 @@
   keys."
   [sub-key]
   (count (inventory/cell-readers sub-key)))
+
+(defn dispatch-memo-frames
+  "The frames the ambient-dispatch memo holds bundles for.
+
+  Populated by RENDER: `impl.collector/run-once` binds
+  `(frame-dispatch frame-kw)` for each body's dynamic extent, and the
+  memo is `impl.frames/!frame-dispatch`. So two frames rendering is two
+  entries, and a runtime that resolved one frame for both mounts would
+  hold one — a second frame-keyed table saying the same thing the cell
+  keys say, on a different axis.
+
+  Its sibling `impl.frames/!frame-ops` is NOT this and must not be
+  confused with it: `capture-frame` bundles are minted by
+  `impl.collector/dispatch!`, so that table is empty until something
+  dispatches. `impl.inventory/stats`'s `:frames` counts that one."
+  []
+  (set (keys @frames/!frame-dispatch)))
+
+(defn ops-memo-frames
+  "The frames the `capture-frame` op-bundle memo holds — populated by
+  DISPATCH, not by render. See [[dispatch-memo-frames]]."
+  []
+  (set (keys @frames/!frame-ops)))
 
 (defn body-runs-delta!
   "Run `f`, answer how many boundary bodies ran while it did.


### PR DESCRIPTION
Witnesses for **rf2-hic-012** — multi-root, frame isolation, and root-scoped hydration adoption. Three new files under `implementation/hicasso/test/`, nothing else touched.

- `roots_frames_support.cljs` — the harness and the observables
- `roots_frames_isolation_dom_cljs_test.cljs` — W1..W5
- `roots_frames_hydration_dom_cljs_test.cljs` — H1..H4

They run on **both** lanes automatically: `:browser-test` (`-dom-cljs-test$`) for the real DOM, and `:node-test` / `:node-test-hicasso`, where every DOM claim degrades to a stated skip rather than a false green. No build config was edited — `hicasso/test` is already on the shared source paths.

## Why these observables and not the DOM

**React will make a broken frame boundary, and a thrown-away adoption, look correct in the final DOM.** A boundary that resolved the wrong frame still renders a value; a root whose server DOM was discarded still ends the event displaying the right markup, because React re-rendered it from the client model. Value-level assertions are therefore not evidence here. Three observables were chosen because React cannot forge them:

1. **The cell table's KEY SET.** A sub-key is `[frame-kw query-v]`, so one view under two frames is two cells with one reader each, and a frame leak is *one* cell with *two* readers. React has no opinion about this structure and no way to repair it. Measured under the leak control: `[2 2 0 0]` readers instead of `[1 1 1 1]`.
2. **`collector/body-runs`** — monotone, always on, bumped inside `run-once` where a body actually runs. React's end-of-event repair *raises* this count rather than hiding it, which is the safe direction: a repair cannot make a spurious run look like no run.
3. **A DOM-node EXPANDO.** A JS property on the node object cannot survive serialisation and cannot be reconstructed. A node still carrying it after hydration is the node the server markup produced. This is the only observable that tells *adopted* from *re-rendered* — and the control below shows every text assertion staying green while it goes red.

The harness reimplements the prototype's technique (`bench.hicasso.arm1.hydration-support`, `…lane`) rather than importing it: the freeze gate forbids the package from requiring the bench tree. Naming it in prose is provenance, not a dependency — `check_freeze.py` parses `:require` forms.

## Properties witnessed, each with its negative control

Every control was run in the browser lane, confirmed red, restored, and confirmed green.

| # | Property | Observable | Negative control → red |
|---|---|---|---|
| W1 | Two roots under two frames split the cell table | 4 keys, `[1 1 1 1]` readers, `dispatch-memo-frames` = both, `ops-memo-frames` empty | **Mount both roots under `frame-a`** — the state a frame leak produces. 6 reds: keys collapse to 2, frames to `#{frame-a}`, readers `[2 2 0 0]`, dispatch memo to one, and both DOM corroborations. |
| W2 | A dispatch moves one frame and re-runs one body | `body-runs` delta 1; `ops-memo-frames` = `#{frame-a}` | **Dispatch into both frames** in the region claiming one. 4 reds: delta 2, B's count moved, ops memo gained `frame-b`. |
| W3 | A real click reaches its own root only | `body-runs` delta 1 + per-root counts | **Click root B's button** in the region claiming A moved. 4 reds. (Also caught naturally on the first run: without `settle!` the delta read 0 — the notification schedules at the sync lane.) |
| W4 | Independent unmount | keys-for each frame across `unmount!` + `quiesced!`; survivor still dispatches; final census | **Never unmount root A.** 3 reds, including the census reading `{:cell-refs 2 :boundaries 1 :edges 2}`. |
| W5 | A failing teardown is contained | survivor's keys, readers, live dispatch | **Root A carries no charge.** The premise assertion goes red — the row cannot pass unless the teardown genuinely failed. |
| H1 | Two overlapping hydrating roots each adopt their own server DOM | **node identity (expando)** | **Root B mounts with `root!` instead of `hydrate-root!`.** One red — the stamp — while `(= "B" title)`, `(= "beta" value)`, the cell keys and the frame split **all stayed green**. This is the demonstration that value assertions cannot see the fault. |
| H2 | Recovery is independent; complaint is not | React complaint count vs Spec 011 emit count | **Root B stops diverging.** React count 1 not 2 → red. |
| H3 | Independent teardown of two hydrated roots | keys, expando, `body-runs`, final census | **`release!` instead of `unmount!`** — `release!` resets the runtime by fiat, so the census reads `#{}`. Red, and it is the rf2-2rtt6.48 hollow-gate class made visible. |
| H4 | The adoption window's arity | `adopting?` across two opens and one close | **Assert the root-scoped expectation** (`true?` after the close) → red. The row discriminates page-scope from root-scope. |

The overlap in H1–H3 is a *construction*, not a timing guess: `(is (true? (roots/adopting?)))` on the line after both `hydrate-root!` calls is what says both roots were in flight. Completion is waited on per root via `wait-until! both-committed?` — a cell is acquired at commit, so a frame appearing in the table is that root's own signal. The page-wide `adopting?` flag cannot be that signal, and the harness says so where it would be tempting to use it.

## What the bead names that I could NOT witness, and why

**Deliverable 3 — "the shared hydration adoption window moved to root scope" — is not done, and deliverable 2 is red because of it.**

Measured, in `two-overlapping-hydrating-roots-recover-independently-but-only-one-complains`:

- two roots diverge, and **React reports both** — two `Hydration failed because…` errors reach the page's own error channel, because `report-recoverable-default!` delegates unconditionally;
- **Spec 011's `:rf.ssr/hydration-mismatch` fires once.** The emit is gated `(when (roots/adopting?))`; the window is one boolean for the whole page (`impl/roots.cljs`); root A's closer shuts it from a passive effect before root B's hydration commit reports. Root B's mismatch is invisible to every tool that reads the instrumentation stream.

Those two counts *together* are what make this a finding about this arm rather than about React: the divergence was detected and reported, and only the framework's own diagnostic went missing. The row asserts the **relation** (`< seen react-complaints`) beside both absolute counts, because the absolute `1` alone is equally true when only one root diverged — the relation is red under that control and red again the moment the window is root-scoped and the counts equalise.

This is exactly the bead's acceptance sabotage — *"re-globalizing the adoption window must turn the overlapping-roots witness red"* — except the window has never been de-globalized, so the witness is red on arrival. The fix is `impl/roots.cljs` + `impl/mount.cljs` (and `impl/presence_react.cljs`, the other reader).

**Bead vs. brief.** The bead is the authority and it wants the window root-scoped. My dispatch fences runtime source: *"If a witness requires changing runtime source under `implementation/hicasso/src/`, STOP and report."* The bead's own deliverable 3 offers the alternative branch — *"or each remaining global justified in writing — feeding hic-017"* — so I took that branch and made the justification a **measurement** rather than an argument. `impl/roots.cljs`'s own docstring already names rf2-hic-012 as the bead that must resolve it, and rf2-hic-017 (*the mutable-global sweep*) is open and blocked by this one. **The root-scoping change is unstarted and needs a follow-up dispatch**; H2's pinned `1` and H4 both carry in-file instructions to become `2` / be deleted when it lands.

Not fabricated to look complete: no row asserts a property this runtime does not have, and the one row that pins a defect says so in its name, its comment block and its assertion message.

## Quality gates

All foreground, to completion, exit codes read directly.

| Gate | Command | Exit |
|---|---|---|
| hicasso package compile | `npx shadow-cljs compile node-test-hicasso` | **0** |
| hicasso package suite (node lane) | `node out/node-test-hicasso.js` — 11 tests, 14 assertions, 0 failures | **0** |
| hicasso freeze gate | `npm run test:hicasso-freeze` — 11 frozen rows match; no package file imports the bench tree | **0** |
| focused browser lane | `shadow-cljs compile browser-test --config-merge {:ns-regexp "^re-frame.hicasso..+-dom-cljs-test$"}` + runner — 9 tests, 71 assertions, 0 failures | **0** |
| full browser lane | `npm run test:browser` — **1141 tests, 7040 assertions, 0 failures, 0 errors** | **0** |
| fast-PR spine | `sh scripts/test-fast-pr.sh` — `PASS fast PR spine`, 61 gates | **0** |
| JS lint | `npm run lint:js` (eslint) — no JavaScript in this diff; run anyway | **0** |

`--config-merge` is a CLI flag: `implementation/shadow-cljs.edn` was **not** edited, and the freeze gate and `frozen-sources.edn` were not touched.
