### PR TITLE
docs(hicasso): rf2-hic-008 acceptance verified; nine ports left their bench originals standing

### DIFF
--- a/docs/design/hicasso/product/prototype-suite-triage.md
+++ b/docs/design/hicasso/product/prototype-suite-triage.md
@@ -349,8 +349,16 @@ Four are blocked on something concrete, and the block is the interesting part:
   witness in the tree, and a clean rename apart from one thing: it `:require`s
   `re-frame.bench.hicasso.front.slot-cljs-test`'s corpus, and that file cannot move (below). Port
   it once the slot question is settled, or inline the corpus.
+  **LANDED (rf2-a15c, PR #7842), and the corpus was what unblocked it.** rf2-b6ja settled the slot
+  question and found the queue behind it was never a lane question at all — a namespace that defines
+  no `deftest` is not a test file, so the bijection gate never reaches a corpus. The corpus went
+  across as an ordinary support namespace, `re-frame.hicasso.slot-corpus`, and both this row and the
+  one below went with it. The verdict here is therefore **PORT, executed**; the bench original still
+  stands and should not, which is
+  [The nine ports whose originals still stand](#the-nine-ports-whose-originals-still-stand).
 - **`arm1/raw_escape_dom_cljs_test.cljs`** (403) — the `[:>]` raw escape against real React. Reads
-  `front.codec-cljs-test`'s corpus; queued behind it for the same reason.
+  `front.codec-cljs-test`'s corpus; queued behind it for the same reason. **LANDED with it** — same
+  bead, same PR, same standing original.
 - **`arm1/host_ssr_dom_cljs_test.cljs`** (670) and **`arm1/fallback_contents_cljs_test.cljs`** (376)
   — `defhost`'s `:ssr` policy in all three places it has to hold, and the contract for what an
   `:ssr` fallback may contain. Genuine package behaviour, and at census time

--- a/docs/design/hicasso/product/prototype-suite-triage.md
+++ b/docs/design/hicasso/product/prototype-suite-triage.md
@@ -75,6 +75,78 @@ copies' lanes rather than reading the path filters: derive which builds select e
 deleted. The measurements are in
 [2. the `:ssr` trio](#2-the-ssr-trio--not-blocked-and-the-third-member-is-a-different-bead).
 
+### The nine ports whose originals still stand
+
+**rf2-hic-008, 2026-08-11 16:37 AUSEST.** The convention above was ruled while eleven ports were
+already on the ground, and it resolved the two it was written about. **It was never applied to the
+other nine.** rf2-a15c landed eleven ported suites in PR #7842; rf2-c78g deleted two of their bench
+originals; the remaining nine still stand, and under the default stated above every one of them is a
+duplicate that should have gone with its port.
+
+They are duplicates by measurement rather than by name. Each package file carries its bench
+original's `deftest` roster entire — same names, same count:
+
+| bench original | lines | deftests | package port | roster |
+|---|---|---|---|---|
+| `arm1/boundary_intent_dom_cljs_test.cljs` | 453 | 7 | `boundary_intent_dom_cljs_test.cljs` | identical |
+| `arm1/callback_form_dom_cljs_test.cljs` | 156 | 3 | `callback_form_dom_cljs_test.cljs` | identical |
+| `front/codec_cljs_test.cljs` | 1,593 | 67 | `codec_cljs_test.cljs` | identical |
+| `arm1/hframe_cljs_test.cljs` | 360 | 8 | `hframe_cljs_test.cljs` | identical |
+| `arm1/hframe_dom_cljs_test.cljs` | 458 | 5 | `hframe_dom_cljs_test.cljs` | identical |
+| `arm1/keywarn_dom_cljs_test.cljs` | 190 | 3 | `keywarn_dom_cljs_test.cljs` | identical |
+| `arm1/presence_intent_dom_cljs_test.cljs` | 460 | 8 | `presence_intent_dom_cljs_test.cljs` | **one row renamed** |
+| `arm1/raw_escape_dom_cljs_test.cljs` | 403 | 6 | `raw_escape_dom_cljs_test.cljs` | identical |
+| `arm1/state_dom_cljs_test.cljs` | 265 | 4 | `state_dom_cljs_test.cljs` | identical |
+
+4,338 lines over nine files, out of the bench tree's 61 suites and 24,223 lines (`wc -l`, read on
+`origin/main` at the timestamp above).
+
+**The discriminator is a measurement because it also separates the other class.**
+`arm1/first_registration_cljs_test.cljs` shares its basename with a package file too and is **not**
+in the table: it carries five `deftest`s against the package file's one, and the claims differ. That
+is correct and expected — it is a RE-AUTHORED row, rf2-wjag wrote the package's witness from the
+behaviour rather than from the file, and a re-authoring leaves its original standing by definition.
+A roster comparison puts the nine on one side of that line and `first_registration` on the other,
+which a basename match cannot do.
+
+**One pair has already drifted, which is the ruling's own predicted failure mode observed.**
+`presence_intent_dom_cljs_test`'s eighth row is
+`presence-costs-three-hooks-and-the-shell-still-costs-two` in the bench tree and
+`presence-costs-four-hooks-and-the-shell-still-costs-two` on the package. The counts are both right
+about their own subject: rf2-6tmu gave the package's presence a root-scoped adoption window — a
+second `useContext` — and the prototype never received it. **Both copies are green**, because the
+assertion beneath the name is over `(distinct tail)` and a second `useContext` collapses into a name
+already in the list, so the whole divergence is carried by the `deftest` name and the prose around
+it. That is precisely the shape this section warns about: *"the stale one keeps passing. Nothing goes
+red to announce it."* Five days after the ruling, the tree has an instance.
+
+**The reverse-dependency scan is clean, and the two prose references are not requires.** Each of the
+nine namespaces is named by its own `ns` form and by nothing else in the repo. Two docstring mentions
+survive: `arm1/raw_escape_dom_cljs_test.cljs` line 6 wiki-links `front.codec-cljs-test`, and both
+files are in the table, so they go together; and
+`implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs` line 53 cites
+`arm1.hframe-dom-cljs-test` as the provenance of a technique it reimplements. That second one
+dangles when the file goes, and whoever removes it owns re-pointing it — a citation into a deleted
+file is a reference to git history, not a link. Neither is a dependency; see
+[the `[[wiki-link]]` lesson](#2-the-ssr-trio--not-blocked-and-the-third-member-is-a-different-bead).
+
+**No exception is available for any of the nine.** The only capability the exception has ever
+recognised is a host, and rf2-c78g measured that one shut for exactly this file class:
+`check_test_lane_bijection.py`'s `loadable_by` gives JVM lanes `.clj` and `.cljc` and nothing else,
+so a `.cljs` suite rides no JVM host to lose. All nine are `.cljs`. The default therefore decides
+every row.
+
+**Why the deletion is not executed here, and what it waits on.** `compile_gate.cjs` **derives** the
+lane's namespace roster by walking the directory rather than listing it — deliberately, in its own
+words, because *"a roster in this file would be the staleness class the gate exists to catch"* — so
+removing nine files changes what that gate compiles. **rf2-bl0j is rewriting that gate now**, and its
+version widens the walk to include the `*_cljs_test.cljs` files these nine are. Two branches changing
+one derived roster from opposite ends is a merge nobody should have to referee, so the deletion is
+sequenced behind that gate rather than raced against it. The `MIN_NAMESPACES` floor is **not** the
+obstacle and should not be quoted as one: it is 40 in both versions against a lane of ~101, and 92
+clears it comfortably. **Owner: rf2-3ewp**, which carries the measurement, the deletion-safety scan
+and the sequencing.
+
 ## The three facts that decide most rows
 
 ### 1. All 69 already run on every PR
@@ -597,6 +669,11 @@ row needs no follow-up bead** — it needed the tier named, and the tier is name
   blocked and has since been ported. The third is a documented no, and the measurement behind it is
   the one worth carrying forward — the file already rides two jobs where it sits, and the move is
   what would cost it one.
+- **It does not execute the verdicts it records, and executing one is not finished until the
+  original is gone.** Every PORT row is now across, but nine of the ports left their bench originals
+  standing and one of those pairs has already drifted — see
+  [The nine ports whose originals still stand](#the-nine-ports-whose-originals-still-stand). That is
+  rf2-3ewp's, sequenced behind rf2-bl0j.
 - **It does not distinguish a `[[wiki-link]]` from a `:require` by tooling, because nothing here
   can.** Three of this document's blockers turned out to be docstring cross-references read as
   dependencies, and one of them was in a correction of the other two. The counts are stated as


### PR DESCRIPTION
Closes rf2-hic-008.

## What this PR is, and why it is not what the bead's title says

**rf2-hic-008's four deliverables are all already on `main`.** The bead's own notes say so for three
of them; the fourth turned out to be done as well, across four PRs that landed after the note was
written. So this PR does not implement the bead — it **verifies its acceptance mechanically**, and
records the one thing the tree still owes.

| deliverable | state | where it landed |
|---|---|---|
| tiny consumer app, public namespaces only | **landed** | PR #7814 |
| HMR path demonstrated | **landed** | PR #7814 |
| production release build green | **landed** | PR #7814 (`:hicasso-release`) |
| all Hicasso suites migrated, per-suite record | **landed** | #7842 · #7850 · #7851 · #7866 |

The fourth was never a mechanical rename, and the bead's own note says so: it is a **triage**. That
triage is in the tree as `docs/design/hicasso/product/prototype-suite-triage.md` (rf2-6ync), with
its sequencing questions settled by rf2-b6ja, its "a port is a move" convention ruled by rf2-c78g,
and every PORT verdict executed by rf2-a15c and rf2-6rw9.

**The title deviates from the dispatch brief deliberately.** The brief specified a `feat(hicasso):`
title naming the four deliverables. The diff is one markdown file; a `feat(` title claiming to add a
consumer app that landed in #7814 would misdescribe it.

## The finding: nine ports left their bench originals standing

rf2-c78g ruled that **executing a PORT verdict MOVES the suite — it does not copy it**, because a
duplicated suite drifts silently and *"the stale one keeps passing"*. It was ruled while eleven ports
were already on the ground (rf2-a15c, PR #7842) and it resolved only the two it was written about.
**The other nine bench originals still stand.**

They are duplicates **by measurement, not by name** — each package file carries its bench original's
whole `deftest` roster:

| bench original (`implementation/freehand/test/re_frame/bench/hicasso/`) | lines | deftests | roster vs package port |
|---|---|---|---|
| `arm1/boundary_intent_dom_cljs_test.cljs` | 453 | 7 | identical |
| `arm1/callback_form_dom_cljs_test.cljs` | 156 | 3 | identical |
| `front/codec_cljs_test.cljs` | 1,593 | 67 | identical |
| `arm1/hframe_cljs_test.cljs` | 360 | 8 | identical |
| `arm1/hframe_dom_cljs_test.cljs` | 458 | 5 | identical |
| `arm1/keywarn_dom_cljs_test.cljs` | 190 | 3 | identical |
| `arm1/presence_intent_dom_cljs_test.cljs` | 460 | 8 | **one row renamed — drifted** |
| `arm1/raw_escape_dom_cljs_test.cljs` | 403 | 6 | identical |
| `arm1/state_dom_cljs_test.cljs` | 265 | 4 | identical |

**The discriminator is a measurement because it also separates the other class.**
`arm1/first_registration_cljs_test.cljs` shares a basename with a package file and is **not** in the
table: five `deftest`s against the package's one, different claims. Correct — it is a RE-AUTHORED
row (rf2-wjag), and a re-authoring leaves its original standing by definition. A basename match
cannot tell those two classes apart; a roster comparison can.

**One pair has already drifted — the ruling's predicted failure mode, observed.**
`presence_intent_dom_cljs_test`'s eighth row is `presence-costs-three-hooks-…` in the bench tree and
`presence-costs-four-hooks-…` on the package. rf2-6tmu gave the package's presence a root-scoped
adoption window (a second `useContext`); the prototype never received it. **Both copies are green**,
because the assertion is over `(distinct tail)` and the fourth call collapses into a name already in
the list — so the entire divergence is carried by the `deftest` name and its prose.

**Not executed here, and the reason is a live worker.** `compile_gate.cjs` **derives** the lane
roster by walking the directory rather than listing it (deliberately — *"a roster in this file would
be the staleness class the gate exists to catch"*), so deleting nine files changes what that gate
compiles. **rf2-bl0j is rewriting that gate right now**, with the walk widened to include exactly
these `*_cljs_test.cljs` files. Sequenced behind it as **rf2-3ewp** (depends-on rf2-bl0j) rather than
raced against it. `MIN_NAMESPACES` is *not* the obstacle and the record says so: 40 in both versions
against a lane of ~101.

Deletion safety is already measured and carried on rf2-3ewp: the reverse-dependency scan is **clean**
(each of the nine namespaces is named only by its own `ns` form); the two surviving mentions are
docstring `[[wiki-link]]`s rather than `:require`s; and no exception is available, because
rf2-c78g measured the only recognised one (a JVM host) shut for `.cljs` files and all nine are
`.cljs`.

## The per-suite moved-or-copied record

The full 61-row record is the triage document; this is its state. Standing verdict **15 PORT · 9
RE-AUTHORED · 45 STAYS** over the 69-file census.

| class | count | disposition |
|---|---|---|
| PORT — executed as a **MOVE**, original deleted | 8 | 6 × `front/*` at port time; 2 × `:ssr` by rf2-c78g |
| PORT — executed as a **COPY**, original still standing | 7 | the `arm1/*` rows — **should be moves**, rf2-3ewp |
| RE-AUTHORED — original correctly stays | 9 | rf2-wjag; the package witness is written from the behaviour, not the file |
| STAYS | 45 | measurement, tier-1 shapes, SSR-programme evidence, already-covered |
| **census total** | **69** | 8 + 7 + 9 + 45 |

**Two of the 45 STAYS rows are counted there but no longer behave like it.**
`front/codec_cljs_test` and `arm1/raw_escape_dom_cljs_test` were parked in STAYS as *blocked* on the
slot corpus; rf2-b6ja discharged the block and rf2-a15c ported both. Their verdict is effectively
PORT, they were executed as **copies**, and their originals stand — which is why the nine above is
7 + 2 rather than 7.

Two STAYS bullets in the document were stale — `front/codec_cljs_test` and
`arm1/raw_escape_dom_cljs_test` still read "blocked … port it once the slot question is settled".
The slot question was settled by rf2-b6ja and both were ported by rf2-a15c; both bullets now record
that, in the document's own inline-correction style.

## Mechanical import-discipline proof

Not by reading — from the release build's own manifest and bundle.

- **Entry**: `re-frame.hicasso.consumer-app`; **162 transitive sources** in
  `out/hicasso-release/manifest.edn`.
- **0** sources under `re_frame/bench/`, `tools/`, `re_frame/story` or `re_frame/testbed`.
- **17** package sources under `re_frame/hicasso`.
- Bundle greps over `out/hicasso-release/main.js`, all **0**: `re_frame.bench`,
  `day8.re_frame2_xray`, `re_frame2_pair_mcp`, `day8.re_frame2_machines_viz`, `re_frame.story`,
  `re_frame.testbed`, `re_frame.mcp_base`. **Control**: `re-frame.hicasso` → **26** (present, so the
  greps are live).

## Frozen tree, verified by hash

`check_freeze.py` digests with CRLF collapsed to LF, so a line-ending rewrite cannot read clean —
which `git diff` would. Result: *"1 frozen row(s) match the bench tree, and each package file is its
donor moved; no package file imports it."* The manifest pins exactly one row (`front/slot.cljc`) and
**is not edited by this PR**.

## Quality gates

Each run alone, nothing appended, exit code captured on the same command line and read back from the
`.exit` file — not from the harness's report.

| gate | command | captured exit |
|---|---|---|
| Hicasso invariants (freeze hash, module reachability, complaint catalogue) | `npm run test:hicasso-invariants` | **0** |
| Production release build, `:advanced` + `goog.DEBUG` false, + erasure check | `npm run build:hicasso-release` | **0** |
| Migrated suites — the package's named surface | `compile-node-test.cjs node-test-hicasso` then run | **0** |
| Doc slugs (the gate for this diff's tree) | `python scripts/check_doc_slugs.py` | **0** |
| Fast-PR spine | `sh scripts/test-fast-pr.sh` | **0** |
| Doc slugs, re-run after the final edit | `python scripts/check_doc_slugs.py` | **0** |

Results:

- **release build** — `[:hicasso-release] Build completed. (162 files, 107 compiled, 0 warnings,
  25.56s)`; erasure `OK: no dev-only Hicasso surface in the :advanced / goog.DEBUG=false bundle (5
  sentinels absent, 3 positive controls present)`.
- **migrated suites** — `[:node-test-hicasso] Build completed. (312 files, 311 compiled, 0
  warnings)`; **553 tests, 2498 assertions, 0 failures, 0 errors**.
- **spine** — `gate root: /c/Users/miket/code/re-frame2-worktrees/pkgdone-hic008`, confirmed against
  the worktree before the run was trusted. **Every number above is read back from the `.exit` file,
  not from the harness's own report** — the two agreed on this run, which is not something to assume.

**Disclosure: the spine ran one commit before the tip.** The second commit (`daaf913014`) corrects
two stale STAYS bullets and touches nothing but the same markdown file, in a tree
`mkdocs build --strict` excludes. Its sole validator is `check_doc_slugs.py`, which was re-run
against the final tree at exit **0**. Nothing else in the spine reads `docs/design/hicasso/**`.

**`mkdocs build --strict` is NOT the gate for this diff** and was not run: `mkdocs.yml`'s
`exclude_docs` keeps `design/hicasso/` out of the site. `scripts/check_doc_slugs.py` is what
validates that tree's link targets and heading anchors, and it is green. Nothing validates its
tables or rendering, so **verified by hand**: the new section's one table is 5 columns across header,
separator and all 9 body rows; the two tables above are 4 and 3 columns likewise; and both new
in-document links resolve — `#the-nine-ports-whose-originals-still-stand` (the new heading) and the
existing `#2-the-ssr-trio--not-blocked-and-the-third-member-is-a-different-bead`.

`python scripts/check_fast_pr_gap.py --list` reports **96** required checks the spine does not
decide. No `.cjs` is touched, so the `test:script-policy` / `test:script-helpers` pair is not in this
diff's blast radius.

## Hot zone

**None touched.** `implementation/shadow-cljs.edn`, `implementation/deps.edn`,
`.github/workflows/**` and `spec/**` are all unmodified — the build ids and `:dev-http` ports a
consumer app and an HMR demonstration would have wanted (`:hicasso-release`, `:hicasso/hmr-testbed`,
port 8061) were already added by PR #7814, so no hot-zone edit was needed and none was made.

## Scope fence

`implementation/freehand/test/**` is held by **rf2-bl0j**, and this PR does not touch it. That is the
finding above: the deletion the record calls for is deliberately left to rf2-3ewp, sequenced behind
that worker, because both would be changing one derived namespace roster from opposite ends.
