### PR TITLE
docs(xray): the staged freehand-views deck does not migrate — it retires with the panel (rf2-u5b4)

### DIFF
--- a/tools/xray/spec/017-Test-Coverage-Matrix.md
+++ b/tools/xray/spec/017-Test-Coverage-Matrix.md
@@ -359,6 +359,22 @@ assertion is therefore pinned to the readout's DOM NODE as well as its text: a
 repaint writes into the node already standing there, a remount replaces it, and
 both halves have to hold.
 
+**Disposition — the deck retires with the panel, and is not independently
+migratable (rf2-u5b4).** The reason is the panel's rather than the deck's:
+[`021-Dynamic-Panel-Designs.md`](021-Dynamic-Panel-Designs.md) §3.4.3 records
+that §3.4.1 and §3.4.2 cannot move to `re-frame.hicasso.tool`, because five of
+their eight questions have no answer there, so they stay on
+`re-frame.freehand.tool` until the Freehand tree goes. This deck is the
+browser-lane populated arm of exactly those two sections and has no other
+consumer, and every fact its scenario asserts — the view id, the occurrence key,
+the lowering, the per-row read count, the declared sites — is one the target
+does not publish. Repointing it would leave a scenario asserting facts that
+cannot exist; removing it while the panel still ships would restore the
+gate-blindness rf2-6pohj closed. So it goes when they go, under rf2-hic-062,
+and it is four artefacts: this source tree, the `:testbeds/freehand-views` build
+id, its port-8036 `:dev-http` entry, and the scenario together with its
+`STAGED_SURFACES` wiring.
+
 ## Cross-references
 
 - [`000-Vision.md`](./000-Vision.md) - panel inventory and the five canonical questions.

--- a/tools/xray/spec/017-Test-Coverage-Matrix.md
+++ b/tools/xray/spec/017-Test-Coverage-Matrix.md
@@ -367,10 +367,10 @@ their eight questions have no answer there, so they stay on
 `re-frame.freehand.tool` until the Freehand tree goes. This deck is the
 browser-lane populated arm of exactly those two sections and has no other
 consumer, and every fact its scenario asserts — the view id, the occurrence key,
-the lowering, the per-row read count, the declared sites — is one the target
-does not publish. Repointing it would leave a scenario asserting facts that
-cannot exist; removing it while the panel still ships would restore the
-gate-blindness rf2-6pohj closed. So it goes when they go, under rf2-hic-062,
+the lowering, the per-row generation, the declared sites — sits in that
+disposition's **none** column. Repointing it would leave a scenario asserting
+facts that cannot exist; removing it while the panel still ships would restore
+the gate-blindness rf2-6pohj closed. So it goes when they go, under rf2-hic-062,
 and it is four artefacts: this source tree, the `:testbeds/freehand-views` build
 id, its port-8036 `:dev-http` entry, and the scenario together with its
 `STAGED_SURFACES` wiring.

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -977,11 +977,12 @@ questions only a view registry could have answered.
 **The staged `freehand-views` deck inherits this disposition, and retiring it is
 four artefacts rather than one** (rf2-u5b4, against census rows X6/X7/X8). The
 deck exists for no purpose other than putting real connected occurrences in
-front of §3.4.1 and §3.4.2, so it cannot be migrated separately: a deck
-repointed at Hicasso would assert on precisely the five facts the table above
-says the target does not publish — the view id, the occurrence key, the
-lowering, the per-row read count and the whole Declared View Sites section — and
-retiring it early, while the panel still ships, would restore the gate-blindness
+front of §3.4.1 and §3.4.2, so it cannot be migrated separately: every fact its
+scenario asserts is one the table above puts in the **none** column — the view
+id, the occurrence key, the lowering, the per-row generation and the whole
+Declared View Sites section — leaving it nothing to assert but the frame and a
+read set scoped to the live boundary rather than to the commit. Nor can it go
+early: retiring it while the panel still ships would restore the gate-blindness
 rf2-6pohj closed, an empty roster and a roster emptied by a broken read being
 the same DOM. What goes with §3.4.1 and §3.4.2 is therefore
 `tools/xray/testbeds/freehand_views/`, the `:testbeds/freehand-views` build id

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -974,6 +974,26 @@ that moment: a Hicasso host's boundaries, reads, intents and explanations are
 answered in full by the Hicasso tab, and what disappears is exactly the set of
 questions only a view registry could have answered.
 
+**The staged `freehand-views` deck inherits this disposition, and retiring it is
+four artefacts rather than one** (rf2-u5b4, against census rows X6/X7/X8). The
+deck exists for no purpose other than putting real connected occurrences in
+front of §3.4.1 and §3.4.2, so it cannot be migrated separately: a deck
+repointed at Hicasso would assert on precisely the five facts the table above
+says the target does not publish — the view id, the occurrence key, the
+lowering, the per-row read count and the whole Declared View Sites section — and
+retiring it early, while the panel still ships, would restore the gate-blindness
+rf2-6pohj closed, an empty roster and a roster emptied by a broken read being
+the same DOM. What goes with §3.4.1 and §3.4.2 is therefore
+`tools/xray/testbeds/freehand_views/`, the `:testbeds/freehand-views` build id
+and its port-8036 `:dev-http` entry (both in top-level
+`implementation/shadow-cljs.edn`), and the PR-smoke `freehand-views populated
+Views roster` scenario in `tools/xray/testbeds/feature_matrix/scenarios.cjs`
+together with its `STAGED_SURFACES` entry. A pass that takes the two sections
+and the `deps.edn` coordinate but leaves those behind reds the PR gate on a
+scenario whose panel no longer exists.
+[`017-Test-Coverage-Matrix.md`](017-Test-Coverage-Matrix.md) carries the deck's
+own record.
+
 ### §3.5 Queries
 
 | From | Reads |


### PR DESCRIPTION
## The verdict is a refusal, and it is the deliverable

`rf2-u5b4` was filed as *migrate the staged freehand-views deck (census cluster X6-X8)*, and
dispatched with an exclusive `implementation/shadow-cljs.edn` window because the census recorded the
deck's build id and `:dev-http` port as the cost of moving it. **The window was not needed, and it is
released unheld — this PR does not touch `implementation/shadow-cljs.edn`.** There is no migration to
perform, for a reason that is structural rather than budgetary.

The deck exists for exactly one purpose, stated in its own ns docstring, in the `shadow-cljs.edn`
comment above its build id, and in the scenario's own preamble: to put real connected Freehand
occurrences in front of spec 021 §3.4.1 (Mounted views) and §3.4.2 (Declared view sites), so the
browser lane can tell *empty because nothing is mounted* from *empty because the read through
`re-frame.freehand.tool` is broken* — the same DOM otherwise.

Those two sections are census cluster X1/X2/X4/X5 = **`rf2-jkdy`, closed with a refusal**: of the
panel's eight questions two carry across, one degrades structurally and five have no answer on
`re-frame.hicasso.tool`, which mints no boundary identity and ships no manifest. The panel therefore
stays on the donor until the Freehand tree goes.

The deck inherits that disposition exactly, and both directions fail:

- **Repointing it at Hicasso** would leave a scenario asserting on precisely the five facts §3.4.3's
  table puts in the **none** column — the view id, the occurrence key, the lowering, the per-row
  generation, and the whole Declared View Sites section. Those are not incidental assertions; they
  are the scenario's entire content, leaving it nothing to assert but the frame and a read set
  scoped to the live boundary rather than to the commit.
- **Retiring it early**, while §3.4.1/§3.4.2 still ship, restores the gate-blindness `rf2-6pohj`
  closed.

So it goes when they go, under `rf2-hic-062`. This PR records that, spec-only, in the same shape as
`rf2-jkdy`'s.

## What landed

**`tools/xray/spec/021-Dynamic-Panel-Designs.md` §3.4.3** — the retirement inventory previously named
only the `day8/re-frame2-freehand` coordinate in `tools/xray/deps.edn`. It now also names the deck,
because retiring it is **four** artefacts and a pass that takes the panel and the coordinate but
leaves the rest behind reds the PR gate on a scenario whose panel no longer exists:
`tools/xray/testbeds/freehand_views/`, the `:testbeds/freehand-views` build id, its port-8036
`:dev-http` entry, and the PR-smoke `freehand-views populated Views roster` scenario together with
its `STAGED_SURFACES` wiring.

**`tools/xray/spec/017-Test-Coverage-Matrix.md`** — the deck's own section gains the matching
disposition paragraph and the pointer to §3.4.3, so a reader arriving at the deck is not left to
re-derive the refusal.

Per the standing `tools/xray/` spec-sync rule, **this PR is the spec change**. No coverage moved, so
the §017 matrix rows themselves are untouched.

## Row premises, re-verified from the consumer code

Not read off the census. `git grep -l -E "freehand|re[-_]frame[./]ui" -- tools` returns **43** at
`07bcee726b`, reconciling with the census's own recorded count.

| row | premise | verdict |
|---|---|---|
| **X6** `tools/xray/testbeds/freehand_views/core.cljs` | `:require` of `re-frame.freehand` at L97 | **HELD, exactly.** L97 is `[re-frame.freehand :as v]`, and it is load-bearing throughout — `v/defview` ×3, `v/sub`, `v/mount`, `v/unmount!` |
| **X7** `tools/xray/testbeds/freehand_views/index.html` | "the deck's host page, wired from `freehand-views.core/run`" | **DID NOT HOLD as stated — corrected below** |
| **X8** `tools/xray/testbeds/feature_matrix/scenarios.cjs` | scenario at L3819 + `build`/`bundleDir`/`html`/`servedPath` at L184-187 | **HELD, exactly**, and understated — see below |

### X7 is an over-count of the shape the census warns about

The file's only two matches for the census's own grep are L5, the `<title>` string
`re-frame2 testbed: freehand-views (Xray demo)`, and L29, a **comment**. Both name the deck's *own*
namespace prefix `freehand-views`, not the donor `re-frame.freehand`. **The file names no donor
namespace in any position.** It is in the 43-file grep purely by name collision — exactly the
`[[wiki-link]]`-in-a-docstring failure mode the census's methodology section calls out.

The stated wiring is also in the wrong file: `freehand-views.core/run` is bound by
`:init-fn freehand-views.core/run` in `implementation/shadow-cljs.edn` L2042, not by `index.html`.

The row is not spurious — the file *is* load-bearing **to the deck** (the `#app` mount target read at
`core.cljs` L204, the `fh-mount`/`fh-unmount` ids read at L231-232, the `data-rf-xray-host` slot) —
but its "donor surface named, and how" claim does not hold. **Since the census file is held by
another worker, this correction is reported rather than applied**; it does not move the 43/29
arithmetic, because the file is a genuine grep hit and a genuine cluster member either way.

### X8 is understated

The census calls it "a gated browser scenario". It carries `smoke: true` (L3821), which puts it in
the **PR-smoke tier**, not nightly — so the deck is load-bearing on the PR gate, which is what makes
the ordering in §3.4.3 matter. It additionally names `re-frame.freehand.tool` at L1097, L1125 and
L3812.

## Both sides of the wire

The Pair hole was a conformance corpus that stubbed replies keyed on the wire string, so a form
naming a nonexistent read matched a stub as happily as a real one. **This deck does not have that
hole — it is the artefact that closes it.**

Its wire is Xray's Views panel ← `re-frame.freehand.tool`, and nothing between the runtime and the
screen is stubbed: a real Freehand root in a real Chromium, the real tool door over the real
occurrence index, the real panel DOM. The assertions are per-row facts a uniform stub cannot satisfy
— `1 read` on the sole reader against `0 reads` elsewhere, one interpreted lowering against two
compiled, and three **freshly minted** occurrence keys after an unmount/remount, which a projection
over a static registry cannot produce. The scenario says so in its own words: *"Everything asserted
below is a fact only a WORKING read can produce."*

**Found while checking, and reported rather than taken:** the Hicasso tab's *populated* arms
(`rf-xray-hicasso-mounted`, `-attribution`, `-intents`, `-explain`) have **no browser-lane proof at
all**. The only browser assertion on `rf-xray-hicasso` is the tab-render walk at `scenarios.cjs` L69
over the counter testbed, which lands on the honest `rf-xray-hicasso-absent` state. That is the same
shape `rf2-6pohj` closed for the Views panel — though materially weaker, because Hicasso's commit
seam *is* answerable in Node and `hicasso_cljs_test.cljs` drives it over a real runtime with nothing
stubbed between runtime and screen (its two `with-redefs` at L239/L266 synthesise the absent and
mismatch **loss** arms deliberately, not the happy path). Flagged for a bead; out of fence here.

## Quality gates

| gate | exit | note |
|---|---|---|
| `scripts/test-fast-pr.sh` | `0` | Run twice — once on the first commit, again on the final tree after the fix-up commit. Classified `docs=true jvm=false node=false`, the correct lane for a `tools/xray/spec/*.md`-only diff |
| `python scripts/check_gate_scheduling.py` | `0` | Run because the bead reserved a `shadow-cljs.edn` window. `49 gate commands, 41 scheduled, 8 declared (0 of them known holes with beads)` |
| `python scripts/check_doc_slugs.py` | `0` | Covers `tools/*/spec/**/*.md`, so both edited files are in scope. Silent on success — coverage proved by planted anchor, below |
| `python scripts/check_fast_pr_gap.py --list` | `0` | Derived: 96 required checks the spine does not decide; `fast-PR gap map clean: 83 required jobs across 3 workflows` |

**Build-ids touched: none.** The bead's premise was that the deck's build id and port needed moving;
the verdict is that they do not move at all, so `implementation/shadow-cljs.edn` is unmodified and no
build needed recompiling to prove it. The hot-zone window is released.

**Not run, and why:** `scripts/test-jvm-implementation.sh`, `test-jvm-tools.sh` and
`test-rigorous-local.sh` — the diff is two markdown files under `tools/xray/spec/`, reaches no
compiled surface, and the spine's own classifier agrees (`jvm=false node=false`). `mkdocs build
--strict` — `tools/*/spec/` is not in the mkdocs site; `check_doc_slugs.py` is the gate that
validates this tree's link targets and heading anchors, and it ran.

**Doc-slug coverage proof.** `check_doc_slugs.py` is silent on success, so silence was not accepted
as evidence. A `#planted-anchor-deck-u5b4-proof` fragment was appended to the new cross-link in
`017-Test-Coverage-Matrix.md` and the checker re-run: it went to **exit 1** and named the plant
precisely —

```
BROKEN ANCHOR: tools\xray\spec\017-Test-Coverage-Matrix.md:364 -> 021-Dynamic-Panel-Designs.md#planted-anchor-deck-u5b4-proof
```

— which proves the checker reaches this tree, this file and this specific link rather than passing
vacuously. The plant was made and reverted with the editor (never `sed -i`, which rewrites CRLF→LF
on Windows and leaves `git diff` and `git status` both reading clean over changed bytes), and the
restore was verified **by hash**, not by `git diff`:

```
b03904f3c209cb453a19a48a27511279d3119f66a2e7aecfe387ebeb41bfb795  017-Test-Coverage-Matrix.md
27a790b203de8bd9304ac378f852d79359ff059a171a1bbc6dd9339278710c3b  021-Dynamic-Panel-Designs.md
```

identical before the plant and after the revert.

**Hand-verified** (nothing validates these): no tables were added or altered in either file, so no
column counts changed. Both added cross-links (`017-Test-Coverage-Matrix.md` ↔
`021-Dynamic-Panel-Designs.md`) resolve to siblings in `tools/xray/spec/`, and no new headings were
introduced, so no anchors were minted or invalidated.

## Bead

`rf2-u5b4` — the verdict is reported for the mayor to close; no state-mutating `bd` command was run.
