### PR TITLE
docs(xray): the Views panel retires with the donor rather than migrating to Hicasso (rf2-jkdy)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -929,6 +929,51 @@ Freehand host's views and mounting Xray's own chrome into it are separate
 questions, and the refusal is what makes the second one an
 `:unsupported-substrate` diagnostic instead of an uncaught React child error.
 
+### §3.4.3 Disposition — these sections retire WITH the donor rather than moving to Hicasso
+
+Spec SN §12 Phase 6 requires every live Xray consumer onto the adapter-neutral
+Hicasso evidence provider before the donor tool surfaces are disposed of. For
+§3.4.1 and §3.4.2 that cannot be carried out as a migration, and the reason is
+recorded here so it is neither re-derived nor re-attempted (rf2-jkdy, against
+the rf2-hic-076 census rows X1/X2/X4/X5).
+
+Donor 1 → donor 2 was a rename: `re-frame.ui.tool` and `re-frame.freehand.tool`
+publish the same five reads, so the earlier crossing cost this panel its
+`:require` lines and nothing else. The target is not a rename.
+`re-frame.hicasso.tool` publishes FOUR reads — `read-mounted-boundaries`,
+`read-read-attribution`, `read-intents`, `explain-render` — over a runtime that
+mints no boundary identity and ships no manifest (`re-frame.hicasso.impl.evidence`:
+*"No evidence subsystem ships: no manifest, no registry, no buffering"*). Only
+`explain-render` even shares a name.
+
+| What §3.4 asks | Freehand field | On `re-frame.hicasso.tool` |
+|---|---|---|
+| Which VIEW is mounted | `:view-id` | **none.** `:view` and `:source` are `:unknown` under an `:opaque` naming projection whose own `:why` states that naming a boundary would need a registry this producer will not levy — not a gap awaiting closure |
+| Which OCCURRENCE of it | `:occurrence` | **none.** A boundary is keyed by its READ SET, so two boundaries reading alike are indistinguishable and collapse into one row carrying `:instances` |
+| Compiled or interpreted | `:lowering` | **none.** There is no execution-mode axis to state (spec SN §13); "lowering" in Hicasso names intent lowering, a different thing |
+| When, at which generation, under which cascade | `:at`, `:generation`, `:dispatch-id` | **none per row.** `:generation` is one runtime-wide number on the envelope, a boundary row carries no clock reading, and the commit seam records no cascade id |
+| What it read | `:reads`, the selected commit's staged set | `:reads` — the closest counterpart, but the boundary's LIVE edge set rather than one commit's |
+| Over which frame | `:frame` | `:frame`, or `:unknown` where the read set spans frames |
+| Why it rendered | `explain-render` `:cause`, joined when the window holds the run | `explain-render`, but `:cause` is `:unknown` STRUCTURALLY every time — `:uncorrelated`, with candidates offered as leads |
+| What each view DECLARES (§3.4.2) | the manifest triple | **none.** There is no manifest, and no fourth read stands in for one |
+
+Two of the eight carry across, one degrades, and five — including the panel's
+whole subject — have no answer. A §3.4 re-pointed at the target would render a
+mounted roster that can name no view, beside
+[`027-Hicasso-Evidence.md`](027-Hicasso-Evidence.md)'s tab, which already
+renders all four of those envelopes whole. That is a second rendering of one
+runtime's evidence and a strictly smaller panel, which is not what *move the
+consumer onto the provider* asks for.
+
+**So the disposition is retirement, not migration.** §3.4.1 and §3.4.2 stay on
+`re-frame.freehand.tool` for as long as the Freehand tree ships and go when it
+goes, under rf2-hic-062 — together with the `day8/re-frame2-freehand`
+coordinate in `tools/xray/deps.edn`, which sits at top-level `:deps` only
+because `day8.re-frame2-xray.mounted-views` is in `src`. Nothing is stranded at
+that moment: a Hicasso host's boundaries, reads, intents and explanations are
+answered in full by the Hicasso tab, and what disappears is exactly the set of
+questions only a view registry could have answered.
+
 ### §3.5 Queries
 
 | From | Reads |

--- a/tools/xray/spec/027-Hicasso-Evidence.md
+++ b/tools/xray/spec/027-Hicasso-Evidence.md
@@ -179,6 +179,16 @@ are a census keyed on data the door has promised not to carry, or two rows
 sharing one exported identity — which gives a panel duplicate DOM ids and a
 consumer an ambiguous join.
 
+**This is why the Views panel's Mounted Views section does not move here.**
+`021-Dynamic-Panel-Designs.md` §3.4.1/§3.4.2 read Freehand's five-read tool
+door for a roster keyed by view id and occurrence, plus a compiler manifest.
+Neither has a counterpart on this door, and neither is a gap awaiting closure —
+the read set is the only identity this runtime retains, and no evidence
+subsystem ships. Those sections therefore retire with the Freehand tree rather
+than being re-pointed at `re-frame.hicasso.tool`; the question-by-question
+mapping and the disposition are recorded once, in
+[`021-Dynamic-Panel-Designs.md`](021-Dynamic-Panel-Designs.md) §3.4.3.
+
 ### Causality is never inferred from adjacency
 
 The Why view has a proven half and an uncorrelated half, and they are separate


### PR DESCRIPTION
Closes rf2-jkdy.

The census (rf2-hic-076) rows X1/X2/X4/X5 mark Xray's Views panel STILL-LIVE on the
Freehand donor tier and disposition the cluster to a follow-up bead. This is that bead.
**All four premises were re-verified against the code, and all four hold — but the
migration itself must not happen.** What lands is the finding, recorded in Xray's own
spec so it is neither re-derived nor re-attempted.

## The four rows, re-verified

Every row was checked by reading the consumer, not by grepping — and the whole of
`tools/xray/` was re-swept for the string- and keyword-shaped coupling a require scan
cannot see.

| row | premise | verdict | how it was checked |
|---|---|---|---|
| **X1** | `day8/re-frame2-freehand {:local/root "../../implementation/freehand"}` at top-level `:deps`, L53 | **HELD** | read `tools/xray/deps.edn`; L53 exactly, in `:deps`, not under `:aliases {:test …}`. The L44-52 comment above it names the Views panel as the reason |
| **X2** | requires `re-frame.freehand.evidence` + `.tool`; pins `:re-frame.freehand.evidence/v1`; calls `tool/read-mounted-views` at L118 and L182 | **HELD** | read `mounted_views.cljs` whole. Requires at L91-92, pin at L101, `read-mounted-views` at L118 (`schema-status`) and L182 (`rows`). Also `tool/explain-render` L184 and the manifest triple at L229-232, which the row does not mention and which matter to the verdict below |
| **X4** | seven `re-frame.freehand.*` requires — the suite of X2 | **HELD** | `re-frame.freehand` L31, `.cell` L32, `.evidence` L33, `.occurrences` L34, `.test` L35, `.tool` L36, `.release-app` L51 = seven |
| **X5** | no require; asserts the literal schema values `/v1` and `/v9` at L451, L466 | **HELD** | no `freehand` in the `ns` form; L451 is `/v9` and L466 is `/v1` (the census lists the two values in the opposite order to the two line numbers — a transposition in the prose, not an error in the claim) |

The liveness chain the bead asked to re-confirm still holds exactly as traced:
`reactive_panel_subs.cljs` L131 requires the namespace and registers
`:rf.xray/mounted-views` / `-schema` / `:rf.xray/mounted-view-sites` at L689-716;
`reactive_panel_view.cljs` L72 requires it and renders `mounted-views-section` +
`view-sites-section` at L1050/L1051 and L1060/L1061; `registry.cljs` L353 calls
`reactive-panel/install-mounted-views-subs!` at boot.

## Why the migration does not happen

`re-frame.hicasso.tool` publishes four reads over a runtime that mints no boundary
identity and ships no manifest — `re-frame.hicasso.impl.evidence` says it in its own
words: *"No evidence subsystem ships: no manifest, no registry, no buffering."* Mapping
§3.4's questions onto it:

- **two carry across** — the boundary's reads, and its frame (`:unknown` where the read
  set spans frames);
- **one degrades** — `explain-render` exists, but `:cause` is `:unknown` *structurally*,
  every time, because the commit seam records no cascade id;
- **five have no answer** — which view, which occurrence of it, its lowering, its clock
  reading / generation / cascade, and the entire Declared View Sites section. `:view`
  and `:source` are `:unknown` under an `:opaque` naming projection whose own `:why`
  states this is not a gap awaiting closure.

A §3.4 re-pointed at the target would render a mounted roster that can name no view,
beside the Hicasso tab (spec 027) that already renders all four of those envelopes
whole — a second rendering of one runtime's evidence, and a strictly smaller panel.
That is not what *move the consumer onto the provider* asks for. **The correct
disposition is retirement, not migration**: §3.4.1/§3.4.2 stay on
`re-frame.freehand.tool` while the Freehand tree ships and go when it goes, under
rf2-hic-062, taking X1's `deps.edn` coordinate with them — it sits at top level only
because `mounted-views` is in `src`.

## What landed

Spec only, and deliberately so — there is no code change to make that is not either a
half-migration or a deletion that belongs to rf2-hic-062.

- `tools/xray/spec/021-Dynamic-Panel-Designs.md` — new **§3.4.3 Disposition** after
  §3.4.2, carrying the eight-row question mapping and the verdict.
- `tools/xray/spec/027-Hicasso-Evidence.md` — one paragraph in *A boundary's identity is
  its READ SET*, the section a reader would ask the question from, pointing at §3.4.3.
  Recorded once, cross-referenced once.

**Spec sync**: this PR *is* the spec change, per the `tools/xray/` standing rule.
`017-Test-Coverage-Matrix.md` is deliberately untouched — no coverage changed.

## Census correction, reported not applied

`tools/xray/src/day8/re_frame2_xray/registry.cljs` is listed under *Named, not consumed*
with "ten mentions, **all comments**". One is not a comment: L273 is a runtime
`js/console.warn` string in `warn-donor-ownership-resident!` that names both
`re-frame.ui` and `re-frame.freehand.tool` to a developer. By the census's own
definition of load-bearing ("a runtime string or keyword the code actually uses") and by
its own treatment of Pair's P2 — MCP `:description` prose naming the donor, classified
STILL-LIVE — that mention is load-bearing. It is exactly the under-count trap: invisible
to a require scan, and it survives any deletion of the rows above it.

**Not applied here.** The census document is held by another worker, and `registry.cljs`
is outside this cluster. Reported for the mayor to route.

## Quality gates

| gate | exit | note |
|---|---|---|
| `scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`. Read from the `.exit` file. Docs tier ran (incl. `mkdocs build --strict`); JVM and node tiers correctly not armed |
| `clojure -M:test` (from `tools/xray/`) | **0** | 1288 tests, 6045 assertions, 0 failures, 0 errors — the lane the bead names |
| `scripts/check_doc_slugs.py` | **0** | silent on success, so coverage was proven: a bogus anchor `027-Hicasso-Evidence.md#no-such-anchor-rf2-jkdy` planted in the new §3.4.3 gave **exit 1** with `BROKEN ANCHOR: tools\xray\spec\021-Dynamic-Panel-Designs.md:963`, then restored byte-identically (`git diff --stat HEAD` empty) and re-run green |
| `python scripts/check_fast_pr_gap.py --list` | 0 | derived: 96 required checks the spine does not decide |

Not run, with reasons: **CLJS/node suites** and **all JVM artefact suites** — the
surface classifier (`.github/scripts/report-changed-surfaces.sh`) answers `false` for
every one of its 32 surfaces on this diff, so no runtime tier arms; **browser lanes,
Xray feature matrix, mcp-conformance, bundle-isolation, perf gates** — CI-only per
`TESTING.md`, and none is reachable from a markdown-only diff.

No `implementation/node_modules` junction was created in the worktree (the node tier
never armed, so none was needed) — the mayor checkout's tree was never linked to and
still holds its usual 101 entries.
