### PR TITLE
docs(hicasso): add draft-guide glossary and link chapters to it

### DIFF
--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -115,7 +115,7 @@ Click the button. The count changes. This screen shows the three habits of a
 [Views and reads](02-views-and-reads.md) and
 [Events as data](03-events-as-data.md) teach each habit in more depth.
 
-## What [`h/mount!`](glossary.md#mount) did
+## What `h/mount!` did
 
 > **One [`h/mount!`](glossary.md#mount) associates a DOM node, a frame, and initial events, and
 > returns an idempotent handle.**

--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -1,7 +1,7 @@
 # Getting started
 
 You already know re-frame2's pipeline: events write app-db, subscriptions
-derive values, and views paint the screen. This page puts a Hicasso view on
+derive values, and views paint the screen. This page puts a [Hicasso](glossary.md#hicasso) view on
 that screen. You install the artifact, mount a root, click a button, and
 build for production.
 
@@ -46,8 +46,8 @@ allow-list, no build flag. Any ordinary shadow-cljs browser build works:
 ```
 
 You require one namespace: `[re-frame.hicasso :as h]`. The usual alias is
-`h`. The optional modules (forms, overlays, motion, routing, the native tier,
-the test kit) are separate requires, and each has its own chapter. A build
+`h`. The optional modules (forms, [overlays](glossary.md#overlay), motion, routing, the [native tier](glossary.md#native-tier),
+the [test kit](glossary.md#test-kit)) are separate requires, and each has its own chapter. A build
 that never requires them carries none of their code.
 
 ## The app
@@ -97,14 +97,14 @@ npx shadow-cljs watch app    # then open http://localhost:8080
 ```
 
 Click the button. The count changes. This screen shows the three habits of a
-Hicasso view:
+[Hicasso](glossary.md#hicasso) view:
 
-- **`h/defview` mints a view, and a view is a Hiccup head.** You mount it as
+- **[`h/defview`](glossary.md#defview) mints a view, and a view is a Hiccup head.** You mount it as
   `[counter]`, which is a vector. You never call it as a function. A direct
   call refuses (see the first row of the
   [troubleshooting table](#troubleshooting)). Markup that should inline into
   its caller is a plain `defn` helper.
-- **`h/sub` reads at the point of use.** It is an ordinary call. It is legal
+- **[`h/sub`](glossary.md#hsub) reads at the point of use.** It is an ordinary call. It is legal
   in a `let`, a `when`, a loop, a helper — anywhere in the view's synchronous
   body.
 - **The click handler is data.** `{:on-click [:counter/increment]}` is an
@@ -115,12 +115,12 @@ Hicasso view:
 [Views and reads](02-views-and-reads.md) and
 [Events as data](03-events-as-data.md) teach each habit in more depth.
 
-## What `h/mount!` did
+## What [`h/mount!`](glossary.md#mount) did
 
-> **One `h/mount!` associates a DOM node, a frame, and initial events, and
+> **One [`h/mount!`](glossary.md#mount) associates a DOM node, a frame, and initial events, and
 > returns an idempotent handle.**
 
-`h/mount!` takes the DOM node, a config map, and one view. `:frame` names the
+[`h/mount!`](glossary.md#mount) takes the DOM node, a config map, and one view. `:frame` names the
 frame that the root ensures. The frame holds its own isolated app-db, queue,
 and subscription cache. Two roots with two frame ids are two isolated apps on
 one page. `:initial-events` runs ordinary events once, in order. They seed
@@ -138,14 +138,14 @@ The handle controls the rest of the root's life:
 (h/unmount! root)            ;; idempotent — a second call is a no-op
 ```
 
-After `h/unmount!`, the root unmounts, subscriptions release with ref-counts
+After [`h/unmount!`](glossary.md#mount), the root unmounts, subscriptions release with ref-counts
 at zero, and the DOM node is available to you again. Teardown paths run from
 `finally` blocks, fixtures, and reload hooks, and these paths do not
 coordinate. For that reason a second call is a no-op, not a crash.
 
 ## More than one root
 
-`h/mount!` composes. A page can hold several roots, and `:frame` decides
+[`h/mount!`](glossary.md#mount) composes. A page can hold several roots, and `:frame` decides
 whether they are one app or two apps.
 
 **Two roots, one frame — one app in two containers.** The root *ensures* its
@@ -180,14 +180,14 @@ state — an ordinary page. The independent second frame is a deliberate
 choice. Use one when two surfaces must not share state; share the frame when
 they must.
 
-Teardown stays per root in both cases. `h/unmount!` releases that root's
+Teardown stays per root in both cases. [`h/unmount!`](glossary.md#mount) releases that root's
 subscriptions and returns its DOM node. A frame that other roots still use
 keeps its state and continues to serve them.
 
 ## Hot reload
 
 Leave the watch running and edit the `:h1` text. On save, shadow-cljs reloads
-the namespace, and the `^:dev/after-load` hook calls `h/render!` with the
+the namespace, and the `^:dev/after-load` hook calls [`h/render!`](glossary.md#mount) with the
 redefined view. The root, the frame, and app-db survive, so the count keeps
 its value. The changed body is the body that runs, and no subscriptions leak.
 
@@ -212,17 +212,17 @@ alters what your views mean.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| Calling a view throws — `(counter {})` | The refusal fires at the call and names the view: you mount a `defview` as a Hiccup head; you never invoke it | Write `[counter {}]`. Markup that should inline into its caller is a plain `defn` helper |
-| `h/sub` in a callback, timeout, or promise throws, naming the query | `:rf.error/hicasso-sub-outside-render` — the read escaped the synchronous body that owned it | Read during the body and close over the value; async work reads app-db through events and coeffects |
+| Calling a view throws — `(counter {})` | The refusal fires at the call and names the view: you mount a [`defview`](glossary.md#defview) as a Hiccup head; you never invoke it | Write `[counter {}]`. Markup that should inline into its caller is a plain `defn` helper |
+| [`h/sub`](glossary.md#hsub) in a callback, timeout, or promise throws, naming the query | `:rf.error/hicasso-sub-outside-render` — the read escaped the synchronous body that owned it | Read during the body and close over the value; async work reads app-db through events and coeffects |
 | First paint is empty, then content flickers in | Seeding raced the first render | Seed through `:initial-events`, not a post-mount dispatch |
-| Second `h/mount!` on the same node | A live root already owns that DOM node | `defonce` the handle; `h/unmount!` it before mounting again |
+| Second [`h/mount!`](glossary.md#mount) on the same node | A live root already owns that DOM node | `defonce` the handle; [`h/unmount!`](glossary.md#mount) it before mounting again |
 | A second root's `:initial-events` never ran | Its `:frame` already existed — ensure joins a live frame and replays nothing | Seed from the root that creates the frame; joining roots omit `:initial-events` |
 | View body runs twice on mount in development | React StrictMode double-invokes bodies | Expected — bodies are pure and re-runnable |
 
 ## When not to use Hicasso
 
 The Reagent and UIx adapters are first-class, and to stay on one is a good
-answer. Pick Hicasso for markup as data, reads at the point of use, and event
+answer. Pick [Hicasso](glossary.md#hicasso) for markup as data, reads at the point of use, and event
 vectors that a test asserts with `=` — not because the adapters are second
 tier. If you want React-first authoring, with hooks everywhere and a React
 design system at the centre of the app, UIx fits better. Hicasso meets

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -5,8 +5,8 @@ where you use them, are the same problem twice. Either you hoist a value high
 in the tree and re-render many sibling views, or you invent a second way to
 read so that a helper can see the current filter.
 
-Hicasso's answer has two parts. A view is a function from a props map to
-hiccup. There is **one** way to read — `h/sub`, an ordinary function call at
+[Hicasso](glossary.md#hicasso)'s answer has two parts. A view is a function from a props map to
+hiccup. There is **one** way to read — [`h/sub`](glossary.md#hsub), an ordinary function call at
 the point of use:
 
 ```clojure
@@ -24,14 +24,14 @@ the point of use:
                 :on-input [:todo.ui/edit id ::h/value]}])]))
 ```
 
-> **Read where you use.** `h/sub` is legal anywhere in the body — inside a
+> **Read where you use.** [`h/sub`](glossary.md#hsub) is legal anywhere in the body — inside a
 > `let`, a `when`, a `for`, an ordinary helper call.
 
-`h/sub` is the only read form. There is no second spelling for helpers. A
+[`h/sub`](glossary.md#hsub) is the only read form. There is no second spelling for helpers. A
 bare `rf/subscribe` in a body is not a fallback: it refuses instead of
-resolving, and it names the read that went around the collector — the
-runtime mechanism that records each boundary's reads. (The event vectors in
-those attributes — *intents* — and `::h/value` belong to
+resolving, and it names the read that went around the [collector](glossary.md#collector) — the
+runtime mechanism that records each [boundary](glossary.md#boundary)'s reads. (The event vectors in
+those attributes — *[intents](glossary.md#intent)* — and [`::h/value`](glossary.md#hvalue) belong to
 [Events as data](03-events-as-data.md).)
 
 ## Boundaries and inlining
@@ -44,20 +44,20 @@ difference is visible in the syntax:
 (row-icon {:kind :urgent})    ;; a call to a plain defn — INLINED into this boundary
 ```
 
-A **view in head position** mints a **boundary** — Hicasso's unit of
-independent re-rendering, and the thing `h/defview` exists to make. A
+A **view in head position** mints a **[boundary](glossary.md#boundary)** — [Hicasso](glossary.md#hicasso)'s unit of
+independent re-rendering, and the thing [`h/defview`](glossary.md#defview) exists to make. A
 boundary owns four things:
 
 - React's identity for the boundary.
-- The `h/sub` reads that its body makes.
+- The [`h/sub`](glossary.md#hsub) reads that its body makes.
 - Its value-equality bail-out.
-- The frame to which the intents in its hiccup dispatch.
+- The frame to which the [intents](glossary.md#intent) in its hiccup dispatch.
 
-Native tags, fragments, and `h/defhost` heads also sit in vector position.
+Native tags, fragments, and [`h/defhost`](glossary.md#defhost) heads also sit in vector position.
 None of them is a boundary.
 
 A **plain `defn` call** is only a function call, and it owns none of the
-four. The runtime splices its hiccup into the caller's tree. Any `h/sub`
+four. The runtime splices its hiccup into the caller's tree. Any [`h/sub`](glossary.md#hsub)
 that the helper performs gives that read *upward* to the enclosing boundary.
 Helpers cost nothing at runtime, and they add no re-render granularity.
 Because reads are ordinary calls, **helpers can read**: a `filter-button`
@@ -74,8 +74,8 @@ The two spellings do not cross, and both crossings fail with a named error:
 (todo-row {:id 7})           ;; refuses at the call, naming the view; write [todo-row {:id 7}]
 ```
 
-Re-render granularity should be visible in the source. A boundary is always
-a vector, and an inline helper is always a call. A `defview` never degrades
+Re-render granularity should be visible in the source. A [boundary](glossary.md#boundary) is always
+a vector, and an [inline helper](glossary.md#inline-helper) is always a call. A [`defview`](glossary.md#defview) never degrades
 into an inline function because you invoked it differently.
 
 ## Keys go in the props map
@@ -88,7 +88,7 @@ into an inline function because you invoked it differently.
 ```
 
 A seq of children needs keys, whatever the head is. The key lives **in the
-props map**. Hicasso does not read `^{:key id}` metadata here (the most
+props map**. [Hicasso](glossary.md#hicasso) does not read `^{:key id}` metadata here (the most
 common Reagent carry-over), and no `for`-lowering invents a key for you. If
 you miss a key, development warns with `:rf.warning/hicasso-missing-key` and
 names the view and the child. That is all this page teaches about keys. What
@@ -96,14 +96,14 @@ makes a key *good* (a stable domain identity, never an index, never the
 whole entity) is the law of
 [Lists and collections](06-lists-and-collections.md).
 
-## The component ABI
+## The [component ABI](glossary.md#component-abi)
 
 | Head | Props | Children | `:key` | `:ref` |
 |---|---|---|---|---|
 | Native tag — `[:div …]` | attribute map | trailing forms | in the attribute map | callback ref, legal |
-| Hicasso view — `[todo-row …]` | one props map | trailing forms, arriving as `(:children props)` | in the props map, **extracted before your body sees props** | not a view surface — use ids |
+| [Hicasso](glossary.md#hicasso) view — `[todo-row …]` | one props map | trailing forms, arriving as `(:children props)` | in the props map, **extracted before your body sees props** | not a view surface — use ids |
 | Fragment — `[:<> …]` | — | trailing forms | on the fragment's props map | — |
-| Foreign — `h/defhost` and `[:>]` | converted per declaration | hiccup children become elements | in props | callback ref, legal |
+| Foreign — [`h/defhost`](glossary.md#defhost) and `[:>]` | converted per declaration | hiccup children become elements | in props | callback ref, legal |
 
 Children arrive realized and flattened in a predictable way. The runtime
 realizes nested and lazy sequences once and flattens them one level. `nil`
@@ -142,8 +142,8 @@ mutation of a captured atom, the start of a fetch, a render counter.
 
 ## Boundaries memoize by default
 
-Every head that `h/defview` mints carries one stable memo wrapper. The
-wrapper compares the whole props map with CLJS `=`. If a boundary's props
+Every head that [`h/defview`](glossary.md#defview) mints carries one stable memo wrapper. The
+wrapper compares the whole props map with CLJS `=`. If a [boundary](glossary.md#boundary)'s props
 compare equal to the last render, its body does not run, even when its
 parent's body ran. There is no mode flag and no public opt-out. A boundary
 that must re-run with its parent takes a prop that changes.
@@ -202,12 +202,12 @@ Five rules cover the conversions.
 - **`:key` is not an attribute.** The runtime reads it off the map and never
   emits it as a prop.
 
-The reserved-data vocabulary is deliberately small: `::h/value`,
-`::h/checked`, `::h/prevent`, and `::h/revision`. The chapter that owns each
+The reserved-data vocabulary is deliberately small: [`::h/value`](glossary.md#hvalue),
+[`::h/checked`](glossary.md#hchecked), [`::h/prevent`](glossary.md#hprevent), and [`::h/revision`](glossary.md#hrevision). The chapter that owns each
 word teaches it ([events](03-events-as-data.md),
 [controlled inputs](04-controlled-inputs.md)).
 
-## Forwarding attributes: owned wins
+## Forwarding attributes: [owned wins](glossary.md#owned-wins)
 
 A reusable field takes caller attributes and still owns its control keys.
 The merge is a pure recipe — a plain `merge`, with the attributes that you
@@ -232,16 +232,16 @@ One risk: `merge` works by key, so forward maps spelled the way you write
 attributes — kebab keywords — not a foreign props object's `"className"`
 strings.
 
-The case that makes this law necessary is a controlled input: a forwarded
+The case that makes this law necessary is a [controlled input](glossary.md#controlled-field): a forwarded
 map must never supply the value, checked, handler, key, or revision slots.
 [Controlled inputs](04-controlled-inputs.md) teaches that case in full.
 
-## The read-extent law
+## The [read-extent law](glossary.md#read-extent-law)
 
-`h/sub` is legal during the **direct synchronous execution** of the active
+[`h/sub`](glossary.md#hsub) is legal during the **direct synchronous execution** of the active
 body. Branches, loops, and ordinary helpers are included. Reads inside a
 lazy `for` count as direct: the same pass that turns hiccup into elements
-forces them, so they land in the boundary that is rendering.
+forces them, so they land in the [boundary](glossary.md#boundary) that is rendering.
 
 A read **deferred past the render** refuses, with source and recovery. It
 does not go silently stale. A callback, a promise, a timer, a stashed lazy
@@ -249,7 +249,7 @@ seq, a `delay` forced later — each raises
 `:rf.error/hicasso-sub-outside-render` and names the query. The runtime
 refuses an unforced `delay` that crosses into a boundary's props at the
 crossing (`:rf.error/hicasso-deferred-read-at-boundary`), before it can
-freeze a child. Hicasso never guesses which render owns a deferred read. The
+freeze a child. [Hicasso](glossary.md#hicasso) never guesses which render owns a deferred read. The
 alternative is a value that looks correct on screen and never updates again,
 with no error to point to.
 
@@ -271,11 +271,11 @@ that needs current state declares that state as a coeffect with
 not a side effect in a body. There is no `@`-anywhere form and no second
 read form for free-standing code.
 
-## How `h/sub` tracks reads
+## How [`h/sub`](glossary.md#hsub) tracks reads
 
 There are four operational claims:
 
-1. Each boundary opens one collection window for the duration of its body.
+1. Each [boundary](glossary.md#boundary) opens one collection window for the duration of its body.
    The commit installs **exactly** the edge set that the body made. A branch
    not taken contributes no edge.
 2. Framework subscriptions — machine tags, resource status, route identity —
@@ -296,8 +296,8 @@ There are four operational claims:
 | Symptom | Error | Fix |
 |---|---|---|
 | A read after the render throws, naming the query | `:rf.error/hicasso-sub-outside-render` | Read during the render; close over the value. Handlers declare state with `:rf.cofx/requires` |
-| An unforced `delay` in props refuses at the boundary | `:rf.error/hicasso-deferred-read-at-boundary` | Hand a function, or force the delay in your own body |
-| A plain `defn` in head position throws | `:rf.error/hicasso-bad-head` | Call it — `(row-icon …)` — or mint it with `h/defview` |
+| An unforced `delay` in props refuses at the [boundary](glossary.md#boundary) | `:rf.error/hicasso-deferred-read-at-boundary` | Hand a function, or force the delay in your own body |
+| A plain `defn` in head position throws | `:rf.error/hicasso-bad-head` | Call it — `(row-icon …)` — or mint it with [`h/defview`](glossary.md#defview) |
 | Calling a view directly throws, naming the view | refusal at the call site | Write the head: `[todo-row {:id 7}]` |
 | Console warns about a missing key, naming view and child | `:rf.warning/hicasso-missing-key` | Put `:key` in each member's props map; `^{:key}` metadata is not read ([Lists and collections](06-lists-and-collections.md) owns key quality) |
 | First render throws naming a query id | `:rf.error/no-such-sub` | Registration happens on namespace load; require the subs namespace at boot |
@@ -310,24 +310,24 @@ There are four operational claims:
 
 Not every function needs to be a view. If markup has no reads of its own and
 always re-renders with its parent, a plain function is cheaper and simpler.
-Mint a boundary when you want a part of the tree to update independently,
+Mint a [boundary](glossary.md#boundary) when you want a part of the tree to update independently,
 not because the markup became long. When a measured hot region outgrows
 boundary tuning — the ~2% case, not the default 98% — the escape ladder in
 [Performance](18-performance.md) owns the next step.
 
 ## Advanced
 
-### The collector
+### The [collector](glossary.md#collector)
 
 The mechanism behind the four operational claims is one fixed runtime hook
-per boundary. The hook opens a collection window for the duration of the
+per [boundary](glossary.md#boundary). The hook opens a collection window for the duration of the
 body. The claims imply two more facts. First, abandoned renders install
 nothing: the render probes reads, and the commit owns them, so a render that
 React retries or discards leaves no subscriptions behind. Second, reads
 inside lazy seqs land correctly, because the hiccup-to-element pass forces
 them while the window is open, not later when other code walks the seq.
 
-An escaped read fails loudly by design. A closed-over `h/sub` call site
+An escaped read fails loudly by design. A closed-over [`h/sub`](glossary.md#hsub) call site
 (rather than its value), a stashed unforced seq, or a `delay` forced after
 the render — each fails and names the query, because the collector can no
 longer say which boundary owns the read.

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -96,7 +96,7 @@ makes a key *good* (a stable domain identity, never an index, never the
 whole entity) is the law of
 [Lists and collections](06-lists-and-collections.md).
 
-## The [component ABI](glossary.md#component-abi)
+## The component ABI
 
 | Head | Props | Children | `:key` | `:ref` |
 |---|---|---|---|---|
@@ -207,7 +207,7 @@ The reserved-data vocabulary is deliberately small: [`::h/value`](glossary.md#hv
 word teaches it ([events](03-events-as-data.md),
 [controlled inputs](04-controlled-inputs.md)).
 
-## Forwarding attributes: [owned wins](glossary.md#owned-wins)
+## Forwarding attributes: owned wins
 
 A reusable field takes caller attributes and still owns its control keys.
 The merge is a pure recipe — a plain `merge`, with the attributes that you
@@ -236,7 +236,7 @@ The case that makes this law necessary is a [controlled input](glossary.md#contr
 map must never supply the value, checked, handler, key, or revision slots.
 [Controlled inputs](04-controlled-inputs.md) teaches that case in full.
 
-## The [read-extent law](glossary.md#read-extent-law)
+## The read-extent law
 
 [`h/sub`](glossary.md#hsub) is legal during the **direct synchronous execution** of the active
 body. Branches, loops, and ordinary helpers are included. Reads inside a
@@ -271,7 +271,7 @@ that needs current state declares that state as a coeffect with
 not a side effect in a body. There is no `@`-anywhere form and no second
 read form for free-standing code.
 
-## How [`h/sub`](glossary.md#hsub) tracks reads
+## How `h/sub` tracks reads
 
 There are four operational claims:
 
@@ -317,7 +317,7 @@ boundary tuning — the ~2% case, not the default 98% — the escape ladder in
 
 ## Advanced
 
-### The [collector](glossary.md#collector)
+### The collector
 
 The mechanism behind the four operational claims is one fixed runtime hook
 per [boundary](glossary.md#boundary). The hook opens a collection window for the duration of the

--- a/docs/design/hicasso/draft-guide/03-events-as-data.md
+++ b/docs/design/hicasso/draft-guide/03-events-as-data.md
@@ -14,20 +14,20 @@ stops being inspectable, comparable, or assertable by equality.
 This is not syntactic sugar for a closure that you could write yourself. The
 tree still holds data at that node, so a test asserts the node with `=`, and
 a tool reads it off the tree. When the user clicks the button, the runtime
-dispatches the vector to the frame of the rendering boundary. The runtime
+dispatches the vector to the frame of the rendering [boundary](glossary.md#boundary). The runtime
 built that callback at render, and the callback carries the frame with it.
 
 Lowering — the step that turns an attribute into a React prop — works by
 shape, not by a roster. Any prop whose name is `on-` plus a letter is an
 event position. CamelCase `onClick` also works, for the migrating author.
 There is no list of approved event names to keep in step with the DOM. An
-event vector at an event position is an **intent**: the meaning of the
+event vector at an event position is an **[intent](glossary.md#intent)**: the meaning of the
 interaction, stated as data. That is the word this guide uses for it.
 
 ## The value vocabulary
 
 Most handlers need a value out of the event. The runtime substitutes two
-reserved words, `::h/value` and `::h/checked`, at dispatch time with the
+reserved words, [`::h/value`](glossary.md#hvalue) and [`::h/checked`](glossary.md#hchecked), at dispatch time with the
 event target's `.value` and `.checked`:
 
 ```clojure
@@ -41,11 +41,11 @@ event target's `.value` and `.checked`:
 
 At dispatch, the handler receives `[:todo.ui/edit 7 "milk"]` or
 `[:todo/set-done 7 true]`. These are ordinary event vectors, the same as
-vectors that you dispatch by hand. Substitution happens at the intent
+vectors that you dispatch by hand. Substitution happens at the [intent](glossary.md#intent)
 vector's top level only. The runtime does not look for a marker in nested
 structure. An intent that carries no marker never reads its event.
 
-These two words, plus `::h/prevent` below and `::h/revision`
+These two words, plus [`::h/prevent`](glossary.md#hprevent) below and [`::h/revision`](glossary.md#hrevision)
 ([Controlled inputs](04-controlled-inputs.md)), are the entire reserved
 vocabulary. For the full controlled round-trip — value in from a
 subscription, intent out, caret and same-turn echo — see
@@ -54,7 +54,7 @@ subscription, intent out, caret and same-turn echo — see
 ## Prevention is explicit — one head
 
 Nothing auto-prevents — not a click, and not a form submit. Prevention is a
-decision. The decision travels **as data**, in the intent itself:
+decision. The decision travels **as data**, in the [intent](glossary.md#intent) itself:
 
 ```clojure
 [:form {:on-submit [::h/prevent [:signup/submit]]}
@@ -64,7 +64,7 @@ decision. The decision travels **as data**, in the intent itself:
 ```
 
 `[::h/prevent INTENT]` prevents the browser default and dispatches the inner
-intent. The same head serves an anchor that acts as a button — the feed tab,
+[intent](glossary.md#intent). The same head serves an anchor that acts as a button — the feed tab,
 the tag pill. An unconditional default *cannot* exist there, because a
 modifier-click on a real link must still open a tab:
 
@@ -73,10 +73,10 @@ modifier-click on a real link must still open a tab:
  "Your Feed"]
 ```
 
-!!! warning "A bare intent at `:on-submit` still submits"
+!!! warning "A bare [intent](glossary.md#intent) at `:on-submit` still submits"
     `{:on-submit [:signup/submit]}` dispatches your intent **and** lets the
     browser navigate. There is no submit special case. If the page reloads
-    on submit, the `::h/prevent` head is missing. The rare form that wants a
+    on submit, the [`::h/prevent`](glossary.md#hprevent) head is missing. The rare form that wants a
     real browser submission omits the head.
 
 The grammar is closed: exactly one inner intent vector, and that vector is
@@ -92,11 +92,11 @@ The prevent form is a head, not metadata on the vector, for one reason:
 to a structural test that compares the tree, to `pr-str`, and to any code
 that hashes the intent. A head is visible to all three.
 
-## `h/event`: value-first and calculated events
+## [`h/event`](glossary.md#hevent): value-first and calculated events
 
 Sometimes you must read the callback's arguments before you know what to
 dispatch. Examples: a file list, a drag payload, a foreign component that
-calls `(on-change date)` with no DOM event. `h/event` is the one explicit
+calls `(on-change date)` with no DOM event. [`h/event`](glossary.md#hevent) is the one explicit
 event-producing form:
 
 ```clojure
@@ -108,7 +108,7 @@ event-producing form:
 Its contract has three clauses, and they hold in **every** position:
 
 - It **captures the frame at the place where you write it**. Inside a view
-  body, that is the rendering boundary's frame.
+  body, that is the rendering [boundary](glossary.md#boundary)'s frame.
 - When the invoker calls it later, it receives **every argument that the
   invoker passes, in order**: one DOM event at a native position,
   `(date event)` from a value-first library — whatever the caller's contract
@@ -123,21 +123,21 @@ Its contract has three clauses, and they hold in **every** position:
                     [:upload/dropped (.-name f)]))}]
 ```
 
-The meaning never varies by position. An `h/event` given to a `h/defhost`
+The meaning never varies by position. An [`h/event`](glossary.md#hevent) given to a [`h/defhost`](glossary.md#defhost)
 callback, retained by a vendor SDK, or placed in a raw `#js` prop does the
 same thing: it runs, it can return a vector, and the runtime dispatches that
-vector to the frame it captured. Prevention inside an `h/event` is your
+vector to the frame it captured. Prevention inside an [`h/event`](glossary.md#hevent) is your
 task: the function holds the event, so it calls `.preventDefault` itself, as
 the drop example does.
 
-**The vector spelling is event-first; `h/event` is not.** `::h/value`,
-`::h/checked`, and `::h/prevent` all read the DOM event, and they read it
+**The vector spelling is event-first; [`h/event`](glossary.md#hevent) is not.** [`::h/value`](glossary.md#hvalue),
+[`::h/checked`](glossary.md#hchecked), and [`::h/prevent`](glossary.md#hprevent) all read the DOM event, and they read it
 from argument one. Every native position and every event-first foreign
 contract puts the event there. A value-first invoker, such as a date
 picker's `(on-change date)`, has no event at argument one. Nothing guesses
-which argument might be an event. The intent refuses with
+which argument might be an event. The [intent](glossary.md#intent) refuses with
 `:rf.error/hicasso-intent-needs-the-event`. The error names the position and
-points to `h/event`, the spelling that sees the library's own arguments in
+points to [`h/event`](glossary.md#hevent), the spelling that sees the library's own arguments in
 order:
 
 ```clojure
@@ -153,7 +153,7 @@ callback semantics: it runs, and the runtime ignores its return value:
 [:canvas {:on-pointer-move (fn [e] (draw! (.-clientX e) (.-clientY e)))}]
 ```
 
-Use an ordinary `fn` when the *work* is imperative and no intent exists:
+Use an ordinary `fn` when the *work* is imperative and no [intent](glossary.md#intent) exists:
 geometry, pointer capture, `stopPropagation`, an SDK's imperative call.
 Render props and slots on foreign components also take ordinary functions.
 They run during a foreign render, so they stay pure. A dispatch from inside
@@ -174,12 +174,12 @@ An ordinary `fn` must not dispatch on its own:
 [:button {:on-click [:todo/toggle id]} "✓"]
 ```
 
-The intent vector and `h/event` exist so that the runtime answers the frame
+The [intent](glossary.md#intent) vector and [`h/event`](glossary.md#hevent) exist so that the runtime answers the frame
 question at render, once.
 
 ## Keyboard as data
 
-Keyboard handling is a map from key name to intent, not a `case` over
+Keyboard handling is a map from key name to [intent](glossary.md#intent), not a `case` over
 `.-key`:
 
 ```clojure
@@ -191,9 +191,9 @@ Keyboard handling is a map from key name to intent, not a `case` over
 
 The names are strings. The runtime matches them against the DOM event's own
 `.key`, and it ignores keys that you do not list. There is no modifier
-language: a handler that needs `ctrl+Enter` reads the event with `h/event`.
+language: a handler that needs `ctrl+Enter` reads the event with [`h/event`](glossary.md#hevent).
 Key maps are legal at **keyboard props only** (`:on-key-down`,
-`:on-key-up`). A map is not an intent spelling anywhere else.
+`:on-key-up`). A map is not an [intent](glossary.md#intent) spelling anywhere else.
 
 The composition rule is explicit, and the runtime owns it. An IME (input
 method editor) composes text such as Japanese or Chinese from several
@@ -206,8 +206,8 @@ that some browsers still send (see [Advanced](#advanced)).
 
 ## Callbacks carry their frame
 
-Every generated callback closes over its boundary's frame. Intent vectors
-capture the frame at lowering; `h/event` captures it at creation. This
+Every generated callback closes over its [boundary](glossary.md#boundary)'s frame. Intent vectors
+capture the frame at [lowering](glossary.md#lowering); [`h/event`](glossary.md#hevent) captures it at creation. This
 matters because the browser invokes callbacks long after the render that
 created them, when the render's extent is gone. A hand-written
 `#(rf/dispatch …)` raises `:rf.error/no-frame-context` from that gap. The
@@ -238,7 +238,7 @@ else. Capture it there with core's one carry primitive:
                (sdk/on-select node #(dispatch [:map/marker-selected id %]))))}]))
 ```
 
-Inside a Hicasso body, `(rf/capture-frame)` resolves the boundary's frame.
+Inside a [Hicasso](glossary.md#hicasso) body, `(rf/capture-frame)` resolves the [boundary](glossary.md#boundary)'s frame.
 It returns `{:frame :dispatch :dispatch-sync :subscribe}` locked to that
 frame. `(rf/current-frame-id)` returns the bare id when a foreign API wants
 one. These are core's frame doors; Hicasso adds no duplicate. (Ambient
@@ -249,21 +249,21 @@ id, an operation from the stale handle refuses with
 `:rf.error/frame-destroyed` and does not reach the successor frame. Capture
 from the live render, never from a stash.
 
-The general rule: **intents are always safe; async work goes through `:fx`;
+The general rule: **[intents](glossary.md#intent) are always safe; async work goes through `:fx`;
 a closure that crosses into foreign code carries `(rf/capture-frame)`.**
 
 One nearby case is not this chapter's case. An anchor that *navigates* is a
-route link from `re-frame.hicasso.routing`, not a hand-written `:on-click`.
+[route link](glossary.md#route-link) from `re-frame.hicasso.routing`, not a hand-written `:on-click`.
 [Routing and navigation](07-routing-and-navigation.md) owns it.
 
 ## Troubleshooting
 
 | Symptom | Error | Fix |
 |---|---|---|
-| Page navigates and reloads on form submit | none — nothing auto-prevents | Wrap the intent: `{:on-submit [::h/prevent [:signup/submit]]}` |
+| Page navigates and reloads on form submit | none — nothing auto-prevents | Wrap the [intent](glossary.md#intent): `{:on-submit [::h/prevent [:signup/submit]]}` |
 | Refusal at render naming an event attribute | `:rf.error/hicasso-malformed-prevent` | `[::h/prevent INTENT]` wraps exactly one inner intent vector — no second payload, no nesting |
-| Handler receives the literal `::h/value` keyword | none — marker below top level | Markers substitute at the vector's top level only; compute nested payloads in the handler, or read the event with `h/event` |
-| A foreign callback refuses a marker-carrying intent | `:rf.error/hicasso-intent-needs-the-event` | The invoker is value-first — no DOM event at argument one. Use `h/event`, which receives every argument in order |
+| Handler receives the literal [`::h/value`](glossary.md#hvalue) keyword | none — marker below top level | Markers substitute at the vector's top level only; compute nested payloads in the handler, or read the event with [`h/event`](glossary.md#hevent) |
+| A foreign callback refuses a marker-carrying intent | `:rf.error/hicasso-intent-needs-the-event` | The invoker is value-first — no DOM event at argument one. Use [`h/event`](glossary.md#hevent), which receives every argument in order |
 | Dispatch from a timeout or interval throws | `:rf.error/no-frame-context` | Own the async work in an fx handler (`:dispatch-later`); a closure handed to foreign code carries `(rf/capture-frame)` from the body |
 | Enter commits half-typed Japanese text | none — hand-rolled key handling | Use the `:on-key-down` map; composition is centralised there |
 | An intent fires but no handler runs | `:rf.error/no-such-handler` | Registration happens on namespace load; require the handlers namespace at boot |
@@ -272,10 +272,10 @@ route link from `re-frame.hicasso.routing`, not a hand-written `:on-click`.
 
 ## When not to use an intent
 
-Do not use an intent when you need the event object itself and no dispatch:
+Do not use an [intent](glossary.md#intent) when you need the event object itself and no dispatch:
 pointer coordinates, `dataTransfer`, `stopPropagation`, a DOM measurement.
 Those cases take ordinary functions, and an ordinary function is not a
-failure. Use `h/event` when you want to read the arguments *and* dispatch.
+failure. Use [`h/event`](glossary.md#hevent) when you want to read the arguments *and* dispatch.
 Use a plain `fn` when you want to read the arguments and do other work.
 
 ## Advanced

--- a/docs/design/hicasso/draft-guide/03-events-as-data.md
+++ b/docs/design/hicasso/draft-guide/03-events-as-data.md
@@ -92,7 +92,7 @@ The prevent form is a head, not metadata on the vector, for one reason:
 to a structural test that compares the tree, to `pr-str`, and to any code
 that hashes the intent. A head is visible to all three.
 
-## [`h/event`](glossary.md#hevent): value-first and calculated events
+## `h/event`: value-first and calculated events
 
 Sometimes you must read the callback's arguments before you know what to
 dispatch. Examples: a file list, a drag payload, a foreign component that

--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -1,7 +1,7 @@
 # Controlled inputs
 
 A controlled text field keeps its value in app-db. The value comes in from a
-subscription, and an intent goes out on every keystroke. That is the whole
+subscription, and an [intent](glossary.md#intent) goes out on every keystroke. That is the whole
 required path.
 
 ```clojure
@@ -68,8 +68,8 @@ element commits. Events that land after unmount find nothing. A blur
 delivered to a field that has just left the tree is a no-op, with zero
 residue.
 
-Every keystroke on a controlled field is a full pipeline run: state write,
-subscription recomputation, boundary run, React commit, painted echo. The
+Every keystroke on a [controlled field](glossary.md#controlled-field) is a full pipeline run: state write,
+subscription recomputation, [boundary](glossary.md#boundary) run, React commit, painted echo. The
 [performance chapter](18-performance.md) publishes that path, with counts for
 the four-field editor and the controlled grid. This page owns the law; that
 page owns the cost.
@@ -89,13 +89,13 @@ platform gives you a value:
 
 | Control | Value in | Intent out |
 |---|---|---|
-| `:input` (text, email, password, search, url, tel) | `:value` | `:on-input` with `::h/value` |
-| `:textarea` | `:value` | `:on-input` with `::h/value` |
-| `:input` number, date, time, range | `:value` | `:on-input` with `::h/value` — the DOM hands you strings; parse in the handler |
-| `:input` checkbox | `:checked` | `:on-change` with `::h/checked` |
+| `:input` (text, email, password, search, url, tel) | `:value` | `:on-input` with [`::h/value`](glossary.md#hvalue) |
+| `:textarea` | `:value` | `:on-input` with [`::h/value`](glossary.md#hvalue) |
+| `:input` number, date, time, range | `:value` | `:on-input` with [`::h/value`](glossary.md#hvalue) — the DOM hands you strings; parse in the handler |
+| `:input` checkbox | `:checked` | `:on-change` with [`::h/checked`](glossary.md#hchecked) |
 | `:input` radio | `:checked` per option | `:on-change` carrying the option's own value literally |
-| `:select` | `:value` on the select | `:on-change` with `::h/value` |
-| `:input` file | none — the platform owns a file input's value | `:on-change` with `h/event`, reading `.files` off the event |
+| `:select` | `:value` on the select | `:on-change` with [`::h/value`](glossary.md#hvalue) |
+| `:input` file | none — the platform owns a file input's value | `:on-change` with [`h/event`](glossary.md#hevent), reading `.files` off the event |
 
 ```clojure
 [:select {:value     (h/sub [:cart/shipping])
@@ -138,21 +138,21 @@ where a key lands, not on its spelling. A forwarded `:onInput` against your
 matters. A forwarded map can never replace the owned value, checked, handler,
 key, or revision slots of a control. When you *want* a caller's value to win,
 do not write your literal. Put the element's own classes on the tag
-(`[:input.form-control …]`). Never forward `:key` or `::h/revision`: these
+(`[:input.form-control …]`). Never forward `:key` or [`::h/revision`](glossary.md#hrevision): these
 keys address the element *you* wrote, and the runtime reads them only from
 the map you wrote.
 
 ## Resets are by revision, never by value
 
 To force a field back to a value — a form reset, a revert, a
-server-normalized write that comes back — is a real intent, and it has its
+server-normalized write that comes back — is a real [intent](glossary.md#intent), and it has its
 own door: an **explicit revision** from the caller. The runtime never infers
 a reset from a comparison of the incoming value with a target. With a
 value-equality reset, a user who types the "reset" value loses the edit in
 progress. Also, a same-value reassertion (the caller rejects a draft and
 restores the old value) becomes invisible.
 
-`::h/revision` is that one door. The view reads it like any other value,
+[`::h/revision`](glossary.md#hrevision) is that one door. The view reads it like any other value,
 beside `:value`:
 
 ```clojure
@@ -202,7 +202,7 @@ map, so a caller cannot force a re-baseline on a field whose author did not
 write one. The prop never reaches the DOM as an attribute, on the client or
 on the server.
 
-This is the single prop and nothing more: no commit or cancel intents, no
+This is the single prop and nothing more: no commit or cancel [intents](glossary.md#intent), no
 acknowledgement that a reset landed, no caret-policy options. When you want
 draft-and-commit behavior — free edits, commit on Enter or blur, cancel on
 Escape — use the [forms module](05-forms.md). The module *consumes* this
@@ -214,13 +214,13 @@ trigger; it does not extend it.
 |---|---|---|
 | Characters drop when typing fast | Something async sat between keystroke and commit — debounce, `setTimeout`, a queued effect | Keep the controlled write synchronous; debounce *consumers* of the value, not the write itself |
 | Caret jumps to the end on every keystroke | Value reasserted without caret preservation | Runtime bug, not your view — report it |
-| Enter commits half-typed text mid-composition | A hand-written key handler bypassed the intent path | Use the data key map ([Events as data](03-events-as-data.md)); the composition check lives there |
+| Enter commits half-typed text mid-composition | A hand-written key handler bypassed the [intent](glossary.md#intent) path | Use the data key map ([Events as data](03-events-as-data.md)); the composition check lives there |
 | Composition dies when the model refuses mid-draft | On the controlled path this cannot happen — composition is left alone until it ends. Something else wrote the field: a ref, a foreign script, an uncontrolled sibling | Find the second writer; the controlled element must have one |
 | An IME commit lands stale text, then corrects itself | Something async sat between keystroke and commit, so the composition's close reconciled against a model the deferred write had not reached | Keep the controlled write synchronous; the composition survives either way — only what it commits is late |
-| Typing the "reset" value clears the field | A reset keyed on value equality somewhere in your code | Move `::h/revision`; a value comparison is not a reset |
+| Typing the "reset" value clears the field | A reset keyed on value equality somewhere in your code | Move [`::h/revision`](glossary.md#hrevision); a value comparison is not a reset |
 | The field resets on every render | A revision minted in render — `random-uuid`, a render-order index, a counter the body increments | Read a revision your *events* wrote into app-db |
-| The field never resets, and devtools shows a `revision="…"` attribute | A bare `:revision`. The match is the exact namespaced keyword. Every other spelling flows through as an ordinary attribute, silently. A namespaced value loses its namespace on the way, so two distinct revisions can collapse to one | Write `::h/revision` |
-| `:rf.error/hicasso-revision-not-controlled` at render | `::h/revision` on something that is not controlled text — a `:div`, a `:select`, a value-less checkbox | Put the revision on the controlled `input`/`textarea` whose draft it re-baselines; a select or checkbox resets by writing the model |
+| The field never resets, and devtools shows a `revision="…"` attribute | A bare `:revision`. The match is the exact namespaced keyword. Every other spelling flows through as an ordinary attribute, silently. A namespaced value loses its namespace on the way, so two distinct revisions can collapse to one | Write [`::h/revision`](glossary.md#hrevision) |
+| `:rf.error/hicasso-revision-not-controlled` at render | [`::h/revision`](glossary.md#hrevision) on something that is not controlled text — a `:div`, a `:select`, a value-less checkbox | Put the revision on the controlled `input`/`textarea` whose draft it re-baselines; a select or checkbox resets by writing the model |
 | Focus lost after validation fails | Something remounted the node | Never remount to reset — that is exactly what destroys focus |
 
 ## When not to control an input
@@ -233,7 +233,7 @@ If the user's edit must be a *draft* — commit on Enter or blur, revert on
 Escape, reject without loss of the field — do not build that yourself on top
 of this page. That is the [forms module](05-forms.md).
 
-If no other code needs the intermediate values — a scratch field in a modal,
+If no other code needs the intermediate values — a scratch field in a [modal](glossary.md#overlay),
 a filter box that only feeds a debounced query — leave the input uncontrolled
 (`:default-value` to seed it, no `:value`) and commit on blur. DOM-owned
 state is a legitimate explicit choice. The cost is this: app-db, tests, and
@@ -255,7 +255,7 @@ turn — including when the model rejected or normalized the keystroke. That
 path runs once per keystroke, on controlled text entry only (an `input` that
 has a caret, or a `textarea`, with a non-nil `:value`). It also runs once at
 the close of an IME composition. Everywhere else it is inert, and a page with
-no controlled input pays nothing for it. If your own code needs `flushSync`
+no [controlled input](glossary.md#controlled-field) pays nothing for it. If your own code needs `flushSync`
 for anything else, that is a design problem, not a feature.
 
 ### Rejection and React's restore

--- a/docs/design/hicasso/draft-guide/05-forms.md
+++ b/docs/design/hicasso/draft-guide/05-forms.md
@@ -1,6 +1,6 @@
 # Forms
 
-A bare controlled field ([Controlled inputs](04-controlled-inputs.md)) binds
+A bare [controlled field](glossary.md#controlled-field) ([Controlled inputs](04-controlled-inputs.md)) binds
 directly to app-db, and that is all. Real forms need three more things:
 
 - fields that buffer a *draft* — commit on Enter or blur, revert on Escape,
@@ -23,7 +23,7 @@ guarantees the failure.
 | Trap | The hand-rolled shape | Here |
 |---|---|---|
 | Twin-atom stack | An "external" and an "internal" atom per field, synced by render-phase resets | A draft is addressed app-db state with one owner; there is nothing to sync |
-| Same-value blindness | Rejecting a draft by reasserting the equal model value — invisible to `not=`, so the rejected text stays on screen | The reset signal is `::h/revision`, distinct from the value by design |
+| Same-value blindness | Rejecting a draft by reasserting the equal model value — invisible to `not=`, so the rejected text stays on screen | The reset signal is [`::h/revision`](glossary.md#hrevision), distinct from the value by design |
 | Commit flicker | A forced reset on every commit misfires "changed"; async acceptance flickers between stale and new | A commit is decided against committed state at event time; acceptance is your event, and a stale commit no-ops |
 | Arity-sniffed done-fn | The flicker's escape hatch: probing the change callback's `.length` for a completion arity | There is no completion-callback protocol; submit status is data, read per instance |
 | Re-minted ephemeral state | Interaction state created inside the render function — dies on any re-render | Nothing lives in a render closure; drafts and status live at addresses and survive re-render and remount |
@@ -40,7 +40,7 @@ One require serves the whole page:
 
 ## The draft field
 
-`forms/buffered-field` is one controlled input with a draft in front of it.
+`forms/buffered-field` is one [controlled input](glossary.md#controlled-field) with a draft in front of it.
 The caller supplies four things: a stable address for the draft, the
 committed value, the value's revision, and the event that receives a commit.
 
@@ -161,7 +161,7 @@ form instance.
         (get (validate draft) field)))))
 ```
 
-The field is an ordinary controlled input; blur is the touch:
+The field is an ordinary [controlled input](glossary.md#controlled-field); blur is the touch:
 
 ```clojure
 (h/defview title-field []
@@ -273,7 +273,7 @@ Most fields need none of this page. A search box that feeds a debounced
 query, a settings toggle, a filter — bind them directly to app-db and stop.
 That whole story is [Controlled inputs](04-controlled-inputs.md). Use the
 forms module when you want a draft the user can abandon, errors that wait, or
-a submit lifecycle — and only then. Every buffered field is one more address
+a submit lifecycle — and only then. Every [buffered field](glossary.md#buffered-field) is one more address
 and one more commit protocol in your app's state. An application that never
 requires `re-frame.hicasso.forms` ships zero bytes of it.
 
@@ -291,7 +291,7 @@ refusal. So these rows name mechanisms:
 | The button enables but the handler refuses (or vice versa) | Two validity computations drifting apart | One materialised gate; the view subscribes, the handler reads `db` — never recompute per site |
 | Escape reverts, then the old draft reappears | A second copy of the draft outside the module — a local atom, a duplicated slice | One draft, one address; let the field own cancel — its trailing blur no-ops |
 | Two fields fight over one draft | Duplicate `:control` address | Address per instance: `[:invoice id :amount]`, not `[:invoice :amount]` |
-| A rejected draft still reads as accepted | The revision did not move, so the same-value rejection is invisible | Move `::h/revision` whenever you reject or rewrite |
+| A rejected draft still reads as accepted | The revision did not move, so the same-value rejection is invisible | Move [`::h/revision`](glossary.md#hrevision) whenever you reject or rewrite |
 | The field ignores an external value change mid-edit | By design: a value change under an unchanged revision continues the draft | Move the revision when you mean *replace the edit* |
 | A late async accept clobbers newer typing | The settle wrote the value without fencing | Settle writes value **and** revision; commits under the old revision no-op. Deeper supersession policy: [async resources](08-async-resources.md) |
 | A half-typed draft resurfaces much later | Drafts are durable state, and no causal owner cleared them | Clear at the causal end — route entry, or the save's reply (see Advanced) |
@@ -318,5 +318,5 @@ A buffered draft still writes app-db on each keystroke. The buffering changes
 *when the committed value moves*, not how the draft is tracked. That is what
 keeps drafts testable and visible to tools. For a dense grid where writes per
 cell per keystroke cost too much, the answer is not this module. The answer
-is the explicit uncontrolled choice, or a native island — both with their
+is the explicit uncontrolled choice, or a [native island](glossary.md#native-island) — both with their
 costs in [Performance](18-performance.md).

--- a/docs/design/hicasso/draft-guide/06-lists-and-collections.md
+++ b/docs/design/hicasso/draft-guide/06-lists-and-collections.md
@@ -69,7 +69,7 @@ neither.
 Keys are one half of list identity. The other half is the [read topology](glossary.md#read-topology):
 which rows *re-render*. That half is a genuine design choice.
 
-## Choosing a [read topology](glossary.md#read-topology)
+## Choosing a read topology
 
 [`h/sub`](glossary.md#hsub) is legal anywhere in a body, so you choose *where* the reads sit. For
 a collection, that position decides what an update costs. Four shapes cover

--- a/docs/design/hicasso/draft-guide/06-lists-and-collections.md
+++ b/docs/design/hicasso/draft-guide/06-lists-and-collections.md
@@ -3,10 +3,10 @@
 Every app has a table that started at twenty rows and now holds two thousand.
 At that size, a plain map over the data is no longer the whole answer. Two
 decisions govern how a collection behaves from there: **what identifies a row**
-(keys) and **which rows find out when a row changes** (read topology). This
+(keys) and **which rows find out when a row changes** ([read topology](glossary.md#read-topology)). This
 chapter owns both decisions.
 
-> **A key states which row this is. The read topology states which rows an
+> **A key states which row this is. The [read topology](glossary.md#read-topology) states which rows an
 > update reaches.**
 
 ## Keys are identity
@@ -48,7 +48,7 @@ running at all.
     booleans and functions.
 
 Forget a key entirely and development gives you two warnings: React's own, and
-`:rf.warning/hicasso-missing-key`. The Hicasso warning names the enclosing
+`:rf.warning/hicasso-missing-key`. The [Hicasso](glossary.md#hicasso) warning names the enclosing
 view, the child head, and the index of the first offender. The second warning
 exists because React dedupes its own warning per parent tag for the life of
 the page — under a `:ul`, every list after the first is silent. Hicasso's
@@ -66,12 +66,12 @@ neither.
     most common trigger of `:rf.warning/hicasso-missing-key`, and the message
     says exactly that.
 
-Keys are one half of list identity. The other half is the read topology:
+Keys are one half of list identity. The other half is the [read topology](glossary.md#read-topology):
 which rows *re-render*. That half is a genuine design choice.
 
-## Choosing a read topology
+## Choosing a [read topology](glossary.md#read-topology)
 
-`h/sub` is legal anywhere in a body, so you choose *where* the reads sit. For
+[`h/sub`](glossary.md#hsub) is legal anywhere in a body, so you choose *where* the reads sit. For
 a collection, that position decides what an update costs. Four shapes cover
 real workloads:
 
@@ -162,7 +162,7 @@ plus the view-model recompute itself. At 300 rows the sweep is cheap. At
 Two rules keep the bail-out honest here. First, rows must receive **values**.
 Persistent maps built with `select-keys` compare `=` across renders; a row
 that receives a freshly built closure re-renders on every sweep, which is one
-more reason event intents are data. Second, the row map should carry only
+more reason event [intents](glossary.md#intent) are data. Second, the row map should carry only
 what the row shows. A `:updated-at` timestamp that nobody renders defeats `=`
 on every touch.
 
@@ -192,7 +192,7 @@ sweep spans more than a block:
      [order-chunk {:key i :ids (vec ids)}])])
 ```
 
-A sparse update now changes one chunk's output. One chunk boundary re-renders,
+A sparse update now changes one chunk's output. One chunk [boundary](glossary.md#boundary) re-renders,
 and the sweep is 50 compares instead of the whole table. Mount retains one
 read per block instead of one per row. The equality gate on subscriptions
 keeps the untouched chunks quiet: their selects re-run cheaply, their outputs
@@ -212,7 +212,7 @@ Past a few thousand rows, ask why the DOM for row 8,000 exists at all. A
 one you already have: pagination. The page number is app-db state, and
 `(h/sub [:orders/page n])` is a windowed read whose bounds move at click
 rate. When the product wants continuous scrolling instead, bring a
-virtualizer through `h/defhost` and let it own the window:
+virtualizer through [`h/defhost`](glossary.md#defhost) and let it own the window:
 
 ```clojure
 ;; A .cljs host namespace — JS requires stay out of .cljc bodies.
@@ -243,11 +243,11 @@ Read the shape closely. Every piece does a job:
   cost.
 - **`:item-content` is declared `:render`** — the library calls it during its
   own render, and the body stays pure. The returned hiccup crosses through
-  `h/as-element`, which lowers it under the frame of the boundary that
+  [`h/as-element`](glossary.md#as-element), which lowers it under the frame of the [boundary](glossary.md#boundary) that
   supplied the callback. Intents inside the row later dispatch to the right
   frame, exactly as they would outside the host.
 - **The closure closes over `ids`, not over a read.** `(h/sub ...)` ran in the
-  body; the callback captures the *value*. A `h/sub` call inside the callback
+  body; the callback captures the *value*. A [`h/sub`](glossary.md#hsub) call inside the callback
   would be a deferred read, and the runtime refuses it loudly.
 - **`:compute-item-key` carries the keys law across the crossing.** When a
   virtualizer owns the list, it owns item identity too. Hand it the same
@@ -257,10 +257,10 @@ Read the shape closely. Every piece does a job:
   mechanics ([Ephemeral state](11-ephemeral-state.md)). Your state sees reads,
   not scrolling.
 
-The virtualizer's server policy is the host default, Client-only. That
+The virtualizer's [server policy](glossary.md#server-policy) is the host default, Client-only. That
 default is what a DOM-measuring component wants;
 [chapter 17](17-ssr-and-hydration.md) owns the SSR story.
-[Interop](09-interop.md) owns full `defhost` mechanics, including callback
+[Interop](09-interop.md) owns full [`defhost`](glossary.md#defhost) mechanics, including callback
 contracts. Also verify focus and keyboard behavior in a browser test. The
 keyboard cannot reach rows that do not exist, and that is a product decision,
 not a bug.
@@ -277,7 +277,7 @@ a filter that changes which rows are visible. Every keystroke of the filter
 then costs a hundreds-wide re-subscribe.
 
 The fix is structural, and you already saw both arms. Either push per-row
-reads down into row boundaries: each row's set is then small and stable, and
+reads down into row [boundaries](glossary.md#boundary): each row's set is then small and stable, and
 membership churn costs only the rows that actually enter or leave. Or go
 coarse, where the set is one read that never churns. Xray shows reads per
 boundary and read-set churn directly ([Diagnostics](15-diagnostics.md)), so
@@ -292,9 +292,9 @@ you observe this cost instead of guessing at it.
 | Input state or animation jumps to a different row after insert/reorder | Index keys — position renamed the rows | Key on domain ids |
 | One order changes and every row re-renders | The read lives too high — coarse topology where the workload is sparse | Fine reads: rows read their own entity; or accept the sweep knowingly |
 | A page-wide write runs every row body despite the bail-out | Row props are not `=` — a fresh closure, a JS object, or dead weight in the row map | Intents as data, persistent values, `select-keys` to what the row shows |
-| Filter typing is heavy on a large list | A large oscillating read set in one boundary, or a whole-table view-model recomputing per keystroke | Rows own their reads, chunk the table, or move the filter into the subscription |
-| A plain function — CLJS or a JS component — in head position is refused | `:rf.error/hicasso-bad-head` — only minted views, native tags, fragments and hosts are heads | Mint views with `h/defview`; declare foreign components once with `h/defhost` ([Interop](09-interop.md)) |
-| Virtualized list renders but rows are inert or mis-framed | Row hiccup returned raw from the render callback | Return it through `h/as-element` so it lowers under the captured frame |
+| Filter typing is heavy on a large list | A large oscillating read set in one [boundary](glossary.md#boundary), or a whole-table view-model recomputing per keystroke | Rows own their reads, chunk the table, or move the filter into the subscription |
+| A plain function — CLJS or a JS component — in head position is refused | `:rf.error/hicasso-bad-head` — only minted views, native tags, fragments and hosts are heads | Mint views with [`h/defview`](glossary.md#defview); declare foreign components once with [`h/defhost`](glossary.md#defhost) ([Interop](09-interop.md)) |
+| Virtualized list renders but rows are inert or mis-framed | Row hiccup returned raw from the render callback | Return it through [`h/as-element`](glossary.md#as-element) so it lowers under the captured frame |
 
 ## When not to tune a list
 

--- a/docs/design/hicasso/draft-guide/07-routing-and-navigation.md
+++ b/docs/design/hicasso/draft-guide/07-routing-and-navigation.md
@@ -1,7 +1,7 @@
 # Routing and navigation
 
 Your views are Hiccup and your events are vectors; navigation should not bring
-ceremony back. This page wires a Hicasso app to the re-frame2 router. It covers
+ceremony back. This page wires a [Hicasso](glossary.md#hicasso) app to the re-frame2 router. It covers
 the link you render, the warm-up before the click, scroll and focus after the
 route changes, and the "unsaved changes" guard. All of it is data and ordinary
 state.
@@ -40,7 +40,7 @@ Views require the integration module:
 
 ## Route links
 
-Spell an in-app link as `route-link`: name the route and its params, never a
+Spell an in-app link as [`route-link`](glossary.md#route-link): name the route and its params, never a
 URL. It is a plain function. Use it inline, inside the view that already owns
 the region:
 
@@ -59,7 +59,7 @@ the region:
 The call returns one real `<a>`, so hover preview, copy-link, and middle-click
 all behave. The router synthesizes the `:href`. The `:on-click` carries the
 click decision as data, under the routing module's reserved head. This is the
-second reserved head in the intent grammar, beside `::h/prevent` from
+second reserved head in the [intent](glossary.md#intent) grammar, beside [`::h/prevent`](glossary.md#hprevent) from
 [Events as data](03-events-as-data.md):
 
 ```clojure
@@ -77,19 +77,19 @@ second reserved head in the intent grammar, beside `::h/prevent` from
 
 Two renders of one link are equal under `=`, so a structural test reads the
 click decision straight off the tree ([Testing](14-testing.md)). Because
-`route-link` is a plain function, not a boundary, it inlines. There is no
+[`route-link`](glossary.md#route-link) is a plain function, not a [boundary](glossary.md#boundary), it inlines. There is no
 hook, no subscription read, and no row in any boundary count. A nav bar of
 thirty links costs what thirty anchors cost.
 
 The click law is the router's, and the link restates none of it:
 
-- A plain left-click: `preventDefault` runs, then the routing intent
+- A plain left-click: `preventDefault` runs, then the routing [intent](glossary.md#intent)
   dispatches to the frame captured at render.
 - A modifier or auxiliary click belongs to the browser — a new tab opens, and
   nothing dispatches.
 - A `:target` or `:download` anchor navigates natively, untouched.
 
-You never write `[::h/navigate …]` by hand. `route-link` mints it, and the
+You never write `[::h/navigate …]` by hand. [`route-link`](glossary.md#route-link) mints it, and the
 grammar is closed: exactly `:frame`, `:payload`, `:native?`, and `:veto`. Any
 other key refuses at render with `:rf.error/hicasso-malformed-navigate`,
 naming the position. A link rendered while the routing artefact is absent
@@ -99,7 +99,7 @@ through to the `<a>`: classes, `:data-*`, ARIA attributes.
 
 ### The active link
 
-`route-link` computes no active state. "Am I on this page?" is a comparison
+[`route-link`](glossary.md#route-link) computes no active state. "Am I on this page?" is a comparison
 against a route subscription, read once where the nav renders:
 
 ```clojure
@@ -115,7 +115,7 @@ against a route subscription, read once where the nav renders:
      (nav :app/articles "Articles")]))
 ```
 
-One boundary, one read, and a plain local helper — links stay inline.
+One [boundary](glossary.md#boundary), one read, and a plain local helper — links stay inline.
 `:aria-current "page"` is what a screen reader announces; the class is what you
 style.
 
@@ -123,8 +123,8 @@ style.
 
 A link may need to cancel its own navigation and do something else — for
 example, confirm before it discards a scratch pane. The `:on-click` you pass
-to `route-link` is that veto. Its roster is closed: `nil`,
-`[::h/prevent [:app/event]]`, an `h/event` form, or a plain function.
+to [`route-link`](glossary.md#route-link) is that veto. Its roster is closed: `nil`,
+`[::h/prevent [:app/event]]`, an [`h/event`](glossary.md#hevent) form, or a plain function.
 
 ```clojure
 (route-link {:to       :app/inbox
@@ -134,7 +134,7 @@ to `route-link` is that veto. Its roster is closed: `nil`,
 ```
 
 The prevent form is the declarative veto: it cancels the navigation and
-dispatches your intent instead. The link refuses a *bare* intent vector
+dispatches your [intent](glossary.md#intent) instead. The link refuses a *bare* intent vector
 there, loudly. The click already produces the one routing intent, and one
 user action must not yield two semantic events.
 
@@ -156,7 +156,7 @@ then lands on a fetch already in flight:
 hover delay. A passive link (no `:prefetch` key at all) dispatches nothing. A
 `:prefetch` key present with any other value fails loud at render. The
 reason: a link that should warm but does not looks exactly like one that
-does. Internally the intent handlers dispatch
+does. Internally the [intent](glossary.md#intent) handlers dispatch
 `[:rf.route/prefetch {:to … :params …}]` — an ordinary event that you can
 also dispatch yourself from any handler.
 
@@ -165,7 +165,7 @@ runs with every ensure ownerless and `:blocking?` inert. No route state
 moves: no slice write, no URL, no scroll, no guards, no `:on-match`. Click
 through, and the ordinary resource dedupe reuses the warmed work. Never
 click, and the warmed work stays garbage-collectable. Prefetch is a
-performance hint, not an authorization boundary. To warm a destination whose
+performance hint, not an authorization [boundary](glossary.md#boundary). To warm a destination whose
 `:can-enter` would refuse is permitted and means nothing, because activation
 still evaluates the guard.
 
@@ -227,8 +227,8 @@ the scroll policy above: routing owns scroll, and this recipe owns focus. If
 "a new page" means more than the route id to you — article 7 to article 9 —
 widen the key with the identifying param: `{:key (str route "|" article-id)}`.
 
-Focus for overlays — modals, popovers — is a different job with its own owner:
-the focus intent in [Overlays and focus](12-overlays-and-focus.md).
+Focus for [overlays](glossary.md#overlay) — modals, popovers — is a different job with its own owner:
+the focus [intent](glossary.md#intent) in [Overlays and focus](12-overlays-and-focus.md).
 
 ## The dirty-leave guard
 
@@ -254,7 +254,7 @@ changes* recipe is the full treatment:
 
 When the guard returns `false`, nothing commits: the URL and state do not
 change, and the attempt parks in `[:rf/pending-navigation]`. Render the
-prompt off that value, with the choices as intent vectors that carry the
+prompt off that value, with the choices as [intent](glossary.md#intent) vectors that carry the
 pending id:
 
 ```clojure
@@ -270,7 +270,7 @@ Mount it once near the root; it renders nothing until an attempt parks.
 `:rf.route/continue` replays exactly the navigation the user asked for —
 destination, `:replace?`, scroll policy. `:rf.route/cancel` drops it. Both
 take the pending id, so a stale click on an already-resolved dialog is a safe
-no-op. In a real app, render the box through the overlay module's modal, so
+no-op. In a real app, render the box through the [overlay](glossary.md#overlay) module's modal, so
 focus is trapped and restored ([Overlays and focus](12-overlays-and-focus.md)).
 The state shape here does not change.
 
@@ -324,7 +324,7 @@ boot, and Back/Forward are history inputs. Both run the same match → validate
 ??? info "Coming from React Router?"
 
     Three instincts mislead here. There is no `<Link>` component:
-    `route-link` is a plain function that returns an anchor with data on it.
+    [`route-link`](glossary.md#route-link) is a plain function that returns an anchor with data on it.
     There is no `useBlocker` or `usePrompt`: the blocked attempt is app state
     you render. There is no `router.prefetch()` call: warming is an event.
     Everything you would reach into router context for is a subscription.
@@ -334,9 +334,9 @@ boot, and Back/Forward are history inputs. Both run the same match → validate
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | Rendering a link throws `:rf.error/routing-artefact-missing` | The core routing artefact is not loaded | `(:require [re-frame.routing])` at boot, before first render |
-| A link full-page reloads | A hand-written `[:a {:href …}]` bypasses interception | Use `route-link`, or the document-level click listener recipe from the routing corpus |
-| `:rf.error/hicasso-malformed-navigate` at render | A hand-built or edited `::h/navigate` head | Don't write the head; `route-link` mints it |
-| A `route-link` refuses your `:on-click` intent vector | One click must not yield two semantic events | Wrap it: `[::h/prevent [:app/event]]` — cancel-and-replace |
+| A link full-page reloads | A hand-written `[:a {:href …}]` bypasses interception | Use [`route-link`](glossary.md#route-link), or the document-level click listener recipe from the routing corpus |
+| `:rf.error/hicasso-malformed-navigate` at render | A hand-built or edited `::h/navigate` head | Don't write the head; [`route-link`](glossary.md#route-link) mints it |
+| A [`route-link`](glossary.md#route-link) refuses your `:on-click` [intent](glossary.md#intent) vector | One click must not yield two semantic events | Wrap it: `[::h/prevent [:app/event]]` — cancel-and-replace |
 | A link carrying `:prefetch` refuses at render | Only `:intent` is accepted; passivity must be visible | Remove the key, or spell `:prefetch :intent` |
 | Leaving always blocks, and an error names the guard | The `:can-leave` sub returned a non-boolean — fail-closed | `:rf.error/can-leave-non-boolean`: return a strict `true`/`false` |
 | Back lands at the top of a long page | Restore ran before the page had its height | Make the page's data blocking route `:resources`, or keep previous data on screen |
@@ -348,5 +348,5 @@ boot, and Back/Forward are history inputs. Both run the same match → validate
 |---|---|
 | Single-screen app, no shareable URLs | No routing artefact at all — there is nothing to integrate |
 | In-memory UI steps that shouldn't touch the URL — wizard panes, non-linkable tabs | app-db state, or a machine |
-| External links | A plain `[:a {:href …}]` — `route-link` is for the route table |
+| External links | A plain `[:a {:href …}]` — [`route-link`](glossary.md#route-link) is for the route table |
 | Guarding one button, not a page's exits | The veto roster on that link, or ordinary app logic |

--- a/docs/design/hicasso/draft-guide/08-async-resources.md
+++ b/docs/design/hicasso/draft-guide/08-async-resources.md
@@ -1,20 +1,20 @@
 # Async resources
 
 Async replies arrive late. They arrive out of order. They arrive for screens
-that no longer exist. This page teaches the Hicasso patterns for that problem
+that no longer exist. This page teaches the [Hicasso](glossary.md#hicasso) patterns for that problem
 class:
 
 - the settle-merge, which stops a late reply from overwriting newer edits
 - per-instance mutation status, with optimistic rollback
 - the owners of cancellation and supersession
-- demand-driven committed reads, shown in a full typeahead example
+- [demand-driven committed reads](glossary.md#demand-driven-committed-read), shown in a full typeahead example
 
 The transport is the core resource/event model (`re-frame.resources`). That
 model supplies registered reads with scope and tags, causes, the five-status
 projection, and mutations that invalidate by tag. The corpus under
 `docs/resources/` teaches that model. This page assumes it and owns the
 patterns on top of it. In a Hicasso view, you read a resource with the same
-`h/sub` as any subscription.
+[`h/sub`](glossary.md#hsub) as any subscription.
 
 > **The read owns the lifetime, you own the policy, and the runtime owns the race.**
 
@@ -116,7 +116,7 @@ row, and each button watches its own write:
 ```
 
 Look at the click. It is one literal event vector — mutation, params, instance,
-and cause, all data. A structural test therefore asserts the whole write intent
+and cause, all data. A structural test therefore asserts the whole write [intent](glossary.md#intent)
 with `=`. The instance sub yields `:pending?`, `:success?`, `:error?`,
 `:settled?`, `:optimistic?`, `:result`, and `:error`. Focused projections such
 as `[:rf.mutation/pending? {…}]` exist for a button that needs one boolean.
@@ -188,7 +188,7 @@ ceremony:
 - release on unmount
 - re-ensure on parameter change
 
-Each step is an opportunity for a leak or for an orphaned fetch. Hicasso
+Each step is an opportunity for a leak or for an orphaned fetch. [Hicasso](glossary.md#hicasso)
 closes the gap with the committed read itself. A read of a resource may
 declare demand:
 
@@ -220,7 +220,7 @@ The law, in full:
   decides *how* the resource behaves.
 - **It costs nothing elsewhere.** Demand uses the committed-read membership
   that the runtime already keeps. A read contributes membership, not a record,
-  and no per-read ledger exists. A boundary that reads no resource carries
+  and no per-read ledger exists. A [boundary](glossary.md#boundary) that reads no resource carries
   none of this.
 
 Without `:demand true`, the sub is the core passive projection, and it never
@@ -303,7 +303,7 @@ list's committed read declares demand:
 
 Walk the timeline, and every policy is visible:
 
-1. **`c` … `cl`** — each keystroke echoes through the controlled input at
+1. **`c` … `cl`** — each keystroke echoes through the [controlled input](glossary.md#controlled-field) at
    once. The generation increments. Nothing fetches. Debounce is your
    event-layer policy.
 2. **250 ms of quiet** — the surviving timer's generation matches, and
@@ -334,7 +334,7 @@ owner — the read.
 
 Two edges remain. Under Xray, held demand is a bounded projection: which
 resources are owned by which committed reads, and why each fetch fired
-([Diagnostics](15-diagnostics.md)). On the server, the boundary is Client-only
+([Diagnostics](15-diagnostics.md)). On the server, the [boundary](glossary.md#boundary) is Client-only
 by default — a deterministic fallback and zero acquisition, because
 acquisition is a client commit fact. Hydration then adopts without a duplicate
 fetch ([SSR and hydration](17-ssr-and-hydration.md)).

--- a/docs/design/hicasso/draft-guide/09-interop.md
+++ b/docs/design/hicasso/draft-guide/09-interop.md
@@ -26,7 +26,7 @@ component once. Then use it anywhere a view is legal:
 > **Declare the host once. Then use it as an ordinary view head.**
 
 Children cross as ordinary hiccup, and they lower where they render.
-`h/defhost` is the one declared door to foreign React. Everything else on this
+[`h/defhost`](glossary.md#defhost) is the one declared door to foreign React. Everything else on this
 page is that door's contract, seen from a different side.
 
 Why declare at all? A raw JS component dropped into the tree breaks three
@@ -37,7 +37,7 @@ things at once:
 - The node holds an opaque JS object, so `=` tests stop working at that point.
 - Tools get a bare value where they wanted an identity.
 
-`h/defhost` quarantines the require in one `.cljs` host namespace. The rest of
+[`h/defhost`](glossary.md#defhost) quarantines the require in one `.cljs` host namespace. The rest of
 the tree stays data. You pay the friction once, and every use after that is
 free.
 
@@ -80,19 +80,19 @@ A declared slot carries a contract. The contract is never inferred from an
                :on-render-row :render}})
 ```
 
-**`:event`** — this slot works as a native `:on-*` does. Write an intent
-vector, or write `h/event` when you need the library's arguments. Foreign
+**`:event`** — this slot works as a native `:on-*` does. Write an [intent](glossary.md#intent)
+vector, or write [`h/event`](glossary.md#hevent) when you need the library's arguments. Foreign
 invokers pass *their* arguments — `onPick(value, event)`, `onChange(date)` —
-and every argument reaches the `h/event` body in library order.
+and every argument reaches the [`h/event`](glossary.md#hevent) body in library order.
 
 **`:handler`** — the function crosses by identity, with no wrapper. The
 library gets exactly the function that you wrote, and your return value goes
 back to that caller. Use this contract for imperative APIs such as `open()`
-and `scrollTo()`. Hicasso does not invent meaning for those calls.
+and `scrollTo()`. [Hicasso](glossary.md#hicasso) does not invent meaning for those calls.
 
 **`:render`** — the library calls you *during its own render* (`renderRow`,
 `renderItem`). The body must be pure, and it returns hiccup only through
-`h/as-element`:
+[`h/as-element`](glossary.md#as-element):
 
 ```clojure
 ;; ids came from (h/sub [:feed/ids]) earlier in the body
@@ -104,10 +104,10 @@ and `scrollTo()`. Hicasso does not invent meaning for those calls.
                    (str (nth ids i))]))}]
 ```
 
-`h/as-element` is the one explicit hiccup-to-element conversion, and the
+[`h/as-element`](glossary.md#as-element) is the one explicit hiccup-to-element conversion, and the
 declared position supplies the frame. The row built in that body carries its
-intents. The intents fire later, on the user's click, into the frame of the
-boundary that *supplied* the callback. A dispatch *while* the call runs raises
+[intents](glossary.md#intent). The intents fire later, on the user's click, into the frame of the
+[boundary](glossary.md#boundary) that *supplied* the callback. A dispatch *while* the call runs raises
 `:rf.error/hicasso-dispatch-in-render-position`, and the error names the
 position.
 
@@ -118,13 +118,13 @@ and `:render` contracts refuse the same carrier with
 function crosses untouched at all three contracts. Second, **intent vectors
 stay event-first** ([Events as data](03-events-as-data.md)). A value-first
 invoker has no DOM event at argument one, so a marker-carrying intent refuses
-with `:rf.error/hicasso-intent-needs-the-event`. `h/event` is the spelling for
+with `:rf.error/hicasso-intent-needs-the-event`. [`h/event`](glossary.md#hevent) is the spelling for
 those slots. A bare intent with no marker never touches its arguments, so
 `{:on-pick [:city/picked "paris"]}` is legal under any invoker.
 
-## ReactNode slots
+## [ReactNode slots](glossary.md#reactnode-slot)
 
-Some props are not data. They are markup positions: a modal's title, a footer,
+Some props are not data. They are markup positions: a [modal](glossary.md#overlay)'s title, a footer,
 a Suspense fallback. Declare those props as slots. Hiccup written at a
 declared slot then lowers under the captured frame:
 
@@ -138,8 +138,8 @@ declared slot then lowers under the captured frame:
         :footer   [:button.danger {:on-click [:article/delete id]} "Delete"]}]
 ```
 
-Intents inside a declared slot fire into the declaring boundary's frame,
-exactly as intents in children do. A string or a ready React element at a
+Intents inside a declared slot fire into the declaring [boundary](glossary.md#boundary)'s frame,
+exactly as [intents](glossary.md#intent) in children do. A string or a ready React element at a
 declared slot passes as-is. React's own wrappers host the same way: declare
 `Suspense` once with `:slots #{:fallback}`, and write the fallback as hiccup.
 
@@ -184,7 +184,7 @@ hydration, and fresh mount.
 **Client-only** — the default. The server emits nothing at the crossing, and
 the component appears when the client adopts it. Until adoption,
 `{:fallback [:div.chart-skeleton]}` renders *instead of* the crossing. The
-fallback is inert markup: the declaration refuses a `defview` or `defhost`
+fallback is inert markup: the declaration refuses a [`defview`](glossary.md#defview) or [`defhost`](glossary.md#defhost)
 head inside one (`:rf.error/hicasso-host-fallback-boundary-head`). `:fallback`
 beside `{:server :render}`, or any other policy value, refuses at mint with
 `:rf.error/hicasso-host-bad-ssr-policy`. The full server story is
@@ -193,7 +193,7 @@ beside `{:server :render}`, or any other policy value, refuses at mint with
 ## Portals
 
 Sometimes markup must land in a different DOM container — a toast rack, a
-vendor-owned overlay div — while it stays part of your tree. The portal helper
+vendor-owned [overlay](glossary.md#overlay) div — while it stays part of your tree. The [portal](glossary.md#portal) helper
 lowers hiccup into React's `createPortal` and preserves the frame:
 
 ```clojure
@@ -211,7 +211,7 @@ Keep three facts straight:
   usual.
 - **A changed `:target` is a remount.** The subtree unmounts and remounts in
   the new container. Keep the target stable.
-- **The portal is Client-only.** No DOM target exists on a server, so the
+- **The [portal](glossary.md#portal) is Client-only.** No DOM target exists on a server, so the
   portal contributes nothing to the response. An explicit `:fallback` may emit
   placeholder markup at the portal's tree position.
 
@@ -222,7 +222,7 @@ mechanism for containers that you do not control.
 ## The escape: `[:>]`
 
 `[:> Component props & children]` is the raw element escape. It is the same
-foreign path as `h/defhost`, with the declaration erased. It exists for two
+foreign path as [`h/defhost`](glossary.md#defhost), with the declaration erased. It exists for two
 cases. Migration is the first: Reagent codebases arrive full of `[:>]` sites,
 and those sites are legal here. The second is the one-off crossing that a
 declaration cannot express, such as a component selected at runtime from data:
@@ -239,27 +239,27 @@ The escape is **not** the performance tier. A measured hot region takes the
 **Declare what you use twice.** When you erase the declaration, you lose
 exactly what the declaration carried:
 
-| A declaration carries | `h/defhost` | `[:>]` |
+| A declaration carries | [`h/defhost`](glossary.md#defhost) | `[:>]` |
 |---|---|---|
 | A crossing name for tools | authored | the constant `"[:>]"` |
 | Callback contracts | exact, per slot | none — every prop is unclaimed |
-| ReactNode slots | declared | none — hiccup in a prop is data |
-| A server policy | Render or Client-only with fallback | fixed Client-only, unspellable |
+| [ReactNode slots](glossary.md#reactnode-slot) | declared | none — hiccup in a prop is data |
+| A [server policy](glossary.md#server-policy) | Render or Client-only with fallback | fixed Client-only, unspellable |
 | An early site for refusals | checked once, at the declaration | every refusal fires at the crossing |
 | A `.cljc` quarantine | one host namespace | the require lands in your view namespace |
 
 Every prop at an escape is unclaimed. Two refusals guard the silent failures
 that would follow:
 
-- An intent vector at an `on*`-spelled prop refuses with
+- An [intent](glossary.md#intent) vector at an `on*`-spelled prop refuses with
   `:rf.error/hicasso-host-undeclared-callback`. The runtime never infers a
   contract from a name. Without the refusal, your intent would cross as an
   inert array.
-- An `h/event` at any escape prop refuses with
+- An [`h/event`](glossary.md#hevent) at any escape prop refuses with
   `:rf.error/hicasso-host-unclaimed-callback`. The marked form asks its
   position for a contract, and no escape position can answer.
 
-Both refusals name `h/defhost` as the recovery.
+Both refusals name [`h/defhost`](glossary.md#defhost) as the recovery.
 
 A plain function crosses by identity and runs. But it carries no frame, and
 the render has unwound by the time the library calls it. A bare `rf/dispatch`
@@ -287,15 +287,15 @@ that.
 The component position takes what React accepts as an element type. `nil` —
 the usual result of a `:default` import from a library with no default
 export — is refused as `:rf.error/hicasso-raw-no-component`. A string, a
-keyword, a `defview` head, a `defhost` head, or an already-built React
+keyword, a [`defview`](glossary.md#defview) head, a [`defhost`](glossary.md#defhost) head, or an already-built React
 *element* is refused as `:rf.error/hicasso-raw-not-a-component`. Each refusal
 carries its own recovery. Each fires in your render, on the server too, with
 your stack pointing at the line that you wrote.
 
-## The outward bridge
+## The [outward bridge](glossary.md#outward-bridge)
 
 Interop runs in the other direction too. A native React parent —
-`n/defcomponent`, UIx, or plain JavaScript — renders a minted Hicasso view
+[`n/defcomponent`](glossary.md#ndefcomponent), UIx, or plain JavaScript — renders a minted [Hicasso](glossary.md#hicasso) view
 under the existing frame. There is no second root and no second state owner.
 
 ```clojure
@@ -304,14 +304,14 @@ under the existing frame. There is no second root and no second state owner.
 (def article-card* (h/as-component article-card))
 ```
 
-`h/as-component` returns a real React component. The parent's props arrive as
+[`h/as-component`](glossary.md#outward-bridge) returns a real React component. The parent's props arrive as
 the view's ordinary props map: names come back through the canonical rule
 (`articleId` → `:article-id`), and values cross by identity. The view keeps
 its memo wrapper, its reads, its key identity, and its teardown law. Its frame
 comes from React context, and that context flows through any foreign
-components in between. When the view renders outside a Hicasso root, the
-mount refuses with `:rf.error/no-frame-context`. `h/as-element` and
-`h/as-component` are the two halves of one seam. Use the element for a
+components in between. When the view renders outside a [Hicasso](glossary.md#hicasso) root, the
+mount refuses with `:rf.error/no-frame-context`. [`h/as-element`](glossary.md#as-element) and
+[`h/as-component`](glossary.md#outward-bridge) are the two halves of one seam. Use the element for a
 one-shot subtree handed through a callback. Use the component for a view that
 a native parent will mount, key, and re-render itself.
 
@@ -320,18 +320,18 @@ a native parent will mount, key, and re-render itself.
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | Library ignores or rejects a prop — a keyword, a ClojureScript map, a kebab key inside a nested map | Values cross by identity; nested keys are not camelCased; deep conversion is not offered | Hand the library what it documents — the string, `#js`, or `clj->js`, at the call site |
-| Hiccup passed in a prop renders as array data | Only children and declared slots lower; an undeclared prop is data | Declare the prop in `:slots`, or wrap in `h/as-element` |
-| React refuses an object as a child, from a render callback | The body returned a raw vector; a `:render` return crosses unconverted | Return through `h/as-element` |
+| Hiccup passed in a prop renders as array data | Only children and declared slots lower; an undeclared prop is data | Declare the prop in `:slots`, or wrap in [`h/as-element`](glossary.md#as-element) |
+| React refuses an object as a child, from a render callback | The body returned a raw vector; a `:render` return crosses unconverted | Return through [`h/as-element`](glossary.md#as-element) |
 | `:rf.error/hicasso-intent-at-a-non-event-contract` | Intent carrier at `:handler` or `:render`; neither dispatches | Declare `:event`, or write the real function |
 | `:rf.error/hicasso-host-undeclared-callback` at a `[:>]` | Intent at an `on*`-spelled escape prop; contracts are never inferred | Declare the host and name the prop in `:callbacks` |
 | A `[:>]` callback runs, then `:rf.error/no-frame-context` | A plain function carries no frame; the render has unwound | `(rf/capture-frame)` in the body; close over its `:dispatch` |
 | Namespace does not load on the JVM | A JS require reached a `.cljc` file | Quarantine the require in a `.cljs` host namespace |
 | `:rf.error/hicasso-host-bad-ssr-policy` at mint | A policy value outside Render / Client-only, or `:fallback` beside `:server :render` | Two policies; the fallback belongs to Client-only |
-| Hosted component does not update when the app state did | The boundary above bailed out on equal props; the host was never re-entered | Put the changing value on the host's *own* props |
+| Hosted component does not update when the app state did | The [boundary](glossary.md#boundary) above bailed out on equal props; the host was never re-entered | Put the changing value on the host's *own* props |
 
 ## When not to host
 
-`defhost` is for components that you do not own. A hot, **hand-written**
+[`defhost`](glossary.md#defhost) is for components that you do not own. A hot, **hand-written**
 component is the [native tier](10-native-tier.md)'s job, not a host
 declaration around your own code. If the library is a thin wrapper over DOM,
 and twenty lines of hiccup reproduce it, write the twenty lines. A hosted
@@ -342,7 +342,7 @@ less about. Most applications end with only two or three hard hosted widgets.
 
 ### The crossing has no memo wrapper
 
-A `defview` boundary memoizes on its props. A host crossing does not. The
+A [`defview`](glossary.md#defview) [boundary](glossary.md#boundary) memoizes on its props. A host crossing does not. The
 foreign component re-renders whenever the boundary that wrote it re-renders.
 The bail-out you want is the enclosing boundary's: put the crossing behind a
 small `defview` of its own. The corollary applies in reverse. A host that must
@@ -391,7 +391,7 @@ on attach and detach only, never on a config change. Therefore keep the config
 fixed for the connection's life, and route steady-state change through an
 ordinary event and effect. Sometimes the attach must close over per-instance
 props — an API key, a per-panel config. Then it needs `react/useCallback` to
-stay stable, and hooks do not belong in a `defview` body. That is the signal
+stay stable, and hooks do not belong in a [`defview`](glossary.md#defview) body. That is the signal
 that the edge has outgrown this recipe. It wants a named native component,
 where hooks are legal and the same ref shape carries over
 ([The native tier](10-native-tier.md)).

--- a/docs/design/hicasso/draft-guide/09-interop.md
+++ b/docs/design/hicasso/draft-guide/09-interop.md
@@ -122,7 +122,7 @@ with `:rf.error/hicasso-intent-needs-the-event`. [`h/event`](glossary.md#hevent)
 those slots. A bare intent with no marker never touches its arguments, so
 `{:on-pick [:city/picked "paris"]}` is legal under any invoker.
 
-## [ReactNode slots](glossary.md#reactnode-slot)
+## ReactNode slots
 
 Some props are not data. They are markup positions: a [modal](glossary.md#overlay)'s title, a footer,
 a Suspense fallback. Declare those props as slots. Hiccup written at a
@@ -292,7 +292,7 @@ keyword, a [`defview`](glossary.md#defview) head, a [`defhost`](glossary.md#defh
 carries its own recovery. Each fires in your render, on the server too, with
 your stack pointing at the line that you wrote.
 
-## The [outward bridge](glossary.md#outward-bridge)
+## The outward bridge
 
 Interop runs in the other direction too. A native React parent —
 [`n/defcomponent`](glossary.md#ndefcomponent), UIx, or plain JavaScript — renders a minted [Hicasso](glossary.md#hicasso) view

--- a/docs/design/hicasso/draft-guide/10-native-tier.md
+++ b/docs/design/hicasso/draft-guide/10-native-tier.md
@@ -1,8 +1,8 @@
-# The native tier
+# The [native tier](glossary.md#native-tier)
 
-Most applications never need this page. Ordinary Hicasso — interpreted hiccup, `h/sub` where you read, events as data — is the product, and it is the right choice for roughly 98% of the view code you will ever write. This page is for the other 1–2%: the row that repaints on every market tick, the drag handle that tracks a pointer at display rate, the vendor widget with hooks at its core. For that code Hicasso keeps an explicit exit to native React. Take it and you write React directly — direct element construction, real hooks, full native speed — and your frame, your app-db, and your React root all come with you.
+Most applications never need this page. Ordinary [Hicasso](glossary.md#hicasso) — interpreted hiccup, [`h/sub`](glossary.md#hsub) where you read, events as data — is the product, and it is the right choice for roughly 98% of the view code you will ever write. This page is for the other 1–2%: the row that repaints on every market tick, the drag handle that tracks a pointer at display rate, the vendor widget with hooks at its core. For that code Hicasso keeps an explicit exit to native React. Take it and you write React directly — direct element construction, real hooks, full native speed — and your frame, your app-db, and your React root all come with you.
 
-> **`[...]` is always interpreted Hiccup. `n/$` is always native React. Neither form ever changes the other's meaning — and nothing, anywhere, compiles hiccup.**
+> **`[...]` is always interpreted Hiccup. [`n/$`](glossary.md#n-dollar) is always native React. Neither form ever changes the other's meaning — and nothing, anywhere, compiles hiccup.**
 
 That sentence is the whole architecture. There is no compiler tier, no `:fast` flag, no mode switch. Crossing is explicit in your source, visible to your tests, and named by Xray. The tier also costs nothing when you do not use it: an application that never requires the native namespace ships zero native-tier code.
 
@@ -12,15 +12,15 @@ The hot path is a gradient of explicit choices. You climb it one rung at a time,
 
 | Rung | You write | What changes | Climb when |
 |---|---|---|---|
-| 1. Ordinary Hicasso | Hiccup, `h/sub`, event vectors | Nothing — this is the product | Always start here |
+| 1. Ordinary [Hicasso](glossary.md#hicasso) | Hiccup, [`h/sub`](glossary.md#hsub), event vectors | Nothing — this is the product | Always start here |
 | 2. Tuned topology | The same language | Boundary placement, keys, read shape (fine / coarse / chunked / windowed), virtualization | A named interaction misses its budget — [Lists and collections](06-lists-and-collections.md) |
-| 3. Direct native return | A `defview` whose body returns `n/$` | Hiccup lowering is skipped for that result; frame, reads, memo, and lifecycle stay | Attribution names lowering as the cost owner |
-| 4. Named native island | `n/defcomponent` (or UIx) with `n/use-sub` / `n/use-frame` | Hooks, vendor widgets, and high-rate mechanics live in a real native component with an explicit crossing | Hooks, reconciliation, vendor behavior, or high-rate local work dominates |
+| 3. Direct native return | A [`defview`](glossary.md#defview) whose body returns [`n/$`](glossary.md#n-dollar) | Hiccup [lowering](glossary.md#lowering) is skipped for that result; frame, reads, memo, and lifecycle stay | Attribution names lowering as the cost owner |
+| 4. Named [native island](glossary.md#native-island) | [`n/defcomponent`](glossary.md#ndefcomponent) (or UIx) with [`n/use-sub`](glossary.md#nuse-sub) / [`n/use-frame`](glossary.md#nuseframe) | Hooks, vendor widgets, and high-rate mechanics live in a real native component with an explicit crossing | Hooks, reconciliation, vendor behavior, or high-rate local work dominates |
 | 5. Native screen | A whole screen in the native namespace or UIx | The view language for that screen — same root, same frames, same app-db | The screen is React-shaped by design |
 
 Rungs 1 and 2 are the ordinary product — [Views and reads](02-views-and-reads.md) and [Lists and collections](06-lists-and-collections.md) own them. This page owns rungs 3 to 5, and the rule that disciplines all three:
 
-**An escape stays only if it recovers at least 20% of the measured interaction, saves at least 2 ms at p95, or converts a failed user-visible budget into a pass — otherwise it comes out.** Native code that cannot meet that rule is a permanent cost with no return. Reverting a rung-3 escape is a five-minute diff, so the rule has no exceptions.
+**An escape stays only if it recovers at least 20% of the measured interaction, saves at least 2 ms at p95, or converts a failed [user-visible budget](glossary.md#user-visible-budget) into a pass — otherwise it comes out.** Native code that cannot meet that rule is a permanent cost with no return. Reverting a rung-3 escape is a five-minute diff, so the rule has no exceptions.
 
 ## Rung 3 — return native React from a boundary
 
@@ -41,9 +41,9 @@ Here is a watchlist row after rung 2 is already done properly. The table is wind
      [:td.vol vol]]))
 ```
 
-Market ticks update most visible rows four times a second. On this app's low-tier reference laptop, Xray's attribution for the tick event reads: bodies 3 ms, hiccup lowering 9 ms, React reconcile-and-commit 6 ms, paint 3 ms — 21 ms at p95. Every row did change, so there is no read-topology fix left to make. The owner is lowering: forty rows of vectors turn into React elements, four times a second. That is the one situation rung 3 exists for.
+Market ticks update most visible rows four times a second. On this app's low-tier reference laptop, Xray's attribution for the tick event reads: bodies 3 ms, hiccup [lowering](glossary.md#lowering) 9 ms, React reconcile-and-commit 6 ms, paint 3 ms — 21 ms at p95. Every row did change, so there is no read-topology fix left to make. The owner is lowering: forty rows of vectors turn into React elements, four times a second. That is the one situation rung 3 exists for.
 
-A `defview` may return an existing React element instead of hiccup. Build it with `n/$`:
+A [`defview`](glossary.md#defview) may return an existing React element instead of hiccup. Build it with [`n/$`](glossary.md#n-dollar):
 
 ```clojure
 (ns app.watchlist.row
@@ -61,26 +61,26 @@ A `defview` may return an existing React element instead of hiccup. Build it wit
          (n/$ :td {:class "vol"} vol))))
 ```
 
-The boundary did not change. The parent still renders `[quote-row {:key sym :sym sym}]`. The view keeps its React identity, its value-equality memo, its frame, its `h/sub` reads, its lifecycle, and its name in Xray. What changed is the return value: an already-constructed React element, so hiccup lowering is skipped for this result entirely. Re-measured, the tick lands at 13 ms p95 — 38% recovered, 8 ms saved. That passes the benefit rule on two of its conditions; the escape stays. Your numbers will differ. The point is that you have numbers.
+The [boundary](glossary.md#boundary) did not change. The parent still renders `[quote-row {:key sym :sym sym}]`. The view keeps its React identity, its value-equality memo, its frame, its [`h/sub`](glossary.md#hsub) reads, its lifecycle, and its name in Xray. What changed is the return value: an already-constructed React element, so hiccup [lowering](glossary.md#lowering) is skipped for this result entirely. Re-measured, the tick lands at 13 ms p95 — 38% recovered, 8 ms saved. That passes the benefit rule on two of its conditions; the escape stays. Your numbers will differ. The point is that you have numbers.
 
 Read the diff closely. Every changed line marks the semantic fence:
 
 - **`[:td.sym …]` became `(n/$ :td {:class "sym"} …)`.** The native grammar has no selector shorthand. You spell class and id as props.
-- **`:on-click [:watchlist/select sym]` became `(h/event [_] [:watchlist/select sym])`.** Past the fence there is no intent lowering. An event vector in a native prop is an error, not a callback. `h/event` is the same explicit form you use everywhere else. It captures the frame while the body runs, and it hands React an ordinary function that dispatches its result. Plain `fn` values are equally legal when you do not dispatch.
-- **Children are nested `n/$` forms, not vectors.** A hiccup vector as a native child refuses at its source. If a native subtree needs one Hicasso-rendered child, convert it explicitly: `(h/as-element [sparkline {:points pts}])` lowers the hiccup under the captured frame and yields a legal ReactNode.
+- **`:on-click [:watchlist/select sym]` became `(h/event [_] [:watchlist/select sym])`.** Past the fence there is no [intent](glossary.md#intent) lowering. An event vector in a native prop is an error, not a callback. [`h/event`](glossary.md#hevent) is the same explicit form you use everywhere else. It captures the frame while the body runs, and it hands React an ordinary function that dispatches its result. Plain `fn` values are equally legal when you do not dispatch.
+- **Children are nested [`n/$`](glossary.md#n-dollar) forms, not vectors.** A hiccup vector as a native child refuses at its source. If a native subtree needs one Hicasso-rendered child, convert it explicitly: `(h/as-element [sparkline {:points pts}])` lowers the hiccup under the captured frame and yields a legal ReactNode.
 
 The whole fence fits in one table. The left column is why rung 3 is cheap to adopt and cheap to revert. The right column is the price of native semantics, paid at the crossing:
 
 | Stays with the boundary | Stops at the returned element |
 |---|---|
-| The frame — and `h/sub` anywhere in the body | Hiccup interpretation — a vector is not markup here |
+| The frame — and [`h/sub`](glossary.md#hsub) anywhere in the body | Hiccup interpretation — a vector is not markup here |
 | The props ABI, value-equality memo, and the parent's `:key` | Intent lowering — an event vector in a prop is an error |
-| Lifecycle, HMR identity, and the view's name in Xray | Controlled repair — no `::h/value`, `::h/checked`, `::h/prevent`, `::h/revision` |
+| Lifecycle, HMR identity, and the view's name in Xray | Controlled repair — no [`::h/value`](glossary.md#hvalue), [`::h/checked`](glossary.md#hchecked), [`::h/prevent`](glossary.md#hprevent), [`::h/revision`](glossary.md#hrevision) |
 | Server rendering — intrinsic-headed output produces the same deterministic bytes | Structural assertions and key diagnostics — the element is opaque to the pure test tiers, which refuse with a pointer to the mounted tier ([Testing](14-testing.md)) |
 
-Two consequences deserve their own sentences. First, form fields stay interpreted. An `<input>` inside `n/$` is a raw React controlled input: you do all of React's manual controlled-input work, and you get none of Hicasso's caret, IME, or same-turn guarantees ([Controlled inputs](04-controlled-inputs.md)). Second, hooks still do not belong in the body. A `defview` body is dynamically composed — branches and loops are legal, and that is exactly the environment where hook order breaks. The wish for a hook in a `defview` body is the signal that you are at rung 4, not rung 3.
+Two consequences deserve their own sentences. First, form fields stay interpreted. An `<input>` inside [`n/$`](glossary.md#n-dollar) is a raw React [controlled input](glossary.md#controlled-field): you do all of React's manual controlled-input work, and you get none of [Hicasso](glossary.md#hicasso)'s caret, IME, or same-turn guarantees ([Controlled inputs](04-controlled-inputs.md)). Second, hooks still do not belong in the body. A [`defview`](glossary.md#defview) body is dynamically composed — branches and loops are legal, and that is exactly the environment where hook order breaks. The wish for a hook in a `defview` body is the signal that you are at rung 4, not rung 3.
 
-### The `n/$` grammar
+### The [`n/$`](glossary.md#n-dollar) grammar
 
 The authoring shape is deliberately small:
 
@@ -94,8 +94,8 @@ The authoring shape is deliberately small:
 - **Heads.** An unqualified keyword such as `:div` names an intrinsic React element. A string names an intrinsic or custom element verbatim (SVG and web components work). Any other head expression must evaluate to a native React component.
 - **The props operand.** The macro treats exactly four forms as props: `nil`, a literal ClojureScript map, a literal `#js` object, or the explicit `(n/props expression)` marker. **Every other trailing form is a child.**
 - **Prop names.** ClojureScript-map keys use the canonical React slot-name rule: kebab spellings become camelCase (`:on-click` → `onClick`); `:class` and `:for` become the React names; `data-*` / `aria-*` stay hyphenated; camelCase keywords are fixpoints; string keys pass verbatim. A raw JavaScript object is never renamed — it already uses React's names.
-- **Prop values pass by identity.** No intent lowering, no class-collection merge, no style-map conversion, no keyword-value conversion, no controlled-field repair, no deep conversion. Where a native API expects a JavaScript object — React style objects included — hand it one: `:style #js {:transform "translateX(4px)"}`.
-- **Children** are trailing ReactNode values. Nest with `n/$`; collections must already be valid React children, normally a JavaScript array (`(into-array (map row-el rows))`, each element carrying its `:key`). The grammar refuses `:children` inside the props map — there is one child channel.
+- **Prop values pass by identity.** No [intent](glossary.md#intent) [lowering](glossary.md#lowering), no class-collection merge, no style-map conversion, no keyword-value conversion, no controlled-field repair, no deep conversion. Where a native API expects a JavaScript object — React style objects included — hand it one: `:style #js {:transform "translateX(4px)"}`.
+- **Children** are trailing ReactNode values. Nest with [`n/$`](glossary.md#n-dollar); collections must already be valid React children, normally a JavaScript array (`(into-array (map row-el rows))`, each element carrying its `:key`). The grammar refuses `:children` inside the props map — there is one child channel.
 - **`:key` and `:ref`** use the ordinary React slots. Two source keys that normalize to the same slot — for example `:class` and `"className"` in one map — refuse rather than let map order pick a winner.
 
 !!! warning "Dynamic props must be marked"
@@ -103,20 +103,20 @@ The authoring shape is deliberately small:
 
     ```clojure
     ;; Don't: a dynamic map in second position is a CHILD, not props.
-    (let [cell-props {:class "px" :dir "ltr"}]
-      (n/$ :td cell-props px))   ;; refuses — a map is not a valid React child,
-                                 ;; and the recovery names (n/props …)
+    (let cell-props {:class "px" :dir "ltr"}]
+      ([n/$](glossary.md#n-dollar) :td cell-props px))   ;; refuses — a map is not a valid React child,
+                                 ;; and the recovery names ([n/props](glossary.md#nprops) …)
 
-    ;; Do: mark the operand. n/props emits no wrapper — it only classifies.
-    (let [cell-props {:class "px" :dir "ltr"}]
-      (n/$ :td (n/props cell-props) px))
+    ;; Do: mark the operand. [n/props](glossary.md#nprops) emits no wrapper — it only classifies.
+    (let cell-props {:class "px" :dir "ltr"}]
+      ([n/$](glossary.md#n-dollar) :td ([n/props](glossary.md#nprops) cell-props) px))
     ```
 
-    A dynamic ClojureScript map inside `n/props` converts shallowly under the same slot-name rule; a JavaScript object passes by identity.
+    A dynamic ClojureScript map inside [`n/props`](glossary.md#nprops) converts shallowly under the same slot-name rule; a JavaScript object passes by identity.
 
-## Rung 4 — a named native island
+## Rung 4 — a named [native island](glossary.md#native-island)
 
-When the cost owner is not lowering but *behavior* — hooks, a retained vendor widget, React reconciliation itself, or work that runs per animation frame — the answer is a named, top-level native component. The self-contained route is `n/defcomponent`. UIx is an equally supported, mature route. A JavaScript or TypeScript component enters through the host bridge ([Interop](09-interop.md)). Every route stays inside the same React root, the same frame context, and the same state owner. An island is a place, not a second architecture.
+When the cost owner is not [lowering](glossary.md#lowering) but *behavior* — hooks, a retained vendor widget, React reconciliation itself, or work that runs per animation frame — the answer is a named, top-level native component. The self-contained route is [`n/defcomponent`](glossary.md#ndefcomponent). UIx is an equally supported, mature route. A JavaScript or TypeScript component enters through the host bridge ([Interop](09-interop.md)). Every route stays inside the same React root, the same frame context, and the same state owner. An island is a place, not a second architecture.
 
 Here is a column-resize handle. Pointer movement is 120 Hz mechanics — host-private, not an application fact. It stays in local React state, and app-db receives exactly one write, on release ([Ephemeral state](11-ephemeral-state.md)):
 
@@ -154,17 +154,17 @@ Here is a column-resize handle. Pointer movement is 120 Hz mechanics — host-pr
 What this teaches, piece by piece:
 
 - **The ABI is one raw JavaScript props object** — read it with `.-col`; children arrive at `.-children`. There is no hidden map allocation, and no second "fast" ABI anywhere in the tier.
-- **A declaration map before the argument vector carries the server policy** — `{:server :render}` or `{:server :client-only}`. Omit it and the policy is Client-only, which is exactly right for a pointer-driven widget.
-- **Ordinary React hooks are used directly.** `react/useState`, `react/useEffect`, refs — React's surface, React's rules. Hicasso adds no hook wrappers here.
-- **`n/use-sub` and `n/use-frame` join the frame you were already in.** The first reads a subscription under the current frame and re-renders the island when the value changes. The second is frame capture in hook position. It returns the frame-locked ops map — `{:frame :dispatch :dispatch-sync :subscribe}` — and the map is reference-stable across re-renders. It is therefore safe to pull `:dispatch` off it and close over it in callbacks.
+- **A declaration map before the argument vector carries the [server policy](glossary.md#server-policy)** — `{:server :render}` or `{:server :client-only}`. Omit it and the policy is Client-only, which is exactly right for a pointer-driven widget.
+- **Ordinary React hooks are used directly.** `react/useState`, `react/useEffect`, refs — React's surface, React's rules. [Hicasso](glossary.md#hicasso) adds no hook wrappers here.
+- **[`n/use-sub`](glossary.md#nuse-sub) and [`n/use-frame`](glossary.md#nuseframe) join the frame you were already in.** The first reads a subscription under the current frame and re-renders the island when the value changes. The second is frame capture in hook position. It returns the frame-locked ops map — `{:frame :dispatch :dispatch-sync :subscribe}` — and the map is reference-stable across re-renders. It is therefore safe to pull `:dispatch` off it and close over it in callbacks.
 - **High-rate work never touches app-db.** The drag guide tracks the pointer through local React state; the component dispatches the single committed fact — the final width — once, on release.
 
 The two read doors deserve one table, because they look similar but obey different laws:
 
 | Door | Lives in | Rules |
 |---|---|---|
-| `h/sub` | Hicasso bodies | Direct synchronous body only; branches, loops, and plain helpers are fine; not a hook |
-| `n/use-sub` | Native components | A real React hook; the rules of hooks apply — top level of the component, unconditional |
+| [`h/sub`](glossary.md#hsub) | Hicasso bodies | Direct synchronous body only; branches, loops, and plain helpers are fine; not a hook |
+| [`n/use-sub`](glossary.md#nuse-sub) | Native components | A real React hook; the rules of hooks apply — top level of the component, unconditional |
 
 ### Mounting the island
 
@@ -177,17 +177,17 @@ From interpreted hiccup, you mount an island behind the named host seam. Declare
 [:th {:class "px"} "Price" [resize-handle {:col :px}]]
 ```
 
-From native code, a component is a head as-is: `(n/$ col-resizer {:col :px})`. Both directions cross under the same root and frame. The one-off raw element escape also exists ([Interop](09-interop.md)), but it is for migration and for true one-off interop. Repeated or hot crossings deserve a name, a declaration, and tests — which is what `defhost` gives you.
+From native code, a component is a head as-is: `(n/$ col-resizer {:col :px})`. Both directions cross under the same root and frame. The one-off raw element escape also exists ([Interop](09-interop.md)), but it is for migration and for true one-off interop. Repeated or hot crossings deserve a name, a declaration, and tests — which is what [`defhost`](glossary.md#defhost) gives you.
 
 !!! note "Islands and the server"
-    An intrinsic `n/$` return renders on the server like the hiccup it replaced. A component-headed island defaults to Client-only — a source-located refusal with a deterministic fallback — until its declaration selects `{:server :render}` and proves matching hydration. [SSR and hydration](17-ssr-and-hydration.md) owns the full contract.
+    An intrinsic [`n/$`](glossary.md#n-dollar) return renders on the server like the hiccup it replaced. A component-headed island defaults to Client-only — a source-located refusal with a deterministic fallback — until its declaration selects `{:server :render}` and proves matching hydration. [SSR and hydration](17-ssr-and-hydration.md) owns the full contract.
 
 ??? info "If your team already writes UIx"
-    Everything above has a UIx spelling, and it is not a second-class one. A `defview` at rung 3 may return a `uix.core/$` element, and an island at rung 4 may be a `defui`. The native hooks are substrate-neutral, so `n/use-sub` and `n/use-frame` work inside a `defui` exactly as inside `n/defcomponent`. The Hicasso-native surface is held to parity against both handwritten React and UIx, so the choice is taste and scale, not speed. Two instincts need correction. First, `n/*` is not UIx-lite and never imports UIx: a Hicasso app without UIx islands ships zero UIx bytes. Second, when a native region grows into substantial React-first work, UIx is the designed answer, not a defeat — the native namespace is deliberately too small to be a component framework.
+    Everything above has a UIx spelling, and it is not a second-class one. A [`defview`](glossary.md#defview) at rung 3 may return a `uix.core/$` element, and an island at rung 4 may be a `defui`. The native hooks are substrate-neutral, so [`n/use-sub`](glossary.md#nuse-sub) and [`n/use-frame`](glossary.md#nuseframe) work inside a `defui` exactly as inside [`n/defcomponent`](glossary.md#ndefcomponent). The Hicasso-native surface is held to parity against both handwritten React and UIx, so the choice is taste and scale, not speed. Two instincts need correction. First, `n/*` is not UIx-lite and never imports UIx: a [Hicasso](glossary.md#hicasso) app without UIx islands ships zero UIx bytes. Second, when a native region grows into substantial React-first work, UIx is the designed answer, not a defeat — the native namespace is deliberately too small to be a component framework.
 
 ## Keeping the marker: the ABI helpers
 
-`n/defcomponent` stamps its component with stable identity, source and display metadata, and HMR conduct — the marker. The marker lets Xray name the boundary, lets hot reload replace the implementation without remounting the island, and lets the embedding seams recognize the head. Raw React wrappers erase it:
+[`n/defcomponent`](glossary.md#ndefcomponent) stamps its component with stable identity, source and display metadata, and HMR conduct — the marker. The marker lets Xray name the [boundary](glossary.md#boundary), lets hot reload replace the implementation without remounting the island, and lets the embedding seams recognize the head. Raw React wrappers erase it:
 
 ```clojure
 ;; given (n/defcomponent quote-cell* …) — a pure display cell worth memoizing:
@@ -200,7 +200,7 @@ From native code, a component is a head as-is: `(n/$ col-resizer {:col :px})`. B
 (def quote-cell (n/memo quote-cell*))
 ```
 
-`n/memo` and `n/lazy` carry the one props/children ABI through memoization and code-split loading. Refs need no helper: `:ref` uses React's ordinary slot, and a function component receives it through props. The same preservation applies to the two embedding directions: hiccup rendering an island (above), and a native parent rendering a minted Hicasso view through the outward bridge ([Interop](09-interop.md)).
+[`n/memo`](glossary.md#nmemo) and [`n/lazy`](glossary.md#nlazy) carry the one props/children ABI through memoization and code-split loading. Refs need no helper: `:ref` uses React's ordinary slot, and a function component receives it through props. The same preservation applies to the two embedding directions: hiccup rendering an island (above), and a native parent rendering a minted [Hicasso](glossary.md#hicasso) view through the [outward bridge](glossary.md#outward-bridge) ([Interop](09-interop.md)).
 
 ## Rung 5 — a native screen
 
@@ -208,16 +208,16 @@ Some screens are React-shaped from their first commit — a canvas editor, a dia
 
 ## Every crossing runs the loop
 
-The numbered working loop — reproduce, attribute with Xray, tune topology first, then compare an escape and keep it only if it passes the benefit rule — is [Performance](18-performance.md)'s method. Every rung on this page is entered through it: rung 3 when attribution names lowering, rung 4 when it names hooks, vendor behavior, reconciliation, or high-rate local work. What this page adds is the follow-through a crossing owes. Re-run the contracts you can no longer see — DOM and intent parity, focus and selection, frame routing, SSR and hydration, cleanup, and the performance script — before you call the escape done.
+The numbered working loop — reproduce, attribute with Xray, tune topology first, then compare an escape and keep it only if it passes the benefit rule — is [Performance](18-performance.md)'s method. Every rung on this page is entered through it: rung 3 when attribution names [lowering](glossary.md#lowering), rung 4 when it names hooks, vendor behavior, reconciliation, or high-rate local work. What this page adds is the follow-through a crossing owes. Re-run the contracts you can no longer see — DOM and [intent](glossary.md#intent) parity, focus and selection, frame routing, SSR and hydration, cleanup, and the performance script — before you call the escape done.
 
-Xray stays honest on both sides of the fence. It names and times the native boundary, it shows the reads made through `n/use-sub`, and it labels the inner React tree *opaque* — a real answer, never a silently empty one. The advisor may recommend a boundary and scaffold a comparison. It never rewrites your code, and nothing ever switches semantics at runtime.
+Xray stays honest on both sides of the fence. It names and times the native [boundary](glossary.md#boundary), it shows the reads made through [`n/use-sub`](glossary.md#nuse-sub), and it labels the inner React tree *opaque* — a real answer, never a silently empty one. The advisor may recommend a boundary and scaffold a comparison. It never rewrites your code, and nothing ever switches semantics at runtime.
 
 ## When not to go native
 
 - **You have no named measurement.** "The app feels slow" is almost always a rung-1 or rung-2 problem underneath. No profile, no escape.
-- **The owner is read topology.** On the worst mounts we have measured, most of the deficit was read shape — too many fine per-row subscriptions — not the hiccup walk. That fix is [Lists and collections](06-lists-and-collections.md), and it keeps every convenience the fence would cost you.
+- **The owner is [read topology](glossary.md#read-topology).** On the worst mounts we have measured, most of the deficit was read shape — too many fine per-row subscriptions — not the hiccup walk. That fix is [Lists and collections](06-lists-and-collections.md), and it keeps every convenience the fence would cost you.
 - **The problem is typing latency.** Keystroke echo is an event-volume and controlled-field question ([Controlled inputs](04-controlled-inputs.md), [Performance](18-performance.md)); native construction does not move it.
-- **A controlled field is involved.** The native tier has no controlled repair — same-turn convergence, caret and IME preservation, and `::h/revision` live on the hiccup side. Fields stay interpreted.
+- **A [controlled field](glossary.md#controlled-field) is involved.** The [native tier](glossary.md#native-tier) has no controlled repair — same-turn convergence, caret and IME preservation, and [`::h/revision`](glossary.md#hrevision) live on the hiccup side. Fields stay interpreted.
 - **You want rung 4 "for consistency".** One island is an escape; islands everywhere is a rewrite of the product you chose. The 2% is a set of local islands, not a general style.
 
 ## Troubleshooting
@@ -225,10 +225,10 @@ Xray stays honest on both sides of the fence. It names and times the native boun
 | Symptom | What is happening | Fix |
 |---|---|---|
 | Refusal: a ClojureScript map appeared as a React child | A dynamic map in the props position is classified as a child — the grammar only recognizes `nil`, literal maps, `#js` literals, and `(n/props …)` as props | Mark it: `(n/$ :td (n/props m) …)` |
-| Refusal on a vector child inside `n/$` | Hiccup is not interpreted past the fence — square brackets have no meaning in native children | Convert explicitly with `h/as-element`, or keep that subtree interpreted |
-| Refusal: event vector in a native prop (`:on-click [:x/select id]`) | No intent lowering past the fence — native callbacks are functions | `(h/event [_] [:x/select id])` in a rung-3 body; `:dispatch` from `n/use-frame` inside an island |
+| Refusal on a vector child inside [`n/$`](glossary.md#n-dollar) | Hiccup is not interpreted past the fence — square brackets have no meaning in native children | Convert explicitly with [`h/as-element`](glossary.md#as-element), or keep that subtree interpreted |
+| Refusal: event vector in a native prop (`:on-click [:x/select id]`) | No [intent](glossary.md#intent) [lowering](glossary.md#lowering) past the fence — native callbacks are functions | `(h/event [_] [:x/select id])` in a rung-3 body; `:dispatch` from [`n/use-frame`](glossary.md#nuseframe) inside an island |
 | Refusal: `:children` in the props map | There is one child channel — trailing forms | Pass children after the props operand |
 | Refusal: two keys normalize to one slot (`:class` and `"className"`) | Canonical-slot collision — the grammar refuses rather than letting map order pick a winner | Keep one spelling per slot |
-| `:rf.error/no-frame-context` from `n/use-sub` or `n/use-frame` | The island rendered outside any frame provider — a separate root, a portal outside the app, or a test without the harness | Mount under the app root, or use the test kit's provider ([Testing](14-testing.md)) |
-| Xray shows an anonymous boundary; HMR remounts the island | The component marker was erased by a raw wrapper (`react/memo`, `React.lazy`) | Use `n/memo` / `n/lazy` — same semantics, marker intact |
+| `:rf.error/no-frame-context` from [`n/use-sub`](glossary.md#nuse-sub) or [`n/use-frame`](glossary.md#nuseframe) | The island rendered outside any frame provider — a separate root, a [portal](glossary.md#portal) outside the app, or a test without the harness | Mount under the app root, or use the [test kit](glossary.md#test-kit)'s provider ([Testing](14-testing.md)) |
+| Xray shows an anonymous [boundary](glossary.md#boundary); HMR remounts the island | The component marker was erased by a raw wrapper (`react/memo`, `React.lazy`) | Use [`n/memo`](glossary.md#nmemo) / [`n/lazy`](glossary.md#nlazy) — same semantics, marker intact |
 | Went native, numbers did not move | The cost owner was never construction — usually reads or event volume | Back to loop step 2; expect the fix at rung 2, and take the unearned escape out |

--- a/docs/design/hicasso/draft-guide/10-native-tier.md
+++ b/docs/design/hicasso/draft-guide/10-native-tier.md
@@ -1,4 +1,4 @@
-# The [native tier](glossary.md#native-tier)
+# The native tier
 
 Most applications never need this page. Ordinary [Hicasso](glossary.md#hicasso) — interpreted hiccup, [`h/sub`](glossary.md#hsub) where you read, events as data — is the product, and it is the right choice for roughly 98% of the view code you will ever write. This page is for the other 1–2%: the row that repaints on every market tick, the drag handle that tracks a pointer at display rate, the vendor widget with hooks at its core. For that code Hicasso keeps an explicit exit to native React. Take it and you write React directly — direct element construction, real hooks, full native speed — and your frame, your app-db, and your React root all come with you.
 
@@ -80,7 +80,7 @@ The whole fence fits in one table. The left column is why rung 3 is cheap to ado
 
 Two consequences deserve their own sentences. First, form fields stay interpreted. An `<input>` inside [`n/$`](glossary.md#n-dollar) is a raw React [controlled input](glossary.md#controlled-field): you do all of React's manual controlled-input work, and you get none of [Hicasso](glossary.md#hicasso)'s caret, IME, or same-turn guarantees ([Controlled inputs](04-controlled-inputs.md)). Second, hooks still do not belong in the body. A [`defview`](glossary.md#defview) body is dynamically composed — branches and loops are legal, and that is exactly the environment where hook order breaks. The wish for a hook in a `defview` body is the signal that you are at rung 4, not rung 3.
 
-### The [`n/$`](glossary.md#n-dollar) grammar
+### The `n/$` grammar
 
 The authoring shape is deliberately small:
 
@@ -114,7 +114,7 @@ The authoring shape is deliberately small:
 
     A dynamic ClojureScript map inside [`n/props`](glossary.md#nprops) converts shallowly under the same slot-name rule; a JavaScript object passes by identity.
 
-## Rung 4 — a named [native island](glossary.md#native-island)
+## Rung 4 — a named native island
 
 When the cost owner is not [lowering](glossary.md#lowering) but *behavior* — hooks, a retained vendor widget, React reconciliation itself, or work that runs per animation frame — the answer is a named, top-level native component. The self-contained route is [`n/defcomponent`](glossary.md#ndefcomponent). UIx is an equally supported, mature route. A JavaScript or TypeScript component enters through the host bridge ([Interop](09-interop.md)). Every route stays inside the same React root, the same frame context, and the same state owner. An island is a place, not a second architecture.
 

--- a/docs/design/hicasso/draft-guide/11-ephemeral-state.md
+++ b/docs/design/hicasso/draft-guide/11-ephemeral-state.md
@@ -3,7 +3,7 @@
 Is this dropdown open? Is this row selected? Where do the half-typed draft, the
 in-flight drag position, and the vendor SDK handle go?
 
-In Reagent you use `r/atom`. In React you use `useState`. Hicasso has neither:
+In Reagent you use `r/atom`. In React you use `useState`. [Hicasso](glossary.md#hicasso) has neither:
 no component-local reactive cell, no local-state tier. These cells are not
 discouraged; they do not exist. Most of the "local state" a view layer teaches
 you to want came from machinery Hicasso does not have — reaction capture, argv
@@ -24,8 +24,8 @@ click, mount a component, or start a timer. The full open/close/dismiss policy
 of a widget is provable headlessly ([Testing](14-testing.md)). A private cell
 would move every one of those tests into a browser.
 
-**Xray can attribute work.** The causal lens runs *event → subscriptions →
-boundaries → commit → paint*. Every re-render has a cause that Xray can name,
+**Xray can attribute work.** The [causal lens](glossary.md#causal-lens) runs *event → subscriptions →
+[boundaries](glossary.md#boundary) → commit → paint*. Every re-render has a cause that Xray can name,
 because every application write goes through the one write clock: the
 re-frame2 state commit. A second reactive store invalidates views on a clock
 Xray cannot see. That work has no cause, permanently
@@ -105,9 +105,9 @@ spend an event, a subscription pass, and a paint per pointer-move on a fact
 with no meaning.
 
 That state stays **inside a native host** — a named native component (or a
-`defhost` edge) where ordinary React state and hooks are the correct tool
+[`defhost`](glossary.md#defhost) edge) where ordinary React state and hooks are the correct tool
 ([The native tier](10-native-tier.md), [Interop](09-interop.md)). The host is
-**diagnostic-opaque by contract**. Xray names and times the island's boundary.
+**diagnostic-opaque by contract**. Xray names and times the island's [boundary](glossary.md#boundary).
 It labels the inside `opaque`; it does not pretend to know it. You trade
 visibility for locality, on purpose, in a fenced place.
 
@@ -141,11 +141,11 @@ The law at the edge: *motion stays inside; meaning leaves as one event.*
                        :on-drop (h/event [col] [:card/dropped id col])})))
 ```
 
-The drop is semantic, so it commits. `h/event` captures the frame and
+The drop is semantic, so it commits. [`h/event`](glossary.md#hevent) captures the frame and
 dispatches `[:card/dropped id col]` when the host calls the callback. The end
 of a drag reaches app-db. The moves of a drag do not.
 
-One boundary rule applies. A `defview` body is a real React function
+One [boundary](glossary.md#boundary) rule applies. A [`defview`](glossary.md#defview) body is a real React function
 component, so a hook physically runs there. But dynamic composition makes
 hook order your problem, and a hook body falls out of headless testing. Hook
 mechanics belong in a separately defined native component, where hook order
@@ -227,17 +227,17 @@ server HTML never carries entry-phase attributes
 |---|---|---|
 | Dropdown open | App-db, explicit address (the [overlay module](12-overlays-and-focus.md) reconciles the platform to it) | It changes what the user can do next; tests and Xray need it |
 | Draft text in a field | App-db through the [forms module](05-forms.md) | Validation, submit gating, dirty-leave and replay all read it |
-| Drag position, mid-drag | Host-private, inside the native island | 60–240 Hz mechanics; only the widget cares. The drop dispatches one event |
+| Drag position, mid-drag | Host-private, inside the [native island](glossary.md#native-island) | 60–240 Hz mechanics; only the widget cares. The drop dispatches one event |
 | Scroll offset | The DOM owns it; the [routing module](07-routing-and-navigation.md) restores it per route | Nobody re-renders per scrolled pixel. If the app cares ("read 80%"), commit thresholds as events |
 | Animation phase | CSS for the animation itself; `motion/presence` for leave-retention; host-private for rAF mechanics | App-db says what is true, not what is still painted |
-| Focus | The platform. One-shot intent as data — `:auto-focus`, [overlay focus conduct](12-overlays-and-focus.md) — never mirrored | A mirror of "what has focus" drifts from reality and re-renders per Tab |
+| Focus | The platform. One-shot [intent](glossary.md#intent) as data — `:auto-focus`, [overlay focus conduct](12-overlays-and-focus.md) — never mirrored | A mirror of "what has focus" drifts from reality and re-renders per Tab |
 | Selected tab | App-db — or the route, when a reload should land on the same tab | Semantic; other views, tests and deep links care |
 | WebGL context, vendor handle | Host-private, inside its declared host, acquired and released at the edge ([Interop](09-interop.md)) | An object identity, not application data; unmount must release it |
 
 ## Choosing the address
 
 Valves 1 and 2 need an instance key — the `panel-id` above — so a hundred
-panels do not share one `expanded?`. Hicasso mints no identity for you.
+panels do not share one `expanded?`. [Hicasso](glossary.md#hicasso) mints no identity for you.
 React's `useId` does not fit: its ids are render-order counters, they do not
 survive a remount, and address-resident state cannot tolerate that loss. The
 key is authored data: a keyword, a string, a number, or a flat vector of
@@ -300,7 +300,7 @@ exactly one memory.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| Reaching for `useState` / `r/atom` to hold "is this open?" | Application-visible state headed for a private store | An app-db address (valve 1), or the overlay module's reconciled flag |
+| Reaching for `useState` / `r/atom` to hold "is this open?" | Application-visible state headed for a private store | An app-db address (valve 1), or the [overlay](glossary.md#overlay) module's reconciled flag |
 | A view's atom resets every render, or never repaints | Bodies re-run and are abandoned; render-minted cells are re-minted, and nothing tracks them | Move the fact to its valve; if it is genuinely widget mechanics, move it into a native host |
 | Searching for `:on-mount`, `componentDidMount`, a mount `useEffect` | There is none | Name the job and use its home — the table above |
 | Every panel in a list opens at once | One shared address | Key the address per instance — [Choosing the address](#choosing-the-address) |
@@ -312,7 +312,7 @@ exactly one memory.
 | A test simulates clicks to open a dropdown | The state is data | Seed the address with a `:db` write ([Testing](14-testing.md)) |
 
 ??? info "If you're coming from Reagent"
-    `r/atom` was necessary against machinery Hicasso does not have. In the
+    `r/atom` was necessary against machinery [Hicasso](glossary.md#hicasso) does not have. In the
     idiomatic corpus this model was distilled from — 85 files, ~140 views —
     the count of view-local reactive cells is zero. The machinery
     manufactured the demand. The valves absorb what was real: addresses for

--- a/docs/design/hicasso/draft-guide/12-overlays-and-focus.md
+++ b/docs/design/hicasso/draft-guide/12-overlays-and-focus.md
@@ -1,9 +1,9 @@
 # Overlays and focus
 
 You need a filter menu anchored to its button, and a delete confirmation that
-blocks the page behind it. The classic build — a portal, a z-index ladder, a
+blocks the page behind it. The classic build — a [portal](glossary.md#portal), a z-index ladder, a
 document click listener, hand-rolled focus management — leaks and breaks in
-known ways. `re-frame.hicasso.overlay` gives you two primitives, popover and
+known ways. `re-frame.hicasso.overlay` gives you two primitives, [popover](glossary.md#overlay) and
 modal, that mount on the browser's **native top layer** (`popover` /
 `<dialog>`). The platform owns stacking, dismissal, and focus. Your app owns
 exactly one thing: the data.
@@ -51,11 +51,11 @@ The caller owns the open flag, as ordinary state at an address
 
 What the module does with those four options:
 
-- **`:open?` is the one owner.** While the flag is false, the popover renders
+- **`:open?` is the one owner.** While the flag is false, the [popover](glossary.md#overlay) renders
   *nothing*: no DOM node, no listener, and the body's reads never run. When
   the flag goes true, the panel mounts directly onto the top layer. There the
   panel sits above every stacking context, and no ancestor `overflow: hidden`
-  or `transform` can affect it. There is no portal and no z-index anywhere.
+  or `transform` can affect it. There is no [portal](glossary.md#portal) and no z-index anywhere.
 - **`:on-dismiss` is how the platform reports.** Outside click and Esc are
   the popover's native light-dismiss. There is no document listener. The
   browser closes the panel, and the module dispatches your event. Your
@@ -75,7 +75,7 @@ What the module does with those four options:
 
 ## A modal
 
-A modal has the same shape and stronger conduct. `overlay/modal` drives a
+A [modal](glossary.md#overlay) has the same shape and stronger conduct. `overlay/modal` drives a
 native `<dialog>` through `showModal`, and that call is the source of the
 focus contract:
 
@@ -106,11 +106,11 @@ focus contract:
 ## Focus is a one-shot intent
 
 Focus is platform state. You never mirror "what has focus" into app-db
-([Ephemeral state](11-ephemeral-state.md)). What you *can* express is intent,
+([Ephemeral state](11-ephemeral-state.md)). What you *can* express is [intent](glossary.md#intent),
 as data, exactly once per open:
 
 - **Mount focus.** Put `:auto-focus true` on the element that must receive
-  focus when the overlay opens — the Delete button above, or the search field
+  focus when the [overlay](glossary.md#overlay) opens — the Delete button above, or the search field
   in a command palette. The attribute fires when the overlay opens, never
   again on a re-render, and it is inert markup on the server. A modal with no
   `:auto-focus` focuses the dialog itself. A popover leaves focus on the
@@ -125,7 +125,7 @@ as data, exactly once per open:
 
 A popover can sit inside a modal, and a submenu inside a menu. The native top
 layer is a stack, so nesting is last-in-first-out by construction. Esc closes
-only the innermost open overlay. An outside click on an inner popover
+only the innermost open [overlay](glossary.md#overlay). An outside click on an inner popover
 light-dismisses that popover and does not touch the modal under it. Your side
 of the contract is one address and one `:on-dismiss` per overlay. If two
 overlays share one dismiss event, you rebuild the problem the stack solves.
@@ -142,13 +142,13 @@ A closed overlay costs nothing. Not a small amount — nothing:
   overlay, restores focus, and leaves zero residue.
 
 A table of five hundred rows, each with a closed row-menu, is exactly as
-heavy as the same table without menus. Design with overlays freely; you pay
+heavy as the same table without menus. Design with [overlays](glossary.md#overlay) freely; you pay
 only for the open one.
 
 ## Compose a dropdown from the popover
 
 Dropdowns, comboboxes, and toggletips are not separate primitives. Each is
-the popover plus your own semantics as ordinary events and subs. Here is a
+the [popover](glossary.md#overlay) plus your own semantics as ordinary events and subs. Here is a
 single-select with full keyboard support:
 
 ```clojure
@@ -215,11 +215,11 @@ Note what is *not* here:
   the panel and `:on-dismiss` fires;
 - no focus moves — focus stays on the trigger;
 - no document listener;
-- no portal.
+- no [portal](glossary.md#portal).
 
 The whole open/move/commit/dismiss policy is events over an address. A test
 can prove the policy headlessly and seed it directly, and Xray shows it. A
-toggletip — a click-to-open rich hint — is the same popover with a single
+toggletip — a click-to-open rich hint — is the same [popover](glossary.md#overlay) with a single
 dismiss event and no listbox.
 
 ## When you don't need the module
@@ -233,7 +233,7 @@ placement and focus conduct.
   of hover through any state system costs a re-render per pointer-move.
 - **Disclosure is `<details>`.** The platform tracks open; the triangle
   costs nothing.
-- **A presentational hint can be a bare popover.** `[:button {:popovertarget "help-tip"} "?"]`
+- **A presentational hint can be a bare [popover](glossary.md#overlay).** `[:button {:popovertarget "help-tip"} "?"]`
   with `[:div {:id "help-tip" :popover "auto"} …]` — the browser does
   everything, and the app never knows. That is DOM-owned state as a declared
   choice ([Ephemeral state](11-ephemeral-state.md)). When a test or another
@@ -269,7 +269,7 @@ leak, no stacking context to lose to, no z-index contest.
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | Panel clipped by `overflow: hidden` or stuck under a sticky header | The panel is an in-flow positioned div, not on the top layer | Render it through `overlay/popover` |
-| Outside click closes the popover but it re-opens | Light-dismiss fired and `:on-dismiss` was dispatched, but the handler never wrote the flag — the module re-shows to match the owner | Make the `:on-dismiss` handler set open to false |
+| Outside click closes the [popover](glossary.md#overlay) but it re-opens | Light-dismiss fired and `:on-dismiss` was dispatched, but the handler never wrote the flag — the module re-shows to match the owner | Make the `:on-dismiss` handler set open to false |
 | Esc closes the whole stack at once | The layers share one dismiss event or one address | One address and one `:on-dismiss` per overlay; the platform unwinds innermost-first |
 | Focus lands on `<body>` after close | The opener unmounted while the overlay was open — usually unstable list keys remounting the trigger | Stable `:key` on the trigger's row; restore targets the element focused at open, if it still exists |
 | `:rf.error/hicasso-overlay-anchor-missing` at open | `:anchor` names an id that is not in the document — or two instances share one id | Per-instance anchor ids: `(str "combo-" id "-trigger")` |
@@ -278,7 +278,7 @@ leak, no stacking context to lose to, no z-index contest.
 | Every row's menu opens at once | One shared address | Key the address per instance ([Ephemeral state](11-ephemeral-state.md#choosing-the-address)) |
 
 ??? info "If you're coming from Reagent or UIx"
-    The instinct is a portal + z-index + floating-ui + a `with-let` document
+    The instinct is a [portal](glossary.md#portal) + z-index + floating-ui + a `with-let` document
     listener. Here the panel never leaves its place in the tree — the top
     layer changes *paint* order, not *tree* order. So frame context,
     subscriptions, SSR, and hydration need no special path, and light-dismiss

--- a/docs/design/hicasso/draft-guide/13-theming-and-i18n.md
+++ b/docs/design/hicasso/draft-guide/13-theming-and-i18n.md
@@ -2,7 +2,7 @@
 
 You want a dark mode and a second language. In most React stacks each arrives
 with machinery: a ThemeProvider, an i18n context, a hook per consumer.
-Hicasso ships neither, because neither job needs adapter support. Tokens live
+[Hicasso](glossary.md#hicasso) ships neither, because neither job needs adapter support. Tokens live
 in CSS, strings are ordinary values, and the current choice — theme or locale
 — is one key in app-db that ordinary subs read.
 
@@ -33,7 +33,7 @@ is a subtree, and the mechanism is platform-native. Put your tokens on
 }
 ```
 
-The `--app-*` prefix is not Hicasso's. Name your custom properties the way
+The `--app-*` prefix is not [Hicasso](glossary.md#hicasso)'s. Name your custom properties the way
 your stylesheet already does. `:root` *is* the light theme, so nobody writes
 a `[data-theme="light"]` block.
 
@@ -80,12 +80,12 @@ Three placement details carry the rest:
   element and nothing above it, so `data-theme` goes on `theme-scope`'s own
   `div`. That is what frame isolation needs. Two frames on one page, one
   light and one dark, is an ordinary page.
-- **Keep a `defview` head immediately below the scope.** The scope re-renders
-  on every switch — one boundary, a known cost. `[app {}]` below the scope
+- **Keep a [`defview`](glossary.md#defview) head immediately below the scope.** The scope re-renders
+  on every switch — one [boundary](glossary.md#boundary), a known cost. `[app {}]` below the scope
   bails out, because `app` is a `defview` and its props are unchanged
   ([Views and reads](02-views-and-reads.md)). A native-tag subtree, or a view
   called as a plain function, in that position re-runs with the scope.
-- **Keep the scope at the frame's root, above any `defhost` crossing.** On
+- **Keep the scope at the frame's root, above any [`defhost`](glossary.md#defhost) crossing.** On
   the server, a Client-only crossing renders its fallback instead of its
   subtree. A scope below such a crossing is absent from the response,
   together with everything the scope covered
@@ -126,7 +126,7 @@ cosmetic:
     (.setAttribute js/document.documentElement "data-page-theme" (name theme))))
 ```
 
-The top layer needs no echo. An overlay's `::backdrop` pseudo-element
+The top layer needs no echo. An [overlay](glossary.md#overlay)'s `::backdrop` pseudo-element
 inherits custom properties from the element that opened it, so a modal opened
 inside `theme-scope` takes the scope's tokens. Style the backdrop with the
 same variables ([Overlays and focus](12-overlays-and-focus.md)).
@@ -201,7 +201,7 @@ provider with a hook per consumer — and the sub already is the provider.
 
 A component library that themes itself through React context gets its
 provider the way any foreign component arrives: declared once with
-`h/defhost`, used as an ordinary head, with children lowered where they
+[`h/defhost`](glossary.md#defhost), used as an ordinary head, with children lowered where they
 render ([Interop](09-interop.md)).
 
 ```clojure
@@ -231,7 +231,7 @@ the door; your own app's theming never needed context.
 |---|---|---|
 | Blank page on first load; console shows `Doesn't support name:` | Nobody had chosen a theme, the sub read `nil`, and `(name nil)` threw at the root | Give the sub a default: `(:theme/current db :light)` |
 | The theme key changes in app-db and nothing on screen changes | No view renders the attribute — the cascade keys off the DOM, not app-db | Mount `theme-scope` (or your equivalent) at the frame root |
-| Theme switch re-renders the whole app | What sits below the scope carries no boundary — a native-tag subtree, or a view called as a plain function | Keep a `defview` head immediately below the scope, as `[app {}]` is |
+| Theme switch re-renders the whole app | What sits below the scope carries no [boundary](glossary.md#boundary) — a native-tag subtree, or a view called as a plain function | Keep a [`defview`](glossary.md#defview) head immediately below the scope, as `[app {}]` is |
 | Locale switches but some strings stay in the old language | Those strings were captured once — in a `def`, a prop computed at load, a memoized helper — instead of read at render | Read strings where you use them: `(h/sub [:i18n/t k])` |
 | A missing translation renders as the key's name | The sub's miss fallback, working as designed | Add the key to the table; the fallback names it so you can find it |
 | The hydrated page keeps the server's theme | The hydration payload did not carry the choice, and an attribute-only divergence is the one class React never reports | Carry `:theme/current` in the payload ([SSR and hydration](17-ssr-and-hydration.md)) |

--- a/docs/design/hicasso/draft-guide/14-testing.md
+++ b/docs/design/hicasso/draft-guide/14-testing.md
@@ -132,7 +132,7 @@ as a codec round-trip or the owned-wins attribute merge. When you own a
 you apply to mounted nodes when a claim compares two pages (mechanics under
 Advanced).
 
-## L2 — the [semantic harness](glossary.md#semantic-harness)
+## L2 — the semantic harness
 
 A [`defview`](glossary.md#defview) body is not directly callable. It needs a render extent to read
 in, and a direct call refuses with a source-located recovery. The harness
@@ -186,7 +186,7 @@ model, not a renderer. It refuses to fake the facts it does not have:
     keep the semantic half as data you can compare with `=`, and mount-test
     the mechanics once.
 
-## L3 — the [mounted facade](glossary.md#mounted-facade)
+## L3 — the mounted facade
 
 When the claim is about React or the DOM — lifecycle, hooks, a real error
 [boundary](glossary.md#boundary), real nodes — mount the view. The facade gives every test an
@@ -268,7 +268,7 @@ a dev-only dual mount. It drives a ported view and its Reagent original with
 one script, and it diffs [canonical DOM](glossary.md#canonical-dom) and [intent](glossary.md#intent) streams at every
 checkpoint. [Migrating from Reagent](19-migration-from-reagent.md) owns it.
 
-## The [sabotage twin](glossary.md#sabotage-control)
+## The sabotage twin
 
 An assertion that quantifies over a collection can pass because the
 collection was empty by accident — `every?` over nothing is vacuously true.

--- a/docs/design/hicasso/draft-guide/14-testing.md
+++ b/docs/design/hicasso/draft-guide/14-testing.md
@@ -1,17 +1,17 @@
 # Testing
 
 You have a feature to test. You must decide which tests to write, and how
-much machinery each test needs. In a Hicasso app, the answer is a ladder of
+much machinery each test needs. In a [Hicasso](glossary.md#hicasso) app, the answer is a ladder of
 five rungs, and most of the ladder runs without a browser. Handlers and
 subscriptions are plain functions. Markup helpers return plain data. View
-bodies run under a semantic harness with no DOM and no React — other view
+bodies run under a [semantic harness](glossary.md#semantic-harness) with no DOM and no React — other view
 layers make you mount them. The browser is the top rung. Keep it for the
 facts that only a browser knows.
 
 > **Test at the lowest rung that can prove the claim. Know which equality
 > that rung proves.**
 
-The test kit is one namespace, `re-frame.hicasso.test`. It is a supported
+The [test kit](glossary.md#test-kit) is one namespace, `re-frame.hicasso.test`. It is a supported
 product surface, not a loose collection of utilities. This page aliases it
 as `ht`.
 
@@ -20,9 +20,9 @@ as `ht`.
 | Rung | What it proves | Mechanism |
 |---|---|---|
 | **L0** | event handlers, subscriptions, state transitions | pure function calls |
-| **L1** | intents, prevent and navigate decisions, codecs, control and revision laws, native-form expansion | pure data, property, and macro-expansion tests |
-| **L2** | registered hook-free view bodies | the semantic harness — `ht/tree` under injected read fixtures |
-| **L3** | React lifecycle, hooks, context, refs, errors, hosts | the mounted facade, with Testing Library and user-event |
+| **L1** | [intents](glossary.md#intent), prevent and navigate decisions, codecs, control and revision laws, native-form expansion | pure data, property, and macro-expansion tests |
+| **L2** | registered hook-free view bodies | the [semantic harness](glossary.md#semantic-harness) — `ht/tree` under injected read fixtures |
+| **L3** | React lifecycle, hooks, context, refs, errors, hosts | the [mounted facade](glossary.md#mounted-facade), with Testing Library and user-event |
 | **L4** | IME, caret, focus, layout, hydration, performance | Chromium, Firefox, and WebKit |
 
 Each rung proves a different equality. L1 proves authored data. L2 proves
@@ -74,7 +74,7 @@ toggle.
 
 ## L0 — handlers and subscriptions are plain functions
 
-Nothing here is specific to Hicasso, and that is the point: the logic layer
+Nothing here is specific to [Hicasso](glossary.md#hicasso), and that is the point: the logic layer
 tests the same under every view layer. Take the handler from the registrar.
 Call it with literal values. Check the map it returns:
 
@@ -120,21 +120,21 @@ function. Call it. The whole assertion is `=`:
 
 The same method covers every data spelling in the product, because each
 spelling is a value in an attribute map that some function returned: an
-intent vector, a `::h/prevent` head, a route link's navigate decision. You
+[intent](glossary.md#intent) vector, a [`::h/prevent`](glossary.md#hprevent) head, a [route link](glossary.md#route-link)'s navigate decision. You
 never mount and click to learn what a button means. The meaning is a value
 that you compare.
 
 L1 is also the rung for property tests: laws that hold for all inputs, such
 as a codec round-trip or the owned-wins attribute merge. When you own a
-native island, `n/$` macro-expansion tests belong here too
+[native island](glossary.md#native-island), [`n/$`](glossary.md#n-dollar) macro-expansion tests belong here too
 ([Native tier](10-native-tier.md)). The canonical-DOM comparator,
 `ht/canonical-dom`, also lives at this rung. It is a pure serializer that
 you apply to mounted nodes when a claim compares two pages (mechanics under
 Advanced).
 
-## L2 — the semantic harness
+## L2 — the [semantic harness](glossary.md#semantic-harness)
 
-A `defview` body is not directly callable. It needs a render extent to read
+A [`defview`](glossary.md#defview) body is not directly callable. It needs a render extent to read
 in, and a direct call refuses with a source-located recovery. The harness
 supplies that extent without React. `ht/tree` invokes a registered hook-free
 body under a discardable read resolver — your fixtures — and returns a
@@ -157,7 +157,7 @@ versioned semantic tree. Four small helpers assert on the tree: `ht/find`,
     (is (= [[:todo/toggle 7]] (ht/intents tree)))))
 ```
 
-The fixtures replace the whole subscription layer. The body's `h/sub` calls
+The fixtures replace the whole subscription layer. The body's [`h/sub`](glossary.md#hsub) calls
 resolve against the map. The harness never touches the real cache, and it
 discards the resolver afterwards. Fixture identity is the same as sub
 identity — `(query-id, args)` under value equality — so `[:todo/by-id 7]`
@@ -172,7 +172,7 @@ subtree.
 model, not a renderer. It refuses to fake the facts it does not have:
 
 - A body (or expanded child) that reaches a **hook**, a **raw React
-  element**, an **`n/$` result**, or a **`defhost` crossing** refuses with a
+  element**, an **[`n/$`](glossary.md#n-dollar) result**, or a **[`defhost`](glossary.md#defhost) crossing** refuses with a
   structured, source-located complaint that points at L3. React facts belong
   to React.
 - A read with **no fixture** refuses and names the query. The harness never
@@ -186,10 +186,10 @@ model, not a renderer. It refuses to fake the facts it does not have:
     keep the semantic half as data you can compare with `=`, and mount-test
     the mechanics once.
 
-## L3 — the mounted facade
+## L3 — the [mounted facade](glossary.md#mounted-facade)
 
 When the claim is about React or the DOM — lifecycle, hooks, a real error
-boundary, real nodes — mount the view. The facade gives every test an
+[boundary](glossary.md#boundary), real nodes — mount the view. The facade gives every test an
 isolated frame (its own app-db, queue, and subscription cache), a real root,
 and a residue guarantee:
 
@@ -198,7 +198,7 @@ and a residue guarantee:
 | `ht/mount!` | mounts a view under a fresh isolated frame; records the residue baseline first; returns a handle |
 | `ht/hydrate!` | mounts by adopting server bytes ([SSR and hydration](17-ssr-and-hydration.md)) |
 | `ht/rerender!` | renders a new element into the same root — for props-change tests |
-| `ht/dispatch-and-settle!` | dispatches into the mount's frame and returns once Hicasso and React are quiescent |
+| `ht/dispatch-and-settle!` | dispatches into the mount's frame and returns once [Hicasso](glossary.md#hicasso) and React are quiescent |
 | `ht/settle!` | waits for quiescence after outside stimulation — a user-event pointer or keyboard sequence |
 | `ht/unmount!` | tears the root down |
 | `ht/assert-clean!` | after unmount: compares exact post-quiescence residue with the pre-mount baseline, then resets |
@@ -240,7 +240,7 @@ sequence, call `(ht/settle! m)` before you assert.
 
 Use L3 when the claim needs it:
 
-- a real error boundary that catches a real throw ([Errors](16-errors.md));
+- a real [error boundary](glossary.md#error-boundary) that catches a real throw ([Errors](16-errors.md));
 - StrictMode double-invoke, and renders that React abandoned;
 - keyed insert, delete, and reorder against real nodes;
 - a foreign component's hooks, context, or refs ([Interop](09-interop.md));
@@ -265,15 +265,15 @@ measurement discipline live in [Performance](18-performance.md).
 
 One more entry completes the kit: `ht/shadow!`, the migration harness. It is
 a dev-only dual mount. It drives a ported view and its Reagent original with
-one script, and it diffs canonical DOM and intent streams at every
+one script, and it diffs [canonical DOM](glossary.md#canonical-dom) and [intent](glossary.md#intent) streams at every
 checkpoint. [Migrating from Reagent](19-migration-from-reagent.md) owns it.
 
-## The sabotage twin
+## The [sabotage twin](glossary.md#sabotage-control)
 
 An assertion that quantifies over a collection can pass because the
 collection was empty by accident — `every?` over nothing is vacuously true.
 Two habits close that hole. First, pin the population with a count. Second,
-give an important test a **sabotage twin**: break the input deliberately and
+give an important test a **[sabotage twin](glossary.md#sabotage-control)**: break the input deliberately and
 confirm that the measurement moves. A moved measurement proves the
 instrument can fail.
 
@@ -304,21 +304,21 @@ instrument can fail.
 ```
 
 The kit's own release gates carry the same discipline: every important
-witness has a negative or sabotage control. A test that cannot fail
+witness has a negative or [sabotage control](glossary.md#sabotage-control). A test that cannot fail
 verifies nothing.
 
 ## Troubleshooting
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| `ht/tree` refuses, pointing at L3 | The body (or an expanded child) reaches a hook, raw React element, `n/$` result, or `defhost` crossing | Honest opacity, working as designed. Mount that view at L3; if you want L2 coverage for the rest, split the hook-free part into its own view or helper |
+| `ht/tree` refuses, pointing at L3 | The body (or an expanded child) reaches a hook, raw React element, [`n/$`](glossary.md#n-dollar) result, or [`defhost`](glossary.md#defhost) crossing | Honest opacity, working as designed. Mount that view at L3; if you want L2 coverage for the rest, split the hook-free part into its own view or helper |
 | `ht/tree` refuses, naming a query | A read the body made has no fixture | Add it. Fixture identity is `(query-id, args)` under value equality — the args must match exactly |
-| `:rf.error/hicasso-sub-outside-render` in a plain test | A reading helper was called with no render extent (a direct `defview` call refuses at the call itself, naming the view) | L2 supplies the extent; L0 targets handlers and subs, not bodies |
+| `:rf.error/hicasso-sub-outside-render` in a plain test | A reading helper was called with no render extent (a direct [`defview`](glossary.md#defview) call refuses at the call itself, naming the view) | L2 supplies the extent; L0 targets handlers and subs, not bodies |
 | `:rf.error/hicasso-deferred-read-at-boundary` | A stored closure, stashed lazy seq, or unforced `delay` carried a read past the render | Read during the body and close over the value ([Views and reads](02-views-and-reads.md)) |
 | `assert-clean!` fails after unmount | Something outlived the root — a retained subscription, listener, or scheduled task | A bug, not a tolerance: fix the leak. A foreign host retaining a callback is the common culprit ([Interop](09-interop.md)) |
 | Data-level test passes, mounted test fails | Real React does things data does not — effect order, StrictMode double-invoke, commit timing | The mounted result is the truth for lifecycle |
 | Assertion fails on a `nil` in a tree | A `when` produced `nil` — it renders nothing but is still in the data | Assert the `nil`, or filter before comparing |
-| A list test stays green with an empty list | Quantified assertion over an empty population | Pin the count; add the sabotage twin |
+| A list test stays green with an empty list | Quantified assertion over an empty population | Pin the count; add the [sabotage twin](glossary.md#sabotage-control) |
 
 ## When not to test through the view
 
@@ -361,7 +361,7 @@ attribute names sorted. `innerHTML` preserves insertion order, and two
 front ends write props in different orders — a comparison of `innerHTML`
 compares the serializer, not the page. A comparison of the sorted output
 compares the DOM. Use `ht/canonical-dom` whenever the claim is "these two
-mounts built the same page": before and after a refactor, a Hicasso view
+mounts built the same page": before and after a refactor, a [Hicasso](glossary.md#hicasso) view
 against its Reagent original during migration
 ([Migration](19-migration-from-reagent.md)), or an island against its
-pre-extraction boundary ([Native tier](10-native-tier.md)).
+pre-extraction [boundary](glossary.md#boundary) ([Native tier](10-native-tier.md)).

--- a/docs/design/hicasso/draft-guide/15-diagnostics.md
+++ b/docs/design/hicasso/draft-guide/15-diagnostics.md
@@ -12,17 +12,17 @@ Xray answers the questions you ask:
 
 1. What ran or committed in this epoch — mounted, hidden, suspended, recently
    committed?
-2. Why did this boundary run — which reads changed, and what was their fan-out?
+2. Why did this [boundary](glossary.md#boundary) run — which reads changed, and what was their fan-out?
 3. Was the cause props, context, a read-set change, a retry, abandonment, an
    error, or a host?
-4. Where is the pressure — computation, topology, lowering, React, or layout —
+4. Where is the pressure — computation, topology, [lowering](glossary.md#lowering), React, or layout —
    and what remedy is credible?
 5. What is unknown, capped, opaque, or uncorrelated?
 
 An *epoch* is one pipeline run: one dispatched event carried through to its
 commit. The epoch is the unit that Xray organises evidence around.
 
-## The causal lens
+## The [causal lens](glossary.md#causal-lens)
 
 Every diagnosis follows one chain:
 
@@ -44,7 +44,7 @@ browser owns paint. Xray tells you which claim each number makes.
 
 ## Explain-render
 
-Select a boundary occurrence and ask the first question that matters: *why
+Select a [boundary](glossary.md#boundary) occurrence and ask the first question that matters: *why
 did this view run?* The answer is data, in the same shape that the whole
 evidence surface uses:
 
@@ -63,7 +63,7 @@ evidence surface uses:
 The `:cause` kinds are the honest taxonomy of question 3. The possible
 causes: the boundary's own reads moved (with the changed queries named);
 its props changed; a context it consumes changed; a host boundary forced
-it; or React retried or abandoned an attempt. When several boundaries ran
+it; or React retried or abandoned an attempt. When several [boundaries](glossary.md#boundary) ran
 for one event, fan-out tells you which case you have. One changed
 subscription that reaches many readers is a topology problem. Many
 independent causes are ordinary work.
@@ -75,7 +75,7 @@ exactly what it holds and which generation of the contract produced it.
 ## Read attribution
 
 The complementary standing view is the map from subscriptions to the
-boundaries that currently read them: who depends on what, right now. Four
+[boundaries](glossary.md#boundary) that currently read them: who depends on what, right now. Four
 numbers on this view do most of the diagnostic work:
 
 | Number | What it tells you |
@@ -95,10 +95,10 @@ boundary placement, fine versus coarse versus chunked reads — are owned by
 [Lists and collections](06-lists-and-collections.md). Xray's job is to make
 the topology observable instead of guessed.
 
-## The hot-view advisor
+## The [hot-view advisor](glossary.md#hot-view-advisor)
 
 The advisor is the part of Xray that turns evidence into a recommendation.
-It ranks boundaries by time, frequency, read churn, and fan-out. Then it
+It ranks [boundaries](glossary.md#boundary) by time, frequency, read churn, and fan-out. Then it
 does the step that matters: it **classifies the pressure** before it names
 a remedy.
 
@@ -106,19 +106,19 @@ a remedy.
 |---|---|---|
 | Computation | your own code — the body's work or an expensive sub chain | fix the computation; derive it in the subscription layer, where it is a pure function you can test |
 | Topology | too many boundaries invalidated, or churning read sets | move reads, split or merge boundaries, coarse or chunked or windowed reads ([Lists and collections](06-lists-and-collections.md)) |
-| Lowering | turning one hot boundary's Hiccup into React elements | a direct `n/$` return from that same boundary ([Native tier](10-native-tier.md)) |
-| React | reconciliation, hooks, vendor component internals | a named native island — `n/defcomponent` or UIx ([Native tier](10-native-tier.md)) |
+| Lowering | turning one hot boundary's Hiccup into React elements | a direct [`n/$`](glossary.md#n-dollar) return from that same boundary ([Native tier](10-native-tier.md)) |
+| React | reconciliation, hooks, vendor component internals | a named [native island](glossary.md#native-island) — [`n/defcomponent`](glossary.md#ndefcomponent) or UIx ([Native tier](10-native-tier.md)) |
 | Layout | the browser — style, layout, paint | shrink the DOM, virtualize, fix the CSS; browser tools own this ground |
 
 The advisor never breaks one rule: **it recommends a native escape only
-when the measured owner is a class that native addresses.** If lowering is
+when the measured owner is a class that native addresses.** If [lowering](glossary.md#lowering) is
 four percent of a slow interaction, extraction cannot buy more than four
 percent. The advisor says so, and points at the real owner instead. There
 is no automatic promotion. The advisor recommends; you decide. An escape
 you take must meet the thresholds in [Performance](18-performance.md), or
 it comes back out.
 
-## Honest loss labels
+## Honest [loss labels](glossary.md#loss-labels)
 
 An interpreted runtime cannot know some facts. Xray reports that limit as
 an answer; it does not present an empty panel. Unknown is never encoded as
@@ -135,11 +135,11 @@ an empty collection.
 A dashboard that filled those cells with zeros would be easier to read and
 worse to trust. The label tells you which tool to use next.
 
-## The complaint catalogue
+## The [complaint catalogue](glossary.md#complaint-catalogue)
 
 Every refusal in this guide carries a stable id: `:rf.error/*` for errors,
 `:rf.warning/*` for recoverable misuse. Every id is an entry in the
-complaint catalogue — a docs anchor that states what fired, why it fired,
+[complaint catalogue](glossary.md#complaint-catalogue) — a docs anchor that states what fired, why it fired,
 and the concrete recovery. A complaint is structured data end to end. When
 thrown, it carries its id in `ex-data` under `:rf.error/id`. On the trace,
 it is a record with the id as its category and the recovery the runtime
@@ -151,11 +151,11 @@ A sample of entries from earlier chapters:
 | Id | Complaint | Recovery |
 |---|---|---|
 | `:rf.error/hicasso-sub-outside-render` | a read escaped every render extent | read during the body; in a handler, declare the fact as a coeffect ([Views and reads](02-views-and-reads.md)) |
-| `:rf.error/hicasso-deferred-read-at-boundary` | an unforced `delay` carrying a read tried to cross a boundary | force it in the body; close over the value ([Views and reads](02-views-and-reads.md)) |
-| `:rf.error/hicasso-bad-head` | a plain `defn` in head position | mint it with `h/defview`, or call it inline ([Views and reads](02-views-and-reads.md)) |
-| `:rf.error/hicasso-intent-outside-boundary` | an intent vector reached a position with no boundary frame | dispatch belongs inside a boundary; at a foreign edge, use `h/event` ([Events as data](03-events-as-data.md)) |
-| `:rf.error/hicasso-host-unclaimed-callback` | an `h/event` arrived at a host slot with no declared contract | declare the slot on the `defhost` ([Interop](09-interop.md)) |
-| `:rf.error/hicasso-revision-not-controlled` | `::h/revision` on a field that is not controlled | control the field, or drop the revision ([Controlled inputs](04-controlled-inputs.md)) |
+| `:rf.error/hicasso-deferred-read-at-boundary` | an unforced `delay` carrying a read tried to cross a [boundary](glossary.md#boundary) | force it in the body; close over the value ([Views and reads](02-views-and-reads.md)) |
+| `:rf.error/hicasso-bad-head` | a plain `defn` in head position | mint it with [`h/defview`](glossary.md#defview), or call it inline ([Views and reads](02-views-and-reads.md)) |
+| `:rf.error/hicasso-intent-outside-boundary` | an [intent](glossary.md#intent) vector reached a position with no boundary frame | dispatch belongs inside a boundary; at a foreign edge, use [`h/event`](glossary.md#hevent) ([Events as data](03-events-as-data.md)) |
+| `:rf.error/hicasso-host-unclaimed-callback` | an [`h/event`](glossary.md#hevent) arrived at a host slot with no declared contract | declare the slot on the [`defhost`](glossary.md#defhost) ([Interop](09-interop.md)) |
+| `:rf.error/hicasso-revision-not-controlled` | [`::h/revision`](glossary.md#hrevision) on a field that is not controlled | control the field, or drop the revision ([Controlled inputs](04-controlled-inputs.md)) |
 | `:rf.warning/hicasso-missing-key` | a seq of boundary children without `:key` | put `:key` in each child's props map ([Lists and collections](06-lists-and-collections.md)) |
 | `:rf.error/frame-destroyed` | an operation minted against a destroyed frame incarnation fired after its successor seated | drop the stale handle; capture from the live frame ([Events as data](03-events-as-data.md)) |
 
@@ -218,7 +218,7 @@ feature may read evidence, count complaints, or branch on a panel's data.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| A view you know ran is absent from the epoch | Its boundary bailed out — a skipped body emits nothing | Absence is the measurement of work not done; if you expected it to run, explain-render the parent that did |
+| A view you know ran is absent from the epoch | Its [boundary](glossary.md#boundary) bailed out — a skipped body emits nothing | Absence is the measurement of work not done; if you expected it to run, [explain-render](glossary.md#explain-render) the parent that did |
 | Explain-render answers `:uncorrelated` | The event-to-render link could not be established for that occurrence | An honest answer, not a failure; reproduce with a scripted interaction and read the fresh epoch |
 | A foreign subtree shows `:host-opaque` | Raw React internals are not enumerable past the crossing | Xray still names and times the crossing; open React DevTools for the inside |
 | History stops with `:cap` | The bounded retention window dropped older epochs | Reproduce and capture fresh; retention does not grow to fit the question |
@@ -251,7 +251,7 @@ schema: byte-equivalent projections, one contract. Query arguments pass
 through the privacy projector. Raw values and text are omitted by default.
 Nothing leaves the process unless an explicitly authorized consumer
 requests it. If you script your own diagnosis through the pair, you read
-exactly what the panel reads, including the loss labels.
+exactly what the panel reads, including the [loss labels](glossary.md#loss-labels).
 
 ### Optional modules bring their own evidence
 
@@ -260,7 +260,7 @@ ownership. Overlays contribute the active top-layer region. Motion
 contributes the current transition posture. Resources contribute the live
 demand. Each is a bounded projection that exists only while the module is
 installed and in use. None of them adds a standing accumulator to ordinary
-Hicasso. An app that uses none of them pays for none of this.
+[Hicasso](glossary.md#hicasso). An app that uses none of them pays for none of this.
 
 ### Retention is bounded on purpose
 

--- a/docs/design/hicasso/draft-guide/15-diagnostics.md
+++ b/docs/design/hicasso/draft-guide/15-diagnostics.md
@@ -22,7 +22,7 @@ Xray answers the questions you ask:
 An *epoch* is one pipeline run: one dispatched event carried through to its
 commit. The epoch is the unit that Xray organises evidence around.
 
-## The [causal lens](glossary.md#causal-lens)
+## The causal lens
 
 Every diagnosis follows one chain:
 
@@ -95,7 +95,7 @@ boundary placement, fine versus coarse versus chunked reads — are owned by
 [Lists and collections](06-lists-and-collections.md). Xray's job is to make
 the topology observable instead of guessed.
 
-## The [hot-view advisor](glossary.md#hot-view-advisor)
+## The hot-view advisor
 
 The advisor is the part of Xray that turns evidence into a recommendation.
 It ranks [boundaries](glossary.md#boundary) by time, frequency, read churn, and fan-out. Then it
@@ -118,7 +118,7 @@ is no automatic promotion. The advisor recommends; you decide. An escape
 you take must meet the thresholds in [Performance](18-performance.md), or
 it comes back out.
 
-## Honest [loss labels](glossary.md#loss-labels)
+## Honest loss labels
 
 An interpreted runtime cannot know some facts. Xray reports that limit as
 an answer; it does not present an empty panel. Unknown is never encoded as
@@ -135,7 +135,7 @@ an empty collection.
 A dashboard that filled those cells with zeros would be easier to read and
 worse to trust. The label tells you which tool to use next.
 
-## The [complaint catalogue](glossary.md#complaint-catalogue)
+## The complaint catalogue
 
 Every refusal in this guide carries a stable id: `:rf.error/*` for errors,
 `:rf.warning/*` for recoverable misuse. Every id is an entry in the

--- a/docs/design/hicasso/draft-guide/16-errors.md
+++ b/docs/design/hicasso/draft-guide/16-errors.md
@@ -20,14 +20,14 @@ gets a blank page.
 If `article-body` throws during render, the header and footer stay up, and
 the paragraph takes the article's place. Nothing else in the tree notices.
 
-`h/error-boundary` is a component that you write into the tree. It is not the
-rendering boundary that a `defview` mints
+[`h/error-boundary`](glossary.md#error-boundary) is a component that you write into the tree. It is not the
+rendering [boundary](glossary.md#boundary) that a [`defview`](glossary.md#defview) mints
 ([Views and reads](02-views-and-reads.md)). The word is the same, the thing
-is different — and only `h/error-boundary` catches.
+is different — and only [`h/error-boundary`](glossary.md#error-boundary) catches.
 
 ## The three keys
 
-`h/error-boundary` takes exactly three props. There is no built-in
+[`h/error-boundary`](glossary.md#error-boundary) takes exactly three props. There is no built-in
 classification, retry policy, or logging. Those are your app's decisions, and
 you make them in `:on-error`.
 
@@ -40,7 +40,7 @@ you make them in `:on-error`.
 **`:fallback` can read the error.** Pass a function, and the function
 receives the thrown value. Show `(ex-message error)` in development and a
 plain sentence in production. The returned hiccup is lowered like any other,
-intents included, under the frame where the region was mounted.
+[intents](glossary.md#intent) included, under the frame where the region was mounted.
 
 **`:reset-key` is how retry works.** The region never guesses. When the key
 changes, the region clears the caught failure and remounts the children — a
@@ -89,7 +89,7 @@ catches the throw, and everything outside that region continues to render.
 
 When `live-chart` throws, the inner region catches. The panel shows its
 fallback, `report-summary` and the header stay up, and the outer region never
-fires. The retry button is an ordinary intent. Its handler increments
+fires. The retry button is an ordinary [intent](glossary.md#intent). Its handler increments
 `:chart/attempt`, the `:reset-key` changes, and the chart remounts. If the
 bad data is still there, the region catches again, and the panel shows its
 fallback again. A throw in `report-summary`, which sits outside the inner
@@ -109,7 +109,7 @@ of the tree below the region.
 
 **Not caught:** anything the browser calls outside render — an event handler,
 a `setTimeout`, a promise continuation. Those failures belong to re-frame2,
-not to the view layer. An intent's handler runs inside the event pipeline.
+not to the view layer. An [intent](glossary.md#intent)'s handler runs inside the event pipeline.
 The pipeline catches the throw, reports a structured error record
 (`:rf.error/handler-exception`, with the event, frame, and recovery
 attached), and the app continues to run. A raw `fn` callback that throws goes
@@ -162,13 +162,13 @@ region higher.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| Whole page blanks when one view throws | Nothing caught it — React unmounts the root by default | Put `h/error-boundary` around the region that can fail |
+| Whole page blanks when one view throws | Nothing caught it — React unmounts the root by default | Put [`h/error-boundary`](glossary.md#error-boundary) around the region that can fail |
 | A throw from an event handler is not caught by the region | Handlers run in the event pipeline, not in render; the pipeline catches it and reports `:rf.error/handler-exception` | Expected — read the error record; the view layer never sees it |
 | Fallback shows and never leaves | No `:reset-key`, or the key never changes | Drive the key from app-db and bump it to retry |
-| Retry button in the fallback does nothing | The intent lowers under the region's frame; without a frame in scope it refuses with `:rf.error/hicasso-intent-outside-boundary`, naming the intent | Keep the fallback ordinary hiccup inside the mounted tree; dispatch a plain intent |
+| Retry button in the fallback does nothing | The [intent](glossary.md#intent) lowers under the region's frame; without a frame in scope it refuses with `:rf.error/hicasso-intent-outside-boundary`, naming the intent | Keep the fallback ordinary hiccup inside the mounted tree; dispatch a plain intent |
 | One panel breaks and the page follows it down | The fallback itself threw; the next region up caught that | Keep fallbacks plain — no reads of the failed state, no heavy work |
 | `:on-error` seems to fire twice in development | It does not — StrictMode re-runs the failing render; React reports one catch | Two fires means two real failures |
-| The region did not catch during a server render | React routes server render errors through its server error channel; client regions never see them | The surface's server policy owns that path ([SSR and hydration](17-ssr-and-hydration.md)) |
+| The region did not catch during a server render | React routes server render errors through its server error channel; client regions never see them | The surface's [server policy](glossary.md#server-policy) owns that path ([SSR and hydration](17-ssr-and-hydration.md)) |
 
 ## When not
 

--- a/docs/design/hicasso/draft-guide/17-ssr-and-hydration.md
+++ b/docs/design/hicasso/draft-guide/17-ssr-and-hydration.md
@@ -308,7 +308,7 @@ does not know raises `:rf.error/hicasso-host-unknown-option`. A raw React
 element escape carries no declaration, so it carries no server-safety
 assertion either. It renders nothing server-side, always.
 
-## The [native tier](glossary.md#native-tier) under SSR
+## The native tier under SSR
 
 The same per-surface rule applies, at the same sources. An intrinsic [`n/$`](glossary.md#n-dollar)
 form is markup, and it Renders. A named native component declares its

--- a/docs/design/hicasso/draft-guide/17-ssr-and-hydration.md
+++ b/docs/design/hicasso/draft-guide/17-ssr-and-hydration.md
@@ -3,7 +3,7 @@
 You want real HTML in the first response, and you want the same app to take
 over in the browser. You do not want to write the UI twice, and you do not
 want a second HTML emitter that drifts from what the client renders.
-Hicasso's answer is a contract, not a mode. Every public surface either
+[Hicasso](glossary.md#hicasso)'s answer is a contract, not a mode. Every public surface either
 renders deterministic React server bytes or refuses at its source with a
 recovery. The browser adopts the server's DOM; it does not repaint over it.
 
@@ -30,18 +30,18 @@ One renderer serves every surface. Two policies govern each surface:
 | Surface | Policy |
 |---|---|
 | Hiccup elements, fragments, text | Render |
-| `h/defview` bodies and `h/sub` reads | Render — reads probe the request snapshot |
+| [`h/defview`](glossary.md#defview) bodies and [`h/sub`](glossary.md#hsub) reads | Render — reads probe the request snapshot |
 | Controlled fields | Render — value/checked attributes come from the model |
-| `h/error-boundary` | Render — a throw during a server render takes React's server error channel, not the boundary's fallback |
-| Roots and the outward bridge | Render — request-isolated, prefix-matched |
-| `h/defhost`, ReactNode slots, render props, `h/as-element` | Client-only until the declaration selects Render |
+| [`h/error-boundary`](glossary.md#error-boundary) | Render — a throw during a server render takes React's server error channel, not the [boundary](glossary.md#boundary)'s fallback |
+| Roots and the [outward bridge](glossary.md#outward-bridge) | Render — request-isolated, prefix-matched |
+| [`h/defhost`](glossary.md#defhost), [ReactNode slots](glossary.md#reactnode-slot), render props, [`h/as-element`](glossary.md#as-element) | Client-only until the declaration selects Render |
 | Portals, raw React elements, opaque foreign components | Client-only — no hydration claim is made for bytes that were never sent |
-| Intrinsic `n/$` forms | Render |
-| `n/defcomponent` and component-headed `n/$` | Client-only until the declaration selects Render |
+| Intrinsic [`n/$`](glossary.md#n-dollar) forms | Render |
+| [`n/defcomponent`](glossary.md#ndefcomponent) and component-headed [`n/$`](glossary.md#n-dollar) | Client-only until the declaration selects Render |
 | Resource and demand boundaries | Client-only until their module contract selects Render |
 
 Two consequences deserve a plain statement. First, a server render runs no
-effects. Every `h/sub` read is a cold probe against one coherent snapshot:
+effects. Every [`h/sub`](glossary.md#hsub) read is a cold probe against one coherent snapshot:
 no subscription registered, no commit, no disposal owed. A request
 therefore leaves nothing behind, by design. Second, determinism is the part
 you own. Same bundle, same snapshot, same bytes — that is the Render
@@ -81,7 +81,7 @@ only in a browser.
    [trend-chart {:points (clj->js (h/sub [:feed/trend]))}]])
 ```
 
-Nothing here is SSR-specific. That is the point: idiomatic Hicasso is
+Nothing here is SSR-specific. That is the point: idiomatic [Hicasso](glossary.md#hicasso) is
 already the app that serves.
 
 The server side is the optional server module: the deployable Node
@@ -161,19 +161,19 @@ trees disagree before React compares a single node.
               [views/page {}]))
 ```
 
-!!! note "Two `hydrate!`s, two halves"
+!!! note "Two [`hydrate!`](glossary.md#hydrate)s, two halves"
     `ssr/hydrate!` is the framework's state half. It reads the payload,
     dispatches `:rf/hydrate` against the target frame — the server's slice
     replaces the client's — and validates the wire frame id against
     `:frame`. A conflict raises `:rf.error/hydration-frame-id-mismatch`; an
-    absent `:frame` raises `:rf.error/no-frame-context`. `h/hydrate!` is
+    absent `:frame` raises `:rf.error/no-frame-context`. [`h/hydrate!`](glossary.md#hydrate) is
     the DOM half: React's `hydrateRoot` on a container that already holds
     server bytes. The two calls share a verb because they are two halves of
     one adoption — and the order between them is fixed.
 
-`h/hydrate!` stands beside `h/mount!` ([Getting started](01-getting-started.md)):
+[`h/hydrate!`](glossary.md#hydrate) stands beside [`h/mount!`](glossary.md#mount) ([Getting started](01-getting-started.md)):
 the same association of a container, a frame, and one view, and the same
-idempotent handle for `h/unmount!`. These properties matter when you write
+idempotent handle for [`h/unmount!`](glossary.md#mount). These properties matter when you write
 apps:
 
 - **Adoption is root-scoped.** The handle owns its container, its
@@ -193,7 +193,7 @@ apps:
 
 `ssr/hydrate!` returns the applied payload, or `nil` when the page carries
 none. The same boot therefore serves a client-only load: on `nil`, fall
-through to `h/mount!` with your ordinary `:initial-events` seed.
+through to [`h/mount!`](glossary.md#mount) with your ordinary `:initial-events` seed.
 
 ## Two roots, two verdicts
 
@@ -230,7 +230,7 @@ bus as:
 ```
 
 The `#app` root hydrated clean; its stream is empty. That per-root
-attribution is the contract. Each `h/hydrate!` wires its own recoverable,
+attribution is the contract. Each [`h/hydrate!`](glossary.md#hydrate) wires its own recoverable,
 caught, and uncaught error channels, so one faulty root cannot contaminate
 the other's verdict. Xray's hydration lane shows the complaints joined to
 view source and host policy ([Diagnostics](15-diagnostics.md)). The fix
@@ -247,7 +247,7 @@ disagreement ends up reported.
 ??? info "Coming from Reagent: where is the structural hash?"
     The Reagent-tier adapters hash their hiccup tree on the server and
     re-hash the client's first render. Views there are pure functions that
-    return a data tree, so there is a tree to hash. Hicasso views reach
+    return a data tree, so there is a tree to hash. [Hicasso](glossary.md#hicasso) views reach
     React as elements, and React walks the tree internally, so no data tree
     exists to hash and no hash rides the payload. Verification on this tier
     is React's own adoption, reported per root. An absent hash cannot lie;
@@ -255,7 +255,7 @@ disagreement ends up reported.
 
 ## Render and Client-only, at the host
 
-Every `h/defhost` declaration carries its server policy. One declaration
+Every [`h/defhost`](glossary.md#defhost) declaration carries its [server policy](glossary.md#server-policy). One declaration
 covers the server render, hydration's first client pass, and a fresh
 client-only mount ([Interop](09-interop.md)):
 
@@ -278,8 +278,8 @@ component mounts after adoption completes. A fresh client mount renders the
 component immediately, with no fallback flash. The fallback must be
 deterministic, inert markup. It is walked once at the declaration, and it
 lands in the server bytes *and* in hydration's first client pass; those two
-must agree by construction. The runtime enforces this. A `defview` or
-`defhost` head written into a fallback is an element whose body runs later
+must agree by construction. The runtime enforces this. A [`defview`](glossary.md#defview) or
+[`defhost`](glossary.md#defhost) head written into a fallback is an element whose body runs later
 — differently per frame and per write — and the declaration refuses it
 with `:rf.error/hicasso-host-fallback-boundary-head`.
 
@@ -308,9 +308,9 @@ does not know raises `:rf.error/hicasso-host-unknown-option`. A raw React
 element escape carries no declaration, so it carries no server-safety
 assertion either. It renders nothing server-side, always.
 
-## The native tier under SSR
+## The [native tier](glossary.md#native-tier) under SSR
 
-The same per-surface rule applies, at the same sources. An intrinsic `n/$`
+The same per-surface rule applies, at the same sources. An intrinsic [`n/$`](glossary.md#n-dollar)
 form is markup, and it Renders. A named native component declares its
 policy, and the default is conservative:
 
@@ -322,7 +322,7 @@ policy, and the default is conservative:
     (n/$ :span {:class "ticker"} price)))
 ```
 
-Under a server render, `n/use-sub` reads the request snapshot through the
+Under a server render, [`n/use-sub`](glossary.md#nuse-sub) reads the request snapshot through the
 hook's server path: the same cold-probe discipline, with no registration.
 Omit the declaration map, and the component stays Client-only until its
 declaration selects Render ([The native tier](10-native-tier.md)).
@@ -353,7 +353,7 @@ them requires that a second renderer ever exist.
 ## When not to server-render
 
 A client-only application never ships the service: no Node process, no
-payload, no snapshot plumbing. Boot is `h/mount!` and an `:initial-events`
+payload, no snapshot plumbing. Boot is [`h/mount!`](glossary.md#mount) and an `:initial-events`
 seed. None of the service's operational weight exists in your deployment.
 Apps behind a login wall usually belong here. First-response HTML of
 private, per-user state rarely justifies a render fleet.
@@ -369,9 +369,9 @@ configuration — a snapshot, an allowlist, a prefix — and not a rewrite.
 | Symptom | What it is | Fix |
 |---|---|---|
 | `:rf.ssr/hydration-mismatch` naming a root and a view | The two renders disagreed — a body read the platform (clock, random, `js/window`) instead of props and reads | Keep bodies pure; platform work goes to `:platforms #{:client}` effects and host edges |
-| Every `useId`-derived id on one root complains at once | That root's `:identifier-prefix` does not match the server render's | Pass the same prefix to `server/render` and that root's `h/hydrate!`; keep prefixes unique per root |
+| Every `useId`-derived id on one root complains at once | That root's `:identifier-prefix` does not match the server render's | Pass the same prefix to `server/render` and that root's [`h/hydrate!`](glossary.md#hydrate); keep prefixes unique per root |
 | A Client-only host shows its fallback, then the live widget swaps in | The policy working: the fallback is in the server bytes and the first client pass; the component mounts at adoption | Make the fallback a same-footprint skeleton to kill the layout jump; only `{:server :render}` removes the swap |
-| `:rf.error/hicasso-host-fallback-boundary-head` at a declaration | A `defview`/`defhost` head in a fallback — a body that runs later cannot be deterministic, and the fallback must render identically on the server and hydration's first pass | Plain hiccup in the fallback, or `{:server :render}` and render the real subtree |
+| `:rf.error/hicasso-host-fallback-boundary-head` at a declaration | A [`defview`](glossary.md#defview)/[`defhost`](glossary.md#defhost) head in a fallback — a body that runs later cannot be deterministic, and the fallback must render identically on the server and hydration's first pass | Plain hiccup in the fallback, or `{:server :render}` and render the real subtree |
 | `window is not defined` during a server render under `{:server :render}` | The Render assertion is false — the component is not server-safe | Drop back to Client-only with a fallback; this failure is loud by design |
 | A crossing's children are missing from the server HTML, silently | The crossing is Client-only, and both Client-only shapes render instead of the component — a transparent wrapper takes its subtree with it, and both passes agree so nothing reports | Declare `{:server :render}` on the wrapper if it is server-safe |
 | `:rf.error/hicasso-host-bad-ssr-policy` at a declaration | A policy value outside the two, or `:fallback` combined with Render | Two policies: `:render`, or `:client-only` with an optional `:fallback` |

--- a/docs/design/hicasso/draft-guide/18-performance.md
+++ b/docs/design/hicasso/draft-guide/18-performance.md
@@ -1,6 +1,6 @@
 # Performance
 
-"Is it fast enough?" is not a feeling. Hicasso ships with budgets stated in
+"Is it fast enough?" is not a feeling. [Hicasso](glossary.md#hicasso) ships with budgets stated in
 user-visible terms, and performance work is the method that meets them:
 measure, attribute, change the smallest thing, then verify again. This
 chapter gives you the budgets, the ladder, the loop, and one example with
@@ -19,7 +19,7 @@ percentile that represents real hardware:
 | Budget | The user-visible fact |
 |---|---|
 | Discrete interactions | Click, toggle, submit reach the next paint within **50 ms p95** (100 ms p99) |
-| Keystroke echo | A controlled field is correct **in the same turn** and visibly echoed within **one 60 Hz frame** at p95 |
+| Keystroke echo | A [controlled field](glossary.md#controlled-field) is correct **in the same turn** and visibly echoed within **one 60 Hz frame** at p95 |
 | Broad operations | Bulk replace, big filter flips complete within **100 ms p95**, unless explicitly classified as background work |
 | Drag and animation | Stay inside the frame budget — normally by keeping high-rate mechanics host-local ([Ephemeral state](11-ephemeral-state.md)) |
 | Narrow updates | Body work scales with **changed rows**, not mounted rows |
@@ -37,20 +37,20 @@ whatever score a synthetic benchmark reports.
 
 The teardown row needs one expansion, because people forget that this budget
 is user-visible. An SPA session is long, and leave-and-return cycles must
-not accumulate residue. Hicasso guarantees its own side: abandoned renders
+not accumulate residue. [Hicasso](glossary.md#hicasso) guarantees its own side: abandoned renders
 own nothing, and unmount releases every read. Your side is the escapes. A
 host or island that acquires an SDK, a listener, or a timer releases it on
-teardown ([Interop](09-interop.md)), and the test kit's `assert-clean!`
+teardown ([Interop](09-interop.md)), and the [test kit](glossary.md#test-kit)'s `assert-clean!`
 proves the whole claim after quiescence ([Testing](14-testing.md)).
 
 ## Why most apps never leave rung 1
 
-Rung 1 is ordinary Hicasso: write ordinary views, read at the point of use,
-put intents in the markup, and ship. Do not pre-optimise, and do not build a
+Rung 1 is ordinary [Hicasso](glossary.md#hicasso): write ordinary views, read at the point of use,
+put [intents](glossary.md#intent) in the markup, and ship. Do not pre-optimise, and do not build a
 second architecture for problems that you have not measured — the
-interpreter is not the cost. Interpreted lowering is fast. When a screen
+interpreter is not the cost. Interpreted [lowering](glossary.md#lowering) is fast. When a screen
 misses a budget, the cost almost always lives somewhere else: **where the
-reads sit, how many boundaries exist, what React itself does, or what a host
+reads sit, how many [boundaries](glossary.md#boundary) exist, what React itself does, or what a host
 does**. Per read, Hicasso's retained cost is low; the read *topology* is
 what you chose. That is why the ladder's second rung is "move your reads",
 not "abandon Hiccup".
@@ -69,10 +69,10 @@ what Hiccup means:
 
 | Rung | What you write | Reach for it when | Taught in |
 |---|---|---|---|
-| 1 — Ordinary Hicasso | Hiccup, `h/sub` at point of use, intents as data | Always. Start every feature here | [Views and reads](02-views-and-reads.md) |
-| 2 — Tuned topology | The same language; boundary placement, keys, read shape | A named boundary or read pressure | [Lists and collections](06-lists-and-collections.md) |
-| 3 — Direct React return | A `defview` returns an `n/$` element; frame, reads, memo stay | Lowering itself is the measured owner | [The native tier](10-native-tier.md) |
-| 4 — Named native island | `n/defcomponent` (or UIx) under the same root and frame | Hooks, vendor behavior, reconciliation, or high-rate local work dominate | [The native tier](10-native-tier.md) |
+| 1 — Ordinary [Hicasso](glossary.md#hicasso) | Hiccup, [`h/sub`](glossary.md#hsub) at point of use, [intents](glossary.md#intent) as data | Always. Start every feature here | [Views and reads](02-views-and-reads.md) |
+| 2 — Tuned topology | The same language; [boundary](glossary.md#boundary) placement, keys, read shape | A named boundary or read pressure | [Lists and collections](06-lists-and-collections.md) |
+| 3 — Direct React return | A [`defview`](glossary.md#defview) returns an [`n/$`](glossary.md#n-dollar) element; frame, reads, memo stay | Lowering itself is the measured owner | [The native tier](10-native-tier.md) |
+| 4 — Named [native island](glossary.md#native-island) | [`n/defcomponent`](glossary.md#ndefcomponent) (or UIx) under the same root and frame | Hooks, vendor behavior, reconciliation, or high-rate local work dominate | [The native tier](10-native-tier.md) |
 | 5 — Native screen | A React-first screen authored natively | The screen is React-shaped by nature | [The native tier](10-native-tier.md) |
 
 The full lessons for rungs 3–5 are in [chapter 10](10-native-tier.md). This
@@ -87,10 +87,10 @@ Performance work that skips a step of this loop is guessing. The loop:
    the same way in every run. "The app is slow" is not actionable; "expedite
    on a 1,000-row table takes 180 ms" is actionable.
 2. **Attribute.** Correlate the event with the work that ran — which
-   subscriptions recomputed, which boundaries became invalid, how much body
-   work, then commit and paint. Xray's explain-render and read attribution
-   answer the first half. Its hot-view advisor classifies the pressure —
-   computation, topology, lowering, React, or layout — and recommends the
+   subscriptions recomputed, which [boundaries](glossary.md#boundary) became invalid, how much body
+   work, then commit and paint. Xray's [explain-render](glossary.md#explain-render) and read attribution
+   answer the first half. Its [hot-view advisor](glossary.md#hot-view-advisor) classifies the pressure —
+   computation, topology, [lowering](glossary.md#lowering), React, or layout — and recommends the
    smallest credible remedy ([Diagnostics](15-diagnostics.md)).
 3. **Tune topology.** Adjust boundary placement, keys, and read shape —
    rung 2 ([Lists and collections](06-lists-and-collections.md)). Most hot
@@ -100,7 +100,7 @@ Performance work that skips a step of this loop is guessing. The loop:
 5. **Isolate an island** if hooks, vendor behavior, reconciliation, or
    high-rate local work is the owner — rung 4. Choose the route by the
    component's needs, not by habit.
-6. **Re-verify.** The change must preserve DOM and intent behavior, focus
+6. **Re-verify.** The change must preserve DOM and [intent](glossary.md#intent) behavior, focus
    and selection, frame routing, SSR/hydration, and cleanup — and the budget
    must flip from fail to pass. A faster screen that behaves wrongly is
    wrong.
@@ -128,7 +128,7 @@ Attribute *before* you change architecture. Unattributed "slow" is usually a
 rung-2 problem, and an island built on a misattributed cause makes the code
 worse without making it faster.
 
-## The escape-benefit rule
+## The [escape-benefit rule](glossary.md#escape-benefit-rule)
 
 An escape is a standing cost: a second semantics in that region, a body that
 structural tests cannot see into, a diff that reviewers read more slowly.
@@ -143,7 +143,7 @@ a threshold is ordinary code that still pays escape costs.
 ## The cost of one keystroke: the editor and the grid
 
 The budgets become concrete when you trace one keystroke through the
-machine. Take the smallest complete example — a controlled field in a
+machine. Take the smallest complete example — a [controlled field](glossary.md#controlled-field) in a
 four-field article editor:
 
 ```clojure
@@ -167,13 +167,13 @@ four-field article editor:
 One keystroke in the title field takes this path, entirely inside the
 browser's own input event:
 
-1. The DOM event fires. The intent dispatches **synchronously** in the
+1. The DOM event fires. The [intent](glossary.md#intent) dispatches **synchronously** in the
    discrete event — no queue sits between the key and the handler.
 2. One handler runs, and it writes **one address**.
 3. The subscriptions that read that address recompute. Equality gates stop
    every subscription whose output did not change. **One** subscription's
    value changes.
-4. The runtime notifies the boundaries whose reads changed. **One** body
+4. The runtime notifies the [boundaries](glossary.md#boundary) whose reads changed. **One** body
    runs — the title field's body. The other three fields receive no
    notification.
 5. React commits, and the controlled converge applies the value **and the
@@ -241,7 +241,7 @@ itself.
 | "The app feels slow" and nothing else | No reproduction, so nothing is attributable | Script one named interaction; run the loop from step 1 |
 | One keystroke or event runs hundreds of bodies | Read topology — a value read too high, or a coarse read on a narrow-update surface | Rung 2: [Lists and collections](06-lists-and-collections.md) |
 | Characters drop under fast typing | Something async sits between keystroke and commit — a debounced write, a queued effect | Keep the controlled write synchronous; debounce consumers of the value |
-| An island shipped and the interaction is no faster | The pressure owner was misattributed — usually reads or event volume, not lowering | Re-attribute with Xray; remove the island if it fails the benefit rule |
+| An island shipped and the interaction is no faster | The pressure owner was misattributed — usually reads or event volume, not [lowering](glossary.md#lowering) | Re-attribute with Xray; remove the island if it fails the benefit rule |
 | Fast on your machine, budget missed in the field | Dev build, fast hardware, best-run numbers | Production build, mid-tier hardware, p95 across runs |
 | Heap grows across leave-and-return cycles | An escape acquires without a paired release | Pair acquire/teardown at the host ([Interop](09-interop.md)); prove it with `assert-clean!` ([Testing](14-testing.md)) |
 | An escape clears no threshold but "feels safer to keep" | The benefit rule read backwards — escapes are a cost held against a measured gain | Remove the escape; that is the rule working correctly |

--- a/docs/design/hicasso/draft-guide/18-performance.md
+++ b/docs/design/hicasso/draft-guide/18-performance.md
@@ -128,7 +128,7 @@ Attribute *before* you change architecture. Unattributed "slow" is usually a
 rung-2 problem, and an island built on a misattributed cause makes the code
 worse without making it faster.
 
-## The [escape-benefit rule](glossary.md#escape-benefit-rule)
+## The escape-benefit rule
 
 An escape is a standing cost: a second semantics in that region, a body that
 structural tests cannot see into, a diff that reviewers read more slowly.

--- a/docs/design/hicasso/draft-guide/19-migration-from-reagent.md
+++ b/docs/design/hicasso/draft-guide/19-migration-from-reagent.md
@@ -1,6 +1,6 @@
 # Migration from Reagent
 
-You have a working Reagent codebase, and you want it on Hicasso without an
+You have a working Reagent codebase, and you want it on [Hicasso](glossary.md#hicasso) without an
 unverified rewrite. This page is the migration path for the view layer:
 components, hiccup dialect, local state, and interop sites. (If the app is
 still on re-frame v1, the events-and-subscriptions half is its own
@@ -12,8 +12,8 @@ The path is three tools and one rule:
    converts mechanically, needs your hands, or will refuse at runtime — and
    it puts a named class and a recovery sentence on each line.
 2. **Shadow mode** proves that a ported screen behaves identically to the
-   original. It is a dev-only dual mount that live-diffs canonical DOM and
-   intent streams.
+   original. It is a dev-only dual mount that live-diffs [canonical DOM](glossary.md#canonical-dom) and
+   [intent](glossary.md#intent) streams.
 3. **The codemod** repairs the `[:>]` props dialect mechanically. It applies
    only the rewrites that are decidable from the source text, and it is
    idempotent.
@@ -25,7 +25,7 @@ The path is three tools and one rule:
 
 ## Step 1 — run the reporter
 
-The migration tool ships with Hicasso. It runs on a bare JVM against any
+The migration tool ships with [Hicasso](glossary.md#hicasso). It runs on a bare JVM against any
 Reagent corpus. It never loads your app, and in its default mode it changes
 nothing:
 
@@ -38,7 +38,7 @@ clojure -M:run --report out.edn src/      # choose where the report goes
 
 Why is there a reporter? Reagent *converted* props on the way across a
 `[:>]` crossing — it deep-camelCased nested keys, converted keyword values
-to their string names, wrapped `r/partial`, and read metadata keys. Hicasso
+to their string names, wrapped `r/partial`, and read metadata keys. [Hicasso](glossary.md#hicasso)
 does not convert. `[:>]` stays legal, so a migrated site keeps rendering
 while it quietly means something else. The reporter reads every `[:>]` site
 in your tree and puts each site in one of three buckets:
@@ -58,7 +58,7 @@ not an error code. The report also carries each component's *name*, which
 the runtime never can: a `[:>]` refusal at runtime prints the constant
 `"[:>]"`, because the escape has no name of its own.
 
-The report ends with a **suggestions block** — candidate `h/defhost`
+The report ends with a **suggestions block** — candidate [`h/defhost`](glossary.md#defhost)
 declarations with guessed `:callbacks` maps. The block is labelled as
 guesses, because the entries are guesses. Fluent's `onRenderCell` and Ant's
 `onRow` are event-*spelled* render props whose return value the caller
@@ -76,26 +76,26 @@ Migrate screen by screen, not file type by file type. The port itself is
 mostly deletion — closures become data, and state machinery becomes
 addresses:
 
-| Reagent habit | Hicasso |
+| Reagent habit | [Hicasso](glossary.md#hicasso) |
 |---|---|
-| `defn` component returning hiccup | `h/defview` — a boundary, used as a head |
+| `defn` component returning hiccup | [`h/defview`](glossary.md#defview) — a [boundary](glossary.md#boundary), used as a head |
 | `@(rf/subscribe [:q])` in the body | `(h/sub [:q])` — legal in branches, loops, and helpers |
-| `#(rf/dispatch [:x])` handlers | the event vector itself; `h/event` when the callback's arguments matter |
+| `#(rf/dispatch [:x])` handlers | the event vector itself; [`h/event`](glossary.md#hevent) when the callback's arguments matter |
 | `r/atom` in a form-2 closure | a forms-module draft or an explicit app-db address — there is no local-state tier |
 | `r/with-let` | ordinary `let`; state that must survive a re-render is application state |
 | form-3 / `r/create-class` lifecycle | a callback ref at the host edge, or a named native component ([Native tier](10-native-tier.md)) |
 | `r/track`, `reaction`, `r/cursor` | layered subscriptions |
 | `^{:key k}` metadata | `:key` in the props map |
-| `[:> Component …]` | legal as-is; the codemod repairs the dialect; declare with `h/defhost` what you keep ([Interop](09-interop.md)) |
+| `[:> Component …]` | legal as-is; the codemod repairs the dialect; declare with [`h/defhost`](glossary.md#defhost) what you keep ([Interop](09-interop.md)) |
 | `r/adapt-react-class` | nothing — the codemod rewrites it to `[:>]`; declare it if it stays |
-| `r/as-element` in a render prop | `h/as-element`, at a declared `:render` position |
-| `r/reactify-component` | `h/as-component` — the outward bridge |
+| `r/as-element` in a render prop | [`h/as-element`](glossary.md#as-element), at a declared `:render` position |
+| `r/reactify-component` | [`h/as-component`](glossary.md#outward-bridge) — the [outward bridge](glossary.md#outward-bridge) |
 
 Two of these ports fail loudly instead of silently, and the loud failure
 helps you. A Reagent-style `#(rf/dispatch …)` closure still *runs* when the
 library or the DOM calls it, but the bare ambient dispatch inside it raises
 `:rf.error/no-frame-context` at the call — the recovery names the
-event-vector and `h/event` spellings. An intent vector at an undeclared
+event-vector and [`h/event`](glossary.md#hevent) spellings. An [intent](glossary.md#intent) vector at an undeclared
 `[:>]` prop refuses at render instead of crossing as an inert array. The
 inert array is what Reagent silently did, and the handler never fired there
 either.
@@ -103,9 +103,9 @@ either.
 ## Step 3 — prove it in shadow mode
 
 A port that "looks right" is a guess. Shadow mode is the proof: mount the
-Reagent original and the Hicasso port together, against isolated copies of
-the same seeded frame; drive both with one script; diff the canonical DOM
-plus the intent streams at every checkpoint.
+Reagent original and the [Hicasso](glossary.md#hicasso) port together, against isolated copies of
+the same seeded frame; drive both with one script; diff the [canonical DOM](glossary.md#canonical-dom)
+plus the [intent](glossary.md#intent) streams at every checkpoint.
 
 ```clojure
 (ns app.migration.article-row-shadow
@@ -124,9 +124,9 @@ plus the intent streams at every checkpoint.
 
 Each side gets its own copy of the seeded frame, so writes never cross, and
 a divergence *compounds* instead of hiding: when the port dispatches a
-different intent at step one, its state — and therefore its DOM — drifts
+different [intent](glossary.md#intent) at step one, its state — and therefore its DOM — drifts
 further at every later step. At each checkpoint the harness compares the
-canonical DOM of both mounts and the intents that each side's handlers
+[canonical DOM](glossary.md#canonical-dom) of both mounts and the intents that each side's handlers
 dispatched. A red names the checkpoint and the exact node or intent that
 differed. When the harness can attribute a difference to a *declared* policy
 — a Client-only crossing region, a named refusal — it reports the difference
@@ -147,7 +147,7 @@ work, and watch divergence appear as you type.
 Shadow mode is dev-only. The harness, the dual mount, and the Reagent
 dependency itself are development scope; on the day the last shadow goes
 green, Reagent leaves your `deps.edn`. The scope is also limited, and the
-limit is stated: shadow mode compares canonical DOM and intent streams, not
+limit is stated: shadow mode compares [canonical DOM](glossary.md#canonical-dom) and intent streams, not
 focus, caret, IME, or paint. Those are browser laws, and the browser tier of
 [Testing](14-testing.md) owns them.
 
@@ -173,7 +173,7 @@ rewrite families:
 
 | | At | Written | Preserving |
 |---|---|---|---|
-| W1 | `^{:key k}` on the vector | `:key k` inside the props map | Reagent read the metadata key; Hicasso reads `(:key props)` — left alone the key goes dead |
+| W1 | `^{:key k}` on the vector | `:key k` inside the props map | Reagent read the metadata key; [Hicasso](glossary.md#hicasso) reads `(:key props)` — left alone the key goes dead |
 | W2 | a literal map reached from the props map through map values | the same map, its literal keys respelled camelCase | Reagent deep-camelCased nested keys; Hicasso does not |
 | W3 | a literal keyword, or a quoted symbol, at a prop value | its `name`, as a string | Reagent's `(name x)` arm — a namespaced keyword loses its namespace here, exactly as it already did |
 | W4 | a literal `(r/partial f a …)` at a prop value | a hygienic `let` capture, then Reagent's own wrapper | Reagent evaluated the callee and arguments **once**, at construction — the `let` keeps that |
@@ -198,19 +198,19 @@ standing behind it.
 
 ## What stays manual, and why
 
-- **Every `h/defhost` declaration and every `:callbacks` contract.** A
+- **Every [`h/defhost`](glossary.md#defhost) declaration and every `:callbacks` contract.** A
   contract states what a prop *means*, and the meaning is not in your source
   text — it is in the library's documentation. The suggestions block drafts
   the declaration; you approve it.
-- **The blockers.** An intent vector at a `[:>]` prop
+- **The blockers.** An [intent](glossary.md#intent) vector at a `[:>]` prop
   (`:intent-needs-a-declaration`) needs a decision about what it was for.
   `dangerouslySetInnerHTML` (`:dangerous-html`) needs a deliberate yes:
-  Reagent deleted it unless wrapped, Hicasso passes it through, so the
+  Reagent deleted it unless wrapped, [Hicasso](glossary.md#hicasso) passes it through, so the
   migration turns a dead prop into a live one. Port `[:r> …]` and `[:f> …]`
   sites by hand — Hicasso reads those as tag keywords and quietly renders an
   unknown element. Restructure `r/as-element` inside a callback
   (`:as-element-island`) by hand: that closure runs outside the owner's
-  render window, so its lowering is not a text substitution.
+  render window, so its [lowering](glossary.md#lowering) is not a text substitution.
 - **Local state and lifecycle** (`:reagent-api-residue`): `r/atom`, cursors,
   form-2/form-3 shapes. Where a piece of state lives is a design decision —
   [Ephemeral state](11-ephemeral-state.md) owns the homes — and no tool
@@ -223,14 +223,14 @@ standing behind it.
 
 | Symptom | What is happening | Fix |
 |---|---|---|
-| A `[:>]` site renders but behaves subtly differently than under Reagent | Props dialect drift — Reagent converted on the way across; Hicasso does not | Run the reporter; let the codemod repair the decidable sites |
-| A page throws at render at a `[:>]` site that "worked" before | `:rf.error/hicasso-host-undeclared-callback` — an intent vector at an escape prop; under Reagent it crossed as an inert array and never fired | Declare the host and name the prop in `:callbacks`, or hand a plain function — and decide what the dead handler was for |
-| A handler runs, then `:rf.error/no-frame-context` | A Reagent-style `#(rf/dispatch …)` closure — it carries no frame | Make it an event vector, or `h/event` |
+| A `[:>]` site renders but behaves subtly differently than under Reagent | Props dialect drift — Reagent converted on the way across; [Hicasso](glossary.md#hicasso) does not | Run the reporter; let the codemod repair the decidable sites |
+| A page throws at render at a `[:>]` site that "worked" before | `:rf.error/hicasso-host-undeclared-callback` — an [intent](glossary.md#intent) vector at an escape prop; under Reagent it crossed as an inert array and never fired | Declare the host and name the prop in `:callbacks`, or hand a plain function — and decide what the dead handler was for |
+| A handler runs, then `:rf.error/no-frame-context` | A Reagent-style `#(rf/dispatch …)` closure — it carries no frame | Make it an event vector, or [`h/event`](glossary.md#hevent) |
 | A keyed list remounts once right after migration | The `:key` slot is reported, never rewritten: `:foo` and `"foo"` keys collided under Reagent and are distinct now, so the key value changes once | Accept the one-time remount; keys are stable after |
 | The codemod refused a whole nested map | `:normalized-key-collision` — sibling keys like `:foo-bar`/`:fooBar` collapsed onto one JS property under Reagent, with an iteration-order winner | Delete the key you did not mean; re-run |
 | A W2 diff camelCased keys in what is clearly a *data* map | Behaviour preserved: Reagent already sent the library camelCase | Do **not** revert the keys — a revert changes what the library receives. If the map was data, notice it now |
-| Shadow run red on a region the port renders client-only | A declared Client-only crossing, classified as a policy difference, not drift | Choose the server policy deliberately (`{:server :render}` or a fallback) or accept the classification |
-| Shadow green, but focus/IME behaves differently in a real browser | Shadow compares canonical DOM and intents; browser laws are out of its scope | Run the browser tier ([Testing](14-testing.md)) |
+| Shadow run red on a region the port renders client-only | A declared Client-only crossing, classified as a policy difference, not drift | Choose the [server policy](glossary.md#server-policy) deliberately (`{:server :render}` or a fallback) or accept the classification |
+| Shadow green, but focus/IME behaves differently in a real browser | Shadow compares [canonical DOM](glossary.md#canonical-dom) and intents; browser laws are out of its scope | Run the browser tier ([Testing](14-testing.md)) |
 | Second codemod run produced a diff | It cannot — outputs are outside the input language. If files changed, something else edited them between runs | Diff against the report's coordinates; re-run the reporter |
 
 ## When not to migrate this way
@@ -290,7 +290,7 @@ names are fresh.
 ### Divergences the tool deliberately leaves alone
 
 These divergences are named so that you do not file them as gaps. Each is a
-place where Hicasso is better than the donor, or where the difference is
+place where [Hicasso](glossary.md#hicasso) is better than the donor, or where the difference is
 invisible:
 
 - Class collections in any spelling now coerce and compose (Reagent read

--- a/docs/design/hicasso/draft-guide/20-code-splitting.md
+++ b/docs/design/hicasso/draft-guide/20-code-splitting.md
@@ -88,7 +88,7 @@ module downloads before the click. Hot reload is undisturbed — a loaded
 module's namespaces reload like any others, and an unloaded module has
 nothing to reload.
 
-## The React bridge: [`n/lazy`](glossary.md#nlazy) and a Suspense host
+## The React bridge: `n/lazy` and a Suspense host
 
 A [native island](glossary.md#native-island) or a React-shaped screen can instead load through React's
 own lazy machinery. That is the correct choice when the region already lives

--- a/docs/design/hicasso/draft-guide/20-code-splitting.md
+++ b/docs/design/hicasso/draft-guide/20-code-splitting.md
@@ -4,8 +4,8 @@ Your admin area is a third of the bundle, and most sessions never open it.
 This page splits the build so that code loads when it is first wanted. It
 covers three things:
 
-- the route-and-module boundary, which covers almost every real split;
-- the `React.lazy` bridge for native islands;
+- the route-and-module [boundary](glossary.md#boundary), which covers almost every real split;
+- the `React.lazy` bridge for [native islands](glossary.md#native-island);
 - what Suspense and Activity do to your reads while a subtree waits or
   hides.
 
@@ -76,9 +76,9 @@ Wire the load to the route — `:on-match` dispatches when the route activates
 ```
 
 Every piece is machinery that you already know. The pending placeholder is a
-branch, not a Suspense fallback. The failure is a value with a retry intent,
+branch, not a Suspense fallback. The failure is a value with a retry [intent](glossary.md#intent),
 not an exception. The loaded screen is an ordinary view head — after the
-load, `@admin-screen` is the `h/defview`-minted view, with its boundary,
+load, `@admin-screen` is the [`h/defview`](glossary.md#defview)-minted view, with its [boundary](glossary.md#boundary),
 reads, and name intact. The `:loading`/`:loaded` check is the dedupe, so
 navigation away and back never double-loads.
 
@@ -88,15 +88,15 @@ module downloads before the click. Hot reload is undisturbed — a loaded
 module's namespaces reload like any others, and an unloaded module has
 nothing to reload.
 
-## The React bridge: `n/lazy` and a Suspense host
+## The React bridge: [`n/lazy`](glossary.md#nlazy) and a Suspense host
 
-A native island or a React-shaped screen can instead load through React's
+A [native island](glossary.md#native-island) or a React-shaped screen can instead load through React's
 own lazy machinery. That is the correct choice when the region already lives
-on the native tier and you want React to own the pending swap. The bridge is
-`n/lazy`, the ABI helper from [the native tier](10-native-tier.md). It has
+on the [native tier](glossary.md#native-tier) and you want React to own the pending swap. The bridge is
+[`n/lazy`](glossary.md#nlazy), the ABI helper from [the native tier](10-native-tier.md). It has
 the same thunk-returning-a-promise contract as `React.lazy`, and it resolves
 to the component. It keeps the component marker, so Xray still names the
-boundary, and HMR still replaces the implementation without remounting it.
+[boundary](glossary.md#boundary), and HMR still replaces the implementation without remounting it.
 
 ```clojure
 (ns app.charts.gate
@@ -126,12 +126,12 @@ boundary, and HMR still replaces the implementation without remounting it.
 
 While the code loads, React shows the Suspense fallback — hiccup in a
 declared slot, like any other ([Interop](09-interop.md)). A loader rejection
-throws into the render, so the nearest `h/error-boundary` catches it, and
+throws into the render, so the nearest [`h/error-boundary`](glossary.md#error-boundary) catches it, and
 the `:reset-key` counter is the retry, exactly as in [Errors](16-errors.md)
 — the next attempt re-runs the loader.
 
 !!! warning "Declare lazy components outside render"
-    `n/lazy` (like `React.lazy`) mints a component identity. When the mint
+    [`n/lazy`](glossary.md#nlazy) (like `React.lazy`) mints a component identity. When the mint
     happens inside a body, every render mints a fresh identity, so React
     unmounts and remounts the subtree — and re-triggers the load — each time
     the body runs. Both declarations above are top-level `def`s; keep yours
@@ -165,10 +165,10 @@ law holds through both, because commit owns acquisition
   from state:
 
   ```clojure
-  (h/defhost activity react/Activity)
+  ([h/defhost](glossary.md#defhost) activity react/Activity)
 
-  [activity {:mode (if (h/sub [:inbox/visible?]) "visible" "hidden")}
-   [inbox-pane {}]]
+  activity {:mode (if ([h/sub](glossary.md#hsub) :inbox/visible?]) "visible" "hidden")}
+   inbox-pane {}]]
   ```
 
   While the pane is hidden, React cleans up effects, and the subtree's
@@ -187,9 +187,9 @@ law holds through both, because commit owns acquisition
 | Navigation to the split route renders nothing, and then the screen appears after a delay | The shell renders the loaded view unconditionally, so the pre-load render was empty | Branch on the module status; render the skeleton and failed states |
 | The module double-loads on repeated visits | The load event does not consult state | Gate on the status, as `:admin/wanted` does — `:loading`/`:loaded` is the dedupe |
 | Works in `watch`, 404s in a release build | Module config drift — a missing `:depends-on`, or the entry namespace not in the module | Declare the dependency edge; keep one entries list per module |
-| The Suspense fallback flashes on every render of the parent | The lazy component was minted inside a body — fresh identity, fresh mount, fresh load | Declare `n/lazy` (and the loadable) at top level |
-| A failed chunk load leaves the skeleton up forever | Nothing catches the loader's rejection | Wrap the Suspense host in `h/error-boundary`; retry through `:reset-key` |
-| Xray shows an anonymous boundary; HMR remounts the island | Raw `React.lazy` erased the component marker | Use `n/lazy` — same semantics, marker intact ([Native tier](10-native-tier.md)) |
+| The Suspense fallback flashes on every render of the parent | The lazy component was minted inside a body — fresh identity, fresh mount, fresh load | Declare [`n/lazy`](glossary.md#nlazy) (and the loadable) at top level |
+| A failed chunk load leaves the skeleton up forever | Nothing catches the loader's rejection | Wrap the Suspense host in [`h/error-boundary`](glossary.md#error-boundary); retry through `:reset-key` |
+| Xray shows an anonymous [boundary](glossary.md#boundary); HMR remounts the island | Raw `React.lazy` erased the component marker | Use [`n/lazy`](glossary.md#nlazy) — same semantics, marker intact ([Native tier](10-native-tier.md)) |
 | The lazy region is missing from server HTML | Client-only by design — the server carries the fallback, never the un-arrived component | Make the fallback a same-footprint skeleton; the live component mounts after adoption |
 | A hidden pane's state is gone on reveal | The pane was unmounted, not hidden — a `when`, not an Activity `:mode` flip | Hide with `:mode "hidden"` to retain UI state; unmount when you mean gone. App-db state at addresses survives either way |
 
@@ -200,7 +200,7 @@ law holds through both, because commit owns acquisition
   and rarely visited, not on principle.
 - **Below the route or screen grain.** Per-widget chunks multiply pending
   states and round trips; users already expect a pause at the route
-  boundary.
+  [boundary](glossary.md#boundary).
 - **For data.** Suspense is not your loading UI, and lazy loading is not
   your fetch layer. Resource status is explicit state with a better
   vocabulary ([Async resources](08-async-resources.md)).

--- a/docs/design/hicasso/draft-guide/21-accessibility.md
+++ b/docs/design/hicasso/draft-guide/21-accessibility.md
@@ -1,7 +1,7 @@
 # Accessibility
 
 A screen reader announces "clickable, group" where you meant "Delete, button",
-and Tab skips your busiest control. Hicasso ships no accessibility subsystem
+and Tab skips your busiest control. [Hicasso](glossary.md#hicasso) ships no accessibility subsystem
 to fix that, because the fix is not a subsystem. Semantic Hiccup and native
 controls carry names, roles, and keyboard behaviour on their own. Your job is
 mostly to keep those behaviours in place — and then prove it in tests.
@@ -27,7 +27,7 @@ hand is a copy of one platform behaviour, minus the ones you forgot:
 
 The same trade repeats across the vocabulary:
 
-- `:a` for navigation — `route-link` returns a real anchor, so middle-click
+- `:a` for navigation — [`route-link`](glossary.md#route-link) returns a real anchor, so middle-click
   and copy-link work.
 - `:label` wrapping its control, or pointing at it with `:for`.
 - `:ul`/`:li` for lists, and `:table` for tabular data.
@@ -64,7 +64,7 @@ share one address, and they break the same way.
 
 `:aria-*` attributes pass through exactly as written
 ([Views and reads](02-views-and-reads.md)), so there is nothing
-Hicasso-specific to learn — including on `h/defhost` crossings, where
+Hicasso-specific to learn — including on [`h/defhost`](glossary.md#defhost) crossings, where
 `aria-*` stays hyphenated.
 
 ## State assistive tech reads is the state you already have
@@ -90,7 +90,7 @@ The chapters that own each widget already write this shape:
 `:aria-hidden` ride [an exiting node](11-ephemeral-state.md). What those
 chapters never do is mirror platform state back into app-db. Focus in
 particular belongs to the platform
-([Ephemeral state](11-ephemeral-state.md)): you express intent once, and the
+([Ephemeral state](11-ephemeral-state.md)): you express [intent](glossary.md#intent) once, and the
 restore contracts do the rest.
 
 Error display pairs the message to the field the same way — derived, per
@@ -112,7 +112,7 @@ already has its owner page, and this table is the inventory:
 | Moment | Conduct | Owner |
 |---|---|---|
 | Route change | Focus the keyed main region, `:tab-index -1`, `preventScroll` | [Routing and navigation](07-routing-and-navigation.md) |
-| Overlay opens / closes | `:auto-focus` intent in; platform trap; restore on close | [Overlays and focus](12-overlays-and-focus.md) |
+| Overlay opens / closes | `:auto-focus` [intent](glossary.md#intent) in; platform trap; restore on close | [Overlays and focus](12-overlays-and-focus.md) |
 | Composite widget (menu, listbox) | Focus stays on the trigger; `:aria-activedescendant` walks options | [Overlays and focus](12-overlays-and-focus.md) |
 | Exit animation | `:inert` + `:aria-hidden` ride the unmounting phase | [Ephemeral state](11-ephemeral-state.md) |
 | Virtualized list | The keyboard cannot reach rows that do not exist — decide, then verify in a browser | [Lists and collections](06-lists-and-collections.md) |
@@ -138,7 +138,7 @@ discipline are the same as everything else in [Testing](14-testing.md):
 ```
 
 Data cannot prove focus and traversal: where focus lands after a route
-change, whether Tab is trapped in a modal, whether a virtualized grid is
+change, whether Tab is trapped in a [modal](glossary.md#overlay), whether a virtualized grid is
 walkable. Those are engine facts, so they live in the browser tier, next to
 an automated axe pass over each screen's mounted state. The axe run is a
 floor, not the test. It catches missing names and broken pairings, and it
@@ -156,7 +156,7 @@ walk yourself for the screens where it matters.
 | Validation errors appear silently | The message div is not announced and not paired | `:role "alert"` on the message; `:aria-invalid` and `:aria-describedby` on the field |
 | Focus goes nowhere after navigating | The main region is not keyed and focusable | The route-focus recipe ([Routing and navigation](07-routing-and-navigation.md)) |
 | A fading toast still takes focus and clicks | The exit override lacks the a11y pair | `:inert` and `:aria-hidden` in `::motion/unmounting` ([Ephemeral state](11-ephemeral-state.md)) |
-| The modal traps focus but the page behind still scrolls | A hand-written dialog, not the native modal path | `overlay/modal` ([Overlays and focus](12-overlays-and-focus.md)) |
+| The [modal](glossary.md#overlay) traps focus but the page behind still scrolls | A hand-written dialog, not the native modal path | `overlay/modal` ([Overlays and focus](12-overlays-and-focus.md)) |
 | axe flags nothing but keyboard users are lost | axe checks attributes, not traversal order | Script the Tab walk in the browser tier for that screen |
 
 ## When not to add more

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -1,4 +1,4 @@
-# Hicasso — user guide
+# [Hicasso](glossary.md#hicasso) — user guide
 
 > **End-state guide.** This guide describes Hicasso as the completed programme ships it. Names follow the naming ledger's recommended defaults and can change at the one naming sitting (rf2-hic-065's packet).
 
@@ -11,24 +11,24 @@ of re-frame2.
 | Page | Its one job | Mode |
 |---|---|---|
 | [Getting started](01-getting-started.md) | Install Hicasso, mount a first app, release one screen | start/tutorial |
-| [Views and reads](02-views-and-reads.md) | Write views; read subscriptions where you use them; the read-extent law | concept |
-| [Events as data](03-events-as-data.md) | Put event vectors in attributes; `h/event` for computed events; prevention; keyboard | concept |
-| [Controlled inputs](04-controlled-inputs.md) | Fields whose value round-trips through app-db — caret, IME, and reset with `::h/revision` | concept |
+| [Views and reads](02-views-and-reads.md) | Write views; read subscriptions where you use them; the [read-extent law](glossary.md#read-extent-law) | concept |
+| [Events as data](03-events-as-data.md) | Put event vectors in attributes; [`h/event`](glossary.md#hevent) for computed events; prevention; keyboard | concept |
+| [Controlled inputs](04-controlled-inputs.md) | Fields whose value round-trips through app-db — caret, IME, and reset with [`::h/revision`](glossary.md#hrevision) | concept |
 | [Forms](05-forms.md) | Drafts, validation display, and submit status with `re-frame.hicasso.forms` | concept/how-to |
-| [Lists and collections](06-lists-and-collections.md) | Keys, read topology — fine, coarse, chunked, windowed — and virtualization | concept |
+| [Lists and collections](06-lists-and-collections.md) | Keys, [read topology](glossary.md#read-topology) — fine, coarse, chunked, windowed — and virtualization | concept |
 | [Routing and navigation](07-routing-and-navigation.md) | Route links, prefetch, scroll and focus, dirty-leave guards | how-to |
-| [Async resources](08-async-resources.md) | Settle-merge, per-instance mutation status, demand-driven committed reads, typeahead | how-to |
-| [Interop](09-interop.md) | Use React components from npm: `h/defhost`, ReactNode slots, `h/as-element`, portals, the outward bridge | concept/how-to |
-| [The native tier](10-native-tier.md) | The five-rung gradient to direct React — `n/$`, `n/props`, `n/defcomponent`, hooks — and when not to take it | concept/tutorial |
+| [Async resources](08-async-resources.md) | Settle-merge, per-instance mutation status, [demand-driven committed reads](glossary.md#demand-driven-committed-read), typeahead | how-to |
+| [Interop](09-interop.md) | Use React components from npm: [`h/defhost`](glossary.md#defhost), [ReactNode slots](glossary.md#reactnode-slot), [`h/as-element`](glossary.md#as-element), [portals](glossary.md#portal), the [outward bridge](glossary.md#outward-bridge) | concept/how-to |
+| [The native tier](10-native-tier.md) | The five-rung gradient to direct React — [`n/$`](glossary.md#n-dollar), [`n/props`](glossary.md#nprops), [`n/defcomponent`](glossary.md#ndefcomponent), hooks — and when not to take it | concept/tutorial |
 | [Ephemeral state](11-ephemeral-state.md) | Where each kind of UI state lives — there is no second store | explanation |
-| [Overlays and focus](12-overlays-and-focus.md) | Popovers and modals on the native top layer; focus intent; zero cost when closed | how-to |
+| [Overlays and focus](12-overlays-and-focus.md) | Popovers and modals on the native top layer; focus [intent](glossary.md#intent); zero cost when closed | how-to |
 | [Theming and i18n](13-theming-and-i18n.md) | Theme tokens, CSS variables, and live locale switching — without a subsystem | how-to |
-| [Testing](14-testing.md) | The test kit, from pure tree and intent assertions to mounted trees and real browsers | concept/how-to |
-| [Diagnostics](15-diagnostics.md) | Xray: explain-render, read attribution, the hot-view advisor, and the complaint catalogue | concept/how-to |
-| [Errors](16-errors.md) | `h/error-boundary` regions; expected failures stay data | concept |
-| [SSR and hydration](17-ssr-and-hydration.md) | The per-surface server contract, `h/hydrate!`, host policies, and the Node service | concept/how-to |
+| [Testing](14-testing.md) | The [test kit](glossary.md#test-kit), from pure tree and intent assertions to mounted trees and real browsers | concept/how-to |
+| [Diagnostics](15-diagnostics.md) | Xray: [explain-render](glossary.md#explain-render), read attribution, the [hot-view advisor](glossary.md#hot-view-advisor), and the [complaint catalogue](glossary.md#complaint-catalogue) | concept/how-to |
+| [Errors](16-errors.md) | [`h/error-boundary`](glossary.md#error-boundary) regions; expected failures stay data | concept |
+| [SSR and hydration](17-ssr-and-hydration.md) | The per-surface server contract, [`h/hydrate!`](glossary.md#hydrate), host policies, and the Node service | concept/how-to |
 | [Performance](18-performance.md) | Budgets first, then the ladder; per-keystroke mechanics; when an escape is justified | explanation/how-to |
 | [Migrating from Reagent](19-migration-from-reagent.md) | Reporter, shadow mode, codemod — and the refusal classes you will see | how-to |
-| [Code splitting and lazy loading](20-code-splitting.md) | Split at the route/module boundary; the `n/lazy` bridge; Suspense and Activity conduct | concept/how-to |
+| [Code splitting and lazy loading](20-code-splitting.md) | Split at the route/module [boundary](glossary.md#boundary); the [`n/lazy`](glossary.md#nlazy) bridge; Suspense and Activity conduct | concept/how-to |
 | [Accessibility](21-accessibility.md) | Names, roles, keyboard, and focus through semantic Hiccup — and how to test them | how-to |
 | [Glossary](glossary.md) | Hicasso nouns, verbs, and laws — one term, definition first | reference |

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -31,3 +31,4 @@ of re-frame2.
 | [Migrating from Reagent](19-migration-from-reagent.md) | Reporter, shadow mode, codemod — and the refusal classes you will see | how-to |
 | [Code splitting and lazy loading](20-code-splitting.md) | Split at the route/module boundary; the `n/lazy` bridge; Suspense and Activity conduct | concept/how-to |
 | [Accessibility](21-accessibility.md) | Names, roles, keyboard, and focus through semantic Hiccup — and how to test them | how-to |
+| [Glossary](glossary.md) | Hicasso nouns, verbs, and laws — one term, definition first | reference |

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -1,4 +1,4 @@
-# [Hicasso](glossary.md#hicasso) — user guide
+# Hicasso — user guide
 
 > **End-state guide.** This guide describes Hicasso as the completed programme ships it. Names follow the naming ledger's recommended defaults and can change at the one naming sitting (rf2-hic-065's packet).
 

--- a/docs/design/hicasso/draft-guide/glossary.md
+++ b/docs/design/hicasso/draft-guide/glossary.md
@@ -12,6 +12,7 @@ Grouped by role: [authoring](#authoring), [events and control](#events-and-contr
 
 ## Authoring
 
+<a id="hicasso"></a>
 ### **Hicasso**
 
 re-frame2's native view adapter: interpreted [Hiccup](../../../core/glossary.md#hiccup)
@@ -26,6 +27,7 @@ absent.
 
 Related: [Getting started](01-getting-started.md).
 
+<a id="defview"></a>
 ### **defview**
 
 `h/defview` — mints a Hicasso [view](#view): a React/re-frame [boundary](#boundary)
@@ -45,12 +47,14 @@ invocation refuses; mount it as a vector:
 
 Related: [Views and reads](02-views-and-reads.md).
 
+<a id="view"></a>
 ### **view**
 
 A function from a props map to markup, registered with [`defview`](#defview).
 In head position of a Hiccup vector it is a [boundary](#boundary). Plain
 `defn` helpers are not views: call them as functions so they [inline](#inline-helper).
 
+<a id="boundary"></a>
 ### **boundary**
 
 Hicasso's unit of independent re-render, minted by [`defview`](#defview). Owns
@@ -61,6 +65,7 @@ heads also sit in vector position; none of those is a boundary.
 
 Related: [Views and reads](02-views-and-reads.md).
 
+<a id="inline-helper"></a>
 ### **inline helper**
 
 An ordinary `defn` called from a view body. Its Hiccup splices into the caller;
@@ -92,6 +97,7 @@ into [native](#native-tier) code, use [`n/use-sub`](#nuse-sub) instead.
 
 Related: [Views and reads](02-views-and-reads.md).
 
+<a id="read-extent-law"></a>
 ### **read-extent law**
 
 `h/sub` is legal only during the **direct synchronous execution** of the
@@ -103,6 +109,7 @@ async work re-enters through events and coeffects.
 
 Related: [Views and reads](02-views-and-reads.md).
 
+<a id="collector"></a>
 ### **collector**
 
 Runtime mechanism that records which subscriptions a [boundary](#boundary)
@@ -112,6 +119,7 @@ the [read-extent law](#read-extent-law) forbids.
 
 Related: [Views and reads](02-views-and-reads.md#the-collector).
 
+<a id="component-abi"></a>
 ### **component ABI**
 
 The props/children contract for a head: what converts, what is opaque, where
@@ -121,6 +129,7 @@ metadata); [hosts](#defhost) convert per declaration; native
 
 Related: [Views and reads](02-views-and-reads.md#the-component-abi).
 
+<a id="lowering"></a>
 ### **lowering**
 
 The step that turns Hicasso data into React props and elements: Hiccup walk,
@@ -130,6 +139,7 @@ owner when Xray names "lowering"; the narrow escape is a direct
 
 Related: [Events as data](03-events-as-data.md), [Native tier](10-native-tier.md).
 
+<a id="owned-wins"></a>
 ### **owned wins**
 
 Attribute-merge rule: literal keys written on the element always beat
@@ -138,6 +148,7 @@ through a generic merge.
 
 Related: [Views and reads](02-views-and-reads.md#forwarding-attributes-owned-wins).
 
+<a id="read-topology"></a>
 ### **read topology**
 
 Where [reads](#hsub) sit relative to list structure — the main performance
@@ -156,6 +167,7 @@ Related: [Lists and collections](06-lists-and-collections.md).
 
 ## Events and control
 
+<a id="intent"></a>
 ### **intent**
 
 An [event](../../../core/glossary.md#event) vector written in an attribute at
@@ -207,6 +219,7 @@ intent. Nothing auto-prevents — not click, not submit.
 
 Related: [Events as data](03-events-as-data.md).
 
+<a id="controlled-field"></a>
 ### **controlled field**
 
 An input whose displayed value is owned by app-db (via a subscription) and
@@ -233,6 +246,7 @@ namespaced keyword only; a bare `:revision` is an ordinary attribute.
 
 Related: [Controlled inputs](04-controlled-inputs.md).
 
+<a id="buffered-field"></a>
 ### **buffered-field**
 
 `forms/buffered-field` — optional forms helper: one controlled input with a
@@ -242,6 +256,7 @@ validation display.
 
 Related: [Forms](05-forms.md).
 
+<a id="keyboard-map"></a>
 ### **keyboard map**
 
 Data map on a keyboard prop (e.g. `:on-key-down`) from key chord → intent.
@@ -254,6 +269,7 @@ Related: [Events as data](03-events-as-data.md#keyboard-as-data).
 
 ## Interop
 
+<a id="defhost"></a>
 ### **defhost**
 
 `h/defhost` — declared door to a foreign React component. Names the React
@@ -269,6 +285,7 @@ Quarantines the npm require in one host namespace.
 
 Related: [Interop](09-interop.md).
 
+<a id="reactnode-slot"></a>
 ### **ReactNode slot**
 
 A prop position a [host](#defhost) declares as carrying React children or
@@ -277,6 +294,7 @@ lowers under the captured frame without deep-converting arbitrary data maps.
 
 Related: [Interop](09-interop.md#reactnode-slots).
 
+<a id="as-element"></a>
 ### **as-element**
 
 `h/as-element` — explicit Hiccup → React element conversion for render props
@@ -290,6 +308,7 @@ ReactNode, not data.
 
 Related: [Interop](09-interop.md), [Lists and collections](06-lists-and-collections.md).
 
+<a id="outward-bridge"></a>
 ### **as-component** / **outward bridge**
 
 `h/as-component` returns a real React component so a native parent
@@ -299,6 +318,7 @@ Symmetric to hosts embedding foreign React inward.
 
 Related: [Interop](09-interop.md#the-outward-bridge).
 
+<a id="portal"></a>
 ### **portal**
 
 Optional helper that lowers Hiccup into `createPortal`, preserves frame and
@@ -308,6 +328,7 @@ overlay module instead of a hand-rolled portal.
 
 Related: [Interop](09-interop.md#portals), [Overlays and focus](12-overlays-and-focus.md).
 
+<a id="server-policy"></a>
 ### **server policy**
 
 Per-surface answer for SSR: **Render** (deterministic React server bytes) or
@@ -329,6 +350,7 @@ Related: [Interop](09-interop.md#the-escape-).
 
 ## Native tier
 
+<a id="native-tier"></a>
 ### **native tier**
 
 Optional namespace `re-frame.hicasso.native` (alias `n`): explicit exit to
@@ -380,6 +402,7 @@ or UIx `defui` — not inside a dynamically branched [`defview`](#defview) body.
 
 Related: [Native tier](10-native-tier.md).
 
+<a id="native-island"></a>
 ### **native island**
 
 A named native component under the same React root and re-frame2 frame as
@@ -400,6 +423,7 @@ need.
 Related: [Native tier](10-native-tier.md#keeping-the-marker-the-abi-helpers),
 [Code splitting](20-code-splitting.md).
 
+<a id="performance-ladder"></a>
 ### **performance ladder**
 
 Five explicit rungs from ordinary Hicasso to a full native screen. No
@@ -413,6 +437,7 @@ Five explicit rungs from ordinary Hicasso to a full native screen. No
 
 Related: [Performance](18-performance.md), [Native tier](10-native-tier.md).
 
+<a id="escape-benefit-rule"></a>
 ### **escape-benefit rule**
 
 An escape stays only if it recovers **≥20%** of the measured interaction,
@@ -425,6 +450,7 @@ Related: [Performance](18-performance.md#the-escape-benefit-rule).
 
 ## State homes
 
+<a id="one-state-owner"></a>
 ### **one state owner**
 
 Application-visible state lives in re-frame2 [app-db](../../../core/glossary.md#app-db)
@@ -434,6 +460,7 @@ invisible duplicate of application facts.
 
 Related: [Ephemeral state](11-ephemeral-state.md).
 
+<a id="pressure-valve"></a>
 ### **pressure valve**
 
 Named legitimate home for a kind of UI state under [one state owner](#one-state-owner):
@@ -443,6 +470,7 @@ fits no valve, it goes to app-db.
 
 Related: [Ephemeral state](11-ephemeral-state.md).
 
+<a id="overlay"></a>
 ### **overlay (popover / modal)**
 
 `re-frame.hicasso.overlay` primitives on the browser's native top layer.
@@ -451,6 +479,7 @@ light-dismiss, and focus trap/return. Closed means zero DOM and zero listeners.
 
 Related: [Overlays and focus](12-overlays-and-focus.md).
 
+<a id="route-link"></a>
 ### **route-link**
 
 Routing helper: navigates by event, optional intent [prefetch](../../../routing/glossary.md#intent-prefetch),
@@ -459,6 +488,7 @@ comparison, not a built-in class.
 
 Related: [Routing and navigation](07-routing-and-navigation.md).
 
+<a id="demand-driven-committed-read"></a>
 ### **demand-driven committed read**
 
 Optional resource read that declares `:demand true`: **commit acquires**,
@@ -479,6 +509,7 @@ Related: [Async resources](08-async-resources.md#demand-driven-committed-reads),
 
 ## Testing
 
+<a id="test-kit"></a>
 ### **test kit**
 
 Supported namespace `re-frame.hicasso.test` (alias `ht`): pure data tiers,
@@ -487,6 +518,7 @@ Product surface, not a loose utility bag.
 
 Related: [Testing](14-testing.md).
 
+<a id="testing-ladder"></a>
 ### **testing ladder**
 
 Five rungs; use the lowest that can prove the claim:
@@ -503,6 +535,7 @@ A green lower rung never claims a higher equality (L2 ≠ hydration bytes).
 
 Related: [Testing](14-testing.md).
 
+<a id="semantic-harness"></a>
 ### **semantic harness**
 
 L2: `ht/tree` runs a registered hook-free body under injected read fixtures
@@ -511,6 +544,7 @@ are **opaque** and refuse — mount those at L3.
 
 Related: [Testing](14-testing.md#l2--the-semantic-harness).
 
+<a id="mounted-facade"></a>
 ### **mounted facade**
 
 L3 helpers: isolated-frame mount, hydrate, rerender, dispatch-and-settle,
@@ -519,6 +553,7 @@ quiescence).
 
 Related: [Testing](14-testing.md#l3--the-mounted-facade).
 
+<a id="sabotage-control"></a>
 ### **sabotage control**
 
 Negative twin of an important gate: a deliberate mutation that must make the
@@ -526,6 +561,7 @@ gate fail, so an empty population cannot pass green.
 
 Related: [Testing](14-testing.md#the-sabotage-twin).
 
+<a id="canonical-dom"></a>
 ### **canonical DOM**
 
 Normalized DOM / structure equality used by differential and migration
@@ -539,6 +575,7 @@ Related: [Testing](14-testing.md#canonical-dom),
 
 ## Diagnostics
 
+<a id="causal-lens"></a>
 ### **causal lens**
 
 Xray's diagnostic chain:
@@ -553,6 +590,7 @@ paint.** Timing proximity alone never proves a link.
 
 Related: [Diagnostics](15-diagnostics.md).
 
+<a id="explain-render"></a>
 ### **explain-render**
 
 Xray answer to *why did this [boundary](#boundary) run?* — cause kind (reads,
@@ -561,6 +599,7 @@ completeness and loss.
 
 Related: [Diagnostics](15-diagnostics.md#explain-render).
 
+<a id="hot-view-advisor"></a>
 ### **hot-view advisor**
 
 Ranks hot boundaries (time, frequency, read churn, fan-out), **classifies
@@ -571,6 +610,7 @@ addresses the measured owner; never auto-promotes.
 Related: [Diagnostics](15-diagnostics.md#the-hot-view-advisor),
 [Performance](18-performance.md).
 
+<a id="loss-labels"></a>
 ### **loss labels**
 
 Honest gaps instead of empty panels: `:unknown`, `:opaque` /
@@ -579,6 +619,7 @@ never encoded as an empty collection.
 
 Related: [Diagnostics](15-diagnostics.md#honest-loss-labels).
 
+<a id="complaint-catalogue"></a>
 ### **complaint catalogue**
 
 Stable `:rf.error/*` / `:rf.warning/*` ids with cause, recovery, and
@@ -587,6 +628,7 @@ id, not prose.
 
 Related: [Diagnostics](15-diagnostics.md#the-complaint-catalogue).
 
+<a id="production-erasure"></a>
 ### **production erasure**
 
 Dev diagnostics, source maps for complaints, and evidence sentinels are absent
@@ -617,6 +659,7 @@ hooks).
 
 Related: [Getting started](01-getting-started.md).
 
+<a id="hydrate"></a>
 ### **hydrate!**
 
 Client adoption of server-rendered HTML for a root: install the payload and
@@ -625,6 +668,7 @@ share one React renderer; mismatches surface as hydration errors.
 
 Related: [SSR and hydration](17-ssr-and-hydration.md).
 
+<a id="error-boundary"></a>
 ### **error-boundary**
 
 `h/error-boundary` — React error region in the tree (`:fallback`,
@@ -634,6 +678,7 @@ exceptions.
 
 Related: [Errors](16-errors.md).
 
+<a id="user-visible-budget"></a>
 ### **user-visible budget**
 
 Performance contract in terms a user can notice (e.g. discrete interaction
@@ -643,6 +688,7 @@ synthetic scores never redefine "fast enough."
 
 Related: [Performance](18-performance.md#the-budgets).
 
+<a id="shadow-comparison"></a>
 ### **shadow comparison**
 
 Migration witness: dual-render canonical DOM / intent diff against a Reagent

--- a/docs/design/hicasso/draft-guide/glossary.md
+++ b/docs/design/hicasso/draft-guide/glossary.md
@@ -1,0 +1,652 @@
+# Hicasso glossary
+
+Hicasso nouns, verbs, and laws. One term, definition first; short code when
+the spelling matters; Related points at the teaching page. Core re-frame2
+terms (`app-db`, [frame](../../../core/glossary.md#frame), [event](../../../core/glossary.md#event),
+[subscription](../../../core/glossary.md#subscription)) live in the
+[core glossary](../../../core/glossary.md).
+
+Grouped by role: [authoring](#authoring), [events and control](#events-and-control),
+[interop](#interop), [native tier](#native-tier), [state homes](#state-homes),
+[testing](#testing), [diagnostics](#diagnostics), and [lifecycle and delivery](#lifecycle-and-delivery).
+
+## Authoring
+
+### **Hicasso**
+
+re-frame2's native view adapter: interpreted [Hiccup](../../../core/glossary.md#hiccup)
+on a modern React function-component host. You write vectors and maps, read
+with [`h/sub`](#hsub) at the point of use, and put event vectors in attributes
+as [intents](#intent). The app-db, events, and pipeline stay ordinary
+re-frame2.
+
+Require `[re-frame.hicasso :as h]`. Optional modules (forms, overlays, native
+tier, test kit, routing helpers) are separate requires and cost nothing when
+absent.
+
+Related: [Getting started](01-getting-started.md).
+
+### **defview**
+
+`h/defview` — mints a Hicasso [view](#view): a React/re-frame [boundary](#boundary)
+used as a Hiccup head. Props map in, Hiccup (or a native React element at
+[rung 3 of the performance ladder](#performance-ladder)) out. Direct Clojure
+invocation refuses; mount it as a vector:
+
+```clojure
+(h/defview counter [_]
+  [:main
+   [:h1 "Clicked " (h/sub [:counter/count]) " times"]
+   [:button {:on-click [:counter/increment]} "Click me"]])
+
+[counter]          ;; legal
+(counter {})       ;; refuses — write [counter]
+```
+
+Related: [Views and reads](02-views-and-reads.md).
+
+### **view**
+
+A function from a props map to markup, registered with [`defview`](#defview).
+In head position of a Hiccup vector it is a [boundary](#boundary). Plain
+`defn` helpers are not views: call them as functions so they [inline](#inline-helper).
+
+### **boundary**
+
+Hicasso's unit of independent re-render, minted by [`defview`](#defview). Owns
+four things: React identity, the body's [`h/sub`](#hsub) reads, value-equality
+memoization, and the [frame](../../../core/glossary.md#frame) to which
+[intents](#intent) dispatch. Native tags, fragments, and [`defhost`](#defhost)
+heads also sit in vector position; none of those is a boundary.
+
+Related: [Views and reads](02-views-and-reads.md).
+
+### **inline helper**
+
+An ordinary `defn` called from a view body. Its Hiccup splices into the caller;
+any `h/sub` it performs donates membership **upward** to the enclosing
+[boundary](#boundary). Helpers cost no re-render granularity. A plain `defn`
+in head position refuses (`:rf.error/hicasso-bad-head`).
+
+```clojure
+[todo-row {:key id :id id}]   ;; boundary child
+(row-icon {:kind :urgent})    ;; inlined helper
+```
+
+Related: [Views and reads](02-views-and-reads.md).
+
+<a id="hsub"></a>
+### **h/sub**
+
+The only view-side subscription read. Ordinary function call at the point of
+use — legal in `let`, `when`, loops, and synchronous helpers. Tracks reads for
+the active [boundary](#boundary) under the [read-extent law](#read-extent-law).
+
+```clojure
+(let [todo (h/sub [:todo/by-id id])]
+  [:span (:title todo)])
+```
+
+Bare `rf/subscribe` in a body is not a fallback: it refuses. Past the fence
+into [native](#native-tier) code, use [`n/use-sub`](#nuse-sub) instead.
+
+Related: [Views and reads](02-views-and-reads.md).
+
+### **read-extent law**
+
+`h/sub` is legal only during the **direct synchronous execution** of the
+active [boundary](#boundary) body (including ordinary helpers it calls). A
+read deferred through a callback, promise, timer, lazy sequence, or other
+escaped extent refuses with source and recovery
+(`:rf.error/hicasso-sub-outside-render`). Capture values during the body;
+async work re-enters through events and coeffects.
+
+Related: [Views and reads](02-views-and-reads.md).
+
+### **collector**
+
+Runtime mechanism that records which subscriptions a [boundary](#boundary)
+took during one body run. Commit reconciles that read set; abandoned and
+retried renders acquire no durable ownership. Escaping the collector is what
+the [read-extent law](#read-extent-law) forbids.
+
+Related: [Views and reads](02-views-and-reads.md#the-collector).
+
+### **component ABI**
+
+The props/children contract for a head: what converts, what is opaque, where
+keys live. [Views](#view) take a Clojure props map (keys in the map, not
+metadata); [hosts](#defhost) convert per declaration; native
+[`n/$`](#n) uses React slots and no intent lowering.
+
+Related: [Views and reads](02-views-and-reads.md#the-component-abi).
+
+### **lowering**
+
+The step that turns Hicasso data into React props and elements: Hiccup walk,
+[intent](#intent) → callback, controlled-field repair, attribute rules. Cost
+owner when Xray names "lowering"; the narrow escape is a direct
+[`n/$`](#n-dollar) return from the same [boundary](#boundary).
+
+Related: [Events as data](03-events-as-data.md), [Native tier](10-native-tier.md).
+
+### **owned wins**
+
+Attribute-merge rule: literal keys written on the element always beat
+forwarded maps, by presence. Do not forward `:key` or [`::h/revision`](#hrevision)
+through a generic merge.
+
+Related: [Views and reads](02-views-and-reads.md#forwarding-attributes-owned-wins).
+
+### **read topology**
+
+Where [reads](#hsub) sit relative to list structure — the main performance
+knob while staying on ordinary Hicasso:
+
+| Shape | Idea |
+|---|---|
+| **Fine** | each row reads itself — sparse independent updates |
+| **Coarse** | one view-model for the whole list — cheap mount / bulk replace |
+| **Chunked** | page-sized batches bound the invalidation sweep |
+| **Windowed** | only visible rows exist in the DOM (usually a foreign virtualizer) |
+
+Related: [Lists and collections](06-lists-and-collections.md).
+
+---
+
+## Events and control
+
+### **intent**
+
+An [event](../../../core/glossary.md#event) vector written in an attribute at
+an event position (`on-*` / `onClick`). The runtime builds the callback and
+dispatches the vector to the rendering [boundary](#boundary)'s frame. The tree
+stays data: tests assert with `=`; tools read meaning without running the app.
+
+```clojure
+[:button {:on-click [:todo/toggle id]} "✓"]
+```
+
+Related: [Events as data](03-events-as-data.md).
+
+<a id="hevent"></a>
+### **h/event**
+
+Explicit handler form when a vector intent is not enough: value-first foreign
+callbacks, calculated events, or reading the invoker's arguments. Captures
+the current frame at creation; one meaning everywhere (including host slots).
+
+```clojure
+{:on-change (h/event [date] [:calendar/picked date])}
+```
+
+Related: [Events as data](03-events-as-data.md).
+
+<a id="hvalue"></a>
+<a id="hchecked"></a>
+### **::h/value** / **::h/checked**
+
+Reserved markers substituted at dispatch from the DOM event target's
+`.value` / `.checked`. Top level of the intent vector only.
+
+```clojure
+[:input {:value (h/sub [:draft]) :on-input [:edit ::h/value]}]
+```
+
+Related: [Events as data](03-events-as-data.md), [Controlled inputs](04-controlled-inputs.md).
+
+<a id="hprevent"></a>
+### **::h/prevent**
+
+Intent head that prevents the browser default, then dispatches the inner
+intent. Nothing auto-prevents — not click, not submit.
+
+```clojure
+[:form {:on-submit [::h/prevent [:signup/submit]]} …]
+```
+
+Related: [Events as data](03-events-as-data.md).
+
+### **controlled field**
+
+An input whose displayed value is owned by app-db (via a subscription) and
+whose edits return as [intents](#intent). Hicasso's controlled law covers
+same-turn convergence, committed echo, caret/selection, IME composition, and
+identity-preserving [revision](#hrevision) reset. Form fields stay on the
+interpreted side; the [native tier](#native-tier) has no controlled repair.
+
+Related: [Controlled inputs](04-controlled-inputs.md).
+
+<a id="hrevision"></a>
+### **::h/revision**
+
+Reserved controlled-text prop: change this value to re-baseline the field's
+draft (accept, reject, or rewrite). Reset is never by value equality — a
+model that reasserts the same string would be invisible to `not=`. Exact
+namespaced keyword only; a bare `:revision` is an ordinary attribute.
+
+```clojure
+[:input {:value       (h/sub [:field/value id])
+         ::h/revision (h/sub [:field/revision id])
+         :on-input    [:field/edit id ::h/value]}]
+```
+
+Related: [Controlled inputs](04-controlled-inputs.md).
+
+### **buffered-field**
+
+`forms/buffered-field` — optional forms helper: one controlled input with a
+draft in front of the model. Accepts, rejects, and rewrites through
+[`::h/revision`](#hrevision); pairs with per-instance submit status and
+validation display.
+
+Related: [Forms](05-forms.md).
+
+### **keyboard map**
+
+Data map on a keyboard prop (e.g. `:on-key-down`) from key chord → intent.
+IME composition is explicit: Enter during composition commits nothing.
+Richer chords use [`h/event`](#hevent).
+
+Related: [Events as data](03-events-as-data.md#keyboard-as-data).
+
+---
+
+## Interop
+
+### **defhost**
+
+`h/defhost` — declared door to a foreign React component. Names the React
+value once, documents ReactNode [slots](#reactnode-slot), callback contracts
+(`:event` / `:handler` / `:render`), and [server policy](#server-policy).
+Quarantines the npm require in one host namespace.
+
+```clojure
+(h/defhost date-picker DatePicker
+  {:slots #{:calendar}
+   :server :client-only})
+```
+
+Related: [Interop](09-interop.md).
+
+### **ReactNode slot**
+
+A prop position a [host](#defhost) declares as carrying React children or
+named content (Suspense `:fallback`, compound slots). Hiccup in that position
+lowers under the captured frame without deep-converting arbitrary data maps.
+
+Related: [Interop](09-interop.md#reactnode-slots).
+
+### **as-element**
+
+`h/as-element` — explicit Hiccup → React element conversion for render props
+and foreign callbacks. The one honest conversion when a library expects a
+ReactNode, not data.
+
+```clojure
+{:renderItem (fn [row]
+               (h/as-element [row-view {:id (:id row)}]))}
+```
+
+Related: [Interop](09-interop.md), [Lists and collections](06-lists-and-collections.md).
+
+### **as-component** / **outward bridge**
+
+`h/as-component` returns a real React component so a native parent
+(`n/defcomponent`, UIx, or JS) can render a minted Hicasso view under the
+existing frame provider — no second root, no exposed internal codec ABI.
+Symmetric to hosts embedding foreign React inward.
+
+Related: [Interop](09-interop.md#the-outward-bridge).
+
+### **portal**
+
+Optional helper that lowers Hiccup into `createPortal`, preserves frame and
+context, and documents event bubbling / target-change identity plus
+client/server policy. Overlays that need the **native top layer** use the
+overlay module instead of a hand-rolled portal.
+
+Related: [Interop](09-interop.md#portals), [Overlays and focus](12-overlays-and-focus.md).
+
+### **server policy**
+
+Per-surface answer for SSR: **Render** (deterministic React server bytes) or
+**Client-only** (source-located refusal + deterministic fallback). Silent
+`nil` is not a policy. Declared on hosts and native components; intrinsic
+Hiccup renders by default.
+
+Related: [SSR and hydration](17-ssr-and-hydration.md), [Interop](09-interop.md#server-policy-per-declaration).
+
+### **raw escape** (`:>`)
+
+Hiccup head that passes a React component through without a lasting
+[host](#defhost) declaration. Useful once; repeated use graduates to
+`defhost` so slots, server policy, and callbacks stay declared.
+
+Related: [Interop](09-interop.md#the-escape-).
+
+---
+
+## Native tier
+
+### **native tier**
+
+Optional namespace `re-frame.hicasso.native` (alias `n`): explicit exit to
+direct React construction and hooks. **`[...]` is always interpreted Hiccup;
+`n/$` is always native React.** Neither form rewrites the other; nothing
+compiles Hiccup. Absent from bundles that never require the namespace.
+
+Related: [Native tier](10-native-tier.md).
+
+<a id="n-dollar"></a>
+### **n/$**
+
+Macro: one explicit element form → direct React construction. No intent
+lowering, no controlled repair, no Hiccup children (convert with
+[`as-element`](#as-element)). Dynamic props maps must be marked with
+[`n/props`](#nprops).
+
+```clojure
+(n/$ :td {:class "px"} px)
+(n/$ :td (n/props cell-props) px)
+```
+
+Related: [Native tier](10-native-tier.md#the-n-grammar).
+
+<a id="nprops"></a>
+### **n/props**
+
+Marker that classifies a dynamic expression as the props operand of
+[`n/$`](#n-dollar). Emits no runtime wrapper — classification only. An unmarked
+dynamic map in second position is a **child**, not props.
+
+<a id="ndefcomponent"></a>
+### **n/defcomponent**
+
+Defines a stable top-level native function component: display name, source,
+HMR, and one props/children ABI. Default self-contained route for a
+[named native island](#native-island). Ordinary React hooks are legal inside;
+frame access via [`n/use-sub`](#nuse-sub) / [`n/use-frame`](#nuseframe).
+
+Related: [Native tier](10-native-tier.md).
+
+<a id="nuse-sub"></a>
+<a id="nuseframe"></a>
+### **n/use-sub** / **n/use-frame**
+
+Native React hooks that join the installed Hicasso frame. Substrate-neutral
+(shared spine; no UIx dependency). Use inside [`n/defcomponent`](#ndefcomponent)
+or UIx `defui` — not inside a dynamically branched [`defview`](#defview) body.
+
+Related: [Native tier](10-native-tier.md).
+
+### **native island**
+
+A named native component under the same React root and re-frame2 frame as
+the rest of the app — hooks, vendor widgets, high-rate mechanics. Authored
+with [`n/defcomponent`](#ndefcomponent), UIx, or a JS host. Xray names the
+crossing; the inner React tree is [host-opaque](#loss-labels).
+
+Related: [Native tier](10-native-tier.md#rung-4--a-named-native-island).
+
+<a id="nmemo"></a>
+<a id="nlazy"></a>
+### **n/memo** / **n/lazy**
+
+Marker-preserving memoization and `React.lazy` loading for native components.
+Raw `react/memo` / `React.lazy` erase identity metadata that Xray and HMR
+need.
+
+Related: [Native tier](10-native-tier.md#keeping-the-marker-the-abi-helpers),
+[Code splitting](20-code-splitting.md).
+
+### **performance ladder**
+
+Five explicit rungs from ordinary Hicasso to a full native screen. No
+`:fast` flag and no second meaning for Hiccup:
+
+1. Ordinary Hicasso  
+2. Tuned [read topology](#read-topology)  
+3. Direct native return (`n/$` from a `defview`)  
+4. [Named native island](#native-island)  
+5. Native screen  
+
+Related: [Performance](18-performance.md), [Native tier](10-native-tier.md).
+
+### **escape-benefit rule**
+
+An escape stays only if it recovers **≥20%** of the measured interaction,
+saves **≥2 ms** at p95, or converts a failed user-visible budget into a pass;
+otherwise remove it. Thresholds never widen to keep a red row green.
+
+Related: [Performance](18-performance.md#the-escape-benefit-rule).
+
+---
+
+## State homes
+
+### **one state owner**
+
+Application-visible state lives in re-frame2 [app-db](../../../core/glossary.md#app-db)
+only. There is no component-local reactive cell and no second store. Hosts may
+hold host-private mechanics (motion, focus, vendor handles) that are never an
+invisible duplicate of application facts.
+
+Related: [Ephemeral state](11-ephemeral-state.md).
+
+### **pressure valve**
+
+Named legitimate home for a kind of UI state under [one state owner](#one-state-owner):
+explicit app-db address (default); optional forms/draft modules; host-private
+React/DOM state; uncontrolled DOM as an explicit interop choice. If a fact
+fits no valve, it goes to app-db.
+
+Related: [Ephemeral state](11-ephemeral-state.md).
+
+### **overlay (popover / modal)**
+
+`re-frame.hicasso.overlay` primitives on the browser's native top layer.
+`:open?` is app-db data; `:on-dismiss` is an event; the platform owns stacking,
+light-dismiss, and focus trap/return. Closed means zero DOM and zero listeners.
+
+Related: [Overlays and focus](12-overlays-and-focus.md).
+
+### **route-link**
+
+Routing helper: navigates by event, optional intent [prefetch](../../../routing/glossary.md#intent-prefetch),
+scroll/focus conduct. Plain function (inlines); active state is a subscription
+comparison, not a built-in class.
+
+Related: [Routing and navigation](07-routing-and-navigation.md).
+
+### **demand-driven committed read**
+
+Optional resource read that declares `:demand true`: **commit acquires**,
+unmount / param change / stopped read **releases**. Abandoned renders acquire
+nothing. Uses existing committed-read membership — no second per-read ledger.
+Without `:demand`, a resource sub stays a passive projection.
+
+```clojure
+(h/sub [:rf/resource {:resource :app/suggestions
+                      :params   {:q q}
+                      :demand   true}])
+```
+
+Related: [Async resources](08-async-resources.md#demand-driven-committed-reads),
+[Resources glossary](../../../resources/glossary.md).
+
+---
+
+## Testing
+
+### **test kit**
+
+Supported namespace `re-frame.hicasso.test` (alias `ht`): pure data tiers,
+[semantic harness](#semantic-harness), mounted facade, and browser helpers.
+Product surface, not a loose utility bag.
+
+Related: [Testing](14-testing.md).
+
+### **testing ladder**
+
+Five rungs; use the lowest that can prove the claim:
+
+| Rung | Proves | Mechanism |
+|---|---|---|
+| L0 | handlers, subs, transitions | pure functions |
+| L1 | intents, codecs, revision laws, `n/$` expansion | pure data / property tests |
+| L2 | registered hook-free bodies | [semantic harness](#semantic-harness) |
+| L3 | lifecycle, hooks, hosts, errors | mounted React DOM |
+| L4 | IME, caret, focus, hydration, perf | real browsers |
+
+A green lower rung never claims a higher equality (L2 ≠ hydration bytes).
+
+Related: [Testing](14-testing.md).
+
+### **semantic harness**
+
+L2: `ht/tree` runs a registered hook-free body under injected read fixtures
+and returns a semantic tree. Hosts, hooks, raw React, and [`n/$`](#n-dollar) results
+are **opaque** and refuse — mount those at L3.
+
+Related: [Testing](14-testing.md#l2--the-semantic-harness).
+
+### **mounted facade**
+
+L3 helpers: isolated-frame mount, hydrate, rerender, dispatch-and-settle,
+settle, unmount, `assert-clean!` (residue vs pre-mount baseline after
+quiescence).
+
+Related: [Testing](14-testing.md#l3--the-mounted-facade).
+
+### **sabotage control**
+
+Negative twin of an important gate: a deliberate mutation that must make the
+gate fail, so an empty population cannot pass green.
+
+Related: [Testing](14-testing.md#the-sabotage-twin).
+
+### **canonical DOM**
+
+Normalized DOM / structure equality used by differential and migration
+witnesses. Distinct from semantic-tree equality (L2) and from React server
+byte / hydration equality.
+
+Related: [Testing](14-testing.md#canonical-dom),
+[Migration from Reagent](19-migration-from-reagent.md).
+
+---
+
+## Diagnostics
+
+### **causal lens**
+
+Xray's diagnostic chain:
+
+```
+event → subscriptions recomputed → values changed → boundaries notified
+      → bodies run → React commit → paint
+```
+
+Each link has its own evidence seam. **Render is not commit; commit is not
+paint.** Timing proximity alone never proves a link.
+
+Related: [Diagnostics](15-diagnostics.md).
+
+### **explain-render**
+
+Xray answer to *why did this [boundary](#boundary) run?* — cause kind (reads,
+props, context, host, retry/abandonment), current read set, fan-out,
+completeness and loss.
+
+Related: [Diagnostics](15-diagnostics.md#explain-render).
+
+### **hot-view advisor**
+
+Ranks hot boundaries (time, frequency, read churn, fan-out), **classifies
+pressure** (computation, topology, lowering, React, layout), then recommends
+the smallest credible remedy. Recommends a native escape only when native
+addresses the measured owner; never auto-promotes.
+
+Related: [Diagnostics](15-diagnostics.md#the-hot-view-advisor),
+[Performance](18-performance.md).
+
+### **loss labels**
+
+Honest gaps instead of empty panels: `:unknown`, `:opaque` /
+`:no-static-analysis`, `:host-opaque`, `:cap`, `:uncorrelated`. Unknown is
+never encoded as an empty collection.
+
+Related: [Diagnostics](15-diagnostics.md#honest-loss-labels).
+
+### **complaint catalogue**
+
+Stable `:rf.error/*` / `:rf.warning/*` ids with cause, recovery, and
+jump-to-source in Xray. Every refusal in the guide is an entry; branch on the
+id, not prose.
+
+Related: [Diagnostics](15-diagnostics.md#the-complaint-catalogue).
+
+### **production erasure**
+
+Dev diagnostics, source maps for complaints, and evidence sentinels are absent
+from default production bundles. Budgets and teardown are verified on
+production builds.
+
+Related: [Diagnostics](15-diagnostics.md#production-erasure).
+
+---
+
+## Lifecycle and delivery
+
+<a id="mount"></a>
+### **mount!** / **render!** / **unmount!**
+
+Root lifecycle. `h/mount!` associates a DOM node, a [frame](../../../core/glossary.md#frame)
+id, and optional `:initial-events` (seed app-db before first paint), and
+returns an idempotent **root handle**. `render!` re-renders into that handle;
+`unmount!` is a no-op if already unmounted (safe for fixtures and reload
+hooks).
+
+```clojure
+(defonce root
+  (h/mount! (js/document.getElementById "app")
+            {:frame :rf/default :initial-events [[:app/init]]}
+            [app-shell]))
+```
+
+Related: [Getting started](01-getting-started.md).
+
+### **hydrate!**
+
+Client adoption of server-rendered HTML for a root: install the payload and
+attach listeners instead of repainting over the server DOM. Server and client
+share one React renderer; mismatches surface as hydration errors.
+
+Related: [SSR and hydration](17-ssr-and-hydration.md).
+
+### **error-boundary**
+
+`h/error-boundary` — React error region in the tree (`:fallback`,
+`:reset-key`, `:on-error`). Distinct from a re-render [boundary](#boundary);
+only this component catches throws. Expected failures stay data, not
+exceptions.
+
+Related: [Errors](16-errors.md).
+
+### **user-visible budget**
+
+Performance contract in terms a user can notice (e.g. discrete interaction
+paint ≤50 ms p95; controlled echo within one frame; broad ops ≤100 ms p95;
+zero teardown residue). Comparative bands and island parity sit beside these;
+synthetic scores never redefine "fast enough."
+
+Related: [Performance](18-performance.md#the-budgets).
+
+### **shadow comparison**
+
+Migration witness: dual-render canonical DOM / intent diff against a Reagent
+(or other) twin so conversion preserves behaviour before codemod. Refusals
+are named classes, not silent drift.
+
+Related: [Migration from Reagent](19-migration-from-reagent.md).


### PR DESCRIPTION
## Summary

- Add `docs/design/hicasso/draft-guide/glossary.md` in the same style as the other guide corpora (term first, short code when spelling matters, Related links).
- Explicit `<a id>` anchors on glossary headings so chapter links resolve reliably.
- Wire **~555** glossary hyperlinks through the 21-chapter draft guide and the index `README.md`:
  - multi-word terms and API spellings (`h/sub`, `n/$`, `::h/revision`, …) link on every prose occurrence;
  - single-word overloaded terms (boundary, intent, portal, collector, lowering, Hicasso, …) link once per H2 section;
  - fenced code blocks are left unchanged.
- Index table links key terms in each chapter blurb.

## Test plan

- [ ] Spot-check a few chapters (views, native tier, testing, diagnostics) that first teaching mentions of key terms link to the right glossary anchors
- [ ] Confirm no glossary links appear inside fenced code blocks
- [ ] Confirm em dashes and other Unicode prose are preserved
- [ ] Click through a sample of `glossary.md#…` targets in preview