### PR TITLE
test(hicasso): port eleven prototype witnesses onto the package (rf2-a15c, rf2-npch, rf2-6rw9)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/boundary_intent_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/boundary_intent_dom_cljs_test.cljs
@@ -1,0 +1,453 @@
+(ns re-frame.hicasso.boundary-intent-dom-cljs-test
+  "AN INTENT ON A BOUNDARY'S FALLBACK, AND ON ITS CHILDREN (rf2-uo9di).
+
+  The sibling of [[re-frame.hicasso.presence-intent-dom-cljs-test]], and the identical
+  mechanism one component along. A `h/boundary`'s `:fallback` and its
+  `:children` are hiccup **data**, written in the parent boundary's body
+  — and both are **lowered inside the class component's own React
+  render**, after that body's dynamic extent has unwound. With no ambient
+  frame re-bound there, `intent/*dispatch*` was nil at the moment the
+  codec walked those props, so
+
+      [boundary {:fallback [:button {:on-click [:app/retry]} \"try again\"]
+                 :reset-key attempt}
+       [risky {}]]
+
+  raised `:rf.error/hicasso-intent-outside-boundary` while the boundary
+  rendered its fallback — and an `h/fn` at an event position raised the
+  same id at invocation.
+
+  ## Why the fallback half is the sharp one
+
+  HD-020(c) ships `:fallback` **beside** `:reset-key`, and the reason it
+  gives is that \"the retry is the CALLER's to schedule\". The control that
+  schedules it is a button, the button lives in the fallback, and its
+  `:on-click` is an intent — so the ruling's own worked example was the
+  one thing the component could not render. Worse than unwritable: a
+  fallback that throws while rendering does not fail quietly in a corner,
+  it takes the *next* boundary up, so an application's error path became
+  an application-wide failure.
+
+  Seven claims:
+
+  1. a **retry button on the fallback** dispatches, and the `:reset-key`
+     it moves actually re-mounts the child — HD-020(c)'s whole story,
+     end to end;
+  2. an **`h/fn` at an event position on a function fallback** dispatches
+     what it returns, closing over the error the fallback was handed;
+  3. a **bare intent vector on a native child** of `h/boundary`
+     dispatches;
+  4. an **`h/fn` on a native child** does;
+  5. the intent lands in the frame the **boundary** was mounted under,
+     proved against a second live frame rather than against an absence;
+  6. a boundary with no frame above it is still legal until something
+     below it writes an intent, and that intent is still the loud error,
+     **named**;
+  7. the class still spends **no hook** — in its error state as well as
+     its healthy one, so the repair did not buy the fence what
+     `impl.presence-react` had to buy it.
+
+  ## Why the shapes are on SEPARATE subjects
+
+  The two intent shapes fail at different **moments**. A bare vector is
+  refused at LOWERING, during the boundary's own render, so a subject
+  carrying one never reaches the screen at all; an `h/fn` is lowered
+  happily with no frame (the dispatch is captured, not required), renders,
+  and raises at INVOCATION. Mixed onto one subject the first would mask
+  the second, and every red on the callback path could be blamed on its
+  louder sibling. So rows 2 and 4 carry the callback form and nothing
+  else.
+
+  ## Why most rows mount under a watching boundary
+
+  A throw while the boundary lowers its own fallback or children escapes
+  the class and lands on the **next** boundary above it, and React does
+  not print the `ex-info` it swallowed. [[watched-root!]] puts an
+  ordinary `h/boundary` there for no reason except to catch that and hand
+  it to the assertion message, so a mutation names
+  `:rf.error/hicasso-intent-outside-boundary` in the test output rather
+  than in a browser console somebody has to go and read. Its own fallback
+  is deliberately intent-free — it is the instrument, and an instrument
+  that can fail the way the subject fails measures nothing.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every DOM claim degrades to a stated
+  skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.context :as adapter-context]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.hicasso.impl.boundary :refer [boundary]]
+            [re-frame.hicasso.hook-probe :as probe]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private frame-id ::boundary-intent)
+(def ^:private other-frame-id ::boundary-intent-other)
+
+;; Registered ABOVE `use-fixtures`, deliberately — the reset fixture captures
+;; its source-store baseline when the `use-fixtures` form is EVALUATED and
+;; restores it before every test, so a `reg-sub` written below it is erased
+;; before the first row runs.
+
+(rf/reg-sub :hicasso.bdy/boom? (fn [db _] (:boom? db)))
+(rf/reg-sub :hicasso.bdy/attempt (fn [db _] (:attempt db)))
+
+(rf/reg-event :hicasso.bdy/seed (fn [_ _] {:db {:boom? true :attempt 0}}))
+
+(rf/reg-event :hicasso.bdy/retry
+              (fn [{:keys [db]} _]
+                {:db (-> db (assoc :boom? false) (update :attempt inc))}))
+
+(rf/reg-event :hicasso.bdy/dismissed
+              (fn [{:keys [db]} [_ id]]
+                {:db (update db :dismissed (fnil conj []) id)}))
+
+(rf/reg-event :hicasso.bdy/noted
+              (fn [{:keys [db]} [_ tag]]
+                {:db (update db :noted (fnil conj []) tag)}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     ;; `:ambient-frame nil` is load-bearing. The fixture's default leaves a
+     ;; dynamic-var frame stamp in scope, and a boundary that resolved its
+     ;; frame through that tier instead of through React context would look
+     ;; correct here for the wrong reason. With no ambient stamp, the only
+     ;; thing that can name a frame is the provider above the tree.
+     :ambient-frame nil
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+(defn- skip! [why]
+  (is true (str "an intent-on-a-boundary claim needs a real React DOM — " why)))
+
+(defn- fresh! [frame-kw]
+  (support/leave-act-environment!)
+  (rf/make-frame {:id frame-kw})
+  (rf/with-frame frame-kw (rf/dispatch-sync [:hicasso.bdy/seed]))
+  frame-kw)
+
+(defn- db [frame-kw] (rf/app-db-value frame-kw))
+
+(defn- query [handle sel] (.querySelector (:container handle) sel))
+
+(defn- click! [node]
+  (.click node)
+  ;; TWICE, and not for luck. The click's own dispatch commits on the first
+  ;; settle; a `:reset-key` that moved is then read by `componentDidUpdate`,
+  ;; which clears the caught error with a `setState` of its own — a second
+  ;; commit, from a lifecycle rather than from the event. Row 1 reads the DOM
+  ;; after both.
+  (mount/settle!)
+  (mount/settle!))
+
+;; ---------------------------------------------------------------------------
+;; The instrument — a boundary that records what escaped the subject
+;; ---------------------------------------------------------------------------
+
+(def ^:private !caught (atom nil))
+
+(defn- watched-root!
+  "Mount `hiccup` under an ordinary `h/boundary` whose only job is to
+  catch what the subject threw and hand it to the assertion message. Its
+  fallback and its `:on-error` are intent-free: an instrument that fails
+  the way the subject fails measures nothing."
+  [frame-kw hiccup]
+  (reset! !caught nil)
+  (mount/root! (mount/fresh-container!) frame-kw
+               [boundary {:fallback [:p.escaped "the subject refused to render"]
+                          :on-error (fn [e] (reset! !caught e))}
+                hiccup]))
+
+(defn- escaped
+  "What the watching boundary caught, as the two fields a reader wants."
+  []
+  (select-keys (ex-data @!caught) [:rf.error/id :intent :position]))
+
+;; ---------------------------------------------------------------------------
+;; The screens
+;; ---------------------------------------------------------------------------
+
+(h/defview risky
+  "Throws from the render phase while the model says so — which is where a
+  React error boundary is the only thing that can catch."
+  [_]
+  (when (collector/sub [:hicasso.bdy/boom?])
+    (throw (ex-info "the child threw" {:planted true})))
+  [:p.ok "recovered"])
+
+(h/defview retry-screen
+  "HD-020(c)'s ADVERTISED CASE, and the reason this bead is P2: a fallback
+  whose whole point is a retry control, beside the `:reset-key` that makes
+  the retry the caller's to schedule rather than the boundary's to guess."
+  [_]
+  [boundary {:fallback  [:div.fb
+                         [:p "that did not work"]
+                         [:button.retry {:on-click [:hicasso.bdy/retry]} "try again"]]
+             :reset-key (collector/sub [:hicasso.bdy/attempt])}
+   [risky {}]])
+
+(h/defview note-fallback-screen
+  "The FUNCTION fallback, carrying **only** the one callback form. Two
+  things at once: `h/fn` is the second row of the position table, and the
+  closure reads the error the fallback was handed — so this is also the
+  `(fn [error] hiccup)` contract exercised at an event position rather
+  than at a text node."
+  [_]
+  [boundary {:fallback (fn [error]
+                         [:div.fb
+                          [:button.note
+                           {:data-role "note"
+                            :on-click  (h/hfn [e]
+                                         ;; A live event read, and ONE
+                                         ;; intent returned — the event
+                                         ;; contract the position imposes.
+                                         (when (= "note" (.. e -target -dataset -role))
+                                           [:hicasso.bdy/noted (ex-message error)]))}
+                           "note"]])}
+   [risky {}]])
+
+(h/defview child-intent-screen
+  "The CHILDREN half. Nothing throws here: these are ordinary native
+  children of `h/boundary`, written in this body and lowered one render
+  later inside the class's."
+  [_]
+  [boundary {:fallback [:p.fb "unused — nothing throws on this screen"]}
+   [:div.body
+    [:button.dismiss {:on-click [:hicasso.bdy/dismissed 1]} "dismiss"]]])
+
+(h/defview child-callback-screen
+  "The children half, carrying **only** the callback form — the same
+  separation rows 1 and 2 keep, for the same reason."
+  [_]
+  [boundary {:fallback [:p.fb "unused — nothing throws on this screen"]}
+   [:button.note
+    {:data-role "note"
+     :on-click  (h/hfn [e]
+                  (when (= "note" (.. e -target -dataset -role))
+                    [:hicasso.bdy/noted "child"]))}
+    "note"]])
+
+;; ---------------------------------------------------------------------------
+;; 1 — the retry button HD-020(c) is sold on
+;; ---------------------------------------------------------------------------
+
+(deftest a-fallbacks-retry-button-dispatches-and-the-reset-key-retries
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id)
+      (let [handle (watched-root! frame-id [retry-screen {}])]
+        (try
+          (is (nil? @!caught)
+              (str "the boundary lowered its fallback with no ambient frame, so "
+                   "the retry intent raised while it rendered and the failure "
+                   "escaped to the boundary ABOVE — an application's error path "
+                   "becoming an application-wide one. Escaped: " (pr-str (escaped))))
+          (is (some? (query handle ".retry"))
+              "the fallback, and the retry control on it, are on screen")
+          (is (nil? (query handle ".ok"))
+              "and the child that threw rendered nothing")
+          (testing "the click reaches the frame, and the reset-key it moved
+                    re-mounts the child — the whole of what `:fallback` beside
+                    `:reset-key` was sold on"
+            (click! (query handle ".retry"))
+            (is (= 1 (:attempt (db frame-id)))
+                "the intent on the fallback dispatched")
+            (is (some? (query handle ".ok"))
+                "and the retry succeeded: a changed :reset-key cleared the caught
+                 failure and the child rendered")
+            (is (nil? (query handle ".fb"))
+                "with the fallback gone"))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the one callback form on a function fallback
+;; ---------------------------------------------------------------------------
+
+(deftest a-callback-on-the-fallback-dispatches-what-it-returned
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id)
+      ;; The callback-ONLY fallback, deliberately: see the namespace docstring.
+      ;; A bare vector on the same fallback would fail earlier and louder, and
+      ;; would take the credit for this row's red.
+      (let [handle (watched-root! frame-id [note-fallback-screen {}])]
+        (try
+          (is (some? (query handle ".note"))
+              "the fallback rendered — an h/fn is LOWERED with no frame in
+               scope, because the dispatch is captured rather than required, so
+               this path fails at invocation and not here")
+          (click! (query handle ".note"))
+          (is (= ["the child threw"] (:noted (db frame-id)))
+              "at invocation the h/fn read the real event, closed over the error
+               the fallback was handed, and the vector it RETURNED drained
+               through the arm's synchronous door")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — a bare intent vector on a native child of h/boundary
+;; ---------------------------------------------------------------------------
+
+(deftest a-native-child-of-a-boundary-dispatches-its-inline-intent
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id)
+      (let [handle (watched-root! frame-id [child-intent-screen {}])]
+        (try
+          (is (nil? @!caught)
+              (str "the boundary lowered its CHILDREN with no ambient frame. "
+                   "Escaped: " (pr-str (escaped))))
+          (is (some? (query handle ".dismiss"))
+              "the screen rendered at all — before this repair the intent on the
+               child raised during the class's own render and there was no
+               button to click")
+          (is (nil? (:dismissed (db frame-id))))
+          (click! (query handle ".dismiss"))
+          (is (= [1] (:dismissed (db frame-id))))
+          (click! (query handle ".dismiss"))
+          (is (= [1 1] (:dismissed (db frame-id)))
+              "and again, so this is a live handler and not a one-shot")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — the one callback form on a native child
+;; ---------------------------------------------------------------------------
+
+(deftest a-callback-on-a-native-child-dispatches-what-it-returned
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id)
+      (let [handle (watched-root! frame-id [child-callback-screen {}])]
+        (try
+          (is (some? (query handle ".note")))
+          (click! (query handle ".note"))
+          (is (= ["child"] (:noted (db frame-id)))
+              "the callback path, at a child position, on its own subject")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 5 — the frame is the BOUNDARY's, proved against a second live frame
+;; ---------------------------------------------------------------------------
+
+(deftest a-fallbacks-intent-lands-in-the-frame-the-boundary-was-mounted-under
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id)
+      (fresh! other-frame-id)
+      (let [a (watched-root! frame-id [retry-screen {}])
+            b (mount/root! (mount/fresh-container!) other-frame-id
+                           [retry-screen {}])]
+        (try
+          (click! (query a ".retry"))
+          (is (= 1 (:attempt (db frame-id))))
+          (is (= 0 (:attempt (db other-frame-id)))
+              "the second frame's app-db did not move — a frame is an isolated
+               context, and a fallback that dispatched to whatever was ambient
+               rather than to its own provider would have moved both")
+          (click! (query b ".retry"))
+          (is (= 1 (:attempt (db other-frame-id))))
+          (is (= 1 (:attempt (db frame-id)))
+              "and symmetrically the other way")
+          (finally (mount/release! a) (mount/release! b)))))))
+
+;; ---------------------------------------------------------------------------
+;; 6 — a frameless boundary is legal; an intent under one is still the loud error
+;; ---------------------------------------------------------------------------
+
+(defn- frameless-root!
+  "A root whose provider carries the **no-provider sentinel** — the React
+  context default, so this is exactly a tree with no frame boundary above
+  it, reached without a second door in `mount`. The children are native
+  hiccup throughout: a `defview` product refuses to render frameless on
+  its own account (`:rf.error/no-frame-context`), which would answer a
+  different question."
+  [hiccup]
+  (reset! !caught nil)
+  (mount/root! (mount/fresh-container!) adapter-context/no-provider-sentinel
+               [boundary {:fallback [:p.escaped "the subject refused to render"]
+                          :on-error (fn [e] (reset! !caught e))}
+                hiccup]))
+
+(deftest a-frameless-boundary-is-legal-until-something-below-writes-an-intent
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (support/leave-act-environment!)
+      (testing "a boundary with no frame above it and no intent below it
+                renders. The class reads no subscription, so requiring a frame
+                it does not need would refuse a legal page — the binding is
+                unconditional and simply carries nil"
+        (let [handle (frameless-root!
+                       [boundary {:fallback [:p.fb "unused"]}
+                        [:p.body "quiet"]])]
+          (try
+            (is (some? (query handle ".body")))
+            (is (nil? @!caught) (str "nothing was raised. Escaped: " (pr-str (escaped))))
+            (finally (mount/release! handle)))))
+      (testing "and an intent under one is the loud error, NAMED — the
+                diagnostic points at the intent rather than at the boundary"
+        (let [handle (frameless-root!
+                       [boundary {:fallback [:p.fb "unused"]}
+                        [:button.dismiss {:on-click [:hicasso.bdy/dismissed 1]} "x"]])]
+          (try
+            (is (some? (query handle ".escaped"))
+                "the boundary failed rather than rendering an inert handler")
+            (is (= :rf.error/hicasso-intent-outside-boundary
+                   (:rf.error/id (ex-data @!caught)))
+                (str "and it named the intent: " (pr-str (ex-data @!caught))))
+            (is (= [:hicasso.bdy/dismissed 1] (:intent (ex-data @!caught))))
+            (finally (mount/release! handle))))))))
+
+;; ---------------------------------------------------------------------------
+;; 7 — the fence: the class still spends no hook, in its error state too
+;; ---------------------------------------------------------------------------
+
+(deftest the-boundary-spends-no-hook-in-its-error-state-either
+  (testing "`impl.presence-react` had to buy a `useContext` to resolve its frame,
+           and paid for it in HD-025's stated cost. This class did not: it
+           already resolves its frame through `contextType`, which is a
+           property of the component rather than a hook call, so the repair
+           is invisible at React's dispatcher. Counted on the page where the
+           new binding actually runs — a boundary in its ERROR state,
+           rendering the fallback"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (if-not (probe/install!)
+        (is false (str "React's internals slot was not found, so this claim is "
+                       "UNWITNESSED on this build. A gate nobody has watched "
+                       "fire is not evidence — fix "
+                       (pr-str 're-frame.hicasso.hook-probe)
+                       " rather than reading this as a pass."))
+        (do
+          (fresh! frame-id)
+          (let [handle (volatile! nil)
+                names  (probe/record!
+                         (fn [] (vreset! handle
+                                         (watched-root! frame-id
+                                                        [retry-screen {}]))))]
+            (try
+              (is (some? (query @handle ".retry"))
+                  "the fallback really did render, so the counts below were
+                   taken over the path this repair changed")
+              (is (= #{"useContext" "useSyncExternalStore"} (set names))
+                  (str "every dispatcher read on this page belongs to a "
+                       "`defview` SHELL — the two `collector/shell-hook-ledger` "
+                       "declares. Two `h/boundary` classes are in this tree "
+                       "(the watcher and the subject) and between them they "
+                       "contributed none. Raw: " (pr-str names)))
+              (is (= 2 (count collector/shell-hook-ledger) (count (distinct names)))
+                  "and the declared shell ledger is the measured roster")
+              (is (empty? (filter #{"useRef" "useMemo" "useCallback" "useState"
+                                    "useEffect"}
+                                  names))
+                  "no useRef, no memo, no state and no effect — the class is
+                   still a class")
+              (finally (mount/release! @handle)))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/boundary_intent_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/boundary_intent_dom_cljs_test.cljs
@@ -1,8 +1,9 @@
 (ns re-frame.hicasso.boundary-intent-dom-cljs-test
   "AN INTENT ON A BOUNDARY'S FALLBACK, AND ON ITS CHILDREN (rf2-uo9di).
 
-  The sibling of [[re-frame.hicasso.presence-intent-dom-cljs-test]], and the identical
-  mechanism one component along. A `h/boundary`'s `:fallback` and its
+  The sibling of [[re-frame.hicasso.presence-intent-dom-cljs-test]], and
+  the identical mechanism one component along. A `h/boundary`'s
+  `:fallback` and its
   `:children` are hiccup **data**, written in the parent boundary's body
   — and both are **lowered inside the class component's own React
   render**, after that body's dynamic extent has unwound. With no ambient

--- a/implementation/hicasso/test/re_frame/hicasso/callback_form_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/callback_form_dom_cljs_test.cljs
@@ -1,0 +1,156 @@
+(ns re-frame.hicasso.callback-form-dom-cljs-test
+  "THE ONE CALLBACK FORM, DRIVEN BY A REAL BROWSER EVENT
+  (rf2-2rtt6.35, HD-024).
+
+  [[re-frame.hicasso.intent-cljs-test]] proves the position table's
+  algebra against stand-in events, which is the right altitude for it —
+  a stand-in makes `preventDefault`, the target and the composition
+  signals observable in a way a real event does not. What a stand-in
+  cannot show is that React routes a genuine click to a closure this
+  runtime minted, that the intent it returns drains through the
+  synchronous door, and that the echo is on screen. That is this file.
+
+  Three rows, and each one is a row of the position table:
+
+  1. **Event position.** `(h/hfn [e] …)` at `:on-click`, clicked for
+     real; its returned VECTOR reaches app-db and the DOM re-paints in
+     the same turn.
+  2. **Event position, no intent.** The same form whose body returns
+     something that is not a vector: the body runs and nothing is
+     dispatched. In the predecessor this is a SECOND form (`v/handler`)
+     with its own contract; here it is the same form at the same
+     position, and the return value is the only difference.
+  3. **Outside every walked position.** The form handed straight into a
+     raw `#js` props object and called the way a JavaScript library calls
+     it. This is the row that deletes the predecessor's fifth rule: there,
+     a roster carrier in that position is a marker OBJECT, so the call
+     raises the engine's own `TypeError` \"naming nothing you wrote\".
+     Here it is a function, so it simply runs.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every DOM claim degrades to a stated
+  skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.intent :as intent]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.todo-support :as todo]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+(def ^:private frame-id ::callback-form)
+
+(defonce ^:private !ran (atom 0))
+
+(defn- skip! [why] (is true (str "a callback-form claim needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (reset! !ran 0)
+  (support/leave-act-environment!)
+  (todo/make-frame! frame-id 3)
+  (todo/reseed! frame-id 3)
+  frame-id)
+
+;; ---------------------------------------------------------------------------
+;; The screen — one form at one position, three times
+;; ---------------------------------------------------------------------------
+
+(h/defview toggle-row
+  "The row a real click lands on. `hfn` is the ONE form; `:on-click` is
+  the position; the returned vector is the contract that position
+  imposes. Nothing here names a form: the author wrote a function and
+  returned data."
+  [{:keys [id]}]
+  (let [done? (collector/sub [:hicasso.todo/done? id])]
+    [:li.row {:data-id id :data-done (str done?)}
+     [:button.toggle
+      {:on-click (h/hfn [e]
+                   (swap! !ran inc)
+                   ;; A live event: the same form the predecessor would
+                   ;; need `v/event` for, reading the DOM event and
+                   ;; returning ONE intent.
+                   (when (= "toggle" (.. e -target -dataset -role))
+                     [:hicasso.todo/toggle id]))
+       :data-role "toggle"}
+      "toggle"]
+     [:button.silent
+      ;; The same form, same position, whose body returns something that
+      ;; is not a vector. The predecessor spells this `v/handler`.
+      {:on-click (h/hfn [_] (swap! !ran inc) :nothing-to-dispatch)}
+      "silent"]]))
+
+(defn- query [handle sel] (.querySelector (:container handle) sel))
+
+;; ---------------------------------------------------------------------------
+;; 1 — event position: a returned vector reaches app-db and the DOM
+;; ---------------------------------------------------------------------------
+
+(deftest a-real-click-on-the-one-form-dispatches-what-it-returned
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [toggle-row {:id 1}])]
+        (try
+          (is (= "false" (.getAttribute (query handle ".row") "data-done")))
+          (.click (query handle ".toggle"))
+          (mount/settle!)
+          (is (= 1 @!ran) "React routed the click to the closure the runtime minted")
+          (is (= "true" (.getAttribute (query handle ".row") "data-done"))
+              "and the intent it RETURNED drained through the synchronous
+               door, so the echo is on screen in the same turn")
+          (.click (query handle ".toggle"))
+          (mount/settle!)
+          (is (= "false" (.getAttribute (query handle ".row") "data-done"))
+              "and again, so this is a working handler and not a one-shot")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — event position: a return that is not a vector dispatches nothing
+;; ---------------------------------------------------------------------------
+
+(deftest the-same-form-at-the-same-position-can-return-nothing
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [toggle-row {:id 1}])]
+        (try
+          (.click (query handle ".silent"))
+          (mount/settle!)
+          (is (= 1 @!ran) "the body ran")
+          (is (= "false" (.getAttribute (query handle ".row") "data-done"))
+              "and nothing was dispatched — in the predecessor this is a
+               different FORM with a different contract; here it is the same
+               form, and the return value is the whole of the difference")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — outside every walked position, it is a function
+;; ---------------------------------------------------------------------------
+
+(deftest a-javascript-library-calling-it-natively-gets-a-real-call
+  (testing "the predecessor's fifth rule, deleted. Its roster forms are
+            site-owned, and a carrier that reaches a raw `#js` prop is a
+            marker object rather than a function — so `props.onPing(…)`
+            raises the engine's own TypeError, worded after whatever
+            expression it tripped on and naming nothing the author wrote.
+            The one form is a function everywhere, so a position Hicasso
+            never walks costs the CONTRACT and nothing else."
+    (let [cb       (h/hfn [x] (swap! !ran inc) [:would-have-dispatched x])
+          js-props #js {:onPing cb}]
+      (reset! !ran 0)
+      (is (fn? (.-onPing js-props)))
+      (is (= [:would-have-dispatched 3] ((.-onPing js-props) 3)))
+      (is (= 1 @!ran))
+      (is (true? (intent/callback? cb))
+          "and it is still the marked form, so a position that DOES walk it
+           would impose that position's contract on the same value"))))

--- a/implementation/hicasso/test/re_frame/hicasso/codec_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/codec_cljs_test.cljs
@@ -331,7 +331,7 @@
     (is (nil? (codec/as-element false)))
     (is (= [nil nil "x"] (child-vec (codec/as-element [:p nil false "x"])))))
   (testing "true is an error"
-    (is (thrown-with-msg? js/Error #"not a renderable child" (codec/as-element true)))
+    (is (thrown-with-msg? js/Error #"true is an error" (codec/as-element true)))
     (try
       (codec/as-element true)
       (is false "should have thrown")
@@ -408,8 +408,16 @@
         (is (= :call-it-or-make-it-a-view (:recovery (ex-data e))))))))
 
 (deftest an-empty-hiccup-vector-and-a-nonsense-head-are-loud-errors
-  (is (thrown-with-msg? js/Error #"Empty hiccup vector" (codec/as-element [])))
-  (is (thrown-with-msg? js/Error #"not a valid element head" (codec/as-element [42 {}]))))
+  ;; The prose is the CATALOGUED prose (rf2-hic-007 moved the package's
+  ;; refusals to `impl.error/fail!` under `check_complaint_catalogue.py`),
+  ;; so each row pins the id — the stable contract — beside the wording.
+  (is (thrown-with-msg? js/Error #"must have a head" (codec/as-element [])))
+  (is (= :rf.error/hicasso-empty-vector
+         (try (codec/as-element []) nil (catch :default e (:rf.error/id (ex-data e))))))
+  (is (thrown-with-msg? js/Error #"Hiccup head must be a tag keyword"
+                        (codec/as-element [42 {}])))
+  (is (= :rf.error/hicasso-bad-head
+         (try (codec/as-element [42 {}]) nil (catch :default e (:rf.error/id (ex-data e)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; `:&` — one merge, and the owned-literal law unconditional

--- a/implementation/hicasso/test/re_frame/hicasso/codec_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/codec_cljs_test.cljs
@@ -1,0 +1,1593 @@
+(ns re-frame.hicasso.codec-cljs-test
+  "THE HICCUP CODEC, tested at the element (rf2-2rtt6.8).
+
+  Every assertion here reads a React element's `type`, `props` and `key`
+  rather than rendered DOM. That is the right altitude for a codec and it
+  is also the cheap one: the question this file answers is *what did the
+  codec build*, and a mounted tree would answer it through two more
+  layers that have their own opinions. What React then does with these
+  elements is the arms' browser witness set, not this file's."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.intent :as intent]
+            [re-frame.hicasso.impl.slot :as slot]
+            [re-frame.hicasso.slot-corpus :as slot-corpus]
+            ["react" :as react]))
+
+(use-fixtures :each {:before (fn [] (codec/reset-caches!))})
+
+;; ---------------------------------------------------------------------------
+;; Reading an element
+;; ---------------------------------------------------------------------------
+
+(defn- el-type [e] (.-type e))
+(defn- el-key [e] (.-key e))
+(defn- prop [e k] (aget (.-props e) k))
+(defn- prop-names [e] (vec (sort (js/Object.keys (.-props e)))))
+(defn- children [e] (prop e "children"))
+(defn- child-vec [e] (let [c (children e)] (if (array? c) (vec c) [c])))
+
+;; ---------------------------------------------------------------------------
+;; Tags
+;; ---------------------------------------------------------------------------
+
+(deftest a-bare-tag-becomes-an-element-of-that-type
+  (let [e (codec/as-element [:div])]
+    (is (= "div" (el-type e)))
+    (is (= [] (prop-names e)))))
+
+(deftest the-id-and-class-shorthand-is-parsed-and-folded-into-the-props
+  (testing "id alone"
+    (is (= "main" (prop (codec/as-element [:div#main]) "id"))))
+  (testing "classes alone, dot-separated"
+    (is (= "wide tall" (prop (codec/as-element [:div.wide.tall]) "className"))))
+  (testing "id then classes, in the one spelling the donor supports"
+    (let [e (codec/as-element [:section#main.wide.tall])]
+      (is (= "section" (el-type e)))
+      (is (= "main" (prop e "id")))
+      (is (= "wide tall" (prop e "className")))))
+  (testing "an explicit :id wins over the shorthand"
+    (is (= "explicit" (prop (codec/as-element [:div#short {:id "explicit"}]) "id"))))
+  (testing "the shorthand class is prepended to an explicit one"
+    (is (= "short explicit" (prop (codec/as-element [:div.short {:class "explicit"}]) "className"))))
+  (testing "a collection class value joins, dropping nils"
+    (is (= "a b" (prop (codec/as-element [:div {:class ["a" nil :b]}]) "className")))))
+
+(deftest the-tag-cache-holds-one-entry-per-distinct-literal
+  (is (= 0 (:tags (codec/cache-sizes))))
+  (codec/as-element [:div.row])
+  (codec/as-element [:div.row])
+  (codec/as-element [:div.row])
+  (is (= 1 (:tags (codec/cache-sizes))) "three renders of one literal, one entry")
+  (codec/as-element [:span])
+  (is (= 2 (:tags (codec/cache-sizes))))
+  (testing "a cached parse produces the same element a fresh parse does"
+    (is (= "row" (prop (codec/as-element [:div.row]) "className")))))
+
+(deftest the-caches-refuse-the-prototype-poisoning-keys
+  (testing "a tag named __proto__ parses without being cached"
+    (is (= "__proto__" (el-type (codec/as-element [:__proto__]))))
+    (is (= 0 (:tags (codec/cache-sizes)))))
+  (testing "a prop named __proto__ is neither cached nor set"
+    (let [e (codec/as-element [:div {:__proto__ "nope"}])]
+      (is (= [] (prop-names e))))
+    (is (= 3 (:props (codec/cache-sizes)))
+        "the three seeded entries and nothing else — the refusal is on the write")))
+
+(deftest a-literal-named-after-an-inherited-property-cannot-be-served-one
+  ;; rf2-2rtt6.63. Both caches are `Object.create(null)`, so a lookup can
+  ;; only ever answer an own property. Keyed against `#js {}` these
+  ;; literals would read `Object.prototype`'s OWN members — a function
+  ;; where a ParsedTag or a PropSlot belongs — and the codec would emit
+  ;; whatever that function's `.tag` / `.js-name` happened to be, which
+  ;; is `undefined`. The lookup guard the shipping code used to carry
+  ;; (`hasOwnProperty.call`) answered this; nothing but the cache's own
+  ;; construction answers it now, so it is witnessed rather than assumed.
+  (testing "a TAG named after an Object.prototype member parses as itself"
+    (doseq [n ["toString" "valueOf" "hasOwnProperty" "isPrototypeOf" "constructor"]]
+      (is (= n (el-type (codec/as-element [(keyword n)])))
+          (str "tag " n " must render as itself"))))
+  (testing "and the second render of one reads its own cached entry"
+    (codec/reset-caches!)
+    (codec/as-element [:toString])
+    (is (= 1 (:tags (codec/cache-sizes))))
+    (is (= "toString" (el-type (codec/as-element [:toString]))))
+    (is (= 1 (:tags (codec/cache-sizes)))))
+  (testing "a PROP named after an Object.prototype member converts as itself"
+    (codec/reset-caches!)
+    (let [e (codec/as-element [:div {:toString "a" :valueOf "b" :hasOwnProperty "c"}])]
+      (is (= ["hasOwnProperty" "toString" "valueOf"] (prop-names e)))
+      (is (= "a" (prop e "toString")))
+      (is (= "b" (prop e "valueOf")))
+      (is (= "c" (prop e "hasOwnProperty"))))
+    (testing "and the second element reads the cached slots"
+      (is (= "d" (prop (codec/as-element [:div {:toString "d"}]) "toString"))))))
+
+;; ---------------------------------------------------------------------------
+;; Prop names
+;; ---------------------------------------------------------------------------
+
+(deftest prop-names-follow-the-donors-kebab-to-camel-rule
+  (is (= "onClick" (slot/prop-name :on-click)))
+  (is (= "tabIndex" (slot/prop-name :tab-index)))
+  (is (= "className" (codec/cached-prop-name :class)))
+  (is (= "htmlFor" (codec/cached-prop-name :for)))
+  (is (= "charSet" (codec/cached-prop-name :charset)))
+  (testing "aria and data are HTML attribute names in React too"
+    (is (= "aria-label" (slot/prop-name :aria-label)))
+    (is (= "data-index" (slot/prop-name :data-index))))
+  (testing "a CSS custom property is preserved verbatim"
+    (is (= "--gap" (slot/prop-name :--gap))))
+  (testing "the three seeded entries are the rule, not a memo of one"
+    (is (= 3 (:props (codec/cache-sizes))))
+    (codec/cached-prop-name :on-click)
+    (codec/cached-prop-name :on-click)
+    (is (= 4 (:props (codec/cache-sizes))))))
+
+(deftest the-codecs-cached-slot-is-the-shared-rules-answer
+  (testing "THE OTHER HALF OF THE EQUIVALENCE PIN (rf2-ani6y). The rule
+            lives in `.cljc` so the JVM codemod and this runtime share one
+            implementation, and `slot-cljs-test` runs its corpus on both
+            hosts. That pins the RULE. What it cannot see is this codec
+            putting something else in front of the rule — a
+            hand-written seed in `prop-cache`, a cache keyed so two
+            spellings share one entry, a re-introduced local copy — each
+            of which would answer a slot the codemod would never predict.
+            So the codec's own doors are asked the same corpus: whatever
+            the rule answers, `cached-prop-name` and `canonical-slot`
+            answer, for every spelling the codec accepts."
+    (doseq [[k expected] slot-corpus/corpus]
+      (is (= expected (codec/cached-prop-name k) (codec/canonical-slot k))
+          (str "codec slot for " (pr-str k)))))
+  (testing "and again warm, because the first ask is the one that writes
+            the cache and the second is the one that reads it"
+    (doseq [[k expected] slot-corpus/corpus]
+      (is (= expected (codec/cached-prop-name k))
+          (str "warm codec slot for " (pr-str k))))))
+
+(deftest the-slot-is-a-pure-function-of-the-key-and-a-string-cannot-poison-it
+  (testing "a string prop name is already a React name and is taken verbatim,
+            so `\"on-input\"` and `:on-input` are DIFFERENT slots. They share
+            a cache entry if the cache is keyed by name alone, and then the
+            first string spelling rendered anywhere answers every later
+            keyword — emitting every handler written the taught way into a
+            slot React ignores, and making the canonical slot depend on what
+            the page happened to render first."
+    (is (= "on-input" (codec/cached-prop-name "on-input")))
+    (is (= "onInput" (codec/cached-prop-name :on-input))
+        "the keyword still camelCases, whatever was asked before it")
+    (is (= "on-input" (codec/cached-prop-name "on-input"))
+        "and the string is still itself, whatever was asked before IT"))
+  (testing "the other way round, from a cold cache"
+    (codec/reset-caches!)
+    (is (= "onInput" (codec/cached-prop-name :on-input)))
+    (is (= "on-input" (codec/cached-prop-name "on-input"))))
+  (testing "the three React renames are the rule, so they hold for every
+            spelling of the one attribute"
+    (doseq [k [:class :className "class" :x/class 'class]]
+      (is (= "className" (codec/canonical-slot k)) (str "spelled " (pr-str k))))))
+
+(deftest the-cached-classification-is-spelling-aware-and-no-spelling-poisons-another
+  ;; rf2-y1jkm: the prop cache's entries carry the POSITION CLASSIFICATION
+  ;; beside the React name, and the entry is keyed by name — so a symbol
+  ;; spelled `on-click` shares the keyword's entry while `event-prop?`
+  ;; answers false for it. The flag must therefore be minted from the NAME
+  ;; and applied spelling-aware at the call site; either shortcut turns
+  ;; whichever spelling renders first into the answer for both, which is
+  ;; exactly the order dependence the string/keyword law above exists to
+  ;; remove. Both directions, both from a cold cache.
+  (testing "a symbol minted FIRST does not cost the keyword its event lowering"
+    (codec/reset-caches!)
+    (codec/cached-prop-name 'on-click)
+    (let [!seen (atom [])
+          e     (intent/with-frame (fn [ev] (swap! !seen conj ev))
+                                   (fn [] (codec/as-element [:button {:on-click [:go]}])))]
+      (is (fn? (prop e "onClick")) "the keyword position still lowers to a handler")
+      ((prop e "onClick") #js {:target #js {}})
+      (is (= [[:go]] @!seen))))
+  (testing "a keyword minted FIRST does not make the symbol an event position"
+    (codec/reset-caches!)
+    (codec/cached-prop-name :on-click)
+    (let [e (codec/as-element [:div {'on-click [:go]}])]
+      (is (array? (prop e "onClick"))
+          "a symbol key is never an event position (event-prop? says so), so
+           the vector is a plain prop value and converts through clj->js —
+           lowering it here would also have thrown, there being no ambient
+           frame in this test"))))
+
+(deftest the-shorthand-composes-with-a-class-however-it-is-spelled
+  ;; THIS TEST WAS THE OTHER WAY ROUND (rf2-2rtt6.36, merged-PR audit
+  ;; #7332). Under rf2-y1jkm's lane 2 the shorthand's className was written
+  ;; over whatever the loop had emitted, and an exotic spelling that
+  ;; canonicalises onto the same slot lost outright — `[:div.a {:x/class
+  ;; "b"}]` was pinned at "a". It was pinned because it MATCHED the general
+  ;; path, and the general path was itself wrong: the shorthand merge read
+  ;; `:class` and `:className` off the map by raw key, so it saw three of
+  ;; the spellings this codec accepts and silently dropped the rest.
+  ;;
+  ;; The shorthand is folded onto the EMITTED object now, where there is
+  ;; no spelling left to miss, so every one of them composes. The
+  ;; assertion below is the flipped one and it is the whole repair in a
+  ;; line.
+  (testing "a namespaced class spelling composes with the shorthand rather
+            than losing to it"
+    (is (= "a b" (prop (codec/as-element [:div.a {:x/class "b"}]) "className"))))
+  (testing "and so does every other spelling the codec accepts"
+    (doseq [k [:class :className "class" "className" 'class :x/class :class-name]]
+      (is (= "a b" (prop (codec/as-element [:div.a {k "b"}]) "className"))
+          (str "spelled " (pr-str k)))))
+  (testing "a caller remainder composes too, in every spelling"
+    (doseq [k [:class :className "class" "className" 'class :x/class]]
+      (is (= "a b" (prop (codec/as-element [:div.a {:& {k "b"}}]) "className"))
+          (str "forwarded as " (pr-str k)))))
+  (testing "the class value is coerced at the slot, so a collection joins
+            whatever key carried it — the coercion used to live in the map
+            surgery, where only `:class` and `:className` reached it"
+    (doseq [k [:class "className" :x/class]]
+      (is (= "a x y" (prop (codec/as-element [:div.a {k ["x" nil :y]}]) "className"))
+          (str "spelled " (pr-str k)))))
+  (testing "two spellings of the one slot COMPOSE rather than the last write
+            silently winning — a dropped class is the failure class the
+            ruling exists to delete"
+    (is (= "a b c" (prop (codec/as-element [:div.a {:class "b" :x/class "c"}]) "className")))))
+
+(deftest the-shorthand-id-loses-to-an-explicit-one-however-it-is-spelled
+  ;; The other half of merged-PR audit #7332. `#tag` is the weakest source
+  ;; of an id there is, and the rule "an explicit :id wins" was stated on
+  ;; the raw key — so `[:div#tag {"id" "explicit"}]` kept BOTH, landed both
+  ;; on React's one `id` slot, and left which one survived to the order the
+  ;; props map happened to iterate in.
+  (testing "written on the element"
+    (doseq [k [:id "id" 'id :x/id]]
+      (is (= "explicit" (prop (codec/as-element [:div#tag {k "explicit"}]) "id"))
+          (str "spelled " (pr-str k)))))
+  (testing "forwarded through the one merge — the door where the author of
+            the element never sees the key at all"
+    (doseq [k [:id "id" 'id :x/id]]
+      (is (= "caller" (prop (codec/as-element [:div#tag {:& {k "caller"}}]) "id"))
+          (str "forwarded as " (pr-str k)))))
+  (testing "and the shorthand still lands when nothing claims the slot"
+    (is (= "tag" (prop (codec/as-element [:div#tag {:& {:title "t"}}]) "id"))))
+  (testing "a near miss is not the id slot and keeps its own name"
+    (let [e (codec/as-element [:div#tag {:data-id "d" :ids "many"}])]
+      (is (= "tag" (prop e "id")))
+      (is (= "d" (prop e "data-id")))
+      (is (= "many" (prop e "ids"))))))
+
+(deftest the-shorthand-fold-does-not-depend-on-map-order
+  ;; The audit's phrasing: the answer must hold "independent of cache/render
+  ;; /map order". Both spellings of both slots in one remainder, written in
+  ;; both orders, and again in a map big enough to be a PersistentHashMap
+  ;; rather than an array map — the iteration order changes underneath and
+  ;; the emitted element does not.
+  (let [expected {"id" "caller" "className" "foo bar"}
+        emitted  (fn [e] {"id" (prop e "id") "className" (prop e "className")})]
+    (testing "the audit's own witness, both ways round"
+      (is (= expected (emitted (codec/as-element
+                                [:div#tag.foo {:& {"id" "caller" "className" "bar"}}]))))
+      (is (= expected (emitted (codec/as-element
+                                [:div#tag.foo {:& {"className" "bar" "id" "caller"}}])))))
+    (testing "and out of a hash map, whose iteration order is neither"
+      (let [caller (into {} (map (fn [i] [(keyword (str "data-" i)) i])) (range 12))]
+        (is (= expected (emitted (codec/as-element
+                                  [:div#tag.foo {:& (assoc caller "id" "caller" :x/class "bar")}]))))))
+    (testing "renders are independent of what the caches were asked first"
+      (codec/reset-caches!)
+      (codec/cached-prop-name "class")
+      (codec/cached-prop-name :x/id)
+      (is (= expected (emitted (codec/as-element
+                                [:div#tag.foo {:& {"id" "caller" "className" "bar"}}])))))))
+
+(deftest prop-values-are-converted-in-the-shapes-react-wants
+  (testing "a style map becomes a JS object with camelCased keys"
+    (let [style (prop (codec/as-element [:div {:style {:font-size "12px" :color :red}}]) "style")]
+      (is (= "12px" (aget style "fontSize")))
+      (is (= "red" (aget style "color")) "a keyword value stringifies")))
+  (testing "a CSS custom property survives inside style"
+    (let [style (prop (codec/as-element [:div {:style {:--gap "4px"}}]) "style")]
+      (is (= "4px" (aget style "--gap")))))
+  (testing "a function passes through BY IDENTITY, so downstream bail-outs still work"
+    (let [f (fn [_])]
+      (is (identical? f (prop (codec/as-element [:div {:on-click f}]) "onClick")))))
+  (testing "a ref is an ordinary prop — callback refs are legal on native tags"
+    (let [r (fn [_node])]
+      (is (identical? r (prop (codec/as-element [:div {:ref r}]) "ref")))))
+  (testing "scalars are left alone"
+    (let [e (codec/as-element [:input {:value "x" :disabled true :tab-index 3}])]
+      (is (= "x" (prop e "value")))
+      (is (= true (prop e "disabled")))
+      (is (= 3 (prop e "tabIndex"))))))
+
+;; ---------------------------------------------------------------------------
+;; Keys — `:key` in the props position, never metadata (HD-016)
+;; ---------------------------------------------------------------------------
+
+(deftest a-native-elements-key-is-key-in-the-props-map-and-is-not-an-attribute
+  (let [e (codec/as-element [:li {:key 7 :class "row"}])]
+    (is (= "7" (el-key e)) "React stringifies keys")
+    (is (= ["className"] (prop-names e)) ":key never reaches the DOM props")))
+
+;; ---------------------------------------------------------------------------
+;; Children
+;; ---------------------------------------------------------------------------
+
+(deftest children-are-realized-once-and-flattened-one-level
+  (testing "one child arrives as the single child, not an array"
+    (let [e (codec/as-element [:p "text"])]
+      (is (= "text" (children e)))))
+  (testing "several children arrive in order"
+    (let [e (codec/as-element [:p "a" "b" "c"])]
+      (is (= ["a" "b" "c"] (child-vec e)))))
+  (testing "a seq is expanded, and an interior nil does NOT truncate it"
+    (let [e (codec/as-element [:ul (for [i (range 4)] (when (odd? i) [:li {:key i} i]))])
+          expanded (vec (children e))]
+      (is (= 4 (count expanded)) "all four slots survive the single pass")
+      (is (nil? (nth expanded 0)))
+      (is (= "li" (el-type (nth expanded 1))))
+      (is (nil? (nth expanded 2)))
+      (is (= "li" (el-type (nth expanded 3))))))
+  (testing "nil and false render nothing"
+    (is (nil? (codec/as-element nil)))
+    (is (nil? (codec/as-element false)))
+    (is (= [nil nil "x"] (child-vec (codec/as-element [:p nil false "x"])))))
+  (testing "true is an error"
+    (is (thrown-with-msg? js/Error #"not a renderable child" (codec/as-element true)))
+    (try
+      (codec/as-element true)
+      (is false "should have thrown")
+      (catch :default e
+        (is (= :rf.error/hicasso-true-child (:rf.error/id (ex-data e)))))))
+  (testing "an existing React element is a legal child anywhere"
+    (let [foreign (react/createElement "b" nil "bold")
+          e       (codec/as-element [:p foreign])]
+      (is (identical? foreign (children e))))))
+
+(deftest a-map-in-the-first-slot-is-props-and-anything-else-is-a-child
+  (testing "a map is props"
+    (is (= "row" (prop (codec/as-element [:div {:class "row"}]) "className"))))
+  (testing "a string in the first slot is a child, not props"
+    (is (= "hello" (children (codec/as-element [:div "hello"])))))
+  (testing "a vector in the first slot is a child"
+    (is (= "b" (el-type (children (codec/as-element [:div [:b]])))))))
+
+;; ---------------------------------------------------------------------------
+;; Fragments
+;; ---------------------------------------------------------------------------
+
+(deftest the-fragment-spelling-is-a-fragment
+  (let [e (codec/as-element [:<> [:li "a"] [:li "b"]])]
+    (is (identical? (.-Fragment react) (el-type e)))
+    (is (= 2 (count (child-vec e)))))
+  (testing "a keyed fragment carries its key"
+    (is (= "k" (el-key (codec/as-element [:<> {:key "k"} [:li "a"]]))))))
+
+;; ---------------------------------------------------------------------------
+;; Boundaries — the HD-016 head rules
+;; ---------------------------------------------------------------------------
+
+(defn- a-view
+  "Stands in for a `defview` product: an arm mints the function component
+  once, at definition, and marks it. The codec never wraps it, which is
+  why HD-004's cached-component-head has nothing to do here."
+  [_js-props]
+  nil)
+
+(codec/mark-boundary! a-view)
+
+(deftest a-marked-view-in-head-position-is-a-boundary-child
+  (let [e (codec/as-element [a-view {:id 7}])]
+    (is (identical? a-view (el-type e)))
+    (is (= {:id 7} (prop e "rfProps")) "the body receives one CLJS props map")))
+
+(deftest a-boundarys-key-is-extracted-before-the-body-sees-props
+  (let [e (codec/as-element [a-view {:key 3 :id 7}])]
+    (is (= "3" (el-key e)))
+    (is (= {:id 7} (prop e "rfProps")) ":key is React's contract, not the body's")))
+
+(deftest a-boundarys-children-arrive-as-a-realized-vector-of-hiccup
+  (testing "trailing forms become (:children props)"
+    (let [e (codec/as-element [a-view {:id 7} [:li "a"] [:li "b"]])]
+      (is (= {:id 7 :children [[:li "a"] [:li "b"]]} (prop e "rfProps")))))
+  (testing "a seq child is realized once and flattened exactly one level"
+    (let [e (codec/as-element [a-view {} (for [i (range 2)] [:li i])])]
+      (is (= [[:li 0] [:li 1]] (:children (prop e "rfProps"))))))
+  (testing "with no trailing forms there is no :children key at all"
+    (is (= {:id 7} (prop (codec/as-element [a-view {:id 7}]) "rfProps"))))
+  (testing "a boundary with no props map still works"
+    (is (= {} (prop (codec/as-element [a-view]) "rfProps")))))
+
+(deftest a-plain-function-in-head-position-is-a-loud-error
+  (let [helper (fn [_] [:div])]
+    (is (false? (codec/boundary-head? helper)))
+    (is (thrown-with-msg? js/Error #"never a silent" (codec/as-element [helper {}])))
+    (try
+      (codec/as-element [helper {}])
+      (is false "should have thrown")
+      (catch :default e
+        (is (= :rf.error/hicasso-bad-head (:rf.error/id (ex-data e))))
+        (is (= :call-it-or-make-it-a-view (:recovery (ex-data e))))))))
+
+(deftest an-empty-hiccup-vector-and-a-nonsense-head-are-loud-errors
+  (is (thrown-with-msg? js/Error #"Empty hiccup vector" (codec/as-element [])))
+  (is (thrown-with-msg? js/Error #"not a valid element head" (codec/as-element [42 {}]))))
+
+;; ---------------------------------------------------------------------------
+;; `:&` — one merge, and the owned-literal law unconditional
+;; (HD-023, rf2-2rtt6.36)
+;; ---------------------------------------------------------------------------
+
+(deftest a-caller-remainder-merges-under-the-literals-that-are-written
+  (testing "the law, in its plainest form: keys the caller supplies and the
+            element does not, land; keys the element writes are not
+            reachable from `:&` at all."
+    (let [e (codec/as-element [:div {:& {:title "from caller" :id "caller"}
+                                     :id "owned"}])]
+      (is (= "from caller" (prop e "title")) "an unclaimed key lands")
+      (is (= "owned" (prop e "id")) "a written literal always wins")
+      (is (not (contains? (set (prop-names e)) "&"))
+          ":& is a reserved key, never an attribute")))
+  (testing "the whole point of the direction: a caller override is spelled by
+            NOT writing the literal, because the dangerous default is the
+            other way round"
+    (is (= "caller" (prop (codec/as-element [:div {:& {:id "caller"}}]) "id")))))
+
+(deftest a-hostile-remainder-cannot-forfeit-the-controlled-input-door
+  (testing "the predecessor's silent failure, deleted. There, a dynamic map
+            merged onto a controlled input WITHOUT the door-preserving spread
+            form forfeits caret and IME protection, and no diagnostic is
+            raised anywhere — the choice of syntax is the choice of
+            correctness. Here there is one merge and the law is
+            unconditional, so a remainder carrying the whole controlled
+            contract reaches none of it."
+    (let [!seen (atom [])
+          caller {:value      "HOSTILE"
+                  :on-input   [:hostile/edit]
+                  :key        "hostile"
+                  :ref        (fn [_] (swap! !seen conj :ref-fired))
+                  :class      "from-caller"
+                  :aria-label "kept"}
+          e (intent/with-frame (fn [ev] (swap! !seen conj ev))
+                               (fn [] (codec/as-element
+                                       [:input {:& caller
+                                                :value    "owned"
+                                                :on-input [:todo.ui/edit 7 :re-frame.hicasso/value]}])))]
+      (is (= "owned" (prop e "value")) "the controlled value survives")
+      (is (nil? (el-key e)) ":key is never taken from a remainder")
+      (is (nil? (prop e "ref")) ":ref is never taken from a remainder")
+      (is (= "from-caller" (prop e "className")) "an unclaimed key still lands")
+      (is (= "kept" (prop e "aria-label")))
+      ((prop e "onInput") #js {:target #js {:value "typed"}})
+      (is (= [[:todo.ui/edit 7 "typed"]] @!seen)
+          "and the owned handler is the one that fired — the caller's intent
+           never reached the element"))))
+
+(deftest an-owned-class-composes-through-the-tag-shorthand
+  (testing "the one place a caller's value and an owned value both survive,
+            and it needs no exception to the law: the element's own classes
+            are written on the TAG, which is not a literal attribute key, so
+            the shorthand merge composes them with whatever the remainder
+            brought."
+    (let [e (codec/as-element [:input.form-control {:& {:class "form-control-lg"}}])]
+      (is (= "form-control form-control-lg" (prop e "className"))))
+    (testing "and a literal :class still wins outright, because it is a literal"
+      (let [e (codec/as-element [:input.base {:& {:class "from-caller"} :class "owned"}])]
+        (is (= "base owned" (prop e "className")))))
+    (testing "composition does not reopen the deny: what composes is what
+              SURVIVED the merge, and an alias at a slot an owned literal
+              claims never gets that far — in either spelling"
+      (doseq [k ["className" :x/class 'class]]
+        (is (= "base owned"
+               (prop (codec/as-element [:input.base {:& {k "from-caller"} :class "owned"}])
+                     "className"))
+            (str "forwarded as " (pr-str k))))
+      (doseq [k ["id" :x/id 'id]]
+        (is (= "owned"
+               (prop (codec/as-element [:div#tag {:& {k "hostile"} :id "owned"}]) "id"))
+            (str "forwarded as " (pr-str k)))))))
+
+(deftest the-same-merge-and-the-same-law-hold-at-a-crossing
+  (testing "the case the predecessor needs a THIRD rule for. Its spread forms
+            are element forms, so forwarding a remainder through one onto a
+            declared foreign head rewrites `:className` into the `:class`
+            slot and the component never sees the prop it reads — hence
+            'neither spread form is legal there' and an ordinary `merge`
+            instead. `:&` is not a spread: it is a key in the props map,
+            merged before any conversion, and the conversion that follows is
+            the position's own."
+    (let [e (codec/as-element [a-view {:& {:className "react-name" :selected "caller"}
+                                       :selected "owned"}])]
+      (is (= {:className "react-name" :selected "owned"} (prop e "rfProps"))
+          ":className crosses under the name it was written as, and the
+           owned literal still wins")))
+  (testing "a remainder's :key cannot become the crossing's key either"
+    (let [e (codec/as-element [a-view {:& {:key "hostile"} :id 7}])]
+      (is (nil? (el-key e)))
+      (is (= {:id 7} (prop e "rfProps"))))))
+
+(deftest the-merge-costs-one-lookup-when-it-is-absent
+  (testing "the overwhelming case. No `:&` means the map comes back by
+            identity — the feature allocates nothing on an element that does
+            not use it."
+    (let [props {:id "x" :class "y"}]
+      (is (identical? props (codec/merge-caller props)))))
+  (testing "an explicit nil remainder is a no-op that still removes the key"
+    (is (= {:id "x"} (codec/merge-caller {:& nil :id "x"}))))
+  (testing "a non-map remainder is a loud error rather than a silent drop"
+    (is (thrown-with-msg? js/Error #"carries a caller's attribute map"
+                          (codec/as-element [:div {:& [:not :a :map]}])))
+    (try
+      (codec/as-element [:div {:& "nope"}])
+      (is false "should have thrown")
+      (catch :default e
+        (is (= :rf.error/hicasso-merge-not-a-map (:rf.error/id (ex-data e))))))))
+
+;; ---------------------------------------------------------------------------
+;; The canonical structural-slot filter (rf2-2rtt6.36)
+;; ---------------------------------------------------------------------------
+
+(deftest a-structural-slot-is-recognised-in-every-spelling-the-codec-accepts
+  (testing "the mechanism the whole of this bead's repair rests on: the slot
+            a key EMITS INTO, not the key it was written as. React's key and
+            ref are reachable as a keyword, a string, a symbol and a
+            namespaced keyword, and a rule that names `#{:key :ref}` sees
+            exactly one of the four."
+    (doseq [k [:key "key" 'key :x/key :re-frame.hicasso/key]]
+      (is (true? (codec/structural-slot? k)) (str "key, spelled " (pr-str k))))
+    (doseq [k [:ref "ref" 'ref :x/ref]]
+      (is (true? (codec/structural-slot? k)) (str "ref, spelled " (pr-str k))))
+    (doseq [k [:id :class :on-click :data-key "aria-ref" :keyboard]]
+      (is (false? (codec/structural-slot? k))
+          (str "and nothing else is structural: " (pr-str k)))))
+  (testing "the filter drops every one of them and returns the map by
+            identity when there is nothing to drop"
+    (is (= {:class "x"} (codec/without-structural
+                          {:class "x" :key 1 "key" 2 :x/key 3 :ref (fn [_]) "ref" 4 :x/ref 5})))
+    (let [clean {:class "x" :id "y"}]
+      (is (identical? clean (codec/without-structural clean))))))
+
+(deftest an-alternate-spelling-in-a-remainder-reaches-neither-structural-slot
+  (testing "the hole this repair closes. A remainder is about ATTRIBUTES;
+            `key` and `ref` are about node identity. Denying `:key` and
+            `:ref` by map-key identity denies one spelling of each and lets
+            three through — and with no literal at that slot to overwrite it
+            afterwards, the caller's value is simply what React gets."
+    (doseq [spelling ["key" 'key :x/key]]
+      (let [e (codec/as-element [:li {:& {spelling "hostile"} :class "row"}])]
+        (is (nil? (el-key e)) (str "a remainder's " (pr-str spelling) " is not the element's key"))
+        (is (= ["className"] (prop-names e))
+            "and it does not land as an attribute either")))
+    (doseq [spelling ["ref" 'ref :x/ref]]
+      (let [!fired (atom false)
+            e      (codec/as-element [:div {:& {spelling (fn [_] (reset! !fired true))}}])]
+        (is (nil? (prop e "ref")) (str "a remainder's " (pr-str spelling) " is not a ref"))
+        (is (= [] (prop-names e)))
+        (is (false? @!fired)))))
+  (testing "and the element's OWN literal is untouched by the filter — the
+            law is about what a remainder may reach, not about what an
+            author may write on their own node"
+    (let [f (fn [_node])
+          e (codec/as-element [:li {:key 7 :ref f :& {:title "caller"}}])]
+      (is (= "7" (el-key e)))
+      (is (identical? f (prop e "ref")))
+      (is (= "caller" (prop e "title"))))))
+
+(deftest an-alias-cannot-defeat-an-owned-literal-at-the-slot-they-share
+  (testing "the second half of the same hole. `:onInput` and `:on-input` are
+            two map keys and ONE React slot, so a raw-key merge leaves both
+            in the map and lets whichever the map iterates last decide —
+            which is a law that holds by luck of map ordering rather than by
+            construction. The deny is on the slot, so the alias never
+            reaches the map at all."
+    (is (= {:on-input [:owned/edit]}
+           (codec/merge-caller {:& {:onInput [:hostile/edit]} :on-input [:owned/edit]})))
+    (is (= {:on-input [:owned/edit]}
+           (codec/merge-caller {:& {"onInput" [:hostile/edit]} :on-input [:owned/edit]}))
+        "including the string spelling of the same React name"))
+  (testing "at a crossing the map is handed over UNRENAMED, so the alias is
+            visible in the props a structural test reads — and the law is
+            the same one rule at both positions (HD-023(d))"
+    (let [e (codec/as-element [a-view {:& {:onInput [:hostile/edit] :title "kept"}
+                                       :on-input [:owned/edit]}])]
+      (is (= {:on-input [:owned/edit] :title "kept"} (prop e "rfProps")))))
+  (testing "and the owned handler is the one React calls"
+    (let [!seen (atom [])
+          e (intent/with-frame (fn [ev] (swap! !seen conj ev))
+                               (fn [] (codec/as-element
+                                       [:input {:& {:onInput [:hostile/edit]
+                                                    :onFocus  [:hostile/focus]}
+                                                :on-input [:todo.ui/edit 7]}])))]
+      ((prop e "onInput") #js {:target #js {}})
+      (is (= [[:todo.ui/edit 7]] @!seen))
+      (is (fn? (prop e "onFocus"))
+          "an alias the element does NOT write still lands — the deny is the
+           slot the literal claimed, never the shape of the spelling")))
+  (testing "the same for the controlled pair spelled with a namespace"
+    (let [e (codec/as-element [:input {:& {:x/value "HOSTILE"} :value "owned"}])]
+      (is (= "owned" (prop e "value"))))))
+
+;; ---------------------------------------------------------------------------
+;; The reserved `:ref` value-space (HD-022, rf2-2rtt6.38)
+;; ---------------------------------------------------------------------------
+
+(deftest a-callback-ref-is-the-v0-surface-and-reaches-react-by-identity
+  (testing "HD-003's escape hatch and HD-016's callback-refs-only rule are
+            unchanged by the reservation: a function at :ref is the v0
+            spelling, and it arrives at React as the same function object —
+            rewrapping it would detach and reattach the node every render."
+    (let [f (fn [_node] nil)
+          e (codec/as-element [:div {:ref f}])]
+      (is (identical? f (prop e "ref"))))))
+
+(deftest a-vector-at-ref-is-reserved-and-refused-loudly
+  (testing "the whole of rf2-2rtt6.38. `{:ref [registered-id config]}` is the
+            spelling the later data form wants, so v0 claims the value-space
+            now and refuses it with a diagnostic naming the reservation —
+            rather than handing React an opaque array, which it would ignore
+            in silence and which would look like a ref that never fires."
+    (is (thrown-with-msg? js/Error #"RESERVED"
+                          (codec/as-element [:div {:ref [::autosize {:max-rows 8}]}])))
+    (try
+      (codec/as-element [:textarea.composer {:ref [::autosize {:max-rows 8}]}])
+      (is false "should have thrown")
+      (catch :default e
+        (let [d (ex-data e)]
+          (is (= :rf.error/hicasso-ref-vector-reserved (:rf.error/id d)))
+          (is (= :use-a-callback-ref-or-an-effect (:recovery d)))
+          (is (= [::autosize {:max-rows 8}] (:ref d))
+              "the refusal carries the value it refused, so a later
+               migration can find its own call sites"))))))
+
+(deftest the-reservation-holds-at-the-ref-slot-however-the-ref-is-spelled
+  (testing "the hole. This codec deliberately accepts string, symbol and
+            namespaced prop spellings and emits them all under one React
+            name, so a reservation that reads `(:ref props)` is a
+            reservation `\"ref\"` and `:x/ref` walk straight past — on their
+            way to React with the opaque array the reservation exists to
+            stop, which is the silent ref-that-never-fires it was written to
+            replace."
+    (doseq [spelling ["ref" 'ref :x/ref :re-frame.hicasso/ref]]
+      (try
+        (codec/as-element [:textarea.composer {spelling [::autosize {:max-rows 8}]}])
+        (is false (str "should have thrown for " (pr-str spelling)))
+        (catch :default e
+          (let [d (ex-data e)]
+            (is (= :rf.error/hicasso-ref-vector-reserved (:rf.error/id d))
+                (str "refused, spelled " (pr-str spelling)))
+            (is (= spelling (:position d))
+                "and the diagnostic names the spelling that was written")
+            (is (= [::autosize {:max-rows 8}] (:ref d))))))))
+  (testing "and a callback ref under an alternate spelling still reaches
+            React's ref slot BY IDENTITY — the reservation is the VECTOR
+            arm, not a claim on the spelling, and the ref position is
+            excluded from callback lowering at the slot rather than at the
+            key. Wrapping it would both forbid a dispatch that is legitimate
+            there and change the identity React uses to decide whether to
+            re-attach the node."
+    (let [f (intent/callback (fn [_node]))]
+      (is (identical? f (prop (codec/as-element [:div {"ref" f}]) "ref")))
+      (is (identical? f (prop (codec/as-element [:div {:x/ref f}]) "ref")))))
+  (testing "a vector anywhere else is still an ordinary prop value"
+    (is (= "a b" (prop (codec/as-element [:div {:class ["a" "b"]}]) "className")))
+    (is (some? (prop (codec/as-element [:div {:data-refs [1 2]}]) "data-refs")))))
+
+(deftest the-reservation-costs-one-branch-and-claims-nothing-else
+  (testing "no other :ref value moves. A string ref, a nil ref and a map at
+            :ref all pass through the ordinary conversion — the reservation
+            is the VECTOR arm and nothing wider, because a wider claim would
+            be designing the later surface rather than reserving room for it."
+    (is (nil? (prop (codec/as-element [:div {:ref nil}]) "ref")))
+    (is (= "legacy" (prop (codec/as-element [:div {:ref "legacy"}]) "ref")))
+    (is (some? (prop (codec/as-element [:div {:ref {:a 1}}]) "ref"))))
+  (testing "and :ref is not an event position, so intent lowering never sees it"
+    (is (false? (intent/event-prop? :ref)))))
+
+
+;; ---------------------------------------------------------------------------
+;; The codec's one policy call — intent lowering happens inside the walk
+;; ---------------------------------------------------------------------------
+
+(deftest event-vectors-in-attributes-lower-during-prop-conversion
+  (let [!seen (atom [])
+        e     (intent/with-frame (fn [ev] (swap! !seen conj ev))
+                                 (fn [] (codec/as-element
+                                         [:button {:on-click [:todo/toggle 7] :class "btn"}
+                                          "done"])))]
+    (is (= "btn" (prop e "className")))
+    (is (fn? (prop e "onClick")))
+    (is (= [] @!seen))
+    ((prop e "onClick") #js {:target #js {}})
+    (is (= [[:todo/toggle 7]] @!seen))))
+
+(deftest a-controlled-field-lowers-its-marker-through-the-codec
+  (let [!seen (atom [])
+        e     (intent/with-frame (fn [ev] (swap! !seen conj ev))
+                                 (fn [] (codec/as-element
+                                         [:input {:value "milk"
+                                                  :on-input [:todo.ui/edit 7 :re-frame.hicasso/value]}])))]
+    (is (= "milk" (prop e "value")))
+    ((prop e "onInput") #js {:target #js {:value "bread"}})
+    (is (= [[:todo.ui/edit 7 "bread"]] @!seen))))
+
+;; ---------------------------------------------------------------------------
+;; The named value at a foreign crossing (rf2-vrvv9)
+;; ---------------------------------------------------------------------------
+
+(defn- a-foreign-component
+  "Stands in for a library's component — anything React would accept as
+  an element type. Nothing renders here; the questions below are all
+  about what the codec BUILT."
+  [_js-props]
+  nil)
+
+(def ^:private a-host (codec/mint-host! "AHost" a-foreign-component))
+
+(defn- host-prop
+  "The value the codec emitted at `slot` for a one-prop host crossing.
+  Reads the GATE element's props, which are the props object the foreign
+  component receives — the gate forwards it verbatim."
+  [k v slot]
+  (prop (codec/as-element [a-host {k v}]) slot))
+
+(deftest a-namespaced-keyword-keeps-its-namespace-at-a-host-prop
+  (testing "the shape rf2-vrvv9 names. `(name :theme/dark)` is \"dark\", so
+            the namespace used to be discarded on its way to a hosted
+            React-context provider and the value arrived as a plausible
+            string that had lost half its identity."
+    (is (= :theme/dark (host-prop :value :theme/dark "value"))
+        "the keyword crosses whole — not \"dark\", not \"theme/dark\""))
+  (testing "and the collision that made the loss silent is gone. Two
+            keywords from different namespaces used to arrive as ONE
+            string; a crossing that answers two inputs with one output is
+            not a conversion."
+    (let [crossed #{(host-prop :value :theme/dark "value")
+                    (host-prop :value :other/dark "value")}]
+      (is (= 2 (count crossed))
+          "two distinct values in, two distinct values out")
+      (is (= #{:theme/dark :other/dark} crossed))))
+  (testing "an unnamespaced keyword and a symbol take the same rule — the
+            question is the position, never the shape of the name"
+    (is (= :contained (host-prop :variant :contained "variant")))
+    (is (= 'sym (host-prop :variant 'sym "variant")))))
+
+(deftest a-named-value-bound-for-an-html-attribute-still-stringifies
+  (testing "className, id and role: the value is an HTML attribute wherever
+            the component passes it on, and a string is the only
+            representation there is"
+    (is (= "primary" (host-prop :class :primary "className")))
+    (is (= "greeting" (host-prop :id :greeting "id")))
+    (is (= "dialog" (host-prop :role :dialog "role"))))
+  (testing "the data-* / aria-* families, by prefix"
+    (is (= "row" (host-prop :data-kind :row "data-kind")))
+    (is (= "close" (host-prop :aria-label :close "aria-label"))))
+  (testing "the rule is written against the emitted SLOT, never the map key
+            — `:class` and `:className` are one position, and a rule that
+            read the spelling is a rule the other spelling walks past"
+    (is (= "primary" (host-prop :className :primary "className")))
+    (is (= "primary" (host-prop "class" :primary "className"))))
+  (testing "the namespace drop survives ONLY here, and it is the same answer
+            the native walk gives at the same name"
+    (is (= "dark" (host-prop :class :theme/dark "className")))
+    (is (= "dark" (prop (codec/as-element [:div {:class :theme/dark}]) "className"))
+        "the native crossing, unchanged")))
+
+;; ---------------------------------------------------------------------------
+;; The class slot is a POSITION at the crossing too (rf2-2rtt6.119)
+;; ---------------------------------------------------------------------------
+
+(deftest a-class-collection-crosses-as-a-class-string-at-a-host-and-at-a-tag
+  (testing "THE DEVIATION rf2-2rtt6.119 names. The class slot has a coercion
+            of its own — `class-names` — and it was taken at the native
+            position only, so ONE authored shape got TWO answers. The
+            crossing sent `{:class [\"a\" nil :b]}` through `clj->js` and
+            handed the foreign component a JS array, which React writes to
+            the DOM as \"a,,b\" wherever the component passes it on: nothing
+            threw and the styling was simply wrong."
+    (let [crossed (host-prop :class ["a" nil :b] "className")
+          native  (prop (codec/as-element [:div {:class ["a" nil :b]}]) "className")]
+      (is (string? crossed)
+          "a class string, not the JS array clj->js used to build here")
+      (is (= "a b" crossed))
+      (is (= native crossed)
+          "and it is the SAME answer the native walk gives — which is the
+           rule rf2-vrvv9 already stated for the named value at this slot,
+           applied to the arm a collection takes")))
+  (testing "the coercion is on the SLOT, so it holds in every spelling of it
+            — the discipline `canonical-slot` and the owned-literal law
+            already use, and the reason a rule written against `:class`
+            would be one that `:className`, `\"class\"` and `:x/class` walk
+            past"
+    (doseq [k [:class :className "class" "className" 'class :x/class]]
+      (is (= "a b" (host-prop k ["a" nil :b] "className"))
+          (str "spelled " (pr-str k)))))
+  (testing "a nested collection joins one level down too, exactly as at a tag"
+    (is (= "a b c" (host-prop :class ["a" ["b" nil] :c] "className"))))
+  (testing "and it COMPOSES, for the reason the native position composes:
+            two spellings of one element's class are two map keys and one
+            React slot, so letting the last write win would drop a class
+            silently"
+    (let [e (codec/as-element [a-host {:class "a" :x/class ["b" :c]}])]
+      (is (= "a b c" (prop e "className"))))
+    ;; the guide's own example, asserted verbatim so the page cannot drift
+    ;; from the door (draft-guide/05-interop.md §Defaults)
+    (is (= "btn on wide"
+           (prop (codec/as-element [a-host {:class ["btn" nil :on] :className "wide"}])
+                 "className"))))
+  (testing "nothing else at the slot moves. A string is verbatim, a keyword
+            still stringifies (rf2-vrvv9's rule, unchanged), and a
+            namespaced keyword still drops its namespace HERE and only here"
+    (is (= "primary" (host-prop :class "primary" "className")))
+    (is (= "primary" (host-prop :class :primary "className")))
+    (is (= "dark" (host-prop :class :theme/dark "className")))
+    (is (nil? (host-prop :class nil "className"))))
+  (testing "and the deviation was the class slot ALONE — `id` and `role`
+            hand a collection to `clj->js` at BOTH positions, so there is
+            nothing to reconcile there and nothing here that changed them"
+    (is (array? (host-prop :id ["a" "b"] "id")))
+    (is (array? (prop (codec/as-element [:div {:id ["a" "b"]}]) "id"))
+        "the native walk's own answer, quoted so the claim is not asserted
+         about a function nobody ran")))
+
+(deftest a-declared-contract-still-outranks-the-class-coercion
+  (testing "HD-011's whole point is that a DECLARED position means what the
+            declaration says it means, so the slot coercion sits BELOW the
+            declaration in the cond rather than above it. Nobody sensible
+            declares a contract on `className`; the row exists so the
+            precedence is pinned rather than incidental — and a vector is
+            the value that tells the two orders apart, because
+            `class-names` would quietly answer it \"a b\" where the
+            declaration refuses it."
+    (let [declared (codec/mint-host! "ClassContractHost" a-foreign-component
+                                     {:callbacks {:class :handler}})]
+      (try
+        (codec/as-element [declared {:class ["a" "b"]}])
+        (is false "should have thrown")
+        (catch :default e
+          (is (= :rf.error/hicasso-intent-at-a-non-event-contract
+                 (:rf.error/id (ex-data e)))
+              "the declaration decided, not the slot")))))
+  (testing "and an undeclared host is unaffected — the same value at the
+            same slot is an ordinary class collection"
+    (is (= "a b" (host-prop :class ["a" "b"] "className")))))
+
+(deftest every-other-host-prop-value-crosses-exactly-as-it-did
+  (testing "functions by identity — `React.memo` and every downstream
+            bail-out that compares handler identity"
+    (let [f (fn [_])]
+      (is (identical? f (host-prop :on-thing f "onThing")))))
+  (testing "collections through clj->js, whose nested keys keep the spelling
+            the author wrote"
+    (let [o (host-prop :options {:pageSize 10} "options")]
+      (is (= 10 (aget o "pageSize")))))
+  (testing "strings, numbers, booleans and nil, verbatim"
+    (is (= "due date" (host-prop :label "due date" "label")))
+    (is (= 7 (host-prop :count 7 "count")))
+    (is (true? (host-prop :open true "open")))
+    (is (nil? (host-prop :label nil "label")))))
+
+;; ---------------------------------------------------------------------------
+;; What "callback refs only" actually is (rf2-d03av)
+;; ---------------------------------------------------------------------------
+
+(deftest an-object-ref-crosses-by-identity-at-both-positions
+  (testing "rf2-d03av, settled as a RECORD rather than a refusal. HD-016
+            reads 'callback refs only', and HD-022 — later, and the ruling
+            that is actually about `:ref`'s value space — says the whole of
+            the claim is ONE refusal branch and one error id: the reserved
+            vector. An object ref is neither reserved nor broken. React 19
+            carries `ref` as an ordinary prop, so `(react/createRef)`
+            attaches and detaches exactly as React documents it. It is
+            untaught rather than illegal, and refusing a spelling that
+            works correctly is friction rather than safety.
+
+            This witness is what makes that a decision instead of an
+            oversight: a later refusal cannot land silently, because it has
+            to delete these rows first."
+    (let [r (react/createRef)]
+      (is (identical? r (prop (codec/as-element [:div {:ref r}]) "ref"))
+          "a native tag")
+      (is (identical? r (host-prop :ref r "ref"))
+          "and a defhost crossing — HD-011's conversion parity, which is
+           what makes 'enforced at one crossing and not the other' the
+           outcome design C ruled out")))
+  (testing "and it is one rule at one slot, so an alternate spelling of the
+            ref position answers the same way"
+    (let [r (react/createRef)]
+      (is (identical? r (prop (codec/as-element [:div {"ref" r}]) "ref")))
+      (is (identical? r (host-prop :x/ref r "ref")))))
+  (testing "the reserved VECTOR is still refused at both, which is the rule
+            that IS enforced — so the two questions stay separable"
+    (let [reserved [::autosize {:max-rows 8}]]
+      (is (thrown-with-msg? js/Error #"RESERVED"
+                            (codec/as-element [:div {:ref reserved}])))
+      (is (thrown-with-msg? js/Error #"RESERVED"
+                            (codec/as-element [a-host {:ref reserved}]))))))
+
+;; ---------------------------------------------------------------------------
+;; The `[:>]` raw escape (HD-011, rf2-2rtt6.103)
+;; ---------------------------------------------------------------------------
+;;
+;; The escape is `defhost` with the declaration erased, so almost every
+;; row below is a PARITY row: the same fixture component, the same prop
+;; corpus, one answer. What is not parity is stated as its own row — the
+;; carrier, the head test, the value roster, and the fact that no `:ssr`
+;; policy is spellable here (the DOM/SSR half of that lives in
+;; `arm1/raw_escape_dom_cljs_test`, which needs a server renderer).
+
+(defn- raw-carrier
+  "The gate element's own props — the two-slot carrier."
+  [e]
+  (.-props e))
+
+(defn- raw-component-of [e] (aget (raw-carrier e) "c"))
+
+(defn- raw-props
+  "The props object the FOREIGN component receives: the gate hands its
+  `p` slot straight through, so this is the object under test in every
+  parity row."
+  [e]
+  (aget (raw-carrier e) "p"))
+
+(defn- raw-prop
+  "The value the escape emitted at `slot` for a one-prop crossing —
+  [[host-prop]]'s twin, so the two can be read against each other."
+  [k v slot]
+  (aget (raw-props (codec/as-element [:> a-foreign-component {k v}])) slot))
+
+(defn- crossed-same?
+  "Did the two crossings answer the same thing? Functions by identity —
+  which is the point of the row — and everything else by value, through
+  `js->clj`, because two `clj->js` results are two distinct objects and
+  `=` on those is identity."
+  [a b]
+  (if (fn? a) (identical? a b) (= (js->clj a) (js->clj b))))
+
+(defn- error-id [f]
+  (try (f) ::did-not-throw (catch :default e (:rf.error/id (ex-data e)))))
+
+(deftest the-escape-is-a-crossing-and-not-a-tag-named-angle-bracket
+  (testing "THE MIS-PARSE REGRESSION. `:>` was not an error before this:
+            `hiccup-tag?` accepted any keyword that is not `:<>`, so
+            `[:> Foo {}]` routed to the native path and asked React for
+            an element literally named `<>`"
+    (let [e (codec/as-element [:> a-foreign-component {}])]
+      (is (not= ">" (el-type e)) "not a native tag any more")
+      (is (fn? (el-type e)) "a component — the shared gate")
+      (is (= "[:>]" (.-displayName (el-type e)))
+          "named by the CONSTANT, never by the component: React resolves
+           `displayName || name || null`, Closure renames `.name` under
+           :advanced, and foreign production bundles ship without
+           displayName — so any derived identity is build-dependent")
+      (is (identical? a-foreign-component (raw-component-of e))
+          "and the component rides in the carrier's `c` slot")))
+  (testing "the head is compared with `=` and never `identical?`. A
+            keyword built at runtime is a DIFFERENT object from the
+            literal, so an identity test would work under :advanced —
+            where the build interns literals — and silently route every
+            escape back into the native path everywhere else"
+    (let [computed (keyword ">")]
+      (is (not (identical? :> computed))
+          "precondition: the row is only meaningful because these are two
+           objects")
+      (is (= "[:>]" (.-displayName (el-type (codec/as-element [computed a-foreign-component {}])))))))
+  (testing "and the arms either side of the new one are untouched"
+    (is (= (.-Fragment react) (el-type (codec/as-element [:<> "x"]))))
+    (is (= "div" (el-type (codec/as-element [:div]))))
+    (is (= "toString" (el-type (codec/as-element [:toString])))
+        "the redundant second fragment test that paid for this arm is
+         gone; a native tag still parses as itself")))
+
+(deftest conversion-parity-with-the-door-on-one-prop-corpus
+  (testing "THE LOAD-BEARING ROW. HD-011 rules that the escape lowers
+            through the SAME foreign path with the SAME default
+            conversions, and one walk serves both — so this is an
+            identity by construction and the row is a tripwire against a
+            future fork rather than a detector of a present one"
+    (let [f       (fn [_])
+          ref-fn  (fn [_node])
+          corpus  {:on-thing   f
+                   :plain-fn   f
+                   :menu-items [{:day-of-week 1}]
+                   :options    {:pageSize 10}
+                   :variant    :compact
+                   :theme      :theme/dark
+                   :class      ["btn" nil :on]
+                   :className  "wide"
+                   :aria-label :close
+                   :data-kind  :row
+                   :id         :greeting
+                   :role       :dialog
+                   :label      "due date"
+                   :count      7
+                   :open       true
+                   :ref        ref-fn}
+          door    (.-props (codec/as-element [a-host corpus]))
+          raw     (raw-props (codec/as-element [:> a-foreign-component corpus]))]
+      (is (= (vec (sort (js/Object.keys door))) (vec (sort (js/Object.keys raw))))
+          "prop for prop, the same emitted slots")
+      (doseq [k (js/Object.keys door)]
+        (is (crossed-same? (aget door k) (aget raw k))
+            (str "the slot " k " crossed the same way at both")))))
+  (testing "including the two conversions that are the slot's own rather
+            than the walk's — the class coercion (rf2-2rtt6.119) and the
+            named value bound for an HTML attribute (rf2-vrvv9)"
+    (is (= "a b" (raw-prop :class ["a" nil :b] "className")))
+    (is (= "dark" (raw-prop :class :theme/dark "className")))
+    (is (= :theme/dark (raw-prop :value :theme/dark "value"))
+        "and NOT at an ordinary slot: the keyword crosses whole"))
+  (testing "the class slot composes across spellings here too, because the
+            rule is on the SLOT and the walk is the door's"
+    (let [e (codec/as-element [:> a-foreign-component {:class "a" :x/class ["b" :c]}])]
+      (is (= "a b c" (aget (raw-props e) "className"))))))
+
+(deftest the-carrier-never-leaks-and-key-rides-the-outer-element
+  (testing "the foreign component's props carry NEITHER internal slot.
+            Carrying the component beside the converted props and
+            stripping it inside would cost a shallow copy per crossing
+            per render and leave the key one bug away from React; two
+            slots make the leak unrepresentable instead"
+    (let [p (raw-props (codec/as-element [:> a-foreign-component {:label "x"}]))]
+      (is (= ["label"] (vec (sort (js/Object.keys p)))))))
+  (testing "and the carrier itself holds exactly the two slots, plus
+            children when there are any"
+    (is (= ["c" "p"] (vec (sort (js/Object.keys (raw-carrier (codec/as-element [:> a-foreign-component {}])))))))
+    (is (= ["c" "children" "p"]
+           (vec (sort (js/Object.keys (raw-carrier (codec/as-element [:> a-foreign-component {} [:span]]))))))))
+  (testing "`:key` is React's contract on the crossing's own element, not
+            an attribute and not a carrier slot — the door's rule,
+            unchanged"
+    (let [e (codec/as-element [:> a-foreign-component {:key "k7" :label "x"}])]
+      (is (= "k7" (el-key e)))
+      ;; `Object.keys` rather than a read of `.key`: React 19 defines a
+      ;; DEV warning getter at that name on any props object it built
+      ;; from a config carrying a key, so reading it would put React's
+      ;; "`key` is not a prop" line in the shared test log — an assertion
+      ;; whose own mechanism is a console warning. The getter is
+      ;; non-enumerable, so this sees the truth without touching it.
+      (is (= ["c" "p"] (vec (sort (js/Object.keys (raw-carrier e)))))
+          "the key is React's on the element and is not a carrier slot")
+      (is (= ["label"] (vec (sort (js/Object.keys (raw-props e))))))))
+  (testing "a childless crossing does not write `children` onto the props
+            the component receives — which is what makes the parity row
+            above a claim about the object rather than about our walk"
+    (is (not (contains? (set (js/Object.keys (raw-props (codec/as-element [:> a-foreign-component {}]))))
+                        "children")))))
+
+(deftest the-escape-takes-the-doors-unclaimed-slot-conduct-exactly
+  (testing "every slot at this crossing is UNCLAIMED — the roster is
+            empty by construction — so the escape inherits `host-entry`'s
+            conduct with no branch of its own. That is what makes
+            `[:> X …]` → `(h/defhost x X {})` behaviour-preserving, which
+            is the whole theorem of the migration codemod"
+    (testing "an intent vector at an event-SPELLED slot refuses loudly"
+      (try
+        (codec/as-element [:> a-foreign-component {:on-pick [:boom]}])
+        (is false "should have thrown")
+        (catch :default e
+          (let [d (ex-data e)]
+            (is (= :rf.error/hicasso-host-undeclared-callback (:rf.error/id d)))
+            (is (= :on-pick (:position d)))
+            (is (= "[:>]" (:host d)) "the crossing names the form the author wrote")
+            (is (= #{} (:declared d)) "against an empty roster")))))
+    (testing "and so does an event-spelled key-map"
+      (is (= :rf.error/hicasso-host-undeclared-callback
+             (error-id #(codec/as-element [:> a-foreign-component {:on-key-down {"Enter" [:boom]}}])))))
+    (testing "a MARKED h/fn at any slot refuses — rf2-2rtt6.116's ruling,
+              inherited rather than forked. The mark asks the position for
+              a contract and here no position can ever select one"
+      (let [marked (intent/callback (fn [x] [:row/pick x]))]
+        (is (= :rf.error/hicasso-host-unclaimed-callback
+               (error-id #(codec/as-element [:> a-foreign-component {:on-value-change marked}]))))
+        (is (= :rf.error/hicasso-host-unclaimed-callback
+               (error-id #(codec/as-element [:> a-foreign-component {:row-formatter marked}])))
+            "the mark is the trigger, never the on* spelling")))
+    (testing "a PLAIN function crosses by identity — the fence, and the
+              reason React.memo and every downstream bail-out that
+              compares handler identity keep working"
+      (let [f (fn [_])]
+        (is (identical? f (raw-prop :on-value-change f "onValueChange")))))
+    (testing "an intent vector at a NON-event slot is ordinary data"
+      (is (= ["a" "b"] (js->clj (raw-prop :columns ["a" "b"] "columns")))))
+    (testing "`:ref` takes HD-016's rule at this crossing exactly as at the
+              door: a callback ref through, the reserved vector refused"
+      (let [r (fn [_node])]
+        (is (identical? r (raw-prop :ref r "ref"))))
+      (is (= :rf.error/hicasso-ref-vector-reserved
+             (error-id #(codec/as-element [:> a-foreign-component {:ref [::autosize {}]}])))))))
+
+(deftest the-ampersand-law-holds-at-the-escape-before-conversion
+  (testing "HD-023 clause (d): `:&` is merged BEFORE conversion and the
+            conversion that follows is the position's own. Asserted on
+            what the foreign component RECEIVED, not on the hiccup"
+    (let [p (raw-props (codec/as-element
+                         [:> a-foreign-component
+                          {:& {:className "react-name" :selected "caller"}
+                           :selected "owned"}]))]
+      (is (= "react-name" (aget p "className"))
+          "a remainder key crosses under the slot it names")
+      (is (= "owned" (aget p "selected"))
+          "and the owned literal wins, unconditionally")))
+  (testing "the deny is on the canonical SLOT, so a remainder reaches
+            neither structural slot however it is spelled"
+    (doseq [k [:key "key" :x/key]]
+      (is (nil? (el-key (codec/as-element [:> a-foreign-component {:& {k "hostile"}}])))
+          (str "forwarded as " (pr-str k))))
+    (is (nil? (aget (raw-props (codec/as-element [:> a-foreign-component {:& {:ref "hostile"} :ref (fn [_])}]))
+                    "hostile"))))
+  (testing "and the merge is the SAME one — a non-map remainder is the
+            same loud error at this crossing"
+    (is (= :rf.error/hicasso-merge-not-a-map
+           (error-id #(codec/as-element [:> a-foreign-component {:& "nope"}]))))))
+
+(deftest children-lower-eagerly-and-ride-the-outer-element
+  (testing "trailing forms lower here, in the render window of the
+            boundary that wrote the crossing, through `make-element`'s
+            existing three arms — so an intent closure in a child
+            captures the owner's frame-locked dispatch at LOWERING time
+            (the two-frame proof of that is the DOM witness)"
+    (let [one (raw-carrier (codec/as-element [:> a-foreign-component {} [:span "x"]]))]
+      (is (= "span" (.-type (aget one "children")))
+          "one child: an element, not hiccup"))
+    (let [many (raw-carrier (codec/as-element [:> a-foreign-component {} [:span "a"] [:b "c"]]))
+          kids (aget many "children")]
+      (is (array? kids))
+      (is (= ["span" "b"] (mapv #(.-type %) (vec kids))))))
+  (testing "the attribute map is optional, and the indices shift by one
+            from the door's: component at 1, props at 2 when it is a map,
+            children from 3 or from 2"
+    (let [e (codec/as-element [:> a-foreign-component [:span "no props"]])]
+      (is (= "span" (.-type (aget (raw-carrier e) "children"))))
+      (is (= [] (vec (sort (js/Object.keys (raw-props e)))))))
+    (is (some? (codec/as-element [:> a-foreign-component]))
+        "[:> Component] with neither props nor children is legal"))
+  (testing "a lowered intent inside a `[:>]` child is the ordinary
+            frame-locked one — the crossing is transparent to it"
+    (let [!seen (atom [])
+          e     (intent/with-frame (fn [ev] (swap! !seen conj ev))
+                                   (fn [] (codec/as-element
+                                            [:> a-foreign-component {}
+                                             [:button {:on-click [:go]}]])))
+          child (aget (raw-carrier e) "children")]
+      ((aget (.-props child) "onClick") #js {:target #js {}})
+      (is (= [[:go]] @!seen)))))
+
+;; --- Edge 4: the legal Component value -------------------------------------
+;;
+;; THE PINNING ROSTER, and it is not optional. The accepted set is a
+;; REPLICA of what React 19's reconciler mints a fiber for, so a React
+;; upgrade that moved the boundary would have this escape false-refusing
+;; a legal component — the worst failure a hatch can have. These rows
+;; turn that into a red row instead of a silent ship: the accepts assert
+;; that each category crosses, and the refusals assert the id AND the
+;; discriminating reason rather than merely "it threw".
+
+(defn- accepts? [c] (identical? c (raw-component-of (codec/as-element [:> c {}]))))
+
+(deftest every-category-react-mints-a-fiber-for-crosses
+  (testing "functions and classes"
+    (is (accepts? a-foreign-component))
+    (is (accepts? (fn [_]))))
+  (testing "React's built-in `Symbol.for` exotics — the reason a
+            component-keyed weak cache could not have been the mechanism:
+            ES2024 excludes REGISTERED symbols as WeakMap keys by design"
+    (is (accepts? (.-Suspense react)))
+    (is (accepts? (.-Fragment react)))
+    (is (accepts? (.-StrictMode react)))
+    (is (accepts? (.-Profiler react))))
+  (testing "and the `$$typeof`-branded wrapper objects"
+    (is (accepts? (react/memo a-foreign-component)))
+    (is (accepts? (react/lazy (fn [] (js/Promise.resolve #js {:default a-foreign-component})))))
+    (is (accepts? (react/forwardRef (fn [_p _r] nil))))
+    (let [ctx (react/createContext "unset")]
+      (is (accepts? ctx) "a context is a legal type in React 19")
+      (is (accepts? (.-Provider ctx)))
+      (is (accepts? (.-Consumer ctx)))))
+  (testing "`Suspense` and `lazy` in particular are a PAIR — lazy requires
+            a Suspense ancestor, and HD-011 names that pairing as a reason
+            the escape exists, so a roster that took one and not the other
+            would be unsound"
+    (is (some? (codec/as-element [:> (.-Suspense react) {}
+                                  [:> (react/lazy (fn [] (js/Promise.resolve #js {:default a-foreign-component}))) {}]])))))
+
+(deftest a-value-react-would-not-mint-a-fiber-for-is-refused-at-the-crossing
+  (testing "refused HERE, in the owner's render and on the server too,
+            rather than by React. React's own 'Element type is invalid'
+            is minted at fiber creation — behind the gate that is
+            post-adoption and client-only — and it names `typeof type`,
+            so a keyword, map, vector, set or record all read
+            'got: object'"
+    (testing "nil, and the bare form: the broken-import diagnosis"
+      (let [d (ex-data (try (codec/as-element [:> nil {}]) nil (catch :default e e)))]
+        (is (= :rf.error/hicasso-raw-no-component (:rf.error/id d)))
+        (is (= :hand-the-escape-a-real-component (:recovery d))))
+      (is (= :rf.error/hicasso-raw-no-component (error-id #(codec/as-element [:>])))))
+    (testing "a string or a keyword: the GRAMMAR owns tags. Reagent's
+              `[:> \"input\" …]` took its controlled-input wrapper on
+              exactly this path, so accepting one would silently drop
+              caret and IME protection at a site a migrator ports verbatim"
+      (doseq [c ["input" "div" :div]]
+        (let [d (ex-data (try (codec/as-element [:> c {}]) nil (catch :default e e)))]
+          (is (= :rf.error/hicasso-raw-not-a-component (:rf.error/id d)) (str "for " (pr-str c)))
+          (is (re-find #"computed KEYWORD head" (:reason d))
+              "and the message says what to write instead"))))
+    (testing "a defview head, which React WOULD accept — it is fn?-true,
+              so a bare 'is it a function' test mounts the shell raw, the
+              body reads rfProps, gets undefined, and receives nil props"
+      (let [d (ex-data (try (codec/as-element [:> a-view {}]) nil (catch :default e e)))]
+        (is (= :rf.error/hicasso-raw-not-a-component (:rf.error/id d)))
+        (is (= "a defview product" (:shape d)))
+        (is (re-find #"\[my-view" (:reason d)))))
+    (testing "a defhost head — the escape is for what a declaration cannot
+              express, and this one already IS a declaration"
+      (let [d (ex-data (try (codec/as-element [:> a-host {}]) nil (catch :default e e)))]
+        (is (= "a defhost product" (:shape d)))
+        (is (re-find #"\[my-host" (:reason d)))))
+    (testing "a React ELEMENT, which is a legal child and never a type"
+      (let [d (ex-data (try (codec/as-element [:> (codec/as-element [:div]) {}]) nil (catch :default e e)))]
+        (is (= "a React element" (:shape d)))
+        (is (re-find #"legal CHILD" (:reason d)))))
+    (testing "and the ClojureScript shapes React would answer
+              'got: object' for — each NAMED rather than printed, because
+              a foreign or cyclic value would blow `pr-str` inside a
+              diagnostic"
+      (doseq [[c shape] [[{:a 1} "a map"]
+                         [[:a 1] "a vector"]
+                         [#{:a} "a set"]
+                         [(list :a) "a collection"]
+                         [(js/Date.) "a foreign object"]]]
+        (let [d (ex-data (try (codec/as-element [:> c {}]) nil (catch :default e e)))]
+          (is (= :rf.error/hicasso-raw-not-a-component (:rf.error/id d)) (str "for " shape))
+          (is (= shape (:shape d))))))
+    (testing "a non-fn IFn — an r/partial, a multimethod, a keyword used
+              as a lookup — is a WORKING Reagent site that would die here
+              as an opaque object. The refusal steers to wrapping it"
+      (let [d (ex-data (try (codec/as-element [:> (reify IFn (-invoke [_ _] nil)) {}])
+                            nil (catch :default e e)))]
+        (is (= "callable, but not a function" (:shape d)))
+        (is (re-find #"\(fn \[props\]" (:reason d)))))
+    (testing "the shape is in ex-data and the discriminating reason is in
+              the message — one error id is enough because the message
+              carries the difference"
+      (is (re-find #"was handed a map in the Component position"
+                   (ex-message (try (codec/as-element [:> {:a 1} {}]) nil (catch :default e e))))))))
+
+;; ---------------------------------------------------------------------------
+;; What the codec must NOT be
+;; ---------------------------------------------------------------------------
+
+(deftest the-codec-mints-a-fresh-props-object-per-element-and-memoizes-no-element
+  (testing "two renders of the same hiccup are two elements with two props objects"
+    (let [hiccup [:div {:class "row"} "x"]
+          a      (codec/as-element hiccup)
+          b      (codec/as-element hiccup)]
+      (is (not (identical? a b)) "no element memoization — HD-006 stands")
+      (is (not (identical? (.-props a) (.-props b))) "no props-object cache")
+      (is (= (prop-names a) (prop-names b)))))
+  (testing "only the two codec-work caches grow — tags and prop names (HD-004)"
+    (codec/reset-caches!)
+    (dotimes [i 20] (codec/as-element [:div.row {:class (str "c" i)} i]))
+    (is (= {:tags 1 :props 3} (codec/cache-sizes))
+        "one tag literal; `:class` is one of the three seeded prop names, so
+         twenty renders with twenty distinct class VALUES add nothing")))
+
+;; ---------------------------------------------------------------------------
+;; The minted key warnings — development only (rf2-2rtt6.104)
+;; ---------------------------------------------------------------------------
+;;
+;; Every row below owns its own view and member NAMES, because the dedupe
+;; Set is deliberately page-lifetime and has no reset hook: "once per site"
+;; is the contract, and a fixture that reset it would be testing a
+;; different one. Distinct names are the cheaper discipline and they also
+;; make each row's site visible in its own source.
+
+(defn- named-view
+  "A distinct marked boundary head, stamped the way an arm's mint stamps
+  one, so the warning has a name to say."
+  [nm]
+  (let [f (fn [_js-props] nil)]
+    (unchecked-set f "displayName" nm)
+    (codec/mark-boundary! f)))
+
+(defn- warnings-during
+  "Everything the codec said on `console.warn` while `f` ran. The channel
+  matters: React's own key warning is a `console.error`, so a spy on the
+  wrong one would read a Hicasso row green off React's line."
+  [f]
+  (let [seen     (atom [])
+        original (.-warn js/console)]
+    (set! (.-warn js/console) (fn [& args] (swap! seen conj (apply str args))))
+    (try (f) (finally (set! (.-warn js/console) original)))
+    @seen))
+
+(defn- lowering-as
+  "Lower `hiccup` with `owner` recorded as the enclosing view, the way the
+  arm's `run-once` records it — and clear it afterwards, the way `run-once`
+  clears it in its `finally`."
+  [owner hiccup]
+  (codec/set-lowering-owner! owner)
+  (try (codec/as-element hiccup)
+       (finally (codec/set-lowering-owner! nil))))
+
+(deftest an-unkeyed-boundary-seq-warns-once-naming-the-view-the-child-and-the-index
+  (let [row  (named-view "w1.ns/row")
+        out  (warnings-during
+               #(lowering-as "w1.ns/list" [:ul (for [i (range 3)] [row {:id i}])]))
+        line (first out)]
+    (is (= 1 (count out)) "one line, not one per member")
+    (is (re-find #"w1\.ns/list" line) "the enclosing view — the fact React cannot name")
+    (is (re-find #"w1\.ns/row" line) "the member head")
+    (is (re-find #"first at index 0" line))
+    (is (re-find #":key in its props map" line) "the fix spelling, not just the complaint")
+    (is (re-find #":rf\.warning/hicasso-missing-key" line))))
+
+(deftest a-keyed-boundary-seq-is-silent-and-so-is-every-legitimate-key-shape
+  (testing "the canonical keyed list says nothing at all"
+    (let [row (named-view "w2.ns/row")]
+      (is (= [] (warnings-during
+                  #(lowering-as "w2.ns/list"
+                                [:ul (for [i (range 300)] [row {:key i}])]))))))
+  (testing "each primitive key shape individually — a warning that fired on
+            valid code would be worse than no warning"
+    (doseq [[label k] [["number" 1] ["string" "a"] ["keyword" :a]
+                       ["namespaced-keyword" :ns/a] ["negative-number" -1]
+                       ["zero" 0] ["empty-string" ""]]]
+      (let [row (named-view (str "w2b.ns/" label))]
+        (is (= [] (warnings-during
+                    #(lowering-as "w2b.ns/list" [:ul (list [row {:key k}])])))
+            (str "a " label " key is a legitimate key"))))))
+
+(deftest the-site-warns-exactly-once-however-many-renders-it-takes
+  (let [row     (named-view "w3.ns/row")
+        hiccup  [:ul (list [row {}] [row {}])]
+        first-r (warnings-during #(lowering-as "w3.ns/list" hiccup))
+        again   (warnings-during #(lowering-as "w3.ns/list" hiccup))]
+    (is (= 1 (count first-r)) "two unkeyed members of one head are one site")
+    (is (= [] again) "a second render of the same site re-fires nothing")))
+
+(deftest a-site-is-the-pair-of-the-enclosing-view-and-the-member-head
+  (testing "one view, two member heads — two sites"
+    (let [a   (named-view "w4.ns/a")
+          b   (named-view "w4.ns/b")
+          out (warnings-during
+                #(lowering-as "w4.ns/list" [:ul (list [a {}] [b {}])]))]
+      (is (= 2 (count out)) "scanning past the first offender is what finds the second")))
+  (testing "one member head, two views — two sites"
+    (let [row (named-view "w5.ns/row")
+          out (warnings-during
+                (fn []
+                  (lowering-as "w5.ns/one" [:ul (list [row {}])])
+                  (lowering-as "w5.ns/two" [:ul (list [row {}])])))]
+      (is (= 2 (count out))))))
+
+(deftest a-key-that-computed-nil-warns-because-the-emitted-element-is-keyless
+  (testing "`:key nil` and an absent `:key` mint the same keyless element, so
+            the check and the emission gate cannot disagree"
+    (let [row (named-view "w6.ns/row")
+          out (warnings-during
+                #(lowering-as "w6.ns/list" [:ul (list [row {:key nil :id 1}])]))]
+      (is (= 1 (count out)))
+      (is (re-find #"absent or nil" (first out))
+          "the author who DID write :key is pointed at the value")))
+  (testing "the conditional-key idiom that yields no key at all"
+    (let [row (named-view "w7.ns/row")
+          out (warnings-during
+                #(lowering-as "w7.ns/list"
+                              [:ul (list [row (when false {:key 1})])]))]
+      (is (= 1 (count out))))))
+
+(deftest a-mixed-seq-names-the-first-unkeyed-member
+  (let [row (named-view "w8.ns/row")
+        out (warnings-during
+              #(lowering-as "w8.ns/list"
+                            [:ul (list [row {:key 0}] [row {:key 1}]
+                                       [row {}] [row {:key 3}])]))]
+    (is (= 1 (count out)))
+    (is (re-find #"first at index 2" (first out))
+        "keyed members are scanned past and never named")))
+
+(deftest an-entity-valued-key-warns-about-the-coercion-hazard
+  (testing "a map at :key — React string-coerces it, so the child is keyed by
+            its own CONTENT and an edit silently remounts the row"
+    (let [row  (named-view "w9.ns/row")
+          out  (warnings-during
+                 #(lowering-as "w9.ns/list"
+                               [:ul (list [row {:key {:id 1 :label "a"}}])]))
+          line (first out)]
+      (is (= 1 (count out)))
+      (is (re-find #"w9\.ns/list" line))
+      (is (re-find #"carries a map at :key" line))
+      (is (re-find #"first at index 0" line))
+      (is (re-find #":rf\.warning/hicasso-entity-key" line))
+      (is (nil? (re-find #":label" line))
+          "the VALUE never reaches the console — a cyclic or throwing foreign
+           value would blow pr-str inside a diagnostic")))
+  (testing "a vector and a set are the same hazard, and two distinct sites"
+    (let [row (named-view "w10.ns/row")
+          out (warnings-during
+                #(lowering-as "w10.ns/list"
+                              [:ul (list [row {:key [1 2]}] [row {:key #{1}}])]))]
+      (is (= 2 (count out)))
+      (is (re-find #"carries a vector at :key" (first out)))
+      (is (re-find #"carries a set at :key" (second out))))))
+
+;; ---------------------------------------------------------------------------
+;; THE TOTALITY REPAIR (rf2-2rtt6.104)
+;;
+;; `check-member-key!`'s `cond` shipped with two arms and no `:else`, so every
+;; non-nil `:key` that was neither primitive nor a CLJS collection fell out of
+;; the check in silence. The foreign JS object is the shape that makes that a
+;; bug rather than a gap: every one of them string-coerces to the SAME
+;; `[object Object]`, so distinct rows share one key. The rows below pin the
+;; collision on our own lowering first, then the warning, then — just as
+;; load-bearing — the two shapes deliberately classified SAFE, because a
+;; warning that fires on a `uuid` key would teach authors to ignore it.
+;; ---------------------------------------------------------------------------
+
+(deftest a-foreign-object-key-collapses-distinct-children-onto-one-key
+  (testing "the hazard pinned on OUR lowering rather than argued from React's
+            source: two DISTINCT entities mint two elements with ONE key"
+    (let [row  (named-view "w24.ns/row")
+          seen (atom nil)]
+      (warnings-during
+        #(reset! seen (child-vec
+                        (codec/as-element
+                          [:ul (list [row {:key #js {:id 1}}]
+                                     [row {:key #js {:id 2}}])]))))
+      (is (= 2 (count @seen)))
+      (is (= "[object Object]" (el-key (first @seen)))
+          "React's `key = '' + config.key` reaches Object.prototype.toString")
+      (is (= (el-key (first @seen)) (el-key (second @seen)))
+          "two entities, one key — React reconciles them as the same child")))
+  (testing "and it warns, naming the shape without ever printing the value"
+    (let [row  (named-view "w25.ns/row")
+          out  (warnings-during
+                 #(lowering-as "w25.ns/list"
+                               [:ul (list [row {:key #js {:secret "s3cr3t"}}])]))
+          line (first out)]
+      (is (= 1 (count out)))
+      (is (re-find #"w25\.ns/list" line) "the enclosing view")
+      (is (re-find #"w25\.ns/row" line) "the member head")
+      (is (re-find #"carries a foreign object at :key" line))
+      (is (re-find #"first at index 0" line))
+      (is (re-find #":rf\.warning/hicasso-entity-key" line))
+      (is (nil? (re-find #"s3cr3t" line))
+          "the VALUE never reaches the console"))))
+
+(deftest the-diagnostic-holds-on-a-value-that-would-blow-a-printer
+  (testing "a cyclic foreign object warns rather than throwing inside the
+            warning — the check names shapes, so no arm of it can reach the
+            value that would recur"
+    (let [row    (named-view "w26.ns/row")
+          cyclic (js-obj "id" 1)]
+      (unchecked-set cyclic "self" cyclic)
+      (let [out (warnings-during
+                  #(lowering-as "w26.ns/list" [:ul (list [row {:key cyclic}])]))]
+        (is (= 1 (count out)))
+        (is (re-find #"carries a foreign object at :key" (first out)))))))
+
+(deftest every-other-non-primitive-key-shape-is-named-rather-than-dropped
+  (testing "the shapes that used to fall through the missing `:else`"
+    (doseq [[label k pattern]
+            [["boolean"  true         #"carries a boolean at :key"]
+             ["function" (fn [] 1)    #"carries a function at :key"]
+             ["date"     (js/Date. 0) #"carries a foreign object at :key"]
+             ["js-array" #js [1 2]    #"carries a foreign object at :key"]]]
+      (let [row (named-view (str "w27.ns/" label))
+            out (warnings-during
+                  #(lowering-as (str "w27.ns/list-" label)
+                                [:ul (list [row {:key k}])]))]
+        (is (= 1 (count out)) (str "a " label " key must not fall through"))
+        (is (re-find pattern (first out)) (str "a " label " key is named"))))))
+
+(deftest the-object-key-shapes-deliberately-classified-safe-stay-silent
+  (testing "a uuid string-coerces to the identifier the author MEANS, so it is
+            the canonical entity key and warning on it would be the false
+            positive that teaches authors to ignore the warning"
+    (let [row  (named-view "w28.ns/row")
+          ids  [(uuid "00000000-0000-0000-0000-000000000001")
+                (uuid "00000000-0000-0000-0000-000000000002")]
+          seen (atom nil)]
+      (is (= [] (warnings-during
+                  #(reset! seen
+                           (child-vec
+                             (codec/as-element
+                               [:ul (for [id ids] [row {:key id}])]))))))
+      (is (= "00000000-0000-0000-0000-000000000001" (el-key (first @seen)))
+          "the coercion is the identity itself — this is WHY it is classified safe")
+      (is (not= (el-key (first @seen)) (el-key (second @seen)))
+          "distinct entities keep distinct keys, which is the whole test")))
+  (testing "a symbol coerces to its own NAME, exactly as the keyword that
+            `plain-key?` already admits does"
+    (let [row (named-view "w29.ns/row")]
+      (is (= [] (warnings-during
+                  #(lowering-as "w29.ns/list"
+                                [:ul (list [row {:key 'a}] [row {:key 'ns/b}])])))))))
+
+(deftest the-scope-line-holds-in-both-directions
+  (testing "native-tag members are React's beat — there is no boundary head to name"
+    (is (= [] (warnings-during
+                #(lowering-as "w11.ns/list" [:ul (for [i (range 3)] [:li i])])))))
+  (testing "host-headed members are silent in v1"
+    (is (= [] (warnings-during
+                #(lowering-as "w12.ns/list" [:ul (list [a-host {}])])))))
+  (testing "strings, numbers and nils in a seq are not elements"
+    (is (= [] (warnings-during
+                #(lowering-as "w13.ns/list" [:ul (list "a" 1 nil false)])))))
+  (testing "a headless vector is somebody else's refusal — the check tolerates
+            it silently and leaves `vec->element`'s loud error to speak"
+    (is (= [] (warnings-during
+                #(try (lowering-as "w14.ns/list" [:ul (list [])])
+                      (catch :default _ nil)))))))
+
+(deftest every-parent-class-reaches-the-check-through-the-one-site
+  (testing "a fragment parent"
+    (let [row (named-view "w15.ns/row")]
+      (is (= 1 (count (warnings-during
+                        #(lowering-as "w15.ns/list" [:<> (list [row {}])])))))))
+  (testing "a host parent — this is what the [:>] crossing will inherit"
+    (let [row (named-view "w16.ns/row")]
+      (is (= 1 (count (warnings-during
+                        #(lowering-as "w16.ns/list" [a-host {} (list [row {}])])))))))
+  (testing "a nested seq is checked at its own level, one level at a time"
+    (let [row (named-view "w17.ns/row")]
+      (is (= 1 (count (warnings-during
+                        #(lowering-as "w17.ns/list"
+                                      [:ul (list (list [row {}]))]))))))))
+
+(deftest the-crossing-into-a-boundary-warns-where-nothing-else-can
+  (testing "`[a-view {} (for …)]` — realize-children flattens the seq into
+            direct arguments, which React marks validated and never warns
+            about, so this call site is the only signal there is"
+    (let [outer (named-view "w18.ns/outer")
+          row   (named-view "w18.ns/row")
+          out   (warnings-during
+                  #(lowering-as "w18.ns/page"
+                                [outer {} (for [_ (range 3)] [row {}])]))]
+      (is (= 1 (count out)))
+      (is (re-find #"w18\.ns/page" (first out))
+          "the owner slot is the body that WROTE the crossing seq")
+      (is (re-find #"w18\.ns/row" (first out)))))
+  (testing "a keyed crossing seq is silent"
+    (let [outer (named-view "w19.ns/outer")
+          row   (named-view "w19.ns/row")]
+      (is (= [] (warnings-during
+                  #(lowering-as "w19.ns/page"
+                                [outer {} (for [i (range 3)] [row {:key i}])]))))))
+  (testing "a crossing seq of native members is silent — the presence fixture's
+            own shape, and every `[presence {…} (for … [:div.toast {:key id}])]`
+            the guide teaches"
+    (let [tray (named-view "w20.ns/tray")]
+      (is (= [] (warnings-during
+                  #(lowering-as "w20.ns/page"
+                                [tray {:timeout-ms 300}
+                                 (for [i (range 3)]
+                                   [:div.toast {:key i} "x"])])))))))
+
+(deftest the-owner-clause-is-dropped-rather-than-guessed-when-no-body-is-lowering
+  (let [row  (named-view "w21.ns/row")
+        out  (warnings-during
+               (fn []
+                 (codec/set-lowering-owner! nil)
+                 (codec/as-element [:ul (list [row {}])])))
+        line (first out)]
+    (is (= 1 (count out)))
+    (is (re-find #"^\[hicasso\] Unkeyed boundary children: " line)
+        "no owner clause at all, rather than a stale or invented one")
+    (is (re-find #"w21\.ns/row" line) "the member head still names itself")))
+
+(deftest an-unbalanced-owner-pair-is-pinned-on-the-console
+  (testing "setting a non-nil owner over a non-nil one says the pair is unbalanced"
+    (let [out (warnings-during
+                (fn []
+                  (codec/set-lowering-owner! "w22.ns/first")
+                  (codec/set-lowering-owner! "w22.ns/second")
+                  (codec/set-lowering-owner! nil)))]
+      (is (= 1 (count out)))
+      (is (re-find #"w22\.ns/first" (first out)))
+      (is (re-find #"unbalanced" (first out)))))
+  (testing "the set/clear/set the arm actually performs is silent"
+    (is (= [] (warnings-during
+                (fn []
+                  (codec/set-lowering-owner! "w23.ns/a")
+                  (codec/set-lowering-owner! nil)
+                  (codec/set-lowering-owner! "w23.ns/b")
+                  (codec/set-lowering-owner! nil)))))))

--- a/implementation/hicasso/test/re_frame/hicasso/codec_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/codec_cljs_test.cljs
@@ -911,7 +911,7 @@
 ;; corpus, one answer. What is not parity is stated as its own row — the
 ;; carrier, the head test, the value roster, and the fact that no `:ssr`
 ;; policy is spellable here (the DOM/SSR half of that lives in
-;; `arm1/raw_escape_dom_cljs_test`, which needs a server renderer).
+;; [[re-frame.hicasso.raw-escape-dom-cljs-test]], which needs a server renderer).
 
 (defn- raw-carrier
   "The gate element's own props — the two-slot carrier."

--- a/implementation/hicasso/test/re_frame/hicasso/fallback_contents_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/fallback_contents_cljs_test.cljs
@@ -1,0 +1,376 @@
+(ns re-frame.hicasso.fallback-contents-cljs-test
+  "WHAT A `defhost` `:ssr` FALLBACK MAY CONTAIN — **THE CONTRACT**
+  (rf2-nv07k, ruled 2026-08-05).
+
+  [[re-frame.hicasso.impl.codec/mint-host-gate!]] states the rule
+  the guide teaches: *\"a fallback is inert markup — it is not a body, so
+  a subscription or an intent written there is the same loud error it
+  would be anywhere outside a boundary.\"* This namespace used to record
+  that half of it was enforced and half was not. It is now enforced, and
+  these rows are what enforces it.
+
+  ## What was wrong, and it was the ABSENCE of a rule rather than a narrow one
+
+  The fallback is walked into an element ONCE, at the declaration,
+  outside any frame. So what was refused was exactly *what that walk
+  could evaluate* — an intent vector, a `sub` call in the form, hiccup
+  that is not hiccup. A boundary head is none of those: it is a React
+  element whose body runs LATER, so the walk never looked inside it and
+  every refusal it carried was deferred past the declaration, which is
+  the one thing a mint-time walk exists to prevent. It was not a rule
+  about content at all; it was a property of the walk.
+
+  ## Two measurements decided it, and both are kept below
+
+  1. **The declared placeholder was not a value.** `mint-host-gate!`
+     walks once and reuses the element everywhere, and its stated reason
+     is *\"a placeholder that differs per site is not a placeholder\"*.
+     One declaration carrying a boundary head rendered `ALPHA` in one
+     frame, `BRAVO` in another and `ALPHA-TWO` after a write — the
+     justification falsified by what it permitted.
+     [[a-declared-placeholder-is-a-placeholder-again]] keeps that
+     measurement, taken now against an INERT fallback, where all three
+     documents are the same one.
+  2. **It did not survive the arm's own other boundary variant.** This
+     arm ships two mints:
+     [[re-frame.hicasso.impl.collector/mint-view!]] (context-fed,
+     what `defview` mints) and
+     [[re-frame.hicasso.impl.collector/mint-frame-prop-view!]]
+     (rf2-2rtt6.39). A frame-fed head reads `intent/*frame*` when its
+     ELEMENT is created — which in a fallback is mint time, where the
+     var is `nil` — so it baked `nil` in, minted happily, and threw
+     `:rf.error/no-frame-prop` one render into the server response.
+     Whether a boundary head in a fallback worked at all was therefore a
+     property of which mint it came from, which is not a rule an author
+     can hold. The refusal is walk-scoped and asks the MARKER, so it
+     catches that variant for free —
+     [[the-frame-fed-variant-is-caught-by-the-same-refusal]].
+
+  ## The ruling, and the recovery it points at
+
+  `:rf.error/hicasso-host-fallback-boundary-head`, at the declaration,
+  naming the host, the offending head and its position in the declared
+  form. The workaround this deletes — writing a provider's subtree a
+  second time as the declaration's fallback, which was `rf2-l0wfx`'s only
+  recovery — is SUPERSEDED rather than merely removed: `:ssr :render` now
+  renders the real subtree on the server, with the real context value and
+  no duplication ([[re-frame.hicasso.host-ssr-dom-cljs-test]]).
+
+  ## The mutation witnesses — both directions
+
+  **Remove the refusal** (delete `mint-host-gate!`'s call to
+  `refuse-deferring-heads-in-fallback!`) and every row in §2 and §3 goes
+  red: the heads mint again, and the frame-fed one goes back to throwing
+  mid-render rather than at the declaration.
+
+  **Over-refuse** (make `deferring-head-kind` answer a kind for anything
+  non-nil, the shape a walk that confused \"an element\" with \"a
+  deferring head\" would have) and every row in §4 goes red — one row per
+  legitimate fallback position, so the failure names which position was
+  taken away. §1 stays green under BOTH mutations, which is why it is
+  separate: it is about the walk's own evaluation and not about this
+  refusal at all.
+
+  Both were run, `codec.cljs` restored from a byte copy after each.
+
+  Runtime: `-cljs-test`, not `-dom-`. Every claim is a declaration or a
+  `renderToString`, so there is nothing here a DOM would add."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]
+            ["react-dom/server" :as react-dom-server]))
+
+(def ^:private frame-a ::fallback-contents-a)
+(def ^:private frame-b ::fallback-contents-b)
+
+;; Registered above `use-fixtures`, deliberately — the reset fixture
+;; captures its source-store baseline when the `use-fixtures` form is
+;; evaluated (the sibling suites' convention).
+
+(rf/reg-sub :hicasso.fb/title (fn [db _] (:title db)))
+
+(rf/reg-event :hicasso.fb/seed (fn [_ [_ title]] {:db {:title title}}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+(defn- fresh!
+  "Two frames holding different values, because frame isolation is what
+  the placeholder rows are read against."
+  []
+  (support/leave-act-environment!)
+  (rf/make-frame {:id frame-a})
+  (rf/make-frame {:id frame-b})
+  (rf/with-frame frame-a (rf/dispatch-sync [:hicasso.fb/seed "ALPHA"]))
+  (rf/with-frame frame-b (rf/dispatch-sync [:hicasso.fb/seed "BRAVO"])))
+
+;; ---------------------------------------------------------------------------
+;; The component behind the door, and the things a fallback might contain
+;; ---------------------------------------------------------------------------
+
+(def ^:private theme-context
+  "A context PROVIDER is the host used throughout, because it is the shape
+  that makes the fallback matter (rf2-l0wfx): a transparent wrapper
+  contributes no markup of its own, so an unadopted crossing renders the
+  fallback and nothing else."
+  (react/createContext "unset"))
+
+(h/defview fallback-view
+  "A `defview` head written into a fallback — the whole question."
+  [_]
+  [:section.fb-view [:h2.sub (collector/sub [:hicasso.fb/title])]])
+
+(def ^:private frame-fed-view
+  "The SAME body, minted through the arm's other boundary variant
+  (rf2-2rtt6.39). Minted directly rather than through `defview` because
+  `lang.clj`'s macro mints the context-fed one — which is exactly the
+  point: the two are indistinguishable in hiccup and used to disagree
+  here."
+  (collector/mint-frame-prop-view!
+    "fallback-contents/frame-fed-view"
+    (fn frame-fed-view-body [_]
+      [:section.fb-frame-fed [:h2.sub (collector/sub [:hicasso.fb/title])]])))
+
+(defn- inner-component [_props]
+  (react/createElement "i" #js {:className "inner"} "INNER"))
+
+(h/defhost inner-host
+  "A `defhost` head written into a fallback — a second deferring head, so
+  the rule is not a `defview` fact."
+  inner-component
+  {:ssr {:fallback [:em.inner-fallback "INNER-FALLBACK"]}})
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- error-id [f]
+  (try (f) ::did-not-throw (catch :default e (:rf.error/id (ex-data e)))))
+
+(defn- error-data [f]
+  (try (f) {::did-not-throw true} (catch :default e (ex-data e))))
+
+(defn- host-with-fallback
+  "One declaration, made HERE rather than at the top level, so a row that
+  is about the declaration can put its own hiccup in it."
+  [host-name fallback]
+  (codec/mint-host! host-name (.-Provider theme-context)
+                    {:ssr {:fallback fallback}}))
+
+(defn- server-html [frame hiccup]
+  (react-dom-server/renderToString
+    (mount/provider frame (codec/root-element frame hiccup))))
+
+;; ---------------------------------------------------------------------------
+;; 1 — what the mint-time WALK can see, it refuses (unchanged by the ruling)
+;;
+;; These three rows are about `as-element`'s own evaluation and not about
+;; the structural refusal beside it. They were green before rf2-nv07k was
+;; ruled and they are green after, under both mutations named in the ns
+;; docstring — which is why they are a separate deftest.
+;; ---------------------------------------------------------------------------
+
+(deftest a-fallback-refuses-what-the-mint-time-walk-can-see
+  (fresh!)
+  (testing "an intent vector — the fallback is walked outside any frame, so
+            there is no frame-locked dispatch to lower it against, and it
+            is the same loud error it would be anywhere outside a boundary"
+    (is (= :rf.error/hicasso-intent-outside-boundary
+           (error-id #(host-with-fallback "fb/intent"
+                                          [:button {:on-click [:x/y]} "go"])))))
+  (testing "a `sub` call written in the fallback FORM — evaluated where the
+            declaration is, which is outside any render"
+    (is (= :rf.error/hicasso-sub-outside-render
+           (error-id #(host-with-fallback "fb/sub"
+                                          [:div (collector/sub [:hicasso.fb/title])])))))
+  (testing "and hiccup that is not hiccup, which is the property the walk
+            was moved to the declaration FOR"
+    (is (= :rf.error/hicasso-empty-vector
+           (error-id #(host-with-fallback "fb/empty" []))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — and what it CANNOT see is now refused structurally, ahead of it
+;; ---------------------------------------------------------------------------
+
+(deftest a-deferring-head-in-a-fallback-is-refused-at-the-declaration
+  (fresh!)
+  (testing "a `defview` head — an element whose body runs later, so the
+            evaluating walk never looks inside it. The structural walk
+            does, and refuses it where the author's stack is"
+    (is (= :rf.error/hicasso-host-fallback-boundary-head
+           (error-id #(host-with-fallback "fb/view" [fallback-view {}])))))
+  (testing "and so does a `defhost` head, so the rule is about DEFERRAL and
+            not about `defview` — any head whose content the walk cannot
+            reach is refused the same way"
+    (is (= :rf.error/hicasso-host-fallback-boundary-head
+           (error-id #(host-with-fallback "fb/host" [inner-host {}])))))
+  (testing "a bare head, with no vector around it at all — a fallback is a
+            hiccup FORM, so the refusal is written against the form and
+            not against head position"
+    (is (= :rf.error/hicasso-host-fallback-boundary-head
+           (error-id #(host-with-fallback "fb/bare" fallback-view)))))
+  (testing "and a head nested arbitrarily deep, because \"inert markup\"
+            is a claim about the whole form"
+    (is (= :rf.error/hicasso-host-fallback-boundary-head
+           (error-id #(host-with-fallback
+                        "fb/deep"
+                        [:div.skeleton
+                         [:p "loading"]
+                         [:section [:span [fallback-view {}]]]]))))
+    (is (= :rf.error/hicasso-host-fallback-boundary-head
+           (error-id #(host-with-fallback
+                        "fb/seq"
+                        [:ul (for [i (range 2)]
+                               [:li {:key i} [fallback-view {}]])]))))))
+
+(deftest the-refusal-names-the-host-the-head-and-the-position
+  (fresh!)
+  (testing "a message that says only \"a boundary head\" leaves an author
+            grepping a fallback they wrote three screens ago. All three
+            facts are in the ex-data and all three are in the message"
+    (let [data (error-data #(host-with-fallback
+                              "fb/named"
+                              [:div.skeleton [:span [fallback-view {}]]]))]
+      (is (= :rf.error/hicasso-host-fallback-boundary-head (:rf.error/id data)))
+      (is (= "fb/named" (:host data)) "the host whose declaration is at fault")
+      (is (= "re-frame.hicasso.fallback-contents-cljs-test/fallback-view"
+             (:head data))
+          "the offending head, by the displayName its mint stamped")
+      (is (= "defview" (:kind data)) "and which door minted it")
+      (is (= [1 1 0] (:position data))
+          "the index route into the DECLARED form — the div's child 1 is the
+           span, whose child 1 is the offending vector, whose head is at 0")
+      (is (= :write-inert-hiccup-or-declare-ssr-render (:recovery data))
+          "and the recovery names the supersession, not just the ban")
+      (is (re-find #"fb/named" (ex-message (try (host-with-fallback
+                                                  "fb/named"
+                                                  [:div.skeleton
+                                                   [:span [fallback-view {}]]])
+                                                (catch :default e e))))
+          "and the MESSAGE carries them too — ex-data is for a test, the
+           message is for the author")))
+  (testing "the `defhost` case names its own door"
+    (let [data (error-data #(host-with-fallback "fb/named-host" [inner-host {}]))]
+      (is (= "defhost" (:kind data)))
+      (is (= "re-frame.hicasso.fallback-contents-cljs-test/inner-host"
+             (:head data)))
+      (is (= [0] (:position data)) "head position of the fallback itself"))))
+
+(deftest a-declared-placeholder-is-a-placeholder-again
+  (fresh!)
+  (testing "THE MEASUREMENT THAT DECIDED IT, kept and inverted. One
+            declaration is walked ONCE into ONE element and reused at
+            every site, and `mint-host-gate!`'s reason for that is \"a
+            placeholder that differs per site is not a placeholder\". A
+            boundary head made it differ per site AND per write — three
+            different documents from one declaration. With the head
+            refused, the reason holds: the SAME document in two isolated
+            frames and again after a write"
+    (let [head (host-with-fallback "fb/inert" [:section.fb-inert "SKELETON"])
+          in-a (server-html frame-a [:div.page [head {:value "dark"}]])
+          in-b (server-html frame-b [:div.page [head {:value "dark"}]])]
+      (is (re-find #"SKELETON" in-a) (str "the placeholder rendered: " in-a))
+      (is (= in-a in-b)
+          (str "the SAME declared placeholder in a frame holding a different "
+               "value — identical bytes, which is what a placeholder is: "
+               in-a " vs " in-b))
+      (rf/with-frame frame-a (rf/dispatch-sync [:hicasso.fb/seed "ALPHA-TWO"]))
+      (let [after (server-html frame-a [:div.page [head {:value "dark"}]])]
+        (is (= in-a after)
+            (str "and a write moved nothing, because there is nothing there "
+                 "to read a frame: " after)))
+      ;; The non-vacuity control: those frames really do differ, so the
+      ;; equality above is a fact about the placeholder and not about a
+      ;; fixture that never varied.
+      (is (not= (server-html frame-a [:div.page [fallback-view {}]])
+                (server-html frame-b [:div.page [fallback-view {}]]))
+          "the same body in an ordinary POSITION still differs per frame —
+           the two frames are genuinely distinguishable"))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the frame-fed variant, caught by the same refusal
+;; ---------------------------------------------------------------------------
+
+(deftest the-frame-fed-variant-is-caught-by-the-same-refusal
+  (fresh!)
+  (testing "the frame-fed variant reads `intent/*frame*` when its ELEMENT is
+            created. Everywhere else that is inside an ancestor body or
+            `root-element`; in a fallback it is MINT TIME, where the var is
+            nil — so it used to bake nil in, mint happily, and throw
+            `:rf.error/no-frame-prop` one render into the server response.
+            The refusal is walk-scoped and asks the boundary MARKER, so it
+            covers this variant without knowing it exists"
+    (is (= :rf.error/hicasso-host-fallback-boundary-head
+           (error-id #(host-with-fallback "fb/frame-fed" [frame-fed-view {}])))))
+  (testing "and the throw has MOVED to the declaration, which is the whole
+            point — an author's stack now names the line they wrote"
+    (is (not= :rf.error/no-frame-prop
+              (error-id #(host-with-fallback "fb/frame-fed-2"
+                                             [frame-fed-view {}])))))
+  (testing "while the SAME view inside an ordinary body still renders — so
+            the refusal is about the fallback POSITION and not about the
+            view, and the variant is not collateral damage"
+    (let [html (server-html frame-a [:div.page [frame-fed-view {}]])]
+      (is (re-find #"ALPHA" html) (str "control: " html)))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — every legitimate fallback position, proven ONE AT A TIME
+;;
+;; A refusal is only as good as what it leaves alone. One row per shape a
+;; real placeholder is written in, so an over-broad walk fails by NAME
+;; rather than as a wall of red.
+;; ---------------------------------------------------------------------------
+
+(deftest inert-hiccup-in-every-position-still-mints
+  (fresh!)
+  (testing "a bare tag"
+    (is (some? (host-with-fallback "ok/tag" [:div.skel]))))
+  (testing "a tag with a props map"
+    (is (some? (host-with-fallback "ok/props" [:div.skel {:data-live "no"} "loading"]))))
+  (testing "nested vectors, arbitrarily deep"
+    (is (some? (host-with-fallback "ok/nested"
+                                   [:div.skel [:p [:span [:em "loading"]]]]))))
+  (testing "a seq child — the lazy position, which the walk has to descend
+            into by hand because a seq is not a vector"
+    (is (some? (host-with-fallback "ok/seq"
+                                   [:ul (for [i (range 3)] [:li {:key i} i])]))))
+  (testing "a fragment"
+    (is (some? (host-with-fallback "ok/fragment" [:<> [:span "a"] [:span "b"]]))))
+  (testing "string, number, nil and false children — every scalar
+            `as-element` accepts, none of which is a head"
+    (is (some? (host-with-fallback "ok/scalars" [:div "text" 42 nil false]))))
+  (testing "a bare string, which is legal hiccup and is not a vector at all"
+    (is (some? (host-with-fallback "ok/string" "loading"))))
+  (testing "an already-built React element, which the walk must pass over
+            rather than descend into"
+    (is (some? (host-with-fallback
+                 "ok/element"
+                 (react/createElement "div" #js {:className "skel"} "loading")))))
+  (testing "a props map whose VALUES are collections — the walk descends
+            through renderable positions, and a props map is not one"
+    (is (some? (host-with-fallback "ok/prop-values"
+                                   [:div.skel {:class ["a" "b"] :data-n 3}])))))
+
+(deftest an-inert-fallback-still-renders-what-it-always-rendered
+  (fresh!)
+  (testing "the refusal is a declaration-time check and changes nothing
+            about what a legal fallback puts in the server response"
+    (let [head (host-with-fallback "ok/render"
+                                   [:div.skel {:data-live "no"}
+                                    [:span.a "loading"]
+                                    (for [i (range 2)] [:i.dot {:key i} "."])])
+          html (server-html frame-a [:div.page [head {:value "dark"}]])]
+      (is (re-find #"class=\"skel\"" html) (str "the fallback is there: " html))
+      (is (re-find #"loading" html))
+      (is (= 2 (count (re-seq #"class=\"dot\"" html)))
+          (str "including both rows of the seq: " html)))))

--- a/implementation/hicasso/test/re_frame/hicasso/hframe_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/hframe_cljs_test.cljs
@@ -1,0 +1,362 @@
+(ns re-frame.hicasso.hframe-cljs-test
+  "`h/frame` — THE AUTHOR-FACING FRAME READ (rf2-841vn).
+
+  The design is tracked at `docs/design/hicasso/studio/hframe-design.md`,
+  ruled BUILD. This file is its node half: everything the primitive does
+  that is not React's is answerable here, and the `-dom` sibling
+  ([[re-frame.hicasso.hframe-dom-cljs-test]]) then proves React drives
+  *this* seam rather than re-proving what the seam does.
+
+  ## The one thing worth saying about why these rows are not vacuous
+
+  Two of them are claims of ABSENCE — that `h/frame` is not a tracked
+  read, and that it never enters core's ambient resolution chain — and an
+  absence proved by a green row that would have been green anyway is not
+  proof. So each is paired with the positive reading that would have
+  moved: [[the-frame-read-registers-no-edge]] takes the read set of a body
+  that reads a subscription and shows adding `h/frame` leaves it
+  identical, and [[the-frame-read-does-not-go-through-cores-ambient-chain]]
+  asserts core's own resolver answering **nil** in the very extent where
+  `h/frame` answers — which is the refusal (rf2-2rtt6.122) doing its job
+  one line away from the value being read.
+
+  The CARRY under refusal — `rf/capture-frame` inside a body — is a fact
+  about the refusal rather than about this primitive (rf2-hnrww), and the
+  package's refusal witness is the bead that owns it."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.context :as adapter-context]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.intent :as intent]
+            [re-frame.hicasso.todo-support :as todo]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     ;; `:ambient-frame nil` for the reason the refusal suite gives: the
+     ;; fixture's default leaves a dynamic-var stamp in scope, and tier 1
+     ;; wins over everything — so a row claiming core's chain answers
+     ;; nothing inside a body would pass for the wrong reason.
+     :ambient-frame nil
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+(def ^:private frame-a ::hframe-a)
+(def ^:private frame-b ::hframe-b)
+
+(defn- frames! []
+  (todo/make-frame! frame-a 3)
+  (todo/make-frame! frame-b 3)
+  (todo/reseed! frame-a 3)
+  (todo/reseed! frame-b 3)
+  nil)
+
+(defn- outcome
+  "The thrown ex-data, or `::no-throw` with the value — so a row that
+  silently succeeds fails with what it silently produced."
+  [thunk]
+  (try [::no-throw (thunk)]
+       (catch :default e (ex-data e))))
+
+(defn- read-in-body
+  "Run `body-fn` as a boundary body for `frame-kw` and answer whatever it
+  put in the volatile it was handed. `collector/render-body` is the
+  shell's own fence minus React, which contributes nothing to any claim
+  here."
+  [frame-kw body-fn]
+  (let [seen (volatile! ::unset)]
+    (collector/render-body frame-kw (fn [_] (body-fn seen) [:li]) {})
+    @seen))
+
+(defn- with-context-frame
+  "Publish `frame-kw` on the SHARED React frame-context slot for `thunk`'s
+  extent, then restore — the tier-2 publication React performs while
+  rendering under a `frame-provider`, and what the installed adapter's
+  `:adapter/current-frame` reader reads.
+
+  Only one row needs it, and that row needs it badly: without the slot
+  published, core's resolver answers nil inside a body *anyway*, so
+  [[the-frame-read-does-not-go-through-cores-ambient-chain]] would be
+  green against a tree with no refusal in it at all."
+  [frame-kw thunk]
+  (let [^js ctx  adapter-context/frame-context
+        original (.-_currentValue ctx)]
+    (set! (.-_currentValue ctx) frame-kw)
+    (try (thunk)
+         (finally (set! (.-_currentValue ctx) original)))))
+
+;; ---------------------------------------------------------------------------
+;; W1 — it answers the rendering boundary's frame
+;; ---------------------------------------------------------------------------
+
+(deftest the-frame-read-answers-the-rendering-boundarys-frame
+  (frames!)
+  (testing "the whole primitive, in one line: inside a body it is the id
+           keyword of the boundary React is rendering"
+    (is (= frame-a (read-in-body frame-a (fn [seen] (vreset! seen (intent/hframe)))))))
+
+  (testing "and it FOLLOWS the boundary — the same body run for a second
+           frame answers the second frame. A read that was constant per
+           process, or per first-mount, would pass the row above and be
+           useless to the case the primitive exists for: one reusable view
+           mounted under N frames"
+    (is (= frame-b (read-in-body frame-b (fn [seen] (vreset! seen (intent/hframe))))))))
+
+;; ---------------------------------------------------------------------------
+;; W3 — outside a render extent it is loud, and the text is layer-routed
+;; ---------------------------------------------------------------------------
+
+(deftest the-frame-read-outside-a-render-extent-is-loud
+  (frames!)
+  (testing "no extent, no answer — never a guessed frame and never nil"
+    (let [data (outcome intent/hframe)]
+      (is (= :rf.error/hicasso-frame-outside-boundary (:rf.error/id data))
+          (str "expected the loud error; got " (pr-str data)))
+      (is (= :read-the-frame-inside-a-boundary-render (:recovery data)))
+      (is (= 'front.intent/hframe (:where data)))))
+
+  (testing "and the message ROUTES BY LAYER rather than saying 'do it
+           inside a body'. The overwhelmingly common way to reach this
+           error is mis-layered async work, whose fix is not to move the
+           call — it is to move the work"
+    (let [reason (:reason (outcome intent/hframe))]
+      (is (string? reason))
+      (is (re-find #"EVENT layer" reason)
+          "the first thing it names is where async work belongs")
+      (is (re-find #":dispatch-later" reason)
+          "with the framework's own spelling for a delay")
+      (is (re-find #"capture-frame <frame-id>" reason)
+          "and the scope-free door for code that already knows its frame")))
+
+  (testing "the same read inside a body is fine, so the row above is
+           pinning the boundary of the extent rather than a broken call"
+    (is (= frame-a (read-in-body frame-a (fn [seen] (vreset! seen (intent/hframe))))))))
+
+;; ---------------------------------------------------------------------------
+;; W4 — inside a render callback it answers the SUPPLYING boundary
+;; ---------------------------------------------------------------------------
+
+(deftest a-render-callback-reads-the-supplying-boundarys-frame
+  (frames!)
+  (testing "rf2-2rtt6.74's owner rule, reached through `h/frame`. A render
+           callback is minted during the supplying boundary's body and
+           INVOKED later by a foreign component — so the frame it must
+           answer is the owner's. This is the position that makes the
+           choice of `intent/*frame*` over the runtime's own render slot
+           load-bearing: the runtime slot is nil here, because the foreign
+           render runs outside the render pass"
+    (let [callback (volatile! nil)
+          seen     (volatile! ::unset)]
+      ;; Lowered at a NON-event position inside frame-a's body, which is
+      ;; what gives it the render contract.
+      (collector/render-body frame-a
+                             (fn [_]
+                               (vreset! callback
+                                        (intent/lower-prop
+                                          :render-row
+                                          (intent/callback (fn [] (vreset! seen (intent/hframe))))))
+                               [:li])
+                             {})
+      (is (some? @callback) "precondition: the render position lowered a wrapper")
+
+      (testing "invoked from outside any extent at all — the foreign
+               component's own render"
+        (is (not (collector/rendering?))
+            "the premise, asserted rather than described: the runtime's own
+             render slot is EMPTY at the moment the callback runs, so a
+             `h/frame` built on `rstate.frame` would answer nothing here.
+             This is design §3's load-bearing sentence, made measurable")
+        (@callback)
+        (is (= frame-a @seen)))
+
+      (testing "and invoked while a DIFFERENT frame is the ambient one, it
+               still answers the owner's. A foreign component has no frame
+               of its own and frames are isolated contexts, so the
+               supplying boundary is the only frame that can own this call"
+        (vreset! seen ::unset)
+        (intent/with-frame frame-b (collector/frame-dispatch frame-b) (fn [] (@callback)))
+        (is (= frame-a @seen)
+            "the invoker's frame must not colonise the owner's callback")))))
+
+;; ---------------------------------------------------------------------------
+;; W5 (the edge half) — not a tracked read
+;; ---------------------------------------------------------------------------
+
+(deftest the-frame-read-registers-no-edge
+  (frames!)
+  (testing "a body whose ONLY read is `h/frame` records no sub-key at all.
+           Reads become edges because they are sub-KEYS; the frame is not
+           one — it is render-constant per boundary and resolved once by
+           the shell"
+    (collector/render-body frame-a (fn [_] [:li (str (intent/hframe))]) {})
+    (is (= [] (vec (collector/reads-of (collector/last-reads))))))
+
+  (testing "and adding it to a READING body changes the read set not at
+           all — same keys, same order. The control is the point: the
+           first row alone would be green for a body that read nothing
+           for any reason"
+    (collector/render-body frame-a
+                           (fn [_] [:li (str (collector/sub [:hicasso.todo/done? 0]))])
+                           {})
+    (let [without (vec (collector/reads-of (collector/last-reads)))]
+      (collector/render-body frame-a
+                             (fn [_]
+                               [:li (str (intent/hframe))
+                                (str (collector/sub [:hicasso.todo/done? 0]))])
+                             {})
+      (let [with (vec (collector/reads-of (collector/last-reads)))]
+        (is (= 1 (count without)) "precondition: the control body read exactly one key")
+        (is (= without with)
+            (str "the frame read must contribute nothing to the collector: "
+                 (pr-str without) " vs " (pr-str with)))))))
+
+;; ---------------------------------------------------------------------------
+;; It is not core's ambient chain, which is what makes it deterministic
+;; ---------------------------------------------------------------------------
+
+(deftest the-frame-read-does-not-go-through-cores-ambient-chain
+  (frames!)
+  (testing "the two answers taken in the SAME extent, one line apart:
+           core's resolver says 'no ambient frame' — rf2-2rtt6.122's
+           refusal, doing exactly its job — while `h/frame` answers the
+           boundary's id. That gap is the whole reason this primitive is
+           deterministic where the ambient chain was not: it reads the
+           runtime's own binding and never enters the resolution chain, so
+           no adapter, renderer or hook publication can change its answer.
+
+           THE CONTEXT SLOT IS PUBLISHED FOR THE WHOLE ROW, and it has to
+           be. Without it core answers nil inside a body for the boring
+           reason that it would answer nil anywhere, and the row would be
+           green against a tree carrying no refusal at all — the vacuity
+           the refusal suite's own control row exists to rule out"
+    (let [seen (volatile! ::unset)]
+      (with-context-frame frame-a
+        (fn []
+          (is (= frame-a (frame/resolve-current-frame))
+              "control: tier 2 is genuinely answering out here, so the nil
+               below is the withdrawal and not an empty chain")
+          (collector/render-body frame-a
+                                 (fn [_]
+                                   (vreset! seen {:core   (frame/resolve-current-frame)
+                                                  :hframe (intent/hframe)})
+                                   [:li])
+                                 {})))
+      (is (nil? (:core @seen))
+          "core's ambient resolver is withdrawn for the extent")
+      (is (= frame-a (:hframe @seen))
+          "and `h/frame` answers anyway"))))
+
+;; ---------------------------------------------------------------------------
+;; The composition — the ruled carry spelling (design §2(3))
+;; ---------------------------------------------------------------------------
+
+(deftest the-composed-carry-fires-into-its-own-frame-after-the-render
+  (frames!)
+  (testing "`(rf/capture-frame (h/frame))` is the ruled spelling, and this
+           is what it buys: a closure built during a body and fired long
+           after the render's dynamic extent has unwound still dispatches
+           into the boundary's own frame. Two frames side by side, one
+           body, so a capture that reached for an ambient frame at FIRE
+           time — or captured a process-wide one — lands in the wrong
+           place and this row says so"
+    (let [carry (fn [frame-kw]
+                  (let [held (volatile! nil)]
+                    (collector/render-body frame-kw
+                                           (fn [_]
+                                             (vreset! held (rf/capture-frame (intent/hframe)))
+                                             [:li])
+                                           {})
+                    @held))
+          a     (carry frame-a)
+          b     (carry frame-b)]
+      (is (= frame-a (:frame a)))
+      (is (= frame-b (:frame b)))
+
+      (testing "and each dispatches into ITS OWN frame, after the extent
+               has gone"
+        (is (nil? intent/*frame*) "precondition: no render extent is live here")
+        ((:dispatch-sync a) [:hicasso.todo/toggle 0])
+        (is (true? @(rf/subscribe [:hicasso.todo/done? 0] {:frame frame-a})))
+        (is (false? @(rf/subscribe [:hicasso.todo/done? 0] {:frame frame-b}))
+            "frames are isolated contexts — the sibling must not have moved")))))
+
+;; ---------------------------------------------------------------------------
+;; The configuration where the ambient carry used to answer the WRONG frame
+;; ---------------------------------------------------------------------------
+
+(deftest a-carried-outer-scope-refuses-rather-than-answering-the-wrong-frame
+  (frames!)
+  (testing "FOUND while grounding the SSR rows and pinned as a DEFECT
+           (rf2-nqj22); this row is its inversion, not a new claim.
+           rf2-2rtt6.122's refusal withdrew the ambient FIND and never the
+           CARRYING, so a tier-1 stamp — an enclosing `rf/with-frame` — still
+           answered inside a body. Core was behaving exactly as EP-0002
+           specifies: frame identity is carried, and that stamp WAS carried.
+
+           But the boundary renders a different frame, and everything else in
+           the body targets THAT one: the collector's reads, the lowered
+           intents, the presence tray. One body, two frames, chosen by which
+           spelling the author reached for, and silent. Frames are ISOLATED
+           contexts, so the extent now declares its own frame to core and a
+           mismatched stamp refuses instead of quietly winning.
+
+           `h/frame` and the composed carry are unchanged — they read the
+           boundary's own binding and never enter core's chain at all, which
+           is exactly what the primitive is for"
+    (let [seen (volatile! ::unset)]
+      (rf/with-frame frame-b
+        (collector/render-body frame-a
+                               (fn [_]
+                                 (vreset! seen {:ambient  (outcome #(rf/capture-frame))
+                                                :composed (rf/capture-frame (intent/hframe))
+                                                :hframe   (intent/hframe)})
+                                 [:li])
+                               {}))
+      (is (= :rf.error/ambient-frame-refused (:rf.error/id (:ambient @seen)))
+          (str "the ambient carry must refuse rather than answer the ENCLOSING
+                scope; got " (pr-str (:ambient @seen))))
+      (is (= frame-b (:carried-frame (:ambient @seen)))
+          "naming the stamp that was carried")
+      (is (= frame-a (:extent-frame (:ambient @seen)))
+          "and the frame the boundary is rendering")
+      (is (= frame-a (:hframe @seen))
+          "while the boundary is unambiguously rendering under its own frame")
+      (is (= frame-a (:frame (:composed @seen)))
+          "and the composed spelling carries the boundary's — which is the
+           whole of what `h/frame` buys here, and is the spelling that was
+           already correct before the refusal reached this case"))))
+
+;; ---------------------------------------------------------------------------
+;; W9 — an event-time read is not silently wrong
+;; ---------------------------------------------------------------------------
+
+(deftest a-frame-read-inside-an-event-handler-raises
+  (frames!)
+  (testing "the router binds CORE's scope for a handler, not the runtime's,
+           so a handler that reaches for `h/frame` has no render extent and
+           gets the loud error rather than a stale or guessed frame. This
+           is the mis-layering the error text routes: the handler already
+           has its frame, in its ctx"
+    (let [caught (volatile! ::unset)]
+      (rf/reg-event :hicasso.hframe/at-event-time
+                    (fn [_ctx _e]
+                      (vreset! caught (outcome intent/hframe))
+                      {}))
+      (rf/with-frame frame-a (rf/dispatch-sync [:hicasso.hframe/at-event-time]))
+      (is (= :rf.error/hicasso-frame-outside-boundary (:rf.error/id @caught))
+          (str "expected the loud error inside the handler; got " (pr-str @caught)))))
+
+  (testing "and CORE's scope WAS live inside that same handler the whole
+           time — so the row above pins that the two scopes are different
+           things, not that the dispatch happened to be frameless"
+    (let [seen (volatile! ::unset)]
+      (rf/reg-event :hicasso.hframe/core-scope-at-event-time
+                    (fn [_ctx _e]
+                      (vreset! seen (frame/resolve-current-frame))
+                      {}))
+      (rf/with-frame frame-a (rf/dispatch-sync [:hicasso.hframe/core-scope-at-event-time]))
+      (is (= frame-a @seen)
+          "the router binds core's per-handler scope; the runtime's render
+           binding is a different var with a different extent"))))

--- a/implementation/hicasso/test/re_frame/hicasso/hframe_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/hframe_dom_cljs_test.cljs
@@ -1,0 +1,457 @@
+(ns re-frame.hicasso.hframe-dom-cljs-test
+  "`h/frame` AGAINST A REAL REACT ROOT (rf2-841vn).
+
+  The node sibling ([[re-frame.hicasso.hframe-cljs-test]]) settles what
+  the primitive does. Four claims are left over, and each is a claim
+  about REACT rather than about the read, which is why they are asserted
+  against a live `createRoot` rather than reasoned about:
+
+  1. **It answers under BOTH shell variants** (W1). The context shell
+     resolves its frame through `useContext`; the frame-prop shell takes
+     it as an ordinary prop and spends one hook fewer. `h/frame` reads
+     neither — it reads the ambient the runtime binds either way — and
+     that identity is the thing worth pinning, because a variant that
+     answered differently would make the read a property of the shell.
+  2. **The documented trap, made green, plus the isolation law** (W2).
+     ONE reusable view, mounted under TWO frames, each instance building
+     `(rf/capture-frame (h/frame))` and firing it from a `setTimeout`
+     after its render has unwound. This is the case the primitive exists
+     for and the case nothing else can spell: `with-frame` and
+     `{:frame …}` both presuppose knowing the id, which a reusable view
+     does not.
+  3. **The hook ledger does not move** (W5's other half). Counted at
+     React's own dispatcher by the same probe the ≤2-hook budget uses, on
+     both shells. The ledger is a hard fence; a read that spent a hook
+     would be a finding rather than a price.
+  4. **StrictMode's double-invoke is not additive** (W6) — the same value
+     on both runs, and no second edge, entry or registration.
+  5. **The `[:>]` value-first door dispatches through a plain closure
+     over the capture** (W7, rf2-zllp8). The escape carries no
+     declaration, so its callback roster is EMPTY by construction and
+     both spellings that would otherwise carry the frame for the author
+     refuse at the prop — an intent vector is
+     `:rf.error/hicasso-host-undeclared-callback` and an `h/fn` is
+     `:rf.error/hicasso-host-unclaimed-callback`. What crosses is an
+     ordinary function, by identity, and an ordinary function carries no
+     frame. This is the edge `h/frame` names in its own docstring as the
+     one it exists for: *\"a value-first callback on a foreign
+     component\"*.
+
+  ## The mutation witness for W7
+
+  Lock both captures to one frame — `(rf/capture-frame frame-a)` in
+  place of `(rf/capture-frame (h/frame))` in
+  [[escape-picker]] — and
+  [[the-escapes-value-first-door-dispatches-through-a-plain-closure-over-the-capture]]
+  goes red on the second click, which toggles the first frame back off
+  and leaves the pair reading `false`/`false`. That is why the row
+  clicks BOTH crossings: one click alone is green under a capture that
+  resolved one frame for both. Give the escape's roster a contract at
+  `:on-pick` and the premise rows go red before anything mounts; hand
+  the crossing a marked `h/fn` that survives, and the second one does.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every claim degrades to a stated skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.hicasso.hook-probe :as probe]
+            [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.intent :as intent]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.todo-support :as todo]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]
+            ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     ;; The hook-ledger fixture's reason, and it bites harder here: the
+     ;; default leaves a dynamic-var frame stamp in scope, which tier 1
+     ;; would answer — so an isolation miss could read as a rendering
+     ;; difference rather than as the failure it is.
+     :ambient-frame nil
+     ;; The MAP shape, because W2 is `async`: the whole point of that row
+     ;; is a closure firing from a real macrotask, long after the render's
+     ;; dynamic extent has unwound, and `cljs.test` refuses an async test
+     ;; under a fn-form fixture outright — "Async tests require fixtures to
+     ;; be specified as maps. Testing aborted." — which aborts the WHOLE
+     ;; browser run at this namespace, not just this file.
+     :async?        true
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+(def ^:private frame-a ::hframe-dom-a)
+(def ^:private frame-b ::hframe-dom-b)
+
+(def ^:private todos 4)
+
+(defn- skip! [why] (is true (str "this claim needs a real React DOM — " why)))
+
+(defn- unwitnessed! []
+  (is false (str "React's internals slot was not found, so the hook count is "
+                 "UNWITNESSED on this build. A gate nobody has watched fire is "
+                 "not evidence — fix "
+                 (pr-str 're-frame.hicasso.hook-probe)
+                 " rather than reading this as a pass.")))
+
+(defn- frames! []
+  (support/leave-act-environment!)
+  (todo/make-frame! frame-a todos)
+  (todo/make-frame! frame-b todos)
+  (todo/reseed! frame-a todos)
+  (todo/reseed! frame-b todos)
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; The two variants of ONE body — the frame-prop suite's own construction
+;; ---------------------------------------------------------------------------
+
+(defn- printing-body
+  "Prints the frame `h/frame` answered, and reads one subscription beside
+  it so the boundary is an ordinary reading boundary rather than a
+  degenerate one."
+  [{:keys [id]}]
+  [:span.row {:data-frame (str (intent/hframe))
+              :data-done  (str (collector/sub [:hicasso.todo/done? id]))}])
+
+(h/defview context-row
+  "The incumbent shell: the frame arrives through `useContext`."
+  [props]
+  (printing-body props))
+
+(def frame-prop-row
+  "The challenger shell: the frame arrives as `rfFrame` on the element,
+  and the shell spends one hook fewer."
+  (collector/mint-frame-prop-view! "hframe-frame-prop-row" printing-body))
+
+(defn- frame-attr [handle]
+  (some-> (.querySelector (:container handle) ".row") (.getAttribute "data-frame")))
+
+;; ---------------------------------------------------------------------------
+;; W1 — the same answer under both shells
+;; ---------------------------------------------------------------------------
+
+(deftest the-frame-read-answers-under-both-shell-variants
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (frames!)
+      (testing "the context shell"
+        (let [handle (mount/root! (mount/fresh-container!) frame-a [context-row {:id 0}])]
+          (try (is (= (str frame-a) (frame-attr handle)))
+               (finally (mount/release! handle)))))
+
+      (testing "the frame-prop shell — a different route to the frame, one
+               hook fewer, and the SAME answer. `h/frame` reads the ambient
+               the runtime binds either way, so a difference here would mean
+               the read had become a property of the shell"
+        (let [handle (mount/root! (mount/fresh-container!) frame-a [frame-prop-row {:id 0}])]
+          (try (is (= (str frame-a) (frame-attr handle)))
+               (finally (mount/release! handle)))))
+
+      (testing "and both FOLLOW the frame — mounted under a second frame
+               each answers the second. A constant would have passed every
+               row above"
+        (doseq [[label view] [["context" context-row] ["frame-prop" frame-prop-row]]]
+          (let [handle (mount/root! (mount/fresh-container!) frame-b [view {:id 0}])]
+            (try (is (= (str frame-b) (frame-attr handle)) label)
+                 (finally (mount/release! handle)))))))))
+
+;; ---------------------------------------------------------------------------
+;; W5's other half — the hook ledger does not move
+;; ---------------------------------------------------------------------------
+
+(deftest the-frame-read-spends-no-hook-on-either-shell
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (if-not (probe/install!)
+      (unwitnessed!)
+      (do
+        (frames!)
+        (testing "the ≤2-hook shell is a hard fence, so this is counted at
+                 React's own dispatcher rather than declared. A boundary
+                 reading `h/frame` costs exactly what the ledger declares —
+                 the frame is render-constant per boundary and already
+                 resolved, so there is nothing for a hook to hold"
+          (let [handle (volatile! nil)
+                names  (probe/record!
+                         (fn [] (vreset! handle
+                                         (mount/root! (mount/fresh-container!)
+                                                      frame-a [context-row {:id 0}]))))]
+            (mount/release! @handle)
+            (is (= ["useContext" "useSyncExternalStore"] names)
+                (str "hooks React was asked for: " (pr-str names)))
+            (is (= (count collector/shell-hook-ledger) (count names))
+                "and the declared ledger is still the measured one")))
+
+        (testing "and one fewer on the frame-fed shell, unchanged — a read
+                 that had quietly taken a hook would show up as two here"
+          (let [handle (volatile! nil)
+                names  (probe/record!
+                         (fn [] (vreset! handle
+                                         (mount/root! (mount/fresh-container!)
+                                                      frame-a [frame-prop-row {:id 0}]))))]
+            (mount/release! @handle)
+            (is (= ["useSyncExternalStore"] names)
+                (str "hooks React was asked for: " (pr-str names)))
+            (is (= (count collector/frame-prop-shell-hook-ledger) (count names)))))))))
+
+;; ---------------------------------------------------------------------------
+;; W2 — the documented trap made green, and the isolation law
+;; ---------------------------------------------------------------------------
+
+(def ^:private !captures
+  "Where each mounted instance parks the capture it built. Keyed by the
+  frame it believes it is in — so an instance that read the WRONG frame
+  overwrites its sibling's slot and the row goes red on the count before
+  it ever gets to the dispatch."
+  (atom {}))
+
+(h/defview reusable
+  "ONE view, mounted under N frames — the case the primitive exists for.
+  It does not know its own frame id, which is exactly why neither
+  `rf/with-frame` nor a `{:frame …}` opt can serve it: both presuppose the
+  id. `h/frame` supplies it, and `capture-frame`'s 1-arity — which never
+  consults the ambient resolver — carries it out of the render."
+  [{:keys [id]}]
+  (let [f (intent/hframe)]
+    (swap! !captures assoc f (rf/capture-frame f))
+    [:span.row {:data-frame (str f)
+                :data-done  (str (collector/sub [:hicasso.todo/done? id]))}]))
+
+(deftest a-capture-built-in-a-body-fires-into-its-own-frame-after-the-render
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (async done
+      (frames!)
+      (reset! !captures {})
+      (let [a (mount/root! (mount/fresh-container!) frame-a [reusable {:id 0}])
+            b (mount/root! (mount/fresh-container!) frame-b [reusable {:id 0}])]
+        (is (= #{frame-a frame-b} (set (keys @!captures)))
+            (str "two mounts of ONE view must have read two different frames; got "
+                 (pr-str (keys @!captures))))
+        (is (= (str frame-a) (frame-attr a)))
+        (is (= (str frame-b) (frame-attr b)))
+        ;; A real macrotask, which is the whole point: the render's dynamic
+        ;; extent is long gone by the time these fire, and an ambient read
+        ;; taken HERE would find nothing at all.
+        (js/setTimeout
+          (fn []
+            (try
+              (is (nil? intent/*frame*)
+                  "precondition: no render extent is live inside the timeout")
+              ((:dispatch-sync (get @!captures frame-a)) [:hicasso.todo/toggle 0])
+              (mount/settle!)
+              (is (= "true" (.getAttribute (.querySelector (:container a) ".row") "data-done"))
+                  "the closure dispatched into the frame its own boundary rendered under")
+              (is (= "false" (.getAttribute (.querySelector (:container b) ".row") "data-done"))
+                  "and the sibling frame did not move — frames are isolated
+                   contexts, and a capture that had resolved a process-wide
+                   or a last-rendered frame would have moved both")
+              (finally
+                (mount/release! a)
+                (mount/release! b)
+                (done))))
+          0)))))
+
+;; ---------------------------------------------------------------------------
+;; W6 — StrictMode's double-invoke
+;; ---------------------------------------------------------------------------
+
+(def ^:private !runs (atom 0))
+(def ^:private !seen (atom []))
+
+(h/defview strict-reader
+  "Records the frame `h/frame` answered on EVERY body run, so the
+  double-invoke is a measured premise rather than an assumed one."
+  [{:keys [id]}]
+  (swap! !runs inc)
+  (swap! !seen conj (intent/hframe))
+  [:span.row {:data-done (str (collector/sub [:hicasso.todo/done? id]))}])
+
+(defn- strict-root!
+  "`mount/root!`, wrapped in `React.StrictMode`. Written here rather than
+  in the shared mount door because StrictMode is this row's variable, and
+  every other suite must keep measuring the ordinary tree."
+  [container frame-kw hiccup]
+  (let [root (react-dom-client/createRoot container)]
+    (react-dom/flushSync
+      (fn [] (.render root (react/createElement
+                             react/StrictMode nil
+                             (mount/provider frame-kw (codec/as-element hiccup))))))
+    {:root root :frame frame-kw :container container}))
+
+(deftest strictmodes-double-invoke-reads-the-same-frame-and-adds-nothing
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (frames!)
+      (reset! !runs 0)
+      (reset! !seen [])
+      (let [handle (strict-root! (mount/fresh-container!) frame-a [strict-reader {:id 0}])]
+        (try
+          (testing "the premise: React really did invoke the body twice"
+            (is (= 2 @!runs)
+                "if this reads 1 the build is not double-invoking and the
+                 assertions below are a green gate over nothing — fix the
+                 build, do not relax this"))
+          (testing "both invocations read the same frame — the ambient is
+                   bound per body RUN, so a second run re-establishes it
+                   rather than inheriting a stale or half-unwound one"
+            (is (= [frame-a frame-a] @!seen)))
+          (testing "and the read adds nothing on the second pass: one entry,
+                   one boundary, one edge per read. `h/frame` appends no
+                   sub-key, so a double-invoke cannot double anything it
+                   contributes — because it contributes nothing"
+            (let [{:keys [entries boundaries edges]} (inventory/stats)]
+              (is (= 1 entries))
+              (is (= 1 boundaries))
+              (is (= 1 edges) "the one real read, counted once")))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; W7 — the `[:>]` value-first door, and the plain closure over the capture
+;; ---------------------------------------------------------------------------
+;;
+;; W2 proves the composition survives a macrotask. This row proves it is
+;; the ONLY thing that can serve the crossing HD-011 made the escape for.
+;; `[:>]` is `defhost` with the declaration erased, and a declaration is
+;; what a callback contract lives on — so `raw-crossing`'s roster is
+;; empty by construction and every slot at this crossing is UNCLAIMED.
+;; The consequence is not a nuance, it is the whole row: the two
+;; spellings that carry a frame FOR the author are both refused here, and
+;; what remains is a plain function, which carries nothing. The frame has
+;; to be put into it by hand, in the body, where it is knowable.
+
+(def ^:private !built
+  "The closure each mounted instance BUILT, keyed by the frame its body
+  read. The other half of [[!handed]]: two atoms rather than one because
+  the claim that the door is *value-first* is a claim that these are the
+  same object."
+  (atom {}))
+
+(def ^:private !handed
+  "The `onPick` prop each instance of the foreign component was HANDED,
+  keyed by the label it was given — which is the frame its writing
+  boundary read. An instance that never crossed leaves this empty, so
+  neither the identity row nor the dispatch rows below can pass
+  vacuously."
+  (atom {}))
+
+(defn- foreign-picker
+  "A stand-in for the component an author reaches for `[:>]` to mount: it
+  is handed a callback prop, KEEPS it, and calls it from a DOM handler of
+  its own — so the invoker is foreign code running long after our render
+  returned, rather than the test reaching into a stash.
+
+  Written with `react/createElement` on purpose. A library component is
+  not ours and does not lower through this codec, and a fixture that went
+  through the codec would witness our own walk a second time instead of
+  the crossing."
+  [^js props]
+  (let [on-pick (.-onPick props)]
+    (swap! !handed assoc (.-label props) on-pick)
+    (react/createElement "button"
+      #js {:className "pick" :onClick (fn [_e] (on-pick))}
+      "pick")))
+
+(h/defview escape-picker
+  "[[reusable]]'s body at the foreign edge: ONE view, mounted under N
+  frames, that does not know its own frame id — and now has to hand a
+  dispatching closure to a caller it does not control.
+
+  `(rf/capture-frame (h/frame))` is the whole answer, and each half is
+  load-bearing. `h/frame` supplies the id a reusable view cannot name;
+  `capture-frame`'s 1-arity never consults the ambient resolver, so the
+  handle it returns is still good when the foreign component calls back."
+  [{:keys [id]}]
+  (let [f (intent/hframe)
+        d (rf/capture-frame f)
+        on-pick (fn [] ((:dispatch-sync d) [:hicasso.todo/toggle id]))]
+    (swap! !built assoc (str f) on-pick)
+    [:span.row {:data-frame (str f)
+                :data-done  (str (collector/sub [:hicasso.todo/done? id]))}
+     [:> foreign-picker {:label (str f) :on-pick on-pick}]]))
+
+(defn- refusal-id [f]
+  (try (f) ::did-not-throw (catch :default e (:rf.error/id (ex-data e)))))
+
+(defn- done-attr [handle]
+  (some-> (.querySelector (:container handle) ".row") (.getAttribute "data-done")))
+
+(defn- pick! [handle]
+  (.click (.querySelector (:container handle) ".pick"))
+  (mount/settle!)
+  nil)
+
+(deftest the-escapes-value-first-door-dispatches-through-a-plain-closure-over-the-capture
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (async done
+      (frames!)
+      (reset! !built {})
+      (reset! !handed {})
+
+      (testing "THE PREMISE, asserted rather than cited. `[:>]` is a
+                value-first door: its roster is empty by construction, so
+                the two spellings that would carry the frame for the
+                author both refuse at this very prop. That is what leaves
+                the plain closure as the only door rather than one option
+                of two — and if the escape ever grew a contract here, this
+                row goes red before the mount and the rest of W7 stops
+                being the answer to a real question"
+        (is (= :rf.error/hicasso-host-undeclared-callback
+               (refusal-id #(codec/as-element
+                              [:> foreign-picker {:on-pick [:hicasso.todo/toggle 0]}])))
+            "an intent vector at an event-spelled slot")
+        (is (= :rf.error/hicasso-host-unclaimed-callback
+               (refusal-id #(codec/as-element
+                              [:> foreign-picker
+                               {:on-pick (intent/callback (fn [] [:hicasso.todo/toggle 0]))}])))
+            "and a marked h/fn, which asks the position for a contract no
+             position here can ever select"))
+
+      (let [a (mount/root! (mount/fresh-container!) frame-a [escape-picker {:id 0}])
+            b (mount/root! (mount/fresh-container!) frame-b [escape-picker {:id 0}])]
+        (is (= #{(str frame-a) (str frame-b)} (set (keys @!handed)))
+            (str "two mounts of ONE view crossed under two different frames; got "
+                 (pr-str (keys @!handed))))
+        (testing "and what crossed is the body's own function, by
+                  IDENTITY — no wrapper of ours stands between the author
+                  and the library, which is what *value-first* names and
+                  what keeps React.memo and every handler-identity
+                  bail-out working through the escape"
+          (doseq [f [frame-a frame-b]]
+            (is (identical? (get @!built (str f)) (get @!handed (str f))) (str f))))
+
+        ;; A real macrotask, then the FOREIGN component's own click
+        ;; handler: by the time either closure runs, no render extent is
+        ;; live and there is no ambient frame anywhere to resolve.
+        (js/setTimeout
+          (fn []
+            (try
+              (is (nil? intent/*frame*)
+                  "precondition: no render extent is live inside the timeout")
+              (pick! a)
+              (is (= "true" (done-attr a))
+                  "the closure the first crossing handed the foreign
+                   component dispatched into the frame that wrote it")
+              (is (= "false" (done-attr b))
+                  "and nothing reached the other frame")
+              (pick! b)
+              (is (= ["true" "true"] [(done-attr a) (done-attr b)])
+                  "and the second crossing's closure into ITS own frame. A
+                   capture that had resolved one frame for both would have
+                   toggled that one frame twice and left this pair reading
+                   false/false — which is why BOTH crossings are clicked")
+              (finally
+                (mount/release! a)
+                (mount/release! b)
+                (done))))
+          0)))))

--- a/implementation/hicasso/test/re_frame/hicasso/host_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/host_ssr_dom_cljs_test.cljs
@@ -1,0 +1,670 @@
+(ns re-frame.hicasso.host-ssr-dom-cljs-test
+  "DEFHOST'S `:ssr` POLICY, PROVEN IN ALL THREE PLACES IT HAS TO HOLD
+  (rf2-2rtt6.85, HD-011).
+
+  HD-011 listed \"SSR placeholder\" among `defhost`'s strong defaults;
+  HD-020(d) left it inert in v0; the operator's 2026-08-04 ruling makes
+  SSR required scope. The 2026-08-04 runtime audit then found the
+  placeholder was not inert but ABSENT — `mint-host!` read `:callbacks`
+  and silently ignored every other option — so activating it is two
+  jobs: give the declaration a policy, and make an option it does not
+  know a refusal rather than a shrug.
+
+  ## The policy
+
+      (h/defhost chart Chart)                                ; :client-only
+      (h/defhost chart Chart {:ssr :client-only})            ; the same, said
+      (h/defhost chart Chart {:ssr {:fallback [:div.skel]}}) ; markup instead
+      (h/defhost themed (.-Provider ctx) {:ssr :render})     ; run it, server-side
+
+  `:client-only` renders nothing where the host sits until the client
+  has adopted the markup. `{:fallback <hiccup>}` renders that markup
+  there instead. `:render` is the author asserting that the component
+  is safe to run on the server, and it is the ONLY policy under which a
+  crossing's CHILDREN reach the server response — §3 below. There is no
+  fourth value.
+
+  WHAT MAY BE WRITTEN IN THAT FALLBACK is settled (rf2-nv07k, ruled
+  2026-08-05): a fallback is inert markup, enforced — a `defview` or
+  `defhost` head written there is refused at the declaration with
+  `:rf.error/hicasso-host-fallback-boundary-head`. The contract is
+  [[re-frame.hicasso.fallback-contents-cljs-test]]; nothing
+  in this suite depends on it beyond the one refusal row below.
+
+  ## The three places, and why ONE mechanism covers the first two policies
+
+  A `:client-only` or `{:fallback …}` declaration mints one gate — a
+  component whose single `useSyncExternalStore` answers `false` from its
+  SERVER snapshot and `true` from its client one. React reads the server
+  snapshot under `renderToString` AND again on hydration's first client
+  pass, then re-renders with the client snapshot once adoption
+  completes. So:
+
+  1. **The server render** honours the policy without a server walk
+     that knows anything about it — it honours it by rendering.
+  2. **Hydration's first client pass** produces the same markup the
+     server did, so there is nothing to reconcile. That claim is taken
+     here the only way it can be taken honestly: React is asked, via
+     `onRecoverableError` and a console/window capture, whether it
+     found a mismatch. A row that merely asserts the final DOM would
+     pass over a mismatch React silently repaired.
+  3. **A fresh `createRoot` mount** never consults a server snapshot at
+     all, so the foreign component renders on the very first pass and
+     the placeholder never flashes. Asserted on the line after
+     `root!` returns, which is inside its own `flushSync`.
+
+  ## And why `:render` needs NO mechanism at all (rf2-l0wfx)
+
+  Under `:render` the declaration mints no gate: the head's type IS the
+  foreign component. So all three places above render the SAME element
+  type with the same props, the same context and the same children —
+  one tree everywhere. There is no snapshot pair, so no mismatch by
+  identity; no adoption event, so nothing to wait for; and no type swap,
+  so NO REMOUNT.
+
+  That last one is the law that priced every rejected candidate. React
+  reconciles a position by element type, and under a gate the gate is
+  the type — so any policy whose unadopted branch returns something
+  other than the component pays a full subtree destroy-and-rebuild the
+  moment adoption swaps it. Free for a skeleton; not free for the
+  application. [[a-render-crossing-hydrates-once-and-never-remounts]] is
+  where that is measured rather than argued.
+
+  ## The mutation witnesses
+
+  Make `:client-only` render something — `gate-unadopted` answering
+  `true`, or the placeholder becoming the live element — and
+  [[client-only-hydrates-with-nothing-there-and-mounts-after-adoption]]
+  goes red on React's own mismatch report. Make `{:fallback …}` render
+  nothing — `mint-host-gate!`'s `placeholder` forced to `nil` — and
+  [[the-server-render-honours-the-policy]] goes red on the fallback
+  markup missing from the server HTML. Route `:render` through
+  `mint-host-gate!` like the other two — `mint-host!`'s
+  `keyword-identical?` branch removed — and
+  [[the-server-render-honours-the-policy]] goes red on the subtree
+  missing from the server HTML, while
+  [[a-render-crossing-hydrates-once-and-never-remounts]] goes red on the
+  second child mount the adoption swap causes. No mutation is visible to
+  more than one row, which is why there are four.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM. The declaration rows and the `renderToString` rows need no
+  DOM and run under `:node-test` too — `renderToString` is React's
+  server renderer, and the point of using it here is that it is the
+  same runtime the sibling Node entry (rf2-2rtt6.86) drives."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]
+            ["react-dom/client" :as react-dom-client]
+            ["react-dom/server" :as react-dom-server]))
+
+(def ^:private frame-id ::host-ssr)
+
+;; Registered above `use-fixtures`, deliberately — the reset fixture
+;; captures its source-store baseline when the `use-fixtures` form is
+;; evaluated (the sibling suites' convention).
+
+(rf/reg-sub :hicasso.ssr/title (fn [db _] (:title db)))
+
+(rf/reg-event :hicasso.ssr/seed (fn [_ _] {:db {:title "quarterly"}}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     ;; the hydration rows wait on a real clock, and `cljs.test`
+     ;; hard-errors on a fn-form fixture in a suite with an async test.
+     :async?        true
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+(defn- skip! [why] (is true (str "an SSR-policy DOM claim needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (support/leave-act-environment!)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [:hicasso.ssr/seed]))
+  frame-id)
+
+;; ---------------------------------------------------------------------------
+;; The foreign component, and the three declarations
+;; ---------------------------------------------------------------------------
+
+(def ^:private !renders
+  "How many times the foreign component's body ran. The server rows'
+  strongest assertion: a `:client-only` host is not merely absent from
+  the HTML, its component was never INVOKED — which is the property an
+  author relies on when the reason they declared `:client-only` is
+  that the thing reaches for `window`."
+  (atom 0))
+
+(defn- chart
+  "A stand-in for the library nobody wants running on a server: its own
+  state, its own effect, its own DOM."
+  [^js props]
+  (swap! !renders inc)
+  (let [ready-hook (react/useState "cold")
+        ready      (aget ready-hook 0)
+        set-ready  (aget ready-hook 1)]
+    (react/useEffect (fn [] (set-ready "warm") js/undefined) #js [])
+    (react/createElement "div"
+      #js {:className "chart" :data-live "yes" :data-ready ready}
+      (react/createElement "span" #js {:className "chart-label"} (.-label props))
+      (.-children props))))
+
+(h/defhost bare-chart
+  "No `:ssr` written at all — the default is what an author gets."
+  chart)
+
+(h/defhost client-only-chart chart {:ssr :client-only})
+
+(h/defhost fallback-chart chart
+  {:ssr {:fallback [:div.chart-skeleton {:data-live "no"} "loading"]}})
+
+;; --- the `:render` fixtures: a provider, and something that reads it -------
+;;
+;; A context PROVIDER is the shape that filed rf2-l0wfx, and it is the
+;; shape that makes the policy legible: it contributes no markup of its
+;; own, so under a gate its unadopted arm returns something that is not
+;; the component and the ENTIRE subtree leaves the server response with
+;; it. It is also the case where the author's assertion is trivially
+;; true — a Provider is React's own component and React's server
+;; renderer supports context fully.
+
+(def ^:private theme-context (react/createContext "unset"))
+
+(def ^:private !child-mounts
+  "How many times the counted child's mount effect ran. One is an
+  adoption; two is the destroy-and-rebuild that the type swap under a
+  gate would cause. `useEffect` never runs on the server, so a server
+  render leaves this alone and the count is purely about the client."
+  (atom 0))
+
+(defn- theme-reader
+  "A consumer BELOW the provider. The whole discriminator between
+  `:ssr :render` and the rejected `:ssr :children`: with the provider
+  above it this reads `dark`, and with only the children rendered it
+  reads the context DEFAULT."
+  [_props]
+  (react/createElement "span" #js {:className "theme-reader"}
+                       (react/useContext theme-context)))
+
+(defn- counted-reader [props]
+  (react/useEffect (fn [] (swap! !child-mounts inc) js/undefined) #js [])
+  (theme-reader props))
+
+(h/defhost themed
+  "The guide's own provider example, declared the way the ruling says to
+  declare it."
+  (.-Provider theme-context)
+  {:ssr :render})
+
+(h/defhost themed-client-only
+  "The SAME provider under the default policy — the control that keeps
+  the row below a fact about the policy rather than about the page."
+  (.-Provider theme-context))
+
+(h/defhost reader-host theme-reader {:ssr :render})
+
+(h/defhost counted-reader-host counted-reader {:ssr :render})
+
+;; ---------------------------------------------------------------------------
+;; The pages
+;; ---------------------------------------------------------------------------
+
+(h/defview client-only-page
+  "A native sibling beside the host, so \"the host is absent\" is
+  distinguishable from \"nothing rendered at all\"."
+  [_]
+  [:div.page
+   [:h1.title (collector/sub [:hicasso.ssr/title])]
+   [client-only-chart {:label (collector/sub [:hicasso.ssr/title])}]])
+
+(h/defview fallback-page
+  [_]
+  [:div.page
+   [:h1.title (collector/sub [:hicasso.ssr/title])]
+   [fallback-chart {:label (collector/sub [:hicasso.ssr/title])}]])
+
+(h/defview slotted-page
+  "Children and props still cross the door — the gate forwards its own
+  props object, so this is the regression guard for the crossing that
+  the gate now sits in front of."
+  [_]
+  [:div.page
+   [fallback-chart {:label (collector/sub [:hicasso.ssr/title])}
+    [:span.kid "slotted"]]])
+
+(h/defview provider-page
+  "THE PAGE THAT FILED rf2-l0wfx, under the policy that answers it. A
+  native sibling above the crossing so \"the subtree is absent\" stays
+  distinguishable from \"nothing rendered\", markup inside it so the
+  subtree is visible, and a consumer inside it so the context VALUE is
+  visible too."
+  [_]
+  [:div.page
+   [:h1.title (collector/sub [:hicasso.ssr/title])]
+   [themed {:value "dark"}
+    [:p.body "THE ENTIRE APPLICATION"]
+    [reader-host {}]]])
+
+(h/defview provider-page-client-only
+  "The same page under the default policy — the defect, kept live."
+  [_]
+  [:div.page
+   [:h1.title (collector/sub [:hicasso.ssr/title])]
+   [themed-client-only {:value "dark"}
+    [:p.body "THE ENTIRE APPLICATION"]
+    [reader-host {}]]])
+
+(h/defview unprovided-page
+  "The consumer with NO provider above it — what a policy that rendered
+  the children alone would have emitted, so the `dark` below is a
+  measured contrast and not an assumed one."
+  [_]
+  [:div.page [reader-host {}]])
+
+(h/defview counted-provider-page
+  "[[provider-page]] with a mount-counting consumer, for the hydration
+  row. Same shape, one extra effect."
+  [_]
+  [:div.page
+   [:h1.title (collector/sub [:hicasso.ssr/title])]
+   [themed {:value "dark"}
+    [:p.body "THE ENTIRE APPLICATION"]
+    [counted-reader-host {}]]])
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- error-id [f]
+  (try (f) ::did-not-throw (catch :default e (:rf.error/id (ex-data e)))))
+
+(defn- server-html
+  "The page as a server render — the SAME runtime, under React's server
+  renderer, which is the sibling Node entry's whole architecture
+  (rf2-2rtt6.86) reduced to one call."
+  [hiccup]
+  (react-dom-server/renderToString
+    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+
+(defn- q [root sel] (.querySelector root sel))
+
+(defn- watch-errors!
+  "Everything React has to say about a hydration, from all three
+  channels it uses. `console.error` is the one that carries the
+  mismatch diff; `onRecoverableError` is the one that carries the
+  recovery; a `window` error listener is here because React routes a
+  throw during a commit to `reportError`, where `cljs.test` cannot see
+  it and a row would read 0 failures over a live exception."
+  []
+  (let [seen     (atom [])
+        original (.-error js/console)
+        on-error (fn [e] (swap! seen conj (str "window: " (.-message e))))]
+    (set! (.-error js/console)
+          (fn [& args] (swap! seen conj (str "console.error: " (pr-str (vec args))))))
+    (.addEventListener js/window "error" on-error)
+    {:seen    seen
+     :restore (fn []
+                (set! (.-error js/console) original)
+                (.removeEventListener js/window "error" on-error))}))
+
+(defn- hydrate!
+  "`hydrateRoot` over server HTML, plainly — no `flushSync`, because the
+  claim under test is about the schedule the browser actually runs."
+  [container element seen]
+  (react-dom-client/hydrateRoot
+    container element
+    #js {:onRecoverableError
+         (fn [err _info]
+           (swap! seen conj (str "onRecoverableError: " (ex-message err))))}))
+
+;; ---------------------------------------------------------------------------
+;; 1 — the declaration (these rows run under :node-test too)
+;; ---------------------------------------------------------------------------
+
+(deftest the-default-policy-is-client-only
+  (testing "an author who writes no :ssr gets the conservative answer, and
+            an author who writes it explicitly gets the same one — a
+            foreign component is exactly the node whose render may reach
+            for `window`, and the door does not guess"
+    (is (= :client-only (codec/host-ssr bare-chart)))
+    (is (= :client-only (codec/host-ssr client-only-chart))))
+  (testing "and a declared fallback reads back as the data it was written as"
+    (is (= {:fallback [:div.chart-skeleton {:data-live "no"} "loading"]}
+           (codec/host-ssr fallback-chart)))))
+
+(deftest the-third-policy-is-render-and-it-is-an-assertion
+  (testing "rf2-l0wfx. `:render` is accepted as a bare keyword, alongside
+            the two — the author asserting that this component is safe to
+            run on the server"
+    (is (= :render (codec/host-ssr themed)))
+    (is (= :render (codec/host-ssr reader-host))))
+  (testing "and it reads back as data like every other policy, so a server
+            walk that wants to state what it is honouring still can"
+    (is (= :client-only (codec/host-ssr themed-client-only)))
+    (is (some? (codec/mint-host! "ssr/render-plus-callbacks" chart
+                                 {:callbacks {:on-pick :event} :ssr :render}))
+        "and it composes with :callbacks, which is the other option")))
+
+(deftest the-declaration-refuses-a-policy-it-cannot-honour
+  (testing "a fourth value is refused at the declaration, naming the three"
+    (is (= :rf.error/hicasso-host-bad-ssr-policy
+           (error-id #(codec/mint-host! "ssr/server" chart {:ssr :server}))))
+    (is (= :rf.error/hicasso-host-bad-ssr-policy
+           (error-id #(codec/mint-host! "ssr/true" chart {:ssr true})))))
+  (testing "and the three spellings an author reaches for INSTEAD of
+            `:render` stay refused, every one of them (rf2-l0wfx). They
+            assert a structural property nobody can check — that the
+            component is transparent — and they deliver the subtree under
+            the WRONG context value, which turns a silent absence into a
+            silent wrongness"
+    (doseq [v [:children :transparent :passthrough]]
+      (is (= :rf.error/hicasso-host-bad-ssr-policy
+             (error-id #(codec/mint-host! (str "ssr/" (name v)) chart {:ssr v})))
+          (str (pr-str v) " must stay refused"))))
+  (testing "a fallback MAP spelling of it is not a spelling of it either —
+            `:render` is a bare keyword, and a policy that admitted both
+            would be two ways to say one thing"
+    (is (= :rf.error/hicasso-host-bad-ssr-policy
+           (error-id #(codec/mint-host! "ssr/render-map" chart
+                                        {:ssr {:render true}})))))
+  (testing "an explicit nil is a value, not an absence — `:client-only` is
+            the default of an ABSENT key, and inferring it from nil is how
+            a typo becomes a policy"
+    (is (= :rf.error/hicasso-host-bad-ssr-policy
+           (error-id #(codec/mint-host! "ssr/nil" chart {:ssr nil})))))
+  (testing "a fallback map is exactly one key with a value"
+    (is (= :rf.error/hicasso-host-bad-ssr-policy
+           (error-id #(codec/mint-host! "ssr/empty" chart {:ssr {}}))))
+    (is (= :rf.error/hicasso-host-bad-ssr-policy
+           (error-id #(codec/mint-host! "ssr/nil-fb" chart {:ssr {:fallback nil}}))))
+    (is (= :rf.error/hicasso-host-bad-ssr-policy
+           (error-id #(codec/mint-host! "ssr/extra" chart
+                                        {:ssr {:fallback [:div] :timeout 3}})))))
+  (testing "and a fallback that is not hiccup fails HERE, at the
+            declaration, rather than one render into a server response —
+            it is walked once at mint, where the author's stack is"
+    (is (= :rf.error/hicasso-empty-vector
+           (error-id #(codec/mint-host! "ssr/bad-fb" chart {:ssr {:fallback []}})))))
+  (testing "as does a `defview` head written into a fallback — a fallback
+            is inert markup and that is enforced (rf2-nv07k). The full
+            contract, both directions, is
+            `arm1/fallback_contents_cljs_test`; this row is here because
+            the two halves were ruled together and the refusal is one of
+            this declaration's own"
+    (is (= :rf.error/hicasso-host-fallback-boundary-head
+           (error-id #(codec/mint-host! "ssr/live-fb" chart
+                                        {:ssr {:fallback [client-only-page {}]}}))))))
+
+(deftest the-declaration-refuses-an-option-it-does-not-know
+  (testing "`mint-host!` read :callbacks and IGNORED the rest, so a
+            misspelled policy was a setting that never applied — the same
+            defect class as an intent crossing as inert data, and it gets
+            the same refusal"
+    (is (= :rf.error/hicasso-host-unknown-option
+           (error-id #(codec/mint-host! "ssr/typo" chart {:sssr :client-only}))))
+    (is (= :rf.error/hicasso-host-unknown-option
+           (error-id #(codec/mint-host! "ssr/legacy" chart
+                                        {:callbacks {} :hydrate? true})))))
+  (testing "while the two it does know are accepted together"
+    (is (some? (codec/mint-host! "ssr/both" chart
+                                 {:callbacks {:on-pick :event}
+                                  :ssr       {:fallback [:div.s]}})))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the server render (no DOM needed; runs under :node-test too)
+;; ---------------------------------------------------------------------------
+
+(deftest the-server-render-honours-the-policy
+  (fresh!)
+  (testing ":client-only — the host region is ABSENT from the server HTML,
+            and the component was never even invoked"
+    (reset! !renders 0)
+    (let [html (server-html [client-only-page {}])]
+      (is (re-find #"quarterly" html)
+          (str "the page rendered — the sibling native node is there: " html))
+      (is (not (re-find #"class=\"chart\"" html))
+          (str "and the host region rendered NOTHING: " html))
+      (is (zero? @!renders)
+          "the foreign component's body never ran on the server, which is
+           the property an author declaring :client-only is relying on")))
+  (testing "{:fallback …} — the declared markup is what the server writes,
+            and still not the component"
+    (reset! !renders 0)
+    (let [html (server-html [fallback-page {}])]
+      (is (re-find #"chart-skeleton" html)
+          (str "the fallback hiccup is in the server HTML: " html))
+      (is (not (re-find #"data-live=\"yes\"" html))
+          (str "and the foreign component's own markup is not: " html))
+      (is (zero? @!renders)
+          "nor did its body run"))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — `:ssr :render`: the component runs, and so do its CHILDREN
+;;
+;; The defect rf2-l0wfx filed and the ruling that answers it, in one
+;; place. Every row here is a `renderToString`, so they run under
+;; `:node-test` as well.
+;; ---------------------------------------------------------------------------
+
+(deftest a-client-only-provider-deletes-its-subtree-from-the-server-render
+  (fresh!)
+  (testing "THE DEFECT, kept live (rf2-l0wfx). A provider contributes no
+            markup of its own, so under a gate its unadopted arm returns
+            something that is not the component and the whole subtree
+            leaves the server response with it — silently, because the
+            server snapshot and hydration's first client pass agree by
+            construction. This row is what `:ssr :render` exists to make
+            unnecessary, and it stays green because the DEFAULT is
+            unchanged: the door still does not guess"
+    (let [html (server-html [provider-page-client-only {}])]
+      (is (re-find #"quarterly" html)
+          (str "the page DID render — the sibling above the crossing is
+                there, so an absent subtree is an absent subtree: " html))
+      (is (not (re-find #"THE ENTIRE APPLICATION" html))
+          (str "and the provider took its children with it: " html))
+      (is (not (re-find #"theme-reader" html))
+          (str "including the consumer below it: " html)))))
+
+(deftest a-render-crossing-puts-the-component-and-its-children-on-the-server
+  (fresh!)
+  (testing "the component itself renders server-side — the assertion the
+            declaration makes, honoured"
+    (let [html (server-html [provider-page {}])]
+      (is (re-find #"quarterly" html) (str "sanity — the page rendered: " html))
+      (is (re-find #"THE ENTIRE APPLICATION" html)
+          (str "THE SUBTREE IS IN THE SERVER RESPONSE. This is the whole of
+                rf2-l0wfx: " html))
+      (is (re-find #"class=\"body\"" html)
+          (str "as markup, not as stray text: " html))))
+  (testing "AND THE CONTEXT VALUE IS THE DECLARED ONE, which is what
+            separates this policy from `:ssr :children`. A consumer under
+            the provider reads `dark`; the same consumer with no provider
+            above it reads the context DEFAULT, and a policy that rendered
+            only the children would have emitted exactly that"
+    (let [provided   (server-html [provider-page {}])
+          unprovided (server-html [unprovided-page {}])]
+      (is (re-find #"<span class=\"theme-reader\">dark</span>" provided)
+          (str "the consumer read the DECLARED value: " provided))
+      (is (re-find #"<span class=\"theme-reader\">unset</span>" unprovided)
+          (str "the contrast, measured rather than assumed — with no
+                provider above it the same consumer reads the default: "
+               unprovided))
+      (is (not= provided unprovided)
+          "so the two are genuinely distinguishable in the bytes")))
+  (testing "and a `:render` host with no children of its own is not a
+            special case — the policy is about the TYPE, not about arity"
+    (let [html (server-html [unprovided-page {}])]
+      (is (re-find #"class=\"theme-reader\"" html)
+          (str "a childless `:render` crossing rendered its component: "
+               html)))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — a fresh mount: no placeholder, ever
+;; ---------------------------------------------------------------------------
+
+(deftest a-fresh-mount-renders-the-component-on-its-first-pass
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (testing "a `createRoot` mount never consults a server snapshot, so
+                neither policy costs a placeholder pass — asserted on the
+                line after `root!` returns, which is inside its flushSync"
+        (let [a (mount/root! (mount/fresh-container!) frame-id [client-only-page {}])]
+          (try
+            (is (some? (q (:container a) ".chart"))
+                ":client-only mounted its component immediately")
+            (is (= "yes" (.getAttribute (q (:container a) ".chart") "data-live"))
+                "and it is the real one")
+            (finally (mount/release! a))))
+        (let [b (mount/root! (mount/fresh-container!) frame-id [fallback-page {}])]
+          (try
+            (is (some? (q (:container b) ".chart"))
+                "{:fallback …} mounted its component immediately too")
+            (is (nil? (q (:container b) ".chart-skeleton"))
+                "and the placeholder never flashed — a fallback is for the
+                 server's markup, not for a client that has none")
+            (finally (mount/release! b))))))))
+
+(deftest the-gate-forwards-props-and-children-untouched
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (testing "the gate hands its own props straight through, so the
+                crossing is the object `host-element` built — the door's
+                contract is unchanged by the policy sitting in front of it"
+        (let [h (mount/root! (mount/fresh-container!) frame-id [slotted-page {}])]
+          (try
+            (is (= "quarterly" (.-textContent (q (:container h) ".chart-label")))
+                "a declared prop reached the foreign component")
+            (is (some? (q (:container h) ".chart .kid"))
+                "and so did the children, in the component's own slot")
+            (finally (mount/release! h))))))))
+
+;; ---------------------------------------------------------------------------
+;; 5 — hydration: the first client pass matches, and adoption swaps
+;; ---------------------------------------------------------------------------
+
+(defn- hydration-row
+  "Bake the page on the server, hydrate that HTML, and answer what React
+  reported — plus the HTML it hydrated FROM, because a row that only
+  reads the settled DOM cannot tell a policy that worked from a policy
+  that was never applied on either side. Shared by the two policies
+  because the difference between them is the markup, not the procedure."
+  [hiccup after]
+  (fresh!)
+  (reset! !renders 0)
+  (let [html      (server-html hiccup)
+        container (mount/fresh-container!)
+        {:keys [seen restore]} (watch-errors!)]
+    (set! (.-innerHTML container) html)
+    (let [root (hydrate! container
+                         (mount/provider frame-id (codec/root-element frame-id hiccup))
+                         seen)]
+      (js/setTimeout
+        (fn []
+          (try
+            (after container @seen html)
+            (finally
+              (restore)
+              (.unmount root)
+              (when-some [p (.-parentNode container)] (.removeChild p container))
+              (collector/reset-runtime!))))
+        150))))
+
+(deftest client-only-hydrates-with-nothing-there-and-mounts-after-adoption
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (hydration-row
+        [client-only-page {}]
+        (fn [container seen html]
+          (is (not (re-find #"class=\"chart\"" html))
+              (str "the markup hydrated FROM has no host region in it — the "
+                   "row's own restatement of the policy, so that a gate "
+                   "which stopped gating is red HERE and not only in the "
+                   "server-render row: " html))
+          (is (empty? seen)
+              (str "REACT FOUND NOTHING TO RECONCILE. The client's first "
+                   "pass rendered what the server did — nothing — so there "
+                   "was no mismatch to repair: " (pr-str seen)))
+          (is (some? (q container ".chart"))
+              "and after adoption the foreign component is mounted")
+          (is (= "yes" (.getAttribute (q container ".chart") "data-live"))
+              "the real one, not a placeholder")
+          (is (some? (q container ".title"))
+              "with the server's own markup still in place around it —
+               adoption, not a re-render of the page")
+          (is (pos? @!renders)
+              "the component ran on the client, and only on the client")
+          (done))))))
+
+(deftest a-fallback-hydrates-as-the-placeholder-and-is-swapped-after-adoption
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (hydration-row
+        [fallback-page {}]
+        (fn [container seen html]
+          (is (re-find #"chart-skeleton" html)
+              (str "the markup hydrated FROM carries the declared fallback: "
+                   html))
+          (is (empty? seen)
+              (str "the fallback the server wrote is what the client's "
+                   "first pass rendered, so again there was nothing to "
+                   "reconcile: " (pr-str seen)))
+          (is (nil? (q container ".chart-skeleton"))
+              "and the placeholder is GONE after adoption")
+          (is (some? (q container ".chart"))
+              "replaced by the foreign component")
+          (done))))))
+
+(deftest a-render-crossing-hydrates-once-and-never-remounts
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (do
+        (reset! !child-mounts 0)
+        (hydration-row
+          [counted-provider-page {}]
+          (fn [container seen html]
+            (is (re-find #"THE ENTIRE APPLICATION" html)
+                (str "the markup hydrated FROM carries the provider's whole
+                      subtree — the row's own restatement of the policy, so
+                      a `:render` that stopped rendering is red HERE and not
+                      only in the server-render row: " html))
+            (is (re-find #"<span class=\"theme-reader\">dark</span>" html)
+                (str "under the DECLARED context value: " html))
+            (is (empty? seen)
+                (str "REACT FOUND NOTHING TO RECONCILE. Server render,
+                      hydration's first pass and a fresh mount are one tree
+                      under this policy — the same element type, the same
+                      props, the same children — so there is zero mismatch
+                      by identity rather than by a snapshot pair agreeing: "
+                     (pr-str seen)))
+            (is (some? (q container ".theme-reader"))
+                "the consumer is mounted after hydration")
+            (is (= "dark" (.-textContent (q container ".theme-reader")))
+                "still reading the declared value on the client")
+            (is (some? (q container ".body"))
+                "and the subtree around it is the SERVER'S markup, adopted")
+            (is (= 1 @!child-mounts)
+                (str "**ONE MOUNT.** This is the closing measurement
+                      (rf2-l0wfx): the child's effect ran exactly once, so
+                      the adopted subtree was never destroyed and rebuilt.
+                      Any policy whose unadopted branch returns something
+                      other than the component swaps the position's element
+                      TYPE at adoption, and React reconciles a position by
+                      type — so it would read 2 here. Read "
+                     @!child-mounts))
+            (done)))))))

--- a/implementation/hicasso/test/re_frame/hicasso/host_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/host_ssr_dom_cljs_test.cljs
@@ -397,7 +397,7 @@
   (testing "as does a `defview` head written into a fallback — a fallback
             is inert markup and that is enforced (rf2-nv07k). The full
             contract, both directions, is
-            `arm1/fallback_contents_cljs_test`; this row is here because
+            [[re-frame.hicasso.fallback-contents-cljs-test]]; this row is here because
             the two halves were ruled together and the refusal is one of
             this declaration's own"
     (is (= :rf.error/hicasso-host-fallback-boundary-head

--- a/implementation/hicasso/test/re_frame/hicasso/keywarn_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/keywarn_dom_cljs_test.cljs
@@ -16,14 +16,24 @@
      view, the child head and the fix. Neither suppresses the other, and
      no suppression machinery exists.
 
-  The parent tag is the custom element `:keywarn-list` on purpose. React
-  dedupes its key warning on the PARENT TAG NAME, module-globally and for
-  the life of the page (`ownerHasKeyUseWarning` in react-dom-client's
-  development build), so a row asserting React's channel under a `:ul`
-  would go green or red depending on whether some earlier namespace in
-  the bundle had already warned under a `:ul`. A tag only this file uses
-  makes the assertion deterministic — and the coarse dedupe it works
-  around is the whole reason the Hicasso warning names the view.
+  The parent tag is the custom element `:pkg-keywarn-list` on purpose,
+  and the `pkg-` prefix is load-bearing. React dedupes its key warning on
+  the PARENT TAG NAME, module-globally and for the life of the page
+  (`ownerHasKeyUseWarning` in react-dom-client's development build), so a
+  row asserting React's channel under a `:ul` would go green or red
+  depending on whether some earlier namespace in the bundle had already
+  warned under a `:ul`. A tag only this file uses makes the assertion
+  deterministic — and the coarse dedupe it works around is the whole
+  reason the Hicasso warning names the view.
+
+  **The prototype's `arm1/keywarn_dom_cljs_test` is that earlier
+  namespace.** `:browser-test` compiles `freehand/test` and
+  `hicasso/test` into ONE bundle and its `ns-regexp` selects both files,
+  so this suite and its donor mount into the same page. Reusing the
+  donor's `:keywarn-list` meant React had already warned under that tag
+  by the time this file ran, deduped, and the row measuring React's
+  channel read ZERO — the exact failure this paragraph predicts,
+  observed. The tag is prefixed so the two never share one.
 
   A `window` `error` listener rides alongside the two channel spies
   because React routes a throw during a commit to `reportError`, where
@@ -73,7 +83,7 @@
   "The shape the guide promises a warning for — a bare seq of boundary
   children with no `:key` in sight."
   [_]
-  [:keywarn-list
+  [:pkg-keywarn-list
    (for [i (range 3)]
      [keywarn-row {:label i}])])
 
@@ -83,7 +93,7 @@
   silent on the Hicasso channel in the same bundle, the same render pass
   and the same spy."
   [_]
-  [:keyed-keywarn-list
+  [:pkg-keyed-keywarn-list
    (for [i (range 3)]
      [keywarn-row {:key i :label i}])])
 

--- a/implementation/hicasso/test/re_frame/hicasso/keywarn_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/keywarn_dom_cljs_test.cljs
@@ -1,0 +1,189 @@
+(ns re-frame.hicasso.keywarn-dom-cljs-test
+  "THE MINTED KEY WARNING, END TO END IN A REAL REACT DOM (rf2-2rtt6.104).
+
+  [[re-frame.hicasso.codec-cljs-test]] settles the predicate, the wording
+  and the dedupe at the element, without React. This file asserts the two
+  things only a real render can say:
+
+  1. **The owner threading works from the shell itself.** The codec
+     cannot name the enclosing view by itself — `as-element` carries no
+     context — so `run-once` records it around the lowering and clears it
+     in the `finally` it already had. A unit row can drive that seam by
+     hand; only a mounted `h/defview` proves the runtime actually does.
+  2. **Both warnings arrive, and they are complementary rather than
+     duplicate.** React's own key warning is a `console.error` naming a
+     component stack; the Hicasso one is a `console.warn` naming the
+     view, the child head and the fix. Neither suppresses the other, and
+     no suppression machinery exists.
+
+  The parent tag is the custom element `:keywarn-list` on purpose. React
+  dedupes its key warning on the PARENT TAG NAME, module-globally and for
+  the life of the page (`ownerHasKeyUseWarning` in react-dom-client's
+  development build), so a row asserting React's channel under a `:ul`
+  would go green or red depending on whether some earlier namespace in
+  the bundle had already warned under a `:ul`. A tag only this file uses
+  makes the assertion deterministic — and the coarse dedupe it works
+  around is the whole reason the Hicasso warning names the view.
+
+  A `window` `error` listener rides alongside the two channel spies
+  because React routes a throw during a commit to `reportError`, where
+  `cljs.test` reads 0 failures over a live exception — the same guard
+  [[re-frame.hicasso.host-ssr-dom-cljs-test]]'s `watch-errors!` carries.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every claim degrades to a stated skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.todo-support :as todo]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn (fn [] (collector/reset-runtime!))}))
+
+(def ^:private frame-id ::keywarn)
+
+(defn- skip! [why]
+  (is true (str "a minted-key-warning claim needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (support/leave-act-environment!)
+  (todo/make-frame! frame-id 3)
+  (todo/reseed! frame-id 3)
+  frame-id)
+
+;; ---------------------------------------------------------------------------
+;; The boundaries — one unkeyed list, one keyed control
+;; ---------------------------------------------------------------------------
+
+(h/defview keywarn-row
+  "An ordinary boundary child. Nothing about it is unusual: the defect is
+  entirely in how its parent spells the list."
+  [{:keys [label]}]
+  [:li.keywarn-row (str label)])
+
+(h/defview keywarn-list
+  "The shape the guide promises a warning for — a bare seq of boundary
+  children with no `:key` in sight."
+  [_]
+  [:keywarn-list
+   (for [i (range 3)]
+     [keywarn-row {:label i}])])
+
+(h/defview keyed-list
+  "The same list, written correctly. It is here so the row below is a
+  reading of the WARNING rather than of the fixture: this one must be
+  silent on the Hicasso channel in the same bundle, the same render pass
+  and the same spy."
+  [_]
+  [:keyed-keywarn-list
+   (for [i (range 3)]
+     [keywarn-row {:key i :label i}])])
+
+;; ---------------------------------------------------------------------------
+;; Both channels, plus the one React hides
+;; ---------------------------------------------------------------------------
+
+(defn- watch-console!
+  "Both channels and `reportError`, captured together. `console.warn` is
+  Hicasso's; `console.error` is React's; the `window` listener is the one
+  a green row would otherwise be hiding."
+  []
+  (let [warns    (atom [])
+        errors   (atom [])
+        thrown   (atom [])
+        o-warn   (.-warn js/console)
+        o-error  (.-error js/console)
+        on-error (fn [e] (swap! thrown conj (str (.-message e))))]
+    (set! (.-warn js/console) (fn [& args] (swap! warns conj (apply str args))))
+    (set! (.-error js/console) (fn [& args] (swap! errors conj (apply str args))))
+    (.addEventListener js/window "error" on-error)
+    {:warns   warns
+     :errors  errors
+     :thrown  thrown
+     :restore (fn []
+                (set! (.-warn js/console) o-warn)
+                (set! (.-error js/console) o-error)
+                (.removeEventListener js/window "error" on-error))}))
+
+(defn- one-matching [lines re]
+  (filterv #(re-find re %) lines))
+
+(deftest a-mounted-unkeyed-list-warns-on-both-channels-and-names-its-own-view
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [{:keys [warns errors thrown restore]} (watch-console!)
+            handle (try (mount/root! (mount/fresh-container!) frame-id [keywarn-list {}])
+                        (catch :default e (restore) (throw e)))]
+        (try
+          (mount/settle!)
+          (let [hicasso (one-matching @warns #"rf\.warning/hicasso-missing-key")
+                react   (one-matching @errors #"unique \"key\" prop")]
+            (is (= [] @thrown)
+                "no exception was routed to reportError — without this listener a
+                 live throw inside a render reads as 0 failures")
+            (is (= 1 (count hicasso)) "exactly one Hicasso line, once for the site")
+            (is (re-find #"keywarn-list" (first hicasso))
+                "**the owner threading, end to end**: the codec named the
+                 enclosing view, which it can only do because `run-once` told it")
+            (is (re-find #"keywarn-row" (first hicasso)) "and the child head")
+            (is (re-find #"first at index 0" (first hicasso)))
+            (is (= 1 (count react))
+                "React's own warning fired too — neither is suppressed, and no
+                 suppression machinery exists")
+            (is (not (re-find #"rf\.warning" (first react)))
+                "and they are visibly different lines on different channels"))
+          (finally (mount/release! handle) (restore)))))))
+
+(deftest the-keyed-control-is-silent-in-the-same-bundle-and-the-same-spy
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [{:keys [warns errors thrown restore]} (watch-console!)
+            handle (try (mount/root! (mount/fresh-container!) frame-id [keyed-list {}])
+                        (catch :default e (restore) (throw e)))]
+        (try
+          (mount/settle!)
+          (is (= [] @thrown))
+          (is (= [] (one-matching @warns #"rf\.warning/hicasso"))
+              "a correctly keyed list says nothing at all")
+          (is (= [] (one-matching @errors #"unique \"key\" prop"))
+              "and React agrees, which is the cross-check on the fixture")
+          (finally (mount/release! handle) (restore)))))))
+
+(deftest the-owner-slot-is-cleared-by-the-finally-not-merely-set-by-the-body
+  (testing "after a completed render, a lowering that is NOT inside any body
+            observes a nil owner and drops the owner clause — the end-to-end
+            witness for the clear half of the pair, which a set-only test
+            would pass without"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (do
+        (fresh!)
+        (let [handle (mount/root! (mount/fresh-container!) frame-id [keywarn-list {}])]
+          (mount/settle!)
+          (mount/release! handle))
+        (let [orphan (fn [_js-props] nil)
+              _      (unchecked-set orphan "displayName" "keywarn.dom/orphan")
+              _      (codec/mark-boundary! orphan)
+              seen   (atom [])
+              o-warn (.-warn js/console)]
+          (set! (.-warn js/console) (fn [& args] (swap! seen conj (apply str args))))
+          (try (codec/as-element [:ul (list [orphan {}])])
+               (finally (set! (.-warn js/console) o-warn)))
+          (let [line (first (filterv #(re-find #"hicasso-missing-key" %) @seen))]
+            (is (some? line) "the direct lowering still warns")
+            (is (re-find #"^\[hicasso\] Unkeyed boundary children: " line)
+                "with no owner clause — the slot was cleared when the render
+                 unwound, so nothing stale could be named")
+            (is (re-find #"keywarn\.dom/orphan" line))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/presence_intent_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/presence_intent_dom_cljs_test.cljs
@@ -33,7 +33,9 @@
      absence;
   5. a tray with no frame above it is still legal until a child writes an
      intent, and that intent is still the loud error, **named**;
-  6. presence's roster is three hooks and `runtime/shell`'s is still two —
+  6. presence's roster is four hooks — three distinct names, with
+     `useContext` read twice for the frame and for the root-scoped
+     adoption window — and `collector/shell`'s is still two —
      counted at React's own dispatcher, so the budget claim is a reading
      rather than a docstring. It also reads two things off the same log
      that nothing measured before: presence's body runs exactly **twice**
@@ -407,7 +409,7 @@
                  (pr-str 're-frame.hicasso.hook-probe)
                  " rather than reading this as a pass.")))
 
-(deftest presence-costs-three-hooks-and-the-shell-still-costs-two
+(deftest presence-costs-four-hooks-and-the-shell-still-costs-two
   (if-not (mount/browser?)
     (skip! ":node-test has no DOM")
     (if-not (probe/install!)
@@ -432,23 +434,31 @@
             (is (= (count collector/shell-hook-ledger) (count (take 2 names)))
                 "and the declared shell ledger is the measured one")
             (is (= ["useContext" "useState" "useEffect"] (vec (distinct tail)))
-                (str "presence's own roster is three, in call order: the frame "
-                     "hook this repair added, the retention state, and the "
-                     "clock. `distinct`, because the RAW list is a log of "
-                     "dispatcher reads rather than of calls — see the two "
-                     "claims below for why. Raw tail: " (pr-str tail)))
+                (str "presence's own roster, in call order: the frame hook, "
+                     "the retention state, the ROOT-SCOPED ADOPTION WINDOW "
+                     "(a second useContext, rf2-6tmu) and the clock — four "
+                     "calls over three distinct names. `distinct`, because "
+                     "the RAW list is a log of dispatcher reads rather than "
+                     "of calls — see the two claims below for why. Raw tail: "
+                     (pr-str tail)))
             (is (empty? (filter #{"useRef" "useMemo" "useCallback"
                                   "useSyncExternalStore"}
                                 tail))
                 "and nothing else — no useRef, and no second subscription")
             (testing "the raw log's two multiplicities, both measured rather
                       than assumed"
-              (is (= 2 (get freq "useContext") (get freq "useState"))
+              (is (= 2 (get freq "useState"))
                   "presence's body ran TWICE on this mount, which is the
                    docstring's convergence claim read off React's own
                    dispatcher: `step` is adjusted during render, so React
                    re-runs the body, and `step`'s idempotence is what makes
                    that ONE extra pass rather than a loop")
+              (is (= (* 2 (get freq "useState")) (get freq "useContext"))
+                  "and TWO contexts are read per pass, not one — the frame
+                   hook and the root-scoped adoption window. Stated as a
+                   ratio against the pass count rather than as a bare 4, so
+                   the row keeps saying `two contexts per pass` if the
+                   convergence pass count ever changes")
               (is (= 4 (get freq "useEffect"))
                   "twice per pass, against one call in the body: React 19.2's
                    DEV dispatcher is read more than once per `useEffect` call,

--- a/implementation/hicasso/test/re_frame/hicasso/presence_intent_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/presence_intent_dom_cljs_test.cljs
@@ -1,0 +1,460 @@
+(ns re-frame.hicasso.presence-intent-dom-cljs-test
+  "AN INTENT ON A PRESENCE CHILD (rf2-2rtt6.66).
+
+  [[re-frame.hicasso.motion-presence-dom-cljs-test]] proves the retention machine through a
+  real DOM: the exit attributes land, re-entry takes them off, the node
+  leaves on the timeout. Every child in that file is **callback-free**,
+  and that was not a stylistic choice — it was the shape of a defect.
+
+  A presence child is hiccup **data**, written in the parent boundary's
+  body; it is **lowered inside the presence component's own React
+  render**, one render later, after the parent body's dynamic extent has
+  unwound. With no ambient frame re-bound there, `intent/*dispatch*` was
+  nil at the moment the codec walked those props, so
+
+      [:div.toast {:key id :on-click [:toasts/dismiss id]}]
+
+  raised `:rf.error/hicasso-intent-outside-boundary` at render — and an
+  `h/fn` at an event position raised the same id at invocation. Loud,
+  never silent, and never *writable*: the inline tray with no child view
+  is the whole of what HD-025 sells, and its dismiss button could not be
+  written. This file is that button, clicked.
+
+  Six claims, and the third and fourth are the ones that matter:
+
+  1. a **bare intent vector** on a native presence child dispatches;
+  2. an **`h/fn` at an event position** on one dispatches what it returns;
+  3. both of them still dispatch **while the child is being retained** —
+     the `::h/unmounting` window, where the child is gone from app-db,
+     still on screen, still clickable, and re-lowered by presence on
+     every one of its own renders;
+  4. the intent lands in the frame the **tray** was mounted under, proved
+     against a second live frame on the same page rather than against an
+     absence;
+  5. a tray with no frame above it is still legal until a child writes an
+     intent, and that intent is still the loud error, **named**;
+  6. presence's roster is three hooks and `runtime/shell`'s is still two —
+     counted at React's own dispatcher, so the budget claim is a reading
+     rather than a docstring. It also reads two things off the same log
+     that nothing measured before: presence's body runs exactly **twice**
+     on a mount, which is `step`'s adjust-during-render convergence seen
+     from outside; and a `useEffect` call surfaces more than one
+     dispatcher read on React 19.2's dev build, which is why a hook
+     ROSTER is `distinct` rather than a count.
+
+  One row exists only to make a mutation legible.
+  `an-intent-under-a-framed-tray-raises-nothing` puts an error boundary
+  over an ordinary framed tray and asserts it caught nothing: every other
+  row above reds on an *absence* — no tray, so every query is nil — and
+  React does not print the `ex-info` it swallowed. That row prints it.
+
+  ## The host child, and why it is not witnessed here
+
+  The bead names native and host children alike. The `defhost` door is
+  HD-011's own surface and does not exist on `main` yet (rf2-2rtt6.65),
+  so there is nothing here to mount one with. The repair does not
+  distinguish them and cannot: **both kinds cross the single
+  `codec/as-element` call** `presence-body` now wraps, so a host child's
+  declared `:callbacks` entry is lowered inside the same binding as a
+  native `:on-click`. The host-hatch suite is where that witness belongs,
+  and this bead is what un-fences its presence-tray children.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every DOM claim degrades to a stated
+  skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.context :as adapter-context]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.hicasso.impl.boundary :refer [boundary]]
+            [re-frame.hicasso.hook-probe :as probe]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.impl.presence-react :refer [presence]]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private frame-id ::presence-intent)
+(def ^:private other-frame-id ::presence-intent-other)
+(def ^:private timeout-ms 400)
+
+;; Registered ABOVE `use-fixtures`, deliberately — the reset fixture captures
+;; its source-store baseline when the `use-fixtures` form is EVALUATED and
+;; restores it before every test, so a `reg-sub` written below it is erased
+;; before the first row runs.
+
+(rf/reg-sub :hicasso.presence-intent/visible (fn [db _] (:toasts db)))
+
+(rf/reg-event :hicasso.presence-intent/set
+              (fn [{:keys [db]} [_ ts]] {:db (assoc db :toasts ts)}))
+
+(rf/reg-event :hicasso.presence-intent/dismissed
+              (fn [{:keys [db]} [_ id]]
+                {:db (update db :dismissed (fnil conj []) id)}))
+
+(rf/reg-event :hicasso.presence-intent/noted
+              (fn [{:keys [db]} [_ id]]
+                {:db (update db :noted (fnil conj []) id)}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     ;; `:ambient-frame nil` is load-bearing. The fixture's default leaves a
+     ;; dynamic-var frame stamp in scope, and a tray that resolved the frame
+     ;; through that tier instead of through React context would look correct
+     ;; here for the wrong reason. With no ambient stamp, the only thing that
+     ;; can name a frame is the provider above the tray.
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+(defn- skip! [why]
+  (is true (str "an intent-on-a-presence-child claim needs a real React DOM — " why)))
+
+(defn- fresh! [frame-kw ts]
+  (support/leave-act-environment!)
+  (rf/make-frame {:id frame-kw})
+  (rf/with-frame frame-kw (rf/dispatch-sync [:hicasso.presence-intent/set ts]))
+  frame-kw)
+
+(defn- db [frame-kw] (rf/app-db-value frame-kw))
+
+;; ---------------------------------------------------------------------------
+;; The screen — the tray HD-025 sells, with the button it could not carry
+;; ---------------------------------------------------------------------------
+
+(h/defview toast-tray
+  "The inline tray, with **no child view**, and now with controls on the
+  toast. `:on-click` carries a bare intent vector on one button and the
+  one callback form on the other, so both rows of the position table are
+  written at the same position on the same child."
+  [_]
+  [presence {:timeout-ms timeout-ms}
+   (for [t (collector/sub [:hicasso.presence-intent/visible])]
+     [:div.toast {:key (:id t)
+                  :data-id (:id t)
+                  :re-frame.hicasso/unmounting {:class "toast--exit"}}
+      (:message t)
+      [:button.dismiss {:data-id  (:id t)
+                        :on-click [:hicasso.presence-intent/dismissed (:id t)]}
+       "dismiss"]
+      [:button.note {:data-id  (:id t)
+                     :on-click (h/hfn [e]
+                                 ;; A live event read, and ONE intent
+                                 ;; returned — the event contract the
+                                 ;; position imposes.
+                                 (when (= "note" (.. e -target -dataset -role))
+                                   [:hicasso.presence-intent/noted (:id t)]))
+                     :data-role "note"}
+       "note"]])])
+
+(h/defview note-only-tray
+  "The same tray carrying **only** the callback form, and it exists for
+  what it proves when the frame binding is taken away. The two intent
+  shapes fail at different MOMENTS: a bare vector is refused at LOWERING,
+  during presence's render, so a tray holding one never reaches the
+  screen — and a red on the tray above could always be blamed on that
+  sibling. `h/fn` is lowered happily with no frame (the dispatch is
+  captured, not required); it renders, it clicks, and it raises at
+  INVOCATION. So this tray is the one whose red is the callback path's
+  own."
+  [_]
+  [presence {:timeout-ms timeout-ms}
+   (for [t (collector/sub [:hicasso.presence-intent/visible])]
+     [:div.toast {:key (:id t) :data-id (:id t)}
+      [:button.note {:data-id   (:id t)
+                     :on-click  (h/hfn [e]
+                                  (when (= "note" (.. e -target -dataset -role))
+                                    [:hicasso.presence-intent/noted (:id t)]))
+                     :data-role "note"}
+       "note"]])])
+
+(h/defview toast-card
+  "A BOUNDARY child of presence. It resolves its own frame in its own
+  shell and receives `:rf/phase` as an ordinary prop, so it is the
+  control: presence's new binding must leave this path exactly as it was."
+  [{:keys [id]}]
+  [:div.card {:data-id id}
+   [:button.card-dismiss {:on-click [:hicasso.presence-intent/dismissed id]} "dismiss"]])
+
+(h/defview card-tray
+  [_]
+  [presence {:timeout-ms timeout-ms}
+   (for [t (collector/sub [:hicasso.presence-intent/visible])]
+     [toast-card {:key (:id t) :id (:id t)}])])
+
+(def ^:private two [{:id 1 :message "Saved"} {:id 2 :message "Copied"}])
+(def ^:private one [{:id 1 :message "Saved"}])
+
+(defn- query [handle sel] (.querySelector (:container handle) sel))
+
+(defn- button [handle cls id]
+  (.querySelector (:container handle)
+                  (str ".toast[data-id=\"" id "\"] " cls)))
+
+(defn- click! [node]
+  (.click node)
+  (mount/settle!))
+
+;; ---------------------------------------------------------------------------
+;; 1 — a bare intent vector on a native presence child
+;; ---------------------------------------------------------------------------
+
+(deftest a-native-presence-child-dispatches-its-inline-intent
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id two)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])]
+        (try
+          (is (some? (query handle ".toast"))
+              "the tray rendered at all — before this repair the intent on the
+               child raised :rf.error/hicasso-intent-outside-boundary during
+               presence's own render and there was no tray to click")
+          (is (nil? (:dismissed (db frame-id))))
+          (click! (button handle ".dismiss" 2))
+          (is (= [2] (:dismissed (db frame-id)))
+              "the inline dismiss button dispatched, which is the whole of what
+               the inline tray was sold on")
+          (click! (button handle ".dismiss" 1))
+          (is (= [2 1] (:dismissed (db frame-id)))
+              "and again, so this is a live handler and not a one-shot")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the one callback form at a presence child's event position
+;; ---------------------------------------------------------------------------
+
+(deftest a-callback-at-a-presence-childs-event-position-dispatches-what-it-returned
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id two)
+      ;; The callback-ONLY tray, deliberately: see its docstring. A bare
+      ;; vector on the same child would fail earlier and louder with the
+      ;; binding removed, and would take the credit for this row's red.
+      (let [handle (mount/root! (mount/fresh-container!) frame-id
+                                [note-only-tray {}])]
+        (try
+          (is (some? (button handle ".note" 1))
+              "the tray rendered — an h/fn is LOWERED with no frame in scope,
+               because the dispatch is captured rather than required, so this
+               path fails at invocation and not here")
+          (click! (button handle ".note" 1))
+          (is (= [1] (:noted (db frame-id)))
+              "and at invocation the h/fn read the real event and the vector it
+               RETURNED drained through the arm's synchronous door — the second
+               row of the position table, at a position presence lowered")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the unmounting window: retained, on screen, and still clickable
+;; ---------------------------------------------------------------------------
+
+(deftest a-retained-child-dispatches-during-the-unmounting-window
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id two)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])]
+        (try
+          (mount/dispatch! handle [:hicasso.presence-intent/set one])
+          (is (= 2 (.-length (.querySelectorAll (:container handle) ".toast")))
+              "toast 2 is gone from app-db and RETAINED on screen")
+          (is (.contains (.-classList (query handle ".toast[data-id=\"2\"]"))
+                         "toast--exit")
+              "and it is in the unmounting phase, not merely still present")
+          (testing "the retained child's controls still reach the frame. This is
+                    the sharpest case: the hiccup being lowered is the LAST one
+                    the parent produced for that key, re-lowered by presence on
+                    every one of its own renders, with the parent body long
+                    returned"
+            (click! (button handle ".dismiss" 2))
+            (is (= [2] (:dismissed (db frame-id))))
+            (click! (button handle ".note" 2))
+            (is (= [2] (:noted (db frame-id)))
+                "both intent shapes, from the retained phase"))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — the frame is the TRAY's, proved against a second live frame
+;; ---------------------------------------------------------------------------
+
+(deftest a-presence-child-lands-in-the-frame-the-tray-was-mounted-under
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id two)
+      (fresh! other-frame-id two)
+      (let [a (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])
+            b (mount/root! (mount/fresh-container!) other-frame-id [toast-tray {}])]
+        (try
+          (click! (button a ".dismiss" 1))
+          (is (= [1] (:dismissed (db frame-id))))
+          (is (nil? (:dismissed (db other-frame-id)))
+              "the second frame's app-db did not move — a frame is an isolated
+               context, and a tray that dispatched to whatever was ambient
+               rather than to its own provider would have moved both")
+          (click! (button b ".dismiss" 2))
+          (is (= [2] (:dismissed (db other-frame-id))))
+          (is (= [1] (:dismissed (db frame-id)))
+              "and symmetrically the other way")
+          (finally (mount/release! a) (mount/release! b)))))))
+
+(deftest a-boundary-child-of-presence-still-lowers-in-its-own-render
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id two)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [card-tray {}])]
+        (try
+          (click! (.querySelector (:container handle)
+                                  ".card[data-id=\"2\"] .card-dismiss"))
+          (is (= [2] (:dismissed (db frame-id)))
+              "a boundary child resolves its own frame in its own shell, and
+               presence's binding around the crossing left that path alone")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 5 — a frameless tray is legal; an intent under one is still the loud error
+;; ---------------------------------------------------------------------------
+
+(def ^:private !caught (atom nil))
+
+(defn- frameless-root!
+  "A root whose provider carries the **no-provider sentinel** — which is
+  the React-context default, so this is exactly a tray with no frame
+  boundary above it, reached without a second door in `mount`."
+  [hiccup]
+  (mount/root! (mount/fresh-container!) adapter-context/no-provider-sentinel hiccup))
+
+(deftest a-frameless-tray-is-legal-until-a-child-writes-an-intent
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (support/leave-act-environment!)
+      (testing "a tray with no frame above it and no intent below it renders.
+                Presence reads no subscription, so requiring a frame it does not
+                need would refuse a legal page"
+        (let [handle (frameless-root!
+                       [presence {:timeout-ms timeout-ms}
+                        [:div.toast {:key 1 :data-id 1} "quiet"]])]
+          (try
+            (is (some? (query handle ".toast")))
+            (finally (mount/release! handle)))))
+      (testing "and an intent under one is the loud error, NAMED — the
+                diagnostic points at the intent rather than at the tray"
+        (reset! !caught nil)
+        (let [handle (frameless-root!
+                       [boundary {:fallback [:p.oops "no frame"]
+                                  :on-error (fn [e] (reset! !caught e))}
+                        [presence {:timeout-ms timeout-ms}
+                         [:div.toast {:key 1
+                                      :on-click [:hicasso.presence-intent/dismissed 1]}
+                          "loud"]]])]
+          (try
+            (is (some? (query handle ".oops"))
+                "the tray failed rather than rendering an inert handler")
+            (is (= :rf.error/hicasso-intent-outside-boundary
+                   (:rf.error/id (ex-data @!caught)))
+                (str "and it named the intent: " (pr-str (ex-data @!caught))))
+            (is (= [:hicasso.presence-intent/dismissed 1] (:intent (ex-data @!caught))))
+            (finally (mount/release! handle))))))))
+
+;; ---------------------------------------------------------------------------
+;; 5b — the mutation sentinel: a framed tray raises NOTHING, by name
+;; ---------------------------------------------------------------------------
+;;
+;; Every other row above reds usefully when the binding is removed, but it
+;; reds on an ABSENCE — the tray never renders, so the queries come back nil
+;; and the diagnostic React swallowed is nowhere in the failure text. This row
+;; puts an error boundary over the tray for no reason except to catch what
+;; presence threw and print it, so a mutation names `:rf.error/hicasso-intent-
+;; outside-boundary` in the test output rather than in a browser console
+;; somebody has to go and read.
+
+(deftest an-intent-under-a-framed-tray-raises-nothing
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id two)
+      (reset! !caught nil)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id
+                                [boundary {:fallback [:p.oops "the tray refused"]
+                                           :on-error (fn [e] (reset! !caught e))}
+                                 [toast-tray {}]])]
+        (try
+          (is (nil? @!caught)
+              (str "presence raised while lowering its own children, and the "
+                   "error boundary above the tray caught: "
+                   (pr-str (select-keys (ex-data @!caught)
+                                        [:rf.error/id :intent :position]))))
+          (is (nil? (query handle ".oops"))
+              "so the fallback did not take over")
+          (is (= 2 (.-length (.querySelectorAll (:container handle) ".toast")))
+              "and both toasts, controls and all, are on screen")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 6 — the hook budget, counted at React's own dispatcher
+;; ---------------------------------------------------------------------------
+
+(defn- unwitnessed! []
+  (is false (str "React's internals slot was not found, so the hook counts are "
+                 "UNWITNESSED on this build. A gate nobody has watched fire is "
+                 "not evidence — fix "
+                 (pr-str 're-frame.hicasso.hook-probe)
+                 " rather than reading this as a pass.")))
+
+(deftest presence-costs-three-hooks-and-the-shell-still-costs-two
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (if-not (probe/install!)
+      (unwitnessed!)
+      (do
+        (fresh! frame-id one)
+        (let [handle (volatile! nil)
+              names  (probe/record!
+                       (fn []
+                         (vreset! handle
+                                  (mount/root! (mount/fresh-container!)
+                                               frame-id [toast-tray {}]))))
+              tail   (vec (drop 2 names))
+              freq   (frequencies tail)]
+          (try
+            (is (= ["useContext" "useSyncExternalStore"] (vec (take 2 names)))
+                (str "the SHELL's two come first, in the order "
+                     "collector/shell-hook-ledger declares, and they are still the "
+                     "whole of it — this repair added a hook to presence and "
+                     "to nothing that HD-020(b)'s ≤2 budget governs. Raw: "
+                     (pr-str names)))
+            (is (= (count collector/shell-hook-ledger) (count (take 2 names)))
+                "and the declared shell ledger is the measured one")
+            (is (= ["useContext" "useState" "useEffect"] (vec (distinct tail)))
+                (str "presence's own roster is three, in call order: the frame "
+                     "hook this repair added, the retention state, and the "
+                     "clock. `distinct`, because the RAW list is a log of "
+                     "dispatcher reads rather than of calls — see the two "
+                     "claims below for why. Raw tail: " (pr-str tail)))
+            (is (empty? (filter #{"useRef" "useMemo" "useCallback"
+                                  "useSyncExternalStore"}
+                                tail))
+                "and nothing else — no useRef, and no second subscription")
+            (testing "the raw log's two multiplicities, both measured rather
+                      than assumed"
+              (is (= 2 (get freq "useContext") (get freq "useState"))
+                  "presence's body ran TWICE on this mount, which is the
+                   docstring's convergence claim read off React's own
+                   dispatcher: `step` is adjusted during render, so React
+                   re-runs the body, and `step`'s idempotence is what makes
+                   that ONE extra pass rather than a loop")
+              (is (= 4 (get freq "useEffect"))
+                  "twice per pass, against one call in the body: React 19.2's
+                   DEV dispatcher is read more than once per `useEffect` call,
+                   which is a property of the instrument rather than a second
+                   effect. It is exactly why the roster above is taken with
+                   `distinct` and not by counting, and it is pinned here so a
+                   React bump that changes it reds a test with an explanation
+                   attached rather than a bare number"))
+            (finally (mount/release! @handle))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/presence_intent_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/presence_intent_dom_cljs_test.cljs
@@ -453,12 +453,19 @@
                    dispatcher: `step` is adjusted during render, so React
                    re-runs the body, and `step`'s idempotence is what makes
                    that ONE extra pass rather than a loop")
-              (is (= (* 2 (get freq "useState")) (get freq "useContext"))
-                  "and TWO contexts are read per pass, not one — the frame
-                   hook and the root-scoped adoption window. Stated as a
-                   ratio against the pass count rather than as a bare 4, so
-                   the row keeps saying `two contexts per pass` if the
-                   convergence pass count ever changes")
+              (is (>= (get freq "useContext") (* 2 (get freq "useState")))
+                  "and AT LEAST two contexts are read per pass, not one —
+                   the frame hook and the root-scoped adoption window
+                   (`roots/adopting-here?`, rf2-6tmu), which is the whole
+                   of what this component costs over the prototype's.
+                   Stated as a floor rather than an equality for the same
+                   reason the roster above is taken with `distinct`: the
+                   raw list logs dispatcher READS, and React 19.2's dev
+                   build takes more of them than there are calls — six
+                   here against four calls. The floor moves the day
+                   presence stops reading the adoption window; a bare
+                   number would instead move the day React changes how
+                   often it reads one")
               (is (= 4 (get freq "useEffect"))
                   "twice per pass, against one call in the body: React 19.2's
                    DEV dispatcher is read more than once per `useEffect` call,

--- a/implementation/hicasso/test/re_frame/hicasso/raw_escape_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/raw_escape_dom_cljs_test.cljs
@@ -1,0 +1,404 @@
+(ns re-frame.hicasso.raw-escape-dom-cljs-test
+  "THE `[:>]` RAW ESCAPE AGAINST A REAL REACT (HD-011, rf2-2rtt6.103).
+
+  The element-level contract — the carrier, the prop walk, the value
+  roster, `:&`, `:key`, refs, the mis-parse regression — is
+  [[re-frame.hicasso.codec-cljs-test]]'s, where it can be
+  read off the element without a DOM. This file carries the three claims
+  that a mounted React is the only honest witness for:
+
+  1. **SSR is hard `:client-only`, and hydration's first pass agrees.**
+     The escape carries no declaration, so it carries no `:ssr` policy
+     and there is no spelling for one. Server-absent and
+     first-pass-absent are not two facts kept in step — they are ONE
+     fact, because React reads the gate's SERVER snapshot under
+     `renderToString` and again on hydration's first client pass, then
+     re-renders with the client snapshot once adoption completes. The
+     row therefore asks REACT whether it found a mismatch, through
+     `onRecoverableError` and a console/window capture; a row that only
+     read the settled DOM would pass over a mismatch React repaired.
+
+  2. **The canonical DOM is not reduced at all.** HD-011's ruled phrase
+     is *reduced structural identity*, and the reduction is exactly one
+     slot of the hiccup vector (slot 1 holds a JS value compared by
+     identity). The DOM is not reduced, and that is provable rather than
+     asserted: the gate contributes no node of its own and
+     [[re-frame.hicasso.test/canonical-dom]] serialises element and
+     text nodes only, so a nil-rendering gate is invisible to it. Same
+     component, same props, one through `[:>]` and one through `defhost`
+     — byte-equal.
+
+  3. **Children lower in the WRITING boundary's render window.** An
+     intent closure in a `[:>]` child captures that boundary's
+     frame-locked dispatch at lowering time and fires into it however
+     much later the foreign component renders it — a portal, a
+     virtualised window, a `Suspense` fallback. Two frames are live so
+     that \"the right frame\" is distinguishable from \"any frame\".
+
+  ## The mutation witnesses
+
+  Make the escape render its component server-side — `gate-unadopted`
+  answering `true`, or `raw-element` creating the component's element
+  directly — and [[the-escape-hydrates-with-nothing-there-and-mounts-after-adoption]]
+  goes red on React's own mismatch report. Give the gate a wrapper node
+  of its own and [[the-escape-and-the-door-produce-the-same-dom]] goes
+  red on the canonical bytes. Lower children lazily, or forward them
+  without the owner's frame, and [[a-child-intent-fires-into-the-frame-that-wrote-the-crossing]]
+  goes red on the recorder that should have been empty.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM. The `renderToString` rows need no DOM and run under
+  `:node-test` too."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.test :as htest]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]
+            ["react-dom/client" :as react-dom-client]
+            ["react-dom/server" :as react-dom-server]))
+
+(def ^:private frame-id ::raw-escape)
+
+(rf/reg-sub :hicasso.raw/title (fn [db _] (:title db)))
+
+(rf/reg-event :hicasso.raw/seed (fn [_ _] {:db {:title "quarterly"}}))
+
+(rf/reg-event :hicasso.raw/picked
+              (fn [{:keys [db]} [_ what]]
+                {:db (update db :picked (fnil conj []) what)}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     ;; the hydration row waits on a real clock, and `cljs.test`
+     ;; hard-errors on a fn-form fixture in a suite with an async test.
+     :async?        true
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+(defn- skip! [why] (is true (str "a [:>] DOM claim needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (support/leave-act-environment!)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [:hicasso.raw/seed]))
+  frame-id)
+
+(defn- db [] (rf/app-db-value frame-id))
+
+;; ---------------------------------------------------------------------------
+;; One foreign component, reached two ways
+;; ---------------------------------------------------------------------------
+
+(def ^:private !renders
+  "How many times the foreign component's body ran. The server row's
+  strongest assertion: a `[:>]` crossing is not merely absent from the
+  HTML, its component was never INVOKED — which is the property an
+  author relies on when the reason they reached for the escape is a
+  widget that touches `window`."
+  (atom 0))
+
+(def ^:private !own-props
+  "The OWN property names of the props object the foreign component was
+  last handed. Read by the childless row, which is the only place the
+  gate's `undefined?` branch is observable: `createElement(type, props,
+  undefined)` sets `children` to `undefined` rather than leaving it
+  absent, so a gate that forwarded unconditionally would hand the
+  component a key `defhost` never gives it — and conversion parity is a
+  claim about the object the component RECEIVES."
+  (atom nil))
+
+(defn- widget
+  "A stand-in for the library's component. It renders REAL markup with
+  real attributes so that a canonical comparison has something to
+  compare, and it renders its children so the forwarding claim is
+  visible in the DOM."
+  [^js props]
+  (swap! !renders inc)
+  (reset! !own-props (set (js/Object.keys props)))
+  (react/createElement "div"
+    #js {:className "widget" :data-live "yes" :data-variant (.-variant props)}
+    (react/createElement "span" #js {:className "widget-label"} (.-label props))
+    (.-children props)))
+
+(h/defhost declared-widget
+  "The DOOR, on the same component and under the same default policy —
+  the control that makes every parity row below a fact about the
+  crossing rather than about the page."
+  widget)
+
+;; ---------------------------------------------------------------------------
+;; The pages
+;; ---------------------------------------------------------------------------
+
+(h/defview escape-page
+  "A native sibling beside the crossing, so \"the escape rendered
+  nothing\" stays distinguishable from \"nothing rendered at all\"."
+  [_]
+  [:div.page
+   [:h1.title (collector/sub [:hicasso.raw/title])]
+   [:> widget {:label (collector/sub [:hicasso.raw/title]) :variant "compact"}
+    [:span.kid "slotted"]]])
+
+(h/defview door-page
+  "[[escape-page]] through `defhost`, byte for byte the same authored
+  shape."
+  [_]
+  [:div.page
+   [:h1.title (collector/sub [:hicasso.raw/title])]
+   [declared-widget {:label (collector/sub [:hicasso.raw/title]) :variant "compact"}
+    [:span.kid "slotted"]]])
+
+(h/defview childless-escape-page
+  "A crossing with no children at all — the branch the gate takes when
+  `props.children` is absent."
+  [_]
+  [:div.page [:> widget {:label "bare" :variant "solo"}]])
+
+(h/defview childless-door-page
+  "Its control at the door, so the parity claim is measured rather than
+  assumed."
+  [_]
+  [:div.page [declared-widget {:label "bare" :variant "solo"}]])
+
+(h/defview intent-child-page
+  "A crossing whose CHILD carries an intent. The child's handler is
+  lowered here, in this body's render window, and invoked much later —
+  after every render extent has unwound — from the click."
+  [_]
+  [:div.page
+   [:> widget {:label "rows" :variant "list"}
+    [:button.pick {:on-click [:hicasso.raw/picked "child"]} "pick"]]])
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- server-html
+  "The page as a server render — the same runtime, under React's server
+  renderer."
+  [hiccup]
+  (react-dom-server/renderToString
+    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+
+(defn- q [root sel] (.querySelector root sel))
+
+(defn- watch-errors!
+  "Everything React has to say about a hydration, from all three
+  channels it uses. `console.error` carries the mismatch diff;
+  `onRecoverableError` carries the recovery; the `window` listener is
+  here because React routes a throw during a commit to `reportError`,
+  where `cljs.test` cannot see it and a row would read 0 failures over a
+  live exception."
+  []
+  (let [seen     (atom [])
+        original (.-error js/console)
+        on-error (fn [e] (swap! seen conj (str "window: " (.-message e))))]
+    (set! (.-error js/console)
+          (fn [& args] (swap! seen conj (str "console.error: " (pr-str (vec args))))))
+    (.addEventListener js/window "error" on-error)
+    {:seen    seen
+     :restore (fn []
+                (set! (.-error js/console) original)
+                (.removeEventListener js/window "error" on-error))}))
+
+;; ---------------------------------------------------------------------------
+;; 1 — the server render: nothing, and the component never ran
+;; ---------------------------------------------------------------------------
+
+(deftest the-escape-renders-nothing-on-the-server-and-cannot-say-otherwise
+  (fresh!)
+  (testing "hard `:client-only`. The escape carries no declaration, so it
+            carries no `:ssr` policy and there is no inline spelling for
+            one — a fallback is POLICY, and policy lives on declarations"
+    (reset! !renders 0)
+    (let [html (server-html [escape-page {}])]
+      (is (re-find #"quarterly" html)
+          (str "the page rendered — the sibling native node is there: " html))
+      (is (not (re-find #"class=\"widget\"" html))
+          (str "and the crossing rendered NOTHING: " html))
+      (is (not (re-find #"slotted" html))
+          (str "including its children, which lower eagerly and are then
+                discarded on the server: " html))
+      (is (zero? @!renders)
+          "the foreign component's body never ran on the server, which is
+           the property an author reaching for the escape is relying on")))
+  (testing "and the DOOR under its own default answers identically — the
+            escape inherits `:client-only`, it does not invent it"
+    (reset! !renders 0)
+    (let [html (server-html [door-page {}])]
+      (is (not (re-find #"class=\"widget\"" html)) (str "absent at the door too: " html))
+      (is (zero? @!renders)))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — a fresh mount, and the canonical DOM
+;; ---------------------------------------------------------------------------
+
+(deftest a-fresh-mount-renders-the-component-on-its-first-pass
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (testing "a `createRoot` mount never consults a server snapshot, so
+                the gate costs no placeholder pass — asserted on the line
+                after `root!` returns, which is inside its flushSync"
+        (let [h (mount/root! (mount/fresh-container!) frame-id [escape-page {}])]
+          (try
+            (is (some? (q (:container h) ".widget"))
+                "the component mounted immediately")
+            (is (= "yes" (.getAttribute (q (:container h) ".widget") "data-live"))
+                "the real one, not a placeholder")
+            (is (= "quarterly" (.-textContent (q (:container h) ".widget-label")))
+                "a prop reached the foreign component through the gate")
+            (is (= "compact" (.getAttribute (q (:container h) ".widget") "data-variant"))
+                "and so did the second one")
+            (is (some? (q (:container h) ".widget .kid"))
+                "and the children, in the component's own slot — forwarded
+                 by the gate as createElement's third argument")
+            (finally (mount/release! h))))))))
+
+(deftest a-childless-crossing-hands-the-component-the-doors-own-props-object
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (testing "the gate forwards `props.children` as `createElement`'s
+                third argument, and forwarding it UNCONDITIONALLY would
+                write `children: undefined` onto a childless crossing —
+                a key the door never gives the component. Read off what
+                the component was actually handed, at both crossings"
+        (let [a (mount/root! (mount/fresh-container!) frame-id [childless-escape-page {}])
+              via-escape (do (mount/settle!) @!own-props)]
+          (mount/release! a)
+          (let [b (mount/root! (mount/fresh-container!) frame-id [childless-door-page {}])
+                via-door (do (mount/settle!) @!own-props)]
+            (mount/release! b)
+            (is (= #{"label" "variant"} via-escape)
+                (str "no `children` key at the escape: " (pr-str via-escape)))
+            (is (= via-door via-escape)
+                (str "and the same set the door hands it — escape: "
+                     (pr-str via-escape) " / door: " (pr-str via-door)))))))))
+
+(deftest the-escape-and-the-door-produce-the-same-dom
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (testing "HD-011's *reduced structural identity* is a claim about the
+                hiccup data lane — slot 1 holds a JS value compared by
+                identity — and about the fiber lane's crossing name. It is
+                NOT a claim about the DOM, and this row is why that can be
+                stated rather than hedged: the gate contributes no node of
+                its own, and `htest/canonical-dom` serialises element and text
+                nodes and ignores comments, so a nil-rendering gate is
+                invisible to it"
+        (let [a (mount/root! (mount/fresh-container!) frame-id [escape-page {}])
+              b (mount/root! (mount/fresh-container!) frame-id [door-page {}])]
+          (try
+            (let [via-escape (htest/canonical-dom (:container a))
+                  via-door   (htest/canonical-dom (:container b))]
+              (is (re-find #"class=\"widget\"" via-escape)
+                  (str "precondition — the fixture renders something to
+                        compare, so the row cannot pass on two empty
+                        strings: " via-escape))
+              (is (= via-door via-escape)
+                  (str "BYTE-EQUAL. escape: " via-escape " / door: " via-door)))
+            (finally (mount/release! a) (mount/release! b)))))
+      (testing "and the crossing's own fiber is named by the CONSTANT, not
+                by the component — one greppable frame naming the form the
+                author wrote, with the component naming itself one level
+                down at zero cost"
+        (let [e (codec/as-element [:> widget {}])]
+          (is (= "[:>]" (.-displayName (.-type e)))))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — hydration: the first client pass matches, and adoption swaps
+;; ---------------------------------------------------------------------------
+
+(deftest the-escape-hydrates-with-nothing-there-and-mounts-after-adoption
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (do
+        (fresh!)
+        (reset! !renders 0)
+        (let [hiccup    [escape-page {}]
+              html      (server-html hiccup)
+              container (mount/fresh-container!)
+              {:keys [seen restore]} (watch-errors!)]
+          (set! (.-innerHTML container) html)
+          (let [root (react-dom-client/hydrateRoot
+                       container
+                       (mount/provider frame-id (codec/root-element frame-id hiccup))
+                       #js {:onRecoverableError
+                            (fn [err _info]
+                              (swap! seen conj (str "onRecoverableError: " (ex-message err))))})]
+            (js/setTimeout
+              (fn []
+                (try
+                  (is (not (re-find #"class=\"widget\"" html))
+                      (str "the markup hydrated FROM has no crossing in it — the
+                            row's own restatement of the policy, so a gate that
+                            stopped gating is red HERE and not only in the
+                            server-render row: " html))
+                  (is (empty? @seen)
+                      (str "REACT FOUND NOTHING TO RECONCILE. The client's first
+                            pass rendered what the server did — nothing — because
+                            both read the SAME snapshot, so there was no mismatch
+                            to repair: " (pr-str @seen)))
+                  (is (some? (q container ".widget"))
+                      "and after adoption the foreign component is mounted")
+                  (is (some? (q container ".widget .kid"))
+                      "with its children")
+                  (is (some? (q container ".title"))
+                      "and the server's own markup still in place around it —
+                       adoption, not a re-render of the page")
+                  (is (pos? @!renders)
+                      "the component ran on the client, and only on the client")
+                  (finally
+                    (restore)
+                    (.unmount root)
+                    (when-some [p (.-parentNode container)] (.removeChild p container))
+                    (collector/reset-runtime!)
+                    (done))))
+              150)))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — children capture the WRITING boundary's frame
+;; ---------------------------------------------------------------------------
+
+(deftest a-child-intent-fires-into-the-frame-that-wrote-the-crossing
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (testing "children lower EAGERLY at the crossing, inside the render
+                window of the boundary that wrote it, so a child's intent
+                closure captures that boundary's frame-locked dispatch at
+                lowering time — and fires into it however much later the
+                foreign component renders it. Two frames are live and the
+                page is mounted in ONE of them, so \"the right frame\" is
+                distinguishable from \"any frame\""
+        (let [other ::a-second-frame]
+          (fresh!)
+          (rf/make-frame {:id other})
+          (rf/with-frame other (rf/dispatch-sync [:hicasso.raw/seed]))
+          (let [h (mount/root! (mount/fresh-container!) frame-id [intent-child-page {}])]
+            (try
+              (mount/settle!)
+              (is (some? (q (:container h) ".widget .pick"))
+                  "precondition: the child is mounted BENEATH the foreign
+                   component, so its handler really did cross")
+              (.click (q (:container h) ".pick"))
+              (mount/settle!)
+              (is (= ["child"] (:picked (db)))
+                  "the click dispatched into the frame that wrote the crossing")
+              (is (nil? (:picked (rf/app-db-value other)))
+                  "and nothing reached the other frame, which is what makes
+                   the ownership assertion non-vacuous")
+              (finally (mount/release! h)))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
@@ -404,6 +404,20 @@
                     (.removeEventListener js/window "error" on-error))
                   @captured)})))
 
+(defn capture-console!
+  "Run `f` with React's two failure channels captured, and answer
+  `[result captured]`, where `captured` is an atom holding a vector of
+  one string per complaint.
+
+  **The window is exactly `f`'s synchronous extent.** For a claim about
+  a hydration — which React finishes in a LATER turn — use
+  [[open-console-capture!]] and close it after [[adopted!]] resolves."
+  [f]
+  (let [{:keys [captured close!]} (open-console-capture!)]
+    (try
+      [(f) captured]
+      (finally (close!)))))
+
 (defn watch-mismatches!
   "Capture every `:rf.ssr/hydration-mismatch` the framework emits, on the
   live trace stream. Answers `{:seen atom :stop! fn}`; `stop!` is

--- a/implementation/hicasso/test/re_frame/hicasso/slot_corpus.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/slot_corpus.cljs
@@ -1,0 +1,84 @@
+(ns re-frame.hicasso.slot-corpus
+  "THE CANONICAL SLOT CORPUS — authored prop key → the React slot it
+  emits into.
+
+  A support namespace: it defines NO `deftest`, so the lane-bijection
+  gate's universe (files that evaluate a test-defining form at the top
+  level) never reaches it and it needs no lane, no roster entry and no
+  workflow change. It is required by
+  [[re-frame.hicasso.codec-cljs-test]], which asserts the codec's caches
+  answer the rule over every row.
+
+  The table is one definition read by several suites on purpose: a rule
+  written against ONE spelling is a rule the other spellings walk past,
+  and a corpus that only carried bare kebab keywords could not tell.")
+
+(def corpus
+  "Authored prop key → the canonical React slot it emits into.
+
+  ONE table, read by both hosts and by the codec's cache suite. Every
+  branch of the rule is represented, and every spelling the codec accepts
+  appears at least once — because a rule written against the spelling is
+  a rule the other spellings walk past, and a corpus that only carries
+  bare kebab keywords could not tell."
+  {;; the three React renames — the RULE, so they hold for every spelling
+   :class          "className"
+   :className      "className"
+   "class"         "className"
+   :x/class        "className"
+   'class          "className"
+   :for            "htmlFor"
+   "for"           "htmlFor"
+   :x/for          "htmlFor"
+   :charset        "charSet"
+   'charset        "charSet"
+
+   ;; kebab → camel
+   :on-click       "onClick"
+   :tab-index      "tabIndex"
+   :on-mouse-enter "onMouseEnter"
+   :default-value  "defaultValue"
+   :a-b-c          "aBC"
+   'on-click       "onClick"
+   :x/on-click     "onClick"
+
+   ;; a hump the author already wrote survives — this is why the rule
+   ;; carries its own `capitalize` rather than `str/capitalize`, which
+   ;; would lower-case the tail and hand React `Viewbox`
+   :view-Box       "viewBox"
+   :on-Click       "onClick"
+
+   ;; nothing to camelCase
+   :x              "x"
+   :onInput        "onInput"
+   :viewBox        "viewBox"
+   :id             "id"
+   :ref            "ref"
+   :key            "key"
+
+   ;; aria/data are HTML attribute names in React too
+   :aria-label     "aria-label"
+   :aria-hidden    "aria-hidden"
+   :data-index     "data-index"
+   :data-testid    "data-testid"
+   'aria-label     "aria-label"
+   :x/data-index   "data-index"
+
+   ;; a CSS custom property is preserved verbatim
+   :--gap          "--gap"
+   :--my-custom-x  "--my-custom-x"
+
+   ;; a string is already a React name and is taken verbatim, apart from
+   ;; the three renames above — so `"on-input"` and `:on-input` are
+   ;; DIFFERENT slots
+   "on-input"      "on-input"
+   :on-input       "onInput"
+   "onInput"       "onInput"
+   "data-x"        "data-x"
+   "--gap"         "--gap"
+   "aria-label"    "aria-label"
+
+   ;; the prototype-poisoning names are the codec's problem, not the
+   ;; rule's; the rule answers them like any other name
+   :__proto__      "__proto__"
+   :constructor    "constructor"})

--- a/implementation/hicasso/test/re_frame/hicasso/state_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/state_dom_cljs_test.cljs
@@ -1,0 +1,266 @@
+(ns re-frame.hicasso.state-dom-cljs-test
+  "`h/reg-state`, MOUNTED — two disclosures on one page (rf2-2rtt6.98).
+
+  [[re-frame.hicasso.state-cljs-test]] proves the sugar against a real
+  frame with no React at all, and says so: the DOM half is this file.
+  Here are the three claims only a browser can make, and the first two
+  are the architectural ones:
+
+  1. **It costs no hook.** The widget's shell is counted at React's own
+     dispatcher ([[re-frame.hicasso.hook-probe]]), and it is the same two
+     calls a boundary that had never heard of `reg-state` makes. That is
+     the whole \"ordinary core artefacts\" claim, measured: the sugar
+     mints a sub and an event, and a sub read through the ambient
+     collector is not a hook.
+  2. **HD-028's memo bail-out still bails.** A parent re-render rebuilds
+     its children's key vectors — `(child-key row :detail)` allocates a
+     fresh vector every time — and `React.memo`'s comparator is `=` on the
+     props map, so a fresh-but-equal vector must NOT look like a changed
+     prop. If it did, this sugar would have re-introduced the 300-of-300
+     cascade rf2-2rtt6.52 killed, and it would have done it through the
+     very helper that makes nesting work.
+  3. **Two instances on one page are independent**, clicked in a real
+     browser, read back out of the real DOM.
+
+  ## Why a `console` capture rides the ordinary path
+
+  React routes a handler exception to `reportError` — a `window` `error`
+  event — and reports other faults by `console.error`, and NEITHER
+  reaches `cljs.test`. A row here asserting the page rendered correctly
+  could therefore be green over a live exception. So the ordinary path is
+  driven inside
+  [[re-frame.hicasso.roots-frames-support/capture-console!]], which
+  watches both channels, and the row asserts the capture is EMPTY. That
+  helper is the package's one copy of this refusal; a second copy is the
+  copy that quietly weakens.
+
+  And because a bad instance key is *recovered* rather than thrown (the
+  sub body's throw is caught, fanned on the always-on error channel, and
+  the read answers `nil`), the refusal row reads that channel — the same
+  reasoning [[re-frame.hicasso.state-cljs-test]] sets out at length.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every DOM claim degrades to a stated
+  skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.checkpoint-support :as checkpoint]
+            [re-frame.hicasso.hook-probe :as probe]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.impl.state :as state]
+            [re-frame.hicasso.roots-frames-support :as support]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+(def ^:private frame-id ::state-dom)
+
+(def ^:private open? ::open?)
+(def ^:private label ::label)
+
+;; ---------------------------------------------------------------------------
+;; The screen — one widget, mounted twice
+;; ---------------------------------------------------------------------------
+
+(def ^:private !panel-runs (atom 0))
+(def ^:private !page-runs (atom 0))
+
+(defn- reset-runs! [] (reset! !panel-runs 0) (reset! !page-runs 0) nil)
+
+(h/defview disclosure
+  "A disclosure panel. It holds its own open flag and knows nothing about
+  where it is on the page beyond the instance key it was handed — which
+  is the ergonomic claim: the widget is written ONCE and mounted twice."
+  [{:keys [ikey title]}]
+  (swap! !panel-runs inc)
+  (let [shown? (collector/sub [open? ikey])]
+    [:section.panel {:data-ikey (pr-str ikey)}
+     [:button.toggle {:on-click [open? ikey (not shown?)]} title]
+     (when shown? [:div.body "body of " title])]))
+
+(h/defview page
+  "Two disclosures, and a page-level read of its own so a chrome write
+  can re-render the page without touching either panel. Every child key
+  is REBUILT here on every render — `child-key` allocates — which is
+  exactly the condition claim 2 is about."
+  [_]
+  (swap! !page-runs inc)
+  [:div.page
+   [:h1.chrome (str (collector/sub [label :page]))]
+   [disclosure {:key "billing"  :ikey (state/child-key :panel :billing)  :title "Billing"}]
+   [disclosure {:key "shipping" :ikey (state/child-key :panel :shipping) :title "Shipping"}]])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- skip! [why] (is true (str "a reg-state DOM claim needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (checkpoint/leave-act-environment!)
+  (state/reg-state open? {:default false})
+  (state/reg-state label {:default ""})
+  (rf/make-frame {:id frame-id})
+  (reset-runs!)
+  (collector/reset-body-runs!)
+  frame-id)
+
+(defn- panels [handle]
+  (array-seq (.querySelectorAll (:container handle) "section.panel")))
+
+(defn- bodies [handle]
+  (mapv #(some-> (.querySelector % "div.body") (.-textContent))
+        (panels handle)))
+
+(defn- click! [handle i]
+  (-> (nth (vec (panels handle)) i)
+      (.querySelector "button.toggle")
+      (.click))
+  (mount/settle!)
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; 1 — two instances on one page, independent, in a real browser
+;; ---------------------------------------------------------------------------
+
+(deftest two-mounted-instances-of-one-widget-are-independent
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [[result captured]
+            (support/capture-console!
+              (fn []
+                (let [handle (mount/root! (mount/fresh-container!) frame-id [page {}])]
+                  (try
+                    (let [before (bodies handle)]
+                      (click! handle 0)
+                      {:before before
+                       :after  (bodies handle)
+                       :db     (rf/app-db-value frame-id)})
+                    (finally (mount/release! handle))))))]
+        (is (= [nil nil] (:before result)) "both panels start closed — the default")
+        (is (= ["body of Billing" nil] (:after result))
+            "one click opened ONE panel. Before the explicit-key ruling the
+             guide's own pitfall opened both, silently.")
+        (is (= {:ui {open? {[:panel :billing] true}}} (:db result))
+            "one entry, at the documented app-space path, under the composed key")
+        (is (= [] @captured)
+            "and React complained on NEITHER channel — without this the rows
+             above could be green over a live exception cljs.test never sees")))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — no hook. The ≤2-hook ledger is untouched.
+;; ---------------------------------------------------------------------------
+
+(deftest a-reg-state-widget-shell-still-calls-exactly-two-hooks
+  (cond
+    (not (mount/browser?)) (skip! ":node-test has no DOM")
+
+    (not (probe/install!))
+    (is false (str "React's internals slot was not found, so the ≤2-hook budget "
+                   "is UNWITNESSED for reg-state. A gate nobody has watched fire "
+                   "is not evidence — fix "
+                   (pr-str 're-frame.hicasso.hook-probe)
+                   " rather than reading this as a pass."))
+
+    :else
+    (do
+      (fresh!)
+      (let [container (mount/fresh-container!)
+            !handle   (volatile! nil)
+            names     (probe/record!
+                        (fn []
+                          (vreset! !handle
+                                   (mount/root! container frame-id
+                                                [disclosure {:ikey :solo :title "Solo"}]))))]
+        (mount/release! @!handle)
+        (is (= ["useContext" "useSyncExternalStore"] names)
+            (str "the shell called " (pr-str names) " — reg-state mints a sub "
+                 "and an event, and a sub read through the ambient collector is "
+                 "not a hook. A third call here is a budget breach (HD-020(b)) "
+                 "and would mean this sugar had grown machinery."))
+        (is (= (count collector/shell-hook-ledger) (count names))
+            "and the declared ledger is still the measured one — reg-state
+             added nothing to it")
+        (is (not-any? #{"useRef" "useState"} names)
+            "neither hook is per-instance React state: the value lives in
+             app-db, which is the whole point of keying it explicitly")))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — HD-028's bail-out survives a key vector rebuilt every render
+;; ---------------------------------------------------------------------------
+
+(deftest a-fresh-but-equal-key-vector-does-not-defeat-the-memo-bail-out
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [page {}])]
+        (try
+          (let [nodes-before (vec (panels handle))]
+            (reset-runs!)
+            (mount/dispatch! handle [label :page "chrome moved"])
+            (is (= 1 @!page-runs) "the page re-ran — it reads the chrome")
+            (is (= 0 @!panel-runs)
+                "and NEITHER panel did, although the page rebuilt both their
+                 `ikey` vectors from scratch on the way through. `child-key`
+                 allocates; `React.memo`'s comparator is `=`; a fresh-but-equal
+                 vector is an EQUAL prop. Had it been compared by identity this
+                 sugar would have re-introduced the cascade rf2-2rtt6.52 killed.")
+            (is (= "chrome moved"
+                   (.-textContent (.querySelector (:container handle) "h1.chrome")))
+                "and the write really landed — without this the row above could
+                 pass by doing nothing at all")
+            (is (= nodes-before (vec (panels handle)))
+                "the panels are the IDENTICAL DOM nodes"))
+          (testing "and a bail-out is not a disconnection: the panel still
+                   answers its own write afterwards"
+            (reset-runs!)
+            (click! handle 1)
+            (is (= ["" "body of Shipping"] (mapv #(or % "") (bodies handle))))
+            (is (= 1 @!panel-runs) "exactly the panel that moved, and no other"))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — a bad key refuses on the page, and the page keeps working
+;; ---------------------------------------------------------------------------
+
+(deftest a-nil-keyed-widget-refuses-loudly-and-its-sibling-keeps-rendering
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [records (volatile! [])]
+        (error-emit/register-error-listener! ::state-dom (fn [r] (vswap! records conj r)))
+        (let [handle (mount/root! (mount/fresh-container!) frame-id [:div.empty])]
+          (try
+            (mount/render! handle
+                           [:div.page
+                            [disclosure {:key "good" :ikey :billing :title "Billing"}]
+                            [disclosure {:key "bad" :ikey nil :title "Broken"}]])
+            (let [refusals (->> @records
+                                (mapcat (juxt (comp ex-data :exception)
+                                              (comp ex-data ex-cause :exception)))
+                                (filter #(= :rf.error/hicasso-state-bad-key
+                                            (:rf.error/id %))))]
+              (is (seq refusals)
+                  "a nil instance key refused — this is the guide's silent
+                   every-instance-shares pitfall converted into a loud error")
+              (is (some #(= open? (:concern %)) refusals)
+                  "and the refusal NAMES the concern, which is what makes it
+                   actionable on a page with several of them"))
+            (is (= 2 (count (panels handle)))
+                "the well-keyed sibling still rendered — one widget's bad key
+                 is not the page's problem")
+            (finally
+              (error-emit/unregister-error-listener! ::state-dom)
+              (mount/release! handle))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/todo_support.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/todo_support.cljs
@@ -1,0 +1,77 @@
+(ns re-frame.hicasso.todo-support
+  "THE SHARED TO-DO FRAME the ported `arm1/*` witnesses read from.
+
+  A boundary that reads nothing proves nothing about the read, so the
+  witnesses for `h/hframe`, the one callback form and the minted-key
+  warning all need a frame with rows in it. Each of them needs the same
+  three things — a seeded frame, a narrow per-row write, and a
+  per-row subscription that dirties when that write lands — so they are
+  written once here rather than four times inline.
+
+  ## Why this is not the bench tree's `front.dogfood`
+
+  The suites that became these witnesses read
+  `re-frame.bench.hicasso.front.dogfood`, and this namespace is
+  deliberately NOT that file moved. Two reasons, and both are about the
+  boundary between the package and the benchmark rather than about
+  taste.
+
+  1. **`front.dogfood` is a benchmark artefact.** Its subject is HD-002's
+     three renderings and the ergonomics comparison they feed — the
+     filter, the reorder, the per-instance drafts and the commit/cancel
+     reset law exist to make that comparison measurable. The package
+     asserts none of it, and a support namespace that carries a
+     benchmark's design rationale into `implementation/hicasso/test/`
+     invites the next reader to maintain it against a screen that lives
+     somewhere else.
+  2. **The ids would collide.** `implementation/shadow-cljs.edn` puts
+     `freehand/test` and `hicasso/test` on ONE `:node-test`
+     `:source-paths`, so both trees register into the same global
+     handler registry in the same build. A second `(rf/reg-event
+     :dogfood/toggle …)` would silently redefine the benchmark's, and
+     whichever namespace loaded last would decide what the other one
+     measured. The `:hicasso.todo/*` prefix here cannot reach it.
+
+  So this is the SLICE the package's own witnesses read — one seed, one
+  toggle, one `done?` — under ids the package owns."
+  (:require [re-frame.core :as rf]))
+
+;; ---------------------------------------------------------------------------
+;; The app-db shape
+;; ---------------------------------------------------------------------------
+
+(defn seed-db
+  "`n` to-dos, none done. The one place the shape is written out; every
+  assertion about the shape reads it from here."
+  [n]
+  {:todos (into {} (map (fn [i] [i {:id i :title (str "todo " i) :done? false}])) (range n))
+   :order (vec (range n))})
+
+;; ---------------------------------------------------------------------------
+;; The narrow read and the narrow write
+;; ---------------------------------------------------------------------------
+
+(rf/reg-sub :hicasso.todo/done? (fn [db [_ id]] (get-in db [:todos id :done?])))
+
+(rf/reg-event :hicasso.todo/seed (fn [_ [_ n]] {:db (seed-db n)}))
+
+(rf/reg-event :hicasso.todo/toggle
+  (fn [{:keys [db]} [_ id]] {:db (update-in db [:todos id :done?] not)}))
+
+;; ---------------------------------------------------------------------------
+;; The frame lifecycle
+;; ---------------------------------------------------------------------------
+
+(defn make-frame!
+  "Create (or idempotently replace) `frame-id`'s frame, seeded with `n`
+  to-dos. Runs outside any measured window."
+  [frame-id n]
+  (rf/make-frame {:id frame-id :initial-events [[:hicasso.todo/seed n]]})
+  frame-id)
+
+(defn reseed!
+  "Return the frame to its seeded state, so one witness never reads a
+  page a previous one already mutated."
+  [frame-id n]
+  (rf/with-frame frame-id (rf/dispatch-sync [:hicasso.todo/seed n]))
+  nil)


### PR DESCRIPTION
Three beads, one surface, worked in sequence: **rf2-a15c** (seven `arm1/*` rows), **rf2-npch** (the codec pair), **rf2-6rw9** (the SSR pair). All eleven ported; none reclassified; none dropped as a duplicate.

**What a port buys, stated correctly.** All 69 prototype suites already run on every PR — `freehand/test` is on `:source-paths`, `:node-test`'s `cljs-test$` matches them, and `:browser-test` excludes only `re-frame.freehand.bench.*`, a different tree. So this buys **zero** additional coverage of the prototype. It buys **the package** 130 deftests and 644 assertions over public-door surfaces it did not assert: `h/frame`, `h/reg-state` mounted, the minted-key warning, the one callback form under a real click, intents inside `h/boundary` and on a presence child, the codec, the `[:>]` escape, and the bare `:client-only` SSR arm.

Every ported suite's deftest and assertion counts match its source exactly — nothing was dropped in the move.

## The seven `arm1/*` rows (rf2-a15c) — all seven ported, none reclassified

The brief said to expect friction, and to reclassify to RE-AUTHORED any suite reaching `arm1.runtime` with no package counterpart. **I checked every var rather than every file, and every one has a counterpart**, so the reclassification never fired:

| bench namespace | package namespace |
|---|---|
| `arm1.runtime` (`sub`, `render-body`, `reads-of`, `last-reads`, `rendering?`, `reset-runtime!`, `reset-body-runs!`, `frame-dispatch`, `shell-hook-ledger`, `frame-prop-shell-hook-ledger`, `mint-frame-prop-view!`) | `impl.collector` |
| `arm1.runtime/stats` | `impl.inventory/stats` |
| `arm1.mount` | `impl.mount` (function-for-function, same names, same order) |
| `arm1.lang` macros `defview` / `hfn` / `defhost` | the public door `re-frame.hicasso` |
| `arm1.boundary` / `arm1.presence` | `impl.boundary` / `impl.presence-react` |
| `front.codec` / `front.intent` / `front.state` / `front.slot` | `impl.codec` / `impl.intent` / `impl.state` / `impl.slot` |
| `arm1.hook-probe` | `re-frame.hicasso.hook-probe` (landed by #7835) |
| `lane/leave-act-environment!` | `checkpoint-support/leave-act-environment!` |
| `lane/canonical` | `re-frame.hicasso.test/canonical-dom` |

Only one gap needed filling, and it is `front.dogfood`. See "Two support namespaces" below.

## Two corrections found by checking the premises

**rf2-npch's stated premise is false, and the plan survives it.** The bead says to confirm the corpus namespace carries no `deftest`. It carries **three**: the `corpus` var is at line 42 of `front/slot_cljs_test.cljc`, the deliberate `.cljc` equivalence pin asserted on both the JVM and CLJS hosts. What is `deftest`-free is the namespace this PR **creates** — `slot_corpus.cljs` holds the table and nothing else, so rules B1/B2 never reach it. That is what the triage actually described ("port the corpus as an ordinary support namespace"), so the conclusion stands: plain CLJS port, no lane, no roster entry, no workflow change.

**`arm1/raw_escape_dom_cljs_test` was never blocked by the corpus at all.** The bead pairs it with `front/codec_cljs_test` as "queued behind their shared corpus var". It does not `:require` `front.slot-cljs-test` and never reads `slot-test/corpus`; only `codec_cljs_test` does (lines 139 and 144). Its one genuine cross-suite dependency was `lane/canonical`, whose package counterpart already exists as `re-frame.hicasso.test/canonical-dom` — documented in the test kit as that very function "extracted … unchanged in behaviour".

**rf2-6rw9's mayor correction is right, verified independently before starting.** The two suites do not `:require` each other (each names the other once, in a docstring `[[wiki-link]]`, lines 31 and 57) and neither reaches `re-frame.bench.hicasso.ssr.entry` — both import React's own `react-dom/server` directly. **No SSR entry was added, because none is on the path.**

## `host_hatch` — yes, the landed `hook_probe` covers it

`arm1/host_hatch_dom_cljs_test` uses exactly two probe vars, `probe/install!` (line 1044) and `probe/record!` (line 1052). `re-frame.hicasso.hook-probe`, landed by #7835, exports exactly `install!` and `record!`. **Its blocker is resolved** — it is now an ordinary `arm1/*` port of the same shape as the seven here. It belongs to rf2-wjag, so it is not in this PR, but that bead can proceed.

## Duplication check — no duplicates, all eleven add coverage

Checked each of the eleven against all 28 package witnesses, including #7835's four new ones. The closest calls, and why they are not duplicates:

- **`callback_form_dom`** vs `intent_cljs_test` — the same three claims, but every one is driven by `(ev {…})`, a stand-in map through `intent/lower-prop`. `h/hfn` appears in no package `-dom-` suite; the package's real-click rows fire on intent *vectors*, never on a minted closure.
- **`host_ssr_dom`** vs `public_door_macros_cljs_test` — one row of twelve overlaps (`:render` policy under `renderToString`). The two refusal rows, `the-default-policy-is-client-only`, the provider-subtree deletion and all four hydration/adoption rows have no counterpart.
- **`state_dom`** — `state_cljs_test`'s own docstring names `arm1/state-dom-cljs-test` as the half it does **not** cover. That is a declared gap, not a coverer.

The one package file that names a bench suite explicitly is `roots_frames_support.cljs`, under a **"## Provenance"** heading — it borrows the DOM-expando *technique* from `hframe_dom`, not its claims.

## Two support namespaces, and why one is not a file move

**`todo_support.cljs`** (77 lines) is the seeded frame four ported witnesses read. It is deliberately **not** `front.dogfood` moved, for two reasons:

1. `front.dogfood`'s subject is HD-002's three renderings and the ergonomics comparison — the filter, the reorder, the per-instance drafts, the commit/cancel reset law. The package asserts none of it.
2. **The ids would collide.** `implementation/shadow-cljs.edn` puts `freehand/test` and `hicasso/test` on **one** `:node-test` `:source-paths`, so both trees register into the same global handler registry in the same build. A second `(rf/reg-event :dogfood/toggle …)` would silently redefine the benchmark's.

That same collision hazard is why every ported suite's global ids are re-namespaced under a `:hicasso.*` prefix (`:hicasso.hframe/*`, `:hicasso.bdy/*`, `:hicasso.presence-intent/*`, `:hicasso.ssr/*`, `:hicasso.fb/*`, `:hicasso.raw/*`). It is not cosmetic: `hframe`'s handlers close over their own volatiles, so a shared id would have let the bench registration win and left this suite's volatile unset.

**`slot_corpus.cljs`** (84 lines) is the canonical slot table, `deftest`-free by construction.

`capture-console!` joins `open-console-capture!` in `roots_frames_support.cljs` (+14 lines) — the bench tree already pairs them there, and the thunk-scoped wrapper is what lets `state_dom` drive the ordinary path inside a capture and assert it EMPTY.

## One wart noticed, not fixed

`impl.intent/hframe`'s refusal still reports `:where 'front.intent/hframe` — the package's production refusal names the **bench** namespace. `hframe_cljs_test` asserts it as-is because that is what the package emits. Changing it touches `implementation/hicasso/src/` and `check_complaint_catalogue.py`'s surface, which is outside these three beads; worth a follow-up.

## Five divergences the gates caught, and what each one was

None was a transcription slip. Every one is a real difference between the prototype and the package, which is the argument for running these ports through both lanes rather than eyeballing a rename.

**Three codec refusals had been reworded** (node lane). rf2-hic-007 moved the package's refusals to `impl.error/fail!` under `check_complaint_catalogue.py`, and the prose changed with it: `not a renderable child` → *"nil and false render nothing; true is an error (HD-016)."*; `Empty hiccup vector` → *"A hiccup vector must have a head."*; `not a valid element head` → *"Hiccup head must be a tag keyword, :<>, :>, …"*. Same behaviour, same ids, different sentence. The two rows in the second deftest now pin the **id** beside the wording, so a future catalogue rewording reds a row that names the contract rather than one that only knew a sentence.

**The keywarn suite collided with its own donor** (browser gate) — and this is the failure the file's docstring predicts in prose. React dedupes its key warning on the parent TAG NAME, module-globally for the life of the page. `:browser-test` compiles `freehand/test` and `hicasso/test` into **one** bundle and its `ns-regexp` selects both files, so `arm1/keywarn_dom_cljs_test` had already warned under `:keywarn-list` by the time the port ran; React deduped, and the row measuring React's channel read **zero**. Tags are now `:pkg-keywarn-list` / `:pkg-keyed-keywarn-list`, and the docstring names the donor as the earlier namespace instead of leaving it hypothetical.

**Presence costs four hooks in the package, not three** (browser gate). The prototype's `arm1/presence` reads the adoption window through `rt/adopting?`, a plain function. The package's `impl.presence-react` reads it through `roots/adopting-here?`, which **is** a hook — one `useContext`, root-scoped (rf2-6tmu) — and its own docstring says so. The distinct-name roster was already right (`distinct` collapses the two `useContext` reads); the multiplicity row was not. It is now a **floor** — at least two contexts per pass — because the raw list logs dispatcher *reads*, not calls, and React 19.2's dev build took six against four calls. The sibling `useEffect` row already pins that same instrument property. A floor moves the day presence stops reading the adoption window, which is the claim; an equality would instead move the day React changes how often it reads a context.

The claims' subjects survived all five. Only wording, a DOM tag and one hook count moved, and each is the package's own.

## Quality gates

| gate | exit | notes |
|---|---|---|
| `npm run test:cljs` (hicasso node lane) | **0** | 13181 tests, 66723 assertions, 0 failures, 0 errors (baseline on `main` was 13054 / 65997). Caught three real failures first — see "Five divergences the gates caught". |
| `npm run test:hicasso-invariants` | 0 | freeze + optional-module reachability + complaint catalogue, each with its self-test |
| `python hicasso/scripts/check_freeze.py` | 0 | **manifest unchanged** — 1 frozen row matches the bench tree, no package file imports it. A port MOVES a file; no original was edited. |
| `npm run test:browser` | **0** | 1227 tests, 7561 assertions, 0 failures, 0 errors. This is the gate that matters here — 21 of the package's suites are now `-dom-`, and it caught two failures the node lane cannot see. |
| `scripts/test-fast-pr.sh` | **0** | Invoked from the worktree ROOT. Includes the **test-lane bijection** (1872 test-defining files, 49 lanes, every file selected and every selector reached) and the **JVM roster↔CI bijection** (33 rostered artefacts) — together the proof that no lane, roster or workflow entry was needed. JVM artefact suites correctly skipped: `implementation_jvm` surface unchanged. |

Derived the CI gap with `python scripts/check_fast_pr_gap.py --list`: 96 required checks the spine does not decide. None is reached by this diff, which adds files under `implementation/hicasso/test/**` only — no `spec/*`, no `.github/workflows/*`, no `implementation/package.json`, no `implementation/shadow-cljs.edn`, no docs. No new build id or npm script was needed: the ported `-dom-cljs-test` namespaces are matched by `:browser-test`'s existing `ns-regexp`, and the rest by `:node-test`'s.

**Not run, with reasons:** `mkdocs build --strict` and `scripts/check_doc_slugs.py` — the diff touches no markdown. JVM lanes (`test-jvm-implementation.sh`, `test-jvm-tools.sh`) — the diff adds no `.cljc` under a JVM-rostered root and no JVM artefact; `slot_corpus.cljs` is `.cljs` deliberately.

## Fences

Untouched: the frozen bench tree (no original edited — `check_freeze.py` green with its manifest unchanged), `spec/*`, `.github/workflows/*`, `implementation/package.json`, `implementation/shadow-cljs.edn`, `implementation/hicasso/test_kit/**` and `impl/mount.cljs` (held by `worker/txmount-hic027` — required read-only, never edited), `erasure_*` (held by `worker/erasure-hic024`), `docs/design/hicasso/**` (held by #7836). No `.beads` path is on this branch.
