### PR TITLE
test(hicasso): the public-door lifecycle witness cleans up its own containers (rf2-31xm)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/public_root_lifecycle_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/public_root_lifecycle_dom_cljs_test.cljs
@@ -27,7 +27,20 @@
   Frames are isolated contexts. The two roots below sit under two frames
   and render ONE view, mounted twice; nothing takes a frame-id as a view
   argument. That is what makes \"root A's teardown must not reach root
-  B\" a claim about isolation rather than about bookkeeping."
+  B\" a claim about isolation rather than about bookkeeping.
+
+  ## This suite takes its own containers down
+
+  Every other `fresh-container!` suite in the package hands its nodes to
+  `impl.mount/release!`, the fixture door that detaches the container and
+  empties the runtime. This one cannot: what it is measuring is the
+  PUBLIC teardown, whose contract is that the caller's node survives
+  (rf2-31xm), so the very act that would clean up is the act under test.
+  The suite therefore removes its own nodes, in [[detach!]] — and only in
+  `finally`, AFTER the readings that prove the door left them alone. The
+  reset fixture is no help here: it restores registrars and frames and
+  never touches the document, and the document is shared with every other
+  browser suite."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.core :as rf]
@@ -109,6 +122,25 @@
 
 (defn- attr-at [handle sel a] (some-> (node-at handle sel) (.getAttribute a)))
 
+(defn- detach!
+  "Remove a container THIS suite minted, once every reading of it is
+  taken. The mirror of `fresh-container!`, and the reason it is written
+  out here rather than borrowed: `impl.mount/release!` is the door that
+  would do it, and it also empties the runtime — total teardown, right
+  for a fixture that owns the page and exactly the meaning rf2-31xm took
+  off the public facade.
+
+  **Placement is the whole of it.** Every call sits in `finally`, after
+  the assertions that the container was still connected once its root
+  came down. One line earlier and it would delete the proof of the
+  behaviour this file exists to witness."
+  [handle]
+  (when-some [c (:container handle)]
+    (when-some [p (.-parentNode c)] (.removeChild p c)))
+  nil)
+
+(defn- connected? [handle] (.-isConnected (:container handle)))
+
 ;; ---------------------------------------------------------------------------
 ;; W1 (rf2-31xm) — tearing one root down must not reach the other
 ;; ---------------------------------------------------------------------------
@@ -149,12 +181,12 @@
               "root B stopped repainting when root A was torn down"))
 
         (testing "root B's mount point survives too"
-          (is (true? (.-isConnected (:container b)))))
+          (is (true? (connected? b))))
 
         (testing "and so does root A's — the container was the CALLER's
                   node, handed to `root!`, and a teardown door may not
                   delete a node it did not create"
-          (is (true? (.-isConnected (:container a)))
+          (is (true? (connected? a))
               "tearing down root A removed the caller's own container from
                the document"))
 
@@ -167,6 +199,11 @@
 
         (finally
           (h/unmount! b)
+          (detach! a)
+          (detach! b)
+          (is (= [false false] [(connected? a) (connected? b)])
+              "this witness left one of its own containers in the shared
+               browser-test document")
           (collector/reset-runtime!))))))
 
 ;; ---------------------------------------------------------------------------
@@ -208,4 +245,8 @@
 
         (finally
           (h/unmount! a)
+          (detach! a)
+          (is (false? (connected? a))
+              "this witness left its own container in the shared
+               browser-test document")
           (collector/reset-runtime!))))))


### PR DESCRIPTION
Closes the merged-PR-audit finding recorded on **rf2-31xm**, which is all of that
bead that is still outstanding: the production repair and the facade shape landed
in PR #7830 and are sound on `main` (verified below).

## What was still wrong

#7830 deliberately made `impl.mount/unmount!` **preserve the caller's node** — right,
because the container is handed to `root!` and React's own `root.unmount()` empties a
container and leaves it where it is. The consequence is what the audit caught.

`public_root_lifecycle_dom_cljs_test` is the one suite in the package that mints its
containers with `mount/fresh-container!` and then tears down **through the public door
only**, because the public door is what it is measuring. Its two `finally` blocks called
`h/unmount!` and `collector/reset-runtime!`, and neither touches the DOM;
`make-reset-runtime-fixture` restores registrars and frames and never the document. So
W1 left **two** empty connected `<div>`s and W2 left **one**, in the document every
browser suite shares.

Every other `fresh-container!` suite hands its nodes to `impl.mount/release!` — the
fixture door that detaches the container and empties the runtime, and exactly the door
#7830 removed from the public facade. This file is therefore the bounded exception the
change created, not pre-existing sloppiness.

## The repair

A private `detach!` — the mirror of `fresh-container!` — called in `finally` for every
container each witness minted, `a` **and** `b` in W1. It is written out rather than
borrowed from `mount/release!` because `release!` also empties the runtime, and total
teardown is precisely the meaning this bead took off the public facade.

The register is not new: `host_ssr_dom_cljs_test`'s `hydration-row` already ends
`(.unmount root)` → `removeChild container` → `reset-runtime!`, and `detach!` sits in
the same slot in the same order.

Each witness also closes with one assertion that its own containers are no longer
connected. That is the row that makes the housekeeping bite: the failure the audit found
was a *silent* leak, and without it a `detach!` that stops reaching the node (a changed
handle shape, a reordering) leaks quietly again instead of going red.

## Teardown ordering — before and after

**Production ordering is untouched by this PR.** Stated for the record, because the
bead is ordering-sensitive:

| door | ordering |
| --- | --- |
| `h/unmount!` = `impl.mount/unmount!` | 1. `roots/close-adoption-window!` on the handle's window · 2. `flushSync` around the React root's `.unmount()`. Nothing else — no runtime reset, no container detach. |
| `impl.mount/release!` (fixture door, off the facade) | 1. `unmount!` (window close, then root unmount) · 2. detach the container from its parent · 3. `collector/reset-runtime!` |

**Witness ordering, before:**

- W1 `finally`: `h/unmount! b` → `collector/reset-runtime!`
- W2 `finally`: `h/unmount! a` → `collector/reset-runtime!`

**Witness ordering, after:**

- W1 `finally`: `h/unmount! b` → `detach! a` → `detach! b` → assert both disconnected → `collector/reset-runtime!`
- W2 `finally`: `h/unmount! a` → `detach! a` → assert disconnected → `collector/reset-runtime!`

Same relative order as `release!` (unmount, then detach, then reset), deliberately — the
witness's housekeeping matches the fixture door it may not call.

**The ordering constraint the audit named is preserved.** Every reading of
`.isConnected` — root B's mount point survives, and root A's survives, which is the
witness for the very behaviour #7830 landed — sits in the `try` **body**, before
`finally` runs. Cleanup happens strictly after them. One line earlier and it would
delete the proof; that is why `detach!`'s docstring says so out loud.

## Facade export classification

**No change to the export set.** `re-frame.hicasso` exports exactly `root!`, `render!`
and `unmount!` for the root lifecycle, as #7830 left them; this PR is test-only and adds
and removes nothing. Restated for the standing duty:

| export | classification |
| --- | --- |
| `root!` | root-scoped constructor. Takes a container, a frame keyword and a tree; reaches nothing another root owns. |
| `render!` | root-scoped re-render in place — the hot-reload door. |
| `unmount!` | root-scoped teardown, `root!`'s inverse. Leaves sibling roots and the caller's container alone. |
| `release!` | **not exported** (removed by #7830). Total teardown — container detach plus a page-wide `collector/reset-runtime!` — which is right for a fixture that owns the page and wrong as a public meaning. Lives on at `impl.mount/release!` for the fixtures that legitimately want it. |

## Verification of the parts already landed

- **Part 1 — fixture door off the public facade.** `re-frame.hicasso`'s root-lifecycle
  block exports three vars, and `release!` is not among them.
- **Part 2 — teardown no longer tears down the page.** `impl.mount/unmount!` calls no
  `reset-runtime!` and removes no node.
- **Callers.** No caller anywhere reaches the removed export. The `h/release!` hits in
  `implementation/core/test/re_frame/bench/p0_app.cljs` and
  `implementation/freehand/test/re_frame/freehand/bench/**` alias
  `re-frame.bench.p0-harness` and `re-frame.freehand.bench.b6-harness`, not
  `re-frame.hicasso`; the `release!` in `tools/story/src/re_frame/story/ui/xray_embed.cljs`
  is a local `let`-bound closure. Every `mount/release!` caller is a test fixture using
  the impl door, which is where it lives now.
- **The multi-frame witness.** W1 mounts one view twice under two isolated frames, tears
  root A down through `h/unmount!`, and reads root B's survival three ways — its cell is
  still in the table, its boundary is still the cell's one reader, and a dispatch into
  its frame still reaches its paint. The last is the discriminating one: the markup React
  last committed stays on the page whether or not anything is still wired to it, so the
  DOM alone would pass while the law was broken.

## Quality gates

| gate | exit | note |
| --- | --- | --- |
| `npm run test:browser` (`:browser-test`, headless Chromium) | **0** | 1230 tests / 7590 assertions, 0 failures, 0 errors. **The gate for this change** — the file is a `-dom-cljs-test` and teardown is a real-DOM behaviour that `:node-test` cannot see, because its bodies gate on `mount/browser?` and skip. |
| `npm run test:browser` with `detach!` neutered (RED-CHECK) | **1** | **2 failures, 0 errors** — exactly the two new rows, `actual: (not (= [false false] [true true]))` and `actual: (not (false? true))`. This is the proof the assertions bite rather than decorate; reverted immediately after, tree verified identical to the commit. |
| `scripts/test-fast-pr.sh` | **0** | Full spine from the worktree root; `gate root: /c/Users/miket/code/re-frame2-worktrees/relfacade-31xm`, classified `docs=false jvm=false node=true`. `test:cljs` tier: 13219 tests / 66834 assertions, 0 failures, 0 errors. |
| `npm run test:cljs` | — | rides inside the fast-PR spine (`:node-test` tier); not run a second time. |
| `npm run test:hicasso-controlled`, `test:hicasso-hmr` | not run | testbed browser gates over `hicasso/testbed/**` and the HMR contract; this diff touches neither, and a concurrent worker holds `hicasso/testbed/`. |
| `mkdocs build --strict` | not run | no docs change. |
| hot-zone files | untouched | no `spec/*`, `implementation/deps.edn`, `implementation/shadow-cljs.edn` or `.github/workflows/*` in this diff. |

Fast-PR gap derived with `python scripts/check_fast_pr_gap.py --list` (96 required checks the
spine does not decide). The one that matters for a `-dom-cljs-test` edit is `cljs-browser`,
which is the gate run above.
