### PR TITLE
fix(xray): make a Hicasso row key injective, proved by property (rf2-hic-023)

### DIFF
--- a/tools/xray/spec/027-Hicasso-Evidence.md
+++ b/tools/xray/spec/027-Hicasso-Evidence.md
@@ -355,6 +355,72 @@ registration id project to one identity — the producer's documented ceiling,
 which the mounted census resolves by grouping and the Reads roster inherits
 because it prints the cell table as it stands.
 
+### The key is INJECTIVE, and the label is where readability lives
+
+Carrying all three parts was necessary and not sufficient. For one further
+increment `read-key-str` joined the parts' `pr-str` forms with `-`, and
+`read-slug` and `boundary-slug` spent the result through `id-slug`, which
+replaces every run of non-alphanumerics with `-` and folds case. Namespace
+separators, in-name hyphens, component boundaries and collection punctuation
+therefore all collapsed onto one character, and the encoding reintroduced the
+very collision it had been written to close (audit #7820):
+
+```clojure
+;; on merge dbbcf05584
+(map read-slug [[:a/b :c :d] [:a-b :c :d] [:a :b/c :d]])  ;=> ["a-b-c-d" "a-b-c-d" "a-b-c-d"]
+(map #(boundary-slug {:key [%]}) …)                       ;=> ["a-b-c-d" "a-b-c-d" "a-b-c-d"]
+```
+
+Namespaced and hyphenated ids are ordinary programmer input, not an
+adversarial edge.
+
+A React key and a DOM testid do two jobs that are **not the same job**, so
+the string has two halves and neither compromises for the other:
+
+| Half | Its job | Built by |
+|---|---|---|
+| the stem | readable — a human reading a failing selector can tell which row it named | `id-slug`, lossy on purpose |
+| the tail | unique — the reconciler must never treat two rows as one | `escaped`, reversible |
+
+`escaped` rewrites the identity string into `[A-Za-z0-9%u]`: an ASCII
+alphanumeric survives as itself, and every other character becomes `%` plus
+its UTF-16 code unit in hex — two digits below 256, `%u` plus four digits
+above it. `%` is itself escaped and `u` is not a hex digit, so the encoding
+parses back exactly one way. It emits no `-`, so the LAST `-` in a slug is
+always the join and the tail behind it decodes to exactly one input. That is
+the injectivity argument, and it is an argument about the function rather
+than an observation about three fixtures.
+
+Neither half is the row's LABEL. The projected query and the frame are
+printed on the row, which is where a reader actually looks — which is what
+frees the key to be ugly.
+
+`read-key-str` remains the one projected-identity door and spends one
+`pr-str` over the whole triple rather than three joined by a separator: a
+separator between printed components can be forged by a component that
+contains it, while `pr-str` quotes what it prints. It also normalises the
+triple, so an identity arriving as a seq does not mint a second key for one
+fact, and it is the same canonical string the producer sorts its own rows by.
+Its domain is stated rather than assumed — injective over the EDN a projected
+identity is made of, being keywords, strings, numbers, booleans, nil and
+sequential collections of those. It does not claim to separate what `pr-str`
+cannot print apart: a deliberately reader-hostile symbol, or two `=`-equal
+maps built in two insertion orders, which print in iteration order because
+that is the producer's canonical form and not a second one invented here.
+
+Intent rows are keyed by the same encoding, for the same reason: `id-slug`
+alone gave `:a/b-c` and `:a-b/c` one testid.
+
+**The guard is a property, not three examples.** The audited increment
+asserted that its own three fixtures came out distinct — true, and equally
+true of a constant function on three points, which is how the collision
+shipped green. The suite now generates 21 legal component shapes across the
+three projected positions (9261 identities), 10162 boundary keys and 441
+intent rows, and asserts that distinct identities yield distinct strings over
+the whole space. A non-vacuity assertion pins the pool to its job: the
+three-way control must still collide under `id-slug` alone, or the space has
+stopped testing anything and needs re-choosing.
+
 ### Every absence is a chip, and the five chips differ
 
 `hicasso-helpers/loss-chip` turns a loss (or an `:unknown` value) into
@@ -422,6 +488,6 @@ Adding it moved six governance pins, each of which fails the build on drift:
 |---|---|---|
 | `re-frame.hicasso.evidence-schema-cljs-test` | node | every shape in which a projection would claim more than it knows is refused, each with a positive control |
 | `re-frame.hicasso.tool-reads-cljs-test` | node (reactive substrate) | the four reads over real committed boundaries; the seeded-value privacy witness for a return value AND for a query argument; two frames sharing a sub id with asymmetric windows; the dispatch-ordered, fragment-merged intent stream; determinism; the production-nil arm |
-| `…panels.hicasso-helpers-cljs-test` | node + JVM | the five absences and the empties are pairwise distinct — including the four per-view empties; labels and testids are built from the projected key; a row key carries the WHOLE projected identity, so two frames' boundaries over one query do not collide; two query variants do not collapse; the superseded v1 stamp is refused rather than mis-parsed; the schema pin; row projections |
+| `…panels.hicasso-helpers-cljs-test` | node + JVM | the five absences and the empties are pairwise distinct — including the four per-view empties; labels and testids are built from the projected key; a row key carries the WHOLE projected identity, so two frames' boundaries over one query do not collide; two query variants do not collapse; the key is INJECTIVE as a property over a generated space of 9261 identities, 10162 boundary keys and 441 intent rows, with a non-vacuity control that the space still defeats a lossy slug; the superseded v1 stamp is refused rather than mis-parsed; the schema pin; row projections |
 | `…panels.hicasso-cljs-test` | node (reactive substrate) | the four views answer on a running app; the loss states render under distinct testids, driven between two real window states; a sensitive query argument reaches neither the page nor a testid; the Reads and Why rows carry the frame on the page and in the testid; each view renders its own empty; both the superseded and an unknown stamp render the mismatch; the seam reshapes nothing |
 | `feature_matrix/scenarios.cjs` | browser | the tab reaches a real panel root in the shell sweep |

--- a/tools/xray/src/day8/re_frame2_xray/panels/hicasso_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/hicasso_helpers.cljc
@@ -291,13 +291,82 @@
   (if (keyword? x) (str x) (pr-str x)))
 
 (defn id-slug
-  "A testid-safe slug for `x`. Total: an unprintable value still yields a
-  selectable id rather than an exception at render time."
+  "A READABLE testid stem for `x`. Total: an unprintable value still
+  yields a selectable id rather than an exception at render time.
+
+  Lossy on purpose, and therefore never an identity on its own — it maps
+  every run of non-alphanumerics to one `-` and folds case, so
+  `[:a/b :c :d]`, `[:a-b :c :d]` and `[:a :b/c :d]` all come out
+  `a-b-c-d`. [[identity-slug]] is what a React key and a DOM testid are
+  made of; this is the half of it a human reads."
   [x]
   (-> (str (if (keyword? x) (subs (str x) 1) (pr-str x)))
       (string/replace #"[^a-zA-Z0-9]+" "-")
       (string/replace #"^-|-$" "")
       (string/lower-case)))
+
+(def ^:private hex-digits "0123456789ABCDEF")
+
+(defn- code-unit
+  "One character's UTF-16 code unit.
+
+  Both hosts iterate a string as UTF-16 code units, so both encoders
+  agree character for character — which they must, because the suite that
+  asserts these slugs is a `.cljc` and runs the same expectations under
+  the JVM and under node."
+  [c]
+  #?(:clj  (int c)
+     :cljs (.charCodeAt c 0)))
+
+(defn- hex
+  "`n` as exactly `width` uppercase hex digits."
+  [n width]
+  (apply str (map (fn [shift] (nth hex-digits (bit-and (bit-shift-right n shift) 15)))
+                  (range (* 4 (dec width)) -1 -4))))
+
+(defn- escaped
+  "`s` rewritten into the alphabet `[A-Za-z0-9%u]`, REVERSIBLY.
+
+  An ASCII alphanumeric survives as itself; every other character becomes
+  `%` and its code unit in hex — two digits below 256, and `%u` plus four
+  digits above it. `%` is itself escaped and `u` is not a hex digit, so
+  the result parses back exactly one way and no two strings can encode to
+  one. That is the entire job: [[id-slug]] is a MANY-to-one map, and
+  many-to-one is how two rows came to share a React key."
+  [s]
+  (->> s
+       (map (fn [c]
+              (let [n (code-unit c)]
+                (cond
+                  (or (<= 48 n 57) (<= 65 n 90) (<= 97 n 122)) (str c)
+                  (< n 256) (str "%" (hex n 2))
+                  :else     (str "%u" (hex n 4))))))
+       (string/join)))
+
+(defn identity-slug
+  "The React key and DOM testid for one identity string `s`: the readable
+  [[id-slug]] stem, a `-`, then [[escaped]].
+
+  TWO JOBS, WHICH ARE NOT THE SAME JOB — which is why the string has two
+  halves. A React key must be UNIQUE or the reconciler treats two rows as
+  one. A testid must be STABLE and select exactly one row, and it helps
+  enormously if a human reading a failing selector can tell which row it
+  named. Neither has to be pretty, and neither is the row's LABEL: the
+  projected query and the frame are printed on the row itself, which is
+  where a reader actually looks. So the stem carries the readability and
+  the tail carries the identity, and neither has to compromise for the
+  other.
+
+  INJECTIVE, and provably so rather than by inspection of a few examples:
+  `escaped` emits no `-`, so the LAST `-` in the result is always the
+  join, and the tail behind it decodes to exactly one input string. The
+  encoding that preceded this one was `id-slug` alone, which folded
+  `[:a/b :c :d]`, `[:a-b :c :d]` and `[:a :b/c :d]` onto one `a-b-c-d` —
+  three legal, distinct projected identities under one React key and one
+  testid (audit #7820). Namespaced and hyphenated ids are ordinary
+  programmer input, not an adversarial edge."
+  [s]
+  (str (id-slug s) "-" (escaped s)))
 
 (def redacted
   "The egress projector's whole-value sentinel.
@@ -347,15 +416,34 @@
   Projected fields only. The query arrives already projected and is
   printed as found; re-admitting the raw query to make a slug more
   readable would undo the producer's redaction at the last step, which is
-  the exact escape the #7789 audit caught."
+  the exact escape the #7789 audit caught.
+
+  ONE `pr-str` over the whole triple, not three joined by a separator: a
+  separator BETWEEN printed components can be forged by a component that
+  contains it, while `pr-str` quotes what it prints, so the brackets and
+  the spaces between elements cannot be. It also normalises the triple,
+  so an identity arriving as a seq does not mint a second React key for
+  the same fact. This is the same canonical string the producer sorts its
+  own rows by, so consumer and producer agree on what the identity is.
+
+  DOMAIN, stated rather than assumed: injective over the EDN a projected
+  identity is made of — keywords, strings, numbers, booleans, nil and
+  sequential collections of those — because `pr-str` is reader-faithful
+  there. It does not claim to separate what `pr-str` cannot print apart:
+  a deliberately reader-hostile `(symbol \"a :b\")`, or two `=`-equal
+  maps built in two insertion orders (which print in iteration order —
+  the producer's canonical form, inherited here rather than a second one
+  invented)."
   [[frame-id sub-id query]]
-  (str (pr-str frame-id) "-" (pr-str sub-id) "-" (pr-str query)))
+  (pr-str [frame-id sub-id query]))
 
 (defn read-slug
-  "A testid-safe slug for ONE projected read identity — see
-  [[read-key-str]] for why all three parts are in it."
+  "A React key / DOM testid for ONE projected read identity — see
+  [[read-key-str]] for why all three parts are in it, and
+  [[identity-slug]] for why the string has a readable half and an
+  injective half."
   [read-identity]
-  (id-slug (read-key-str read-identity)))
+  (identity-slug (read-key-str read-identity)))
 
 (defn boundary-label
   "A boundary's edge set as one line — the identity the runtime actually
@@ -381,10 +469,20 @@
   — it was dropped, so `[[:frame/a :row [:row 1]]]` and
   `[[:frame/b :row [:row 1]]]` both slugged `row-row-1`, giving two
   genuinely different boundaries one React key and one testid
-  (audit #7802)."
+  (audit #7802).
+
+  A boundary reads a SET of cells, so the join BETWEEN elements has to be
+  as unforgeable as the join inside one. Each element is already its own
+  `pr-str`, so wrapping the space-joined elements in brackets is exactly
+  `pr-str` of the normalised key — one reader-faithful string for the
+  whole boundary, then [[identity-slug]] over it.
+
+  A read-free key keeps its readable name, and no key with reads in it
+  can mint that name: every other slug carries the `%` that
+  [[escaped]] emits for the leading `[`."
   [{:keys [key]}]
   (if (seq key)
-    (id-slug (string/join "-" (map read-key-str key)))
+    (identity-slug (str "[" (string/join " " (map read-key-str key)) "]"))
     "reads-nothing"))
 
 ;; ---------------------------------------------------------------------------
@@ -475,7 +573,10 @@
              ;; Slugged by DISPATCH-ID as well as event id: the stream is
              ;; ordered by dispatch and one event id can appear many times
              ;; in a window, so an event-only testid would name several rows.
-             :slug        (id-slug (str (pr-str (:event-id i)) "-" (pr-str (:dispatch-id i))))
+             ;; Through the same injective encoding as a read key, for the
+             ;; same reason: `id-slug` alone folded `:a/b-c` and `:a-b/c`
+             ;; onto one intent testid (audit #7820).
+             :slug        (identity-slug (pr-str [(:event-id i) (:dispatch-id i)]))
              :arg-count   (:arg-count i)
              :frames      (:frames i)
              :sub-ids     (:sub-ids i)})

--- a/tools/xray/test/day8/re_frame2_xray/panels/hicasso_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/hicasso_helpers_cljs_test.cljc
@@ -344,6 +344,145 @@
           "the slug is built from the sentinel the producer sent, never from a
            raw query recovered to make the row legible"))))
 
+;; ---------------------------------------------------------------------------
+;; The row key is INJECTIVE — the property, not three examples
+;; ---------------------------------------------------------------------------
+
+(def ^:private legal-components
+  "Every SHAPE a projected identity component legally takes, and the pairs
+  of shapes that a lossy encoding folds together.
+
+  MERGED-PR AUDIT #7820 found the collision this pool exists to catch by
+  GENERATING identities; the increment it audited asserted only that ITS
+  OWN three fixtures came out distinct, which is true of a constant
+  function on three points. So the guard below is a property over a
+  generated space and the hand-written rows underneath it are for
+  readability only.
+
+  The pool is chosen so that the three ways a slug can lose information
+  are all present and all adjacent: the namespace separator (`:a/b`), an
+  in-name hyphen (`:a-b`), and the boundary BETWEEN two components
+  (`:a` then `:b/c`). Numbers `1` and `12` sit next to each other for the
+  same reason, and `[:a :b]` next to `[[:a] :b]` puts a nesting level
+  where a flattening encoding cannot see it."
+  [;; keywords: plain, namespaced, hyphenated, and both
+   :a :b
+   :a/b :b/a
+   :a-b
+   :a/b-c :a-b/c
+   ;; strings — the same three shapes again, where `pr-str` quotes them
+   "a" "a-b" "a/b"
+   ;; numbers, including a two-digit one adjacent to its digits
+   0 1 12
+   ;; vectors: empty, single, multiple, hyphenated, and two nestings
+   [] [:a] [:a :b] [:a-b] [[:a] :b] [:a [:b]]
+   ;; the two sentinels the producer sends in place of a value
+   :rf/redacted :unknown])
+
+(def ^:private legal-identities
+  "The cross-product of [[legal-components]] in all three projected
+  positions — frame, registration id, query. Every element is a legal
+  projected identity and no two are equal, so the count IS the number of
+  distinct keys the panel must be able to mint."
+  (vec (for [frame legal-components
+             sub   legal-components
+             query legal-components]
+         [frame sub query])))
+
+(def ^:private legal-boundary-keys
+  "Boundary keys over the same space: the empty key, every identity as a
+  one-read key, and every ordered pair drawn from a slice of the space —
+  a boundary reads a SET of cells, so the encoding has to survive the
+  join between elements as well as the join inside one."
+  (into [[]]
+        (concat (map vector legal-identities)
+                (for [a (take 30 legal-identities)
+                      b (take 30 legal-identities)]
+                  [a b]))))
+
+(defn- collisions
+  "The values of `f` that more than one input produced, with their inputs
+  — so a failure NAMES the colliding rows instead of quoting two counts."
+  [f xs]
+  (->> xs
+       (group-by f)
+       (filter (fn [[_ ins]] (< 1 (count ins))))
+       (map (fn [[out ins]] [out (vec (take 3 ins))]))
+       (take 3)
+       vec))
+
+(deftest a-row-key-is-INJECTIVE-over-the-whole-legal-identity-space
+  ;; MERGED-PR AUDIT #7820. The fix for #7802 put the whole projected
+  ;; identity into one string and then passed that string through
+  ;; `id-slug`, which replaces every run of non-alphanumerics with `-`.
+  ;; Namespace separators, in-name hyphens, component boundaries and
+  ;; collection punctuation all became the same character, so the encoding
+  ;; REINTRODUCED the collision it was written to close:
+  ;;
+  ;;   [:a/b :c :d]  [:a-b :c :d]  [:a :b/c :d]  ->  "a-b-c-d" x3
+  ;;
+  ;; A React key must be unique and a testid must select one row. Neither
+  ;; has to be pretty — the projected query and the frame are printed as
+  ;; the row's LABEL, which is where a reader looks.
+  (testing "NON-VACUITY: the space really does defeat a lossy slug"
+    (is (= 1 (count (distinct (map #(hh/id-slug (pr-str %))
+                                   [[:a/b :c :d] [:a-b :c :d] [:a :b/c :d]]))))
+        "if these three ever stop colliding under `id-slug` alone, the
+         property below has stopped testing anything and the pool needs
+         re-choosing"))
+
+  (testing "the door itself is injective — one string per identity"
+    (is (= (count legal-identities)
+           (count (distinct (map hh/read-key-str legal-identities))))
+        (str "read-key-str collisions: " (pr-str (collisions hh/read-key-str legal-identities)))))
+
+  (testing "DISTINCT IDENTITIES YIELD DISTINCT READ SLUGS, over the whole space"
+    (is (= (count legal-identities)
+           (count (distinct (map hh/read-slug legal-identities))))
+        (str "read-slug collisions: " (pr-str (collisions hh/read-slug legal-identities)))))
+
+  (testing "and distinct boundary KEYS yield distinct boundary slugs"
+    (let [slug (fn [k] (hh/boundary-slug {:parent nil :key k}))]
+      (is (= (count legal-boundary-keys)
+             (count (distinct (map slug legal-boundary-keys))))
+          (str "boundary-slug collisions: " (pr-str (collisions slug legal-boundary-keys))))
+      (is (= "reads-nothing" (slug []))
+          "the read-free key keeps its readable name")
+      (is (not (contains? (set (map slug (rest legal-boundary-keys))) "reads-nothing"))
+          "and no key with reads in it can mint that name")))
+
+  (testing "an intent row key is injective over the same shapes"
+    (let [rows (for [event-id  legal-components
+                     dispatch  legal-components]
+                 {:event-id event-id :dispatch-id dispatch})
+          slug (fn [r] (:slug (first (hh/intent-rows
+                                       (envelope :intents {:scope {:frames [] :retained-runs 0}
+                                                           :intents [r]})))))]
+      (is (= (count rows) (count (distinct (map slug rows))))
+          (str "intent slug collisions: " (pr-str (collisions slug rows))))))
+
+  (testing "EQUAL identities yield ONE key — a seq and a vector are one row"
+    (is (= (hh/read-slug [:app/main :todo [:todo 7]])
+           (hh/read-slug (seq [:app/main :todo [:todo 7]])))
+        "the door normalises the triple, so an identity that arrives as a
+         seq does not mint a second React key for the same fact"))
+
+  (testing "the three-way control from the audit, spelled out"
+    (let [three [[:a/b :c :d] [:a-b :c :d] [:a :b/c :d]]]
+      (is (= 3 (count (distinct (map hh/read-slug three))))
+          (str "read-slugs: " (pr-str (mapv hh/read-slug three))))
+      (is (= 3 (count (distinct (map #(hh/boundary-slug {:parent nil :key [%]}) three))))
+          (str "boundary-slugs: "
+               (pr-str (mapv #(hh/boundary-slug {:parent nil :key [%]}) three))))))
+
+  (testing "the readable stem survives, so a testid is still greppable"
+    (is (string/starts-with? (hh/read-slug [:frame/a :row [:row 1]]) "frame-a-row-row-1-")
+        "the stem is the old slug; the tail behind the last `-` is what
+         makes it injective")
+    (is (not (string/includes? (hh/read-slug [:app/main :todo :rf/redacted]) "hunter"))
+        "and the encoding re-admits nothing — it encodes the PROJECTED
+         string it was handed and recovers no raw query")))
+
 (deftest intent-rows-carry-an-id-and-an-arity-and-no-arguments
   (let [e (envelope :intents
                     {:scope {:frames [:app/main] :retained-runs 2}


### PR DESCRIPTION
MERGED-PR AUDIT #7820, the one correctness residual. #7820 is otherwise sound
and nothing in it is undone: the v2 lockstep, the projected-fields-only
plumbing, the Reads and Why rows printing the query and the frame all stand.

## The defect

#7820 put the WHOLE projected identity into one string — correctly — and then
spent that string through `id-slug`, which replaces every run of
non-alphanumerics with `-` and folds case. Namespace separators, in-name
hyphens, component boundaries and collection punctuation therefore all
collapse onto one character, so the encoding reintroduced the very collision
it was written to close, by a different mechanism.

Reproduced on the landed helper before any change (JVM, `tools/xray`):

```
identities:      [:a/b :c :d]   [:a-b :c :d]   [:a :b/c :d]
read-key-strs:   ":a/b-:c-:d"    ":a-b-:c-:d"    ":a-:b/c-:d"
read-slugs:      a-b-c-d         a-b-c-d         a-b-c-d
boundary-slugs:  a-b-c-d         a-b-c-d         a-b-c-d
distinct counts: 1 and 1
```

Three legal, distinct projected identities under one React key and one DOM
testid. Namespaced and hyphenated keyword ids are ordinary programmer input,
not an adversarial edge.

## The encoding, and why it has two halves

**A React key and a DOM testid do two jobs that are not the same job.** A key
must be UNIQUE or the reconciler treats two rows as one. A testid must be
STABLE and select exactly one row, and it helps enormously if a human reading
a failing selector can tell which row it named. Neither has to be pretty —
and crucially neither is the row's LABEL. #7820 already prints the projected
query and the frame on the row, which is where a reader actually looks. That
separation is what dissolves the tension: the key is free to be ugly.

So `identity-slug` is the readable `id-slug` stem, a `-`, then `escaped`:

| Half | Its job | Built by |
|---|---|---|
| the stem | readable — a failing selector still names its row | `id-slug`, lossy on purpose |
| the tail | unique — two rows are never one key | `escaped`, reversible |

`escaped` rewrites the identity string into `[A-Za-z0-9%u]`: an ASCII
alphanumeric survives as itself, every other character becomes `%` plus its
UTF-16 code unit in hex — two digits below 256, `%u` plus four above. `%` is
itself escaped and `u` is not a hex digit, so it parses back exactly one way.
It emits no `-`, so the LAST `-` in a slug is always the join and the tail
behind it decodes to exactly one input. **That is an argument about the
function, not an observation about three fixtures.**

```
[:a/b :c :d]         -> a-b-c-d-%5B%3Aa%2Fb%20%3Ac%20%3Ad%5D
[:a-b :c :d]         -> a-b-c-d-%5B%3Aa%2Db%20%3Ac%20%3Ad%5D
[:a :b/c :d]         -> a-b-c-d-%5B%3Aa%20%3Ab%2Fc%20%3Ad%5D
[:app/main :todo [:todo 7]]
                     -> app-main-todo-todo-7-%5B%3Aapp%2Fmain%20%3Atodo%20%5B%3Atodo%207%5D%5D
a wholly redacted read -> app-main-todo-rf-redacted-%5B…%3Arf%2Fredacted%5D
a read-free boundary   -> reads-nothing
```

No ordinal. No store, no framework, no compatibility layer. Nothing raw
returns: `escaped` encodes the string `read-key-str` handed it and recovers
nothing, so a wholly redacted query still slugs from the sentinel the producer
sent, and the read-free boundary keeps its readable name (no key with reads
can mint it — every other slug carries a `%`).

`read-key-str` remains the one projected-identity door and now spends one
`pr-str` over the whole triple instead of three joined by `-`: a separator
between printed components can be forged by a component that contains it,
while `pr-str` quotes what it prints. It also normalises the triple, so an
identity arriving as a seq does not mint a second key for one fact — and it is
the same canonical string the producer sorts its own rows by, so producer and
consumer agree on what the identity is.

**Intent rows** went through the identical lossy encoding one line away —
`:a/b-c` and `:a-b/c` shared a testid — and now go through the same injective
one. Same defect class, one line, covered by the same property.

## The proof is a property, not examples

This is why the bead reopened, so it is where the effort went. #7820 asserted
that ITS OWN three fixtures came out distinct — true, and equally true of a
constant function on three points.

`legal-components` is 21 component shapes chosen so the three ways a slug
loses information are present and ADJACENT: the namespace separator (`:a/b`),
an in-name hyphen (`:a-b`), and the boundary BETWEEN two components (`:a` then
`:b/c`). `1` sits next to `12`; `[:a :b]` next to `[[:a] :b]`. The generated
space:

| Space | Size |
|---|---|
| identities (the cross-product over frame / sub-id / query) | **9261** |
| boundary keys (empty, every identity as a one-read key, every ordered pair from a 30-slice) | **10162** |
| intent rows (`[event-id dispatch-id]`) | **441** |

Distinct inputs must yield distinct strings across all three, and a failure
NAMES the colliding rows rather than quoting two counts. A **non-vacuity**
assertion pins the pool to its job: the three-way control must still collide
under `id-slug` alone, or the space has stopped testing anything.

**Deliberately excluded**, and stated in the docstring and Spec 027 rather
than assumed: values `pr-str` cannot print apart. A reader-hostile
`(symbol "a :b")` can forge structure, and two `=`-equal maps built in two
insertion orders print in iteration order. The latter is the producer's own
canonical form — it sorts its rows by `pr-str` of the same key — inherited
here rather than a second one invented in the consumer. Records were excluded
for the same reason: not part of the stated domain.

## Mutation proof

Reverted `hicasso_helpers.cljc` to the landed encoding with
`git diff a7a0b00b65 a7a0b00b65^ -- <file> | git apply`, and verified the
mutation was really applied before believing the result (`git diff --stat`
showed 10 insertions / 111 deletions, and the four landed call sites were back
in the file). Verbatim red:

```
FAIL in (a-row-key-is-INJECTIVE-over-the-whole-legal-identity-space)
DISTINCT IDENTITIES YIELD DISTINCT READ SLUGS, over the whole space
read-slug collisions: [["a-b-rf-redacted-a-b" [[:a/b :rf/redacted :a/b] [:a/b :rf/redacted :a-b] [:a/b :rf/redacted "a-b"]]] ...]
expected: (= (count legal-identities) (count (distinct (map hh/read-slug legal-identities))))
  actual: (not (= 9261 1031))

FAIL ... and distinct boundary KEYS yield distinct boundary slugs
  actual: (not (= 10162 1276))

FAIL ... an intent row key is injective over the same shapes
  actual: (not (= 441 107))

FAIL ... the three-way control from the audit, spelled out
read-slugs: ["a-b-c-d" "a-b-c-d" "a-b-c-d"]
  actual: (not (= 3 1))

FAIL ... boundary-slugs: ["a-b-c-d" "a-b-c-d" "a-b-c-d"]
  actual: (not (= 3 1))

FAIL ... the readable stem survives, so a testid is still greppable
  actual: (not (string/starts-with? "frame-a-row-row-1" "frame-a-row-row-1-"))

Ran 16 tests containing 126 assertions.
6 failures, 0 errors.
```

Restored with `git checkout --`; `git status` reported the file clean against
HEAD (byte-identical), and the re-run was 16 tests / 126 assertions, 0
failures.

## Spec 027

**Moved.** A new section under the rendering contract, *The key is INJECTIVE,
and the label is where readability lives*, records the collision with its
reproduction, the two-halves shape and why the two jobs are not the same job,
the injectivity argument, `read-key-str`'s stated domain, and that the guard is
a generated property rather than three fixtures. The test-coverage table names
the property and its size. Table column counts and heading anchors verified by
hand (all tables uniform, fences balanced) in addition to the slug checker.

## Quality gates

| Gate | Exit | Result |
|---|---|---|
| `scripts/test-fast-pr.sh` (from the worktree root; `gate root: /c/Users/miket/code/re-frame2-worktrees/slugid-hic023`) | **0** | docs + node tiers classified in; CLJS 13032 tests / 65836 assertions; per-ns isolation 17/17 |
| `tools/xray` JVM `clojure -M:test` | **0** | 1288 tests / 6045 assertions, 0 failures (was 1287 / 6033) |
| `python scripts/check_doc_slugs.py` | **0** | Spec 027 links and anchors |
| mutation proof (property vs the landed encoding) | **1**, then **0** | 6 failures naming the colliding slugs; green byte-identically restored |

Not run, with reasons:

- **JVM implementation artefacts** — the spine classified `implementation_jvm`
  as unchanged and skipped that tier; this diff touches only `tools/xray`.
- **Browser / Playwright** — no adapter or testbed surface changed. No
  `spec.cjs` hardcodes a Hicasso ROW testid (only the tab-level
  `rf-xray-hicasso`), so the encoding is not observable to the browser sweep.
- `python scripts/check_fast_pr_gap.py --list` derives 95 required checks the
  spine does not decide; none is decided here.

## Fences

`tools/xray/spec/027-*` is this bead's to move and moved. Untouched: the
top-level `spec/` tree, `.github/workflows/*`, `implementation/package.json`,
`implementation/shadow-cljs.edn`, `implementation/hicasso/**`, the producer's
redaction, the frame-scoped lead search, dispatch ordering, per-view empties
and the lifecycle wording. No `.beads` path is on this branch. rf2-hic-076
remains the separate Pair migration owner.
