### PR TITLE
fix(hicasso): make cell-readers answer a real copy (rf2-0oy4)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -2006,12 +2006,34 @@
   "The registrations currently reading `sub-key` — the cell's own reader
   list, which is the whole of the fused table's reverse edge.
 
-  A witness reader, answered as a vector so a caller cannot mutate the
-  live list. It replaces the retired index's `readers-of`, and it is what
-  the reader-counting rows assert against."
+  A witness reader, answered as a SNAPSHOT: the cell's live array is
+  cloned before it is wrapped, so a caller may hold the result across a
+  mount, an unmount or a remount and read back what it captured. That is
+  the guarantee the reader-counting rows assert against, and it replaces
+  the retired index's `readers-of`.
+
+  **The clone is load-bearing and `vec` alone was not it (rf2-0oy4).**
+  `cljs.core/vec` says so in its own docstring — *\"JavaScript arrays will
+  be aliased and should not be modified\"* — because on an array it calls
+  `PersistentVector.fromArray` with `no-clone` true, and below length 32,
+  which is every fan-out this table sees, the vector's TAIL *is* the array
+  handed in. [[acquire-cell!]] and [[release-cell!]] then `.push` and
+  `.splice` that array in place, and the result is not a stale value but
+  an INCOHERENT one: `count` and `nth` stay bounded by the `cnt` frozen at
+  construction while `reduce` walks each chunk by the tail's live
+  `alength`, so the same vector answers 2 to `count` and `[b b]` to
+  `mapv`. A baseline that mutates into the result is a witness that cannot
+  see a leak, and by symmetry a leaking runtime that reads clean — which
+  is how this presented, as rf2-vsgq's HMR baseline.
+
+  This file is the PACKAGE's donor and is no longer digest-pinned to it
+  (`hicasso/frozen-sources.edn`, \"the first retirement\"), so the two
+  copies are kept in step by hand. The package's own
+  `re-frame.hicasso.impl.inventory/cell-readers` carries this fix, and
+  `re-frame.hicasso.inventory-snapshot-cljs-test` pins it."
   [sub-key]
   (if-some [^js c (get @!cells sub-key)]
-    (vec (.-readers c))
+    (vec (aclone (.-readers c)))
     []))
 
 (defn boundary-reads

--- a/implementation/hicasso/src/re_frame/hicasso/impl/inventory.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/inventory.cljs
@@ -88,12 +88,29 @@
   "The registrations currently reading `sub-key` — the cell's own reader
   list, which is the whole of the fused table's reverse edge.
 
-  A witness reader, answered as a vector so a caller cannot mutate the
-  live list. It replaces the retired index's `readers-of`, and it is what
-  the reader-counting rows assert against."
+  A witness reader, answered as a SNAPSHOT: the cell's live array is
+  cloned before it is wrapped, so a caller may hold the result across a
+  mount, an unmount or a remount and read back what it captured. That is
+  the guarantee the reader-counting rows assert against, and it replaces
+  the retired index's `readers-of`.
+
+  **The clone is load-bearing and `vec` alone was not it (rf2-0oy4).**
+  `cljs.core/vec` says so in its own docstring — *\"JavaScript arrays will
+  be aliased and should not be modified\"* — because on an array it calls
+  `PersistentVector.fromArray` with `no-clone` true, and below length 32,
+  which is every fan-out this table sees, the vector's TAIL *is* the array
+  handed in. [[re-frame.hicasso.impl.collector]] then `.push`es and
+  `.splice`s that array in place, and the result is not a stale value but
+  an INCOHERENT one: `count` and `nth` stay bounded by the `cnt` frozen at
+  construction while `reduce` walks each chunk by the tail's live
+  `alength`, so the same vector answers 2 to `count` and `[b b]` to
+  `mapv`. A baseline that mutates into the result is a witness that cannot
+  see a leak, and by symmetry a leaking runtime that reads clean — which
+  is how this presented, as rf2-vsgq's HMR baseline.
+  `re-frame.hicasso.inventory-snapshot-cljs-test` pins it."
   [sub-key]
   (if-some [^js c (get @collector/!cells sub-key)]
-    (vec (.-readers c))
+    (vec (aclone (.-readers c)))
     []))
 
 (defn boundary-reads

--- a/implementation/hicasso/test/re_frame/hicasso/inventory_snapshot_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/inventory_snapshot_cljs_test.cljs
@@ -1,0 +1,207 @@
+(ns re-frame.hicasso.inventory-snapshot-cljs-test
+  "THE INSTRUMENT'S OWN CONTRACT — `cell-readers` answers a SNAPSHOT
+  (rf2-0oy4).
+
+  Every reader-counting row in this package captures
+  [[re-frame.hicasso.impl.inventory/cell-readers]], performs an action,
+  and compares. That shape is only a witness if the captured value is a
+  value. If it is a live view of the cell's reader array, the baseline
+  mutates into the result and the comparison is between a thing and
+  itself — a correct runtime reads exactly like a leak, and, by symmetry,
+  a leaking one reads clean. That is not hypothetical: rf2-vsgq's HMR
+  baseline was read that way, and this file is the bead that came of it.
+
+  ## Why `vec` was not enough
+
+  `cljs.core/vec` says so itself: *\"JavaScript arrays will be aliased and
+  should not be modified.\"* On an array it calls
+  `PersistentVector.fromArray` with `no-clone` true, and for a length
+  under 32 — which is every fan-out this table sees — the vector's TAIL
+  **is** the array handed in. The collector then `.push`es and `.splice`s
+  that same array in place (`acquire-cell!` and `release-cell!` in
+  [[re-frame.hicasso.impl.collector]]), so a caller holding the
+  \"snapshot\" watches it change.
+
+  ## What an aliased snapshot actually does — it is INCOHERENT, not stale
+
+  Measured rather than reasoned, because the reasoning was wrong the first
+  time. `cnt` is fixed when the vector is built; the tail is not. The two
+  families of vector operation disagree about which bound they trust, so
+  they disagree about the same value:
+
+  - `count`, `nth` and `=` are bounded by `cnt` alone. They keep the
+    length the snapshot was born with, and they read whatever now sits at
+    those indices. An arrival is invisible to them; a departure shifts a
+    later reader into an earlier slot under their feet.
+  - `reduce` — and so `mapv`, `into`, `set`, everything built on it —
+    bounds its OUTER walk by `cnt` but walks each chunk by the tail's
+    LIVE `alength`. It sees an arrival that `count` cannot, and after a
+    departure it re-reads the shrunken array and yields the survivor
+    TWICE.
+
+  So the pre-fix `(cell-readers k)` could answer a two-element vector
+  whose `count` was 2, whose `nth 0` and `nth 1` were the same object, and
+  whose `mapv` was `[:b :b]` — a value that does not agree with itself.
+  Every row below is red against that implementation.
+
+  ## Registrations are NAMED, never printed
+
+  Every assertion here runs through [[named]]. A registration holds the
+  cells it acquired and every cell holds its readers, so the object graph
+  is cyclic and `cljs.test`'s failure report walks it: the first draft of
+  this file answered `RangeError: Maximum call stack size exceeded` where
+  a diff should have been. A witness whose red is unreadable is half a
+  witness, so the rows compare rosters of keywords.
+
+  ## The control
+
+  [[the-live-list-really-does-move]] is what stops the three rows above
+  from passing vacuously. Each would be green under a runtime that
+  registered nothing at all — an empty snapshot never changes either — so
+  the control reads the LIVE list at the same three moments and requires
+  it to have moved every time."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private frame-id ::inventory-snapshot)
+
+(rf/reg-sub :inv/n (fn [db _] (:n db)))
+
+(rf/reg-event :inv/seed (fn [_ [_ db]] {:db db}))
+
+;; The UIx adapter for the reason the package smoke gives: plain-atom has
+;; no reactivity layer, so a subscription under it never notifies and the
+;; cell wiring these rows read would be built against nothing.
+;; `:ambient-frame nil` because this suite seats its own top-level frame.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; Harness — the published commit seam, no DOM
+;; ---------------------------------------------------------------------------
+
+(defn- seeded!
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [:inv/seed {:n 1}]))
+  frame-id)
+
+(def ^:private the-key
+  "The one sub-key every row acquires. Cells are keyed by `[frame-kw
+  query-v]`, because two frames are isolated contexts holding two
+  different app-dbs."
+  [frame-id [:inv/n]])
+
+(defn- mount-reader!
+  "Commit one boundary that reads [[the-key]], the way React would, and
+  answer `{:reg … :cleanup …}`. `:reg` is read off the live list at the
+  moment of the commit — `peek` is eager, so it hands back the object
+  rather than a view of it."
+  []
+  (collector/render-body frame-id (fn [_] [:p (h/sub [:inv/n])]) {})
+  (let [cleanup (collector/commit-boundary! (collector/last-reads) (fn []))]
+    {:reg (peek (inventory/cell-readers the-key)) :cleanup cleanup}))
+
+(defn- named
+  "`readers` with each registration replaced by its name in `roster` — a
+  reader list stated rather than printed, for the reason the ns docstring
+  gives. A keyword passes through (a row appends a sentinel), a slot the
+  live array no longer has reads `:absent`, and anything else `:unknown`."
+  [roster readers]
+  (mapv (fn [r]
+          (cond
+            (nil? r)     :absent
+            (keyword? r) r
+            :else        (get roster r :unknown)))
+        readers))
+
+;; ---------------------------------------------------------------------------
+;; A departure must not rewrite a snapshot taken before it
+;; ---------------------------------------------------------------------------
+
+(deftest a-snapshot-keeps-the-reader-it-captured-across-a-remount
+  (seeded!)
+  ;; The rf2-vsgq shape exactly: capture the sole reader, unmount it,
+  ;; mount a fresh one. `.splice` empties the array and `.push` refills
+  ;; it, so an aliasing snapshot silently BECOMES the post-remount list —
+  ;; and a runtime that correctly replaced its reader reads as one that
+  ;; leaked.
+  (let [{reg-1 :reg cleanup-1 :cleanup} (mount-reader!)
+        snapshot                        (inventory/cell-readers the-key)]
+
+    (cleanup-1)
+    (let [{reg-2 :reg} (mount-reader!)
+          roster       {reg-1 :first-reader reg-2 :second-reader}]
+
+      (testing "the premise: the remount really did install a different
+                registration"
+        (is (false? (identical? reg-1 reg-2))))
+
+      (testing "and the snapshot still names the reader it was taken of"
+        (is (= [:first-reader] (named roster snapshot)))))))
+
+(deftest a-snapshot-keeps-both-readers-when-one-leaves
+  (seeded!)
+  (let [{reg-a :reg cleanup-a :cleanup} (mount-reader!)
+        {reg-b :reg}                    (mount-reader!)
+        snapshot                        (inventory/cell-readers the-key)
+        roster                          {reg-a :a reg-b :b}]
+
+    (testing "the premise: two distinct readers, in mount order"
+      (is (= [:a :b] (named roster snapshot))))
+
+    (cleanup-a)
+
+    (testing "and after the first leaves, the snapshot is unmoved — an
+              aliasing one keeps the length 2 that `cnt` froze while its
+              `mapv` re-reads the one-element array twice and answers
+              `[:b :b]`"
+      (is (= 2 (count snapshot)))
+      (is (= [:a :b] (named roster snapshot))))))
+
+;; ---------------------------------------------------------------------------
+;; An arrival must not enlarge a snapshot taken before it
+;; ---------------------------------------------------------------------------
+
+(deftest a-snapshot-does-not-gain-a-reader-that-joined-after-it
+  (seeded!)
+  (let [{reg-a :reg} (mount-reader!)
+        snapshot     (inventory/cell-readers the-key)
+        {reg-b :reg} (mount-reader!)
+        roster       {reg-a :a reg-b :b}]
+
+    (testing "`count` is bounded by the frozen `cnt`, so it answers 1 over
+              a live array too — stated as the property, never offered as
+              the proof"
+      (is (= 1 (count snapshot))))
+
+    (testing "the proof is the walk that consults the tail's CURRENT
+              length: over a live array `mapv` yields the reader that
+              arrived after the capture, and disagrees with the `count`
+              directly above it"
+      (is (= [:a] (named roster snapshot))))))
+
+;; ---------------------------------------------------------------------------
+;; The control
+;; ---------------------------------------------------------------------------
+
+(deftest the-live-list-really-does-move
+  (seeded!)
+  ;; Without this row, every assertion above is green under a runtime that
+  ;; registers nothing: an empty snapshot never changes either.
+  (let [{cleanup-a :cleanup} (mount-reader!)]
+    (is (= 1 (count (inventory/cell-readers the-key))))
+    (mount-reader!)
+    (is (= 2 (count (inventory/cell-readers the-key))))
+    (cleanup-a)
+    (is (= 1 (count (inventory/cell-readers the-key))))))


### PR DESCRIPTION
Closes rf2-0oy4.

## The defect

`inventory/cell-readers` promised, in its docstring, that its result was "a vector so a caller cannot mutate the live list", and returned `(vec (.-readers c))`.

`cljs.core/vec` says the opposite in its own docstring — *"JavaScript arrays will be aliased and should not be modified."* On an array it calls `PersistentVector.fromArray` with `no-clone` true, and below length 32 — every fan-out this table sees — the returned vector's TAIL **is** the array handed in. `collector/acquire-cell!` `.push`es onto that array and `collector/release-cell!` `.splice`s it, in place. So the snapshot every reader-counting witness in the package rests on was a live view of the very thing it was supposed to be a baseline for.

That is worse than an ordinary sharp edge because the docstring names its own purpose: *"it is what the reader-counting rows assert against"*. A witness that captures a baseline, acts, and compares cannot see a leak when the baseline mutates into the result — and by symmetry a leaking runtime reads clean. It presented exactly that way to the rf2-vsgq worker: a correct HMR runtime read as a leak.

### What the pin measured that the bead did not state

Writing the test first turned up a sharper fact than "the snapshot goes stale". The aliased vector is **incoherent** — it does not agree with itself:

- `count`, `nth` and `=` are bounded by the `cnt` frozen at construction. They keep the old length and read whatever now sits at those indices.
- `reduce` — and so `mapv`, `into`, `set` — bounds its OUTER walk by `cnt` but walks each chunk by the tail's LIVE `alength`. It sees an arrival that `count` cannot, and after a departure it re-reads the shrunken array and yields the survivor twice.

Measured: after one of two readers unmounted, the same pre-fix vector answered `2` to `count` and `[:b :b]` to `mapv`.

## The fix

Shape (a) from the bead — make the copy real: `(vec (aclone (.-readers c)))`.

Shape (b) was rejected. The docstring names the witness use case, and witnesses need a stable baseline; documenting a live view would leave every reader-count row in the package resting on an unstated caller obligation. The docstring now states the guarantee it *does* provide, and why `vec` alone did not provide it, rather than dropping the sentence.

This is an instrument, not a hot path: nothing under `src/` calls `cell-readers`, only witnesses do.

## Red before green — the ordering is the proof

The test was written and confirmed red against the unmodified implementation before anything under `src/` was touched. Verbatim, from `node out/node-test-hicasso.js`, exit **1**:

```
Testing re-frame.hicasso.inventory-snapshot-cljs-test

FAIL in (a-snapshot-keeps-the-reader-it-captured-across-a-remount) (re_frame/hicasso/inventory_snapshot_cljs_test.cljs:145:13)
and the snapshot still names the reader it was taken of
expected: (= [:first-reader] (named roster snapshot))
  actual: (not (= [:first-reader] [:second-reader]))

FAIL in (a-snapshot-keeps-both-readers-when-one-leaves) (re_frame/hicasso/inventory_snapshot_cljs_test.cljs:163:11)
and after the first leaves, the snapshot is unmoved
expected: (= [:a :b] (named roster snapshot))
  actual: (not (= [:a :b] [:b :b]))

FAIL in (a-snapshot-does-not-gain-a-reader-that-joined-after-it) (re_frame/hicasso/inventory_snapshot_cljs_test.cljs:180:11)
expected: (= [:a] (named roster snapshot))
  actual: (not (= [:a] [:a :b]))

FAIL in (a-snapshot-does-not-gain-a-reader-that-joined-after-it) (re_frame/hicasso/inventory_snapshot_cljs_test.cljs:186:11)
expected: (= [:a :re-frame.hicasso.inventory-snapshot-cljs-test/sentinel] (named roster (conj snapshot :re-frame.hicasso.inventory-snapshot-cljs-test/sentinel)))
  actual: (not (= [:a :re-frame.hicasso.inventory-snapshot-cljs-test/sentinel] [:a :b :re-frame.hicasso.inventory-snapshot-cljs-test/sentinel]))

Ran 72 tests containing 321 assertions.
4 failures, 0 errors.
```

The same three rows are red in the consolidated bundle too — `npm run test:cljs` with the fix reverted and the test present ran 12884 tests / 64860 assertions, **3 failures** (the fourth row above was dropped, see below), 0 errors.

Post-fix, the same suite: `Ran 72 tests containing 320 assertions. 0 failures, 0 errors.` exit **0**.

### Two corrections the probe forced on its own author

1. **The first draft's red was unreadable.** A registration holds the cells it acquired and every cell holds its readers, so the object graph is cyclic and `cljs.test`'s report walked it: `RangeError: Maximum call stack size exceeded` where a diff should have been. Every row now compares rosters of keywords through a `named` helper. A witness whose red cannot be read is half a witness.
2. **A row's stated justification was disproved and the row was deleted.** The arrival row originally carried a `conj` assertion, justified as "the only thing that can see a `.push`, because `count` cannot". The measurement showed `mapv` sees it too (live `alength` in `pv-reduce`), so the justification evaporated and the row went with it rather than being kept for enumeration's sake.

### The control

`the-live-list-really-does-move` reads the LIVE list at the same three moments and requires it to have moved each time. Without it every row above is green under a runtime that registers nothing at all — an empty snapshot never changes either.

## Sibling accessors — checked, and left alone

Every other accessor in `impl/inventory.cljs` was read against the same question. None has the defect, and none is widened here:

- **`boundary-reads`** returns `(.-reads reg)`, which is the entry's `"set"` field — `(into #{} ks)`, an immutable persistent set built once at `entry-for` and shared by reference. A caller cannot mutate it and it cannot change underneath one. Its docstring already says "shared by reference", which is true. A bench row pins the identity deliberately (`(is (identical? (rt/reads-of (:entry b)) (rt/boundary-reads (:reg b))))`).
- **`cell-reaction`** answers a single object, not a collection, and the rf2-2rtt6.44 rows must be able to hold it across its disposal — that is the point of it.
- **`stats`**, **`entry-buckets`**, **`residue`** build a fresh map of numbers per call. `stats` reduces over the raw `.-readers` array directly, which is a correct read of live state.
- **`retained-inventory`** answers fresh literals.

## The bench donor was carrying the identical defect, and is ported here

`implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs` — the package's donor — carried a byte-identical `cell-readers` with the byte-identical false docstring, and its own reader-counting rows (`cell_table_laws_cljs_test`, `runtime_cljs_test`, `framework_subs_dom_cljs_test`) assert against it.

This is stated rather than done quietly, because it is scope beyond the one file the bead names. The warrant is in `hicasso/frozen-sources.edn` itself: rf2-hic-009 retired the `arm1/runtime.cljs` row and recorded the consequence — *"the bench tree's `arm1/runtime.cljs` is no longer digest-pinned by anything … a fix landing there is now a fix somebody has to port by reading, not by being told."* The freeze gate cannot catch this divergence in either direction, so leaving it would leave the identical trap in the tree with the densest reader-count assertions. Ported, with the porting obligation named in the docstring.

Measured to contribute nothing: with the bench edit reverted and everything else in place, the 68 bench-hicasso namespaces ran `664 tests / 2886 assertions, 0 failures` — identical to the count with it applied.

## Quality gates

Every gate run alone, in the foreground (the spine detached with a polled exit file), exit code captured with an explicit `echo $?` to its own file — never through a pipeline, whose status is its last command's. Each gate's `gate root:` line was checked against this worktree, `C:/Users/miket/code/re-frame2-worktrees/cellalias-0oy4`.

| Gate | Exit | Result |
| --- | --- | --- |
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` (docs=false jvm=true node=true) |
| `npm run test:cljs` (after) | **0** | 12884 tests / 64860 assertions, 0 failures, 0 errors |
| `npm run test:cljs` (repeat, determinism) | **0** | 12884 / 64860, 0 failures, 0 errors |
| `npm run test:cljs` (baseline at merge base) | **0** | 12880 tests / 64844 assertions, 0 failures, 0 errors |
| `npm run test:hicasso-freeze` | **0** | `7 frozen row(s) match the bench tree, and each package file is its donor moved; no package file imports it` |
| `npm run test:hicasso-compile` | **0** | 137 lane namespaces compiled, zero warnings |
| `node scripts/compile-node-test.cjs node-test-hicasso …` | **0** | 181 files, 0 warnings |
| `node out/node-test-hicasso.js` | **0** | 72 tests / 320 assertions, 0 failures, 0 errors |

The transitive surface was gated rather than the changed files: `cell-readers` is asserted against from ten files across the package and the bench tree, and every one of them runs under `npm run test:cljs`, which the spine's node tier also runs.

### No-regression, as a set difference in both directions

Both directions, same merge base (`495f48fc0d`):

- **Nothing lost.** 12880 → 12884 tests. The +4 are exactly the four `deftest`s added here. No pre-existing test disappeared, and failures/errors are 0 → 0.
- **Nothing newly red.** The only rows that changed colour are the three this bead exists to repair, red → green.

One accounting detail, measured rather than waved past: assertions rose by 16 while the new file contributes 10. The remaining 6 are **not caused by the source change**, and the check that settles it is running the whole consolidated suite with the fix reverted and the new namespace present — identical totals, 12884 / 64860. The delta is a property of adding a namespace to the consolidated bundle (loop assertions elsewhere in the bundle that scale with shared global state), it is deterministic across repeated runs, and every one of those assertions passes on both sides of the fix. It is not localized to a specific test here and is worth an eyebrow, not a hold.

## Design-tree note

No file under `docs/design/**` is touched, so `scripts/check_doc_slugs.py`'s hand-verification obligation does not arise. No hot-zone file is touched: `implementation/shadow-cljs.edn` is unchanged (the new suite rides the existing `:node-test` `cljs-test$` regex and the existing focused `:node-test-hicasso` build).
