### PR TITLE
test(hicasso): a refusal row must prove an intent arrived (rf2-qwwb)

### DIFF
--- a/implementation/hicasso/testbed/spec.cjs
+++ b/implementation/hicasso/testbed/spec.cjs
@@ -370,6 +370,7 @@ async function compositionSafety(page, w) {
   const run = await page.evaluate(() => {
     const node = window.__TB__.el('digits');
     node.focus();
+    const before = window.__TB__.model();
     const seen = [];
     const log = (t) => seen.push(t);
     node.addEventListener('compositionstart', () => log('start'));
@@ -388,13 +389,16 @@ async function compositionSafety(page, w) {
       isComposing: true, inputType: 'insertCompositionText', data: 'あい',
     });
 
-    const midModel = window.__TB__.model().fields.digits;
+    const mid = window.__TB__.model();
 
     window.__TB__.composition(node, 'compositionend', 'あい');
     const ended = window.__TB__.read('digits');
 
     return {
-      started, draft1, draft2, midModel, ended, seen,
+      started, draft1, draft2, ended, seen,
+      editsBefore: before.edits.digits || 0,
+      midEdits: mid.edits.digits,
+      midModel: mid.fields.digits,
       startCount: seen.filter((t) => t === 'start').length,
       endCount: seen.filter((t) => t === 'end').length,
     };
@@ -402,6 +406,11 @@ async function compositionSafety(page, w) {
 
   w.eq(run.draft1.value, '123あ', 'the first composing update survives in the field');
   w.eq(run.draft2.value, '123あい', 'the second composing update survives too');
+  // The PREMISE of the row below, without which it is not a witness at all:
+  // a model nothing spoke to has also "never moved". Both composing updates
+  // reached the store, so the stillness the next row reads is a REFUSAL
+  // rather than an absence.
+  w.eq(run.midEdits, run.editsBefore + 2, 'both composing updates reached the store');
   w.eq(run.midModel, '123', 'the refusing model never moved during the exchange');
   // The exchange was not destroyed: one start, one end. A value write
   // landing mid-composition is what mints a second `compositionstart` in
@@ -462,6 +471,7 @@ async function compositionReleaseEdges(page, w) {
   const unmounted = await page.evaluate(async () => {
     const node = window.__TB__.el('mountable');
     node.focus();
+    const before = window.__TB__.model();
     window.__TB__.composition(node, 'compositionstart', '');
     // A REFUSING field, so the draft in the element is one the model never
     // took — without that the row below would pass on a model that had
@@ -469,15 +479,25 @@ async function compositionReleaseEdges(page, w) {
     const draft = window.__TB__.edit('mountable', '9あ', 2, {
       isComposing: true, inputType: 'insertCompositionText', data: 'あ',
     });
-    const midModel = window.__TB__.model().fields.mountable;
+    const mid = window.__TB__.model();
     window.__TB__.el('toggle-mounted').click();
     await window.__TB__.settle();
     const gone = !!document.querySelector('[data-testid="mountable-gone"]');
     window.__TB__.el('toggle-mounted').click();
     await window.__TB__.settle();
-    return { draft: draft.value, midModel, gone, back: window.__TB__.read('mountable').value };
+    return {
+      draft: draft.value, gone,
+      editsBefore: before.edits.mountable || 0,
+      midEdits: mid.edits.mountable,
+      midModel: mid.fields.mountable,
+      back: window.__TB__.read('mountable').value,
+    };
   });
   w.eq(unmounted.draft, '9あ', 'the field held a draft the model had refused');
+  // Same premise as `composition-safety`'s: "refused it" is a claim about
+  // something the store was asked to do, and only the arrival counter can
+  // tell that apart from an exchange that dispatched nothing.
+  w.eq(unmounted.midEdits, unmounted.editsBefore + 1, 'the composing update reached the store');
   w.eq(unmounted.midModel, '9', 'and the model really had refused it');
   w.eq(unmounted.gone, true, 'the field unmounted mid-composition');
   w.eq(unmounted.back, '9', 'the remounted field shows the model, not a stranded draft');

--- a/implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs
+++ b/implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs
@@ -348,7 +348,7 @@ const ENGINES = ONLY
 // names, so deleting a witness means deliberately editing the gate that
 // requires it.
 //
-// Sum today: 95, which is what each engine reports.
+// Sum today: 97, which is what each engine reports.
 // ---------------------------------------------------------------------------
 
 const REQUIRED_SECTIONS = {
@@ -357,8 +357,8 @@ const REQUIRED_SECTIONS = {
   'caret-across-the-echo': 9,
   'caret-under-real-typing': 4,
   'selection-across-an-out-of-band-write': 4,
-  'composition-safety': 7,
-  'composition-release-edges': 8,
+  'composition-safety': 8,
+  'composition-release-edges': 9,
   'an-accepting-model-during-a-composition': 8,
   'revision-reset-preserves-identity': 7,
   'a-revision-arriving-mid-composition': 15,


### PR DESCRIPTION
Closes rf2-qwwb.

Two rows in `implementation/hicasso/testbed/spec.cjs` asserted that a refusing
model had not moved, and nothing else:

- `composition-safety` — `'the refusing model never moved during the exchange'`
- `composition-release-edges` — `'and the model really had refused it'`

A store nothing ever spoke to satisfies "did not move" perfectly, so neither
row could tell *the refusal worked* from *nothing was refused, because nothing
arrived*. Each verified the absence of bad news in place of the presence of
good news.

## The remedy

No new machinery. The testbed already exposes a per-field arrival counter
(`:edits`), bumped on **every** intent *before* the policy is consulted — a
refusal is an arrival too — and two other sections already read it for exactly
this premise:

- `an-accepting-model-during-a-composition`: `'exactly one intent arrived for it'`
- `a-revision-arriving-mid-composition`: `'the composing update reached the store'`

Each amended row gains one assertion in front of it, in that same idiom: read
the model before the exchange, read it again mid-exchange, and require the
counter to have advanced by the number of composing `input` events actually
dispatched (2 in `composition-safety`, 1 in `composition-release-edges`).

## The coverage floor moves with the rows

`REQUIRED_SECTIONS` in `implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs`
pins each section's minimum at "the number of checks it banks today", and its
counts are what make a row *quietly dropped from a surviving section* red.
Left at 7 and 8, the two rows this PR adds would be deletable in silence —
the same shape being fixed. So `composition-safety` 7 → 8,
`composition-release-edges` 8 → 9, and the `Sum today` comment 95 → 97. The
pin's design is untouched; only its arithmetic follows the file. The floor's
own self-tests derive from `REQUIRED_SECTIONS` (`fullSections()`), so nothing
there needed hand-editing.

## Quality gates

Each run alone, output redirected to a file, exit code captured on the same
command line. Every artefact landed outside the repo; `git status` is clean.

| gate | captured exit |
|---|---|
| `npm run test:hicasso-controlled` (chromium + firefox + webkit) | **0** — `97 checks across 13 sections` in each engine |
| `npm run test:script-policy` | **0** |
| `npm run test:script-helpers` | **0** |
| `npm run lint:js` (ESLint — both edited files are `.cjs`) | **0** |
| `python scripts/check_fast_pr_gap.py --list` | **0** |

`test:script-policy` and `test:script-helpers` are one CI gate in two halves;
both were run.

**What the fast-PR spine does not decide (96 required checks).** The one that
covers this diff is `cljs-hicasso-controlled` — listed under (B), *required
jobs with no lane in this spine at all* — which is why it was run here in full,
all three engines. `eslint` (lint.yml) is the other required job this diff
reaches, and it was run too. The remaining 94 are surface-gated on paths this
PR does not touch: the `.cljs`/`.cljc` linters (clj-kondo, splint) see no
source change, the api-manifest projections see no facade change, and docs.yml
sees no `docs/` change.

## Proving each row can fail

A row that cannot fail is the thing being fixed, so both were made to fail.

**The sabotage** is the real regression these rows now guard, and the one
`controlled.cljs` names: `shadowed-props` calls the author's handler `inner`
*before* it branches on `composing-input?`, which is what puts an intent on the
wire during a composition. Skipping `inner` while composing means no intent
ever reaches the store — precisely "nothing was refused, because nothing
arrived".

```clojure
;; implementation/hicasso/src/re_frame/hicasso/impl/controlled.cljs
 (if (composing-input? e)
   (set-shadow (some-> (.-target e) (.-value)))
-  (release!))
-(inner e)
+  (do (release!) (inner e)))
 nil))
```

| run | what | captured exit | first red |
|---|---|---|---|
| 1 | sabotage, `HICASSO_TESTBED_ENGINES=webkit`, full `SECTIONS` | **1** | `[webkit] both composing updates reached the store: expected 4, got 2` |
| 2 | sabotage, `SECTIONS` cut to `composition-release-edges` so nothing reds first | **1** | `[webkit] the composing update reached the store: expected 1, got undefined` |
| 3 | sabotage, **pre-fix** `spec.cjs` (`git checkout HEAD~1 --`), full `SECTIONS` | **1** | `[webkit] AND the accepting model took it — mid-composition: expected "abcdZあ", got "abcdZ"` |

Run 3 is the counter-proof, and it is the point of the bead. Under the *same*
broken law, the pre-fix spec ran **both** amended sections green from end to
end — `composition-safety` all 7 rows, `composition-release-edges` all 8 —
and the first red is in the section *after* them. Two sections passing while
no intent reached the store at all is the fail-open shape, measured rather
than argued.

**Restore verified by hashing the bytes**, not by reading `git diff` — a
CRLF-flipping rewrite reads clean there. `sha256sum` before the sabotage and
after `git checkout HEAD --`:

```
df91862b1e13c1fd187f734e2655295cc53c3bb56310e4be5499599e78fef2e4  controlled.cljs
dcea324d69d4358a232fe5563c349c8fe9a75fc47698438e27a2c4ec0962a055  spec.cjs
72eeb6081e26358b11ffffbee5aabaa6e17124cb83ff13e39e21432e6fc77b4a  serve-and-run-hicasso-controlled-testbed.cjs
```

Identical in both readings, `git status --porcelain` empty, and the full
three-engine gate re-run green afterwards (captured exit **0**).

## Scope

Two rows in one file, plus the two floor minimums that guard them. The
armed-edges repair and the coverage-floor design from #7896 are untouched, the
other eleven sections were not re-audited (rf2-04tx already did), and the
navigation-ceiling policy is not widened.
