### PR TITLE
test(hicasso): the commit-owns kernel witnesses (rf2-hic-010)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/kernel_commit_owns_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/kernel_commit_owns_cljs_test.cljs
@@ -1,0 +1,479 @@
+(ns re-frame.hicasso.kernel-commit-owns-cljs-test
+  "INVARIANT I5, AT THE SEAM — render probes, commit owns (rf2-hic-010).
+
+  > Render is speculative: it probes reads, acquires no durable ownership,
+  > and publishes no committed evidence. The selected commit reconciles
+  > exactly its read and host set; disconnect releases it. Abandoned
+  > renders leave no subscriptions and no diagnostic records; teardown is
+  > exact and testable, with zero residue after quiescence.
+  >
+  > — `docs/design/hicasso/product/invariants.md`, I5
+
+  This is the **node half** of the bead's witnesses, and it exists because
+  of where the gates are. The five *real* React abandonment mechanisms the
+  bead names — Suspense retry, StrictMode double-invoke, transition abort,
+  error-then-retry, delayed commit — need a real concurrent root, so they
+  live in [[re-frame.hicasso.kernel-commit-owns-dom-cljs-test]] and run on
+  the browser lane. **That lane is not in the fast-PR spine.** This file is
+  therefore the only thing standing over the commit-owns kernel on an
+  ordinary PR, so it takes the properties that can be stated exactly
+  without a DOM and states them where they will actually be run.
+
+  ## The two doors it drives, and why neither is a simulation
+
+  1. **`react-dom/server`.** A server render runs bodies for real — the
+     shell's hooks, the read collection, the codec's element emission —
+     and then React throws the whole tree away: it calls
+     `getServerSnapshot` and never `subscribe`. That is a genuine
+     never-committed render performed by React itself, not a stand-in for
+     one.
+  2. **The published seam.**
+     [[re-frame.hicasso.impl.collector/render-body]] and
+     [[re-frame.hicasso.impl.collector/commit-boundary!]] are the render
+     and the commit React drives, exposed deliberately so the acquisition
+     laws can be stated per-key and per-reader rather than inferred from a
+     page. `commit-boundary!`'s own docstring is the warrant: it hands a
+     caller *the same `subscribe` closure `useSyncExternalStore` would
+     call* and *the same cleanup React would hold*.
+
+     Driving the seam is how a witness says **which** key acquired
+     **which** reader. It is not how a witness says React abandoned
+     anything — that claim is the DOM file's, and this file does not make
+     it.
+
+  ## The observable, and why a value assertion would not do
+
+  Every acquisition law here is asserted on **reader membership** —
+  `inventory/cell-readers`, `inventory/residue` — and never on the value a
+  body rendered. That is deliberate, and it is the lesson a sibling
+  witness paid for on the controlled-input surface the same night: a value
+  assertion stays green under a real leak, because a leaked subscription
+  does not change what is painted. It changes what is **retained** and
+  what will be **notified**. One extra reader slot on a cell is invisible
+  to the markup and fatal to the invariant, so the reader slot is what is
+  read.
+
+  ## No clock, and no hand-rolled reaper delay
+
+  Where a property is only true after the reapers run, the settle is
+  [[re-frame.hicasso.impl.inventory/quiesced!]] — the runtime's own
+  horizon — and never a `setTimeout` of this file's choosing. A copy of
+  the horizon is what drifted in rf2-981nt, and
+  `collector/entry-reap-horizon-ms` is explicitly a margin no caller may
+  rely on. Nothing here reads it, waits a multiple of it, or assumes a
+  reaper has run at any point the runtime has not said it has.
+
+  ## The negative control is in the suite, not only in the report
+
+  [[the-residue-census-can-answer-false]] performs, by hand, the exact
+  mutation the bead's sabotage control describes — it leaks one
+  abandoned-read registration — and asserts the census reports it. Without
+  that row every zero above could be a zero the instrument is incapable of
+  making non-zero, which is the failure mode this repo has been bitten by
+  twice."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.test-support :as test-support]
+            ["react-dom/server" :as react-dom-server]))
+
+(def ^:private frame-id ::kernel-commit-owns)
+
+(rf/reg-sub :kco/left  (fn [db _] (:left db)))
+(rf/reg-sub :kco/right (fn [db _] (:right db)))
+(rf/reg-sub :kco/flag  (fn [db _] (:flag db)))
+
+(rf/reg-event :kco/seed      (fn [_ [_ db]] {:db db}))
+(rf/reg-event :kco/bump-left (fn [{:keys [db]} _] {:db (update db :left inc)}))
+(rf/reg-event :kco/raise     (fn [{:keys [db]} _] {:db (assoc db :flag true)}))
+
+;; The UIx adapter rather than plain-atom, for the reason the package smoke
+;; gives: plain-atom has no reactivity layer, so a subscription under it
+;; never notifies and every commit assertion would pass vacuously by never
+;; firing.
+;;
+;; `:async? true` selects the MAP form. It is not a preference: the rows
+;; that settle against `inventory/quiesced!` are `(async done …)` tests,
+;; and `cljs.test` hard-errors on a fn-form fixture for one — the fn-form
+;; unwinds its ambient scope the instant it returns, which is before an
+;; async body has resumed. `:ambient-frame nil` because this suite seats
+;; its own top-level frame.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- seeded!
+  "A frame with a known db. `IS_REACT_ACT_ENVIRONMENT` is set outright
+  because a server render is not inside React's `act` queue and the helper
+  that carries this line in the prototype lives in the bench tree, which
+  the freeze gate forbids this package from importing."
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [:kco/seed {:left 1 :right 2 :flag false}]))
+  frame-id)
+
+(defn- k
+  "A sub-key: the runtime keys cells by `[frame-kw query-v]`, because two
+  frames are isolated contexts holding two different app-dbs."
+  [query-v]
+  [frame-id query-v])
+
+(def ^:private nothing-owned
+  "The four OWNERSHIP counters at rest. `:entries` is deliberately absent —
+  a read-set entry is a CACHE minted during the render, so it is not
+  ownership and the rows that care about it name it separately."
+  {:cells 0 :cell-refs 0 :boundaries 0 :edges 0})
+
+(defn- ownership
+  "The census with the entry cache projected out."
+  []
+  (dissoc (inventory/residue) :entries))
+
+(defn- probe!
+  "Run ONE boundary body under the real generation fence — the same call
+  [[re-frame.hicasso.impl.collector/shell]] makes between its two hooks —
+  and return the read-set entry the render resolved. Commits nothing:
+  `subscribe` is React's to call, and nothing here calls it."
+  [body-fn]
+  (collector/render-body frame-id body-fn {})
+  (collector/last-reads))
+
+(defn- macrotask
+  "One turn of the event loop, for the rows that assert on the CELL reaper
+  specifically (armed at 0 ms by `arm-cell-reaper!`). The entry reaper's
+  horizon is longer and is never waited on by hand — that is
+  `inventory/quiesced!`'s job."
+  []
+  (js/Promise. (fn [resolve] (js/setTimeout (fn [] (resolve nil)) 0))))
+
+;; ---------------------------------------------------------------------------
+;; A real React render that never commits
+;; ---------------------------------------------------------------------------
+
+(h/defview left-line  [_] [:p.left (h/sub [:kco/left])])
+(h/defview right-line [_] [:p.right (h/sub [:kco/right])])
+
+(h/defview both-lines
+  [_]
+  [:div [left-line {}] [right-line {}]])
+
+(defn- server-html
+  [hiccup]
+  (react-dom-server/renderToString
+    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+
+(deftest a-server-render-runs-every-body-and-acquires-nothing-from-any-of-them
+  (async done
+    (seeded!)
+    (collector/reset-body-runs!)
+    (let [markup (server-html [both-lines {}])]
+
+      (testing "the premise: React really did run all three bodies. Without
+                this the zeros below would be the zeros of a render that
+                never happened"
+        (is (= 3 (collector/body-runs)))
+        (is (re-find #"1" markup))
+        (is (re-find #"2" markup)))
+
+      (testing "and it committed none of them, so the runtime owns nothing:
+                no cell was built, no reference taken, no edge recorded"
+        (is (= nothing-owned (ownership))))
+
+      (testing "the individually-named keys confirm it per key, which a
+                summed census could hide"
+        (is (= [] (inventory/cell-readers (k [:kco/left]))))
+        (is (= [] (inventory/cell-readers (k [:kco/right])))))
+
+      (testing "the read-set entries ARE there — a render-phase cache is the
+                one thing a probing render leaves, and calling it out is
+                what keeps the zero above honest"
+        (is (pos? (:entries (inventory/residue)))))
+
+      (.then (inventory/quiesced!)
+             (fn [_]
+               (testing "and the cache evaporates at the runtime's own
+                         horizon: zero residue after quiescence, which is
+                         I5's last clause"
+                 (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                        (inventory/residue))))
+               (done))))))
+
+;; ---------------------------------------------------------------------------
+;; The commit acquires EXACTLY the read set
+;; ---------------------------------------------------------------------------
+
+(deftest the-commit-acquires-exactly-the-current-read-set
+  (async done
+    (seeded!)
+    (let [entry     (probe! (fn [_] [:p (h/sub [:kco/left])]))
+          !notified (atom 0)]
+
+      (testing "the render resolved the read set without owning it"
+        (is (= #{(k [:kco/left])} (collector/reads-of entry)))
+        (is (= nothing-owned (ownership))))
+
+      (let [cleanup (collector/commit-boundary! entry (fn [] (swap! !notified inc)))]
+
+        (testing "the commit takes exactly one cell, one reference, one edge"
+          (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership)))
+          (is (= 1 (count (inventory/cell-readers (k [:kco/left]))))))
+
+        (testing "and NOTHING for a key this body did not read — the
+                  acquisition is the read set, not the registrar"
+          (is (= [] (inventory/cell-readers (k [:kco/right]))))
+          (is (nil? (inventory/cell-reaction (k [:kco/right])))))
+
+        (testing "the acquired boundary is a live reader: a write to its key
+                  notifies it exactly once"
+          (rf/with-frame frame-id (rf/dispatch-sync [:kco/bump-left]))
+          (is (= 1 @!notified)))
+
+        (testing "and a write to a key it does NOT read notifies it not at all
+                  — the dirty set is the dirty CELLS' readers, so an unread
+                  key contributes no phantom reader"
+          (rf/with-frame frame-id (rf/dispatch-sync [:kco/raise]))
+          (is (= 1 @!notified)))
+
+        (cleanup)
+
+        (testing "disconnect releases it: the membership goes immediately,
+                  and the cell survives only until its reaper"
+          (is (= {:cells 1 :cell-refs 0 :boundaries 0 :edges 0} (ownership)))))
+
+      (.then (macrotask)
+             (fn [_]
+               (testing "the reaped cell leaves the ownership census empty"
+                 (is (= nothing-owned (ownership))))
+               (.then (inventory/quiesced!)
+                      (fn [_]
+                        (testing "and quiescence is total"
+                          (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                                 (inventory/residue))))
+                        (done))))))))
+
+(deftest a-branch-not-taken-contributes-no-edge
+  (seeded!)
+  ;; The ambient collector's whole claim: the edge is recorded WHERE THE
+  ;; READ HAPPENS, so a boundary's edge set is a function of the control
+  ;; flow the render actually took.
+  (let [body    (fn [_] [:p (when (h/sub [:kco/flag]) (h/sub [:kco/right]))])
+        cold    (probe! body)
+        cleanup (collector/commit-boundary! cold (fn []))]
+
+    (testing "flag is false, so the guarded read never ran and its key is
+              not in the set"
+      (is (= #{(k [:kco/flag])} (collector/reads-of cold)))
+      (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership)))
+      (is (= [] (inventory/cell-readers (k [:kco/right])))))
+
+    (cleanup)
+    (rf/with-frame frame-id (rf/dispatch-sync [:kco/raise]))
+
+    (let [warm     (probe! body)
+          cleanup2 (collector/commit-boundary! warm (fn []))]
+      (testing "flag is true, so the same body reads two keys and the commit
+                acquires both — the edge set followed the branch"
+        (is (= #{(k [:kco/flag]) (k [:kco/right])} (collector/reads-of warm)))
+        (is (= 1 (count (inventory/cell-readers (k [:kco/right]))))))
+      (cleanup2))))
+
+;; ---------------------------------------------------------------------------
+;; Rollback — a body that throws after its reads
+;; ---------------------------------------------------------------------------
+
+(deftest a-body-that-throws-after-its-reads-leaves-nothing-and-contaminates-nothing
+  (seeded!)
+  (let [before (ownership)]
+
+    (is (thrown-with-msg? js/Error #"planted"
+          (collector/render-body
+            frame-id
+            (fn [_]
+              (h/sub [:kco/left])
+              (h/sub [:kco/right])
+              (throw (js/Error. "planted")))
+            {}))
+        "the body must actually throw — otherwise this row proves nothing")
+
+    (testing "the reads it took before it threw acquired nothing, because a
+              render-phase read acquires nothing to roll back"
+      (is (= before (ownership)))
+      (is (= nothing-owned (ownership))))
+
+    ;; The half that would be a SILENT wrong answer rather than a leak. The
+    ;; scratch is one module-level array reset by overwrite at the top of
+    ;; every body; if a throwing run's reads survived into the next body,
+    ;; the next boundary would commit edges it never read — correct on
+    ;; screen, wrong forever after.
+    (let [entry   (probe! (fn [_] [:p (h/sub [:kco/flag])]))
+          cleanup (collector/commit-boundary! entry (fn []))]
+
+      (testing "the next body's read set is ITS OWN, not the throwing run's
+                concatenated with it"
+        (is (= #{(k [:kco/flag])} (collector/reads-of entry)))
+        (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership))))
+
+      (testing "named per key, because `:cells 1` alone could be the right
+                count of the wrong keys"
+        (is (= 1 (count (inventory/cell-readers (k [:kco/flag])))))
+        (is (= [] (inventory/cell-readers (k [:kco/left]))))
+        (is (= [] (inventory/cell-readers (k [:kco/right])))))
+
+      (cleanup))))
+
+;; ---------------------------------------------------------------------------
+;; A re-render before the commit — the discarded attempt is discarded
+;; ---------------------------------------------------------------------------
+
+(deftest a-re-render-before-the-commit-owns-the-second-read-set-and-only-that
+  (seeded!)
+  (probe! (fn [_] [:p (h/sub [:kco/left]) (h/sub [:kco/right])]))
+
+  (testing "the first attempt owns nothing, so there is nothing for the
+            second to undo"
+    (is (= nothing-owned (ownership))))
+
+  (let [second-entry (probe! (fn [_] [:p (h/sub [:kco/flag])]))
+        cleanup      (collector/commit-boundary! second-entry (fn []))]
+
+    (testing "React selected the second attempt, so the second attempt's set
+              is what got acquired — in full and in isolation"
+      (is (= #{(k [:kco/flag])} (collector/reads-of second-entry)))
+      (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership)))
+      (is (= [] (inventory/cell-readers (k [:kco/left]))))
+      (is (= [] (inventory/cell-readers (k [:kco/right])))))
+
+    (cleanup)))
+
+;; ---------------------------------------------------------------------------
+;; Two fibers on one read set — StrictMode's SHAPE, at the seam
+;; ---------------------------------------------------------------------------
+
+(deftest two-subscribes-on-one-entry-are-two-readers-and-two-cleanups-leave-none
+  (async done
+    (seeded!)
+    ;; StrictMode's double-invoke and its double-mount produce exactly this
+    ;; at the seam: one entry, two `subscribe` calls, two cleanups. The
+    ;; REAL StrictMode witness is the DOM file's; this row states what the
+    ;; seam owes it.
+    (let [entry (probe! (fn [_] [:p (h/sub [:kco/left])]))
+          c1    (collector/commit-boundary! entry (fn []))
+          c2    (collector/commit-boundary! entry (fn []))]
+
+      (testing "two boundaries, two memberships, still ONE cell — the cell
+                is shared per unique key and the reader list is the count"
+        (is (= {:cells 1 :cell-refs 2 :boundaries 2 :edges 2} (ownership)))
+        (is (= 2 (count (inventory/cell-readers (k [:kco/left]))))))
+
+      (testing "and the two registrations are distinct objects: the
+                registration IS the boundary id, so a second subscribe
+                cannot be mistaken for the first"
+        (let [[a b] (inventory/cell-readers (k [:kco/left]))]
+          (is (not (identical? a b)))))
+
+      (c1)
+      (testing "one cleanup removes exactly one membership"
+        (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership))))
+
+      (c2)
+      (.then (inventory/quiesced!)
+             (fn [_]
+               (testing "and the pair leaves zero residue"
+                 (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                        (inventory/residue))))
+               (done))))))
+
+;; ---------------------------------------------------------------------------
+;; The render→commit gap — delayed commit, at the seam
+;; ---------------------------------------------------------------------------
+
+(deftest a-quiet-render-to-commit-gap-moves-the-snapshot-by-nothing
+  (seeded!)
+  ;; The control for the row below, and the reason that row means anything:
+  ;; if the number moved on every commit, a difference would prove nothing.
+  (let [entry     (probe! (fn [_] [:p (h/sub [:kco/left])]))
+        at-render (collector/snapshot-of entry)
+        cleanup   (collector/commit-boundary! entry (fn []))
+        at-commit (collector/snapshot-of entry)]
+    (testing "nothing landed in the gap, so React's post-subscribe re-read
+              sees the number the fiber captured at render and schedules no
+              correcting re-render"
+      (is (= at-render at-commit)))
+    (cleanup)))
+
+(deftest a-commit-landing-in-the-render-to-commit-gap-moves-the-snapshot
+  (seeded!)
+  ;; A STAGED key — nothing holds `:kco/left`, so it has no cell, no watch
+  ;; and no epoch, and the flush generation is structurally blind to it.
+  ;; `commit-basis` is what is not blind, and this is the row that says so.
+  (let [entry     (probe! (fn [_] [:p (h/sub [:kco/left])]))
+        at-render (collector/snapshot-of entry)]
+
+    (testing "the key really is staged: no cell holds it at render time"
+      (is (nil? (get @collector/!cells (k [:kco/left])))))
+
+    ;; The write lands AFTER the body returned and BEFORE React acquires.
+    (rf/with-frame frame-id (rf/dispatch-sync [:kco/bump-left]))
+
+    (let [cleanup   (collector/commit-boundary! entry (fn []))
+          at-commit (collector/snapshot-of entry)]
+      (testing "so the number React re-reads after `subscribe` differs from
+                the one the fiber captured at render, and the boundary is
+                corrected instead of painting a value that moved under it"
+        (is (not= at-render at-commit)))
+      (cleanup))))
+
+;; ---------------------------------------------------------------------------
+;; The negative control — the census can answer false
+;; ---------------------------------------------------------------------------
+
+(deftest the-residue-census-can-answer-false
+  ;; THE SABOTAGE CONTROL, performed from the test rather than from the
+  ;; source. Every zero in this file is only worth what this row is worth:
+  ;; a census that cannot be made non-zero is a gate that cannot go red,
+  ;; and the assertions above would then be proving the instrument's
+  ;; silence rather than the runtime's correctness.
+  ;;
+  ;; What it leaks is exactly one abandoned-read registration — the entry
+  ;; of a render that was never selected, committed by hand and its cleanup
+  ;; discarded. That is the mutation the bead's sabotage clause describes,
+  ;; and it is what a render-phase acquisition would produce on every
+  ;; abandoned attempt.
+  (async done
+    (seeded!)
+    (let [entry (probe! (fn [_] [:p (h/sub [:kco/left])]))]
+
+      (testing "the abandoned render, as every row above finds it"
+        (is (= nothing-owned (ownership))))
+
+      (collector/commit-boundary! entry (fn []))
+
+      (testing "one leaked registration, and the census says so — on the
+                summed counters"
+        (is (not= nothing-owned (ownership)))
+        (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership))))
+
+      (testing "and on the per-key reader list, which is the observable the
+                acquisition rows actually assert on"
+        (is (= 1 (count (inventory/cell-readers (k [:kco/left]))))))
+
+      (.then (inventory/quiesced!)
+             (fn [_]
+               (testing "quiescence does NOT launder it: the reapers drop
+                         what nothing holds, and this is held"
+                 (is (= 1 (count (inventory/cell-readers (k [:kco/left])))))
+                 (is (not= 0 (:cell-refs (inventory/residue)))))
+               (done))))))

--- a/implementation/hicasso/test/re_frame/hicasso/kernel_commit_owns_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/kernel_commit_owns_cljs_test.cljs
@@ -151,14 +151,6 @@
   (collector/render-body frame-id body-fn {})
   (collector/last-reads))
 
-(defn- macrotask
-  "One turn of the event loop, for the rows that assert on the CELL reaper
-  specifically (armed at 0 ms by `arm-cell-reaper!`). The entry reaper's
-  horizon is longer and is never waited on by hand — that is
-  `inventory/quiesced!`'s job."
-  []
-  (js/Promise. (fn [resolve] (js/setTimeout (fn [] (resolve nil)) 0))))
-
 ;; ---------------------------------------------------------------------------
 ;; A real React render that never commits
 ;; ---------------------------------------------------------------------------
@@ -253,16 +245,14 @@
                   and the cell survives only until its reaper"
           (is (= {:cells 1 :cell-refs 0 :boundaries 0 :edges 0} (ownership)))))
 
-      (.then (macrotask)
+      (.then (inventory/quiesced!)
              (fn [_]
-               (testing "the reaped cell leaves the ownership census empty"
-                 (is (= nothing-owned (ownership))))
-               (.then (inventory/quiesced!)
-                      (fn [_]
-                        (testing "and quiescence is total"
-                          (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                                 (inventory/residue))))
-                        (done))))))))
+               (testing "and at the runtime's own horizon — which is strictly
+                         past every reaper armed before it, the cell reapers
+                         included — teardown is exact: total zero"
+                 (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                        (inventory/residue))))
+               (done))))))
 
 (deftest a-branch-not-taken-contributes-no-edge
   (seeded!)

--- a/implementation/hicasso/test/re_frame/hicasso/kernel_commit_owns_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/kernel_commit_owns_dom_cljs_test.cljs
@@ -1,0 +1,528 @@
+(ns re-frame.hicasso.kernel-commit-owns-dom-cljs-test
+  "INVARIANT I5, UNDER REAL REACT — render probes, commit owns
+  (rf2-hic-010).
+
+  > Render is speculative: it probes reads, acquires no durable ownership,
+  > and publishes no committed evidence. The selected commit reconciles
+  > exactly its read and host set; disconnect releases it. Abandoned
+  > renders leave no subscriptions and no diagnostic records; teardown is
+  > exact and testable, with zero residue after quiescence.
+  >
+  > — `docs/design/hicasso/product/invariants.md`, I5
+
+  [[re-frame.hicasso.kernel-commit-owns-cljs-test]] states the acquisition
+  laws exactly, at the collector's published seam, and runs on every PR.
+  **It cannot say that React abandons anything** — it drives the render and
+  the commit itself. This file is where that claim is made, and it is made
+  the only way it can be: by making React 19 abandon a render, four
+  different ways, and reading what the runtime kept.
+
+  ## Abandonment here is REAL, and each row proves its own premise
+
+  A test that asserts \"nothing was acquired\" is worthless if no body ever
+  ran — the assertion would hold for a render that never happened, which
+  is the cheapest possible false green. **Every row below therefore asserts
+  the premise first**: `collector/body-runs` moved, so React genuinely ran
+  the body it then threw away. Where the premise is what the row waits on,
+  it is also the poll condition, so the row cannot proceed without it.
+
+  The four mechanisms, all of them React's own:
+
+  | row | how React abandons the render |
+  |---|---|
+  | [[a-suspended-attempt-acquires-nothing-and-its-retry-acquires-exactly-once]] | a sibling throws a thenable; React discards the attempt and commits the fallback |
+  | [[an-aborted-transition-acquires-nothing-and-its-completion-acquires-exactly-once]] | the tree a `startTransition` rendered suspends, so React keeps the old UI and drops the new render entirely |
+  | [[strictmodes-double-invoke-is-not-additive]] | React runs every body twice and mounts, unmounts and remounts every effect |
+  | [[a-body-that-throws-after-its-reads-is-caught-and-the-retry-acquires-exactly-once]] | a render-phase throw, caught by `h/boundary`, retried through `:reset-key` |
+
+  A fifth property the bead names — **delayed commit** — is
+  [[a-write-landing-in-the-render-to-commit-gap-heals-the-boundary]]: a
+  sibling's `useLayoutEffect` writes after every body has returned and
+  before React runs the passive effect that acquires, which is the
+  render→commit gap with a real write inside it.
+
+  ## The observable, and why it can tell this runtime from plain React
+
+  Two kinds, chosen for two different failure modes.
+
+  **Reader membership** (`inventory/cell-readers`) carries every
+  abandonment row. The reason is the lesson a sibling witness paid for on
+  the controlled-input surface the same night: a value assertion stays
+  green under a real leak. If an abandoned attempt DID acquire, the page
+  still paints the correct text — React committed the right tree, and the
+  leaked registration is simply an extra slot on a cell that no cleanup
+  will ever remove. `exactly 1 reader` and `2 readers` render identically
+  and differ absolutely, so the reader slot is what is read. Plain React
+  has no such structure to read; this is the runtime's own retention, and
+  a leak is invisible anywhere else.
+
+  **The painted value** carries the gap row, and only that one, because
+  there the failure mode IS a stale value: a staged read that moved
+  between render and commit and was never corrected paints the old number
+  forever. That is precisely what plain `useSyncExternalStore` over a
+  store with no commit basis would do, so the value is the observable that
+  distinguishes them.
+
+  ## No clock
+
+  Every wait is [[re-frame.test-support/poll-until]] on the condition
+  itself, or [[re-frame.hicasso.impl.inventory/quiesced!]] — the runtime's
+  own reaper horizon. Nothing here sleeps a chosen number of
+  milliseconds, and nothing assumes a reaper has run at a point the
+  runtime has not said it has.
+
+  ## The census is taken BEFORE the fixture resets anything
+
+  `mount/release!` resets the runtime, so a residue reading taken after it
+  answers zero whether teardown worked or not — a gate that cannot go red
+  (rf2-2rtt6.48). Every row here therefore ends with
+  [[teardown-census!]]: `mount/unmount!`, settle at the runtime's horizon,
+  ASSERT, and only then release.
+
+  ## On the node lane this file states a skip, never a green
+
+  `:node-test` has no DOM. Every row degrades to an explicit skip rather
+  than to an assertion that passes because nothing ran."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [clojure.set :as set]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]
+            ["react-dom/client" :as react-dom-client]))
+
+(def ^:private frame-id ::kernel-commit-owns-dom)
+
+(rf/reg-sub :kcod/left  (fn [db _] (:left db)))
+(rf/reg-sub :kcod/right (fn [db _] (:right db)))
+
+(rf/reg-event :kcod/seed      (fn [_ [_ db]] {:db db}))
+(rf/reg-event :kcod/bump-left (fn [{:keys [db]} _] {:db (update db :left inc)}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; The exercised population — a MEASUREMENT, not a claim
+;; ---------------------------------------------------------------------------
+
+(def ^:private declared-population
+  "The abandonment and commit mechanisms this file undertakes to exercise.
+  [[the-declared-population-was-actually-exercised]] asserts that every one
+  of them was reached at runtime, so the roster cannot drift into a list of
+  things the suite used to do."
+  #{:suspense/abandon-and-retry
+    :transition/abort-and-complete
+    :strict-mode/double-invoke
+    :error-boundary/throw-and-retry
+    :render-to-commit-gap/heal})
+
+(defonce ^:private !exercised (atom #{}))
+
+(defn- exercised! [mechanism] (swap! !exercised conj mechanism) nil)
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- skip!
+  [why]
+  (is true (str "kernel-commit-owns DOM witness needs a real React DOM — " why)))
+
+(defn- seeded!
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [:kcod/seed {:left 1 :right 7}]))
+  frame-id)
+
+(defn- k [query-v] [frame-id query-v])
+
+(def ^:private nothing-owned {:cells 0 :cell-refs 0 :boundaries 0 :edges 0})
+
+(defn- ownership [] (dissoc (inventory/residue) :entries))
+
+(defn- readers-of [query-v] (count (inventory/cell-readers (k query-v))))
+
+(defn- app
+  "The hicasso subtree: the frame provider over a root element."
+  [hiccup]
+  (mount/provider frame-id (codec/root-element frame-id hiccup)))
+
+(defn- mount-concurrent!
+  "A concurrent root, rendered WITHOUT `flushSync`.
+
+  Deliberately not `mount/root!`. That door renders inside `flushSync`
+  because the witnesses it was built for read the DOM on the next line;
+  here a synchronous flush would be inventing a schedule — Suspense and
+  transitions are React's concurrent business, and a row that forced them
+  sync would be a row about the forced schedule. Every wait below is a
+  poll on the condition instead."
+  [container element]
+  (let [root (react-dom-client/createRoot container)]
+    (.render root element)
+    {:root root :container container :frame frame-id}))
+
+(defn- text [handle] (.-textContent ^js (:container handle)))
+
+(defn- poll
+  [pred label]
+  (test-support/poll-until pred {:label label :timeout-ms 4000}))
+
+(defn- teardown-census!
+  "Unmount, settle at the runtime's own horizon, ASSERT, and only then
+  release. `mount/release!` resets the runtime, so a census taken after it
+  cannot go red — see the namespace docstring."
+  [handle]
+  (mount/unmount! handle)
+  (.then (inventory/quiesced!)
+         (fn [_]
+           (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                  (inventory/residue))
+               "teardown is exact: zero residue after quiescence")
+           (mount/release! handle)
+           nil)))
+
+(defn- fail-and-finish!
+  [done label handle]
+  (fn [e]
+    (is false (str label " — " (.-message e)
+                   " | DOM was " (pr-str (when handle (text handle)))
+                   " | ownership " (pr-str (ownership))))
+    (when handle (mount/release! handle))
+    (done)))
+
+(defn- make-gate
+  "A REAL React suspension: a component that throws a thenable until it is
+  released. Everything after the release is React's own retry machinery —
+  nothing here schedules, re-renders or commits anything."
+  []
+  (let [!released (atom false)
+        !resolve  (atom nil)
+        promise   (js/Promise. (fn [res] (reset! !resolve res)))
+        component (fn gate [_] (when-not @!released (throw promise)) nil)]
+    (unchecked-set component "displayName" "kco/gate")
+    {:element  (react/createElement component nil)
+     :release! (fn [] (reset! !released true) (@!resolve nil) nil)}))
+
+;; ---------------------------------------------------------------------------
+;; The views
+;; ---------------------------------------------------------------------------
+
+(h/defview left-line  [_] [:p {:id "left"} (str "left=" (h/sub [:kcod/left]))])
+(h/defview right-line [_] [:p {:id "right"} (str "right=" (h/sub [:kcod/right]))])
+
+(def ^:private !throw? (atom false))
+
+(h/defview thrower
+  "Reads FIRST and throws SECOND — the bead's rollback shape. The reads are
+  real reads, taken before the failure, so a runtime that acquired at
+  render would have acquired them."
+  [_]
+  (let [v (h/sub [:kcod/right])]
+    (when @!throw? (throw (js/Error. "planted kernel-commit-owns throw")))
+    [:p {:id "right"} (str "right=" v)]))
+
+;; ---------------------------------------------------------------------------
+;; 1. Suspense — React discards the attempt and commits the fallback
+;; ---------------------------------------------------------------------------
+
+(deftest a-suspended-attempt-acquires-nothing-and-its-retry-acquires-exactly-once
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (let [_      (seeded!)
+            gate   (make-gate)
+            before (collector/body-runs)
+            handle (mount-concurrent!
+                     (mount/fresh-container!)
+                     (react/createElement
+                       (.-Suspense react)
+                       #js {:fallback (react/createElement "p" nil "waiting")}
+                       (react/createElement (.-Fragment react) nil
+                                            (app [left-line {}])
+                                            (:element gate))))]
+        (-> (poll #(= "waiting" (text handle)) "the fallback commits")
+            (.then
+              (fn [_]
+                (testing "the premise: React RAN the boundary body before it
+                          threw the attempt away. Without this the zeros
+                          below are the zeros of a render that never was"
+                  (is (pos? (- (collector/body-runs) before))))
+
+                (testing "and the attempt was genuinely abandoned — the
+                          fallback is on the page, the boundary's markup is
+                          not"
+                  (is (= "waiting" (text handle))))
+
+                (testing "so the abandoned render acquired nothing: no cell,
+                          no reference, no edge, and no reader on the key it
+                          read"
+                  (is (= nothing-owned (ownership)))
+                  (is (zero? (readers-of [:kcod/left]))))
+
+                ((:release! gate))
+                (poll #(= "left=1" (text handle)) "the retry commits")))
+            (.then
+              (fn [_]
+                (testing "the retry committed the boundary React had thrown
+                          away, and acquired its read set EXACTLY ONCE — two
+                          readers here would paint the identical page and
+                          leak a subscription for the life of the mount"
+                  (is (= 1 (readers-of [:kcod/left])))
+                  (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1}
+                         (ownership))))
+                (exercised! :suspense/abandon-and-retry)
+                (teardown-census! handle)))
+            (.then (fn [_] (done)))
+            (.catch (fail-and-finish! done "suspense witness" handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. Transition abort — React renders the new tree and drops it whole
+;; ---------------------------------------------------------------------------
+
+(def ^:private !set-phase (atom nil))
+
+(defn- phase-host
+  [^js props]
+  (let [[phase set-phase] (react/useState 0)]
+    (react/useEffect (fn [] (reset! !set-phase set-phase) js/undefined)
+                     #js [set-phase])
+    (if (zero? phase)
+      (react/createElement "p" nil "old")
+      (unchecked-get props "next"))))
+
+(unchecked-set phase-host "displayName" "kco/phase-host")
+
+(deftest an-aborted-transition-acquires-nothing-and-its-completion-acquires-exactly-once
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (let [_    (seeded!)
+            gate (make-gate)
+            next (react/createElement (.-Fragment react) nil
+                                      (app [right-line {}])
+                                      (:element gate))
+            handle (mount-concurrent!
+                     (mount/fresh-container!)
+                     (react/createElement
+                       (.-Suspense react)
+                       #js {:fallback (react/createElement "p" nil "fallback")}
+                       (react/createElement phase-host #js {:next next})))]
+        (-> (poll #(and (= "old" (text handle)) (some? @!set-phase))
+                  "the old tree commits")
+            (.then
+              (fn [_]
+                (let [before (collector/body-runs)]
+                  ;; A REAL transition. React renders the new tree at
+                  ;; transition priority; it suspends; React keeps the
+                  ;; committed UI and throws the new render away.
+                  ((.-startTransition react) (fn [] (@!set-phase 1)))
+                  ;; The poll condition IS the premise — the row cannot
+                  ;; proceed until React has actually run the new body.
+                  (-> (poll #(> (collector/body-runs) before)
+                            "the transition renders the new body")
+                      (.then
+                        (fn [_]
+                          (testing "React kept the committed UI rather than
+                                    showing the fallback, which is what makes
+                                    this an ABORTED transition and not a
+                                    suspension"
+                            (is (= "old" (text handle))))
+
+                          (testing "the new body ran and was discarded, so it
+                                    acquired nothing at all"
+                            (is (zero? (readers-of [:kcod/right])))
+                            (is (= nothing-owned (ownership))))
+
+                          ((:release! gate))
+                          (poll #(= "right=7" (text handle))
+                                "the transition completes")))))))
+            (.then
+              (fn [_]
+                (testing "and the completion acquires the read set exactly
+                          once — the abandoned attempt contributed no second
+                          reader"
+                  (is (= 1 (readers-of [:kcod/right])))
+                  (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1}
+                         (ownership))))
+                (exercised! :transition/abort-and-complete)
+                (teardown-census! handle)))
+            (.then (fn [_] (done)))
+            (.catch (fail-and-finish! done "transition witness" handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. StrictMode — two body runs, one mount/unmount/remount, one acquisition
+;; ---------------------------------------------------------------------------
+
+(deftest strictmodes-double-invoke-is-not-additive
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (let [_      (seeded!)
+            before (collector/body-runs)
+            handle (mount-concurrent!
+                     (mount/fresh-container!)
+                     (react/createElement (.-StrictMode react) nil
+                                          (app [left-line {}])))]
+        (-> (poll #(= "left=1" (text handle)) "the strict tree commits")
+            (.then
+              (fn [_]
+                (testing "the premise, and it is the whole point of the row:
+                          StrictMode really did run the body TWICE. A green
+                          here with a delta of 1 would be a green for a
+                          StrictMode that never engaged"
+                  (is (= 2 (- (collector/body-runs) before))))
+
+                (testing "two body runs, and ONE acquisition. The scratch is
+                          reset by overwrite at the top of every body, so the
+                          second run replaces the first's reads instead of
+                          being appended to them"
+                  (is (= 1 (readers-of [:kcod/left])))
+                  (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1}
+                         (ownership))))
+
+                (testing "and StrictMode's mount/unmount/remount of every
+                          effect left exactly one live registration, not a
+                          stranded one beside it"
+                  (is (= 1 (:entries (inventory/residue)))))
+
+                (testing "the boundary is the LIVE one: a write still reaches
+                          it, so the surviving registration is the remounted
+                          one and not a detached first"
+                  (mount/dispatch! handle [:kcod/bump-left])
+                  (poll #(= "left=2" (text handle)) "the write reaches it"))))
+            (.then
+              (fn [_]
+                (is (= 1 (readers-of [:kcod/left]))
+                    "and the write added no reader")
+                (exercised! :strict-mode/double-invoke)
+                (teardown-census! handle)))
+            (.then (fn [_] (done)))
+            (.catch (fail-and-finish! done "strictmode witness" handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 4. Error then retry — a render-phase throw, caught and retried
+;; ---------------------------------------------------------------------------
+
+(defn- guarded
+  [reset-key]
+  (app [h/boundary {:fallback [:p {:id "fb"} "caught"] :reset-key reset-key}
+        [thrower {}]]))
+
+(deftest a-body-that-throws-after-its-reads-is-caught-and-the-retry-acquires-exactly-once
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (let [_      (seeded!)
+            _      (reset! !throw? true)
+            before (collector/body-runs)
+            handle (mount-concurrent! (mount/fresh-container!) (guarded 0))]
+        (-> (poll #(= "caught" (text handle)) "the error boundary catches")
+            (.then
+              (fn [_]
+                (testing "the premise: the body RAN, took its read, and then
+                          threw"
+                  (is (pos? (- (collector/body-runs) before))))
+
+                (testing "the throwing attempt is rolled back to nothing —
+                          there is nothing to roll back, because a
+                          render-phase read acquires nothing"
+                  (is (zero? (readers-of [:kcod/right])))
+                  (is (= nothing-owned (ownership))))
+
+                (reset! !throw? false)
+                ;; The retry is the CALLER's to schedule: a changed
+                ;; `:reset-key` clears the caught failure and remounts.
+                (.render ^js (:root handle) (guarded 1))
+                (poll #(= "right=7" (text handle)) "the retry commits")))
+            (.then
+              (fn [_]
+                (testing "and the retry acquires exactly its read set, with
+                          no contribution from the attempt that threw"
+                  (is (= 1 (readers-of [:kcod/right])))
+                  (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1}
+                         (ownership))))
+                (exercised! :error-boundary/throw-and-retry)
+                (teardown-census! handle)))
+            (.then (fn [_] (reset! !throw? false) (done)))
+            (.catch (fn [e]
+                      (reset! !throw? false)
+                      ((fail-and-finish! done "error-retry witness" handle) e))))))))
+
+;; ---------------------------------------------------------------------------
+;; 5. Delayed commit — a write inside the render→commit gap
+;; ---------------------------------------------------------------------------
+
+(defn- gap-writer
+  "Writes from a LAYOUT effect: after every body in the tree has returned,
+  and before React runs the passive effect in which
+  `useSyncExternalStore` acquires. That interval is the render→commit gap,
+  and this is a real write landing inside it."
+  [_]
+  (react/useLayoutEffect
+    (fn [] (collector/dispatch! frame-id [:kcod/bump-left]) js/undefined)
+    #js [])
+  nil)
+
+(unchecked-set gap-writer "displayName" "kco/gap-writer")
+
+(deftest a-write-landing-in-the-render-to-commit-gap-heals-the-boundary
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (let [_      (seeded!)
+            handle (mount-concurrent!
+                     (mount/fresh-container!)
+                     (react/createElement (.-Fragment react) nil
+                                          (app [left-line {}])
+                                          (react/createElement gap-writer nil)))]
+        ;; `:kcod/left` is STAGED at render — no cell holds it, so it has no
+        ;; watch and no epoch, and the flush generation is structurally
+        ;; blind to a move. `commit-basis` is what is not blind, and the
+        ;; painted value is what says whether the repair worked: a boundary
+        ;; that never heard about the write paints `left=1` forever.
+        (-> (poll #(= "left=2" (text handle)) "the boundary heals to the value that moved")
+            (.then
+              (fn [_]
+                (testing "the body rendered against left=1, the layout effect
+                          wrote left=2 before the commit acquired, and React's
+                          post-subscribe re-read of the snapshot corrected the
+                          boundary rather than leaving it stale"
+                  (is (= "left=2" (text handle))))
+
+                (testing "and the healed boundary holds exactly one reader —
+                          the correcting re-render replaced its registration,
+                          it did not add one"
+                  (is (= 1 (readers-of [:kcod/left])))
+                  (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1}
+                         (ownership))))
+
+                (exercised! :render-to-commit-gap/heal)
+                (teardown-census! handle)))
+            (.then (fn [_] (done)))
+            (.catch (fail-and-finish! done "render-to-commit-gap witness" handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; The population, asserted rather than described
+;; ---------------------------------------------------------------------------
+
+(deftest the-declared-population-was-actually-exercised
+  ;; Declared LAST so every row above has run. The roster is not prose: a
+  ;; mechanism that stops being reached — a row deleted, a row that returns
+  ;; early, a row whose poll silently degrades — fails here instead of
+  ;; quietly shrinking what the suite covers.
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM, so no mechanism is exercised there")
+    (is (= declared-population @!exercised)
+        (str "every declared abandonment mechanism must be reached; missing: "
+             (pr-str (set/difference declared-population @!exercised))))))

--- a/implementation/hicasso/test/re_frame/hicasso/kernel_commit_owns_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/kernel_commit_owns_dom_cljs_test.cljs
@@ -101,8 +101,9 @@
 (rf/reg-sub :kcod/left  (fn [db _] (:left db)))
 (rf/reg-sub :kcod/right (fn [db _] (:right db)))
 
-(rf/reg-event :kcod/seed      (fn [_ [_ db]] {:db db}))
-(rf/reg-event :kcod/bump-left (fn [{:keys [db]} _] {:db (update db :left inc)}))
+(rf/reg-event :kcod/seed       (fn [_ [_ db]] {:db db}))
+(rf/reg-event :kcod/bump-left  (fn [{:keys [db]} _] {:db (update db :left inc)}))
+(rf/reg-event :kcod/bump-right (fn [{:keys [db]} _] {:db (update db :right inc)}))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -177,6 +178,38 @@
 (defn- poll
   [pred label]
   (test-support/poll-until pred {:label label :timeout-ms 4000}))
+
+(defn- prove-live!
+  "Settle the commit's PASSIVE phase on a condition, never on a duration —
+  and prove the acquisition is real in the same act.
+
+  The DOM text appears at the mutation phase, but `useSyncExternalStore`
+  calls `subscribe` in a **passive** effect that React flushes later. A row
+  that read the reader count the moment its text appeared would be reading
+  it before the acquisition it is asserting about — measured: the
+  StrictMode row failed exactly there, at `0` readers, on a page already
+  showing the committed value.
+
+  Waiting a chosen number of milliseconds would fix that and would be the
+  assumption this file refuses to make. So the wait is a **write
+  round-trip**: dispatch, and poll until the boundary repaints. A boundary
+  React has not finished subscribing cannot repaint, so the new text is
+  proof the passive phase is done — and it is proof the surviving
+  registration is LIVE rather than merely present, which is a stronger
+  statement than the count alone.
+
+  It cannot deadlock on the race it closes. If the write lands before
+  `subscribe`, the notification reaches nobody — and the boundary heals
+  anyway, because the cell is then born at a later `commit-basis` than the
+  render's snapshot and React's post-subscribe re-read schedules the
+  correcting render. Both orders arrive at the same repaint.
+
+  It cannot mask a leak either, because the condition is orthogonal to the
+  quantity under test: the count is asserted afterwards, and a second
+  reader changes the count without changing the text."
+  [handle event expected label]
+  (mount/dispatch! handle event)
+  (poll #(= expected (text handle)) label))
 
 (defn- teardown-census!
   "Unmount, settle at the runtime's own horizon, ASSERT, and only then
@@ -274,6 +307,10 @@
                 (poll #(= "left=1" (text handle)) "the retry commits")))
             (.then
               (fn [_]
+                (prove-live! handle [:kcod/bump-left] "left=2"
+                             "the retried boundary is subscribed and live")))
+            (.then
+              (fn [_]
                 (testing "the retry committed the boundary React had thrown
                           away, and acquired its read set EXACTLY ONCE — two
                           readers here would paint the identical page and
@@ -349,6 +386,10 @@
                                 "the transition completes")))))))
             (.then
               (fn [_]
+                (prove-live! handle [:kcod/bump-right] "right=8"
+                             "the completed boundary is subscribed and live")))
+            (.then
+              (fn [_]
                 (testing "and the completion acquires the read set exactly
                           once — the abandoned attempt contributed no second
                           reader"
@@ -370,41 +411,50 @@
       (do (skip! ":node-test has no DOM") (done))
       (let [_      (seeded!)
             before (collector/body-runs)
+            ;; TWO boundaries reading DIFFERENT keys, and that is the whole
+            ;; design of this row rather than incidental scenery.
+            ;;
+            ;; With one boundary reading one key the additivity defect is
+            ;; INVISIBLE: a scratch that accumulated `[left left]` still
+            ;; resolves to the read SET `#{left}`, so the acquired edges are
+            ;; identical and the row passes with the reset defeated —
+            ;; measured, on the sabotage run that was supposed to red it.
+            ;; With two boundaries the second body's scratch accumulates the
+            ;; FIRST's key, so it acquires an edge it never read and `left`
+            ;; gains a reader nothing will ever release. That is the defect
+            ;; this row is named for, and this is the smallest tree in which
+            ;; it can be seen.
             handle (mount-concurrent!
                      (mount/fresh-container!)
                      (react/createElement (.-StrictMode react) nil
-                                          (app [left-line {}])))]
-        (-> (poll #(= "left=1" (text handle)) "the strict tree commits")
+                                          (app [:div
+                                                [left-line {}]
+                                                [right-line {}]])))]
+        (-> (poll #(= "left=1right=7" (text handle)) "the strict tree commits")
             (.then
               (fn [_]
+                ;; Taken BEFORE the write below, which would add further runs.
                 (testing "the premise, and it is the whole point of the row:
-                          StrictMode really did run the body TWICE. A green
-                          here with a delta of 1 would be a green for a
+                          StrictMode really did run BOTH bodies twice. A green
+                          here with a delta of 2 would be a green for a
                           StrictMode that never engaged"
-                  (is (= 2 (- (collector/body-runs) before))))
-
-                (testing "two body runs, and ONE acquisition. The scratch is
-                          reset by overwrite at the top of every body, so the
-                          second run replaces the first's reads instead of
-                          being appended to them"
-                  (is (= 1 (readers-of [:kcod/left])))
-                  (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1}
-                         (ownership))))
-
-                (testing "and StrictMode's mount/unmount/remount of every
-                          effect left exactly one live registration, not a
-                          stranded one beside it"
-                  (is (= 1 (:entries (inventory/residue)))))
-
-                (testing "the boundary is the LIVE one: a write still reaches
-                          it, so the surviving registration is the remounted
-                          one and not a detached first"
-                  (mount/dispatch! handle [:kcod/bump-left])
-                  (poll #(= "left=2" (text handle)) "the write reaches it"))))
+                  (is (= 4 (- (collector/body-runs) before))))
+                (prove-live! handle [:kcod/bump-left] "left=2right=7"
+                             "the strict boundaries are subscribed and live")))
             (.then
               (fn [_]
-                (is (= 1 (readers-of [:kcod/left]))
-                    "and the write added no reader")
+                (testing "four body runs, and ONE acquisition each. The
+                          scratch is reset by overwrite at the top of every
+                          body, so neither the second run of a body nor the
+                          body after it inherits the reads already taken —
+                          and StrictMode's mount/unmount/remount of every
+                          effect left one live registration per boundary
+                          rather than a stranded one beside it"
+                  (is (= 1 (readers-of [:kcod/left])))
+                  (is (= 1 (readers-of [:kcod/right])))
+                  (is (= {:cells 2 :cell-refs 2 :boundaries 2 :edges 2}
+                         (ownership)))
+                  (is (= 2 (:entries (inventory/residue)))))
                 (exercised! :strict-mode/double-invoke)
                 (teardown-census! handle)))
             (.then (fn [_] (done)))
@@ -445,6 +495,10 @@
                 ;; `:reset-key` clears the caught failure and remounts.
                 (.render ^js (:root handle) (guarded 1))
                 (poll #(= "right=7" (text handle)) "the retry commits")))
+            (.then
+              (fn [_]
+                (prove-live! handle [:kcod/bump-right] "right=8"
+                             "the retried boundary is subscribed and live")))
             (.then
               (fn [_]
                 (testing "and the retry acquires exactly its read set, with


### PR DESCRIPTION
Witnesses for invariant **I5 — render probes, commit owns** (`docs/design/hicasso/product/invariants.md`), in two new files:

- `implementation/hicasso/test/re_frame/hicasso/kernel_commit_owns_cljs_test.cljs` — node lane, 9 rows
- `implementation/hicasso/test/re_frame/hicasso/kernel_commit_owns_dom_cljs_test.cljs` — browser lane, 6 rows

No runtime source changed. The five sabotages below were applied temporarily, run, and reverted; `git diff HEAD -- implementation/hicasso/src` is empty on every commit.

## Why two lanes

The bead's five abandonment mechanisms need a real concurrent root, so they live in the DOM file — and **the browser lane is not in the fast-PR spine**. The node file is therefore the only thing guarding this kernel on an ordinary PR, and it takes the properties that can be stated exactly without a DOM.

## The observables, and why they can distinguish this runtime from plain React

Every abandonment row asserts on **reader membership** (`inventory/cell-readers`), never on the painted value. If an abandoned attempt *did* acquire, the page still paints correctly — React committed the right tree, and the leak is an extra slot on a cell that no cleanup will ever remove. `1 reader` and `2 readers` render identically and differ absolutely. Plain React has no such structure; the retention is this runtime's own, and the leak is invisible anywhere else. This is the generalisation of the controlled-input finding: value-level assertions stay green under real regressions.

The gap row is the deliberate exception and reads the **painted value**, because there the failure mode *is* a stale value — precisely what plain `useSyncExternalStore` over a store with no commit basis would produce.

## Properties witnessed

**DOM lane — real React abandonment.** Each row asserts its own premise (`body-runs` moved, so React genuinely ran the body it discarded) before asserting any zero; a row that skipped that would hold for a render that never happened.

| Property | How React abandons | Negative control |
|---|---|---|
| Suspense: abandoned attempt acquires nothing; retry acquires exactly once | sibling throws a thenable, fallback commits | S1 |
| Transition abort: new tree renders and is dropped whole, old UI kept | `startTransition` whose tree suspends | S1 |
| StrictMode double-invoke is not additive | React runs both bodies twice, mounts/unmounts/remounts every effect | S1, S2 |
| Error-then-retry: throwing attempt leaves nothing; `:reset-key` retry acquires exactly once | render-phase throw caught by `h/boundary` | S1 |
| Delayed commit: a write in the render-to-commit gap heals the boundary | sibling's `useLayoutEffect` writes after every body returned, before the passive subscribe | S1, S3b |

**Node lane — exact acquisition laws.** Server render runs every body and acquires nothing; commit acquires exactly the current read set and nothing else; a branch not taken contributes no edge; a body that throws after its reads leaves nothing **and contaminates no later body's read set**; a re-render before the commit owns only the second attempt's set; two subscribes on one entry are two readers whose two cleanups leave none; the gap moves the snapshot when something lands in it and by nothing when it does not.

## Negative controls — every witness shown to fail first

| # | Sabotage in `impl/collector.cljs` | Node lane | Browser lane |
|---|---|---|---|
| S1 | acquire during the render (leak one abandoned-read registration per body run) — **the bead's named sabotage** | 28 failures, 5 errors, exit 1 | 19 failures, exit 1 (all five rows + every teardown census) |
| S2 | scratch reset made conditional (`if empty`) | 8 failures, 4 errors, exit 1 | 4 failures, exit 1 *(after the fix below)* |
| S3a | staged key contributes 0 to `getSnapshot` | 1 failure (the quiet control row), exit 1 | not run |
| S3b | faithful rf2-2rtt6.42: staged 0 **and** cell born at epoch 0 | 1 failure (the gap row), exit 1 | 3 failures, exit 1 |
| S4 | `release-cell!` never splices the membership | 5 failures, exit 1 | not run |

S1 also reds the pre-existing package smoke, which is the right blast radius.

### Two things the controls found that review would not have

**The StrictMode row was not testing what it claimed.** Under S2 the browser lane stayed **green**. One boundary reading one key cannot see that defect: an accumulated scratch of `[left left]` still resolves to the read *set* `#{left}`, so the acquired edges are byte-identical. The row is now two boundaries reading different keys — the smallest tree in which the second body inherits the first's key, acquires an edge it never read, and leaves a reader nothing releases. The same sabotage then reds four assertions. Commit `8c2cae9013`.

**S3a and S3b are different defects.** S3a reds the *quiet* control row, S3b the *gap* row. The pair is one witness in two halves; neither alone pins the property, and the first sabotage I wrote was not faithful to the historical bug.

## A race the controls also exposed

`useSyncExternalStore` calls `subscribe` in a **passive** effect that runs after the DOM shows the committed value. The first DOM run failed at `0 readers` on a page already painting correctly — the row was reading the count before the acquisition it asserted about. The other four rows passed by luck and shared the latent race.

Fixed with `prove-live!`: dispatch a write and poll until the boundary repaints. A boundary React has not finished subscribing cannot repaint, so the repaint is a **condition, not a duration**; it cannot deadlock (if the write beats `subscribe`, the boundary heals via the commit-basis path instead — both orders reach the same repaint); and it cannot mask a leak, because the settle condition is orthogonal to the quantity asserted afterwards. It also strengthens each row: the surviving registration is proven *live*, not merely present.

## Gate-rule compliance

- **Residue census before any fixture reset.** Every DOM row ends `mount/unmount!` then settle then **assert** then `mount/release!`. A census after `release!` answers zero whether teardown worked or not (rf2-2rtt6.48).
- **Published exercised population.** `declared-population` is asserted, not described: a final row fails naming the missing mechanisms if any was not reached at runtime. Under S3b it fired correctly with `missing: #{:render-to-commit-gap/heal :strict-mode/double-invoke}`.
- **Zero time-based / reaper assumptions.** Every wait is `poll-until` on the condition itself or `inventory/quiesced!`, the runtime's own horizon. Neither file contains a timer of its own (`7f67f4e1a9` removed the last one).
- **In-suite sabotage control.** `the-residue-census-can-answer-false` leaks one abandoned-read registration by hand and asserts the census reports it, so no zero in the file can be an instrument's silence. This is durable; the source-mutation controls above are not committed.

## Notes for the reviewer

- **Bead vs brief.** The bead names `impl/collector.cljs` in-surface and declares this bead the owner of collector mutations while open; my brief said runtime source was off-limits. No permanent source change was needed either way, and none was made.
- The DOM file cannot reuse the prototype's `arm1/mount.cljs` harness — the freeze gate's SEALED check forbids the package importing `re-frame.bench.*` — so it carries a minimal concurrent-root harness of its own. It deliberately does **not** use `mount/root!`, whose `flushSync` would invent a schedule for Suspense and transitions.
- No hot-zone file touched: no `shadow-cljs.edn`, no `deps.edn`, no workflow, no `invariants.md`. The new namespaces join `:browser-test`, `:node-test` and `:node-test-hicasso` by existing regex, and the browser DOM-lane partition still holds (matched by exactly one lane).
- Section 7 of `invariants.md` is rf2-hic-013's landing slot and is untouched. No freeze paragraph is recorded here.

## Quality gates

| Gate | Command | Exit |
|---|---|---|
| hicasso package node suite | `shadow-cljs compile node-test-hicasso && node out/node-test-hicasso.js` — 17 tests, 61 assertions | **0** |
| repo-wide node/CLJS | `npm run test:cljs` — 12829 tests, 64523 assertions | **0** |
| browser lane | `shadow-cljs compile browser-test && node scripts/serve-and-run-browser-tests.cjs` — 1138 tests, 6999 assertions | **0** |
| hicasso freeze + SEALED | `npm run test:hicasso-freeze` — 11 frozen rows match; no package file imports the bench tree | **0** |
| fast PR spine | `sh scripts/test-fast-pr.sh` — `PASS fast PR spine` | **0** |

Spine tiering: docs and JVM tiers classified out (CLJS-test-only diff); node tier ran. The browser lane is not in the spine and was run separately, above.
