### PR TITLE
test(pair): enforce the onboarding-prose token budget where the prose is written (rf2-3dmj)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -4079,3 +4079,23 @@ Maintenance: the text lives in
 Edit it when the catalogue grows or shrinks. The structural peer
 is the `re-frame2-pair-mcp.tools/tool-descriptors` docstring;
 keep the two in lockstep when adding or removing tools.
+
+**The prose has a hard budget, and it is the wire cap** (rf2-3dmj). The
+response egresses through the universal wire-boundary cap like any
+other, so once it exceeds `default-max-tokens` the entire payload is
+replaced by the `{:rf.mcp/overflow ...}` marker — the first call an agent
+makes on a fresh session returns no onboarding text at all, and the
+marker's "re-call with narrower args" hint cannot help, because this
+tool takes no narrowing args. So the budget is enforced where the prose
+is written: `test/re_frame2_pair_mcp/instructions_budget_test.cljs` runs
+the production `cap/apply-cap` over the real result and fails with the
+budget, the current usage and the remaining margin named in the message.
+
+Note the exchange rate when estimating headroom. `wire/ok-text` writes
+the same payload into BOTH `:content[0].text` (the `pr-str` EDN) and
+`:structuredContent` (the JSON projection), and the cap counts both —
+correctly, since both ride the wire. The prose is therefore measured
+**twice**: one character of prose costs ~0.5 tokens of budget, so the
+effective prose budget is about half the nominal cap. Sizing a draft
+from the raw character count of `instructions-text` is wrong by a factor
+of two.

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/instructions_budget_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/instructions_budget_test.cljs
@@ -63,14 +63,14 @@
        "  margin: " (- budget tokens) " tokens\n"
        "At egress the whole response is REPLACED by the {:rf.mcp/overflow ...} "
        "marker, so an agent's first-contact call returns no onboarding text at "
-       "all — and the marker's hint ('re-call with narrower args') cannot help, "
+       "all - and the marker's hint ('re-call with narrower args') cannot help, "
        "because this tool takes no narrowing args.\n"
        "FIX: shorten `instructions-text` in "
        "tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/"
        "get_re_frame2_pair_instructions.cljs. The `## Tool catalogue` section is "
        "~75% of it and is the only part that grows with the tool count.\n"
-       "EXCHANGE RATE: the prose rides the wire TWICE — once as the pr-str EDN "
-       ":content[0].text and once as the :structuredContent JSON — so one "
+       "EXCHANGE RATE: the prose rides the wire TWICE - once as the pr-str EDN "
+       ":content[0].text and once as the :structuredContent JSON - so one "
        "character of prose costs ~0.5 tokens of this budget (~2 characters per "
        "token, not the ~4 a single copy would suggest).\n"
        "NOT THE FIX: raising default-max-tokens. It is a cross-MCP constant in "
@@ -81,9 +81,18 @@
   (async done
     (-> (instr/get-re-frame2-pair-instructions-tool nil nil)
         (.then (fn [result]
-                 (let [tokens (cap/sum-payload-tokens result)
-                       budget cap/default-max-tokens
-                       capped (cap/apply-cap result {:tool tool-name :cap budget})]
+                 (let [tokens  (cap/sum-payload-tokens result)
+                       budget  cap/default-max-tokens
+                       capped  (cap/apply-cap result {:tool tool-name :cap budget})
+                       ;; `apply-cap` returns the result object UNCHANGED when
+                       ;; it fits, and a fresh overflow-marker result when it
+                       ;; does not. Identity is therefore the exact question —
+                       ;; "would the wire boundary have replaced this?" —
+                       ;; collapsed to a boolean HERE so the `actual:` line
+                       ;; stays one word. Asserting `(identical? capped result)`
+                       ;; directly would print both ~10 KB envelopes above the
+                       ;; message, burying the numbers the author needs.
+                       replaced? (not (identical? capped result))]
                    ;; Self-check: a zero sum would make the budget
                    ;; assertion vacuously green — it would "pass" on an
                    ;; empty result just as happily as on a well-sized one.
@@ -92,11 +101,7 @@
                             " — the result shape changed and this guard is "
                             "measuring nothing; re-check cap/sum-payload-tokens "
                             "against the tool's result envelope"))
-                   ;; `apply-cap` returns the result object UNCHANGED when
-                   ;; it fits, and a fresh overflow-marker result when it
-                   ;; does not. Identity is therefore the exact question:
-                   ;; "would the wire boundary have replaced this?"
-                   (is (identical? capped result)
+                   (is (false? replaced?)
                        (over-budget-message tokens budget)))
                  (done)))
         (.catch (fn [e]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/instructions_budget_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/instructions_budget_test.cljs
@@ -1,0 +1,104 @@
+(ns re-frame2-pair-mcp.instructions-budget-test
+  "Authoring-time budget guard for the onboarding prose (rf2-3dmj).
+
+  `get-re-frame2-pair-instructions` returns one hand-written string —
+  `instructions-text` in `tools/get_re_frame2_pair_instructions.cljs` —
+  and that string grows every time a tool is added to the catalogue. It
+  egresses through the same wire-boundary cap as every other response,
+  so once the response exceeds `default-max-tokens` the WHOLE payload is
+  replaced by the `{:rf.mcp/overflow ...}` marker: the first call an
+  agent makes on a fresh session returns no onboarding text at all, and
+  the marker's hint (\"re-call with narrower args\") is useless here
+  because this tool has no narrowing args.
+
+  ## Why a dedicated test rather than letting the cap speak
+
+  The cap already stops the over-budget payload from reaching the wire —
+  correctness is not in question. What was missing is a failure that
+  NAMES THE CAUSE. Without this ns the breach surfaces as three
+  unrelated-looking reds — `closed_world_test`'s
+  `instructions-answered-before-connection` (`:ok?` is absent from an
+  overflow marker, and so is `:text`), the `conformance_test` fixture
+  `:get-re-frame2-pair-instructions/happy` (`:edn-submap` mismatch), and
+  the mcp-conformance closed-world block — none of which mentions
+  tokens, and all of which land in whatever PR happened to add the next
+  tool. This test fails in the same run with the budget, the current
+  usage and the remaining margin in the message, pointing at the file
+  that must be edited.
+
+  ## Measured through the production gate, never re-derived
+
+  The assertion runs the REAL `cap/apply-cap` — the same function the
+  `:apply-cap` step of `tools/invoke` runs — over the REAL result the
+  tool handler produced, against `cap/default-max-tokens`. There is no
+  second copy of the token arithmetic here to drift from the first, and
+  no hard-coded `5000`: change the constant or the summing rule and this
+  test follows.
+
+  ## The exchange rate is ~2 characters per token, not ~4
+
+  `wire/ok-text` writes the same payload into BOTH `:content[0].text`
+  (the `pr-str` EDN) AND `:structuredContent` (the JSON projection), and
+  `cap/sum-payload-tokens` counts both — correctly, since both ride the
+  wire. So the prose is measured TWICE: one character of prose costs
+  about half a token of budget, and the effective prose budget is about
+  half the nominal cap. An author estimating headroom from the raw
+  character count of `instructions-text` will be wrong by a factor of
+  two, which is precisely how a draft lands 88 tokens over."
+  (:require [cljs.test :refer-macros [deftest is async]]
+            [re-frame2-pair-mcp.tools.cap :as cap]
+            [re-frame2-pair-mcp.tools.get-re-frame2-pair-instructions :as instr]))
+
+(def ^:private tool-name "get-re-frame2-pair-instructions")
+
+(defn- over-budget-message
+  "The failure an author reads. Names the budget, the current usage and
+  the margin; says what the breach does to a consuming agent; points at
+  the file to edit; states the exchange rate; and names the answer that
+  is NOT the fix."
+  [tokens budget]
+  (str tool-name " is OVER its wire-boundary token budget.\n"
+       "  usage : " tokens " tokens\n"
+       "  budget: " budget " tokens (re-frame.mcp-base.overflow/default-max-tokens)\n"
+       "  margin: " (- budget tokens) " tokens\n"
+       "At egress the whole response is REPLACED by the {:rf.mcp/overflow ...} "
+       "marker, so an agent's first-contact call returns no onboarding text at "
+       "all — and the marker's hint ('re-call with narrower args') cannot help, "
+       "because this tool takes no narrowing args.\n"
+       "FIX: shorten `instructions-text` in "
+       "tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/"
+       "get_re_frame2_pair_instructions.cljs. The `## Tool catalogue` section is "
+       "~75% of it and is the only part that grows with the tool count.\n"
+       "EXCHANGE RATE: the prose rides the wire TWICE — once as the pr-str EDN "
+       ":content[0].text and once as the :structuredContent JSON — so one "
+       "character of prose costs ~0.5 tokens of this budget (~2 characters per "
+       "token, not the ~4 a single copy would suggest).\n"
+       "NOT THE FIX: raising default-max-tokens. It is a cross-MCP constant in "
+       "re-frame.mcp-base.overflow shared with story-mcp, and raising it only "
+       "defers the same failure to a larger blob (rf2-3dmj)."))
+
+(deftest instructions-response-fits-the-wire-token-budget
+  (async done
+    (-> (instr/get-re-frame2-pair-instructions-tool nil nil)
+        (.then (fn [result]
+                 (let [tokens (cap/sum-payload-tokens result)
+                       budget cap/default-max-tokens
+                       capped (cap/apply-cap result {:tool tool-name :cap budget})]
+                   ;; Self-check: a zero sum would make the budget
+                   ;; assertion vacuously green — it would "pass" on an
+                   ;; empty result just as happily as on a well-sized one.
+                   (is (pos? tokens)
+                       (str "token sum for " tool-name " is " tokens
+                            " — the result shape changed and this guard is "
+                            "measuring nothing; re-check cap/sum-payload-tokens "
+                            "against the tool's result envelope"))
+                   ;; `apply-cap` returns the result object UNCHANGED when
+                   ;; it fits, and a fresh overflow-marker result when it
+                   ;; does not. Identity is therefore the exact question:
+                   ;; "would the wire boundary have replaced this?"
+                   (is (identical? capped result)
+                       (over-budget-message tokens budget)))
+                 (done)))
+        (.catch (fn [e]
+                  (is false (str tool-name " handler rejected: " (.-message e)))
+                  (done))))))


### PR DESCRIPTION
Closes rf2-3dmj.

The bead frames this as a decision, not a repair, and names the wrong answer. This PR lands
the part that is clearly right and mechanical; it does **not** take the structural change,
which is written up below as a recommendation for the operator.

## The measurement

Measured through the production gate — `cap/sum-payload-tokens` over the real result the
handler returns, which is the same summer `tools/invoke`'s `:apply-cap` step uses.

| | |
|---|---|
| current usage | **4888 tokens** |
| cap | **5000** (`re-frame.mcp-base.overflow/default-max-tokens`) |
| margin | **112 tokens** |

112 tokens is about **226 characters of prose**, or two to three catalogue lines. The bead's
"tens of tokens" was the right order of magnitude.

Where the count comes from, and it is not obvious: `wire/ok-text` writes the payload into
**both** `:content[0].text` (the `pr-str` EDN) and `:structuredContent` (the JSON
projection), and the cap counts both — correctly, since both ride the wire.

| slot | chars | tokens |
|---|---|---|
| `:content[0].text` | 9,776 | 2,444 |
| `:structuredContent` | 9,777 | 2,444 |
| **total** | 19,553 | **4,888** |

So the prose is measured **twice**. One character of prose costs ~0.5 tokens of budget; the
effective prose budget is ~2,500 tokens, not 5,000. An author sizing a draft from the raw
character count of `instructions-text` is wrong by a factor of two — which is exactly how the
`rf2-n3mb` worker's draft landed at 5088.

The secondary character gate is not close: 19,553 of a 40,000 ceiling.

## What the breach actually costs

Not three red tests — that is the symptom. `apply-cap` replaces the **whole payload** with the
`{:rf.mcp/overflow ...}` marker, so `get-re-frame2-pair-instructions` — the first call an
agent makes on a fresh session — returns no onboarding text at all, and the marker's generic
hint ("re-call with narrower args, or raise `max-tokens`") cannot help, because this tool
takes no narrowing args.

The three reds, reproduced by planting an over-budget draft (see below), are
`closed_world_test/instructions-answered-before-connection` (two assertions — an overflow
marker carries neither `:ok?` nor `:text`), the conformance-corpus fixture
`:get-re-frame2-pair-instructions/happy`, and, at the SDK boundary, the closed-world block in
`tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs`. **None of them mentions tokens.**

## What landed

`tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/instructions_budget_test.cljs` — a single
`deftest` that runs the production `cap/apply-cap` over the real handler result against
`cap/default-max-tokens`, and fails with the budget, the usage and the margin in the message.

- No second copy of the token arithmetic to drift from the first, and no hard-coded `5000`:
  change the constant or the summing rule and the guard follows.
- A `(pos? tokens)` self-check so the assertion cannot go vacuously green on an empty result
  (mirrors the parser floor in `onboarding_catalogue_test`).
- The identity question is collapsed to a boolean at the binding site. Asserting
  `(identical? capped result)` directly prints both ~10 KB envelopes on the `actual:` line,
  burying the four numbers the author needs — the planted run proved that too.

Plus one paragraph in `spec/003-Tool-Catalogue.md` under the tool's Maintenance note, stating
the budget and the exchange rate.

This does not buy headroom and is not meant to. It converts a diffuse failure into a legible
one: same run, same moment, but one test that says what is wrong and what to do.

## Verbatim failure, from a planted over-budget draft

~300 characters of realistic catalogue prose were added to the `explain-render` entry (as
continuation lines, so the phantom-name guard stays quiet and the budget failure is isolated),
the suite was run, and the file was restored and re-verified by sha256. The planted run exits
**1** with **4 failures**; the measured overflow is **5112 tokens**, matching an independent
prediction of the same number to the token.

```
FAIL in (instructions-response-fits-the-wire-token-budget) (re_frame2_pair_mcp/instructions_budget_test.cljs:104:24)
get-re-frame2-pair-instructions is OVER its wire-boundary token budget.
  usage : 5112 tokens
  budget: 5000 tokens (re-frame.mcp-base.overflow/default-max-tokens)
  margin: -112 tokens
At egress the whole response is REPLACED by the {:rf.mcp/overflow ...} marker, so an agent's first-contact call returns no onboarding text at all - and the marker's hint ('re-call with narrower args') cannot help, because this tool takes no narrowing args.
FIX: shorten `instructions-text` in tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_re_frame2_pair_instructions.cljs. The `## Tool catalogue` section is ~75% of it and is the only part that grows with the tool count.
EXCHANGE RATE: the prose rides the wire TWICE - once as the pr-str EDN :content[0].text and once as the :structuredContent JSON - so one character of prose costs ~0.5 tokens of this budget (~2 characters per token, not the ~4 a single copy would suggest).
NOT THE FIX: raising default-max-tokens. It is a cross-MCP constant in re-frame.mcp-base.overflow shared with story-mcp, and raising it only defers the same failure to a larger blob (rf2-3dmj).
expected: (false? replaced?)
  actual: (not (false? true))
```

## The three questions

### Is a single blob the right shape, or should it paginate / split by surface?

**One blob, and do not paginate or split — but stop enumerating the tool list in it.**

Pagination solves the wrong problem. This tool is *first contact*: its whole value is that an
agent calls it once, before anything else, and knows how to drive the server. Splitting by
surface means the agent must know the surfaces before it can ask about them; paginating means
N round-trips to learn what one call teaches. That is a friction regression at the moment
friction is most expensive. And it would not stop the growth — each *page* would fit while the
total kept climbing.

The growth vector is measurable, and it is one section:

| section | chars | share | ~wire tokens |
|---|---|---|---|
| `## Tool catalogue` | 7,188 | **75.3%** | ~3,594 |
| `## Streaming subscribe semantics` | 473 | 5.0% | ~236 |
| `## Wire-boundary pipeline` | 448 | 4.7% | ~224 |
| `## Session entry-point` | 347 | 3.6% | ~173 |
| `## Tagged mutations` | 341 | 3.6% | ~170 |
| `## EDN posture` | 324 | 3.4% | ~162 |
| `## What this server is` | 321 | 3.4% | ~160 |
| preamble | 107 | 1.1% | ~53 |

Every section except the catalogue is a *convention* and is constant-size in the tool count.
Together they are 2,360 chars ≈ **1,180 wire tokens** — under a quarter of the budget, forever.

And the catalogue duplicates what the host already holds. `tools/list` ships 33
`:description` paragraphs totalling **79,127 chars ≈ 19,781 tokens** (mean 2,397 chars each),
loaded at session start before any tool is called. The catalogue restates that, thinner, at a
cost of ~3,594 tokens and a hand-maintained drift guard.

**Recommendation (not taken here):** retire the 33-line per-tool enumeration and keep the
conventions. If first-contact routing guidance is genuinely load-bearing — and
`onboarding_catalogue_test`'s docstring argues it is, saying an omitted tool leaves a model
reaching for `snapshot` / raw `eval-cljs` instead of the bounded reads — replace it with a
short **decision** section: half a dozen routing rules of the form "to read one sub, `read-sub`,
not `eval-cljs`". That is the one thing a descriptor structurally cannot say, because a
descriptor can only describe itself and never "prefer me over that one" — and it does not grow
linearly with the tool count.

This is a decision, not a repair: it deletes 75% of an AI-facing artefact and changes what
`onboarding_catalogue_test` guards. It is the operator's to make.

### Should the cap be enforced at authoring time?

**Yes.** Landed, above.

One honest limitation, and it is itself evidence for the recommendation: I could not set the
authoring budget *below* the wire cap with a reserve — the natural design, so the guard trips
while the tool still works. At 4888/5000 the blob already consumes **97.8%** of its budget, so
any reserve would be red on arrival, and manufacturing room by trimming prose is exactly the
deferral the bead forbids. The guard therefore sits at the wire cap. A reserve becomes
available the moment the structural question is settled.

### Is 5000 the right budget?

**Right for the wire, and it must not move. But it is the wrong number to reason about for
this blob.**

It is not a local constant. `default-max-tokens` lives in `re-frame.mcp-base.overflow`, is
shared with story-mcp, is the documented per-response budget in `spec/Principles.md`, and is
used by `mcp-base/envelope.cljc`'s `marker-text?` as the "sub-cap by construction" test for
wire markers. Raising it changes every tool's budget on two servers to accommodate one static
string.

And it buys half of what it looks like it buys, per the double-count above: 5,000 tokens of
budget is ~2,500 tokens of prose.

So the real question is not "is 5000 right" but "how many tokens of onboarding prose should an
agent read on first contact, having already been handed ~19,800 tokens of tool descriptions?"
On that framing ~2,400 tokens of prose is too much — and the part to cut is precisely the part
that duplicates those descriptions. The budget does not need to change; the content does.

## Quality gates

| gate | exit | notes |
|---|---|---|
| `tools/re-frame2-pair-mcp` `npm test` (shadow-cljs `:server-test`) | 0 | 1223 tests / 4438 assertions, 0 failures. The required PR job `node-test-tools-re-frame2-pair-mcp`. |
| same suite, **planted over-budget draft** | 1 | 4 failures, overflow at 5112 tokens — proof the guard bites. File restored, verified by sha256. |
| `tools/re-frame2-pair-mcp` `shadow-cljs compile server` | 0 | Shipped Node bundle, prerequisite for the SDK driver below. |
| `tools/mcp-conformance` `npm run test:re-frame2-pair` | 0 | The SDK-Client driver that calls every tool by name, including the closed-world success block for this tool. |
| `python scripts/check_skill_mcp_drift.py` | 0 | Skill ↔ descriptor manifest, both directions. |
| `python scripts/check_skill_pair_authoring_drift.py --verbose --ci` | 0 | Scanned 4 re-authoring files, no drift. |
| `python scripts/check_doc_slugs.py` | 0 | |
| `check_doc_slugs.py`, **planted broken anchor** | 1 | Proof of coverage on the edited file: `BROKEN ANCHOR: tools\re-frame2-pair-mcp\spec\003-Tool-Catalogue.md:4084 -> #no-such-heading-planted-rf2-3dmj`. Restored, verified by sha256 (not by `git diff` — `git diff` reads clean across a CRLF rewrite). |
| `sh scripts/test-fast-pr.sh` | 0 | `--plan` classified the diff: JVM tier skip, node/CLJS tier skip, documentation gates run. |

Gates deliberately not run, with reasons:

- **`npm run test:mcp-conformance` (the six-gate chain) — not run whole.** It chains the JVM
  and Node story-mcp gates and a second story conformance driver. The diff touches no
  descriptor, no tool name and no wire shape, so the story surface cannot be reached from it.
  Gate #4, the pair SDK-Client driver — the one that calls this tool by name — was run directly
  and is in the table above.
- **Browser / Playwright / hermetic live probes — not run.** No runtime, view or adapter surface
  in the diff; the change is one test namespace and one spec paragraph.
- **`mkdocs build --strict` — covered inside the spine run**, which its own plan selected
  (`PLAN-MKDOCS python -m mkdocs`).

The spec edit added no tables; the added markdown carries no links or headings, so no new anchor
targets exist to verify beyond the planted-anchor proof above.
