### PR TITLE
fix(hicasso): complete the lint roster, and make its arity rows discriminating (rf2-hic-022, rf2-ka4d, rf2-c6t6)

### DIFF
--- a/implementation/hicasso/lint-fixtures/negative.cljs
+++ b/implementation/hicasso/lint-fixtures/negative.cljs
@@ -14,9 +14,18 @@
   `for` whose body is a call, an element whose props are a symbol. That
   silence is the design, not a gap: see the export's README for what each
   check refuses to know."
-  (:require [re-frame.hicasso :as h]))
+  (:require [re-frame.hicasso :as h :refer [sub use-subs]]))
 
 (declare row-view sanitize icon-node props)
+
+;; A protocol and a multimethod for the method-parameter rows at the end of
+;; this file. They are declared here rather than borrowed because a method
+;; parameter that is a FUNCTION is what makes calling it ordinary code rather
+;; than a mistake, and `Object`'s only method takes nothing but `this`.
+(defprotocol Applies
+  (apply-to [this f]))
+
+(defmulti dispatch-on :kind)
 
 ;; ---------------------------------------------------------------------------
 ;; An EVENT VECTOR is not an element. `[:button]` at a prop and the element
@@ -37,10 +46,10 @@
 ;; `mapv` calls its fn during this body, so these reads are this boundary's
 ;; edges. An "fn literal inside a body" is NOT evidence of deferral.
 (h/defview reads-inside-a-mapv [{:keys [ids]}]
-  [:ul (mapv (fn [id] [:li {:key id} (h/sub [:todo/label id])]) ids)])
+  [:ul (mapv (fn [id] [:li {:key id} (sub [:todo/label id])]) ids)])
 
 (h/defview reads-inside-a-for [{:keys [ids]}]
-  [:ul (for [id ids] [:li {:key id} (h/sub [:todo/label id])])])
+  [:ul (for [id ids] [:li {:key id} (sub [:todo/label id])])])
 
 ;; A callback that dispatches is exactly what the callback form is for.
 (h/defview dispatch-inside-a-callback [_]
@@ -50,7 +59,7 @@
 ;; A read at the top of a body, then used inside a callback, is correct: the
 ;; READ happened during the body and the callback closes over its value.
 (h/defview read-then-close-over-it [_]
-  (let [id (h/sub [:todo/current])]
+  (let [id (sub [:todo/current])]
     [:button {:on-click (h/hfn [_e] [:todo/toggle id])} "toggle"]))
 
 ;; ---------------------------------------------------------------------------
@@ -58,7 +67,7 @@
 ;; ---------------------------------------------------------------------------
 
 (h/defview reset-of-a-plain-value [{:keys [cache]}]
-  (reset! cache (h/sub [:todo/current]))
+  (reset! cache (sub [:todo/current]))
   [:div "fine"])
 
 (h/defview reset-of-a-delay-that-reads-nothing [{:keys [cache]}]
@@ -302,3 +311,120 @@
                       ([nested y] (nested y)))]
               (str (inner (fn [& _] x)) (inner (fn [& _] x) 1))))]
     [:div (outer "ok")]))
+
+;; ---------------------------------------------------------------------------
+;; direct-view-call — the binding forms that are neither `let`-shaped nor a
+;; `fn` tail
+;;
+;; The rows above drive the roster. A ROSTER is also the whole defect: the hook
+;; has no scope table, so it recognises a binding form by NAME, and a local
+;; introduced by a form nobody wrote down is not seen — so calling it reports,
+;; at ERROR, which stops the build. Six such forms were measured live at the CI
+;; pin after the `letfn` repair landed (rf2-ka4d).
+;;
+;; So, once more, from the GRAMMAR rather than from the repair: one row per
+;; production of each form, with the local spelled like the enclosing view and
+;; nothing else in that row bound, so that no row passes on a neighbour's
+;; coverage.
+;; ---------------------------------------------------------------------------
+
+;; `(dotimes [name n] body*)` is the whole grammar — one pair, the target a
+;; symbol, no second production. It is the one row here that no correct program
+;; reaches: a counter is an integer, and calling one throws whatever the linter
+;; says. The hole is closed anyway, because the roster it was missing from is
+;; otherwise the COMPLETE `let`-shaped family, and a hole in a roster is what
+;; all of this is made of.
+(h/defview tick [_]
+  (dotimes [tick 3] (tick))
+  [:div "ticked"])
+
+;; `(this-as name body*)`, and `this` in a JS callback may perfectly well be a
+;; function — that is what makes this one a program somebody writes.
+(h/defview handler [_]
+  [:div {:ref (fn [] (this-as handler (handler)))}])
+
+;; A `reify` method is a `fn` tail with its name in front, exactly as a `letfn`
+;; fnspec is, and its parameters are ordinary locals.
+(h/defview boxed [_]
+  [:div (str (reify Applies (apply-to [_ boxed] (boxed))))])
+
+;; The binding method in the SECOND protocol group, behind another method and
+;; behind a bare protocol NAME: a reader that stops at the first spec, or that
+;; mistakes a token for a method, does not reach this one.
+(h/defview second-group [_]
+  [:div (str (reify
+               Object  (toString [_] "first")
+               Applies (apply-to [_ second-group] (second-group))))])
+
+;; `specify!` takes an ordinary EXPRESSION where the others take a name, and
+;; that expression is written as a LIST here on purpose: it sits exactly where
+;; a method sits, and reading it as one is the mistake available.
+(h/defview marked [_]
+  [:div (str (specify! (js-obj) Applies (apply-to [_ marked] (marked))))])
+
+;; `extend-type` names a type and then the same method lists.
+(h/defview extended [_]
+  (extend-type string Applies (apply-to [_ extended] (extended)))
+  [:div "extended"])
+
+;; `extend-protocol` inverts that — one protocol, then a type before each
+;; group — so the binding method here follows both a token and another method.
+(h/defview spread-out [_]
+  (extend-protocol Applies
+    string (apply-to [_ f] (f))
+    number (apply-to [_ spread-out] (spread-out)))
+  [:div "spread"])
+
+;; `(defmethod multifn dispatch-val & fn-tail)`, first production: the tail
+;; written flat. A `defmethod` inside a body is unusual code, and it is the
+;; only place a hook can see one — a top-level `defmethod` is not inside any
+;; view, so nothing here ever reads it.
+(h/defview run-it [_]
+  (defmethod dispatch-on :fn [run-it] (run-it))
+  [:div "registered"])
+
+;; Second production: the tail written as arity lists. Both arities bind, and
+;; both must go quiet.
+(h/defview run-any [_]
+  (defmethod dispatch-on :any
+    ([run-any] (run-any))
+    ([run-any x] (run-any x)))
+  [:div "registered"])
+
+;; ---------------------------------------------------------------------------
+;; parked-read / deferred-read — a READING DOOR that a local has taken
+;;
+;; `:refer [sub]` leaves an ordinary simple symbol behind, and a local may be
+;; named `sub` like anything else. `api/resolve` answers with the var either
+;; way — it reads the ns form and never sees locals — so all three read rules
+;; reported somebody's own function as a subscription read (rf2-c6t6). Warning
+;; level, unlike the rows above, which is why this half is smaller: a spurious
+;; warning is noise, and a spurious error stops a programmer working.
+;;
+;; The doors are referred here, and read once unshadowed, so that the shadowed
+;; rows below are shadowing something real.
+;; ---------------------------------------------------------------------------
+
+(h/defview referred-doors [_]
+  [:div (sub [:todo/current]) (str (use-subs {:x [:todo/current]}))])
+
+(h/defview shadowed-parked-read [{:keys [cache]}]
+  (let [sub (fn [_] "ordinary")]
+    (reset! cache (delay (sub [:x]))))
+  [:div "fine"])
+
+(h/defview shadowed-deferred-read [_]
+  (let [sub (fn [_] "ordinary")]
+    (js/setTimeout (fn [] (sub [:x])) 100))
+  [:div "fine"])
+
+;; The callback form's own PARAMETER is a binding like any other, and it is
+;; outside the body the check walks.
+(h/defview shadowed-in-a-callback [_]
+  [:button {:on-click (h/hfn [sub] [:todo/toggle (sub :value)])} "Save"])
+
+;; The second door shadows the same way.
+(h/defview shadowed-use-subs [{:keys [cache]}]
+  (let [use-subs (fn [_] {:x 1})]
+    (reset! cache (delay (use-subs {:x [:y]}))))
+  [:div "fine"])

--- a/implementation/hicasso/lint-fixtures/negative.cljs
+++ b/implementation/hicasso/lint-fixtures/negative.cljs
@@ -25,6 +25,9 @@
 (defprotocol Applies
   (apply-to [this f]))
 
+(defprotocol Twice
+  (apply-twice [this f]))
+
 (defmulti dispatch-on :kind)
 
 ;; ---------------------------------------------------------------------------
@@ -342,73 +345,109 @@
 ;; at ERROR, which stops the build. Six such forms were measured live at the CI
 ;; pin after the `letfn` repair landed (rf2-ka4d).
 ;;
-;; So, once more, from the GRAMMAR rather than from the repair: one row per
-;; production of each form, with the local spelled like the enclosing view and
-;; nothing else in that row bound, so that no row passes on a neighbour's
-;; coverage.
+;; So, once more, from the GRAMMAR rather than from the repair — and past
+;; where grammar alone stops (merged-PR audit #7818): a shape answers "did I
+;; test this form?", and a POSITION answers "can this row tell the
+;; difference?". Only the second makes a row a witness. So each row below
+;; binds the view's name in the position hardest to reach, with some OTHER
+;; name bound in the position an easier reading would find, and the comment
+;; names the narrowing it reds under.
 ;; ---------------------------------------------------------------------------
 
 ;; `(dotimes [name n] body*)` is the whole grammar — one pair, the target a
-;; symbol, no second production. It is the one row here that no correct program
-;; reaches: a counter is an integer, and calling one throws whatever the linter
-;; says. The hole is closed anyway, because the roster it was missing from is
-;; otherwise the COMPLETE `let`-shaped family, and a hole in a roster is what
-;; all of this is made of.
+;; symbol, no second production, so there is no harder position to reach. It
+;; is also the one row here that no correct program needs: a counter is an
+;; integer, and calling one throws whatever the linter says. REDS UNDER the
+;; only narrowing available, `dotimes` dropped from the `let`-shaped roster —
+;; and it is in that roster because the roster is otherwise the complete
+;; family, and a hole in a roster is what all of this is made of.
 (h/defview tick [_]
   (dotimes [tick 3] (tick))
   [:div "ticked"])
 
-;; `(this-as name body*)`, and `this` in a JS callback may perfectly well be a
-;; function — that is what makes this one a program somebody writes.
+;; `(this-as name body*)` binds at the FIRST position, where `catch` and `as->`
+;; — its neighbours in the same `cond` — bind at the second. `this` in a JS
+;; callback may perfectly well be a function, which is what makes this a
+;; program somebody writes. REDS UNDER reading the second position, which
+;; finds `(handler)`: a list, and a list binds nothing.
 (h/defview handler [_]
   [:div {:ref (fn [] (this-as handler (handler)))}])
 
 ;; A `reify` method is a `fn` tail with its name in front, exactly as a `letfn`
-;; fnspec is, and its parameters are ordinary locals.
+;; fnspec is. The binding method is FIRST here with another method after it, so
+;; this row REDS UNDER keeping only the last spec; `second-group` binds behind
+;; both a spec NAME and another method, so that one REDS UNDER keeping only the
+;; first. Neither can pass on the other's coverage.
 (h/defview boxed [_]
-  [:div (str (reify Applies (apply-to [_ boxed] (boxed))))])
+  [:div (str (reify
+               Applies (apply-to    [_ boxed] (boxed))
+               Twice   (apply-twice [_ g] (g))))])
 
-;; The binding method in the SECOND protocol group, behind another method and
-;; behind a bare protocol NAME: a reader that stops at the first spec, or that
-;; mistakes a token for a method, does not reach this one.
 (h/defview second-group [_]
   [:div (str (reify
                Object  (toString [_] "first")
                Applies (apply-to [_ second-group] (second-group))))])
 
-;; `specify!` takes an ordinary EXPRESSION where the others take a name, and
-;; that expression is written as a LIST here on purpose: it sits exactly where
-;; a method sits, and reading it as one is the mistake available.
+;; `specify!` takes an ordinary EXPRESSION where the other three take a name,
+;; and it is written as a LIST here on purpose: it sits exactly where a method
+;; sits. The binding method is LAST, behind a whole other spec group, so this
+;; REDS UNDER keeping only the first. That the first argument is DROPPED
+;; rather than read is not witnessed here — reading it could only bind an
+;; extra name, and an extra name only silences — so `self-calling-specify-
+;; target` in the positive half carries that half.
+;;
+;; `specify`, the non-mutating twin, is deliberately NOT driven and not in the
+;; roster: clj-kondo does not read it as a spec-bearing form at all, so its
+;; method parameters are not locals to kondo's OWN analysis either, and a row
+;; for it reports `invalid-arity` before any check here is consulted.
 (h/defview marked [_]
-  [:div (str (specify! (js-obj) Applies (apply-to [_ marked] (marked))))])
+  [:div (str (specify! (js-obj)
+               Twice   (apply-twice [_ g] (g))
+               Applies (apply-to    [_ marked] (marked))))])
 
-;; `extend-type` names a type and then the same method lists.
+;; `extend-type` names a type and then the same method lists. REDS UNDER
+;; keeping only the first method, and under reading the TYPE as a binding —
+;; which would bind `string`.
 (h/defview extended [_]
-  (extend-type string Applies (apply-to [_ extended] (extended)))
+  (extend-type string
+    Twice   (apply-twice [_ g] (g))
+    Applies (apply-to    [_ extended] (extended)))
   [:div "extended"])
 
-;; `extend-protocol` inverts that — one protocol, then a type before each
-;; group — so the binding method here follows both a token and another method.
+;; `extend-protocol` inverts that — one protocol, a type before each group —
+;; so this binding follows both a spec token and another method. REDS UNDER
+;; stopping at the first group.
 (h/defview spread-out [_]
   (extend-protocol Applies
     string (apply-to [_ f] (f))
     number (apply-to [_ spread-out] (spread-out)))
   [:div "spread"])
 
-;; `(defmethod multifn dispatch-val & fn-tail)`, first production: the tail
-;; written flat. A `defmethod` inside a body is unusual code, and it is the
-;; only place a hook can see one — a top-level `defmethod` is not inside any
-;; view, so nothing here ever reads it.
+;; `(defmethod multifn dispatch-val & fn-tail)`, tail written flat. The
+;; multimethod's own NAME sits at position 0 and the dispatch value at 1, so
+;; this REDS UNDER reading the tail from either — position 0 binds
+;; `dispatch-on`, position 1 finds a keyword. A `defmethod` inside a body is
+;; unusual code and it is the only place a hook can see one: a top-level
+;; `defmethod` is inside no view, so nothing here ever reads it.
 (h/defview run-it [_]
   (defmethod dispatch-on :fn [run-it] (run-it))
   [:div "registered"])
 
-;; Second production: the tail written as arity lists. Both arities bind, and
-;; both must go quiet.
+;; The tail written as arity lists, and — per rf2-hic-022 — one row per arity
+;; POSITION rather than one per shape. Bound by the FIRST arity alone here, so
+;; it REDS UNDER skipping the first arity ...
 (h/defview run-any [_]
   (defmethod dispatch-on :any
     ([run-any] (run-any))
-    ([run-any x] (run-any x)))
+    ([x y] (str x y)))
+  [:div "registered"])
+
+;; ... and by the LAST alone here, the first arity binding nothing at all, so
+;; it REDS UNDER reading only the first.
+(h/defview run-last [_]
+  (defmethod dispatch-on :last
+    ([] "none")
+    ([run-last] (run-last)))
   [:div "registered"])
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/hicasso/lint-fixtures/negative.cljs
+++ b/implementation/hicasso/lint-fixtures/negative.cljs
@@ -303,6 +303,26 @@
             ([mutual n] (evens mutual n)))]
     [:div (evens (fn [& _] "ok") 2)]))
 
+;; The name bound by the FIRST arity ALONE, every later arity binding
+;; something else.
+;;
+;; Every row above binds the view's name in EVERY arity, which is one row per
+;; shape and no row per POSITION. `locals-bound-by` unions the whole `letfn`
+;; and `self-call-nodes` silences the form as soon as ANY arity is recognised,
+;; so reading only the later arities passes all of them — measured, not
+;; argued: `fn-locals` was pointed at `(rest forms)`, deliberately skipping the
+;; first arity, and the pinned gate still exited 0 (merged-PR audit #7818).
+;;
+;; The opposite narrowing, reading only the FIRST arity, is caught by
+;; `zero-arity` above, whose first arity binds nothing at all. So the two rows
+;; together pin both ends, and enumerating shapes is now what it was not
+;; before: a row that can fail for the reason it names.
+(h/defview first-arity [_]
+  (letfn [(only-first
+            ([first-arity] (first-arity))
+            ([x y] (str x y)))]
+    [:div (only-first (fn [] "ok")) (only-first 1 2)]))
+
 ;; And a multi-arity fnspec nested inside another fnspec's body.
 (h/defview nested [_]
   (letfn [(outer [x]

--- a/implementation/hicasso/lint-fixtures/positive.cljs
+++ b/implementation/hicasso/lint-fixtures/positive.cljs
@@ -173,6 +173,14 @@
   [:div (str (specify! (js-obj) Applies
                (apply-to [_ f] (f (self-call-in-specify {})))))])
 
+;; The view called in `specify!`'s OBJECT position — the one place a self-call
+;; can hide behind a first argument. This is what makes DROPPING that argument
+;; load-bearing rather than tidy: read as a method spec instead, its head
+;; symbol would be a local, and the whole form would go quiet.
+(h/defview self-calling-specify-target [_]
+  [:div (str (specify! (self-calling-specify-target {}) Applies
+               (apply-to [_ f] (f))))])
+
 (h/defview self-call-in-extend-type [_]
   (extend-type string Applies
     (apply-to [_ f] (f (self-call-in-extend-type {}))))

--- a/implementation/hicasso/lint-fixtures/positive.cljs
+++ b/implementation/hicasso/lint-fixtures/positive.cljs
@@ -13,7 +13,7 @@
   `re_frame/hicasso/lint_export_test.clj` is what reads it. Every form
   carries the finding type it must produce, so a row that stops firing is
   read as a broken rule rather than as tidy code."
-  (:require [re-frame.hicasso :as h]))
+  (:require [re-frame.hicasso :as h :refer [use-subs]]))
 
 ;; ---------------------------------------------------------------------------
 ;; :re-frame.hicasso/direct-view-call -- a view called like a function
@@ -34,7 +34,7 @@
 
 (h/defview grouped-read-inside-a-callback [_]
   [:button {:on-click (h/hfn [_e]
-                        (let [{:keys [id]} (h/use-subs {:id [:todo/current]})]
+                        (let [{:keys [id]} (use-subs {:id [:todo/current]})]
                           [:todo/toggle id]))}
    "toggle"])
 
@@ -57,7 +57,7 @@
   [:div "parked"])
 
 (h/defview parked-in-a-volatile [{:keys [cache]}]
-  (vreset! cache (delay (h/use-subs {:x [:todo/expensive]})))
+  (vreset! cache (delay (use-subs {:x [:todo/expensive]})))
   [:div "parked"])
 
 ;; ---------------------------------------------------------------------------
@@ -142,3 +142,69 @@
     (if (zero? depth)
       (wrap "leaf")
       [:ul (wrap "deep" (self-calling-through-letfn {:depth (dec depth)}))])))
+
+;; ---------------------------------------------------------------------------
+;; A genuine self-call inside each binding form rf2-ka4d added still reports.
+;;
+;; This is the other direction of that repair, and the one nothing would notice
+;; if it broke: an arm that read a whole `reify` or `defmethod` as "bound"
+;; would blind the check inside every one of them, and silence is what this
+;; check does when it declines. No construct below binds anything spelled like
+;; its view, so every call in it is still a self-call and still an ERROR.
+;; ---------------------------------------------------------------------------
+
+(defprotocol Applies
+  (apply-to [this f]))
+
+(defmulti dispatch-on :kind)
+
+(h/defview self-call-in-dotimes [{:keys [depth]}]
+  (dotimes [_i depth] (js/console.log (self-call-in-dotimes {:depth 0})))
+  [:div "counted"])
+
+(h/defview self-call-in-this-as [_]
+  [:div {:ref (fn [] (this-as me
+                       (js/console.log me (self-call-in-this-as {}))))}])
+
+(h/defview self-call-in-reify [_]
+  [:div (str (reify Applies (apply-to [_ f] (f (self-call-in-reify {})))))])
+
+(h/defview self-call-in-specify [_]
+  [:div (str (specify! (js-obj) Applies
+               (apply-to [_ f] (f (self-call-in-specify {})))))])
+
+(h/defview self-call-in-extend-type [_]
+  (extend-type string Applies
+    (apply-to [_ f] (f (self-call-in-extend-type {}))))
+  [:div "extended"])
+
+(h/defview self-call-in-extend-protocol [_]
+  (extend-protocol Applies
+    string (apply-to [_ f] (f (self-call-in-extend-protocol {}))))
+  [:div "extended"])
+
+(h/defview self-call-in-defmethod [_]
+  (defmethod dispatch-on :self [f] (f (self-call-in-defmethod {})))
+  [:div "registered"])
+
+;; ---------------------------------------------------------------------------
+;; A READING DOOR that no local has taken still reports (rf2-c6t6).
+;;
+;; The repair that stopped the read rules firing on a shadowed `sub` fails in
+;; the other direction by going quiet everywhere, and the corpus would not
+;; notice: it is quiet already. Both rows below park a real read.
+;; ---------------------------------------------------------------------------
+
+;; The door REFERRED and not shadowed: a bare spelling is still the door.
+(h/defview parked-referred-read [{:keys [cache]}]
+  (reset! cache (delay (use-subs {:x [:todo/expensive]})))
+  [:div "parked"])
+
+;; And a QUALIFIED read in a body that binds a local named `sub` somewhere
+;; else. Nothing is ever named `h/sub`, so a shadow read by SPELLING cannot
+;; reach this one — and a repair that compared the door's bare name instead
+;; would silence it.
+(h/defview parked-read-beside-a-shadow [{:keys [cache]}]
+  (let [sub (fn [_] "ordinary")] (js/console.log (sub :x)))
+  (reset! cache (delay (h/sub [:todo/expensive])))
+  [:div "parked"])

--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/README.md
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/README.md
@@ -116,6 +116,17 @@ exempt. `(some-helper (fn [] (h/sub …)))` may well call its argument during th
 body too, and this cannot know; if it does, ignore the warning. Proving read
 extent in general is the runtime's law, not lint's.
 
+It also refuses a read whose **door has been rebound**, and so does
+`parked-read`. `:refer [sub]` leaves an ordinary simple symbol behind, and a
+local may take that name like any other; `api/resolve` answers with the var
+either way, because it reads your `ns` form and never sees locals. Both read
+checks therefore consult the same shadowing roster the self-call check above
+uses — bluntly, though: a body that binds `sub` anywhere silences the bare
+spelling for that **whole body**, rather than for the form that binds it. The
+blunt reading costs a missed warning and nothing else, which is the only
+direction these are allowed to be wrong. A qualified `h/sub` is untouched,
+because nothing is ever named `h/sub`.
+
 ### `:re-frame.hicasso/function-in-head-position` — error
 
 A `(fn …)`, `#(…)` or `(hfn …)` written as the head of a vector that sits in a
@@ -142,7 +153,9 @@ enforces it. It is assistance, and it is the whole of the assistance.
 
 **Refuses to know:** anything that needs a binding followed.
 `(let [d (delay (h/sub …))] (reset! r d))` is invisible, and so is
-`(reset! r (make-thunk))`, and so is a `swap!` that assoc's a thunk into a map.
+`(reset! r (make-thunk))`, and so is a `swap!` that assoc's a thunk into a map;
+and so, per the note under `deferred-read` above, is any read written through a
+door spelling some local in the same body has taken.
 Catching those means following bindings and resolving symbols across forms,
 which is whole-program analysis wearing a lint hat — and the ruling that asked
 for this check forbids building it.

--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/README.md
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/README.md
@@ -73,13 +73,26 @@ Missing one is the only way this check is allowed to be wrong.
 
 **Refuses to know** — and this direction is the one that costs you something —
 that a form *outside its roster* binds anything. Having no scope table, the
-hook recognises binding forms by name, and the roster is `let`-shaped forms
-(`let`, `loop`, `when-let`, `if-let`, `when-some`, `if-some`, `when-first`,
-`doseq`, `for`, `with-open`, `with-local-vars`, `binding`, `with-redefs`),
-`fn`/`fn*`/`hfn`, `letfn`, `catch` and `as->`. A local introduced by anything
-else — `dotimes`, `this-as`, a `reify` / `specify!` / `extend-type` method
-parameter, a `defmethod` parameter — is not seen, so calling one *does* report.
-Name your local something other than the view, or switch the check off.
+hook recognises binding forms by **name**, and the roster is:
+
+* the **`let`-shaped** forms, whose first argument is a binding vector —
+  `let`, `loop`, `when-let`, `if-let`, `when-some`, `if-some`, `when-first`,
+  `doseq`, `dotimes`, `for`, `with-open`, `with-local-vars`, `binding`,
+  `with-redefs`;
+* the **`fn` tails** — `fn`, `fn*`, `hfn`, every fnspec of a `letfn`, every
+  method of a `reify`, `specify!`, `extend-type` or `extend-protocol`, and a
+  `defmethod`'s tail. Every parameter of every arity, in each case, and a
+  local function's or method's own name;
+* the **single names** bound by `catch`, `as->` and `this-as`.
+
+A local introduced by anything else is not seen, so calling one *does* report.
+The notable absentees are `deftype`, `defrecord`, `proxy` and `specify` — the
+last because clj-kondo does not read it as a spec-bearing form either, so its
+method parameters are not locals to kondo's own analysis, and the first three
+because a hook fires only at registered call sites: it never sees anything but
+a `defview`, `defhost` or `hfn` form, and a type defined inside a view body is
+not a program anyone has. If you have one, name your local something other
+than the view, or switch the check off.
 
 ### `:re-frame.hicasso/deferred-read` — warning
 

--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj
@@ -65,9 +65,20 @@
         :else                                      nil))))
 
 (defn- reads-hicasso-state?
-  "Does this node name one of the two reading doors?"
-  [node]
-  (contains? #{'sub 'use-subs} (hicasso-var node)))
+  "Does this node name one of the two reading doors — and does that spelling
+  still MEAN the door here?
+
+  `:refer [sub]` leaves an ordinary simple symbol behind, and a local may be
+  named `sub` like anything else, at which point `(sub …)` is somebody's own
+  function. `api/resolve` answers with the var either way: it reads the ns
+  form and never sees locals, which is the same limit the self-call check
+  ran into (rf2-c6t6). So `locals` is consulted, and it is the SAME roster
+  that check reads — `locals-bound-by`, through `lexical-locals` — rather
+  than a second notion of what a binding is. A qualified `h/sub` is never in
+  it, because nothing is named `h/sub`."
+  [locals node]
+  (and (not (contains? locals (token-sexpr node)))
+       (contains? #{'sub 'use-subs} (hicasso-var node))))
 
 ;; ---------------------------------------------------------------------------
 ;; Walking — every node under `node`, quoted data excepted
@@ -218,11 +229,11 @@
   circumstance, and the runtime refuses it with
   `:rf.error/hicasso-sub-outside-render`. This is the ONLY deferred-read
   shape that is a syntactic fact; see README."
-  [body]
+  [locals body]
   (doseq [node (mapcat subforms body)
           :when (api/list-node? node)
           :let  [head (first (:children node))]
-          :when (reads-hicasso-state? head)]
+          :when (reads-hicasso-state? locals head)]
     (finding! node :re-frame.hicasso/deferred-read
               (str "A subscription is read inside `hfn`, which runs AFTER the body "
                    "that wrote it, so the read has no boundary to belong to and "
@@ -250,11 +261,11 @@
 (defn- parked-thunk?
   "Does this node defer a Hicasso read, written out in full at this
   position?"
-  [node]
+  [locals node]
   (boolean
     (when-let [body (thunk-body node)]
       (some #(and (api/list-node? %)
-                  (reads-hicasso-state? (first (:children %))))
+                  (reads-hicasso-state? locals (first (:children %))))
             (mapcat subforms body)))))
 
 (defn- check-parked-read!
@@ -266,12 +277,12 @@
   undefined conduct rather than an error, so this is a WARNING and nothing
   here enforces anything. It is syntactic in the strictest sense: the thunk
   must be written literally as the argument of the `reset!`."
-  [body]
+  [locals body]
   (doseq [node (mapcat subforms body)
           :when (api/list-node? node)
           :let  [[head _target & args] (:children node)]
           :when (contains? #{'reset! 'vreset! 'swap!} (core-var head))
-          value (filter parked-thunk? args)]
+          value (filter #(parked-thunk? locals %) args)]
     (finding! value :re-frame.hicasso/parked-read
               (str "A subscription read is parked in a mutable reference. The "
                    "read-extent law covers the structure a body RETURNS, so a "
@@ -474,7 +485,7 @@
 
   Read extent in general remains the RUNTIME's law (I7 / hic-011); this
   never pretends otherwise, which is why it does not block a build."
-  [body]
+  [locals body]
   (doseq [node (mapcat subforms body)
           :when (api/list-node? node)
           :let  [callee (core-var (first (:children node)))]
@@ -487,7 +498,7 @@
           :when (and (function-literal? arg)
                      (not= 'hfn (hicasso-var (first (:children arg)))))
           :when (some #(and (api/list-node? %)
-                            (reads-hicasso-state? (first (:children %))))
+                            (reads-hicasso-state? locals (first (:children %))))
                       (mapcat subforms (or (thunk-body arg) [])))]
     (finding! arg :re-frame.hicasso/deferred-read
               (str "A subscription is read inside a function that nothing here "
@@ -632,6 +643,21 @@
 
         :else #{}))))
 
+(defn- lexical-locals
+  "Every name bound ANYWHERE under these forms, plus the ones the enclosing
+  argument vector binds.
+
+  The self-call check reads the same roster per SUBTREE, which is sharper:
+  a binding silences only the form it heads. This reads it bluntly — one set
+  for the whole body — and the two read rules below are what use it. They are
+  WARNINGS, the cost of the blunt reading is silence, and silence is the only
+  failure this file permits, so the sharper answer would buy precision in the
+  one direction nobody is harmed by."
+  [argv body]
+  (into (bound-symbols argv)
+        (comp (mapcat subforms) (mapcat locals-bound-by))
+        body))
+
 (defn- self-call-nodes
   "Every `(nm …)` under `node` that is NOT inside a form binding `nm`.
 
@@ -683,14 +709,14 @@
 
 (defn- check-body!
   "Every hiccup-shaped check, over one body."
-  [body]
+  [locals body]
   (let [elements (mapcat element-subforms body)]
     (run! check-unkeyed-children! elements)
     (run! check-nameless-interactive! elements)
     (run! check-function-head! elements))
   (check-root-head! (last body))
-  (check-deferred-read-in-fn! body)
-  (check-parked-read! body))
+  (check-deferred-read-in-fn! locals body)
+  (check-parked-read! locals body))
 
 (defn defview
   "`(defview sym doc? [props] body+)` -> `(defn sym doc? [props] body+)`,
@@ -701,7 +727,7 @@
                                 [(first more) (rest more)]
                                 [nil more])
         [argv & body]         more]
-    (check-body! body)
+    (check-body! (lexical-locals argv body) body)
     (check-direct-view-call! sym argv body)
     {:node (api/list-node
              (concat [(api/token-node 'clojure.core/defn) sym]
@@ -714,7 +740,7 @@
   check the callback form makes decidable."
   [{:keys [node]}]
   (let [[_hfn argv & body] (:children node)]
-    (check-read-in-callback! body)
+    (check-read-in-callback! (lexical-locals argv body) body)
     {:node (api/list-node
              (list* (api/token-node 'clojure.core/fn) argv body))}))
 

--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj
@@ -502,9 +502,14 @@
 
   `binding` and `with-redefs` rebind VARS rather than introducing locals, and
   they are here anyway for the same reason: inside one, the name no longer
-  denotes the view either."
+  denotes the view either.
+
+  `dotimes` takes the same pair and was simply absent (rf2-ka4d). It is the
+  one member no correct program needs — a counter is an integer, and calling
+  one throws whatever the linter says — but a roster with a hole in it is the
+  entire defect class, and this family is now complete."
   '#{let let* loop loop* when-let if-let when-some if-some when-first
-     with-open with-local-vars doseq for binding with-redefs})
+     with-open with-local-vars doseq dotimes for binding with-redefs})
 
 (defn- bound-symbols
   "Every symbol a binding TARGET binds, destructuring included.
@@ -549,6 +554,20 @@
           (comp (filter api/vector-node?) (mapcat bound-symbols))
           params)))
 
+(defn- fn-tail-locals
+  "The names a SEQUENCE of NAMED `fn` tails binds.
+
+  Two families write one. A `letfn` binding vector holds fnspecs, which are
+  `fn` tails by construction. The specs of `reify`, `specify!`, `extend-type`
+  and `extend-protocol` hold methods, `(name [params*] body*)` — the same
+  production, so the same reading answers both.
+
+  Only LIST nodes are read, which is what lets one function serve five forms:
+  the protocol and type NAMES a spec also carries are tokens, and a token
+  binds nothing."
+  [nodes]
+  (into #{} (mapcat #(when (api/list-node? %) (fn-locals (:children %)))) nodes))
+
 (defn- locals-bound-by
   "The names this node binds over its own subforms, when it is a form that
   binds names at all — and `#{}` for everything else, which is most nodes.
@@ -585,13 +604,31 @@
         ;; read and every use of one reported at ERROR (merged-PR audit #7804).
         (= 'letfn core)
         (if (api/vector-node? (first more))
-          (into #{}
-                (mapcat #(when (api/list-node? %) (fn-locals (:children %))))
-                (:children (first more)))
+          (fn-tail-locals (:children (first more)))
           #{})
 
-        (= 'catch core)  (if-let [s (token-sexpr (second more))] #{s} #{})
-        (= 'as-> core)   (if-let [s (token-sexpr (second more))] #{s} #{})
+        ;; `(reify P (m [v] …))` and the three forms that write the same specs
+        ;; somewhere else: a METHOD is a named `fn` tail exactly as a fnspec
+        ;; is, so its parameters are locals exactly as theirs are.
+        ;;
+        ;; The first argument is dropped for all four, which is uniform rather
+        ;; than clever. `reify`, `extend-type` and `extend-protocol` name a
+        ;; protocol or a type there and a name binds nothing, so dropping it
+        ;; costs them nothing. `specify!` takes an ordinary EXPRESSION —
+        ;; `(specify! (js-obj) …)` — sitting precisely where a method sits,
+        ;; and reading THAT as a method would bind its head symbol and silence
+        ;; the whole form, self-call and all.
+        (contains? '#{reify specify! extend-type extend-protocol} core)
+        (fn-tail-locals (rest more))
+
+        ;; `(defmethod area :square [{:keys [side]}] …)` — everything past the
+        ;; multimethod and the dispatch value is a `fn` tail, arity lists
+        ;; included, and `fn` is what `defmethod` hands it to.
+        (= 'defmethod core) (fn-locals (drop 2 more))
+
+        (= 'catch core)   (if-let [s (token-sexpr (second more))] #{s} #{})
+        (= 'as-> core)    (if-let [s (token-sexpr (second more))] #{s} #{})
+        (= 'this-as core) (if-let [s (token-sexpr (first more))] #{s} #{})
 
         :else #{}))))
 

--- a/implementation/hicasso/scripts/check_lint_export.py
+++ b/implementation/hicasso/scripts/check_lint_export.py
@@ -60,11 +60,12 @@ HOOK_FILE = os.path.join(EXPORT_DIR, "hooks", "re_frame", "hicasso.clj")
 # cannot see.
 EXPECTED = {
     # ERRORS -- true invariants (operator ruling, rf2-hic-022).
-    "direct-view-call":             [25, 144],
+    "direct-view-call":             [25, 144, 162, 167, 170, 174, 178, 183,
+                                     187],
     "function-in-head-position":    [99, 102, 105, 110, 114],
     # WARNINGS -- heuristics and assistance. Nothing blocks a build.
     "deferred-read":                [32, 37, 43],
-    "parked-read":                  [52, 56, 60],
+    "parked-read":                  [52, 56, 60, 200, 209],
     "unkeyed-mapped-child":         [68, 73, 76, 79],
     "nameless-interactive-element": [86, 89, 92, 123, 126],
 }

--- a/implementation/hicasso/scripts/check_lint_export.py
+++ b/implementation/hicasso/scripts/check_lint_export.py
@@ -270,6 +270,18 @@ def self_test():
          "(fn-locals (:children %))",
          "(fn-locals (take 1 (:children %)))",
          "direct-view-call"),
+        # The same claim, one notch narrower, and the reason a shape is not a
+        # witness (merged-PR audit #7818). "Every parameter of every arity"
+        # was true of the code and untested by the rows: each multi-arity row
+        # bound the view's name in EVERY arity, and one recognised arity
+        # silences the whole `letfn`, so skipping the first arity left the
+        # pinned gate at exit 0. The row that binds only in the first arity
+        # is what this mutation reds; `zero-arity`, whose first arity binds
+        # nothing, reds the opposite narrowing.
+        ("a letfn arity SKIPPED reds", "hook",
+         "(keep #(when (api/list-node? %) (first (:children %))) forms))]",
+         "(keep #(when (api/list-node? %) (first (:children %))) (rest forms)))]",
+         "direct-view-call"),
     ]
 
     ok = True

--- a/implementation/hicasso/scripts/check_lint_export.py
+++ b/implementation/hicasso/scripts/check_lint_export.py
@@ -60,12 +60,12 @@ HOOK_FILE = os.path.join(EXPORT_DIR, "hooks", "re_frame", "hicasso.clj")
 # cannot see.
 EXPECTED = {
     # ERRORS -- true invariants (operator ruling, rf2-hic-022).
-    "direct-view-call":             [25, 144, 162, 167, 170, 174, 178, 183,
-                                     187],
+    "direct-view-call":             [25, 144, 162, 167, 170, 174, 181, 186,
+                                     191, 195],
     "function-in-head-position":    [99, 102, 105, 110, 114],
     # WARNINGS -- heuristics and assistance. Nothing blocks a build.
     "deferred-read":                [32, 37, 43],
-    "parked-read":                  [52, 56, 60, 200, 209],
+    "parked-read":                  [52, 56, 60, 208, 217],
     "unkeyed-mapped-child":         [68, 73, 76, 79],
     "nameless-interactive-element": [86, 89, 92, 123, 126],
 }
@@ -281,6 +281,17 @@ def self_test():
         ("a letfn arity SKIPPED reds", "hook",
          "(keep #(when (api/list-node? %) (first (:children %))) forms))]",
          "(keep #(when (api/list-node? %) (first (:children %))) (rest forms)))]",
+         "direct-view-call"),
+        # A binding form MISSING FROM THE ROSTER (rf2-ka4d). The hook has no
+        # scope table, so it knows a binding form by name; six were absent and
+        # each one blocked a build on correct code. Blind the arm that reads
+        # method parameters and the reify / specify! / extend-type /
+        # extend-protocol rows must red. The other arms of the same class --
+        # `dotimes` in the let-shaped set, `this-as`, `defmethod` -- are one
+        # mechanism with this one, and their rows pin them individually.
+        ("a binding form dropped from the roster reds", "hook",
+         "(fn-tail-locals (rest more))",
+         "(do more #{})",
          "direct-view-call"),
     ]
 

--- a/implementation/hicasso/scripts/check_lint_export.py
+++ b/implementation/hicasso/scripts/check_lint_export.py
@@ -293,6 +293,15 @@ def self_test():
          "(fn-tail-locals (rest more))",
          "(do more #{})",
          "direct-view-call"),
+        # A READ whose door a local has taken (rf2-c6t6). Same blindness, at
+        # warning level: `:refer [sub]` leaves a simple symbol and a local may
+        # be named `sub`, but `api/resolve` reads the ns form and never sees
+        # locals. Stop consulting the shadow roster and the read rows in the
+        # negative half must red.
+        ("a read rule blind to a shadowed door reds", "hook",
+         "  (and (not (contains? locals (token-sexpr node)))",
+         "  (and (do locals true)",
+         "parked-read"),
     ]
 
     ok = True


### PR DESCRIPTION
Three beads, one surface, in the order a reopened P1 demands: **rf2-hic-022**
(merged-PR audit of #7818, reopened), then **rf2-ka4d** (P2, six build-blocking
false ERRORs), then **rf2-c6t6** (P4, the same blindness at warning level).

Everything below was measured at the CI pin — `clj-kondo 2026.04.15`, via the
artefact's `:clj-kondo` alias. The npm binary on this host is 2025.10.23 and was
kept off `PATH` for every run in this PR, because a pass from a mismatched
version proves nothing either way.

---

## rf2-hic-022 — the `letfn` arity rows were not discriminating

**The audit's claim, reproduced here before repairing.** `locals-bound-by` unions
every name for the whole `letfn`, and `self-call-nodes` silences that form as soon
as **any** arity binds the view's name — so a row that binds the same name in
*every* arity stays green under an implementation that reads only the later ones.
Every committed multi-arity row was written that way.

Pointing `fn-locals`' multi-arity source at `(rest forms)`, deliberately skipping
the first arity:

```
sha256 before=6b94e473af05fd9c after=2e3e94ce0944fcad  changed=True  token-present=True
--- gate exit 0 ---
OK: 6 checks fire on their fixtures, correct code is silent, and the artefact's own testbeds are quiet.
```

**The repair is one negative row and one self-test mutation. No hook change** —
the walker, the roster and the whole-form silencing are untouched. `first-arity`
binds the view's name in the FIRST arity alone, every later arity binding
something else:

```
--- (rest forms) ---   gate exit 1
  lint-fixtures/negative.cljs:322:28 fired re-frame.hicasso/direct-view-call --
  correct code must be silent: `first-arity` is a view, so it is a hiccup HEAD…
```

The opposite narrowing was already pinned and is now *stated* where someone will
find it: `zero-arity`'s first arity binds nothing, so `(take 1 forms)` reds there —

```
--- (take 1 forms) --- gate exit 1
  lint-fixtures/negative.cljs:285:27 fired re-frame.hicasso/direct-view-call --
  correct code must be silent: `zero-arity` is a view…
```

**The generalisation, and it governed the rest of this PR.** Enumerating a form's
legal shapes answers *"did I test this form?"*. It does not answer *"can this row
tell the difference?"* — and only the second makes a row a witness. Every rf2-ka4d
row below therefore binds the view's name in the position hardest to reach, with a
*different* name bound where an easier reading would look, and each names the
narrowing it reds under.

---

## rf2-ka4d — six binding forms missing from the roster

### Reproduced first, all six, at the pin

Probe run against `main` as it stood after #7818 merged. `errors: 6` on the first
probe, exit 3 — the required lane runs `--fail-level error`, so each of these
refuses a build for correct Clojure:

| form | probe | result |
|---|---|---|
| `dotimes` | `(dotimes [v 3] (v))` | `error: 'v' is a view…` |
| `this-as` | `(this-as v (v))` | `error` |
| `reify` method param | `(reify Object (toString [v] (str (v))))` | `error` |
| `specify!` method param | `(specify! (js-obj) Object (toString [v] (str (v))))` | `error` |
| `extend-type` method param | `(extend-type T Object (toString [v] (str (v))))` | `error` |
| `defmethod` param | `(defmethod mm :k [v] (v))` | `error` |

In the committed fixture the same six (plus `extend-protocol`) produce **ten**
build-blocking ERRORs, because two rows drive two positions each. The witness
commit (`9f3d7e7`) is red on purpose and records all fourteen findings.

### The repair deletes more than it adds

`letfn`'s fnspecs and a `reify` method are the **same production** — a named `fn`
tail — so the reading moves into one `fn-tail-locals` that both ask, and the four
spec forms collapse into a single arm. `dotimes` is one symbol in the `let`-shaped
set. `this-as` sits beside `catch` and `as->`, differing only in binding at the
first position rather than the second. `defmethod`'s tail is a `fn` tail past the
multimethod and the dispatch value.

`extend-protocol` is a **seventh** form, not in the bead: identical grammar to
`extend-type`, read by the same arm, so omitting it would have been arbitrary
rather than bounded.

The first argument is dropped for all four spec forms, uniformly. Three of them
name a protocol or a type there and lose nothing; `specify!` takes an
**expression** that sits exactly where a method sits, and reading it as one would
bind its head symbol and silence the whole form.

### Shapes DRIVEN, and the narrowing each row reds under

| form | row | binds in | reds under |
|---|---|---|---|
| `dotimes` | `tick` | the only production | `dotimes` dropped from the `let`-shaped set |
| `this-as` | `handler` | position 1 | reading position 2, as `catch`/`as->` do |
| `reify` | `boxed` | first method, another method after | keeping only the last spec |
| `reify` | `second-group` | second protocol group | keeping only the first spec; treating a token as a method |
| `specify!` | `marked` | last method, behind a whole other group | keeping only the first spec |
| `extend-type` | `extended` | second method | keeping only the first; reading the TYPE as a binding |
| `extend-protocol` | `spread-out` | second type group | stopping at the first group |
| `defmethod` | `run-it` | flat tail | reading the tail from position 0 or 1 |
| `defmethod` | `run-any` | FIRST arity alone | skipping the first arity |
| `defmethod` | `run-last` | LAST arity alone | reading only the first arity |

Nine positive rows guard the over-silencing direction: a genuine self-call inside
each construct must still ERROR. `self-calling-specify-target` calls the view in
`specify!`'s **object position**, which is what makes dropping that argument
load-bearing rather than tidy — see the sixth mutation below.

### Shapes NOT driven, and why

* **A `&` rest name in head position** (any `fn` tail). A rest seq is never a legal
  callee, so there is no correct program to protect. (Inherited from #7818.)
* **A destructured `this-as` target.** `this-as` expands through `let`, so the
  reader accepts one, but a JS `this` does not destructure. The arm reads the
  symbol production only — claim and witness are the same size, as for `catch`
  and `as->`.
* **A destructured `dotimes` target.** Not legal: the counter must be a symbol.
* **`specify`** (the non-mutating twin). Deliberately left out of the roster:
  clj-kondo does not read it as a spec-bearing form at all, so its method
  parameters are not locals to kondo's *own* analysis either, and a fixture row
  for it reports `invalid-arity` before any check here is consulted. Recorded in
  the README.
* **`deftype`, `defrecord`, `proxy`.** A hook fires only at registered call sites,
  so it never sees anything but a `defview`/`defhost`/`hfn` form, and a type
  defined inside a view body is not a program anyone has. Recorded in the README.
* **`dotimes` from correct code.** Stated plainly in the fixture: no correct
  program reaches that finding, because a counter is an integer and calling one
  throws whatever the linter says. The row is the mechanical witness; the reason
  to close the hole is that the `let`-shaped family is otherwise complete.

---

## rf2-c6t6 — the read rules, at WARNING

Reproduced at the pin over all three read shapes plus the callback form's own
parameter, which is bound *outside* the body the check walks:

```clojure
(let [sub (fn [_] "ordinary")]
  (reset! cache (delay (sub [:x]))))    ; warning: parked-read — somebody's own function
```

**Reused the existing shadow test; wrote no second walker.** `reads-hicasso-state?`
now consults the same roster `locals-bound-by` publishes — the one rf2-ka4d just
completed — so the read rules and the self-call rule cannot disagree about what a
binding is, and the read rules inherit the six new forms for free. That ordering is
why this lands *after* rf2-ka4d.

Read **bluntly**, and the docstring and README say so: a body that binds `sub`
anywhere silences the bare spelling for that whole body, where the self-call check
prunes per subtree. The cost is a missed warning; silence is the only failure this
file permits. Nothing new was needed beyond a `locals` argument threaded to the
three read checks and one `lexical-locals` helper built from `locals-bound-by`.

Two positive rows guard the other direction: `parked-referred-read` (a bare
spelling no local has taken is still the door) and `parked-read-beside-a-shadow`
(a qualified `h/sub` beside a local named `sub` still fires — nothing is ever
named `h/sub`).

---

## Mutation proof — every arm, by hand

Each mutation was applied **from a file, not a heredoc**, with sha256 before /
after / restored and a token grep, because a worker on this exact surface once had
a heredoc silently mangle a mutation while the suite reported green. Every restore
was byte-identical and every post-restore gate exit 0.

| # | mutation | gate | verbatim red |
|---|---|---|---|
| 1 | `dotimes` out of `let-shaped` | 1 | `negative.cljs:365:21 fired re-frame.hicasso/direct-view-call … 'tick' is a view` |
| 2 | `this-as` arm → `#{}` | 1 | `negative.cljs:374:39 … 'handler' is a view` |
| 3 | spec-form arm → `#{}` | 1 | `383:47 'boxed'; 389:51 'second-group'; 406:48 'marked'; 414:39 'extended'; 423:37 'spread-out'` |
| 4 | `defmethod` arm → `#{}` | 1 | `433:39 'run-it'; 441:16 'run-any'; 450:17 'run-last'` |
| 5 | read rules stop consulting `locals` | 1 | `472:19 parked-read; 477:20 deferred-read; 483:50 deferred-read; 488:19 parked-read` |
| 6 | `(rest more)` → `more` (specify!'s object read as a spec) | 1 | `direct-view-call: expected rows […181…], got […] ` — row 181 `self-calling-specify-target` stops firing |
| 7 | `fn-locals` multi-arity → `(rest forms)` | 1 | `negative.cljs:322:28 … 'first-arity' is a view` |
| 8 | `fn-locals` multi-arity → `(take 1 forms)` | 1 | `negative.cljs:285:27 … 'zero-arity' is a view` |

Three of these are now permanent `--self-test` cases (the arity skip, the roster
arm, the read-rule shadow). The self-test runs **eight** mutations and passes:

```
  ok   a disabled check reds the positive half
  ok   an element check reading props maps reds the negative half
  ok   a check firing at the wrong ROWS reds
  ok   a self-call check blind to lexical shadowing reds
  ok   a letfn fnspec read past its NAME reds
  ok   a letfn arity SKIPPED reds
  ok   a binding form dropped from the roster reds
  ok   a read rule blind to a shadowed door reds
  ok   the unmutated export passes
check_lint_export self-test: PASS
```

**rf2-93u6 note.** `.github/workflows/lint.yml` still says `--self-test` "mutates
the export FOUR ways"; it was already stale at five on `main` and this PR takes it
to eight. I am fenced out of `.github/workflows/*`, so the line is untouched.
rf2-93u6 records that the count should be **deleted** rather than corrected.

---

## Tree-wide accounting

clj-kondo at the pin over `lint.yml`'s exact path list, cold cache on both sides,
the source tree byte-identical between runs (only the export directory differed):

```
kondo_before.json (origin/main export)  findings=4699  errors 0 / warnings 4542 / info 157   files=3119
kondo_after.json  (this branch)         findings=4699  errors 0 / warnings 4542 / info 157   files=3119

removed by this branch: 0
added by this branch:   0
```

Sorted finding-set diff is **empty**, holding at #7804's and #7818's numbers.

---

## Quality gates

| gate | exit | note |
|---|---|---|
| `scripts/test-fast-pr.sh` | **0** | run to completion, never piped; `gate root: /c/Users/miket/code/re-frame2-worktrees/lintarms-ka4d`. The first run exited 1 at *CLJS node integration* with `Cannot find module 'shadow-cljs/cli/runner.js'` — the worktree had no `implementation/node_modules`. Junctioned it at the mayor checkout's real one, re-ran the whole spine to completion: exit 0, no `FAIL`/`ERROR` lines. The junction was removed with `cmd /c rmdir` before reporting, and the mayor's `node_modules` re-counted at 101 entries afterwards. |
| `python scripts/check_lint_export.py` (at the pin) | 0 | `OK: 6 checks fire on their fixtures, correct code is silent, and the artefact's own testbeds are quiet.` |
| `python scripts/check_lint_export.py --self-test` (at the pin) | 0 | eight mutations, all red; unmutated export green |
| corpus run (`implementation/hicasso/testbed`, at the pin) | 0 | part of the gate above — silent |
| tree-wide clj-kondo, both sides | 0 errors | empty finding-set diff, above |
| `python scripts/check_fast_pr_gap.py --list` | 0 | 95 required checks this spine does not decide |
| `mkdocs build --strict` | not run | no file under `docs/` is touched |
| browser/adapter smokes | not run | no substrate, adapter or testbed source is touched; this PR is a clj-kondo export, its fixtures and its gate script |

Fences held: the small syntax-local walker, conservative whole-form silencing, no
`api/resolve`, no whole-program analysis, and nothing outside
`implementation/hicasso/resources/clj-kondo.exports/**`,
`implementation/hicasso/lint-fixtures/**` and
`implementation/hicasso/scripts/check_lint_export.py`.
