### PR TITLE
fix(hicasso): make the L3 mounted facade's construction transactional (rf2-hic-027, rf2-cw7p)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_mounted_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_mounted_dom_cljs_test.cljs
@@ -292,7 +292,20 @@
                      ;; Restore: the orphan is this row's, and it does not
                      ;; belong to the next one.
                      (mount/release! orphan)
-                     (done))))))))
+
+                     ;; And FINALISE. `residue` reads; only `assert-clean!`
+                     ;; records the verdict and releases this mount's private
+                     ;; bookkeeping, so a sabotage row that stops at the
+                     ;; reading leaves the facade holding a mount that will
+                     ;; never be read — and holds the reset gate off zero for
+                     ;; every row after it. The tests for a cleanliness
+                     ;; instrument have to be clean themselves (PR #7822's
+                     ;; audit).
+                     (-> (hm/assert-clean! m)
+                         (.then (fn [after]
+                                  (is (true? (:clean? after))
+                                      "the induced fault was repaired before the verdict")
+                                  (done)))))))))))
 
 (deftest l3-assert-clean-sees-a-frame-the-app-left-behind
   (if-not (mount/browser?)
@@ -315,7 +328,13 @@
                                subscription that is not there"
                        (is (= [:frames] (keys (:leaked report)))))
                      (rf/destroy-frame! ::spawned)
-                     (done))))))))
+
+                     ;; And FINALISE — see the row above.
+                     (-> (hm/assert-clean! m)
+                         (.then (fn [after]
+                                  (is (true? (:clean? after))
+                                      "the spawned frame was destroyed before the verdict")
+                                  (done)))))))))))
 
 (deftest l3-assert-clean-sees-a-root-that-was-never-unmounted
   (if-not (mount/browser?)

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_mounted_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_mounted_dom_cljs_test.cljs
@@ -570,7 +570,28 @@
             _           (rf/destroy-frame! bytes-frame)
             _           (collector/reset-runtime!)
             before      (hm/census)
-            children    (body-children)]
+            children    (body-children)
+            ;; THE ROLLBACK'S OWN NOISE, captured rather than suppressed.
+            ;;
+            ;; Taking down a root React has not yet hydrated IS a switch to
+            ;; client rendering, and React says so: it queues a hydration
+            ;; error, which reaches the root's `onRecoverableError` — the one
+            ;; `impl.mount/hydrate-root!` installs, which always delegates to
+            ;; React's default (rf2-mwx08's fail-open) — and so reaches the
+            ;; window uncaught, where the browser runner treats it as fatal.
+            ;;
+            ;; That rule is right and this row does not soften it. The row
+            ;; MANUFACTURES the fault and ASSERTS on the report, so the signal
+            ;; moves into the row instead of being lost, and `preventDefault`
+            ;; marks the event handled for the extent of this one rollback and
+            ;; nowhere else. The bench lane's hydration witnesses spell the
+            ;; same rule as `:swallow-uncaught?`; naming it is provenance, not
+            ;; a dependency — the freeze gate forbids importing that tree.
+            reported    (atom [])
+            on-error    (fn [^js e]
+                          (swap! reported conj (.-message e))
+                          (.preventDefault e))
+            _           (.addEventListener js/window "error" on-error)]
         ;; THE FAULT: a budget already spent when the first poll runs, which is
         ;; the deterministic way into the timeout branch. The alternative — a
         ;; body that throws during adoption — never resolves EITHER, but it
@@ -599,6 +620,7 @@
                              (str frame " is still registered"))))))
             (.then (fn [_] (inventory/quiesced!)))
             (.then (fn [_]
+                     (.removeEventListener js/window "error" on-error)
                      (is (= before (hm/census))
                          (str "the census moved: " (pr-str before) " → "
                               (pr-str (hm/census))))
@@ -606,4 +628,11 @@
                                server bytes is gone, because this one IS the
                                facade's to remove"
                        (is (= children (body-children))))
+                     (testing "and React reported the teardown of a root it had
+                               not yet hydrated, exactly once — the rollback's
+                               own consequence, named here so that a reader
+                               meeting it in their own suite knows what it is"
+                       (is (= 1 (count @reported)) (str "got " (pr-str @reported)))
+                       (is (some? (some #(re-find #"early update" %) @reported))
+                           (str "got " (pr-str @reported))))
                      (done))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_mounted_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_mounted_dom_cljs_test.cljs
@@ -69,6 +69,7 @@
             [re-frame.core :as rf]
             [re-frame.hicasso :as h]
             [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.inventory :as inventory]
             [re-frame.hicasso.impl.mount :as mount]
             [re-frame.hicasso.roots-frames-support :as sup]
             [re-frame.hicasso.test.mounted :as hm]
@@ -91,6 +92,23 @@
                                    (range n))}}))
 (rf/reg-event ::toggle (fn [{:keys [db]} [_ id]]
                          {:db (update-in db [:todos id :done?] not)}))
+
+(defn- plain-child
+  "An ORDINARY function, and that is the whole of it: in child head
+  position the runtime refuses a plain function outright (HD-016,
+  `:rf.error/hicasso-bad-head`) rather than calling it. Deliberately not
+  a `defview`, and deliberately referred to through its var so nothing
+  can decide the question before the render does."
+  [_props]
+  [:span.unreachable "never rendered"])
+
+(h/defview row-with-a-plain-function-child
+  "A VALID registered view whose BODY is malformed — PR #7822's audit
+  witness, kept. The view itself mounts; what the runtime refuses is the
+  child head inside its body, from inside React's own render, which is
+  the reason the refusal used to be lost."
+  [_]
+  [:li.row [plain-child {}]])
 
 (h/defview row
   "One to-do, with a toggle button. Reads exactly ONE subscription, which
@@ -397,3 +415,176 @@
                          (.then (fn [report]
                                   (is (true? (:clean? report)))
                                   (done)))))))))))
+
+;; ---------------------------------------------------------------------------
+;; W6 — construction is TRANSACTIONAL: a refused mount leaves NOTHING behind
+;; ---------------------------------------------------------------------------
+;;
+;; Three rows, one claim: a `mount!` or a `hydrate!` that does not become a
+;; mount puts the page back exactly as it found it and hands the caller the
+;; runtime's own refusal.
+;;
+;; Each row drives a DIFFERENT failure channel, because the three fail in
+;; three places and a repair to one says nothing about the others:
+;;
+;;   | row | fails in | reaches the caller as |
+;;   |---|---|---|
+;;   | W6a | a body's render, which React swallows | a throw |
+;;   | W6b | the codec, on `hydrate-root!`'s own stack | a rejection |
+;;   | W6c | adoption, which never completes | a rejection |
+;;
+;; And every row asserts the RESTORED STATE as well as the refusal, which is
+;; the difference between a row that would have caught PR #7822's audit
+;; finding and one that would not: the fault there was never that nothing
+;; was refused — React reported the error at the window — it was that
+;; `mount!` answered a handle and left a registered frame and an attached
+;; container behind. A row that merely observed a refusal passes against
+;; every one of those leaks.
+
+(defn- body-children [] (.-childElementCount js/document.body))
+
+(deftest l3-mount-propagates-the-runtimes-refusal-and-leaves-nothing-behind
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM")
+    (async done
+      (let [before   (hm/census)
+            children (body-children)
+            outcome  (try (hm/mount! [row-with-a-plain-function-child {}])
+                          (catch :default e e))]
+
+        (testing "the refusal reached the CALLER, carrying the runtime's own id,
+                  recovery and offending value — not a paraphrase minted here,
+                  and not the handle a mount that rendered nothing used to
+                  answer. React 19 does not re-throw a failed render out of
+                  `flushSync`: it hands the error to the root's
+                  `onUncaughtError`, whose default reports it at the window and
+                  returns — which is exactly how a mount could refuse and
+                  succeed at the same time (PR #7822's audit)"
+          (is (instance? ExceptionInfo outcome)
+              (str "mount! answered " (pr-str outcome) " instead of refusing"))
+          (when (instance? ExceptionInfo outcome)
+            (let [data (ex-data outcome)]
+              (is (= :rf.error/hicasso-bad-head (:rf.error/id data)))
+              (is (= :call-it-or-make-it-a-view (:recovery data)))
+              (is (identical? plain-child (:head data))
+                  "the offending head is the one the body wrote"))))
+
+        (-> (inventory/quiesced!)
+            (.then
+              (fn [_]
+                (testing "and the page is as the call found it. The frame this
+                          mount minted is gone, the container it appended is
+                          gone, and every residue counter is back — so a
+                          programmer who catches this refusal has nothing left
+                          to clean up and no handle they would have had to be
+                          given one"
+                  (is (= before (hm/census))
+                      (str "the census moved: " (pr-str before) " → "
+                           (pr-str (hm/census))))
+                  (is (= children (body-children))
+                      "the container the failed mount appended is still attached"))
+
+                (testing "and the facade's own bookkeeping is untouched: the next
+                          mount reports no standing peer and goes clean. A
+                          `!standing` left incremented by the failed call shows
+                          up here and nowhere else"
+                  (let [m (seeded)]
+                    (hm/unmount! m)
+                    (-> (hm/assert-clean! m)
+                        (.then (fn [report]
+                                 (is (zero? (:standing report)))
+                                 (is (true? (:clean? report)))
+                                 (done)))))))))))))
+
+(deftest l3-hydrate-rejects-a-form-the-codec-refuses-and-leaves-nothing-behind
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM")
+    (async done
+      (let [;; The caller's OWN container, carrying the caller's own bytes —
+            ;; the arm where the rollback must NOT tidy up, because the node is
+            ;; not the facade's to delete (rf2-31xm, the same rule `unmount!`
+            ;; follows).
+            container (js/document.createElement "div")
+            _         (set! (.-innerHTML container) "<li class=\"row\">server</li>")
+            _         (.appendChild js/document.body container)
+            before    (hm/census)
+            children  (body-children)]
+        ;; THE FAULT: an empty hiccup vector has no head, and the codec refuses
+        ;; it while `hydrate-root!` is still building its root element — on
+        ;; that call's own stack, before React is handed anything.
+        (-> (hm/hydrate! [] {:container container})
+            (.then (fn [m]
+                     (is false (str "hydrate! resolved with " (pr-str m)
+                                    " for a form the codec refuses")))
+                   (fn [e]
+                     (testing "a promise-returning door refuses by REJECTING.
+                               A synchronous throw would land outside every
+                               `.catch` the caller attached and hang the async
+                               test instead of failing it"
+                       (is (instance? ExceptionInfo e))
+                       (is (= :rf.error/hicasso-empty-vector
+                              (:rf.error/id (ex-data e)))))))
+            (.then (fn [_] (inventory/quiesced!)))
+            (.then (fn [_]
+                     (testing "the frame is destroyed and no counter moved"
+                       (is (= before (hm/census))
+                           (str "the census moved: " (pr-str before) " → "
+                                (pr-str (hm/census)))))
+                     (testing "and the caller's container is EXACTLY where they
+                               left it, with the bytes they put in it. A
+                               rollback that removed it would delete a node the
+                               facade did not create"
+                       (is (true? (.-isConnected container)))
+                       (is (= children (body-children)))
+                       (is (= "<li class=\"row\">server</li>" (.-innerHTML container))))
+                     (.removeChild js/document.body container)
+                     (done))))))))
+
+(deftest l3-hydrate-that-never-adopts-rejects-and-leaves-nothing-behind
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM")
+    (async done
+      (let [bytes-frame ::timeout-server
+            _           (rf/make-frame {:id bytes-frame
+                                        :initial-events [[::seed 3]]})
+            html        (sup/server-html! bytes-frame [row {:id 1}])
+            _           (rf/destroy-frame! bytes-frame)
+            _           (collector/reset-runtime!)
+            before      (hm/census)
+            children    (body-children)]
+        ;; THE FAULT: a budget already spent when the first poll runs, which is
+        ;; the deterministic way into the timeout branch. The alternative — a
+        ;; body that throws during adoption — never resolves EITHER, but it
+        ;; also reports an uncaught error at the window, and that is a
+        ;; different fault with a channel of its own.
+        (-> (hm/hydrate! [row {:id 1}] {:html html :initial-events [[::seed 3]]} -1)
+            (.then (fn [m]
+                     (is false (str "hydrate! resolved with " (pr-str m)
+                                    " on a spent budget")))
+                   (fn [e]
+                     (testing "it rejects rather than resolving with a handle
+                               whose adoption never happened"
+                       (is (instance? ExceptionInfo e))
+                       (is (some? (re-find #"never shut" (ex-message e)))
+                           (str "got " (pr-str (ex-message e)))))
+
+                     (testing "and the frame it minted is DESTROYED. This is
+                               what a rejection-only row cannot see: before the
+                               repair the timeout branch rejected and did
+                               nothing else — the frame stayed registered, the
+                               container stayed attached, the root stayed up
+                               with its adoption window open"
+                       (let [frame (:frame (ex-data e))]
+                         (is (keyword? frame))
+                         (is (not (contains? (set (rf/frame-ids)) frame))
+                             (str frame " is still registered"))))))
+            (.then (fn [_] (inventory/quiesced!)))
+            (.then (fn [_]
+                     (is (= before (hm/census))
+                         (str "the census moved: " (pr-str before) " → "
+                              (pr-str (hm/census))))
+                     (testing "and the container the facade minted for the
+                               server bytes is gone, because this one IS the
+                               facade's to remove"
+                       (is (= children (body-children))))
+                     (done))))))))

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
@@ -35,7 +35,9 @@
   The handle is the runtime's own root handle (`impl.mount`) with this
   namespace's bookkeeping added beside it, so `(:container m)` and
   `(:frame m)` are the real container node and the real frame id rather
-  than accessors over a wrapper.
+  than accessors over a wrapper. Every door in `impl.mount` takes it
+  unchanged, including the one [[mount!]] mints for itself
+  ([[catching-root!]]).
 
   ## `mount!` OWNS its frame, and takes no frame argument
 
@@ -80,7 +82,7 @@
   reads the page. After a door returns, the next line sees the DOM a user
   would have seen. [[hydrate!]] is the one exception and says why.
 
-  ## Refusals: this namespace mints none
+  ## Refusals: this namespace mints none, and PROPAGATES the runtime's
 
   Every other file in the kit refuses loudly, and this one deliberately
   does not, for two reasons that agree.
@@ -91,15 +93,23 @@
   established (§Children, and the runtime-parity suite). A guard here
   would paraphrase a refusal that already exists.
 
+  What this facade owes that refusal is DELIVERY. [[mount!]] re-throws it
+  and [[hydrate!]] rejects with it, each having put the page back first,
+  so a refusal raised inside React's render reaches the caller as data
+  instead of as an uncaught page error beside a handle for a root that
+  rendered nothing. That was PR #7822's audit finding and it is the one
+  thing this section used to overstate: the runtime refused all along;
+  the facade swallowed it.
+
   And a residue finding is not a refusal at all: it is a TEST FAILURE, so
   [[assert-clean!]] reports it through `cljs.test/do-report` rather than
   throwing. That distinction is the useful one — the kit REFUSES misuse of
   the instrument and REPORTS a fact about the code under test — and it is
   also what keeps this file free of new `:rf.error/*` ids.
-  (`:rf.error/hicasso-test-residue-after-quiescence` is RESERVED in the
-  complaint register for a raising variant; promoting a reservation is a
-  deliberate act across `spec/009` and the register, and this bead does
-  not take it.)
+  (`:rf.error/hicasso-test-residue-after-quiescence` was reserved for a
+  raising variant of that report and is now a TOMBSTONE in the complaint
+  register: residue is settled as a reported test failure, so the
+  spelling is retired and will never be raised.)
 
   ## Scope
 
@@ -113,7 +123,8 @@
             [re-frame.hicasso.impl.collector :as collector]
             [re-frame.hicasso.impl.inventory :as inventory]
             [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.roots :as roots]))
+            [re-frame.hicasso.impl.roots :as roots]
+            ["react-dom/client" :as react-dom-client]))
 
 ;; ---------------------------------------------------------------------------
 ;; Bookkeeping
@@ -262,6 +273,11 @@
     [frame-kw ordinal]))
 
 (defn- handle-for
+  "The runtime's root handle, made this facade's — and the moment a
+  construction BECOMES a mount. Nothing before this line counts against
+  the standing or the unread census, which is what lets [[abandon!]]
+  restore the page without touching either: a mount that never was is
+  not a mount that came down."
   [root ordinal baseline]
   (swap! !standing inc)
   (swap! !open inc)
@@ -269,6 +285,87 @@
          baseline-key baseline
          ordinal-key  ordinal
          state-key    (volatile! :mounted)))
+
+;; ---------------------------------------------------------------------------
+;; Construction is TRANSACTIONAL
+;; ---------------------------------------------------------------------------
+;;
+;; A mount allocates three things before it can be a mount — a frame, a
+;; container, a React root — and until PR #7822's merged-PR audit the failure
+;; of the third left the first two standing.
+;;
+;; The audit drove it. A valid registered view whose body holds a plain
+;; function child head is a genuine `:rf.error/hicasso-bad-head`; React 19
+;; does not re-throw a failed render out of `flushSync`, it hands the error
+;; to the root's `onUncaughtError`, whose default reports it globally and
+;; returns. So `mount!` answered a handle for a root that had rendered
+;; nothing, the page carried an uncaught error a browser runner treats as
+;; fatal, and the programmer had neither the refusal's data nor a teardown
+;; that would have found the leftovers.
+;;
+;; `hydrate!` had the same shape twice over: a refusal raised on
+;; `hydrate-root!`'s own stack escaped a promise-returning door
+;; SYNCHRONOUSLY, past every `.catch` a caller could attach, and its timeout
+;; branch rejected without taking the half-adopted root down.
+;;
+;; So both doors now either complete or leave nothing. [[abandon!]] is the
+;; allocation order run backwards, and it is the whole of the machinery:
+;; there is no lifecycle here and nothing tracks a resource. Each door knows
+;; what it allocated because it allocated it three lines earlier.
+
+(defn- catching-root!
+  "`impl.mount/root!`, with THIS root's uncaught render errors handed to
+  `catch!` instead of to React's default. Answers the handle either way,
+  because a root whose first render failed still has to be taken down.
+
+  Minted here rather than taken from `impl.mount` because the divergence
+  is the INSTRUMENT's and not the runtime's. A shipped root wants React's
+  default — the error reported at the window, where a host's own reporter
+  and the browser console can see it — and a test facade wants it
+  returned, so that [[mount!]] can put the page back and re-throw the
+  runtime's own refusal on the caller's stack. Installing any
+  `onUncaughtError` takes React's default off, which is both halves of
+  that: the refusal is captured, and the page never carries the uncaught
+  error.
+
+  Two channels reach `catch!` and both are real. A body that throws is
+  caught by React and arrives through the root option. A root FORM the
+  codec refuses — `[]`, a head it will not classify — throws on this
+  call's own stack, before React is handed an element, so the `try` is
+  the other half. Joining them here is what lets a caller read one
+  volatile."
+  [container frame-kw hiccup catch!]
+  (let [handle {:root      (react-dom-client/createRoot
+                             container
+                             #js {:onUncaughtError (fn [error _info] (catch! error))})
+                :frame     frame-kw
+                :container container}]
+    (try (mount/render! handle hiccup)
+         (catch :default e (catch! e)))
+    handle))
+
+(defn- abandon!
+  "Put the page back as the call found it, after a construction that never
+  became a mount. Answers nil.
+
+  The allocation order, backwards: the root comes down — which also shuts
+  an adoption window whose closer will now never run — a container this
+  facade appended is removed, and the frame is destroyed and forgotten.
+
+  A container the CALLER supplied is left exactly where it was, with
+  whatever it held. That is [[unmount!]]'s rule and it is the same rule
+  for the same reason: a teardown may not delete a node it did not
+  create (rf2-31xm).
+
+  Neither counter is here, and that is deliberate rather than an omission
+  — see [[handle-for]]."
+  [frame-kw node supplied? root]
+  (when (some? root) (mount/unmount! root))
+  (when-not supplied?
+    (when-some [p (.-parentNode node)] (.removeChild p node)))
+  (swap! !facade-frames disj frame-kw)
+  (rf/destroy-frame! frame-kw)
+  nil)
 
 (defn mount!
   "Mount `form` on a fresh React root under a frame of this mount's own,
@@ -304,13 +401,36 @@
   it.
 
   The frame is this facade's — minted, made and destroyed here. See the
-  namespace docstring on why there is no `:frame` option."
+  namespace docstring on why there is no `:frame` option.
+
+  ## It either mounts or it THROWS, and a throw leaves nothing behind
+
+  A form the runtime refuses is refused here too, with the runtime's own
+  `ex-info` re-thrown unchanged — same id, same reason, same recovery,
+  same offending value — and the page put back exactly as this call found
+  it: no frame registered, no container appended, no counter moved. So
+  `(try (hm/mount! form) (catch :default e (ex-data e)))` is the whole of
+  a refusal witness, and there is no handle to be given because there is
+  nothing left to tear down.
+
+  React 19 is why this needs saying: a body that throws does not re-throw
+  out of `flushSync`, so before PR #7822's audit this door answered a
+  handle for a root that had rendered nothing and reported the error at
+  the window instead. See [[catching-root!]]."
   ([form] (mount! form {}))
   ([form {:keys [initial-events container]}]
    (let [[frame-kw ordinal] (mint-frame! initial-events)
          baseline           (census)
-         node               (or container (mount/fresh-container!))]
-     (handle-for (mount/root! node frame-kw form) ordinal baseline))))
+         node               (or container (mount/fresh-container!))
+         !refusal           (volatile! nil)
+         root               (catching-root! node frame-kw form
+                                            (fn [error]
+                                              (when (nil? @!refusal)
+                                                (vreset! !refusal error))))]
+     (if-some [refusal @!refusal]
+       (do (abandon! frame-kw node (some? container) root)
+           (throw refusal))
+       (handle-for root ordinal baseline)))))
 
 (defn hydrate!
   "Mount `form` by ADOPTING server-rendered bytes already in the
@@ -345,36 +465,59 @@
   `budget-ms` (default 3000) bounds the wait. Exceeding it REJECTS rather
   than resolving with a handle whose adoption never happened — a hydration
   that silently timed out and then asserted green is the exact failure
-  this door exists to prevent."
+  this door exists to prevent.
+
+  ## Every failure is a REJECTION, and every failure leaves nothing behind
+
+  Both of them: a form the codec refuses while `hydrate-root!` is still
+  building its element, which raises on this call's own stack, and an
+  adoption that never completes. A promise-returning door that threw
+  synchronously would throw past every `.catch` a caller had attached and
+  hang the test rather than fail it, so the refusal is handed to the
+  promise — the runtime's own `ex-info` unchanged for the first, this
+  door's timeout for the second.
+
+  In both cases the page is put back as the call found it: the frame
+  destroyed, the root taken down with its adoption window shut, and a
+  container this facade minted removed. One the CALLER supplied is left
+  where it is (see [[abandon!]])."
   ([form] (hydrate! form {}))
   ([form opts] (hydrate! form opts 3000))
   ([form {:keys [initial-events container html]} budget-ms]
    (let [[frame-kw ordinal] (mint-frame! initial-events)
-         baseline (census)
-         node     (or container (mount/fresh-container!))
-         _        (when (some? html) (set! (.-innerHTML node) html))
-         handle   (handle-for (mount/hydrate-root! node frame-kw form)
-                              ordinal baseline)
-         window   (:adoption handle)
-         deadline (+ (js/Date.now) budget-ms)]
-     (js/Promise.
-       (fn [resolve reject]
-         (letfn [(tick []
-                   (cond
-                     (not (roots/adopting? window))
-                     ;; Past the closer AND past the reap horizon, so the
-                     ;; handle a caller receives is one whose tables have
-                     ;; settled.
-                     (js/setTimeout (fn [] (resolve handle)) 16)
+         baseline  (census)
+         node      (or container (mount/fresh-container!))
+         supplied? (some? container)
+         _         (when (some? html) (set! (.-innerHTML node) html))
+         !refusal  (volatile! nil)
+         root      (try (mount/hydrate-root! node frame-kw form)
+                        (catch :default e (vreset! !refusal e) nil))]
+     (if-some [refusal @!refusal]
+       (do (abandon! frame-kw node supplied? nil)
+           (js/Promise.reject refusal))
+       (let [window   (:adoption root)
+             deadline (+ (js/Date.now) budget-ms)]
+         (js/Promise.
+           (fn [resolve reject]
+             (letfn [(tick []
+                       (cond
+                         (not (roots/adopting? window))
+                         ;; Past the closer AND past the reap horizon, so the
+                         ;; handle a caller receives is one whose tables have
+                         ;; settled. This is also where the construction
+                         ;; becomes a MOUNT — see [[handle-for]].
+                         (js/setTimeout
+                           (fn [] (resolve (handle-for root ordinal baseline))) 16)
 
-                     (< deadline (js/Date.now))
-                     (reject (ex-info (str "hydrate! waited " budget-ms
-                                           "ms and this root's adoption window "
-                                           "never shut — the tree was not adopted.")
-                                      {:frame frame-kw :budget-ms budget-ms}))
+                         (< deadline (js/Date.now))
+                         (do (abandon! frame-kw node supplied? root)
+                             (reject (ex-info (str "hydrate! waited " budget-ms
+                                                   "ms and this root's adoption window "
+                                                   "never shut — the tree was not adopted.")
+                                              {:frame frame-kw :budget-ms budget-ms})))
 
-                     :else (js/setTimeout tick 4)))]
-           (tick)))))))
+                         :else (js/setTimeout tick 4)))]
+               (tick)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Driving

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
@@ -358,7 +358,17 @@
   create (rf2-31xm).
 
   Neither counter is here, and that is deliberate rather than an omission
-  — see [[handle-for]]."
+  — see [[handle-for]].
+
+  **Taking down a root that never adopted makes React complain, and it is
+  right to.** An update to a root mid-hydration IS a switch to client
+  rendering, so React queues a hydration error, which reaches the
+  reporter `impl.mount/hydrate-root!` installs and — that reporter always
+  delegating to React's default (rf2-mwx08) — the window. Leaving the
+  root standing instead would be worse: the hydration is still scheduled,
+  and it would commit into a detached container after this call returned.
+  So the rollback takes it down and the complaint is the honest residue
+  of a hydration that failed."
   [frame-kw node supplied? root]
   (when (some? root) (mount/unmount! root))
   (when-not supplied?


### PR DESCRIPTION
Reopened by the merged-PR audit of #7822. The L3 mounted facade allocates a
frame, a container and a React root before it can be a mount, and the failure of
the third left the first two standing.

The audit drove one case. This PR drives three, repairs them at one seam, and
finalises the two facade tests that were reading the instrument without ever
recording a verdict.

## The defect, as driven

A valid registered Hicasso view whose body holds a **plain function child head**
is a genuine `:rf.error/hicasso-bad-head`. React 19 does not re-throw a failed
render out of `flushSync` — it hands the error to the root's `onUncaughtError`,
whose default reports it globally and returns. So `hm/mount!` **answered a
handle** for a root that had rendered nothing. Verbatim, from the run taken
before the repair:

```
FAIL in (l3-mount-propagates-the-runtimes-refusal-and-leaves-nothing-behind)
mount! answered {:root #object[ReactDOMRoot [object Object]],
                 :frame :re-frame.hicasso.test.mounted/mount-9, ...} instead of refusing
expected: (instance? ExceptionInfo outcome)
  actual: cljs.core/PersistentArrayMap

the census moved: {... :frames #{:rf/default}}
                → {... :frames #{:rf/default :re-frame.hicasso.test.mounted/mount-9}}

the container the failed mount appended is still attached
expected: (= children (body-children))
  actual: (not (= 20 21))

expected: (zero? (:standing report))
  actual: (not (zero? 1))

[browser:pageerror] cljs$core$ExceptionInfo
```

One extra registered frame, one attached container, one leaked standing count,
and an uncaught page error — the runner treats that last one as fatal on its own
(rf2-mwx08). The close record's claim that malformed form is surfaced by the
runtime was broader than what the code did: the runtime refused all along; the
facade swallowed it.

**The same run also drove the first `hydrate!` case, by hanging.** A form the
codec refuses raises on `hydrate-root!`'s own stack, and `hydrate!` returns a
promise — so the throw escaped past every `.catch` a caller could attach and the
whole suite stopped: `Timed out after 360000ms waiting for cljs.test summary.`
That is why the pre-repair run never reached the third row.

## The repair — one seam, in the test kit

`implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs` only.

- **`catching-root!`** reproduces `impl.mount/root!`'s two lines with the root's
  own `onUncaughtError` installed. That is both halves at once: the runtime's
  `ex-info` is captured, and React's global report is off, so the page never
  carries the uncaught error. A refusal raised on the call's own stack — a root
  form the codec rejects before React sees an element — joins it through the
  same volatile.
- **`abandon!`** is the allocation order run backwards: the root down (shutting
  an adoption window whose closer will never run), a container this facade
  appended removed, the frame destroyed and forgotten. A container the CALLER
  supplied is left where it is — `unmount!`'s rule, rf2-31xm.
- **Neither census counter is in the rollback**, because `handle-for` is what
  makes a construction a *mount* and a failed construction never reaches it.
  `hydrate!` therefore counts at resolution rather than at `hydrateRoot`: a
  hydration that never adopted was never standing.
- `mount!` throws the runtime's `ex-info` unchanged; `hydrate!` **rejects** with
  it. Each currency is the door's own.

**`impl/mount.cljs` is untouched.** The seam did not require it: `root!` is two
lines, and the divergence — a root that returns its errors instead of reporting
them — belongs to the instrument, not to the shipped door. Putting it in
`impl.mount` would have meant a test-only var in a namespace that ships.

No new error id, no lifecycle, no resource tracker. Each door knows what it
allocated because it allocated it three lines earlier.

## The three rows, and what each catches

| row | fails in | reaches the caller as |
|---|---|---|
| W6a | a body's render, which React swallows | a throw |
| W6b | the codec, on `hydrate-root!`'s own stack | a rejection |
| W6c | adoption, which never completes | a rejection |

Every row asserts the **restored state** as well as the refusal, and that is the
difference between a row that would have caught the audit's finding and one that
would not. The fault was never that nothing was refused.

**Mutation proof for W6c, which the audit specifically warned about.** With only
`(abandon! …)` removed from the timeout branch — the rejection left exactly as it
was — the row's rejection assertions still pass and it reds on the state:

```
FAIL in (l3-hydrate-that-never-adopts-rejects-and-leaves-nothing-behind)
:re-frame.hicasso.test.mounted/mount-12 is still registered
expected: (not (contains? (set (rf/frame-ids)) frame))

the census moved: {... :entries 0, :frames #{:rf/default}}
                → {... :entries 1, :frames #{:rf/default :re-frame.hicasso.test.mounted/mount-12}}

expected: (= children (body-children))
  actual: (not (= 21 22))

got []
expected: (= 1 (count @reported))
  actual: (not (= 1 0))
```

A rejection-only row passes against every one of those.

W6a's and W6b's mutation is the whole seam removed, which is the pre-repair run
quoted above.

## The rollback's own noise, named rather than suppressed

Taking down a root React has not yet hydrated **is** a switch to client
rendering, so React queues a hydration error, which reaches the reporter
`impl.mount/hydrate-root!` installs and — that reporter always delegating to
React's default (rf2-mwx08's fail-open) — the window. Leaving the root standing
would be worse: its hydration is still scheduled and would commit into a detached
container after the promise rejected.

So the rollback takes it down, and W6c **manufactures the fault and asserts on
the report** rather than hiding it; `preventDefault` covers the extent of that one
rollback and nothing else. That is the bench lane's `:swallow-uncaught?` rule,
spelled locally (the freeze gate forbids importing that tree). `abandon!`'s
docstring says the same thing where a future reader of the rollback will meet it.

## The facade's own tests now exercise its bookkeeping

The two residue sabotage rows called `hm/residue`, repaired their induced fault,
and stopped. Only `assert-clean!` records the verdict and releases the mount's
private bookkeeping, so those rows left process-global facade state behind and
held the unread-mount reset gate off zero for every row after them. Each now
finalises and asserts the repaired mount goes clean.

`assert-clean!`'s design is unchanged and deliberately so: it **reports** through
`cljs.test/do-report` rather than throwing, because a residue finding is a test
failure and not a refusal of the instrument. Nothing in the rollback turns that
into a throw.

## Also carried: rf2-cw7p

Reopened by the audit of #7827, and in a file this PR already holds. The
namespace docstring still called `:rf.error/hicasso-test-residue-after-quiescence`
a live reservation; #7827 retired it to a tombstone. The parenthetical now says
the spelling is retired and will never be raised. No emitter, no Spec 009 row, no
checker rule — and none is possible to add, since `check_complaint_catalogue.py`
masks docstrings by design.

While there, two more sentences were brought back into line with the code, which
is the same species of drift: the "Refusals" section's claim that malformed form
"is already refused by the runtime" now names what the facade owes that refusal
(delivery), and the handle paragraph names the root `mount!` mints for itself.

## Quality gates

| gate | exit |
|---|---|
| `npm run test:browser` (post-rebase) | 0 |
| `sh scripts/test-fast-pr.sh` | 0 |

`test:browser` is the lane that matters here: every row is a real-DOM behaviour
and the node lane sees none of it. Post-repair: **1182 tests, 7378 assertions, 0
failures, 0 errors, 0 pageerrors.**

The spine ran the hicasso gates the brief named — `npm run test:hicasso-invariants`
(complaint catalogue, freeze, optional-module reachability, each with its
self-test), `npm run test:hicasso-lint`, `npm run test:hicasso-compile` — plus the
node tier (`test:cljs`, the per-namespace isolation gate) and the repo-wide static
checks. The spine's own PASS line enumerates its skips.

Gap derived with `python scripts/check_fast_pr_gap.py --list`. Not run, and why:

- **`test:browser-prod-elision`, `test:browser-schemas-boundary-prod`,
  `build:hicasso-release`** — `:advanced` builds over the package's `:paths`.
  `test_kit/src` is deliberately outside `:paths` and the test tree is not in any
  release build, so no line of this diff reaches them.
- **bundle-isolation, perf-bundle, schemas-bundle, elision probes** — same
  reason: nothing here ships.
- **adapter smokes, Xray feature gate, story lanes, tenant-switcher, hicasso
  controlled/HMR testbeds, mcp-conformance, tool JVM suites** — no adapter, tool,
  story, testbed or MCP surface is touched.
- **JVM tiers beyond the spine's selection** — no `.clj`/`.cljc` in the diff.
- **docs tier** — no Markdown in the diff.
- **clj-kondo / splint / eslint** — CI pins clj-kondo 2026.04.15; a differently
  versioned local binary proves nothing, so this is read in CI.

## Fences honoured

`spec/*`, `.github/workflows/*`, `implementation/package.json` and
`implementation/shadow-cljs.edn` are untouched. No new `:rf.error/*` id was
needed — the repair propagates the runtime's own. `implementation/hicasso/test/**`
is touched only in `test_kit_mounted_dom_cljs_test.cljs`, which PR #7835 does not
carry (it adds four new files).
