### PR TITLE
fix(hicasso): share the vector preflight so a malformed form refuses once (rf2-hic-020)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
@@ -2847,9 +2847,16 @@
   much later the foreign component renders it.
 
   The element's TYPE is always [[raw-gate]]; the component rides in the
-  carrier's `c` slot."
+  carrier's `c` slot.
+
+  **The Component slot is already validated.** [[vector-kind]] runs
+  [[raw-component]] as part of answering `:raw`, and [[vec->element]] —
+  this fn's only caller, which is why it is private — dispatches on that
+  answer. So position 1 is read here rather than re-derived, and the
+  escape's grammar is enforced in exactly one place for the runtime and
+  for `re-frame.hicasso.test` alike (rf2-hic-020)."
   [argv]
-  (let [component  (raw-component argv)
+  (let [component  (nth argv 1)
         has-props? (props-map? argv 2)
         props      (merge-caller (if has-props? (nth argv 2) {}))
         js-props   (reduce-kv (partial host-entry raw-crossing {}) #js {} props)
@@ -2898,7 +2905,7 @@
   (or (keyword? head) (symbol? head) (string? head)))
 
 ;; ---------------------------------------------------------------------------
-;; The two discriminations, each named once (rf2-hic-020)
+;; The discriminations, each named once (rf2-hic-020)
 ;; ---------------------------------------------------------------------------
 ;;
 ;; [[vec->element]] and [[as-element]] each answer a question before they do
@@ -2918,6 +2925,20 @@
 ;; the two `cond`s were tuned to (see [[as-element]]'s accounting); moving a
 ;; test here moves it for the runtime and the kit together, which is the
 ;; whole point.
+;;
+;; A SECOND audit (PR #7796) found that sharing the answers was not yet
+;; enough, because [[vec->element]] does not only classify: it REFUSES two
+;; shapes before and around the classification — an empty vector, which has
+;; no head to classify, and a raw escape whose Component slot holds
+;; something React will not mint a fiber for. Those refusals were the
+;; runtime's alone, so the kit met the same two forms and answered with ids
+;; of its own: a generic malformed head for `[]`, and an L3 opacity pointer
+;; for `[:> :div]` — telling the programmer to go mount, at L3, a form that
+;; cannot mount anywhere. Wrong advice, not merely a different id.
+;;
+;; [[vector-kind]] is where that stops. It is the discrimination WITH the
+;; guards that have to pass before there is anything to discriminate, so a
+;; malformed vector raises ONE refusal, from one guard, whichever side asked.
 
 (defn head-kind
   "WHICH KIND OF HEAD a hiccup vector has — `:fragment`, `:raw`, `:tag`,
@@ -2935,8 +2956,46 @@
     (host-head? head)     :host
     :else                 :invalid))
 
-(defn vec->element
-  "Interpret one hiccup vector."
+(defn vector-kind
+  "WHICH KIND OF VECTOR this hiccup vector is — [[head-kind]]'s answer for
+  its head, once the vector has passed the two checks that must pass
+  before ANY reader can act on it.
+
+  **The vector preflight, named once.** [[vec->element]] runs it before
+  it builds; `re-frame.hicasso.test`'s L2 walk runs it before it records.
+  The two checks are the two places [[head-kind]] alone leaves a reader
+  to invent an answer:
+
+  - **An empty vector has no head.** Refused ahead of any classification,
+    because every branch below reads position 0 — and a reader that asks
+    [[head-kind]] about the `nil` it finds there is told `:invalid`, and
+    reports a malformed HEAD for a vector that has none.
+  - **A raw escape's Component slot is the escape's own grammar.**
+    [[raw-component]] is the door for it, and running it here rather than
+    inside [[raw-element]] is what lets a reader that will never build an
+    element still get the escape's real refusal. `[:>]`, `[:> nil]` and
+    `[:> :div]` are malformed, not opaque: there is nothing for React to
+    interpret, so answering them with a pointer to a mounted test would
+    send the programmer to mount a form that cannot mount.
+
+  Both refusals are minted by the RUNTIME's own guards, in the runtime's
+  own order — so the id, the reason and the recovery a consumer sees are
+  one set of values with one home, which is the whole of what a parity
+  table can promise about a form neither side can interpret.
+
+  **`:where` names [[vec->element]] and [[raw-element]], not this
+  function**, because the contracts being enforced are those doors' and
+  Spec 009 pins those spellings against the ids. A second spelling here
+  would be a second identity for one fault — the drift this seam exists
+  to end.
+
+  **What it costs**, on the accounting this file keeps: one direct call,
+  and one keyword `=` against a keyword produced two lines above it. The
+  `count` guard and the [[head-kind]] call were already on every vector's
+  path; nothing was added to them and nothing was reordered. Only the
+  `:raw` population pays anything more — [[raw-component]]'s `cond`,
+  which [[raw-element]] used to run and no longer does, so an escape pays
+  it exactly once, as before."
   [argv]
   (when (zero? (count argv))
     (fail! :rf.error/hicasso-empty-vector
@@ -2944,14 +3003,27 @@
            "A hiccup vector must have a head."
            :supply-a-hiccup-head
            {}))
-  (let [head (nth argv 0)]
-    (case (head-kind head)
-      :fragment (fragment-element argv)
-      :raw      (raw-element argv)
-      :tag      (native-element argv)
-      :boundary (boundary-element argv)
-      :host     (host-element argv)
-      :invalid
+  (let [kind (head-kind (nth argv 0))]
+    (when (= :raw kind)
+      (raw-component argv))
+    kind))
+
+(defn vec->element
+  "Interpret one hiccup vector. [[vector-kind]] is the preflight: it has
+  refused an empty vector and a malformed escape before any arm below
+  runs, so every arm here reads a vector it knows is well formed."
+  [argv]
+  (case (vector-kind argv)
+    :fragment (fragment-element argv)
+    :raw      (raw-element argv)
+    :tag      (native-element argv)
+    :boundary (boundary-element argv)
+    :host     (host-element argv)
+    :invalid
+    ;; `:invalid` implies a head, because [[vector-kind]] refused the
+    ;; headless vector — so this reads position 0 without a default, and
+    ;; reads it on the cold arm only.
+    (let [head (nth argv 0)]
       (fail! :rf.error/hicasso-bad-head
              'front.codec/vec->element
              (if (fn? head)

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_runtime_parity_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_runtime_parity_cljs_test.cljs
@@ -30,9 +30,21 @@
 
   **Refusals are asserted as identity, never as `thrown?`.** A bare
   `(is (thrown? …))` is green for a throw from any layer carrying any id,
-  and two rows here are specifically about WHICH refusal is raised. The
-  rows compare the ex-data map."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+  and several rows here are specifically about WHICH refusal is raised.
+  The rows compare the ex-data map — id, `:where` and `:recovery`.
+
+  **Where a row's refusal is the RUNTIME's, the table says so in
+  `:where`.** A second audit (PR #7796) found the covered corpus stopping
+  one layer short: it held a VALID raw escape, for which opacity is the
+  honest answer, and no malformed one — so the claim that the two sides
+  cannot disagree quietly was not load-bearing on that arm, and in fact
+  they did. An empty vector and a malformed `[:> …]` are refused by the
+  runtime, and the kit now raises those refusals rather than its own by
+  running the runtime's guards (`codec/vector-kind`). Asserting `:where`
+  is what makes that structural rather than coincidental: a kit
+  paraphrase would carry `re-frame.hicasso.test` and red."
+  (:require [clojure.string :as str]
+            [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.hicasso :as h]
             [re-frame.hicasso.impl.codec :as codec]
@@ -83,12 +95,18 @@
       [:element tag]  is a native element
       [:fragment]     is a fragment
       [:opaque]       is an element only React can interpret
-      [:refused id]   is a loud error, with its id"
+      [:refused id r] is a loud error, with its id and its recovery
+
+  The refusal token carries the RECOVERY as well as the id, because the
+  advice is half of what a refusal is: the audit that reopened this bead
+  found the kit answering a malformed raw escape with a pointer to L3,
+  which is not merely a different id but the wrong instruction. A column
+  that named only the id would have called that a near miss."
   [x]
   (let [o (outcome #(intent/with-frame frame-id (collector/frame-dispatch frame-id)
                       (fn [] (codec/as-element x))))]
     (if-some [d (:refused o)]
-      [:refused (:rf.error/id d)]
+      [:refused (:rf.error/id d) (:recovery d)]
       (let [v (:returned o)]
         (cond
           (nil? v)    [:nothing]
@@ -166,11 +184,15 @@
 
    {:case    "a `true` child RAISES, and raises the runtime's own id"
     :form    [:div true]
-    :runtime [:refused :rf.error/hicasso-true-child]
-    :refuses {:rf.error/id :rf.error/hicasso-true-child}
+    :runtime [:refused :rf.error/hicasso-true-child :use-nil-or-false]
+    :refuses {:rf.error/id :rf.error/hicasso-true-child
+              :recovery    :use-nil-or-false}
     :why     (str "codec/as-element — nil and false render nothing; true is an "
                   "error (HD-016). Dropping it silently teaches a spelling the "
-                  "runtime rejects.")}
+                  "runtime rejects. 004B §Child normalization drops a `true` "
+                  "that reaches TREE BUILD; Hicasso's grammar refuses it "
+                  "upstream of that, so one never arrives — see the namespace "
+                  "docstring's §Scope of the 004B claim.")}
 
    {:case    "a `false` child renders nothing — the true child's legal twin"
     :form    [:div false "x"]
@@ -178,22 +200,94 @@
     :tree    {:rf.ui/tree-version v :tag :div :children ["x"]}
     :why     "codec/as-element — `(false? x) nil`."}
 
-   {:case    "`[:> …]` is the raw-React escape, and refuses to L3"
+   {:case    "a VALID `[:> …]` is the raw-React escape, and refuses to L3"
     :form    [:div [:> raw-component]]
     :subject [:> raw-component]
     :runtime [:opaque]
-    :refuses {:rf.error/id :rf.error/hicasso-test-react-is-opaque}
+    :refuses {:rf.error/id :rf.error/hicasso-test-react-is-opaque
+              :recovery    :assert-it-at-l3}
     :why     (str "codec/raw-head? — `[:> C]` hands C to React untouched "
                   "(HD-011). The namespace docstring promises anything the "
                   "codec hands to React untouched refuses with a pointer to "
-                  "L3; a generic malformed says the author wrote nonsense.")}
+                  "L3; a generic malformed says the author wrote nonsense. "
+                  "This row is the CONTROL for the three below: opacity is "
+                  "the answer only when the escape is well formed.")}
+
+   ;; ---- The seam's own rows (rf2-hic-020, audit of PR #7796) --------------
+   ;;
+   ;; `:opaque` is a claim about a form the kit CANNOT read, and it is only
+   ;; honest where the runtime can. For a MALFORMED escape the runtime cannot
+   ;; either — it refuses — so a kit that answered `:assert-it-at-l3` sent the
+   ;; programmer to write a browser test for a hiccup vector that will never
+   ;; render anywhere. Same for an empty vector, which the runtime refuses
+   ;; before it classifies a head at all. Both are the RUNTIME's refusal,
+   ;; raised by the runtime's own guards through `codec/vector-kind`, so these
+   ;; rows assert `:where` as well: a kit paraphrase would name
+   ;; `re-frame.hicasso.test` and red here.
+
+   {:case    "an EMPTY VECTOR raises the runtime's own empty-vector refusal"
+    :form    [:div []]
+    :subject []
+    :runtime [:refused :rf.error/hicasso-empty-vector :supply-a-hiccup-head]
+    :refuses {:rf.error/id :rf.error/hicasso-empty-vector
+              :where       'front.codec/vec->element
+              :recovery    :supply-a-hiccup-head}
+    :why     (str "codec/vec->element refuses an empty vector AHEAD of any "
+                  "head classification, because every branch below reads "
+                  "position 0. A kit that asks `head-kind` about the nil it "
+                  "found there answers `:invalid` and reports a generic "
+                  "malformed head — a second identity for one fault.")}
+
+   {:case    "`[:>]` with NO component raises the runtime's own refusal"
+    :form    [:div [:>]]
+    :subject [:>]
+    :runtime [:refused :rf.error/hicasso-raw-no-component
+              :hand-the-escape-a-real-component]
+    :refuses {:rf.error/id :rf.error/hicasso-raw-no-component
+              :where       'front.codec/raw-element
+              :recovery    :hand-the-escape-a-real-component}
+    :why     (str "codec/raw-component — the escape's Component slot is empty. "
+                  "Opacity is not the answer: there is nothing for React to "
+                  "interpret, so `:assert-it-at-l3` sends the programmer to "
+                  "mount a form that cannot mount.")}
+
+   {:case    "`[:> nil]` — the broken-import spelling — raises the same id"
+    :form    [:div [:> nil]]
+    :subject [:> nil]
+    :runtime [:refused :rf.error/hicasso-raw-no-component
+              :hand-the-escape-a-real-component]
+    :refuses {:rf.error/id :rf.error/hicasso-raw-no-component
+              :where       'front.codec/raw-element
+              :recovery    :hand-the-escape-a-real-component}
+    :why     (str "codec/raw-component — a `:default` import that resolved "
+                  "nothing is the usual cause, and it is the case a test kit "
+                  "is most likely to meet first. Distinct SPELLING from `[:>]` "
+                  "(the ex-data's `:argv-count` differs), same fault.")}
+
+   {:case    "`[:> :div]` — a keyword in the Component slot — raises the runtime's own refusal"
+    :form    [:div [:> :div]]
+    :subject [:> :div]
+    :runtime [:refused :rf.error/hicasso-raw-not-a-component
+              :hand-the-escape-a-component-react-accepts]
+    :refuses {:rf.error/id :rf.error/hicasso-raw-not-a-component
+              :where       'front.codec/raw-element
+              :recovery    :hand-the-escape-a-component-react-accepts}
+    :why     (str "codec/raw-component — the GRAMMAR owns tags, so a keyword "
+                  "is one of the escape's three deliberate narrowings. The "
+                  "second refusal id on this arm, which is why the arm needs "
+                  "two rows and not one.")}
 
    {:case    "a `defhost` crossing refuses to L3 — the escape's neighbour"
     :form    [:div [a-host]]
     :subject [a-host]
     :runtime [:opaque]
-    :refuses {:rf.error/id :rf.error/hicasso-test-host-is-opaque}
-    :why     "The kit's stated opacity, and the row that keeps it distinct."}
+    :refuses {:rf.error/id :rf.error/hicasso-test-host-is-opaque
+              :where       're-frame.hicasso.test
+              :recovery    :assert-it-at-l3}
+    :why     (str "The kit's stated opacity, and the row that keeps it "
+                  "distinct. `:where` is the KIT here, deliberately: L2's own "
+                  "opacity is the kit's claim to make, and the rows above show "
+                  "what it looks like when a refusal is the runtime's instead.")}
 
    {:case    "an SVG subtree carries `:ns`, and `:foreignObject` reverts"
     :form    [:svg {:view-box "0 0 1 1"}
@@ -267,3 +361,17 @@
     (is (seq (filter :refuses rows)))
     (is (seq (filter :tree rows)))
     (is (every? (fn [r] (or (:refuses r) (contains? r :tree))) rows))))
+
+(deftest the-table-covers-forms-BOTH-sides-refuse
+  (testing "the corpus holds rows where the RUNTIME refuses too, and the kit
+            answers with the runtime's own id, recovery and raising site —
+            the coverage PR #7796's audit found missing"
+    (let [shared (filter (fn [{:keys [runtime refuses]}]
+                           (and (= :refused (first runtime))
+                                (= (second runtime) (:rf.error/id refuses))
+                                (= (nth runtime 2) (:recovery refuses))))
+                         rows)]
+      (is (seq shared))
+      (is (seq (filter #(str/starts-with? (str (:where (:refuses %))) "front.codec/")
+                       shared))
+          "at least one row's refusal is raised by the runtime's own guard"))))

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
@@ -87,6 +87,26 @@
   - **A view-boundary node records the CALL, never the child's
     rendering.** See §Children below.
 
+  ### The scope of the claim: TREES EMITTED, not forms accepted
+
+  004B version 1 governs the tree this namespace **emits**. It does not
+  govern which author forms Hicasso accepts, and the two are different
+  questions with different owners: the grammar is Hicasso's (spec SN, the
+  HD rulings), the tree schema is 004B's, and this walk is both stages in
+  one pass because it takes author hiccup and answers a node.
+
+  The distinction is load-bearing at exactly one row. 004B §Child
+  normalization says `nil`/`false`/`true` children are dropped **at tree
+  build**; Hicasso raises `:rf.error/hicasso-true-child` for a `true`
+  child (HD-016). There is no contradiction: Hicasso's grammar refuses
+  the value upstream of tree build, so a `true` never reaches the rule
+  that would drop it, and every tree this namespace emits satisfies 004B
+  as written. What a reader must not conclude from *\"the tree is 004B
+  version 1\"* is that a form 004B tolerates is a form Hicasso accepts —
+  the schema describes the output, and the refusals are the substrate's.
+  `re-frame.hicasso.test-kit-runtime-parity-cljs-test` drives both sides
+  of that row so the two never drift apart quietly.
+
   ## What L2 runs, and what it refuses
 
   [[render]] takes a hiccup form whose head is **a body function** — the
@@ -117,13 +137,25 @@
   ### Children
 
   **What a child IS is the runtime's answer, never a second one.** The
-  walk dispatches on `codec/child-kind` and `codec/head-kind` — the same
-  two functions `codec/as-element` and `codec/vec->element` dispatch on —
-  so a keyword child is the text the runtime renders it as, `[:<> …]` is
-  a fragment because it is React's Fragment there, and a `true` child
+  walk dispatches on `codec/child-kind` and `codec/vector-kind` — the
+  same two doors `codec/as-element` and `codec/vec->element` dispatch on
+  — so a keyword child is the text the runtime renders it as, `[:<> …]`
+  is a fragment because it is React's Fragment there, and a `true` child
   raises `:rf.error/hicasso-true-child` because the runtime raises it.
   rf2-hic-020's audit found nine places where this walk had its own
   opinion; a branch that exists twice agrees once.
+
+  **A form the runtime REFUSES is refused here with the runtime's own
+  id.** `codec/vector-kind` is the preflight and not merely the head
+  discrimination, so an empty vector raises
+  `:rf.error/hicasso-empty-vector` and a malformed escape — `[:>]`,
+  `[:> nil]`, `[:> :div]` — raises `:rf.error/hicasso-raw-no-component`
+  or `:rf.error/hicasso-raw-not-a-component`, each carrying the runtime's
+  recovery rather than one of this namespace's. **Opacity is a claim
+  about a form L2 cannot read, and it is honest only where the runtime
+  CAN read it**: a second audit found `[:> :div]` answered
+  `:assert-it-at-l3`, which tells the programmer to mount, in a browser,
+  a form that will not mount anywhere.
 
   - A **nested body function** is refused: a plain function in head
     position is a loud error in Hicasso itself (HD-016), and a kit that
@@ -133,10 +165,11 @@
     children. Its body does NOT run, and the node claims nothing about
     what it would render. Assert its props here; render its body to
     assert its contents.
-  - A **`defhost` crossing**, the **raw escape `[:> …]`**, a **raw React
-    element** and anything else the codec hands to React untouched are
-    **opaque** and refuse with a pointer to L3. So does an unforced
-    `delay`, which Hicasso itself refuses at a boundary crossing.
+  - A **`defhost` crossing**, a **well-formed raw escape `[:> …]`**, a
+    **raw React element** and anything else the codec hands to React
+    untouched are **opaque** and refuse with a pointer to L3. So does an
+    unforced `delay`, which Hicasso itself refuses at a boundary
+    crossing. A MALFORMED escape is not opaque — see above.
 
   ### Reads
 
@@ -888,34 +921,51 @@
       (seq children)         (assoc :children children))))
 
 (defn- walk-vector
-  "One hiccup VECTOR to its 004B node. `codec/head-kind` is the runtime's
-  own head discrimination, so `:<>` is a fragment here because it is a
-  fragment there, and the two escapes React interprets for itself refuse
-  to L3 rather than being recorded as elements named `:<>` and `:>`."
-  [form ns-ctx]
-  (let [head (nth form 0 nil)]
-    (case (codec/head-kind head)
-      :tag      (element-node form ns-ctx)
-      :fragment (fragment-node form ns-ctx)
-      :boundary (boundary-node form ns-ctx)
+  "One hiccup VECTOR to its 004B node. `codec/vector-kind` is the
+  runtime's own vector preflight, so `:<>` is a fragment here because it
+  is a fragment there, and the two escapes React interprets for itself
+  refuse to L3 rather than being recorded as elements named `:<>` and
+  `:>`.
 
-      :host
+  **The preflight, and not `codec/head-kind` alone, because opacity is a
+  claim about a form the kit cannot read and it is honest only where the
+  runtime CAN.** `codec/vector-kind` raises the runtime's own refusal for
+  the two shapes that are malformed rather than opaque — a headless
+  vector, and a `[:> …]` whose Component slot holds nothing React will
+  mint a fiber for — so those arrive here already refused, with the
+  runtime's id, reason and recovery. Before rf2-hic-020's second audit
+  this walk asked `head-kind` directly and answered `[]` with a generic
+  malformed HEAD, and `[:> :div]` with a pointer to L3: an instruction to
+  go mount, in a browser, a form that cannot mount anywhere."
+  [form ns-ctx]
+  (case (codec/vector-kind form)
+    :tag      (element-node form ns-ctx)
+    :fragment (fragment-node form ns-ctx)
+    :boundary (boundary-node form ns-ctx)
+
+    :host
+    (let [head (nth form 0)]
       (refuse-opaque! :rf.error/hicasso-test-host-is-opaque
                       (str "a `h/defhost` crossing (" (pr-str (view-name head))
                            ") reached the semantic tree. What a foreign React "
                            "component renders is React's answer, not "
                            "Hicasso's, and L2 has no way to ask it.")
-                      {:host (view-name head) :value form})
+                      {:host (view-name head) :value form}))
 
-      :raw
-      (refuse-opaque! :rf.error/hicasso-test-react-is-opaque
-                      (str "the raw escape `[:> …]` reached the semantic tree. "
-                           "It hands its component to React untouched (HD-011), "
-                           "so what it renders is React's answer and L2 has no "
-                           "way to ask it.")
-                      {:value form})
+    ;; Reached only for a WELL-FORMED escape: `codec/vector-kind` has run
+    ;; the escape's own grammar and a malformed one never gets here.
+    :raw
+    (refuse-opaque! :rf.error/hicasso-test-react-is-opaque
+                    (str "the raw escape `[:> …]` reached the semantic tree. "
+                         "It hands its component to React untouched (HD-011), "
+                         "so what it renders is React's answer and L2 has no "
+                         "way to ask it.")
+                    {:value form})
 
-      :invalid
+    :invalid
+    ;; `:invalid` implies a head, because the preflight refused the
+    ;; headless vector under its own id.
+    (let [head (nth form 0)]
       (if (fn? head)
         (refuse! :rf.error/hicasso-test-plain-fn-head
                  (str "a plain function is in hiccup head position. Hicasso "


### PR DESCRIPTION
Closes the reopened charge on **rf2-hic-020**, from the merged-PR audit of #7796.

The audit accepted the shared `child-kind` / `head-kind` split — "substantially
better than nine copied patches" — and then found it stopping one layer short.
`vec->element` does not only classify. It **refuses two shapes around the
classification**, and those refusals were the runtime's alone, so the kit met
the same two forms and invented answers.

Both disagreements reproduced against `origin/main` at `298f15a595` before
anything was written. Neither had been fixed by the moves under this file.

## The verbatim reds

The four identity rows were committed first (`1235a8e604`), and reddened
exactly as the audit described. `the-runtime-answers-what-the-table-says` was
**green on all four** — the disagreement is entirely the kit's:

```
FAIL in (the-kit-answers-what-the-table-says)
  an EMPTY VECTOR raises the runtime's own empty-vector refusal
  actual: (not (= {:rf.error/id :rf.error/hicasso-empty-vector, :where front.codec/vec->element, :recovery :supply-a-hiccup-head}
                  {:rf.error/id :rf.error/ui-tree-malformed,    :where re-frame.hicasso.test, :recovery :fix-the-head}))

FAIL in (the-kit-answers-what-the-table-says)
  `[:>]` with NO component raises the runtime's own refusal
  actual: (not (= {:rf.error/id :rf.error/hicasso-raw-no-component,      :where front.codec/raw-element, :recovery :hand-the-escape-a-real-component}
                  {:rf.error/id :rf.error/hicasso-test-react-is-opaque,  :where re-frame.hicasso.test,   :recovery :assert-it-at-l3}))

FAIL in (the-kit-answers-what-the-table-says)
  `[:> nil]` — the broken-import spelling — raises the same id
  actual: (not (= {:rf.error/id :rf.error/hicasso-raw-no-component,      :where front.codec/raw-element, :recovery :hand-the-escape-a-real-component}
                  {:rf.error/id :rf.error/hicasso-test-react-is-opaque,  :where re-frame.hicasso.test,   :recovery :assert-it-at-l3}))

FAIL in (the-kit-answers-what-the-table-says)
  `[:> :div]` — a keyword in the Component slot — raises the runtime's own refusal
  actual: (not (= {:rf.error/id :rf.error/hicasso-raw-not-a-component,   :where front.codec/raw-element, :recovery :hand-the-escape-a-component-react-accepts}
                  {:rf.error/id :rf.error/hicasso-test-react-is-opaque,  :where re-frame.hicasso.test,   :recovery :assert-it-at-l3}))

Ran 168 tests containing 830 assertions.
4 failures, 0 errors.
```

Each row asserts the refusal **as a map** — id, `:where`, `:recovery` — because
both sides throw and the whole question is *which* refusal. `(is (thrown? …))`
would have been green throughout.

## The seam: `codec/vector-kind`, one function

```clojure
(defn vector-kind [argv]
  (when (zero? (count argv))
    (fail! :rf.error/hicasso-empty-vector 'front.codec/vec->element …))
  (let [kind (head-kind (nth argv 0))]
    (when (= :raw kind) (raw-component argv))
    kind))
```

**Why this is one seam and not two patches.** The empty-vector guard and the
escape's Component grammar are the same question asked at the same door — *is
there anything here to classify* — and both were already in the runtime: the
`count` guard at the top of `vec->element`, and `raw-component` inside
`raw-element`. This **moves** them into the answer rather than restating either.
Nothing is duplicated and nothing new is validated: `raw-element` now reads
position 1 instead of re-deriving it, so an escape pays `raw-component`'s `cond`
exactly once, as before. The hot path pays one direct call and one keyword `=`.

`vec->element` and the kit's `walk-vector` both dispatch on it, which is the
same discipline the accepted `head-kind` / `child-kind` split established: **a
branch that exists twice agrees once.**

`:where` still names `vec->element` and `raw-element`. Those are the doors whose
contracts these are, and **Spec 009 pins those spellings against the ids** — a
second spelling would have been a second identity for one fault, and would have
needed an edit to `spec/009`, which rf2-hic-007 holds. No spec file is touched
by this PR.

The parity rows assert `:where` for exactly that reason: it is what makes "the
kit raises the runtime's refusal" structural rather than coincidental. A kit
paraphrase would carry `re-frame.hicasso.test` and red.

## Why opacity was the wrong answer, not merely a different id

`:rf.error/hicasso-test-react-is-opaque` carries `:recovery :assert-it-at-l3`.
For `[:> :div]` that told the programmer to go mount, in a browser, a form that
will not mount anywhere. **Opacity is a claim about a form L2 cannot read, and
it is honest only where the runtime CAN read it.** A well-formed `[:> C]` still
refuses to L3 — that row is now the *control* for the three below it rather than
the whole of the coverage, which is what the audit meant by the table's claim
not yet being load-bearing on that arm.

## Clause 3 — Spec 004B, answered by scoping

**Scoped the kit's claim; did not edit the spec.** Both were honest and this is
the smaller change.

004B §Child normalization drops `nil`/`false`/`true` children **at tree build**.
Hicasso raises `:rf.error/hicasso-true-child` for a `true` child (HD-016). There
is no contradiction, and 004B is not wrong: the grammar is the *substrate's* and
refuses the value **upstream of tree build**, so a `true` never reaches the rule
that would drop it, and every tree the kit emits satisfies 004B as written. The
kit's walk is both stages in one pass, which is why the conflation was reachable.

The namespace docstring now carries a §*The scope of the claim: trees emitted,
not forms accepted*, saying which question 004B owns (the tree emitted) and
which the substrate owns (the forms accepted). The `true`-child parity row cites
it and drives both sides.

## The coverage guard

`the-table-covers-forms-BOTH-sides-refuse` asserts the corpus still holds rows
where the runtime refuses too, and where that refusal is raised by a
`front.codec/*` guard. Deleting the shared rows and leaving only the valid-raw
one reds it — which is the regression the audit had to find by hand.

## Quality gates

| Gate | Command | Result | Exit |
|---|---|---|---|
| Fast-PR spine | `sh scripts/test-fast-pr.sh` | **PASS fast PR spine**; classified `docs=false jvm=false node=true`; `gate root:` names this worktree. Includes the consolidated CLJS `:node-test` run (**13000 tests / 65669 assertions**), per-ns isolation, hicasso freeze gate, hicasso lint-export fixture witness, hicasso bench-lane compile (137 namespaces, 0 warnings) | `0` |
| Focused Hicasso node lane (before fix) | `node scripts/compile-node-test.cjs node-test-hicasso …` then `node out/node-test-hicasso.js` | 168 tests / 830 assertions, **4 failures**, 0 errors — the reds above, on purpose | `1` |
| Focused Hicasso node lane (after fix) | same | 168 tests / 830 assertions, **0 failures, 0 errors** | `0` |
| Hicasso freeze gate (standalone) | `python hicasso/scripts/check_freeze.py --self-test && … check_freeze.py` | self-test passed; 1 frozen row matches the bench tree | `0` |
| Fast-PR gap map | `python scripts/check_fast_pr_gap.py --list` | 94 required checks this spine does not run, derived not hand-listed | `0` |
| clj-kondo | `clj-kondo --parallel --fail-level error --lint implementation` | **INFORMATIONAL ONLY** — local binary is `v2025.10.23`, CI pins `2026.04.15`, and per the gap map a pass from a differently-versioned binary proves nothing. 10 errors reported, **all pre-existing in `implementation/ui/test/` and `implementation/epoch/test/`**, none in any file this diff touches. The `re-frame.hicasso/direct-view-call` hazard was **not** hit | `3` |

**Skipped, with reasons:**

- **Docs gates** — the spine classified the docs surface unchanged, and this diff
  touches no `docs/`, `spec/` or `migration/` file. `mkdocs build --strict` has
  nothing to decide here.
- **JVM artefact suites** — the spine classified the `implementation_jvm` surface
  unchanged; this diff is CLJS-only (`.cljs` in `implementation/hicasso/`).
- **Browser lanes, prod-elision / bundle-isolation / perf gates, adapter smokes,
  Xray feature matrix, mcp-conformance, tool JVM suites** — CI-only per
  `TESTING.md`; no local lane exists.
- **Splint, ESLint, api-manifest drift** — no local lane in the spine; this diff
  adds no public `re-frame.core` facade export and touches no JS.

The full derived list of required checks not decided locally is
`python scripts/check_fast_pr_gap.py --list` (94), catalogued in `TESTING.md`
§*Required checks the fast-PR spine does not run*.

## Declined

- **A second validator in the kit.** The fence was explicit and it is also the
  right call: the kit runs the runtime's guards, it does not re-implement them.
  There is no new validation anywhere in this diff — only a relocation of two
  existing guards into the answer both readers already dispatch on.
- **Editing `spec/004B`.** See clause 3 above. Scoping the kit's claim is honest,
  smaller, and keeps this PR out of the hot zone entirely.
- **Renaming `:where` to `front.codec/vector-kind`.** It would have been
  marginally more literal and would have required editing `spec/009`, which
  another worker holds — for no gain, since both sides now read the same value.
