### PR TITLE
fix(core): key the adapter use-frame memo on the frame incarnation (rf2-40kv)

### DIFF
--- a/docs/api/re-frame.adapter.uix.md
+++ b/docs/api/re-frame.adapter.uix.md
@@ -91,7 +91,7 @@ For narrative coverage and the substrate decision set, see [Use UIx or reagent-s
   `capture-frame` is *the* hold primitive; `reg-view` injection (Reagent) and `use-frame` (UIx) are its two ergonomic spellings — one primitive, three faces.
 
   - Frame resolution matches `use-subscribe`: `with-frame` dynamic scope first, then the surrounding `frame-provider` / `frame-root` via React context. It raises `:rf.error/no-frame-context` when neither is in scope.
-  - The returned map is reference-stable across re-renders for the same resolved frame (safe in effect deps and child props); a provider swap re-renders the caller and yields a map locked to the new frame.
+  - The returned map is reference-stable across re-renders for the same resolved frame *incarnation* (safe in effect deps and child props). A provider swap re-renders the caller and yields a map locked to the new frame — and so does destroying the resolved frame and creating another under the same id, because a frame keyword is an address and the ops bundle is pinned to the incarnation it was captured against.
   - No options map, no variants — for an explicit frame, call `(rf/capture-frame frame-id)` directly.
 - **Example**:
   ```clojure

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -159,10 +159,14 @@
   Resolution matches the ambient `use-subscribe`: dynamic-var tier first,
   then the surrounding `frame-provider` / `frame-root` via React context;
   no scope raises `:rf.error/no-frame-context`. The returned map is
-  reference-stable across re-renders for the same resolved frame (safe in
-  effect deps / child props); a provider swap re-renders the caller and
-  yields a map locked to the new frame. No options map, no variants — for
-  an explicit frame call `(rf/capture-frame frame-id)` directly."
+  reference-stable across re-renders for the same resolved frame
+  INCARNATION (safe in effect deps / child props); a provider swap
+  re-renders the caller and yields a map locked to the new frame, and so
+  does destroying the resolved frame and creating another under the same
+  id — a frame keyword is an address, and the bundle is pinned to the
+  incarnation it was captured against (rf2-40kv). No options map, no
+  variants — for an explicit frame call `(rf/capture-frame frame-id)`
+  directly."
   use-frame-hook/use-frame)
 
 (def flush-views!

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -427,6 +427,13 @@
 (deftest use-frame-capture-frame-in-hook-position
   (suite/assert-use-frame-capture-frame-in-hook-position cfg))
 
+;; rf2-40kv — the same memo across a same-id REINCARNATION. The row above
+;; pins that a re-render returns the identical map; this one pins what that
+;; memo is keyed on, because a frame keyword is `=` across a destroy +
+;; same-id create and the bundle is pinned to an incarnation.
+(deftest use-frame-retargets-across-a-same-id-reincarnation
+  (suite/assert-use-frame-retargets-across-a-same-id-reincarnation cfg))
+
 ;; rf2-4mi2zj — 1-arg full frame-resolution chain (the bug: spine fed the
 ;; raw use-context read into the explicit 2-arg path, bypassing the chain).
 (deftest use-subscribe-provider-tier-resolution-ambient-cleared

--- a/implementation/core/src/re_frame/adapter/use_frame.cljs
+++ b/implementation/core/src/re_frame/adapter/use_frame.cljs
@@ -34,14 +34,31 @@
   `:rf.error/no-frame-context`). No scope, no `:rf/default` floor — absence
   fails loud, exactly as the no-arg `capture-frame` does.
 
-  ## Reference stability
+  ## Reference stability, and what it is keyed on
 
   The returned ops map is REFERENCE-STABLE across re-renders for the same
-  resolved frame (safe in `useEffect` deps / memoized child props): a
-  render-phase `useRef` memo-by-value keyed on the resolved frame by CLJS
-  `=` (the rf2-mwft2 discipline — CLJS keywords are not `Object.is`-stable,
-  so a raw deps-array memo would rebuild per render). A provider swap
-  re-renders the caller and returns a fresh map locked to the new frame."
+  resolved frame INCARNATION (safe in `useEffect` deps / memoized child
+  props): a render-phase `useRef` memo-by-value keyed on the resolved
+  frame by CLJS `=` (the rf2-mwft2 discipline — CLJS keywords are not
+  `Object.is`-stable, so a raw deps-array memo would rebuild per render)
+  AND on that frame's incarnation token by `identical?`. A provider swap
+  re-renders the caller and returns a fresh map locked to the new frame.
+
+  The incarnation half is load-bearing (rf2-40kv). A frame keyword is an
+  ADDRESS, not an identity: destroy `:watchlist` and create another under
+  the same id and the two are `=`, while `capture-frame` PINS the exact
+  incarnation live when it ran (rf2-9pyles / rf2-tdjv7p — every op on the
+  bundle refuses a superseded target rather than leaking into its
+  successor). A memo keyed on the keyword alone therefore passes every
+  stability test and fails exactly this one: it keeps handing out the DEAD
+  incarnation's bundle for the rest of the mount, and every dispatch and
+  subscribe through it recover-but-emits `:rf.error/frame-destroyed`
+  against a frame the caller can plainly see is alive. Keying on
+  `frame/frame-incarnation-token` — the `:drain-lock` identity, constant
+  across one incarnation and distinct across a reconstruction — makes the
+  reincarnation a memo MISS, so the next render carries ops pinned to the
+  successor. This is the same rule Hicasso's `n/use-frame` keeps by
+  memoising on the runtime's incarnation row."
   (:require ["react" :as React]
             [re-frame.adapter.context :as adapter-context]
             [re-frame.core :as rf-core]
@@ -69,8 +86,11 @@
   in the dispatch opts cannot override it.
 
   The returned map is reference-stable across re-renders for the same
-  resolved frame; a surrounding provider swapping frames re-renders the
-  caller and yields a map locked to the new frame.
+  resolved frame INCARNATION; a surrounding provider swapping frames
+  re-renders the caller and yields a map locked to the new frame, and so
+  does destroying the resolved frame and creating another under the same
+  id — the bundle is pinned to the incarnation it was captured against,
+  never to the address.
 
   No options map and no explicit-frame arity — this is capture-frame in
   hook position, nothing more. For an explicit frame there is no hook tax:
@@ -87,13 +107,23 @@
         ref   (React/useRef nil)
         frame (frame/require-current-frame!
                 :use-frame {:where 're-frame.adapter.use-frame/use-frame})
+        ;; The identity half of the key (rf2-40kv). `capture-frame` pins the
+        ;; incarnation live when IT runs; read the same identity here so the
+        ;; memo's notion of "same frame" is the bundle's. nil — the id is not
+        ;; live at render — is a legitimate key: the bundle it pairs with is
+        ;; the unpinned, address-directed capture, and the frame appearing
+        ;; later moves the token off nil and correctly misses.
+        token (frame/frame-incarnation-token frame)
         prev  (.-current ref)]
     ;; Render-phase memo-by-value (rf2-mwft2 pattern): rebuild the ops map
-    ;; ONLY when the resolved frame changes by `=`. The ref write during
-    ;; render is sanctioned for exactly this pattern — idempotent given
-    ;; identical inputs, never mutated after commit.
-    (if (and (some? prev) (= (aget prev 0) frame))
-      (aget prev 1)
+    ;; ONLY when the resolved frame changes by `=` OR its incarnation changes
+    ;; by `identical?`. The ref write during render is sanctioned for exactly
+    ;; this pattern — idempotent given identical inputs, never mutated after
+    ;; commit.
+    (if (and (some? prev)
+             (= (aget prev 0) frame)
+             (identical? (aget prev 1) token))
+      (aget prev 2)
       (let [ops (rf-core/capture-frame frame)]
-        (set! (.-current ref) #js [frame ops])
+        (set! (.-current ref) #js [frame token ops])
         ops))))

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -3678,6 +3678,107 @@
             (finally
               (try (.unmount root) (catch :default _ nil))))))))))
 
+(defn assert-use-frame-retargets-across-a-same-id-reincarnation
+  "rf2-40kv: the hook's render-phase memo is keyed on the frame's
+  INCARNATION, not on its keyword — so destroying the resolved frame and
+  creating another under the same id makes the memo MISS and the next
+  render carries ops pinned to the successor.
+
+  WHY A KEYWORD KEY IS NOT ENOUGH, which is the whole of this row. A frame
+  keyword is an ADDRESS: `:f` is `=` to `:f` across a reincarnation, while
+  `capture-frame` PINS the exact incarnation live when it ran (rf2-9pyles /
+  rf2-tdjv7p) and every op on the bundle refuses a superseded target. So a
+  memo keyed on the keyword alone passes the stability row above and fails
+  here — silently, because the bundle it keeps handing out still reports
+  `:frame :f` and still compares `=` to a live one. THAT is why nothing
+  below is an equality assertion: the dead and the live bundle are `=`.
+  What separates them is object identity and what a dispatch through them
+  DOES.
+
+  Four things pinned, in one mount so the control and the law share a
+  fiber (and therefore share the one `useRef` cell the memo lives in):
+
+    1. PREMISE — destroy + same-id create yields a DIFFERENT incarnation
+       token under one public keyword.
+    2. CONTROL — a re-render that changed no frame still returns the
+       IDENTICAL map. Without this row a fix that simply rebuilt every
+       render would pass 3 and 4 while destroying the reference stability
+       `useEffect` deps and memoised child props depend on.
+    3. IDENTITY — after the reincarnation the map is a DIFFERENT object.
+    4. THE OBSERVABLE — a `dispatch-sync` off the post-reincarnation map
+       moves the LIVE frame's app-db, and one off the pre-reincarnation
+       map moves nothing (core's fence recovers it rather than letting it
+       write whoever occupies the address now).
+
+  cfg keys: `:name`, `:substrate-kw`, `:frame-provider-mount-element`,
+  `:probe-use-frame-element`, `:use-frame-observed` — the same probe the
+  stability assertion above drives; nothing substrate-specific is added."
+  [{:keys [name substrate-kw frame-provider-mount-element
+           probe-use-frame-element use-frame-observed]}]
+  (testing (str name " — use-frame retargets across a same-id reincarnation (rf2-40kv)")
+    (with-browser-act
+     (fn [act-fn]
+      ;; Clear the fixture's ambient `:rf/default` dynamic scope so the
+      ;; provider tier is the genuine decider (the rf2-4mi2zj masking note).
+      (binding [frame/*current-frame* nil]
+        (let [uf-frame (mint-kw substrate-kw "use-frame-reincarnation")]
+          (reset! use-frame-observed [])
+          (rf/reg-event ::reincarnation-set (fn [_ [_ n]] {:db {:n n}}))
+          (rf/make-frame {:id uf-frame :doc "use-frame reincarnation probe — incarnation A"})
+          (rf/dispatch-sync [::reincarnation-set 1] {:frame uf-frame})
+          (let [mount-node (make-mount-node!)
+                root       (react-dom-client/createRoot mount-node)
+                render!    #(act-fn (fn [] (.render root (frame-provider-mount-element
+                                                           uf-frame (probe-use-frame-element)))))]
+            (try
+              (render!)
+              (let [ops-1   (peek @use-frame-observed)
+                    token-1 (frame/frame-incarnation-token uf-frame)]
+                ;; 2. CONTROL — a re-render under the SAME incarnation must
+                ;; still hit the memo. Runs before the reincarnation so the
+                ;; two outcomes are read off one mount and one ref cell.
+                (render!)
+                (is (identical? ops-1 (peek @use-frame-observed))
+                    "same incarnation ⇒ IDENTICAL ops map (the memo still hits)")
+
+                ;; The reincarnation. Same public id, different object — and
+                ;; the mounted probe is told nothing by it, which is exactly
+                ;; what makes the defect silent.
+                (rf/destroy-frame! uf-frame)
+                (rf/make-frame {:id uf-frame :doc "use-frame reincarnation probe — incarnation B"})
+                (rf/dispatch-sync [::reincarnation-set 100] {:frame uf-frame})
+                (let [token-2 (frame/frame-incarnation-token uf-frame)]
+                  ;; 1. PREMISE.
+                  (is (not (identical? token-1 token-2))
+                      "a DIFFERENT incarnation now occupies the same public id")
+
+                  (render!)
+                  (let [ops-2 (peek @use-frame-observed)]
+                    ;; 3. IDENTITY — never `=`: the two bundles compare equal
+                    ;; on every readable key, which is the defect's disguise.
+                    (is (not (identical? ops-1 ops-2))
+                        (str "the ops map RETARGETED. A `useRef` memo keyed on the "
+                             "resolved frame by `=` alone hits here — the keyword is "
+                             "`=` across a reincarnation — and serves incarnation A's "
+                             "bundle for the rest of the mount"))
+                    (is (= uf-frame (:frame ops-2))
+                        "and it is still the provider's frame")
+
+                    ;; 4. THE OBSERVABLE — the live incarnation moves.
+                    (act-fn (fn [] ((:dispatch-sync ops-2) [::reincarnation-set 7])))
+                    (is (= 7 (:n (rf/app-db-value uf-frame)))
+                        "the post-reincarnation bundle WRITES the live incarnation")
+
+                    ;; …and the dead one does not. Core's capture fence
+                    ;; (rf2-9pyles) recovers it; the point here is that a hook
+                    ;; still handing this bundle out is not a harmless memo
+                    ;; hit — it is a consumer whose every dispatch is dropped.
+                    (act-fn (fn [] ((:dispatch-sync ops-1) [::reincarnation-set 999])))
+                    (is (= 7 (:n (rf/app-db-value uf-frame)))
+                        "the pre-reincarnation bundle writes NOTHING — it is pinned to a frame that no longer exists"))))
+              (finally
+                (try (.unmount root) (catch :default _ nil)))))))))))
+
 (defn assert-use-subscribe-2-arg-pins-explicit-frame
   "rf2-rcgsc / rf2-y0db2: use-subscribe's 2-arg form
   `(use-subscribe frame-kw query-v)` reads from the named frame's app-db,


### PR DESCRIPTION
Closes rf2-40kv.

## The defect, and the premise verified first

`re-frame.adapter.use-frame/use-frame` — core's shared React hook, re-exported
unchanged as the **UIx adapter's** `use-frame` — memoised its `capture-frame`
bundle in a render-phase `useRef`, keyed on the resolved frame **keyword**
compared by `=`:

```clojure
(if (and (some? prev) (= (aget prev 0) frame))
  (aget prev 1)
  (let [ops (rf-core/capture-frame frame)] …))
```

The bead came from another worker's reading and said to verify before fixing.
It holds. `frame/require-current-frame!` returns "the frame stamp (id)" — a
keyword — so `frame` there is an address, and `=` is the whole key.

What makes that wrong is on the other side of the call.
`make-capture-frame` pins the incarnation live when it ran
(`capture-target-incarnation`, rf2-9pyles) and **every** op on the returned
bundle refuses a superseded target: `capture-dispatch!` and `capture-subscribe!`
(rf2-tdjv7p) recover-but-emit `:rf.error/frame-destroyed` rather than leak into
a same-id successor. So a frame keyword is an **ADDRESS, not an identity** —
`:f` is `=` to `:f` across a destroy + same-id create, while the bundle is not.
After a reincarnation the hook kept handing out the **dead** incarnation's
bundle for the rest of the mount, and every dispatch and subscribe a consumer
made through it was dropped against a frame it could plainly see was alive.
Nothing signalled it: the keyword still compared equal, the memo still hit, and
the stale bundle still reported `:frame :f`.

This is the warm half of the `rf2-hic-013` failure, living in core.

## The fix

Key the memo on the frame **and** on `frame/frame-incarnation-token` — the
frame record's `:drain-lock` identity, constant across one incarnation and
distinct across a reconstruction — compared by `identical?`. A reincarnation is
then a memo MISS and the next render carries ops pinned to the successor. This
is the rule Hicasso's `n/use-frame` already keeps by memoising on
`impl.frames`' incarnation row.

A `nil` token (the id is not live at render) is a legitimate key rather than a
special case: it pairs with the unpinned, address-directed capture
`capture-frame` makes in exactly that situation, and the frame appearing later
moves the token off `nil` and correctly misses.

## Blast radius — established before the behaviour changed

Callers of the hook:

| caller | what a miss costs it |
|---|---|
| `implementation/adapters/uix/src/re_frame/adapter/uix.cljs` (`def use-frame`) | the re-export — every UIx consumer reaches the hook through it |
| `examples/substrates/uix/{counter,dashboard,login}/core.cljs` (4 sites) | one `capture-frame` on a reincarnation that today leaves them dispatching into a corpse |
| `tools/template/resources/day8/re_frame2_template/_uix/views.cljs` | same |
| `implementation/freehand/test/re_frame/bench/hicasso/**` (5 sites: `dogfood_uix`, `ime_app`, `controlled_grid`, `controlled_restore`) | bench/dogfood apps; none destroys a frame mid-mount |
| the suite's own `ProbeUseFrame` | the witness |

**Steady state**: one extra `frame/frame-incarnation-token` per render on the
memo-HIT path — `(some-> (frame id) :drain-lock)`, i.e. one atom deref, one map
lookup and two keyword reads, no allocation. That is strictly less than the
`capture-frame` the same render performs on a miss, and negligible beside the
`use-subscribe` sitting next to it in the same component.

**On the changed path**: the memo now misses exactly where it previously hit
wrongly — after a genuine destroy + same-id create of the resolved frame. Cost
is one `capture-frame`: a registry read, a 4-entry map, three closures, once per
affected component per reincarnation. A `useEffect` holding the ops map in its
deps re-runs once. That is the correct behaviour and not a cost worth reporting
as a decision: **no consumer can depend on the bundle surviving a reincarnation,
because core's fence already refuses every op on it.** "Surviving" here means
"silently dead".

## The witness

`assert-use-frame-retargets-across-a-same-id-reincarnation` in the shared React
suite, forwarded from the UIx `-dom-cljs-test` entry file, driving the same
`ProbeUseFrame` the existing stability row uses. It needs no new cfg key and
nothing substrate-specific.

Shape copied from `native_hooks_dom_cljs_test`'s W6. **Nothing in it is an
equality assertion** — the dead and the live bundle compare `=` on every
readable key, which is the defect's disguise. It asserts on object identity and
on what a dispatch through each bundle DOES. Four rows on one mount, so the
control and the law share the one `useRef` cell:

1. **premise** — destroy + same-id create yields a different incarnation token;
2. **control** — a re-render that changed no frame still returns the IDENTICAL
   map (without this, a "fix" that rebuilt every render would pass 3 and 4 while
   destroying the reference stability effect deps depend on);
3. **identity** — after the reincarnation the map is a different object;
4. **the observable** — a `dispatch-sync` off the post-reincarnation map moves
   the live frame's app-db, and one off the pre-reincarnation map moves nothing.

### Proved red

Fix broken (the `identical?` clause deleted from the memo condition, nothing
else touched), `npm run test:browser`, verbatim:

```
FAIL in (use-frame-retargets-across-a-same-id-reincarnation) (re_frame/adapter/react_shared_suite.cljs:3759:25)
UIx — use-frame retargets across a same-id reincarnation (rf2-40kv)
the ops map RETARGETED. A `useRef` memo keyed on the resolved frame by `=` alone hits here — the keyword is `=` across a reincarnation — and serves incarnation A's bundle for the rest of the mount
expected: (not (identical? ops-1 ops-2))
  actual: (not (not true))

FAIL in (use-frame-retargets-across-a-same-id-reincarnation) (re_frame/adapter/react_shared_suite.cljs:3769:25)
UIx — use-frame retargets across a same-id reincarnation (rf2-40kv)
the post-reincarnation bundle WRITES the live incarnation
expected: (= 7 (:n (rf/app-db-value uf-frame)))
  actual: (not (= 7 100))

FAIL in (use-frame-retargets-across-a-same-id-reincarnation) (re_frame/adapter/react_shared_suite.cljs:3777:25)
UIx — use-frame retargets across a same-id reincarnation (rf2-40kv)
the pre-reincarnation bundle writes NOTHING — it is pinned to a frame that no longer exists
expected: (= 7 (:n (rf/app-db-value uf-frame)))
  actual: (not (= 7 100))
```

Three of the four rows red; **the control passed**, which is the point — the
memo worked, only its key was an address. The fix was then restored
byte-identically (`git checkout --` off the commit; `git diff --quiet HEAD`
confirms) and the three rows are green.

One unrelated row, `fh-event-001-a-live-scroll-event-reaches-app-db-as-its-offset`
(`re_frame/freehand/projection_roster_dom_cljs_test.cljs`, a scroll-event timing
assertion in a namespace that never mentions `use-frame`), failed in the two
runs on the pre-rebase base and **did not recur** on the rebased tree, where the
lane is 0 failures. `:browser-test` is green on `main`'s CI.

## Documentation

The UIx re-export's docstring and `docs/api/re-frame.adapter.uix.md` both
promised "reference-stable across re-renders for the same resolved frame". That
is precisely the sentence a keyword-keyed memo satisfies, and the sentence the
defect hid behind — the same *resolved frame* spans a destroy and a same-id
create; the bundle does not. Both now say **incarnation**.

`spec/006-ReactiveSubstrate.md` (§2620, §2651) and `spec/API.md` (§579) carry
the same imprecise sentence. Both are hot-zone — **not touched; reported for a
follow-up bead.**

## Quality gates

| gate | exit | result |
|---|---|---|
| `npm run test:browser` (`:browser-test`, headless Chromium) | **0** | 1178 files, 0 warnings; **1239 tests / 7652 assertions, 0 failures, 0 errors**. The lane that owns `-dom-cljs-test$` — the witness's home, and the one a hook-lifetime bug actually needs. |
| `scripts/test-fast-pr.sh` (fast-PR spine, from the worktree root) | 1 | One `FAIL` line: **`CLJS node integration`**, whose own repro is `npm run test:cljs` — see below. Everything the spine reached before it passed: `mkdocs build --strict`, **JVM `implementation/core` (2233 tests / 11645 assertions, 0 failures)**, JVM `implementation/adapters/uix`, every `python scripts/check_*.py` gate, and every JS harness-helper suite. The spine aborts at the first failure, so the lanes after it did not run. |
| `npm run test:cljs` (`:node-test`) | 1 | 2273 files, 0 warnings; **13240 tests / 66924 assertions, 1 failure** — a spawned child process returning `3221226505`. **Environmental, not this diff — see below.** |
| `python scripts/check_doc_slugs.py` | **0** | the docs edit; no link or anchor changed |

### The `test:cljs` failure, in full

The suite compiled clean (2273 files, 0 warnings) and ran **13240 tests / 66924
assertions with 1 failure**, in the single namespace
`re-frame.test-quiet-shadow-node-cljs-test` — the meta-test that **spawns child
node processes** to check the quiet runner. The failure is the child not
starting, with empty stdout and empty stderr:

```
FAIL in (unknown-arg-is-fatal-not-false-green) (re_frame/test_quiet_shadow_node_cljs_test.cljs:570:11)
a clean focused invocation still exits 0 (negative control)
a clean focused run must STILL exit 0 — the guard must not reject valid args; got status 3221226505
--- stdout ---

--- stderr ---

expected: (zero? status)
  actual: (not (zero? 3221226505))
```

`3221226505` is `0xC0000409`. An earlier complete run of the same suite on this
tree produced **18** failures, all in that same namespace and all
`3221225794` = `0xC0000142` (`STATUS_DLL_INIT_FAILED`) — the same class. Three
attempts in between could not finish the `:node-test` **compile** at all,
reporting `Multiple files failed to compile.` followed only by downstream
`aborted par-compile … still waiting for #{…}` entries and **no root compile
error**, naming a completely different and unrelated namespace set each time
(`re-frame.freehand.structural-runner`; then `re-frame.ssr` / `login.stories` /
`re-frame.late-bind.directory`; then `re-frame.ui.parity-fixtures` /
`re-frame.ui.proof-pack.library`). The host was running 26 concurrent node
processes and 2 JVMs from other agents throughout, with ~7.5 GB free.

Three independent reasons this is not the diff:

1. every failing row is a **child process refusing to launch**, with a Windows
   NTSTATUS exit code and no output — never an assertion about re-frame2
   behaviour, and the code differs run to run;
2. the aborting compile namespaces are unrelated to each other and to
   `use-frame`, and differ on every attempt — the signature of compile threads
   dying, not of source breakage;
3. `:browser-test` compiled the **same** core and adapter sources plus the new
   witness (0 warnings) and ran **0 failures**.

**CI decides this one.**

Not run, and why:

- `mkdocs build --strict` — the spine runs it.
- The `:advanced` / elision lanes (`test:browser-prod-elision`,
  `test:elision`, bundle-isolation): the diff adds one always-on registry read
  inside an existing always-on code path; nothing dev-only, nothing new on the
  require graph (`re-frame.frame` was already required by the hook).
- Adapter/testbed browser smokes, Story/Xray gates, mcp-conformance: no
  surface reached — the diff is one hook body, one suite assertion, one
  forwarding deftest and two docstrings.
- The full `check_fast_pr_gap.py --list` set (96 checks) is CI's; none is
  decided locally.
