### PR TITLE
docs(hicasso): neither arm has both inputs in the required form (rf2-t2ba)

### DIFF
--- a/docs/design/hicasso/production-server-arm.md
+++ b/docs/design/hicasso/production-server-arm.md
@@ -20,11 +20,16 @@ the shipped Node entry does not have), and §10's Arm B table (repriced from tha
 contract). Nothing else changed, and the page still draws no conclusion.
 
 **Amended 2026-08-11 (`rf2-t2ba`), from the `rf2-2rtt6` ruling's packet-hygiene
-item.** One cell moved. §9's root-naming row let the walk arm read as though a
-Hicasso root were already a Var the JVM could call, while its sidecar
-counterpart carried the absence clause; `rf2-2rtt6.88`'s ruling comment
+item.** Two places moved, in two passes. §9's root-naming row let the walk arm
+read as though a Hicasso root were already a Var the JVM could call, while its
+sidecar counterpart carried the absence clause; `rf2-2rtt6.88`'s ruling comment
 establishes that **neither host has a callable Hicasso root today** — which is
-what §5 has said all along — and the row now says so on both sides.
+what §5 has said all along — and the row now says so on both sides. The
+merged-PR audit on that pass then found the same premise earlier and less
+guarded: §1's paragraph introducing job one's two inputs had a db snapshot and a
+root form both in hand where a JVM walk would run. That paragraph now says what
+§5 and §9 say — **neither arm has both inputs in the form job one requires** —
+and names what each is missing.
 
 Two facts of status travel with that correction, so that a later reader is not
 misled about what this page is. `rf2-2rtt6.88` closed as **ruled on 2026-08-08:
@@ -72,10 +77,16 @@ payload is Spec 011's, the mismatch machinery is Spec 011's, and neither arm may
 mint a parallel Hicasso-only mechanism. **So the arms are a choice about job one
 only** — and the interesting costs are what job one drags behind it.
 
-Job one's two inputs are not equally available to both arms. A db snapshot and a
-root form are both in hand where a JVM walk would run; only one of them is, and
-neither in the shape the sentence implies, where a sidecar would. That is where
-the sidecar's real contract lives — §5.
+Job one's two inputs are not equally available to the two arms, and **neither
+arm has both of them in the form job one requires**. Where a JVM walk would run
+the state is in hand — `ssr-ring` holds the post-drain request frame, and
+`compute-sub` is `.cljc`, so the JVM can read against it — but the root form is
+not: a Hicasso root's head is a JavaScript function `defview` mints at namespace
+load, with no JVM referent, and no registry maps a name back to it on either
+host. Where a sidecar would run the root form can be built, because the bundle
+that renders it holds the codec — but the JVM has no name to ask for one by, and
+the state has to arrive as a projection under a policy nobody has written. What
+each arm is missing, and what supplying it would cost, is §4 and §5.
 
 ## 2. The floor both arms stand on — what is already built
 


### PR DESCRIPTION
Reopened `rf2-t2ba`. The merged-PR audit on #7894 found the premise that PR corrected in §9 still standing **earlier in the page**, in §1.

## What lines 75–78 said

> Job one's two inputs are not equally available to both arms. A db snapshot and a
> root form are both in hand where a JVM walk would run; only one of them is, and
> neither in the shape the sentence implies, where a sidecar would. That is where
> the sidecar's real contract lives — §5.

Two defects in four lines. The **first clause asserts the walk arm has both of job one's inputs in hand** — the same false Arm-A premise the §9 root-naming row carried until `c821f716e7`. And *"the shape the sentence implies"* is a **dangling back-reference**: it points at the retracted sentence §5 quotes (*"the JVM serialises the request's db snapshot plus the root form as EDN"*), but §1 never contained that sentence and the reader has no antecedent. Both arrived together in `be045ac3bd2` (2026-08-05), where this paragraph was added whole.

## What it says now

> Job one's two inputs are not equally available to the two arms, and **neither
> arm has both of them in the form job one requires**. Where a JVM walk would run
> the state is in hand — `ssr-ring` holds the post-drain request frame, and
> `compute-sub` is `.cljc`, so the JVM can read against it — but the root form is
> not: a Hicasso root's head is a JavaScript function `defview` mints at namespace
> load, with no JVM referent, and no registry maps a name back to it on either
> host. Where a sidecar would run the root form can be built, because the bundle
> that renders it holds the codec — but the JVM has no name to ask for one by, and
> the state has to arrive as a projection under a policy nobody has written. What
> each arm is missing, and what supplying it would cost, is §4 and §5.

That is what the dossier already establishes in §5 and (since #7894) §9. The pointer now reaches **§4 and §5** rather than §5 alone, because the walk arm's missing half is priced in §4.

The 2026-08-11 amendment note opened *"One cell moved"*, which this change would falsify. It now records both passes and this one's provenance. **No figure, band, table or argument moved**, and the page still draws no conclusion.

### Verified at source, not from the bead

Bead premises have been proved stale at source repeatedly, so every load-bearing clause was read in the tree rather than taken from the note:

| Claim | Source | Holds |
|---|---|---|
| The returned value of a minted head is still the function | `arm1/runtime.cljs` `mint-view!` docstring, and its body sets `displayName` + memoizes — **no `registrar/register!`** | yes |
| `defview` captures the name only for `displayName` | `arm1/lang.clj` ns docstring: *"The only thing it captures at expansion time is the view's name, for `displayName`"* | yes |
| No JVM-side implementation of the runtime | `arm1/lang.clj`: `.clj` not `.cljc` because *"a `.cljc` would invite a JVM-side implementation this arm does not have"* | yes |
| The entry takes a root form, not a name | `ssr/entry.cljs`: `:hiccup  REQUIRED. The root hiccup form.` | yes |
| The JVM does have the state | `ssr-ring/…/pipeline.clj` registers the per-request frame, which drains `:initial-events`; `compute-sub` is public in `implementation/core/src/re_frame/subs.cljc` | yes |
| The Node snapshot door seeds app-db only | `ssr/entry.cljs`: `:snapshot  a map seeded whole through :rf/set-db` | yes |

One thing needed a second look and did **not** contradict the page: `arm1/runtime.cljs` mentions `reg-view*`, which reads like an id→head registry. It is **core's** registration API, named there only as a contrast (*"not on which registration API minted the head"*). Hicasso's `defview` registers nothing, so §5's *"The inverse map exists in neither host"* stands.

## Whole-page sweep

The defect's shape — a page stating an absence correctly four times in §5 while §9 asserted the opposite in a row about something else — is the reason the audit asked for a sweep rather than a one-line fix. Every mention of a root, a registry, an entry table or an identifier was checked (`grep` over `root|registry|registrar|entry table|identifier|inverse|reg-view`, then read in context).

**Found: exactly one more instance, the one fixed here.** No other sentence presumes a JVM root, an inverse registry or a Node entry registry exists today.

Checked and judged **correct**, listed so the judgement is reviewable rather than implied:

- §5's Arm-B table — *"A root the JVM can name | **no**"*; and *"A JVM↔Node contract | does not exist"*.
- §5 — *"What is absent is Hicasso participating in any such registry"*, *"The inverse map exists in neither host"*, *"A viable sidecar **needs** an application-defined stable entry identifier"*.
- §5's `resolve-root-view` paragraph — the Var the JVM *can* call is explicitly **core's** root, and the paragraph's own next clause is *"the head is not a reference the JVM can resolve — on the JVM it does not exist at all"*. Correct, and the contrast is what makes it correct.
- §9's root-naming row (`c821f716e7`) and its *"What crosses per request"* row.
- §8 item 2 — *"there is no stable entry identifier, no entry table and no render-visibility projection either"*.
- §10 B1a/B4/B5 and §5's cost list — all future-tense (*"needs"*, *"has to publish"*, *"would land"*), pricing unbuilt work. Correct for a pricing table.
- §11's entry-table tripwire — conditional on an arm being chosen.
- §1's job table (*"turn a db snapshot plus a root form into HTML"*) — a statement of the **job**, not of availability. Left alone; it is what the corrected paragraph is now about.
- §2's *"The JVM back half … is not a thing to be built; it is a thing to be called"* — scoped to `emit-ui-tree`, confirmed shipped at `implementation/ssr/src/re_frame/ssr/ui_tree.cljc:1035`. True, and about the serialiser, not a root.
- §3/§4's *"inherits `ssr-ring`'s host wholesale … one function call changes"* — about R0 host reuse, presuming no root.

## Quality gates

Each run alone, nothing appended, exit code captured on the same command line. Artefacts written to gitignored `*.log` / `*.exit` and removed; `git status` clean.

| Gate | Captured exit |
|---|---|
| `python scripts/check_doc_slugs.py` (pre-change baseline) | **0** |
| `python scripts/check_doc_slugs.py` (negative control, link broken) | **1** |
| `python scripts/check_doc_slugs.py` (restored) | **0** |
| `python scripts/check_doc_slugs.py` (final, post-rebase) | **0** |
| `python scripts/check_fast_pr_gap.py --list` | **0** |

**Negative control.** Broke the page's one link (line 12, `studio/ssr-spike-witness.md` → `studio/NEGATIVE-CONTROL-t2ba.md`). The gate went **0 → 1** and named the file and line:

```
BROKEN TARGET: docs\design\hicasso\production-server-arm.md:12 -> studio/NEGATIVE-CONTROL-t2ba.md
```

Restored, re-ran, back to **0**, `git status --porcelain` empty.

**Honestly: for this diff the slug gate is a residue check, not a correctness check.** It proves it can see `docs/design/hicasso/`, but this change edits prose only — it adds no link, moves no heading, and changes no anchor. Nothing in the diff is in that gate's remit.

**`mkdocs build --strict` was not run and is not the gate here.** `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site, so it would exit green having verified nothing about this file.

**Tables: none touched.** `git diff origin/main -- <file> | grep -c '^[+-]|'` returns **0** — no added or removed line begins with a table pipe. §9's 3-column, 17-row table (the one the previous PR edited) is untouched; both hunks are prose.

**No `node_modules` junction was minted.** This is a documentation-only diff and needed no npm or shadow-cljs run, so nothing was linked into the mayor checkout's `node_modules`.

**Required checks this spine does not decide: 96**, per `check_fast_pr_gap.py --list` — 45 `test.yml` jobs, 5 `lint.yml`, 1 `docs.yml` detect job, plus steps nested inside jobs the spine does run. Most are surface-gated and will skip on a docs-only diff; the ones with a real say here are `docs.yml`'s **MkDocs build** and **Provenance pins**, and `lint.yml`'s **Detect lint surface**.

Closes rf2-t2ba.
