### PR TITLE
fix(hicasso): re-classify the census's registry.cljs row; retire two stale eslint counts; rule rf2-4k9m deliberate

### DIFF
--- a/docs/design/hicasso/product/tool-consumer-census.md
+++ b/docs/design/hicasso/product/tool-consumer-census.md
@@ -197,8 +197,9 @@ that a later reader who repeats the grep can reconcile 48 against 24 without re-
 distinction, and so that none of them is ever counted as a dependency.
 
 `registry.cljs` was on this list until `rf2-kqls` and is now row **X13**: eight of its ten hits are
-comments, but two are a runtime `js/console.warn` string. A reader repeating the grep should expect
-to land where the census did before the correction, and should not.
+comments, but two are a runtime `js/console.warn` string. The mistake is an easy one to repeat — a
+reader running the grep sees ten hits in a file carrying no `:require`, which is precisely what this
+census concluded before the correction.
 
 Two deserve a note because their prose is load-bearing *documentation of a live row* rather than
 incidental:

--- a/docs/design/hicasso/product/tool-consumer-census.md
+++ b/docs/design/hicasso/product/tool-consumer-census.md
@@ -1,7 +1,8 @@
 # Tool-consumer census — Xray, Story and Pair against the donor surfaces
 
-**rf2-hic-076**, 2026-08-11 05:37:14 AUSEST. The census `rf2-hic-062` cites before it disposes of
-the donor tool surfaces.
+**rf2-hic-076**, 2026-08-11 05:37:14 AUSEST; row **X13** added and the counts carried through by
+`rf2-kqls`, 2026-08-11 07:13:28 AUSEST. The census `rf2-hic-062` cites before it disposes of the
+donor tool surfaces.
 
 The obligation is one sentence of the specification
 ([§12 Phase 6](specification.md#phase-6--adoption-and-release)):
@@ -50,8 +51,10 @@ onto the target is a **re-authoring against a different question set**, not a re
 `git grep -E "freehand|re[-_]frame[./]ui"` over `tools/` returns **48 files**. That number is not a
 dependency count and must never be quoted as one: **a grep returns requires, docstrings, comments and
 prose identically**, and in this tree the prose dominates. Xray's `registry.cljs` alone contributes
-ten hits, every one of which is a comment, and four of them exist specifically to record that the
-file has *no* `re-frame.ui` dependency.
+ten hits, four of which exist specifically to record that the file has *no* `re-frame.ui`
+dependency. Eight of the ten sit in docstrings and comments; the other two are inside one runtime
+`js/console.warn` string, which is why every hit had to be read rather than classified by shape —
+those two are row X13.
 
 So each hit was read. A consumer row is a file that names a donor **in a load-bearing position** — a
 `:require`, a classpath coordinate, a runtime string or keyword the code actually uses, or a build /
@@ -63,14 +66,14 @@ comments stripped, which caught two requires a line-oriented regex missed
 The two counts, each with the question it answers:
 
 - **48 files name a donor** under `tools/` — the grep surface, prose included.
-- **23 of those 48 are load-bearing**; the other **25 name a donor only in a comment, a docstring or
+- **24 of those 48 are load-bearing**; the other **24 name a donor only in a comment, a docstring or
   a spec sentence** and are listed in [Named, not consumed](#named-not-consumed) so no later reader
   mistakes them for dependencies.
-- **27 consumer rows** — the 23 load-bearing files, plus one extra row because
+- **28 consumer rows** — the 24 load-bearing files, plus one extra row because
   `tools/story/deps.edn` carries two independent donor coordinates with different verdicts, plus the
   3 MIGRATED files that name **no** donor at all and therefore never appear in the grep.
 
-**27 rows = 18 STILL-LIVE · 5 FIXTURE-ONLY · 4 MIGRATED.** By tool: Xray 12 (8 · 0 · 4), Story 10
+**28 rows = 19 STILL-LIVE · 5 FIXTURE-ONLY · 4 MIGRATED.** By tool: Xray 13 (9 · 0 · 4), Story 10
 (5 · 5 · 0), Pair 5 (5 · 0 · 0).
 
 Liveness was established per row, not assumed from the presence of a `:require` — the "how" column
@@ -79,7 +82,7 @@ fixture.
 
 ---
 
-## Xray — 12 rows (8 STILL-LIVE, 4 MIGRATED)
+## Xray — 13 rows (9 STILL-LIVE, 4 MIGRATED)
 
 Xray is the only tool that has any presence on the target at all, and it has it **alongside**, not
 instead of, the donor: the Hicasso tab reads `re-frame.hicasso.tool`, while the Reactive panel's
@@ -99,19 +102,30 @@ instead of, the donor: the Hicasso tab reads `re-frame.hicasso.tool`, while the 
 | X10 | `tools/xray/src/day8/re_frame2_xray/panels/hicasso_helpers.cljc` | pins `:re-frame.hicasso.evidence/v2` (L66) as the consumer-owned schema literal | MIGRATED |
 | X11 | `tools/xray/test/day8/re_frame2_xray/panels/hicasso_cljs_test.cljs` | requires `re-frame.hicasso`, `.evidence`, `.impl.collector`, `.tool` | MIGRATED |
 | X12 | `tools/xray/test/day8/re_frame2_xray/panels/hicasso_helpers_cljs_test.cljc` | names `:re-frame/freehand` once (L175) **only to assert `supported?` returns false for it** — the donor appears as the rejected case | MIGRATED |
+| X13 | `tools/xray/src/day8/re_frame2_xray/registry.cljs` | the schema-4 reload warning (`js/console.warn`, L268-278) names `re-frame.ui` (L270, L273) and `re-frame.freehand.tool` (L273) in the sentence a developer reads when it fires — a runtime string the code actually uses, load-bearing on the same footing as P2's shipped `:description` prose. The file's other eight donor hits are docstrings and comments | STILL-LIVE |
 
 **How X2's liveness was established** — not from its `:require`, which proves nothing on its own. The
 chain is: `panels/reactive_panel_subs.cljs` L131 requires `day8.re-frame2-xray.mounted-views` and
 registers `:rf.xray/mounted-views`, `:rf.xray/mounted-views-schema` and the view-sites sub against
 it (L689-716); `panels/reactive_panel_view.cljs` L72 requires the same namespace and renders
 `mounted-views-section` into the panel body (L1050, L1060); and `registry.cljs` L353 calls
-`reactive-panel/install-mounted-views-subs!` at boot. Three files, none of which names a donor
-except in comments — which is exactly why liveness had to be traced through Xray's own namespaces
-rather than read off the grep.
+`reactive-panel/install-mounted-views-subs!` at boot. Three files, none of which *requires* a donor
+— `registry.cljs` names one in X13's warning and in comments, the other two only in comments — which
+is exactly why liveness had to be traced through Xray's own namespaces rather than read off the
+grep.
 
 **X1 is the load-bearing one for `rf2-hic-062`.** Every other Xray row is downstream of it: the
 Freehand artefact is on the shipped tool's classpath at top level, so Xray does not merely tolerate
 Freehand's absence, it is built against its presence.
+
+**Why X13 counts, and why it is the row most easily lost** (`rf2-kqls`). A `js/console.warn`
+argument is a runtime string the code actually uses, which the verdict table already calls
+load-bearing, and P2 is the same species one tool over — a donor name shipped as prose a human or an
+agent reads. What makes X13 the dangerous one is the direction its absence errs in: no require, no
+coordinate, so a `:require` scan and clj-kondo both pronounce the file clean, and unlike every other
+Xray row it *survives* the deletion of the four clusters — which is precisely the moment someone
+consults this census to learn what is left. Under-counting here is what would make that deletion
+look safe. The census filed it as "ten mentions, all comments" until `rf2-kqls`.
 
 ## Story — 10 rows (5 STILL-LIVE, 5 FIXTURE-ONLY)
 
@@ -178,16 +192,17 @@ Pair's five reads have no counterpart on the target.
 
 ## Named, not consumed
 
-These **25 files** name a donor only in a comment, a docstring or a spec sentence. They are listed so
-that a later reader who repeats the grep can reconcile 48 against 23 without re-deriving this
+These **24 files** name a donor only in a comment, a docstring or a spec sentence. They are listed so
+that a later reader who repeats the grep can reconcile 48 against 24 without re-deriving this
 distinction, and so that none of them is ever counted as a dependency.
 
-Three deserve a note because their prose is load-bearing *documentation of a live row* rather than
+`registry.cljs` was on this list until `rf2-kqls` and is now row **X13**: eight of its ten hits are
+comments, but two are a runtime `js/console.warn` string. A reader repeating the grep should expect
+to land where the census did before the correction, and should not.
+
+Two deserve a note because their prose is load-bearing *documentation of a live row* rather than
 incidental:
 
-- `tools/xray/src/day8/re_frame2_xray/registry.cljs` — ten mentions, all comments, four of which
-  exist to record that this build has **no** `re-frame.ui` dependency "nor may it acquire one". It
-  is nonetheless where X2 is installed at boot (L353), which is how X2's liveness was proved.
 - `tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md` — twelve mentions; the normative catalogue
   entry for the five tools of P1. Spec prose, not a dependency, but it moves when P1 moves.
 - `tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs` — one comment; wires the five
@@ -214,7 +229,6 @@ The full list:
 - `tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs`
 - `tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs`
 - `tools/xray/src/day8/re_frame2_xray/preload.cljs`
-- `tools/xray/src/day8/re_frame2_xray/registry.cljs`
 - `tools/xray/src/day8/re_frame2_xray/settings/effects.cljs`
 - `tools/xray/src/day8/re_frame2_xray/test_support.cljs`
 - `tools/xray/test/day8/re_frame2_xray/core_cljs_test.cljs`
@@ -225,9 +239,10 @@ The full list:
 
 ## Disposition of the still-live rows
 
-**Seventeen** of the 18 STILL-LIVE rows resolve into **four migration clusters**, not eighteen
-independent problems. The eighteenth, **X3**, is not a migration at all: it is an adapter-identity
-cleanup that folds into `rf2-hic-062` itself. Seventeen plus X3 is the whole still-live set.
+**Seventeen** of the 19 STILL-LIVE rows resolve into **four migration clusters**, not nineteen
+independent problems. The remaining two, **X3** and **X13**, are not migrations at all: one is an
+adapter-identity cleanup and the other a developer-facing string, and both fold into `rf2-hic-062`
+itself. Seventeen plus X3 plus X13 is the whole still-live set.
 
 | cluster | rows | what moving it costs | disposition |
 |---|---|---|---|
@@ -236,6 +251,7 @@ cleanup that folds into `rf2-hic-062` itself. Seventeen plus X3 is the whole sti
 | Story presence bridge | S2, S3, S4, S5, S6 | Hicasso's presence surface is `re-frame.hicasso.impl.presence` / `.presence-react`, not a published `presence-runtime` door with `advance-clock!`; the bridge needs a target-side verb that does not exist yet | follow-up bead `rf2-5gka` |
 | Pair's five view tools | P1, P2, P3, P4, P5 | same four-reads problem as the Xray cluster, plus a regenerated `tool-descriptors.edn` and a spec-catalogue rewrite | follow-up bead `rf2-n3mb` |
 | Xray adapter-id set | X3 | `:rf.adapter/ui` and `:rf.adapter/freehand` are adapter identities, not evidence reads; they retire when the adapters do, under `rf2-hic-062` itself | fold into `rf2-hic-062` — no follow-up bead |
+| Xray's schema-4 reload warning | X13 | nothing to migrate: the donor names are prose inside one `js/console.warn` about a schema-3 residue. With the tiers gone the message names namespaces that no longer exist, so the cost is a stale developer-facing string, not a broken read | fold into `rf2-hic-062` — reword or drop the warning with the tiers; no follow-up bead |
 
 **No migration was made in this bead, and that is the finding rather than a shortfall.** Every
 still-live cluster fails the same test: the target does not publish the read the consumer needs, so
@@ -251,22 +267,25 @@ coverage" the specification sentence permits fixtures to retain.
 
 For `rf2-hic-062` to cite:
 
-> **Primary tool paths are not yet donor-free.** Of 27 tool-consumer rows across Xray, Story and
+> **Primary tool paths are not yet donor-free.** Of 28 tool-consumer rows across Xray, Story and
 > Pair, 4 are MIGRATED to the adapter-neutral Hicasso provider (all in Xray's Hicasso tab), 5 are
 > FIXTURE-ONLY compatibility evidence in Story's `test/` tree on a `:test`-alias classpath, and
-> **18 are STILL-LIVE on a donor tier**. **Seventeen** of those form four migration clusters, each
+> **19 are STILL-LIVE on a donor tier**. **Seventeen** of those form four migration clusters, each
 > with a filed follow-up: Xray's Reactive-panel Views section and its `tools/xray/deps.edn`
 > top-level `day8/re-frame2-freehand` coordinate (`rf2-jkdy`); the staged `freehand-views` browser
 > deck and its feature-matrix scenario (`rf2-u5b4`); Story's shipped `presence-host` bridge
 > (`rf2-5gka`); and all five of Pair's view tools, which reach `re-frame.freehand.tool` by wire
 > string rather than by `:require` and therefore do not appear in any classpath scan (`rf2-n3mb`).
 >
-> The eighteenth is **X3**, the live set of React-element-shaped adapter ids in
-> `tools/xray/src/day8/re_frame2_xray/mount.cljs`. It is **not** a fifth migration and has no
-> follow-up bead: `:rf.adapter/ui` and `:rf.adapter/freehand` are adapter *identities* rather than
-> evidence reads, so they retire when the adapters do — which makes X3 an adapter-identity cleanup
-> **folded into `rf2-hic-062` itself**. Anything acting on the four clusters alone leaves X3
-> unaccounted for.
+> The remaining two are **X3**, the live set of React-element-shaped adapter ids in
+> `tools/xray/src/day8/re_frame2_xray/mount.cljs`, and **X13**, the schema-4 `js/console.warn` in
+> `tools/xray/src/day8/re_frame2_xray/registry.cljs` that names both `re-frame.ui` and
+> `re-frame.freehand.tool` in the sentence a developer reads. Neither is a fifth migration and
+> neither has a follow-up bead: `:rf.adapter/ui` and `:rf.adapter/freehand` are adapter *identities*
+> rather than evidence reads, and X13's donor names are prose inside a runtime string — both retire
+> when the adapters do, which makes them cleanups **folded into `rf2-hic-062` itself**. X13 is also
+> the one still-live row that no `:require` scan can find and that survives the deletion of all four
+> clusters. Anything acting on the four clusters alone leaves X3 and X13 unaccounted for.
 >
 > **The blocker is not effort, it is question shape.** `re-frame.ui.tool` and
 > `re-frame.freehand.tool` publish the same five reads, so donor 1 → donor 2 was a rename.
@@ -277,6 +296,8 @@ For `rf2-hic-062` to cite:
 >
 > `rf2-hic-062` may therefore **archive or remove `implementation/ui/` as far as the tools are
 > concerned** — no tool has a live `re-frame.ui` dependency; Story's four `re-frame.ui` witnesses are
-> fixture-only and Xray's `registry.cljs` records that it may not acquire such a dependency.
+> fixture-only and Xray's `registry.cljs` records that it may not acquire such a dependency. The one
+> residue is X13: that same file names `re-frame.ui` in a shipped warning, which has to be reworded
+> rather than left pointing at a deleted namespace.
 > **It may not yet dispose of the Freehand tree**: Xray depends on it at top-level `:deps`, Story's
 > shipped bridge compiles against it, and every one of Pair's five view tools targets it.

--- a/docs/design/hicasso/product/tool-consumer-census.md
+++ b/docs/design/hicasso/product/tool-consumer-census.md
@@ -102,7 +102,7 @@ instead of, the donor: the Hicasso tab reads `re-frame.hicasso.tool`, while the 
 | X10 | `tools/xray/src/day8/re_frame2_xray/panels/hicasso_helpers.cljc` | pins `:re-frame.hicasso.evidence/v2` (L66) as the consumer-owned schema literal | MIGRATED |
 | X11 | `tools/xray/test/day8/re_frame2_xray/panels/hicasso_cljs_test.cljs` | requires `re-frame.hicasso`, `.evidence`, `.impl.collector`, `.tool` | MIGRATED |
 | X12 | `tools/xray/test/day8/re_frame2_xray/panels/hicasso_helpers_cljs_test.cljc` | names `:re-frame/freehand` once (L175) **only to assert `supported?` returns false for it** — the donor appears as the rejected case | MIGRATED |
-| X13 | `tools/xray/src/day8/re_frame2_xray/registry.cljs` | the schema-4 reload warning (`js/console.warn`, L268-278) names `re-frame.ui` (L270, L273) and `re-frame.freehand.tool` (L273) in the sentence a developer reads when it fires — a runtime string the code actually uses, load-bearing on the same footing as P2's shipped `:description` prose. The file's other eight donor hits are docstrings and comments | STILL-LIVE |
+| X13 | `tools/xray/src/day8/re_frame2_xray/registry.cljs` | the schema-4 reload warning (`js/console.warn`, L268-277, in `warn-donor-ownership-resident!` at L260) names `re-frame.ui` (L270, L273) and `re-frame.freehand.tool` (L273) in the sentence a developer reads when it fires — a runtime string the code actually uses, load-bearing on the same footing as P2's shipped `:description` prose. The file's other eight donor hits are docstrings and comments | STILL-LIVE |
 
 **How X2's liveness was established** — not from its `:require`, which proves nothing on its own. The
 chain is: `panels/reactive_panel_subs.cljs` L131 requires `day8.re-frame2-xray.mounted-views` and

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,9 +2,9 @@
 //
 // WHAT THIS IS FOR, AND WHAT IT DELIBERATELY IS NOT.
 //
-// Before this file the repo had ~205 tracked `.cjs` / `.mjs` / `.js` files —
-// bench drivers, gate runners, browser harnesses, MCP conformance suites — and
-// NOTHING checked any of them. A syntax error or a typo'd identifier was
+// Before this file NOTHING checked the repo's tracked `.cjs` / `.mjs` / `.js`
+// files — bench drivers, gate runners, browser harnesses, MCP conformance
+// suites, in every tool tree. A syntax error or a typo'd identifier was
 // discovered the first time somebody ran the file, which for a nightly bench
 // driver can be days. clj-kondo and Splint cover the Clojure trees; this closes
 // the JS hole with the same shape: a BUG-CLASS linter, not a style linter.
@@ -187,9 +187,11 @@ export default [
       '**/target/**',
       '**/classes/**',
       // shadow-cljs compile output: `release/externs.shadow.js` plus the
-      // `{dev,release}/{goog-js,shadow-js}/` trees. 8811 JS files in a fully
-      // built checkout of this repo, against 215 tracked JS files in the
-      // whole tree.
+      // `{dev,release}/{goog-js,shadow-js}/` trees. A fully built checkout
+      // carries more than an ORDER OF MAGNITUDE more JS under here than the
+      // whole tracked tree contains, so this one entry is the difference
+      // between a gate that reads the repo and one that reads the compiler's
+      // output.
       '**/.shadow-cljs/**',
       // shadow-cljs `:output-dir`s. Empty in a fresh checkout, which is the
       // only reason neither surfaced as a symptom alongside the externs file;

--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -595,8 +595,20 @@
 ;; absolute `:file` ships the right URI regardless of which
 ;; `:project-root` the host configured. Absolutisation runs once per
 ;; macro expansion (JVM-side); the CLJS runtime sees a literal string
-;; (cheap), and production builds elide both the literal and the
-;; surrounding coord-form per the existing rf2-3un2g gate.
+;; (cheap).
+;;
+;; PRODUCTION KEEPS THIS PATH. The rf2-3un2g gate drops the DEV
+;; coord-form — the one carrying `:column` — and keeps
+;; [[prod-coords-form]], which absolutises `:file` exactly as the dev
+;; branch does, so the always-on error-coord registry can still name a
+;; source line in the builds that actually break. A release bundle
+;; therefore carries the BUILDING MACHINE's directory layout, once per
+;; macro-driven registration. That is the contract rather than an
+;; oversight, and `spec/Privacy.md` §What the production bundle itself
+;; discloses owns it — including the remedy for anyone who needs
+;; path-independent bytes, which is to build in a neutral working
+;; directory rather than relativise a path the framework promised to keep
+;; absolute. Asked and answered as rf2-4k9m.
 ;;
 ;; Failure modes that fall through to the unchanged input:
 ;;   - Already-absolute path (e.g. a JVM-compile `*file*` that

--- a/implementation/core/src/re_frame/source_coords/open_endpoint.cljs
+++ b/implementation/core/src/re_frame/source_coords/open_endpoint.cljs
@@ -17,10 +17,12 @@
   handler can stat it. rf2-wvsxg bakes that absolute path at macro-expansion
   time, which works for the common classpath-`file:` case but leaves a
   RELATIVE coord for JAR/in-jar/odd-classpath sources (the gap Option B
-  closes) and bakes the builder's home path into the dev bundle. The
-  endpoint resolves the relative `:file` against the live source-paths on
-  the dev machine at runtime and launches via the cross-platform
-  `launch-editor` package — zero-config for everyone.
+  closes) and bakes the builder's home path into the bundle — the RELEASE
+  bundle as much as the dev one, since the production coord-form
+  absolutises too (`spec/Privacy.md` §What the production bundle itself
+  discloses). The endpoint resolves the relative `:file` against the live
+  source-paths on the dev machine at runtime and launches via the
+  cross-platform `launch-editor` package — zero-config for everyone.
 
   ## Additive — the URI fallback stays
 


### PR DESCRIPTION
Three small beads on disjoint surfaces. Worked bottom-up, one commit each.

## rf2-kqls — the census under-counted `registry.cljs`, in the deletion-enabling direction

**L273 is not a comment.** Verified at source before editing:

```clojure
;; tools/xray/src/day8/re_frame2_xray/registry.cljs, in
;; warn-donor-ownership-resident! (L260), .warn call L268-277
(.warn js/console
       (str "[re-frame2 Xray] Registration schema 4 needs a page reload "
            "to finish. This process claimed the re-frame.ui ViewCell "     ; L270
            ...
            "re-frame.freehand.tool and has no re-frame.ui dependency, so " ; L273
```

Ten `git grep` hits in that file, and the split is **eight to two**, not ten to zero: L165, L166, L183, L184, L239, L245, L356 and L357 are docstrings and `;;` comments, while **L270 and L273 sit inside one `js/console.warn` string** — the schema-4 reload warning, naming `re-frame.ui` and `re-frame.freehand.tool` to a developer at the moment it fires.

That is load-bearing by the census's own definition (*"a runtime string or keyword the code actually uses"*) and by its still-live treatment of Pair's P2, which is STILL-LIVE precisely because the donor name rides in shipped `:description` prose. So the file leaves **Named, not consumed** and becomes row **X13**, verdict STILL-LIVE, with the row saying why a console string counts.

Worth noting for `rf2-hic-062`: one of the *four* mentions the census cites as recording that Xray may not acquire a `re-frame.ui` dependency **is** the warning string. The census's own proof of donor-freedom was partly quoting a runtime string it had classified as a comment.

**Arithmetic followed through** — leaving a new inconsistency would have undone `rf2-hic-076`'s fresh correction:

| | before | after |
|---|---|---|
| load-bearing of the 48 | 23 | **24** |
| named-not-consumed | 25 | **24** |
| consumer rows | 27 | **28** |
| STILL-LIVE · FIXTURE-ONLY · MIGRATED | 18 · 5 · 4 | **19** · 5 · 4 |
| by tool (Xray) | 12 (8 · 0 · 4) | **13 (9 · 0 · 4)** |

Cross-checks: 28 = 24 + 1 (`tools/story/deps.edn`'s two coordinates) + 3 (MIGRATED files naming no donor); 28 = 19 + 5 + 4; by-tool 13 + 10 + 5 = 28 with 9 + 5 + 5 = 19 still-live. The **Named, not consumed** list now enumerates exactly 24 paths (counted, not asserted).

Also carried through, because each would otherwise contradict the new row: the "how the census was taken" paragraph; the X2-liveness note (which claimed all three files "name a donor except in comments"); the disposition prose and table (X13 joins X3 as a fold-into-`rf2-hic-062` cleanup rather than a fifth migration cluster); and both affected paragraphs of the proof statement, including the `implementation/ui/` clearance, which now names X13 as the one residue that must be reworded rather than left pointing at a deleted namespace.

**Not done, deliberately**: the other 26 rows were not re-audited, nothing was re-derived, and nothing was deleted on the strength of this. X13 is appended rather than inserted so no existing row id shifts.

## rf2-fxpn — `eslint.config.mjs`'s two counts are deleted, not refreshed

Both premises re-verified at source first: `git ls-files '*.cjs' '*.mjs' '*.js'` finds **235** tracked, ESLint itself lints **234**, and the one-file gap is `docs/cljs/playground.js` — the generated bundle the config ignores at **L213**, exactly as the bead recorded.

**Neither number came back.** Per `rf2-93u6`, a hand-maintained count in a config file goes stale by default, so each sentence keeps the fact it was carrying and loses the number that dated it:

- the header's `~205 tracked` was decoration on a claim about **coverage**, and the true claim is an absolute: before this config, NOTHING checked those files. That stays true as the tree grows and cannot be tightened into a wrong number.
- the `.shadow-cljs` ignore's `8811 … against 215` was really asserting a **ratio**, and the ratio is what makes that one entry load-bearing. It now says a built checkout carries more than an order of magnitude more JS there than the whole tracked tree — true with a wide margin at the last measurement (8811:215 ≈ 40×), and robust to growth on either side.

I did not reuse `rf2-93u6`'s name-the-exception technique here: this file *is* where the exception is declared (L209-213), so re-stating it in the header would duplicate the ignore list rather than guard an absolute. The absolutes that remain are true without qualification.

Comment-only — no rule, ignore, glob or option changed.

## rf2-4k9m — deliberate, already ruled, already written down; no behaviour change

The bead's own first question ("is the absolute path DELIBERATE?") decides it, and the answer was already in the normative spec. **`spec/Privacy.md` § *What the production bundle itself discloses*** states it outright:

> The `:file` it stores is the **absolute on-disk path resolved at macro-expansion time**: it is absolutised deliberately (rf2-wvsxg) so the editor-URI builder resolves regardless of the host's `:project-root`. The consequence … is that a production bundle carries the compiling machine's directory layout — `/home/<user>/…`, `/Users/<user>/…`, `C:/Users/<user>/…` — as ordinary string literals, once per registration.
>
> There is no knob and no projection profile for this; the retention is the contract.

It even prescribes the remedy the bead was reaching for — build in a neutral working directory — and pre-empts the `check-no-hardcoded-paths.sh` confusion.

**Source of the embedded string, traced rather than assumed.** `re-frame.source-coords/absolutise-file` (`source_coords.cljc` L621) resolves the compiler's classpath-relative `:file` to an absolute on-disk path at macro-expansion time on the JVM. `prod-coords-form` (L736) calls it on the same footing as the dev `coords-form`, and the `rf2-3un2g` gate — `(if interop/debug-enabled? <dev> <prod>)` — DCEs the **dev** branch under `:advanced` + `goog.DEBUG=false` and keeps the **prod** one, so the absolutised literal is what survives into the release bundle. `implementation/hicasso/scripts/check_production_erasure.cjs` records the independent measurement (`consumer_app.cljs`, three occurrences in a green release bundle, emitted "through `re-frame.source-coords/prod-coords-form`, which keeps" `:file`).

**Per the bead's fence, the code is untouched.** Relativising `prod-coords-form`'s `:file` would change a coordinate contract — `compose-path` passes absolute paths through and joins `:project-root` for relative ones, so production-mode inspection via the `editor://` fallback would regress to the exact failure `rf2-wvsxg` fixed — and the ruling that governs it lives in hot-zone `spec/`. That is a STOP-and-report, and the bead itself says that if the path is wanted "the answer is to record why, not to strip it".

**What I did fix is that the emitting file said the opposite of the ruling.** `source_coords.cljc`'s `rf2-wvsxg` header claimed *"production builds elide both the literal and the surrounding coord-form per the existing rf2-3un2g gate"* — false, and precisely the sentence that makes this look like a defect worth filing. `open_endpoint.cljs` had the softer version, scoping the baked home path to "the dev bundle". Both now state what production actually keeps and point at `spec/Privacy.md`, which owns the ruling. Comment-only: no fn, literal or emitted form changed.

**No build evidence is offered, and none is owed** — nothing was changed that a build could disprove. Had I stripped the path, the standard would have been two builds from different paths.

### Surfaces outside the brief's named two

`implementation/core/src/re_frame/source_coords.cljc` and `implementation/core/src/re_frame/source_coords/open_endpoint.cljs` — comment-only, held by no in-flight worker, and squarely "whatever bead 3 turns out to need". Not hot-zone. Neither `implementation/shadow-cljs.edn` nor `implementation/deps.edn` was touched; `implementation/package.json` was not touched, so PR #7844's erasure-scan chaining into `build:hicasso-release` is intact.

## Quality gates

| gate | exit | notes |
|---|---|---|
| `scripts/test-fast-pr.sh` | **0** | run from the worktree root, unpiped, exit captured on the same command line and read from the `.exit` file; log line 1 reads `gate root: /c/Users/miket/code/re-frame2-worktrees/smallmisc-kqls` and the terminal marker `PASS fast PR spine` is present. (The 35 `FAIL` substrings in the log are all inside PASSING self-test case names — "PASS an undeclared … gate FAILS" — not failures.) |
| `python scripts/check_doc_slugs.py` | **0** | the census edit's real gate — silent on success, so coverage is proved below |
| `check_doc_slugs.py` (planted-anchor probe) | **1** | coverage proof, quoted below |
| `eslint .` (repo root, ESLint 10.8.0) | **0** | **234 files linted, 0 errors, 0 warnings** — bead 2's own gate, and an independent recount of the number the stale comments got wrong |

**Coverage proof for the silent gate.** `check_doc_slugs.py` prints nothing and exits 0 on success, so a clean run is not evidence it read the file. Repointing the census's one internal link to a nonexistent heading produced:

```
1 broken anchor link(s) found:

  BROKEN ANCHOR: docs\design\hicasso\product\tool-consumer-census.md:69 -> #kqls-bogus-anchor-probe
      (target: docs\design\hicasso\product\tool-consumer-census.md)
```

exit **1**. Restored byte-identically from a pre-probe copy; the re-run is exit 0 and `git diff` shows no residue.

**`mkdocs build --strict` ran — as a spine stage — but it is NOT this edit's gate.** `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site, so it is green here whatever the census says; nominating it would be claiming a gate that cannot fail on the file it is supposed to guard.

**Tables hand-verified, because nothing validates them.** `check_doc_slugs.py` reads link targets and heading anchors only. Every markdown row in the census was column-counted mechanically and read back: the tier table 4, the verdict table 2, the Xray/Story/Pair row tables 4 (X1-X13, S1-S10, P1-P5), the disposition table 4 — each matching its own header and delimiter. Both rows I added (X13 in the Xray table, X13's disposition) are 4 columns.

**Derived, not assumed — `python scripts/check_fast_pr_gap.py --list` reports 96 required checks the spine does not decide.** The three required contexts remain `All required checks passed`, `Lint required` and `Docs required`. Most are surface-gated and skip on a diff this shape; the ones nearest this change are the `docs.yml` MkDocs job (which excludes `design/`) and the `lint.yml` ESLint job, which runs the same `eslint .` reported above.

Scratch (`*.log`, `*.exit`, the ESLint JSON, the pre-probe copy) deleted; both `node_modules` junctions removed and the mayor checkout's trees re-counted.
