### PR TITLE
test(hicasso): Activity hide/reveal and Suspense ownership (rf2-hic-014)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/activity_suspense_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/activity_suspense_cljs_test.cljs
@@ -140,6 +140,7 @@
   one of them was reached at runtime, so the roster cannot drift into a
   list of things the suite used to do."
   #{:activity/hide-releases
+    :activity/hide-inside-a-deferred-notification-window
     :activity/hidden-render-publishes-nothing
     :activity/reveal-reacquires
     :activity/conditional-read-moved-while-hidden
@@ -190,6 +191,28 @@
   "The registrations currently reading `query-v`, as a snapshot vector."
   [query-v]
   (inventory/cell-readers (k query-v)))
+
+(defn- reader-count
+  "How many registrations read `query-v`.
+
+  **Assertions here take the COUNT and never the vector**, and that is a
+  legibility repair measured on this file's own sabotage run rather than
+  a preference. A registration holds the cells it acquired and each of
+  those holds the registration back on its reader list, so the object
+  graph is cyclic: `cljs.test`'s failure printer walks it and dies, and
+  every `(= [] (readers …))` red arrived as
+  `RangeError: Maximum call stack size exceeded`, naming nothing. A
+  witness whose red output is a stack overflow is not a witness.
+
+  Every positive identity claim below is spelled
+  `(is (true? (identical? a b)))` rather than `(is (identical? a b))` for
+  exactly the same reason: `cljs.test` reports a failing predicate's
+  EVALUATED ARGUMENTS, so the first form reports `(not (true? false))`
+  and the second reports the cyclic graph. A helper cannot fix that —
+  `(is (same? a b))` would report the two registrations again — so the
+  wrapping is written out at each site."
+  [query-v]
+  (count (readers query-v)))
 
 (defn- sole-reader
   "The one registration reading `query-v`, or nil when that is not the
@@ -293,7 +316,7 @@
                 the instant the cleanup runs, and the key is read by
                 nobody. The cell survives only until its reaper, which is
                 why `:cells` is 1 here and 0 after quiescence"
-        (is (= [] (readers [:acs/a])))
+        (is (zero? (reader-count [:acs/a])))
         (is (= {:cells 1 :cell-refs 0 :boundaries 0 :edges 0} (ownership))))
 
       (testing "and the released registration is DEAF, which is the half a
@@ -308,7 +331,7 @@
                 incarnation, its app-db is intact, and the write above
                 landed in it — a hide releases this arm's ownership and
                 touches nothing the substrate owns"
-        (is (identical? token (frame/frame-incarnation-token frame-id))
+        (is (true? (identical? token (frame/frame-incarnation-token frame-id)))
             "same incarnation — a hide is not a teardown")
         (is (= 3 (:a (app-db)))
             "seeded 1, bumped twice, and the second bump landed AFTER the
@@ -324,6 +347,73 @@
                          retained a cell would show here"
                  (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
                         (inventory/residue))))
+               (done))))))
+
+;; ---------------------------------------------------------------------------
+;; 1b. A hide landing inside a DEFERRED notification window
+;; ---------------------------------------------------------------------------
+
+(defn- writing-body
+  "A body that writes to `:acs/a` on its first run and on no later one.
+
+  A write taken while a body is running is the one case
+  [[re-frame.hicasso.impl.collector/flush!]] defers: an `onStoreChange`
+  fired from inside somebody's render is a render-phase update on another
+  component, which React rejects, so the readers are collected NOW and
+  notified a macrotask later. That gap is a window a hide can land in,
+  and an Activity hide is exactly the thing that lands in it — React
+  hides a subtree while its siblings are still rendering.
+
+  The flag is what keeps the generation fence terminating: the fence
+  re-runs a body that observed a new commit, and a body that writes on
+  every run is the exhaustion case `render-body` refuses outright."
+  [!wrote?]
+  (fn writer [_]
+    (when-not @!wrote?
+      (reset! !wrote? true)
+      (rf/with-frame frame-id (rf/dispatch-sync [:acs/bump :a])))
+    [:p "writer"]))
+
+(deftest a-hide-landing-inside-a-deferred-notification-window-is-not-notified
+  ;; **This row is the only place `unsubscribe`'s notifier clear is
+  ;; load-bearing, and finding that out is what it is for.** Measured:
+  ;; deleting `(set! (.-notify reg) nil)` reds nothing else in this file,
+  ;; and deleting the membership release reds nothing that depends on
+  ;; deafness — because on the synchronous path each mechanism alone is
+  ;; sufficient. `flush!` reads the reader lists BEFORE the deferral, so
+  ;; on this path the release has already happened and cannot help; the
+  ;; nil notifier is the whole of the guard.
+  (async done
+    (seeded!)
+    (let [visible (commit! (render! panel-body))
+          !wrote? (atom false)]
+
+      ;; A second boundary renders and writes from inside its own body, so
+      ;; the notification `visible` has earned is DEFERRED rather than
+      ;; delivered inline.
+      (render! (writing-body !wrote?))
+
+      (testing "the premise: the write landed inside a render, so the
+                notification is owed and not yet delivered. An inline
+                notification here would defeat the row by leaving no window
+                for the hide to land in"
+        (is (true? @!wrote?))
+        (is (zero? @(:notified visible))))
+
+      ;; The hide lands in the window — after the readers were collected
+      ;; and before they are notified.
+      (hide! visible)
+
+      (exercised! :activity/hide-inside-a-deferred-notification-window)
+
+      (.then (inventory/quiesced!)
+             (fn [_]
+               (testing "and the deferred notification is not delivered to
+                         it. React has torn this subscription down; calling
+                         its `onStoreChange` now is a store notification to
+                         a boundary that no longer exists, which React
+                         answers with a warning and a re-render of nothing"
+                 (is (zero? @(:notified visible))))
                (done))))))
 
 ;; ---------------------------------------------------------------------------
@@ -355,9 +445,9 @@
                   it probes reads, acquires no durable ownership, and
                   installs no reverse edge — three of them, on two keys,
                   leave every reader list empty"
-          (is (= [] (readers [:acs/which])))
-          (is (= [] (readers [:acs/a])))
-          (is (= [] (readers [:acs/b])))
+          (is (zero? (reader-count [:acs/which])))
+          (is (zero? (reader-count [:acs/a])))
+          (is (zero? (reader-count [:acs/b])))
           (is (= 0 (:cell-refs (ownership))))
           (is (= 0 (:boundaries (ownership))))
           (is (= 0 (:edges (ownership)))))
@@ -485,13 +575,13 @@
                 predecessor's membership back on a key the current body
                 never touches — a subscription nothing will ever release,
                 notifying a boundary that does not read it"
-        (is (= [] (readers [:acs/a]))))
+        (is (zero? (reader-count [:acs/a]))))
 
       (testing "and the CURRENT read set is owned, by the reveal's own
                 registration, on both of its keys"
         (is (some? reveal-reg))
         (is (not (identical? pre-hide reveal-reg)))
-        (is (identical? reveal-reg (sole-reader [:acs/which]))
+        (is (true? (identical? reveal-reg (sole-reader [:acs/which])))
             "one registration per boundary, holding both its keys — not two
              registrations holding one each")
         (is (= #{(k [:acs/which]) (k [:acs/b])}
@@ -541,7 +631,7 @@
         (is (= 1 (count (readers [:acs/a])))
             "the assertion the real row makes — `(= [] (readers [:acs/a]))`
              — is FALSE here, which is what makes that row a witness")
-        (is (identical? pre-hide (first (readers [:acs/a])))))
+        (is (true? (identical? pre-hide (first (readers [:acs/a]))))))
 
       (testing "and the census the real row pins moves with it: two
                 boundaries where there should be one, four memberships
@@ -598,10 +688,10 @@
                 reads, and does not acquire the key it does"
         (is (= 1 (count (readers [:acs/a])))
             "resurrected — the assertion the real row makes is FALSE here")
-        (is (= [] (readers [:acs/b]))
+        (is (zero? (reader-count [:acs/b]))
             "and the current read is owned by nobody, so a write to it
              re-renders nothing")
-        (is (identical? (sole-reader [:acs/a]) (sole-reader [:acs/which]))
+        (is (true? (identical? (sole-reader [:acs/a]) (sole-reader [:acs/which])))
             "one registration, holding the PRE-HIDE pair"))
       (hide! stale))))
 
@@ -704,7 +794,7 @@
           (is (some? reg)
               (str "cycle " cycle ": and exactly one registration holds it"))
           (hide! committed)
-          (is (= [] (readers [:acs/a]))
+          (is (zero? (reader-count [:acs/a]))
               (str "cycle " cycle ": the suspension releases it whole"))))
 
       (testing "four cycles, four distinct registrations — no cycle reused a
@@ -712,11 +802,15 @@
                 rebuilt the subscription rather than finding one still
                 installed"
         (is (= 4 (count @!regs)))
-        (is (every? some? @!regs))
-        (is (apply distinct? @!regs)
-            "distinct by identity: a JS object without IEquiv compares
-             `identical?`, so this is the identity statement and not a
-             value one"))
+        (is (= 4 (count (remove nil? @!regs))))
+        ;; The set is built OUTSIDE the assertion so a failure reports a
+        ;; number rather than a set of cyclic registrations. A JS object
+        ;; carries no IEquiv, so `into #{}` de-duplicates by `identical?`
+        ;; and this count IS the identity statement.
+        (let [distinct-regs (count (into #{} @!regs))]
+          (is (= 4 distinct-regs)
+              "four reveals, four registration identities — no cycle found a
+               subscription still installed")))
 
       (exercised! :suspense/repeated-hide-reveal-cycles)
 
@@ -756,7 +850,7 @@
                 list and the entry's claim is dropped, but the entry
                 OBJECT survives in React's retained fiber, and its
                 `subscribe` is what a reveal calls"
-        (is (= [] (readers [:acs/a])))
+        (is (zero? (reader-count [:acs/a])))
         (is (= 0 (entry-refs entry)))
         (is (= #{(k [:acs/a])} (inventory/boundary-reads connected))
             "the released registration still answers its read set — the

--- a/implementation/hicasso/test/re_frame/hicasso/activity_suspense_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/activity_suspense_cljs_test.cljs
@@ -1,0 +1,814 @@
+(ns re-frame.hicasso.activity-suspense-cljs-test
+  "ACTIVITY HIDE/REVEAL AND SUSPENSE CONDUCT, AT THE SEAM (rf2-hic-014).
+
+  > - hide releases committed subscription ownership without destroying
+  >   re-frame state;
+  > - hidden work does not publish speculative read sets;
+  > - reveal reacquires the current read set and corrects before visible
+  >   paint;
+  > - conditional reads changed while hidden do not resurrect stale
+  >   membership;
+  > - intents retained before hide obey the documented callback/frame-
+  >   incarnation rule;
+  > - Xray distinguishes hidden-retained, visible-connected, and
+  >   unmounted rather than collapsing them.
+  >
+  > — `docs/design/hicasso/product/lanes/react-compatibility-notes.md`,
+  >   *Activity lifecycle witness*
+
+  This is the **node half**, and it exists because of where the gates
+  are. React 19.2's `<Activity>` needs a real concurrent root, so the
+  matrix driven by React itself lives in
+  [[re-frame.hicasso.activity-suspense-dom-cljs-test]] and runs on the
+  browser lane — which is not in the fast-PR spine. This file is
+  therefore the only thing standing over the hide/reveal kernel on an
+  ordinary PR, so it takes the properties that can be stated exactly
+  without a DOM and states them where they will actually be run.
+
+  ## What an Activity hide IS, at this seam
+
+  React's contract for a hidden `<Activity>` is that it *cleans up
+  effects and active subscriptions* while retaining the subtree's UI
+  state, and *recreates* them on reveal.
+  `useSyncExternalStore`'s subscription is one of those effects, so a
+  hide runs the cleanup
+  [[re-frame.hicasso.impl.collector/commit-boundary!]] hands back and a
+  reveal calls that entry's `subscribe` again. Both are exposed
+  deliberately, and `commit-boundary!`'s own docstring is the warrant: it
+  hands a caller *the same `subscribe` closure `useSyncExternalStore`
+  would call* and *the same cleanup React would hold*.
+
+  So the transitions below are not a simulation of the Activity
+  lifecycle. They are the lifecycle's two calls, made in the order React
+  makes them, with the ownership tables read between each one — which is
+  how a witness says **which** key is owned by **which** registration
+  rather than inferring it from a page.
+
+  Driving the seam is emphatically not how a witness says React hides
+  anything. That claim is the DOM file's, and this file does not make it.
+
+  ## The observable is IDENTITY, never a count
+
+  Every ownership assertion here names the surviving registration by
+  `identical?`, not by `count`. `rf2-hic-011`'s ledger records why: a
+  runtime that **leaks the predecessor and fails to acquire for the
+  successor** still counts one. The two failures are opposite and the
+  count is blind to both, so the count is asserted beside the identity
+  and never instead of it.
+
+  Nothing here asserts on rendered markup, for the reason
+  `reincarnation_routing_cljs_test` states in full: this arm's read path
+  is address-directed, so a boundary re-rendered after a botched reveal
+  paints the correct value out of the wrong ownership. A value-level
+  assertion is green in both directions.
+
+  ## The negative controls are in the suite, not only in the report
+
+  Two rows perform, by hand, the exact mutations that would make the
+  matrix vacuous —
+  [[NEGATIVE-CONTROL-skipping-the-release-on-hide-resurrects-the-stale-membership]]
+  is the bead's own named sabotage (*skipping release-on-hide must turn
+  the stale-membership witness red*), and
+  [[NEGATIVE-CONTROL-a-reveal-that-reuses-the-pre-hide-read-set-reacquires-the-wrong-key]]
+  is the reveal-side twin. Without them every zero above could be a zero
+  the instrument is incapable of making non-zero, which is the failure
+  mode this repo has been bitten by twice.
+
+  ## No clock
+
+  Where a property is only true after the reapers run, the settle is
+  [[re-frame.hicasso.impl.inventory/quiesced!]] — the runtime's own
+  horizon — and never a `setTimeout` of this file's choosing."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [clojure.set :as set]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.frame :as frame]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.frames :as frames]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private frame-id ::activity-suspense)
+
+;; Registered above `use-fixtures`, as this package's other suites are and
+;; for the same reason: the reset fixture captures its source-store
+;; baseline when the `use-fixtures` form is evaluated.
+;;
+;; `:acs/which` selects between `:acs/a` and `:acs/b`, so a body reading it
+;; has a read set that MOVES — which is the whole of the conditional-read
+;; row. `:acs/mark` writes a distinctive leaf, so a write that reached the
+;; wrong incarnation is unmistakable in that incarnation's app-db rather
+;; than merely absent from the right one.
+(rf/reg-sub :acs/which (fn [db _] (:which db)))
+(rf/reg-sub :acs/a     (fn [db _] (:a db)))
+(rf/reg-sub :acs/b     (fn [db _] (:b db)))
+
+(rf/reg-event :acs/seed  (fn [_ [_ db]] {:db db}))
+(rf/reg-event :acs/flip  (fn [{:keys [db]} [_ which]] {:db (assoc db :which which)}))
+(rf/reg-event :acs/bump  (fn [{:keys [db]} [_ k]] {:db (update db k inc)}))
+(rf/reg-event :acs/mark  (fn [{:keys [db]} [_ tag]] {:db (assoc db :marked tag)}))
+
+;; The UIx adapter rather than plain-atom, for the reason the package smoke
+;; gives: plain-atom has no reactivity layer, so a subscription under it
+;; never notifies and every commit assertion would pass vacuously by never
+;; firing.
+;;
+;; `:async? true` selects the MAP form, which the rows settling against
+;; `inventory/quiesced!` require — `cljs.test` hard-errors on a fn-form
+;; fixture for an `(async done …)` test, because the fn form unwinds its
+;; ambient scope the instant it returns. `:ambient-frame nil` because this
+;; suite seats its own top-level frame.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (collector/reset-runtime!)
+                      (error-emit/clear-error-listeners!))}))
+
+;; ---------------------------------------------------------------------------
+;; The exercised population — a MEASUREMENT, not a claim
+;; ---------------------------------------------------------------------------
+
+(def ^:private declared-population
+  "The Activity/Suspense transitions this file undertakes to exercise.
+  [[the-declared-population-was-actually-exercised]] asserts that every
+  one of them was reached at runtime, so the roster cannot drift into a
+  list of things the suite used to do."
+  #{:activity/hide-releases
+    :activity/hidden-render-publishes-nothing
+    :activity/reveal-reacquires
+    :activity/conditional-read-moved-while-hidden
+    :activity/retained-intent-across-a-reincarnation
+    :suspense/repeated-hide-reveal-cycles
+    :lifecycle/three-states-distinguished})
+
+(defonce ^:private !exercised (atom #{}))
+
+(defn- exercised! [transition] (swap! !exercised conj transition) nil)
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- seeded!
+  "Seat a first incarnation under the fixed public id, with a known db.
+
+  Any live predecessor is destroyed and the arm's frame memo emptied
+  first: `commit-basis` is a sum of counters and a leftover frame would
+  carry its installs into the next row's arithmetic. React's `act` queue
+  is not the browser's scheduler and none of this runs inside one — set
+  outright, as the package smoke does, rather than importing the bench
+  tree's helper, which the freeze gate forbids this package to require."
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  (when (frame/frame-incarnation-token frame-id) (rf/destroy-frame! frame-id))
+  (frames/forget-frame-ops! frame-id)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id
+    (rf/dispatch-sync [:acs/seed {:which :a :a 1 :b 100}]))
+  frame-id)
+
+(defn- k
+  "A sub-key: the runtime keys cells by `[frame-kw query-v]`, because two
+  frames are isolated contexts holding two different app-dbs."
+  [query-v]
+  [frame-id query-v])
+
+(defn- ownership
+  "The census with the entry cache projected out. A read-set entry is a
+  render-phase CACHE, not ownership, so the rows that care about it name
+  it separately."
+  []
+  (dissoc (inventory/residue) :entries))
+
+(defn- readers
+  "The registrations currently reading `query-v`, as a snapshot vector."
+  [query-v]
+  (inventory/cell-readers (k query-v)))
+
+(defn- sole-reader
+  "The one registration reading `query-v`, or nil when that is not the
+  count. Answering nil rather than throwing keeps a failing row's message
+  about the identity it expected instead of about this helper."
+  [query-v]
+  (let [rs (readers query-v)]
+    (when (= 1 (count rs)) (first rs))))
+
+(defn- app-db [] (rf/app-db-value frame-id))
+
+(defn- entry-refs
+  "How many committed boundaries hold `entry`.
+
+  Read with `unchecked-get` and the same string key the runtime writes
+  (`entry-for`'s `#js {\"refs\" 0}`), so no new reader has to be exported
+  from the collector for a witness to count claims on an entry — and so
+  the read survives `:advanced` renaming exactly as the runtime's own
+  writes do."
+  [entry]
+  (unchecked-get entry "refs"))
+
+;; ---------------------------------------------------------------------------
+;; The bodies
+;; ---------------------------------------------------------------------------
+;;
+;; Plain functions rather than `h/defview` boundaries, because
+;; `render-body` is the seam and a body-fn is what it takes. The views the
+;; DOM file mounts are `defview`s over these same reads.
+
+(defn- panel-body
+  "One unconditional read."
+  [_]
+  [:p (str "a=" (h/sub [:acs/a]))])
+
+(defn- conditional-body
+  "A read set that MOVES. The selector is itself a read, so the boundary
+  is notified when the selection changes — which is what makes the
+  hidden-window flip below reach it at all — and the selected key is read
+  through the ambient collector, so a branch not taken contributes no
+  edge."
+  [_]
+  (let [which (h/sub [:acs/which])]
+    [:p (str (name which) "="
+             (if (= :a which) (h/sub [:acs/a]) (h/sub [:acs/b])))]))
+
+(defn- render!
+  "Run ONE body under the real generation fence — the same call
+  [[re-frame.hicasso.impl.collector/shell]] makes between its two hooks —
+  and answer the read-set entry the render resolved. Commits nothing:
+  `subscribe` is React's to call, and nothing here calls it."
+  [body-fn]
+  (collector/render-body frame-id body-fn {})
+  (collector/last-reads))
+
+(defn- commit!
+  "React's commit: call the entry's own `subscribe` and keep the cleanup.
+  Answers `{:cleanup … :notified …}` where `:notified` counts the
+  `onStoreChange` calls the registration has received."
+  [entry]
+  (let [!notified (atom 0)]
+    {:cleanup   (collector/commit-boundary! entry (fn [] (swap! !notified inc)))
+     :notified  !notified}))
+
+(defn- hide!
+  "React's hide: run the cleanup `useSyncExternalStore` holds. This is the
+  whole of what a hidden `<Activity>` does to a subscription."
+  [committed]
+  ((:cleanup committed))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; 1. Hide releases committed ownership, and leaves re-frame state standing
+;; ---------------------------------------------------------------------------
+
+(deftest hide-releases-committed-ownership-and-leaves-re-frame-state-standing
+  (async done
+    (seeded!)
+    (let [entry     (render! panel-body)
+          committed (commit! entry)
+          visible   (sole-reader [:acs/a])
+          token     (frame/frame-incarnation-token frame-id)]
+
+      (testing "VISIBLE-CONNECTED — the commit acquired exactly the read
+                set, and the registration holding it is the one this
+                commit minted"
+        (is (= #{(k [:acs/a])} (collector/reads-of entry)))
+        (is (some? visible))
+        (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership)))
+        (is (= #{(k [:acs/a])} (inventory/boundary-reads visible))
+            "and its forward edge is the entry's own key set"))
+
+      (testing "it is LIVE, not merely present — a write to its key
+                notifies it exactly once"
+        (rf/with-frame frame-id (rf/dispatch-sync [:acs/bump :a]))
+        (is (= 1 @(:notified committed))))
+
+      (hide! committed)
+
+      (testing "HIDE releases the committed ownership: the membership goes
+                the instant the cleanup runs, and the key is read by
+                nobody. The cell survives only until its reaper, which is
+                why `:cells` is 1 here and 0 after quiescence"
+        (is (= [] (readers [:acs/a])))
+        (is (= {:cells 1 :cell-refs 0 :boundaries 0 :edges 0} (ownership))))
+
+      (testing "and the released registration is DEAF, which is the half a
+                census cannot see: a write after the hide reaches it not at
+                all"
+        (rf/with-frame frame-id (rf/dispatch-sync [:acs/bump :a]))
+        (is (= 1 @(:notified committed))
+            "still 1 — the notifier was cleared by the cleanup, so a hidden
+             subtree cannot be re-rendered by a write it no longer reads"))
+
+      (testing "WITHOUT DESTROYING RE-FRAME STATE. The frame is the same
+                incarnation, its app-db is intact, and the write above
+                landed in it — a hide releases this arm's ownership and
+                touches nothing the substrate owns"
+        (is (identical? token (frame/frame-incarnation-token frame-id))
+            "same incarnation — a hide is not a teardown")
+        (is (= 3 (:a (app-db)))
+            "seeded 1, bumped twice, and the second bump landed AFTER the
+             hide: the state is live, not merely retained")
+        (is (= :a (:which (app-db)))))
+
+      (exercised! :activity/hide-releases)
+
+      (.then (inventory/quiesced!)
+             (fn [_]
+               (testing "and at the runtime's own horizon the hidden
+                         boundary's residue is exactly zero — a hide that
+                         retained a cell would show here"
+                 (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                        (inventory/residue))))
+               (done))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. Hidden work publishes no read sets
+;; ---------------------------------------------------------------------------
+
+(deftest a-hidden-render-publishes-no-read-set
+  (async done
+    (seeded!)
+    (let [committed (commit! (render! panel-body))]
+      (hide! committed)
+
+      (let [before (collector/body-runs)
+            ;; React renders hidden children at lower priority. Three runs,
+            ;; because a leak of one membership per hidden render is
+            ;; invisible in a single one — the shape `rf2-hic-011` names.
+            entries (doall (repeatedly 3 #(render! conditional-body)))
+            delta   (- (collector/body-runs) before)]
+
+        (testing "the premise: the bodies genuinely RAN. Without this the
+                  zeros below are the zeros of a render that never
+                  happened, which is the cheapest possible false green"
+          (is (= 3 delta))
+          (is (every? #(= #{(k [:acs/which]) (k [:acs/a])} (collector/reads-of %))
+                      entries)
+              "and each one resolved a real, non-empty read set"))
+
+        (testing "and published none of it. A hidden render is a render:
+                  it probes reads, acquires no durable ownership, and
+                  installs no reverse edge — three of them, on two keys,
+                  leave every reader list empty"
+          (is (= [] (readers [:acs/which])))
+          (is (= [] (readers [:acs/a])))
+          (is (= [] (readers [:acs/b])))
+          (is (= 0 (:cell-refs (ownership))))
+          (is (= 0 (:boundaries (ownership))))
+          (is (= 0 (:edges (ownership)))))
+
+        (testing "the entries ARE minted — a render-phase cache is the one
+                  thing a probing render leaves, and calling it out is what
+                  keeps the zeros above honest — but not one of them is
+                  CLAIMED"
+          (is (pos? (:entries (inventory/residue))))
+          (is (every? #(zero? (entry-refs %)) entries)
+              "zero refs on every hidden render's entry: React never called
+               `subscribe`, so nothing above counted a claim that was
+               merely cached")))
+
+      (exercised! :activity/hidden-render-publishes-nothing)
+
+      (.then (inventory/quiesced!)
+             (fn [_]
+               (testing "and the speculative cache evaporates at the
+                         runtime's own horizon"
+                 (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                        (inventory/residue))))
+               (done))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. Reveal reacquires — and the survivor is the NEW registration
+;; ---------------------------------------------------------------------------
+
+(deftest reveal-reacquires-and-the-surviving-registration-is-the-reveals-own
+  (async done
+    (seeded!)
+    (let [before-hide (commit! (render! panel-body))
+          pre-hide    (sole-reader [:acs/a])]
+
+      ;; One write while it is VISIBLE, so its notifier has a non-zero
+      ;; reading to stay at. A deafness assertion against a counter that
+      ;; was never going to move is not a deafness assertion.
+      (rf/with-frame frame-id (rf/dispatch-sync [:acs/bump :a]))
+      (is (= 1 @(:notified before-hide))
+          "the premise: the pre-hide registration was live and notified")
+
+      (hide! before-hide)
+
+      (let [after-reveal (commit! (render! panel-body))
+            revealed     (sole-reader [:acs/a])]
+
+        (testing "REVEAL reacquires: exactly one reader on exactly the key
+                  the current render read"
+          (is (some? revealed))
+          (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership))))
+
+        (testing "and the survivor is the REVEAL's registration, not the
+                  pre-hide one. This is the assertion a count cannot make:
+                  a runtime that leaked the predecessor and failed to
+                  acquire for the successor also answers 1 here"
+          (is (not (identical? pre-hide revealed))
+              "the reveal minted a fresh registration — a subscription
+               rebuilt is a new boundary id by construction")
+          (is (not (some #(identical? pre-hide %) (readers [:acs/a])))
+              "and the pre-hide registration is nowhere in the reader list"))
+
+        (testing "the pre-hide registration stays deaf and the revealed one
+                  is live — one write, and it reaches exactly one of them"
+          (rf/with-frame frame-id (rf/dispatch-sync [:acs/bump :a]))
+          (is (= 1 @(:notified before-hide))
+              "still 1 — the pre-hide notifier moved for the write it was
+               live for and for nothing since the hide")
+          (is (= 1 @(:notified after-reveal))
+              "and the reveal's own registration took that same write"))
+
+        (hide! after-reveal))
+
+      (exercised! :activity/reveal-reacquires)
+
+      (.then (inventory/quiesced!)
+             (fn [_]
+               (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                      (inventory/residue))
+                   "teardown after a hide/reveal/hide cycle is exact")
+               (done))))))
+
+;; ---------------------------------------------------------------------------
+;; 4. A conditional read changed while hidden does not resurrect stale
+;;    membership — and the bead's named sabotage for it
+;; ---------------------------------------------------------------------------
+
+(defn- hidden-window-flip!
+  "The transition the row is about, with `release-on-hide?` a parameter so
+  the sabotage is the SAME code path with one call removed rather than a
+  second, differently-written scenario.
+
+  Visible under `:which = :a`; hidden; flipped to `:b` while hidden;
+  re-rendered while hidden; revealed. Answers the two registrations and
+  the reveal's entry."
+  [release-on-hide?]
+  (let [entry-a   (render! conditional-body)
+        committed (commit! entry-a)
+        pre-hide  (sole-reader [:acs/a])]
+    (when release-on-hide? (hide! committed))
+    (rf/with-frame frame-id (rf/dispatch-sync [:acs/flip :b]))
+    (let [entry-b  (render! conditional-body)
+          revealed (commit! entry-b)]
+      {:pre-hide      pre-hide
+       :pre-committed committed
+       :entry-a       entry-a
+       :entry-b       entry-b
+       :revealed      revealed})))
+
+(deftest a-conditional-read-changed-while-hidden-does-not-resurrect-stale-membership
+  (async done
+    (seeded!)
+    (let [{:keys [pre-hide entry-a entry-b revealed]} (hidden-window-flip! true)
+          reveal-reg (sole-reader [:acs/b])]
+
+      (testing "the premise: the read set really did MOVE across the hidden
+                window. Without this the row is a hide/reveal of one
+                unchanged set, which section 3 already covers"
+        (is (= #{(k [:acs/which]) (k [:acs/a])} (collector/reads-of entry-a)))
+        (is (= #{(k [:acs/which]) (k [:acs/b])} (collector/reads-of entry-b)))
+        (is (some? pre-hide)))
+
+      (testing "THE ROW. `:acs/a` was read before the hide and is not read
+                now, so the reveal must leave it with no reader at all. A
+                reveal that replayed the pre-hide read set would put the
+                predecessor's membership back on a key the current body
+                never touches — a subscription nothing will ever release,
+                notifying a boundary that does not read it"
+        (is (= [] (readers [:acs/a]))))
+
+      (testing "and the CURRENT read set is owned, by the reveal's own
+                registration, on both of its keys"
+        (is (some? reveal-reg))
+        (is (not (identical? pre-hide reveal-reg)))
+        (is (identical? reveal-reg (sole-reader [:acs/which]))
+            "one registration per boundary, holding both its keys — not two
+             registrations holding one each")
+        (is (= #{(k [:acs/which]) (k [:acs/b])}
+               (inventory/boundary-reads reveal-reg))))
+
+      (testing "so the census is the reveal's read set and nothing else.
+                `:cells` is 3 because `:acs/a`'s cell is still inside its
+                one macrotask of reaper grace; `:cell-refs` and `:edges`
+                are 2, which is the number that would move if the stale
+                membership had come back"
+        (is (= {:cells 3 :cell-refs 2 :boundaries 1 :edges 2} (ownership))))
+
+      (testing "the revealed boundary is live on the key it now reads, and
+                deaf on the one it dropped"
+        (rf/with-frame frame-id (rf/dispatch-sync [:acs/bump :b]))
+        (is (= 1 @(:notified revealed)))
+        (rf/with-frame frame-id (rf/dispatch-sync [:acs/bump :a]))
+        (is (= 1 @(:notified revealed))
+            "still 1 — a write to the dropped key notifies nobody, because
+             a key nothing holds has no cell and contributes no reader"))
+
+      (hide! revealed)
+      (exercised! :activity/conditional-read-moved-while-hidden)
+
+      (.then (inventory/quiesced!)
+             (fn [_]
+               (testing "and the dropped key's cell is gone at the horizon,
+                         so nothing survives the transition on `:acs/a`'s
+                         behalf"
+                 (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                        (inventory/residue))))
+               (done))))))
+
+(deftest NEGATIVE-CONTROL-skipping-the-release-on-hide-resurrects-the-stale-membership
+  ;; The bead's own sabotage, run as a row rather than described in a
+  ;; report: *skipping release-on-hide must turn the stale-membership
+  ;; witness red*. It is the same helper with `release-on-hide?` false, so
+  ;; what changed between green and red is one call and not one scenario.
+  (async done
+    (seeded!)
+    (let [{:keys [pre-hide pre-committed revealed]} (hidden-window-flip! false)]
+
+      (testing "with the release skipped, the predecessor's membership on
+                the dropped key SURVIVES the transition — and it is the
+                pre-hide registration itself, by identity, not merely a
+                non-zero count"
+        (is (= 1 (count (readers [:acs/a])))
+            "the assertion the real row makes — `(= [] (readers [:acs/a]))`
+             — is FALSE here, which is what makes that row a witness")
+        (is (identical? pre-hide (first (readers [:acs/a])))))
+
+      (testing "and the census the real row pins moves with it: two
+                boundaries where there should be one, four memberships
+                where there should be two"
+        (is (= {:cells 3 :cell-refs 4 :boundaries 2 :edges 4} (ownership))))
+
+      (testing "the leaked registration is still LIVE, which is the cost.
+                A write to a key NO visible boundary reads re-renders the
+                subtree React has hidden, and leaves the visible one
+                untouched — so the leak is not merely retention, it is
+                work"
+        (let [visible-before @(:notified revealed)]
+          (rf/with-frame frame-id (rf/dispatch-sync [:acs/bump :a]))
+          (is (pos? @(:notified pre-committed))
+              "the hidden subtree is notified by a key it no longer shows")
+          (is (= visible-before @(:notified revealed))
+              "and the visible one is not")))
+
+      (testing "and the stale membership is still there afterwards, because
+                nothing will ever release it: the cleanup that would have
+                was the one this control skipped"
+        (is (= 1 (count (readers [:acs/a])))))
+
+      ;; Release the visible one only. The leak is the point of the row, so
+      ;; it is left for quiescence to fail to collect.
+      (hide! revealed)
+      (.then (inventory/quiesced!)
+             (fn [_]
+               (is (pos? (:cell-refs (inventory/residue)))
+                   "and the leak OUTLIVES quiescence — a reaper cannot
+                    collect a cell that still has a reader, which is
+                    precisely why the release is the invariant")
+               ;; Release it now, so the row leaves the runtime as it found
+               ;; it rather than handing the next row a live registration.
+               (hide! pre-committed)
+               (done))))))
+
+(deftest NEGATIVE-CONTROL-a-reveal-that-reuses-the-pre-hide-read-set-reacquires-the-wrong-key
+  ;; The reveal-side twin. Release-on-hide is performed correctly; what is
+  ;; sabotaged is WHICH entry the reveal subscribes — the pre-hide one
+  ;; rather than the current render's. That is the failure a reveal has if
+  ;; React re-mounts a stale effect, and no assertion in section 4 above
+  ;; would catch it if the row asserted only `count`.
+  (seeded!)
+  (let [entry-a   (render! conditional-body)
+        committed (commit! entry-a)]
+    (hide! committed)
+    (rf/with-frame frame-id (rf/dispatch-sync [:acs/flip :b]))
+    (render! conditional-body)
+    ;; The sabotage: subscribe the PRE-HIDE entry, which is exactly what a
+    ;; reveal replaying a stale effect would do.
+    (let [stale (commit! entry-a)]
+      (testing "the stale reveal reacquires the key the body no longer
+                reads, and does not acquire the key it does"
+        (is (= 1 (count (readers [:acs/a])))
+            "resurrected — the assertion the real row makes is FALSE here")
+        (is (= [] (readers [:acs/b]))
+            "and the current read is owned by nobody, so a write to it
+             re-renders nothing")
+        (is (identical? (sole-reader [:acs/a]) (sole-reader [:acs/which]))
+            "one registration, holding the PRE-HIDE pair"))
+      (hide! stale))))
+
+;; ---------------------------------------------------------------------------
+;; 5. An intent retained before the hide obeys the incarnation rule
+;; ---------------------------------------------------------------------------
+
+(defn- with-refusals
+  "Run `thunk` and collect the always-on corpus
+  `:rf.error/frame-destroyed` records it fans.
+
+  Axis 1 (`error-emit`) rather than the dev trace deliberately: it
+  survives `-Dre-frame.debug=false`, so these assertions hold under the
+  production posture too. Gensym'd listener key, unregistered on the way
+  out."
+  [thunk]
+  (let [seen (atom [])
+        key  (keyword "rf2-hic-014" (name (gensym "refusal")))]
+    (error-emit/register-error-listener!
+      key (fn [r] (when (= :rf.error/frame-destroyed (:error r)) (swap! seen conj r))))
+    (try {:result (thunk) :refusals @seen}
+         (finally (error-emit/unregister-error-listener! key)))))
+
+(deftest an-intent-retained-across-a-hidden-window-obeys-the-incarnation-rule
+  ;; The Activity form of `rf2-hic-013`'s rule. A hidden subtree keeps its
+  ;; UI state, so it keeps every callback its last render lowered — and a
+  ;; hidden window is exactly where a route change has time to destroy and
+  ;; re-seat the frame under the same public id. The rule is that the
+  ;; retained callback refuses and the reveal's fresh one routes; this row
+  ;; is that pair, taken across the hide.
+  (seeded!)
+  (let [committed (commit! (render! panel-body))
+        ;; The ambient dispatch this render bound — exactly what every
+        ;; callback the body lowered retains.
+        retained  (collector/frame-dispatch frame-id)]
+    (hide! committed)
+
+    ;; The reincarnation, inside the hidden window: same public id, new
+    ;; incarnation, different seed so a write that reached the wrong one is
+    ;; unmistakable.
+    (rf/destroy-frame! frame-id)
+    (rf/make-frame {:id frame-id})
+    (rf/with-frame frame-id (rf/dispatch-sync [:acs/seed {:which :a :a 50 :b 500}]))
+
+    (testing "SAFETY — the callback the hidden subtree retained refuses the
+              successor, loudly"
+      (let [{:keys [refusals]} (with-refusals #(retained [:acs/mark :retained]))]
+        (is (nil? (:marked (app-db)))
+            "the successor's app-db is UNTOUCHED by a callback lowered
+             under the incarnation that was visible")
+        (is (= 1 (count refusals))
+            "exactly one always-on record — the only observable separating
+             refused from silently delivered to the wrong frame")
+        (is (= {:error    :rf.error/frame-destroyed
+                :frame    frame-id
+                :event-id :acs/mark
+                :op       :dispatch-sync}
+               (select-keys (first refusals) [:error :frame :event-id :op]))
+            "asserted as a MAP — id, target frame, refused event head and
+             operation realm together. A `thrown?`-shaped assertion would
+             stay green for a refusal raised by a different layer for a
+             different reason")))
+
+    (testing "LIVENESS — the reveal lowers a fresh callback, and it routes
+              into the incarnation that is live now"
+      (let [revealed  (commit! (render! panel-body))
+            on-reveal (collector/frame-dispatch frame-id)
+            {:keys [refusals]} (with-refusals #(on-reveal [:acs/mark :revealed]))]
+        (is (= :revealed (:marked (app-db)))
+            "the revealed subtree's own control writes its own app-db")
+        (is (empty? refusals))
+        (is (not (identical? retained on-reveal))
+            "and it is a different closure — the memo row was replaced when
+             the successor seated, which is what makes safety and liveness
+             the same fact seen twice")
+        (hide! revealed)))
+
+    (exercised! :activity/retained-intent-across-a-reincarnation)))
+
+;; ---------------------------------------------------------------------------
+;; 6. Suspense conduct — repeated hide/reveal cycles leave EXACT ownership
+;; ---------------------------------------------------------------------------
+
+(deftest repeated-suspend-retry-cycles-leave-exactly-one-commits-ownership
+  ;; A Suspense fallback and a hidden `<Activity>` are the same mechanism:
+  ;; React hides the already-committed primary tree, destroying its
+  ;; effects, and re-creates them when the retry resolves. So the conduct
+  ;; a suspend/retry cycle owes is the conduct of a hide/reveal, and the
+  ;; property that a single cycle cannot state is REPETITION — a leak of
+  ;; one membership per cycle looks exactly like a correct single cycle.
+  (async done
+    (seeded!)
+    (let [!regs (atom [])]
+      (dotimes [cycle 4]
+        (let [committed (commit! (render! panel-body))
+              reg       (sole-reader [:acs/a])]
+          (swap! !regs conj reg)
+          (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership))
+              (str "cycle " cycle ": the retry owns exactly one membership"))
+          (is (some? reg)
+              (str "cycle " cycle ": and exactly one registration holds it"))
+          (hide! committed)
+          (is (= [] (readers [:acs/a]))
+              (str "cycle " cycle ": the suspension releases it whole"))))
+
+      (testing "four cycles, four distinct registrations — no cycle reused a
+                predecessor's, which is what says each reveal genuinely
+                rebuilt the subscription rather than finding one still
+                installed"
+        (is (= 4 (count @!regs)))
+        (is (every? some? @!regs))
+        (is (apply distinct? @!regs)
+            "distinct by identity: a JS object without IEquiv compares
+             `identical?`, so this is the identity statement and not a
+             value one"))
+
+      (exercised! :suspense/repeated-hide-reveal-cycles)
+
+      (.then (inventory/quiesced!)
+             (fn [_]
+               (testing "and the census after four full cycles is the census
+                         after none: exact ownership does not accumulate"
+                 (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                        (inventory/residue))))
+               (done))))))
+
+;; ---------------------------------------------------------------------------
+;; 7. The three lifecycle states, and the one the runtime cannot tell apart
+;;    on its own
+;; ---------------------------------------------------------------------------
+
+(deftest the-three-lifecycle-states-are-distinguishable-and-one-pair-needs-react
+  ;; ASSERTION ONLY. The Xray view is `rf2-hic-023`'s; this row says what
+  ;; that view has to read, and — the part worth writing down — what it
+  ;; cannot read from these tables alone.
+  (async done
+    (seeded!)
+    (let [entry     (render! panel-body)
+          committed (commit! entry)
+          connected (sole-reader [:acs/a])]
+
+      (testing "VISIBLE-CONNECTED — the registration is in its keys' reader
+                lists, its forward edge answers its read set, and the
+                entry it was minted from is CLAIMED"
+        (is (some? connected))
+        (is (= #{(k [:acs/a])} (inventory/boundary-reads connected)))
+        (is (= 1 (entry-refs entry))))
+
+      (hide! committed)
+
+      (testing "HIDDEN-RETAINED — the registration is out of every reader
+                list and the entry's claim is dropped, but the entry
+                OBJECT survives in React's retained fiber, and its
+                `subscribe` is what a reveal calls"
+        (is (= [] (readers [:acs/a])))
+        (is (= 0 (entry-refs entry)))
+        (is (= #{(k [:acs/a])} (inventory/boundary-reads connected))
+            "the released registration still answers its read set — the
+             forward edge is the entry's key set, shared by reference and
+             never cleared, so a projection can still say WHAT a hidden
+             boundary was reading"))
+
+      (let [revealed (commit! entry)]
+        (testing "and the retention is demonstrable rather than assumed:
+                  the SAME entry object re-subscribes, which is the fact
+                  that separates hidden-retained from unmounted"
+          (is (= 1 (entry-refs entry)))
+          (is (not (identical? connected (sole-reader [:acs/a])))))
+        (hide! revealed))
+
+      (exercised! :lifecycle/three-states-distinguished)
+
+      (.then (inventory/quiesced!)
+             (fn [_]
+               (testing "UNMOUNTED — every table is empty, and the entry has
+                         been evicted from the cache"
+                 (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                        (inventory/residue))))
+
+               (testing "THE FINDING, stated where a reader of this file will
+                         meet it. Between the hide above and the quiescence
+                         here, these tables answer the SAME census — zero
+                         memberships, zero boundaries, an unclaimed entry.
+                         The runtime's ownership tables therefore do NOT
+                         distinguish hidden-retained from unmounted, and no
+                         projection over them alone can: the distinguishing
+                         fact is React's retention of the fiber, and the
+                         only evidence of it available here is the
+                         re-subscribe against the same entry object that the
+                         middle section just performed. rf2-hic-023's view
+                         has to take its third state from that transition —
+                         an entry whose refs go 1 → 0 → 1 was hidden; an
+                         entry whose refs go 1 → 0 and is then reaped was
+                         unmounted"
+                 (is (= 0 (entry-refs entry))
+                     "the same number the hidden state answered, which is
+                      the whole of the finding"))
+               (done))))))
+
+;; ---------------------------------------------------------------------------
+;; The roster, asserted rather than described
+;; ---------------------------------------------------------------------------
+
+(deftest the-declared-population-was-actually-exercised
+  ;; Ordered last by `cljs.test`'s declaration order, which is what makes it
+  ;; readable: every row above has run by the time this one does.
+  (is (= declared-population @!exercised)
+      (str "every declared Activity/Suspense transition must be reached at
+            runtime. Missing: "
+           (pr-str (set/difference declared-population @!exercised)))))

--- a/implementation/hicasso/test/re_frame/hicasso/activity_suspense_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/activity_suspense_dom_cljs_test.cljs
@@ -1,0 +1,731 @@
+(ns re-frame.hicasso.activity-suspense-dom-cljs-test
+  "ACTIVITY AND SUSPENSE, UNDER REAL REACT 19.2 (rf2-hic-014).
+
+  [[re-frame.hicasso.activity-suspense-cljs-test]] states the hide/reveal
+  ownership algebra exactly, at the collector's published seam, and runs
+  on every PR. **It cannot say that React hides anything** — it drives the
+  cleanup and the re-subscribe itself. This file is where that claim is
+  made, and it is made the only way it can be: by handing a real
+  `<Activity>` a real `mode` change and reading what the runtime kept.
+
+  ## What React undertakes to do, and what this file therefore reads
+
+  React 19.2's [`<Activity>`](https://react.dev/reference/react/Activity)
+  hides a subtree while retaining its UI state: it cleans up effects and
+  active subscriptions on hide and recreates them on reveal, and hidden
+  children may still render at lower priority.
+  `useSyncExternalStore`'s subscription is one of those effects, so every
+  transition below is React's own — nothing here calls `subscribe`,
+  nothing here calls a cleanup, and nothing here schedules a render.
+
+  Three observables, chosen for three different failure modes.
+
+  **Reader membership** (`inventory/cell-readers`) carries the ownership
+  rows, and it is read by IDENTITY. A leaked predecessor beside a missing
+  successor counts the same as a correct reveal, and both paint the same
+  page: this arm's reads are address-directed, so a revealed boundary
+  renders the right value out of the wrong ownership.
+
+  **Retained host state** — a `useState` counter and its DOM node — is
+  what separates *hidden* from *unmounted*. It is the only observable in
+  the file that React owns rather than this runtime, and it is here
+  because the runtime's own tables cannot make that distinction; the
+  seam file's last row says so in terms.
+
+  **The painted value, read by event-loop POSITION**, carries the
+  correction row. `reincarnation_paint_dom_cljs_test` established the
+  instrument and the reason: design law React 3 requires a render/commit
+  tear to be corrected *before visible paint*, the microtask checkpoint
+  drains in full before the same task's rendering update, and a later
+  task carries no such promise. A duration cannot tell those apart.
+
+  ## The premise is asserted, every time
+
+  A row that asserts \"nothing was acquired\" is worthless if React never
+  rendered anything — the assertion holds for a render that never
+  happened. Every transition below therefore asserts its own premise
+  first: `collector/body-runs` moved, or the DOM changed, or the reader
+  count reached the value the next assertion is about.
+
+  ## The census is taken BEFORE the fixture resets anything
+
+  `mount/release!` resets the runtime, so a residue reading taken after
+  it answers zero whether teardown worked or not (rf2-2rtt6.48). Every
+  row ends with [[teardown-census!]]: unmount, settle at the runtime's
+  own horizon, ASSERT, and only then release.
+
+  ## On the node lane this file states a skip, never a green
+
+  `:node-test` has no DOM. Every row degrades to an explicit skip rather
+  than to an assertion that passes because nothing ran. The real run is
+  `npm run test:browser`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [clojure.set :as set]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]
+            ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]))
+
+(def ^:private frame-id ::activity-suspense-dom)
+
+(rf/reg-sub :acsd/a (fn [db _] (:a db)))
+(rf/reg-sub :acsd/b (fn [db _] (:b db)))
+
+(rf/reg-event :acsd/seed (fn [_ [_ db]] {:db db}))
+(rf/reg-event :acsd/bump (fn [{:keys [db]} [_ key]] {:db (update db key inc)}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; The exercised population — a MEASUREMENT, not a claim
+;; ---------------------------------------------------------------------------
+
+(def ^:private declared-population
+  "The React-driven mechanisms this file undertakes to exercise.
+  [[the-declared-population-was-actually-exercised]] asserts that every
+  one was reached at runtime, so the roster cannot drift into a list of
+  things the suite used to do."
+  #{:activity/hide
+    :activity/hidden-render
+    :activity/reveal
+    :activity/reveal-corrects-a-stale-fiber
+    :suspense/post-commit-fallback-and-retry})
+
+(defonce ^:private !exercised (atom #{}))
+
+(defn- exercised! [mechanism] (swap! !exercised conj mechanism) nil)
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- skip!
+  [why]
+  (is true (str "Activity/Suspense DOM witness needs a real React DOM — " why)))
+
+(defn- seeded!
+  []
+  (support/leave-act-environment!)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [:acsd/seed {:a 1 :b 100}]))
+  frame-id)
+
+(defn- k [query-v] [frame-id query-v])
+
+(def ^:private nothing-owned {:cells 0 :cell-refs 0 :boundaries 0 :edges 0})
+
+(defn- ownership [] (dissoc (inventory/residue) :entries))
+
+(defn- reader-count
+  "How many registrations read `query-v`.
+
+  A COUNT rather than the reader vector: a registration and the cells it
+  acquired hold each other, so `cljs.test`'s failure printer walks a
+  cycle and dies on the vector. The seam file's `reader-count` carries
+  the full note."
+  [query-v]
+  (count (inventory/cell-readers (k query-v))))
+
+(defn- sole-reader
+  [query-v]
+  (let [rs (inventory/cell-readers (k query-v))]
+    (when (= 1 (count rs)) (first rs))))
+
+(defn- poll
+  [pred label]
+  (test-support/poll-until pred {:label label :timeout-ms 4000}))
+
+(defn- mount-concurrent!
+  "A concurrent root, rendered WITHOUT `flushSync`.
+
+  Deliberately not `mount/root!`. That door renders inside `flushSync`
+  because the witnesses it was built for read the DOM on the next line;
+  Activity's reveal and Suspense's retry are React's concurrent business,
+  and a row that forced them sync would be a row about the forced
+  schedule. Every wait below is a poll on the condition instead."
+  [container element]
+  (let [root (react-dom-client/createRoot container)]
+    (.render root element)
+    {:root root :container container :frame frame-id}))
+
+(defn- text [handle] (.-textContent ^js (:container handle)))
+
+(defn- node [handle id] (.querySelector ^js (:container handle) (str "#" id)))
+
+(defn- visible?
+  "Is `id`'s node in the layout? A hidden `<Activity>` keeps its host
+  nodes in the document and takes them out of the layout with
+  `display: none`, so presence in the DOM is NOT visibility and
+  `textContent` still reports hidden text. Every paint reading below is
+  taken through this."
+  [handle id]
+  (when-some [el (node handle id)]
+    (not= "none" (.-display (js/getComputedStyle el)))))
+
+(defn- painted
+  "What the user can see of `id` right now: its text, or nil while it is
+  out of the layout."
+  [handle id]
+  (when (visible? handle id) (.-textContent ^js (node handle id))))
+
+(defn- teardown-census!
+  [handle]
+  (mount/unmount! handle)
+  (.then (inventory/quiesced!)
+         (fn [_]
+           (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                  (inventory/residue))
+               "teardown is exact: zero residue after quiescence")
+           (mount/release! handle)
+           nil)))
+
+(defn- fail-and-finish!
+  [done label handle]
+  (fn [e]
+    (is false (str label " — " (.-message e)
+                   " | DOM was " (pr-str (when handle (text handle)))
+                   " | ownership " (pr-str (ownership))))
+    (when handle (mount/release! handle))
+    (done)))
+
+;; ---------------------------------------------------------------------------
+;; The tree
+;; ---------------------------------------------------------------------------
+
+(h/defview panel
+  "The boundary under Activity. Its read set is a function of a PROP, not
+  of a subscription, and that is deliberate: while the subtree is hidden
+  it holds no subscription, so an app-db change cannot reach it — the
+  only way to move a hidden boundary's read set is for its visible parent
+  to hand it a different prop, which is exactly the case
+  *conditional reads changed while hidden* names."
+  [{:keys [which]}]
+  [:p {:id "panel"}
+   (str (name which) "=" (if (= :a which) (h/sub [:acsd/a]) (h/sub [:acsd/b])))])
+
+(def ^:private !bump-count (atom nil))
+
+(defn- host-state
+  "A plain React `useState` beside the boundary. Its value surviving a
+  hide is React retaining the fiber; its value resetting is React having
+  unmounted the subtree. It is the ONLY thing in this file that separates
+  hidden-retained from unmounted, and it is not this runtime's to
+  provide."
+  [_]
+  (let [[n set-n] (react/useState 0)]
+    (react/useEffect (fn [] (reset! !bump-count #(set-n inc)) js/undefined)
+                     #js [set-n])
+    (react/createElement "span" #js {:id "count"} (str n))))
+
+(unchecked-set host-state "displayName" "acsd/host-state")
+
+(def ^:private !set-mode (atom nil))
+(def ^:private !set-which (atom nil))
+
+(defn- activity-host
+  "Owns the Activity mode and the boundary's prop. Both setters are
+  published from a passive effect, so a row cannot drive the tree before
+  React has mounted it."
+  [_]
+  (let [[mode set-mode]   (react/useState "visible")
+        [which set-which] (react/useState :a)]
+    (react/useEffect (fn []
+                       (reset! !set-mode set-mode)
+                       (reset! !set-which set-which)
+                       js/undefined)
+                     #js [set-mode set-which])
+    (react/createElement
+      (.-Activity react) #js {:mode mode}
+      (react/createElement (.-Fragment react) nil
+                           (codec/root-element frame-id [panel {:which which}])
+                           (react/createElement host-state nil)))))
+
+(unchecked-set activity-host "displayName" "acsd/activity-host")
+
+(defn- activity-tree
+  []
+  (mount/provider frame-id (react/createElement activity-host nil)))
+
+(defn- act!
+  "Drive a React state setter and let its commit land. `flushSync`
+  because the row's next line reads the DOM or the tables; the SCHEDULE
+  under test is Activity's own hide/reveal work, which React performs
+  inside this commit and in the passive phase after it — neither of which
+  a flush invents."
+  [f]
+  (react-dom/flushSync f)
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; 1. The lifecycle: hide releases, hidden work publishes nothing, reveal
+;;    reacquires the CURRENT read set
+;; ---------------------------------------------------------------------------
+
+(deftest an-activity-hide-releases-ownership-and-its-reveal-reacquires-the-current-read-set
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (let [_      (seeded!)
+            handle (mount-concurrent! (mount/fresh-container!) (activity-tree))
+            !state (atom {})]
+        (-> (poll #(and (= 1 (reader-count [:acsd/a])) (some? @!set-mode))
+                  "the visible Activity commits and its boundary subscribes")
+            (.then
+              (fn [_]
+                (testing "VISIBLE-CONNECTED — one reader on the key the body
+                          read, nothing on the key it did not, and the page
+                          shows it"
+                  (is (= "a=1" (painted handle "panel")))
+                  (is (= 1 (reader-count [:acsd/a])))
+                  (is (zero? (reader-count [:acsd/b])))
+                  (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership))))
+
+                (swap! !state assoc :visible-reg (sole-reader [:acsd/a]))
+
+                ;; Move React's own state so the hide has something to
+                ;; retain that is not this runtime's.
+                (act! (fn [] (@!bump-count)))
+                (act! (fn [] (@!bump-count)))
+                (is (= "2" (.-textContent ^js (node handle "count")))
+                    "the premise for retention: React's own state is at 2")
+
+                ;; HIDE. React's cleanup phase runs the subscription
+                ;; teardown; nothing here calls it.
+                (act! (fn [] (@!set-mode "hidden")))
+                (poll #(zero? (reader-count [:acsd/a]))
+                      "React releases the hidden subtree's subscription")))
+            (.then
+              (fn [_]
+                (testing "HIDE releases the committed ownership. React tore
+                          the `useSyncExternalStore` subscription down, so
+                          the reverse edge went with it"
+                  (is (zero? (reader-count [:acsd/a])))
+                  (is (zero? (:cell-refs (ownership))))
+                  (is (zero? (:boundaries (ownership))))
+                  (is (zero? (:edges (ownership)))))
+
+                (testing "WITHOUT destroying anything. React kept the
+                          subtree — its host node is still in the document
+                          and merely out of the layout, and its own state
+                          is where it was. An unmounted subtree would have
+                          neither"
+                  (is (some? (node handle "panel"))
+                      "the node is retained, not removed")
+                  (is (false? (visible? handle "panel"))
+                      "and it is out of the layout, which is what hidden IS")
+                  (is (= "2" (.-textContent ^js (node handle "count")))
+                      "React's own state survived the hide — this is the
+                       observable that separates hidden from unmounted, and
+                       it is React's rather than this runtime's"))
+
+                (testing "and re-frame state is untouched"
+                  (is (= 1 (:a (rf/app-db-value frame-id)))))
+
+                (exercised! :activity/hide)
+
+                ;; A WRITE while hidden, and a PROP change while hidden.
+                ;; The write is what the reveal will have to correct for;
+                ;; the prop change is what moves the hidden read set.
+                (mount/dispatch! handle [:acsd/bump :a])
+                (swap! !state assoc :runs-before (collector/body-runs))
+                (act! (fn [] (@!set-which :b)))
+                (poll #(> (collector/body-runs) (:runs-before @!state))
+                      "React renders the hidden child against its new prop")))
+            (.then
+              (fn [_]
+                (testing "the premise: React really did run the hidden
+                          body. Without this the zeros below are the zeros
+                          of a render that never happened"
+                  (is (pos? (- (collector/body-runs) (:runs-before @!state)))))
+
+                (testing "and the hidden render published nothing — no
+                          durable ownership on the key it just read, none
+                          on the key it stopped reading"
+                  (is (zero? (reader-count [:acsd/b])))
+                  (is (zero? (reader-count [:acsd/a])))
+                  (is (zero? (:cell-refs (ownership))))
+                  (is (zero? (:edges (ownership)))))
+
+                (exercised! :activity/hidden-render)
+
+                ;; REVEAL.
+                (act! (fn [] (@!set-mode "visible")))
+                (poll #(= 1 (reader-count [:acsd/b]))
+                      "React recreates the subscription on reveal")))
+            (.then
+              (fn [_]
+                (let [revealed (sole-reader [:acsd/b])]
+                  (testing "REVEAL reacquires the CURRENT read set. The
+                            prop moved while the subtree was hidden, so
+                            `:acsd/b` is what the body reads now — and
+                            `:acsd/a`, read before the hide and not since,
+                            must be read by nobody"
+                    (is (zero? (reader-count [:acsd/a]))
+                        "no stale membership was resurrected")
+                    (is (= 1 (reader-count [:acsd/b])))
+                    (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1}
+                           (ownership))))
+
+                  (testing "and the survivor is the REVEAL's own
+                            registration. A count cannot make this
+                            statement: a runtime that leaked the
+                            predecessor and failed to acquire for the
+                            successor answers 1 here too"
+                    (is (some? revealed))
+                    (is (false? (identical? (:visible-reg @!state) revealed)))))
+
+                (testing "the revealed subtree is back in the layout, and
+                          React's own state came back with it"
+                  (is (= "b=100" (painted handle "panel")))
+                  (is (= "2" (.-textContent ^js (node handle "count")))))
+
+                (testing "and the revealed boundary is LIVE — a write to
+                          the key it now reads repaints it"
+                  (mount/dispatch! handle [:acsd/bump :b])
+                  (poll #(= "b=101" (painted handle "panel"))
+                        "the revealed boundary repaints"))))
+            (.then
+              (fn [_]
+                (is (= 1 (reader-count [:acsd/b]))
+                    "and the repaint did not add a second reader")
+                (exercised! :activity/reveal)
+                (teardown-census! handle)))
+            (.then (fn [_] (done)))
+            (.catch (fail-and-finish! done "activity lifecycle witness" handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. The reveal corrects a stale fiber, and WHERE in the event loop
+;; ---------------------------------------------------------------------------
+
+(defn- sample-frames!
+  "Record `(painted handle id)` on every animation frame until `done?`
+  holds or the frame budget runs out. Answers a promise of the samples.
+
+  A `requestAnimationFrame` callback runs at the rendering opportunity
+  and before that frame's paint, so what it reads is what the user is
+  about to see. Sampling EVERY frame rather than waiting for one is what
+  makes it an assertion about the whole interval: the question is not
+  *does the corrected value arrive*, it is *was the stale value ever on
+  screen*, and only a sample per frame can answer that."
+  [handle id done?]
+  (let [samples (atom [])]
+    (js/Promise.
+      (fn [resolve]
+        (letfn [(step [n]
+                  (swap! samples conj (painted handle id))
+                  (if (or (done?) (> n 120))
+                    (resolve @samples)
+                    (js/requestAnimationFrame (fn [_] (step (inc n))))))]
+          (js/requestAnimationFrame (fn [_] (step 0))))))))
+
+(deftest the-reveal-corrects-the-stale-fiber-before-the-rendering-opportunity
+  ;; While hidden the boundary holds no subscription, so a write cannot
+  ;; reach it: the fiber goes on holding the value it last rendered. The
+  ;; reveal therefore commits a subtree that is KNOWN stale, and the
+  ;; correction has to arrive before the event loop can paint it — design
+  ;; law React 3, which rf2-2l17 ruled is an ordering and not a duration.
+  ;;
+  ;; **MEASURED, and stronger than the law requires.** The first draft of
+  ;; this row waited for the correction at the microtask checkpoint, the
+  ;; instrument `reincarnation_paint_dom_cljs_test` needs, and
+  ;; `at-the-checkpoint`'s own vacuity guard red it: *the condition
+  ;; already held synchronously, before the checkpoint this row is about*.
+  ;; React 19.2 re-renders the revealed subtree as part of the reveal
+  ;; itself, reading `getSnapshot` during that render — so a flushed
+  ;; reveal is corrected before `flushSync` returns and there is no
+  ;; deferral to position at all. The row asserts that, because asserting
+  ;; a weaker ordering than the runtime actually keeps would stop noticing
+  ;; the day it weakened.
+  ;;
+  ;; Two readings, because the flushed one alone would be a reading of a
+  ;; schedule this file invented. The second reveals CONCURRENTLY and
+  ;; samples every animation frame, so the claim is about the whole
+  ;; interval rather than about one convenient moment in it — **and it is
+  ;; where the gap is.** Reading 2 measured one animation frame showing
+  ;; the pre-hide value: React reveals the retained subtree and corrects
+  ;; it from the passive effect that re-subscribes, and a rendering
+  ;; opportunity can fall between the two. The ceiling assertion at the
+  ;; end of the row carries the analysis and the reason it is React's
+  ;; scheduling rather than this runtime's.
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (let [_      (seeded!)
+            handle (mount-concurrent! (mount/fresh-container!) (activity-tree))]
+        (-> (poll #(and (= 1 (reader-count [:acsd/a])) (some? @!set-mode))
+                  "the visible Activity commits and its boundary subscribes")
+            (.then
+              (fn [_]
+                (is (= "a=1" (painted handle "panel")))
+                (act! (fn [] (@!set-mode "hidden")))
+                (poll #(zero? (reader-count [:acsd/a]))
+                      "React releases the hidden subtree's subscription")))
+            (.then
+              (fn [_]
+                ;; Four writes the hidden subtree cannot hear.
+                (dotimes [_ 4] (mount/dispatch! handle [:acsd/bump :a]))
+
+                (testing "the premise, and it is the whole row: app-db moved
+                          four times while the subtree was hidden, and the
+                          retained fiber still holds the pre-hide value. A
+                          reveal with nothing to correct proves nothing"
+                  (is (= 5 (:a (rf/app-db-value frame-id))))
+                  (is (nil? (painted handle "panel"))
+                      "still out of the layout")
+                  (is (= "a=1" (.-textContent ^js (node handle "panel")))
+                      "and still holding the predecessor's value"))
+
+                ;; READING 1 — the flushed reveal.
+                (act! (fn [] (@!set-mode "visible")))
+
+                (testing "READING 1. The reveal commit has landed and
+                          control has not left this task — no microtask
+                          checkpoint has drained, no later task has run, and
+                          no rendering opportunity has occurred. The subtree
+                          is in the layout and it is CORRECT, so the
+                          correction is inside the reveal's own render
+                          rather than deferred to any position after it"
+                  (is (= "a=5" (painted handle "panel")))
+                  (is (= 1 (reader-count [:acsd/a]))
+                      "holding exactly one reader — the reveal replaced the
+                       released registration, it did not add one"))
+
+                ;; READING 2 — the concurrent reveal, in the browser's own
+                ;; vocabulary. Hide again, move the store again, and let
+                ;; React schedule the reveal itself.
+                (act! (fn [] (@!set-mode "hidden")))
+                (poll #(zero? (reader-count [:acsd/a]))
+                      "React releases the subscription a second time")))
+            (.then
+              (fn [_]
+                (dotimes [_ 3] (mount/dispatch! handle [:acsd/bump :a]))
+                (is (= 8 (:a (rf/app-db-value frame-id))))
+                (is (= "a=5" (.-textContent ^js (node handle "panel")))
+                    "the premise for reading 2: stale again, by three")
+                ;; NO flushSync. React owns the schedule from here.
+                (@!set-mode "visible")
+                (sample-frames! handle "panel" #(= "a=8" (painted handle "panel")))))
+            (.then
+              (fn [samples]
+                (let [visible-samples (remove nil? samples)
+                      stale-frames    (count (take-while #(not= "a=8" %)
+                                                         visible-samples))]
+                  (testing "the premise: the subtree came back into the
+                            layout, so there were frames to judge, and it
+                            settled corrected"
+                    (is (seq visible-samples))
+                    (is (= "a=8" (last visible-samples))))
+
+                  (testing "nothing but the two legitimate values was ever on
+                            screen. Every frame showed either the value the
+                            retained fiber held or the corrected one — never
+                            a third state, never a torn one, never a value
+                            from a key this body does not read"
+                    (is (every? #{"a=5" "a=8"} visible-samples)
+                        (str "samples were " (pr-str (vec (take 10 samples))))))
+
+                  ;; THE CEILING, and the finding it records.
+                  ;;
+                  ;; Reading 1 shows the reveal corrected before control
+                  ;; left the task. This reading shows that is a property of
+                  ;; the FLUSH and not of the reveal: scheduled
+                  ;; concurrently, React reveals the retained subtree with
+                  ;; the value its fiber held and corrects it from the
+                  ;; passive effect that re-subscribes — and React flushes
+                  ;; passive effects in a scheduler TASK, so a rendering
+                  ;; opportunity can fall between the two. Measured here:
+                  ;; one animation frame showed `a=5` while app-db held 8.
+                  ;;
+                  ;; It is React's scheduling rather than this runtime's:
+                  ;; the only signal that the store moved arrives when React
+                  ;; re-subscribes, and React re-subscribes in a passive
+                  ;; effect. There is no earlier hook to hoist the
+                  ;; correction into, and `invalidate-cell!`'s microtask —
+                  ;; the repair rf2-2l17 made for the reincarnation tear —
+                  ;; is not reachable here because no cell was retired.
+                  ;;
+                  ;; A discrete event does not have the gap: React flushes
+                  ;; passive effects at the end of the event, which is what
+                  ;; reading 1 stands in for, so a user revealing a hidden
+                  ;; tab by clicking paints nothing stale. The exposure is a
+                  ;; reveal scheduled from a timer, a promise or a
+                  ;; transition.
+                  ;;
+                  ;; A CEILING rather than an enshrinement: it reds if the
+                  ;; gap ever widens, and stays green if it is ever closed.
+                  (testing "and the concurrent reveal's stale window is at
+                            most one frame wide"
+                    (is (>= 1 stale-frames)
+                        (str "the revealed subtree showed the pre-hide value "
+                             "for " stale-frames " animation frames. One is "
+                             "the measured cost of React flushing the "
+                             "re-subscribe as a passive effect; more than "
+                             "one means the correction has slipped further "
+                             "from the reveal."))))
+                (exercised! :activity/reveal-corrects-a-stale-fiber)
+                (teardown-census! handle)))
+            (.then (fn [_] (done)))
+            (.catch (fail-and-finish! done "reveal paint-order witness" handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. Suspense — a POST-COMMIT suspension hides the committed tree
+;; ---------------------------------------------------------------------------
+
+(def ^:private !gate-resolve (atom nil))
+(def ^:private !gate-promise (atom nil))
+(def ^:private !set-gate (atom nil))
+
+(defn- gate
+  "Throws a thenable while closed. Everything after the release is
+  React's own retry machinery — nothing here schedules, re-renders or
+  commits anything."
+  [_]
+  (let [[closed? set-closed] (react/useState false)]
+    (react/useEffect (fn [] (reset! !set-gate set-closed) js/undefined)
+                     #js [set-closed])
+    (when closed? (throw @!gate-promise))
+    nil))
+
+(unchecked-set gate "displayName" "acsd/gate")
+
+(defn- suspense-tree
+  []
+  (react/createElement
+    (.-Suspense react) #js {:fallback (react/createElement "p" #js {:id "fb"} "waiting")}
+    (react/createElement (.-Fragment react) nil
+                         (mount/provider frame-id
+                                         (codec/root-element frame-id [panel {:which :a}]))
+                         (react/createElement gate nil))))
+
+(deftest a-post-commit-suspension-retains-the-subscription-and-the-retry-leaves-exact-ownership
+  ;; The Suspense half of the bead, and the half NOT already covered by
+  ;; `kernel_commit_owns_dom_cljs_test`. That file suspends BEFORE the
+  ;; commit, so its boundary never owned anything. Here the boundary is
+  ;; committed and live first and the suspension arrives afterwards.
+  ;;
+  ;; **A SUSPENSE FALLBACK IS NOT AN ACTIVITY HIDE, and this row is where
+  ;; that was measured rather than assumed.** It was written expecting the
+  ;; release the Activity rows above assert — the two look like the same
+  ;; Offscreen mechanism, and the primary tree is hidden the same way,
+  ;; `display: none` with its host nodes retained. React 19.2 does not
+  ;; treat them the same: hiding for a fallback leaves the primary tree's
+  ;; PASSIVE effects mounted, so the `useSyncExternalStore` subscription
+  ;; survives, and `<Activity mode="hidden">` destroys them, so it does
+  ;; not. Measured here, on the run this row failed: one reader throughout
+  ;; the suspension, and the retry's reader `identical?` to the first.
+  ;;
+  ;; That difference is a fact rf2-hic-023's lifecycle view has to carry:
+  ;; a Suspense-hidden subtree is VISIBLE-CONNECTED in this runtime's
+  ;; tables while being invisible on screen, and an Activity-hidden one is
+  ;; not. Collapsing them would label a live subscription as released.
+  ;;
+  ;; So the conduct owed is not "release then reacquire" — it is EXACT
+  ;; OWNERSHIP across the cycle: the count never leaves 1, the identity
+  ;; never changes, and the retry adds nothing. That is what is asserted.
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (let [_       (seeded!)
+            _       (reset! !gate-promise (js/Promise. (fn [res] (reset! !gate-resolve res))))
+            handle  (mount-concurrent! (mount/fresh-container!) (suspense-tree))
+            !state  (atom {})]
+        (-> (poll #(and (= 1 (reader-count [:acsd/a])) (some? @!set-gate))
+                  "the primary tree commits and its boundary subscribes")
+            (.then
+              (fn [_]
+                (testing "the premise: the boundary is committed, live and
+                          owning its read set BEFORE anything suspends —
+                          which is what makes this a post-commit suspension
+                          rather than the pre-commit one the commit-owns
+                          suite already covers"
+                  (is (= "a=1" (painted handle "panel")))
+                  (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership))))
+
+                (swap! !state assoc :first-reg (sole-reader [:acsd/a]))
+
+                ;; A sibling suspends AFTER the commit. React hides the
+                ;; primary children and shows the fallback.
+                (act! (fn [] (@!set-gate true)))
+                (poll #(= "waiting" (painted handle "fb"))
+                      "the fallback takes the layout")))
+            (.then
+              (fn [_]
+                (testing "React hid the committed primary tree rather than
+                          unmounting it — the boundary's node is still in
+                          the document and out of the layout"
+                  (is (some? (node handle "panel")))
+                  (is (false? (visible? handle "panel"))))
+
+                (testing "but hiding it for a FALLBACK does not release its
+                          ownership — the measurement this row exists to
+                          record. The subscription is still installed, and
+                          it is still the SAME registration, so the runtime
+                          regards the suspended subtree as connected"
+                  (is (= 1 (reader-count [:acsd/a])))
+                  (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership)))
+                  (is (true? (identical? (:first-reg @!state)
+                                         (sole-reader [:acsd/a])))
+                      "the same registration, not a rebuilt one"))
+
+                ;; A write DURING the suspension. Because the subscription
+                ;; survived, the hidden primary tree hears it.
+                (mount/dispatch! handle [:acsd/bump :a])
+
+                ;; The retry.
+                (act! (fn [] (@!set-gate false)))
+                (poll #(= "a=2" (painted handle "panel"))
+                      "the retry reveals the primary tree, up to date")))
+            (.then
+              (fn [_]
+                (testing "the retry leaves EXACT ownership. The cycle
+                          neither released nor re-acquired, so the count is
+                          where it started and so is the identity — and a
+                          suspend/retry that had quietly re-subscribed
+                          without releasing would show here as two"
+                  (is (= 1 (reader-count [:acsd/a])))
+                  (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership)))
+                  (is (true? (identical? (:first-reg @!state)
+                                         (sole-reader [:acsd/a])))))
+
+                (testing "and the revealed tree is up to date without a
+                          correction having been needed: it heard the write
+                          while it was hidden, which is exactly what an
+                          Activity-hidden subtree cannot do"
+                  (is (= "a=2" (painted handle "panel"))))
+
+                (testing "still live after the retry"
+                  (mount/dispatch! handle [:acsd/bump :a])
+                  (poll #(= "a=3" (painted handle "panel"))
+                        "the retried boundary repaints"))))
+            (.then
+              (fn [_]
+                (is (= 1 (reader-count [:acsd/a])))
+                (exercised! :suspense/post-commit-fallback-and-retry)
+                (teardown-census! handle)))
+            (.then (fn [_] (done)))
+            (.catch (fail-and-finish! done "post-commit suspension witness" handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; The roster, asserted rather than described
+;; ---------------------------------------------------------------------------
+
+(deftest the-declared-population-was-actually-exercised
+  (if-not (mount/browser?)
+    (skip! ":node-test runs none of the mechanisms above")
+    (is (= declared-population @!exercised)
+        (str "every declared Activity/Suspense mechanism must be reached at
+              runtime. Missing: "
+             (pr-str (set/difference declared-population @!exercised))))))

--- a/implementation/hicasso/test/re_frame/hicasso/activity_suspense_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/activity_suspense_dom_cljs_test.cljs
@@ -125,9 +125,11 @@
 
 (defn- k [query-v] [frame-id query-v])
 
-(def ^:private nothing-owned {:cells 0 :cell-refs 0 :boundaries 0 :edges 0})
-
-(defn- ownership [] (dissoc (inventory/residue) :entries))
+(defn- ownership
+  "The census with the entry cache projected out. A read-set entry is a
+  render-phase cache, not ownership."
+  []
+  (dissoc (inventory/residue) :entries))
 
 (defn- reader-count
   "How many registrations read `query-v`.


### PR DESCRIPTION
# Activity hide/reveal and Suspense ownership (rf2-hic-014)

Two new witness files and no runtime change. The Activity matrix from
`docs/design/hicasso/product/lanes/react-compatibility-notes.md` §*Activity
lifecycle witness*, stated at the collector's published seam on the lane that
runs every PR, and driven by real React 19.2 on the browser lane.

- `implementation/hicasso/test/re_frame/hicasso/activity_suspense_cljs_test.cljs`
  — 11 rows, node lane.
- `implementation/hicasso/test/re_frame/hicasso/activity_suspense_dom_cljs_test.cljs`
  — 4 rows, browser lane.

**No collector change was needed, and that is a result rather than an
omission.** Every clause of the matrix already holds: hide releases through the
cleanup `commit-boundary!` hands back, hidden renders publish nothing because
the only global write is inside `subscribe`, and reveal reacquires the current
render's entry. The one place the runtime could have been asked to do better —
the reveal's correction ordering — turns out to be React's passive-effect
scheduling and not reachable from here; the analysis is in the paint row and
summarised below.

## The matrix

| row | what it asserts |
|---|---|
| `hide-releases-committed-ownership-and-leaves-re-frame-state-standing` | the cleanup drops every membership; the frame is the same incarnation, its app-db is intact, and a write *after* the hide still lands in it |
| `a-hide-landing-inside-a-deferred-notification-window-is-not-notified` | a hide arriving between `flush!` collecting the readers and notifying them delivers nothing |
| `a-hidden-render-publishes-no-read-set` | three hidden body runs, premise asserted, zero memberships and zero claimed entries |
| `reveal-reacquires-and-the-surviving-registration-is-the-reveals-own` | the survivor is the reveal's registration **by identity**, and the pre-hide one is nowhere |
| `a-conditional-read-changed-while-hidden-does-not-resurrect-stale-membership` | the dropped key ends with no reader; the current pair is held by one registration |
| `NEGATIVE-CONTROL-skipping-the-release-on-hide-…` | the bead's own named sabotage, as a row: same helper, one call removed |
| `NEGATIVE-CONTROL-a-reveal-that-reuses-the-pre-hide-read-set-…` | the reveal-side twin: a stale effect reacquires the wrong key and leaves the current one owned by nobody |
| `an-intent-retained-across-a-hidden-window-obeys-the-incarnation-rule` | safety and liveness of the rf2-hic-013 rule across the hidden window, refusal asserted as a map |
| `repeated-suspend-retry-cycles-leave-exactly-one-commits-ownership` | four cycles, four distinct registration identities, and a census after four equal to the census after none |
| `the-three-lifecycle-states-are-distinguishable-and-one-pair-needs-react` | visible-connected / hidden-retained / unmounted, and the finding below |
| `an-activity-hide-releases-ownership-and-its-reveal-reacquires-…` (DOM) | the whole lifecycle under a real `<Activity>` mode change, including React's own retained `useState` surviving the hide |
| `the-reveal-corrects-the-stale-fiber-before-the-rendering-opportunity` (DOM) | two readings — flushed and concurrent — of the correction's event-loop position |
| `a-post-commit-suspension-retains-the-subscription-and-the-retry-leaves-exact-ownership` (DOM) | exact ownership across a suspend/retry cycle through a host boundary |
| `the-declared-population-was-actually-exercised` (both) | the roster, asserted rather than described |

## Three findings

**1. A Suspense fallback is not an Activity hide.** The Suspense row was written
expecting the release the Activity rows assert — the two look like one Offscreen
mechanism and hide the primary tree identically, `display: none` with host nodes
retained. React 19.2 does not treat them the same: hiding for a fallback leaves
the primary tree's *passive* effects mounted, so the `useSyncExternalStore`
subscription survives and the retry's reader is `identical?` to the first;
`<Activity mode="hidden">` destroys them, so it does not. The conduct owed is
therefore exact ownership across the cycle rather than release-then-reacquire,
and that is what the row now asserts. **rf2-hic-023's lifecycle view has to
carry this**: a Suspense-hidden subtree is *visible-connected* in these tables
while being invisible on screen, and collapsing the two would label a live
subscription as released.

**2. The reveal's correction is bounded by React's passive flush, and a
concurrent reveal paints one stale frame.** The first draft of the paint row
waited at the microtask checkpoint — `rf2-2l17`'s instrument — and
`at-the-checkpoint`'s own vacuity guard red it: a *flushed* reveal is already
corrected before `flushSync` returns, which is stronger than design law React 3
requires. So the row takes a second reading, revealing concurrently and sampling
every animation frame. That reading found one frame showing the pre-hide value
while app-db had moved three times.

It is React's scheduling rather than this runtime's. While hidden the boundary
holds no subscription, so the only signal that the store moved arrives when
React re-subscribes — and React re-subscribes in a *passive* effect, which it
flushes in a scheduler task, so a rendering opportunity can fall between the
reveal commit and the correction. There is no earlier hook to hoist it into, and
`invalidate-cell!`'s microtask (the rf2-2l17 repair) is not reachable here
because no cell was retired. A **discrete event has no gap** — React flushes
passive effects at the end of the event — so a user revealing a hidden tab by
clicking paints nothing stale; the exposure is a reveal scheduled from a timer,
a promise or a transition. The row asserts a **ceiling of one stale frame**: it
reds if the gap widens and stays green if it is ever closed.

**3. The ownership tables collapse hidden-retained into unmounted.** Between an
Activity hide and quiescence they answer the same census — zero memberships,
zero boundaries, an unclaimed entry. No projection over them alone can separate
the two states. The distinguishing fact is React's retention of the fiber, and
the only evidence of it available at the seam is a re-subscribe against the
*same entry object*: refs going `1 → 0 → 1` is a hide, `1 → 0` then reaped is an
unmount. The DOM file adds the other half — a retained `useState` and its
surviving host node — which is React's observable and not this runtime's. Stated
in the last row of each file, assertion only; the view is rf2-hic-023's.

## Witness discipline

Four runtime perturbations, each restored and each verified by
`git diff --stat` afterwards. Every red is legible — see below.

| perturbation | reds |
|---|---|
| `unsubscribe` does not `release-cell!` | node: 32 assertions across 7 rows. browser: all 4 rows, including the roster catching that three mechanisms were never reached |
| `unsubscribe` does not clear `.-notify` | exactly one row: the deferred-notification window |
| `render-body` acquires its read set | the hidden-render row, at 4 readers where 0 is asserted |
| `frames/mint-row` re-resolves the address at fire time (pre-rf2-x874) | the retained-intent row, reproducing the silent successor-write: `:marked` became `:retained` in the successor's app-db with **zero** refusals |

Two things the perturbations found that reading the file would not have:

**The reds were unreadable.** A registration holds the cells it acquired and
each of those holds the registration back, so the graph is cyclic — and
`cljs.test` reports a failing predicate's *evaluated arguments*. Every
`(= [] (readers …))` red arrived as `RangeError: Maximum call stack size
exceeded`, naming nothing. Assertions now take the count, and positive identity
claims are spelled `(is (true? (identical? a b)))` so the report is
`(not (true? false))`. The same sabotage now reds 32 assertions with zero errors.

**One mechanism had no witness.** Deleting `unsubscribe`'s notifier clear red
nothing, and deleting its membership release red nothing that depended on
deafness: on the synchronous path each alone is sufficient, so no single-fault
perturbation could make a hidden boundary audible. `flush!` defers a
notification taken during a render and reads the reader lists *before*
deferring, so in that window the release has already happened and cannot help
and the nil notifier is the whole of the guard. That window is now a row, and it
is the only row the notifier-clear sabotage reds.

## Quality gates

Run one at a time, in the foreground, exit code captured to its own file. Every
gate printed `gate root: /c/Users/miket/code/re-frame2-worktrees/activity-hic014`.

| gate | exit |
|---|---|
| `sh scripts/test-fast-pr.sh` | **0** |
| `cd implementation && npm run test:cljs` (inside the spine) | **0** — 12938 tests, 65250 assertions |
| `cd implementation && npm run test:browser` (full Playwright lane) | **0** — 1162 tests, 7211 assertions |
| `cd implementation && npm run test:hicasso-freeze` | **0** (self-test + real run) |

Focused runs, to prove these namespaces ran rather than were merely compiled:

- `re-frame.hicasso.activity-suspense-cljs-test` alone: **11 tests, 89
  assertions, 0 failures** — matching its 11 `deftest` forms.
- `re-frame.hicasso.activity-suspense-dom-cljs-test` alone in Chromium: **4
  tests, 54 assertions, 0 failures**, repeated four times with identical
  counts (the animation-frame sampling row is not flaky).

Required CI checks this spine does **not** decide: 93, per
`python scripts/check_fast_pr_gap.py --list`.

`implementation/shadow-cljs.edn` and `implementation/deps.edn` are untouched —
`hicasso/test` is already on the `:node-test` source paths and `:browser-test`
already selects `-dom-cljs-test$`, so both files are scheduled by the arms
rf2-8a6s added without any build-config edit.

No `tools/xray/` change: this bead's Xray deliverable is assertion only and the
view lands in rf2-hic-023, so `tools/xray/spec/*` is unchanged because this PR
touches no Xray surface.
