### PR TITLE
test(hicasso): make the controlled-input coverage floor fail-closed (rf2-hic-016)

### DIFF
--- a/implementation/hicasso/testbed/spec.cjs
+++ b/implementation/hicasso/testbed/spec.cjs
@@ -137,6 +137,9 @@ class Witness {
     this.engine = engine;
     this.checks = 0;
     this.recorded = {};
+    // What each named section banked, so the runner can require the
+    // sections BY NAME rather than by a total a deleted section survives.
+    this.sections = {};
   }
 
   eq(actual, expected, what) {
@@ -542,25 +545,35 @@ async function formResetAndFillProxy(page, w) {
 
 // ---------------------------------------------------------------------------
 
+// Every witness that must run, in order, under the name the runner pins it
+// by. The order matters — several sections read fields the previous ones
+// left — and the NAMES matter, because the runner's coverage floor requires
+// this exact set and reds naming whatever is absent. A section deleted from
+// this list therefore fails the gate rather than shrinking a total.
+const SECTIONS = [
+  ['same-turn-convergence', sameTurnConvergence],
+  ['caret-across-the-echo', caretAcrossTheEcho],
+  ['caret-under-real-typing', caretUnderRealTyping],
+  ['selection-across-an-out-of-band-write', selectionAcrossAnOutOfBandWrite],
+  ['composition-safety', compositionSafety],
+  ['composition-release-edges', compositionReleaseEdges],
+  ['revision-reset-preserves-identity', revisionResetPreservesIdentity],
+  ['owned-checked-pair', ownedCheckedPair],
+  ['form-reset-and-fill-proxy', formResetAndFillProxy],
+];
+
 module.exports = {
   name: 'Hicasso controlled input (I15) — three engines',
   url: '/index.html',
   pageHelpers: PAGE_HELPERS,
 
-  // Every row that must hold in every engine, in order. The runner reports
-  // the check count and refuses a run that banked too few, so a section
-  // that silently stopped running cannot pass as green.
   run: async (page, ctx) => {
     const w = new Witness(ctx.engine);
-    await sameTurnConvergence(page, w);
-    await caretAcrossTheEcho(page, w);
-    await caretUnderRealTyping(page, w);
-    await selectionAcrossAnOutOfBandWrite(page, w);
-    await compositionSafety(page, w);
-    await compositionReleaseEdges(page, w);
-    await revisionResetPreservesIdentity(page, w);
-    await ownedCheckedPair(page, w);
-    await formResetAndFillProxy(page, w);
-    return { checks: w.checks, recorded: w.recorded };
+    for (const [name, section] of SECTIONS) {
+      const before = w.checks;
+      await section(page, w);
+      w.sections[name] = w.checks - before;
+    }
+    return { checks: w.checks, recorded: w.recorded, sections: w.sections };
   },
 };

--- a/implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs
+++ b/implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs
@@ -186,9 +186,12 @@ const ENGINES = ONLY
 // So the pin is the section NAMES, each with the number of checks it banks
 // today. The names make a deleted section a red gate that says which one is
 // gone; the counts make a row quietly dropped from a surviving section red
-// too. Adding rows is free — these are minimums. The list is deliberately
-// in THIS file rather than beside the sections it names, so deleting a
-// witness means deliberately editing the gate that requires it.
+// too. Adding rows is free — these are minimums — but adding a SECTION is
+// not: the set must match exactly, so a witness added tomorrow is required
+// from the moment it lands instead of being deletable again silently. The
+// list is deliberately in THIS file rather than beside the sections it
+// names, so deleting a witness means deliberately editing the gate that
+// requires it.
 //
 // Sum today: 55, which is what each engine reports.
 // ---------------------------------------------------------------------------
@@ -306,6 +309,14 @@ function coverageReport(result, required = REQUIRED_SECTIONS) {
       problems.push(
         `section "${name}" banked ${sections[name]} checks, was ${min} — ` +
         `rows were dropped from a section that still runs.`);
+    }
+  }
+  for (const name of Object.keys(sections)) {
+    if (!has(required, name)) {
+      problems.push(
+        `section "${name}" ran but is not pinned in REQUIRED_SECTIONS — add ` +
+        `it with the rows it banks, or it is a witness that can be deleted ` +
+        `again silently.`);
     }
   }
   return problems;
@@ -434,6 +445,12 @@ function runMutationTeeth() {
 
   bite('a recorded row nobody pinned reds', () =>
     recordSchemaReport({ ...fullRecords(), invented: 1 }).length === 1);
+
+  // Both pins are bijections, so a witness added tomorrow is required from
+  // the moment it lands rather than being deletable again silently.
+  bite('a section nobody pinned reds', () =>
+    coverageReport({ checks: 56, sections: { ...fullSections(), invented: 1 } })
+      .length === 1);
 
   return teeth;
 }

--- a/implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs
+++ b/implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs
@@ -44,9 +44,16 @@
  * quietly starts behaving differently is therefore a red gate rather than a
  * silently-updated record.
  *
- * The comparator and the check floor both carry mutation teeth that run
- * before any browser launches: a gate whose own verdict logic cannot fail
- * is worse than a gate that is red.
+ * Both verdicts rest on the suite having actually run, so the coverage
+ * floor is STRUCTURAL rather than a total: `REQUIRED_SECTIONS` pins the
+ * witnesses by name and `REQUIRED_RECORDS` pins the keys each measured row
+ * carries. A count alone was fail-open in both directions — a whole section
+ * could be deleted and still clear it, and three engines recording nothing
+ * agree perfectly. Neither passes now.
+ *
+ * The comparator, the section floor and the record schema all carry
+ * mutation teeth that run before any browser launches: a gate whose own
+ * verdict logic cannot fail is worse than a gate that is red.
  *
  * ## Coverage — what these witnesses reach, and what they do not
  *
@@ -167,11 +174,63 @@ const ENGINES = ONLY
   ? ALL_ENGINES.filter((e) => ONLY.split(',').map((s) => s.trim()).includes(e))
   : ALL_ENGINES;
 
-// The check floor (the discipline `ime_run.cjs` carries): a run that
-// asserted almost nothing must not exit 0. A full engine banks 55 checks;
-// 50 refuses a section that silently stopped running — the smallest of the
-// nine is 6 rows — while leaving room for a row to be retired.
-const MIN_CHECKS_PER_ENGINE = 50;
+// ---------------------------------------------------------------------------
+// The coverage floor — STRUCTURAL, not a total.
+//
+// A bare count cannot see a deleted section, and this gate learned that the
+// hard way: with a floor of 50 against a full engine's 55 checks, either of
+// the two three-row sections could be deleted WHOLE and the run still
+// banked 52 and exited 0. A floor that survives the deletion of what it
+// guards is decoration.
+//
+// So the pin is the section NAMES, each with the number of checks it banks
+// today. The names make a deleted section a red gate that says which one is
+// gone; the counts make a row quietly dropped from a surviving section red
+// too. Adding rows is free — these are minimums. The list is deliberately
+// in THIS file rather than beside the sections it names, so deleting a
+// witness means deliberately editing the gate that requires it.
+//
+// Sum today: 55, which is what each engine reports.
+// ---------------------------------------------------------------------------
+
+const REQUIRED_SECTIONS = {
+  'same-turn-convergence': 8,
+  'caret-across-the-echo': 9,
+  'caret-under-real-typing': 4,
+  'selection-across-an-out-of-band-write': 3,
+  'composition-safety': 7,
+  'composition-release-edges': 8,
+  'revision-reset-preserves-identity': 7,
+  'owned-checked-pair': 6,
+  'form-reset-and-fill-proxy': 3,
+};
+
+// The RECORDED rows, with the keys each must carry. Without this the
+// comparator was fail-open in the worst way available to it: three engines
+// all recording `{}` agree perfectly, so every measured conduct could
+// vanish at once and `divergenceReport` would raise nothing. Agreement is
+// only evidence when there is something to agree about.
+//
+// `[]` means a scalar row — the pin is that it is present and defined. A
+// row the spec records but nobody pinned is also a problem: a new
+// measurement joins the schema or it is not measured.
+const REQUIRED_RECORDS = {
+  'out-of-band-write-lands-in-the-same-task': [],
+  'selection-across-out-of-band-write': ['start', 'end', 'direction', 'collapsed'],
+  'form-reset': [
+    'default-value-mirrors-the-model',
+    'value-after-reset',
+    'model-after-reset',
+    'reset-is-visually-inert',
+  ],
+  'fill-proxy': [
+    'eventless-fill-leaves-a-draft',
+    'form-reset-clears-the-eventless-draft',
+    'value-after-reset',
+  ],
+};
+
+const has = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
 
 // ---------------------------------------------------------------------------
 // Cross-engine narrowings — every RECORDED row that is allowed to differ,
@@ -227,6 +286,72 @@ function divergenceReport(perEngine, narrowings = NARROWINGS) {
   return problems;
 }
 
+/**
+ * Did this engine run the whole suite? Returns a list of problems — empty
+ * when every pinned section ran and banked at least the rows it banks
+ * today. A spec that reports no sections at all fails every entry, which is
+ * the fail-closed direction.
+ */
+function coverageReport(result, required = REQUIRED_SECTIONS) {
+  const problems = [];
+  const sections = (result && result.sections) || {};
+  for (const [name, min] of Object.entries(required)) {
+    if (!has(sections, name)) {
+      problems.push(
+        `required section "${name}" did not run — the suite reported ` +
+        `[${Object.keys(sections).join(', ') || 'nothing'}]. Deleting a ` +
+        `witness means deleting its entry in REQUIRED_SECTIONS too, ` +
+        `deliberately.`);
+    } else if (sections[name] < min) {
+      problems.push(
+        `section "${name}" banked ${sections[name]} checks, was ${min} — ` +
+        `rows were dropped from a section that still runs.`);
+    }
+  }
+  return problems;
+}
+
+/**
+ * Are the RECORDED rows actually there, carrying what they claim to
+ * measure? Returns a list of problems. This is what stops the cross-engine
+ * comparator from passing on unanimous emptiness.
+ */
+function recordSchemaReport(recorded, required = REQUIRED_RECORDS) {
+  const problems = [];
+  const rows = recorded || {};
+  for (const [row, keys] of Object.entries(required)) {
+    if (!has(rows, row) || rows[row] === undefined) {
+      problems.push(
+        `RECORDED row "${row}" is missing — the comparator cannot find a ` +
+        `divergence in a measurement nobody took.`);
+      continue;
+    }
+    if (keys.length === 0) continue;
+    const value = rows[row];
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+      problems.push(
+        `RECORDED row "${row}" should be an object carrying ` +
+        `[${keys.join(', ')}], got ${JSON.stringify(value)}.`);
+      continue;
+    }
+    const missing = keys.filter((k) => !has(value, k));
+    if (missing.length > 0) {
+      problems.push(
+        `RECORDED row "${row}" is missing key(s) [${missing.join(', ')}] — ` +
+        `got [${Object.keys(value).join(', ')}].`);
+    }
+  }
+  for (const row of Object.keys(rows)) {
+    if (!has(required, row)) {
+      problems.push(
+        `RECORDED row "${row}" is not pinned in REQUIRED_RECORDS — add it ` +
+        `with the keys it carries, so a new measurement cannot be dropped ` +
+        `again later without reddening.`);
+    }
+  }
+  return problems;
+}
+
 // ---------------------------------------------------------------------------
 // Mutation teeth — the gate's own verdict logic, proven able to fail before
 // a single browser is launched.
@@ -262,14 +387,55 @@ function runMutationTeeth() {
   bite('a single engine cannot diverge from itself', () =>
     divergenceReport({ chromium: { row: { a: 1 } } }, []).length === 0);
 
+  // A full run, as the spec reports it, and the same run with one thing
+  // taken away. Derived from the pins so a tooth cannot rot against them.
+  const fullSections = () => ({ ...REQUIRED_SECTIONS });
+  const fullRecords = () => Object.fromEntries(
+    Object.entries(REQUIRED_RECORDS).map(([row, keys]) => [
+      row,
+      keys.length === 0 ? true : Object.fromEntries(keys.map((k) => [k, 'x'])),
+    ]));
+
   bite('the check floor refuses a run that asserted almost nothing', () =>
-    belowFloor({ checks: 3 }) === true && belowFloor({ checks: MIN_CHECKS_PER_ENGINE }) === false);
+    coverageReport({ checks: 3, sections: {} }).length
+      === Object.keys(REQUIRED_SECTIONS).length
+    && coverageReport({ checks: 55, sections: fullSections() }).length === 0);
+
+  // The hole this gate was reopened for: 55 checks with a floor of 50 meant
+  // either three-row section could be deleted whole and still exit 0.
+  bite('deleting a whole section reds, and the message names it', () => {
+    const sections = fullSections();
+    delete sections['form-reset-and-fill-proxy'];
+    const problems = coverageReport({ checks: 52, sections });
+    return problems.length === 1
+      && problems[0].includes('form-reset-and-fill-proxy');
+  });
+
+  bite('a section that stopped banking rows reds', () => {
+    const sections = fullSections();
+    sections['selection-across-an-out-of-band-write'] -= 1;
+    return coverageReport({ checks: 54, sections }).length === 1;
+  });
+
+  // The second hole: unanimous emptiness is not agreement.
+  bite('an engine that recorded nothing reds', () =>
+    recordSchemaReport({}).length === Object.keys(REQUIRED_RECORDS).length
+    && divergenceReport({ chromium: {}, firefox: {}, webkit: {} }, []).length === 0);
+
+  bite('the record schema accepts the rows the spec records', () =>
+    recordSchemaReport(fullRecords()).length === 0);
+
+  bite('a recorded row missing a key reds', () => {
+    const records = fullRecords();
+    delete records['selection-across-out-of-band-write'].direction;
+    const problems = recordSchemaReport(records);
+    return problems.length === 1 && problems[0].includes('direction');
+  });
+
+  bite('a recorded row nobody pinned reds', () =>
+    recordSchemaReport({ ...fullRecords(), invented: 1 }).length === 1);
 
   return teeth;
-}
-
-function belowFloor(result) {
-  return result.checks < MIN_CHECKS_PER_ENGINE;
 }
 
 // ---------------------------------------------------------------------------
@@ -346,10 +512,14 @@ async function driveEngine(engine, baseUrl) {
         `[${engine}] page emitted ${pageErrors.length} uncaught error(s); ` +
         `first: ${pageErrors[0].message}`);
     }
-    if (belowFloor(result)) {
+    const gaps = [
+      ...coverageReport(result),
+      ...recordSchemaReport(result.recorded),
+    ];
+    if (gaps.length > 0) {
       throw new Error(
-        `[${engine}] banked only ${result.checks} checks, floor is ` +
-        `${MIN_CHECKS_PER_ENGINE} — a section stopped running.`);
+        `[${engine}] banked ${result.checks} checks but the coverage floor ` +
+        `is not met:\n  - ${gaps.join('\n  - ')}`);
     }
     passed = true;
   } catch (err) {
@@ -360,7 +530,8 @@ async function driveEngine(engine, baseUrl) {
   }
   if (!passed) for (const ln of lines) console.log(ln);
   console.log(passed
-    ? `PASS  ${engine} — ${result.checks} checks`
+    ? `PASS  ${engine} — ${result.checks} checks across ` +
+      `${Object.keys(result.sections).length} sections`
     : `FAIL  ${engine}`);
   return { passed, result };
 }
@@ -448,7 +619,15 @@ async function main() {
   }
 }
 
-module.exports = { divergenceReport, runMutationTeeth, belowFloor, NARROWINGS };
+module.exports = {
+  divergenceReport,
+  runMutationTeeth,
+  coverageReport,
+  recordSchemaReport,
+  NARROWINGS,
+  REQUIRED_SECTIONS,
+  REQUIRED_RECORDS,
+};
 
 if (require.main === module) {
   main().then((code) => process.exit(code)).catch((error) => {


### PR DESCRIPTION
Closes the fail-open in this suite's own coverage floor, on the reopened **rf2-hic-016**. The witnesses themselves are unchanged — 55 checks per engine, same rows, same claims. What changes is that the floor can no longer be evaded.

## The two holes

**1. A count cannot see a deleted section.** `MIN_CHECKS_PER_ENGINE` was 50 against a full engine's 55, and `selectionAcrossAnOutOfBandWrite` and `formResetAndFillProxy` bank 3 assertions each. Deleting either one *whole* left 52 checks, and `belowFloor` returned false. A floor that survives the deletion of what it guards is decoration.

**2. The recorded-row schema was unpinned.** All three engines returning `{}` agree perfectly, so `divergenceReport` raised nothing — every measured conduct could disappear at once without reddening. Agreement is only evidence when there is something to agree about.

## How each is closed

The floor is now **structural rather than a total**.

- The spec reports what each named section banked (`SECTIONS` is a declarative list; `run` banks `w.sections[name]`).
- `REQUIRED_SECTIONS` in the runner pins the nine names with the rows each carries today. A missing section reds and the message names it; a section that still runs but dropped rows reds too. Adding rows is free (minimums), adding a *section* is not — the set must match exactly, so a witness added tomorrow is required from the moment it lands rather than being deletable again silently.
- `REQUIRED_RECORDS` pins each recorded row and the keys it carries. A missing row, a row of the wrong shape, a row missing a key, or a row the spec records that nobody pinned are all problems.

`MIN_CHECKS_PER_ENGINE` / `belowFloor` are gone rather than raised: a bigger number would still have missed hole 2, and a weaker count floor sitting beside a strictly stronger structural one is the same decoration in a new place. The pins live in the **runner**, not beside the witnesses they name, so deleting a witness means deliberately editing the gate that requires it.

## Proof, both directions

**Section deletion.** Deleting `form-reset-and-fill-proxy` from `SECTIONS`, three engines, exit **1**:

```
FAIL ... (chromium): [chromium] banked 52 checks but the coverage floor is not met:
  - required section "form-reset-and-fill-proxy" did not run — the suite reported [same-turn-convergence, caret-across-the-echo, caret-under-real-typing, selection-across-an-out-of-band-write, composition-safety, composition-release-edges, revision-reset-preserves-identity, owned-checked-pair]. Deleting a witness means deleting its entry in REQUIRED_SECTIONS too, deliberately.
  - RECORDED row "form-reset" is missing — the comparator cannot find a divergence in a measurement nobody took.
  - RECORDED row "fill-proxy" is missing — the comparator cannot find a divergence in a measurement nobody took.
3 of 3 engine(s) failed.
```

Deleting `selection-across-an-out-of-band-write`, three engines, exit **1**:

```
FAIL ... (chromium): [chromium] banked 52 checks but the coverage floor is not met:
  - required section "selection-across-an-out-of-band-write" did not run — the suite reported [same-turn-convergence, caret-across-the-echo, caret-under-real-typing, composition-safety, composition-release-edges, revision-reset-preserves-identity, owned-checked-pair, form-reset-and-fill-proxy]. ...
  - RECORDED row "out-of-band-write-lands-in-the-same-task" is missing — ...
  - RECORDED row "selection-across-out-of-band-write" is missing — ...
3 of 3 engine(s) failed.
```

Both are exactly the 52-check case that used to exit 0.

**All nine sections, swept.** Each section deleted in turn (Chromium, for speed) — every one reds, exit 1 in all nine. Eight are named by the coverage floor. The ninth, `caret-across-the-echo`, reds one section earlier still, on a real assertion, because `caret-under-real-typing` reads the field it leaves: `[chromium] a real keystroke normalised: expected "AQXBC", got "AQBC"`. No section can be removed silently.

**Empty records.** With `Witness.record` neutered so all three engines return `{}` — a full **55 checks banked**, which cleared the old floor — exit **1**:

```
FAIL ... (chromium): [chromium] banked 55 checks but the coverage floor is not met:
  - RECORDED row "out-of-band-write-lands-in-the-same-task" is missing — the comparator cannot find a divergence in a measurement nobody took.
  - RECORDED row "selection-across-out-of-band-write" is missing — ...
  - RECORDED row "form-reset" is missing — ...
  - RECORDED row "fill-proxy" is missing — ...
3 of 3 engine(s) failed.
```

A tooth also pins the reason this was invisible: `divergenceReport({chromium:{}, firefox:{}, webkit:{}})` still returns zero problems, and now the schema check catches it first.

**Restored, green:** `PASS chromium/firefox/webkit — 55 checks across 9 sections` in every case.

## Nothing else re-cut

- **55 checks per engine, unchanged** in all three engines, and the pinned section total sums to exactly 55.
- **The six original verdict teeth are unchanged** — not one `bite(...)` line was removed. Only the sixth's body was re-expressed against `coverageReport` because `belowFloor` no longer exists; its name and claim ("the check floor refuses a run that asserted almost nothing") are byte-identical. Seven new teeth cover the new verdict logic, 13 in total, all biting before any browser launches.
- **The synthetic-composition limitation is retained and still stated.** No prose in the `## Composition` block or the runner's `### Out of reach here` block was touched: `Input.imeSetComposition` is CDP, real composition ranges stay Chromium-only with `bench/hicasso/ime_run.cjs`, and the abort signature is still explicitly not claimed here. The claim was not upgraded.
- **No CI wiring.** `rf2-ga8m` owns the missing scheduling; `.github/workflows/**` and `scripts/check_gate_scheduling.py` are untouched.

## No probe residue

Every probe was reverted via `git checkout --`; the working tree was clean before each gate.

```
 implementation/hicasso/testbed/spec.cjs            |  39 ++--
 .../serve-and-run-hicasso-controlled-testbed.cjs   | 232 +++++++++++++++++++--
 2 files changed, 240 insertions(+), 31 deletions(-)
```

## Quality gates

| gate | exit |
|---|---|
| `npm run test:hicasso-controlled` (Chromium + Firefox + WebKit) | **0** on the final tree — 13 teeth bit; `PASS` 55 checks across 9 sections in each engine; all four recorded rows byte-identical across engines |
| `npm run lint:js` (repo root) | **0** on the final tree |
| `sh scripts/test-fast-pr.sh` (full) | **0** on the first commit (1304 lines, zero real failures). The re-run over the second commit was cut short when this PR merged and the hygiene loop reaped the worktree under it — the `exit 1` recorded there is the worktree disappearing mid-run, not a suite failure (it was at 1125 lines with zero real failures at the time). CI covers the merged state: **28 checks pass, 0 fail**, "All required checks passed", including ESLint, `JS harness self-tests (quiet reporters + path policy)` and `Detect changed test surfaces`. |

rf2-hic-016 is left **open** — the review agent owns its lifecycle.
