### PR TITLE
fix(gate): match the renderer's column-zero ATX rule (rf2-b2cr)

### DIFF
--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -269,14 +269,24 @@ _INLINE_CODE_SPAN_RE = re.compile(r"(`+)(?:.+?)\1(?!`)", re.DOTALL)
 #
 # Deliberately bounded: this is boundary recognition for a CI guard, not a
 # markdown parser.  Only the interrupting starters this corpus actually uses are
-# listed, each matched at the ≤3-space indent CommonMark allows (4+ spaces is an
-# indented code block, which cannot interrupt a paragraph and so is a
-# continuation line here, exactly as it is for the renderer).  They split in two
-# by whether the block can be CONTINUED by the following line:
+# listed, each matched at the indent THE RENDERER allows it — for most of them
+# the ≤3 spaces CommonMark permits (4+ spaces is an indented code block, which
+# cannot interrupt a paragraph and so is a continuation line here, exactly as it
+# is for the renderer).  They split in two by whether the block can be CONTINUED
+# by the following line:
 #
 # `_LEAF_LINE_BLOCK_RE` — blocks that are complete on their own line, so they
 # bound the unit on BOTH sides (nothing after them continues them either):
-#   * ATX heading — `#` .. `######`.
+#   * ATX heading — `#` .. `######`, at COLUMN ZERO ONLY (rf2-b2cr).  This is
+#     the one place the renderer is STRICTER than CommonMark:
+#     `HashHeaderProcessor.RE` is anchored `(?:^|\n)#{1,6}` and allows no
+#     leading space whatsoever, so `   ### Title` is paragraph text, not a
+#     heading.  `_HEADING_RE` already mints ids on that rule; matching it here
+#     is what stops the two halves of this file from disagreeing about what a
+#     heading is.  Encoding CommonMark's ≤3 instead cost the gate in both
+#     directions: it ended a unit mid-code-span and invented a link to check,
+#     and it split a single rendered paragraph in two and dropped the real link
+#     that wrapped across the split.
 #   * Thematic break / setext underline — `---`, `***`, `___`, `===`.  A setext
 #     underline ENDS the paragraph above it (turning it into a heading), so it
 #     bounds the unit either way and the two readings need not be told apart.
@@ -295,13 +305,15 @@ _INLINE_CODE_SPAN_RE = re.compile(r"(`+)(?:.+?)\1(?!`)", re.DOTALL)
 # the paragraph above, while a following unprefixed line is CommonMark lazy
 # continuation of the quoted paragraph and must NOT bound the unit.
 _LEAF_LINE_BLOCK_RE = re.compile(
-    r"""^[ ]{0,3}(?:
-          \#{1,6}(?:[ \t]|$)              # ATX heading
-        | (?:\*[ \t]*){3,}$               # thematic break ***
-        | (?:-[ \t]*){3,}$                # thematic break --- / setext H2
-        | (?:_[ \t]*){3,}$                # thematic break ___
-        | =+[ \t]*$                       # setext H1 underline
-        | \|                              # table row
+    r"""^(?:
+          \#{1,6}(?:[ \t]|$)                  # ATX heading — COLUMN ZERO ONLY
+        | [ ]{0,3}(?:
+              (?:\*[ \t]*){3,}$               # thematic break ***
+            | (?:-[ \t]*){3,}$                # thematic break --- / setext H2
+            | (?:_[ \t]*){3,}$                # thematic break ___
+            | =+[ \t]*$                       # setext H1 underline
+            | \|                              # table row
+          )
     )""",
     re.VERBOSE,
 )

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -2385,6 +2385,52 @@ def _run_self_tests(verbose: bool = False) -> int:
          [(1, "A stray ` backtick opens no span,"),
           (2, "and [the real link](target.md#anchor) follows.")],
          [(2, "target.md#anchor")]),
+        # ------------------------------------------------------------------
+        # rf2-b2cr — an ATX heading interrupts a paragraph only at COLUMN ZERO.
+        #
+        # `_LEAF_LINE_BLOCK_RE` allowed the ≤3-space indent CommonMark permits.
+        # python-markdown does not: `HashHeaderProcessor.RE` is anchored
+        # `(?:^|\n)#{1,6}`, with no leading-space allowance at all, so an
+        # indented `###` is ordinary paragraph text.  `_HEADING_RE` above
+        # already encodes the column-zero rule — this predicate was the lone
+        # dissenter, and the two now agree.
+        #
+        # It cost the gate in BOTH directions, which is why the bead's
+        # "spurious complaint" framing understates it.  Renderer-derived, via
+        # mkdocs.config.load_config('mkdocs.yml') into a markdown.Markdown.
+        #
+        # FALSE POSITIVE — the span really does close on line 3, so the
+        # bracket is code and the renderer resolves nothing.  The gate ended
+        # the unit at line 2, saw two unpaired backtick runs, masked neither
+        # and invented a link to check.
+        ("indented ATX heading does not bound an inline code span",
+         [(1, "Prose with `a code span"),
+          (2, "   ### not a heading to python-markdown"),
+          (3, "[in](in-target.md)` closing here.")],
+         []),
+        ("indented ATX heading inside a quote does not bound one either",
+         [(1, "> Prose with `a code span"),
+          (2, ">    ### not a heading to python-markdown"),
+          (3, "> [in](in-target.md)` closing here.")],
+         []),
+        # FALSE GREEN, the direction that actually costs coverage: with no code
+        # span in play the three lines are ONE paragraph, and the renderer
+        # emits `<a href="missing.md">`.  Bounding the unit at line 2 dropped
+        # that link on the floor — a real broken link, never checked.
+        ("indented ATX heading does not bound a paragraph at all",
+         [(1, "A stray [opening"),
+          (2, "   ### Separate heading"),
+          (3, "](missing.md)")],
+         [(3, "missing.md")]),
+        # CONTROLS at column zero, where the two agree and must keep agreeing.
+        # Without these the three cases above are satisfied by a predicate that
+        # recognises no ATX heading at all.  ("ATX heading is not bridged"
+        # above is the third such control, from the other side.)
+        ("column-zero ATX heading still bounds an inline code span",
+         [(1, "Prose with `a code span"),
+          (2, "### a real heading to python-markdown"),
+          (3, "[in](in-target.md)` closing here.")],
+         [(3, "in-target.md")]),
     ]
     for label, lines, expected_links in extraction_cases:
         got_links = list(_iter_inline_links(lines))


### PR DESCRIPTION
Renderer-parity defect in `scripts/check_doc_slugs.py`. Cut from `5216c9626` (rf2-mmyc / #7795), whose matched-pair insight and renderer oracle carry directly into this work.

**SCOPE CORRECTION.** This PR was opened for the two-bead cluster rf2-b2cr + rf2-1cpt and merged while only the rf2-b2cr commits were on the branch. **It carries rf2-b2cr only.** rf2-1cpt (the quoted-fence prefix-width repair) landed separately in #7803 — do not read this PR as closing it.

## rf2-b2cr — `_LEAF_LINE_BLOCK_RE` bounded an inline block at an indented ATX heading

`_LEAF_LINE_BLOCK_RE` followed CommonMark's ≤3-space allowance for ATX headings. python-markdown does not: `HashHeaderProcessor.RE` is anchored `(?:^|\n)#{1,6}` with no leading-space allowance, so `   ### Title` is paragraph text. The fix hoists the ATX alternative out of the shared `[ ]{0,3}` prefix; the thematic break, setext underline and table row keep it, correctly, since `HRProcessor.SEARCH_RE` carries `^[ ]{0,3}` itself.

This also settles an inconsistency *inside* the file: `_HEADING_RE` has always required column zero before minting a slug, so the indexer and the block-boundary predicate disagreed about what a heading is.

**The bead's framing understates it — this is not only a false positive.** The bead calls the direction "a FALSE POSITIVE, not a blind spot", which is true of the reproducer it gives, but the same rule costs the gate in the other direction too:

```
A stray [opening
   ### Separate heading
](missing.md)
```

The renderer emits `<a href="missing.md">` — the three lines are one paragraph. The gate split the unit at line 2 and extracted nothing, so a real broken link went unchecked. Both directions are pinned, with column-zero controls that must not red.

CORPUS MOVEMENT: zero links, zero ids — and the rule demonstrably fires. 28 lines in scanned prose are reclassified; inline blocks corpus-wide drop 94202 → 94174, exactly 1:1 with those 28, across five `skills/*/SKILL.md` files. No markdown link wraps across any of those boundaries, so nothing is gained or lost.

## Quality gates

| Gate | Result | Exit |
|---|---|---|
| `python scripts/check_doc_slugs.py --self-test` | pass | 0 |
| `python scripts/check_doc_slugs.py` (full corpus, 718 files) | pass | 0 |
| `python scripts/check_readme_links.py` (consumer gate, shares the extractor) | pass | 0 |
| `python scripts/check_readme_links.py --self-test` | pass | 0 |
| `sh scripts/test-fast-pr.sh` | pass | 0 |
