### PR TITLE
fix(gate): cover blockquoted fences and disarm the colliding-anchor trap (rf2-1cpt)

### DIFF
--- a/scripts/_test_fixtures/check_doc_slugs/README.md
+++ b/scripts/_test_fixtures/check_doc_slugs/README.md
@@ -38,4 +38,10 @@ Fixtures:
 | `wrapped_link_block_bound`         | 0               | False-positive control: the join stops at a block boundary, so `[text` … blank … `](x.md)` is not a link (rf2-vpc4c) |
 | `multiline_code_span_not_a_link`   | 1               | A code span crossing a line ending is masked whole, so the link-shaped text inside it yields nothing; the 1 is a real broken wrapped link (rf2-8wcbe) |
 | `non_blank_block_bound`            | 1               | The join stops at every NON-blank boundary — heading (before and after), thematic break, list item, table row, blockquote entry; the 1 is a real wrapped link inside one list item (rf2-8wcbe) |
+| `indented_fence_link_ignored`      | 0               | A fence carrying its container's indentation — list item, admonition — is still a fence, so the sample inside it carries no links to resolve (rf2-mmyc) |
+| `indented_fence_negative_control`  | 1               | Widening the fence matcher must not quieten the gate: the 1 is a real broken link in prose after an indented fence, and an unclosed fence ends with its container (rf2-mmyc) |
+| `fenced_doc_link_in_scope`         | 1               | A doc link INSIDE a fence, in a `FENCED_DOC_LINK_TREES` tree — it resolves, so only the assertion can see it (rf2-mmyc) |
+| `fenced_doc_link_out_of_scope`     | 0               | The identical sample under a sibling tree stays silent — the assertion is scoped, not corpus-wide (rf2-mmyc) |
+| `fenced_doc_link_blockquoted`      | 1               | The same assertion on a BLOCKQUOTED fence (`> ```clojure`) — the shape `docs/design/hicasso/studio/` actually writes (rf2-1cpt) |
+| `blockquoted_fence_not_indexed`    | 2               | A `###` line and an `<a id>` inside a blockquoted fence mint no fragment target, so links to them are broken; the real heading and the blockquoted heading below must still resolve (rf2-1cpt) |
 | `compat_anchor_teeth`              | driven directly | The compat-anchor manifest, placement, and source-comment teeth — invoked with explicit fixture inputs, not from this table (rf2-57k74 / rf2-zq5i6 / rf2-k30r7) |

--- a/scripts/_test_fixtures/check_doc_slugs/blockquoted_fence_not_indexed/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/blockquoted_fence_not_indexed/docs/index.md
@@ -1,0 +1,30 @@
+# Index — A Blockquoted Fence Mints No Fragment Target (rf2-1cpt)
+
+python-markdown renders the block below as one `<code>` element, so neither the
+`###` line nor the `<a id>` inside it becomes a fragment target on the built
+site.  A scanner that reads the block as prose indexes both and then happily
+validates links that resolve nowhere — the gate agreeing with itself instead of
+with the renderer.
+
+Both of these links are therefore broken and must be reported:
+[the fenced heading](#not-a-real-heading) and
+[the fenced anchor](#not-a-real-anchor).
+
+> Captured from a run, quoted so it reads as evidence rather than instruction:
+>
+> ```bash
+> ### Not a real heading
+> <a id="not-a-real-anchor"></a>
+> ```
+
+## A real heading
+
+And the link to [that one](#a-real-heading) must still resolve — the positive
+control, so the count fails upward if the fence is still read as prose and
+downward if blanking runs past the blockquote and eats the page.
+
+> #### A blockquoted heading outside the fence
+
+The blockquoted heading above is a real `<h4 id="a-blockquoted-heading-outside-the-fence">`
+(rf2-869k9m), and [the link to it](#a-blockquoted-heading-outside-the-fence)
+must keep resolving.

--- a/scripts/_test_fixtures/check_doc_slugs/blockquoted_fence_not_indexed/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/blockquoted_fence_not_indexed/mkdocs.yml
@@ -1,0 +1,1 @@
+# Self-test fixture marker.

--- a/scripts/_test_fixtures/check_doc_slugs/compat_anchor_teeth/docs/machines/stacked.md
+++ b/scripts/_test_fixtures/check_doc_slugs/compat_anchor_teeth/docs/machines/stacked.md
@@ -1,0 +1,16 @@
+# Page
+
+<a id="alias-one"></a>
+<a id="dup-me"></a>
+<a id="alias-two"></a>
+
+## Dup Me
+
+The corpus's real shape (rf2-1cpt): a STACK of alias anchors above the heading
+they name, one of which duplicates the heading's own generated slug. Anchor
+elements render empty, so the whole stack and the heading are one landing spot
+— a co-location test that only tolerates blank lines between the occurrences
+gets this wrong, and two spec pages are written exactly this way.
+
+It still fails the unique-target check (rf2-zq5i6); co-location changes what the
+diagnostic SAYS, not whether the gate fails. No markdown links here.

--- a/scripts/_test_fixtures/check_doc_slugs/fenced_doc_link_blockquoted/docs/design/hicasso/glossary.md
+++ b/scripts/_test_fixtures/check_doc_slugs/fenced_doc_link_blockquoted/docs/design/hicasso/glossary.md
@@ -1,0 +1,5 @@
+# Glossary
+
+## nprops
+
+The operand-marking form.

--- a/scripts/_test_fixtures/check_doc_slugs/fenced_doc_link_blockquoted/docs/design/hicasso/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/fenced_doc_link_blockquoted/docs/design/hicasso/index.md
@@ -1,0 +1,19 @@
+# Index — Linked Blockquoted Fence (rf2-1cpt)
+
+The rf2-re0m shape again, this time inside a blockquote callout: a link that
+RESOLVES, so link validation is satisfied, sitting inside a fence where it
+renders literally and makes the sample invalid to copy.
+
+`docs/design/hicasso/studio/` really does write samples this way — a quoted
+block of prose that carries its evidence in a `> ```bash` fence — so the tree
+the assertion guards is exactly the tree that has them.
+
+> **Mark the operand.** The command below is the whole of it:
+>
+> ```clojure
+> ([n/props](glossary.md#nprops) cell-props)
+>
+> ;; renders literally; copying this sample yields code that will not read
+> ```
+
+The link above is the only defect on this page.

--- a/scripts/_test_fixtures/check_doc_slugs/fenced_doc_link_blockquoted/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/fenced_doc_link_blockquoted/mkdocs.yml
@@ -1,0 +1,1 @@
+# Self-test fixture marker.

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -47,8 +47,9 @@ Notes on what is and isn't checked:
     * Pure section-anchor permalinks (e.g. #fragment-only-anchor) and link
       definitions inside fenced code blocks are skipped.  A fence counts as a
       fence wherever its container puts it — indented inside a list item or an
-      admonition as readily as at column 0 (rf2-mmyc).  See `_strip_fences` for
-      what that recognition covers and, just as importantly, what it does not.
+      admonition as readily as at column 0 (rf2-mmyc), and inside a blockquote
+      (`> ```clojure`) as readily as outside one (rf2-1cpt).  See `_strip_fences`
+      for what that recognition covers and, just as importantly, what it does not.
     * In the trees listed in FENCED_DOC_LINK_TREES a markdown doc link inside a
       fence is itself reported (rf2-mmyc).  Everywhere else it is merely
       skipped: 88 links in `spec/Spec-Schemas.md` alone sit legitimately inside
@@ -307,10 +308,17 @@ _LIST_ITEM_START_RE = re.compile(
     re.VERBOSE,
 )
 
-# Leading blockquote markers, e.g. `> ` or `> > `.  The count of `>` is the
-# quote depth; the remainder is the quoted line's own content, which is what
-# `_BLOCK_START_RE` must be tested against (a `> # Heading` is still a heading).
-_QUOTE_PREFIX_RE = re.compile(r"^(?:[ ]{0,3}>[ \t]?)+")
+# ONE leading blockquote marker, e.g. `> ` or `>`.  Applied repeatedly by
+# `_quote_depth_and_body`: the number of markers consumed is the quote depth and
+# the remainder is the quoted line's own content, which is what `_BLOCK_START_RE`
+# and `_FENCE_RE` must be tested against (a `> # Heading` is still a heading, and
+# a `> ```clojure` is still a fence).
+#
+# The optional trailing space is the blockquote's own content column — which is
+# why `>` + four spaces is a fence indented three (the renderer's allowance) and
+# `>` + five is an indented code block.  Consuming it here is what makes the
+# in-quote indent directly comparable to a column-0 one.
+_QUOTE_MARKER_RE = re.compile(r"[ ]{0,3}>[ \t]?")
 
 
 # rf2-t0ituo / rf2-57k74 — cross-handbook compatibility-anchor manifest +
@@ -557,30 +565,63 @@ def _strip_fences(lines: list[str]) -> list[tuple[int, str]]:
     from the fence to EOF — a gate going silent, which is the same failure as
     the one being fixed, pointing the other way.
 
+    A BLOCKQUOTE is a container too (rf2-1cpt).  `> ```clojure` opens a real
+    fence — python-markdown renders the lines under it as a code block, mints no
+    heading id for a `> ### Title` inside it, and resolves no link written there
+    — so quote depth joins the marker and the indentation as part of a fence's
+    identity.  The quote's markers ARE the container: the in-quote indent is
+    measured after them (each `>` absorbing one following space), so a fence sits
+    at the quote's content column exactly as an unquoted one sits at its list
+    item's.  A quoted fence closes only at its own depth, and ends with its
+    blockquote — an unclosed one cannot reach the prose below the quote.
+
     Bounded deliberately, and these are the edges:
 
-    * A fence inside a BLOCKQUOTE (`> ```clojure`) is not recognised, exactly as
-      before.  The renderer does treat it as a fence; the corpus has 28 such
-      lines.  Teaching the stack about quote depth is a separate change with a
-      far larger blast radius (measured: 138 lines flipping back to prose and 36
-      rendered ids appearing), so it stays out of a gate-correctness fix.
     * An INDENTED code block's content is still scanned as prose.  This function
       recognises where a fence is, not where an indented code block is; telling
       one from a paragraph continuation needs paragraph state this scanner does
       not keep.  Measured across the corpus: zero markdown links live in one.
+      Inside a blockquote the same bound applies, and the renderer agrees:
+      superfences opens a fence at any indent but RESTORES the literal source
+      when an indented block swallows it, so `>` + five spaces renders the fence
+      markers as text.
+    * List items and admonitions nested INSIDE a blockquote do not push a content
+      column; a quoted fence is measured from the quote's own.  Within the
+      renderer's three-space allowance that agrees (`> - item` / `>   ```clj` is
+      still a fence); past it the fence simply does not register, which costs
+      recognition rather than inventing it.  The corpus has no such fence.
     * Indentation is counted in SPACES.  The corpus has no tab-indented fence.
     """
     out: list[tuple[int, str]] = []
     open_columns: list[int] = []
-    fence: tuple[str, int] | None = None  # (opening marker, its indentation)
+    # (opening marker, its indentation, its blockquote depth)
+    fence: tuple[str, int, int] | None = None
     for i, raw in enumerate(lines, start=1):
         if fence is not None:
-            marker, fence_indent = fence
+            marker, fence_indent, fence_depth = fence
             if not raw.strip():
+                # A blank line neither closes a fence nor ends a blockquote for
+                # fence purposes — superfences counts it and reads on.
                 out.append((i, ""))
                 continue
             indent = len(raw) - len(raw.lstrip(" "))
-            if indent >= (open_columns[-1] if open_columns else 0):
+            if fence_depth:
+                depth, body = _quote_depth_and_body(raw[indent:], limit=fence_depth)
+                if depth == fence_depth:
+                    m = _FENCE_RE.match(body)
+                    if (
+                        m
+                        and m.group("marker") == marker
+                        and len(m.group("indent")) == fence_indent
+                        and not m.group("info").strip()
+                    ):
+                        fence = None
+                    out.append((i, ""))
+                    continue
+                # Shallower than the fence: the blockquote holding it ended, so
+                # the fence ended with it.
+                fence = None
+            elif indent >= (open_columns[-1] if open_columns else 0):
                 m = _FENCE_RE.match(raw)
                 if (
                     m
@@ -591,9 +632,10 @@ def _strip_fences(lines: list[str]) -> list[tuple[int, str]]:
                     fence = None
                 out.append((i, ""))
                 continue
-            # The container holding the fence ended, so the fence ended with it.
-            # Fall through and read this line as ordinary source.
-            fence = None
+            else:
+                # The container holding the fence ended, so the fence ended with
+                # it.  Fall through and read this line as ordinary source.
+                fence = None
 
         if not raw.strip():
             out.append((i, ""))
@@ -604,9 +646,18 @@ def _strip_fences(lines: list[str]) -> list[tuple[int, str]]:
             open_columns.pop()
         content_column = open_columns[-1] if open_columns else 0
 
+        if indent <= content_column + 3:
+            quote_depth, quoted_body = _quote_depth_and_body(raw[indent:])
+            if quote_depth:
+                qm = _FENCE_RE.match(quoted_body)
+                if qm and len(qm.group("indent")) <= 3:
+                    fence = (qm.group("marker"), len(qm.group("indent")), quote_depth)
+                    out.append((i, ""))
+                    continue
+
         m = _FENCE_RE.match(raw)
         if m and content_column <= indent <= content_column + 3:
-            fence = (m.group("marker"), indent)
+            fence = (m.group("marker"), indent, 0)
             out.append((i, ""))
             continue
 
@@ -853,12 +904,27 @@ def _strip_inline_code(line: str) -> str:
     return _INLINE_CODE_RE.sub(lambda m: " " * (m.end() - m.start()), line)
 
 
-def _quote_depth_and_body(content: str) -> tuple[int, str]:
-    """Split a line into its blockquote depth and the quoted line's own content."""
-    m = _QUOTE_PREFIX_RE.match(content)
-    if not m:
-        return 0, content
-    return m.group(0).count(">"), content[m.end():]
+def _quote_depth_and_body(content: str, limit: int | None = None) -> tuple[int, str]:
+    """Split a line into its blockquote depth and the quoted line's own content.
+
+    `limit` caps how many markers are consumed, which is what a line INSIDE an
+    open blockquoted fence needs (rf2-1cpt).  superfences parses a content
+    line's prefix only as far as the OPENING line's prefix reached
+    (`parse_fence_line` stops at the opener's width), so a line quoted more
+    deeply than the fence is ordinary content rather than a nested quote — the
+    extra `>` is simply the first character of a line of code.  Passing the
+    fence's own depth as `limit` reproduces that; the default (`None`) consumes
+    every marker, which is what block-boundary detection wants.
+    """
+    depth = 0
+    pos = 0
+    while limit is None or depth < limit:
+        m = _QUOTE_MARKER_RE.match(content, pos)
+        if m is None:
+            break
+        depth += 1
+        pos = m.end()
+    return depth, content[pos:]
 
 
 def _inline_blocks(
@@ -1701,6 +1767,19 @@ def _run_self_tests(verbose: bool = False) -> int:
         # a sibling tree stays silent.
         ("fenced_doc_link_in_scope",         1),
         ("fenced_doc_link_out_of_scope",     0),
+        # rf2-1cpt — the same assertion, on a BLOCKQUOTED fence.  The guarded
+        # tree writes its samples this way (two files under
+        # docs/design/hicasso/studio/), and the assertion could not see them
+        # while the scanner read a quoted fence as prose.  The link resolves, so
+        # again only the assertion can find it.
+        ("fenced_doc_link_blockquoted",      1),
+        # rf2-1cpt — the id side of the same blind spot, and the one that fails
+        # in BOTH directions.  The 2 are links to a `###` line and an `<a id>`
+        # that live INSIDE a blockquoted fence and therefore mint no fragment
+        # target: the count rises to 0 if the fence is still read as prose (both
+        # links then resolve against phantom ids), and to 3 if blanking runs past
+        # the blockquote and takes the real heading below it.
+        ("blockquoted_fence_not_indexed",    2),
     ]
 
     failures = 0
@@ -2243,6 +2322,177 @@ def _run_self_tests(verbose: bool = False) -> int:
           "",
           "Prose after, back at column zero."],
          [1, 6]),
+        # ------------------------------------------------------------------
+        # rf2-1cpt — BLOCKQUOTED fences.  A blockquote is a container like any
+        # other, and superfences opens a fence at the column its prefix leaves
+        # (`parse_whitespace` consumes `>`, spaces and tabs alike).  These
+        # expectations were read off python-markdown + pymdownx.superfences
+        # directly, case by case.
+        # ------------------------------------------------------------------
+        ("blockquoted fence blanks its body",
+         ["> Prose before.",
+          ">",
+          "> ```clojure",
+          "> [not a link](missing.md)",
+          "> ```",
+          ">",
+          "> Prose after."],
+         [1, 2, 6, 7]),
+        ("heading inside a blockquoted fence is not a heading",
+         ["> ```clojure",
+          "> ### Heading inside a quoted fence",
+          "> ```",
+          "",
+          "Prose after."],
+         [5]),
+        ("nested-blockquote fence is a fence",
+         ["> > ```clojure",
+          "> > [not a link](missing.md)",
+          "> > ```",
+          "",
+          "Prose after."],
+         [5]),
+        # `>` is a prefix character in its own right — superfences does not
+        # require a space after it.
+        ("blockquote marker with no following space",
+         [">```clojure",
+          ">[not a link](missing.md)",
+          ">```",
+          "",
+          "Prose after."],
+         [5]),
+        ("three-space slack after the quote marker is still a fence",
+         [">    ```clojure",
+          ">    [not a link](missing.md)",
+          ">    ```",
+          "",
+          "Prose after."],
+         [5]),
+        # THE CONTROL THAT REJECTS AN UNBOUNDED QUOTE MATCHER.  Four spaces past
+        # the quote's content column is an INDENTED CODE BLOCK inside the quote,
+        # exactly as it is at column 0: superfences opens a fence greedily and
+        # then RESTORES the literal source when an indented block consumes it
+        # (`_store` / `restore_raw_text`).  The rendered page shows the fence
+        # markers as text, so lines 3-5 are not a fence and stay visible.
+        ("four spaces after the quote marker is an indented code block",
+         ["> Prose.",
+          ">",
+          ">     ```clojure",
+          ">     [not a link](missing.md)",
+          ">     ```",
+          "",
+          "Prose after."],
+         [1, 2, 3, 4, 5, 7]),
+        ("blockquoted fence inside an admonition",
+         ["!!! note",
+          "",
+          "    > ```clojure",
+          "    > [not a link](missing.md)",
+          "    > ```",
+          "",
+          "Prose after."],
+         [1, 7]),
+        # A blank line does not end a blockquote for fence purposes: superfences
+        # counts it as an empty line and keeps the fence open (`eval_quoted`
+        # treats empty content as OK), so the closer four lines down still
+        # closes THIS fence.  The renderer emits one code block holding `(code)`.
+        ("unquoted blank line does not break a blockquoted fence",
+         ["> ```clojure",
+          "> (code)",
+          "",
+          "> ```",
+          "",
+          "Prose after."],
+         [6]),
+        ("quoted blank line does not break a blockquoted fence",
+         ["> ```clojure",
+          "> (code)",
+          ">",
+          "> (more code)",
+          "> ```",
+          "",
+          "Prose after."],
+         [7]),
+        # THE CONTROL THAT REJECTS "STRIP THE `>` AND REUSE THE OLD MATCHER".
+        # A quote-stripping pre-pass turns line 3 into a bare closing fence and
+        # ends the block early, flipping lines 4-5 back to prose.  The renderer
+        # disagrees: a fence opened at quote depth 0 measures a content line's
+        # depth only within its OWN prefix width, which here is zero — so the
+        # `>` is just the first character of a code line.  One code block,
+        # lines 1-5, and only line 7 is prose.
+        ("a quoted closer does not close a column-0 fence",
+         ["```clojure",
+          "(code)",
+          "> ```",
+          "(still code)",
+          "```",
+          "",
+          "Prose after."],
+         [7]),
+        # The closing rules inside a quote are superfences' usual strict ones:
+        # the closer must be the opener's EXACT marker run with nothing after
+        # it.  Neither of these closes, so each fence runs to the end of its
+        # blockquote — and no further.
+        ("longer closing run does not close a blockquoted fence",
+         ["> ```clojure",
+          "> (code)",
+          "> ````",
+          "",
+          "Prose after at column zero."],
+         [5]),
+        ("closer with an info string does not close a blockquoted fence",
+         ["> ```clojure",
+          "> (code)",
+          "> ```clojure",
+          "",
+          "Prose after at column zero."],
+         [5]),
+        # A line quoted MORE deeply than the fence is content, not a nested
+        # quote: superfences reads a content line's prefix only as far as the
+        # opener's reached, so the extra `>` is the first character of a line of
+        # code.  The renderer puts `&gt;` inside the <code> for both of these.
+        ("deeper-quoted line inside a blockquoted fence is content",
+         ["> ```clojure",
+          "> > (deeper-quoted line, still code)",
+          "> ```",
+          "",
+          "Prose after."],
+         [5]),
+        ("deeper-quoted closer does not close a blockquoted fence",
+         ["> ```clojure",
+          "> (code)",
+          "> > ```",
+          "> ```",
+          "",
+          "Prose after."],
+         [6]),
+        # ...and the converse: a SHALLOWER non-blank line is the quote ending,
+        # which ends the fence with it.  The line itself is ordinary source
+        # again, so it stays visible.
+        ("shallower line ends a nested blockquoted fence",
+         ["> > ```clojure",
+          "> > (code)",
+          "> shallower prose",
+          "",
+          "Prose after."],
+         [3, 5]),
+        # RUNAWAY GUARD for the quoted case.  An unclosed blockquoted fence must
+        # not blank the document below it; the blockquote bounds it, exactly as
+        # a list item bounds an indented one.
+        ("unclosed blockquoted fence ends with its blockquote",
+         ["> ```clojure",
+          "> (unclosed",
+          "",
+          "Prose after at column zero."],
+         [4]),
+        # POSITIVE CONTROL — the blockquoted HEADING support added by rf2-869k9m
+        # must survive.  `> #### Foo` is a real `<h4 id="quoted-heading">`, so
+        # the line stays prose and the indexer keeps minting its slug.
+        ("blockquoted heading outside a fence is still prose",
+         ["> #### Quoted heading",
+          ">",
+          "> Quoted prose."],
+         [1, 2, 3]),
     ]
     for label, lines, expected_visible in fence_cases:
         got_visible = [n for n, content in _strip_fences(lines) if content.strip()]

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -147,6 +147,12 @@ _HTML_ANCHOR_RE = re.compile(
     re.IGNORECASE,
 )
 
+# How a rendered fragment id came to exist, for diagnostics that name the two
+# apart (rf2-1cpt).  A duplicate reads very differently depending on which
+# mechanisms collided.
+ANCHOR_MECHANISM = "explicit <a id>"
+HEADING_MECHANISM = "heading"
+
 # Markdown inline link.  Captures destination only.  Reference-style links
 # ([text][ref]) are ignored — none in this corpus per spot-check, and a full
 # parser is out of scope for a CI guard.
@@ -349,6 +355,27 @@ _QUOTE_MARKER_RE = re.compile(r"[ ]{0,3}>[ \t]?")
 # covered handbooks (Machines, Async, API, Routing); rf2-zq5i6 made that set
 # DERIVED from this manifest's page keys (see COMPAT_HANDBOOKS) rather than a
 # separate hand-maintained tuple.
+#
+# BEFORE YOU ADD AN ANCHOR HERE, read this (rf2-1cpt).  118 fragment ids across
+# 15 pages are already minted TWICE: an explicit `<a id="x">` stacked with the
+# heading whose generated slug is also `x`.  The concentrations are
+# docs/design/hicasso/draft-guide/glossary.md (50), docs/routing/concepts.md and
+# spec/015-Data-Classification.md (18 each), and spec/012-Routing.md (10).  Every
+# one is the same deliberate idiom — an explicit anchor written to outlive a
+# heading rename — and every one is co-located with its heading, so deep-links
+# land correctly today and nothing is broken on the site.
+#
+# But rf2-zq5i6 ruled that a MANIFEST anchor must resolve to exactly one rendered
+# target, so listing any of the 118 reds the gate with DUPLICATE COMPAT ANCHOR.
+# None was listed here before, which is why the corpus is green and the hazard
+# has never fired.  The ruling stands and this file does not exempt the pattern:
+# the check would stop meaning "this bookmark lands in one knowable place", and
+# a structural exemption is an allowlist wearing a predicate.  What changed is
+# that the failure now names the two colliding positions and says when they are
+# co-located, so it reads as the corpus's idiom rather than as your mistake —
+# see the DUPLICATE COMPAT ANCHOR report in `check`.  The fix is to delete the
+# redundant `<a id>` on that page: your manifest entry is what pins the slug
+# from then on, so a later heading rename fails here instead.
 HANDBOOK_COMPAT_ANCHORS = {
     "docs/machines/concepts.md": (
         "state-machines",
@@ -727,10 +754,15 @@ def _mask_html_comments(
     return out
 
 
-def _scan_rendered_ids(path: Path) -> dict[str, int]:
-    """Map every rendered fragment id on the page to its occurrence count.
+def _scan_rendered_id_lines(path: Path) -> dict[str, list[tuple[int, str]]]:
+    """Map every rendered fragment id on the page to WHERE it is minted.
 
-    Two anchor mechanisms mint a fragment target, and both are counted so a
+    The value is the list of `(1-based line number, mechanism)` pairs that mint
+    the id, in document order.  `_scan_rendered_ids` derives the occurrence count
+    from it, so there is one scan and one answer; the positions exist so a
+    duplicate can be REPORTED precisely (rf2-1cpt) rather than only counted.
+
+    Two anchor mechanisms mint a fragment target, and both are recorded so a
     duplicate/colliding id is visible (rf2-zq5i6 — the predecessor collapsed
     everything into a set, hiding collisions):
 
@@ -753,18 +785,17 @@ def _scan_rendered_ids(path: Path) -> dict[str, int]:
     heading title is part of the rendered slug.
     """
     text = path.read_text(encoding="utf-8", errors="replace")
-    counts: dict[str, int] = {}
+    places: dict[str, list[tuple[int, str]]] = {}
     seen_counts: dict[str, int] = {}
     fence_stripped = _strip_fences(text.splitlines())
     comment_masked = _mask_html_comments(fence_stripped)
-    for _, masked_line in comment_masked:
+    for line_no, masked_line in comment_masked:
         # HTML anchor elements can appear on any line (heading or not). Only a
         # RENDERED anchor counts, so recognise them on the comment- and
         # inline-code-masked line.
         anchor_line = _strip_inline_code(masked_line)
         for am in _HTML_ANCHOR_RE.finditer(anchor_line):
-            aid = am.group(1)
-            counts[aid] = counts.get(aid, 0) + 1
+            places.setdefault(am.group(1), []).append((line_no, ANCHOR_MECHANISM))
 
         # Headings are recognised on the comment-masked line (rf2-ehxs8): a
         # heading that lives entirely inside a multiline HTML comment renders no
@@ -787,14 +818,51 @@ def _scan_rendered_ids(path: Path) -> dict[str, int]:
         # counts as its own distinct rendered target.
         n = seen_counts.get(slug, 0)
         rid = slug if n == 0 else f"{slug}_{n}"
-        counts[rid] = counts.get(rid, 0) + 1
+        places.setdefault(rid, []).append((line_no, HEADING_MECHANISM))
         seen_counts[slug] = n + 1
-    return counts
+    return places
+
+
+def _scan_rendered_ids(path: Path) -> dict[str, int]:
+    """Map every rendered fragment id on the page to its occurrence count."""
+    return {aid: len(where) for aid, where in _scan_rendered_id_lines(path).items()}
 
 
 def _slug_index(path: Path) -> set[str]:
     """Return the set of rendered fragment ids on the page (see _scan_rendered_ids)."""
     return set(_scan_rendered_ids(path))
+
+
+def _rendered_source_lines(path: Path) -> list[tuple[int, str]]:
+    """The page reduced to the lines `_scan_rendered_id_lines` reads."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    return _mask_html_comments(_strip_fences(text.splitlines()))
+
+
+def _anchors_are_colocated(path: Path, where: list[tuple[int, str]]) -> bool:
+    """True if every occurrence of one id sits in the same place on the page.
+
+    "The same place" means a reader cannot tell the landings apart: between the
+    first occurrence and the last there is nothing but blank lines and further
+    anchor elements, which render as empty and occupy no visible space.  A
+    stack of alias anchors above (or below) the heading they name therefore
+    counts as ONE landing, which is what the corpus's 118 colliding ids are
+    (rf2-1cpt) — including the two spec pages that stack three aliases.
+
+    This decides only what the DIAGNOSTIC says, never whether the gate fails.
+    rf2-zq5i6 ruled that a manifest anchor must resolve to exactly one rendered
+    target and pinned it with a fixture; co-location is the explanation for the
+    failure, not an exemption from it.
+    """
+    if len(where) < 2:
+        return True
+    lo, hi = where[0][0], where[-1][0]
+    for line_no, content in _rendered_source_lines(path):
+        if not lo < line_no < hi:
+            continue
+        if _HTML_ANCHOR_RE.sub("", content).replace("</a>", "").strip():
+            return False
+    return True
 
 
 _ANCHOR_ID_RE_CACHE: dict[str, re.Pattern[str]] = {}
@@ -1194,9 +1262,13 @@ def _check_fenced_doc_links(
 
 def _check_compat_anchors(
     repo_root: Path,
-    counts_for,
+    places_for,
     manifest: dict[str, tuple[str, ...]],
-) -> tuple[list[tuple[str, str]], list[str], list[tuple[str, str, int]]]:
+) -> tuple[
+    list[tuple[str, str]],
+    list[str],
+    list[tuple[str, str, list[tuple[int, str]], bool]],
+]:
     """Validate every manifest compat anchor resolves to exactly one target (rf2-57k74/zq5i6).
 
     Returns (missing_anchors, missing_pages, duplicate_anchors):
@@ -1207,32 +1279,39 @@ def _check_compat_anchors(
           bookmarks it carries cannot silently disappear behind an ordinary
           link-rename (rf2-57k74 closed this hole — the Machines-only predecessor
           silently `continue`d past an absent page).
-        * duplicate_anchors — (page-rel, anchor, count) for each manifest anchor
-          that resolves to MORE THAN ONE rendered target on its page (rf2-zq5i6):
-          a duplicate explicit id, or an explicit id colliding with a generated
-          heading slug. A fragment id that appears twice is an invalid, ambiguous
-          bookmark (the browser resolves only the first), so it fails the gate.
+        * duplicate_anchors — (page-rel, anchor, where, colocated) for each
+          manifest anchor that resolves to MORE THAN ONE rendered target on its
+          page (rf2-zq5i6): a duplicate explicit id, or an explicit id colliding
+          with a generated heading slug. A fragment id that appears twice is an
+          invalid, ambiguous bookmark (the browser resolves only the first), so
+          it fails the gate. `where` is the occurrence list from
+          `_scan_rendered_id_lines` and `colocated` says whether those
+          occurrences share one landing spot — both carried so the report can
+          say WHICH collision this is (rf2-1cpt), neither consulted in deciding
+          that it fails.
 
-    `counts_for(page)` returns the page's {rendered-id: occurrence-count} map. The
-    manifest is an explicit parameter, NOT a module global, so the fixture-based
-    self-tests stay isolated by passing their own inputs (a fixture manifest or
-    `{}`) rather than relying on production pages being absent.
+    `places_for(page)` returns the page's {rendered-id: [(line, mechanism)]} map.
+    The manifest is an explicit parameter, NOT a module global, so the
+    fixture-based self-tests stay isolated by passing their own inputs (a fixture
+    manifest or `{}`) rather than relying on production pages being absent.
     """
     missing_anchors: list[tuple[str, str]] = []
     missing_pages: list[str] = []
-    duplicate_anchors: list[tuple[str, str, int]] = []
+    duplicate_anchors: list[tuple[str, str, list[tuple[int, str]], bool]] = []
     for page_rel, anchors in manifest.items():
         page = repo_root / page_rel
         if not page.is_file():
             missing_pages.append(page_rel)
             continue
-        page_counts = counts_for(page)
+        page_places = places_for(page)
         for anchor in anchors:
-            n = page_counts.get(anchor, 0)
-            if n == 0:
+            where = page_places.get(anchor, [])
+            if not where:
                 missing_anchors.append((page_rel, anchor))
-            elif n > 1:
-                duplicate_anchors.append((page_rel, anchor, n))
+            elif len(where) > 1:
+                duplicate_anchors.append(
+                    (page_rel, anchor, where, _anchors_are_colocated(page, where))
+                )
     return missing_anchors, missing_pages, duplicate_anchors
 
 
@@ -1377,21 +1456,22 @@ def check(
         sys.stderr.write(f"scanning {len(files)} markdown files...\n")
 
     # Build the rendered-id index lazily — many files are never linked to with an
-    # anchor. `counts_for` yields the {id: occurrence-count} map (used by the
-    # uniqueness check); `slugs_for` derives the membership set from it.
-    counts_cache: dict[Path, dict[str, int]] = {}
+    # anchor. `places_for` yields the {id: [(line, mechanism)]} map (used by the
+    # uniqueness check and its diagnostic); `slugs_for` derives the membership set
+    # from it. One cached scan feeds both, so they cannot disagree.
+    places_cache: dict[Path, dict[str, list[tuple[int, str]]]] = {}
     slug_cache: dict[Path, set[str]] = {}
 
-    def counts_for(path: Path) -> dict[str, int]:
+    def places_for(path: Path) -> dict[str, list[tuple[int, str]]]:
         ap = path.resolve()
-        if ap not in counts_cache:
-            counts_cache[ap] = _scan_rendered_ids(path)
-        return counts_cache[ap]
+        if ap not in places_cache:
+            places_cache[ap] = _scan_rendered_id_lines(path)
+        return places_cache[ap]
 
     def slugs_for(path: Path) -> set[str]:
         ap = path.resolve()
         if ap not in slug_cache:
-            slug_cache[ap] = set(counts_for(path))
+            slug_cache[ap] = set(places_for(path))
         return slug_cache[ap]
 
     broken_anchor: list[tuple[Path, int, str, str]] = []
@@ -1459,7 +1539,7 @@ def check(
     # rf2-57k74 / rf2-zq5i6 — the cross-handbook compat-anchor manifest, uniqueness,
     # placement, and source-comment link gates.
     compat_missing, compat_missing_pages, compat_duplicate = _check_compat_anchors(
-        repo_root, counts_for, compat_anchors
+        repo_root, places_for, compat_anchors
     )
     compat_misplaced = _check_compat_anchor_placement(repo_root, placement)
     source_comment_broken = _check_source_comment_links(
@@ -1569,17 +1649,36 @@ def check(
             f"\n{len(compat_duplicate)} colliding handbook compat anchor(s) "
             "found (rf2-zq5i6):\n\n"
         )
-        for page_rel, anchor, count in compat_duplicate:
+        for page_rel, anchor, where, colocated in compat_duplicate:
             sys.stderr.write(
                 f"  DUPLICATE COMPAT ANCHOR: {page_rel}#{anchor} "
-                f"(resolves to {count} rendered targets)\n"
+                f"(resolves to {len(where)} rendered targets)\n"
             )
+            for line_no, mechanism in where:
+                sys.stderr.write(f"      {mechanism} at line {line_no}\n")
+            if colocated:
+                sys.stderr.write(
+                    "      (co-located, so both land in the same place — the "
+                    "redundant-explicit-anchor pattern, not a stale bookmark)\n"
+                )
         sys.stderr.write(
             "\nFix: a compatibility fragment must resolve to exactly one rendered "
             "target. Remove the duplicate `<a id>` element, or rename it so it no "
             "longer collides with the other explicit anchor or the generated "
             "heading slug of the same name.\n"
         )
+        if any(colocated for _, _, _, colocated in compat_duplicate):
+            sys.stderr.write(
+                "\nFor a CO-LOCATED collision this is very likely not your "
+                "mistake: 118 fragment ids across 15 pages are written this way "
+                "— an explicit `<a id>` stacked with the heading whose generated "
+                "slug it already duplicates — and none of them was in the "
+                "manifest before, so listing one is what surfaces it (rf2-1cpt). "
+                "Delete the redundant `<a id>` on that page: the manifest entry "
+                "you just added is what pins the slug from here on, so the "
+                "explicit anchor is no longer the thing protecting the bookmark "
+                "and a later heading rename fails HERE instead.\n"
+            )
 
     if compat_misplaced:
         sys.stderr.write(
@@ -1864,6 +1963,14 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("explicit id vs generated heading slug collide",
          dict(compat_anchors={"docs/machines/collision.md": ("dup-me",)},
               source_files=(), placement={}), 1),
+        # rf2-1cpt — a co-located collision is the corpus's own idiom (118 ids
+        # across 15 pages) and still fails. This is the tooth that pins the
+        # rf2-zq5i6 ruling against the option of teaching the gate to accept the
+        # pattern: co-location is why the failure is explainable, not a reason to
+        # stop failing.
+        ("co-located collision still fails",
+         dict(compat_anchors={"docs/machines/stacked.md": ("dup-me",)},
+              source_files=(), placement={}), 1),
         # rf2-zq5i6 placement teeth.
         ("placement ok — anchor precedes passage",
          dict(compat_anchors={}, source_files=(),
@@ -1927,6 +2034,48 @@ def _run_self_tests(verbose: bool = False) -> int:
                     f"expected broken={expected}, got {got}\n"
                 )
                 failures += 1
+
+    # rf2-1cpt — the DIAGNOSTIC for a colliding compat anchor. The gate's verdict
+    # is rf2-zq5i6's and unchanged; what is pinned here is that the report can say
+    # WHERE the collision is and WHICH of the two shapes it is, because that is
+    # the whole of this bead's answer to the armed-trap problem. The predicate
+    # fails in both directions: a stack of alias anchors above a heading is ONE
+    # landing spot (anchor elements render empty), while two anchors with a
+    # paragraph between them are two.
+    diagnostic_cases: list[tuple[str, str, str, list[tuple[int, str]], bool]] = [
+        ("explicit anchor above its own heading",
+         "docs/machines/collision.md", "dup-me",
+         [(3, ANCHOR_MECHANISM), (5, HEADING_MECHANISM)], True),
+        ("alias stack above its own heading",
+         "docs/machines/stacked.md", "dup-me",
+         [(4, ANCHOR_MECHANISM), (7, HEADING_MECHANISM)], True),
+        ("two anchors with prose between them are NOT co-located",
+         "docs/machines/duplicate.md", "dup-me",
+         [(3, ANCHOR_MECHANISM), (7, ANCHOR_MECHANISM)], False),
+    ]
+    for label, page_rel, anchor, expected_where, expected_colocated in diagnostic_cases:
+        _missing, _pages, dupes = _check_compat_anchors(
+            teeth_root, _scan_rendered_id_lines, {page_rel: (anchor,)}
+        )
+        if len(dupes) != 1:
+            sys.stderr.write(
+                f"self-test FAIL: duplicate diagnostic [{label}] expected exactly "
+                f"one duplicate, got {dupes}\n"
+            )
+            failures += 1
+            continue
+        _page, _anchor, where, colocated = dupes[0]
+        if where != expected_where or colocated != expected_colocated:
+            sys.stderr.write(
+                f"self-test FAIL: duplicate diagnostic [{label}] expected "
+                f"where={expected_where} colocated={expected_colocated}, got "
+                f"where={where} colocated={colocated}\n"
+            )
+            failures += 1
+        elif verbose:
+            sys.stderr.write(
+                f"self-test PASS: duplicate diagnostic [{label}]\n"
+            )
 
     # rf2-zq5i6 — the source-comment handbook vocabulary is DERIVED from the
     # manifest, with no independent COMPAT_HANDBOOKS authority. Assert the derived


### PR DESCRIPTION
Both clauses of rf2-1cpt, each measured and excluded from PR #7785 by the rf2-mmyc worker as too large a blast radius for a fence-correctness fix. That was the right call; this is where they land.

## Clause 1 — blockquoted fences

`> ```clojure` is a real fence to python-markdown: the lines under it render as a code block, a `> ### Title` inside it mints no heading id, and a link written there resolves nowhere. `check_doc_slugs.py` read all of it as prose, so the in-fence assertion rf2-mmyc landed could not see the two files in the tree it guards that write their samples exactly that way (`docs/design/hicasso/studio/p0-converged-witness-set.md`, `.../rows-re-adjudicated-on-the-corrected-clock.md`).

Quote depth now joins the marker and the indentation as part of a fence's identity. The quote's markers **are** the container: each `>` absorbs one following space, so the in-quote indent is directly comparable to a column-0 one, a quoted fence closes only at its own depth, and an unclosed one ends with its blockquote rather than blanking the document below it.

**The model is renderer-derived, not spec-derived.** rf2-mmyc's first draft regressed four real lines by reading CommonMark; this one was read off `pymdownx.superfences`' `search_nested`/`eval_quoted` and confirmed case by case against python-markdown 3.10 + pymdownx 10.21.3. Two rules that CommonMark would not have given: a content line's quote depth is counted only within the *opener's* prefix width (so `> > x` inside a `> ```…` fence is code, not a nested quote), and `>` plus five spaces is an indented code block because superfences opens the fence greedily and then restores the literal source when an indented block swallows it.

Seventeen new `fence_cases`. Fourteen red against the merge-base scanner; **three are positive controls that must not red**, and each guards a specific wrong turn:

* *a quoted closer does not close a column-0 fence* — rejects "strip the `>` and reuse the old matcher", which would end a column-0 block early at any quoted fence line and flip its body back to prose;
* *four spaces after the quote marker is an indented code block* — rejects an unbounded quote matcher;
* *blockquoted heading outside a fence is still prose* — keeps rf2-869k9m's blockquoted-heading anchors alive.

### Corpus delta, both directions, same merge base

| | |
|---|---|
| files touched | 12 |
| prose lines **lost** (prose → recognised as code) | 151 |
| prose lines **gained** (blanked → prose) | 0 |
| links **lost** (stop being checked) | **0** |
| links **gained** | 0 |
| rendered ids **gained** | 0 |
| rendered ids **lost** | 3 |

Nothing stops being checked: zero links move in either direction, so no link that was validated before is unvalidated now.

All three lost ids are in `rows-re-adjudicated-on-the-corrected-clock.md`, and all three were phantoms — `#` comments inside a quoted ` ```bash ` sample that the scanner had been indexing as markdown headings:

* `exit-0--row-m1-pair-hicasso--uix-subs`
* `point-11718x--95-ci-11263--12190--over-8-reportable-runs`
* `verdict-k1-missed-decisively--the-whole-interval-is-above-the-11x-mount-gate`

The built site never carried them and nothing links to them; the corpus run is green before and after.

### The 138/36 figures do not reproduce

The bead records a prototype that flipped **138 lines back to prose and minted 36 rendered ids**, and asks for an explicit judgement if that reproduces. It does not — not in magnitude, and not in direction.

The decisive point needs no corpus archaeology: **a blanking-only change cannot mint an id.** Removing a heading can only drop a slug or renumber a `_N` suffix downward. Both figures describe a change that turned code back into *prose*, which is the signature of the quote-stripping model the first control above now forbids. My change moves 151 lines the other way, which is the direction the renderer says is correct, and mints nothing.

I did try to reconstruct the prototype rather than just assert this: a de-quoting variant measured 717 prose lines lost / 0 gained / 0 ids gained, and blockquoted headings corpus-wide number 18, not 36. Neither reproduces the pair, so I stopped there rather than keep guessing at uncommitted code. **Judgement: the blast radius was an artefact of the model, not a cost of the feature, and there is nothing here to accept or refuse** — the gate got strictly quieter about lines that are code and no quieter about anything else.

## Clause 2 — the colliding-anchor trap

118 fragment ids across 15 pages are minted twice: an explicit `<a id="x">` stacked with the heading whose generated slug is also `x`. Counted independently here and matching the bead exactly. The corpus is uniform:

| shape | count |
|---|---|
| explicit anchor immediately **above** its heading | 72 |
| explicit anchor immediately **below** its heading | 44 |
| separated only by further alias anchors | 2 |
| anything else | **0** |

Concentrations: `docs/design/hicasso/draft-guide/glossary.md` (50), `docs/routing/concepts.md` and `spec/015-Data-Classification.md` (18 each), `spec/012-Routing.md` (10). Every one is co-located with its heading, so deep-links land correctly today and nothing on the site is broken.

### This takes option (c), and the measurement is why (b) is not available

Option (b) — teach the duplicate gate to treat the pattern as intentional — would mean overturning a decision rf2-zq5i6 made deliberately and pinned with a fixture. `compat_anchor_teeth/docs/machines/collision.md` **is** this exact shape (an explicit anchor above the heading it duplicates) and is asserted to fail, with prose saying so. Taking (b) means deleting that tooth. A structural "intentional pattern" exemption is also an allowlist wearing a predicate, and it would cost the check its meaning: *this bookmark lands in one knowable place*. Option (a) touches 15 files to delete the very anchors that exist to outlive a heading rename, and can move where a stale external link lands.

So the verdict is untouched and the **explanation** is what changes. `DUPLICATE COMPAT ANCHOR` now names both colliding positions and which mechanism minted each, and says when they are co-located; a co-located collision adds the corpus count and the fix. What someone who lists one of the 118 now sees:

```
  DUPLICATE COMPAT ANCHOR: docs/routing/concepts.md#url-strategies (resolves to 2 rendered targets)
      heading at line 709
      explicit <a id> at line 711
      (co-located, so both land in the same place — the redundant-explicit-anchor
       pattern, not a stale bookmark)
```

…followed by the note that this is very likely not their mistake, that 118 ids are written this way, and that the fix is to delete the redundant `<a id>` — because *the manifest entry they just added* is what pins the slug from then on, so a later heading rename fails at the gate instead. `HANDBOOK_COMPAT_ANCHORS` carries the same record for whoever edits it. Same inputs fail, same exit code.

`_scan_rendered_id_lines` is now the primitive and `_scan_rendered_ids` derives counts from it, so positions and counts come from one scan and cannot disagree. The co-location predicate tolerates blank lines **and further anchor elements** between occurrences — anchor elements render empty, and two spec pages stack three aliases, which a blanks-only rule reads as separated. Its tooth pins both directions.

## Verification

Every counting script used here has a `--prove` mode that runs the same machinery over synthetic known-bad input and requires non-zero, per rf2-mmyc's practice. One of them earned its keep: the corpus-delta harness initially reported `ids_lost=0` for a reconstructed variant because `_scan_rendered_ids` still resolved the unmodified scanner internally — a zero that meant "never looked", not "nothing there".

The new self-test cases were written and confirmed red **before** any implementation change. Verbatim, against the merge-base scanner:

```
self-test FAIL: fence [blockquoted fence blanks its body] expected visible lines [1, 2, 6, 7], got [1, 2, 3, 4, 5, 6, 7]
self-test FAIL: fence [heading inside a blockquoted fence is not a heading] expected visible lines [5], got [1, 2, 3, 5]
self-test FAIL: fence [nested-blockquote fence is a fence] expected visible lines [5], got [1, 2, 3, 5]
self-test FAIL: fence [blockquote marker with no following space] expected visible lines [5], got [1, 2, 3, 5]
self-test FAIL: fence [three-space slack after the quote marker is still a fence] expected visible lines [5], got [1, 2, 3, 5]
self-test FAIL: fence [blockquoted fence inside an admonition] expected visible lines [1, 7], got [1, 3, 4, 5, 7]
self-test FAIL: fence [unquoted blank line does not break a blockquoted fence] expected visible lines [6], got [1, 2, 4, 6]
self-test FAIL: fence [quoted blank line does not break a blockquoted fence] expected visible lines [7], got [1, 2, 3, 4, 5, 7]
self-test FAIL: fence [longer closing run does not close a blockquoted fence] expected visible lines [5], got [1, 2, 3, 5]
self-test FAIL: fence [closer with an info string does not close a blockquoted fence] expected visible lines [5], got [1, 2, 3, 5]
self-test FAIL: fence [deeper-quoted line inside a blockquoted fence is content] expected visible lines [5], got [1, 2, 3, 5]
self-test FAIL: fence [deeper-quoted closer does not close a blockquoted fence] expected visible lines [6], got [1, 2, 3, 4, 6]
self-test FAIL: fence [shallower line ends a nested blockquoted fence] expected visible lines [3, 5], got [1, 2, 3, 5]
self-test FAIL: fence [unclosed blockquoted fence ends with its blockquote] expected visible lines [4], got [1, 2, 4]
self-test FAIL: fenced_doc_link_blockquoted expected broken=1, got 0
self-test FAIL: blockquoted_fence_not_indexed expected broken=2, got 0

14 self-test failure(s).
```

The two new fixtures red at `got 0` — the exact signature of the blind spot, since the link inside the quoted fence resolves and the phantom ids inside it satisfy links pointing at them. Both fixtures were rendered through python-markdown to confirm the built page carries the ids the fixture claims and none of the ones it claims are absent.

## Quality gates

Each run alone, in the foreground, exit code echoed to its own file, never piped through a filter. All four re-run after rebasing onto `origin/main` (`08d81f0d21`).

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py --self-test` | **0** |
| `python scripts/check_doc_slugs.py --verbose` (full corpus, 715 files, "no broken links") | **0** |
| `python scripts/check_readme_links.py` | **0** |
| `sh scripts/test-fast-pr.sh` — `PASS fast PR spine` | **0** |

Every gate printed `gate root: …/re-frame2-worktrees/anchors-1cpt`, checked each time.

No `implementation/**` or `tools/xray/**` file is touched; the surface is `scripts/check_doc_slugs.py` and its fixtures. No corpus prose was edited, so no inbound link changes where it lands.
