### PR TITLE
fix(hicasso): a throwing interval callback must not disarm the bridged timer (rf2-w2e6)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_clock_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_clock_dom_cljs_test.cljs
@@ -645,3 +645,102 @@
                 (.then (fn [report]
                          (is (true? (:clean? report)))
                          (done))))))))))
+
+;; ---------------------------------------------------------------------------
+;; W8 — a THROWING tick does not disarm the handed-back interval (rf2-w2e6)
+;; ---------------------------------------------------------------------------
+;;
+;; The handover arms the cadence from INSIDE the first tick's one-shot, so the
+;; order of two statements decides whether a repeating timer survives its own
+;; callback throwing. Written sequentially it does not: control leaves the
+;; one-shot with the exception, the `setInterval` under it is never reached,
+;; and the interval is gone for the rest of the page's life with nothing on
+;; screen to say so.
+;;
+;; The platform does the opposite. HTML's timer initialisation steps report
+;; the handler's exception (step 9.7) and then reinitialise the still-live
+;; repeating timer (step 9.11), so a real `setInterval` keeps its cadence
+;; across a throwing tick. A test kit that diverges from the platform on the
+;; EXCEPTION path teaches a false model of the platform, which is the worst
+;; thing a test kit can do.
+;;
+;; W7 above drives the same handover with a callback that returns, which is
+;; exactly why it cannot see this. This row throws on the first bridged tick
+;; and reads both halves of the platform's rule — the exception escapes, AND
+;; the cadence is armed anyway — because keeping the timer alive by eating the
+;; throw would only move the divergence.
+
+(deftest a-throwing-tick-does-not-disarm-the-handed-back-interval
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM, so no root and no clock")
+    (async done
+      (let [platform                      (platform-surface)
+            {:keys [log surface cancel!]} (recorder platform)
+            !ticks                        (atom [])
+            intervals                     (fn [es] (filterv #(= :interval (:kind %)) es))]
+        (install-surface! surface)
+        (let [m (two-toasts)]
+          ;; The FIRST tick throws and every tick after it returns, so one row
+          ;; can read the exception and the cadence that outlived it.
+          (js/setInterval (fn [& args]
+                            (swap! !ticks conj (vec args))
+                            (when (= 1 (count @!ticks))
+                              (throw (js/Error. "the first bridged tick throws, deliberately"))))
+                          retention-ms "tick" 7)
+          (hm/advance-clock! m (dec retention-ms))
+          (is (empty? @!ticks) "premise: one virtual millisecond short of the first tick")
+
+          (let [mark (count @log)
+                _    (hm/unmount! m)
+                over (vec (drop mark @log))]
+            (install-surface! platform)
+
+            (let [firsts (filterv #(and (= :timeout (:kind %)) (= 1 (:delay %))) over)]
+              (testing "premise: the handover armed what was left of the tick the
+                        interval was already waiting for"
+                (is (seq firsts)))
+
+              ;; Cancel the real arming and fire it here, so the readings below
+              ;; are this row's rather than the wall clock's.
+              (doseq [e firsts] (cancel! e))
+              (let [mark2  (count @log)
+                    thrown (atom [])]
+                (doseq [e firsts]
+                  (try ((:f e))
+                       (catch :default err (swap! thrown conj (ex-message err)))))
+
+                (testing "the exception is REPORTED rather than swallowed. A
+                          bridge that kept the timer alive by eating the throw
+                          would trade one divergence from the platform for
+                          another, and this row would pass on the wrong half"
+                  (is (= ["the first bridged tick throws, deliberately"] @thrown)))
+
+                (testing "premise: the tick that threw did run, once, with the
+                          arguments it was armed with"
+                  (is (= [["tick" 7]] @!ticks)))
+
+                (let [after   (vec (drop mark2 @log))
+                      cadence (filterv (fn [e] (and (= :interval (:kind e))
+                                                    (= retention-ms (:delay e))
+                                                    (= ["tick" 7] (:args e))))
+                                       after)]
+                  (testing "AND THE CADENCE IS ARMED ANYWAY — this is the row.
+                            Written sequentially the throw left the one-shot
+                            before the `setInterval` under it, and the captured
+                            scheduler was never asked for this at all"
+                    (is (= 1 (count cadence))))
+
+                  ;; Whatever that found, nothing this row armed is left
+                  ;; repeating on the real scheduler.
+                  (doseq [e (intervals after)] (cancel! e))
+
+                  (testing "…and what it armed is the interval's OWN callback at
+                            its own period, so the tick after the throwing one
+                            lands the way every later tick will"
+                    (doseq [e cadence] (apply (:f e) (:args e)))
+                    (is (= [["tick" 7] ["tick" 7]] @!ticks))))))
+
+            (-> (hm/assert-clean! m)
+                (.then (fn [report]
+                         (is (true? (:clean? report)))
+                         (done))))))))))

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
@@ -317,7 +317,10 @@
   and that one-shot arms the platform's own repeat at the original
   period. A `setInterval` for the full period here would hand a timer
   with 1 ms to run a whole fresh 1000 and shift its phase for the rest of
-  the page's life (rf2-w2e6).
+  the page's life (rf2-w2e6). The cadence is armed whether or not that
+  first tick THROWS, which is what a real repeating timer does — the
+  exception is reported and the timer reinitialised — and the exception
+  still escapes to be reported (rf2-w2e6).
 
   What that does not preserve is the ids: from here on they are the
   platform's, so a `clearTimeout` held across the boundary no longer
@@ -340,9 +343,21 @@
           (if-some [p (:period e)]
             (.call (:set-timeout real) g
                    (fn []
-                     (.apply (:f e) g (to-array (:args e)))
-                     (.apply (:set-interval real) g
-                             (to-array (list* (:f e) p (:args e)))))
+                     ;; `finally`, because a REPEATING timer outlives a
+                     ;; throwing tick on the platform: HTML's timer
+                     ;; initialisation steps report the exception (9.7) and
+                     ;; then reinitialise the still-live timer (9.11). Arming
+                     ;; the cadence after the call instead lets one throw
+                     ;; retire the interval for the rest of the page's life.
+                     ;; And the throw still ESCAPES, or the divergence has only
+                     ;; moved: a swallowed exception is a tick the page never
+                     ;; hears about. Which of the two happens first is not
+                     ;; observable — no script runs between them.
+                     (try
+                       (.apply (:f e) g (to-array (:args e)))
+                       (finally
+                         (.apply (:set-interval real) g
+                                 (to-array (list* (:f e) p (:args e)))))))
                    left)
             (.apply (:set-timeout real) g
                     (to-array (list* (:f e) left (:args e)))))))))


### PR DESCRIPTION
Closes rf2-w2e6 (the reopened half — the `MERGED-PR AUDIT #7883` note).

## The defect

`release-clock!` hands a still-pending virtual interval back to the real
scheduler as a **one-shot for the tick it had left**, and that one-shot arms the
platform's own repeat at the original period. The two statements ran in
sequence:

```clojure
(fn []
  (.apply (:f e) g (to-array (:args e)))
  (.apply (:set-interval real) g
          (to-array (list* (:f e) p (:args e)))))
```

So a tick that **throws** leaves the one-shot before the `setInterval` under it
is ever reached, and the interval is gone for the rest of the page's life with
nothing on screen to say so.

The platform does the opposite. HTML's [timer initialisation
steps](https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timer-initialisation-steps)
**report** the handler's exception (step 9.7) and then **reinitialise** the
still-live repeating timer (step 9.11), so a real `setInterval` keeps ticking
across a throwing tick. A test kit that diverges from the platform on the
exception path teaches a false model of the platform, which is the worst thing a
test kit can do.

## The repair

The re-arm now runs in a `finally`. That keeps **both** halves of the platform's
rule, which is the whole point:

- the cadence is armed whether or not the tick throws;
- and the throw still **escapes to be reported**. Keeping the timer alive by
  swallowing the exception would only move the divergence — a tick the page
  never hears about is the same lie wearing different clothes.

Which of the two happens first is not observable: no script runs between the
re-arm and the report.

Scope held to the interval re-arm and its witness. No redesign of the clock, no
other timer path, no diagnostics. `rf2-4mvd` stays closed and untouched.

## The witness

`W8 — a-throwing-tick-does-not-disarm-the-handed-back-interval` in
`implementation/hicasso/test/re_frame/hicasso/test_kit_clock_dom_cljs_test.cljs`.

It drives the **actual** failing path: a real `setInterval` armed on the virtual
clock, advanced to one virtual millisecond short of its first tick, handed back
by a real `unmount!` through the row's recording scheduler, and then fired by
hand so no reading depends on the wall clock. Its callback throws on the first
tick and returns on every one after it, so a single row reads three things:

1. the exception **escapes** (a bridge that ate it fails here);
2. the cadence is **armed anyway** — exactly one `setInterval` at the original
   period with the original arguments;
3. and what was armed is the interval's own callback, so the tick after the
   throwing one lands the way every later tick will.

W7 next to it drives the same handover with a callback that **returns**, which is
precisely why the defect survived it.

## Quality gates

Every gate run alone, nothing appended, nothing piped. Exit codes below are the
**captured** ones (`echo "$?" > *.exit`), not the harness's report.

| Gate | Command | Captured exit | Result |
|---|---|---|---|
| Browser lane — **the lane that executes the clock suite** | `npm run test:browser` | **`0`** | Ran 1264 tests containing 7806 assertions. 0 failures, 0 errors. |
| Node CLJS lane — the hicasso node lane rides the consolidated `:node-test` build | `npm run test:cljs` | **`0`** | Ran 13267 tests containing 67061 assertions. 0 failures, 0 errors. |
| Fast-PR spine | `scripts/test-fast-pr.sh` | **`0`** | `PASS fast PR spine`; `gate root:` confirmed as this worktree; tiering `docs=false jvm=false node=true` |

The spine's classifier puts this diff in the **node tier only**, and correctly: `implementation/hicasso/**` is deliberately off `implementation_jvm` (the runtime requires React, so every suite the artefact owns is CLJS — see `TESTING.md`). Its `NOT RUN` line names the documentation gates, all JVM artefact suites, and the browser/prod-elision/bundle families.

`python scripts/check_fast_pr_gap.py --list` — **96 required checks the spine does
not decide.** The ones this diff actually reaches: `cljs-browser` (run above,
separately, because the spine has no lane for it), plus `cljs-hicasso-controlled`
and `cljs-hicasso-hmr`, which arm on `implementation/hicasso/**` and are
three-engine browser gates CI owns. `lint.yml`'s `clj-kondo` pins 2026.04.15 and a
differently-versioned local binary proves nothing, so that one is read in CI.

### Plant and restore, both directions

Proved on a narrowed `:browser-test` compile of this one namespace (via CLI
`--config-merge`, so no `shadow-cljs.edn` edit — that file is hot zone).

| | Captured exit | Result |
|---|---|---|
| With the fix | `0` | `Ran 8 tests containing 86 assertions. 0 failures, 0 errors.` |
| **Pre-fix behaviour planted** (`try`/`finally` collapsed back to the two sequential statements) | **`1`** | `2 failures` — **both in `a-throwing-tick-does-not-disarm-the-handed-back-interval` and nowhere else**: `expected: (= 1 (count cadence)) / actual: (not (= 1 0))`, and `expected: (= [["tick" 7] ["tick" 7]] @!ticks) / actual: (not (= … [["tick" 7]]))` |
| Restored | `0` | `Ran 8 tests containing 86 assertions. 0 failures, 0 errors.` |

The restore was verified by **hashing the bytes**, not by reading `git diff`:
`sha256sum -c` over both files returned `OK / OK` against the pre-plant digests,
and `git status --porcelain` was empty against the committed HEAD.

Worth noting what stayed green under the plant: the exception-escape assertion
passed in both versions (the throw always escaped), and W7 passed in both. The
row discriminates on exactly the thing that changed.

## Scope

Two files, 118 insertions / 4 deletions. The diff touches **none** of
`hicasso.cljc`, `impl/codec.cljs`, `impl/portal.cljs`, `host_ssr_dom_cljs_test.cljs`
or `portal_dom_cljs_test.cljs` (PR #7892's surface), and no hot-zone file —
`shadow-cljs.edn` in particular is untouched, which is why the plant/restore proof
narrows the browser build via the CLI's `--config-merge` rather than a new build id.
