### PR TITLE
fix(xray): handlers must return effects the closed map actually carries (rf2-04tx)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
@@ -163,6 +163,14 @@
   ;; rf2-3d987 issue #4 — toggle the per-machine chart-collapsed flag.
   ;; `mode` is :collapsed / :expanded / :toggle. Persists the post-mutation
   ;; map to localStorage so the operator's choice survives reloads.
+  ;;
+  ;; rf2-04tx — the persist fx rides `:fx`, not the top level. The effect
+  ;; map is CLOSED (`#{:db :rf.db/runtime :fx}` plus the four EP-0025
+  ;; classification keys, per Spec 002 §Write authority): an fx-id sitting
+  ;; at the top level is policed as `:rf.error/effect-map-shape` and
+  ;; DROPPED, so the localStorage write never happened and the operator's
+  ;; collapse choice never survived a reload. The `:db` write landed either
+  ;; way, so the toggle looked like it worked.
   (rf/reg-event :rf.xray.machine-canvas/set-chart-collapsed
     (fn [{:keys [db]} [_ {:keys [machine-id mode]}]]
       (let [current (chart-collapsed-of db machine-id)
@@ -175,7 +183,7 @@
                               next)
             by-id   (get-in db' [slot-root :chart-collapsed-by-id])]
         {:db db'
-         :rf.xray.machine-canvas/persist-chart-collapsed by-id})))
+         :fx [[:rf.xray.machine-canvas/persist-chart-collapsed by-id]]})))
 
   (rf/reg-event :rf.xray.machine-canvas/hydrate-chart-collapsed
     (fn [{:keys [db]} [_ by-id]]

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs
@@ -104,6 +104,40 @@
           :fx :rf.xray.machine-canvas/persist-chart-collapsed))
       "persist-chart-collapsed fx is in the registrar"))
 
+(deftest persist-chart-collapsed-fx-actually-fires-rf2-04tx
+  (testing "rf2-04tx — the set-chart-collapsed handler must REACH the
+            persist fx, not merely have one registered. The handler used
+            to return the fx-id as a TOP-LEVEL effect key beside `:db`;
+            the effect map is closed, so the runtime policed the key as
+            `:rf.error/effect-map-shape` and dropped it — the `:db` write
+            landed, the toggle looked like it worked, and the operator's
+            choice never reached localStorage. `persist-chart-collapsed-
+            fx-registered` above cannot see that: a registered fx nobody
+            routes to satisfies it perfectly. This one observes the do-fx
+            plane, which is the only place the drop is visible."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (let [persisted (atom [])]
+        (rf/dispatch-sync
+          [:rf.xray.machine-canvas/set-chart-collapsed
+           {:machine-id :auth/login :mode :collapsed}]
+          {:fx-overrides
+           {:rf.xray.machine-canvas/persist-chart-collapsed
+            (fn [_ctx by-id] (swap! persisted conj by-id))}})
+        (is (= 1 (count @persisted))
+            "the persist fx ran exactly once — it reached the :fx walk")
+        (is (= {:auth/login true} (first @persisted))
+            "and carried the POST-mutation chart-collapsed map")
+        (rf/dispatch-sync
+          [:rf.xray.machine-canvas/set-chart-collapsed
+           {:machine-id :checkout/flow :mode :collapsed}]
+          {:fx-overrides
+           {:rf.xray.machine-canvas/persist-chart-collapsed
+            (fn [_ctx by-id] (swap! persisted conj by-id))}})
+        (is (= {:auth/login true :checkout/flow true} (second @persisted))
+            "a second toggle persists the WHOLE by-id map, not just the
+             machine that moved — the reload-restore contract")))))
+
 ;; ---- 3. Chart view hiccup shape ---------------------------------------
 
 (defn- hiccup-seq [tree]


### PR DESCRIPTION
rf2-04tx owns the CLASS, not the two `:tb/arm` handlers PR #7896 already fixed:
a handler returning a v1-shaped top-level effect key that the closed effect map
does not carry, so the effect never happens and the `:db` write lands anyway,
disguising the failure as a partial success.

## The sweep found exactly one more, and it had shipped

`tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs:177`

```clojure
{:db db'
 :rf.xray.machine-canvas/persist-chart-collapsed by-id}
```

`:rf.xray.machine-canvas/persist-chart-collapsed` is registered with `rf/reg-fx`
ten lines further down. It is an **fx-id returned as a top-level effect key**, so
the runtime policed it (`:rf.error/effect-map-shape`) and dropped it, and
`save-chart-collapsed-by-id!` has never run. The operator's per-machine
chart-collapse choice has never survived a reload. The `:db` write landed either
way, so the toggle looked like it worked — the same disguise as `:tb/arm`.

Fixed to ride `:fx`.

**The Xray spec is unchanged, and deliberately so.**
`tools/xray/spec/007-UX-IA.md:708` already says the slot is "persisted to
localStorage and rehydrated on load". The spec was right; the code had drifted
from it. Closing the drift leaves nothing to restate.

## Why the existing test could not see it

The only test naming this fx asserted it **is in the registrar**:

```clojure
(deftest persist-chart-collapsed-fx-registered
  (is (some? (registrar/handler :fx :rf.xray.machine-canvas/persist-chart-collapsed))))
```

A registered fx nobody routes to satisfies that perfectly. That is the same
fail-open family as `armed-edges-are-wired` — a check that verifies the parts are
present rather than that the thing happened — one plane down. The new test
observes the **do-fx plane** through `:fx-overrides`, which is the only place the
drop is visible, and additionally pins that the *whole* by-id map is persisted
(the reload-restore contract), not just the machine that moved.

## What the sweep did NOT find, and how to re-run it

Reader-based, not regex-based, over `git ls-files` **tracked** `.clj/.cljs/.cljc`
— 3278 files parsed with edamame, every map literal in every form walked. That
is the right instrument here: after reading, a key inside an `:fx` vector is a
**vector element**, never a map key, so the "`[:dispatch …]` inside `:fx` is
correct and not the target" false-positive class cannot arise at all.

Five arms — (A) state key + v1 spelling anywhere; (B) v1 spelling in map-key
position inside a `reg-event*` form; (C) state key + **any** non-closed key
inside a `reg-event*` form, which catches typos that are not v1 spellings;
(D) map literal whose keys are *all* v1 spellings (a bare `{:dispatch-later …}`
with no `:db` beside it); (E) regex fallback over the 14 mustache-template files
edamame cannot parse. Plus hand greps for dynamically-built returns
(`(assoc|merge|into … :v1key)` and `^\s*:v1key\s`).

Every hit was read. Everything else was a deliberate negative fixture, an
`:fx-overrides` map (legitimately keyed by fx-id), a Malli `[:multi {:dispatch
:t} …]` schema property, a synthetic `:rf.fx/do-fx` trace payload in the Xray
panel gallery, or the inner value map of a `:db` effect. **Beyond the one fix,
the tree is clean.**

The full method, the per-hit rejection reasons, the fail-open audit of the
hicasso testbed gate, and the cost analysis for the "should the closed map
REFUSE?" question are all recorded **on the bead** — the durable record.

## Two things that did not hold at source, worth knowing

1. **The closed set is seven keys, not three.** `events.cljc:309-330` — the four
   EP-0025 classification keys (`:sensitive` / `:large` / `:clear-sensitive` /
   `:clear-large`) are in it, so `police-final-effects!` does not drop them.
2. **The runtime does not silently ignore a foreign top-level key.** It has
   policed every one, on every dispatch, in every build, since rf2-ooc5
   (`police-effect-map-shape!`, `police-final-effects!`). The **drop is
   production-real**; only the `:rf.error/effect-map-shape` **diagnostic** is
   dev-only, and that is spec-pinned (Spec 009 catalogue row, Channel
   `diagnostic`). So the reason these defects cost real time is not that nothing
   noticed — it is that the thing that noticed reported to a channel with no
   reader attached. That reframing is on the bead.

## Scope

`implementation/hicasso/testbed/**` is PR #7896's. This branch reads those files
and edits none of them. The two further fail-open rows the audit found there
(`spec.cjs:405`, `spec.cjs:481`) are **reported on the bead, not fixed here** —
both need only one extra assertion against the `:edits` arrival counter the
testbed already exposes, which two sections in that same file already use for
exactly this premise.

## Quality gates

All exit codes below are **captured**, each gate run alone with nothing appended.

| Gate | Captured exit | Result |
| --- | --- | --- |
| `npm run test:cljs` (the `cljs_node_test` lane) | **0** | `Ran 13278 tests containing 67093 assertions. 0 failures, 0 errors.` |
| `cd tools/xray && clojure -M:test` (`jvm-tools-xray`) | **0** | `Ran 1288 tests containing 6045 assertions. 0 failures, 0 errors.` |
| `python scripts/check_fast_pr_gap.py --list` | **0** | 96 required checks the spine does not decide |

`../tools/xray/test` is on the `:node-test` source path
(`implementation/shadow-cljs.edn:363`), which is what makes `test:cljs` the lane
that covers this change rather than a gate that exits green over an excluded
path.

### Sabotage proof

Restoring the top-level-key form in `machine_canvas.cljs` and re-running the same
lane:

- **captured exit 1**, three failures, **all** in
  `persist-chart-collapsed-fx-actually-fires-rf2-04tx`, the first reading
  *"the persist fx ran exactly once — it reached the `:fx` walk"*. No collateral
  failures — the gate names exactly the right thing and nothing else.
- Restored and **verified by hashing the bytes** (`sha256sum`), not by reading
  `git diff`, then re-run: **captured exit 0**, as tabled above.

### Required checks this PR reaches that are NOT decided locally

`story-xray-browser` (`test:xray-feature-gate:smoke`, fires on `tools/xray/src`
changes), `clj-kondo` + `splint` (both lint `tools/xray`), and `api-manifest`
(`xray-spec-check`). CI owns all four. clj-kondo in particular pins 2026.04.15,
so a pass from a differently-versioned local binary would prove nothing.
