### PR TITLE
fix(hicasso): take the accessible-name rule from the substrates, not from scratch (rf2-hic-022)

### DIFF
--- a/implementation/hicasso/lint-fixtures/negative.cljs
+++ b/implementation/hicasso/lint-fixtures/negative.cljs
@@ -134,7 +134,12 @@
    [:button {:on-click [:d]} icon-node]
    ;; Dynamic props: the name may be in there.
    [:button props]
-   [:a {:href "/help"} "Help"]])
+   [:a {:href "/help"} "Help"]
+   ;; An <a> with NO href is not a link and not focusable, so it needs no
+   ;; accessible name. The tag set and this condition are the compiled
+   ;; substrates' (`re-frame.ui.compiler.a11y`), not invented here.
+   [:a {:name "section-3"}]
+   [:a {:class "anchor-target"}]])
 
 ;; ---------------------------------------------------------------------------
 ;; function-in-head-position — ordinary heads, and fn literals at PROP

--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/README.md
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/README.md
@@ -116,14 +116,22 @@ not at a fixed position.
 
 ### `:re-frame.hicasso/nameless-interactive-element` — warning
 
-`[:button {…}]` or `[:a {…}]` with **no children at all** and none of
-`:aria-label`, `:aria-labelledby` or `:title`. Such an element has no
-accessible name and a screen reader announces it as an unlabelled control.
+`[:button {…}]`, or `[:a {…}]` **that carries an `href`**, with **no children
+at all** and none of `:aria-label`, `:aria-labelledby` or `:title`. Such an
+element has no accessible name and a screen reader announces it as an
+unlabelled control.
+
+The tag set and the `href` condition are taken from this project's compiled
+substrates rather than invented here — `re-frame.ui.compiler.a11y`'s
+`:rf.ui.compile/a11y-missing-accessible-name` names a `<button>` always and an
+`<a>` only when it is a real link — so the two agree about what a nameless
+control is. An `<a>` without `href` is not focusable and not a link.
 
 **Refuses to know:** what any child renders. One child of any kind — even a
 symbol that turns out to be an icon with no text — makes this silent, because
 it may well render text. Dynamic props answer the same way: the name may be in
-there. `:input` is deliberately absent: its name usually comes from a sibling
+there. `:input`, `:select` and `:textarea` are in that compiler pass's set and
+deliberately absent here: their name usually comes from a sibling
 `<label for=…>`, which is a fact about the tree rather than about the element.
 The real accessibility pass is a separate piece of work; this is one always-
 right corner of it.

--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj
@@ -356,17 +356,31 @@
 
 ;; --- an interactive element with nothing to name it -----------------------
 
-(def ^:private interactive-tags
-  "Tags whose whole purpose is to be operated, and which are inoperable
-  from a screen reader without an accessible name. Deliberately two: an
-  `:input`'s name usually comes from a sibling `<label for=…>`, which is a
-  fact about the TREE rather than about the element, and belongs to the
-  real a11y pass (hic-043)."
-  #{"button" "a"})
-
 (def ^:private naming-attributes
-  "The attributes that give an element an accessible name on their own."
+  "The attributes that give an element an accessible name on their own.
+  The same three the compiled substrates' a11y pass names
+  (`re-frame.ui.compiler.a11y`, `:rf.ui.compile/a11y-missing-accessible-name`)."
   #{:aria-label :aria-labelledby :title})
+
+(defn- needs-an-accessible-name?
+  "Is this an element that is named by its CONTENT, and so unusable without
+  one when it has none?
+
+  The tag set and the `:href` condition are taken from the compiled
+  substrates' a11y pass rather than invented here, so the two agree about
+  what a nameless control is: a `<button>` always, and an `<a>` only when it
+  is a real link. An `<a>` with no `href` is not focusable and not a link,
+  so demanding a name for one would be a false positive.
+
+  `:input`, `:select` and `:textarea` are in that pass's set and NOT here:
+  their name usually comes from a sibling `<label for=…>`, which is a fact
+  about the TREE rather than about the form in hand, and belongs to the real
+  a11y pass (hic-043)."
+  [tag props]
+  (let [base (base-tag tag)]
+    (or (= "button" base)
+        (and (= "a" base)
+             (contains? (some-> props map-keys) :href)))))
 
 (defn- check-nameless-interactive!
   "`[:button {…}]` / `[:a {…}]` with NO children and no naming attribute.
@@ -380,7 +394,7 @@
           children (child-nodes node)
           props    (props-node node)
           at-1     (second (:children node))]
-      (when (and (contains? interactive-tags (base-tag tag))
+      (when (and (needs-an-accessible-name? tag props)
                  (empty? children)
                  (or props (definitely-not-props? at-1))
                  (empty? (into #{} (filter naming-attributes)


### PR DESCRIPTION
Follow-up to **#7784** (rf2-hic-022), which merged while this fix was in flight.
One commit, one check narrowed, no new surface.

## The false positive

`:re-frame.hicasso/nameless-interactive-element` shipped in #7784 firing on
`[:button {…}]` **or** `[:a {…}]` with no children and no naming attribute.

This project already decides what a nameless control is, and it does not agree:
`re-frame.ui.compiler.a11y` and its freehand sibling raise
`:rf.ui.compile/a11y-missing-accessible-name` for a `<button>` **always**, but
for an `<a>` **only when it carries an `href`**:

```clojure
(and (or (= :button tag) (and (= :a tag) (has-attr? props :href)))
     (= :none (content-evidence children)))
```

An `<a>` without `href` is not a link and not focusable, so demanding an
accessible name for one is wrong. These were flagged and should not have been:

```clojure
[:a {:name "section-3"}]      ;; a fragment target
[:a {:class "anchor-target"}]
```

That is exactly the class of defect the lint layer must not have — a rule that
fires on correct code teaches people to ignore the linter.

## The fix

The tag set and the `href` condition now come from that compiler pass rather
than from the hook file, so the two agree about what a nameless control is. The
three naming attributes (`:aria-label` / `:aria-labelledby` / `:title`) were
already identical.

`:input`, `:select` and `:textarea` are in the compiler's set and stay out of
this one, on the grounds already stated in the export's README: their name
usually comes from a sibling `<label for=…>`, which is a fact about the TREE
rather than about the form in hand, and a clj-kondo hook sees one form. That
remains hic-043's.

Both hrefless spellings are added to `lint-fixtures/negative.cljs`, so the
shape is pinned rather than merely fixed. The README's entry for the check is
updated to state the `href` condition and to name the compiler pass it is taken
from.

## How it was found

The repo's own a11y diagnostic scrolled past in a `test:cljs` log during the
last spine run, which prompted a cross-check of #7784's rule against it. That
is the "audit what already exists before adding anything" instruction paying
for itself, and it is the second false positive the negative-fixture half of
this work has caught — the first was the event vector `[:a]` at `:on-click`
being read as an unnamed anchor.

## Quality gates

Each run alone, in the foreground, exit echoed to its own file.

| Gate | Exit | Notes |
|---|---|---|
| `npm run test:hicasso-lint` (gate + `--self-test`) | `0` | `OK: 6 checks fire on their fixtures, correct code is silent, and the artefact's own testbeds are quiet.` All three self-test mutations still red. |

`sh scripts/test-fast-pr.sh` exited **0** on the immediately preceding commit
(`gate root: /c/Users/miket/code/re-frame2-worktrees/lint-hic022`, `PASS fast PR
spine`, 0 FAILs, with `hicasso lint export gate` running inside it), and this
commit changes only the hook's tag predicate, two negative fixtures and the
export README — it cannot reach any other lane. The gate that genuinely covers
this surface is `lint.yml`'s required `clj-kondo` job, since
`.clj-kondo/config.edn` points `:config-paths` at the export; it was green on
#7784 and this change only NARROWS a warning-level check, so it cannot
introduce an error-level finding.

Required checks the local spine does not run, per
`python scripts/check_fast_pr_gap.py --list`: `Lint required` (`lint.yml` —
clj-kondo, Splint, ESLint, the public-API manifest drift-check) and `Docs
required` (`docs.yml`) have no tier in the spine.
