### PR TITLE
fix(hicasso): the #7789 audit repair — projected identity, frame-scoped Why, per-view empties (rf2-hic-023)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/tool.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/tool.cljs
@@ -785,7 +785,15 @@
   []
   (when interop/debug-enabled?
     (let [rows      (entry-rows)
-          frame-ids (hicasso-frames)
+          ;; Every frame that could hold a lead for one of these rows: the
+          ;; frames this runtime dispatches through, PLUS any frame a
+          ;; boundary reads from. A boundary reading across a frame the
+          ;; frame-ops table does not name still has a window, and scoping
+          ;; the search per boundary is only honest if that window is in it.
+          frame-ids (vec (sort-by pr-str
+                                  (into (set (hicasso-frames))
+                                        (mapcat (fn [r] (map :frame-id (:reads r))))
+                                        rows)))
           windows   (into {} (map (fn [fid] [fid (trace-tooling/trace-buffer fid)])) frame-ids)
           runs      (reduce + 0 (map count (vals windows)))
           ;; Keyed by [frame-id sub-id]: a run that recomputed `:todo` in

--- a/implementation/hicasso/src/re_frame/hicasso/tool.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/tool.cljs
@@ -82,6 +82,18 @@
   declarations are applied. It fails CLOSED: a frameless or destroyed-frame
   read redacts the whole query rather than shipping it under no policy.
 
+  **A BOUNDARY'S KEY IS A PROJECTION TOO, and that is not a detail.** The
+  identity here is the read set, so a key built from raw sub-keys would
+  carry every query argument a moment after the `:query` FIELD had been
+  projected — and carry it further, because a key is what joins two
+  rosters, prints in a boundary's label and becomes a DOM id. It shipped
+  that way once and the merged-PR audit of #7789 caught it. Every exported
+  key element is now a [[read-identity]]: frame, registration id, and the
+  projected query. The join is unaffected — both rosters derive keys
+  through the one function, so identical read sets still produce identical
+  keys — while the arguments stay behind the projector on every path out
+  of this namespace, including after frame destruction.
+
   Retained-window events are carried as an event ID and an argument
   COUNT. The event vector itself is not carried at any classification,
   because the classification model is fail-open — an event that declared
@@ -133,17 +145,6 @@
   [key-fn xs]
   (vec (sort-by (fn [x] (pr-str (key-fn x))) xs)))
 
-(defn- boundary-key
-  "The tool-tier identity of a boundary: its read-key set, in
-  [[ordered]]'s order.
-
-  Derived identically from a registration's `.-reads` and from a read-set
-  entry's `.-set`, which is what makes [[read-mounted-boundaries]] and
-  [[read-read-attribution]] join. See the namespace docstring for why the
-  edge set is the identity the runtime actually retains."
-  [read-key-set]
-  (ordered identity read-key-set))
-
 ;; ---------------------------------------------------------------------------
 ;; Privacy — the existing projectors, at this door
 ;; ---------------------------------------------------------------------------
@@ -179,9 +180,53 @@
         (and (vector? query-v) (seq query-v)) (nth query-v 0)
         :else                                 evidence/unknown))
 
+(defn- read-identity
+  "One read edge's EXPORTED identity: `[frame-id sub-id projected-query]`.
+
+  Three fields rather than the raw sub-key's two, and the third is
+  projected. The `sub-id` is carried explicitly because it is the one
+  spelling that survives redaction: when a frame's policy elides a query
+  whole, `[:cart/item \"…\"]` and `[:user/token \"…\"]` both project to the
+  same sentinel, and without the registration id beside it a reader —
+  and a boundary key — could no longer tell those two edges apart at all.
+
+  This is therefore as fine an identity as the egress policy allows and
+  no finer, which is the honest ceiling: where an application has
+  declared its arguments sensitive, two boundaries differing only in
+  those arguments ARE one row here, and `:read-orders` counts what
+  folded in."
+  [sub-key]
+  (let [frame-id (nth sub-key 0)
+        query-v  (nth sub-key 1)]
+    [frame-id (sub-id-of query-v) (projected-query frame-id query-v)]))
+
+(defn- boundary-key
+  "The tool-tier identity of a boundary: its read-key set PROJECTED, in
+  [[ordered]]'s order.
+
+  Derived identically from a registration's `.-reads` and from a read-set
+  entry's `.-set`, which is what makes [[read-mounted-boundaries]] and
+  [[read-read-attribution]] join. See the namespace docstring for why the
+  edge set is the identity the runtime actually retains.
+
+  **Every element is a [[read-identity]], never a raw sub-key.** The raw
+  sub-key carries the application's own query VECTOR, arguments and all,
+  so a key built from it would be an egress path for exactly the data
+  [[projected-query]] exists to project — and a worse one, because a key
+  is also what a panel prints in a label and hashes into a DOM id. The
+  join survives because both sides derive the key by this one function:
+  identical raw sets project to identical keys, and the projection is a
+  pure function of the query and its frame."
+  [read-key-set]
+  (ordered identity (map read-identity read-key-set)))
+
 (defn- read-row
   "One read edge, as a row — the query and where it lives, and NEVER what
-  it returned."
+  it returned.
+
+  Takes the RAW sub-key because the cell table is keyed by it: the epoch
+  lookup is an internal read against live runtime state, and nothing raw
+  survives into the row this builds."
   [sub-key]
   (let [frame-id (nth sub-key 0)
         query-v  (nth sub-key 1)]
@@ -223,7 +268,23 @@
   Commit, paint, retry, abandonment, StrictMode duplication and Activity
   hide/reveal are all decided above this runtime, and a render measure is
   none of them. Stated once, on every envelope that would otherwise invite
-  a reader to infer them from an epoch."
+  a reader to infer them from an epoch.
+
+  `:visibility` and `:hidden-retained` are here because the real-React
+  lifecycle witness established that this door's tables CANNOT tell three
+  states apart, and a reader would otherwise assume they can (rf2-hic-023,
+  merged-PR audit #7792):
+
+  - an Activity-hidden subtree that has released its reads and an
+    UNMOUNTED one are the same census row — namely, no row at all — until
+    a later 0-to-1 re-subscribe reveals the retention retrospectively;
+  - a Suspense-fallback-hidden subtree stays SUBSCRIBED, so it is present
+    in every roster here while absent from the screen.
+
+  Both are stated as [[re-frame.hicasso.evidence/unknown]] on a
+  `:host-opaque` basis rather than guessed at. The alternative — inferring
+  hidden-retained from an empty census, or labelling a subscribed row
+  visible — is the exact fabrication the schema exists to refuse."
   {:scope           :host-private
    :basis           :host-opaque
    :complete?       false
@@ -231,12 +292,19 @@
    :commit          evidence/unknown
    :paint           evidence/unknown
    :attempt-outcome evidence/unknown
+   :visibility      evidence/unknown
+   :hidden-retained evidence/unknown
    :why             (str "Whether a notified boundary re-ran, retried, was "
                          "abandoned, was bailed out by its memo comparator, or "
-                         "committed and painted is React's to know. React "
-                         "DevTools and the browser performance tools are the "
-                         "authority; this producer does not restate them from "
-                         "timing adjacency.")})
+                         "committed and painted is React's to know. So is "
+                         "whether it is on screen: an Activity-hidden subtree "
+                         "that released its reads is indistinguishable here "
+                         "from an unmounted one, and a Suspense-fallback-hidden "
+                         "subtree stays subscribed and so still appears in "
+                         "every roster. These rosters are about SUBSCRIPTION, "
+                         "not visibility. React DevTools and the browser "
+                         "performance tools are the authority; this producer "
+                         "does not restate them from timing adjacency.")})
 
 ;; ---------------------------------------------------------------------------
 ;; Read 1 — mounted boundaries
@@ -256,7 +324,15 @@
   Two entries whose key ARRAYS differ only in order are one row, because
   their edge sets are equal and the edge set is this door's identity. The
   runtime distinguishes them — the entry compare is ordered — so the row
-  says `:read-orders` when it has collapsed more than one."
+  says `:read-orders` when it has collapsed more than one.
+
+  Rows are grouped by the PROJECTED [[boundary-key]], so `:read-orders`
+  also counts entries folded together because an application declared the
+  arguments that told them apart sensitive. That is the right place for
+  that collapse to happen: the alternative is a census keyed on data the
+  door has promised not to carry, or two rows sharing one exported
+  identity — which would give a panel duplicate DOM ids and a consumer an
+  ambiguous join."
   []
   (let [live (for [[_ bucket] @collector/!entries
                    ^js entry  bucket
@@ -265,14 +341,19 @@
     (->> live
          (group-by (fn [^js entry] (boundary-key (.-set entry))))
          (map (fn [[bkey entries]]
-                {:boundary    {:parent nil :key bkey}
-                 :view        evidence/unknown
-                 :source      evidence/unknown
-                 :instances   (reduce + 0 (map (fn [^js e] (.-refs e)) entries))
-                 :read-orders (count entries)
-                 :frame       (let [fs (into #{} (map #(nth % 0)) bkey)]
-                                (if (= 1 (count fs)) (first fs) evidence/unknown))
-                 :reads       (mapv read-row bkey)}))
+                ;; The RAW sub-keys stay here and go no further: `read-row`
+                ;; needs them to reach the cell table, and every field it
+                ;; answers with is projected.
+                (let [raw-keys (ordered identity
+                                        (into #{} (mapcat (fn [^js e] (seq (.-set e)))) entries))]
+                  {:boundary    {:parent nil :key bkey}
+                   :view        evidence/unknown
+                   :source      evidence/unknown
+                   :instances   (reduce + 0 (map (fn [^js e] (.-refs e)) entries))
+                   :read-orders (count entries)
+                   :frame       (let [fs (into #{} (map #(nth % 0)) bkey)]
+                                  (if (= 1 (count fs)) (first fs) evidence/unknown))
+                   :reads       (mapv read-row raw-keys)})))
          (ordered (comp :key :boundary)))))
 
 (defn read-mounted-boundaries
@@ -287,7 +368,7 @@
       ;;     :basis      :observation
       ;;     :complete?  true
       ;;     :loss       nil
-      ;;     :boundaries [{:boundary  {:parent nil :key [[:app/main [:todo 7]]]}
+      ;;     :boundaries [{:boundary  {:parent nil :key [[:app/main :todo [:todo 7]]]}
       ;;                   :view      :unknown
       ;;                   :source    :unknown
       ;;                   :instances 3
@@ -306,12 +387,20 @@
   table. A rendered-but-not-yet-committed boundary is outside the scope
   rather than missing from the roster; its entry has no reference yet.
 
-  An EMPTY `:boundaries` is the one empty answer that is a clean bill of
-  health, because the entry cache is authoritative about what is mounted.
+  An EMPTY `:boundaries` says exactly one thing: **no boundary holds a
+  live read edge right now.** The entry cache is authoritative about that
+  and this read is complete for it. What the empty does NOT establish is
+  that nothing is retained above — an Activity-hidden subtree that has
+  released its reads leaves the same empty census as an unmounted one, and
+  only a later re-subscribe distinguishes them, retrospectively (audit
+  #7792). Read the other way round, a row here is not proof the boundary
+  is on SCREEN: a Suspense-fallback-hidden subtree stays subscribed and
+  stays in this roster.
+
   Everything this read does not know is in `:naming` and `:host`, which
   are projections of their own with their own bases and their own losses —
   so a reader can never mistake *nothing is mounted* for *nothing could be
-  seen*."
+  seen*, nor *subscribed* for *visible*."
   []
   (when interop/debug-enabled?
     (evidence/envelope
@@ -362,7 +451,7 @@
       ;;     :scope :read-edges :basis :observation :complete? true :loss nil
       ;;     :edges [{:sub-id :todo :query [:todo 7] :frame-id :app/main
       ;;              :epoch 4 :fan-out 3
-      ;;              :readers [{:parent nil :key [[:app/main [:todo 7]]]}]}]
+      ;;              :readers [{:parent nil :key [[:app/main :todo [:todo 7]]]}]}]
       ;;     :host  {…}}
 
   THIS IS THE ONE READ THAT IS EXACT WITHOUT QUALIFICATION. The others
@@ -430,17 +519,74 @@
   where a reader knows they are looking at application data.
 
   `:sub-ids` is what that run recomputed, which is the axis an
-  [[explain-render]] candidate is matched on."
+  [[explain-render]] candidate is matched on.
+
+  `:frames` is a SET rather than the one frame whose ring this bundle was
+  drawn from — see [[intent-rows]] for why one dispatch can surface in
+  more than one ring, and why answering per ring would print one event
+  twice."
   [frame-id bundle]
   (let [event (:event bundle)]
-    {:frame-id    frame-id
+    {:frames      #{frame-id}
      :dispatch-id (:dispatch-id bundle)
      :event-id    (if (vector? event) (nth event 0) evidence/unknown)
      :arg-count   (if (vector? event) (dec (count event)) evidence/unknown)
-     :sub-ids     (vec (sort-by pr-str
-                                (into #{}
-                                      (keep #(get-in % [:tags :rf.sub/id]))
-                                      (:subs bundle))))}))
+     :sub-ids     (into #{} (keep #(get-in % [:tags :rf.sub/id])) (:subs bundle))}))
+
+(defn- merge-fragments
+  "Fold the ring fragments of ONE dispatch into one row.
+
+  Spec 009's rings are per frame, and a dispatch that touched two frames
+  is captured in both — so the same `:dispatch-id` can arrive twice. Two
+  rows would print one user action as two events; keeping only the first
+  would drop half of what it recomputed. Merging says the true thing:
+  one dispatch, the frames it reached, everything it recomputed."
+  [rows]
+  (-> (reduce (fn [acc row]
+                (update acc (:dispatch-id row)
+                        (fn [seen]
+                          (if seen
+                            (-> seen
+                                (update :frames into (:frames row))
+                                (update :sub-ids into (:sub-ids row)))
+                            row))))
+              {}
+              rows)
+      vals))
+
+(defn- intent-rows
+  "The retained window as ONE stream: every fragment merged by dispatch,
+  ordered by `:dispatch-id`, oldest first.
+
+  The id is allocated process-monotonically at queue time
+  (`re-frame.router`), so it IS the dispatch order across every frame —
+  which is what lets this read promise order and mean it. The previous
+  shape concatenated whole per-frame rings in frame-id ORDER, so with two
+  frames live the stream claimed a sequence that never happened; frame-id
+  order is alphabetical, not temporal.
+
+  A row whose bundle carries no id cannot be joined or placed, so it
+  keeps its own identity and sorts last rather than merging with every
+  other such row into one fictitious event."
+  [windows frame-ids]
+  (let [rows (into []
+                   (mapcat (fn [fid]
+                             (map-indexed
+                               (fn [i bundle]
+                                 (let [row (intent-row fid bundle)]
+                                   (cond-> row
+                                     (nil? (:dispatch-id row))
+                                     (assoc :dispatch-id [::unjoinable fid i]))))
+                               (get windows fid))))
+                   frame-ids)]
+    (->> (merge-fragments rows)
+         (sort-by (fn [{:keys [dispatch-id]}]
+                    (if (number? dispatch-id) dispatch-id js/Number.MAX_SAFE_INTEGER)))
+         (mapv (fn [row]
+                 (-> row
+                     (update :frames #(vec (sort-by pr-str %)))
+                     (update :sub-ids #(vec (sort-by pr-str %)))
+                     (update :dispatch-id #(if (number? %) % evidence/unknown))))))))
 
 (defn read-intents
   "What was dispatched inside Spec 009's RETAINED WINDOW, oldest first,
@@ -452,10 +598,16 @@
       ;;     :scope {:frames [:app/main] :retained-runs 12}
       ;;     :basis :observation :complete? false
       ;;     :loss  {:reason :cap :dropped :unknown}
-      ;;     :intents [{:frame-id :app/main :dispatch-id 41
+      ;;     :intents [{:frames [:app/main] :dispatch-id 41
       ;;                :event-id :todo/toggle :arg-count 1
       ;;                :sub-ids [:todo]}]
       ;;     :origin  {…:basis :opaque :intent-origin :unknown}}
+
+  **ORDER IS THE POINT, so it is reconstructed rather than assumed.**
+  Spec 009's rings are per frame; the stream is one, ordered by the
+  process-monotonic `:dispatch-id` the router allocates at queue time, and
+  fragments of one dispatch captured in two rings are merged into the one
+  row they describe. See [[intent-rows]].
 
   NOTHING IS RETAINED TO ANSWER THIS. The stream is the per-frame
   retained-event ring Spec 009 already owns, under its single knob
@@ -481,9 +633,7 @@
   (when interop/debug-enabled?
     (let [frame-ids (hicasso-frames)
           windows   (into {} (map (fn [fid] [fid (trace-tooling/trace-buffer fid)])) frame-ids)
-          rows      (into []
-                          (mapcat (fn [fid] (map #(intent-row fid %) (get windows fid))))
-                          frame-ids)]
+          rows      (intent-rows windows frame-ids)]
       (evidence/envelope
         {:schema    evidence/schema
          :producer  evidence/producer
@@ -538,19 +688,38 @@
   retention off, or nothing dispatched since the ring was released — no
   search happened, so `:candidates` states
   [[re-frame.hicasso.evidence/unknown]] and the reason is `:cap`. An `[]`
-  in that state would be the fail-open shape this schema refuses."
-  [window-runs candidates-by-sub-id row]
+  in that state would be the fail-open shape this schema refuses.
+
+  **BOTH HALVES ARE SCOPED TO THE BOUNDARY'S OWN FRAMES.** The window
+  searched is the rings of the frames this boundary actually reads from,
+  and a candidate must match a read on `[frame-id sub-id]` — not on the
+  sub-id alone. Counting runs globally would let activity in frame B make
+  a frame-A row claim its window was searched when frame A's ring is
+  empty, which converts a `:cap` into an `:uncorrelated` and tells the
+  reader a survey happened that did not. Matching on the sub-id alone
+  would then offer B's runs as A's leads for no better reason than that
+  two frames registered the same sub id — the definition of a lead
+  fabricated from a coincidence (audit #7789).
+
+  A read-free boundary reads from no frame, so it searches nothing and
+  reports `:cap`. That is exact: there is no window in which its cause
+  could be found, because it holds nothing that could have moved."
+  [windows candidates-by-frame-sub row]
   (let [reads   (:reads row)
+        frames  (into #{} (map :frame-id) reads)
+        runs    (reduce + 0 (map #(count (get windows %)) frames))
         epochs  (into [] (keep #(when (number? (:epoch %)) (:epoch %))) reads)
         peak    (when (seq epochs) (reduce max epochs))
-        looked? (pos? window-runs)
+        looked? (pos? runs)
         leads   (ordered :dispatch-id
                          (into #{}
-                               (mapcat (fn [{:keys [sub-id]}]
-                                         (get candidates-by-sub-id sub-id)))
+                               (mapcat (fn [{:keys [frame-id sub-id]}]
+                                         (get candidates-by-frame-sub [frame-id sub-id])))
                                reads))]
     (evidence/projection
-      {:scope        {:boundary (:key (:boundary row)) :retained-runs window-runs}
+      {:scope        {:boundary (:key (:boundary row))
+                      :frames   (vec (sort-by pr-str frames))
+                      :retained-runs runs}
        :basis        :observation
        :complete?    false
        :loss         (if looked?
@@ -561,8 +730,16 @@
        :instances    (:instances row)
        :snapshot     (if (seq epochs) (reduce + epochs) evidence/unknown)
        :peak-epoch   (or peak evidence/unknown)
+       ;; The READ IDENTITY, not the bare sub-id: `[:row 1]` and `[:row 2]`
+       ;; are one sub-id and two different reads, and a Why view that
+       ;; collapsed them would answer "`:row` moved" to a developer looking
+       ;; at eight rows. The query is already projected on the read row, so
+       ;; naming it here carries nothing new (audit #7789).
        :latest-reads (if (seq epochs)
-                       (into [] (comp (filter #(= peak (:epoch %))) (map :sub-id)) reads)
+                       (into []
+                             (comp (filter #(= peak (:epoch %)))
+                                   (map #(select-keys % [:sub-id :query :frame-id])))
+                             reads)
                        evidence/unknown)
        :cause        evidence/unknown
        :candidates   (if looked? leads evidence/unknown)})))
@@ -577,10 +754,11 @@
       ;;     :complete? false :loss {:reason :uncorrelated :dropped :unknown}
       ;;     :explanations [{:boundary {…} :frame :app/main :instances 1
       ;;                     :snapshot 9 :peak-epoch 5
-      ;;                     :latest-reads [:todo]
+      ;;                     :latest-reads [{:sub-id :todo :query [:todo 7]
+      ;;                                     :frame-id :app/main}]
       ;;                     :cause :unknown
       ;;                     :candidates [{:dispatch-id 41 :event-id :todo/toggle
-      ;;                                   :sub-id :todo}]
+      ;;                                   :frame-id :app/main :sub-id :todo}]
       ;;                     :basis :observation :complete? false
       ;;                     :loss {:reason :uncorrelated :dropped :unknown}}]
       ;;     :host {…}}
@@ -610,14 +788,18 @@
           frame-ids (hicasso-frames)
           windows   (into {} (map (fn [fid] [fid (trace-tooling/trace-buffer fid)])) frame-ids)
           runs      (reduce + 0 (map count (vals windows)))
+          ;; Keyed by [frame-id sub-id]: a run that recomputed `:todo` in
+          ;; frame B is not a lead for a boundary reading `:todo` in frame
+          ;; A, however alike the two ids look.
           leads     (for [fid    frame-ids
                           bundle (get windows fid)
                           sid    (keep #(get-in % [:tags :rf.sub/id]) (:subs bundle))]
-                      [sid {:dispatch-id (:dispatch-id bundle)
-                            :event-id    (when (vector? (:event bundle))
-                                           (nth (:event bundle) 0))
-                            :sub-id      sid}])
-          by-sub-id (reduce (fn [m [sid lead]] (update m sid (fnil conj #{}) lead)) {} leads)]
+                      [[fid sid] {:dispatch-id (:dispatch-id bundle)
+                                  :event-id    (when (vector? (:event bundle))
+                                                 (nth (:event bundle) 0))
+                                  :frame-id    fid
+                                  :sub-id      sid}])
+          by-frame-sub (reduce (fn [m [k lead]] (update m k (fnil conj #{}) lead)) {} leads)]
       (evidence/envelope
         {:schema       evidence/schema
          :producer     evidence/producer
@@ -626,6 +808,6 @@
          :basis        :observation
          :complete?    false
          :loss         {:reason :uncorrelated :dropped evidence/unknown}
-         :explanations (mapv #(explanation runs by-sub-id %) rows)
+         :explanations (mapv #(explanation windows by-frame-sub %) rows)
          :window       {:frames frame-ids :retained-runs runs}
          :host         (evidence/projection host-projection)}))))

--- a/implementation/hicasso/test/re_frame/hicasso/tool_reads_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/tool_reads_cljs_test.cljs
@@ -83,15 +83,27 @@
                                  :rows [:a :b :c]}]))
   frame-id)
 
-(defn- mount!
-  "Render `body-fn` as a boundary and COMMIT it — the entry claims its
-  reference exactly as React's passive effect would. Answers the
+(defn- mount-in!
+  "Render `body-fn` as a boundary in `fid` and COMMIT it — the entry claims
+  its reference exactly as React's passive effect would. Answers the
   unsubscribe React would hold."
-  [body-fn]
-  (collector/render-body frame-id body-fn {})
+  [fid body-fn]
+  (collector/render-body fid body-fn {})
   (collector/commit-boundary! (collector/last-reads) (fn [])))
 
-(defn- k [query-v] [frame-id query-v])
+(defn- mount! [body-fn] (mount-in! frame-id body-fn))
+
+(defn- k
+  "A RAW cell key — what the runtime's own tables are keyed by."
+  [query-v]
+  [frame-id query-v])
+
+(defn- bk
+  "One element of an EXPORTED boundary key: frame, registration id, and the
+  projected query. Distinct from [[k]] on purpose — the raw key is what the
+  runtime holds, this is what the door is allowed to say (audit #7789)."
+  ([query-v] (bk frame-id query-v))
+  ([fid query-v] [fid (first query-v) query-v]))
 
 (defn- envelopes
   "All four reads, in one turn."
@@ -135,9 +147,9 @@
       (let [e    (tool/read-mounted-boundaries)
             rows (into {} (map (juxt (comp :key :boundary) identity)) (:boundaries e))]
         (is (= 2 (count rows)) "one row per DISTINCT edge set")
-        (is (= 2 (:instances (get rows [(k [:tr/left])]))))
-        (is (= 1 (:instances (get rows [(k [:tr/left]) (k [:tr/right])]))))
-        (is (= frame-id (:frame (get rows [(k [:tr/left])]))))))
+        (is (= 2 (:instances (get rows [(bk [:tr/left])]))))
+        (is (= 1 (:instances (get rows [(bk [:tr/left]) (bk [:tr/right])]))))
+        (is (= frame-id (:frame (get rows [(bk [:tr/left])]))))))
 
     (testing "a boundary that read NOTHING is still counted — the cell table cannot see it"
       (let [d (mount! (fn [_] nil))
@@ -205,7 +217,7 @@
     (testing ":readers are the SAME keys the mounted roster states — the rosters join"
       (let [mounted (boundary-keys (tool/read-mounted-boundaries))
             readers (into #{} (map :key) (:readers (:tr/left by-sub)))]
-        (is (= #{[(k [:tr/left])] [(k [:tr/left]) (k [:tr/right])]} readers))
+        (is (= #{[(bk [:tr/left])] [(bk [:tr/left]) (bk [:tr/right])]} readers))
         (is (every? mounted readers)
             "every reader key must resolve in the mounted roster, with no correlation step")))
     (testing "a key nothing holds is ABSENT — not a subscription with zero readers"
@@ -253,7 +265,8 @@
         (is (false? (:complete? e)))
         (is (= {:reason :uncorrelated :dropped evidence/unknown} (:loss e))))
       (testing "PROVEN: the reads whose values moved most recently, off the epoch stamps"
-        (is (= [:tr/left] (:latest-reads ex))
+        (is (= [{:sub-id :tr/left :query [:tr/left] :frame-id frame-id}]
+               (:latest-reads ex))
             "only :tr/left was written, so only its cell was re-stamped")
         (is (number? (:peak-epoch ex)))
         (is (number? (:snapshot ex))))
@@ -329,6 +342,153 @@
         (is (= :tr/row (:sub-id (first (:reads row))))
             "the registration id is not application data and still rides"))
       (release))))
+
+(deftest a-sensitive-query-argument-never-reaches-a-key-a-reader-or-an-explanation
+  ;; AUDIT #7789, CORRECTNESS 1. `projected-query` guarded the `:query`
+  ;; FIELD while the boundary KEY was built from raw sub-keys — so the
+  ;; argument the projector had just redacted was re-exported under
+  ;; `:boundary :key`, again under `:readers`, and again through
+  ;; `explain-render`. The shipped witness asserted only `:reads :query`,
+  ;; which is precisely why it did not see this.
+  ;;
+  ;; The forcing function is frame destruction, where the door PROMISES to
+  ;; fail closed: no policy is reachable, so nothing derived from the query
+  ;; may leave. A seeded secret in ARGUMENT position makes the escape
+  ;; observable wherever it happens.
+  (testing "with the policy unreachable, the argument is absent from EVERY path out"
+    (seeded!)
+    ;; No release: the frame is destroyed below, which is the point.
+    (mount-in! frame-id (fn [_] (h/sub [:tr/row the-secret]) nil))
+    (rf/with-frame frame-id (rf/dispatch-sync [:tr/bump]))
+    (is (leaked? (tool/read-mounted-boundaries))
+        (str "NON-VACUITY: with the frame ALIVE and nothing declared, the "
+             "argument really is in the state these projections read — the "
+             "classification model is fail-open and the query rides as itself. "
+             "If this row ever fails, the assertions below are passing against "
+             "a boundary that never carried the argument at all"))
+    (rf/destroy-frame! frame-id)
+    (let [mounted     (tool/read-mounted-boundaries)
+          attribution (tool/read-read-attribution)
+          why         (tool/explain-render)]
+      (is (not (leaked? (map (comp :key :boundary) (:boundaries mounted))))
+          "the mounted roster's boundary KEY must not carry the argument")
+      (is (not (leaked? mounted))
+          "nor may anything else on that envelope")
+      (is (not (leaked? (map :readers (:edges attribution))))
+          "attribution's :readers keys must not carry it either")
+      (is (not (leaked? attribution))
+          "nor anything else on the attribution envelope")
+      (is (not (leaked? why))
+          "and explain-render must not carry it onward — keys, scope or leads"))))
+
+(deftest two-parameterizations-of-one-sub-do-not-collapse
+  ;; AUDIT #7789, ERGONOMICS. `:latest-reads` named sub-ids only, so a Why
+  ;; row over `[:tr/row 1]` and `[:tr/row 2]` answered ":tr/row moved" —
+  ;; one name for two different reads whose projected identity the door
+  ;; already held.
+  (seeded!)
+  (let [release (mount! (fn [_] (h/sub [:tr/row 1]) (h/sub [:tr/row 2]) nil))]
+    (rf/with-frame frame-id (rf/dispatch-sync [:tr/bump]))
+    (let [ex     (first (:explanations (tool/explain-render)))
+          latest (:latest-reads ex)]
+      (is (= 2 (count latest))
+          "two reads of one registered sub are two entries, never one")
+      (is (= #{[:tr/row 1] [:tr/row 2]} (into #{} (map :query) latest))
+          "and each names its own projected query, which is what tells them apart"))
+    (release)))
+
+(deftest the-census-is-about-subscription-not-visibility
+  ;; AUDIT #7792, the real-React lifecycle supplement. Activity-hidden and
+  ;; unmounted leave the same census; a Suspense-fallback-hidden subtree
+  ;; stays subscribed and stays listed. No observable here can tell them
+  ;; apart, so the door states the distinction as host-opaque rather than
+  ;; letting a reader infer it. This pins that it is STATED — an absent
+  ;; field would read as "not applicable".
+  (seeded!)
+  (let [release (mount! (fn [_] (h/sub [:tr/left]) nil))
+        hp      (:host (tool/read-mounted-boundaries))]
+    (is (= :host-opaque (:basis hp)))
+    (is (= evidence/unknown (:visibility hp))
+        "whether a listed boundary is on SCREEN is React's, and is named")
+    (is (= evidence/unknown (:hidden-retained hp))
+        "and so is whether an absent one is hidden-but-retained")
+    (release)))
+
+;; ---------------------------------------------------------------------------
+;; FRAME ISOLATION — a second frame must not answer for the first
+;; ---------------------------------------------------------------------------
+
+(def ^:private other-frame-id ::tool-reads-other)
+
+(defn- seed-other! []
+  (rf/make-frame {:id other-frame-id})
+  (rf/with-frame other-frame-id
+    (rf/dispatch-sync [:tr/seed {:left 10 :right 20 :rows [:x :y :z]}]))
+  other-frame-id)
+
+(deftest explain-render-scopes-its-window-and-its-leads-to-the-boundarys-own-frames
+  ;; AUDIT #7789, CORRECTNESS 2. `explain-render` summed retained runs
+  ;; GLOBALLY and indexed leads by sub-id ALONE. Two frames registering the
+  ;; same sub id — the ordinary case for two mounted apps — therefore let a
+  ;; run in B report that A's window had been searched (turning A's honest
+  ;; :cap into a false :uncorrelated) and offered B's runs as A's leads.
+  (seeded!)
+  (seed-other!)
+  (let [in-a (mount-in! frame-id       (fn [_] (h/sub [:tr/left]) nil))
+        in-b (mount-in! other-frame-id (fn [_] (h/sub [:tr/left]) nil))]
+    ;; ASYMMETRIC WINDOWS: B has run, A has not.
+    (rf/with-frame other-frame-id (rf/dispatch-sync [:tr/bump]))
+    (trace-tooling/clear-trace-buffer! frame-id)
+    (let [by-frame (into {} (map (juxt :frame identity))
+                         (:explanations (tool/explain-render)))
+          a        (get by-frame frame-id)
+          b        (get by-frame other-frame-id)]
+      (is (some? a) "frame A's boundary must be explained")
+      (is (some? b) "and so must frame B's")
+      (testing "A's window is A's — B's activity cannot claim a search of it"
+        (is (= :cap (:reason (:loss a)))
+            "A's ring is empty, so nothing was searched for A")
+        (is (= evidence/unknown (:candidates a))
+            "and its leads state the explicit unknown, never an [] nor B's runs"))
+      (testing "B's window really was searched, and B keeps its own leads"
+        (is (= :uncorrelated (:reason (:loss b))))
+        (is (some #(= :tr/bump (:event-id %)) (:candidates b))))
+      (testing "a lead names the frame it came from, so the match cannot be on the id alone"
+        (is (every? #(= other-frame-id (:frame-id %)) (:candidates b)))))
+    (in-a) (in-b))
+  (rf/destroy-frame! other-frame-id))
+
+(deftest the-intent-stream-is-one-dispatch-ordered-stream
+  ;; AUDIT #7789, CORRECTNESS 2 (second half). The roster concatenated
+  ;; whole per-frame rings in FRAME-ID order while the read promised
+  ;; dispatch order — so with two frames live the stream asserted a
+  ;; sequence that never happened, alphabetically. `:dispatch-id` is
+  ;; allocated process-monotonically at queue time, so the true order is
+  ;; recoverable and is now used.
+  (seeded!)
+  (seed-other!)
+  ;; A boundary in each frame, so BOTH rings are ones this runtime
+  ;; dispatches through and the stream really has two sources to order.
+  (let [in-b    (mount-in! other-frame-id (fn [_] (h/sub [:tr/left]) nil))
+        release (mount! (fn [_] (h/sub [:tr/left]) nil))]
+    ;; Interleave the two frames. `other-frame-id` sorts AFTER frame-id by
+    ;; pr-str, so a frame-ordered concatenation cannot reproduce this.
+    (rf/with-frame other-frame-id (rf/dispatch-sync [:tr/bump]))
+    (rf/with-frame frame-id       (rf/dispatch-sync [:tr/bump]))
+    (rf/with-frame other-frame-id (rf/dispatch-sync [:tr/bump]))
+    (let [rows (:intents (tool/read-intents))
+          ids  (mapv :dispatch-id rows)]
+      (is (= ids (vec (sort ids)))
+          "the stream is ordered by the process-monotonic dispatch id, oldest first")
+      (is (apply distinct? ids)
+          (str "one dispatch is one row: a run captured in two frames' rings is "
+               "merged, never printed twice"))
+      (is (every? #(vector? (:frames %)) rows)
+          "each row names the frames it reached rather than a single ring's id")
+      (is (= #{frame-id other-frame-id} (into #{} (mapcat :frames) rows))
+          "both rings really are in the stream — otherwise the order proves nothing"))
+    (release) (in-b))
+  (rf/destroy-frame! other-frame-id))
 
 ;; ---------------------------------------------------------------------------
 ;; ONE DOOR, DETERMINISTIC — the byte-for-byte precondition

--- a/tools/xray/spec/027-Hicasso-Evidence.md
+++ b/tools/xray/spec/027-Hicasso-Evidence.md
@@ -125,6 +125,30 @@ every live boundary would need a registry or a field on the priced
 registration — a standing memory cost this producer will not levy for a
 panel's benefit.
 
+**The EXPORTED key is projected, element by element.** Each element is
+`[frame-id sub-id projected-query]` — never a raw sub-key. A key built from
+raw sub-keys carries every query ARGUMENT past the projector that had just
+been applied to the `:query` field, and carries it further than any field
+does: a key is what joins two rosters, what a panel prints in a boundary
+label, and what a DOM testid is derived from. It shipped that way in the
+first increment and the merged-PR audit of #7789 caught it.
+
+Two properties survive the change and both are load-bearing. The **join** is
+untouched, because both rosters derive keys through the one function and
+identical read sets still project to identical keys. The **registration id**
+rides beside the query because it is the one spelling redaction cannot take:
+where a frame's policy elides a query whole, `[:cart/item …]` and
+`[:user/token …]` project to the same sentinel and only the sub-id keeps them
+apart.
+
+The identity is therefore as fine as the egress policy allows and no finer.
+Where an application has declared the arguments that told two boundaries
+apart sensitive, those boundaries are ONE row here and `:read-orders` counts
+what folded in. That is the correct place for the collapse: the alternatives
+are a census keyed on data the door has promised not to carry, or two rows
+sharing one exported identity — which gives a panel duplicate DOM ids and a
+consumer an ambiguous join.
+
 ### Causality is never inferred from adjacency
 
 The Why view has a proven half and an uncorrelated half, and they are separate
@@ -133,7 +157,11 @@ fields on the row and separate lines on the screen.
 - **Proven.** A cell's `epoch` is re-stamped by every commit that moved its
   value, so `:latest-reads` — the boundary's reads at its highest epoch — are
   the ones that moved most recently. `:snapshot` is the exact number React
-  compares in `checkIfSnapshotChanged`.
+  compares in `checkIfSnapshotChanged`. Each entry names the READ
+  (`{:sub-id :query :frame-id}`, the query projected), not a bare sub-id:
+  `[:row 1]` and `[:row 2]` are one registration and two different reads, and
+  a Why view that answered ":row moved" to a developer looking at eight rows
+  would be collapsing an identity the door already held (audit #7789).
 - **Uncorrelated.** Hicasso's commit seam records no cascade id, so nothing in
   the retained window can be JOINED to a boundary's re-run. `:cause` is
   `:unknown` every time — structurally, not circumstantially: a bigger ring
@@ -146,6 +174,31 @@ fields on the row and separate lines on the screen.
 An empty window flips the row's loss from `:uncorrelated` to `:cap` and its
 `:candidates` from `[]` to `:unknown`, because no search happened — a
 distinction the tab renders and the suite drives.
+
+**Both halves are scoped to the boundary's own frames.** The window a row
+searches is the rings of the frames that row's reads actually name, and a
+candidate must match a read on `[frame-id sub-id]`. Counting retained runs
+globally lets activity in frame B report that frame A's window was searched —
+converting A's honest `:cap` into a false `:uncorrelated` — and matching on
+the sub-id alone then offers B's runs as A's leads for no better reason than
+that two frames registered the same sub id, which is a lead fabricated from a
+coincidence. Two mounted apps is the ordinary case, not the exotic one.
+`tool_reads_cljs_test/explain-render-scopes-its-window-and-its-leads-to-the-boundarys-own-frames`
+drives two frames sharing a sub id with asymmetric windows.
+
+### The intent stream is ordered by dispatch, not by frame
+
+Spec 009's rings are per frame; the stream is one. Rows are ordered by the
+process-monotonic `:dispatch-id` the router allocates at queue time, which IS
+the dispatch order across every frame — so the read can promise order and mean
+it. Concatenating whole per-frame rings in frame-id order asserts a sequence
+that never happened, alphabetically, the moment a second frame is live.
+
+A dispatch that touched two frames is captured in both rings, so fragments
+sharing a `:dispatch-id` are merged into the one row they describe: a row
+names `:frames` (plural) and the union of what it recomputed. Two rows would
+print one user action as two events; keeping the first would drop half of what
+it did.
 
 ### No read carries application data
 
@@ -164,21 +217,70 @@ Spec 015 governs that egress. `tool_reads_cljs_test`'s seeded-value witness
 proves the hazard is real (a cell's live reaction derefs to the seeded secret)
 before asserting the secret reaches none of the four envelopes.
 
+That witness covers a secret RETURN VALUE. A second pair covers a secret
+QUERY ARGUMENT, which is a different path and was the one that leaked:
+`a-sensitive-query-argument-never-reaches-a-key-a-reader-or-an-explanation`
+spans the mounted, attribution and Why envelopes, and
+`hicasso_cljs_test/a-sensitive-query-argument-reaches-neither-the-page-nor-a-testid`
+spans the rendered tree — text AND `data-testid`, because the helpers printed
+the raw query in a label and hashed it into a DOM id, so an envelope-only
+control cannot see the escape. Both use frame destruction as the forcing
+function (there the door promises to fail closed) and both carry a
+non-vacuity row proving the argument really was reachable first.
+
 ---
 
 ## Rendering contract
 
-### Three empties, three sentences
+### Every empty is its own sentence
 
-A tab showing no rows can mean three unrelated things with three unrelated
-remedies. Collapsing them would undo the schema one level up, so each renders
-under its own testid with its own prose.
+A tab showing no rows can mean unrelated things with unrelated remedies.
+Collapsing them would undo the schema one level up, so each renders under its
+own testid with its own prose.
 
 | Presence | testid | Means |
 |---|---|---|
 | `:absent` | `rf-xray-hicasso-absent` | the door answered `nil` — not running Hicasso, or a production build |
 | `:mismatch` | `rf-xray-hicasso-mismatch` | Hicasso answered, stamping a schema/producer this build was not taught |
-| `:idle` | `rf-xray-hicasso-idle` | Hicasso is running and nothing is mounted — the one empty that is a clean bill of health |
+| `:idle` | per view, below | Hicasso answered with an EMPTY roster — which is a different fact in each view |
+
+**The empty roster is four facts, not one.** The original single sentence —
+*nothing is mounted, the one empty that is a clean bill of health* — was
+written for the mounted census and then shown under all four views, where it
+told a reader that a capped intent window proved nothing had been dispatched
+(audit #7789). A confident wrong answer is worse than a visible gap, so each
+view answers for its own scope:
+
+| View | testid | What an empty roster means there |
+|---|---|---|
+| Mounted | `rf-xray-hicasso-empty-mounted` | no boundary holds a live read edge — a survey result, about SUBSCRIPTION rather than the screen |
+| Reads | `rf-xray-hicasso-empty-attribution` | no cell is held; compatible with mounted boundaries that read nothing |
+| Intents | `rf-xray-hicasso-empty-intents` | the retained window is empty — a CAP, which cannot say whether anything was dispatched |
+| Why | `rf-xray-hicasso-empty-explain` | there is no mounted boundary to explain; it follows the census and inherits its qualifications |
+
+Each view's loss and remedy render whether or not there are rows. A view that
+showed its qualifications only when it had something to qualify would drop
+them exactly where the reader has least else to go on.
+
+### Mounted means subscribed, and the tab says so
+
+The real-React lifecycle witness (audit #7792) established two facts this
+census cannot see, and the tab states both rather than letting a reader
+supply them:
+
+- an **Activity-hidden** subtree that has released its reads leaves the same
+  census as an **unmounted** one, and only a later 0-to-1 re-subscribe
+  distinguishes them, retrospectively;
+- a **Suspense-fallback-hidden** subtree stays SUBSCRIBED, so it is listed
+  here while absent from the screen.
+
+The producer names `:visibility` and `:hidden-retained` on the `:host`
+projection as `:unknown` on a `:host-opaque` basis, and the Mounted view
+renders the distinction beside the rows under
+`rf-xray-hicasso-mounted-visibility`. No observable is invented for it: the
+governing promise is amended instead, which is the honest half of the choice
+the audit offered. Hidden-retained is never inferred from an empty census, and
+a subscribed row is never labelled visible.
 
 ### Every absence is a chip, and the five chips differ
 
@@ -246,7 +348,7 @@ Adding it moved six governance pins, each of which fails the build on drift:
 | Suite | Tier | Proves |
 |---|---|---|
 | `re-frame.hicasso.evidence-schema-cljs-test` | node | every shape in which a projection would claim more than it knows is refused, each with a positive control |
-| `re-frame.hicasso.tool-reads-cljs-test` | node (reactive substrate) | the four reads over real committed boundaries; the seeded-value privacy witness; determinism; the production-nil arm |
-| `…panels.hicasso-helpers-cljs-test` | node + JVM | the five absences and the three empties are pairwise distinct; the schema pin; row projections |
-| `…panels.hicasso-cljs-test` | node (reactive substrate) | the four views answer on a running app; the loss states render under distinct testids, driven between two real window states; the seam reshapes nothing |
+| `re-frame.hicasso.tool-reads-cljs-test` | node (reactive substrate) | the four reads over real committed boundaries; the seeded-value privacy witness for a return value AND for a query argument; two frames sharing a sub id with asymmetric windows; the dispatch-ordered, fragment-merged intent stream; determinism; the production-nil arm |
+| `…panels.hicasso-helpers-cljs-test` | node + JVM | the five absences and the empties are pairwise distinct — including the four per-view empties; labels and testids are built from the projected key; two query variants do not collapse; the schema pin; row projections |
+| `…panels.hicasso-cljs-test` | node (reactive substrate) | the four views answer on a running app; the loss states render under distinct testids, driven between two real window states; a sensitive query argument reaches neither the page nor a testid; each view renders its own empty; the seam reshapes nothing |
 | `feature_matrix/scenarios.cjs` | browser | the tab reaches a real panel root in the shell sweep |

--- a/tools/xray/src/day8/re_frame2_xray/panels/hicasso.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/hicasso.cljs
@@ -17,11 +17,14 @@
   collection, and this panel's whole design follows from taking that
   seriously one layer further out. Three things fall out of it:
 
-  1. **Three empties, three sentences.** *Not running Hicasso*, *running a
-     schema this build cannot parse* and *running with nothing mounted*
+  1. **Every empty is its own sentence.** *Not running Hicasso*, *running
+     a schema this build cannot parse* and *running with an empty roster*
      are unrelated facts with unrelated remedies, and each renders under
      its own testid with its own prose. A tab that showed one blank table
-     for all three would verify the absence of bad news.
+     for all three would verify the absence of bad news. The last of them
+     splits again PER VIEW: an empty mounted census is a survey result, an
+     empty intent stream is a capped window, and one sentence covering
+     both would be false of one of them (audit #7789).
   2. **Every absence is a CHIP, and the five chips differ.** `capped`,
      `opaque`, `host-opaque`, `uncorrelated` and `unknown` render with
      different words under different testids, so the distinction survives
@@ -139,21 +142,49 @@
 ;; ---- the three non-live states -------------------------------------------
 
 (defn- presence-note
-  "The honest empty. Three states, three testids, three sentences — see
-  the ns docstring for why collapsing them would undo the schema."
-  [state]
-  (when-some [{:keys [testid-suffix says]} (get hh/presence-copy state)]
+  "The honest empty. Each state gets its own testid and its own sentence —
+  see the ns docstring for why collapsing them would undo the schema.
+
+  `view` is passed because an EMPTY roster is a different fact in each of
+  the four, so the sentence and the testid come from the view's own entry
+  in `hh/empty-copy` rather than from one shared line that could only ever
+  be true of one view (audit #7789)."
+  [state view]
+  (when-some [{:keys [testid-suffix says]} (hh/state-copy state view)]
     [:div {:data-testid (str "rf-xray-" panel-id "-" testid-suffix)
            :style       (if (= :mismatch state) mismatch-style state-style)}
      says]))
 
 ;; ---- view 1 — mounted boundaries -----------------------------------------
 
+(defn- visibility-note
+  "Mounted means SUBSCRIBED, and this view says so rather than letting a
+  reader supply the other word.
+
+  The real-React lifecycle witness (audit #7792) established that this
+  census cannot distinguish three states React owns: an Activity-hidden
+  subtree that released its reads leaves the same census as an unmounted
+  one, and a Suspense-fallback-hidden subtree stays subscribed and so
+  stays in this table while absent from the screen. The producer states
+  both as `:host-opaque`; the panel's job is to make sure the reader is
+  told before they infer otherwise, which is why it renders with the rows
+  and not only when the roster is empty."
+  [envelope]
+  (when (hh/supported? envelope)
+    (let [chip (hh/loss-chip (:loss (:host envelope)) (:visibility (:host envelope)))]
+      [:div {:data-testid (str "rf-xray-" panel-id "-mounted-visibility")
+             :style       (assoc detail-style :margin-top "6px")}
+       (str (:short chip) " — these rows are about SUBSCRIPTION, not about the "
+            "screen. A hidden-but-retained subtree that released its reads is "
+            "indistinguishable here from an unmounted one, and a "
+            "Suspense-fallback-hidden subtree stays subscribed and stays "
+            "listed. React DevTools is the authority on what is visible.")])))
+
 (defn- mounted-view
   [{:keys [envelope rows]}]
   (let [[shown over? hidden] (ch/cap-rows rows)]
     [:div {:data-testid (str "rf-xray-" panel-id "-mounted")}
-     (or (presence-note (hh/presence envelope (empty? rows)))
+     (or (presence-note (hh/presence envelope (empty? rows)) :mounted)
          [:<>
           (into [:ul {:style {:list-style "none" :margin 0 :padding 0}}]
                 (concat
@@ -176,11 +207,18 @@
                                               (str "frame " (hh/format-id (:frame row))))
                                             (str (count (:reads row)) " read"
                                                  (when (not= 1 (count (:reads row))) "s"))]))]])
-                  [(overflow/overflow-row {:panel-id panel-id :over-cap? over? :hidden-count hidden})]))
-          (absence-note (str "rf-xray-" panel-id "-mounted-naming")
-                        (hh/loss-chip (:loss (:naming envelope)) hh/unknown))
-          (absence-note (str "rf-xray-" panel-id "-mounted-host")
-                        (hh/loss-chip (:loss (:host envelope)) hh/unknown))])]))
+                  [(overflow/overflow-row {:panel-id panel-id :over-cap? over? :hidden-count hidden})]))])
+     ;; The qualifications are stated whether or not there are rows. A view
+     ;; that showed them only when it had something to qualify would drop
+     ;; them exactly where the reader has least else to go on — which is the
+     ;; empty roster the audit found reading as a clean bill of health.
+     (when (hh/supported? envelope)
+       [:<>
+        (absence-note (str "rf-xray-" panel-id "-mounted-naming")
+                      (hh/loss-chip (:loss (:naming envelope)) hh/unknown))
+        (absence-note (str "rf-xray-" panel-id "-mounted-host")
+                      (hh/loss-chip (:loss (:host envelope)) hh/unknown))
+        (visibility-note envelope)])]))
 
 ;; ---- view 2 — read attribution -------------------------------------------
 
@@ -188,7 +226,7 @@
   [{:keys [envelope rows]}]
   (let [[shown over? hidden] (ch/cap-rows rows)]
     [:div {:data-testid (str "rf-xray-" panel-id "-attribution")}
-     (or (presence-note (hh/presence envelope (empty? rows)))
+     (or (presence-note (hh/presence envelope (empty? rows)) :attribution)
          (into [:ul {:style {:list-style "none" :margin 0 :padding 0}}]
                (concat
                  (for [row shown]
@@ -210,26 +248,36 @@
   [{:keys [envelope rows]}]
   (let [[shown over? hidden] (ch/cap-rows rows)]
     [:div {:data-testid (str "rf-xray-" panel-id "-intents")}
-     (or (presence-note (hh/presence envelope (empty? rows)))
-         [:<>
-          (into [:ol {:style {:list-style "none" :margin 0 :padding 0}}]
-                (concat
-                  (for [[i row] (map-indexed vector shown)]
-                    ^{:key i}
-                    [:li {:data-testid (str "rf-xray-" panel-id "-intent-" (:slug row))
-                          :style       row-style}
-                     [:div [:span {:style {:font-family mono-stack}}
-                            (hh/format-id (:event-id row))]
-                      [:span {:style (assoc detail-style :display "inline" :margin-left "8px")}
-                       (str (:arg-count row) " arg"
-                            (when (not= 1 (:arg-count row)) "s")
-                            " (not carried)")]]
-                     (when (seq (:sub-ids row))
-                       [:div {:style detail-style}
-                        (str "recomputed " (string/join ", " (map hh/format-id (:sub-ids row))))])])
-                  [(overflow/overflow-row {:panel-id (str panel-id "-intents") :over-cap? over? :hidden-count hidden})]))
-          (absence-note (str "rf-xray-" panel-id "-intents-origin")
-                        (hh/loss-chip (:loss (:origin envelope)) hh/unknown))])]))
+     (or (presence-note (hh/presence envelope (empty? rows)) :intents)
+         (into [:ol {:style {:list-style "none" :margin 0 :padding 0}}]
+               (concat
+                 (for [[i row] (map-indexed vector shown)]
+                   ^{:key i}
+                   [:li {:data-testid (str "rf-xray-" panel-id "-intent-" (:slug row))
+                         :style       row-style}
+                    [:div [:span {:style {:font-family mono-stack}}
+                           (hh/format-id (:event-id row))]
+                     [:span {:style (assoc detail-style :display "inline" :margin-left "8px")}
+                      (str (:arg-count row) " arg"
+                           (when (not= 1 (:arg-count row)) "s")
+                           " (not carried)")]]
+                    [:div {:style detail-style}
+                     (string/join " · "
+                                  (remove nil?
+                                          [(str "dispatch " (hh/format-id (:dispatch-id row)))
+                                           (when (seq (:frames row))
+                                             (str "frame" (when (not= 1 (count (:frames row))) "s")
+                                                  " " (string/join ", " (map hh/format-id (:frames row)))))
+                                           (when (seq (:sub-ids row))
+                                             (str "recomputed "
+                                                  (string/join ", " (map hh/format-id (:sub-ids row)))))]))]])
+                 [(overflow/overflow-row {:panel-id (str panel-id "-intents") :over-cap? over? :hidden-count hidden})])))
+     ;; The window is ALWAYS a cap, so the cap and the opaque origin are
+     ;; stated even when the stream is empty — an empty window with its
+     ;; loss hidden is the shape that reads as "nothing was dispatched".
+     (when (hh/supported? envelope)
+       (absence-note (str "rf-xray-" panel-id "-intents-origin")
+                     (hh/loss-chip (:loss (:origin envelope)) hh/unknown)))]))
 
 ;; ---- view 4 — explain render ---------------------------------------------
 
@@ -237,7 +285,7 @@
   [{:keys [envelope rows]}]
   (let [[shown over? hidden] (ch/cap-rows rows)]
     [:div {:data-testid (str "rf-xray-" panel-id "-explain")}
-     (or (presence-note (hh/presence envelope (empty? rows)))
+     (or (presence-note (hh/presence envelope (empty? rows)) :explain)
          (into [:ul {:style {:list-style "none" :margin 0 :padding 0}}]
                (concat
                  (for [row shown]
@@ -250,7 +298,9 @@
                            :style       detail-style}
                      (if (:proven? row)
                        (str "moved most recently: "
-                            (string/join ", " (map hh/format-id (:latest-reads row)))
+                            ;; Already rendered per READ by the helpers, so two
+                            ;; parameterizations of one sub stay two entries.
+                            (string/join ", " (:latest-reads row))
                             " · snapshot " (:snapshot row)
                             " · epoch " (:peak-epoch row))
                        "this boundary reads nothing, so no epoch moved for it")]

--- a/tools/xray/src/day8/re_frame2_xray/panels/hicasso_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/hicasso_helpers.cljc
@@ -27,8 +27,15 @@
   |---|---|
   | `:absent`   | this host is not running Hicasso, or this is a production build — the door answered `nil` |
   | `:mismatch` | Hicasso answered, stamping a schema THIS build was not taught to parse |
-  | `:idle`     | Hicasso answered, and nothing is mounted — the one empty that is a clean bill of health |
-  | `:live`     | there are rows |"
+  | `:idle`     | Hicasso answered with an empty roster — and what THAT means is per view, see [[empty-copy]] |
+  | `:live`     | there are rows |
+
+  The third row used to carry one sentence for all four views, and that
+  sentence was written for the mounted census: *nothing is mounted, a
+  clean bill of health*. Under Intents the same words claimed a capped
+  window proved nothing had been dispatched. Four scopes need four
+  sentences ([[empty-copy]]) — an empty roster is a different fact in
+  each, with a different remedy."
   (:require [clojure.string :as string]))
 
 ;; ---------------------------------------------------------------------------
@@ -187,6 +194,50 @@
     rows-empty?              :idle
     :else                    :live))
 
+(def empty-copy
+  "What an EMPTY roster means — PER VIEW, because it is a different fact
+  in each of the four.
+
+  The four reads have four scopes, and one shared sentence about an empty
+  one can be true of at most a single scope. It was written for the
+  mounted census (where the entry cache really is authoritative) and then
+  shown under Intents, where an empty roster means a capped window and
+  proves nothing about what was dispatched, and under Reads, where it is
+  compatible with mounted boundaries that read nothing at all. A confident
+  wrong answer is worse than a visible gap, so each view answers for its
+  own scope and keeps its own remedy in view (rf2-hic-023, audit #7789).
+
+  Each entry carries its own testid suffix, so a browser assertion cannot
+  match the wrong view's empty."
+  {:mounted
+   {:testid-suffix "empty-mounted"
+    :says (str "Hicasso is running and no boundary holds a live read edge. "
+               "The read-set entry cache is authoritative about that, so this "
+               "is a survey result and not an absence of evidence — but it is "
+               "a statement about SUBSCRIPTION, not about the screen. A hidden "
+               "subtree that released its reads leaves exactly this census, "
+               "and only a later re-subscribe tells the two apart.")}
+   :attribution
+   {:testid-suffix "empty-attribution"
+    :says (str "No subscription cell is currently held. This is not the same "
+               "as nothing being mounted: a boundary whose body reads nothing "
+               "still mounts and still holds an entry, and it has no edge to "
+               "appear here. Check the Mounted view before concluding the "
+               "application is idle.")}
+   :intents
+   {:testid-suffix "empty-intents"
+    :says (str "The retained window holds nothing. This is a CAP, not a "
+               "finding — Spec 009's ring keeps `:rf.trace/events-retained` "
+               "runs and cannot say what fell off it, and a ring of size 0 "
+               "cannot say whether anything was dispatched at all. Raise the "
+               "retention knob to see further back.")}
+   :explain
+   {:testid-suffix "empty-explain"
+    :says (str "There is no mounted boundary to explain. Why answers per "
+               "boundary, so an empty roster here follows the mounted census "
+               "and carries its qualifications — it is not a statement that "
+               "nothing has re-run.")}})
+
 (def presence-copy
   "The sentence each non-live presence gets, and the testid it renders
   under.
@@ -194,7 +245,8 @@
   Written out rather than composed, because the whole point is that a
   reader can tell *not running Hicasso* from *running it with nothing
   mounted*, and prose assembled from a shared stem is how those two come
-  to look alike again."
+  to look alike again. The `:idle` case is not here — it is per view, in
+  [[empty-copy]], because there is no one true sentence for it."
   {:absent
    {:testid-suffix "absent"
     :says (str "No Hicasso evidence on this host. The tool door answered nil, "
@@ -206,14 +258,18 @@
     :says (str "Hicasso answered with an evidence schema this Xray build was "
                "not taught to parse. Rows are suppressed rather than "
                "mis-parsed: an evolved shape read as though it were the "
-               "expected one is worse than no rows at all.")}
-   :idle
-   {:testid-suffix "idle"
-    :says (str "Hicasso is running and nothing is mounted. This is the one "
-               "empty answer that is a clean bill of health — the read-set "
-               "entry cache is authoritative about what is mounted, so an "
-               "empty roster here is a survey result and not an absence of "
-               "evidence.")}})
+               "expected one is worse than no rows at all.")}})
+
+(defn state-copy
+  "The copy for `state` in `view` — the one lookup a renderer needs.
+
+  `:idle` resolves through [[empty-copy]] and therefore depends on the
+  view; everything else is view-independent. Answering nil for `:live` is
+  deliberate: there is nothing to say when there are rows."
+  [state view]
+  (if (= :idle state)
+    (get empty-copy view)
+    (get presence-copy state)))
 
 ;; ---------------------------------------------------------------------------
 ;; Formatting
@@ -233,6 +289,40 @@
       (string/replace #"^-|-$" "")
       (string/lower-case)))
 
+(def redacted
+  "The egress projector's whole-value sentinel.
+
+  A literal for the same reason [[unknown]] is one: this namespace reads a
+  wire shape and states what it found, and a renderer that could not
+  recognise the sentinel would print it at a developer as though it were
+  a query."
+  :rf/redacted)
+
+(defn read-label
+  "One read edge as a reader reads it, from the PROJECTED key element
+  `[frame-id sub-id query]` the producer exports.
+
+  The query is already projected when it arrives, so this prints it as
+  found and invents nothing. When the projector redacted it WHOLE the
+  query no longer identifies anything, so the registration id is named
+  beside the sentinel — otherwise every redacted read on the page reads
+  the same, and a reader loses the one distinction the producer took care
+  to keep (rf2-hic-023, audit #7789)."
+  [[_frame-id sub-id query]]
+  (if (= redacted query)
+    (str (format-id sub-id) " " (format-id query))
+    (format-id query)))
+
+(defn latest-read-label
+  "One `:latest-reads` entry as a reader reads it.
+
+  The producer answers `{:sub-id :query :frame-id}` rather than a bare
+  sub-id, so this renders the projected QUERY — which is what tells two
+  parameterizations of one registered sub apart. Falls back to the sub-id
+  when the query redacted whole, exactly as [[read-label]] does."
+  [{:keys [sub-id query]}]
+  (read-label [nil sub-id query]))
+
 (defn boundary-label
   "A boundary's edge set as one line — the identity the runtime actually
   retains, spelled out.
@@ -242,14 +332,21 @@
   rendered as blank, one level down."
   [{:keys [key]}]
   (if (seq key)
-    (string/join " + " (map (fn [[_frame query]] (format-id query)) key))
+    (string/join " + " (map read-label key))
     "(reads nothing)"))
 
 (defn boundary-slug
-  "A stable testid slug for a boundary key."
+  "A stable testid slug for a boundary key.
+
+  Built from the sub-id AND the projected query, never the raw query: a
+  testid is a string a browser assertion selects on and a screenshot
+  carries, so deriving one from an application's arguments would put
+  those arguments in the DOM after the schema had projected them out of
+  the data. Including the sub-id keeps two wholly-redacted reads
+  selectable apart."
   [{:keys [key]}]
   (if (seq key)
-    (id-slug (string/join "-" (map (fn [[_ q]] (pr-str q)) key)))
+    (id-slug (string/join "-" (map (fn [[_f sid q]] (str (pr-str sid) "-" (pr-str q))) key)))
     "reads-nothing"))
 
 ;; ---------------------------------------------------------------------------
@@ -326,9 +423,12 @@
     (mapv (fn [i]
             {:dispatch-id (:dispatch-id i)
              :event-id    (:event-id i)
-             :slug        (id-slug (:event-id i))
+             ;; Slugged by DISPATCH-ID as well as event id: the stream is
+             ;; ordered by dispatch and one event id can appear many times
+             ;; in a window, so an event-only testid would name several rows.
+             :slug        (id-slug (str (pr-str (:event-id i)) "-" (pr-str (:dispatch-id i))))
              :arg-count   (:arg-count i)
-             :frame-id    (:frame-id i)
+             :frames      (:frames i)
              :sub-ids     (:sub-ids i)})
           (:intents envelope))))
 
@@ -351,7 +451,11 @@
                :instances    (:instances ex)
                :snapshot     (:snapshot ex)
                :peak-epoch   (:peak-epoch ex)
-               :latest-reads (:latest-reads ex)
+               ;; The producer now names the READ, not just its sub-id, so
+               ;; `[:row 1]` and `[:row 2]` no longer answer as one `:row`.
+               :latest-reads (if (unknown? (:latest-reads ex))
+                               (:latest-reads ex)
+                               (mapv latest-read-label (:latest-reads ex)))
                :proven?      (not (unknown? (:latest-reads ex)))
                :cause-chip   (loss-chip (:loss ex) (:cause ex))
                :leads        (if (unknown? leads) [] leads)

--- a/tools/xray/test/day8/re_frame2_xray/panels/hicasso_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/hicasso_cljs_test.cljs
@@ -177,18 +177,64 @@
 ;; THE HONEST EMPTIES — three states, three renderings
 ;; ---------------------------------------------------------------------------
 
-(deftest a-running-runtime-with-nothing-mounted-is-IDLE-not-absent
+(deftest a-running-runtime-with-nothing-mounted-is-EMPTY-not-absent
   (setup!)
-  (let [ids (testids (show! :mounted))]
-    (is (contains? ids "rf-xray-hicasso-idle")
-        "Hicasso answered and nothing is mounted — the one empty that is a
-         clean bill of health")
+  (let [tree (show! :mounted)
+        ids  (testids tree)]
+    (is (contains? ids "rf-xray-hicasso-empty-mounted")
+        "Hicasso answered and no boundary holds a read edge — a survey result")
     (is (not (contains? ids "rf-xray-hicasso-absent"))
-        "an idle runtime must NOT render as `no Hicasso on this host` — those
+        "an empty runtime must NOT render as `no Hicasso on this host` — those
          are unrelated facts with unrelated remedies")
-    (is (string/includes? (text-of (show! :mounted)) "clean bill of health"))))
+    (is (string/includes? (text-of tree) "survey result"))))
 
-(deftest a-host-without-hicasso-is-ABSENT-not-idle
+(deftest an-empty-roster-says-something-different-in-each-view
+  ;; AUDIT #7789, CORRECTNESS 3, on the page. One `:idle` note — "nothing is
+  ;; mounted, a clean bill of health" — rendered under all four views. Under
+  ;; Intents it told the reader a CAPPED window proved nothing had been
+  ;; dispatched. The four empties are now four testids and four sentences,
+  ;; and this drives the real panel to prove it.
+  (setup!)
+  (let [by-view (into {} (map (fn [v] [v (show! v)])) [:mounted :attribution
+                                                       :intents :explain])]
+    (testing "each view renders its OWN empty testid and no other view's"
+      (doseq [[view suffix] [[:mounted     "rf-xray-hicasso-empty-mounted"]
+                             [:attribution "rf-xray-hicasso-empty-attribution"]
+                             [:intents     "rf-xray-hicasso-empty-intents"]
+                             [:explain     "rf-xray-hicasso-empty-explain"]]]
+        (let [ids (testids (get by-view view))]
+          (is (contains? ids suffix)
+              (str view " must render its own empty note"))
+          (is (= 1 (count (filter #(string/starts-with? % "rf-xray-hicasso-empty-") ids)))
+              (str view " must render exactly one empty note — not a second view's")))))
+
+    (testing "the Intents empty is a CAP, and never a clean bill of health"
+      (let [txt (text-of (get by-view :intents))]
+        (is (string/includes? txt "CAP"))
+        (is (string/includes? txt "cannot say whether anything was dispatched"))
+        (is (not (string/includes? txt "clean bill of health"))
+            (str "the mounted census's verdict must not be read out here — an "
+                 "empty ring is a knob setting, not a finding"))))
+
+    (testing "and the cap's own loss note is rendered even with no rows at all"
+      (is (contains? (testids (get by-view :intents)) "rf-xray-hicasso-intents-origin")
+          (str "a view that showed its qualifications only when it had rows would "
+               "drop them exactly where the reader has least else to go on")))))
+
+(deftest the-mounted-census-does-not-claim-the-screen
+  ;; AUDIT #7792. The census cannot distinguish Activity-hidden from
+  ;; unmounted, and lists a Suspense-fallback-hidden subtree though it is
+  ;; off screen. The panel states that beside the rows rather than leaving
+  ;; the reader to supply the word "visible".
+  (setup!)
+  (let [release (mount! (fn [_] (h/sub [:htab/left]) nil))
+        tree    (show! :mounted)]
+    (is (contains? (testids tree) "rf-xray-hicasso-mounted-visibility"))
+    (is (string/includes? (text-of tree) "SUBSCRIPTION"))
+    (is (string/includes? (text-of tree) "Suspense"))
+    (release)))
+
+(deftest a-host-without-hicasso-is-ABSENT-not-empty
   (setup!)
   (with-redefs [reads/evidence (constantly {:mounted-boundaries nil
                                             :read-attribution   nil
@@ -196,7 +242,7 @@
                                             :explain-render     nil})]
     (let [ids (testids (show! :mounted))]
       (is (contains? ids "rf-xray-hicasso-absent"))
-      (is (not (contains? ids "rf-xray-hicasso-idle"))))))
+      (is (not (contains? ids "rf-xray-hicasso-empty-mounted"))))))
 
 (deftest an-unparseable-schema-is-MISMATCH-and-suppresses-rows
   (setup!)
@@ -215,7 +261,7 @@
       (let [tree (show! :mounted)
             ids  (testids tree)]
         (is (contains? ids "rf-xray-hicasso-mismatch"))
-        (is (not (contains? ids "rf-xray-hicasso-idle")))
+        (is (not (contains? ids "rf-xray-hicasso-empty-mounted")))
         (is (string/includes? (text-of tree) "not taught to parse"))))
     (release)))
 
@@ -232,7 +278,7 @@
         txt  (text-of tree)
         ids  (testids tree)]
     (is (contains? ids "rf-xray-hicasso-mounted"))
-    (is (not (contains? ids "rf-xray-hicasso-idle")))
+    (is (not (contains? ids "rf-xray-hicasso-empty-mounted")))
     (is (string/includes? txt "2 instances")
         "the two boundaries with one edge set report as one row of two")
     (is (string/includes? txt "[:htab/left]"))
@@ -327,6 +373,52 @@
             "and the leads are not rendered as an empty list, which would read
              as `nothing recomputed anything`")))
     (release)))
+
+;; ---------------------------------------------------------------------------
+;; A SENSITIVE QUERY ARGUMENT REACHES NEITHER THE TEXT NOR A TESTID
+;; ---------------------------------------------------------------------------
+
+(def ^:private the-secret
+  "A value that exists nowhere else in this process, so finding it in the
+  rendered tree is proof of egress rather than a coincidence of spelling."
+  "RF2-HIC-023-PANEL-SECRET-4c1e8a07")
+
+(deftest a-sensitive-query-argument-reaches-neither-the-page-nor-a-testid
+  ;; AUDIT #7789, CORRECTNESS 1 — the half a data-only assertion cannot
+  ;; reach. The producer's key carried raw query arguments, and these
+  ;; helpers then PRINTED them in a boundary label and hashed them into a
+  ;; DOM testid. So the escape was observable on the page, under a
+  ;; `data-testid` a screenshot or a browser assertion would carry off the
+  ;; developer's box. An envelope-only control would have missed it, which
+  ;; is exactly what happened.
+  ;;
+  ;; Frame destruction is the forcing function: there the door PROMISES to
+  ;; fail closed, so nothing derived from the query may render.
+  (setup!)
+  (mount! (fn [_] (h/sub [:htab/left the-secret]) nil))
+  (rf/with-frame app-frame (rf/dispatch-sync [:htab/bump]))
+
+  (testing "NON-VACUITY: with the frame alive the argument really is on the page"
+    (is (string/includes? (text-of (show! :mounted)) the-secret)
+        (str "the classification model is fail-open, so an undeclared argument "
+             "rides as itself while the frame lives. If this row fails, the "
+             "assertions below are passing against a panel that was never "
+             "shown the value at all")))
+
+  (rf/destroy-frame! app-frame)
+  (doseq [view [:mounted :attribution :explain]]
+    (let [tree (show! view)]
+      (is (not (string/includes? (text-of tree) the-secret))
+          (str "the " view " view rendered a redacted query's argument as text"))
+      (is (not-any? #(string/includes? % the-secret) (testids tree))
+          (str "the " view " view put a redacted query's argument in a DOM "
+               "testid — which is where it leaves the box"))))
+
+  (testing "and the rows are still THERE, so the redaction is not merely an empty page"
+    (let [ids (testids (show! :mounted))]
+      (is (not (contains? ids "rf-xray-hicasso-empty-mounted"))
+          (str "a panel that rendered nothing would pass every assertion above "
+               "while proving none of them")))))
 
 ;; ---------------------------------------------------------------------------
 ;; BYTE-FOR-BYTE

--- a/tools/xray/test/day8/re_frame2_xray/panels/hicasso_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/hicasso_helpers_cljs_test.cljc
@@ -9,10 +9,13 @@
      unknown as an empty collection buys nothing if the panel then draws
      `capped` and `uncorrelated` identically, and \"distinct\" is a
      property a suite can check where \"we were careful\" is not.
-  2. **The three empties are pairwise distinct.** *Not running Hicasso*,
-     *a schema this build cannot parse* and *running with nothing mounted*
-     have unrelated remedies, and a reader who cannot tell them apart is
-     back where the schema found them.
+  2. **The empties are pairwise distinct.** *Not running Hicasso* and *a
+     schema this build cannot parse* have unrelated remedies, and a reader
+     who cannot tell them apart is back where the schema found them. The
+     third empty — *the roster came back empty* — is not one fact but
+     four, one per view, and the audit of #7789 found the mounted census's
+     verdict being read out under Intents where it was false. Each view
+     therefore answers for its own scope.
 
   Everything else here is the row projections, which are ordinary."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
@@ -24,9 +27,14 @@
 ;; Fixtures — envelopes shaped exactly as the producer emits them
 ;; ---------------------------------------------------------------------------
 
-(def ^:private boundary-a {:parent nil :key [[:app/main [:todo 7]]]})
-(def ^:private boundary-b {:parent nil :key [[:app/main [:todo 7]]
-                                             [:app/main [:user 1]]]})
+;; Keys are the PROJECTED shape the producer exports —
+;; `[frame-id sub-id projected-query]`, never a raw sub-key (audit #7789).
+(def ^:private boundary-a {:parent nil :key [[:app/main :todo [:todo 7]]]})
+(def ^:private boundary-b {:parent nil :key [[:app/main :todo [:todo 7]]
+                                             [:app/main :user [:user 1]]]})
+(def ^:private boundary-redacted
+  {:parent nil :key [[:app/main :todo :rf/redacted]
+                     [:app/main :user :rf/redacted]]})
 
 (defn- envelope [read m]
   (merge {:schema    hh/consumed-evidence-schema
@@ -93,7 +101,7 @@
         "an absent :dropped must not render as nothing — that is the shape the
          producer refuses to emit, reintroduced at the last step")))
 
-(deftest the-three-empties-are-pairwise-distinct
+(deftest the-empties-are-pairwise-distinct
   (testing "presence classifies the four states"
     (is (= :absent   (hh/presence nil true)))
     (is (= :mismatch (hh/presence (assoc mounted :schema :something/else) true)))
@@ -105,13 +113,56 @@
   (testing "no two states share a sentence or a testid"
     (let [says     (map :says (vals hh/presence-copy))
           suffixes (map :testid-suffix (vals hh/presence-copy))]
-      (is (= 3 (count says) (count (set says))))
-      (is (= 3 (count suffixes) (count (set suffixes))))))
+      (is (= 2 (count says) (count (set says))))
+      (is (= 2 (count suffixes) (count (set suffixes))))))
 
   (testing "each sentence names its own remedy rather than a shared stem"
     (is (string/includes? (:says (:absent hh/presence-copy)) "production build"))
-    (is (string/includes? (:says (:mismatch hh/presence-copy)) "not taught to parse"))
-    (is (string/includes? (:says (:idle hh/presence-copy)) "clean bill of health"))))
+    (is (string/includes? (:says (:mismatch hh/presence-copy)) "not taught to parse"))))
+
+(deftest an-empty-roster-means-something-different-in-each-view
+  ;; AUDIT #7789, CORRECTNESS 3. One `:idle` sentence — written for the
+  ;; mounted census, "nothing is mounted, a clean bill of health" — was
+  ;; shown under all four views. Under Intents it told a reader a CAPPED
+  ;; window proved nothing had been dispatched; under Reads it denied the
+  ;; existence of mounted boundaries that read nothing.
+  (testing "every view has its own copy — a view with none would fall back to silence"
+    (is (= (set (map :id hh/sub-modes)) (set (keys hh/empty-copy)))))
+
+  (testing "no two views share a sentence or a testid suffix"
+    (let [says     (map :says (vals hh/empty-copy))
+          suffixes (map :testid-suffix (vals hh/empty-copy))]
+      (is (= 4 (count says) (count (set says))))
+      (is (= 4 (count suffixes) (count (set suffixes))))))
+
+  (testing "each names ITS OWN scope's fact and remedy"
+    (is (string/includes? (:says (:mounted hh/empty-copy)) "read edge"))
+    (is (string/includes? (:says (:attribution hh/empty-copy)) "reads nothing"))
+    (is (string/includes? (:says (:intents hh/empty-copy)) "CAP"))
+    (is (string/includes? (:says (:explain hh/empty-copy)) "no mounted boundary")))
+
+  (testing "the CAPPED window never claims nothing was dispatched"
+    (let [says (:says (:intents hh/empty-copy))]
+      (is (string/includes? says "cannot say whether anything was dispatched"))
+      (is (not (string/includes? says "clean bill of health"))
+          "the mounted census's verdict must not be reused where it is false")))
+
+  (testing "state-copy resolves the empty per view and everything else view-free"
+    (is (= "empty-intents" (:testid-suffix (hh/state-copy :idle :intents))))
+    (is (= "empty-mounted" (:testid-suffix (hh/state-copy :idle :mounted))))
+    (is (= "absent" (:testid-suffix (hh/state-copy :absent :intents))))
+    (is (= "absent" (:testid-suffix (hh/state-copy :absent :mounted)))
+        "a door that answered nil says the same thing in every view")
+    (is (nil? (hh/state-copy :live :mounted))
+        "there is nothing to say when there are rows")))
+
+(deftest the-mounted-empty-does-not-claim-the-screen-is-empty
+  ;; AUDIT #7792. An Activity-hidden subtree that released its reads leaves
+  ;; exactly this census, so the copy may not read as proof that nothing is
+  ;; retained above.
+  (let [says (:says (:mounted hh/empty-copy))]
+    (is (string/includes? says "SUBSCRIPTION"))
+    (is (string/includes? says "re-subscribe"))))
 
 ;; ---------------------------------------------------------------------------
 ;; The schema pin
@@ -146,6 +197,32 @@
       (is (= :unknown (:kind (:frame-chip read-free)))
           "with no reads there is no frame, and the chip says unknown"))))
 
+(deftest a-label-and-a-testid-are-built-from-the-PROJECTED-key
+  ;; AUDIT #7789, CORRECTNESS 1, consumer half. The helpers printed the raw
+  ;; query in a label and hashed it into a DOM testid, so an argument the
+  ;; producer had projected out of the data arrived on the page anyway.
+  ;; They now read the projected key element, and a redacted query is
+  ;; rendered as the sentinel it is.
+  (testing "a redacted read names its registration id, so two of them stay apart"
+    (is (= ":todo :rf/redacted" (hh/read-label [:app/main :todo :rf/redacted])))
+    (is (= ":user :rf/redacted" (hh/read-label [:app/main :user :rf/redacted])))
+    (is (= "[:todo 7]" (hh/read-label [:app/main :todo [:todo 7]]))
+        "an unredacted query still reads as itself"))
+
+  (testing "a wholly redacted boundary is still labelled and still selectable"
+    (let [row (first (hh/mounted-rows
+                       (assoc mounted :boundaries
+                              [{:boundary boundary-redacted :view :unknown
+                                :source :unknown :instances 1 :read-orders 1
+                                :frame :app/main :reads []}])))]
+      (is (= ":todo :rf/redacted + :user :rf/redacted" (:label row)))
+      (is (not (string/includes? (:slug row) "hunter"))
+          "nothing from an argument may reach a testid")
+      (is (not= (hh/boundary-slug boundary-redacted)
+                (hh/boundary-slug {:parent nil :key [[:app/main :todo :rf/redacted]]}))
+          (str "two redacted boundaries must not collapse to one testid — a "
+               "browser assertion selecting one would silently match the other")))))
+
 (deftest attribution-rows-carry-fan-out-and-readers
   (let [e (envelope :read-attribution
                     {:scope :read-edges
@@ -161,14 +238,23 @@
                     {:scope {:frames [:app/main] :retained-runs 2}
                      :complete? false
                      :loss {:reason :cap :dropped :unknown}
-                     :intents [{:frame-id :app/main :dispatch-id 41
+                     :intents [{:frames [:app/main] :dispatch-id 41
+                                :event-id :todo/toggle :arg-count 1
+                                :sub-ids [:todo]}
+                               {:frames [:app/main :app/other] :dispatch-id 42
                                 :event-id :todo/toggle :arg-count 1
                                 :sub-ids [:todo]}]})
-        [row] (hh/intent-rows e)]
+        [row second-row] (hh/intent-rows e)]
     (is (= :todo/toggle (:event-id row)))
     (is (= 1 (:arg-count row)))
+    (is (= [:app/main] (:frames row))
+        "a row names the frames the dispatch reached, not one ring's id")
     (is (not (contains? row :event))
-        "an argument vector must not reach a row — the producer does not send one")))
+        "an argument vector must not reach a row — the producer does not send one")
+    (testing "two runs of ONE event id get two testids"
+      (is (not= (:slug row) (:slug second-row))
+          (str "the stream is ordered by dispatch and one event id recurs, so an "
+               "event-only testid would name several rows at once")))))
 
 (deftest explain-rows-keep-the-proven-half-apart-from-the-uncorrelated-half
   (let [with-leads
@@ -177,10 +263,12 @@
                    :loss {:reason :uncorrelated :dropped :unknown}
                    :explanations [{:boundary boundary-a :frame :app/main
                                    :instances 1 :snapshot 9 :peak-epoch 5
-                                   :latest-reads [:todo] :cause :unknown
+                                   :latest-reads [{:sub-id :todo :query [:todo 7]
+                                                   :frame-id :app/main}]
+                                   :cause :unknown
                                    :loss {:reason :uncorrelated :dropped :unknown}
                                    :candidates [{:dispatch-id 41 :event-id :todo/toggle
-                                                 :sub-id :todo}]}]})
+                                                 :frame-id :app/main :sub-id :todo}]}]})
         blind
         (envelope :explain-render
                   {:complete? false
@@ -194,7 +282,8 @@
     (testing "with a live window the row is proven AND uncorrelated at once"
       (let [[row] (hh/explain-rows with-leads)]
         (is (true? (:proven? row)))
-        (is (= [:todo] (:latest-reads row)))
+        (is (= ["[:todo 7]"] (:latest-reads row))
+            "the READ, not the bare sub-id — see the two-variants row below")
         (is (= :uncorrelated (:kind (:cause-chip row))))
         (is (true? (:leads-known? row)))
         (is (= 1 (count (:leads row))))))
@@ -208,6 +297,25 @@
         (is (= [] (:leads row))
             "rendered as an empty seq so a renderer cannot iterate a keyword —
              `:leads-known?` is what carries the distinction")))))
+
+(deftest two-parameterizations-of-one-sub-do-not-collapse-in-the-why-view
+  ;; AUDIT #7789, ERGONOMICS. `:latest-reads` named sub-ids, so eight rows
+  ;; of one registered sub all answered ":row moved".
+  (let [e (envelope :explain-render
+                    {:complete? false
+                     :loss {:reason :uncorrelated :dropped :unknown}
+                     :explanations [{:boundary boundary-a :frame :app/main
+                                     :instances 1 :snapshot 9 :peak-epoch 5
+                                     :latest-reads [{:sub-id :row :query [:row 1]
+                                                     :frame-id :app/main}
+                                                    {:sub-id :row :query [:row 2]
+                                                     :frame-id :app/main}]
+                                     :cause :unknown
+                                     :loss {:reason :uncorrelated :dropped :unknown}
+                                     :candidates []}]})
+        [row] (hh/explain-rows e)]
+    (is (= ["[:row 1]" "[:row 2]"] (:latest-reads row))
+        "two reads of one sub read as two, because their queries differ")))
 
 (deftest the-summary-line-states-the-claim-even-when-it-is-good
   (testing "a complete envelope still says so — an absence of bad news is not news"


### PR DESCRIPTION
Repairs the four findings of the merged-PR audit of #7789, plus the lifecycle
supplement the same bead carries from #7792. Bead: rf2-hic-023.

`#7789` is merged and cannot be reopened, so this is a second increment on a
new branch. Nothing here touches the Pair migration — that stays exactly owned
by open rf2-hic-076.

## Finding 1 — privacy (the one that mattered most)

`projected-query` guarded the `:query` FIELD, but the boundary KEY was built
from raw sub-keys. So `entry-rows` re-exported every query argument under
`:boundary :key`, `edge-row` exported it again under `:readers`,
`explain-render` carried it onward, and the Xray helpers then printed it in a
boundary label and hashed it into a DOM testid. A sensitive argument bypassed
the projector entirely, including after frame destruction where the door
promises to fail closed.

Each exported key element is now `[frame-id sub-id projected-query]`. The join
is untouched — both rosters derive keys through the one function, so identical
read sets still produce identical keys — while nothing raw leaves the
namespace. The registration id rides beside the query because it is the one
spelling redaction cannot take: where a policy elides a query whole,
`[:cart/item …]` and `[:user/token …]` project to the same sentinel and only
the sub-id keeps them apart.

The census is grouped on the projected key, so exported identity and row
identity agree. Where an application declared the arguments that told two
boundaries apart sensitive, those boundaries are one row and `:read-orders`
counts what folded in — the alternative is either a census keyed on data the
door promised not to carry, or two rows sharing one exported identity, which
gives a panel duplicate DOM ids and a consumer an ambiguous join.

## Finding 2 — frame isolation

`explain-render` summed retained runs GLOBALLY and indexed leads by sub-id
ALONE. The window a row searches is now the rings of the frames that row's
reads name, and a candidate must match on `[frame-id sub-id]`.

Separately the Intents roster concatenated whole per-frame rings in frame-id
order while promising dispatch order. It is now one stream ordered by the
router's process-monotonic `:dispatch-id`, with fragments of one dispatch
merged into the row they describe rather than printed twice. This is the
"reconstruct the intended order and identity" arm — the id is allocated at
queue time, so the true order was recoverable and no per-frame retreat was
needed.

## Finding 3 — empty semantics

One `:idle` sentence, written for the mounted census, rendered under all four
views. Each view now answers for its own scope under its own testid, and every
view's loss and remedy render whether or not there are rows.

## Finding 4 — ergonomics

`:latest-reads` carries the projected read identity rather than bare sub-ids,
so `[:row 1]` and `[:row 2]` no longer collapse into one `:row`.

## The #7792 lifecycle supplement

Taken as the audit's second permitted answer: no observable is invented. The
host projection states `:visibility` and `:hidden-retained` as `:unknown` on a
`:host-opaque` basis, the mounted read's promise is amended from "a clean bill
of health" to a claim about SUBSCRIPTION, and the Mounted view renders the
distinction beside the rows. Hidden-retained is never inferred from an empty
census; a subscribed row is never labelled visible.

## Mutation proof

Every new control was mutation-proved: six defects planted at once (each
producing a distinct red), diff confirmed applied by `git diff --stat` and by
grepping the marker back out, then restored and re-run green.

| Control | Planted defect | Red |
|---|---|---|
| `a-sensitive-query-argument-never-reaches-a-key-a-reader-or-an-explanation` | key back to raw sub-keys | 5 assertions |
| `a-sensitive-query-argument-reaches-neither-the-page-nor-a-testid` | same | non-vacuity + text/testid |
| `explain-render-scopes-its-window-and-its-leads-to-the-boundarys-own-frames` | global run count, sub-id-only leads | `(not (= :cap :uncorrelated))` |
| `the-intent-stream-is-one-dispatch-ordered-stream` | per-frame concatenation, no merge | `[8088 8091 8089 8090 8092]` vs sorted |
| `two-parameterizations-of-one-sub-do-not-collapse` | `:latest-reads` back to sub-ids | 1 assertion |
| `the-census-is-about-subscription-not-visibility` | host fields removed | 2 assertions |
| `an-empty-roster-…-different-in-each-view` (helpers + panel) | one shared empty sentence | 7 assertions |
| `a-label-and-a-testid-are-built-from-the-PROJECTED-key` | sub-id dropped from a redacted label | 3 assertions |

Two of the reds are worth quoting, because they are the defects rather than
proxies for them:

```
FAIL in (explain-render-scopes-its-window-and-its-leads-to-the-boundarys-own-frames)
and its leads state the explicit unknown, never an [] nor B's runs
expected: (= evidence/unknown (:candidates a))
  actual: (not (= :unknown [{:dispatch-id 8087, :event-id :tr/bump,
                             :frame-id :…/tool-reads-other, :sub-id :tr/left}]))
```

```
FAIL in (the-intent-stream-is-one-dispatch-ordered-stream)
the stream is ordered by the process-monotonic dispatch id, oldest first
expected: (= ids (vec (sort ids)))
  actual: (not (= [8088 8091 8089 8090 8092] [8088 8089 8090 8091 8092]))
```

## Scope

Bounded witnesses only, per the audit's fence: sensitive query arguments, two
frames, per-view empties, two query variants. No new store, no new framework,
no new retention mechanism, no new knob.

## Spec

`tools/xray/spec/027-Hicasso-Evidence.md` records the projected key and why the
join survives it, the frame-scoped Why window, the dispatch-ordered stream, the
four per-view empties, the amended mounted promise, and the two new privacy
controls. Anchors and table column counts checked by hand.

## Quality gates

| Gate | Exit |
|---|---|
| `implementation` CLJS node suite (`npm run test:cljs`) — 13008 tests / 65692 assertions | 0 |
| `tools/xray` JVM (`clojure -M:test`) — 1285 tests / 6009 assertions | 0 |
| `scripts/test-fast-pr.sh` | 0 |

The fast-PR spine classifies this diff as `jvm=false`, so the `tools/xray` JVM
lane was run directly and is reported separately above.
