### PR TITLE
feat(hicasso): the L3 mounted test facade (rf2-hic-027)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_mounted_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_mounted_dom_cljs_test.cljs
@@ -1,0 +1,386 @@
+(ns re-frame.hicasso.test-kit-mounted-dom-cljs-test
+  "THE MOUNTED FACADE'S OWN WITNESSES (rf2-hic-027).
+
+  `re-frame.hicasso.test.mounted` is an instrument, so every row here is
+  either a POSITIVE control — the facade does what it claims on a working
+  app — or a SABOTAGE control — a deliberate fault, and the instrument
+  moves. An instrument asserted only on the working case is satisfied by
+  one that always answers *fine*.
+
+  ## The dogfood claim, one rung up
+
+  `test-kit-dogfood-cljs-test`'s L1 row proves that *an intent written in
+  the authoring spelling, lowered through the codec's prop walk, invoked
+  as the browser would invoke it, reaches a real re-frame2 event handler
+  and moves a real app-db* — through `ht/fire!`, with no element anywhere.
+  That row states plainly what it does NOT prove: \"No element exists, so
+  there is no bubbling, no default action, no focus … and no React event
+  system.\"
+
+  [[l3-a-real-click-on-a-real-button-moves-the-real-page]] is that same
+  claim with every one of those present. The button is a DOM node in
+  `document.body`, the click is the browser's own `HTMLElement.click()` —
+  which is what `user-event` ultimately performs — it travels React's
+  event system, and the assertion is on the repainted page rather than on
+  a returned intent vector.
+
+  ## What `assert-clean!` is driven with
+
+  Four leak kinds, each driven rather than assumed:
+
+  | leak | driven by | seen as |
+  |---|---|---|
+  | a subscription | a second root left standing inside the mount's window | `:cells` / `:cell-refs` / `:boundaries` / `:edges` |
+  | a read-set entry | the same root | `:entries` |
+  | a live frame | `rf/make-frame` inside the mount's window | `:frames`, naming the id |
+  | a mounted root | skipping `unmount!` | `:still-mounted?` |
+
+  And two it does NOT see, stated here rather than left to be discovered:
+  an armed **timer** and a **DOM listener on `document`/`window`** have no
+  census in this runtime, and taking one would mean monkeypatching the
+  host's scheduler and `addEventListener` — an instrument that rewrites
+  the platform under the code it is measuring. A retained foreign-host
+  **callback** is visible only through what it retains: if it holds a
+  subscription it is the first row, and if it holds nothing else it is
+  invisible here.
+
+  ## Browser lane
+
+  Every row needs a real document and a real React DOM. `:node-test`
+  compiles this namespace too (`cljs-test$` matches `-dom-cljs-test`), and
+  each row degrades there to a STATED skip rather than to a false green."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.roots-frames-support :as sup]
+            [re-frame.hicasso.test.mounted :as hm]
+            [re-frame.test-support :as test-support]))
+
+;; ---------------------------------------------------------------------------
+;; The screen — the dogfood row's shape, local to this file
+;; ---------------------------------------------------------------------------
+;;
+;; Registered ABOVE `use-fixtures`, deliberately: the reset fixture captures
+;; its source-store baseline when the `use-fixtures` form is EVALUATED, so a
+;; `reg-sub` written below it is erased before the first row runs.
+
+(def ^:private todo-q [::todo])
+
+(rf/reg-sub ::todo (fn [db [_ id]] (get-in db [:todos id])))
+
+(rf/reg-event ::seed
+              (fn [_ [_ n]]
+                {:db {:todos (into {} (map (fn [i] [i {:id i :title (str "todo " i)
+                                                      :done? false}]))
+                                   (range n))}}))
+(rf/reg-event ::toggle (fn [{:keys [db]} [_ id]]
+                         {:db (update-in db [:todos id :done?] not)}))
+
+(h/defview row
+  "One to-do, with a toggle button. Reads exactly ONE subscription, which
+  is what makes the residue arithmetic below readable: one live row is one
+  cell, one reader membership, one boundary and one edge.
+
+  It takes no frame argument. The frame arrives from the root it is
+  mounted under — see `roots-frames-isolation-dom-cljs-test`, which states
+  the same rule for the same reason."
+  [{:keys [id]}]
+  (let [todo (h/sub [::todo id])]
+    [:li.row {:data-id id}
+     [:span.title (:title todo)]
+     [:span.done (str (boolean (:done? todo)))]
+     [:button.toggle {:on-click [::toggle id]} "toggle"]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     ;; `nil` and not the default: a dynamic-var frame stamp left in ambient
+     ;; scope would let a boundary that failed to resolve its own frame
+     ;; answer that one instead, and the isolation row below would read a
+     ;; rendering difference where the failure is a frame miss.
+     :ambient-frame nil
+     ;; The MAP shape, because every row here is `async`. `cljs.test` refuses
+     ;; an async test under a fn-form fixture and aborts the whole run at
+     ;; this namespace.
+     :async?        true
+     :init-fn       (fn []
+                      (sup/leave-act-environment!)
+                      (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; Reading the page
+;; ---------------------------------------------------------------------------
+
+(defn- node-at [m sel] (.querySelector (:container m) sel))
+(defn- text-at [m sel] (some-> (node-at m sel) .-textContent))
+
+(defn- seeded
+  "One mount of the row, under its own frame, seeded with three to-dos."
+  ([] (seeded 1))
+  ([id] (hm/mount! [row {:id id}] {:initial-events [[::seed 3]]})))
+
+;; ---------------------------------------------------------------------------
+;; W1 — the dogfood claim, one rung up: a REAL click on a REAL page
+;; ---------------------------------------------------------------------------
+
+(deftest l3-a-real-click-on-a-real-button-moves-the-real-page
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM")
+    (async done
+      (let [m (seeded)]
+        (testing "the mount rendered the seeded screen into a container that is
+                  ATTACHED to the document — which is the whole of the Testing
+                  Library interop contract: `screen`, `within` and `getBy*` take
+                  this node, and the facade adds no selector language of its own"
+          (is (some? (:container m)))
+          (is (true? (.-isConnected (:container m))))
+          (is (true? (.contains js/document.body (:container m))))
+          (is (= "todo 1" (text-at m ".title")))
+          (is (= "false"  (text-at m ".done"))))
+
+        (testing "a REAL click — `HTMLElement.click()`, which is what a
+                  user-event sequence ultimately performs — travels React's own
+                  event system, reaches the handler, moves app-db, and the page
+                  repaints. This is the claim ht/fire! states it CANNOT make:
+                  at L1 no element exists, so there is no bubbling, no default
+                  action and no React event system"
+          (.click (node-at m ".toggle"))
+          (hm/settle! m)
+          (is (= "true" (text-at m ".done")))
+          (is (true? (:done? (rf/with-frame (:frame m)
+                               (deref (rf/subscribe [::todo 1])))))))
+
+        (testing "and dispatch-and-settle! drives the same page from OUTSIDE
+                  it — the handle's frame, the runtime's synchronous door, the
+                  commit landed before the next line"
+          (hm/dispatch-and-settle! m [::toggle 1])
+          (is (= "false" (text-at m ".done"))))
+
+        (testing "teardown is clean, and this is the positive control the
+                  sabotage rows below are measured against: without it, an
+                  assert-clean! that never went green would be satisfied by an
+                  instrument that always reds"
+          (-> (hm/unmount! m)
+              (hm/assert-clean!)
+              (.then (fn [report]
+                       (is (true? (:clean? report)))
+                       (is (nil? (:leaked report)))
+                       (done)))))))))
+
+;; ---------------------------------------------------------------------------
+;; W2 — frames are isolated contexts
+;; ---------------------------------------------------------------------------
+
+(deftest l3-two-mounts-are-two-isolated-frames
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM")
+    (async done
+      (let [a (seeded)
+            b (seeded)]
+        (testing "neither mount was handed a frame — each minted its own, and
+                  they are different"
+          (is (not= (:frame a) (:frame b)))
+          (is (keyword? (:frame a))))
+
+        (testing "one view, two frames, one read each — TWO cells, and the frame
+                  is what tells them apart. React has no opinion about this
+                  structure and cannot repair it, which is why the claim is read
+                  here rather than off the page"
+          (is (= #{[(:frame a) [::todo 1]] [(:frame b) [::todo 1]]}
+                 (sup/cell-keys))
+              (str "got " (pr-str (sup/cell-keys))))
+          (is (= [1 1] [(sup/readers-of [(:frame a) [::todo 1]])
+                        (sup/readers-of [(:frame b) [::todo 1]])])
+              "one reader each — a leak is TWO readers on ONE key"))
+
+        (testing "a dispatch into A's frame moves A's page and NOT B's. This is
+                  the property the whole framework rests on, and a facade that
+                  let one mount reach the other would have broken it"
+          (hm/dispatch-and-settle! a [::toggle 1])
+          (is (= "true"  (text-at a ".done")))
+          (is (= "false" (text-at b ".done"))))
+
+        (testing "both come down clean, each measured against its own baseline"
+          (hm/unmount! a)
+          (hm/unmount! b)
+          (-> (hm/assert-clean! a)
+              (.then (fn [ra]
+                       (is (true? (:clean? ra)))
+                       (hm/assert-clean! b)))
+              (.then (fn [rb]
+                       (is (true? (:clean? rb)))
+                       (done)))))))))
+
+;; ---------------------------------------------------------------------------
+;; W3 — SABOTAGE: a leaked subscription
+;; ---------------------------------------------------------------------------
+
+(deftest l3-assert-clean-sees-a-leaked-subscription
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM")
+    (async done
+      (let [m      (seeded)
+            ;; THE SABOTAGE. A second root, put up inside the mount's window
+            ;; through the runtime's own door and left standing when the root
+            ;; under test comes down — the shape a foreign host that mounts its
+            ;; own root and returns no cleanup leaves behind. Its boundary keeps
+            ;; its cell, its reader membership, its edge and its read-set entry.
+            ;;
+            ;; Manufactured through `impl.mount` rather than through the facade
+            ;; deliberately: a facade mount is a PEER and says so in the report
+            ;; (`:standing`), and a peer explained by the instrument is not the
+            ;; fault this row exists to detect.
+            orphan (mount/root! (mount/fresh-container!) (:frame m) [row {:id 2}])]
+        (hm/unmount! m)
+        (-> (hm/residue m)
+            (.then (fn [report]
+                     (testing "the instrument moved: the mount is not clean"
+                       (is (false? (:clean? report)))
+                       (is (false? (:still-mounted? report))
+                           "and not because the root is still up — it came down")
+                       (is (zero? (:standing report))
+                           "and not because a peer mount was standing — none was"))
+
+                     (testing "and it says precisely what leaked. One live row is
+                               one cell, one reader membership (which is both the
+                               reference and the edge), one boundary and one
+                               read-set entry"
+                       (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1 :entries 1}
+                              (:leaked report))
+                           (str "baseline " (pr-str (:baseline report))
+                                " now " (pr-str (:now report)))))
+
+                     (testing "the baseline it is measured against is this
+                               mount's own, taken before its root existed"
+                       (is (= 0 (:cells (:baseline report))))
+                       (is (= 1 (:cells (:now report)))))
+
+                     ;; Restore: the orphan is this row's, and it does not
+                     ;; belong to the next one.
+                     (mount/release! orphan)
+                     (done))))))))
+
+(deftest l3-assert-clean-sees-a-frame-the-app-left-behind
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM")
+    (async done
+      (let [m (seeded)]
+        ;; THE SABOTAGE. A frame opened inside the mount's window and never
+        ;; destroyed — an app that spawns a sub-frame for a dialog, a tenant or
+        ;; a preview and forgets it. A count would say "one more frame"; the
+        ;; report names the id, which is the one thing here a reader can act on.
+        (rf/make-frame {:id ::spawned})
+        (hm/unmount! m)
+        (-> (hm/residue m)
+            (.then (fn [report]
+                     (is (false? (:clean? report)))
+                     (is (= #{::spawned} (:frames (:leaked report)))
+                         (str "got " (pr-str (:leaked report))))
+                     (testing "and nothing else moved — the frame leak is
+                               reported alone, so a reader is not sent hunting a
+                               subscription that is not there"
+                       (is (= [:frames] (keys (:leaked report)))))
+                     (rf/destroy-frame! ::spawned)
+                     (done))))))))
+
+(deftest l3-assert-clean-sees-a-root-that-was-never-unmounted
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM")
+    (async done
+      (let [m (seeded)]
+        ;; THE SABOTAGE. No unmount! at all. A live root's cells ARE residue by
+        ;; every number in the census, so an instrument that only counted would
+        ;; red with a leak report and send a reader hunting a subscription. The
+        ;; missing teardown is reported as itself.
+        (-> (hm/residue m)
+            (.then (fn [report]
+                     (is (true? (:still-mounted? report)))
+                     (is (false? (:clean? report))
+                         "the live root's own cell is above the baseline")
+                     (is (= 1 (:cells (:leaked report))))
+                     (-> (hm/unmount! m)
+                         (hm/assert-clean!)
+                         (.then (fn [after]
+                                  (testing "and after the teardown it does go
+                                            clean — the control that says the
+                                            row above is a missing unmount and
+                                            not a real leak"
+                                    (is (false? (:still-mounted? after)))
+                                    (is (true? (:clean? after))))
+                                  (done)))))))))))
+
+;; ---------------------------------------------------------------------------
+;; W4 — render!: a props change through the same root
+;; ---------------------------------------------------------------------------
+
+(deftest l3-render-changes-props-without-remounting
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM")
+    (async done
+      (let [m  (seeded 1)
+            li (node-at m ".row")]
+        (hm/render! m [row {:id 2}])
+
+        (testing "the new props reached the body and the page moved"
+          (is (= "todo 2" (text-at m ".title")))
+          (is (= "2" (.getAttribute (node-at m ".row") "data-id"))))
+
+        (testing "and the SAME DOM node is still there — React re-rendered the
+                  root rather than replacing it, which is the whole reason this
+                  door exists and a claim no semantic tree can make"
+          (is (identical? li (node-at m ".row"))))
+
+        (-> (hm/unmount! m)
+            (hm/assert-clean!)
+            (.then (fn [report] (is (true? (:clean? report))) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; W5 — hydrate!: the promise resolves on ADOPTION, not on the call returning
+;; ---------------------------------------------------------------------------
+
+(deftest l3-hydrate-adopts-the-server-nodes
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM")
+    (async done
+      (let [;; A throwaway frame, purely to produce the bytes an SSR route
+            ;; would deliver. Released before anything is measured, so the
+            ;; runtime the hydration is measured on is empty.
+            bytes-frame ::server
+            _           (rf/make-frame {:id bytes-frame
+                                        :initial-events [[::seed 3]]})
+            html        (sup/server-html! bytes-frame [row {:id 1}])
+            _           (rf/destroy-frame! bytes-frame)
+            _           (collector/reset-runtime!)
+            ;; The page as it arrives: the server's nodes, stamped with an
+            ;; EXPANDO. An expando cannot survive serialisation and cannot be
+            ;; reconstructed, so a node still carrying it is THE node the
+            ;; server markup produced — the only observable that tells adoption
+            ;; from a client render that happens to agree.
+            container   (sup/stamp-server-nodes! (sup/server-dom! html))]
+        (is (sup/every-server-node? container ".row") "premise: the bytes were stamped")
+        (-> (hm/hydrate! [row {:id 1}] {:container container
+                                        :initial-events [[::seed 3]]})
+            (.then (fn [m]
+                     (testing "the promise resolved on THIS root's adoption
+                               window shutting, so the DOM on this line is the
+                               adopted one — hydrate-root! itself returns while
+                               the page is still the server's"
+                       (is (sup/every-server-node? (:container m) ".row")
+                           "the server's own nodes were adopted, not replaced")
+                       (is (= "todo 1" (text-at m ".title"))))
+
+                     (testing "and it is live: a dispatch reaches the adopted
+                               tree"
+                       (hm/dispatch-and-settle! m [::toggle 1])
+                       (is (= "true" (text-at m ".done")))
+                       (is (sup/every-server-node? (:container m) ".row")
+                           "still the same nodes after a commit"))
+
+                     (-> (hm/unmount! m)
+                         (hm/assert-clean!)
+                         (.then (fn [report]
+                                  (is (true? (:clean? report)))
+                                  (done)))))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_mounted_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_mounted_dom_cljs_test.cljs
@@ -35,14 +35,29 @@
   | a live frame | `rf/make-frame` inside the mount's window | `:frames`, naming the id |
   | a mounted root | skipping `unmount!` | `:still-mounted?` |
 
-  And two it does NOT see, stated here rather than left to be discovered:
-  an armed **timer** and a **DOM listener on `document`/`window`** have no
-  census in this runtime, and taking one would mean monkeypatching the
-  host's scheduler and `addEventListener` — an instrument that rewrites
-  the platform under the code it is measuring. A retained foreign-host
-  **callback** is visible only through what it retains: if it holds a
-  subscription it is the first row, and if it holds nothing else it is
-  invisible here.
+  And four it does NOT see, stated here rather than left to be
+  discovered:
+
+  - an armed **timer** (`setTimeout` / `setInterval` /
+    `requestAnimationFrame`) and a **DOM listener on `document` or
+    `window`** have no census in this runtime, and taking one would mean
+    monkeypatching the host's scheduler and `addEventListener` — an
+    instrument that rewrites the platform under the code it is measuring;
+  - a **pending effect** — an async `rf/dispatch` still queued, or an fx
+    in flight — likewise. Core publishes no queue census, and
+    [[hm/dispatch-and-settle!]] uses the runtime's SYNCHRONOUS door, which
+    drains to fixed point before it returns; so what this facade could
+    honestly see is exactly what it already settles, and what it cannot
+    see is what a test put in flight by another route;
+  - a **core-level subscription** — `rf/subscribe` held outside a Hicasso
+    body — is in core's sub-cache and not in the cell table this census
+    reads;
+  - a retained foreign-host **callback** is visible only through what it
+    retains: if it holds a subscription it is the first row, and if it
+    holds nothing countable it is invisible here.
+
+  A facade that claimed cleanliness while checking one kind of residue
+  would be worse than one that names its scope, so the scope is named.
 
   ## Browser lane
 

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_mounted_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_mounted_dom_cljs_test.cljs
@@ -67,8 +67,6 @@
 ;; its source-store baseline when the `use-fixtures` form is EVALUATED, so a
 ;; `reg-sub` written below it is erased before the first row runs.
 
-(def ^:private todo-q [::todo])
-
 (rf/reg-sub ::todo (fn [db [_ id]] (get-in db [:todos id])))
 
 (rf/reg-event ::seed

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
@@ -119,26 +119,41 @@
 ;; Bookkeeping
 ;; ---------------------------------------------------------------------------
 
+;; `!mount-seq` mints the frame keyword and the ordinal a report names.
+;;
+;; `!facade-frames` is the frames this facade has minted and not yet
+;; destroyed. It is SUBTRACTED from the frame delta, so one mount is never
+;; blamed for another's frame: `:frames` exists to name a frame the APP
+;; opened and left behind, and a sibling mount's frame is neither the app's
+;; nor a leak — it is a peer, with an `assert-clean!` of its own.
+;;
+;; `!standing` is how many mounts are up and not yet taken down. It is
+;; REPORTED — a sibling root's cells are inside a reading whether or not
+;; anybody remembered it was there, so the reading says so.
+;;
+;; `!open` is how many mounts have not yet had a verdict, and it decides
+;; ONE thing: whether `assert-clean!` may reset.
+;; `impl.collector/reset-runtime!` empties every table by fiat and the
+;; tables are page-wide, so a reset performed while ANOTHER mount is still
+;; waiting to be read makes that mount's eventual reading vacuous — a
+;; census taken after a reset answers zero whether the teardown released
+;; anything or not, which is the shape of gate that cannot go red
+;; (`impl.mount/unmount!`, rf2-2rtt6.48). Unmounted is NOT the same
+;; question: two mounts can both be down and only one of them read.
+;;
+;; A mount that never gets a verdict leaves the counter above zero and
+;; suppresses the reset from then on. That is the benign direction and it
+;; is why the gate is spelled this way round: a reset that does not happen
+;; costs nothing (every reading is relative to its own baseline, and a test
+;; fixture resets between tests anyway), while a reset that happens too
+;; early manufactures a green.
+
 (defonce ^:private !mount-seq (atom 0))
+(defonce ^:private !facade-frames (atom #{}))
+(defonce ^:private !standing (atom 0))
+(defonce ^:private !open (atom 0))
 
-(defonce ^:private !standing
-  "How many mounts this facade has put up and not yet taken down.
-
-  Read by [[assert-clean!]] for ONE decision: whether its reset is safe.
-  `impl.collector/reset-runtime!` empties every table by fiat and the
-  tables are page-wide, so a reset performed while a sibling root is still
-  standing would both break that root and — worse — make ITS eventual
-  cleanliness reading vacuous. A census taken after a reset answers zero
-  whether the teardown released anything or not, which is the shape of
-  gate that cannot go red (`impl.mount/unmount!`, rf2-2rtt6.48).
-
-  So the reset happens only when the last standing mount has come down.
-  A test that forgets to unmount leaves the counter above zero, which is
-  correct rather than unfortunate: there IS a live root, and the leak
-  shows up in the residue delta of whichever mount asks."
-  (atom 0))
-
-(def ^:private mounted-key ::mounted?)
+(def ^:private state-key ::state)
 (def ^:private baseline-key ::baseline)
 (def ^:private ordinal-key ::ordinal)
 
@@ -177,14 +192,22 @@
   "What `now` has that `baseline` did not — the report's `:leaked` map, or
   `nil` when there is nothing. Only INCREASES are residue; a count that
   fell is a teardown that released more than this mount ever took, which
-  is somebody else's business and never this mount's complaint."
+  is somebody else's business and never this mount's complaint.
+
+  The frame arm subtracts this facade's OWN live frames as well as the
+  baseline's, so what `:frames` can name is a frame the APP opened inside
+  the mount's window and did not destroy — never a peer mount's."
   [baseline now]
   (let [numbers (reduce (fn [m k]
                           (let [d (- (get now k 0) (get baseline k 0))]
                             (cond-> m (pos? d) (assoc k d))))
                         {}
                         counted)
-        frames  (into #{} (remove (:frames baseline #{})) (:frames now))]
+        peers   (set @!facade-frames)
+        frames  (into #{}
+                      (remove (fn [f] (or (contains? (:frames baseline #{}) f)
+                                          (contains? peers f))))
+                      (:frames now))]
     (not-empty (cond-> numbers (seq frames) (assoc :frames frames)))))
 
 (defn- pad
@@ -203,14 +226,18 @@
   else. A residue finding is a bug in the code under test; naming it
   precisely is the whole of this instrument's job, and anything beyond
   that is scolding."
-  [{:keys [frame baseline now leaked ordinal]}]
+  [{:keys [frame baseline now leaked ordinal standing]}]
   (str "the mount left residue behind after quiescence.\n"
        "The baseline was taken inside mount! #" ordinal ", after this mount's own\n"
        "frame " frame " existed and before its root did; the reading below was\n"
        "taken after unmount! and after the runtime's own reaper horizon.\n\n"
        (str/join "\n" (map (fn [[k v]] (leak-line baseline now k v)) leaked))
        "\n\nSomething outlived the root. A retained subscription, a foreign host that\n"
-       "mounts its own root, or a frame the app made and did not destroy."))
+       "mounts its own root, or a frame the app made and did not destroy."
+       (when (pos? standing)
+         (str "\n\n" standing " other facade mount(s) were still standing when this reading\n"
+              "was taken, so their cells are inside it. Take every mount down before\n"
+              "asserting any of them clean."))))
 
 ;; ---------------------------------------------------------------------------
 ;; Mounting
@@ -231,15 +258,17 @@
         frame-kw (keyword "re-frame.hicasso.test.mounted" (str "mount-" ordinal))]
     (rf/make-frame (cond-> {:id frame-kw}
                      (seq initial-events) (assoc :initial-events (vec initial-events))))
+    (swap! !facade-frames conj frame-kw)
     [frame-kw ordinal]))
 
 (defn- handle-for
   [root ordinal baseline]
   (swap! !standing inc)
+  (swap! !open inc)
   (assoc root
          baseline-key baseline
          ordinal-key  ordinal
-         mounted-key  (volatile! true)))
+         state-key    (volatile! :mounted)))
 
 (defn mount!
   "Mount `form` on a fresh React root under a frame of this mount's own,
@@ -405,8 +434,8 @@
   counts against the standing-mount census."
   [handle]
   (mount/unmount! handle)
-  (when @(get handle mounted-key)
-    (vreset! (get handle mounted-key) false)
+  (when (= :mounted @(get handle state-key))
+    (vreset! (get handle state-key) :unmounted)
     (swap! !standing dec))
   handle)
 
@@ -418,12 +447,14 @@
   "**What this mount left behind, as data.** Answers a promise of the
   report; asserts nothing and resets nothing.
 
-      {:clean?   false
-       :frame    :re-frame.hicasso.test.mounted/mount-3
-       :ordinal  3
-       :baseline {:cells 0 :cell-refs 0 … :frames #{…}}
-       :now      {:cells 2 :cell-refs 2 … :frames #{…}}
-       :leaked   {:cells 2 :cell-refs 2 :boundaries 1 :edges 2}}
+      {:clean?         false
+       :frame          :re-frame.hicasso.test.mounted/mount-3
+       :ordinal        3
+       :still-mounted? false
+       :standing       0
+       :baseline       {:cells 0 :cell-refs 0 … :frames #{…}}
+       :now            {:cells 2 :cell-refs 2 … :frames #{…}}
+       :leaked         {:cells 2 :cell-refs 2 :boundaries 1 :edges 2}}
 
   The reading is taken after `impl.inventory/quiesced!` — the runtime's
   OWN settling point, not a macrotask. The entry reaper's horizon sits
@@ -436,21 +467,28 @@
   INCREASES against the baseline (see [[census]] for what is counted and
   [[mount!]] for when the baseline was taken).
 
+  `:still-mounted?` and `:standing` are the two facts that explain a
+  reading rather than being read out of the tables: this mount's own root
+  still being up, and how many OTHER facade mounts were up when the census
+  was taken. Both are inside the numbers, so both are stated beside them.
+
   This is [[assert-clean!]]'s other half, and it exists so the instrument
   can have a sabotage control of its own: a witness that deliberately
   leaks must be able to read the verdict rather than fail on it."
   [handle]
   (let [baseline (get handle baseline-key)
-        frame    (:frame handle)]
+        mounted? (= :mounted @(get handle state-key))]
     (.then (inventory/quiesced!)
            (fn [_]
              (let [now (census)
                    l   (leaked baseline now)]
-               (cond-> {:clean?   (nil? l)
-                        :frame    frame
-                        :ordinal  (get handle ordinal-key)
-                        :baseline baseline
-                        :now      now}
+               (cond-> {:clean?         (nil? l)
+                        :frame          (:frame handle)
+                        :ordinal        (get handle ordinal-key)
+                        :still-mounted? mounted?
+                        :standing       (cond-> @!standing mounted? dec)
+                        :baseline       baseline
+                        :now            now}
                  (some? l) (assoc :leaked l)))))))
 
 (defn assert-clean!
@@ -484,36 +522,45 @@
   anything or not. This mount's frame is destroyed with it.
 
   The reset is page-wide, so it is held back while any OTHER mount is
-  still standing; see `!standing`. Which makes the ordinary shape the
-  right one: assert each mount clean after it comes down, and the last one
-  to come down does the clearing."
+  still waiting to be read — not merely while one is still standing, since
+  two mounts can both be down and only one of them read, and resetting
+  between them would make the second reading vacuous. See `!open`. The
+  last mount to be asserted does the clearing."
   [handle]
-  (let [frame (:frame handle)]
-    (if @(get handle mounted-key)
-      (let [report {:clean? false :frame frame :ordinal (get handle ordinal-key)
-                    :still-mounted? true}]
-        (t/do-report
-          {:type     :fail
-           :message  (str "assert-clean! was called on a mount that is still "
-                          "standing. Call unmount! first: this reading is about "
-                          "what survives a teardown, and there has not been one.")
-           :expected '(unmounted? handle)
-           :actual   report})
-        (js/Promise.resolve report))
-      (.then (residue handle)
-             (fn [report]
-               (t/do-report
-                 (if (:clean? report)
-                   {:type     :pass
-                    :message  (str "the mount left no residue: every counter is "
-                                   "back at its pre-mount baseline")
-                    :expected '(clean? handle)
-                    :actual   report}
-                   {:type     :fail
-                    :message  (leak-report report)
-                    :expected '(clean? handle)
-                    :actual   (:leaked report)}))
-               (when (zero? @!standing)
-                 (collector/reset-runtime!))
-               (rf/destroy-frame! frame)
-               report)))))
+  (.then (residue handle)
+         (fn [report]
+           (t/do-report
+             (cond
+               (:still-mounted? report)
+               {:type     :fail
+                :message  (str "assert-clean! was called on a mount that is still "
+                               "standing. Call unmount! first: this reading is "
+                               "about what survives a teardown, and there has "
+                               "not been one.")
+                :expected '(unmounted? handle)
+                :actual   report}
+
+               (:clean? report)
+               {:type     :pass
+                :message  (str "the mount left no residue: every counter is back "
+                               "at its pre-mount baseline")
+                :expected '(clean? handle)
+                :actual   report}
+
+               :else
+               {:type     :fail
+                :message  (leak-report report)
+                :expected '(clean? handle)
+                :actual   (:leaked report)}))
+           ;; The verdict is taken ONCE per mount: a second call reports
+           ;; again (it is an assertion, and a repeated assertion is
+           ;; allowed to speak) but moves no bookkeeping, so `!open`
+           ;; cannot be driven below the number of mounts still waiting
+           ;; to be read.
+           (when (= :unmounted @(get handle state-key))
+             (vreset! (get handle state-key) :read)
+             (when (zero? (swap! !open dec))
+               (collector/reset-runtime!))
+             (swap! !facade-frames disj (:frame handle))
+             (rf/destroy-frame! (:frame handle)))
+           report)))

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
@@ -1,0 +1,519 @@
+(ns re-frame.hicasso.test.mounted
+  "`hm` — HICASSO'S MOUNTED TEST FACADE, L3 (rf2-hic-027).
+
+  The rung above `re-frame.hicasso.test`. That namespace runs ONE body and
+  reads the hiccup it returned; this one puts a real React root on a real
+  page and lets React do everything L2 refuses to pretend about —
+  lifecycle, hooks, context, refs, error boundaries, foreign hosts, the
+  DOM.
+
+      (:require [re-frame.hicasso.test :as ht]        ;; L1–L2
+                [re-frame.hicasso.test.mounted :as hm]) ;; L3
+
+  ## Seven doors and one handle
+
+      (hm/mount! form opts)             → handle
+      (hm/hydrate! form opts)           → promise of handle
+      (hm/render! handle form)          → handle
+      (hm/dispatch-and-settle! h event) → handle
+      (hm/settle! handle)               → handle
+      (hm/unmount! handle)              → handle
+      (hm/assert-clean! handle)         → promise of the residue report
+
+  Every door takes the handle first and answers it, so a whole mounted
+  test threads:
+
+      (deftest toggle-reaches-the-real-dom
+        (async done
+          (let [m (hm/mount! [views/todo-row {:id 7}]
+                             {:initial-events [[:todo/seed …]]})]
+            (is (some? (tl/getByText (:container m) \"Buy milk\")))
+            (hm/dispatch-and-settle! m [:todo/toggle 7])
+            (is (true? (.-checked (tl/getByRole (:container m) \"checkbox\"))))
+            (-> (hm/unmount! m) (hm/assert-clean!) (.then done)))))
+
+  The handle is the runtime's own root handle (`impl.mount`) with this
+  namespace's bookkeeping added beside it, so `(:container m)` and
+  `(:frame m)` are the real container node and the real frame id rather
+  than accessors over a wrapper.
+
+  ## `mount!` OWNS its frame, and takes no frame argument
+
+  **Frames are isolated contexts.** A mounted app resolves its frame from
+  the root it sits under, through the substrate's single internal React
+  context, and never from an argument — so there is no frame id to pass
+  down a view, and no helper here that could reach across. This facade
+  makes that structural rather than documented: `mount!` MINTS a frame of
+  its own for every call, seeds it with `:initial-events`, and destroys it
+  in [[assert-clean!]].
+
+  There is deliberately no `:frame` option. Two mounted apps therefore
+  cannot see each other's state — not by convention, but because neither
+  can be handed the other's frame. Anything a test needs the frame FOR is
+  on the handle: `(rf/with-frame (:frame m) (deref (rf/subscribe …)))`
+  reads it, and [[dispatch-and-settle!]] writes it.
+
+  (The deliberately shared-frame multi-root case is a claim about the
+  RUNTIME rather than about a consumer's app, and it belongs where it
+  already lives — `re-frame.hicasso.roots-frames-*` drives it against
+  `impl.mount` directly.)
+
+  ## No selector language, and no library dependency
+
+  Querying is Testing Library's job and this facade does not take it back.
+  `(:container m)` is a real element attached to `document.body`, so
+  `getBy*` / `queryBy*` / `within` and `screen` work on it unchanged, and
+  a `user-event` sequence dispatches real DOM events at real nodes. What
+  this namespace owns is the other half — mounting, settling and
+  cleanliness. Nothing here `:require`s `@testing-library/dom`, so a
+  consumer chooses (or omits) it freely.
+
+  After anything that stimulates the page from OUTSIDE a facade door — a
+  user-event sequence, a raw `.click`, a timer you fired yourself — call
+  [[settle!]] before you assert.
+
+  ## Settled, not `act`
+
+  Every door here commits through `flushSync` and none of them uses
+  React's `act`. `act` diverts React's work onto a queue that is not the
+  browser's: right for an effect-ordering test, wrong for a witness that
+  reads the page. After a door returns, the next line sees the DOM a user
+  would have seen. [[hydrate!]] is the one exception and says why.
+
+  ## Refusals: this namespace mints none
+
+  Every other file in the kit refuses loudly, and this one deliberately
+  does not, for two reasons that agree.
+
+  A malformed form, a bad handle or a hiccup shape the substrate rejects
+  is already refused BY THE RUNTIME, with the runtime's own id, reason and
+  recovery — which is the whole discipline `re-frame.hicasso.test`
+  established (§Children, and the runtime-parity suite). A guard here
+  would paraphrase a refusal that already exists.
+
+  And a residue finding is not a refusal at all: it is a TEST FAILURE, so
+  [[assert-clean!]] reports it through `cljs.test/do-report` rather than
+  throwing. That distinction is the useful one — the kit REFUSES misuse of
+  the instrument and REPORTS a fact about the code under test — and it is
+  also what keeps this file free of new `:rf.error/*` ids.
+  (`:rf.error/hicasso-test-residue-after-quiescence` is RESERVED in the
+  complaint register for a raising variant; promoting a reservation is a
+  deliberate act across `spec/009` and the register, and this bead does
+  not take it.)
+
+  ## Scope
+
+  Dev/test only, and a browser tier: every door needs a real document.
+  Like `re-frame.hicasso.test` it lives in the kit's own source root
+  (`hicasso/test_kit/src`), outside the artefact's published `:paths`, so
+  nothing in a production bundle can reach it."
+  (:require [clojure.string :as str]
+            [cljs.test :as t]
+            [re-frame.core :as rf]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.impl.roots :as roots]))
+
+;; ---------------------------------------------------------------------------
+;; Bookkeeping
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !mount-seq (atom 0))
+
+(defonce ^:private !standing
+  "How many mounts this facade has put up and not yet taken down.
+
+  Read by [[assert-clean!]] for ONE decision: whether its reset is safe.
+  `impl.collector/reset-runtime!` empties every table by fiat and the
+  tables are page-wide, so a reset performed while a sibling root is still
+  standing would both break that root and — worse — make ITS eventual
+  cleanliness reading vacuous. A census taken after a reset answers zero
+  whether the teardown released anything or not, which is the shape of
+  gate that cannot go red (`impl.mount/unmount!`, rf2-2rtt6.48).
+
+  So the reset happens only when the last standing mount has come down.
+  A test that forgets to unmount leaves the counter above zero, which is
+  correct rather than unfortunate: there IS a live root, and the leak
+  shows up in the residue delta of whichever mount asks."
+  (atom 0))
+
+(def ^:private mounted-key ::mounted?)
+(def ^:private baseline-key ::baseline)
+(def ^:private ordinal-key ::ordinal)
+
+;; ---------------------------------------------------------------------------
+;; The census — what the facade knows how to count
+;; ---------------------------------------------------------------------------
+
+(def counted
+  "The residue counters [[assert-clean!]] compares, in report order.
+
+  `impl.inventory/residue`'s own five, which are the runtime's own
+  numbers rather than a copy of them: live cells, the reader memberships
+  that are simultaneously the cell references and the dependency edges,
+  the distinct boundaries holding one, and the cached read-set entries.
+
+  Data rather than prose because the report iterates it — a counter the
+  runtime grows is picked up by construction rather than by somebody
+  remembering to add a line here."
+  [:cells :cell-refs :boundaries :edges :entries])
+
+(defn census
+  "Everything this facade counts, as ONE map — the five runtime residue
+  counters plus `:frames`, the set of registered non-destroyed frame ids.
+
+  `:frames` is a SET and not a count on purpose: a delta then NAMES the
+  frame that outlived the mount, and a frame id is the one thing in this
+  report a reader can act on directly.
+
+  Public because a witness that wants to read the world at a moment the
+  facade does not visit should read it through the same door the report
+  does, rather than through a second assembly of the same numbers."
+  []
+  (assoc (inventory/residue) :frames (set (rf/frame-ids))))
+
+(defn- leaked
+  "What `now` has that `baseline` did not — the report's `:leaked` map, or
+  `nil` when there is nothing. Only INCREASES are residue; a count that
+  fell is a teardown that released more than this mount ever took, which
+  is somebody else's business and never this mount's complaint."
+  [baseline now]
+  (let [numbers (reduce (fn [m k]
+                          (let [d (- (get now k 0) (get baseline k 0))]
+                            (cond-> m (pos? d) (assoc k d))))
+                        {}
+                        counted)
+        frames  (into #{} (remove (:frames baseline #{})) (:frames now))]
+    (not-empty (cond-> numbers (seq frames) (assoc :frames frames)))))
+
+(defn- pad
+  [s n]
+  (apply str s (repeat (max 0 (- n (count s))) " ")))
+
+(defn- leak-line
+  [baseline now k v]
+  (if (= :frames k)
+    (str "  " (pad ":frames" 12) (pr-str v) " still registered")
+    (str "  " (pad (str k) 12) (get baseline k 0) " → " (get now k 0) "  (+" v ")")))
+
+(defn- leak-report
+  "The sentence a red carries. It says what leaked, by how much, and when
+  the baseline it is measured against was taken — and it says nothing
+  else. A residue finding is a bug in the code under test; naming it
+  precisely is the whole of this instrument's job, and anything beyond
+  that is scolding."
+  [{:keys [frame baseline now leaked ordinal]}]
+  (str "the mount left residue behind after quiescence.\n"
+       "The baseline was taken inside mount! #" ordinal ", after this mount's own\n"
+       "frame " frame " existed and before its root did; the reading below was\n"
+       "taken after unmount! and after the runtime's own reaper horizon.\n\n"
+       (str/join "\n" (map (fn [[k v]] (leak-line baseline now k v)) leaked))
+       "\n\nSomething outlived the root. A retained subscription, a foreign host that\n"
+       "mounts its own root, or a frame the app made and did not destroy."))
+
+;; ---------------------------------------------------------------------------
+;; Mounting
+;; ---------------------------------------------------------------------------
+
+(defn- mint-frame!
+  "This mount's own frame — a keyword nothing else can name, made live and
+  seeded in one call. Answers `[frame-kw ordinal]`.
+
+  `:initial-events` reaches `rf/make-frame` rather than being dispatched
+  here afterwards, because that is core's own construction channel: the
+  steps run in order and drain to fixed point BEFORE the call returns, so
+  the frame the root is about to render against is already at rest. A
+  seeding loop written here would be a second mechanism wearing core's
+  spelling."
+  [initial-events]
+  (let [ordinal  (swap! !mount-seq inc)
+        frame-kw (keyword "re-frame.hicasso.test.mounted" (str "mount-" ordinal))]
+    (rf/make-frame (cond-> {:id frame-kw}
+                     (seq initial-events) (assoc :initial-events (vec initial-events))))
+    [frame-kw ordinal]))
+
+(defn- handle-for
+  [root ordinal baseline]
+  (swap! !standing inc)
+  (assoc root
+         baseline-key baseline
+         ordinal-key  ordinal
+         mounted-key  (volatile! true)))
+
+(defn mount!
+  "Mount `form` on a fresh React root under a frame of this mount's own,
+  and answer the handle.
+
+      (hm/mount! [todo-row {:id 7}]
+                 {:initial-events [[:todo/seed [{:id 7 :title \"Buy milk\"}]]]})
+
+  `form` is ordinary hiccup — `[some-view props]`, a `defview` head where
+  a call site would write one — and it is handed to the runtime untouched,
+  so a form the substrate refuses is refused by the substrate with the
+  substrate's own id.
+
+  `opts`:
+
+      :initial-events  a vector of setup steps dispatched into the new
+                       frame at construction, in order, draining to fixed
+                       point before the mount renders. Core's own
+                       `rf/make-frame` vocabulary; seed a literal app-db
+                       with `[[:rf/set-db {…}]]`.
+      :container       an existing DOM element to render into. The default
+                       is a fresh `<div>` appended to `document.body` —
+                       attached, so `screen`-scoped Testing Library
+                       queries and real focus both work.
+
+  ## What it records before it renders
+
+  The residue BASELINE, taken after this mount's frame exists and before
+  its root does. [[assert-clean!]] compares against it rather than against
+  zero, which is what makes the reading a statement about THIS mount: a
+  page that already held a live root when the mount began is not this
+  mount's residue, and a test that opened one is not made to answer for
+  it.
+
+  The frame is this facade's — minted, made and destroyed here. See the
+  namespace docstring on why there is no `:frame` option."
+  ([form] (mount! form {}))
+  ([form {:keys [initial-events container]}]
+   (let [[frame-kw ordinal] (mint-frame! initial-events)
+         baseline           (census)
+         node               (or container (mount/fresh-container!))]
+     (handle-for (mount/root! node frame-kw form) ordinal baseline))))
+
+(defn hydrate!
+  "Mount `form` by ADOPTING server-rendered bytes already in the
+  container, and answer a **promise** of the handle — resolved once this
+  root's own adoption window has shut.
+
+      (-> (hm/hydrate! [app {}] {:html server-bytes})
+          (.then (fn [m] … (hm/unmount! m) …)))
+
+  `opts` is [[mount!]]'s, plus one of:
+
+      :html       server bytes; a fresh attached container is created
+                  carrying them
+      :container  a container you already filled
+
+  ## Why this one answers a promise
+
+  `impl.mount/hydrate-root!` deliberately performs no `flushSync`:
+  nothing in the runtime forces adoption synchronously, and a flush there
+  would manufacture a schedule no shipped caller has. So the call returns
+  while the DOM on screen is still the SERVER's, and a facade that handed
+  back a bare handle would hand back one whose next line reads the wrong
+  page.
+
+  The promise resolves on this root's own adoption window closing — the
+  closer component's passive effect, which is the earliest moment that is
+  unambiguously after the hydration commit — and then one macrotask
+  later, past the entry reaper. A sibling root still adopting cannot
+  resolve it: the window belongs to this root and nothing else can shut
+  it.
+
+  `budget-ms` (default 3000) bounds the wait. Exceeding it REJECTS rather
+  than resolving with a handle whose adoption never happened — a hydration
+  that silently timed out and then asserted green is the exact failure
+  this door exists to prevent."
+  ([form] (hydrate! form {}))
+  ([form opts] (hydrate! form opts 3000))
+  ([form {:keys [initial-events container html]} budget-ms]
+   (let [[frame-kw ordinal] (mint-frame! initial-events)
+         baseline (census)
+         node     (or container (mount/fresh-container!))
+         _        (when (some? html) (set! (.-innerHTML node) html))
+         handle   (handle-for (mount/hydrate-root! node frame-kw form)
+                              ordinal baseline)
+         window   (:adoption handle)
+         deadline (+ (js/Date.now) budget-ms)]
+     (js/Promise.
+       (fn [resolve reject]
+         (letfn [(tick []
+                   (cond
+                     (not (roots/adopting? window))
+                     ;; Past the closer AND past the reap horizon, so the
+                     ;; handle a caller receives is one whose tables have
+                     ;; settled.
+                     (js/setTimeout (fn [] (resolve handle)) 16)
+
+                     (< deadline (js/Date.now))
+                     (reject (ex-info (str "hydrate! waited " budget-ms
+                                           "ms and this root's adoption window "
+                                           "never shut — the tree was not adopted.")
+                                      {:frame frame-kw :budget-ms budget-ms}))
+
+                     :else (js/setTimeout tick 4)))]
+           (tick)))))))
+
+;; ---------------------------------------------------------------------------
+;; Driving
+;; ---------------------------------------------------------------------------
+
+(defn render!
+  "Render `form` into `handle`'s existing root, synchronously, and answer
+  the handle. The props-change door: same root, same frame, same DOM
+  nodes wherever React can keep them, so identity and effect claims are
+  about a re-render rather than about a remount.
+
+  Takes a hydrated handle unchanged."
+  [handle form]
+  (mount/render! handle form)
+  handle)
+
+(defn settle!
+  "Let everything React has already scheduled commit, and answer the
+  handle. The empty `flushSync` — no work of its own.
+
+  Call it after anything that stimulated the page from outside a facade
+  door: a `user-event` sequence, a raw `.click`, a resolved promise, a
+  timer you fired yourself. After it returns the DOM is the one a user
+  would be looking at.
+
+  The flush is React's and is therefore page-wide; the handle is taken so
+  that every door in this facade reads the same way."
+  [handle]
+  (mount/settle!)
+  handle)
+
+(defn dispatch-and-settle!
+  "Dispatch `event` into this mount's frame, drain it, commit the echo,
+  and answer the handle.
+
+  The dispatch is the runtime's own frame-locked synchronous door — the
+  same one an intent written in a view reaches — so handlers really run,
+  app-db really moves, and the commit React schedules for the store
+  notification lands before this returns. Assert the DOM on the next
+  line.
+
+  It is not `act`: see the namespace docstring."
+  [handle event]
+  (mount/dispatch! handle event)
+  handle)
+
+(defn unmount!
+  "Tear the root down, detach its container, and answer the handle.
+
+  It touches NOTHING the runtime holds. Whatever cells, edges and cached
+  closures survive this call are exactly the ones React's own cleanup
+  failed to release, which is what makes [[assert-clean!]] able to see
+  them — a teardown that reset the tables first would answer clean whether
+  the unmount released anything or not.
+
+  Idempotent: unmounting twice is not an error, and only the first call
+  counts against the standing-mount census."
+  [handle]
+  (mount/unmount! handle)
+  (when @(get handle mounted-key)
+    (vreset! (get handle mounted-key) false)
+    (swap! !standing dec))
+  handle)
+
+;; ---------------------------------------------------------------------------
+;; Cleanliness
+;; ---------------------------------------------------------------------------
+
+(defn residue
+  "**What this mount left behind, as data.** Answers a promise of the
+  report; asserts nothing and resets nothing.
+
+      {:clean?   false
+       :frame    :re-frame.hicasso.test.mounted/mount-3
+       :ordinal  3
+       :baseline {:cells 0 :cell-refs 0 … :frames #{…}}
+       :now      {:cells 2 :cell-refs 2 … :frames #{…}}
+       :leaked   {:cells 2 :cell-refs 2 :boundaries 1 :edges 2}}
+
+  The reading is taken after `impl.inventory/quiesced!` — the runtime's
+  OWN settling point, not a macrotask. The entry reaper's horizon sits
+  deliberately outside a bare `setTimeout 0`, so a census taken one
+  macrotask after an unclaimed render still counts entries the runtime is
+  about to drop, and a gate comparing against such a reading fails on
+  every arm whose row outlives the horizon.
+
+  `:leaked` is absent when the mount was clean, and only ever names
+  INCREASES against the baseline (see [[census]] for what is counted and
+  [[mount!]] for when the baseline was taken).
+
+  This is [[assert-clean!]]'s other half, and it exists so the instrument
+  can have a sabotage control of its own: a witness that deliberately
+  leaks must be able to read the verdict rather than fail on it."
+  [handle]
+  (let [baseline (get handle baseline-key)
+        frame    (:frame handle)]
+    (.then (inventory/quiesced!)
+           (fn [_]
+             (let [now (census)
+                   l   (leaked baseline now)]
+               (cond-> {:clean?   (nil? l)
+                        :frame    frame
+                        :ordinal  (get handle ordinal-key)
+                        :baseline baseline
+                        :now      now}
+                 (some? l) (assoc :leaked l)))))))
+
+(defn assert-clean!
+  "**The cleanliness assertion.** Waits for quiescence, compares the
+  residue with this mount's pre-mount baseline, REPORTS, and only then
+  resets. Answers a promise of the report [[residue]] describes.
+
+      (-> (hm/unmount! m) (hm/assert-clean!) (.then done))
+
+  ## What it reports
+
+  Through `cljs.test/do-report`, so a residue finding is an ordinary
+  `FAIL in (your-test)` naming exactly what leaked — not a thrown refusal
+  a `.then` chain would swallow into a hung async test, and not a boolean
+  the caller has to remember to assert. It never throws, so the promise
+  never rejects and `(.then done)` is the whole of the plumbing.
+
+  Two things fail it:
+
+  - **residue** — a counter above its baseline, or a frame that outlived
+    the mount;
+  - **a mount still standing** — calling this before [[unmount!]]. Reported
+    on its own rather than allowed to present as residue, because a live
+    root's cells ARE residue by every number here and the resulting red
+    would send a reader hunting a leak that is really a missing teardown.
+
+  ## And only then resets
+
+  `impl.collector/reset-runtime!` runs after the reading, never before —
+  a census taken after a reset answers zero whether the teardown released
+  anything or not. This mount's frame is destroyed with it.
+
+  The reset is page-wide, so it is held back while any OTHER mount is
+  still standing; see `!standing`. Which makes the ordinary shape the
+  right one: assert each mount clean after it comes down, and the last one
+  to come down does the clearing."
+  [handle]
+  (let [frame (:frame handle)]
+    (if @(get handle mounted-key)
+      (let [report {:clean? false :frame frame :ordinal (get handle ordinal-key)
+                    :still-mounted? true}]
+        (t/do-report
+          {:type     :fail
+           :message  (str "assert-clean! was called on a mount that is still "
+                          "standing. Call unmount! first: this reading is about "
+                          "what survives a teardown, and there has not been one.")
+           :expected '(unmounted? handle)
+           :actual   report})
+        (js/Promise.resolve report))
+      (.then (residue handle)
+             (fn [report]
+               (t/do-report
+                 (if (:clean? report)
+                   {:type     :pass
+                    :message  (str "the mount left no residue: every counter is "
+                                   "back at its pre-mount baseline")
+                    :expected '(clean? handle)
+                    :actual   report}
+                   {:type     :fail
+                    :message  (leak-report report)
+                    :expected '(clean? handle)
+                    :actual   (:leaked report)}))
+               (when (zero? @!standing)
+                 (collector/reset-runtime!))
+               (rf/destroy-frame! frame)
+               report)))))


### PR DESCRIPTION
Closes **rf2-hic-027** — the mounted half of the testing ladder. Two new files;
nothing existing is rewritten. The L0–L2 kit (`test_kit/src/.../test.cljs`) is
untouched.

## The public surface

`re-frame.hicasso.test.mounted`, aliased `hm`, beside `ht` rather than inside it:
the pure kit runs L0–L2 with no React DOM anywhere, and folding `react-dom/client`
into it would make the cheap tiers depend on the expensive one's substrate.

```clojure
(hm/mount! form opts)             → handle    ;; :initial-events, :container
(hm/hydrate! form opts [budget])  → promise of handle   ;; + :html
(hm/render! handle form)          → handle
(hm/dispatch-and-settle! h event) → handle
(hm/settle! handle)               → handle
(hm/unmount! handle)              → handle
(hm/assert-clean! handle)         → promise of the report   ;; reports
(hm/residue handle)               → promise of the report   ;; asserts nothing
(hm/census)                       → the count map
hm/counted                        → the five counters, as data
```

Every door takes the handle first and answers it, so a whole test threads:

```clojure
(-> (hm/unmount! m) (hm/assert-clean!) (.then done))
```

The handle **is** the runtime's own root handle with bookkeeping added beside it,
so `(:container m)` and `(:frame m)` are the real container node and the real
frame id, not accessors over a wrapper.

### `mount!` owns its frame, and takes no `:frame`

The hardest constraint — *frames are isolated contexts* — is made **structural**
rather than documented. `mount!` mints a frame per call, seeds it through
`rf/make-frame`'s own `:initial-events` channel, and destroys it in
`assert-clean!`. There is no `:frame` option, so two mounted apps cannot see each
other's state: neither can be handed the other's frame. Nothing takes a frame-id
as a view argument anywhere in the diff. The deliberately shared-frame multi-root
case is a claim about the *runtime*, and stays where it already lives
(`roots-frames-*` against `impl.mount`).

### No selector language, no library dependency

`(:container m)` is a real element attached to `document.body`, so `getBy*`,
`within` and `screen` work on it unchanged and a `user-event` sequence dispatches
real DOM events at real nodes. Nothing `:require`s `@testing-library/dom` — the
repo does not install it, and the facade would not want to force it. `settle!` is
the door you call after an outside stimulus. The interop contract is *asserted*
rather than claimed: the witness checks `.-isConnected` and
`document.body.contains`, then drives a real `HTMLElement.click()`.

### `assert-clean!` reports; it does not throw

`residue` is the data half, `assert-clean!` is `residue` plus one
`cljs.test/do-report`. A residue finding is a **test failure**, not a refusal of
the instrument, so it lands as an ordinary `FAIL in (your-test)` — never a
rejected promise a `.then` chain turns into a hung async test, and never a boolean
the caller must remember to assert. It never throws, so `(.then done)` is the whole
of the plumbing.

**This namespace mints no `:rf.error/*` id at all.** A malformed form is refused by
the *runtime* with the runtime's own id, reason and recovery — the discipline
`re-frame.hicasso.test` established. And
`:rf.error/hicasso-test-residue-after-quiescence` is **reserved** in the complaint
register for a raising variant; promoting a reservation is a deliberate act across
`spec/009` and the register, both of which this bead is fenced out of. Reported,
not taken — see *Reported* below.

### Two design decisions worth reading

**The baseline is per mount, taken after this mount's frame exists and before its
root does.** A page that already held a live root when the mount began is not this
mount's residue. Frames minted by *other* facade mounts are subtracted from the
frame delta, so one mount is never blamed for a peer's frame.

**The reset is gated on unread mounts, not standing ones** (commit `3034369dbb`).
`reset-runtime!` empties every table by fiat and the tables are page-wide, so
resetting while another mount is still waiting to be read makes *that* reading
vacuous — a census after a reset answers zero whether the teardown released
anything or not. Two mounts can both be down and only one of them read, which is
why "unmounted" is the wrong question. A mount that never gets a verdict suppresses
the reset from then on: that is the benign direction, and it is why the gate is
spelled this way round.

## Which leak kinds `assert-clean!` drives — and which it does not

Derived from the grammar (*what can outlive a root*), not from the implementation.

**Driven, in `test_kit_mounted_dom_cljs_test`:**

| leak | driven by | seen as |
|---|---|---|
| a subscription | a second root put up inside the mount's window and left standing | `:cells` / `:cell-refs` / `:boundaries` / `:edges` |
| a read-set entry | the same root | `:entries` |
| a live frame | `rf/make-frame` inside the mount's window | `:frames`, **naming the id** |
| a mounted root | skipping `unmount!` | `:still-mounted?`, reported as itself |

The frame row additionally asserts `(= [:frames] (keys (:leaked report)))` — the
leak is reported *alone*, so a reader is not sent hunting a subscription that is
not there. The still-mounted row is paired with its own control: after the
teardown it *does* go clean.

**NOT driven, and not visible — named in the witness docstring rather than left to
be discovered:**

- **an armed timer** (`setTimeout` / `setInterval` / `requestAnimationFrame`) and a
  **DOM listener on `document`/`window`**: no census exists, and taking one means
  monkeypatching the host's scheduler and `addEventListener` — an instrument that
  rewrites the platform under the code it measures;
- **a pending effect** — an async `rf/dispatch` still queued, or an fx in flight.
  Core publishes no queue census; `dispatch-and-settle!` uses the runtime's
  *synchronous* door, which drains to fixed point before returning, so what the
  facade could honestly see is exactly what it already settles;
- **a core-level `rf/subscribe`** held outside a Hicasso body: it lives in core's
  sub-cache, not in the cell table this census reads;
- **a retained foreign-host callback**: visible only through what it retains. If it
  holds a subscription it is the first row; if it holds nothing countable it is
  invisible here.

## Mutation proof — the verbatim red

The shipped sabotage row reads its verdict through `residue` (so it is green when
the instrument works). To see `assert-clean!` itself redden, that one call was
changed to `assert-clean!`, `npm run test:browser` re-run, and the file restored
with `git checkout` — `git status` clean, byte-identical, re-confirmed green.

Mutated run: **exit 1, exactly one failure**, and the assertion count moved by
exactly one (7335 vs 7334) — the `do-report` and nothing else.

```
Testing re-frame.hicasso.test-kit-mounted-dom-cljs-test

FAIL in (l3-assert-clean-sees-a-leaked-subscription) (:)
the mount left residue behind after quiescence.
The baseline was taken inside mount! #4, after this mount's own
frame :re-frame.hicasso.test.mounted/mount-4 existed and before its root did; the reading below was
taken after unmount! and after the runtime's own reaper horizon.

  :cells      0 → 1  (+1)
  :cell-refs  0 → 1  (+1)
  :boundaries 0 → 1  (+1)
  :edges      0 → 1  (+1)
  :entries    0 → 1  (+1)

Something outlived the root. A retained subscription, a foreign host that
mounts its own root, or a frame the app made and did not destroy.
expected: (clean? handle)
  actual: {:cells 1, :cell-refs 1, :boundaries 1, :edges 1, :entries 1}
```

Restored: `Ran 1177 tests containing 7334 assertions. 0 failures, 0 errors.`

## The witnesses

- **W1 — the dogfood claim, one rung up.** `test-kit-dogfood-cljs-test`'s L1 row
  proves a lowered intent reaches a real handler *with no element anywhere*, and
  says so: "no bubbling, no default action … and no React event system". W1 is the
  same claim with every one of those present — a real `HTMLElement.click()` (what
  `user-event` ultimately performs) on a button in `document.body`, through React's
  own event system, asserted on the repainted page. Plus `dispatch-and-settle!`
  driving the same page from outside, and a clean teardown as the sabotage rows'
  positive control.
- **W2 — two mounts are two isolated frames.** Two frames neither test supplied;
  the cell table split by frame; one reader per key (a leak is *two* readers on
  *one* key); and a dispatch into A moving A's page and not B's.
- **W3–W5 — the three sabotages** above.
- **W6 — `render!` changes props without remounting**: the same DOM node is still
  there afterwards (`identical?`), which is the claim no semantic tree can make.
- **W7 — `hydrate!` resolves on adoption**, not on the call returning. Server bytes
  are stamped with an **expando** (an attribute round-trips through `innerHTML`; an
  expando does not), and the row asserts the stamp survives — adoption, not a client
  render that happens to agree — before and after a commit.

## Quality gates

| gate | exit | note |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | **0** | `gate root: /c/Users/miket/code/re-frame2-worktrees/mounted-hic027`; `PASS fast PR spine`. Node tier: `Ran 13029 tests containing 65790 assertions. 0 failures, 0 errors.` |
| `npm run test:browser` (`:browser-test`, the required `cljs-browser` job) | **0** | `Ran 1177 tests containing 7334 assertions. 0 failures, 0 errors.` — the lane where every row in this diff actually executes |
| `npm run test:browser` under the sabotage mutation | **1** | 1 failure, quoted verbatim above; restored byte-identically and re-run green |
| hicasso node lane (`:node-test-hicasso`) | **0** | `Ran 190 tests containing 886 assertions. 0 failures, 0 errors.` (rows degrade to stated skips — no DOM) |
| `npm run test:hicasso-freeze` | **0** | freeze + optional-module reachability + **complaint catalogue**: `59 live, 12 reserved … every reservation is unbuilt`. The reason this diff mints no error id. |
| `npm run test:hicasso-lint` | **0** | clj-kondo export witness |
| `python scripts/check_test_lane_bijection.py` | **0** | the new namespace is selected by an existing lane; no build id or npm script added |

`npm run test:hicasso-invariants` **does not exist on this base** — the script is
`test:hicasso-freeze` (PR #7813 may rename it), and that is what was run.

Gap derived with `python scripts/check_fast_pr_gap.py --list`. Not run, with reasons:

- **lint.yml (clj-kondo 2026.04.15, splint, eslint, api-manifest)** — the pinned
  binary is not installed locally and a differently-versioned pass proves nothing;
  no JS and no public API manifest changed.
- **docs.yml** — no documentation content changed. (`mkdocs build --strict` would
  not cover this diff at all.)
- **JVM artefact suites** — this diff is CLJS-only, and `hicasso/deps.edn` declares
  zero JVM tests by design (`--probe`).
- **Production-elision / bundle-isolation / perf-bundle / examples-compile** — the
  kit is dev/test-only, lives outside the artefact's published `:paths`, and no
  production source, `deps.edn`, `shadow-cljs.edn` or example moved.
- **Adapter smokes, Xray feature gate, Story, mcp-conformance, tools JVM** — no
  adapter, tool or example surface touched.
- **`test:hicasso-controlled` / `test:hicasso-hmr`** — the controlled-input and HMR
  testbeds are untouched.

## Reported, not taken

1. **`:rf.error/hicasso-test-residue-after-quiescence` stays reserved.** The
   register earmarks it for "the mounted test facade's clean-state assertion", and
   this facade reports instead of raising. Promoting it needs an emitter, a
   `spec/009` row and a register move — both files are hot-zone and fenced from this
   bead. Worth a decision: *does the mounted facade ever want a raising variant, or
   is the reservation now retirable?* Reporting is the better default for an
   assertion, so my recommendation is to retire it.
2. **`docs/design/hicasso/draft-guide/14-testing.md` spells the facade `ht/…` and
   `ht/rerender!`.** The bead's deliverable list (authoritative) says `render!`, and
   this ships as `hm/render!` in its own namespace for the packaging reason above.
   The chapter also documents `ht/tree`, an API the shipped kit does not have (PR
   #7812 already flagged that). One doc-sync bead covers all three; that tree is
   fenced to `worker/kitdocs-hpoy`.
3. **No `@testing-library/dom` dependency was added** — that is an
   `implementation/package.json` change with lockfile churn, and the facade
   deliberately does not need one. If the project wants the guide's exact example to
   be runnable in-repo, that is its own bead.
