### PR TITLE
docs(hicasso): correct chapter 10 to the shipped HMR contract (rf2-hic-092)

### DIFF
--- a/docs/design/hicasso/draft-guide/10-native-tier.md
+++ b/docs/design/hicasso/draft-guide/10-native-tier.md
@@ -85,7 +85,7 @@ The whole fence fits in one table. The left column is why rung 3 is cheap to ado
 |---|---|
 | The frame — and [`h/sub`](glossary.md#hsub) anywhere in the body | Hiccup interpretation — a vector is not markup here |
 | The props ABI, value-equality memo, and the parent's `:key` | Intent lowering — an event vector in a prop is an error |
-| Lifecycle, HMR identity, and the view's name in Xray | Controlled repair — no [`::h/value`](glossary.md#hvalue), [`::h/checked`](glossary.md#hchecked), [`::h/prevent`](glossary.md#hprevent), [`::h/revision`](glossary.md#hrevision) |
+| Lifecycle, HMR conduct, and the view's name in Xray | Controlled repair — no [`::h/value`](glossary.md#hvalue), [`::h/checked`](glossary.md#hchecked), [`::h/prevent`](glossary.md#hprevent), [`::h/revision`](glossary.md#hrevision) |
 | Server rendering — intrinsic-headed output produces the same deterministic bytes | Structural assertions and key diagnostics — the element is opaque to the pure test tiers, which refuse with a pointer to the mounted tier ([Testing](14-testing.md)) |
 
 Two consequences deserve their own sentences. First, form fields stay interpreted. An `<input>` inside [`n/$`](glossary.md#n-dollar) is a raw React [controlled input](glossary.md#controlled-field): you do all of React's manual controlled-input work, and you get none of [Hicasso](glossary.md#hicasso)'s caret, IME, or same-turn guarantees ([Controlled inputs](04-controlled-inputs.md)). Second, hooks still do not belong in the body. A [`defview`](glossary.md#defview) body is dynamically composed — branches and loops are legal, and that is exactly the environment where hook order breaks. The wish for a hook in a `defview` body is the signal that you are at rung 4, not rung 3.
@@ -197,13 +197,13 @@ From native code, a component is a head as-is: `(n/$ col-resizer {:col :px})`. B
 
 ## Keeping the marker: the ABI helpers
 
-[`n/defcomponent`](glossary.md#ndefcomponent) stamps its component with stable identity, source and display metadata, and HMR conduct — the marker. The marker lets Xray name the [boundary](glossary.md#boundary), lets hot reload replace the implementation without remounting the island, and lets the embedding seams recognize the head. Raw React wrappers erase it:
+[`n/defcomponent`](glossary.md#ndefcomponent) stamps its component with a display name and a tier marker carrying that name and the declared server policy. The marker lets Xray name the [boundary](glossary.md#boundary), and it is the seam every ABI helper and every embedding direction reads to recognize a native head. What it does not do is carry the component across a hot reload, and it is not meant to. Minting a component is allocation, never a lookup by name: a save re-evaluates the module, the component is allocated afresh, the element type at that position is a new object, and React replaces the subtree. **A clean remount across a save is the designed conduct, not a fault** — a component's name is an address, not an identity, exactly as [`defview`](glossary.md#defview)'s is. Raw React wrappers erase the marker:
 
 ```clojure
 ;; given (n/defcomponent quote-cell* …) — a pure display cell worth memoizing:
 
 ;; Don't: works at runtime, but the marker is gone — Xray shows an anonymous
-;; boundary and HMR now remounts the island on every edit.
+;; boundary, and the embedding seams no longer recognize the head.
 (def quote-cell (react/memo quote-cell*))
 
 ;; Do: same React.memo semantics, marker intact.
@@ -240,5 +240,6 @@ Xray stays honest on both sides of the fence. It names and times the native [bou
 | Refusal: `:children` in the props map | There is one child channel — trailing forms | Pass children after the props operand |
 | Refusal: two keys normalize to one slot (`:class` and `"className"`) | Canonical-slot collision — the grammar refuses rather than letting map order pick a winner | Keep one spelling per slot |
 | `:rf.error/no-frame-context` from [`n/use-sub`](glossary.md#nuse-sub) or [`n/use-frame`](glossary.md#nuseframe) | The island rendered outside any frame provider — a separate root, a [portal](glossary.md#portal) outside the app, or a test without the harness | Mount under the app root, or use the [test kit](glossary.md#test-kit)'s provider ([Testing](14-testing.md)) |
-| Xray shows an anonymous [boundary](glossary.md#boundary); HMR remounts the island | The component marker was erased by a raw wrapper (`react/memo`, `React.lazy`) | Use [`n/memo`](glossary.md#nmemo) / [`n/lazy`](glossary.md#nlazy) — same semantics, marker intact |
+| Xray shows an anonymous [boundary](glossary.md#boundary) where a named island should be | The component marker was erased by a raw wrapper (`react/memo`, `React.lazy`) — the display name and the declared server policy went with it | Use [`n/memo`](glossary.md#nmemo) / [`n/lazy`](glossary.md#nlazy) — same semantics, marker intact |
+| Local state inside an island resets whenever you save | Nothing is wrong. A reload allocates a fresh component, so the element type changes and React remounts the subtree — the designed HMR conduct, and [`defview`](glossary.md#defview)'s too | Nothing to fix. State that must outlive a save belongs in `app-db`, read back through [`n/use-sub`](glossary.md#nuse-sub) |
 | Went native, numbers did not move | The cost owner was never construction — usually reads or event volume | Back to loop step 2; expect the fix at rung 2, and take the unearned escape out |


### PR DESCRIPTION
Corrects `docs/design/hicasso/draft-guide/10-native-tier.md`, which taught the
inverse of the shipped native-tier HMR contract. Scope is deliberately narrow:
the chapter-10 HMR correction from MERGED-PR AUDIT #7839 only. Documentation
only — no runtime change, no new checker.

## The contract, from the source

`implementation/hicasso/src/re_frame/hicasso/native.cljc` (read, never edited —
another worker holds it) states the contract in its own words.

`component`, lines ~281-287:

> **Allocation, never a lookup by name**, and that is the HMR contract
> (rf2-hic-015) rather than an implementation detail. A reload re-evaluates the
> module, this runs again, and the element type at that position is a NEW object
> — so React replaces the subtree outright and the default expectation across a
> save is a clean remount. A component's name is an address, not an identity,
> exactly as `defview`'s is [...] Caching by name here would preserve identity
> across a reload and quietly contradict the recorded contract.

`defcomponent`, lines ~452-455:

> **HMR conduct is `defview`'s, unchanged** (rf2-hic-015): a reload re-evaluates
> the module, `component` allocates a fresh function, the element type at that
> position changes, and React replaces the subtree. A clean remount is the
> default expectation across a save, never preservation.

`marker`, lines ~294-297, names the marker's actual job:

> The seam every ABI helper and every embedding direction reads to recognise a
> native head — and the reason a raw `react/memo` wrapper loses it.

So an ordinary unwrapped `n/defcomponent` cleanly remounts after a save, by
design, and the marker does no HMR work at all.

## What changed

**1. Line 200 — the marker's job.**

Was:

> `n/defcomponent` stamps its component with stable identity, source and display
> metadata, and HMR conduct — the marker. The marker lets Xray name the
> boundary, **lets hot reload replace the implementation without remounting the
> island**, and lets the embedding seams recognize the head.

Now:

> `n/defcomponent` stamps its component with a display name and a tier marker
> carrying that name and the declared server policy. The marker lets Xray name
> the boundary, and it is the seam every ABI helper and every embedding
> direction reads to recognize a native head. What it does not do is carry the
> component across a hot reload, and it is not meant to. Minting a component is
> allocation, never a lookup by name: a save re-evaluates the module, the
> component is allocated afresh, the element type at that position is a new
> object, and React replaces the subtree. **A clean remount across a save is the
> designed conduct, not a fault** — a component's name is an address, not an
> identity, exactly as `defview`'s is.

Note the old sentence also claimed the marker carries "stable identity", which
`native.cljc` contradicts directly ("a component's name is an address, not an
identity"). The replacement names only what `component` actually stamps:
`displayName`, and a marker object holding `{:name :server}`. The source
coordinate is captured for declaration-time refusals, not stamped on the
function, so the old "source [...] metadata" claim is dropped rather than
restated.

**2. Line 206 — the "Don't" code comment.** The `react/memo` example claimed the
consequence was that "HMR now remounts the island on every edit". That remount
happens either way. Now the comment names the real losses: the anonymous Xray
boundary, and the embedding seams no longer recognizing the head.

**3. Line 243 — the troubleshooting row, rewritten not deleted.** The old row
paired a genuine symptom with a healthy one:

> | Xray shows an anonymous boundary; HMR remounts the island | The component
> marker was erased by a raw wrapper | Use `n/memo` / `n/lazy` |

An anonymous boundary in Xray is a real symptom of an erased marker, so the row
keeps that half and drops the healthy half, gaining a note that the display name
and declared server policy went with the marker.

**4. Line 244 — one new row, replacing what the old row was fielding.** The old
row's worst property was that it sent a programmer hunting for an erased marker
when nothing was wrong. Deleting it silently would leave that reader with
nowhere to land, so a row now answers them honestly: local state resetting on
save is the designed conduct, and state that must outlive a save belongs in
`app-db`. This is the one addition beyond a strict revert of the false claims,
and it is a correction of the same defect rather than new guidance.

**5. Line 88 — one word in the rung-3 fence table.** "Lifecycle, HMR *identity*,
and the view's name in Xray" → "HMR *conduct*". This is the chapter's last echo
of the inversion, and leaving it one screen above the corrected line 200 (which
now says a name is an address, not an identity) would read as a contradiction.
Flagged explicitly because it is the one change outside the two the audit named.

`n/memo` / `n/lazy` guidance is untouched — those helpers are real and the
chapter still recommends them. Only the *reason* attributed to the marker moved;
line 213's ABI rationale for the helpers was already correct.

## Audit #7788's three defects are already repaired on main

Confirmed independently before touching anything; no action taken on any:

1. `01-getting-started.md:55-56` already reads "an `h/defview` in head position
   mints a boundary, and a plain `defn` helper call inlines into the boundary
   already rendering".
2. `17-ssr-and-hydration.md:24-26` already states the honest three outcomes:
   "three outcomes in the server bytes — the rendered markup, a fallback, or
   nothing".
3. Chapter 01 has no `## Next` footer; its headings are `## What Hicasso is` and
   `## When not to use Hicasso`.

## Out of fence — reported, not touched

The same inversion propagated beyond chapter 10. My fence was
`10-native-tier.md`, and these are corrections rather than trivially additive
edits, so they are left for a follow-up:

- `20-code-splitting.md:99` — "It keeps the component marker, so Xray still names
  the boundary, **and HMR still replaces the implementation without remounting
  it**." Same false claim, about `n/lazy`.
- `20-code-splitting.md:192` — troubleshooting row `| Xray shows an anonymous
  boundary; HMR remounts the island | Raw React.lazy erased the component marker
  | ... |`. The same healthy-symptom row as the one fixed here.
- `glossary.md:428-429` — "Raw `react/memo` / `React.lazy` erase identity
  metadata that Xray **and HMR** need." HMR needs no marker.

`installation.md:191-199` was checked and is **correct** — its "hot reload
preserves state past your setup event" is about the root, frame and app-db
surviving a reload, which is true and is exactly what the new troubleshooting
row points at.

## Table column counts (hand-verified)

Nothing validates tables in `docs/design/**`, so both touched tables were counted
by hand and then cross-checked mechanically.

- Troubleshooting table, lines 235-245: header `| Symptom | What is happening |
  Fix |` is 3 columns; separator `|---|---|---|` is 3; all 9 body rows including
  the rewritten row 243 and the new row 244 are 3 cells. No literal `|` occurs
  inside any cell (no pipes in the code spans or link text).
- Rung-3 fence table, lines 84-89: 2 columns throughout; the line-88 edit changes
  text inside cell 1 only and adds no delimiter.

## Quality gates

| Gate | Exit | Notes |
|---|---|---|
| `python scripts/check_doc_slugs.py` (the bead's named gate) | **0** | Silent on success — coverage proven below |
| `scripts/check_doc_slugs.py` with a planted bogus anchor | **1** | Proof of coverage |
| `sh scripts/test-fast-pr.sh` | **0** | Full fast-PR spine, invoked from the worktree root; exit read from the `.exit` file, not the harness |

**Coverage proof for the silent gate.** `check_doc_slugs.py` prints nothing and
exits 0 on success, so a clean run alone proves nothing. Planted
`glossary.md#nuse-sub-bogus-hic092` in the new troubleshooting row; the checker
exited **1** and named the exact line:

```
1 broken anchor link(s) found:

  BROKEN ANCHOR: docs\design\hicasso\draft-guide\10-native-tier.md:244 -> glossary.md#nuse-sub-bogus-hic092
      (target: docs\design\hicasso\draft-guide\glossary.md)
```

Restored byte-identically — `sha256` before planting and after restoring both
`9fddaf70a46a2d9eb349dcc06eb2b4b0d2b4aee2556252833afdd3c9e41e5201` — and re-ran
to exit 0. The checker was re-run after every edit, not only at the end, because
this chapter is dense with `glossary.md#...` anchors.

**Gates deliberately not run.**

- `mkdocs build --strict` — **does not cover `docs/design/**`**. `mkdocs.yml`'s
  `exclude_docs` keeps `design/hicasso/` out of the built site, so it cannot
  decide this edit. It ran anyway as part of the fast-PR spine, and its own log
  confirms the exclusion (`... contains a link to
  'design/freehand/decisions/...' which is excluded from the built site`).
- Every CLJS/JVM suite — no code changed. Only one markdown file under
  `docs/design/` is touched.
- CI gap derived with `python scripts/check_fast_pr_gap.py --list`: 96 required
  checks the spine does not decide. All are surface-gated on a diff that this
  one-file docs change does not reach.

Bead `rf2-hic-092` left open for the mayor to close; no `bd` state was mutated.
