### PR TITLE
fix(hicasso): a lexical binding is not the view it is spelled like (rf2-hic-022)

### DIFF
--- a/implementation/hicasso/lint-fixtures/negative.cljs
+++ b/implementation/hicasso/lint-fixtures/negative.cljs
@@ -163,3 +163,53 @@
 ;; interpret, so nothing judges inside a quotation.
 (h/defview quoted-hiccup [_]
   [:div (str '[(fn [] :a) "quoted, so never interpreted"])])
+
+;; ---------------------------------------------------------------------------
+;; direct-view-call — a LOCAL that happens to be spelled like the view
+;;
+;; The self-call check knows exactly one name: the view's own. A parameter, a
+;; destructured prop, a `let`, a `for` binding or a function argument spelled
+;; the same way is an ORDINARY LOCAL, and calling one is ordinary Clojure. The
+;; first draft of the check compared SPELLING and nothing else, so every form
+;; below was reported at ERROR — and because the required lane runs
+;; `--fail-level error`, correct code was refused (merged-PR audit #7794).
+;; ---------------------------------------------------------------------------
+
+;; A parameter shadows the view for the whole body.
+(h/defview card [card]
+  [:div.card (card)])
+
+;; Destructuring binds exactly the same way.
+(h/defview label [{:keys [label]}]
+  [:div (label)])
+
+;; So does a `let` ...
+(h/defview via-let [_]
+  (let [via-let (fn [] "ordinary")]
+    [:div (via-let)]))
+
+;; ... a `for` binding, where `(cell :label)` is an ordinary map lookup ...
+(h/defview cell [{:keys [cells]}]
+  [:ul (for [cell cells] [:li {:key (:id cell)} (cell :label)])])
+
+;; ... the parameter of a function literal ...
+(h/defview row [{:keys [rows]}]
+  [:ul (mapv (fn [row] [:li {:key (row :id)} (row :label)]) rows)])
+
+;; ... the parameter of the callback form ...
+(h/defview event [_]
+  [:button {:on-click (h/hfn [event] [:form/submit (event :value)])} "Save"])
+
+;; ... and a `letfn` name.
+(h/defview badge [{:keys [n]}]
+  (letfn [(badge [x] (str "#" x))]
+    [:span (badge n)]))
+
+;; A `catch` binding and an `as->` name are locals too. Contrived — nobody
+;; names a caught value after a view — but a rule with a hole in its notion of
+;; "bound" is a rule that fires on correct code, so the hole is closed and
+;; witnessed rather than argued about.
+(h/defview retry [{:keys [attempt]}]
+  [:div
+   (try (attempt) (catch :default retry (retry)))
+   (as-> attempt retry (retry))])

--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/README.md
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/README.md
@@ -37,30 +37,56 @@ every prop reads as `Unresolved symbol`.
 
 ## The checks
 
-### `:re-frame.hicasso/merge-not-a-map` — error
+### `:re-frame.hicasso/direct-view-call` — error
 
-`{:& …}` given a literal the runtime will refuse
-(`:rf.error/hicasso-merge-not-a-map`): a vector, set, string, keyword, number,
-boolean or character.
+A view calling **itself** like a function — `(todo-row {…})` written inside
+`(defview todo-row …)`, where `[todo-row {…}]` was meant. A view is a minted
+component and a hiccup head. Called directly it returns the runtime's component
+object instead of rendering, and no boundary is minted, so its reads belong to
+whichever body called it.
 
-**Refuses to know:** what any *expression* evaluates to. `{:& attrs}`,
-`{:& (merge a b)}` and `{:& (get props :attrs)}` are the ordinary spellings and
-are always silent — which means the common runtime failure, forwarding
-something that turns out not to be a map, is still the runtime's to catch.
-`{:& nil}` is legal and silent.
+**Refuses to know:** that any *other* symbol names a view. `(some-other-view …)`
+needs to resolve a var minted by `defview` in another namespace, and a hook sees
+one form — see the table at the end for why the cache-backed version of that is
+worse than nothing.
 
-### `:re-frame.hicasso/deferred-read` — error
+It also refuses any call whose name has been **rebound**. A parameter, a
+destructured prop, or a `let`, `for`, `fn`, `hfn`, `letfn` or `catch` binding
+spelled like the view introduces an ordinary local, and calling a local is
+ordinary Clojure:
 
-`h/sub` or `h/use-subs` written inside an `hfn` body. `hfn` **is** the callback
-form: its whole contract is that it runs after the body that wrote it, so a
-read there is deferred by construction rather than by circumstance, and the
-runtime refuses it with `:rf.error/hicasso-sub-outside-render`.
+```clojure
+(h/defview card [card]                    ; the parameter, not the view
+  [:div.card (card)])
+```
 
-**Refuses to know:** whether any *other* function value is deferred. A read
-inside a `(fn …)` handed to `mapv`, `for`, `keep` or an inlined helper runs
-*during* the body and is completely legal — a helper may donate reads to the
-boundary that called it. "An `fn` literal inside a body" is therefore not
-evidence of deferral, and this check does not treat it as any. Proving read
+Shadowing is read off the form in hand, because that is the only kind of fact
+available here: `api/resolve` answers `nil` for the view's own name — not yet a
+var when the hook runs — and never sees locals at all. A binding silences the
+entire form it heads, initialisers included, so a genuine self-call written in
+the initialiser of a `let` that goes on to bind the view's name is missed too.
+Missing one is the only way this check is allowed to be wrong.
+
+### `:re-frame.hicasso/deferred-read` — warning
+
+`h/sub` or `h/use-subs` read where nothing is going to call the surrounding
+function during this body. Two shapes:
+
+* inside an `hfn` body. `hfn` **is** the callback form: its whole contract is
+  that it runs after the body that wrote it, so a read there is deferred by
+  construction rather than by circumstance, and the runtime refuses it with
+  `:rf.error/hicasso-sub-outside-render`.
+* inside a plain `(fn …)` or `#(…)` that is *not* handed straight to `map`,
+  `mapv`, `for`, `keep`, `filter`, `reduce`, `run!`, `doseq` or another core
+  form that calls it synchronously — a callback, a timer, a promise, a thunk
+  stashed for later.
+
+**Refuses to know:** whether the second shape is really deferred, which is why
+it is a warning and why nothing here blocks a build. A read inside a `(fn …)`
+handed to `mapv` or `for` runs *during* the body and is completely legal — a
+helper may donate reads to the boundary that called it — so those are named and
+exempt. `(some-helper (fn [] (h/sub …)))` may well call its argument during the
+body too, and this cannot know; if it does, ignore the warning. Proving read
 extent in general is the runtime's law, not lint's.
 
 ### `:re-frame.hicasso/function-in-head-position` — error
@@ -144,11 +170,11 @@ same afternoon.
 
 | Wanted check | Why it is not here |
 |---|---|
-| **Direct invocation of a `defview`** — `(todo-row {…})` instead of `[todo-row {…}]` | Needs to know that a symbol resolves to a var minted by `defview`, usually in another namespace. A hook sees one form. `clj-kondo.hooks-api/ns-analysis` can answer it from the analysis cache, which makes the check fire in a full CI run and stay silent in an editor linting one file — a rule that fires *sometimes* is worse than one that never does. |
+| **Direct invocation of *another* view** — `(todo-row {…})` where `todo-row` is defined elsewhere | Needs to know that a symbol resolves to a var minted by `defview`, usually in another namespace. A hook sees one form. `clj-kondo.hooks-api/ns-analysis` can answer it from the analysis cache, which makes the check fire in a full CI run and stay silent in an editor linting one file — a rule that fires *sometimes* is worse than one that never does. The self-call slice above is the part a hook can settle on its own. |
 | **A plain function in head position, by symbol** — `[helper {…}]` where `helper` is a `defn` | Same problem, same answer. The literal-function slice above is the part that is decidable. |
-| **A deferred read in general** — a `sub` reachable from any callback, timer, promise or lazy escape | Read extent is a property of *execution*, and the runtime owns it. Lint can only see the one position (`hfn`) whose deferral is syntactic. |
+| **A deferred read in general** — a `sub` reachable from any callback, timer, promise or lazy escape | Read extent is a property of *execution*, and the runtime owns it. Lint can see only the `hfn` position, whose deferral is syntactic, and the fn literal nothing standard is about to call — and the second of those is advice, not a verdict. |
 | **A `sub` naming an unregistered query id** | Registration is a whole-program fact, and ids are frequently built rather than written. |
-| **`:&` forwarding something that is not a map** | Only literals are decidable. See the check above. |
+| **`:&` forwarding something that is not a map** | The `:&` grammar key is retired from the end-state design in favour of the owned-wins merge recipe. A lint layer must not police a ghost. |
 | **An `:input` without a label** | The name comes from a sibling or ancestor. That is tree knowledge, not form knowledge. |
 | **Hiccup written in an ordinary `defn` helper** | Not a decision — a limit. Hooks fire only at registered call sites, so every check here sees hiccup inside `defview`, `defhost` and `hfn` forms and nowhere else. A helper that returns hiccup is unlinted. |
 

--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj
@@ -497,6 +497,112 @@
                    "IS called synchronously, ignore this: read extent is the "
                    "runtime's law, not lint's."))))
 
+(def ^:private let-shaped
+  "Forms whose first argument is a `let`-shaped binding VECTOR.
+
+  `binding` and `with-redefs` rebind VARS rather than introducing locals, and
+  they are here anyway for the same reason: inside one, the name no longer
+  denotes the view either."
+  '#{let let* loop loop* when-let if-let when-some if-some when-first
+     with-open with-local-vars doseq for binding with-redefs})
+
+(defn- bound-symbols
+  "Every symbol a binding TARGET binds, destructuring included.
+
+  A SUPERSET is the safe direction and the reason this can be so blunt: the
+  only thing an extra name here can do is silence the self-call check, and
+  silence is the only failure that check is allowed."
+  [node]
+  (into #{} (keep token-sexpr) (subforms node)))
+
+(defn- pair-targets
+  "The binding TARGETS of a `let`-shaped vector — `for` / `doseq` modifiers
+  included, because `:let [b 1]` binds too and `:when`/`:while` do not."
+  [children]
+  (loop [[target value & more] children
+         acc                   []]
+    (if (nil? target)
+      acc
+      (let [kw (tag-keyword target)]
+        (recur more
+               (cond
+                 (= :let kw)   (if (api/vector-node? value)
+                                 (into acc (pair-targets (:children value)))
+                                 acc)
+                 (keyword? kw) acc
+                 :else         (conj acc target)))))))
+
+(defn- fn-locals
+  "The names a `fn` / `fn*` / `hfn` binds: its own optional name, and every
+  parameter of every arity."
+  [children]
+  (let [self   (token-sexpr (first children))
+        forms  (if self (rest children) children)
+        params (if (api/vector-node? (first forms))
+                 [(first forms)]
+                 (keep #(when (api/list-node? %) (first (:children %))) forms))]
+    (into (if self #{self} #{})
+          (comp (filter api/vector-node?) (mapcat bound-symbols))
+          params)))
+
+(defn- locals-bound-by
+  "The names this node binds over its own subforms, when it is a form that
+  binds names at all — and `#{}` for everything else, which is most nodes.
+
+  Enumerated rather than inferred: a hook has no scope table, so knowing a
+  lexical binding when it sees one means naming the forms that make them.
+  The list is the price of never firing on a local."
+  [node]
+  (if-not (api/list-node? node)
+    #{}
+    (let [[head & more] (:children node)
+          core          (core-var head)]
+      (cond
+        (contains? let-shaped core)
+        (if (api/vector-node? (first more))
+          (into #{} (mapcat bound-symbols) (pair-targets (:children (first more))))
+          #{})
+
+        (or (contains? '#{fn fn*} core) (= 'hfn (hicasso-var head)))
+        (fn-locals more)
+
+        ;; `(letfn [(f [x] …)] …)` binds each local function's NAME and its
+        ;; parameters — and the name sits in head position of its own form,
+        ;; which is precisely where a self-call is looked for.
+        (= 'letfn core)
+        (if (api/vector-node? (first more))
+          (into #{}
+                (mapcat (fn [f]
+                          (when (api/list-node? f)
+                            (let [[nm params] (:children f)]
+                              (into (if-let [s (token-sexpr nm)] #{s} #{})
+                                    (when (api/vector-node? params)
+                                      (bound-symbols params)))))))
+                (:children (first more)))
+          #{})
+
+        (= 'catch core)  (if-let [s (token-sexpr (second more))] #{s} #{})
+        (= 'as-> core)   (if-let [s (token-sexpr (second more))] #{s} #{})
+
+        :else #{}))))
+
+(defn- self-call-nodes
+  "Every `(nm …)` under `node` that is NOT inside a form binding `nm`.
+
+  A form that binds the name silences its WHOLE subtree, initialisers and
+  all, so a genuine `(card …)` written in the initialiser of a `let` that
+  goes on to bind `card` is missed. That is the deliberate direction: the
+  check exists to be always right, and a miss is the only way it is allowed
+  to be wrong."
+  [nm node]
+  (when (and node
+             (not (api/quote-node? node))
+             (not (contains? (locals-bound-by node) nm)))
+    (concat (when (and (api/list-node? node)
+                       (= nm (token-sexpr (first (:children node)))))
+              [node])
+            (mapcat #(self-call-nodes nm %) (:children node)))))
+
 (defn- check-direct-view-call!
   "A view called like a function, where that is decidable.
 
@@ -505,18 +611,29 @@
   that a symbol resolves to a var minted by `defview`, usually in another
   namespace, and a hook sees one form — so the decidable slice is the view
   calling ITSELF, whose name this hook is holding. Narrow, but always right
-  and editor-reliable, which the wider version is not (see README)."
-  [sym body]
+  and editor-reliable, which the wider version is not (see README).
+
+  Always right needs one thing more than the name, though, and the first
+  draft did not have it: a call is a SELF-call only when the name still
+  denotes the view at that point. `(defview card [card] (card))` calls its
+  parameter, and `(let [via-let …] (via-let))` calls its binding. Comparing
+  spelling alone reported both at ERROR, and the required lane runs
+  `--fail-level error`, so correct code was refused (merged-PR audit #7794).
+
+  `api/resolve` cannot settle this — it answers `nil` for the view's own
+  name, which is not yet a var when the hook runs, and it never sees locals
+  at all. Lexical shadowing is instead read off the form in hand, which is
+  the only kind of fact this file is allowed to use."
+  [sym argv body]
   (when-let [nm (token-sexpr sym)]
-    (doseq [node (mapcat subforms body)
-            :when (api/list-node? node)
-            :when (= nm (token-sexpr (first (:children node))))]
-      (finding! node :re-frame.hicasso/direct-view-call
-                (str "`" nm "` is a view, so it is a hiccup HEAD rather than a "
-                     "function: write [" nm " {…}]. Called directly it returns "
-                     "the runtime's component object instead of rendering, and "
-                     "no boundary is minted, so its reads belong to whichever "
-                     "body called it.")))))
+    (when-not (contains? (bound-symbols argv) nm)
+      (doseq [node (mapcat #(self-call-nodes nm %) body)]
+        (finding! node :re-frame.hicasso/direct-view-call
+                  (str "`" nm "` is a view, so it is a hiccup HEAD rather than a "
+                       "function: write [" nm " {…}]. Called directly it returns "
+                       "the runtime's component object instead of rendering, and "
+                       "no boundary is minted, so its reads belong to whichever "
+                       "body called it."))))))
 
 (defn- check-body!
   "Every hiccup-shaped check, over one body."
@@ -539,7 +656,7 @@
                                 [nil more])
         [argv & body]         more]
     (check-body! body)
-    (check-direct-view-call! sym body)
+    (check-direct-view-call! sym argv body)
     {:node (api/list-node
              (concat [(api/token-node 'clojure.core/defn) sym]
                      (when doc [doc])

--- a/implementation/hicasso/scripts/check_lint_export.py
+++ b/implementation/hicasso/scripts/check_lint_export.py
@@ -247,6 +247,16 @@ def self_test():
         ("a check firing at the wrong ROWS reds", "fixture",
          '  [:a {:href "/help"}])', '  [:a {:href "/help"} "Help"])',
          "nameless-interactive-element"),
+        # The ERROR-level rule that blocked correct code (merged-PR audit
+        # #7794): a self-call check comparing SPELLING alone reports every
+        # local that happens to share the view's name -- a parameter, a
+        # `let`, a `for` binding. Blind the one helper that reads a binding
+        # target and the negative half must red, because an ERROR firing on
+        # somebody's `let` is the failure this whole layer exists to avoid.
+        ("a self-call check blind to lexical shadowing reds", "hook",
+         "  (into #{} (keep token-sexpr) (subforms node)))",
+         "  (do node #{}))",
+         "direct-view-call"),
     ]
 
     ok = True


### PR DESCRIPTION
Closes the defect the merged-PR audit of #7794 reopened `rf2-hic-022` for.

Rebased onto `origin/main` at `90a4b24146` and every gate below re-run on that
base. The rebase touched nothing: `main` moved 27+ files since the original
base and not one of them is among this diff's four, so no conflict was
resolved and no intent was merged away.

## The defect, reproduced first

`check-direct-view-call!` compared token **spelling** and nothing else. The rule
is ERROR level and the required `clj-kondo` lane runs `--fail-level error`, so
correct programmer code was refused. Both of the audit's cases reproduce against
the shipped export on `origin/main` (verified at `c057ce03c8`), at the CI pin
(`clj-kondo 2026.04.15`) and again on a local `2025.10.23`:

```
.scratch/repro.cljs:4:24: error: `card` is a view, so it is a hiccup HEAD rather than a function: write [card {…}]. …
.scratch/repro.cljs:6:57: error: `via-let` is a view, so it is a hiccup HEAD rather than a function: write [via-let {…}]. …
linting took 418ms, errors: 2, warnings: 0
EXIT=3
```

Each call resolves to a legal local binding — a parameter in the first, a `let`
binding in the second. A gate that blocks correct code is worse than no gate.

## The repair

The rule stays **bounded and editor-reliable**. No whole-program resolution: that
was declined on this bead because cache-backed `ns-analysis` fires in a full CI
run and stays silent in an editor, and a rule that behaves differently in the two
places a programmer meets it is worse than a narrower one that behaves the same
in both.

What it gains is the second half of "is this a self-call": the name must still
**denote the view** at that point.

`api/resolve` cannot answer that, which is worth recording because the audit
suggested it. A probe against the shipped export prints `nil` for all three of
`card`, `via-let` and the positive fixture's `self-calling-view` — the view's own
name is not yet a var when the hook runs, and `api/resolve` never sees locals at
all. So shadowing is read off the form in hand instead, which is the only class
of fact this hook is allowed to use:

* the argument vector, destructuring included;
* `let` / `let*` / `loop` / `when-let` / `if-let` / `when-some` / `if-some` /
  `when-first` / `with-open` / `with-local-vars` / `doseq` / `for` / `binding` /
  `with-redefs`, with `for` and `doseq` `:let` modifiers folded in and
  `:when` / `:while` excluded;
* `fn` / `fn*` / `hfn` parameters and a `fn`'s optional self-name, every arity;
* `letfn` names and their parameters — the name sits in head position of its own
  form, which is exactly where a self-call is looked for;
* `catch` and `as->` bindings.

A binding silences the **whole form it heads**, initialisers included. That loses
a genuine self-call written in the initialiser of a `let` that goes on to bind
the view's name. It is the deliberate direction: silence is the only failure this
check is allowed, and the README says so.

## Evidence — red first, and the control that matters

**BEFORE** (`python hicasso/scripts/check_lint_export.py`, pinned clj-kondo,
with the eight new negative fixtures and the old hook) — exit **1**, eleven
findings on correct code:

```
FAIL: Hicasso lint export gate

  lint-fixtures/negative.cljs:180:14 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `card` is a view …
  lint-fixtures/negative.cljs:184:9  fired re-frame.hicasso/direct-view-call -- correct code must be silent: `label` is a view …
  lint-fixtures/negative.cljs:189:11 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `via-let` is a view …
  lint-fixtures/negative.cljs:193:49 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `cell` is a view …
  lint-fixtures/negative.cljs:197:35 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `row` is a view …
  lint-fixtures/negative.cljs:197:46 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `row` is a view …
  lint-fixtures/negative.cljs:201:52 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `event` is a view …
  lint-fixtures/negative.cljs:205:11 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `badge` is a view …
  lint-fixtures/negative.cljs:206:12 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `badge` is a view …
  lint-fixtures/negative.cljs:214:41 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `retry` is a view …
  lint-fixtures/negative.cljs:215:24 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `retry` is a view …
```

Note row 205: `letfn`'s binding form `(badge [x] …)` puts the bound name in head
position, so the naive rule reported the binding site itself.

**AFTER** — exit **0**:

```
OK: 6 checks fire on their fixtures, correct code is silent, and the artefact's own testbeds are quiet.
```

The audit's two verbatim cases, linted directly against the rebuilt export:
`linting took 621ms, errors: 0, warnings: 0`, exit 0.

**The positive row is preserved, and that was measured rather than assumed.**
`lint-fixtures/positive.cljs:25` still reports `direct-view-call` at ERROR. To
prove the rule was not silenced rather than repaired, the recursive self-call was
mutated to its correct spelling (`(self-calling-view {…})` → `[self-calling-view
{…}]`) and the gate red by name:

```
FAIL: Hicasso lint export gate

  direct-view-call: expected rows [25] in lint-fixtures/positive.cljs, got nothing -- the check did not fire
```

Every mutation was confirmed applied — `git diff --stat` non-empty and the token
grepped back out of the file — before any verdict was believed. The fixture was
restored from a copy and `git status` re-checked clean.

That control is now **permanent**: `check_lint_export.py` gains a fourth
self-test mutation which blinds `bound-symbols`, the one helper that reads a
binding target, and asserts the negative half reds with `direct-view-call`.

## Also fixed: the export README described a different export

Found while documenting the check. The shipped `README.md` a consumer copies
documented `:re-frame.hicasso/merge-not-a-map`, a check deleted by the operator's
roster ruling; gave `deferred-read` the level `error` where `config.edn` ships
`warning`, and described only one of its two shapes; and had no entry at all for
`direct-view-call`. It now matches `config.edn` exactly — six checks, six
sections, levels agreeing. The `:&` row in the "not here" table cites the
retirement rather than a check that is gone.

## Quality gates

Every gate below was run **on the rebased tree** (`origin/main` @ `90a4b24146`),
alone, in the foreground, to completion, redirected to a worktree-local log with
the runner's own exit code captured **on the same command line** as the gate.
Every gate printed a root naming this worktree
(`gate root: /c/Users/miket/code/re-frame2-worktrees/lintlocal-hic022`).

| Gate | Result | Exit |
|---|---|---|
| `check_lint_export.py --self-test` (pinned clj-kondo 2026.04.15) | 4/4 mutations red, unmutated export passes, `check_lint_export self-test: PASS` | `0` |
| `check_lint_export.py` (pinned clj-kondo 2026.04.15) | `OK: 6 checks fire on their fixtures, correct code is silent, and the artefact's own testbeds are quiet.` | `0` |
| tree-wide `clj-kondo` (pinned 2026.04.15, `lint.yml`'s own `--lint` roster, `--fail-level error`) | `errors: 0, warnings: 4542` — counts below | `0` |
| `npm run test:hicasso-hmr` — CLJS hicasso HMR contract | `HICASSO HMR PASS (chromium + firefox + webkit) — 36 real shadow reloads`, 105 checks per engine | `0` |
| `scripts/test-fast-pr.sh` | full spine green, `hicasso lint export gate` inside it green | `0` |

The two `check_lint_export.py` rows are what `npm run test:hicasso-lint` chains;
they are listed separately because they are separate assertions with separate
exit codes. The fast-PR spine runs that same npm script at its
`hicasso lint export gate` step, and its transcript there reads:

```
  ok   a disabled check reds the positive half
  ok   an element check reading props maps reds the negative half
  ok   a check firing at the wrong ROWS reds
  ok   a self-call check blind to lexical shadowing reds
  ok   the unmutated export passes
check_lint_export self-test: PASS
OK: 6 checks fire on their fixtures, correct code is silent, and the artefact's own testbeds are quiet.
```

**The HMR contract gate was run deliberately.** `report-changed-surfaces.sh`
opens its arm on the glob `implementation/hicasso/*`, so this diff schedules
`cljs-hicasso-hmr` even though nothing here is compiled — `lint-fixtures/` is on
no shadow-cljs source path, `resources/clj-kondo.exports/**` is data read by
clj-kondo's SCI, and the remaining two files are prose and a Python gate. The
gate was run rather than argued away, and it passes.

Tree-wide `clj-kondo` — the repo dogfoods this export through
`.clj-kondo/config.edn`'s `:config-paths`, so a hook change lints the whole tree.
Both sides measured on the rebased base with the identical command, "before"
taken by checking the hook out from `origin/main` and back again:

| | errors | warnings | findings |
|---|---|---|---|
| before | 0 | 4542 | 4699 lines |
| after | 0 | 4542 | 4699 lines |

`diff` of the two sorted finding sets is **empty** — byte-identical, so zero new
findings and zero removed. That is the expected result: this change only
*narrows* an ERROR rule, and no tracked source shadows its own view name. (The
`62 pre-existing warnings removed` baseline belongs to the earlier PR on this
bead, not to this one.)

Note the local `clj-kondo` binary on this machine is `2025.10.23`, which is
**not** the CI pin. Every clj-kondo verdict above was therefore taken with the
artefact's pinned `:clj-kondo` alias (`2026.04.15`) forced onto the path. The
defect reproduces identically on both versions.

**Not run here, and why:** the required checks this spine does not decide are not
hand-listed — they move, which is exactly what happened twice during this PR.
Derive them with `python scripts/check_fast_pr_gap.py --list`, catalogued in
`TESTING.md` § *Required checks the fast-PR spine does not run*.

## Fences

Untouched, per the dispatch: `impl/error.cljc`, the `defview` / `defhost` macro
expansion, `spec/009-Instrumentation.md`, `impl/collector.cljs`, `evidence.cljs`,
`tool.cljs`, `tools/xray/**`, the root-lifecycle and hydration files,
`.github/workflows/*`, `scripts/check_gate_scheduling.py` and
`scripts/check_doc_slugs.py`. No hot-zone file is touched — no `spec/*`, no
`deps.edn`, no `shadow-cljs.edn`, no workflow. No `.beads` path is in this diff.
