### PR TITLE
rf2-hic-032 — ABI-preserving helpers + the two embedding bridges

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso.cljc
@@ -71,6 +71,7 @@
   #?(:clj (:require [re-frame.source-coords :as source-coords]))
   #?(:cljs
      (:require [re-frame.hicasso.impl.boundary :as impl-boundary]
+               [re-frame.hicasso.impl.codec :as impl-codec]
                [re-frame.hicasso.impl.collector :as impl-collector]
                [re-frame.hicasso.impl.intent :as impl-intent]
                [re-frame.hicasso.impl.mount :as impl-mount]
@@ -334,6 +335,23 @@
   it mints no boundary and adds no hook.
   [[re-frame.hicasso.impl.route-link/route-link]]."}
        route-link impl-route-link/route-link)
+
+     (def ^{:doc "`h/as-component` — **the outward bridge** (rf2-hic-032).
+  Answers a real React component for a hiccup head, so a native parent —
+  `n/defcomponent`, UIx, or plain JavaScript — mounts a minted Hicasso
+  view under the frame it is already in:
+
+      (def article-card* (h/as-component article-card))
+
+  Declared once at top level, beside the view. The parent's props arrive
+  as the view's ordinary props map (`articleId` → `:article-id`),
+  children at `:children`, values by identity; the frame comes from React
+  context, and no second root, state owner or props ABI appears anywhere.
+  Sits HERE rather than on the native tier because a UIx or JavaScript
+  parent must not have to require the native namespace — and therefore
+  ship it — to cross inward.
+  [[re-frame.hicasso.impl.codec/as-component]]."}
+       as-component impl-codec/as-component)
 
      ;; ---- the root lifecycle: mount, re-render, tear down ----------------
      ;;

--- a/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
@@ -3142,6 +3142,132 @@
     (as-element hiccup)))
 
 ;; ---------------------------------------------------------------------------
+;; THE OUTWARD BRIDGE (rf2-hic-032) — the codec's other half
+;; ---------------------------------------------------------------------------
+;;
+;; Every other function in this file ENCODES: a hiccup form goes in and a
+;; React element comes out. The bridge is the one place the traffic runs
+;; the other way — a React parent holds a props OBJECT and wants a
+;; Hicasso element — so the decode belongs here, beside the vocabulary it
+;; is the inverse of, and nowhere else.
+;;
+;; **The bridge mints no crossing of its own.** It converts the props and
+;; then calls [[vec->element]], which is the same entry every hiccup
+;; vector in every body already goes through. That is what makes "one
+;; props/children ABI" (native-boundary law, clause 5) true by
+;; construction rather than by inspection: there is no second element
+;; builder to keep in step, `rfProps` is written in exactly the one place
+;; it was written before, and the bridge inherits every refusal the codec
+;; already raises at the coordinates the complaint register already
+;; records — a head outside the closed set refuses as
+;; `:rf.error/hicasso-bad-head` from [[vec->element]], from out here as
+;; from a body.
+
+(def ^:private slot-keys
+  "The three React spellings read back to the hiccup key they came from.
+
+  [[re-frame.hicasso.impl.slot/prop-name]] is deliberately NOT injective
+  — `:class`, `:className`, `\"class\"` and `:x/class` are one slot — so
+  an inverse has to CHOOSE, and it chooses the spelling the guide
+  teaches. `className` therefore arrives at a body as `:class`, which is
+  the key that body's author would have written."
+  {"className" :class "htmlFor" :for "charSet" :charset})
+
+(defn prop-key
+  "The hiccup prop key a React slot name came from —
+  [[re-frame.hicasso.impl.slot/prop-name]] read backwards.
+
+  `\"onClick\"` → `:on-click`; `\"aria-label\"` and `\"data-index\"` pass
+  through, because the forward rule leaves those two families alone; a
+  `--custom-property` is preserved verbatim; the three React renames go
+  back to their HTML spellings through [[slot-keys]].
+
+  **The round trip is the contract**, and it is what lets the two fences
+  compose. A native parent writing `(n/$ card {:article-id 7})` has its
+  key lowered to `\"articleId\"` by the native macro, and this function
+  hands the body back `:article-id` — so an author who writes the same
+  keyword on both sides of the fence reads the same keyword in the body,
+  and a JavaScript parent writing `articleId={7}` reaches the same place.
+  Witnessed over `slot-corpus` in
+  `re-frame.hicasso.outward-bridge-cljs-test`, on every row whose
+  authored key is already the canonical spelling.
+
+  A slot carrying a hyphen is answered verbatim, which is the only rule
+  that can be right: the forward direction camelCases a key by consuming
+  its hyphens, so a slot that still has one was never camelCased and
+  splitting it again would invent a key the author never wrote."
+  [s]
+  (or (slot-keys s)
+      (if (str/includes? s "-")
+        (keyword s)
+        (keyword (str/replace s #"[A-Z]" #(str "-" (str/lower-case %)))))))
+
+(defn- outward-props
+  "A React props object, decoded into the ordinary ClojureScript props map
+  a boundary body destructures. Shallow, by identity, own properties
+  only — the mirror of what [[boundary-element]] does on the way out,
+  and no deeper for the same reason: the values are the parent's, and
+  converting them would be the deep conversion HD-011 refuses in the
+  other direction.
+
+  React's children arrive at the `children` slot and therefore land at
+  `:children`, which is where [[boundary-element]] puts a hiccup body's
+  children too — one spelling, whichever side of the bridge filled it."
+  [^js js-props]
+  (if (nil? js-props)
+    {}
+    (persistent!
+      (reduce (fn [m s] (assoc! m (prop-key s) (unchecked-get js-props s)))
+              (transient {})
+              (js/Object.keys js-props)))))
+
+(defn as-component
+  "**Hand a hiccup head to React.** Answers a real React function
+  component, so a native parent — `n/defcomponent`, UIx, or plain
+  JavaScript — can render a minted Hicasso view without a second root,
+  a second frame, or a sight of the internal `rfProps` ABI.
+
+      (def article-card* (h/as-component article-card))
+      ;; on the React side: <ArticleCard articleId={7} />
+
+  The parent's props arrive as the view's ordinary props map
+  ([[prop-key]]), React's children arrive at `:children`, and values
+  cross by identity. Called ONCE, at top level, beside the view it
+  bridges: it allocates a component, so minting one inside a render would
+  hand React a fresh element type on every pass and remount the subtree —
+  `n/lazy`'s law and `defcomponent`'s, for the same reason.
+
+  ## What it preserves, and why the list is short
+
+  Nothing here re-implements the crossing. The element is built by
+  [[vec->element]] from `[head props]`, so the view keeps its stable memo
+  wrapper (a fresh-but-`=` props map still bails out under
+  [[boundary-props=]]), its reads, its teardown, and its refusals — and
+  the head's own `:key` identity stays React's, written by the parent on
+  the element it creates. The frame is the one the surrounding React
+  context carries, which is what makes this a bridge rather than a root:
+  the shell reads the same `re-frame.adapter.context/frame-context` a
+  boundary two levels up reads, through any foreign components in
+  between. Rendered outside every Hicasso root the shell refuses with
+  `:rf.error/no-frame-context`, unchanged.
+
+  **`*dispatch*` is not bound, and neither is `*frame*`**, for
+  [[root-element]]'s reason: this wrapper is not a boundary body, so an
+  intent vector written in the props of a `[:div]` handed through here
+  stays the loud `:rf.error/hicasso-intent-outside-boundary` it is
+  everywhere else. A frame-fed head ([[mark-frame-prop!]]) is the one
+  head this does not serve; it refuses with `:rf.error/no-frame-prop`,
+  whose recovery already names the outward bridge as the creator that
+  must supply the frame."
+  [head]
+  (let [named     (when (fn? head) (unchecked-get head "displayName"))
+        component (fn hicasso-as-component [js-props]
+                    (vec->element [head (outward-props js-props)]))]
+    (unchecked-set component "displayName"
+                   (str "hicasso/as-component" (when named (str "(" named ")"))))
+    component))
+
+;; ---------------------------------------------------------------------------
 ;; Cache observation — for the tests and the bench, never for the runtime
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
@@ -3188,14 +3188,27 @@
   hands the body back `:article-id` — so an author who writes the same
   keyword on both sides of the fence reads the same keyword in the body,
   and a JavaScript parent writing `articleId={7}` reaches the same place.
-  Witnessed over `slot-corpus` in
-  `re-frame.hicasso.outward-bridge-cljs-test`, on every row whose
-  authored key is already the canonical spelling.
+  Witnessed over `slot-corpus` in `re-frame.hicasso.native-abi-cljs-test`,
+  twice: every keyword or symbol row's decoded key emits back into the
+  SAME slot, and the taught spellings decode to themselves.
 
   A slot carrying a hyphen is answered verbatim, which is the only rule
   that can be right: the forward direction camelCases a key by consuming
   its hyphens, so a slot that still has one was never camelCased and
-  splitting it again would invent a key the author never wrote."
+  splitting it again would invent a key the author never wrote.
+
+  ## The one correspondence this does not have, stated
+
+  [[re-frame.hicasso.impl.slot/prop-name]]'s STRING arm is an escape from
+  the rule rather than a spelling within it — a string key means *emit
+  exactly this name*, so `\"on-input\"` emits `on-input`, which no keyword
+  reaches. Decoding that name gives `:on-input`, whose slot is `onInput`,
+  and the round trip is broken because the forward direction was never
+  a function of the hiccup vocabulary there. That is the right answer
+  anyway: a props MAP handed to a view body is application data, and a
+  body that receives `foo-bar` from a JavaScript parent wants
+  `:foo-bar` — answering the string back to make an internal law
+  universal would be optimising for the law rather than for the author."
   [s]
   (or (slot-keys s)
       (if (str/includes? s "-")

--- a/implementation/hicasso/src/re_frame/hicasso/native.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso/native.cljc
@@ -100,6 +100,27 @@
   the pair: a commit observed through the hook is a BLOCKING update and
   no part of this surface is transition-aware.
 
+  ## The ABI helpers, and the two directions across the boundary
+
+  [[memo]] and [[lazy]] are `react/memo` and `react/lazy` with the tier
+  [[marker]] carried across, and they are the whole helper surface: React
+  19 hands a function component its `ref` as an ordinary prop, so refs
+  need no helper and get none. Neither helper touches props or children —
+  the ABI is one raw JavaScript props object at every rung, and a second
+  \"fast\" one does not appear here or anywhere else in the tier.
+
+  Crossing the boundary is likewise not this namespace's invention in
+  either direction. **Inward** — hiccup mounting an island — a native
+  component is a foreign React component like any other, so it enters
+  through the seams that already exist: `h/defhost` for a named crossing,
+  the `[:>]` escape for a one-off. Neither knows this tier exists, and
+  that is what keeps clause 6 true: an interpreted-only bundle cannot
+  reach the native runtime through a door that never names it.
+  **Outward** — a native parent mounting a Hicasso view — is
+  `h/as-component`, and it lives on the interpreted door for the mirror
+  reason: a UIx or JavaScript parent must not have to require this
+  namespace, and therefore ship it, to cross.
+
   ## Dependency isolation
 
   This namespace is separately reachable and nothing in `re-frame.hicasso`
@@ -318,6 +339,113 @@
   and the reason a raw `react/memo` wrapper loses it."
        [x]
        (when (some? x) (unchecked-get x tier-sentinel)))
+
+     ;; ----------------------------------------------------------------
+     ;; The two ABI helpers (rf2-hic-032)
+     ;; ----------------------------------------------------------------
+     ;;
+     ;; TWO, and refs make a third that needs no code. React 19 hands a
+     ;; function component its `ref` as an ordinary prop, so `:ref` is
+     ;; already the one ABI at the one slot and a `forwardRef` helper
+     ;; would be a wrapper that preserved what nothing was taking away.
+     ;;
+     ;; What `react/memo` and `react/lazy` DO take away is the marker.
+     ;; Both answer a NEW object — a memo record, a lazy record — and the
+     ;; marker is an own property of the component they were handed, so
+     ;; the display name and the declared server policy stop at the
+     ;; wrapper and Xray names an anonymous boundary where an island
+     ;; should be. Neither changes the props or children ABI at all: a
+     ;; memo passes props through untouched and a lazy resolves TO the
+     ;; component. So the whole of the repair is carrying the two stamps
+     ;; across, and these helpers are deliberately nothing else.
+
+     (defn- carry!
+       "Copy `f`'s display name and tier marker onto `wrapper`, and answer
+  the wrapper. Both are absent for a component this tier did not mint —
+  a UIx `defui`, a handwritten React function — and the copy is silently
+  a no-op there rather than a refusal: UIx is a supported authoring
+  route, so memoising one of its components through here is legal and
+  simply carries nothing, which is exactly what it had."
+       [wrapper f]
+       (when-some [d (unchecked-get f "displayName")]
+         (unchecked-set wrapper "displayName" d))
+       (when-some [m (marker f)]
+         (unchecked-set wrapper tier-sentinel m))
+       wrapper)
+
+     (defn memo
+       "**`React.memo`, with the marker intact.**
+
+      (n/defcomponent quote-cell* [^js props] …)
+      (def quote-cell (n/memo quote-cell*))
+
+  Identical semantics to `react/memo` — a shallow props comparison, or
+  the `props=` you supply, and React's own bail-out — and the ONE
+  difference is that the memo record carries [[marker]] and the display
+  name forward. `(react/memo quote-cell*)` works at runtime and is the
+  defect: Xray shows an anonymous boundary, and the seams that recognise
+  a native head no longer do.
+
+  Declared at top level, never in a render. A memo record IS the element
+  type React reconciles on, so one minted inside a body is a fresh type
+  per pass — no bail-out, and a remount instead. That is `React.memo`'s
+  own law, not an addition.
+
+  **It does not survive a hot reload, and must not.** A save
+  re-evaluates the module, [[component]] allocates a fresh function, this
+  allocates a fresh memo around it, and React replaces the subtree. A
+  clean remount across a save is the designed conduct (rf2-hic-015); a
+  helper that preserved identity here would be fighting the contract."
+       ([f] (carry! (react/memo f) f))
+       ([f props=] (carry! (react/memo f props=) f)))
+
+     (defn lazy
+       "**`React.lazy`, with the marker intact and the loader unwrapped.**
+
+      (def chart-loadable (lazy/loadable app.charts.island/heavy-chart))
+      (def heavy-chart (n/lazy #(lazy/load chart-loadable)))
+
+  `load` is `React.lazy`'s contract with one knot untied: a thunk
+  returning a promise, which resolves **to the component** rather than to
+  a `#js {:default component}` module record. Every ClojureScript code
+  splitter already resolves to the value — `shadow.lazy/load` does — so
+  the module wrapper would be a shape the author invents for React and
+  then never reads. This puts it on once, where it is React's business.
+
+  Suspend and error conduct are React's whole: while the promise is
+  pending the nearest Suspense host shows its fallback, and a rejection
+  throws into the render for the nearest `h/error-boundary` to catch and
+  a `:reset-key` to retry.
+
+  ## The marker, and the one field that cannot be known yet
+
+  A lazy head is a head before its component exists, so its marker is
+  minted here and its `:name` is filled in when the payload arrives —
+  the SAME object throughout, so a seam that read it early sees the name
+  appear rather than being handed a second marker to reconcile. Before
+  arrival the honest answer is that the head has no name, and that is
+  what it says.
+
+  **`:server` is `client-only` and is not the inner component's to
+  override.** The server never sent the chunk, so no policy the component
+  declares can make bytes exist: the region is Client-only whatever
+  `n/defcomponent` said, and the server carries the fallback.
+
+  Declared at top level, never in a render — `React.lazy`'s own law.
+  Minting inside a body allocates a fresh identity per pass, so the
+  fallback flashes and the load re-triggers on every render of the
+  parent."
+       [load]
+       (let [m     #js {:name nil :server "client-only"}
+             lazy* (react/lazy
+                     (fn []
+                       (.then (load)
+                              (fn [component]
+                                (when-some [inner (marker component)]
+                                  (unchecked-set m "name" (unchecked-get inner "name")))
+                                #js {:default component}))))]
+         (unchecked-set lazy* tier-sentinel m)
+         lazy*))
 
      ;; ----------------------------------------------------------------
      ;; The two hooks (rf2-hic-031)

--- a/implementation/hicasso/test/re_frame/hicasso/native_abi_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_abi_cljs_test.cljs
@@ -1,0 +1,319 @@
+(ns re-frame.hicasso.native-abi-cljs-test
+  "THE ONE ABI, CARRIED (rf2-hic-032) — what can be settled without a
+  fiber.
+
+  Native-boundary law clause 5 says element construction, `defcomponent`,
+  memo, lazy loading, refs and BOTH embedding directions share one
+  props/children ABI, and that there is no separate ergonomic and fast
+  one. The characteristic way that clause is broken is not that a wrapper
+  stops working — `(react/memo hot-row)` renders perfectly — it is that
+  the wrapper QUIETLY DROPS what the boundary is recognised by. So every
+  row here reads the marker or the slot, never the pixels.
+
+  ## What each row is for, and the narrowing it is written against
+
+  | row | what it establishes | the one-line narrowing it catches |
+  |---|---|---|
+  | [[a-decoded-slot-emits-back-into-the-slot-it-came-from]] | the bridge's inverse is a real inverse of the slot rule, over the whole corpus | an inverse that re-splits a name the forward rule never joined — `data-userId` |
+  | [[the-taught-spellings-decode-to-themselves]] | `className` comes back as `:class`, not as `:class-name` | a missing rename table, which row 1 passes with because both spellings emit into `className` |
+  | [[a-native-parents-props-arrive-as-the-views-own-props-map]] | the outward bridge's whole promise, measured in the body | a bridge that handed the body the raw JavaScript object — the second ABI clause 5 forbids |
+  | [[the-outward-bridge-adds-no-refusal-of-its-own]] | a bad head refuses through the codec's own id and coordinate | a bridge that minted a private complaint, which is a spelling no catalogue carries |
+  | [[n-memo-keeps-the-marker-where-a-raw-react-memo-loses-it]] | the helper's entire reason to exist, with its own control beside it | a `memo` that forwarded the call and stamped nothing |
+  | [[n-lazy-is-a-native-head-from-the-moment-it-is-declared]] | a code-split head is recognisable during the whole window it is waiting | a marker minted inside the loader — nil until the chunk lands |
+  | [[a-lazy-region-is-client-only-whatever-its-component-declared]] | the server never sent the chunk, so no declaration can make bytes exist | copying `:server` off the loaded component |
+  | [[refs-need-no-helper-because-ref-is-an-ordinary-slot]] | why the helper surface is two and not three | a `forward-ref` helper preserving what nothing took away |
+
+  ## The DOM half
+
+  Identity across a re-render, a bail-out, a remount and StrictMode are
+  claims about a fiber, and a wrapper that works on the first render and
+  loses the marker on the second is exactly the defect this bead is
+  about. Those rows — and the lazy head's ARRIVAL, which only a real
+  Suspense render drives — are
+  `re-frame.hicasso.native-abi-dom-cljs-test`. What is here is what a
+  server render and a pure function can settle, and the server renderer
+  runs bodies for real, so the props-arrival row is a measurement rather
+  than an assertion about a data structure."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.impl.slot :as slot]
+            [re-frame.hicasso.native :as n]
+            [re-frame.hicasso.slot-corpus :as slot-corpus]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]
+            ["react-dom/server" :as react-dom-server]))
+
+(def ^:private frame-id ::native-abi)
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; The consumer's source
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !received
+  ;; What the view's body was handed, held whole. A props claim asserted
+  ;; against a rendered string can only see what the body chose to print;
+  ;; this sees the map.
+  (atom nil))
+
+(h/defview article-card
+  "An ordinary view. Nothing about it knows a React parent exists — which
+  is the outward bridge's entire claim, so the view must not be written
+  for one."
+  [props]
+  (reset! !received props)
+  [:article {:class (:class props)} (str "#" (:article-id props))])
+
+(n/defcomponent quote-cell*
+  "A pure display island, the sort worth memoising."
+  [^js props]
+  (n/$ :b nil (.-label props)))
+
+(n/defcomponent server-cell*
+  {:server :render}
+  [^js props]
+  (n/$ :em nil (.-label props)))
+
+(def ^:private memoised (n/memo quote-cell*))
+(def ^:private raw-memoised (react/memo quote-cell*))
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- render-outward!
+  "Server-render `element` — a React parent's element — under a live
+  frame provider, and answer the markup. The provider is the ONE root and
+  the ONE frame: the bridge's promise is that a native parent needs
+  neither of its own."
+  [element]
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  (rf/make-frame {:id frame-id})
+  (react-dom-server/renderToStaticMarkup (mount/provider frame-id element)))
+
+(defn- refusal
+  [f]
+  (try
+    (f)
+    {::outcome :returned-without-refusing}
+    (catch :default e
+      (or (ex-data e) {::outcome :threw-without-ex-data ::message (ex-message e)}))))
+
+;; ---------------------------------------------------------------------------
+;; 1. The slot rule, read backwards
+;; ---------------------------------------------------------------------------
+
+(def ^:private bridge-corpus
+  "The corpus rows the shared table has no reason to carry: a
+  hyphen-bearing family member with a hump inside it, and the ordinary
+  application keys a view's props map is actually made of. `slot-corpus`
+  exists to pin the CODEC's emission rule and is right not to grow for
+  this."
+  {:data-userId     "data-userId"
+   :aria-labelledby "aria-labelledby"
+   :article-id      "articleId"
+   :on-pick         "onPick"
+   :children        "children"
+   :--brand-hue     "--brand-hue"})
+
+(deftest a-decoded-slot-emits-back-into-the-slot-it-came-from
+  (testing "for every authored key in the corpus, decoding its slot and
+            re-emitting the result lands on the SAME slot. That is the
+            law an inverse of a non-injective rule can actually keep —
+            `:class`, `:className`, `\"class\"` and `:x/class` are one
+            slot, so the inverse chooses a spelling and what must survive
+            is the slot, not the choice.
+
+            Narrowing caught: an inverse that re-splits a name the
+            forward rule never joined. `data-userId` keeps its hyphen
+            because `data-*` is exempt from camelCasing, so a decoder
+            that camel-split it would answer `:data-user-id` and emit
+            `data-user-id` — a prop React sends to the DOM under a name
+            the author never wrote"
+    (doseq [[k expected-slot] (merge slot-corpus/corpus bridge-corpus)]
+      (let [slot    (slot/prop-name k)
+            decoded (codec/prop-key slot)]
+        (is (= expected-slot slot)
+            (str "the corpus row itself moved: " (pr-str k)))
+        (is (= slot (slot/prop-name decoded))
+            (str "decoding " (pr-str slot) " gave " (pr-str decoded)
+                 ", which emits into " (pr-str (slot/prop-name decoded))))))))
+
+(deftest the-taught-spellings-decode-to-themselves
+  (testing "the keys the guide teaches come back as themselves, so a
+            body destructures the keyword its author would have written.
+
+            This row and the one above are BOTH needed and neither
+            subsumes the other: `className` decoded to `:class-name`
+            passes row 1 whole, because `:class-name` emits back into
+            `className` — the rename table is invisible to a
+            slot-preservation law and visible only here"
+    (doseq [k [:class :for :charset
+               :on-click :aria-label :data-index :article-id
+               :children :key :ref :x :--brand-hue]]
+      (is (= k (codec/prop-key (slot/prop-name k)))
+          (str "round trip lost " (pr-str k))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. The outward bridge
+;; ---------------------------------------------------------------------------
+
+(deftest a-native-parents-props-arrive-as-the-views-own-props-map
+  (let [handler (fn [_] :picked)
+        card    (h/as-component article-card)
+        markup  (render-outward!
+                  (react/createElement
+                    card
+                    #js {"articleId" 7
+                         "className" "wide"
+                         "onPick"    handler}
+                    (react/createElement "span" nil "kid")))
+        props   @!received]
+
+    (testing "the view rendered, under the surrounding provider's frame
+              and inside the one root the parent already had. Narrowing
+              caught: a bridge that mounted its own root — the markup
+              would still be right and the frame would not be the
+              parent's"
+      (is (= "<article class=\"wide\">#7</article>" markup)))
+
+    (testing "and the body was handed an ordinary ClojureScript props
+              map, keyed the way its author writes keys. Narrowing
+              caught: handing the body the raw JavaScript object, which
+              renders identically for a body written against it and is
+              precisely the second ABI clause 5 forbids"
+      (is (map? props))
+      (is (= 7 (:article-id props)))
+      (is (= "wide" (:class props))))
+
+    (testing "values cross by identity — nothing is converted, copied or
+              deep-walked on the way in, exactly as nothing is on the way
+              out"
+      (is (identical? handler (:on-pick props))))
+
+    (testing "React's children arrive at `:children`, which is the slot a
+              hiccup caller's children land in too — one spelling,
+              whichever side of the bridge filled it"
+      (is (react/isValidElement (:children props))))
+
+    (testing "and the internal crossing is nowhere in what the body was
+              given: the bridge decodes INTO the props map, so no
+              spelling of `rfProps` is a key a consumer can see"
+      (is (= #{:article-id :class :on-pick :children} (set (keys props)))))))
+
+(deftest the-outward-bridge-adds-no-refusal-of-its-own
+  (testing "a head outside the closed set refuses through the codec's own
+            complaint, at the codec's own coordinate — because the bridge
+            converts props and then calls the same `vec->element` every
+            hiccup vector in every body goes through. The minted
+            component is an ordinary function, so this needs no React
+            between the mistake and the refusal.
+
+            Narrowing caught: a bridge that policed its own argument with
+            a private id. It would read better in isolation and be a
+            spelling no catalogue carries, at a `:where` naming a var the
+            register does not know"
+    (let [bad  (h/as-component 42)
+          data (refusal #(bad #js {}))]
+      (is (= :rf.error/hicasso-bad-head (:rf.error/id data)))
+      (is (= 're-frame.hicasso.impl.codec/vec->element (:where data)))
+      (is (= 42 (:head data)))))
+
+  (testing "and the component it mints names the view it bridges, so a
+            React DevTools tree and an Xray trace agree about which view
+            the extra fiber belongs to"
+    (is (= "hicasso/as-component(re-frame.hicasso.native-abi-cljs-test/article-card)"
+           (.-displayName (h/as-component article-card))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. The ABI helpers
+;; ---------------------------------------------------------------------------
+
+(deftest n-memo-keeps-the-marker-where-a-raw-react-memo-loses-it
+  (testing "`n/memo` answers a real React memo record wrapping the very
+            component it was given — the wrapper is React's, not a
+            reimplementation of it, and nothing sits between them"
+    (is (= (unchecked-get raw-memoised "$$typeof")
+           (unchecked-get memoised "$$typeof")))
+    (is (identical? quote-cell* (unchecked-get memoised "type"))))
+
+  (testing "and it carries the tier marker and the display name across.
+            Narrowing caught: a `memo` that forwarded the call and
+            stamped nothing — it renders identically and every seam that
+            recognises a native head stops recognising this one"
+    (let [m (n/marker memoised)]
+      (is (some? m))
+      (is (= "re-frame.hicasso.native-abi-cljs-test/quote-cell*"
+             (unchecked-get m "name")))
+      (is (= "client-only" (unchecked-get m "server")))
+      (is (= "re-frame.hicasso.native-abi-cljs-test/quote-cell*"
+             (unchecked-get memoised "displayName")))))
+
+  (testing "THE CONTROL, and the reason the helper exists at all: the raw
+            wrapper around the same component answers no marker. If this
+            assertion ever goes green the helper has become decorative"
+    (is (nil? (n/marker raw-memoised))))
+
+  (testing "a component this tier did not mint carries nothing, and the
+            helper says so rather than refusing — UIx is a supported
+            authoring route, and memoising one of its components here is
+            legal and simply has no marker to carry"
+    (is (nil? (n/marker (n/memo (fn [_])))))))
+
+(deftest n-lazy-is-a-native-head-from-the-moment-it-is-declared
+  (let [head (n/lazy (fn [] (js/Promise.resolve quote-cell*)))]
+    (testing "React's own lazy record, so Suspense and the error boundary
+              treat it exactly as they treat any other"
+      (is (= (unchecked-get (react/lazy (fn [] (js/Promise.resolve #js {}))) "$$typeof")
+             (unchecked-get head "$$typeof"))))
+
+    (testing "declared, and already a native head. Narrowing caught:
+              stamping the marker on resolve — every seam reading the
+              head between declaration and arrival would get nil, and
+              that window is the whole of what a code-split head spends
+              being looked at"
+      (is (some? (n/marker head))))
+
+    (testing "with the one field that cannot be known yet honestly
+              absent, rather than guessed from the loader"
+      (is (nil? (unchecked-get (n/marker head) "name"))))))
+
+(deftest a-lazy-region-is-client-only-whatever-its-component-declared
+  (testing "the component itself declares Render — the control, without
+            which the row below cannot tell a policy that was carried
+            from one that was never asked for"
+    (is (= "render" (unchecked-get (n/marker server-cell*) "server"))))
+
+  (testing "and the lazy head around it is Client-only. The server never
+            sent the chunk, so no declaration inside it can make bytes
+            exist; copying the component's policy up would have the
+            runtime claiming hydration for markup it never emitted"
+    (let [head (n/lazy (fn [] (js/Promise.resolve server-cell*)))]
+      (is (= "client-only" (unchecked-get (n/marker head) "server"))))))
+
+(deftest refs-need-no-helper-because-ref-is-an-ordinary-slot
+  (testing "`:ref` normalises to React's own `ref` slot and its value
+            crosses by identity, like every other native prop. React 19
+            hands a function component its ref as a prop, so there is
+            nothing between the author and the ABI for a helper to
+            preserve — which is why the helper surface is two and not
+            three"
+    (let [cell     #js {}
+          js-props (n/props {:ref cell :label "px"})]
+      (is (identical? cell (unchecked-get js-props "ref")))
+      (is (= "px" (unchecked-get js-props "label")))))
+
+  (testing "and a memo record passes props through untouched, so the same
+            slot survives the helper. The DOM half — where the ref
+            actually receives a node — is the dom suite's"
+    (is (identical? quote-cell* (unchecked-get memoised "type")))))

--- a/implementation/hicasso/test/re_frame/hicasso/native_abi_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_abi_cljs_test.cljs
@@ -14,7 +14,7 @@
 
   | row | what it establishes | the one-line narrowing it catches |
   |---|---|---|
-  | [[a-decoded-slot-emits-back-into-the-slot-it-came-from]] | the bridge's inverse is a real inverse of the slot rule, over the whole corpus | an inverse that re-splits a name the forward rule never joined — `data-userId` |
+  | [[a-decoded-slot-emits-back-into-the-slot-it-came-from]] | the bridge's inverse is a real inverse of the slot rule over the corpus's keyword and symbol vocabulary, and the string escape it cannot invert is named rather than skipped | an inverse that re-splits a name the forward rule never joined — `data-userId` |
   | [[the-taught-spellings-decode-to-themselves]] | `className` comes back as `:class`, not as `:class-name` | a missing rename table, which row 1 passes with because both spellings emit into `className` |
   | [[a-native-parents-props-arrive-as-the-views-own-props-map]] | the outward bridge's whole promise, measured in the body | a bridge that handed the body the raw JavaScript object — the second ABI clause 5 forbids |
   | [[the-outward-bridge-adds-no-refusal-of-its-own]] | a bad head refuses through the codec's own id and coordinate | a bridge that minted a private complaint, which is a spelling no catalogue carries |
@@ -127,12 +127,12 @@
    :--brand-hue     "--brand-hue"})
 
 (deftest a-decoded-slot-emits-back-into-the-slot-it-came-from
-  (testing "for every authored key in the corpus, decoding its slot and
-            re-emitting the result lands on the SAME slot. That is the
-            law an inverse of a non-injective rule can actually keep —
-            `:class`, `:className`, `\"class\"` and `:x/class` are one
-            slot, so the inverse chooses a spelling and what must survive
-            is the slot, not the choice.
+  (testing "for every keyword or symbol authored key in the corpus,
+            decoding its slot and re-emitting the result lands on the
+            SAME slot. That is the law an inverse of a non-injective rule
+            can actually keep — `:class`, `:className`, `\"class\"` and
+            `:x/class` are one slot, so the inverse chooses a spelling
+            and what must survive is the slot, not the choice.
 
             Narrowing caught: an inverse that re-splits a name the
             forward rule never joined. `data-userId` keeps its hyphen
@@ -140,14 +140,39 @@
             that camel-split it would answer `:data-user-id` and emit
             `data-user-id` — a prop React sends to the DOM under a name
             the author never wrote"
-    (doseq [[k expected-slot] (merge slot-corpus/corpus bridge-corpus)]
+    (doseq [[k expected-slot] (merge slot-corpus/corpus bridge-corpus)
+            :when             (not (string? k))]
       (let [slot    (slot/prop-name k)
             decoded (codec/prop-key slot)]
         (is (= expected-slot slot)
             (str "the corpus row itself moved: " (pr-str k)))
         (is (= slot (slot/prop-name decoded))
             (str "decoding " (pr-str slot) " gave " (pr-str decoded)
-                 ", which emits into " (pr-str (slot/prop-name decoded))))))))
+                 ", which emits into " (pr-str (slot/prop-name decoded)))))))
+
+  (testing "and the string keys the loop above steps over are named here
+            rather than swept up, because a reader who checks the corpus
+            will find them. A string key is an escape FROM the rule — it
+            means `emit exactly this name` — so `\"on-input\"` emits a slot
+            no keyword reaches, and decoding it gives `:on-input`, whose
+            slot is `onInput`. The correspondence is broken because the
+            forward direction was never a function of the hiccup
+            vocabulary there.
+
+            That is the right answer anyway: a props map handed to a body
+            is application data, and a body receiving `foo-bar` from a
+            JavaScript parent wants `:foo-bar`. Answering the string back
+            would make the law universal by handing the author a key
+            their destructuring cannot see"
+    (is (= "on-input" (slot/prop-name "on-input")))
+    (is (= :on-input (codec/prop-key "on-input")))
+    (is (= "onInput" (slot/prop-name (codec/prop-key "on-input"))))
+
+    (testing "the two string rows that DO round trip do it through the
+              rename table, which is the whole reason they behave
+              differently from the one above"
+      (is (= :class (codec/prop-key (slot/prop-name "class"))))
+      (is (= :for (codec/prop-key (slot/prop-name "for")))))))
 
 (deftest the-taught-spellings-decode-to-themselves
   (testing "the keys the guide teaches come back as themselves, so a

--- a/implementation/hicasso/test/re_frame/hicasso/native_abi_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_abi_dom_cljs_test.cljs
@@ -1,0 +1,587 @@
+(ns re-frame.hicasso.native-abi-dom-cljs-test
+  "THE TWO EMBEDDING DIRECTIONS, AND THE HELPERS, UNDER A REAL REACT
+  (rf2-hic-032).
+
+  A wrapper that preserves the ABI on its FIRST render and loses it on
+  the second is the characteristic defect this bead is about, and no
+  amount of reading a data structure catches it: identity, bail-out,
+  remount and StrictMode are properties of a fiber. So every row here
+  mounts, and every row drives at least one more render or one remount
+  past the mount.
+
+  ## What each row is for, and the narrowing it is written against
+
+  | row | what it establishes | the one-line narrowing it catches |
+  |---|---|---|
+  | [[a-native-parent-mounts-a-view-under-the-frame-it-is-already-in]] | the outward bridge — one root, one frame, no second state owner | a bridge that resolved a frame of its own; the DOM is identical under it |
+  | [[two-frames-are-two-cells-across-the-bridge]] | frames are isolated contexts on the outward crossing too | resolving the frame anywhere but the surrounding context |
+  | [[the-views-memo-wrapper-survives-the-bridge]] | a fresh-but-equal props map still bails the boundary out | a bridge handing the raw object through — every re-render re-runs the body, and the screen is right throughout |
+  | [[a-hicasso-body-hosts-a-native-component-through-the-doors-that-exist]] | the inward door, both spellings, with the native ABI intact at the crossing | a door that allocated a props MAP for the island — the second ABI clause 5 forbids |
+  | [[n-memo-bails-out-and-still-carries-its-marker-on-the-second-render]] | the helper across a re-render, which is where a stamp gets lost | copying the marker into a per-render wrapper |
+  | [[a-fresh-mint-replaces-the-subtree-and-that-is-the-hmr-contract]] | allocation, never a lookup by name | a helper caching by display name to "survive" a reload |
+  | [[strict-modes-double-mount-crosses-the-bridge-exactly-once]] | acquire is commit-owned on both sides of the crossing | a bridge acquiring during render |
+  | [[a-ref-reaches-a-real-dom-node-through-the-memo-helper]] | why there is no third helper | a `forward-ref` helper — the row is green with and without it, and the point is that it is green WITHOUT |
+  | [[a-lazy-head-suspends-and-then-names-its-own-component]] | the marker is filled by arrival, in the object minted at declaration | a second marker minted on resolve |
+  | [[teardown-across-the-bridge-releases-exactly-what-mount-acquired]] | the bridge adds no ownership of its own | a wrapper holding a cell reference past unmount |
+  | [[the-declared-population-was-actually-exercised]] | the roster, asserted rather than described | a row that started returning early |
+
+  ## Browser lane
+
+  `:node-test` compiles this namespace too (`cljs-test$` matches
+  `-dom-cljs-test`), and each row degrades there to a STATED skip rather
+  than to a false green. What can be said without a fiber is said in
+  `re-frame.hicasso.native-abi-cljs-test`."
+  (:require [clojure.set :as set]
+            [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.native :as n]
+            [re-frame.hicasso.roots-frames-support :as support]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]))
+
+(def ^:private alpha ::alpha)
+(def ^:private beta  ::beta)
+
+(rf/reg-sub ::label (fn [db _] (:label db)))
+(rf/reg-event ::seed (fn [_ [_ label]] {:db {:label label}}))
+(rf/reg-event ::relabel (fn [{:keys [db]} [_ label]] {:db (assoc db :label label)}))
+
+;; ---------------------------------------------------------------------------
+;; The roster this file undertakes to reach
+;; ---------------------------------------------------------------------------
+
+(def ^:private declared-population
+  #{:bridge/outward
+    :bridge/two-frames
+    :bridge/memo-bail-out
+    :bridge/inward
+    :helper/memo-across-a-re-render
+    :helper/fresh-mint-remounts
+    :bridge/strict-mode
+    :helper/ref-to-a-node
+    :helper/lazy-arrival
+    :bridge/teardown})
+
+(defonce ^:private !exercised (atom #{}))
+
+(defn- exercised! [mechanism] (swap! !exercised conj mechanism) nil)
+
+;; ---------------------------------------------------------------------------
+;; The consumer's source — one view, bridged outward; one island, hosted
+;; inward
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !view-runs (atom 0))
+(defonce ^:private !island-runs (atom 0))
+(defonce ^:private !island-props (atom nil))
+
+(h/defview article-card
+  "An ordinary boundary. It reads a subscription, so the frame it
+  resolved is observable in the cell table rather than only on screen."
+  [props]
+  (swap! !view-runs inc)
+  [:article {:class "card"} (str "#" (:article-id props) " " (h/sub [::label]))])
+
+(def ^:private card
+  "THE OUTWARD BRIDGE, declared once at top level beside the view it
+  bridges — which is the law, not a habit: it allocates a component."
+  (h/as-component article-card))
+
+(n/defcomponent bridging-parent
+  "A native parent that renders the bridged view and can re-render itself
+  for a reason the runtime knows nothing about. The local state is what
+  makes the bail-out row possible: without it there is no way to drive a
+  second render whose props are equal."
+  [^js props]
+  (let [[local set-local] (react/useState 0)]
+    (n/$ :div nil
+         (n/$ :button {:class "nudge" :on-click (fn [_] (set-local inc))} "nudge")
+         (n/$ :i {:class "local"} (str local))
+         ;; A LITERAL props map, lowered by the native macro into React's
+         ;; own slot names and decoded back by the bridge — so this row
+         ;; also drives the two fences' round trip end to end.
+         (n/$ card {:article-id (.-articleId props)}))))
+
+(h/defview outward-host
+  "Rung 3: a boundary returning the native parent, which is how the
+  outward bridge is reached from a root without a second root."
+  [{:keys [article-id]}]
+  (n/$ bridging-parent {:article-id article-id}))
+
+(h/defview strict-outward-host
+  [{:keys [article-id]}]
+  (n/$ react/StrictMode nil (n/$ bridging-parent {:article-id article-id})))
+
+(defn- island-body
+  "The island's body, held apart from any mint so a row can allocate two
+  components over ONE body — which is what a module reload does."
+  [^js props]
+  (swap! !island-runs inc)
+  (reset! !island-props props)
+  (n/$ :b {:class "island"} (str (.-label props) "/" (n/use-sub [::label]))))
+
+(def ^:private hot-cell (n/component "app/hot-cell" :client-only island-body))
+(def ^:private memo-cell (n/memo hot-cell))
+
+(h/defhost cell-host memo-cell)
+
+(h/defview inward-host
+  "The inward door, both spellings in one body: the named `defhost`
+  crossing and the one-off `[:>]` escape.
+
+  `:tick` is what makes the bail-out row possible and it is not
+  decoration. A boundary compares its complete props map, so re-rendering
+  this root with the SAME props bails the boundary itself out and nothing
+  below it runs — the row would then be measuring a body that never
+  executed. `:tick` moves, the body runs, and the two crossings beneath
+  it are the thing under test."
+  [{:keys [tick]}]
+  [:div
+   [:span.tick (str tick)]
+   [cell-host {:label "hosted"}]
+   [:> hot-cell {:label "raw"}]])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (support/leave-act-environment!)
+                      (reset! !view-runs 0)
+                      (reset! !island-runs 0)
+                      (reset! !island-props nil)
+                      (collector/reset-runtime!))}))
+
+(defn- seat!
+  [frame-kw label]
+  (rf/make-frame {:id frame-kw})
+  (rf/with-frame frame-kw (rf/dispatch-sync [::seed label]))
+  nil)
+
+(defn- at [handle sel] (.querySelector ^js (:container handle) sel))
+(defn- text-at [handle sel] (some-> (at handle sel) .-textContent))
+(defn- click! [handle sel] (.click ^js (at handle sel)) (mount/settle!) nil)
+
+(defn- label-key [frame-kw] [frame-kw [::label]])
+(defn- readers-of [sub-key] (inventory/cell-readers sub-key))
+
+(defn- mount-live!
+  "Mount `hiccup` under `frame-kw` and return only once `sub-key` has
+  exactly `readers` subscribed readers — a commit-owned fact, so a row
+  that started before it would be measuring a tree that had not yet
+  joined the runtime."
+  [frame-kw hiccup sub-key readers]
+  (let [container (mount/fresh-container!)
+        handle    (mount/root! container frame-kw hiccup)]
+    (-> (support/wait-until! #(= readers (count (readers-of sub-key))))
+        (.then (fn [subscribed?]
+                 (when-not subscribed?
+                   (throw (ex-info (str "expected " readers " reader(s) on "
+                                        (pr-str sub-key))
+                                   {:residue (inventory/residue)})))
+                 handle)))))
+
+(defn- fail-and-finish!
+  [done label handle]
+  (fn [e]
+    (is false (str label " — " (.-message e)
+                   " | residue " (pr-str (inventory/residue))))
+    (when handle (mount/release! handle))
+    (done)))
+
+;; ---------------------------------------------------------------------------
+;; 1. The outward bridge
+;; ---------------------------------------------------------------------------
+
+(deftest a-native-parent-mounts-a-view-under-the-frame-it-is-already-in
+  (async done
+    (if-not (mount/browser?)
+      (do (support/skip! ":node-test has no React DOM") (done))
+      (do
+        (seat! alpha "seed")
+        (-> (mount-live! alpha [outward-host {:article-id 7}] (label-key alpha) 1)
+            (.then
+              (fn [handle]
+                (testing "the view painted, inside the parent's own DOM and
+                          with the props the native macro lowered and the
+                          bridge decoded — `:article-id` out, `articleId`
+                          across, `:article-id` back"
+                  (is (= "#7 seed" (text-at handle ".card"))))
+
+                (testing "and its read built ONE cell, under the frame the
+                          surrounding root installed. Narrowing caught: a
+                          bridge resolving a frame of its own — the paint
+                          above is identical under it, and this key would
+                          name a different frame or no cell would exist at
+                          all"
+                  (is (= #{(label-key alpha)} (support/cell-keys)))
+                  (is (= 1 (count (readers-of (label-key alpha))))))
+
+                (testing "a write through the surrounding frame reaches the
+                          bridged view, so the crossing is a place in the
+                          application rather than an island of its own
+                          state"
+                  (rf/with-frame alpha (rf/dispatch-sync [::relabel "moved"]))
+                  (mount/settle!)
+                  (is (= "#7 moved" (text-at handle ".card"))))
+
+                (exercised! :bridge/outward)
+                (support/teardown-census! handle)
+                (done)))
+            (.catch (fail-and-finish! done "outward bridge" nil)))))))
+
+(deftest two-frames-are-two-cells-across-the-bridge
+  (async done
+    (if-not (mount/browser?)
+      (do (support/skip! ":node-test has no React DOM") (done))
+      (do
+        (seat! alpha "A")
+        (seat! beta "B")
+        (-> (mount-live! alpha [outward-host {:article-id 1}] (label-key alpha) 1)
+            (.then (fn [a]
+                     (-> (mount-live! beta [outward-host {:article-id 2}]
+                                      (label-key beta) 1)
+                         (.then (fn [b] [a b])))))
+            (.then
+              (fn [[a b]]
+                (testing "one view, two frames, two paints — each reading
+                          its own frame's value through the bridge"
+                  (is (= "#1 A" (text-at a ".card")))
+                  (is (= "#2 B" (text-at b ".card"))))
+
+                (testing "and TWO cells, differing only in their frame.
+                          Narrowing caught: a bridge that resolved one
+                          frame for both — there would be ONE key here and
+                          two visually plausible subtrees above"
+                  (is (= #{(label-key alpha) (label-key beta)}
+                         (support/cell-keys))))
+
+                (testing "a write to one frame moves one screen. Frames are
+                          isolated contexts, and the outward crossing is
+                          not a hole in that"
+                  (rf/with-frame alpha (rf/dispatch-sync [::relabel "A'"]))
+                  (mount/settle!)
+                  (is (= "#1 A'" (text-at a ".card")))
+                  (is (= "#2 B" (text-at b ".card"))))
+
+                (exercised! :bridge/two-frames)
+                (support/teardown-census! a)
+                (support/teardown-census! b)
+                (done)))
+            (.catch (fail-and-finish! done "two frames across the bridge" nil)))))))
+
+(deftest the-views-memo-wrapper-survives-the-bridge
+  (async done
+    (if-not (mount/browser?)
+      (do (support/skip! ":node-test has no React DOM") (done))
+      (do
+        (seat! alpha "seed")
+        (-> (mount-live! alpha [outward-host {:article-id 7}] (label-key alpha) 1)
+            (.then
+              (fn [handle]
+                (let [after-mount @!view-runs]
+                  (testing "the parent re-renders for a reason of its own —
+                            local React state — and hands the bridge a
+                            FRESH props object carrying an equal value"
+                    (click! handle ".nudge")
+                    (is (= "1" (text-at handle ".local"))
+                        "the parent really did re-render"))
+
+                  (testing "and the view's body did not run again. The
+                            boundary's stable memo wrapper compares the
+                            complete props map by `=`, and the bridge hands
+                            it a map — so a fresh object with equal
+                            contents still bails out.
+
+                            Narrowing caught: a bridge passing React's raw
+                            props object through to the shell. `Object.is`
+                            is false on every render, the body re-runs
+                            every time, and the screen is correct
+                            throughout"
+                    (is (= after-mount @!view-runs)))
+
+                  (testing "a CHANGED prop crosses, which is the control
+                            without which the row above is satisfied by a
+                            bridge that never re-renders anything"
+                    (mount/render! handle [outward-host {:article-id 8}])
+                    (is (= "#8 seed" (text-at handle ".card")))
+                    (is (< after-mount @!view-runs))))
+
+                (exercised! :bridge/memo-bail-out)
+                (support/teardown-census! handle)
+                (done)))
+            (.catch (fail-and-finish! done "memo across the bridge" nil)))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. The inward door
+;; ---------------------------------------------------------------------------
+
+(deftest a-hicasso-body-hosts-a-native-component-through-the-doors-that-exist
+  (async done
+    (if-not (mount/browser?)
+      (do (support/skip! ":node-test has no React DOM") (done))
+      (do
+        (seat! alpha "in")
+        ;; Two islands, one key: the wait is for both readers, so neither
+        ;; crossing can be measured before it has joined the runtime.
+        (-> (mount-live! alpha [inward-host {:tick 0}] (label-key alpha) 2)
+            (.then
+              (fn [handle]
+                (testing "both doors mounted the island and both islands
+                          read the SURROUNDING frame — the named `defhost`
+                          crossing and the one-off `[:>]` escape. There is
+                          no third door and neither of these two needed to
+                          learn that a native tier exists"
+                  (let [cells (.querySelectorAll ^js (:container handle) ".island")]
+                    (is (= 2 (.-length cells)))
+                    (is (= "hosted/in" (.-textContent (aget cells 0))))
+                    (is (= "raw/in" (.-textContent (aget cells 1))))))
+
+                (testing "and the crossing handed the island the ONE ABI: a
+                          raw JavaScript props object under React's own
+                          slot names, values by identity. Narrowing
+                          caught: a door allocating a ClojureScript map for
+                          the island — it renders identically for a body
+                          written against a map, and it is the second ABI
+                          clause 5 forbids"
+                  (let [props @!island-props]
+                    (is (not (map? props)))
+                    (is (= "raw" (unchecked-get props "label")))))
+
+                (testing "one key, two readers — the two islands share the
+                          runtime's own cell rather than each building a
+                          private one"
+                  (is (= #{(label-key alpha)} (support/cell-keys)))
+                  (is (= 2 (count (readers-of (label-key alpha))))))
+
+                (exercised! :bridge/inward)
+                (support/teardown-census! handle)
+                (done)))
+            (.catch (fail-and-finish! done "inward door" nil)))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. The helpers, across a second render and a remount
+;; ---------------------------------------------------------------------------
+
+(deftest n-memo-bails-out-and-still-carries-its-marker-on-the-second-render
+  (async done
+    (if-not (mount/browser?)
+      (do (support/skip! ":node-test has no React DOM") (done))
+      (do
+        (seat! alpha "in")
+        (-> (mount-live! alpha [inward-host {:tick 0}] (label-key alpha) 2)
+            (.then
+              (fn [handle]
+                (let [after-mount @!island-runs]
+                  (testing "the hosting body re-runs — `:tick` moved, so the
+                            boundary above did not bail out and both
+                            crossings were re-created — and the memoised
+                            island bails out while the un-memoised one
+                            beside it re-renders. The second island is the
+                            control: without it a helper that broke the
+                            whole subtree would read the same"
+                    (mount/render! handle [inward-host {:tick 1}])
+                    (is (= "1" (text-at handle ".tick"))
+                        "the hosting body really did re-run")
+                    (is (= (inc after-mount) @!island-runs)
+                        "exactly one of the two islands re-ran"))
+
+                  (testing "and the marker is still on the memo record after
+                            the render that used it. Narrowing caught: a
+                            helper that stamped a per-render wrapper — the
+                            first read is green, every later one is nil,
+                            and nothing on screen changes"
+                    (let [m (n/marker memo-cell)]
+                      (is (some? m))
+                      (is (= "app/hot-cell" (unchecked-get m "name")))
+                      (is (= "client-only" (unchecked-get m "server"))))))
+
+                (exercised! :helper/memo-across-a-re-render)
+                (support/teardown-census! handle)
+                (done)))
+            (.catch (fail-and-finish! done "memo across a re-render" nil)))))))
+
+(deftest a-fresh-mint-replaces-the-subtree-and-that-is-the-hmr-contract
+  (async done
+    (if-not (mount/browser?)
+      (do (support/skip! ":node-test has no React DOM") (done))
+      ;; The reload, performed: the SAME body function, allocated a second
+      ;; time, exactly as re-evaluating a module does.
+      (let [reloaded (n/memo (n/component "app/hot-cell" :client-only island-body))]
+        (seat! alpha "in")
+        ;; The SAME crossing on both renders — the `[:>]` escape shares one
+        ;; gate type for every component on the page — so the only thing
+        ;; that changes between them is the mint. Swapping the crossing
+        ;; itself would remount for a reason that is not the one under
+        ;; test.
+        (-> (mount-live! alpha [:> memo-cell {:label "one"}] (label-key alpha) 1)
+            (.then
+              (fn [handle]
+                (let [before (at handle ".island")]
+                  (testing "the reloaded mint is a DIFFERENT element type
+                            under the same name, which is the contract:
+                            minting is allocation, never a lookup"
+                    (is (not (identical? memo-cell reloaded)))
+                    (is (= "app/hot-cell"
+                           (unchecked-get (n/marker reloaded) "name"))))
+
+                  (testing "so React replaces the subtree rather than
+                            updating it — a clean remount across a save,
+                            which is the designed conduct and not a fault.
+                            Narrowing caught: a helper caching by display
+                            name to `preserve` identity across a reload; it
+                            would keep this node and quietly contradict the
+                            recorded contract"
+                    (mount/render! handle [:> reloaded {:label "two"}])
+                    (let [after (at handle ".island")]
+                      (is (= "two/in" (.-textContent after)))
+                      (is (not (identical? before after))))))
+
+                (exercised! :helper/fresh-mint-remounts)
+                (support/teardown-census! handle)
+                (done)))
+            (.catch (fail-and-finish! done "fresh mint" nil)))))))
+
+(deftest strict-modes-double-mount-crosses-the-bridge-exactly-once
+  (async done
+    (if-not (mount/browser?)
+      (do (support/skip! ":node-test has no React DOM") (done))
+      (do
+        (seat! alpha "strict")
+        (-> (mount-live! alpha [strict-outward-host {:article-id 3}]
+                         (label-key alpha) 1)
+            (.then
+              (fn [handle]
+                (testing "React's double invoke and mount/unmount/mount over
+                          every effect leaves ONE cell with ONE reader
+                          through the bridge. Narrowing caught: a bridge
+                          acquiring during render rather than at commit —
+                          the extra acquisition has no matching release"
+                  (is (= "#3 strict" (text-at handle ".card")))
+                  (is (= #{(label-key alpha)} (support/cell-keys)))
+                  (is (= 1 (count (readers-of (label-key alpha))))))
+
+                (exercised! :bridge/strict-mode)
+                (support/teardown-census! handle)
+                (done)))
+            (.catch (fail-and-finish! done "strict mode" nil)))))))
+
+(deftest a-ref-reaches-a-real-dom-node-through-the-memo-helper
+  (async done
+    (if-not (mount/browser?)
+      (do (support/skip! ":node-test has no React DOM") (done))
+      (let [cell     (react/createRef)
+            forwards (n/memo
+                       (n/component "app/ref-cell" :client-only
+                                    (fn [^js props]
+                                      (n/$ :input {:class "reffed"
+                                                   :ref   (.-ref props)}))))]
+        (seat! alpha "refs")
+        (let [container (mount/fresh-container!)
+              handle    (mount/root! container alpha [:> forwards {:ref cell}])]
+          (testing "the ref reached the DOM node, through a memo record and
+                    with no helper between the author and it. React 19
+                    hands a function component its ref as an ordinary prop,
+                    which is why the helper surface is two rather than
+                    three — this row is green WITHOUT a `forward-ref`
+                    helper, and that is its point"
+            (is (some? (.-current cell)))
+            (is (= "INPUT" (.-tagName (.-current cell))))
+            (is (identical? (at handle ".reffed") (.-current cell))))
+
+          (testing "and the marker rode across the memo unharmed"
+            (is (= "app/ref-cell" (unchecked-get (n/marker forwards) "name"))))
+
+          (exercised! :helper/ref-to-a-node)
+          (mount/release! handle)
+          (done))))))
+
+(deftest a-lazy-head-suspends-and-then-names-its-own-component
+  (async done
+    (if-not (mount/browser?)
+      (do (support/skip! ":node-test has no React DOM") (done))
+      (let [arrived  (n/component "app/arrived" :client-only
+                                  (fn [^js props]
+                                    (n/$ :b {:class "arrived"} (.-label props))))
+            head     (n/lazy (fn [] (js/Promise.resolve arrived)))
+            marker-0 (n/marker head)
+            shell    (n/component
+                       "app/suspense-shell" :client-only
+                       (fn [^js _props]
+                         (n/$ react/Suspense
+                              {:fallback (n/$ :i {:class "waiting"} "…")}
+                              (n/$ head {:label "late"}))))]
+        (seat! alpha "lazy")
+        (let [container (mount/fresh-container!)
+              handle    (mount/root! container alpha [:> shell {}])]
+          (testing "before arrival the head is already a native head, and
+                    the one field that cannot be known yet says so"
+            (is (some? marker-0))
+            (is (nil? (unchecked-get marker-0 "name"))))
+
+          (-> (support/wait-until! #(some? (at handle ".arrived")))
+              (.then
+                (fn [ok?]
+                  (is ok? "the lazy component never arrived")
+                  (testing "the component mounted where the fallback stood"
+                    (is (= "late" (text-at handle ".arrived")))
+                    (is (nil? (at handle ".waiting"))))
+
+                  (testing "and the SAME marker object now names it.
+                            Narrowing caught: a second marker minted on
+                            resolve — a seam that read the head while it was
+                            loading would hold a stale one forever"
+                    (is (identical? marker-0 (n/marker head)))
+                    (is (= "app/arrived" (unchecked-get marker-0 "name")))
+                    (is (= "client-only" (unchecked-get marker-0 "server"))))
+
+                  (exercised! :helper/lazy-arrival)
+                  (mount/release! handle)
+                  (done)))
+              (.catch (fail-and-finish! done "lazy arrival" handle))))))))
+
+;; ---------------------------------------------------------------------------
+;; 4. Teardown, and the roster
+;; ---------------------------------------------------------------------------
+
+(deftest teardown-across-the-bridge-releases-exactly-what-mount-acquired
+  (async done
+    (if-not (mount/browser?)
+      (do (support/skip! ":node-test has no React DOM") (done))
+      (do
+        (seat! alpha "bye")
+        (-> (mount-live! alpha [outward-host {:article-id 9}] (label-key alpha) 1)
+            (.then
+              (fn [handle]
+                (let [census (support/teardown-census! handle)]
+                  (testing "unmounting the root through the bridge leaves
+                            nothing behind. The census is read BEFORE the
+                            fixture's page-wide reset, which empties every
+                            table by fiat and would read zeros whether the
+                            teardown released anything or not.
+
+                            Narrowing caught: a bridge wrapper retaining a
+                            cell reference — the screen is gone and the
+                            runtime still holds the subscription"
+                    (is (= {:cell-refs 0 :boundaries 0 :edges 0} census))))
+
+                (exercised! :bridge/teardown)
+                (done)))
+            (.catch (fail-and-finish! done "teardown" nil)))))))
+
+(deftest the-declared-population-was-actually-exercised
+  (if-not (mount/browser?)
+    (support/skip! ":node-test has no React DOM, so no mechanism was reached")
+    (is (= declared-population @!exercised)
+        (str "unreached: " (pr-str (set/difference declared-population
+                                                   @!exercised))))))

--- a/implementation/hicasso/test/re_frame/hicasso/native_abi_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_abi_dom_cljs_test.cljs
@@ -123,7 +123,8 @@
   [^js props]
   (swap! !island-runs inc)
   (reset! !island-props props)
-  (n/$ :b {:class "island"} (str (.-label props) "/" (n/use-sub [::label]))))
+  (let [label (n/use-sub [::label])]
+    (n/$ :b {:class "island"} (str (.-label props) "/" label))))
 
 (def ^:private hot-cell (n/component "app/hot-cell" :client-only island-body))
 (def ^:private memo-cell (n/memo hot-cell))
@@ -573,7 +574,7 @@
                             Narrowing caught: a bridge wrapper retaining a
                             cell reference — the screen is gone and the
                             runtime still holds the subscription"
-                    (is (= {:cell-refs 0 :boundaries 0 :edges 0} census))))
+                    (is (= support/released census))))
 
                 (exercised! :bridge/teardown)
                 (done)))

--- a/implementation/hicasso/test/re_frame/hicasso/native_abi_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_abi_dom_cljs_test.cljs
@@ -18,7 +18,7 @@
   | [[the-views-memo-wrapper-survives-the-bridge]] | a fresh-but-equal props map still bails the boundary out | a bridge handing the raw object through — every re-render re-runs the body, and the screen is right throughout |
   | [[a-hicasso-body-hosts-a-native-component-through-the-doors-that-exist]] | the inward door, both spellings, with the native ABI intact at the crossing | a door that allocated a props MAP for the island — the second ABI clause 5 forbids |
   | [[n-memo-bails-out-and-still-carries-its-marker-on-the-second-render]] | the helper across a re-render, which is where a stamp gets lost | copying the marker into a per-render wrapper |
-  | [[a-fresh-mint-replaces-the-subtree-and-that-is-the-hmr-contract]] | allocation, never a lookup by name | a helper caching by display name to "survive" a reload |
+  | [[a-fresh-mint-replaces-the-subtree-and-that-is-the-hmr-contract]] | allocation, never a lookup by name | a helper caching by display name so a component outlives a reload |
   | [[strict-modes-double-mount-crosses-the-bridge-exactly-once]] | acquire is commit-owned on both sides of the crossing | a bridge acquiring during render |
   | [[a-ref-reaches-a-real-dom-node-through-the-memo-helper]] | why there is no third helper | a `forward-ref` helper — the row is green with and without it, and the point is that it is green WITHOUT |
   | [[a-lazy-head-suspends-and-then-names-its-own-component]] | the marker is filled by arrival, in the object minted at declaration | a second marker minted on resolve |


### PR DESCRIPTION
## rf2-hic-032 — ABI-preserving helpers + the two embedding bridges

Native-boundary law clause 5 says element construction, `n/defcomponent`, memo,
lazy loading, refs and **both** embedding directions share one props/children
ABI, and that there is no separate ergonomic and fast one. Three of those six
had no code. This lands them, and the shape of the landing is that almost
nothing new was needed.

### `n/memo` and `n/lazy` — they did not exist, and the guide already taught them

`docs/design/hicasso/draft-guide/10-native-tier.md` has been telling readers to
reach for `n/memo` / `n/lazy` when a raw React wrapper erases the tier marker —
"same semantics, marker intact" — and `20-code-splitting.md` builds its whole
Suspense recipe on `n/lazy`. Verified before writing anything: a grep for both
across `implementation/hicasso/src/` returned nothing. They exist now and the
guide's sentences are true.

What they preserve, and how it is proved:

- **`n/memo`** is `react/memo` with the tier marker and `displayName` carried
  onto the memo record. Nothing else — a memo passes props through untouched,
  so there is no ABI to repair, only a stamp to carry. Proved with its own
  control beside it: `(react/memo quote-cell*)` answers `nil` from `n/marker`
  and `(n/memo quote-cell*)` answers the marker, in the same row. A second row
  drives a real re-render and re-reads the marker, because the characteristic
  failure is a stamp that is right on render one and gone on render two.
  Wrapping a component this tier did not mint (a UIx `defui`) carries nothing
  and refuses nothing — UIx is a supported authoring route.
- **`n/lazy`** is `react/lazy` with two knots untied. The loader is a thunk
  returning a promise that resolves **to the component**, not to a
  `#js {:default …}` module record — every ClojureScript splitter already
  resolves to the value, so the wrapper goes on here once. And the marker is
  minted **at declaration**, with its `:name` filled in when the payload
  arrives, in the *same object*: a lazy head is a head during the whole window
  it spends waiting, which is the window a seam actually looks at it in. Its
  `:server` is `client-only` and is **not** the inner component's to override —
  the server never sent the chunk, so no declaration inside it can make bytes
  exist. The DOM row mounts a real Suspense host, waits for arrival and asserts
  the marker object's identity across it.
- **Refs need no helper and get none.** React 19 hands a function component its
  `ref` as an ordinary prop, so `:ref` is already the one ABI at the one slot.
  The witness is a ref reaching a real `<input>` through `n/memo` with nothing
  between the author and it — the row is green *without* a `forward-ref` helper,
  and that is its point. The guide already says this; the code now agrees.

The HMR contract is honoured rather than fought: a fresh mint is a fresh element
type and React replaces the subtree. There is a row that performs the reload —
the same body function, allocated twice — and asserts the DOM node identity
changed.

### The outward bridge: `h/as-component`

A native, UIx or plain-JavaScript parent renders a minted Hicasso view under the
frame it is already in.

```clojure
(def article-card* (h/as-component article-card))
;; on the React side: <ArticleCard articleId={7} />
```

**It mints no crossing of its own.** It decodes the React props object into an
ordinary ClojureScript props map and calls `codec/vec->element` — the same entry
every hiccup vector in every body already goes through. That single decision is
what makes clause 5 true by construction rather than by inspection:

- one props/children ABI, because there is no second element builder;
- `rfProps` is written in exactly the one place it was written before, and is
  invisible to the consumer (the body's props map has only the parent's keys);
- the view keeps its stable memo wrapper — a fresh-but-`=` props map still bails
  the boundary out, witnessed by a parent re-rendering on its own local state
  while the view's body run count does not move, with a changed-prop control
  beside it;
- **no new complaint id and no Spec 009 row**: a bad head refuses through
  `:rf.error/hicasso-bad-head` at `:where`
  `re-frame.hicasso.impl.codec/vec->element`, from out here as from a body.

The props decode is `codec/prop-key`, `slot/prop-name` read backwards — so
`(n/$ card {:article-id 7})` on the native side arrives at the body as
`:article-id`, and `articleId={7}` from JavaScript reaches the same place. The
correspondence is witnessed twice over `slot-corpus`: every keyword/symbol row's
decoded key emits back into the *same* slot, and the taught spellings decode to
themselves. Neither row subsumes the other — `className` decoded to
`:class-name` passes the first and fails the second, which is what the rename
table is for. The one correspondence it does **not** have is named in the
docstring and in a row of its own rather than skipped: `slot/prop-name`'s
*string* arm is an escape from the rule (`"on-input"` emits `on-input`, which no
keyword reaches), so decoding it gives `:on-input` — the right answer for a
props map that is application data, and a broken round trip.

**Why it lives on `h` and not on `n`.** Clause 6 (optional native-tier rent): a
UIx or JavaScript parent must not have to require the native namespace, and
therefore ship it, in order to cross inward. The guide and `naming-ledger.md`
row 28 already place and name it here.

### The inward door: it already existed, and that is the finding

A Hicasso boundary hosts an `n/defcomponent` through the seams that are already
built — `h/defhost` for a named crossing, `[:>]` for a one-off. **No new API,
and deliberately none**: making a marked native component a first-class hiccup
head would put native-tier knowledge inside the interpreted codec and break
clause 6, since an interpreted-only bundle would then reach the tier through a
door that names it. Both doors already hand the component a raw JavaScript props
object under React's own slot names, which *is* the native ABI.

Tested rather than asserted: one body carrying both spellings, both islands
reading the surrounding frame through `n/use-sub`, one cell with two readers, and
a row proving the props object the island received is not a ClojureScript map.

### Coverage across the matrix

Two frames, HMR (a real second mint), StrictMode, memo bail-out, lazy arrival,
ref forwarding, teardown census — each in its own row, each driving a second
render or a remount past the mount, each carrying the one-line narrowing it is
written against. The DOM suite declares its population and the last row fails if
any mechanism went unreached. No test reads `rfProps`.

### Sabotage control

`carry!`'s marker copy deleted from `native.cljc`, focused suite re-run:

```
FAIL in (n-memo-keeps-the-marker-where-a-raw-react-memo-loses-it) (re_frame/hicasso/native_abi_cljs_test.cljs:280:11)
expected: (some? m)
  actual: (not (some? nil))

ERROR in (n-memo-keeps-the-marker-where-a-raw-react-memo-loses-it) (re_frame/hicasso/native_abi_cljs_test.cljs:281:11)
expected: (= "re-frame.hicasso.native-abi-cljs-test/quote-cell*" (unchecked-get m "name"))
  actual: #object[TypeError TypeError: Cannot read properties of undefined (reading 'name')]

Ran 8 tests containing 124 assertions.
1 failures, 2 errors.
```

Restored with `git checkout --` and verified **by hash**, not by `git diff`:
`sha256 f63743f54c6dbc7136e4676f533f92b981b586305070c745551c96ec63cfd032`
before and after, identical.

### Facade export classification

One new export: **`re-frame.hicasso/as-component`** — a public runtime fn,
aliasing `re-frame.hicasso.impl.codec/as-component`.

| Question | Answer |
|---|---|
| Classification | Public authoring surface, interop tier. The outward half of the seam `defhost` / `[:>]` form the inward half of. |
| Why it must be public | There is no other spelling. A `defview` product mounted raw reads `rfProps`, gets `undefined` and receives nil props — the codec already refuses that mistake at `[:>]` (`:rf.error/hicasso-raw-not-a-component`, recovery "a Hicasso view is a head in its own right") and had no answer for a React *parent*. |
| Why on this facade | Clause 6 rent — see above. |
| Name | Settled: `naming-ledger.md` row 28, "keep as taught"; glossary and guide ch09 already carry it. |
| Cost when unused | One `def` alias. `impl.codec` was already reachable from this facade transitively (`impl.mount` requires it), so the new `:require` adds no bundle reachability. |
| New surface area | None beyond the fn: no new complaint id, no Spec 009 row, no new option map, no second ABI. |

### Two gaps found while reading, NOT actioned (out of fence — `docs/**`)

1. **`h/as-element` does not exist.** Guide ch09 calls it and `h/as-component`
   "the two halves of one seam", ch10's troubleshooting table prescribes it, and
   `impl/intent`'s own docstring records that four design documents copied the
   spelling before anyone checked it resolved — the gap is `rf2-2rtt6.120`. This
   bead's brief scopes it to the two *embedding* bridges, so it is untouched.
2. **`defhost`'s `:slots` option does not exist.** `codec/host-options` is
   `#{:callbacks :ssr}`, and an unknown key refuses at mint with
   `:rf.error/hicasso-host-unknown-option`. So guide ch20's taught Suspense-host
   recipe — `(h/defhost suspense react/Suspense {:slots #{:fallback}})` — cannot
   be written today. The lazy DOM row hosts Suspense natively (`n/$ react/Suspense`)
   instead, which works and is inside the fence. Worth a bead.

Also worth the operator's eye: `n/lazy`'s **loader shape** is recorded as open in
`naming-ledger.md` row 29 (the sitting, rf2-hic-093). What shipped is the shape
the guide teaches — thunk → promise → the component. If the sitting rules
otherwise, one line of `n/lazy` changes.

## Quality gates

| Gate | Exit | Notes |
|---|---|---|
| `scripts/test-fast-pr.sh` | 0 | the spine, from the worktree root — ends `PASS fast PR spine` |
| `implementation` `npm run test:cljs` | 0 | 13261 tests, 67073 assertions, 0 failures |
| `implementation` `npm run test:browser` | 0 | 1252 tests, 7717 assertions, 0 failures — the real-DOM lane, where every identity/remount row actually runs |
| `hicasso/scripts/check_complaint_catalogue.py` | 0 | 65 live, 6 reserved, 1 pending, 1 retired — unchanged, because this PR mints no id |
| `hicasso/scripts/check_freeze.py` | 0 | `impl/slot.cljc` is frozen at 109 lines, so the slot rule's inverse went into the codec instead |
| `hicasso/scripts/check_optional_module_reachability.py` | 0 | motion still unreachable from the public door |
| `hicasso/scripts/check_lint_export.py` | 0 | |
| `scripts/check_test_lane_bijection.py` | 0 | both new suites are selected by their regexes; no build config changed |
| `scripts/check_fast_pr_gap.py --list` | — | derived; 96 required checks the spine does not decide |

Not run, with reasons:

- `mkdocs build --strict` — no `docs/` file changed.
- `scripts/check_doc_slugs.py` — same.
- `npm run build:hicasso-release` (`:advanced`) — CI's own step; nothing here is
  `goog.DEBUG`-gated or adds a production sentinel, and the tier sentinel's
  reachability proof is unchanged.
- The Xray / Story / perf-bundle / mcp-conformance gates — no surface touched.
