### PR TITLE
story: re-verify the S2-S6 presence cluster; the Freehand bridge cannot move yet (rf2-5gka)

### DIFF
--- a/tools/story/deps.edn
+++ b/tools/story/deps.edn
@@ -92,8 +92,23 @@
                        day8/re-frame2-ui         {:local/root "../../implementation/ui"}
                        ;; The presence rung's host bridge
                        ;; (`re-frame.story.play.presence-host`) requires the
-                       ;; Freehand presence runtime, and the view-tool /
-                       ;; sub-override consumers read Freehand projections.
+                       ;; Freehand presence runtime, and this entry is what
+                       ;; compiles it. Its three test arms read the same
+                       ;; runtime (`play/presence_cljs_test`,
+                       ;; `play/presence_freehand_dom_cljs_test`,
+                       ;; `play/presence_real_clock_cljs_test`) — and so does
+                       ;; `realworld_ui_consumer_cljs_test`, which drives a
+                       ;; real retained exit through the shipped bridge. That
+                       ;; last one is why RETIRING THE PRESENCE BRIDGE WOULD
+                       ;; NOT RETIRE THIS COORDINATE (rf2-5gka): a consumer
+                       ;; outside the presence rung shares it.
+                       ;;
+                       ;; The view-tool / sub-override consumers do NOT read
+                       ;; Freehand and never did: `re-frame.story.view-tool`
+                       ;; reads `re-frame.ui.tool`, which is the
+                       ;; `day8/re-frame2-ui` entry above, and the sub-override
+                       ;; Provider is core's own
+                       ;; `re-frame.adapter.sub-override-context`.
                        ;; TEST-ONLY for the same reason the donor entry above
                        ;; is: `day8/re-frame2-freehand` carries no `:clein`
                        ;; deploy aliases (publication is F6 territory), so


### PR DESCRIPTION
## The migration was not made, and the bead's own STOP clause is why

`rf2-5gka` says: *"If the answer is that the affordance belongs in the runtime, STOP and report
rather than taking it: that is a different bead on a surface other workers hold."* That is the
answer. `rf2-r7zq` cleared the dependency edge but not the blocker — it built a **test-kit
fake-timer facility**, and what a shipped bridge needs is a **production presence-clock door**.
The two share a name and nothing else.

This PR therefore carries one comment-only correction (below) and the re-verification. It does not
carry a half-migration.

### What S3 actually composes, and what the target publishes

`presence_host.cljc` ships in Story's `src/` tree as a taught, one-`:require` integration. It
composes exactly two Freehand verbs:

| | Freehand (today) | Hicasso (the target) |
|---|---|---|
| logical advance | `presence-runtime/advance-clock!` — production `src/`, arities `[]` (to quiescence) and `[ms]` | **nothing.** No clock verb anywhere in `hicasso/src/`; the public facade `hicasso.cljc` names no presence or clock export |
| synchronous commit | `(:flush-render! v/adapter)` — the published Spec 006 adapter slot | **nothing.** `git grep flush-render! -- implementation/hicasso/` is empty and no `adapter` value is defined anywhere in the artefact |

The facade's whole export list is nine vars — `sub`, `use-subs`, `hframe`, `boundary`, `reg-state`,
`route-link`, `root!`, `render!`, `unmount!` — plus the `defview` / `hfn` / `defhost` macros. The
nearest candidate, `render!`, is `[handle form]`: the hot-reload door that reconciles a *new tree*
against the page. It is not a thunk-taking commit boundary and cannot stand in for `flush-render!`,
which the bridge needs in order to run the advance *inside* the commit
(`(freehand-commit! #(advance-clock! ms))`). The point is moot regardless, since there is no clock
verb to wrap.

Hicasso's presence is a bare React component: `impl/presence_react.cljs` arms `js/setTimeout`
directly (L142 expiry, L150 enter-flip) and reads `js/Date.now` (L97). There is no exit registry,
no `pending-count`, no `set-wall-clock!`, and no id-keyed exactly-once guard — the five things
Freehand's `presence-runtime` publishes that the bridge and its witnesses stand on.

The missing commit boundary is a **deliberate ruling, not an omission**:
`impl/controlled.cljs` L266-272 states HD-019 grants the `flushSync` exception "to an AUDITED
MECHANISM, not to a count" — `converge!` holds the namespace's one `flushSync`, reachable from
exactly two call sites. Hicasso is designed to refuse the general commit door the bridge reads off
`v/adapter`.

### Why the test-kit `advance-clock!` cannot stand in

Read at `implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs:781`, with its
`install-clock!` at L248. Four independent blockers, any one of which is fatal:

1. **It lives in the test kit.** S3 ships in Story's `src/` and is required by a user app at boot.
   Routing a production bridge through `test_kit/src/` puts a test kit in a user's production boot
   path. `rf2-31xm` is the live bug about exactly this class of mistake, and `rf2-r7zq` closed
   citing "the fixture door stayed behind the fixture door" as its most important clause.
2. **The signature is `[handle ms]`** and needs a `{:clock true}` mount handle minted by
   `hm/mount!`. Story's bridge holds no such handle — Story's shell mounts the app, and a variant
   mounts inside a Reagent process.
3. **There is no quiescence arity.** Bare `[:flush-presence]` means "advance to quiescence"; the
   control takes an explicit `ms` only. Story's two script arities map 1:1 onto Freehand's two and
   have no counterpart here.
4. **It mutates `js/globalThis` process-wide** (verified in `install-clock!`, not taken from the
   docstring: it `set!`s `setTimeout`, `setInterval`, `clearTimeout`, `clearInterval` and
   `Date.now` on `globalThis`, refcounted by `:holders`). S3's docstring says the bridge
   deliberately leaves the wall clock armed, because disabling it "would freeze every retained
   child in a variant a human is merely clicking through in the canvas". The Hicasso control is
   *strictly more invasive* than the thing the Freehand bridge already declines — it freezes
   `Date.now` for the whole page.

### What the clock control covers for this case

The brief flagged that `rf2-r7zq`'s verification did not establish `requestAnimationFrame` or
microtask coverage. I read `install-clock!` rather than trusting the docstring, and the docstring
is honest: rAF, `queueMicrotask`/promises, `performance.now` and the `Date` constructor are absent
from both the saved-`real` map and the `set!` list, so none of them advances.

**For a presence witness that gap does not bite.** Hicasso's presence path arms only plain
`js/setTimeout` (two sites) and compares against `js/Date.now`, and `impl/presence/expire` takes
`now` as an argument — so the deadline comparison reads the swapped clock, which is precisely the
trap the control's docstring says it exists to avoid. Coverage is complete for this case. **The
blocker is not coverage; it is the home, the signature, the missing arity and the wall-clock
policy.**

## The options, and a recommendation (the bead asks for this before anything is built)

None of these is taken here — all three land on `implementation/**`, which this bead fences out and
other workers hold.

**Option A — mirror Freehand: a public `re-frame.hicasso.presence-runtime`.** Publish
`advance-clock!` (both arities), `pending-count`, `set-wall-clock!`, `reset-clock!` over a real exit
registry, and have `impl/presence_react` schedule into that registry instead of arming bare
`js/setTimeout`. *Cost:* a genuine runtime change to the presence effect, four or five new public
exports (each carrying the standing classification duty), **and** a commit boundary that HD-019
deliberately withholds. *Benefit:* exact parity with the shape S3 and all three witnesses already
stand on; the migration then becomes a small local edit.

**Option B — one narrow verb: `flush-presence!` on the facade**, doing advance-and-commit in a
single call so the bridge composes nothing. *Cost:* still needs the exit registry (there is nothing
to advance without one) and still needs a `flushSync` site, so the HD-019 problem is unchanged.
*Benefit:* the smallest public surface — one export, one classification — and the bridge shrinks to
a bare install.

**Option C — add nothing to the target; do not ship a Hicasso bridge yet.** Story's rung is already
substrate-neutral: `install-presence-flush!` is public precisely so a host can register its own
advance, and Story's jar depends on no substrate. A Hicasso-hosted shell that wants scripted
presence registers its own verb; until one exists, `[:flush-presence]` refuses loudly, which is the
designed behaviour rather than a gap. *Cost:* no scripted presence on a Hicasso shell until someone
writes that advance. *Benefit:* zero target-side surface and no re-opened ruling.

**Recommendation: C now, B if and when a Hicasso-hosted Story shell needs scripted presence.**
The reasoning is that A and B both require re-opening HD-019's settled refusal of a general commit
door — which is a **Hicasso architecture decision, not a Story migration**, and so belongs on a
Hicasso bead with Mike's ruling rather than inside this one. Meanwhile C costs nothing, because the
seam Story already ships is the extension point: no Story-side change is needed to support a Hicasso
host whenever one arrives.

## Row-by-row re-verification (premises re-derived from consumer code, not from the census)

| row | census premise | verdict |
|---|---|---|
| **S2** `tools/story/deps.edn` → `day8/re-frame2-freehand` | `:test`-alias only, "exists to compile S3" | **HELD, but INCOMPLETE** — see below |
| **S3** `play/presence_host.cljc` | requires `presence-runtime` unconditionally + `re-frame.freehand` under `#?@(:cljs …)`; reads `(:flush-render! v/adapter)`; calls `advance-clock!` | **HELD exactly** — read the whole file; all three claims are literal |
| **S4** `play/presence_cljs_test.cljc` | requires `presence-runtime` | **HELD** — L71 |
| **S5** `play/presence_freehand_dom_cljs_test.cljs` | requires `re-frame.freehand` + `.presence-runtime` | **HELD** — L112, L113 |
| **S6** `play/presence_real_clock_cljs_test.cljs` | requires `presence-runtime` | **HELD** — L57 |

**S2 is the one that moves.** The coordinate compiles S3, but `git grep -ln "re-frame.freehand" --
tools/story/` returns a fifth consumer the S2 row does not account for:
`test/re_frame/story/realworld_ui_consumer_cljs_test.cljs` L67 requires
`re-frame.freehand.presence-runtime` and drives a real retained exit through the shipped bridge.
That file is census row **S10 — FIXTURE-ONLY**, which this bead's fence explicitly keeps out of the
cluster. So **retiring S2-S6 would not retire the coordinate**: a consumer outside the presence rung
shares it. The commit in this PR records that in the comment, which previously implied the opposite.

The same comment also named two consumers that have never read Freehand — the view-tool consumer
reads `re-frame.ui.tool` (the `day8/re-frame2-ui` entry declared immediately above) and the
sub-override Provider is core's own `re-frame.adapter.sub-override-context`. Both corrected.

### The FIXTURE-ONLY fence was honoured

S1 and S7-S10 were not touched, not swept in, and not counted. S10 is named above only because it
consumes the S2 coordinate — a fact about S2, not a migration of S10.

## Both sides of the wire — Story does NOT have Pair's hole

The wire here is the late-bind hook token `:flush-presence!`: `presence_host.cljc` installs into it,
`runner_events/exec-flush-presence!` reads out of it. Unlike Pair, **three tests see both sides**,
and one asserts the token itself:

- `presence_cljs_test.cljc` L329 — `(is (identical? (story-presence/presence-flush-fn) (late-bind/get-fn :flush-presence!)) "installed into the SAME late-bind slot the executor reads")`.
  The literal wire token, asserted across the seam, driving the **shipped** `install!` rather than a copy.
- `presence_real_clock_cljs_test.cljs` L148-215 — the shipped bridge against the real framework
  clock, watching `presence-rt/pending-count` fall, **with a RED arm**
  (`real-playback-without-the-step-cannot-settle-the-retention`) proving the step is load-bearing.
- `presence_freehand_dom_cljs_test.cljs` L243/L493 — the same bridge asserted against real
  `document`, under both `v/adapter` and the shipped Reagent seating.

So the deletion-safety question for this cluster is answered by evidence, not by absence.

## An under-count in the census (reported, not fixed — that file is held)

`tools/story/src/re_frame/story/play/runner_events.cljc` sits in the "Named, not consumed" list of
`docs/design/hicasso/product/tool-consumer-census.md`. That is a **mis-classification**. L1080 is
inside `(runner/step-fail … {:message (str …)})` — a **runtime string a Story user reads** on a
`:cannot-run` refusal:

> `"… An app that renders Freehand views installs the verb by requiring re-frame.story.play.presence-host …"`

This is exactly the X13 class that `rf2-kqls` corrected for Xray's `registry.cljs`
(`js/console.warn`), and the same audit was not applied to Story. The word "Freehand" there is
untested — `presence_cljs_test.cljc` L305 asserts only on
`#"install-presence-flush!|presence-host"` — so it would go stale silently. The file's other hit
(L1104) and all of `runner.cljc` / `late_bind.cljc` / `presence.cljc` are genuine docstrings and
comments, so those stay correctly classified.

**Story's row count should read 11, not 10.** I did not edit the census: `docs/design/hicasso/product/**`
is held by two other workers.

## Story's spec

**Deliberately unchanged, and that is the answer to the standing obligation.** The census confirmed
Story carries no "same PR" spec-sync duty; only the weaker per-tool `spec/` convention in
`tools/README.md` applies. `tools/story/spec/017-Testing-Story.md` L1105-1118 already describes the
presence-host integration accurately — including that
`re-frame.story.play.presence/install-presence-flush!` "stays public for a host registering a
different advance", which is the sentence that makes Story's rung substrate-neutral by design.
Nothing in the spec became false. Recording a transient target-side blocker in a normative document
would be documenting the state of another artefact's backlog, so it belongs on the bead and in this
body instead.

**The finding worth carrying forward: Story's presence RUNG is already substrate-neutral. Only the
BRIDGE is Freehand-specific, and it is blocked on target-side surface rather than on any Story-side
coupling.** When Hicasso publishes a presence-clock door and a commit boundary, S3 becomes a small,
local edit.

## Quality gates

| gate | exit | note |
|---|---|---|
| `tools/story` `clojure -M:test` | **0** | 1847 tests, 6824 assertions, 0 failures, 0 errors. The artefact whose `deps.edn` this PR edits — running it *is* the proof the file still parses and resolves. This is CI's `jvm-tools-story` lane, which the fast-PR spine does not itself run. |
| `scripts/test-fast-pr.sh` | **0** | full pre-checkin spine, invoked from the worktree root |

Both exit codes were captured on the same command line and read back from the `.exit` file, not
inferred from a pipeline. No known-flake was hit (`read_profile_baseline_cljs_test` did not fire).

Not run, with reasons:

- **Story / Xray browser gates** — the change reaches no view, no build id and no scenario; it is a
  comment inside one `:test`-alias `deps.edn`.
- **`mkdocs build --strict`** — no file under `docs/` was touched.
- **`scripts/check_doc_slugs.py`** — no markdown was touched, so there is no anchor or link target
  to validate and no planted-anchor proof to give.
- **Bundle isolation** — unchanged by construction: nothing in `implementation/` was touched, and
  no `:require` was added anywhere.

`python scripts/check_fast_pr_gap.py --list` reports 96 required checks the spine does not decide;
none is reached by a comment-only edit to a per-artefact `deps.edn`.
