### PR TITLE
fix(hicasso): make defview's emitted body fn anonymous (rf2-jan2)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso.cljc
@@ -102,6 +102,33 @@
   makes the head's identity stable by construction and leaves the codec's
   stable-component-head cache with nothing to do.
 
+  ## The fn this expands to is ANONYMOUS, and that is the contract
+  (rf2-jan2)
+
+  The expansion binds NO name inside your body, so every symbol a body
+  resolves is one you wrote. The ordinary extract-a-helper spelling is
+  therefore safe at the ordinary spelling:
+
+      (defn todo-row-body [props] …)
+      (h/defview todo-row [props] (todo-row-body props))
+
+  It was not always. The macro used to name the fn it emits
+  `<sym>-body`, and a named `fn` binds its own name for its own body — so
+  the pair above expanded to `(fn todo-row-body [p] (todo-row-body p))`
+  and recursed until the stack overflowed, under React exactly as under
+  the test kit, reporting `Maximum call stack size exceeded` and naming
+  neither the view nor the macro that shadowed the helper.
+
+  Anonymity rather than a gensym or a reserved prefix, because those make
+  the collision improbable where this makes it unrepresentable: a fn with
+  no name has nothing to shadow with. Nothing was spent for it. The
+  identifiers this macro decides are the `\"<ns>/<sym>\"` view name and
+  the coordinate below, both computed here and both passed as VALUES —
+  `mint-view!` stamps the view name as `displayName` on the body and on
+  the component, and Spec 009 keys its render measure `rf:render:<view
+  name>` off the same string. The emitted fn's own symbol fed none of
+  them; it reached nothing but a stack frame.
+
   ## The source coordinate (rf2-hic-007)
 
   The expansion opens a declaration extent around the mint, carrying the
@@ -124,7 +151,6 @@
      (let [doc       (when (string? (first more)) (first more))
            [argv & body] (if doc (rest more) more)
            view-name (str (ns-name *ns*) "/" sym)
-           body-name (symbol (str sym "-body"))
            coord     (source-coords/coords-form (meta &form) *file* (ns-name *ns*))]
        `(def ~(if doc (vary-meta sym assoc :doc doc) sym)
           (do
@@ -133,7 +159,11 @@
             (try
               (re-frame.hicasso.impl.collector/mint-view!
                 ~view-name
-                (fn ~body-name ~argv ~@body))
+                ;; ANONYMOUS — see the docstring's rf2-jan2 section. A
+                ;; named `fn` binds its own name for its own body, so any
+                ;; name derived from `sym` shadows the author's helper of
+                ;; that name.
+                (fn ~argv ~@body))
               (finally
                 (when re-frame.interop/debug-enabled?
                   (re-frame.hicasso.impl.error/declared!)))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/hmr_remount_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/hmr_remount_cljs_test.cljs
@@ -25,8 +25,9 @@
   top-level forms run again. For a Hicasso source file that is exactly
   two things — the `reg-sub` / `reg-event` forms re-register, and the
   `def` that [[re-frame.hicasso/defview]] expands to re-runs. The macro
-  expands to `(def sym (mint-view! \"<ns>/<sym>\" (fn <sym>-body …)))`, so
-  re-evaluating the form is re-running that one call and rebinding the
+  expands to `(def sym (mint-view! \"<ns>/<sym>\" (fn …)))` — the emitted
+  fn is anonymous, so it can shadow no helper the body calls (rf2-jan2) —
+  so re-evaluating the form is re-running that one call and rebinding the
   var. [[load-namespace!]] below is those two things and nothing else,
   and [[the-defview-macro-mints-what-a-reload-re-mints]] holds the model
   to the macro so the two cannot drift apart silently.

--- a/implementation/hicasso/test/re_frame/hicasso/public_door_macros_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/public_door_macros_cljs_test.cljs
@@ -25,11 +25,13 @@
   symbol and def-layout detail would make safe refactoring noisy for no
   consumer confidence.
 
-  Three witnesses cover the three macros, and only two of them are here.
-  `defview` is already witnessed by
-  [[re-frame.hicasso.smoke-cljs-test]] — a boundary minted through the
-  door, asserted `boundary-head?`, rendering a live subscription read —
-  and that suite is the third witness, unchanged.
+  Three witnesses cover the three macros. `defview`'s round-trip — a
+  boundary minted through the door, asserted `boundary-head?`, rendering
+  a live subscription read — is [[re-frame.hicasso.smoke-cljs-test]]'s
+  and stays there. Witness C below is a different claim about the same
+  macro, and it is here because it is about the EXPANSION rather than
+  about the runtime: what `defview` names inside the fn it emits
+  (rf2-jan2).
 
   ## Why these assertions and not others
 
@@ -41,21 +43,29 @@
     mints — `callback?` and `host-head?`, one own-property read each;
   - that the author's own value survives the expansion unwrapped;
   - that an argument the author wrote reaches the declaration, which is
-    `defhost`'s `opts`.
+    `defhost`'s `opts`;
+  - that the fn `defview` emits binds NO name a body could reach, so the
+    author's lexical scope is the one the body runs in.
 
   Reaching to `impl.intent` and `impl.codec` for those two predicates is
   the same reach the package smoke makes for `boundary-head?`: the marker
   is the observable, and there is no other way to ask.
 
-  ## The NODE lane, and no runtime state
+  ## The NODE lane
 
-  This is the node lane. Nothing here subscribes, dispatches or mounts, so
-  nothing here needs a DOM, a registered frame or a runtime reset — the
-  server renderer runs the crossing for real and the file leaves no state
-  behind it. `defhost`'s DOM-driven counterpart is the isolation suite's
-  containment row; this witness exists because that usage is incidental to
-  a different contract and could refactor away without anyone noticing the
-  door had gone unchecked.
+  This is the node lane, and the server renderer runs both crossings for
+  real. Witnesses A and B subscribe, dispatch and mount nothing, so they
+  need no DOM, no registered frame and no runtime reset. Witness C runs a
+  BODY, and a body binds the ambient frame whether or not it reads
+  anything — so it seats a frame of its own and scopes the render with
+  `impl.mount/provider`, exactly as the package smoke does. A
+  `renderToString` never commits, so it still leaves no runtime state
+  behind it.
+
+  `defhost`'s DOM-driven counterpart is the isolation suite's containment
+  row; witness B exists because that usage is incidental to a different
+  contract and could refactor away without anyone noticing the door had
+  gone unchecked.
 
   ## Naming
 
@@ -63,9 +73,11 @@
   `defhost`. The naming review recommends `h/event` for the callback form;
   when that lands, the sweep renames these witnesses with everything else."
   (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.core :as rf]
             [re-frame.hicasso :as h]
             [re-frame.hicasso.impl.codec :as codec]
             [re-frame.hicasso.impl.intent :as intent]
+            [re-frame.hicasso.impl.mount :as mount]
             ["react" :as react]
             ["react-dom/server" :as react-dom-server]))
 
@@ -127,3 +139,56 @@
             with the crossing rendering the foreign component's own markup"
     (let [markup (html [:div.crossing [badge {:label "hicasso"}]])]
       (is (re-find #"<b[^>]*class=\"badge\"[^>]*>hicasso</b>" markup)))))
+
+;; ---------------------------------------------------------------------------
+;; Witness C — `h/defview`, and the name its emitted fn does NOT bind
+;; ---------------------------------------------------------------------------
+;;
+;; rf2-jan2. The macro used to name the fn it emits `<sym>-body`, and a
+;; NAMED `fn` binds its own name inside its body — so the ordinary
+;; extract-a-helper spelling below expanded to
+;; `(fn ticket-body [p] (ticket-body p))` and recursed until the stack
+;; overflowed. Under React the symptom was `Maximum call stack size
+;; exceeded` with no id, no view name and nothing pointing at the macro.
+;;
+;; The helper is named after the view DELIBERATELY: that is the collision,
+;; and a helper named any other way would leave this row green whatever the
+;; expansion binds.
+
+(defn- ticket-body
+  "The helper a body extracts, spelled the way an author spells it — the
+  view's own name with `-body` on the end."
+  [{:keys [id]}]
+  [:li.ticket (str "ticket " id)])
+
+(h/defview ticket [props] (ticket-body props))
+
+(defn- rendered
+  "One boundary, server-rendered under a frame — React running the body
+  for real, which is the level this collision bit at as hard as it bit at
+  the kit's."
+  [hiccup]
+  ;; `renderToString` is not inside React's act queue, and the flag is set
+  ;; outright for the reason the package smoke gives: the helper that
+  ;; carries it lives in the bench tree, which this package may not import.
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  (rf/make-frame {:id frame-id})
+  (react-dom-server/renderToString
+    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+
+(deftest the-fn-defview-emits-binds-no-name-a-body-could-reach
+  (testing "the door hands back a minted boundary, so what renders below is
+            the expansion's own product"
+    (is (true? (codec/boundary-head? ticket))))
+
+  (testing "a body that calls a helper named after its view resolves the
+            AUTHOR's helper: React runs the body once and the markup is the
+            helper's, where the emitted fn's self-binding recursed forever"
+    (is (re-find #"<li[^>]*class=\"ticket\"[^>]*>ticket 7</li>"
+                 (rendered [ticket {:id 7}]))))
+
+  (testing "and the identifier the expansion DOES decide is unchanged — the
+            `\"<ns>/<sym>\"` name React DevTools shows and Spec 009 keys
+            `rf:render:<name>` on"
+    (is (= "re-frame.hicasso.public-door-macros-cljs-test/ticket"
+           (unchecked-get ticket "displayName")))))

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_cljs_test.cljs
@@ -114,16 +114,21 @@
 
 (h/defhost badge badge-component {:ssr :render})
 
+;; The `<name>-body` pair, which is the spelling this suite's own examples
+;; teach — and which used to be unrenderable (rf2-jan2). `h/defview` named
+;; its emitted body fn `<sym>-body`, and a named `fn` binds its own name
+;; inside its body, so this declaration expanded to
+;; `(fn greeting-body [p] (greeting-body p))` and recursed until the stack
+;; overflowed. The expansion names nothing now, so the only `greeting-body`
+;; in scope is the author's; `a-body-may-call-a-helper-named-after-its-view`
+;; below is what says so.
 (defn- greeting-body [{:keys [who]}] [:p (str "hi " who)])
 (h/defview greeting [props] (greeting-body props))
 
-;; The pair the minted-head render rows below run. The helper is NOT named
-;; `farewell-body`, and that is deliberate: `h/defview` names its emitted
-;; body fn `<sym>-body`, and a named `fn` binds its own name in its body —
-;; so `(h/defview farewell [p] (farewell-body p))` expands to
-;; `(fn farewell-body [p] (farewell-body p))`, which recurses forever. That
-;; is a defect in the public door macro rather than in this suite, and it is
-;; filed as its own finding; `greeting` above carries it and is never run.
+;; The pair the minted-head render rows below run, spelled the OTHER way —
+;; a helper whose name is not derived from the view's — so those rows keep
+;; measuring the retention contract rather than doubling as the rf2-jan2
+;; witness.
 (defn- farewell-text [{:keys [who]}] [:p (str "bye " who)])
 (h/defview farewell [props] (farewell-text props))
 
@@ -422,6 +427,29 @@
              (refusal o [:view])))
       (is (re-find #"L3 owns React lifecycle" (:message o))
           "the message points up the ladder rather than restating the tier"))))
+
+(deftest a-body-may-call-a-helper-named-after-its-view
+  ;; rf2-jan2, at L2. `greeting`'s body calls `greeting-body` — the extract-a-
+  ;; helper spelling this file's own examples use — and until the macro stopped
+  ;; naming its emitted fn, that call resolved to the emitted fn itself and
+  ;; recursed until the stack overflowed. Rendered through the kit, the failure
+  ;; was a `Maximum call stack size exceeded` naming no view, no id and no
+  ;; macro.
+  (testing "the helper the body calls is the author's, so a view whose helper
+            is named after it renders rather than recursing"
+    (let [tree (ht/render [greeting {:who "ada"}])]
+      (is (= :p (:tag tree)))
+      (is (= "hi ada" (ht/text tree)))))
+
+  (testing "and it is the SAME tree the helper answers when rendered directly,
+            which rules out a body that recursed once and happened to stop"
+    (is (= (ht/render [greeting-body {:who "ada"}])
+           (ht/render [greeting {:who "ada"}]))))
+
+  (testing "the control: `farewell`, whose helper is NOT named after it, was
+            always renderable — so the rows above measure the collision and
+            not the kit's minted-head path in general"
+    (is (= "bye ada" (ht/text (ht/render [farewell {:who "ada"}]))))))
 
 (deftest a-host-crossing-is-opaque-at-l2
   (testing "at the root"


### PR DESCRIPTION
Closes rf2-jan2.

## The defect

`h/defview` named the fn it emits `<sym>-body`, and a named `fn` binds its own name for its own body. So the ordinary extract-a-helper spelling — the one this package's own suites and guide use —

```clojure
(defn row-body [props] ...)
(h/defview row [p] (row-body p))
```

expanded to `(fn row-body [p] (row-body p))` and recursed until the stack overflowed. The programmer's helper was shadowed by the macro's own emitted name, and the report was `Maximum call stack size exceeded` naming neither the view, nor a refusal id, nor the macro.

It was latent while a minted head always refused before its body could run; PR #7801 (rf2-kjf5) made dev builds retain the body, which exposed it.

## Reproduced first, at both levels

Both witnesses were added before the macro changed, and both failed for the stated reason:

```
Testing re-frame.hicasso.public-door-macros-cljs-test

ERROR in (the-fn-defview-emits-binds-no-name-a-body-could-reach) (public_door_macros_cljs_test.cljs:187:9)
expected: (re-find #"<li[^>]*class=\"ticket\"[^>]*>ticket 7</li>" (rendered [ticket {:id 7}]))
  actual: #object[RangeError RangeError: Maximum call stack size exceeded]

Testing re-frame.hicasso.test-kit-cljs-test

ERROR in (a-body-may-call-a-helper-named-after-its-view) (RangeError:NaN:NaN)
  actual: #object[RangeError RangeError: Maximum call stack size exceeded]

Ran 180 tests containing 859 assertions.
0 failures, 2 errors.
```

The React-level row is a real `react-dom/server` render of a boundary under a frame — React running the body — so this is pinned under React and at L2, not at L2 alone.

## The answer chosen: the emitted fn is ANONYMOUS

Not a gensym and not a reserved prefix. Those make the collision improbable; anonymity makes it unrepresentable — a fn with no name has nothing to shadow with, so there is no reserved spelling to document and nothing for a future edit to reintroduce by accident.

The expansion, on the JVM, after:

```clojure
(def row
 (do
  (clojure.core/when re-frame.interop/debug-enabled?
   (re-frame.hicasso.impl.error/declaring! "user/row" {:ns 'user, :line 1, :column 95}))
  (try
   (re-frame.hicasso.impl.collector/mint-view! "user/row"
    (clojure.core/fn [p] (row-body p)))
   (finally
    (clojure.core/when re-frame.interop/debug-enabled?
     (re-frame.hicasso.impl.error/declared!))))))
```

## `displayName` and the render entry id cost nothing

Both are keyed on `view-name` — the `"<ns>/<sym>"` string the macro computes at its own line and passes to `mint-view!` as a VALUE — never on the emitted symbol:

- `collector/mint-view!` stamps `view-name` as `displayName` on the body fn (dev) and on the component (unconditionally);
- Spec 009's render measure is `rf:render:<view-name>`, closed over at the component fn;
- `codec/set-lowering-owner!` and the test kit's `view-name` both read that `displayName`.

Nothing in `implementation/hicasso/` reads a body fn's JS `.name`. Witness C asserts the `displayName` explicitly so the two cannot drift.

## Also in this PR

- `test_kit_cljs_test`: the reproducer the rf2-kjf5 worker deliberately left in the tree (`greeting`) is now *rendered* rather than merely declared, so it pins the fixed behaviour instead of carrying the defect. `farewell`, whose helper is not named after it, is the control. The comment explaining why `farewell-text` is not called `farewell-body` is replaced by one explaining why it no longer has to be.
- `public_door_macros_cljs_test`: witness C joins witnesses A (`hfn`) and B (`defhost`) — this suite exists to pin what the macro EXPANSION decides, which is exactly what this is.
- `hmr_remount_cljs_test`: its namespace docstring documented the expansion as `(fn <sym>-body …)`; corrected.

## Declined

The prototype donor `implementation/freehand/test/re_frame/bench/hicasso/arm1/lang.clj` carries the same expression. Left alone: its `frozen-sources.edn` row is retired, the package is the artefact from the module split forward, and no bench view names a helper after its view (they could not — they would already overflow). Editing the measured donor to fix a package defect churns the one tree whose value is being unchanged.

No new `:rf.error/*` id, so no `spec/009-Instrumentation.md` co-edit.
