### PR TITLE
test(hicasso): the production-erasure proof — unique sentinels, reachable controls (rf2-hic-024)

### DIFF
--- a/implementation/hicasso/scripts/check_production_erasure.cjs
+++ b/implementation/hicasso/scripts/check_production_erasure.cjs
@@ -164,18 +164,25 @@ const SENTINELS = [
       '`re-frame.hicasso.tool` that made it reachable from the public door.',
   },
   {
-    surface: 'dev diagnostics — the codec\'s key-warning console text',
-    sentinel: 'A boundary body began lowering while',
+    surface: 'dev diagnostics — the codec\'s console messages',
+    sentinel: '[hicasso]',
     source: 'src/re_frame/hicasso/impl/codec.cljs',
-    premise: 'A boundary body began lowering while',
+    premise: '"[hicasso] ',
     why:
-      'The unbalanced set/clear warning `codec/set-lowering-owner!` prints. ' +
-      'Every reader of the `keywarn` state sits behind `goog.DEBUG`, so ' +
-      'under `:advanced` the object, its tables and every message string ' +
-      'fold away with the branches that reach them.',
+      'The prefix every console message the package prints begins with, and ' +
+      'the FAMILY rather than one member: all four live in impl/codec.cljs — ' +
+      '`boundary-props=`\'s fail-open notice, `set-lowering-owner!`\'s ' +
+      'unbalanced set/clear warning, and `check-seq-keys!` / ' +
+      '`check-member-key!`\'s two key warnings. Every one of them sits behind ' +
+      '`(when ^boolean js/goog.DEBUG …)`, so under `:advanced` the `keywarn` ' +
+      'object, its tables and every message string fold away with the ' +
+      'branches that reach them. A row per message would name the leak more ' +
+      'narrowly and leave three of the four uncovered the day a fifth is ' +
+      'written; the prefix cannot.',
     remedy:
-      'Check the `(when ^boolean js/goog.DEBUG …)` wrappers around `keywarn` ' +
-      'and its readers in impl/codec.cljs.',
+      'Check the `goog.DEBUG` wrappers at those four sites in ' +
+      'impl/codec.cljs — both the call site and the message itself have to ' +
+      'be inside one.',
   },
 ];
 

--- a/implementation/hicasso/scripts/check_production_erasure.cjs
+++ b/implementation/hicasso/scripts/check_production_erasure.cjs
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+/*
+ * THE PRODUCTION-ERASURE PROOF for implementation/hicasso/ (rf2-hic-024).
+ *
+ * Spec SN §3.6 buys Hicasso's dev affordances — coordinates, complaint
+ * detail, the evidence projection, the test kit's route back to a body —
+ * with an erasure: under `:advanced` + `goog.DEBUG=false` none of them
+ * reaches the artefact a consumer ships. This gate is the proof, read off
+ * the one build in the repo that compiles the package the way a consumer
+ * ships it (`:hicasso-release`, entry `re-frame.hicasso.consumer-app`,
+ * PR #7823).
+ *
+ * ## Unique sentinels, never a public-name grep
+ *
+ * Grepping a release bundle for `hicasso` proves nothing: the public names
+ * legitimately survive, which is the whole point of shipping the package.
+ * So every row of the roster below is a string that ONE dev-only surface
+ * emits and nothing else does — a hit names WHICH surface leaked, not
+ * merely that something did.
+ *
+ * A sentinel is only worth scanning for if it is LOAD-BEARING in the
+ * surface it stands for: a marker planted beside the code would be dropped
+ * by Closure whether or not the erasure held, and the gate would pass for
+ * the wrong reason. Every sentinel here is a string the surface cannot
+ * function without — an own-property name written and read by name, a
+ * stable refusal id, a schema version pin, a console message.
+ *
+ * ## Reachable positive controls
+ *
+ * An absence check over a bundle that never compiled the surface is a
+ * green that means nothing, and it is the failure this gate is most
+ * exposed to. So each sentinel is PAIRED with a control that must be
+ * PRESENT — chosen so that the control and the sentinel differ by the
+ * `goog.DEBUG` gate and by nothing else wherever that pairing is
+ * available:
+ *
+ *   - `hicassoBody` (dev-only) against `hicassoBoundary` (ungated) — two
+ *     adjacent own-property slots in `impl/codec.cljs`, both written with
+ *     `unchecked-set` on the same minted head, one behind the gate.
+ *   - `hicasso-refusal-incomplete` (dev-only) against
+ *     `rf.error/hicasso-empty-vector` (ungated) — a refusal minted inside
+ *     `fail!`'s `debug-enabled?` guard against one minted by `fail!` on
+ *     the shipped path. If `fail!` had not compiled at all, both would be
+ *     absent and the second says so.
+ *   - the entry's own view name, which `mint-view!` stamps
+ *     unconditionally, proving the bundle really compiled a declaration.
+ *
+ * ## The live half is a test, not a comment
+ *
+ * A sentinel that has quietly stopped being emitted is absent from every
+ * bundle for a reason that has nothing to do with erasure. That is why
+ * `re-frame.hicasso.erasure-sentinels-cljs-test` exists: it runs in the
+ * ordinary `goog.DEBUG` node lane and asserts each string below is what a
+ * LIVE surface produces. The two halves are the A/B — surface on, string
+ * present; surface off, string gone — and neither is evidence alone.
+ *
+ * The roster premise is also checked here, before the bundle is opened:
+ * every sentinel and every control must still be found in the source file
+ * this file names for it, so a rename fails the gate rather than reporting
+ * a green absence for a string nobody emits any more.
+ *
+ * ## What this gate does NOT cover, and why
+ *
+ * `defview` / `defhost` SOURCE COORDINATES (rf2-hic-007) are not
+ * scannable in THIS bundle, and the reason is worth stating rather than
+ * leaving to be rediscovered. The coordinate the macro bakes is an
+ * absolute file path, so the sentinel would have to be the declaring
+ * file's name — and the only declaration reachable from `:hicasso-release`
+ * lives in `consumer_app.cljs`, whose name core's own `reg-sub` /
+ * `reg-event` coordinates already put in the release bundle: they are
+ * emitted through `re-frame.source-coords/prod-coords-form`, which keeps
+ * `:file` and `:line` in production by design and drops only `:column`.
+ * Measured, not assumed — `consumer_app.cljs` occurs three times in the
+ * current green bundle, at lines 87, 89 and 91, which are the three
+ * `reg-sub` / `reg-event` forms; the `h/defview` at line 99 contributes
+ * nothing. A filename sentinel here would be red on a correct build.
+ *
+ * That surface is covered where the sentinel IS discriminating:
+ * `check_source_coord_elision.cjs` scans the `:browser-test-prod-elision`
+ * bundle (also `:advanced` + `goog.DEBUG=false`) for
+ * `coord_sentinel_source.cljs`, a namespace that carries declarations and
+ * no registrations, and `re-frame.hicasso.error-source-coord-elision-prod-test`
+ * asserts the ledger is empty in that build. Both are rf2-hic-007's and
+ * both run today.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const HERE = path.dirname(path.resolve(__filename));
+const PACKAGE_ROOT = path.dirname(HERE);
+const IMPL_ROOT = path.dirname(PACKAGE_ROOT);
+
+const BUNDLE = path.join(IMPL_ROOT, 'out', 'hicasso-release', 'main.js');
+
+// ---------------------------------------------------------------------------
+// The roster
+//
+// `sentinel` is scanned for in the bundle and must be ABSENT. `source` is
+// where it is emitted from, and `premise` is the text that must still be
+// found there — usually the sentinel itself, spelled the way the source
+// spells it.
+// ---------------------------------------------------------------------------
+
+const SENTINELS = [
+  {
+    surface: 'test kit — the dev-only body-retention door (rf2-hic-020, rf2-kjf5)',
+    sentinel: 'hicassoBody',
+    source: 'src/re_frame/hicasso/impl/codec.cljs',
+    premise: '(def ^:private body-slot "hicassoBody")',
+    why:
+      'The own property `codec/retain-body!` writes and `codec/retained-body` ' +
+      'reads — the L0-L2 kit\'s only route from a minted head back to the ' +
+      'body its author wrote. Written from `mint-view!` inside ' +
+      '`(when ^boolean js/goog.DEBUG …)`.',
+    remedy:
+      'Check that gate at impl/collector.cljs `mint-view!`; a production head ' +
+      'must carry no body.',
+  },
+  {
+    surface: 'test kit — the kit itself (rf2-hic-020)',
+    sentinel: 'rf.error/hicasso-test-',
+    source: 'test_kit/src/re_frame/hicasso/test.cljs',
+    premise: ':rf.error/hicasso-test-',
+    why:
+      'The refusal-id family `re-frame.hicasso.test` mints, and nothing else ' +
+      'does. The kit is a separate source root that no `src/` namespace may ' +
+      'require, so one of its ids in a consumer bundle means the testing ' +
+      'surface itself became reachable from the public door.',
+    remedy:
+      'Find the `:require` of `re-frame.hicasso.test` under ' +
+      'implementation/hicasso/src/ and move it into the test that needs it.',
+  },
+  {
+    surface: 'complaint payload detail — `fail!`\'s completeness guard (rf2-hic-007)',
+    sentinel: 'hicasso-refusal-incomplete',
+    source: 'src/re_frame/hicasso/impl/error.cljc',
+    premise: ':rf.error/hicasso-refusal-incomplete',
+    why:
+      'The meta-refusal `check-complete!` mints when a refusal reaches ' +
+      '`fail!` without the required four. `fail!` calls it inside ' +
+      '`(when interop/debug-enabled? …)` — in production the incomplete ' +
+      'refusal is thrown as-is rather than replaced, so this id and the ' +
+      'sentence around it are dev-only in terms.',
+    remedy:
+      'Check the `(when interop/debug-enabled? (check-complete! data))` line ' +
+      'in impl/error.cljc `fail!`.',
+  },
+  {
+    surface: 'evidence projection — the versioned envelope (rf2-hic-023)',
+    sentinel: 're-frame.hicasso.evidence',
+    source: 'src/re_frame/hicasso/evidence.cljs',
+    premise: ':re-frame.hicasso.evidence/v2',
+    why:
+      'The schema pin every envelope carries, and the namespace half of ' +
+      'every defect keyword the projection raises. `re-frame.hicasso.evidence` ' +
+      'and its consumer `re-frame.hicasso.tool` are dev-only by ' +
+      'REACHABILITY: no namespace under src/ requires them, so a consumer ' +
+      'who never asks for the projection never ships it.',
+    remedy:
+      'Find the `:require` of `re-frame.hicasso.evidence` or ' +
+      '`re-frame.hicasso.tool` that made it reachable from the public door.',
+  },
+  {
+    surface: 'dev diagnostics — the codec\'s key-warning console text',
+    sentinel: 'A boundary body began lowering while',
+    source: 'src/re_frame/hicasso/impl/codec.cljs',
+    premise: 'A boundary body began lowering while',
+    why:
+      'The unbalanced set/clear warning `codec/set-lowering-owner!` prints. ' +
+      'Every reader of the `keywarn` state sits behind `goog.DEBUG`, so ' +
+      'under `:advanced` the object, its tables and every message string ' +
+      'fold away with the branches that reach them.',
+    remedy:
+      'Check the `(when ^boolean js/goog.DEBUG …)` wrappers around `keywarn` ' +
+      'and its readers in impl/codec.cljs.',
+  },
+];
+
+const CONTROLS = [
+  {
+    control: 're-frame.hicasso.consumer-app/app',
+    source: 'test/re_frame/hicasso/consumer_app.cljs',
+    premise: '(h/defview app',
+    proves:
+      'the release entry\'s `h/defview` really compiled — `mint-view!` stamps ' +
+      'this name as the boundary\'s `displayName` and as its `:render` measure ' +
+      'id, unconditionally. Without it the absences below would be the ' +
+      'absences of a bundle that compiled no declaration at all.',
+  },
+  {
+    control: 'hicassoBoundary',
+    source: 'src/re_frame/hicasso/impl/codec.cljs',
+    premise: '(unchecked-set f "hicassoBoundary" true)',
+    proves:
+      'impl/codec.cljs\'s own-property marker machinery compiled. It is the ' +
+      'UNGATED sibling of the `hicassoBody` slot two hundred lines below it: ' +
+      'same file, same `unchecked-set`, same minted head, and the only ' +
+      'difference between them is the `goog.DEBUG` gate. That is what makes ' +
+      '"no hicassoBody" a statement about erasure rather than about ' +
+      'compilation.',
+  },
+  {
+    control: 'rf.error/hicasso-empty-vector',
+    source: 'src/re_frame/hicasso/impl/codec.cljs',
+    premise: ':rf.error/hicasso-empty-vector',
+    proves:
+      '`impl.error/fail!` and a shipped refusal id compiled. The complaint ' +
+      'sentinel above is a refusal minted INSIDE `fail!`\'s dev guard; this ' +
+      'is one minted by `fail!` on the path every build keeps. If `fail!` ' +
+      'had been dropped entirely, both would be absent and this control is ' +
+      'what says so.',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// The scan
+// ---------------------------------------------------------------------------
+
+/** Answer the problems `bundle` has, as a list of strings. */
+function scan(bundle) {
+  const problems = [];
+
+  for (const c of CONTROLS) {
+    if (!bundle.includes(c.control)) {
+      problems.push(
+        `POSITIVE CONTROL ABSENT: ${c.control}\n` +
+        `    It proves ${c.proves}\n` +
+        '    Every absence this gate reports below is therefore ' +
+        'unfalsifiable. Fix this first.'
+      );
+    }
+  }
+
+  for (const s of SENTINELS) {
+    if (bundle.includes(s.sentinel)) {
+      problems.push(
+        `DEV SURFACE LEAKED: ${s.surface}\n` +
+        `    sentinel: ${JSON.stringify(s.sentinel)}\n` +
+        `    ${s.why}\n` +
+        `    ${s.remedy}`
+      );
+    }
+  }
+
+  return problems;
+}
+
+/** Answer the roster's own broken premises, as a list of strings. */
+function checkPremises() {
+  const problems = [];
+  const rows = [
+    ...SENTINELS.map((s) => ({ text: s.premise, source: s.source, of: `sentinel ${JSON.stringify(s.sentinel)}` })),
+    ...CONTROLS.map((c) => ({ text: c.premise, source: c.source, of: `positive control ${JSON.stringify(c.control)}` })),
+  ];
+
+  for (const row of rows) {
+    const file = path.join(PACKAGE_ROOT, row.source);
+    if (!fs.existsSync(file)) {
+      problems.push(
+        `ROSTER PREMISE BROKEN: the source of ${row.of} is gone — ${row.source}\n` +
+        '    A scan for a string nobody emits any more is a green that means nothing.'
+      );
+      continue;
+    }
+    if (!fs.readFileSync(file, 'utf8').includes(row.text)) {
+      problems.push(
+        `ROSTER PREMISE BROKEN: ${row.source} no longer contains ${JSON.stringify(row.text)},\n` +
+        `    which is where ${row.of} comes from. Either the string was renamed — in ` +
+        'which case rename it here too — or the surface was removed, in which case ' +
+        'drop the row.'
+      );
+    }
+  }
+
+  return problems;
+}
+
+// ---------------------------------------------------------------------------
+// The self-test — because a scanner that stopped seeing reports a clean
+// bundle forever, and this one's whole claim is about what it does not find
+// ---------------------------------------------------------------------------
+
+function selfTest() {
+  const green = CONTROLS.map((c) => c.control).join(' … ');
+
+  const clean = scan(green);
+  assert(clean.length === 0, `a bundle with every control and no sentinel is green: ${clean}`);
+
+  // Every sentinel is seen, individually, and names its own surface.
+  for (const s of SENTINELS) {
+    const problems = scan(`${green} … ${s.sentinel} …`);
+    assert(problems.length === 1, `one problem for ${s.sentinel}: ${problems}`);
+    assert(problems[0].includes('DEV SURFACE LEAKED'), problems[0]);
+    assert(problems[0].includes(s.surface), problems[0]);
+    assert(problems[0].includes(s.sentinel), problems[0]);
+  }
+
+  // The scan FAILS CLOSED: a bundle with no controls in it is refused even
+  // though every sentinel is absent from it, which is the shape an empty or
+  // wrong bundle has.
+  const empty = scan('');
+  assert(empty.length === CONTROLS.length, `an empty bundle fails on every control: ${empty}`);
+  for (const p of empty) assert(p.includes('POSITIVE CONTROL ABSENT'), p);
+
+  // Each control is missed on its own, so a control that quietly stopped
+  // being emitted cannot hide behind its siblings.
+  for (const c of CONTROLS) {
+    const others = CONTROLS.filter((o) => o !== c).map((o) => o.control).join(' … ');
+    const problems = scan(others);
+    assert(problems.length === 1, `one problem for a missing ${c.control}: ${problems}`);
+    assert(problems[0].includes(c.control), problems[0]);
+  }
+
+  // The roster's premises hold against the real tree — a renamed sentinel
+  // fails here rather than reporting a green absence.
+  const premises = checkPremises();
+  assert(premises.length === 0, `roster premises hold:\n${premises.join('\n')}`);
+
+  // No sentinel may be a substring of another, or of a control: a hit has
+  // to name one surface.
+  const all = [...SENTINELS.map((s) => s.sentinel), ...CONTROLS.map((c) => c.control)];
+  for (const a of all) {
+    for (const b of all) {
+      if (a !== b) assert(!a.includes(b), `${JSON.stringify(a)} contains ${JSON.stringify(b)}`);
+    }
+  }
+
+  process.stdout.write(
+    `hicasso production erasure: self-test OK ` +
+    `(${SENTINELS.length} sentinels, ${CONTROLS.length} positive controls)\n`
+  );
+  return 0;
+}
+
+function assert(ok, message) {
+  if (!ok) {
+    process.stderr.write(`hicasso production erasure: SELF-TEST FAILED\n  ${message}\n`);
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+function fail(problems) {
+  process.stderr.write('hicasso production erasure: FAIL\n');
+  for (const p of problems) process.stderr.write(`  ${p}\n`);
+  return 1;
+}
+
+function main(argv) {
+  if (argv.includes('--self-test')) return selfTest();
+
+  const premises = checkPremises();
+  if (premises.length > 0) return fail(premises);
+
+  if (!fs.existsSync(BUNDLE)) {
+    return fail([
+      `MISSING RELEASE BUNDLE: ${path.relative(IMPL_ROOT, BUNDLE)}\n` +
+      '    Run `npm run build:hicasso-release`, which compiles it.',
+    ]);
+  }
+
+  const problems = scan(fs.readFileSync(BUNDLE, 'utf8'));
+  if (problems.length > 0) return fail(problems);
+
+  process.stdout.write(
+    `OK: no dev-only Hicasso surface in the :advanced / goog.DEBUG=false bundle ` +
+    `(${SENTINELS.length} sentinels absent, ${CONTROLS.length} positive controls present).\n`
+  );
+  return 0;
+}
+
+process.exit(main(process.argv.slice(2)));

--- a/implementation/hicasso/test/re_frame/hicasso/erasure_sentinels_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/erasure_sentinels_cljs_test.cljs
@@ -53,7 +53,7 @@
    :test-kit-refusal "rf.error/hicasso-test-"
    :complaint-guard  "hicasso-refusal-incomplete"
    :evidence-schema  "re-frame.hicasso.evidence"
-   :key-warning      "A boundary body began lowering while"})
+   :console-prefix   "[hicasso]"})
 
 (def controls
   "The scan's positive controls that this namespace can produce itself."
@@ -106,8 +106,8 @@
         "every envelope carries it, so a projection in a consumer bundle
          cannot hide")))
 
-(deftest the-key-warning-prints-the-sentence-the-scan-names
-  (testing "the codec's unbalanced set/clear warning carries its text"
+(deftest the-console-diagnostics-print-the-prefix-the-scan-names
+  (testing "`[hicasso]` opens the codec's dev console messages"
     (let [said     (atom [])
           original (.-warn js/console)]
       (try
@@ -117,8 +117,10 @@
         (finally
           (set! (.-warn js/console) original)
           (codec/set-lowering-owner! nil)))
-      (is (some #(str/includes? % (:key-warning sentinels)) @said)
-          "the message string the scan requires the bundle not to carry"))))
+      (is (some #(str/starts-with? % (:console-prefix sentinels)) @said)
+          "the prefix the scan requires the bundle not to carry — the
+           unbalanced set/clear warning is the member reached from here,
+           and all four are written with it"))))
 
 ;; ---------------------------------------------------------------------------
 ;; The positive controls

--- a/implementation/hicasso/test/re_frame/hicasso/erasure_sentinels_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/erasure_sentinels_cljs_test.cljs
@@ -1,0 +1,140 @@
+(ns re-frame.hicasso.erasure-sentinels-cljs-test
+  "THE LIVE HALF OF THE PRODUCTION-ERASURE PROOF (rf2-hic-024).
+
+  `implementation/hicasso/scripts/check_production_erasure.cjs` scans the
+  `:advanced` / `goog.DEBUG=false` bundle and requires five strings to be
+  ABSENT. An absence is only evidence about erasure if the string is
+  something a live surface really emits — a sentinel that quietly stopped
+  being produced is absent from every bundle for a reason that has nothing
+  to do with the law being proved, and the scan would report green
+  forever.
+
+  So this namespace is the other half of the A/B, and it runs in the
+  ordinary `goog.DEBUG` node lane: **surface on, string present**. The
+  scan's claim is *surface off, string gone*. Neither is evidence alone,
+  and neither can rot silently while the other holds — rename a refusal
+  id and the assertion below goes red; rename it in the roster and the
+  scan's own premise check goes red.
+
+  The strings are written out here as literals rather than read from the
+  surface that emits them. That is deliberate and it is the whole point:
+  a test that asked the code what it emits and then asserted it emits
+  that would pass through any rename, which is exactly the drift the
+  roster has to notice.
+
+  ## What is asserted, and what is not
+
+  Five sentinels and two of the scan's three positive controls. The third
+  control — the release entry's own view name — is not asserted here
+  because this namespace is not that entry; what it depends on is the
+  MECHANISM, that `mint-view!` stamps `\"<ns>/<sym>\"` unconditionally, and
+  that is asserted on the probe below.
+
+  `defview` / `defhost` SOURCE COORDINATES are not on this roster. The
+  scan's docstring says why in full: their sentinel would be the
+  declaring file's name, and core's own production registration
+  coordinates already put the only such name in the `:hicasso-release`
+  bundle. That surface is witnessed by rf2-hic-007's own two gates —
+  `check_source_coord_elision.cjs` and
+  `re-frame.hicasso.error-source-coord-elision-prod-test` — against the
+  `:browser-test-prod-elision` bundle, where the sentinel discriminates."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as str]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.evidence :as evidence]
+            [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.error :as error]
+            [re-frame.hicasso.test :as ht]))
+
+(def sentinels
+  "The five strings the release-bundle scan requires to be ABSENT, spelled
+  exactly as `check_production_erasure.cjs` spells them."
+  {:body-slot        "hicassoBody"
+   :test-kit-refusal "rf.error/hicasso-test-"
+   :complaint-guard  "hicasso-refusal-incomplete"
+   :evidence-schema  "re-frame.hicasso.evidence"
+   :key-warning      "A boundary body began lowering while"})
+
+(def controls
+  "The scan's positive controls that this namespace can produce itself."
+  {:boundary-marker "hicassoBoundary"
+   :shipped-refusal "rf.error/hicasso-empty-vector"})
+
+(h/defview probe
+  "A declared boundary, minted at namespace load, for its head alone."
+  [_]
+  [:p "the erasure roster's probe"])
+
+(defn- refusal
+  "The ex-data `thunk` refuses with, or nil."
+  [thunk]
+  (try (thunk) nil (catch :default e (ex-data e))))
+
+;; ---------------------------------------------------------------------------
+;; The sentinels
+;; ---------------------------------------------------------------------------
+
+(deftest the-test-kits-body-retention-door-writes-the-slot-the-scan-names
+  (testing "`hicassoBody` is the own property a dev-built head carries"
+    (is (some? (unchecked-get probe (:body-slot sentinels)))
+        "the mint writes the body under this exact property name")
+    (is (= (unchecked-get probe (:body-slot sentinels))
+           (codec/retained-body probe))
+        "and `retained-body` reads that same slot — the kit's only route
+         from a minted head back to the body its author wrote")))
+
+(deftest the-test-kits-refusal-ids-carry-the-family-the-scan-names
+  (testing "`rf.error/hicasso-test-` prefixes the ids the kit mints"
+    (let [id (:rf.error/id (refusal #(ht/tree [42 {}])))]
+      (is (= :rf.error/hicasso-test-not-a-body id))
+      (is (str/includes? (str id) (:test-kit-refusal sentinels))))))
+
+(deftest the-completeness-guard-mints-the-id-the-scan-names
+  (testing "`hicasso-refusal-incomplete` is what `fail!`'s dev guard raises"
+    (let [data (refusal #(error/fail! :rf.error/erasure-probe
+                                      're-frame.hicasso.erasure-sentinels-cljs-test/probe
+                                      "A refusal with no recovery."
+                                      nil
+                                      {}))]
+      (is (= :rf.error/hicasso-refusal-incomplete (:rf.error/id data)))
+      (is (str/includes? (str (:rf.error/id data)) (:complaint-guard sentinels))))))
+
+(deftest the-evidence-schema-pin-is-the-slug-the-scan-names
+  (testing "`re-frame.hicasso.evidence` is the projection's identity slug"
+    (is (= :re-frame.hicasso.evidence/v2 evidence/schema))
+    (is (= (:evidence-schema sentinels) (namespace evidence/schema))
+        "every envelope carries it, so a projection in a consumer bundle
+         cannot hide")))
+
+(deftest the-key-warning-prints-the-sentence-the-scan-names
+  (testing "the codec's unbalanced set/clear warning carries its text"
+    (let [said     (atom [])
+          original (.-warn js/console)]
+      (try
+        (set! (.-warn js/console) (fn [& args] (swap! said conj (str/join " " args))))
+        (codec/set-lowering-owner! "erasure/outer")
+        (codec/set-lowering-owner! "erasure/inner")
+        (finally
+          (set! (.-warn js/console) original)
+          (codec/set-lowering-owner! nil)))
+      (is (some #(str/includes? % (:key-warning sentinels)) @said)
+          "the message string the scan requires the bundle not to carry"))))
+
+;; ---------------------------------------------------------------------------
+;; The positive controls
+;; ---------------------------------------------------------------------------
+
+(deftest the-boundary-marker-is-the-ungated-sibling-of-the-body-slot
+  (testing "`hicassoBoundary` is written on the same head, without a gate"
+    (is (true? (unchecked-get probe (:boundary-marker controls)))))
+  (testing "and the mint stamps the view name unconditionally"
+    (is (= "re-frame.hicasso.erasure-sentinels-cljs-test/probe"
+           (.-displayName probe))
+        "the mechanism the scan's third control — the release entry's own
+         view name — depends on")))
+
+(deftest a-shipped-refusal-id-is-minted-on-the-path-every-build-keeps
+  (testing "`rf.error/hicasso-empty-vector` comes out of `fail!` ungated"
+    (let [data (refusal #(codec/vector-kind []))]
+      (is (= :rf.error/hicasso-empty-vector (:rf.error/id data)))
+      (is (str/includes? (str (:rf.error/id data)) (:shipped-refusal controls))))))


### PR DESCRIPTION
Closes rf2-hic-024.

Spec SN §3.6 buys Hicasso's dev affordances with an erasure: under `:advanced` +
`goog.DEBUG=false` none of them reaches the artefact a consumer ships. Until now
nothing measured that. This proves it the way the corpus demands — **unique
sentinels plus a reachable positive control, never a public-name grep** — against
`out/hicasso-release/main.js`, the package's only Closure-optimised compile
(PR #7823).

Two files, and they are the two halves of one A/B:

- `implementation/hicasso/scripts/check_production_erasure.cjs` — the release-side
  scan. **Surface off, string gone.**
- `implementation/hicasso/test/re_frame/hicasso/erasure_sentinels_cljs_test.cljs` —
  the live half, in the ordinary `goog.DEBUG` node lane. **Surface on, string
  present.**

Neither is evidence alone. A sentinel that has quietly stopped being emitted is
absent from every bundle for a reason that has nothing to do with the law, and the
scan would report green forever; the live half is what stops that. The strings are
written as literals on both sides rather than read back from the code that emits
them, so a rename reds the live test and the scan's own premise check together
instead of passing through both.

## The roster — five sentinels, what each covers

Every sentinel is **load-bearing** in the surface it stands for. A marker planted
beside the code would be dropped by Closure whether or not the erasure held, and
the gate would pass for the wrong reason.

| Sentinel | Dev-only surface | Why it is load-bearing |
|---|---|---|
| `hicassoBody` | test kit's body-retention door (rf2-hic-020 / rf2-kjf5) | the own property `retain-body!` writes and `retained-body` reads — the kit's only route from a minted head back to the authored body |
| `rf.error/hicasso-test-` | the L0–L2 kit itself (rf2-hic-020) | the refusal-id family `re-frame.hicasso.test` mints, and nothing else does |
| `hicasso-refusal-incomplete` | complaint payload detail (rf2-hic-007) | the meta-refusal `check-complete!` mints, inside `fail!`'s `debug-enabled?` guard |
| `re-frame.hicasso.evidence` | versioned evidence projection (rf2-hic-023) | the v2 schema pin every envelope carries, and the ns half of every defect keyword |
| `[hicasso]` | the codec's dev console diagnostics | the prefix all four messages open with — the FAMILY, not one member |

The last row is deliberately the family. The first draft named
`A boundary body began lowering while` and would have left the other three console
messages uncovered, and a fifth uncovered the day it was written.

### Three positive controls, each paired with what it makes falsifiable

| Control (must be PRESENT) | What its absence would mean |
|---|---|
| `re-frame.hicasso.consumer-app/app` | the bundle compiled no declaration at all |
| `hicassoBoundary` | `impl/codec.cljs`'s marker machinery never compiled — this is the **ungated sibling** of `hicassoBody`: same file, same `unchecked-set`, same minted head, differing only by the `goog.DEBUG` gate |
| `rf.error/hicasso-empty-vector` | `impl.error/fail!` was dropped entirely, so an absent `hicasso-refusal-incomplete` would say nothing about erasure |

## Reachability, demonstrated rather than assumed

Each sentinel was made reachable on the release path by a deliberate edit,
`:hicasso-release` rebuilt, and the gate run. **All five turn it red, each named by
name.** Every edit was reverted with `git checkout --` and `git status --porcelain`
verified empty after each.

**S1 — `hicassoBody`.** `impl/collector.cljs` `mint-view!`: dropped the
`(when ^boolean js/goog.DEBUG …)` around `(codec/retain-body! head body-fn)`.

```
hicasso production erasure: FAIL
  DEV SURFACE LEAKED: test kit — the dev-only body-retention door (rf2-hic-020, rf2-kjf5)
    sentinel: "hicassoBody"
```

**S2 — `rf.error/hicasso-test-`.** `impl/mount.cljs`: required
`re-frame.hicasso.test` and called `ht/tree` from `root!`.

```
hicasso production erasure: FAIL
  DEV SURFACE LEAKED: test kit — the dev-only body-retention door (rf2-hic-020, rf2-kjf5)
    sentinel: "hicassoBody"
  DEV SURFACE LEAKED: test kit — the kit itself (rf2-hic-020)
    sentinel: "rf.error/hicasso-test-"
```

Two reds for one break, and correctly: `ht/tree` reads `codec/retained-body`, which
pulls the body slot back into the bundle with it. Bundle probes on that build:
`hicasso-test-` ×16, `hicassoBody` ×1.

**S3 — `hicasso-refusal-incomplete`.** `impl/error.cljc` `fail!`: dropped the
`(when interop/debug-enabled? …)` around `(check-complete! data)`.

```
hicasso production erasure: FAIL
  DEV SURFACE LEAKED: complaint payload detail — `fail!`'s completeness guard (rf2-hic-007)
    sentinel: "hicasso-refusal-incomplete"
```

**S4 — `re-frame.hicasso.evidence`.** `impl/error.cljc`: required the projection and
appended `evidence/schema` to the thrown message.

```
hicasso production erasure: FAIL
  DEV SURFACE LEAKED: evidence projection — the versioned envelope (rf2-hic-023)
    sentinel: "re-frame.hicasso.evidence"
```

**S5 — `[hicasso]`.** Both gates that hold the console text out: the call-site
`goog.DEBUG` in `impl/collector.cljs` `run-once`, and `set-lowering-owner!`'s own in
`impl/codec.cljs`.

```
hicasso production erasure: FAIL
  DEV SURFACE LEAKED: dev diagnostics — the codec's console messages
    sentinel: "[hicasso]"
```

**Two first-pass sabotages were not enough, and that is the finding.** Breaking only
`set-lowering-owner!`'s own gate left the gate GREEN, because the function is called
only from inside another `goog.DEBUG` gate and Closure dropped it whole — string and
all. Requiring the test kit and touching one trivial var of it was green for the same
reason: the kit was in the graph but its refusal ids were not reached. Both had to be
broken at the gate that really holds the surface out. That is exactly the failure the
bead warns about — a sentinel that was never in the bundle to begin with — caught by
running the sabotage rather than reasoning about it.

## Fail-closed, demonstrated four ways

| Provocation | Result |
|---|---|
| bundle truncated to its first 100 KB | red on **all three** positive controls, "every absence this gate reports below is therefore unfalsifiable" |
| bundle absent | red, `MISSING RELEASE BUNDLE` |
| `body-slot` renamed in `impl/codec.cljs` (roster premise) | red, `ROSTER PREMISE BROKEN`, before the bundle is opened |
| `--self-test` | every sentinel seen individually and named; every control missed individually; an empty bundle red on every control; no sentinel a substring of another |

The roster premise arm is why "positive control absent while the roster still looks
healthy" is not reachable by a rename: the premise is checked against the source
file that emits the string, so a rename reds the gate rather than greening it. The
absent-control arm exists for the case a rename cannot cause — a stale, partial or
wrong bundle — and the truncation above is that case.

Non-vacuity of the live half was shown the same way: `"hicassoBody"` →
`"hicassoBodyMUTANT"` in the test's roster, and
`the-test-kits-body-retention-door-writes-the-slot-the-scan-names` failed with
`(not (some? nil))`. Reverted.

## What this does NOT cover, and why

- **`defview` / `defhost` source coordinates (rf2-hic-007) are not scannable in
  THIS bundle.** The coordinate is an absolute file path, so the sentinel would have
  to be the declaring file's name — and the only declaration reachable from
  `:hicasso-release` lives in `consumer_app.cljs`, whose name **core's own
  registration coordinates already put in the release bundle**: they come from
  `re-frame.source-coords/prod-coords-form`, which keeps `:file` and `:line` in
  production by design and drops only `:column`. Measured, not assumed —
  `consumer_app.cljs` occurs three times in the green bundle, at lines 87, 89 and 91,
  which are the three `reg-sub` / `reg-event` forms; the `h/defview` at line 99
  contributes nothing. A filename sentinel here would be **red on a correct build**.
  The surface is covered where the sentinel does discriminate:
  `check_source_coord_elision.cjs` (the `coord_sentinel_source.cljs` sentinel against
  `:browser-test-prod-elision`) and
  `re-frame.hicasso.error-source-coord-elision-prod-test`. Both are rf2-hic-007's and
  both run today. The scan's docstring records this so it is not rediscovered.
- **`re-frame.hicasso.tool` has no sentinel of its own.** It is covered
  transitively — `tool` requires and uses `re-frame.hicasso.evidence`, so any
  reachability of `tool` lights that row — but a hit would name the projection rather
  than the tool.
- **`impl.evidence` (the sink seam) is not on the roster and should not be.** It is
  two lines that ship: a `defonce` atom and a setter. It is not a dev-only surface.
- **`re-frame.hicasso.motion`** is an optional-module reachability question, already
  owned by `check_optional_module_reachability.py`.
- **Nothing here re-witnesses what the `:browser-test-prod-elision` prod tests
  already assert** — the empty coordinate ledger, `retained-body` answering nil on a
  production head. Those are behavioural claims from inside the page; this is the
  complementary one a page cannot make.

## STOPPED ON: the wiring needs a fenced file

The bead asks for the gate to be "wired into the package's test entry so it runs per
PR". Every candidate entry is hot-zone and this worker is fenced out of all of them,
so **the check is not yet wired** and needs one line, sequenced by the mayor:

```
"build:hicasso-release": "shadow-cljs release hicasso-release && node hicasso/scripts/check_production_erasure.cjs --self-test && node hicasso/scripts/check_production_erasure.cjs"
```

in `implementation/package.json`. That spelling is the recommendation rather than a
new job or a new `test:*` script, and for one reason: the check's whole subject is
that build's output, so making it part of the build's definition means the bundle
cannot be produced without being checked — no predicate to keep in step, and it
inherits the `cljs` job's step in `test.yml` (line 2983) exactly as PR #7823 left it.
`test:hicasso-invariants` is the wrong home: that gate is sub-second static reads and
runs in the fast-PR spine, which does not build the bundle.

Until it lands, the gate is run by hand — as `check_freeze.py` was before rf2-8a6s.
The live half needs no wiring: it is picked up by `:node-test-hicasso`'s
`^re-frame\.hicasso\..+-cljs-test$` and ran in the sweep below.

## An observation, not actioned

`out/hicasso-release/main.js` contains the **absolute filesystem path of the machine
that built it** — `C:/Users/…/implementation/hicasso/test/re_frame/hicasso/consumer_app.cljs`
— three times, through core's production registration coordinates. That is core's
deliberate design (a production coordinate keeps `:file` and `:line`), and it is
outside this bead entirely; recorded here because it is what made the source-coordinate
sentinel undecidable in this bundle, and because a release artefact that is not
path-independent may matter to somebody else later.

## Quality gates

| Gate | Exit | Notes |
|---|---|---|
| `npm run build:hicasso-release` | **0** | 161 files, 0 warnings |
| `node hicasso/scripts/check_production_erasure.cjs --self-test` | **0** | 5 sentinels, 3 positive controls |
| `node hicasso/scripts/check_production_erasure.cjs` | **0** | green on the real bundle |
| `npm run test:hicasso-invariants` | **0** | includes `check_freeze.py --self-test` and `check_freeze.py` — manifest untouched |
| `:node-test-hicasso` (compile + run) | **0** | 300 tests / 1342 assertions, 0 failures, 0 errors |
| `sh scripts/test-fast-pr.sh` | **0** | run from the worktree root |
| `python scripts/check_fast_pr_gap.py --list` | **0** | derived — see below |

**The derived gap.** `check_fast_pr_gap.py --list` reports 96 required checks the
spine does not decide, and the one that matters for this PR is named explicitly in
section (A): `test.yml` job *CLJS (shadow-cljs :node-test)*, step **"Hicasso release
build (:advanced, goog.DEBUG false)"**. That is the step this gate belongs to, and
the spine does not run it — which is precisely why the release build, the erasure
scan and its self-test were all run here by hand and are reported above.

Not run, with reasons: `scripts/test-jvm-implementation.sh` and
`scripts/test-jvm-tools.sh` (no JVM artefact touched — `implementation/hicasso` has
no JVM suite by design, see `hicasso/deps.edn`); `mkdocs build --strict` (no
`docs/**` change); the browser lanes (`test:browser-prod-elision`,
`test:hicasso-controlled`, `test:hicasso-hmr`) — no DOM surface changed, and the new
CLJS namespace is a non-DOM `-cljs-test` compiled by `:node-test-hicasso`, which was
run.

## Fences respected

No edit under `spec/`, `.github/workflows/`, `implementation/package.json` or
`implementation/shadow-cljs.edn`. `check_freeze.py` green with its manifest
unchanged. PR #7835's five test files untouched; `implementation/hicasso/test_kit/**`
and `impl/mount.cljs` untouched on this branch (both were sabotaged and restored;
`git status` verified clean after every restore). No `.beads` path staged.
