### PR TITLE
docs(bench): re-point surviving rf2-2rtt6.1 citations at the governance set that superseded it (rf2-p9c5)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs
@@ -147,7 +147,9 @@
   four rows (rf2-ouwh8).
 
   Authority: `docs/EP/EP-0038-the-hicasso-view-layer-programme.md`;
-  the bar and the P0 table are operator-owned on bead rf2-2rtt6.1.
+  the bar and the P0 table are operator-owned on the governance set that
+  superseded bead rf2-2rtt6.1 on 2026-08-10, enumerated once in
+  `docs/design/hicasso/studio/README.md`.
   Spec donor: rf2-ssn1o (closed, do-not-refile)."
   (:require ["react-dom" :as react-dom]
             [goog.object :as gobj]

--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
@@ -5,8 +5,9 @@
 //   HN_ROUNDS=6 node .../hicasso_narrow_run.cjs --no-build
 //
 // Bead rf2-2rtt6.3. The bar, the budgets and the P0 table this feeds are
-// operator-owned on rf2-2rtt6.1; workers append measurements and only the
-// operator amends the numbers.
+// operator-owned on the governance set that superseded rf2-2rtt6.1 on
+// 2026-08-10, enumerated once in `docs/design/hicasso/studio/README.md`;
+// workers append measurements and only the operator amends the numbers.
 //
 // WHAT IS BEING PRICED, AND WHY IT IS ONE NUMBER AND NOT TWO
 // ----------------------------------------------------------

--- a/implementation/core/test/re_frame/bench/p0_app.cljs
+++ b/implementation/core/test/re_frame/bench/p0_app.cljs
@@ -56,7 +56,9 @@
 
   Built and driven by `p0_run.cjs` beside this file.
 
-  Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4."
+  Owner: the operator-owned governance set that superseded rf2-2rtt6.1 on
+  2026-08-10, enumerated once in `docs/design/hicasso/studio/README.md`;
+  this arm rf2-2rtt6.4."
   (:require [cljs.reader :as reader]
             [re-frame.bench.hicasso.lane :as lane]
             [re-frame.bench.order-guard :as guard]

--- a/implementation/core/test/re_frame/bench/p0_arms.cljs
+++ b/implementation/core/test/re_frame/bench/p0_arms.cljs
@@ -52,7 +52,9 @@
   FASTER, with a range that still overlapped the valid window's — the
   clock alone would have accepted it. Only the DOM read-back caught either.
 
-  Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4."
+  Owner: the operator-owned governance set that superseded rf2-2rtt6.1 on
+  2026-08-10, enumerated once in `docs/design/hicasso/studio/README.md`;
+  this arm rf2-2rtt6.4."
   (:require ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]
             [re-frame.adapter.reagent :as reagent-adapter]

--- a/implementation/core/test/re_frame/bench/p0_fixture.cljc
+++ b/implementation/core/test/re_frame/bench/p0_fixture.cljc
@@ -57,7 +57,9 @@
   value-stable by construction, so key churn cannot enter what the arms
   measure.
 
-  Owner: the operator-owned standard bead rf2-2rtt6.1; this arm rf2-2rtt6.4."
+  Owner: the operator-owned governance set that superseded the standard bead
+  rf2-2rtt6.1 on 2026-08-10, enumerated once in
+  `docs/design/hicasso/studio/README.md`; this arm rf2-2rtt6.4."
   (:require [re-frame.core :as rf]))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/core/test/re_frame/bench/p0_floor.cljs
+++ b/implementation/core/test/re_frame/bench/p0_floor.cljs
@@ -37,7 +37,9 @@
   row, and a ratio below 1.0 there is a real result about localisation,
   not an instrument fault.
 
-  Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4."
+  Owner: the operator-owned governance set that superseded rf2-2rtt6.1 on
+  2026-08-10, enumerated once in `docs/design/hicasso/studio/README.md`;
+  this arm rf2-2rtt6.4."
   (:require ["react" :as react]
             [re-frame.bench.p0-fixture :as fx]))
 

--- a/implementation/core/test/re_frame/bench/p0_harness.cljs
+++ b/implementation/core/test/re_frame/bench/p0_harness.cljs
@@ -52,7 +52,9 @@
   a range that straddles 1.0 is reported as INDISTINGUISHABLE rather than
   as a winner.
 
-  Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4."
+  Owner: the operator-owned governance set that superseded rf2-2rtt6.1 on
+  2026-08-10, enumerated once in `docs/design/hicasso/studio/README.md`;
+  this arm rf2-2rtt6.4."
   (:require ["react-dom" :as react-dom]
             [clojure.string :as str]
             [re-frame.bench.order-guard :as guard]))

--- a/implementation/core/test/re_frame/bench/p0_heap.cljs
+++ b/implementation/core/test/re_frame/bench/p0_heap.cljs
@@ -65,8 +65,10 @@
   plan asked for. A Q that is asserted rather than counted is the same
   class of decoration as a mount count that is printed and not gated.
 
-  Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4; the fan-out family
-  and the additive model rf2-5prok."
+  Owner: the operator-owned governance set that superseded rf2-2rtt6.1 on
+  2026-08-10, enumerated once in `docs/design/hicasso/studio/README.md`;
+  this arm rf2-2rtt6.4; the fan-out family and the additive model
+  rf2-5prok."
   (:require ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]
             [clojure.string :as str]

--- a/implementation/core/test/re_frame/bench/p0_hicasso.cljs
+++ b/implementation/core/test/re_frame/bench/p0_hicasso.cljs
@@ -51,7 +51,9 @@
   the driver gates it against B, so the claim is a counted number rather
   than an argument.
 
-  Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.34."
+  Owner: the operator-owned governance set that superseded rf2-2rtt6.1 on
+  2026-08-10, enumerated once in `docs/design/hicasso/studio/README.md`;
+  this arm rf2-2rtt6.34."
   (:require [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
             [re-frame.bench.p0-fixture :as fx])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))

--- a/implementation/core/test/re_frame/bench/p0_reagent.cljs
+++ b/implementation/core/test/re_frame/bench/p0_reagent.cljs
@@ -28,7 +28,9 @@
   pipeline and the signal graph, so it is a LOWER BOUND on Reagent and not
   a fair denominator. Everything here goes through `re-frame.core`.
 
-  Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4."
+  Owner: the operator-owned governance set that superseded rf2-2rtt6.1 on
+  2026-08-10, enumerated once in `docs/design/hicasso/studio/README.md`;
+  this arm rf2-2rtt6.4."
   (:require [re-frame.bench.p0-fixture :as fx]
             [re-frame.core :as rf])
   (:require-macros [re-frame.core :refer [reg-view]]))

--- a/implementation/core/test/re_frame/bench/p0_uix.cljs
+++ b/implementation/core/test/re_frame/bench/p0_uix.cljs
@@ -31,7 +31,9 @@
   spelling; the counterpart Reagent arm is a `reg-view` derefing
   `(rf/subscribe …)` once. Neither is doing the other's work.
 
-  Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4."
+  Owner: the operator-owned governance set that superseded rf2-2rtt6.1 on
+  2026-08-10, enumerated once in `docs/design/hicasso/studio/README.md`;
+  this arm rf2-2rtt6.4."
   (:require [re-frame.adapter.uix :as uix-adapter]
             [re-frame.bench.p0-fixture :as fx]
             [uix.core :refer [$ defui]]))


### PR DESCRIPTION
Closes `rf2-p9c5`.

## The bead's counts held exactly; the filing brief's did not

`rf2-p9c5` was filed as a merged-PR audit of #7885, whose body reported the residue as
"~30 sites, 22 files". The bead corrects that to **51 exact citations across 30 files**,
and narrows the work to **15 hits across 11 files** in the surviving adapter/core bench
harnesses — leaving the Freehand/Hicasso evidence trees to `rf2-hic-062`, which owns
their disposition.

I re-derived both numbers at source rather than trusting either, using a boundary-aware
pattern over tracked files only (`git grep -n -E 'rf2-2rtt6\.1([^0-9]|$)'`, so `.10`,
`.16`, `.34`, `.56`, `.73`, `.100`, `.116` and friends cannot inflate the count):

| Set | Hits | Files |
|---|---|---|
| Whole of `implementation/**` | **51** | **30** |
| `implementation/adapters/**` + `implementation/core/**` (this PR's scope) | **15** | **11** |
| `implementation/freehand/**` evidence trees (left to `rf2-hic-062`) | **36** | **19** |

**The bead is exact on both.** The audit's "~30 / 22" was the undercount, and the file
list in #7885's body is otherwise correct — nothing has moved since it was written.

## What changed — 11 sites, and only the present-tense ones

`rf2-2rtt6.1` was closed as superseded on 2026-08-10. Every hit was READ before it was
touched; the test applied is the one the corpus sweep in #7885 used and the one the bead
restates — **present tense is the test.** A citation asserting that the bar, the budgets
or the P0 table *are* operator-owned on `rf2-2rtt6.1` is stale. A citation recording that
a ruling *was recorded on* it is history and stays.

Eleven present-tense Owner / standard / operator-owned claims, one per file, now name the
governance set that superseded it:

| File | Line | Was |
|---|---|---|
| `adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs` | 150 | "the bar and the P0 table **are** operator-owned on bead rf2-2rtt6.1" |
| `adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs` | 8 | "The bar, the budgets and the P0 table this feeds **are** operator-owned on rf2-2rtt6.1" |
| `core/test/re_frame/bench/p0_app.cljs` | 59 | `Owner: rf2-2rtt6.1 (standard)` |
| `core/test/re_frame/bench/p0_arms.cljs` | 55 | `Owner: rf2-2rtt6.1 (standard)` |
| `core/test/re_frame/bench/p0_fixture.cljc` | 60 | `Owner: the operator-owned standard bead rf2-2rtt6.1` |
| `core/test/re_frame/bench/p0_floor.cljs` | 40 | `Owner: rf2-2rtt6.1 (standard)` |
| `core/test/re_frame/bench/p0_harness.cljs` | 55 | `Owner: rf2-2rtt6.1 (standard)` |
| `core/test/re_frame/bench/p0_heap.cljs` | 68 | `Owner: rf2-2rtt6.1 (standard)` |
| `core/test/re_frame/bench/p0_hicasso.cljs` | 54 | `Owner: rf2-2rtt6.1 (standard)` |
| `core/test/re_frame/bench/p0_reagent.cljs` | 31 | `Owner: rf2-2rtt6.1 (standard)` |
| `core/test/re_frame/bench/p0_uix.cljs` | 34 | `Owner: rf2-2rtt6.1 (standard)` |

### The supersession is ANNOTATED, not erased — and pointed at, not restated

Each now reads, in the shape the studio pages were swept into:

> Owner: the operator-owned governance set that superseded rf2-2rtt6.1 on
> 2026-08-10, enumerated once in `docs/design/hicasso/studio/README.md`;
> this arm rf2-2rtt6.4.

`rf2-2rtt6.1` is still named and still dated, so a reader who arrives at one of these
harnesses from an old bead reference lands where the trail continues rather than at a
dead end.

**The four governance beads are deliberately NOT copied into eleven docstrings.** K1 price
acceptance `rf2-hic-003`, budgets and shell line `rf2-hic-006`/`rf2-hic-018` with gates
`rf2-hic-089` and `rf2-hic-071`, bulk verdict protocol `rf2-hic-036`, and the kill rules in
the decision brief are enumerated in exactly one place — `docs/design/hicasso/studio/README.md` —
and these harnesses point at it. Eleven copies would be eleven things to drift the next
time the set changes, which is the defect this sweep exists to repair, re-committed one
layer down.

## What was deliberately LEFT — 4 delegated-ruling provenance citations

The bead's instruction is explicit: *"Preserve dated/delegated historical provenance, but
repoint present-tense Owner/standard/operator-owned claims and console strings."* These
four cite `rf2-2rtt6.1` as the **locus where a delegated ruling was recorded**, not as a
live owner, and the docs corpus preserves the same class of citation for the same reason
(`p0-uix-on-subs-frontier-arm.md:242`, `reads-per-boundary-heap-ladder.md:600` — both
"transcription on rf2-2rtt6.1", both correct and both untouched by the doc sweep):

| File | Line | Text | Why it stays |
|---|---|---|---|
| `core/test/re_frame/bench/p0_app.cljs` | 329 | "the **delegated ruling** on rf2-2rtt6.1 makes this number the threshold itself" | The subject is the ruling, which is still in force; the bead is where it was recorded |
| `core/test/re_frame/bench/p0_app.cljs` | 350 | published `:meaning` string — "(delegated ruling, rf2-2rtt6.1)" | Same, and it is **published record data**: rewriting it would edit a record's own text |
| `core/test/re_frame/bench/p0_heap.cljs` | 4 | "The **delegated ruling** on rf2-2rtt6.1 sets a UIx threshold" | Provenance |
| `core/test/re_frame/bench/p0_uix.cljs` | 6 | "the delegated ruling **recorded on** rf2-2rtt6.1 makes the ratios this arm produces the RED-ZONE THRESHOLDS" | Provenance, and explicitly "recorded on" |

Nothing about the delegated red-zone ruling was overturned by the governance set that
superseded `rf2-2rtt6.1`; the studio pages still cite it as recorded there. Repointing
these would erase a true statement about where a ruling lives and replace it with a false
one about where it was made.

## What was deliberately LEFT — 36 hits in 19 files under the evidence trees

The bead: *"Do not bulk-sweep or churn disposition-owned Freehand/Hicasso evidence trees
under `rf2-hic-062` … Coordinate any evidence-tree changes with `rf2-hic-062`."*

All 36 are under `implementation/freehand/test/re_frame/bench/hicasso/**` and
`implementation/freehand/test/re_frame/freehand/bench/**`, whose disposition (archive /
remove / keep-as-evidence) `rf2-hic-062` is open to decide. Sweeping citations through a
tree that may be archived or removed is churn against a decision not yet made.

The exact residue, re-derived here so `rf2-hic-062` does not have to:

```
implementation/freehand/test/re_frame/bench/hicasso/clock_app.cljs                    1
implementation/freehand/test/re_frame/bench/hicasso/clock_views.cljs                  1
implementation/freehand/test/re_frame/bench/hicasso/hd8_clock_app.cljs                2
implementation/freehand/test/re_frame/bench/hicasso/hd8_clock_run.cjs                 2
implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs                     1
implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs                       2
implementation/freehand/test/re_frame/bench/hicasso/hd8_witnesses.cljs                2
implementation/freehand/test/re_frame/bench/hicasso/inpage_ladder_aggregate.cjs       2
implementation/freehand/test/re_frame/bench/hicasso/inpage_ladder_exit_path.test.cjs  3
implementation/freehand/test/re_frame/bench/hicasso/lane.cljs                         1
implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs              4
implementation/freehand/test/re_frame/bench/hicasso/p0_uix_views.cljs                 2
implementation/freehand/test/re_frame/bench/hicasso/retention_probe.cljs              1
implementation/freehand/test/re_frame/bench/hicasso/retention_run.cjs                 3
implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_app.cljs      2
implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_arms.cljs     2
implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_run.cjs       2
implementation/freehand/test/re_frame/freehand/bench/reads_ladder.cljs                2
implementation/freehand/test/re_frame/freehand/bench/reads_ladder_run.cjs             1
                                                                            total    36
```

These are **not** all stale — they carry the same mixture this PR sorted, so whoever takes
them needs the same read-each-hit judgement rather than a `sed`.

**One item OUTSIDE `implementation/**` and inside another worker's fence, reported not
crossed:** `docs/design/hicasso/production-server-arm.md:37` (`serverarm-t2ba`). Read: it
says *"nothing under `decisions.md`, `validation.md` or `rf2-2rtt6.1`'s own notes is
touched"* — a historical statement about what a past change did not do. **It is correct as
written and would need no edit even if the fence were open.**

Outside `implementation/` and `docs/`, the only tracked file matching the pattern at all is
`.beads/issues.jsonl`, which is the tracker export and not a citation surface.

## The freeze manifest was checked rather than assumed

`implementation/hicasso/frozen-sources.edn` pins **exactly one row today** —
`front/slot.cljc` — the rest having been retired by `rf2-hic-009`, `rf2-hic-001` and
`rf2-hic-007` (the manifest's three retirements, each documented in its own header).
**No file in this diff is pinned by it**, and no file in this diff is under the donor root
at all. The FREEZE arm of `test:hicasso-invariants` therefore has nothing to say about
this change, and nominating it would be the false assurance this repo keeps repairing.

## Scope fences observed

Nothing touched under `implementation/hicasso/src` or `implementation/hicasso/test`
(`portal-hic028`, PR #7892), `implementation/hicasso/test_kit/**` (PR #7893),
`tools/xray/**` (`xraylive-r98a`), `docs/design/hicasso/production-server-arm.md`
(`serverarm-t2ba`), or `dispositions.md` §2.3 (`imewitness-hic016`). No hot-zone file:
`implementation/shadow-cljs.edn`, `implementation/deps.edn`, `spec/**` and
`.github/workflows/**` are all untouched.

`production-server-arm.md:37` does carry an `rf2-2rtt6.1` citation, and it is inside
`serverarm-t2ba`'s fence — left, and reported here rather than crossed.

## Nothing measured moved

Docstrings and comments only. **No behaviour, threshold, fixture, arm, entry list or
measured number changed.** The diff is 11 files, +34 / −13, and every hunk is inside a
`"…"` docstring or a `//` comment.

## Quality gates

A docstring edit to a `.cljs` / `.cljc` / `.cjs` file is still a code edit, so this ran the
lanes that COMPILE and LINT these files, one at a time, each unpiped, each with its status
captured on the same command line. **Every number below is the CAPTURED one.**

| # | Gate | Captured exit |
|---|---|---|
| 1 | `npm run test:hicasso-compile` (the bench-lane compile gate, and the only spine arm that decides this surface) | **0** |
| 2 | **Negative control A** — `p0_uix.cljs`'s docstring broken, same gate | **1** |
| 3 | Targeted `:hicasso-bench` compile of the two namespaces gate 1 does NOT reach | **0** |
| 4 | **Negative control B** — `p0_app.cljs`'s docstring broken, same compile | **1** |
| 5 | `npm run lint:js` (ESLint — the command `lint.yml`'s required ESLint job runs) | **0** |
| 6 | `clj-kondo --fail-level error` over the 11 changed files | **0** |
| 7 | `clj-kondo --parallel --fail-level error --lint implementation` (the full arm) | **3** — see below |
| 8 | `sh scripts/test-fast-pr.sh` (`gate root:` = this worktree) | **0** |
| 9 | `python scripts/check_fast_pr_gap.py --list` | **0** (informational) |

Gate 1: `[hicasso-compile] ok — 129 lane namespaces compiled with zero warnings`
(`436 files, 435 compiled, 0 warnings, 34.42s`).
Gate 3: `187 files, 186 compiled, 0 warnings, 26.66s`.
Gate 8 ran end to end — 60 steps, ~58 minutes. Its own arms: JVM `implementation/core`
**2233 tests / 11645 assertions / 0 failures / 0 errors**; `test:cljs`, per-ns isolation,
the JS harness suites and the hicasso trio (invariants incl. FREEZE, lint export,
bench-lane compile) all green. Every `FAILED` string in its log belongs to a checker's own
self-test asserting that its negative case fires.

### One honest limit on gates 6 and 7, from the spine's own words

`check_fast_pr_gap.py` warns: *"CI pins clj-kondo 2026.04.15. A pass from a
differently-versioned local binary PROVES NOTHING — versions disagree about which findings
are errors."* **My local binary is v2025.10.23.** So gates 6 and 7 are reported as
informational, not as proof, and the version gap is a second reason — beside the untouched-
file argument — not to read gate 7's exit 3 as this branch's. The deciding lint run is
`lint.yml`'s pinned `clj-kondo` job in CI. Gates 1–5 and 8 are unaffected: none of them is
clj-kondo.

### The lane gate does NOT reach 2 of the 10 namespaces I edited — checked rather than assumed

This is the trap of nominating a gate that exits green having verified nothing, so I did not
take the lane gate's word for its own coverage. `compile_gate.cjs` derives its entries by
walking **its own directory only** (`implementation/freehand/test/re_frame/bench/hicasso/`).
Nine of my ten CLJS files live outside that directory and are reached — if at all — only
transitively. I checked the emitted modules:

| Namespace | In gate 1's output? |
|---|---|
| `re-frame.bench.p0-arms`, `-fixture`, `-floor`, `-harness`, `-heap`, `-hicasso`, `-reagent`, `-uix` | **yes** — pulled in transitively via the lane's `retention_probe.cljs` |
| `re-frame.bench.p0-app` | **NO** |
| `re-frame.bench.hicasso-narrow` | **NO** |

Neither is `*-cljs-test$`; the only namespaces requiring them are `p0_pageerror_probe.cljs`
and `hicasso_narrow_app.cljs`, which are not test-shaped either, and their drivers
(`p0_run.cjs`, `hicasso_narrow_run.cjs`) are hand-run. **So far as I can find, no PR gate
compiles either namespace** — which is the same fail-open shape `rf2-2rtt6.73` built the
lane gate to close, one directory over, and is worth recording independently of this PR.
Gate 3 closes that
for this diff by compiling exactly those two through the same `:hicasso-bench` id and the
same `--config-merge` mechanism the lane was built for (no `shadow-cljs.edn` edit, and the
`rf2-2rtt6.20` cache rule honoured — the shared build cache is cleared first).

### Both compile gates were made to FAIL, naming my exact files

A gate never seen to fail is not a tested gate. I removed the closing `"` from the edited
ns docstring — the smallest mutation that is unambiguously *my* text — once per gate.

**Control A**, gate 1, captured exit **1**:

```
 File: …\implementation\core\test\re_frame\bench\p0_uix.cljs:47:58
re_frame/bench/p0_uix.cljs [line 47, col 58] Invalid number: 4px.
[hicasso-compile] BUILD REFUSED — shadow-cljs exited 1
```

**Control B**, gate 3, captured exit **1**:

```
 File: …\implementation\core\test\re_frame\bench\p0_app.cljs:74:18
re_frame/bench/p0_app.cljs [line 74, col 18] Invalid number: 2.01x.
```

Both restored; `git diff --exit-code` against the committed state then returned **0** and
`git status --porcelain` is empty, so nothing from the controls survives in the diff.

**Worth flagging for anyone reading captured codes:** the harness surfaced control A as
*"completed (exit code 0)"* while the status captured on the command line was **1**, and the
log says `BUILD REFUSED`. The captured number is the one quoted throughout this section.

### Gate 7's exit 3 is pre-existing and provably not this branch's

`clj-kondo` over the whole of `implementation` reports **10 errors and 4023 warnings**. All
10 are `Expected: throwable, received: …` in `implementation/epoch/test/` and
`implementation/ui/test/`. **This branch changes 11 files and not one of them appears in
that list**, so every one of those 10 exists identically on `origin/main`. Gate 6 — the same
linter, same `--fail-level error`, restricted to the 11 changed files — captured **0** with
`errors: 0, warnings: 1`, and that single warning is `p0_fixture.cljc:206 Unresolved var:
rf/reg-event`, 146 lines below my line-60 docstring edit and equally pre-existing. The
required job is titled *"clj-kondo (fail on errors, warnings informational)"*.

### `test:hicasso-invariants` (the FREEZE gate) deliberately NOT nominated as the decider

It runs in the spine (gate 8) and is green there, but it decides nothing about this diff and
saying otherwise would be false assurance: `frozen-sources.edn` pins one row, `front/slot.cljc`,
and this branch touches no file under the donor root.

### `mkdocs build --strict` not nominated either

No file in this diff is under `docs/`.
