### PR TITLE
test(xray): a real-React liveness witness for the populated Hicasso tab (rf2-r98a)

### DIFF
--- a/tools/xray/spec/027-Hicasso-Evidence.md
+++ b/tools/xray/spec/027-Hicasso-Evidence.md
@@ -510,8 +510,8 @@ The tab has no populated arm on a STAGED SURFACE. The shell sweep clicks
 `:hicasso` on the counter surface, which is not a Hicasso application, so the
 root it asserts is holding the `absent` note. That is the whole of the tab's
 staged-surface browser coverage, and it is a decision rather than an unfilled
-gap — but it is not the whole of the tab's browser coverage, because liveness
-is held in a browser and separately, three paragraphs down.
+gap. It is not the whole of the tab's browser coverage, though: liveness has a
+browser row of its own, three paragraphs down.
 
 **The tab is one of four on the same footing.** Resources, Graph, Modules and
 Hicasso are documented exclusions from the panel gallery, with their coverage

--- a/tools/xray/spec/027-Hicasso-Evidence.md
+++ b/tools/xray/spec/027-Hicasso-Evidence.md
@@ -499,16 +499,19 @@ Adding it moved six governance pins, each of which fails the build on drift:
 | `re-frame.hicasso.evidence-schema-cljs-test` | node | every shape in which a projection would claim more than it knows is refused, each with a positive control |
 | `re-frame.hicasso.tool-reads-cljs-test` | node (reactive substrate) | the four reads over real committed boundaries; the seeded-value privacy witness for a return value AND for a query argument; two frames sharing a sub id with asymmetric windows; the dispatch-ordered, fragment-merged intent stream; determinism; the production-nil arm |
 | `…panels.hicasso-helpers-cljs-test` | node + JVM | the five absences and the empties are pairwise distinct — including the four per-view empties; labels and testids are built from the projected key; a row key carries the WHOLE projected identity, so two frames' boundaries over one query do not collide; two query variants do not collapse; the key is INJECTIVE as a property over a generated space of 9261 identities, 10162 boundary keys and 441 intent rows, with a non-vacuity control that the space still defeats a lossy slug; the superseded v1 stamp is refused rather than mis-parsed; the schema pin; row projections |
-| `…panels.hicasso-cljs-test` | node (reactive substrate) | the four views answer on a running app; the populated roster arrives on a real `:rf.xray/trace-buffer` tick with no cache clear, against a held reaction proved stale first; the loss states render under distinct testids, driven between two real window states; a sensitive query argument reaches neither the page nor a testid; the Reads and Why rows carry the frame on the page and in the testid; each view renders its own empty; both the superseded and an unknown stamp render the mismatch; the seam reshapes nothing |
+| `…panels.hicasso-cljs-test` | node (reactive substrate) | the four views answer on a running app; `:rf.xray.hicasso/data` INVALIDATES and RECOMPUTES on a real `:rf.xray/trace-buffer` tick with no cache clear, against a held reaction proved stale first — the SUBSCRIPTION's half of liveness, the panel's half being the browser row below; the loss states render under distinct testids, driven between two real window states; a sensitive query argument reaches neither the page nor a testid; the Reads and Why rows carry the frame on the page and in the testid; each view renders its own empty; both the superseded and an unknown stamp render the mismatch; the seam reshapes nothing |
+| `…panels.hicasso-live-panel-dom-cljs-test` | browser (real React DOM) | the RUNNING panel is live: one `Panel` mounted into a real `reagent.dom.client` root, inside the shell's own `[frame-provider {:frame :rf/xray}]`, picks up a newly-mounted boundary on a trace tick and commits the row to the DOM. Nothing calls `Panel` a second time; a drained render queue proves the panel stale across the mount first; the `<section>` node afterwards is the one it started with, so the roster arrived by reconciliation and not by a remount |
 | `frame_singleton_guard_test` | JVM (source text) | the sub-strip dispatches through the `reg-view`-injected frame-bound `dispatch`, never a bare global one |
 | `feature_matrix/scenarios.cjs` | browser | the tab reaches a real panel root in the shell sweep |
 
-### Why the populated arms have no browser row
+### The populated arms in the browser: one liveness row, and no deck
 
-The browser lane sees this tab in one state. The shell sweep clicks `:hicasso`
-on the counter surface, which is not a Hicasso application, so the root it
-asserts is holding the `absent` note. That is the whole of the tab's browser
-coverage, and it is a decision rather than an unfilled gap.
+The tab has no populated arm on a STAGED SURFACE. The shell sweep clicks
+`:hicasso` on the counter surface, which is not a Hicasso application, so the
+root it asserts is holding the `absent` note. That is the whole of the tab's
+staged-surface browser coverage, and it is a decision rather than an unfilled
+gap — but it is not the whole of the tab's browser coverage, because liveness
+is held in a browser and separately, three paragraphs down.
 
 **The tab is one of four on the same footing.** Resources, Graph, Modules and
 Hicasso are documented exclusions from the panel gallery, with their coverage
@@ -517,7 +520,7 @@ CLJS unit tests (`panel_gallery/core.cljs` §Intentional gallery exclusions).
 `panel_gallery_inventory_smoke_cljs_test` fails the build if that partition
 drifts. Of the four, Hicasso has much the strongest unit lane.
 
-**Nothing about the populated rendering is out of that lane's reach.**
+**Nothing about the populated RENDERING is out of that lane's reach.**
 `hicasso_cljs_test` mounts real boundaries through the real commit seam under a
 reactive substrate and stubs nothing between the runtime and the hiccup — its
 two `with-redefs` synthesise the loss arms and touch no populated path. Narrow
@@ -526,22 +529,40 @@ labels, the fan-out counts, the frame on the row and in its testid, the
 redaction of a sensitive query argument from both the text and the testids, and
 the two loss chips driven between two genuinely different window states.
 
-**What a browser is genuinely the authority on is held elsewhere.** That
-`Panel` mounts and routes under real React in the real chrome is the shell-sweep
-row above. That the sub-strip dispatches through the frame-bound `dispatch` is
-held by `frame_singleton_guard_test`, a source-text guard over every panel —
-broader than a per-panel click and cheaper. Liveness was the one property
-nothing asserted, and it needed no browser either: `:rf.xray/trace-buffer` is an
-ordinary app-db slot written by an ordinary dispatch, so the tick is drivable in
-Node, and the trace-tick row now drives it against a held reaction it proves
-stale first.
+**LIVENESS is the one property that lane cannot carry, and it has a
+real-React row.** That `Panel` mounts and routes under real React in the real
+chrome is the shell-sweep row above; that the sub-strip dispatches through the
+frame-bound `dispatch` is held by `frame_singleton_guard_test`, a source-text
+guard over every panel — broader than a per-panel click and cheaper. Liveness is
+two claims, and the Node lane can only reach the first.
+`:rf.xray.hicasso/data` composes off `:rf.xray/trace-buffer`, an ordinary app-db
+slot written by an ordinary dispatch, so
+`hicasso_cljs_test/the-populated-roster-arrives-on-the-TRACE-TICK-and-not-on-a-cache-clear`
+drives the tick in Node against a held reaction it proves stale first, and
+proves the SUBSCRIPTION invalidates and recomputes. It does not prove the
+RUNNING PANEL re-renders: it calls `Panel` a second time itself, with no React
+root mounted, nothing committed and no DOM read — a claim about the sub, cited
+for a claim about the tab (merged-PR audit of #7881). The panel's half is
+`hicasso_live_panel_dom_cljs_test/the-mounted-panel-picks-up-a-new-boundary-on-the-trace-tick`:
+one `Panel` mounted into a real `reagent.dom.client` root inside the shell's own
+`[frame-provider {:frame :rf/xray}]`, a real boundary mounted, the render queue
+DRAINED with the panel still showing its empty note — the control, because a
+mount moves nothing in Xray's app-db and a tab wired to no tick would sit on an
+empty roster forever — then one tick, after which the committed DOM carries the
+boundary row and the same `<section>` node it started with.
 
-**And the row would not be one assertion.** No surface staged in
-`feature_matrix/scenarios.cjs` is a Hicasso host, so a populated arm needs a new
-deck, a new `implementation/shadow-cljs.edn` build id and a new `:dev-http`
-port — the shape rf2-6pohj built for the Views panel. If that deck is ever
-wanted its moment is rf2-hic-062, because `testbeds/freehand-views` exists
-solely to give the Views panel a populated roster, that panel retires with the
-Freehand tree (`021-Dynamic-Panel-Designs.md` §3.4.3), and its build id, port
-and scenario slot free up together. This tab is the survivor of that
-disposition, not a casualty of it.
+**That row needed no deck, no build id and no port**, and the claim that a
+browser proof would is a cost belonging to a different lane. It is an ordinary
+`*_dom_cljs_test` namespace in the EXISTING `:browser-test` build, which already
+carries `tools/xray/test` on `:source-paths`; `_browser-dom-lane-partition.test.cjs`
+picks it up automatically. What DOES need a deck is a STAGED-SURFACE row: no
+surface in `feature_matrix/scenarios.cjs` is a Hicasso host, so a populated arm
+in the shell sweep needs a new deck, a new `implementation/shadow-cljs.edn`
+build id and a new `:dev-http` port — the shape rf2-6pohj built for the Views
+panel. That cost is why there is no staged Hicasso host, and it is not a reason
+against the DOM row above. If that deck is ever wanted its moment is
+rf2-hic-062, because `testbeds/freehand-views` exists solely to give the Views
+panel a populated roster, that panel retires with the Freehand tree
+(`021-Dynamic-Panel-Designs.md` §3.4.3), and its build id, port and scenario
+slot free up together. This tab is the survivor of that disposition, not a
+casualty of it.

--- a/tools/xray/test/day8/re_frame2_xray/panels/hicasso_live_panel_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/hicasso_live_panel_dom_cljs_test.cljs
@@ -1,0 +1,241 @@
+(ns day8.re-frame2-xray.panels.hicasso-live-panel-dom-cljs-test
+  "The Hicasso tab is LIVE under real React — the running panel's own DOM
+  (rf2-r98a, merged-PR audit of #7881).
+
+  ## The claim this row exists to carry, and the one it replaces
+
+  `hicasso_cljs_test/the-populated-roster-arrives-on-the-TRACE-TICK-and-not-on-a-cache-clear`
+  proves that `:rf.xray.hicasso/data` INVALIDATES and RECOMPUTES on a
+  `:rf.xray/trace-buffer` tick. That is real and it stays. But it reaches
+  the panel by CALLING `hicasso/Panel` a second time itself and reading the
+  hiccup that comes back: no React root is mounted, nothing commits, and
+  no DOM is asserted. A panel wired to a live subscription and a panel
+  whose sub happens to recompute when something calls it are not the same
+  panel, and only the second was witnessed. The audit of #7881 named the
+  gap; this row closes it.
+
+  Here `Panel` is mounted ONCE, into a real `reagent.dom.client` root,
+  wrapped in `[rf/frame-provider {:frame :rf/xray}]` exactly as
+  `shell/shell-view` wraps it in production. **Nothing in this file ever
+  calls `Panel` again.** Every later assertion reads
+  `container.querySelector…` — the DOM React committed on its own.
+
+  ## The three phases, and which one is the control
+
+  1. **Mounted, empty.** The committed DOM carries
+     `rf-xray-hicasso-empty-mounted`, so the panel really did render its
+     empty arm before anything moved.
+  2. **A real boundary mounts, and the panel does NOT move.** This is the
+     load-bearing control. Hicasso's tables are process-global rather than
+     part of Xray's app-db, so a mount invalidates nothing the panel's
+     reaction watches — a tab wired to no tick at all would sit on an
+     empty roster forever while the application it inspects mounts
+     boundaries. The render queue is DRAINED here (same
+     `:flush-render!` op as phase 3), so the staleness asserted is a
+     reaction that never invalidated and not a commit that never
+     happened.
+  3. **One trace tick, and the roster arrives in the DOM.** The tick is
+     the collector's own seam — `refresh-trace-rings!` dispatches
+     `:rf.xray/sync-trace-buffer` on every coalesced drain (rf2-43koh) —
+     and after it the committed DOM carries a boundary ROW naming the
+     read the boundary really holds.
+
+  The row testid, not the section wrapper: `rf-xray-hicasso-mounted` is
+  what `mounted-view` renders in EVERY arm, with the empty note inside it,
+  so a selector for the wrapper would match the stale empty roster this
+  row exists to catch.
+
+  ## Why the `<section>` identity is asserted
+
+  Phase 3 also pins that the panel's root `<section>` is the SAME DOM node
+  it was in phase 1. React reconciled the live tree in place; the roster
+  did not arrive because something remounted the panel from scratch, which
+  is the one other way a fresh roster could reach the screen and is not
+  liveness.
+
+  ## Substrate
+
+  The Reagent adapter, because a real React commit is the whole point and
+  because Hicasso's cell wiring calls `add-watch` on the substrate's
+  derived value — under the ratom family that value IS a
+  `reagent.ratom/Reaction` (`impl/collector.cljs` §`wire-cell!`), while
+  plain-atom's is not `IWatchable`.
+
+  `:ambient-frame nil` is load-bearing: the panel's `rf/subscribe` calls
+  must resolve `:rf/xray` through the React-context tier the
+  `frame-provider` establishes, the way the shipped shell resolves them.
+  The fixture's default ambient `:rf/default` scope is still in effect
+  during a synchronous `flushSync`, and would shadow that tier at tier 1 —
+  the panel would then read `:rf/default`'s app-db and the test would be
+  about a frame the shell never renders in.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test` so it runs under the `:browser-test`
+  build (real DOM / React via Chromium) per
+  `implementation/shadow-cljs.edn` — the existing browser lane, which
+  already carries `tools/xray/test` on `:source-paths`. No new deck, no
+  new build id, no `:dev-http` port. The `:node-test` build's `cljs-test$`
+  regex also matches the ns, so it loads under Node too, where the body
+  short-circuits via `(browser?)`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as string]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [day8.re-frame2-xray.panels.hicasso :as hicasso]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(def ^:private app-frame ::hicasso-live-app)
+
+(rf/reg-sub :hlive/left (fn [db _] (:left db)))
+(rf/reg-event :hlive/seed (fn [_ [_ db]] {:db db}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       reagent-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Hicasso's tables are process-global `defonce`s that
+                      ;; the core fixture knows nothing about; without this a
+                      ;; neighbour's boundary is still in the entry cache and
+                      ;; the empty arm of phase 1 is not empty.
+                      (collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- flush-render!
+  "Run `thunk`, then SYNCHRONOUSLY commit whatever re-render it scheduled.
+
+  The adapter's own `:flush-render!` contract slot (Spec 006), which is
+  what the Pair MCP drives a headless render with — not a test-only
+  mechanism. Reagent schedules a dependent component's re-render on a
+  `requestAnimationFrame` turn, so without this the committed DOM would
+  lag every phase below by a frame and the assertions would be about
+  timing rather than about liveness."
+  [thunk]
+  ((:flush-render! reagent-adapter/adapter) thunk))
+
+(defn- setup! []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:hlive/seed {:left 1}]))
+  nil)
+
+(defn- mount-panel!
+  "Mount the real `Panel` into a real React root, committed synchronously
+  (React 19's `root.render` is otherwise async). The `frame-provider` is
+  the shell's own wrapper — `shell/shell-view` renders every panel inside
+  `[rf/frame-provider {:frame :rf/xray}]`."
+  []
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame :rf/xray}
+                          [hicasso/Panel]])))
+    {:container container :root root}))
+
+(defn- mount-boundary!
+  "A real Hicasso boundary, rendered and committed through the runtime's
+  own seam — the same `subscribe` closure React calls. Returns the
+  release fn."
+  []
+  (collector/render-body app-frame (fn [_] (h/sub [:hlive/left]) nil) {})
+  (collector/commit-boundary! (collector/last-reads) (fn [])))
+
+(defn- tick-trace!
+  "One trace-buffer tick, delivered the way the collector delivers it:
+  `trace-collector/refresh-trace-rings!` dispatches
+  `:rf.xray/sync-trace-buffer` with its snapshot on every coalesced task
+  drain, and `:rf.xray/trace-buffer` reads the slot that dispatch writes
+  (rf2-43koh)."
+  []
+  (rf/dispatch-sync [:rf.xray/sync-trace-buffer
+                     [{:id 1 :op-type :rf.event
+                       :operation :rf.event/dispatched :tags {}}]]
+                    {:frame :rf/xray}))
+
+(defn- q [container sel] (.querySelector container sel))
+
+(defn- boundary-rows
+  "The boundary ROWS in the committed DOM.
+
+  `li[…]`, not a bare prefix match: the row's two loss chips render under
+  testids that EXTEND the row's own (`…-boundary-<slug>-view-loss-…`), so
+  an unqualified prefix selector would count one boundary three times."
+  [container]
+  (vec (js/Array.from
+         (.querySelectorAll container "li[data-testid^=\"rf-xray-hicasso-boundary-\"]"))))
+
+(deftest the-mounted-panel-picks-up-a-new-boundary-on-the-trace-tick
+  (testing "rf2-r98a — a REAL React root holding the Hicasso tab re-renders
+            itself on a `:rf.xray/trace-buffer` tick and commits the
+            populated roster to the DOM. Nothing here calls `Panel` a second
+            time; the roster arrives because the panel is live. Reddens if
+            `:rf.xray.hicasso/data` stops composing off `:rf.xray/trace-buffer`."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_          (setup!)
+            {:keys [container root]} (mount-panel!)
+            release    (volatile! nil)]
+        (try
+          ;; ---- phase 1: mounted, and rendering its empty arm --------------
+          (let [section (q container "[data-testid=\"rf-xray-hicasso\"]")]
+            (is (some? section)
+                "the Hicasso Panel committed a real DOM root under React")
+            (is (some? (q container "[data-testid=\"rf-xray-hicasso-empty-mounted\"]"))
+                "the live panel rendered the EMPTY mounted census — nothing is
+                 mounted yet, so the roster this test drives in cannot already
+                 be on screen")
+            (is (empty? (boundary-rows container))
+                "NON-VACUITY: no boundary row is in the DOM before one mounts")
+
+            ;; ---- phase 2: a real boundary mounts, and the panel is deaf ---
+            ;; The render queue is drained here too, so what is asserted is a
+            ;; reaction that never invalidated — not a commit that never ran.
+            (flush-render! (fn [] (vreset! release (mount-boundary!))))
+            (is (some? (q container "[data-testid=\"rf-xray-hicasso-empty-mounted\"]"))
+                "CONTROL: a real mount moves nothing the panel's reaction
+                 watches — Hicasso's tables are process-global, not Xray
+                 app-db — so the committed DOM still shows the empty note.
+                 Without this the last phase would pass on a panel that had
+                 simply never rendered before the tick")
+
+            ;; ---- phase 3: one tick, and the roster is on screen -----------
+            (flush-render! tick-trace!)
+            (let [rows (boundary-rows container)]
+              (is (= 1 (count rows))
+                  (str "the trace tick re-fired the live panel and ONE boundary "
+                       "row committed to the DOM — with no cache clear and no "
+                       "second call to Panel anywhere in this test. DOM: "
+                       (.-textContent container)))
+              (is (string/includes? (.-textContent (first rows)) "[:hlive/left]")
+                  (str "and the row names the read the boundary really holds, so "
+                       "the assertion above cannot pass on a row projected from "
+                       "nothing. row text: " (.-textContent (first rows)))))
+            (is (nil? (q container "[data-testid=\"rf-xray-hicasso-empty-mounted\"]"))
+                "the empty note is gone from the DOM — the roster REPLACED it
+                 rather than rendering beside it")
+            (is (identical? section (q container "[data-testid=\"rf-xray-hicasso\"]"))
+                "and it is the SAME <section> node — React reconciled the live
+                 tree in place, so the roster did not arrive by the panel being
+                 remounted from scratch, which would not be liveness"))
+          (finally
+            (when-some [r @release] (r))
+            (try (.unmount root) (catch :default _ nil))
+            (.remove container)))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/hicasso_live_panel_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/hicasso_live_panel_dom_cljs_test.cljs
@@ -218,16 +218,21 @@
 
             ;; ---- phase 3: one tick, and the roster is on screen -----------
             (flush-render! tick-trace!)
-            (let [rows (boundary-rows container)]
+            (let [rows (boundary-rows container)
+                  ;; `some->`, so an empty roster reds the row below as a
+                  ;; clean assertion failure rather than throwing on nil and
+                  ;; reporting the same defect twice — once as a failure and
+                  ;; once as an uncaught error.
+                  row-text (str (some-> (first rows) .-textContent))]
               (is (= 1 (count rows))
                   (str "the trace tick re-fired the live panel and ONE boundary "
                        "row committed to the DOM — with no cache clear and no "
                        "second call to Panel anywhere in this test. DOM: "
                        (.-textContent container)))
-              (is (string/includes? (.-textContent (first rows)) "[:hlive/left]")
+              (is (string/includes? row-text "[:hlive/left]")
                   (str "and the row names the read the boundary really holds, so "
                        "the assertion above cannot pass on a row projected from "
-                       "nothing. row text: " (.-textContent (first rows)))))
+                       "nothing. row text: " (pr-str row-text))))
             (is (nil? (q container "[data-testid=\"rf-xray-hicasso-empty-mounted\"]"))
                 "the empty note is gone from the DOM — the roster REPLACED it
                  rather than rendering beside it")


### PR DESCRIPTION
Closes rf2-r98a (reopened by the merged-PR audit of #7881).

## What the audit overturned

#7881 closed this bead on `hicasso_cljs_test/the-populated-roster-arrives-on-the-TRACE-TICK-and-not-on-a-cache-clear`,
citing it as proof of the running tab's React liveness. The audit found that
that row **manually invokes `Panel` again** after the trace tick — no mounted
React root, no `act`/flush, no automatic render, no DOM assertion. It proves
`:rf.xray.hicasso/data` **invalidates and recomputes**, which is real and worth
having; it does not prove the **running panel re-renders**, which is the claim
it was cited for. Two different claims; only the second answers the bead.

**The Node row stays.** It is not wrong, it was narrower than its citation.
What changes is the prose around it and the addition of the missing half.

## The witness

`tools/xray/test/day8/re_frame2_xray/panels/hicasso_live_panel_dom_cljs_test.cljs`
— one deftest,
`the-mounted-panel-picks-up-a-new-boundary-on-the-trace-tick`, in the EXISTING
`:browser-test` DOM lane (`reactive_data_view_rows_dom_cljs_test.cljs` is the
shape it follows). `Panel` is mounted ONCE into a real
`reagent.dom.client` root inside the shell's own
`[rf/frame-provider {:frame :rf/xray}]`, and **nothing in the file ever calls
`Panel` again** — every assertion reads `container.querySelector…`.

Three phases:

1. **Mounted, empty.** The committed DOM carries `rf-xray-hicasso-empty-mounted`
   and no boundary row.
2. **A real Hicasso boundary mounts, and the panel does not move.** The
   load-bearing control. The render queue is DRAINED here through the same
   adapter op phase 3 uses, so what is asserted is a reaction that never
   invalidated — not a commit that never happened. Hicasso's tables are
   process-global, so a mount moves nothing Xray's app-db watches; a tab wired
   to no tick would sit on an empty roster forever.
3. **One `:rf.xray/sync-trace-buffer` tick** (the collector's own seam,
   rf2-43koh) — after which the DOM carries a boundary `<li>` naming
   `[:hlive/left]`, the empty note is gone, and the root `<section>` is the
   SAME DOM node, so the roster arrived by React reconciling the live tree and
   not by a remount.

The row testid, not the section wrapper: `rf-xray-hicasso-mounted` renders in
every arm with the empty note inside it. `li[data-testid^=…-boundary-]` rather
than a bare prefix, because the row's loss chips carry testids that EXTEND the
row's own.

**No build id, no `:dev-http` port, no deck, no production mechanism.** The
global `:source-paths` already carry `tools/xray/test`; the two DOM lanes'
partition gate picks the namespace up automatically. `implementation/shadow-cljs.edn`
is untouched.

## Spec 027 disposition (`tools/xray/spec/027-Hicasso-Evidence.md`)

Per the standing rule, `tools/xray/spec/*` is updated in this PR. Three claims
narrowed:

- **"That is the whole of the tab's browser coverage"** → the whole of its
  *staged-surface* browser coverage. Liveness now has a browser row.
- **"Liveness … needed no browser either"** → liveness is two claims. The Node
  row proves the SUBSCRIPTION invalidates and recomputes; it cannot prove the
  running panel re-renders, because it calls `Panel` itself with no root
  mounted and reads no DOM. The panel's half is the new row.
- **"a populated arm needs a new deck, a new build id and a new `:dev-http`
  port"** → true of a STAGED-SURFACE row in `feature_matrix/scenarios.cjs`,
  and stated there as such; false of a browser proof in general, and the new
  row needed none of the three.

The coverage table's `…panels.hicasso-cljs-test` row is narrowed to say
"`:rf.xray.hicasso/data` INVALIDATES and RECOMPUTES … the SUBSCRIPTION's half
of liveness", and a row for the new browser suite is added. Section heading
renamed to match what it now says; nothing links to the old anchor.

## Quality gates

Every number below is the exit status CAPTURED on the same command line as the
run, not one the harness reported about it. (The mutation run is a case in
point: the harness surfaced it as *completed (exit code 0)* while its captured
status was **1**.)

| Gate | Captured exit | Result |
|---|---|---|
| `npm run test:browser` (baseline, mutation-free) | `0` | Ran 1264 tests containing 7806 assertions. 0 failures, 0 errors. |
| `npm run test:browser` (**mutation applied**) | `1` | Ran 1264 tests containing 7804 assertions. **1 failures, 1 errors** |
| `npm run test:browser` (**mutation restored**) | `0` | Ran 1264 tests containing 7806 assertions. 0 failures, 0 errors. |
| `npm run test:cljs` | `0` | Ran 13267 tests containing 67067 assertions. 0 failures, 0 errors. |
| `python scripts/check_doc_slugs.py` | `0` | clean |
| `node scripts/_browser-dom-lane-partition.test.cjs` | `0` | 2 passed — the new ns is selected by `:browser-test` and by nothing else |

`npm run test:browser` is the lane that owns the new witness: the
`:browser-test` build's `:ns-regexp` is
`^(?!re-frame\.freehand\.bench\.).*-dom-cljs-test$` and the exclusion is the
Freehand bench prefix only, so this namespace is inside it — verified
independently by the partition gate above rather than assumed.

### Mutation test, both directions

The mutation: point `:rf.xray.hicasso/data` at a signal that does not move on
host activity — `:<- [:rf.xray/trace-buffer]` → `:<- [:rf.xray.hicasso/view]`
in `tools/xray/src/day8/re_frame2_xray/panels/hicasso.cljs`. That is exactly
the defect the row exists to catch: the tab stops being live.

**Broken → RED, and it names this row and only this row:**

```
FAIL in (the-mounted-panel-picks-up-a-new-boundary-on-the-trace-tick)
        (day8/re_frame2_xray/panels/hicasso_live_panel_dom_cljs_test.cljs:222)
expected: (= 1 (count rows))
  actual: (not (= 1 0))
```

1 failure across 1264 tests, captured exit 1. Phases 1 and 2 stayed GREEN under
the mutation — the control is a control, not a second copy of the proof.

That run also caught a defect in the row itself: with no roster, reading
`.textContent` off the absent first row threw, so one defect was reported twice
(a failure AND an uncaught `TypeError`). Fixed with `some->` in
c00ec00e6a; the row still reds, once and cleanly.

**Restored → GREEN:** the third table row above, from a re-run with the source
file back at `HEAD` (`git status` clean on `tools/xray/src/`).

### What the fast-PR spine does not decide

`python scripts/check_fast_pr_gap.py --list` reports **96** required checks the
spine does not run — among them, for this diff's surfaces: `test.yml`'s "Repo
invariant checks", the `CLJS (shadow-cljs :node-test)` job's
`test:ui-isolation` and `build:hicasso-release` steps, and the whole `docs.yml`
MkDocs job. The browser lane that owns this witness is not in the fast-PR
spine either, which is why it was run here in full, three times.
