### PR TITLE
fix(gate): teach check_doc_slugs to see an indented fence (rf2-mmyc)

### DIFF
--- a/scripts/_test_fixtures/check_doc_slugs/fenced_doc_link_in_scope/docs/design/hicasso/glossary.md
+++ b/scripts/_test_fixtures/check_doc_slugs/fenced_doc_link_in_scope/docs/design/hicasso/glossary.md
@@ -1,0 +1,5 @@
+# Glossary
+
+## nprops
+
+The operand-marking form.

--- a/scripts/_test_fixtures/check_doc_slugs/fenced_doc_link_in_scope/docs/design/hicasso/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/fenced_doc_link_in_scope/docs/design/hicasso/index.md
@@ -1,0 +1,16 @@
+# Index — Linked Code Fence (rf2-mmyc)
+
+This fixture reproduces the rf2-re0m shape exactly: a bulk link pass rewrote
+lines *inside* Clojure samples, and every link it added RESOLVED — so the
+link validator was satisfied while the samples became invalid to copy.
+
+The link below therefore points at a real anchor on a real page.  The only
+thing wrong with it is that it is inside a code fence.
+
+- Mark the operand:
+
+  ```clojure
+  ([n/props](glossary.md#nprops) cell-props)
+
+  ;; renders literally; copying this sample yields code that will not read
+  ```

--- a/scripts/_test_fixtures/check_doc_slugs/fenced_doc_link_in_scope/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/fenced_doc_link_in_scope/mkdocs.yml
@@ -1,0 +1,1 @@
+# Self-test fixture marker.

--- a/scripts/_test_fixtures/check_doc_slugs/fenced_doc_link_out_of_scope/docs/design/freehand/glossary.md
+++ b/scripts/_test_fixtures/check_doc_slugs/fenced_doc_link_out_of_scope/docs/design/freehand/glossary.md
@@ -1,0 +1,5 @@
+# Glossary
+
+## nprops
+
+The operand-marking form.

--- a/scripts/_test_fixtures/check_doc_slugs/fenced_doc_link_out_of_scope/docs/design/freehand/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/fenced_doc_link_out_of_scope/docs/design/freehand/index.md
@@ -1,0 +1,14 @@
+# Index — Linked Code Fence, Out Of Scope (rf2-mmyc)
+
+Byte-for-byte the in-scope fixture's sample, under a tree the fenced-link
+assertion does not cover.  The assertion is scoped, not corpus-wide: 109
+in-repo links legitimately live inside fences elsewhere in this repo
+(88 of them in `spec/Spec-Schemas.md`, as commentary inside schema samples).
+
+- Mark the operand:
+
+  ```clojure
+  ([n/props](glossary.md#nprops) cell-props)
+
+  ;; legitimate here — this tree is not covered
+  ```

--- a/scripts/_test_fixtures/check_doc_slugs/fenced_doc_link_out_of_scope/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/fenced_doc_link_out_of_scope/mkdocs.yml
@@ -1,0 +1,1 @@
+# Self-test fixture marker.

--- a/scripts/_test_fixtures/check_doc_slugs/indented_fence_link_ignored/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/indented_fence_link_ignored/docs/index.md
@@ -1,0 +1,34 @@
+# Index — Indented Fence Recognition (rf2-mmyc)
+
+A fenced code block is code wherever it sits.  The scanner used to anchor
+its fence matcher at column 0, so a fence indented by its container was
+never recognised and the sample inside it was scanned as ordinary prose.
+
+Each sample below carries a blank line, which splits the inline block so
+the inline-code-span mask cannot pair the fence's own backtick runs and
+accidentally hide the link.  Without that blank line these fixtures would
+pass for the wrong reason.
+
+## A fence indented inside a list item
+
+- Mark the operand, then read it back:
+
+  ```clojure
+  ([n/$](glossary.md#n-dollar) :td cell-props px)
+
+  ;; the sample above is code, not a cross-reference
+  ```
+
+## A fence indented inside an admonition
+
+!!! note
+
+    ```clojure
+    ([h/defhost](glossary.md#defhost) activity react/Activity)
+
+    ;; likewise code
+    ```
+
+## A real link, to prove the file is still scanned
+
+The fixture's own [target](target.md#hello-world) must still validate.

--- a/scripts/_test_fixtures/check_doc_slugs/indented_fence_link_ignored/docs/target.md
+++ b/scripts/_test_fixtures/check_doc_slugs/indented_fence_link_ignored/docs/target.md
@@ -1,0 +1,5 @@
+# Target
+
+## Hello World
+
+Some content here.

--- a/scripts/_test_fixtures/check_doc_slugs/indented_fence_link_ignored/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/indented_fence_link_ignored/mkdocs.yml
@@ -1,0 +1,1 @@
+# Self-test fixture marker.

--- a/scripts/_test_fixtures/check_doc_slugs/indented_fence_negative_control/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/indented_fence_negative_control/docs/index.md
@@ -1,0 +1,24 @@
+# Index — Indented Fence Negative Control (rf2-mmyc)
+
+Widening the fence matcher must not make the gate quieter than it was.
+An indented fence ends where its container ends, and prose after it is
+still prose.
+
+- Mark the operand:
+
+  ```clojure
+  ([n/$](glossary.md#n-dollar) :td cell-props px)
+
+  ;; code, ignored
+  ```
+
+Back at column zero, this link [is real and broken](missing.md) and must
+still be flagged as BROKEN TARGET.
+
+- An unclosed fence must not swallow the document either:
+
+  ```clojure
+  (let [cell-props {}]
+
+Back at column zero again — the list item ended, so the fence ended with
+it, and nothing here is code.

--- a/scripts/_test_fixtures/check_doc_slugs/indented_fence_negative_control/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/indented_fence_negative_control/mkdocs.yml
@@ -1,0 +1,1 @@
+# Self-test fixture marker.

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -1458,6 +1458,23 @@ def _run_self_tests(verbose: bool = False) -> int:
         # invented, downward if bounding the join discards real links.
         ("multiline_code_span_not_a_link",   1),
         ("non_blank_block_bound",            1),
+        # rf2-mmyc — a fence indented by its container is still a fence, so the
+        # sample inside it is code and carries no links to resolve.  Each
+        # fixture's samples contain a blank line, which splits the inline block
+        # so the code-span mask cannot pair the fence's own backtick runs and
+        # hide the links by accident; without it these would pass for the wrong
+        # reason.  The negative control fails in BOTH directions — its single
+        # finding is a REAL broken link in prose AFTER an indented fence, so it
+        # counts up if the fences are still scanned as prose and down if
+        # widening the matcher swallows the document.
+        ("indented_fence_link_ignored",      0),
+        ("indented_fence_negative_control",  1),
+        # rf2-mmyc — the fenced-doc-link assertion, in the rf2-re0m shape: the
+        # link inside the fence RESOLVES, so link validation is satisfied and
+        # only the assertion can see it.  Scoped, so the identical sample under
+        # a sibling tree stays silent.
+        ("fenced_doc_link_in_scope",         1),
+        ("fenced_doc_link_out_of_scope",     0),
     ]
 
     failures = 0
@@ -1890,12 +1907,135 @@ def _run_self_tests(verbose: bool = False) -> int:
             )
             failures += 1
 
+    # rf2-mmyc — FENCE RECOGNITION, driven directly at `_strip_fences`.  That
+    # function is the scanner's only notion of "this is code, not prose", so
+    # every other check inherits whatever it gets wrong: the rf2-re0m bulk link
+    # pass rewrote six lines inside three Clojure samples and the gate stayed
+    # green because a column-0-anchored matcher could not see the indented
+    # fences those samples lived in.
+    #
+    # Each case states the 1-based line numbers that survive as PROSE.  Driving
+    # the primitive rather than a fixture matters here: the inline-code-span
+    # mask pairs a balanced fence's own backtick runs by accident, so a
+    # fixture-level count can come out right while the scanner is still blind.
+    #
+    # The expectations are RENDERER-DERIVED, not read off CommonMark: each was
+    # confirmed against python-markdown + pymdownx.superfences, the pair MkDocs
+    # actually runs, which is stricter than CommonMark about closing fences.
+    fence_cases: list[tuple[str, list[str], list[int]]] = [
+        # POSITIVE CONTROL — the column-0 case that always worked.  It cannot
+        # red before the fix; its job is to stay green after it.
+        ("column-0 fence still blanks its body",
+         ["Prose before.",
+          "",
+          "```clojure",
+          "[not a link](missing.md)",
+          "```",
+          "Prose after."],
+         [1, 6]),
+        # THE DEFECT — a fence carrying its container's indent.
+        ("fence indented inside a list item is a fence",
+         ["- A bullet:",
+          "",
+          "  ```clojure",
+          "  [not a link](missing.md)",
+          "  ```",
+          "",
+          "Prose after."],
+         [1, 7]),
+        ("fence indented inside an admonition is a fence",
+         ["!!! note",
+          "",
+          "    ```clojure",
+          "    [not a link](missing.md)",
+          "    ```",
+          "",
+          "Prose after."],
+         [1, 7]),
+        ("indented tilde fence is a fence",
+         ["- A bullet:",
+          "",
+          "  ~~~clojure",
+          "  [not a link](missing.md)",
+          "  ~~~",
+          "",
+          "Prose after."],
+         [1, 7]),
+        # CommonMark's three-space allowance, which the renderer honours: a
+        # fence may be indented up to three spaces in ordinary context.  The
+        # corpus has 100 such lines.
+        ("fence indented three spaces in ordinary context is a fence",
+         ["Prose.",
+          "",
+          "   ```clojure",
+          "   [not a link](missing.md)",
+          "   ```",
+          "",
+          "Prose after."],
+         [1, 7]),
+        # THE CONTROL THAT REJECTS THE ONE-CHARACTER FIX.  Four or more spaces
+        # in ordinary context is an INDENTED CODE BLOCK, a different construct
+        # with no closing delimiter.  A matcher relaxed to `^\s*` opens a fence
+        # here and, finding no closer, blanks the rest of the file.  Lines 3-4
+        # stay visible because this scanner recognises where a FENCE is, not
+        # where an indented code block is — see `_strip_fences`.
+        ("four-space indented code block in ordinary context is not a fence",
+         ["Prose.",
+          "",
+          "    ```clojure",
+          "    (a literal fence, inside an indented code block)",
+          "",
+          "Prose after."],
+         [1, 3, 4, 6]),
+        # THE CONTROL THAT REJECTS CommonMark'S CLOSING-FENCE SLACK.  Taken
+        # from skills/re-frame2-implementor/references/output-format.md, which
+        # displays a nested fence inside a ```markdown sample.  CommonMark lets
+        # a closing fence be indented up to three spaces regardless of its
+        # opener, which would end the outer block at line 3; superfences does
+        # not, and neither do we — the closer must be the opener's exact marker
+        # at the opener's exact indentation.
+        ("indented bare fence inside a column-0 fence does not close it",
+         ["```markdown",
+          "- **Claimed tags:**",
+          "  ```",
+          "  :core/*",
+          "  ```",
+          "- **Score:** 10",
+          "```",
+          "",
+          "Prose after."],
+         [9]),
+        # RUNAWAY GUARD.  rf2-re0m shipped three unbalanced fences, so this is
+        # not hypothetical.  A fence ends with the container that holds it, so
+        # an unclosed one cannot blank the rest of the document — which is the
+        # mirror-image failure of the defect: a gate that goes quiet.
+        ("unclosed indented fence ends with its container",
+         ["- A bullet:",
+          "",
+          "  ```clojure",
+          "  (unclosed",
+          "",
+          "Prose after, back at column zero."],
+         [1, 6]),
+    ]
+    for label, lines, expected_visible in fence_cases:
+        got_visible = [n for n, content in _strip_fences(lines) if content.strip()]
+        if got_visible == expected_visible:
+            if verbose:
+                sys.stderr.write(f"self-test PASS: fence [{label}]\n")
+        else:
+            sys.stderr.write(
+                f"self-test FAIL: fence [{label}] expected visible lines "
+                f"{expected_visible}, got {got_visible}\n"
+            )
+            failures += 1
+
     if failures:
         sys.stderr.write(f"\n{failures} self-test failure(s).\n")
         return 1
     if verbose:
         sys.stderr.write(
-            f"all {len(cases) + len(teeth_cases) + len(extraction_cases) + 4} "
+            f"all {len(cases) + len(teeth_cases) + len(extraction_cases) + len(fence_cases) + 4} "
             "self-tests passed.\n"
         )
     return 0

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -45,7 +45,14 @@ Notes on what is and isn't checked:
     * Anchors are decoded before comparison — links written as #foo%20bar
       are compared as #foo bar (rare in this corpus but defensive).
     * Pure section-anchor permalinks (e.g. #fragment-only-anchor) and link
-      definitions inside fenced code blocks are skipped.
+      definitions inside fenced code blocks are skipped.  A fence counts as a
+      fence wherever its container puts it — indented inside a list item or an
+      admonition as readily as at column 0 (rf2-mmyc).  See `_strip_fences` for
+      what that recognition covers and, just as importantly, what it does not.
+    * In the trees listed in FENCED_DOC_LINK_TREES a markdown doc link inside a
+      fence is itself reported (rf2-mmyc).  Everywhere else it is merely
+      skipped: 88 links in `spec/Spec-Schemas.md` alone sit legitimately inside
+      schema samples as `;;` commentary.
 
 The script is intentionally dependency-light. Beyond pymdown-extensions
 (already pinned in requirements.txt for the MkDocs build) it relies only
@@ -155,8 +162,51 @@ _HTML_ANCHOR_RE = re.compile(
 # newline there is not a link the renderer would produce either.
 _LINK_RE = re.compile(r"\[(?:[^\]\\]|\\.)*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
 
-# Fenced code block delimiter (``` or ~~~ optionally followed by language).
-_FENCE_RE = re.compile(r"^(```|~~~)")
+# Fenced code block delimiter — a run of three or more backticks or tildes,
+# its leading indentation, and its info string (rf2-mmyc).
+#
+# The predecessor was anchored at column 0 (`^(```|~~~)`), so a fence carrying
+# its container's indentation was not recognised as a fence AT ALL and the
+# sample inside it was scanned as ordinary prose.  That is how rf2-re0m shipped:
+# a bulk link pass rewrote six lines inside three Clojure samples, adding seven
+# markdown links that render literally — and because markdown read the samples'
+# own square brackets as link text, the rewrite ate opening brackets, leaving
+# three fences unbalanced.  This gate passed throughout, correctly by its own
+# lights: every one of those links RESOLVED.  It asks whether a link has a
+# target, never whether the text should be a link at all — and could not ask the
+# second question while it believed it was reading prose.
+_FENCE_RE = re.compile(
+    r"^(?P<indent>[ ]*)(?P<marker>(?P<char>[`~])(?P=char){2,})(?P<info>.*)$"
+)
+
+# Block containers whose content column is what a fence inside them is indented
+# to.  `_strip_fences` tracks these so it can tell a fence from an INDENTED CODE
+# BLOCK: four or more spaces past the current content column is the latter, a
+# different construct with no closing delimiter, and a matcher relaxed to `^\s*`
+# would open a never-closed fence on one and blank the rest of the file.
+#
+# A list item's content column is the column after its marker and the spaces
+# following it (CommonMark caps that run at four; a wider one starts an indented
+# code block inside the item, which we do not model — the item simply does not
+# register, which costs recognition rather than inventing it).
+_LIST_ITEM_OPEN_RE = re.compile(
+    r"^(?P<indent>[ ]*)(?P<marker>[-+*]|\d{1,9}[.)])(?P<gap>[ \t]{1,4})(?=\S)"
+)
+
+# `admonition` (`!!! note`), `pymdownx.details` (`??? note` / `???+ note`) and
+# `pymdownx.tabbed` (`=== "Tab"`) are all enabled in mkdocs.yml and all indent
+# their content by four spaces.  `===` needs the quote to tell a content tab
+# from a setext H1 underline.
+_MKDOCS_BLOCK_OPEN_RE = re.compile(
+    r"""^(?P<indent>[ ]*)(?:
+          !!![ \t]
+        | \?{3}\+?[ \t]
+        | ===[ \t]+["']
+    )""",
+    re.VERBOSE,
+)
+
+_MKDOCS_BLOCK_CONTENT_INDENT = 4
 
 # Inline-code span (CommonMark §6.1).  A span opens with a run of N
 # backticks and closes with the next run of EXACTLY N backticks on the same
@@ -484,25 +534,106 @@ def _strip_fences(lines: list[str]) -> list[tuple[int, str]]:
 
     Lines inside a fenced block are replaced with empty strings (preserving
     line numbering) so heading-pattern lines inside code samples don't get
-    indexed as real headings.
+    indexed as real headings, and links inside code samples are not resolved as
+    cross-references.  This is the scanner's only notion of "code, not prose":
+    every other check in this file inherits whatever it gets wrong.
+
+    A fence is recognised at the indentation its CONTAINER gives it (rf2-mmyc).
+    `_LIST_ITEM_OPEN_RE` and `_MKDOCS_BLOCK_OPEN_RE` maintain a stack of open
+    content columns, and a fence opens at up to three spaces past the innermost
+    one — CommonMark's allowance, which the renderer honours.  Four or more
+    spaces past it is an indented code block instead, and opens nothing.
+
+    Closing is RENDERER-DERIVED rather than read off CommonMark, because
+    pymdownx.superfences (what MkDocs runs) is stricter than the spec: it closes
+    a fence only on the opener's EXACT marker, at the opener's EXACT
+    indentation, with no info string.  CommonMark's ≤3-space slack would end a
+    ```markdown sample at the first nested bare fence inside it — which the
+    corpus has, in skills/re-frame2-implementor/references/output-format.md.
+
+    A fence also ends with the container that holds it: a non-blank line
+    indented less than the fence's content column closes both.  rf2-re0m shipped
+    three UNBALANCED fences, so without that an authoring slip blanks a document
+    from the fence to EOF — a gate going silent, which is the same failure as
+    the one being fixed, pointing the other way.
+
+    Bounded deliberately, and these are the edges:
+
+    * A fence inside a BLOCKQUOTE (`> ```clojure`) is not recognised, exactly as
+      before.  The renderer does treat it as a fence; the corpus has 28 such
+      lines.  Teaching the stack about quote depth is a separate change with a
+      far larger blast radius (measured: 138 lines flipping back to prose and 36
+      rendered ids appearing), so it stays out of a gate-correctness fix.
+    * An INDENTED code block's content is still scanned as prose.  This function
+      recognises where a fence is, not where an indented code block is; telling
+      one from a paragraph continuation needs paragraph state this scanner does
+      not keep.  Measured across the corpus: zero markdown links live in one.
+    * Indentation is counted in SPACES.  The corpus has no tab-indented fence.
     """
     out: list[tuple[int, str]] = []
-    in_fence = False
-    fence_marker = ""
+    open_columns: list[int] = []
+    fence: tuple[str, int] | None = None  # (opening marker, its indentation)
     for i, raw in enumerate(lines, start=1):
-        m = _FENCE_RE.match(raw)
-        if m:
-            marker = m.group(1)
-            if not in_fence:
-                in_fence = True
-                fence_marker = marker
-            elif marker == fence_marker:
-                in_fence = False
-                fence_marker = ""
+        if fence is not None:
+            marker, fence_indent = fence
+            if not raw.strip():
+                out.append((i, ""))
+                continue
+            indent = len(raw) - len(raw.lstrip(" "))
+            if indent >= (open_columns[-1] if open_columns else 0):
+                m = _FENCE_RE.match(raw)
+                if (
+                    m
+                    and m.group("marker") == marker
+                    and len(m.group("indent")) == fence_indent
+                    and not m.group("info").strip()
+                ):
+                    fence = None
+                out.append((i, ""))
+                continue
+            # The container holding the fence ended, so the fence ended with it.
+            # Fall through and read this line as ordinary source.
+            fence = None
+
+        if not raw.strip():
             out.append((i, ""))
             continue
-        out.append((i, "" if in_fence else raw))
+
+        indent = len(raw) - len(raw.lstrip(" "))
+        while open_columns and indent < open_columns[-1]:
+            open_columns.pop()
+        content_column = open_columns[-1] if open_columns else 0
+
+        m = _FENCE_RE.match(raw)
+        if m and content_column <= indent <= content_column + 3:
+            fence = (m.group("marker"), indent)
+            out.append((i, ""))
+            continue
+
+        if indent <= content_column + 3:
+            lm = _LIST_ITEM_OPEN_RE.match(raw)
+            if lm:
+                open_columns.append(
+                    len(lm.group("indent")) + len(lm.group("marker")) + len(lm.group("gap"))
+                )
+            elif _MKDOCS_BLOCK_OPEN_RE.match(raw):
+                open_columns.append(indent + _MKDOCS_BLOCK_CONTENT_INDENT)
+        out.append((i, raw))
     return out
+
+
+def _fenced_lines(lines: list[str]) -> Iterable[tuple[int, str]]:
+    """Yield (1-based line-number, source content) for every line INSIDE a fence.
+
+    Derived from `_strip_fences` rather than re-scanning, so the two can never
+    disagree about where a fence is: a line is fenced exactly when the scanner
+    blanked it and the source line was not itself blank.  One scanner, one
+    answer — a second implementation of the fence model is precisely the sort of
+    drift this gate exists to catch.
+    """
+    for (line_no, stripped), raw in zip(_strip_fences(lines), lines):
+        if raw.strip() and not stripped.strip():
+            yield line_no, raw
 
 
 def _mask_html_comments(
@@ -929,6 +1060,72 @@ def _is_ai_findings_link(path_part: str) -> bool:
     return False
 
 
+# rf2-mmyc — trees in which a markdown link inside a code fence is always a
+# defect.  This is the check that would have caught rf2-re0m at the gate: the
+# seven links that bulk pass added all RESOLVED, so link validation had nothing
+# to say about them, and the damage (samples that render a literal `](...)` and
+# no longer read as Clojure) was only visible to a reader.
+#
+# SCOPED, NOT CORPUS-WIDE, and the corpus is why: 109 in-repo links live inside
+# fences elsewhere in this repo — 88 of them in `spec/Spec-Schemas.md`, as
+# ordinary `;;` commentary cross-referencing other specs from inside a schema
+# sample, which is a good idiom and not something to legislate away.  Making the
+# assertion corpus-wide would need an allowlist for those, and an allowlist is
+# how a gate stops meaning anything.  `docs/design/hicasso/` is a working design
+# record whose fences are Clojure, bash and captured output; it measures clean
+# today, so the check lands green.
+#
+# `docs/design/freehand/` measures clean too and is the same class of artefact —
+# a defensible extension, deliberately not taken here: it had no incident, and
+# widening a new gate past its evidence is how gates acquire a reputation for
+# arbitrary friction.
+FENCED_DOC_LINK_TREES = ("docs/design/hicasso",)
+
+
+def _is_doc_destination(dest: str) -> bool:
+    """True if a link destination names an in-repo markdown page or a fragment.
+
+    Deliberately narrower than "contains `](`" (rf2-mmyc).  A bare `](` is legal
+    Clojure — `(fn [x](inc x))` closes a vector and opens a list — and a gate
+    that nags valid code for its spacing is worse than no gate.  A destination
+    ending `.md`, or a pure `#fragment`, is the signature of a documentation
+    link pass and cannot be produced by the Clojure, EDN, bash and captured
+    output these fences actually hold.
+    """
+    if dest.startswith(("http://", "https://", "mailto:", "tel:", "//")):
+        return False
+    path_part = dest.partition("#")[0].split("?", 1)[0]
+    if not path_part:
+        return dest.startswith("#")
+    return path_part.endswith(".md")
+
+
+def _check_fenced_doc_links(
+    repo_root: Path,
+    files: Iterable[Path],
+    trees: tuple[str, ...] = FENCED_DOC_LINK_TREES,
+) -> list[tuple[Path, int, str]]:
+    """Find markdown doc links written INSIDE a code fence (rf2-mmyc).
+
+    Returns (source-file, line-no, destination) for each one, in the covered
+    trees only.  Runs off `_fenced_lines`, so it inherits the one fence model
+    this file has rather than carrying a second opinion about where code starts.
+    """
+    prefixes = tuple(f"{tree.rstrip('/')}/" for tree in trees)
+    if not prefixes:
+        return []
+    found: list[tuple[Path, int, str]] = []
+    for path in files:
+        if not path.relative_to(repo_root).as_posix().startswith(prefixes):
+            continue
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        for line_no, raw in _fenced_lines(lines):
+            for m in _LINK_RE.finditer(raw):
+                if _is_doc_destination(m.group(1)):
+                    found.append((path, line_no, m.group(1)))
+    return found
+
+
 def _check_compat_anchors(
     repo_root: Path,
     counts_for,
@@ -1088,6 +1285,12 @@ def check(
         * BROKEN SOURCE-COMMENT LINK — (default scope, rf2-57k74) a
                               `docs/<handbook>/*.md#anchor` reference embedded in
                               a non-markdown source comment does not resolve.
+        * LINK INSIDE A FENCE — (rf2-mmyc) a markdown link to a doc page or
+                              anchor written INSIDE a code fence, in the trees
+                              listed in FENCED_DOC_LINK_TREES. Such a link
+                              resolves perfectly and is still a defect: it
+                              renders literally and the sample stops being
+                              valid code.
 
     The compat-anchor manifest, source-comment scan, and placement rules default
     to the production inventory (HANDBOOK_COMPAT_ANCHORS / the tracked Clojure tree
@@ -1199,6 +1402,9 @@ def check(
         source_files=source_files,
         link_re=source_comment_re,
     )
+    # rf2-mmyc — links written INSIDE a code fence, in the trees where a fenced
+    # sample is only ever code.
+    fenced_doc_links = _check_fenced_doc_links(repo_root, files)
 
     total = (
         len(broken_anchor)
@@ -1209,6 +1415,7 @@ def check(
         + len(compat_duplicate)
         + len(compat_misplaced)
         + len(source_comment_broken)
+        + len(fenced_doc_links)
     )
 
     if broken_target:
@@ -1339,6 +1546,25 @@ def check(
             "\nFix: point the comment at a live canonical heading, or restore a "
             "compatibility anchor on the target page (and list it in "
             "HANDBOOK_COMPAT_ANCHORS).\n"
+        )
+
+    if fenced_doc_links:
+        sys.stderr.write(
+            f"\n{len(fenced_doc_links)} markdown link(s) inside a code fence "
+            "found (rf2-mmyc):\n\n"
+        )
+        for src, line_no, dest in fenced_doc_links:
+            rel = src.relative_to(repo_root)
+            sys.stderr.write(
+                f"  LINK INSIDE A FENCE: {rel}:{line_no} -> {dest}\n"
+            )
+        sys.stderr.write(
+            "\nFix: a fenced block is code, so a markdown link inside one "
+            "renders literally and makes the sample invalid to copy — and "
+            "markdown reads the sample's own square brackets as link text, so "
+            "the rewrite that adds one often eats an opening bracket too "
+            "(rf2-re0m). Restore the plain code and put the cross-reference in "
+            "the prose around the fence.\n"
         )
 
     if total == 0 and verbose:


### PR DESCRIPTION
Closes rf2-mmyc.

`scripts/check_doc_slugs.py` anchored its fence matcher at column 0:

```python
_FENCE_RE = re.compile(r"^(```|~~~)")
```

A fence carrying its container's indentation — two spaces inside a list item,
four inside an admonition — was therefore never recognised as a fence at all,
and the sample inside it was scanned as **ordinary prose**.

That is how rf2-re0m shipped. A bulk link pass rewrote six lines inside three
Clojure samples, adding seven markdown links that render literally; markdown
read the samples' own square brackets as link text, so the rewrite ate opening
brackets and three fences shipped unbalanced. This gate passed the whole time
and was right to by its own lights — every one of those seven links **resolved**.
It asks whether a link has a target, never whether the text should be a link at
all, and it could not ask the second question while it believed it was reading
prose.

## Not a one-character relaxation

`^\s*` is the wrong fix. Four or more spaces past the current content column is
an **indented code block** — a different construct, with no closing delimiter —
so `^\s*` opens a fence that is never closed and blanks the file from there to
EOF. `_strip_fences` now tracks the content column of open list items and MkDocs
block containers (`admonition`, `pymdownx.details`, `pymdownx.tabbed`, all
enabled in `mkdocs.yml`, all indenting content by four), and admits a fence up
to three spaces past it.

## The rules are renderer-derived, not read off CommonMark

Every rule below was confirmed against python-markdown + `pymdownx.superfences`
— the pair MkDocs actually runs — rather than inferred from the CommonMark
prose, because superfences is stricter than the spec in two places that matter
to this corpus:

| shape | renderer | this scanner |
|---|---|---|
| fence at ordinary-context indent 0/1/2/3 | fence | fence |
| fence at ordinary-context indent 4 | indented code block | not a fence |
| fence at indent 2 in a list item, 4 in an admonition | fence | fence |
| closer indented **more** than its opener (CommonMark allows ≤3) | does **not** close | does not close |
| closer indented **less** than its opener | does **not** close | does not close |
| closer run **longer** than its opener (CommonMark allows ≥) | does **not** close | does not close |
| closer carrying an info string | does not close | does not close |
| fence inside a blockquote | fence | **not covered — see below** |

The closing rule matters concretely:
`skills/re-frame2-implementor/references/output-format.md` displays a nested
bare fence inside a ` ```markdown ` sample. CommonMark's three-space slack would
end the outer block at that nested fence; the renderer does not, and an earlier
draft of this fix that followed CommonMark regressed exactly those four lines
back to prose. A fence also ends with the container that holds it, so an
unbalanced fence — and rf2-re0m shipped three — cannot silently blank the rest
of a document.

## Measured in both directions, same merge base

Baseline is `scripts/check_doc_slugs.py` at `origin/main`, loaded from git into
a scratch module and run beside the working-tree version over the same 715
files. **A gate that gets quieter is not automatically a gate that got better**,
so the extracted-link set, the rendered-id index and the whole-gate finding
count were each diffed both ways:

```
files scanned                    : 715
lines prose -> code (now skipped): 3725
lines code -> prose (REGRESSION) : 0
links LOST (stop being checked)  : 0
links GAINED (newly checked)     : 0
slug ids LOST                    : 0
slug ids GAINED                  : 0

whole-gate finding count — baseline 0, candidate 0
```

**Every link that stops being checked: the set is empty.** That deserves an
explanation rather than a shrug, because 3725 lines changed classification.

The baseline was already suppressing links inside *balanced* indented fences —
by accident. `_INLINE_CODE_SPAN_RE` (added under rf2-8wcbe) masks a multiline
inline-code span, and a balanced fence's own opening and closing backtick runs
pair up as exactly that. The accident fails the moment a blank line inside the
sample splits the inline block, which is precisely how rf2-re0m's seven links
reached validation. Replayed against the real pre-repair documents at
`97d6acecf5^`:

```
docs/design/hicasso/draft-guide/10-native-tier.md      5 in-fence doc links
docs/design/hicasso/draft-guide/20-code-splitting.md   2 in-fence doc links
  validated by the baseline scanner : 7
  validated after this change       : 0   (and all 7 now reported)
```

So the corpus delta is zero because the corpus was repaired under rf2-re0m, not
because the change is inert. It converts a fragile accident into a stated rule.

`scripts/check_readme_links.py` imports `_strip_fences` and `_extract_links`, so
it inherits this over its own roster: 72 files, 25 lines newly recognised as
code, **0 links lost, 0 gained**. Both gates still exit 0 with unchanged output
on a healthy tree.

## The second half: a link inside a fence is itself a finding

New `LINK INSIDE A FENCE` diagnostic. This is the check that would have caught
rf2-re0m *at the gate* rather than in a merged PR.

**It lives in this checker, not beside it.** A sibling script would need its own
copy of the fence model, and two copies of this particular model drifting apart
is the exact failure this bead exists to fix. It reads off `_fenced_lines`,
which is derived from `_strip_fences` rather than re-scanning, so there is one
scanner and one answer.

**Scoped to `docs/design/hicasso/`, not corpus-wide.** Corpus-wide is not
available: 109 in-repo links live inside fences elsewhere in this repo, 88 of
them in `spec/Spec-Schemas.md` as ordinary `;;` commentary cross-referencing
other specs from inside a schema sample. That is a good idiom, and the only way
to make a corpus-wide rule survive it is an allowlist — which is how a gate
stops meaning anything. `docs/design/hicasso/` measures clean today, so the
check lands green.

`docs/design/freehand/` measures clean too and is the same class of artefact. I
deliberately did **not** widen to it: it had no incident, and extending a brand
new gate past its evidence is how gates earn a reputation for arbitrary
friction. Adding it later is a one-token change to `FENCED_DOC_LINK_TREES`.

The predicate is narrower than "contains `](`": it fires on a destination ending
`.md` or a bare `#fragment`. A bare `](` is legal Clojure — `(fn [x](inc x))`
closes a vector and opens a list — and a gate that nags valid code about its
spacing is worse than no gate. The doc-link signature is what a bulk
documentation pass produces and cannot come from the Clojure, EDN, bash and
captured output these fences actually hold.

## The order is the proof

The self-tests were written and committed **red against the current
implementation** (commit 1) before a line of the scanner changed (commit 2).
Verbatim:

```
self-test FAIL: indented_fence_link_ignored expected broken=0, got 2
self-test FAIL: indented_fence_negative_control expected broken=1, got 2
self-test FAIL: fenced_doc_link_in_scope expected broken=1, got 0
self-test FAIL: fence [fence indented inside a list item is a fence] expected visible lines [1, 7], got [1, 3, 4, 5, 7]
self-test FAIL: fence [fence indented inside an admonition is a fence] expected visible lines [1, 7], got [1, 3, 4, 5, 7]
self-test FAIL: fence [indented tilde fence is a fence] expected visible lines [1, 7], got [1, 3, 4, 5, 7]
self-test FAIL: fence [fence indented three spaces in ordinary context is a fence] expected visible lines [1, 7], got [1, 3, 4, 5, 7]
self-test FAIL: fence [unclosed indented fence ends with its container] expected visible lines [1, 6], got [1, 3, 4, 6]

8 self-test failure(s).
```

Four further cases pass *before* the fix, and that is their job — they are
controls, not teeth, and each rejects a specific wrong fix:

* **column-0 fence** — the regression guard.
* **four-space indented code block in ordinary context is not a fence** —
  rejects `^\s*`.
* **nested bare fence inside a ` ```markdown ` sample** — rejects CommonMark's
  closing-fence slack. Drawn from a real corpus file.
* **`fenced_doc_link_out_of_scope`** — the same sample under
  `docs/design/freehand/`, proving the new assertion is scoped.

The fence cases drive `_strip_fences` directly rather than going through a
fixture, because the inline-code-span accident described above can make a
fixture-level count come out right while the scanner is still blind.

`fenced_doc_link_in_scope` reproduces the rf2-re0m shape exactly: the link
inside the fence **resolves**, so link validation is satisfied and only the new
assertion can see it.

## Checked and reported, not fixed

* **Indented code blocks.** The renderer treats their content as code; this
  scanner still reads it as prose. Recognising a fence and recognising an
  indented code block are different problems — telling the latter from a
  paragraph continuation needs paragraph state this scanner does not keep.
  Measured: **zero** markdown links live inside an ordinary-context indented
  code block anywhere in the corpus, so there is nothing to catch today. The
  container model does correctly refuse to call one a fence, which is the part
  that matters for this fix.
* **Blockquoted fences.** The renderer treats `> ```clojure ` as a fence; this
  scanner does not, exactly as before. 28 such lines exist, in `spec/`,
  `skills/` and both `docs/design/` subtrees. A prototype that taught the stack
  about quote depth flipped **138 lines back to prose and minted 36 new
  rendered ids** — a far larger blast radius than a gate-correctness fix should
  carry, so it stays out. Both limits are stated in `_strip_fences`' docstring
  rather than left for the next reader to discover.
* **The bead's "also noted" item** (explicit ids duplicating the generated slug
  of the heading they precede) is **larger than filed**: not 50 in
  `glossary.md`, but **118 colliding fragment ids across 15 pages** —
  `glossary.md` 50, `docs/routing/concepts.md` 18,
  `spec/015-Data-Classification.md` 18, `spec/012-Routing.md` 10, and eleven
  more. Verdict: **latent ambiguity, not harmless redundancy.** Duplicate `id`
  attributes are invalid HTML and browsers resolve the first, which is why
  nothing has broken — in the glossary pattern the explicit anchor comes first
  and sits immediately above its heading, so deep-links land correctly. The
  live hazard is that all 118 are traps for `HANDBOOK_COMPAT_ANCHORS`: adding
  any one of them to the manifest reds the gate instantly with
  `DUPLICATE COMPAT ANCHOR`. Currently **0** are in the manifest. Worth its own
  bead; not mass-edited here, per the bead.

## Fences honoured

No existing check weakened; no ignore mechanism or allowlist added (and the
scoping decision above is explicitly the *alternative* to one); the corpus is
untouched — the only files changed are the checker and its fixtures.

## Quality gates

Each run alone, in the foreground, with its exit status echoed to its own file —
never through a pipeline, whose exit status is its last command's.

| gate | exit |
|---|---|
| `python scripts/check_doc_slugs.py --self-test` (before the fix, expected red) | 1 — 8 failures, quoted above |
| `python scripts/check_doc_slugs.py --self-test` | 0 |
| `python scripts/check_doc_slugs.py` (full corpus) | 0, no output |
| `python scripts/check_readme_links.py --self-test` (shares the extractor) | 0 |
| `python scripts/check_readme_links.py` (full roster) | 0 |
| `sh scripts/test-fast-pr.sh` | 0 — `PASS fast PR spine` |

`gate root:` printed by the spine was
`/c/Users/miket/code/re-frame2-worktrees/fencescan-mmyc`, this worker's
worktree.

The measurement scripts behind the numbers above were run from a file, never a
heredoc, and each carries a `--prove` mode that runs the identical diff
machinery over synthetic known-bad input and requires a non-zero answer on
every axis — an ad-hoc verification script is itself unverified until it has
been shown it can report a non-zero. The first version of that harness reported
a false zero for links lost; `--prove` is what caught it.
