### PR TITLE
docs(hicasso): the walk arm has no callable JVM root either (rf2-t2ba)

### DIFF
--- a/docs/design/hicasso/production-server-arm.md
+++ b/docs/design/hicasso/production-server-arm.md
@@ -19,6 +19,22 @@ render contract and topology arrows (the sidecar was priced against a crossing
 the shipped Node entry does not have), and §10's Arm B table (repriced from that
 contract). Nothing else changed, and the page still draws no conclusion.
 
+**Amended 2026-08-11 (`rf2-t2ba`), from the `rf2-2rtt6` ruling's packet-hygiene
+item.** One cell moved. §9's root-naming row let the walk arm read as though a
+Hicasso root were already a Var the JVM could call, while its sidecar
+counterpart carried the absence clause; `rf2-2rtt6.88`'s ruling comment
+establishes that **neither host has a callable Hicasso root today** — which is
+what §5 has said all along — and the row now says so on both sides.
+
+Two facts of status travel with that correction, so that a later reader is not
+misled about what this page is. `rf2-2rtt6.88` closed as **ruled on 2026-08-08:
+the production server arm is the Node sidecar**, so the choice this page was
+written to inform has since been made. And ruling is not start — the pricing
+below still prices unbuilt work, and `ssr-ring`'s render call is still the
+hard-wired `ssr/render-to-string` line §2 quotes. No figure, band or argument
+moved; the page still draws no conclusion of its own, and the ruling is recorded
+here rather than re-argued.
+
 ## What this document deliberately does not contain, and the tension that produced it
 
 `rf2-2rtt6.88`'s description asks for "both branches priced in beads/weeks,
@@ -786,7 +802,7 @@ One row per axis, and no column is a score.
 | Text-separator row | must be settled first, with new apparatus | does not arise |
 | Attribute-only divergence | possible, and unreportable by React | impossible by construction |
 | Codec churn exposure | a twin to keep in step; 3–19 commits/day into `front/` this week | none |
-| How the host names the root | a Var the JVM calls in-process, as `ssr-ring` already does | a stable identifier resolved against a table the app's Node bundle publishes — neither the identifier nor the table exists (§5) |
+| How the host names the root | a Var the JVM calls in-process — the shape `ssr-ring` already uses for core roots, but no Hicasso root is one today: `defview` mints a JavaScript function with no JVM referent (§5) | a stable identifier resolved against a table the app's Node bundle publishes — neither the identifier nor the table exists (§5) |
 | `defhost` `:ssr :render` (rf2-l0wfx, 2026-08-05) | not reachable — no React on the JVM; such a host must be written `:client-only` or `{:fallback …}`, so the arm constrains the authoring surface rather than failing | reachable — it is the same React that renders it in the browser |
 | What crosses per request | nothing — one process | a render-visibility projection of the post-drain frame-state, in a domain and under a policy not yet written (§5); unmeasured |
 | Deploy lockstep | none | two artefacts must ship together; the entry table is the one thing that would make the skew detectable at all |


### PR DESCRIPTION
Closes rf2-t2ba. One page, two hunks, no figure moved.

## What was actually wrong at source — narrower than the bead reads

The bead says the page "still reads as though a callable Hicasso JVM root already
exists". Verified at source, and the honest finding is that **the page says the
opposite four times over, in one place, and contradicts itself in exactly one
cell.**

§5 is emphatic and correct:

- `| A root the JVM can name | **no** — … whose head is a JavaScript function with no JVM referent. See below |`
- "**The root form is not an EDN value and has no JVM referent.**"
- "the head is not a reference the JVM can resolve — on the JVM it does not exist at all"
- "**The inverse map exists in neither host.**"

The single residual is §9's comparison row, line 789 at the base commit:

```
| How the host names the root | a Var the JVM calls in-process, as `ssr-ring` already does | a stable identifier … — neither the identifier nor the table exists (§5) |
```

The sidecar column carries an absence clause; the walk column carries an
`already`. In a row whose axis is *how the host names the root*, that asymmetry
reads as: the sidecar has to build its naming mechanism, the walk arm already
has one. It does not. `defview` mints a `def` whose value is a JavaScript
function; there is no Var for the JVM to call, and §4's A1 (the `.cljc` codec
twin) does not produce one either.

I swept the rest of the page for the same defect (`git grep` over `in-process`,
`already does`, `to be called`, `JVM referent`, `callable`). Every other hit is
either accurate or about something else: line 87's "a thing to be called" is
`emit-ui-tree`, which genuinely is shipped and JVM-runnable; line 461's "the JVM
can call the Var in-process" is about core's `rf/view`, and its very next clause
states the Hicasso case is the harder one. **Nothing else needed touching.**

## Does the packet cite the page? No — and the page is not packet-ward at all

The packet is the one-page K1–K7 table due to freeze Tue 2026-08-25; it does not
exist as an artefact yet. Its home is `docs/design/hicasso/product/`, and a
recursive grep of that whole tree for `production-server-arm`, `server arm` and
`server-arm` returns **zero hits** — `decision-brief.md`, `k1-price-acceptance.md`
and `dispositions.md` included.

The only three citations of the page in the tree are the design-tree `README.md`
index row, `defhost-ssr-provider-costing.md`'s residue/pointer table, and
EP-0038's programme text. None is the packet.

So, stated plainly rather than dressed up: **this did not defuse a live risk.**
The urgency drops to ordinary drift, exactly as the ruling's conditional
anticipated. It is worth landing anyway — the row is wrong on a page a sitting
reader may open by hand, and the ruling's own governing rule is that a claim
carried into a decision states its landed state.

## What `rf2-2rtt6.88` establishes (stated, not re-derived)

Its 2026-08-08 ruling comment: the arm is **Arm B, the Node sidecar** — `ssr-ring`
stays the HTTP host and a supervised Node process returns body markup only. It
then records, in terms, that **selecting an arm is not starting one**: "today
there is no JVM<->Node request protocol, no entry registry, no supervised pool,
no real body-only round trip; the Ring pipeline still calls JVM
`ssr/render-to-string`". Start gate 2 requires "one per-application Node registry
resolving the stable root id" — i.e. the registry is a thing to be built, on the
Node side, and the JVM side was never in the running for one. That is the
"neither host has a callable Hicasso root today" the bead cites.

I re-verified the load-bearing half at source rather than trusting the note:
`implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj:548` still calls
`ssr/render-to-string`, so §2's "the one seam neither arm has" is still true and
nothing has been built since the ruling.

Not re-opened, not re-litigated. The ruling is recorded on the page, not argued.

## Correct, not caveat — and why

**Corrected.** Four reasons, in order of weight:

1. **The page can simply say what is true, which is the bead's own test for
   preferring a correction.** §5 already supplies the words; the row just was not
   using them.
2. **Its own row models the fix.** The sidecar cell in the *same row* ends
   "— neither the identifier nor the table exists (§5)". Correcting restores a
   symmetry the table already has; a caveat block would be new apparatus for a
   one-cell defect.
3. **A caveat would duplicate four sections.** §4 is titled "What has to be
   built", §5 is "What has to be built" for the sidecar, §8 is the unmeasured
   roster, §10 prices both arms in weeks and beads. The page could hardly say
   "designed, not built" more often. The defect was never that the page failed to
   say it — it was that §9 forgot to.
4. **Nothing is deleted.** The row still carries both arms' designed shape. Only
   the tense and the missing absence clause changed.

The dated amendment note follows the page's own established convention
("**Amended 2026-08-05 at `a9aa3e43cb`**", "**Corrected 2026-08-05, from the
merged-PR audit**").

**One deliberate half-step beyond the literal sentence, flagged for the mayor to
reject if unwanted.** The amendment note also records that `rf2-2rtt6.88` closed
as ruled on 2026-08-08. The bead's scope is "sentences that assert present-tense
existence", and a status line is not literally one. I included it because the
page's first line still reads "**Ruling prep for the P2/HD-013 sitting. No
verdict**", so a page fixed only at §9 would still present a decided question as
open — the same packet-hygiene defect one level up, which is the bead's own
stated rationale. It is one paragraph, it quotes the close reason, and it argues
nothing. Revert that hunk alone if you disagree; the §9 fix stands without it.

## Quality gates

Every gate run alone, output redirected to a scratchpad file outside the repo,
exit code echoed on the same command line. **These are captured statuses, not
harness-reported ones.**

| Gate | Captured exit |
|---|---|
| `python scripts/check_doc_slugs.py` (before negative control) | **0** |
| `python scripts/check_doc_slugs.py` (negative control, link broken) | **1** |
| `python scripts/check_doc_slugs.py` (after restore) | **0** |
| `python scripts/check_fast_pr_gap.py --list` | **0** |

**Negative control — the gate was seen to fail, and it named this file.** I broke
the page's own link (`(studio/ssr-spike-witness.md)` →
`(studio/ssr-spike-witness-NEGATIVE-CONTROL.md)`) and re-ran. Captured exit **1**:

```
1 broken target file(s) found:

  BROKEN TARGET: docs\design\hicasso\production-server-arm.md:12 -> studio/ssr-spike-witness-NEGATIVE-CONTROL.md
      (missing: docs\design\hicasso\studio\ssr-spike-witness-NEGATIVE-CONTROL.md)
```

Restored via `git checkout --`, `git status --porcelain` clean, gate re-run
captured **0**. Because this diff adds no link and no heading, the gate is a
**residue check** for these two hunks rather than a correctness check of them —
but the control was run against a real link in this file, not an injected one, so
the gate is demonstrated live on this page.

**`mkdocs build --strict` deliberately NOT run and NOT nominated.** `mkdocs.yml`'s
`exclude_docs` keeps `design/hicasso/` out of the site, so a build over this diff
would exit green having verified nothing.

**Tables hand-verified**, since nothing gates them. §9's table is 3 columns
(`| Axis | JVM structural walk | Node sidecar |`). All 17 body rows, including the
edited one, carry exactly 3 cells — counted programmatically over the whole table
rather than eyeballed, and no cell in the new text contains a bare `|`.

**No `node_modules` junction was created.** A two-hunk documentation diff cannot
justify an operation that has twice emptied the mayor's real `node_modules`; no
gate here needs Node.

**Fast-PR spine gap** (`check_fast_pr_gap.py --list`, captured **0**): the spine
does not decide **96** required checks — every job under `All required checks
passed` (45), `Lint required` (5) and `Docs required` (1), plus steps nested
inside jobs the spine does run. For this diff the relevant one is `docs.yml`'s
`detect` job, which classifies the changed files against the docs surface; the
build it gates excludes this tree either way. None of the 96 is decided locally.

## Files changed

- `docs/design/hicasso/production-server-arm.md` — §9's root-naming row, plus a
  dated amendment note in the header block.

No spec, no code, no workflow, nothing under `docs/design/hicasso/product/`, no
`.beads` path.
