### PR TITLE
docs(hicasso): finish the HMR-inversion correction, and fix one reserved-note's condition (rf2-dly1, rf2-j4qz)

### DIFF
--- a/docs/design/hicasso/draft-guide/20-code-splitting.md
+++ b/docs/design/hicasso/draft-guide/20-code-splitting.md
@@ -96,7 +96,11 @@ on the [native tier](glossary.md#native-tier) and you want React to own the pend
 [`n/lazy`](glossary.md#nlazy), the ABI helper from [the native tier](10-native-tier.md). It has
 the same thunk-returning-a-promise contract as `React.lazy`, and it resolves
 to the component. It keeps the component marker, so Xray still names the
-[boundary](glossary.md#boundary), and HMR still replaces the implementation without remounting it.
+[boundary](glossary.md#boundary) and the embedding seams still recognize the head. What it does
+not do is carry the component across a hot reload, and it is not meant to:
+minting a component is allocation, never a lookup by name, so a save
+re-evaluates the module, allocates a fresh component, and React replaces the
+subtree. A clean remount across a save is the designed conduct, not a fault.
 
 ```clojure
 (ns app.charts.gate
@@ -189,7 +193,8 @@ law holds through both, because commit owns acquisition
 | Works in `watch`, 404s in a release build | Module config drift — a missing `:depends-on`, or the entry namespace not in the module | Declare the dependency edge; keep one entries list per module |
 | The Suspense fallback flashes on every render of the parent | The lazy component was minted inside a body — fresh identity, fresh mount, fresh load | Declare [`n/lazy`](glossary.md#nlazy) (and the loadable) at top level |
 | A failed chunk load leaves the skeleton up forever | Nothing catches the loader's rejection | Wrap the Suspense host in [`h/error-boundary`](glossary.md#error-boundary); retry through `:reset-key` |
-| Xray shows an anonymous [boundary](glossary.md#boundary); HMR remounts the island | Raw `React.lazy` erased the component marker | Use [`n/lazy`](glossary.md#nlazy) — same semantics, marker intact ([Native tier](10-native-tier.md)) |
+| Xray shows an anonymous [boundary](glossary.md#boundary) where a named island should be | Raw `React.lazy` erased the component marker — the display name and the declared server policy went with it | Use [`n/lazy`](glossary.md#nlazy) — same semantics, marker intact ([Native tier](10-native-tier.md)) |
+| Local state inside a lazily loaded island resets whenever you save | Nothing is wrong. A reload allocates a fresh component, so the element type changes and React remounts the subtree — the designed HMR conduct, and [`defview`](glossary.md#defview)'s too | Nothing to fix. State that must outlive a save belongs in `app-db`, read back through [`n/use-sub`](glossary.md#nuse-sub) |
 | The lazy region is missing from server HTML | Client-only by design — the server carries the fallback, never the un-arrived component | Make the fallback a same-footprint skeleton; the live component mounts after adoption |
 | A hidden pane's state is gone on reveal | The pane was unmounted, not hidden — a `when`, not an Activity `:mode` flip | Hide with `:mode "hidden"` to retain UI state; unmount when you mean gone. App-db state at addresses survives either way |
 

--- a/docs/design/hicasso/draft-guide/glossary.md
+++ b/docs/design/hicasso/draft-guide/glossary.md
@@ -394,7 +394,7 @@ Related: [Native tier](10-native-tier.md#the-n-grammar).
 ### **n/defcomponent**
 
 Defines a stable top-level native function component: display name, source,
-HMR, and one props/children ABI. Default self-contained route for a
+HMR conduct, and one props/children ABI. Default self-contained route for a
 [named native island](#native-island). Ordinary React hooks are legal inside;
 frame access via [`n/use-sub`](#nuse-sub) / [`n/use-frame`](#nuseframe).
 
@@ -425,8 +425,9 @@ Related: [Native tier](10-native-tier.md#rung-4--a-named-native-island).
 ### **n/memo** / **n/lazy**
 
 Marker-preserving memoization and `React.lazy` loading for native components.
-Raw `react/memo` / `React.lazy` erase identity metadata that Xray and HMR
-need.
+Raw `react/memo` / `React.lazy` erase the tier marker that Xray and the
+embedding seams read. Hot reload is unaffected either way — a save allocates a
+fresh component, and a clean remount is the designed conduct.
 
 Related: [Native tier](10-native-tier.md#keeping-the-marker-the-abi-helpers),
 [Code splitting](20-code-splitting.md).

--- a/docs/design/hicasso/product/complaints.md
+++ b/docs/design/hicasso/product/complaints.md
@@ -177,7 +177,7 @@ into the live table in the same PR.
 |---|---|---|
 | `:rf.error/hicasso-view-called-directly` | a `defview` invoked as a function instead of mounted as a hiccup head | `defview` expansion. `re-frame.hicasso/direct-view-call` catches the static case today; this is the runtime half. Freehand's `:rf.error/view-called-directly` belongs to that substrate and is not shared |
 | `:rf.error/hicasso-test-hook-is-opaque` | a React hook reached from a body run at L2, where no React is running | the test kit's opacity family |
-| `:rf.error/hicasso-test-native-is-opaque` | a native-tier element reaching the L2 semantic tree | the test kit's opacity family, once the native tier lands |
+| `:rf.error/hicasso-test-native-is-opaque` | a native-tier element reaching the L2 semantic tree | the test kit's opacity family, once its L2 refusal covers native-tier elements as it already covers host and raw-React ones. The native tier landing does **not** promote this row — the emitter is the test kit's to write |
 | `:rf.error/hicasso-contenteditable-not-controllable` | a controlled `:value` binding on a contenteditable region | the controlled-input law |
 | `:rf.error/hicasso-route-link-bad-prefetch` | a route link's `:prefetch` carrying a value the link does not accept | the route-link door, once `:prefetch` is accepted rather than declined. **Not** `:rf.error/hicasso-route-link-prefetch-declined`, which is live today and retires under *Retiring later* below |
 | `:rf.error/hicasso-overlay-anchor-missing` | an overlay declaring an anchor that resolves to no element | the overlay module. **Spelling provisional** — [`naming-ledger.md`](naming-ledger.md) row 30 holds it for the naming packet; this row catalogues whatever that settles on |


### PR DESCRIPTION
Two bounded doc corrections on disjoint surfaces, one commit each.

- **rf2-dly1** (bug) — the HMR inversion PR #7856 fixed in chapter 10 survived in
  `20-code-splitting.md` and `glossary.md`.
- **rf2-j4qz** — one reserved row's note named a condition that has been met but
  was never the governing one.

## rf2-dly1 — the contract, read from the source

`implementation/hicasso/src/re_frame/hicasso/native.cljc` was read, never edited
(another worker holds that tree). `component`, lines 302-308:

> **Allocation, never a lookup by name**, and that is the HMR contract
> (rf2-hic-015) rather than an implementation detail. A reload re-evaluates the
> module, this runs again, and the element type at that position is a NEW object
> — so React replaces the subtree outright and the default expectation across a
> save is a clean remount. A component's name is an address, not an identity.

`defcomponent`, lines 623-627:

> **HMR conduct is `defview`'s, unchanged** (rf2-hic-015): a reload re-evaluates
> the module, `component` allocates a fresh function, the element type at that
> position changes, and React replaces the subtree. A clean remount is the
> default expectation across a save, never preservation.

`marker`, lines 315-318, names the marker's actual job: "The seam every ABI
helper and every embedding direction reads to recognise a native head — and the
reason a raw `react/memo` wrapper loses it." So the marker does no HMR work at
all, and a clean remount across a save is designed conduct.

**This is independently machine-verified.** `implementation/hicasso/testbed/hmr_spec.cjs`
(the `cljs-hicasso-hmr` CI job, "HMR contract through a real shadow reload")
asserts at lines 359-361 exactly what the guide now teaches: *"the save cleared
the child hook state"*, and *"it is a different fiber — the state was not reset,
the component was rebuilt"*. The prose was checked against that, not only
against the docstrings.

### Site 1 — `20-code-splitting.md:99`, `n/lazy` prose

Was:

> It keeps the component marker, so Xray still names the
> [boundary](glossary.md#boundary), **and HMR still replaces the implementation
> without remounting it.**

Now:

> It keeps the component marker, so Xray still names the
> [boundary](glossary.md#boundary) and the embedding seams still recognize the
> head. What it does not do is carry the component across a hot reload, and it
> is not meant to: minting a component is allocation, never a lookup by name, so
> a save re-evaluates the module, allocates a fresh component, and React
> replaces the subtree. **A clean remount across a save is the designed conduct,
> not a fault.**

The true half of the sentence is kept (the marker really does keep Xray naming
the boundary), and the correction reuses chapter 10's own words — "What it does
not do is carry the component across a hot reload, and it is not meant to",
"allocation, never a lookup by name", "a clean remount across a save is the
designed conduct, not a fault" — so the two chapters say one thing. Chapter 10
owns the contract and is already linked three lines above, so no second link was
added.

### Site 2 — `20-code-splitting.md:192`, the troubleshooting row

Chapter 10's repair is the model, and it is followed rather than the row being
deleted. Was one row:

> `| Xray shows an anonymous boundary; HMR remounts the island | Raw React.lazy erased the component marker | Use n/lazy — same semantics, marker intact |`

Now two. The genuine half is kept and sharpened (an anonymous Xray boundary
really is an erased-marker symptom), the healthy half dropped:

> `| Xray shows an anonymous boundary where a named island should be | Raw React.lazy erased the component marker — the display name and the declared server policy went with it | Use n/lazy — same semantics, marker intact (Native tier) |`

and a new row fields the reader the old row was mis-serving — deleting silently
would leave them nowhere, which was the old row's worst property:

> `| Local state inside a lazily loaded island resets whenever you save | Nothing is wrong. A reload allocates a fresh component, so the element type changes and React remounts the subtree — the designed HMR conduct, and defview's too | Nothing to fix. State that must outlive a save belongs in app-db, read back through n/use-sub |`

The table header here is `| Symptom | What went wrong | Fix |` (chapter 10's is
"What is happening"). The header was left alone rather than churned across eight
untouched rows; "Nothing is wrong." reads as a direct answer to "what went
wrong", which is the point of the row.

### Site 3 — `glossary.md:428`, `n/memo` / `n/lazy`

Was:

> Raw `react/memo` / `React.lazy` erase **identity metadata that Xray and HMR
> need.**

Now:

> Raw `react/memo` / `React.lazy` erase **the tier marker that Xray and the
> embedding seams read. Hot reload is unaffected either way — a save allocates a
> fresh component, and a clean remount is the designed conduct.**

Two defects in one sentence: HMR needs no marker, and "identity metadata" is the
framing `native.cljc` denies outright ("a component's name is an address, not an
identity"). The positive statement is kept short but is kept, for the same
reason chapter 10 added a row rather than deleting one.

### Site 4 — `glossary.md:397`, flagged explicitly

The `n/defcomponent` entry listed bare "HMR" among what the macro defines:
"display name, source, HMR, and one props/children ABI" → "display name, source,
**HMR conduct**, and one props/children ABI".

This is the same class of change, and the same one word, as PR #7856's own
out-of-scope fix at `10-native-tier.md:88` ("Lifecycle, HMR *identity*" → "HMR
*conduct*"), made for the same reason: leaving a bare "HMR" in a feature list one
screen from an entry that now says hot reload needs no marker reads as a
contradiction. Flagged because it is beyond the three sites the bead enumerated.
"source" is left alone — it is accurate about the *macro*, which captures the
source coordinate for declaration-time refusals (rf2-hic-007), even though
PR #7856 correctly dropped it from a sentence about what the *marker* stamps.

### Does the claim appear anywhere else? Swept — no.

`git grep` over `docs/design/hicasso/draft-guide/` for `HMR`, `hot reload`,
`hot-reload`, `remount`, `without remounting`, `HMR need`, `HMR still`,
`hot reload replace`, `HMR identity`, `identity metadata` and `preserv` returns,
outside chapter 10, only the four sites above plus two that were read and judged
**correct**:

- `20-code-splitting.md:87` — "Hot reload is undisturbed — a loaded module's
  namespaces reload like any others, and an unloaded module has nothing to
  reload." This is about module-splitting mechanics, not component identity, and
  is true. Untouched.
- `installation.md:191-199` — "hot reload preserves state *past your setup
  event*" is about the root, frame and app-db surviving a reload. True, out of
  fence, and independently confirmed correct by PR #7856. Untouched.

## rf2-j4qz — verified, then a note-only edit

**The row is still reserved and still emitted nowhere. Verified before editing,
not assumed:** `:rf.error/hicasso-test-native-is-opaque` returns zero hits across
`spec/`, `implementation/hicasso/src/` and `implementation/hicasso/test_kit/`
(the only hit anywhere in the repo is the bead's own row in `.beads/issues.jsonl`).
`check_complaint_catalogue.py` agrees: "65 live, 6 reserved … every reservation
is unbuilt". So R3 is satisfied by the row remaining reserved, and this is a note
fix, not a promotion — CHECK C never came into play, because there is no emit
site to read. **Status, id, the "Will refuse" cell and every other row are
unchanged, and no diagnostic was added to satisfy the note.**

Owner cell was:

> the test kit's opacity family, **once the native tier lands**

Now:

> the test kit's opacity family, **once its L2 refusal covers native-tier
> elements as it already covers host and raw-React ones. The native tier landing
> does not promote this row — the emitter is the test kit's to write**

The replacement is grounded in the code rather than restated from the table: the
family's two live siblings, `:rf.error/hicasso-test-host-is-opaque` and
`:rf.error/hicasso-test-react-is-opaque`, are raised through `refuse-opaque!` in
`implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs` (lines 973,
983, 1039). The native arm is simply the one not yet written — that is the
condition that actually governs. The second sentence records why the neighbouring
condition does not promote the row, which is the exact trap that produced this
bead.

## Table column counts (hand-verified)

Nothing validates tables under `docs/design/**`, and two of the four edited sites
are table rows, so both tables were counted by hand against their headers.

- **`20-code-splitting.md` troubleshooting table, lines 189-199.** Header
  `| Symptom | What went wrong | Fix |` is 3 columns; separator `|---|---|---|`
  is 3. All 9 body rows — including the rewritten row and the added row — are 3
  cells. Mechanically cross-checked: every one of the 11 lines carries exactly 4
  pipe characters, so no cell contains a literal `|` and no row is short or long.
- **`complaints.md` Reserved spellings table, lines 176-183.** Header
  `| Reserved | Will refuse | Owner |` is 3 columns; separator is 3; all 6 body
  rows are 3 cells. Same mechanical cross-check: exactly 4 pipes on every one of
  the 8 lines. The edited cell adds no delimiter and contains no `|`.

## Quality gates

| Gate | Exit | Notes |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | **0** | Full fast-PR spine, invoked from the worktree root; exit read from the `.exit` file, never from a pipeline |
| `python scripts/check_doc_slugs.py` | **0** | The bead's named gate. Silent on success — coverage proven below |
| `check_doc_slugs.py` with a planted bogus anchor | **1** | Proof of coverage |
| `python implementation/hicasso/scripts/check_complaint_catalogue.py --self-test` | **0** | `OK: check_complaint_catalogue self-test passed` |
| `python implementation/hicasso/scripts/check_complaint_catalogue.py` | **0** | `65 live, 6 reserved, 1 pending retirement, 1 retired; … every reservation is unbuilt, every anchor resolves` |
| `python scripts/check_keyword_catalogue_drift.py` | **0** | Keyword-drift check, clean |
| `python scripts/check_fast_pr_gap.py --list` | **0** | Gap derived, not guessed — see below |

The spine also re-ran the two catalogue gates inside its own lanes: `docs corpus
anchor self-test` + `docs corpus anchor validator`, `keyword-catalogue drift`
(self-test + live), and the `hicasso invariants gate`, whose npm script carries
the complaint-catalogue round trip.

**Coverage proof for the silent gate.** `check_doc_slugs.py` prints nothing and
exits 0 on success, so a clean run alone proves nothing. Planted
`glossary.md#nuse-sub-bogus-dly1` in the *new* troubleshooting row; the checker
exited **1** and named the exact line:

```
1 broken anchor link(s) found:

  BROKEN ANCHOR: docs\design\hicasso\draft-guide\20-code-splitting.md:197 -> glossary.md#nuse-sub-bogus-dly1
      (target: docs\design\hicasso\draft-guide\glossary.md)
```

Restored **byte-identically** and verified by hash rather than by eye:
`sha256` of `20-code-splitting.md` is
`8170c680f64226b032f658469b8246d7fe1309fa67f8cc437f381e21bcf1bfd5` both before
planting and after restoring, with `git status` clean. (Worth recording: `sed -i`
rewrote the working copy from CRLF to LF, so the first restore attempt matched on
content — `git diff` empty — but *not* on bytes. `git checkout --` was used to
put the exact checked-out bytes back, and the hash is what caught it.)

**Gates deliberately not run.**

- **`mkdocs build --strict` is not nominated as the gate for this change.**
  `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the built site, so
  it cannot decide any of these four sites. It ran anyway inside the spine and
  passed; its own log confirms the exclusion (`… contains a link to
  'design/freehand/decisions/…' which is excluded from the built site`).
- **Every CLJS/JVM suite** — no code changed. The diff is three markdown files
  under `docs/design/`.
- **CI gap, derived with `python scripts/check_fast_pr_gap.py --list`**: 96
  required checks the spine does not decide. All are surface-gated on a diff this
  docs-only change does not reach. Named explicitly because it is the closest
  relevant one: `cljs-hicasso-hmr` ("HMR contract through a real shadow reload")
  is gated on `implementation/hicasso/**`, which this PR does not touch — the
  runtime contract is unchanged and only its description moved.

Both beads are left **open** for the mayor to close; no `bd` state was mutated
and `.beads` was never staged.
