### PR TITLE
docs(hicasso): correct two contradictory guide openings (rf2-hic-092)

### DIFF
--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -51,8 +51,9 @@ AI pairs can read an intent off the tree without running the app.
 **Reads live where you use them.** You do not thread subscription values down
 from a parent "so the helper can see the filter." An ordinary `defn` helper
 calls [`h/sub`](glossary.md#hsub); the enclosing [boundary](glossary.md#boundary)
-owns the read. Re-render granularity stays visible in the source: a vector is
-a boundary; a call is inline.
+owns the read. Re-render granularity stays visible in the source: an
+[`h/defview`](glossary.md#defview) in head position mints a boundary, and a
+plain `defn` helper call inlines into the boundary already rendering.
 
 **Controlled fields are a law, not a folk recipe.** Caret jumps, dropped
 keystrokes, and IME mishaps are the same bugs every React app rediscovers.
@@ -86,13 +87,9 @@ Stay on **Reagent** if the migration cost is the dominant fact and the app
 already works — Hicasso can wait. Choose **UIx** when React-first authoring
 (hooks everywhere, a design system at the centre) is the product shape, not
 an island. [Hicasso](glossary.md#hicasso) is for data-first views on the
-re-frame2 pipeline: markup as data, reads at the point of use, intents you
-can assert. It meets foreign React at [`h/defhost`](09-interop.md); it does
-not try to be the best pure-React CLJS library.
-
-## Next
-
-[Install Hicasso](installation.md), mount a first root, and click a button.
-Then [Views and reads](02-views-and-reads.md) and
-[Events as data](03-events-as-data.md) deepen the three habits the first
-screen already uses.
+re-frame2 pipeline: markup as data,
+[reads at the point of use](02-views-and-reads.md),
+[intents you can assert](03-events-as-data.md). It meets foreign React at
+[`h/defhost`](09-interop.md); it does not try to be the best pure-React CLJS
+library. If that is your product, [installing it](installation.md) is one
+dependency and one DOM node.

--- a/docs/design/hicasso/draft-guide/17-ssr-and-hydration.md
+++ b/docs/design/hicasso/draft-guide/17-ssr-and-hydration.md
@@ -5,8 +5,10 @@ over in the browser. You do not want to write the UI twice, and you do not
 want a second HTML emitter that drifts from what the client renders.
 [Hicasso](glossary.md#hicasso) renders the same views on the server that you
 mount in the browser. Each host and native component either renders
-deterministic HTML or declares Client-only with a fallback — no silent empty
-hole. The browser adopts the server's DOM; it does not repaint over it.
+deterministic HTML or is Client-only; a Client-only surface leaves its
+declared fallback in the server bytes, or — the bare default — nothing at
+all, until the browser takes over. The browser adopts the server's DOM; it
+does not repaint over it.
 
 > **One renderer runs in two places, and React's own adoption judges the
 > result.**
@@ -19,14 +21,19 @@ parallel string emitter and no JVM twin of the view layer. With one
 renderer, hydration parity holds by construction. Parity that is only a
 claim admits a whole class of bug.
 
-One renderer serves every surface. Two policies govern each surface:
+One renderer serves every surface. Two policies govern each surface, and
+between them they produce three outcomes in the server bytes — the rendered
+markup, a fallback, or nothing:
 
 - **Render** — the surface produces deterministic React server bytes from an
   immutable request snapshot. Hydration adopts those bytes.
-- **Client-only** — the surface refuses server use at its declaration and
-  names its recovery: a deterministic fallback in the server bytes, then the
-  live component in the browser after adoption completes. A silent `nil`
-  return is not a policy.
+- **Client-only** — the surface refuses server use at its declaration. What
+  stands in its place is a deterministic fallback, if the declaration carries
+  one, and otherwise nothing: the fallback is optional, and bare Client-only
+  is the default. Either way the live component arrives in the browser after
+  adoption completes. An empty region is conservative rather than broken —
+  but it is genuinely empty, so a surface whose absence would show wants a
+  fallback declared.
 
 | Surface | Policy |
 |---|---|


### PR DESCRIPTION
Merged-PR audit #7788 reopened rf2-hic-092 on two top-level contradictions the
authoring pass introduced. Both are in **openings**, which is why they matter more
than their size: a wrong sentence in an opening sets the model the reader carries
through the rest of the topic. Both still reproduced against current `origin/main`.
No runtime change and no new checker, per the audit.

### 1. `01-getting-started.md` — "a vector is a boundary"

That is false for native tags, fragments, `defhost` heads and raw escapes, all of
which sit in vector position without minting a boundary. `02-views-and-reads.md`
("Native tags, fragments, and `h/defhost` heads also sit in vector position. None
of them is a boundary.") and `glossary.md#boundary` both say so, so the guide
contradicted itself within two pages.

Before:

> Re-render granularity stays visible in the source: a vector is a boundary; a call is inline.

After:

> Re-render granularity stays visible in the source: an `h/defview` in head position mints a boundary, and a plain `defn` helper call inlines into the boundary already rendering.

### 2. `17-ssr-and-hydration.md` — every Client-only host has a fallback

The executable contract in `implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs`
makes bare `:client-only` the **default** (`(get opts :ssr :client-only)`, and
"`:client-only` renders NOTHING where the host sits until the client has adopted
the markup"). A fallback is optional. This chapter's own host section already said
"renders its declared fallback, or nothing", so it contradicted its opening.

Two sentences carried the false claim; both are repaired.

Before:

> Each host and native component either renders deterministic HTML or declares Client-only with a fallback — no silent empty hole.

> - **Client-only** — the surface refuses server use at its declaration and names its recovery: a deterministic fallback in the server bytes, then the live component in the browser after adoption completes. A silent `nil` return is not a policy.

After:

> Each host and native component either renders deterministic HTML or is Client-only; a Client-only surface leaves its declared fallback in the server bytes, or — the bare default — nothing at all, until the browser takes over.

> - **Client-only** — the surface refuses server use at its declaration. What stands in its place is a deterministic fallback, if the declaration carries one, and otherwise nothing: the fallback is optional, and bare Client-only is the default. Either way the live component arrives in the browser after adoption completes. An empty region is conservative rather than broken — but it is genuinely empty, so a surface whose absence would show wants a fallback declared.

The list lead-in now names the three outcomes ("Two policies govern each surface,
and between them they produce three outcomes in the server bytes — the rendered
markup, a fallback, or nothing") while keeping the chapter's two-policy framing,
which matches both the troubleshooting row and `09-interop.md`.

### 3. The `## Next` footer in chapter 01 (audit note, third item)

`docs/AUTHORING.md` non-negotiable 5 forbids "What's next" footers and lists of
later chapters. The footer is removed and its three links **folded inline where
they are relevant** rather than dropped: `02-views-and-reads.md` and
`03-events-as-data.md` now sit on the phrases "reads at the point of use" and
"intents you can assert" in the closing paragraph — which already enumerated
exactly those habits — and `installation.md` on a closing clause. No link was
lost; no heading other than `## Next` changed.

## Quality gates

`mkdocs build --strict` is **not** nominated: `mkdocs.yml`'s `exclude_docs` keeps
`design/hicasso/` off the site, so it would exit 0 having verified nothing.

| Gate | Command | Exit |
|---|---|---|
| Markdown link + anchor slugs | `python scripts/check_doc_slugs.py` | **0** ("scanning 718 markdown files... no broken links.") |

Run alone, foreground, to completion; output redirected to a worktree-local log
(gitignored) with the exit code captured in the same shell, never through a pipe.

**Coverage proved, not assumed.** The checker is silent on success, so a negative
control confirmed it actually reaches this tree: appending a bogus anchor link to
`01-getting-started.md` made it exit **1** with `BROKEN ANCHOR:
docs\design\hicasso\draft-guide\01-getting-started.md:97 -> glossary.md#definitely-not-a-real-anchor`.
The file was restored with `git checkout --` (no stash).

**Required-check gap** derived with `python scripts/check_fast_pr_gap.py --list`,
not hand-listed: 95 required checks are not decided locally. This diff is two
Markdown files under `docs/design/**`, so it reaches no CLJS, lint or MkDocs
surface; `Docs required`'s detect job classifies the docs surface in CI.

### Verified by hand (nothing validates these)

Per `CLAUDE.md`, nothing checks tables or rendering in `docs/design/**`.

- **Table column counts** — every row of both tables in `17-ssr-and-hydration.md`
  counted: the Surface/Policy table is uniformly **2** columns (header, separator,
  10 body rows) and the Troubleshooting table uniformly **3** (header, separator,
  10 body rows). `01-getting-started.md` contains no tables. My edits changed no
  table row — only the paragraph above the first table.
- **Heading anchors** — removing `## Next` orphans nothing: `git grep` for
  `01-getting-started.md#` and `17-ssr-and-hydration.md#` across the repo finds
  exactly one inbound anchor, `studio/108-...md` ->
  `17-ssr-and-hydration.md#render-and-client-only-at-the-host`, and that heading
  is untouched and still present. New links point at `glossary.md#defview`,
  `02-views-and-reads.md`, `03-events-as-data.md` and `installation.md`;
  `<a id="defview"></a>` confirmed present in the glossary.
- **Naming** — the guide's `{:server :client-only :fallback ...}` spelling was left
  as-is. It differs from codec's `:ssr` key, but that is the naming ledger's
  end-state default and belongs to the kit-parity owner, not this repair.

### Off-fence finding, reported not fixed

`glossary.md#server-policy` carries the **same** contradiction as item 2 — it
defines Client-only as "source-located refusal + deterministic fallback" and says
"Silent `nil` is not a policy" — and it is the entry both chapters link to, so a
reader following the link lands back on the claim just corrected. It is outside
this task's two-file fence, so it is left untouched and flagged here; the same
wording also sits in `product/dispositions.md:134` and
`product/lanes/react-compatibility-notes.md:14`. Worth a one-line follow-up bead.
