### PR TITLE
docs(hicasso): the ruled IME acceptance and its manual-witness checklist (rf2-hic-016)

### DIFF
--- a/docs/design/hicasso/native-ime-manual-witness.md
+++ b/docs/design/hicasso/native-ime-manual-witness.md
@@ -1,0 +1,202 @@
+# Native IME on Firefox and WebKit — the one bounded manual witness
+
+A checklist for a single operator session. It is run **once**, by hand, and its results are written into
+[`product/dispositions.md` §2.3](product/dispositions.md#23-per-control-and-dom-conformance-dispositions). It is not a
+gate, it does not run in CI, and nothing here is scheduled to repeat.
+
+## 1. Why this is a manual session and not a test
+
+`rf2-hic-016` proved invariant I15 — the §4.2 accept / refuse / normalise / reset policy family — in three real engines.
+What its gate drives on Firefox and WebKit is the *event sequence* a composition produces (`compositionstart`,
+`beforeinput` and `input` carrying `isComposing`, `compositionend`), dispatched at the real node through real React.
+That reaches every mechanism the composition carve-out is made of, but it does not reach the browser's composition
+**range**, because `Input.imeSetComposition` is a CDP method and CDP is Chromium's protocol.
+
+The operator ruled on that gap on 2026-08-10, and the ruling is what this document exists to serve:
+
+> **OPERATOR RULING (2026-08-10 19:47 AUSEST, Mike, in session) — OPTION 3: AMEND + ONE BOUNDED MANUAL WITNESS.**
+>
+> (1) AMENDED ACCEPTANCE: the synthetic composition sequence IS the recurring three-engine CI witness (ratified; the
+> landed 55-check/13-teeth gate stands as-is). Real native-IME conduct on Firefox and WebKit is verified ONCE by a
+> manual operator session, recorded, not automated, not recurring.
+>
+> (2) THE MANUAL WITNESS: the operator types through a real Windows IME (e.g. Japanese Microsoft IME) in Playwright's
+> Firefox and WebKit builds against a written checklist … Results are recorded in the hic-005 support table with date +
+> engine builds. Anything strange becomes a bead.
+>
+> FENCES: no changes to the landed gate's semantics; no automation attempts at real IME (ruled over-engineering).
+
+So the recurring witness is the synthetic sequence, and it is enough. This session answers one narrower question the
+synthetic sequence cannot: does a **real** IME, holding a **real** composition range, behave the same way?
+
+**Do not try to automate this.** Driving a real IME from a script was considered and ruled over-engineering. If the
+session is awkward, that is the expected cost of running it once.
+
+## 2. What you need
+
+- Windows, with a Japanese IME installed and reachable from the language bar — Microsoft IME is the reference. Any IME
+  that composes from kana into candidate kanji will do; the point is a multi-keystroke composition with a candidate
+  window, not the specific language.
+- A checkout with `implementation/` dependencies installed (`npm ci`), and the pinned browsers installed — §3.
+
+## 3. Build the page, serve it, and open it
+
+Every command below runs **from `implementation/`**, and that is load-bearing rather than a convention. Read §3.1
+before running the install.
+
+```bash
+cd implementation
+npm ci
+npx playwright install --with-deps chromium firefox webkit
+```
+
+Then build the testbed and serve it:
+
+```bash
+npx shadow-cljs compile :hicasso/testbed
+cp hicasso/testbed/index.html out/hicasso-testbed/index.html
+npx http-server out/hicasso-testbed -p 8065 -c-1
+```
+
+The page to open is **`http://127.0.0.1:8065/`**. Leave the server running in its own terminal.
+
+These are the same three steps the gate's own launcher
+(`implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs`) performs before it drives anything — compile
+the `:hicasso/testbed` build, stage the HTML beside the bundle, serve the directory — done by hand so the page stays up
+for as long as the session needs it. The launcher is not modified and is not used here; running the gate would drive
+its own automated spec and tear the server down.
+
+### 3.1 The pin, and the one command that will cost you an afternoon
+
+**Never run a bare `npx playwright install` from the repository root.** From the root, `npx` resolves a *newer*
+Playwright than the repo pins, fetches that release's browser revisions, and **prunes the pinned WebKit out of the
+shared cache** — so the engine this session exists to exercise is the one it removes. `--no-install` does not save you;
+only the working directory does.
+
+Two facts are the entire pin: the working directory is `implementation/`, and `npm ci` has already run. Together they
+make `npx` resolve `implementation/node_modules/.bin/playwright`, which is the version `implementation/package.json`
+pins. Measured on this repo:
+
+| run from | `npx playwright --version` |
+|---|---|
+| `implementation/` | **1.59.1** — the pinned CLI |
+| repository root | 1.62.1 — resolved from npx's own cache |
+
+This is the same pin the CI lane carries; see the `Install pinned Chromium + Firefox + WebKit` step of the
+`cljs-hicasso-controlled` job in `.github/workflows/test.yml`, and `rf2-ga8m`.
+
+### 3.2 The two launch commands
+
+From `implementation/`, with the server from §3 still running:
+
+```bash
+npx playwright open -b firefox http://127.0.0.1:8065/
+```
+
+```bash
+npx playwright open -b webkit http://127.0.0.1:8065/
+```
+
+Run one at a time and work the whole checklist through before moving to the other engine. Each opens a real, headed
+browser window that the Windows IME can type into like any other.
+
+Under the pinned Playwright 1.59.1 these launch:
+
+| Engine | Playwright build | Version |
+|---|---|---|
+| Chromium | `chromium-1217` | 147.0.7727.15 |
+| Firefox | `firefox-1511` | 148.0.2 |
+| WebKit | `webkit-2272` | 26.4 |
+
+Confirm the versions at the top of the session rather than trusting this table — a browser install between now and then
+moves them, and the recorded result is only worth what its engine build is.
+
+## 4. Reading the store without a console
+
+Every check below is observable **from the screen**, and that is deliberate: Playwright's WebKit build on Windows is a
+minimal browser shell with no devtools, so a checklist that depended on a JavaScript console would be unrunnable in
+exactly the engine it most needs to cover.
+
+The testbed makes the store visible through its fields instead. Three of them are the instrument:
+
+| Field | Model policy | What it shows you |
+|---|---|---|
+| `plain` | takes what is typed | the model **accepted** — the field keeps what you committed |
+| `digits` | refuses anything that is not a digit | the model **refused** — the field snaps back to its committed value |
+| `empty` | refuses everything; the model stays `""` | the same, at the hardest setting |
+
+So "the store did not move" is not something you have to take on trust: type kana into `digits`, and if the field is
+still showing `123` afterwards, the model refused it. If a draft is on screen while `digits` still reads its committed
+value underneath the composition, that is the carve-out working — the draft is the IME's, and the model never saw it.
+
+Where a build does offer devtools (Firefox's usually does; WebKit's does not), `window.__RF2_HIC_TB__.model()` returns
+the store as JSON and is a direct cross-check. Treat it as a convenience, never as the check itself.
+
+## 5. The checks
+
+The seed values are `plain` = `abc`, `digits` = `123`, `upper` = `ABC`, `revision` = `keep`, `mountable` = `9`.
+Reload the page between checks if you lose track of state.
+
+**1 — Draft text visible during composition.** Click into `digits` and begin composing kana (e.g. type `nihongo`).
+*Pass:* the composing draft is visible in the field, underlined, while the candidate window is open — even though the
+model refuses every character of it.
+
+**2 — Caret correct.** Click into `upper`, place the caret between `A` and `B`, and compose there.
+*Pass:* the draft appears at the caret, not at the end of the string, and the caret stays inside the draft as it grows.
+The end-of-string jump is the failure this check exists to catch.
+
+**3 — app-db clean until commit.** With a composition open in `digits`, look at the field before committing.
+*Pass:* nothing has been written to the model — no flicker of `123` replacing the draft, no snap-back mid-composition.
+The field holds the draft until the exchange closes.
+
+**4 — Commit echo.** Commit the composition (Enter or a candidate selection) in `digits`, then repeat in `plain`.
+*Pass:* `digits` snaps back to `123` — the committed value, echoed in the same turn. `plain` keeps the committed kanji.
+Two fields, two policies, one law.
+
+**5 — Escape / abort mid-composition.** Begin composing in `plain`, then press Escape before committing.
+*Pass:* the draft is discarded, the field returns to `abc`, and no fragment of the abandoned composition is left in the
+field or written to the model.
+
+**6 — `compositionend` ordering.** Compose in `plain` and watch the moment of commit.
+*Pass:* the committed text arrives exactly once, at the close of the exchange — not progressively during composition,
+and not a second time after. A double-application (the committed text appearing twice, or the draft and the commit both
+landing) is the failure.
+
+**7 — Revision reset during and after composition.** Click into `revision`, begin composing, and press the **bump**
+button while the composition is still open. Then repeat, pressing **bump** *after* committing.
+*Pass:* mid-composition the reset **defers to the exchange's close** — the composition is not destroyed under the
+user. After commit, the reset re-baselines the field to the model on the same DOM node.
+
+**8 — Blur mid-composition.** Begin composing in `mountable`, then click away (or Tab) without committing. Then repeat,
+pressing **toggle** to unmount the field mid-composition.
+*Pass:* no stranded draft — the field (or its replacement) shows committed state, the model is unmoved, and nothing
+throws.
+
+## 6. The result table
+
+Tick both engines for each check. A cross is as valuable as a tick — it is the finding.
+
+| # | Check | Firefox | WebKit | Note |
+|---|---|---|---|---|
+| 1 | Draft text visible during composition | [ ] | [ ] | |
+| 2 | Caret correct | [ ] | [ ] | |
+| 3 | app-db clean until commit | [ ] | [ ] | |
+| 4 | Commit echo | [ ] | [ ] | |
+| 5 | Escape / abort mid-composition | [ ] | [ ] | |
+| 6 | `compositionend` ordering | [ ] | [ ] | |
+| 7 | Revision reset during / after composition | [ ] | [ ] | |
+| 8 | Blur / unmount mid-composition | [ ] | [ ] | |
+
+Session date: ______________  Firefox build: ______________  WebKit build: ______________
+
+## 7. What to do with the results
+
+1. Write the outcome into
+   [`product/dispositions.md` §2.3](product/dispositions.md#23-per-control-and-dom-conformance-dispositions), in the
+   native-IME block appended there, with the date and both engine builds.
+2. **Anything strange becomes a bead** — per the ruling. A cross in the table is not a reason to re-run the session
+   until it passes; it is a defect report with an engine name on it.
+3. `rf2-hic-016` closes when these results are recorded. Until then it stays open, whatever else has landed against it.
+
+If an engine turns out not to accept Windows IME input at all — the Playwright WebKit shell is a plausible candidate —
+that is itself the finding. Record it as such and file the bead. It is not a reason to start automating.

--- a/docs/design/hicasso/product/dispositions.md
+++ b/docs/design/hicasso/product/dispositions.md
@@ -236,7 +236,7 @@ failure.
 | Date input | Owed | Owed |
 | Range input | Owed | Owed |
 | Contenteditable | Owed | Owed |
-| Composition and IME | Owed | Owed |
+| Composition and IME | Supported. The recurring cross-engine witness is the composition event **sequence**; real native-IME conduct is dispositioned per engine in the block below | `implementation/hicasso/testbed/spec.cjs` on all three engines (`rf2-hic-016`); native ranges on Chromium by `implementation/freehand/test/re_frame/bench/hicasso/ime_run.cjs` |
 | Caret and selection preservation | Owed | Owed |
 | Blur after unmount | Owed | Owed |
 | Async normalization | Owed | Owed |
@@ -246,9 +246,30 @@ failure.
 | SVG attributes | Owed | Owed |
 | Custom elements | Owed | Owed |
 
-Every cell reads Owed because Phase 0 precedes the conformance run. The rows exist now so the run has a fixed roster to
-fill and cannot quietly shrink; `rf2-hic-040` replaces the cells in place and adds a row only for a control case this
-roster missed.
+Every remaining cell reads Owed because Phase 0 precedes the conformance run. The rows exist now so the run has a fixed
+roster to fill and cannot quietly shrink; `rf2-hic-040` replaces the cells in place and adds a row only for a control
+case this roster missed.
+
+**Native IME, per engine (`rf2-hic-016`).** The Composition-and-IME row above is filled in two parts because the
+evidence has two tiers, and collapsing them would claim more than is held. The recurring witness is the composition
+event **sequence** — `compositionstart`, `beforeinput` and `input` carrying `isComposing`, `compositionend`, dispatched
+at the real node through real React — and it is green on all three engines in the required `cljs-hicasso-controlled`
+gate. It reaches the carve-out, the draft shadow and React's end-of-event restore; it does not reach the browser's
+composition **range**, because `Input.imeSetComposition` is a CDP method and CDP is Chromium's protocol.
+
+Per the operator ruling of 2026-08-10, that synthetic sequence **is** the ratified recurring witness, and real
+native-IME conduct beyond Chromium is settled once by a bounded manual session rather than by automation — the
+checklist is [`../native-ime-manual-witness.md`](../native-ime-manual-witness.md). Engine builds are those the pinned
+Playwright 1.59.1 installs.
+
+| Engine | Playwright build | Synthetic sequence | Native IME | Session date |
+|---|---|---|---|---|
+| Chromium | `chromium-1217` (147.0.7727.15) | Green | **Witness-verified** — real composition ranges driven over CDP by `bench/hicasso/ime_run.cjs` | n/a — automated |
+| Firefox | `firefox-1511` (148.0.2) | Green | **Pending the manual session** | — |
+| WebKit | `webkit-2272` (26.4) | Green | **Pending the manual session** | — |
+
+`rf2-hic-016` closes when the two pending cells are filled from that session, not before. Anything the session finds
+strange becomes a bead.
 
 ### 2.4 The default rule and how a row is upgraded
 
@@ -278,7 +299,7 @@ those amendments from colliding.
 | [1.2](#12-rows-without-a-complete-planned-witness) | The coverage-matrix owner | Remove a bullet when its gap is genuinely owned; add one when a new gap is found |
 | [2.1](#21-surface-inventory-and-dispositions) | Per-surface SSR/hydration witnesses (`rf2-hic-046`) | Rewrite the operative-disposition cell of an existing row; append a row for a surface created after Phase 0 |
 | [2.2](#22-public-surfaces-with-no-server-render-behavior) | Per-surface SSR/hydration witnesses (`rf2-hic-046`) | Append a row for a new non-rendering public surface |
-| [2.3](#23-per-control-and-dom-conformance-dispositions) | Control/DOM conformance (`rf2-hic-040`) | Fill the policy and witness cells; append a row for a missed control case |
+| [2.3](#23-per-control-and-dom-conformance-dispositions) | Control/DOM conformance (`rf2-hic-040`); the native-IME block within it is `rf2-hic-016`'s under the 2026-08-10 ruling | Fill the policy and witness cells; append a row for a missed control case. `rf2-hic-040` fills the roster around the native-IME block rather than through it — the two tiers of composition evidence are kept apart deliberately |
 | [2.4](#24-the-default-rule-and-how-a-row-is-upgraded) | Product operator | Change the rule itself |
 
 Two constraints apply to every amendment. **Amend in place; do not restructure.** Two beads in the same wave write into


### PR DESCRIPTION
Worker prep for `rf2-hic-016` under the operator's Option-3 ruling. **This PR does not close the bead** — per the ruling's item (4), `rf2-hic-016` closes when the operator's manual session results are recorded, and this is the prep that makes that session runnable.

## The ruling this implements

> **OPERATOR RULING (2026-08-10 19:47 AUSEST, Mike, in session) — OPTION 3: AMEND + ONE BOUNDED MANUAL WITNESS.**
>
> (1) AMENDED ACCEPTANCE: the synthetic composition sequence IS the recurring three-engine CI witness (ratified; the landed 55-check/13-teeth gate stands as-is). Real native-IME conduct on Firefox and WebKit is verified ONCE by a manual operator session, recorded, not automated, not recurring.
>
> (2) THE MANUAL WITNESS: the operator types through a real Windows IME (e.g. Japanese Microsoft IME) in Playwright's Firefox and WebKit builds against a written checklist (~8 checks: draft text visible during composition; caret correct; app-db clean until commit; commit echo; Escape/abort mid-composition; compositionend ordering; revision reset during/after composition; blur mid-composition). Results are recorded in the hic-005 support table with date + engine builds. Anything strange becomes a bead.
>
> (3) WORKER PREP (dispatchable now, one PR): amend this bead's acceptance text in the tracker-adjacent docs if restated anywhere; fix TESTING.md controlled-input row 11→13 negative controls; add the manual-witness checklist as a runnable session doc (page to open, the two launch commands with the PINNED Playwright CLI — never bare npx playwright install, per the rf2-ga8m note — and the checklist table with tick boxes); record in the hic-005 table that Chromium native IME is witness-verified, Firefox/WebKit native IME pending the manual session, synthetic gate green on all three.
>
> (4) CLOSE RULE: this bead closes when the operator's session results are recorded. The prep PR does not close it.
>
> FENCES: no changes to the landed gate's semantics; no automation attempts at real IME (ruled over-engineering).

Both fences held. No file under `implementation/` is touched, so the landed gate — its runner, its nine pinned sections, its 55 checks and its 13 mutation teeth — is bit-identical. Nothing here attempts to drive a real IME from a script.

## What landed

**`docs/design/hicasso/native-ime-manual-witness.md`** (new) — the runnable session doc. It carries the page to open, the launch commands, the eight checks and a tick-box result table.

It is runnable rather than aspirational: **every command in it was executed while writing it.** The compile, the HTML stage and the `http-server` serve are the same three steps the gate's own launcher performs, done by hand so the page stays up for as long as the session needs; the testbed was confirmed to mount and expose its harness door under both Playwright Firefox and Playwright WebKit, and both `playwright open` launches were run.

The pin gets its own section because it is the detail that costs an afternoon, and it reproduced exactly on this machine:

| run from | `npx playwright --version` |
|---|---|
| `implementation/` | **1.59.1** — the pinned CLI |
| repository root | 1.62.1 — resolved from npx's own cache |

The shared browser cache shows the same story directly: `webkit-2272` (the 1.59.1 pin) sits beside `chromium-1223` and `firefox-1538` left by the newer release — and there is no newer WebKit, which is precisely the engine a bare root-level `npx playwright install` would fetch and prune. The doc therefore states the two facts that *are* the pin: working directory `implementation/`, after `npm ci`.

**The checklist is deliberately screen-only.** Playwright's WebKit build on Windows is a minimal shell with no devtools, so a checklist that read the store through a JavaScript console would be unrunnable in the very engine it most needs to cover. The testbed's refusing fields do the job instead: `digits` refuses any non-digit and `empty` refuses everything, so a field that snaps back to its committed value after a kana commit *is* the model refusal, visible without a console. `window.__RF2_HIC_TB__.model()` is offered as a cross-check where a build has devtools, never as the check itself.

**`docs/design/hicasso/product/dispositions.md` §2.3** — the hic-005 record, appended per §3's protocol (amend in place, do not restructure). The Composition-and-IME row is filled, and a native-IME block appended beneath the roster keeps the two tiers of evidence apart rather than collapsing them:

| Engine | Playwright build | Synthetic sequence | Native IME |
|---|---|---|---|
| Chromium | `chromium-1217` (147.0.7727.15) | Green | Witness-verified over CDP |
| Firefox | `firefox-1511` (148.0.2) | Green | Pending the manual session |
| WebKit | `webkit-2272` (26.4) | Green | Pending the manual session |

Engine builds were measured under the pinned Playwright, not copied from anywhere. The session-date column is left ready. §3's protocol row now also names the block's owner, so `rf2-hic-040` fills the roster *around* it rather than through it — without that, the next worker to "replace the cells in place" would erase this record.

## The one restatement I did not amend, and why

Clause A asked me to amend the superseded acceptance wherever it is restated. It is restated in exactly one tracked place, and it is a file a worker may not edit.

`docs/design/hicasso/product/lanes/adversarial-risks.md` line 13, the Controlled-input-portability row, still names its deciding witness as *"WebKit/Firefox native composition and `beforeinput`, range/direction, autofill, reset, blur, unmount and upgrade matrix"*. That is the superseded acceptance verbatim — and the bead's own worker notes point at this row ("codex/adversarial-risks.md controlled-input row"), so it is the intended target.

But `lanes/**`, `decision-brief.md` and `specification.md` are a **published snapshot** of an operator-local source set, and `docs/design/hicasso/product/README.md` is explicit:

> **The originals remain the working set.** … Do not edit them here: the next publication overwrites the edit, and the operator who owns the original never sees it. A correction to one of them is made to the source, and arrives by republication.

So editing it here would be silently discarded at the next republication. **It is left untouched, and the correction is owed to the operator-local `codex/adversarial-risks.md` by republication.** The ruled position does reach the tracked tree by the correct route — `dispositions.md` §2.3 is tracked-native and is the authoritative per-control disposition, and that is where it now lives.

Two further notes on the same search:

- **`TESTING.md` was already correct.** The ruling's "row 11→13" item landed in #7777; the row now reads "55 checks per engine, 13 mutation teeth". Not touched. No other stale restatement of that count exists in the tracked tree.
- **`lanes/testing-xray.md` line 29** ("real IME composition" among the required browser witnesses) was considered and deliberately left. It carries no engine attribution, so it is not a restatement of the superseded *beyond-Chromium* acceptance — and it is in the same uneditable snapshot regardless.

## Quality gates

Each run alone, in the foreground, from this worktree, with its exit code captured to its own file. Every gate reported `gate root: /c/Users/miket/code/re-frame2-worktrees/imeprep-hic016`.

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** (silent) |
| `git diff --check origin/main...HEAD` | **0** (silent) |
| `sh scripts/test-fast-pr.sh` | **0** — classified `docs=true jvm=false node=false` |

**`mkdocs build --strict` is deliberately not nominated.** `mkdocs.yml`'s `exclude_docs` lists `design/hicasso/`, so a run would exit green having verified nothing about either changed file. `check_doc_slugs.py` is the gate that genuinely covers this tree; it validates the link targets and heading anchors, including the two new cross-links (`product/dispositions.md#23-per-control-and-dom-conformance-dispositions` and `../native-ime-manual-witness.md`).

**Table column counts were verified by hand, because no gate validates them.** All 10 tables across both changed files were checked cell-by-cell against their headers: 4 tables in the new session doc (2, 3, 3 and 5 columns) and 6 in `dispositions.md` (6, 6, 4, 3, 5 and 3 columns), including the two I edited and the one I appended. Zero column-count mismatches. The scratch checker was removed before commit.

## Follow-up owed

- Republish `codex/adversarial-risks.md` with its controlled-input deciding witness amended to the ruled position — the synthetic sequence as the recurring three-engine witness, native FF/WebKit IME as a one-off manual witness. Worker-uneditable; needs the operator's source.
- The manual session itself, then the two pending cells in `dispositions.md` §2.3. **That is what closes `rf2-hic-016`.**
