### PR TITLE
fix(hicasso): schedule the erasure proof; correct the census arithmetic (rf2-hic-024, rf2-hic-076)

### DIFF
--- a/docs/design/hicasso/product/tool-consumer-census.md
+++ b/docs/design/hicasso/product/tool-consumer-census.md
@@ -225,15 +225,17 @@ The full list:
 
 ## Disposition of the still-live rows
 
-The 18 STILL-LIVE rows resolve into **four clusters**, not eighteen independent problems.
+**Seventeen** of the 18 STILL-LIVE rows resolve into **four migration clusters**, not eighteen
+independent problems. The eighteenth, **X3**, is not a migration at all: it is an adapter-identity
+cleanup that folds into `rf2-hic-062` itself. Seventeen plus X3 is the whole still-live set.
 
 | cluster | rows | what moving it costs | disposition |
 |---|---|---|---|
-| Xray Views panel on donor 2 | X1, X2, X4, X5 | re-authoring against four different reads; the panel's whole question ("which *views* are mounted") is one the target cannot answer, because Hicasso keys boundaries by read set and has no view registry | follow-up bead |
-| The staged Freehand deck | X6, X7, X8 | the deck's shadow-cljs build id and `:dev-http` port live in top-level `implementation/shadow-cljs.edn` — hot zone, and fenced out of this bead | follow-up bead |
-| Story presence bridge | S2, S3, S4, S5, S6 | Hicasso's presence surface is `re-frame.hicasso.impl.presence` / `.presence-react`, not a published `presence-runtime` door with `advance-clock!`; the bridge needs a target-side verb that does not exist yet | follow-up bead |
-| Pair's five view tools | P1, P2, P3, P4, P5 | same four-reads problem as the Xray cluster, plus a regenerated `tool-descriptors.edn` and a spec-catalogue rewrite | follow-up bead |
-| Xray adapter-id set | X3 | `:rf.adapter/ui` and `:rf.adapter/freehand` are adapter identities, not evidence reads; they retire when the adapters do, under `rf2-hic-062` itself | fold into rf2-hic-062 |
+| Xray Views panel on donor 2 | X1, X2, X4, X5 | re-authoring against four different reads; the panel's whole question ("which *views* are mounted") is one the target cannot answer, because Hicasso keys boundaries by read set and has no view registry | follow-up bead `rf2-jkdy` |
+| The staged Freehand deck | X6, X7, X8 | the deck's shadow-cljs build id and `:dev-http` port live in top-level `implementation/shadow-cljs.edn` — hot zone, and fenced out of this bead | follow-up bead `rf2-u5b4` |
+| Story presence bridge | S2, S3, S4, S5, S6 | Hicasso's presence surface is `re-frame.hicasso.impl.presence` / `.presence-react`, not a published `presence-runtime` door with `advance-clock!`; the bridge needs a target-side verb that does not exist yet | follow-up bead `rf2-5gka` |
+| Pair's five view tools | P1, P2, P3, P4, P5 | same four-reads problem as the Xray cluster, plus a regenerated `tool-descriptors.edn` and a spec-catalogue rewrite | follow-up bead `rf2-n3mb` |
+| Xray adapter-id set | X3 | `:rf.adapter/ui` and `:rf.adapter/freehand` are adapter identities, not evidence reads; they retire when the adapters do, under `rf2-hic-062` itself | fold into `rf2-hic-062` — no follow-up bead |
 
 **No migration was made in this bead, and that is the finding rather than a shortfall.** Every
 still-live cluster fails the same test: the target does not publish the read the consumer needs, so
@@ -252,11 +254,19 @@ For `rf2-hic-062` to cite:
 > **Primary tool paths are not yet donor-free.** Of 27 tool-consumer rows across Xray, Story and
 > Pair, 4 are MIGRATED to the adapter-neutral Hicasso provider (all in Xray's Hicasso tab), 5 are
 > FIXTURE-ONLY compatibility evidence in Story's `test/` tree on a `:test`-alias classpath, and
-> **18 are STILL-LIVE on a donor tier**. The 18 form four clusters: Xray's Reactive-panel Views
-> section and its `tools/xray/deps.edn` top-level `day8/re-frame2-freehand` coordinate; the staged
-> `freehand-views` browser deck and its feature-matrix scenario; Story's shipped `presence-host`
-> bridge; and all five of Pair's view tools, which reach `re-frame.freehand.tool` by wire string
-> rather than by `:require` and therefore do not appear in any classpath scan.
+> **18 are STILL-LIVE on a donor tier**. **Seventeen** of those form four migration clusters, each
+> with a filed follow-up: Xray's Reactive-panel Views section and its `tools/xray/deps.edn`
+> top-level `day8/re-frame2-freehand` coordinate (`rf2-jkdy`); the staged `freehand-views` browser
+> deck and its feature-matrix scenario (`rf2-u5b4`); Story's shipped `presence-host` bridge
+> (`rf2-5gka`); and all five of Pair's view tools, which reach `re-frame.freehand.tool` by wire
+> string rather than by `:require` and therefore do not appear in any classpath scan (`rf2-n3mb`).
+>
+> The eighteenth is **X3**, the live set of React-element-shaped adapter ids in
+> `tools/xray/src/day8/re_frame2_xray/mount.cljs`. It is **not** a fifth migration and has no
+> follow-up bead: `:rf.adapter/ui` and `:rf.adapter/freehand` are adapter *identities* rather than
+> evidence reads, so they retire when the adapters do — which makes X3 an adapter-identity cleanup
+> **folded into `rf2-hic-062` itself**. Anything acting on the four clusters alone leaves X3
+> unaccounted for.
 >
 > **The blocker is not effort, it is question shape.** `re-frame.ui.tool` and
 > `re-frame.freehand.tool` publish the same five reads, so donor 1 → donor 2 was a rename.

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -38,7 +38,7 @@
     "build:machines-viz-viewer": "shadow-cljs release machines-viz-viewer && node ../tools/machines-viz/scripts/stage-viewer-page.cjs",
     "build:freehand-release": "shadow-cljs release freehand-release",
     "build:freehand-evidence-elision": "shadow-cljs release freehand-release freehand-release-control",
-    "build:hicasso-release": "shadow-cljs release hicasso-release",
+    "build:hicasso-release": "shadow-cljs release hicasso-release && node hicasso/scripts/check_production_erasure.cjs --self-test && node hicasso/scripts/check_production_erasure.cjs",
     "test:ui": "npm run test:ui-isolation && node out/node-test-ui.js",
     "test:ui-isolation": "node scripts/check-ui-adapter-isolation.cjs --self-test && node scripts/compile-node-test.cjs node-test-ui out/node-test-ui.js && node scripts/check-ui-adapter-isolation.cjs",
     "test:ui-warm-watch": "node scripts/check-ui-warm-watch.cjs",


### PR DESCRIPTION
Two reopened-by-audit beads, both bounded repairs to work that already landed. Neither is a redesign: `rf2-hic-024` schedules a proof that existed and ran nowhere, `rf2-hic-076` corrects one arithmetic claim in a census that otherwise reconciles.

## rf2-hic-024 — the erasure proof existed and nothing ran it

PR #7838 landed a five-sentinel / three-control production-erasure proof, and then `implementation/package.json` still defined:

```
"build:hicasso-release": "shadow-cljs release hicasso-release"
```

`test.yml` runs only that npm command. So every PR could build the exact release artefact successfully without executing `check_production_erasure.cjs --self-test` or the real bundle scan. Confirming the shape of it before touching anything — `check_production_erasure.cjs` was referenced by **no workflow, no npm script and no document** anywhere in the tree:

```
$ grep -rn "check_production_erasure" --include=*.yml --include=*.md --include=*.json --include=*.py .
(no output)
```

The repair is the erasure worker's own recommendation, which this PR simply executes:

```
"build:hicasso-release": "shadow-cljs release hicasso-release && node hicasso/scripts/check_production_erasure.cjs --self-test && node hicasso/scripts/check_production_erasure.cjs"
```

**Why the build's definition and not a new gate.** Making the scan part of what *building* means is what makes the bundle unproducible unchecked, and it inherits `test.yml`'s existing `cljs`-job step with **no new job, predicate or script family** — the `rf2-hic-021` lesson that the cheapest condition to keep correct is the one nobody had to write. `test:hicasso-invariants` would have been the wrong home: that gate is sub-second static reads in the fast-PR spine and never builds the bundle.

Flags and paths were read off the script rather than transcribed: `main()` takes `--self-test` and otherwise scans, and the bundle path derives from `__filename`, so it is cwd-independent — but npm runs scripts with cwd `implementation/` anyway, where `hicasso/scripts/…` resolves.

### Proving the wiring bites

The entire finding is that a gate existed and nothing invoked it, so "the command still succeeds" would have reproduced the defect. The sabotage had to break the gate that **actually holds the surface out** — per the merged bead's own note, two first-pass sabotages went green because Closure dropped the surface for unrelated reasons. Here: the `goog.DEBUG` wrapper on `codec/retain-body!` in `mint-view!` (`implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs:1873`), which is what keeps the `hicassoBody` own-property slot out of a production head.

**Green baseline** — `npm run build:hicasso-release`, exit `0`:

```
[:hicasso-release] Build completed. (161 files, 106 compiled, 0 warnings, 25.56s)
hicasso production erasure: self-test OK (5 sentinels, 3 positive controls)
OK: no dev-only Hicasso surface in the :advanced / goog.DEBUG=false bundle (5 sentinels absent, 3 positive controls present).
```

**Sabotaged, new script body** — exit `1`:

```
[:hicasso-release] Build completed. (161 files, 5 compiled, 0 warnings, 24.45s)
hicasso production erasure: self-test OK (5 sentinels, 3 positive controls)
hicasso production erasure: FAIL
  DEV SURFACE LEAKED: test kit — the dev-only body-retention door (rf2-hic-020, rf2-kjf5)
    sentinel: "hicassoBody"
    The own property `codec/retain-body!` writes and `codec/retained-body` reads — the L0-L2 kit's only route from a minted head back to the body its author wrote. Written from `mint-view!` inside `(when ^boolean js/goog.DEBUG …)`.
    Check that gate at impl/collector.cljs `mint-view!`; a production head must carry no body.
```

**The counterfactual, which is the actual proof of the defect** — the *old* script body (`shadow-cljs release hicasso-release` alone) against that same sabotaged tree, exit `0`:

```
[:hicasso-release] Build completed. (161 files, 0 compiled, 0 warnings, 21.48s)
```

That is a green CI run shipping `hicassoBody` in the consumer bundle. Note it in both logs above: the *build* succeeds in every case with 0 warnings. Only the appended scan distinguishes them, which is precisely why the scan had to become part of the build.

**Restored byte-identically, green again** — exit `0`:

```
[:hicasso-release] Build completed. (161 files, 5 compiled, 0 warnings, 21.55s)
hicasso production erasure: self-test OK (5 sentinels, 3 positive controls)
OK: no dev-only Hicasso surface in the :advanced / goog.DEBUG=false bundle (5 sentinels absent, 3 positive controls present).
```

Byte-identity is by blob hash, not by eye: `git hash-object` on `collector.cljs` reads `d8a022440a86fcc3695507fd43dd16f220f5c7a4` both before the sabotage and after the restore. The diff of this PR touches one line of `package.json` and nothing else under `implementation/`.

**`check_gate_scheduling.py` is unaffected and stays green.** It walks the `npm run` closure; these are direct `node` invocations inside a script that was already scheduled, so no disposition changes: `49 gate commands, 41 scheduled, 8 declared (0 of them known holes with beads)`.

## rf2-hic-076 — the census proof statement's arithmetic

The durable proof statement said all 18 STILL-LIVE rows "form four clusters". The four named clusters total **seventeen**. X3 is a fifth disposition — present in the table and assigned to `rf2-hic-062`, but missing from the paragraph.

**Arithmetic re-derived from the tables rather than taken on trust:**

| | count | source |
|---|---|---|
| STILL-LIVE | 18 | `grep -c "\| STILL-LIVE \|"` |
| FIXTURE-ONLY | 5 | `grep -c "\| FIXTURE-ONLY \|"` |
| MIGRATED | 4 | `grep -c "\| MIGRATED \|"` |
| total rows | 27 | 18 + 5 + 4 |

And the cluster sum: X1/X2/X4/X5 = 4, X6-X8 = 3, S2-S6 = 5, P1-P5 = 5 → **17**. Plus X3 → **18**. Confirmed against the per-tool headings too (Xray 8 still-live, Story 5, Pair 5 = 18).

The repair states that seventeen rows form four *migration* clusters and that X3 is the separate adapter-identity cleanup folded into `rf2-hic-062` itself, and names the four filed follow-ups where the clusters are: `rf2-jkdy` (Xray Views panel), `rf2-u5b4` (staged freehand-views deck), `rf2-5gka` (Story presence bridge), `rf2-n3mb` (Pair's five view tools). Each id was verified open and matched to its cluster by reading the bead, not by position.

This matters beyond one digit because the paragraph is what `rf2-hic-062` cites when deciding what may be **deleted**. A row real in the table but absent from the paragraph is one a reader acting on the paragraph will not account for.

**Nothing else in the census moved**: no classification re-derived, no row re-counted, no census method restated, nothing under `tools/` touched.

## Quality gates

| gate | exit | note |
|---|---|---|
| `npm run build:hicasso-release` (the changed script, green tree) | `0` | build + self-test (5 sentinels, 3 controls) + real bundle scan |
| `npm run build:hicasso-release` (sabotaged tree) | `1` | verbatim red quoted above — the wiring bites |
| `shadow-cljs release hicasso-release` alone (sabotaged tree) | `0` | the counterfactual: what CI would have passed before this PR |
| `npm run build:hicasso-release` (restored tree) | `0` | restore is byte-identical by blob hash |
| `python scripts/check_gate_scheduling.py --self-test` | `0` | |
| `python scripts/check_gate_scheduling.py` | `0` | 49 gate commands, 41 scheduled, 8 declared |
| `python scripts/check_doc_slugs.py` | `0` | silent on success — coverage proven below |
| `python scripts/check_doc_slugs.py` (planted bogus anchor) | `1` | `BROKEN ANCHOR: docs\design\hicasso\product\tool-consumer-census.md:252 -> #wirescan-hic024-anchor-that-does-not-exist`; restored byte-identically (blob `16e330bbefc6cd59088ed5a990e3518c9d378dbb` before and after) |
| `sh scripts/test-fast-pr.sh` | `0` | `PASS fast PR spine`, run from the worktree root. Tiers not run, as the spine itself reports: all JVM artefact suites (`implementation_jvm` surface unchanged) and the CI-only lanes (browser, prod-elision/bundle-isolation/perf, adapter probes + smokes, Xray feature matrix, mcp-conformance, tool JVM suites) |

**Not run, with reasons.** `mkdocs build --strict` does **not** cover `docs/design/**` — `mkdocs.yml`'s `exclude_docs` block deliberately keeps `design/hicasso/` out of the site, so it is not the gate for this edit; `check_doc_slugs.py` is, and it ran with its coverage proven. Nothing validates markdown tables, so the disposition table's columns were counted by hand: every row carries 5 pipes = 4 columns, matching the header and the separator, before and after the edit.

**The derived gap.** `python scripts/check_fast_pr_gap.py --list` places `npm run build:hicasso-release` as a **step inside `test.yml`'s `cljs` job** — a required check the fast-PR spine does not run, reported under the job's name rather than as a test. That is exactly why the build was executed directly here four times rather than left to the spine, and it is also the reason this wiring was worth doing: the step is already required, so the scan is now required with it.

## Fence

Surface held: `implementation/package.json` and `docs/design/hicasso/product/tool-consumer-census.md`. Nothing outside it was changed — `collector.cljs` was sabotaged and restored byte-identically within the run and carries no diff. `implementation/package.json` is hot-zone sequential-access; it was edited, committed and pushed before any long gate run and not held across one. Stayed clear of #7839, #7842 and #7843 throughout.
