### PR TITLE
fix(hicasso): close the refusal constructor's two remaining payload bypasses (rf2-1oan, rf2-hic-007, rf2-0w0l)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/error.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/error.cljc
@@ -62,8 +62,10 @@
   has checked a map that no longer exists: `extra` carrying
   `{:recovery nil}` used to win outright, so the one field the guard
   exists to insist on could be erased immediately after it was insisted
-  on. [[required]] and [[ambient]] are now the CONSTRUCTOR's, merged over
-  `extra` rather than under it, and [[missing-fields]] reads the result."
+  on. [[required]] and [[ambient]] are now the CONSTRUCTOR's — the
+  required four merged over `extra` rather than under it, the ambient
+  pair stripped from `extra` outright — and [[missing-fields]] reads the
+  result."
   (:require [clojure.string :as str]
             [re-frame.interop :as interop]))
 
@@ -191,10 +193,18 @@
   docstring on why those are different claims).
 
   Named as data beside [[required]] because together the two lists are
-  exactly the keys the CONSTRUCTOR owns. [[fail!]] merges them over its
-  `extra` argument rather than under it, so a call site cannot erase or
-  replace one — which is what makes the completeness guard a guarantee
-  about the emitted refusal rather than about four arguments."
+  exactly the keys the CONSTRUCTOR owns — and because [[fail!]] READS
+  this vector, to remove these two keys from `extra` before the merge.
+
+  Removing rather than overwriting, and the difference is why this pair
+  needs its own rule. A required field is always there to overwrite
+  with; an ambient one exists only while an origin names a view, so
+  outside every declaration extent — and in production, where
+  [[with-origin]] folds to its input — there was nothing to overwrite
+  and a forged `:view` in `extra` simply survived. The ABSENCE promised
+  above is a claim about what the constructor knows, and it is only
+  worth making if the constructor's silence beats a call site's
+  invention."
   [:source :view])
 
 (def shape
@@ -318,8 +328,15 @@
 
   **`extra` merges UNDER the shape, never over it.** It carries the
   refusal CLASS's own slots and only those; [[required]] and [[ambient]]
-  are the constructor's, and a spelling of one in `extra` loses. The
-  merge used to run the other way, on the reading that a call site might
+  are the constructor's, and a spelling of one in `extra` loses — the
+  required four by being overwritten, the ambient pair by being REMOVED
+  before the merge. Two mechanisms rather than one because overwriting
+  only reaches a field the constructor has a value for, and the ambient
+  pair is absent exactly where a forgery would matter most: outside
+  every declaration extent, and in every production build. A forged
+  `:view` there had nothing to lose to.
+
+  The merge used to run the other way, on the reading that a call site might
   know better than the ambient ledger — but no call site in the package
   ever did, and the cost of the option was that the four fields the guard
   had just insisted on could be erased one line later. An `extra` of
@@ -327,7 +344,7 @@
   emitted exactly that map. The guard now reads the merged result, so its
   claim is about the refusal a catch site receives."
   [id where reason recovery extra]
-  (let [data (merge extra
+  (let [data (merge (apply dissoc extra ambient)
                     (with-origin {:rf.error/id id :where where
                                   :reason reason :recovery recovery}))]
     (when interop/debug-enabled?

--- a/implementation/hicasso/test/re_frame/hicasso/error_shape_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/error_shape_cljs_test.cljs
@@ -327,3 +327,35 @@
           "the whole ex-data, so an overridden field cannot hide behind a
            select-keys that never looked at it")
       (is (= [] (error/missing-fields data))))))
+
+(deftest a-forged-ambient-pair-loses-where-there-is-no-origin-to-overwrite-it
+  ;; The row above runs INSIDE a declaration extent, and that is exactly
+  ;; what made it insufficient: overwriting only reaches a field the
+  ;; constructor has a value for. The ambient pair has one only while an
+  ;; origin names a view, so the case worth driving is the one where it
+  ;; does not — which is every event handler, every timer, every callback,
+  ;; and every production build. `extra` used to keep its forgery there.
+  (testing "outside every extent a forged `:view` and `:source` are DROPPED,
+            not overwritten — the constructor's silence is the answer, and a
+            catch site reading `:view` gets absence rather than a file name
+            the call site made up"
+    (let [data (refusal #(error/fail! :rf.error/hicasso-state-bad-option
+                                      'front.state/reg-state
+                                      "reg-state options must be a map."
+                                      :pass-a-map-of-options
+                                      {:view    "app.impostor/not-a-view"
+                                       :source  {:ns 'app.impostor
+                                                 :file "app/impostor.cljs"
+                                                 :line 1 :column 1}
+                                       :options :not-a-map}))]
+      (is (= {:rf.error/id :rf.error/hicasso-state-bad-option
+              :where       'front.state/reg-state
+              :reason      "reg-state options must be a map."
+              :recovery    :pass-a-map-of-options
+              :options     :not-a-map}
+             data)
+          "the whole ex-data — the class's own slot rides through, the two
+           ambient keys are gone, and nothing was left nil in their place")
+      (is (not (contains? data :view)))
+      (is (not (contains? data :source)))
+      (is (= [] (error/missing-fields data))))))

--- a/implementation/hicasso/test/re_frame/hicasso/error_source_coord_elision_prod_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/error_source_coord_elision_prod_test.cljs
@@ -90,6 +90,39 @@
         (is (not (re-find #"\.clj[sc]?" flat)))
         (is (not (re-find #"coord_sentinel_source" flat)))))))
 
+(deftest a-forged-coordinate-in-the-payload-does-not-reach-a-prod-refusal
+  ;; The row above hands `fail!` an EMPTY payload, so it proves the ledger
+  ;; is unwritten and nothing more. The absence contract is a claim about
+  ;; every refusal a production build emits, and the payload is the one
+  ;; place a `.cljs` path can still come from — a call site's own map. It
+  ;; used to survive here: `with-origin` folds to its input under
+  ;; `goog.DEBUG=false`, so there was no ambient value to overwrite it with
+  ;; and the forgery merged through untouched.
+  (let [data (try
+               (error/fail! :rf.error/hicasso-empty-vector
+                            'front.codec/vec->element
+                            "A hiccup vector must have a head."
+                            :supply-a-hiccup-head
+                            {:view   "app.impostor/not-a-view"
+                             :source {:ns 'app.impostor :file "app/impostor.cljs"
+                                      :line 1 :column 1}
+                             :head   :the-class-s-own-slot})
+               (catch :default e (ex-data e)))]
+
+    (testing "the class's own slot rides through and the forged ambient pair
+              does not — production absence is the constructor's answer, not
+              a property of well-behaved call sites"
+      (is (= {:rf.error/id :rf.error/hicasso-empty-vector
+              :where       'front.codec/vec->element
+              :reason      "A hiccup vector must have a head."
+              :recovery    :supply-a-hiccup-head
+              :head        :the-class-s-own-slot}
+             data)))
+
+    (testing "and the same cross-check the row above runs, now against a
+              payload that deliberately carried a source path"
+      (is (not (re-find #"impostor" (pr-str data)))))))
+
 ;; ---------------------------------------------------------------------------
 ;; What elided is the diagnostic, not the feature
 ;; ---------------------------------------------------------------------------

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_cljs_test.cljs
@@ -40,6 +40,7 @@
             [re-frame.hicasso :as h]
             [re-frame.hicasso.impl.codec :as codec]
             [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.error :as error]
             [re-frame.hicasso.impl.inventory :as inventory]
             [re-frame.hicasso.test :as ht]
             [re-frame.test-support :as test-support]
@@ -104,6 +105,46 @@
             :where       're-frame.hicasso.test
             :recovery    :pass-the-body-fn}
            (refusal (outcome #(ht/render [:not-a-body-fn 1])) [])))))
+
+(deftest a-refusal-s-payload-cannot-rewrite-the-identity-it-rides-on
+  ;; The constructor directly, because no refusal site in the kit spells an
+  ;; identity field in its payload today — and the whole point is that none
+  ;; can, including the one somebody writes next year. Driving the weakest
+  ;; case means handing it the four keys it guarantees, not a well-formed
+  ;; payload that would pass under either merge order (rf2-1oan).
+  (let [o (outcome #(#'ht/refuse! :rf.error/hicasso-test-not-a-body
+                                  "render's head is the BODY FUNCTION."
+                                  :pass-the-body-fn
+                                  {:rf.error/id :rf.error/hicasso-true-child
+                                   :where       'app.impostor/elsewhere
+                                   :reason      "replaced"
+                                   :recovery    nil
+                                   :value       :the-class-s-own-slot}))]
+
+    (testing "the identity is the constructor's, whole — a payload spelling
+              any of the four loses, and the class's own slot rides alongside
+              untouched. It used to merge LAST, so this call emitted the
+              impostor's id, a nil recovery and no raising site at all"
+      (is (= {:rf.error/id :rf.error/hicasso-test-not-a-body
+              :where       're-frame.hicasso.test
+              :reason      "render's head is the BODY FUNCTION."
+              :recovery    :pass-the-body-fn
+              :value       :the-class-s-own-slot}
+             (:refused o))
+          "the whole ex-data, so an overwritten field cannot hide behind a
+           select-keys that never looked at it"))
+
+    (testing "and the message still names the id the map carries — the parity
+              this kit exists to provide is that its refusal IS the runtime's,
+              and a map and a message disagreeing about which refusal occurred
+              defeats that before a reader gets to the id"
+      (is (= "render's head is the BODY FUNCTION. [:rf.error/hicasso-test-not-a-body]"
+             (:message o))))
+
+    (testing "and the emitted map satisfies the PACKAGE's completeness rule,
+              read from `impl.error` rather than copied — the kit's shape and
+              the runtime's are one shape or the parity is a coincidence"
+      (is (= [] (error/missing-fields (:refused o)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; L1 — the boundary ABI

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
@@ -110,7 +110,8 @@
   ## What L2 runs, and what it refuses
 
   [[render]] takes a hiccup form whose head is **a body function** — the
-  `(fn [props] …)` a `defview` is minted from:
+  `(fn [props] …)` a `defview` is minted from — or the minted view
+  itself:
 
       (defn todo-row-body [{:keys [id]}]
         (let [todo (h/sub [:todo/by-id id])]
@@ -125,14 +126,20 @@
           (is (= \"milk\" (ht/text li)))
           (is (= [:todo/toggle 1] (:on-click (ht/attrs li))))))
 
-  **A minted `defview` head is refused, and the refusal is the honest
-  answer rather than a limitation nobody wrote down.**
-  `re-frame.hicasso.impl.collector/mint-view!` closes over the body and
-  retains no reference to it — `boundary-head?` is one own-property read,
-  there is no registry and no map — so a minted head cannot be run
-  without React, and running it under React is L3. Naming the body, as
-  above, costs one line and keeps the view under test running AS
-  WRITTEN. See [[render]]'s refusal for the full statement.
+  **The minted `h/defview` head is accepted too, at the ROOT of the
+  form**, and either spelling runs the body AS WRITTEN.
+  `re-frame.hicasso.impl.collector/mint-view!` attaches the body to the
+  head it mints under one dev-only own property (`codec/retain-body!`,
+  rf2-kjf5) — no registry and no map, just a second own property beside
+  the boundary marker `boundary-head?` already reads — so a harness
+  that runs no hook can still reach the body. An `:advanced` build with
+  `goog.DEBUG=false`
+  carries no such property and a minted head refuses there, which costs
+  nothing because a production bundle may not `:require` this namespace
+  at all. See [[render]] for the full statement.
+
+  That is the ROOT form's rule. A boundary reached as a CHILD records
+  the call rather than expanding it, whatever the build — see §Children.
 
   ### Children
 
@@ -258,7 +265,7 @@
     :proves    "codecs, intents, controlled/revision laws, the boundary ABI"
     :mechanism "pure data and property assertions"}
    {:tier :l2 :here? true
-    :proves    "one registered hook-free Hicasso body, as a semantic tree"
+    :proves    "one hook-free Hicasso body, as a semantic tree"
     :mechanism "re-frame.hicasso.test/render under injected read fixtures"}
    {:tier :l3 :here? false
     :proves    "React lifecycle, context, hooks, refs, errors, foreign hosts"
@@ -908,9 +915,18 @@
 (defn- boundary-node
   "A child boundary, recorded as the CALL it is: its view id, the props
   the call site passed and the children the call site wrote. Its body
-  does not run — `mint-view!` retains no reference to it — so this node
-  claims nothing about what the child would render, and [[text]] over it
-  answers the call site's own children and no more."
+  does not run, so this node claims nothing about what the child would
+  render, and [[text]] over it answers the call site's own children and
+  no more.
+
+  A CHOICE, and the ladder's own definition of the tier rather than a
+  reach that failed: L2 is ONE body, run for its semantic tree, and it
+  expands no children of its own. The child's body is perfectly
+  reachable — the mint retains it on the head under a dev-only own
+  property, which is how [[render]] accepts a minted head at the ROOT —
+  so expanding it here would be L2 quietly becoming a renderer, and a
+  tree spanning two views cannot say which of them a red belongs to.
+  Render the child's own form to assert its contents."
   [form ns-ctx]
   (let [head     (nth form 0)
         props    (form-props form)

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
@@ -213,15 +213,24 @@
   The ex-data is the ASSERTABLE identity — `:rf.error/id`, `:where`,
   `:reason`, `:recovery` and whatever the site adds — because
   `(is (thrown? …))` is not a witness: it is green for a throw from any
-  layer with any id. A test of a refusal asserts the map."
+  layer with any id. A test of a refusal asserts the map.
+
+  **`extra` merges UNDER the identity, never over it**, exactly as the
+  package's own `impl.error/fail!` does (rf2-hic-007). `extra` carries
+  the refusal CLASS's own slots — the offending value, the key, the
+  path — and a spelling of an identity field in it loses. It used to
+  merge last, so a payload could hand a catch site a different
+  `:rf.error/id` from the one in the message beside it, and this kit's
+  whole reason to exist is that its refusal is the runtime's refusal:
+  an id a payload can rewrite is a parity claim nobody can rely on."
   [id reason recovery extra]
   ;; rf2:builder-bypass-ok - `id` is a PARAMETER, so the message carries the
   ;; `[:rf.error/...]` token the source cannot show. Same shape as
   ;; `re-frame.hicasso.impl.collector/fail!`.
   (throw (ex-info (str reason " [" id "]")
-                  (merge {:rf.error/id id :where where
-                          :reason reason :recovery recovery}
-                         extra))))
+                  (merge extra
+                         {:rf.error/id id :where where
+                          :reason reason :recovery recovery}))))
 
 ;; ---------------------------------------------------------------------------
 ;; L0 — the ladder, as data


### PR DESCRIPTION
Three beads on one surface: the refusal constructor, and the places PR #7797's repair did not reach.

## rf2-1oan — the same bypass, in the shipped test kit

**Reproduced.** `test_kit/src/re_frame/hicasso/test.cljs`'s `refuse!` merged `extra` LAST, unchanged by PR #7805. A payload could erase or replace `:where`, `:recovery` and `:rf.error/id`. `extra` now merges under the identity, matching `impl.error/fail!` rather than inventing a second idiom.

Why it matters here specifically: the kit's whole deliverable (rf2-hic-020) is that it raises *the runtime's* refusal rather than paraphrasing it. The message is built from the parameters and the ex-data was built from the payload, so the two could name **different refusals** — the map said `:rf.error/hicasso-true-child` while the message beside it said `[:rf.error/hicasso-test-not-a-body]`.

**Witness drives the weakest case.** No refusal site in the kit spells an identity field today, so a witness through a public door would pass under either merge order and prove nothing. The row calls the constructor directly (`(#'ht/refuse! …)`, an established CLJS idiom in this repo) with a payload naming all four identity keys, and asserts the **whole** ex-data — plus `impl.error/missing-fields` on the emitted map, so the kit's shape and the package's are read as one rule rather than two copies.

**Declined:** a completeness guard in the kit. The bead fences to "merge order alone", the kit has no such check to make read the emitted map, and adding one would be the reserved-key policing rf2-hic-007 already declined.

## rf2-hic-007 — the ambient hole the repair left open

**Reproduced** on the JVM before touching anything, exactly as the `MERGED-PR AUDIT #7797` note records:

```
(fail! :rf.error/demo 'demo/site "reason" :recover
       {:view "forged" :source {:file "forged.cljs"} :payload 1})
;; before: {:view "forged", :source {:file "forged.cljs"}, :payload 1, :rf.error/id ...}
;; after:  {:payload 1, :rf.error/id :rf.error/demo, :where demo/site, ...}
```

Required keys always overwrite `extra`; ambient keys only overwrite it while `!origin` names a view. Outside every declaration extent — and in production, where `with-origin` folds to its input — there was nothing to overwrite with, and the forgery survived.

**The fix is one expression:** `(merge (apply dissoc extra ambient) (with-origin …))`. It reads the `ambient` vector rather than spelling the pair again, so a field the shape grows later is stripped by the same rule. Overwriting is the wrong instrument for a field the constructor is often silent about; the documented absence contract is now a property of the constructor rather than of well-behaved call sites. Docstrings on `ambient`, `fail!` and the ns corrected — they claimed the guarantee unconditionally while it was conditional on being inside an extent.

**Two witnesses, both at the weakest point.** The existing override test supplied a real origin via `declaring!` first, which is exactly why it passed throughout — the assertion's claim was broader than its coverage. Added: one outside every extent (dev lane), and one under `:advanced` + `goog.DEBUG=false`, where the existing prod row handed `fail!` an **empty** payload and so proved only that the ledger was unwritten.

**Declined, per the bead's hard fence and the earlier worker's reasoning:** no reserved-key machinery, no new `:rf.error/*` id, no catalogue row, no diagnostic that scolds the caller.

**Reported, not taken — spec/009 is hot-zone and held by PR #7808.** `spec/009-Instrumentation.md:2513` says "the four slots and the two ambient ones merge OVER `extra`, never under it, so a per-arm payload … cannot erase or replace one this section says rides every row." The normative claim is now **true for the first time**; only the mechanism clause is loose (the ambient pair is removed, not overwritten). Nothing on main is falsified by this PR, so the line is safe to leave; a one-clause refinement is a follow-up for whoever holds 009.

## rf2-0w0l — the remainder, now that #7805 has merged

The doc half (specification.md section 9, decision-brief.md:83) landed in `70808d5a2e`; verified before editing. Three test-kit sites remained, all describing the mechanism PR #7801 replaced:

- The namespace doc said a minted `h/defview` head is **refused** because `mint-view!` retains no body reference. `render` has accepted one since rf2-kjf5.
- `boundary-node`'s docstring gave the same retired reason for behaviour that is still correct. The nested-call recording stays; its reason is now the ladder's own definition of L2, matching specification.md section 9's "expands no children of its own".
- The `ladder` L2 `:proves` string said "one **registered** hook-free Hicasso body" — the last copy of a word describing no mechanism this project has.

Vocabulary matched to `render`'s landed docstring and section 9 rather than invented a third time.

**Out of scope, worth a bead:** `docs/design/hicasso/draft-guide/14-testing.md` and `glossary.md` also say "registered hook-free", but they describe `ht/tree` — an API the shipped kit does not have. That is a larger drift than one word and outside this bead's fence.

## Mutation proof

Each fix reverted to its exact prior expression, the focused suite re-run, the red quoted verbatim, then restored byte-identically (`git checkout`, `git status` clean) and re-confirmed green.

**rf2-1oan** — `refuse!` back to `extra`-last, `:node-test-hicasso`, 2 failures:

```
FAIL in (a-refusal-s-payload-cannot-rewrite-the-identity-it-rides-on)
expected: {:rf.error/id :rf.error/hicasso-test-not-a-body, :where re-frame.hicasso.test,
           :reason "render's head is the BODY FUNCTION.", :recovery :pass-the-body-fn,
           :value :the-class-s-own-slot}
  actual: {:rf.error/id :rf.error/hicasso-true-child, :where app.impostor/elsewhere,
           :reason "replaced", :recovery nil, :value :the-class-s-own-slot}

FAIL ... expected: (= [] (error/missing-fields (:refused o)))
           actual: (not (= [] [:recovery]))
```

Note the message assertion stayed green through the mutation — which *is* the parity defect: the map named one refusal and the message beside it named another.

**rf2-hic-007, dev lane** — `(apply dissoc extra ambient)` back to `extra`, `:node-test-hicasso`, 3 failures:

```
FAIL in (a-forged-ambient-pair-loses-where-there-is-no-origin-to-overwrite-it)
  actual: (not (= {...no ambient keys...}
                  {:view "app.impostor/not-a-view",
                   :source {:ns app.impostor, :file "app/impostor.cljs", :line 1, :column 1},
                   :options :not-a-map, ...}))
expected: (not (contains? data :view))    actual: (not (not true))
expected: (not (contains? data :source))  actual: (not (not true))
```

**rf2-hic-007, production lane** — same mutation, `test:browser-prod-elision` (`:advanced` + `goog.DEBUG=false`), exit 1, 2 failures:

```
FAIL in (a-forged-coordinate-in-the-payload-does-not-reach-a-prod-refusal)
  actual: (not (= {...}
                  {:view "app.impostor/not-a-view",
                   :source {:ns app.impostor, :file "app/impostor.cljs", :line 1, :column 1},
                   :head :the-class-s-own-slot, ...}))
expected: (not (re-find #"impostor" (pr-str data)))   actual: (not (not "impostor"))
```

Worth recording: under that mutation `check_source_coord_elision.cjs` still **passed**. The bundle scan cannot see a coordinate assembled at runtime, which is precisely the two-halves split that file's docstring claims — and the behavioural row is the half that catches this.

**rf2-0w0l has no mutation proof, and cannot have one.** It changes two docstrings and one `:proves` string that no assertion reads. Nothing executable moved; the only claim is that the file still compiles clean and the suite stays green, which it does.

## Quality gates

| Gate | Exit |
|---|---|
| `sh scripts/test-fast-pr.sh` (foreground, to completion, unpiped) | **0** |
| `:node-test-hicasso` compile + run — 183 tests / 879 assertions, 0 warnings | **0** |
| `npm run test:browser-prod-elision` — 129 tests / 547 assertions | **0** |
| `npm run test:hicasso-freeze` (freeze + optional-module reachability + complaint catalogue: 59 live / 12 reserved, every anchor resolves) | **0** |

An earlier fast-PR run reported `_ai-tracking-ratchet.test.cjs` red with `Command failed: git init -q` in its `os.tmpdir()` fixture. It passes standalone (`8 passed`) and passed in the completed run above; it was local contention with a concurrent build, not this diff.

**Gap, derived rather than hand-listed** — `python scripts/check_fast_pr_gap.py --list` reports **95 required checks the spine does not run**. Relevant ones, and why each was or was not taken:

- `cljs-browser-prod-elision` — **run** (above). This diff adds an assertion to that lane.
- `cljs-browser`, `cljs-elision`, `cljs-bundle-isolation`, `cljs-hicasso-controlled`, `cljs-hicasso-hmr`, adapter/ui/story-xray smokes — **not run.** Browser lanes over surfaces this diff does not reach: no adapter, controlled-input, HMR or bundle-boundary behaviour changed. `test:cljs` (in the spine) already covers the hicasso suites on the node lane.
- `lint.yml / clj-kondo` — **not run.** CI pins 2026.04.15 and a differently-versioned local binary proves nothing, per the gap map's own note. `implementation/hicasso/resources/clj-kondo.exports/**` and `check_lint_export.py` are held by `worker/lintlocal-hic022` and untouched here.
- `docs.yml` — **not run, and not applicable.** No file under `docs/` changed. (`mkdocs build --strict` would in any case not cover `docs/design/**`.)
- `jvm-migration-hicasso-codemod`, api-manifest, MCP/skill and tools jobs — **not run.** No public facade export, manifest entry, skill or tool surface changed.

## Fences respected

`spec/009-Instrumentation.md` untouched (hot-zone, held by PR #7808) — the one line it wants is reported above rather than taken. `implementation/hicasso/resources/clj-kondo.exports/**`, `scripts/check_lint_export.py`, `docs/design/hicasso/product/complaints.md`, `implementation/hicasso/scripts/check_complaint_catalogue.py` and `implementation/package.json` untouched (held by other branches). No `.beads` path staged. Branch rebased onto `origin/main` after those merges landed; the complaint-catalogue gate that arrived with them passes.
