### PR TITLE
test(xray): the Hicasso tab needs no populated browser row — pin its liveness in Node instead (rf2-r98a)

### DIFF
--- a/tools/xray/spec/027-Hicasso-Evidence.md
+++ b/tools/xray/spec/027-Hicasso-Evidence.md
@@ -499,5 +499,49 @@ Adding it moved six governance pins, each of which fails the build on drift:
 | `re-frame.hicasso.evidence-schema-cljs-test` | node | every shape in which a projection would claim more than it knows is refused, each with a positive control |
 | `re-frame.hicasso.tool-reads-cljs-test` | node (reactive substrate) | the four reads over real committed boundaries; the seeded-value privacy witness for a return value AND for a query argument; two frames sharing a sub id with asymmetric windows; the dispatch-ordered, fragment-merged intent stream; determinism; the production-nil arm |
 | `…panels.hicasso-helpers-cljs-test` | node + JVM | the five absences and the empties are pairwise distinct — including the four per-view empties; labels and testids are built from the projected key; a row key carries the WHOLE projected identity, so two frames' boundaries over one query do not collide; two query variants do not collapse; the key is INJECTIVE as a property over a generated space of 9261 identities, 10162 boundary keys and 441 intent rows, with a non-vacuity control that the space still defeats a lossy slug; the superseded v1 stamp is refused rather than mis-parsed; the schema pin; row projections |
-| `…panels.hicasso-cljs-test` | node (reactive substrate) | the four views answer on a running app; the loss states render under distinct testids, driven between two real window states; a sensitive query argument reaches neither the page nor a testid; the Reads and Why rows carry the frame on the page and in the testid; each view renders its own empty; both the superseded and an unknown stamp render the mismatch; the seam reshapes nothing |
+| `…panels.hicasso-cljs-test` | node (reactive substrate) | the four views answer on a running app; the populated roster arrives on a real `:rf.xray/trace-buffer` tick with no cache clear, against a held reaction proved stale first; the loss states render under distinct testids, driven between two real window states; a sensitive query argument reaches neither the page nor a testid; the Reads and Why rows carry the frame on the page and in the testid; each view renders its own empty; both the superseded and an unknown stamp render the mismatch; the seam reshapes nothing |
+| `frame_singleton_guard_test` | JVM (source text) | the sub-strip dispatches through the `reg-view`-injected frame-bound `dispatch`, never a bare global one |
 | `feature_matrix/scenarios.cjs` | browser | the tab reaches a real panel root in the shell sweep |
+
+### Why the populated arms have no browser row
+
+The browser lane sees this tab in one state. The shell sweep clicks `:hicasso`
+on the counter surface, which is not a Hicasso application, so the root it
+asserts is holding the `absent` note. That is the whole of the tab's browser
+coverage, and it is a decision rather than an unfilled gap.
+
+**The tab is one of four on the same footing.** Resources, Graph, Modules and
+Hicasso are documented exclusions from the panel gallery, with their coverage
+ruled to be the feature-matrix shipped-surface sweep plus their own per-panel
+CLJS unit tests (`panel_gallery/core.cljs` §Intentional gallery exclusions).
+`panel_gallery_inventory_smoke_cljs_test` fails the build if that partition
+drifts. Of the four, Hicasso has much the strongest unit lane.
+
+**Nothing about the populated rendering is out of that lane's reach.**
+`hicasso_cljs_test` mounts real boundaries through the real commit seam under a
+reactive substrate and stubs nothing between the runtime and the hiccup — its
+two `with-redefs` synthesise the loss arms and touch no populated path. Narrow
+the populated path and it reds: the roster's two-instance fold, both edge
+labels, the fan-out counts, the frame on the row and in its testid, the
+redaction of a sensitive query argument from both the text and the testids, and
+the two loss chips driven between two genuinely different window states.
+
+**What a browser is genuinely the authority on is held elsewhere.** That
+`Panel` mounts and routes under real React in the real chrome is the shell-sweep
+row above. That the sub-strip dispatches through the frame-bound `dispatch` is
+held by `frame_singleton_guard_test`, a source-text guard over every panel —
+broader than a per-panel click and cheaper. Liveness was the one property
+nothing asserted, and it needed no browser either: `:rf.xray/trace-buffer` is an
+ordinary app-db slot written by an ordinary dispatch, so the tick is drivable in
+Node, and the trace-tick row now drives it against a held reaction it proves
+stale first.
+
+**And the row would not be one assertion.** No surface staged in
+`feature_matrix/scenarios.cjs` is a Hicasso host, so a populated arm needs a new
+deck, a new `implementation/shadow-cljs.edn` build id and a new `:dev-http`
+port — the shape rf2-6pohj built for the Views panel. If that deck is ever
+wanted its moment is rf2-hic-062, because `testbeds/freehand-views` exists
+solely to give the Views panel a populated roster, that panel retires with the
+Freehand tree (`021-Dynamic-Panel-Designs.md` §3.4.3), and its build id, port
+and scenario slot free up together. This tab is the survivor of that
+disposition, not a casualty of it.

--- a/tools/xray/test/day8/re_frame2_xray/panels/hicasso_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/hicasso_cljs_test.cljs
@@ -159,6 +159,31 @@
     (refresh!)
     (hicasso/Panel)))
 
+(defn- render-now
+  "Render the panel the way the RUNNING shell renders it — no `refresh!`.
+
+  Every other row here reaches the runtime through `show!`, and `show!`
+  drops Xray's sub cache first. That is a harness mechanism; the shipped
+  panel has no such thing. This one renders against whatever the held
+  reaction currently answers, which is the only way to ask whether the tab
+  is a live projection or a screenshot of one."
+  []
+  (rf/with-frame :rf/xray (hicasso/Panel)))
+
+(defn- tick-trace!
+  "One trace-buffer tick, delivered the way the collector delivers it.
+
+  `trace-collector/refresh-trace-rings!` dispatches
+  `:rf.xray/sync-trace-buffer` with its snapshot on every coalesced task
+  drain; `:rf.xray/trace-buffer` reads the slot that dispatch writes
+  (rf2-43koh). Dispatching it directly is therefore the collector's own
+  seam, not a stand-in for it."
+  []
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/sync-trace-buffer
+                       [{:id 1 :op-type :rf.event
+                         :operation :rf.event/dispatched :tags {}}]])))
+
 ;; ---------------------------------------------------------------------------
 ;; Registration
 ;; ---------------------------------------------------------------------------
@@ -375,6 +400,47 @@
                         (string/includes? % "hicasso-tab-app"))
                   ids))))
     (release)))
+
+;; ---------------------------------------------------------------------------
+;; AND THEY KEEP ANSWERING AS THE APPLICATION RUNS
+;; ---------------------------------------------------------------------------
+
+(deftest the-populated-roster-arrives-on-the-TRACE-TICK-and-not-on-a-cache-clear
+  ;; rf2-r98a. The populated arms above are all reached through `show!`,
+  ;; and `show!` drops Xray's sub cache first. So every one of them proves
+  ;; what the panel renders GIVEN a fresh projection, and none of them
+  ;; proves the projection ever refreshes on its own — the tab's liveness
+  ;; was a comment on `:rf.xray.hicasso/data` and nothing else.
+  ;;
+  ;; That is the property a browser row was proposed for, and it does not
+  ;; need one. The tab is live because the sub composes off
+  ;; `:rf.xray/trace-buffer`, and that signal is an ordinary app-db slot
+  ;; written by an ordinary dispatch, so the tick is drivable right here.
+  ;;
+  ;; The middle assertion is the load-bearing one. Hicasso's tables are
+  ;; process-global rather than part of Xray's app-db, so a mount moves
+  ;; nothing the held reaction watches — which is precisely why a panel
+  ;; wired to no tick at all would sit on an empty roster forever while
+  ;; the application it is inspecting mounts boundaries. Without that
+  ;; control the last assertion would pass on a reaction that had simply
+  ;; never been computed before the tick.
+  (setup!)
+  (let [empty-testid "rf-xray-hicasso-empty-mounted"]
+    (is (contains? (testids (show! :mounted)) empty-testid)
+        "the projection is computed and HELD while nothing is mounted")
+    (let [release (mount! (fn [_] (h/sub [:htab/left]) nil))]
+      (is (contains? (testids (render-now)) empty-testid)
+          "NON-VACUITY: a real mount alone leaves the held reaction stale,
+           so the tick below is the only thing that can move this roster")
+      (tick-trace!)
+      (let [ids (testids (render-now))]
+        (is (contains? ids "rf-xray-hicasso-mounted")
+            "the trace tick re-fired the projection and the roster arrived —
+             with no cache clear anywhere in this test")
+        (is (not (contains? ids empty-testid))
+            "and the empty note is gone, so the roster replaced it rather
+             than rendering beside it"))
+      (release))))
 
 ;; ---------------------------------------------------------------------------
 ;; THE LOSS STATES ARE DISTINGUISHABLE ON THE PAGE

--- a/tools/xray/test/day8/re_frame2_xray/panels/hicasso_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/hicasso_cljs_test.cljs
@@ -433,10 +433,19 @@
           "NON-VACUITY: a real mount alone leaves the held reaction stale,
            so the tick below is the only thing that can move this roster")
       (tick-trace!)
-      (let [ids (testids (render-now))]
-        (is (contains? ids "rf-xray-hicasso-mounted")
-            "the trace tick re-fired the projection and the roster arrived —
-             with no cache clear anywhere in this test")
+      (let [tree (render-now)
+            ids  (testids tree)]
+        ;; A BOUNDARY ROW, not the section wrapper. `rf-xray-hicasso-mounted`
+        ;; is the wrapper `mounted-view` renders in every arm — the empty
+        ;; note lives inside it — so asserting the wrapper would pass on the
+        ;; stale empty roster this row exists to catch. That is the bead's own
+        ;; question turned on this test, and the first draft failed it.
+        (is (some #(string/starts-with? % "rf-xray-hicasso-boundary-") ids)
+            "the trace tick re-fired the projection and a boundary ROW
+             arrived — with no cache clear anywhere in this test")
+        (is (string/includes? (text-of tree) "[:htab/left]")
+            "and the row names the read the boundary really holds, so the
+             assertion above cannot pass on a row projected from nothing")
         (is (not (contains? ids empty-testid))
             "and the empty note is gone, so the roster replaced it rather
              than rendering beside it"))


### PR DESCRIPTION
## The answer to the bead's question: NO — and the one thing it named needed no browser

rf2-r98a asks whether the POPULATED Hicasso tab has a failure mode the Node lane
structurally cannot see. It does not. What it named — liveness — is real, was
genuinely unasserted, and is drivable in Node. This PR closes it there and records
the verdict.

**Retirement check first (the bead's gate 1).** rf2-hic-062 dispositions
`implementation/ui/`, the Freehand tree and the frozen Hicasso bench tree. This tab
reads `re-frame.hicasso.tool` — the surviving native tier — and rf2-jkdy's refusal
argues for retiring the Views panel precisely *because* "a Hicasso tab already
renders those same four envelopes whole". The tab is the survivor of that
disposition, not a casualty. Coverage on it is not waste on retirement grounds.

**The split is a ruling, not a gap.** Resources, Graph, Modules and Hicasso are
documented gallery exclusions whose coverage is ruled to be the feature-matrix
shipped-surface sweep plus their own per-panel CLJS unit tests
(`panel_gallery/core.cljs` §Intentional gallery exclusions), and
`panel_gallery_inventory_smoke_cljs_test` fails the build if the partition drifts.
Of the four, Hicasso has much the strongest unit lane.

**The bead's premise is true of the row and false of the lane.** "Nearly any
narrowing of the populated path would pass" holds for the browser assertion, which
only reaches `rf-xray-hicasso` on a non-Hicasso host. It does not hold for the
coverage set: `hicasso_cljs_test` mounts real boundaries through the real commit
seam under a reactive substrate, stubs nothing on any populated path (its two
`with-redefs` synthesise the loss arms), and reds on the two-instance fold, both
edge labels, the fan-out counts, the frame on the row and in its testid, the
redaction of a sensitive query argument, and the two loss chips.

**What a browser is genuinely the authority on is already held.** Real-React mount
and tab routing: the existing shell-sweep row. The sub-strip's frame-bound
`dispatch` (rf2-1w07r): `frame_singleton_guard_test`, a source-text guard over every
panel — broader than a per-panel click and cheaper.

**And the row would not be one assertion.** No surface staged in
`feature_matrix/scenarios.cjs` is a Hicasso host, so a populated arm needs a new
deck plus a hot-zone `implementation/shadow-cljs.edn` build id and `:dev-http` port —
the rf2-6pohj shape. Its moment, if ever, is rf2-hic-062: `testbeds/freehand-views`
exists solely to give the retiring Views panel a populated roster, so its build id,
port and scenario slot free up together.

## What this PR does add

One Node row, `the-populated-roster-arrives-on-the-TRACE-TICK-and-not-on-a-cache-clear`.
Every other row in that namespace reaches the runtime through `show!`, which drops
Xray's sub cache by hand — a harness mechanism the shipped panel has none of. So the
suite proved what the panel renders GIVEN a fresh projection and never that the
projection refreshes on its own. This row never calls `refresh!`: it holds the
reaction, proves it stale across a real mount (Hicasso's tables are process-global,
so a mount moves nothing Xray's app-db watches), then dispatches
`:rf.xray/sync-trace-buffer` — the collector's own seam, not a stand-in — and asserts
a boundary row arrives.

**Mutation-tested, in both directions.** Point `:rf.xray.hicasso/data` at a signal
that does not move on host activity and 14 of the namespace's 15 tests stay green:
that is the blind spot, measured rather than argued. Under the same mutation this row
reds on all three assertions.

That mutation also caught the bead's own defect in my first draft: it asserted
`rf-xray-hicasso-mounted`, which is the wrapper `mounted-view` renders in every arm
with the empty note inside it — an assertion that passed whether the roster arrived
or not. Second commit fixes it to read a `rf-xray-hicasso-boundary-` row testid and
the read the boundary actually holds.

## `tools/xray/spec/*` disposition

Updated, per the standing rule. `027-Hicasso-Evidence.md` gains a
§Why the populated arms have no browser row beside the coverage table, plus the
liveness clause on the `hicasso-cljs-test` row and a new `frame_singleton_guard_test`
row. A fresh maintainer can now read the verdict without this PR.

No production code changed. No browser row added, so no browser lane is touched.

## Quality gates

Run alone, each redirected to a file with its exit code captured on the same command
line; artefacts removed before push.

| Gate | Command | Exit |
|---|---|---|
| clj-kondo — CI's exact invocation, at CI's pin | `clj-kondo --parallel --fail-level error --lint …` (all 12 `--lint` paths from `lint.yml`), pinned to `2026.04.15` via `clojure -Sdeps` | **0** — `errors: 0, warnings: 4543`; no finding at any level names either file in this diff |
| Xray CLJS suite (the edited surface), re-run post-rebase | `npm run test:cljs` (implementation/) | **0** — 13262 tests, 67056 assertions, 0 failures, 0 errors |
| Doc slugs (covers `tools/*/spec`) | `python scripts/check_doc_slugs.py` | **0** |
| Focused mutation — sub pointed off the trace tick | `node out/node-test.js --test=day8.re-frame2-xray.panels.hicasso-cljs-test` | **1** — 3 failures, all in the new row; other 14 green |
| Focused control — source reverted | same | **0** — 15 tests, 92 assertions |

### The clj-kondo red was an install failure, not a lint finding

Run 31456796279 reported this PR's `clj-kondo` job red, and the job never reached
clj-kondo. It died in the **Install clj-kondo** step: `install-clj-kondo` began
`Downloading …/clj-kondo-2026.04.15-linux-static-amd64.zip` and exited **35** — a
curl SSL-connect error — 0.24 s later. The log carries no lint output at all, so
there was nothing in the diff to fix. This is the same class as rf2-cq0s2j, which
added `--retry 5 --retry-all-errors` to the step's *first* curl; the failure here is
in the download the fetched script performs afterwards, which those flags do not
reach.

Two things establish the diff is clean rather than merely unexamined. The table's
first row runs the gate locally at CI's pinned version over CI's exact path list and
captures **0**. The re-pushed branch then re-ran the real job on GitHub, which is now
green.

The branch was rebased onto current `origin/main` (`f563ac0455`) and force-pushed to
re-trigger CI. The rebase was clean and moved nothing this diff depends on — the base
delta touches only `.beads/`, `.claude/`, `docs/the-mayor-method/` and three
`freehand/test/…/bench/hicasso/*.cjs` node bench drivers, none of them on the
`:node-test` classpath — which is why the suite re-run above still reports 0 failures
(its count rises from 13248 only because `main` gained tests elsewhere). No file in
this PR changed, and `.clj-kondo/config.edn` was not touched.

An earlier full run reported 10 failures in
`re-frame.test-quiet-shadow-node-cljs-test`. Self-inflicted and diagnosed, not
flake: I read a stale `.exit` file, launched a second gate over a still-running
first, and the second's `compile-node-test.cjs` deleted `out/node-test.js` — which
that namespace spawns as a child — out from under it. Every failure was
`MODULE_NOT_FOUND` on that path. Re-run alone with fresh artefact names: green above.

`python scripts/check_fast_pr_gap.py --list` reports 96 required checks the fast-PR
spine does not decide. The spine was not run here: this diff reaches
`tools/xray/test/**` and `tools/xray/spec/**` only, and the suite that owns the first
plus the validator that owns the second are both above. Nothing in `implementation/`,
no workflow, no hot-zone file, no browser surface.

