### PR TITLE
docs(hicasso): route rf2-84w6 authoring names into the naming ledger

### DIFF
--- a/docs/design/hicasso/product/naming-ledger.md
+++ b/docs/design/hicasso/product/naming-ledger.md
@@ -4,7 +4,7 @@
 
 | # | Current name | Candidate(s) | Recommendation | Status |
 |---|---|---|---|---|
-| 1 | `h/fn` | `h/handler` | `h/handler` (one invariant meaning; spec §4) | open |
+| 1 | `hfn` (taught as `h/fn`) | `h/handler` (spec §4 facade table); `h/event` (cross-adaptor vocabulary) | `h/event` — the established v/·ui/ vocabulary reserves `event` for "convert invoker's args to one event vector or `nil`" and `handler` for imperative return-ignored work (spec/004-Views.md §4.x table, 004D callback table); Hicasso's form has exactly the `event` contract, so `handler` would be a cross-adaptor false friend. One invariant meaning either way; never `fn` (shadows `cljs.core/fn` for `:refer` users). Both candidates stand for the sitting (rf2-84w6) | open |
 | 2 | `:&` merge key | remove; pure owned-wins merge helper/recipe | remove from grammar (spec §4 disposition) | open |
 | 3 | `h/reg-state` | remove from adaptor core; reconsider in forms | remove from core | open |
 | 4 | `subscribe-once` | internal/advanced | internal until a caller proves `sub` inadequate | open |
@@ -16,8 +16,9 @@
 | 10 | `n/use-sub` / `n/use-frame` | keep | keep | open |
 | 11 | `h/as-element` | keep | keep | open |
 | 12 | `h/error-boundary` | keep | keep | open |
-| 13 | root lifecycle | `mount!` `hydrate!` `render!` `unmount!` | keep the four | open |
+| 13 | root lifecycle: door has `root!` + `release!` (impl also holds `hydrate-root!` `render!` `unmount!`, docstring-unfrozen) | `mount!` `hydrate!` `render!` `unmount!` on the facade; `release!` → test kit | the four verbs (`root!`→`mount!`, `hydrate-root!`→`hydrate!`; matches React's createRoot/hydrateRoot model); retire `release!` from the door — it calls process-wide `collector/reset-runtime!`, a test-fixture reset, not per-root lifecycle in a multi-root product; it moves to the test kit under an explicit test-wide-reset name. `root!`/`release!` ratified provisional until the sweep (rf2-84w6) | open |
 | 14 | package/artifact name | `implementation/hicasso`, artifact name TBD | `re-frame.hicasso` (provisional) | open |
 | 15 | test-kit namespace | `re-frame.hicasso.test` | keep | open |
 | 16 | forms module ns | `re-frame.hicasso.forms` | provisional | open |
 | 17 | overlay module ns | `re-frame.hicasso.overlay` | provisional | open |
+| 18 | `hframe` (taught as `h/frame`) | `frame` (mechanical rename); or retire in favour of the core doors `rf/current-frame-id` + zero-arity `rf/capture-frame` admitted during a Hicasso body | retire — spec §4 already says "Existing `rf/current-frame-id` and `rf/capture-frame` remain the frame doors; Hicasso should not duplicate them"; and `hframe` returns a frame-id keyword while `ui/frame`/`n/use-frame` name frame *operations* (false friend). NOTE: the retire path is SEMANTIC, not mechanical — the ambient-refusal seam must admit exactly `:current-frame-id`/`:capture-frame` inside a Hicasso body (resolving to the body's `:extent-frame`; ambient `rf/subscribe`/`rf/dispatch` stay refused), so rf2-hic-066 files a bead for it rather than improvising (rf2-84w6) | open |


### PR DESCRIPTION
Routes bead rf2-84w6 (ratify hfn / hframe / root!+release!) into the ruled naming machinery: rename nothing now; the ledger accumulates, rf2-hic-065 publishes the packet, rf2-hic-066 sweeps once, the operator's single sitting settles overrides.

- Row 1: current name corrected to the actual var (hfn, taught as h/fn); carries BOTH candidates — h/handler (spec §4 facade table) and h/event (cross-adaptor vocabulary: v/event and ui/event return an event vector or nil, v/handler and ui/handler are imperative/return-ignored) — with h/event recommended. Never fn (shadows cljs.core/fn for :refer users).
- Row 13: current name corrected to the actual door pair root!/release!; recommends the spec's four-verb lifecycle (root! to mount!, hydrate-root! to hydrate!, render!, unmount!) and retiring release! to the test kit (it calls process-wide collector/reset-runtime!, a test-fixture reset, not per-root lifecycle). Pair ratified provisional until the sweep.
- Row 18 (new): hframe (taught h/frame); candidates frame vs retire-in-favour-of-core-doors; retire recommended per spec §4's own text (core keeps the frame doors; Hicasso should not duplicate them), flagged SEMANTIC for the sweep — the refusal seam must admit :current-frame-id/:capture-frame during a Hicasso body, so hic-066 files a bead rather than improvising.

Full decision record with implementation guidance is on bead rf2-84w6.

Verification: this tree is excluded from mkdocs; verified by hand — the table stays one table, every row has exactly 5 cells, no markdown links added (nothing for check_doc_slugs.py to break).