### PR TITLE
fix(hicasso): release the clock hold and make its timer boundary lossless (rf2-4mvd, rf2-w2e6)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_clock_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_clock_dom_cljs_test.cljs
@@ -174,6 +174,54 @@
   (doseq [[k nm] surface-names]
     (is (identical? (get expected k) (get actual k)) (str nm " — " why))))
 
+(defn- recorder
+  "A recording scheduler over `platform`. Installed BEFORE a clocked
+  mount, it is what `install-clock!` captures and what a release hands
+  back to — so a row can read what the clock asked the platform for, and
+  with which ids.
+
+  It DELEGATES every call to the genuine function. A stub that only
+  recorded would strand the runtime's own reapers at handover and turn
+  `assert-clean!` red for a reason with nothing to do with the row.
+
+  And it hands out ids of its own, counting up from 1 — which is where a
+  fresh page's timer ids start, and therefore exactly the domain a
+  virtual handle must not be able to walk into. A row that armed only
+  virtual timers could never see a collision at all.
+
+  Answers `{:surface … :log … :cancel! …}`: the surface to install, the
+  log as an atom of `{:kind :timeout|:interval|:cleared, :f, :delay,
+  :args, :id}`, and a `cancel!` that stops a logged entry's real timer
+  without logging."
+  [platform]
+  (let [g     js/globalThis
+        !log  (atom [])
+        !live (atom {})
+        !next (atom 0)
+        arm   (fn [kind real-fn]
+                (fn [f delay & args]
+                  (let [real (.apply real-fn g (to-array (list* f delay args)))
+                        id   (swap! !next inc)]
+                    (swap! !live assoc id real)
+                    (swap! !log conj {:kind kind :f f :delay delay :args (vec args) :id id})
+                    id)))
+        ;; One clearer for both kinds, which is the platform's own rule.
+        stop! (fn [id]
+                (when-some [real (get @!live id)]
+                  (swap! !live dissoc id)
+                  (.call (:clear-timeout platform) g real)
+                  true))
+        clear (fn [id]
+                (when (stop! id) (swap! !log conj {:kind :cleared :id id}))
+                js/undefined)]
+    {:log     !log
+     :cancel! (fn [entry] (stop! (:id entry)) nil)
+     :surface {:set-timeout    (arm :timeout (:set-timeout platform))
+               :clear-timeout  clear
+               :set-interval   (arm :interval (:set-interval platform))
+               :clear-interval clear
+               :date-now       (:date-now platform)}}))
+
 ;; ---------------------------------------------------------------------------
 ;; W1 — the discriminating row: retired at the deadline, and not before it
 ;; ---------------------------------------------------------------------------
@@ -436,3 +484,164 @@
             (.then (fn [report]
                      (is (true? (:clean? report)))
                      (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; W6 — the two schedulers' handles are DISJOINT (rf2-w2e6)
+;; ---------------------------------------------------------------------------
+;;
+;; The clock replaces the global scheduler but not the timers already armed
+;; on the real one, so `clearTimeout` inside the window has to decide which
+;; of two schedulers an id belongs to — and it decides by looking the number
+;; up in its own table. That is only honest while the two id domains are
+;; disjoint, which they were not: the platform numbers a fresh page's timers
+;; from 1 and the clock numbered its own from 1 as well.
+;;
+;; The failure is silent in BOTH directions from one collision. A
+;; `clearTimeout` meant for the real timer finds the virtual one and kills it
+;; instead, leaving the real one running; and once the virtual timer has
+;; fired, ordinary cleanup of its now-stale id is passed to the platform and
+;; cancels the unrelated real timer.
+;;
+;; A row using only virtual timers cannot see any of this. This one arms two
+;; real timers BEFORE the install, through a captured scheduler that hands
+;; out the ids a fresh page hands out.
+
+(deftest a-virtual-handle-cannot-alias-a-platform-one
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM, so no root and no clock")
+    (async done
+      (let [platform              (platform-surface)
+            {:keys [log surface]} (recorder platform)
+            !fired                (atom [])
+            note                  (fn [k] (fn [] (swap! !fired conj k)))
+            cleared?              (fn [id]
+                                    (boolean (some (fn [e] (and (= :cleared (:kind e))
+                                                                (= id (:id e))))
+                                                   @log)))]
+        (install-surface! surface)
+        (let [r1 (js/setTimeout (note :real-1) 60000)
+              r2 (js/setTimeout (note :real-2) 60000)
+              m  (two-toasts)
+              v1 (js/setTimeout (note :v1) 50)
+              v2 (js/setTimeout (note :v2) 100)
+              iv (js/setInterval (note :iv) 50)]
+
+          (testing "premise: the scheduler the clock captured numbers its
+                    timers the way a platform does — from 1, upward, positive
+                    — and the first two of them are real timers armed BEFORE
+                    the install"
+            (is (= [1 2] [r1 r2])))
+
+          (testing "so no virtual handle can be a platform handle — not these
+                    two, and not any the platform has yet to issue. A platform
+                    handle is positive BY DEFINITION (HTML's timer
+                    initialisation steps), and the clock's count the other way,
+                    which is the whole of the disjointness. Reading it as
+                    `(not= r1 v1)` would prove only that these particular
+                    numbers missed each other"
+            (is (every? neg? [v1 v2 iv])))
+
+          (testing "clearing a REAL id reaches the real clearer instead of
+                    being swallowed by a virtual timer wearing that number"
+            (js/clearTimeout r1)
+            (is (cleared? r1) "the captured scheduler was asked to cancel it"))
+
+          (testing "…and the virtual timers are untouched by it. A collision
+                    would have cleared THIS one and left the real one running"
+            (hm/advance-clock! m 50)
+            (is (= [:v1 :iv] @!fired)))
+
+          (testing "and a SPENT virtual id — the ordinary cleanup of a timer
+                    that has already fired — cannot cancel an unrelated real
+                    timer. It is out of the table, so it goes to the platform;
+                    it just names nothing the platform holds"
+            (hm/advance-clock! m 50)
+            (is (= [:v1 :iv :v2 :iv] @!fired) "premise: v2 fired, so its id is stale")
+            (js/clearTimeout v2)
+            (is (not (cleared? r2)) "the real timer numbered 2 is still armed"))
+
+          (testing "either clearer cancels either kind, as the platform's own
+                    do — and on both sides of the boundary"
+            (js/clearTimeout iv)
+            (hm/advance-clock! m 500)
+            (is (= [:v1 :iv :v2 :iv] @!fired) "a clearTimeout retired the VIRTUAL interval")
+            (js/clearInterval r2)
+            (is (cleared? r2) "and a clearInterval reached the REAL timeout"))
+
+          (hm/unmount! m)
+          (install-surface! platform)
+          (-> (hm/assert-clean! m)
+              (.then (fn [report]
+                       (is (true? (:clean? report)))
+                       (done)))))))))
+
+;; ---------------------------------------------------------------------------
+;; W7 — an interval hands back the deadline it had left (rf2-w2e6)
+;; ---------------------------------------------------------------------------
+;;
+;; `release-clock!` promises every outstanding timer goes back to the real
+;; scheduler "with the time it had left", and for a one-shot it did: `(:due
+;; e) - now`. A repeating one was handed its whole PERIOD, so an interval
+;; released one millisecond before its tick waited another full period for
+;; it and every tick after that was out of phase — for the rest of the
+;; page's life, and invisibly.
+;;
+;; Asserting that the interval eventually fires would not see this. The row
+;; asserts the FIRST post-release deadline, by reading what the captured
+;; scheduler was asked for, and then drives the handover by hand so that no
+;; reading here depends on the wall clock.
+
+(deftest an-interval-hands-back-the-deadline-it-had-left
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM, so no root and no clock")
+    (async done
+      (let [platform                      (platform-surface)
+            {:keys [log surface cancel!]} (recorder platform)
+            !ticks                        (atom [])
+            intervals                     (fn [es] (filterv #(= :interval (:kind %)) es))]
+        (install-surface! surface)
+        (let [m (two-toasts)]
+          (js/setInterval (fn [& args] (swap! !ticks conj (vec args))) retention-ms "tick" 7)
+          (hm/advance-clock! m (dec retention-ms))
+          (is (empty? @!ticks) "premise: one virtual millisecond short of the first tick")
+
+          (let [mark (count @log)
+                _    (hm/unmount! m)
+                over (vec (drop mark @log))]
+            (install-surface! platform)
+
+            (testing "the handover asked the captured scheduler for no INTERVAL
+                      at all. One here is the phase shift itself: a timer with
+                      one millisecond to run, given a whole fresh second"
+              (is (empty? (intervals over))))
+            ;; Whatever that found, nothing this row armed is left repeating.
+            (doseq [e (intervals over)] (cancel! e))
+
+            (let [firsts (filterv #(and (= :timeout (:kind %)) (= 1 (:delay %))) over)]
+              (testing "…it asked for a ONE-MILLISECOND timeout — what was left
+                        of the tick the interval was already waiting for"
+                (is (seq firsts)))
+
+              ;; Cancel the real arming and fire it here, so the readings below
+              ;; are this row's rather than the wall clock's.
+              (doseq [e firsts] (cancel! e))
+              (let [mark2 (count @log)]
+                (doseq [e firsts] ((:f e)))
+
+                (testing "firing it runs the interval's own callback — once, and
+                          with the arguments it was armed with"
+                  (is (= [["tick" 7]] @!ticks)))
+
+                (testing "…and only THEN is the original cadence re-armed, at
+                          the period the caller asked for"
+                  (let [after (vec (drop mark2 @log))]
+                    (is (some (fn [e] (and (= :interval (:kind e))
+                                           (= retention-ms (:delay e))
+                                           (= ["tick" 7] (:args e))))
+                              after))
+                    (doseq [e (intervals after)] (cancel! e))))))
+
+            (-> (hm/assert-clean! m)
+                (.then (fn [report]
+                         (is (true? (:clean? report)))
+                         (done))))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_clock_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_clock_dom_cljs_test.cljs
@@ -34,6 +34,20 @@
   forced a re-render, or one whose callbacks read an unmoved `Date.now`,
   fails one half of that row each.
 
+  ## The other half: the INSTRUMENT'S own transactions and boundaries
+
+  Presence is what the clock is FOR; the rows below it are about the
+  clock as a thing installed on a page. `mount!` installs it before it
+  seeds the frame — a timer armed by an `:initial-events` step has to be
+  this mount's — so a step that FAILS escapes before any handle exists to
+  release the hold through, and a clock left installed does not fail the
+  run, it hangs it or greens it (rf2-4mvd). And what the clock hands back
+  at the boundary is a claim of its own: ids that cannot be confused with
+  the platform's, and an interval that resumes on the deadline it had
+  left rather than a fresh full period (rf2-w2e6). Those rows read the
+  five platform functions directly, and drive a captured scheduler that
+  records what it was asked for.
+
   ## Browser lane
 
   Every row needs a real document and a real React DOM: the timers are
@@ -63,6 +77,14 @@
 (rf/reg-sub ::toasts (fn [db _] (:toasts db)))
 
 (rf/reg-event ::set (fn [{:keys [db]} [_ ks]] {:db (assoc db :toasts (vec ks))}))
+
+(rf/reg-event ::boom
+  ;; A setup step that FAILS, deterministically. The chain catches the
+  ;; handler-body throw in band and strict construction turns it into
+  ;; `:rf.error/initial-events-step-failed` — which is the escape route
+  ;; rf2-4mvd is about: it leaves `mount!` from `mint-frame!`, before the
+  ;; frame, the container, the root or the handle exist.
+  (fn [_ _] (throw (js/Error. "the seeding step fails, deliberately"))))
 
 (def ^:private retention-ms
   "The retention window every row drives. A whole second, so that
@@ -105,6 +127,52 @@
   "One clocked mount of the tray, seeded with two toasts."
   []
   (hm/mount! [tray] {:clock true :initial-events [[::set [:a :b]]]}))
+
+;; ---------------------------------------------------------------------------
+;; Reading the PLATFORM — the five functions the clock replaces
+;; ---------------------------------------------------------------------------
+
+(def ^:private surface-names
+  "The whole of what an install replaces — each key under the name a red
+  should call it by. One place, so that a row asserting the platform came
+  back cannot assert about four of them and leave the fifth frozen."
+  {:set-timeout    "js/setTimeout"
+   :clear-timeout  "js/clearTimeout"
+   :set-interval   "js/setInterval"
+   :clear-interval "js/clearInterval"
+   :date-now       "js/Date.now"})
+
+(defn- platform-surface
+  "The five functions as they are RIGHT NOW. Identity is the whole of the
+  reading: two of these maps agree exactly when the same functions are
+  installed."
+  []
+  {:set-timeout    (.-setTimeout js/globalThis)
+   :clear-timeout  (.-clearTimeout js/globalThis)
+   :set-interval   (.-setInterval js/globalThis)
+   :clear-interval (.-clearInterval js/globalThis)
+   :date-now       (.-now js/Date)})
+
+(defn- install-surface!
+  "Put `surface` back on the globals. Every row below that can be red is
+  red about a clock that stayed installed, so each of them repairs the
+  page unconditionally once it has taken its reading — a witness that
+  detected the leak and then left it in place would take the rest of the
+  browser run down with it."
+  [surface]
+  (set! (.-setTimeout js/globalThis)    (:set-timeout surface))
+  (set! (.-clearTimeout js/globalThis)  (:clear-timeout surface))
+  (set! (.-setInterval js/globalThis)   (:set-interval surface))
+  (set! (.-clearInterval js/globalThis) (:clear-interval surface))
+  (set! (.-now js/Date)                 (:date-now surface))
+  nil)
+
+(defn- surface-is!
+  "Assert `actual` is `expected`, function by function so a red names the
+  one that is wrong."
+  [expected actual why]
+  (doseq [[k nm] surface-names]
+    (is (identical? (get expected k) (get actual k)) (str nm " — " why))))
 
 ;; ---------------------------------------------------------------------------
 ;; W1 — the discriminating row: retired at the deadline, and not before it
@@ -234,3 +302,137 @@
                              (.then (fn [report]
                                       (is (true? (:clean? report)))
                                       (done)))))))))))))
+
+;; ---------------------------------------------------------------------------
+;; W4 — a clocked mount that FAILS puts the platform back (rf2-4mvd)
+;; ---------------------------------------------------------------------------
+;;
+;; The install is `mount!`'s first act, deliberately: a timer armed by an
+;; `:initial-events` step is one this mount has to be able to drive. That
+;; ordering is what makes the failure interesting. Strict construction runs
+;; the seeding inside `rf/make-frame`, so a step that fails leaves `mount!`
+;; from `mint-frame!` — before a frame, a container, a root or a HANDLE
+;; exists, and therefore before anything the caller could pass to `unmount!`.
+;;
+;; The row makes the step fail and then reads the globals. Asserting the
+;; throw alone would prove nothing whatever: core raises
+;; `:rf.error/initial-events-step-failed` whether or not the clock came down
+;; with it, and a run that inherits a frozen `setTimeout` does not go red —
+;; it hangs, or it goes GREEN on a surface it never exercised.
+
+(deftest a-failed-clocked-mount-leaves-no-clock-installed
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM, so no root and no clock")
+    (async done
+      (let [platform (platform-surface)
+            frames   (set (rf/frame-ids))
+            thrown   (try (hm/mount! [tray] {:clock          true
+                                             :initial-events [[::set [:a]] [::boom]]})
+                          nil
+                          (catch :default e e))
+            after    (platform-surface)]
+
+        (testing "premise: the seeding really failed, and the door delivered
+                  CORE's refusal unchanged — same id, same failing step"
+          (is (some? thrown) "mount! threw")
+          (is (= :rf.error/initial-events-step-failed (:rf.error/id (ex-data thrown))))
+          (is (= [::boom] (:event (ex-data thrown))))
+          (is (= 1 (:step-index (ex-data thrown)))))
+
+        (testing "the provisional frame is absent — core tore it down and the
+                  facade never adopted it"
+          (is (= frames (set (rf/frame-ids)))))
+
+        (testing "AND THE CLOCK IS GONE. This is the reading the row exists
+                  for: the hold was taken before the failing step ran, and
+                  there was never a handle to give it back through, so
+                  nothing but `mount!` itself could release it"
+          (surface-is! platform after "the platform's own again after a failed clocked mount"))
+
+        ;; Whatever the reading found, the page is the page from here on.
+        (install-surface! platform)
+
+        (testing "and the HOLD went with the globals, not just the globals:
+                  the clock is holder-counted, so a leaked holder would show
+                  up as the NEXT clocked mount's unmount failing to restore
+                  anything"
+          (let [m (two-toasts)]
+            (is (not (identical? (:set-timeout platform) (.-setTimeout js/globalThis)))
+                "premise: this mount really installed a clock of its own")
+            (hm/unmount! m)
+            (surface-is! platform (platform-surface)
+                         "back after the only remaining holder let go")
+            (install-surface! platform)
+            (-> (hm/assert-clean! m)
+                (.then (fn [report]
+                         (is (true? (:clean? report)))
+                         ;; The last word is the platform's: a real timer,
+                         ;; on the real scheduler, actually firing.
+                         (js/setTimeout
+                           (fn []
+                             (is true "a real timer still settles after a failed clocked mount")
+                             (done))
+                           0))))))))))
+
+;; ---------------------------------------------------------------------------
+;; W5 — the failure releases EXACTLY its own hold (rf2-4mvd)
+;; ---------------------------------------------------------------------------
+;;
+;; The clock is page-wide because the thing it replaces is, so it is
+;; holder-counted and two clocked mounts share one. That makes the repair
+;; two-sided, and a row that only proved "the globals came back" would be
+;; blind to the other side: a failed mount that RESTORED the platform would
+;; take the instrument out from under a peer that is still driving it, and
+;; the peer's next advance would move nothing.
+;;
+;; So this row runs the failure with a clocked peer standing, and asserts
+;; both directions — the peer's clock survives the failure and still works,
+;; and the peer's own teardown is then enough to put the platform back.
+
+(deftest a-failed-clocked-mount-releases-only-its-own-hold
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM, so no root and no clock")
+    (async done
+      (let [platform (platform-surface)
+            peer     (two-toasts)
+            clocked  (platform-surface)]
+
+        (testing "premise: the peer is standing on a clock"
+          (is (not (identical? (:set-timeout platform) (:set-timeout clocked)))))
+
+        (let [thrown (try (hm/mount! [tray] {:clock true :initial-events [[::boom]]})
+                          nil
+                          (catch :default e e))]
+
+          (testing "premise: the second clocked mount fails in its seeding"
+            (is (= :rf.error/initial-events-step-failed (:rf.error/id (ex-data thrown)))))
+
+          (testing "the peer's clock is UNDISTURBED — the failed call gave back
+                    one hold, and one hold is not the installation"
+            (surface-is! clocked (platform-surface) "still the clock the peer is using"))
+
+          (testing "…and the peer can still DRIVE it. The strongest reading
+                    here, because a restored platform would leave these
+                    globals looking fine to `identical?` on a later install
+                    and still move nothing on an advance"
+            (hm/dispatch-and-settle! peer [::set [:a]])
+            (is (= 2 (toast-count peer)) "retained, mid-exit")
+            (hm/advance-clock! peer (dec retention-ms))
+            (is (= 2 (toast-count peer)) "one millisecond short")
+            (hm/advance-clock! peer 1)
+            (is (= 1 (toast-count peer)) "and gone at its deadline")))
+
+        (hm/unmount! peer)
+
+        (testing "and now — the peer being the last holder — the platform comes
+                  back. A failure that released NOTHING would leave a holder
+                  standing and this reading would still be the clock's"
+          (surface-is! platform (platform-surface)
+                       "the platform's own again once the peer let go"))
+
+        (install-surface! platform)
+
+        (-> (hm/assert-clean! peer)
+            (.then (fn [report]
+                     (is (true? (:clean? report)))
+                     (done))))))))

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
@@ -220,26 +220,53 @@
   A repeating timer's period is floored at 1 ms. The platform floors it
   too (and clamps harder still for nested timers); without a floor a
   zero-period interval inside an advance would be due forever at the same
-  instant and the advance would not terminate."
+  instant and the advance would not terminate.
+
+  **The id counts DOWN from zero, and that is what keeps the two
+  schedulers' handles apart.** A platform handle is positive BY
+  DEFINITION — HTML's timer initialisation steps mint \"an
+  implementation-defined integer that is greater than zero\" — so a
+  negative number is one no browser can ever have issued, and the two id
+  domains cannot meet however long the window stays open. Without that,
+  they overlap from the first timer: [[disarm!]] decides which scheduler
+  an id belongs to purely by looking it up, so a virtual timer numbered
+  1 answers to the `clearTimeout` of a real timer numbered 1 that was
+  armed before the install — the real one lives on and the virtual one
+  dies in its place (rf2-w2e6)."
   [repeat? f delay args]
   (let [d (if (and (number? delay) (pos? delay)) delay 0)]
-    (:seq (swap! !clock
-                 (fn [c]
-                   (let [id (inc (:seq c))]
-                     (-> c
-                         (assoc :seq id)
-                         (assoc-in [:pending id]
-                                   {:id     id
-                                    :f      f
-                                    :args   args
-                                    :due    (+ (:now c) d)
-                                    :period (when repeat? (max 1 d))}))))))))
+    (- (:seq (swap! !clock
+                    (fn [c]
+                      (let [n  (inc (:seq c))
+                            id (- n)]
+                        (-> c
+                            (assoc :seq n)
+                            (assoc-in [:pending id]
+                                      {:id     id
+                                       :f      f
+                                       :args   args
+                                       :due    (+ (:now c) d)
+                                       :period (when repeat? (max 1 d))})))))))))
+
+(defn- arm-ordinal
+  "The ordinal a timer was armed with. Ids count down from zero (see
+  [[arm!]]), so negating one recovers the order it was armed in — which
+  is the order timers due at the same instant fire in, and the order a
+  handover gives them back in."
+  [e]
+  (- (:id e)))
 
 (defn- disarm!
   "Drop the virtual timer `id`, and answer whether there was one. False
-  means the id is not this clock's — a timer armed before the install —
-  and the caller hands it to the platform's own clearer, which is what
-  keeps a `clearTimeout` across the boundary honest."
+  means the id is not this clock's — a timer armed before the install, or
+  a virtual one that has already fired — and the caller hands it to the
+  platform's own clearer, which is what keeps a `clearTimeout` across the
+  boundary honest.
+
+  Honest in BOTH directions, because the id domains are disjoint (see
+  [[arm!]]): a live platform handle can never be found in this table, and
+  a spent virtual handle passed on to the platform names nothing the
+  platform holds."
   [id]
   (if (contains? (:pending @!clock) id)
     (do (swap! !clock update :pending dissoc id) true)
@@ -284,6 +311,14 @@
   nobody can act on. So every outstanding timer is re-armed on the real
   scheduler with the time it had left.
 
+  **An interval's time left is its NEXT TICK, not its period**, and only
+  the ticks after that one are a cadence. So a repeating timer goes back
+  as a one-shot for what remained of the tick it was already waiting for,
+  and that one-shot arms the platform's own repeat at the original
+  period. A `setInterval` for the full period here would hand a timer
+  with 1 ms to run a whole fresh 1000 and shift its phase for the rest of
+  the page's life (rf2-w2e6).
+
   What that does not preserve is the ids: from here on they are the
   platform's, so a `clearTimeout` held across the boundary no longer
   reaches its timer. Nothing in the runtime clears a timer it armed once
@@ -300,11 +335,17 @@
         (set! (.-clearInterval g) (:clear-interval real))
         (set! (.-now js/Date)     (:date-now real))
         (reset! !clock nil)
-        (doseq [e (sort-by :id (vals pending))]
+        (doseq [e (sort-by arm-ordinal (vals pending))
+                :let [left (max 0 (- (:due e) now))]]
           (if-some [p (:period e)]
-            (.apply (:set-interval real) g (to-array (list* (:f e) p (:args e))))
+            (.call (:set-timeout real) g
+                   (fn []
+                     (.apply (:f e) g (to-array (:args e)))
+                     (.apply (:set-interval real) g
+                             (to-array (list* (:f e) p (:args e)))))
+                   left)
             (.apply (:set-timeout real) g
-                    (to-array (list* (:f e) (max 0 (- (:due e) now)) (:args e)))))))))
+                    (to-array (list* (:f e) left (:args e)))))))))
   nil)
 
 (defn- release-clock-for!
@@ -335,7 +376,7 @@
     (let [c   @!clock
           due (->> (vals (:pending c))
                    (filter (fn [e] (<= (:due e) target)))
-                   (sort-by (juxt :due :id))
+                   (sort-by (juxt :due arm-ordinal))
                    first)]
       (if (nil? due)
         (do (swap! !clock update :now max target) fired)

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
@@ -593,7 +593,8 @@
                        BEFORE anything else this call does, so a timer
                        armed by `:initial-events` or by the first render's
                        effects is already this clock's; released by
-                       [[unmount!]].
+                       [[unmount!]], or by the throw that stops this call
+                       ever answering a handle.
 
   ## What it records before it renders
 
@@ -612,10 +613,22 @@
   A form the runtime refuses is refused here too, with the runtime's own
   `ex-info` re-thrown unchanged — same id, same reason, same recovery,
   same offending value — and the page put back exactly as this call found
-  it: no frame registered, no container appended, no counter moved. So
+  it: no frame registered, no container appended, no counter moved, and
+  no clock left installed. So
   `(try (hm/mount! form) (catch :default e (ex-data e)))` is the whole of
   a refusal witness, and there is no handle to be given because there is
   nothing left to tear down.
+
+  The clock is the one allocation [[abandon!]] cannot undo, because it is
+  taken before there is anything to hang it on: a `:initial-events` step
+  that fails leaves from `mint-frame!` with core's own
+  `:rf.error/initial-events-step-failed`, before a frame, a container, a
+  root or a handle exists. So the hold belongs to the CALL until
+  [[handle-for]] hands it to the mount, and the `try` below is that
+  lifetime — one release, on every escaping path, of exactly the one hold
+  this call took (rf2-4mvd). A clocked peer mount therefore keeps the
+  clock it is standing on: the release is a decrement, and the failed
+  call gives back only its own.
 
   React 19 is why this needs saying: a body that throws does not re-throw
   out of `flushSync`, so before PR #7822's audit this door answered a
@@ -627,20 +640,28 @@
    ;; seeding below already runs handlers and the render below already
    ;; runs effects — either can arm a timer, and one armed on the platform
    ;; clock is one this mount can never drive.
+   ;;
+   ;; ONE release covers every way out of this call that is not a handle,
+   ;; the render refusal below included — it throws through this catch
+   ;; rather than releasing for itself, so no path can decrement twice
+   ;; and restore the platform out from under a clocked peer.
    (when clock (install-clock!))
-   (let [[frame-kw ordinal] (mint-frame! initial-events)
-         baseline           (census)
-         node               (or container (mount/fresh-container!))
-         !refusal           (volatile! nil)
-         root               (catching-root! node frame-kw form
-                                            (fn [error]
-                                              (when (nil? @!refusal)
-                                                (vreset! !refusal error))))]
-     (if-some [refusal @!refusal]
-       (do (abandon! frame-kw node (some? container) root)
-           (when clock (release-clock!))
-           (throw refusal))
-       (handle-for root ordinal baseline (boolean clock))))))
+   (try
+     (let [[frame-kw ordinal] (mint-frame! initial-events)
+           baseline           (census)
+           node               (or container (mount/fresh-container!))
+           !refusal           (volatile! nil)
+           root               (catching-root! node frame-kw form
+                                              (fn [error]
+                                                (when (nil? @!refusal)
+                                                  (vreset! !refusal error))))]
+       (if-some [refusal @!refusal]
+         (do (abandon! frame-kw node (some? container) root)
+             (throw refusal))
+         (handle-for root ordinal baseline (boolean clock))))
+     (catch :default e
+       (when clock (release-clock!))
+       (throw e)))))
 
 (defn hydrate!
   "Mount `form` by ADOPTING server-rendered bytes already in the


### PR DESCRIPTION
Two merged-PR-audit findings against the virtual clock that landed in #7861, worked in
priority order. Both are bounded repairs to
`implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs`: **no public API
and no new diagnostic**, and one witness file beside it.

---

## rf2-4mvd (P1) — a failed clocked mount left the global clock installed

`hm/mount!` installs the page-wide virtual clock *before* `mint-frame!`, which is right: a
timer armed by an `:initial-events` step has to be one this mount can drive. But strict
construction runs that seeding inside `rf/make-frame`, so a step that **fails** leaves
`mount!` from `mint-frame!` with core's `:rf.error/initial-events-step-failed` — before a
frame, a container, a root or a **handle** exists. The only pre-handle release was the
later render-refusal branch, so that escape left `!clock` holding a holder nobody could
give back, with global `setTimeout`, `setInterval`, both clearers and `Date.now` still
replaced. There was no handle to pass to `unmount!` or `residue`. The rest of the browser
run then inherits a frozen clock — worse than a failure, because it hangs or greens on a
surface it never exercised.

**How the hold now releases on every escaping path.** The hold belongs to the *call* until
`handle-for` hands it to the mount, and one `try` spans exactly that lifetime:

```clojure
(when clock (install-clock!))
(try
  (let [[frame-kw ordinal] (mint-frame! initial-events)
        …]
    (if-some [refusal @!refusal]
      (do (abandon! frame-kw node (some? container) root)
          (throw refusal))
      (handle-for root ordinal baseline (boolean clock))))
  (catch :default e
    (when clock (release-clock!))
    (throw e)))
```

- **Every escaping path, once.** The render-refusal branch no longer releases for itself —
  it throws *through* the same catch. That is what makes a double decrement structurally
  impossible rather than merely absent: there is one release site, not two.
- **No peer disturbed.** The release is `release-clock!`, a decrement. With a clocked peer
  standing, holders go 2 → 1 and the globals stay the clock's; only the last holder puts
  the platform back.
- **`install-clock!` stays outside the `try`** deliberately — a hold that was never taken
  must not be given back, or a failed install would decrement a peer's count.
- The original refusal is re-thrown unchanged, ex-data included.

---

## rf2-w2e6 (P2) — the clock crossed the real-timer boundary lossily

### 1. Virtual ids could alias live platform ids

`disarm!` decides which of two schedulers an id belongs to purely by looking it up in
`:pending`, which is only honest while the domains are disjoint — and they were not: the
platform numbers a fresh page's timers from 1 and the virtual scheduler restarted at 1 too.
One collision failed silently in **both** directions: a `clearTimeout` meant for a
pre-install real timer found the virtual one and killed it instead (real one lives on), and
once the virtual timer had fired, ordinary cleanup of its stale id reached the platform and
cancelled the unrelated real timer.

**How the ids became collision-free.** They count **down** from zero. A platform handle is
positive *by definition* — HTML's timer initialisation steps mint "an implementation-defined
integer that is greater than zero" — so a negative number is one no browser can ever have
issued, and the domains cannot meet however long the window stays open. That is a
disjointness proof rather than a large-offset guess, and it costs one negation rather than a
registry. `arm-ordinal` (`(- (:id e))`) recovers the arm order the two orderings need: at
one instant timers still fire in arm order, and a handover still gives them back in it.
Either clearer still cancels either kind, and a spent virtual id is still passed on to the
platform — it just names nothing the platform holds.

### 2. Interval handover lost its next deadline

`release-clock!` promises every outstanding timer is re-armed with the time it had left.
Timeouts used `(:due e) - now`; intervals asked the platform for the **full period**. A
1000 ms interval released after 999 virtual ms therefore fired 1000 ms later instead of 1 ms
later, and stayed out of phase for the rest of the page's life.

An interval's time left is its **next tick**; only the ticks after that are a cadence. So a
repeating timer goes back as a one-shot for what remained of that tick, and that one-shot
arms the platform's own repeat at the original period. **First post-release deadline for a
1000 ms interval advanced to 999: `setTimeout(bridge, 1)`, and only after it runs,
`setInterval(f, 1000)`.** Callback arguments are carried through both.

The existing statement that handles cannot clear a timer after handover is unchanged.

---

## Witnesses

All four are in `test_kit_clock_dom_cljs_test.cljs` and all four are **real-browser** rows
(`:node-test` degrades each to a stated skip). Every row repairs the globals unconditionally
after taking its reading, so a red about a leaked clock cannot take the rest of the run down
with it.

| Row | The narrowing it refuses to allow |
| --- | --- |
| `a-failed-clocked-mount-leaves-no-clock-installed` | Asserting the throw proves nothing — core raises the same refusal whether or not the clock came down. The row makes an `:initial-events` step **throw**, then reads the five platform functions by identity; then proves the **hold** went too, by requiring a fresh clocked mount's own unmount to restore the platform (a leaked holder prevents that); then a real timer fires. |
| `a-failed-clocked-mount-releases-only-its-own-hold` | The peer control. With a clocked peer standing: the peer's clock survives untouched, **still drives** (a child retires at its own deadline, not one millisecond early), and the peer's teardown is then enough to put the platform back. Catches "released nothing" and "released twice". |
| `a-virtual-handle-cannot-alias-a-platform-one` | A row using only virtual timers can never see aliasing, so this one arms **two real timers before the install**, through a recording scheduler that numbers from 1. It asserts the law itself (`every? neg?` — not `(not= r1 v1)`, which would only prove these particular numbers missed), then both behavioural directions, then clearTimeout/clearInterval cross-use. |
| `an-interval-hands-back-the-deadline-it-had-left` | Asserting the interval eventually fires would pass with the bug. This asserts the **first** post-release deadline: no `setInterval` at release at all, a one-millisecond timeout instead, and the cadence re-armed only after that timeout has run the callback **once with its arguments**. The handover is driven by hand — no wall-clock sleeps. |

The recording scheduler **delegates** to the genuine functions (a stub that only recorded
would strand the runtime's own reapers at handover and turn `assert-clean!` red for an
unrelated reason) while handing out ids from 1.

## Confirm-by-revert

Both laws were broken together in the tree and the browser lane re-run, so each of the four
rows had to red for a reason of its own rather than one of them carrying the others.
**Exit 1 — 15 failures, 0 errors**, and every one of the four rows is among them:

| Row | Reds |
| --- | --- |
| `a-failed-clocked-mount-leaves-no-clock-installed` | 6 |
| `a-failed-clocked-mount-releases-only-its-own-hold` | 2 |
| `a-virtual-handle-cannot-alias-a-platform-one` | 4 |
| `an-interval-hands-back-the-deadline-it-had-left` | 3 |

The plants were the pre-fix code exactly: `mount!`'s hold released only on the
render-refusal branch; `arm!` counting **up** from 1 with `arm-ordinal` reading `:id`
straight; and the interval handover asking the captured scheduler for a fresh full-period
`setInterval`. The restore is verified by **sha256** against the pre-plant file
(`git diff` reads clean too), and the green lane below was run on the restored tree.

The reds are the bugs' own signatures rather than incidental breakage:

```
FAIL in (a-failed-clocked-mount-leaves-no-clock-installed) (…test_kit_clock_dom_cljs_test.cljs:175:9)
AND THE CLOCK IS GONE. …
js/setTimeout — the platform's own again after a failed clocked mount
  (×5, one per replaced platform function, plus the leaked-holder arm)

FAIL in (a-virtual-handle-cannot-alias-a-platform-one) (…:542:17)
so no virtual handle can be a platform handle …
expected: (every? neg? [v1 v2 iv])

FAIL in (an-interval-hands-back-the-deadline-it-had-left) (…:623:21)
…it asked for a ONE-MILLISECOND timeout — what was left of the tick the
interval was already waiting for
expected: (seq firsts)
  actual: (not (seq []))
```

That last red is the phase shift itself: a timer with **1 ms** left handed back as a fresh
full-period `setInterval`, so the captured scheduler was never asked for a 1 ms timeout at
all.

## Quality gates

Each gate was run alone, its output redirected to a log, and its exit code captured on the
same command line — never through a pipe, whose status would be the last stage's. (That
precaution earned itself here: the harness reported the confirm-by-revert run as "exit code
0" because the wrapper's last command succeeded, while the gate's own captured status was
**1**.)

| Gate | Exit | Result |
| --- | --- | --- |
| `npm run test:browser` (real Chromium, `-dom-cljs-test$`) — **the gate that matters here** | **0** | 1249 tests, 7748 assertions, **0 failures, 0 errors** |
| `scripts/test-fast-pr.sh` (full spine, absolute path, from this worktree) | **0** | `PASS fast PR spine` — 61 steps, of which the CLJS node integration ran 13251 tests / 67005 assertions, **0 failures, 0 errors** |
| confirm-by-revert, both plants together (browser lane) | **1** | 15 failures, 0 errors — all four rows red, restore verified by sha256 |

The branch was **rebased onto `origin/main`** before these runs, so the green above is
against what will merge rather than against a stale base; the rebase was clean and the diff
is unchanged at two files.

Both gates name this checkout as their root — `config:
…/re-frame2-worktrees/clockfix2-4mvd/implementation/shadow-cljs.edn` for the browser lane
and `gate root: /c/Users/miket/code/re-frame2-worktrees/clockfix2-4mvd` for the spine — so
neither verdict is about another live worktree.

The confirm-by-revert above was run against **byte-identical** sources (the restored file's
sha256 matches, and the two commits carry the same tree), on an earlier base. Its subject is
the fix and the four witnesses, neither of which the rebase touched.

The **browser lane is run deliberately and is not optional here**: this is timer and
global-scheduler behaviour, and `test:cljs` cannot see a frozen clock leaking into a later
browser test — which is the P1's actual symptom. A node-only verdict would not establish the
fix.

### What CI decides that this spine does not

`python scripts/check_fast_pr_gap.py --list` reports **96** required checks the fast-PR
spine does not decide. The ones this diff's surface actually arms, and their status here:

- **`cljs-browser`** (`npm run test:browser`) — the required job that runs these four rows.
  Run above, green. This is the one that matters and it is not in the spine.
- **`cljs-hicasso-controlled`** and **`cljs-hicasso-hmr`** — three-engine Chromium/Firefox/WebKit
  gates armed by `implementation/hicasso/**`. **Not run locally** (each launches three engines;
  the HMR one drives a live `shadow-cljs watch`). Neither reaches this diff: nothing under
  `hicasso/testbed/` requires `re-frame.hicasso.test.mounted` — `git grep` shows its only two
  requirers are the two `test_kit_*_dom_cljs_test` namespaces, both of which are in the
  `cljs-browser` lane run above. CI will run them anyway on the surface predicate.
- **`clj-kondo`** — the local binary is v2025.10.23 and CI pins **2026.04.15**; the two
  versions disagree about which findings are errors, so a local pass would prove nothing.
  Left to CI, per `check_fast_pr_gap.py`'s own note.

The spine classified this diff as `docs=false jvm=false node=true` and named its own three
omissions, which match the diff's surface:

- **documentation gates** — no docs changed, so `mkdocs build --strict` is not the gate for
  this edit.
- **all JVM artefact suites** — the `implementation_jvm` surface is unchanged; no JVM
  artefact tree is touched.
- **browser lanes, prod-elision / bundle-isolation / perf gates, adapter probes and smokes,
  the Xray feature matrix, mcp-conformance, tool JVM suites** — CI-only by design. The one
  of these that matters here is the browser lane, and it is run above rather than deferred.
  The rest cannot reach this diff: `test_kit/src` is outside the artefact's published
  `:paths`, so nothing in a production bundle can require it, and no adapter, example or
  tool is touched.

One gate worth naming because it *did* fire on this exact surface: the retired-spelling gate
(EP-0007), whose Clojure coordinate boundary tightened in #7875, scans
`implementation/hicasso/test_kit` with tests always included. It reports
`no retired spellings in any scanned source tree`.

## Fences

`spec/**`, `docs/design/hicasso/**`, `implementation/hicasso/src/**`,
`implementation/core/**`, `tools/**`, `deps.edn`, `shadow-cljs.edn` and
`.github/workflows/*` are untouched. Two files changed, both inside the brief's fence.

Closes rf2-4mvd. Closes rf2-w2e6.
