### PR TITLE
docs(hicasso): an id is frozen, its recovery keyword is not — bad-reads keeps its spelling (rf2-k855)

### DIFF
--- a/docs/design/hicasso/product/complaints.md
+++ b/docs/design/hicasso/product/complaints.md
@@ -221,6 +221,35 @@ bypass of the contract.
 Stated above under *What every complaint carries*, and repeated here because
 it is the promise most easily made too broadly.
 
+**An id is frozen; the `:recovery` beside it is not.** The stability rule
+governs the id and nothing else in the row. A recovery keyword is advice —
+read once by a human at the moment of failure, and branched on by nothing —
+so it tracks whatever API it points at, and is rewritten when that API is
+renamed. An id is a handle: a stored error, a monitor's grouping rule and a
+test's assertion all match on it, which is the whole reason rule 3 keeps a
+dead one dead. Freezing both would put every refusal's advice under the id's
+contract, and leave the substrate telling a programmer to type a word that
+no longer exists.
+
+**`:rf.error/hicasso-test-bad-reads` keeps its spelling.** The L2 fixture
+option it polices settles as `:subs` (naming-ledger row 23), so the id names
+a key a caller no longer writes. That is not a rule-1 trigger: the refusal
+means exactly what it always meant — *the fixture map was not a map from
+query vector to value* — and an id names the refusal, not the option. Under
+rule 2 the rename would buy one better word for a tombstone kept forever, a
+fresh spelling every consumer must re-learn, and two more Spec 009 rows; it
+is the same trade that leaves `:rf.error/no-frame-prop` recorded below as
+found rather than corrected. The current spelling belongs in the Trigger
+column and in the message, which is where a reader meets it. This id's own
+recovery, `:pass-a-map-of-query-to-value`, names a shape rather than a key
+and needed no change at all — the same distinction seen from the other side,
+and the shape a recovery keyword should prefer wherever one is available.
+The sibling advice on `:rf.error/hicasso-test-missing-read-fixture` does
+name the key, so it moves with it: `:add-the-query-to-reads` is rewritten in
+the pass that renames the option, in the kit's source and in its Spec 009
+row together, because the two must never disagree about what the runtime
+raises (rf2-k855).
+
 ## Open, and not settled here
 
 - **The forms module's failure modes have no ids.** The guide teaches them


### PR DESCRIPTION
Closes rf2-k855 in the half that is decidable today, and reports the half that is not.

## What the bead asked

Two artefacts spell the retired L2 fixture option. The bead's own framing is that they are **not the same question**: the recovery keyword gives unfollowable advice and should be fixed; the id is a stable public contract and should probably stay.

## What I verified at the source, and where the premises moved

**PR #7828 has NOT merged.** It is still `OPEN` on `worker/kitname-0ckh`, so I read the branch. Three corrections follow from that, and they change the shape of the answer.

1. **The two artefacts are on different rows.** `:add-the-query-to-reads` is the recovery for `:rf.error/hicasso-test-missing-read-fixture` (`spec/009-Instrumentation.md:2613`). `:rf.error/hicasso-test-bad-reads` (line 2617) carries `:pass-a-map-of-query-to-value`, which names a *shape* rather than a key and needs no change at all. The brief read them as one row; they are two, and the contrast between them is the most useful thing in the bead.

2. **The recovery keyword is not wrong yet — it is wrong the moment #7828 merges.** On `main` today the kit's option *is* `:reads` (`test.cljs:1179`, `{:keys [reads] :or {reads {}}}`), so `:add-the-query-to-reads` is presently correct advice. #7828 renames `render`→`tree` and `:reads`→`:subs` and *creates* the defect. Changing the spec row now would make `main` wrong in the other direction.

3. **There is no contradiction on `main` between the message and the recovery keyword.** The `bad-reads` message updated by #7828 (`":subs is the fixture map…"`) sits beside `:pass-a-map-of-query-to-value` — consistent. The real inconsistency is the pending one in (2).

## The recovery keyword: not fixed here, and why

`:add-the-query-to-reads` has **three** sites, and two are behind fences I was given:

| Site | Owner |
|---|---|
| `spec/009-Instrumentation.md:2613` (the row) | free — mine |
| `implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs:1117` (the emit) | open PR #7828 |
| `implementation/hicasso/test/re_frame/hicasso/test_kit_cljs_test.cljs:558` (the assertion) | `worker/reauth-wjag` |

The change is **atomic across those three**. `spec/009`'s recovery column states what the runtime raises, and consumers may branch on `:recovery`; a spec row that disagrees with the emitter is a normative lie, and **no gate catches it** — `check_complaint_catalogue.py` tracks ids only, and `check_keyword_catalogue_drift.py` only reconciles `:rf.error/*` / `:rf.warning/*` ids. Taking the spec half alone would trade a stale-but-consistent word for silent, untracked, unfindable drift. That is strictly worse, and it is exactly why the #7828 worker correctly took neither half.

Note also that the emit line is a **context line inside a #7828 hunk**, so editing it on this branch would guarantee a textual conflict against an open PR.

**Recommendation:** re-dispatch rf2-k855 as one pass *after* #7828 merges, holding `spec/009` + `test_kit/**` + `test/**` together. The whole change is then three lines: `:add-the-query-to-reads` → `:add-the-query-to-subs` at all three sites, plus the `:reads`/`render` wording in the `missing-read-fixture` and `bad-reads` Trigger cells and in `complaints.md`'s two row descriptions.

## The id: it STAYS — the judgement call, made deliberately

`:rf.error/hicasso-test-bad-reads` keeps its spelling.

- **Rule 1 does not fire.** The refusal means precisely what it always meant — *the fixture map was not a map from query vector to value*. Only the option's spelling moved. An id names the refusal, not the option.
- **Rule 2 prices the alternative honestly.** A rename is a retirement plus a mint: a tombstone row kept forever, a new live row, a struck `spec/009` row and a fresh one, and a new spelling every consumer must re-learn — bought for one better word.
- **Cost asymmetry is the whole point.** A recovery keyword is read once by a human and branched on by nothing. An id is matched on by stored errors, monitor grouping rules and test assertions. Changing the first is free; changing the second breaks consumers for cosmetics.
- **The register already set this precedent.** `:rf.error/no-frame-prop` is recorded under *Open, and not settled here* as found rather than corrected, on exactly this reasoning. A different answer here would make the register inconsistent with itself.

I did **not** let the fence drive this. It is worth noting the two agree, though: an id rename would also need the fenced source, so the merits and the mechanics point the same way.

## What actually changed

One file, `docs/design/hicasso/product/complaints.md` — two rulings added under *Rulings this catalogue owns*:

- **"An id is frozen; the `:recovery` beside it is not."** The register's stability rule governs the id and says nothing about the rest of the row, so a reader had no way to know whether the recovery keyword was equally frozen. It is not, and it must not be — freezing both would leave the substrate telling a programmer to type a word that no longer exists. This settles the *class*, not just this instance, which is the durable part of the bead.
- **"`:rf.error/hicasso-test-bad-reads` keeps its spelling"** — the ruling above, with its reasoning recorded, plus the note that its sibling `:add-the-query-to-reads` does name the key and therefore moves with it, in source and `spec/009` together.

Framed on naming-ledger row 23's settled recommendation (already on `main`: guide teaches `{:subs …}`, kit ships `{:reads …}`, recommendation is `ht/tree`/`:subs`), so the text is true today and stays true after #7828 merges either way.

No shim, no alias, no deprecation path.

## Other recovery keywords checked

I enumerated **all 56** hicasso recovery keywords from the `spec/009` §Hicasso rows. Ten name a literal API spelling rather than a shape: `:declare-callbacks-or-ssr`, `:declare-client-only-a-fallback-or-render`, `:declare-event-handler-or-render`, `:give-presence-a-positive-timeout-ms`, `:spell-prefetch-as-an-on-mouse-enter-intent`, `:write-inert-hiccup-or-declare-ssr-render`, `:declare-the-callback-contract`, `:declare-contracts-on-ordinary-props-only`, `:declare-the-position-event-or-write-an-h-fn`, `:write-an-h-fn-at-a-value-first-position`. I checked each named key against `implementation/hicasso/src` — `:callbacks` (19), `:ssr` (36), `:server` (1), `:timeout-ms` (15), `:prefetch` (13), `:on-mouse-enter` (3), `:event` (31), `:handler` (17), `:render` (54) all still exist. **`:add-the-query-to-reads` is the only one pointing at a key that is being renamed.** No sweep needed, and none performed.

## `docs/design/**` hand-verification (per CLAUDE.md)

`mkdocs build --strict` does not cover `docs/design/**` (`exclude_docs` in `mkdocs.yml`), so it is not the gate for this edit and was not run. Hand-checked as required: the diff adds **no table rows, no headings and no links** (verified by grep over the added lines), so every table's column count is unchanged (tables remain 2- and 3-column throughout) and every existing anchor still resolves. `check_doc_slugs.py`, which *does* validate this tree, is green below.

## Quality gates

| Gate | Exit | Note |
|---|---|---|
| `implementation/hicasso/scripts/check_complaint_catalogue.py` | **0** | the gate with teeth; 59 live, 11 reserved, 1 pending retirement, 1 retired |
| `check_complaint_catalogue.py --self-test` | **0** | proves the red/green classification, not just the run |
| `scripts/check_doc_slugs.py` | **0** | the validator that *does* cover `docs/design/**` |
| `scripts/check_keyword_catalogue_drift.py --verbose` | **0** | 412 files, 504 active + 9 retired rows; checks A/B/C findings = 0 |
| `scripts/check_retired_spellings.py --verbose` | **0** | 1026 source files; no retired spellings |
| `scripts/check_fast_pr_gap.py --list` | **0** | gap derived, not assumed (96 required checks this spine does not decide) |
| `scripts/test-fast-pr.sh` | **0** | full spine, run to completion from the worktree root, unpiped; exit captured on the same command line |

Not run, with reasons: `mkdocs build --strict` — `docs/design/**` is excluded from the site and nothing under `spec/` or any published page changed (see hand-verification above). The hicasso node lane — no refusal site was touched; this PR changes one markdown file and no code, so no `.cljs` compiles differently.
