### PR TITLE
docs(hicasso): record why the checkpoint turn count is not a vacuity check (rf2-2l17)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/checkpoint_support.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/checkpoint_support.cljs
@@ -83,10 +83,13 @@
   number of turns it took, or of `nil` when [[checkpoint-turn-budget]] is
   exhausted.
 
-  The turn count is reported rather than discarded because zero is a
-  distinct and interesting answer: it means the condition already held
-  before the drain began, so the row measured nothing. A witness that
-  asserts the correction happened should assert the count moved."
+  The turn count is reported for diagnosis, and **is not a vacuity
+  check** — a mistake worth recording, because it was made here first and
+  red four rows. The drain necessarily spends one turn before its first
+  probe, and the collector queues its microtask *before* that, so `0`
+  turns is the ordinary healthy answer rather than evidence of a row that
+  watched nothing. The vacuity check has to be taken SYNCHRONOUSLY,
+  before the checkpoint the row is about; [[at-the-checkpoint]] takes it."
   [ready?]
   (let [!turns (volatile! 0)]
     (letfn [(step [_]


### PR DESCRIPTION
Tail of **rf2-2l17** / PR #7766. This one commit raced that PR's merge and did not make it in; everything else from the bead landed.

`drain-checkpoint`'s docstring advised callers to assert the turn count moved. That advice is wrong, and it red four rows when it was followed during this bead's own work: the drain necessarily spends one promise turn before its first probe, and the collector queues its microtask *before* that, so `0` turns is the ordinary healthy answer rather than evidence of a row that watched nothing.

The vacuity check has to be taken **synchronously**, before the checkpoint the row is about — which is what `at-the-checkpoint` already does. The docstring now says so, and records the mistake rather than quietly deleting it, so the next reader does not re-derive it from a red suite.

Docstring only; no behaviour changes.

## Quality gates

| gate | command | exit |
|---|---|---|
| hicasso package compile | `node scripts/compile-node-test.cjs node-test-hicasso out/node-test-hicasso.js` | **0** |
| hicasso node suite | `node out/node-test-hicasso.js` | **0** — 68 tests / 310 assertions / 0 failures |

Both were run on this exact content before PR #7766 was merged (the commit is unchanged, cherry-picked onto current `main`). CI carries the rest.

Does not close rf2-2l17 — the bead stays open for the owner.