### PR TITLE
fix(hicasso): scope the hydration adoption window to its root (rf2-6tmu)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
@@ -21,7 +21,7 @@
   | **this one** | the render context, the cell table, the commit, the two read tiers, the read-set entries, the generation fence, the two shells and the two mint doors |
   | [[re-frame.hicasso.impl.generation]] | the flush generation, the registry epoch and `commit-basis` |
   | [[re-frame.hicasso.impl.frames]] | the two frame-locked memo tables and their invalidation |
-  | [[re-frame.hicasso.impl.roots]] | the hydration adoption window |
+  | [[re-frame.hicasso.impl.roots]] | the hydration adoption window — one per root, and NOT this module's to empty (rf2-6tmu) |
   | [[re-frame.hicasso.impl.evidence]] | the dev-only sink seam |
   | [[re-frame.hicasso.impl.inventory]] | what the runtime RETAINS: the declared census and the measured one |
 
@@ -401,7 +401,6 @@
             [re-frame.hicasso.impl.frames :as frames]
             [re-frame.hicasso.impl.generation :as generation]
             [re-frame.hicasso.impl.intent :as intent]
-            [re-frame.hicasso.impl.roots :as roots]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.live-frame :as live-frame]
@@ -1809,7 +1808,18 @@
   It lives here because the collector holds most of what it drops, and it
   calls each sibling's own door for the rest — a module that owns state
   owns the act of emptying it, so this fn cannot silently miss a slot
-  somebody adds elsewhere."
+  somebody adds elsewhere.
+
+  **It does NOT touch the hydration adoption window** (rf2-6tmu). It used
+  to, because the window was one boolean for the whole page and a fixture
+  that threw mid-hydration would otherwise leave the page permanently
+  adopting. A window now belongs to the root that minted it and is
+  reachable only from that root's handle, so there is nothing page-wide
+  left to rescue: a root whose construction threw left an unreachable
+  object, and a root that is torn down is closed by
+  `impl.mount/unmount!`. Reaching in from here would be the opposite of
+  the repair — a reset in one root shutting a sibling root's window while
+  it is still adopting."
   []
   (doseq [[_ cell] @!cells] (dispose-cell! cell))
   (reset! !cells {})
@@ -1822,8 +1832,6 @@
   (set! (.-frame rstate) nil)
   (set! (.-probe rstate) nil)
   (set! (.-length scratch) 0)
-  ;; A fixture that threw mid-hydration must not leave the page adopting.
   ;; `bodyRuns` is deliberately NOT reset here — see [[body-runs]].
-  (roots/close-adoption-window!)
   (frames/forget-frame-ops!)
   nil)

--- a/implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs
@@ -63,27 +63,34 @@
   tree's SHAPE is decided**, and the reason it is a function of the
   handle rather than of its two callers.
 
-  A hydrated root carries [[adoption-window-closer]] as a Fragment
-  sibling of the app subtree, and it has to carry it on EVERY subsequent
-  render: React reconciles a root by its top element, so handing a
-  hydrated root a bare provider where a Fragment stood would not be a
-  cheaper render, it would be a different tree — React unmounts the
-  adopted subtree and mounts a fresh one, discarding every node, cell and
-  subscription the adoption just established. Measured: the first
-  `render!` after a hydration re-ran all four boundary bodies and
-  replaced all four DOM nodes.
+  A hydrated root carries [[adoption-window-closer]] and its own
+  adoption-window provider as a Fragment around the app subtree, and it
+  has to carry them on EVERY subsequent render: React reconciles a root
+  by its top element, so handing a hydrated root a bare provider where a
+  Fragment stood would not be a cheaper render, it would be a different
+  tree — React unmounts the adopted subtree and mounts a fresh one,
+  discarding every node, cell and subscription the adoption just
+  established. Measured: the first `render!` after a hydration re-ran all
+  four boundary bodies and replaced all four DOM nodes.
+
+  **The window is what says a root is hydrated** (rf2-6tmu). The handle
+  used to carry a separate `:hydrated?` boolean to drive this branch;
+  now the presence of `:adoption` says the same thing and is the thing
+  the wrapper is FOR, so there is one fact here rather than two that
+  could disagree.
 
   An ordinary root gets no wrapper at all, which keeps the tree the whole
   bench lane measures exactly what it was — no extra fiber, no extra
-  passive effect, and nothing new in
+  passive effect, no context provider, and nothing new in
   `re-frame.hicasso.impl.inventory/retained-inventory`."
   [handle hiccup]
   (let [app (provider (:frame handle)
                       (codec/root-element (:frame handle) hiccup))]
-    (if (:hydrated? handle)
+    (if-some [window (:adoption handle)]
       (react/createElement (.-Fragment react) nil
-                           (react/createElement adoption-window-closer nil)
-                           app)
+                           (react/createElement adoption-window-closer
+                                                #js {:rfWindow window})
+                           (roots/with-adoption window app))
       app)))
 
 (defn render!
@@ -112,21 +119,28 @@
     handle))
 
 (defn adoption-window-closer
-  "The component that CLOSES the adoption window, on the hydration commit
-  and not before (rf2-2rtt6.84).
+  "The component that CLOSES **its own root's** adoption window, on that
+  root's hydration commit and not before (rf2-2rtt6.84, rf2-6tmu).
 
-  Lifted verbatim in shape from the spine's own
-  `re-frame.substrate.spine/adoption-window-closer`: a passive
-  `useEffect` with empty deps, so it runs exactly once and strictly AFTER
-  the commit that adopted the server DOM. Renders nil — no DOM, so it
-  adds nothing for `hydrateRoot` to match and cannot itself mismatch.
+  Lifted in shape from the spine's own
+  `re-frame.substrate.spine/adoption-window-closer`, down to taking the
+  window off a prop: a passive `useEffect` with empty deps, so it runs
+  exactly once and strictly AFTER the commit that adopted the server DOM.
+  Renders nil — no DOM, so it adds nothing for `hydrateRoot` to match and
+  cannot itself mismatch.
+
+  The window arrives as `rfWindow` rather than being read from a module
+  slot, and that prop IS the repair: a closer can only shut the window
+  its own root minted, so a sibling root still adopting stays adopting.
 
   Public because that is what makes adoption OBSERVABLE without a probe:
-  `(roots/adopting?)` answering false is this effect having run, which is
-  the completion signal a witness waits on in place of the `flushSync`
-  [[hydrate-root!]] refuses to perform."
-  [_props]
-  (react/useEffect (fn close-window [] (roots/close-adoption-window!) js/undefined)
+  `(roots/adopting? (:adoption handle))` answering false is this effect
+  having run, which is the completion signal a witness waits on in place
+  of the `flushSync` [[hydrate-root!]] refuses to perform."
+  [^js props]
+  (react/useEffect (fn close-window []
+                     (roots/close-adoption-window! (.-rfWindow props))
+                     js/undefined)
                    #js [])
   nil)
 
@@ -194,30 +208,44 @@
                 :recovery :warned-and-replaced}))
 
 (defn hydration-reporter
-  "The `onRecoverableError` a hydrating root installs. **The callback
-  itself, not a builder** — the spine builds one per root because its
-  adoption window is root-local; this arm's window is module-level
-  (`roots/adopting?`, and the reason is stated there), so there is
-  nothing to close over.
+  "BUILD the `onRecoverableError` for the root that owns `window`
+  (rf2-6tmu). A builder, exactly as the spine's
+  `re-frame.substrate.spine/native-hydration-reporter` is a builder, and
+  for the spine's reason: the window it consults belongs to ONE root, so
+  the callback has to close over it.
 
-  Emits the framework diagnostic ONLY while the adoption window is open,
-  then ALWAYS reports. React holds this callback for the root's whole
-  lifetime and fires it for post-hydration recoverable errors too — a
-  concurrent render it retried and recovered — and emitting outside the
-  window would label one of those a hydration mismatch. The window shuts
-  on the hydration commit, from [[adoption-window-closer]]'s passive
-  effect.
+  Emits the framework diagnostic ONLY while THAT root's window is open,
+  then ALWAYS reports. Both halves matter and they fail in opposite
+  directions:
+
+    - React holds this callback for the root's whole lifetime and fires
+      it for post-hydration recoverable errors too — a concurrent render
+      it retried and recovered. Emitting outside the window would label
+      one of those a hydration mismatch. **Reading a page-wide window
+      here would mislabel a completed root's later recovery whenever any
+      sibling was still adopting** — which is what a page-global
+      reference count would have bought.
+    - Never emitting is the other failure, and it is the one that was
+      shipping: a page-wide boolean let root A's closer silence root B's
+      genuine mismatch.
+
+  The delegation is unconditional in both cases — installing ANY
+  `onRecoverableError` takes React's default off, so `rf2-mwx08`'s
+  fail-open is preserved by reporting whether or not the framework
+  emitted.
 
   Public because that is what lets a witness drive the REAL callback
   across the window boundary rather than a copy of it — the spine's own
   reason for publishing `native-hydration-reporter`."
-  [error _error-info]
-  (when (roots/adopting?)
-    (emit-hydration-mismatch! error))
-  (report-recoverable-default! error))
+  [^js window]
+  (fn on-recoverable [error _error-info]
+    (when (roots/adopting? window)
+      (emit-hydration-mismatch! error))
+    (report-recoverable-default! error)))
 
 (defn- hydrate-root-options
-  "The `react-dom/client` root options for a hydrating root, or nil.
+  "The `react-dom/client` root options for the root owning `window`, or
+  nil.
 
   Nil in production, where the emit DCEs behind `interop/debug-enabled?`
   and the only thing left to install would be a replica of the default
@@ -226,9 +254,9 @@
   way, one clause wider: it also installs for a host-authored
   `:on-recoverable-error`, and this arm has no host-authored callback to
   compose with."
-  []
+  [window]
   (when interop/debug-enabled?
-    #js {:onRecoverableError hydration-reporter}))
+    #js {:onRecoverableError (hydration-reporter window)}))
 
 (defn hydrate-root!
   "Associate `container`'s **existing server-rendered DOM** with
@@ -274,18 +302,31 @@
   [[hydrate-root-options]] answers nil and this call is the bare
   two-argument one it always was.
 
-  ## The handle carries `:hydrated?`, and it has to
+  ## The handle carries `:adoption` — this root's OWN window (rf2-6tmu)
 
   [[root!]]'s three keys are all here and every door takes this handle
-  unchanged. The fourth key is not decoration: the wrapper above is part
-  of the ROOT's shape, so [[render!]] has to reproduce it or React tears
-  the adopted tree down and rebuilds it. [[tree]] is the one place that
-  decision is made and `:hydrated?` is what it reads."
+  unchanged. The fourth key is not decoration and it is not a flag: it is
+  the window itself, minted here and reachable from nowhere else. Three
+  things need it and each gets the same object — the closer, the
+  reporter, and the provider presence reads — so \"this root is adopting\"
+  is one fact with one owner rather than a page-wide slot four callers
+  race for.
+
+  It is also what [[tree]] branches on, because the wrapper is part of the
+  ROOT's shape and [[render!]] has to reproduce it or React tears the
+  adopted tree down and rebuilds it.
+
+  **Minted unconditionally, unlike the spine's** — which mints only when
+  it is going to install a reporter, because its window has no other
+  reader. This arm's window has a PRODUCTION reader: presence starts an
+  adopted child `:present` rather than `:mounting`, which is behaviour a
+  release build must keep. So the window and its provider ride in
+  production and only the reporter is debug-gated."
   [container frame-kw hiccup]
-  (roots/open-adoption-window!)
-  (let [handle  {:frame frame-kw :container container :hydrated? true}
+  (let [window  (roots/open-adoption-window!)
+        handle  {:frame frame-kw :container container :adoption window}
         element (tree handle hiccup)
-        opts    (hydrate-root-options)]
+        opts    (hydrate-root-options window)]
     (assoc handle :root (if opts
                           (react-dom-client/hydrateRoot container element opts)
                           (react-dom-client/hydrateRoot container element)))))
@@ -302,8 +343,19 @@
   wants to assert on teardown therefore calls this, waits one macrotask
   for the cell and entry reapers, asserts, and resets afterwards.
 
-  Idempotent, for the same reason [[release!]] is."
+  **Shuts this root's adoption window first** (rf2-6tmu). A root torn
+  down before its passive effects ever ran never gets its closer, and an
+  open window that outlives its root is a window nothing can ever shut.
+  Root teardown owns root state, so it is this door's job and not a
+  page-wide reset's — closing a sibling's window from a reset is exactly
+  the cross-root reach this bead removed.
+
+  Idempotent, for the same reason [[release!]] is —
+  `roots/close-adoption-window!` is idempotent and nil-tolerant, so an
+  ordinary handle (which carries no window) and a second call are both
+  no-ops."
   [handle]
+  (roots/close-adoption-window! (:adoption handle))
   (when-some [r (:root handle)]
     (react-dom/flushSync (fn [] (.unmount r))))
   (when-some [c (:container handle)]

--- a/implementation/hicasso/src/re_frame/hicasso/impl/presence_react.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/presence_react.cljs
@@ -6,11 +6,14 @@
 
   ## What this costs, stated rather than buried
 
-  **Three React hooks — `useContext`, `useState` and `useEffect` — in
-  THIS component.** The ≤2-hook budget HD-020(b) polices is the *boundary
-  shell's*, and this is not a boundary shell: it reads no subscription,
-  mounts no registration and takes no cell. `collector/shell` is untouched
-  and the dispatcher-level ledger still counts exactly two there.
+  **Four React hooks — two `useContext`, one `useState` and one
+  `useEffect` — in THIS component.** The ≤2-hook budget HD-020(b)
+  polices is the *boundary shell's*, and this is not a boundary shell: it
+  reads no subscription, mounts no registration and takes no cell.
+  `collector/shell` is untouched and the dispatcher-level ledger still
+  counts exactly two there. The second `useContext` is the root-scoped
+  adoption window (rf2-6tmu); it is paid HERE, by the optional component
+  that reads it, and nowhere else in the arm.
 
   The two lifecycle hooks are legitimate under HD-003's placement rule
   rather than in spite of it: presence is animation lifecycle, which is
@@ -71,9 +74,18 @@
 
   A hydrating tree's children are already on the screen, so they start
   `:present` rather than `:mounting` — the machine's own `settle`,
-  applied one render earlier, gated on `roots/adopting?`. It costs no
-  hook, changes no transform, and is scoped to the adoption window; see
-  the comment at the binding below."
+  applied one render earlier, gated on `roots/adopting-here?`. It changes
+  no transform, and it is scoped to the adoption window of **the root
+  this tray is actually in** (rf2-6tmu).
+
+  That scoping is the fourth hook, and it is the one cost this component
+  grew. It reads a context whose default is `nil`, so a tray in an
+  ordinary root — including a tray mounted while some *other* root is
+  hydrating — reads no provider and answers false. Before rf2-6tmu the
+  gate was a page-wide boolean, and an unrelated ordinary root's tray was
+  told it was adopting for as long as any root anywhere was hydrating:
+  it skipped its enter transition for a hydration it had nothing to do
+  with. The window it reads now can only be its own root's."
   (:require [re-frame.adapter.context :as adapter-context]
             [re-frame.hicasso.impl.codec :as codec]
             [re-frame.hicasso.impl.collector :as collector]
@@ -111,15 +123,15 @@
         ;; earlier. So this is ADOPTION BEHAVIOUR — a different starting
         ;; phase for a tree that is being adopted — and not a second
         ;; render mode: the transform, the overrides, the deadlines and
-        ;; the terminal bound are all unchanged, and `adopting?` is false
-        ;; for every ordinary mount and false again the moment the
-        ;; closer commits.
+        ;; the terminal bound are all unchanged, and `adopting-here?` is
+        ;; false for every ordinary mount and false again the moment
+        ;; THIS root's closer commits.
         ;;
-        ;; A SERVER render entry opens the same window, so the server's
-        ;; HTML and the client's first pass agree by construction; that
-        ;; agreement is the whole reason the flag is read here in the
-        ;; RENDER rather than in the effect below.
-        next       (if (roots/adopting?) (presence/settle stepped) stepped)]
+        ;; A SERVER render entry opens a window of its own around its own
+        ;; request, so the server's HTML and the client's first pass agree
+        ;; by construction; that agreement is the whole reason the window
+        ;; is read here in the RENDER rather than in the effect below.
+        next       (if (roots/adopting-here?) (presence/settle stepped) stepped)]
     ;; Adjusting state while rendering — React's own answer to "a value
     ;; derived from props that must persist". `step` is idempotent, so the
     ;; equality test converges rather than looping.

--- a/implementation/hicasso/src/re_frame/hicasso/impl/roots.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/roots.cljs
@@ -1,74 +1,120 @@
 (ns re-frame.hicasso.impl.roots
-  "THE HYDRATION ADOPTION WINDOW (rf2-2rtt6.84) — one boolean, and the
-  three doors that move it (rf2-hic-009).
+  "THE HYDRATION ADOPTION WINDOW (rf2-2rtt6.84) — one window PER ROOT, and
+  the three doors that move it (rf2-hic-009, rf2-6tmu).
 
-  The window is what tells a render *whether the DOM it is about to
-  produce is already on the screen*. `re-frame.hicasso.impl.mount` opens
-  it around `hydrateRoot` and the root's closer component shuts it on the
-  hydration commit; `re-frame.hicasso.impl.presence-react` is the one
-  reader, and it reads it during a RENDER.
+  A window is what tells a render *whether the DOM it is about to produce
+  is already on the screen*. `re-frame.hicasso.impl.mount` opens one
+  around each `hydrateRoot` and hands it to that root's closer, which
+  shuts it on that root's hydration commit;
+  `re-frame.hicasso.impl.presence-react` is the one reader, and it reads
+  it during a RENDER, through the context [[with-adoption]] installs.
 
-  It is its own namespace because the flag is **module-level and the
-  runtime is multi-root**, and those two facts are in tension. Today that
-  tension is stated rather than engineered around (see [[adoption]]);
-  rf2-hic-012 is the bead that has to resolve it, by making adoption
-  root-scoped. A boundary drawn here means that bead edits one small file
-  whose entire contents are the thing it is changing, rather than
-  thirty lines inside two thousand — and means the reviewer of that
-  change can see the whole of the before at once.
+  It is its own namespace because the window is the whole mechanism and
+  it is worth being able to see all of it at once: the ref, the three
+  doors, the context that carries it down a subtree, and the hook that
+  reads it. The root LIFECYCLE proper — `root!`, `hydrate-root!`,
+  `render!`, `unmount!`, `release!` — lives in
+  `re-frame.hicasso.impl.mount`.
 
-  The root LIFECYCLE proper — `root!`, `hydrate-root!`, `render!`,
-  `unmount!`, `release!` — lives in `re-frame.hicasso.impl.mount`, which
-  the copy brought over as its own file and which rf2-hic-009 therefore
-  did not carve. The two files together are rf2-hic-012's surface.")
+  ## It used to be ONE BOOLEAN FOR THE WHOLE PAGE, and that was a defect
 
-(def ^:private ^js adoption
-  "Is this page's tree being ADOPTED from server-rendered HTML right now?
+  Every hydrating root opened the same module-level flag and every root's
+  closer shut it, so N overlapping adoptions performed N opens and the
+  FIRST close ended the window for all of them. Two consequences, both
+  measured (PR #7751, rf2-6tmu):
 
-  Opened by [[re-frame.hicasso.impl.mount/hydrate-root!]] before it
-  calls `hydrateRoot`, and closed by that root's closer component from a
-  passive effect on the hydration commit — the spine's own pattern
-  (`re-frame.substrate.spine/adoption-window-closer`), whose whole point
-  is that a passive effect runs strictly AFTER the commit and therefore
-  cannot close the window early.
+    - **A silenced diagnostic.** Two overlapping divergent hydrations
+      produced two React `Hydration failed` complaints and only ONE
+      `:rf.ssr/hydration-mismatch`. Root B's mismatch was discarded, so
+      every tool reading the instrumentation stream saw a healthy root
+      that had in fact failed to adopt.
+    - **Cross-root presence interference.** While ANY root hydrated, a
+      presence tray in an unrelated ORDINARY root was told it was
+      adopting too, and lost its enter transition.
 
-  **Module-level, like every other slot in this arm.** The collector's
-  `rstate`, its scratch and its cell table are one-per-page too. A page
-  hydrates once, at boot, so one window is the shape the case has; a
-  second hydrating root opened while the first window is still open would
-  share it, and that limit is stated rather than engineered around. The
-  spine keeps its flag root-local because it hands the flag to its closer
-  as a prop — doing the same here would put a prop or a context read on
-  `impl.presence-react`, which is a cost this arm has no case for.
+  Correctness rested on the relative ordering of commits, passive
+  effects, presence renders and recoverable-error callbacks across
+  otherwise-independent roots. React's root API gives no reason to treat
+  page-wide ordering as an invariant — `onRecoverableError` is an option
+  of an *individual* `hydrateRoot`, and independently configured roots on
+  one page are supported — so the ordering was an accident this arm
+  depended on. Now each root carries its own window and nothing about one
+  root's lifecycle is visible in another's.
 
-  A boolean and nothing else: it selects **adoption behaviour** in a
-  renderer that still has exactly one render mode (the charter's
-  one-mode law). Nothing branches on it but presence's born-present
-  seeding."
-  #js {"open" false})
-
-(defn adopting?
-  "Is a hydration adoption in flight?
-
-  False on every ordinary client mount, and false again the moment the
-  adopted root's closer commits. A server render entry opens the same
-  window around its own `renderToString`, so the two halves of an SSR
-  route answer this identically — which is what stops the client's first
-  pass from rendering something the server did not."
-  []
-  (.-open adoption))
+  A page-global REFERENCE COUNT would not have fixed it: it keeps B's
+  window open when A commits, so a later recoverable error from the
+  already-committed A is falsely labelled a hydration mismatch, and it
+  still leaks adoption semantics into presence components outside both
+  hydrating subtrees. It converts one interference bug into another."
+  (:require ["react" :as react]))
 
 (defn open-adoption-window!
-  "Declare the renders that follow to be adopting server-rendered DOM."
+  "Open a window and answer it — the ONLY handle on it there is.
+
+  Minted per `hydrate-root!` call and per server render/request. Born
+  open: the renders that follow it are adopting server-rendered DOM until
+  something calls [[close-adoption-window!]] on this very object.
+
+  A bare mutable ref rather than a registry entry, and deliberately.
+  A registry keyed by frame cannot work — several roots may intentionally
+  share a frame — and one keyed by container recreates React context
+  badly and adds a cleanup path that can leak. The ref is reachable only
+  from the root that minted it, so a root whose construction throws
+  leaves nothing behind to close: the window it would have opened is
+  simply unreachable. That is the shape of the prior art in this repo —
+  `re-frame.substrate.spine` mints `#js {:adopting true}` per root and
+  closes over it in its reporter, and the Freehand root does the same
+  while also closing over its root-id."
   []
-  (set! (.-open adoption) true)
-  nil)
+  #js {"open" true})
+
+(defn adopting?
+  "Is `window` open — is THIS root adopting server-rendered DOM?
+
+  **Nil is closed**, and that is the load-bearing default rather than
+  defensiveness: an ordinary client mount has no window at all, and a
+  subtree with no [[adoption-context]] provider above it reads `nil` and
+  answers false. So the absence of an adoption is spelled the same way
+  everywhere and there is no third state to reason about."
+  [^js window]
+  (and (some? window) (true? (.-open window))))
 
 (defn close-adoption-window!
-  "Close the window. The closer component's passive effect calls this,
-  and so does [[re-frame.hicasso.impl.collector/reset-runtime!]] — a
-  fixture that throws mid-hydration must not leave the page permanently
-  adopting."
-  []
-  (set! (.-open adoption) false)
+  "Shut `window`. Idempotent, and nil-tolerant for the same reason
+  [[adopting?]] is.
+
+  Called by that root's closer component from a passive effect on the
+  hydration commit, and again by `impl.mount/unmount!` — a root torn down
+  before its passive effect ever ran must not leave an open window
+  behind. Both doors belong to the root that minted the window; nothing
+  page-wide closes it, because a reset or a sibling's teardown must not
+  change the lifecycle state of a root that is still adopting."
+  [^js window]
+  (when (some? window) (set! (.-open window) false))
   nil)
+
+(defonce ^:private adoption-context
+  ;; The window, carried down ONE root's subtree. The default is `nil`,
+  ;; which [[adopting?]] reads as closed — so every tree with no provider
+  ;; above it (every ordinary mount, every Hicasso boundary anywhere) gets
+  ;; the right answer with no provider, no object and no branch. Only a
+  ;; hydrating root installs one. This is the shape the compiled tier's
+  ;; phase context already uses for the same fact.
+  (react/createContext nil))
+
+(defn with-adoption
+  "Scope `window` over `element`'s subtree. Renders no DOM of its own, so
+  it cannot move a canonical-DOM parity comparison and cannot itself
+  mismatch."
+  [window element]
+  (react/createElement (.-Provider adoption-context) #js {:value window} element))
+
+(defn adopting-here?
+  "A hook — is the subtree THIS component renders in being adopted?
+
+  False on every ordinary client mount, false in any root that is not
+  hydrating however many siblings are, and false again the moment this
+  root's own closer commits. One `useContext` and no other cost, paid
+  only by the optional presence component that reads it."
+  []
+  (adopting? (react/useContext adoption-context)))

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
@@ -1,17 +1,26 @@
 (ns re-frame.hicasso.roots-frames-hydration-dom-cljs-test
   "TWO OVERLAPPING HYDRATING ROOTS — independent adoption, independent
-  complaints, independent teardown; and the ONE remaining process-global
-  in the way (rf2-hic-012).
+  complaints, independent presence, independent teardown (rf2-hic-012,
+  rf2-6tmu).
 
-  The bead's second and third deliverables. The second is a property:
-  two roots adopting server markup at the same time must not corrupt or
-  silence one another. The third is a decision: the shared hydration
-  adoption window is moved to root scope, *or* the remaining global is
-  justified in writing, feeding rf2-hic-017 (\"the mutable-global sweep —
-  root-scope or justify every one\"). This suite takes the second branch,
-  and it takes it by MEASURING the global rather than by arguing about
-  it — see [[the-adoption-window-is-one-boolean-for-the-whole-page]],
-  which is the row rf2-hic-017 inherits.
+  The property: two roots adopting server markup at the same time must
+  not corrupt or silence one another. rf2-hic-012 wrote these rows and
+  found the property FALSE — the hydration adoption window was one
+  boolean for the whole page, so root A's closer shut the window root B
+  was still adopting in, and root B's mismatch diagnostic was silently
+  discarded. That worker was fenced off runtime source, so it measured
+  the global rather than repairing it and left in-file instructions for
+  the repair to follow.
+
+  rf2-6tmu is that repair: one window per root, minted by
+  `hydrate-root!`, reachable only from that root's handle, and carried to
+  that root's closer, its reporter and its presence subtree. The rows
+  below are the same rows with their measurements turned into
+  properties — H2's two counts are now equal, and the row that existed
+  only to record the global (`the-adoption-window-is-one-boolean-for-the-whole-page`)
+  is deleted rather than re-pinned, exactly as its own comment
+  instructed. H4 replaces it with the property it was standing in for,
+  and H5 covers the window's second reader.
 
   ## Why adoption cannot be witnessed on the markup
 
@@ -93,6 +102,47 @@
    [:p.value (h/sub label-q)]])
 
 ;; ---------------------------------------------------------------------------
+;; The presence app — H5's, and the observable that makes a PHASE readable
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !phases
+  ;; `tag -> [phase …]`, every phase each probe was rendered with, in
+  ;; order. Reset at the top of the row that reads it.
+  (atom {}))
+
+(h/defview phase-probe
+  "A presence child that is a BOUNDARY, so the machine hands it its phase
+  as the ordinary prop `:rf/phase` (`impl.presence/with-phase`) instead of
+  merging attribute overrides into a node.
+
+  **That prop is why this row has an observable at all.** A NATIVE
+  presence child wears its phase as `::h/mounting` attributes, which React
+  patches in place and which are gone a macrotask later when the enter
+  flip lands — so a row that waited for a commit and then read the DOM
+  could not tell a child that was BORN present from one that entered and
+  settled. Both end as the same markup, which is the same trap node
+  identity exists to escape elsewhere in this file. Recording the phase
+  where the machine computes it records the FIRST one, and the first one
+  is the entire question.
+
+  Recorded as a sequence rather than a last-value, so a body that runs
+  twice cannot turn a `:mounting` first render into a `:present` one."
+  [{:keys [tag] :as props}]
+  (let [phase (:rf/phase props)]
+    (swap! !phases update tag (fnil conj []) phase)
+    [:span.probe (name phase)]))
+
+(h/defview tray-screen
+  "A screen with a presence tray in it. Reads the label subscription as
+  [[screen]] does, so this root acquires a frame-keyed cell and its commit
+  is observable; the tray is what the row is about."
+  [{:keys [tag]}]
+  [:div.screen
+   [:p.value (h/sub label-q)]
+   [h/presence {:timeout-ms 50}
+    [phase-probe {:key "one" :tag tag}]]])
+
+;; ---------------------------------------------------------------------------
 ;; Harness
 ;; ---------------------------------------------------------------------------
 
@@ -139,10 +189,15 @@
                 hb (mount/hydrate-root! cb frame-b [screen {:title "B"}])]
             ;; The overlap is a CONSTRUCTION, not a timing guess: both
             ;; roots were handed to React before either had adopted, and
-            ;; the window being open on this line is what says so.
-            (is (true? (roots/adopting?))
-                "both roots are in flight — `hydrate-root!` returns before
-                 the tree is adopted, so the window outlives both calls")
+            ;; each root's OWN window being open on this line is what says
+            ;; so. Two windows, because since rf2-6tmu there are two —
+            ;; asserting one page-wide flag here would have been satisfied
+            ;; by either root alone.
+            (is (true? (roots/adopting? (:adoption ha)))
+                "root A is in flight — `hydrate-root!` returns before the
+                 tree is adopted, so its window outlives the call")
+            (is (true? (roots/adopting? (:adoption hb)))
+                "and so is root B, in its own window")
             (-> (sup/wait-until! both-committed?)
                 (.then
                   (fn [ok]
@@ -178,42 +233,47 @@
 ;; H2 — two overlapping mismatches, two independent complaints
 ;; ---------------------------------------------------------------------------
 
-;; ## MEASURED DEFECT — the second root's complaint is LOST (rf2-hic-012)
+;; ## THE INDEPENDENCE WITNESS — two divergences, two complaints EACH WAY
+;; (rf2-hic-012 measured it; rf2-6tmu repaired it)
 ;;
-;; The bead asks for two overlapping hydrating roots with *independent
-;; mismatch complaints*. Run, they are not independent, and this row is the
-;; measurement rather than an argument:
+;; The bead asked for two overlapping hydrating roots with *independent
+;; mismatch complaints*. As shipped they were not independent, and the
+;; version of this row that PR #7751 landed was the measurement:
 ;;
-;;   - React reports BOTH divergences. Two roots diverge, and two
+;;   - React reported BOTH divergences. Two roots diverge, and two
 ;;     "Hydration failed because…" errors reach the page's own error
 ;;     channel, because `impl.mount/report-recoverable-default!` delegates
 ;;     unconditionally.
-;;   - Spec 011's `:rf.ssr/hydration-mismatch` fires ONCE. The emit is
-;;     gated `(when (roots/adopting?))`, the window is one boolean for the
-;;     whole page (`impl.roots`), and root A's closer shuts it from a
-;;     passive effect before root B's hydration commit reports. Root B's
-;;     mismatch is therefore invisible to every tool that reads the
-;;     instrumentation stream.
+;;   - Spec 011's `:rf.ssr/hydration-mismatch` fired ONCE. The emit was
+;;     gated on a window that was one boolean for the whole page, and root
+;;     A's closer shut it from a passive effect before root B's hydration
+;;     commit reported. Root B's mismatch was invisible to every tool that
+;;     reads the instrumentation stream.
 ;;
-;; Those two counts together are what make this a finding about THIS ARM
-;; and not about React: the divergence was detected and reported, and only
-;; the framework's own diagnostic went missing. It is exactly the sabotage
-;; the bead's acceptance describes — "re-globalizing the adoption window
-;; must turn the overlapping-roots witness red" — except that the window
-;; has never been de-globalized, so the witness is red on arrival.
+;; Those two counts together are what made it a finding about THIS ARM and
+;; not about React: the divergence was detected and reported, and only the
+;; framework's own diagnostic went missing.
 ;;
-;; **The fix is the bead's third deliverable: root-scope the window.** That
-;; is a change to `impl/roots.cljs` and `impl/mount.cljs`, which this
-;; worker's dispatch fences off ("if a witness requires changing runtime
-;; source under implementation/hicasso/src/, STOP and report"), so it is
-;; reported rather than made — see the PR body. rf2-hic-017 owns the
-;; global sweep and is blocked by this bead.
+;; rf2-6tmu root-scoped the window — one per `hydrate-root!`, reachable
+;; only from that root's handle, carried to that root's closer, reporter
+;; and presence subtree — so the two counts are now EQUAL and this row
+;; asserts that. **The row PR #7751 left carried in-file instructions to
+;; replace both of its assertions with `(= 2 (count @seen))`, and that is
+;; what happened**: the strict-inequality assertion became an equality
+;; against the React count, and the `1` became `2`. Neither was re-pinned
+;; and neither was deleted.
 ;;
-;; The assertion below therefore pins `1` and says why. **It must be
-;; changed to `2` — not re-pinned, not deleted — when the window becomes
-;; root-scoped**, at which point it becomes the independence witness the
-;; bead asked for.
-(deftest two-overlapping-hydrating-roots-recover-independently-but-only-one-complains
+;; Both halves are load-bearing and they fail in opposite directions. The
+;; equality catches a diagnostic going missing again — the defect that was
+;; here. The absolute `2` catches the opposite repair, a window that is
+;; never shut at all, which would keep both counts equal while making
+;; every later recoverable error on either root a "hydration mismatch";
+;; H4 below is the row that separates those two.
+;;
+;; SABOTAGE (run by hand, PR body records it): mint ONE window in
+;; `hydrate-root!` and hand it to both roots, and this row goes red on the
+;; count — one root's closer shuts the other's window again.
+(deftest two-overlapping-hydrating-roots-recover-and-complain-independently
   (async done
     (if-not (mount/browser?)
       (do (sup/skip! ":node-test has no DOM") (done))
@@ -250,19 +310,18 @@
                             (str "two roots diverged, so two React complaints; got "
                                  (pr-str (mapv #(subs % 0 (min 60 (count %))) @captured)))))
 
-                      (testing "but the framework's own stream carried FEWER than
-                                the page did. MEASURED DEFECT (rf2-hic-012 /
-                                rf2-hic-017): the Spec 011 emit is gated on a
-                                page-scoped adoption window, and one root's
-                                closer shut it before the other root's mismatch
-                                was reported. Root-scope the window and these two
-                                counts become equal — at which point BOTH
-                                assertions below must be replaced by
-                                `(= 2 (count @seen))`."
-                        (is (< (count @seen) (count react-complaints))
-                            "a divergence React reported went missing from the
-                             instrumentation stream")
-                        (is (= 1 (count @seen))
+                      (testing "and the framework's own stream carried exactly
+                                what the page did. This is the rf2-6tmu repair:
+                                each root's Spec 011 emit is gated on the window
+                                THAT root minted, so no root's closer can shut
+                                another root's window and no divergence React
+                                reported goes missing"
+                        (is (= (count react-complaints) (count @seen))
+                            (str "every divergence React reported reached the
+                                  instrumentation stream; React said "
+                                 (count react-complaints) ", the framework said "
+                                 (count @seen)))
+                        (is (= 2 (count @seen))
                             (str "`:rf.ssr/hydration-mismatch` count; got "
                                  (count @seen) " — "
                                  (pr-str (mapv (comp :error sup/tags-of) @seen)))))
@@ -343,57 +402,245 @@
                                 (done)))))))))))))))
 
 ;; ---------------------------------------------------------------------------
-;; H4 — the remaining global, MEASURED. rf2-hic-017's row.
+;; H4 — a COMPLETED root's later recovery is not a mismatch, however many
+;;      siblings are still adopting. THE ROW THAT RULES OUT A COUNTER.
 ;; ---------------------------------------------------------------------------
 
-;; **This row exists to be DELETED**, and saying so is the point.
+;; The row that stood here measured the page-global — two opens shut by one
+;; close — and carried an in-file instruction to be DELETED rather than
+;; re-pinned once the window became root-scoped (rf2-hic-012 → rf2-6tmu).
+;; It is deleted. What follows is not a re-pin of it: it is the property
+;; that measurement was standing in for, and it discriminates against a
+;; strictly larger set of wrong answers.
 ;;
-;; rf2-hic-012's third deliverable is to move the hydration adoption window
-;; to root scope *or* to justify the remaining global in writing. This is
-;; the justification, in the only form worth having: a measurement, taken
-;; through the shipping doors, of exactly what the global does.
+;; **H2 alone would pass under a page-global REFERENCE COUNT.** Two opens,
+;; one close, count still one — both roots' mismatches emit and the two
+;; numbers match. What a count cannot do is tell root A's window from root
+;; B's, and React makes that difference matter: it holds
+;; `onRecoverableError` for a root's WHOLE LIFETIME and fires it for
+;; post-hydration recoveries too, a concurrent render it retried. Once A has
+;; committed, an error arriving on A is not a hydration mismatch. Under a
+;; count it would be labelled one for as long as B kept the page-wide window
+;; open — one interference bug traded for another.
 ;;
-;; `impl.roots` holds ONE boolean. `impl.mount/hydrate-root!` opens it per
-;; root, and each root's `adoption-window-closer` shuts it from a passive
-;; effect on that root's hydration commit. So N overlapping roots perform N
-;; opens and the FIRST close ends the window for all of them. The readers
-;; are `impl.presence-react`, during render, and
-;; `impl.mount/hydration-reporter`, which emits the Spec 011 diagnostic
-;; only `(when (roots/adopting?))`.
+;; So this row completes A, leaves B adopting, and sends one error to each:
 ;;
-;; The consequence is a conditional, and the condition is React's: while
-;; React commits two same-tick hydrations before flushing either root's
-;; passive effects, no complaint is lost, and H2 above measures that it is
-;; not. **The property therefore holds today by React's scheduling and not
-;; by this runtime's design** — a root whose hydration commit landed after
-;; another root's closer had run would have its mismatch diagnostic
-;; silently dropped, and nothing in this arm prevents that ordering. That
-;; is the whole of the case for rf2-hic-017, and the two rows together are
-;; its evidence: H2 says the property holds, this row says what it rests
-;; on.
+;;   | root | its window        | the error it gets         | must emit |
+;;   |---|---|---|---|
+;;   | A    | committed, closed | a later recoverable error | NO        |
+;;   | B    | still adopting    | its hydration mismatch    | YES       |
 ;;
-;; When the window becomes root-scoped this row goes RED, because two opens
-;; will no longer be shut by one close. That is its job. Re-pinning it
-;; would be the wrong repair; deleting it is the right one.
-(deftest the-adoption-window-is-one-boolean-for-the-whole-page
+;; Three shapes fail it and only root-scoping passes. A page-global BOOLEAN
+;; emits nothing, because A's close shut B's window too. A page-global
+;; COUNT emits twice, because A's later error arrives inside a page window B
+;; is still holding open. One shared ref does whichever of those its last
+;; write said.
+;;
+;; The doors are called DIRECTLY — `open-adoption-window!`, the real
+;; `hydration-reporter` builder over the real window, `close-adoption-window!`
+;; — which is exactly what `hydrate-root!` does per root with React's
+;; schedule removed. That is deliberate rather than a shortcut: the two
+;; orderings this row separates are orderings React does not let a caller
+;; choose, so a version that waited for them would be measuring the
+;; scheduler and would go green or red on timing. It is the same technique
+;; the deleted row used, turned on the property instead of on the defect.
+(deftest a-completed-roots-later-recovery-is-not-a-mismatch-while-a-sibling-adopts
   (if-not (mount/browser?)
     (sup/skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (try
-        (is (false? (roots/adopting?)) "premise: no adoption is in flight")
-        ;; The two doors a hydrating root takes, called directly — this is
-        ;; what `hydrate-root!` does per root, with React's schedule
-        ;; removed so the arity is the only variable left.
-        (roots/open-adoption-window!)
-        (roots/open-adoption-window!)
-        (is (true? (roots/adopting?)) "two roots, adopting")
-        ;; What ONE root's closer does, on ONE root's hydration commit.
-        (roots/close-adoption-window!)
-        (is (false? (roots/adopting?))
-            "MEASURED (rf2-hic-017): one root's closer shuts the window for
-             every root. The window is page-scoped, so a second root still
-             adopting is no longer adopting as far as every reader is
-             concerned. This assertion must be DELETED, not re-pinned, when
-             the window becomes root-scoped.")
-        (finally (roots/close-adoption-window!))))))
+      (let [{:keys [seen stop!]}      (sup/watch-mismatches!)
+            ;; MANUFACTURED here and asserted on here — the only shape of
+            ;; call site at which swallowing an uncaught error is not the
+            ;; fail-open rf2-mwx08 forbids.
+            {:keys [captured close!]} (sup/open-console-capture! {:swallow-uncaught? true})
+            window-a (roots/open-adoption-window!)
+            window-b (roots/open-adoption-window!)
+            report-a (mount/hydration-reporter window-a)
+            report-b (mount/hydration-reporter window-b)
+            later-a  (js/Error. "a concurrent render root A recovered from")
+            genuine-b (js/Error. "Hydration failed on root B")]
+        (try
+          (is (true? (roots/adopting? window-a)) "premise: root A is adopting")
+          (is (true? (roots/adopting? window-b)) "premise: root B is adopting")
+
+          ;; Root A's hydration commits. Its closer shuts ITS window.
+          (roots/close-adoption-window! window-a)
+
+          (testing "one root's closer shuts one root's window"
+            (is (false? (roots/adopting? window-a)) "root A has completed")
+            (is (true? (roots/adopting? window-b))
+                "and root B is STILL ADOPTING — this single pair of readings
+                 is the whole repair, and it is what the deleted row
+                 measured going the other way"))
+
+          (testing "a LATER recoverable error on the completed root A is not a
+                    hydration mismatch, however many siblings are adopting —
+                    the assertion a page-global reference count fails"
+            (report-a later-a nil)
+            (is (= 0 (count @seen))
+                (str "nothing should have been emitted; got "
+                     (pr-str (mapv (comp :error sup/tags-of) @seen)))))
+
+          (testing "while root B's genuine mismatch, arriving while B is still
+                    adopting, DOES emit — the assertion a page-global boolean
+                    fails"
+            (report-b genuine-b nil)
+            (is (= 1 (count @seen)) "exactly one diagnostic")
+            (is (= "Hydration failed on root B"
+                   (:error (sup/tags-of (first @seen))))
+                "and it is B's error, not A's"))
+
+          (testing "IN-ROW DISCRIMINATION: the same later error on A, read
+                    against a window some OTHER root is still holding open, is
+                    mislabelled a mismatch. So the zero above is a property of
+                    the scoping and not of the error"
+            ((mount/hydration-reporter window-b) later-a nil)
+            (is (= 2 (count @seen))
+                "a page-wide window still open elsewhere would have labelled
+                 A's later recovery a hydration mismatch")
+            (is (= "a concurrent render root A recovered from"
+                   (:error (sup/tags-of (last @seen))))))
+
+          (testing "and rf2-mwx08's fail-open is untouched in every case: the
+                    reporter ALWAYS delegates, emit or no emit"
+            (is (= 3 (count (filterv #(re-find #"root A|root B" %) @captured)))
+                (str "all three errors reached the page's own error channel: "
+                     (pr-str @captured))))
+          (finally
+            (close!)
+            (stop!)
+            (roots/close-adoption-window! window-b)))))))
+
+;; ---------------------------------------------------------------------------
+;; H5 — presence isolation: adoption belongs to a SUBTREE, not to the page
+;; ---------------------------------------------------------------------------
+
+;; The mismatch diagnostic was the LOUD half of the page-global. This is the
+;; quiet half, and it is the one an application would have felt: presence is
+;; a second reader of the same window, and it reads it during a RENDER.
+;;
+;; While ANY root hydrated, the window answered true for every presence tray
+;; on the page — including one in an ORDINARY root that had nothing to do
+;; with the hydration and was not adopting anything. Such a tray was told its
+;; children were already on the screen, so it started them `:present` and
+;; skipped the enter transition its author wrote. Nothing complained; the
+;; animation simply did not play, and only when a sibling root happened to be
+;; hydrating.
+;;
+;; The construction makes that overlap a FACT rather than a race, the way H1
+;; does: `hydrate-root!` returns before its tree is adopted, so root A's
+;; window is provably open on the line where root B mounts, and `root!`
+;; commits inside a `flushSync` so root B's first render is readable on the
+;; line after it. No timer stands between the two.
+;;
+;; SABOTAGE (run by hand, PR body records it): point `impl.presence-react`
+;; back at a page-wide window and the ordinary root's first phase becomes
+;; `:present` — this row reds on that assertion, which is the assertion the
+;; shipped code failed.
+(deftest presence-adoption-belongs-to-a-subtree-not-to-the-page
+  (async done
+    (if-not (mount/browser?)
+      (do (sup/skip! ":node-test has no DOM") (done))
+      (do
+        (fresh!)
+        (reset! !phases {})
+        (-> (sup/settled-server-html!
+              frame-a [tray-screen {:tag :hydrated}]
+              (fn [c] (= "present" (text-in c ".probe"))))
+            (.then
+              (fn [html]
+                (is (re-find #"present" html)
+                    (str "premise: the server's bytes show the child already
+                          PRESENT — " html))
+                ;; The server render's own phases are not this row's subject.
+                (reset! !phases {})
+                (collector/reset-runtime!)
+                (let [ca (sup/stamp-server-nodes! (sup/server-dom! html))
+                      cb (mount/fresh-container!)
+                      {:keys [seen stop!]} (sup/watch-mismatches!)
+                      ha (mount/hydrate-root! ca frame-a [tray-screen {:tag :hydrated}])]
+                  (is (true? (roots/adopting? (:adoption ha)))
+                      "premise: root A is adopting on THIS line, so what follows
+                       happens inside its window by construction")
+                  ;; An ORDINARY root, mounted inside root A's adoption window.
+                  (let [hb (mount/root! cb frame-b [tray-screen {:tag :ordinary}])]
+                    (testing "the ordinary sibling gets its ENTER phase, even
+                              though a hydration is in flight elsewhere on the
+                              page — the row the shipped page-global failed"
+                      (is (= :mounting (first (get @!phases :ordinary)))
+                          (str "root B's first render must see :mounting; saw "
+                               (pr-str (get @!phases :ordinary))))
+                      (is (= "mounting" (text-in cb ".probe"))
+                          "and it reached the DOM that way"))
+
+                    (testing "an ordinary root has no adoption window at all —
+                              nil, which `adopting?` reads as closed. That is
+                              what makes the repair free for it: no object, no
+                              provider, no branch"
+                      (is (nil? (:adoption hb)))
+                      (is (false? (roots/adopting? (:adoption hb)))))
+
+                    (-> (sup/adopted! ha)
+                        (.then
+                          (fn [ok]
+                            (stop!)
+                            (try
+                              (is (true? ok) "root A's own closer ran")
+
+                              (testing "root A was BORN PRESENT: its tray never
+                                        rendered a :mounting phase at all, so no
+                                        enter transition replayed over DOM the
+                                        user already watched arrive"
+                                (is (= :present (first (get @!phases :hydrated)))
+                                    (str "root A's first render; saw "
+                                         (pr-str (get @!phases :hydrated))))
+                                (is (not (contains? (set (get @!phases :hydrated))
+                                                    :mounting))
+                                    "and no later render entered one either"))
+
+                              (testing "so the client's first pass AGREED with the
+                                        server's bytes — the adopted nodes are the
+                                        server's own, and nothing diverged"
+                                (is (sup/every-server-node? ca ".screen, .probe"))
+                                (is (= 0 (count @seen))
+                                    (str "no hydration mismatch; got "
+                                         (pr-str (mapv (comp :error sup/tags-of)
+                                                       @seen)))))
+
+                              (testing "closing root A's window changed nothing
+                                        about root B: B still completed its own
+                                        enter transition, on its own clock"
+                                (is (false? (roots/adopting? (:adoption ha))))
+                                (is (= [:mounting :present]
+                                       (vec (distinct (get @!phases :ordinary))))
+                                    (str "root B entered and then settled; saw "
+                                         (pr-str (get @!phases :ordinary))))
+                                (is (= "present" (text-in cb ".probe"))))
+
+                              (testing "and TEARDOWN BEFORE THE PASSIVE EFFECT
+                                        leaves no open window behind. A root
+                                        unmounted before its hydration commit
+                                        never gets its closer, so `unmount!`
+                                        owns the shut — driven here on a handle
+                                        with no root, which is what a closer
+                                        that never ran leaves behind (the
+                                        `:root nil` idiom `teardown-census!`
+                                        uses), rather than on a live root whose
+                                        mid-hydration teardown would be
+                                        measuring React's unmount instead"
+                                (let [window (roots/open-adoption-window!)
+                                      orphan {:frame     frame-a
+                                              :container (mount/fresh-container!)
+                                              :root      nil
+                                              :adoption  window}]
+                                  (is (true? (roots/adopting? window))
+                                      "premise: open, and its closer has not run")
+                                  (mount/unmount! orphan)
+                                  (is (false? (roots/adopting? window))
+                                      "teardown shut it")))
+
+                              (finally
+                                (mount/release! ha)
+                                (mount/release! hb)
+                                (done)))))))))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
@@ -205,15 +205,24 @@
 (defn server-html!
   "The bytes an SSR route would deliver for `hiccup` under `frame-kw`.
 
-  Rendered under an OPEN adoption window, which is the state a server
-  render is in, and released afterwards so the runtime the hydration is
-  measured on is empty. The prototype's
-  `arm1.hydration-support/server-html!` does exactly this, and the
-  honesty caveat is the same: these are the client tier's own bytes, so
-  a row that cares about a *particular* string reads it back out of the
-  captured markup rather than assuming it."
+  Rendered on an ordinary root and released afterwards, so the runtime
+  the hydration is measured on is empty. The prototype's
+  `arm1.hydration-support/server-html!` does the same, and the honesty
+  caveat is the same: these are the client tier's own bytes, so a row
+  that cares about a *particular* string reads it back out of the
+  captured markup rather than assuming it.
+
+  **It no longer opens an adoption window** (rf2-6tmu). It used to, on
+  the grounds that an open window is the state a server render is in —
+  but the window was page-global then, so \"opening\" one was a free
+  module write. A window is now minted per root and reaches a subtree
+  only through the provider `impl.mount` installs for a HYDRATING root,
+  and there is no product door that opens one around an ordinary render;
+  giving the harness a private one would be inventing product API for a
+  test. Nothing is lost, because the only reader is presence and the
+  trees rendered through this fn carry none — see
+  [[settled-server-html!]] for the ones that do."
   [frame-kw hiccup]
-  (roots/open-adoption-window!)
   (let [container (mount/fresh-container!)
         handle    (mount/root! container frame-kw hiccup)
         html      (.-innerHTML container)]
@@ -261,28 +270,32 @@
     (and (seq ns') (every? server-node? ns'))))
 
 (defn adopted!
-  "Wait for the adoption window to shut — the closer component's passive
-  effect — and then for the reapers. Answers a promise of true, or of
-  false if the window never shut inside `budget-ms`.
+  "Wait for `handle`'s OWN adoption window to shut — that root's closer
+  component's passive effect — and then for the reapers. Answers a
+  promise of true, or of false if the window never shut inside
+  `budget-ms`.
 
   Real timers only: no `act`, no `flushSync`. `impl.mount/hydrate-root!`
   deliberately does not force hydration synchronously, so there is no
   flush that would make this a straight line, and manufacturing one
   would manufacture a schedule no shipped caller has.
 
-  **The window it polls is one boolean for the whole page**
-  (`impl.roots`), so in a two-root row this answers *some* root's closer
-  and not a named one. Where that distinction matters, the hydration
-  suite says so at the call site and reads a per-root observable
-  instead."
-  ([] (adopted! 3000))
-  ([budget-ms]
+  **This is a NAMED root's completion signal, and before rf2-6tmu it
+  could not be one.** The window it polls used to be one boolean for the
+  whole page, so it answered *some* root's closer and never said which —
+  which is why the two-root rows below were written against
+  [[wait-until!]] and the cell table instead. Now the window is the one
+  this root minted and nothing else can shut it, so waiting on it is
+  waiting on this root."
+  ([handle] (adopted! handle 3000))
+  ([handle budget-ms]
    (js/Promise.
      (fn [resolve]
-       (let [deadline (+ (js/Date.now) budget-ms)]
+       (let [deadline (+ (js/Date.now) budget-ms)
+             window   (:adoption handle)]
          (letfn [(tick []
                    (cond
-                     (not (roots/adopting?))
+                     (not (roots/adopting? window))
                      ;; Past the closer AND past the entry reap horizon,
                      ;; so a reading of the entry cache is taken on the
                      ;; far side of the race.
@@ -298,12 +311,11 @@
   "Poll `pred?` on real timers until it answers truthy. Answers a promise
   of true, or of false if `budget-ms` elapses first.
 
-  **This is how a two-root row waits, and [[adopted!]] is not.** The
-  adoption window is one boolean for the whole page, so `(adopting?)`
-  going false says *some* root's closer ran and never says which. A
-  per-root completion signal has to come from something the root itself
-  produced — its cells, which are acquired at COMMIT and therefore cannot
-  appear before that root committed."
+  How a two-root row waits on something that is not a window: the cell
+  table, which acquires at COMMIT and therefore cannot mention a frame
+  before that frame's root committed. [[adopted!]] is the other per-root
+  signal and since rf2-6tmu it is a genuine one; the rows below use
+  whichever names the fact they are about."
   ([pred?] (wait-until! pred? 3000))
   ([pred? budget-ms]
    (js/Promise.
@@ -315,6 +327,39 @@
                      (< deadline (js/Date.now)) (resolve false)
                      :else                     (js/setTimeout tick 4)))]
            (tick)))))))
+
+(defn settled-server-html!
+  "The bytes an SSR route delivers for a tree that contains a PRESENCE
+  tray: every child already PRESENT, which is what a server emits because
+  a server has no enter transition to play. Answers a promise of the
+  html; `settled?` is called with the container and says when the tray
+  has stopped moving.
+
+  Down here rather than beside [[server-html!]] only because it waits,
+  and [[wait-until!]] is what it waits with.
+
+  [[server-html!]] cannot be used for such a tree. It reads `innerHTML`
+  on the line after a `flushSync` render, and on an ordinary root that is
+  the FIRST pass — every child `:mounting`, wearing its `::h/mounting`
+  overrides. Hydrating against those bytes would compare a settled client
+  tree with an entering server tree and manufacture a divergence no row
+  here is about.
+
+  So the harness lets the client tier's own enter flip land and reads
+  afterwards. That is the honest way to get settled bytes out of a client
+  renderer, and it needs no adoption window: the tray reaches `:present`
+  by PLAYING its transition, which is precisely the thing the hydrated
+  root must not do."
+  [frame-kw hiccup settled?]
+  (let [container (mount/fresh-container!)
+        handle    (mount/root! container frame-kw hiccup)]
+    (-> (wait-until! (fn [] (settled? container)))
+        (.then (fn [ok]
+                 (is (true? ok)
+                     "premise: the server tree settled before its bytes were read")
+                 (let [html (.-innerHTML container)]
+                   (mount/release! handle)
+                   html))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The two complaint channels


### PR DESCRIPTION
Fixes rf2-6tmu.

## The mechanism, before and after

**Before.** `impl/roots.cljs` allocated ONE private JS object at module load and its no-argument `open` / `close` / `read` doors all addressed that singleton. `hydrate-root!` opened it for every hydrating root; every hydrated root mounted a closer that shut it; every root installed the same `hydration-reporter`, which consulted the singleton rather than anything belonging to its React root. So N overlapping adoptions performed N opens and the **first** close ended the window for all of them.

Two readers, two consequences, both measured by PR #7751 rather than inferred:

* **A silenced diagnostic.** Two overlapping divergent hydrations produced **two** React `Hydration failed` complaints and **one** `:rf.ssr/hydration-mismatch`. Root A's closer shut the window before root B's mismatch reported, so root B's mismatch was invisible to everything reading the instrumentation stream — Xray, tests, and every future SSR witness saw a healthy root that had failed to adopt.
* **Cross-root presence interference.** `impl/presence_react.cljs` is a second reader, and it reads during a *render*. While any root hydrated, a presence tray in an unrelated **ordinary** root was told it was adopting too, so it started its children `:present` and silently skipped the enter transition its author wrote.

Correctness rested on the relative ordering of commits, passive effects, presence renders and recoverable-error callbacks across otherwise-independent roots. React gives no reason to treat page-wide ordering as an invariant: `onRecoverableError` is an option of an *individual* `hydrateRoot`, and independently configured roots on one page are supported.

**After.** One small mutable window per hydrating root, kept internal.

* `roots/open-adoption-window!` mints `#js {"open" true}` and answers it — the only handle on it there is. `adopting?` and `close-adoption-window!` take that object; both are nil-tolerant, and **nil is closed**, so "no adoption" has one spelling everywhere and there is no third state.
* `hydrate-root!` mints the window **before** it builds the root element, and stores it on the handle as `:adoption`. Three things get the same object: the closer (as the `rfWindow` prop), the reporter, and the provider presence reads.
* `hydration-reporter` is now a **builder** closing over that window — the spine's shape (`native-hydration-reporter`), for the spine's reason. It emits only while *that* root's window is open, then **always** delegates, so `rf2-mwx08`'s fail-open is untouched.
* The window rides down the root's subtree in a React context whose default is `nil`. `presence` reads it through `roots/adopting-here?`. An ordinary root, an ordinary boundary, and any tray outside a hydrating subtree acquire **no object, no provider, no hook, no registry lookup and no branch** — the context default answers for them.
* `tree` branches on `(:adoption handle)` instead of a separate `:hydrated?` boolean. The wrapper is still reproduced on every `render!` (React reconciles a root by its top element; changing it would tear the adopted subtree down), but the fact driving it is now the thing the wrapper is *for*, so there are no longer two facts that could disagree.
* `unmount!` shuts the window. A root torn down before its passive effects ran never gets its closer, and root teardown owns root state.

**Rejected shapes, and why the witnesses rule them out.** A page-global reference count keeps B's window open when A commits — so a later recoverable error from the already-committed A gets labelled a hydration mismatch, converting one interference bug into another. It also still leaks adoption semantics into presence components outside both hydrating subtrees. A registry keyed by frame cannot work (several roots may intentionally share a frame); one keyed by container recreates React context badly and adds a cleanup path that can leak.

**Production cost.** The window and its provider ride in production; only the reporter stays debug-gated. That is deliberate and differs from the spine, which mints its ref only when it will install a reporter: this arm's window has a **production reader** — presence's born-present behaviour is release behaviour, not a diagnostic. The common SPA path (no hydration) pays nothing at all.

## The four witnesses, each with its sabotage control

All four are browser-lane rows in `implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs`. Witnessed at the **instrumentation layer**, per the bead: PR #7751 proved value-level assertions cannot see this, having replaced root B's `hydrate-root!` with `root!` and reddened only the node-identity expando while every text assertion stayed green.

Both sabotages were run by hand through the full browser lane, and both reverted (`git checkout --` on the single file; the working tree is clean and the reverted file contains zero "sabotage" tokens).

### 1 — two overlapping divergent hydrations yield two React complaints AND two framework mismatch events

`two-overlapping-hydrating-roots-recover-and-complain-independently` (was `…-but-only-one-complains`). Asserts `(= (count react-complaints) (count @seen))` and `(= 2 (count @seen))`.

Both halves are load-bearing in opposite directions: the equality catches a diagnostic going missing again, and the absolute `2` catches the *opposite* repair — a window that is never shut at all would keep both counts equal while mislabelling every later recoverable error on either root.

**Control (S1): re-globalize the window** — make `open-adoption-window!` return a module singleton. **RED**, and it reproduces the original measurement exactly:

```
FAIL in (two-overlapping-hydrating-roots-recover-and-complain-independently)
expected: (= (count react-complaints) (count @seen))
  actual: (not (= 2 1))
```

### 2 — a completed root's later recovery is not a mismatch while a sibling still adopts

`a-completed-roots-later-recovery-is-not-a-mismatch-while-a-sibling-adopts`. Root A completes (its closer shuts its window), root B stays adopting, then one error goes to each:

| root | its window | the error it gets | must emit |
|---|---|---|---|
| A | committed, closed | a later recoverable error | NO |
| B | still adopting | its hydration mismatch | YES |

**Why this rules out a global counter.** Witness 1 alone would pass under one: two opens, one close, count still one, both mismatches emit, both numbers match. What a count cannot do is tell root A's window from root B's — and React makes that difference matter, because it holds `onRecoverableError` for a root's whole lifetime and fires it for post-hydration recoveries too. Once A has committed, an error arriving on A is not a hydration mismatch; under a count it would be labelled one for as long as B kept the page-wide window open. So the row's three shapes fail distinctly: a page-global **boolean** emits nothing (A's close shut B's window), a page-global **count** emits twice (A's later error is inside the still-open page window), and only a per-root window emits exactly B's.

The row drives the real doors directly — `open-adoption-window!`, the real `hydration-reporter` builder over the real window, `close-adoption-window!` — which is what `hydrate-root!` does per root with React's schedule removed. That is deliberate, not a shortcut: the two orderings it separates are orderings React does not let a caller choose, so a version that waited for them would be measuring the scheduler. It is the technique the deleted row used, turned on the property instead of on the defect.

It also carries a **permanent in-row control**: A's same later error, sent through a window some *other* root is still holding open, IS mislabelled a mismatch. So the zero above is a property of the scoping and not of the error, and the row cannot go vacuously green.

**Control (S1, same mutation): RED.**

```
expected: (true? (roots/adopting? window-b))
  actual: (not (true? false))
expected: (= 1 (count @seen))
  actual: (not (= 1 0))
```

### 3 — presence isolation

`presence-adoption-belongs-to-a-subtree-not-to-the-page`. One row covering every clause the ruling names:

* **A hydrated root is born present** — its tray's first render sees `:present` and no later render enters `:mounting`; the adopted nodes are still the server's own (expando), and zero mismatches were emitted, so the client's first pass agreed with the server's bytes.
* **An ordinary sibling root still gets its enter phase** — mounted *inside* the hydrating root's open window and asserted to see `:mounting` first. This is a construction rather than a race: `hydrate-root!` returns before its tree is adopted (asserted on the line above), and `root!` commits inside a `flushSync` so the first render is readable on the line after.
* **Closing either root cannot change the other** — A's closer shuts A's window only; B has no window at all (`nil`, read as closed) and goes on to complete its own enter transition on its own clock.
* **Teardown before the passive effect** — a handle carrying an open window and no root (the `:root nil` idiom `teardown-census!` already uses, which is what a closer that never ran leaves behind) is shut by `unmount!`. Driven this way rather than on a live mid-hydration root, whose teardown would be measuring React's unmount instead.

**How the phase is observed.** The probe is a **boundary** child, so `impl.presence/with-phase` hands it `:rf/phase` as an ordinary prop instead of merging attribute overrides into a node. That is what makes the phase readable at all: a *native* child wears its phase as `::h/mounting` attributes which React patches in place and which are gone a macrotask later, so a row that waited for a commit and then read the DOM could not tell a child that was born present from one that entered and settled. The phase is recorded as a sequence, so a body that runs twice cannot turn a `:mounting` first render into a `:present` one.

**Control (S2): point `adopting-here?` back at a page-wide open-count**, leaving the per-root windows intact. **RED** on exactly the interference clause:

```
FAIL in (presence-adoption-belongs-to-a-subtree-not-to-the-page)
expected: (= :mounting (first (get @!phases :ordinary)))
  actual: (not (= :mounting :present))
expected: (= "mounting" (text-in cb ".probe"))
  actual: (not (= "mounting" "present"))
```

S1 does *not* red this row, and correctly so: presence's isolation comes from the context, which is a separate mechanism from the window's identity. Two sabotages are needed because there are two readers.

### 4 — root identity in the emitted event

**Not done, and explicitly not a blocker for this repair** (the ruling says so). Suppression is fixable now without the final public root API; attribution should close over the stable root identity the root-lifecycle work selects, and `frame-kw` must not be used as a substitute. `emit-hydration-mismatch!` still emits no `:root-id`.

No request-isolation witness either: **no server entry ships in the product**. The SSR entry lives in the frozen bench tree (`freehand/test/re_frame/bench/hicasso/ssr/entry.cljs`), which the package may not import. When one is promoted, ruling point (5) applies — each render/request gets its own window and provider, and the module flag is not retained as a separate server mechanism.

## PR #7751's two flagged assertions, updated per their in-file instructions

The instructions were followed literally; neither was re-pinned and neither was silently dropped.

1. **H2's pair.** The in-file comment read: *"Root-scope the window and these two counts become equal — at which point BOTH assertions below must be replaced by `(= 2 (count @seen))`."* The strict inequality `(< (count @seen) (count react-complaints))` — which existed to say a complaint went missing — became the equality `(= (count react-complaints) (count @seen))`, and `(= 1 (count @seen))` became `(= 2 (count @seen))`. The deftest name lost `-but-only-one-complains`.
2. **H4, `the-adoption-window-is-one-boolean-for-the-whole-page`.** Its comment read: *"This row exists to be DELETED … When the window becomes root-scoped this row goes RED … Re-pinning it would be the wrong repair; deleting it is the right one."* It is **deleted**. What stands in its place is not a re-pin: it is the property that measurement was standing in for (witness 2 above), which discriminates against a strictly larger set of wrong answers.

Also updated, because they read the page-global and could not survive it: H1's single `(roots/adopting?)` became two per-root reads (asserting one page-wide flag there would have been satisfied by either root alone); `sup/adopted!` now waits on a **named** root's own window, which it could not do before — the docstring saying it "answers *some* root's closer and never says which" is gone because the statement stopped being true; and `sup/server-html!` no longer opens a window, with a `settled-server-html!` sibling added for presence trees that gets born-present bytes by letting the client tier's own enter flip land, needing no product API.

## Divergences from the ruling, and one file beyond the fence

Reported rather than quietly absorbed.

* **`impl/collector.cljs` is a fourth file.** The bead's FENCES clause lists three source files, but the same ruling's implementation point (6) says *"Remove the global adoption close from runtime reset — a reset must not change the lifecycle state of a sibling root."* That call lives in `collector/reset-runtime!`, and it is also a compile-blocker once the doors take an argument. The edit is: the `(roots/close-adoption-window!)` call and its comment removed, the now-unused `roots` require removed, and two doc lines updated. Nothing else in the file changed.
* **Ruling point (3)'s third close — "on synchronous hydration-construction failure" — is satisfied by construction rather than by code, and no `try`/`catch` was added.** Under the page-global a throw left the *page* adopting, which is why `reset-runtime!` had to rescue it. A window is now reachable only from the handle `hydrate-root!` has not yet returned, so a construction that throws leaves an **unreachable** object: there is no observable a close could change, and no witness could red without it. Adding a catch that cannot alter behaviour would be code no test can justify. The property the point asks for holds; the mechanism is scoping, not cleanup. Flagging it because it is a deliberate departure from an enumerated instruction.
* **`:hydrated?` is gone**, subsumed by `:adoption` (same branch, one fact instead of two).
* **Ruling point (5)** (server entry per-request windows) is not implemented because there is no server entry to implement it in — see witness 4 above.

## Not touched

* **`impl/frames.cljs` — untouched.** `git diff --stat` confirms it is not in the diff; rf2-x874 holds it and there was no point at which the fix appeared to need it.
* `docs/design/hicasso/product/invariants.md`, `.github/workflows/**`, `TESTING.md`, `implementation/freehand/test/re_frame/bench/hicasso/**` — all untouched. No `spec/*` file, no facade export change, no new public API.
* Two design docs state the requirement *"no process-global hydration adoption window"* (`lanes/react-compatibility-notes.md`) and *"two simultaneous roots without a process-global adoption window"* (`dispositions.md`). They were requirements the code failed; they are now satisfied, so nothing needed editing.

## Quality gates

Each gate run **alone**, in the foreground, to completion, with its exit code echoed to its own file. No filter was appended to any gate's command line.

| gate | command | exit |
|---|---|---|
| hicasso node suite | `npx shadow-cljs compile node-test-hicasso && node out/node-test-hicasso.js` | **0** — 34 tests / 123 assertions, 0 failures, 0 errors (compile: 175 files, 0 warnings) |
| browser lane (PR #7751's) | `npm run test:browser` | **0** — 1148 tests / 7099 assertions, 0 failures, 0 errors (compile: 1147 files, 0 warnings) |
| hicasso freeze gate | `npm run test:hicasso-freeze` | **0** — self-test passed; 7 frozen rows match, every package file is its donor moved, no package file imports the bench tree |
| fast-PR spine | `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine`; includes `test:cljs` at 12846 tests / 64615 assertions, 0 failures, 0 errors, plus the per-namespace isolation gate and the freeze gate again |
| sabotage S1 (re-globalize the window) | `npm run test:browser` | **1** — 7 failures, witnesses 1 and 2 red, reverted |
| sabotage S2 (page-wide presence reader) | `npm run test:browser` | **1** — 3 failures, witness 3 red, reverted |

**On the freeze gate.** It is green rather than worked around. The `arm1/*` rows — `mount.cljs`, `presence.cljs`, `runtime.cljs` and `lang.clj` — were already **retired** by rf2-hic-001's second retirement, because `arm1.runtime` became six namespaces and a one-to-one `:renames` table can no longer express those files. The seven surviving rows are all `front/*`, and this PR touches none of them; `impl/presence.cljs` (the pure machine, pinned from `front/presence.cljs`) is unchanged. The gate's SEALED half still applies and still passes: the new `["react" :as react]` require in `roots.cljs` is not a bench-tree import.
