### PR TITLE
fix(hicasso): pin the incarnation into the callback closure (rf2-x874)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
@@ -29,11 +29,13 @@
   context, the commit and the shells are one strongly-connected
   component: `flush!` has to know whether a body is running (it must not
   call React's `onStoreChange` from inside somebody's render), which is a
-  read of [[rstate]]; [[with-commit]] is `flush!`'s window; [[dispatch!]]
-  is `with-commit` applied to a frame's `:dispatch-sync`;
-  [[frame-dispatch]] is `dispatch!` memoised per frame; and [[run-once]]
-  — which owns `rstate` — binds `frame-dispatch` for the body's dynamic
-  extent. Cut that chain anywhere and the two halves require each other.
+  read of [[rstate]]; [[with-commit]] is `flush!`'s window;
+  [[frame-dispatch]] is `with-commit` applied to a captured frame's
+  `:dispatch-sync`, memoised per frame INCARNATION; [[dispatch!]] is that
+  closure applied; and [[run-once]] — which owns `rstate` — binds
+  `frame-dispatch` for the body's dynamic extent, which is how a lowered
+  callback comes to hold one incarnation's dispatch for the rest of its
+  life (rf2-x874). Cut that chain anywhere and the two halves require each other.
   So the chain is one namespace, and what left are the parts with an edge
   in one direction only.
 
@@ -464,42 +466,67 @@
   (some? (.-frame rstate)))
 
 ;; ---------------------------------------------------------------------------
-;; The ambient dispatch a body binds — the memo table is
+;; The ambient dispatch a body binds — the memo row is
 ;; `re-frame.hicasso.impl.frames`'s; the closure in it is this file's,
-;; because it is `dispatch!` partially applied
+;; because it is `with-commit` partially applied
 ;; ---------------------------------------------------------------------------
 
-(declare dispatch!)
+(declare with-commit)
+
+(defn- mint-frame-dispatch
+  "Mint the ambient dispatch closure for ONE frame incarnation, over the
+  `capture-frame` bundle that incarnation was pinned with.
+
+  It closes over `ops` and never over the frame keyword, and that is the
+  whole of rf2-x874. A callback lowered under incarnation A calls A's own
+  `:dispatch-sync`, so once A is destroyed core's `capture-frame` fence
+  refuses it (recover-but-emit `:rf.error/frame-destroyed`) instead of
+  resolving the address a second time and finding whoever occupies it now.
+  Before the fix the closure re-resolved the keyword at fire time, which
+  silently wrote the successor whenever the memo was cold.
+
+  `:dispatch-sync` is destructured once, at mint, rather than on every
+  event: the row is per incarnation, so there is nothing left to look up."
+  [ops]
+  (let [dispatch-sync (:dispatch-sync ops)]
+    (fn dispatch-for-frame [event]
+      (with-commit (fn [] (dispatch-sync event)))
+      nil)))
+
+(defn frame-row
+  "The arm's one memo row for `frame-kw` — `{:incarnation :ops :dispatch}`,
+  pinned to the incarnation live right now.
+
+  [[re-frame.hicasso.impl.frames/frame-row]] owns the table and the
+  incarnation discipline; this is the door that supplies the closure factory,
+  so every caller in the arm reads the SAME row and the bundle can never
+  describe a different incarnation than the closure that calls it."
+  [frame-kw]
+  (frames/frame-row frame-kw mint-frame-dispatch))
 
 (defn frame-dispatch
   "The ambient dispatch a boundary binds for its render's dynamic extent
-  (HD-020(a)), memoised per frame so binding it allocates nothing.
+  (HD-020(a)), memoised per frame INCARNATION so binding it allocates
+  nothing.
 
   **Public because a boundary shell is not the only thing that lowers
   hiccup** (rf2-2rtt6.66). `impl.presence-react` renders retained
   children inside its OWN React render, after the parent body's dynamic
   extent has unwound, so it must re-bind the ambient frame before it
   hands them to the codec — and the dispatch it binds has to be *this*
-  one. Handing it a private route of its own (a fresh
-  `(fn [e] (dispatch! frame-kw e))` per render) would allocate a closure
-  per presence render and would make \"a presence child lowers exactly as
-  it would in the parent's body\" an approximation rather than an
-  identity. Nothing new is exported: the memo, the `capture-frame` pin
-  and the [[with-commit]] batching are the ones `run-once` already binds,
-  and [[re-frame.hicasso.impl.frames/frame-ops]] beside it has been
-  public for the same reason.
+  one. Handing it a private route of its own (a fresh closure per render)
+  would allocate a closure per presence render and would make \"a presence
+  child lowers exactly as it would in the parent's body\" an approximation
+  rather than an identity. Nothing new is exported: the memo, the
+  `capture-frame` pin and the [[with-commit]] batching are the ones
+  `run-once` already binds.
 
-  **The table it memoises into is
-  [[re-frame.hicasso.impl.frames/!frame-dispatch]]**, because
-  `forget-frame-ops!` has to empty it in the same act it empties the op
-  bundles; the closure is minted here because it is [[dispatch!]]
-  partially applied, and `dispatch!` is [[with-commit]] partially
-  applied."
+  The identity it hands back is stable across repeated renders of one
+  incarnation and CHANGES when the same public id names a new one — which
+  is the point, because that identity is what every lowered callback
+  retains."
   [frame-kw]
-  (or (get @frames/!frame-dispatch frame-kw)
-      (let [f (fn dispatch-for-frame [event] (dispatch! frame-kw event))]
-        (swap! frames/!frame-dispatch assoc frame-kw f)
-        f)))
+  (:dispatch (frame-row frame-kw)))
 
 ;; ---------------------------------------------------------------------------
 ;; THE CELL TABLE — one cell per unique (frame, query), shared by every
@@ -966,10 +993,16 @@
   "The arm's frame-locked dispatch — HD-019's synchronous door. The event
   drains synchronously inside the caller's turn (the discrete browser
   event, for an intent) and the store notification runs before that turn
-  ends, so React commits the echo in the same turn."
+  ends, so React commits the echo in the same turn.
+
+  It is [[frame-dispatch]] applied, not a second route to the same place:
+  resolving the keyword and dispatching are ONE act, taken now, against the
+  incarnation live now. A caller handing it a bare keyword is asking for the
+  frame at that ADDRESS, and that is what it gets — whereas a callback
+  lowered into markup holds the closure itself and stays pinned to the
+  incarnation it was lowered under."
   [frame-kw event]
-  (with-commit (fn [] ((:dispatch-sync (frames/frame-ops frame-kw)) event)))
-  nil)
+  ((frame-dispatch frame-kw) event))
 
 ;; ---------------------------------------------------------------------------
 ;; The two read tiers (HD-002) — the render phase mutates nothing global

--- a/implementation/hicasso/src/re_frame/hicasso/impl/frames.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/frames.cljs
@@ -1,61 +1,134 @@
 (ns re-frame.hicasso.impl.frames
-  "FRAME-LOCKED OPS — resolved once per frame and not once per boundary
-  (rf2-hic-009).
+  "FRAME-LOCKED OPS — resolved once per frame INCARNATION, and not once per
+  boundary (rf2-hic-009, rf2-x874).
 
-  Two memo tables, keyed by frame keyword, and the one door that empties
-  them. HD-020(a) has each boundary read the frame *once* from the
+  One memo table keyed by frame keyword, one ROW per frame, and the one door
+  that empties it. HD-020(a) has each boundary read the frame *once* from the
   substrate's single internal context; it does not ask each boundary to
-  rebuild the bundle, and `capture-frame` pins a frame incarnation and is
-  not free.
+  rebuild the bundle, and `capture-frame` pins a frame incarnation and is not
+  free.
 
   ## Why this is an ownership boundary and not a filing convenience
 
-  **Every entry in both tables is pinned to a frame INCARNATION**, and
-  nothing in either table can tell that its incarnation died. That is the
-  whole of rf2-hic-013's problem — a destroyed-and-recreated frame with
-  the same public id must not be reachable through a handle minted
-  against the previous one — and [[forget-frame-ops!]] is the whole of
-  today's answer to it: a blunt, caller-driven invalidation with no
-  notion of *which* incarnation a memoised bundle belongs to. Putting the
-  two tables and their invalidation in one small file is what makes that
-  answer legible, and makes replacing it a change to one file.
+  A frame's public keyword id names an ADDRESS, not an object. Destroy a frame
+  and create another under the same id and you have a NEW incarnation,
+  distinct by identity, and everything a render minted against the predecessor
+  — the `capture-frame` bundle, the ambient dispatch closure lowered into
+  every callback — belongs to the predecessor for the rest of its life.
+
+  Until rf2-x874 nothing in this file could tell that its incarnation had
+  died, and the ambient closure closed over the frame KEYWORD and resolved its
+  bundle when it FIRED rather than when it was minted. Where a delayed
+  callback landed was therefore decided by the memo's warmth at that instant,
+  and both answers were wrong (measured, rf2-hic-013 / PR #7749):
+
+    warm — the stale bundle refused the LIVE successor, so a control the
+           successor had just rendered was dead. Perfect markup above dead
+           controls.
+    cold — `capture-frame` ran at fire time and so pinned the SUCCESSOR: a
+           predecessor-era callback silently wrote the successor's app-db,
+           with no error emitted at all. Cold is the ORDINARY case — a
+           boundary that rendered but that nobody clicked before the teardown.
+
+  [[frame-row]] is the repair, and it is ONE repair rather than two. The row
+  carries the incarnation it was minted under; a lookup compares that against
+  the incarnation live *right now* and a mismatch replaces the row. So a
+  retained closure keeps the predecessor's bundle and core's own
+  `capture-frame` fence refuses it (recover-but-emit
+  `:rf.error/frame-destroyed`), while the next render under the successor gets
+  a row pinned to the successor and routes. Safety of retained callbacks and
+  liveness of fresh ones are the same fact seen twice.
+
+  **Eviction on destruction was measured and REJECTED** (PR #7749's NC6): it
+  converts the one accidentally-correct branch into the broken one and makes
+  the silent successor-write universal. Correctness here therefore does not
+  depend on a destruction hook at all — the replacement is LAZY, driven by the
+  next lookup. [[forget-frame-ops!]] is reset and hygiene only, and its sole
+  runtime caller is the whole-runtime reset.
 
   ## What lives here, and the one thing that does not
 
-  [[!frame-dispatch]] is the arm's ambient-dispatch memo, but the closure
-  it caches is minted by `re-frame.hicasso.impl.collector/frame-dispatch`
-  — because that closure is a partial application of the collector's
-  commit door (`dispatch!` → `with-commit`), and a namespace cycle is the
-  alternative. The TABLE is here because [[forget-frame-ops!]] must empty
-  it in the same act it empties the op bundles: they are pinned to the
-  same incarnation, and an invalidation that cleared one of them would
-  leave a live route into a dead frame. So both tables are public, and
-  their only writer outside this file is that one memo-miss branch."
-  (:require [re-frame.core :as rf]))
+  The row's `:dispatch` closure is minted by
+  `re-frame.hicasso.impl.collector/frame-row` and handed in, because it is a
+  partial application of the collector's commit door (`with-commit` over the
+  captured bundle's `:dispatch-sync`), and a namespace cycle is the
+  alternative. It is ONE row rather than two tables so that the bundle and the
+  closure that calls it can never describe different incarnations: the
+  coupling is structural, not a rule somebody has to keep."
+  (:require [re-frame.core :as rf]
+            [re-frame.frame :as frame]))
 
+;; frame-kw -> {:incarnation <token or nil>   the exact incarnation this row
+;;                                            was minted under
+;;              :ops         <bundle>         `rf/capture-frame`'s
+;;                                            {:frame :dispatch :dispatch-sync
+;;                                             :subscribe}, pinned to it
+;;              :dispatch    <closure>        the arm's ambient dispatch over
+;;                                            THAT bundle}
+;;
+;; The residue ledger counts this table under the `:frame-ops` token, which has
+;; always been priced as "one capture-frame bundle and one ambient dispatch per
+;; frame" — one row is what that sentence describes.
 (defonce !frame-ops (atom {}))
-(defonce !frame-dispatch (atom {}))
 
-(defn frame-ops
-  "The frame-locked op bundle for `frame-kw` — `rf/capture-frame`'s
-  `{:frame :dispatch :dispatch-sync :subscribe}` — memoised per frame.
+(defn- mint-row
+  "A fresh row for `frame-kw` pinned to `incarnation`.
 
-  HD-020(a) has each boundary read the frame *once* from the substrate's
-  single internal context; it does not ask each boundary to rebuild the
-  bundle. `capture-frame` pins a frame incarnation and is not free, so
-  the shell's cost here is one map lookup per render and no allocation."
-  [frame-kw]
-  (or (get @!frame-ops frame-kw)
-      (let [ops (rf/capture-frame frame-kw)]
-        (swap! !frame-ops assoc frame-kw ops)
-        ops)))
+  `rf/capture-frame` is called HERE — while the caller has just established
+  that the incarnation is live — and never again for this row. That is the
+  pin: everything downstream holds this one bundle."
+  [frame-kw incarnation mint-dispatch]
+  (let [ops (rf/capture-frame frame-kw)]
+    {:incarnation incarnation
+     :ops         ops
+     :dispatch    (mint-dispatch ops)}))
+
+(defn frame-row
+  "The memo row for `frame-kw`, pinned to the incarnation live RIGHT NOW.
+  `mint-dispatch` is called with the freshly captured bundle when a row is
+  minted, and its result becomes the row's `:dispatch`.
+
+  Three cases, and the middle one is the whole hot path:
+
+    absent   — no live frame under the id, so `capture-frame` pins nothing and
+               the bundle stays address-directed (the documented dynamic-id
+               semantics). Deliberately NOT memoised: a row whose incarnation
+               is nil would hit forever, and this id is precisely the one that
+               may be about to name a real frame.
+    hit      — the row's incarnation IS the live one. Returned as-is, so
+               repeated renders of one incarnation share one bundle and one
+               handler identity and allocate nothing.
+    replaced — the id now names a different incarnation. The row is rebuilt
+               and overwritten in place, which is why no destruction hook is
+               needed: the successor's first lookup does the eviction.
+
+  Nothing here re-checks liveness at FIRE time and nothing here is a fence.
+  The fence is core's, inside the captured bundle (`capture-frame` pins the
+  incarnation and recover-but-emits `:rf.error/frame-destroyed` once it is
+  superseded); this table's only job is to hand out a bundle that was captured
+  while the frame it names was alive."
+  [frame-kw mint-dispatch]
+  (let [incarnation (frame/frame-incarnation-token frame-kw)
+        row         (get @!frame-ops frame-kw)]
+    (cond
+      (nil? incarnation)
+      (mint-row frame-kw nil mint-dispatch)
+
+      (identical? incarnation (:incarnation row))
+      row
+
+      :else
+      (let [fresh (mint-row frame-kw incarnation mint-dispatch)]
+        (swap! !frame-ops assoc frame-kw fresh)
+        fresh))))
 
 (defn forget-frame-ops!
-  "Drop the memoised bundles. A destroyed and re-created frame is a new
-  incarnation, and a captured bundle is pinned to the old one.
+  "Drop the memoised rows — RESET AND HYGIENE ONLY.
 
-  It clears BOTH tables in one act, which is why they sit in one file."
-  ([] (reset! !frame-ops {}) (reset! !frame-dispatch {}) nil)
-  ([frame-kw] (swap! !frame-ops dissoc frame-kw)
-              (swap! !frame-dispatch dissoc frame-kw)
-              nil))
+  It is not what makes a reincarnation safe: [[frame-row]] replaces a row
+  whose incarnation has been superseded whether or not anyone ever calls this,
+  and eviction on destruction was measured to make the fault universal rather
+  than to cure it. The sole runtime caller is the whole-runtime reset; the
+  rest are test fixtures."
+  ([] (reset! !frame-ops {}) nil)
+  ([frame-kw] (swap! !frame-ops dissoc frame-kw) nil))

--- a/implementation/hicasso/test/re_frame/hicasso/hmr_registry_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/hmr_registry_cljs_test.cljs
@@ -292,6 +292,14 @@
   ;; because what the arm cares about is whether the incarnation moved.
   (seeded! "A")
   (let [token-before  (frame/frame-incarnation-token frame-id)
+        ;; Acquire the arm's frame row BEFORE the reload (rf2-x874). Since the
+        ;; incarnation is pinned into the row at mint time, a render acquires
+        ;; the row rather than a first dispatch — so a count sampled while the
+        ;; table was still empty would compare an empty table against a
+        ;; populated one and say nothing about the reload. Priming here is what
+        ;; makes this row's own rationale — "a bundle captured before the
+        ;; reload" — name something that exists.
+        row-before    (collector/frame-row frame-id)
         frames-before (:frames (inventory/stats))]
 
     (rf/make-frame {:id frame-id})
@@ -305,7 +313,14 @@
 
     (testing "and the arm's frame-op memo is untouched, so a bundle captured
               before the reload still addresses the same incarnation"
-      (is (= frames-before (:frames (inventory/stats)))))
+      (is (= frames-before (:frames (inventory/stats)))
+          "the reload added no row")
+      (is (true? (same-object? row-before (collector/frame-row frame-id)))
+          "and it is the SAME row object — so the bundle captured before the
+           reload is the one still in use, which is the claim this row makes
+           and could not previously check")
+      (is (true? (same-object? token-before (:incarnation (collector/frame-row frame-id))))
+          "pinned to the pre-reload incarnation, by object identity"))
 
     ;; NEGATIVE CONTROL. The token reader is only worth anything if it can
     ;; report a change; this is the transition that produces one, and it is

--- a/implementation/hicasso/test/re_frame/hicasso/reincarnation_routing_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/reincarnation_routing_cljs_test.cljs
@@ -35,13 +35,20 @@
   *refused* from *silently delivered to the wrong frame*, which no other
   observable here distinguishes.
 
-  ## Section 4 records a DEFECT, not a contract
+  ## Sections 4–8 are the lowered callback's contract (rf2-x874)
 
-  Sections 1–3 are contracts. Section 4 is a measurement of behaviour that
-  is wrong, recorded because the remedy is a runtime change outside this
-  bead's surface. It is written so that it FAILS when the defect is fixed,
-  and its docstring says what to replace it with. See
-  `docs/design/hicasso/product/invariants.md` §7.
+  Section 4 recorded a DEFECT when this suite landed: the ambient dispatch a
+  boundary lowered into its callbacks closed over the frame KEYWORD and
+  resolved its bundle when the callback FIRED, so where a delayed callback
+  landed was decided by the memo's warmth at that instant. rf2-x874 pinned the
+  incarnation into the closure at mint time, and the sections below are the
+  positive contract that replaced the recording — safety (a retained callback
+  refuses) and liveness (a fresh one routes) asserted together in every cache
+  posture, because cache warmth is precisely what used to choose between two
+  different failures. Section 8 is the negative control: it rebuilds the old
+  late-binding mechanism out of the documented seam and reproduces BOTH
+  failures, so nothing here can be passing because the instruments are dead.
+  See `docs/design/hicasso/product/invariants.md` §7.
 
   ## Companion
 
@@ -56,6 +63,8 @@
             [re-frame.hicasso.impl.collector :as collector]
             [re-frame.hicasso.impl.frames :as frames]
             [re-frame.hicasso.impl.generation :as generation]
+            [re-frame.hicasso.impl.intent :as intent]
+            [re-frame.hicasso.impl.inventory :as inventory]
             [re-frame.test-support :as test-support]))
 
 (def ^:private frame-id ::reincarnation)
@@ -190,9 +199,10 @@
                        [:dispatch      (fn [h] ((:dispatch h)      [:reinc/mark :stale-handle]))]]]
     (testing (str "a stale " (name op) " is refused, never retargeted")
       (let [_        (incarnate! "A")
-            ;; Exactly what a render leaves behind: the memoised bundle
-            ;; `re-frame.hicasso.impl.frames/frame-ops` hands every boundary.
-            handle-a (frames/frame-ops frame-id)
+            ;; Exactly what a render leaves behind: the memoised bundle in the
+            ;; arm's one frame row, which every boundary of that incarnation
+            ;; shares.
+            handle-a (:ops (collector/frame-row frame-id))
             _        (reincarnate! "B")
             _        (is (nil? (marked)) "sanity: the successor starts unmarked")
             {:keys [refusals]} (with-refusals #(invoke handle-a))]
@@ -209,7 +219,7 @@
             successor's app-db nor leave a reaction in the successor's
             sub-cache"
     (let [_        (incarnate! "A")
-          handle-a (frames/frame-ops frame-id)
+          handle-a (:ops (collector/frame-row frame-id))
           _        (reincarnate! "B")
           {:keys [result refusals]} (with-refusals #((:subscribe handle-a) [:reinc/who]))]
       (is (nil? result) "the recovery is nil, never the successor's value")
@@ -246,84 +256,275 @@
         (is (empty? refusals) "and nothing is refused, because nothing was pinned")))))
 
 ;; ---------------------------------------------------------------------------
-;; 4. DEFECT — a lowered callback's destination is decided when it FIRES
+;; 4. THE CONTRACT — a lowered callback's destination is decided when it is
+;;    MINTED, in every state the memo can be in when it fires (rf2-x874)
 ;; ---------------------------------------------------------------------------
 
-;; **This test records a defect and is expected to FAIL when it is fixed.**
+;; This section replaces the DEFECT recording PR #7749 shipped here. That
+;; recording measured a callback that closed over the frame KEYWORD and
+;; resolved its bundle at FIRE time, and it had three branches because the
+;; memo's state at that instant chose which of two different wrong answers you
+;; got. The repair pins the incarnation into the closure at mint time, so the
+;; memo's state stops being an input — and the way to say that is to assert the
+;; SAME contract in all three states rather than to assert it once.
 ;;
-;; `re-frame.hicasso.impl.intent` captures the ambient dispatch at LOWERING
-;; time and the browser invokes it long after the render's dynamic extent
-;; has unwound. That closure is
-;; [[re-frame.hicasso.impl.collector/frame-dispatch]]'s, and it closes over
-;; the frame KEYWORD — so `dispatch!` resolves
-;; [[re-frame.hicasso.impl.frames/frame-ops]] when the user CLICKS, not
-;; when the body rendered. The closure carries no incarnation.
-;;
-;; What it reaches is therefore whatever the memo happens to hold at that
-;; instant, and the memo is filled lazily by the first dispatch and evicted
-;; by nothing on a frame destroy. The three branches below are the three
-;; states that produces, and only the first looks like the law:
-;;
-;;   warm    — a dispatch happened under the predecessor, so the memo still
-;;             holds its pinned bundle: the click is REFUSED. Correct, and
-;;             correct by accident.
-;;   cold    — the boundary rendered and lowered its callback but nobody
-;;             clicked before the teardown, so the memo is empty: the click
-;;             captures a bundle pinned to the SUCCESSOR and writes it,
-;;             silently. This is the revival the bead forbids, and it needs
-;;             no unusual sequence — a first click after a reincarnation is
-;;             an ordinary thing for a user to do.
-;;   evicted — the memo was warm and then cleared, which is what *exact
-;;             eviction on destruction* (one of the two remedies the bead
-;;             names) would do on every destroy: the same silent revival.
-;;
-;; So eviction alone is not the remedy — it converts the one correct branch
-;; into the broken one. The incarnation has to be pinned into what lowering
-;; captures, which is the bead's other named option (incarnation-keyed
-;; operation bundles) and a change to
-;; `implementation/hicasso/src/re_frame/hicasso/impl/frames.cljs`, outside
-;; this bead's declared surface.
-;;
-;; **When the remedy lands**, delete this test and assert the contract in
-;; its place: all three branches leave `(marked)` nil and fan exactly one
-;; `:rf.error/frame-destroyed`.
-(deftest DEFECT-a-retained-callback-can-revive-the-successor
-  (testing "WARM memo — refused, which is the only branch that looks correct"
-    (let [_        (incarnate! "A")
-          on-click (collector/frame-dispatch frame-id)]
-      (collector/dispatch! frame-id [:reinc/mark :under-a])   ; warms !frame-ops
-      (is (contains? @frames/!frame-ops frame-id) "the memo is warm")
-      (reincarnate! "B")
-      (is (identical? (frames/frame-ops frame-id) (frames/frame-ops frame-id))
-          "and survives the destroy — nothing evicts it")
-      (let [{:keys [refusals]} (with-refusals #(on-click [:reinc/mark :warm]))]
-        (is (nil? (marked)) "the retained click is refused")
-        (is (= 1 (count refusals)) "loudly"))))
+;; The two halves are asserted together on purpose. Before the repair, cache
+;; warmth traded them off: a warm memo refused the retained callback (safe) AND
+;; refused the live successor's fresh one (dead controls); a cold or evicted
+;; memo routed the fresh one AND silently revived the successor through the
+;; retained one. A suite asserting only the refusals would be green on a
+;; runtime where nothing dispatches at all.
 
-  (testing "COLD memo — the SAME retained closure writes the successor, silently.
-            The defect: nothing about the callback changed, only whether some
-            earlier click had happened to fill the memo"
-    (let [_        (incarnate! "A")
-          on-click (collector/frame-dispatch frame-id)]
-      (is (not (contains? @frames/!frame-ops frame-id))
-          "no dispatch has happened under the predecessor, so the memo is cold")
-      (reincarnate! "B")
-      (let [{:keys [refusals]} (with-refusals #(on-click [:reinc/mark :cold]))]
-        (is (= :cold (marked))
-            "REVIVAL — a predecessor-era callback wrote the successor's app-db")
+(defn- render-dispatch
+  "The ambient dispatch a boundary acquires during its render — exactly what
+  `impl.collector/run-once` binds for a body's dynamic extent, and therefore
+  exactly what every callback that body lowers retains."
+  []
+  (collector/frame-dispatch frame-id))
+
+(def ^:private postures
+  "The three states the arm's one frame row can be in when a retained callback
+  fires, established AFTER the successor has seated. Each was a different wrong
+  answer before rf2-x874, which is why all three are asserted:
+
+    :cold   nothing has touched the row since the successor seated, so it still
+            describes the PREDECESSOR. Pre-fix this was the single
+            accidentally-correct branch — the refusal was the stale memo's
+            doing rather than any check — and the branch that
+            eviction-on-destruction would have destroyed.
+    :warm   the successor has rendered, so the row describes the SUCCESSOR.
+            Pre-fix a retained keyword-closure read this row and wrote B.
+    :reset  the row was dropped outright. Pre-fix the fire-time
+            `capture-frame` pinned B and wrote it with nothing emitted, which
+            is the ordinary case: a boundary that rendered but that nobody
+            clicked before the teardown."
+  [[:cold  (fn [])]
+   [:warm  (fn [] (collector/frame-dispatch frame-id))]
+   [:reset (fn [] (frames/forget-frame-ops! frame-id))]])
+
+(deftest a-retained-callback-is-pinned-to-the-incarnation-that-lowered-it
+  (doseq [[posture establish!] postures]
+    (testing (str "SAFETY, " (name posture)
+                  " — a callback minted under A refuses once A is destroyed")
+      (let [_        (incarnate! "A")
+            on-click (render-dispatch)]
+        (reincarnate! "B")
+        (establish!)
+        (let [{:keys [refusals]} (with-refusals #(on-click [:reinc/mark posture]))]
+          (is (nil? (marked))
+              "the successor's app-db is UNTOUCHED by a predecessor-era callback")
+          (is (= 1 (count refusals))
+              "and the drop is LOUD — exactly one always-on
+               :rf.error/frame-destroyed, the only observable separating
+               refused from silently delivered to the wrong frame")
+          (is (= frame-id (:frame (first refusals)))
+              "attributed to the captured id")
+          (is (= :reinc/mark (:event-id (first refusals)))
+              "carrying the refused event's head"))))
+
+    (testing (str "LIVENESS, " (name posture)
+                  " — a callback minted under B dispatches, with no refusal")
+      (let [_ (incarnate! "A")
+            ;; A render under the PREDECESSOR, so the row genuinely describes A
+            ;; when the successor seats. Without it the `:cold` posture would be
+            ;; an empty table rather than a stale row, and the stale row is the
+            ;; case that used to leave the successor's own controls dead.
+            _        (render-dispatch)
+            _        (reincarnate! "B")
+            _        (establish!)
+            on-click (render-dispatch)
+            {:keys [refusals]} (with-refusals #(on-click [:reinc/mark posture]))]
+        (is (= posture (marked))
+            "the live incarnation's own control WRITES its own app-db — the
+             half that was red on main whenever the memo was warm")
         (is (empty? refusals)
-            "and nothing was emitted, which is the worse half: the write is
+            "and nothing is refused, because the closure was minted against
+             the incarnation it is dispatching into")))))
+
+;; ---------------------------------------------------------------------------
+;; 5. One handler identity per incarnation — the property the perf budget and
+;;    the fix both rest on
+;; ---------------------------------------------------------------------------
+
+(deftest the-ambient-dispatch-has-one-identity-per-live-incarnation
+  (let [_     (incarnate! "A")
+        a1    (render-dispatch)
+        a2    (render-dispatch)
+        ops-a (:ops (collector/frame-row frame-id))
+        _     (reincarnate! "B")
+        b1    (render-dispatch)
+        b2    (render-dispatch)
+        ops-b (:ops (collector/frame-row frame-id))]
+    (is (identical? a1 a2)
+        "repeated renders of ONE incarnation share one handler — the memo is
+         still a memo, and a boundary re-render allocates nothing")
+    (is (not (identical? a1 b1))
+        "the same public id naming a NEW incarnation hands back a new one, and
+         this lazy replacement is what makes a destruction hook unnecessary")
+    (is (identical? b1 b2)
+        "and it is stable again under the successor")
+    (is (not (identical? ops-a ops-b))
+        "the captured bundle underneath moved with it — the row is ONE record,
+         so the closure and the bundle cannot describe different incarnations")
+    (is (true? (frame/frame-incarnation-live?
+                 frame-id (:incarnation (collector/frame-row frame-id))))
+        "and the row answering now is pinned to the incarnation live now")))
+
+;; ---------------------------------------------------------------------------
+;; 6. Every lowering path inherits the same pinned ambient dispatch
+;; ---------------------------------------------------------------------------
+
+;; Four spellings reach the ambient closure by four different routes through
+;; `impl.intent`, and all four capture `*dispatch*` at LOWERING time. One table
+;; rather than four tests, because they share the mechanism and the question
+;; asked of each is identical — if they ever stop sharing it, the table is
+;; where that shows up.
+(def ^:private lowering-paths
+  [[:intent-vector
+    (fn [tag] (intent/lower-prop :on-click [:reinc/mark tag]))]
+   [:h-fn-returning-an-intent
+    (fn [tag] (intent/lower-prop :on-click (intent/callback (fn [_e] [:reinc/mark tag]))))]
+   [:key-map-branch
+    (fn [tag] (intent/lower-prop :on-key-down {"Enter" [:reinc/mark tag]}))]
+   [:handler-inside-a-render-callback
+    ;; The render callback is lowered under the boundary, then INVOKED — which
+    ;; is when its inner handler is lowered, against the gate — and the handler
+    ;; it returned is what fires later. The gate forwards to the SUPPLYING
+    ;; boundary's dispatch once the call has returned, so this path inherits
+    ;; the pin one level deeper than the other three.
+    (fn [tag]
+      ((intent/lower-prop :row-render
+                          (intent/callback
+                            (fn [] (intent/lower-prop :on-click [:reinc/mark tag]))))))]])
+
+(defn- lower-under-boundary
+  "Lower through `f` inside the render-time ambient binding a boundary body
+  runs under — `impl.collector/run-once`'s, spelled out."
+  [f]
+  (intent/with-frame frame-id (render-dispatch) f))
+
+(defn- fire!
+  "Invoke a lowered handler the way its position's invoker would. One event
+  object serves all four: the key-map branch reads `.key`, and the other three
+  ignore the argument."
+  [h]
+  (h #js {:key "Enter"}))
+
+(deftest every-lowering-path-inherits-the-pinned-ambient-dispatch
+  (doseq [[path lower] lowering-paths]
+    (testing (str "SAFETY — " (name path) " lowered under A refuses once A dies")
+      (incarnate! "A")
+      (let [h (lower-under-boundary #(lower :stale))]
+        (reincarnate! "B")
+        (let [{:keys [refusals]} (with-refusals #(fire! h))]
+          (is (nil? (marked))
+              (str (name path) " reached the successor's app-db"))
+          (is (= 1 (count refusals))
+              (str (name path) " did not fan exactly one refusal"))
+          (is (= :reinc/mark (:event-id (first refusals)))))))
+
+    (testing (str "LIVENESS — " (name path) " lowered under B dispatches")
+      (incarnate! "A")
+      (lower-under-boundary #(lower :under-a))
+      (reincarnate! "B")
+      (let [h (lower-under-boundary #(lower :live))
+            {:keys [refusals]} (with-refusals #(fire! h))]
+        (is (= :live (marked))
+            (str (name path) " did not reach the LIVE incarnation"))
+        (is (empty? refusals))))))
+
+;; ---------------------------------------------------------------------------
+;; 7. Reset still empties the inventory
+;; ---------------------------------------------------------------------------
+
+(deftest reset-empties-the-frame-memo
+  (incarnate! "A")
+  (render-dispatch)
+  (is (contains? @frames/!frame-ops frame-id)
+      "a render leaves exactly one row behind — the bundle and the ambient
+       dispatch are one record now, so acquiring the dispatch acquires both")
+  (is (= 1 (:frames (inventory/stats)))
+      "which is what the residue census counts under its `:frame-ops` token")
+  (collector/reset-runtime!)
+  (is (= {} @frames/!frame-ops) "and the whole-runtime reset empties it")
+  (is (= 0 (:frames (inventory/stats)))))
+
+;; ---------------------------------------------------------------------------
+;; 8. NEGATIVE CONTROL — restore late keyword resolution and BOTH failures
+;;    come back
+;; ---------------------------------------------------------------------------
+
+;; A control that showed only a stale callback going inert would be incomplete:
+;; a cache in which nothing resolves at all would pass it too. So this one
+;; asserts a positive WRITE in one branch and a positive REFUSAL in the other —
+;; the two failures the defect actually had — and then runs the same two
+;; scenarios through the runtime under test, which must answer the opposite way
+;; in both.
+
+(defn- late-binding-dispatch
+  "**The mechanism as it stood before rf2-x874**, rebuilt out of the documented
+  seam rather than by redefining a runtime var.
+
+  `!memo` stands in for the arm's frame table as it then was, and the returned
+  closure for `impl.collector/frame-dispatch`'s: it closes over the frame
+  KEYWORD and resolves a `rf/capture-frame` bundle when it FIRES. The commit
+  window is the arm's real [[re-frame.hicasso.impl.collector/with-commit]] — it
+  batches notifications and has no say in where a write lands, but using the
+  real door keeps this a reconstruction rather than a paraphrase."
+  [!memo]
+  (fn late-frame-dispatch [frame-kw]
+    (fn late-dispatch-for-frame [event]
+      (collector/with-commit
+        (fn []
+          (let [ops (or (get @!memo frame-kw)
+                        (let [captured (rf/capture-frame frame-kw)]
+                          (swap! !memo assoc frame-kw captured)
+                          captured))]
+            ((:dispatch-sync ops) event)))))))
+
+(deftest NEGATIVE-CONTROL-late-keyword-resolution-reproduces-both-failures
+  (testing "COLD memo — a retained PREDECESSOR callback silently writes the
+            successor, which is the revival the contract forbids"
+    (incarnate! "A")
+    (let [!memo    (atom {})
+          on-click ((late-binding-dispatch !memo) frame-id)]
+      (reincarnate! "B")
+      (let [{:keys [refusals]} (with-refusals #(on-click [:reinc/mark :late-cold]))]
+        (is (= :late-cold (marked))
+            "the predecessor's callback WROTE the successor's app-db")
+        (is (empty? refusals)
+            "and nothing was emitted, which is the worse half — the write is
              indistinguishable from a legitimate one"))))
 
-  (testing "EVICTED memo — what eviction-on-destruction would produce on every
-            destroy, and the reason it is refused as a remedy on its own"
-    (let [_        (incarnate! "A")
-          on-click (collector/frame-dispatch frame-id)]
-      (collector/dispatch! frame-id [:reinc/mark :under-a])
+  (testing "WARM memo — a callback minted AFTER the successor seated is refused
+            by the stale bundle: perfect markup above a dead control"
+    (incarnate! "A")
+    (let [!memo (atom {})
+          late  (late-binding-dispatch !memo)]
+      ((late frame-id) [:reinc/mark :under-a])       ; fills the memo with A's bundle
       (reincarnate! "B")
-      (frames/forget-frame-ops! frame-id)
-      (let [{:keys [refusals]} (with-refusals #(on-click [:reinc/mark :evicted]))]
-        (is (= :evicted (marked))
-            "the warm branch's refusal was the STALE MEMO's doing; evict it and
-             the same click revives")
-        (is (empty? refusals))))))
+      (let [on-click (late frame-id)                 ; minted AFTER B seated
+            {:keys [refusals]} (with-refusals #(on-click [:reinc/mark :late-warm]))]
+        (is (nil? (marked))
+            "the LIVE incarnation's own control does not write its own app-db")
+        (is (= 1 (count refusals))
+            "it is refused — the liveness half of the same defect"))))
+
+  (testing "and the runtime under test answers the OPPOSITE way in both, which
+            is what makes the two branches above a control on the FIX rather
+            than two more measurements of a dead cache"
+    (incarnate! "A")
+    (let [retained (render-dispatch)]
+      (reincarnate! "B")
+      (let [{:keys [refusals]} (with-refusals #(retained [:reinc/mark :repaired-cold]))]
+        (is (nil? (marked)) "the silent write is REFUSED here")
+        (is (= 1 (count refusals)) "loudly")))
+
+    (incarnate! "A")
+    (render-dispatch)
+    (reincarnate! "B")
+    (let [fresh (render-dispatch)
+          {:keys [refusals]} (with-refusals #(fresh [:reinc/mark :repaired-warm]))]
+      (is (= :repaired-warm (marked)) "and the dead control ROUTES here")
+      (is (empty? refusals)))))
+

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
@@ -225,7 +225,7 @@
                                 adoptions, exactly as it does across two ordinary
                                 mounts"
                         (is (= #{[frame-a label-q] [frame-b label-q]} (sup/cell-keys)))
-                        (is (= #{frame-a frame-b} (sup/dispatch-memo-frames))))
+                        (is (= #{frame-a frame-b} (sup/frame-memo-frames))))
 
                       (finally (mount/release! ha) (mount/release! hb) (done))))))))))))
 

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_isolation_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_isolation_dom_cljs_test.cljs
@@ -41,6 +41,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.hicasso :as h]
             [re-frame.hicasso.impl.collector :as collector]
             [re-frame.hicasso.impl.inventory :as inventory]
@@ -195,12 +196,17 @@
         (testing "and the frame-locked ambient dispatch memoised for each body
                   is keyed by frame too — a second table saying the same thing
                   on a different axis"
-          (is (= #{frame-a frame-b} (sup/dispatch-memo-frames))
-              (str "got " (pr-str (sup/dispatch-memo-frames))))
-          (is (= #{} (sup/ops-memo-frames))
-              "and nothing has dispatched yet, so the `capture-frame` bundle
-               memo is still empty — which is what makes the reading above a
-               reading of RENDER and not of something a dispatch left behind"))
+          (is (= #{frame-a frame-b} (sup/frame-memo-frames))
+              (str "got " (pr-str (sup/frame-memo-frames))))
+          (is (= [true true]
+                 (mapv #(frame/frame-incarnation-live?
+                          % (:incarnation (sup/frame-memo-row %)))
+                       [frame-a frame-b]))
+              "and each row is pinned to the incarnation that is LIVE under its
+               id (rf2-x874) — the reading that replaced 'the bundle memo is
+               still empty'. Since the row is acquired during render, one row
+               per rendered frame is the reading of RENDER, and pinning is what
+               a dispatch could otherwise have left behind wrongly"))
 
         (testing "the markup corroborates, and it corroborates on BOTH frames
                   — a constant would satisfy either one alone"
@@ -220,7 +226,10 @@
     (sup/skip! ":node-test has no DOM")
     (let [_ (fresh!)
           a (mount/root! (mount/fresh-container!) frame-a [panel {:tag "a"}])
-          b (mount/root! (mount/fresh-container!) frame-b [panel {:tag "b"}])]
+          b (mount/root! (mount/fresh-container!) frame-b [panel {:tag "b"}])
+          ;; Sampled BEFORE the dispatch, because the property below is that
+          ;; the dispatch did not disturb it.
+          row-b-before (sup/frame-memo-row frame-b)]
       (try
         (testing "one dispatch into frame A re-runs exactly one body"
           (let [ran (sup/body-runs-delta! (fn [] (mount/dispatch! a [::bump])))]
@@ -232,10 +241,13 @@
           (is (= "1" (text-at a ".count")))
           (is (= "0" (text-at b ".count"))))
 
-        (testing "the `capture-frame` bundle memo now holds frame A alone —
-                  the dispatch pinned one incarnation, not both"
-          (is (= #{frame-a} (sup/ops-memo-frames))
-              (str "got " (pr-str (sup/ops-memo-frames)))))
+        (testing "and the dispatch touched frame A's memo row alone — B's row is
+                  the SAME object it was before, so one frame's traffic cannot
+                  re-pin another's"
+          (is (identical? row-b-before (sup/frame-memo-row frame-b))
+              "frame B's row was replaced by a dispatch into frame A")
+          (is (= #{frame-a frame-b} (sup/frame-memo-frames))
+              (str "got " (pr-str (sup/frame-memo-frames)))))
 
         (testing "the counter can read 2, so `1` above was a discrimination
                   and not a ceiling — both frames are exercised, which is

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
@@ -120,28 +120,32 @@
   [sub-key]
   (count (inventory/cell-readers sub-key)))
 
-(defn dispatch-memo-frames
-  "The frames the ambient-dispatch memo holds bundles for.
+(defn frame-memo-frames
+  "The frames the arm's frame memo holds a row for.
 
   Populated by RENDER: `impl.collector/run-once` binds
-  `(frame-dispatch frame-kw)` for each body's dynamic extent, and the
-  memo is `impl.frames/!frame-dispatch`. So two frames rendering is two
+  `(frame-dispatch frame-kw)` for each body's dynamic extent, and that
+  lookup is what mints the frame's row. So two frames rendering is two
   entries, and a runtime that resolved one frame for both mounts would
   hold one — a second frame-keyed table saying the same thing the cell
   keys say, on a different axis.
 
-  Its sibling `impl.frames/!frame-ops` is NOT this and must not be
-  confused with it: `capture-frame` bundles are minted by
-  `impl.collector/dispatch!`, so that table is empty until something
-  dispatches. `impl.inventory/stats`'s `:frames` counts that one."
-  []
-  (set (keys @frames/!frame-dispatch)))
-
-(defn ops-memo-frames
-  "The frames the `capture-frame` op-bundle memo holds — populated by
-  DISPATCH, not by render. See [[dispatch-memo-frames]]."
+  Since rf2-x874 `impl.frames/!frame-ops` is ONE row per frame rather
+  than two sibling tables: the row carries the incarnation, the
+  `capture-frame` bundle pinned to it, and the ambient dispatch closure
+  over that bundle. Acquiring the dispatch acquires the bundle in the
+  same act, which is what stops the two from ever describing different
+  incarnations — and which is why a render, not a dispatch, is now what
+  fills this. `impl.inventory/stats`'s `:frames` counts the same rows."
   []
   (set (keys @frames/!frame-ops)))
+
+(defn frame-memo-row
+  "The arm's memo row for `frame-kw`, or nil — `{:incarnation :ops
+  :dispatch}`. Read by IDENTITY, never by value: what a witness wants to
+  know is whether this is the same row it saw before."
+  [frame-kw]
+  (get @frames/!frame-ops frame-kw))
 
 (defn body-runs-delta!
   "Run `f`, answer how many boundary bodies ran while it did.


### PR DESCRIPTION
Fixes the P1 silent corruption rf2-x874 records: a lowered callback whose destination was decided when it *fired* rather than when it was *minted*.

## The mechanism, before and after

**Before.** `impl.frames` held two memo tables keyed by the bare public frame keyword — `!frame-ops` (the `rf/capture-frame` bundle) and `!frame-dispatch` (the ambient closure). The closure was `(fn [event] (dispatch! frame-kw event))`, and `dispatch!` was `(with-commit #((:dispatch-sync (frames/frame-ops frame-kw)) event))`. So the closure carried a **keyword**, and the bundle it used was resolved at fire time. Nothing in either table could tell that its incarnation had died, and `forget-frame-ops!`'s only runtime caller is the whole-runtime reset.

After a same-public-id frame is destroyed and a successor seats, where a retained callback landed was therefore chosen by the memo's warmth at that instant, and *both* answers were wrong:

- **warm** — the stale bundle refused the retained callback (safe, but by accident: the stale memo, not a check) *and* refused the live successor's freshly rendered control. Perfect markup above dead controls.
- **cold** — `capture-frame` ran at fire time and so pinned the **successor**: a predecessor-era callback silently wrote the successor's app-db, with nothing emitted. Cold is the ordinary case — a boundary that rendered but that nobody clicked before the teardown.

**After.** One row per public id, replacing both tables:

```
frame-kw -> {:incarnation <token>  :ops <capture-frame bundle>  :dispatch <closure>}
```

`frames/frame-row` reads the incarnation live *right now* (`frame/frame-incarnation-token`), returns the row on an identity hit, and rebuilds it when the id names a different incarnation. `collector/mint-frame-dispatch` closes over the **bundle**, never the keyword, so a callback lowered under incarnation A calls A's own `:dispatch-sync` and core's existing `capture-frame` fence answers for it — recover-but-emit `:rf.error/frame-destroyed`, never a resolve of the address a second time.

Three consequences worth stating:

- **Safety and liveness are one repair.** The same row replacement that keeps a retained closure pinned to A is what hands the successor's next render a closure pinned to B. The liveness half was red on `main` (the arm's own `dispatch!` door refused the *live* incarnation whenever the memo was warm) and PR #7749 reported it as unfixed; it is fixed here.
- **No destruction hook.** Replacement is lazy, driven by the next lookup. `forget-frame-ops!` stays reset/hygiene only.
- **The fire path got cheaper.** `:dispatch-sync` is destructured once at mint, so firing is a direct call rather than a table lookup plus a keyword get. The added cost — one incarnation-token read plus one `identical?` — lands on the once-per-body row lookup, exactly where the ruling anticipated it.

`dispatch!` is now `frame-dispatch` applied: resolving a bare keyword and dispatching are one act taken against the incarnation live now, which is what an address-directed caller is asking for.

## The ruling's acceptance criteria

**(a) A callback minted under A refuses after A is destroyed, in cold, warm and explicitly-reset postures.** `a-retained-callback-is-pinned-to-the-incarnation-that-lowered-it`, table-driven over the three states the row can be in at fire time (`:cold` — untouched since B seated, so the row still describes A; `:warm` — B has rendered, so the row describes B; `:reset` — the row dropped outright). Each asserts B's app-db untouched, exactly one always-on `:rf.error/frame-destroyed` (axis 1, so it survives `-Dre-frame.debug=false`), the captured frame id, and the refused event's head.

**(b) A callback freshly minted under B dispatches in each posture, including the previously broken warm case.** The LIVENESS half of the same table. Each liveness row deliberately renders under the predecessor first, so the `:cold` posture is a *stale row* rather than an empty table — that is the case that used to leave the successor's own controls dead.

**(c) Identity is stable across repeated renders of A, changes A→B, stable again under B.** `the-ambient-dispatch-has-one-identity-per-live-incarnation`, plus the bundle moving with it and the answering row being pinned to the live token. This is also the property the perf budget rests on: one shared handler identity per live incarnation, zero allocation on a hit.

**(d) All four lowering paths inherit the same pinned ambient dispatch.** `every-lowering-path-inherits-the-pinned-ambient-dispatch`, one table over the intent vector, an `h/fn` returning an intent, a key-map branch, and a handler minted inside a declared render callback (which inherits the pin one level deeper, through the render gate's `owner-dispatch`). Safety and liveness asserted for each.

**(e) Reset still empties the memo inventory.** `reset-empties-the-frame-memo` — one row after a render, counted by `inventory/stats`'s `:frames`, and both zero after `reset-runtime!`. Focused Hicasso suite green: **37 tests / 168 assertions, 0 failures**.

**(f) The negative control reproduces BOTH failures.** Two of them, run and shipped.

*Shipped* — `NEGATIVE-CONTROL-late-keyword-resolution-reproduces-both-failures` rebuilds the pre-fix mechanism out of the documented seam (a keyword-keyed `rf/capture-frame` memo behind a closure that resolves it when it fires, inside the arm's real `with-commit`), never by redefining a runtime var. It asserts a positive **write** in the cold branch and a positive **refusal** in the warm branch — so an all-controls-dead cache cannot pass it — and then runs the same two scenarios through the runtime under test, which must answer the opposite way in both.

*Run* — the source perturbation: `frames/frame-row` stripped of its incarnation check and `mint-frame-dispatch` restored to late keyword resolution, i.e. the pre-fix runtime expressed in the post-fix shape. Result **21 failures**, and they are exactly the two failures:

| Branch | NC result | Which failure |
|---|---|---|
| SAFETY `:reset` (4 assertions) | `(marked)` = `:reset`, zero refusals | **the cold predecessor-write** — silent, nothing emitted |
| LIVENESS `:cold` and `:warm` (2 + 2) | refused, `:rf.error/frame-destroyed` | **the warm successor-refusal** — the live control is dead |
| identity (3) | A's and B's closures `identical?`; row not pinned live | |
| the four lowering paths, LIVENESS (8) | refused under B | |
| section 8's runtime anchor, warm (2) | refused under B | |
| SAFETY `:cold` and `:warm` | **green** | the accidentally-correct branch, unchanged |

Runtime source restored and the suite re-run green (`git checkout HEAD --`, then 37/168, exit 0); `git status` clean.

**(g) NC6 comparison — no mismatch.** PR #7749's NC6 applied the candidate remedy to the old section-4 recording and predicted the **two defect branches flip while the warm branch and every other witness stay green**. Mapping its branch names onto the row states:

- #7749 *warm* (the row holds A's bundle at fire) → my SAFETY `:cold`. NC6: no flip. Measured: green before, green after, and green under the NC. ✔
- #7749 *cold* (empty table at fire) → my SAFETY `:reset`. NC6: flips to a refusal. Measured: refuses now, and reverts to the silent write under the NC. ✔
- #7749 *evicted* (`forget-frame-ops!` after warming) → the same `:reset` state. NC6: flips to a refusal. Measured: same. ✔
- "every other witness stayed green" — sections 1–3 of this suite and the whole `reincarnation_cells_cljs_test` companion are untouched and green. ✔

Two branches flipped, the third did not, nothing else moved. That is NC6's prediction exactly.

## Eviction, and the seam-audit callers

**Eviction on destruction is not implemented** and the fix does not depend on a destruction hook — `forget-frame-ops!` keeps its reset/hygiene role and its single runtime caller, and both the source docstring and the `:reset` posture record why eviction alone would make the silent write universal.

**The seam-audit callers are untouched.** `impl/boundary.cljs`'s error reporting and `impl/mount.cljs`'s witness still call `collector/dispatch!` with a bare keyword, and `::h/navigate` still delegates an address-directed keyword to routing. No retained-operation witness here demonstrates a revival through them: they resolve at call time *by intent*, and `dispatch!` now resolves against the live incarnation, so the liveness half improves for them and the safety half was never theirs to violate. Left for rf2-q9cf, as the ruling directs.

**The macrotask deferral and the read-repair timing are untouched** (rf2-2l17's separate ruling). No public API additions.

## Corrections to the brief

- **The dispatch brief fenced the runtime edit to `impl/frames.cljs` alone; the bead's ruling authorizes `impl/frames.cljs` plus the smallest corresponding change in `impl/collector.cljs`,** because the late-binding closure is minted in `collector/frame-dispatch`. The bead governs, and `frames.cljs` alone genuinely cannot carry the fix. Runtime edits are confined to those two files.
- **The brief said the freeze gate "now reconstructs `frames.cljs` from its donor". It does not.** `frozen-sources.edn` carries seven rows, all `front/*`; the `arm1/runtime.cljs` row that became `impl/frames.cljs` was **retired** by rf2-hic-009's module split, exactly as the manifest header prescribes. The gate is green and reports "7 frozen row(s) match" — but it never looks at either file I changed. Worth knowing before anyone treats it as cover for this surface.
- **The named boundary-shell/per-render benchmark cannot observe this change.** `npm run bench:hicasso` drives `re-frame.bench.hicasso.arm1.runtime`, which is an independent copy with its own `!frame-ops` / `!frame-dispatch` and does not require the package — the same divergence `frozen-sources.edn`'s header records. So the perf claim rests on the analysis above plus criterion (c), which asserts the shared-handler-identity property directly rather than timing it.
- **Test-tree adjacency with rf2-6tmu.** No runtime file that bead holds was touched (`impl/roots.cljs`, `impl/mount.cljs`, `impl/presence_react.cljs` are unmodified). Three roots *test* files are touched, minimally, because my change moves the observable they read: the two memo tables became one, and the row is now acquired during render. `sup/dispatch-memo-frames` + `sup/ops-memo-frames` collapse into `sup/frame-memo-frames` + `sup/frame-memo-row`, and two assertions in the isolation suite are restated — "the bundle memo is still empty" becomes "each row is pinned to the incarnation live under its id", and "the ops memo holds frame A alone" becomes "a dispatch into A left B's row the same object". Both restatements are stronger discriminations than the ones they replace, but they are a textual collision risk if rf2-6tmu edits the same rows.

## Quality gates

Every gate run alone, foreground, exit code read from its own file.

| Gate | Command | Exit | Result |
|---|---|---|---|
| Focused Hicasso compile | `npx shadow-cljs compile node-test-hicasso` | **0** | 175 files, 0 warnings |
| Focused Hicasso suite | `node out/node-test-hicasso.js` | **0** | 37 tests / 168 assertions, 0 failures |
| Negative control (run) | same, with the perturbation applied | **1** | 21 failures — intended; branch table above |
| Focused Hicasso suite, after restore | `node out/node-test-hicasso.js` | **0** | 37 tests / 168 assertions, 0 failures |
| Hicasso freeze gate | `npm run test:hicasso-freeze` | **0** | self-test passed; 7 frozen rows match |
| CLJS node suite | `npm run test:cljs` | **0** | 12,849 tests / 64,660 assertions, 0 failures |
| CLJS browser suite | `npm run test:browser` | **0** | 1,147 tests / 7,071 assertions, 0 failures |
| Fast-PR spine, in full | `sh scripts/test-fast-pr.sh` | **0** | 60 gate steps, all green |

The browser suite is not in the ruling's list but is run because the two restated roots assertions execute **only** there — `roots_frames_isolation_dom_cljs_test` skips under `:node-test`. Its compiled namespace was confirmed present in `out/browser-test` so the green is a real pass and not an absence.
