### PR TITLE
feat(hicasso): the ruled lint roster, and the fixture witness now runs in CI (rf2-hic-022)

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -49,6 +49,9 @@
  {re-frame.hicasso.read-extent-cljs-test
   {:linters {:re-frame.hicasso/deferred-read {:level :off}}}
 
+  re-frame.hicasso.read-extent-dom-cljs-test
+  {:linters {:re-frame.hicasso/deferred-read {:level :off}}}
+
   re-frame.hicasso.error-shape-cljs-test
   {:linters {:re-frame.hicasso/function-in-head-position {:level :off}}}}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -294,6 +294,25 @@ jobs:
             --lint tools/template/src \
             --lint tools/template/test
 
+      # THE FIXTURE WITNESS FOR HICASSO'S LINT EXPORT (rf2-hic-022).
+      #
+      # The step above loads that export's hooks against current repository
+      # code, which proves they LOAD and stay quiet. It cannot prove they still
+      # CATCH: every check could stop firing and this job would stay green,
+      # because silence is what it is looking for. That is a gate reporting
+      # success over a case it never exercises — the defect class this repo
+      # keeps finding in its own instruments — so the positive fixtures have to
+      # execute somewhere required, and this is the only required job that
+      # already has clj-kondo installed at the pin.
+      #
+      # It costs about a second: pure Python driving the binary above over two
+      # fixture files. No JDK, no Node modules, no shadow-cljs. `--self-test`
+      # runs first and mutates the shipped hook three ways to prove the gate's
+      # RED, restoring each in a `finally`; then the gate itself runs.
+      - name: Hicasso lint export — fixture witness
+        working-directory: implementation
+        run: npm run test:hicasso-lint
+
   splint:
     name: Splint (fail on errors, warnings informational)
     needs: detect

--- a/implementation/hicasso/lint-fixtures/negative.cljs
+++ b/implementation/hicasso/lint-fixtures/negative.cljs
@@ -10,39 +10,25 @@
   body rather than after it, the mapped child that carries its `:key`, the
   button named four different legal ways, the head that is an ordinary view.
 
-  Several forms here are silent because the check DECLINED to guess — a `:&`
-  whose value is an expression, a `for` whose body is a call. That silence
-  is the design, not a gap: see the export's README for what each check
-  refuses to know."
+  Several forms here are silent because the check DECLINED to guess — a
+  `for` whose body is a call, an element whose props are a symbol. That
+  silence is the design, not a gap: see the export's README for what each
+  check refuses to know."
   (:require [re-frame.hicasso :as h]))
 
 (declare row-view sanitize icon-node props)
 
 ;; ---------------------------------------------------------------------------
-;; merge-not-a-map — a map literal is right, and an expression is unknowable
-;; ---------------------------------------------------------------------------
-
-(h/defview merge-carrying-a-map-literal [_]
-  [:div {:& {:class "caller" :data-x 1}} "x"])
-
-(h/defview merge-carrying-an-expression [{:keys [attrs]}]
-  [:div {:& attrs}
-   [:span {:& (merge attrs {:class "y"})} "x"]])
-
-(h/defview merge-carrying-nil [_]
-  [:div {:& nil} "x"])
-
-;; ---------------------------------------------------------------------------
-;; An EVENT VECTOR is not an element. `[:a]` at `:on-click` and the anchor
-;; `[:a]` are the same three characters; only position tells them apart, so
-;; no element check looks inside a props map.
+;; An EVENT VECTOR is not an element. `[:button]` at a prop and the element
+;; `[:button]` are the same characters; only POSITION tells them apart, so no
+;; element check looks inside a props map.
 ;; ---------------------------------------------------------------------------
 
 (h/defview event-vectors-that-look-like-elements [_]
   [:div
+   [:span {:on-mouse-enter [:button]} "hover"]
    [:button {:on-click [:a]} "Save"]
-   [:button {:on-click [:a :with :args]} "Save with args"]
-   [:span {:on-mouse-enter [:button]} "hover"]])
+   [:button {:on-click [:a :with :args]} "Save with args"]])
 
 ;; ---------------------------------------------------------------------------
 ;; deferred-read — a read inside a fn literal that runs DURING the body
@@ -162,19 +148,18 @@
   (let [handlers [(fn [] :a) (fn [] :b)]]
     [:div (str (count handlers))]))
 
+
 ;; ---------------------------------------------------------------------------
-;; A QUALIFIED keyword head is tagged data, not a tag. `[:app/button …]` is
-;; not a `<button>`, and reading a base tag out of one would invent an
-;; element wherever an app spells its own data that way.
+;; A qualified keyword IS a tag -- the runtime reads it through `name` -- so
+;; these are ordinary non-interactive elements rather than exemptions.
 ;; ---------------------------------------------------------------------------
 
 (h/defview qualified-keyword-heads [{:keys [rows]}]
   [:div
-   (str [:app/button {:id 1}])
-   (str (for [r rows] [:app/row r]))
-   (str [:app/a {:href "/x"}])])
+   [:app/row {:id 1}]
+   (for [r rows] [:app/cell {:key (:id r)} r])])
 
 ;; Quoted hiccup is data an author wrote down, not hiccup the runtime will
 ;; interpret, so nothing judges inside a quotation.
 (h/defview quoted-hiccup [_]
-  [:div (str '[:button {:& [:not :a :map]}])])
+  [:div (str '[(fn [] :a) "quoted, so never interpreted"])])

--- a/implementation/hicasso/lint-fixtures/negative.cljs
+++ b/implementation/hicasso/lint-fixtures/negative.cljs
@@ -134,7 +134,12 @@
    [:button {:on-click [:d]} icon-node]
    ;; Dynamic props: the name may be in there.
    [:button props]
-   [:a {:href "/help"} "Help"]])
+   [:a {:href "/help"} "Help"]
+   ;; An <a> with NO href is not a link and not focusable, so it needs no
+   ;; accessible name. The tag set and this condition are the compiled
+   ;; substrates' (`re-frame.ui.compiler.a11y`), not invented here.
+   [:a {:name "section-3"}]
+   [:a {:class "anchor-target"}]])
 
 ;; ---------------------------------------------------------------------------
 ;; function-in-head-position — ordinary heads, and fn literals at PROP

--- a/implementation/hicasso/lint-fixtures/positive.cljs
+++ b/implementation/hicasso/lint-fixtures/positive.cljs
@@ -16,17 +16,13 @@
   (:require [re-frame.hicasso :as h]))
 
 ;; ---------------------------------------------------------------------------
-;; :re-frame.hicasso/merge-not-a-map — `:&` carrying a literal non-map
+;; :re-frame.hicasso/direct-view-call -- a view called like a function
 ;; ---------------------------------------------------------------------------
 
-(h/defview merge-carrying-a-vector [_]
-  [:div {:& [:a :b]} "x"])
-
-(h/defview merge-carrying-a-string [_]
-  [:div {:& "class-string"} "x"])
-
-(h/defview merge-carrying-a-keyword [_]
-  [:input {:& :caller}])
+(h/defview self-calling-view [{:keys [depth]}]
+  (if (zero? depth)
+    [:li "leaf"]
+    [:ul (self-calling-view {:depth (dec depth)})]))
 
 ;; ---------------------------------------------------------------------------
 ;; :re-frame.hicasso/deferred-read — a read inside the one callback form
@@ -41,6 +37,11 @@
                         (let [{:keys [id]} (h/use-subs {:id [:todo/current]})]
                           [:todo/toggle id]))}
    "toggle"])
+
+;; A plain fn literal that nothing here calls during the body -- roster item 3.
+(h/defview read-in-a-deferred-fn [_]
+  (js/setTimeout (fn [] (h/sub [:todo/current])) 100)
+  [:div "later"])
 
 ;; ---------------------------------------------------------------------------
 ;; :re-frame.hicasso/parked-read — a read parked in a mutable reference
@@ -102,3 +103,24 @@
 
 (h/defview callback-form-in-head [_]
   [:div [(h/hfn [_e] [:noop])]])
+
+;; The RETURNED ROOT vector is itself the illegal head -- the children-position
+;; rule cannot see this one (merged-PR audit #7784).
+(h/defview fn-literal-at-the-root [_]
+  [(fn [] [:span "hi"])])
+
+(h/defview fn-literal-at-the-root-through-a-let [{:keys [x]}]
+  (let [y (inc x)]
+    [(fn [] [:span y])]))
+
+;; ---------------------------------------------------------------------------
+;; A STRING head and a QUALIFIED-KEYWORD head are both native tags: the runtime
+;; accepts them (`codec/hiccup-tag?`) and reads them through `name`, so these
+;; really are nameless <button>s (merged-PR audit #7784).
+;; ---------------------------------------------------------------------------
+
+(h/defview nameless-string-head-button [_]
+  [:div ["button" {:on-click [:panel/close]}]])
+
+(h/defview nameless-qualified-keyword-button [_]
+  [:div [:app/button {:on-click [:panel/close]}]])

--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/README.md
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/README.md
@@ -116,14 +116,22 @@ not at a fixed position.
 
 ### `:re-frame.hicasso/nameless-interactive-element` — warning
 
-`[:button {…}]` or `[:a {…}]` with **no children at all** and none of
-`:aria-label`, `:aria-labelledby` or `:title`. Such an element has no
-accessible name and a screen reader announces it as an unlabelled control.
+`[:button {…}]`, or `[:a {…}]` **that carries an `href`**, with **no children
+at all** and none of `:aria-label`, `:aria-labelledby` or `:title`. Such an
+element has no accessible name and a screen reader announces it as an
+unlabelled control.
+
+The tag set and the `href` condition are taken from this project's compiled
+substrates rather than invented here — `re-frame.ui.compiler.a11y`'s
+`:rf.ui.compile/a11y-missing-accessible-name` names a `<button>` always and an
+`<a>` only when it is a real link — so the two agree about what a nameless
+control is. An `<a>` without `href` is not focusable and not a link.
 
 **Refuses to know:** what any child renders. One child of any kind — even a
 symbol that turns out to be an icon with no text — makes this silent, because
 it may well render text. Dynamic props answer the same way: the name may be in
-there. `:input` is deliberately absent: its name usually comes from a sibling
+there. `:input`, `:select` and `:textarea` are in that compiler pass's set and
+deliberately absent here: their name usually comes from a sibling
 `<label for=…>`, which is a fact about the tree rather than about the element.
 The real accessibility pass is a separate piece of work; this is one always-
 right corner of it.

--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/config.edn
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/config.edn
@@ -10,27 +10,32 @@
 ;; for what each check knows, and — the more useful half — what it refuses to
 ;; know.
 ;;
-;; LEVELS. The three errors are forms the RUNTIME already refuses, so lint is
-;; only telling the author sooner: a `:&` that cannot merge, a read in the one
-;; position that is deferred by construction, and a function where a head
-;; belongs. The three warnings are advice: two are correctness heuristics that
-;; a reader might have meant, and one (`parked-read`) is conduct the project
-;; has explicitly declined to enforce (rf2-djxr). Every level is a consumer's
-;; to change, and turning one off is a supported answer.
+;; SEVERITY LAW (operator ruling, rf2-hic-022, 2026-08-10): ERRORS only for
+;; TRUE INVARIANTS; WARNINGS for heuristics; nothing blocks a build.
+;; Assistance, not enforcement.
+;;
+;; So two errors, and they are the two forms that are wrong under every
+;; circumstance and that the runtime itself refuses: a view called like a
+;; function, and a function where a hiccup head belongs. The rest are advice,
+;; and a warning cannot red the repo's own gate either — `clj-kondo` runs
+;; `--fail-level error`, so items 3-5 are advisory by construction.
+;;
+;; The `:&`-carrying-a-non-map check was here and is GONE: the `:&` grammar key
+;; is retired from the end-state design in favour of the owned-wins merge
+;; recipe, and a lint layer must not police a ghost.
+;;
+;; Every level is a consumer's to change, and turning one off is a supported
+;; answer:
+;;
+;;   {:linters {:re-frame.hicasso/unkeyed-mapped-child {:level :off}}}
 {:linters
- {:re-frame.hicasso/merge-not-a-map              {:level :error}
-  :re-frame.hicasso/deferred-read                {:level :error}
-  :re-frame.hicasso/function-in-head-position    {:level :error}
-  :re-frame.hicasso/parked-read                  {:level :warning}
-  :re-frame.hicasso/unkeyed-mapped-child         {:level :warning}
-  :re-frame.hicasso/nameless-interactive-element {:level :warning}}
+ {:re-frame.hicasso/direct-view-call               {:level :error}
+  :re-frame.hicasso/function-in-head-position      {:level :error}
+  :re-frame.hicasso/deferred-read                  {:level :warning}
+  :re-frame.hicasso/unkeyed-mapped-child           {:level :warning}
+  :re-frame.hicasso/nameless-interactive-element   {:level :warning}
+  :re-frame.hicasso/parked-read                    {:level :warning}}
 
- ;; `defview`, `hfn` and `defhost` are `defn`-, `fn`- and `def`-shaped. The
- ;; hooks rewrite them so kondo's own arglist / arity / lexical-binding
- ;; analysis applies, which is what stops a view's name and every destructured
- ;; prop reading as `Unresolved symbol`. `:lint-as` cannot do this job for
- ;; `defview` — the checks need the body — and would be a second, divergent
- ;; description of the same three shapes if it did half of it.
  :hooks
  {:analyze-call
   {re-frame.hicasso/defview hooks.re-frame.hicasso/defview

--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj
@@ -108,28 +108,41 @@
   (let [v (first (scalar node))]
     (when (keyword? v) v)))
 
+(defn- native-tag
+  "The tag a node names when it is a LITERAL native head, else nil.
+
+  Taken from the runtime rather than guessed: `codec/hiccup-tag?` is
+  `(or (keyword? head) (symbol? head) (string? head))` and `parse-tag`
+  reads it through `name`. So a STRING head is a tag, and a QUALIFIED
+  keyword is one too — `[:app/button …]` renders a `<button>`, because
+  `(name :app/button)` is \"button\". An earlier draft of this file claimed
+  the opposite and was simply wrong about shipped behaviour.
+
+  Only a literal answers. A symbol head is a runtime VALUE — a view or a
+  host — and is not decidable here."
+  [node]
+  (let [v (first (scalar node))]
+    (cond
+      (keyword? v) (name v)
+      (string? v)  v
+      :else        nil)))
+
 (defn- hiccup-vector?
-  "Is this node a vector whose head is a LITERAL keyword — `[:div …]`,
-  `[:button.icon …]`, `[:<> …]`, `[:> Foo …]`?
+  "Is this node a vector whose head is a literal native tag — `[:div …]`,
+  `[:button.icon …]`, `[\"button\" …]`, `[:app/button …]`, `[:<> …]`?
 
-  A keyword head is what makes a vector unambiguously hiccup. A SYMBOL
-  head — a view, a host, or an ordinary two-element data vector — is not
-  decidable here, so nothing below judges one.
-
-  The head must be UNQUALIFIED. A hiccup tag never carries a namespace, and
-  a qualified keyword at the head of a vector is ordinary tagged data —
-  `[:app/button 1]` is not a `<button>`, and `base-tag` would happily read
-  one out of it."
+  A literal head is what makes a vector decidably hiccup. A SYMBOL head (a
+  view or a host) is a value this cannot resolve, so nothing below judges
+  one."
   [node]
   (boolean (and (api/vector-node? node)
-                (when-let [kw (tag-keyword (first (:children node)))]
-                  (nil? (namespace kw))))))
+                (native-tag (first (:children node))))))
 
 (defn- base-tag
-  "`:button.icon#close` -> \"button\". The selector shorthand is sugar for
-  attributes and never changes which element is being written."
-  [kw]
-  (first (str/split (name kw) #"[.#]")))
+  "`\"button.icon#close\"` -> `\"button\"`. The selector shorthand is sugar
+  for attributes and never changes which element is being written."
+  [tag]
+  (first (str/split tag #"[.#]")))
 
 (defn- props-node
   "The props map a hiccup vector writes, or nil when it writes none.
@@ -195,44 +208,6 @@
   [node type message]
   (api/reg-finding! (assoc (meta node) :type type :message message)))
 
-;; --- `:&` carries a caller's attribute map and nothing else ----------------
-
-(defn- merge-value-problem
-  "A one-word description of what `:&` was literally given, when that is a
-  literal of a type it can never accept; nil otherwise.
-
-  A symbol or a call answers nil on purpose: `{:& attrs}` is the ordinary
-  spelling and its value is unknowable here. `nil` answers nil too — the
-  runtime folds it away."
-  [node]
-  (cond
-    (api/vector-node? node) "a vector"
-    (api/set-node? node)    "a set"
-    :else
-    (when-let [[v] (scalar node)]
-      (cond
-        (nil? v)     nil
-        (string? v)  "a string"
-        (keyword? v) "a keyword"
-        (number? v)  "a number"
-        (boolean? v) "a boolean"
-        (char? v)    "a character"
-        :else        nil))))
-
-(defn- check-merge-key!
-  "`:&` carrying a literal the runtime will refuse
-  (`:rf.error/hicasso-merge-not-a-map`)."
-  [node]
-  (when (api/map-node? node)
-    (let [children (:children node)]
-      (doseq [[k v] (partition 2 children)
-              :when (= :& (tag-keyword k))
-              :let  [problem (merge-value-problem v)]
-              :when problem]
-        (finding! v :re-frame.hicasso/merge-not-a-map
-                  (str ":& carries a caller's attribute map and nothing else. "
-                       "It was given " problem ". Forward a map, or drop the key."))))))
-
 ;; --- a read in the one position that is deferred by construction ----------
 
 (defn- check-read-in-callback!
@@ -294,9 +269,9 @@
   [body]
   (doseq [node (mapcat subforms body)
           :when (api/list-node? node)
-          :let  [[head _target value] (:children node)]
-          :when (contains? #{'reset! 'vreset!} (core-var head))
-          :when (parked-thunk? value)]
+          :let  [[head _target & args] (:children node)]
+          :when (contains? #{'reset! 'vreset! 'swap!} (core-var head))
+          value (filter parked-thunk? args)]
     (finding! value :re-frame.hicasso/parked-read
               (str "A subscription read is parked in a mutable reference. The "
                    "read-extent law covers the structure a body RETURNS, so a "
@@ -390,7 +365,7 @@
   way — the name may be in there."
   [node]
   (when (hiccup-vector? node)
-    (let [tag      (tag-keyword (first (:children node)))
+    (let [tag      (native-tag (first (:children node)))
           children (child-nodes node)
           props    (props-node node)
           at-1     (second (:children node))]
@@ -428,28 +403,130 @@
   same vector written as a child of `[:div …]` is a head, and a function is
   never a legal one (`:rf.error/hicasso-bad-head`)."
   [node]
-  (when (hiccup-vector? node)
-    (doseq [child (child-nodes node)
-            :when (api/vector-node? child)
-            :let  [head (first (:children child))]
-            :when (function-literal? head)]
-      (finding! head :re-frame.hicasso/function-in-head-position
-                (str "A function in head position is never a silent embedding. "
-                     "Call it, or make it a view with `defview`: a view is a "
-                     "real component and is a legal head; a function is not.")))))
+  (doseq [child (if (hiccup-vector? node) (child-nodes node) nil)
+          :when (api/vector-node? child)
+          :let  [head (first (:children child))]
+          :when (function-literal? head)]
+    (finding! head :re-frame.hicasso/function-in-head-position
+              (str "A function in head position is never a silent embedding. "
+                   "Call it, or make it a view with `defview`: a view is a "
+                   "real component and is a legal head; a function is not."))))
+
+(defn- check-root-head!
+  "The same law at the ROOT of a body.
+
+  `(defview root [_] [(fn [] …)])` is the identical mistake, and the
+  children-position rule above cannot see it: the offending vector is what
+  the body RETURNS rather than a child of anything. A body's return value
+  is a hiccup position by construction — that is what a boundary is — so
+  the head of a literal vector there is decidable without guessing.
+
+  Applied to the last form of the body, and through the tails of the
+  ordinary wrappers a body's return threads out of."
+  [node]
+  (when node
+    (cond
+      (api/vector-node? node)
+      (let [head (first (:children node))]
+        (when (function-literal? head)
+          (finding! head :re-frame.hicasso/function-in-head-position
+                    (str "A function in head position is never a silent "
+                         "embedding, and this one is what the body RETURNS. "
+                         "Call it, or make it a view with `defview`."))))
+
+      ;; `let`, `when`, `if`, `do`, `when-let`… — a body's return threads
+      ;; out through the tail of each, so the same position is still a
+      ;; hiccup position one level in. Only the TAIL: a non-tail form is an
+      ;; ordinary expression and none of this check's business.
+      (api/list-node? node)
+      (let [nm (some-> (core-var (first (:children node))) str)]
+        (when (contains? #{"let" "when" "when-let" "when-some" "if-let"
+                           "if-some" "do" "when-not" "with-redefs" "binding"}
+                         nm)
+          (check-root-head! (last (:children node))))
+        (when (= "if" nm)
+          (let [[_if _test then else] (:children node)]
+            (check-root-head! then)
+            (check-root-head! else)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The hooks
 ;; ---------------------------------------------------------------------------
 
+(def ^:private synchronous-iteration
+  "Core forms that call their function DURING the body. A `sub` inside a fn
+  literal handed to one of these is an ordinary read of the boundary that
+  wrote it, not a deferred one, and the codec's eager walk is what makes it
+  so. Naming them is what keeps the check below off correct code."
+  '#{map mapv keep keep-indexed map-indexed mapcat filter remove
+     reduce reduce-kv some every? sort-by group-by run! doseq for})
+
+(defn- check-deferred-read-in-fn!
+  "`h/sub` inside a plain `(fn …)` / `#(…)` written in a body, unless that
+  function is handed straight to a synchronous iteration form.
+
+  Roster item 3 (operator ruling): the obviously-deferred read, at WARNING.
+  A warning rather than an error because the judgement is a HEURISTIC —
+  `(some-helper (fn [] (h/sub …)))` may well call its argument during the
+  body, and this cannot know. What it can see is that nothing standard is
+  about to call it synchronously, which is where the mistake actually
+  lives: a callback, a timer, a promise, a thunk stashed for later.
+
+  Read extent in general remains the RUNTIME's law (I7 / hic-011); this
+  never pretends otherwise, which is why it does not block a build."
+  [body]
+  (doseq [node (mapcat subforms body)
+          :when (api/list-node? node)
+          :let  [callee (core-var (first (:children node)))]
+          ;; `parked-read` owns the mutable-reference shape and says
+          ;; something sharper about it. Two warnings on one site is
+          ;; nagging, so this one yields.
+          :when (not (contains? synchronous-iteration callee))
+          :when (not (contains? #{'reset! 'vreset! 'swap!} callee))
+          arg   (rest (:children node))
+          :when (and (function-literal? arg)
+                     (not= 'hfn (hicasso-var (first (:children arg)))))
+          :when (some #(and (api/list-node? %)
+                            (reads-hicasso-state? (first (:children %))))
+                      (mapcat subforms (or (thunk-body arg) [])))]
+    (finding! arg :re-frame.hicasso/deferred-read
+              (str "A subscription is read inside a function that nothing here "
+                   "calls during this body, so the read is very likely deferred "
+                   "— and a deferred read has no boundary to belong to. Read "
+                   "during the body and close over the value. If this function "
+                   "IS called synchronously, ignore this: read extent is the "
+                   "runtime's law, not lint's."))))
+
+(defn- check-direct-view-call!
+  "A view called like a function, where that is decidable.
+
+  `defview` mints a React component and it is used as a HEAD:
+  `[todo-row {…}]`, never `(todo-row {…})`. The general check needs to know
+  that a symbol resolves to a var minted by `defview`, usually in another
+  namespace, and a hook sees one form — so the decidable slice is the view
+  calling ITSELF, whose name this hook is holding. Narrow, but always right
+  and editor-reliable, which the wider version is not (see README)."
+  [sym body]
+  (when-let [nm (token-sexpr sym)]
+    (doseq [node (mapcat subforms body)
+            :when (api/list-node? node)
+            :when (= nm (token-sexpr (first (:children node))))]
+      (finding! node :re-frame.hicasso/direct-view-call
+                (str "`" nm "` is a view, so it is a hiccup HEAD rather than a "
+                     "function: write [" nm " {…}]. Called directly it returns "
+                     "the runtime's component object instead of rendering, and "
+                     "no boundary is minted, so its reads belong to whichever "
+                     "body called it.")))))
+
 (defn- check-body!
   "Every hiccup-shaped check, over one body."
   [body]
-  (run! check-merge-key! (mapcat subforms body))
   (let [elements (mapcat element-subforms body)]
     (run! check-unkeyed-children! elements)
     (run! check-nameless-interactive! elements)
     (run! check-function-head! elements))
+  (check-root-head! (last body))
+  (check-deferred-read-in-fn! body)
   (check-parked-read! body))
 
 (defn defview
@@ -462,6 +539,7 @@
                                 [nil more])
         [argv & body]         more]
     (check-body! body)
+    (check-direct-view-call! sym body)
     {:node (api/list-node
              (concat [(api/token-node 'clojure.core/defn) sym]
                      (when doc [doc])

--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj
@@ -356,17 +356,31 @@
 
 ;; --- an interactive element with nothing to name it -----------------------
 
-(def ^:private interactive-tags
-  "Tags whose whole purpose is to be operated, and which are inoperable
-  from a screen reader without an accessible name. Deliberately two: an
-  `:input`'s name usually comes from a sibling `<label for=…>`, which is a
-  fact about the TREE rather than about the element, and belongs to the
-  real a11y pass (hic-043)."
-  #{"button" "a"})
-
 (def ^:private naming-attributes
-  "The attributes that give an element an accessible name on their own."
+  "The attributes that give an element an accessible name on their own.
+  The same three the compiled substrates' a11y pass names
+  (`re-frame.ui.compiler.a11y`, `:rf.ui.compile/a11y-missing-accessible-name`)."
   #{:aria-label :aria-labelledby :title})
+
+(defn- needs-an-accessible-name?
+  "Is this an element that is named by its CONTENT, and so unusable without
+  one when it has none?
+
+  The tag set and the `:href` condition are taken from the compiled
+  substrates' a11y pass rather than invented here, so the two agree about
+  what a nameless control is: a `<button>` always, and an `<a>` only when it
+  is a real link. An `<a>` with no `href` is not focusable and not a link,
+  so demanding a name for one would be a false positive.
+
+  `:input`, `:select` and `:textarea` are in that pass's set and NOT here:
+  their name usually comes from a sibling `<label for=…>`, which is a fact
+  about the TREE rather than about the form in hand, and belongs to the real
+  a11y pass (hic-043)."
+  [tag props]
+  (let [base (base-tag tag)]
+    (or (= "button" base)
+        (and (= "a" base)
+             (contains? (some-> props map-keys) :href)))))
 
 (defn- check-nameless-interactive!
   "`[:button {…}]` / `[:a {…}]` with NO children and no naming attribute.
@@ -380,7 +394,7 @@
           children (child-nodes node)
           props    (props-node node)
           at-1     (second (:children node))]
-      (when (and (contains? interactive-tags (base-tag tag))
+      (when (and (needs-an-accessible-name? tag props)
                  (empty? children)
                  (or props (definitely-not-props? at-1))
                  (empty? (into #{} (filter naming-attributes)

--- a/implementation/hicasso/scripts/check_lint_export.py
+++ b/implementation/hicasso/scripts/check_lint_export.py
@@ -70,6 +70,31 @@ EXPECTED = {
 }
 
 
+def _kondo_command():
+    """How to invoke clj-kondo here, preferring the NATIVE BINARY.
+
+    The binary is what `.github/workflows/lint.yml` installs, at the pin this
+    gate asserts against, and it needs no JDK — which is what lets the fixture
+    witness run as a step of the existing `clj-kondo` job rather than waiting
+    for a JVM lane that does not exist. The artefact's `:clj-kondo` alias is
+    the local fallback, so a developer with no binary still gets the gate.
+    """
+    for name in ("clj-kondo", "clojure"):
+        # The RESOLVED path, not the bare name. On Windows an npm-installed
+        # tool leaves both an extensionless shell shim and a `.cmd`; only the
+        # latter is executable by `subprocess` without a shell, and `which`
+        # can hand back either.
+        found = (shutil.which(name + ".cmd") or shutil.which(name + ".bat")
+                 or shutil.which(name))
+        if found:
+            return [found] if name == "clj-kondo" else [found, "-M:clj-kondo"]
+    raise SystemExit(
+        "FAIL: neither `clj-kondo` nor `clojure` is on PATH, so the Hicasso "
+        "lint export gate cannot run. This is a HARD failure on purpose: it "
+        "used to SKIP green, which is a gate reporting success over a case it "
+        "never exercised -- the exact defect class it exists to catch.")
+
+
 def _kondo(paths, config_dir=EXPORT_DIR):
     """Every finding clj-kondo reports for `paths`, as data.
 
@@ -79,8 +104,8 @@ def _kondo(paths, config_dir=EXPORT_DIR):
     copies.
     """
     proc = subprocess.run(
-        ["clojure", "-M:clj-kondo",
-         "--config-dir", config_dir,
+        _kondo_command() +
+        ["--config-dir", config_dir,
          "--config", '{:output {:format :json} :cache false}',
          "--lint"] + list(paths),
         cwd=ARTEFACT_ROOT, capture_output=True, text=True,
@@ -274,11 +299,6 @@ def main(argv=None):
     parser.add_argument("--self-test", action="store_true",
                         help="prove the gate's red/green classification, then exit")
     args = parser.parse_args(argv)
-
-    if shutil.which("clojure") is None:
-        print("SKIP: clojure CLI not on PATH; the Hicasso lint export gate "
-              "needs it to run the pinned clj-kondo.")
-        return 0
 
     if args.self_test:
         return self_test()

--- a/implementation/hicasso/scripts/check_lint_export.py
+++ b/implementation/hicasso/scripts/check_lint_export.py
@@ -59,12 +59,14 @@ HOOK_FILE = os.path.join(EXPORT_DIR, "hooks", "re_frame", "hicasso.clj")
 # still firing the right NUMBER of times is precisely the collapse a count
 # cannot see.
 EXPECTED = {
-    "merge-not-a-map":              [23, 26, 29],
-    "deferred-read":                [36, 41],
-    "parked-read":                  [51, 55, 59],
-    "unkeyed-mapped-child":         [67, 72, 75, 78],
-    "nameless-interactive-element": [85, 88, 91],
-    "function-in-head-position":    [98, 101, 104],
+    # ERRORS -- true invariants (operator ruling, rf2-hic-022).
+    "direct-view-call":             [25],
+    "function-in-head-position":    [99, 102, 105, 110, 114],
+    # WARNINGS -- heuristics and assistance. Nothing blocks a build.
+    "deferred-read":                [32, 37, 43],
+    "parked-read":                  [52, 56, 60],
+    "unkeyed-mapped-child":         [68, 73, 76, 79],
+    "nameless-interactive-element": [86, 89, 92, 123, 126],
 }
 
 
@@ -216,10 +218,10 @@ def self_test():
          "(mapcat element-subforms body)", "(mapcat subforms body)",
          "negative.cljs"),
         # Rows, not counts: deleting one positive case must red even though
-        # the check itself still fires twice.
+        # the check itself still fires four more times.
         ("a check firing at the wrong ROWS reds", "fixture",
-         '  [:div {:& [:a :b]} "x"])', '  [:div "x"])',
-         "merge-not-a-map"),
+         '  [:a {:href "/help"}])', '  [:a {:href "/help"} "Help"])',
+         "nameless-interactive-element"),
     ]
 
     ok = True

--- a/scripts/check_gate_scheduling.py
+++ b/scripts/check_gate_scheduling.py
@@ -243,6 +243,15 @@ DISPOSITIONS: dict[str, dict] = {
                "DOES yield a verdict, which is why that one is scheduled "
                "(freehand-bench.yml) and pinned into the local rigorous sweep",
     },
+    # `test:hicasso-lint` (rf2-hic-022) was declared `unscheduled` here for
+    # exactly one commit, and its entry is DELETED rather than kept: the
+    # fixture witness now runs as a step of lint.yml's required `clj-kondo`
+    # job, which already installs the pinned binary the gate needs. The hole
+    # it named was load-bearing — the job loaded the export's hooks but never
+    # ran the positive fixtures, so a check could stop FIRING with CI still
+    # green — and a declared hole that outlives its gate's schedule is the
+    # same class of lie as an undeclared one, told the other way round.
+    #
     # NO DECLARED HOLE REMAINS.  The last one was `test:hicasso-controlled`
     # (rf2-hic-016): the Hicasso three-engine controlled-input gate, declared
     # `unscheduled` rather than left silently unrun because the PR that built
@@ -305,36 +314,6 @@ DISPOSITIONS: dict[str, dict] = {
                "implementation` after `npm ci` is the measured fix",
     },
 
-    "test:hicasso-lint": {
-        "kind": "unscheduled",
-        "bead": "rf2-hic-022",
-        "why": "the Hicasso lint export's witness (rf2-hic-022) — the gate "
-               "that proves each of the six published clj-kondo checks fires "
-               "at its exact fixture rows, that correct code resembling each "
-               "mistake produces NO finding of any kind, and that the "
-               "artefact's own testbeds stay quiet. Declared here having been "
-               "RUN green, and with its own `--self-test` proving its red "
-               "three ways, rather than merely written: a gate wired without a "
-               "green run hands the alerting a false positive on its debut. "
-               "The same fence as the `test:hicasso-controlled` entry deleted "
-               "above — the PR that built it is fenced out of "
-               ".github/workflows/**, which is hot-zone and sequential, so the "
-               "step is a scheduling decision rather than a detail that bead "
-               "could take. UNSCHEDULED rather than covered-by: no existing "
-               "job's closure reaches it. Two things whoever schedules it "
-               "should know. It belongs beside `test:hicasso-freeze` in "
-               "test.yml's `cljs` job, whose `cljs_node_test` arm already "
-               "covers implementation/hicasso/** — one added step, no new job "
-               "and no classifier change. And it needs the `clojure` CLI (it "
-               "runs the pinned clj-kondo through the artefact's `:clj-kondo` "
-               "alias) which that job does not currently install; the script "
-               "SKIPs green without it, so scheduling it into a job with no "
-               "JVM would wire a gate that verifies nothing. Note this is only "
-               "the FIXTURE witness: the export itself is already gated per-PR "
-               "by lint.yml's required `clj-kondo` job, since "
-               ".clj-kondo/config.edn points :config-paths at it. The local "
-               "fast-PR spine does run this script",
-    },
 }
 
 KINDS = {"covered-by", "ci-runs-it-directly", "not-a-gate", "unscheduled"}


### PR DESCRIPTION
Second increment of rf2-hic-022, on top of the merged #7784 and #7791. It
implements the **operator's corrected roster** (2026-08-10 20:36) and closes
the fail-open the merged-PR audit called out.

## The roster, as ruled

**Severity law: errors only for true invariants; warnings for heuristics;
nothing blocks a build. Assistance, not enforcement.**

| # | Check | Level | Change |
|---|---|---|---|
| 1 | `direct-view-call` | ERROR | **new** |
| 2 | `function-in-head-position` | ERROR | extended — root heads, string heads, qualified keywords |
| 3 | `deferred-read` | WARNING | **was ERROR**; broadened from `hfn`-only to any fn literal |
| 4 | `unkeyed-mapped-child` | WARNING | unchanged |
| 5 | `nameless-interactive-element` | WARNING | `href` condition landed in #7791 |
| 6 | `parked-read` | WARNING | gains `swap!` |
| — | ~~`merge-not-a-map`~~ | — | **DROPPED** |

**Dropped.** The `:&` grammar key is retired from the end-state design in
favour of the owned-wins merge recipe, so the check, its fixtures, its config
entry and its self-test mutation are all gone. A lint layer must not police a
ghost.

**Item 1, and the honest slice.** The general form needs to know that a symbol
resolves to a var minted by `defview`, usually in another namespace, and a hook
sees one form. `clj-kondo.hooks-api/ns-analysis` *can* answer it from the
analysis cache — which is worse than not answering, because the check would
fire in a full CI run and stay silent in an editor linting one file. So the
slice is the one that is decidable and **editor-reliable**: the view calling
*itself*, whose name the hook is holding. The audit asked for exactly this
("implement only an editor-reliable bounded slice"); the wider version stays in
the README's declined table.

**Item 3, and why it is a warning.** Broadened to `sub` inside any fn literal a
body writes, **less** those handed straight to a synchronous iteration form
(`map`, `mapv`, `for`, `keep`, `reduce`, `filter`, `some`, `sort-by`, …), which
really do run during the body. That exclusion is what keeps it off correct
code. It remains a *heuristic* — `(some-helper (fn [] (h/sub …)))` may call its
argument synchronously and this cannot know — and its own message says so:
*"If this function IS called synchronously, ignore this: read extent is the
runtime's law, not lint's."* Warning level is therefore the honest level, which
is what the ruling says. Where `parked-read` already owns a site, this one
yields: two warnings on one site is nagging.

**Item 6** gained `swap!` and now scans every argument, since `swap!` puts its
updater at position 2.

## The tag model was wrong, and the audit caught it

`codec/hiccup-tag?` is `(or (keyword? head) (symbol? head) (string? head))` and
`parse-tag` reads it through `name`. So `["button" …]` **and** `[:app/button …]`
are both real `<button>`s. The hook claimed the opposite — it treated a
qualified keyword as ordinary tagged data, and ignored string heads entirely.
Both are now taken from the runtime, and the qualified-keyword *negative*
fixture (which asserted the wrong thing) is replaced by a true one.

## Root heads

`(defview root [_] [(fn [] …)])` is the same illegal head as the nested case,
and the children-position rule could not see it: the offending vector is what
the body **returns**. Now checked at the body's tail, and through the tails of
`let` / `when` / `if` / `do` / `when-let` that a return threads out of. Both
spellings are positive fixtures.

## The fail-open — the load-bearing item

`lint.yml`'s required `clj-kondo` job loaded the export's hooks against current
repository code, which proves they **load** and stay quiet. It could not prove
they still **catch**: every check could stop firing and the job would stay
green, because silence is what it is looking for.

**HOT-ZONE CHANGE, DECLARED LOUDLY.** One step added to the *existing*
`clj-kondo` job in `.github/workflows/lint.yml` — no new job, no classifier
arm, no `needs:` change, so the required-context graph is untouched. That job
is the only required one that already installs clj-kondo at the pin, and the
witness is ~1s of Python driving it over two fixture files: no JDK, no
`node_modules`, no shadow-cljs. `--self-test` runs first and mutates the
shipped hook three ways to prove the gate's RED.

The other half of the fail-open was inside the checker: it **SKIPped GREEN**
when the Clojure CLI was absent — the same lie one level down. It now prefers
the native binary (which is what makes a JDK-free CI step possible), falls back
to the artefact's `:clj-kondo` alias locally, and **hard fails** when neither
exists.

`test:hicasso-lint`'s `unscheduled` DISPOSITIONS entry is **deleted** rather
than kept, per that file's own rule that a declared hole outliving its gate's
schedule is the same class of lie told the other way round.

## Quality gates

Each run alone, in the foreground, exit echoed to its own file.

| Gate | Exit | Notes |
|---|---|---|
| `clj-kondo --parallel --fail-level error` over CI's `--lint` paths | `0` | pin `2026.04.15`. **errors: 0, and ZERO of the six checks firing on real code.** |
| `npm run test:hicasso-lint` (gate + `--self-test`) | `0` | `OK: 6 checks fire on their fixtures, correct code is silent, and the artefact's own testbeds are quiet.` All four controls red. |
| `python scripts/check_gate_scheduling.py` | `0` | `37 scheduled` (was 36), `1` known hole (was 2) |
| `python scripts/check_gate_scheduling.py --self-test` | `0` | |

The broadened rule 3 found one more **refusal suite** on real code —
`read-extent-dom-cljs-test`, the DOM sibling of one already declared — so it
joins the same *enumerated* class in `.clj-kondo/config.edn` rather than
widening it to a `*-cljs-test$` pattern, which would blind the checks across
every hicasso suite where an authoring mistake is still a mistake.

Required checks the local spine does not run, per `python
scripts/check_fast_pr_gap.py --list`: `Lint required` and `Docs required` have
no tier in the spine. The `clj-kondo` job is the one that matters here and it
was run directly at the pin, as above — and it now carries the fixture witness
too.

## Names

Built against today's prototype spellings (`defview`, `hfn`, `defhost`, `sub`,
`use-subs`). The exports are already on the rename sweep's grep surface by
construction: `scripts/check_retired_spellings.py` scans `implementation/` for
`.clj` / `.cljc` / `.cljs`, which covers both the hook and the fixtures.
