### PR TITLE
feat(gate): catch a retired hicasso bench coordinate as a STRING, not just a symbol (rf2-r4jy)

### DIFF
--- a/scripts/_test_fixtures/check_retired_spellings/coord/negative/bare_comment_provenance.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/coord/negative/bare_comment_provenance.cljc
@@ -1,0 +1,31 @@
+(ns fixture.coord.negative.bare-comment-provenance
+  "NEGATIVE fixture: the THREE places the shipped package names a prototype
+  coordinate BARE — no backticks — in a comment or a docstring. Reproduced
+  verbatim from
+  `implementation/hicasso/src/re_frame/hicasso/impl/{state.cljc,presence_react.cljs}`.
+
+  rf2-r4jy's brief named ONE of these (the state.cljc section header) and asked
+  whether to allowlist it or mask comments generally. Scanning the real surface
+  with comments unmasked answers it: there are three, the other two are
+  `[[wiki-link]]` doc references whose `[` grants token start exactly as the
+  header's `(` does, and any allowlist would grow with the next provenance
+  comment someone writes. Rule (d) masks comments; this fixture is what pins
+  that decision to the corpus that forced it.
+
+  All three are prose provenance into a frozen prototype tree, kept verbatim by
+  the freeze manifest, carried by NO refusal.")
+
+;; ---------------------------------------------------------------------------
+;; Errors — the lane's shape (front.presence/fail!)
+;; ---------------------------------------------------------------------------
+
+(defn step
+  "The React half of the presence machine.
+
+  that is what happens here — [[front.presence/step]] is idempotent, so"
+  [state]
+  state)
+
+(defn settle [state]
+  ;; The fix is the machine's own [[front.presence/settle]], the
+  state)

--- a/scripts/_test_fixtures/check_retired_spellings/coord/negative/refusal_message_prose.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/coord/negative/refusal_message_prose.cljc
@@ -1,0 +1,36 @@
+(ns fixture.coord.negative.refusal-message-prose
+  "NEGATIVE fixture: the two SHIPPED refusal MESSAGES that name the prototype
+  in backticked prose. Reproduced verbatim from
+  `implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs` (the
+  `:rf.error/no-frame-context` hint at :1738 and the `:rf.error/no-frame-prop`
+  hint at :1790).
+
+  These are the closest thing in the corpus to a false positive for the STRING
+  half of rule (d): a retired coordinate, inside a string literal, in shipped
+  code, unmasked by design. What keeps them green is that the rule requires the
+  ENTIRE literal to be the coordinate — these are sentences, so they carry
+  whitespace, and the literal cannot close before the first space.")
+
+(defn- resolve-frame-context! [frame-kw where]
+  (if (nil? frame-kw)
+    (fail! :rf.error/no-frame-context
+           where
+           (str "A Hicasso boundary rendered with no frame in scope. Mount the "
+                "tree under a frame boundary — `arm1.mount/root!` installs one.")
+           :mount-under-a-frame
+           {})
+    frame-kw))
+
+(defn- resolve-frame-prop! [frame-kw]
+  (if (nil? frame-kw)
+    (fail! :rf.error/no-frame-prop
+           're-frame.hicasso.impl.collector/frame-prop-shell
+           (str "A frame-fed Hicasso boundary rendered with no frame in its "
+                "props. Every boundary element below the root is minted by an "
+                "ancestor body, which carries the frame; the root and any "
+                "outward React bridge mint theirs outside a body and must name "
+                "it (`front.codec/root-element`, which `arm1.mount/render!` "
+                "calls).")
+           :mint-the-root-element-with-a-frame
+           {})
+    frame-kw))

--- a/scripts/_test_fixtures/check_retired_spellings/coord/negative/shipped_coordinates.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/coord/negative/shipped_coordinates.cljc
@@ -1,0 +1,26 @@
+(ns fixture.coord.negative.shipped-coordinates
+  "NEGATIVE fixture: the shipped shapes rf2-hic-007 moved the corpus ONTO —
+  a `:where` on the package's own namespace, and the corrected parity assertion
+  that reads the PACKAGE prefix instead of one file's. If rule (d) fired on
+  either, it would red the very fix it exists to protect.
+
+  The corrected assertion is the interesting half: it is still a string, still
+  compared with `str/starts-with?`, and still names a namespace prefix — so the
+  rule cannot be 'a string that looks like a coordinate'. It has to be
+  `front.`/`arm1.` specifically.")
+
+(defn- fail-here! [id reason]
+  (fail! id 're-frame.hicasso.impl.error/fail! reason :none {}))
+
+(defn hydrate-root! [el]
+  (fail! :rf.error/no-frame-context
+         're-frame.hicasso.impl.mount/hydrate-root!
+         "A Hicasso boundary rendered with no frame in scope."
+         :mount-under-a-frame
+         {:el el}))
+
+(deftest a-shared-row-is-raised-by-the-runtimes-own-guard
+  (is (seq (filter #(str/starts-with? (str (:where (:refuses %)))
+                                      "re-frame.hicasso.impl.")
+                   shared))
+      "at least one row's refusal is raised by the runtime's own guard"))

--- a/scripts/_test_fixtures/check_retired_spellings/coord/negative/spec_boundary_cases.md
+++ b/scripts/_test_fixtures/check_retired_spellings/coord/negative/spec_boundary_cases.md
@@ -1,0 +1,25 @@
+# NEGATIVE fixture (d, Markdown surface) — every boundary, unmasked
+
+Markdown is the surface where rule (d) has NO comment or string masking to fall
+back on, so it is the honest place to prove that each constraint in the pattern
+is doing its own work rather than riding on the mask. Every line below names a
+prototype coordinate and every one of them must stay green.
+
+* **A backtick denies token start.** `front.codec/realize-deep` and
+  `arm1.mount/render!` are provenance prose — the overwhelmingly common in-tree
+  spelling, and the one the fix hint tells authors to use.
+* **A preceding `.` denies token start.** The honest fully-qualified
+  re-frame.bench.hicasso.front.slot-cljs-test names the prototype tree
+  truthfully; it is not a coordinate anyone could mistake for a shipped one.
+  Same for re-frame.bench.hicasso.arm1.hydrate-dom-cljs-test.
+* **The namespace dot is mandatory.** arm1/host_hatch_dom_cljs_test is the
+  pervasive shorthand for a FILE in the prototype's arm1 directory, not a
+  namespace coordinate. Roughly twenty comments spell it that way.
+* **The `/` is mandatory.** front.sub-index, front.dogfood and front.intent name
+  retired MODULES in provenance prose and resolve to nothing executable.
+* **The string shape needs the coordinate to open the literal.** A whole
+  literal that is a *backticked* coordinate, "`front.codec/root-element`", is
+  denied by both patterns at once.
+
+The shipped spelling, for contrast:
+`re-frame.hicasso.impl.collector/frame-prop-shell`.

--- a/scripts/_test_fixtures/check_retired_spellings/coord/positive/assertion_string_arm1.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/coord/positive/assertion_string_arm1.cljc
@@ -1,0 +1,7 @@
+(ns fixture.coord.positive.assertion-string-arm1
+  "POSITIVE fixture (d/string): the `arm1.*` half, and a FULL coordinate rather
+  than the bare `front.codec/` prefix — the rule must not depend on the member
+  after `/` being absent.")
+
+(deftest the-refusal-names-its-raising-site
+  (is (= "arm1.mount/render!" (str (:where refusal)))))

--- a/scripts/_test_fixtures/check_retired_spellings/coord/positive/assertion_string_front.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/coord/positive/assertion_string_front.cljc
@@ -1,0 +1,17 @@
+(ns fixture.coord.positive.assertion-string-front
+  "POSITIVE fixture (d/string) — THE ONE THIS RULE EXISTS FOR.
+
+  Reproduces the rf2-hic-007 regression verbatim in shape: a GREEN test
+  assertion pinning a shipped refusal's `:where` to a benchmark-tree namespace
+  the shipped package does not contain. The coordinate is a STRING, so every
+  `'front.` scan is blind to it — including the two the sweep's own author used
+  to verify the close. It surfaced only in CI.
+
+  The symbol rule cannot see this line: string literals are masked before the
+  symbol pattern runs. The finding must come from the STRING pattern, and there
+  must be exactly one of them.")
+
+(deftest a-shared-row-is-raised-by-the-runtimes-own-guard
+  (is (seq (filter #(str/starts-with? (str (:where (:refuses %))) "front.codec/")
+                   shared))
+      "at least one row's refusal is raised by the runtime's own guard"))

--- a/scripts/_test_fixtures/check_retired_spellings/coord/positive/spec_code_block.md
+++ b/scripts/_test_fixtures/check_retired_spellings/coord/positive/spec_code_block.md
@@ -1,0 +1,11 @@
+# POSITIVE fixture (d/string, Markdown surface)
+
+A fenced example in the spec carries the same weight as a test assertion: a
+reader copies it. The string shape must fire inside a fence as it does in
+source, and the symbol pattern must NOT also fire on it — a coordinate opening
+a string literal is denied token start by the `"`, so this file yields exactly
+one finding, not two.
+
+```clojure
+(is (str/starts-with? (str (:where refusal)) "front.codec/"))
+```

--- a/scripts/_test_fixtures/check_retired_spellings/coord/positive/spec_prose.md
+++ b/scripts/_test_fixtures/check_retired_spellings/coord/positive/spec_prose.md
@@ -1,0 +1,9 @@
+# POSITIVE fixture (d/symbol, Markdown surface)
+
+`spec/009-Instrumentation.md` owns the `:where` coordinate contract, so a
+worked example there teaches whatever it spells. Markdown gets no
+comment/string masking — it has neither — so on `.md` the backtick token
+boundary is the whole prose defence, and an UNBACKTICKED coordinate must fire.
+
+The refusal below is raised by front.presence/settle, which is a namespace in
+the retired prototype tree and not in the shipped package.

--- a/scripts/_test_fixtures/check_retired_spellings/coord/positive/where_symbol_arm1.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/coord/positive/where_symbol_arm1.cljc
@@ -1,0 +1,12 @@
+(ns fixture.coord.positive.where-symbol-arm1
+  "POSITIVE fixture (d/symbol): the `arm1.*` half of the retired prototype
+  coordinate. `arm1.mount` is a NAMESPACE (dotted); the pervasive in-tree
+  `arm1/some_test` shorthand names a FILE and is a negative — see
+  coord/negative/bench_path_and_dir_shorthand.cljc.")
+
+(defn mount-root! [el]
+  (fail! :rf.error/no-frame-context
+         'arm1.mount/render!
+         "A Hicasso boundary rendered with no frame in scope."
+         :mount-under-a-frame
+         {:el el}))

--- a/scripts/_test_fixtures/check_retired_spellings/coord/positive/where_symbol_front.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/coord/positive/where_symbol_front.cljc
@@ -1,0 +1,14 @@
+(ns fixture.coord.positive.where-symbol-front
+  "POSITIVE fixture (d/symbol): a refusal raised with a `:where` naming the
+  retired prototype namespace `front.codec`. This is the OBVIOUS half of the
+  rule — the shape a symbol-aware grep would also have caught — and it is here
+  so the two shapes are proven independently of each other.")
+
+(defn- resolve-frame-prop! [frame-kw]
+  (if (nil? frame-kw)
+    (fail! :rf.error/no-frame-prop
+           'front.codec/root-element
+           "A frame-fed Hicasso boundary rendered with no frame in its props."
+           :mint-the-root-element-with-a-frame
+           {})
+    frame-kw))

--- a/scripts/check_retired_spellings.py
+++ b/scripts/check_retired_spellings.py
@@ -3,8 +3,8 @@
 
 EP-0007 rule 2 ("no stable accepted synonyms") gets the no-floor-lint
 treatment "where shapes allow": a *retired* spelling reappearing in
-repo source is a CI failure, not a doc note. Three renames have merged,
-so three retired spellings are now lintable:
+repo source is a CI failure, not a doc note. Four renames have merged,
+so four retired spellings are now lintable:
 
   (a) The bare `:frame` event-context COEFFECT (sweep item 1, rf2-1m6rf1).
       EP-0002 R3 "one carrier, one name" retired the duplicate `:frame`
@@ -26,6 +26,16 @@ so three retired spellings are now lintable:
       and it no longer widens the query-key promotion vocabulary. Carrying
       query state across routes is application policy spelled as a pure
       function over the destination address.
+
+  (d) A hicasso BENCH-TREE coordinate — `front.<ns>/<name>` or
+      `arm1.<ns>/<name>` (rf2-hic-007, rf2-r4jy). The shipped
+      `implementation/hicasso` package was measured as the prototype
+      `re-frame.bench.hicasso.{front,arm1}.*` and carries that tree's
+      provenance all through its prose, but the prototype is NOT in this
+      repo and no consumer can follow a coordinate into it. rf2-hic-007
+      moved 42 `:where` coordinates onto the package's own
+      `re-frame.hicasso.impl.*` namespaces; a coordinate naming `front.*`
+      or `arm1.*` is retired.
 
 WHY THE SHAPES ARE SCOPED PRECISELY (the "where shapes allow" caveat)
 
@@ -91,6 +101,46 @@ retired SHAPES:
       correct if the suffix filter is ever widened, and the self-test pins all
       five verbatim.
 
+  (d) TWO shapes, and the second one is the whole reason the rule exists:
+
+        - the SYMBOL   `'front.codec/root-element`, `arm1.mount/render!`
+        - the STRING   `"front.codec/"`
+
+      A `:where` is a symbol, so a symbol-shaped check is the obvious rule and
+      it is the one that misses. rf2-hic-007 moved the 42 coordinates, and CI
+      went red on `test_kit_runtime_parity_cljs_test`, whose row asserted
+      `(str/starts-with? (str (:where …)) "front.codec/")` — a GREEN test
+      holding a shipped refusal to a benchmark coordinate no consumer could
+      follow. It was a string; every `'front.` scan was blind to it, including
+      the two the sweep's own verification used. It surfaced only in CI, from
+      an assertion, in a file the sweep's author had already edited.
+
+      SYMBOL: the namespace segment carries a MANDATORY dot and the coordinate
+      a mandatory `/` (member optional, so the bare-prefix string `front.codec/`
+      is covered as a symbol too). Both are load-bearing prose defences:
+
+        * The dot rejects `arm1/host_hatch_dom_cljs_test` — the pervasive
+          in-tree shorthand for a FILE in the prototype's `arm1` directory, not
+          a namespace coordinate. ~20 comments spell it that way.
+        * The `/` rejects the bare namespace mentions (`front.sub-index`,
+          `front.dogfood`, `front.intent`), which name a retired MODULE in
+          provenance prose and resolve to nothing executable.
+        * Token start denies a preceding backtick — the same device rule (c)
+          uses — so `` `front.codec/realize-deep` `` in prose cannot fire even
+          where masking does not reach (a `.md` line, say). It also denies a
+          preceding `.`, so the honest fully-qualified
+          `re-frame.bench.hicasso.front.slot-cljs-test` stays green: that
+          spelling names the prototype tree truthfully and is not a coordinate
+          anyone could mistake for a shipped one.
+
+      STRING: a double-quoted literal whose ENTIRE content is such a
+      coordinate — the opening quote is immediately followed by `front.`/
+      `arm1.`, and the literal closes with no whitespace in between. That is
+      exactly the `str/starts-with?` / `=` comparison shape, and it is what
+      keeps the rule off the two shipped refusal MESSAGES that name the
+      prototype in backticked prose (`impl/collector.cljs:1738` and `:1790`) —
+      those literals are sentences, so they carry spaces and cannot match.
+
 WHERE A SHAPE IS TOO AMBIGUOUS TO LINT WITHOUT NOISE (documented, not shipped)
 
 EP-0007 §Enforcement says "where shapes allow"; two shapes are deliberately
@@ -116,6 +166,29 @@ code without unacceptable false-positive noise:
     framework-injected coeffect key set so a `:frame` coeffect cannot ride
     back IN even if a read of it slipped past this gate.
 
+  * A retired bench coordinate inside a `;` COMMENT. Rule (d) masks comments,
+    which is the same treatment rules (a)-(c) get and is decided on evidence
+    rather than convention. rf2-r4jy proposed allowlisting the one line the
+    audit had found — `impl/state.cljc:104`, the section header
+    `;; Errors — the lane's shape (front.presence/fail!)`, prose provenance
+    kept verbatim by the freeze manifest and carried by no refusal. Scanning
+    the real surface with comments UNMASKED finds THREE such lines, not one:
+    that header, plus `impl/presence_react.cljs:64` and `:121`, both
+    `[[front.presence/step]]` / `[[front.presence/settle]]` wiki-links whose
+    `[` grants token start exactly as the header's `(` does. So the allowlist
+    was never one line; it was three, and it would grow with every future
+    provenance comment — an allowlist that a correct edit keeps having to
+    extend is a maintenance tax that teaches people to extend it.
+
+    The cost is real and worth stating: masking blinds rule (d) to a comment
+    that LIES about where a refusal is raised. That is a documentation defect,
+    and this gate is not the thing that catches documentation defects — the
+    failure it exists to close was an EXECUTABLE assertion holding a shipped
+    refusal to a dead coordinate, which is a different and worse animal. A
+    stale comment misleads a reader; a stale assertion turns green and reds
+    someone else's PR. Note the asymmetry inside rule (d): comments are masked
+    but STRING LITERALS ARE NOT, because the string shape is the whole point.
+
 SCAN SURFACE
 
 Every Clojure source tree in the repo — `.clj` / `.cljc` / `.cljs` under
@@ -128,6 +201,28 @@ the retired spelling is gone (the `event_context_coeffect_keys_test` checks
 `:to` to assert the throw). A test fixture deliberately exercising a retired
 spelling is correct, not drift. Pass `--include-tests` to scan them too
 (used by the self-test fixtures, which live under a `test`-named dir).
+
+Rule (d) has its OWN surface (`COORD_SCAN_PATHS`) and its own suffix filter,
+and both differences are load-bearing:
+
+  * It scans `implementation/hicasso/test/**` — with no `--include-tests` opt,
+    unconditionally. The demonstrated regression WAS a test assertion, so a
+    coordinate rule that skipped test trees would be a rule that skips the only
+    place the failure has ever occurred. The other rules' reason for excluding
+    tests does not transfer: a hicasso test has no reason to assert that a
+    refusal still names the prototype, which is precisely what rf2-hic-007
+    found one doing.
+  * It adds `.md`, for the single file `spec/009-Instrumentation.md` — the spec
+    that owns the `:where` coordinate contract, where a worked example naming a
+    prototype coordinate would teach the retired spelling. Markdown gets no
+    comment/string masking (it has neither), so on `.md` the backtick token
+    boundary is the entire prose defence, which is why rule (d)'s symbol
+    pattern denies a preceding backtick everywhere rather than only there.
+  * It does NOT scan the whole repo. `docs/design/hicasso/**` is a working
+    design record of the prototype and names `front.*` / `arm1.*` throughout
+    on purpose; so does `implementation/hicasso`'s own freeze manifest. The
+    subject here is a coordinate a SHIPPED refusal can carry, and that is the
+    package's source, its tests, its test-kit and its spec.
 
 Exit code:
     0  no retired spelling in any scanned source tree
@@ -194,6 +289,21 @@ DEFAULT_SCAN_DIRS = (
 )
 
 _SOURCE_SUFFIXES = (".clj", ".cljc", ".cljs")
+
+# Rule (d)'s surface — the four paths a shipped hicasso refusal's `:where` can
+# reach: the package source, its tests (where rf2-hic-007's regression lived),
+# its test-kit, and the spec that owns the coordinate contract. Deliberately NOT
+# the whole repo; see SCAN SURFACE in the module docstring. Rostered paths are
+# required to exist for the same reason `DEFAULT_SCAN_DIRS` are: a skipped tree
+# reports success for a surface it never opened.
+COORD_SCAN_PATHS = (
+    "implementation/hicasso/src",
+    "implementation/hicasso/test",
+    "implementation/hicasso/test_kit",
+    "spec/009-Instrumentation.md",
+)
+
+_COORD_SUFFIXES = _SOURCE_SUFFIXES + (".md",)
 
 # Directory names whose contents are never scannable source for this gate.
 _EXCLUDE_DIR_NAMES = frozenset({
@@ -270,6 +380,31 @@ _RETIRED_QUERY_RETAIN_RE = re.compile(
     r"(?:^|(?<=[\s(\[{,]))"      # keyword-token start (a backtick denies it)
     r":query-retain"
     r"(?=[\s)\]},]|$)"           # keyword-token end
+)
+
+
+# (d) A retired hicasso bench-tree coordinate, in its TWO shapes.
+#
+# SYMBOL. `front.<ns>/<name>` or `arm1.<ns>/<name>` as a delimited Clojure
+# symbol token. The namespace dot and the `/` are both mandatory (the member
+# after `/` is not, so the bare prefix `front.codec/` matches); token start
+# denies a preceding backtick AND a preceding `.`. Each of those four
+# constraints is what keeps a specific class of in-tree provenance prose green
+# — see (d) under "WHY THE SHAPES ARE SCOPED PRECISELY".
+_RETIRED_COORD_SYMBOL_RE = re.compile(
+    r"(?:^|(?<=[\s(\[{,'~@^]))"            # token start; a backtick denies it
+    r"(?:front|arm1)\.[\w.+!*?<>=-]+"      # namespace segment; dot MANDATORY
+    r"/[\w.+!*?<>=-]*"                     # `/` mandatory, member optional
+)
+
+# STRING. A double-quoted literal whose ENTIRE content is such a coordinate:
+# the opening quote is immediately followed by `front.`/`arm1.` (so a leading
+# backtick denies it), and the literal closes with no whitespace anywhere in
+# between (so a prose sentence naming the coordinate can never match). This is
+# the `(str/starts-with? (str (:where …)) "front.codec/")` shape that went red
+# in CI — the one a symbol-shaped check cannot see.
+_RETIRED_COORD_STRING_RE = re.compile(
+    r'"(?:front|arm1)\.[^"\s]*/[^"\s]*"'
 )
 
 
@@ -370,6 +505,29 @@ def _masked_lines(text: str) -> list[str]:
     return masked
 
 
+def _comment_masked_lines(text: str) -> list[str]:
+    """Return per-line content with `;` comments blanked, STRINGS INTACT.
+
+    Rule (d)'s string shape LIVES inside a string literal, so `_masked_lines`
+    would blank the very thing it looks for. Comments still have to go: a
+    retirement note may quote the retired string verbatim, and a note is not a
+    reintroduction.
+
+    String masking is still used, but only to LOCATE the comment — so a `;`
+    inside a string literal does not open one — while the blanking is applied
+    to the RAW line. Length-preserving, like its sibling.
+    """
+    out: list[str] = []
+    in_string = False
+    for raw in text.splitlines():
+        probe, in_string = _mask_strings(raw, in_string)
+        m = _LINE_COMMENT_RE.search(probe)
+        out.append(
+            raw[: m.start()] + (" " * (len(raw) - m.start())) if m else raw
+        )
+    return out
+
+
 # --------------------------------------------------------------------------
 # File iteration
 # --------------------------------------------------------------------------
@@ -422,6 +580,28 @@ def _iter_source_files(scan_root: Path, include_tests: bool) -> Iterable[Path]:
         if not include_tests and (parts & _TEST_DIR_NAMES):
             continue
         yield path
+
+
+def _iter_coordinate_files(scan_root: Path) -> Iterable[Path]:
+    """Yield rule (d)'s scannable files under scan_root.
+
+    Two deliberate differences from `_iter_source_files`, both argued in the
+    module docstring's SCAN SURFACE section: `.md` is scannable (for
+    `spec/009-Instrumentation.md`), and there is NO test-dir exclusion and no
+    opt to reinstate one — the regression this rule exists to close was a test
+    assertion.
+    """
+    if scan_root.is_file():
+        if scan_root.suffix in _COORD_SUFFIXES:
+            yield scan_root
+        return
+    matches: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(scan_root):
+        dirnames[:] = [d for d in dirnames if d not in _EXCLUDE_DIR_NAMES]
+        for name in filenames:
+            if os.path.splitext(name)[1] in _COORD_SUFFIXES:
+                matches.append(Path(dirpath) / name)
+    yield from sorted(matches)
 
 
 # --------------------------------------------------------------------------
@@ -496,6 +676,57 @@ def scan(scan_root: Path, include_tests: bool = False) -> list[Finding]:
     return findings
 
 
+def _scan_coordinates(path: Path, text: str) -> list[Finding]:
+    """Return rule (d) findings — retired hicasso bench coordinates.
+
+    Rule (d) is the one rule in this gate that reads INSIDE string literals, so
+    it cannot share `_scan_text`'s single masked view. It takes two:
+
+      * the SYMBOL shape runs over the fully masked lines (strings + comments
+        blanked), the standard treatment — a coordinate spelled in prose is
+        provenance, not a reintroduction;
+      * the STRING shape runs over comment-masked lines with string literals
+        INTACT, because the literal is the subject.
+
+    Markdown gets neither: it has no Clojure comments and no Clojure strings,
+    and applying the state machine to prose would let a stray `"` blank a real
+    finding. On `.md` both patterns run raw, which is safe because the symbol
+    pattern's token boundary already denies a preceding backtick and the string
+    pattern already requires a whitespace-free whole literal.
+    """
+    findings: list[Finding] = []
+    raw = text.splitlines()
+    prose = path.suffix == ".md"
+    symbol_lines = raw if prose else _masked_lines(text)
+    string_lines = raw if prose else _comment_masked_lines(text)
+
+    def raw_snippet(line_no: int) -> str:
+        return raw[line_no - 1].strip() if 0 <= line_no - 1 < len(raw) else ""
+
+    for line_no, line in enumerate(symbol_lines, start=1):
+        if _RETIRED_COORD_SYMBOL_RE.search(line):
+            findings.append(
+                Finding(path, line_no, "retired-bench-coordinate:symbol",
+                        raw_snippet(line_no))
+            )
+    for line_no, line in enumerate(string_lines, start=1):
+        if _RETIRED_COORD_STRING_RE.search(line):
+            findings.append(
+                Finding(path, line_no, "retired-bench-coordinate:string",
+                        raw_snippet(line_no))
+            )
+    return findings
+
+
+def scan_coordinates(scan_root: Path) -> list[Finding]:
+    """Scan rule (d)'s surface under scan_root for retired bench coordinates."""
+    findings: list[Finding] = []
+    for path in _iter_coordinate_files(scan_root):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        findings.extend(_scan_coordinates(path, text))
+    return findings
+
+
 # --------------------------------------------------------------------------
 # Reporting
 # --------------------------------------------------------------------------
@@ -530,6 +761,19 @@ _FIX_HINTS = {
         "state across routes). To edit the CURRENT route's query, use the "
         "in-place `:query` / `:query-merge` request."
     ),
+    "retired-bench-coordinate": (
+        "A hicasso BENCH-TREE coordinate — `front.*` / `arm1.*` — was retired "
+        "by rf2-hic-007. The shipped package was measured as the prototype "
+        "`re-frame.bench.hicasso.{front,arm1}.*`, which is NOT in this repo: a "
+        "refusal whose `:where` names it points a consumer at nothing. Raise "
+        "from the package's own namespace — e.g. "
+        "`:where 're-frame.hicasso.impl.collector/frame-prop-shell` — and "
+        "assert against the PACKAGE prefix `\"re-frame.hicasso.impl.\"` rather "
+        "than one file's, so the next move of a guard between `impl` "
+        "namespaces does not red the row. If you are writing PROSE about the "
+        "prototype, backtick it (`` `front.codec/realize-deep` ``): a "
+        "backticked mention is provenance and this rule never fires on one."
+    ),
 }
 
 
@@ -561,7 +805,8 @@ def main(argv: list[str]) -> int:
         description=(
             "EP-0007 §Enforcement: fail on a retired spelling reappearing in "
             "repo source (the bare :frame coeffect; redirect :url/:to; "
-            "route :query-retain)."
+            "route :query-retain; a hicasso front.*/arm1.* bench coordinate, "
+            "as a symbol OR as a string)."
         ),
     )
     parser.add_argument(
@@ -577,7 +822,8 @@ def main(argv: list[str]) -> int:
         help=(
             "Directory (relative to repo-root) to scan. Repeatable. Defaults to "
             "every Clojure source tree in the repo: "
-            f"{', '.join(DEFAULT_SCAN_DIRS)}."
+            f"{', '.join(DEFAULT_SCAN_DIRS)}. Scopes rules (a)-(c) only; the "
+            "bench-coordinate rule (d) has a fixed roster and always runs."
         ),
     )
     parser.add_argument(
@@ -585,7 +831,8 @@ def main(argv: list[str]) -> int:
         action="store_true",
         help=(
             "Scan test/ trees too. Off by default — tests legitimately name "
-            "the retired spelling to assert it is gone / rejected."
+            "the retired spelling to assert it is gone / rejected. Does not "
+            "apply to rule (d), which scans hicasso tests unconditionally."
         ),
     )
     parser.add_argument(
@@ -618,12 +865,16 @@ def main(argv: list[str]) -> int:
 
     scan_dirs = args.scan_dirs or list(DEFAULT_SCAN_DIRS)
     scan_roots = [repo_root / d for d in scan_dirs]
+    coord_roots = [repo_root / p for p in COORD_SCAN_PATHS]
 
     # A rostered tree that has been renamed or deleted is NOT skipped. Skipping
     # is how a widened gate quietly narrows again — it would report success for
     # a tree it never opened, which is the whole defect class rf2-kqxe6.25 is
     # about. Same posture as the test-lane bijection gate's phantom-path rule.
-    missing = [r for r in scan_roots if not r.exists()]
+    # Rule (d)'s roster gets the identical treatment, and needs it more: three
+    # of its four entries are hicasso subtrees, and a package reorganisation
+    # that renamed one would otherwise silently unratchet the rule.
+    missing = [r for r in scan_roots + coord_roots if not r.exists()]
     if missing:
         for root in missing:
             sys.stderr.write(f"error: scan dir {root} does not exist.\n")
@@ -640,10 +891,17 @@ def main(argv: list[str]) -> int:
             f"{', '.join(str(r.relative_to(repo_root)) for r in scan_roots)} "
             f"(tests {'included' if args.include_tests else 'excluded'})...\n"
         )
+        c = sum(1 for root in coord_roots for _ in _iter_coordinate_files(root))
+        sys.stderr.write(
+            f"scanning {c} file(s) under {', '.join(COORD_SCAN_PATHS)} for "
+            "retired bench coordinates (tests always included)...\n"
+        )
 
     findings: list[Finding] = []
     for root in scan_roots:
         findings.extend(scan(root, include_tests=args.include_tests))
+    for root in coord_roots:
+        findings.extend(scan_coordinates(root))
     if findings:
         _report(findings, repo_root)
         return 1
@@ -682,6 +940,27 @@ _SANCTIONED_PROSE_MENTIONS: tuple[tuple[str, str], ...] = (
      "must now be declared in `:query` / `:query-defaults`."),
 )
 
+# Rule (d) fixtures, scanned through `scan_coordinates` rather than `scan` —
+# different surface, different masking, so a separate roster. Each POSITIVE
+# plants exactly one shape and expects exactly one finding, which is itself an
+# assertion: a coordinate must not be double-reported by both patterns.
+_COORD_SELF_TEST_CASES: tuple[tuple[str, int], ...] = (
+    # --- positives: BOTH shapes must fire, in source AND in Markdown ---
+    ("coord/positive/where_symbol_front.cljc",     1),
+    ("coord/positive/where_symbol_arm1.cljc",      1),
+    # The two that a symbol-shaped check cannot see — the rf2-hic-007 blind
+    # spot, which is the entire reason rule (d) exists.
+    ("coord/positive/assertion_string_front.cljc", 1),
+    ("coord/positive/assertion_string_arm1.cljc",  1),
+    ("coord/positive/spec_prose.md",               1),
+    ("coord/positive/spec_code_block.md",          1),
+    # --- negatives: the corpus's real provenance prose must stay GREEN ---
+    ("coord/negative/bare_comment_provenance.cljc", 0),
+    ("coord/negative/refusal_message_prose.cljc",   0),
+    ("coord/negative/shipped_coordinates.cljc",     0),
+    ("coord/negative/spec_boundary_cases.md",       0),
+)
+
 
 def _run_self_tests(verbose: bool = False) -> int:
     """Scan each fixture file and assert the expected finding count.
@@ -695,6 +974,13 @@ def _run_self_tests(verbose: bool = False) -> int:
     A second phase scans `_SANCTIONED_PROSE_MENTIONS` — verbatim retirement
     notes from trees this gate does not scan, where no masking applies — as raw
     lines, so the shape scoping is proven independently of the masking.
+
+    A third phase runs `_COORD_SELF_TEST_CASES` through `scan_coordinates`.
+    Rule (d) needs its own phase because it needs its own scanner: it reads
+    INSIDE string literals and it accepts `.md`. Its negatives are reproduced
+    verbatim from the shipped hicasso corpus, so a future widening of the rule
+    that would red real files fails here first, in this repo, rather than in
+    someone else's PR.
     """
     cases: list[tuple[str, int]] = [
         # (fixture-file relative to fixture-root, expected finding count)
@@ -759,11 +1045,34 @@ def _run_self_tests(verbose: bool = False) -> int:
             )
             failures += 1
 
+    # Phase 3: rule (d), through its own scanner. Same direct-file mode, but
+    # `scan_coordinates` — rule (d) reads inside string literals and accepts
+    # `.md`, neither of which `scan` does.
+    for fixture, expected in _COORD_SELF_TEST_CASES:
+        path = _SELF_TEST_FIXTURE_ROOT / fixture
+        if not path.is_file():
+            sys.stderr.write(
+                f"self-test FAIL: fixture {fixture!r} missing at {path}\n"
+            )
+            failures += 1
+            continue
+        got = len(scan_coordinates(path))
+        if got == expected:
+            if verbose:
+                sys.stderr.write(f"self-test PASS: {fixture} (findings={got})\n")
+        else:
+            sys.stderr.write(
+                f"self-test FAIL: {fixture} expected findings={expected}, "
+                f"got {got}\n"
+            )
+            failures += 1
+
     if failures:
         sys.stderr.write(f"\n{failures} self-test failure(s).\n")
         return 1
     if verbose:
-        total = len(cases) + len(_SANCTIONED_PROSE_MENTIONS)
+        total = (len(cases) + len(_SANCTIONED_PROSE_MENTIONS)
+                 + len(_COORD_SELF_TEST_CASES))
         sys.stderr.write(f"all {total} self-tests passed.\n")
     return 0
 


### PR DESCRIPTION
Closes rf2-r4jy.

## The failure this closes

`rf2-hic-007` moved 42 `:where` coordinates off the retired prototype namespaces `front.*` / `arm1.*`, and CI went red on `test_kit_runtime_parity_cljs_test.cljs`, whose row asserted:

```clojure
(str/starts-with? (str (:where (:refuses %))) "front.codec/")
```

A **green test** holding a shipped refusal to a benchmark-tree coordinate the shipped package does not contain. It was a **string**, so every `'front.` scan was blind to it — including the two greps used to verify that bead's close. It surfaced only in CI, from an assertion, in a file the sweep's own author had already edited.

Per the ruling: a rule in the **existing** `scripts/check_retired_spellings.py`, not a second checker. `front.*` / `arm1.*` are retired spellings by any reading, and a new checker would duplicate this one's prose + self-test machinery for one pattern.

## The rule as written

Rule (d), two patterns, because a symbol-only rule reproduces the exact blind spot:

```python
_RETIRED_COORD_SYMBOL_RE = re.compile(
    r"(?:^|(?<=[\s(\[{,'~@^]))"            # token start; a backtick denies it
    r"(?:front|arm1)\.[\w.+!*?<>=-]+"      # namespace segment; dot MANDATORY
    r"/[\w.+!*?<>=-]*"                     # `/` mandatory, member optional
)

_RETIRED_COORD_STRING_RE = re.compile(
    r'"(?:front|arm1)\.[^"\s]*/[^"\s]*"'
)
```

Every constraint is load-bearing against a real class of in-tree provenance prose, which is why the pattern is not simply `front\.`:

| constraint | keeps green |
|---|---|
| namespace dot mandatory | `arm1/host_hatch_dom_cljs_test` — the shorthand for a FILE in the prototype's `arm1` directory (~20 comments) |
| `/` mandatory | `front.sub-index`, `front.dogfood`, `front.intent` — retired MODULE names in prose |
| backtick denies token start | `` `front.codec/realize-deep` `` — the overwhelmingly common in-tree spelling |
| `.` denies token start | `re-frame.bench.hicasso.front.slot-cljs-test` — the honest fully-qualified prototype path |
| string must be the WHOLE literal | the two **shipped refusal messages** at `impl/collector.cljs:1738` and `:1790`, which name the prototype in backticked prose inside a string — sentences carry spaces, so the literal cannot close |

**Masking is asymmetric inside rule (d), and deliberately so**: the symbol shape runs over fully masked lines (strings + comments blanked, the standard treatment); the string shape runs over **comment-masked lines with string literals intact**, because the literal is the subject. A new `_comment_masked_lines()` provides the second view — it uses string masking only to *locate* the comment (so a `;` inside a literal does not open one) and blanks the raw line.

## Scan surface

Rule (d) carries its own roster (`COORD_SCAN_PATHS`) and suffix filter, with the same phantom-path posture as `DEFAULT_SCAN_DIRS` (a renamed tree is an error, not a skip):

- `implementation/hicasso/src/**`, `implementation/hicasso/test/**`, `implementation/hicasso/test_kit/**`, `spec/009-Instrumentation.md` — 90 files.
- **Tests are scanned unconditionally**, with no `--include-tests` opt. The other rules exclude test trees because tests legitimately assert a retired spelling is gone; that reason does not transfer, and a coordinate rule skipping test trees would skip the only place the failure has ever occurred.
- `.md` is added for `spec/009-Instrumentation.md`, which owns the `:where` contract. Markdown gets no masking (it has neither Clojure comments nor Clojure strings), so there the backtick token boundary is the entire prose defence — which is why the symbol pattern denies a preceding backtick everywhere rather than only there.
- Deliberately **not** the whole repo: `docs/design/hicasso/**` and hicasso's freeze manifest name `front.*` / `arm1.*` throughout on purpose.

## The `state.cljc:104` exclusion — comments are masked, and the corpus is why

The brief named one line to protect (`;; Errors — the lane's shape (front.presence/fail!)`) and asked: exclude comments generally, or allowlist that line?

**Comments are masked.** Not as a formality — scanning the real surface with comments *unmasked* finds **three** bare provenance mentions, not one:

| file:line | text | why token start is granted |
|---|---|---|
| `impl/state.cljc:104` | `;; Errors — the lane's shape (front.presence/fail!)` | `(` |
| `impl/presence_react.cljs:64` | `that is what happens here — [[front.presence/step]] is idempotent, so` | `[` (a **docstring**, not a comment) |
| `impl/presence_react.cljs:121` | `;; The fix is the machine's own [[front.presence/settle]], the` | `[` |

So the allowlist was never one line; it was three, and it would grow with every future provenance comment — an allowlist a *correct* edit keeps having to extend teaches people to extend it.

The cost is real and is stated in the docstring rather than glossed: **masking blinds rule (d) to a comment that lies** about where a refusal is raised. That is a documentation defect, and this gate is not what catches documentation defects. The failure it exists to close was an *executable* assertion holding a shipped refusal to a dead coordinate — a different and worse animal. A stale comment misleads a reader; a stale assertion turns green and reds someone else's PR.

All three lines are pinned verbatim as a negative fixture (`coord/negative/bare_comment_provenance.cljc`), so the decision is anchored to the corpus that forced it.

## Proof it bites — both shapes, on real files, verified by hash

Planted byte-exactly (no `sed -i`, so CRLF was never rewritten), run, restored with `git checkout --`, and confirmed with sha256 **before and after** — `git diff` is not evidence on Windows.

**1. STRING shape** — the rf2-hic-007 regression restored verbatim in `implementation/hicasso/test/re_frame/hicasso/test_kit_runtime_parity_cljs_test.cljs` (a **test** file, so this also proves the test-tree widening):

```
1 retired spelling(s) found in repo source (EP-0007 §Enforcement):

  retired-bench-coordinate:string: implementation\hicasso\test\re_frame\hicasso\test_kit_runtime_parity_cljs_test.cljs:390
      "front.codec/")
```

exit 1 · sha256 `5f17597a…cf2f8a93` → planted `c6d7f089…0d3a8d9c` → restored `5f17597a…cf2f8a93`

**2. SYMBOL shape** — `impl/mount.cljs:240`, `:where 're-frame.hicasso.impl.mount/hydrate-root!` → `'front.codec/hydrate-root!`:

```
1 retired spelling(s) found in repo source (EP-0007 §Enforcement):

  retired-bench-coordinate:symbol: implementation\hicasso\src\re_frame\hicasso\impl\mount.cljs:240
      :where    'front.codec/hydrate-root!
```

exit 1 · sha256 `429e2328…b971f75b8` → planted `8d98514c…cfc156dc` → restored `429e2328…b971f75b8`

**3. Markdown surface** — `spec/009-Instrumentation.md:1784`, proving the roster actually reaches the fourth path:

```
  retired-bench-coordinate:symbol: spec\009-Instrumentation.md:1784
      :where       'front.codec/<surface>          ;; the user-facing fn symbol that threw
```

exit 1 · sha256 `10ab8478…bac79d4f` → planted `77ca3e5c…a0559d97` → restored `10ab8478…bac79d4f`

Each run also emits the fix hint, which names the package spelling **and** the package-*prefix* assertion (`"re-frame.hicasso.impl."` rather than one file's), so the next move of a guard between `impl` namespaces does not red the row again.

## No existing file is newly red

`python scripts/check_retired_spellings.py --verbose` is green on this branch's clean tree: 90 files scanned by rule (d), 0 findings. The three bare comment/docstring mentions above are the only near-misses in the corpus and all are masked.

## Self-test corpus

Ten new fixtures under `scripts/_test_fixtures/check_retired_spellings/coord/`, run through a third self-test phase (rule (d) needs its own scanner: it reads inside string literals and accepts `.md`). Every positive expects **exactly one** finding, which is itself an assertion that a coordinate is not double-reported by both patterns.

- **positives** — symbol and string, `front.` and `arm1.`, in `.cljc` **and** in `.md` (prose + fenced block).
- **negatives** — the three bare provenance mentions, the two shipped refusal messages, the shipped coordinates plus the *corrected* package-prefix assertion (still a string, still `str/starts-with?`, still a namespace prefix — so the rule cannot be "a string that looks like a coordinate"), and a Markdown fixture carrying every boundary case unmasked.

`python scripts/check_retired_spellings.py --self-test --verbose` → **33/33 pass** (was 23).

## Quality gates

| gate | exit | note |
|---|---|---|
| `python scripts/check_retired_spellings.py --self-test --verbose` | **0** | 33/33, up from 23 |
| `python scripts/check_retired_spellings.py --verbose` | **0** | 1027 files rules (a)-(c) + 90 files rule (d), 0 findings |
| planted STRING shape (real test file) | **1** | intended; restored, sha256-verified |
| planted SYMBOL shape (real src file) | **1** | intended; restored, sha256-verified |
| planted `.md` shape (`spec/009`) | **1** | intended; restored, sha256-verified |
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`; gate root `/c/Users/miket/code/re-frame2-worktrees/strshape-r4jy`; classified `docs=true jvm=false node=false`. Both `check_retired_spellings` stages run inside it, so the spine is both this PR's gate and its subject. |

Not run, with reason:

- **JVM artefact suites** — the spine classified `implementation_jvm` unchanged. This diff is Python under `scripts/` plus fixture files; it compiles no Clojure.
- **npm/CLJS/isolation** — `cljs_node_test` surface unchanged, same reason.
- **Browser lanes, prod-elision / bundle-isolation / perf gates, adapter probes + smokes, Xray feature matrix, mcp-conformance, tool JVM suites** — CI-only, in no tier of this spine (per its own PASS line and `TESTING.md`).
- **`scripts/check_fast_pr_gap.py --list`** — run to derive the gap: 96 required checks this spine does not decide. None is reachable from a Python-only `scripts/` diff; the two that gate this file (`check_retired_spellings` self-test + live scan, in `test.yml`'s always-on Python job) both run above.
- **`mkdocs build --strict`** — ran inside the spine's documentation tier (armed, `docs=true`).
