### PR TITLE
docs(hicasso): record the erasure gate's reachability rule (rf2-nkr3)

### DIFF
--- a/implementation/hicasso/scripts/check_production_erasure.cjs
+++ b/implementation/hicasso/scripts/check_production_erasure.cjs
@@ -59,6 +59,34 @@
  * this file names for it, so a rename fails the gate rather than reporting
  * a green absence for a string nobody emits any more.
  *
+ * ## A tap drags its namespace's requires onto the shipped path
+ *
+ * The evidence row below says `re-frame.hicasso.evidence` is dev-only BY
+ * REACHABILITY rather than by any marker on it, and one rule follows from
+ * that which this gate keeps having to teach the hard way (rf2-hic-081,
+ * rf2-nkr3). Reachability is a property of NAMESPACES, not of expressions:
+ * a collector tap on the shipped path is reachable from the public door,
+ * so everything the tap's namespace `:require`s is reachable too. The
+ * capability-receipts spike put a receipt envelope in `impl/receipt` and
+ * required `re-frame.hicasso.evidence` to build it. Nothing the tap DID
+ * was dev surface; the gate went red on what the tap's namespace
+ * IMPORTED.
+ *
+ * So, for any runtime-tapped evidence: RAW COUNTERS WHERE THE TAP IS,
+ * ENVELOPE IN A DEV-ONLY CONSUMER. Split that way the same spike read OK
+ * against this gate — 5 sentinels absent, 3 positive controls present.
+ *
+ * It is written down because it cannot be seen at the edit site. The diff
+ * that breaks it adds no dev surface and touches no dev namespace; it adds
+ * a `:require`, and a reviewer reading it has nothing to notice. Nor can
+ * the failure teach it: the message this gate prints names the leaked
+ * SENTINEL, not the mechanism, so the reader it sends here is the reader
+ * who still has to be told why an import alone was enough.
+ *
+ * The source-side counterpart is `check_optional_module_reachability.py`,
+ * which decides the same property over `:require` forms rather than over a
+ * bundle, for the optional modules where absence is the contract.
+ *
  * ## What this gate does NOT cover, and why
  *
  * `defview` / `defhost` SOURCE COORDINATES (rf2-hic-007) are not


### PR DESCRIPTION
Records a general rule that a shipped gate already enforces and nobody had written down. Documentation only — no checker added, no gate behaviour changed.

## rf2-nkr3 — the rule, and where it went

The rf2-hic-081 capability-receipts spike put a receipt envelope in `impl/receipt`, which `:require`d `re-frame.hicasso.evidence`. `npm run build:hicasso-release` then failed with `DEV SURFACE LEAKED: evidence projection — sentinel "re-frame.hicasso.evidence"`.

The tap did nothing dev-only. Its **namespace** imported something dev-only, and a tap on the shipped path is reachable from the public door, so its whole require graph is reachable too. The rule: **raw counters where the tap is; envelope in a dev-only consumer.**

It earns a record rather than vigilance because it is invisible at the edit site — the diff that breaks it adds no dev surface and touches no dev namespace, only a `:require` — and the gate's own message names the leaked *sentinel*, not the mechanism, so the failure cannot teach it either.

**Where it went, and why there.** `implementation/hicasso/scripts/check_production_erasure.cjs`'s header block, as a new section `## A tap drags its namespace's requires onto the shipped path`, immediately above `## What this gate does NOT cover, and why`.

That header is the **only** prose record of this gate's behaviour. I looked: nothing under `docs/` describes it (`docs/design/hicasso/product/invariants.md` carries a one-line I12 invariant row, not the mechanism); `TESTING.md` documents the `build:hicasso-release` *build* and its CI scheduling, not the erasure mechanism; and the sibling live-half test `erasure_sentinels_cljs_test.cljs` explicitly defers — *"The scan's docstring says why in full"* — rather than restating. So the bead's fallback clause ("if the gate has no prose record at all … put the rule wherever the gate's behaviour IS described") and its primary instruction ("beside the erasure gate's own documentation") land in the same place.

Deliberately **not** filed under the capability-receipts design (rf2-eoo9): the rule is general to the erasure gate, and burying it under one feature is how nobody hunting an erasure failure finds it.

The new text also cross-references `check_optional_module_reachability.py`, which decides the same property over `:require` forms rather than over a bundle — the source-side counterpart a reader hitting this rule will want next.

**Considered and rejected:** amending the evidence row's `remedy` string so the printed failure names the mechanism. That would change what the gate emits, and both the bead and the brief fence the gate's behaviour. The header addition leaves the roster, sentinels, controls, premises and every emitted string byte-identical.

## rf2-w8pz — closed unfixed, no code in this PR

`hd8_rows.cljs:1289`'s `[[denominator-resolution]]` was **only ever prose**, so there is nothing to re-point to. `git log -S "denominator-resolution"` over the bench tree returns exactly one commit — `8d8831336f` *bench(hd8): measure the clock's own grain instead of asserting it (rf2-d2tzk)* — which added the token in a docstring line and nowhere else. `git log -S "defn denominator" -- implementation/` returns nothing. The token has one occurrence in the whole tracked tree.

Separately, and correcting the bead note's first premise: **the freeze does not forbid the edit.** `implementation/hicasso/frozen-sources.edn` pins exactly one bench-tree file, `front/slot.cljc`, and says so in terms — *"the only bench-tree file this gate still watches is `front/slot.cljc`"*. `hd8_rows.cljs`'s row was retired. The studio blob tables that name it pin it **at named producing commits** ("they survive a rebase; they pin the files they name and nothing else"), and HEAD's blob `86331333c1` already differs from the pinned `b34cf52b9d`, so an edit falsifies nothing; `hd8_clock_run.cjs` re-reads the blob at run time and stamps whatever it finds. `bench_bytes.test.cjs` pins source text of `hd8_clock_app.cljs`, not this file.

So the disposition rests on the second constraint, not the first: a dangling wiki-link to a name that never existed, in a measured benchmark's docstring, is minutiae. Closed as not-worth-fixing with that reasoning on the bead, per its own note.

## Quality gates

Diff is a 28-line block comment inside one Node script. `implementation/node_modules` is absent in a fresh worktree.

| gate | exit | result |
|---|---|---|
| `node implementation/hicasso/scripts/check_production_erasure.cjs --self-test` | **0** | `hicasso production erasure: self-test OK (5 sentinels, 3 positive controls)` |
| `python scripts/check_retired_spellings.py --self-test` | **0** | pass |
| `python scripts/check_retired_spellings.py --verbose` | **0** | 1027 source files + 93 hicasso files scanned; no retired spellings |
| `python scripts/check_thrown_error_messages.py --self-test` | **0** | pass |
| `python scripts/check_thrown_error_messages.py --verbose` | **0** | 444 framework sources; no bare-keyword thrown-error messages |
| `python scripts/check_gate_scheduling.py --self-test` | **0** | pass |
| `python scripts/check_gate_scheduling.py` | **0** | 49 gate commands, 41 scheduled, 8 declared, 0 unscheduled |
| `python scripts/check_fast_pr_gap.py --list` | **0** | 96 required checks the spine does not decide (below) |

The self-test is the half of the production-erasure gate that reads the edited bytes: it parses the file, runs the complete `scan()` logic over synthetic bundles in both directions, exercises every control in isolation, and re-checks every roster premise against the real sources. Its printed counts independently confirm the `5 sentinels / 3 positive controls` figure the new prose quotes.

**Skipped, with reasons:**

- `npm run build:hicasso-release` (the bundle half of the erasure gate) and `npm run test:cljs` (Hicasso CLJS suite) — both need `implementation/node_modules`, and supplying it means junctioning into the mayor checkout, the operation that has twice emptied the mayor's real `node_modules`; an external process emptied six worktrees during this session, so that junction is unusually unsafe right now. Neither reads the edited bytes: the change is a block comment, every emitted string and roster entry is unchanged, and no CLJS build compiles a `.cjs` script. CI runs `build:hicasso-release` in the required `cljs` job.
- `scripts/test-fast-pr.sh` — same `node_modules` dependency (it runs `npm run test:cljs`), and it has no tier flag. The members of its python tier that can see this diff were run individually instead, above.
- `mkdocs build --strict` and `python scripts/check_doc_slugs.py` — no markdown changed. (`mkdocs build --strict` excludes `docs/design/**` in any case.)
- No tables added anywhere under `docs/design/**`, so no hand column-count verification was needed.

**Required checks this spine does not decide** (`check_fast_pr_gap.py --list`, 96 total): the three required contexts are `All required checks passed` (test.yml), `Lint required` (lint.yml) and `Docs required` (docs.yml). Nothing run locally decides any of them. Most relevant to this diff: test.yml's `cljs` job step **"Hicasso release build (:advanced, goog.DEBUG false)"** — `npm run build:hicasso-release`, the full erasure gate — plus lint.yml's `eslint` job and `clj-kondo` (CI pins 2026.04.15; a differently-versioned local binary proves nothing).

## Scope

One file: `implementation/hicasso/scripts/check_production_erasure.cjs`, comment only. Touches no live worker's surface — not `implementation/hicasso/src/**`, not `test_kit/**`, not `tools/xray/**`, not `docs/design/hicasso/**`, and nothing in the hot zone.
