### PR TITLE
docs(hicasso): advance-clock! accepts a hydrate! handle too, in its own words (rf2-5786)

### DIFF
--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
@@ -850,10 +850,10 @@
         (hm/advance-clock! m 300)
         (is (= 1 (count (toasts m)))))  ;; the deadline passed
 
-  Requires `{:clock true}` on the [[mount!]] that made `handle`, and
-  throws without it. That is not decoration: an advance with no clock
-  under it would move nothing and assert nothing, and the row would go
-  green for the reason it was written to rule out.
+  Requires `{:clock true}` on the [[mount!]] or [[hydrate!]] that made
+  `handle`, and throws without it. That is not decoration: an advance
+  with no clock under it would move nothing and assert nothing, and the
+  row would go green for the reason it was written to rule out.
 
   ## What advances
 
@@ -908,7 +908,7 @@
                            "and this handle owns none"
                            (if (some? held)
                              " any longer — it was released when the mount came down."
-                             ": mount! was not given {:clock true}.")
+                             ": mount! or hydrate! was not given {:clock true}.")
                            " An advance with no clock under it would move nothing "
                            "and assert nothing.")
                       {:ms ms :frame (:frame handle)})))


### PR DESCRIPTION
PR #7877 corrected the three exhaustive mounted-facade rosters, the guide's L3 door table and
naming-ledger row 41 to say that **both** `hm/mount!` and `hm/hydrate!` can produce a `{:clock true}`
handle. That was verified at source: shipped `hydrate!` destructures `:clock`, installs the clock on
the resolve branch rather than at the top of the door, and hands back a handle `advance-clock!`
accepts.

Two carriers outlived that repair, and **both were still stale at source** on `origin/main`
`d26757d493` — re-read before editing rather than trusted from the bead, whose line numbers
(791, 849) had been moved by the virtual-clock repair (PR #7883) landing in the same file:

| carrier | was | now |
|---|---|---|
| `advance-clock!`'s own docstring | `` Requires `{:clock true}` on the [[mount!]] that made `handle` `` | `` Requires `{:clock true}` on the [[mount!]] or [[hydrate!]] that made `handle` `` |
| its throw message | `": mount! was not given {:clock true}."` | `": mount! or hydrate! was not given {:clock true}."` |

These two are the most authoritative carriers there are, because they sit **on the function**. A
docstring is what an author reads at the call site; a throw message is what they read when it goes
wrong. They are the last carriers a reader consults and the ones most likely to be believed — so
leaving them behind inverted the repair. Every surrounding document said *`mount!` or `hydrate!`*
while the function itself said *`mount!`*, and a reader who trusts the code over the docs concludes
`hydrate!` is unsupported. Same defect species `rf2-dsnq` closed: a confident sentence outliving the
behaviour it described.

The wording is **#7877's, not a third phrasing** — the guide's door row reads "needs `{:clock true}`
on the `mount!` or `hydrate!` that made the handle", and naming-ledger row 41 reads "the
`{:clock true}` option on `hm/mount!` or `hm/hydrate!` that arms it". The docstring keeps its own
register and its own `[[wiki-link]]` form (the namespace already links `[[hydrate!]]` at L84 and
L121, and `hydrate!` is defined in this namespace at L707, so the link resolves); the throw message
keeps its clause shape exactly and gains three words. The paragraph is re-wrapped to the file's
column, which is why four docstring lines move for one inserted phrase.

**No behaviour change.** The same predicate throws on the same handles; only the sentence explaining
why names one more door.

### No test pinned the old wording, checked rather than assumed

`implementation/hicasso/test/re_frame/hicasso/test_kit_clock_dom_cljs_test.cljs` is the suite that
drives both refusals (a released clock at L335-337, a mount that never asked for one at L344-347).
Both rows assert `(ex-data thrown)` and `(some? thrown)` — **never the message text**. A repo-wide
search for the message's three literal fragments (`was not given {:clock true}`, `owns none`,
`moves the virtual clock a mount owns`) finds them only in `mounted.cljs` itself. So there is no test
to update in the same change, and no mutually-invalidating pair with anything in flight.

That file is also inside another worker's fence (`implementation/hicasso/test/**` → `portal-hic028`)
and is **not touched here** — the check was a read.

### Scope kept

The `render!` / `rerender!` naming divergence across these rosters is `rf2-hic-065`'s and is left
exactly as found. Nothing under `implementation/hicasso/src/**` or `implementation/hicasso/test/**`
is touched. One file, two strings.

## Quality gates

Each gate was run **alone**, nothing appended, never piped through `tail` / `head` / `grep` — output
redirected to a `.log` and `$?` captured to a `.exit` on the same command line in the same shell. The
numbers below are the ones **captured**, not any the harness reported about the same run. The spine
printed `gate root: /c/Users/miket/code/re-frame2-worktrees/clockdoc-5786`, checked against this
worktree before any verdict was believed.

| gate | captured exit | result |
|---|---|---|
| `sh scripts/test-fast-pr.sh` (full spine) | **0** | `PASS fast PR spine` — 61 stages, no failing stage |
| └ `npm run test:cljs` — CLJS node integration | 0 | compile 2276 files / 2275 compiled / **0 warnings**; **13266 tests, 67060 assertions, 0 failures, 0 errors** |
| └ per-ns test isolation | 0 | all 17 namespaces pass standalone (196 tests, 731 assertions) |
| └ `npm run test:hicasso-invariants` | 0 | freeze (1 frozen row matches, no package file imports the bench tree) + optional-module reachability + complaint catalogue (66 live / 6 reserved / 1 pending retirement / 1 retired) |
| └ `npm run test:hicasso-lint` | 0 | self-test PASS, then 6 checks fire on their fixtures and the testbeds stay quiet |
| └ `npm run test:hicasso-compile` | 0 | 129 lane namespaces, 436 files / 435 compiled, **0 warnings** |
| └ implementation JS harness helpers, script/path policy, static invariants | 0 | included in the 61; nothing red |
| `python scripts/check_fast_pr_gap.py --list` | **0** | 96 required checks the spine does not decide (enumerated below) |

The spine itself declared **3 tiers NOT RUN**, and neither is nominated here as covering anything:
documentation gates (*surface unchanged*), all JVM artefact suites (*`implementation_jvm` surface
unchanged* — this diff is CLJS only), and the browser / prod-elision / bundle-isolation / perf /
mcp-conformance / tool-JVM lanes (CI only).

The freeze gate deserves an explicit note, because it is the one gate a **docstring** edit can red on
purpose: `check_freeze.py` treats a changed docstring as changed code. `mounted.cljs` is not a pinned
row — `implementation/hicasso/frozen-sources.edn` names no `mounted` entry, checked before editing —
and the gate confirms it, matching its 1 frozen row and passing.

### Which gate actually covers the surface

`implementation/hicasso/test_kit/src/` is on the global `:source-paths`
(`implementation/shadow-cljs.edn:168`), and `re-frame.hicasso.test.mounted` is required by the two
`-dom-cljs-test$` suites that exercise it. Those namespaces also match `:node-test`'s `cljs-test$`
regexp, so **`npm run test:cljs` compiles this file** — which is the gate for a change to a
docstring and a `str` form, since both are compiled artefacts and a broken string literal is a
compile error. The spine's own classifier arms `cljs_node_test` on `implementation/hicasso/*`
(`.github/scripts/report-changed-surfaces.sh:1116`), so the node tier ran rather than being skipped;
`implementation_jvm` and the documentation tier correctly reported *surface unchanged* and were
skipped, and neither is nominated here as covering anything.

**The lane that EXECUTES the clock suite is not in the spine.** `test_kit_clock_dom_cljs_test`'s DOM
rows run under `:browser-test` in the required `cljs-browser` job (`npm run test:browser`); in Node
they report as stated green skips. That is named as a gap rather than papered over — CI decides it,
and this diff cannot change what those rows assert, because they assert `ex-data`.

**Which required checks the spine does NOT decide** — `python scripts/check_fast_pr_gap.py --list`
(captured exit **0**) reports **96**. The three required contexts are `All required checks passed`
(test.yml), `Lint required` (lint.yml) and `Docs required` (docs.yml). Undecided here are (A) steps
inside jobs the spine does run — the repo-invariant reporter, freehand's donor-grep step,
`test:ui-isolation`, `build:hicasso-release`, and MkDocs' playground-bundle steps — and (B) every job
with no spine lane at all: the whole browser tier (`cljs-browser` above all, plus
`cljs-hicasso-controlled`, `cljs-hicasso-hmr`, the ui G-gates, adapter/ui/tenant-switcher smokes,
Story/Xray browser gates), every prod-gate and bundle-isolation lane, all tool JVM/Node artefacts,
mcp-conformance, the playground, `beads-pr-boundary`, and all of `lint.yml` (clj-kondo, Splint,
ESLint, api-manifest drift).

### Beads

`rf2-5786`, one bead, one commit, bead id in the commit subject.
