### PR TITLE
docs: three refusal-and-mechanics truth fixes (rf2-z5ji, rf2-u2vz, rf2-kn67)

### DIFF
--- a/docs/design/hicasso/draft-guide/15-diagnostics.md
+++ b/docs/design/hicasso/draft-guide/15-diagnostics.md
@@ -160,19 +160,28 @@ never the message:
 
 ```clojure
 ;; ht is the test kit from 14-testing.md
-(defn badge [_props] [:span.badge "hi"])   ;; a plain defn — not a view
+(defn badge [_props] [:span.badge "hi"])       ;; a plain defn — not a view
+(defn card  [_props] [:div.card [badge {}]])   ;; …and here it is, in a head
 
 (defn refusal-id [f]
   (try (f) ::did-not-throw
        (catch :default e (:rf.error/id (ex-data e)))))
 
-(deftest plain-defn-head-refuses
-  (is (= :rf.error/hicasso-bad-head
-         (refusal-id #(ht/tree [badge {}] {:subs {}})))))
+(deftest plain-defn-child-head-refuses
+  (is (= :rf.error/hicasso-test-plain-fn-head
+         (refusal-id #(ht/tree [card {}] {:subs {}})))))
 ```
 
 Message text improves between releases; ids are frozen. A string assertion
 tests the message text, not the refusal.
+
+**The head that refuses is a child's.** `ht/tree`'s root form is headed by
+the body function the kit is about to run, so `[badge {}]` written as the
+root form is the accepted spelling — it runs, and nothing refuses. Only a
+plain `defn` reached *inside* the tree is a mistake, and which id you catch
+tells you which layer caught it: at L2 the kit answers with its own
+`:rf.error/hicasso-test-plain-fn-head`, and the same child mounted at L3 is
+the runtime's `:rf.error/hicasso-bad-head` from the table above.
 
 ## Production erasure
 

--- a/docs/design/hicasso/product/complaints.md
+++ b/docs/design/hicasso/product/complaints.md
@@ -142,7 +142,7 @@ rowed in the Hicasso section, and is the single live id without the
 | `:rf.error/hicasso-test-not-a-native-form` | gave an L1 projection a form whose head is not a tag keyword | — |
 | `:rf.error/hicasso-test-not-a-render-form` | gave an L2 render something other than a hiccup form | — |
 | `:rf.error/hicasso-test-not-an-intent` | gave the L1 marker materializer something other than an intent vector | — |
-| `:rf.error/hicasso-test-plain-fn-head` | put a plain function in a hiccup head inside an L2 tree | — |
+| `:rf.error/hicasso-test-plain-fn-head` | put a plain function in a hiccup head inside an L2 tree | ch15 |
 | `:rf.error/hicasso-test-position-is-not-a-handler` | fired at a position that lowers to something other than a function | — |
 | `:rf.error/hicasso-test-react-is-opaque` | let a raw React element reach the L2 semantic tree | — |
 | `:rf.error/no-frame-context` | (corpus-owned) rendered a Hicasso boundary whose React context carries no frame | ch03, ch09, ch10, ch17, ch19 |

--- a/docs/design/hicasso/product/lanes/testing-xray.md
+++ b/docs/design/hicasso/product/lanes/testing-xray.md
@@ -10,7 +10,7 @@ Testing and diagnostics are product surfaces, not documentation afterthoughts. S
 |---|---|---|
 | L0 | event handlers, subscriptions, state transitions | pure CLJ/CLJS tests |
 | L1 | codecs, intents, controlled-field/presence laws, native-form expansion and ABI helpers | pure data/property and macro-expansion tests |
-| L2 | hook-free Hicasso bodies and owned Hicasso children | restricted semantic-tree harness |
+| L2 | one hook-free Hicasso body; it expands no children of its own, and a nested boundary is recorded as the call it is | restricted semantic-tree harness |
 | L3 | React lifecycle, hooks, context, refs, foreign hosts and native components | mounted React DOM tests |
 | L4 | IME, caret, focus, hydration, layout, performance | Chromium, Firefox, and WebKit witnesses |
 

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -143,14 +143,19 @@ relying on CI"). A silent skip fails review.
 Four rules about the mechanics. Each is here because it cost real hours, and
 none of them is obvious from the gate command itself.
 
-- **Foreground, to completion.** A worker that backgrounds a long gate and ends
-  its turn waiting for the completion notification can wait forever: the
+- **Foreground, to completion — within the harness's ten-minute ceiling.** A
+  worker that backgrounds a long gate and ends its turn waiting for the
+  completion notification can wait forever: the
   notification does not always arrive, and a turn that has ended has nothing
   left to wake. The worker then reports "standing by" through idle tick after
   idle tick while its branch sits unmoved — four such incidents in a single day,
   every one recovered intact the moment somebody asked it for a status. If you
   background a gate anyway, **poll its log on a timer**; never end a turn
-  waiting to be woken.
+  waiting to be woken. For the full spine that polling is the normal path and
+  not the exception: the harness hard-kills a foreground command at ten minutes
+  (exit 143) and `scripts/test-fast-pr.sh` needs roughly twenty-five, so "to
+  completion" is not on offer for it however the brief is worded. That ceiling
+  killed four spine runs in one night before it was written down here.
 - **Invoke a backgrounded gate by its ABSOLUTE path.** The gate scripts derive
   their repo root from `${BASH_SOURCE[0]}`, which is relative when the
   invocation is — and a `cd <worktree> && sh scripts/…` does not reliably keep
@@ -164,7 +169,12 @@ none of them is obvious from the gate command itself.
 - **Never pipe a gate through `tail`, `head` or `grep`.** A pipeline's exit
   status is its *last* command's, so a red runner reads green and the PR claims
   a pass it never got. Redirect to a log file, echo the runner's own exit code
-  explicitly, and quote that number in the PR body.
+  explicitly, and quote that number in the PR body — with the redirect and the
+  echo on **one command line, in one shell**, as the snippet below writes them.
+  A separate invocation starts a *fresh* shell whose `$?` is not the gate's but
+  whatever that shell last did, which is typically the `cd`: silent, and it
+  yields a plausible zero. That is this bullet's own defeat by a second route,
+  so a paraphrase that drops the single line drops the rule.
 - **Put *every* gate artefact where git ignores it** — the log and the exit-code
   file both. `*.log`, `*.exit` and `*-exit.txt` all are, so this leaves nothing
   behind:


### PR DESCRIPTION
Three small documentation truth-fixes. No runtime source touched; no new refusal id minted.

## rf2-z5ji — the diagnostics chapter named the wrong refusal for the wrong position

**Reproduced, and it is worse than the bead's suspicion.** The example at
`15-diagnostics.md:169-171` asserted `:rf.error/hicasso-bad-head` for a plain `defn`
written at the ROOT of an `ht/tree` call. Read at the source rather than reasoned out:

- `implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs:1186-1223` — `render`'s
  root head is the body function it is about to run. It substitutes a minted head's
  retained body, then refuses only when the head is **not** a fn
  (`:rf.error/hicasso-test-not-a-body`). A plain `defn` IS a fn, so at the root it is the
  accepted spelling: it runs, and **nothing refuses**. The old assertion would have
  returned `::did-not-throw`.
- `test.cljs:990-1002` — the plain-function refusal is a CHILD-position rule, and inside an
  L2 tree the kit raises **its own** id, `:rf.error/hicasso-test-plain-fn-head`, not the
  runtime's. Its recovery sentence says so in as many words: *"Mint the boundary with
  `h/defview`, or — to run this body at L2 — pass it as the ROOT form of `render`."*
- `implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs:3011-3040` — `vec->element`
  is where `:rf.error/hicasso-bad-head` fires, i.e. when the same child is interpreted by
  the runtime (L3), not by the kit.

So the example was wrong twice: wrong position, and wrong layer's id. It now puts the
helper in a child head, asserts the id that actually fires there, and a following
paragraph states the root case plainly — the absence is documented rather than papered
over with an invented refusal. The catalogue table row for `hicasso-bad-head` is unchanged
and still correct.

**Neighbours checked, all correct — every one describes a head *inside* a hiccup tree,
which is exactly where `hicasso-bad-head` fires:**

| Checked | Verdict |
|---|---|
| `15-diagnostics.md:149` (catalogue table row) | correct — "a plain `defn` in head position", no claim about the root |
| `02-views-and-reads.md:76-77` (the `[row-icon {:kind :urgent}]` don't-example) | correct — child position in a body |
| `02-views-and-reads.md:330` (troubleshooting row) | correct |
| `06-lists-and-collections.md:297` (troubleshooting row) | correct — "only minted views, native tags, fragments and hosts are heads" |
| `glossary.md:76` (inline-helper entry) | correct |
| `15-diagnostics.md:147-154`, the remaining catalogue rows | checked each against `complaints.md` and Spec 009; no other position error found |

Not fixed, and not mine: the draft guide spells the kit `ht/tree` with `{:subs …}` where the
shipped kit is `render` with `:reads`. That divergence is already recorded as
`REWRITE-NOTES.md` item 13 and is a naming reconciliation, not a truth defect — I kept the
guide's own spelling so this diff stays about position and id.

`complaints.md`'s row for `hicasso-test-plain-fn-head` moves from `—` to `ch15`, because
`—` is defined in that file as "no page names it yet" and now one does. The gate's R8 runs
in the direction that matters (a cited chapter must name the id) and passes.

## rf2-u2vz — the last copy of the corrected claim

`lanes/testing-xray.md:13` still described L2's scope as "hook-free Hicasso bodies **and
owned Hicasso children**". Wording taken from `specification.md:319` (§9, landed by #7809)
rather than phrased afresh — inventing a third phrasing is the fault this family exists to
stop. `git grep` confirms this was the last copy: the only other statements of the claim are
§9 itself and the kit's own docstring at `test.cljs:916-924`, which already agree.

## rf2-kn67 — the method rule whose fallback was unstated

Two clauses in `dispatch-prompt-template.md`, no restructuring, snippet untouched:

- The "never pipe a gate" bullet now says the redirect and the echo go on **one command
  line, in one shell**, and why: a separate invocation starts a fresh shell whose `$?` is
  whatever *that* shell last did — typically the `cd` — which is silent and answers a
  plausible zero. That is the bullet's own fail-open reached by a second route, so a
  paraphrase that drops the single line drops the rule.
- The "foreground, to completion" bullet now carries the measured ceiling: the harness
  hard-kills a foreground command at ten minutes (exit 143) and `scripts/test-fast-pr.sh`
  needs roughly twenty-five, so its existing "poll its log on a timer" fallback is the
  spine's **normal path**, not an exception. The bold lead was extended to carry the
  ceiling too, because the lead is the part that gets copied — which is this bead's own
  lesson.

"Four rules about the mechanics" is still four bullets.

## Quality gates

| Gate | Exit | Notes |
|---|---|---|
| `sh <WT>/scripts/test-fast-pr.sh` | **0** | `gate root: /c/Users/miket/code/re-frame2-worktrees/diagtruth-z5ji` — my worktree. Classified `docs=true jvm=false node=false`. Backgrounded by absolute path and polled to completion in-turn (185s); log and exit file deleted afterwards. Final line `PASS fast PR spine`. |
| `python scripts/check_doc_slugs.py` | **0** | inside the spine, and standalone. Coverage proved, below. |
| `mkdocs build --strict` | **0** | inside the spine. |
| `python implementation/hicasso/scripts/check_complaint_catalogue.py` | **0** | not in the spine (CI-only), so run by hand: *59 live, 12 reserved, 1 pending retirement, 0 retired; every live row is emitted and rowed in Spec 009, every reservation is unbuilt, every anchor resolves.* |

**`check_doc_slugs.py` is silent on success, so coverage was proved rather than assumed.**
A bogus anchor planted in one file per edited tree:

```
2 broken anchor link(s) found:

  BROKEN ANCHOR: docs\design\hicasso\draft-guide\15-diagnostics.md:178 -> glossary.md#rf2-z5ji-no-such-anchor
      (target: docs\design\hicasso\draft-guide\glossary.md)
  BROKEN ANCHOR: docs\the-mayor-method\dispatch-prompt-template.md:169 -> README.md#rf2-kn67-no-such-anchor
      (target: docs\the-mayor-method\README.md)
```

exit **1**. Restored with `git checkout --` (byte-identical by construction; `git status`
clean afterwards) and re-run: exit **0**.

**The three gate facts, verified rather than assumed.**
`mkdocs.yml:32-37` `exclude_docs` lists `design/hicasso/`, so mkdocs covers **neither**
`15-diagnostics.md` nor `complaints.md` nor `testing-xray.md` — and the build proves it:
`site/design` does not exist. `docs/the-mayor-method/` is in no exclusion and IS built:
`site/the-mayor-method/dispatch-prompt-template/index.html` exists, and the build's own
not-in-nav INFO names the file. So mkdocs is the right gate for the rf2-kn67 edit and the
wrong one for the other two.

**Tables: nothing validates them, so counted by hand.** Two tables edited, one cell each.
`testing-xray.md` ladder — header 3 columns (`Tier | Scope | Correct tool`), separator 3,
all five body rows 3, edited L2 row 3. `complaints.md` live table — header 3 columns
(`Complaint | Raised when you | Taught in`), separator 3, edited row 3. The catalogue table
in `15-diagnostics.md` was not touched.

**Gates not run, with reasons.** `test-jvm-implementation.sh`, `test-jvm-tools.sh` and
`test-rigorous-local.sh` — the diff is three markdown files under `docs/`; no CLJS, CLJC or
CLJ source, no `deps.edn`, no build config, so no artefact's compile or test surface is
reachable from it, and the spine's own classifier agreed (`jvm=false node=false`).
`clj-kondo` — CI pins 2026.04.15 and a differently-versioned local pass proves nothing;
there is no Clojure source in the diff either way.

Residue: no `*.log` or `*.exit` left in the worktree; no `node_modules` link was created.
