### PR TITLE
fix(gate): check reference-style links, all three forms (rf2-2ryk)

### DIFF
--- a/scripts/_test_fixtures/check_doc_slugs/README.md
+++ b/scripts/_test_fixtures/check_doc_slugs/README.md
@@ -44,4 +44,5 @@ Fixtures:
 | `fenced_doc_link_out_of_scope`     | 0               | The identical sample under a sibling tree stays silent — the assertion is scoped, not corpus-wide (rf2-mmyc) |
 | `fenced_doc_link_blockquoted`      | 1               | The same assertion on a BLOCKQUOTED fence (`> ```clojure`) — the shape `docs/design/hicasso/studio/` actually writes (rf2-1cpt) |
 | `blockquoted_fence_not_indexed`    | 2               | A `###` line and an `<a id>` inside a blockquoted fence mint no fragment target, so links to them are broken; the real heading and the blockquoted heading below must still resolve (rf2-1cpt) |
+| `reference_style_links`            | 2               | Reference-style links — full, collapsed and shortcut — resolve through their `[label]: dest` definitions; the 2 are a broken target and a broken anchor reached that way, and the page's bracketed prose, footnote, padded label and UNUSED definition must all stay silent (rf2-2ryk) |
 | `compat_anchor_teeth`              | driven directly | The compat-anchor manifest, placement, and source-comment teeth — invoked with explicit fixture inputs, not from this table (rf2-57k74 / rf2-zq5i6 / rf2-k30r7) |

--- a/scripts/_test_fixtures/check_doc_slugs/reference_style_links/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/reference_style_links/docs/index.md
@@ -1,0 +1,62 @@
+# Index — Reference-Style Links (rf2-2ryk)
+
+The gate matched inline links only, so every link the renderer emits from a
+`[label]: destination` definition went unchecked. This fixture expects **2**
+findings — one broken target and one broken anchor, both reached through a
+reference definition — and every other construct on the page must contribute
+nothing.
+
+## Resolving, in all three forms
+
+Full form: [the greeting section][hello].
+
+Collapsed form: [hello][].
+
+Shortcut form: [hello].
+
+Case is not significant, and an internal whitespace run folds to one space:
+[the greeting][HELLO] and [the greeting][spaced  label].
+
+Inside a blockquote, where the definition carries its own quote marker:
+
+> Per the note, [quoted] is live.
+>
+> [quoted]: target.md#hello-world
+
+## The two findings
+
+A definition whose target file does not exist, reached by the shortcut
+form: [gone].
+
+A definition whose target file exists but whose anchor does not, reached by
+the full form: [the missing section][bad-anchor].
+
+## Negative controls — none of these is a link
+
+A bare bracket run with no definition anywhere is not a link, which is the
+whole reason resolution has to happen before reporting: [nolink],
+[also missing][nowhere] and [neither][] all render as literal brackets.
+
+A definition that is NEVER used emits no link, so its missing target is not
+a finding: see `unused` below.
+
+An inline link outranks a definition of the same name, so this resolves to
+`target.md`, not to the definition: [hello](target.md#hello-world).
+
+A reference use inside a code span is code: `[hello][]`.
+
+A footnote is not a reference link[^1].
+
+A label may not contain brackets, so `[a[b]]` defines nothing and
+[bracketed][a[b]] is prose.
+
+A use label is folded but never stripped, so [padded][  hello  ] resolves to
+nothing at all.
+
+[^1]: Footnote bodies are consumed by the `footnotes` extension.
+
+[hello]: target.md#hello-world
+[spaced label]: target.md#hello-world
+[gone]: no-such-file.md
+[bad-anchor]: target.md#no-such-anchor
+[unused]: also-no-such-file.md

--- a/scripts/_test_fixtures/check_doc_slugs/reference_style_links/docs/target.md
+++ b/scripts/_test_fixtures/check_doc_slugs/reference_style_links/docs/target.md
@@ -1,0 +1,5 @@
+# Target — Reference-Style Links (rf2-2ryk)
+
+## Hello World
+
+The section every resolving reference definition in `index.md` points at.

--- a/scripts/_test_fixtures/check_doc_slugs/reference_style_links/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/reference_style_links/mkdocs.yml
@@ -1,0 +1,1 @@
+# Self-test fixture marker.

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -1362,6 +1362,86 @@ def _mask_code_spans(text: str) -> str:
     return _INLINE_CODE_SPAN_RE.sub(_blank, text)
 
 
+def _blank_spans(text: str, spans: list[tuple[int, int]]) -> str:
+    """Blank the given spans, preserving length and line endings.
+
+    Same contract as `_mask_code_spans`: a position in the result still maps
+    back to its source line.
+    """
+    if not spans:
+        return text
+    out = list(text)
+    for start, end in spans:
+        for i in range(start, end):
+            if out[i] != "\n":
+                out[i] = " "
+    return "".join(out)
+
+
+def _reference_id(label: str) -> str:
+    """Normalise a reference label the way a USE site is normalised (rf2-2ryk).
+
+    `.lower()` then `\\s+` → one space, matching
+    `ReferenceInlineProcessor.NEWLINE_CLEANUP_RE`.  Deliberately NOT stripped:
+    the renderer does not strip the use side, so `[text][  x  ]` resolves to
+    nothing and this must agree.  The DEFINITION side is stripped and not
+    folded — see `_reference_definitions`, and the grammar block by
+    `_REF_DEF_RE` for why the asymmetry is real rather than an oversight here.
+    """
+    return _REF_ID_WS_RE.sub(" ", label.lower())
+
+
+def _reference_definitions(
+    pairs: list[tuple[int, str]],
+) -> tuple[dict[str, tuple[int, str]], set[int]]:
+    """Collect `[label]: destination` definitions (rf2-2ryk).
+
+    Returns ({id: (line-of-destination, destination)}, {lines the definitions
+    occupy}).  The line set is what the caller blanks before scanning for
+    inline content: the renderer's block processor REMOVES a definition from
+    the document, so `[tsobl]` on its own definition line is not a shortcut
+    use of itself, and blanking is how that stays true here.
+
+    Scanned over the whole file at once, not per block, because a definition's
+    destination may sit on the following line.  Blockquote markers come off
+    first — `> [q]: x` defines `q` — and fenced lines arrived blank, so a
+    definition inside a code sample defines nothing.
+
+    `[^label]: …` is a FOOTNOTE, consumed by the `footnotes` extension long
+    before the block parser sees it, so it is skipped here rather than
+    registered as a reference with a destination of "the first word of the
+    footnote body".
+
+    Later definitions overwrite earlier ones, which is what python-markdown
+    does (`md.references[id] = …`) and the opposite of CommonMark's
+    first-wins rule.
+    """
+    bodies: list[str] = []
+    for _, content in pairs:
+        _, body = _quote_depth_and_body(content)
+        bodies.append(body)
+    text = "\n".join(bodies)
+    line_starts: list[int] = []
+    offset = 0
+    for body in bodies:
+        line_starts.append(offset)
+        offset += len(body) + 1
+
+    defs: dict[str, tuple[int, str]] = {}
+    lines: set[int] = set()
+    for m in _REF_DEF_RE.finditer(text):
+        label = m.group(1)
+        if label.startswith("^"):
+            continue
+        first = bisect.bisect_right(line_starts, m.start()) - 1
+        last = bisect.bisect_right(line_starts, max(m.end() - 1, m.start())) - 1
+        for i in range(first, last + 1):
+            lines.add(pairs[i][0])
+        dest_line = pairs[bisect.bisect_right(line_starts, m.start(2)) - 1][0]
+        defs[label.strip().lower()] = (dest_line, m.group(2).lstrip("<").rstrip(">"))
+    return defs, lines
+
+
 def _iter_inline_links(
     pairs: Iterable[tuple[int, str]],
 ) -> Iterable[tuple[int, str]]:
@@ -1389,7 +1469,39 @@ def _iter_inline_links(
     destination's line is the line an author edits to fix the anchor, and it is
     the more robust of the two — an unclosed stray `[` earlier in the block can
     drag the match start backwards, but never the destination.
+
+    REFERENCE-STYLE links are resolved here too (rf2-2ryk), against the
+    definitions `_reference_definitions` collected from the same lines.  Three
+    properties of that, each renderer-derived and each load-bearing:
+
+    * A use is reported at its DEFINITION's line, not its own, because that is
+      where the destination is written and therefore the line an author edits
+      to fix it — the same rule the inline case already follows.  It is
+      reported ONCE per definition however many times the label is used: three
+      uses of one broken `[tsobl]` are one broken destination on one line, and
+      three identical diagnostics would be noise, not coverage.
+    * Inline links are matched and BLANKED first, so `[foo](a.md)` cannot also
+      be read as a shortcut use of a `[foo]:` definition.  That is the
+      renderer's precedence — its inline link pattern outranks its reference
+      patterns — and blanking is length-preserving, so line mapping survives.
+    * A use is only a link once its label RESOLVES.  Without that gate a bare
+      `[1]` in prose becomes a link, which is exactly what the renderer
+      refuses to do, and this corpus is full of bracketed text that is not a
+      link.
+
+    A definition never used yields nothing: the renderer emits no `<a>` for
+    it, so there is nothing to check, and flagging it would be a lint this
+    gate has no business running.
     """
+    pairs = list(pairs)
+    refs, ref_def_lines = _reference_definitions(pairs)
+    if ref_def_lines:
+        pairs = [
+            (line_no, "" if line_no in ref_def_lines else content)
+            for line_no, content in pairs
+        ]
+    seen_refs: set[str] = set()
+
     for block in _inline_blocks(pairs):
         joined = _mask_code_spans("\n".join(content for _, content in block))
         # Offset of each line's first character within `joined`, for mapping a
@@ -1400,9 +1512,20 @@ def _iter_inline_links(
         for _, content in block:
             line_starts.append(offset)
             offset += len(content) + 1  # +1 for the joining newline
+        inline_spans: list[tuple[int, int]] = []
         for m in _LINK_RE.finditer(joined):
+            inline_spans.append((m.start(), m.end()))
             i = bisect.bisect_right(line_starts, m.start(1)) - 1
             yield block[i][0], m.group(1)
+        if not refs:
+            continue
+        for m in _REF_USE_RE.finditer(_blank_spans(joined, inline_spans)):
+            explicit = m.group(2)
+            ref_id = _reference_id(explicit if explicit else m.group(1))
+            if ref_id in seen_refs or ref_id not in refs:
+                continue
+            seen_refs.add(ref_id)
+            yield refs[ref_id]
 
 
 def _extract_links(path: Path) -> Iterable[tuple[int, str]]:
@@ -2171,6 +2294,16 @@ def _run_self_tests(verbose: bool = False) -> int:
         # links then resolve against phantom ids), and to 3 if blanking runs past
         # the blockquote and takes the real heading below it.
         ("blockquoted_fence_not_indexed",    2),
+        # rf2-2ryk — reference-style links, which the extractor matched not at
+        # all.  The 2 are a broken TARGET and a broken ANCHOR, each reached
+        # through a `[label]: destination` definition, so the count fails in
+        # both directions: down to 0 if reference extraction regresses, and up
+        # past 2 the moment resolution stops gating — the page is full of
+        # bracketed prose (`[nolink]`, `[a[b]]`, a footnote, a padded label)
+        # that the renderer refuses to make a link of, plus an UNUSED
+        # definition pointing at a missing file, which is a finding only for an
+        # extractor that has stopped asking whether a link is emitted at all.
+        ("reference_style_links",            2),
     ]
 
     failures = 0
@@ -2766,6 +2899,153 @@ def _run_self_tests(verbose: bool = False) -> int:
          [(1, ">> Per the note, see [§Compiled"),
           (2, "> views](API.md#compiled-views).")],
          [(2, "API.md#compiled-views")]),
+        # ------------------------------------------------------------------
+        # rf2-2ryk — REFERENCE-STYLE links, which this extractor matched not at
+        # all: nine links the renderer emits from `[label]: dest` definitions
+        # were never checked, and a link checker's false negatives are the
+        # expensive direction.
+        #
+        # The cases are driven from the GRAMMAR — every legal form, each
+        # position a definition may take relative to its use, and the label
+        # normalisation on both sides — not from the repair, and every verdict
+        # is what mkdocs' own markdown.Markdown returned for that exact input.
+        # A reference use is reported at its DEFINITION's line, because that is
+        # where the destination is written, and ONCE per definition however
+        # many times the label is used.
+        #
+        # THE THREE FORMS.
+        ("full form [text][label] resolves",
+         [(1, "See [the doc][t] for detail."), (2, ""), (3, "[t]: target.md#anchor")],
+         [(3, "target.md#anchor")]),
+        ("collapsed form [label][] resolves",
+         [(1, "See [t][] for detail."), (2, ""), (3, "[t]: target.md#anchor")],
+         [(3, "target.md#anchor")]),
+        ("shortcut form [label] resolves",
+         [(1, "See [t] for detail."), (2, ""), (3, "[t]: target.md#anchor")],
+         [(3, "target.md#anchor")]),
+        # THE SHORTCUT FORM'S GATE, and the reason resolution runs before
+        # reporting: with no definition the renderer emits literal brackets,
+        # and this corpus is full of bracketed prose and Clojure vectors.
+        ("shortcut with no definition is not a link",
+         [(1, "The path [1] and a stray [nolink] are prose.")],
+         []),
+        ("full form with no definition is not a link",
+         [(1, "See [the doc][missing] for detail.")],
+         []),
+        ("collapsed form with no definition is not a link",
+         [(1, "See [missing][] for detail.")],
+         []),
+        # DEFINITION POSITION — before the use, after it, in the middle of a
+        # paragraph, and with the destination on its own line.  All four are
+        # one `md.references` dictionary to the renderer, which is document-
+        # wide and order-free.
+        ("definition BEFORE the use resolves",
+         [(1, "[t]: target.md#anchor"), (2, ""), (3, "See [t] for detail.")],
+         [(1, "target.md#anchor")]),
+        ("definition interrupting a paragraph resolves",
+         [(1, "See [t] for detail."), (2, "[t]: target.md#anchor")],
+         [(2, "target.md#anchor")]),
+        ("destination on the line below the label resolves",
+         [(1, "See [t] for detail."), (2, ""), (3, "[t]:"),
+          (4, "    target.md#anchor")],
+         [(4, "target.md#anchor")]),
+        ("definition indented three spaces resolves",
+         [(1, "See [t] for detail."), (2, ""), (3, "   [t]: target.md#anchor")],
+         [(3, "target.md#anchor")]),
+        # ...and four spaces is an indented code block, which defines nothing.
+        ("definition indented four spaces defines nothing",
+         [(1, "See [t] for detail."), (2, ""), (3, "    [t]: target.md#anchor")],
+         []),
+        # A DEFINITION IS REMOVED FROM THE INLINE STREAM.  Without blanking it
+        # the label on the definition line reads as a shortcut use of itself,
+        # and one definition reports twice.
+        ("a definition line is not a shortcut use of itself",
+         [(1, "[t]: target.md#anchor")],
+         []),
+        # ONE REPORT PER DEFINITION.  Three uses of one label are one broken
+        # destination on one line; three identical diagnostics would be noise.
+        ("three uses of one definition report once",
+         [(1, "See [t], then [the doc][t], then [t][] again."), (2, ""),
+          (3, "[t]: target.md#anchor")],
+         [(3, "target.md#anchor")]),
+        # LABEL NORMALISATION, and the asymmetry CommonMark does not have.  The
+        # definition side is `.strip().lower()`; the use side is `.lower()`
+        # with `\s+` folded to one space and NO strip.
+        ("label matching is case-insensitive on both sides",
+         [(1, "See [the doc][HeLLo] for detail."), (2, ""),
+          (3, "[hEllO]: target.md#anchor")],
+         [(3, "target.md#anchor")]),
+        ("a whitespace run in the USE label folds to one space",
+         [(1, "See [the doc][a  b] for detail."), (2, ""),
+          (3, "[a b]: target.md#anchor")],
+         [(3, "target.md#anchor")]),
+        ("a use label wrapping across a newline folds the same way",
+         [(1, "See [the doc][a"), (2, "b] for detail."), (3, ""),
+          (4, "[a b]: target.md#anchor")],
+         [(4, "target.md#anchor")]),
+        ("the USE label is folded but NOT stripped, so padding kills it",
+         [(1, "See [the doc][  t  ] for detail."), (2, ""),
+          (3, "[t]: target.md#anchor")],
+         []),
+        ("the DEFINITION label is stripped but NOT folded, so a run kills it",
+         [(1, "See [the doc][a b] for detail."), (2, ""),
+          (3, "[a  b]: target.md#anchor")],
+         []),
+        # LAST DEFINITION WINS — `md.references[id] = …` is an assignment, the
+        # opposite of CommonMark's first-wins rule.
+        ("the LAST definition of a label wins",
+         [(1, "See [t] for detail."), (2, ""), (3, "[t]: first.md#a"),
+          (4, "[t]: second.md#b")],
+         [(4, "second.md#b")]),
+        # PRECEDENCE — the inline pattern outranks the reference one, so an
+        # inline link is never also read as a shortcut use of a definition that
+        # happens to share its text.
+        ("an inline link outranks a definition of the same name",
+         [(1, "See [t](inline.md#a) for detail."), (2, ""),
+          (3, "[t]: reference.md#b")],
+         [(1, "inline.md#a")]),
+        # A WRAPPED full-form use, the shape 003-Tool-Catalogue.md actually
+        # writes: the text wraps and the label lands on the following line.
+        ("a full-form use wrapping across a newline resolves",
+         [(1, "**Returns** the shape (per [Tool-Pair §Tool-surface"),
+          (2, "obligations][tsobl] — `:frames` and the rest."), (3, ""),
+          (4, "[tsobl]: Tool-Pair.md#tool-surface-obligations")],
+         [(4, "Tool-Pair.md#tool-surface-obligations")]),
+        # BLOCKQUOTES.  Markers come off before the definition is matched, and
+        # `md.references` is document-wide, so a definition written inside a
+        # quote serves a use outside it.
+        ("a definition inside a blockquote resolves",
+         [(1, "> See [q] for detail."), (2, ">"),
+          (3, "> [q]: target.md#anchor")],
+         [(3, "target.md#anchor")]),
+        ("a definition inside a blockquote serves a use outside it",
+         [(1, "> [q]: target.md#anchor"), (2, ""), (3, "See [q] for detail.")],
+         [(1, "target.md#anchor")]),
+        # AN UNUSED DEFINITION EMITS NO LINK, so there is nothing to check.
+        # Reporting it would be a lint about dead markup, not a link check.
+        ("a definition that is never used yields nothing",
+         [(1, "Just prose."), (2, ""), (3, "[unused]: target.md#anchor")],
+         []),
+        # CODE, in both directions.  A use inside a code span is code; a
+        # definition inside a fence arrives already blanked by `_strip_fences`,
+        # so it defines nothing.
+        ("a reference use inside a code span is not a link",
+         [(1, "See `[t][]` for detail."), (2, ""), (3, "[t]: target.md#anchor")],
+         []),
+        ("a definition inside a fence defines nothing",
+         [(1, "See [t] for detail."), (2, ""), (3, ""), (4, ""), (5, "")],
+         []),
+        # NOT REFERENCE LINKS.  A footnote is consumed by the `footnotes`
+        # extension before either processor runs, and a label may not contain
+        # brackets at all.
+        ("a footnote is not a reference link",
+         [(1, "See the note[^1] for detail."), (2, ""),
+          (3, "[^1]: target.md#anchor is only prose here.")],
+         []),
+        ("a label containing brackets defines nothing",
+         [(1, "See [the doc][a[b]] for detail."), (2, ""),
+          (3, "[a[b]]: target.md#anchor")],
+         []),
     ]
     for label, lines, expected_links in extraction_cases:
         got_links = list(_iter_inline_links(lines))

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -241,7 +241,23 @@ _LINK_RE = re.compile(r"\[(?:[^\]\\]|\\.)*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
 # NOT reference links, and left alone: `[^1]` is a footnote (the `footnotes`
 # extension consumes both the use and its `[^1]: body` definition before
 # either processor here runs), and `![alt][ref]` builds an `<img>`, never an
-# `<a>`.
+# `<a>` — that last one is EXTRACTED here anyway, because `_LINK_RE` has
+# always extracted inline images the same way (22 of them in the corpus) and a
+# destination that is not a `.md` file is skipped downstream regardless.
+#
+# THE DECLARED GAPS, all measured against the renderer and all absent from the
+# corpus — the point of writing them down is that the next reader knows which
+# side of the line they are on:
+#   * A definition inside an INDENTED CONTAINER — a list item, an admonition,
+#     a tabbed block.  The renderer de-indents the container's content before
+#     `ReferenceProcessor` sees it, so `- [t]: x` defines `t`; the `[ ]{0,3}`
+#     bound here reads the same line as an indented code block.  Closing it
+#     needs container open/close state, which is a parser.
+#   * A use inside a RAW HTML BLOCK.  `html_block` stashes the block before
+#     inline processing, so the renderer emits nothing and this does.  The
+#     inline form has the same gap and always has.
+#   * AUTOLINKS (`<http://…>`) are not extracted at all.  One in the corpus,
+#     external, so it would be skipped even if it were.
 #
 # Port of `ReferenceProcessor.RE`.  The title alternative is carried, unused,
 # because `$` is anchored: drop it and a definition that has a title stops
@@ -257,9 +273,10 @@ _REF_DEF_RE = re.compile(
 # back to the text).  The text excludes BOTH brackets where `_LINK_RE` excludes
 # only the closing one: python-markdown balances nested brackets with a
 # scanner, this file does not have one, and excluding `[` is the reading that
-# declines to match rather than mismatching.  `[[a] more][b]` therefore yields
-# `b` alone where the renderer emits both — declared, and absent from the
-# corpus.
+# declines to match rather than mismatching.  Nested link text still comes out
+# right, by a different route than the renderer takes — `[[a] more][b]` yields
+# `a` (as a shortcut, since the outer `[` cannot open a match) and then `b`,
+# which is the pair the renderer emits.
 _REF_USE_RE = re.compile(r"\[((?:[^\[\]\\]|\\.)*)\](?:\s?\[((?:[^\[\]\\]|\\.)*)\])?")
 
 # `ReferenceInlineProcessor.NEWLINE_CLEANUP_RE`, applied after `.lower()`.

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -153,17 +153,34 @@ _HTML_ANCHOR_RE = re.compile(
 ANCHOR_MECHANISM = "explicit <a id>"
 HEADING_MECHANISM = "heading"
 
-# Markdown inline link.  Captures destination only.  Reference-style links
-# ([text][ref]) are ignored — and the corpus DOES have them, which the
-# "none per spot-check" this comment used to claim did not (rf2-skpf).
-# Rendering all 718 in-scope files through mkdocs' own markdown.Markdown and
-# diffing the emitted hrefs against this extractor finds ten links the
-# renderer emits from `[ref]: dest` definitions and this gate never checks:
-# seven in tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md, one in
-# tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md, two in
-# tools/story-mcp/spec/002-Tool-Registry.md.  A live false negative, its own
-# defect, and NOT this surface — recorded here so the next reader of this
-# regex starts from the measurement rather than the spot-check.
+# Markdown INLINE link.  Captures destination only.  Reference-style links
+# (`[text][ref]`, `[ref][]`, `[ref]`) are handled by `_REF_DEF_RE` /
+# `_REF_USE_RE` below, not here — see the grammar block above them.
+#
+# THE COUNT, AND A CORRECTION TO IT (rf2-2ryk).  This comment claimed for a
+# long time that the corpus had no reference-style links "per spot-check"; PR
+# #7811 (rf2-skpf) measured that it does and recorded "ten links … seven in
+# 003-Tool-Catalogue.md, one in DESIGN-RATIONALE.md, two in
+# 002-Tool-Registry.md".  Ten was the size of a MULTISET DIFF between the
+# renderer's hrefs and this extractor's, and the diff is not the same
+# question: a reference link whose destination is ALSO written inline
+# elsewhere in the same file cancels out of it, and a link the extractor
+# misses for some OTHER reason lands in it.  Both happened.
+#
+# Counted at the source instead — marking `ReferenceInlineProcessor.makeTag`,
+# the one place python-markdown builds an `<a>` out of `md.references`, and
+# rendering all 719 in-scope files — the corpus holds NINE reference-emitted
+# links, from seven definitions:
+#
+#   6  tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md   ([tsobl] ×3,
+#      [1], [2], [resolve])
+#   1  tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md     ([tp-tsobl])
+#   2  tools/story-mcp/spec/002-Tool-Registry.md             ([conv], [s009])
+#
+# The tenth miss in that diff was not reference-style at all: it is the
+# AUTOLINK `<http://localhost:8020>` in docs/resources/tutorial/index.md,
+# which this gate would skip as external even if it extracted it.  Autolinks
+# remain unextracted and that is the whole of what is left in the corpus.
 #
 # The link TEXT may contain newlines: markdown wraps a paragraph freely, so
 # `[§Compiled\nviews](Doc.md#anchor)` is one rendered link.  The negated
@@ -176,6 +193,77 @@ HEADING_MECHANISM = "heading"
 # (`[^)\s]+`): CommonMark does not permit a bare destination to wrap, so a
 # newline there is not a link the renderer would produce either.
 _LINK_RE = re.compile(r"\[(?:[^\]\\]|\\.)*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+
+# THE REFERENCE-LINK GRAMMAR (rf2-2ryk), read off the renderer rather than off
+# CommonMark — the two disagree, and the gate has to match the renderer.  Every
+# claim below was driven through `mkdocs.config.load_config('mkdocs.yml')` into
+# a real `markdown.Markdown` (python-markdown 3.10, pymdownx 10.21.3), one
+# input per claim, and the two regexes here are ports of the two places
+# python-markdown implements it: `blockprocessors.ReferenceProcessor` for the
+# DEFINITION and `inlinepatterns.ReferenceInlineProcessor` (plus its
+# `ShortReferenceInlineProcessor` subclass) for the USE.
+#
+# A DEFINITION is `[label]: destination "optional title"`:
+#   * indented at most three spaces — four is an indented code block, and
+#     defines nothing;
+#   * the label may not contain `[` or `]` AT ALL, escaped or not, so
+#     `[a[b]]: x` is prose;
+#   * the destination may sit on the FOLLOWING line, and may be wrapped in
+#     angle brackets, which are stripped;
+#   * blockquote markers are cleaned off first, so `>    [q]: x` defines `q`;
+#   * the LAST definition of a label wins — `md.references[id] = …` is a plain
+#     assignment, not a `setdefault`, so CommonMark's first-wins rule is not
+#     what happens here;
+#   * the definition is REMOVED from the inline stream: the block processor
+#     splits the text around it, which is why `[label]` on the definition line
+#     is not itself a shortcut use.
+#
+# A USE is one of three forms — full `[text][label]`, collapsed `[text][]`
+# (the label falls back to the text) and shortcut `[text]`:
+#   * a bare `[text]` IS a link when, and only when, a matching definition
+#     exists; with none it renders as literal square brackets, which is what
+#     makes resolution-before-reporting mandatory rather than a nicety —
+#     `[1]`, `[x]` and Clojure vectors are all over this corpus;
+#   * at most ONE whitespace character may sit between `]` and `[`
+#     (`RE_LINK` is `\s?\[…\]`), and it may be a newline;
+#   * an INLINE link wins: `[foo](a.md)` with a `[foo]: b.md` definition in
+#     scope renders `a.md`, because the inline pattern outranks the reference
+#     one.
+#
+# LABEL MATCHING IS ASYMMETRIC, and this is the trap.  CommonMark folds both
+# sides the same way; python-markdown does not.  The definition side is
+# `label.strip().lower()` — stripped, never folded.  The use side is
+# `label.lower()` with `\s+` collapsed to a single space — folded, never
+# stripped.  So `[text][a  b]` and `[text][a\nb]` both resolve to `[a b]: x`,
+# while `[a  b]: x` is unreachable by any use and `[text][  x  ]` resolves to
+# nothing.  Case-insensitivity is the only part both sides agree on.
+#
+# NOT reference links, and left alone: `[^1]` is a footnote (the `footnotes`
+# extension consumes both the use and its `[^1]: body` definition before
+# either processor here runs), and `![alt][ref]` builds an `<img>`, never an
+# `<a>`.
+#
+# Port of `ReferenceProcessor.RE`.  The title alternative is carried, unused,
+# because `$` is anchored: drop it and a definition that has a title stops
+# matching.  Group 1 is the label, group 2 the destination.
+_REF_DEF_RE = re.compile(
+    r"""^[ ]{0,3}\[([^\[\]]*)\]:[ ]*\n?[ ]*(\S+)[ ]*
+        (?:\n[ ]*)?(?:(["'])(?:.*)\3[ ]*|\((?:.*)\)[ ]*)?$""",
+    re.MULTILINE | re.VERBOSE,
+)
+
+# All three USE forms in one pattern: group 1 is the text, group 2 the explicit
+# label (`None` for the shortcut form, empty for the collapsed one — both fall
+# back to the text).  The text excludes BOTH brackets where `_LINK_RE` excludes
+# only the closing one: python-markdown balances nested brackets with a
+# scanner, this file does not have one, and excluding `[` is the reading that
+# declines to match rather than mismatching.  `[[a] more][b]` therefore yields
+# `b` alone where the renderer emits both — declared, and absent from the
+# corpus.
+_REF_USE_RE = re.compile(r"\[((?:[^\[\]\\]|\\.)*)\](?:\s?\[((?:[^\[\]\\]|\\.)*)\])?")
+
+# `ReferenceInlineProcessor.NEWLINE_CLEANUP_RE`, applied after `.lower()`.
+_REF_ID_WS_RE = re.compile(r"\s+")
 
 # Fenced code block delimiter — a run of three or more backticks or tildes,
 # its leading indentation, and its info string (rf2-mmyc).

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -3959,7 +3959,7 @@ of the [operating-frame resolution table][resolve] — and are the escape
 from the tier-4 `:ambiguous-frame` refusal a multi-frame app otherwise
 traps an agent in.
 
-[resolve]: ../../../spec/Tool-Pair.md#operating-frame-resolution
+[resolve]: ../../../spec/Tool-Pair.md#operating-frame--multi-frame-resolution
 
 ### Why these ship (rf2-zomfq)
 


### PR DESCRIPTION
Closes **rf2-2ryk** — reference-style links were never validated. Ten links, said the bead. Nine, says the renderer.

## The count, remeasured

The bead's ten came from a **multiset diff** between the renderer's hrefs and this extractor's, and that is not the same question as "how many reference links are there": a reference link whose destination is also written inline elsewhere in the same file cancels out of the diff, and a link missed for some *other* reason lands in it. Both happened.

Counted at the source instead — marking `ReferenceInlineProcessor.makeTag`, the one place python-markdown builds an `<a>` from `md.references`, and rendering all **719** in-scope files:

| file | reference-emitted `<a>` | definitions |
| --- | --- | --- |
| `tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md` | 6 | `[tsobl]` x3, `[1]`, `[2]`, `[resolve]` |
| `tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md` | 1 | `[tp-tsobl]` |
| `tools/story-mcp/spec/002-Tool-Registry.md` | 2 | `[conv]`, `[s009]` |
| **total** | **9** | **7** |

The bead's "seven in 003-Tool-Catalogue" is six; the tenth miss was not reference-style at all. It is the **autolink** `<http://localhost:8020>` in `docs/resources/tutorial/index.md`, which this gate skips as external either way. Autolinks remain unextracted and that is the whole of what is left in the corpus.

## The instrument, and proof it moves in both directions

Oracle: `mkdocs.config.load_config('mkdocs.yml')` into a real `markdown.Markdown` (`extensions=cfg['markdown_extensions']`, `extension_configs=cfg['mdx_configs']`), against this repo's python-markdown 3.10 + pymdownx 10.21.3 on Python 3.14.0 — the same pair #7803, #7809 and #7811 used. Three synthetic `<a>` sources filtered: `toc(permalink)` headerlinks, `pymdownx.highlight(anchor_linenums)` `#__codelineno-*`, footnote back/forward refs.

**The #7811 worker's lesson applied: a sweep's generator defines which failure directions it can ever find.** Its fence-triple sweep could produce only false positives *by construction*, so the false-negative half was invisible however many shapes it ran. This probe compares two multisets — renderer minus gate, and gate minus renderer — so neither direction is structurally unreachable, and both harnesses carry `--prove` to demonstrate it rather than assert it:

- **shape** `--prove`: planted false negative (a reference link), planted false positive (an inline link inside an HTML comment), agreeing control → `PROVE: instrument moves in BOTH directions`
- **corpus** `--prove`: the same two plants appended to a real corpus file, plus the unplanted control → `PROVE: corpus instrument moves in BOTH directions`

## The witness, verbatim

Same input, two gates. `[conv]` in `002-Tool-Registry.md` pointed at an anchor that does not exist:

```
=== BASELINE GATE (origin/main extractor) ===
BASELINE_EXIT=0
=== THIS BRANCH ===

1 broken anchor link(s) found:

  BROKEN ANCHOR: tools\story-mcp\spec\002-Tool-Registry.md:117 -> ../../../spec/Conventions.md#no-such-anchor-rf2-2ryk
      (target: spec\Conventions.md)

Fix: confirm the heading still exists in the target file and update the link, or rename the heading and re-link.
BRANCH_EXIT=1
```

Restored with `git checkout HEAD --`; the **control** on the restored corpus is `CONTROL_EXIT=0`.

**Teeth, separately** — the gate is silent on success, so exit 0 proves nothing on its own. A bogus anchor planted at the end of a real page:

```
  BROKEN ANCHOR: docs\index.md:45 -> index.md#no-such-heading-rf2-2ryk
      (target: docs\index.md)
TEETH_EXIT=1
```

Restored byte-identically (`git diff --stat docs/index.md` empty).

## A genuinely broken link, found not introduced

`003-Tool-Catalogue.md:3962` carried `[resolve]: ../../../spec/Tool-Pair.md#operating-frame-resolution`. That anchor does not exist in `Tool-Pair.md` and never has; it went unchecked only because it is written as a reference definition. The section it means is `## Operating frame — multi-frame resolution`, and the form the rest of the corpus uses across files is the heading slug (`skills/shared/tool-pair-surfaces.md` and `spec/Conventions.md` both write `#operating-frame--multi-frame-resolution`). Fixed in **its own commit**, separate from the gate change.

## Corpus movement, both directions

`_extract_links` over the whole corpus, `(file, line, destination)` triples, this branch against `origin/main`:

```
links checked BEFORE    : 19675
links checked AFTER     : 19682
ADDED (new coverage)    : 7
REMOVED (lost coverage) : 0
```

The seven added are the seven definitions, each reported at its definition's line, together covering all nine rendered reference links. **Zero removed** — the answer to the silent-coverage-drop question, and it is not free: definition lines are blanked before the inline scan, which is exactly the kind of change that can quietly take a real link with it.

Renderer-vs-gate corpus diff, before → after: missed **10 → 3** (the autolink, plus two repeat uses of `[tsobl]` that the per-definition dedupe deliberately collapses); extra **22 → 22**, the identical list, so no new false positive reached the corpus.

## The two questions asked up front

**A bare `[ref]` is only a link if a definition exists** — confirmed against the renderer, and it is why resolution gates reporting rather than decorating it. `ReferenceInlineProcessor.handleMatch` returns no element when `id not in self.md.references`. Without that gate every bracketed run in the corpus becomes a link: `[1]`, `[x]`, Clojure vectors in prose.

**Label matching is case-insensitive and whitespace-folded — but ASYMMETRICALLY, which is not what CommonMark says.** Read off both implementations:

- definition side (`ReferenceProcessor.run`): `label.strip().lower()` — stripped, never folded
- use side (`ReferenceInlineProcessor.handleMatch`): `label.lower()` then `\s+` collapsed to one space — folded, never stripped

So `[text][a  b]` and a use label wrapping across a newline both resolve to `[a b]: x`, while `[a  b]: x` is unreachable by any use and `[text][  x  ]` resolves to nothing. Both halves are driven as self-test cases. A third fact in the same class: **the LAST definition of a label wins** (`md.references[id] = ...` is an assignment), the opposite of CommonMark's first-wins rule.

## Shapes driven — and the ones not driven

The enumeration came from the grammar, before the fix existed, and every expectation is what mkdocs' own `markdown.Markdown` returned for that exact input. `scripts/check_doc_slugs.py`'s 60 `extraction_cases` were each re-driven through the renderer by pulling the literal out of the source with `ast` — **60 cases, 0 disagreements** — so the self-test cannot claim something the renderer does not do.

**Driven (28 new self-test cases):** full / collapsed / shortcut, each with and without a definition; definition before the use, after it, and interrupting a paragraph with no blank line; destination on the following line; three-space indent (defines) and four-space (does not); a definition line is not a shortcut use of itself; three uses report once; case-insensitivity on both sides; a use-label whitespace run folded; a use label wrapping across a newline; padding kills a use label; a run kills a definition label; last-definition-wins; inline outranks reference; a wrapped full-form use (the shape `003-Tool-Catalogue.md` actually writes); definition inside a blockquote, serving uses inside and outside it; an unused definition yields nothing; a use in a code span; a definition in a fence; a footnote; a bracketed label. Plus 50 shapes in the throwaway harness, including titles, angle-bracketed destinations, table cells, list items, empty labels, bare-`#fragment` destinations, and nested link text with and without the inner definition.

**NOT driven, or driven and declined** — the valuable half:

| shape | renderer | this gate | disposition |
| --- | --- | --- | --- |
| definition inside an indented container (`- [t]: x`, admonition, tabbed block) | resolves | nothing | **declared gap.** The renderer de-indents container content before defining; the three-space bound here reads the same line as an indented code block. Closing it needs container open/close state — a parser. Zero in corpus. |
| use inside a raw HTML block or comment | nothing | a link | **declared.** `html_block` stashes it before inline processing. The inline form has had this gap all along (it is the probe's own false-positive plant). Zero in corpus. |
| reference-style image | `<img>`, no `<a>` | extracts the destination | **kept, for consistency.** `_LINK_RE` has always extracted inline images this way (22 in the corpus); a non-`.md` destination is skipped downstream. Zero reference-style images in corpus. |
| autolink | a link | nothing | **out of scope**, pre-existing and unchanged. One in corpus, external, skipped either way. |
| multiplicity | one `<a>` per use | one report per definition | **deliberate.** Three uses of one broken label are one broken destination on one line. |
| nested link text | `a` and `b` | `a` and `b` | agrees, by a different route — driven, both with and without the inner definition. The first draft of this comment claimed a loss here; it was wrong and is corrected in its own commit. |
| definition inside a table cell | nothing | nothing | agrees. |
| definition with parens in the destination | resolves | resolves | agrees. |

**Not driven at all**, and named so nobody has to guess: reference links under `attr_list` syntax (the extension is off), definitions carrying parenthesised titles, labels containing HTML entities or backslash-escaped brackets on the *definition* side (the label grammar forbids brackets outright, escaped or not, so there is nothing to escape), and any interaction with `pymdownx.snippets` (not enabled).

## Bounds

No general markdown parser and no fence-scanner widening. Two regexes ported from `blockprocessors.ReferenceProcessor` and `inlinepatterns.ReferenceInlineProcessor`, run over the scan units the file already builds — `_strip_fences` and `_inline_blocks` are untouched, so fence-stripping, code-span masking, block bounding and wrapped-link joining all come for free. `check_doc_slugs.py` stays the small self-testing gate it is.

## Quality gates

Every gate foreground, to completion, exit code captured on the same command line, worktree-local log paths. `gate root:` on every spine run reads `/c/Users/miket/code/re-frame2-worktrees/refstyle-2ryk`.

| gate | exit |
| --- | --- |
| `sh scripts/test-fast-pr.sh` (classified `docs=true`; includes `docs corpus anchor self-test`, `docs corpus anchor validator`, `README link/anchor validator`, `mkdocs --strict build`) | **0** — run twice, before and after the final comment commit |
| `python scripts/check_doc_slugs.py --self-test -v` | **0** — `all 145 self-tests passed` (was 116 on `origin/main`; +29) |
| `python scripts/check_doc_slugs.py` (full corpus) | **0** — and **1** before the `[resolve]` anchor fix, witness above |
| `python scripts/check_readme_links.py --self-test` | **0** — 21 self-tests; it imports `_extract_links`, so it inherits reference extraction |
| `python scripts/check_readme_links.py` (corpus) | **0** |
| `python scripts/check_fast_pr_gap.py --list` | derived: **95** required checks the spine does not run |
| renderer oracle — 50 grammar shapes, `--prove` both directions | 45 agree, 5 accounted for above |
| renderer oracle — all 60 `extraction_cases` re-driven | **0 disagreements** |
| corpus movement, `origin/main` to branch | +7 / -0 |

**Not run, and why:** every CLJS/JVM/browser lane (`npm run test:*`, `clojure -M:test`, adapter smokes, mcp-conformance) — the diff is one Python script, its fixtures, and one markdown link in an MCP spec tree; no Clojure, EDN, JS or build config is touched, and the fast-PR spine classified the change `jvm=false node=false` itself. `clj-kondo` / `splint` / `eslint` — no Clojure or JS in the diff. `mkdocs build --strict` ran inside the spine; the diff touches no page under `docs/design/**`, so the `exclude_docs` caveat does not apply.

## Fixture note

`scripts/_test_fixtures/check_doc_slugs/reference_style_links/` expects **2** findings — a broken target and a broken anchor, each reached through a definition — so the count fails in both directions: down to 0 if reference extraction regresses, and up past 2 the moment resolution stops gating. The page is deliberately full of things that must stay silent: bracketed prose, a bracketed label, a footnote, a padded use label, a reference use inside a code span, an inline link shadowing a definition of the same name, and an **unused definition pointing at a missing file** — a finding only for an extractor that has stopped asking whether a link is emitted at all. Renderer-checked: it emits exactly the three destinations the gate extracts.
