### PR TITLE
test(hicasso): the four re-authored witnesses — index laws, cold probe, first registration, hook budget (rf2-wjag)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/cold_probe_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/cold_probe_cljs_test.cljs
@@ -1,0 +1,319 @@
+(ns re-frame.hicasso.cold-probe-cljs-test
+  "THE COLD PROBE'S CONTRACT — what a read guarantees on a first,
+  uncached read (rf2-wjag).
+
+  A boundary body's read is warm when a committed cell already holds the
+  key: a pure deref, nothing global touched. Every OTHER read is cold —
+  the first read of a mounting boundary, every read of a render React
+  will abandon, and every read taken while a cell's reaction has been
+  invalidated out from under it. That is the majority of the reads this
+  runtime performs, and the package had no witness for any of it.
+
+  The contract, from the observation port's cold-probe discipline
+  (rf2-6c237), is four promises in one sentence:
+
+  > reuse a live sub-cache reaction by deref alone, else compute pure
+  > against ONE render-scoped frame-state snapshot through ONE
+  > render-scoped memo — **no reaction build, no cache insert, no in-tick
+  > effect**.
+
+  ## Why the promises are worth a witness rather than a comment
+
+  The negative half is the whole design. `subscribe-once` — the door this
+  path replaced — paid a reaction build, a cache insert, an in-tick evict
+  and a dispose cascade **per read**, and a render React abandons is a
+  render whose every read did all four for nothing. So `render probes,
+  commit owns` (invariant I5) is not a property of the commit path alone:
+  it is equally a property of the read path, and a probe that quietly
+  cached would satisfy every acquisition assertion in
+  `kernel_commit_owns_cljs_test` while leaving a cache entry per
+  abandoned read.
+
+  The positive half is a coherence promise. Within one body run a cold
+  key computes ONCE, against one frame-state snapshot, through a memo
+  the run owns — and the run's end is where that memo dies. Both halves
+  of that are load-bearing in opposite directions: a memo that did not
+  dedup would recompute per read, and a memo that outlived its run would
+  serve a later render a value from an earlier commit.
+
+  ## The instrument
+
+  A counted sub body. Sub bodies are pure by contract and this one is
+  pure in everything but a counter, which is what makes `how many times
+  did the sub actually compute` an observable at all. It is the only way
+  to tell rung 1 from rung 2, and the only way to tell one memoised
+  compute from three unmemoised ones — neither of which changes a single
+  value on screen.
+
+  Beside it, the frame's own `:sub-cache` and the arm's `!cells`, read
+  directly. `retains nothing` is a claim about two tables, so both are
+  read, and each row that asserts a table is empty is paired with the
+  committed case that fills it.
+
+  ## What this file does not claim
+
+  The generation fence — that a commit landing mid-body makes the body
+  run again against the newer basis — is `render-body`'s law, not the
+  probe's, and it is asserted where the tear can be seen
+  (`reincarnation_paint_dom_cljs_test`). The probe's whole share of it is
+  that its memo box is reset by every body run, which is the second half
+  of the one-compute-per-run row below."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.frame :as frame]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.interop :as interop]
+            [re-frame.subs :as subs]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private frame-id ::cold-probe)
+
+(def ^:private !runs
+  "How many times the counted sub's body ran. A test instrument and not a
+  contract — sub bodies are pure by contract, and this one is pure in
+  everything but the count."
+  (volatile! 0))
+
+(rf/reg-sub :coldprobe/counted (fn [db _] (vswap! !runs inc) (:v db)))
+(rf/reg-sub :coldprobe/plain   (fn [db _] (:v db)))
+
+(rf/reg-event :coldprobe/seed (fn [_ [_ db]] {:db db}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (collector/reset-runtime!) (vreset! !runs 0))}))
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- seeded!
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [:coldprobe/seed {:v 7}]))
+  (vreset! !runs 0)
+  frame-id)
+
+(defn- k [query-v] [frame-id query-v])
+
+(defn- run-body!
+  "Run one boundary body under the real fence and answer what it read.
+  `f` is handed a `read` fn, so a row states its read SEQUENCE rather
+  than a shape — which is the surface the probe's per-run memo is about."
+  [f]
+  (let [!seen (volatile! [])]
+    (collector/render-body
+      frame-id
+      (fn [_] (f (fn [query-v] (vswap! !seen conj (collector/sub query-v)))) [:p])
+      {})
+    @!seen))
+
+(defn- sub-cache-entry
+  "The frame's own sub-cache slot for `query-v`, or nil. The probe
+  promises not to create one; `subs/subscribe` is what does."
+  [query-v]
+  (get @(:sub-cache (frame/frame frame-id)) query-v))
+
+(defn- errors-during
+  "Run `thunk` with the always-on error listener attached; answer the
+  records it emitted."
+  [thunk]
+  (let [!records (volatile! [])]
+    (error-emit/register-error-listener! ::cold-probe (fn [r] (vswap! !records conj r)))
+    (try (thunk)
+         (finally (error-emit/unregister-error-listener! ::cold-probe)))
+    @!records))
+
+;; ---------------------------------------------------------------------------
+;; 1. A cold read answers, and leaves the world as it found it
+;; ---------------------------------------------------------------------------
+
+(deftest a-cold-read-answers-correctly-and-retains-nothing
+  (seeded!)
+  (testing "the read answers the value the committed state holds"
+    (is (= [7] (run-body! (fn [read] (read [:coldprobe/plain]))))))
+
+  (testing "and nothing was built for it. No cell, so no reference, no
+            reverse edge and no watch; no sub-cache slot, so no reaction
+            and no ref-count. An abandoned render pays for its reads and
+            keeps none of them"
+    (is (nil? (get @collector/!cells (k [:coldprobe/plain]))))
+    (is (nil? (sub-cache-entry [:coldprobe/plain])))
+    (is (= [] (inventory/cell-readers (k [:coldprobe/plain]))))
+    (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0}
+           (dissoc (inventory/residue) :entries))))
+
+  ;; THE CONTROL, and the reason the four nils above mean anything. Both
+  ;; tables are perfectly capable of holding this key; what decides is
+  ;; whether React committed the render.
+  (let [entry   (do (collector/render-body
+                      frame-id (fn [_] (collector/sub [:coldprobe/plain]) [:p]) {})
+                    (collector/last-reads))
+        release (collector/commit-boundary! entry (fn []))]
+    (testing "committing the very same read fills both tables — so the
+              emptiness above is the probe's promise, not an instrument
+              that cannot see"
+      (is (some? (get @collector/!cells (k [:coldprobe/plain]))))
+      (is (some? (sub-cache-entry [:coldprobe/plain])))
+      (is (= 1 (count (inventory/cell-readers (k [:coldprobe/plain]))))))
+    (release)))
+
+(deftest a-cold-read-answers-what-the-committed-path-answers
+  (seeded!)
+  ;; The equivalence the port staked commit-free Tier-1 reads on: the
+  ;; probe's pure compute and the reactive build share the input grammar,
+  ;; so a value must not depend on which rung answered it.
+  (let [cold (first (run-body! (fn [read] (read [:coldprobe/plain]))))]
+    (let [entry   (do (collector/render-body
+                        frame-id (fn [_] (collector/sub [:coldprobe/plain]) [:p]) {})
+                      (collector/last-reads))
+          release (collector/commit-boundary! entry (fn []))
+          warm    (first (run-body! (fn [read] (read [:coldprobe/plain]))))]
+      (testing "the warm read really is warm — a committed cell now holds
+                the key, so this second read is a pure deref and not a
+                second cold one"
+        (is (some? (get @collector/!cells (k [:coldprobe/plain])))))
+      (is (= cold warm))
+      (is (= 7 warm))
+      (release))))
+
+;; ---------------------------------------------------------------------------
+;; 2. One memo, and it belongs to the run
+;; ---------------------------------------------------------------------------
+
+(deftest a-cold-key-computes-once-per-body-run-however-often-it-is-read
+  (seeded!)
+  (let [seen (run-body! (fn [read]
+                          (read [:coldprobe/counted])
+                          (read [:coldprobe/counted])
+                          (read [:coldprobe/counted])))]
+
+    (testing "three reads, three answers, and they agree"
+      (is (= [7 7 7] seen)))
+
+    (testing "and ONE compute — the run's own memo is what the second and
+              third reads hit, so a body that reads a key in a loop pays
+              for it once"
+      (is (= 1 @!runs))))
+
+  (testing "the edges the three reads recorded are one key, because the
+            scratch's sub-keys are values: a repeated read is a repeated
+            entry in the sequence and one member of the set"
+    (is (= #{(k [:coldprobe/counted])}
+           (collector/reads-of (collector/last-reads)))))
+
+  ;; THE OTHER HALF, and it is the half a global memo would break. The box
+  ;; is reset by every body run, so a LATER render computes again rather
+  ;; than serving a value from a snapshot taken at some earlier commit.
+  (let [before @!runs]
+    (run-body! (fn [read] (read [:coldprobe/counted])))
+    (testing "a second body run computes again: the memo is render-scoped,
+              so it can never serve a stale snapshot to a later render"
+      (is (= (inc before) @!runs)))))
+
+;; ---------------------------------------------------------------------------
+;; 3. The unregistered query — the recovery is memoised as a HIT
+;; ---------------------------------------------------------------------------
+
+(deftest an-unknown-query-recovers-to-nil-and-is-refused-once-per-run
+  (seeded!)
+  (let [records (errors-during
+                  (fn []
+                    (is (= [nil nil nil]
+                           (run-body! (fn [read]
+                                        (read [:coldprobe/never-registered])
+                                        (read [:coldprobe/never-registered])
+                                        (read [:coldprobe/never-registered])))))))
+        misses  (filter (comp #{:rf.error/no-such-sub} :error) records)]
+
+    (testing "the probe keeps the reactive path's contract for an id
+              nobody registered: it emits, and it recovers to nil rather
+              than throwing through a render"
+      (is (= 1 (count misses))))
+
+    (testing "and it emits ONCE for the run, not once per read. A memoised
+              nil has to be a HIT — a lookup that treated `no value` and
+              `the value nil` alike would re-emit and recompute on every
+              read of every unregistered key a body touches"
+      (is (= 1 (count misses)))))
+
+  ;; The mirror: the emission is per RUN, so the next run emits again.
+  (let [records (errors-during
+                  (fn [] (run-body! (fn [read] (read [:coldprobe/never-registered])))))]
+    (testing "a second run emits its own"
+      (is (= 1 (count (filter (comp #{:rf.error/no-such-sub} :error) records)))))))
+
+;; ---------------------------------------------------------------------------
+;; 4. A registration earlier in this very tick
+;; ---------------------------------------------------------------------------
+
+(deftest a-sub-registered-earlier-in-this-tick-is-visible-to-this-very-read
+  (seeded!)
+  ;; The probe computes inside `live-frame/call-with-frame-resolution`,
+  ;; whose read-time coalesced flush is what makes a registration issued
+  ;; earlier in the same tick reach this read. Without it a
+  ;; register-then-render-sync sequence computes against a stale
+  ;; projection and misses the handler — which presents as a boundary
+  ;; painting nil on a query that is by then perfectly well registered.
+  ;; A lazily loaded module that registers and renders in one turn is
+  ;; exactly this shape.
+  (let [records (errors-during
+                  (fn []
+                    (rf/reg-sub :coldprobe/registered-just-now (fn [db _] (inc (:v db))))
+                    (is (= [8] (run-body! (fn [read] (read [:coldprobe/registered-just-now])))))))]
+    (testing "and it resolved through the real handler rather than through
+              the recovery, which is the difference a value of nil would
+              have hidden behind a `no such sub` nobody was watching for"
+      (is (= [] (filterv (comp #{:rf.error/no-such-sub} :error) records))))))
+
+;; ---------------------------------------------------------------------------
+;; 5. Rung 1 — a live sub-cache reaction is reused by deref alone
+;; ---------------------------------------------------------------------------
+
+(deftest a-live-sub-cache-reaction-is-reused-by-deref-alone
+  (seeded!)
+  ;; Rung 1 is for a key no COMMITTED CELL holds but which some other
+  ;; holder keeps warm — a cell on another boundary mid-anything, a tool,
+  ;; a test. The holder here is a test, and it holds the reaction exactly
+  ;; as `wire-cell!` does: subscribe, ACTIVATE, settle. Activation is not
+  ;; ceremony — a subscription under the ratom family learns its sources
+  ;; only through a capturing deref, and an unactivated container
+  ;; recomputes on every deref, which would make the count below say
+  ;; nothing.
+  (let [reaction (subs/subscribe [:coldprobe/counted] {:frame frame-id})]
+    (interop/activate-derived-value! reaction)
+    @reaction
+    (vreset! !runs 0)
+
+    (testing "the premise: the reaction is in the frame's sub-cache and no
+              cell holds the key, so this read is cold by the runtime's
+              own definition and rung 1 is the rung it must take"
+      (is (some? (sub-cache-entry [:coldprobe/counted])))
+      (is (nil? (get @collector/!cells (k [:coldprobe/counted])))))
+
+    (testing "the read answers the reaction's own value"
+      (is (= [7] (run-body! (fn [read] (read [:coldprobe/counted]))))))
+
+    (testing "and computes NOTHING. The warm reaction was deref'd, not
+              recomputed and not rebuilt — which is the whole of what
+              rung 1 buys over the pure compute beneath it"
+      (is (= 0 @!runs)))
+
+    (subs/unsubscribe frame-id [:coldprobe/counted]))
+
+  ;; THE CONTROL. Same key, same body, same value — with the warm reaction
+  ;; released, so rung 1 has nothing to find and the read falls to the
+  ;; pure compute. A zero that cannot become a one is not a measurement.
+  (testing "the sub-cache slot went with the last holder"
+    (is (nil? (sub-cache-entry [:coldprobe/counted]))))
+
+  (vreset! !runs 0)
+  (testing "and the same read now computes exactly once"
+    (is (= [7] (run-body! (fn [read] (read [:coldprobe/counted])))))
+    (is (= 1 @!runs))))

--- a/implementation/hicasso/test/re_frame/hicasso/cold_probe_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/cold_probe_cljs_test.cljs
@@ -57,7 +57,17 @@
   probe's, and it is asserted where the tear can be seen
   (`reincarnation_paint_dom_cljs_test`). The probe's whole share of it is
   that its memo box is reset by every body run, which is the second half
-  of the one-compute-per-run row below."
+  of the one-compute-per-run row below.
+
+  **Nor that a `reg-sub` issued earlier in this tick reaches this read.**
+  `cold-read!` computes inside `live-frame/call-with-frame-resolution`,
+  and its docstring credits that wrapper's read-time coalesced flush with
+  making a same-tick registration visible. A row was written for it and
+  then deleted: replacing the wrapper with a bare call reds nothing here,
+  because a frame made with `make-frame` resolves the registrar directly
+  and has no stale projection to flush. The claim is real and the witness
+  was not — it would need an image-loaded frame — and a row a one-line
+  narrowing cannot turn red is not evidence, however true its subject."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.core :as rf]
@@ -250,30 +260,7 @@
       (is (= 1 (count (filter (comp #{:rf.error/no-such-sub} :error) records)))))))
 
 ;; ---------------------------------------------------------------------------
-;; 4. A registration earlier in this very tick
-;; ---------------------------------------------------------------------------
-
-(deftest a-sub-registered-earlier-in-this-tick-is-visible-to-this-very-read
-  (seeded!)
-  ;; The probe computes inside `live-frame/call-with-frame-resolution`,
-  ;; whose read-time coalesced flush is what makes a registration issued
-  ;; earlier in the same tick reach this read. Without it a
-  ;; register-then-render-sync sequence computes against a stale
-  ;; projection and misses the handler — which presents as a boundary
-  ;; painting nil on a query that is by then perfectly well registered.
-  ;; A lazily loaded module that registers and renders in one turn is
-  ;; exactly this shape.
-  (let [records (errors-during
-                  (fn []
-                    (rf/reg-sub :coldprobe/registered-just-now (fn [db _] (inc (:v db))))
-                    (is (= [8] (run-body! (fn [read] (read [:coldprobe/registered-just-now])))))))]
-    (testing "and it resolved through the real handler rather than through
-              the recovery, which is the difference a value of nil would
-              have hidden behind a `no such sub` nobody was watching for"
-      (is (= [] (filterv (comp #{:rf.error/no-such-sub} :error) records))))))
-
-;; ---------------------------------------------------------------------------
-;; 5. Rung 1 — a live sub-cache reaction is reused by deref alone
+;; 4. Rung 1 — a live sub-cache reaction is reused by deref alone
 ;; ---------------------------------------------------------------------------
 
 (deftest a-live-sub-cache-reaction-is-reused-by-deref-alone

--- a/implementation/hicasso/test/re_frame/hicasso/first_registration_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/first_registration_cljs_test.cljs
@@ -1,0 +1,178 @@
+(ns re-frame.hicasso.first-registration-cljs-test
+  "THE OTHER REGISTRY TRANSITION — an id that had **no** handler and got
+  one (rf2-wjag).
+
+  The registry axis of `impl.generation/commit-basis` has two transitions,
+  and they reach this arm by two different routes because they are two
+  different events.
+
+  A **replacement** — an id that already had a handler and got another —
+  arrives as a disposal: the sub-cache evicts the query's entry and
+  disposes its reaction, and `impl.collector/invalidate-cell!` rides that
+  event. `hmr_registry_cljs_test` witnesses that route in full, from the
+  synchronous drop to the microtask rewire, under the name a developer
+  knows it by: a save. **This file does not restate any of it.**
+
+  A **first** registration arrives as nothing at all.
+  `registrar/add-replacement-hook!` fires only when a previous handler
+  existed, so a first `reg-sub` for a query evicts nothing and disposes
+  nothing, and an arm listening for disposals alone would hear about it by
+  no route whatsoever.
+
+  ## Why a boundary can hold the miss
+
+  That would matter to nobody if a boundary could not hold an unregistered
+  query, and the substrate is careful that it should not: a subscribe to
+  an unregistered query emits `:rf.error/no-such-sub`, recovers to a
+  nil-yielding reaction, and **deliberately does not cache it**, precisely
+  so that a later registration is observed by the next `subscribe`.
+
+  This arm has exactly one property that breaks that assumption. A cell
+  holds its reaction for the life of every boundary reading the key, and
+  never subscribes again — so the recovery the substrate declined to cache
+  is cached anyway, in a cell, where nothing evicts it. Measured before
+  the repair existed: the boundary painted nil for the life of the mount,
+  the first `reg-sub` for the query changed nothing, and no later write
+  ever notified it — on a query that was by then perfectly well
+  registered. That is the shape a lazily loaded module hits, and it is
+  the shape of a page that renders correctly, errors nowhere, and is
+  simply frozen.
+
+  ## What is asserted, and what already is elsewhere
+
+  The transition has two halves. A boundary inside the render→commit gap
+  holds no cell, so the registration scan reaches nothing on its behalf;
+  it is repaired by the `registry-epoch` term of `commit-basis`, and
+  `hmr_registry_cljs_test`'s `one-save-is-invisible-to-a-mounted-boundary-and-visible-to-an-in-flight-one`
+  is that half's witness. The bill that pairs with it — a first
+  registration of an id no cell holds must disturb a mounted boundary by
+  nothing at all — is that file's
+  `an-unrelated-namespaces-save-disturbs-no-mounted-boundary`.
+
+  **The HELD half is what has never been asserted**, in either direction:
+  that a cell holding an unregistered id's recovery is found by the scan,
+  invalidated, rewired against the real registration, and notified by
+  writes thereafter. That is this file, and it is one row plus the control
+  that makes the row attributable."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private frame-id ::first-registration)
+
+;; `:firstreg/late` is REGISTERED BY THE ROW, not by this file: an id that
+;; already has a handler at mount time is the replacement case, which is
+;; the case this file exists not to be.
+(rf/reg-event :firstreg/seed (fn [_ [_ db]] {:db db}))
+(rf/reg-event :firstreg/bump (fn [{:keys [db]} _] {:db (update db :late inc)}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+(def ^:private late-key [frame-id [:firstreg/late]])
+
+(defn- seeded!
+  []
+  (support/leave-act-environment!)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [:firstreg/seed {:late 5}]))
+  frame-id)
+
+(defn- read-late!
+  "One body run reading the late-registered key, and what it saw."
+  []
+  (let [!seen (volatile! ::unread)]
+    (collector/render-body frame-id
+                           (fn [_] (vreset! !seen (collector/sub [:firstreg/late])) [:p])
+                           {})
+    @!seen))
+
+(defn- mount-late!
+  "React's place at the commit seam, for a boundary whose body reads the
+  late-registered key."
+  []
+  (let [!seen   (volatile! ::unread)
+        _       (collector/render-body
+                  frame-id
+                  (fn [_] (vreset! !seen (collector/sub [:firstreg/late])) [:p])
+                  {})
+        entry    (collector/last-reads)
+        !notified (volatile! 0)
+        release  (collector/commit-boundary! entry (fn [] (vswap! !notified inc)))]
+    {:value @!seen :entry entry :notified !notified :release release}))
+
+(deftest a-cell-holding-an-unregistered-ids-recovery-is-repaired-by-the-first-registration
+  (async done
+    (seeded!)
+    (let [{:keys [value notified release]} (mount-late!)]
+
+      (testing "the premise, and it is the whole defect. The boundary
+                committed against a query nobody had registered, so the
+                cell holds the substrate's nil-recovery — the very thing
+                the substrate declined to cache, cached anyway, where
+                nothing evicts it"
+        (is (nil? value))
+        (is (some? (inventory/cell-reaction late-key))))
+
+      ;; NEGATIVE CONTROL, taken FIRST, so the drop measured below is
+      ;; attributable to registering THIS id rather than to the mere fact
+      ;; that some registration happened. The scan is narrowed to cells
+      ;; holding the id being registered, and this is the assertion that
+      ;; makes that narrowing a measured property.
+      (rf/reg-sub :firstreg/unrelated (fn [db _] (:late db)))
+      (is (some? (inventory/cell-reaction late-key))
+          "an unrelated first registration leaves this cell's reaction in place")
+
+      (let [notified-before @notified]
+
+        ;; THE FIRST REGISTRATION. Nothing is evicted, nothing is disposed,
+        ;; and the registrar's replacement hook does not fire — so every
+        ;; assertion below is reached by the registration hook alone.
+        (rf/reg-sub :firstreg/late (fn [db _] (:late db)))
+
+        (testing "synchronously the held recovery is dropped — the repair's
+                  first phase, which is all a correct READ needs"
+          (is (nil? (inventory/cell-reaction late-key))))
+
+        (testing "and a body run inside the window already answers with the
+                  real handler, because a cell with no reaction takes the
+                  cold probe and the probe resolves the registration that
+                  is live now"
+          (is (= 5 (read-late!))))
+
+        (support/at-the-checkpoint
+          #(some? (inventory/cell-reaction late-key))
+          "the first-registration repair"
+          done
+          (fn [_turns]
+            (testing "at the microtask checkpoint the cell is wired against
+                      the real registration, and the boundary has been told
+                      to correct itself — it painted nil, and a correction
+                      that arrived in a later task could arrive after the
+                      paint"
+              (is (some? (inventory/cell-reaction late-key)))
+              (is (> @notified notified-before)))
+
+            (testing "and the property the repair exists for: a LATER write
+                      reaches it. This is the assertion the pre-repair
+                      runtime failed — the cell was deaf for the life of
+                      the mount, so the page rendered, painted, errored
+                      nowhere, and never moved again"
+              (let [before @notified]
+                (collector/dispatch! frame-id [:firstreg/bump])
+                (is (= (inc before) @notified))))
+
+            (testing "reading through the repaired cell answers the moved
+                      value, so the rewire attached to the live handler and
+                      not to a second recovery"
+              (is (= 6 (read-late!))))
+
+            (release)))))))

--- a/implementation/hicasso/test/re_frame/hicasso/hook_budget_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/hook_budget_cljs_test.cljs
@@ -1,0 +1,241 @@
+(ns re-frame.hicasso.hook-budget-cljs-test
+  "THE ≤2-HOOK BUDGET, COUNTED AT REACT'S OWN DISPATCHER (rf2-wjag).
+
+  > Hook budget ≤ 2 per boundary (paper rule), fully consumed by the
+  > subscription/epoch hook and the frame-context hook (HD-020); refs are
+  > callback refs, never `useRef` in the shell. A ViewCell-class
+  > per-boundary object graph appearing means the arm has failed.
+  >
+  > — `docs/design/hicasso/architecture.md`, Arm 1
+
+  A hard architectural line, and the package has never had a witness for
+  it. [[re-frame.hicasso.impl.collector/shell-hook-ledger]] is a
+  DECLARATION — a vector of two keywords the shell says it calls — and a
+  budget a runtime reports about itself is not evidence. This file counts
+  the calls React actually received, through
+  [[re-frame.hicasso.hook-probe]], which wraps React's own dispatcher slot
+  and records what was asked of it.
+
+  ## The boundary is a COUNT, so the instrument has to be able to say 3
+
+  Every assertion here is of the form *exactly these two*, and a
+  prohibition is trivially satisfied by an instrument that cannot report
+  more. So the first row drives a control component that calls three
+  hooks — `useRef`, `useState`, `useMemo`, the first two of which
+  HD-020(b) names as forbidden in a shell — and asserts the probe answers
+  all three, by name and in call order. The two below are the same
+  instrument, on the same page, in the same run.
+
+  ## Three claims, and the third is the one that matters
+
+  1. a boundary's shell calls exactly the two hooks its ledger declares,
+     and neither is `useRef` or `useState`;
+  2. the budget is PER BOUNDARY — a nested boundary costs its own two,
+     and shares nothing that would make a page's total sublinear or a
+     boundary's cost conditional on its parent;
+  3. **the count does not move with the read count.** One read, seven,
+     twenty — all cost two. That is the whole argument for the ambient
+     collector over a per-read hook: N reads = N hooks cannot satisfy this
+     budget on any rung, and no amount of care about the other two claims
+     substitutes for it.
+
+  ## Why a server render is the right lane for this
+
+  `react-dom/server` runs bodies for real — the shell's hooks, the read
+  collection, the codec's element emission — through React's own hook
+  dispatcher, and it runs in the node lane, which IS in the fast-PR
+  spine. The browser lane is not. A budget breach is a fact about the
+  shell's source, not about the host, so counting it where a PR will
+  actually run it is worth more than counting it in a lane a PR does not
+  reach. `kernel_commit_owns_cljs_test` takes the same view for the same
+  reason.
+
+  ## The variant this file does not measure
+
+  [[re-frame.hicasso.impl.collector/frame-prop-shell]] declares ONE hook,
+  and its ledger says so. It is a hypothesis under measurement rather
+  than the default — `h/defview` mints the context-fed shell — so what is
+  asserted here is the shipped shell against its own ledger. The same
+  probe answers the variant the day it is taken up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.hicasso.hook-probe :as probe]
+            [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]
+            ["react-dom/server" :as react-dom-server]))
+
+(def ^:private frame-id ::hook-budget)
+
+(rf/reg-sub :hookbudget/item (fn [db [_ i]] (get-in db [:items i])))
+
+(rf/reg-event :hookbudget/seed (fn [_ [_ db]] {:db db}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- seeded!
+  []
+  (support/leave-act-environment!)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id
+    (rf/dispatch-sync [:hookbudget/seed {:items (vec (range 20))}]))
+  frame-id)
+
+(defn- armed!
+  "Install the probe, and fail loudly if React's internals have moved.
+  Every count in this file is worthless if this is not true, so it is
+  asserted rather than branched on."
+  []
+  (is (true? (probe/install!))
+      "React's client-internals dispatcher slot was not found — the hook
+       budget is UNWITNESSED, not satisfied"))
+
+(defn- server-render!
+  "Render `hiccup` to markup through React's own server renderer, and
+  answer `{:html … :hooks [name …]}` — the hook names React was asked for
+  while it ran, in call order."
+  [hiccup]
+  (let [!html (volatile! nil)
+        hooks (probe/record!
+                (fn []
+                  (vreset! !html
+                           (react-dom-server/renderToString
+                             (mount/provider frame-id
+                                             (codec/root-element frame-id hiccup))))))]
+    {:html @!html :hooks hooks}))
+
+;; ---------------------------------------------------------------------------
+;; The boundaries under the probe
+;; ---------------------------------------------------------------------------
+
+(h/defview reader
+  "One boundary reading `n` subscriptions through the ambient collector.
+  The reads sit in a `for` — which no hook-shaped read surface can do,
+  and which is exactly why the count is interesting."
+  [{:keys [n]}]
+  [:ul.reads
+   (for [i (range n)]
+     [:li.read {:key i} (str (h/sub [:hookbudget/item i]))])])
+
+(h/defview outer
+  "A boundary whose body mints another boundary's element."
+  [_]
+  [:div.outer (str (h/sub [:hookbudget/item 0])) [reader {:n 1}]])
+
+(defn- three-hook-control
+  "A plain React component calling three hooks, two of which HD-020(b)
+  names as forbidden in a shell. Not a Hicasso boundary and not meant to
+  be one: it exists so that `exactly two` below is a reading taken by an
+  instrument that has been seen to answer three."
+  [_props]
+  (react/useRef nil)
+  (react/useState 0)
+  (react/useMemo (fn [] 1) #js [])
+  (react/createElement "p" nil "control"))
+
+;; ---------------------------------------------------------------------------
+;; 1. The instrument can count, and can count past the budget
+;; ---------------------------------------------------------------------------
+
+(deftest the-probe-answers-what-react-was-asked-for-and-can-count-to-three
+  (seeded!)
+  (armed!)
+  (let [hooks (probe/record!
+                (fn [] (react-dom-server/renderToString
+                         (react/createElement three-hook-control nil))))]
+
+    (testing "three hooks, named, in call order. `useRef` and `useState`
+              are the two HD-020(b) forbids a shell outright, so this row
+              also establishes that the probe would SEE either of them if
+              a shell ever called one"
+      (is (= ["useRef" "useState" "useMemo"] hooks)))
+
+    (testing "and the count is three, which is the number every `exactly
+              two` below is a measurement against rather than a limit of"
+      (is (= 3 (count hooks))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. A boundary shell calls exactly the two hooks its ledger declares
+;; ---------------------------------------------------------------------------
+
+(deftest a-boundary-shell-calls-exactly-the-two-hooks-its-ledger-declares
+  (seeded!)
+  (armed!)
+  (let [{:keys [html hooks]} (server-render! [reader {:n 1}])]
+
+    (testing "the premise: React really rendered the boundary's body"
+      (is (= 1 (count (re-seq #"<li" html)))))
+
+    (testing "two hooks, and WHICH two: the frame-context hook and the
+              subscription/epoch hook, in that order — the body runs
+              between them, which is what lets the second close over the
+              reads the first made possible"
+      (is (= ["useContext" "useSyncExternalStore"] hooks)))
+
+    (testing "the budget, as a number. HD-020(b) is a count, so it is
+              asserted as one"
+      (is (= 2 (count hooks))))
+
+    (testing "and the ledger the shell declares agrees with what React was
+              asked for — which is what makes the declaration a checked
+              statement rather than a comment that can rot"
+      (is (= (count collector/shell-hook-ledger) (count hooks))))
+
+    (testing "neither is `useRef` and neither is `useState`: HD-020(b)'s
+              two named prohibitions, stated as themselves rather than
+              left implied by the sequence above"
+      (is (= [] (filterv #{"useRef" "useState"} hooks))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. The budget is per boundary
+;; ---------------------------------------------------------------------------
+
+(deftest a-nested-boundary-costs-its-own-two-and-shares-nothing
+  (seeded!)
+  (armed!)
+  (let [{:keys [html hooks]} (server-render! [outer {}])]
+
+    (testing "the premise: both bodies ran"
+      (is (some? (re-find #"outer" html)))
+      (is (= 1 (count (re-seq #"<li" html)))))
+
+    (testing "two boundaries, two hooks each, in the order React renders
+              them — the budget is PER BOUNDARY, so a page's cost is
+              linear in its boundaries and no boundary's cost depends on
+              its parent's"
+      (is (= ["useContext" "useSyncExternalStore" "useContext" "useSyncExternalStore"]
+             hooks)))
+
+    (is (= 4 (count hooks)))))
+
+;; ---------------------------------------------------------------------------
+;; 4. The count does not move with the read count
+;; ---------------------------------------------------------------------------
+
+(deftest the-hook-count-does-not-move-with-the-read-count
+  (seeded!)
+  (armed!)
+  ;; The claim the ambient collector exists to make. A per-read hook
+  ;; surface answers N here, and cannot be brought under a budget of two
+  ;; by any amount of care elsewhere.
+  (doseq [n [1 7 20]]
+    (let [{:keys [html hooks]} (server-render! [reader {:n n}])]
+
+      (testing (str "the premise: the body really performed " n " reads")
+        (is (= n (count (re-seq #"<li" html)))))
+
+      (testing (str n " reads still cost exactly the same two hooks")
+        (is (= ["useContext" "useSyncExternalStore"] hooks))))))

--- a/implementation/hicasso/test/re_frame/hicasso/hook_probe.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/hook_probe.cljs
@@ -1,0 +1,105 @@
+(ns re-frame.hicasso.hook-probe
+  "COUNTING HOOKS AT REACT'S OWN DISPATCHER (rf2-wjag).
+
+  HD-020(b) makes the ≤2-hook budget a hard architectural line, and **a
+  budget a runtime reports about itself is not a witness**. The shell
+  declares its hooks in [[re-frame.hicasso.impl.collector/shell-hook-ledger]];
+  this counts the calls React actually receives, so the declaration is
+  checked rather than believed.
+
+  ## Why it lives under `test/` and not under `src/`
+
+  It installs a property accessor on a private React internals slot.
+  That is a legitimate thing for an instrument to do and an illegitimate
+  thing for a substrate to ship: nothing a consumer's production bundle
+  loads should be able to see, let alone wrap, React's dispatcher. So it
+  is a test-tree support namespace, beside `checkpoint-support` and
+  `roots-frames-support`, and the package's module graph never reaches
+  it.
+
+  ## How
+
+  React routes every hook call through one mutable slot on its shared
+  internals — `H`, the current dispatcher, reassigned as React enters and
+  leaves each render. [[install!]] replaces that slot with an accessor
+  whose getter wraps whatever React last assigned in a counting `Proxy`,
+  so a read of `H.useRef` is recorded and then forwarded untouched.
+  React never sees a different function; it sees the same one, one
+  property read later.
+
+  Two properties make this the right instrument rather than a clever one:
+
+  - **It counts what the component body calls, not what React implements
+    with.** `useSyncExternalStore` is ONE dispatcher call; React's
+    internal machinery for it does not go back through `H`. So the
+    shell's two hooks read as two.
+  - **It cannot be satisfied by a runtime that reports on itself.** The
+    numbers come from React.
+
+  ## When it cannot answer, it says so — and the caller goes red
+
+  The internals slot is a private React implementation detail and its
+  name is version-bound. [[install!]] answers `false` when it is not
+  found. The prototype's convention was to record the claim as
+  *unwitnessed* at that point; **this package's suite fails instead**,
+  and deliberately: React is a pinned dependency here, a slot that moved
+  is a fact somebody has to look at, and a gate that quietly stops
+  gating on a version bump is the failure mode this repo has been bitten
+  by. `unwitnessed` is the honest verdict for a benchmark reporting a
+  number; `red` is the honest verdict for a gate."
+  (:require ["react" :as react]))
+
+(def ^:private internals-key
+  "React 19's client-internals export. Version-bound by construction."
+  "__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE")
+
+(defonce ^:private !log (atom []))
+(defonce ^:private !counting (atom false))
+(defonce ^:private !installed (atom false))
+
+(defn- hook-name?
+  "A dispatcher property that is a hook. React reads a few non-hook keys
+  off the same object, and counting those would inflate every reading."
+  [prop]
+  (and (string? prop)
+       (> (count prop) 3)
+       (= "use" (subs prop 0 3))
+       (let [c (subs prop 3 4)] (= c (.toUpperCase c)))))
+
+(defn- counting-proxy [dispatcher]
+  (if (nil? dispatcher)
+    dispatcher
+    (js/Proxy. dispatcher
+               #js {"get" (fn [target prop receiver]
+                            (when (and @!counting (hook-name? prop))
+                              (swap! !log conj prop))
+                            (js/Reflect.get target prop receiver))})))
+
+(defn install!
+  "Arm the probe. Idempotent; answers true when the dispatcher slot was
+  found and wrapped, false when React's internals are not where this
+  version expects them."
+  []
+  (if @!installed
+    true
+    (if-some [internals (unchecked-get react internals-key)]
+      (let [raw (volatile! (unchecked-get internals "H"))]
+        (js/Object.defineProperty
+          internals "H"
+          #js {"configurable" true
+               "get"          (fn [] (counting-proxy @raw))
+               "set"          (fn [v] (vreset! raw v))})
+        (reset! !installed true)
+        true)
+      false)))
+
+(defn record!
+  "Run `thunk` with counting on, and answer the hook names React was asked
+  for while it ran, in call order. Counting is off outside the thunk, so
+  a render performed by anything else in the process contributes nothing."
+  [thunk]
+  (reset! !log [])
+  (reset! !counting true)
+  (try (thunk)
+       (finally (reset! !counting false)))
+  @!log)

--- a/implementation/hicasso/test/re_frame/hicasso/index_laws_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/index_laws_cljs_test.cljs
@@ -1,0 +1,431 @@
+(ns re-frame.hicasso.index-laws-cljs-test
+  "THE SIX INDEX LAWS, over the fused cell table (rf2-wjag).
+
+  > (1) after mount+read, a commit of that sub dirties that boundary only;
+  > (2) two boundaries sharing a sub both dirty; (3) unmount removes edges;
+  > (4) a re-run with fewer reads drops edges (conditional read); (5) the
+  > broad dirty set is the union of all readers of any dirty sub; (6) an
+  > unknown dirty sub yields the empty set — no phantom boundaries.
+  >
+  > — `docs/design/hicasso/architecture.md` §2, restated verbatim when
+  >   rf2-dabt3 retired `front.sub-index` and fused the reverse edge onto
+  >   the key cell. *Nothing about the laws themselves changed.*
+
+  These six are the whole contract of the subscription→boundary index,
+  and since the fusion the package has had no witness for any of them.
+  `inventory_snapshot_cljs_test` asserts that `cell-readers` answers a
+  SNAPSHOT, which is a claim about the instrument. `kernel_commit_owns_cljs_test`
+  asserts ACQUISITION — which keys a commit takes and which readers it
+  installs. Neither asks the question the laws ask, which is the one the
+  runtime exists to answer: **given a commit, which boundaries re-run?**
+
+  ## The observable is the notification, and it has to be
+
+  Every law below is asserted on the count of `onStoreChange` calls a
+  committed boundary received, and on `inventory/cell-readers` beside it.
+  Reader membership alone is not the law: an edge that is present and a
+  commit that never consults it produce identical censuses and opposite
+  screens. So each row reads the edge to establish its premise and the
+  notification to make its claim.
+
+  ## Every zero here is paired with a one
+
+  A dirty-set law is half prohibition — *and no other boundary*, *not at
+  all*, *the empty set* — and a prohibition is trivially satisfied by a
+  runtime that has stopped notifying anybody. So **no row asserts a zero
+  without asserting, in the same commit or the one after it, a boundary
+  that DID move**. That pairing is the negative control, distributed
+  across the rows rather than parked in one, because what has to stay
+  live is the specific counter the zero is being claimed of.
+
+  ## The doors
+
+  `render-body` + `commit-boundary!` are the published seam — the render
+  React drives and the commit it drives, exposed so acquisition and
+  dirtying can be stated per key and per reader without a browser. The
+  write door is `collector/dispatch!`, which is the arm's own: it is
+  `with-commit` applied, so ONE dispatch is ONE commit window however
+  many subscriptions it moves. Law 5 is a claim about that window and
+  would be untestable through a door that flushed per key, so the row
+  asserts the window's existence — `generation` moves by exactly one —
+  before it asserts what the window did.
+
+  The adapter is UIx's rather than `plain-atom`'s, and that is
+  load-bearing for the whole file: plain-atom has no reactivity layer, so
+  a subscription under it never notifies, `mark-dirty!` never fires, and
+  every row would pass vacuously by never firing at all.
+
+  ## What is deliberately not restated here
+
+  The bench ancestor carried three obligations beneath the six that the
+  fusion changed the shape of, and all three are now asserted elsewhere
+  in this package: abandoned-render safety is structural and is
+  `kernel_commit_owns_cljs_test`'s server-render row; StrictMode's
+  double-invoke leaving no residue is that file's two-subscribes row and
+  its DOM sibling's; and the registration sharing the entry's key set by
+  reference is `impl.inventory/boundary-reads`' own definition. A second
+  copy of any of them would double the maintenance and the two would
+  drift."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.generation :as generation]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private frame-id ::index-laws)
+
+(rf/reg-sub :idxlaw/a      (fn [db _] (:a db)))
+(rf/reg-sub :idxlaw/b      (fn [db _] (:b db)))
+(rf/reg-sub :idxlaw/c      (fn [db _] (:c db)))
+(rf/reg-sub :idxlaw/unread (fn [db _] (:unread db)))
+
+(rf/reg-event :idxlaw/seed     (fn [_ [_ db]] {:db db}))
+(rf/reg-event :idxlaw/bump     (fn [{:keys [db]} [_ k]] {:db (update db k inc)}))
+(rf/reg-event :idxlaw/bump-two (fn [{:keys [db]} [_ k1 k2]]
+                                 {:db (-> db (update k1 inc) (update k2 inc))}))
+
+;; `:ambient-frame nil` because this suite seats its own top-level frame,
+;; and the carried-invariant chain resolves the dynamic-var tier BEFORE
+;; React context — a fixture-installed ambient frame would answer reads
+;; for a frame this file never made. The fn form is correct here: no row
+;; is `async`, because every law is a statement about one synchronous
+;; commit and the one reaper window law 6 needs is entered, not waited on.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- seeded!
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id
+    (rf/dispatch-sync [:idxlaw/seed {:a 0 :b 0 :c 0 :unread 0}]))
+  frame-id)
+
+(defn- k
+  "A sub-key. The runtime keys cells by `[frame-kw query-v]` — two frames
+  are isolated contexts holding two different app-dbs, so the frame is
+  part of the identity the laws are stated over."
+  [query-v]
+  [frame-id query-v])
+
+(defn- reading
+  "A body that reads exactly `query-vs`, in order, through the ambient
+  collector. The reads sit in a `mapv` rather than at fixed sites, which
+  is the surface the laws are about: the edge is recorded WHERE THE READ
+  HAPPENS."
+  [query-vs]
+  (fn [_props] [:p (str (mapv collector/sub query-vs))]))
+
+(defn- mount!
+  "Render a body and commit it, exactly as React does — `render-body`,
+  then the same `subscribe` closure `useSyncExternalStore` would call.
+  Answers the notification counter React's `onStoreChange` increments,
+  and the cleanup React would hold."
+  ([body] (mount! body {}))
+  ([body props]
+   (collector/render-body frame-id body props)
+   (let [entry   (collector/last-reads)
+         !n      (volatile! 0)
+         release (collector/commit-boundary! entry (fn [] (vswap! !n inc)))]
+     {:entry entry :notified !n :release release})))
+
+(defn- woken
+  "How many times a commit has told this boundary to re-run."
+  [b]
+  @(:notified b))
+
+(defn- release! [b] ((:release b)))
+
+(defn- readers-of [query-v] (count (inventory/cell-readers (k query-v))))
+
+;; ---------------------------------------------------------------------------
+;; Law 1 — a commit of that sub dirties that boundary ONLY
+;; ---------------------------------------------------------------------------
+
+(deftest law-1-a-commit-dirties-the-readers-of-the-moved-sub-and-no-other-boundary
+  (seeded!)
+  (let [reads-a (mount! (reading [[:idxlaw/a]]))
+        reads-b (mount! (reading [[:idxlaw/b]]))]
+
+    (testing "the premise: two boundaries, two keys, one reader each"
+      (is (= 1 (readers-of [:idxlaw/a])))
+      (is (= 1 (readers-of [:idxlaw/b]))))
+
+    (collector/dispatch! frame-id [:idxlaw/bump :a])
+
+    (testing "the reader of the moved sub is woken exactly once"
+      (is (= 1 (woken reads-a))))
+
+    (testing "and the boundary that does not read it is not woken at all —
+              `only` is the whole law, and a runtime that woke every
+              committed boundary would satisfy the line above"
+      (is (= 0 (woken reads-b))))
+
+    ;; The mirror, on the same two counters, in the same test. Without it
+    ;; the zero above is equally the zero of a runtime that notifies
+    ;; nobody, and this file would be asserting silence.
+    (collector/dispatch! frame-id [:idxlaw/bump :b])
+
+    (testing "moving the OTHER sub wakes the other boundary and leaves the
+              first where it was: both counters are live, and each moved
+              only for its own key"
+      (is (= 1 (woken reads-b)))
+      (is (= 1 (woken reads-a))))
+
+    (release! reads-a)
+    (release! reads-b)))
+
+;; ---------------------------------------------------------------------------
+;; Law 2 — two boundaries sharing a sub BOTH dirty
+;; ---------------------------------------------------------------------------
+
+(deftest law-2-two-boundaries-sharing-a-sub-are-both-dirtied
+  (seeded!)
+  (let [first-reader  (mount! (reading [[:idxlaw/a]]))
+        second-reader (mount! (reading [[:idxlaw/a]]))
+        bystander     (mount! (reading [[:idxlaw/c]]))]
+
+    (testing "the premise: ONE cell, TWO readers. The fan-out lives on the
+              key's own reader list, which since rf2-dabt3 IS the reverse
+              edge — so a law about fan-out is a law about this list"
+      (is (= 2 (readers-of [:idxlaw/a]))))
+
+    (collector/dispatch! frame-id [:idxlaw/bump :a])
+
+    (testing "both sharers are woken — the dirty set is the cell's readers,
+              plural, and not the reader that got there first"
+      (is (= 1 (woken first-reader)))
+      (is (= 1 (woken second-reader))))
+
+    (testing "and the boundary reading another key is not swept in with
+              them, which is what keeps `both` from meaning `all`"
+      (is (= 0 (woken bystander))))
+
+    (release! first-reader)
+    (release! second-reader)
+    (release! bystander)))
+
+;; ---------------------------------------------------------------------------
+;; Law 3 — unmount removes edges
+;; ---------------------------------------------------------------------------
+
+(deftest law-3-an-unmount-removes-the-edge-and-the-next-commit-passes-that-boundary-by
+  (seeded!)
+  (let [leaving  (mount! (reading [[:idxlaw/a]]))
+        staying  (mount! (reading [[:idxlaw/a]]))]
+
+    (testing "the premise: two memberships on one key"
+      (is (= 2 (readers-of [:idxlaw/a]))))
+
+    (release! leaving)
+
+    (testing "disconnect drops the departing boundary's edge immediately,
+              and exactly one of them — the survivor's membership is
+              untouched"
+      (is (= 1 (readers-of [:idxlaw/a]))))
+
+    (collector/dispatch! frame-id [:idxlaw/bump :a])
+
+    (testing "so a later commit of that very sub reaches the survivor and
+              not the departed. The PAIR is the law: a runtime that had
+              simply stopped notifying would satisfy the zero on its own"
+      (is (= 1 (woken staying)))
+      (is (= 0 (woken leaving))))
+
+    (release! staying)))
+
+;; ---------------------------------------------------------------------------
+;; Law 4 — a re-run with fewer reads drops edges (the conditional read)
+;; ---------------------------------------------------------------------------
+
+(defn- conditional-body
+  "One body, two read sets. `wide?` false takes the branch that never
+  performs the second read at all — which is what makes the dropped edge
+  a consequence of control flow rather than of a declaration."
+  [{:keys [wide?]}]
+  (let [a (collector/sub [:idxlaw/a])
+        b (when wide? (collector/sub [:idxlaw/b]))]
+    [:p (str a "/" b)]))
+
+(deftest law-4-a-re-run-with-fewer-reads-drops-the-edge-it-stopped-holding
+  (seeded!)
+  ;; `keeper` exists so the row cannot pass vacuously. Without a second
+  ;; reader, `:idxlaw/b`'s last membership leaves with the wide render and
+  ;; the cell is handed to the reaper — at which point a commit of `:b`
+  ;; notifies nobody because the key has no cell, which is LAW 6 and not
+  ;; this one. The keeper holds the cell alive, so the silence measured
+  ;; below is an edge that was dropped rather than a table that emptied.
+  (let [keeper (mount! (reading [[:idxlaw/b]]))
+        wide   (mount! conditional-body {:wide? true})]
+
+    (testing "the premise: the wide render read both keys, so `b` carries
+              two memberships"
+      (is (= #{(k [:idxlaw/a]) (k [:idxlaw/b])} (collector/reads-of (:entry wide))))
+      (is (= 2 (readers-of [:idxlaw/b]))))
+
+    ;; The re-run, with one read fewer. At the seam a read-set change is
+    ;; the pair — a fresh `subscribe` against the new entry, then the old
+    ;; entry's cleanup — because the registration IS the boundary id, so a
+    ;; changed read set is a new registration by construction.
+    (let [narrow (mount! conditional-body {:wide? false})]
+      (release! wide)
+
+      (testing "the narrow read set is the branch the body actually took"
+        (is (= #{(k [:idxlaw/a])} (collector/reads-of (:entry narrow)))))
+
+      (testing "and `b` has lost the boundary that stopped reading it while
+                keeping the one that did not"
+        (is (= 1 (readers-of [:idxlaw/b]))))
+
+      (collector/dispatch! frame-id [:idxlaw/bump :b])
+
+      (testing "so the sub the re-run dropped passes it by"
+        (is (= 0 (woken narrow))))
+
+      (testing "while the boundary that still reads `b` is woken — which is
+                what makes the zero above a DROPPED EDGE and not a key
+                nothing holds"
+        (is (= 1 (woken keeper))))
+
+      (collector/dispatch! frame-id [:idxlaw/bump :a])
+
+      (testing "and the read the re-run kept still reaches it, so the
+                replacement dropped one edge rather than all of them"
+        (is (= 1 (woken narrow)))
+        (is (= 1 (woken keeper))))
+
+      (release! narrow)
+      (release! keeper))))
+
+;; ---------------------------------------------------------------------------
+;; Law 5 — the broad dirty set is the UNION of all readers of any dirty sub
+;; ---------------------------------------------------------------------------
+
+(deftest law-5-the-broad-dirty-set-is-the-union-and-a-double-reader-is-woken-once
+  (seeded!)
+  (let [only-a    (mount! (reading [[:idxlaw/a]]))
+        reads-ab  (mount! (reading [[:idxlaw/a] [:idxlaw/b]]))
+        only-c    (mount! (reading [[:idxlaw/c]]))
+        gen-before (generation/generation)]
+
+    ;; ONE commit window moving TWO subs. `collector/dispatch!` is the
+    ;; arm's own door and is `with-commit` applied, so the writes inside
+    ;; it are collected and flushed once.
+    (collector/dispatch! frame-id [:idxlaw/bump-two :a :b])
+
+    (testing "the premise, and it is not decoration: `flush!` bumps the
+              generation once per flush that found a dirty cell, so ONE
+              here is the whole claim that this was one commit window. Two
+              flushes would make `woken once` an accident of a second
+              flush finding nothing rather than a union"
+      (is (= (inc gen-before) (generation/generation))))
+
+    (testing "every reader of every dirty sub is in the set"
+      (is (= 1 (woken only-a)))
+      (is (= 1 (woken reads-ab))))
+
+    (testing "and it is a UNION rather than a concatenation: the boundary
+              that read BOTH dirty subs is woken once, not once per dirty
+              key it happened to read"
+      (is (= 1 (woken reads-ab))))
+
+    (testing "and a reader of neither dirty sub is not in the union"
+      (is (= 0 (woken only-c))))
+
+    ;; The mirror for `only-c`, so its zero is a live counter's zero.
+    (collector/dispatch! frame-id [:idxlaw/bump :c])
+    (testing "moving `c` wakes it and nobody else"
+      (is (= 1 (woken only-c)))
+      (is (= 1 (woken only-a)))
+      (is (= 1 (woken reads-ab))))
+
+    (release! only-a)
+    (release! reads-ab)
+    (release! only-c)))
+
+;; ---------------------------------------------------------------------------
+;; Law 6 — an unknown dirty sub yields the empty set: no phantom boundaries
+;; ---------------------------------------------------------------------------
+
+(deftest law-6-a-sub-no-boundary-reads-becomes-no-commit-work-at-all
+  (seeded!)
+  (let [reader     (mount! (reading [[:idxlaw/a]]))
+        gen-before (generation/generation)]
+
+    (collector/dispatch! frame-id [:idxlaw/bump :unread])
+
+    (testing "the write really happened — a body run reads the moved value
+              back, so the silence below is the index's answer and not a
+              dispatch that did nothing"
+      (let [!seen (volatile! nil)]
+        (collector/render-body frame-id
+                               (fn [_] (vreset! !seen (collector/sub [:idxlaw/unread])) [:p])
+                               {})
+        (is (= 1 @!seen))))
+
+    (testing "no cell holds the key, so it never enters the dirty set and
+              the flush finds nothing to do"
+      (is (nil? (get @collector/!cells (k [:idxlaw/unread]))))
+      (is (= gen-before (generation/generation))))
+
+    (testing "and no phantom boundary is conjured for it: the one committed
+              boundary in the runtime is not woken"
+      (is (= 0 (woken reader))))
+
+    ;; The mirror, on that very counter.
+    (collector/dispatch! frame-id [:idxlaw/bump :a])
+    (testing "which it is, the moment a sub it actually reads moves"
+      (is (= 1 (woken reader))))
+
+    (release! reader)))
+
+(deftest law-6-a-dirty-cell-whose-readers-have-all-left-yields-the-empty-set
+  (seeded!)
+  ;; The sharper half, and the one a `no cell` row cannot make: a cell
+  ;; that EXISTS, is genuinely dirtied by a commit, and still contributes
+  ;; no boundary. A released cell is given one macrotask of grace before
+  ;; the reaper takes it, so this whole row sits inside that window — the
+  ;; watch is still armed, `mark-dirty!` still fires, `flush!` still runs.
+  ;; The dirty set is non-empty and the boundary set derived from it is
+  ;; empty, which is the strongest available statement of `no phantom
+  ;; boundaries`.
+  (let [_          (seeded!)
+        departed   (mount! (reading [[:idxlaw/a]]))
+        elsewhere  (mount! (reading [[:idxlaw/c]]))]
+
+    (release! departed)
+
+    (testing "the premise: the cell survives its last reader, holding no
+              readers at all"
+      (is (some? (get @collector/!cells (k [:idxlaw/a]))))
+      (is (= 0 (readers-of [:idxlaw/a]))))
+
+    (let [gen-before (generation/generation)]
+      (collector/dispatch! frame-id [:idxlaw/bump :a])
+
+      (testing "the cell really was dirtied — the generation moved, so a
+                flush found it. Without this the zeros below would be the
+                zeros of a commit that never reached the index"
+        (is (= (inc gen-before) (generation/generation))))
+
+      (testing "and the union over that dirty cell is empty: the departed
+                boundary is not resurrected, and the live boundary reading
+                another key is not swept in to stand for it"
+        (is (= 0 (woken departed)))
+        (is (= 0 (woken elsewhere)))))
+
+    ;; The mirror for `elsewhere`, so its zero is a live counter's zero.
+    (collector/dispatch! frame-id [:idxlaw/bump :c])
+    (testing "the surviving boundary is woken by its own key"
+      (is (= 1 (woken elsewhere))))
+
+    (release! elsewhere)))

--- a/implementation/hicasso/test/re_frame/hicasso/index_laws_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/index_laws_cljs_test.cljs
@@ -398,9 +398,9 @@
   ;; The dirty set is non-empty and the boundary set derived from it is
   ;; empty, which is the strongest available statement of `no phantom
   ;; boundaries`.
-  (let [_          (seeded!)
-        departed   (mount! (reading [[:idxlaw/a]]))
-        elsewhere  (mount! (reading [[:idxlaw/c]]))]
+  (seeded!)
+  (let [departed  (mount! (reading [[:idxlaw/a]]))
+        elsewhere (mount! (reading [[:idxlaw/c]]))]
 
     (release! departed)
 


### PR DESCRIPTION
Closes rf2-wjag.

The four genuine coverage gaps the rf2-6ync triage (PR #7824) left filed rather
than closed, re-authored against the package's own structure. **Four witnesses,
plus one dropped as already covered and one row deleted after its mutation proved
it decorative.** No spec, no workflow, no `package.json`, no `shadow-cljs.edn`,
and nothing under the frozen bench tree.

| # | gap | verdict |
|---|---|---|
| 1 | the six index laws over the fused cell table | **delivered** — `index_laws_cljs_test` |
| 2 | the cold probe's contract | **delivered** — `cold_probe_cljs_test` |
| 3 | the two registry-transition axes | **half delivered, half dropped as covered** — see below |
| 4 | the ≤2-hook budget at React's dispatcher | **delivered** — `hook_probe` + `hook_budget_cljs_test` |

**The hook-probe was built, not deferred.** It is 100 lines with one mechanism and
no package coupling, so items 3 and 4 both landed. It lives under `test/`, not
`src/`: installing a property accessor on React's private internals is a
legitimate thing for an instrument to do and an illegitimate thing for a substrate
to ship, so it sits beside `checkpoint-support` and the package's module graph
never reaches it.

## What was dropped as already covered

**Item 3's replacement axis.** `hmr_registry_cljs_test/editing-a-sub-and-saving-repairs-its-readers-at-the-microtask-checkpoint`
already witnesses it end to end — the synchronous drop of the held reaction, the
cold-path read inside the window, the microtask rewire, the number moving and the
notification landing — under the name a developer knows it by. Its staged half is
that file's `one-save-is-invisible-to-a-mounted-boundary-and-visible-to-an-in-flight-one`,
and the bill that pairs with it is `an-unrelated-namespaces-save-disturbs-no-mounted-boundary`.
None of it is restated here.

What was **not** covered, in either direction, is the **held half of the FIRST
registration**: a cell holding an unregistered id's nil-recovery — the very thing
the substrate declined to cache, cached anyway in a cell where nothing evicts it —
found by the scan, invalidated, rewired, and notified by writes thereafter. That
is one row plus the control that makes it attributable, and it is what
`first_registration_cljs_test` is.

## What was deleted after its mutation proved it decorative

`cold_probe_cljs_test` briefly carried a row for *a `reg-sub` issued earlier in
this tick is visible to this very read* — the claim `cold-read!`'s docstring
credits `live-frame/call-with-frame-resolution`'s coalesced flush with. Replacing
that wrapper with a bare call (**m9**) red **nothing**: a frame made by
`make-frame` resolves the registrar directly and has no stale projection to flush,
so the row would need an image-loaded frame to mean anything. The claim is real
and the witness was not. It is deleted, and the file's docstring says why — a row
a one-line narrowing cannot turn red is not evidence, however true its subject.

## The narrowing each row catches, and the verbatim red

Every mutation was applied by a line-exact harness that **refuses unless the line
already reads what the mutation expects**, then re-reads the file off disk to
confirm the replacement landed, and prints `git diff --stat` as the applied-check.
Every restore was `git checkout --` and left `git diff --stat` empty.

### 1. The six index laws

| law | the narrowing the row catches | red |
|---|---|---|
| **1** — a commit dirties that boundary *only* | `dirty-readers` unions **every** cell's readers instead of the dirty ones' — a runtime that wakes the whole page | m1 |
| **2** — two boundaries sharing a sub *both* dirty | `dirty-readers` takes each dirty cell's **first** reader only — fan-out collapse | m2 |
| **3** — unmount removes edges | `release-cell!` stops splicing the membership out | m3 |
| **4** — a re-run with fewer reads drops edges | same splice removal: the replacement never drops the edge it stopped holding | m3 |
| **5** — the broad dirty set is the *union* | `dirty-readers` accumulates into a **vector** instead of a set — the double reader is woken twice | m4 |
| **6** — an unknown dirty sub yields the empty set | `dirty-readers` unions every cell's readers, conjuring a phantom for a dirty cell whose readers all left | m1 |

```
m1 (#{} dirty -> #{} (vals @!cells))
FAIL in (law-1-a-commit-dirties-the-readers-of-the-moved-sub-and-no-other-boundary)
  and the boundary that does not read it is not woken at all — `only` is the whole
  law, and a runtime that woke every committed boundary would satisfy the line above
FAIL in (law-6-a-dirty-cell-whose-readers-have-all-left-yields-the-empty-set)
Ran 309 tests containing 1428 assertions.  15 failures, 0 errors.

m2 (into acc (.-readers c) -> conj acc (aget (.-readers c) 0))
FAIL in (law-2-two-boundaries-sharing-a-sub-are-both-dirtied)
  both sharers are woken — the dirty set is the cell's readers, plural, and not
  the reader that got there first
expected: (= 1 (woken second-reader))
  actual: (not (= 1 0))
Ran 309 tests containing 1428 assertions.  2 failures, 0 errors.

m3 ((when (<= 0 i) (.splice readers i 1)) -> (when (<= 0 i) nil))
FAIL in (law-3-an-unmount-removes-the-edge-and-the-next-commit-passes-that-boundary-by)
FAIL in (law-4-a-re-run-with-fewer-reads-drops-the-edge-it-stopped-holding)
Ran 309 tests containing 1429 assertions.  58 failures, 1 errors.

m4 (#{} dirty -> [] dirty)
FAIL in (law-5-the-broad-dirty-set-is-the-union-and-a-double-reader-is-woken-once)
  and it is a UNION rather than a concatenation: the boundary that read BOTH dirty
  subs is woken once, not once per dirty key it happened to read
expected: (= 1 (woken reads-ab))
  actual: (not (= 1 2))
Ran 309 tests containing 1428 assertions.  3 failures, 0 errors.
```

Law 3's row is deliberately **not** red by m1, and law 6's *no-cell* row is
deliberately not red by m3 — each law's row moves for its own narrowing and stands
still for the others', which is what makes the six six.

### 2. The cold probe

| row | the narrowing it catches | red |
|---|---|---|
| a cold read retains nothing | the probe builds and **caches** instead of computing pure — the sub-cache slot survives the abandoned render | m5 |
| one compute per body run | the run's memo is never consulted — three reads, three computes | m6 |
| the memo belongs to the run | the probe box survives `run-once`, so a later render is served an earlier commit's snapshot | m7 |
| an unknown query is refused once per run | a memoised **nil** is treated as a miss (`find` → `get`) — re-emitted and recomputed on every read | m8 |
| rung 1 reuses a warm reaction by deref alone | rung 1 is skipped, so a key some other holder keeps warm is recomputed | m10 |

```
m5  FAIL a-cold-read-answers-correctly-and-retains-nothing
      "and nothing was built for it. No cell … no sub-cache slot…"   7 failures

m6  FAIL a-cold-key-computes-once-per-body-run-however-often-it-is-read
      expected: (= 1 (deref !runs))                                   3 failures

m7  FAIL a-cold-key-computes-once-per-body-run-however-often-it-is-read
      a second body run computes again: the memo is render-scoped
      expected: (= (inc before) (deref !runs))  actual: (not (= 2 1)) 11 failures

m8  FAIL an-unknown-query-recovers-to-nil-and-is-refused-once-per-run
      A memoised nil has to be a HIT                                  2 failures

m10 FAIL a-live-sub-cache-reaction-is-reused-by-deref-alone
      and computes NOTHING … expected: (= 0 (deref !runs))            1 failure
```

m10 reds **exactly one assertion in the whole hicasso lane** — the rung-1 row is
the only thing in the package that can see that branch at all.

### 3. The first-registration axis

Narrowing: `first-registration!`'s guard is flipped from `(nil? was)` to
`(some? was)` — an arm that rides the disposal alone, which is precisely the
pre-repair state.

```
m11 FAIL a-cell-holding-an-unregistered-ids-recovery-is-repaired-by-the-first-registration
  synchronously the held recovery is dropped — the repair's first phase
expected: (nil? (inventory/cell-reaction late-key))
  actual: (not (nil? #object[re-frame.substrate.spine.t_re_frame$substrate$spine16404]))
… and the checkpoint row, the notification row and the later-write row with it.
Ran 309 tests containing 1428 assertions.  6 failures, 0 errors.
```

### 4. The ≤2-hook budget — fails at 3, passes at 2

The boundary is a **count**, so it is proven from both sides.

**Passes at 2**: the unmutated lane is green, and the shell reads as exactly
`["useContext" "useSyncExternalStore"]`.

**Fails at 3**: `m12` inserts `(react/useRef nil)` into `shell` — one line, one
extra hook, nothing else changed.

```
m12 (shell gains (react/useRef nil))
FAIL in (a-boundary-shell-calls-exactly-the-two-hooks-its-ledger-declares)
  two hooks, and WHICH two: the frame-context hook and the subscription/epoch hook
FAIL in (a-boundary-shell-calls-exactly-the-two-hooks-its-ledger-declares)
  the budget, as a number. HD-020(b) is a count, so it is asserted as one
FAIL in (a-nested-boundary-costs-its-own-two-and-shares-nothing)
FAIL in (the-hook-count-does-not-move-with-the-read-count)   × 3 (n = 1, 7, 20)
Ran 309 tests containing 1428 assertions.  9 failures, 0 errors.
```

The instrument's own control is in the suite rather than only in this report: a
plain React component calling `useRef`, `useState`, `useMemo` must read as all
three, by name and in call order. Without it, `exactly two` could be the number of
an instrument that cannot say three.

## Quality gates

| gate | exit | note |
|---|---|---|
| `sh scripts/test-fast-pr.sh` (from the worktree ROOT) | **0** | `PASS fast PR spine`. Classified `docs=false jvm=false node=true` — correct for a CLJS-test-only diff. The node tier ran the repo-wide `:node-test` build (**13048 tests, 65965 assertions, 0 failures**), the JS harness self-tests and the per-namespace isolation sweep |
| hicasso node lane — `compile-node-test.cjs node-test-hicasso` + run | **0** | 309 tests, 1428 assertions, 0 failures |
| `npm run test:hicasso-invariants` | **0** | includes `check_freeze.py` — 1 frozen row still matches, manifest unchanged |
| `python hicasso/scripts/check_freeze.py` | **0** | run again standalone inside the above; the frozen bench tree is untouched |
| `npm run test:browser` | **not run** | no row touches real DOM. All four suites are node-lane; the hook budget is counted through `react-dom/server`, which drives React's real hook dispatcher and runs in the fast-PR spine, where the browser lane does not |
| `npm run test:hicasso-controlled` / `test:hicasso-hmr` | **not run** | browser testbeds for the controlled-input and HMR surfaces; this diff adds no source and touches neither |
| `npm run build:hicasso-release` | **not run** | the diff is test-tree only; `hook_probe` is under `test/` and is not in the release module graph |
| `python scripts/check_fast_pr_gap.py --list` | derived | **96** required checks the spine does not decide, all pre-existing families (browser lanes, prod-elision / bundle-isolation / perf-bundle, adapter classpath probes and smokes, Xray feature matrix, mcp-conformance, tool JVM suites, and the three lint jobs). None is newly reached by this diff. `clj-kondo` is among them and CI pins 2026.04.15, so it is left to CI rather than claimed from an unpinned local binary |

## Fences observed

- No `spec/*`, no `.github/workflows/*`, no `implementation/package.json`, no
  `implementation/shadow-cljs.edn`. The new suites need no build id and no npm
  script: they are `re-frame.hicasso.*-cljs-test`, which `:node-test`'s existing
  `cljs-test$` selector and the focused `:node-test-hicasso` build already match.
- The frozen bench tree is unedited; `check_freeze.py` is exit 0 with its manifest
  unchanged.
- `implementation/hicasso/src/**` is unmodified — every mutation above was applied
  and reverted, and `git diff --stat` on `src` is empty.
- No collision with the live workers: nothing under `test_kit/**`, nothing in the
  public facade, `impl/mount.cljs` or `impl/collector.cljs` (both are *required*
  by the new suites, as the existing ones already do, and neither is edited); no
  clj-kondo export, no `complaints.md`, no workflows, no `tools/xray/**`.
