### PR TITLE
feat(hicasso): a virtual clock for the mounted test kit (rf2-r7zq)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_clock_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_clock_dom_cljs_test.cljs
@@ -186,8 +186,8 @@
                   and a quarter-second have passed for the code under test and
                   no measurable time has passed for the machine"
           (is (= (+ t0 60250) (js/Date.now)))
-          (is (< 60000 (- (js/Date.now) (.getTime (js/Date.))))
-              "over a minute of virtual time, none of it real"))
+          (is (< 30000 (- (js/Date.now) (.getTime (js/Date.))))
+              "the virtual instant has run away from the machine's own clock"))
 
         (-> (hm/unmount! m) (hm/assert-clean!) (.then (fn [_] (done))))))))
 

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_clock_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_clock_dom_cljs_test.cljs
@@ -1,0 +1,236 @@
+(ns re-frame.hicasso.test-kit-clock-dom-cljs-test
+  "THE MOUNTED FACADE'S CLOCK, WITNESSED (rf2-r7zq).
+
+  `hm/advance-clock!` is an instrument for driving TIME, and the thing an
+  instrument like that fails at is the thing it is easiest to write a
+  green row for. A test that advances the clock and then asserts
+  something that would have been true anyway proves nothing whatever; so
+  does one whose subject leaves the page because a re-render dropped it
+  rather than because a deadline passed.
+
+  Every row here is therefore built around a condition that is FALSE
+  before the advance and TRUE after it, with the advance as the only
+  thing in between.
+
+  ## The subject: presence, because it is the reason the door exists
+
+  `h/presence` retains a dismissed child for `:timeout-ms` and drops it
+  when the deadline passes. It is the shipped feature whose next step is
+  a `setTimeout`, and it is what `rf2-5gka` — Story's presence bridge —
+  is blocked on. Two facts about it decide the shape of the whole
+  control, and both are asserted below rather than assumed:
+
+  - the retirement is a `setTimeout` the React half arms
+    (`impl.presence-react`), so the timer has to be virtual;
+  - the callback then compares a DEADLINE against `Date.now`
+    (`impl.presence/expire` takes `now`), so `Date.now` has to move with
+    it. A fake timer alone fires on time and then decides that nothing
+    has expired — green for the wrong reason, in the direction that
+    flatters the instrument.
+
+  [[the-clock-retires-a-retained-child-and-only-at-its-deadline]] is
+  where those two meet: the child survives an advance to one millisecond
+  short of its deadline and leaves on the next one. A clock that merely
+  forced a re-render, or one whose callbacks read an unmoved `Date.now`,
+  fails one half of that row each.
+
+  ## Browser lane
+
+  Every row needs a real document and a real React DOM: the timers are
+  armed inside `useEffect` and nothing about them exists without a
+  mounted component. `:node-test` compiles this namespace too
+  (`:ns-regexp \"cljs-test$\"` matches `-dom-cljs-test`), and each row
+  degrades there to a STATED skip rather than to a false green."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.motion :as motion]
+            [re-frame.hicasso.roots-frames-support :as sup]
+            [re-frame.hicasso.test.mounted :as hm]
+            [re-frame.test-support :as test-support]))
+
+;; ---------------------------------------------------------------------------
+;; The screen
+;; ---------------------------------------------------------------------------
+;;
+;; Registered ABOVE `use-fixtures`, deliberately: the reset fixture captures
+;; its source-store baseline when the `use-fixtures` form is EVALUATED, so a
+;; `reg-sub` written below it is erased before the first row runs.
+
+(rf/reg-sub ::toasts (fn [db _] (:toasts db)))
+
+(rf/reg-event ::set (fn [{:keys [db]} [_ ks]] {:db (assoc db :toasts (vec ks))}))
+
+(def ^:private retention-ms
+  "The retention window every row drives. A whole second, so that
+  \"advanced to one millisecond short\" is a claim about the deadline
+  rather than about rounding."
+  1000)
+
+(h/defview tray
+  "A toast tray: presence over the keyed children a subscription
+  supplies. The dismissed child declares its own exit appearance as data,
+  which is what gives the rows below a second, independent reading of the
+  same fact — the node's count, and the exit class on it."
+  [_]
+  [motion/presence {:timeout-ms retention-ms}
+   (for [t (h/sub [::toasts])]
+     [:div.toast {:key           t
+                  ::h/unmounting {:class "toast toast--exit"}}
+      (name t)])])
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     ;; The MAP shape, because every row here is `async`. `cljs.test`
+     ;; refuses an async test under a fn-form fixture and aborts the whole
+     ;; run at this namespace.
+     :async?        true
+     :init-fn       (fn []
+                      (sup/leave-act-environment!)
+                      (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; Reading the page
+;; ---------------------------------------------------------------------------
+
+(defn- toast-count [m] (.-length (.querySelectorAll (:container m) ".toast")))
+(defn- exiting [m] (.querySelector (:container m) ".toast--exit"))
+
+(defn- two-toasts
+  "One clocked mount of the tray, seeded with two toasts."
+  []
+  (hm/mount! [tray] {:clock true :initial-events [[::set [:a :b]]]}))
+
+;; ---------------------------------------------------------------------------
+;; W1 — the discriminating row: retired at the deadline, and not before it
+;; ---------------------------------------------------------------------------
+
+(deftest the-clock-retires-a-retained-child-and-only-at-its-deadline
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM, so no effect runs and no timer is armed")
+    (async done
+      (let [m (two-toasts)]
+        (testing "premise: both toasts are painted before anything leaves"
+          (is (= 2 (toast-count m)))
+          (is (nil? (exiting m))))
+
+        (hm/dispatch-and-settle! m [::set [:a]])
+
+        (testing "RETENTION: the dismissed toast outlives its data, wearing the
+                  exit phase. This is the state every assertion below is
+                  measured against — and on the wall clock it would stay this
+                  way for a full second"
+          (is (= 2 (toast-count m)) "the node survives the data — that is the module")
+          (is (some? (exiting m)) "wearing the author's own `::h/unmounting` class"))
+
+        (hm/advance-clock! m (dec retention-ms))
+
+        (testing "ONE MILLISECOND SHORT — and it is still here. The retirement
+                  belongs to the DEADLINE, not to the advance: a clock that
+                  merely forced a re-render, or one that fired every armed timer
+                  regardless of when it was due, would have dropped the child on
+                  this line"
+          (is (= 2 (toast-count m)))
+          (is (some? (exiting m))))
+
+        (hm/advance-clock! m 1)
+
+        (testing "AT the deadline it leaves. Nothing between this reading and
+                  the one above except one virtual millisecond — no dispatch, no
+                  render, no wall-clock wait"
+          (is (= 1 (toast-count m)))
+          (is (nil? (exiting m)))
+          (is (= "a" (.-textContent (.querySelector (:container m) ".toast")))
+              "and the toast that remains is the one that was never dismissed"))
+
+        (testing "teardown is clean. The positive control for the HANDOVER: the
+                  runtime's own reapers were armed on the virtual clock inside
+                  this window, and a release that dropped them instead of
+                  re-arming them would report residue the runtime was about to
+                  release"
+          (-> (hm/unmount! m)
+              (hm/assert-clean!)
+              (.then (fn [report]
+                       (is (true? (:clean? report)))
+                       (is (nil? (:leaked report)))
+                       (done)))))))))
+
+;; ---------------------------------------------------------------------------
+;; W2 — `Date.now` moves with the timers, and the wall clock does not move
+;; ---------------------------------------------------------------------------
+
+(deftest the-virtual-instant-moves-and-the-wall-clock-does-not
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM")
+    (async done
+      (let [m  (two-toasts)
+            t0 (js/Date.now)]
+
+        (hm/advance-clock! m 250)
+
+        (testing "the instant moved exactly as far as it was told — which is
+                  what lets a timer callback's own deadline comparison come out
+                  right (`impl.presence/expire` takes `now`)"
+          (is (= (+ t0 250) (js/Date.now))))
+
+        (hm/advance-clock! m 60000)
+
+        (testing "AND THE WALL CLOCK DID NOT MOVE WITH IT. The `Date`
+                  CONSTRUCTOR reads the system clock and is deliberately not
+                  this window's, so it is the honest second opinion: a minute
+                  and a quarter-second have passed for the code under test and
+                  no measurable time has passed for the machine"
+          (is (= (+ t0 60250) (js/Date.now)))
+          (is (< 60000 (- (js/Date.now) (.getTime (js/Date.))))
+              "over a minute of virtual time, none of it real"))
+
+        (-> (hm/unmount! m) (hm/assert-clean!) (.then (fn [_] (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; W3 — the window: installed by the mount, gone with it, and refused outside
+;; ---------------------------------------------------------------------------
+
+(deftest the-clock-is-the-mounts-window-and-nothing-wider
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM")
+    (async done
+      (let [platform (.-setTimeout js/globalThis)
+            m        (two-toasts)]
+
+        (testing "inside the window the platform's scheduler has been replaced"
+          (is (not (identical? platform (.-setTimeout js/globalThis)))))
+
+        (hm/unmount! m)
+
+        (testing "and the teardown puts it back. An instrument that rewrote the
+                  platform and left it rewritten would make every later suite in
+                  the run its subject"
+          (is (identical? platform (.-setTimeout js/globalThis))))
+
+        (testing "the door then refuses, with the handle it was given as data.
+                  An advance with no clock under it would move nothing and
+                  assert nothing — the row would go green for exactly the reason
+                  it was written to rule out"
+          (let [thrown (try (hm/advance-clock! m 5) nil (catch :default e e))]
+            (is (some? thrown))
+            (is (= {:ms 5 :frame (:frame m)} (ex-data thrown)))))
+
+        (-> (hm/assert-clean! m)
+            (.then (fn [_]
+                     (testing "and a mount that never asked for one is refused
+                               the same way"
+                       (let [plain  (hm/mount! [tray] {:initial-events [[::set [:a]]]})
+                             thrown (try (hm/advance-clock! plain 5) nil
+                                         (catch :default e e))]
+                         (is (some? thrown))
+                         (is (= {:ms 5 :frame (:frame plain)} (ex-data thrown)))
+                         (-> (hm/unmount! plain)
+                             (hm/assert-clean!)
+                             (.then (fn [report]
+                                      (is (true? (:clean? report)))
+                                      (done)))))))))))))

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
@@ -10,13 +10,14 @@
       (:require [re-frame.hicasso.test :as ht]        ;; L1–L2
                 [re-frame.hicasso.test.mounted :as hm]) ;; L3
 
-  ## Seven doors and one handle
+  ## Eight doors and one handle
 
       (hm/mount! form opts)             → handle
       (hm/hydrate! form opts)           → promise of handle
       (hm/render! handle form)          → handle
       (hm/dispatch-and-settle! h event) → handle
       (hm/settle! handle)               → handle
+      (hm/advance-clock! handle ms)     → handle
       (hm/unmount! handle)              → handle
       (hm/assert-clean! handle)         → promise of the residue report
 
@@ -82,6 +83,29 @@
   reads the page. After a door returns, the next line sees the DOM a user
   would have seen. [[hydrate!]] is the one exception and says why.
 
+  ## Time is OPT-IN, and it is a mount's own window
+
+  A tray that retains an exiting child for 300 ms, a debounce, a
+  `:dispatch-later` — anything whose next step is a `setTimeout` — cannot
+  be asserted without waiting, and a witness that waits on the wall clock
+  is the flake this repo keeps out of its gates. So one mount at a time
+  may ask for a **virtual clock**:
+
+      (let [m (hm/mount! [tray] {:clock true})]
+        (hm/dispatch-and-settle! m [:toast/dismiss 1])
+        (hm/advance-clock! m 300)     ;; 300 ms happen, now
+        …)
+
+  Time then moves only when [[advance-clock!]] moves it, and it moves
+  exactly as far as it is told. See that door for what advances and —
+  just as load-bearing — what deliberately does not.
+
+  **It is the mount's window and nothing wider.** The clock is installed
+  by [[mount!]] and taken back down by [[unmount!]], with whatever was
+  still armed handed back to the real scheduler, so the residue reading
+  that follows is the reading it always was. Nothing outside that window
+  is affected, and no mount that did not ask gets one.
+
   ## Refusals: this namespace mints none, and PROPAGATES the runtime's
 
   Every other file in the kit refuses loudly, and this one deliberately
@@ -124,6 +148,7 @@
             [re-frame.hicasso.impl.inventory :as inventory]
             [re-frame.hicasso.impl.mount :as mount]
             [re-frame.hicasso.impl.roots :as roots]
+            ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]))
 
 ;; ---------------------------------------------------------------------------
@@ -167,6 +192,161 @@
 (def ^:private state-key ::state)
 (def ^:private baseline-key ::baseline)
 (def ^:private ordinal-key ::ordinal)
+(def ^:private clock-key ::clock)
+
+;; ---------------------------------------------------------------------------
+;; The clock — virtual time, for the window of a mount that asked for one
+;; ---------------------------------------------------------------------------
+;;
+;; `!clock` is nil, or the whole of the installation: the platform functions
+;; that were replaced, the virtual instant, and the timers armed against it.
+;; Page-wide, because the thing it replaces is — so it is HOLDER-COUNTED and
+;; the last mount to let go is the one that puts the platform back. Two
+;; clocked mounts share one clock rather than one silently restoring the
+;; globals out from under the other.
+;;
+;; `:pending` is id → `{:id :f :args :due :period}`. `:period` is nil for a
+;; one-shot and the repeat interval for a `setInterval`, which is the only
+;; difference between them: both live in one table so that ONE ordering
+;; decides what fires next.
+
+(defonce ^:private !clock (atom nil))
+
+(defn- arm!
+  "Record one virtual timer and answer its id. `repeat?` distinguishes
+  `setInterval` from `setTimeout`; a non-numeric or negative delay is 0,
+  as the platform's own is.
+
+  A repeating timer's period is floored at 1 ms. The platform floors it
+  too (and clamps harder still for nested timers); without a floor a
+  zero-period interval inside an advance would be due forever at the same
+  instant and the advance would not terminate."
+  [repeat? f delay args]
+  (let [d (if (and (number? delay) (pos? delay)) delay 0)]
+    (:seq (swap! !clock
+                 (fn [c]
+                   (let [id (inc (:seq c))]
+                     (-> c
+                         (assoc :seq id)
+                         (assoc-in [:pending id]
+                                   {:id     id
+                                    :f      f
+                                    :args   args
+                                    :due    (+ (:now c) d)
+                                    :period (when repeat? (max 1 d))}))))))))
+
+(defn- disarm!
+  "Drop the virtual timer `id`, and answer whether there was one. False
+  means the id is not this clock's — a timer armed before the install —
+  and the caller hands it to the platform's own clearer, which is what
+  keeps a `clearTimeout` across the boundary honest."
+  [id]
+  (if (contains? (:pending @!clock) id)
+    (do (swap! !clock update :pending dissoc id) true)
+    false))
+
+(defn- install-clock!
+  "Replace the platform's timer surface and `Date.now` with this clock's,
+  or take a second hold on the one already installed. Answers nil.
+
+  The virtual instant STARTS at the real one, so a deadline computed
+  before the install and a deadline computed after are the same kind of
+  number."
+  []
+  (if (some? @!clock)
+    (swap! !clock update :holders inc)
+    (let [g    js/globalThis
+          real {:set-timeout    (.-setTimeout g)
+                :clear-timeout  (.-clearTimeout g)
+                :set-interval   (.-setInterval g)
+                :clear-interval (.-clearInterval g)
+                :date-now       (.-now js/Date)}]
+      (reset! !clock {:holders 1 :real real :now (js/Date.now) :seq 0 :pending {}})
+      (set! (.-setTimeout g)  (fn [f delay & args] (arm! false f delay args)))
+      (set! (.-setInterval g) (fn [f delay & args] (arm! true f delay args)))
+      (set! (.-clearTimeout g)
+            (fn [id] (when-not (disarm! id) (.call (:clear-timeout real) g id)) js/undefined))
+      (set! (.-clearInterval g)
+            (fn [id] (when-not (disarm! id) (.call (:clear-interval real) g id)) js/undefined))
+      (set! (.-now js/Date) (fn [] (:now @!clock)))))
+  nil)
+
+(defn- release-clock!
+  "Let go of one hold, and — on the last one — put the platform back and
+  HAND OVER what is still armed. Answers nil.
+
+  The handover is the half that is easy to leave out and impossible to
+  see afterwards. The runtime arms reapers of its own inside a mount's
+  window (`impl.collector`'s entry and cell reapers, whose horizon
+  `impl.inventory/quiesced!` waits out), and a clock that simply dropped
+  its table on the way out would strand them — [[assert-clean!]] would
+  then report residue the runtime was about to release, which is a red
+  nobody can act on. So every outstanding timer is re-armed on the real
+  scheduler with the time it had left.
+
+  What that does not preserve is the ids: from here on they are the
+  platform's, so a `clearTimeout` held across the boundary no longer
+  reaches its timer. Nothing in the runtime clears a timer it armed once
+  its root is down, and a consumer's cleanup runs inside the window
+  (React's teardown is [[unmount!]]'s first act, this release its last)."
+  []
+  (when-some [{:keys [holders real now pending]} @!clock]
+    (if (< 1 holders)
+      (swap! !clock update :holders dec)
+      (let [g js/globalThis]
+        (set! (.-setTimeout g)    (:set-timeout real))
+        (set! (.-setInterval g)   (:set-interval real))
+        (set! (.-clearTimeout g)  (:clear-timeout real))
+        (set! (.-clearInterval g) (:clear-interval real))
+        (set! (.-now js/Date)     (:date-now real))
+        (reset! !clock nil)
+        (doseq [e (sort-by :id (vals pending))]
+          (if-some [p (:period e)]
+            (.apply (:set-interval real) g (to-array (list* (:f e) p (:args e))))
+            (.apply (:set-timeout real) g
+                    (to-array (list* (:f e) (max 0 (- (:due e) now)) (:args e)))))))))
+  nil)
+
+(defn- release-clock-for!
+  "Let go of `handle`'s hold, at most once however often this is called.
+  Answers nil."
+  [handle]
+  (when-some [held (get handle clock-key)]
+    (when @held
+      (vreset! held false)
+      (release-clock!)))
+  nil)
+
+(defn- fire-due!
+  "Run every timer due at or before `target`, earliest first and — at one
+  instant — in the order they were armed. Answers how many fired.
+
+  The virtual instant moves to each timer's OWN due time before that
+  timer runs, never to the end of the window: a callback that reads
+  `Date.now` reads the moment it was scheduled for, which is the whole
+  reason a deadline comparison inside one (`impl.presence/expire`) can
+  come out right.
+
+  A callback that arms another timer inside the window is fired too, by
+  construction — the table is re-read on every pass rather than
+  snapshotted."
+  [target]
+  (loop [fired 0]
+    (let [c   @!clock
+          due (->> (vals (:pending c))
+                   (filter (fn [e] (<= (:due e) target)))
+                   (sort-by (juxt :due :id))
+                   first)]
+      (if (nil? due)
+        (do (swap! !clock update :now max target) fired)
+        (do (swap! !clock
+                   (fn [c]
+                     (let [c (update c :now max (:due due))]
+                       (if-some [p (:period due)]
+                         (assoc-in c [:pending (:id due) :due] (+ (:due due) p))
+                         (update c :pending dissoc (:id due))))))
+            (.apply (:f due) js/globalThis (to-array (:args due)))
+            (recur (inc fired)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The census — what the facade knows how to count
@@ -277,14 +457,21 @@
   construction BECOMES a mount. Nothing before this line counts against
   the standing or the unread census, which is what lets [[abandon!]]
   restore the page without touching either: a mount that never was is
-  not a mount that came down."
-  [root ordinal baseline]
+  not a mount that came down.
+
+  `clock?` puts this mount's HOLD on the virtual clock onto the handle,
+  as a volatile the release flips: the hold is a fact about the mount and
+  belongs with the mount's other two, so [[unmount!]] and [[residue]] can
+  each let go without either of them having to know whether the other
+  already did."
+  [root ordinal baseline clock?]
   (swap! !standing inc)
   (swap! !open inc)
-  (assoc root
-         baseline-key baseline
-         ordinal-key  ordinal
-         state-key    (volatile! :mounted)))
+  (cond-> (assoc root
+                 baseline-key baseline
+                 ordinal-key  ordinal
+                 state-key    (volatile! :mounted))
+    clock? (assoc clock-key (volatile! true))))
 
 ;; ---------------------------------------------------------------------------
 ;; Construction is TRANSACTIONAL
@@ -400,6 +587,13 @@
                        is a fresh `<div>` appended to `document.body` —
                        attached, so `screen`-scoped Testing Library
                        queries and real focus both work.
+      :clock           `true` installs a virtual clock for this mount's
+                       window, so a timed transition is driven by
+                       [[advance-clock!]] instead of waited on. Installed
+                       BEFORE anything else this call does, so a timer
+                       armed by `:initial-events` or by the first render's
+                       effects is already this clock's; released by
+                       [[unmount!]].
 
   ## What it records before it renders
 
@@ -428,7 +622,12 @@
   handle for a root that had rendered nothing and reported the error at
   the window instead. See [[catching-root!]]."
   ([form] (mount! form {}))
-  ([form {:keys [initial-events container]}]
+  ([form {:keys [initial-events container clock]}]
+   ;; The clock is the FIRST allocation and the last release, because the
+   ;; seeding below already runs handlers and the render below already
+   ;; runs effects — either can arm a timer, and one armed on the platform
+   ;; clock is one this mount can never drive.
+   (when clock (install-clock!))
    (let [[frame-kw ordinal] (mint-frame! initial-events)
          baseline           (census)
          node               (or container (mount/fresh-container!))
@@ -439,8 +638,9 @@
                                                 (vreset! !refusal error))))]
      (if-some [refusal @!refusal]
        (do (abandon! frame-kw node (some? container) root)
+           (when clock (release-clock!))
            (throw refusal))
-       (handle-for root ordinal baseline)))))
+       (handle-for root ordinal baseline (boolean clock))))))
 
 (defn hydrate!
   "Mount `form` by ADOPTING server-rendered bytes already in the
@@ -455,6 +655,10 @@
       :html       server bytes; a fresh attached container is created
                   carrying them
       :container  a container you already filled
+
+  `:clock` is honoured, and installed once adoption has completed rather
+  than before it — see the resolve branch below for why that is the only
+  point at which it can be.
 
   ## Why this one answers a promise
 
@@ -493,7 +697,7 @@
   where it is (see [[abandon!]])."
   ([form] (hydrate! form {}))
   ([form opts] (hydrate! form opts 3000))
-  ([form {:keys [initial-events container html]} budget-ms]
+  ([form {:keys [initial-events container html clock]} budget-ms]
    (let [[frame-kw ordinal] (mint-frame! initial-events)
          baseline  (census)
          node      (or container (mount/fresh-container!))
@@ -516,8 +720,23 @@
                          ;; handle a caller receives is one whose tables have
                          ;; settled. This is also where the construction
                          ;; becomes a MOUNT — see [[handle-for]].
+                         ;;
+                         ;; `:clock` is installed HERE and not at the top of
+                         ;; this door, unlike [[mount!]]'s. Adoption is
+                         ;; React's own concurrent business and this promise
+                         ;; is driven by real `setTimeout`s that wait it out;
+                         ;; a clock installed before them would freeze the
+                         ;; wait it is inside, and the caller would hold a
+                         ;; promise that can never resolve. Nothing is lost:
+                         ;; an adopted tray is born settled (rf2-2rtt6.84),
+                         ;; so the timers a hydrated page arms are armed
+                         ;; after this line.
                          (js/setTimeout
-                           (fn [] (resolve (handle-for root ordinal baseline))) 16)
+                           (fn []
+                             (when clock (install-clock!))
+                             (resolve (handle-for root ordinal baseline
+                                                  (boolean clock))))
+                           16)
 
                          (< deadline (js/Date.now))
                          (do (abandon! frame-kw node supplied? root)
@@ -559,6 +778,81 @@
   (mount/settle!)
   handle)
 
+(defn advance-clock!
+  "Move this mount's virtual clock forward by `ms`, run everything that
+  falls due on the way, and answer the handle.
+
+      (let [m (hm/mount! [tray] {:clock true :initial-events […]})]
+        (hm/dispatch-and-settle! m [:toast/dismiss :b])
+        (is (= 2 (count (toasts m))))   ;; retained, mid-exit
+        (hm/advance-clock! m 300)
+        (is (= 1 (count (toasts m)))))  ;; the deadline passed
+
+  Requires `{:clock true}` on the [[mount!]] that made `handle`, and
+  throws without it. That is not decoration: an advance with no clock
+  under it would move nothing and assert nothing, and the row would go
+  green for the reason it was written to rule out.
+
+  ## What advances
+
+  **`setTimeout`, `setInterval`, and `Date.now` — the three together, in
+  lockstep.** The clock is the whole of them or it is a trap: retention
+  is a deadline COMPARISON (`impl.presence/expire` takes `now`), so a
+  fake timer whose callback reads an unmoved `Date.now` fires on time and
+  then decides nothing has expired. The instant moves to each timer's own
+  due time before that timer runs, so a callback reads the moment it was
+  scheduled for; a callback that arms another timer inside the window is
+  fired in its turn.
+
+  ## What deliberately does NOT advance, and why each is right
+
+  - **`requestAnimationFrame`.** A frame is a paint, not a duration, and
+    `ms` says nothing about how many of them there were. It is left on
+    the platform's own schedule, where it still fires — so a rAF-driven
+    witness is not blocked by the clock, it is simply not driven by it.
+    (The substrate arms none: presence's whole frame budget is zero rAF
+    and zero interval, and `re-frame.hicasso.motion-presence-dom-cljs-test`
+    is what says so.)
+  - **Microtasks, and therefore promises.** A microtask queue cannot be
+    drained from inside a task by anything in userland, so no control
+    could honestly claim it. A `.then` still lands where it always did —
+    after this door returns, not inside it.
+  - **`performance.now`.** React's scheduler reads it to decide whether
+    it has time left in the frame; a clock that jumped it forward would
+    be telling React it is out of budget on every advance.
+  - **The `Date` CONSTRUCTOR.** `(js/Date.)` reads the system clock
+    rather than `Date.now`, and is not this window's.
+  - **A `setTimeout` somebody CAPTURED before the window opened.** The
+    clock replaces the global, so it reaches every call that looks the
+    global up when it fires — which is every `(js/setTimeout …)` in
+    ClojureScript, and the substrate's presence timers among them. React's
+    own scheduler is the deliberate exception and reads the reference it
+    took at module load: React keeps its real scheduler, and a flush is
+    still a flush.
+
+  ## It does not replace [[settle!]]; it is that flush with work in it
+
+  The due callbacks run INSIDE the same `flushSync` [[settle!]] performs
+  empty, so an update a timer schedules is committed before this returns
+  and the next line reads the repainted page — the rule every door here
+  keeps. Nothing about the runtime's own settling is duplicated or
+  bypassed: after stimulating the page from outside a door, [[settle!]]
+  is still the call to make, and this one is [[settle!]] for the work
+  that had a delay on it."
+  [handle ms]
+  (let [held (get handle clock-key)]
+    (when-not (and (some? held) @held)
+      (throw (ex-info (str "advance-clock! moves the virtual clock a mount owns, "
+                           "and this handle owns none"
+                           (if (some? held)
+                             " any longer — it was released when the mount came down."
+                             ": mount! was not given {:clock true}.")
+                           " An advance with no clock under it would move nothing "
+                           "and assert nothing.")
+                      {:ms ms :frame (:frame handle)})))
+    (react-dom/flushSync (fn [] (fire-due! (+ (:now @!clock) ms))))
+    handle))
+
 (defn dispatch-and-settle!
   "Dispatch `event` into this mount's frame, drain it, commit the echo,
   and answer the handle.
@@ -590,6 +884,13 @@
   `root.unmount()` empties a container and leaves it where it is, and
   `impl.mount/unmount!` now does no more than that.
 
+  **A `:clock` mount's clock is released here**, after React's teardown
+  and not before it: a component's cleanup clears the timers it armed,
+  and it has to be able to reach them. What is still armed afterwards
+  goes back to the real scheduler with the time it had left — see
+  [[advance-clock!]] for the window and `release-clock!` for the
+  handover.
+
   Idempotent: unmounting twice is not an error, and only the first call
   counts against the standing-mount census."
   [handle]
@@ -597,6 +898,7 @@
   (when (= :mounted @(get handle state-key))
     (vreset! (get handle state-key) :unmounted)
     (swap! !standing dec))
+  (release-clock-for! handle)
   handle)
 
 ;; ---------------------------------------------------------------------------
@@ -634,8 +936,18 @@
 
   This is [[assert-clean!]]'s other half, and it exists so the instrument
   can have a sabotage control of its own: a witness that deliberately
-  leaks must be able to read the verdict rather than fail on it."
+  leaks must be able to read the verdict rather than fail on it.
+
+  **It lets go of a `:clock` mount's clock first**, and that is a repair
+  rather than a courtesy. The reading below waits out the runtime's own
+  reaper horizon on a `setTimeout`, so a virtual clock still installed
+  here would freeze the wait and this promise would never settle —
+  turning the one reported failure this door exists to make loud (a
+  reading taken on a mount nobody unmounted) into a hung async test.
+  [[unmount!]] normally gets there first; this is the case where it was
+  not called at all."
   [handle]
+  (release-clock-for! handle)
   (let [baseline (get handle baseline-key)
         mounted? (= :mounted @(get handle state-key))]
     (.then (inventory/quiesced!)


### PR DESCRIPTION
The mounted test kit had no way to move time, so anything whose next step is a
`setTimeout` — a presence tray retaining an exiting child, a debounce, a
`:dispatch-later` — could only be witnessed by waiting on the wall clock. That
is the flakiness this repo deliberately keeps out of its gates, and it is what
blocks **rf2-5gka** (migrate Story's presence bridge off Freehand), whose own
fence forbids it from building the affordance it names.

Re-verified before building, as the bead asks: no `defn` matching *clock*,
*tick*, *advance*, *flush-timers* or *run-timers* existed anywhere under
`implementation/hicasso/test_kit/src/` or `implementation/hicasso/src/`. Still
true at this branch point. The kit's L2 vocabulary is `tree`/`:subs` (rf2-0ckh
has landed) and this PR uses it.

## One control, and where it lives

`re-frame.hicasso.test.mounted` gains an eighth door and one option:

```clojure
(let [m (hm/mount! [tray] {:clock true :initial-events [[::set [:a :b]]]})]
  (hm/dispatch-and-settle! m [::set [:a]])
  (is (= 2 (toast-count m)))       ;; retained, mid-exit
  (hm/advance-clock! m 1000)
  (is (= 1 (toast-count m))))      ;; the deadline passed, in virtual time
```

Nothing else moves. `mount!` gains `:clock`; `advance-clock!` takes the handle
first and answers it, like every other door here.

## The three design questions, settled

**1. What exactly advances?** `setTimeout`, `setInterval` and `Date.now` — the
three together, in lockstep, and that combination is the whole point rather than
a convenience. Presence retirement is a deadline COMPARISON:
`impl.presence-react` arms the timer and the callback then runs
`impl.presence/expire`, which takes `now`. A fake timer alone fires on time and
then decides that nothing has expired — green for the wrong reason, in the
direction that flatters the instrument. The virtual instant moves to each
timer's own due time *before* that timer runs, so a callback reads the moment it
was scheduled for; a callback that arms another timer inside the window is fired
in its turn.

Deliberately NOT advanced, each stated in the door's docstring with its reason:

- **`requestAnimationFrame`** — a frame is a paint, not a duration, and `ms`
  says nothing about how many there were. Left on the platform's own schedule,
  where it still fires: a rAF-driven witness is not blocked by the clock, it is
  simply not driven by it. (The substrate arms none — presence's frame budget is
  zero rAF and zero interval, and `motion-presence-dom-cljs-test` says so.)
- **Microtasks, and therefore promises** — a microtask queue cannot be drained
  from inside a task by anything in userland, so no control could honestly claim
  it. A `.then` still lands where it always did.
- **`performance.now`** — React's scheduler reads it to decide whether it has
  time left in the frame. A clock that jumped it forward would be telling React
  it is out of budget on every advance.
- **The `Date` CONSTRUCTOR** — `(js/Date.)` reads the system clock, not
  `Date.now`. W2 below uses that as its independent second opinion.
- **A `setTimeout` captured before the window opened** — the clock replaces the
  global, so it reaches every call that looks the global up when it fires (every
  `(js/setTimeout …)` in ClojureScript, the substrate's presence timers among
  them). React's own scheduler is the deliberate exception and keeps the
  reference it took at module load, so a flush is still a flush.

**2. Does it compose with `settle!`, or replace it?** It composes, and it does
not duplicate the runtime's settling. The due callbacks run INSIDE the same
`flushSync` that `settle!` performs empty, so an update a timer schedules is
committed before the call returns and the next line reads the repainted page —
the rule every door here keeps. After stimulating the page from outside a door,
`settle!` is still the call to make; `advance-clock!` is `settle!` for the work
that had a delay on it.

**3. Test-kit-only?** Yes, and structurally rather than by convention. It is in
`hicasso/test_kit/src`, which is outside the artefact's published `:paths`, so a
production bundle cannot reach it — the kit's existing zero-reachability
property, unchanged. Nothing is added to `re-frame.hicasso`; no new
`:rf.error/*` id is minted (the one refusal is a plain `ex-info`, the shape
`hydrate!`'s own timeout already uses). rf2-31xm's mistake — a fixture door on
the public surface — is not repeated.

## The two things that are easy to get wrong, and are handled

**Release hands the outstanding timers back.** The runtime arms reapers of its
own inside a mount's window (`impl.collector`'s entry and cell reapers, whose
horizon `impl.inventory/quiesced!` waits out). A clock that dropped its table on
the way out would strand them and `assert-clean!` would report residue the
runtime was about to release — a red nobody can act on. So every outstanding
timer is re-armed on the real scheduler with the time it had left. W1's
`assert-clean!` is the positive control for that.

**`residue` lets go of the clock first.** Its reading waits out the reaper
horizon on a `setTimeout`; a virtual clock still installed there would freeze
the wait and the promise would never settle, turning the one failure that door
exists to make loud (a reading taken on a mount nobody unmounted) into a hung
async test. `unmount!` normally gets there first; this covers the case where it
was never called.

The clock is holder-counted, so two clocked mounts share one rather than the
first teardown restoring the globals out from under the second.

## The witness discriminates, and here is the red

`implementation/hicasso/test/re_frame/hicasso/test_kit_clock_dom_cljs_test.cljs`
— 3 rows, 25 assertions, real Chromium.

- **W1** `the-clock-retires-a-retained-child-and-only-at-its-deadline` — the
  discriminating row. A presence tray retains a dismissed toast for 1000 ms. The
  child survives an advance to *one millisecond short* of its deadline and
  leaves on the next one. A clock that merely forced a re-render fails the first
  half; a clock whose callbacks read an unmoved `Date.now` fails the second.
  Ends on `assert-clean!` (the handover control).
- **W2** `the-virtual-instant-moves-and-the-wall-clock-does-not` — `Date.now`
  moves exactly as far as it is told, and the untouched `Date` constructor is
  the independent reading that says no real time passed while it did.
- **W3** `the-clock-is-the-mounts-window-and-nothing-wider` — the platform's
  `setTimeout` is replaced inside the window and identical to itself again after
  `unmount!`; the door then refuses, with its ex-data asserted as a value rather
  than through a bare `(is (thrown? …))`. A mount that never asked for a clock
  is refused the same way.

**Disabling the advance** — both `advance-clock!` calls in W1 commented out,
nothing else touched — produces this, verbatim, from the real-browser run:

```
FAIL in (the-clock-retires-a-retained-child-and-only-at-its-deadline) (re_frame/hicasso/test_kit_clock_dom_cljs_test.cljs:146:15)
AT the deadline it leaves. Nothing between this reading and
                  the one above except one virtual millisecond — no dispatch, no
                  render, no wall-clock wait
expected: (= 1 (toast-count m))
  actual: (not (= 1 2))

FAIL in (the-clock-retires-a-retained-child-and-only-at-its-deadline) (re_frame/hicasso/test_kit_clock_dom_cljs_test.cljs:147:15)
AT the deadline it leaves. Nothing between this reading and
                  the one above except one virtual millisecond — no dispatch, no
                  render, no wall-clock wait
expected: (nil? (exiting m))
  actual: (not (nil? #object[HTMLDivElement [object HTMLDivElement]]))

Ran 3 tests containing 25 assertions.
2 failures, 0 errors.
```

Stated honestly: the *one-millisecond-short* assertions stay green under that
sabotage, and are supposed to — they are the half that says the retirement is
not merely "any advance drops the child". The deadline assertions are the ones
that discriminate, and they are the ones that go red. The advance was then
restored byte-identically (`git diff` clean against the sabotage) and the row is
green again.

## Quality gates

| gate | exit | note |
|---|---|---|
| `shadow-cljs compile node-test-hicasso` | 0 | the artefact's focused compile |
| targeted `browser-test` (this ns only) + Chromium | 0 | `Ran 3 tests containing 25 assertions. 0 failures, 0 errors.` |
| sabotage run (advance disabled) | 1 | 2 failures — quoted above |
| `npm run test:browser` (full `-dom-cljs-test` lane, Chromium) | **0** | `Ran 1241 tests containing 7671 assertions. 0 failures, 0 errors.` — the real-DOM lane; `test:cljs` cannot see a timer that never fired |
| `scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`; classified `docs=false jvm=false node=true`. Its `npm run test:cljs` step reported `Ran 13242 tests containing 66932 assertions. 0 failures, 0 errors.`, per-ns isolation passed 17/17, and the hicasso invariants / lint-export / bench-lane-compile gates passed. |

Not run, and why:

- **`mkdocs build --strict`** — no `docs/` file is touched.
- **JVM suites** (`test-jvm-implementation.sh`, `test-jvm-tools.sh`) — Hicasso's
  own lane is CLJS-only and declares zero JVM tests (`--probe` in its `:test`
  alias); no JVM artefact is touched.
- **Bundle-isolation / prod-elision / perf / Xray / mcp-conformance** — CI-only
  per `TESTING.md`, and nothing here reaches a production build: both files are
  test-tier and outside every published `:paths`.
- `python scripts/check_fast_pr_gap.py --list` reports 96 required checks the
  spine does not decide; none is reached by a change confined to
  `hicasso/test_kit/src` and `hicasso/test`.

## Fences

- In fence: `implementation/hicasso/test_kit/**`.
- **Outside the fence, flagged**: the witness is a **brand-new file** under
  `implementation/hicasso/test/`, which is HELD by the `:where` sweep. No
  existing file in that tree is touched, so there is no textual overlap with a
  sweep of existing files, and the witness asserts no `:where` key. Sequence the
  merge as you see fit.
- Untouched: `implementation/hicasso/src/**`, `spec/**`, `deps.edn`,
  `shadow-cljs.edn`, `.github/workflows/**`, `docs/**`.

## Follow-up (not taken — the tree is in flight)

`docs/design/hicasso/draft-guide/14-testing.md` carries an `hm/*` door table
that now omits `advance-clock!`, and `product/naming-ledger.md` is where a new
door name would earn a row. Both are under `docs/design/hicasso/**`, which this
worker was fenced out of.

