### PR TITLE
fix(hicasso): a letfn fnspec is a fn tail, arities and all (rf2-hic-022)

### DIFF
--- a/implementation/hicasso/lint-fixtures/negative.cljs
+++ b/implementation/hicasso/lint-fixtures/negative.cljs
@@ -213,3 +213,92 @@
   [:div
    (try (attempt) (catch :default retry (retry)))
    (as-> attempt retry (retry))])
+
+;; ---------------------------------------------------------------------------
+;; direct-view-call — the `letfn` GRAMMAR, one row per production
+;;
+;; The row above drives a `letfn` NAME, and the repair that added it claimed
+;; `letfn` parameters generally. It had read a fnspec as `[nm params]` and
+;; collected `params` only where that second node was a VECTOR — true of the
+;; single-arity spelling and of nothing else, because a MULTI-ARITY fnspec's
+;; second node is the first arity LIST. No arity's parameters were read at all,
+;; so every use of one reported at ERROR and clj-kondo exited 3 (merged-PR
+;; audit #7804). The claim was wider than the one shape the witness drove.
+;;
+;; So these rows come from the GRAMMAR rather than from the repair. A fnspec is
+;; a `fn` tail — `letfn` expands each one to `(fn nm …)` — and that grammar is
+;;
+;;   fnspec => (name [params*] prepost-map? exprs*)
+;;           | (name ([params*] prepost-map? exprs*)+)
+;;
+;; every production of which is written out below, with the local spelled like
+;; the enclosing view. Not driven, and deliberately: a `&` REST name in head
+;; position, because a rest seq is never a legal callee, so there is no correct
+;; program to protect.
+;; ---------------------------------------------------------------------------
+
+;; Multi-arity — the shape the audit reproduced.
+(h/defview arity-lists [_]
+  (letfn [(apply-it
+            ([arity-lists] (arity-lists))
+            ([arity-lists x] (arity-lists x)))]
+    [:div (apply-it (fn [& _] "ok"))]))
+
+;; A prepost map sits exactly where a beginner's eye expects the next arity, so
+;; a walker that counts positions rather than reading them goes wrong here.
+(h/defview arity-prepost [_]
+  (letfn [(guarded
+            ([arity-prepost] {:pre [(some? arity-prepost)]} (arity-prepost))
+            ([arity-prepost x] (arity-prepost x)))]
+    [:div (guarded (fn [& _] "ok"))]))
+
+;; Destructuring inside an arity list binds the same names it binds anywhere.
+(h/defview arity-destructured [_]
+  (letfn [(unpack
+            ([{:keys [arity-destructured]}] (arity-destructured))
+            ([{:keys [arity-destructured] :as m} x]
+             (str (arity-destructured x) m)))]
+    [:div (unpack {:arity-destructured (fn [& _] "ok")})]))
+
+;; A variadic arity beside a fixed one: the FIXED parameters of the variadic
+;; arity are ordinary locals, `&` notwithstanding.
+(h/defview arity-variadic [_]
+  (letfn [(spread
+            ([arity-variadic] (arity-variadic))
+            ([arity-variadic & xs] (arity-variadic (count xs))))]
+    [:div (spread (fn [& _] "ok")) (spread (fn [& _] "ok") 1 2)]))
+
+;; An arity can bind nothing at all, and an EMPTY parameter vector beside a
+;; binding one must not stop the binding one being read.
+(h/defview zero-arity [_]
+  (letfn [(maybe
+            ([] "ok")
+            ([zero-arity] (zero-arity)))]
+    [:div (maybe) (maybe (fn [] "also ok"))]))
+
+;; `fn` has no docstring, so a leading string is an ordinary body expression —
+;; and an expression sitting where the next arity might have gone.
+(h/defview string-first [_]
+  (letfn [(described
+            ([string-first] "one argument" (string-first))
+            ([string-first x] "two arguments" (string-first x)))]
+    [:div (described (fn [& _] "ok"))]))
+
+;; Several fnspecs, mutually recursive. A binding in ANY fnspec silences the
+;; whole `letfn`, so only the multi-arity one binds the name here — otherwise
+;; the row would pass on its neighbour's coverage rather than its own.
+(h/defview mutual [_]
+  (letfn [(evens [f n] (if (zero? n) (f) (odds f (dec n))))
+          (odds
+            ([mutual] (mutual))
+            ([mutual n] (evens mutual n)))]
+    [:div (evens (fn [& _] "ok") 2)]))
+
+;; And a multi-arity fnspec nested inside another fnspec's body.
+(h/defview nested [_]
+  (letfn [(outer [x]
+            (letfn [(inner
+                      ([nested] (nested))
+                      ([nested y] (nested y)))]
+              (str (inner (fn [& _] x)) (inner (fn [& _] x) 1))))]
+    [:div (outer "ok")]))

--- a/implementation/hicasso/lint-fixtures/positive.cljs
+++ b/implementation/hicasso/lint-fixtures/positive.cljs
@@ -124,3 +124,21 @@
 
 (h/defview nameless-qualified-keyword-button [_]
   [:div [:app/button {:on-click [:panel/close]}]])
+
+;; ---------------------------------------------------------------------------
+;; A genuine self-call inside a MULTI-ARITY `letfn` still reports.
+;;
+;; Reading every arity's parameters (merged-PR audit #7804) has one risk in the
+;; opposite direction: a repair that treated a whole fnspec as "bound" would
+;; blind the check inside every `letfn` and nothing would notice, because
+;; silence is what this check does when it declines. `wrap` binds nothing
+;; spelled like the view, so this call is still a self-call and still an ERROR.
+;; ---------------------------------------------------------------------------
+
+(h/defview self-calling-through-letfn [{:keys [depth]}]
+  (letfn [(wrap
+            ([x] [:li x])
+            ([x y] [:li x y]))]
+    (if (zero? depth)
+      (wrap "leaf")
+      [:ul (wrap "deep" (self-calling-through-letfn {:depth (dec depth)}))])))

--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/README.md
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/README.md
@@ -60,12 +60,26 @@ ordinary Clojure:
   [:div.card (card)])
 ```
 
+A `letfn` fnspec is read as the `fn` tail it is — `letfn` expands each one to
+`(fn f …)` — so a local function's name and **every parameter of every arity**
+are locals, the multi-arity spelling included.
+
 Shadowing is read off the form in hand, because that is the only kind of fact
 available here: `api/resolve` answers `nil` for the view's own name — not yet a
 var when the hook runs — and never sees locals at all. A binding silences the
 entire form it heads, initialisers included, so a genuine self-call written in
 the initialiser of a `let` that goes on to bind the view's name is missed too.
 Missing one is the only way this check is allowed to be wrong.
+
+**Refuses to know** — and this direction is the one that costs you something —
+that a form *outside its roster* binds anything. Having no scope table, the
+hook recognises binding forms by name, and the roster is `let`-shaped forms
+(`let`, `loop`, `when-let`, `if-let`, `when-some`, `if-some`, `when-first`,
+`doseq`, `for`, `with-open`, `with-local-vars`, `binding`, `with-redefs`),
+`fn`/`fn*`/`hfn`, `letfn`, `catch` and `as->`. A local introduced by anything
+else — `dotimes`, `this-as`, a `reify` / `specify!` / `extend-type` method
+parameter, a `defmethod` parameter — is not seen, so calling one *does* report.
+Name your local something other than the view, or switch the check off.
 
 ### `:re-frame.hicasso/deferred-read` — warning
 

--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj
@@ -534,7 +534,11 @@
 
 (defn- fn-locals
   "The names a `fn` / `fn*` / `hfn` binds: its own optional name, and every
-  parameter of every arity."
+  parameter of every arity.
+
+  `children` is a `fn` TAIL — everything after the head — which is also
+  exactly what a `letfn` fnspec is, so `letfn` asks this rather than
+  re-deriving it."
   [children]
   (let [self   (token-sexpr (first children))
         forms  (if self (rest children) children)
@@ -566,18 +570,23 @@
         (or (contains? '#{fn fn*} core) (= 'hfn (hicasso-var head)))
         (fn-locals more)
 
-        ;; `(letfn [(f [x] …)] …)` binds each local function's NAME and its
-        ;; parameters — and the name sits in head position of its own form,
-        ;; which is precisely where a self-call is looked for.
+        ;; `(letfn [(f [x] …) (g ([x] …) ([x y] …))] …)` binds each local
+        ;; function's NAME — which sits in head position of its own form,
+        ;; precisely where a self-call is looked for — and every parameter of
+        ;; every arity.
+        ;;
+        ;; A fnspec IS a `fn` tail: `letfn` expands each one to `(fn f …)`, so
+        ;; the shapes it accepts are the shapes `fn` accepts, and `fn-locals`
+        ;; is asked instead of a second reading being written here. The second
+        ;; reading is what went wrong: it took a fnspec to be `[nm params]`
+        ;; and collected `params` only where that node was a VECTOR, which is
+        ;; the single-arity spelling and nothing else — a MULTI-ARITY fnspec's
+        ;; second node is the first arity LIST, so no arity's parameters were
+        ;; read and every use of one reported at ERROR (merged-PR audit #7804).
         (= 'letfn core)
         (if (api/vector-node? (first more))
           (into #{}
-                (mapcat (fn [f]
-                          (when (api/list-node? f)
-                            (let [[nm params] (:children f)]
-                              (into (if-let [s (token-sexpr nm)] #{s} #{})
-                                    (when (api/vector-node? params)
-                                      (bound-symbols params)))))))
+                (mapcat #(when (api/list-node? %) (fn-locals (:children %))))
                 (:children (first more)))
           #{})
 

--- a/implementation/hicasso/scripts/check_lint_export.py
+++ b/implementation/hicasso/scripts/check_lint_export.py
@@ -60,7 +60,7 @@ HOOK_FILE = os.path.join(EXPORT_DIR, "hooks", "re_frame", "hicasso.clj")
 # cannot see.
 EXPECTED = {
     # ERRORS -- true invariants (operator ruling, rf2-hic-022).
-    "direct-view-call":             [25],
+    "direct-view-call":             [25, 144],
     "function-in-head-position":    [99, 102, 105, 110, 114],
     # WARNINGS -- heuristics and assistance. Nothing blocks a build.
     "deferred-read":                [32, 37, 43],

--- a/implementation/hicasso/scripts/check_lint_export.py
+++ b/implementation/hicasso/scripts/check_lint_export.py
@@ -222,11 +222,13 @@ def _mutate(original, old, new):
 
 
 def self_test():
-    """Break the export three ways and prove the gate reds on each.
+    """Break the export one way at a time and prove the gate reds on each.
 
     A gate that has only ever been observed green is a gate nobody has tested.
-    These are the two controls run by hand when the checks were written, made
-    permanent, plus the packaging one.
+    The first cases are the controls run by hand while the checks were being
+    written, made permanent; the rest are the defects that reached main anyway,
+    each pinned by the mutation that would bring it back. No count is stated
+    here on purpose — the list grows, and a number in prose does not.
     """
     with open(HOOK_FILE, encoding="utf-8") as fh:
         original = fh.read()
@@ -256,6 +258,16 @@ def self_test():
         ("a self-call check blind to lexical shadowing reds", "hook",
          "  (into #{} (keep token-sexpr) (subforms node)))",
          "  (do node #{}))",
+         "direct-view-call"),
+        # The SECOND false ERROR (merged-PR audit #7804), and the reason this
+        # case reads a fnspec's TAIL rather than its name: the repair above
+        # took a `letfn` fnspec to be `[nm params]`, which is the single-arity
+        # spelling and nothing else, so no arity of a MULTI-ARITY fnspec was
+        # read and every use of one blocked the build again. Hand `fn-locals`
+        # the name alone and the grammar rows in the negative half must red.
+        ("a letfn fnspec read past its NAME reds", "hook",
+         "(fn-locals (:children %))",
+         "(fn-locals (take 1 (:children %)))",
          "direct-view-call"),
     ]
 


### PR DESCRIPTION
A `letfn` fnspec is a `fn` tail, so the walker asks `fn-locals` about it instead
of carrying a second, narrower reading of the same grammar.

## The defect

`locals-bound-by` read each fnspec as `[nm params]` and collected `params` only
where that second node was a **vector**. That is the single-arity spelling and
nothing else: a multi-arity fnspec's second node is the first arity **list**. So
no arity's parameters were recognised, and every use of a legal local reported
`re-frame.hicasso/direct-view-call` at ERROR — which the required lane runs with
`--fail-level error`, so the build stopped.

Reproduced against `origin/main` at the CI pin (`clj-kondo 2026.04.15`, via the
artefact's `:clj-kondo` alias — the npm binary on this machine is 2025.10.23 and
a pass from it would prove nothing):

```clojure
(h/defview card [_]
  (letfn [(invoke
            ([card] (card))
            ([card x] (card x)))]
    [:div (invoke (fn [& _] :ok))]))
```

```
probe.cljs:7:21: error: `card` is a view, so it is a hiccup HEAD rather than a function: write [card {…}]. …
probe.cljs:8:23: error: `card` is a view, so it is a hiccup HEAD rather than a function: write [card {…}]. …
probe.cljs:15:10: error: `genuine` is a view, so it is a hiccup HEAD rather than a function: write [genuine {…}]. …
linting took 512ms, errors: 3, warnings: 0
KONDO_EXIT=3
```

Rows 7 and 8 are the false ERRORs. Row 15 is a genuine self-call in the same
probe, so the check was not simply dead. After the repair only row 15 reports.

## The repair

```clojure
(= 'letfn core)
(if (api/vector-node? (first more))
  (into #{}
        (mapcat #(when (api/list-node? %) (fn-locals (:children %))))
        (:children (first more)))
  #{})
```

`letfn` expands each fnspec to `(fn f …)`, so a fnspec **is** a `fn` tail and
`fn-locals` already reads exactly that: an optional name, then either a
parameter vector or a run of arity lists. No second walker, no resolution, no
whole-program anything; the walker stays syntax-local and a binding still
silences the whole form it heads.

## The witness, derived from the grammar rather than from the fix

The previous repair's witness drove single-arity `letfn` and its PR body and the
export README claimed `letfn` parameters generally. So these rows come from
`letfn`'s grammar instead:

```
fnspec => (name [params*] prepost-map? exprs*)
        | (name ([params*] prepost-map? exprs*)+)
```

Each new row is written to be the **only** thing in its `letfn` binding the
view's name — a binding anywhere in the form silences the whole form, so a row
sharing a `letfn` with a covered neighbour would pass on the neighbour's
coverage rather than its own.

### Shapes driven

| Production | Row | False ERRORs at `origin/main` |
|---|---|---|
| single arity, plain parameter vector | `badge` (pre-existing) | 0 — already covered |
| the fnspec NAME in head position | `badge`, `zero-arity` | 0 — already covered |
| **multi-arity arity lists** | `arity-lists` | 2 |
| **a prepost map, in an arity list** | `arity-prepost` | 2 |
| **destructuring inside arity lists** (`:keys`, `:as`) | `arity-destructured` | 2 |
| **a variadic arity beside a fixed one** | `arity-variadic` | 2 |
| **an empty parameter vector among the arities** | `zero-arity` | 1 |
| **a leading string body form** (what people write as a docstring) | `string-first` | 2 |
| **several fnspecs, only the multi-arity one binding** | `mutual` | 1 |
| **a multi-arity fnspec nested in another's body** | `nested` | 2 |

14 false ERRORs before, 0 after. Driven by throwaway probe rather than committed
as fixtures, because each asserts "the hook does not crash" rather than a
finding: an empty binding vector `(letfn [] …)`; a non-list fnspec `(letfn [x] …)`,
which is illegal `letfn`; and metadata on a parameter vector — clj-kondo hands
the hook an unwrapped vector node, so metadata is not a distinct shape at this
layer (silent before and after).

`positive.cljs` gains the guard for the opposite direction: a genuine self-call
inside a multi-arity `letfn` that binds something else must still report. A
repair that treated a whole fnspec as bound would blind the check inside every
`letfn` and nothing would notice, because declining is what this check does when
it declines.

### Shapes NOT driven, and why

* **A `&` rest NAME in head position.** A rest parameter is a seq and never a
  legal callee, so there is no correct program to protect. The name is still
  collected (`bound-symbols` is a deliberate superset); it is the *fixed*
  parameters of a variadic arity that matter, and `arity-variadic` drives those.
* **A prepost map on a single-arity fnspec**, and **a leading string on a
  single-arity fnspec.** Both reduce to the single-arity vector branch plus one
  more body form, and a body form cannot move the parameter vector. The rows
  above drive both in the arity-list position, which is where a body form can
  actually be mistaken for an arity.
* **`letfn` inside a quotation.** `subforms` never descends into a quote node;
  the existing `quoted-hiccup` row covers that.
* **A fnspec with no parameters at all** — `(letfn [(f)] …)`, illegal `letfn`.
  Probed for non-crash only.

## Other arms whose coverage is narrower than their claim — reported, not fixed

The README says the check "refuses any call whose name has been **rebound**".
The roster it actually reads is finite, and six binding forms sit outside it.
Each of these reproduces as a false ERROR at the pin, **on this branch, after the
repair**:

| Form | Probe |
|---|---|
| `dotimes` | `(dotimes [v 3] (v))` |
| `this-as` | `(this-as v (v))` |
| `reify` method parameter | `(reify Object (toString [v] (str (v))))` |
| `specify!` method parameter | `(specify! (js-obj) Object (toString [v] (str (v))))` |
| `extend-type` method parameter | `(extend-type T Object (toString [v] (str (v))))` |
| `defmethod` parameter | `(defmethod mm :k [v] (v))` |

`dotimes` is one symbol in the `let-shaped` set; the rest are one small arm of
the same class as `catch` and `as->`. They are out of this bead's fence (the
brief: report, do not necessarily fix), so the README now states the roster's
finiteness plainly rather than leaving the broad claim standing.

Arms measured and found **not** narrower than their claim: `fn` / `fn*`
multi-arity, named multi-arity and with a prepost map; `hfn` parameters;
`catch`; `as->`; the whole `let`-shaped roster (`let`, `loop`, `doseq`, `for`
including its `:let` modifier and a `:when` between bindings, `if-let`,
`if-some`, `when-first`, `binding`, `with-redefs`); destructuring in the
`defview` argument vector, associative, sequential and `:as`; metadata on a
parameter vector or on the argument vector; quoted forms.

## One report the fix removes, on purpose

A genuine self-call inside a `letfn` whose *other* arity binds the view's name
is now missed:

```clojure
(h/defview c3 [{:keys [depth]}]
  (letfn [(wrap ([c3] [:li c3]) ([x y] [:li x y]))]
    [:ul (wrap "deep" (c3 {:depth (dec depth)}))]))   ; no longer reported
```

That is the documented direction — a binding silences the whole form it heads,
initialisers and all — and missing one is the only way this check is allowed to
be wrong. It reported before the repair only because *no* arity was read at all;
the report was correct by coincidence, and the coincidence came bundled with the
false ERRORs.

## The mutation, run by hand

The letfn arm reverted to its pre-repair reading, byte-exact, verified applied
before the gate was believed (`sha256` before `647947ee…3037`, after
`a78caa5d…6989`; `(fn-locals (:children %))` present: **False**;
`(let [[nm params] (:children f)]` present: **True**; `git diff --stat` 18
insertions / 4 deletions).

```
FAIL: Hicasso lint export gate

  lint-fixtures/negative.cljs:243:28 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `arity-lists` is a view, …
  lint-fixtures/negative.cljs:244:30 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `arity-lists` is a view, …
  lint-fixtures/negative.cljs:251:61 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `arity-prepost` is a view, …
  lint-fixtures/negative.cljs:252:32 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `arity-prepost` is a view, …
  lint-fixtures/negative.cljs:258:45 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `arity-destructured` is a view, …
  lint-fixtures/negative.cljs:260:19 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `arity-destructured` is a view, …
  lint-fixtures/negative.cljs:267:31 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `arity-variadic` is a view, …
  lint-fixtures/negative.cljs:268:36 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `arity-variadic` is a view, …
  lint-fixtures/negative.cljs:276:27 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `zero-arity` is a view, …
  lint-fixtures/negative.cljs:283:44 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `string-first` is a view, …
  lint-fixtures/negative.cljs:284:47 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `string-first` is a view, …
  lint-fixtures/negative.cljs:293:23 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `mutual` is a view, …
  lint-fixtures/negative.cljs:301:33 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `nested` is a view, …
  lint-fixtures/negative.cljs:302:35 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `nested` is a view, …
```

Restored byte-identically (`sha256` back to `647947ee…3037`, confirmed equal to
the pre-mutation digest) and the gate is green again. The same mutation is now
permanent in `--self-test` as *"a letfn fnspec read past its NAME reds"*.

## Tree-wide clj-kondo, at the CI pin

`clj-kondo 2026.04.15`, `lint.yml`'s exact path list, cold cache both sides,
`origin/main`'s `implementation/hicasso/` versus this branch's:

| | errors | warnings | finding lines |
|---|---|---|---|
| before | 0 | 4542 | 4699 |
| after | 0 | 4542 | 4699 |

`diff` of the sorted finding sets: **empty**. Matching PR #7804's standard, and
expected — nothing in the repo names a local after its enclosing view.

## Note for rf2-zzdg

`--self-test` now runs **five** mutation cases (it was four; `lint.yml`'s comment
still says three). `.github/workflows/lint.yml` is hot-zone and untouched here.
The self-test's own docstring no longer states a count, so it cannot go stale
again.

## Quality gates

Every gate foreground, to completion, never piped; exit codes captured on the
same command line as the gate. All logs written under this worktree and deleted
afterwards.

| Gate | Exit |
|---|---|
| `sh scripts/test-fast-pr.sh` (79 gates; `gate root: /c/Users/miket/code/re-frame2-worktrees/letfnarity-hic022`, `docs=true jvm=false node=true`) | **0** — `PASS fast PR spine` |
| `python scripts/check_lint_export.py` at the CI pin (2026.04.15) | **0** |
| `python scripts/check_lint_export.py --self-test` at the pin | **0** — five mutations + the unmutated export |
| the same pair inside the spine, at the npm binary's 2025.10.23 | **0** — the two versions agree on this surface |
| the plain corpus run (`hicasso/testbed`, inside `check()`) | **0** — quiet |
| tree-wide `clj-kondo 2026.04.15`, `lint.yml`'s path list, before | **0** — errors 0 / warnings 4542 |
| tree-wide `clj-kondo 2026.04.15`, `lint.yml`'s path list, after | **0** — errors 0 / warnings 4542, sorted diff empty |
| `python scripts/check_fast_pr_gap.py --list` | **0** — 95 required checks the spine does not decide |

The pinned runs go through the artefact's `:clj-kondo` alias rather than the
npm binary on PATH, which is 2025.10.23; a pass from a mismatched version proves
nothing either way (#7805).

Not run, and why:

* `scripts/test-jvm-implementation.sh` / `scripts/test-jvm-tools.sh` — the diff
  touches no JVM artefact source. The hook file is SCI data clj-kondo reads from
  a config directory and is on no classpath; `check_lint_export.py` is a checker,
  not a `deftest`, and is in no JVM roster.
* `mkdocs build --strict` — no file under `docs/` changed. The spine ran it
  anyway (the export README classifies as documentation surface) and it passed.
* `scripts/test-rigorous-local.sh` — release-sized sweep; nothing here reaches a
  build output or a bundle.
* Browser smokes — no runtime code changed; the export is lint-time only.
