### PR TITLE
fix(gate): blank only what the renderer recognises as a fence (rf2-mmyc)

### DIFF
--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -586,11 +586,28 @@ def _strip_fences(lines: list[str]) -> list[tuple[int, str]]:
     ```markdown sample at the first nested bare fence inside it — which the
     corpus has, in skills/re-frame2-implementor/references/output-format.md.
 
-    A fence also ends with the container that holds it: a non-blank line
-    indented less than the fence's content column closes both.  rf2-re0m shipped
-    three UNBALANCED fences, so without that an authoring slip blanks a document
-    from the fence to EOF — a gate going silent, which is the same failure as
-    the one being fixed, pointing the other way.
+    A FENCE IS A MATCHED PAIR (rf2-mmyc, MERGED-PR AUDIT #7785).  An opener is
+    only a fence once its closer has been FOUND — `_fence_close` looks ahead for
+    one, and a block is blanked only when that lookahead succeeds.  Where it
+    fails, nothing is blanked at all: superfences collects lines from the opener
+    and, on reaching the end of the container or the document without its
+    closer, RESTORES the source verbatim, so python-markdown reads every one of
+    those lines as ordinary prose.
+
+    That distinction is the whole of this function's history of getting it
+    wrong, in both directions.  The predecessor to THIS revision read "the
+    closer does not match, so the fence stays open" and blanked the body and
+    every line after it — five shapes' worth of document going dark below an
+    authoring slip: a longer closing run, a shorter one, a closer carrying an
+    info string, a closer outside the opener's container, and a fence never
+    closed at all.  A broken link or heading below any of them was invisible
+    here while rendering perfectly normally on the page.  rf2-re0m shipped three
+    unbalanced fences, so none of this is hypothetical.
+
+    The container bound survives as the lookahead's stopping rule rather than as
+    a way to end an open fence: a non-blank line indented less than the fence's
+    content column means the container closed first, so the closer cannot be
+    below it and the opener was never a fence.
 
     A BLOCKQUOTE is a container too (rf2-1cpt).  `> ```clojure` opens a real
     fence — python-markdown renders the lines under it as a code block, mints no
@@ -621,51 +638,13 @@ def _strip_fences(lines: list[str]) -> list[tuple[int, str]]:
     """
     out: list[tuple[int, str]] = []
     open_columns: list[int] = []
-    # (opening marker, its indentation, its blockquote depth)
-    fence: tuple[str, int, int] | None = None
-    for i, raw in enumerate(lines, start=1):
-        if fence is not None:
-            marker, fence_indent, fence_depth = fence
-            if not raw.strip():
-                # A blank line neither closes a fence nor ends a blockquote for
-                # fence purposes — superfences counts it and reads on.
-                out.append((i, ""))
-                continue
-            indent = len(raw) - len(raw.lstrip(" "))
-            if fence_depth:
-                depth, body = _quote_depth_and_body(raw[indent:], limit=fence_depth)
-                if depth == fence_depth:
-                    m = _FENCE_RE.match(body)
-                    if (
-                        m
-                        and m.group("marker") == marker
-                        and len(m.group("indent")) == fence_indent
-                        and not m.group("info").strip()
-                    ):
-                        fence = None
-                    out.append((i, ""))
-                    continue
-                # Shallower than the fence: the blockquote holding it ended, so
-                # the fence ended with it.
-                fence = None
-            elif indent >= (open_columns[-1] if open_columns else 0):
-                m = _FENCE_RE.match(raw)
-                if (
-                    m
-                    and m.group("marker") == marker
-                    and len(m.group("indent")) == fence_indent
-                    and not m.group("info").strip()
-                ):
-                    fence = None
-                out.append((i, ""))
-                continue
-            else:
-                # The container holding the fence ended, so the fence ended with
-                # it.  Fall through and read this line as ordinary source.
-                fence = None
-
+    i = 0
+    total = len(lines)
+    while i < total:
+        raw = lines[i]
         if not raw.strip():
-            out.append((i, ""))
+            out.append((i + 1, ""))
+            i += 1
             continue
 
         indent = len(raw) - len(raw.lstrip(" "))
@@ -673,31 +652,90 @@ def _strip_fences(lines: list[str]) -> list[tuple[int, str]]:
             open_columns.pop()
         content_column = open_columns[-1] if open_columns else 0
 
+        # (opening marker, its indentation, its blockquote depth)
+        opener: tuple[str, int, int] | None = None
         if indent <= content_column + 3:
             quote_depth, quoted_body = _quote_depth_and_body(raw[indent:])
             if quote_depth:
                 qm = _FENCE_RE.match(quoted_body)
                 if qm and len(qm.group("indent")) <= 3:
-                    fence = (qm.group("marker"), len(qm.group("indent")), quote_depth)
-                    out.append((i, ""))
-                    continue
+                    opener = (qm.group("marker"), len(qm.group("indent")), quote_depth)
+        if opener is None:
+            m = _FENCE_RE.match(raw)
+            if m and content_column <= indent <= content_column + 3:
+                opener = (m.group("marker"), indent, 0)
 
-        m = _FENCE_RE.match(raw)
-        if m and content_column <= indent <= content_column + 3:
-            fence = (m.group("marker"), indent, 0)
-            out.append((i, ""))
-            continue
+        if opener is not None:
+            close = _fence_close(lines, i + 1, opener, content_column)
+            if close is not None:
+                # A matched pair: the renderer emits a code block, so blank the
+                # delimiters and everything between them.
+                for k in range(i, close + 1):
+                    out.append((k + 1, ""))
+                i = close + 1
+                continue
+            # No closer anywhere in the container: superfences withdraws the
+            # fence and restores the source, so this line is ordinary prose and
+            # so is everything below it.  Fall through.
 
-        if indent <= content_column + 3:
-            lm = _LIST_ITEM_OPEN_RE.match(raw)
-            if lm:
-                open_columns.append(
-                    len(lm.group("indent")) + len(lm.group("marker")) + len(lm.group("gap"))
-                )
-            elif _MKDOCS_BLOCK_OPEN_RE.match(raw):
-                open_columns.append(indent + _MKDOCS_BLOCK_CONTENT_INDENT)
-        out.append((i, raw))
+        lm = _LIST_ITEM_OPEN_RE.match(raw)
+        if lm:
+            open_columns.append(
+                len(lm.group("indent")) + len(lm.group("marker")) + len(lm.group("gap"))
+            )
+        elif _MKDOCS_BLOCK_OPEN_RE.match(raw):
+            open_columns.append(indent + _MKDOCS_BLOCK_CONTENT_INDENT)
+        out.append((i + 1, raw))
+        i += 1
     return out
+
+
+def _fence_close(
+    lines: list[str],
+    start: int,
+    opener: tuple[str, int, int],
+    content_column: int,
+) -> int | None:
+    """Index of the line closing `opener`, or None if it never closes.
+
+    Split out of `_strip_fences` so that a fence is committed to only once its
+    closer is in hand (rf2-mmyc).  The closing test is superfences': the
+    opener's EXACT marker run, at the opener's EXACT indentation, carrying no
+    info string, at the opener's own blockquote depth.
+
+    Returning None is the load-bearing case.  It means the renderer never sees a
+    fenced block here, so the caller must blank NOTHING — not the body, not the
+    opener, and above all not the rest of the document.
+
+    A blank line closes nothing and ends no container: superfences counts it and
+    reads on.  A non-blank line shallower than the fence's container (or, in a
+    blockquote, quoted less deeply than the opener) means the container closed
+    first, so the closer cannot be below it.
+    """
+    marker, fence_indent, fence_depth = opener
+    for j in range(start, len(lines)):
+        raw = lines[j]
+        if not raw.strip():
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+        if fence_depth:
+            depth, body = _quote_depth_and_body(raw[indent:], limit=fence_depth)
+            if depth != fence_depth:
+                return None  # the blockquote holding the fence ended first
+            candidate = body
+        else:
+            if indent < content_column:
+                return None  # the container holding the fence ended first
+            candidate = raw
+        m = _FENCE_RE.match(candidate)
+        if (
+            m
+            and m.group("marker") == marker
+            and len(m.group("indent")) == fence_indent
+            and not m.group("info").strip()
+        ):
+            return j
+    return None  # end of document, with no closer
 
 
 def _fenced_lines(lines: list[str]) -> Iterable[tuple[int, str]]:

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -2460,9 +2460,14 @@ def _run_self_tests(verbose: bool = False) -> int:
           "Prose after."],
          [9]),
         # RUNAWAY GUARD.  rf2-re0m shipped three unbalanced fences, so this is
-        # not hypothetical.  A fence ends with the container that holds it, so
-        # an unclosed one cannot blank the rest of the document — which is the
-        # mirror-image failure of the defect: a gate that goes quiet.
+        # not hypothetical.  An unclosed opener cannot blank the rest of the
+        # document — which is the mirror-image failure of the defect: a gate
+        # that goes quiet.
+        #
+        # It cannot blank its OWN body either (rf2-mmyc, audit #7785): with no
+        # closer there is no fenced block, so superfences restores the source
+        # and the renderer emits `<p>```clojure\n  (unclosed</p>`.  Lines 3-4
+        # are prose on the rendered page and must be scanned as prose here.
         ("unclosed indented fence ends with its container",
          ["- A bullet:",
           "",
@@ -2470,7 +2475,7 @@ def _run_self_tests(verbose: bool = False) -> int:
           "  (unclosed",
           "",
           "Prose after, back at column zero."],
-         [1, 6]),
+         [1, 3, 4, 6]),
         # ------------------------------------------------------------------
         # rf2-1cpt — BLOCKQUOTED fences.  A blockquote is a container like any
         # other, and superfences opens a fence at the column its prefix leaves
@@ -2580,22 +2585,26 @@ def _run_self_tests(verbose: bool = False) -> int:
          [7]),
         # The closing rules inside a quote are superfences' usual strict ones:
         # the closer must be the opener's EXACT marker run with nothing after
-        # it.  Neither of these closes, so each fence runs to the end of its
-        # blockquote — and no further.
+        # it.  Neither of these closes — and an opener with no closer is not a
+        # fence at all (rf2-mmyc, audit #7785), so the quoted lines are prose.
+        # The renderer emits `<blockquote><p>```clojure ...</p></blockquote>`
+        # for both, which is where the earlier "runs to the end of its
+        # blockquote" reading went wrong: superfences does not leave a fence
+        # open, it withdraws the fence.
         ("longer closing run does not close a blockquoted fence",
          ["> ```clojure",
           "> (code)",
           "> ````",
           "",
           "Prose after at column zero."],
-         [5]),
+         [1, 2, 3, 5]),
         ("closer with an info string does not close a blockquoted fence",
          ["> ```clojure",
           "> (code)",
           "> ```clojure",
           "",
           "Prose after at column zero."],
-         [5]),
+         [1, 2, 3, 5]),
         # A line quoted MORE deeply than the fence is content, not a nested
         # quote: superfences reads a content line's prefix only as far as the
         # opener's reached, so the extra `>` is the first character of a line of
@@ -2615,25 +2624,26 @@ def _run_self_tests(verbose: bool = False) -> int:
           "",
           "Prose after."],
          [6]),
-        # ...and the converse: a SHALLOWER non-blank line is the quote ending,
-        # which ends the fence with it.  The line itself is ordinary source
-        # again, so it stays visible.
+        # ...and the converse: a SHALLOWER non-blank line ends the quote, so the
+        # opener never meets a closer and no fence is recognised.  All three
+        # quoted lines render as one paragraph inside the nested blockquote.
         ("shallower line ends a nested blockquoted fence",
          ["> > ```clojure",
           "> > (code)",
           "> shallower prose",
           "",
           "Prose after."],
-         [3, 5]),
+         [1, 2, 3, 5]),
         # RUNAWAY GUARD for the quoted case.  An unclosed blockquoted fence must
         # not blank the document below it; the blockquote bounds it, exactly as
-        # a list item bounds an indented one.
+        # a list item bounds an indented one — and, having no closer, it is not
+        # a fence, so it does not blank its own body either.
         ("unclosed blockquoted fence ends with its blockquote",
          ["> ```clojure",
           "> (unclosed",
           "",
           "Prose after at column zero."],
-         [4]),
+         [1, 2, 4]),
         # POSITIVE CONTROL — the blockquoted HEADING support added by rf2-869k9m
         # must survive.  `> #### Foo` is a real `<h4 id="quoted-heading">`, so
         # the line stays prose and the indexer keeps minting its slug.
@@ -2642,6 +2652,93 @@ def _run_self_tests(verbose: bool = False) -> int:
           ">",
           "> Quoted prose."],
          [1, 2, 3]),
+        # ------------------------------------------------------------------
+        # rf2-mmyc (MERGED-PR AUDIT #7785) — MALFORMED AND UNTERMINATED fences.
+        #
+        # A fenced block is a MATCHED PAIR.  superfences collects lines from an
+        # opener until it finds THAT opener's closer; if it never finds one it
+        # restores the source verbatim (`_store` / `restore_raw_text`) and
+        # python-markdown reads those lines as ordinary prose.  The predecessor
+        # read "this closer does not close the block" as "the block stays
+        # open", which is the opposite conclusion: it blanked the body AND
+        # every line after it, so a broken link or heading below a malformed
+        # fence was invisible to this gate — the same going-silent failure as
+        # rf2-re0m, reached from the other side.
+        #
+        # Every expectation below was READ OFF THE RENDERER, driven through
+        # MkDocs' own configuration (`mkdocs.config.load_config('mkdocs.yml')`,
+        # then its `markdown_extensions` / `mdx_configs` into a
+        # `markdown.Markdown`) — not off CommonMark, and not off a probe.
+        # CommonMark disagrees with what MkDocs actually does in BOTH
+        # directions here, which is how the wrong reading survived review.
+        # ------------------------------------------------------------------
+        # CONTROL — the well-formed pair, which must keep working.  Without it
+        # the five cases below are satisfied by a scanner that recognises no
+        # fence at all.
+        ("oracle: a valid exact closer IS a fence",
+         ["Prose before.",
+          "",
+          "```clojure",
+          "[not a link](missing.md)",
+          "```",
+          "",
+          "Prose after."],
+         [1, 7]),
+        # MARKER LENGTH, both ways.  superfences closes only on the opener's
+        # own run length, so neither of these pairs is a fenced block —
+        # the renderer emits one paragraph per shape and resolves the link
+        # inside it.
+        ("oracle: a longer closing run closes nothing, so nothing is a fence",
+         ["Prose before.",
+          "",
+          "```clojure",
+          "[a real link](missing.md)",
+          "````",
+          "",
+          "Prose after."],
+         [1, 3, 4, 5, 7]),
+        ("oracle: a shorter closing run closes nothing, so nothing is a fence",
+         ["Prose before.",
+          "",
+          "````clojure",
+          "[a real link](missing.md)",
+          "```",
+          "",
+          "Prose after."],
+         [1, 3, 4, 5, 7]),
+        # INFO STRING on the closer — likewise not a closer, likewise no fence.
+        ("oracle: a closer carrying an info string closes nothing",
+         ["Prose before.",
+          "",
+          "```clojure",
+          "[a real link](missing.md)",
+          "```clojure",
+          "",
+          "Prose after."],
+         [1, 3, 4, 5, 7]),
+        # UNCLOSED at top level.  This is the shape that most directly costs
+        # the gate its sight: `Prose after.` is a rendered paragraph, and a
+        # broken link on it must still be caught.
+        ("oracle: an unclosed top-level opener is not a fence",
+         ["Prose before.",
+          "",
+          "```clojure",
+          "[a real link](missing.md)",
+          "",
+          "Prose after."],
+         [1, 3, 4, 6]),
+        # CONTAINER DE-INDENT.  The closer sits outside the list item that
+        # holds the opener, so it is not this fence's closer and the item has
+        # already ended; no fence is recognised anywhere.
+        ("oracle: a closer outside the opener's container closes nothing",
+         ["- A bullet:",
+          "",
+          "  ```clojure",
+          "  [a real link](missing.md)",
+          "```",
+          "",
+          "Prose after."],
+         [1, 3, 4, 5, 7]),
     ]
     for label, lines, expected_visible in fence_cases:
         got_visible = [n for n, content in _strip_fences(lines) if content.strip()]

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -678,13 +678,14 @@ def _strip_fences(lines: list[str]) -> list[tuple[int, str]]:
             # fence and restores the source, so this line is ordinary prose and
             # so is everything below it.  Fall through.
 
-        lm = _LIST_ITEM_OPEN_RE.match(raw)
-        if lm:
-            open_columns.append(
-                len(lm.group("indent")) + len(lm.group("marker")) + len(lm.group("gap"))
-            )
-        elif _MKDOCS_BLOCK_OPEN_RE.match(raw):
-            open_columns.append(indent + _MKDOCS_BLOCK_CONTENT_INDENT)
+        if indent <= content_column + 3:
+            lm = _LIST_ITEM_OPEN_RE.match(raw)
+            if lm:
+                open_columns.append(
+                    len(lm.group("indent")) + len(lm.group("marker")) + len(lm.group("gap"))
+                )
+            elif _MKDOCS_BLOCK_OPEN_RE.match(raw):
+                open_columns.append(indent + _MKDOCS_BLOCK_CONTENT_INDENT)
         out.append((i + 1, raw))
         i += 1
     return out
@@ -2777,6 +2778,36 @@ def _run_self_tests(verbose: bool = False) -> int:
           "",
           "Prose after."],
          [1, 3, 4, 5, 7]),
+        # THE CONTAINER-PUSH GUARD, which had no coverage until the lookahead
+        # refactor above went looking for it.  A list marker four or more spaces
+        # past the current content column is an INDENTED CODE BLOCK, not a list
+        # item, so it must not push a content column — otherwise the fence two
+        # lines down is measured against a phantom container and recognised
+        # where the renderer sees literal text.  MkDocs emits ONE indented code
+        # block spanning lines 3-6 here, markers and all.
+        ("a four-space list marker is an indented code block, not a container",
+         ["Prose.",
+          "",
+          "    - a bullet four spaces in",
+          "      ```clojure",
+          "      [a real link](missing.md)",
+          "      ```",
+          "",
+          "Prose after."],
+         [1, 3, 4, 5, 6, 8]),
+        # ...and the control at three spaces, where the marker IS a list item and
+        # the fence indented to its content column is a real fence.
+        ("a three-space list marker is a container",
+         ["Prose.",
+          "",
+          "   - a bullet three spaces in",
+          "",
+          "     ```clojure",
+          "     [not a link](missing.md)",
+          "     ```",
+          "",
+          "Prose after."],
+         [1, 3, 9]),
     ]
     for label, lines, expected_visible in fence_cases:
         got_visible = [n for n, content in _strip_fences(lines) if content.strip()]


### PR DESCRIPTION
Implements the audit obligation on **rf2-mmyc** under the operator ruling of
2026-08-10 ~20:45 AUSEST: fix the five cases the oracle actually disagrees on,
and stop there. No second Markdown parser.

## The defect

A fenced block is a **matched pair**. `pymdownx.superfences` collects lines from
an opener until it finds *that opener's* closer; on reaching the end of the
container or the document without one it restores the source verbatim, and
python-markdown then reads every one of those lines as ordinary prose.

`_strip_fences` drew the opposite conclusion from a closer that does not match:
it left the fence **open** and blanked the body and everything after it, to the
end of the container or the file. Five shapes reached that path — a longer
closing run, a shorter one, a closer carrying an info string, a closer outside
the opener's container, and a fence never closed at all. Below any of them a
broken link or heading was invisible to this gate while rendering perfectly
normally on the page: the same going-quiet failure as rf2-re0m, reached from the
other side.

The audit's diagnosis was exact. The landed PR's renderer-derived claim confused
*"superfences does not accept this pair as a fenced block"* with *"a fence opens
and continues"*, and because the committed teeth encoded the same assumption,
every gate passed while the trap stayed armed.

## The fix

An opener is committed to only once `_fence_close` has found its closer. Where
the lookahead fails, **nothing is blanked** — not the body, not the opener, and
above all not the rest of the document.

The closing test itself is unchanged (the opener's exact marker run, at its exact
indentation, with no info string, at its own blockquote depth) and the container
bound survives as the lookahead's stopping rule rather than as a way to end an
open fence. No check is weakened, no ignore mechanism or allowlist is added, and
the in-fence predicate still keys on `.md`/`#fragment` destinations rather than a
bare `](`.

## The oracle

Expectations are read off MkDocs' **actual** renderer, not off CommonMark and not
off a probe: `mkdocs.config.load_config('mkdocs.yml')`, then its
`markdown_extensions` (11 of them, `pymdownx.superfences` among them) and
`mdx_configs` into a `markdown.Markdown`. Three independent instruments were
driven against it, and they agree:

| instrument | asks | before | after |
|---|---|---:|---:|
| per-line span | does the renderer emit a fenced block covering this line? | 12 | 3 |
| gate-level | do the renderer's `<a href>` / heading `id` sets match the gate's? | 10 | 1 |
| token-level | is this probe token rendered as code or as prose? | 7 | 3 |

The per-line span oracle validates against four controls that already agreed
(column-0, list-item, admonition and blockquoted fences), so its verdict on the
malformed shapes is trustworthy. It found **no fenced block at all** in any of the
five — which is the whole finding in one line.

The 12 it started at were the 5 audit shapes, 5 committed teeth encoding the same
wrong assumption, and 2 cases of the pre-existing indented-code-block bound.

Residuals, all accounted for and none in scope:

- **span, 3** — all three are that one indented-code-block bound, already
  documented in `_strip_fences` and pinned by committed self-tests (the third is
  the new container-push case below, same class). Direction is the safe one: the
  gate sees *more* than the renderer, never less.
- **token, 3** — shapes 3/4/6, where the probe token lands inside an *inline* code
  span. `_strip_fences` correctly leaves those lines visible and the downstream
  `_INLINE_CODE_SPAN_RE` masker handles them; the gate-level instrument confirms
  it, agreeing exactly on shapes 3 and 4.
- **gate-level, 1** — the sixth shape, below.

## Red first

All ten expectations failed against the previous implementation before anything
was fixed. Verbatim:

```
self-test FAIL: fence [unclosed indented fence ends with its container] expected visible lines [1, 3, 4, 6], got [1, 6]
self-test FAIL: fence [longer closing run does not close a blockquoted fence] expected visible lines [1, 2, 3, 5], got [5]
self-test FAIL: fence [closer with an info string does not close a blockquoted fence] expected visible lines [1, 2, 3, 5], got [5]
self-test FAIL: fence [shallower line ends a nested blockquoted fence] expected visible lines [1, 2, 3, 5], got [3, 5]
self-test FAIL: fence [unclosed blockquoted fence ends with its blockquote] expected visible lines [1, 2, 4], got [4]
self-test FAIL: fence [oracle: a longer closing run closes nothing, so nothing is a fence] expected visible lines [1, 3, 4, 5, 7], got [1]
self-test FAIL: fence [oracle: a shorter closing run closes nothing, so nothing is a fence] expected visible lines [1, 3, 4, 5, 7], got [1]
self-test FAIL: fence [oracle: a closer carrying an info string closes nothing] expected visible lines [1, 3, 4, 5, 7], got [1]
self-test FAIL: fence [oracle: an unclosed top-level opener is not a fence] expected visible lines [1, 3, 4, 6], got [1]
self-test FAIL: fence [oracle: a closer outside the opener's container closes nothing] expected visible lines [1, 3, 4, 5, 7], got [1]

10 self-test failure(s).
```

Five of those are new cases (marker length both ways, info string, unclosed,
container de-indent). **Five are committed teeth that encoded the same wrong
assumption**, which is the audit's point: fixing the classifier without fixing
them would have left the trap armed.

The sixth new case — `oracle: a valid exact closer IS a fence` — deliberately
does **not** red. The audit records that the normal exact fence control agrees,
and it passes before and after; without it the five malformed cases would be
satisfied by a scanner that recognised no fence at all. The red-first state is
its own commit so the ordering is auditable.

## Corpus delta, both directions, same merge base

718 files. Base is `origin/main`; both scanners run over the same corpus files in
one process, so nothing but the scanner differs.

| | base | head | delta |
|---|---:|---:|---:|
| lines blanked as fenced | 49,756 | 49,756 | 0 |
| links checked | 19,671 | 19,671 | 0 |
| rendered ids | 14,164 | 14,164 | 0 |

Links no longer checked: **0**. Links newly checked: **0**. Ids lost: **0**. Ids
gained: **0**. Nothing to enumerate in either direction.

That zero is earned rather than assumed. A census of fence-marker lines that the
new scanner does *not* place inside a recognised fence returns **0 across 0
files** — every fence in the corpus is well-formed and properly closed, so there
is nothing for the fix to reclassify today. The repair is for the day an
unbalanced fence lands, which rf2-re0m did three times.

Every counting script carries a `--prove` mode that runs **the production walk and
report path** over a planted known-bad page and requires a non-zero result; it
reports `-8` fenced lines, 2 links newly checked and 1 id gained, then removes
the page. It earned its keep immediately: the first version of that fixture
closed its second block with a bare three-backtick run, which is a valid closer
for the opener above it, so both scanners agreed and nothing moved — the prove
run failed loudly rather than certifying a false zero.

No runtime cost: warm, the full-corpus run is 12.6–15.6s against the base's
15.0–16.7s. The lookahead is paid for by skipping a matched body in one jump.

## One guard the refactor dropped, caught and pinned

Splitting `_strip_fences` into an opener plus a lookahead lost the
`indent <= content_column + 3` guard on the container-stack push. A list marker
four or more spaces past the current content column is an indented code block,
not a list item; the phantom content column it pushed made the fence two lines
below it recognisable, where MkDocs emits one indented code block spanning the
marker and both fence markers as literal text. Nothing in the suite covered that
guard, which is how it went missing silently — all 96 self-tests passed with it
gone.

It is restored and pinned by two cases read off the renderer. Neutralising the
guard flips the four-space case from `[1, 3, 4, 5, 6, 8]` to `[1, 3, 8]`; the
three-space control is unaffected, so the container mechanism still works where
it should.

The way that was checked is worth recording, because the first attempt reported a
false pass: running `--self-test` from a scratch directory dies on the
script-relative fixture root long before the fence cases and prints nothing about
them at all. The silence was indistinguishable from success. The teeth check
drives `_strip_fences` directly from both modules instead.

## The sixth shape, recorded and declined

One gate-level disagreement survives, and it is **not a fence question**. It
reproduces with no fence anywhere:

```
Prose with `a code span
  ### not a heading to python-markdown
[in](in-target.md)` closing here.
```

The renderer emits one `<code>` span across all three lines and no link.
`_LEAF_LINE_BLOCK_RE` bounds an inline block at an ATX heading indented up to
three spaces (CommonMark's allowance), but python-markdown's `HashHeaderProcessor`
requires the `#` at column zero — so the gate sees two unpaired backtick runs,
masks neither, and extracts a link the renderer renders as code. With the heading
at column zero the two agree.

That is `_inline_blocks`' surface (rf2-8wcbe), not `_strip_fences`', the direction
is a false positive rather than a blind spot, and the ruling says stop at five.
Recorded here, not actioned.

## Quality gates

Each run alone, in the foreground, exit code captured to its own file, never
piped. Every run confirmed `gate root:
C:/Users/miket/code/re-frame2-worktrees/fenceoracle-mmyc`.

| gate | exit |
|---|---:|
| `python scripts/check_doc_slugs.py --self-test` | 0 |
| `python scripts/check_doc_slugs.py` (full corpus) | 0 |
| `python scripts/check_readme_links.py` | 0 |
| `python scripts/check_readme_links.py --self-test` | 0 |
| `sh scripts/test-fast-pr.sh` (72 gates) | 0 |

`check_readme_links.py` imports the same extractor, so it moves with this change
and is gated alongside it.

Refs rf2-mmyc.
