### PR TITLE
hic-031 — Native hooks: n/use-sub + n/use-frame

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
@@ -1522,9 +1522,9 @@
   (entry-for #js [sub-key]))
 
 (defn hook-read
-  "The value of `[frame-kw query-v]`, read from OUTSIDE every boundary
-  body — [[read-key!]]'s two tiers with the scratch and the ambient
-  frame taken away.
+  "The value of `sub-key`, read from OUTSIDE every boundary body —
+  [[read-key!]]'s two tiers with the scratch and the ambient frame taken
+  away.
 
   Warm is the same pure deref: once the hook's `subscribe` has run, the
   cell exists and holds the reaction, so every render after the first is
@@ -1541,14 +1541,17 @@
   makes the question unaskable. The saved value is nil in every path
   that exists today — React renders a component after its parent body
   has returned, never inside one — so what the restore protects is the
-  invariant rather than a caller."
-  [frame-kw query-v]
-  (if-some [^js r (some-> ^js (get @!cells [frame-kw query-v]) (.-reaction))]
+  invariant rather than a caller.
+
+  It takes the SUB-KEY rather than the pair, so a hook builds the one
+  vector the cell table is keyed by and hands it to both doors."
+  [sub-key]
+  (if-some [^js r (some-> ^js (get @!cells sub-key) (.-reaction))]
     @r
     (let [saved (.-probe rstate)]
       (set! (.-probe rstate) nil)
       (try
-        (cold-read! frame-kw query-v)
+        (cold-read! (nth sub-key 0) (nth sub-key 1))
         (finally (set! (.-probe rstate) saved))))))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
@@ -1225,9 +1225,14 @@
   ;; was, the first sub-key.
   (atom {}))
 
-(defn- scratch-bucket-key
-  "The bucket the scratch's current read sequence belongs to: an
-  **order-sensitive hash of the whole sequence**.
+(defn- bucket-key-of
+  "The bucket a read sequence belongs to: an **order-sensitive hash of
+  the whole sequence**.
+
+  Two callers hand it two arrays and neither is special-cased — the
+  scratch a body just filled ([[entry-for]]), and the one-key array a
+  React hook reads with ([[hook-entry]]). A bucket rule that knew which
+  of the two it was answering for would be two rules.
 
   It selects a bucket and is never an equality test — [[entry-matches?]]
   still compares every key pairwise before an entry is reused. That
@@ -1257,15 +1262,15 @@
   the bucket a function of the read set rather than of its first element,
   and `the-bucket-scan-does-not-grow-with-the-number-of-boundaries`
   holds it there."
-  []
-  (let [n (alength scratch)]
+  [^js ks]
+  (let [n (alength ks)]
     (loop [i 0 h 1]
       (if (== i n)
         h
         (recur (inc i)
                ;; h*31 + hash(k), truncated to int32 — order-sensitive,
                ;; allocation-free, and the arithmetic is JS-exact.
-               (bit-or 0 (+ (bit-shift-left h 5) (- h) (hash (aget scratch i)))))))))
+               (bit-or 0 (+ (bit-shift-left h 5) (- h) (hash (aget ks i)))))))))
 
 (defn- drop-entry! [^js entry]
   (let [bucket-key (.-bucketKey entry)]
@@ -1328,41 +1333,46 @@
   nil)
 
 (defn- entry-matches?
-  "Ordered pairwise compare of an entry's key array against the scratch.
+  "Ordered pairwise compare of an entry's key array against `ks`.
   Allocates nothing. A false negative — same set, different order — costs
   a second entry and a symmetric difference that removes and re-adds the
   same edges; it is never a wrong answer, which is why the hash in
-  [[scratch-bucket-key]] chooses the bucket and this decides the match."
-  [^js entry]
-  (let [ks (.-keys entry)
-        n  (alength ks)]
-    (and (== n (alength scratch))
+  [[bucket-key-of]] chooses the bucket and this decides the match."
+  [^js entry ^js ks]
+  (let [eks (.-keys entry)
+        n   (alength eks)]
+    (and (== n (alength ks))
          (loop [i 0]
            (cond
-             (== i n)                          true
-             (= (aget ks i) (aget scratch i))  (recur (inc i))
-             :else                             false)))))
+             (== i n)                    true
+             (= (aget eks i) (aget ks i)) (recur (inc i))
+             :else                       false)))))
 
 (declare make-subscribe make-snapshot)
 
 (defn- entry-for
-  "The read-set entry for the scratch's current contents — the cached
+  "The read-set entry for the read sequence `ks` — the cached
   `subscribe` / `getSnapshot` pair React sees. A hit allocates nothing and
   keeps `subscribe`'s identity, so React does not re-subscribe and the
   commit does no work; a miss materialises the key array, the key set and
   the two closures **once**, for every boundary that will ever read that
   set.
 
-  The bucket is [[scratch-bucket-key]]'s hash of the whole read sequence,
+  The bucket is [[bucket-key-of]]'s hash of the whole read sequence,
   so what a lookup scans is the set of read sequences that COLLIDE — not,
   as it once was, the set of live boundaries that happen to share a first
   key. `drop-entry!`'s rebuild of the bucket vector is O(1) for the same
-  reason."
-  []
-  (let [bucket-key (scratch-bucket-key)
+  reason.
+
+  `ks` is the scratch when a boundary body resolves its reads, and a
+  one-key array when a React hook does ([[hook-entry]]). The array is
+  never retained: a miss `.slice`s it, and a hit reads nothing off it
+  after the compare."
+  [^js ks]
+  (let [bucket-key (bucket-key-of ks)
         bucket     (get @!entries bucket-key)]
-    (or (some (fn [^js e] (when (entry-matches? e) e)) bucket)
-        (let [ks    (.slice scratch)
+    (or (some (fn [^js e] (when (entry-matches? e ks) e)) bucket)
+        (let [ks    (.slice ks)
               ^js entry #js {"keys"      ks
                          "set"       (into #{} ks)
                          "refs"      0
@@ -1474,6 +1484,74 @@
   ((.-subscribe entry) notify))
 
 ;; ---------------------------------------------------------------------------
+;; The hook seam — one read, from a React component that is not a boundary
+;; ---------------------------------------------------------------------------
+;;
+;; `re-frame.hicasso.native/use-sub` is a real React hook inside a real
+;; React function component (rf2-hic-031), and a component is not a
+;; boundary: no shell ran, no body ran, `rstate` names no frame and the
+;; scratch holds somebody else's reads or none. So the hook cannot take
+;; [[sub]], and the two doors below are what it takes instead.
+;;
+;; **They are doors onto this module's tables, never a second copy of
+;; them.** [[hook-entry]] mints its entry from the same cache, with the
+;; same `subscribe` and the same `getSnapshot`, so a hook and a boundary
+;; reading one key SHARE one entry, one registration shape and one cell —
+;; which is why `re-frame.hicasso.tool`'s rosters see a hook's reads
+;; without knowing hooks exist, and why the residue census counts them.
+;; A private table here would have bought a hook that leaked invisibly.
+
+(defn hook-entry
+  "The read-set entry for the SINGLE key `sub-key` — what a hook hands
+  `useSyncExternalStore`.
+
+  **Identity is the whole point.** React re-subscribes whenever the
+  `subscribe` it is given is a new function, so a hook that built its
+  closure per render would tear the subscription down and rebuild it on
+  every re-render — releasing and re-acquiring the cell, and doing it
+  invisibly, because the value on screen would be right the whole time.
+  The entry cache already answers that: the same key hits the same
+  entry, so `subscribe` is identical across re-renders and React does
+  not call it again. A hook therefore needs no `useMemo` and no
+  `useRef`, and holds to the shell's own hook budget.
+
+  A one-key read set is an ordinary read set. Nothing below this line
+  knows the difference, and a boundary whose body reads exactly this one
+  key shares this very entry."
+  [sub-key]
+  (entry-for #js [sub-key]))
+
+(defn hook-read
+  "The value of `[frame-kw query-v]`, read from OUTSIDE every boundary
+  body — [[read-key!]]'s two tiers with the scratch and the ambient
+  frame taken away.
+
+  Warm is the same pure deref: once the hook's `subscribe` has run, the
+  cell exists and holds the reaction, so every render after the first is
+  a `get` and an `@`. Cold is [[cold-read!]]'s probe, unchanged and
+  still retaining nothing — which is what the render→commit gap needs,
+  because a hook's first render happens before React has called
+  `subscribe` and therefore before any cell exists.
+
+  **The probe box is scoped to this call, and that is not tidiness.**
+  `cold-read!` shares one frame-state snapshot across a body run and
+  [[run-once]] is what resets it; a hook read that left the box behind
+  would hand the NEXT hook read, arbitrarily later, a snapshot of a
+  world that has since moved. Saving and restoring costs one local and
+  makes the question unaskable. The saved value is nil in every path
+  that exists today — React renders a component after its parent body
+  has returned, never inside one — so what the restore protects is the
+  invariant rather than a caller."
+  [frame-kw query-v]
+  (if-some [^js r (some-> ^js (get @!cells [frame-kw query-v]) (.-reaction))]
+    @r
+    (let [saved (.-probe rstate)]
+      (set! (.-probe rstate) nil)
+      (try
+        (cold-read! frame-kw query-v)
+        (finally (set! (.-probe rstate) saved))))))
+
+;; ---------------------------------------------------------------------------
 ;; The body run, and the generation fence
 ;; ---------------------------------------------------------------------------
 
@@ -1540,7 +1618,7 @@
           element (run-once frame-kw body-fn props)]
       (cond
         (= before (generation/commit-basis frame-kw))
-        (do (set! (.-entry rstate) (entry-for)) element)
+        (do (set! (.-entry rstate) (entry-for scratch)) element)
 
         (< attempt max-fence-retries)
         (recur (inc attempt))
@@ -1630,10 +1708,29 @@
   fails a test rather than a review."
   [:use-context/frame :use-sync-external-store/subscription-epoch])
 
-(defn- resolve-frame! [frame-kw]
+(defn resolve-frame!
+  "The frame a React component is IN, taken from the one context every
+  React-shaped substrate in this repo writes — or the refusal, when
+  nothing above it wrote one.
+
+  Public, and `where`-taking, because the boundary shell is no longer
+  its only caller: the native tier's hooks (rf2-hic-031) resolve their
+  frame HERE rather than through a second chain of their own. That is
+  the property `frames are isolated contexts` reduces to in code — an
+  island and the boundary beside it ask one question of one context and
+  cannot be told different answers, so `n/use-sub` has no door onto a
+  frame the surrounding tree is not already in.
+
+  Deliberately NOT `frame/require-current-frame!`'s dynamic-var →
+  context chain, which is what the UIx-adapter hooks use. A body's
+  dynamic extent has unwound by the time React renders the component it
+  returned, so the var tier can only ever answer for a *different*
+  render than the one asking — and answering from it would let an
+  island read a frame its own subtree is not under."
+  [frame-kw where]
   (if (or (nil? frame-kw) (= adapter-context/no-provider-sentinel frame-kw))
     (fail! :rf.error/no-frame-context
-           're-frame.hicasso.impl.collector/shell
+           where
            (str "A Hicasso boundary rendered with no frame in scope. Mount the "
                 "tree under a frame boundary — `arm1.mount/root!` installs one.")
            :mount-under-a-frame
@@ -1646,7 +1743,8 @@
   position of ordinary code around them, and it is what lets the
   subscription hook close over the reads the body just made."
   [body-fn js-props]
-  (let [frame-kw (resolve-frame! (react/useContext adapter-context/frame-context))
+  (let [frame-kw (resolve-frame! (react/useContext adapter-context/frame-context)
+                                 're-frame.hicasso.impl.collector/shell)
         props    (or (unchecked-get js-props "rfProps") {})
         element  (render-body frame-kw body-fn props)
         ^js entry (.-entry rstate)]

--- a/implementation/hicasso/src/re_frame/hicasso/native.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso/native.cljc
@@ -81,6 +81,25 @@
   — a slot collision resolved by map order is a wrong program that no
   build should quietly run.
 
+  ## The two hooks, and the frame they join
+
+  An island is a place in the application, not a second application, so
+  [[use-sub]] and [[use-frame]] join the frame the surrounding tree is
+  already in — the same React context the boundary shell reads, and the
+  only channel either hook has. There is no argument, option map or
+  spelling by which a native read reaches a sibling frame, and that is
+  what makes an island cheap to reason about: it can see exactly what
+  the hiccup around it can see.
+
+  They are also the whole of the hook surface, deliberately. React's own
+  hooks are used directly, by `[\"react\" :as react]` interop, and nothing
+  here wraps `useState`, `useEffect`, `useRef` or `useTransition` —
+  what React cannot supply is the frame, so the frame is all these
+  supply. [[use-sub]]'s docstring carries the external-store ceiling
+  React's own documentation states, which is the one honest caveat on
+  the pair: a commit observed through the hook is a BLOCKING update and
+  no part of this surface is transition-aware.
+
   ## Dependency isolation
 
   This namespace is separately reachable and nothing in `re-frame.hicasso`
@@ -93,6 +112,8 @@
             [re-frame.hicasso.impl.slot :as slot])
   #?(:clj (:require [re-frame.source-coords :as source-coords]))
   #?(:cljs (:require ["react" :as react]
+                     [re-frame.adapter.context :as adapter-context]
+                     [re-frame.hicasso.impl.collector :as collector]
                      [re-frame.interop :as interop]))
   #?(:cljs (:require-macros [re-frame.hicasso.native :refer [$ props defcomponent]])))
 
@@ -296,7 +317,146 @@
   helper and every embedding direction reads to recognise a native head —
   and the reason a raw `react/memo` wrapper loses it."
        [x]
-       (when (some? x) (unchecked-get x tier-sentinel)))))
+       (when (some? x) (unchecked-get x tier-sentinel)))
+
+     ;; ----------------------------------------------------------------
+     ;; The two hooks (rf2-hic-031)
+     ;; ----------------------------------------------------------------
+     ;;
+     ;; Two, and there will not be a third by accident. Everything else a
+     ;; native component needs is React's own — `useState`, `useEffect`,
+     ;; `useRef`, `useTransition` — reached by direct `["react"]` interop,
+     ;; and Hicasso wraps none of it. What React cannot supply is the
+     ;; frame, so that is exactly what these two supply and no more.
+     ;;
+     ;; Both take their frame from [[re-frame.hicasso.impl.collector/resolve-frame!]],
+     ;; which is the boundary shell's own resolution: ONE React context,
+     ;; no dynamic-var tier, no `:rf/default` floor. An island therefore
+     ;; reads the frame its own subtree is mounted under and there is no
+     ;; spelling — not an argument, not an option map — by which either
+     ;; hook reaches a sibling frame.
+
+     (defn use-frame
+       "**Frame-locked operations, in hook position.** `rf/capture-frame`'s
+  bundle for the frame this island is mounted in:
+
+      {:frame         :watchlist
+       :dispatch      (fn ([event] [event opts]))
+       :dispatch-sync (fn ([event] [event opts]))
+       :subscribe     (fn [query-v])}
+
+      (n/defcomponent col-resizer
+        [^js props]
+        (let [{:keys [dispatch]} (n/use-frame)]
+          (n/$ :div {:on-pointer-up (fn [_] (dispatch [:col/commit]))})))
+
+  It is `capture-frame` and nothing wider — no options map, no explicit
+  frame arity — because Hicasso does not duplicate core's frame doors.
+  For a named frame there is no hook tax: `(rf/capture-frame frame-id)`
+  takes one directly.
+
+  ## Reference-stable, and pinned to an INCARNATION
+
+  The map is the Hicasso runtime's own memo row
+  ([[re-frame.hicasso.impl.collector/frame-row]]), so repeated renders
+  under one frame hand back the identical object — safe in `useEffect`
+  deps, safe as a memoised child's prop, safe to pull `:dispatch` off
+  and close over.
+
+  What it is keyed on is the load-bearing part. A frame's public keyword
+  is an ADDRESS, not an object: destroy `:watchlist` and create another
+  under the same id and the ops captured against the first belong to the
+  first forever (rf2-hic-013). The row carries the incarnation it was
+  minted under and is replaced when that incarnation is superseded, so
+  the next render gets ops pinned to the successor while a callback
+  still holding the predecessor's is refused by core's own fence
+  (`:rf.error/frame-destroyed`) rather than silently writing whoever
+  occupies the address now. **A memo keyed on the frame KEYWORD would
+  pass every stability test and fail exactly this one**, because the
+  keyword is `=` across a reincarnation.
+
+  Rendering outside every frame refuses with
+  `:rf.error/no-frame-context`."
+       []
+       (let [frame-kw (collector/resolve-frame!
+                        (react/useContext adapter-context/frame-context)
+                        're-frame.hicasso.native/use-frame)]
+         (:ops (collector/frame-row frame-kw))))
+
+     (defn use-sub
+       "**Read a subscription from a native component.** A real React
+  hook, so React's rules of hooks are the rules — top level of the
+  component, unconditional, one call per read:
+
+      (n/defcomponent ticker
+        [^js props]
+        (n/$ :span nil (n/use-sub [:quote/price (.-symbol props)])))
+
+  It is the native tier's counterpart to `h/sub`, and the two obey
+  different laws on purpose. `h/sub` is an ambient collector legal
+  inside a `when`, inside a `for` and inside an inlined helper, because
+  a `defview` body is not a component and its reads are recorded where
+  they happen. Past the fence there is no body and no ambient extent —
+  there is a fiber — so a read is a hook and a conditional read is a
+  bug React itself names.
+
+  ## One runtime, not a second one
+
+  The hook hands `useSyncExternalStore` the very `subscribe` and
+  `getSnapshot` a boundary reading this one key would be handed
+  ([[re-frame.hicasso.impl.collector/hook-entry]]). So an island's read
+  builds the same cell, takes the same reader membership, is woken by
+  the same commit, is counted by the same residue census, and is named
+  by the same `re-frame.hicasso.tool` rosters Xray consumes — which is
+  why nothing in the tool tier had to learn that hooks exist.
+
+  A steady-state re-render performs **no re-subscribe**: an unchanged
+  key hits the same cached entry, so `subscribe` is identical and React
+  never calls it again. Unmount releases exactly what mount acquired,
+  and React StrictMode's double mount is the acquire/release pair run
+  twice rather than a leak, because the only global write is inside
+  `subscribe` and React calls it at commit and nowhere else.
+
+  ## The external-store ceiling, stated rather than papered over
+
+  React's own `useSyncExternalStore` documentation is explicit that
+  **external-store mutations cannot be non-blocking Transition
+  updates**: React may restart a transition as blocking when the
+  snapshot changes. A re-frame2 commit observed through this hook is
+  therefore a BLOCKING update, and wrapping the dispatch in
+  `startTransition` does not make it otherwise. Reads stay tear-free
+  under a transition — that is witnessed — but no part of this surface
+  is transition-aware and none of it should be described that way.
+
+  React likewise discourages SUSPENDING on a value read from an
+  external store, because an update can then replace visible content
+  with a fallback. So `n/use-sub` is not the door to a promise-driven
+  resource: prepare the resource at the route, model an explicit
+  pending state, or put React Suspense in a native island that owns its
+  own resource.
+
+  Rendering outside every frame refuses with
+  `:rf.error/no-frame-context`."
+       [query-v]
+       (let [frame-kw  (collector/resolve-frame!
+                         (react/useContext adapter-context/frame-context)
+                         're-frame.hicasso.native/use-sub)
+             ;; The refusal above sits between the two hooks deliberately.
+             ;; Without a frame there is no read set, so there is nothing
+             ;; for the store hook to subscribe to and nothing to invent;
+             ;; and a render that throws never reaches React's hook
+             ;; reconciliation, so no count can disagree with a previous
+             ;; render's.
+             ^js entry (collector/hook-entry [frame-kw query-v])]
+         ;; The epoch, not the value: `getSnapshot` answers one monotone
+         ;; number, React compares it with `Object.is`, and the value is
+         ;; read after — from the same synchronous instant, since a
+         ;; render is a turn and nothing can commit inside one. This is
+         ;; the shell's own arrangement, and the third argument is the
+         ;; same closure for the same reason it is there.
+         (react/useSyncExternalStore (.-subscribe entry) (.-snapshot entry)
+                                     (.-snapshot entry))
+         (collector/hook-read frame-kw query-v)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The macros

--- a/implementation/hicasso/src/re_frame/hicasso/native.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso/native.cljc
@@ -417,6 +417,14 @@
   twice rather than a leak, because the only global write is inside
   `subscribe` and React calls it at commit and nowhere else.
 
+  Two calls in one component are two subscriptions, where a `defview`
+  body's several `h/sub` reads are ONE. That is React's arithmetic and
+  not a choice: a store subscription is a hook, so `n` reads cost `n` of
+  them, and the tool tier will show `n` single-edge boundaries rather
+  than one with `n` edges. Nothing is incorrect about it and the cost is
+  a hook cell each; it is simply the shape, and an island reading a
+  dozen keys is an island that wanted a `defview`.
+
   ## The external-store ceiling, stated rather than papered over
 
   React's own `useSyncExternalStore` documentation is explicit that
@@ -447,7 +455,8 @@
              ;; and a render that throws never reaches React's hook
              ;; reconciliation, so no count can disagree with a previous
              ;; render's.
-             ^js entry (collector/hook-entry [frame-kw query-v])]
+             sub-key   [frame-kw query-v]
+             ^js entry (collector/hook-entry sub-key)]
          ;; The epoch, not the value: `getSnapshot` answers one monotone
          ;; number, React compares it with `Object.is`, and the value is
          ;; read after — from the same synchronous instant, since a
@@ -456,7 +465,7 @@
          ;; same closure for the same reason it is there.
          (react/useSyncExternalStore (.-subscribe entry) (.-snapshot entry)
                                      (.-snapshot entry))
-         (collector/hook-read frame-kw query-v)))))
+         (collector/hook-read sub-key)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The macros

--- a/implementation/hicasso/test/re_frame/hicasso/native_hooks_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_hooks_cljs_test.cljs
@@ -1,0 +1,209 @@
+(ns re-frame.hicasso.native-hooks-cljs-test
+  "THE TWO NATIVE HOOKS, WHERE NO DOM IS NEEDED (rf2-hic-031).
+
+  `n/use-sub` and `n/use-frame` are React hooks and most of what is true
+  about them is true only once React is driving a real fiber — identity
+  across re-renders, StrictMode's double mount, teardown. That is
+  `native_hooks_dom_cljs_test`'s subject and it is the larger half.
+
+  Three claims do NOT need a fiber, and they are the ones here, because
+  the server renderer runs a component body for real:
+
+  | row | what it establishes |
+  |---|---|
+  | [[a-native-read-under-a-live-frame-answers-without-committing-anything]] | the COLD tier. A body runs, the value is right, and the runtime retained nothing — because nothing committed. |
+  | [[both-hooks-refuse-outside-every-frame-and-each-names-itself]] | the refusal the guide's chapter 10 table promises, and that the two hooks are distinguishable in it. |
+  | [[use-frame-answers-the-runtimes-own-row-rather-than-capturing-its-own]] | the hook is not a second `capture-frame`. This is the row the incarnation rule rests on, and it is an IDENTITY test because an equality test passes for the wrong implementation. |
+
+  ## Why the server renderer is the harness
+
+  `native_fence_cljs_test` established it for this tier and the reason is
+  the same: `renderToStaticMarkup` invokes bodies, resolves context and
+  runs hooks, in a Node process with no `document`. What it does NOT do
+  is commit — React never calls `subscribe` on the server — so it is
+  also the only harness in which *what a render retains* can be read as
+  a flat zero. A DOM lane would have to distinguish \"retained nothing\"
+  from \"retained and then released\", and those are different claims.
+
+  Nothing here is an SSR claim. A native component's server policy is
+  `n/defcomponent`'s declaration (`{:server :render}` / Client-only) and
+  its enforcement is rf2-hic-046's; this file uses the server renderer as
+  an instrument, exactly as the fence suite does."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.native :as n]
+            [re-frame.test-support :as test-support]
+            ["react-dom/server" :as react-dom-server]))
+
+(def ^:private frame-id ::native-hooks)
+
+;; Registered ABOVE `use-fixtures`, as every suite in this package does:
+;; the reset fixture captures its source-store baseline when the
+;; `use-fixtures` form is EVALUATED, so a registration written below it is
+;; erased before the first row runs.
+(rf/reg-sub ::price (fn [db [_ sym]] (get-in db [:prices sym])))
+(rf/reg-event ::seed (fn [_ [_ prices]] {:db {:prices prices}}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; The islands
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !observed-ops
+  ;; What `use-frame` handed the body on its last run. A module atom rather
+  ;; than a returned value because the thing under test is what a COMPONENT
+  ;; saw, and a component's return value is markup.
+  (atom nil))
+
+(n/defcomponent reader
+  "Reads one subscription, and nothing else."
+  [^js props]
+  (n/$ :span nil (str (n/use-sub [::price (.-sym props)]))))
+
+(n/defcomponent framed
+  "Takes the frame-locked ops and reports the frame it was locked to."
+  [^js _props]
+  (let [ops (n/use-frame)]
+    (reset! !observed-ops ops)
+    (n/$ :span nil (str (:frame ops)))))
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- seat!
+  "Create the frame and seed it. Answers nothing — a row that wants the
+  incarnation asks `frame/frame-incarnation-token` for it."
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [::seed {"AAPL" 191}]))
+  nil)
+
+(defn- render-under-frame!
+  "Render `element` with the frame context installed — the same provider
+  `h/root!` installs, reached through the runtime's own door rather than
+  through a hand-built context wrapper this suite would then be pinning
+  instead of the product."
+  [element]
+  (react-dom-server/renderToStaticMarkup (mount/provider frame-id element)))
+
+(defn- render-frameless!
+  "Render `element` with NO provider above it. The island in a portal
+  outside the app, in a second root, or in a test without the harness —
+  the three cases the guide's chapter 10 error table names."
+  [element]
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  (react-dom-server/renderToStaticMarkup element))
+
+(defn- refusal
+  "Run `f` and answer the refusal's ex-data — or a marker saying what
+  happened instead, so a failing row reports WHICH of the two ways it
+  failed rather than throwing out of the assertion."
+  [f]
+  (try
+    (f)
+    {::outcome :returned-without-refusing}
+    (catch :default e
+      (or (ex-data e) {::outcome :threw-without-ex-data ::message (ex-message e)}))))
+
+;; ---------------------------------------------------------------------------
+;; 1. The cold tier — a read before any commit
+;; ---------------------------------------------------------------------------
+
+(deftest a-native-read-under-a-live-frame-answers-without-committing-anything
+  (seat!)
+  (testing "the island reads the frame it is mounted in, on a render that
+            never commits — which is every island's FIRST render, since
+            React calls `subscribe` in a passive effect after the commit.
+            Narrowing caught: a hook whose only read path is the warm cell
+            deref. It would answer nil here and on the first render of
+            every island ever mounted, and the DOM lane would not see it
+            because React repaints the moment the subscription lands"
+    (is (= "<span>191</span>" (render-under-frame! (n/$ reader {:sym "AAPL"})))))
+
+  (testing "and it RETAINED nothing. A cold read is the observation port's
+            probe: no cell, no reader membership, no boundary, no edge, no
+            disposal obligation. Narrowing caught: acquiring during the
+            render rather than at commit — the ownership state machine's
+            one prohibition — which would leave a cell and a membership
+            behind on a render React discarded, and which is invisible
+            from the markup because the markup is right either way"
+    (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0}
+           (dissoc (inventory/residue) :entries))))
+
+  (testing "`:entries` is deliberately outside that reading, and being
+            exact about it is the difference between a census and a
+            slogan. A read-set entry is minted during the RENDER — it is
+            the cached `subscribe`/`getSnapshot` pair React is about to be
+            handed — and claimed at the COMMIT that never came here; an
+            unclaimed one belongs to
+            `collector/entry-reap-horizon-ms`'s reaper. That is not a
+            property of hooks: a boundary body whose render React
+            discards leaves exactly the same one, and the hook seam mints
+            through the same door precisely so there is one story"
+    (is (= 1 (:entries (inventory/residue))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. The refusal, and that the two hooks are distinguishable in it
+;; ---------------------------------------------------------------------------
+
+(deftest both-hooks-refuse-outside-every-frame-and-each-names-itself
+  (testing "`n/use-sub` outside every frame refuses with the id the guide
+            promises. Narrowing caught: resolving through the dynamic-var
+            tier or falling back to `:rf/default` — either would answer
+            SOMETHING here, and an island silently reading a frame its own
+            subtree is not under is the isolation failure this tier must
+            not have"
+    (let [data (refusal #(render-frameless! (n/$ reader {:sym "AAPL"})))]
+      (is (= :rf.error/no-frame-context (:rf.error/id data)))
+      (is (= :mount-under-a-frame (:recovery data)))
+      (is (= 're-frame.hicasso.native/use-sub (:where data)))))
+
+  (testing "`n/use-frame` refuses identically, and names ITSELF. The two
+            `:where` values are the reason the shell's resolution takes
+            one: a single hardcoded `:where` would send a reader of either
+            refusal to the boundary shell, which is not what refused"
+    (let [data (refusal #(render-frameless! (n/$ framed nil)))]
+      (is (= :rf.error/no-frame-context (:rf.error/id data)))
+      (is (= 're-frame.hicasso.native/use-frame (:where data))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. `use-frame` is the runtime's row, not a second capture
+;; ---------------------------------------------------------------------------
+
+(deftest use-frame-answers-the-runtimes-own-row-rather-than-capturing-its-own
+  (seat!)
+  (reset! !observed-ops nil)
+  (let [markup (render-under-frame! (n/$ framed nil))
+        ops    @!observed-ops]
+
+    (testing "the shape is `capture-frame`'s, locked to the ambient frame"
+      (is (= (str "<span>" frame-id "</span>") markup))
+      (is (= frame-id (:frame ops)))
+      (is (every? #(fn? (get ops %)) [:dispatch :dispatch-sync :subscribe])))
+
+    (testing "and it is IDENTICAL to the arm's own memo row for this frame
+              — the bundle a lowered intent's ambient dispatch was minted
+              over, not a second `rf/capture-frame` the hook took for
+              itself.
+
+              This is the row the incarnation rule rests on, and equality
+              would not have caught it: `rf/capture-frame` called twice on
+              one live frame answers two maps that are `=` and are not the
+              same object. The UIx adapter's `use-frame` is exactly that
+              implementation, memoised on the frame KEYWORD — which is `=`
+              across a same-id reincarnation, so it would hand a destroyed
+              incarnation's bundle out forever. `native_hooks_dom_cljs_test`
+              drives the reincarnation itself; this row is where the
+              structural reason lives"
+      (is (identical? (:ops (collector/frame-row frame-id)) ops)))))

--- a/implementation/hicasso/test/re_frame/hicasso/native_hooks_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_hooks_dom_cljs_test.cljs
@@ -1,0 +1,655 @@
+(ns re-frame.hicasso.native-hooks-dom-cljs-test
+  "THE TWO NATIVE HOOKS UNDER A REAL REACT (rf2-hic-031).
+
+  `n/use-sub` and `n/use-frame` are React hooks, so they inherit React's
+  rules whole, and the characteristic way a hook is wrong is not that it
+  reads the wrong value — it is that it reads the RIGHT value while
+  quietly rebuilding its subscription on every render, or leaking one
+  under StrictMode's double mount, or holding a destroyed frame's ops
+  forever. Every one of those is invisible on screen. So no row below
+  reads only the DOM.
+
+  ## What each row is for, and the narrowing it is written against
+
+  | row | what it establishes | the one-line narrowing it catches |
+  |---|---|---|
+  | [[an-islands-read-is-the-runtimes-own-and-xray-sees-it]] | the read builds a real cell under the mounted frame, and the tool tier's projection names it | reading through `subscribe-once` per render — right value, no cell, invisible to Xray |
+  | [[a-write-wakes-the-island-that-reads-it-and-nothing-else]] | notification is edge-driven, not store-wide | subscribing to the generation, which repaints every island on every write |
+  | [[a-re-render-that-changed-no-read-performs-no-re-subscribe]] | `subscribe` identity is stable, so React never re-subscribes | any per-render `subscribe` closure — the screen stays correct throughout |
+  | [[strict-modes-double-mount-acquires-once-and-unmount-releases-exactly]] | acquire is commit-owned and teardown is its exact inverse | acquiring during render, or a cleanup that releases a successor's cells |
+  | [[two-frames-are-two-cells-and-an-island-cannot-see-across]] | frames are isolated contexts, on the native side of the fence too | resolving the frame anywhere but the island's own context |
+  | [[use-frame-is-stable-across-renders-and-retargets-across-a-reincarnation]] | the hic-013 incarnation rule, both halves | memoising on the frame KEYWORD, which is `=` across a reincarnation |
+  | [[a-transition-around-a-write-stays-tear-free-and-is-still-blocking]] | React's external-store ceiling, measured rather than advertised | a docstring that claimed transition-awareness |
+  | [[the-declared-population-was-actually-exercised]] | the roster, asserted rather than described | a row that started returning early |
+
+  ## Why the readings are counts and identities, not text
+
+  React will make a broken subscription look correct in the final DOM:
+  it re-renders from the model it already has, so a torn-down-and-rebuilt
+  subscription and a stable one paint the same pixels. The observables
+  here are therefore the ones React cannot forge — the cell table's keys
+  and reader lists, the REGISTRATION OBJECT's identity across a
+  re-render, and a body-run count — which is
+  `roots_frames_support`'s argument applied to a tier it was not written
+  for, through the same helpers.
+
+  ## Browser lane
+
+  Every row needs a real document and a real React DOM. `:node-test`
+  compiles this namespace too (`cljs-test$` matches `-dom-cljs-test`), and
+  each row degrades there to a STATED skip rather than to a false green.
+  What can be said without a fiber is said in `native_hooks_cljs_test`."
+  (:require [clojure.set :as set]
+            [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.frame :as frame]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.native :as n]
+            [re-frame.hicasso.roots-frames-support :as support]
+            [re-frame.hicasso.tool :as tool]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]))
+
+(def ^:private alpha ::alpha)
+(def ^:private beta  ::beta)
+
+;; Registered ABOVE `use-fixtures` — the reset fixture captures its
+;; source-store baseline when the `use-fixtures` form is EVALUATED, so a
+;; registration written below it is erased before the first row runs.
+
+(rf/reg-sub ::price     (fn [db [_ sym]] (get-in db [:prices sym])))
+(rf/reg-sub ::elsewhere (fn [db _] (:elsewhere db)))
+
+(rf/reg-event ::seed (fn [_ [_ prices]] {:db {:prices prices :elsewhere 0}}))
+(rf/reg-event ::set-price
+              (fn [{:keys [db]} [_ sym v]] {:db (assoc-in db [:prices sym] v)}))
+(rf/reg-event ::touch-elsewhere
+              (fn [{:keys [db]} _] {:db (update db :elsewhere inc)}))
+
+;; ---------------------------------------------------------------------------
+;; The roster this file undertakes to reach
+;; ---------------------------------------------------------------------------
+
+(def ^:private declared-population
+  "A row that starts returning early, or a mechanism that stops being
+  driven, fails the last deftest instead of quietly shrinking the
+  evidence."
+  #{:hooks/mounted-read
+    :hooks/selective-wake
+    :hooks/no-resubscribe
+    :hooks/strict-mode
+    :hooks/frame-isolation
+    :hooks/incarnation
+    :hooks/transition})
+
+(defonce ^:private !exercised (atom #{}))
+
+(defn- exercised! [mechanism] (swap! !exercised conj mechanism) nil)
+
+;; ---------------------------------------------------------------------------
+;; The island, and the two things it reports about itself
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !island-runs
+  ;; Body invocations, counted where the body actually runs. The native
+  ;; counterpart of `collector/body-runs`, which counts BOUNDARY bodies and
+  ;; therefore says nothing about an island.
+  (atom 0))
+
+(defonce ^:private !last-ops
+  ;; What `use-frame` handed the body on its last run, held by identity.
+  (atom nil))
+
+(n/defcomponent ticker
+  "One island: one subscription read, the frame-locked ops, and a piece
+  of purely local React state.
+
+  The local state is not decoration — it is how a row re-renders the
+  island for a reason the runtime knows nothing about, which is the only
+  way to ask whether an unchanged read costs a re-subscribe."
+  [^js props]
+  (swap! !island-runs inc)
+  (let [sym               (.-sym props)
+        price             (n/use-sub [::price sym])
+        ops               (n/use-frame)
+        [local set-local] (react/useState 0)]
+    (reset! !last-ops ops)
+    (n/$ :div nil
+         (n/$ :b {:class "price"} (str price))
+         (n/$ :i {:class "local"} (str local))
+         (n/$ :button {:class    "nudge"
+                       :on-click (fn [_] (set-local inc))}
+              "nudge")
+         (n/$ :button {:class    "commit"
+                       :on-click (fn [_]
+                                   ((:dispatch-sync ops)
+                                    [::set-price sym "from-the-island"]))}
+              "commit"))))
+
+(h/defview host
+  "Rung 3: an ordinary boundary body returning a native element. The
+  island reaches the frame through the context this boundary's root
+  installed, and through nothing else."
+  [{:keys [sym]}]
+  (n/$ ticker {:sym sym}))
+
+(h/defview strict-host
+  "The same island under React's own StrictMode, which double-invokes
+  the body and runs mount/unmount/mount over every effect."
+  [{:keys [sym]}]
+  (n/$ react/StrictMode nil (n/$ ticker {:sym sym})))
+
+(h/defview boundary-reader
+  "A BOUNDARY reading the identical key the island reads — the control
+  for the shared-entry claim."
+  [{:keys [sym]}]
+  [:u.boundary (str (h/sub [::price sym]))])
+
+(h/defview shared-host
+  "One boundary and one island, reading one key."
+  [{:keys [sym]}]
+  [:div [boundary-reader {:sym sym}] (n/$ ticker {:sym sym})])
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     ;; `nil` and not the default: a dynamic-var frame left in ambient scope
+     ;; would let a hook that failed to resolve its own frame answer that one
+     ;; instead, and the isolation row would read a rendering difference where
+     ;; the failure is a frame miss.
+     :ambient-frame nil
+     ;; The MAP shape, because every row here is `async`.
+     :async?        true
+     :init-fn       (fn []
+                      (support/leave-act-environment!)
+                      (reset! !island-runs 0)
+                      (reset! !last-ops nil)
+                      (error-emit/clear-error-listeners!)
+                      (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- price-key [frame-kw sym] [frame-kw [::price sym]])
+
+(defn- seat!
+  "Create `frame-kw` and seed it. Answers the incarnation token, so a row
+  that claims a reincarnation can prove one happened."
+  [frame-kw prices]
+  (rf/make-frame {:id frame-kw})
+  (rf/with-frame frame-kw (rf/dispatch-sync [::seed prices]))
+  (frame/frame-incarnation-token frame-kw))
+
+(defn- at [handle sel] (.querySelector ^js (:container handle) sel))
+(defn- text-at [handle sel] (some-> (at handle sel) .-textContent))
+(defn- click! [handle sel] (.click ^js (at handle sel)) (mount/settle!) nil)
+
+(defn- readers-of [sub-key] (inventory/cell-readers sub-key))
+
+(defn- mount-live!
+  "Mount `hiccup` under `frame-kw` and return only once the island is
+  provably SUBSCRIBED.
+
+  `useSyncExternalStore` calls `subscribe` from a passive effect React
+  flushes after the commit, and an island that has not reached it cannot
+  be notified by anything — so a row that started before it would be
+  measuring an unsubscribed component and would stay green through a hook
+  that never subscribed at all. The wait is on the CELL's reader list,
+  which only the commit can populate."
+  [frame-kw hiccup sub-key]
+  (let [container (mount/fresh-container!)
+        handle    (mount/root! container frame-kw hiccup)]
+    (-> (support/wait-until! #(= 1 (count (readers-of sub-key))))
+        (.then (fn [subscribed?]
+                 (when-not subscribed?
+                   (throw (ex-info "the island never subscribed"
+                                   {:residue (inventory/residue)})))
+                 handle)))))
+
+(defn- skip! [why] (is true (str "a native-hook claim needs a real React DOM — " why)))
+
+(defn- fail-and-finish!
+  [done label handle]
+  (fn [e]
+    (is false (str label " — " (.-message e)
+                   " | residue " (pr-str (inventory/residue))))
+    (when handle (mount/release! handle))
+    (done)))
+
+(defn- teardown!
+  "Unmount, read the census while it is still exact, then finish the
+  release. The order is the load-bearing part: `mount/release!` calls
+  `collector/reset-runtime!`, which empties every table BY FIAT, so a
+  census taken after it reads zeros whether the teardown released
+  anything or not."
+  [handle]
+  (support/teardown-census! handle))
+
+;; ---------------------------------------------------------------------------
+;; W1. The read is the runtime's own, and the tool tier can see it
+;; ---------------------------------------------------------------------------
+
+(deftest an-islands-read-is-the-runtimes-own-and-xray-sees-it
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no React DOM") (done))
+      (let [k (price-key alpha "AAPL")]
+        (seat! alpha {"AAPL" 191})
+        (-> (mount-live! alpha [shared-host {:sym "AAPL"}] k)
+            (.then
+              (fn [handle]
+                (testing "the island painted the value, and so did the boundary
+                          beside it — the same key, read through the two
+                          different doors the two tiers offer"
+                  (is (= "191" (text-at handle ".price")))
+                  (is (= "191" (text-at handle ".boundary"))))
+
+                (testing "and there is exactly ONE cell, under the frame the
+                          root installed, with TWO readers. Narrowing caught: a
+                          hook that read through `subscribe-once` per render —
+                          the paint above is identical under it and there would
+                          be one reader here, or none"
+                  (is (= #{k} (support/cell-keys)))
+                  (is (= 2 (count (readers-of k)))))
+
+                (testing "and TWO read-set entries exist, which is the honest
+                          count: the one-key entry the boundary and the island
+                          SHARE, and the empty one `shared-host` claimed — a
+                          body that reads nothing still mints and claims an
+                          entry, and that is what makes the tool tier's census
+                          complete"
+                  (is (= 2 (:entries (inventory/residue)))))
+
+                (testing "and `re-frame.hicasso.tool`'s mounted-boundary
+                          projection — hic-023's, the one Xray consumes — NAMES
+                          the read, without knowing that hooks exist. That is
+                          the whole return on routing the hook through the
+                          runtime's tables instead of beside them.
+
+                          `:read-orders 1` is the discriminating field.
+                          Narrowing caught: a private entry cache for hooks —
+                          the cell, the two readers and `:instances` are all
+                          unchanged under it, because two entries with equal
+                          key sets group into one row; what doubles is the
+                          number of entries folded into that row"
+                  (let [projection (tool/read-mounted-boundaries)
+                        row        (first (filter (fn [r]
+                                                    (some #(= ::price (:sub-id %))
+                                                          (:reads r)))
+                                                  (:boundaries projection)))]
+                    (is (= :mounted-boundaries (:scope projection)))
+                    (is (some? row) "the projection names no read of ::price")
+                    (is (= alpha (:frame row)))
+                    (is (= alpha (:frame-id (first (:reads row)))))
+                    (is (= 2 (:instances row))
+                        "one edge set, two holders — the runtime keys a
+                         boundary by what it reads, and an island reading what
+                         a boundary reads is indistinguishable to it")
+                    (is (= 1 (:read-orders row)))))
+
+                (exercised! :hooks/mounted-read)
+                (testing "teardown releases every membership the mount took"
+                  (is (= support/released (teardown! handle))))
+                (done)))
+            (.catch (fail-and-finish! done "W1 mounted read" nil)))))))
+
+;; ---------------------------------------------------------------------------
+;; W2. A write wakes its readers and nobody else
+;; ---------------------------------------------------------------------------
+
+(deftest a-write-wakes-the-island-that-reads-it-and-nothing-else
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no React DOM") (done))
+      (let [k (price-key alpha "AAPL")]
+        (seat! alpha {"AAPL" 191})
+        (-> (mount-live! alpha [host {:sym "AAPL"}] k)
+            (.then
+              (fn [handle]
+                (testing "a write to the key the island reads repaints it"
+                  (mount/dispatch! handle [::set-price "AAPL" 204])
+                  (is (= "204" (text-at handle ".price"))))
+
+                (let [runs (deref !island-runs)]
+                  (testing "a write to a key NOTHING in the tree reads runs no
+                            island body at all. Narrowing caught: a hook
+                            subscribed to the generation, or to the store as a
+                            whole — it repaints correctly on the row above and
+                            wakes on every write in the application here, which
+                            is the cost the whole cell table exists to avoid"
+                    (mount/dispatch! handle [::touch-elsewhere])
+                    (is (= runs (deref !island-runs)))
+                    (is (= "204" (text-at handle ".price")))))
+
+                (testing "and the island's own dispatch — `:dispatch-sync` off
+                          the ops map, fired from a real click through React's
+                          event system — moves the same app-db the rest of the
+                          page reads"
+                  (click! handle ".commit")
+                  (is (= "from-the-island" (text-at handle ".price")))
+                  (is (= "from-the-island"
+                         (rf/with-frame alpha @(rf/subscribe [::price "AAPL"])))))
+
+                (exercised! :hooks/selective-wake)
+                (is (= support/released (teardown! handle)))
+                (done)))
+            (.catch (fail-and-finish! done "W2 selective wake" nil)))))))
+
+;; ---------------------------------------------------------------------------
+;; W3. THE characteristic failure: a re-render that changed no read
+;; ---------------------------------------------------------------------------
+
+(deftest a-re-render-that-changed-no-read-performs-no-re-subscribe
+  ;; This is the row the design is FOR. A hook that mints its `subscribe`
+  ;; closure per render is correct on screen forever: React tears the
+  ;; subscription down and rebuilds it after every single re-render,
+  ;; releasing and re-acquiring the cell, and the value is right the whole
+  ;; time. Only the registration's IDENTITY says so.
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no React DOM") (done))
+      (let [k (price-key alpha "AAPL")]
+        (seat! alpha {"AAPL" 191})
+        (-> (mount-live! alpha [host {:sym "AAPL"}] k)
+            (.then
+              (fn [handle]
+                (let [reg-at-mount (first (readers-of k))
+                      runs         (deref !island-runs)
+                      residue      (inventory/residue)]
+
+                  (testing "three re-renders driven by the island's OWN React
+                            state — a `useState` bump behind a real click,
+                            which the runtime knows nothing about and cannot
+                            have moved a read"
+                    (click! handle ".nudge")
+                    (click! handle ".nudge")
+                    (click! handle ".nudge")
+                    (is (= "3" (text-at handle ".local")))
+                    (is (= 3 (- (deref !island-runs) runs))
+                        "the body really did run three more times, which is
+                         what makes the readings below a test of anything"))
+
+                  (testing "and the registration React holds is the IDENTICAL
+                            object. Narrowing caught: an inline `subscribe`
+                            closure, or a `useCallback` keyed on a CLJS vector
+                            (which is never `Object.is`-stable, so its deps
+                            array rebuilds every render) — either makes this a
+                            different object three times over, and nothing on
+                            screen changes"
+                    (is (identical? reg-at-mount (first (readers-of k)))))
+
+                  (testing "so nothing was released and re-acquired: one cell,
+                            one membership, one boundary, one edge, one entry —
+                            the numbers the mount established, unmoved"
+                    (is (= residue (inventory/residue))))
+
+                  (testing "the same holds across a re-render the RUNTIME
+                            caused. A write moves the value, React re-renders
+                            the island, and the read set is what it was — so
+                            React is never handed a new `subscribe` and the
+                            commit does no work"
+                    (mount/dispatch! handle [::set-price "AAPL" 204])
+                    (is (= "204" (text-at handle ".price")))
+                    (is (identical? reg-at-mount (first (readers-of k))))
+                    (is (= residue (inventory/residue))))
+
+                  (exercised! :hooks/no-resubscribe)
+                  (is (= support/released (teardown! handle)))
+                  (done))))
+            (.catch (fail-and-finish! done "W3 no re-subscribe" nil)))))))
+
+;; ---------------------------------------------------------------------------
+;; W4. StrictMode's double mount, and exact teardown
+;; ---------------------------------------------------------------------------
+
+(deftest strict-modes-double-mount-acquires-once-and-unmount-releases-exactly
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no React DOM") (done))
+      (let [k (price-key alpha "AAPL")]
+        (seat! alpha {"AAPL" 191})
+        (-> (mount-live! alpha [strict-host {:sym "AAPL"}] k)
+            (.then
+              (fn [handle]
+                (testing "StrictMode really is engaged — the body ran more than
+                          once for one mount, which is the premise the rest of
+                          this row rests on and which a production React build
+                          would silently remove"
+                  (is (< 1 (deref !island-runs))
+                      (str "the island body ran " (deref !island-runs)
+                           " time(s); StrictMode double-invokes render")))
+
+                (testing "and after mount → unmount → mount over every effect,
+                          there is exactly ONE reader on ONE cell. Narrowing
+                          caught: acquiring during the render — the ownership
+                          state machine's one prohibition — which under a
+                          double-invoked render acquires twice and reads 2 here
+                          while painting perfectly"
+                  (is (= #{k} (support/cell-keys)))
+                  (is (= 1 (count (readers-of k))))
+                  (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1}
+                         (dissoc (inventory/residue) :entries))))
+
+                (testing "the island is live, not merely tidy — a subscription
+                          torn down by StrictMode's first cleanup and never
+                          rebuilt would satisfy every count above and repaint
+                          nothing"
+                  (mount/dispatch! handle [::set-price "AAPL" 204])
+                  (is (= "204" (text-at handle ".price"))))
+
+                (testing "and unmount releases EXACTLY what mount acquired,
+                          read between the unmount and the reset. Narrowing
+                          caught: a cleanup that released by key rather than by
+                          the cells it acquired — after a reap and rebuild it
+                          would release a successor's and leave its own"
+                  (is (= support/released (teardown! handle))))
+
+                (exercised! :hooks/strict-mode)
+                (-> (support/quiesced!)
+                    (.then (fn [_]
+                             (testing "past the reapers the tables are empty"
+                               (is (= {:cells 0 :cell-refs 0 :boundaries 0
+                                       :edges 0 :entries 0}
+                                      (inventory/residue))))
+                             (done))))))
+            (.catch (fail-and-finish! done "W4 StrictMode" nil)))))))
+
+;; ---------------------------------------------------------------------------
+;; W5. Frames are isolated contexts — on this side of the fence too
+;; ---------------------------------------------------------------------------
+
+(deftest two-frames-are-two-cells-and-an-island-cannot-see-across
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no React DOM") (done))
+      (let [ka (price-key alpha "AAPL")
+            kb (price-key beta "AAPL")]
+        (seat! alpha {"AAPL" "alpha-price"})
+        (seat! beta  {"AAPL" "beta-price"})
+        (-> (mount-live! alpha [host {:sym "AAPL"}] ka)
+            (.then (fn [a] (.then (mount-live! beta [host {:sym "AAPL"}] kb)
+                                  (fn [b] #js [a b]))))
+            (.then
+              (fn [^js pair]
+                (let [a (aget pair 0)
+                      b (aget pair 1)]
+                  (testing "one island source, two frames, one query — TWO
+                            cells, differing only in their frame, one reader
+                            each. Narrowing caught: any frame resolution that
+                            is not the island's own React context — a module
+                            global, a dynamic var, a `:rf/default` floor —
+                            every one of which produces ONE key here and two
+                            visually plausible subtrees"
+                    (is (= #{ka kb} (support/cell-keys)))
+                    (is (= 1 (count (readers-of ka))))
+                    (is (= 1 (count (readers-of kb)))))
+
+                  (testing "and each island painted its own frame's value"
+                    (is (= "alpha-price" (text-at a ".price")))
+                    (is (= "beta-price"  (text-at b ".price"))))
+
+                  (testing "a write in one frame moves that frame's island and
+                            leaves the other exactly where it was — the
+                            isolation claim as a REPAINT rather than as a count"
+                    (mount/dispatch! a [::set-price "AAPL" "alpha-moved"])
+                    (is (= "alpha-moved" (text-at a ".price")))
+                    (is (= "beta-price"  (text-at b ".price"))))
+
+                  (exercised! :hooks/frame-isolation)
+                  (mount/unmount! a)
+                  (is (= support/released (teardown! b)))
+                  (mount/release! (assoc a :root nil))
+                  (done))))
+            (.catch (fail-and-finish! done "W5 frame isolation" nil)))))))
+
+;; ---------------------------------------------------------------------------
+;; W6. `use-frame`, both halves of the incarnation rule
+;; ---------------------------------------------------------------------------
+
+(defn- destroyed-frame-complaints
+  "Collect the always-on `:rf.error/frame-destroyed` corpus records raised
+  while `thunk` runs. Axis 1 (`error-emit`) rather than the dev trace,
+  because the refusal this row is about is always on."
+  [thunk]
+  (let [seen (atom [])
+        k    ::destroyed-listener]
+    (error-emit/register-error-listener!
+      k (fn [r] (when (= :rf.error/frame-destroyed (:error r)) (swap! seen conj r))))
+    (try (thunk) @seen
+         (finally (error-emit/unregister-error-listener! k)))))
+
+(deftest use-frame-is-stable-across-renders-and-retargets-across-a-reincarnation
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no React DOM") (done))
+      (let [k (price-key alpha "AAPL")]
+        (seat! alpha {"AAPL" "predecessor"})
+        (-> (mount-live! alpha [host {:sym "AAPL"}] k)
+            (.then
+              (fn [handle]
+                (let [ops-1   (deref !last-ops)
+                      token-1 (frame/frame-incarnation-token alpha)]
+
+                  (testing "reference stability: three re-renders that changed
+                            no frame hand back the IDENTICAL map, which is what
+                            makes it safe in `useEffect` deps and as a memoised
+                            child's prop"
+                    (click! handle ".nudge")
+                    (click! handle ".nudge")
+                    (click! handle ".nudge")
+                    (is (identical? ops-1 (deref !last-ops))))
+
+                  ;; The reincarnation. Same public id, different object — and
+                  ;; the runtime learns of it through the cell the frame's
+                  ;; teardown disposed, which is what re-renders the island.
+                  (rf/destroy-frame! alpha)
+                  (let [token-2 (seat! alpha {"AAPL" "successor"})]
+                    (testing "the premise: a different incarnation under one
+                              public id"
+                      (is (not (identical? token-1 token-2))))
+
+                    (-> (support/wait-until! #(= "successor" (text-at handle ".price")))
+                        (.then
+                          (fn [corrected?]
+                            (is (true? corrected?)
+                                (str "the island never observed the successor; "
+                                     "it reads " (pr-str (text-at handle ".price"))))
+
+                            (let [ops-2 (deref !last-ops)]
+                              (testing "the ops map RETARGETED. Narrowing
+                                        caught, and it is a shipping
+                                        implementation: a `useRef` memo keyed
+                                        on the resolved frame by `=` — the UIx
+                                        adapter's `use-frame` — passes the
+                                        stability block above and fails here,
+                                        because a frame keyword is `=` across a
+                                        reincarnation and the hook would hand
+                                        out the destroyed incarnation's bundle
+                                        for the rest of the mount"
+                                (is (not (identical? ops-1 ops-2)))
+                                (is (= alpha (:frame ops-2))))
+
+                              (testing "and the fresh bundle WRITES the
+                                        successor"
+                                ((:dispatch-sync ops-2) [::set-price "AAPL" "live"])
+                                (is (= "live" (rf/with-frame alpha
+                                                @(rf/subscribe [::price "AAPL"])))))
+
+                              (testing "while the bundle a callback captured
+                                        before the transition refuses — loudly,
+                                        once, through the always-on corpus —
+                                        rather than silently writing whoever
+                                        occupies the address now. That silent
+                                        write is the failure rf2-hic-013
+                                        repaired, and it is the reason the
+                                        memo is keyed on an incarnation"
+                                (let [seen (destroyed-frame-complaints
+                                             #((:dispatch-sync ops-1)
+                                               [::set-price "AAPL" "from-the-dead"]))]
+                                  (is (= 1 (count seen)))
+                                  (is (= "live" (rf/with-frame alpha
+                                                  @(rf/subscribe [::price "AAPL"])))))))
+
+                            (exercised! :hooks/incarnation)
+                            (is (= support/released (teardown! handle)))
+                            (done)))
+                        (.catch (fail-and-finish! done "W6 incarnation" handle)))))))
+            (.catch (fail-and-finish! done "W6 incarnation" nil)))))))
+
+;; ---------------------------------------------------------------------------
+;; W7. The external-store ceiling, measured
+;; ---------------------------------------------------------------------------
+
+(deftest a-transition-around-a-write-stays-tear-free-and-is-still-blocking
+  ;; React's `useSyncExternalStore` documentation is explicit that an
+  ;; external store's mutations cannot be non-blocking Transition updates
+  ;; and that React may restart such a transition as blocking. The lane
+  ;; note (`lanes/react-compatibility-notes.md`) rules that Hicasso TEST
+  ;; tear-freedom under `startTransition` and DOCUMENT the blocking
+  ;; fallback honestly rather than advertise transition-awareness. This is
+  ;; the test half; `n/use-sub`'s docstring is the documented half.
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no React DOM") (done))
+      (let [k (price-key alpha "AAPL")]
+        (seat! alpha {"AAPL" 191})
+        (-> (mount-live! alpha [host {:sym "AAPL"}] k)
+            (.then
+              (fn [handle]
+                (react/startTransition
+                  (fn [] (collector/dispatch! alpha [::set-price "AAPL" 204])))
+                (mount/settle!)
+                (testing "the paint agrees with app-db — no tear. A hook that
+                          returned a value captured independently of the epoch
+                          `getSnapshot` reports could disagree here, and React
+                          would have no way to know"
+                  (is (= "204" (text-at handle ".price")))
+                  (is (= 204 (rf/with-frame alpha @(rf/subscribe [::price "AAPL"])))))
+
+                (testing "and the subscription was not rebuilt by the
+                          transition"
+                  (is (= 1 (count (readers-of k))))
+                  (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1}
+                         (dissoc (inventory/residue) :entries))))
+
+                (exercised! :hooks/transition)
+                (is (= support/released (teardown! handle)))
+                (done)))
+            (.catch (fail-and-finish! done "W7 transition" nil)))))))
+
+;; ---------------------------------------------------------------------------
+;; The roster
+;; ---------------------------------------------------------------------------
+
+(deftest the-declared-population-was-actually-exercised
+  (if-not (mount/browser?)
+    (skip! ":node-test reaches none of the mechanisms")
+    (is (= declared-population (deref !exercised))
+        (str "declared but never reached: "
+             (pr-str (set/difference declared-population (deref !exercised)))))))

--- a/implementation/hicasso/test/re_frame/hicasso/native_hooks_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_hooks_dom_cljs_test.cljs
@@ -193,22 +193,30 @@
 (defn- readers-of [sub-key] (inventory/cell-readers sub-key))
 
 (defn- mount-live!
-  "Mount `hiccup` under `frame-kw` and return only once the island is
-  provably SUBSCRIBED.
+  "Mount `hiccup` under `frame-kw` and return only once `sub-key` has
+  exactly `readers` readers — which is to say, once every holder in the
+  tree is provably SUBSCRIBED.
 
   `useSyncExternalStore` calls `subscribe` from a passive effect React
   flushes after the commit, and an island that has not reached it cannot
   be notified by anything — so a row that started before it would be
   measuring an unsubscribed component and would stay green through a hook
   that never subscribed at all. The wait is on the CELL's reader list,
-  which only the commit can populate."
-  [frame-kw hiccup sub-key]
+  which only the commit can populate.
+
+  `readers` is stated by the caller rather than assumed to be one,
+  because a tree may hold the key more than once — the shared-entry row
+  mounts a boundary and an island on one key deliberately — and a wait
+  that stopped at the first arrival would let the second commit land
+  underneath the assertions."
+  [frame-kw hiccup sub-key readers]
   (let [container (mount/fresh-container!)
         handle    (mount/root! container frame-kw hiccup)]
-    (-> (support/wait-until! #(= 1 (count (readers-of sub-key))))
+    (-> (support/wait-until! #(= readers (count (readers-of sub-key))))
         (.then (fn [subscribed?]
                  (when-not subscribed?
-                   (throw (ex-info "the island never subscribed"
+                   (throw (ex-info (str "expected " readers
+                                        " subscribed reader(s) on " (pr-str sub-key))
                                    {:residue (inventory/residue)})))
                  handle)))))
 
@@ -241,7 +249,7 @@
       (do (skip! ":node-test has no React DOM") (done))
       (let [k (price-key alpha "AAPL")]
         (seat! alpha {"AAPL" 191})
-        (-> (mount-live! alpha [shared-host {:sym "AAPL"}] k)
+        (-> (mount-live! alpha [shared-host {:sym "AAPL"}] k 2)
             (.then
               (fn [handle]
                 (testing "the island painted the value, and so did the boundary
@@ -309,7 +317,7 @@
       (do (skip! ":node-test has no React DOM") (done))
       (let [k (price-key alpha "AAPL")]
         (seat! alpha {"AAPL" 191})
-        (-> (mount-live! alpha [host {:sym "AAPL"}] k)
+        (-> (mount-live! alpha [host {:sym "AAPL"}] k 1)
             (.then
               (fn [handle]
                 (testing "a write to the key the island reads repaints it"
@@ -356,7 +364,7 @@
       (do (skip! ":node-test has no React DOM") (done))
       (let [k (price-key alpha "AAPL")]
         (seat! alpha {"AAPL" 191})
-        (-> (mount-live! alpha [host {:sym "AAPL"}] k)
+        (-> (mount-live! alpha [host {:sym "AAPL"}] k 1)
             (.then
               (fn [handle]
                 (let [reg-at-mount (first (readers-of k))
@@ -414,7 +422,7 @@
       (do (skip! ":node-test has no React DOM") (done))
       (let [k (price-key alpha "AAPL")]
         (seat! alpha {"AAPL" 191})
-        (-> (mount-live! alpha [strict-host {:sym "AAPL"}] k)
+        (-> (mount-live! alpha [strict-host {:sym "AAPL"}] k 1)
             (.then
               (fn [handle]
                 (testing "StrictMode really is engaged — the body ran more than
@@ -472,8 +480,8 @@
             kb (price-key beta "AAPL")]
         (seat! alpha {"AAPL" "alpha-price"})
         (seat! beta  {"AAPL" "beta-price"})
-        (-> (mount-live! alpha [host {:sym "AAPL"}] ka)
-            (.then (fn [a] (.then (mount-live! beta [host {:sym "AAPL"}] kb)
+        (-> (mount-live! alpha [host {:sym "AAPL"}] ka 1)
+            (.then (fn [a] (.then (mount-live! beta [host {:sym "AAPL"}] kb 1)
                                   (fn [b] #js [a b]))))
             (.then
               (fn [^js pair]
@@ -530,7 +538,7 @@
       (do (skip! ":node-test has no React DOM") (done))
       (let [k (price-key alpha "AAPL")]
         (seat! alpha {"AAPL" "predecessor"})
-        (-> (mount-live! alpha [host {:sym "AAPL"}] k)
+        (-> (mount-live! alpha [host {:sym "AAPL"}] k 1)
             (.then
               (fn [handle]
                 (let [ops-1   (deref !last-ops)
@@ -619,7 +627,7 @@
       (do (skip! ":node-test has no React DOM") (done))
       (let [k (price-key alpha "AAPL")]
         (seat! alpha {"AAPL" 191})
-        (-> (mount-live! alpha [host {:sym "AAPL"}] k)
+        (-> (mount-live! alpha [host {:sym "AAPL"}] k 1)
             (.then
               (fn [handle]
                 (react/startTransition

--- a/implementation/hicasso/test/re_frame/hicasso/native_hooks_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_hooks_dom_cljs_test.cljs
@@ -390,7 +390,9 @@
                             array rebuilds every render) — either makes this a
                             different object three times over, and nothing on
                             screen changes"
-                    (is (identical? reg-at-mount (first (readers-of k)))))
+                    (is (true? (identical? reg-at-mount (first (readers-of k))))
+                        "React holds a DIFFERENT registration, so the
+                         subscription was torn down and rebuilt"))
 
                   (testing "so nothing was released and re-acquired: one cell,
                             one membership, one boundary, one edge, one entry —
@@ -404,7 +406,9 @@
                             commit does no work"
                     (mount/dispatch! handle [::set-price "AAPL" 204])
                     (is (= "204" (text-at handle ".price")))
-                    (is (identical? reg-at-mount (first (readers-of k))))
+                    (is (true? (identical? reg-at-mount (first (readers-of k))))
+                        "React holds a DIFFERENT registration, so the
+                         subscription was torn down and rebuilt")
                     (is (= residue (inventory/residue))))
 
                   (exercised! :hooks/no-resubscribe)


### PR DESCRIPTION
Closes rf2-hic-031.

`n/use-sub` reads a subscription from a native React component; `n/use-frame`
answers the frame-locked ops bundle. Two hooks, and there is not a third —
`useState`, `useEffect`, `useRef` and `useTransition` stay React's own, reached
by direct interop. What React cannot supply is the frame, so the frame is all
these supply.

## The design, in one line

**They are doors onto the collector's existing tables, never a second copy of
them.** A native component is not a boundary — no shell ran, no body ran,
`rstate` names no frame and the scratch holds somebody else's reads — so
`n/use-sub` cannot take `sub`. It takes two new collector doors instead:

| door | what it is |
|---|---|
| `collector/hook-entry` | the read-set entry for a SINGLE key, from the same cache the shell uses |
| `collector/hook-read` | `read-key!`'s two tiers with the scratch and the ambient frame taken away |

`hook-entry` is where the hard part is paid. React re-subscribes whenever the
`subscribe` it is handed is a new function, so a hook that built its closure per
render would tear the subscription down and rebuild it after **every** re-render
— releasing and re-acquiring the cell, invisibly, because the screen stays
correct throughout. The entry cache already answers that: the same key hits the
same entry, so `subscribe` is identical and React does not call it again. The
hook therefore needs no `useMemo` and no `useRef`, and holds to the shell's own
hook budget (`useContext` + `useSyncExternalStore`).

The return on routing through the one runtime is that **nothing downstream had
to learn hooks exist**: an island's read builds a cell in the same table, takes
the same reader membership, is woken by the same commit, is counted by the same
residue census, and is named by the `re-frame.hicasso.tool` rosters Xray
consumes — which is what hic-023's acceptance asked for, witnessed rather than
asserted.

## `n/use-frame` and the incarnation rule

It answers `impl.frames`' memo row, which is keyed on the frame's
**incarnation** — so the map is reference-stable across re-renders (safe in
`useEffect` deps, safe to close over), and a same-id reincarnation retargets the
next render while a callback still holding the predecessor's bundle is refused
by core's own fence rather than silently writing whoever occupies the address
now.

A memo keyed on the frame KEYWORD passes every stability test and fails exactly
this one, because a keyword is `=` across a reincarnation. That is not
hypothetical: it is the shape `re-frame.adapter.use-frame/use-frame` ships
today. Not touched here — filed as an observation in the worker report.

## Frames are isolated contexts

Both hooks resolve through `collector/resolve-frame!` — the boundary shell's own
resolution, now `where`-taking so each hook names itself in the refusal. One
React context, no dynamic-var tier, no `:rf/default` floor. There is no
argument, option map or spelling by which a native read reaches a sibling frame.
Deliberately NOT `frame/require-current-frame!`'s chain (which the UIx adapter
hooks use): a body's dynamic extent has unwound by the time React renders the
component it returned, so the var tier can only ever answer for a *different*
render than the one asking.

## The external-store ceiling, stated rather than papered over

Per `lanes/react-compatibility-notes.md`: reads stay tear-free under
`startTransition` (witnessed, W7), and `n/use-sub`'s docstring says plainly that
a commit observed through the hook is a **blocking** update, that
`startTransition` around a dispatch does not make it otherwise, and that this is
not the door to a promise-driven resource. No transition-aware claim is made
anywhere.

## Relation to the collector's recorded `use-subs` judgement

The 2026-07-31 ruling — grouped `use-subs` sits below the usability bar, `sub`
is the surface engineered for — is a ruling about a *grouped* read surface
competing with an *ambient* one inside a `defview` body. `n/use-sub` is neither
and does not reopen it. Past the fence there is no body and no ambient extent
(React renders a component after its parent body has returned), so there is no
ambient collector available to compete with, and React's rules of hooks force
one hook call per read. `n/use-sub` is the single-key hook that reasoning
implies. The one visible consequence — `n` reads in one island are `n`
subscriptions where a body's `n` `h/sub` reads are one entry — is React's
arithmetic, and the docstring states it rather than hiding it.

## Files outside the stated fence

`implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs`, held by
nobody at dispatch time and untouched by anything merged to `main` since. The
change is additive apart from two mechanical generalisations, one call site
each: `scratch-bucket-key` → `bucket-key-of ks`, `entry-matches?` and
`entry-for` take the key array instead of reading the module scratch. No spec,
`deps.edn`, `shadow-cljs.edn` or workflow file is touched, and no complaint id
is added or changed (`:rf.error/no-frame-context` is already live and already
taught for both hooks in guide chapter 10).

## Witnesses

`native_hooks_cljs_test` (lane-independent, server renderer as the instrument —
the only harness in which *what a render retains* reads as a flat zero, because
nothing commits):

- the cold tier answers on a render that never commits, and retains no cell, no
  membership, no boundary and no edge — with `:entries` named explicitly as a
  cache the reaper owns rather than folded into the zero;
- both hooks refuse outside every frame, and each names ITSELF in `:where`;
- `use-frame` answers the runtime's own row **by identity**, which equality
  would not have caught.

`native_hooks_dom_cljs_test` (browser lane; stated skips in `:node-test`), seven
rows, each written against a named narrowing:

| row | narrowing it catches |
|---|---|
| the read is the runtime's own, and Xray sees it | `subscribe-once` per render — right value, no cell, invisible to the projection |
| a write wakes its readers and nobody else | subscribing to the generation: repaints every island on every write |
| a re-render that changed no read performs no re-subscribe | any per-render `subscribe` closure; the screen stays correct throughout |
| StrictMode's double mount acquires once, unmount releases exactly | acquiring during render (2 readers), or a cleanup that releases a successor's cells |
| two frames are two cells | any frame resolution that is not the island's own context |
| `use-frame` is stable and retargets across a reincarnation | memoising on the frame keyword |
| a transition stays tear-free and is still blocking | a docstring that claimed transition-awareness |

plus a roster row that reds if any mechanism stops being driven.

### Sabotage control

`hook-entry`'s body changed from `(entry-for #js [sub-key])` to
`(doto (entry-for #js [sub-key]) (drop-entry!))` — the entry is still correct
and still works, it is merely evicted from the cache, so the next render mints a
fresh one with a fresh `subscribe`. Identity only; correctness untouched. Full
browser gate went **6 failures, 2 errors** (from 0/0), verbatim:

```
FAIL in (an-islands-read-is-the-runtimes-own-and-xray-sees-it) ... :275:23
expected: (= 2 (:entries (inventory/residue)))
  actual: (not (= 2 1))

FAIL in (an-islands-read-is-the-runtimes-own-and-xray-sees-it) ... :295:25
the projection names no read of ::price
expected: (some? row)
  actual: (not (some? nil))

FAIL ... :302:25
expected: (= 1 (:read-orders row))
  actual: (not (= 1 nil))

ERROR in (a-re-render-that-changed-no-read-performs-no-re-subscribe) ... :393:25
expected: (identical? reg-at-mount (first (readers-of k)))
  actual: #object[RangeError RangeError: Maximum call stack size exceeded]
```

Restored byte-identically (`git checkout --`), and the gate is green again on
the restored tree.

The `RangeError` is itself a finding and is fixed in this PR: a registration
holds its cells and a cell holds its readers, so the graph is cyclic and
`cljs.test`'s printing of a failed `identical?` overflows the stack — a hard red
that says nothing. Those two rows now assert the boolean, so a real regression
prints `(not (true? false))` with a message naming the failure.

## Quality gates

| gate | exit | notes |
|---|---|---|
| `scripts/test-fast-pr.sh` | 0 | the spine |
| `npm run test:browser` (headless Chromium) | 0 | 1238 tests / 7646 assertions, 0 failures — re-run AFTER the rebase onto current `main`. The lane the mounted witnesses ride, and NOT in the spine |
| `npm run test:cljs` | 0 | inside the spine's node tier |
| `node-test-hicasso` focused build + run | 0 | 489 tests / 2255 assertions |
| `npm run test:hicasso-invariants` | 0 | freeze, optional-module reachability, complaint catalogue (each with `--self-test`) |
| `npm run test:hicasso-lint` | 0 | |
| `python scripts/check_fast_pr_gap.py --list` | — | derived; the gap this PR reaches is `cljs-browser`, run above |

Not run, with reasons:

- `npm run test:browser-prod-elision` / `test:browser-schemas-boundary-prod` /
  `build:hicasso-release` — `:advanced` + `goog.DEBUG=false` lanes. Nothing here
  adds a debug-gated path or a source-coord emission; CI owns them.
- `test:hicasso-controlled`, `test:hicasso-hmr` — Chromium/Firefox/WebKit
  testbed lanes for the controlled-input and HMR contracts, neither of which
  this diff reaches.
- `mkdocs build --strict` — no file under `docs/` is touched.
- JVM artefact suites beyond what the spine selects from the changed paths.
