### PR TITLE
ci: arm the codemod lane from the hicasso door (rf2-erjv)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -1181,6 +1181,34 @@ else
         # green under regressions these rows catch. A hicasso diff that
         # did not run it would be relying on the weaker witness.
         hicasso_controlled=true
+        # rf2-erjv — migration_hicasso_codemod, the SECOND reverse edge into
+        # the codemod's JVM lane. The `implementation/freehand/*` arm above
+        # carries the first and states the shape; this is the same shape by a
+        # different mechanism, and it was missing.
+        #
+        # There the edge is a CLASSPATH one: the codemod's deps.edn puts
+        # `../../../implementation/freehand/test` on `:paths` so the tool and
+        # the door share ONE slot rule (rf2-ani6y). Here it is a SOURCE-TEXT
+        # one. `shared_rule_test.clj`'s `the-callback-contracts-are-the-doors`
+        # (rf2-vi11) reaches back up the tree with a relative `io/file` and
+        # slurps `implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs`,
+        # because that roster is `.cljs` this JVM cannot load but CAN read —
+        # then asserts the door's own `callback-contracts` set equals the one
+        # the codemod PRINTS into the `defhost` sketch it invites a migrator to
+        # paste. Add a fourth contract at the door, or rename one, and the
+        # tool's advice goes wrong; that pin is the assertion that says so, and
+        # before this line it lived in a lane a hicasso-only diff never ran.
+        # The pin also asserts the file EXISTS where it looks, so a MOVE of
+        # codec.cljs reds it rather than silently skipping — which is only
+        # worth having if the move's own PR schedules the lane.
+        #
+        # COARSER than the edge, for the reason the freehand arm gives: the
+        # read file sits inside this tree, and an arm naming it alone would
+        # have to precede this one, where it would shadow the three outputs
+        # above and silently narrow the package's own coverage. Over-
+        # classifying a seconds-long pure JVM suite is the cheaper error, and
+        # TESTING.md says to prefer it.
+        migration_hicasso_codemod=true
         ;;
       implementation/scripts/run-ui-bench.cjs)
         # rf2-vxgfnd.6 — false-green fix, mirroring the launcher cases

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -760,6 +760,12 @@ const CODEMOD_LANE = {
   // runtime door share ONE slot rule (rf2-ani6y), and shared_rule_test.clj
   // pins the two `identical?`.
   sharedRule: 'implementation/freehand/test/re_frame/bench/hicasso/front/slot.cljc',
+  // rf2-erjv — the SECOND cross-tree edge, and a different mechanism. The one
+  // above is a classpath entry; this one is source TEXT. shared_rule_test.clj's
+  // `the-callback-contracts-are-the-doors` (rf2-vi11) slurps the door's own
+  // `.cljs` with a relative `io/file` and asserts the roster the codemod prints
+  // into its `defhost` sketch equals the door's `callback-contracts`.
+  door: 'implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs',
 };
 
 test('the codemod JVM job is gated on its own output and runs the artefact (rf2-2rtt6.143)', () => {
@@ -817,6 +823,56 @@ test('the codemod lane arms on its own tree and on the shared slot rule (rf2-2rt
   for (const output of ['implementation_jvm', 'cljs_node_test', 'cljs_browser', 'cljs_prod']) {
     assert.equal(shared[output], 'true', `${CODEMOD_LANE.sharedRule} must still arm ${output}`);
   }
+});
+
+test('the codemod lane arms on the DOOR the roster pin reads (rf2-erjv)', () => {
+  // The second reverse edge, and the one that was missing. PR #7762 put the
+  // roster pin in the codemod's JVM lane while the classifier armed that lane
+  // from `implementation/freehand/*` only — so a fourth contract at the door,
+  // or a renamed one, ran no suite that pins it and reds later on an unrelated
+  // PR that happens to arm the lane.
+  assert.equal(
+    classify(CODEMOD_LANE.door)[CODEMOD_LANE.output],
+    'true',
+    `${CODEMOD_LANE.door} is read by shared_rule_test.clj and must arm ${CODEMOD_LANE.output}`,
+  );
+  // …and the arm WIDENS the hicasso case rather than replacing it. The arm is
+  // shared, `cljs_browser` and `hicasso_controlled` joined it only recently,
+  // and trading one output for another here would close this hole by opening
+  // others — the same constraint rf2-8a6s pinned one block down.
+  const door = classify(CODEMOD_LANE.door);
+  for (const output of ['cljs_node_test', 'cljs_browser', 'hicasso_controlled']) {
+    assert.equal(door[output], 'true', `${CODEMOD_LANE.door} must still arm ${output}`);
+  }
+});
+
+test('the door the codemod pin reads is the file the arm names (rf2-erjv)', () => {
+  // NON-VACUITY. Arming a lane off a path is worth nothing if the suite in that
+  // lane reads a DIFFERENT path, so this does not assert the edge in prose: it
+  // lifts the `io/file` segments out of the pin itself, resolves them the way
+  // the JVM does — relative to the codemod's working directory, which is what
+  // `working-directory:` sets in the job — and requires the answer to be the
+  // file this block arms on. Move the door, or repoint the pin, and the arm
+  // becomes a lie; this row is what says so.
+  const pin = fs.readFileSync(
+    path.join(REPO_ROOT, CODEMOD_LANE.dir, 'test/re_frame/migration/hicasso/shared_rule_test.clj'),
+    'utf8',
+  );
+  const form = /\(io\/file\s+((?:"[^"]*"\s*)+)\)/.exec(pin);
+  assert.notEqual(form, null, 'shared_rule_test.clj must locate the door with an (io/file ...) form');
+  const segments = form[1].match(/"([^"]*)"/g).map((s) => s.slice(1, -1));
+  const resolved = path
+    .relative(REPO_ROOT, path.resolve(REPO_ROOT, CODEMOD_LANE.dir, ...segments))
+    .replace(/\\/g, '/');
+  assert.equal(
+    resolved,
+    CODEMOD_LANE.door,
+    `the pin reads ${resolved}, so that is the path the classifier must arm on`,
+  );
+  assert.ok(
+    fs.existsSync(path.join(REPO_ROOT, resolved)),
+    `${resolved} must exist — the pin asserts it does and reds on a move`,
+  );
 });
 
 test('the codemod lane stays dark for surfaces it does not depend on (rf2-2rtt6.143)', () => {


### PR DESCRIPTION
PR #7762 added a door pin: `shared_rule_test.clj`'s `the-callback-contracts-are-the-doors` reads the door's own `codec.cljs` and asserts the mirrored callback-contract roster equals it. That pin lives in the codemod's JVM lane — but the classifier armed `migration_hicasso_codemod` from `implementation/freehand/*` and **not** from `implementation/hicasso/*`. So a change to the door's roster ran no suite that pins it, and drift reds late, on some unrelated PR that happens to arm the lane.

## The arm

One line on the `implementation/hicasso/*` arm of `.github/scripts/report-changed-surfaces.sh`:

```sh
migration_hicasso_codemod=true
```

**Every output that arm already set is preserved.** Nothing was traded — the arm gained `cljs_browser` and `hicasso_controlled` only recently, and this is strictly additive:

| | `cljs_node_test` | `cljs_browser` | `hicasso_controlled` | `migration_hicasso_codemod` |
|---|---|---|---|---|
| `origin/main` | true | true | true | **false** |
| this PR | true | true | true | **true** |

(`cljs_node_test` is the output that schedules the freeze gate, so the freeze gate is untouched.)

## The comment

The `rf2-2rtt6.143` block on the `implementation/freehand/*` arm documents the first reverse edge. The new block documents the second the same way, and states what is *different* about it.

The freehand edge is a **classpath** one: the codemod's `deps.edn` puts `../../../implementation/freehand/test` on `:paths` so the tool and the door share one slot rule (rf2-ani6y). This one is a **source-text** edge: the pin cannot load `.cljs` from a JVM, so it reaches back up the tree with a relative `io/file` and *slurps* `implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs`, then asserts the door's `callback-contracts` equals the roster the codemod prints into the `defhost` sketch it invites a migrator to paste. Add a fourth contract at the door, or rename one, and the tool's advice becomes wrong. The pin also asserts the file exists where it looks, so a *move* reds it rather than silently skipping — which is only worth having if the move's own PR schedules the lane.

The comment carries the same coarseness argument the freehand block gives, because it applies unchanged: the read file sits inside this tree, so an arm naming it alone would have to precede this one, where it would shadow the three outputs above and silently narrow the package's own coverage. Over-classifying a seconds-long pure JVM suite is the cheaper error, and `TESTING.md` says to prefer it.

## The classifier proof

A real commit touching **only** the door, probed through the `pull_request` code path against a **real remote base**:

```
$ git diff --no-renames --name-only origin/worker/reverseedge-erjv...HEAD
implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
$ git diff --no-renames --name-only origin/worker/reverseedge-erjv...HEAD | wc -l
1

$ GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=worker/reverseedge-erjv \
    bash .github/scripts/report-changed-surfaces.sh
...
migration_hicasso_codemod=true
hicasso_controlled=true
migration_v1_codemod=false
```

Reviewer-reproducible short form, no probe commit needed:

```
$ bash .github/scripts/report-changed-surfaces.sh \
    implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
cljs_node_test=true
cljs_browser=true
migration_hicasso_codemod=true
hicasso_controlled=true
```

### Why the probe is not vacuous

Three things, because "it printed true" on its own proves nothing:

1. **The bases resolve.** Both `origin/main` (`691db88028`) and `origin/worker/reverseedge-erjv` resolved in the probing checkout, so the classifier took the real `git diff` path and not a conservative fallback. The probe branch was a branch of the pushed work, not a scratch repo.
2. **Committed before probing.** Both commits were pushed before the probe ran, so the rule being measured is the rule in this PR — not an uncommitted edit that a later checkout could drop.
3. **A control run isolates the change.** `origin/main`'s own classifier was extracted with `git show` and run against the *same* probe diff. Diffing the two full 30-line outputs:

```
$ diff control-out.log after-out.log
28c28
< migration_hicasso_codemod=false
---
> migration_hicasso_codemod=true
```

One line across the entire output. The `false` is the bug this bead describes, the `true` is the fix, and nothing else moved.

## The regression

The first narrowing went stale unnoticed because no regression pinned it — that is how this bead came to exist, so the arm gets pinned. Two rows extend the existing `CODEMOD_LANE` block in `implementation/scripts/_changed-surfaces.test.cjs`, which already pins the first reverse edge:

- **`the codemod lane arms on the DOOR the roster pin reads`** — the door arms `migration_hicasso_codemod`, *and* still arms `cljs_node_test`, `cljs_browser` and `hicasso_controlled`, so a future edit cannot trade one output for another.
- **`the door the codemod pin reads is the file the arm names`** — non-vacuity. Arming a lane off a path is worthless if the suite in that lane reads a *different* path, so this does not assert the edge in prose: it lifts the `io/file` segments out of `shared_rule_test.clj`, resolves them against the codemod's working directory (what `working-directory:` sets in the job), and requires the answer to be the path the arm fires on. Move the door or repoint the pin and the arm becomes a lie; this row is what says so.

## Quality gates

Each run alone, foreground, with `$?` echoed to its own file. All results were taken **after** the classifier edit.

| Gate | Exit | Result |
|---|---|---|
| `sh scripts/test-fast-pr.sh` (full) | **0** | `PASS fast PR spine` |
| `node implementation/scripts/_changed-surfaces.test.cjs` | **0** | `changed-surfaces tests: 317 passed.` |
| `python scripts/check_test_lane_bijection.py` | **0** | 1835 test-defining files, 49 lanes, every file selected and every selector reached |
| `python scripts/check_jvm_lane_rosters.py` | **0** | 33 rostered artefacts, every roster entry required in CI and every required JVM job rostered |
| `python scripts/check_gate_scheduling.py` | **0** | 42 gate commands, 36 scheduled, 6 declared (0 known holes) |
| `python scripts/check_fast_pr_gap.py` | **0** | gap map clean; 81 required jobs across 3 workflows |
| `clojure -M:test` in `migration/reagent-to-hicasso/codemod` | **0** | Ran 28 tests containing 300 assertions. 0 failures, 0 errors. |

The last one is the lane this PR arms, and `re-frame.migration.hicasso.shared-rule-test` — the door pin — is among the namespaces it ran.

Bead: rf2-erjv (left open deliberately — a review agent reopens the owner with findings).
