### PR TITLE
test(hicasso): two roots on one frame — the other isolation axis (rf2-hic-012)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_shared_frame_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_shared_frame_dom_cljs_test.cljs
@@ -1,0 +1,483 @@
+(ns re-frame.hicasso.roots-frames-shared-frame-dom-cljs-test
+  "TWO ROOTS, ONE FRAME — the other axis (rf2-hic-012).
+
+  The bead's goal sentence has two nouns in it: independent roots *and*
+  frames cannot observe or corrupt one another. Its sibling suites take
+  the second noun. `roots-frames-isolation-dom-cljs-test` and
+  `roots-frames-hydration-dom-cljs-test` both mount root A under frame A
+  and root B under frame B, every row, so across all ten of them the root
+  axis and the frame axis are the SAME axis and nothing separates them. A
+  runtime in which roots were not independent at all — in which everything
+  root-shaped were really frame-shaped — passes every one of those rows.
+
+  This file is the case that separates them, and it is not a hypothetical:
+  `re-frame.hicasso.impl.roots/open-adoption-window!` rejects a
+  frame-keyed window registry in its own docstring, on the grounds that
+  **several roots may intentionally share a frame**. That sentence is a
+  design decision with real consequences (it is why the window is a bare
+  ref reachable only from its root's handle) and nothing anywhere
+  exercised the situation it names.
+
+  ## Sharing a frame is the case where the kernel's arithmetic is load-bearing
+
+  A sub-key is `[frame-kw query-v]` and nothing about it mentions a root.
+  So one root per frame means every cell has exactly ONE reader, which
+  means `impl.collector/release-cell!`'s `(zero? (alength readers))`
+  branch is the only branch any existing row has ever taken: every
+  unmount is a last-reader unmount and the reaper always fires. Put two
+  roots on one frame and the same key has two readers, and the arithmetic
+  starts mattering. Root A's teardown must DECREMENT that key and leave
+  it alive, because root B is still reading it.
+
+  The failure if it does not is silent in the way this bead exists to
+  catch. Root B keeps its DOM, keeps its markup, keeps rendering — it
+  simply never hears another commit, because the cell it subscribed
+  through was disposed out from under it by a sibling's teardown. No
+  error, no complaint, no visible difference until someone dispatches and
+  the screen does not move. [[unmounting-one-root-decrements-the-shared-key-and-does-not-dispose-it]]
+  is that row, and it reads liveness afterwards rather than counts alone
+  for exactly that reason.
+
+  ## The completion signal has to change with the axis
+
+  The two-frame suites wait on a frame appearing in the cell table: a
+  cell is acquired at commit, so a frame that is present has committed.
+  That signal is unavailable here — both roots share one frame, so the
+  frame appears the moment the FIRST root commits and a row waiting on it
+  would proceed with one root still in flight. The shared-frame analogue
+  is the READER COUNT on the shared key, which reaches two only when both
+  roots have committed. [[both-committed?]] is that, and it is the same
+  kind of observable for the same reason: React cannot forge it.
+
+  Everything else — why the DOM is corroboration and never the primary
+  reading, why node identity is what tells adoption from a re-render, why
+  a residue census is taken before the reset and not after —
+  `re-frame.hicasso.roots-frames-support` states once for all three
+  files."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.impl.roots :as roots]
+            [re-frame.hicasso.roots-frames-support :as sup]
+            [re-frame.test-support :as test-support]))
+
+;; ONE frame. The whole file is about what two roots do to it.
+(def ^:private shared-frame ::shared)
+
+(def ^:private label-q [::label])
+(def ^:private count-q [::count])
+
+;; Registered ABOVE `use-fixtures` — the reset fixture captures its
+;; source-store baseline when the `use-fixtures` form is EVALUATED, so a
+;; registration written below it is erased before the first row runs and
+;; every screen renders nothing.
+
+(rf/reg-sub ::label (fn [db _] (:label db)))
+(rf/reg-sub ::count (fn [db _] (:count db)))
+
+(rf/reg-event ::seed (fn [_ [_ label]] {:db {:label label :count 0}}))
+(rf/reg-event ::bump (fn [{:keys [db]} _] {:db (update db :count inc)}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     ;; `nil` and not the default: the default leaves a dynamic-var frame
+     ;; stamp in ambient scope, so a boundary that failed to resolve its
+     ;; own frame could answer that one instead. This suite makes its own.
+     :ambient-frame nil
+     ;; The MAP shape, because rows below are `async` — `cljs.test`
+     ;; refuses an async test under a fn-form fixture and aborts the whole
+     ;; browser run at this namespace when it does.
+     :async?        true
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; The app — one view, mounted twice, under ONE frame
+;; ---------------------------------------------------------------------------
+
+(h/defview panel
+  "The whole app: two subscription reads and one intent, in a single
+  boundary body. Takes no frame argument — the frame arrives from the
+  root it is mounted under, which here is the same frame for both.
+
+  One body reading two keys is what makes the two numbers below
+  independent: `:boundaries` counts registrations and `readers-of` counts
+  slots per key, so `2` and `2` are a genuine cross-check rather than one
+  number read twice."
+  [{:keys [tag]}]
+  [:div.panel {:data-tag tag :data-frame (str (h/hframe))}
+   [:span.label (h/sub label-q)]
+   [:span.count (str (h/sub count-q))]])
+
+(h/defview screen
+  "The hydration rows' app. `title` is a PROP, so a server/client
+  divergence is a one-argument change at the call site rather than a
+  second app; the subscription read is what makes the root acquire a
+  frame-keyed cell and so makes its commit observable."
+  [{:keys [title]}]
+  [:div.screen
+   [:h1.title title]
+   [:p.value (h/sub label-q)]])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- fresh!
+  "One frame, seeded, and an empty runtime."
+  []
+  (sup/leave-act-environment!)
+  (rf/make-frame {:id shared-frame})
+  (rf/with-frame shared-frame (rf/dispatch-sync [::seed "alpha"]))
+  (collector/reset-runtime!)
+  (collector/reset-body-runs!)
+  nil)
+
+(defn- text-at [handle sel]
+  (some-> (.querySelector (:container handle) sel) .-textContent))
+
+(defn- text-in [container sel]
+  (some-> (.querySelector container sel) .-textContent))
+
+(defn- both-committed?
+  "Have BOTH roots committed?
+
+  Not `cell-frames`, which the two-frame suites use: one frame is
+  mentioned by the cell table as soon as the first root commits, so that
+  predicate would answer true with a root still in flight. Two readers on
+  the shared key is the reading that needs both."
+  []
+  (= 2 (sup/readers-of [shared-frame label-q])))
+
+;; ---------------------------------------------------------------------------
+;; S1 — one cell, two readers, and both of them real
+;; ---------------------------------------------------------------------------
+
+(deftest two-roots-under-one-frame-share-one-cell-and-both-read-it
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no DOM")
+    (let [_ (fresh!)
+          a (mount/root! (mount/fresh-container!) shared-frame [panel {:tag "a"}])
+          b (mount/root! (mount/fresh-container!) shared-frame [panel {:tag "b"}])]
+      (try
+        (testing "two roots reading two queries under one frame make TWO cells,
+                  not four — the sub-key is (frame, query) and mentions no
+                  root, so sharing a frame is sharing the cell. This is the
+                  exact shape the two-frame suites never produce"
+          (is (= #{[shared-frame label-q] [shared-frame count-q]} (sup/cell-keys))
+              (str "got " (pr-str (sup/cell-keys))))
+          (is (= #{shared-frame} (sup/cell-frames))))
+
+        (testing "and each shared key carries TWO readers — the fan-out that
+                  makes `release-cell!`'s arithmetic load-bearing, and that
+                  every existing row pins at one"
+          (is (= [2 2] [(sup/readers-of [shared-frame label-q])
+                        (sup/readers-of [shared-frame count-q])])
+              (str "reader counts: " (pr-str (inventory/residue)))))
+
+        (testing "and the two readers are two DISTINCT boundaries, not one
+                  counted twice — `:boundaries` counts registrations and
+                  `readers-of` counts slots, so the two numbers can disagree
+                  and here they corroborate"
+          (is (= 2 (:boundaries (inventory/stats)))
+              (str "got " (pr-str (inventory/stats))))
+          (is (= 4 (:cell-refs (inventory/residue)))
+              "two keys at fan-out two"))
+
+        (testing "one frame is one memo row, however many roots render it —
+                  the row is keyed by frame and a second root must not mint a
+                  second"
+          (is (= #{shared-frame} (sup/frame-memo-frames))
+              (str "got " (pr-str (sup/frame-memo-frames)))))
+
+        (testing "BOTH roots are live readers of the shared key: one dispatch
+                  re-runs TWO bodies. This is what stops the counts above
+                  passing vacuously — a second reader slot that never re-ran
+                  would satisfy every assertion so far"
+          (let [ran (sup/body-runs-delta! (fn [] (mount/dispatch! a [::bump])))]
+            (is (= 2 ran)
+                (str "a commit on a shared key must notify every reader of it; "
+                     ran " bodies ran"))))
+
+        (testing "and the markup corroborates on BOTH roots — roots sharing a
+                  frame share its state, which is the whole point of allowing
+                  it, and both screens moved on one dispatch"
+          (is (= "1" (text-at a ".count")))
+          (is (= "1" (text-at b ".count")))
+          (is (= "alpha" (text-at a ".label")))
+          (is (= "alpha" (text-at b ".label")))
+          (is (= (str shared-frame) (.getAttribute (.querySelector (:container a) ".panel")
+                                                   "data-frame")))
+          (is (= (str shared-frame) (.getAttribute (.querySelector (:container b) ".panel")
+                                                   "data-frame"))))
+
+        (finally (mount/release! a) (mount/release! b))))))
+
+;; ---------------------------------------------------------------------------
+;; S2 — a teardown DECREMENTS a shared key. It does not dispose it.
+;; ---------------------------------------------------------------------------
+
+;; THE ROW THIS FILE EXISTS FOR.
+;;
+;; `impl.collector/release-cell!` splices the departing reader out and arms
+;; the reaper only `(when (zero? (alength readers)))`. With one root per
+;; frame that guard is unconditional in practice — the fan-out is always
+;; one, so every teardown is a last-reader teardown — and no landed row has
+;; ever taken the other branch. Here root A leaves a reader behind, and the
+;; guard has to hold.
+;;
+;; The failure it prevents is silent, which is why the row does not stop at
+;; the counts. A disposed cell does not throw and does not clear the screen:
+;; root B keeps every node it has and simply stops hearing commits. So after
+;; asserting the key survived, the row DISPATCHES and reads both the body
+;; count and the DOM — a stranded root re-runs zero bodies and shows a
+;; frozen number, and nothing else about it looks wrong.
+;;
+;; MUTATION (PR body records the red): make `release-cell!` arm the reaper
+;; unconditionally — `(arm-cell-reaper! cell)` with no `when` — and this row
+;; reds on the surviving key set and again on the survivor's body count,
+;; while every row in both two-frame suites stays green.
+(deftest unmounting-one-root-decrements-the-shared-key-and-does-not-dispose-it
+  (async done
+    (if-not (mount/browser?)
+      (do (sup/skip! ":node-test has no DOM") (done))
+      (let [_ (fresh!)
+            a (mount/root! (mount/fresh-container!) shared-frame [panel {:tag "a"}])
+            b (mount/root! (mount/fresh-container!) shared-frame [panel {:tag "b"}])]
+        (is (= [2 2] [(sup/readers-of [shared-frame label-q])
+                      (sup/readers-of [shared-frame count-q])])
+            "precondition: both roots are reading the shared keys")
+        ;; `unmount!` and NOT `release!` — `release!` resets the runtime, so
+        ;; every count below would read zero whether the teardown released
+        ;; anything or not.
+        (mount/unmount! a)
+        (-> (sup/quiesced!)
+            (.then
+              (fn [_]
+                (try
+                  (testing "the shared keys SURVIVE their first reader's
+                            departure — the reaper is armed on the last reader
+                            and root B is still one"
+                    (is (= #{[shared-frame label-q] [shared-frame count-q]}
+                           (sup/cell-keys))
+                        (str "a sibling's teardown disposed a key root B still
+                              reads; got " (pr-str (sup/cell-keys)))))
+
+                  (testing "decremented, not merely present: one reader each,
+                            and one boundary. A cell that kept root A's slot
+                            would be a leak and reads the same as a survivor
+                            unless the number is taken"
+                    (is (= [1 1] [(sup/readers-of [shared-frame label-q])
+                                  (sup/readers-of [shared-frame count-q])])
+                        (str "got " (pr-str (inventory/residue))))
+                    (is (= 1 (:boundaries (inventory/stats)))
+                        (str "got " (pr-str (inventory/stats)))))
+
+                  (testing "and the survivor is LIVE, which is the half a count
+                            cannot show. A cell disposed out from under root B
+                            leaves its DOM intact and its body silent — no
+                            error, no complaint, just a screen that stopped
+                            moving"
+                    (let [ran (sup/body-runs-delta!
+                                (fn [] (mount/dispatch! b [::bump])))]
+                      (is (= 1 ran)
+                          (str "the surviving root must still re-run on a
+                                commit; " ran " bodies ran")))
+                    (is (= "1" (text-at b ".count"))
+                        "and the survivor's DOM moved")
+                    (is (= "alpha" (text-at b ".label"))))
+
+                  (testing "and tearing the survivor down then releases
+                            everything — residue read BEFORE the reset, which
+                            is the only reading that can go red"
+                    (is (= sup/released (sup/teardown-census! b))))
+                  (finally
+                    (mount/release! a)
+                    (mount/release! b)
+                    (done))))))))))
+
+;; ---------------------------------------------------------------------------
+;; S3 — two hydrating roots on one frame hold two windows
+;; ---------------------------------------------------------------------------
+
+;; The witness for the sentence `impl.roots/open-adoption-window!` argues
+;; from and nothing tested: "A registry keyed by frame cannot work — several
+;; roots may intentionally share a frame."
+;;
+;; Under such a registry these two roots would look up ONE window, so root
+;; A's closer would shut the window root B is still adopting in — the exact
+;; page-global defect rf2-6tmu repaired, reintroduced at frame granularity
+;; and invisible to every landed row, because every landed row gives each
+;; root a frame of its own and a frame-keyed registry is per-root there.
+;;
+;; The two readings that discriminate are both taken by CONSTRUCTION rather
+;; than on a timer. `hydrate-root!` returns before its tree is adopted, so
+;; both windows are provably open on the line after the second call; and
+;; the windows are compared by IDENTITY, which a registry keyed by anything
+;; these two roots share cannot satisfy however it is implemented.
+;;
+;; MUTATION (PR body records the red): key the window off the frame in
+;; `hydrate-root!` — mint into a `defonce` map on first use per frame and
+;; hand both roots the same object — and this row reds on `identical?` and
+;; again on root B still adopting after root A's window is shut.
+(deftest two-hydrating-roots-on-one-frame-hold-windows-of-their-own
+  (async done
+    (if-not (mount/browser?)
+      (do (sup/skip! ":node-test has no DOM") (done))
+      (do
+        (fresh!)
+        (let [html-a (sup/server-html! shared-frame [screen {:title "A"}])
+              html-b (sup/server-html! shared-frame [screen {:title "B"}])
+              ca     (sup/stamp-server-nodes! (sup/server-dom! html-a))
+              cb     (sup/stamp-server-nodes! (sup/server-dom! html-b))]
+          (is (sup/every-server-node? ca ".screen, .title, .value")
+              "premise: the stamps are on the server's own nodes")
+          (collector/reset-runtime!)
+          (let [ha (mount/hydrate-root! ca shared-frame [screen {:title "A"}])
+                hb (mount/hydrate-root! cb shared-frame [screen {:title "B"}])]
+            (testing "each root minted a window OF ITS OWN, though both name
+                      one frame — the reading a frame-keyed registry cannot
+                      produce, taken by construction and not on a timer"
+              (is (true? (roots/adopting? (:adoption ha)))
+                  "root A is in flight — `hydrate-root!` returns before the
+                   tree is adopted, so its window outlives the call")
+              (is (true? (roots/adopting? (:adoption hb)))
+                  "and so is root B")
+              (is (not (identical? (:adoption ha) (:adoption hb)))
+                  "two roots sharing a frame must not share a window"))
+
+            (testing "so one root's closer shuts one root's window. This is
+                      the page-global defect rf2-6tmu repaired, asked again at
+                      frame granularity — where every existing row happens to
+                      be immune because no two of its roots share a frame"
+              (roots/close-adoption-window! (:adoption ha))
+              (is (false? (roots/adopting? (:adoption ha))))
+              (is (true? (roots/adopting? (:adoption hb)))
+                  "root B must still be adopting after its frame-mate closed"))
+
+            (-> (sup/wait-until! both-committed?)
+                (.then
+                  (fn [ok]
+                    (try
+                      (is (true? ok)
+                          (str "both roots must commit; readers on the shared
+                                key were "
+                               (sup/readers-of [shared-frame label-q])))
+
+                      (testing "and each root ADOPTED ITS OWN server DOM — the
+                                nodes are the very nodes each container's
+                                markup produced, which no re-render could
+                                reconstruct, and sharing a frame did not make
+                                either root adopt the other's tree"
+                        (is (sup/every-server-node? ca ".screen, .title, .value")
+                            "root A kept the server's nodes")
+                        (is (sup/every-server-node? cb ".screen, .title, .value")
+                            "root B kept the server's nodes"))
+
+                      (testing "the two roots differ where their markup differs
+                                and agree where their frame does"
+                        (is (= "A" (text-in ca ".title")))
+                        (is (= "B" (text-in cb ".title")))
+                        (is (= "alpha" (text-in ca ".value")))
+                        (is (= "alpha" (text-in cb ".value"))))
+
+                      (testing "and the shared frame is one cell with two
+                                readers here exactly as it is for two ordinary
+                                mounts — adoption changes the acquisition's
+                                timing and not its shape"
+                        (is (= #{[shared-frame label-q]} (sup/cell-keys))
+                            (str "got " (pr-str (sup/cell-keys))))
+                        (is (= 2 (sup/readers-of [shared-frame label-q]))))
+
+                      (finally (mount/release! ha) (mount/release! hb) (done))))))))))))
+
+;; ---------------------------------------------------------------------------
+;; S4 — two divergent roots on one frame complain twice
+;; ---------------------------------------------------------------------------
+
+;; H2 in the sibling suite asserts this across two frames. The fact is not
+;; the same fact here, and the difference is the whole reason this file
+;; exists: a window keyed by frame is per-root when the roots hold
+;; different frames, so H2 stays green under it. Only when the frame is
+;; SHARED does a frame-keyed window collapse two roots into one, and then
+;; root A's closer silences root B's genuine mismatch — a diagnostic
+;; missing from the instrumentation stream while the page's own error
+;; channel still shows both, which is precisely how the original
+;; page-global presented (PR #7751).
+;;
+;; So the row is read against React's own count rather than against a
+;; literal, and then against the literal too. The equality catches a
+;; diagnostic going missing; the absolute `2` catches the opposite repair,
+;; a window never shut at all.
+(deftest two-divergent-hydrating-roots-on-one-frame-complain-independently
+  (async done
+    (if-not (mount/browser?)
+      (do (sup/skip! ":node-test has no DOM") (done))
+      (do
+        (fresh!)
+        (let [html-a (sup/server-html! shared-frame [screen {:title "server-A"}])
+              html-b (sup/server-html! shared-frame [screen {:title "server-B"}])
+              ca     (sup/server-dom! html-a)
+              cb     (sup/server-dom! html-b)]
+          (collector/reset-runtime!)
+          (let [{:keys [seen stop!]}      (sup/watch-mismatches!)
+                ;; MANUFACTURED here and asserted on here — the only shape of
+                ;; call site at which swallowing an uncaught error is not the
+                ;; fail-open rf2-mwx08 forbids.
+                {:keys [captured close!]} (sup/open-console-capture! {:swallow-uncaught? true})
+                ha (mount/hydrate-root! ca shared-frame [screen {:title "client-A"}])
+                hb (mount/hydrate-root! cb shared-frame [screen {:title "client-B"}])]
+            (-> (sup/wait-until! both-committed?)
+                (.then
+                  (fn [ok]
+                    (close!)
+                    (stop!)
+                    (try
+                      (is (true? ok) "both roots must commit")
+
+                      (let [react-complaints (filterv #(re-find #"Hydration failed" %)
+                                                      @captured)]
+                        (testing "both divergences were detected and reported —
+                                  React saw two, and the reporter delegates
+                                  unconditionally, so two reach the page"
+                          (is (= 2 (count react-complaints))
+                              (str "got "
+                                   (pr-str (mapv #(subs % 0 (min 60 (count %)))
+                                                 @captured)))))
+
+                        (testing "and the framework's own stream carried exactly
+                                  what the page did, THOUGH BOTH ROOTS NAME ONE
+                                  FRAME. A window keyed by frame would have let
+                                  root A's closer silence root B here while
+                                  leaving every two-frame row green"
+                          (is (= (count react-complaints) (count @seen))
+                              (str "React said " (count react-complaints)
+                                   ", the framework said " (count @seen)))
+                          (is (= 2 (count @seen))
+                              (str "`:rf.ssr/hydration-mismatch` count; got "
+                                   (count @seen) " — "
+                                   (pr-str (mapv (comp :error sup/tags-of) @seen))))))
+
+                      (testing "and what fired is the framework diagnostic Spec
+                                011 names, tier-discriminated by its door"
+                        (doseq [ev @seen]
+                          (let [tags (sup/tags-of ev)]
+                            (is (= :rf.ssr/hydration-mismatch (:operation ev)))
+                            (is (= 're-frame.hicasso.impl.mount/hydrate-root!
+                                   (:where tags)))
+                            (is (= :warned-and-replaced (:recovery tags)))
+                            (is (string? (:error tags))))))
+
+                      (testing "and each root recovered to ITS OWN client model
+                                — a shared frame means a shared value and it
+                                does not mean a shared tree"
+                        (is (= "client-A" (text-in ca ".title")))
+                        (is (= "client-B" (text-in cb ".title")))
+                        (is (= "alpha" (text-in ca ".value")))
+                        (is (= "alpha" (text-in cb ".value"))))
+
+                      (finally (mount/release! ha) (mount/release! hb) (done))))))))))))


### PR DESCRIPTION
Closes the last open gap in **rf2-hic-012** — *Kernel: multi-root + frame isolation + root-scoped hydration adoption*.

## What was already done, and what was not

Three commits already on `main` carry this bead's id (`604dffb2b1`, `721d72ad1a`, `956027cdd5`), and `rf2-6tmu` (PR #7751) landed the root-scoped adoption window the bead's third deliverable asks for. Read against the bead's four deliverables, all four have witnesses — ten rows across `roots_frames_isolation_dom_cljs_test` and `roots_frames_hydration_dom_cljs_test`, green.

What none of them separates is the bead's own goal sentence, which has **two** nouns in it: *independent roots **and** frames cannot observe or corrupt one another*. Every one of those ten rows mounts root A under frame A and root B under frame B. Across the whole suite the root axis and the frame axis are therefore the **same axis**, and a runtime in which nothing was root-scoped at all — in which everything root-shaped were really frame-shaped — passes every existing row.

That is not a hypothetical gap. `impl/roots.cljs` rejects a frame-keyed adoption-window registry in its own docstring, on the grounds that **"several roots may intentionally share a frame"**. That sentence is load-bearing (it is why the window is a bare ref reachable only from its root's handle) and nothing anywhere exercised the situation it names.

## The new suite

`implementation/hicasso/test/re_frame/hicasso/roots_frames_shared_frame_dom_cljs_test.cljs` — two roots, one frame, four rows.

Sharing a frame is the case where the kernel's arithmetic is load-bearing. A sub-key is `[frame-kw query-v]` and mentions no root, so one root per frame means every cell has exactly **one** reader — `impl.collector/release-cell!`'s "last reader leaves" branch is the only branch any landed row has ever taken, and every unmount is a last-reader unmount. Two roots on one frame give the same key two readers, and a teardown has to *decrement* rather than dispose or the survivor is left reading a disposed cell: no error, no complaint, just a screen that stopped moving.

| row | fact |
|---|---|
| S1 | one cell, two readers, two boundaries, one memo row — and one dispatch re-runs **both** bodies, which is what stops the counts passing vacuously |
| S2 | unmounting one root decrements the shared key and does **not** dispose it; the survivor still re-runs and still moves its DOM; residue census read before the reset |
| S3 | two hydrating roots on one frame hold windows of their own — distinct by identity, independently closed, each adopting its own server nodes |
| S4 | two divergent roots on one frame complain twice, read against React's own complaint count |

The completion signal changes with the axis and the file says so: one frame is mentioned by the cell table as soon as the **first** root commits, so a `cell-frames` predicate would proceed with a root still in flight. These rows wait on the reader count reaching two.

No production code changed. The diff is one new test namespace.

## Mutation proofs

Every mutation was applied to the worktree, confirmed present in the **compiled bundle** (not merely in source), run, then reverted and re-verified byte-identical against `HEAD`. Two of the five did not red, and both non-reds are findings rather than adjustments.

**M1 — `release-cell!` arms the reaper unconditionally. DID NOT RED (0 failures).**
Confirmed in the emitted JS: `arm_cell_reaper_BANG_(cell)` with no guard. Green anyway, because the reaper's own callback re-checks `(zero? (alength (.-readers cell)))` before disposing.

**M1′ — the reader-count check removed from inside the reaper. DID NOT RED (0 failures).**
Also confirmed in the emitted JS. Green because `release-cell!` still refuses to *arm* the reaper while a reader remains, so the mutated code is unreachable.

> **Finding: the shared-cell reference count is guarded twice, and neither guard alone is load-bearing.** `release-cell!` arms only at zero *and* the reaper re-checks zero before disposing. This is defence in depth and reads as correct — the outer guard also avoids arming a timer on every release — but it means **no single-point mutation can red the survival property**, which is worth knowing for anyone grading this surface. It is exactly the "second defence downstream keeps it green" shape a witness is supposed to rule out.

**M1″ — both guards removed together (the coherent "the runtime forgot a cell can have more than one reader" defect). RED, 5 failures, all in S2:**

```
FAIL in (unmounting-one-root-decrements-the-shared-key-and-does-not-dispose-it)
expected: (= #{[shared-frame count-q] [shared-frame label-q]} (sup/cell-keys))
  actual: (not (= #{...count...} ...label...}} #{}))
expected: (= [1 1] [(sup/readers-of [shared-frame label-q]) (sup/readers-of [shared-frame count-q])])
  actual: (not (= [1 1] [0 0]))
expected: (= 1 (:boundaries (inventory/stats)))
  actual: (not (= 1 0))
expected: (= 1 ran)
  actual: (not (= 1 0))
expected: (= "1" (text-at b ".count"))
  actual: (not (= "1" "0"))
```

The last two are the silent failure the row exists for: the survivor re-ran **zero** bodies and its screen stayed on `"0"`.

**M2 — the frame-keyed window registry `impl/roots.cljs` rejects.** Modelled as a *competent* implementation (a closed entry is treated as absent and re-minted), so the only roots that collide are ones adopting the same frame at the same time. **RED, 4 failures:**

```
FAIL in (two-hydrating-roots-on-one-frame-hold-windows-of-their-own)
expected: (not (identical? (:adoption ha) (:adoption hb)))
  actual: (not (not true))
expected: (true? (roots/adopting? (:adoption hb)))
  actual: (not (true? false))

FAIL in (two-divergent-hydrating-roots-on-one-frame-complain-independently)
expected: (= (count react-complaints) (count (clojure.core/deref seen)))
  actual: (not (= 2 1))
expected: (= 2 (count (clojure.core/deref seen)))
  actual: (not (= 2 1))
```

That is the original page-global defect reproduced exactly, at frame granularity: React reported two divergences and the framework's instrumentation stream carried one.

**M3 — the reader list collapsed to a flag (`acquire-cell!` records only the first reader). RED, 14 failures** across all four new rows, including S1's `[2 2] → [1 1]`, `:boundaries 2 → 1`, `:cell-refs 4 → 2`, `(= 2 ran) → 1`, and root B's DOM frozen at `"0"`.

**M4 — the bead's own stated acceptance sabotage**, run here because no PR had re-verified it: *"re-globalizing the adoption window must turn the overlapping-roots witness red."* One `defonce` window for the whole page, handed to every hydrating root (the pre-rf2-6tmu shape). **RED, 6 failures**, and the overlapping-roots witness is among them:

```
FAIL in (two-overlapping-hydrating-roots-recover-and-complain-independently)
expected: (= (count react-complaints) (count (clojure.core/deref seen)))
  actual: (not (= 2 1))
expected: (= 2 (count (clojure.core/deref seen)))
  actual: (not (= 2 1))
```

That is the historical signature exactly: React reported two divergences, the framework's instrumentation stream carried one. **The bead's acceptance criterion is therefore discharged with evidence.** The other four failures are S3 and S4.

`presence-adoption-belongs-to-a-subtree-not-to-the-page` (H5) correctly stayed green under M4, and that is not a miss: M4 changes only where the window is *minted*, while H5's defect lives in the *reader* path. The provider still wraps only the hydrating root's subtree, so an ordinary root still reads `nil`. H5's own in-file note names the different sabotage it needs.

**The control that matters most: on M1″, M2 and M3 alike, all ten rows in the two existing two-frame suites stayed green.** Their fan-out is always one and their roots never share a frame, so a collapsed reference count and a frame-keyed window are both invisible to them. That is the empirical form of this PR's argument. (M4 is the deliberate exception — a page-global window is the one defect the existing overlapping-roots row *was* built to catch, and it caught it.)

One assertion is honestly *not* independently mutation-proved: S1's `#{two keys}` "two cells, not four" reading. No mutation run here changes the cell **key** shape (that would mean re-keying cells by root, an invasive rewrite rather than a defect model). It is descriptive — it records that sharing happens — and the reader-count assertions on those same keys carry the discrimination. The equivalent cell-key assertion in S2 *is* proved, by M1″.

## Quality gates

| gate | exit | notes |
|---|---|---|
| `shadow-cljs compile browser-test` (hicasso `roots-frames-*`) + `serve-and-run-browser-tests.cjs` | `0` | **14 tests / 153 assertions / 0 failures, 0 errors.** Baseline before this change was 10 / 101 / 0. Gate root confirmed as this worktree. |
| `npm run test:hicasso-freeze` | `0` | self-test + freeze + optional-module reachability, all OK |
| `npm run test:hicasso-lint` | `0` | `check_lint_export` self-test PASS; 6 checks fire on their fixtures |
| `clj-kondo --parallel --fail-level error --lint implementation` | `3` locally, **`0` in CI** | **Zero findings in the new file** — `grep -c roots_frames_shared_frame` on the report is `0`. The 10 local errors are all pre-existing `Expected: throwable, received: …` in `implementation/ui/**` and `implementation/epoch/**`, untouched by this diff (the diff adds exactly one file). Local clj-kondo is `2025.10.23`; **CI pins `2026.04.15`** (`lint.yml`), so the local exit code is version drift, not a finding — and CI's `clj-kondo` job has since passed, which settles it. |
| `scripts/test-fast-pr.sh` | `0` | `PASS fast PR spine`. First line `gate root: /c/Users/miket/code/re-frame2-worktrees/rootsframes-hic012` — this worktree, not another's. Run to completion; detached only because it outruns the tool's time ceiling, and blocked on until it exited. |
| `python scripts/check_fast_pr_gap.py --list` | `0` | derived rather than hand-listed; see below |
| `npm run test:browser` (full lane) | **not run locally** | Deliberate, and stated rather than silently skipped. The machine was running three other workers' gates concurrently; the full lane is a ~20-minute compile that would have contended with them. What was run locally is the **same `:browser-test` build and the same Playwright runner**, narrowed by `--config-merge` to `^re-frame[.]hicasso[.]roots-frames-.*-dom-cljs-test$` — i.e. every namespace this diff can affect, since the diff adds one file that requires only existing namespaces. **CI has since run the full lane: `CLJS (shadow-cljs :browser-test, headless Chromium)` — pass, 2m5s.** |

**CI on this PR is green**, including all three required contexts: `All required checks passed`, `Lint required`, `Docs required`. Also green: `CLJS (shadow-cljs :node-test)` 12m23s, `CLJS hicasso controlled-input correctness` 1m30s, `clj-kondo` 2m0s, `Splint` 1m0s.

Gate-selection notes:

- `python scripts/check_fast_pr_gap.py --list` (exit `0`) was run rather than hand-listing. It names 94 required checks the spine does not decide. The one this diff actually arms is **`cljs-browser` — "CLJS (shadow-cljs :browser-test, headless Chromium)" — `cd implementation && npm run test:browser`**, which is why the full lane is run above and not only the narrowed build used for the mutation work.
- The changed-surface classifier arms `cljs_node_test` **and** `cljs_browser` for `implementation/hicasso/*` (`report-changed-surfaces.sh`, widened by rf2-8a6s). The new namespace ends `-dom-cljs-test`, so `:browser-test`'s `^(?!re-frame\.freehand\.bench\.).*-dom-cljs-test$` selects it with no config edit, and `:node-test` / `:node-test-hicasso`'s `cljs-test$` also matches it, where it degrades to `sup/skip!`'s stated skip. `check_test_lane_bijection.py` reads lanes from the build files, so a new file in an existing lane needs no roster entry.
- **No hot-zone file is touched**: no `spec/*`, no `implementation/deps.edn`, no `implementation/shadow-cljs.edn`, no `.github/workflows/*`. No new `:rf.error/*` id is minted, so `check_keyword_catalogue_drift` needs no spec/009 co-edit — spec/009 is held by the rf2-hic-007 worker and this PR stays off it.
- `mkdocs build --strict` is **not** nominated: this diff adds no documentation and mkdocs does not cover `docs/design/**` in any case. `scripts/check_doc_slugs.py` does not scan `implementation/`, so it is not the gate for this surface either.

## Fences

Off every named surface: `impl/error.cljc` and the `defview`/`defhost` macro expansion (rf2-hic-007), `impl/collector.cljs`'s `mint-view!` (the retention worker), the `re-frame.hicasso.test` kit (rf2-hic-020), `evidence.cljs` / `tool.cljs` / the Xray hicasso panels (rf2-hic-023), and `scripts/check_doc_slugs.py`.

`collector.cljs` and `mount.cljs` were mutated **temporarily and locally** for the proofs above and restored byte-identical — `git status` clean, no `RF2HIC012MUT` token anywhere in the tree. Neither file appears in this diff. No `tools/xray/` file is touched, so `tools/xray/spec/*` is unchanged because this PR adds no Xray surface.

## Note for rf2-hic-022

The `re-frame.hicasso/direct-view-call` false positive was **not** hit. None of this suite's views shadows its own name with a parameter, destructured key or `let` binding, so no rename was needed and no suppression was added. Recording the negative so the repair bead is not credited with a second instance it did not have.
