### PR TITLE
feat(hicasso): the consumer app and the artefact's first production build (rf2-hic-008)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/consumer_app.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/consumer_app.cljs
@@ -1,0 +1,136 @@
+(ns re-frame.hicasso.consumer-app
+  "THE CONSUMER APP — the smallest complete Hicasso application, written
+  the way a consumer writes one (rf2-hic-008).
+
+  Phase 0 exits when *a clean consumer can compile and run a minimal view
+  without benchmark-tree imports* (product specification §12). Everything
+  else this package owns is a test, and no test can answer that question,
+  because every one of them is allowed to reach past the door it is
+  proving: the package smoke renders through React's server renderer and
+  drives it from `impl.codec` and `impl.mount`; the controlled testbed
+  hangs a harness door on `window`; the HMR testbed patches React's own
+  `useSyncExternalStore` and reads `impl.inventory`. Each reach is correct
+  for what it measures and disqualifying for what this file claims.
+
+  This file is allowed nothing. **Its `:require` list is the deliverable**
+  — three namespaces, all public, not one of them under
+  `re-frame.bench.*` or `tools/`:
+
+  - `re-frame.core`, for the events and subscriptions any re-frame2 app
+    has;
+  - `re-frame.adapter.uix`, because the reactive substrate wants an
+    adapter installed before the first frame is made (Spec 006 §Adapter
+    selection at boot) and Hicasso deliberately ships none of its own —
+    a consumer picks one, the way they already do for Reagent or UIx
+    views;
+  - `re-frame.hicasso`, the public door, for `defview`, `sub` and
+    `root!`.
+
+  ## Why it is also the release build's entry
+
+  `:hicasso-release` compiles this namespace under `:advanced` with
+  `goog.DEBUG` false, and until it existed nothing in the repo had ever
+  compiled Hicasso the way a consumer ships it. A namespace that merely
+  REQUIRED the door would be no use for that: Closure keeps what is
+  reachable and an unused require is not, so the bundle would DCE to
+  nearly nothing and report a cost no consumer pays. Everything below is
+  reached from the mount instead — a declared view whose body reads a
+  subscription, a controlled field that writes back through an intent,
+  and a root that owns its frame.
+
+  ## Why it lives under `test/`
+
+  For the reason the sibling `re-frame.freehand.release-app` does:
+  `hicasso/deps.edn` publishes `src` and `resources` alone, so a fixture
+  that exists to be compiled stays out of the artefact a consumer
+  resolves, while shadow-cljs — which carries `hicasso/test` on
+  `:source-paths` — can still build it into a real production bundle. It
+  is not a test and matches no test regexp: `:node-test-hicasso` selects
+  `^re-frame\\.hicasso\\..+-cljs-test$`, and this namespace does not end
+  in `-cljs-test`.
+
+  ## What is deliberately absent
+
+  A `^:dev/after-load` hook. The HMR path is demonstrated by
+  `hicasso/testbed/hmr` under the `test:hicasso-hmr` gate, which drives a
+  real shadow-cljs watch and a real reload; inventing a second one here
+  would add machinery without adding a witness. Writing the hook's body
+  on public namespaces only is a separate matter and currently cannot be
+  done — the door exposes no re-render, and its `release!` is a fixture
+  door that resets the page-wide runtime and removes the container from
+  the document. That is reported as a follow-up rather than papered over
+  with a hook this file cannot honestly recommend copying."
+  (:require [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]))
+
+(def ^:private frame-id ::frame)
+
+;; ---------------------------------------------------------------------------
+;; The app's model — ordinary re-frame2, and all of it. The root's frame is
+;; seeded through `:initial-events`, so the view's first render reads a value
+;; that is already there rather than a nil it has to defend against.
+;; ---------------------------------------------------------------------------
+
+(rf/reg-sub ::greeting (fn [db _] (:greeting db)))
+
+(rf/reg-event ::seed (fn [_ _] {:db {:greeting "hello"}}))
+
+(rf/reg-event ::typed
+  (fn [{:keys [db]} [_ typed]]
+    {:db (assoc db :greeting typed)}))
+
+;; ---------------------------------------------------------------------------
+;; The view — one boundary, one read, one intent, one controlled field
+;; ---------------------------------------------------------------------------
+
+(h/defview app
+  "The whole application.
+
+  The field is controlled in the substrate's own sense: `:value` is the
+  subscription and `:on-input` is a plain event vector with `::h/value`
+  standing in for what was typed. There is no ref, no `on-change`
+  closure, no local draft and no effect reconciling the two — the model
+  is the only place the text lives, and the paragraph beneath the field
+  reads the same subscription to show it.
+
+  The `<label>` is not decoration either: an interactive element with no
+  accessible name is a warning under this package's own clj-kondo export
+  (`:re-frame.hicasso/nameless-interactive-element`, rf2-hic-022), and an
+  exemplar that trips the lint it ships would be a poor first thing to
+  copy."
+  [_]
+  [:main#hicasso-consumer-app
+   [:h1 "Hicasso"]
+   [:label {:for "greeting"} "Greeting"]
+   [:input#greeting {:type     "text"
+                     :value    (h/sub [::greeting])
+                     :on-input [::typed ::h/value]}]
+   [:p.echo "Committed: " (h/sub [::greeting])]])
+
+;; ---------------------------------------------------------------------------
+;; The mount
+;; ---------------------------------------------------------------------------
+
+(defn ^:export -main
+  "The `:hicasso-release` build's `:init-fn`, and the three lines that
+  start a Hicasso application.
+
+  `rf/init!` first, because `make-frame` raises
+  `:rf.error/no-adapter-installed` until a reactive adapter is installed
+  (Spec 006 §Adapter selection at boot). This is an INTERACTIVE mount — a
+  keystroke dispatches an event, app-db changes, and the boundary
+  re-renders — so the adapter has to bridge reactive change into React's
+  re-render, which the headless plain-atom adapter does not: its derived
+  value is not `IWatchable`, and a moving subscription under it would
+  notify nothing at all.
+
+  Then the frame, seeded; then the root, which is where a container, a
+  frame id and a hiccup tree meet. `h/root!` returns a handle, and this
+  app has no use for one: it mounts once and lives for the life of the
+  page."
+  []
+  (rf/init! uix-adapter/adapter)
+  (rf/make-frame {:id frame-id :initial-events [[::seed]]})
+  (h/root! (js/document.getElementById "app") frame-id [app {}])
+  nil)

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -977,6 +977,53 @@
    ;; The load-bearing watch hook is inherited from :build-defaults.
    :compiler-options {:infer-externs false}}
 
+  ;; rf2-hic-008 — the Hicasso artefact's RELEASE build: the substrate
+  ;; compiled the way a consumer ships it.
+  ;;
+  ;; Everything above this line is a TEST build, and until this id existed
+  ;; that was the whole inventory: nothing in the repo had ever compiled
+  ;; Hicasso under `:advanced` with `goog.DEBUG` false, so the two claims
+  ;; Phase 0 has to be able to make — that a clean consumer's application
+  ;; compiles for production at all, and that the dev-only seams are not
+  ;; in the bundle when it does — had no artefact to point at.
+  ;;
+  ;; The entry is `re-frame.hicasso.consumer-app`, which is a small real
+  ;; APPLICATION rather than a require-only stub, for the reason its
+  ;; sibling `:freehand-release` gives: Closure keeps what is reachable
+  ;; and an unused require is not, so a namespace that merely required the
+  ;; door would DCE to nearly nothing and the bundle would report a cost
+  ;; no consumer pays. It reaches a declared view, an ambient read, a
+  ;; controlled field's converge and a root that owns its frame — and it
+  ;; reaches them through `re-frame.hicasso`, `re-frame.core` and one
+  ;; adapter, with nothing from the bench tree or from `tools/`. That
+  ;; fence is the bead's acceptance and the entry's whole point.
+  ;;
+  ;; Shape follows the sibling advanced builds (:freehand-release,
+  ;; :proof-pack-single, :ui-g13-prod): both settings pinned rather than
+  ;; left to `release`'s defaults, so the build says what it is at the
+  ;; point a reader is looking. The entry sits under `hicasso/test/` — on
+  ;; :source-paths above, outside the artefact's published :paths — which
+  ;; is where every sibling bundle probe lives, and it matches no test
+  ;; regexp, so it is compiled here and nowhere else.
+  ;;
+  ;; The bundle lands at out/hicasso-release/main.js. No :dev-http — like
+  ;; every other advanced build here it is compiled and inspected, never
+  ;; served. The SERVED Hicasso builds are :hicasso/testbed and
+  ;; :hicasso/hmr-testbed, further down.
+  ;;
+  ;; NOT YET on an npm script or a CI job: implementation/package.json and
+  ;; .github/workflows/ were held by another worker when this landed, so
+  ;; `build:hicasso-release` and its gate are sequenced behind that. Built
+  ;; meanwhile with `npx shadow-cljs release hicasso-release`.
+  :hicasso-release
+  {:target     :browser
+   :output-dir "out/hicasso-release"
+   :asset-path "."
+   :compiler-options {:optimizations :advanced
+                      :infer-externs :auto
+                      :closure-defines {goog.DEBUG false}}
+   :modules {:main {:init-fn re-frame.hicasso.consumer-app/-main}}}
+
   ;; rf2-8kas5 — the Freehand artefact's RELEASE build: the substrate
   ;; compiled the way a consumer ships it.
   ;;


### PR DESCRIPTION
Closes rf2-hic-008 in part. Phase 0's exit criterion is that *a clean consumer can
compile and run a minimal view without benchmark-tree imports* (product
specification §12). This PR supplies the two halves that were missing, verifies
the two that were not, and corrects the record on the third deliverable, which is
much further from done than the bead's shape suggests.

## What I found already landed

**The HMR path — landed, and nothing further is owed.** `hicasso/testbed/hmr/`,
the `:hicasso/hmr-testbed` shadow build (id + `:dev-http` 8061), the driver
`scripts/serve-and-run-hicasso-hmr-testbed.cjs`, the `test:hicasso-hmr` npm gate
and `test/re_frame/hicasso/hmr_remount_cljs_test.cljs` all exist and are scheduled
in CI (639ad02e52, 4ebf8ae81b, 993d42c4e3 — rf2-vsgq / rf2-hic-015, "the last
declared hole, closed"). Run here: **PASS on chromium + firefox + webkit, 105
checks each, 36 real shadow reloads.**

**The build wiring — landed.** `hicasso/src`, `hicasso/test`,
`hicasso/test_kit/src` and `hicasso/testbed` are on `:source-paths`, and the
focused `:node-test-hicasso` build exists. Measured green here: compile 215 files
/ 0 warnings, run **181 tests, 872 assertions, 0 failures, 0 errors**. (For the
record, the ~13,000-test figure is the repo-wide `:node-test` build, not this
artefact's lane.)

## What was missing, and is here now

**The consumer app.** There was no application anywhere under
`implementation/hicasso/` written on public namespaces only. The two that exist
are testbeds and both are disqualified by their own reach: `hicasso_testbed.core`
hangs a harness door on `window.__RF2_HIC_TB__`, and `hicasso_hmr_testbed.core`
reads `impl.collector`, `impl.inventory` and `impl.mount` and patches React's
`useSyncExternalStore`. Each reach is right for what it measures and
disqualifying for the exit criterion.

`re-frame.hicasso.consumer-app` is allowed nothing. One `defview`, one
subscription, one intent, one controlled field — `:value` off the sub and an
event vector at `:on-input` with `::h/value` standing in for what was typed; no
ref, no local draft, no reconciling effect. The `<label>` is load-bearing: an
unnamed interactive element is a warning under the package's own clj-kondo export
(`:re-frame.hicasso/nameless-interactive-element`, rf2-hic-022), and an exemplar
that trips the lint it ships is a poor first thing to copy.

**The production release build.** `:hicasso-release` is the artefact's first
`:advanced` / `goog.DEBUG false` build; before it, the whole inventory was test
builds, so no claim about what Hicasso costs on a page had an artefact to point
at. The entry is the consumer app rather than a require-only stub, for the reason
its sibling `:freehand-release` gives: Closure keeps what is reachable and an
unused require is not, so a stub would DCE to nearly nothing and report a cost no
consumer pays.

The entry sits under `hicasso/test/` — on `:source-paths`, outside the artefact's
published `:paths` — exactly where `re-frame.freehand.release-app` sits, and it
matches no test regexp (`:node-test-hicasso` selects
`^re-frame\.hicasso\..+-cljs-test$`), so it is compiled by this build and nowhere
else.

## The import fence, mechanically

The app's complete `:require` list — three namespaces, all public:

```clojure
(:require [re-frame.adapter.uix :as uix-adapter]
          [re-frame.core :as rf]
          [re-frame.hicasso :as h])
```

`grep -n "bench\|tools\|impl\." consumer_app.cljs` returns four hits, all inside
prose in the namespace docstring; no form in the file names either.

Stronger than the source grep, the **transitive** fence, read off the release
build's own `out/hicasso-release/manifest.edn` (the authoritative source list for
what the bundle compiled). Not one of its 161 entries is under `re_frame/bench/`
or `tools/`. Counted in the emitted bundle:

| probe | occurrences in `out/hicasso-release/main.js` |
|---|---|
| `re_frame.bench` | 0 |
| `re_frame.story` | 0 |
| `re_frame.mcp_base` | 0 |
| `re_frame.testbed` | 0 |
| `day8.re_frame2_xray` | 0 |
| `day8.re_frame2_machines_viz` | 0 |
| `re_frame2_pair_mcp` | 0 |
| `day8.re_frame2_template` | 0 |
| `re-frame.hicasso` (control — the grep can find things) | 16 |

The manifest also witnesses `check_optional_module_reachability.py`'s claim from
the other side: `re_frame/hicasso/motion.cljs`, `evidence.cljs`, `tool.cljs`,
`impl/presence*.cljs` and `impl/inventory.cljs` are all absent from the bundle —
the optional modules are genuinely unreachable from the public door.

Bundle: 653,717 bytes, 0 warnings.

## Correction: the test migration is NOT done

The bead's third deliverable is "all existing Hicasso CLJS test suites migrated to
the new namespaces". This is much further from done than a directory listing
suggests, and it is not mechanical.

The 31 suites under `implementation/hicasso/test/` (12,491 lines) are **new
Phase-1 witnesses** authored by rf2-hic-007/010/011/012/013/014/015/016/020/022/023.
Not one is a migration. The prototype's own suites are all still in the bench tree
on `re-frame.bench.hicasso.*`: **69 files, 28,035 lines, none renamed.** hic-001's
own smoke test says so in its docstring — "the runtime's ~30 suites live in the
frozen bench tree and go on running there, which is the point of freezing it."

Why it is not a rename:

- **~35 of the 69 require `re-frame.bench.hicasso.arm1.runtime`**, which
  rf2-hic-009 carved into six package modules and whose four freeze rows were then
  retired (f9c3103e24). Their requires would have to fan out across
  `impl.collector` / `impl.generation` / `impl.frames` / `impl.roots` /
  `impl.evidence` / `impl.inventory` against an API that has since moved.
- A further tranche reaches bench **harness and measurement** namespaces with no
  package counterpart at all — `arm1.lang`, `arm1.mount`, `arm1.boundary`,
  `arm1.hook-probe`, `lane`, `shapes.*`, `ssr.*` — and several of those suites are
  measurements (`render_measure`, `lane_bytes`, `*_profile_baseline`) rather than
  behaviour witnesses that belong to the package at all.

Deciding which suites port, which are re-authored against the carved modules, and
which correctly stay with the benchmark is a design call, not a rename, and is
well beyond this bead's `Est: M`. **Reported for a follow-up bead rather than
taken here**, per the bead's own "mechanical; semantic changes become follow-up
beads".

## Two findings for follow-up beads (not decided here)

1. **The public door has no re-render, so an ordinary `^:dev/after-load` hook
   cannot be written on public namespaces only.** The HMR testbed's reload hook
   calls `impl.mount/render!`. The door exports `root!` and `release!` and nothing
   between them, and `root!` calls `createRoot` on each invocation, so it cannot
   re-render an existing root. This is why the consumer app deliberately carries
   no reload hook: the honest public shape does not exist yet, and writing a
   dubious one into the artefact a reader copies first is worse than omitting it.
2. **`h/release!` is a test-fixture door on the public facade.** It is
   `unmount!` + `collector/reset-runtime!`, and its own docstrings say so:
   `unmount!` **removes the container from the document** (`removeChild`), and
   `reset-runtime!` drops *every* cell, edge, entry and frame bundle page-wide —
   so a consumer with two roots who releases one has torn down the other's
   runtime, and has lost the mount point besides. Both are correct for a fixture;
   neither is what "the public teardown door" should mean.

## Deliberately not done

- **No npm script and no CI job for `:hicasso-release`.** `implementation/package.json`
  and `.github/workflows/**` were held by `worker/catalogrows-vkle` for the whole
  of this bead, so `build:hicasso-release` and its gate must be sequenced behind
  it. The shadow build id carries a comment saying so, and the meantime command
  (`npx shadow-cljs release hicasso-release`). **This is the one thing I stopped
  on rather than taking.**
- **No second HMR machine.** `hicasso/testbed/hmr` under `test:hicasso-hmr` already
  drives a real shadow watch and a real reload across three engines; a second one
  would add surface without adding a witness.
- **No new dev/`:dev-http` build for the consumer app.** `:freehand-release` sets
  the precedent — advanced builds here are compiled and inspected, never served —
  and the two served Hicasso builds already exist.

## Quality gates

| gate | exit | note |
|---|---|---|
| `python hicasso/scripts/check_freeze.py` | **0** | "1 frozen row(s) match the bench tree, and each package file is its donor moved; no package file imports it" — **the hic-001 manifest is unchanged; the frozen bench tree is untouched by this PR** |
| `npm run test:hicasso-freeze` (freeze + optional-module reachability + complaint catalogue, each with its self-test) | **0** | motion unreachable from the public door; 59 live / 12 reserved / 1 pending-retirement complaint rows |
| `npx shadow-cljs release hicasso-release` | **0** | 161 files, 106 compiled, 0 warnings, 653,717 B |
| `npx shadow-cljs compile node-test-hicasso` | **0** | 215 files, 214 compiled, 0 warnings |
| `node out/node-test-hicasso.js` | **0** | 181 tests, 872 assertions, 0 failures, 0 errors |
| `npm run test:hicasso-hmr` | **0** | PASS chromium + firefox + webkit, 105 checks each, 36 real shadow reloads |
| `npm run test:hicasso-lint` | **0** | 6 checks fire on their fixtures, correct code silent |
| `clj-kondo --lint hicasso/test/re_frame/hicasso/consumer_app.cljs` | **0** | 0 errors, 0 warnings — including the package's own six `:re-frame.hicasso/*` checks |
| `npm run test:cljs` (the spine's node tier, run by hand) | **0** | 13,020 tests, 65,770 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` | **aborts locally** | 54 always-on checks pass with 0 failures, then it dies in a step this diff cannot reach — see below |

`gate root:` on every run named
`/c/Users/miket/code/re-frame2-worktrees/consumerapp-hic008`.

### The spine's local abort, and why it is not this diff

Run twice, from this worktree, with nothing else running. Both runs classify the
diff `docs=false jvm=false node=true`, clear **54 always-on repo-invariant steps
with zero failures** — test-lane bijection (1,855 test-defining files, 49 lanes),
JVM roster/CI bijection, the gate-scheduling audit, keyword-catalogue drift, CI
reproduce-commands, the lockstep gate, adapter disposition and the rest — and then
die inside `npm run test:script-policy`, at
`implementation/scripts/_changed-surfaces.test.cjs`. Every failure there has the
same shape:

```
Error: Command failed: bash -lc ./.github/scripts/report-changed-surfaces.sh '<some path>'
```

That is a **local process-spawn failure on this Windows host, not a content
failure**, and three things say so:

1. Run directly — `node implementation/scripts/_changed-surfaces.test.cjs` — the
   suite reports **`changed-surfaces tests: 322 passed.`, exit 0**. Same worktree,
   same diff, same session.
2. The two spine runs fail on *different* cases (first failure at file offset ~477
   in one run, ~1537 in the other), which a deterministic assertion failure cannot
   do.
3. The classification the failing cases assert on is correct when the same command
   is issued by hand: `report-changed-surfaces.sh 'implementation/shadow-cljs.edn'`
   answers `ui_gates=true`, exactly what the test expects, exit 0.

The suite also cannot reach this diff by construction: it classifies hard-coded
path strings against `.github/scripts/report-changed-surfaces.sh`, and this PR
touches neither that script nor the workflows it reads.

So the spine's tiers were completed by hand instead. The always-on block ran
inside the spine itself (54 steps, 0 failures); the node tier is the
`npm run test:cljs` row above; the JVM tier is `jvm=false` for this diff by the
spine's own classification; the docs tier is `docs=false` (no `docs/` file
changed). The artefact gates in the table are what actually cover the new code,
and all are green.

Gates NOT run, and why: `scripts/test-jvm-implementation.sh` and
`scripts/test-jvm-tools.sh` — this artefact is deliberately probe-only on the JVM
(`hicasso/deps.edn` `:test` uses `--probe`, and rf2-hic-022 kept it off the JVM
roster on purpose), and no JVM tree is touched; the spine classified the diff
`jvm=false` for the same reason. `test:hicasso-controlled` — the controlled-input
testbed is `worker/engines-hic016`'s surface and untouched here.
`mkdocs build --strict` — no `docs/` file changed.

