### PR TITLE
test(hicasso): pin the public door's macro shapes (rf2-0xgk)

### DIFF
--- a/implementation/hicasso/frozen-sources.edn
+++ b/implementation/hicasso/frozen-sources.edn
@@ -124,6 +124,11 @@
 ;; consumer actually writes against, is now the least-checked thing here.
 ;; Re-pinning that surface by some means other than a donor diff is worth a
 ;; follow-up bead; it is not something this bead should invent schema for.
+;;
+;; 2026-08-10 (rf2-0xgk) — DISPOSITION: `arm1/` provenance-pinning ended at the
+;; module split (PR #7744; retirement in PR #7748) and does not resume — the
+;; package is the artefact from that commit forward, and the door is held to
+;; its CONTRACT instead, by `public_door_macros_cljs_test`.
 
 {:donor-root "implementation/freehand/test/re_frame/bench/hicasso"
 

--- a/implementation/hicasso/test/re_frame/hicasso/public_door_macros_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/public_door_macros_cljs_test.cljs
@@ -1,0 +1,129 @@
+(ns re-frame.hicasso.public-door-macros-cljs-test
+  "THE PUBLIC DOOR'S MACRO SHAPES, pinned by contract rather than by donor
+  digest (rf2-0xgk).
+
+  `arm1/lang.clj` defines the three macros a consumer writes against, and
+  until rf2-hic-009 split the runtime its row in `frozen-sources.edn` held
+  each of them to its donor. The split made that row inexpressible —
+  `defview`'s expansion target moved from `impl.runtime/mint-view!` to
+  `impl.collector/mint-view!`, and `:renames` is a one-to-one table that
+  cannot say which of six modules a call site should now name — so the row
+  was retired, and retiring a row drops the donor digest along with the
+  comparison. The other two macros were collateral: `hfn` and `defhost`
+  still match their donor exactly, but a row is judged whole, and the
+  alternative — a per-shape exemption — is the one thing that gate must
+  never grow.
+
+  So the AUTHORING SURFACE, the part of the package a consumer actually
+  writes against, briefly became the least-checked thing in it. This file
+  is the replacement instrument, and it is deliberately a different KIND
+  of check: the freeze gate answers *is the package the prototype, moved*,
+  which stopped being answerable for a file whose namespace legitimately
+  moved. What a consumer needs answered instead is *does the door still
+  hand back what it promises* — a contract, not a provenance diff. Byte-
+  for-byte expansion snapshots were considered and rejected: incidental
+  symbol and def-layout detail would make safe refactoring noisy for no
+  consumer confidence.
+
+  Three witnesses cover the three macros, and only two of them are here.
+  `defview` is already witnessed by
+  [[re-frame.hicasso.smoke-cljs-test]] — a boundary minted through the
+  door, asserted `boundary-head?`, rendering a live subscription read —
+  and that suite is the third witness, unchanged.
+
+  ## Why these assertions and not others
+
+  Each row below pins one thing the macro EXPANSION decides, chosen so
+  that changing the expansion cannot leave the row green:
+
+  - what the expansion targets (`impl.intent/callback`,
+    `impl.codec/mint-host!`), read back through the predicate that target
+    mints — `callback?` and `host-head?`, one own-property read each;
+  - that the author's own value survives the expansion unwrapped;
+  - that an argument the author wrote reaches the declaration, which is
+    `defhost`'s `opts`.
+
+  Reaching to `impl.intent` and `impl.codec` for those two predicates is
+  the same reach the package smoke makes for `boundary-head?`: the marker
+  is the observable, and there is no other way to ask.
+
+  ## The NODE lane, and no runtime state
+
+  This is the node lane. Nothing here subscribes, dispatches or mounts, so
+  nothing here needs a DOM, a registered frame or a runtime reset — the
+  server renderer runs the crossing for real and the file leaves no state
+  behind it. `defhost`'s DOM-driven counterpart is the isolation suite's
+  containment row; this witness exists because that usage is incidental to
+  a different contract and could refactor away without anyone noticing the
+  door had gone unchecked.
+
+  ## Naming
+
+  The spellings asserted here are the prototype's — `defview`, `hfn`,
+  `defhost`. The naming review recommends `h/event` for the callback form;
+  when that lands, the sweep renames these witnesses with everything else."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.intent :as intent]
+            ["react" :as react]
+            ["react-dom/server" :as react-dom-server]))
+
+(def ^:private frame-id ::public-door)
+
+;; ---------------------------------------------------------------------------
+;; Witness A — `h/hfn`, the one callback form
+;; ---------------------------------------------------------------------------
+
+(deftest hfn-mints-an-ordinary-function-that-a-position-can-recognise
+  (let [picked (h/hfn [e] [:door/picked (.-value e)])]
+
+    (testing "the value is an ordinary function — no carrier object, nothing
+              that can fail to be callable where Hicasso does not walk"
+      (is (fn? picked)))
+
+    (testing "and calling it returns what the author wrote, unwrapped"
+      (is (= [:door/picked "todo"] (picked #js {:value "todo"}))))
+
+    (testing "the mark the expansion applies is on it, so a walked position
+              can impose its contract"
+      (is (true? (intent/callback? picked))))
+
+    (testing "and the witness discriminates rather than restating `fn?`: a
+              plain `fn` written the same way is NOT the callback form"
+      (is (false? (intent/callback? (fn [e] [:door/picked (.-value e)])))))))
+
+;; ---------------------------------------------------------------------------
+;; Witness B — `h/defhost`, the interop door
+;; ---------------------------------------------------------------------------
+
+(defn- badge-component
+  "A foreign React component: not a boundary, not hiccup, nothing Hicasso
+  minted. The crossing is the only thing that can put its markup on the
+  page."
+  [^js props]
+  (react/createElement "b" #js {"className" "badge"} (.-label props)))
+
+(h/defhost badge badge-component {:ssr :render})
+
+(defn- html
+  [hiccup]
+  (react-dom-server/renderToString (codec/root-element frame-id hiccup)))
+
+(deftest defhost-mints-a-host-head-that-carries-the-option-it-was-declared-with
+  (testing "the door hands back a minted host head, not the component the
+            author named"
+    (is (true? (codec/host-head? badge)))
+    (is (not (identical? badge badge-component))))
+
+  (testing "the `opts` argument reaches the declaration: the policy read back
+            off the head is the one written at the call site, and it is the
+            only reason the server render below produces anything at all —
+            `:client-only`, the default a dropped argument would leave,
+            renders no host region on the server"
+    (is (= :render (codec/host-ssr badge))))
+
+  (testing "and the minted var is a legal hiccup head inside an ordinary tree,
+            with the crossing rendering the foreign component's own markup"
+    (let [markup (html [:div.crossing [badge {:label "hicasso"}]])]
+      (is (re-find #"<b[^>]*class=\"badge\"[^>]*>hicasso</b>" markup)))))


### PR DESCRIPTION
Closes rf2-0xgk.

Retiring the `arm1/` rows from the freeze manifest dropped the donor digest along with the MOVED comparison, so the three macros a consumer writes against — `defview`, `hfn`, `defhost` — became the least-checked thing in the package. Only `defview` actually re-points to a new namespace after the module split, but a row is judged whole, and the alternative is the per-shape exemption the gate must never grow.

This is the bead's delegated decision as ruled: **option (c) plus the (d) record**, in the small-contract-witness form. Option (a) (split-aware manifest schema) and option (b) (narrow re-pin) were both rejected on the bead and neither is attempted here. No freeze-schema extension, no new harness, no JVM lane, no per-shape exemption, and the rename table is untouched.

## What landed

Two witnesses replace the lost coverage with a different KIND of check. The freeze gate answers *is the package the prototype, moved*, which stopped being answerable for a file whose namespace legitimately moved; a consumer needs *does the door hand back what it promises* instead. Byte-for-byte macro-expansion snapshots were considered and rejected — incidental symbol and def-layout detail would make safe pre-alpha refactoring noisy for zero consumer confidence.

- **Witness A — `h/hfn`.** It is an ordinary function that returns the author's value unwrapped, carries the mark `impl.intent/callback?` reads, and a plain `fn` written the same way does not. The last assertion is what stops the witness from merely restating `fn?`.
- **Witness B — `h/defhost`.** It mints a host head rather than returning the named component, forwards its `opts` to the declaration (`{:ssr :render}`, read back as `codec/host-ssr`), and is a legal hiccup head whose crossing renders the foreign component through a real server render.
- **`defview` is the third witness and is unchanged** — the package smoke already mints one through the door and renders a live subscription read.

New file: `implementation/hicasso/test/re_frame/hicasso/public_door_macros_cljs_test.cljs` (the `:node-test` lane; nothing here subscribes, dispatches or mounts, so it needs no DOM, no registered frame and no runtime reset, and leaves no state behind).

The (d) record is one dated disposition in `frozen-sources.edn`'s header: `arm1/` provenance-pinning ended at the module split (PR #7744; retirement in PR #7748) and does not resume. The header already stated the cost; this is a disposition, not a rewrite.

Naming follows the bead's item (8): the witnesses target the prototype spellings that exist today (`defview`, `hfn`, `defhost`). The naming review recommends `h/event` for the callback form; the rename sweep updates these mechanically when it lands, and nothing here pre-empts it.

## Hard fences, both respected

- **The rename table is not pruned.** `arm1.presence` and `arm1.lang` remain load-bearing for the surviving `front/*` reconstructions (`front/presence.cljs`, `front/intent.cljs`). The diff on `frozen-sources.edn` is a comment insertion in the header and nothing else — `+5, -0`, all comment lines.
- **No per-shape exemption mechanism was added to the freeze gate.** `implementation/hicasso/scripts/check_freeze.py` is not touched by this branch at all. A row stays judged whole.

## Mutation proof

Bead item (7): each witness shown able to fail exactly once. Each mutation was applied to the **macro under test**, not to the assertion, then reverted; the working tree is clean at the committed state and neither mutation is in this diff.

| Witness | Temporary mutation | Result |
|---|---|---|
| A — `hfn` | dropped the `impl.intent/callback` wrapper from the expansion (`` `(fn ~argv ~@body) ``) | **RED**, exit `1` — 1 failure: `expected (true? (intent/callback? picked))`, `actual (not (true? false))` |
| B — `defhost` | dropped `opts` forwarding into `mint-host!` (`~(or opts {})` → `{}`) | **RED**, exit `1` — 2 failures: `expected (= :render (codec/host-ssr badge))`, `actual (not (= :render :client-only))`; and the server render collapsed to `<div class="crossing"></div>`, which is the docstring's own claim demonstrated literally |

Baseline for the same namespace, unmutated: `2 tests, 8 assertions, 0 failures, 0 errors`, exit `0`.

## Quality gates

All run in the worktree `C:/Users/miket/code/re-frame2-worktrees/macropin-0xgk`, each alone and in the foreground, each exit code captured explicitly to its own file rather than read off a pipeline. The spine printed `gate root: /c/Users/miket/code/re-frame2-worktrees/macropin-0xgk`, confirming it adopted this checkout.

| Gate | Command | Result | Exit |
|---|---|---|---|
| Fast-PR spine | `sh scripts/test-fast-pr.sh` | **PASS** — `PASS fast PR spine`; tiers classified `docs=false jvm=false node=true` | `0` |
| CLJS `:node-test` lane (post-rebase) | `npm run test:cljs` | **PASS** — Ran 12887 tests containing 64884 assertions. 0 failures, 0 errors | `0` |
| Hicasso freeze gate + self-test (post-rebase) | `npm run test:hicasso-freeze` | **PASS** — `check_freeze self-test passed`; `7 frozen row(s) match the bench tree, and each package file is its donor moved; no package file imports it` | `0` |
| New witnesses, focused | `node out/node-test.js --test=re-frame.hicasso.public-door-macros-cljs-test` | **PASS** — Ran 2 tests containing 8 assertions. 0 failures, 0 errors | `0` |
| Mutation proof A (`hfn`) | as above, macro temporarily mutated | **RED as required**, then reverted | `1` |
| Mutation proof B (`defhost`) | as above, macro temporarily mutated | **RED as required**, then reverted | `1` |

The spine was run before the final rebase onto `origin/main`; the node lane and the freeze gate — the only two lanes this diff's surface reaches — were re-run afterwards and are the figures quoted above. The spine's own tier classification was identical across both bases, since the diff surface did not change across the rebase.

Not run locally, with reasons:

- **Documentation tier** — skipped by the spine, documentation surface unchanged (`--with-docs` forces it). No Markdown or MkDocs config in this diff.
- **All JVM artefact suites** — skipped by the spine, `implementation_jvm` surface unchanged (`--all` forces it). The hicasso package is correctly off that surface: its runtime requires React, so every suite it owns is CLJS.
- **The 93 required CI checks with no local lane** — enumerated by `python scripts/check_fast_pr_gap.py --list` (exit `0`), the one path that derives the required set, cited rather than hand-listed because that set moves. Green locally is not green in CI, and none of those 93 is decided here.

Two of those 93 are worth naming because `implementation/hicasso/**` arms them and this diff is inside that tree: `cljs-browser` (the Playwright `:browser-test` lane, widened onto hicasso by rf2-8a6s) and `cljs-hicasso-controlled` (the three-engine I15 gate). Both are CI's to run; neither touches the two namespaces this branch adds, but neither is decided locally.

## Doc-slug / anchor note

Not applicable — this branch adds no Markdown and edits nothing under `docs/`.
