### PR TITLE
docs(hicasso): unlink code fences and finish the glossary anchors (rf2-re0m)

### DIFF
--- a/docs/design/hicasso/draft-guide/10-native-tier.md
+++ b/docs/design/hicasso/draft-guide/10-native-tier.md
@@ -103,13 +103,13 @@ The authoring shape is deliberately small:
 
     ```clojure
     ;; Don't: a dynamic map in second position is a CHILD, not props.
-    (let cell-props {:class "px" :dir "ltr"}]
-      ([n/$](glossary.md#n-dollar) :td cell-props px))   ;; refuses — a map is not a valid React child,
-                                 ;; and the recovery names ([n/props](glossary.md#nprops) …)
+    (let [cell-props {:class "px" :dir "ltr"}]
+      (n/$ :td cell-props px))   ;; refuses — a map is not a valid React child,
+                                 ;; and the recovery names (n/props …)
 
-    ;; Do: mark the operand. [n/props](glossary.md#nprops) emits no wrapper — it only classifies.
-    (let cell-props {:class "px" :dir "ltr"}]
-      ([n/$](glossary.md#n-dollar) :td ([n/props](glossary.md#nprops) cell-props) px))
+    ;; Do: mark the operand. n/props emits no wrapper — it only classifies.
+    (let [cell-props {:class "px" :dir "ltr"}]
+      (n/$ :td (n/props cell-props) px))
     ```
 
     A dynamic ClojureScript map inside [`n/props`](glossary.md#nprops) converts shallowly under the same slot-name rule; a JavaScript object passes by identity.

--- a/docs/design/hicasso/draft-guide/20-code-splitting.md
+++ b/docs/design/hicasso/draft-guide/20-code-splitting.md
@@ -165,10 +165,10 @@ law holds through both, because commit owns acquisition
   from state:
 
   ```clojure
-  ([h/defhost](glossary.md#defhost) activity react/Activity)
+  (h/defhost activity react/Activity)
 
-  activity {:mode (if ([h/sub](glossary.md#hsub) :inbox/visible?]) "visible" "hidden")}
-   inbox-pane {}]]
+  [activity {:mode (if (h/sub [:inbox/visible?]) "visible" "hidden")}
+   [inbox-pane {}]]
   ```
 
   While the pane is hidden, React cleans up effects, and the subtree's

--- a/docs/design/hicasso/draft-guide/glossary.md
+++ b/docs/design/hicasso/draft-guide/glossary.md
@@ -338,6 +338,7 @@ Hiccup renders by default.
 
 Related: [SSR and hydration](17-ssr-and-hydration.md), [Interop](09-interop.md#server-policy-per-declaration).
 
+<a id="raw-escape"></a>
 ### **raw escape** (`:>`)
 
 Hiccup head that passes a React component through without a lasting
@@ -429,11 +430,11 @@ Related: [Native tier](10-native-tier.md#keeping-the-marker-the-abi-helpers),
 Five explicit rungs from ordinary Hicasso to a full native screen. No
 `:fast` flag and no second meaning for Hiccup:
 
-1. Ordinary Hicasso  
-2. Tuned [read topology](#read-topology)  
-3. Direct native return (`n/$` from a `defview`)  
-4. [Named native island](#native-island)  
-5. Native screen  
+1. Ordinary Hicasso
+2. Tuned [read topology](#read-topology)
+3. Direct native return (`n/$` from a `defview`)
+4. [Named native island](#native-island)
+5. Native screen
 
 Related: [Performance](18-performance.md), [Native tier](10-native-tier.md).
 


### PR DESCRIPTION
Closes rf2-re0m — the three defects the merged-PR audit of #7776 (`fad49ac25`) found in the bulk glossary-link pass.

## What was wrong, and what git says about it

**Correctness.** The link pass rewrote six lines *inside* fenced Clojure examples, adding seven Markdown links. A fence renders its content literally, so those links were visible as source text and every copied sample was invalid.

The damage was not confined to link syntax. Markdown parsed the samples' own square brackets as link text, so the same rewrite also ate the opening bracket of a `let` binding vector and of two Hiccup forms:

| file | before the pass | after the pass |
|---|---|---|
| `10-native-tier.md` | `(let [cell-props {…}]` | `(let cell-props {…}]` |
| `20-code-splitting.md` | `[activity {:mode …}` | `activity {:mode …}` |
| `20-code-splitting.md` | `(h/sub [:inbox/visible?])` | `(h/sub :inbox/visible?])` |
| `20-code-splitting.md` | `[inbox-pane {}]]` | `inbox-pane {}]]` |

It mattered which of the two it was, because a pre-existing defect would have been out of this bead's scope. Git settles it. `git log --follow` gives each file exactly three commits: `93ad830cc6` (landed the guide), `afbf6c68da` (the link pass), `fad49ac250` (kept links out of headings). `93ad830cc6` is therefore the last state before the glossary work, and `git show 93ad830cc6:<path>` carries the correct spellings in both fences. The brackets are collateral of the link pass, not older breakage.

That makes the repair a single move rather than two: both fences are restored to their pre-pass text, which removes the links and repairs the brackets together. This is the "preserve the original code spellings" the bead asks for — recovered from git, not reconstructed.

Exact before/after of all six lines:

```
10-native-tier.md:106  - (let cell-props {:class "px" :dir "ltr"}]
                       + (let [cell-props {:class "px" :dir "ltr"}]
10-native-tier.md:107  - ([n/$](glossary.md#n-dollar) :td cell-props px))   ;; refuses …
                       + (n/$ :td cell-props px))   ;; refuses …
10-native-tier.md:108  - ;; and the recovery names ([n/props](glossary.md#nprops) …)
                       + ;; and the recovery names (n/props …)
10-native-tier.md:110  - ;; Do: mark the operand. [n/props](glossary.md#nprops) emits no wrapper …
                       + ;; Do: mark the operand. n/props emits no wrapper …
10-native-tier.md:111  - (let cell-props {:class "px" :dir "ltr"}]
                       + (let [cell-props {:class "px" :dir "ltr"}]
10-native-tier.md:112  - ([n/$](glossary.md#n-dollar) :td ([n/props](glossary.md#nprops) cell-props) px))
                       + (n/$ :td (n/props cell-props) px))
20-code-splitting.md:168 - ([h/defhost](glossary.md#defhost) activity react/Activity)
                         + (h/defhost activity react/Activity)
20-code-splitting.md:170 - activity {:mode (if ([h/sub](glossary.md#hsub) :inbox/visible?]) "visible" "hidden")}
                         + [activity {:mode (if (h/sub [:inbox/visible?]) "visible" "hidden")}
20-code-splitting.md:171 -  inbox-pane {}]]
                         +  [inbox-pane {}]]
```

(The audit named six lines carrying the seven links; lines 106, 111 and 171 are the bracket collateral on the same two fences.)

**Completeness.** ``### **raw escape** (`:>`)`` was the sole term H3 with no preceding explicit anchor. It now carries `<a id="raw-escape"></a>`, in the same shape as the other 57. This heading is exactly the case an explicit id exists for: its generated slug is `raw-escape-`, with a trailing hyphen inherited from the ``(`:>`)`` in the title. `raw-escape` is short, stable, and — unlike most ids in this file — resolves to exactly one rendered target, because it does not coincide with the generated slug. Nothing linked to it before, so no existing link changes meaning.

**Implementation quality.** The five performance-ladder items each ended in two trailing spaces. An ordered-list item needs no forced line break, so they are removed.

## Verification

Prose was not otherwise touched, no fence was mechanically relinked, and no checker was added.

- **No `glossary.md#` link survives inside a fenced region anywhere under `draft-guide`** — the whole 24-file tree, not just the two named. A scan that tracks fence state with indentation-tolerant open/close matching (both ` ``` ` and `~~~`) reports **6 fenced links before → 0 after**. There was no seventh line: the audit's six lines carried all seven links. Inline code spans were checked too — zero, before and after.
- **Every term H3 in `glossary.md` has an explicit unique id** — 58 term H3s, **1 without an explicit id before → 0 after**; 61 distinct explicit ids, no duplicate explicit id.
- **Trailing whitespace** — 5 lines in `glossary.md` before → 0 after, file-wide.
- **Both repaired samples parse.** Delimiters balance in all three Clojure fences touched or adjacent, and no `](` remains in any of them.

Link scan over `docs/design/hicasso/draft-guide/**`, reusing `check_doc_slugs.py`'s own extractor and slug index:

| | before | after |
|---|---|---|
| all intra-repo `.md` links | 904 | 897 |
| links to `glossary.md` | 543 | 536 |
| dangling targets/anchors | **0** | **0** |

Zero dangling either way, and the deltas are exactly the seven removed links. One honest note: I could not reproduce the audit's **531** under any natural definition. The nearest candidates on the pre-fix tree are 532 (glossary links from source files other than `glossary.md` itself) and 543 (all glossary links); the tree is byte-identical to `fad49ac250`, so the difference is in how the two scans count, not in what they scanned. The number that carries the acceptance — **zero dangling** — reproduces exactly.

## Quality gates

Each run alone, in the foreground, exit code captured on its own. `gate root` matched the worktree (`/c/Users/miket/code/re-frame2-worktrees/fencelinks-re0m`) on every gate.

| gate | exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `git diff --check origin/main...HEAD` | **0** |
| `sh scripts/test-fast-pr.sh` | **0** (`PASS fast PR spine`; classified `docs=true jvm=false node=false`) |

`check_doc_slugs.py` and the range-form `git diff --check` were re-run after the rebase onto current `origin/main`; both still 0.

Two coverage gaps stated rather than assumed:

- **`mkdocs build --strict` verifies nothing here.** It ran green inside the spine's docs tier, but `mkdocs.yml`'s `exclude_docs` lists `design/hicasso/`, so this surface is not in the site build. It is not evidence for this PR.
- **`check_doc_slugs.py` validates link targets and anchors, not tables or rendering.** Verified by hand instead: the diff changes no table row (0 changed lines begin with `|`, so no column count moved), the anchor follows the file's established `<a id="…"></a>`-then-`###` shape, and the ordered list renders identically without the forced breaks.

The bare `git diff --check` was also run and also exits 0 — but on a committed clean tree it inspects nothing, so only the `origin/main...HEAD` form above is evidence.

## One observation, not actioned

`check_doc_slugs.py` structurally cannot catch this bug class, for two independent reasons. `_FENCE_RE` is anchored at column 0 with no indent tolerance, so the indented fences in both files (4 spaces inside an admonition, 2 inside a list item) were never recognised as fences at all, and their contents were scanned as prose. Even had they been, the checker only asks whether a link *resolves*; all seven of these did. That is why the pass shipped green.

The natural small assertion point is a rule that a `](` sequence must not appear inside a fenced region under `docs/design/hicasso/`, which would want the fence matcher to tolerate indentation first. Per the bead's fence I am proposing it rather than building it — widening the fence regex changes what the checker validates corpus-wide and deserves its own bead.

Separately, and pre-existing: 50 of the glossary's explicit ids duplicate the generated slug of the heading they precede (e.g. `<a id="portal"></a>` above `### **portal**`, both minting `portal`). Browsers resolve the first, so the anchors work, and the checker's duplicate-id gate only covers the `HANDBOOK_COMPAT_ANCHORS` manifest, which this tree is not in. Out of scope here; noted in case it is worth a bead.
