### PR TITLE
docs(hicasso): settle the three prototype-suite sequencing questions (rf2-b6ja)

### DIFF
--- a/docs/design/hicasso/product/prototype-suite-triage.md
+++ b/docs/design/hicasso/product/prototype-suite-triage.md
@@ -20,6 +20,14 @@ Three verdicts, defined once:
 **13 PORT (5,108 lines) · 9 RE-AUTHORED (3,236) · 47 STAYS (19,691).** The three sum to 69 files and
 28,035 lines; every suite is named exactly once below, and line counts are `wc -l`.
 
+**Two rows have moved since, and the counts below are the census as it landed rather than the
+standing verdict.** rf2-b6ja found that `arm1/host_ssr_dom_cljs_test` (670) and
+`arm1/fallback_contents_cljs_test` (376) were parked in STAYS on a block that does not exist, so the
+standing verdict is **15 PORT (6,154) · 9 RE-AUTHORED (3,236) · 45 STAYS (18,645)** — still 69 files
+and 28,035 lines. Both rows keep their single home in STAYS (vi), where the bullet now carries the
+PORT verdict and the correction; see
+[The three sequencing questions, settled](#the-three-sequencing-questions-settled).
+
 ## The three facts that decide most rows
 
 ### 1. All 69 already run on every PR
@@ -219,12 +227,17 @@ Four are blocked on something concrete, and the block is the interesting part:
   — `defhost`'s `:ssr` policy in all three places it has to hold, and the contract for what an
   `:ssr` fallback may contain. Genuine package behaviour, and `implementation/hicasso/` has no
   `:ssr` witness of its own, so **this pair is the answer to rf2-6rw9** and whoever takes that bead
-  should start here rather than write a new one. Blocked twice over: the two files `:require` each
+  should start here rather than write a new one. ~~Blocked twice over: the two files `:require` each
   other, so they move together; and both reach `re-frame.bench.hicasso.ssr.entry`, which has no
   package counterpart. Porting them means giving the package an SSR entry first — which is
-  rf2-6rw9's work, not a triage's. `arm1/host_hatch_dom_cljs_test.cljs` (1,259), `defhost` end to
-  end, is the natural third member of that bead: 21 deftests deep in `arm1.hook-probe` and
-  `arm1.lane`, and pointless to move without the `:ssr` half.
+  rf2-6rw9's work, not a triage's.~~ **CORRECTED (rf2-b6ja): neither block exists. The files do not
+  `:require` each other and neither reaches `ssr.entry`; both readings came from docstring
+  `[[wiki-links]]`.** The pair is an ordinary `arm1/*` port and is **PORT**, not STAYS — see
+  [2. the `:ssr` trio](#2-the-ssr-trio--not-blocked-and-the-third-member-is-a-different-bead).
+  `arm1/host_hatch_dom_cljs_test.cljs` (1,259) is **not** the third member of that bead: it is the
+  only one of the three that needs `arm1.hook-probe`, which is the RE-AUTHORED blocker
+  `hook_ledger_dom_cljs_test` and `frame_prop_dom_cljs_test` already carry, and it belongs with
+  those rather than with the `:ssr` pair. It stays here, blocked on the probe.
 - **`front/slot_cljs_test.cljc`** (140) — blocked on a hot-zone change, and the block is worth
   naming precisely. It is `.cljc` on purpose: `scripts/check_test_lane_bijection.py` rule B2
   requires a `.cljc` suite under a CLJS-owned test root to be selected by a CLJS lane as well as a
@@ -317,6 +330,51 @@ defines no `deftest` is not a test file, so B1 and B2 never reach it — the bij
 is files that evaluate a test-defining form at the top level. Port the corpus as an ordinary support
 namespace beside the codec suite and both rows unblock as plain CLJS ports. **That is a follow-up
 dispatch, not this row.**
+
+### 2. The `:ssr` trio — not blocked, and the third member is a different bead
+
+**The verdict: `arm1/host_ssr_dom_cljs_test` + `arm1/fallback_contents_cljs_test` are PORT and are
+not waiting on anything. `arm1/host_hatch_dom_cljs_test` is not their third member.** The two
+blockers this triage recorded, and which rf2-6rw9's note then restated as that bead's real content,
+are both misreadings. Read off the files on `origin/main`, 2026-08-11:
+
+- **They do not `:require` each other.** `host_ssr_dom_cljs_test`'s `ns` form requires
+  `cljs.test`, `re-frame.adapter.uix`, `arm1.mount`, `arm1.runtime`, `front.codec`, `lane`,
+  `re-frame.core`, `re-frame.test-support`, `react`, `react-dom/client` and `react-dom/server`, with
+  `defview` / `defhost` from `arm1.lang`. `fallback_contents_cljs_test`'s is the same list without
+  `react-dom/client`. Neither names the other. Each *mentions* the other exactly once, in a
+  docstring `[[wiki-link]]` — `host_ssr` line 31, `fallback_contents` line 57. A cross-reference in
+  prose is not a dependency.
+- **Neither reaches `re-frame.bench.hicasso.ssr.entry`.** Neither file mentions the namespace at
+  all. `ssr.entry` has exactly seven requirers in the tree, and they are the five `ssr/*` suites
+  already parked in STAYS (iii) — `entry_cljs_test`, `hframe_ssr_cljs_test`,
+  `instance_key_payload_dom_cljs_test`, `spike_cljs_test`, `spike_dom_cljs_test` — plus the entry's
+  own `ssr/node.cljs` driver and `ssr/fixtures.cljs` corpus. **These two render to string with
+  React's own `react-dom/server`**, which they import directly. The bake driver is not on their
+  path, and the package needs no SSR entry to receive them.
+
+So the pair is an `arm1/*` port of exactly the shape the PORT table's sequencing paragraph
+describes: re-point `arm1.runtime` at the six modules, `arm1.lang`'s macros at the public door
+`re-frame.hicasso`, `arm1.mount` at `impl.mount`, `front.codec` at `impl.codec`. Their only `lane`
+call is `lane/leave-act-environment!`, once each, and its package counterpart already exists —
+`re-frame.hicasso.roots-frames-support/leave-act-environment!`, which cites the prototype by name.
+**They still move together**, but for the reason their own docstrings give rather than for a
+require: each is written as the other's arm, and the bare arm is the one that matters. A witness
+that only ever supplies a fallback proves nothing about the default, and `:client-only` is what an
+author gets by writing nothing.
+
+**`arm1/host_hatch_dom_cljs_test.cljs` (1,259) is blocked, on something else.** It is the only one
+of the three whose `ns` form requires `arm1.hook-probe`, and it uses it — `probe/install!`,
+`probe/record!`. Hook-probe proxies React's internal dispatcher slot and has no package
+counterpart, which is precisely the blocker RE-AUTHORED already records for
+`hook_ledger_dom_cljs_test` and `frame_prop_dom_cljs_test`. **It belongs with that bead**, whose
+deliverable is the probe. Bundling it with the `:ssr` pair would have held two unblocked suites
+behind a probe neither of them needs — on top of an SSR entry none of the three needs.
+
+**rf2-6rw9's content changes accordingly.** The bead reads "give the package an SSR entry, then port
+the pair onto it". The entry is not on the path: give the package the pair. Whether the package ever
+wants an SSR entry of its own is a separate question, and the rows that would answer it are the five
+`ssr/*` suites in STAYS (iii), which genuinely do reach one.
 
 ---
 

--- a/docs/design/hicasso/product/prototype-suite-triage.md
+++ b/docs/design/hicasso/product/prototype-suite-triage.md
@@ -234,6 +234,89 @@ Four are blocked on something concrete, and the block is the interesting part:
   needs an artefact-roster entry, which is only legal with a matching `test.yml` job, and
   `.github/workflows/` is hot zone. **Sequential access required — this one file cannot move
   without an operator-sequenced workflow change.**
+  **ANSWERED: no lane, and the row is closed rather than pending** — the claim is already armed on
+  both hosts and the package's copy is held identical to the armed one. See
+  [1. `front/slot_cljs_test.cljc` — no JVM lane](#1-frontslot_cljs_testcljc--no-jvm-lane).
+
+---
+
+## The three sequencing questions, settled
+
+**rf2-b6ja**, 2026-08-11 04:01 AUSEST. The triage stopped at three rows rather than take decisions
+that were not a triage's to take. All three are decided here, each with the measurement it rests on,
+so that the next reader inherits the answer instead of the question. Two are a **no**; the third
+turns out to rest on a premise that does not hold.
+
+### 1. `front/slot_cljs_test.cljc` — no JVM lane
+
+**The verdict: do not open a `jvm-hicasso` lane. The suite stays in the bench tree, and this row is
+closed rather than pending.** The claim it makes is already asserted on both hosts, and the
+package's copy of the rule is held identical to the copy being asserted — by a checker that is
+stronger than the suite.
+
+**The number that decides it is zero.** Nothing follows this file into a JVM lane. It is the *only*
+`.cljc` test file among the 69; the other 62 are `.cljs`, and a `.cljs` file is not loadable by a
+JVM lane at all — `check_test_lane_bijection.py`'s `loadable_by` gives JVM lanes `.clj` and `.cljc`
+and nothing else. `implementation/hicasso/test/` is 35 test files, every one of them `.cljs`. So the
+lane would open for one file and stay at one file until somebody *authors* a `.cljc` suite, and the
+package offers only three namespaces to author one against — `impl/slot.cljc`, `impl/state.cljc`,
+`impl/error.cljc` — of which only `slot` requires nothing but `clojure.string` (`state` reaches
+`re-frame.events` and `re-frame.subs`; `error` is the complaint catalogue's, already gated by
+`check_complaint_catalogue.py`). A whole CI job for one file, and no queue behind it.
+
+**And the cheap answer holds, which is what makes the no comfortable rather than merely thrifty.**
+The cross-host claim is armed four ways already, none of them a new lane:
+
+- **The pin runs on both hosts today.** Asking the bijection gate's own lane model which lanes
+  select this file — `select()` in `check_test_lane_bijection.py`, roots and all — answers exactly
+  two: `implementation::node-test` (the always-on CLJS lane) and `implementation/freehand` (the JVM
+  lane, on `scripts/test-jvm-implementation.sh`'s roster with its matching `test.yml` job). One
+  corpus, one implementation, two runtimes — which is the whole mechanism the file's own docstring
+  claims, and it is intact.
+- **The package's copy is held identical to the pinned one.** `frozen-sources.edn` has exactly one
+  surviving row and it is this rule: `front/slot.cljc` → `src/re_frame/hicasso/impl/slot.cljc`,
+  `:whole-file?` unset, so `check_freeze.py`'s MOVED rule applies — it *reconstructs* the package
+  file from donor text with `:renames` applied at symbol boundaries and compares line by line. That
+  is not a digest of the donor alone; it is an equality between the two files. So a cross-host
+  assertion about the bench rule is an assertion about the package rule, and the equality is checked
+  rather than believed.
+- **That checker is armed from the package's own surface.** `npm run test:hicasso-invariants` runs
+  it, `implementation/hicasso/*` sets `cljs_node_test=true` in `report-changed-surfaces.sh`, and
+  that arm's own comment names the invariants gate as one of the three things the output schedules.
+  It also runs unconditionally in `scripts/test-fast-pr.sh`.
+- **The JVM consumer the pin exists for is armed too.** The codemod's `deps.edn` puts
+  `../../../implementation/freehand/test` on `:paths` and `shared_rule_test.clj` asserts
+  `(identical? dest/canonical-slot slot/prop-name)` — plus that the file came off
+  `implementation/freehand/test/…` and not a copy inside the tool. Since rf2-erjv that lane is armed
+  from `implementation/hicasso/*` as well as from `implementation/freehand/*`.
+
+**The precedent is on the record, and it is the same wall.** rf2-hic-022 walked this exact chain and
+backed out of it: `140620d291` landed a JVM-runnable suite in `implementation/hicasso/test/` and
+dropped `--probe`; `b18bc8e1ad` found that `check_jvm_lane_rosters.py` R1 refuses a roster entry with
+no `test.yml` job and reverted the roster half; `dd9f31bbc4` re-expressed the witness as
+`scripts/check_lint_export.py`, in a lane it already had. The long comment at the foot of
+`scripts/test-jvm-implementation.sh` still narrates the middle state and is the artefact of it. A
+second bead arriving at the same wall is not new information about the wall.
+
+**The revisit trigger, because a no without one is exactly the rf2-hic-021 defect restated.**
+Everything above rests on one row in `frozen-sources.edn`, and that file's entire history is rows
+retiring as the package diverges — five `front/*` rows and every `arm1/*` row are already gone. Its
+own header anticipates the last one: *"when `front/slot.cljc` diverges for its own reasons"*. On the
+day that row is retired the package's slot rule has no cross-host assertion left, and **nothing will
+say so** — the freeze gate will go green having stopped looking. So: **whoever retires that row owns
+the replacement**, and the replacement is still not a `jvm-hicasso` lane. The cheap shape is to
+repoint the codemod's `:paths` entry at `implementation/hicasso/src` — a `migration/` artefact
+reading a shared `.cljc` out of `implementation/` is the direction the rule was extracted to serve,
+and the codemod's JVM lane already has a `test.yml` job and is already armed from
+`implementation/hicasso/*`.
+
+**What this leaves for the two rows queued behind it.** `front/codec_cljs_test.cljs` (1,593) and
+`arm1/raw_escape_dom_cljs_test.cljs` (403) are queued behind this file's `corpus` var, not behind
+its JVM half, and the corpus needs no lane. A namespace under `implementation/hicasso/test/` that
+defines no `deftest` is not a test file, so B1 and B2 never reach it — the bijection gate's universe
+is files that evaluate a test-defining form at the top level. Port the corpus as an ordinary support
+namespace beside the codec suite and both rows unblock as plain CLJS ports. **That is a follow-up
+dispatch, not this row.**
 
 ---
 

--- a/docs/design/hicasso/product/prototype-suite-triage.md
+++ b/docs/design/hicasso/product/prototype-suite-triage.md
@@ -197,7 +197,10 @@ Spec 009's `:render` bucket. These do assert package behaviour (`mint-view!` wra
 in `performance/mark-and-measure`), but the ON half runs in the `:node-test-nightly` build via the
 `-emit-nightly-test$` selector and the pair is written as a matched OFF/ON couple. Splitting them
 across two trees would break the couple; moving both needs a nightly-lane decision that is not a
-triage's to take. **Flagged for a follow-up bead rather than ported.**
+triage's to take. **Flagged for a follow-up bead rather than ported.** **ANSWERED (rf2-b6ja): there
+was no lane decision to take — measurement is tier 3 and the ON half is already in it, and a port
+would need no build, lane or workflow change.** See
+[3. the `render_measure` couple](#3-the-render_measure-couple--already-in-the-tier-that-runs-measurements).
 
 ### (vi) It is a control arm, or its move is blocked — 13 suites, 8,220 lines
 
@@ -376,6 +379,39 @@ the pair onto it". The entry is not on the path: give the package the pair. Whet
 wants an SSR entry of its own is a separate question, and the rows that would answer it are the five
 `ssr/*` suites in STAYS (iii), which genuinely do reach one.
 
+### 3. The `render_measure` couple — already in the tier that runs measurements
+
+**The verdict: nightly, tier 3, and the couple is already there. There was no lane decision waiting
+to be taken.** `TESTING.md`'s four tier scenarios put measurement in **tier 3, *Nightly / manual***
+(`.github/workflows/expensive-tests.yml`), and the couple already sits astride that boundary in
+exactly the way the split intends:
+
+- **The OFF half**, `arm1/render_measure_cljs_test.cljs`, is selected by `implementation::node-test`
+  and nothing else — `npm run test:cljs`, always-on, tier 1 and tier 2. Correct: with
+  `re-frame.performance/enabled?` off there is no measurement to be noisy, only a claim about what
+  `mint-view!` wraps.
+- **The ON half**, `arm1/render_measure_emit_nightly_test.cljs`, is selected by
+  `implementation::node-test-perf-nightly` and nothing else, run by `npm run
+  test:cljs-perf-emit-nightly`, whose only scheduled home is `expensive-tests.yml`. The build's own
+  comment gives the reason in a line: *"Perf-timing assertions are noisy under per-PR CI runners;
+  nightly cadence reduces false negatives from runner load."* It is **not** one of the two rf2-65ajl
+  PR exceptions (`test:story-feature-load`, `test:story-static`) and should not become one — those
+  exist for gates whose own definition a PR can edit unrun, which is a different problem.
+
+**And the port the row was actually holding is cheaper than it looked.** `:node-test-perf-nightly`
+declares no `:source-paths`, so it inherits the config's, and `hicasso/src` and `hicasso/test` are
+on that vector. Its selector is `-emit-nightly-test$`, applied with shadow's `re-find`. So a
+package-side `re-frame.hicasso.render-measure-emit-nightly-test` would be selected by the existing
+nightly build, and its OFF half by `:node-test`'s `cljs-test$` — **no new build, no new lane, no
+`test.yml` change, and no double-selection** (`…-emit-nightly-test` does not end in `cljs-test`, and
+`:node-test-hicasso`'s `^re-frame\.hicasso\..+-cljs-test$` does not reach it either). This is read
+off the build config rather than run.
+
+The couple is therefore portable whenever somebody wants the *package's* `mint-view!` measured
+rather than the prototype's, and the port carries no hot-zone edge. **Until somebody wants that, it
+stays**: what it measures today is the prototype, and the STAYS reasoning above is unchanged. **This
+row needs no follow-up bead** — it needed the tier named, and the tier is named.
+
 ---
 
 ## What this triage does not do
@@ -388,5 +424,8 @@ wants an SSR entry of its own is a separate question, and the rows that would an
   (`cell_table_laws`), the cold probe's contract (`cold_read`), the two registry-transition axes
   (`disposed_cell` with `first_registration`), and the ≤2-hook budget counted at React's dispatcher
   (`hook_ledger` with `frame_prop`). Those are re-authorings, and each wants its own bead.
-- **It leaves three sequencing questions for the operator**: the `:ssr` trio (rf2-6rw9), the
+- **It left three sequencing questions for the operator**: the `:ssr` trio (rf2-6rw9), the
   `render_measure` nightly couple, and `front/slot_cljs_test.cljc`'s workflow-gated `.cljc` lane.
+  **All three are now settled** — rf2-b6ja, above. Two of them cost nothing to close: the
+  `render_measure` couple was already in the tier it belongs to, and the `:ssr` pair was never
+  blocked. The third is a documented no with a named revisit trigger.


### PR DESCRIPTION
Closes rf2-b6ja. **Analysis and decision only** — three sequencing questions the rf2-6ync triage (PR #7824) raised and stopped at, now decided and recorded on the triage document. No lane opened, no suite ported, no job added. One markdown file, 186 insertions / 6 deletions.

Two of the three are a **no**, and the third turns out to rest on a premise that does not hold.

## Decision 1 — `front/slot_cljs_test.cljc`: no JVM lane for hicasso

**The number that decides it is zero.** Nothing follows this file in. It is the *only* `.cljc` test file among the 69; the other 62 are `.cljs`, and a `.cljs` file is not loadable by a JVM lane at all (`check_test_lane_bijection.py`'s `loadable_by` gives JVM lanes `.clj`/`.cljc`). `implementation/hicasso/test/` is 35 test-defining files, every one `.cljs`. The lane would open for one file and stay at one file — the package offers only `impl/{slot,state,error}.cljc` to author a second against, and only `slot` requires nothing but `clojure.string`.

**And the cheaper answer holds** — the PR #7823 move, asked here. The claim is already armed four ways, none of them a new lane:

- Feeding the bijection gate's own model (`select()`, roots and all) answers **exactly two lanes** for the file: `implementation::node-test` and the `implementation/freehand` JVM lane. The cross-host pin runs today.
- `frozen-sources.edn`'s **one surviving row** is this rule (`front/slot.cljc` to `impl/slot.cljc`, `:whole-file?` unset), so `check_freeze.py`'s MOVED rule reconstructs the package file from donor text with `:renames` applied and compares line by line. An assertion about the bench rule *is* an assertion about the package rule.
- That checker is armed from the package's own surface — `npm run test:hicasso-invariants`, scheduled by `cljs_node_test`, which `implementation/hicasso/*` sets; also unconditional in the fast-PR spine.
- The **JVM consumer the pin exists for** is armed too: the codemod's `deps.edn` puts `implementation/freehand/test` on `:paths` and `shared_rule_test.clj` asserts `(identical? dest/canonical-slot slot/prop-name)`. Since rf2-erjv that lane is armed from `implementation/hicasso/*` as well.

**Precedent:** rf2-hic-022 walked this exact chain and backed out — `140620d291` (suite lands, `--probe` dropped), then `b18bc8e1ad` (`check_jvm_lane_rosters.py` R1 refuses a roster entry with no `test.yml` job), then `dd9f31bbc4` (re-expressed as a checker in a lane it already had). The footer comment in `scripts/test-jvm-implementation.sh` still narrates the middle state.

**Revisit trigger recorded**, because a no without one is the rf2-hic-021 defect restated: it all rests on that one freeze row, and that file's history is rows retiring as the package diverges. When it retires, the cross-host assertion vanishes silently. The doc names the owner (whoever retires it) and the cheap shape — repoint the codemod's `:paths` at `implementation/hicasso/src`, whose JVM lane is already rostered (`scripts/test-jvm-tools.sh`) with a `test.yml` job (line 4963) and already armed from `implementation/hicasso/*`.

**Follow-up dispatch implied:** the two rows queued behind this one (`front/codec_cljs_test.cljs` 1,593, `arm1/raw_escape_dom_cljs_test.cljs` 403) need the `corpus` var, **not** the JVM half. A support namespace that defines no `deftest` is not a test file, so B1/B2 never reach it — no lane required, ordinary CLJS port.

## Decision 2 — the `:ssr` trio: not blocked, and the third member is a different bead

**Both blockers on record are misreadings**, verified against the files on `origin/main`:

- **They do not `:require` each other.** Each names the other exactly once, in a docstring `[[wiki-link]]` — `host_ssr` line 31, `fallback_contents` line 57. The `ns` forms name `arm1.{mount,runtime}`, `front.codec`, `lane`, `re-frame.core`, `re-frame.test-support`, the UIx adapter, React, and `arm1.lang`'s macros. Neither names the other.
- **Neither reaches `re-frame.bench.hicasso.ssr.entry`.** Neither file mentions it. That namespace has exactly seven requirers: the five `ssr/*` suites already in STAYS (iii) plus `ssr/node.cljs` and `ssr/fixtures.cljs`. These two render to string with **React's own `react-dom/server`**, imported directly.

So `arm1/host_ssr_dom_cljs_test` + `arm1/fallback_contents_cljs_test` are an ordinary `arm1/*` port and the verdict is **PORT, not STAYS**. Their one `lane` call is `lane/leave-act-environment!`, once each, and the package counterpart exists. They still move together, for the editorial reason their docstrings give.

**`arm1/host_hatch_dom_cljs_test` (1,259) is not their third member.** It is the only one of the three requiring `arm1.hook-probe` (`probe/install!`, `probe/record!`) — the same blocker RE-AUTHORED already carries for `hook_ledger_dom_cljs_test` and `frame_prop_dom_cljs_test`. It belongs with that bead.

**Follow-up implied:** rf2-6rw9's content changes. It reads "give the package an SSR entry, then port the pair onto it" — the entry is not on the path. Give the package the pair. Whether the package wants an SSR entry at all is a separate question owned by the five `ssr/*` rows that genuinely reach one.

Standing totals amended at the top of the doc: **15 PORT (6,154) / 9 RE-AUTHORED (3,236) / 45 STAYS (18,645)**, still 69 files and 28,035 lines. Both rows keep their single home in STAYS (vi), where the bullet now carries the PORT verdict — no suite is named twice.

## Decision 3 — the `render_measure` couple: nightly, and already there

Read off `TESTING.md`'s tier split rather than assumed. Measurement is **tier 3, *Nightly / manual*** (`expensive-tests.yml`), and the couple already sits astride the boundary correctly:

- OFF half selected by `implementation::node-test` alone (always-on, tiers 1 and 2) — with the perf gate off there is no measurement to be noisy.
- ON half selected by `implementation::node-test-perf-nightly` alone, run by `test:cljs-perf-emit-nightly`, whose only scheduled home is `expensive-tests.yml` (line 185). Not one of the two rf2-65ajl PR exceptions, and should not become one.

**There was no lane decision waiting to be taken, and the port it was holding needs no hot-zone edge either.** `:node-test-perf-nightly` declares no `:source-paths` (verified), so it inherits the config's, and `hicasso/src` and `hicasso/test` are on that vector (lines 158-159). Its `-emit-nightly-test$` selector would reach a package-side `re-frame.hicasso.render-measure-emit-nightly-test` with no double-selection from either `cljs-test$` lane. Read off the build config, not run. **No follow-up bead: the row needed the tier named.**

## Quality gates

| gate | exit | note |
|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | The gate that actually covers `docs/design/**`. Run again after rebase, still 0. |
| coverage proof for the above | **1, expected** | Planted a bogus anchor and the gate fired: `BROKEN ANCHOR: docs\design\hicasso\product\prototype-suite-triage.md:239 -> #b6ja-deliberately-bogus-anchor`. Restored byte-identically, sha256 `a12b5cddc79f77b1e26120f274156f91253df1fd35bd126ebb823fedd25d6b16` equal before and after. |
| `scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`. Tiered `docs=true jvm=false node=false (classified)` and enumerated 3 skipped tiers — correct for a prose-only markdown diff. Invoked by absolute path from the worktree root; `gate root:` printed this worktree. |
| markdown tables | hand-counted | Four tables, uniform cell count within each: line 14 gives 2 cells across 5 rows; line 82 gives 3 across 15; line 114 gives 3 across 11; line 168 gives 3 across 15. **The diff touches zero table lines** — every edit is prose, confirmed by grepping the diff for table rows and getting 0. |

Gates **not** run, with reasons:

- `mkdocs build --strict` — it ran inside the spine's documentation tier and passed, but it does **not** cover this file: `mkdocs.yml`'s `exclude_docs` block keeps `design/hicasso/` out of the site. Not nominated as the gate for this edit.
- All JVM artefact suites, `npm run test:cljs`, browser / bundle-isolation / prod-elision / perf lanes, adapter smokes, Xray feature matrix, mcp-conformance, tool JVM suites — the diff changes one markdown file under `docs/design/` and touches no source, build config or workflow, so the changed-surface classifier tiers it to documentation only. The spine printed exactly this and skipped them.
- `test:hicasso-invariants`, `check_freeze.py`, `check_test_lane_bijection.py` — read during the analysis, and the bijection checker was run for evidence (exit 0), but the diff touches none of their inputs.

## Fences

Writable surface was `docs/design/hicasso/product/prototype-suite-triage.md` and nothing else; the diff is that one file. No edit to `spec/*`, `.github/workflows/*`, `implementation/package.json`, `implementation/shadow-cljs.edn`, `implementation/deps.edn`, the frozen bench tree, `implementation/hicasso/test/**` or `test_kit/**`, the public facade, or the clj-kondo hooks. No `.beads` path staged. Worktree root `/c/Users/miket/code/re-frame2-worktrees/portseq-b6ja`; the mayor checkout stayed clean throughout.
