### PR TITLE
measurement: keep the clock grain the clock drivers already measure (rf2-dzus)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -553,6 +553,12 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   ];
   const CITED = { layout: 2.06, style: 1.85, script: 2.3 };
 
+  // rf2-dzus: the row's own clock grain, as `runRow` hands it over — the
+  // distinct non-zero per-sample `TaskDuration` deltas, sorted at the
+  // measuring site. Deliberately unsorted-looking nowhere: the smallest is
+  // first because that is the contract `report` prints against.
+  const FIXTURE_GRAIN = [0.094, 0.107, 0.123, 0.152];
+
   // What the row DECLARES itself to be: the arms its plan named and the
   // dimensions its design ran. Both travel beside the split rather than out of
   // it — `report` reads them from the row and the run's design, a reader of a
@@ -570,6 +576,7 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     blocksNet: [[{ floor: [1, 2], 'ctl-2x': [2, 4] }]],
     blocksInPage: [[{ floor: [1, 2], 'ctl-2x': [2, 4] }]],
     blocksDecomp: FIXTURE_DECOMP,
+    granularity: FIXTURE_GRAIN,
     tally: { writes: 36, unverified: 0 },
     runtime: 'fixture',
     quiet: { ok: true },
@@ -629,6 +636,30 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     delete legacy.blocksDecomp;
     assert.throws(() => foldDecomposition(legacy.blocksDecomp, DECLARED), /NOT recomputable/);
     assert.throws(() => foldDecomposition([], DECLARED), /NOT recomputable/);
+  });
+
+  // --- rf2-dzus: the clock's grain must reach the file too -------------------
+  //
+  // The same species as the split above, one level down and about the
+  // INSTRUMENT rather than the arm. `runRow` accumulates the distinct
+  // non-zero per-sample `TaskDuration` deltas and `report` prints the
+  // smallest as the row's grain; `datasetFor` dropped the set. A dataset of
+  // durations that does not record the resolution they were measured at
+  // cannot say from itself whether a quantity was measurable — the answer
+  // has to come from a remembered constant, which is the exact failure
+  // rf2-d2tzk closed on the in-page clock. Hermetic, like the tests above:
+  // what regressed is what the serialiser keeps, so no measurement is taken
+  // here and none is needed.
+
+  t('the grain the row measured reaches the written dataset', () => {
+    assert.deepStrictEqual(written().granularity, FIXTURE_GRAIN);
+  });
+
+  t('the smallest interval the clock resolved is recoverable from the file alone', () => {
+    // `report` prints `granularity[0]` as the row's grain, and the set is
+    // sorted where it is measured — so the file carries the printed number
+    // rather than requiring somebody to have kept the console.
+    assert.strictEqual(written().granularity[0], Math.min(...FIXTURE_GRAIN));
   });
 
   // Every committed census row, paired with the declared shape its own file
@@ -2040,6 +2071,21 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
     // a consumer that finds no `canonical` field has not found a pass.
     assert.match(SRC, /canonical: meta\.dest\.canonical/);
     assert.match(SRC, /notCanonicalWhy: meta\.dest\.why/);
+  });
+
+  // rf2-dzus, on the driver whose `datasetFor` is not exported: the check the
+  // census block above makes behaviourally, made here the way this block
+  // already makes its others. Both halves are pinned — the site that MEASURES
+  // the grain and the line that KEEPS it — because a serialiser naming a
+  // field the row stopped collecting is the same silent nothing as a row
+  // collecting a field nobody serialises.
+  t("the clock's own grain is measured, and then kept", () => {
+    assert.match(SRC, /if \(d\.task > 0\) granularity\.add\(d\.task\);/);
+    const KEPT = /^\s*granularity: r\.granularity,$/m;
+    assert.match(SRC, KEPT);
+    // ... and the check refuses the shape it was written against, so it
+    // cannot pass by matching something that is always there.
+    assert.ok(!KEPT.test(SRC.replace(/^[ \t]*granularity: r\.granularity,\r?\n/m, '')));
   });
 
   t('the dataset is built OUTSIDE `drive`, so recording never looks like deciding', () => {

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_clock_run.cjs
@@ -909,6 +909,21 @@ function datasetFor(rows, meta) {
       blocksTask: r.blocksTask,
       blocksNet: r.blocksNet.map((rd) => rd.map((b) => Object.fromEntries(Object.entries(b).map(([a, xs]) => [a, r4(p50(xs))])))),
       blocksInPage: r.blocksInPage.map((rd) => rd.map((b) => Object.fromEntries(Object.entries(b).map(([a, xs]) => [a, r4(p50(xs.filter(Number.isFinite)))])))),
+      // THE CLOCK'S OWN GRAIN, in the run it governs — the sorted distinct
+      // non-zero per-sample `TaskDuration` deltas this row observed, the
+      // smallest of which is the finest interval the published clock
+      // resolved here.
+      //
+      // rf2-dzus. `runRow` has always measured it and `report` has always
+      // printed it; this function dropped it. So a dataset carried durations
+      // with no record of what could be told apart from what, and "was this
+      // measurable?" had to be answered from outside the file — from a
+      // remembered constant, which is the failure `rf2-d2tzk` closed on the
+      // in-page clock and `clock_run.cjs` had already closed here. This
+      // driver took that driver's contract and did not inherit this part of
+      // it. Persisting it backfills nothing: the grain travels with the NEXT
+      // canonical run, not with this line.
+      granularity: r.granularity,
       tally: r.tally,
       runtime: r.runtime,
       quiet: r.quiet,

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs
@@ -1603,6 +1603,19 @@ function datasetFor(rows, meta) {
           )
         )
       ),
+      // THE CLOCK'S OWN GRAIN, in the run it governs — the sorted distinct
+      // non-zero per-sample `TaskDuration` deltas this row observed, the
+      // smallest of which is the finest interval the published clock
+      // resolved here. `report` prints that smallest value; until now it
+      // printed it and nothing kept it.
+      //
+      // rf2-dzus, and the same species as `blocksDecomp` above: collected in
+      // `runRow`, dropped at write time. A file of durations with no record
+      // of its own resolution cannot answer "was this measurable?" from
+      // itself — the answer has to come from a constant somebody remembers,
+      // which is exactly what `rf2-d2tzk` stopped the in-page clock doing.
+      // It backfills nothing; the grain travels with the NEXT canonical run.
+      granularity: r.granularity,
       tally: r.tally,
       runtime: r.runtime,
       quiet: r.quiet,


### PR DESCRIPTION
Closes rf2-dzus.

## What the bead claimed, and what is actually true

rf2-dzus says no committed dataset records a clock resolution, so the 100 µs
`performance.now()` clamp is an uncited constant. **Two thirds of that is
false, and the false parts are worth stating** because they are the reason
this PR is two lines rather than an instrument.

**The 100 µs figure is cited, to primary sources, with a read date.**
`docs/design/hicasso/studio/the-candidates-clock.md` §2.1 — "The resolution
figures, verified rather than remembered" — is a table quoting each figure
with its source, checked on 2026-08-01.
`docs/design/hicasso/studio/the-clock-behind-the-published-rows.md` §6 goes
further and names the Chromium constant: `time_clamper.h`,
`kCoarseResolutionMicroseconds = 100`.

**It is also measured per run, in the run it governs.** `hd8_rows/clock-resolution!`
exists precisely because the constant was being quoted rather than read
(rf2-d2tzk), and `hd8_app.cljs` records it as `:clock-resolution`.

**And 16 of the 38 committed datasets already carry a measured grain** —
`clock_run.cjs` serialises `granularity`, the sorted distinct non-zero
per-sample deltas, and `the-candidates-clock.md`'s published range
(0.092–0.153 ms over ~980 distinct values per row) recomputes from those
files.

## The part that was true

`hd8_clock_run.cjs` and `shapes/census_clock_run.cjs` both **measure** the
grain — `if (d.task > 0) granularity.add(d.task)` — and both **print** it,
and neither **kept** it. `datasetFor` dropped the set on the floor. So the
datasets those two drivers write carried durations with no record of the
resolution they were taken at, and could not answer "was this measurable?"
from themselves.

Both drivers took their contract from `clock_run.cjs`, which already keeps
it. This is the part they did not inherit.

## The change

One field per driver, on a value the run already produces. Same species as
rf2-jo60g (`blocksDecomp` collected, then dropped at write time) and the
same remedy, so it follows that precedent's comment shape and its honest
caveat: **nothing measured changes, and nothing is backfilled** — the grain
travels with the next canonical run, not with this commit.

No checker, no threshold, no refusal arm, no re-take. No published figure is
restated and no gate is widened.

**Not done, deliberately:** the in-page `performance.now()` grain is still
not in any committed dataset. The lane that measures it (`hd8_run.cjs`)
writes no dataset file at all, and giving it one is a `destination` /
`publication` / `canonical` discipline plus its coverage in
`clock_exit_path.test.cjs` — a rig change, not a field. Recorded on the bead
rather than started here.

## Quality gates

Run alone, nothing appended, exit code captured on the same line.

| gate | exit | result |
|---|---|---|
| `cd implementation && npm run test:script-helpers` | 0 | `clock_exit_path.test.cjs: 375 passed` (+ every sibling suite green) |
| `cd implementation && npm run test:script-policy` | 0 | green |

`test:script-helpers` is the gate that runs `clock_exit_path.test.cjs` — it
is one step of `test.yml` (line 3000) and one step of the fast-PR spine
(`scripts/test-fast-pr.sh:1355`). The diff is three `.cjs` files under
`implementation/freehand/test/re_frame/bench/hicasso/`; no CLJS, no docs, no
spec, no workflow, so no other spine step can reach it.

`python scripts/check_fast_pr_gap.py --list` reports **96** required checks
the spine does not decide. None is reachable from this diff.

**The three new tests are mutation-proven, not merely green.** Deleting the
two serialised lines and re-running gives `3/375 failed`, naming exactly the
three new tests, exit 1. Restored, exit 0. No measurement was taken for any
of this — what regressed is what the serialiser keeps, so the tests drive
`datasetFor` on a fixture row.
