### PR TITLE
fix(codemod): the printed sketch is acceptable to the door (rf2-vi11)

### DIFF
--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -300,10 +300,14 @@ component, with strong defaults:
 
 Usage `[date-picker {...}]` is indistinguishable from a native view; the JS
 require stays quarantined in one `.cljs` host namespace; the crossing has a
-declared identity for tooling; policy overrides live on the declaration. A
-migration codemod (collect `[:> X …]` sites → emit the defhost block → rewrite
-call sites) upgrades sites incrementally. **The one raw escape** (HD-011),
-explicitly secondary to the declaration:
+declared identity for tooling; policy overrides live on the declaration.
+Upgrading a `[:>]` site to a declaration is three moves per namespace — collect
+the sites, emit the `defhost`, rewrite the call sites — and all three are by
+hand. The shipped migration codemod is a props-dialect **fixer**: it repairs the
+crossings you already have and leaves them `[:>]`, minting no declaration and
+hoisting nothing. The hoist that would mint them is demand-gated and unbuilt
+([the codemod](draft-guide/05-interop.md#the-codemod)).
+**The one raw escape** (HD-011), explicitly secondary to the declaration:
 `[:> Component props & children]` — same foreign lowering path, same default
 conversions, `.cljs`-only at that node, reduced structural identity; for
 runtime-selected components, `memo`/`lazy` values, render-prop-supplied

--- a/migration/reagent-to-hicasso/codemod/README.md
+++ b/migration/reagent-to-hicasso/codemod/README.md
@@ -106,7 +106,12 @@ the head.
 
 The suggestions block is labelled as guesses, and its header carries the
 Fluent/Ant counter-example. The tool never synthesizes a `:callbacks` map and
-there is no flag to make it.
+there is no flag to make it. The `defhost` sketch it prints is therefore a
+SCAFFOLD — the positions listed inside an empty `:callbacks` map as comments,
+with `:event`, `:handler` and `:render` named above them — which is acceptable
+to the door verbatim. Paste it, uncomment a row, type a contract.
+`sketch_test.clj` round-trips every sketch the corpus emits and keeps it that
+way.
 
 ## The three amendments
 

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/dest.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/dest.clj
@@ -19,6 +19,7 @@
   | [[canonical-slot]] | which React slot does this key emit into? | No — it selects which §3 row applies, and both runtimes compute it identically from the key alone |
   | [[html-attr-slot?]] | is this slot bound for an HTML attribute? | No — a yes means both runtimes `name` here, so W3 SKIPS |
   | [[event-prop?]] | will `host-entry` refuse a carrier at this slot? | No — a yes is always a REFUSAL, never a wrap |
+  | [[callback-contracts]] | what may a declaration name at a slot? | No — it is not asked of the source at all; the report PRINTS it |
   | literalness (`rewrite`'s own syntactic tests) | can this form's value be read off the text? | Yes — and it is the only term that can |
 
   Exactly one term can authorise a rewrite and it is the one that asks
@@ -31,12 +32,18 @@
   ## What is mirrored, and what is shared
 
   [[canonical-slot]] is the shared `.cljc` rule itself (rf2-ani6y) — not a
-  mirror, the actual function the codec calls. [[html-attr-slots]] and
-  [[re-event-prop]] ARE mirrors, of `codec/html-attr-slots` and
-  `intent/event-prop?`, because both live in `.cljs` this JVM tool cannot
-  load. Each is one small pure form carrying the symbol it mirrors, which
-  is the design's §9.5 partial mitigation — a convention, and the page is
-  candid that a convention is not a pin."
+  mirror, the actual function the codec calls. [[html-attr-slots]],
+  [[re-event-prop]] and [[callback-contracts]] ARE mirrors, of
+  `codec/html-attr-slots`, `intent/event-prop?` and
+  `codec/callback-contracts`, because all three live in `.cljs` this JVM
+  tool cannot load. Each is one small pure form carrying the symbol it
+  mirrors, which is the design's §9.5 partial mitigation — a convention,
+  and the page is candid that a convention is not a pin.
+
+  [[callback-contracts]] is the one mirror the tool does not merely
+  consult but REPRINTS, so `shared-rule-test` reads the door's own file
+  and asserts the two rosters equal rather than leaving this one to the
+  convention (rf2-vi11)."
   (:require [clojure.string :as str]
             [re-frame.bench.hicasso.front.slot :as slot]))
 
@@ -101,6 +108,23 @@
   [k]
   (boolean (and (or (keyword? k) (string? k))
                 (re-find re-event-prop (name k)))))
+
+(def callback-contracts
+  "MIRRORS `front.codec/callback-contracts` — the three contracts a
+  `defhost` declaration may name at a slot, and the whole of what the door
+  will accept there.
+
+  A VECTOR where the door holds a set, because this is the one piece of
+  destination vocabulary the report PRINTS rather than merely consults,
+  and printed prose needs an order. The order is the door's own literal
+  and the guide's: `:event`, `:handler`, `:render`.
+
+  The tool never chooses one. It cannot: `onRenderCell` is
+  [[event-prop?]]-true and is a RENDER prop, so a contract read off a name
+  is a guess that fails silently. The roster is carried here so the report
+  can tell a migrator what the three answers ARE, which is the part of the
+  decision the tool genuinely knows."
+  [:event :handler :render])
 
 (defn nested-key-name
   "What `clj->js` emits for a key inside a NESTED map — which is the

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/report.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/report.clj
@@ -30,7 +30,8 @@
   consumer's code needs a human decision is a tool that gets run once."
   (:require [clojure.java.io :as io]
             [clojure.pprint :as pp]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [re-frame.migration.hicasso.dest :as dest]))
 
 (def ^:private class-order
   "Report ordering within one site. Blockers first, then the refusals that
@@ -69,19 +70,71 @@
        "carry a function, and a name is not a meaning. Fluent's `onRenderCell` and Ant's `onRow` "
        "are event-SPELLED RENDER PROPS: the caller reads their RETURN VALUE. Declaring one as an "
        "`:event` contract would hand it a nil-returning wrapper and blank your cell renderer with "
-       "nothing thrown. That failure is why this tool never synthesizes a `:callbacks` map and "
-       "why there is no flag to make it."))
+       "nothing thrown. That failure is why this tool never synthesizes a `:callbacks` map, why "
+       "there is no flag to make it, and why every position in the sketch below is left blank for "
+       "you to fill."))
+
+(def ^:private sketch-indent
+  "The column `:callbacks`' entries start at, which is where the `{` after
+  `{:callbacks ` lands."
+  (apply str (repeat 15 \space)))
+
+(def ^:private simple-name
+  "A name `def` will take: lowercase-initial, and none of the `/` or `.`
+  that a qualified or dotted symbol carries."
+  #"[a-z][a-z0-9*+!?<>=_'-]*")
+
+(defn- host-name-for
+  "A `def`-able name for the sketch, derived from the head.
+
+  The final segment of a symbol head, lower-cased — `Btn` → `btn`,
+  `js/Foo.Bar` → `bar`, `some.ns/Widget` → `widget`. A NAME is the one
+  thing in a declaration that nobody's behaviour rides on, so deriving one
+  is free where deriving a contract is not, and a migrator renames it
+  without consequence.
+
+  A head that is an EXPRESSION rather than a symbol — `(.-Provider ctx)`,
+  `@registry` — yields no segment that `def` would take, and gets the
+  placeholder. That is the whole rule: anything that does not reduce to a
+  clean lowercase name is not guessed at."
+  [head]
+  (let [seg (some-> head str/trim (str/split #"[/.]") last str/lower-case)]
+    (if (and seg (re-matches simple-name seg)) seg "your-host")))
+
+(defn- contract-roster
+  "`\":event, :handler or :render\"` — generated from [[dest/callback-contracts]]
+  rather than transcribed beside it, so the sentence the report prints and
+  the roster the door enforces cannot drift apart in prose."
+  []
+  (let [ss (mapv pr-str dest/callback-contracts)]
+    (str (str/join ", " (pop ss)) " or " (peek ss))))
 
 (defn- defhost-sketch
   "A ready-to-paste declaration for one component. It is TEXT in a report,
   never a form the tool writes into a file: `:callbacks` synthesis is
   never mechanical, and the hoist that would mint these is demand-gated
-  and out of scope."
+  and out of scope.
+
+  **The sketch names no contract, because the tool does not know one.**
+  It used to print `:fn` at every position, which is not one of the three
+  the door accepts, so a migrator who pasted what the tool suggested was
+  refused at mint by `:rf.error/hicasso-unknown-callback-contract`
+  (rf2-vi11). A diagnostic that tells you what to write and is wrong is
+  worse than one that says nothing.
+
+  What is emitted instead is a SCAFFOLD, and it is acceptable to the door
+  verbatim: `:callbacks` is optional and an empty map is a legal
+  declaration, so the positions are listed inside it as comments with the
+  three contracts named above them. Paste it, uncomment a row, type a
+  contract. Uncommenting a row and typing NOTHING leaves the map with an
+  odd number of forms, which the reader refuses on the spot — the one
+  failure mode this shape can have is loud and immediate."
   [{:keys [head event-slots fn-slots]}]
   (let [slots (distinct (concat event-slots fn-slots))]
-    (str "(h/defhost " (str/lower-case (or head "component")) " " (or head "Component") "\n"
-         "  {:callbacks {" (str/join "\n               "
-                                     (for [s slots] (str s " :fn"))) "}})")))
+    (str "(h/defhost " (host-name-for head) " " (or head "Component") "\n"
+         "  {:callbacks {;; each position takes " (contract-roster) " — see :caution\n"
+         (str/join (for [s slots] (str sketch-indent ";; " s "\n")))
+         sketch-indent "}})")))
 
 (defn build
   "Assemble the report artefact from the per-file results."

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
@@ -836,7 +836,13 @@
 (defn- suggestions
   "The per-component suggestion block (§7.6), LABELLED AS GUESSES. The
   tool suggests a declaration and never writes one: `:callbacks` synthesis
-  is never mechanical."
+  is never mechanical.
+
+  Only a FOREIGN component earns one. A string head is a native tag —
+  W6 rewrites `[:> \"input\" …]` to `[:input …]`, and the two string heads
+  W6 declines (the broken `\"div#id\"` shorthand, and a carrier at
+  `\"button\"`) are native too — so there is nothing to declare and the
+  caller gates on that."
   [head props-node]
   (when props-node
     (let [ps (pairs props-node)
@@ -1056,7 +1062,9 @@
                           w1? (conj (entry :metadata-key :rewrote
                                            {:key (str/trim (n/string key-node))}
                                            (meta-key-note))))
-               :suggest (suggestions head props)
+               ;; `head-str` is a string only when the head is a string
+               ;; LITERAL, which is a native tag and never a host.
+               :suggest (when-not (string? head-str) (suggestions head props))
                :edit edit))
 
       base)))

--- a/migration/reagent-to-hicasso/codemod/test/corpus/the-suggested-declaration/expected-report.edn
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/the-suggested-declaration/expected-report.edn
@@ -1,0 +1,8 @@
+[{:line 34,
+  :col 3,
+  :class :string-tag-head,
+  :action :rewrote,
+  :head "\"input\"",
+  :detail {:head "input"},
+  :note
+  "Under Reagent `[:> \"input\" …]` took the controlled-input wrapper when the tag was `input` or `textarea`, because `input-component?` matches on exactly this path. Under Hicasso a string head is REFUSED at the crossing. Rewritten to `[:input …]`, which lands the site on Hicasso's own controlled door — the taught form. Reagent's deep camelCasing and its `(name …)` arm are both present at a native tag, so the prop rewrites are fixpoints here and are deliberately not applied."}]

--- a/migration/reagent-to-hicasso/codemod/test/corpus/the-suggested-declaration/expected.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/the-suggested-declaration/expected.cljs
@@ -1,0 +1,34 @@
+(ns app.suggested
+  "The suggested declaration (design §7.6) — the report's one piece of
+  forward-looking advice, and the one thing in it a migrator is invited to
+  PASTE.
+
+  So the sketch has to be acceptable to the door VERBATIM, and rf2-vi11
+  found that it was not: it printed `:fn` at every position, which is not
+  one of the three contracts `defhost` accepts, and it built the name
+  position by lower-casing whatever text the head happened to be — which
+  for a string head produced `(h/defhost \"button\" \"button\" …)`, a form
+  the reader refuses before the door ever sees it.
+
+  This case exists to put the head shapes in front of `sketch_test.clj`,
+  which reads every sketch the corpus emits and round-trips it."
+  (:require [reagent.core :as r]))
+
+(defn a-symbol-head []
+  ;; The ordinary case: `Btn` names the host `btn`.
+  [:> Btn {:on-pick (fn [x] x)}])
+
+(defn a-qualified-and-dotted-head []
+  ;; `js/Foo.Bar` names the host `bar` — the last segment. A NAME is free
+  ;; to derive because nobody's behaviour rides on it; a CONTRACT is not.
+  [:> js/Foo.Bar {:on-change (fn [e] e) :on-render-row (fn [row] row)}])
+
+(defn an-expression-head []
+  ;; No segment `def` would take, so the name position is left as an
+  ;; obvious placeholder rather than mangled into a plausible one.
+  [:> (.-Provider ctx) {:on-close (fn [] nil)}])
+
+(defn a-string-head-is-a-native-tag []
+  ;; W6 rewrites this to `[:input …]`. There is no host here to declare,
+  ;; so the report suggests nothing — a native tag never took a `defhost`.
+  [:input {:on-change (fn [e] e)}])

--- a/migration/reagent-to-hicasso/codemod/test/corpus/the-suggested-declaration/input.cljs
+++ b/migration/reagent-to-hicasso/codemod/test/corpus/the-suggested-declaration/input.cljs
@@ -1,0 +1,34 @@
+(ns app.suggested
+  "The suggested declaration (design §7.6) — the report's one piece of
+  forward-looking advice, and the one thing in it a migrator is invited to
+  PASTE.
+
+  So the sketch has to be acceptable to the door VERBATIM, and rf2-vi11
+  found that it was not: it printed `:fn` at every position, which is not
+  one of the three contracts `defhost` accepts, and it built the name
+  position by lower-casing whatever text the head happened to be — which
+  for a string head produced `(h/defhost \"button\" \"button\" …)`, a form
+  the reader refuses before the door ever sees it.
+
+  This case exists to put the head shapes in front of `sketch_test.clj`,
+  which reads every sketch the corpus emits and round-trips it."
+  (:require [reagent.core :as r]))
+
+(defn a-symbol-head []
+  ;; The ordinary case: `Btn` names the host `btn`.
+  [:> Btn {:on-pick (fn [x] x)}])
+
+(defn a-qualified-and-dotted-head []
+  ;; `js/Foo.Bar` names the host `bar` — the last segment. A NAME is free
+  ;; to derive because nobody's behaviour rides on it; a CONTRACT is not.
+  [:> js/Foo.Bar {:on-change (fn [e] e) :on-render-row (fn [row] row)}])
+
+(defn an-expression-head []
+  ;; No segment `def` would take, so the name position is left as an
+  ;; obvious placeholder rather than mangled into a plausible one.
+  [:> (.-Provider ctx) {:on-close (fn [] nil)}])
+
+(defn a-string-head-is-a-native-tag []
+  ;; W6 rewrites this to `[:input …]`. There is no host here to declare,
+  ;; so the report suggests nothing — a native tag never took a `defhost`.
+  [:> "input" {:on-change (fn [e] e)}])

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/corpus_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/corpus_test.clj
@@ -19,6 +19,13 @@
      rewrite's input language;
   4. determinism — a second analysis of `input` reports identically.
 
+  **`entries` is not the whole report.** The `:suggestions` block — the
+  half that tells a migrator what to WRITE — is assembled by
+  `report/build` and is not compared here, which is how a sketch that
+  named a contract the door refuses survived for the tool's whole life
+  (rf2-vi11). `sketch_test.clj` is the gate on that half, and it runs
+  over these same cases.
+
   The report is compared as DATA read back from EDN rather than as
   characters. The claim being gated is what the tool says, and every field
   including the full `:note` participates in that comparison; pinning the
@@ -58,8 +65,17 @@
 
 (defn- read-edn [f] (edn/read-string (slurp f)))
 
-(defn- write-edn! [f data]
-  (spit f (with-out-str (pp/pprint data))))
+(defn- write-edn!
+  "Write an expectation file, LF whoever regenerated it.
+
+  `pp/pprint` emits the PLATFORM line separator, so a regen on Windows
+  rewrote all ten fixtures to CRLF — the exact thing `.gitattributes`
+  pins this tree against, and noise that buries the one case a regen was
+  meant to change. Normalise here: the bytes a regen produces must not
+  depend on who ran it, which is the same claim the fixtures themselves
+  make."
+  [f data]
+  (spit f (str/replace (with-out-str (pp/pprint data)) "\r\n" "\n")))
 
 (deftest corpus-is-not-empty
   (testing "a corpus that silently found no cases would pass every

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/shared_rule_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/shared_rule_test.clj
@@ -85,7 +85,7 @@
           second
           edn/read-string))
 
-(deftest the-callback-contracts-are-the-door's
+(deftest the-callback-contracts-are-the-doors
   (testing "the door's file is where this test thinks it is — a moved
             file must red this pin rather than silently skip it"
     (is (.exists door-file) (str "the door is not at " door-file)))

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/shared_rule_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/shared_rule_test.clj
@@ -33,7 +33,8 @@
   pins it — `codemod-contract-donor-*` in
   `implementation/adapters/reagent/test/re_frame/reagent_codemod_contract_donor_cljs_test.cljs`
   (rf2-d2mwk)."
-  (:require [clojure.java.io :as io]
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [re-frame.bench.hicasso.front.slot :as slot]
@@ -64,6 +65,45 @@
                path))
       (is (not (str/includes? path "/migration/reagent-to-hicasso/"))
           "a copy of the slot rule has appeared inside the codemod's own tree"))))
+
+;; ---------------------------------------------------------------------------
+;; The one mirror the tool REPRINTS, held against the door's own file
+;; ---------------------------------------------------------------------------
+
+(def ^:private door-file
+  "`mint-host!`'s namespace. `.cljs`, so this JVM cannot load it — but it
+  can READ it, and for the one roster the tool prints back to a migrator
+  that is worth doing."
+  (io/file ".." ".." ".." "implementation" "hicasso" "src" "re_frame"
+           "hicasso" "impl" "codec.cljs"))
+
+(defn- door-contracts
+  "The contract roster as the DOOR spells it, lifted out of its own
+  source text."
+  []
+  (some-> (re-find #"\(def \^:private callback-contracts[\s\S]*?(#\{[^}]*\})" (slurp door-file))
+          second
+          edn/read-string))
+
+(deftest the-callback-contracts-are-the-door's
+  (testing "the door's file is where this test thinks it is — a moved
+            file must red this pin rather than silently skip it"
+    (is (.exists door-file) (str "the door is not at " door-file)))
+
+  (testing "rf2-vi11 — the report PRINTS this roster into the `defhost`
+            sketch it invites a migrator to paste, so a fourth contract at
+            the door, or a renamed one, makes the tool's own advice wrong.
+            `html-attr-slots` and `re-event-prop` are mirrors the design
+            calls conventions; this one is a mirror with an alarm on it."
+    (let [door (door-contracts)]
+      (is (set? door) "the door's `callback-contracts` set was not found in its source")
+      (is (= door (set dest/callback-contracts))
+          (str "the door accepts " (pr-str door) " and this tool prints "
+               (pr-str dest/callback-contracts)))))
+
+  (testing "`:fn` — the keyword the sketch used to print at every
+            position — is not among them, which is the whole of the bug"
+    (is (not (contains? (door-contracts) :fn)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The donor's key function, and its two deltas from the shared rule

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/sketch_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/sketch_test.clj
@@ -1,0 +1,202 @@
+(ns re-frame.migration.hicasso.sketch-test
+  "**The suggested declaration, round-tripped** (rf2-vi11).
+
+  The report's `:defhost` sketch is the one thing in the artefact a
+  migrator is invited to PASTE, and for the tool's whole life it printed a
+  declaration the destination would refuse:
+
+      (h/defhost btn Btn
+        {:callbacks {:on-pick :fn}})
+
+  `:fn` is not one of the three contracts `defhost` accepts, so pasting
+  what the tool suggested threw
+  `:rf.error/hicasso-unknown-callback-contract` at mint. At a string head
+  it was worse — `(h/defhost \"button\" \"button\" …)` is not a form the
+  READER takes, let alone the door.
+
+  It survived because nothing ever read it back. The golden corpus asserts
+  the report's `:entries` and stops there, so the suggestions block — the
+  half of the report that tells a migrator what to WRITE — was ungated.
+  This namespace closes that: it builds the real report artefact over
+  every corpus case and round-trips every sketch it finds.
+
+  ## What \"acceptable to the door\" is asserted to mean
+
+  `mint-host!` is `.cljs` and this JVM cannot call it, so the door is
+  asserted through its rules rather than through its code:
+
+  1. the sketch READS — one form, no reader error;
+  2. it is `(h/defhost <name> <component> …)` with a name `def` will take;
+  3. every contract it names is in [[dest/callback-contracts]], which
+     `shared-rule-test` holds equal to the door's own roster;
+  4. and — the assertion that is not vacuous — FILLING the scaffold
+     yields a `:callbacks` map of exactly this site's positions, each
+     mapped to a real contract. The sketch leaves the contracts blank
+     because the tool cannot know them; [[filling-the-scaffold-mints]]
+     is what proves the blanks are blanks in the right places."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.migration.hicasso.codemod :as cm]
+            [re-frame.migration.hicasso.dest :as dest]
+            [re-frame.migration.hicasso.report :as report]))
+
+;; ---------------------------------------------------------------------------
+;; The corpus, through the REAL report builder
+;; ---------------------------------------------------------------------------
+
+(defn- corpus-inputs []
+  (->> (.listFiles (io/file "test" "corpus"))
+       (filter #(.isDirectory ^java.io.File %))
+       (sort-by #(.getName ^java.io.File %))
+       (keep (fn [dir]
+               (first (filter #(str/starts-with? (.getName ^java.io.File %) "input.")
+                              (.listFiles ^java.io.File dir)))))))
+
+(defn- corpus-report
+  "The artefact the CLI writes, over the whole corpus at once — so this
+  suite exercises `report/build` rather than a private helper, and sees
+  the sketches exactly as a migrator does."
+  []
+  (let [results (mapv #(cm/scan-string (slurp %) (str "src/app/" (.getName ^java.io.File %)))
+                      (corpus-inputs))]
+    (report/build {:entries          (vec (mapcat :entries results))
+                   :suggestions      (vec (mapcat :suggestions results))
+                   :files-scanned    (count results)
+                   :files-changed    0
+                   :sites-total      (reduce + 0 (map :sites results))
+                   :sites-left-alone (reduce + 0 (map :left-alone results))})))
+
+(defn- components [] (get-in (corpus-report) [:suggestions :components]))
+
+(def ^:private contracts (set dest/callback-contracts))
+
+;; ---------------------------------------------------------------------------
+;; The pin is only worth something if it has something to read
+;; ---------------------------------------------------------------------------
+
+(deftest the-corpus-emits-sketches
+  (testing "a corpus that produced no suggestion block would pass every
+            assertion below and mean nothing — which is the shape of the
+            hole `:fn` lived in"
+    (let [cs (components)]
+      (is (<= 3 (count cs))
+          "the corpus must exercise the suggestion path — see
+           test/corpus/the-suggested-declaration")
+      (is (every? #(seq (:defhost %)) cs)
+          "every suggested component carries a sketch"))))
+
+;; ---------------------------------------------------------------------------
+;; 1–3. The sketch is a declaration the door would take
+;; ---------------------------------------------------------------------------
+
+(defn- read-one
+  "Read the sketch as data. `clojure.edn` and not `read-string`: a report
+  is text from a consumer's tree and nothing here should be able to run."
+  [sketch]
+  (edn/read-string sketch))
+
+(deftest every-sketch-is-acceptable-to-the-door
+  (doseq [{:keys [head defhost]} (components)]
+    (testing (str "the sketch for " head)
+      (let [form (read-one defhost)
+            [op nm _component opts] form]
+
+        (testing "reads as one `h/defhost` form"
+          (is (list? form))
+          (is (= 'h/defhost op))
+          (is (<= 3 (count form)) "head, name and component at least"))
+
+        (testing "names the host with a symbol `def` will take — the old
+                  sketch lower-cased the head text, which at a string head
+                  produced `(h/defhost \"button\" …)`"
+          (is (symbol? nm) (str "the name position is not a symbol: " (pr-str nm)))
+          (is (nil? (namespace nm)) (str "a qualified name cannot be `def`ed: " nm))
+          (is (not (str/includes? (name nm) "."))
+              (str "a dotted name cannot be `def`ed: " nm)))
+
+        (testing "names no contract outside the door's roster — this is
+                  the assertion `:fn` failed"
+          (doseq [[slot contract] (:callbacks opts)]
+            (is (contains? contracts contract)
+                (str "the sketch declares " (pr-str slot) " as " (pr-str contract)
+                     ", which the door refuses; the contracts are "
+                     (str/join ", " (map pr-str dest/callback-contracts))))))
+
+        (testing "declares no structural slot — `key` and `ref` are
+                  refused at mint in every spelling"
+          (doseq [slot (keys (:callbacks opts))]
+            (is (not (contains? #{"key" "ref"} (dest/canonical-slot slot)))
+                (str "the sketch declares the structural slot " (pr-str slot)))))))))
+
+;; ---------------------------------------------------------------------------
+;; 4. The scaffold fills — the assertion that is not vacuous
+;; ---------------------------------------------------------------------------
+
+(def ^:private commented-row
+  "A scaffold row: an indented `;;` carrying exactly one token, which is a
+  position. The roster sentence on the first line carries several words
+  and never matches."
+  #"(?m)^(\s*);; (\S+)$")
+
+(defn- fill
+  "What a migrator does to the sketch: uncomment every position row and
+  give each one a contract."
+  [sketch contract]
+  (str/replace sketch commented-row (str "$1$2 " (pr-str contract))))
+
+(deftest filling-the-scaffold-mints
+  (doseq [{:keys [head defhost event-slots fn-slots]} (components)
+          contract dest/callback-contracts]
+    (testing (str "the sketch for " head " filled with " contract)
+      (let [slots (mapv edn/read-string (distinct (concat event-slots fn-slots)))
+            opts  (nth (read-one (fill defhost contract)) 3)]
+
+        (is (= (set slots) (set (keys (:callbacks opts))))
+            (str "the filled sketch declares " (pr-str (keys (:callbacks opts)))
+                 " where the site uses " (pr-str slots)))
+
+        (is (seq (:callbacks opts))
+            "a filled scaffold that declared nothing would make every
+             assertion here vacuous")
+
+        (is (every? contracts (vals (:callbacks opts)))
+            "every filled position carries a contract the door accepts")))))
+
+;; ---------------------------------------------------------------------------
+;; 5. A native tag is not a host
+;; ---------------------------------------------------------------------------
+
+(deftest a-string-head-is-never-suggested
+  (testing "W6 rewrites `[:> \"input\" …]` to `[:input …]`; there is no
+            host at a native tag, and the sketch that used to be offered
+            there — `(h/defhost \"input\" \"input\" …)` — was not even
+            readable"
+    (doseq [{:keys [head]} (components)]
+      (is (not (string? (edn/read-string head)))
+          (str "a string head was offered a declaration: " head)))))
+
+;; ---------------------------------------------------------------------------
+;; 6. The text itself, where a reader will look for it
+;; ---------------------------------------------------------------------------
+
+(defn- sketch-for [head]
+  (->> (components) (filter #(= head (:head %))) first :defhost))
+
+(deftest the-sketch-reads-the-way-it-is-meant-to
+  (testing "an ordinary symbol head"
+    (is (= (str "(h/defhost bar js/Foo.Bar\n"
+                "  {:callbacks {;; each position takes :event, :handler or :render — see :caution\n"
+                "               ;; :on-change\n"
+                "               ;; :on-render-row\n"
+                "               }})")
+           (sketch-for "js/Foo.Bar"))))
+
+  (testing "an expression head takes the placeholder name, and the
+            component position is the head verbatim"
+    (is (= (str "(h/defhost your-host (.-Provider ctx)\n"
+                "  {:callbacks {;; each position takes :event, :handler or :render — see :caution\n"
+                "               ;; :on-close\n"
+                "               }})")
+           (sketch-for "(.-Provider ctx)")))))


### PR DESCRIPTION
Fixes the two defects on `rf2-vi11`: the report's `defhost` sketch suggested a declaration its own door would refuse, and `authoring.md` still described the codemod as the hoist.

## Fix 1 — the printed sketch

### Before

```clojure
(h/defhost btn Btn
  {:callbacks {:on-pick :fn}})
```

`:fn` is not one of the three contracts `defhost` accepts. A migrator who pasted what the tool printed got `:rf.error/hicasso-unknown-callback-contract` at mint — *"defhost app.hosts/btn declares :on-pick with the callback contract :fn. The contracts are :event, :handler and :render."*

### After

```clojure
(h/defhost btn Btn
  {:callbacks {;; each position takes :event, :handler or :render — see :caution
               ;; :on-pick
               }})
```

### Why this shape

Of the three honest options on the bead, **omit the callbacks map and say why** is the one the door and the tool's own stated law both point at.

Inference was ruled out first, and not by preference: the door's law is that a contract is *never* inferred from an `on*` name (`impl/intent.cljs:43-46`, `impl/codec.cljs:1105-1111`), and the caution the report already prints carries the counter-example — `onRenderCell` is event-*spelled* and is a render prop, so a guess there blanks a cell renderer with nothing thrown. A tool that guesses the contract reproduces the exact failure the design rejected.

A marked-placeholder keyword was ruled out by the acceptance test the bead set: the sketch has to be **acceptable to the door**, and any placeholder in value position is a keyword the door refuses. `:callbacks` is optional and `{}` is a legal declaration (`codec.cljs:1482`), so the scaffold above mints verbatim.

Keeping the map, empty, with the positions inside it as comments buys three things over dropping it: the positions stay where they must be typed, the report finally **states the roster** (it never did — the only contract it named was the wrong one), and uncommenting a row without typing a contract leaves the map with an odd number of forms, which the reader refuses on the spot. The one failure mode this shape has is loud and immediate.

The `:caution` gains one clause, so the block's claim that the tool "never synthesizes a `:callbacks` map" is now true of the artefact beneath it.

### Two further repairs the round-trip forced

Both are the same defect class — the sketch not being acceptable to the door — and both were found by writing the pin rather than by reading the line.

- **The name position.** It was `(str/lower-case head)` over the head's raw source text, so a string head produced `(h/defhost "button" "button" …)` — a `def` with a string name, refused by the *reader* before the door sees it. The name is now derived only when the head reduces to a clean lowercase segment (`Btn` → `btn`, `js/Foo.Bar` → `bar`); an expression head such as `(.-Provider ctx)` takes an obvious placeholder rather than a mangled plausible one. A name is the one thing in a declaration nobody's behaviour rides on, so deriving one is free where deriving a contract is not.
- **A string head is never a host.** W6 rewrites `[:> "input" …]` to `[:input …]` — a native tag. There is nothing to declare, so no declaration is offered. The two string heads W6 declines (the broken `"div#id"` shorthand, and a carrier at `"button"`) are native too.

### The round-trip pin

The defect survived because **nothing ever read the sketch back**. `corpus_test.clj` asserts the report's `:entries` and stops there, so the suggestions block — the half that tells a migrator what to *write* — was ungated, and the corpus docstring's claim that "a change to what the tool SAYS is gated exactly as hard as a change to what it WRITES" was false of that half. Its docstring now says so and points at the new gate.

- **New corpus case `test/corpus/the-suggested-declaration/`** — a symbol head, a qualified-and-dotted head, an expression head and a string head, so every head shape is in front of the pin.
- **New `test/re_frame/migration/hicasso/sketch_test.clj`** — builds the real artefact through `report/build` (which the corpus never exercised) over *every* corpus case, and asserts each sketch: reads as one form; is `(h/defhost <name> <component> …)` with a name `def` will take; names no contract outside the roster; declares no structural slot; and — the assertion that is not vacuous — **fills** into a `:callbacks` map of exactly that site's positions, once per contract in the roster. A sketch whose commented rows were in the wrong place, or which dropped a position, fails there. It also refuses to run vacuously: `the-corpus-emits-sketches` fails if the corpus stops producing suggestions.
- **`shared_rule_test.clj`** gains `the-callback-contracts-are-the-doors`, which reads `implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs` and holds the mirrored roster equal to the door's own literal. `dest.clj` carries the roster as a mirror in the house style, but this is the one mirror the tool *reprints* to users rather than merely consults, so it gets an alarm rather than the convention that `html-attr-slots` and `re-event-prop` rely on.

Sabotage controls, both run:

- restoring `:fn` in the sketch → **exit 1**, `the sketch declares :on-close as :fn, which the door refuses; the contracts are :event, :handler, :render`
- adding a fourth contract to the mirror → **exit 1**, `the door accepts #{:render :event :handler} and this tool prints [:event :handler :render :callback]`

### One thing I could not do

The pin reads `codec.cljs`, but the CI classifier does not arm `migration_hicasso_codemod` from `implementation/hicasso/`'s tree, so a change to the door alone will not re-run it — it reds on the codemod tree's next change instead. The classifier and rosters are off-limits on this branch (PR #7760). Worth a follow-up bead; it is strictly better than the status quo either way, since the two existing mirrors have no source-text alarm at all.

## Fix 2 — `authoring.md:304`

### Before

> policy overrides live on the declaration. A migration codemod (collect `[:> X …]` sites → emit the defhost block → rewrite call sites) upgrades sites incrementally.

### After

> policy overrides live on the declaration. Upgrading a `[:>]` site to a declaration is three moves per namespace — collect the sites, emit the `defhost`, rewrite the call sites — and all three are by hand. The shipped migration codemod is a props-dialect **fixer**: it repairs the crossings you already have and leaves them `[:>]`, minting no declaration and hoisting nothing. The hoist that would mint them is demand-gated and unbuilt ([the codemod](draft-guide/05-interop.md#the-codemod)).

The three moves are still named — they are the *hand* migration, exactly as guide 05's "Migrating off it" has it — but they are no longer attributed to the tool. "demand-gated and unbuilt" is guide 05's own phrasing, per `rf2-2rtt6.112`.

Verified by hand, as `docs/design/**` requires: the edit is prose inside one paragraph, adds no table and no heading, so there are no column counts or anchors of its own to check. The one anchor it introduces, `draft-guide/05-interop.md#the-codemod`, resolves to `### The codemod` at 05-interop.md:448 — and `check_doc_slugs.py` validates it (sabotage control below). The link stays inside `docs/`, which is the only link style this page uses.

## Quality gates

Each run alone, foreground, exit code echoed to its own file — no filter appended to any gate's command line.

| Gate | Exit |
|---|---|
| `clojure -M:test` (from `migration/reagent-to-hicasso/codemod`) | **0** — 28 tests, 300 assertions, 0 failures / 0 errors (was 22 / 158) |
| `python scripts/check_doc_slugs.py` | **0** |
| `sh scripts/test-fast-pr.sh` (full) | **0** — `PASS fast PR spine` |

Sabotage controls, all confirming the gate genuinely covers the change:

| Sabotage | Gate | Result |
|---|---|---|
| sketch emits `:fn` again | `clojure -M:test` | exit **1** — `the sketch declares :on-close as :fn, which the door refuses` |
| fourth contract in the mirrored roster | `clojure -M:test` | exit **1** — `the door accepts #{…} and this tool prints [… :callback]` |
| `#the-codemod` broken to `#the-codemod-XX` | `check_doc_slugs.py` | exit **1** — `BROKEN ANCHOR: authoring.md:309` |

Baseline before any edit was `clojure -M:test` exit 0 at 22 tests / 158 assertions, so the suite went green → green.

### One incidental repair, called out because it is not on the bead

`corpus_test.clj`'s `write-edn!` regen helper wrote the **platform** line separator, because `pp/pprint` does. A regen on Windows therefore rewrote all ten fixtures to CRLF — precisely what `.gitattributes` pins this tree against (`test/corpus/** text eol=lf`), and noise that buries the one case a regen was meant to change. It now normalises to LF, so the bytes a regen produces do not depend on who ran it — the same claim the fixtures themselves make. This is why the diff shows exactly one new corpus case and no churn in the other ten.

CRLF was read rather than assumed throughout: `newlines_test.clj` passes, and the new fixtures are LF (verified byte-wise).

Does not close `rf2-vi11`.
