### PR TITLE
fix(hicasso): evidence schema v2 + the whole projected identity in Xray row keys (rf2-hic-023)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/evidence.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/evidence.cljs
@@ -111,8 +111,36 @@
   A consumer validates this FIRST and refuses an envelope it does not
   recognise. Versioning an evidence surface is not ceremony: the
   alternative is tools inferring the shape from the fields that happen to
-  be present, which makes every field an accidental ABI."
-  :re-frame.hicasso.evidence/v1)
+  be present, which makes every field an accidental ABI.
+
+  ## v1 → v2, and why a version that lies is worse than none
+
+  The #7789 audit repair changed the WIRE SHAPE without changing this
+  literal, and the merged-PR audit of #7802 called that out as the one
+  defect a version exists to prevent. Four changes, each of which a v1
+  parser reads as something it is not:
+
+  | Field | v1 | v2 |
+  |---|---|---|
+  | a boundary key element | `[frame-id query]` | `[frame-id sub-id projected-query]` |
+  | an intent row's frame | `:frame-id`, singular | `:frames`, a vector |
+  | `:latest-reads` | bare sub-ids | `{:sub-id :query :frame-id}` maps |
+  | the `:host` projection | commit/paint/attempt | `:visibility` and `:hidden-retained` besides |
+
+  A consumer pinned to v1 and handed a v2 envelope would take the sub-id
+  in a key element for the query, iterate a map where it expected a
+  keyword, and read an absent `:frame-id` as a frameless intent. The pin's
+  whole purpose is that an evolved shape MISMATCHES rather than being
+  mis-parsed as exact, so it is the version — not the reader — that has to
+  move.
+
+  **There is no v1 acceptance path and no compatibility adapter.** This is
+  pre-alpha; the honest bump is a bump, and a shim would recreate exactly
+  the silent misread the pin refuses. A v1-stamped envelope is a
+  MISMATCH at every consumer, and
+  `hicasso-helpers-cljs-test/the-superseded-v1-shape-is-refused-rather-than-mis-parsed`
+  is the witness that it still bites."
+  :re-frame.hicasso.evidence/v2)
 
 (def producer
   "Which substrate produced the envelope.

--- a/implementation/hicasso/src/re_frame/hicasso/tool.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/tool.cljs
@@ -361,7 +361,7 @@
   says how far to trust the roster. `nil` in a production build.
 
       (tool/read-mounted-boundaries)
-      ;; => {:schema     :re-frame.hicasso.evidence/v1
+      ;; => {:schema     :re-frame.hicasso.evidence/v2
       ;;     :producer   :re-frame/hicasso
       ;;     :read       :mounted-boundaries
       ;;     :scope      :mounted-boundaries

--- a/implementation/hicasso/test/re_frame/hicasso/evidence_schema_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/evidence_schema_cljs_test.cljs
@@ -215,7 +215,11 @@
         (is (= :incomplete-envelope (refusal-id o)))
         (is (= [{:defect :missing :key key}] (defect-ids o))))))
   (testing "a foreign schema, producer or read is refused rather than parsed"
-    (doseq [[key v] [[:schema :re-frame.hicasso.evidence/v2]
+    ;; v1 is the SUPERSEDED version, not a hypothetical one: the shape moved
+    ;; under it in the #7789 repair and the stamp moved with it in the #7802
+    ;; repair. Naming the real predecessor here is what makes the refusal a
+    ;; statement about this door's own history rather than about a spelling.
+    (doseq [[key v] [[:schema :re-frame.hicasso.evidence/v1]
                      [:producer :re-frame/somebody-else]
                      [:read :whatever]]]
       (let [o (outcome #(evidence/envelope (assoc good-envelope key v)))]

--- a/tools/xray/spec/027-Hicasso-Evidence.md
+++ b/tools/xray/spec/027-Hicasso-Evidence.md
@@ -312,6 +312,49 @@ governing promise is amended instead, which is the honest half of the choice
 the audit offered. Hidden-retained is never inferred from an empty census, and
 a subscribed row is never labelled visible.
 
+### A row's key and testid carry the WHOLE projected identity
+
+The producer exports each key element as `[frame-id sub-id projected-query]`
+and names the frame on every edge and explanation row. The panel must spend
+all three, and for one increment it did not: `boundary-slug` ignored the
+frame, `attribution-rows` slugged every edge by sub-id alone, and the Reads
+view printed neither the projected query nor the frame. Rows that are
+genuinely different facts therefore shared a React key and a DOM testid, and
+read identically on screen (audit #7802):
+
+```clojure
+;; on merge 7c45f3ca9
+(map boundary-slug [{:key [[:frame/a :row [:row 1]]]}
+                    {:key [[:frame/b :row [:row 1]]]}])   ;=> ["row-row-1" "row-row-1"]
+(map :slug (attribution-rows …))                          ;=> ["row" "row"]
+;;   for [:row 1] in frame A and [:row 2] in frame B
+```
+
+**Frames are isolated contexts**, so the first pair is two applications'
+boundaries, not one boundary counted twice — collapsing them is the same
+class of error as collapsing two empties. `hicasso-helpers/read-key-str` is
+now the one place a projected read identity becomes a string, and
+`boundary-slug`, `read-slug` and the Reads and Why rows all go through it.
+
+| Surface | Carries |
+|---|---|
+| a boundary testid / React key | every key element's frame, sub-id and projected query |
+| a Reads row testid / React key | the edge's frame, sub-id and projected query |
+| the Reads row on screen | the projected query as its label, and the frame beside the fan-out |
+| the Why row on screen | the boundary label, and the frame beside it |
+
+**Projected fields only.** The query arrives already projected and is printed
+as found; recovering the raw query to make a slug more readable would undo
+the producer's redaction at the last step, which is the escape the #7789
+audit caught. A frame whose value is `:unknown` renders the `unknown` chip
+rather than the word, exactly as the Mounted view does.
+
+The identity remains as fine as the egress policy allows and no finer. Where
+a policy elides two queries whole, two edges sharing a frame and a
+registration id project to one identity — the producer's documented ceiling,
+which the mounted census resolves by grouping and the Reads roster inherits
+because it prints the cell table as it stands.
+
 ### Every absence is a chip, and the five chips differ
 
 `hicasso-helpers/loss-chip` turns a loss (or an `:unknown` value) into
@@ -379,6 +422,6 @@ Adding it moved six governance pins, each of which fails the build on drift:
 |---|---|---|
 | `re-frame.hicasso.evidence-schema-cljs-test` | node | every shape in which a projection would claim more than it knows is refused, each with a positive control |
 | `re-frame.hicasso.tool-reads-cljs-test` | node (reactive substrate) | the four reads over real committed boundaries; the seeded-value privacy witness for a return value AND for a query argument; two frames sharing a sub id with asymmetric windows; the dispatch-ordered, fragment-merged intent stream; determinism; the production-nil arm |
-| `…panels.hicasso-helpers-cljs-test` | node + JVM | the five absences and the empties are pairwise distinct — including the four per-view empties; labels and testids are built from the projected key; two query variants do not collapse; the schema pin; row projections |
-| `…panels.hicasso-cljs-test` | node (reactive substrate) | the four views answer on a running app; the loss states render under distinct testids, driven between two real window states; a sensitive query argument reaches neither the page nor a testid; each view renders its own empty; the seam reshapes nothing |
+| `…panels.hicasso-helpers-cljs-test` | node + JVM | the five absences and the empties are pairwise distinct — including the four per-view empties; labels and testids are built from the projected key; a row key carries the WHOLE projected identity, so two frames' boundaries over one query do not collide; two query variants do not collapse; the superseded v1 stamp is refused rather than mis-parsed; the schema pin; row projections |
+| `…panels.hicasso-cljs-test` | node (reactive substrate) | the four views answer on a running app; the loss states render under distinct testids, driven between two real window states; a sensitive query argument reaches neither the page nor a testid; the Reads and Why rows carry the frame on the page and in the testid; each view renders its own empty; both the superseded and an unknown stamp render the mismatch; the seam reshapes nothing |
 | `feature_matrix/scenarios.cjs` | browser | the tab reaches a real panel root in the shell sweep |

--- a/tools/xray/spec/027-Hicasso-Evidence.md
+++ b/tools/xray/spec/027-Hicasso-Evidence.md
@@ -41,7 +41,7 @@ Every envelope carries seven axes. Three identify it; four state how far to
 trust it.
 
 ```clojure
-{:schema     :re-frame.hicasso.evidence/v1   ; validated FIRST
+{:schema     :re-frame.hicasso.evidence/v2   ; validated FIRST
  :producer   :re-frame/hicasso               ; the schema is adapter-neutral
  :read       :mounted-boundaries             ; which question this answers
  :scope      :mounted-boundaries             ; what it covers
@@ -97,6 +97,36 @@ producer makes any bump silently "supported", so an evolved shape would be
 mis-parsed as exact and the version boundary would be nominal. A projection
 stamped a schema (or a producer) this build was not taught suppresses rows
 and renders the mismatch banner.
+
+### v1 → v2: the version tells the truth or it is worse than nothing
+
+The #7789 audit repair changed the wire shape and left the stamp at `v1`, so
+for one increment the pin accepted — as exact — a shape it had never been
+taught. The merged-PR audit of #7802 called that the one defect a version
+exists to prevent, and producer and consumer now stamp `v2` in lockstep.
+
+| Field | v1 | v2 |
+|---|---|---|
+| a boundary key element | `[frame-id query]` | `[frame-id sub-id projected-query]` |
+| an intent row's frame | `:frame-id`, singular | `:frames`, a vector |
+| `:latest-reads` | bare sub-ids | `{:sub-id :query :frame-id}` maps |
+| the `:host` projection | commit / paint / attempt-outcome | `:visibility` and `:hidden-retained` besides |
+
+Each row is a silent misread waiting to happen: a v1 parser takes the sub-id
+in a key element for the query, iterates a map where it expected a keyword,
+and reads an absent `:frame-id` as a frameless intent. That is why a version
+that lies is worse than no version — it converts a loud failure into a quiet
+wrong answer.
+
+**There is no v1 acceptance path and no compatibility adapter.** This is
+pre-alpha; a shim would restore exactly the mis-parse the pin refuses. A
+v1-stamped envelope is a mismatch at the data layer
+(`hicasso_helpers_cljs_test/the-superseded-v1-shape-is-refused-rather-than-mis-parsed`,
+with a non-vacuity row proving the same envelope parses under the current
+stamp) and on the page
+(`hicasso_cljs_test/an-unparseable-schema-is-MISMATCH-and-suppresses-rows`,
+which drives both the superseded `v1` and an unknown future `v99`, because the
+pin is exact rather than a floor).
 
 ---
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/hicasso.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/hicasso.cljs
@@ -233,10 +233,19 @@
                    ^{:key (:slug row)}
                    [:li {:data-testid (str "rf-xray-" panel-id "-edge-" (:slug row))
                          :style       row-style}
-                    [:div [:span {:style {:font-family mono-stack}}
-                           (hh/format-id (:sub-id row))]
+                    ;; The PROJECTED QUERY, not the bare sub-id. `[:row 1]`
+                    ;; and `[:row 2]` are one registration and two cells, and
+                    ;; a view naming only the registration printed them as two
+                    ;; identical lines (audit #7802).
+                    [:div [:span {:style {:font-family mono-stack}} (:label row)]
+                     (loss-chip (str "rf-xray-" panel-id "-edge-" (:slug row) "-frame")
+                                (:frame-chip row))
                      [:span {:style (assoc detail-style :display "inline" :margin-left "8px")}
-                      (str "fan-out " (:fan-out row))]]
+                      (string/join " · "
+                                   (remove nil?
+                                           [(when-not (hh/unknown? (:frame-id row))
+                                              (str "frame " (hh/format-id (:frame-id row))))
+                                            (str "fan-out " (:fan-out row))]))]]
                     [:div {:data-testid (str "rf-xray-" panel-id "-edge-" (:slug row) "-readers")
                            :style       detail-style}
                      (str "read by " (string/join ", " (map :label (:readers row))))]])
@@ -292,7 +301,15 @@
                    ^{:key (:slug row)}
                    [:li {:data-testid (str "rf-xray-" panel-id "-explain-" (:slug row))
                          :style       row-style}
-                    [:div [:span {:style {:font-family mono-stack}} (:label row)]]
+                    ;; The frame rides beside the label. Frames are isolated
+                    ;; contexts, so one query read in two of them is two facts
+                    ;; — and their labels are identical (audit #7802).
+                    [:div [:span {:style {:font-family mono-stack}} (:label row)]
+                     (loss-chip (str "rf-xray-" panel-id "-explain-" (:slug row) "-frame")
+                                (:frame-chip row))
+                     (when-not (hh/unknown? (:frame row))
+                       [:span {:style (assoc detail-style :display "inline" :margin-left "8px")}
+                        (str "frame " (hh/format-id (:frame row)))])]
                     ;; THE PROVEN HALF — off the cells' own epoch stamps.
                     [:div {:data-testid (str "rf-xray-" panel-id "-explain-" (:slug row) "-proven")
                            :style       detail-style}

--- a/tools/xray/src/day8/re_frame2_xray/panels/hicasso_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/hicasso_helpers.cljc
@@ -333,6 +333,30 @@
   [{:keys [sub-id query]}]
   (read-label [nil sub-id query]))
 
+(defn read-key-str
+  "The WHOLE projected read identity as one string: frame, registration
+  id, projected query — in the order the producer exports them.
+
+  Every part is load-bearing and the frame is the one that was missing
+  (rf2-hic-023, audit #7802). Frames are isolated contexts, so a read of
+  `[:row 1]` in frame A and a read of `[:row 1]` in frame B are two
+  different facts about two different applications, not one fact seen
+  twice. Dropping the frame here made them one string, which made them one
+  React key and one DOM testid.
+
+  Projected fields only. The query arrives already projected and is
+  printed as found; re-admitting the raw query to make a slug more
+  readable would undo the producer's redaction at the last step, which is
+  the exact escape the #7789 audit caught."
+  [[frame-id sub-id query]]
+  (str (pr-str frame-id) "-" (pr-str sub-id) "-" (pr-str query)))
+
+(defn read-slug
+  "A testid-safe slug for ONE projected read identity — see
+  [[read-key-str]] for why all three parts are in it."
+  [read-identity]
+  (id-slug (read-key-str read-identity)))
+
 (defn boundary-label
   "A boundary's edge set as one line — the identity the runtime actually
   retains, spelled out.
@@ -346,17 +370,21 @@
     "(reads nothing)"))
 
 (defn boundary-slug
-  "A stable testid slug for a boundary key.
+  "A stable testid slug for a boundary key — the WHOLE projected key, one
+  [[read-key-str]] per element.
 
-  Built from the sub-id AND the projected query, never the raw query: a
-  testid is a string a browser assertion selects on and a screenshot
-  carries, so deriving one from an application's arguments would put
-  those arguments in the DOM after the schema had projected them out of
-  the data. Including the sub-id keeps two wholly-redacted reads
-  selectable apart."
+  Never the raw query: a testid is a string a browser assertion selects on
+  and a screenshot carries, so deriving one from an application's
+  arguments would put those arguments in the DOM after the schema had
+  projected them out of the data. The sub-id keeps two wholly-redacted
+  reads selectable apart, and the FRAME keeps two frames' boundaries apart
+  — it was dropped, so `[[:frame/a :row [:row 1]]]` and
+  `[[:frame/b :row [:row 1]]]` both slugged `row-row-1`, giving two
+  genuinely different boundaries one React key and one testid
+  (audit #7802)."
   [{:keys [key]}]
   (if (seq key)
-    (id-slug (string/join "-" (map (fn [[_f sid q]] (str (pr-str sid) "-" (pr-str q))) key)))
+    (id-slug (string/join "-" (map read-key-str key)))
     "reads-nothing"))
 
 ;; ---------------------------------------------------------------------------
@@ -409,19 +437,30 @@
 
 (defn attribution-rows
   "The Reads view's rows: one per live subscription cell, with its
-  fan-out and the boundaries holding it."
+  fan-out and the boundaries holding it.
+
+  The row's identity is the edge's WHOLE projected identity — frame,
+  registration id, projected query — in both the label and the slug. It
+  was the sub-id alone, so `[:row 1]` in frame A and `[:row 2]` in frame B
+  were two rows named `row` under one testid, and the view printed neither
+  the query nor the frame that told them apart (audit #7802). Every field
+  it prints is one the producer already projected; nothing raw is
+  recovered to make a row legible."
   [envelope]
   (if-not (supported? envelope)
     []
     (mapv (fn [edge]
-            {:sub-id   (:sub-id edge)
-             :slug     (id-slug (:sub-id edge))
-             :query    (:query edge)
-             :frame-id (:frame-id edge)
-             :epoch    (:epoch edge)
-             :fan-out  (:fan-out edge)
-             :readers  (mapv (fn [b] {:label (boundary-label b)
-                                      :slug  (boundary-slug b)}) (:readers edge))})
+            (let [read-id [(:frame-id edge) (:sub-id edge) (:query edge)]]
+              {:sub-id     (:sub-id edge)
+               :slug       (read-slug read-id)
+               :label      (read-label read-id)
+               :query      (:query edge)
+               :frame-id   (:frame-id edge)
+               :frame-chip (loss-chip nil (:frame-id edge))
+               :epoch      (:epoch edge)
+               :fan-out    (:fan-out edge)
+               :readers    (mapv (fn [b] {:label (boundary-label b)
+                                          :slug  (boundary-slug b)}) (:readers edge))}))
           (:edges envelope))))
 
 (defn intent-rows
@@ -458,6 +497,12 @@
                :label        (boundary-label (:boundary ex))
                :slug         (boundary-slug (:boundary ex))
                :frame        (:frame ex)
+               ;; The frame is rendered, not merely carried. Two boundaries
+               ;; reading the same query in two frames have the same label,
+               ;; and frames are isolated contexts — so without the frame on
+               ;; screen the reader is looking at two identical lines that
+               ;; are two different facts (audit #7802).
+               :frame-chip   (loss-chip nil (:frame ex))
                :instances    (:instances ex)
                :snapshot     (:snapshot ex)
                :peak-epoch   (:peak-epoch ex)

--- a/tools/xray/src/day8/re_frame2_xray/panels/hicasso_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/hicasso_helpers.cljc
@@ -52,8 +52,18 @@
   shape would be mis-parsed as exact and the version boundary would be
   nominal. Pinning a literal makes a producer that evolves its shape a
   DETECTABLE mismatch until this build is taught the new shape and this
-  pin is bumped in lockstep."
-  :re-frame.hicasso.evidence/v1)
+  pin is bumped in lockstep.
+
+  **v2 is that lockstep bump, and it is the point of the mechanism.** The
+  #7789 audit repair evolved the wire shape — projected key elements,
+  plural intent frames, `:latest-reads` as maps, new host fields — while
+  leaving the stamp at v1, so for one increment this pin was accepting a
+  shape it had NOT been taught and parsing it as exact (audit #7802). A
+  version that lies is worse than no version: it converts a loud failure
+  into a silent misread. There is no v1 acceptance path here — pre-alpha
+  needs no compatibility adapter, and a shim would restore the very
+  mis-parse the pin exists to refuse."
+  :re-frame.hicasso.evidence/v2)
 
 (def consumed-producer
   "The producing substrate this tab renders.

--- a/tools/xray/test/day8/re_frame2_xray/panels/hicasso_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/hicasso_cljs_test.cljs
@@ -307,12 +307,25 @@
         txt  (text-of tree)
         ids  (testids tree)]
     (is (contains? ids "rf-xray-hicasso-attribution"))
-    (is (contains? ids "rf-xray-hicasso-edge-htab-left"))
     (is (string/includes? txt "fan-out 2") ":htab/left is read by both boundaries")
     (is (string/includes? txt "fan-out 1") ":htab/right by one")
     (is (string/includes? txt "[:htab/left] + [:htab/right]")
         "each edge names the boundaries holding it, by the same key the
          mounted roster uses")
+    (testing "each row carries its WHOLE projected identity in the testid (audit #7802)"
+      (let [edge-ids (into #{} (filter #(and (string/starts-with? % "rf-xray-hicasso-edge-")
+                                             (not (string/ends-with? % "-readers"))))
+                           ids)]
+        (is (= 2 (count edge-ids)) "two cells, two testids")
+        (is (every? #(string/includes? % "hicasso-tab-app") edge-ids)
+            (str "an edge testid must carry the FRAME as well as the sub id — "
+                 "frames are isolated contexts, so two frames holding one sub id "
+                 "are two rows and not one seen twice"))
+        (is (some #(string/includes? % "htab-left") edge-ids))
+        (is (some #(string/includes? % "htab-right") edge-ids))))
+    (testing "and the frame is on the page, not merely in the testid"
+      (is (string/includes? txt (str "frame " (hh/format-id app-frame)))
+          "a reader looking at two identically-labelled rows needs the frame"))
     (a) (b)))
 
 (deftest the-intents-view-answers-what-was-dispatched
@@ -353,7 +366,14 @@
       (testing "UNCORRELATED: the cause is a labelled absence, beside a lead count"
         (is (some #(string/ends-with? % "-cause") ids))
         (is (some #(string/ends-with? % "-loss-uncorrelated") ids))
-        (is (string/includes? txt "lead"))))
+        (is (string/includes? txt "lead")))
+      (testing "the FRAME is on the row, and in its testid (audit #7802)"
+        (is (string/includes? txt (str "frame " (hh/format-id app-frame)))
+            (str "two boundaries reading one query in two frames have the same "
+                 "label, so without the frame the reader sees one line twice"))
+        (is (some #(and (string/starts-with? % "rf-xray-hicasso-explain-")
+                        (string/includes? % "hicasso-tab-app"))
+                  ids))))
     (release)))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/panels/hicasso_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/hicasso_cljs_test.cljs
@@ -246,23 +246,32 @@
 
 (deftest an-unparseable-schema-is-MISMATCH-and-suppresses-rows
   (setup!)
-  ;; A producer that has EVOLVED: real rows, stamped a version this build was
-  ;; not taught. Rows are suppressed rather than mis-parsed — an evolved shape
-  ;; read as though it were the expected one is worse than no rows at all.
-  (let [release  (mount! (fn [_] (h/sub [:htab/left]) nil))
-        evolved  (assoc (tool/read-mounted-boundaries)
-                        :schema :re-frame.hicasso.evidence/v99)]
-    (is (seq (:boundaries evolved))
-        "NON-VACUITY: the envelope being refused really does carry rows")
-    (with-redefs [reads/evidence (constantly {:mounted-boundaries evolved
-                                              :read-attribution   evolved
-                                              :intents            evolved
-                                              :explain-render     evolved})]
-      (let [tree (show! :mounted)
-            ids  (testids tree)]
-        (is (contains? ids "rf-xray-hicasso-mismatch"))
-        (is (not (contains? ids "rf-xray-hicasso-empty-mounted")))
-        (is (string/includes? (text-of tree) "not taught to parse"))))
+  ;; Real rows, stamped a version this build was not taught. Rows are
+  ;; suppressed rather than mis-parsed — a shape read as though it were the
+  ;; expected one is worse than no rows at all.
+  ;;
+  ;; BOTH DIRECTIONS, because the pin is exact rather than a floor. `/v99` is
+  ;; a producer that evolved ahead of this build. `/v1` is the SUPERSEDED
+  ;; stamp, and it is the one that matters: the #7789 repair moved the wire
+  ;; shape and left the stamp behind, so for one increment a v1 envelope
+  ;; carrying a v2 shape parsed as exact (audit #7802). There is no v1
+  ;; acceptance path — the predecessor mismatches on the page, like anything
+  ;; else this build was not taught.
+  (let [release (mount! (fn [_] (h/sub [:htab/left]) nil))]
+    (doseq [stamp [:re-frame.hicasso.evidence/v1
+                   :re-frame.hicasso.evidence/v99]]
+      (let [other (assoc (tool/read-mounted-boundaries) :schema stamp)]
+        (is (seq (:boundaries other))
+            "NON-VACUITY: the envelope being refused really does carry rows")
+        (with-redefs [reads/evidence (constantly {:mounted-boundaries other
+                                                  :read-attribution   other
+                                                  :intents            other
+                                                  :explain-render     other})]
+          (let [tree (show! :mounted)
+                ids  (testids tree)]
+            (is (contains? ids "rf-xray-hicasso-mismatch") (str stamp))
+            (is (not (contains? ids "rf-xray-hicasso-empty-mounted")) (str stamp))
+            (is (string/includes? (text-of tree) "not taught to parse"))))))
     (release)))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/panels/hicasso_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/hicasso_helpers_cljs_test.cljc
@@ -171,13 +171,46 @@
 (deftest the-schema-pin-is-consumer-owned-and-exact
   (testing "an envelope stamped anything else degrades rather than mis-parses"
     (is (true? (hh/supported? mounted)))
-    (is (false? (hh/supported? (assoc mounted :schema :re-frame.hicasso.evidence/v2))))
+    (is (false? (hh/supported? (assoc mounted :schema :re-frame.hicasso.evidence/v99))))
     (is (false? (hh/supported? (assoc mounted :producer :re-frame/freehand))))
     (is (false? (hh/supported? nil))))
   (testing "an unsupported envelope yields NO rows — never a half-parsed one"
     (doseq [f [hh/mounted-rows hh/attribution-rows hh/intent-rows hh/explain-rows]]
-      (is (= [] (f (assoc mounted :schema :re-frame.hicasso.evidence/v2))))
+      (is (= [] (f (assoc mounted :schema :re-frame.hicasso.evidence/v99))))
       (is (= [] (f nil))))))
+
+(deftest the-superseded-v1-shape-is-refused-rather-than-mis-parsed
+  ;; MERGED-PR AUDIT #7802, RESIDUAL 1. The #7789 repair evolved the wire
+  ;; shape — key elements from `[frame-id query]` to
+  ;; `[frame-id sub-id projected-query]`, intent rows from a singular
+  ;; `:frame-id` to a plural `:frames`, `:latest-reads` from bare sub-ids to
+  ;; `{:sub-id :query :frame-id}` maps, plus new host fields — and left the
+  ;; stamp at v1. So for one increment this pin accepted, as EXACT, a shape
+  ;; it had never been taught: a version that lies, which is worse than no
+  ;; version because it turns a loud refusal into a silent misread.
+  ;;
+  ;; The pin only earns its keep if the predecessor now MISMATCHES. There is
+  ;; no v1 acceptance path and no compatibility adapter to route around this.
+  (let [v1 (assoc mounted :schema :re-frame.hicasso.evidence/v1)]
+    (testing "the pin names the version whose shape this build actually parses"
+      (is (= :re-frame.hicasso.evidence/v2 hh/consumed-evidence-schema)
+          (str "the wire shape and the stamp move together or the pin is "
+               "nominal — change one and this row says so")))
+
+    (testing "NON-VACUITY: the identical envelope under the current stamp parses"
+      (is (true? (hh/supported? mounted)))
+      (is (= 2 (count (hh/mounted-rows mounted)))
+          (str "if this row fails, the refusals below are passing against an "
+               "envelope that would have yielded nothing anyway")))
+
+    (testing "the superseded stamp is a MISMATCH, not an older dialect"
+      (is (false? (hh/supported? v1)))
+      (is (= :mismatch (hh/presence v1 false))
+          "and it renders the mismatch banner, not an empty roster"))
+
+    (testing "and every view suppresses its rows rather than half-parsing them"
+      (doseq [f [hh/mounted-rows hh/attribution-rows hh/intent-rows hh/explain-rows]]
+        (is (= [] (f v1)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The row projections

--- a/tools/xray/test/day8/re_frame2_xray/panels/hicasso_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/hicasso_helpers_cljs_test.cljc
@@ -264,7 +264,85 @@
                               :readers [boundary-a boundary-b]}]})
         [row] (hh/attribution-rows e)]
     (is (= 3 (:fan-out row)))
+    (is (= "[:todo 7]" (:label row))
+        "the row names the projected QUERY, which is what a reader tells cells apart by")
+    (is (nil? (:frame-chip row)) "the frame IS known here, so no chip")
     (is (= ["[:todo 7]" "[:todo 7] + [:user 1]"] (mapv :label (:readers row))))))
+
+(deftest a-row-key-carries-the-WHOLE-projected-identity
+  ;; MERGED-PR AUDIT #7802, RESIDUAL 2. `boundary-slug` ignored the frame and
+  ;; `attribution-rows` slugged every edge by sub-id alone, so rows that are
+  ;; genuinely different facts shared a React key and a DOM testid. The direct
+  ;; witness on merge 7c45f3ca9:
+  ;;
+  ;;   boundary keys [[:frame/a :row [:row 1]]] and [[:frame/b :row [:row 1]]]
+  ;;     -> slugs ["row-row-1" "row-row-1"]
+  ;;   attribution rows for [:row 1] in frame A and [:row 2] in frame B
+  ;;     -> slugs ["row" "row"]
+  ;;
+  ;; Frames are ISOLATED CONTEXTS, so the first pair is two applications'
+  ;; boundaries and not one boundary counted twice.
+  (testing "two frames' boundaries over one query are two keys, not one"
+    (let [a {:parent nil :key [[:frame/a :row [:row 1]]]}
+          b {:parent nil :key [[:frame/b :row [:row 1]]]}]
+      (is (not= (hh/boundary-slug a) (hh/boundary-slug b))
+          (str "both slugged `row-row-1` before the frame was in the key — a "
+               "browser assertion selecting one silently matched the other, and "
+               "React saw one child where there were two"))
+      (is (string/includes? (hh/boundary-slug a) "frame-a"))
+      (is (string/includes? (hh/boundary-slug b) "frame-b"))))
+
+  (testing "and the projected query is in the key too, so two variants stay apart"
+    (is (not= (hh/boundary-slug {:parent nil :key [[:frame/a :row [:row 1]]]})
+              (hh/boundary-slug {:parent nil :key [[:frame/a :row [:row 2]]]}))))
+
+  (testing "the Reads rows differ in frame AND in query, and say so on the row"
+    (let [e (envelope :read-attribution
+                      {:scope :read-edges
+                       :edges [{:sub-id :row :query [:row 1] :frame-id :frame/a
+                                :epoch 1 :fan-out 1 :readers []}
+                               {:sub-id :row :query [:row 2] :frame-id :frame/b
+                                :epoch 1 :fan-out 1 :readers []}]})
+          [a b] (hh/attribution-rows e)]
+      (is (not= (:slug a) (:slug b))
+          "both slugged `row` before — one testid over two subscriptions")
+      (is (= ["[:row 1]" "[:row 2]"] [(:label a) (:label b)])
+          "and the view printed only `:row`, so the rows also READ the same")
+      (is (= [:frame/a :frame/b] [(:frame-id a) (:frame-id b)])
+          "the frame is on the row for the renderer to print")))
+
+  (testing "the Why rows carry the frame, because two frames' labels are equal"
+    (let [ex (fn [frame q]
+               {:boundary {:parent nil :key [[frame :row q]]} :frame frame
+                :instances 1 :snapshot 9 :peak-epoch 5
+                :latest-reads [{:sub-id :row :query q :frame-id frame}]
+                :cause :unknown
+                :loss {:reason :uncorrelated :dropped :unknown}
+                :candidates []})
+          [a b] (hh/explain-rows (envelope :explain-render
+                                           {:complete? false
+                                            :loss {:reason :uncorrelated :dropped :unknown}
+                                            :explanations [(ex :frame/a [:row 1])
+                                                           (ex :frame/b [:row 1])]}))]
+      (is (= (:label a) (:label b))
+          "NON-VACUITY: the labels really are identical, so the frame is the
+           only thing that can tell these two rows apart on screen")
+      (is (not= (:slug a) (:slug b)))
+      (is (= [:frame/a :frame/b] [(:frame a) (:frame b)]))
+      (is (nil? (:frame-chip a)) "a known frame renders as itself, not as a chip")))
+
+  (testing "NOTHING RAW returns through the slug — only projected fields"
+    (let [row (first (hh/attribution-rows
+                       (envelope :read-attribution
+                                 {:scope :read-edges
+                                  :edges [{:sub-id :todo :query :rf/redacted
+                                           :frame-id :app/main :epoch 1
+                                           :fan-out 1 :readers []}]})))]
+      (is (= ":todo :rf/redacted" (:label row))
+          "a wholly redacted query is named by its registration id and the sentinel")
+      (is (string/includes? (:slug row) "rf-redacted")
+          "the slug is built from the sentinel the producer sent, never from a
+           raw query recovered to make the row legible"))))
 
 (deftest intent-rows-carry-an-id-and-an-arity-and-no-arguments
   (let [e (envelope :intents


### PR DESCRIPTION
Repairs the two bounded residuals the merged-PR audit of #7802 left in the same
evidence/Xray owner. Bead: rf2-hic-023. Nothing here touches the Pair migration
(open rf2-hic-076), and nothing touches the producer surfaces the audit reviewed
clean: the redaction, the frame-scoped lead search, the dispatch ordering and
fragment merge, the per-view empties, the host-opaque lifecycle wording.

## Residual 1 — the wire shape changed and the version did not

**Reproduced.** On `origin/main` the producer stamped
`:re-frame.hicasso.evidence/v1`, `hicasso-helpers/consumed-evidence-schema`
pinned that same literal, and Spec 027 called it v1 — while #7802 had already
changed boundary key elements from `[frame-id query]` to
`[frame-id sub-id projected-query]`, intent rows from a singular `:frame-id` to
a plural `:frames`, `:latest-reads` from bare sub-ids to
`{:sub-id :query :frame-id}` maps, and added host fields.

That defeats the consumer-owned pin on its own purpose-built grounds. The pin's
docstring says an evolved shape must MISMATCH rather than be mis-parsed as
exact; a version that lies converts a loud failure into a silent misread.

Producer and consumer now stamp **v2**, in lockstep, in the four places the
literal lives plus the producer's own foreign-schema fixture. **No compatibility
adapter and no v1 acceptance path** — pre-alpha, and a shim would restore
exactly the mis-parse the pin refuses.

The witness is that the pin still bites, which a rename alone would not
establish. `the-superseded-v1-shape-is-refused-rather-than-mis-parsed` feeds the
consumer a v1-stamped v2 payload and asserts `supported?` is false, `presence`
is `:mismatch`, and all four row projections answer `[]` — with a non-vacuity
row proving the identical envelope parses under the current stamp. On the page,
`an-unparseable-schema-is-MISMATCH-and-suppresses-rows` now drives both the
superseded `v1` and an unknown future `v99`, because the pin is exact rather
than a floor.

## Residual 2 — Xray dropped part of the projected identity

**Reproduced verbatim, on merge `7c45f3ca9`, before any change:**

```
:boundary-slugs [row-row-1 row-row-1]
:attribution-slugs [row row]
```

for boundary keys `[[:frame/a :row [:row 1]]]` / `[[:frame/b :row [:row 1]]]`,
and for attribution rows `[:row 1]` in frame A / `[:row 2]` in frame B. Distinct
rows shared a React key and a DOM testid, and the Reads renderer printed neither
the projected query nor the frame, so they also read identically.

Frames are isolated contexts, so the first pair is two applications' boundaries,
not one counted twice. `read-key-str` is now the ONE place a projected read
identity becomes a string, and `boundary-slug`, the new `read-slug`, the Reads
rows and the Why rows all go through it. The Reads view prints the projected
query as its label with the frame beside the fan-out; the Why view prints the
frame beside the boundary label, as an `unknown` chip when the frame is
unknown — the same shape the Mounted view already used.

**Only projected fields.** A wholly redacted query slugs from the sentinel the
producer sent, asserted directly, so nothing raw returns through the slug.

### What I declined, and why

The identity stays as fine as the egress policy allows and no finer. Where a
policy elides two queries whole, two edges sharing a frame and a registration id
still project to one identity. That is the producer's documented ceiling — the
mounted census resolves it by grouping, and the Reads roster inherits it because
it prints the cell table as it stands. Disambiguating with an arbitrary ordinal
would put a number on the page that names nothing, so it is recorded in the spec
instead. The audit's finding was dropped fields, and the dropped fields are back.

## Mutation proof

Each residual reverted, the focused suite re-run, the red quoted, then restored
byte-identically and re-run green.

**Residual 1** — both literals back to `v1` (`tools/xray` JVM, 4 failures):

```
FAIL in (the-superseded-v1-shape-is-refused-rather-than-mis-parsed)
the superseded stamp is a MISMATCH, not an older dialect
expected: (false? (hh/supported? v1))
  actual: (not (false? true))

FAIL in (the-superseded-v1-shape-is-refused-rather-than-mis-parsed)
and it renders the mismatch banner, not an empty roster
expected: (= :mismatch (hh/presence v1 false))
  actual: (not (= :mismatch :live))

FAIL in (the-superseded-v1-shape-is-refused-rather-than-mis-parsed)
and every view suppresses its rows rather than half-parsing them
expected: (= [] (f v1))
  actual: (not (= [] [{:boundary {:parent nil, :key [[:app/main :todo [:todo 7]]]},
                       :label "[:todo 7]", :slug "todo-todo-7", :instances 3, ...
```

The third is the defect itself: the v1 stamp accepted, and the v2 shape parsed
under it.

**Residual 2** — frame dropped from `read-key-str`, edge slug back to the sub-id
(`tools/xray` JVM, 6 failures). The red is the collision, not a proxy for it:

```
FAIL in (a-row-key-carries-the-WHOLE-projected-identity)
two frames' boundaries over one query are two keys, not one
expected: (not= (hh/boundary-slug a) (hh/boundary-slug b))
  actual: (not (not= "row-row-1" "row-row-1"))

FAIL in (a-row-key-carries-the-WHOLE-projected-identity)
the Reads rows differ in frame AND in query, and say so on the row
both slugged `row` before — one testid over two subscriptions
expected: (not= (:slug a) (:slug b))
  actual: (not (not= "row" "row"))

FAIL in (a-row-key-carries-the-WHOLE-projected-identity)
NOTHING RAW returns through the slug — only projected fields
expected: (string/includes? (:slug row) "rf-redacted")
  actual: (not (string/includes? "todo" "rf-redacted"))
```

## Spec

`tools/xray/spec/027-Hicasso-Evidence.md` records the v1 to v2 bump with the
four-row shape delta and the no-shim ruling, and a new *A row's key and testid
carry the WHOLE projected identity* section with the reproduced collision, the
surface table, the projected-fields-only rule and the stated identity ceiling.
The envelope example and the two test-coverage rows are updated. Anchors and
table column counts checked by hand — every table is internally consistent, and
no new cross-references were introduced.

## Quality gates

| Gate | Exit |
|---|---|
| `scripts/test-fast-pr.sh` (`gate root` = this worktree; `docs=true jvm=false node=true`) | 0 |
| `implementation` CLJS node suite (`npm run test:cljs`) — 13022 tests / 65804 assertions | 0 |
| `tools/xray` JVM (`clojure -M:test`) — 1287 tests / 6033 assertions | 0 |
| `python scripts/check_doc_slugs.py` | 0 |
| `python scripts/check_skill_xray_tab_inventory_drift.py --verbose` (10 Dynamic tabs verified) | 0 |

Gates NOT run, and why:

- **JVM tier of the spine** — the spine classified this diff `jvm=false`, so the
  `tools/xray` JVM lane was run directly and is reported above.
  `implementation/hicasso` declares no JVM tests (`implementation/hicasso/deps.edn`).
- **Focused `:node-test-hicasso` build** — subsumed by construction. `hicasso/test`
  is on the always-on `:node-test` source paths and the hicasso suites match its
  `cljs-test$` regexp, so `npm run test:cljs` above ran them; no npm script or CI
  job invokes the focused id.
- **Browser lanes, bundle-isolation, perf-bundle, prod-elision, adapter smokes,
  Xray feature matrix, mcp-conformance, other tool JVM suites** — the remaining
  gap the spine itself enumerates (`python scripts/check_fast_pr_gap.py --list`,
  95 checks). This diff reaches no browser surface, no bundle boundary and no
  production build; the Xray feature matrix asserts the tab reaches a panel root,
  which no testid change here removes.

One note for the reviewer: the first spine run on a loaded box produced 142
spurious `changed-surfaces` reds — every `bash -lc` classify call, and even a
`git ls-files`, failing to spawn. The mayor checkout passed the same harness
322/322 concurrently, a single classify call reproduced clean, and the re-run on
a quiet box is the exit-0 above. This diff touches no `.cjs` script, no workflow
and no `.sh`.

## Scope

Within the existing schema, helpers and panel tests, per the audit's fence. No
new store, no new framework, no new retention mechanism, no new knob. Untouched:
`spec/*` (top level), `implementation/package.json`, `.github/workflows/*`,
`docs/design/hicasso/**` — all held by other branches in flight.
