### PR TITLE
fix(gate): a bare > ends a quoted paragraph, and lazy continuation resumes (rf2-skpf)

### DIFF
--- a/scripts/_test_fixtures/check_doc_slugs/README.md
+++ b/scripts/_test_fixtures/check_doc_slugs/README.md
@@ -36,8 +36,8 @@ Fixtures:
 | `wrapped_link_broken_anchor`       | 2               | A link whose TEXT wraps across a newline is still validated (rf2-vpc4c)            |
 | `wrapped_link_ok`                  | 0               | Correct wrapped links — plain, multi-line, same-file, blockquoted — are not flagged (rf2-vpc4c) |
 | `wrapped_link_block_bound`         | 0               | False-positive control: the join stops at a block boundary, so `[text` … blank … `](x.md)` is not a link (rf2-vpc4c) |
-| `multiline_code_span_not_a_link`   | 1               | A code span crossing a line ending is masked whole, so the link-shaped text inside it yields nothing; the 1 is a real broken wrapped link (rf2-8wcbe) |
-| `non_blank_block_bound`            | 1               | The join stops at every NON-blank boundary — heading (before and after), thematic break, list item, table row, blockquote entry; the 1 is a real wrapped link inside one list item (rf2-8wcbe) |
+| `multiline_code_span_not_a_link`   | 1               | A code span crossing a line ending is masked whole, so the link-shaped text inside it yields nothing; the 1 is a real broken wrapped link (rf2-skpf) |
+| `non_blank_block_bound`            | 1               | The join stops at every NON-blank boundary — heading (before and after), thematic break, list item, table row, blockquote entry; the 1 is a real wrapped link inside one list item (rf2-skpf) |
 | `indented_fence_link_ignored`      | 0               | A fence carrying its container's indentation — list item, admonition — is still a fence, so the sample inside it carries no links to resolve (rf2-mmyc) |
 | `indented_fence_negative_control`  | 1               | Widening the fence matcher must not quieten the gate: the 1 is a real broken link in prose after an indented fence, and an unclosed fence ends with its container (rf2-mmyc) |
 | `fenced_doc_link_in_scope`         | 1               | A doc link INSIDE a fence, in a `FENCED_DOC_LINK_TREES` tree — it resolves, so only the assertion can see it (rf2-mmyc) |

--- a/scripts/_test_fixtures/check_doc_slugs/multiline_code_span_not_a_link/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/multiline_code_span_not_a_link/docs/index.md
@@ -1,4 +1,4 @@
-# Index — A Multiline Code Span Is Not A Link (rf2-8wcbe)
+# Index — A Multiline Code Span Is Not A Link (rf2-skpf)
 
 A CommonMark code span may contain a line ending, so the backticked text
 below is one `<code>` element and holds no link at all — python-markdown

--- a/scripts/_test_fixtures/check_doc_slugs/non_blank_block_bound/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/non_blank_block_bound/docs/index.md
@@ -1,4 +1,4 @@
-# Index — Non-Blank Block Bounds The Join (rf2-8wcbe)
+# Index — Non-Blank Block Bounds The Join (rf2-skpf)
 
 A blank line is a block boundary, but it is not the only one. Every pair
 below sits either side of a boundary that is NOT a blank line, so no

--- a/scripts/_test_fixtures/check_readme_links/block_bound_link_ignored/README.md
+++ b/scripts/_test_fixtures/check_readme_links/block_bound_link_ignored/README.md
@@ -2,7 +2,7 @@
 
 This gate imports `_extract_links` from `check_doc_slugs.py` rather than
 carrying its own copy, so the block bound and the multiline code-span mask
-must reach it too (rf2-8wcbe). Both samples below are link-SHAPED text that
+must reach it too (rf2-skpf). Both samples below are link-SHAPED text that
 no renderer turns into a link.
 
 A code span may contain a line ending, so this is one `<code>` element:

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -1156,36 +1156,60 @@ def _inline_blocks(
        thematic break or a table row, so the following line opens a fresh unit
        and a stray `[` in a heading cannot reach into the paragraph under it.
        A list item is a container that DOES continue, so it only opens a unit.
-    4. Entering a blockquote (or nesting one level deeper).  A quote interrupts
-       the paragraph above it.  The converse is not a boundary: an unprefixed
-       line after a quoted one is CommonMark lazy continuation of the SAME
-       quoted paragraph, and a `>`-prefixed continuation line inside one quote
-       keeps the depth unchanged — which is why the corpus's blockquoted
+    4. Nesting DEEPER into a blockquote than the unit was opened at.  A quote
+       interrupts the paragraph above it.  The converse is not a boundary: an
+       unprefixed line after a quoted one is CommonMark lazy continuation of the
+       SAME quoted paragraph, and a `>`-prefixed continuation line inside one
+       quote keeps the depth unchanged — which is why the corpus's blockquoted
        wrapped links still join.
+
+       Deeper than THE UNIT, not deeper than the line before it (rf2-skpf).
+       Lazy continuation makes the two differ: in
+
+           > Per the note, see [§Compiled
+           views and the
+           > rest](API.md#compiled-views).
+
+       the middle line is lazy continuation, so the third line RESUMES a quote
+       that never closed — `BlockQuoteProcessor` cleans all three lines into one
+       paragraph and emits the link.  Comparing against the previous line's
+       depth read the resume as an entry, split the unit, and dropped a real
+       link on the floor unchecked; comparing against the depth the unit was
+       opened at is what makes this docstring's rule and the code agree.
+
+    A line whose content is nothing but blockquote markers — `>`, `>   `, `> >`
+    — is a BLANK LINE inside the quote, not a continuation line (rf2-skpf).
+    `BlockQuoteProcessor.clean` maps it to the empty string, so it ends the
+    quoted paragraph exactly as a blank line ends an unquoted one.  Testing
+    blankness on the marker-stripped body rather than the raw line is the whole
+    of that: without it the join reached across a paragraph break and a code
+    span pairing two stray backtick runs either side of it swallowed a link the
+    renderer really does emit.  569 such lines are in the corpus.
 
     The block tests run against the line's content with any blockquote markers
     removed, so `> ## Heading` bounds a unit just as `## Heading` does.
     """
     block: list[tuple[int, str]] = []
-    prev_depth = 0
+    block_depth = 0
     ended = False
     for line_no, content in pairs:
-        if not content.strip():
+        depth, body = _quote_depth_and_body(content)
+        if not body.strip():
             if block:
                 yield block
                 block = []
-            prev_depth = 0
+            block_depth = 0
             ended = False
             continue
-        depth, body = _quote_depth_and_body(content)
         leaf = bool(_LEAF_LINE_BLOCK_RE.match(body))
         if block and (
-            ended or leaf or depth > prev_depth or _LIST_ITEM_START_RE.match(body)
+            ended or leaf or depth > block_depth or _LIST_ITEM_START_RE.match(body)
         ):
             yield block
             block = []
+        if not block:
+            block_depth = depth
         block.append((line_no, content))
-        prev_depth = depth
         ended = leaf
     if block:
         yield block
@@ -2528,6 +2552,88 @@ def _run_self_tests(verbose: bool = False) -> int:
           (2, "### a real heading to python-markdown"),
           (3, "[in](in-target.md)` closing here.")],
          [(3, "in-target.md")]),
+        # ------------------------------------------------------------------
+        # rf2-skpf — the two blockquote boundaries `_inline_blocks` did not
+        # have.  Renderer-derived, via mkdocs.config.load_config('mkdocs.yml')
+        # into a markdown.Markdown against python-markdown 3.10 + pymdownx
+        # 10.21.3, one case per verdict the renderer actually returned.
+        #
+        # FIRST: a line of nothing but blockquote markers.
+        # `BlockQuoteProcessor.clean` maps it to the empty string, so it ends
+        # the quoted paragraph — 569 of them are in this corpus.  Reading it as
+        # a continuation line let the join reach across a paragraph break.
+        #
+        # FALSE GREEN, the expensive direction: the two backtick runs are in
+        # DIFFERENT paragraphs, so neither opens a span, and the renderer emits
+        # `<a href="in-target.md">`.  Joining across the break paired them and
+        # masked a real link out of existence — unchecked, silently.
+        ("a bare > ends the quoted paragraph, so no span swallows the link",
+         [(1, "> Prose with `a code span"),
+          (2, ">"),
+          (3, "> [in](in-target.md)` closing here.")],
+         [(3, "in-target.md")]),
+        ("...spelled with trailing spaces, which clean() also empties",
+         [(1, "> Prose with `a code span"),
+          (2, ">   "),
+          (3, "> [in](in-target.md)` closing here.")],
+         [(3, "in-target.md")]),
+        # FALSE POSITIVE, the same boundary from the other side.
+        ("a bare > ends the quoted paragraph, so the wrap is not one link",
+         [(1, "> A stray [opening"),
+          (2, ">"),
+          (3, "> ](missing.md)")],
+         []),
+        # CONTROLS.  Without these both cases above are satisfied by a rule
+        # that bounds at EVERY quoted line, which would undo rf2-vpc4c's
+        # blockquoted wrapped links.
+        ("a quoted continuation line does not end the span",
+         [(1, "> Prose with `a code span"),
+          (2, "> continues"),
+          (3, "> [in](in-target.md)` closing here.")],
+         []),
+        ("a quoted continuation line does not end the paragraph",
+         [(1, "> A stray [opening"),
+          (2, "> and more"),
+          (3, "> ](missing.md)")],
+         [(3, "missing.md")]),
+        # SECOND: lazy continuation RESUMES a quote, it does not enter one.
+        # The unit's depth is the depth it OPENED at, not the previous line's —
+        # after an unmarked middle line the previous line's depth is 0, so a
+        # `>`-marked third line read as an entry and split a paragraph the
+        # renderer keeps whole.
+        #
+        # FALSE GREEN: `BlockQuoteProcessor` cleans all three lines into one
+        # paragraph and emits `<a href="API.md#compiled-views">`.  The split
+        # dropped it unchecked.
+        ("a re-marked line after lazy continuation is not a new quote",
+         [(1, "> Per the note, see [§Compiled"),
+          (2, "views and the"),
+          (3, "> rest](API.md#compiled-views).")],
+         [(3, "API.md#compiled-views")]),
+        # FALSE POSITIVE, same boundary: with a code span in play the three
+        # lines are one run, the span closes on line 3, and the renderer
+        # resolves nothing.  The split saw two unpaired runs and invented a
+        # link to check.
+        ("...and a span across that resume still masks",
+         [(1, "> Prose with `a code span"),
+          (2, "lazy continuation"),
+          (3, "> [in](in-target.md)` closing here.")],
+         []),
+        # CONTROLS for the depth rule — entering ("blockquote entry is not
+        # bridged" above) is one; these are the other three.
+        ("nesting deeper still bounds",
+         [(1, "> A paragraph holding a stray ["),
+          (2, ">> and a deeper quote](missing.md) interrupts it.")],
+         []),
+        ("nesting deeper after lazy continuation still bounds",
+         [(1, "> A paragraph holding a stray ["),
+          (2, "lazy continuation"),
+          (3, ">> deeper](missing.md)")],
+         []),
+        ("a shallower quoted line after a deeper one still joins",
+         [(1, ">> Per the note, see [§Compiled"),
+          (2, "> views](API.md#compiled-views).")],
+         [(2, "API.md#compiled-views")]),
     ]
     for label, lines, expected_links in extraction_cases:
         got_links = list(_iter_inline_links(lines))

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -154,8 +154,16 @@ ANCHOR_MECHANISM = "explicit <a id>"
 HEADING_MECHANISM = "heading"
 
 # Markdown inline link.  Captures destination only.  Reference-style links
-# ([text][ref]) are ignored — none in this corpus per spot-check, and a full
-# parser is out of scope for a CI guard.
+# ([text][ref]) are ignored — and the corpus DOES have them, which the
+# "none per spot-check" this comment used to claim did not (rf2-skpf).
+# Rendering all 718 in-scope files through mkdocs' own markdown.Markdown and
+# diffing the emitted hrefs against this extractor finds ten links the
+# renderer emits from `[ref]: dest` definitions and this gate never checks:
+# seven in tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md, one in
+# tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md, two in
+# tools/story-mcp/spec/002-Tool-Registry.md.  A live false negative, its own
+# defect, and NOT this surface — recorded here so the next reader of this
+# regex starts from the measurement rather than the spot-check.
 #
 # The link TEXT may contain newlines: markdown wraps a paragraph freely, so
 # `[§Compiled\nviews](Doc.md#anchor)` is one rendered link.  The negated

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -238,7 +238,16 @@ _MKDOCS_BLOCK_CONTENT_INDENT = 4
 #   never sees the language tag of a fence as a stray backtick run.
 _INLINE_CODE_RE = re.compile(r"(`+)(?:.+?)\1(?!`)")
 
-# The same span rule, applied over a JOINED scan unit (rf2-8wcbe).  Identical
+# THE ID ON THIS SURFACE.  Every rf2-skpf citation in this file, in
+# `check_readme_links.py` and in the fixtures under `scripts/_test_fixtures/`
+# read `rf2-8wcbe` until 2026-08-10.  That id was never durable — it exists in
+# neither the Dolt ledger nor any `issues.jsonl` — so PRs #7785, #7795 and #7803
+# and the rf2-1cpt / rf2-b2cr / rf2-feit ledger text all handed the residual to
+# a bead nobody could open.  rf2-skpf is the bead that owns it, and the
+# citations now say so.  A reader who meets `rf2-8wcbe` in those PR bodies is
+# looking at this surface.
+#
+# The same span rule, applied over a JOINED scan unit (rf2-skpf).  Identical
 # to `_INLINE_CODE_RE` but for `re.DOTALL`: CommonMark §6.1 explicitly permits
 # a code span to contain a line ending, so
 #
@@ -254,11 +263,12 @@ _INLINE_CODE_RE = re.compile(r"(`+)(?:.+?)\1(?!`)")
 # CommonMark does — an unpaired backtick is literal text.
 _INLINE_CODE_SPAN_RE = re.compile(r"(`+)(?:.+?)\1(?!`)", re.DOTALL)
 
-# Non-blank block boundaries (rf2-8wcbe).  A blank line is a block boundary in
-# every markdown flavour, but it is NOT the only one: these leaf blocks all
-# INTERRUPT an open paragraph, so the text either side of one is never a single
-# run of inline content and no inline construct — link, emphasis, code span —
-# can bridge them.  Recognising them is what stops the join from stitching
+# Non-blank block boundaries (rf2-skpf).  A blank line is a block boundary in
+# every markdown flavour, but it is NOT the only one: these leaf blocks
+# INTERRUPT an open paragraph (all but the two carrying a declared
+# disagreement below), so the text either side of one is never a single run of
+# inline content and no inline construct — link, emphasis, code span — can
+# bridge them.  Recognising them is what stops the join from stitching
 #
 #     A stray [opening
 #     # Separate heading
@@ -291,7 +301,8 @@ _INLINE_CODE_SPAN_RE = re.compile(r"(`+)(?:.+?)\1(?!`)", re.DOTALL)
 #     underline ENDS the paragraph above it (turning it into a heading), so it
 #     bounds the unit either way and the two readings need not be told apart.
 #   * Table row — a leading `|`.  A table's rows render as separate cells; no
-#     inline construct spans two of them.
+#     inline construct spans two of them.  Only once the table has STARTED,
+#     though — see the declared disagreement below.
 #
 # `_LIST_ITEM_START_RE` — a container that DOES continue, so it opens a unit but
 # does not close one:
@@ -300,10 +311,35 @@ _INLINE_CODE_SPAN_RE = re.compile(r"(`+)(?:.+?)\1(?!`)", re.DOTALL)
 #     next bullet — while a continuation line of an item carries no marker, so a
 #     link wrapping inside one item still joins.
 #
+# THE LIST-MARKER AND TABLE-ROW BOUNDS ARE A DECLARED DISAGREEMENT, not
+# agreement (rf2-skpf), and this is the edge of what a non-parser can do.
+# python-markdown starts a list or a table only at a BLOCK START —
+# `OListProcessor.test` / `UListProcessor.test` are `RE.match(block)` and
+# `TableProcessor.test` reads the block's first two rows — so a marker line
+# appearing PART-WAY THROUGH an open paragraph is ordinary prose to the
+# renderer and a boundary here.  Renderer-derived, one shape per verdict:
+#
+#     > Per the note, see [§Compiled
+#     > - views](API.md#compiled-views).
+#
+# renders `<a href="API.md#compiled-views">` and this gate reports nothing —
+# a false negative, and the same for a `|`-leading continuation line.
+#
+# It stays, because the alternative is worse and the fix is a parser.  Bounding
+# only at a block start would need list-and-table open/close state, and the
+# shape it would buy is a link whose TEXT wraps onto a line beginning `- `,
+# `* `, `+ `, `1. ` or `|` — prose does not do that.  The shape it would COST
+# is the corpus's most common structure of all: a real list, where the block
+# does start with the marker and each item is genuinely its own container.
+# Measured over the 718-file corpus, this bound moves nothing in either
+# direction (the ingredient — a marker line interrupting an open paragraph —
+# occurs 6,743 times; a link wrapping across one occurs 0 times).
+#
 # Blockquote entry is handled separately in `_inline_blocks` because it is
-# relative, not absolute: entering (or nesting deeper into) a quote interrupts
-# the paragraph above, while a following unprefixed line is CommonMark lazy
-# continuation of the quoted paragraph and must NOT bound the unit.
+# relative, not absolute: nesting DEEPER than the unit opened interrupts the
+# paragraph above, while a following unprefixed line is CommonMark lazy
+# continuation of the quoted paragraph — and so is a `>`-marked line after it,
+# which RESUMES the same quote rather than entering a new one (rf2-skpf).
 _LEAF_LINE_BLOCK_RE = re.compile(
     r"""^(?:
           \#{1,6}(?:[ \t]|$)                  # ATX heading — COLUMN ZERO ONLY
@@ -655,7 +691,7 @@ def _strip_fences(lines: list[str]) -> list[tuple[int, str]]:
       triples through mkdocs.config.load_config('mkdocs.yml') into a
       markdown.Markdown, that costs 180 shapes where the renderer emits a link
       this gate never reports — the opener past the allowance every time, and the
-      downstream inline-span masking (rf2-8wcbe) swallowing what survives — and
+      downstream inline-span masking (rf2-skpf) swallowing what survives — and
       none in the other direction.  The corpus measurement above is what carries
       the bound; agreement never did.
     * List items and admonitions nested INSIDE a blockquote do not push a content
@@ -1141,7 +1177,7 @@ def _inline_blocks(
     construct may wrap.  Scanning per unit rather than per line is what lets
     `_iter_inline_links` see a wrapped link (rf2-vpc4c); bounding the unit at
     every real block boundary is what stops it from stitching unrelated blocks
-    into a link no renderer would produce (rf2-8wcbe).
+    into a link no renderer would produce (rf2-skpf).
 
     Four kinds of boundary end a unit:
 
@@ -1216,7 +1252,7 @@ def _inline_blocks(
 
 
 def _mask_code_spans(text: str) -> str:
-    """Mask inline-code spans across a joined scan unit (rf2-8wcbe).
+    """Mask inline-code spans across a joined scan unit (rf2-skpf).
 
     Length- and newline-preserving, so a match position in the masked text still
     maps back to its source line.  Unlike the per-line `_strip_inline_code`, this
@@ -1237,7 +1273,7 @@ def _iter_inline_links(
 
     `pairs` are (line_no, content) pairs the CALLER has already reduced to
     scannable source — fence-stripped.  Inline code is masked HERE, over the
-    joined unit, not by the caller (rf2-8wcbe).
+    joined unit, not by the caller (rf2-skpf).
 
     Each inline block (`_inline_blocks`) is joined with `\\n` and scanned as ONE
     string, so a link whose text wraps across a newline is seen.  The
@@ -1249,7 +1285,7 @@ def _iter_inline_links(
     Masking runs over the same joined unit `_LINK_RE` scans, so the two agree on
     what the text is: a code span that crosses a line ending is masked whole and
     yields no link, where per-line masking saw two unpaired backticks, masked
-    neither, and invented one (rf2-8wcbe).
+    neither, and invented one (rf2-skpf).
 
     The reported line is the one carrying the DESTINATION (`m.start(1)`), not
     the one carrying the opening `[`.  For an unwrapped link the two are the
@@ -1280,7 +1316,7 @@ def _extract_links(path: Path) -> Iterable[tuple[int, str]]:
     skipped — both are "code", not real cross-references (rf2-mqv8s).
     Links that wrap across a newline ARE seen (rf2-vpc4c) — see
     `_iter_inline_links`, which is also where inline code is masked and where
-    the join is bounded to one rendered inline block (rf2-8wcbe).
+    the join is bounded to one rendered inline block (rf2-skpf).
 
     This function's only job is reducing the file to fence-stripped
     (line_no, content) pairs.  `check_readme_links.py` imports it so both gates
@@ -2002,7 +2038,7 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("wrapped_link_broken_anchor",       2),  # negative control
         ("wrapped_link_ok",                  0),  # no false positives
         ("wrapped_link_block_bound",         0),  # join stops at a blank line
-        # rf2-8wcbe — the join must not bridge a NON-blank block boundary, and
+        # rf2-skpf — the join must not bridge a NON-blank block boundary, and
         # inline code must be masked over the same unit the link regex scans.
         # Each expects 1, not 0: the single finding is a REAL broken wrapped
         # link, so the count fails in BOTH directions — upward if a phantom is
@@ -2401,7 +2437,7 @@ def _run_self_tests(verbose: bool = False) -> int:
             "rejects the drifted mutation\n"
         )
 
-    # rf2-vpc4c / rf2-8wcbe — link extraction driven directly with explicit line
+    # rf2-vpc4c / rf2-skpf — link extraction driven directly with explicit line
     # lists, so the wrap contract is pinned at the mechanism rather than only
     # through a fixture's aggregate count. Each case states the (line_no,
     # destination) pairs `_iter_inline_links` must yield from FENCE-STRIPPED
@@ -2409,7 +2445,7 @@ def _run_self_tests(verbose: bool = False) -> int:
     # code is masked inside `_iter_inline_links` over the joined unit, so these
     # inputs are raw source lines. The cases run in both directions: the join
     # must reach across a wrap (rf2-vpc4c) and must stop at every real block
-    # boundary and inside a multiline code span (rf2-8wcbe).
+    # boundary and inside a multiline code span (rf2-skpf).
     extraction_cases: list[tuple[str, list[tuple[int, str]], list[tuple[int, str]]]] = [
         # POSITIVE CONTROL — the unwrapped case that always worked. The reported
         # line is the link's own line, exactly as before the fix.
@@ -2449,7 +2485,7 @@ def _run_self_tests(verbose: bool = False) -> int:
          [(1, "An unclosed [ bracket opens here,"),
           (2, "and [the real link](target.md#anchor) follows.")],
          [(2, "target.md#anchor")]),
-        # rf2-8wcbe — NON-BLANK block boundaries. A blank line is not the only
+        # rf2-skpf — NON-BLANK block boundaries. A blank line is not the only
         # boundary; each pair below spans a real one, so no renderer produces a
         # link from it. THE BEAD'S SECOND COUNTEREXAMPLE leads.
         ("ATX heading is not bridged",
@@ -2488,7 +2524,7 @@ def _run_self_tests(verbose: bool = False) -> int:
          [(1, "> Per the note, [§Compiled"),
           (2, "views](API.md#compiled-views) is live.")],
          [(2, "API.md#compiled-views")]),
-        # rf2-8wcbe — code spans are masked over the JOINED unit, because a
+        # rf2-skpf — code spans are masked over the JOINED unit, because a
         # CommonMark code span may contain a line ending. THE BEAD'S FIRST
         # COUNTEREXAMPLE: per-line masking saw two unpaired backticks, masked
         # neither, and invented a link the renderer never produces.

--- a/scripts/check_readme_links.py
+++ b/scripts/check_readme_links.py
@@ -833,7 +833,7 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("dup_suffix_out_of_range_broken",   1),  # `#errors-2` with only two headings
         ("github_dup_collision_bump_ok",     0),  # `## Errors-1` after two `## Errors`
         ("inline_code_link_ignored",         0),  # fence + inline-code guard
-        # rf2-8wcbe — the shared extractor's block bound and multiline
+        # rf2-skpf — the shared extractor's block bound and multiline
         # code-span mask reach this gate too. Expects 1, not 0: the finding is
         # a REAL broken wrapped link, so the count moves if a phantom is
         # invented (up) or if wrapped links stop being seen (down).


### PR DESCRIPTION
Closes **rf2-skpf** — the residual PR #7803 measured and handed to a bead that did not exist.

## The verdict, up front

Reachable, in the direction that costs coverage. Two of the three residual causes are **false negatives** — a link the renderer emits and this gate never checks — and both are `_inline_blocks` failing to do what its own docstring already said. The third is a genuine parser boundary and is **declined**, now recorded as a declared disagreement rather than left reading as parity.

## The instrument, and proof it can move

Oracle: `mkdocs.config.load_config('mkdocs.yml')` into a real `markdown.Markdown` (`extensions=cfg['markdown_extensions']`, `extension_configs=cfg['mdx_configs']`), against this repo's installed python-markdown 3.10 + pymdownx 10.21.3 on Python 3.14.0 — the same pair #7803 and the rf2-feit measurement used. Three synthetic `<a>` sources are filtered, each of which had to be found the hard way: `toc(permalink)` headerlinks, `pymdownx.highlight(anchor_linenums)` `#__codelineno-*` anchors, and `footnotes` back/forward refs.

Every harness carries `--prove`, because a harness that has never reported a failure is not evidence of absence:

- shape harness — planted false-negative, planted false-positive, agreeing control → `PROVE: instrument moves`
- corpus harness — the same two plants appended to a real corpus file, plus the unplanted control → `PROVE: corpus instrument moves`

The corpus `--prove` earned its keep immediately: my first planted "false positive" was not one (both sides masked it), and the harness said so.

## The witnesses, verbatim

**FALSE NEGATIVE 1 — a bare `>` is a blank line inside the quote.**

```
> Prose with `a code span
>
> [in](in-target.md)` closing here.
```

`BlockQuoteProcessor.clean` maps a line whose content is nothing but blockquote markers to the empty string, so the two backtick runs are in **different paragraphs** and neither opens a span. Renderer: `['in-target.md']`. Gate before this branch: `[]` — the join reached across the paragraph break, the runs paired, and a real link was masked out of existence. `>   ` (trailing spaces) and `> >` behave identically.

**FALSE NEGATIVE 2 — lazy continuation *resumes* a quote, it does not enter one.**

```
> Per the note, see [§Compiled
views and the
> rest](API.md#compiled-views).
```

All three lines clean into one paragraph. Renderer: `['API.md#compiled-views']`. Gate before this branch: `[]` — it compared line 3's depth against the *previous* line's, which lazy continuation had put at 0, read the resume as an entry, split the paragraph and dropped the link.

**AGREEING CONTROLS** (green before and after; without them both fixes are satisfied by a rule that bounds at every quoted line, which would undo rf2-vpc4c):

```
> Prose with `a code span
> continues
> [in](in-target.md)` closing here.
```

both `[]` — the span really does close, so there is no link.

```
>> Per the note, see [§Compiled
> views](API.md#compiled-views).
```

both `['API.md#compiled-views']` — a shallower line after a deeper one is still one paragraph.

## Reachability — measured, not asserted

The bar is not "constructible". These are the ingredient counts over the 718-file corpus:

| ingredient | occurrences |
|---|---|
| a bare `>` line inside a blockquote | **569** |
| ...with an odd backtick-run count in the paragraph either side of it | 0 |
| lazy continuation followed by a re-marked line | 0 |
| a list marker or table row interrupting an open paragraph | 6,743 |
| ...with a link whose text wraps across it | 0 |

So the first shape's **primary** ingredient is house style, at 569 sites, and only a second slip (an unpaired backtick) turns one into a lost link today. That is the reachability answer that matters: the gate is one typo away from silently dropping a link in 569 places, and a typo in a blockquote is exactly the thing a link checker exists to survive.

The second shape does not occur today. It is fixed anyway because it costs two lines and because **`_inline_blocks` was contradicting its own docstring** — the docstring already said "an unprefixed line after a quoted one is CommonMark lazy continuation of the SAME quoted paragraph", and the code then compared against that lazy line's depth. This is not speculative widening; it is making the code do the renderer-derived thing it claims to.

## The change

`_inline_blocks`, in full: blankness is tested on the **marker-stripped body** rather than the raw line, and the depth comparison is against the depth the unit **opened at** rather than the previous line's. Nothing else moved. `_mask_code_spans` is untouched — it was always right, given the right unit.

## What is declined, and why

A list marker or table row part-way through an open paragraph. python-markdown starts a list or a table **only at a block start** (`OListProcessor.test` / `UListProcessor.test` are `RE.match(block)`; `TableProcessor.test` reads the block's first two rows), so

```
> Per the note, see [§Compiled
> - views](API.md#compiled-views).
```

renders `<a href="API.md#compiled-views">` and this gate reports nothing. It stays:

- bounding only at a block start needs list-and-table open/close state this scanner does not keep — that is the parser the bead forbids;
- the shape it would buy is a link whose *text* wraps onto a line beginning `- `, `* `, `+ `, `1. ` or `|`, which prose does not do (0 in the corpus);
- the shape it would cost is the corpus's most common structure of all — a real list, where the block *does* start with the marker and each item genuinely is its own container.

Recorded in the source as a declared disagreement with the measurement attached, in the same voice rf2-feit used for `_strip_fences`' five-space bound.

## Corpus movement, both directions

| | |
|---|---|
| links the gate now checks that it did not | **0** |
| links it no longer checks | **0** |
| files whose inline-block partition changed | **117** |
| inline units corpus-wide | 34,541 → **34,985** |
| units replaced | 270 → 714 |

The zero is explained rather than asserted, because a zero meaning "the code never runs" would be worthless: the partition really does move, in 117 files, splitting 270 units into 714 at newly-recognised paragraph breaks. In none of them did a link straddle the boundary that moved.

Renderer parity over the whole corpus is **byte-identical before and after** — 718 files, 10 renderer-only and 22 gate-only, every one of the 32 outside this surface:

- 20 gate-only are `![alt](x.png)` images (`<img>`, not `<a>`) — harness artefact, the gate is right to validate them;
- 1 renderer-only is an autolink `<http://localhost:8020>` — harness artefact;
- **10 renderer-only are reference-style links** (`[ref]: dest`) the gate never checks — a live false negative, its own defect, **not** this surface; see below;
- 1 gate-only is a link inside an HTML comment (`docs/EP/EP-template.md:12`) the renderer strips;
- 1 gate-only is the already-declared indented-code-block bound (rf2-feit) at `docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md:475`.

## Re-measuring #7803's own domain

Swept the same three-line quoted-fence prefix triples #7803 used — 12 prefixes, 1,728 shapes. (My prefix alphabet is not identical to #7803's, so the absolute counts are not comparable to its 235/123; the classification is the point.) Each disagreement is classified by whether **either** side saw a code block:

| | before (origin/main) | after |
|---|---|---|
| disagreements | 236 | **48** |
| ...inline-mask / block-bound | 188 (all false-positive) | **0** |
| ...fence classification | 48 (41 FN + 7 fp) | 48 (41 FN + 7 fp) |

A strict subset: 188 fixed, **0 introduced**. The residue is entirely `_strip_fences` classification in the two classes #7803 declared out of domain, untouched here.

One correction to the bead's premise, stated because it changes how the next reader reads #7803: within that triple domain the inline-mask defect produced **only false positives**. Its false-negative half is unreachable from three-line fence triples — none of them puts an unpaired backtick either side of a bare `>`. It took a purpose-built boundary probe (22 candidate middle lines × a masking probe and a wrapping probe = 44 shapes; 18 disagreements before, 8 after, the 8 being the declined class) to surface it. A sweep that is wide in one dimension is not wide.

## The ghost owner

`rf2-8wcbe` was cited **19 times** as the owner of this surface and exists in neither the Dolt ledger nor any `issues.jsonl`. All 19 now name `rf2-skpf`; `git grep rf2-8wcbe` outside `.beads/` is empty. One note at the head of the surface records where the old id went, so a reader who meets it in #7785 / #7795 / #7803 lands here.

- `scripts/check_doc_slugs.py` (13)
- `scripts/check_readme_links.py` (1)
- `scripts/_test_fixtures/check_doc_slugs/README.md` (2)
- `scripts/_test_fixtures/check_doc_slugs/multiline_code_span_not_a_link/docs/index.md` (1)
- `scripts/_test_fixtures/check_doc_slugs/non_blank_block_bound/docs/index.md` (1)
- `scripts/_test_fixtures/check_readme_links/block_bound_link_ignored/README.md` (1)

rf2-b2cr and rf2-1cpt are untouched — both are correctly closed against narrower faults.

## Follow-up worth a bead (not filed — no mutating `bd` from a worker branch)

**Reference-style links are never validated.** `_LINK_RE`'s comment claimed there are none in this corpus "per spot-check"; there are, and ten links the renderer emits from `[ref]: dest` definitions go unchecked today — seven in `tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md`, one in `tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md`, two in `tools/story-mcp/spec/002-Tool-Registry.md`. The comment now records the measurement; the defect is untouched.

## Evidence: red-first

The ten new self-test cases run against `origin/main`'s `_inline_blocks` (same file, that function's body reverted): **5 red, 5 controls green**.

```
RED  a bare > ends the quoted paragraph, so no span swallows the link  expected [(3, 'in-target.md')]  got []
RED  ...spelled with trailing spaces, which clean() also empties       expected [(3, 'in-target.md')]  got []
RED  a bare > ends the quoted paragraph, so the wrap is not one link   expected []  got [(3, 'missing.md')]
PASS a quoted continuation line does not end the span
PASS a quoted continuation line does not end the paragraph
RED  a re-marked line after lazy continuation is not a new quote       expected [(3, 'API.md#compiled-views')]  got []
RED  ...and a span across that resume still masks                      expected []  got [(3, 'in-target.md')]
PASS nesting deeper still bounds
PASS nesting deeper after lazy continuation still bounds
PASS a shallower quoted line after a deeper one still joins
```

The five controls never redded, which is what stops the fix from being satisfied by a rule that bounds everywhere.

## Evidence: the gate still has teeth

`check_doc_slugs.py` is silent on success, so a green run proves nothing on its own. Planted a bogus anchor into a real doc — deliberately into a blockquote that has bare `>` lines, so the plant travels the changed path:

```
docs/cljs/index.md:13  + See [the planted anchor](../api/re-frame.core.md#rf2-skpf-no-such-anchor).
```

```
PLANTED EXIT=1
1 broken anchor link(s) found:
  BROKEN ANCHOR: docs\cljs\index.md:13 -> ../api/re-frame.core.md#rf2-skpf-no-such-anchor
      (target: docs\api\re-frame.core.md)
```

Restored with `git checkout --`, `git status` confirms the file is byte-identical, re-run `RESTORED EXIT=0`.

## Quality gates

Each run alone, in the foreground, to completion; no gate piped through a filter; exit code captured on the same command line.

| Gate | Result | Exit |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | pass | 0 |
| `python scripts/check_doc_slugs.py --self-test` (now +10 cases) | pass | 0 |
| `python scripts/check_doc_slugs.py` (full corpus, 718 files) | pass | 0 |
| `python scripts/check_readme_links.py --self-test` | pass | 0 |
| `python scripts/check_readme_links.py` (shares the extractor) | pass | 0 |
| `python scripts/check_fast_pr_gap.py --list` | derived, 95 | 0 |

The spine was re-run on the final tree and printed `gate root: /c/Users/miket/code/re-frame2-worktrees/inlinemask-skpf` — this worktree. Its docs lane genuinely covers this surface: `README link validator self-test`, `README link/anchor validator`, `docs corpus anchor self-test`, `docs corpus anchor validator`.

Required checks the spine does not run were **derived**, not hand-listed: `check_fast_pr_gap.py --list` reports 95, all surface-gated, none reaching a change confined to `scripts/`.

Gates deliberately not run, with reasons:

- `mkdocs build --strict` — does not exercise this scanner at all, and excludes `docs/design/**`. Same call #7803 made.
- CLJS/JVM artefact suites (`test-jvm-implementation.sh`, `test-rigorous-local.sh`, browser smokes) — this diff is one Python gate plus four of its own fixtures; nothing under `implementation/`, `tools/` or `examples/` is reachable from it.
- `clj-kondo` / `splint` / `eslint` — no Clojure, ClojureScript or JavaScript in the diff.

## Files

Only `scripts/check_doc_slugs.py` changes behaviour. `scripts/check_readme_links.py` and the four fixtures are comment/prose id corrections. No `spec/`, no `.github/workflows/`, no `.beads`.
