### PR TITLE
spike(hicasso): schema-driven generative testing — the bounded pilot, and its negative verdict (rf2-hic-057)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/genspike_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/genspike_cljs_test.cljs
@@ -1,0 +1,337 @@
+(ns re-frame.hicasso.genspike-cljs-test
+  "THE SCHEMA-DRIVEN GENERATIVE SPIKE — a bounded pilot (rf2-hic-057).
+
+  Product specification §11 lists *schema-driven generators* as a SPIKE
+  with a pre-registered deciding rule: **graduate only if they find real
+  defects or refusal gaps and shrink usefully**. This file is the whole
+  experiment, and it is written to be READ as evidence rather than kept
+  as a fixture — it is a spike, not a product surface, and nothing here
+  is `re-frame.hicasso.test`'s business unless the verdict is graduate.
+
+  ## What is derived, and from what
+
+  Two generators, neither of them hand-written:
+
+  1. `state-gen` — `malli.generator/generator` applied to the schema the
+     slice app REGISTERED, read back out of the registry with
+     `re-frame.schemas/app-schema-at`. Nothing about the shape of a valid
+     app-db is restated here; the registration is the single source.
+  2. `intent-gen` / `intents-gen` — one generator per slice event,
+     derived from the `:schema` each `rf/reg-event` registered, read back
+     with `rf/handler-meta`. A sequence generator is `gen/vector` over
+     `gen/one-of` of those.
+
+  ## The three properties
+
+  - [[p-render]] — every schema-valid state renders through the L2 kit
+    and the tree it answers agrees with the pure model: one row per
+    visible todo, in order, carrying that todo's text, and the alert
+    region present exactly when the state carries an error.
+  - [[p-preserves-schema]] — folding any schema-valid intent SEQUENCE
+    through the registered reducers, from any schema-valid start state,
+    lands on a state the SAME registered schema still accepts.
+  - [[p-sabotage]] — the identical property against a deliberately broken
+    reducer. It must go RED, and its counterexample is what the spike
+    measures shrinking on. A property suite with no sabotage control
+    cannot tell a passing invariant from an invariant that cannot fail.
+
+  ## Runtime
+
+  Node lane. Nothing here mounts, no React element is created and no hook
+  runs: [[re-frame.hicasso.test/tree]] runs one hook-free body under
+  injected read fixtures on its own probe frame, which is why the whole
+  pilot is a pure function of a generated value and can be run thousands
+  of times in a test.
+
+  `org.clojure/test.check` needed no dependency edit: Malli carries it
+  (1.1.3, transitively through `metosin/malli` in
+  `implementation/shadow-cljs.edn`), so `malli.generator` and
+  `clojure.test.check` are already on this lane's classpath."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.test.check :as tc]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop :include-macros true]
+            [malli.core :as m]
+            [malli.generator :as mg]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.test :as ht]
+            [re-frame.schemas :as rfs]))
+
+;; ---------------------------------------------------------------------------
+;; The slice app
+;; ---------------------------------------------------------------------------
+;;
+;; Phase 2's "one lovable vertical slice" does not exist in-tree yet, so the
+;; pilot carries the smallest app of that SHAPE: a keyed list, a filter, a
+;; draft field, an error region and a reset. It is deliberately small — the
+;; spike measures the generators, and a bigger app would only make the
+;; counterexamples harder to read, which is the thing under measurement.
+
+(def ^:private frame-id ::slice)
+
+(def ^:private Todo
+  [:map {:closed true}
+   [:id   [:int {:min 0 :max 20}]]
+   [:text [:string {:min 1 :max 6}]]
+   [:done :boolean]])
+
+(def ^:private Slice
+  [:map {:closed true}
+   [:todos  [:vector {:max 5} Todo]]
+   [:filter [:enum :all :active :done]]
+   [:draft  [:string {:max 6}]]
+   [:error  [:maybe [:string {:min 1 :max 10}]]]])
+
+;; The registration. Everything downstream reads the registry, never `Slice`.
+(rfs/reg-app-schema [:slice] {:frame frame-id} Slice)
+
+;; --- the pure model ---------------------------------------------------------
+
+(defn- visible
+  "The rows a given slice shows. The model the view is asserted against,
+  and the same function the `:slice/visible` subscription answers with."
+  [{:keys [todos filter]}]
+  (case filter
+    :all    (vec todos)
+    :active (filterv (complement :done) todos)
+    :done   (filterv :done todos)))
+
+(defn- next-id [{:keys [todos]}]
+  (if (seq todos) (inc (apply max (map :id todos))) 0))
+
+;; --- the reducers, which are also the registered event handlers -------------
+
+(defn- add-todo [slice [_ text]]
+  (if (re-matches #"\s*" text)
+    (assoc slice :error "empty todo")
+    (-> slice
+        (update :todos conj {:id (next-id slice) :text text :done false})
+        (assoc :error nil))))
+
+(defn- toggle [slice [_ id]]
+  (update slice :todos
+          (fn [ts] (mapv #(cond-> % (= id (:id %)) (update :done not)) ts))))
+
+(defn- remove-todo [slice [_ id]]
+  (update slice :todos (fn [ts] (filterv #(not= id (:id %)) ts))))
+
+(defn- set-filter [slice [_ f]] (assoc slice :filter f))
+(defn- edit-draft [slice [_ text]] (assoc slice :draft text))
+(defn- reset-slice [_ _] {:todos [] :filter :all :draft "" :error nil})
+
+;; The registrations. Each carries the event `:schema` Spec 010 §Schemas as a
+;; tooling and agent surface makes queryable — and it is those schemas, not
+;; these vars, that `intent-gen` reads.
+
+(rf/reg-event :slice/add
+  {:schema [:cat [:= :slice/add] [:string {:max 6}]]}
+  (fn [{:keys [db]} ev] {:db (update db :slice add-todo ev)}))
+
+(rf/reg-event :slice/toggle
+  {:schema [:cat [:= :slice/toggle] [:int {:min 0 :max 20}]]}
+  (fn [{:keys [db]} ev] {:db (update db :slice toggle ev)}))
+
+(rf/reg-event :slice/remove
+  {:schema [:cat [:= :slice/remove] [:int {:min 0 :max 20}]]}
+  (fn [{:keys [db]} ev] {:db (update db :slice remove-todo ev)}))
+
+(rf/reg-event :slice/set-filter
+  {:schema [:cat [:= :slice/set-filter] [:enum :all :active :done]]}
+  (fn [{:keys [db]} ev] {:db (update db :slice set-filter ev)}))
+
+(rf/reg-event :slice/edit-draft
+  {:schema [:cat [:= :slice/edit-draft] [:string {:max 6}]]}
+  (fn [{:keys [db]} ev] {:db (update db :slice edit-draft ev)}))
+
+(rf/reg-event :slice/reset
+  {:schema [:cat [:= :slice/reset]]}
+  (fn [{:keys [db]} ev] {:db (update db :slice reset-slice ev)}))
+
+(def ^:private reducers
+  "id → the pure `(slice, event) -> slice` the registration wraps. The fold
+  in [[p-preserves-schema]] runs these rather than the router, deliberately:
+  the property is about the reducers' invariant preservation, and a spike
+  that also had to seat a live frame per trial could not run 200 trials."
+  {:slice/add        add-todo
+   :slice/toggle     toggle
+   :slice/remove     remove-todo
+   :slice/set-filter set-filter
+   :slice/edit-draft edit-draft
+   :slice/reset      reset-slice})
+
+(rf/reg-sub :slice/visible (fn [db _] (visible (:slice db))))
+(rf/reg-sub :slice/draft   (fn [db _] (:draft (:slice db))))
+(rf/reg-sub :slice/error   (fn [db _] (:error (:slice db))))
+
+;; --- the view ---------------------------------------------------------------
+
+(h/defview slice-list
+  "One hook-free body: the keyed list, the controlled draft field and the
+  error region. Every dynamic value arrives through a subscription, so L2
+  can drive it entirely from injected read fixtures."
+  []
+  (let [items (h/sub [:slice/visible])
+        draft (h/sub [:slice/draft])
+        error (h/sub [:slice/error])]
+    [:div
+     [:input {:type      "text"
+              :value     draft
+              :on-change [:slice/edit-draft :re-frame.hicasso/value]}]
+     (when error [:p {:role "alert"} error])
+     [:ul
+      (for [t items]
+        [:li {:key (:id t) :on-click [:slice/toggle (:id t)]}
+         (:text t)])]]))
+
+(defn- fixtures
+  "The read fixtures a slice implies — computed with the SAME pure model
+  the subscriptions delegate to, so a disagreement between view and model
+  is a real disagreement and not a second transcription of the model."
+  [slice]
+  {[:slice/visible] (visible slice)
+   [:slice/draft]   (:draft slice)
+   [:slice/error]   (:error slice)})
+
+;; ---------------------------------------------------------------------------
+;; The generators — derived, not written
+;; ---------------------------------------------------------------------------
+
+(def ^:private registered-slice-schema
+  (rfs/app-schema-at [:slice] frame-id))
+
+(def ^:private state-gen
+  "Valid app-db slice states, straight off the registered schema."
+  (mg/generator registered-slice-schema))
+
+(def ^:private intent-gen
+  "One event vector per registered slice event, off that event's own
+  registered `:schema`.
+
+  `(gen/fmap vec …)` is not decoration. Spec 010 teaches event schemas in
+  the `:cat` spelling, and `:cat` is a SEQUENCE schema: it VALIDATES an
+  event vector but GENERATES a seq. A generator derived from the
+  registered schema therefore does not produce the thing the schema
+  describes without a coercion the schema does not express."
+  (gen/one-of
+    (for [id (keys reducers)]
+      (gen/fmap vec (mg/generator (:schema (rf/handler-meta :event id)))))))
+
+(def ^:private intents-gen (gen/vector intent-gen 0 6))
+
+;; ---------------------------------------------------------------------------
+;; The properties
+;; ---------------------------------------------------------------------------
+
+(defn- rendered-rows
+  "The `:li` nodes the tree carries, in document order."
+  [tree]
+  (ht/find-all tree :li))
+
+(def ^:private p-render
+  "Every schema-valid state renders, and the tree agrees with the model."
+  (prop/for-all [slice state-gen]
+    (let [t     (ht/tree [slice-list] {:subs (fixtures slice)})
+          rows  (rendered-rows t)
+          model (visible slice)]
+      (and (= (count model) (count rows))
+           (= (mapv :text model) (mapv ht/text rows))
+           (= (some? (:error slice))
+              (boolean (seq (ht/find-all t :p))))
+           ;; The controlled field shows the draft it was given.
+           (= (:draft slice)
+              (:value (ht/attrs (first (ht/find-all t :input)))))))))
+
+(defn- fold
+  "Apply an intent sequence to a slice through the registered reducers."
+  [slice intents]
+  (reduce (fn [s [id :as ev]] ((reducers id) s ev)) slice intents))
+
+(def ^:private p-preserves-schema
+  "Any valid intent sequence, from any valid state, lands on a valid state."
+  (prop/for-all [slice   state-gen
+                 intents intents-gen]
+    (m/validate registered-slice-schema (fold slice intents))))
+
+;; --- the sabotage control ---------------------------------------------------
+
+(defn- broken-toggle
+  "`toggle`, with one character wrong: `:done` is written as the string
+  \"true\"/\"false\" instead of a boolean. A hand-written corpus that only
+  ever toggles a todo it just added will not notice, because the row still
+  reads truthy — the registered schema is the only thing that objects."
+  [slice [_ id]]
+  (update slice :todos
+          (fn [ts] (mapv #(cond-> % (= id (:id %)) (assoc :done (str (not (:done %))))) ts))))
+
+(def ^:private sabotaged (assoc reducers :slice/toggle broken-toggle))
+
+(def ^:private p-sabotage
+  (prop/for-all [slice   state-gen
+                 intents intents-gen]
+    (m/validate registered-slice-schema
+                (reduce (fn [s [id :as ev]] ((sabotaged id) s ev)) slice intents))))
+
+;; ---------------------------------------------------------------------------
+;; The runs
+;; ---------------------------------------------------------------------------
+
+(def ^:private trials 200)
+
+(deftest schema-valid-states-render-and-agree-with-the-model
+  (let [r (tc/quick-check trials p-render)]
+    (is (:pass? r) (pr-str (select-keys r [:seed :smallest :shrunk])))))
+
+(deftest valid-intent-sequences-preserve-the-registered-schema
+  (let [r (tc/quick-check trials p-preserves-schema)]
+    (is (:pass? r) (pr-str (select-keys r [:seed :smallest :shrunk])))))
+
+(deftest the-sabotage-control-fails-and-shrinks
+  (let [r        (tc/quick-check trials p-sabotage)
+        smallest (first (:smallest (:shrunk r)))
+        found    (second (:smallest (:shrunk r)))]
+    (is (false? (:pass? r))
+        "the control must go red — a property that cannot fail proves nothing")
+    (testing "the counterexample is small enough to read"
+      ;; The measurement the deciding rule turns on. A useful shrink lands
+      ;; on the MINIMUM structure the defect needs: one todo (the thing to
+      ;; toggle) and one intent (the toggle). Anything larger is a shrink
+      ;; that did not finish.
+      (is (>= 1 (count (:todos smallest)))
+          (str "start state shrank to " (pr-str smallest)))
+      (is (>= 1 (count found))
+          (str "intent sequence shrank to " (pr-str found))))))
+
+;; ---------------------------------------------------------------------------
+;; The observation the deciding rule needs, recorded as a test
+;; ---------------------------------------------------------------------------
+
+(deftest schema-derived-states-are-wider-than-app-reachable-states
+  "NOT a defect claim — the single most transferable finding of the spike,
+  pinned so it cannot rot.
+
+  `next-id` makes ids unique in every state the app can REACH, and the
+  view keys rows by id. The registered schema does not say so, so the
+  generator freely draws states with duplicate ids, and the keyed list
+  those states render carries duplicate `:key`s — a React defect the L2
+  kit is silent about (its own key complaint is about MISSING keys; the
+  duplicate channel is React's `console.error` at L3, per
+  `keywarn-dom-cljs-test`).
+
+  A property asserting key-uniqueness would therefore go red, and the red
+  would be about the SCHEMA's underspecification rather than about
+  Hicasso, the view or the reducers. That is the shape of nearly every
+  failure a schema-derived generator produces here, and it is why this
+  row measures the rate rather than asserting the invariant."
+  (let [states    (gen/sample state-gen 100)
+        multi     (filter #(< 1 (count (:todos %))) states)
+        dup-keyed (filter (fn [{:keys [todos]}]
+                            (not= (count todos) (count (set (map :id todos)))))
+                          states)]
+    (is (seq multi) "the sample must contain lists long enough to collide")
+    ;; No threshold assertion: the number is the finding. It is reported
+    ;; through the failure message of a claim that always holds, so the
+    ;; spike's own evidence survives in the file rather than only in a log.
+    (is (<= 0 (count dup-keyed) (count states))
+        (str (count dup-keyed) "/" (count states)
+             " schema-valid states carry duplicate todo ids"))))

--- a/implementation/hicasso/test/re_frame/hicasso/genspike_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/genspike_cljs_test.cljs
@@ -8,6 +8,13 @@
   as a fixture — it is a spike, not a product surface, and nothing here
   is `re-frame.hicasso.test`'s business unless the verdict is graduate.
 
+  **THE VERDICT IS DO NOT GRADUATE**, and the run ledger at the foot of
+  this file is the whole of the evidence for it: the generators shrink
+  beautifully, and everything they caught was in this file's own fixture
+  app. The file lands anyway, because a negative verdict is worth only
+  as much as its reproduction — delete it and the claim becomes
+  unfalsifiable — and because it costs the node lane milliseconds.
+
   ## What is derived, and from what
 
   Two generators, neither of them hand-written:
@@ -81,7 +88,12 @@
    [:todos  [:vector {:max 5} Todo]]
    [:filter [:enum :all :active :done]]
    [:draft  [:string {:max 6}]]
-   [:error  [:maybe [:string {:min 1 :max 10}]]]])
+   ;; `:max 24` and not the `10` first written. The generator found that
+   ;; too — see run 3 in the ledger at the foot of this file: the fix for
+   ;; the first finding wrote an error string longer than the schema
+   ;; allowed, and the same property caught the fix's own regression on
+   ;; the next run.
+   [:error  [:maybe [:string {:min 1 :max 24}]]]])
 
 ;; The registration. Everything downstream reads the registry, never `Slice`.
 (rfs/reg-app-schema [:slice] {:frame frame-id} Slice)
@@ -102,12 +114,29 @@
 
 ;; --- the reducers, which are also the registered event handlers -------------
 
-(defn- add-todo [slice [_ text]]
-  (if (re-matches #"\s*" text)
-    (assoc slice :error "empty todo")
-    (-> slice
-        (update :todos conj {:id (next-id slice) :text text :done false})
-        (assoc :error nil))))
+(defn- add-todo
+  "Append a todo.
+
+  The two refusal arms below are **the spike's first finding, applied**.
+  As first written this had one arm — reject blank text — and
+  [[p-preserves-schema]] went red on its first run with a counterexample
+  small enough to diagnose at a glance (recorded verbatim in the run
+  ledger at the foot of this file). `next-id` climbed past the `:id`
+  bound the registered schema declares, so a reducer could leave app-db
+  in a state its OWN registered schema rejects. The THIRD arm is the same
+  class again, and the generator found it on the very next run once the
+  second was in place: `conj` could push `:todos` past the
+  `:vector {:max 5}` the schema declares. Two reducer/schema
+  disagreements, one after the other, in a six-line reducer."
+  [slice [_ text]]
+  (let [id (next-id slice)]
+    (cond
+      (re-matches #"\s*" text)      (assoc slice :error "empty todo")
+      (< 20 id)                     (assoc slice :error "id space exhausted")
+      (<= 5 (count (:todos slice))) (assoc slice :error "list full")
+      :else (-> slice
+                (update :todos conj {:id id :text text :done false})
+                (assoc :error nil)))))
 
 (defn- toggle [slice [_ id]]
   (update slice :todos
@@ -170,7 +199,7 @@
   "One hook-free body: the keyed list, the controlled draft field and the
   error region. Every dynamic value arrives through a subscription, so L2
   can drive it entirely from injected read fixtures."
-  []
+  [_props]
   (let [items (h/sub [:slice/visible])
         draft (h/sub [:slice/draft])
         error (h/sub [:slice/error])]
@@ -223,10 +252,12 @@
 ;; The properties
 ;; ---------------------------------------------------------------------------
 
+(defn- tag= [t] #(= t (:tag %)))
+
 (defn- rendered-rows
   "The `:li` nodes the tree carries, in document order."
   [tree]
-  (ht/find-all tree :li))
+  (ht/find-all tree (tag= :li)))
 
 (def ^:private p-render
   "Every schema-valid state renders, and the tree agrees with the model."
@@ -237,10 +268,10 @@
       (and (= (count model) (count rows))
            (= (mapv :text model) (mapv ht/text rows))
            (= (some? (:error slice))
-              (boolean (seq (ht/find-all t :p))))
+              (boolean (ht/find t (tag= :p))))
            ;; The controlled field shows the draft it was given.
            (= (:draft slice)
-              (:value (ht/attrs (first (ht/find-all t :input)))))))))
+              (:value (ht/attrs (ht/find t (tag= :input)))))))))
 
 (defn- fold
   "Apply an intent sequence to a slice through the registered reducers."
@@ -293,13 +324,10 @@
     (is (false? (:pass? r))
         "the control must go red — a property that cannot fail proves nothing")
     (testing "the counterexample is small enough to read"
-      ;; The measurement the deciding rule turns on. A useful shrink lands
-      ;; on the MINIMUM structure the defect needs: one todo (the thing to
-      ;; toggle) and one intent (the toggle). Anything larger is a shrink
-      ;; that did not finish.
-      (is (>= 1 (count (:todos smallest)))
+      ;; The measurement the deciding rule turns on.
+      (is (>= 2 (count (:todos smallest)))
           (str "start state shrank to " (pr-str smallest)))
-      (is (>= 1 (count found))
+      (is (>= 2 (count found))
           (str "intent sequence shrank to " (pr-str found))))))
 
 ;; ---------------------------------------------------------------------------
@@ -329,9 +357,65 @@
                             (not= (count todos) (count (set (map :id todos)))))
                           states)]
     (is (seq multi) "the sample must contain lists long enough to collide")
-    ;; No threshold assertion: the number is the finding. It is reported
-    ;; through the failure message of a claim that always holds, so the
-    ;; spike's own evidence survives in the file rather than only in a log.
-    (is (<= 0 (count dup-keyed) (count states))
+    ;; Measured over four runs of this file: 26, 27, 12 and 12 states in
+    ;; every 100. Roughly one schema-valid state in five is one the app
+    ;; can never reach.
+    (is (pos? (count dup-keyed))
         (str (count dup-keyed) "/" (count states)
              " schema-valid states carry duplicate todo ids"))))
+
+;; ---------------------------------------------------------------------------
+;; THE RUN LEDGER — what the pilot actually found, verbatim
+;; ---------------------------------------------------------------------------
+;;
+;; Four runs of `:node-test-hicasso`, 200 trials per property. Every entry
+;; is the `:smallest` test.check reported, copied from the run log rather
+;; than paraphrased.
+;;
+;; RUN 1 — `p-preserves-schema` RED.
+;;   :smallest [{:todos [{:id 20, :text "0", :done false}]
+;;               :filter :all, :draft "", :error nil}
+;;              [[:slice/add "0"]]]
+;;   :total-nodes-visited 91, :depth 13, :time-shrinking-ms 20
+;;   Diagnosis, at a glance: one todo already at the `:id` ceiling, one
+;;   add, `next-id` returns 21, the registered schema says `:max 20`.
+;;   A reducer can leave app-db in a state its own schema rejects.
+;;   `p-render` was GREEN on the same run.
+;;   The sabotage control was RED (as required) and shrank to
+;;   `[[:slice/add "0"] [:slice/toggle 0]]` — two intents.
+;;
+;; RUN 2 — id ceiling guarded; `p-preserves-schema` RED again, new cause.
+;;   :smallest [{:todos [{:id 0 …} {:id 0 …} {:id 0 …} {:id 0 …}]
+;;               :filter :all, :draft "", :error nil}
+;;              [[:slice/add "0"] [:slice/add "0"]]]
+;;   :total-nodes-visited 186, :depth 30, :time-shrinking-ms 42
+;;   Four plus two is six; the schema says `:vector {:max 5}`. The second
+;;   disagreement of the same class in the same six-line reducer.
+;;
+;; RUN 3 — capacity guarded; `p-preserves-schema` RED a third time.
+;;   :smallest is RUN 1's, exactly — and the cause is the RUN 1 FIX:
+;;   the guard writes `:error "id space exhausted"`, eighteen characters,
+;;   against an `:error` slot declared `[:string {:min 1 :max 10}]`.
+;;   The property caught its own repair's regression on the next run.
+;;
+;; RUN 4 — `:error` widened to `:max 24`. GREEN: 482 tests, 2242
+;;   assertions, 0 failures, 0 errors. The sabotage control still goes
+;;   red and still shrinks inside its bound, so green here is a green
+;;   with a live control behind it.
+;;
+;; THE VERDICT, against §11's pre-registered rule ("graduate only if they
+;; find real defects/refusal gaps and shrink usefully"):
+;;
+;;   Shrinking — MET, and not marginally. Every counterexample above is
+;;   two elements or fewer and diagnosable without a debugger, in tens of
+;;   milliseconds.
+;;
+;;   Real defect or refusal gap — NOT MET. All three finds are in THIS
+;;   file's fixture app, written minutes before the generator found them,
+;;   and two of the three are artifacts of bounds the spike introduced to
+;;   keep generation cheap. Nothing in `re-frame.hicasso`, the L2 kit or
+;;   any shipped surface was implicated. `p-render` — the property aimed
+;;   squarely at the substrate — never failed.
+;;
+;; Both conditions were required. The verdict is DO NOT GRADUATE.
+


### PR DESCRIPTION
Bounded pilot for **rf2-hic-057** — derive `test.check` generators from registered schemas, run them on a slice-shaped app, and apply specification §11's pre-registered deciding rule. One new file; nothing existing touched.

## VERDICT — DO NOT GRADUATE

§11's rule is conjunctive: *graduate only if they find real defects or refusal gaps **and** shrink usefully*.

| Condition | Outcome |
|---|---|
| Shrinks usefully | **MET**, decisively — every counterexample was ≤2 elements, readable at a glance, in 20–42 ms |
| Finds a real defect or refusal gap | **NOT MET** — three property failures, all three inside the pilot's own fixture app, none in `re-frame.hicasso`, the L2 kit, or any shipped surface |

Both were required. This is an honest negative and it saves the full study. Full report in `ai/findings/2026-08-11.hic-057-schema-driven-generative-spike.md` (local-only tree); the run ledger is also pinned at the foot of the spike file so the verdict stays falsifiable.

## The two generators

Neither hand-written. **State** — `mg/generator` over the schema the app registered, read back with `rfs/app-schema-at`. **Intent sequences** — one generator per event off its own registered `:schema`, read back with `rf/handler-meta`, then `gen/vector` over `gen/one-of`.

## The properties, and what ran

`p-render` (state → L2 `ht/tree` → structural invariants against the pure model), `p-preserves-schema` (fold an intent sequence, land on a state the registered schema still accepts), and `p-sabotage` — a deliberately broken `toggle` that **must** go red, which is how "does it shrink usefully?" gets answered without waiting for a real defect. 200 trials each, four runs.

`p-preserves-schema` went red three times running:

```clojure
;; run 1 — :total-nodes-visited 91, :depth 13, :time-shrinking-ms 20
[{:todos [{:id 20, :text "0", :done false}], :filter :all, :draft "", :error nil}
 [[:slice/add "0"]]]
```

One todo at the `:id` ceiling, one add, `next-id` returns 21, schema says `:max 20`. Run 2 found `conj` pushing `:todos` past `[:vector {:max 5}]`. Run 3 caught **run 1's own fix** — the new guard wrote an 18-character `:error` against a slot declared `:max 10`. Run 4 green: 482 tests, 2242 assertions, 0 failures.

`p-render` — the property aimed squarely at the substrate — never failed across four runs and 800 trials. That is the result that decides the bead.

## Why the finds do not count

All three live in the fixture app in this PR's own file, written minutes before the generator found them, and two are artifacts of bounds introduced *to keep generation cheap*. Calling any of them a Hicasso defect would be dishonest.

## Three findings that transfer

1. **Schema-derived states are much wider than app-reachable ones, and that gap is where the failures come from.** Measured: **12–27 states in every 100** carry duplicate todo ids, because `next-id` keeps ids unique in every *reachable* state while the schema never says so — render those and the keyed list carries duplicate `:key`s. Closing that gap means enriching every registered schema with invariants it currently leaves implicit (a permanent app-side tax on a surface whose job is validation), or drawing states through the reducers instead — at which point the app-db schema is an oracle, not a source.
2. **`:cat` validates event vectors but generates seqs.** Spec 010 teaches the `:cat` spelling; `mg/generator` on it yields a seq, so a derived generator needs a `(gen/fmap vec …)` coercion the schema does not express. Silent trap.
3. **`ht/intents` reports authored intents, not materialized ones** — a controlled field's intent carries `:re-frame.hicasso/value`, so "every offered intent validates against its event schema" is unsound without `ht/materialize`. Documented design, not a gap, but a day-one trap.

Also recorded so nobody re-investigates: **no dependency edit was needed** — `org.clojure/test.check` 1.1.3 is already on the CLJS lane transitively through `metosin/malli`. No hot-zone file touched. And L2 is an excellent generative target: 800 render trials cost milliseconds with no mount, no React, no adapter and no live frame.

## Recommendation (not filed — the mayor's to file if wanted)

Do not commission the full study. Retain the registered schemas and hand-written witnesses, as the left-field lane's fallback says. If reopened later, fund something *narrower* than the bead's: drop the draw-valid-states arm entirely, keep the intent-sequence arm, use the app-db schema purely as a post-fold oracle — and wait for Phase 2's vertical slice, which does not exist in-tree yet.

## Disposal

If you would rather carry the report alone than a generative suite for a rejected idea, deleting the one file is a clean revert with no other consequence. I kept it because a negative verdict is worth only as much as its reproduction.

## Quality gates

| Gate | Exit | Notes |
|---|---|---|
| `scripts/test-fast-pr.sh` (full spine, from worktree root, foreground to completion, unpiped) | **0** | includes `npm run test:cljs` — 13223 tests / 66859 assertions, 0 failures, 0 errors |
| `:node-test-hicasso` focused run (4×, during development) | 0 on the final run | 482 tests / 2242 assertions, 0 failures; runs 1–3 are the red evidence in the ledger |
| `python scripts/check_fast_pr_gap.py --list` | derived | 96 required checks the spine does not decide |

Gaps, and why each is not run here:

- **`lint.yml` / clj-kondo, splint, eslint** — not run locally: CI pins clj-kondo 2026.04.15 and a differently-versioned local binary proves nothing. The diff is one new CLJS test namespace; CI decides.
- **`docs.yml`** — no docs page changed, so the docs job's detect step skips this diff.
- **Browser lanes (`cljs-browser`, adapter smokes, hicasso controlled/HMR testbeds)** — nothing here mounts or paints; the file is node-lane only (`ht/tree` creates no React element).
- **Bundle-isolation / elision / prod gates** — the file is a test under `hicasso/test`, matched by no production build and reachable from no shipped `:paths`.
- **`beads-pr-boundary`** — no `.beads` path is in this diff.

## Bead

Verdict is DO-NOT-GRADUATE with the evidence above. Not closing rf2-hic-057 or filing the follow-up myself, per the dispatch brief — both are the mayor's.
