### PR TITLE
docs: replace AUTHORING.md with a human-first writing brief

### DIFF
--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -1,302 +1,867 @@
-# Guide authoring brief
+# Guide authoring
 
-> **Who this is for.** Anyone writing or revising pages under `/docs` — core,
-> machines, async, resources, routing, ssr, and the other guide corpora. Readers
-> never land here (not in the site nav). Start learning at
-> [the guide](core/introduction.md).
+This document governs pages under `/docs`.
 
-This is a **taste brief**, not a process manual. Non-negotiables first; craft and
-pacing after that. Prefer judgment over form compliance — but if you skip a rule
-below, know *why*.
+The goal is simple: help a competent developer understand re-frame2 quickly,
+accurately, and with as little friction as possible.
 
-> **If a page can't state its one job, it's two pages.**
+The guide is not the spec. It is not a design diary. It is not a catalogue of
+everything the framework knows.
 
-## Non-negotiables
+It is the thing a developer reads when they want to build something.
 
-1. **One job, one Diátaxis mode.** Each page is *start / tutorial / how-to /
-   explanation / index / reference* all the way down. Opening states the reader's
-   problem in a sentence or two. Tutorials don't catalogue alternatives; how-tos
-   don't re-teach concepts; explanations don't carry task steps; indexes route with
-   judgment (never restate the left nav).
+Readers never land here (it is not in the site nav). They start learning at
+[the guide](core/introduction.md).
 
-2. **Standalone corpus.** Never link into `spec/`. Repeat what the reader needs,
-   with a CLJS flavour, on the page that owns the topic. Exact shapes →
-   [API reference](api/README.md); definitions → [glossary](core/glossary.md).
-   Contributors still *verify* against the spec and implementation; the rule is
-   about reader-facing links.
+---
 
-3. **True snippets.** Readers copy-paste. Every example is complete, idiomatic, and
-   would pass review — never a pedagogical anti-pattern presented as the way. Prefer
-   adapting from `examples/` with a source comment (`;; cf. examples/...`). Verify
-   every taught API symbol and every `:rf.error/*` / `:rf.warning/*` id against
-   `implementation/` (and `spec/API.md` for authors) before teaching it. Async
-   callbacks carry a frame — bare `dispatch` from a timeout raises
-   `:rf.error/no-frame-context`.
+## The reader
 
-4. **Reader-first order.** Goal → working code → explanation. Never open with
-   internals. Examples and gotchas sit beside the step they serve.
+Assume the reader:
 
-5. **No navigation ceremony.** The guide is built and published with
-   **[MkDocs](https://www.mkdocs.org/)** (Material theme; config in repo-root
-   `mkdocs.yml`). Readers already get a left sidebar, section nesting, and
-   prev/next from that build — do **not** re-implement navigation on the page.
-   No "What's next" / "You can now" footers; no mini-TOCs that restate the left
-   nav; no **`## Start here`** (or similar) reading-order lists — MkDocs already
-   puts those headings in the page TOC and they only restate the sidebar. Useful
-   cross-links go inline where relevant. A short "you can ship with this" recap is
-   not ceremony; a list of later chapters is.
+* is a working developer
+* understands ordinary programming concepts
+* probably knows React, Redux, re-frame, or another frontend framework
+* does not yet know re-frame2
+* is reading because they need to do something
 
-## Voice
+Do not talk down to them.
 
-One persona: a **friendly senior developer** — simple, direct, a little Yegge on
-teaching pages. Tight prose, not terse telegram. Register shifts by page kind; the
-person doesn't:
+Do not make them decode framework internals before they can use the framework.
 
-| Register | Where |
-|---|---|
-| Warm teaching | start, concepts, tutorials |
-| Tight recipe | how-to, testing |
-| Argument | explanation shelf |
-| Terse reference | glossaries, `docs/api/` — boring on purpose |
+Introduce re-frame2 vocabulary when the vocabulary earns its keep.
 
-**Why "senior".** Not status — a **vocabulary filter**. Write the words a working
-senior would actually say in a PR review, stand-up, or whiteboard session. Domain
-terms and ordinary engineering English are in (`app-db`, coeffect, handler, queue,
-pure, race). Abstract coinages and consultant/AI-ish intensifiers are out when
-they aren't common human usage for that idea. If a tired colleague would raise an
-eyebrow at the *word choice* (not the concept), rephrase with the plain mechanism.
+---
 
-The test: say it aloud at 11pm. Would a peer nod, or ask what you meant by the
-metaphor? The reader knows React or Redux; meet them as a colleague.
+## The basic rule
 
-Prefer operational claims ("X does Y / fails with Z") over status language ("this
-is the foundational / load-bearing / pivotal …"). Name the thing: boundary, API,
-handler, error id — not spine, seam, surface area, heart of the system, unless that
-phrase is already a re-frame term of art.
+**Teach the smallest useful model first.**
 
-**Yegge seasoning (teaching pages only).** Blunt, peer-to-peer, occasionally savage
-about *bad ideas*. Humor earns its keep by making a real failure mode stick — not by
-decorating. Shape: true claim → short rephrase with teeth → operational rule. One
-jab, then back to business. Keep the attitude; drop digressions and war-story length.
-If the sentence is only funny, cut it. A precise claim must survive if you delete the
-joke. **Never trade precision for charm.**
+A page should answer, in roughly this order:
 
-Owned opinions are fine ("two copies of one truth is two chances to disagree");
-invented personal biography is not. Explain a short *why* after instructions. One
-committed metaphor per concept — only if a senior would use it unprompted.
+1. What problem does this solve?
+2. What do I write?
+3. What happens when I write it?
+4. What can go wrong?
+5. What else matters once I understand the normal case?
 
-Define key terms (`app-db`, frame, coeffect, …) at first use in a few plain words.
-Don't pack the reader off mid-flow for a basic word.
+If the implementation detail does not help answer one of those questions, it
+probably does not belong yet.
 
-## What a concept page must carry
+A page that teaches *how to do a job*, *how a concept works*, *why a design
+exists*, or *how to find the right page* still obeys that order — it should not
+mix those jobs on one page. If you need a label: tutorials show a path,
+how-tos complete a task, explanations argue a model, indexes route with
+judgment. The label is optional; the one-job rule is not.
 
-Concept pages (the main track under Core, and *concepts* / model pages in domain
-corpora) are incomplete until they have all five:
+---
 
-| Piece | Role |
-|---|---|
-| **Problem open** | One or two sentences: what pain, what job |
-| **Required path** | Working code first (live cell when it teaches more than reading). This *is* the page — do not label it "basics" or "day one" |
-| **Troubleshooting** | Short table: symptom → named error/recovery → fix. Prefer this heading over "When things go wrong" |
-| **When *not*** | Situations where another tool is better (or "this is rare") |
-| **Advanced (if any)** | Optional depth after the reader can ship — only when the page needs it. Heading: **`## Advanced`** (not "Going further", "Day one", or "Basics") |
+# Writing style
 
-Missing "when not" and missing named errors are the two most common ways a page
-looks finished and still strands the reader at 11pm.
+## Write like a developer explaining code to another developer
 
-**Do not** bury what the reader must know under migration notes, full config maps,
-or optional forms. Collapse those (`??? note` / `??? info`) or put them after the
-required path — at the end under `## Advanced` if needed.
+Use ordinary technical English.
 
-### Don't label the required path
+Prefer:
 
-The body of the page is what they have to know. No "Day one", "Basics",
-"Essential", or "Day-one checklist" banner over material that is simply the job of
-the page. If a short ship recap helps, write it as ordinary prose or bullets —
-not a second curriculum track. Optional depth goes at the end under **`## Advanced`**
-(or a specific topic heading). "Going further" is the old name for Advanced; use
-**Advanced**.
+> Call `h/sub` where you need the value.
 
-### Standard headings (when present)
+over:
 
-| Use | Not |
-|---|---|
-| `## Troubleshooting` | "When things go wrong", "Unhappy path" |
-| `## Advanced` | "Going further", "Day one / Going further" two-speed openers |
-| (no label) | "Basics", "Day-one checklist", "Essential" |
-| (omit) | `## Start here`, on-page reading-order mini-TOCs |
+> Reads live at the point of use.
 
-## Progressive pacing
+Prefer:
 
-Teach like a good tutorial, not like a reference dump with anecdotes.
+> A plain `defn` does not create a re-render boundary.
 
-1. **Happy path first.** One growing example (counter for pure Core; domain noun
-   for batteries) that adds exactly one idea per step.
-2. **Required, then optional.** Long pages put what you need to ship first. Optional
-   depth (full config maps, Form-2/3, chain algebra, mint policies) comes **after**
-   under `## Advanced` — not a polite promise mid-page, not a "day one vs later
-   career" frame. Skip two-speed openers ("Day one: … Going further: …"); the
-   structure of the page does that job.
-3. **Troubleshooting as tables**, not essays. Prefer
-   `:rf.error/no-such-handler` over "things might fail quietly." Recovery belongs
-   in the same row as the error. Heading: **Troubleshooting**.
-4. **Depth is earned.** Argument-dependent input-fns, Form-2/3, full frame-config,
-   mint policies, interceptor chain algebra — after the required path, or collapsed.
-5. **Length is a smell, not a rule.** If the reader still cannot ship after a scroll
-   of essay, the page is two pages or one page with optional depth mixed into the
-   required path.
+over:
 
-### Slim model vs catalogue
+> Helpers surrender their reads upward to the enclosing boundary.
 
-Guide pages teach. When a page accumulates option tables, precedence rules, or every
-keyword of a map, **move that weight to the API** (or glossary). Keep a pointer.
-The model page stays quotable; the API stays complete.
+Prefer:
 
-Same split for domain corpora: a *concepts* page is the flat grammar; growth pages
-each add one capability; operate pages own production failure modes.
+> Hicasso creates the callback and dispatches the event vector for you.
 
-## Structure of the corpus
+over:
 
-Diátaxis with reference first-class.
+> The runtime lowers the intent into a callback carrying the frame.
 
-**Core track** (flat nav, learning order; the arc below is conceptual):
-introduction (the **event pipeline**) → hiccup (the notation) →
-**pure pipeline** (events → app-db → subscriptions → views) → **impurity**
-(effects, including run-to-completion teaching; coeffects) → **structure**
-(frames → flows → interceptors) → **operations** (errors → observability) →
-**advanced** (images; run-to-completion operational detail) → how-to → testing →
-explanation → migration → glossary.
+Use specialised terminology when the distinction matters. Do not use
+specialised terminology merely because the implementation has a name for
+something.
 
-Prefer **event pipeline** (and *pipeline run*) for the fixed stage sequence. Do
-not call that structure "the loop" — a pipeline is linear per event; apps advance
-as a *sequence of pipeline runs*, not a free-form cycle. "Pure pipeline" names the
-first four pages (no impurity yet). Legitimate "loop" uses remain: drain loop,
-dispatch cycle, `for`/loop index, "loop the render" as a bug.
+---
 
-### Technique owners (do not invent a second home)
+## Do not perform a voice
 
-One technique, one concept owner. Recipes and tests *use* the technique; they do
-not re-teach it.
+The documentation should have personality, but the writer should mostly
+disappear.
 
-| Technique | Owner |
-|---|---|
-| Event vocabulary, `dispatch` | [Events](core/events.md) |
-| `{:db}`, facts vs conclusions, seed-as-event | [app-db](core/app-db.md) |
-| Named derivation, layers, `=` gate | [Subscriptions](core/subscriptions.md) |
-| Hiccup notation, view-in-view composition | [Hiccup](core/hiccup.md) |
-| `reg-view` semantics, thin views | [Views](core/views.md) |
-| `:fx` grammar, RTC *idea*, `reg-fx` | [Effects](core/effects.md) |
-| Managed HTTP depth / retry / abort | [async](async/http.md) (not Core) |
-| `:rf.cofx/requires`, grades, `reg-cofx` | [Coeffects](core/coeffects.md) |
-| Isolation, carry, ensure vs scope | [Frames](core/frames.md) |
-| `init!`, hot reload, host listeners | [Boot how-to](core/how-to/boot-and-mount-an-app.md) |
-| Materialise for handlers | [Flows](core/flows.md) |
-| Four homes (which tool) | [Where state lives](core/where-state-lives.md) |
-| Cross-cutting chain (rare) | [Interceptors](core/interceptors.md) |
-| Registration sets (rare) | [Images](core/images.md) |
-| Dossiers / recovery verbs | [Errors](core/errors.md) |
-| Trace wire; classification *why* | [Observability](core/observability.md) |
-| Classification *recipe* | [Secrets how-to](core/how-to/keep-secrets-out-of-traces.md) |
-| Machines / resources / routing / SSR | Their battery corpora — pointer only from Core |
+Avoid trying to make every paragraph:
 
-Interceptors and images are **structure but rare** — open with when-not; do not
-imply every app needs them on day two.
+* witty
+* punchy
+* memorable
+* philosophical
+* opinionated
+* quotable
 
-**Domain corpora** (machines, resources, async, routing, ssr): **nav order** is the
-reading order (tutorial first when one exists, then model, then growth in dependency
-order) — do not restate it on the index under `## Start here`. Index states
-**prerequisites** and **when not to use this artefact**, then the page's own job
-(demo, scope table, …).
+One good sentence is better than three clever ones.
 
-**Canon apps.** Counter for Core model pages (no server). RealWorld once server data
-enters. Domain corpora keep their own anchors (XState / login+websocket; TanStack
-Query + RealWorld nouns; same nouns for async, routing, SSR). No throwaway narrative
-apps invented for one page.
+Do not write slogans around ordinary mechanics.
 
-**Nav.** Order pages so each leans only on what came before. Descriptive labels help
-(`"Frames: isolated worlds"` beats `"Frames"`). Numbered sequential tracks help when
-the track is long. Open each page by placing it in the thread — one clause, not a
-mini-TOC of the whole guide.
+Avoid lines like:
 
-**Delta teaching.** Domain pages name the ecosystem anchor (Redux, TanStack Query,
-XState, re-frame v1, …) and the deliberate divergences. Persona deltas are collapsed
-`??? info` callouts — short, never required reading. A v1 callout is earned only where
-the v1 instinct *misleads*; most pages need zero. Retired v1 surfaces
-(`inject-cofx`; the retired/renamed `:rf.world/inputs` → flat `:rf.cofx` map)
-appear **only** on the [migration page](core/25-from-re-frame-v1.md), marked
-superseded — never as live teaching elsewhere.
+> The attractions are few, and they compound.
 
-## Live cells and demo shapes
+> The two spellings do not cross.
 
-Use ` ```cljs-rf2 ` when editing teaches more than reading. Keep cells small and
-self-contained; RealWorld stays static with a link to the example. Prefer:
-why → cell → optional `!!! tip "Try it"`.
+> Those are deliberate prices.
 
-**Shapes that stay true:**
+> Data survives all the way to the leaf.
 
-| Context | Prefer | Avoid as "the way" |
-|---|---|---|
-| Pure-pipeline Core demos | `frame-root` + named initialise event + `reg-view` | Bare `defn` that `subscribe`s under a provider (raises `:rf.error/no-frame-context`) |
-| Multi-frame / frames *are* the topic | `make-frame` + `frame-provider`, or two `frame-root`s | Inventing a second boot story earlier than Frames |
-| Seed state | Named `reg-event` in `:initial-events` | Implying a `:db` config key exists; leading with `:rf/set-db` before the named-event pattern |
-| Anti-patterns | Labeled `;; Don't` / before-after | Working cells that silently teach the anti-pattern |
+They may sound polished in isolation. Across a guide they make the prose feel
+written rather than useful.
 
-Rules that bite: top-level forms only (no wrapping `do`); last form renderable
-hiccup; seed with `:initial-events` (or `dispatch-sync` where appropriate) so the
-first paint isn't a race; one frame per cell unless the lesson *is* multi-frame;
-stay on surfaces already proven in shipped cells, or click a new surface in a
-browser before merging. Full cell-environment details live with the playground
-tooling — don't re-encode a second runtime spec here.
+Say what happens.
 
-## Callouts and takeaways
+---
 
-Use MkDocs admonitions, not bold-lead blockquotes, for asides:
+## Let the example do the work
 
-- Gotchas → expanded `!!! warning`
-- Notes → expanded `!!! note`
-- Experiments beside live cells → `!!! tip "Try it"`
-- Persona / v1 deltas and optional depth → collapsed `??? info` / `??? note`
+If code demonstrates the idea clearly, do not explain the same idea three more
+times.
 
-Budget them. Three boxes in a row means the prose is hiding structure. A page that
-is more box than prose has inverted itself.
+Bad:
 
-Teaching pages benefit from **one** quotable takeaway — the sentence that sticks.
-Prefer a single `> **…**` pull-quote near the open. That's craft, not a lint rule —
-better one clear sentence in prose than a forced slogan.
+> Event handlers are normally where a data-oriented system loses its
+> data-oriented nature. This is an important boundary because closures are
+> opaque...
 
-## Reference
+Then a code sample.
 
-**Glossary:** one term, standalone definition first, short code when the spelling
-matters, *See* line to the teaching page. Defines and routes; never teaches.
+Then another paragraph restating that the vector is inspectable.
 
-**API (`docs/api/`):** every public symbol; fixed fields Kind / Signature /
-Description / Example. Description is the contract (including error ids), not the
-motivation.
+Better:
 
-## Honesty
+```clojure
+[:button {:on-click [:todo/toggle id]} "Toggle"]
+```
 
-Say when *not* to use a feature. Mark deferred surfaces and CLIENT-ONLY paths. No
-marketing voice. No bead ids in prose. Pages state current truth.
+Hicasso accepts an event vector directly. It creates the callback and
+dispatches the vector when the button is clicked.
 
-## What CI enforces
+Because the tree still contains `[:todo/toggle id]`, tests and tools can
+inspect it as ordinary data.
+
+Three sentences. Done.
+
+---
+
+## Prefer concrete verbs
+
+Good verbs:
+
+* calls
+* returns
+* reads
+* writes
+* dispatches
+* renders
+* compares
+* creates
+* stores
+* retries
+* cancels
+* warns
+* throws
+* subscribes
+* re-renders
+
+Be suspicious of unnecessarily literary verbs:
+
+* mints
+* carries
+* narrates
+* owns, when "stores" or "tracks" is clearer
+* flows, unless an actual data flow is being described
+* crosses a boundary, unless the boundary itself matters
+
+When the runtime signals failure, prefer **throws**, **raises**, or **returns
+an error**, and name the `:rf.error/*` or `:rf.warning/*` id when one exists.
+"Refuses" is fine only when you immediately say how that surfaces to the
+caller.
+
+Precision beats flavour.
+
+---
+
+## Prefer one explanation over a chain of abstractions
+
+Do not write:
+
+> A boundary owns the collector which records the reads produced while lowering
+> the view.
+
+If what the reader needs is:
+
+> Each `defview` tracks the subscriptions read while it renders. When one of
+> those values changes, that view re-renders.
+
+The second explanation may be less implementation-complete. It is much more
+useful.
+
+Introduce `boundary`, `collector`, `lowering`, and similar terms only when the
+reader needs those distinctions later.
+
+---
+
+# Page structure
+
+## One page, one job
+
+Every page should have one clear reason to exist.
+
+Examples:
+
+* teach subscriptions
+* show how controlled inputs work
+* explain routing
+* show how to test an event handler
+* document the `reg-view` API
+
+If the page is trying to be both a tutorial and a reference catalogue, split it.
+
+If the page cannot be described in one sentence, reconsider the scope.
+
+**Index pages** (corpus home pages) state prerequisites, when not to use the
+artefact, and the page's own job. They do not restate the left-hand nav as a
+roster or a "start here" reading-order list. MkDocs already lists the pages.
+
+---
+
+## Start with the problem, not the architecture
+
+Bad:
+
+> Hicasso's rendering model consists of boundaries, collectors and an
+> interpreted Hiccup lowering phase.
+
+Better:
+
+> A view often needs several subscription values, including values needed only
+> inside a helper or conditional. In Hicasso, you can call `h/sub` exactly
+> where you need the value.
+
+Start with what the developer is trying to accomplish.
+
+Explain the machinery afterward, if it helps.
+
+---
+
+## Show working code early
+
+Readers should see the normal form quickly.
+
+Do not make them read several paragraphs before seeing the API.
+
+Typical shape:
+
+````markdown
+# Subscriptions
+
+Use `h/sub` to read a registered subscription from a Hicasso view.
+
+```clojure
+(h/defview todo-count [_]
+  [:span (h/sub [:todo/count])])
+```
+
+`h/sub` records the subscription as a dependency of this view. If the value
+changes, the view re-renders.
+````
+
+Then expand.
+
+---
+
+## Teach the normal path before edge cases
+
+The main body should teach what most applications should do.
+
+Move the following later:
+
+* alternative forms
+* migration details
+* obscure configuration
+* unusual performance cases
+* implementation internals
+* rarely used escape hatches
+* exhaustive option tables
+
+A reader should be able to stop halfway through a page and still know the
+normal solution.
+
+---
+
+## Advanced material belongs after the useful model
+
+Use:
+
+```markdown
+## Advanced
+```
+
+when there is genuinely optional depth.
+
+Do not create artificial categories such as:
+
+* Basics
+* Day one
+* Essential
+* Going further
+* Expert mode
+
+The page itself is the normal material. `Advanced` is optional material.
+
+---
+
+# Concepts and terminology
+
+## Introduce terms only when they buy precision
+
+A term earns a place when ordinary language becomes ambiguous without it.
+
+For example, `frame` matters because it names a real re-frame2 concept with
+observable behaviour.
+
+`collector` may not matter on the first subscriptions page if the reader only
+needs to understand that a view tracks what it reads.
+
+Prefer:
+
+> `defview` creates an independently re-rendering view.
+
+Then, if the distinction becomes important:
+
+> The guide calls this independently re-rendering unit a **boundary**.
+
+Definition follows usefulness, not the other way around.
+
+---
+
+## Define a term once, briefly
+
+Do not repeatedly parenthesise definitions throughout the guide.
+
+Bad:
+
+> the boundary (the independently re-rendering view which owns the frame...)
+
+every time `boundary` appears.
+
+Define it clearly once. Link to the glossary when needed.
+
+---
+
+## Use one term for one thing
+
+Do not casually rename framework concepts for variety.
+
+If the guide calls it an **event pipeline**, keep calling it an event pipeline.
+
+Do not rotate through:
+
+* pipeline
+* loop
+* cycle
+* machine
+* flow
+
+unless those are genuinely different things.
+
+Prefer **event pipeline** (and *pipeline run*) for the fixed stage sequence of
+one dispatched event. Do not call that structure "the loop" — a pipeline is
+linear per event. Legitimate "loop" uses remain: drain loop, dispatch cycle,
+`for`/loop index, "loop the render" as a bug.
+
+Technical prose does not benefit from synonym variety.
+
+---
+
+# Examples
+
+## Examples must be real
+
+Every example should:
+
+* use the actual API
+* be valid ClojureScript
+* demonstrate the recommended approach
+* contain enough surrounding code to make sense
+* avoid hidden prerequisites where practical
+
+Never invent an API because it makes the example easier to explain.
+
+Verify unfamiliar or recently changed API shapes — and every taught
+`:rf.error/*` / `:rf.warning/*` id — against:
+
+1. the implementation
+2. the spec (while authoring; do not link readers into `spec/`)
+3. tests or examples where useful
+
+The guide must teach what ships, not what sounds plausible.
+
+Async callbacks carry a frame. A bare `dispatch` from a timeout or promise
+raises `:rf.error/no-frame-context`. Examples that leave the view body must
+show capture or an effect that carries the frame.
+
+Prefer adapting from `examples/` with a source comment
+(`;; cf. examples/...`) when a shipped example already teaches the shape.
+
+---
+
+## Prefer one continuing example
+
+Where practical, use the same domain across related pages.
+
+For Core, a small todo or counter application is usually enough.
+
+Do not invent:
+
+* a shopping cart on one page
+* a spaceship on the next
+* a chat app on the next
+* a banking dashboard on the next
+
+Novel examples make the reader repeatedly reconstruct irrelevant context.
+
+Domain corpora (machines, resources, async, routing, SSR) should pick a stable
+domain noun for their track the same way Core uses counter/todo.
+
+---
+
+## Do not teach anti-patterns accidentally
+
+If showing incorrect code, mark it unmistakably:
+
+```clojure
+;; Don't do this
+```
+
+Then show the correct form immediately afterward.
+
+The copy-pastable code on a page should overwhelmingly be good code.
+
+---
+
+# Explanation depth
+
+## Explain the useful why
+
+Good:
+
+> Put the key in the props map. Hicasso passes it to React but removes it
+> before calling your view body, matching React's component semantics.
+
+Too little:
+
+> Keys go in props.
+
+Too much:
+
+> During lowering, the interpreter identifies the reserved identity slot
+> before the component ABI conversion phase...
+
+Explain enough that the behaviour stops feeling arbitrary.
+
+Stop there.
+
+---
+
+## Do not re-argue the framework on every page
+
+The guide does not need to repeatedly persuade the reader that:
+
+* data is good
+* views should be derivative
+* effects as data are useful
+* deterministic systems are easier to reason about
+* re-frame2 differs from React
+
+Those ideas belong in the introduction and relevant explanation pages.
+
+Once established, later pages can simply use them.
+
+---
+
+## Distinguish behaviour from rationale
+
+First say what happens.
+
+Then, if useful, say why.
+
+Example:
+
+> Hicasso compares view props with ClojureScript `=`. If the props are equal
+> and none of the view's own subscriptions changed, the body does not run
+> again.
+>
+> This makes structural values cheap to pass between views without requiring
+> the caller to manage memoization.
+
+Mechanism first. Rationale second.
+
+---
+
+# Errors and troubleshooting
+
+## Name concrete failures
+
+Do not say:
+
+> This can behave unexpectedly.
+
+Say:
+
+> Calling a `defview` directly raises `:rf.error/...`.
+
+When re-frame2 provides a named error or warning, use it.
+
+---
+
+## Keep troubleshooting operational
+
+Use a table when several failures belong together:
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Page reloads on form submit | Browser default was not prevented | Wrap the event with `::h/prevent` |
+| View does not re-render | Value was read outside the view's tracked subscription context | Read it with `h/sub` inside the view |
+| React warns about list keys | Child has no stable `:key` | Put a stable domain id in the props map |
+
+Prefer the heading **Troubleshooting**. Do not turn troubleshooting into an
+essay.
+
+---
+
+# How much personality?
+
+A little is good.
+
+A sentence can occasionally have teeth:
+
+> An array index is not an identity. It merely happens to be standing where an
+> identity should be.
+
+But use that kind of line rarely.
+
+The test is simple:
+
+**If removing the joke improves the page, remove the joke.**
+
+Humour should make a technical point easier to remember.
+
+It should not prove that the author can write.
+
+---
+
+# Things to remove during editing
+
+On the final pass, search for these problems.
+
+## Empty emphasis
+
+Words such as:
+
+* deeply
+* fundamentally
+* importantly
+* deliberately
+* powerful
+* elegant
+* clean
+* first-class
+* naturally
+* simply
+
+are often unnecessary.
+
+Keep them only when they distinguish one behaviour from another.
+
+---
+
+## Repeated framing
+
+Delete sentences that merely announce what the next sentence will explain.
+
+Bad:
+
+> There are two important things to understand about this.
+
+Then two bullets.
+
+Just write the bullets.
+
+---
+
+## Duplicate conclusions
+
+If the paragraph says:
+
+> `h/sub` can be called from helpers.
+
+do not end it with:
+
+> The important point is that helpers can read subscriptions.
+
+The reader got it.
+
+---
+
+## Unnecessary metaphors
+
+Do not describe architecture as:
+
+* a spine
+* a seam
+* a contract boundary
+* a bridge
+* a highway
+* a surveillance state
+* a skyscraper
+* an escape hatch
+
+unless the metaphor materially makes the mechanism clearer.
+
+One literal sentence is usually better.
+
+---
+
+## AI-shaped prose
+
+Watch for:
+
+* repeated `X, not Y` constructions
+* repeated three-item rhetorical lists
+* dramatic em dashes
+* one-sentence paragraphs used for fake emphasis
+* constant bolded mini-slogans
+* every section ending with a neat thesis
+* unnecessarily symmetrical sentences
+* phrases such as "the key insight", "the important thing", "at its core"
+
+These patterns are not forbidden. Repetition makes the prose feel synthetic.
+
+Vary structure according to the material, not according to a writing formula.
+
+---
+
+# Guide versus reference
+
+The guide teaches how to think and work.
+
+The API reference records exact forms.
+
+If a guide page starts accumulating:
+
+* every option
+* every map key
+* every overload
+* every error code
+* every return shape
+* every precedence rule
+
+move that information to the API reference and keep the useful subset in the
+guide.
+
+A guide page should answer:
+
+> What should I normally do?
+
+The reference should answer:
+
+> What exactly is possible?
+
+Definitions live in the [glossary](core/glossary.md) when the term needs a
+standalone home; exact public symbols live under [API reference](api/README.md).
+
+---
+
+# Guide versus spec
+
+The spec is the semantic authority.
+
+The guide is standalone user documentation.
+
+Do not send readers into `spec/` to understand how to use re-frame2.
+
+Read the spec while authoring. Rewrite the relevant idea for a user.
+
+The guide should explain the public model in the language of the
+implementation.
+
+---
+
+# Navigation and MkDocs
+
+The guide is rendered with **MkDocs Material** (config in repo-root
+`mkdocs.yml`).
+
+MkDocs already provides:
+
+* the left-hand navigation
+* section hierarchy
+* page table of contents
+* previous/next navigation
+* breadcrumbs and site-level orientation
+
+Do not recreate those things inside the page.
+
+Avoid:
+
+* `## Start here` sections that restate the sidebar
+* manual reading-order lists
+* mini tables of contents
+* "Next, read…" footers
+* "What's next" sections
+* lists of neighbouring chapters purely for navigation
+
+Use inline links when they help explain the current topic:
+
+> Managed retries are covered in [HTTP](async/http.md).
+
+That is useful context.
+
+This is not:
+
+> Next:
+>
+> 1. HTTP
+> 2. Resources
+> 3. Routing
+
+Let MkDocs handle navigation. The page should spend its words teaching.
+
+---
+
+# Editing test
+
+Before a page is finished, ask:
+
+### Can a developer find the normal code quickly?
+
+If not, move code earlier.
+
+### Does the page introduce machinery before the reader needs it?
+
+If yes, delay the machinery.
+
+### Is every paragraph teaching something?
+
+If not, cut it.
+
+### Is the same point made twice?
+
+Keep the better version.
+
+### Is a framework term being used because it helps the reader?
+
+If not, use ordinary English.
+
+### Could this sentence appear in generic AI-generated framework documentation?
+
+If yes, make it more concrete or delete it.
+
+### Does the prose sound impressive when the underlying idea is simple?
+
+Make the prose simple too.
+
+### Can the page lose 20–30% of its prose without losing information?
+
+Try it.
+
+Most first drafts can.
+
+---
+
+# Default page shape
+
+This is a useful starting structure, not a template that every page must
+visibly follow.
+
+````markdown
+# Topic
+
+One or two sentences describing the problem.
+
+```clojure
+;; normal working example
+```
+
+Explain what the code does.
+
+## Important behaviour
+
+Explain the few rules the reader needs to use the feature correctly.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| ------- | ----- | --- |
+
+## When not to use it
+
+Briefly explain when another re-frame2 feature or another approach is more
+appropriate.
+
+## Advanced
+
+Optional details that are genuinely useful after the normal model is
+understood.
+````
+
+Delete headings that do not earn their place.
+
+---
+
+# How pages get written
+
+Rules without a short process lose to volume. Three habits:
+
+1. **Bullet spine first.** Do not draft full prose until the page's problem,
+   normal code, and one-job sentence are clear.
+2. **Content, then cut.** After the facts are right, do a pass that only
+   removes slogans, duplication, and AI-shaped cadence — ideally with a
+   different editor or model than the first draft.
+3. **Gold samples.** Match the tone of pages the project already trusts (for
+   Core, start from a strong existing teaching page). Do not match the tone of
+   a long first-draft dump.
+
+---
+
+# Final principle
+
+The reader should come away thinking:
+
+> That was straightforward.
+
+Not:
+
+> That was beautifully written.
+
+And definitely not:
+
+> I can tell an LLM wrote this.
+
+---
+
+# What CI enforces
 
 On docs PRs: `mkdocs build --strict`, the link/anchor validator
-(`scripts/check_doc_slugs.py`), and residue scans (retired `inject-cofx` /
-`:rf.world/inputs`, retired composition vocabulary, retired image keys) in
+(`scripts/check_doc_slugs.py`), and residue scans in
 `.github/workflows/docs.yml`.
 
-Everything else is human judgment: feature PRs update the affected guide page (or
-say why not); click live cells you touched; prefer cited `examples/` sources so the
-examples compile gate covers them.
-
-## Before you open a PR
-
-- [ ] One job, clear open; no `spec/` links
-- [ ] Happy path works (snippets true); anti-patterns labeled, not demoed as success
-- [ ] Required path is the unlabeled body; optional/advanced is after it (if any)
-- [ ] Troubleshooting table (or equivalent) with verified `:rf.error/*` / recovery ids
-- [ ] "When not" stated where a feature can be misapplied
-- [ ] Callouts not a wall of boxes; catalogue weight pushed to API if the page bloats
-- [ ] Pure-pipeline cells: `frame-root` + `reg-view` + named initialise (unless Frames is the topic)
-- [ ] New/changed live cells clicked in a browser
-- [ ] Nav row if the page is new; descriptive nav label; `mkdocs build --strict` and `python scripts/check_doc_slugs.py` green
+Everything else is human judgment: feature PRs update the affected guide page
+(or say why not); click live cells you touched; prefer cited `examples/`
+sources so the examples compile gate covers them.


### PR DESCRIPTION
## Summary

Replace `docs/AUTHORING.md` with the rewrite from `ai/findings/new-authoring.md`, cleaned up and tightened for use as the full governing brief.

### Why

The previous brief stated taste and Diátaxis rules but did not stop LLM-shaped guide prose or architecture-first pages. The new document centres:

- goal (guide is for building, not the spec or a design diary)
- reader model
- smallest useful model first (five questions)
- ordinary developer English and concrete verbs
- **do not perform a voice** (banned slogans / AI cadence)
- page structure, terms, examples, troubleshooting
- guide vs API vs spec
- MkDocs owns navigation
- editing test and default page shape

### Small additions beyond the findings draft

- One-sentence Diátaxis/job split without requiring Diátaxis jargon
- Index-page rule (prereqs / when-not / job — no second sidebar)
- True-snippet / verify-API / `:rf.error/*` / async frame capture retained from the old brief
- Event-pipeline vs \"loop\" naming note kept
- Prefer throws/raises over literary \"refuses\" unless the surface is named
- Three-line process habits (spine → content → cut; gold samples)
- CI enforcement pointer retained
- Markdown fence nesting fixed

## Test plan

- [x] `python scripts/check_doc_slugs.py` in the worktree
- [ ] Skim as an author: can you apply this to a bad draft-guide paragraph?
- [ ] Confirm no unintended links into `spec/` were introduced (none expected)