### PR TITLE
ci(lint): retry the clj-kondo release-zip download, not just the installer script (rf2-rkl9)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -265,20 +265,26 @@ jobs:
         # supports `--retry-all-errors` (since 7.71). `-f` additionally means
         # an error page can never be mistaken for an archive.
         #
-        # The platform triple is written out rather than probed: this job is
+        # The URL is written out in full — platform triple and version pin
+        # literal, no shell interpolation — so that the string in this file is
+        # the string a reader is holding when they come here from a failed
+        # log, and so `scripts/check_fast_pr_gap.py` can still read the pin off
+        # this step (it reports which clj-kondo version CI pins, because a pass
+        # from a locally-installed clj-kondo of another version proves nothing).
+        # The platform is fixed rather than probed because this job is
         # `runs-on: ubuntu-latest`, i.e. linux/amd64, for which upstream
-        # publishes the `-static` build. Were the runner ever to change, the
-        # URL 404s and `-f` fails the step outright rather than installing
-        # something else. `/usr/local/bin` is on $PATH and is where the
-        # upstream script installs too, so the run step below is unchanged.
+        # publishes the `-static` build; were the runner to change, the URL
+        # 404s and `-f` fails the step loudly rather than installing something
+        # else. Bumping the pin means changing BOTH occurrences below — miss
+        # one and the URL 404s immediately, which is a louder failure than the
+        # one this step exists to stop. `/usr/local/bin` is on $PATH and is
+        # where the upstream script installed too, so nothing downstream moves.
         run: |
-          version=2026.04.15
-          dir="$(mktemp -d)"
           curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 \
-            -o "$dir/clj-kondo.zip" \
-            "https://github.com/clj-kondo/clj-kondo/releases/download/v${version}/clj-kondo-${version}-linux-static-amd64.zip"
-          unzip -qq "$dir/clj-kondo.zip" clj-kondo -d "$dir"
-          sudo install -m 0755 "$dir/clj-kondo" /usr/local/bin/clj-kondo
+            -o /tmp/clj-kondo.zip \
+            https://github.com/clj-kondo/clj-kondo/releases/download/v2026.04.15/clj-kondo-2026.04.15-linux-static-amd64.zip
+          unzip -qq -o /tmp/clj-kondo.zip clj-kondo -d /tmp
+          sudo install -m 0755 /tmp/clj-kondo /usr/local/bin/clj-kondo
           clj-kondo --version
 
       # Cache the kondo classpath / project-analysis under

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -236,22 +236,49 @@ jobs:
 
       # Install the official binary directly — the published GitHub
       # Actions for clj-kondo are either unmaintained (DeLaGuardo's runs
-      # on node12, deprecated by GitHub) or community-forked. The
-      # upstream `install-clj-kondo` script is the documented path and
-      # leaves the binary on $PATH.
+      # on node12, deprecated by GitHub) or community-forked.
       - name: Install clj-kondo
-        # `raw.githubusercontent.com` is CDN-fronted and HTTP-429s under
-        # rate limiting, which (with bare `curl -f`) dies in ~11s and reds
-        # unrelated PRs (rf2-cq0s2j; cost a fix-worker cycle on #5304).
+        # Fetch the pinned release archive ourselves rather than delegating
+        # to upstream's `install-clj-kondo` script (rf2-rkl9). The script is
+        # the documented path, but it fetches that archive with a bare
+        # `curl -o "$filename" -sL` — no `-f`, no retry — and THAT hop is
+        # where this gate actually dies. PR #7881's job logged one line,
+        # `Downloading …/clj-kondo-2026.04.15-linux-static-amd64.zip to
+        # /tmp`, then exit 35 (curl's SSL-connect error) 0.24s in, with no
+        # lint output anywhere. A transient install failure wearing the
+        # costume of a RED LINT GATE is the worst possible disguise: the
+        # natural response is to hunt the diff for an error that does not
+        # exist, and that is exactly what it cost.
+        #
+        # Retry-hardening the fetch of the SCRIPT (rf2-cq0s2j, below) was
+        # right in intent but one hop short of reach, and pre-fetching the
+        # archive in front of the script cannot close the gap either — the
+        # script `rm -rf`s the archive immediately before downloading it, so
+        # a warm copy is discarded unread. Fetching it directly is the only
+        # placement where the retry policy covers the download that fails,
+        # and it drops this step from two network hops to one.
+        #
         # `--retry 5 --retry-all-errors --retry-delay 3` retries transient
-        # failures — including the 429 that `-f` alone treats as fatal —
-        # with a 3s base backoff. GNU curl on ubuntu-24.04 runners supports
-        # `--retry-all-errors` (since 7.71).
+        # failures with a 3s base backoff — the SSL-connect drop above, and
+        # the CDN HTTP-429 that `-f` alone treats as fatal (rf2-cq0s2j; cost
+        # a fix-worker cycle on #5304). GNU curl on ubuntu-24.04 runners
+        # supports `--retry-all-errors` (since 7.71). `-f` additionally means
+        # an error page can never be mistaken for an archive.
+        #
+        # The platform triple is written out rather than probed: this job is
+        # `runs-on: ubuntu-latest`, i.e. linux/amd64, for which upstream
+        # publishes the `-static` build. Were the runner ever to change, the
+        # URL 404s and `-f` fails the step outright rather than installing
+        # something else. `/usr/local/bin` is on $PATH and is where the
+        # upstream script installs too, so the run step below is unchanged.
         run: |
-          curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o install-clj-kondo \
-            https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/script/install-clj-kondo
-          chmod +x install-clj-kondo
-          sudo ./install-clj-kondo --version 2026.04.15
+          version=2026.04.15
+          dir="$(mktemp -d)"
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 \
+            -o "$dir/clj-kondo.zip" \
+            "https://github.com/clj-kondo/clj-kondo/releases/download/v${version}/clj-kondo-${version}-linux-static-amd64.zip"
+          unzip -qq "$dir/clj-kondo.zip" clj-kondo -d "$dir"
+          sudo install -m 0755 "$dir/clj-kondo" /usr/local/bin/clj-kondo
           clj-kondo --version
 
       # Cache the kondo classpath / project-analysis under

--- a/scripts/check_fast_pr_gap.py
+++ b/scripts/check_fast_pr_gap.py
@@ -127,9 +127,13 @@ SETUP_PATTERNS = (
     r"^npx playwright install\b",
     r"^sudo apt-get\b",
     r"^apt-get\b",
-    r"^curl .*install-clj-kondo",
-    r"^chmod \+x install-clj-kondo$",
-    r"^sudo \./install-clj-kondo\b",
+    # The clj-kondo installer step (lint.yml). It fetches the pinned release
+    # archive straight from the GitHub release rather than by way of upstream's
+    # `install-clj-kondo` script (rf2-rkl9: the script re-downloads the archive
+    # with a bare un-retried `curl -sL`, which is the hop that actually flakes).
+    r"^curl .*clj-kondo/releases/download/",
+    r"^unzip .*clj-kondo",
+    r"^sudo install .*/clj-kondo$",
     r"^clj-kondo --version$",
 )
 _SETUP_RE = tuple(re.compile(p) for p in SETUP_PATTERNS)
@@ -260,7 +264,13 @@ _PY_CHECKER_RE = re.compile(r"^python scripts/(check_[A-Za-z0-9_]+)\.py\b(.*)$")
 _SPINE_CHECKER_RE = re.compile(
     r'python\s+"\$spine_root/scripts/(check_[A-Za-z0-9_]+)\.py"(.*)$'
 )
-_KONDO_PIN_RE = re.compile(r"install-clj-kondo --version (\S+)")
+# The clj-kondo pin, read off the release URL the installer step fetches. The
+# pin used to be read from `install-clj-kondo --version <pin>`, but that script
+# re-downloads the archive over an un-retried `curl -sL` and reds the lint gate
+# on a transient network fault (rf2-rkl9), so lint.yml now fetches the archive
+# itself. The release URL carries the same pin and is a tighter anchor: nothing
+# else in any workflow can match it.
+_KONDO_PIN_RE = re.compile(r"clj-kondo/releases/download/v([^/\s]+)/")
 
 
 def _mode(flags: str) -> str:
@@ -594,9 +604,9 @@ class GapMap:
         if self.kondo_pin is None:
             self.problems.append(
                 "the clj-kondo version pin could not be read from any required job's "
-                "installer step (expected `install-clj-kondo --version <pin>`); the "
-                "report would omit the pin, and a local clj-kondo of another version "
-                "proves nothing"
+                "installer step (expected a fetch of "
+                "`.../clj-kondo/releases/download/v<pin>/...`); the report would omit "
+                "the pin, and a local clj-kondo of another version proves nothing"
             )
 
         for lane in SPINE_LANES:
@@ -1038,8 +1048,11 @@ def run_self_tests(verbose: bool) -> int:
         any("expected at least" in p and SPINE in p for p in empty.problems),
     )
 
-    check("the kondo pin regex reads a real pin", _KONDO_PIN_RE.search(
-        "sudo ./install-clj-kondo --version 2026.04.15") is not None)
+    _pin = _KONDO_PIN_RE.search(
+        "curl -fsSL -o /tmp/clj-kondo.zip https://github.com/clj-kondo/clj-kondo"
+        "/releases/download/v2026.04.15/clj-kondo-2026.04.15-linux-static-amd64.zip")
+    check("the kondo pin regex reads a real pin off the release URL",
+          _pin is not None and _pin.group(1) == "2026.04.15")
 
     # `${{ github.workspace }}` is the repo root -- the EP-0036 donor grep
     # declares it, and echoing the raw expression as a `cd` target would print a


### PR DESCRIPTION
Closes rf2-rkl9.

PR #7881's `clj-kondo` job went red **without ever running clj-kondo**. The entire "Install clj-kondo" step was one line:

```
Downloading https://github.com/clj-kondo/clj-kondo/releases/download/v2026.04.15/clj-kondo-2026.04.15-linux-static-amd64.zip to /tmp
##[error]Process completed with exit code 35.
```

Exit 35 is curl's SSL-connect error, 0.24 s in. No lint output anywhere. A transient install failure wearing the costume of a red lint gate is the worst possible disguise: the natural response is to hunt the diff for an error that does not exist, and that is exactly what it cost.

## The premise held, and the first remedy option did not

`lint.yml` did already carry `--retry 5 --retry-all-errors --retry-delay 3`, and it was on the wrong hop — it covered fetching the `install-clj-kondo` **script** from `raw.githubusercontent.com`, not the release archive the script then fetches itself. Confirmed at source before editing.

But the bead's first option — *pre-fetch the release zip, then invoke the installer* — **cannot work**, and this is only visible by reading the installer. From `script/install-clj-kondo`:

```sh
filename="clj-kondo-$version-$platform$static_suffix-$arch.zip"

rm -rf "$filename"
rm -rf "clj-kondo"
curl -o "$filename" -sL "$download_url"
```

It deletes the archive immediately before downloading it, so a warm copy placed in `/tmp` is discarded unread. The script's own `curl` has no `-f` and no retry, and it is not configurable. **Any remedy that keeps the installer script keeps the bug.**

## Remedy chosen: fetch the pinned archive directly

Closest in spirit to the bead's first option (reuse the retry vocabulary already established here by rf2-cq0s2j), adjusted for the `rm -rf` above — the retry policy is placed on the download that actually fails, which is only possible if we perform that download:

```yaml
run: |
  curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 \
    -o /tmp/clj-kondo.zip \
    https://github.com/clj-kondo/clj-kondo/releases/download/v2026.04.15/clj-kondo-2026.04.15-linux-static-amd64.zip
  unzip -qq -o /tmp/clj-kondo.zip clj-kondo -d /tmp
  sudo install -m 0755 /tmp/clj-kondo /usr/local/bin/clj-kondo
  clj-kondo --version
```

Two network hops become one, and the one that remains is the retried one. `-f` additionally means an error page can never be mistaken for an archive — the un-`-f`'d fetch it replaces would have written a 429 body into the zip and failed later, at `unzip`, wearing a different costume again. `/usr/local/bin` is where the upstream script installed too, so nothing downstream moves.

No wrapper script, no retry loop of our own, no third mechanism: curl's own retry flags, the same five words already in this file.

**Why not the cached-action option.** It reverses a decision this file documents in place (the published clj-kondo actions are unmaintained or community-forked), adds a third-party action to a *required* gate, and — on ephemeral GitHub-hosted runners with a cold tool cache — does not actually remove the download. It relocates it into a dependency whose retry behaviour we do not control. Bigger change, weaker guarantee.

**Cost accepted:** the version pin appears twice in the URL, so a bump edits both. Miss one and the URL 404s under `-f` — immediate, loud, and unambiguous, which is a strictly better failure than the one this PR removes. In exchange the URL in the workflow is byte-identical to the URL in the failure log, which is the string a confused reader is actually holding.

## The second file, and why this could not be a one-file change

`scripts/check_fast_pr_gap.py` reads the clj-kondo pin **off this very step** (deliberately — prose would go stale, and a local clj-kondo of another version proves nothing). It knew only the old shape, `install-clj-kondo --version <pin>`. Dropping the installer therefore broke a required gate, which the local run caught:

```
1 problem(s) in the fast-PR gap map:
  - the clj-kondo version pin could not be read from any required job's installer step ...
```

and, separately, the new lines no longer matched `SETUP_PATTERNS`, so the installer was misreported as an unrun CI *gate* (97 unrun required checks instead of 96). Both are fixed at the parser: the pin now comes off the release URL — a tighter anchor than the old one, since nothing else in any workflow can match `clj-kondo/releases/download/v<pin>/` — and the setup patterns follow the new lines. The self-test fixture moves with them.

This coupling is worth knowing about in its own right: **the pin parser is coupled to the installer's literal command shape**, so any future change to how clj-kondo is installed is a two-file change.

## Check-NAME set: UNCHANGED

Verified by parsing both sides rather than by eye — `origin/main`'s `lint.yml` against this branch's:

```
TRIGGERS/PATH-FILTERS IDENTICAL: True
JOB id+name+if+needs IDENTICAL: True
step NAMES in clj-kondo job identical: True
added jobs: set()   removed jobs: set()
```

No job added, removed or renamed; no path filter touched; no `if:` changed. **PRs behind this one do not need their check sets recomputed.**

## Quality gates

**A workflow change cannot be honestly gated locally — the only real proof is the job itself.** Stating that plainly rather than nominating a gate that does not cover it. What helps here: this PR *is* its own proof. `detect` classifies `.github/workflows/lint.yml` as lint surface (it is listed explicitly in the case arm), so `lint_surface=true` and the `clj-kondo` job runs on this PR with the new install step. If the step is wrong, this PR goes red for it.

**There is no actionlint or yamllint in this repo** — `git grep` for both returns nothing, and `scripts/` has no workflow-validation checker. So no workflow linter was run, because none exists.

Each gate run alone, nothing appended, exit code captured in the same shell:

| Gate | Exit |
|---|---|
| `python -c "yaml.safe_load(...lint.yml)"` — parses; install-step body dumps as intended | `0` |
| check-NAME/trigger comparison vs `origin/main` (script above) | `0` |
| `python scripts/check_fast_pr_gap.py --self-test` | `0` |
| `python scripts/check_fast_pr_gap.py --check` | `0` |
| `python scripts/check_fast_pr_gap.py --list` | `0` |
| `python scripts/check_gate_scheduling.py --self-test --verbose` | `0` |
| `python scripts/check_gate_scheduling.py --verbose` | `0` |

The last four are the spine's own lanes over the file I co-changed (`scripts/test-fast-pr.sh` runs exactly these). `--check` and `--list` both exited **1 before** the parser fix and **0 after**, which is what caught the coupling.

Live confirmation the pin is still derived, from `--list`:

```
NOTE clj-kondo: CI pins 2026.04.15. A pass from a differently-versioned
     local binary PROVES NOTHING ...
```

`check_fast_pr_gap.py --list` reports **96** required checks the fast-PR spine does not decide (down from 97 only because the install step stopped being miscounted as a gate). None of the three required contexts — `All required checks passed`, `Lint required`, `Docs required` — is decided locally.
