### PR TITLE
perf(ci): stop the changed-surfaces suite spawning a login shell per case (rf2-fal5)

### DIFF
--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -18,23 +18,78 @@ function test(name, fn) {
   tests.push({ name, fn });
 }
 
+// Relative POSIX path, resolved against REPO_ROOT as the child's cwd — the same
+// form every other suite in this directory uses, and the one that works
+// unchanged on Windows, macOS and Linux.
+const SURFACES_SCRIPT = './.github/scripts/report-changed-surfaces.sh';
+
+// rf2-fal5 — memo table for classify(). The classifier reads NOTHING but its
+// argument list when paths are passed explicitly (the `git diff` discovery
+// branch is unreachable in that mode), so for a fixed checkout it is a pure
+// function and the same path list can only ever produce the same verdicts.
+// Measured on this suite: 447 invocations over 235 distinct argument lists.
+const classifyCache = new Map();
+
+/**
+ * Classify one path list and return the classifier's key -> "true"/"false" map.
+ *
+ * rf2-fal5 — TWO spawn economies, and the suite's reliability rests on both.
+ *
+ * NOT A LOGIN SHELL. This used to build a quoted command string and hand it to
+ * `bash -lc`. A login shell sources /etc/profile and every /etc/profile.d/*.sh
+ * before it reaches the command, each of which forks children of its own — so
+ * one classification cost a whole profile evaluation, and this suite ran
+ * hundreds. Measured on the Windows host: 713ms per `bash -lc` against 75ms for
+ * spawning the script as bash's own argv, a 9.5x difference in wall clock and a
+ * far larger one in PROCESS CREATIONS, which is what actually ran out. Twice,
+ * on different diffs and different worktrees, the msys2 fork emulation gave way
+ * under concurrent load and printed the mechanism outright —
+ * `dofork: child -1 ... exit code 0xC0000142` (STATUS_DLL_INIT_FAILED) then
+ * `fork: retry: Resource temporarily unavailable` — surfacing as an exit-127
+ * child that never started, on a DIFFERENT case each run, which is how it was
+ * told apart from an assertion. Be precise about what is established: a
+ * deliberate load test (18k login shells, three concurrent copies of this
+ * suite) did NOT recreate that crash, so what this change rests on is the
+ * measured cost above, not a reproduction. `_playground-sci-inputs.test.cjs`
+ * recorded the same finding one file over (56s -> 3s for 144 classifications)
+ * and reached for the same remedy.
+ *
+ * Passing the script as argv also retires the hand-rolled shell quoting the
+ * command string needed: there is no shell to quote for. That is the
+ * shell-free posture `_script-spawn-policy.test.cjs` already requires of every
+ * launcher in this directory, applied to the suites beside them.
+ *
+ * MEMOIZED. Distinct cases legitimately re-classify the same exemplar —
+ * `spec/006-ReactiveSubstrate.md` and `implementation/core/src/re_frame/
+ * core.cljc` are the controls for a dozen arms each — and re-running the
+ * classifier for an answer already in hand buys nothing. The cached verdict is
+ * frozen so a caller that mutates it fails loudly here rather than poisoning a
+ * later case.
+ *
+ * NEITHER economy drops a case, weakens an assertion or merges two path lists:
+ * every call still gets the classifier's real verdict for its own arguments.
+ */
 function classify(...files) {
-  const quote = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`;
-  const command = ['./.github/scripts/report-changed-surfaces.sh', ...files.map(quote)].join(' ');
+  const key = JSON.stringify(files);
+  if (classifyCache.has(key)) return classifyCache.get(key);
   const env = { ...process.env };
   delete env.GITHUB_OUTPUT;
-  const out = execFileSync('bash', ['-lc', command], {
+  const out = execFileSync('bash', [SURFACES_SCRIPT, ...files], {
     cwd: REPO_ROOT,
     env,
     encoding: 'utf8',
   });
-  return Object.fromEntries(
-    out
-      .trim()
-      .split(/\r?\n/)
-      .filter(Boolean)
-      .map((line) => line.split('=')),
+  const result = Object.freeze(
+    Object.fromEntries(
+      out
+        .trim()
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .map((line) => line.split('=')),
+    ),
   );
+  classifyCache.set(key, result);
+  return result;
 }
 
 // rf2-k9ekz — Story/Xray browser Playwright gate trigger is narrowed
@@ -3721,12 +3776,10 @@ test('a docs/spec-only change does NOT arm cljs_browser (negative — scope disc
 // invoke the script's local discovery branch (HEAD^ HEAD) with no explicit
 // paths, so they exercise the exact Git-derived path the matrix cannot.
 
-const SCRIPT_PATH = path.join(
-  REPO_ROOT,
-  '.github',
-  'scripts',
-  'report-changed-surfaces.sh',
-);
+// The same file classify() spawns, as an absolute path: this branch READS the
+// script's bytes to pipe into a scratch repo rather than executing it in place.
+// Derived from the one constant so the two cannot drift apart.
+const SCRIPT_PATH = path.join(REPO_ROOT, SURFACES_SCRIPT);
 
 // Run a git command against a scratch repo, with GIT_* inherited from a hook
 // context stripped so the temp repo is never confused with the real worktree.


### PR DESCRIPTION
## What this is

rf2-fal5 — `scripts/test-fast-pr.sh` could not complete on the Windows host: it cleared its always-on repo-invariant steps and then died inside `npm run test:script-policy` at `implementation/scripts/_changed-surfaces.test.cjs`, with `Command failed: bash -lc ./.github/scripts/report-changed-surfaces.sh <path>`. Two independent workers reported it on different diffs and different worktrees, and the failing CASE differed between runs — so it was never an assertion.

The suite classifies one path list per case by spawning the classifier. Every one of those spawns was a **login** shell (`bash -lc`), which sources `/etc/profile` and every `/etc/profile.d/*.sh` — each forking children of its own — before it reaches the one-line command.

## Measured, on the host that fails

| | spawns | distinct arg lists | wall clock |
|---|---:|---:|---:|
| base, quiet host | 447 | 235 | 478.3s |
| base, under deliberate load | 447 | 235 | **920.7s** |
| this branch, under the same load | 245 | 235 | **82.6s** |

Per invocation, measured directly (20 iterations each, quiet host):

| form | ms/spawn |
|---|---:|
| `bash -lc "<quoted command>"` | 713 |
| `bash -c "<quoted command>"` | 114 |
| `bash <script> <argv…>` | **75** |

447 × 713ms is ~319 seconds of pure shell startup, and thousands of process creations, for work that costs ~18s and 235 of them. The 245 on this branch is 235 memoized classifications plus the 10 `bash -s` spawns the git-discovery block makes, which are unchanged.

## The fix, and where it sits

At the CALL, not in a retry, and not in the harness.

1. **Spawn the script as bash's argv** instead of building a command string for a login shell. No profile evaluation, and no hand-rolled shell quoting either — there is no shell to quote for. This is the shell-free posture `_script-spawn-policy.test.cjs` already requires of every launcher in this directory.
2. **Memoize on the argument list.** Passed explicit paths the classifier reads nothing but its arguments (the `git diff` discovery branch is unreachable in that mode), so for a fixed checkout it is a pure function. Distinct cases legitimately re-classify the same exemplar — `spec/006-ReactiveSubstrate.md` and `implementation/core/src/re_frame/core.cljc` are the controls for a dozen arms each. Cached verdicts are frozen so a caller that mutates one fails loudly here rather than poisoning a later case.

No retry was added. A retry would have hidden genuine classifier failures behind the same code path, and after these two economies there was nothing left for it to hide.

`_playground-sci-inputs.test.cjs` recorded the identical finding one file over — "a `bash -lc` per file sources the login profile and cost 56s for 144 files; one `bash -c` driver looping over `"$@"` is ~3s" — which is the prior art this follows.

**Cross-platform:** the login shell was pure overhead on Mac and Linux too. Both economies are platform-neutral; nothing is gated on the platform, and the POSIX path gets strictly faster and simpler.

## Equivalence

Byte-identical classifier output, old form vs new, over:

* 9 hand-picked path lists including multi-file cases and paths containing spaces, parentheses and a single quote — 9/9 identical;
* a deterministic sample of 150 REAL tracked paths — every 35th of the 5,269 tracked files, so the sample spans every classified tree — **150/150 identical, 0 mismatches**.

## Teeth — the suite still catches a real misclassification

Nothing here weakens, skips or loosens an assertion, and no case is dropped: 324 tests before, 324 after, same names. Demonstrated rather than asserted, in a throwaway detached worktree so the in-flight gate could not be disturbed.

**Break** — comment out the single `ui_gates=true` line in the classifier's `implementation/core/*)` arm (rf2-vxgfnd.209), the arm that schedules G-13 for any core runtime change:

```
FAIL Core observation-port change schedules G-13 (ui_gates true) (rf2-vxgfnd.209)
AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:

'false' !== 'true'

    at .../implementation/scripts/_changed-surfaces.test.cjs:235:10
FAIL Core router/drain change schedules G-13 (ui_gates true) (rf2-vxgfnd.209)
FAIL Core frame/scheduler change schedules G-13 (ui_gates true) (rf2-vxgfnd.209)
FAIL Core facade change schedules G-13 (ui_gates true) (rf2-vxgfnd.209)
changed-surfaces tests: 4 failed.
```

exit 1, four named rows, each naming the bead whose guarantee was broken.

**Restore** — `git checkout --` the classifier; `git hash-object` returns `b9035b6654beb77ed25bc9347757964d06427d9a`, identical to the pre-break hash, and `git status --porcelain` is empty. Byte-identical, not merely equivalent.

**Re-run** — `changed-surfaces tests: 324 passed.`, exit 0.

## Reproduction — read this before merging

**The crash signature did not reproduce on this host, and this PR does not claim it did.** What reproduced, and what the change is justified by, is the COST — measured, not inferred.

What was tried, deliberately, on the failing host (Windows 11, Git-Bash `GNU bash 5.2.37(1)-release (x86_64-pc-msys)`, node v24.13.0, 63GB RAM, ~620 processes and ~23 pre-existing node/bash processes from other agents already resident at the start):

* three overlapping load waves of dedicated workers spawning `bash -lc` in a tight loop — 8 workers × 400MB ballast, then 8 × 300MB, then 10 with no ballast, **18,289 login shells in total, 0 spawn failures**;
* **three concurrent copies of `_changed-surfaces.test.cjs` on BASE code**, i.e. 3 × 447 login shells interleaved, which is the "two agents both running the spine" shape both original reports were under;
* a 150-path classifier sweep instrumented to print `status`/`signal`/`stderr` on any child that fails to start;
* the full `scripts/test-fast-pr.sh` on top of all of it;
* free physical memory driven from 14.3GB down to 4.1GB at the peak.

Across those 18,289 deliberate login-shell spawns, plus 1,341 from the three base suite runs and 150 from the equivalence sweep, no `dofork` / `0xC0000142` / `Resource temporarily unavailable` ever appeared. So this is **not** a reproduction of the reported crash, and anyone reading this later should not record it as one.

One adjacent data point, unsolicited and worth having: partway through, an ordinary `bash` heredoc in this session died on its own with `child_copy: cygheap read copy failed, 0x800000000..0x80000DFD0` then `fatal error - couldn't create signal pipe, Win32 error 5`. That is the same msys2 fork emulation failing under the same load, in the same failure family as the reported `dofork` / `0xC0000142`, on a command that had nothing to do with this suite. It corroborates that the host's fork path is what gives way under load, which is exactly the resource this change stops consuming — but it is corroboration, not the reproduction that was asked for.

What it IS, on base code and under that load:

| run | spawns | wall clock | exit |
|---|---:|---:|---:|
| base, quiet host | 447 | 478.3s | 0 |
| base, under load #1 | 447 | 920.7s | 0 |
| base, under load #2 | 447 | 1003.9s | 0 |
| base, under load #3 | 447 | 1006.0s | 0 |
| **this branch, same load** | **245** | **82.6s** | **0** |

One suite taking 15-17 minutes of almost pure process creation is the same fact as the crash, seen from the side that a healthy host survives: the reported hosts were doing this and their fork emulation stopped coping. The fix is therefore NOT by inspection — it is 713ms vs 75ms per spawn, 447 vs 235 spawns, and 920s vs 83s under identical concurrent load, all measured. But the causal step from "far fewer, far cheaper spawns" to "the reported crash cannot recur" is an inference, and it is the mayor's call whether that is enough.

## Quality gates

Run from the worker worktree `C:/Users/miket/code/re-frame2-worktrees/spawnfix-fal5`, never piped, exit code captured on the same command line.

| gate | exit | note |
|---|---:|---|
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`, zero `FAIL` lines, `gate root: /c/Users/miket/code/re-frame2-worktrees/spawnfix-fal5`. Tiers `docs=false jvm=false node=true` — what the classifier reports for this diff. Run **under the deliberate concurrent load described above**: this is the witness the bead asked for, the spine completing on the host where it could not. `test:cljs` compiled 2,234 files with 0 warnings and reported `0 failures, 0 errors`; per-ns isolation passed all 17 namespaces (196 tests, 731 assertions). |
| `node implementation/scripts/_changed-surfaces.test.cjs` (the changed suite, alone) | 0 | 324 passed. Re-run on the FINAL tree after the last (comment-only) amend, so this table and the pushed HEAD describe the same bytes. Also 324 passed inside the spine's `test:script-policy`. |
| classifier-output equivalence, old form vs new | 0 | 9/9 hand-picked lists + 150/150 sampled tracked paths, byte-identical. |
| teeth witness (break → red → restore → green) | 1 then 0 | 4 named FAIL rows, then byte-identical restore, then 324 passed. |

Not run, and why:

* **JVM tier** (`scripts/test-jvm-implementation.sh`, `scripts/test-jvm-tools.sh`) — the classifier reports `implementation_jvm=false` for this diff, so the spine skipped the tier by design. The diff is one Node test-harness file; it puts nothing on a JVM classpath.
* **Browser / Playwright lanes, bundle-isolation, perf-bundle, mcp-conformance, Xray feature matrix** — in no tier of the spine at all (its own header says so), and unreachable from a change to how a Node suite spawns a shell.
* **`mkdocs build --strict`** — no `docs/**` file is touched.
* **`scripts/test-rigorous-local.sh`** — the release-sized sweep; nothing in this diff is release-shaped.
