### PR TITLE
fix(gate): compare the quoted fence prefix by width, as superfences does (rf2-1cpt)

### DIFF
--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -338,6 +338,15 @@ _LIST_ITEM_START_RE = re.compile(
 # in-quote indent directly comparable to a column-0 one.
 _QUOTE_MARKER_RE = re.compile(r"[ ]{0,3}>[ \t]?")
 
+# superfences' `PREFIX_CHARS` (rf2-1cpt).  It does not parse blockquote markers
+# as markers at all: `parse_whitespace` walks the leading run of these three
+# characters and keeps its RAW WIDTH, so `>`, `> ` and `>   ` are three
+# different prefixes rather than three spellings of depth 1.  That width is what
+# decides whether a quoted fence closes, which is why `_quote_depth_and_body` —
+# which deliberately normalises the prefix away — cannot answer the question on
+# its own.
+_FENCE_PREFIX_CHARS = frozenset(">  \t")
+
 
 # rf2-t0ituo / rf2-57k74 — cross-handbook compatibility-anchor manifest +
 # source-comment link gate.
@@ -664,18 +673,22 @@ def _strip_fences(lines: list[str]) -> list[tuple[int, str]]:
             open_columns.pop()
         content_column = open_columns[-1] if open_columns else 0
 
-        # (opening marker, its indentation, its blockquote depth)
-        opener: tuple[str, int, int] | None = None
+        # (opening marker, its indentation, its superfences PREFIX).  The
+        # prefix is "" for an unquoted fence and the literal `>`/space run for
+        # a quoted one, which is the form `_fence_close` has to compare
+        # against (rf2-1cpt).
+        opener: tuple[str, int, str] | None = None
         if indent <= content_column + 3:
             quote_depth, quoted_body = _quote_depth_and_body(raw[indent:])
             if quote_depth:
                 qm = _FENCE_RE.match(quoted_body)
                 if qm and len(qm.group("indent")) <= 3:
-                    opener = (qm.group("marker"), len(qm.group("indent")), quote_depth)
+                    prefix, _rest = _fence_prefix(raw)
+                    opener = (qm.group("marker"), len(qm.group("indent")), prefix)
         if opener is None:
             m = _FENCE_RE.match(raw)
             if m and content_column <= indent <= content_column + 3:
-                opener = (m.group("marker"), indent, 0)
+                opener = (m.group("marker"), indent, "")
 
         if opener is not None:
             close = _fence_close(lines, i + 1, opener, content_column)
@@ -706,7 +719,7 @@ def _strip_fences(lines: list[str]) -> list[tuple[int, str]]:
 def _fence_close(
     lines: list[str],
     start: int,
-    opener: tuple[str, int, int],
+    opener: tuple[str, int, str],
     content_column: int,
 ) -> int | None:
     """Index of the line closing `opener`, or None if it never closes.
@@ -714,33 +727,35 @@ def _fence_close(
     Split out of `_strip_fences` so that a fence is committed to only once its
     closer is in hand (rf2-mmyc).  The closing test is superfences': the
     opener's EXACT marker run, at the opener's EXACT indentation, carrying no
-    info string, at the opener's own blockquote depth.
+    info string.
 
     Returning None is the load-bearing case.  It means the renderer never sees a
     fenced block here, so the caller must blank NOTHING — not the body, not the
     opener, and above all not the rest of the document.
 
     A blank line closes nothing and ends no container: superfences counts it and
-    reads on.  A non-blank line shallower than the fence's container (or, in a
-    blockquote, quoted less deeply than the opener) means the container closed
-    first, so the closer cannot be below it.
+    reads on.  A non-blank line shallower than the fence's container means the
+    container closed first, so the closer cannot be below it.
+
+    INSIDE A BLOCKQUOTE the test is the raw PREFIX WIDTH, not the quote depth
+    (rf2-1cpt, MERGED-PR AUDIT #7786).  `eval_quoted` abandons the fence when a
+    line is quoted more deeply than the opener or carries a NARROWER prefix than
+    it, and `parse_fence_line` reads each line's prefix only as far as the
+    opener's reached.  Comparing depth instead treats `>`, `> ` and `>  ` as the
+    same prefix, which closed fences the renderer never opens and hid the real
+    links written inside them.
     """
-    marker, fence_indent, fence_depth = opener
+    marker, fence_indent, fence_prefix = opener
+    if fence_prefix:
+        return _quoted_fence_close(lines, start, marker, fence_prefix)
     for j in range(start, len(lines)):
         raw = lines[j]
         if not raw.strip():
             continue
         indent = len(raw) - len(raw.lstrip(" "))
-        if fence_depth:
-            depth, body = _quote_depth_and_body(raw[indent:], limit=fence_depth)
-            if depth != fence_depth:
-                return None  # the blockquote holding the fence ended first
-            candidate = body
-        else:
-            if indent < content_column:
-                return None  # the container holding the fence ended first
-            candidate = raw
-        m = _FENCE_RE.match(candidate)
+        if indent < content_column:
+            return None  # the container holding the fence ended first
+        m = _FENCE_RE.match(raw)
         if (
             m
             and m.group("marker") == marker
@@ -748,6 +763,39 @@ def _fence_close(
             and not m.group("info").strip()
         ):
             return j
+    return None  # end of document, with no closer
+
+
+def _quoted_fence_close(
+    lines: list[str],
+    start: int,
+    marker: str,
+    prefix: str,
+) -> int | None:
+    """`_fence_close` for a fence opened inside a blockquote (rf2-1cpt).
+
+    A direct port of superfences' `eval_quoted`, in its order, because the order
+    is load-bearing: an EMPTY content line is accepted before the prefix-width
+    test, which is what lets a bare `>` sit inside a `> ` fence without ending
+    it.
+    """
+    width = len(prefix)
+    quote_level = prefix.count(">")
+    empty_lines = 0
+    for j in range(start, len(lines)):
+        ws, content = _fence_prefix(lines[j], limit=width)
+        if ws.count(">") > quote_level:
+            return None  # quoted deeper than the opener: superfences clears
+        if not content.strip():
+            empty_lines += 1
+            continue
+        if len(ws) < width:
+            return None  # "not indented enough" — the fence is abandoned
+        if empty_lines and ws.count(">") < quote_level:
+            return None  # a blank line, then a shallower quote: the quote ended
+        if content.startswith(marker) and not content[len(marker):].strip(" \t"):
+            return j  # the opener's exact run, with nothing after it
+        empty_lines = 0
     return None  # end of document, with no closer
 
 
@@ -1044,6 +1092,35 @@ def _quote_depth_and_body(content: str, limit: int | None = None) -> tuple[int, 
         depth += 1
         pos = m.end()
     return depth, content[pos:]
+
+
+def _fence_prefix(line: str, limit: int | None = None) -> tuple[str, str]:
+    """Split a line into superfences' fence PREFIX and the content after it.
+
+    A port of superfences' `parse_whitespace` (`limit=None`, used on the opening
+    line) and `parse_fence_line` (`limit=<opener width>`, used on every line
+    below it).  Both walk the leading run of `>`, space and tab without giving
+    `>` any special meaning; the second stops once it has consumed as many
+    columns as the OPENER's prefix occupied.
+
+    That cap is the whole mechanism (rf2-1cpt).  A line quoted more deeply than
+    its fence is not a nested quote to superfences — the cap simply stops before
+    the extra `>`, which is then the first character of a line of code.  And a
+    line whose prefix is NARROWER than the opener's is "not indented enough", so
+    the fence is abandoned rather than continued.
+
+    Tabs are counted as one column, matching this scanner's existing bound: the
+    corpus has no tab-indented fence, and superfences would expand them to the
+    configured tab length.
+    """
+    end = 0
+    for ch in line:
+        if limit is not None and end >= limit:
+            break
+        if ch not in _FENCE_PREFIX_CHARS:
+            break
+        end += 1
+    return line[:end], line[end:]
 
 
 def _inline_blocks(

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -2866,6 +2866,66 @@ def _run_self_tests(verbose: bool = False) -> int:
           "",
           "Prose after."],
          [1, 3, 9]),
+        # ------------------------------------------------------------------
+        # rf2-1cpt (MERGED-PR AUDIT #7786) — the quote prefix's SPELLING is
+        # renderer-significant, and quote DEPTH alone is not parity.
+        #
+        # superfences does not parse blockquote markers as markers.  Its
+        # `parse_whitespace` treats PREFIX_CHARS — `>`, space and tab — as one
+        # undifferentiated prefix run and remembers its RAW WIDTH (`ws_len`);
+        # `parse_fence_line` then reads a content line's prefix only that many
+        # CHARACTERS in, and `eval_quoted` clears the fence when a line's prefix
+        # is narrower (`len(ws) < self.ws_len`) or quoted deeper
+        # (`quote_level > self.quote_level`).
+        #
+        # The previous model stored (marker, in-quote indent, quote DEPTH) and
+        # compared with `_quote_depth_and_body`, which normalises the prefix:
+        # it absorbs one optional space after each `>`, so `>` and `> ` and
+        # `>  ` all read as depth 1.  Three shapes therefore closed a fence the
+        # renderer never opens, and each hid a REAL, VISIBLE link — the exact
+        # going-silent failure rf2-mmyc fixed from the other direction.
+        #
+        # All three render as `<blockquote><p>```clojure</p><blockquote><p><a
+        # href="missing.md">…` — the deeper-quoted line is a nested blockquote,
+        # which is a separate block, so the stray backtick runs cannot pair into
+        # a code span and the link resolves for real.
+        #
+        # A sweep of 1728 opener/body/closer prefix triples against the renderer
+        # found 235 disagreements before this change; these three are
+        # representative, not exhaustive.
+        ("a closer whose prefix is narrower than the opener's closes nothing",
+         [">```clojure",
+          "> >[a real link](missing.md)",
+          "> ```",
+          "",
+          "Prose after."],
+         [1, 2, 3, 5]),
+        ("a body quoted deeper than the opener is not fence content",
+         ["> ```clojure",
+          ">> [a real link](missing.md)",
+          ">```",
+          "",
+          "Prose after."],
+         [1, 2, 3, 5]),
+        ("an indented quoted opener is not closed at column zero",
+         ["   > ```clojure",
+          "> >[a real link](missing.md)",
+          "> ```",
+          "",
+          "Prose after."],
+         [1, 2, 3, 5]),
+        # THE MATCHED-PREFIX CONTROL.  Identical shape, prefix spelled the same
+        # on all three lines: this IS a fence, the renderer emits
+        # `<pre><code>`, and the link inside it must stay unresolved.  Without
+        # it the three cases above are satisfied by a scanner that recognises no
+        # quoted fence at all — which would silently undo rf2-1cpt's first half.
+        ("matched quote prefixes still open and close a fence",
+         ["> ```clojure",
+          "> [not a link](missing.md)",
+          "> ```",
+          "",
+          "Prose after."],
+         [5]),
     ]
     for label, lines, expected_visible in fence_cases:
         got_visible = [n for n, content in _strip_fences(lines) if content.strip()]


### PR DESCRIPTION
Second half of the rf2-b2cr / rf2-1cpt cluster. The first half (rf2-b2cr) merged as #7798; this branch was rebased onto it, so it carries only the rf2-1cpt commits.

Closes the correctness half of **rf2-1cpt**, reopened by the merged-PR audit on #7786. The 118 co-located compat-anchor collisions half of that bead was already complete and is untouched here.

## The defect

superfences does not parse blockquote markers as markers. `parse_whitespace` treats `PREFIX_CHARS` — `>`, space and tab — as one undifferentiated prefix run and remembers its **raw width**; `parse_fence_line` reads a content line's prefix only that many *characters* in; `eval_quoted` then abandons the fence when a line's prefix is narrower (`len(ws) < self.ws_len`) or quoted deeper (`quote_level > self.quote_level`).

The scanner stored `(marker, in-quote indent, quote DEPTH)` and compared through `_quote_depth_and_body`, which deliberately normalises the prefix away — it absorbs one optional space after each `>`, so `>`, `> ` and `>  ` all read as depth 1. **Depth alone is not renderer parity.** That is the right primitive for block boundaries and the wrong one for fences, and nothing said so.

Three shapes therefore closed a fence the renderer never opens, and each hid a **real, visible link**:

```
>```clojure
> >[a real link](missing.md)
> ```
```

The renderer emits `<blockquote><p>```clojure</p><blockquote><p><a href="missing.md">a real link</a>…` — the deeper-quoted line is a nested blockquote, a separate block, so the stray backtick runs cannot pair into a code span and the link resolves for real. The gate reported only line 5 visible and extracted no link at all. That is rf2-mmyc's going-silent failure reached from the other side.

## The repair

`_fence_prefix` ports `parse_whitespace`/`parse_fence_line`; `_quoted_fence_close` ports `eval_quoted` **in its original order**, because the order is load-bearing — an empty content line is accepted *before* the width test, which is what lets a bare `>` sit inside a `> ` fence without ending it. Depth is now derived from the prefix (`prefix.count(">")`) rather than standing in for it. The one-scanner design and every collision diagnostic are preserved; the unquoted path is untouched. No Markdown parser was built — this mirrors ~20 lines of superfences, exactly as the scanner already mirrored its marker/indent/info-string rules.

## Evidence

Red-first, as its own commit. The three fixtures are **re-confirmed red against current `origin/main`** after the rebase (the base moved when #7798 merged): 3 red, control green.

**The matched-prefix control** — same shape, prefix spelled identically on all three lines — is green before *and* after. Without it all three reds are satisfied by a scanner that recognises no quoted fence at all, which would silently undo rf2-1cpt's first half. It did not red at any point.

Renderer oracle: `mkdocs.config.load_config('mkdocs.yml')` into a real `markdown.Markdown`, against the repository's installed python-markdown 3.10 + pymdownx 10.21.3 — the exact pair the audit used. Every harness carries a `--prove` mode; the oracle's caught a genuine false signal on its first run (pymdownx.highlight mints `<a href="#__codelineno-0-1">` line anchors *inside* every highlighted block, which made every fenced shape look like a missed link).

Sweep of **1728** opener/body/closer prefix triples against the renderer:

| | before | after |
|---|---|---|
| disagreements | 235 | 123 |
| ...renderer emits a link the gate never checks | 151 | 72 |
| ...gate checks a link the renderer never renders | 84 | 51 |

The residue is a **strict subset**: 112 fixed, **0 introduced**.

It is also entirely outside this scanner's declared domain — 48 nested-quote openers (depth ≥ 2) and 75 with in-quote indent ≥ 4 (indented-code-block territory). In the **depth-1, in-quote-indent ≤ 3 domain — every shape the corpus can contain — the residue is zero.**

And the residue is not a fence disagreement at all: in it the scanner and the renderer *agree* no fence is present, and differ over whether a lazy blockquote continuation lets two stray backtick runs pair into an inline code span. That is `_inline_blocks`/`_mask_code_spans` (rf2-8wcbe), unchanged here and pre-existing.

## Corpus movement

**Zero links, zero ids, and zero fence-classification movement** — `_strip_fences` output is byte-identical on all 718 files, in both directions.

Explained rather than asserted, because a zero that means "the code never runs" would be worthless:

* The path is **not dead**: 14 quoted fences are recognised corpus-wide (fable-design.md, two hicasso studio pages, spec/005-StateMachines.md, seven skills pages), recorded from *inside* `_strip_fences` rather than re-derived by regex — a regex cannot tell an opener from a closer, and my first attempt at this census reported 12 spurious "mixed prefix" hits for exactly that reason.
* **None of the 14** is spelled with a mixed prefix, so the width rule and the depth rule return the same answer on every one.

This is the missing tooth audit #7786 described, not a current-corpus break — which is what that audit concluded when it found the gate green on the full scan.

## Quality gates

Each run alone, in the foreground, to completion; no gate piped through a filter; exit code captured to its own file.

| Gate | Result | Exit |
|---|---|---|
| `python scripts/check_doc_slugs.py --self-test` | pass | 0 |
| `python scripts/check_doc_slugs.py` (full corpus, 718 files) | pass | 0 |
| `python scripts/check_readme_links.py` (consumer gate — shares the extractor) | pass | 0 |
| `python scripts/check_readme_links.py --self-test` | pass | 0 |
| `sh scripts/test-fast-pr.sh` | pass | 0 |

All five re-run after the rebase onto current `main` except the fast-PR spine, which was run on the pre-rebase tree carrying the identical diff plus rf2-b2cr (now merged); relying on CI for the post-rebase spine.

`scripts/test-fast-pr.sh` printed `gate root: /c/Users/miket/code/re-frame2-worktrees/slugparity-1cpt` — this worktree. Its docs lane genuinely covered this surface: `docs corpus anchor self-test` and `docs corpus anchor validator`, plus both README-link gates.

Required checks the spine does not run were derived, not hand-listed: `python scripts/check_fast_pr_gap.py --list` reports 94, all surface-gated and none reaching a one-file change under `scripts/`. `mkdocs build --strict` is **not** a meaningful gate for this diff (it excludes `docs/design/**`, and does not exercise this scanner at all); `check_doc_slugs.py` likewise does not scan `implementation/`.
