### PR TITLE
docs(hicasso): drop capability receipts from the decision brief's spike list (rf2-sxl5)

### DIFF
--- a/docs/design/hicasso/product/decision-brief.md
+++ b/docs/design/hicasso/product/decision-brief.md
@@ -132,8 +132,8 @@ Comparative bands follow: an initial mount ceiling of 1.25x direct UIx; tuned br
 
 **The ideas ledger** (full designs in `lanes/left-field-ideas.md`, and in its operator-local source `fable/left-field-ideas.md`, which is not published in this tree):
 
-- *Adopt*: complaint catalogue, cause-aware hot advisor, direct React output with the Hicasso-owned native tier (`n/$` and companions; gates in Part II).
-- *Spike with deciding rules*: committed-read resource demand; pull-shaped reads; schema-driven generators; counterfactual topology advice; capability receipts; replayable view capsules after L2; MCP-queryable runtime and migration shadowing through existing tools; shared read-set notification groups after a census.
+- *Adopt*: complaint catalogue, cause-aware hot advisor, capability receipts (counts only; self time refused), direct React output with the Hicasso-owned native tier (`n/$` and companions; gates in Part II).
+- *Spike with deciding rules*: committed-read resource demand; pull-shaped reads; schema-driven generators; counterfactual topology advice; replayable view capsules after L2; MCP-queryable runtime and migration shadowing through existing tools; shared read-set notification groups after a census.
 - *Watch*: a read-free shell as a read-nothing optimization, not a heap fix; codec shape planning only when classification/lowering exceeds 10% of hot-boundary self time; intent replay through Story; keyed-list maintenance only after a red bulk verdict; a future React store seam.
 - *Reject*: compiler/JIT modes, second renderers, worker view runtimes, signals replacement, universal callback cells, and hydration-free inference.
 


### PR DESCRIPTION
Closes rf2-sxl5.

## The drift

PR #7882 (rf2-eoo9) moved the capability-receipts row in `docs/design/hicasso/product/specification.md` §11 from *Spike* to **Adopt (counts only)**, and recorded the `rf2-hic-081` verdict in `lanes/left-field-ideas.md`. The decision brief's ideas ledger was outside that PR's fence and still named the row among the open spikes.

Verified still present at source before editing: `origin/main` (f3590d10) `decision-brief.md:136` carried `capability receipts` in the *Spike with deciding rules* line. Not already fixed under another bead.

## Adopt, not neither — and why

The brief now names it on the *Adopt* line with the qualification the verdict turns on:

> - *Adopt*: complaint catalogue, cause-aware hot advisor, **capability receipts (counts only; self time refused)**, direct React output with the Hicasso-owned native tier (`n/$` and companions; gates in Part II).

Three reasons for *Adopt* over dropping the row from both lines:

1. It matches the source of truth. Spec §11 says `Adopt (counts only)`, and the lane says the spike "retained no code: the counts graduate as a design, and self time is killed". An adopted design belongs on the adopt line; silence would read as a row that was never dispositioned.
2. The unqualified word "adopt" would be wrong on its own here, because the paragraph immediately below the ledger reads "Every spike must retain the detailed fence and deciding witness in `lanes/left-field-ideas.md`" — a bare listing invites the reader to assume the whole idea graduated, including self time. The qualification is load-bearing, not decoration.
3. The parenthetical is the register the line already uses — the native-tier item carries `(`n/$` and companions; gates in Part II)`. The receipt entry is placed before it so the long trailing item keeps the end of the sentence.

Deliberately **not** restated here: the derivation of the five fields, the clock-grain and attempt-count arithmetic that kills self time, and the owed witness. `specification.md` §11 and `lanes/left-field-ideas.md` own that design; a third copy is a third thing to drift. The ledger entry is a pointer.

`specification.md` and `lanes/left-field-ideas.md` are **untouched** — they are already correct as of #7882.

## Quality gates

Each run alone, nothing piped, exit code captured from the same shell line as the command.

| Command | Captured exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_doc_slugs.py` (negative control, broken anchor injected) | **1** — see below |
| `python scripts/check_doc_slugs.py` (re-run after restore) | **0** |
| `python scripts/check_fast_pr_gap.py --list` | **0** |

**Negative control.** `decision-brief.md` contains no markdown links at all, so there was no existing target to break; the control injected one. Appending `[negative control](lanes/no-such-file-briefdrift-sxl5.md)` made the gate fail with exit **1**, naming this file by path and line:

```
1 broken target file(s) found:

  BROKEN TARGET: docs\design\hicasso\product\decision-brief.md:158 -> lanes/no-such-file-briefdrift-sxl5.md
      (missing: docs\design\hicasso\product\lanes\no-such-file-briefdrift-sxl5.md)
```

Restored with `git checkout HEAD -- docs/design/hicasso/product/decision-brief.md`; the re-run returned to exit 0 and `git status --porcelain` is empty, so no control residue reached the branch. The gate is proven to cover this file, not merely to have been run over it.

**`mkdocs build --strict` is not nominated and was not run.** `mkdocs.yml`'s `exclude_docs` keeps `docs/design/` out of the site, so a build over this tree exits green having verified nothing about it.

**Tables: none touched.** The diff changes two bullet-list lines in the ideas ledger; no table row, and no heading, is added, removed, or reworded, so no column count and no anchor changed. Hand-checked against the diff.

**Gap check.** `scripts/check_fast_pr_gap.py --list` reports **96 required checks the fast-PR spine does not decide** — all 45 `test.yml` jobs behind `All required checks passed` (browser/Playwright gates, prod-gate JVM lanes, bundle-isolation and elision probes, every `tools/*` artefact suite, MCP conformance, skills structural), the 5 `lint.yml` jobs behind `Lint required` (clj-kondo pinned to 2026.04.15, Splint, ESLint, the public-API manifest drift-check), and the `docs.yml` surface detector behind `Docs required`. This diff is one markdown file under `docs/design/`, which reaches none of those surfaces, and the lint/docs detectors classify it out; CI remains the authority.

**No `node_modules` junction was created.** A documentation-only diff needs no build, and that operation has twice emptied the mayor checkout's real `node_modules`.
