### PR TITLE
fix(hicasso): a method's name is neither a binding nor a call, and the array pair joins the roster (rf2-ka4d)

### DIFF
--- a/implementation/hicasso/lint-fixtures/negative.cljs
+++ b/implementation/hicasso/lint-fixtures/negative.cljs
@@ -488,6 +488,15 @@
 (h/defview step [{:keys [xs]}]
   [:div (str (areduce xs step total 0 (+ total (step))))])
 
+;; The accumulator DESTRUCTURED, which the `loop` it expands into accepts and
+;; clj-kondo's own analysis reads — so a rule that read the symbol production
+;; alone would leave the same hole one shape further in. Folding an array into a
+;; function and a count is the ordinary reason to want two accumulators. REDS
+;; UNDER an arm reading a symbol rather than a binding TARGET.
+(h/defview pair [{:keys [xs]}]
+  [:div (str (areduce xs i [pair n] [identity 0]
+                      [(fn [y] (pair ((aget xs i) y))) (inc n)]))])
+
 ;; `(amap a idx ret expr)` is the same grammar one argument shorter — the
 ;; accumulator arrives as `(aclone a)` rather than from an `init` — and its two
 ;; names sit at the SAME two positions, which is why one arm reads both forms.

--- a/implementation/hicasso/lint-fixtures/negative.cljs
+++ b/implementation/hicasso/lint-fixtures/negative.cljs
@@ -343,7 +343,9 @@
 ;; has no scope table, so it recognises a binding form by NAME, and a local
 ;; introduced by a form nobody wrote down is not seen — so calling it reports,
 ;; at ERROR, which stops the build. Six such forms were measured live at the CI
-;; pin after the `letfn` repair landed (rf2-ka4d).
+;; pin after the `letfn` repair landed (rf2-ka4d), and the array pair `areduce`
+;; / `amap` was measured the same way after THAT repair landed (merged-PR audit
+;; #7829) — a roster is only ever as good as its last reading of the grammar.
 ;;
 ;; So, once more, from the GRAMMAR rather than from the repair — and past
 ;; where grammar alone stops (merged-PR audit #7818): a shape answers "did I
@@ -423,6 +425,24 @@
     number (apply-to [_ spread-out] (spread-out)))
   [:div "spread"])
 
+;; A method's own NAME, which is the one thing in a spec form that is NOT a
+;; binding. `reify` compiles its methods into a type's prototype and the four
+;; spec forms expand the same way; nothing in any expansion puts the method name
+;; in scope, so a body that mentions it means the var, not the method.
+;;
+;; It still sits in HEAD POSITION of a list, exactly where a callee sits, so a
+;; walk that reads every list head reports the DEFINITION as a call. That is the
+;; false ERROR the repair for the false silence would otherwise introduce, which
+;; is why it is witnessed here rather than argued about. REDS UNDER a walk that
+;; does not skip a method's name.
+(h/defview toString [_]
+  [:div (str (reify Object (toString [_] "a definition, not a call")))])
+
+(h/defview valueOf [_]
+  (extend-type string Object
+    (valueOf [_] "also a definition"))
+  [:div "extended"])
+
 ;; `(defmethod multifn dispatch-val & fn-tail)`, tail written flat. The
 ;; multimethod's own NAME sits at position 0 and the dispatch value at 1, so
 ;; this REDS UNDER reading the tail from either — position 0 binds
@@ -449,6 +469,35 @@
     ([] "none")
     ([run-last] (run-last)))
   [:div "registered"])
+
+;; `(areduce a idx ret init expr)` binds TWO names, and neither is written in a
+;; binding vector: macroexpansion puts both into a `loop`, so `idx` and `ret`
+;; are in scope over `expr`. The accumulator is an ORDINARY VALUE and may
+;; perfectly well be a function — folding an array of steps into one function is
+;; a program somebody writes, and calling the accumulator is the whole point of
+;; it. Reported at ERROR (merged-PR audit #7829). REDS UNDER an arm that reads
+;; the index position alone.
+(h/defview folded [{:keys [steps]}]
+  [:div (str (areduce steps i folded identity
+                      (fn [x] ((aget steps i) (folded x)))))])
+
+;; The INDEX position, pinned separately so neither row passes on the other's
+;; coverage. No correct program calls this one — an index is an integer, and
+;; calling one throws whatever the linter says — exactly as for `dotimes`'s
+;; counter above. REDS UNDER an arm that reads the accumulator position alone.
+(h/defview step [{:keys [xs]}]
+  [:div (str (areduce xs step total 0 (+ total (step))))])
+
+;; `(amap a idx ret expr)` is the same grammar one argument shorter — the
+;; accumulator arrives as `(aclone a)` rather than from an `init` — and its two
+;; names sit at the SAME two positions, which is why one arm reads both forms.
+;; Neither of ITS positions is a program somebody calls (an index is an integer
+;; and the accumulator is an array), so this row pins MEMBERSHIP rather than a
+;; position: it REDS UNDER an arm naming `areduce` alone. The positions are
+;; pinned by the two rows above, which the identical expression reads. Measured
+;; live at the pin alongside `areduce`, and left out only by being unnamed.
+(h/defview slot [{:keys [xs]}]
+  [:div (str (amap xs i slot (do (slot) (aget xs i))))])
 
 ;; ---------------------------------------------------------------------------
 ;; parked-read / deferred-read — a READING DOOR that a local has taken

--- a/implementation/hicasso/lint-fixtures/positive.cljs
+++ b/implementation/hicasso/lint-fixtures/positive.cljs
@@ -195,6 +195,33 @@
   (defmethod dispatch-on :self [f] (f (self-call-in-defmethod {})))
   [:div "registered"])
 
+(h/defview self-call-in-areduce [{:keys [steps]}]
+  [:div (str (areduce steps i acc 0 (+ acc (count (self-call-in-areduce {})))))])
+
+(h/defview self-call-in-amap [{:keys [xs]}]
+  [:div (str (amap xs i acc (+ (aget acc i) (count (self-call-in-amap {})))))])
+
+;; ---------------------------------------------------------------------------
+;; A METHOD NAMED LIKE THE VIEW does not bind it, so a self-call in that
+;; method's body still reports.
+;;
+;; This is the direction nothing surfaces on its own. Reading a method as a
+;; named `fn` tail — which is what a `letfn` fnspec is — treats its NAME as the
+;; optional self binding, and a `reify` / `extend` method name is not lexical:
+;; no expansion puts it in scope. The whole spec form then went quiet, so a
+;; genuine direct self-call inside any method was silently missed (merged-PR
+;; audit #7829). A false silence is worse than a false error, because nothing
+;; will ever ask about it.
+;; ---------------------------------------------------------------------------
+
+(h/defview toString [_]
+  [:div (str (reify Object (toString [_] (str (toString {})))))])
+
+(h/defview valueOf [_]
+  (extend-type string Object
+    (valueOf [_] (str (valueOf {}))))
+  [:div "extended"])
+
 ;; ---------------------------------------------------------------------------
 ;; A READING DOOR that no local has taken still reports (rf2-c6t6).
 ;;

--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/README.md
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/README.md
@@ -79,10 +79,24 @@ hook recognises binding forms by **name**, and the roster is:
   `let`, `loop`, `when-let`, `if-let`, `when-some`, `if-some`, `when-first`,
   `doseq`, `dotimes`, `for`, `with-open`, `with-local-vars`, `binding`,
   `with-redefs`;
-* the **`fn` tails** — `fn`, `fn*`, `hfn`, every fnspec of a `letfn`, every
-  method of a `reify`, `specify!`, `extend-type` or `extend-protocol`, and a
-  `defmethod`'s tail. Every parameter of every arity, in each case, and a
-  local function's or method's own name;
+* the **array pair**, `areduce` and `amap`, which write their index and their
+  accumulator as bare arguments rather than in a vector and expand into a
+  `loop` binding both. An accumulator is an ordinary value and may well be a
+  function — `(areduce steps i f identity …)` folds an array of steps into
+  one — so calling it is ordinary code;
+* the **`fn` tails** — `fn`, `fn*`, `hfn`, every fnspec of a `letfn`, and a
+  `defmethod`'s tail: every parameter of every arity, and for a `letfn` the
+  local function's own **name** as well, because `letfn` expands each fnspec to
+  `(fn f …)` and `f` is in scope throughout;
+* the **parameters of every method** of a `reify`, `specify!`, `extend-type` or
+  `extend-protocol`, every arity's, exactly as above. A method's **name** is
+  deliberately *not* in that list: a method is written like a fnspec and is not
+  one, and no expansion of these four forms puts its name in scope, so a body
+  that mentions the name means the var. Reading it as a binding is what made a
+  genuine self-call inside such a method go unreported — the check's only
+  permitted failure is silence, so a silence that is *wrong* has nothing to
+  surface it. The name is not read as a **call** either: it sits in head
+  position of a list, but writing one defines a method and invokes nothing;
 * the **single names** bound by `catch`, `as->` and `this-as`.
 
 A local introduced by anything else is not seen, so calling one *does* report.

--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/hooks/re_frame/hicasso.clj
@@ -548,36 +548,68 @@
                  (keyword? kw) acc
                  :else         (conj acc target)))))))
 
+(defn- params-locals
+  "Every name the ARITIES of a `fn` tail bind — `forms` being everything after
+  the optional name.
+
+  Both productions are read here: `([params*] body*)` writes its vector first,
+  and `(([params*] body*)+)` writes one per arity list. Both ends of that are
+  pinned by fixtures, because both have been got wrong — reading only the first
+  form blocked every use of a multi-arity `letfn` (merged-PR audit #7804), and
+  reading only the later arities was invisible to rows that bound the same name
+  in each of them (merged-PR audit #7818)."
+  [forms]
+  (into #{}
+        (comp (filter api/vector-node?) (mapcat bound-symbols))
+        (if (api/vector-node? (first forms))
+          [(first forms)]
+          (keep #(when (api/list-node? %) (first (:children %))) forms))))
+
 (defn- fn-locals
   "The names a `fn` / `fn*` / `hfn` binds: its own optional name, and every
   parameter of every arity.
 
   `children` is a `fn` TAIL — everything after the head — which is also
   exactly what a `letfn` fnspec is, so `letfn` asks this rather than
-  re-deriving it."
+  re-deriving it. The NAME is read because a fnspec's name is a local
+  function: `letfn` expands each spec to `(fn f …)` and `f` is in scope
+  throughout."
   [children]
-  (let [self   (token-sexpr (first children))
-        forms  (if self (rest children) children)
-        params (if (api/vector-node? (first forms))
-                 [(first forms)]
-                 (keep #(when (api/list-node? %) (first (:children %))) forms))]
-    (into (if self #{self} #{})
-          (comp (filter api/vector-node?) (mapcat bound-symbols))
-          params)))
+  (let [self  (token-sexpr (first children))
+        forms (if self (rest children) children)]
+    (into (if self #{self} #{}) (params-locals forms))))
 
-(defn- fn-tail-locals
-  "The names a SEQUENCE of NAMED `fn` tails binds.
+(defn- method-locals
+  "The names ONE METHOD binds: the parameters of every arity, and NOTHING else.
 
-  Two families write one. A `letfn` binding vector holds fnspecs, which are
-  `fn` tails by construction. The specs of `reify`, `specify!`, `extend-type`
-  and `extend-protocol` hold methods, `(name [params*] body*)` — the same
-  production, so the same reading answers both.
+  A method is written like a fnspec — `(name [params*] body*)` — and is not
+  one, which is the whole of the difference. `letfn` expands a fnspec to
+  `(fn f …)`, so its name is a local; a method compiles into a protocol
+  implementation and no expansion puts its name in scope at all. Reading a
+  method as a named `fn` tail therefore INVENTED a binding, and because a
+  binding silences the entire form it heads, every genuine self-call anywhere
+  inside a `reify` / `extend` whose method happened to share the view's name
+  went unreported (merged-PR audit #7829).
 
-  Only LIST nodes are read, which is what lets one function serve five forms:
-  the protocol and type NAMES a spec also carries are tokens, and a token
-  binds nothing."
-  [nodes]
-  (into #{} (mapcat #(when (api/list-node? %) (fn-locals (:children %)))) nodes))
+  That direction is the one to be careful about. Silence is the only failure
+  this file permits, which is exactly why a silence that is WRONG is invisible:
+  no build fails, no message appears, and nothing but a reading of the grammar
+  will ever raise it."
+  [children]
+  (params-locals (rest children)))
+
+(defn- each-list
+  "`read-locals` applied to the children of every LIST in `nodes`, unioned.
+
+  Only lists are read, which is what lets one call serve four spec forms: the
+  protocol and type NAMES a spec also carries are tokens, and a token binds
+  nothing."
+  [read-locals nodes]
+  (into #{} (mapcat #(when (api/list-node? %) (read-locals (:children %)))) nodes))
+
+(def ^:private spec-forms
+  "The forms that write METHOD SPECS after one leading argument."
+  '#{reify specify! extend-type extend-protocol})
 
 (defn- locals-bound-by
   "The names this node binds over its own subforms, when it is a form that
@@ -615,27 +647,44 @@
         ;; read and every use of one reported at ERROR (merged-PR audit #7804).
         (= 'letfn core)
         (if (api/vector-node? (first more))
-          (fn-tail-locals (:children (first more)))
+          (each-list fn-locals (:children (first more)))
           #{})
 
         ;; `(reify P (m [v] …))` and the three forms that write the same specs
-        ;; somewhere else: a METHOD is a named `fn` tail exactly as a fnspec
-        ;; is, so its parameters are locals exactly as theirs are.
+        ;; somewhere else: a METHOD's PARAMETERS are locals exactly as a
+        ;; fnspec's are — and its NAME, unlike a fnspec's, is not one. See
+        ;; `method-locals`.
         ;;
         ;; The first argument is dropped for all four, which is uniform rather
         ;; than clever. `reify`, `extend-type` and `extend-protocol` name a
         ;; protocol or a type there and a name binds nothing, so dropping it
         ;; costs them nothing. `specify!` takes an ordinary EXPRESSION —
         ;; `(specify! (js-obj) …)` — sitting precisely where a method sits,
-        ;; and reading THAT as a method would bind its head symbol and silence
-        ;; the whole form, self-call and all.
-        (contains? '#{reify specify! extend-type extend-protocol} core)
-        (fn-tail-locals (rest more))
+        ;; and reading THAT as a method would bind its parameters and, worse,
+        ;; hide the call in it from the walk below.
+        (contains? spec-forms core)
+        (each-list method-locals (rest more))
 
         ;; `(defmethod area :square [{:keys [side]}] …)` — everything past the
         ;; multimethod and the dispatch value is a `fn` tail, arity lists
         ;; included, and `fn` is what `defmethod` hands it to.
         (= 'defmethod core) (fn-locals (drop 2 more))
+
+        ;; `(areduce a idx ret init expr)` and `(amap a idx ret expr)` bind two
+        ;; names each, and write neither in a binding vector: both expand into
+        ;; a `loop`, so the index and the accumulator are in scope over `expr`.
+        ;; The accumulator is an ORDINARY VALUE and may perfectly well be a
+        ;; function — `(areduce steps i f identity …)` folds an array of steps
+        ;; into one — so calling it is ordinary code, and it reported at ERROR
+        ;; (merged-PR audit #7829). `amap` is here beside it because the two
+        ;; names sit at the SAME positions in both forms, so this is one arm
+        ;; rather than two, and `amap` reproduced identically at the pin.
+        ;;
+        ;; Binding TARGETS rather than symbols: the `loop` accepts
+        ;; destructuring at the accumulator and clj-kondo's own analysis reads
+        ;; it, so a symbol-only reading would leave the same hole one shape in.
+        (contains? '#{areduce amap} core)
+        (into #{} (mapcat bound-symbols) (take 2 (rest more)))
 
         (= 'catch core)   (if-let [s (token-sexpr (second more))] #{s} #{})
         (= 'as-> core)    (if-let [s (token-sexpr (second more))] #{s} #{})
@@ -658,6 +707,31 @@
         (comp (mapcat subforms) (mapcat locals-bound-by))
         body))
 
+(defn- call-positions
+  "The children of `node` a CALL may be found in — all of them, unless `node`
+  writes method specs.
+
+  A method puts its NAME in head position of a list, which is exactly where a
+  callee sits, and that name is a DEFINITION rather than a call: nothing is
+  invoked by `(reify Object (toString [_] …))`. It is not a binding either (see
+  `method-locals`), so it cannot be quietened by binding it — the walk has to
+  skip it and read the method's tail, which it does here.
+
+  The head and the FIRST ARGUMENT are kept, because `specify!` writes an
+  ordinary expression there and a view called in it is a real self-call.
+
+  The question does not arise for `letfn`, whose fnspec name IS a local and so
+  silences its own form, nor for `defmethod`, whose multimethod name is an
+  argument rather than a head."
+  [node]
+  (let [cs (:children node)]
+    (if (and (api/list-node? node)
+             (contains? spec-forms (core-var (first cs))))
+      (into (vec (take 2 cs))
+            (mapcat #(if (api/list-node? %) (rest (:children %)) [%]))
+            (drop 2 cs))
+      cs)))
+
 (defn- self-call-nodes
   "Every `(nm …)` under `node` that is NOT inside a form binding `nm`.
 
@@ -673,7 +747,7 @@
     (concat (when (and (api/list-node? node)
                        (= nm (token-sexpr (first (:children node)))))
               [node])
-            (mapcat #(self-call-nodes nm %) (:children node)))))
+            (mapcat #(self-call-nodes nm %) (call-positions node)))))
 
 (defn- check-direct-view-call!
   "A view called like a function, where that is decidable.

--- a/implementation/hicasso/scripts/check_lint_export.py
+++ b/implementation/hicasso/scripts/check_lint_export.py
@@ -61,11 +61,11 @@ HOOK_FILE = os.path.join(EXPORT_DIR, "hooks", "re_frame", "hicasso.clj")
 EXPECTED = {
     # ERRORS -- true invariants (operator ruling, rf2-hic-022).
     "direct-view-call":             [25, 144, 162, 167, 170, 174, 181, 186,
-                                     191, 195],
+                                     191, 195, 199, 202, 218, 222],
     "function-in-head-position":    [99, 102, 105, 110, 114],
     # WARNINGS -- heuristics and assistance. Nothing blocks a build.
     "deferred-read":                [32, 37, 43],
-    "parked-read":                  [52, 56, 60, 208, 217],
+    "parked-read":                  [52, 56, 60, 235, 244],
     "unkeyed-mapped-child":         [68, 73, 76, 79],
     "nameless-interactive-element": [86, 89, 92, 123, 126],
 }
@@ -267,8 +267,8 @@ def self_test():
         # read and every use of one blocked the build again. Hand `fn-locals`
         # the name alone and the grammar rows in the negative half must red.
         ("a letfn fnspec read past its NAME reds", "hook",
-         "(fn-locals (:children %))",
-         "(fn-locals (take 1 (:children %)))",
+         "(each-list fn-locals (:children (first more)))",
+         "(each-list #(fn-locals (take 1 %)) (:children (first more)))",
          "direct-view-call"),
         # The same claim, one notch narrower, and the reason a shape is not a
         # witness (merged-PR audit #7818). "Every parameter of every arity"
@@ -279,8 +279,8 @@ def self_test():
         # is what this mutation reds; `zero-arity`, whose first arity binds
         # nothing, reds the opposite narrowing.
         ("a letfn arity SKIPPED reds", "hook",
-         "(keep #(when (api/list-node? %) (first (:children %))) forms))]",
-         "(keep #(when (api/list-node? %) (first (:children %))) (rest forms)))]",
+         "(first (:children %))) forms)",
+         "(first (:children %))) (rest forms))",
          "direct-view-call"),
         # A binding form MISSING FROM THE ROSTER (rf2-ka4d). The hook has no
         # scope table, so it knows a binding form by name; six were absent and
@@ -290,9 +290,43 @@ def self_test():
         # `dotimes` in the let-shaped set, `this-as`, `defmethod` -- are one
         # mechanism with this one, and their rows pin them individually.
         ("a binding form dropped from the roster reds", "hook",
-         "(fn-tail-locals (rest more))",
+         "(each-list method-locals (rest more))",
          "(do more #{})",
          "direct-view-call"),
+        # The array pair, which the roster still had no name for after the six
+        # above went in (merged-PR audit #7829). `areduce` and `amap` expand
+        # into a `loop` binding an index and an accumulator, and an accumulator
+        # may be a function -- so calling one is ordinary code and was reported
+        # at ERROR. One arm reads both, because the two names sit at the same
+        # positions in both forms; drop the arm and the four grammar rows in
+        # the negative half must red.
+        ("the array-macro binding pair dropped from the roster reds", "hook",
+         "(contains? '#{areduce amap} core)",
+         "(contains? '#{} core)",
+         "direct-view-call"),
+        # The FALSE SILENCE a repair introduced (merged-PR audit #7829), and
+        # the reason a method is read differently from a fnspec. `letfn`
+        # expands a fnspec to `(fn f ...)`, so its name is a local; NOTHING
+        # binds a `reify` / `extend` method's name. Reading a method as a named
+        # `fn` tail invented that binding, and a binding silences the form it
+        # heads, so every genuine self-call inside such a form went unreported
+        # -- with no message, no failing build and nothing to notice. Hand the
+        # methods to `fn-locals` again and the two same-name POSITIVE rows must
+        # stop firing.
+        ("a method NAME read as a binding reds", "hook",
+         "(each-list method-locals (rest more))",
+         "(each-list fn-locals (rest more))",
+         "direct-view-call"),
+        # The opposite error, which repairing that one invites: a method's name
+        # sits in head position of a list, exactly where a callee sits, so a
+        # walk that reads every list head reports the DEFINITION as a call --
+        # a fresh false ERROR, at the level that stops a build. Walk the raw
+        # children and the two method-definition rows in the negative half must
+        # red.
+        ("a method NAME read as a call reds", "hook",
+         "(mapcat #(self-call-nodes nm %) (call-positions node))",
+         "(mapcat #(self-call-nodes nm %) (:children node))",
+         "negative.cljs"),
         # A READ whose door a local has taken (rf2-c6t6). Same blindness, at
         # warning level: `:refer [sub]` leaves a simple symbol and a local may
         # be named `sub`, but `api/resolve` reads the ns form and never sees


### PR DESCRIPTION
Both gaps the merged-PR audit of #7829 found on **rf2-ka4d**, in the order that
matters: the false SILENCE first, because it is the one nothing surfaces.

Everything below was measured at the CI pin — `clj-kondo 2026.04.15`, via the
artefact's `:clj-kondo` alias. The npm binary on this host is 2025.10.23 and was
kept off `PATH` for every run in this PR, the gate's own runs included, because
a pass from a mismatched version proves nothing either way.

---

## Reproduced first, both of them, before either fix

### GAP 2 — a false silence #7829 introduced

`fn-tail-locals` fed method lists to `fn-locals`, which reads the leading token
as a named-`fn` self binding. A `reify` / `extend` method's name is **not**
lexical — no expansion of the four spec forms puts it in scope — so the invented
binding silenced the whole spec form, self-call and all.

```clojure
(h/defview toString [_]
  [:div (str (reify Object (toString [_] (str (toString {})))))])
```

```
linting took 484ms, errors: 0, warnings: 0        <- exit 0
```

That is a genuine direct self-call reported as nothing at all. The control
isolates the cause exactly — the identical call, in a method named `show`
instead:

```clojure
(h/defview toString [_]
  [:div (str (reify Shows (show [_] (str (toString {})))))])
```

```
probe.cljs:8:42: error: `toString` is a view, so it is a hiccup HEAD rather than a function…
linting took 379ms, errors: 1, warnings: 0        <- exit 3
```

So the method's **name** was the whole difference. This matters more than an
extra false ERROR because silence is the check's only permitted failure *by
design*: a wrong silence prints nothing, fails no build, and is invisible until
somebody re-reads the grammar. It was introduced by a repair, which is why the
audit caught it and no gate did.

### GAP 1 — a false ERROR still standing

`(areduce a idx ret init expr)` binds **both** `idx` and `ret` over `expr` —
macroexpansion puts them in a `loop` — and the accumulator is an ordinary value
that may perfectly well be a function.

```
probe.cljs:7:47:  error: `folded` is a view…      (areduce's accumulator)
probe.cljs:11:44: error: `step` is a view…        (areduce's index)
probe.cljs:15:36: error: `mapped` is a view…      (amap's accumulator)
probe.cljs:19:43: error: `cursor` is a view…      (amap's index)
linting took 451ms, errors: 4, warnings: 1        <- exit 3
```

`amap` is the same grammar one argument shorter, reproduced identically, and is
in this PR for the reason #7829 added `extend-protocol`: its two names sit at
the **same positions**, so one arm reads both forms and naming only `areduce`
would have been arbitrary rather than bounded. A destructured accumulator
reproduces too — the `loop` accepts one and clj-kondo's own analysis follows it.

Both gaps are then committed as fixtures in `4c9e533364`, **red on purpose**:
four ERRORs on correct code in the negative half, and two positive rows
reporting nothing.

---

## The repair, and what it is bounded to

Three grammar facts, and no more. No scope engine, no `api/resolve` (PR #7804
established by probe that it answers nil for the cases that matter and never
sees locals), no whole-program analysis; the small syntax-local walker and the
conservative whole-form silencing are untouched.

1. **A method's name is not a binding.** The reading is split. `fn-locals` keeps
   the optional self name, because a `letfn` fnspec's name *is* a local —
   `letfn` expands each spec to `(fn f …)`. `method-locals` reads the parameters
   of every arity and nothing else. `params-locals` is now the one place either
   finds an arity, so the two cannot drift apart about what an arity is.

2. **A method's name is not a call either** — and this one is the trap the first
   repair sets. A method name sits in head position of a list, exactly where a
   callee sits, and it can no longer be quietened by binding it, so
   `call-positions` skips it. The head and the **first argument** are kept:
   `specify!` writes an ordinary expression there, and a view called in it is a
   real self-call (`self-calling-specify-target`).

3. **The array pair joins the roster.** One arm, both forms, reading binding
   TARGETS rather than symbols.

Every method-parameter negative #7829 landed is preserved unchanged — `boxed`,
`second-group`, `marked`, `extended`, `spread-out` all bind the view's name as a
method *parameter*, which `method-locals` still reads.

---

## Rows added, and the narrowing each one catches

Derived from each form's grammar, then filtered by the harder question #7818
made the standard: *what single narrowing of the implementation would let this
row pass while the rule is broken?* A row with no such narrowing is decoration.
Gap 2 is itself the proof — #7829's method-parameter rows all passed while the
method-**head** rule was wrong, because none of them drove a method whose *name*
matched the view.

| half | row | binds / calls in | reds under |
|---|---|---|---|
| neg | `folded` | `areduce`'s **accumulator**, index named `i` | an arm reading the index position alone |
| neg | `step` | `areduce`'s **index**, accumulator named `total` | an arm reading the accumulator position alone |
| neg | `pair` | `areduce`'s accumulator **destructured** | an arm reading a symbol rather than a binding TARGET |
| neg | `slot` | `amap`'s accumulator | an arm naming `areduce` alone |
| neg | `toString` | a **method named like the view**, calling nothing | a walk that reads a method's head as a call (a fresh false ERROR) |
| neg | `valueOf` | the same, in `extend-type` | the same, past a type token |
| pos | `self-call-in-areduce` | a genuine self-call inside `areduce` | an arm that silences the whole form instead of binding two names |
| pos | `self-call-in-amap` | the same, inside `amap` | the same |
| pos | `toString` | a genuine self-call **inside a method named like the view** | reading the method HEAD as a self binding — the #7829 defect |
| pos | `valueOf` | the same, in `extend-type` | the same, past a type token |

The two `toString` / `valueOf` pairs are deliberately one negative and one
positive each: the negative pins that a method DEFINITION is not a call, the
positive pins that the method's name does not bind. A repair that got either
half alone would pass one row and red the other.

### Shapes NOT driven, and why — the valuable half

* **`amap`'s index, and a destructured `amap` accumulator.** Both forms reach
  the same expression through one arm, so the position and destructuring
  narrowings are already pinned by `step` and `pair`. A row per form would
  re-witness the identical code path; `slot` pins the only thing `amap` adds,
  which is membership.
* **`areduce`'s `a` and `init` positions.** Neither binds anything — `a` is
  evaluated before the loop and `init` is an ordinary expression in the loop's
  binding vector — so there is no local to protect.
* **A same-name method in `specify!` or `extend-protocol`.** All four spec forms
  reach `method-locals` through a **single** call site and `call-positions`
  through a single `spec-forms` membership test, so a row per form witnesses one
  narrowing four times. `reify` and `extend-type` are driven instead, which are
  the two shapes that differ in what precedes the method.
* **A multi-arity METHOD** (`(-invoke ([this] …) ([this a] …))`). `method-locals`
  reads arities through `params-locals`, shared with `fn-locals`, and both ends
  of that reading are already pinned — `first-arity` and `zero-arity` on the
  `letfn` side, `run-any` and `run-last` on `defmethod`'s. A fifth pair would
  witness `params-locals` again, not the method reading.
* **A non-method LIST in a spec position** — `(extend-protocol P (compute-type)
  (m [x] …))`. `call-positions` would drop its head from the walk. The cost is a
  missed finding, which is the failure this file permits, and the form is not a
  program anyone has.
* **A `&` rest name in head position; `specify`; `deftype` / `defrecord` /
  `proxy`.** Inherited from #7818 and #7829 and unchanged; recorded in the
  README.
* **`dotimes`- and index-class rows generally.** Stated plainly in the fixture,
  as #7829 stated it: no correct program calls an integer. Those rows are
  mechanical position witnesses, and the reason to close the hole is that a
  roster with a hole in it is this bead's entire defect class.

---

## Mutation proof

Applied **from a file, never a heredoc**, by a harness that refuses unless the
target text is present *and unique*, re-reads the file off disk after writing,
and prints sha256 before / mutated / restored plus `git diff --stat` — because a
worker on this exact surface had a heredoc silently mangle a mutation while the
suite reported green. Every restore was byte-identical (`da466e5e13defcea`
throughout) and `git diff --numstat` returned to 105/31 after each.

**1 — the array arm dropped** (`'#{areduce amap}` → `'#{}`), gate exit 1:

```
sha256 before=da466e5e13defcea mutated=1660db9157c58a17 changed=True target-gone=True replacement-present=True
  lint-fixtures/negative.cljs:482:47 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `folded` is a view…
  lint-fixtures/negative.cljs:489:48 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `step` is a view…
  lint-fixtures/negative.cljs:498:32 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `pair` is a view…
  lint-fixtures/negative.cljs:509:34 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `slot` is a view…
```

**2 — a method name read as a binding again** (`method-locals` → `fn-locals`,
i.e. the #7829 defect restored), gate exit 1:

```
sha256 before=da466e5e13defcea mutated=ab766400ca9e40cb changed=True target-gone=True replacement-present=True
  direct-view-call: expected rows [25, 144, 162, 167, 170, 174, 181, 186, 191, 195, 199, 202, 218, 222]
                    in lint-fixtures/positive.cljs, got [25, 144, 162, 167, 170, 174, 181, 186, 191, 195, 199, 202]
```

Rows 218 and 222 — the two same-name methods — go quiet, and *nothing else
changes*. That is the shape of the defect: a green gate over a missing finding.

**3 — a method name read as a call** (`call-positions` → `:children`), gate
exit 1:

```
sha256 before=da466e5e13defcea mutated=78d608bddb110c3f changed=True target-gone=True replacement-present=True
  direct-view-call: expected rows […, 218, 222] in lint-fixtures/positive.cljs,
                    got […, 218, 218, 222, 222]
  lint-fixtures/negative.cljs:439:28 fired re-frame.hicasso/direct-view-call -- correct code must be silent: `toString` is a view…
  lint-fixtures/negative.cljs:443:5  fired re-frame.hicasso/direct-view-call -- correct code must be silent: `valueOf` is a view…
```

The doubled rows are the definition *and* the call both reported. This is the
false ERROR the Gap 2 repair would have introduced on its own.

### The self-test, and three cases it caught on itself

Three new permanent cases (the array arm, the method name as a binding, the
method name as a call). Three **existing** cases then failed with `the mutation
target is gone from hicasso.clj` — the refactor had moved their targets, and the
harness's own guard refused to report a cheerful `ok` over a mutation that never
applied. Repointed to the new spellings and re-run: eleven mutations, all red,
unmutated export green.

```
  ok   a disabled check reds the positive half
  ok   an element check reading props maps reds the negative half
  ok   a check firing at the wrong ROWS reds
  ok   a self-call check blind to lexical shadowing reds
  ok   a letfn fnspec read past its NAME reds
  ok   a letfn arity SKIPPED reds
  ok   a binding form dropped from the roster reds
  ok   the array-macro binding pair dropped from the roster reds
  ok   a method NAME read as a binding reds
  ok   a method NAME read as a call reds
  ok   a read rule blind to a shadowed door reds
  ok   the unmutated export passes
check_lint_export self-test: PASS
```

`lint.yml`'s self-test description was made count-free by #7831, so the move
from eight to eleven needs no edit there — and I am fenced out of it regardless.

---

## The README rule, corrected

It stated the false rule outright: *"every parameter of every arity, in each
case, and a local function's or method's own name"*. It now reads:

> * the **`fn` tails** — `fn`, `fn*`, `hfn`, every fnspec of a `letfn`, and a
>   `defmethod`'s tail: every parameter of every arity, and for a `letfn` the
>   local function's own **name** as well, because `letfn` expands each fnspec
>   to `(fn f …)` and `f` is in scope throughout;
> * the **parameters of every method** of a `reify`, `specify!`, `extend-type`
>   or `extend-protocol`, every arity's, exactly as above. A method's **name**
>   is deliberately *not* in that list: a method is written like a fnspec and is
>   not one, and no expansion of these four forms puts its name in scope, so a
>   body that mentions the name means the var. Reading it as a binding is what
>   made a genuine self-call inside such a method go unreported — the check's
>   only permitted failure is silence, so a silence that is *wrong* has nothing
>   to surface it. The name is not read as a **call** either: it sits in head
>   position of a list, but writing one defines a method and invokes nothing;

plus a new roster bullet for the array pair, naming why an accumulator is
callable.

---

## Tree-wide accounting

clj-kondo at the pin over `lint.yml`'s exact path list, cold cache on both sides,
the source tree byte-identical between runs — only the export directory differed
(`git checkout origin/main -- …clj-kondo.exports`, run, restore; sha256 verified
back to `9208781920b034ad`).

```
kondo_before.json (origin/main export)  findings=4700  errors 0 / warnings 4543 / info 157   files=3130
kondo_after.json  (this branch)         findings=4700  errors 0 / warnings 4543 / info 157   files=3130

removed by this branch: 0
added by this branch:   0
```

Sorted finding-set diff is **empty**. (#7829 measured 4542 / 157 over 3119 files;
`main` has since gained eleven files and one warning, and both sides here are
that same tree.)

---

## Quality gates

| gate | exit | note |
|---|---|---|
| `scripts/test-fast-pr.sh` | **0** | run to completion from the worktree root, never piped; `gate root: /c/Users/miket/code/re-frame2-worktrees/areduce-ka4d`. `implementation/node_modules` was junctioned at the mayor checkout's real one before the first run and the LINK removed afterwards, with the mayor's tree re-counted at 103 entries. |
| `python scripts/check_lint_export.py` (at the pin) | 0 | `OK: 6 checks fire on their fixtures, correct code is silent, and the artefact's own testbeds are quiet.` |
| `python scripts/check_lint_export.py --self-test` (at the pin) | 0 | eleven mutations, all red; unmutated export green |
| corpus run (`implementation/hicasso/testbed`, at the pin) | 0 | part of the gate above — silent |
| tree-wide clj-kondo, both sides | 0 errors | empty finding-set diff, above |
| `python scripts/check_fast_pr_gap.py --list` | 0 | 96 required checks this spine does not decide |
| `mkdocs build --strict` | not run | no file under `docs/` is touched |
| browser / adapter smokes | not run | no substrate, adapter or testbed source is touched; this PR is a clj-kondo export, its fixtures and its gate script |

Fences held: the small syntax-local walker, conservative whole-form silencing,
no `api/resolve`, no whole-program analysis, and nothing outside
`implementation/hicasso/resources/clj-kondo.exports/**`,
`implementation/hicasso/lint-fixtures/**` and
`implementation/hicasso/scripts/check_lint_export.py`. `spec/*`,
`.github/workflows/*` and `implementation/package.json` are untouched.
