### PR TITLE
docs(hicasso): apply AUTHORING brief to draft-guide

### DIFF
--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -1,95 +1,80 @@
 # Getting started
 
-You already know re-frame2's pipeline: events write app-db, subscriptions
-derive values, and views paint the screen. What you still choose is *how*
-those views are written. That choice is the view adapter — the layer that
-turns your view code into something React can mount.
+re-frame2 already has events, app-db, subscriptions, and frames. What you still
+choose is **how views are written** — the view adapter that turns view code
+into something React can mount.
 
 ## What Hicasso is
 
-[Hicasso](glossary.md#hicasso) is re-frame2's **native view adapter**. You
-write ordinary ClojureScript data: Hiccup vectors, props maps, and event
-vectors in attributes. At the point of use you call [`h/sub`](glossary.md#hsub)
-like any other function. The runtime turns that data into React
-function-component elements. The app-db, the event handlers, the
-subscriptions, the frames — none of that changes. Hicasso is the view
-language on top of the pipeline you already trust.
+[Hicasso](glossary.md#hicasso) is re-frame2's view adapter built around
+interpreted [Hiccup](../../../core/glossary.md#hiccup). You write ordinary
+ClojureScript data: vectors for markup, maps for props, and event vectors in
+handler attributes. Where you need a subscription value, you call
+[`h/sub`](glossary.md#hsub) like any other function. The runtime turns that
+tree into React function-component elements.
 
-"Native" here does not mean "the only legal way to write views." It means
-this is the adapter designed *for* re-frame2's data-first habits, not
-borrowed from another UI library's mental model and bolted on. Reagent and
-UIx adapters remain first-class products you can ship on forever. Hicasso is
-the path that treats markup as data, reads as ordinary calls, and handlers as
-values a test can assert with `=`.
+App-db, event handlers, subscriptions, and frames stay ordinary re-frame2.
+Hicasso is the view language on top of that pipeline.
 
-### Beside Reagent and UIx
+It is not the only legal way to write views. Reagent and UIx adapters remain
+supported products you can ship on indefinitely. Hicasso is the path that
+keeps markup as data, subscription reads as ordinary calls, and click handlers
+as values a test can compare with `=`.
 
-**Reagent** is how a generation of re-frame apps learned to paint: Hiccup that
-feels like HTML, reactions that track reads, and a deep ecosystem. If you are
-migrating a Reagent app, Hicasso is a cousin, not a foreign country —
-[Migrating from Reagent](19-migration-from-reagent.md) is built for that
-journey. What you leave behind is reaction-local state and Form-2 ceremony;
-what you keep is the shape of the tree.
+## Beside Reagent and UIx
 
-**UIx** is the best answer when the *screen* is React-first: hooks everywhere,
-a mature component library at the centre, authors who already think in React.
-Hicasso does not try to win that contest. Foreign React still walks in through
+**Reagent** is how many re-frame apps already paint: Hiccup that feels like
+HTML, reactions that track reads, and a large ecosystem. If you are migrating
+a Reagent app, Hicasso is close in shape —
+[Migrating from Reagent](19-migration-from-reagent.md) is built for that path.
+You leave reaction-local state and Form-2 ceremony; you keep the tree of
+vectors.
+
+**UIx** is the better fit when the screen is React-first: hooks everywhere, a
+mature component library at the centre, authors who already think in React.
+Hicasso does not try to win that contest. Foreign React still enters through
 [`h/defhost`](09-interop.md), and a measured hot region can drop into native
 React or UIx under the same root and frame
 ([Native tier](10-native-tier.md)). Pick UIx when the product *is* a React app
-that happens to use re-frame2 for state. Pick Hicasso when the product is a
-re-frame2 app that wants data all the way to the leaf.
+that uses re-frame2 for state. Pick Hicasso when the product is a re-frame2
+app that wants data all the way to the leaf.
 
-### Why people reach for it
+## What you write differently
 
-The attractions are few, and they compound.
+Four habits show up once you install:
 
-**Markup stays data.** A button's meaning is `[:todo/toggle id]`, not a
-closure you cannot print. Structural tests compare trees with `=`. Tools and
-AI pairs can read an intent off the tree without running the app.
+- A button's handler is data — `[:button {:on-click [:todo/toggle id]} …]` —
+  so structural tests compare trees with `=`.
+- Call [`h/sub`](glossary.md#hsub) where you need the value: in a `let`, a
+  `when`, a loop, or a plain helper. You do not have to thread a subscription
+  value down so the helper can see it.
+- Controlled fields use ordinary `:value` and `:on-input`; the runtime keeps
+  caret and composition correct on that path
+  ([Controlled inputs](04-controlled-inputs.md)).
+- Ordinary screens stay on interpreted Hiccup. When measurement names a hot
+  1–2% of the tree, you can cross to native React on the same frame and
+  app-db ([Performance](18-performance.md), [Native tier](10-native-tier.md)).
+  There is no `:fast` flag and no second meaning for `[...]`.
 
-**Reads live where you use them.** You do not thread subscription values down
-from a parent "so the helper can see the filter." An ordinary `defn` helper
-calls [`h/sub`](glossary.md#hsub); the enclosing [boundary](glossary.md#boundary)
-owns the read. Re-render granularity stays visible in the source: an
-[`h/defview`](glossary.md#defview) in head position mints a boundary, and a
-plain `defn` helper call inlines into the boundary already rendering.
-
-**Controlled fields are a law, not a folk recipe.** Caret jumps, dropped
-keystrokes, and IME mishaps are the same bugs every React app rediscovers.
-Hicasso centralises that path so ordinary `:value` / `:on-input` attributes
-are enough for most forms.
-
-**Performance is "good enough," with an honest exit.** Ordinary screens stay
-on interpreted Hiccup. When measurement names a hot 1–2% of the tree, you
-cross an explicit fence to native React — same frame, same app-db, same
-diagnostics — and only if the escape pays for itself
-([Performance](18-performance.md), [Native tier](10-native-tier.md)). There is
-no `:fast` flag and no second meaning for `[...]`.
-
-### Tradeoffs, said plainly
-
-Interpreted Hiccup is not free. Cold mount carries a small premium against a
-hand-rolled UIx twin on the same screen; much of that premium is capability
-(ambient reads in loops and helpers) rather than walking vectors alone. You
-pay a short fixed cost per boundary so the ordinary path stays simple. If
-every screen is a hook-heavy design-system tree, UIx will feel more natural
-from day one. If you need a second reactive store inside the view layer,
-Hicasso will not give you one — application-visible state lives in app-db
+Interpreted Hiccup is not free. Cold mount can cost a little more than a
+hand-rolled UIx twin on the same screen; much of that cost is capability
+(reads in loops and helpers) rather than walking vectors alone. If every
+screen is a hook-heavy design-system tree, UIx will feel more natural from day
+one. If you need a second reactive store inside the view layer, Hicasso will
+not give you one — application-visible state lives in app-db
 ([Ephemeral state](11-ephemeral-state.md)).
-
-Those are deliberate prices. The rest of this guide is how to spend them
-well.
 
 ## When not to use Hicasso
 
-Stay on **Reagent** if the migration cost is the dominant fact and the app
-already works — Hicasso can wait. Choose **UIx** when React-first authoring
-(hooks everywhere, a design system at the centre) is the product shape, not
-an island. [Hicasso](glossary.md#hicasso) is for data-first views on the
-re-frame2 pipeline: markup as data,
-[reads at the point of use](02-views-and-reads.md),
-[intents you can assert](03-events-as-data.md). It meets foreign React at
+Stay on **Reagent** if migration cost is the dominant fact and the app already
+works — Hicasso can wait. Choose **UIx** when React-first authoring (hooks
+everywhere, a design system at the centre) is the product shape, not an
+island.
+
+Hicasso is for data-first views on the re-frame2 pipeline: markup as data,
+[reads at the point of use](02-views-and-reads.md), and
+[event vectors you can assert](03-events-as-data.md). It meets foreign React at
 [`h/defhost`](09-interop.md); it does not try to be the best pure-React CLJS
-library. If that is your product, [installing it](installation.md) is one
-dependency and one DOM node.
+library.
+
+If that is the product you want, [install a first screen](installation.md).

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -1,16 +1,16 @@
 # Views and reads
 
-After [Installation](installation.md)'s counter, this page is why
-re-renders stay fine-grained and why one read form is enough.
+After [Installation](installation.md)'s counter, this page is how views stay
+fine-grained and why one read form is enough.
 
 Views that re-render too coarsely, and subscription reads that cannot live
 where you use them, are the same problem twice. Either you hoist a value high
 in the tree and re-render many sibling views, or you invent a second way to
 read so that a helper can see the current filter.
 
-[Hicasso](glossary.md#hicasso)'s answer has two parts. A view is a function from a props map to
-hiccup. There is **one** way to read — [`h/sub`](glossary.md#hsub), an ordinary function call at
-the point of use:
+In Hicasso, a view is a function from a props map to Hiccup. There is one way
+to read — [`h/sub`](glossary.md#hsub), an ordinary function call at the point
+of use:
 
 ```clojure
 (ns todo.views
@@ -27,62 +27,60 @@ the point of use:
                 :on-input [:todo.ui/edit id ::h/value]}])]))
 ```
 
-> **Read where you use.** [`h/sub`](glossary.md#hsub) is legal anywhere in the body — inside a
-> `let`, a `when`, a `for`, an ordinary helper call.
+`h/sub` is legal anywhere in the body — inside a `let`, a `when`, a `for`, or
+an ordinary helper call. Each [`h/defview`](glossary.md#defview) tracks the
+subscriptions read while it renders. When one of those values changes, that
+view re-renders.
 
-[`h/sub`](glossary.md#hsub) is the only read form. There is no second spelling for helpers. A
-bare `rf/subscribe` in a body is not a fallback: it refuses instead of
-resolving, and it names the read that went around the [collector](glossary.md#collector) — the
-runtime mechanism that records which subscriptions each
-[boundary](glossary.md#boundary) (one independently re-rendering view) took
-during its body. (The event vectors in those attributes —
-*[intents](glossary.md#intent)* — and [`::h/value`](glossary.md#hvalue) belong to
+`h/sub` is the only read form. There is no second spelling for helpers. A bare
+`rf/subscribe` in a body is not a fallback: it throws instead of resolving.
+(The event vectors in those attributes — *[intents](glossary.md#intent)* —
+and [`::h/value`](glossary.md#hvalue) belong to
 [Events as data](03-events-as-data.md).)
 
-## Boundaries and inlining
+## Views and plain helpers
 
 There are two ways to use another function from a view body, and the
 difference is visible in the syntax:
 
 ```clojure
-[todo-row {:key id :id id}]   ;; a vector — a BOUNDARY child
-(row-icon {:kind :urgent})    ;; a call to a plain defn — INLINED into this boundary
+[todo-row {:key id :id id}]   ;; a vector — a separate view
+(row-icon {:kind :urgent})    ;; a call to a plain defn — inlined into this view
 ```
 
-A **view in head position** mints a **[boundary](glossary.md#boundary)** — [Hicasso](glossary.md#hicasso)'s unit of
-independent re-rendering, and the thing [`h/defview`](glossary.md#defview) exists to make. A
-boundary owns four things:
+A **view in head position** is an independently re-rendering unit — the guide
+calls this a [boundary](glossary.md#boundary). [`h/defview`](glossary.md#defview)
+creates one. That unit tracks:
 
-- React's identity for the boundary.
-- The [`h/sub`](glossary.md#hsub) reads that its body makes.
-- Its value-equality bail-out.
-- The re-frame2 frame (isolated app-db and queue) that its
-  [intents](glossary.md#intent) dispatch into.
+- React's identity for the view
+- the `h/sub` reads its body makes
+- a value-equality bail-out on props
+- the re-frame2 frame (isolated app-db and queue) that its event vectors
+  dispatch into
 
-Native tags, fragments, and [`h/defhost`](glossary.md#defhost) heads also sit in vector position.
-None of them is a boundary.
+Native tags, fragments, and [`h/defhost`](glossary.md#defhost) heads also sit in
+vector position. None of them is a boundary.
 
-A **plain `defn` call** is only a function call, and it owns none of the
-four. The runtime splices its hiccup into the caller's tree. Any [`h/sub`](glossary.md#hsub)
-that the helper performs gives that read *upward* to the enclosing boundary.
-Helpers cost nothing at runtime, and they add no re-render granularity.
-Because reads are ordinary calls, **helpers can read**: a `filter-button`
-that needs the current filter reads it, and the read belongs to the boundary
-that is rendering. You do not thread the value down as an argument.
+A **plain `defn` call** is only a function call. The runtime splices its
+Hiccup into the caller's tree. Any `h/sub` the helper performs is tracked by
+the enclosing view. Helpers add no re-render granularity of their own. Because
+reads are ordinary calls, helpers can read: a `filter-button` that needs the
+current filter reads it, and the read belongs to the view that is rendering.
+You do not thread the value down as an argument.
 
-The two spellings do not cross, and both crossings fail with a named error:
+The two forms are not interchangeable:
 
 ```clojure
 ;; Don't — a plain defn in head position
 [row-icon {:kind :urgent}]   ;; :rf.error/hicasso-bad-head: call it, or make it a view
 
 ;; Don't — a view called directly
-(todo-row {:id 7})           ;; refuses at the call, naming the view; write [todo-row {:id 7}]
+(todo-row {:id 7})           ;; throws at the call, naming the view; write [todo-row {:id 7}]
 ```
 
-Re-render granularity should be visible in the source. A [boundary](glossary.md#boundary) is always
-a vector, and an [inline helper](glossary.md#inline-helper) is always a call. A [`defview`](glossary.md#defview) never degrades
-into an inline function because you invoked it differently.
+Re-render granularity should be visible in the source. A boundary is always a
+vector, and an [inline helper](glossary.md#inline-helper) is always a call. A
+`defview` never becomes an inline function because you invoked it differently.
 
 ## Keys go in the props map
 
@@ -94,35 +92,30 @@ into an inline function because you invoked it differently.
 ```
 
 A seq of children needs keys, whatever the head is. The key lives **in the
-props map**. [Hicasso](glossary.md#hicasso) does not read `^{:key id}` metadata here (the most
-common Reagent carry-over), and no `for`-lowering invents a key for you. If
-you miss a key, development warns with `:rf.warning/hicasso-missing-key` and
-names the view and the child. That is all this page teaches about keys. What
-makes a key *good* (a stable domain identity, never an index, never the
-whole entity) is the law of
+props map**. Hicasso does not read `^{:key id}` metadata here (the most common
+Reagent habit), and no `for` invents a key for you. If you miss a key,
+development warns with `:rf.warning/hicasso-missing-key` and names the view
+and the child. What makes a key *good* (a stable domain identity, never an
+index, never the whole entity) is
 [Lists and collections](06-lists-and-collections.md).
 
-## The component ABI
-
-The [component ABI](glossary.md#component-abi) is the props/children contract
-for a head — what converts, what is opaque, where keys live.
+## Props, children, and fragments
 
 | Head | Props | Children | `:key` | `:ref` |
 |---|---|---|---|---|
 | Native tag — `[:div …]` | attribute map | trailing forms | in the attribute map | callback ref, legal |
-| [Hicasso](glossary.md#hicasso) view — `[todo-row …]` | one props map | trailing forms, arriving as `(:children props)` | in the props map, **extracted before your body sees props** | not a view surface — use ids |
+| Hicasso view — `[todo-row …]` | one props map | trailing forms, arriving as `(:children props)` | in the props map, **removed before your body sees props** | not a view surface — use ids |
 | Fragment — `[:<> …]` | — | trailing forms | on the fragment's props map | — |
-| Foreign — [`h/defhost`](glossary.md#defhost) and `[:>]` | converted per declaration | hiccup children become elements | in props | callback ref, legal |
+| Foreign — [`h/defhost`](glossary.md#defhost) and `[:>]` | converted per declaration | Hiccup children become elements | in props | callback ref, legal |
 
-Children arrive realized and flattened in a predictable way. The runtime
-realizes nested and lazy sequences once and flattens them one level. `nil`
-and `false` render nothing. `true` is an error
-(`:rf.error/hicasso-true-child`). An existing React element is a legal child
-anywhere. A view can return `nil`, a single root, or a fragment. `:key`
-never reaches your body; that is React's contract, not a Hicasso choice.
+Children arrive realized and flattened in a predictable way. Nested and lazy
+sequences are realized once and flattened one level. `nil` and `false` render
+nothing. `true` raises `:rf.error/hicasso-true-child`. An existing React
+element is a legal child anywhere. A view can return `nil`, a single root, or
+a fragment. `:key` never reaches your body; that is React's contract.
 
-`(:children props)` is a **vector of hiccup forms**. Splice it into your
-hiccup; do not insert it as one child:
+`(:children props)` is a **vector of Hiccup forms**. Splice it into your
+Hiccup; do not insert it as one child:
 
 ```clojure
 (h/defview card [{:keys [title children]}]
@@ -131,8 +124,8 @@ hiccup; do not insert it as one child:
         children))
 
 [card {:title "Inbox"}
- [message-row {:id 1}]
- [message-row {:id 2}]]
+ [todo-row {:id 1}]
+ [todo-row {:id 2}]]
 ```
 
 A view that has no single wrapper returns a fragment:
@@ -144,65 +137,61 @@ A view that has no single wrapper returns a fragment:
    [cancel-button {}]])
 ```
 
-**Bodies are pure and re-runnable.** React StrictMode runs your body twice
-in development, and that is safe, because bodies are pure by contract.
-Anything that breaks under a second run does not belong in a body. Examples:
-mutation of a captured atom, the start of a fetch, a render counter.
+**Bodies are pure and re-runnable.** React StrictMode runs your body twice in
+development, and that is safe when bodies stay pure. Anything that breaks
+under a second run does not belong in a body: mutating a captured atom,
+starting a fetch, counting renders.
 
-## Boundaries memoize by default
+## Views skip work when props are equal
 
-Every head that [`h/defview`](glossary.md#defview) mints carries one stable memo wrapper. The
-wrapper compares the whole props map with CLJS `=`. If a [boundary](glossary.md#boundary)'s props
-compare equal to the last render, its body does not run, even when its
-parent's body ran. There is no mode flag and no public opt-out. A boundary
-that must re-run with its parent takes a prop that changes.
+Every `h/defview` compares the whole props map with ClojureScript `=`. If a
+view's props compare equal to the last render, its body does not run, even
+when its parent's body ran. There is no mode flag and no public opt-out. A
+view that must re-run with its parent takes a prop that changes.
 
-Two channels outrank the bail-out, and both are the boundary's **own**
-invalidation. First, a subscription read or a context read that the boundary
-made itself always wins. React checks for the boundary's own pending update
-*before* it asks the comparator, so a boundary whose reads changed
-re-renders regardless of its props. Second, a function-valued prop compares
-unequal by identity, and that is deliberate. A fresh closure is never `=` to
-the last one, so an inline handler passed as a prop defeats the bail-out
-every time.
+Two things still force a re-render. First, a subscription (or context read)
+the view made itself always wins: if one of *its* reads changed, the body
+runs regardless of props. Second, a function-valued prop compares unequal by
+identity. A fresh closure is never `=` to the last one, so an inline handler
+passed as a prop defeats the bail-out every time.
 
-A subscription read high in the tree, with the value passed down, does
-**not** lose an update. The boundary that reads is the boundary that
-invalidates, and every boundary that the changed value reaches receives
-unequal props at that hop. The benefit of the default is this: a boundary
-that the value does *not* reach skips instead of re-rendering for nothing.
-To move a read down is a granularity fix, not a correctness fix.
+A subscription read high in the tree, with the value passed down, does **not**
+lose an update. The view that reads is the view that invalidates, and every
+view that the changed value reaches receives unequal props at that hop. The
+benefit of the default is this: a view that the value does *not* reach skips
+instead of re-rendering for nothing. Moving a read down is a granularity fix,
+not a correctness fix.
 
 ## Attributes
 
-The attribute map is ordinary hiccup. The runtime does the conversions that
-React wants:
+The attribute map is ordinary Hiccup. The runtime does the conversions React
+wants:
 
 ```clojure
 (h/defview title-input [_]
-  (let [invalid? (h/sub [:editor/title-invalid?])]
+  (let [invalid? (h/sub [:todo.ui/title-invalid?])]
     [:input#title.form-control
      {:type        :text
-      :value       (h/sub [:editor/title])
-      :placeholder "Article Title"
+      :value       (h/sub [:todo.ui/title])
+      :placeholder "Todo title"
       :aria-label  "Title"
       :style       {:margin-top 8}
       :class       ["is-wide" (when invalid? "is-invalid")]
-      :on-input    [:editor/set-title ::h/value]}]))
+      :on-input    [:todo.ui/set-title ::h/value]}]))
 ```
 
-Five rules cover the conversions.
+Five rules cover the conversions:
 
 - **Names go from kebab-case to camelCase.** `:on-click` emits `onClick`.
-  `:aria-*` and `:data-*` pass through as written. A `--custom-property`
-  stays verbatim. `:class` → `className`, `:for` → `htmlFor`, `:charset` →
+  `:aria-*` and `:data-*` pass through as written. A `--custom-property` stays
+  verbatim. `:class` → `className`, `:for` → `htmlFor`, `:charset` →
   `charSet`.
 - **Values convert one level deep.** A nested map, such as `:style`, has its
   own keys converted to camelCase, so `{:margin-top 8}` arrives as
   `marginTop`. Keywords and symbols become their names (`:type :text` is
   `type="text"`). Functions cross by identity.
-- **`:class` takes more than a string.** It also takes a keyword, a symbol,
-  or a collection of those. The runtime drops `nil`s and joins the rest with
+- **`:class` takes more than a string.** It also takes a keyword, a symbol, or
+  a collection of those. The runtime drops `nil`s and joins the rest with
   spaces, so the `(when …)` above contributes nothing when it is false.
 - **The tag's `#id.class` shorthand composes.** Write the id first:
   `:input#title.form-control`, never `:input.form-control#title`. An
@@ -211,113 +200,109 @@ Five rules cover the conversions.
 - **`:key` is not an attribute.** The runtime reads it off the map and never
   emits it as a prop.
 
-The reserved-data vocabulary is deliberately small: [`::h/value`](glossary.md#hvalue),
-[`::h/checked`](glossary.md#hchecked), [`::h/prevent`](glossary.md#hprevent), and [`::h/revision`](glossary.md#hrevision). The chapter that owns each
-word teaches it ([events](03-events-as-data.md),
+The reserved-data vocabulary is small: [`::h/value`](glossary.md#hvalue),
+[`::h/checked`](glossary.md#hchecked), [`::h/prevent`](glossary.md#hprevent),
+and [`::h/revision`](glossary.md#hrevision). The page that owns each word
+teaches it ([events](03-events-as-data.md),
 [controlled inputs](04-controlled-inputs.md)).
 
 ## Forwarding attributes: owned wins
 
-The [owned-wins](glossary.md#owned-wins) rule is simple: keys you write on the
-element always beat a forwarded map.
+Keys you write on the element always beat a forwarded map.
 
-A reusable field takes caller attributes and still owns its control keys.
-The merge is a pure recipe — a plain `merge`, with the attributes that you
-own written last:
+A reusable field takes caller attributes and still owns its control keys. The
+merge is a plain `merge`, with the attributes that you own written last:
 
 ```clojure
 (h/defview search-field [{:keys [id] :as attrs}]
   [:input.form-control
    (merge (dissoc attrs :id)
-          {:value    (h/sub [:search/text id])
-           :on-input [:search/set-text id ::h/value]})])
+          {:value    (h/sub [:todo.ui/search id])
+           :on-input [:todo.ui/set-search id ::h/value]})])
 ```
 
 **The literal keys that you write always win over anything forwarded — by
 presence, not truthiness.** A forwarded map can add a `:placeholder`, an
-`:aria-label`, or a `:data-testid`. It can never displace the `:value` or
-the handler that the field owns, because the owned keys merge last. Classes
-still compose: `.form-control` on the tag joins whatever `:class` survives
-the merge, so a caller's class adds to the element's own class instead of
+`:aria-label`, or a `:data-testid`. It can never displace the `:value` or the
+handler that the field owns, because the owned keys merge last. Classes still
+compose: `.form-control` on the tag joins whatever `:class` survives the
+merge, so a caller's class adds to the element's own class instead of
 replacing it. When a caller's value *should* win, do not write the literal.
 One risk: `merge` works by key, so forward maps spelled the way you write
 attributes — kebab keywords — not a foreign props object's `"className"`
 strings.
 
-The case that makes this law necessary is a [controlled input](glossary.md#controlled-field): a forwarded
-map must never supply the value, checked, handler, key, or revision slots.
+The case that makes this rule necessary is a
+[controlled input](glossary.md#controlled-field): a forwarded map must never
+supply the value, checked, handler, key, or revision slots.
 [Controlled inputs](04-controlled-inputs.md) teaches that case in full.
 
-## The read-extent law
+## When `h/sub` is legal
 
-The [read-extent law](glossary.md#read-extent-law): [`h/sub`](glossary.md#hsub)
-is legal during the **direct synchronous execution** of the active
-body. Branches, loops, and ordinary helpers are included. Reads inside a
-lazy `for` count as direct: the same pass that turns hiccup into elements
-forces them, so they land in the [boundary](glossary.md#boundary) that is rendering.
+`h/sub` is legal during the **direct synchronous execution** of the active
+view body. Branches, loops, and ordinary helpers are included. Reads inside a
+lazy `for` count as direct: the same pass that turns Hiccup into elements
+forces them, so they land on the view that is rendering.
 
-A read **deferred past the render** refuses, with source and recovery. It
-does not go silently stale. A callback, a promise, a timer, a stashed lazy
-seq, a `delay` forced later — each raises
-`:rf.error/hicasso-sub-outside-render` and names the query. The runtime
-refuses an unforced `delay` that crosses into a boundary's props at the
-crossing (`:rf.error/hicasso-deferred-read-at-boundary`), before it can
-freeze a child. [Hicasso](glossary.md#hicasso) never guesses which render owns a deferred read. The
+A read **deferred past the render** throws, with source and recovery. It does
+not go silently stale. A callback, a promise, a timer, a stashed lazy seq, a
+`delay` forced later — each raises
+`:rf.error/hicasso-sub-outside-render` and names the query. An unforced
+`delay` that crosses into a view's props raises
+`:rf.error/hicasso-deferred-read-at-boundary` at the crossing, before it can
+freeze a child. Hicasso never guesses which render owns a deferred read. The
 alternative is a value that looks correct on screen and never updates again,
 with no error to point to.
 
 ```clojure
 ;; Don't — a read deferred into a timer callback
 (js/setTimeout
-  #(export! (h/sub [:report/rows]))    ;; :rf.error/hicasso-sub-outside-render
+  #(export! (h/sub [:todo/rows]))    ;; :rf.error/hicasso-sub-outside-render
   1000)
 
 ;; Do — read during the render; close over the value
-(let [rows (h/sub [:report/rows])]
+(let [rows (h/sub [:todo/rows])]
   (js/setTimeout #(export! rows) 1000))
 ```
 
-The recovery always has the same shape: read during the render and close
-over the **value**, or move the work to the event layer. An event handler
-that needs current state declares that state as a coeffect with
-`:rf.cofx/requires`. The read then becomes part of the handler's contract,
-not a side effect in a body. There is no `@`-anywhere form and no second
-read form for free-standing code.
+The recovery always has the same shape: read during the render and close over
+the **value**, or move the work to the event layer. An event handler that
+needs current state declares that state as a coeffect with
+`:rf.cofx/requires`. The read then becomes part of the handler's contract, not
+a side effect in a body. There is no `@`-anywhere form and no second read form
+for free-standing code.
 
-!!! warning "The one escape that does not refuse"
+!!! warning "The one escape that does not throw"
     A read parked in a mutable reference and forced inside another body raises
-    nothing: a body *is* rendering there, just not the one that wrote the read.
-    The page paints, and the read is filed under the
-    [boundary](glossary.md#boundary) that forced the thunk rather than the one
-    that authored it. That boundary keeps every edge it made itself; what it
-    gains is a stranger's — an edge to a cell it does not display and now
-    re-renders on. The runtime does not chase reads through mutable
-    references, so this is undefined conduct rather than a refusal, and yours
-    to avoid; the recovery is the section's own.
+    nothing: a body *is* rendering there, just not the one that wrote the
+    read. The page paints, and the read is tracked by the view that forced
+    the thunk rather than the one that authored it. That view keeps every
+    dependency it made itself; what it gains is a stranger's — a subscription
+    to a cell it does not display and now re-renders on. The runtime does not
+    chase reads through mutable references, so this is undefined conduct
+    rather than a named error, and yours to avoid.
 
     ```clojure
     ;; Don't — the thunk is parked in an atom, and whichever body forces it
     ;; is the one that owns the read
-    (reset! !later #(h/sub [:report/rows]))   ;; no refusal, and no error to point to
+    (reset! !later #(h/sub [:todo/rows]))   ;; no error to point to
     ```
 
-## How `h/sub` tracks reads
+## How tracking works
 
-There are four operational claims:
+Four operational facts:
 
-1. Each [boundary](glossary.md#boundary) opens one collection window for the duration of its body.
-   The commit installs **exactly** the edge set that the body made. A branch
-   not taken contributes no edge.
+1. Each view records exactly the subscriptions its body made on that render.
+   A branch not taken contributes nothing.
 2. Framework subscriptions — machine tags, resource status, route identity —
-   read identically to your own subscriptions. They are rows in the same
-   index, not special cases.
-3. Sub-key identity is `(query-id, args)` under **value equality**. A
-   rebuilt `{:scope :all}` inside the body hits the same cache entry on
-   every render: two structurally equal persistent values are one key. Two
-   argument kinds cause constant re-creation: an argument whose value
-   changed (a timestamp), and an argument that carries reference identity (a
-   function, a JS object). For those, `=` is identity.
-4. The edge set is a function of what the body *did*. A body whose taken
+   read the same way as your own. They are rows in the same index.
+3. Sub-key identity is `(query-id, args)` under **value equality**. A rebuilt
+   `{:scope :all}` inside the body hits the same cache entry on every render:
+   two structurally equal persistent values are one key. Two argument kinds
+   cause constant re-creation: an argument whose value changed (a timestamp),
+   and an argument that uses reference identity (a function, a JS object).
+   For those, `=` is identity.
+4. The recorded set is a function of what the body *did*. A body whose taken
    branches change re-subscribes the whole set, not only the changed key.
    Dynamic reads are legal; a whole-set refresh is their price.
 
@@ -326,38 +311,38 @@ There are four operational claims:
 | Symptom | Error | Fix |
 |---|---|---|
 | A read after the render throws, naming the query | `:rf.error/hicasso-sub-outside-render` | Read during the render; close over the value. Handlers declare state with `:rf.cofx/requires` |
-| An unforced `delay` in props refuses at the [boundary](glossary.md#boundary) | `:rf.error/hicasso-deferred-read-at-boundary` | Hand a function, or force the delay in your own body |
-| A plain `defn` in head position throws | `:rf.error/hicasso-bad-head` | Call it — `(row-icon …)` — or mint it with [`h/defview`](glossary.md#defview) |
-| Calling a view directly throws, naming the view | refusal at the call site | Write the head: `[todo-row {:id 7}]` |
+| An unforced `delay` in props throws at the view | `:rf.error/hicasso-deferred-read-at-boundary` | Hand a function, or force the delay in your own body |
+| A plain `defn` in head position throws | `:rf.error/hicasso-bad-head` | Call it — `(row-icon …)` — or define it with `h/defview` |
+| Calling a view directly throws, naming the view | throws at the call site | Write the head: `[todo-row {:id 7}]` |
 | Console warns about a missing key, naming view and child | `:rf.warning/hicasso-missing-key` | Put `:key` in each member's props map; `^{:key}` metadata is not read ([Lists and collections](06-lists-and-collections.md) owns key quality) |
 | First render throws naming a query id | `:rf.error/no-such-sub` | Registration happens on namespace load; require the subs namespace at boot |
-| Boundary re-renders although props look unchanged | none — bail-out defeated | A prop carries reference identity (inline `fn`, JS object). Hoist it, or pass a persistent value |
-| One cell changes and 300 boundaries re-render | none — reads live too high | Push the read down into the boundary that displays it |
+| View re-renders although props look unchanged | none — bail-out defeated | A prop uses reference identity (inline `fn`, JS object). Hoist it, or pass a persistent value |
+| One cell changes and 300 views re-render | none — reads live too high | Push the read down into the view that displays it |
 | A body's side effect fires twice in development | none — StrictMode double-invoke | Bodies are pure; move the effect out |
 | Subscriptions constantly re-created | none — args not value-stable | Make query args `=` between renders; fresh-but-equal persistent values are fine |
 
-## When not to mint a boundary
+## When not to create a view
 
 Not every function needs to be a view. If markup has no reads of its own and
 always re-renders with its parent, a plain function is cheaper and simpler.
-Mint a [boundary](glossary.md#boundary) when you want a part of the tree to update independently,
-not because the markup became long. When a measured hot region outgrows
-boundary tuning — the ~2% case, not the default 98% — the escape ladder in
+Create a boundary when you want a part of the tree to update independently,
+not because the markup became long. When a measured hot region outgrows view
+tuning — the ~2% case, not the default 98% — the escape ladder in
 [Performance](18-performance.md) owns the next step.
 
 ## Advanced
 
 ### The collector
 
-The mechanism behind the four operational claims is one fixed runtime hook
-per [boundary](glossary.md#boundary). The hook opens a collection window for the duration of the
-body. The claims imply two more facts. First, abandoned renders install
-nothing: the render probes reads, and the commit owns them, so a render that
-React retries or discards leaves no subscriptions behind. Second, reads
-inside lazy seqs land correctly, because the hiccup-to-element pass forces
-them while the window is open, not later when other code walks the seq.
+The mechanism behind the four operational facts is one fixed runtime hook per
+view. The hook opens a collection window for the duration of the body.
+Abandoned renders install nothing: the render probes reads, and the commit
+owns them, so a render that React retries or discards leaves no subscriptions
+behind. Reads inside lazy seqs land correctly because the Hiccup-to-element
+pass forces them while the window is open, not later when other code walks the
+seq.
 
-An escaped read fails loudly by design. A closed-over [`h/sub`](glossary.md#hsub) call site
-(rather than its value), a stashed unforced seq, or a `delay` forced after
-the render — each fails and names the query, because the collector can no
-longer say which boundary owns the read.
+An escaped read fails loudly by design. A closed-over `h/sub` call site
+(rather than its value), a stashed unforced seq, or a `delay` forced after the
+render — each fails and names the query, because the collector can no longer
+say which view owns the read.

--- a/docs/design/hicasso/draft-guide/03-events-as-data.md
+++ b/docs/design/hicasso/draft-guide/03-events-as-data.md
@@ -3,37 +3,35 @@
 With reads in place from [Views and reads](02-views-and-reads.md), this page
 makes handlers data so trees stay inspectable.
 
-Handler attributes are the place where a data-oriented view layer usually
-stops being data. You write pure data down the whole tree. Then `:on-click`
-needs a function, so you write `#(rf/dispatch [:todo/toggle id])`. That node
-stops being inspectable, comparable, or assertable by equality.
+Handler attributes are where a data-oriented view layer usually stops being
+data. You write pure data down the whole tree. Then `:on-click` needs a
+function, so you write `#(rf/dispatch [:todo/toggle id])`. That node stops
+being inspectable, comparable, or assertable by equality.
 
-> **Put the event vector in the attribute.** The runtime builds the callback.
+Put the event vector in the attribute. The runtime creates the callback.
 
 ```clojure
 [:button {:on-click [:todo/toggle id]} "✓"]
 ```
 
-This is not syntactic sugar for a closure that you could write yourself. The
-tree still holds data at that node, so a test asserts the node with `=`, and
-a tool reads it off the tree. When the user clicks the button, the runtime
-dispatches the vector into the re-frame2 frame owned by the rendering
-[boundary](glossary.md#boundary) (the independently re-rendering view that
-produced this hiccup). The runtime built that callback at render, and the
-callback carries the frame with it.
+The tree still holds data at that node, so a test asserts the node with `=`,
+and a tool reads it off the tree. When the user clicks the button, the runtime
+dispatches the vector into the re-frame2 frame owned by the rendering view.
+The runtime built that callback at render, and the callback includes the frame
+so the later click still has context.
 
-[Lowering](glossary.md#lowering) — the step that turns an attribute into a React prop — works by
-shape, not by a roster. Any prop whose name is `on-` plus a letter is an
-event position. CamelCase `onClick` also works, for the migrating author.
-There is no list of approved event names to keep in step with the DOM. An
-event vector at an event position is an **[intent](glossary.md#intent)**: the meaning of the
-interaction, stated as data. That is the word this guide uses for it.
+Any prop whose name is `on-` plus a letter is an event position. CamelCase
+`onClick` also works, for the migrating author. There is no list of approved
+event names to keep in step with the DOM. An event vector at an event position
+is an **[intent](glossary.md#intent)**: the meaning of the interaction, stated
+as data. That is the word this guide uses for it.
 
-## The value vocabulary
+## Value markers
 
 Most handlers need a value out of the event. The runtime substitutes two
-reserved words, [`::h/value`](glossary.md#hvalue) and [`::h/checked`](glossary.md#hchecked), at dispatch time with the
-event target's `.value` and `.checked`:
+reserved words, [`::h/value`](glossary.md#hvalue) and
+[`::h/checked`](glossary.md#hchecked), at dispatch time with the event
+target's `.value` and `.checked`:
 
 ```clojure
 [:input {:value    (h/sub [:todo.ui/draft id])
@@ -46,75 +44,76 @@ event target's `.value` and `.checked`:
 
 At dispatch, the handler receives `[:todo.ui/edit 7 "milk"]` or
 `[:todo/set-done 7 true]`. These are ordinary event vectors, the same as
-vectors that you dispatch by hand. Substitution happens at the [intent](glossary.md#intent)
-vector's top level only. The runtime does not look for a marker in nested
-structure. If the vector has no marker, the runtime never peeks at the DOM event — so
+vectors that you dispatch by hand. Substitution happens at the intent vector's
+top level only. The runtime does not look for a marker in nested structure. If
+the vector has no marker, the runtime never peeks at the DOM event — so
 nothing is substituted, and nothing is read "for free."
 
-These two words, plus [`::h/prevent`](glossary.md#hprevent) below and [`::h/revision`](glossary.md#hrevision)
+These two words, plus [`::h/prevent`](glossary.md#hprevent) below and
+[`::h/revision`](glossary.md#hrevision)
 ([Controlled inputs](04-controlled-inputs.md)), are the entire reserved
-vocabulary. For the full controlled round-trip — value in from a
-subscription, intent out, caret and same-turn echo — see
+vocabulary. For the full controlled round-trip — value in from a subscription,
+intent out, caret and same-turn echo — see
 [Controlled inputs](04-controlled-inputs.md).
 
-## Prevention is explicit — one head
+## Prevention is explicit
 
 Nothing auto-prevents — not a click, and not a form submit. Prevention is a
-decision. The decision travels **as data**, in the [intent](glossary.md#intent) itself:
+decision. The decision travels **as data**, in the intent itself:
 
 ```clojure
-[:form {:on-submit [::h/prevent [:signup/submit]]}
- [:input {:value    (h/sub [:signup/email])
-          :on-input [:signup/set-email ::h/value]}]
- [:button {:type :submit} "Sign up"]]
+[:form {:on-submit [::h/prevent [:todo/submit]]}
+ [:input {:value    (h/sub [:todo.ui/draft])
+          :on-input [:todo.ui/set-draft ::h/value]}]
+ [:button {:type :submit} "Add todo"]]
 ```
 
 `[::h/prevent INTENT]` prevents the browser default and dispatches the inner
-[intent](glossary.md#intent). The same head serves an anchor that acts as a button — the feed tab,
-the tag pill. An unconditional default *cannot* exist there, because a
-modifier-click on a real link must still open a tab:
+intent. The same head serves an anchor that acts as a button — a tab or a tag
+pill. An unconditional default *cannot* exist there, because a modifier-click
+on a real link must still open a tab:
 
 ```clojure
-[:a.nav-link {:href "#" :on-click [::h/prevent [:feed/show-yours]]}
- "Your Feed"]
+[:a.nav-link {:href "#" :on-click [::h/prevent [:todo/filter-active]]}
+ "Active"]
 ```
 
-!!! warning "A bare [intent](glossary.md#intent) at `:on-submit` still submits"
-    `{:on-submit [:signup/submit]}` dispatches your intent **and** lets the
-    browser navigate. There is no submit special case. If the page reloads
-    on submit, the [`::h/prevent`](glossary.md#hprevent) head is missing. The rare form that wants a
-    real browser submission omits the head.
+!!! warning "A bare intent at `:on-submit` still submits"
+    `{:on-submit [:todo/submit]}` dispatches your intent **and** lets the
+    browser navigate. There is no submit special case. If the page reloads on
+    submit, the [`::h/prevent`](glossary.md#hprevent) head is missing. The rare
+    form that wants a real browser submission omits the head.
 
 The shape is fixed: exactly one inner intent vector. That inner vector is what
 actually gets dispatched. Two payloads, a keyword instead of a vector, a
 decorator inside a decorator — each is
-`:rf.error/hicasso-malformed-prevent`. The error names the attribute and
-fires at render time, not at the click. Markers still work inside the head:
-`[::h/prevent [:filter/set ::h/value]]` prevents and substitutes, because
-the runtime unwraps the decorator before it looks for the markers.
+`:rf.error/hicasso-malformed-prevent`. The error names the attribute and fires
+at render time, not at the click. Markers still work inside the head:
+`[::h/prevent [:filter/set ::h/value]]` prevents and substitutes, because the
+runtime unwraps the decorator before it looks for the markers.
 
 The prevent form is a head, not metadata on the vector, for one reason:
-**metadata does not participate in `=`**. An annotation would be invisible
-to a structural test that compares the tree, to `pr-str`, and to any code
-that hashes the intent. A head is visible to all three.
+**metadata does not participate in `=`**. An annotation would be invisible to
+a structural test that compares the tree, to `pr-str`, and to any code that
+hashes the intent. A head is visible to all three.
 
-## `h/event`: value-first and calculated events
+## `h/event`: when you need the callback arguments
 
 Sometimes you must read the callback's arguments before you know what to
 dispatch. Examples: a file list, a drag payload, a foreign component that
-calls `(on-change date)` with no DOM event. [`h/event`](glossary.md#hevent) is the one explicit
-event-producing form:
+calls `(on-change date)` with no DOM event. [`h/event`](glossary.md#hevent) is
+the one explicit event-producing form:
 
 ```clojure
 [:input {:type      "file"
          :on-change (h/event [e]
-                      [:upload/picked (js/Array.from (.. e -target -files))])}]
+                      [:todo/attach (js/Array.from (.. e -target -files))])}]
 ```
 
 Its contract has three clauses, and they hold in **every** position:
 
 - It **captures the frame at the place where you write it**. Inside a view
-  body, that is the rendering [boundary](glossary.md#boundary)'s frame.
+  body, that is the rendering view's frame.
 - When the invoker calls it later, it receives **every argument that the
   invoker passes, in order**: one DOM event at a native position,
   `(date event)` from a value-first library — whatever the caller's contract
@@ -126,28 +125,28 @@ Its contract has three clauses, and they hold in **every** position:
 [:div {:on-drop (h/event [e]
                   (.preventDefault e)
                   (when-let [f (aget (.. e -dataTransfer -files) 0)]
-                    [:upload/dropped (.-name f)]))}]
+                    [:todo/attach-dropped (.-name f)]))}]
 ```
 
-The meaning never varies by position. An [`h/event`](glossary.md#hevent) given to a [`h/defhost`](glossary.md#defhost)
-callback, retained by a vendor SDK, or placed in a raw `#js` prop does the
-same thing: it runs, it can return a vector, and the runtime dispatches that
-vector to the frame it captured. Prevention inside an [`h/event`](glossary.md#hevent) is your
-task: the function holds the event, so it calls `.preventDefault` itself, as
-the drop example does.
+The meaning never varies by position. An `h/event` given to a
+[`h/defhost`](glossary.md#defhost) callback, retained by a vendor SDK, or
+placed in a raw `#js` prop does the same thing: it runs, it can return a
+vector, and the runtime dispatches that vector to the frame it captured.
+Prevention inside an `h/event` is your task: the function holds the event, so
+it calls `.preventDefault` itself, as the drop example does.
 
-**The vector spelling is event-first; [`h/event`](glossary.md#hevent) is not.** [`::h/value`](glossary.md#hvalue),
-[`::h/checked`](glossary.md#hchecked), and [`::h/prevent`](glossary.md#hprevent) all read the DOM event, and they read it
-from argument one. Every native position and every event-first foreign
-contract puts the event there. A value-first invoker, such as a date
-picker's `(on-change date)`, has no event at argument one. Nothing guesses
-which argument might be an event. The [intent](glossary.md#intent) refuses with
+**The vector spelling is event-first; `h/event` is not.** `::h/value`,
+`::h/checked`, and `::h/prevent` all read the DOM event, and they read it from
+argument one. Every native position and every event-first foreign contract
+puts the event there. A value-first invoker, such as a date picker's
+`(on-change date)`, has no event at argument one. Nothing guesses which
+argument might be an event. The intent raises
 `:rf.error/hicasso-intent-needs-the-event`. The error names the position and
-points to [`h/event`](glossary.md#hevent), the spelling that sees the library's own arguments in
+points to `h/event`, the spelling that sees the library's own arguments in
 order:
 
 ```clojure
-(h/event [date _e] [:task/set-due date])
+(h/event [date _e] [:todo/set-due date])
 ```
 
 ## Ordinary functions still work
@@ -159,14 +158,14 @@ callback semantics: it runs, and the runtime ignores its return value:
 [:canvas {:on-pointer-move (fn [e] (draw! (.-clientX e) (.-clientY e)))}]
 ```
 
-Use an ordinary `fn` when the *work* is imperative and no [intent](glossary.md#intent) exists:
+Use an ordinary `fn` when the *work* is imperative and no intent exists:
 geometry, pointer capture, `stopPropagation`, an SDK's imperative call.
 Render props and slots on foreign components also take ordinary functions.
 They run during a foreign render, so they stay pure. A dispatch from inside
-one refuses with `:rf.error/hicasso-dispatch-in-render-position`
-([Interop](09-interop.md) owns that crossing). The intent vector is the
-taught default because it covers almost everything, not because functions
-are forbidden.
+one raises `:rf.error/hicasso-dispatch-in-render-position`
+([Interop](09-interop.md) owns that crossing). The intent vector is the taught
+default because it covers almost everything, not because functions are
+forbidden.
 
 An ordinary `fn` must not dispatch on its own:
 
@@ -180,13 +179,13 @@ An ordinary `fn` must not dispatch on its own:
 [:button {:on-click [:todo/toggle id]} "✓"]
 ```
 
-The [intent](glossary.md#intent) vector and [`h/event`](glossary.md#hevent) exist so that the runtime answers the frame
+The intent vector and `h/event` exist so that the runtime answers the frame
 question at render, once.
 
 ## Keyboard as data
 
-A [keyboard map](glossary.md#keyboard-map) is a data map from DOM `.key` string to
-[intent](glossary.md#intent) — not a `case` over `.-key`:
+A [keyboard map](glossary.md#keyboard-map) is a data map from DOM `.key` string
+to intent — not a `case` over `.-key`:
 
 ```clojure
 [:input {:value       (h/sub [:todo.ui/draft id])
@@ -197,38 +196,38 @@ A [keyboard map](glossary.md#keyboard-map) is a data map from DOM `.key` string 
 
 The names are strings. The runtime matches them against the DOM event's own
 `.key`, and it ignores keys that you do not list. There is no modifier
-language: a handler that needs `ctrl+Enter` reads the event with [`h/event`](glossary.md#hevent).
-Key maps are legal at **keyboard props only** (`:on-key-down`,
-`:on-key-up`). A map is not an [intent](glossary.md#intent) spelling anywhere else.
+language: a handler that needs `ctrl+Enter` reads the event with `h/event`.
+Key maps are legal at **keyboard props only** (`:on-key-down`, `:on-key-up`).
+A map is not an intent spelling anywhere else.
 
 The composition rule is explicit, and the runtime owns it. An IME (input
 method editor) composes text such as Japanese or Chinese from several
-keystrokes. **A key event that arrives during IME composition matches
-nothing in the map.** While a user composes, Enter selects a candidate; it
-is not a commit. Escape cancels the composition; it is not your cancel. A
-wrong hand-written check makes every user who composes lose a sentence. The
-map applies the correct check centrally, and it includes the legacy signals
-that some browsers still send (see [Advanced](#advanced)).
+keystrokes. **A key event that arrives during IME composition matches nothing
+in the map.** While a user composes, Enter selects a candidate; it is not a
+commit. Escape cancels the composition; it is not your cancel. A wrong
+hand-written check makes every user who composes lose a sentence. The map
+applies the correct check centrally, and it includes the legacy signals that
+some browsers still send (see [Advanced](#advanced)).
 
-## Callbacks carry their frame
+## Callbacks include their frame
 
-Every generated callback closes over its [boundary](glossary.md#boundary)'s frame. Intent vectors
-capture the frame at [lowering](glossary.md#lowering); [`h/event`](glossary.md#hevent) captures it at creation. This
-matters because the browser invokes callbacks long after the render that
-created them, when the render's extent is gone. A hand-written
-`#(rf/dispatch …)` raises `:rf.error/no-frame-context` from that gap. The
-data spellings do not, because the frame travelled with them.
+Every generated callback closes over its view's frame. Intent vectors capture
+the frame when the attribute is turned into a React prop; `h/event` captures
+it at creation. This matters because the browser invokes callbacks long after
+the render that created them, when the render's extent is gone. A hand-written
+`#(rf/dispatch …)` raises `:rf.error/no-frame-context` from that gap. The data
+spellings do not, because they closed over the frame.
 
-**Async work belongs in the event layer, which already has the frame.** A
-view that sets a timeout and dispatches when the timeout fires is a
-mis-layered effect. An fx handler receives the frame in its context, and
-`:dispatch-later` states the delay as data. Move the work to the event
-layer, and the frame question moves with it.
+**Async work belongs in the event layer, which already has the frame.** A view
+that sets a timeout and dispatches when the timeout fires is a mis-layered
+effect. An fx handler receives the frame in its context, and
+`:dispatch-later` states the delay as data. Move the work to the event layer,
+and the frame question moves with it.
 
 One case remains after that move: a dispatching closure that you give to **a
 caller you do not control** — an SDK attached through a ref, a library that
 calls back with a value. The frame is knowable during the render and nowhere
-else. Capture it there with core's one carry primitive:
+else. Capture it there with core's one capture primitive:
 
 ```clojure
 (ns app.map
@@ -237,52 +236,53 @@ else. Capture it there with core's one carry primitive:
             [app.sdk :as sdk]))
 
 (h/defview map-panel [{:keys [id]}]
-  (let [{:keys [dispatch]} (rf/capture-frame)]   ;; the rendering boundary's frame
+  (let [{:keys [dispatch]} (rf/capture-frame)]   ;; the rendering view's frame
     [:div.map
      {:ref (fn [node]                            ;; refs run after commit, not in render
              (when node
                (sdk/on-select node #(dispatch [:map/marker-selected id %]))))}]))
 ```
 
-Inside a [Hicasso](glossary.md#hicasso) body, `(rf/capture-frame)` resolves the [boundary](glossary.md#boundary)'s frame.
-It returns `{:frame :dispatch :dispatch-sync :subscribe}` locked to that
-frame. `(rf/current-frame-id)` returns the bare id when a foreign API wants
-one. These are core's frame doors; Hicasso adds no duplicate. (Ambient
-`rf/dispatch` and `rf/subscribe` stay refused in a body. The doors carry the
-frame; the ambient calls do not.) A captured handle is valid for the life of
-its frame's incarnation. If you destroy the frame and remount under the same
-id, an operation from the stale handle refuses with
+Inside a Hicasso body, `(rf/capture-frame)` resolves the view's frame. It
+returns `{:frame :dispatch :dispatch-sync :subscribe}` locked to that frame.
+`(rf/current-frame-id)` returns the bare id when a foreign API wants one.
+These are core's frame doors; Hicasso adds no duplicate. (Ambient
+`rf/dispatch` and `rf/subscribe` throw from a body. The capture doors include
+the frame; the ambient calls do not.) A captured handle is valid for
+the life of its frame's incarnation. If you destroy the frame and remount
+under the same id, an operation from the stale handle raises
 `:rf.error/frame-destroyed` and does not reach the successor frame. Capture
 from the live render, never from a stash.
 
-The general rule: **[intents](glossary.md#intent) are always safe; async work goes through `:fx`;
-a closure that crosses into foreign code carries `(rf/capture-frame)`.**
+The general rule: **intents are always safe; async work goes through `:fx`; a
+closure that crosses into foreign code captures `(rf/capture-frame)`.**
 
-One nearby case is not this chapter's case. An anchor that *navigates* is a
-[route link](glossary.md#route-link) from `re-frame.hicasso.routing`, not a hand-written `:on-click`.
+One nearby case is not this page's case. An anchor that *navigates* is a
+[route link](glossary.md#route-link) from `re-frame.hicasso.routing`, not a
+hand-written `:on-click`.
 [Routing and navigation](07-routing-and-navigation.md) owns it.
 
 ## Troubleshooting
 
 | Symptom | Error | Fix |
 |---|---|---|
-| Page navigates and reloads on form submit | none — nothing auto-prevents | Wrap the [intent](glossary.md#intent): `{:on-submit [::h/prevent [:signup/submit]]}` |
-| Refusal at render naming an event attribute | `:rf.error/hicasso-malformed-prevent` | `[::h/prevent INTENT]` wraps exactly one inner intent vector — no second payload, no nesting |
-| Handler receives the literal [`::h/value`](glossary.md#hvalue) keyword | none — marker below top level | Markers substitute at the vector's top level only; compute nested payloads in the handler, or read the event with [`h/event`](glossary.md#hevent) |
-| A foreign callback refuses a marker-carrying intent | `:rf.error/hicasso-intent-needs-the-event` | The invoker is value-first — no DOM event at argument one. Use [`h/event`](glossary.md#hevent), which receives every argument in order |
-| Dispatch from a timeout or interval throws | `:rf.error/no-frame-context` | Own the async work in an fx handler (`:dispatch-later`); a closure handed to foreign code carries `(rf/capture-frame)` from the body |
+| Page navigates and reloads on form submit | none — nothing auto-prevents | Wrap the intent: `{:on-submit [::h/prevent [:todo/submit]]}` |
+| Throws at render naming an event attribute | `:rf.error/hicasso-malformed-prevent` | `[::h/prevent INTENT]` wraps exactly one inner intent vector — no second payload, no nesting |
+| Handler receives the literal `::h/value` keyword | none — marker below top level | Markers substitute at the vector's top level only; compute nested payloads in the handler, or read the event with `h/event` |
+| A foreign callback rejects a marker-carrying intent | `:rf.error/hicasso-intent-needs-the-event` | The invoker is value-first — no DOM event at argument one. Use `h/event`, which receives every argument in order |
+| Dispatch from a timeout or interval throws | `:rf.error/no-frame-context` | Own the async work in an fx handler (`:dispatch-later`); a closure handed to foreign code captures `(rf/capture-frame)` from the body |
 | Enter commits half-typed Japanese text | none — hand-rolled key handling | Use the `:on-key-down` map; composition is centralised there |
 | An intent fires but no handler runs | `:rf.error/no-such-handler` | Registration happens on namespace load; require the handlers namespace at boot |
-| A vector at a declared host callback refuses | `:rf.error/hicasso-intent-at-a-non-event-contract` | That position's declared contract does not dispatch; give it the value its contract asks for ([Interop](09-interop.md)) |
-| A render prop that dispatches refuses | `:rf.error/hicasso-dispatch-in-render-position` | Render props are pure output; move the dispatch to an event position ([Interop](09-interop.md)) |
+| A vector at a declared host callback is rejected | `:rf.error/hicasso-intent-at-a-non-event-contract` | That position's declared contract does not dispatch; give it the value its contract asks for ([Interop](09-interop.md)) |
+| A render prop that dispatches is rejected | `:rf.error/hicasso-dispatch-in-render-position` | Render props are pure output; move the dispatch to an event position ([Interop](09-interop.md)) |
 
 ## When not to use an intent
 
-Do not use an [intent](glossary.md#intent) when you need the event object itself and no dispatch:
+Do not use an intent when you need the event object itself and no dispatch:
 pointer coordinates, `dataTransfer`, `stopPropagation`, a DOM measurement.
 Those cases take ordinary functions, and an ordinary function is not a
-failure. Use [`h/event`](glossary.md#hevent) when you want to read the arguments *and* dispatch.
-Use a plain `fn` when you want to read the arguments and do other work.
+failure. Use `h/event` when you want to read the arguments *and* dispatch. Use
+a plain `fn` when you want to read the arguments and do other work.
 
 ## Advanced
 
@@ -290,12 +290,12 @@ Use a plain `fn` when you want to read the arguments and do other work.
 
 The composition gate lives in the runtime, not in your view, because the
 correct check is easy to get wrong in two ways. First, the signal is split.
-Modern browsers set `isComposing` on the keyboard event, but some
-IME/browser pairs only send the legacy `keyCode` 229, which means "this
-keystroke belongs to the IME". The gate honours both signals. Second, the
-signal is on the **native** event. React's synthetic keyboard event drops
-`isComposing`. A hand-written handler that reads the synthetic object sees
-`undefined`, and it commits a candidate-selection Enter as a submit. That is
-silent data loss for every user who composes. The map therefore answers one
-question — "was this keystroke the user's or the IME's?" — once, centrally,
-and it matches nothing while composition is active.
+Modern browsers set `isComposing` on the keyboard event, but some IME/browser
+pairs only send the legacy `keyCode` 229, which means "this keystroke belongs
+to the IME". The gate honours both signals. Second, the signal is on the
+**native** event. React's synthetic keyboard event drops `isComposing`. A
+hand-written handler that reads the synthetic object sees `undefined`, and it
+commits a candidate-selection Enter as a submit. That is silent data loss for
+every user who composes. The map therefore answers one question — "was this
+keystroke the user's or the IME's?" — once, centrally, and it matches nothing
+while composition is active.

--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -1,12 +1,13 @@
 # Controlled inputs
 
 Intents and markers from [Events as data](03-events-as-data.md) are enough for
-buttons. A text field that is *controlled* by app-db has a harder job: every
-keystroke is a full round trip, and the usual bugs are dropped characters, a
-caret that jumps to the end, IME compositions destroyed mid-word, and
-rejections that never show. [Hicasso](glossary.md#hicasso) treats that path as a
-[framework law](glossary.md#controlled-field). You write ordinary `:value` and
-`:on-input`; the runtime keeps the round trip inside one browser turn.
+buttons. A text field controlled by app-db has a harder job: every keystroke
+is a full round trip, and the usual bugs are dropped characters, a caret that
+jumps to the end, IME compositions destroyed mid-word, and rejections that
+never show. Hicasso centralises that path as a
+[controlled-field law](glossary.md#controlled-field). You write ordinary
+`:value` and `:on-input`; the runtime keeps the round trip inside one browser
+turn.
 
 ```clojure
 (h/defview title-field [{:keys [id]}]
@@ -15,20 +16,18 @@ rejections that never show. [Hicasso](glossary.md#hicasso) treats that path as a
            :on-input [:todo.ui/edit id ::h/value]}])
 ```
 
-> **You write ordinary `:value` and `:on-input`, with no caret helper and no
-> local atom.**
-
-`:on-change` works the same way. If a field carries both, both can fire, and
+You write ordinary `:value` and `:on-input`, with no caret helper and no local
+atom. `:on-change` works the same way. If a field has both, both can fire, and
 the runtime converges once. For checkboxes, use
-[`::h/checked`](glossary.md#hchecked) the same way — the placeholders and
-the key map are taught in [Events as data](03-events-as-data.md).
+[`::h/checked`](glossary.md#hchecked) the same way — the placeholders and the
+key map are taught in [Events as data](03-events-as-data.md).
 
 ## What the law guarantees
 
 The value on screen is app-db state, so every keystroke is a round trip:
-keystroke → dispatch → handler → commit → subscription → re-render → DOM value.
-The framework keeps that whole path **inside the same browser turn**. Because
-of this, four guarantees hold without any code from you:
+keystroke → dispatch → handler → commit → subscription → re-render → DOM
+value. The framework keeps that whole path **inside the same browser turn**.
+Because of this, four guarantees hold without any code from you:
 
 1. **Same-turn echo.** Dispatch runs synchronously inside the discrete browser
    event. The commit's echo is back in the field before the browser finishes
@@ -43,37 +42,36 @@ of this, four guarantees hold without any code from you:
    and any live composition.
 4. **Composition is safe.** An Enter during composition selects an IME
    candidate and commits nothing. A live composition is never overwritten
-   while it runs. A refusal or normalization lands whole when the composition
-   ends.
+   while it runs. A rejection or normalization lands whole when the
+   composition ends.
 
-Rejection uses the same path as acceptance. Return `nil` from the handler,
-and the field stays on the model value with the caret intact. You do not
-write special rejection code in the view:
+Rejection uses the same path as acceptance. Return `nil` from the handler, and
+the field stays on the model value with the caret intact. You do not write
+special rejection code in the view:
 
 ```clojure
-(rf/reg-event :order/set-quantity
+(rf/reg-event :todo.ui/set-qty
   (fn [{:keys [db]} [_ id typed]]
     (if (re-matches #"\d*" typed)
-      {:db (assoc-in db [:orders id :qty] typed)}
+      {:db (assoc-in db [:todo id :qty] typed)}
       nil)))                                       ;; rejected — model unchanged
 ```
 
 Two smaller clauses complete the law. Controlled means the model owns the
 screen value at every commit. So foreign drift — autofill, a browser
 extension, a script that writes `.value` — is repaired the next time the
-element commits. Events that land after unmount find nothing. A blur
-delivered to a field that has just left the tree is a no-op, with zero
-residue.
+element commits. Events that land after unmount find nothing. A blur delivered
+to a field that has just left the tree is a no-op, with zero residue.
 
-Every keystroke on a [controlled field](glossary.md#controlled-field) is a full pipeline run: state write,
-subscription recomputation, [boundary](glossary.md#boundary) run, React commit, painted echo. The
+Every keystroke on a controlled field is a full pipeline run: state write,
+subscription recomputation, view run, React commit, painted echo. The
 [performance chapter](18-performance.md) publishes that path, with counts for
 the four-field editor and the controlled grid. This page owns the law; that
 page owns the cost.
 
 ??? info "If you come from Reagent"
     The usual Reagent pattern wraps an input in a local ratom, so that async
-    rendering cannot drop keystrokes or move the caret. Do not carry that
+    rendering cannot drop keystrokes or move the caret. Do not bring that
     pattern here. The controlled path is synchronous end to end, and the
     runtime owns caret and composition. A local atom adds nothing, and it
     re-creates the twin-atom stack that the [forms module](05-forms.md)
@@ -95,20 +93,20 @@ platform gives you a value:
 | `:input` file | none — the platform owns a file input's value | `:on-change` with [`h/event`](glossary.md#hevent), reading `.files` off the event |
 
 ```clojure
-[:select {:value     (h/sub [:cart/shipping])
-          :on-change [:cart/set-shipping ::h/value]}
- [:option {:value "standard"} "Standard"]
- [:option {:value "express"}  "Express"]]
+[:select {:value     (h/sub [:todo.ui/priority])
+          :on-change [:todo.ui/set-priority ::h/value]}
+ [:option {:value "normal"} "Normal"]
+ [:option {:value "urgent"} "Urgent"]]
 
 [:input {:type      :checkbox
-         :checked   (h/sub [:cart/gift-wrap?])
-         :on-change [:cart/set-gift-wrap ::h/checked]}]
+         :checked   (h/sub [:todo/done? id])
+         :on-change [:todo/set-done id ::h/checked]}]
 ```
 
-A control that is *not* on the list refuses instead of half-working. A
-contenteditable region is the named refusal. It has no single true value for
-the controlled contract to converge on, so a `:value` binding on it refuses
-at source. The recovery is real: rich text is a job for a
+A control that is *not* on the list is rejected instead of half-working. A
+contenteditable region is the named case. It has no single true value for the
+controlled contract to converge on, so a `:value` binding on it throws at
+source. The recovery is real: rich text is a job for a
 [declared host](09-interop.md) or a [named native island](10-native-tier.md),
 where the editor library owns the DOM that it must own.
 
@@ -122,53 +120,53 @@ entries last:
 (h/defview field [{:keys [id busy?] :as attrs}]
   [:input.form-control
    (merge (dissoc attrs :id :busy?)
-          {:value    (h/sub [:editor/field id])
+          {:value    (h/sub [:todo.ui/field id])
            :disabled busy?
-           :on-input [:editor/edit-field id ::h/value]})])
+           :on-input [:todo.ui/edit-field id ::h/value]})])
 
-[field {:id :title :busy? busy? :type "text" :placeholder "Article Title"}]
+[field {:id :title :busy? busy? :type "text" :placeholder "Todo title"}]
 ```
 
 **The literal keys you write always win.** The law binds on the React slot
 where a key lands, not on its spelling. A forwarded `:onInput` against your
-`:on-input`, or `"value"` against your `:value`, reaches nothing that
-matters. A forwarded map can never replace the owned value, checked, handler,
-key, or revision slots of a control. When you *want* a caller's value to win,
-do not write your literal. Put the element's own classes on the tag
-(`[:input.form-control …]`). Never forward `:key` or [`::h/revision`](glossary.md#hrevision): these
-keys address the element *you* wrote, and the runtime reads them only from
-the map you wrote.
+`:on-input`, or `"value"` against your `:value`, reaches nothing that matters.
+A forwarded map can never replace the owned value, checked, handler, key, or
+revision slots of a control. When you *want* a caller's value to win, do not
+write your literal. Put the element's own classes on the tag
+(`[:input.form-control …]`). Never forward `:key` or
+[`::h/revision`](glossary.md#hrevision): these keys address the element *you*
+wrote, and the runtime reads them only from the map you wrote.
 
 ## Resets are by revision, never by value
 
-To force a field back to a value — a form reset, a revert, a
-server-normalized write that comes back — is a real [intent](glossary.md#intent), and it has its
-own door: an **explicit revision** from the caller. The runtime never infers
-a reset from a comparison of the incoming value with a target. With a
-value-equality reset, a user who types the "reset" value loses the edit in
-progress. Also, a same-value reassertion (the caller rejects a draft and
-restores the old value) becomes invisible.
+To force a field back to a value — a form reset, a revert, a server-normalized
+write that comes back — is a real intent, and it has its own door: an
+**explicit revision** from the caller. The runtime never infers a reset from a
+comparison of the incoming value with a target. With a value-equality reset, a
+user who types the "reset" value loses the edit in progress. Also, a
+same-value reassertion (the caller rejects a draft and restores the old value)
+becomes invisible.
 
-[`::h/revision`](glossary.md#hrevision) is that one door. The view reads it like any other value,
-beside `:value`:
+[`::h/revision`](glossary.md#hrevision) is that one door. The view reads it like
+any other value, beside `:value`:
 
 ```clojure
 (h/defview revertable-field [{:keys [id]}]
   [:input {:type        :text
-           :value       (h/sub [:editor/field id])
-           ::h/revision (h/sub [:editor/baseline id])
-           :on-input    [:editor/edit-field id ::h/value]}])
+           :value       (h/sub [:todo.ui/field id])
+           ::h/revision (h/sub [:todo.ui/baseline id])
+           :on-input    [:todo.ui/edit-field id ::h/value]}])
 ```
 
 The revert event does both halves: it restores the value **and** moves the
-revision. A `[:button {:on-click [:editor/revert id]} "Revert"]` fires it:
+revision. A `[:button {:on-click [:todo.ui/revert id]} "Revert"]` fires it:
 
 ```clojure
-(rf/reg-event :editor/revert
+(rf/reg-event :todo.ui/revert
   (fn [{:keys [db]} [_ id]]
     {:db (-> db
-             (assoc-in [:editor :fields id] (get-in db [:editor :saved id]))
-             (update-in [:editor :baselines id] inc))}))   ;; the revision moves
+             (assoc-in [:todo.ui :fields id] (get-in db [:todo.ui :saved id]))
+             (update-in [:todo.ui :baselines id] inc))}))   ;; the revision moves
 ```
 
 **Only a revision change resets.** A `:value` that moves under an unchanged
@@ -181,25 +179,24 @@ the user has started to type again.
 
 **A reset is not a remount.** The draft in the field goes. The node itself
 stays, and the focus on it stays. The caret lands at the end of the model
-value on the commit that carries the reset. That is the platform's own
+value on the commit that applies the reset. That is the platform's own
 conduct for a `value` assignment.
 
 !!! warning "Write a revision the way you would write an instance key"
-    A revision minted in render changes on every render, so it resets the
+    A revision created in render changes on every render, so it resets the
     field on every render. Never use a render-order index, a counter that the
     body increments, or `random-uuid`. A revision is a domain fact that your
-    *events* put in app-db: a record id, a load generation, a "form opened
-    at" stamp, or a counter that your revert handler increments.
+    *events* put in app-db: a record id, a load generation, a "form opened at"
+    stamp, or a counter that your revert handler increments.
 
-The runtime refuses the prop loudly on anything that is not controlled text —
-a `:div`, a `select`, a value-less checkbox, an input with no `:value`. The
-refusal is `:rf.error/hicasso-revision-not-controlled`, and it names the
-element and the source. The runtime never reads the prop from a forwarded
-map, so a caller cannot force a re-baseline on a field whose author did not
-write one. The prop never reaches the DOM as an attribute, on the client or
-on the server.
+The runtime raises `:rf.error/hicasso-revision-not-controlled` on anything that
+is not controlled text — a `:div`, a `select`, a value-less checkbox, an input
+with no `:value`. The error names the element and the source. The runtime never
+reads the prop from a forwarded map, so a caller cannot force a re-baseline on
+a field whose author did not write one. The prop never reaches the DOM as an
+attribute, on the client or on the server.
 
-This is the single prop and nothing more: no commit or cancel [intents](glossary.md#intent), no
+This is the single prop and nothing more: no commit or cancel intents, no
 acknowledgement that a reset landed, no caret-policy options. When you want
 draft-and-commit behavior — free edits, commit on Enter or blur, cancel on
 Escape — use the [forms module](05-forms.md). The module *consumes* this
@@ -211,13 +208,13 @@ trigger; it does not extend it.
 |---|---|---|
 | Characters drop when typing fast | Something async sat between keystroke and commit — debounce, `setTimeout`, a queued effect | Keep the controlled write synchronous; debounce *consumers* of the value, not the write itself |
 | Caret jumps to the end on every keystroke | Value reasserted without caret preservation | Runtime bug, not your view — report it |
-| Enter commits half-typed text mid-composition | A hand-written key handler bypassed the [intent](glossary.md#intent) path | Use the data key map ([Events as data](03-events-as-data.md)); the composition check lives there |
-| Composition dies when the model refuses mid-draft | On the controlled path this cannot happen — composition is left alone until it ends. Something else wrote the field: a ref, a foreign script, an uncontrolled sibling | Find the second writer; the controlled element must have one |
+| Enter commits half-typed text mid-composition | A hand-written key handler bypassed the intent path | Use the data key map ([Events as data](03-events-as-data.md)); the composition check lives there |
+| Composition dies when the model rejects mid-draft | On the controlled path this cannot happen — composition is left alone until it ends. Something else wrote the field: a ref, a foreign script, an uncontrolled sibling | Find the second writer; the controlled element must have one |
 | An IME commit lands stale text, then corrects itself | Something async sat between keystroke and commit, so the composition's close reconciled against a model the deferred write had not reached | Keep the controlled write synchronous; the composition survives either way — only what it commits is late |
-| Typing the "reset" value clears the field | A reset keyed on value equality somewhere in your code | Move [`::h/revision`](glossary.md#hrevision); a value comparison is not a reset |
-| The field resets on every render | A revision minted in render — `random-uuid`, a render-order index, a counter the body increments | Read a revision your *events* wrote into app-db |
-| The field never resets, and devtools shows a `revision="…"` attribute | A bare `:revision`. The match is the exact namespaced keyword. Every other spelling flows through as an ordinary attribute, silently. A namespaced value loses its namespace on the way, so two distinct revisions can collapse to one | Write [`::h/revision`](glossary.md#hrevision) |
-| `:rf.error/hicasso-revision-not-controlled` at render | [`::h/revision`](glossary.md#hrevision) on something that is not controlled text — a `:div`, a `:select`, a value-less checkbox | Put the revision on the controlled `input`/`textarea` whose draft it re-baselines; a select or checkbox resets by writing the model |
+| Typing the "reset" value clears the field | A reset keyed on value equality somewhere in your code | Move `::h/revision`; a value comparison is not a reset |
+| The field resets on every render | A revision created in render — `random-uuid`, a render-order index, a counter the body increments | Read a revision your *events* wrote into app-db |
+| The field never resets, and devtools shows a `revision="…"` attribute | A bare `:revision`. The match is the exact namespaced keyword. Every other spelling flows through as an ordinary attribute, silently. A namespaced value loses its namespace on the way, so two distinct revisions can collapse to one | Write `::h/revision` |
+| `:rf.error/hicasso-revision-not-controlled` at render | `::h/revision` on something that is not controlled text — a `:div`, a `:select`, a value-less checkbox | Put the revision on the controlled `input`/`textarea` whose draft it re-baselines; a select or checkbox resets by writing the model |
 | Focus lost after validation fails | Something remounted the node | Never remount to reset — that is exactly what destroys focus |
 
 ## When not to control an input
@@ -230,11 +227,11 @@ If the user's edit must be a *draft* — commit on Enter or blur, revert on
 Escape, reject without loss of the field — do not build that yourself on top
 of this page. That is the [forms module](05-forms.md).
 
-If no other code needs the intermediate values — a scratch field in a [modal](glossary.md#overlay),
-a filter box that only feeds a debounced query — leave the input uncontrolled
-(`:default-value` to seed it, no `:value`) and commit on blur. DOM-owned
-state is a legitimate explicit choice. The cost is this: app-db, tests, and
-tools cannot see the text in mid-edit.
+If no other code needs the intermediate values — a scratch field in a
+[modal](glossary.md#overlay), a filter box that only feeds a debounced query —
+leave the input uncontrolled (`:default-value` to seed it, no `:value`) and
+commit on blur. DOM-owned state is a legitimate explicit choice. The cost is
+this: app-db, tests, and tools cannot see the text in mid-edit.
 
 ## Advanced
 
@@ -245,15 +242,15 @@ browser event. Store notification is synchronous too, so React commits the
 echo in the same turn. The value is back in the DOM before the browser
 finishes the event.
 
-`flushSync` is not a general default. The one exception is the
-controlled-text **converge**. The converge flushes the pending commit before
-React's end-of-event restore, so value *and caret* are correct in the same
-turn — including when the model rejected or normalized the keystroke. That
-path runs once per keystroke, on controlled text entry only (an `input` that
-has a caret, or a `textarea`, with a non-nil `:value`). It also runs once at
-the close of an IME composition. Everywhere else it is inert, and a page with
-no [controlled input](glossary.md#controlled-field) pays nothing for it. If your own code needs `flushSync`
-for anything else, that is a design problem, not a feature.
+`flushSync` is not a general default. The one exception is the controlled-text
+**converge**. The converge flushes the pending commit before React's
+end-of-event restore, so value *and caret* are correct in the same turn —
+including when the model rejected or normalized the keystroke. That path runs
+once per keystroke, on controlled text entry only (an `input` that has a
+caret, or a `textarea`, with a non-nil `:value`). It also runs once at the
+close of an IME composition. Everywhere else it is inert, and a page with no
+controlled input pays nothing for it. If your own code needs `flushSync` for
+anything else, that is a design problem, not a feature.
 
 ### Rejection and React's restore
 
@@ -272,29 +269,29 @@ selects an IME candidate; it is not a submit. The key map gates that
 centrally. The signal mechanics (native event, legacy fallbacks) are in the
 Advanced section of [Events as data](03-events-as-data.md).
 
-**A live composition is not overwritten.** If the model refuses or normalizes
+**A live composition is not overwritten.** If the model rejects or normalizes
 the text that the IME composed so far, nothing writes the field while the
 composition runs — not the converge, and not React's end-of-event restore.
-Your handler still runs on every composing update. The field continues to
-show the composition until the user commits it, and the refusal or
-normalization applies whole when the composition ends.
+Your handler still runs on every composing update. The field continues to show
+the composition until the user commits it, and the rejection or normalization
+applies whole when the composition ends.
 
-That second rule is a deliberate divergence from plain React. In plain React,
-a corrected value written during composition aborts the exchange: the kana in
-flight vanish, and the next update starts a fresh composition on a
-half-written draft. On a *normalizing* field, plain React does worse than
-lose the composition. Each aborted draft is written back, and the IME
-composes on top of it. So the sequence `s`, `sh`, commit ends the model at
-`SSHSH`, where this runtime commits the `SH` that was typed. The live
-composition is excluded from that restore on purpose.
+That second rule diverges from plain React. In plain React, a corrected value
+written during composition aborts the exchange: the kana in flight vanish, and
+the next update starts a fresh composition on a half-written draft. On a
+*normalizing* field, plain React does worse than lose the composition. Each
+aborted draft is written back, and the IME composes on top of it. So the
+sequence `s`, `sh`, commit ends the model at `SSHSH`, where this runtime
+commits the `SH` that was typed. The live composition is excluded from that
+restore on purpose.
 
 ### A reset that cannot land immediately
 
 There are two cases. Both are documented conduct, not bugs.
 
-**In mid-composition.** A revision change that arrives while a composition
-runs lands at the close of the exchange: composition end, blur, unmount, or
-the next non-composing input. The reason is the same reason that nothing else
+**In mid-composition.** A revision change that arrives while a composition runs
+lands at the close of the exchange: composition end, blur, unmount, or the
+next non-composing input. The reason is the same reason that nothing else
 writes the field there — the only immediate write available would abort the
 composition silently. The model is correct at all times; the screen converges
 at the close.

--- a/docs/design/hicasso/draft-guide/05-forms.md
+++ b/docs/design/hicasso/draft-guide/05-forms.md
@@ -1,7 +1,8 @@
 # Forms
 
-A bare [controlled field](glossary.md#controlled-field) ([Controlled inputs](04-controlled-inputs.md)) binds
-directly to app-db, and that is all. Real forms need three more things:
+A bare [controlled field](glossary.md#controlled-field)
+([Controlled inputs](04-controlled-inputs.md)) binds directly to app-db, and
+that is all. Real forms need three more things:
 
 - fields that buffer a *draft* — commit on Enter or blur, revert on Escape,
   reject without loss of the field;
@@ -13,8 +14,8 @@ The `re-frame.hicasso.forms` module owns all three. It is separately required
 and separately reachable: an application that never imports it ships none of
 it.
 
-> **A form is three pieces of state — a draft, a gate, a status — and all
-> three are data.**
+A form is three pieces of state — a draft, a gate, a status — and all three
+are data.
 
 Every codebase that builds this by hand collects the same five defects. Each
 one is worth a name, because each one is a *class*, not a bug: the shape
@@ -26,12 +27,12 @@ guarantees the failure.
 | Same-value blindness | Rejecting a draft by reasserting the equal model value — invisible to `not=`, so the rejected text stays on screen | The reset signal is [`::h/revision`](glossary.md#hrevision), distinct from the value by design |
 | Commit flicker | A forced reset on every commit misfires "changed"; async acceptance flickers between stale and new | A commit is decided against committed state at event time; acceptance is your event, and a stale commit no-ops |
 | Arity-sniffed done-fn | The flicker's escape hatch: probing the change callback's `.length` for a completion arity | There is no completion-callback protocol; submit status is data, read per instance |
-| Re-minted ephemeral state | Interaction state created inside the render function — dies on any re-render | Nothing lives in a render closure; drafts and status live at addresses and survive re-render and remount |
+| Re-created ephemeral state | Interaction state created inside the render function — dies on any re-render | Nothing lives in a render closure; drafts and status live at addresses and survive re-render and remount |
 
 One require serves the whole page:
 
 ```clojure
-(ns app.invoices
+(ns app.todos
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.hicasso :as h]
@@ -46,19 +47,19 @@ The caller supplies four things: a stable address for the draft, the
 committed value, the value's revision, and the event that receives a commit.
 
 ```clojure
-(rf/reg-sub :invoice/amount
-  (fn [db [_ id]] (get-in db [:invoice id :amount])))
+(rf/reg-sub :todo/title
+  (fn [db [_ id]] (get-in db [:todo id :title])))
 
-(rf/reg-sub :invoice/amount-revision
-  (fn [db [_ id]] (get-in db [:invoice id :amount-revision] 0)))
+(rf/reg-sub :todo/title-revision
+  (fn [db [_ id]] (get-in db [:todo id :title-revision] 0)))
 
-(h/defview amount-field [{:keys [id]}]
+(h/defview title-field [{:keys [id]}]
   [forms/buffered-field
-   {:control     [:invoice id :amount]
-    :value       (h/sub [:invoice/amount id])
-    ::h/revision (h/sub [:invoice/amount-revision id])
-    :on-commit   [:invoice/amount-committed id]
-    :placeholder "0.00"}])
+   {:control     [:todo id :title]
+    :value       (h/sub [:todo/title id])
+    ::h/revision (h/sub [:todo/title-revision id])
+    :on-commit   [:todo/title-committed id]
+    :placeholder "What needs doing?"}])
 ```
 
 The protocol is fixed, and it is the one users expect:
@@ -77,7 +78,7 @@ During an edit, the draft lives in app-db under the module's own key at the
 `:control` address — no atom, no closure. It appears in a state snapshot, it
 asserts in a headless test, and it reads in Xray like any other state.
 Everything else you pass (`:placeholder`, `:class`, `:name`, a test id) goes
-through to the input. The control slots stay owned, under the merge law from
+through to the input. The control slots stay owned, under the merge rule from
 [Controlled inputs](04-controlled-inputs.md).
 
 ## Accepting, rejecting, rewriting
@@ -88,27 +89,24 @@ nothing. **When you reject or rewrite, move the revision.** That is the whole
 discipline:
 
 ```clojure
-(defn parse-amount [s]
-  (let [n (js/parseFloat s)]
-    (when-not (js/isNaN n) n)))
-
-(rf/reg-event :invoice/amount-committed
+(rf/reg-event :todo/title-committed
   (fn [{:keys [db]} [_ id candidate]]
-    (if-let [amount (parse-amount candidate)]
-      {:db (-> db
-               (assoc-in  [:invoice id :amount] (.toFixed amount 2))
-               (update-in [:invoice id :amount-revision] (fnil inc 0)))}
-      {:db (update-in db [:invoice id :amount-revision] (fnil inc 0))})))
+    (let [title (str/trim candidate)]
+      (if (str/blank? title)
+        {:db (update-in db [:todo id :title-revision] (fnil inc 0))}
+        {:db (-> db
+                 (assoc-in  [:todo id :title] title)
+                 (update-in [:todo id :title-revision] (fnil inc 0)))}))))
 ```
 
 The revision is why a same-value rejection *shows*. Suppose the committed
-value was `"10.00"`, the user drafts `"bad"`, and you reject by keeping
-`"10.00"`. No value comparison can tell the field that anything changed —
+value was `"Buy milk"`, the user drafts `"   "`, and you reject by keeping
+`"Buy milk"`. No value comparison can tell the field that anything changed —
 that is trap two. The moved revision is the explicit signal. The field
 re-baselines to `:value`, visibly, and any edit still in flight under the old
 revision becomes ineligible. The same move makes async acceptance safe.
 Validate in an event, then settle later with a write of value plus revision.
-A commit that raced you carries the revision it began under, so it is a
+A commit that raced you still holds the revision it began under, so it is a
 no-op instead of a flicker.
 
 A caller that never rejects or rewrites can pass a constant `0` as the
@@ -134,46 +132,45 @@ form instance.
 
 ```clojure
 (def blank-editor
-  {:draft             {:title "" :description "" :body ""}
-   :baseline          {:title "" :description "" :body ""}
+  {:draft             {:title "" :notes ""}
+   :baseline          {:title "" :notes ""}
    :touched           #{}
    :submit-attempted? false})
 
-(defn validate [{:keys [title body]}]
+(defn validate [{:keys [title]}]
   (cond-> {}
-    (str/blank? title) (assoc :title "Title is required.")
-    (str/blank? body)  (assoc :body "Body is required.")))
+    (str/blank? title) (assoc :title "Title is required.")))
 
-(rf/reg-event :editor/edit-field
+(rf/reg-event :todo.editor/edit-field
   (fn [{:keys [db]} [_ field text]]
-    {:db (assoc-in db [:editor :draft field] text)}))
+    {:db (assoc-in db [:todo.editor :draft field] text)}))
 
-(rf/reg-event :editor/touch-field
+(rf/reg-event :todo.editor/touch-field
   (fn [{:keys [db]} [_ field]]
-    {:db (update-in db [:editor :touched] (fnil conj #{}) field)}))
+    {:db (update-in db [:todo.editor :touched] (fnil conj #{}) field)}))
 
-(rf/reg-sub :editor/field
-  (fn [db [_ field]] (get-in db [:editor :draft field])))
+(rf/reg-sub :todo.editor/field
+  (fn [db [_ field]] (get-in db [:todo.editor :draft field])))
 
-(rf/reg-sub :editor/field-error
+(rf/reg-sub :todo.editor/field-error
   (fn [db [_ field]]
-    (let [{:keys [draft touched submit-attempted?]} (:editor db)]
+    (let [{:keys [draft touched submit-attempted?]} (:todo.editor db)]
       (when (or submit-attempted? (contains? touched field))
         (get (validate draft) field)))))
 ```
 
-The field is an ordinary [controlled input](glossary.md#controlled-field); blur is the touch:
+The field is an ordinary controlled input; blur is the touch:
 
 ```clojure
-(h/defview title-field []
+(h/defview editor-title-field []
   [:fieldset.form-group
    [:input.form-control
     {:type        :text
-     :placeholder "Article Title"
-     :value       (h/sub [:editor/field :title])
-     :on-input    [:editor/edit-field :title ::h/value]
-     :on-blur     [:editor/touch-field :title]}]
-   (when-let [error (h/sub [:editor/field-error :title])]
+     :placeholder "Todo title"
+     :value       (h/sub [:todo.editor/field :title])
+     :on-input    [:todo.editor/edit-field :title ::h/value]
+     :on-blur     [:todo.editor/touch-field :title]}]
+   (when-let [error (h/sub [:todo.editor/field-error :title])]
      [:div.error-messages error])])
 ```
 
@@ -188,66 +185,66 @@ gating subs apply.
 "Can this form submit?" is needed in two places: the button disables on it,
 and the submit handler gates on it. If you compute it twice, the two
 computations drift — a handler that recomputes validation the button never
-saw is a known trap. So materialise it once, into app-db, where both can
-read it:
+saw is a known trap. So materialise it once, into app-db, where both can read
+it:
 
 ```clojure
 (def can-submit-flow
-  [:editor/can-submit?
+  [:todo.editor/can-submit?
    {:doc         "Valid AND different from the loaded baseline."
-    :inputs      [[:editor :draft] [:editor :baseline]]
-    :output-path [:editor :can-submit?]}
+    :inputs      [[:todo.editor :draft] [:todo.editor :baseline]]
+    :output-path [:todo.editor :can-submit?]}
    (fn [draft baseline]
      (and (empty? (validate draft))
           (not= draft baseline)))])
 
-(rf/reg-event :editor/register-flow   ;; dispatch once, from your boot event
+(rf/reg-event :todo.editor/register-flow   ;; dispatch once, from your boot event
   (fn [_ _]
     {:fx [[:rf.fx/reg-flow can-submit-flow]]}))
 
-(rf/reg-sub :editor/can-submit?
-  (fn [db _] (boolean (get-in db [:editor :can-submit?]))))
+(rf/reg-sub :todo.editor/can-submit?
+  (fn [db _] (boolean (get-in db [:todo.editor :can-submit?]))))
 ```
 
 The view reads the sub. The handler reads plain data from `db`. One
 derivation, two readers — they cannot disagree:
 
 ```clojure
-(def save-instance :editor/save)
+(def save-instance :todo.editor/save)
 
-(rf/reg-event :editor/submit
+(rf/reg-event :todo.editor/submit
   (fn [{:keys [db]} _]
-    (if-not (get-in db [:editor :can-submit?])   ;; plain data — no subscribing mid-handler
-      {:db (assoc-in db [:editor :submit-attempted?] true)}
-      {:db (assoc-in db [:editor :submit-attempted?] true)
+    (if-not (get-in db [:todo.editor :can-submit?])   ;; plain data — no subscribing mid-handler
+      {:db (assoc-in db [:todo.editor :submit-attempted?] true)}
+      {:db (assoc-in db [:todo.editor :submit-attempted?] true)
        :fx [[:dispatch [:rf.mutation/execute
-                        {:mutation :realworld/save-article
-                         :params   (get-in db [:editor :draft])
+                        {:mutation :todo/save
+                         :params   (get-in db [:todo.editor :draft])
                          :instance save-instance
-                         :reply-to [:editor/replied]}]]]})))
+                         :reply-to [:todo.editor/replied]}]]]})))
 ```
 
-A refused submit still sets `:submit-attempted?`. That flag un-gates every
+A rejected submit still sets `:submit-attempted?`. That flag un-gates every
 remaining error at once: the user asked, so the form answers in full.
 
 ## Submit status is per-instance data
 
-The write is a mutation, executed under an **instance** — a stable id for
-this form's save. You read its status wherever it is needed, as data, through
-the framework's own subscription:
+The write is a mutation, executed under an **instance** — a stable id for this
+form's save. You read its status wherever it is needed, as data, through the
+framework's own subscription:
 
 ```clojure
 (h/defview editor-form []
   (let [save (h/sub [:rf/mutation {:instance save-instance}])]
-    [:form {:on-submit [::h/prevent [:editor/submit]]}   ;; nothing auto-prevents — the head is the decision
+    [:form {:on-submit [::h/prevent [:todo.editor/submit]]}   ;; nothing auto-prevents
      (when (:error? save)
        [:ul.error-messages [:li "Save failed — check the fields and try again."]])
-     [title-field]
+     [editor-title-field]
      [:button.btn.btn-primary
       {:type     :submit
        :disabled (or (:pending? save)
-                     (not (h/sub [:editor/can-submit?])))}
-      "Publish Article"]]))
+                     (not (h/sub [:todo.editor/can-submit?])))}
+      "Save todo"]]))
 ```
 
 `:pending?` is the busy discipline. Inputs and buttons disable from the state
@@ -256,10 +253,10 @@ There is no completion callback to give to anyone — trap four. Completion is
 an event that you named at the call site:
 
 ```clojure
-(rf/reg-event :editor/replied
+(rf/reg-event :todo.editor/replied
   (fn [{:keys [db]} [_ {:keys [status]}]]
     (when (= :ok status)
-      {:db (assoc db :editor blank-editor)
+      {:db (assoc db :todo.editor blank-editor)
        :fx [[:dispatch [:rf.mutation/clear {:instance save-instance}]]]})))
 ```
 
@@ -270,29 +267,30 @@ mutation and reads one instance.
 
 ## When a plain field is enough
 
-Most fields need none of this page. A search box that feeds a debounced
-query, a settings toggle, a filter — bind them directly to app-db and stop.
-That whole story is [Controlled inputs](04-controlled-inputs.md). Use the
-forms module when you want a draft the user can abandon, errors that wait, or
-a submit lifecycle — and only then. Every [buffered field](glossary.md#buffered-field) is one more address
-and one more commit protocol in your app's state. An application that never
-requires `re-frame.hicasso.forms` ships zero bytes of it.
+Most fields need none of this page. A search box that feeds a debounced query,
+a settings toggle, a filter — bind them directly to app-db and stop. That
+whole story is [Controlled inputs](04-controlled-inputs.md). Use the forms
+module when you want a draft the user can abandon, errors that wait, or a
+submit lifecycle — and only then. Every
+[buffered field](glossary.md#buffered-field) is one more address and one more
+commit protocol in your app's state. An application that never requires
+`re-frame.hicasso.forms` ships zero bytes of it.
 
 ## Troubleshooting
 
-Refusals on the underlying elements carry the controlled-input error ids
+Failures on the underlying elements use the controlled-input error ids
 ([Controlled inputs](04-controlled-inputs.md), e.g.
 `:rf.error/hicasso-revision-not-controlled`). The module's own failure modes
 are behavioural: a wrong address or an ungated sub misbehaves without a
-refusal. So these rows name mechanisms:
+named error. So these rows name mechanisms:
 
 | Symptom | What is happening | Fix |
 |---|---|---|
-| Errors show on a blank, untouched form | Error display is not gated | Gate on touched-or-attempted, per field (`:editor/field-error` above) |
-| The button enables but the handler refuses (or vice versa) | Two validity computations drifting apart | One materialised gate; the view subscribes, the handler reads `db` — never recompute per site |
+| Errors show on a blank, untouched form | Error display is not gated | Gate on touched-or-attempted, per field (`:todo.editor/field-error` above) |
+| The button enables but the handler rejects (or vice versa) | Two validity computations drifting apart | One materialised gate; the view subscribes, the handler reads `db` — never recompute per site |
 | Escape reverts, then the old draft reappears | A second copy of the draft outside the module — a local atom, a duplicated slice | One draft, one address; let the field own cancel — its trailing blur no-ops |
-| Two fields fight over one draft | Duplicate `:control` address | Address per instance: `[:invoice id :amount]`, not `[:invoice :amount]` |
-| A rejected draft still reads as accepted | The revision did not move, so the same-value rejection is invisible | Move [`::h/revision`](glossary.md#hrevision) whenever you reject or rewrite |
+| Two fields fight over one draft | Duplicate `:control` address | Address per instance: `[:todo id :title]`, not `[:todo :title]` |
+| A rejected draft still reads as accepted | The revision did not move, so the same-value rejection is invisible | Move `::h/revision` whenever you reject or rewrite |
 | The field ignores an external value change mid-edit | By design: a value change under an unchanged revision continues the draft | Move the revision when you mean *replace the edit* |
 | A late async accept clobbers newer typing | The settle wrote the value without fencing | Settle writes value **and** revision; commits under the old revision no-op. Deeper supersession policy: [async resources](08-async-resources.md) |
 | A half-typed draft resurfaces much later | Drafts are durable state, and no causal owner cleared them | Clear at the causal end — route entry, or the save's reply (see Advanced) |
@@ -307,8 +305,8 @@ virtualization, and navigation, because unmount does nothing by design. That
 durability is a feature with an obligation attached: every draft needs a
 causal owner with an end event. The usual owners are route entry (reset the
 form slice when the user arrives) and the save's reply (reset to a clean
-baseline when the server accepts, as `:editor/replied` does above). A form
-whose drafts matter across navigation pairs naturally with a dirty-leave
+baseline when the server accepts, as `:todo.editor/replied` does above). A
+form whose drafts matter across navigation should pair with a dirty-leave
 guard. Derive "dirty" from the same state (`(not= draft baseline)`), and let
 the guard in the [routing chapter](07-routing-and-navigation.md) block the
 exit.
@@ -318,6 +316,7 @@ exit.
 A buffered draft still writes app-db on each keystroke. The buffering changes
 *when the committed value moves*, not how the draft is tracked. That is what
 keeps drafts testable and visible to tools. For a dense grid where writes per
-cell per keystroke cost too much, the answer is not this module. The answer
-is the explicit uncontrolled choice, or a [native island](glossary.md#native-island) — both with their
-costs in [Performance](18-performance.md).
+cell per keystroke cost too much, the answer is not this module. The answer is
+the explicit uncontrolled choice, or a
+[native island](glossary.md#native-island) — both with their costs in
+[Performance](18-performance.md).

--- a/docs/design/hicasso/draft-guide/06-lists-and-collections.md
+++ b/docs/design/hicasso/draft-guide/06-lists-and-collections.md
@@ -1,18 +1,12 @@
 # Lists and collections
 
-Every app has a table that started at twenty rows and now holds two thousand.
-At that size, a plain map over the data is no longer the whole answer. Two
-decisions govern how a collection behaves from there: **what identifies a row**
-(keys) and **which rows find out when a row changes** ([read topology](glossary.md#read-topology)). This
-chapter owns both decisions.
-
-> **A key states which row this is. The [read topology](glossary.md#read-topology) states which rows an
-> update reaches.**
+A list of twenty rows is easy. At a few hundred or a few thousand, two
+choices decide how it behaves: **what identifies each row** (keys), and
+**which rows re-render when one row changes** (where you put the reads).
 
 ## Keys are identity
 
-Every list of children needs a `:key`. The key goes **in the props map** —
-there is no metadata spelling:
+Put a stable `:key` in each child's props map. There is no metadata form:
 
 ```clojure
 (ns app.orders
@@ -28,65 +22,52 @@ there is no metadata spelling:
      [order-row {:key id :id id}])])
 ```
 
-The key must be a **stable domain identifier** — the entity's id, not its
-position. React uses the key to decide which child is *the same child* across
-renders. Key by index, and an insertion at the top renames every row. Row 3's
-DOM, focus, selection, and half-typed input now belong to the data that moved
-into position 3. Key by domain id, and an insertion is one new node. Every
-other row keeps its identity, and the value-equality bail-out
-([Views and reads](02-views-and-reads.md)) usually stops its body from
-running at all.
+Use a **domain id**, not a position. React uses the key to decide which child
+is the same child across renders. Key by index, and an insertion at the top
+renames every row: focus, selection, and half-typed input jump with the
+index. Key by domain id, and an insertion is one new node; other rows keep
+their identity. Value-equality memoization often skips their bodies entirely
+([Views and reads](02-views-and-reads.md)).
 
-!!! warning "Never index, never the entity"
-    An index key breaks under reorder and insertion — controlled-input state
-    and animations visibly jump rows. A whole-entity key breaks under edit.
-    React coerces a non-primitive key to a string, so an edit silently changes
-    the row's key and **remounts** the row. Development names that case
-    `:rf.warning/hicasso-entity-key`. The warning points at the child and
-    tells you to key on a stable identifier. Strings, numbers, keywords,
-    uuids and symbols pass; the warning flags collections, JS objects, dates,
-    booleans and functions.
+!!! warning "Never index, never the whole entity"
+    An index key breaks under reorder and insertion. A whole-entity key
+    breaks under edit: React stringifies a non-primitive key, so an edit
+    changes the key and remounts the row. Development warns with
+    `:rf.warning/hicasso-entity-key` and points at the child. Strings,
+    numbers, keywords, uuids, and symbols are fine; collections, JS objects,
+    dates, booleans, and functions are not.
 
-Forget a key entirely and development gives you two warnings: React's own, and
-`:rf.warning/hicasso-missing-key`. The [Hicasso](glossary.md#hicasso) warning names the enclosing
-view, the child head, and the index of the first offender. The second warning
-exists because React dedupes its own warning per parent tag for the life of
-the page — under a `:ul`, every list after the first is silent. Hicasso's
-warning fires once per call site. It also fires at one crossing React cannot
-see at all: a seq passed as a *view's* children —
-`[card {} (for [t toasts] [toast-row {…}])]`. Hicasso realizes that seq and
-flattens it into direct children. React marks the flattened members validated
-and never warns about them, so there the Hicasso line is the only signal that
-shape gets. Both checks are development-only; a production build carries
-neither.
+If you omit a key, development emits two warnings: React's, and
+`:rf.warning/hicasso-missing-key`. The Hicasso warning names the enclosing
+view, the child head, and the index of the first offender. React dedupes its
+own warning per parent tag for the life of the page — under a `:ul`, later
+lists go silent — so Hicasso fires once per call site. It also covers a case
+React misses: a seq passed as a view's children,
+`[card {} (for [t toasts] [toast-row {…}])]`. Hicasso flattens that seq into
+direct children; React treats the flattened members as already validated and
+never warns. Both checks are development-only.
 
 ??? info "Coming from Reagent"
-    Hicasso does **not read** `^{:key id}` metadata. Keys live in the props
-    map: `[order-row {:key id :id id}]`. A carried-over metadata key is the
-    most common trigger of `:rf.warning/hicasso-missing-key`, and the message
-    says exactly that.
+    Hicasso does not read `^{:key id}` metadata. Keys live in the props map:
+    `[order-row {:key id :id id}]`. A leftover metadata key is a common cause
+    of `:rf.warning/hicasso-missing-key`.
 
-Keys are one half of list identity. The other half is the [read topology](glossary.md#read-topology):
-which rows *re-render*. That half is a genuine design choice.
+## Where the reads live
 
-## Choosing a read topology
+`h/sub` is legal anywhere in a view body, so you choose *where* the reads
+sit. For a collection, that choice decides what an update costs. Four shapes
+cover real workloads:
 
-[`h/sub`](glossary.md#hsub) is legal anywhere in a body, so you choose *where* the reads sit. For
-a collection, that position decides what an update costs. Four shapes cover
-real workloads:
-
-| Topology | Reads | Best at | Price |
+| Shape | Reads | Best at | Cost |
 |---|---|---|---|
-| **Fine** | each row reads its own entity | sparse, independent updates | one retained read per row; mount and heap grow with row count |
-| **Coarse** | one view-model read for the table | cheap mount; bulk replacement | every change recomputes the model and sweeps a props-compare over all rows |
-| **Chunked** | one read per block of rows | large mixed workloads | chunk membership shifts on insert and reorder |
-| **Windowed / virtualized** | fine reads, but only the visible window exists | collections whose DOM should not exist in full | the host owns scrolling; focus and accessibility need their own checks |
+| **Fine** | each row reads its own entity | sparse, independent updates | one retained read per row |
+| **Coarse** | one view-model for the table | cheap mount; bulk replacement | every change recomputes the model and props-compares all rows |
+| **Chunked** | one read per block of rows | large mixed workloads | chunk membership shifts on insert/reorder |
+| **Windowed** | fine reads, only visible rows exist | collections that should not fully exist in the DOM | host owns scrolling; focus and a11y need checks |
 
-Fine is the shape you already write by default. For most screens it is the
-right one. The rest of this section takes **one table** through all four
-shapes, so the deltas are visible. The screen is an orders table — customer,
-status, total. A websocket pushes status changes for single orders, and a
-refresh replaces the whole set.
+Fine is the default and the right choice for most screens. The rest of this
+section walks **one orders table** through all four shapes. A websocket
+updates single order statuses; a refresh replaces the whole set.
 
 ### Fine: rows read themselves
 
@@ -110,22 +91,19 @@ refresh replaces the whole set.
       [order-row {:key id :id id}])]])
 ```
 
-The parent reads only the ids; each row reads its own entity. When one order's
-status changes, one subscription's value changes, one row body runs, and one
-`<td>` commits. The parent does not re-render, because the ids did not move.
-That is the shape you want for sparse edits: **body work scales with
-changed rows, not mounted rows** (the narrow-update idea
-[Performance](18-performance.md) calls out for list updates).
+The parent reads only the ids; each row reads its own entity. When one
+order's status changes, one subscription changes, one row body runs, and one
+cell updates. The parent does not re-render if the ids did not move. Body
+work scales with changed rows, not mounted rows
+([Performance](18-performance.md)).
 
-The price is retention. A thousand mounted rows hold a thousand row reads, and
-mount establishes each of them. For a few hundred rows that cost is noise.
-When your profile names mount time or a bulk *replace-everything* operation,
-fine reads are the wrong shape. Coarse is built for that workload.
+The price is retention: a thousand mounted rows hold a thousand reads.
+For a few hundred rows that is usually noise. When a profile points at mount
+time or a bulk replace-everything, try coarse.
 
 ### Coarse: one view-model
 
-The delta: the table reads **one** subscription shaped for display. Rows
-render from props instead of reading.
+The table reads **one** subscription shaped for display. Rows take props:
 
 ```clojure
 (rf/reg-sub :orders/table-rows
@@ -151,27 +129,24 @@ render from props instead of reading.
       [order-row {:key (:id row) :row row}])]])
 ```
 
-The whole table retains one read, so mount is cheap. A bulk replacement is one
-recompute — the workload this shape is for. Sparse updates still work, but
-they travel differently: the view-model recomputes, the parent re-renders,
-and every row gets a props compare. Unchanged rows carry `=` row maps, so the
-bail-out stops their bodies from running — only the changed row executes.
-The cost that grew is the **sweep**: one compare across all rows per update,
-plus the view-model recompute itself. At 300 rows the sweep is cheap. At
-10,000 rows it is the line item your profile will name.
+Mount is cheap (one read). A bulk replacement is one recompute. Sparse
+updates still work, but differently: the view-model recomputes, the parent
+re-renders, and every row gets a props compare. Unchanged rows still
+compare `=` and skip their bodies — only the changed row runs. What grew is
+the **sweep**: one compare per row, plus the view-model recompute. At a few
+hundred rows that is usually fine; at tens of thousands your profile will
+name it.
 
-Two rules keep the bail-out honest here. First, rows must receive **values**.
-Persistent maps built with `select-keys` compare `=` across renders; a row
-that receives a freshly built closure re-renders on every sweep, which is one
-more reason event [intents](glossary.md#intent) are data. Second, the row map should carry only
-what the row shows. A `:updated-at` timestamp that nobody renders defeats `=`
-on every touch.
+Two rules keep the bail-out honest. Rows must receive **values** — maps from
+`select-keys` compare with `=` across renders; a fresh closure does not.
+Keep the row map to what the row shows: a `:updated-at` nobody renders
+defeats `=` on every touch. Event vectors as data help here
+([Events as data](03-events-as-data.md)).
 
 ### Chunked: bounding the sweep
 
-For large mixed workloads — a big collection with sparse updates *and* bulk
-operations — chunk the rows. Then no single read spans the table, and no
-sweep spans more than a block:
+For a large table with both sparse updates and bulk operations, chunk the
+rows so no single read or props sweep spans the whole table:
 
 ```clojure
 (rf/reg-sub :orders/chunk
@@ -193,30 +168,25 @@ sweep spans more than a block:
      [order-chunk {:key i :ids (vec ids)}])])
 ```
 
-A sparse update now changes one chunk's output. One chunk [boundary](glossary.md#boundary) re-renders,
-and the sweep is 50 compares instead of the whole table. Mount retains one
-read per block instead of one per row. The equality gate on subscriptions
-keeps the untouched chunks quiet: their selects re-run cheaply, their outputs
-are `=`, and nothing downstream moves.
+A sparse update changes one chunk's output. That chunk re-renders; the
+sweep is about 50 compares, not the whole table. Mount retains one read per
+block instead of one per row. Untouched chunks re-select cheaply, their
+outputs are `=`, and nothing downstream moves.
 
-Two notes. First, the chunk is keyed by **index**, and that is correct. A
-chunk is a positional window, not an entity — "rows 0–49" *is* its identity,
-and the entity keys live on the rows inside it. Second, insertion or reorder
-shifts ids across chunk borders. Those operations re-render every chunk they
-shift through — a bulk-shaped cost for a bulk-shaped change, which is the
-trade you accepted.
+Chunk by **index** is correct: a chunk is a positional window ("rows
+0–49"), not an entity. Entity keys still live on the rows inside. Insertion
+or reorder can shift ids across chunk borders and re-render every chunk they
+cross — a bulk-shaped cost for a bulk-shaped change.
 
 ### Windowed: only the visible rows exist
 
-Past a few thousand rows, ask why the DOM for row 8,000 exists at all. A
-**windowed read** materializes only what is visible. The simplest window is
-one you already have: pagination. The page number is app-db state, and
-`(h/sub [:orders/page n])` is a windowed read whose bounds move at click
-rate. When the product wants continuous scrolling instead, bring a
-virtualizer through [`h/defhost`](glossary.md#defhost) and let it own the window:
+Past a few thousand rows, ask whether row 8,000 needs a DOM node at all. The
+simplest window is pagination: page number in app-db, and
+`(h/sub [:orders/page n])` materializes one page. For continuous scrolling,
+bring a virtualizer through `h/defhost` and let it own the window:
 
 ```clojure
-;; A .cljs host namespace — JS requires stay out of .cljc bodies.
+;; A .cljs host namespace — keep JS requires out of .cljc bodies.
 (ns app.orders.virtual
   (:require ["react-virtuoso" :refer [Virtuoso]]
             [re-frame.hicasso :as h]))
@@ -235,83 +205,67 @@ virtualizer through [`h/defhost`](glossary.md#defhost) and let it own the window
                            [order-row {:id (nth ids index)}]))}]))
 ```
 
-Read the shape closely. Every piece does a job:
+What each piece does:
 
-- **`order-row` is the fine-read version** — `{:id id}`, reading its own
+- **`order-row` is still the fine-read version** — `{:id id}`, reading its own
   entity. Virtualization is fine reads with a bounded N. Only ~30 rows exist,
-  so only ~30 reads are retained, and a sparse update still touches exactly
-  one of them. The topology you started with was right; the window caps its
-  cost.
-- **`:item-content` is declared `:render`** — the library calls it during its
-  own render, and the body stays pure. The returned hiccup crosses through
-  [`h/as-element`](glossary.md#as-element), which yields a legal ReactNode. A plain `fn` is enough
-  here because the row is a `[order-row …]` head: it is a [boundary](glossary.md#boundary), so it
-  resolves the frame React already has in scope where the library renders it,
-  and intents written inside `order-row` dispatch to that frame exactly as they
-  would outside the host. Write [`h/event`](glossary.md#hevent) instead when the callback body itself
-  carries an intent ([Interop](09-interop.md)).
-- **The closure closes over `ids`, not over a read.** `(h/sub ...)` ran in the
-  body; the callback captures the *value*. A [`h/sub`](glossary.md#hsub) call inside the callback
-  would be a deferred read, and the runtime refuses it loudly.
-- **`:compute-item-key` carries the keys law across the crossing.** When a
-  virtualizer owns the list, it owns item identity too. Hand it the same
-  domain id you would have written at `:key`. It is a plain function that
-  returns a value, so it crosses by identity, undeclared.
-- Scroll position never touches app-db. High-rate motion is the host's own
-  mechanics ([Ephemeral state](11-ephemeral-state.md)). Your state sees reads,
-  not scrolling.
+  so only ~30 reads are retained; a sparse update still hits one of them.
+- **`:item-content` is `:render`** — the library calls it during its own
+  render; the body must stay pure. Return hiccup through `h/as-element` so
+  React gets a real element. A plain `fn` is fine when the row is a
+  `[order-row …]` head: that view resolves the frame where the library
+  renders it. Use `h/event` when the callback body itself carries an event
+  vector ([Interop](09-interop.md)).
+- **Close over `ids`, not over a read.** Call `h/sub` in the view body; the
+  callback captures the value. An `h/sub` inside the callback is a deferred
+  read and is refused.
+- **`:compute-item-key` carries domain ids** across the host. When a
+  virtualizer owns the list, hand it the same ids you would put at `:key`.
+- Scroll position stays out of app-db. High-rate motion is host mechanics
+  ([Ephemeral state](11-ephemeral-state.md)).
 
-The virtualizer's [server policy](glossary.md#server-policy) is the host default, Client-only. That
-default is what a DOM-measuring component wants;
-[chapter 17](17-ssr-and-hydration.md) owns the SSR story.
-[Interop](09-interop.md) owns full [`defhost`](glossary.md#defhost) mechanics, including callback
-contracts. Also verify focus and keyboard behavior in a browser test. The
-keyboard cannot reach rows that do not exist, and that is a product decision,
-not a bug.
+The virtualizer defaults to Client-only on the server; see
+[SSR and hydration](17-ssr-and-hydration.md). Full `defhost` mechanics are in
+[Interop](09-interop.md). Check focus and keyboard behaviour in a browser:
+rows that do not exist cannot receive keyboard focus.
 
 ## Oscillating read sets
 
-One caution applies across all four shapes. A boundary's subscriptions are
-exactly the reads its body just made. When control flow changes the body's
-read set, the boundary re-subscribes the **whole set**, not the one key that
-changed. That reconciliation is proportional to the current read count. A
-small set that oscillates is fine. A *large* one is the dangerous case.
-Consider a parent that itself reads hundreds of per-row subscriptions, under
-a filter that changes which rows are visible. Every keystroke of the filter
-then costs a hundreds-wide re-subscribe.
+A view's subscriptions are the reads its body just made. When control flow
+changes that set, the view re-subscribes the **whole set**, not one key. That
+cost scales with the current read count. A small set that oscillates is
+fine. A large one is not: a parent that reads hundreds of per-row
+subscriptions under a filter that changes membership re-subscribes hundreds
+of reads on every filter keystroke.
 
-The fix is structural, and you already saw both arms. Either push per-row
-reads down into row [boundaries](glossary.md#boundary): each row's set is then small and stable, and
-membership churn costs only the rows that actually enter or leave. Or go
+Fix it structurally. Push per-row reads into row views so each set is small
+and stable, and membership churn only costs rows that enter or leave. Or go
 coarse, where the set is one read that never churns. Xray shows reads per
-boundary and read-set churn directly ([Diagnostics](15-diagnostics.md)), so
-you observe this cost instead of guessing at it.
+view and read-set churn ([Diagnostics](15-diagnostics.md)).
 
 ## Troubleshooting
 
-| Symptom | What it is | Fix |
+| Symptom | Cause | Fix |
 |---|---|---|
-| Console warning names your view, a child head, and an index | `:rf.warning/hicasso-missing-key` — a list of children with no `:key` | Put `:key` in each member's props map. Reagent `^{:key}` metadata is not read |
-| A row remounts when you edit it; warning names the child | `:rf.warning/hicasso-entity-key` — the key is a value React coerces, so editing changed it | Key on a stable identifier: `{:key (:id row)}` |
-| Input state or animation jumps to a different row after insert/reorder | Index keys — position renamed the rows | Key on domain ids |
-| One order changes and every row re-renders | The read lives too high — coarse topology where the workload is sparse | Fine reads: rows read their own entity; or accept the sweep knowingly |
-| A page-wide write runs every row body despite the bail-out | Row props are not `=` — a fresh closure, a JS object, or dead weight in the row map | Intents as data, persistent values, `select-keys` to what the row shows |
-| Filter typing is heavy on a large list | A large oscillating read set in one [boundary](glossary.md#boundary), or a whole-table view-model recomputing per keystroke | Rows own their reads, chunk the table, or move the filter into the subscription |
-| A plain function — CLJS or a JS component — in head position is refused | `:rf.error/hicasso-bad-head` — only minted views, native tags, fragments and hosts are heads | Mint views with [`h/defview`](glossary.md#defview); declare foreign components once with [`h/defhost`](glossary.md#defhost) ([Interop](09-interop.md)) |
-| Virtualized list renders but rows are inert or mis-framed | Row hiccup returned raw from the render callback | Return it through [`h/as-element`](glossary.md#as-element); when the row itself carries an [intent](glossary.md#intent), write the callback as [`h/event`](glossary.md#hevent) so it captures the frame |
+| Console warning names your view, a child head, and an index | `:rf.warning/hicasso-missing-key` | Put `:key` in each member's props map. Reagent `^{:key}` metadata is not read |
+| Row remounts when you edit it; warning names the child | `:rf.warning/hicasso-entity-key` — key is a value React coerces | Key on a stable id: `{:key (:id row)}` |
+| Input state or animation jumps after insert/reorder | Index keys | Key on domain ids |
+| One order changes and every row re-renders | Read lives too high for a sparse workload | Fine reads: rows read their own entity; or accept the coarse sweep knowingly |
+| Page-wide write runs every row body despite the bail-out | Row props are not `=` — fresh closure, JS object, or dead weight in the map | Event vectors as data; persistent values; `select-keys` to what the row shows |
+| Filter typing is heavy on a large list | Large oscillating read set, or a whole-table view-model per keystroke | Rows own their reads, chunk the table, or filter inside the subscription |
+| Plain function or JS component in head position refused | `:rf.error/hicasso-bad-head` | Define views with `h/defview`; declare foreign components with `h/defhost` ([Interop](09-interop.md)) |
+| Virtualized list renders but rows are inert or mis-framed | Row hiccup returned raw from the render callback | Return through `h/as-element`; if the callback itself carries an event vector, use `h/event` |
 
 ## When not to tune a list
 
-- **Under a few hundred rows with sparse updates**: the fine default is
-  already the right topology. Write it and move on. This chapter's deltas
-  answer a *measured* cost ([Performance](18-performance.md)); they are not a
-  checklist.
-- **Do not virtualize a list people scan**: find-in-page, select-all, and
-  printing only see rows that exist. A virtualized 50-row settings list is
-  strictly worse than a plain one.
-- **Do not pre-chunk speculatively**: chunking answers a profiled sweep. The
-  extra layer of indirection is justified only by a measured cost.
-- **If typing is slow**, the problem is usually event volume in a controlled
-  surface, not list topology —
+- **Under a few hundred rows with sparse updates** — fine is already right.
+  Tune when a profile names a cost ([Performance](18-performance.md)).
+- **Do not virtualize a list people scan** — find-in-page, select-all, and
+  print only see rows that exist. A virtualized 50-row settings list is worse
+  than a plain one.
+- **Do not pre-chunk without a measured sweep** — the extra layer only pays
+  when the profile shows it.
+- **If typing is slow**, the problem is usually event volume on a controlled
+  field, not list shape —
   [Controlled inputs](04-controlled-inputs.md) and
-  [Performance](18-performance.md) own that diagnosis.
+  [Performance](18-performance.md).

--- a/docs/design/hicasso/draft-guide/07-routing-and-navigation.md
+++ b/docs/design/hicasso/draft-guide/07-routing-and-navigation.md
@@ -1,27 +1,22 @@
 # Routing and navigation
 
-Your views are Hiccup and your events are vectors; navigation should not bring
-ceremony back. This page wires a [Hicasso](glossary.md#hicasso) app to the re-frame2 router. It covers
-the link you render, the warm-up before the click, scroll and focus after the
-route changes, and the "unsaved changes" guard. All of it is data and ordinary
-state.
+Views are Hiccup and events are vectors. Navigation should stay the same
+kind of data: the link you render, warm-up before a click, scroll and focus
+after a route change, and an unsaved-changes guard.
 
-The router itself is the core routing artefact (`re-frame.routing`), taught in
-the routing corpus under `docs/routing/`. There, a route is a registry entry,
-navigation is an event, and the active route is a subscription. This page does
-not re-teach any of that. It assumes those three moves and owns the view side.
-
-> **The link renders its click decision as data. Everything after the click is
-> ordinary state.**
+The router itself is the core routing artefact (`re-frame.routing`), taught
+under `docs/routing/`. There a route is a registry entry, navigation is an
+event, and the active route is a subscription. This page assumes those three
+moves and covers the Hicasso view side.
 
 ## Setup
 
-Register routes once, at boot, with the core artefact:
+Register routes once at boot:
 
 ```clojure
 (ns app.routes
   (:require [re-frame.core :as rf]
-            [re-frame.routing]))   ;; the core routing artefact
+            [re-frame.routing]))
 
 (rf/reg-route :app/home     {} "/")
 (rf/reg-route :app/articles {} "/articles")
@@ -40,9 +35,8 @@ Views require the integration module:
 
 ## Route links
 
-Spell an in-app link as [`route-link`](glossary.md#route-link): name the route and its params, never a
-URL. It is a plain function. Use it inline, inside the view that already owns
-the region:
+Spell an in-app link as `route-link`: name the route and its params, not a
+URL. It is a plain function — use it inline in the view that owns the region:
 
 ```clojure
 (h/defview article-card [{:keys [id]}]
@@ -56,11 +50,10 @@ the region:
         author)]]))
 ```
 
-The call returns one real `<a>`, so hover preview, copy-link, and middle-click
-all behave. The router synthesizes the `:href`. The `:on-click` carries the
-click decision as data, under the routing module's reserved head. This is the
-second reserved head in the [intent](glossary.md#intent) grammar, beside [`::h/prevent`](glossary.md#hprevent) from
-[Events as data](03-events-as-data.md):
+The call returns a real `<a>`, so hover preview, copy-link, and middle-click
+work. The router builds the `:href`. The `:on-click` carries the click
+decision as data under a reserved head (alongside `::h/prevent` from
+[Events as data](03-events-as-data.md)):
 
 ```clojure
 [:a {:href     "/profile/jane"
@@ -75,32 +68,31 @@ second reserved head in the [intent](glossary.md#intent) grammar, beside [`::h/p
  "jane"]
 ```
 
-Two renders of one link are equal under `=`, so a structural test reads the
-click decision straight off the tree ([Testing](14-testing.md)). Because
-[`route-link`](glossary.md#route-link) is a plain function, not a [boundary](glossary.md#boundary), it inlines. There is no
-hook, no subscription read, and no row in any boundary count. A nav bar of
-thirty links costs what thirty anchors cost.
+Two renders of one link are equal under `=`, so a structural test can read
+the click decision off the tree ([Testing](14-testing.md)). Because
+`route-link` is a plain function, not a separate re-rendering view, it
+inlines: no subscription, no extra view cost. A nav bar of thirty links
+costs what thirty anchors cost.
 
-The click law is the router's, and the link restates none of it:
+Click behaviour is the router's:
 
-- A plain left-click: `preventDefault` runs, then the routing [intent](glossary.md#intent)
-  dispatches to the frame captured at render.
-- A modifier or auxiliary click belongs to the browser — a new tab opens, and
-  nothing dispatches.
-- A `:target` or `:download` anchor navigates natively, untouched.
+- A plain left-click: `preventDefault`, then the routing event dispatches to
+  the frame captured at render.
+- A modifier or auxiliary click belongs to the browser — new tab, no
+  dispatch.
+- A `:target` or `:download` anchor navigates natively.
 
-You never write `[::h/navigate …]` by hand. [`route-link`](glossary.md#route-link) mints it, and the
-grammar is closed: exactly `:frame`, `:payload`, `:native?`, and `:veto`. Any
-other key refuses at render with `:rf.error/hicasso-malformed-navigate`,
-naming the position. A link rendered while the routing artefact is absent
-also fails at render, with `:rf.error/routing-artefact-missing` naming the
-`:to` — never a dead anchor. Every prop the link does not claim passes
-through to the `<a>`: classes, `:data-*`, ARIA attributes.
+Do not write `[::h/navigate …]` by hand. `route-link` creates it. The map
+allows only `:frame`, `:payload`, `:native?`, and `:veto`. Any other key
+raises `:rf.error/hicasso-malformed-navigate` at render and names the
+position. A link rendered while the routing artefact is missing raises
+`:rf.error/routing-artefact-missing` naming the `:to` — never a dead anchor.
+Other props pass through to the `<a>`: classes, `:data-*`, ARIA.
 
 ### The active link
 
-[`route-link`](glossary.md#route-link) computes no active state. "Am I on this page?" is a comparison
-against a route subscription, read once where the nav renders:
+`route-link` does not compute active state. Compare against a route
+subscription where the nav renders:
 
 ```clojure
 (h/defview site-nav []
@@ -115,62 +107,55 @@ against a route subscription, read once where the nav renders:
      (nav :app/articles "Articles")]))
 ```
 
-One [boundary](glossary.md#boundary), one read, and a plain local helper — links stay inline.
-`:aria-current "page"` is what a screen reader announces; the class is what you
-style.
+One view, one read, and a local helper — links stay inline. Use
+`:aria-current "page"` for screen readers; style with the class.
 
-### The pre-navigation veto
+### Cancel this link's navigation
 
-A link may need to cancel its own navigation and do something else — for
-example, confirm before it discards a scratch pane. The `:on-click` you pass
-to [`route-link`](glossary.md#route-link) is that veto. Its roster is closed: `nil`,
-`[::h/prevent [:app/event]]`, an [`h/event`](glossary.md#hevent) form, or a plain function.
+A link may need to cancel its own navigation — for example, confirm before
+discarding a scratch pane. Pass that as `:on-click` on `route-link`. Allowed
+values: `nil`, `[::h/prevent [:app/event]]`, an `h/event` form, or a plain
+function.
 
 ```clojure
 (route-link {:to       :app/inbox
-             :on-click (when draft-open?          ;; an ordinary read in this view
+             :on-click (when draft-open?
                          [::h/prevent [:composer/confirm-discard]])}
   "Inbox")
 ```
 
-The prevent form is the declarative veto: it cancels the navigation and
-dispatches your [intent](glossary.md#intent) instead. The link refuses a *bare* intent vector
-there, loudly. The click already produces the one routing intent, and one
-user action must not yield two semantic events.
-
-Do not use the veto to guard unsaved work across a whole page. That job
-belongs to the dirty-leave guard below. The guard covers every exit, not
-only the links you remembered to decorate.
+`[::h/prevent …]` cancels the navigation and dispatches your event instead.
+A bare event vector is refused: the click already produces one routing
+event, and one user action must not yield two. Do not use this veto to guard
+unsaved work across a whole page — that is the dirty-leave guard below,
+which covers every exit, not only decorated links.
 
 ## Warm a destination on intent
 
-A link can warm its destination's data on hover, focus, and touch. The click
-then lands on a fetch already in flight:
+A link can start loading its destination data on hover, focus, and touch so
+the click lands on work already in flight:
 
 ```clojure
 (route-link {:to :app/article :params {:id "intro"} :prefetch :intent}
   "Read more")
 ```
 
-Prefetch accepts only one value: `:intent`. Omit the key for a passive link.
-Any other value fails at render on purpose — a silent wrong mode would look
-identical to "warm on hover," and you would never trust the attribute.
-Internally the [intent](glossary.md#intent) handlers dispatch
-`[:rf.route/prefetch {:to … :params …}]` — an ordinary event that you can
-also dispatch yourself from any handler.
+The only accepted value is `:intent`. Omit the key for a passive link. Any
+other value fails at render — a silent wrong mode would look like "warm on
+hover" and be hard to trust. Internally the handlers dispatch
+`[:rf.route/prefetch {:to … :params …}]`, which you can also dispatch from
+any event handler.
 
-A warm run is not a navigation. The destination may start loading data, but
-that load is not "owned" by the route the way a real visit is: nothing blocks
-the transition, the URL does not change, and guards / scroll / `:on-match`
-do not run. Details of resource ownership live in
-[Async resources](08-async-resources.md); here the rule is simpler — prefetch
-is a performance hint, not authorization. Click through, and the ordinary
-resource dedupe reuses the warmed work. Never click, and the warmed work
-stays garbage-collectable. To warm a destination whose `:can-enter` would
-refuse is permitted and means nothing: activation still evaluates that guard
-on a real navigation.
+Prefetch is not navigation. Data may start loading, but nothing blocks a
+transition, the URL does not change, and guards, scroll, and `:on-match` do
+not run. Details of resource ownership live in
+[Async resources](08-async-resources.md). Prefetch is a performance hint,
+not authorization. Click through and ordinary resource dedupe reuses the
+warmed work. Never click, and that work stays garbage-collectable. Warming a
+destination whose `:can-enter` would refuse is allowed and means nothing:
+activation still evaluates the guard on a real navigation.
 
-## Scroll conduct
+## Scroll
 
 Scroll policy is route data, not view code. Declare it per route (`:scroll`
 metadata) or per navigation (`:scroll` on the navigate request):
@@ -181,23 +166,21 @@ metadata) or per navigation (`:scroll` on the navigate request):
 | `:restore` | Return to where the page was left | Back/Forward |
 | `:preserve` | Leave the viewport alone | Opt-in |
 
-The defaults are right for pages. You set two cases by hand:
+Defaults are right for most pages. Set two cases by hand:
 
-- An in-place query navigation on a list — pagination, a filter chip — should
-  usually hold the viewport still:
+- An in-place query navigation on a list — pagination, a filter chip —
+  usually should hold the viewport:
   `(rf/dispatch [:rf.route/navigate {:query-merge {:page 2} :scroll :preserve}])`.
-- Restoration works only when the page has its full height back. Back/Forward
-  onto a page whose list is still loading restores against a short page, and
-  the viewport lands at the top anyway. Declare the page's data as blocking
-  route `:resources` — or keep previous data on screen — so the content is
-  present when the restore runs.
+- Restoration needs full page height. Back/Forward onto a page whose list is
+  still loading restores against a short page and lands at the top. Declare
+  the page's data as blocking route `:resources`, or keep previous data on
+  screen, so content is present when restore runs.
 
 ## Focus after a route change
 
-A route change repaints the whole page but moves focus nowhere. A
-screen-reader user who activated "Articles" is still focused on the link they
-clicked, and hears no announcement that anything happened. The recipe is
-ordinary code, in three moves:
+A route change repaints the page but moves focus nowhere. A screen-reader
+user who activated "Articles" is still on the link they clicked and hears no
+announcement. The recipe:
 
 1. Key the main region by page identity.
 2. Make the region programmatically focusable.
@@ -211,8 +194,8 @@ ordinary code, in three moves:
   (let [route (h/sub [:rf.route/id])]
     [:div.app
      [site-nav]
-     [:main {:key       route        ;; remount exactly when the page changes…
-             :tab-index -1           ;; …focusable, but not in the tab order
+     [:main {:key       route        ;; remount when the page changes
+             :tab-index -1           ;; focusable, not in the tab order
              :ref       focus-page}  ;; refs run after commit
       (case route
         :app/home    [home-page]
@@ -222,24 +205,22 @@ ordinary code, in three moves:
 
 `:key route` remounts `<main>` when the page identity changes, so the ref
 runs again and focus lands on the new page. Query-only and fragment-only
-changes keep the same route id. The region does not remount, and a filter
-click does not move focus. `preventScroll` stops the focus call from fighting
-the scroll policy above: routing owns scroll, and this recipe owns focus. If
-"a new page" means more than the route id to you — article 7 to article 9 —
-widen the key with the identifying param: `{:key (str route "|" article-id)}`.
+changes keep the same route id — the region does not remount, and a filter
+click does not move focus. `preventScroll` stops the focus call from
+fighting scroll policy: routing owns scroll; this recipe owns focus. If "a
+new page" means more than the route id (article 7 → article 9), widen the
+key: `{:key (str route "|" article-id)}`.
 
-Focus for [overlays](glossary.md#overlay) — modals, popovers — is a different job with its own owner:
-the focus [intent](glossary.md#intent) in [Overlays and focus](12-overlays-and-focus.md).
+Focus for modals and popovers is a different job —
+[Overlays and focus](12-overlays-and-focus.md).
 
-## The dirty-leave guard
+## Unsaved changes (dirty-leave guard)
 
-"You have unsaved changes" is state-driven code end to end. The guard is a
+"You have unsaved changes" is ordinary state end to end. The guard is a
 subscription, the blocked attempt is a value, the dialog is a view, and the
 user's choice is an event. There is no blocker hook and no `window.confirm`.
 
-Declare when leaving is safe, and put the guard on the route. The blocking
-mechanism is the router's. The routing corpus's *Guard against unsaved
-changes* recipe is the full treatment:
+Declare when leaving is safe, and put the guard on the route:
 
 ```clojure
 (rf/reg-sub :editor/can-leave?
@@ -255,8 +236,7 @@ changes* recipe is the full treatment:
 
 When the guard returns `false`, nothing commits: the URL and state do not
 change, and the attempt parks in `[:rf/pending-navigation]`. Render the
-prompt off that value, with the choices as [intent](glossary.md#intent) vectors that carry the
-pending id:
+prompt from that value:
 
 ```clojure
 (h/defview leave-guard-dialog []
@@ -268,15 +248,15 @@ pending id:
 ```
 
 Mount it once near the root; it renders nothing until an attempt parks.
-`:rf.route/continue` replays exactly the navigation the user asked for —
+`:rf.route/continue` replays the navigation the user asked for —
 destination, `:replace?`, scroll policy. `:rf.route/cancel` drops it. Both
-take the pending id, so a stale click on an already-resolved dialog is a safe
-no-op. In a real app, render the box through the [overlay](glossary.md#overlay) module's modal, so
-focus is trapped and restored ([Overlays and focus](12-overlays-and-focus.md)).
+take the pending id, so a stale click on an already-resolved dialog is a
+safe no-op. In a real app, render the box through the overlay module's modal
+so focus is trapped and restored ([Overlays and focus](12-overlays-and-focus.md)).
 The state shape here does not change.
 
 "Save and close" must leave without the prompt. Save, then navigate with the
-explicit one-shot bypass:
+one-shot bypass:
 
 ```clojure
 (rf/reg-event :editor/save-and-close
@@ -287,67 +267,65 @@ explicit one-shot bypass:
                                           :bypass-leave? true}]]]}))
 ```
 
-`:bypass-leave?` skips this route's `:can-leave` for this one navigation and
-nothing else. The destination's `:can-enter` still runs.
+`:bypass-leave?` skips this route's `:can-leave` for this one navigation
+only. The destination's `:can-enter` still runs.
 
 !!! warning "The browser's exits are not yours"
-
     A pending value is a fact inside your app; it cannot stop a tab close, an
     external link, or a reload. Pair the guard with a `beforeunload` listener
-    that reads the *same* `:editor/can-leave?` sub — one dirty flag, two
-    exits. The listener recipe is in the routing corpus. Routing deliberately
-    does not wrap the browser's own dialog.
+    that reads the same `:editor/can-leave?` sub — one dirty flag, two exits.
+    The listener recipe is in the routing corpus. Routing does not wrap the
+    browser's own dialog.
 
 ## Deep links, Back and Forward
 
-There is no separate code path for "the user arrived by URL" or "the user
-pressed Back". The URL is an input. A deep link is the first URL input at
-boot, and Back/Forward are history inputs. Both run the same match → validate
-→ guard → activate pipeline as a link click. The conduct that follows:
+There is no separate path for "arrived by URL" or "pressed Back". The URL is
+an input. A deep link is the first URL at boot; Back/Forward are history
+inputs. Both run the same match → validate → guard → activate pipeline as a
+link click.
 
-- A deep link onto a route with `:query-defaults` arrives with the defaults
-  filled. Views read `(h/sub [:rf.route/query])` and never special-case
-  "first load".
+- A deep link onto a route with `:query-defaults` arrives with defaults
+  filled. Views read `(h/sub [:rf.route/query])` and do not special-case
+  first load.
 - Guards run at every entry: navigate, link, address bar, Back/Forward,
-  initial load, SSR. The dirty-leave dialog parks a Back press exactly as it
-  parks a link click.
-- Back/Forward restore scroll by default (`:restore`). The focus recipe moves
-  focus because the route id changed, and `preventScroll` keeps the two from
-  fighting.
-- A navigation does not cancel in-flight async work. A save still pending
-  when the user leaves is a mutation with an instance status readable from
-  anywhere. Its cache consequences land regardless of the current page
+  initial load, SSR. The dirty-leave dialog parks a Back press the same way
+  it parks a link click.
+- Back/Forward restore scroll by default (`:restore`). The focus recipe
+  moves focus because the route id changed; `preventScroll` keeps the two
+  from fighting.
+- Navigation does not cancel in-flight async work. A save still pending when
+  the user leaves keeps an instance status readable from anywhere; cache
+  consequences land regardless of the current page
   ([Async resources](08-async-resources.md)). The guard protects unsaved
   local state; supersession protects the reply race.
-- On the server, the same pipeline runs for the request URL, and the client
+- On the server, the same pipeline runs for the request URL; the client
   hydrates without re-running it ([SSR and hydration](17-ssr-and-hydration.md)).
 
 ??? info "Coming from React Router?"
-
-    Three instincts mislead here. There is no `<Link>` component:
-    [`route-link`](glossary.md#route-link) is a plain function that returns an anchor with data on it.
-    There is no `useBlocker` or `usePrompt`: the blocked attempt is app state
-    you render. There is no `router.prefetch()` call: warming is an event.
-    Everything you would reach into router context for is a subscription.
+    There is no `<Link>` component: `route-link` is a plain function that
+    returns an anchor with data on it. There is no `useBlocker` or
+    `usePrompt`: the blocked attempt is app state you render. There is no
+    `router.prefetch()` call: warming is an event. Everything you would
+    reach into router context for is a subscription.
 
 ## Troubleshooting
 
-| Symptom | What went wrong | Fix |
+| Symptom | Cause | Fix |
 |---|---|---|
-| Rendering a link throws `:rf.error/routing-artefact-missing` | The core routing artefact is not loaded | `(:require [re-frame.routing])` at boot, before first render |
-| A link full-page reloads | A hand-written `[:a {:href …}]` bypasses interception | Use [`route-link`](glossary.md#route-link), or the document-level click listener recipe from the routing corpus |
-| `:rf.error/hicasso-malformed-navigate` at render | A hand-built or edited `::h/navigate` head | Don't write the head; [`route-link`](glossary.md#route-link) mints it |
-| A [`route-link`](glossary.md#route-link) refuses your `:on-click` [intent](glossary.md#intent) vector | One click must not yield two semantic events | Wrap it: `[::h/prevent [:app/event]]` — cancel-and-replace |
-| A link carrying `:prefetch` refuses at render | Only `:intent` is accepted; passivity must be visible | Remove the key, or spell `:prefetch :intent` |
-| Leaving always blocks, and an error names the guard | The `:can-leave` sub returned a non-boolean — fail-closed | `:rf.error/can-leave-non-boolean`: return a strict `true`/`false` |
-| Back lands at the top of a long page | Restore ran before the page had its height | Make the page's data blocking route `:resources`, or keep previous data on screen |
+| Rendering a link throws `:rf.error/routing-artefact-missing` | Core routing artefact not loaded | `(:require [re-frame.routing])` at boot, before first render |
+| Link full-page reloads | Hand-written `[:a {:href …}]` bypasses interception | Use `route-link`, or the document-level click listener from the routing corpus |
+| `:rf.error/hicasso-malformed-navigate` at render | Hand-built or edited `::h/navigate` head | Do not write the head; `route-link` creates it |
+| `route-link` refuses your `:on-click` event vector | One click must not yield two semantic events | Wrap it: `[::h/prevent [:app/event]]` |
+| Link with `:prefetch` refuses at render | Only `:intent` is accepted | Remove the key, or spell `:prefetch :intent` |
+| Leaving always blocks; error names the guard | `:can-leave` sub returned a non-boolean | `:rf.error/can-leave-non-boolean`: return strict `true`/`false` |
+| Back lands at the top of a long page | Restore ran before the page had its height | Blocking route `:resources`, or keep previous data on screen |
 | Focus goes nowhere after navigating | Main region not keyed, or not focusable | `:key` by page identity, `:tab-index -1`, focus in the `:ref` |
 
 ## When not to use this module
 
 | Situation | Prefer |
 |---|---|
-| Single-screen app, no shareable URLs | No routing artefact at all — there is nothing to integrate |
-| In-memory UI steps that shouldn't touch the URL — wizard panes, non-linkable tabs | app-db state, or a machine |
-| External links | A plain `[:a {:href …}]` — [`route-link`](glossary.md#route-link) is for the route table |
+| Single-screen app, no shareable URLs | No routing artefact |
+| In-memory UI steps that should not touch the URL — wizard panes, non-linkable tabs | app-db state, or a machine |
+| External links | A plain `[:a {:href …}]` — `route-link` is for the route table |
 | Guarding one button, not a page's exits | The veto roster on that link, or ordinary app logic |

--- a/docs/design/hicasso/draft-guide/08-async-resources.md
+++ b/docs/design/hicasso/draft-guide/08-async-resources.md
@@ -1,45 +1,41 @@
 # Async resources
 
-Async replies arrive late, out of order, and for screens that no longer exist.
-The transport is the core resource model (`re-frame.resources`); that corpus
-teaches registered reads, causes, status maps you can subscribe to, and
-mutations that invalidate by tag. This page owns the [Hicasso](glossary.md#hicasso)
-patterns on top — starting with the race that eats draft edits. Later sections
-cover per-instance mutation status, cancellation, and
-[demand-driven committed reads](glossary.md#demand-driven-committed-read).
+Async replies arrive late, out of order, and for screens that no longer
+exist. The transport is the core resource model (`re-frame.resources`):
+registered reads, causes, status maps you can subscribe to, and mutations
+that invalidate by tag. That corpus teaches the model. This page owns the
+Hicasso patterns on top — starting with the race that overwrites draft
+edits — then per-instance mutation status, cancellation, and demand-driven
+committed reads.
 
-In a Hicasso view, you read a resource with the same [`h/sub`](glossary.md#hsub)
-as any subscription.
-
-> **The read owns the lifetime, you own the policy, and the runtime owns the race.**
+In a Hicasso view, read a resource with the same `h/sub` as any subscription.
 
 ## A late reply must not overwrite newer edits
 
-This is the race. The user saves a profile. The server normalizes the profile —
-it trims values, canonicalizes them, and fills fields — and replies 800 ms
-later. During those 800 ms, the user continued to type. If you write the reply
-over the draft, you delete the newest edits. If you drop the reply, you lose
-the normalization. The fix is the **correlation recipe**: capture a basis when
+The user saves a profile. The server normalizes fields and replies 800 ms
+later. During those 800 ms the user kept typing. If you write the reply over
+the draft, you delete the newest edits. If you drop the reply, you lose the
+normalization. The fix is a **correlation recipe**: capture a basis when
 work starts, compare when the result lands, and let newer facts win their
-slots. Applied to drafts, this recipe is the **settle-merge**.
+slots. For drafts, that recipe is a **settle-merge**.
 
-Two protections apply here, and they do different jobs:
+Two protections do different jobs:
 
 - **Supersession** is the runtime's job. When a reply loses the race with a
   *newer attempt* under the same instance, the runtime suppresses that reply.
-  The reply never reaches you.
+  It never reaches you.
 - **Settle-merge** is your job. A reply that reaches you is current, but the
-  *draft* can have changed after you sent it. Merge the reply into the draft.
-  Do not overwrite the draft.
+  *draft* may have changed after you sent it. Merge the reply into the draft;
+  do not overwrite the draft.
 
-The registration is ordinary. The submit handler starts the write with the
-draft as params and with a continuation:
+Registration is ordinary. The submit handler starts the write with the draft
+as params and a continuation:
 
 ```clojure
 (ns app.profile
   (:require [re-frame.core :as rf]
-            [re-frame.resources]          ;; the resource/mutation model
-            [re-frame.http.managed]))     ;; the HTTP transport it lowers to
+            [re-frame.resources]          ;; resource/mutation model
+            [re-frame.http.managed]))     ;; HTTP transport
 
 (rf/reg-mutation :profile/save
   {:params-schema [:map [:username :string] [:bio :string] [:email :string]]
@@ -49,7 +45,7 @@ draft as params and with a continuation:
     {:request {:method :put :url "/api/profile" :body {:profile profile}}
      :decode  :json}))
 
-;; dispatched from your submit handler; draft = the current [:profile :draft]
+;; from your submit handler; draft = the current [:profile :draft]
 [:rf.mutation/execute {:mutation :profile/save
                        :params   draft
                        :instance [:profile-save]
@@ -57,11 +53,11 @@ draft as params and with a continuation:
 ```
 
 The recipe lives in the continuation. The uniform reply carries the decoded
-`:value` *and* the accepted `:params`. The `:params` are the basis you sent —
-you do not carry the basis by hand:
+`:value` *and* the accepted `:params` — the basis you sent, so you do not
+carry it by hand:
 
 ```clojure
-;; Field by field: the settled value lands only where the draft still matches
+;; Field by field: settled value lands only where the draft still matches
 ;; what was sent; a newer edit keeps its field.
 (rf/reg-event :profile/save-settled
   (fn [{:keys [db]} [_ {:keys [status value params error]}]]
@@ -79,22 +75,21 @@ you do not carry the basis by hand:
       {:db (assoc-in db [:profile :save-error] error)})))
 ```
 
-The rule in one line: **a field that did not change after the send takes the
-settled value; a field that changed keeps the newer edit.** `:reply-to` fires
-only for a reply that the runtime accepts as current. It never fires for a
-stale or superseded reply. It fires only after cache consequences and after
-instance settlement. Therefore one comparison remains: the current draft
-against the sent params.
+A field that did not change after the send takes the settled value; a field
+that changed keeps the newer edit. `:reply-to` fires only for a reply the
+runtime accepts as current — never for a stale or superseded reply, and only
+after cache consequences and instance settlement. The comparison left for
+you is current draft against sent params.
 
-The same shape answers each "late result versus newer truth" question below.
-In the debounce, a generation number is the basis. In optimistic rollback, the
+The same shape answers other "late result versus newer truth" cases. In a
+debounce, a generation number is the basis. In optimistic rollback, the
 runtime captures the basis for you. Validation display for drafts — touched
 fields and submit gating — is the forms module's job ([Forms](05-forms.md)).
 
 ## Per-instance mutation status
 
-A feed has forty favorite buttons. "Is my save in flight?" is a per-button
-fact. Status is keyed by an instance id that you choose. Key the instance per
+A feed has many favorite buttons. "Is my save in flight?" is a per-button
+fact. Status is keyed by an instance id you choose. Key the instance per
 row, and each button watches its own write:
 
 ```clojure
@@ -110,25 +105,25 @@ row, and each button watches its own write:
      (if favorited? "Favorited" "Favorite")]))
 ```
 
-Look at the click. It is one literal event vector — mutation, params, instance,
-and cause, all data. A structural test therefore asserts the whole write [intent](glossary.md#intent)
-with `=`. The instance sub yields `:pending?`, `:success?`, `:error?`,
-`:settled?`, `:optimistic?`, `:result`, and `:error`. Focused projections such
-as `[:rf.mutation/pending? {…}]` exist for a button that needs one boolean.
+The click is one literal event vector — mutation, params, instance, and
+cause, all data. A structural test can assert the whole write with `=`. The
+instance sub yields `:pending?`, `:success?`, `:error?`, `:settled?`,
+`:optimistic?`, `:result`, and `:error`. Focused projections such as
+`[:rf.mutation/pending? {…}]` exist when a button needs one boolean.
 
-Two instance rules carry this section. First, **different instances never
-overwrite each other**: two rows save concurrently, each with independent
-status. Second, **the same instance supersedes**: when you re-execute while an
-attempt is pending, the runtime suppresses the earlier attempt's reply. A
-settled `:error` stays until you retry with the same execute, or until you
-dismiss it with `[:rf.mutation/clear {:instance …}]`. The clear also aborts
-in-flight work on a best-effort basis.
+Two instance rules matter. **Different instances never overwrite each
+other** — two rows save concurrently with independent status. **The same
+instance supersedes** — re-execute while pending and the runtime suppresses
+the earlier attempt's reply. A settled `:error` stays until you retry with
+the same execute, or dismiss it with
+`[:rf.mutation/clear {:instance …}]` (which also best-effort aborts in-flight
+work).
 
 ### Optimistic flip, automatic rollback
 
-A favorite toggle must not wait 300 ms. Declare the optimistic plan on the
-registration. The runtime then flips the cache before the request. At settle
-time, the runtime commits, rolls back, or reconciles:
+A favorite toggle should not wait hundreds of milliseconds. Declare the
+optimistic plan on the registration. The runtime flips the cache before the
+request, then commits, rolls back, or reconciles at settle time:
 
 ```clojure
 (rf/reg-mutation :article/favorite
@@ -145,47 +140,39 @@ time, the runtime commits, rolls back, or reconciles:
 ```
 
 You never write the rollback. The runtime snapshots each entry before the
-forward patch. On an `:error` or a cancellation, the runtime restores exactly
-that snapshot. You never maintain an inverse patch by hand, so the inverse
-cannot drift. On success, the authoritative reply overwrites the guess. A
-concurrent write can land between the flip and the settle. In that case the
-default `:on-conflict :invalidate` does not restore the snapshot over the
-newer truth. It marks the entry stale and lets a refetch settle it. That is
-the settle-merge principle, applied by the runtime at the cache. While the
-flip is unconfirmed, the instance carries `:optimistic? true`.
+forward patch. On `:error` or cancellation it restores that snapshot — so an
+inverse patch cannot drift. On success, the authoritative reply overwrites
+the guess. If a concurrent write lands between flip and settle, the default
+`:on-conflict :invalidate` does not restore the snapshot over newer truth: it
+marks the entry stale and lets a refetch settle it. While the flip is
+unconfirmed, the instance carries `:optimistic? true`.
 
 ## Cancellation and supersession
 
-Nothing cancels implicitly, and you hand-code no race:
+Nothing cancels implicitly, and you do not hand-code the race:
 
-| Concern | Owner | The move |
+| Concern | Owner | What happens |
 |---|---|---|
-| A reply beaten by a newer attempt, same instance | Runtime | Suppressed; its `:reply-to` never fires |
-| A reply beaten by a newer fetch, same resource identity | Runtime | New generation supersedes; the stale reply never touches the cache |
-| Dismissing a settled error, abandoning a write | You | `[:rf.mutation/clear {:instance …}]` — clears status, best-effort aborts |
-| Stopping a read you no longer want | You | Withdraw the read — a state change; its demand releases (below), in-flight work aborts best-effort |
+| Reply beaten by a newer attempt, same instance | Runtime | Suppressed; its `:reply-to` never fires |
+| Reply beaten by a newer fetch, same resource identity | Runtime | New generation supersedes; stale reply never touches the cache |
+| Dismiss a settled error, abandon a write | You | `[:rf.mutation/clear {:instance …}]` — clears status, best-effort abort |
+| Stop a read you no longer want | You | Withdraw the read — demand releases (below); in-flight work aborts best-effort |
 | What "newer" means | You | Identity is the policy: instance and params decide which attempts race |
 
-The last row is the design point. When you choose `[:favorite slug]` over
-`[:favorite]` as the instance, you choose what supersedes what. The runtime
-enforces the race that you declared. It never invents one.
+When you choose `[:favorite slug]` over `[:favorite]` as the instance, you
+choose what supersedes what. The runtime enforces the race you declared.
 
 ## Demand-driven committed reads
 
-The patterns above leave one correlation hand-written: the correlation between
-a resource's lifetime and the view that reads it. Route `:resources` owns page
-data, and that is correct for page identity. But some resources are keyed by
-view-local state — a typeahead's suggestions, a picker's options, a hover
-preview. Such a resource belongs to no route, and the hand-written answer is
-ceremony:
+The patterns above leave one correlation hand-written: the lifetime of a
+resource versus the view that reads it. Route `:resources` owns page data,
+and that is correct for page identity. Some resources are keyed by view-local
+state — typeahead suggestions, picker options, a hover preview. Those belong
+to no route. The hand-written answer is ceremony: ensure on mount, release
+on unmount, re-ensure on parameter change — each step a chance for a leak.
 
-- ensure on mount
-- release on unmount
-- re-ensure on parameter change
-
-Each step is an opportunity for a leak or for an orphaned fetch. [Hicasso](glossary.md#hicasso)
-closes the gap with the committed read itself. A read of a resource may
-declare demand:
+Hicasso closes that with the committed read. A resource read may declare
+demand:
 
 ```clojure
 (h/sub [:rf/resource {:resource :app/suggestions
@@ -193,37 +180,31 @@ declare demand:
                       :demand   true}])
 ```
 
-The law, in full:
+Rules:
 
 - **Commit acquires.** When a render that took this read commits, the read
-  becomes the owner of demand for exactly that resource and params. The ensure
-  runs after the commit. A render alone acquires nothing. An abandoned render,
-  a StrictMode double-invoke, and a retry each acquire zero times, by
-  construction.
-- **Liveness releases.** Demand releases on unmount. It releases on parameter
-  change: the old identity releases as the new identity acquires. It also
-  releases when a committed render stops taking the read — for example, when a
-  conditional becomes false. That case is ordinary, because reads are legal in
-  branches.
+  owns demand for that resource and params. The ensure runs after commit. A
+  render alone acquires nothing. An abandoned render, a StrictMode
+  double-invoke, and a retry each acquire zero times.
+- **Liveness releases.** Demand releases on unmount, on parameter change
+  (old identity releases as the new acquires), and when a committed render
+  stops taking the read (for example a conditional becomes false). Reads in
+  branches are legal, so that last case is ordinary.
 - **Demand is not retention.** Release withdraws the ownership hold. The
-  cached entry then lives out its ordinary cache lifetime (`:gc-after-ms`). A
-  move between two queries therefore rejoins warm entries instead of
-  refetching.
-- **Nothing else is inferred.** Debounce, supersession, refresh-with-data, and
-  cancellation stay exactly where the rest of this page put them. Demand
-  decides *that* the resource is wanted while the read is live. Demand never
-  decides *how* the resource behaves.
-- **It costs nothing elsewhere.** Demand uses the committed-read membership
-  that the runtime already keeps. A read contributes membership, not a record,
-  and no per-read ledger exists. A [boundary](glossary.md#boundary) that reads no resource carries
-  none of this.
+  cached entry then lives out its ordinary lifetime (`:gc-after-ms`). Moving
+  between two queries can rejoin warm entries instead of refetching.
+- **Nothing else is inferred.** Debounce, supersession, refresh-with-data,
+  and cancellation stay where this page already put them. Demand decides
+  *that* the resource is wanted while the read is live, not *how* it behaves.
+- **It costs nothing elsewhere.** Demand uses committed-read membership the
+  runtime already keeps. A view that reads no resource carries none of this.
 
-Without `:demand true`, the sub is the core passive projection, and it never
+Without `:demand true`, the sub is the core passive projection and never
 causes work. A missing cause still means an honest, permanent `:idle`.
 
-### The typeahead, end to end
+### Typeahead end to end
 
-This worked example exercises every policy at once.
+This example exercises the policies together.
 
 ```clojure
 (rf/reg-resource :app/suggestions
@@ -236,11 +217,10 @@ This worked example exercises every policy at once.
      :decode  :json}))
 ```
 
-The debounce is explicit policy at the event layer. The input echoes every
-keystroke, because the controlled write stays synchronous. Debounce the
-*consumers* of a value, never the write
-([Controlled inputs](04-controlled-inputs.md)). What settles is the committed
-query. A generation guards it, so a stale timer commits nothing:
+Debounce is explicit policy at the event layer. The input echoes every
+keystroke (controlled write stays synchronous). Debounce the *consumers* of
+a value, never the write ([Controlled inputs](04-controlled-inputs.md)). A
+generation guards the committed query so a stale timer commits nothing:
 
 ```clojure
 (rf/reg-sub :search/text        (fn [db _] (get-in db [:search :text] "")))
@@ -256,19 +236,19 @@ query. A generation guards it, so a stale timer commits nothing:
 
 (rf/reg-event :search/settle
   (fn [{:keys [db]} [_ gen]]
-    (if (= gen (get-in db [:search :gen]))     ;; the correlation recipe again
+    (if (= gen (get-in db [:search :gen]))
       {:db (assoc-in db [:search :committed-q] (get-in db [:search :text]))}
-      {})))                                    ;; a stale timer commits nothing
+      {})))
 
 (rf/reg-event :search/clear
   (fn [{:keys [db]} _]
     {:db (update db :search assoc
                  :text "" :committed-q ""
-                 :gen  (inc (get-in db [:search :gen] 0)))}))  ;; pending timers go stale
+                 :gen  (inc (get-in db [:search :gen] 0)))}))
 ```
 
-Now the views. The list exists only while a committed query exists, and the
-list's committed read declares demand:
+The list exists only while a committed query exists, and its committed read
+declares demand:
 
 ```clojure
 (h/defview suggestion-list [{:keys [q]}]
@@ -296,61 +276,55 @@ list's committed read declares demand:
        [suggestion-list {:q q}])]))
 ```
 
-Walk the timeline, and every policy is visible:
+Timeline:
 
-1. **`c` … `cl`** — each keystroke echoes through the [controlled input](glossary.md#controlled-field) at
-   once. The generation increments. Nothing fetches. Debounce is your
-   event-layer policy.
-2. **250 ms of quiet** — the surviving timer's generation matches, and
-   `:committed-q` becomes `"cl"`. `suggestion-list` mounts, and the render
-   commits. The committed read acquires demand for `{:q "cl"}`, and the fetch
+1. **`c` … `cl`** — each keystroke echoes through the controlled input. The
+   generation increments. Nothing fetches. Debounce is event-layer policy.
+2. **250 ms of quiet** — the surviving timer's generation matches;
+   `:committed-q` becomes `"cl"`. `suggestion-list` mounts and the render
+   commits. The committed read acquires demand for `{:q "cl"}` and the fetch
    begins. If React had discarded that render, nothing would have been
    acquired.
-3. **`clo` before the reply lands** — the parameters change. `{:q "cl"}`
-   releases, and `{:q "clo"}` acquires. The in-flight request for `{:q "cl"}`
+3. **`clo` before the reply lands** — parameters change. `{:q "cl"}`
+   releases; `{:q "clo"}` acquires. The in-flight request for `{:q "cl"}`
    aborts best-effort. If its reply arrives anyway, the runtime's stale-reply
    check suppresses it. With `:keep-previous? true`, the `"cl"` list stays on
-   screen with `:fetching?` true. That is refresh-with-data instead of a flash
-   of empty content.
-4. **Escape, or navigation away mid-fetch** — `:search/clear` empties the
-   committed query. The list unmounts, and the demand releases. Navigation
-   away from the page causes the same release by a different path.
-   Cancellation was a state change that you wrote, not a lifecycle hook.
-   Teardown residue is zero.
-5. **Typing `cl` again, seconds later** — release made the entry demand-free;
-   release did not destroy it. Within `:gc-after-ms`, the read rejoins the
-   warm entry. If the entry is still fresh within `:stale-after-ms`, no
-   request occurs at all.
+   screen with `:fetching?` true (refresh-with-data, not a flash of empty).
+4. **Escape or navigate away mid-fetch** — `:search/clear` empties the
+   committed query. The list unmounts; demand releases. Cancellation was a
+   state change you wrote, not a lifecycle hook.
+5. **Typing `cl` again soon** — release made the entry demand-free; it did
+   not destroy it. Within `:gc-after-ms`, the read rejoins the warm entry. If
+   still fresh within `:stale-after-ms`, no request occurs.
 
-The typeahead never contains the ceremony that this feature deletes: no
-ensure-on-mount effect, no release-on-unmount cleanup, no params-change
-watcher. The correlation between read liveness and resource demand has one
-owner — the read.
+There is no ensure-on-mount effect, release-on-unmount cleanup, or
+params-change watcher. The correlation between read liveness and resource
+demand has one owner — the read.
 
-Two edges remain. Under Xray, held demand is a bounded projection: which
-resources are owned by which committed reads, and why each fetch fired
-([Diagnostics](15-diagnostics.md)). On the server, the [boundary](glossary.md#boundary) is Client-only
-by default — a deterministic fallback and zero acquisition, because
-acquisition is a client commit fact. Hydration then adopts without a duplicate
-fetch ([SSR and hydration](17-ssr-and-hydration.md)).
+Under Xray, held demand is a bounded projection: which resources are owned
+by which committed reads, and why each fetch fired
+([Diagnostics](15-diagnostics.md)). On the server, the view is Client-only by
+default — a deterministic fallback and zero acquisition, because acquisition
+is a client commit fact. Hydration then adopts without a duplicate fetch
+([SSR and hydration](17-ssr-and-hydration.md)).
 
 ## Troubleshooting
 
-| Symptom | What went wrong | Fix |
+| Symptom | Cause | Fix |
 |---|---|---|
 | Permanent `:idle` skeleton | Nothing declares demand or any other cause | `:demand true` on the committed read — or a route `:resources` entry / explicit ensure where the route owns the data |
-| `:rf.error/resources-artefact-missing` at boot | The resource model is not loaded | `(:require [re-frame.resources])`, usually with `re-frame.http.managed` |
+| `:rf.error/resources-artefact-missing` at boot | Resource model not loaded | `(:require [re-frame.resources])`, usually with `re-frame.http.managed` |
 | Suggestions flash empty on every keystroke | Each params value is a new cache identity | `:keep-previous? true` on the read; render `:fetching?` as the quiet indicator |
-| Results for an old query overwrite new ones | A hand-rolled fetch outside the resource model | Let the runtime own replies — identity plus generation suppress stale ones; a hand-rolled loader needs the correlation recipe |
-| A read throws after the render, naming the query | The read escaped the direct synchronous body — callback, promise, timer, lazy seq | Read during the body and close over the value ([Views and reads](02-views-and-reads.md)) |
+| Results for an old query overwrite new ones | Hand-rolled fetch outside the resource model | Let the runtime own replies — identity plus generation suppress stale ones |
+| Read throws after the render, naming the query | Read escaped the direct synchronous body — callback, promise, timer, lazy seq | Read during the body and close over the value ([Views and reads](02-views-and-reads.md)) |
 | Every row's button goes pending together | One shared instance id | Key the instance per row: `[:favorite slug]` |
-| Keystrokes vanish when a save reply lands | The reply was written wholesale over the draft | Settle-merge: take settled values only where the draft still equals the sent basis |
-| An optimistic value reverts over a newer concurrent write | `:on-conflict :force` restores the snapshot blindly | Keep the default `:invalidate` — stale-mark and refetch instead of overwriting |
+| Keystrokes vanish when a save reply lands | Reply written wholesale over the draft | Settle-merge: take settled values only where the draft still equals the sent basis |
+| Optimistic value reverts over a newer concurrent write | `:on-conflict :force` restores the snapshot blindly | Keep the default `:invalidate` — stale-mark and refetch |
 
 ## When not to use demand
 
 Demand-driven reads own **resource lifetimes that match a read's lifetime**.
-They are not a fetch library:
+They are not a general fetch library:
 
 | Job | Owner |
 |---|---|
@@ -359,18 +333,15 @@ They are not a fetch library:
 | "Refetch on click" | `[:rf.resource/refetch …]` — an event, because that is a cause, not a lifetime |
 | A one-off uncached call | Managed HTTP: request out, uniform reply in |
 | Draft state, validation gating, submit flow | The forms module ([Forms](05-forms.md)) |
-| A multi-step async workflow with named stages | A machine owning the ensures, with resource status driving transitions |
+| Multi-step async workflow with named stages | A machine owning the ensures, with resource status driving transitions |
 
-If no view reads the resource, demand cannot express it. That is by design: a
-demand with no reader is exactly the hand-written correlation that this
-feature retired.
+If no view reads the resource, demand cannot express it. A demand with no
+reader is exactly the hand-written correlation this feature removes.
 
 ??? info "Coming from TanStack Query?"
-
-    `useQuery` has a close shape: read it and it fetches; unmount and it
-    forgets. Three differences are deliberate. First, acquisition happens at
-    commit, so speculative renders fetch nothing. Second, policies are not
-    call-site options: debounce lives in your events, staleness and GC live on
-    the registration, and supersession lives in the runtime's identity rules.
-    Third, the cache is causal: writes invalidate by declared tags, not by a
-    remembered `invalidateQueries`.
+    `useQuery` is close: read it and it fetches; unmount and it forgets.
+    Three differences matter. Acquisition happens at commit, so speculative
+    renders fetch nothing. Policies are not call-site options: debounce lives
+    in your events, staleness and GC on the registration, supersession in the
+    runtime's identity rules. The cache is causal: writes invalidate by
+    declared tags, not by a remembered `invalidateQueries`.

--- a/docs/design/hicasso/draft-guide/09-interop.md
+++ b/docs/design/hicasso/draft-guide/09-interop.md
@@ -1,7 +1,7 @@
 # Interop
 
 You want a date picker from npm, not a hand-written calendar. Declare the
-component once. Then use it anywhere a view is legal:
+component once, then use it anywhere a view is legal:
 
 ```clojure
 (ns app.hosts.date-picker
@@ -23,50 +23,38 @@ component once. Then use it anywhere a view is legal:
                 :on-change (h/event [date & _] [:task/set-due date])}])
 ```
 
-> **Declare the host once. Then use it as an ordinary view head.**
+Children cross as ordinary hiccup. `h/defhost` is the declared door to
+foreign React. The rest of this page is that door's contract.
 
-Children cross as ordinary hiccup, and they lower where they render.
-[`h/defhost`](glossary.md#defhost) is the one declared door to foreign React. Everything else on this
-page is that door's contract, seen from a different side.
+Why declare at all? A raw JS component in the tree breaks three things:
 
-Why declare at all? A raw JS component dropped into the tree breaks three
-things at once:
-
-- A JS require in a shared namespace stops JVM loading, and it stops your
-  headless tests with it.
-- The node holds an opaque JS object, so `=` tests stop working at that point.
+- A JS require in a shared namespace stops JVM loading and headless tests.
+- The node holds an opaque JS object, so `=` tests stop working there.
 - Tools get a bare value where they wanted an identity.
 
-[`h/defhost`](glossary.md#defhost) quarantines the require in one `.cljs` host namespace. The rest of
-the tree stays data. You pay the friction once, and every use after that is
-free.
+`h/defhost` keeps the require in one `.cljs` host namespace. The rest of the
+tree stays data.
 
 ## What crosses, and how
 
-Mint a declaration at top level, never during render. With no options:
+Declare at top level, never during render. With no options:
 
 | At the crossing | Behaviour |
 |---|---|
-| Top-level prop names | canonical React slot names — `:on-change` → `onChange`, `:class` → `className`; `data-*` and `aria-*` stay hyphenated |
-| Prop values | cross by identity — a keyword stays a keyword, and a map stays a ClojureScript map. There is **no deep conversion**: nested option maps are not camelCased, and collections are not translated (a guess about which nested maps are options and which are data would be a support trap). When the library documents a JavaScript options object, a camelCase map, or a string, hand it exactly that yourself — `#js {…}`, `clj->js`, `"compact"`, `(name :compact)` |
-| HTML-attribute slots | `:class`, `:id`, `:role`, `data-*`, `aria-*` stringify — an HTML attribute is the destination, and a string is the only representation there. `:class` gets the same coercion as a native tag: `["btn" nil :on]` joins to `"btn on"` |
-| Children | hiccup, lowered where you wrote them |
-| Declared callbacks | the `:callbacks` contract below |
-| Declared slots | ReactNode positions — hiccup lowers there under the captured frame |
+| Top-level prop names | Canonical React slot names — `:on-change` → `onChange`, `:class` → `className`; `data-*` and `aria-*` stay hyphenated |
+| Prop values | Cross by identity — a keyword stays a keyword, a map stays a CLJS map. **No deep conversion**: nested option maps are not camelCased, collections are not translated. When the library wants a JS options object, a camelCase map, or a string, hand it that yourself — `#js {…}`, `clj->js`, `"compact"`, `(name :compact)` |
+| HTML-attribute slots | `:class`, `:id`, `:role`, `data-*`, `aria-*` stringify. `:class` gets the same coercion as a native tag: `["btn" nil :on]` joins to `"btn on"` |
+| Children | Hiccup, lowered where you wrote them |
+| Declared callbacks | The `:callbacks` contract below |
+| Declared slots | ReactNode positions — hiccup becomes elements there under the captured frame |
 | Server | Client-only, unless the declaration says `:server :render` |
 
-The declaration takes four options: `:callbacks`, `:slots`, `:server`, and
-`:fallback`. The declaration refuses an unknown option at mint
-(`:rf.error/hicasso-host-unknown-option`); it does not ignore the option.
-These mistakes also fail at the declaration:
-
-- a bad contract
-- a contract on `:key` or `:ref`
-- duplicate prop spellings
-- a component that resolved to `nil` — the usual cause is a `:default` import
-  from a library with no default export
-
-At the declaration, your stack trace points at your line.
+Options: `:callbacks`, `:slots`, `:server`, and `:fallback`. An unknown
+option raises `:rf.error/hicasso-host-unknown-option` at declaration. These
+also fail at declaration: a bad contract, a contract on `:key` or `:ref`,
+duplicate prop spellings, and a component that resolved to `nil` (usually a
+`:default` import from a library with no default export). Failures point at
+your declaration line.
 
 ## Callbacks: `:event`, `:handler`, `:render`
 
@@ -80,19 +68,18 @@ A declared slot carries a contract. The contract is never inferred from an
                :on-render-row :render}})
 ```
 
-**`:event`** — this slot works as a native `:on-*` does. Write an [intent](glossary.md#intent)
-vector, or write [`h/event`](glossary.md#hevent) when you need the library's arguments. Foreign
-invokers pass *their* arguments — `onPick(value, event)`, `onChange(date)` —
-and every argument reaches the [`h/event`](glossary.md#hevent) body in library order.
+**`:event`** — works like a native `:on-*`. Write an event vector, or
+`h/event` when you need the library's arguments. Foreign invokers pass
+*their* arguments — `onPick(value, event)`, `onChange(date)` — and every
+argument reaches the `h/event` body in library order.
 
 **`:handler`** — the function crosses by identity, with no wrapper. The
-library gets exactly the function that you wrote, and your return value goes
-back to that caller. Use this contract for imperative APIs such as `open()`
-and `scrollTo()`. [Hicasso](glossary.md#hicasso) does not invent meaning for those calls.
+library gets exactly the function you wrote; your return value goes back to
+that caller. Use this for imperative APIs such as `open()` and `scrollTo()`.
 
 **`:render`** — the library calls you *during its own render* (`renderRow`,
 `renderItem`). The body must be pure, and it returns hiccup only through
-[`h/as-element`](glossary.md#as-element):
+`h/as-element`:
 
 ```clojure
 ;; ids came from (h/sub [:feed/ids]) earlier in the body
@@ -104,39 +91,37 @@ and `scrollTo()`. [Hicasso](glossary.md#hicasso) does not invent meaning for tho
                    (str (nth ids i))]))}]
 ```
 
-[`h/as-element`](glossary.md#as-element) is the one explicit hiccup-to-element conversion, and the
-marked form is what carries the frame across the invocation: [`h/event`](glossary.md#hevent) captures
-the supplying [boundary](glossary.md#boundary)'s frame when the body lowers it, and the library's
-later call runs under that frame. The row built in that body carries its
-[intents](glossary.md#intent). The intents fire later, on the user's click, into the frame of the
-[boundary](glossary.md#boundary) that *supplied* the callback. A dispatch *while* the call runs raises
-`:rf.error/hicasso-dispatch-in-render-position`, and the error names the
-position.
+`h/as-element` is the explicit hiccup-to-element conversion. `h/event`
+captures the supplying view's frame when the body builds the callback; the
+library's later call runs under that frame. Event vectors built in that body
+fire later, on the user's click, into the frame of the view that *supplied*
+the callback. A dispatch *while* the call runs raises
+`:rf.error/hicasso-dispatch-in-render-position` and names the position.
 
-**Write the marked form whenever the row carries [intents](glossary.md#intent).** A plain function
-is legal at every contract and crosses untouched — no wrapper, and therefore no
-frame. That is the right choice when the callback returns markup with no intents
-in it: a `[some-view {…}]` head is a [boundary](glossary.md#boundary), and it resolves the frame
-React already has in scope where the library renders it. It is the wrong choice
-the moment an intent appears in the row itself, because lowering one with no
-frame in scope raises `:rf.error/hicasso-intent-outside-boundary`.
+**Write `h/event` whenever the row carries event vectors.** A plain function
+is legal at every contract and crosses untouched — no wrapper, and therefore
+no frame. That is right when the callback returns markup with no event
+vectors in it: a `[some-view {…}]` head resolves the frame React already has
+where the library renders it. It is wrong the moment an event vector appears
+in the row itself, because turning an event vector into a callback with no
+frame raises `:rf.error/hicasso-intent-outside-boundary`.
 
-Two laws close the contract. First, **the declaration wins at every carrier**.
-The `:event` contract accepts an intent vector or a key-map. The `:handler`
-and `:render` contracts refuse the same carrier with
+Two laws close the contract. **The declaration wins at every carrier.**
+`:event` accepts an event vector or a key-map. `:handler` and `:render`
+refuse the same carrier with
 `:rf.error/hicasso-intent-at-a-non-event-contract`. An ordinary unmarked
-function crosses untouched at all three contracts. Second, **intent vectors
-stay event-first** ([Events as data](03-events-as-data.md)). A value-first
-invoker has no DOM event at argument one, so a marker-carrying intent refuses
-with `:rf.error/hicasso-intent-needs-the-event`. [`h/event`](glossary.md#hevent) is the spelling for
-those slots. A bare intent with no marker never touches its arguments, so
+function crosses untouched at all three. **Event vectors stay event-first**
+([Events as data](03-events-as-data.md)). A value-first invoker has no DOM
+event at argument one, so a marker-carrying vector refuses with
+`:rf.error/hicasso-intent-needs-the-event`. `h/event` is the spelling for
+those slots. A bare vector with no marker never touches its arguments, so
 `{:on-pick [:city/picked "paris"]}` is legal under any invoker.
 
 ## ReactNode slots
 
-Some props are not data. They are markup positions: a [modal](glossary.md#overlay)'s title, a footer,
-a Suspense fallback. Declare those props as slots. Hiccup written at a
-declared slot then lowers under the captured frame:
+Some props are markup positions: a modal's title, a footer, a Suspense
+fallback. Declare those props as slots. Hiccup written at a declared slot
+then becomes elements under the captured frame:
 
 ```clojure
 (h/defhost modal Modal
@@ -148,22 +133,22 @@ declared slot then lowers under the captured frame:
         :footer   [:button.danger {:on-click [:article/delete id]} "Delete"]}]
 ```
 
-Intents inside a declared slot fire into the declaring [boundary](glossary.md#boundary)'s frame,
-exactly as [intents](glossary.md#intent) in children do. A string or a ready React element at a
+Event vectors inside a declared slot fire into the declaring view's frame,
+the same as vectors in children. A string or ready React element at a
 declared slot passes as-is. React's own wrappers host the same way: declare
 `Suspense` once with `:slots #{:fallback}`, and write the fallback as hiccup.
 
 At an **undeclared** prop, hiccup is data. `{:title [:h2 "Tasks"]}` hands the
-library the vector `["h2" "Tasks"]`. This happens silently, because a vector
-is a legal value at a data position. That is why you declare slots, and why
-the runtime never guesses them. For a one-off, `(h/as-element [:h2 "Tasks"])`
+library the vector `["h2" "Tasks"]`. That is silent, because a vector is a
+legal value at a data position — which is why you declare slots, and why the
+runtime never guesses them. For a one-off, `(h/as-element [:h2 "Tasks"])`
 crosses a real element through any prop.
 
 ## Providers and compound components
 
-A library provider is only a component, and a compound family is only several
-components. Declare each member that you use. The crossings are real React
-elements, so the library's context flows through them unbroken:
+A library provider is only a component; a compound family is only several
+components. Declare each member you use. Crossings are real React elements,
+so the library's context flows through unbroken:
 
 ```clojure
 (h/defhost themed      (.-Provider theme-context) {:server :render})
@@ -175,36 +160,35 @@ elements, so the library's context flows through them unbroken:
 
 !!! warning "Write `{:server :render}` on every transparent wrapper"
     Under the default Client-only policy, a crossing renders nothing on the
-    server — and "nothing" includes the children. A Client-only provider
-    therefore silently deletes everything beneath it from the response, and
-    the runtime reports no mismatch. So declare `{:server :render}` on every
-    transparent wrapper. For React's own context provider, Render is trivially
-    true. The full story — including the provider whose *value* is
-    browser-derived and has no server answer — is
-    [SSR and hydration](17-ssr-and-hydration.md)'s.
+    server — including children. A Client-only provider therefore silently
+    deletes everything beneath it from the response, with no mismatch report.
+    Declare `{:server :render}` on every transparent wrapper. For React's own
+    context provider, Render is trivially true. Providers whose *value* is
+    browser-derived are covered in
+    [SSR and hydration](17-ssr-and-hydration.md).
 
 ## Server policy, per declaration
 
 Every host states one of two policies.
 
-**Render** — `{:server :render}`. You assert that the component renders
-deterministic server bytes. The component is one tree across server render,
-hydration, and fresh mount.
+**Render** — `{:server :render}`. You assert the component renders
+deterministic server bytes: one tree across server render, hydration, and
+fresh mount.
 
-**Client-only** — the default. The server emits nothing at the crossing, and
-the component appears when the client adopts it. Until adoption,
+**Client-only** — the default. The server emits nothing at the crossing; the
+component appears when the client adopts it. Until adoption,
 `{:fallback [:div.chart-skeleton]}` renders *instead of* the crossing. The
-fallback is inert markup: the declaration refuses a [`defview`](glossary.md#defview) or [`defhost`](glossary.md#defhost)
-head inside one (`:rf.error/hicasso-host-fallback-boundary-head`). `:fallback`
-beside `{:server :render}`, or any other policy value, refuses at mint with
-`:rf.error/hicasso-host-bad-ssr-policy`. The full server story is
+fallback is inert markup: a `defview` or `defhost` head inside one raises
+`:rf.error/hicasso-host-fallback-boundary-head`. `:fallback` beside
+`{:server :render}`, or any other policy value, raises
+`:rf.error/hicasso-host-bad-ssr-policy` at declaration. Full server story:
 [SSR and hydration](17-ssr-and-hydration.md).
 
 ## Portals
 
 Sometimes markup must land in a different DOM container — a toast rack, a
-vendor-owned [overlay](glossary.md#overlay) div — while it stays part of your tree. The [portal](glossary.md#portal) helper
-lowers hiccup into React's `createPortal` and preserves the frame:
+vendor-owned overlay div — while it stays part of your tree. The portal
+helper turns hiccup into React's `createPortal` and keeps the frame:
 
 ```clojure
 (h/defview save-toast [_]
@@ -213,30 +197,29 @@ lowers hiccup into React's `createPortal` and preserves the frame:
     (str (h/sub [:toast/message]))]])
 ```
 
-Keep three facts straight:
+Three facts:
 
-- **Events bubble through the React tree, not the DOM tree.** A `:on-click`
-  on `save-toast`'s hiccup ancestor sees clicks inside the toast, even though
-  the toast's DOM lives on `body`. Intents fire into the owner's frame as
-  usual.
+- **Events bubble through the React tree, not the DOM tree.** An `:on-click`
+  on `save-toast`'s hiccup ancestor sees clicks inside the toast even though
+  the toast's DOM lives on `body`. Event vectors fire into the owner's frame
+  as usual.
 - **A changed `:target` is a remount.** The subtree unmounts and remounts in
   the new container. Keep the target stable.
-- **The [portal](glossary.md#portal) is Client-only.** No DOM target exists on a server, so the
+- **The portal is Client-only.** No DOM target exists on a server, so the
   portal contributes nothing to the response. An explicit `:fallback` may emit
   placeholder markup at the portal's tree position.
 
-For popovers and modals as a product — anchoring, dismissal, focus — use
+For popovers and modals as product UI — anchoring, dismissal, focus — use
 [Overlays and focus](12-overlays-and-focus.md). The portal is the raw
-mechanism for containers that you do not control.
+mechanism for containers you do not control.
 
 ## The escape: `[:>]`
 
-`[:> Component props & children]` is the [raw escape](glossary.md#raw-escape):
-the same foreign path as [`h/defhost`](glossary.md#defhost), with the
-declaration erased. It exists for two
-cases. Migration is the first: Reagent codebases arrive full of `[:>]` sites,
-and those sites are legal here. The second is the one-off crossing that a
-declaration cannot express, such as a component selected at runtime from data:
+`[:> Component props & children]` is the raw escape: the same foreign path
+as `h/defhost`, without a declaration. It exists for two cases. Migration is
+the first: Reagent codebases arrive full of `[:>]` sites, and those sites are
+legal here. The second is a one-off crossing a declaration cannot express,
+such as a component selected at runtime from data:
 
 ```clojure
 (def widgets {:chart Chart :table Table :map MapView})
@@ -245,42 +228,40 @@ declaration cannot express, such as a component selected at runtime from data:
   [:> (get widgets kind) {:series (h/sub [:panel/series kind])}])
 ```
 
-The escape is **not** the performance tier. A measured hot region takes the
-[native tier](10-native-tier.md)'s visibly different language instead.
-**Declare what you use twice.** When you erase the declaration, you lose
-exactly what the declaration carried:
+This is not the performance tier. A measured hot region takes the
+[native tier](10-native-tier.md). **Declare what you use twice.** When you
+erase the declaration, you lose what it carried:
 
-| A declaration carries | [`h/defhost`](glossary.md#defhost) | `[:>]` |
+| A declaration carries | `h/defhost` | `[:>]` |
 |---|---|---|
 | A crossing name for tools | authored | the constant `"[:>]"` |
 | Callback contracts | exact, per slot | none — every prop is unclaimed |
-| [ReactNode slots](glossary.md#reactnode-slot) | declared | none — hiccup in a prop is data |
-| A [server policy](glossary.md#server-policy) | Render or Client-only with fallback | fixed Client-only, unspellable |
-| An early site for refusals | checked once, at the declaration | every refusal fires at the crossing |
+| ReactNode slots | declared | none — hiccup in a prop is data |
+| A server policy | Render or Client-only with fallback | fixed Client-only, unspellable |
+| Early site for refusals | checked once, at the declaration | every refusal fires at the crossing |
 | A `.cljc` quarantine | one host namespace | the require lands in your view namespace |
 
-Every prop at an escape is unclaimed. Two refusals guard the silent failures
-that would follow:
+Every prop at an escape is unclaimed. Two refusals guard silent failures:
 
-- An [intent](glossary.md#intent) vector at an `on*`-spelled prop refuses with
+- An event vector at an `on*`-spelled prop raises
   `:rf.error/hicasso-host-undeclared-callback`. The runtime never infers a
-  contract from a name. Without the refusal, your intent would cross as an
+  contract from a name. Without the refusal, your vector would cross as an
   inert array.
-- An [`h/event`](glossary.md#hevent) at any escape prop refuses with
+- An `h/event` at any escape prop raises
   `:rf.error/hicasso-host-unclaimed-callback`. The marked form asks its
   position for a contract, and no escape position can answer.
 
-Both refusals name [`h/defhost`](glossary.md#defhost) as the recovery.
+Both name `h/defhost` as the recovery.
 
-A plain function crosses by identity and runs. But it carries no frame, and
-the render has unwound by the time the library calls it. A bare `rf/dispatch`
-inside therefore raises `:rf.error/no-frame-context`. The recovery is
-[Events as data](03-events-as-data.md)'s: call `(rf/capture-frame)` in the
-body, and close over its `:dispatch` — until a declared `:event` slot builds
-that for you.
+A plain function crosses by identity and runs, but carries no frame. By the
+time the library calls it the render has unwound, so a bare `rf/dispatch`
+raises `:rf.error/no-frame-context`. Recovery is the same as in
+[Events as data](03-events-as-data.md): call `(rf/capture-frame)` in the body
+and close over its `:dispatch` — until a declared `:event` slot builds that
+for you.
 
-The escape renders nothing on the server: it has no declaration, so it has no
-`:fallback`. But a transparent pass-through host around it puts placeholder
+The escape renders nothing on the server: no declaration means no
+`:fallback`. A transparent pass-through host around it can put placeholder
 markup at the site:
 
 ```clojure
@@ -290,76 +271,75 @@ markup at the site:
 [skeleton-slot {} [:> (get widgets kind) {:series data}]]
 ```
 
-On the server, the fallback renders instead of the crossing, children and all.
-In the browser, the escape mounts as usual. This gives a placeholder, never
-server-rendered content: only `{:server :render}` on the real component buys
+On the server, the fallback renders instead of the crossing, children and
+all. In the browser, the escape mounts as usual. That is a placeholder, not
+server-rendered content — only `{:server :render}` on the real component buys
 that.
 
 The component position takes what React accepts as an element type. `nil` —
-the usual result of a `:default` import from a library with no default
-export — is refused as `:rf.error/hicasso-raw-no-component`. A string, a
-keyword, a [`defview`](glossary.md#defview) head, a [`defhost`](glossary.md#defhost) head, or an already-built React
-*element* is refused as `:rf.error/hicasso-raw-not-a-component`. Each refusal
-carries its own recovery. Each fires in your render, on the server too, with
-your stack pointing at the line that you wrote.
+usual result of a `:default` import from a library with no default export —
+raises `:rf.error/hicasso-raw-no-component`. A string, keyword, `defview`
+head, `defhost` head, or already-built React *element* raises
+`:rf.error/hicasso-raw-not-a-component`. Each refusal carries its own
+recovery and fires in your render (on the server too), with your stack at the
+line you wrote.
 
 ## The outward bridge
 
-Interop runs in the other direction too. A native React parent —
-[`n/defcomponent`](glossary.md#ndefcomponent), UIx, or plain JavaScript — renders a minted [Hicasso](glossary.md#hicasso) view
-under the existing frame. There is no second root and no second state owner.
+Interop runs the other way too. A native React parent — `n/defcomponent`,
+UIx, or plain JavaScript — can render a Hicasso view under the existing
+frame. There is no second root and no second state owner.
 
 ```clojure
-;; article-card is an ordinary h/defview; hand article-card* to the React
-;; side and render it like any component: <ArticleCard articleId={7} />
+;; article-card is an h/defview; hand article-card* to the React side and
+;; render it like any component: <ArticleCard articleId={7} />
 (def article-card* (h/as-component article-card))
 ```
 
-[`h/as-component`](glossary.md#outward-bridge) returns a real React component. The parent's props arrive as
+`h/as-component` returns a real React component. The parent's props arrive as
 the view's ordinary props map: names come back through the canonical rule
-(`articleId` → `:article-id`), and values cross by identity. The view keeps
-its memo wrapper, its reads, its key identity, and its teardown law. Its frame
-comes from React context, and that context flows through any foreign
-components in between. When the view renders outside a [Hicasso](glossary.md#hicasso) root, the
-mount refuses with `:rf.error/no-frame-context`. [`h/as-element`](glossary.md#as-element) and
-[`h/as-component`](glossary.md#outward-bridge) are the two halves of one seam. Use the element for a
-one-shot subtree handed through a callback. Use the component for a view that
-a native parent will mount, key, and re-render itself.
+(`articleId` → `:article-id`), values cross by identity. The view keeps its
+memo wrapper, its reads, its key identity, and its teardown. Its frame comes
+from React context, and that context flows through foreign components in
+between. When the view renders outside a Hicasso root, mount raises
+`:rf.error/no-frame-context`. `h/as-element` and `h/as-component` are the two
+halves of one bridge: use the element for a one-shot subtree handed through a
+callback; use the component for a view a native parent will mount, key, and
+re-render itself.
 
 ## Troubleshooting
 
-| Symptom | What went wrong | Fix |
+| Symptom | Cause | Fix |
 |---|---|---|
-| Library ignores or rejects a prop — a keyword, a ClojureScript map, a kebab key inside a nested map | Values cross by identity; nested keys are not camelCased; deep conversion is not offered | Hand the library what it documents — the string, `#js`, or `clj->js`, at the call site |
-| Hiccup passed in a prop renders as array data | Only children and declared slots lower; an undeclared prop is data | Declare the prop in `:slots`, or wrap in [`h/as-element`](glossary.md#as-element) |
-| React refuses an object as a child, from a render callback | The body returned a raw vector; a `:render` return crosses unconverted | Return through [`h/as-element`](glossary.md#as-element) |
-| `:rf.error/hicasso-intent-at-a-non-event-contract` | Intent carrier at `:handler` or `:render`; neither dispatches | Declare `:event`, or write the real function |
-| `:rf.error/hicasso-host-undeclared-callback` at a `[:>]` | Intent at an `on*`-spelled escape prop; contracts are never inferred | Declare the host and name the prop in `:callbacks` |
-| A `[:>]` callback runs, then `:rf.error/no-frame-context` | A plain function carries no frame; the render has unwound | `(rf/capture-frame)` in the body; close over its `:dispatch` |
+| Library ignores or rejects a prop — keyword, CLJS map, kebab key inside a nested map | Values cross by identity; nested keys are not camelCased; no deep conversion | Hand the library what it documents — string, `#js`, or `clj->js` at the call site |
+| Hiccup in a prop renders as array data | Only children and declared slots become elements; undeclared prop is data | Declare the prop in `:slots`, or wrap in `h/as-element` |
+| React refuses an object as a child, from a render callback | Body returned a raw vector; `:render` return crosses unconverted | Return through `h/as-element` |
+| `:rf.error/hicasso-intent-at-a-non-event-contract` | Event carrier at `:handler` or `:render` | Declare `:event`, or write the real function |
+| `:rf.error/hicasso-host-undeclared-callback` at a `[:>]` | Event vector at an `on*`-spelled escape prop | Declare the host and name the prop in `:callbacks` |
+| A `[:>]` callback runs, then `:rf.error/no-frame-context` | Plain function carries no frame; render has unwound | `(rf/capture-frame)` in the body; close over its `:dispatch` |
 | Namespace does not load on the JVM | A JS require reached a `.cljc` file | Quarantine the require in a `.cljs` host namespace |
-| `:rf.error/hicasso-host-bad-ssr-policy` at mint | A policy value outside Render / Client-only, or `:fallback` beside `:server :render` | Two policies; the fallback belongs to Client-only |
-| Hosted component does not update when the app state did | The [boundary](glossary.md#boundary) above bailed out on equal props; the host was never re-entered | Put the changing value on the host's *own* props |
+| `:rf.error/hicasso-host-bad-ssr-policy` at declaration | Policy value outside Render / Client-only, or `:fallback` beside `:server :render` | Two policies; fallback belongs to Client-only |
+| Hosted component does not update when app state did | View above bailed out on equal props; host was never re-entered | Put the changing value on the host's *own* props |
 
 ## When not to host
 
-[`defhost`](glossary.md#defhost) is for components that you do not own. A hot, **hand-written**
-component is the [native tier](10-native-tier.md)'s job, not a host
-declaration around your own code. If the library is a thin wrapper over DOM,
-and twenty lines of hiccup reproduce it, write the twenty lines. A hosted
-component is a node that your tools see less of and that your tests assert
-less about. Most applications end with only two or three hard hosted widgets.
+`defhost` is for components you do not own. A hot, **hand-written**
+component is the [native tier](10-native-tier.md), not a host around your own
+code. If the library is a thin wrapper over DOM and twenty lines of hiccup
+reproduce it, write the twenty lines. A hosted component is a node your tools
+see less of and your tests assert less about. Most applications end with only
+a few hard hosted widgets.
 
 ## Advanced
 
 ### The crossing has no memo wrapper
 
-A [`defview`](glossary.md#defview) [boundary](glossary.md#boundary) memoizes on its props. A host crossing does not. The
-foreign component re-renders whenever the boundary that wrote it re-renders.
-The bail-out you want is the enclosing boundary's: put the crossing behind a
-small `defview` of its own. The corollary applies in reverse. A host that must
-react to a subscription needs the value on its *own* props. If you read the
-value one boundary up and stop there, the host sees a value that never
-changes.
+A `defview` memoizes on its props. A host crossing does not. The foreign
+component re-renders whenever the view that wrote it re-renders. Put the
+crossing behind a small `defview` of its own if you want that bail-out. The
+corollary: a host that must react to a subscription needs the value on its
+*own* props. If you read the value one view up and stop there, the host sees
+a value that never changes.
 
 ### Imperative SDKs
 
@@ -382,7 +362,7 @@ function returns is its cleanup.
   [:div.map {:ref attach-map}])
 ```
 
-Four properties matter here, and each one blocks a real defect:
+Four properties matter:
 
 - **The handle is per-attach.** The cleanup that attach returned captures the
   handle. Never hold it in a module-level `defonce`: a hoisted handle lets the
@@ -396,13 +376,12 @@ Four properties matter here, and each one blocks a real defect:
   every render re-attaches every time, so the SDK rebuilds on every keystroke
   elsewhere in the tree.
 
-Under StrictMode (dev), React runs attach → cleanup → attach, and this shape
+Under StrictMode (dev), React runs attach → cleanup → attach; this shape
 survives: the first handle dies with the cleanup that created it. A ref fires
-on attach and detach only, never on a config change. Therefore keep the config
-fixed for the connection's life, and route steady-state change through an
-ordinary event and effect. Sometimes the attach must close over per-instance
-props — an API key, a per-panel config. Then it needs `react/useCallback` to
-stay stable, and hooks do not belong in a [`defview`](glossary.md#defview) body. That is the signal
-that the edge has outgrown this recipe. It wants a named native component,
-where hooks are legal and the same ref shape carries over
+on attach and detach only, never on a config change — keep config fixed for
+the connection's life, and route steady-state change through an ordinary
+event and effect. When attach must close over per-instance props (API key,
+per-panel config), it needs a stable callback, and hooks do not belong in a
+`defview` body. That is the signal the edge has outgrown this recipe: use a
+named native component, where hooks are legal
 ([The native tier](10-native-tier.md)).

--- a/docs/design/hicasso/draft-guide/10-native-tier.md
+++ b/docs/design/hicasso/draft-guide/10-native-tier.md
@@ -1,40 +1,46 @@
 # The native tier
 
-Most apps never need this page. Ordinary [Hicasso](glossary.md#hicasso) —
-hiccup, [`h/sub`](glossary.md#hsub) where you read, events as data — is the
-product. This page is the exit for the thin slice that is not: market-tick
-rows, display-rate drag, vendor widgets that are hooks all the way down. You
-write React directly; frame, app-db, and root stay the same.
+Most apps never need this page. Ordinary Hicasso — hiccup, `h/sub` where you
+read, events as data — is the product. This page is for the thin slice that
+is not: market-tick rows, display-rate drag, vendor widgets that are hooks
+all the way down. You write React directly; frame, app-db, and root stay the
+same.
 
-> **`[...]` is always interpreted Hiccup. [`n/$`](glossary.md#n-dollar) is always native React. Neither form ever changes the other's meaning — and nothing, anywhere, compiles hiccup.**
-
-That sentence is the whole architecture. There is no compiler tier, no `:fast` flag, no mode switch. Crossing is explicit in your source, visible to your tests, and named by Xray. The tier also costs nothing when you do not use it: an application that never requires the native namespace ships zero native-tier code.
+`[...]` is always interpreted Hiccup. `n/$` is always native React. Neither
+form changes the other's meaning, and nothing compiles hiccup into native
+behind the scenes. Crossing is explicit in source, visible to tests, and
+named by Xray. An application that never requires the native namespace ships
+zero native-tier code.
 
 ## The ladder
 
-The [performance ladder](glossary.md#performance-ladder) is a gradient of
-explicit choices. You climb it one rung at a time, with a measurement at every step.
+Climb one rung at a time, with a measurement at every step.
 
 | Rung | You write | What changes | Climb when |
 |---|---|---|---|
-| 1. Ordinary [Hicasso](glossary.md#hicasso) | Hiccup, [`h/sub`](glossary.md#hsub), event vectors | Nothing — this is the product | Always start here |
-| 2. Tuned topology | The same language | Boundary placement, keys, read shape (fine / coarse / chunked / windowed), virtualization | A named interaction misses its budget — [Lists and collections](06-lists-and-collections.md) |
-| 3. Direct native return | A [`defview`](glossary.md#defview) whose body returns [`n/$`](glossary.md#n-dollar) | Hiccup [lowering](glossary.md#lowering) is skipped for that result; frame, reads, memo, and lifecycle stay | Attribution names lowering as the cost owner |
-| 4. Named [native island](glossary.md#native-island) | [`n/defcomponent`](glossary.md#ndefcomponent) (or UIx) with [`n/use-sub`](glossary.md#nuse-sub) / [`n/use-frame`](glossary.md#nuseframe) | Hooks, vendor widgets, and high-rate mechanics live in a real native component with an explicit crossing | Hooks, reconciliation, vendor behavior, or high-rate local work dominates |
+| 1. Ordinary Hicasso | Hiccup, `h/sub`, event vectors | Nothing — this is the product | Always start here |
+| 2. Tuned topology | The same language | View placement, keys, read shape (fine / coarse / chunked / windowed), virtualization | A named interaction misses its budget — [Lists and collections](06-lists-and-collections.md) |
+| 3. Direct native return | A `defview` whose body returns `n/$` | Hiccup interpretation skipped for that result; frame, reads, memo, and lifecycle stay | Attribution names hiccup construction as the cost owner |
+| 4. Named native island | `n/defcomponent` (or UIx) with `n/use-sub` / `n/use-frame` | Hooks, vendor widgets, and high-rate mechanics live in a real native component with an explicit crossing | Hooks, reconciliation, vendor behavior, or high-rate local work dominates |
 | 5. Native screen | A whole screen in the native namespace or UIx | The view language for that screen — same root, same frames, same app-db | The screen is React-shaped by design |
 
-Rungs 1 and 2 are the ordinary product — [Views and reads](02-views-and-reads.md) and [Lists and collections](06-lists-and-collections.md) own them. This page owns rungs 3 to 5, and the rule that disciplines all three:
+Rungs 1 and 2 are ordinary product —
+[Views and reads](02-views-and-reads.md) and
+[Lists and collections](06-lists-and-collections.md). This page owns rungs 3
+to 5.
 
-**[Escape-benefit rule](glossary.md#escape-benefit-rule):** an escape stays
-only if it recovers at least 20% of the measured interaction, saves at least
-2 ms at p95, or converts a failed [user-visible budget](glossary.md#user-visible-budget)
-into a pass — otherwise it comes out. Native code that cannot meet that rule
-is a permanent cost with no return. Reverting a rung-3 escape is a five-minute
-diff, so the rule has no exceptions.
+**Escape-benefit rule:** keep an escape only if it recovers at least 20% of
+the measured interaction, saves at least 2 ms at p95, or converts a failed
+user-visible budget into a pass. Otherwise take it out. Native code that
+cannot meet that rule is a permanent cost with no return. Reverting a rung-3
+escape is a small diff, so the rule has no exceptions.
 
-## Rung 3 — return native React from a boundary
+## Rung 3 — return native React from a view
 
-Here is a watchlist row after rung 2 is already done properly. The table is windowed to the ~40 visible rows, keys are stable, and each row makes one coarse display read. The subscription returns render-ready strings, so the body does almost no work of its own.
+Here is a watchlist row after rung 2 is already done. The table is windowed
+to the ~40 visible rows, keys are stable, and each row makes one coarse
+display read. The subscription returns render-ready strings, so the body does
+almost no work of its own.
 
 ```clojure
 (ns app.watchlist.row
@@ -51,9 +57,15 @@ Here is a watchlist row after rung 2 is already done properly. The table is wind
      [:td.vol vol]]))
 ```
 
-Market ticks update most visible rows four times a second. On this app's low-tier reference laptop, Xray's attribution for the tick event reads: bodies 3 ms, hiccup [lowering](glossary.md#lowering) 9 ms, React reconcile-and-commit 6 ms, paint 3 ms — 21 ms at p95. Every row did change, so there is no read-topology fix left to make. The owner is lowering: forty rows of vectors turn into React elements, four times a second. That is the one situation rung 3 exists for.
+Market ticks update most visible rows several times a second. On this app's
+low-tier reference laptop, Xray's attribution for the tick event reads:
+bodies 3 ms, hiccup construction 9 ms, React reconcile-and-commit 6 ms, paint
+3 ms — 21 ms at p95. Every row did change, so there is no read-topology fix
+left. The owner is construction: forty rows of vectors turn into React
+elements, several times a second. That is the situation rung 3 exists for.
 
-A [`defview`](glossary.md#defview) may return an existing React element instead of hiccup. Build it with [`n/$`](glossary.md#n-dollar):
+A `defview` may return an existing React element instead of hiccup. Build it
+with `n/$`:
 
 ```clojure
 (ns app.watchlist.row
@@ -71,28 +83,47 @@ A [`defview`](glossary.md#defview) may return an existing React element instead 
          (n/$ :td {:class "vol"} vol))))
 ```
 
-The [boundary](glossary.md#boundary) did not change. The parent still renders `[quote-row {:key sym :sym sym}]`. The view keeps its React identity, its value-equality memo, its frame, its [`h/sub`](glossary.md#hsub) reads, its lifecycle, and its name in Xray. What changed is the return value: an already-constructed React element, so hiccup [lowering](glossary.md#lowering) is skipped for this result entirely. Re-measured, the tick lands at 13 ms p95 — 38% recovered, 8 ms saved. That passes the benefit rule on two of its conditions; the escape stays. Your numbers will differ. The point is that you have numbers.
+The view did not change as a unit. The parent still renders
+`[quote-row {:key sym :sym sym}]`. The view keeps its React identity,
+value-equality memo, frame, `h/sub` reads, lifecycle, and name in Xray. What
+changed is the return value: an already-built React element, so hiccup
+interpretation is skipped for this result. Re-measured, the tick lands at
+13 ms p95 — 38% recovered, 8 ms saved. That passes the benefit rule on two
+conditions; the escape stays. Your numbers will differ. The point is that you
+have numbers.
 
-Read the diff closely. Every changed line marks the semantic fence:
+Read the diff:
 
-- **`[:td.sym …]` became `(n/$ :td {:class "sym"} …)`.** The native grammar has no selector shorthand. You spell class and id as props.
-- **`:on-click [:watchlist/select sym]` became `(h/event [_] [:watchlist/select sym])`.** Past the fence there is no [intent](glossary.md#intent) lowering. An event vector in a native prop is an error, not a callback. [`h/event`](glossary.md#hevent) is the same explicit form you use everywhere else. It captures the frame while the body runs, and it hands React an ordinary function that dispatches its result. Plain `fn` values are equally legal when you do not dispatch.
-- **Children are nested [`n/$`](glossary.md#n-dollar) forms, not vectors.** A hiccup vector as a native child refuses at its source. If a native subtree needs one Hicasso-rendered child, convert it explicitly: `(h/as-element [sparkline {:points pts}])` lowers the hiccup under the captured frame and yields a legal ReactNode.
+- **`[:td.sym …]` became `(n/$ :td {:class "sym"} …)`.** The native grammar
+  has no selector shorthand. Spell class and id as props.
+- **`:on-click [:watchlist/select sym]` became
+  `(h/event [_] [:watchlist/select sym])`.** Past this fence there is no
+  automatic event-vector → callback conversion. An event vector in a native
+  prop is an error, not a callback. `h/event` captures the frame while the
+  body runs and hands React an ordinary function. Plain `fn` values are fine
+  when you do not dispatch.
+- **Children are nested `n/$` forms, not vectors.** A hiccup vector as a
+  native child is refused. If a native subtree needs one Hicasso-rendered
+  child, convert explicitly: `(h/as-element [sparkline {:points pts}])`.
 
-The whole fence fits in one table. The left column is why rung 3 is cheap to adopt and cheap to revert. The right column is the price of native semantics, paid at the crossing:
+What stays with the view, and what stops at the returned element:
 
-| Stays with the boundary | Stops at the returned element |
+| Stays with the view | Stops at the returned element |
 |---|---|
-| The frame — and [`h/sub`](glossary.md#hsub) anywhere in the body | Hiccup interpretation — a vector is not markup here |
-| The props ABI, value-equality memo, and the parent's `:key` | Intent lowering — an event vector in a prop is an error |
-| Lifecycle, HMR conduct, and the view's name in Xray | Controlled repair — no [`::h/value`](glossary.md#hvalue), [`::h/checked`](glossary.md#hchecked), [`::h/prevent`](glossary.md#hprevent), [`::h/revision`](glossary.md#hrevision) |
-| Server rendering — intrinsic-headed output produces the same deterministic bytes | Structural assertions and key diagnostics — the element is opaque to the pure test tiers, which refuse with a pointer to the mounted tier ([Testing](14-testing.md)) |
+| The frame — and `h/sub` anywhere in the body | Hiccup interpretation — a vector is not markup here |
+| The props ABI, value-equality memo, and the parent's `:key` | Event vectors in props — an event vector in a prop is an error |
+| Lifecycle, HMR conduct, and the view's name in Xray | Controlled repair — no `::h/value`, `::h/checked`, `::h/prevent`, `::h/revision` |
+| Server rendering — intrinsic-headed output produces the same deterministic bytes | Structural assertions and key diagnostics — the element is opaque to the pure test tiers ([Testing](14-testing.md)) |
 
-Two consequences deserve their own sentences. First, form fields stay interpreted. An `<input>` inside [`n/$`](glossary.md#n-dollar) is a raw React [controlled input](glossary.md#controlled-field): you do all of React's manual controlled-input work, and you get none of [Hicasso](glossary.md#hicasso)'s caret, IME, or same-turn guarantees ([Controlled inputs](04-controlled-inputs.md)). Second, hooks still do not belong in the body. A [`defview`](glossary.md#defview) body is dynamically composed — branches and loops are legal, and that is exactly the environment where hook order breaks. The wish for a hook in a `defview` body is the signal that you are at rung 4, not rung 3.
+Form fields stay interpreted. An `<input>` inside `n/$` is a raw React
+controlled input: you do all of React's manual work, and you get none of
+Hicasso's caret, IME, or same-turn guarantees
+([Controlled inputs](04-controlled-inputs.md)). Hooks still do not belong in
+the body. A `defview` body is dynamically composed — branches and loops are
+legal, which is where hook order breaks. The wish for a hook in a `defview`
+body is the signal you are at rung 4, not rung 3.
 
 ### The `n/$` grammar
-
-The authoring shape is deliberately small:
 
 ```clojure
 (n/$ head)
@@ -101,34 +132,64 @@ The authoring shape is deliberately small:
 (n/$ head (n/props dynamic-props) child*)
 ```
 
-- **Heads.** An unqualified keyword such as `:div` names an intrinsic React element. A string names an intrinsic or custom element verbatim (SVG and web components work). Any other head expression must evaluate to a native React component.
-- **The props operand.** The macro treats exactly four forms as props: `nil`, a literal ClojureScript map, a literal `#js` object, or the explicit `(n/props expression)` marker. **Every other trailing form is a child.**
-- **Prop names.** ClojureScript-map keys use the canonical React slot-name rule: kebab spellings become camelCase (`:on-click` → `onClick`); `:class` and `:for` become the React names; `data-*` / `aria-*` stay hyphenated; camelCase keywords are fixpoints; string keys pass verbatim. A raw JavaScript object is never renamed — it already uses React's names.
-- **Prop values pass by identity.** No [intent](glossary.md#intent) [lowering](glossary.md#lowering), no class-collection merge, no style-map conversion, no keyword-value conversion, no controlled-field repair, no deep conversion. Where a native API expects a JavaScript object — React style objects included — hand it one: `:style #js {:transform "translateX(4px)"}`.
-- **Children** are trailing ReactNode values. Nest with [`n/$`](glossary.md#n-dollar); collections must already be valid React children, normally a JavaScript array (`(into-array (map row-el rows))`, each element carrying its `:key`). The grammar refuses `:children` inside the props map — there is one child channel.
-- **`:key` and `:ref`** use the ordinary React slots. Two source keys that normalize to the same slot — for example `:class` and `"className"` in one map — refuse rather than let map order pick a winner.
+- **Heads.** An unqualified keyword such as `:div` names an intrinsic React
+  element. A string names an intrinsic or custom element verbatim (SVG and
+  web components work). Any other head expression must evaluate to a native
+  React component.
+- **The props operand.** The macro treats exactly four forms as props: `nil`,
+  a literal ClojureScript map, a literal `#js` object, or the explicit
+  `(n/props expression)` marker. **Every other trailing form is a child.**
+- **Prop names.** ClojureScript-map keys use the canonical React slot-name
+  rule: kebab becomes camelCase (`:on-click` → `onClick`); `:class` and
+  `:for` become the React names; `data-*` / `aria-*` stay hyphenated;
+  camelCase keywords are fixpoints; string keys pass verbatim. A raw
+  JavaScript object is never renamed.
+- **Prop values pass by identity.** No event-vector conversion, no
+  class-collection merge, no style-map conversion, no keyword-value
+  conversion, no controlled-field repair, no deep conversion. Where a native
+  API expects a JavaScript object — React style objects included — hand it
+  one: `:style #js {:transform "translateX(4px)"}`.
+- **Children** are trailing ReactNode values. Nest with `n/$`; collections
+  must already be valid React children, normally a JavaScript array
+  (`(into-array (map row-el rows))`, each element carrying its `:key`). The
+  grammar refuses `:children` inside the props map — there is one child
+  channel.
+- **`:key` and `:ref`** use the ordinary React slots. Two source keys that
+  normalize to the same slot — for example `:class` and `"className"` in one
+  map — refuse rather than let map order pick a winner.
 
 !!! warning "Dynamic props must be marked"
-    The props rule is syntactic on purpose. A dynamic React element is itself a JavaScript object, so the macro never inspects a runtime value to decide "props or child" — a guess would misclassify elements. The cost is one rule you must know:
+    The props rule is syntactic on purpose. A dynamic React element is itself
+    a JavaScript object, so the macro never inspects a runtime value to decide
+    "props or child".
 
     ```clojure
     ;; Don't: a dynamic map in second position is a CHILD, not props.
     (let [cell-props {:class "px" :dir "ltr"}]
-      (n/$ :td cell-props px))   ;; refuses — a map is not a valid React child,
-                                 ;; and the recovery names (n/props …)
+      (n/$ :td cell-props px))   ;; refuses — recovery names (n/props …)
 
     ;; Do: mark the operand. n/props emits no wrapper — it only classifies.
     (let [cell-props {:class "px" :dir "ltr"}]
       (n/$ :td (n/props cell-props) px))
     ```
 
-    A dynamic ClojureScript map inside [`n/props`](glossary.md#nprops) converts shallowly under the same slot-name rule; a JavaScript object passes by identity.
+    A dynamic ClojureScript map inside `n/props` converts shallowly under the
+    same slot-name rule; a JavaScript object passes by identity.
 
 ## Rung 4 — a named native island
 
-When the cost owner is not [lowering](glossary.md#lowering) but *behavior* — hooks, a retained vendor widget, React reconciliation itself, or work that runs per animation frame — the answer is a named, top-level native component. The self-contained route is [`n/defcomponent`](glossary.md#ndefcomponent). UIx is an equally supported, mature route. A JavaScript or TypeScript component enters through the host bridge ([Interop](09-interop.md)). Every route stays inside the same React root, the same frame context, and the same state owner. An island is a place, not a second architecture.
+When the cost owner is not hiccup construction but *behavior* — hooks, a
+retained vendor widget, React reconciliation itself, or work that runs per
+animation frame — the answer is a named, top-level native component. The
+self-contained route is `n/defcomponent`. UIx is an equally supported mature
+route. A JavaScript or TypeScript component enters through the host bridge
+([Interop](09-interop.md)). Every route stays inside the same React root, the
+same frame context, and the same state owner.
 
-Here is a column-resize handle. Pointer movement is 120 Hz mechanics — host-private, not an application fact. It stays in local React state, and app-db receives exactly one write, on release ([Ephemeral state](11-ephemeral-state.md)):
+Here is a column-resize handle. Pointer movement is high-rate mechanics —
+host-private, not an application fact. It stays in local React state; app-db
+receives exactly one write, on release
+([Ephemeral state](11-ephemeral-state.md)):
 
 ```clojure
 (ns app.watchlist.resizer
@@ -161,24 +222,40 @@ Here is a column-resize handle. Pointer movement is 120 Hz mechanics — host-pr
                       :style #js {:transform (str "translateX(" (- live committed) "px)")}})))))
 ```
 
-What this teaches, piece by piece:
+Piece by piece:
 
-- **The ABI is one raw JavaScript props object** — read it with `.-col`; children arrive at `.-children`. There is no hidden map allocation, and no second "fast" ABI anywhere in the tier.
-- **A declaration map before the argument vector carries the [server policy](glossary.md#server-policy)** — `{:server :render}` or `{:server :client-only}`. Omit it and the policy is Client-only, which is exactly right for a pointer-driven widget.
-- **Ordinary React hooks are used directly.** `react/useState`, `react/useEffect`, refs — React's surface, React's rules. [Hicasso](glossary.md#hicasso) adds no hook wrappers here.
-- **[`n/use-sub`](glossary.md#nuse-sub) and [`n/use-frame`](glossary.md#nuseframe) join the frame you were already in.** The first reads a subscription under the current frame and re-renders the island when the value changes. The second is frame capture in hook position. It returns the frame-locked ops map — `{:frame :dispatch :dispatch-sync :subscribe}` — and the map is reference-stable across re-renders of the same frame *incarnation*. A frame keyword is an address, not an identity, so destroying that frame and creating another under the same id retargets the map: within the incarnation it is safe to pull `:dispatch` off it and close over it in callbacks, and a bundle held across a same-id reincarnation is not merely stale — it is silently inert.
-- **High-rate work never touches app-db.** The drag guide tracks the pointer through local React state; the component dispatches the single committed fact — the final width — once, on release.
+- **The ABI is one raw JavaScript props object** — read it with `.-col`;
+  children arrive at `.-children`. There is no hidden map allocation.
+- **A declaration map before the argument vector carries the server
+  policy** — `{:server :render}` or `{:server :client-only}`. Omit it and
+  the policy is Client-only, which is right for a pointer-driven widget.
+- **Ordinary React hooks are used directly.** `react/useState`,
+  `react/useEffect`, refs — React's surface, React's rules.
+- **`n/use-sub` and `n/use-frame` join the frame you were already in.** The
+  first reads a subscription under the current frame and re-renders the
+  island when the value changes. The second is frame capture in hook
+  position. It returns the frame-locked ops map —
+  `{:frame :dispatch :dispatch-sync :subscribe}` — and the map is
+  reference-stable across re-renders of the same frame *incarnation*. A frame
+  keyword is an address, not an identity: destroying that frame and creating
+  another under the same id retargets the map. Within an incarnation it is
+  safe to pull `:dispatch` off it and close over it in callbacks; a bundle
+  held across a same-id reincarnation is silently inert.
+- **High-rate work never touches app-db.** The drag guide tracks the pointer
+  through local React state; the component dispatches the single committed
+  fact — the final width — once, on release.
 
-The two read doors deserve one table, because they look similar but obey different laws:
+The two read doors look similar but obey different laws:
 
 | Door | Lives in | Rules |
 |---|---|---|
-| [`h/sub`](glossary.md#hsub) | Hicasso bodies | Direct synchronous body only; branches, loops, and plain helpers are fine; not a hook |
-| [`n/use-sub`](glossary.md#nuse-sub) | Native components | A real React hook; the rules of hooks apply — top level of the component, unconditional |
+| `h/sub` | Hicasso bodies | Direct synchronous body only; branches, loops, and plain helpers are fine; not a hook |
+| `n/use-sub` | Native components | A real React hook; the rules of hooks apply — top level of the component, unconditional |
 
 ### Mounting the island
 
-From interpreted hiccup, you mount an island behind the named host seam. Declare it once, and use it as an ordinary head:
+From interpreted hiccup, mount an island behind a named host. Declare once,
+use as an ordinary head:
 
 ```clojure
 (h/defhost resize-handle col-resizer)
@@ -187,59 +264,116 @@ From interpreted hiccup, you mount an island behind the named host seam. Declare
 [:th {:class "px"} "Price" [resize-handle {:col :px}]]
 ```
 
-From native code, a component is a head as-is: `(n/$ col-resizer {:col :px})`. Both directions cross under the same root and frame. The one-off raw element escape also exists ([Interop](09-interop.md)), but it is for migration and for true one-off interop. Repeated or hot crossings deserve a name, a declaration, and tests — which is what [`defhost`](glossary.md#defhost) gives you.
+From native code, a component is a head as-is: `(n/$ col-resizer {:col :px})`.
+Both directions cross under the same root and frame. The one-off raw element
+escape also exists ([Interop](09-interop.md)), but it is for migration and
+true one-off interop. Repeated or hot crossings deserve a name, a
+declaration, and tests — which is what `defhost` gives you.
 
 !!! note "Islands and the server"
-    An intrinsic [`n/$`](glossary.md#n-dollar) return renders on the server like the hiccup it replaced. A component-headed island defaults to Client-only — a source-located refusal, leaving its declared fallback in the server bytes or, bare, nothing at all — until its declaration selects `{:server :render}` and proves matching hydration. [SSR and hydration](17-ssr-and-hydration.md) owns the full contract.
+    An intrinsic `n/$` return renders on the server like the hiccup it
+    replaced. A component-headed island defaults to Client-only — leaving its
+    declared fallback in the server bytes or, bare, nothing at all — until
+    its declaration selects `{:server :render}` and proves matching hydration.
+    [SSR and hydration](17-ssr-and-hydration.md) owns the full contract.
 
 ??? info "If your team already writes UIx"
-    Everything above has a UIx spelling, and it is not a second-class one. A [`defview`](glossary.md#defview) at rung 3 may return a `uix.core/$` element, and an island at rung 4 may be a `defui`. The native hooks are substrate-neutral, so [`n/use-sub`](glossary.md#nuse-sub) and [`n/use-frame`](glossary.md#nuseframe) work inside a `defui` exactly as inside [`n/defcomponent`](glossary.md#ndefcomponent). The Hicasso-native surface is held to parity against both handwritten React and UIx, so the choice is taste and scale, not speed. Two instincts need correction. First, `n/*` is not UIx-lite and never imports UIx: a [Hicasso](glossary.md#hicasso) app without UIx islands ships zero UIx bytes. Second, when a native region grows into substantial React-first work, UIx is the designed answer, not a defeat — the native namespace is deliberately too small to be a component framework.
+    Everything above has a UIx spelling. A `defview` at rung 3 may return a
+    `uix.core/$` element, and an island at rung 4 may be a `defui`. The native
+    hooks are substrate-neutral, so `n/use-sub` and `n/use-frame` work inside
+    a `defui` exactly as inside `n/defcomponent`. The Hicasso-native surface
+    is held to parity against both handwritten React and UIx, so the choice is
+    taste and scale, not speed. Two corrections: `n/*` is not UIx-lite and
+    never imports UIx — a Hicasso app without UIx islands ships zero UIx
+    bytes. When a native region grows into substantial React-first work, UIx
+    is the designed answer, not a defeat — the native namespace is deliberately
+    too small to be a component framework.
 
 ## Keeping the marker: the ABI helpers
 
-[`n/defcomponent`](glossary.md#ndefcomponent) stamps its component with a display name and a tier marker carrying that name and the declared server policy. The marker lets Xray name the [boundary](glossary.md#boundary), and it is the seam every ABI helper and every embedding direction reads to recognize a native head. What it does not do is carry the component across a hot reload, and it is not meant to. Minting a component is allocation, never a lookup by name: a save re-evaluates the module, the component is allocated afresh, the element type at that position is a new object, and React replaces the subtree. **A clean remount across a save is the designed conduct, not a fault** — a component's name is an address, not an identity, exactly as [`defview`](glossary.md#defview)'s is. Raw React wrappers erase the marker:
+`n/defcomponent` stamps its component with a display name and a tier marker
+carrying that name and the declared server policy. The marker lets Xray name
+the view, and it is how ABI helpers and embedding directions recognize a
+native head. It does not carry the component across a hot reload. Defining a
+component is allocation, never a lookup by name: a save re-evaluates the
+module, the component is allocated afresh, the element type at that position
+is a new object, and React replaces the subtree. **A clean remount across a
+save is designed conduct, not a fault** — a component's name is an address,
+not an identity, the same as `defview`. Raw React wrappers erase the marker:
 
 ```clojure
 ;; given (n/defcomponent quote-cell* …) — a pure display cell worth memoizing:
 
 ;; Don't: works at runtime, but the marker is gone — Xray shows an anonymous
-;; boundary, and the embedding seams no longer recognize the head.
+;; view, and the embedding seams no longer recognize the head.
 (def quote-cell (react/memo quote-cell*))
 
 ;; Do: same React.memo semantics, marker intact.
 (def quote-cell (n/memo quote-cell*))
 ```
 
-[`n/memo`](glossary.md#nmemo) and [`n/lazy`](glossary.md#nlazy) carry the one props/children ABI through memoization and code-split loading. Refs need no helper: `:ref` uses React's ordinary slot, and a function component receives it through props. The same preservation applies to the two embedding directions: hiccup rendering an island (above), and a native parent rendering a minted [Hicasso](glossary.md#hicasso) view through the [outward bridge](glossary.md#outward-bridge) ([Interop](09-interop.md)).
+`n/memo` and `n/lazy` carry the one props/children ABI through memoization
+and code-split loading. Refs need no helper: `:ref` uses React's ordinary
+slot, and a function component receives it through props. The same
+preservation applies to both embedding directions: hiccup rendering an island
+(above), and a native parent rendering a Hicasso view through the outward bridge
+([Interop](09-interop.md)).
 
 ## Rung 5 — a native screen
 
-Some screens are React-shaped from their first commit — a canvas editor, a diagramming surface, a screen that is mostly one enormous vendor grid. Implement that screen's view tree natively — with the native namespace, with UIx, or in JavaScript behind hosts — under the same installed adapter, the same root, and the same frames. This is a local view-implementation choice, not a second adapter, and never a second state owner. An independent React root remains an isolation choice, not a speed choice. After shipping, the native share of your source is a number you can report. Nothing enforces it, because 0% and 2% are both fine answers.
+Some screens are React-shaped from the first commit — a canvas editor, a
+diagramming surface, a screen that is mostly one large vendor grid. Implement
+that screen's view tree natively — with the native namespace, with UIx, or in
+JavaScript behind hosts — under the same installed adapter, the same root,
+and the same frames. This is a local view-implementation choice, not a second
+adapter, and never a second state owner. An independent React root remains an
+isolation choice, not a speed choice.
 
 ## Every crossing runs the loop
 
-The numbered working loop — reproduce, attribute with Xray, tune topology first, then compare an escape and keep it only if it passes the benefit rule — is [Performance](18-performance.md)'s method. Every rung on this page is entered through it: rung 3 when attribution names [lowering](glossary.md#lowering), rung 4 when it names hooks, vendor behavior, reconciliation, or high-rate local work. What this page adds is the follow-through a crossing owes. Re-run the contracts you can no longer see — DOM and [intent](glossary.md#intent) parity, focus and selection, frame routing, SSR and hydration, cleanup, and the performance script — before you call the escape done.
+The numbered working loop — reproduce, attribute with Xray, tune topology
+first, then compare an escape and keep it only if it passes the benefit
+rule — is [Performance](18-performance.md)'s method. Every rung on this page
+is entered through it: rung 3 when attribution names hiccup construction,
+rung 4 when it names hooks, vendor behavior, reconciliation, or high-rate
+local work. What this page adds is the follow-through a crossing owes.
+Re-run the contracts you can no longer see — DOM and event-vector parity,
+focus and selection, frame routing, SSR and hydration, cleanup, and the
+performance script — before you call the escape done.
 
-Xray stays honest on both sides of the fence. It names and times the native [boundary](glossary.md#boundary), it shows the reads made through [`n/use-sub`](glossary.md#nuse-sub), and it labels the inner React tree *opaque* — a real answer, never a silently empty one. The advisor may recommend a boundary and scaffold a comparison. It never rewrites your code, and nothing ever switches semantics at runtime.
+Xray stays honest on both sides of the fence. It names and times the native
+view, shows reads made through `n/use-sub`, and labels the inner React tree
+*opaque* — a real answer, never a silently empty one. The advisor may
+recommend a view split and scaffold a comparison. It never rewrites your
+code, and nothing switches semantics at runtime.
 
 ## When not to go native
 
-- **You have no named measurement.** "The app feels slow" is almost always a rung-1 or rung-2 problem underneath. No profile, no escape.
-- **The owner is [read topology](glossary.md#read-topology).** On the worst mounts we have measured, most of the deficit was read shape — too many fine per-row subscriptions — not the hiccup walk. That fix is [Lists and collections](06-lists-and-collections.md), and it keeps every convenience the fence would cost you.
-- **The problem is typing latency.** Keystroke echo is an event-volume and controlled-field question ([Controlled inputs](04-controlled-inputs.md), [Performance](18-performance.md)); native construction does not move it.
-- **A [controlled field](glossary.md#controlled-field) is involved.** The [native tier](glossary.md#native-tier) has no controlled repair — same-turn convergence, caret and IME preservation, and [`::h/revision`](glossary.md#hrevision) live on the hiccup side. Fields stay interpreted.
-- **You want rung 4 "for consistency".** One island is an escape; islands everywhere is a rewrite of the product you chose. The 2% is a set of local islands, not a general style.
+- **You have no named measurement.** "The app feels slow" is almost always a
+  rung-1 or rung-2 problem underneath. No profile, no escape.
+- **The owner is read placement.** On the worst mounts we have measured, most
+  of the deficit was read shape — too many fine per-row subscriptions — not
+  the hiccup walk. That fix is [Lists and collections](06-lists-and-collections.md),
+  and it keeps every convenience the fence would cost you.
+- **The problem is typing latency.** Keystroke echo is an event-volume and
+  controlled-field question ([Controlled inputs](04-controlled-inputs.md),
+  [Performance](18-performance.md)); native construction does not move it.
+- **A controlled field is involved.** The native tier has no controlled
+  repair — same-turn convergence, caret and IME preservation, and
+  `::h/revision` live on the hiccup side. Fields stay interpreted.
+- **You want rung 4 "for consistency".** One island is an escape; islands
+  everywhere is a rewrite of the product you chose.
 
 ## Troubleshooting
 
-| Symptom | What is happening | Fix |
+| Symptom | Cause | Fix |
 |---|---|---|
 | Refusal: a ClojureScript map appeared as a React child | A dynamic map in the props position is classified as a child — the grammar only recognizes `nil`, literal maps, `#js` literals, and `(n/props …)` as props | Mark it: `(n/$ :td (n/props m) …)` |
-| Refusal on a vector child inside [`n/$`](glossary.md#n-dollar) | Hiccup is not interpreted past the fence — square brackets have no meaning in native children | Convert explicitly with [`h/as-element`](glossary.md#as-element), or keep that subtree interpreted |
-| Refusal: event vector in a native prop (`:on-click [:x/select id]`) | No [intent](glossary.md#intent) [lowering](glossary.md#lowering) past the fence — native callbacks are functions | `(h/event [_] [:x/select id])` in a rung-3 body; `:dispatch` from [`n/use-frame`](glossary.md#nuseframe) inside an island |
-| Refusal: `:children` in the props map | There is one child channel — trailing forms | Pass children after the props operand |
-| Refusal: two keys normalize to one slot (`:class` and `"className"`) | Canonical-slot collision — the grammar refuses rather than letting map order pick a winner | Keep one spelling per slot |
-| `:rf.error/no-frame-context` from [`n/use-sub`](glossary.md#nuse-sub) or [`n/use-frame`](glossary.md#nuseframe) | The island rendered outside any frame provider — a separate root, a [portal](glossary.md#portal) outside the app, or a test without the harness | Mount under the app root, or use the [test kit](glossary.md#test-kit)'s provider ([Testing](14-testing.md)) |
-| Xray shows an anonymous [boundary](glossary.md#boundary) where a named island should be | The component marker was erased by a raw wrapper (`react/memo`, `React.lazy`) — the display name and the declared server policy went with it | Use [`n/memo`](glossary.md#nmemo) / [`n/lazy`](glossary.md#nlazy) — same semantics, marker intact |
-| Local state inside an island resets whenever you save | Nothing is wrong. A reload allocates a fresh component, so the element type changes and React remounts the subtree — the designed HMR conduct, and [`defview`](glossary.md#defview)'s too | Nothing to fix. State that must outlive a save belongs in `app-db`, read back through [`n/use-sub`](glossary.md#nuse-sub) |
-| Went native, numbers did not move | The cost owner was never construction — usually reads or event volume | Back to loop step 2; expect the fix at rung 2, and take the unearned escape out |
+| Refusal on a vector child inside `n/$` | Hiccup is not interpreted past the fence | Convert with `h/as-element`, or keep that subtree interpreted |
+| Refusal: event vector in a native prop (`:on-click [:x/select id]`) | No event-vector conversion past the fence — native callbacks are functions | `(h/event [_] [:x/select id])` in a rung-3 body; `:dispatch` from `n/use-frame` inside an island |
+| Refusal: `:children` in the props map | One child channel — trailing forms | Pass children after the props operand |
+| Refusal: two keys normalize to one slot (`:class` and `"className"`) | Canonical-slot collision | Keep one spelling per slot |
+| `:rf.error/no-frame-context` from `n/use-sub` or `n/use-frame` | Island rendered outside any frame provider — separate root, portal outside the app, or test without the harness | Mount under the app root, or use the test kit's provider ([Testing](14-testing.md)) |
+| Xray shows an anonymous view where a named island should be | Component marker erased by a raw wrapper (`react/memo`, `React.lazy`) | Use `n/memo` / `n/lazy` — same semantics, marker intact |
+| Local state inside an island resets whenever you save | Designed HMR conduct: reload allocates a fresh component, React remounts | Nothing to fix. State that must outlive a save belongs in `app-db`, read back through `n/use-sub` |
+| Went native, numbers did not move | Cost owner was never construction — usually reads or event volume | Back to loop step 2; expect the fix at rung 2, and take the unearned escape out |

--- a/docs/design/hicasso/draft-guide/11-ephemeral-state.md
+++ b/docs/design/hicasso/draft-guide/11-ephemeral-state.md
@@ -1,54 +1,51 @@
 # Ephemeral state: where everything lives
 
-Is this dropdown open? Is this row selected? Where do the half-typed draft, the
-in-flight drag position, and the vendor SDK handle go?
+Is this dropdown open? Is this row selected? Where do the half-typed draft,
+the in-flight drag position, and the vendor SDK handle go?
 
-In Reagent you use `r/atom`. In React you use `useState`. [Hicasso](glossary.md#hicasso) has neither:
-no component-local reactive cell, no local-state tier. These cells are not
-discouraged; they do not exist. Most of the "local state" a view layer teaches
-you to want came from machinery Hicasso does not have — reaction capture, argv
-memoization, a second reactive system. The state that remains is real, and
-every kind of it has a named home. This page lists each home.
+In Reagent you use `r/atom`. In React you use `useState`. Hicasso has
+neither: no component-local reactive cell, no local-state tier. These cells
+are not discouraged; they do not exist. Much of the "local state" a view
+layer teaches you to want came from machinery Hicasso does not have —
+reaction capture, argv memoization, a second reactive system. The state that
+remains is real, and every kind of it has a named home.
 
-> **App-db owns every fact the application can see, mechanics stay inside
-> their host, and no state ever gets a second reactive store.**
+App-db owns every fact the application can see. Mechanics stay inside their
+host. No state gets a second reactive store.
 
-## Why one owner, really
+## Why one owner
 
-The [one state owner](glossary.md#one-state-owner) law is not a restriction
-for its own sake. Three other product promises depend on it.
+Three product promises depend on it.
 
 **Tests stay data.** When "the dropdown is open" is a value at an address, a
 test opens the dropdown with a `:db` write. The test does not simulate a
-click, mount a component, or start a timer. The full open/close/dismiss policy
-of a widget is provable headlessly ([Testing](14-testing.md)). A private cell
-would move every one of those tests into a browser.
+click, mount a component, or start a timer. The full open/close/dismiss
+policy of a widget is provable headlessly ([Testing](14-testing.md)). A
+private cell would move every one of those tests into a browser.
 
-**Xray can attribute work.** The [causal lens](glossary.md#causal-lens) runs *event → subscriptions →
-[boundaries](glossary.md#boundary) → commit → paint*. Every re-render has a cause that Xray can name,
-because every application write goes through the one write clock: the
-re-frame2 state commit. A second reactive store invalidates views on a clock
-Xray cannot see. That work has no cause, permanently
+**Xray can attribute work.** The causal path is *event → subscriptions →
+views → commit → paint*. Every re-render has a cause Xray can name, because
+every application write goes through the one write clock: the re-frame2 state
+commit. A second reactive store invalidates views on a clock Xray cannot see
 ([Diagnostics](15-diagnostics.md)).
 
 **Frames stay isolated.** State at an address is per-frame by construction.
 Mount the same app in two frames, and their dropdowns cannot interfere. A
-module-level atom is shared by every frame that ever mounts the view. That
-shared cell is exactly the cross-frame leak the frame model exists to delete.
+module-level atom is shared by every frame that ever mounts the view — the
+cross-frame leak the frame model exists to delete.
 
 A host may still hold state — React state, DOM state, a canvas — under one
 condition: the state is never an invisible duplicate of an application fact.
-Each legitimate home is a [pressure valve](glossary.md#pressure-valve) — a
-named place for one kind of UI state. The valves below are the complete list.
-If a piece of state does not fit one valve, the state goes to app-db.
+Each legitimate home below is a place for one kind of UI state. If a piece of
+state does not fit one of them, the state goes to app-db.
 
 ## Valve 1: an explicit app-db address
 
-This valve is the default for everything application-visible: open, expanded,
+This is the default for everything application-visible: open, expanded,
 selected, the chosen tab. The usual objection is ceremony — an event, a
-subscription, and a keypath for "is this open?". But the cost is per
-*concern*, not per instance. One parametric subscription and one named event
-serve every instance:
+subscription, and a keypath for "is this open?". The cost is per *concern*,
+not per instance. One parametric subscription and one named event serve every
+instance:
 
 ```clojure
 (ns app.panels
@@ -68,15 +65,15 @@ serve every instance:
    (when (h/sub [:panel/expanded? id]) [panel-body {:id id}])])
 ```
 
-You write these ten lines once. A hundred panels add no further cost. The
-address also gives what a local cell cannot: the state time-travels, Xray
-shows it, each frame isolates it, and a test sets it with a `:db` write.
+You write these lines once. A hundred panels add no further cost. The address
+also gives what a local cell cannot: the state time-travels, Xray shows it,
+each frame isolates it, and a test sets it with a `:db` write.
 
-Write **named events, not a generic setter**. `[:panel/toggled id]` names what
-happened. A generic `[:ui/set path value]` turns the event log into a diff
-stream that nobody can read. When a write starts to *mean* something — an
-effect fires, or other state reacts — the named event is already the correct
-shape.
+Write **named events, not a generic setter**. `[:panel/toggled id]` names
+what happened. A generic `[:ui/set path value]` turns the event log into a
+diff stream that nobody can read. When a write starts to *mean* something —
+an effect fires, or other state reacts — the named event is already the
+correct shape.
 
 ## Valve 2: drafts and control state — the forms module
 
@@ -99,19 +96,18 @@ appears.
 
 Some state exists only to *operate a widget*: measured geometry, an in-flight
 drag position, composition buffers, focus mechanics inside a composite
-control, a chart library's instance handle. This state updates at 60–240 Hz,
+control, a chart library's instance handle. This state updates at high rate,
 and nobody outside the widget can act on it. A route through app-db would
 spend an event, a subscription pass, and a paint per pointer-move on a fact
 with no meaning.
 
 That state stays **inside a native host** — a named native component (or a
-[`defhost`](glossary.md#defhost) edge) where ordinary React state and hooks are the correct tool
+`defhost` edge) where ordinary React state and hooks are the correct tool
 ([The native tier](10-native-tier.md), [Interop](09-interop.md)). The host is
-**diagnostic-opaque by contract**. Xray names and times the island's [boundary](glossary.md#boundary).
-It labels the inside `opaque`; it does not pretend to know it. You trade
-visibility for locality, on purpose, in a fenced place.
+diagnostic-opaque by contract. Xray names and times the island's view. It
+labels the inside `opaque`; it does not pretend to know it.
 
-The law at the edge: *motion stays inside; meaning leaves as one event.*
+The rule at the edge: *motion stays inside; meaning leaves as one event.*
 
 ```clojure
 (ns app.board.drag
@@ -136,20 +132,20 @@ The law at the edge: *motion stays inside; meaning leaves as one event.*
 
 (h/defview board-card [{:keys [id]}]
   (let [title (h/sub [:card/title id])]
-    ;; app-db hears one event per drag; the 120 Hz stream never leaves the host.
+    ;; app-db hears one event per drag; the high-rate stream never leaves the host.
     (n/$ drag-surface {:label   title
                        :on-drop (h/event [col] [:card/dropped id col])})))
 ```
 
-The drop is semantic, so it commits. [`h/event`](glossary.md#hevent) captures the frame and
+The drop is semantic, so it commits. `h/event` captures the frame and
 dispatches `[:card/dropped id col]` when the host calls the callback. The end
 of a drag reaches app-db. The moves of a drag do not.
 
-One [boundary](glossary.md#boundary) rule applies. A [`defview`](glossary.md#defview) body is a real React function
-component, so a hook physically runs there. But dynamic composition makes
-hook order your problem, and a hook body falls out of headless testing. Hook
-mechanics belong in a separately defined native component, where hook order
-cannot depend on your data paths.
+One rule on views: a `defview` body is a real React function component, so a
+hook physically runs there. Dynamic composition makes hook order your
+problem, and a hook body falls out of headless testing. Hook mechanics belong
+in a separately defined native component, where hook order cannot depend on
+your data paths.
 
 ## Valve 4: DOM-owned state — a declared interop choice
 
@@ -168,10 +164,10 @@ application state is none.
   panel toggled by `:popovertarget` — zero application state
   ([Overlays and focus](12-overlays-and-focus.md)).
 
-The valve's condition is the word *declared*. DOM ownership is a visible,
-priced choice at the site — never a hidden substitute for application state.
-When anything else needs the fact (validation needs the draft, a test needs
-the open flag), the fact moves up a valve.
+The condition is the word *declared*. DOM ownership is a visible, priced
+choice at the site — never a hidden substitute for application state. When
+anything else needs the fact (validation needs the draft, a test needs the
+open flag), the fact moves up a valve.
 
 ## Valve 5: presence — what is still painted
 
@@ -202,7 +198,7 @@ receives `:rf/phase` (`:mounting` / `:present` / `:unmounting`) as an
 ordinary prop and branches on it. A test can pass the prop directly, with no
 timers and no browser.
 
-These rules keep presence honest:
+Rules that keep presence honest:
 
 - `:timeout-ms` is mandatory. It is a hard terminal bound on a clock, never a
   `transitionend` listener. The node leaves on time even when your CSS did
@@ -227,17 +223,17 @@ server HTML never carries entry-phase attributes
 |---|---|---|
 | Dropdown open | App-db, explicit address (the [overlay module](12-overlays-and-focus.md) reconciles the platform to it) | It changes what the user can do next; tests and Xray need it |
 | Draft text in a field | App-db through the [forms module](05-forms.md) | Validation, submit gating, dirty-leave and replay all read it |
-| Drag position, mid-drag | Host-private, inside the [native island](glossary.md#native-island) | 60–240 Hz mechanics; only the widget cares. The drop dispatches one event |
+| Drag position, mid-drag | Host-private, inside a native island | High-rate mechanics; only the widget cares. The drop dispatches one event |
 | Scroll offset | The DOM owns it; the [routing module](07-routing-and-navigation.md) restores it per route | Nobody re-renders per scrolled pixel. If the app cares ("read 80%"), commit thresholds as events |
 | Animation phase | CSS for the animation itself; `motion/presence` for leave-retention; host-private for rAF mechanics | App-db says what is true, not what is still painted |
-| Focus | The platform. One-shot [intent](glossary.md#intent) as data — `:auto-focus`, [overlay focus conduct](12-overlays-and-focus.md) — never mirrored | A mirror of "what has focus" drifts from reality and re-renders per Tab |
+| Focus | The platform. One-shot focus intent as data — `:auto-focus`, [overlay focus conduct](12-overlays-and-focus.md) — never mirrored | A mirror of "what has focus" drifts from reality and re-renders per Tab |
 | Selected tab | App-db — or the route, when a reload should land on the same tab | Semantic; other views, tests and deep links care |
 | WebGL context, vendor handle | Host-private, inside its declared host, acquired and released at the edge ([Interop](09-interop.md)) | An object identity, not application data; unmount must release it |
 
 ## Choosing the address
 
 Valves 1 and 2 need an instance key — the `panel-id` above — so a hundred
-panels do not share one `expanded?`. [Hicasso](glossary.md#hicasso) mints no identity for you.
+panels do not share one `expanded?`. Hicasso creates no identity for you.
 React's `useId` does not fit: its ids are render-order counters, they do not
 survive a remount, and address-resident state cannot tolerate that loss. The
 key is authored data: a keyword, a string, a number, or a flat vector of
@@ -284,7 +280,7 @@ exactly one memory.
 
 ```clojure
 ;; Don't — an atom in a view. The body re-runs, retries, and is abandoned;
-;; the atom is re-minted on each run, and no atom re-renders anything here.
+;; the atom is recreated on each run, and no atom re-renders anything here.
 (h/defview broken-panel [{:keys [id title]}]
   (let [expanded? (atom false)]                    ; reset on every render
     [:section
@@ -292,16 +288,16 @@ exactly one memory.
      (when @expanded? [panel-body {:id id}])]))
 
 ;; Don't — app-db as a motion channel: an event, a sub pass and a paint
-;; per pointer-move, and the event log becomes a 120 Hz diff stream.
+;; per pointer-move, and the event log becomes a high-rate diff stream.
 :on-pointer-move (h/event [e] [:card/drag-moved id (.-clientX e) (.-clientY e)])
 ```
 
 ## Troubleshooting
 
-| Symptom | What went wrong | Fix |
+| Symptom | Cause | Fix |
 |---|---|---|
-| Reaching for `useState` / `r/atom` to hold "is this open?" | Application-visible state headed for a private store | An app-db address (valve 1), or the [overlay](glossary.md#overlay) module's reconciled flag |
-| A view's atom resets every render, or never repaints | Bodies re-run and are abandoned; render-minted cells are re-minted, and nothing tracks them | Move the fact to its valve; if it is genuinely widget mechanics, move it into a native host |
+| Reaching for `useState` / `r/atom` to hold "is this open?" | Application-visible state headed for a private store | An app-db address (valve 1), or the overlay module's reconciled flag |
+| A view's atom resets every render, or never repaints | Bodies re-run and are abandoned; render-created cells are recreated, and nothing tracks them | Move the fact to its valve; if it is genuinely widget mechanics, move it into a native host |
 | Searching for `:on-mount`, `componentDidMount`, a mount `useEffect` | There is none | Name the job and use its home — the table above |
 | Every panel in a list opens at once | One shared address | Key the address per instance — [Choosing the address](#choosing-the-address) |
 | Typing or dragging lags; Xray shows an event per pointer-move | High-rate mechanics routed through app-db | Keep motion host-private; dispatch only the semantic commit |
@@ -312,7 +308,7 @@ exactly one memory.
 | A test simulates clicks to open a dropdown | The state is data | Seed the address with a `:db` write ([Testing](14-testing.md)) |
 
 ??? info "If you're coming from Reagent"
-    `r/atom` was necessary against machinery [Hicasso](glossary.md#hicasso) does not have. In the
+    `r/atom` was necessary against machinery Hicasso does not have. In the
     idiomatic corpus this model was distilled from — 85 files, ~140 views —
     the count of view-local reactive cells is zero. The machinery
     manufactured the demand. The valves absorb what was real: addresses for

--- a/docs/design/hicasso/draft-guide/12-overlays-and-focus.md
+++ b/docs/design/hicasso/draft-guide/12-overlays-and-focus.md
@@ -1,19 +1,17 @@
 # Overlays and focus
 
-You need a filter menu anchored to its button, and a delete confirmation that
-blocks the page behind it. The classic build — a [portal](glossary.md#portal), a z-index ladder, a
-document click listener, hand-rolled focus management — leaks and breaks in
-known ways. `re-frame.hicasso.overlay` gives you two primitives, [popover](glossary.md#overlay) and
-modal, that mount on the browser's **native top layer** (`popover` /
-`<dialog>`). The platform owns stacking, dismissal, and focus. Your app owns
-exactly one thing: the data.
+You need a filter menu anchored to its button, or a delete confirmation that
+blocks the page behind it. Hand-rolled portals, z-index ladders, document
+click listeners, and focus traps leak and break in predictable ways.
 
-> **Open is a boolean at an address, dismissal is an event, and the browser
-> owns stacking, light-dismiss, and the focus trap and return.**
+`re-frame.hicasso.overlay` gives two primitives — [popover](glossary.md#overlay)
+and modal — that mount on the browser's native top layer (`popover` /
+`<dialog>`). The browser handles stacking, light-dismiss, and focus. Your app
+stores one open flag and handles one dismiss event.
 
 ## An anchored popover
 
-The caller owns the open flag, as ordinary state at an address
+The open flag is ordinary app-db state
 ([Ephemeral state](11-ephemeral-state.md)):
 
 ```clojure
@@ -37,7 +35,8 @@ The caller owns the open flag, as ordinary state at an address
   (let [open? (h/sub [:filter-menu/open? id])]
     [:div.filter
      [:button {:id (str "filter-" id "-trigger")
-               :aria-haspopup "menu" :aria-expanded open?
+               :aria-haspopup "menu"
+               :aria-expanded open?
                :on-click [:filter-menu/toggled id]}
       "Filter"]
      [overlay/popover {:open?      open?
@@ -45,39 +44,37 @@ The caller owns the open flag, as ordinary state at an address
                        :anchor     (str "filter-" id "-trigger")
                        :placement  :bottom-start}
       [:ul {:role "menu"}
-       [:li [:button {:role "menuitem" :on-click [:filter/applied id :unread]} "Unread"]]
-       [:li [:button {:role "menuitem" :on-click [:filter/applied id :flagged]} "Flagged"]]]]]))
+       [:li [:button {:role "menuitem"
+                      :on-click [:filter/applied id :unread]}
+             "Unread"]]
+       [:li [:button {:role "menuitem"
+                      :on-click [:filter/applied id :flagged]}
+             "Flagged"]]]]]))
 ```
 
-What the module does with those four options:
+What those options do:
 
-- **`:open?` is the one owner.** While the flag is false, the [popover](glossary.md#overlay) renders
-  *nothing*: no DOM node, no listener, and the body's reads never run. When
-  the flag goes true, the panel mounts directly onto the top layer. There the
-  panel sits above every stacking context, and no ancestor `overflow: hidden`
-  or `transform` can affect it. There is no [portal](glossary.md#portal) and no z-index anywhere.
-- **`:on-dismiss` is how the platform reports.** Outside click and Esc are
-  the popover's native light-dismiss. There is no document listener. The
-  browser closes the panel, and the module dispatches your event. Your
-  handler writes the flag, and the panel follows the address. If the handler
-  intentionally keeps the flag true, the panel stays open — state owns the
-  platform, never the reverse.
-- **`:anchor` names the trigger by DOM id**, per instance. The module
-  computes placement before the first paint, so there is no wrong-position
-  flash. `:placement` takes the compass words: `:bottom-start`,
-  `:bottom-end`, `:top-start`, `:right`, and the others. Where the browser
-  has CSS anchor positioning, the tracking is pure CSS. Elsewhere the module
-  re-places the panel on open and on resize — a declared contract, never an
-  every-frame loop.
-- **The body never leaves the tree.** The body renders in place, under the
-  same frame as its anchor, so its subscriptions resolve exactly as they do
-  in-flow. Nothing special propagates, because nothing moved.
+- **`:open?`** — while false, the popover renders nothing: no DOM node, no
+  listener, and the body's subscriptions do not run. When true, the panel
+  mounts on the top layer, above every stacking context. Ancestor
+  `overflow: hidden` and `transform` do not clip it. There is no
+  [portal](glossary.md#portal) and no z-index.
+- **`:on-dismiss`** — outside click and Esc are the popover's native
+  light-dismiss. The browser closes the panel and the module dispatches your
+  event. Your handler must write the flag false. If the handler leaves the
+  flag true, the panel stays open — app-db is the owner.
+- **`:anchor`** — DOM id of the trigger, unique per instance. The module
+  places the panel before first paint. `:placement` uses compass words such
+  as `:bottom-start`, `:bottom-end`, `:top-start`, and `:right`. Where the
+  browser supports CSS anchor positioning, tracking is CSS; otherwise the
+  module re-places on open and resize.
+- **The body stays in the tree.** It renders under the same frame as its
+  anchor, so subscriptions resolve as they do in-flow.
 
 ## A modal
 
-A [modal](glossary.md#overlay) has the same shape and stronger conduct. `overlay/modal` drives a
-native `<dialog>` through `showModal`, and that call is the source of the
-focus contract:
+A [modal](glossary.md#overlay) has the same shape with stronger focus behaviour.
+`overlay/modal` drives a native `<dialog>` through `showModal`:
 
 ```clojure
 (rf/reg-sub :invoice/confirm-delete?
@@ -105,75 +102,75 @@ focus contract:
      "Delete"]]])
 ```
 
-- **The background is inert.** Focus cannot Tab out, clicks land nowhere, and
-  assistive technology skips the background. The platform owns the trap, not
-  a keydown handler.
-- **Esc dispatches `:on-dismiss`.** A click on the backdrop does too when you
-  pass `:light-dismiss? true`. The default is off, because a destructive
-  confirmation should not close under a stray click.
+- The background is inert: focus cannot Tab out, clicks do not land, and
+  assistive technology skips it. The browser owns the trap.
+- Esc dispatches `:on-dismiss`. Backdrop click does too only when you pass
+  `:light-dismiss? true`. The default is off so a destructive confirmation
+  does not close on a stray click.
 - **`:label`** is the dialog's accessible name.
-- You style the backdrop via `::backdrop` in CSS
+- Style the backdrop with `::backdrop` in CSS
   ([Theming](13-theming-and-i18n.md)).
 
-## Focus is a one-shot intent
+## Focus
 
-Focus is platform state. You never mirror "what has focus" into app-db
-([Ephemeral state](11-ephemeral-state.md)). What you *can* express is [intent](glossary.md#intent),
-as data, exactly once per open:
+Focus is browser state. Do not mirror "what has focus" into app-db
+([Ephemeral state](11-ephemeral-state.md)). Express intent once per open:
 
-- **Mount focus.** Put `:auto-focus true` on the element that must receive
-  focus when the [overlay](glossary.md#overlay) opens — the Delete button above, or the search field
-  in a command palette. The attribute fires when the overlay opens, never
-  again on a re-render, and it is inert markup on the server. A modal with no
+- **Mount focus.** Put `:auto-focus true` on the element that should receive
+  focus when the overlay opens — the Delete button above, or a search field
+  in a command palette. The attribute fires when the overlay opens, not again
+  on re-render, and it is inert markup on the server. A modal with no
   `:auto-focus` focuses the dialog itself. A popover leaves focus on the
-  trigger, which is what menus and comboboxes want: the panel is operated
-  with `:aria-activedescendant`, not with focus moves.
+  trigger (menus and comboboxes usually operate with
+  `:aria-activedescendant`, not focus moves).
 - **Restore on close.** Both primitives return focus to the element that had
-  focus at open — on dismiss, on Esc, and on programmatic close alike. There
-  is nothing to write. The module's contract holds even when the close comes
-  from a `:db` write in a test.
+  it at open — on dismiss, Esc, and programmatic close. You write nothing for
+  restore.
 
-## Nesting is LIFO
+## Nesting
 
 A popover can sit inside a modal, and a submenu inside a menu. The native top
-layer is a stack, so nesting is last-in-first-out by construction. Esc closes
-only the innermost open [overlay](glossary.md#overlay). An outside click on an inner popover
-light-dismisses that popover and does not touch the modal under it. Your side
-of the contract is one address and one `:on-dismiss` per overlay. If two
-overlays share one dismiss event, you rebuild the problem the stack solves.
+layer is a stack, so nesting is last-in-first-out. Esc closes only the
+innermost open overlay. An outside click on an inner popover light-dismisses
+that popover and leaves the modal under it alone.
 
-## The contract while closed
+Use one address and one `:on-dismiss` per overlay. If two overlays share one
+dismiss event, you rebuild the problem the stack solves.
 
-A closed overlay costs nothing. Not a small amount — nothing:
+## Cost while closed
 
-- no DOM node, on the client or in server output;
-- no listener anywhere (light-dismiss is the platform's, and only while
-  open);
-- no subscriptions — the body is not mounted, so its reads do not exist;
-- exact teardown: an unmount of a view whose overlay is open closes the
-  overlay, restores focus, and leaves zero residue.
+A closed overlay costs nothing:
 
-A table of five hundred rows, each with a closed row-menu, is exactly as
-heavy as the same table without menus. Design with [overlays](glossary.md#overlay) freely; you pay
-only for the open one.
+- no DOM node (client or server output)
+- no listener (light-dismiss exists only while open)
+- no subscriptions (the body is not mounted)
+- clean teardown: unmount of a view whose overlay is open closes it, restores
+  focus, and leaves no residue
+
+A table of five hundred rows, each with a closed row-menu, is as heavy as the
+same table without menus. You pay only for the open one.
 
 ## Compose a dropdown from the popover
 
-Dropdowns, comboboxes, and toggletips are not separate primitives. Each is
-the [popover](glossary.md#overlay) plus your own semantics as ordinary events and subs. Here is a
-single-select with full keyboard support:
+Dropdowns, comboboxes, and toggletips are not separate primitives. Each is a
+popover plus your own events and subs. Single-select with keyboard support:
 
 ```clojure
-(rf/reg-sub :combo/open?  (fn [db [_ id]] (get-in db [:ui :combo id :open?] false)))
-(rf/reg-sub :combo/active (fn [db [_ id]] (get-in db [:ui :combo id :active])))
+(rf/reg-sub :combo/open?
+  (fn [db [_ id]] (get-in db [:ui :combo id :open?] false)))
+
+(rf/reg-sub :combo/active
+  (fn [db [_ id]] (get-in db [:ui :combo id :active])))
 
 (rf/reg-event :combo/toggled
-  (fn [{:keys [db]} [_ id]] {:db (update-in db [:ui :combo id :open?] not)}))
+  (fn [{:keys [db]} [_ id]]
+    {:db (update-in db [:ui :combo id :open?] not)}))
 
 (rf/reg-event :combo/dismissed
-  (fn [{:keys [db]} [_ id]] {:db (assoc-in db [:ui :combo id :open?] false)}))
+  (fn [{:keys [db]} [_ id]]
+    {:db (assoc-in db [:ui :combo id :open?] false)}))
 
-(rf/reg-event :combo/moved            ;; consults committed state; opens if closed
+(rf/reg-event :combo/moved
   (fn [{:keys [db]} [_ id step values]]
     (let [at   (get-in db [:ui :combo id :active])
           i    (get (zipmap values (range)) at -1)
@@ -182,7 +179,7 @@ single-select with full keyboard support:
                (assoc-in [:ui :combo id :open?] true)
                (assoc-in [:ui :combo id :active] next))})))
 
-(rf/reg-event :combo/committed        ;; commit reads state at fire time, not render time
+(rf/reg-event :combo/committed
   (fn [{:keys [db]} [_ id on-commit]]
     (let [{:keys [open? active]} (get-in db [:ui :combo id])]
       (cond-> {:db (assoc-in db [:ui :combo id :open?] false)}
@@ -197,10 +194,12 @@ single-select with full keyboard support:
   (let [open?  (h/sub [:combo/open? id])
         active (h/sub [:combo/active id])
         values (mapv :value items)
-        label  (or (some #(when (= value (:value %)) (:label %)) items) placeholder)]
+        label  (or (some #(when (= value (:value %)) (:label %)) items)
+                   placeholder)]
     [:div.combo
      [:button {:id (str "combo-" id "-trigger")
-               :aria-haspopup "listbox" :aria-expanded open?
+               :aria-haspopup "listbox"
+               :aria-expanded open?
                :aria-activedescendant (when (and open? active)
                                         (str "combo-" id "-opt-" active))
                :on-click    [:combo/toggled id]
@@ -216,45 +215,42 @@ single-select with full keyboard support:
        (for [{:keys [value label]} items]
          [:li {:key value
                :id (str "combo-" id "-opt-" value)
-               :role "option" :aria-selected (= value active)
+               :role "option"
+               :aria-selected (= value active)
                :on-click [:combo/selected id on-commit value]}
           label])]]]))
 ```
 
-Note what is *not* here:
+What is not here:
 
-- no Escape row in the key map — Esc is light-dismiss; the platform closes
-  the panel and `:on-dismiss` fires;
-- no focus moves — focus stays on the trigger;
-- no document listener;
-- no [portal](glossary.md#portal).
+- no Escape row — Esc is light-dismiss; the platform closes and `:on-dismiss`
+  fires
+- no focus moves — focus stays on the trigger
+- no document listener
+- no portal
 
-The whole open/move/commit/dismiss policy is events over an address. A test
-can prove the policy headlessly and seed it directly, and Xray shows it. A
-toggletip — a click-to-open rich hint — is the same [popover](glossary.md#overlay) with a single
-dismiss event and no listbox.
+Open / move / commit / dismiss is events over an address. A test can drive
+the policy headlessly; Xray shows it. A toggletip is the same popover with a
+single dismiss event and no listbox.
 
-## When you don't need the module
+## When not to use the module
 
-Use the platform's own features first. The module earns its place only when
-the open state must be *application* data, or when you need anchored
-placement and focus conduct.
+Prefer the platform first. Use the module when open state must be application
+data, or when you need anchored placement and focus behaviour.
 
-- **A hover tooltip is CSS.** Use `:hover` / `:focus-visible` plus a
-  positioned pseudo-element or sibling. No state exists at all, and a route
-  of hover through any state system costs a re-render per pointer-move.
-- **Disclosure is `<details>`.** The platform tracks open; the triangle
-  costs nothing.
-- **A presentational hint can be a bare [popover](glossary.md#overlay).** `[:button {:popovertarget "help-tip"} "?"]`
-  with `[:div {:id "help-tip" :popover "auto"} …]` — the browser does
-  everything, and the app never knows. That is DOM-owned state as a declared
-  choice ([Ephemeral state](11-ephemeral-state.md)). When a test or another
-  view needs the flag, move up to `overlay/popover`.
+- **Hover tooltip** — CSS `:hover` / `:focus-visible` plus a positioned
+  pseudo-element or sibling. No app-db state; routing hover through any state
+  system re-renders on pointer move.
+- **Disclosure** — `<details>`. The browser tracks open.
+- **Presentational hint** — bare popover markup:
+  `[:button {:popovertarget "help-tip"} "?"]` with
+  `[:div {:id "help-tip" :popover "auto"} …]`. The browser does everything.
+  When a test or another view needs the flag, move up to `overlay/popover`.
 
 ## Don't build the old way
 
 ```clojure
-;; Don't — the pre-top-layer overlay: every classic defect in ten lines.
+;; Don't — pre-top-layer overlay: every classic defect in ten lines
 (h/defview old-menu [{:keys [id]}]
   (let [open? (h/sub [:menu/open? id])]
     [:div {:style {:position "relative"}}
@@ -266,52 +262,50 @@ placement and focus conduct.
 ;; …plus a js/document click listener added on open, removed on close.
 ```
 
-Three of its failures:
+Failures that follow:
 
-- An unmount while open leaks the document listener permanently.
-- One ancestor `transform` silently changes `position: fixed` into a wrong
-  position.
-- The z-index values hold only until the next library brings a larger one.
+- Unmount while open leaks the document listener.
+- One ancestor `transform` turns `position: fixed` into the wrong position.
+- Z-index values hold only until the next library brings a larger one.
 
-The module's version removes the whole failure class: there is no listener to
-leak, no stacking context to lose to, no z-index contest.
+The module removes the class: no listener to leak, no stacking context to lose
+to, no z-index contest.
 
 ## Troubleshooting
 
-| Symptom | What went wrong | Fix |
-|---|---|---|
-| Panel clipped by `overflow: hidden` or stuck under a sticky header | The panel is an in-flow positioned div, not on the top layer | Render it through `overlay/popover` |
-| Outside click closes the [popover](glossary.md#overlay) but it re-opens | Light-dismiss fired and `:on-dismiss` was dispatched, but the handler never wrote the flag — the module re-shows to match the owner | Make the `:on-dismiss` handler set open to false |
-| Esc closes the whole stack at once | The layers share one dismiss event or one address | One address and one `:on-dismiss` per overlay; the platform unwinds innermost-first |
-| Focus lands on `<body>` after close | The opener unmounted while the overlay was open — usually unstable list keys remounting the trigger | Stable `:key` on the trigger's row; restore targets the element focused at open, if it still exists |
-| `:rf.error/hicasso-overlay-anchor-missing` at open | `:anchor` names an id that is not in the document — or two instances share one id | Per-instance anchor ids: `(str "combo-" id "-trigger")` |
-| Dialog shows but the page behind still scrolls and clicks | A hand-written `[:dialog {:open true}]` — the `open` attribute is the non-modal path: no top layer, no inert background | `overlay/modal` drives `showModal` for you |
-| Popover flashes at the wrong position for one frame | Something positions it after mount — usually a measuring effect of your own | Pass `:anchor` / `:placement`; the module places before first paint |
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Panel clipped by `overflow: hidden` or stuck under a sticky header | Panel is an in-flow positioned div, not on the top layer | Render through `overlay/popover` |
+| Outside click closes the popover but it re-opens | Light-dismiss fired and `:on-dismiss` ran, but the handler never cleared the flag | Make the `:on-dismiss` handler set open to false |
+| Esc closes the whole stack at once | Layers share one dismiss event or one address | One address and one `:on-dismiss` per overlay |
+| Focus lands on `<body>` after close | Opener unmounted while the overlay was open — often unstable list keys remounting the trigger | Stable `:key` on the trigger's row |
+| `:rf.error/hicasso-overlay-anchor-missing` at open | `:anchor` names an id not in the document, or two instances share one id | Per-instance ids: `(str "combo-" id "-trigger")` |
+| Dialog shows but the page behind still scrolls and clicks | Hand-written `[:dialog {:open true}]` — the `open` attribute is the non-modal path | Use `overlay/modal`, which calls `showModal` |
+| Popover flashes at the wrong position for one frame | Something positions after mount | Pass `:anchor` / `:placement`; the module places before first paint |
 | Every row's menu opens at once | One shared address | Key the address per instance ([Ephemeral state](11-ephemeral-state.md#choosing-the-address)) |
 
 ??? info "If you're coming from Reagent or UIx"
-    The instinct is a [portal](glossary.md#portal) + z-index + floating-ui + a `with-let` document
-    listener. Here the panel never leaves its place in the tree — the top
-    layer changes *paint* order, not *tree* order. So frame context,
-    subscriptions, SSR, and hydration need no special path, and light-dismiss
-    arrives without a listener to leak. What remains yours was always
-    genuinely yours: the open flag, and the meaning of a selection.
+    The usual stack is a portal + z-index + floating-ui + a document listener.
+    Here the panel never leaves its place in the tree — the top layer changes
+    paint order, not tree order. Frame context, subscriptions, SSR, and
+    hydration need no special path, and light-dismiss arrives without a
+    listener to leak. You still own the open flag and the meaning of a
+    selection.
 
 ## Advanced
 
 **Entry animation is pure CSS.** The panel mounts on open, so
-`@starting-style` (or a keyframe on the class) animates the entry with no
-state and no timers:
+`@starting-style` (or a keyframe on the class) animates entry with no state
+and no timers:
 
 ```css
 .menu[popover]:popover-open { opacity: 1; transition: opacity 150ms; }
 @starting-style { .menu[popover]:popover-open { opacity: 0; } }
 ```
 
-**Exit animation gets a clock.** On dismiss the panel normally leaves with
+**Exit animation needs a clock.** On dismiss the panel normally leaves with
 the flag. To let a fade finish, pass `:exit-ms`. The module keeps the node on
-the top layer for that time (inert, `aria-hidden`) and removes the node on
-the clock even when the CSS did not run — the same hard-bound rule that
-presence uses ([Ephemeral state](11-ephemeral-state.md)). A re-open before
-the deadline cancels the exit, and an unmount cancels the timer. State is
-closed the whole time; only the paint remains.
+the top layer for that time (inert, `aria-hidden`) and removes it when the
+clock ends even if the CSS did not run. A re-open before the deadline cancels
+the exit; an unmount cancels the timer. State is closed the whole time; only
+the paint remains.

--- a/docs/design/hicasso/draft-guide/13-theming-and-i18n.md
+++ b/docs/design/hicasso/draft-guide/13-theming-and-i18n.md
@@ -1,18 +1,13 @@
 # Theming and i18n
 
-You want a dark mode and a second language. In most React stacks each arrives
-with machinery: a ThemeProvider, an i18n context, a hook per consumer.
-[Hicasso](glossary.md#hicasso) ships neither, because neither job needs adapter support. Tokens live
-in CSS, strings are ordinary values, and the current choice — theme or locale
-— is one key in app-db that ordinary subs read.
-
-> **Tokens live in CSS, strings are data, the choice lives in app-db, and the
-> absence of a theming or i18n subsystem is the design.**
+You want a dark mode and a second language. Many React stacks add a
+ThemeProvider, an i18n context, and a hook per consumer. Hicasso ships
+neither. Tokens live in CSS, strings are ordinary values, and the current
+theme or locale is one key in app-db that ordinary subscriptions read.
 
 ## Design tokens in CSS
 
-The cascade is already a scoping system: the nearest ancestor wins, the scope
-is a subtree, and the mechanism is platform-native. Put your tokens on
+The cascade already scopes styles: the nearest ancestor wins. Put tokens on
 `:root` and override them under a theme attribute:
 
 ```css
@@ -33,25 +28,29 @@ is a subtree, and the mechanism is platform-native. Put your tokens on
 }
 ```
 
-The `--app-*` prefix is not [Hicasso](glossary.md#hicasso)'s. Name your custom properties the way
-your stylesheet already does. `:root` *is* the light theme, so nobody writes
-a `[data-theme="light"]` block.
+The `--app-*` prefix is yours — name custom properties the way your
+stylesheet already does. `:root` is the light theme, so you do not need a
+`[data-theme="light"]` block.
 
-A theme switch is one attribute flip on one element. After the flip, the
-restyle costs zero React work: the cascade recomputes, and the component tree
-is never consulted.
+A theme switch flips one attribute on one element. After the flip, the cascade
+restyles and React does no work for token changes.
 
 ## The live theme switch
 
-The choice is application state like any other: one sub, one event, and one
-view that renders the attribute.
+The choice is application state: one subscription, one event, and one view
+that renders the attribute.
 
 ```clojure
+(ns app.theme
+  (:require [re-frame.core :as rf]
+            [re-frame.hicasso :as h]))
+
 (rf/reg-sub :theme/current
   (fn [db _query] (:theme/current db :light)))   ;; unset reads as :light
 
 (rf/reg-event :theme/choose
-  (fn [{:keys [db]} [_ theme]] {:db (assoc db :theme/current theme)}))
+  (fn [{:keys [db]} [_ theme]]
+    {:db (assoc db :theme/current theme)}))
 
 (h/defview theme-scope [{:keys [children]}]
   (into [:div {:data-theme (name (h/sub [:theme/current]))}]
@@ -67,57 +66,52 @@ view that renders the attribute.
 ```
 
 `children` arrives as a realized vector; that is why `into` splices it
-([Views and reads](02-views-and-reads.md) has the rule).
+([Views and reads](02-views-and-reads.md)).
 
-**The default belongs in the sub, not in each reader.** A fresh app-db holds
-no choice, so a bare `(:theme/current db)` reads `nil`, and `(name nil)`
-throws. From a root view, that throw is a blank page. One extra argument
-makes the read total and states the fallback once.
+**Put the default in the subscription, not in each reader.** A fresh app-db
+holds no choice, so a bare `(:theme/current db)` is `nil`, and `(name nil)`
+throws. From a root view that throw blanks the page. One extra argument makes
+the read total.
 
-Three placement details carry the rest:
+Placement rules:
 
-- **The attribute lands per frame, not per document.** A view renders its own
-  element and nothing above it, so `data-theme` goes on `theme-scope`'s own
-  `div`. That is what frame isolation needs. Two frames on one page, one
-  light and one dark, is an ordinary page.
-- **Keep a [`defview`](glossary.md#defview) head immediately below the scope.** The scope re-renders
-  on every switch — one [boundary](glossary.md#boundary), a known cost. `[app {}]` below the scope
-  bails out, because `app` is a `defview` and its props are unchanged
-  ([Views and reads](02-views-and-reads.md)). A native-tag subtree, or a view
-  called as a plain function, in that position re-runs with the scope.
-- **Keep the scope at the frame's root, above any [`defhost`](glossary.md#defhost) crossing.** On
+- **Per frame, not per document.** A view renders its own element, so
+  `data-theme` goes on `theme-scope`'s `div`. Two frames on one page — one
+  light, one dark — work without further machinery.
+- **Keep a [`defview`](glossary.md#defview) head immediately below the scope.** The scope
+  re-renders on every switch. `[app {}]` below the scope bails out when its
+  props are unchanged ([Views and reads](02-views-and-reads.md)). A native-tag
+  subtree, or a view called as a plain function, re-runs with the scope.
+- **Keep the scope at the frame root, above any [`defhost`](glossary.md#defhost) crossing.** On
   the server, a Client-only crossing renders its fallback instead of its
-  subtree. A scope below such a crossing is absent from the response,
-  together with everything the scope covered
+  subtree. A scope below that crossing is missing from the response
   ([SSR and hydration](17-ssr-and-hydration.md)).
 
-An app that restores a remembered choice dispatches `:theme/choose` from
-`:initial-events`, which lands before first paint
-([Installation](installation.md)). The default paints only when
-nobody has chosen, never as a flash before a late choice.
+To restore a remembered choice, dispatch `:theme/choose` from
+`:initial-events` so it lands before first paint
+([Installation](installation.md)). The default paints only when nobody has
+chosen.
 
-A class is the same bridge: `{:class (str "app app--" (name theme))}` swaps a
-class instead of an attribute. Density, brand, or compact mode are more keys
-driven the same way — one sub, one class or variable swap. If you measure a
-need for zero render work on the switch, the imperative variant is three
-lines of `rf/reg-fx` that set the attribute on `documentElement`. The price:
-the DOM no longer derives from app-db, so a rewind or a restored snapshot
-shows the old theme. Render the fact unless you have that measurement.
+A class is the same bridge: `{:class (str "app app--" (name theme))}`.
+Density, brand, or compact mode are more keys driven the same way.
 
-If all you want is *follow the OS*, you need no app state at all. A
-`@media (prefers-color-scheme: dark)` block themes the page with no sub, no
-event, and no bridge. Use app-db when the user picks, or when the pick must
-survive a reload.
+If you need zero render work on the switch, an `rf/reg-fx` can set the
+attribute on `documentElement`. The cost: the DOM no longer derives from
+app-db, so a rewind or restored snapshot shows the old theme. Render the fact
+unless you have measured a need for the imperative path.
+
+To follow the OS with no user override, skip app-db entirely and use
+`@media (prefers-color-scheme: dark)`. Use app-db when the user picks, or when
+the pick must survive a reload.
 
 ### Page chrome and the top layer
 
-Two surfaces sit outside every frame. The document's own chrome — the
-scrollbar, the `<body>` canvas, `<meta name="theme-color">` — is above any
-root, so a per-frame attribute never reaches it. When the chrome matters,
-echo the same app-db fact at document level from the choosing event, as a row
-under `:fx` beside its `:db` write. Use a *different* attribute name, so the
-rendered scope stays the one real carrier and the document copy stays
-cosmetic:
+Two surfaces sit outside every frame. Document chrome — scrollbar, `<body>`
+canvas, `<meta name="theme-color">` — is above any root, so a per-frame
+attribute never reaches it. When chrome matters, echo the same app-db fact at
+document level from the choosing event, as a row under `:fx` beside the `:db`
+write. Use a *different* attribute name so the rendered scope stays the real
+carrier and the document copy stays cosmetic:
 
 ```clojure
 (rf/reg-fx :page/echo-theme!
@@ -126,18 +120,17 @@ cosmetic:
     (.setAttribute js/document.documentElement "data-page-theme" (name theme))))
 ```
 
-The top layer needs no echo. An [overlay](glossary.md#overlay)'s `::backdrop` pseudo-element
-inherits custom properties from the element that opened it, so a modal opened
-inside `theme-scope` takes the scope's tokens. Style the backdrop with the
-same variables ([Overlays and focus](12-overlays-and-focus.md)).
+The top layer needs no echo. An [overlay](glossary.md#overlay)'s `::backdrop`
+pseudo-element inherits custom properties from the element that opened it, so
+a modal opened inside `theme-scope` takes the scope's tokens. Style the
+backdrop with the same variables
+([Overlays and focus](12-overlays-and-focus.md)).
 
 ## Strings are values: i18n
 
-I18n has the same shape, one level up. The locale is a key in app-db, the
-strings are a map, and a sub joins them. A translated string is an ordinary
-value that flows through an ordinary sub. When the locale changes, every view
-that read a string re-renders, because its inputs changed. That is the whole
-mechanism: no observer registry, no i18n context, no remount.
+Locale is a key in app-db, strings are a map, and a subscription joins them.
+When the locale changes, every view that read a string re-renders because its
+inputs changed. No observer registry, no i18n context, no remount.
 
 ```clojure
 (def strings
@@ -152,7 +145,8 @@ mechanism: no observer registry, no i18n context, no remount.
     (get-in strings [(:i18n/locale db :en) k] (name k))))  ;; miss shows the key
 
 (rf/reg-event :i18n/set-locale
-  (fn [{:keys [db]} [_ locale]] {:db (assoc db :i18n/locale locale)}))
+  (fn [{:keys [db]} [_ locale]]
+    {:db (assoc db :i18n/locale locale)}))
 
 (h/defview greeting [_props]
   [:header
@@ -160,28 +154,26 @@ mechanism: no observer registry, no i18n context, no remount.
    [:button {:on-click [:i18n/set-locale :fr]} "Français"]])
 ```
 
-Numbers and dates need no framework either. The platform already localizes
-them, with the locale read as an ordinary value:
+Numbers and dates use the platform with the locale as an ordinary value:
 
 ```clojure
 (h/defview price [{:keys [amount]}]
   (let [locale (name (h/sub [:i18n/locale]))]
     [:span.price
-     (.format (js/Intl.NumberFormat. locale #js {:style "currency" :currency "EUR"})
+     (.format (js/Intl.NumberFormat. locale
+                                     #js {:style "currency" :currency "EUR"})
               amount)]))
 ```
 
-Loaded locale packs are the same design with the table in app-db instead of
-code. Fetch the pack, `assoc` the pack in, and let the sub read
-`(get-in db [:i18n/strings locale k])`. A string that arrives late is app-db
-changing, and the views that read the string follow.
+Loaded locale packs use the same design with the table in app-db instead of
+code. Fetch the pack, `assoc` it in, and let the subscription read
+`(get-in db [:i18n/strings locale k])`. A late string is app-db changing; the
+views that read it follow.
 
 ## What over-engineering looks like
 
-The instinct to build a subsystem here is strong, so here is the cost:
-
 ```clojure
-;; Don't — a "theme system": tokens in app-db, every view reading the registry
+;; Don't — tokens in app-db; every view reads the registry
 (rf/reg-sub :theme/token
   (fn [db [_ k]] (get-in db [:theme/tokens (:theme/current db) k])))
 
@@ -193,16 +185,16 @@ The instinct to build a subsystem here is strong, so here is the cost:
 
 Now every view reads the token registry, a theme switch re-renders all of
 those views, and app-db carries a second copy of what the stylesheet already
-owns. The cascade does this job at no cost: tokens in CSS, one attribute
-flip, zero React work after the flip. The same instinct builds an i18n
-provider with a hook per consumer — and the sub already is the provider.
+owns. Tokens in CSS plus one attribute flip cost zero React work for token
+changes. The same instinct builds an i18n provider with a hook per consumer —
+the subscription already is the provider.
 
-## A vendor theme goes through the host door
+## A vendor theme via `defhost`
 
-A component library that themes itself through React context gets its
-provider the way any foreign component arrives: declared once with
-[`h/defhost`](glossary.md#defhost), used as an ordinary head, with children lowered where they
-render ([Interop](09-interop.md)).
+A component library that themes itself through React context gets its provider
+the way any foreign component arrives: declare once with
+[`h/defhost`](glossary.md#defhost), use as an ordinary head
+([Interop](09-interop.md)).
 
 ```clojure
 (ns app.vendor-theme
@@ -221,27 +213,27 @@ render ([Interop](09-interop.md)).
         children))
 ```
 
-The vendor's theme objects are minted once at load. The app-db choice only
-picks which object crosses. Context stays a React fact on the React side of
-the door; your own app's theming never needed context.
+Create the vendor theme objects once at load. App-db only picks which object
+crosses. Context stays a React fact on the React side of the host; your own
+app's theming never needed context.
 
 ## Troubleshooting
 
-| Symptom | What went wrong | Fix |
-|---|---|---|
-| Blank page on first load; console shows `Doesn't support name:` | Nobody had chosen a theme, the sub read `nil`, and `(name nil)` threw at the root | Give the sub a default: `(:theme/current db :light)` |
-| The theme key changes in app-db and nothing on screen changes | No view renders the attribute — the cascade keys off the DOM, not app-db | Mount `theme-scope` (or your equivalent) at the frame root |
-| Theme switch re-renders the whole app | What sits below the scope carries no [boundary](glossary.md#boundary) — a native-tag subtree, or a view called as a plain function | Keep a [`defview`](glossary.md#defview) head immediately below the scope, as `[app {}]` is |
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Blank page on first load; console shows `Doesn't support name:` | Nobody chose a theme, the sub read `nil`, and `(name nil)` threw at the root | Give the sub a default: `(:theme/current db :light)` |
+| Theme key changes in app-db and nothing on screen changes | No view renders the attribute — the cascade keys off the DOM, not app-db | Mount `theme-scope` (or equivalent) at the frame root |
+| Theme switch re-renders the whole app | What sits below the scope has no independent re-render unit — native-tag subtree, or a view called as a plain function | Keep a `defview` head immediately below the scope, as `[app {}]` is |
 | Locale switches but some strings stay in the old language | Those strings were captured once — in a `def`, a prop computed at load, a memoized helper — instead of read at render | Read strings where you use them: `(h/sub [:i18n/t k])` |
 | A missing translation renders as the key's name | The sub's miss fallback, working as designed | Add the key to the table; the fallback names it so you can find it |
-| The hydrated page keeps the server's theme | The hydration payload did not carry the choice, and an attribute-only divergence is the one class React never reports | Carry `:theme/current` in the payload ([SSR and hydration](17-ssr-and-hydration.md)) |
+| Hydrated page keeps the server's theme | Hydration payload did not carry the choice; attribute-only divergence is the class React never reports | Carry `:theme/current` in the payload ([SSR and hydration](17-ssr-and-hydration.md)) |
 
-## When not
+## When not to use it
 
 - **Following the OS with no user override** — skip app state; the media
   query is the whole feature.
 - **One locale today** — do not build the table. Literal strings in views are
-  fine. The table earns its place when the second locale is real, and the
-  migration is mechanical: each literal becomes a key.
-- **Your own app's styling** — never needs the vendor door or context. CSS is
+  fine. The table earns its place when the second locale is real; migration is
+  mechanical (each literal becomes a key).
+- **Your own app's styling** — never needs a vendor host or context. CSS is
   enough.

--- a/docs/design/hicasso/draft-guide/14-testing.md
+++ b/docs/design/hicasso/draft-guide/14-testing.md
@@ -1,44 +1,39 @@
 # Testing
 
-You have a feature to test. You must decide which tests to write, and how
-much machinery each test needs. In a [Hicasso](glossary.md#hicasso) app, the answer is a
-[testing ladder](glossary.md#testing-ladder) of five rungs, and most of the
-ladder runs without a browser. Handlers and
+You have a feature to test. You need to decide which tests to write, and how
+much machinery each test needs.
+
+In a Hicasso app, most of the answer runs without a browser. Handlers and
 subscriptions are plain functions. Markup helpers return plain data. View
-bodies run under a [semantic harness](glossary.md#semantic-harness) with no DOM and no React — other view
-layers make you mount them. The browser is the top rung. Keep it for the
-facts that only a browser knows.
+bodies run under a [semantic harness](glossary.md#semantic-harness) with no
+DOM and no React. The browser is the top rung — keep it for facts only a
+browser knows.
 
-> **Test at the lowest rung that can prove the claim. Know which equality
-> that rung proves.**
+Test at the lowest rung that can prove the claim, and know which equality that
+rung proves.
 
-The [test kit](glossary.md#test-kit) is two namespaces, both supported product
-surfaces rather than loose collections of utilities. `re-frame.hicasso.test`
-holds every rung that runs without a browser, and this page aliases it as
-`ht`. The [mounted facade](glossary.md#mounted-facade) above it is
-`re-frame.hicasso.test.mounted`, aliased `hm`.
+The [test kit](glossary.md#test-kit) is two namespaces. `re-frame.hicasso.test`
+(aliased `ht` below) holds every rung that runs without a browser.
+`re-frame.hicasso.test.mounted` (aliased `hm`) is the
+[mounted facade](glossary.md#mounted-facade).
 
 ## The ladder
 
 | Rung | What it proves | Mechanism |
-|---|---|---|
+| --- | --- | --- |
 | **L0** | event handlers, subscriptions, state transitions | pure function calls |
-| **L1** | [intents](glossary.md#intent), prevent and navigate decisions, codecs, control and revision laws, native-form expansion | pure data, property, and macro-expansion tests |
-| **L2** | one hook-free view body, as a semantic tree | the [semantic harness](glossary.md#semantic-harness) — `ht/tree` under injected read fixtures |
-| **L3** | React lifecycle, hooks, context, refs, errors, hosts | the [mounted facade](glossary.md#mounted-facade), with Testing Library and user-event |
+| **L1** | intents, prevent and navigate decisions, codecs, control and revision laws, native-form expansion | pure data, property, and macro-expansion tests |
+| **L2** | one hook-free view body, as a semantic tree | `ht/tree` under injected read fixtures |
+| **L3** | React lifecycle, hooks, context, refs, errors, hosts | mounted facade with Testing Library and user-event |
 | **L4** | IME, caret, focus, layout, hydration, performance | Chromium, Firefox, and WebKit |
 
-Each rung proves a different equality. L1 proves authored data. L2 proves
-semantic-tree equality. L3 proves real DOM and lifecycle. L4 proves engine
-behaviour. A green test on one rung makes no claim about the rung above it.
-An L2 tree says nothing about React lifecycle. A normalized tree is never a
-proxy for hydration bytes. This honesty is what makes the cheap rungs
-trustworthy: they refuse to make claims they cannot prove.
+Each rung proves a different equality. A green L2 test says nothing about
+React lifecycle. A semantic tree is never a proxy for hydration bytes. That
+honesty is what makes the cheap rungs trustworthy.
 
 ## The feature under test
 
-One small feature serves as the example for this page: a todo row with a
-toggle.
+One small feature serves the whole page: a todo row with a toggle.
 
 ```clojure
 (ns todo.events
@@ -77,9 +72,9 @@ toggle.
 
 ## L0 — handlers and subscriptions are plain functions
 
-Nothing here is specific to [Hicasso](glossary.md#hicasso), and that is the point: the logic layer
-tests the same under every view layer. Take the handler from the registrar.
-Call it with literal values. Check the map it returns:
+Nothing here is Hicasso-specific. The logic layer tests the same under every
+view layer. Take the handler from the registrar, call it with literal values,
+check the map it returns:
 
 ```clojure
 (ns todo.events-test
@@ -94,8 +89,7 @@ Call it with literal values. Check the map it returns:
     (is (true? (get-in result [:db :todos 7 :done?])))))
 ```
 
-A subscription is a pure function over app-db values. Call it with the data
-and check the answer:
+A subscription is a pure function over app-db values:
 
 ```clojure
 (deftest by-id-reads-one-todo
@@ -104,13 +98,13 @@ and check the answer:
                          {:todos {7 {:id 7 :title "Buy milk" :done? false}}}))))
 ```
 
-Both tests run on the JVM: no browser, no React, no adapter. Most of your
-logic lives here, so most of your tests belong here.
+Both tests run on the JVM: no browser, no React. Most of your logic lives
+here, so most of your tests belong here.
 
 ## L1 — helpers and intents are plain data
 
-A helper that takes its data as arguments, and reads nothing, is an ordinary
-function. Call it. The whole assertion is `=`:
+A helper that takes its data as arguments and reads nothing is an ordinary
+function. Call it; the whole assertion is `=`:
 
 ```clojure
 (defn priority-badge [level]
@@ -121,30 +115,30 @@ function. Call it. The whole assertion is `=`:
          (priority-badge :high))))
 ```
 
-The same method covers every data spelling in the product, because each
-spelling is a value in an attribute map that some function returned: an
-[intent](glossary.md#intent) vector, a [`::h/prevent`](glossary.md#hprevent) head, a [route link](glossary.md#route-link)'s navigate decision. You
-never mount and click to learn what a button means. The meaning is a value
-that you compare.
+The same method covers every data spelling in the product: an
+[intent](glossary.md#intent) vector, a [`::h/prevent`](glossary.md#hprevent)
+head, a [route link](glossary.md#route-link)'s navigate decision. You never
+mount and click to learn what a button means — the meaning is a value you
+compare.
 
-L1 is also the rung for property tests: laws that hold for all inputs, such
-as a codec round-trip or the owned-wins attribute merge. When you own a
-[native island](glossary.md#native-island), [`n/$`](glossary.md#n-dollar) macro-expansion tests belong here too
-([Native tier](10-native-tier.md)). The canonical-DOM comparator,
-`ht/canonical-dom`, also lives at this rung. It is a pure serializer that
-you apply to mounted nodes when a claim compares two pages (mechanics under
-Advanced).
+L1 is also the rung for property tests (codec round-trip, owned-wins attribute
+merge). When you own a [native island](glossary.md#native-island),
+[`n/$`](glossary.md#n-dollar) macro-expansion tests belong here
+([Native tier](10-native-tier.md)). The canonical-DOM comparator
+`ht/canonical-dom` lives at this rung too: a pure serializer applied to
+mounted nodes when a claim compares two pages (mechanics under Advanced).
 
 ## L2 — the semantic harness
 
-A [`defview`](glossary.md#defview) body is not directly callable. It needs a render extent to read
-in, and a direct call refuses with a source-located recovery. The harness
-supplies that extent without React. `ht/tree` runs one hook-free body under a
-discardable read resolver — your fixtures — and returns a versioned
-semantic tree. Four small helpers assert on the tree: `ht/find`,
-`ht/attrs`, `ht/text`, and `ht/intents`. `ht/find` takes a **predicate over
-the tree's node maps** — `(:tag %)` names an element, `(:view-id %)` a child
-view call — so a selector language is one function away and none is minted.
+A [`defview`](glossary.md#defview) body is not directly callable. It needs a
+render context to read in; a direct call raises at the call and names the
+view. The harness supplies that context without React.
+
+`ht/tree` runs one hook-free body under a discardable read resolver — your
+fixtures — and returns a versioned semantic tree. Four helpers assert on the
+tree: `ht/find`, `ht/attrs`, `ht/text`, and `ht/intents`. `ht/find` takes a
+predicate over the tree's node maps — `(:tag %)` names an element,
+`(:view-id %)` a child view call.
 
 ```clojure
 (ns todo.views-test
@@ -162,59 +156,56 @@ view call — so a selector language is one function away and none is minted.
     (is (= [[:todo/toggle 7]] (ht/intents tree)))))
 ```
 
-The head may be the [`defview`](glossary.md#defview) itself, as above, or the body function it was
-minted from. Either runs the body as written: no React element is created, no
-hook runs, and nothing is mounted or painted.
+The head may be the `defview` itself, or the body function it was created
+from. Either runs the body as written: no React element, no hook, nothing
+mounted or painted.
 
-The fixtures replace the whole subscription layer. The body's [`h/sub`](glossary.md#hsub) calls
-resolve against the map. The harness never touches the real cache, and it
-discards the resolver afterwards. Fixture identity is the same as sub
-identity — `(query-id, args)` under value equality — so `[:todo/by-id 7]`
-and `[:todo/by-id "7"]` are different fixtures.
+Fixtures replace the whole subscription layer. The body's
+[`h/sub`](glossary.md#hsub) calls resolve against the map. The harness never
+touches the real cache, and it discards the resolver afterwards. Fixture
+identity is `(query-id, args)` under value equality — `[:todo/by-id 7]` and
+`[:todo/by-id "7"]` are different fixtures.
 
 **A child view does not expand.** A nested `[todo-row {:key id :id id}]` is
-recorded as the call it is — its view id, the props the call site passed, and
-the children the call site wrote — and its body does not run, so the node
-claims nothing about what that child would render. That is the tier's
-definition and not a reach that failed: L2 is one body, and a tree spanning
-two views cannot say which of them a red belongs to. Assert a child's props
-where it is called; render the child's own form to assert its contents.
+recorded as the call it is — view id, props, children — and its body does not
+run. L2 is one body; a tree spanning two views cannot say which of them a
+failure belongs to. Assert a child's props where it is called; render the
+child's own form to assert its contents.
 
-**The harness is honest about what it cannot know.** L2 is an assertion
-model, not a renderer. It refuses to fake the facts it does not have:
+**What the harness will not fake:**
 
-- A body that reaches a **hook**, a **raw React
-  element**, an **[`n/$`](glossary.md#n-dollar) result**, or a **[`defhost`](glossary.md#defhost) crossing** refuses with a
-  structured, source-located complaint that points at L3. React facts belong
-  to React.
-- A read with **no fixture** refuses and names the query. The harness never
-  replaces the read with `nil`, and never satisfies it with a fake.
+- A body that reaches a **hook**, a **raw React element**, an
+  [`n/$`](glossary.md#n-dollar) result, or a [`defhost`](glossary.md#defhost)
+  crossing raises with a structured, source-located complaint that points at
+  L3. React facts belong to React.
+- A read with **no fixture** raises and names the query. The harness never
+  substitutes `nil` or invents a value.
 
 !!! warning "No fake hook dispatcher, ever"
 
     A stubbed React dispatcher passes tests that real React would fail —
-    abandoned renders, StrictMode double-invoke, effect ordering. The kit
-    does not supply one, and you must not build one. Split the view instead:
-    keep the semantic half as data you can compare with `=`, and mount-test
-    the mechanics once.
+    abandoned renders, StrictMode double-invoke, effect ordering. The kit does
+    not supply one, and you must not build one. Split the view instead: keep
+    the semantic half as data you can compare with `=`, and mount-test the
+    mechanics once.
 
 ## L3 — the mounted facade
 
 When the claim is about React or the DOM — lifecycle, hooks, a real error
-[boundary](glossary.md#boundary), real nodes — mount the view. The facade gives every test an
-isolated frame (its own app-db, queue, and subscription cache), a real root,
-and a residue guarantee:
+boundary, real nodes — mount the view. The facade gives every test an isolated
+frame (its own app-db, queue, and subscription cache), a real root, and a
+residue guarantee:
 
 | Call | What it does |
-|---|---|
+| --- | --- |
 | `hm/mount!` | mounts a view under a fresh isolated frame; records the residue baseline first; returns a handle |
-| `hm/hydrate!` | mounts by adopting server bytes; answers a promise of the handle, once adoption has committed ([SSR and hydration](17-ssr-and-hydration.md)) |
+| `hm/hydrate!` | mounts by adopting server bytes; answers a promise of the handle once adoption has committed ([SSR and hydration](17-ssr-and-hydration.md)) |
 | `hm/rerender!` | renders a new element into the same root — for props-change tests |
-| `hm/dispatch-and-settle!` | dispatches into the mount's frame and returns once [Hicasso](glossary.md#hicasso) and React are quiescent |
+| `hm/dispatch-and-settle!` | dispatches into the mount's frame and returns once Hicasso and React are quiescent |
 | `hm/settle!` | waits for quiescence after outside stimulation — a user-event pointer or keyboard sequence |
-| `hm/advance-clock!` | moves this mount's virtual clock forward by `ms` and runs everything that falls due on the way, with `setTimeout`, `setInterval` and `Date.now` moving in lockstep; needs `{:clock true}` on the `mount!` or `hydrate!` that made the handle, and throws without it |
+| `hm/advance-clock!` | moves this mount's virtual clock forward by `ms` and runs due work; needs `{:clock true}` on the `mount!` or `hydrate!` that made the handle; throws without it |
 | `hm/unmount!` | tears the root down |
-| `hm/assert-clean!` | after unmount: compares exact post-quiescence residue with the pre-mount baseline, reports, then resets; answers a promise of the report |
+| `hm/assert-clean!` | after unmount: compares post-quiescence residue with the pre-mount baseline, reports, then resets; answers a promise of the report |
 
 ```clojure
 (ns todo.views-mounted-test
@@ -236,85 +227,76 @@ and a residue guarantee:
       (-> (hm/unmount! m) (hm/assert-clean!) (.then done)))))
 ```
 
-Every door takes the handle first and answers it, so a whole teardown threads
-in one expression. The test is `async` because the verdict is: `assert-clean!`
-waits for the runtime's own quiescence before it reads, and a synchronous
-`deftest` would finish before the report arrived.
+Every door takes the handle first and returns it, so teardown threads in one
+expression. The test is `async` because `assert-clean!` waits for the
+runtime's own quiescence before it reads.
 
-The facade brings no selector language of its own, because that job already
-has an owner. `(:container m)` is a real DOM node, so Testing Library
-queries and user-event sequences work unchanged. After a user-event
-sequence, call `(hm/settle! m)` before you assert.
+The facade brings no selector language. `(:container m)` is a real DOM node,
+so Testing Library queries and user-event sequences work unchanged. After a
+user-event sequence, call `(hm/settle! m)` before you assert.
 
 !!! note "Settled, not `act`"
 
-    `dispatch-and-settle!` flushes; it does not divert through React's
-    `act`. `act` queues React's work on a scheduler that is not the
-    browser's. That is correct for an effect-ordering test, and wrong when
-    the assertion reads the page. After the call returns, the next line sees
-    the DOM that the user would have seen.
+    `dispatch-and-settle!` flushes; it does not divert through React's `act`.
+    `act` queues React's work on a scheduler that is not the browser's. That
+    is correct for an effect-ordering test, and wrong when the assertion reads
+    the page. After the call returns, the next line sees the DOM the user
+    would have seen.
 
-!!! note "The clock moves three things, and deliberately not the rest"
+!!! note "What the clock moves"
 
-    `Date.now` moves with the two timer functions because retention is a
-    deadline *comparison*, not a callback: a fake timer whose callback reads
-    an unmoved `Date.now` fires exactly on schedule and then decides nothing
-    has expired — green for the reason the test was written to rule out.
+    `Date.now` moves with `setTimeout` and `setInterval` because retention is
+    a deadline comparison, not a callback: a fake timer whose callback reads
+    an unmoved `Date.now` fires on schedule and then decides nothing has
+    expired.
 
-    It does not move `requestAnimationFrame`, because a frame is a paint
-    rather than a duration; rAF stays on the platform's own schedule, where
-    it still fires. It does not move microtasks, and therefore not promises:
-    a microtask queue cannot be drained from inside a task, so a `.then`
-    still lands after the door returns rather than inside it. It leaves
-    `performance.now` alone, because React's scheduler reads it to decide
-    whether it has budget left in the frame. It does not touch the `Date`
-    constructor, which reads the system clock rather than `Date.now`. And it
-    cannot reach a `setTimeout` somebody captured before the window opened —
-    React's own scheduler being the deliberate exception, keeping the
-    reference it took at module load, so that a flush is still a flush.
+    It does not move `requestAnimationFrame` (a paint, not a duration). It
+    does not move microtasks or promises. It leaves `performance.now` alone
+    (React's scheduler reads it for frame budget). It does not touch the
+    `Date` constructor. It cannot reach a `setTimeout` captured before the
+    window opened — React's own scheduler keeps the reference it took at
+    module load so a flush is still a flush.
 
-    It does not replace `settle!`. The due callbacks run inside the same
-    `flushSync` that `settle!` performs empty, so `advance-clock!` is
-    `settle!` for the work that had a delay on it.
+    `advance-clock!` is `settle!` for work that had a delay on it.
 
 Use L3 when the claim needs it:
 
-- a real [error boundary](glossary.md#error-boundary) that catches a real throw ([Errors](16-errors.md));
-- StrictMode double-invoke, and renders that React abandoned;
-- keyed insert, delete, and reorder against real nodes;
-- a foreign component's hooks, context, or refs ([Interop](09-interop.md));
-- Activity hide and reveal, which releases and re-establishes
-  subscriptions.
+- a real [error boundary](glossary.md#error-boundary) that catches a real
+  throw ([Errors](16-errors.md))
+- StrictMode double-invoke, and renders React abandoned
+- keyed insert, delete, and reorder against real nodes
+- a foreign component's hooks, context, or refs ([Interop](09-interop.md))
+- Activity hide and reveal, which releases and re-establishes subscriptions
 
-The residue rule: **teardown residue is zero.** `assert-clean!` compares
-what remains after quiescence with what existed before the mount. A
-surviving subscription handle, listener, or scheduled task fails the test.
-That failure is a bug to fix — often a foreign host retains a callback. It
-is never a tolerance to raise.
+**Teardown residue is zero.** `assert-clean!` compares what remains after
+quiescence with what existed before the mount. A surviving subscription
+handle, listener, or scheduled task fails the test. That failure is a bug —
+often a foreign host retaining a callback — not a tolerance to raise.
 
 ## L4 — real browsers
 
 Some facts exist only inside a browser engine: IME composition, caret and
 selection movement, focus traversal, layout and scroll geometry, hydration
-against real server bytes, and the performance budgets. For those facts, the
-witness is Chromium, Firefox, and WebKit. No simulation stands in.
-Controlled-input behaviour under composition is the canonical case
-([Controlled inputs](04-controlled-inputs.md)). Budgets and their
-measurement discipline live in [Performance](18-performance.md).
+against real server bytes, and performance budgets. For those, the witness is
+Chromium, Firefox, and WebKit. No simulation stands in. Controlled-input
+behaviour under composition is the canonical case
+([Controlled inputs](04-controlled-inputs.md)). Budgets live in
+[Performance](18-performance.md).
 
 One more entry completes the kit: `ht/shadow!`, the migration harness. It is
-a dev-only dual mount. It drives a ported view and its Reagent original with
-one script, and it diffs [canonical DOM](glossary.md#canonical-dom) and [intent](glossary.md#intent) streams at every
-checkpoint. [Migrating from Reagent](19-migration-from-reagent.md) owns it.
+a dev-only dual mount that drives a ported view and its Reagent original with
+one script and diffs [canonical DOM](glossary.md#canonical-dom) and intent
+streams at every checkpoint.
+[Migrating from Reagent](19-migration-from-reagent.md) owns it.
 
 ## The sabotage twin
 
-An assertion that quantifies over a collection can pass because the
-collection was empty by accident — `every?` over nothing is vacuously true.
-Two habits close that hole. First, pin the population with a count. Second,
-give an important test a **[sabotage twin](glossary.md#sabotage-control)**: break the input deliberately and
-confirm that the measurement moves. A moved measurement proves the
-instrument can fail.
+An assertion that quantifies over a collection can pass because the collection
+was empty by accident — `every?` over nothing is vacuously true. Two habits
+close that hole. First, pin the population with a count. Second, give an
+important test a **[sabotage twin](glossary.md#sabotage-control)**: break the
+input on purpose and confirm that the measurement moves. A moved measurement
+proves the instrument can fail.
 
 ```clojure
 ;; in todo.views
@@ -338,51 +320,45 @@ instrument can fail.
     (is (empty? (:children tree)))))
 ```
 
-The list view's own claim is that it calls one row per visible id, with the
-right props — which is what these assert. What a row then renders is the row's
-claim, proved by rendering the row's own form, as the L2 example above does.
-
-The kit's own release gates carry the same discipline: every important
-witness has a negative or [sabotage control](glossary.md#sabotage-control). A test that cannot fail
-verifies nothing.
+The list view's claim is that it calls one row per visible id with the right
+props. What a row then renders is the row's claim, proved by rendering the
+row's own form.
 
 ## Troubleshooting
 
-| Symptom | What went wrong | Fix |
-|---|---|---|
-| `ht/tree` refuses, pointing at L3 | The body reaches a hook, raw React element, [`n/$`](glossary.md#n-dollar) result, or [`defhost`](glossary.md#defhost) crossing | Honest opacity, working as designed. Mount that view at L3; if you want L2 coverage for the rest, split the hook-free part into its own view or helper |
-| `ht/tree` refuses, naming a query | A read the body made has no fixture | Add it. Fixture identity is `(query-id, args)` under value equality — the args must match exactly |
-| `ht/tree` refuses a [`defview`](glossary.md#defview) head, pointing at L3 | An `:advanced` build with `goog.DEBUG` false: the mint carries the body on the head under a dev-only property, and that property was compiled away | Run view tests in a dev build, or pass the body function instead of the minted head |
-| `:rf.error/hicasso-sub-outside-render` in a plain test | A reading helper was called with no render extent (a direct [`defview`](glossary.md#defview) call refuses at the call itself, naming the view) | L2 supplies the extent; L0 targets handlers and subs, not bodies |
-| `:rf.error/hicasso-deferred-read-at-boundary` | A stored closure, stashed lazy seq, or unforced `delay` carried a read past the render | Read during the body and close over the value ([Views and reads](02-views-and-reads.md)) |
-| `assert-clean!` fails after unmount | Something outlived the root — a retained subscription, listener, or scheduled task | A bug, not a tolerance: fix the leak. A foreign host retaining a callback is the common culprit ([Interop](09-interop.md)) |
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `ht/tree` raises, pointing at L3 | Body reaches a hook, raw React element, `n/$` result, or `defhost` crossing | Mount that view at L3; split the hook-free part if you want L2 coverage for the rest |
+| `ht/tree` raises, naming a query | A read the body made has no fixture | Add it. Fixture identity is `(query-id, args)` under value equality |
+| `ht/tree` raises a `defview` head, pointing at L3 | An `:advanced` build with `goog.DEBUG` false compiled away the body property on the head | Run view tests in a dev build, or pass the body function instead of the `defview` head |
+| `:rf.error/hicasso-sub-outside-render` in a plain test | A reading helper was called with no render context | L2 supplies the context; L0 targets handlers and subs, not bodies |
+| `:rf.error/hicasso-deferred-read-at-boundary` | A stored closure, lazy seq, or unforced `delay` carried a read past the render | Read during the body and close over the value ([Views and reads](02-views-and-reads.md)) |
+| `assert-clean!` fails after unmount | Something outlived the root — retained subscription, listener, or scheduled task | Fix the leak. A foreign host retaining a callback is the common culprit ([Interop](09-interop.md)) |
 | Data-level test passes, mounted test fails | Real React does things data does not — effect order, StrictMode double-invoke, commit timing | The mounted result is the truth for lifecycle |
 | Assertion fails on a `nil` in a tree | A `when` produced `nil` — it renders nothing but is still in the data | Assert the `nil`, or filter before comparing |
-| A list test stays green with an empty list | Quantified assertion over an empty population | Pin the count; add the [sabotage twin](glossary.md#sabotage-control) |
+| A list test stays green with an empty list | Quantified assertion over an empty population | Pin the count; add the sabotage twin |
 
 ## When not to test through the view
 
-If the assertion is about *state*, test the handler. If the assertion is
-about *derived values*, test the subscription. A view test that dispatches
-an event and then asserts on app-db tests three things at once. It will fail
-for reasons that have no relation to the view.
+If the assertion is about *state*, test the handler. If the assertion is about
+*derived values*, test the subscription. A view test that dispatches an event
+and then asserts on app-db tests three things at once, and fails for reasons
+unrelated to the view.
 
 Keep each rung's claim inside its rung. L2 never claims React lifecycle
-parity: abandoned renders, effect ordering, and commit timing are L3's job.
-A semantic tree never claims hydration-wire parity: server-byte and adoption
-claims live in [SSR and hydration](17-ssr-and-hydration.md). Timing claims
-are not tests until they follow the measurement discipline in
+parity. A semantic tree never claims hydration-wire parity
+([SSR and hydration](17-ssr-and-hydration.md)). Timing claims are not tests
+until they follow the measurement discipline in
 [Performance](18-performance.md).
 
 ## Advanced
 
 ### Every witness names its equality
 
-When a test's name or docstring states what the test proves, use these
-terms:
+When a test's name or docstring states what the test proves, use these terms:
 
 | Equality | Rung | The claim |
-|---|---|---|
+| --- | --- | --- |
 | Authored data | L1 | the function returned this value |
 | Semantic tree | L2 | the body, under these reads, means this |
 | Intent stream | L2/L3 | these events, in this order, were the interactions |
@@ -390,18 +366,16 @@ terms:
 | React server bytes | server tests | the server emitted exactly these bytes |
 | Hydrated behaviour | L4 | the adopted page behaves in a real engine |
 
-No row substitutes for another. The most tempting substitution is the
-semantic tree in place of mounted truth. The harness's refusals exist to
-prevent exactly that substitution.
+No row substitutes for another. The most tempting substitution is the semantic
+tree in place of mounted truth. The harness's refusals exist to prevent that.
 
 ### Canonical DOM
 
 `ht/canonical-dom` serializes a live node's subtree with every element's
-attribute names sorted. `innerHTML` preserves insertion order, and two
-front ends write props in different orders — a comparison of `innerHTML`
-compares the serializer, not the page. A comparison of the sorted output
-compares the DOM. Use `ht/canonical-dom` whenever the claim is "these two
-mounts built the same page": before and after a refactor, a [Hicasso](glossary.md#hicasso) view
+attribute names sorted. `innerHTML` preserves insertion order, and two front
+ends write props in different orders — a comparison of `innerHTML` compares
+the serializer, not the page. Use `ht/canonical-dom` when the claim is "these
+two mounts built the same page": before and after a refactor, a Hicasso view
 against its Reagent original during migration
 ([Migration](19-migration-from-reagent.md)), or an island against its
-pre-extraction [boundary](glossary.md#boundary) ([Native tier](10-native-tier.md)).
+pre-extraction boundary ([Native tier](10-native-tier.md)).

--- a/docs/design/hicasso/draft-guide/15-diagnostics.md
+++ b/docs/design/hicasso/draft-guide/15-diagnostics.md
@@ -1,162 +1,140 @@
 # Diagnostics
 
-A list re-rendered and you do not know why. A keystroke feels slow and you
-do not know where the time went. Xray is the development-time instrument for
-those questions. It loads with your dev build as a preload, mounts beside
-the app, and observes the same trace the runtime already emits. Nothing in
-your views changes to support it, and none of it ships to production.
+A list re-rendered and you do not know why. A keystroke feels slow and you do
+not know where the time went. Xray is the development-time instrument for
+those questions. It loads with your dev build as a preload, mounts beside the
+app, and observes the same trace the runtime already emits. Nothing in your
+views changes to support it, and none of it ships to production.
 
-> **A labeled gap is an answer. An empty panel would be a lie.**
+## How to diagnose
 
-**How you use it.** Load Xray with your dev preload so it mounts beside the
-app. Reproduce the slow click or unexpected re-render. Select the
-[boundary](glossary.md#boundary) that ran, and read its cause and fan-out.
-The rest of this page is what those panels mean.
+1. **Load Xray** with your dev preload so it mounts beside the app.
+2. **Reproduce** the slow click or unexpected re-render.
+3. **Select the boundary** that ran — the independently re-rendering view
+   ([Views and reads](02-views-and-reads.md)).
+4. **Read its cause and fan-out.**
+
+That is the whole operational path. The rest of this page explains what those
+panels mean and what to do with the answer.
 
 An *epoch* is one pipeline run: one dispatched event carried through to its
-commit. The epoch is the unit that Xray organises evidence around.
+commit. Xray organises evidence around epochs.
 
-## The causal lens
+## Read the cause
 
-Every diagnosis follows the [causal lens](glossary.md#causal-lens):
+Select a boundary occurrence and ask: *why did this view run?*
 
-```
-event -> subscriptions recomputed -> values changed -> boundaries notified
-      -> bodies run -> React commit -> paint
-```
+Typical answers:
 
-Each link has its own evidence source. Xray does not merge timing on one link
-with cause on another. Timing proximity proves nothing. A body that ran near
-an event may have run for a different reason. A render measure may be a retry,
-a StrictMode duplicate, or work that React abandoned before commit. Xray
-correlates links only when its instruments support the correlation. When they
-do not, Xray labels the link honestly instead of guessing.
+| Cause | Meaning | What you usually do |
+| --- | --- | --- |
+| Own reads moved (queries named) | A subscription this view used changed | Check whether the read should live lower, or whether the sub is coarser than needed |
+| Props changed | Parent passed different props | Check keys, identity of props maps, and whether the parent re-rendered too high |
+| Context changed | A React context this view consumes changed | Trace the provider; vendor themes often land here |
+| Host forced it | A host boundary forced a child | Check the host's props and whether the force is required |
+| Retry / abandoned attempt | React retried or abandoned work | Not always a bug — StrictMode doubles in development |
+
+When several boundaries ran for one event, **fan-out** tells you which case you
+have. One changed subscription that reaches many readers is a topology problem.
+Many independent causes are ordinary work.
 
 **Render is not commit, and commit is not paint.** Bodies run speculatively.
 React owns commit. The browser owns paint. Xray tells you which claim each
-number makes.
+number makes. Timing proximity alone proves nothing: a body that ran near an
+event may have run for a different reason.
 
-## Explain-render
+The chain Xray follows:
 
-Select a [boundary](glossary.md#boundary) occurrence and ask the first question that matters: *why
-did this view run?* The answer is data, in the same shape that the whole
-evidence surface uses:
-
-```clojure
-{:view         todo.views/todo-row
- :frame        :app/main
- :cause        {:kind          :reads
-                :changed-reads [[:todo/by-id 7]]}
- :attempt      :committed          ;; not a retry, not abandoned
- :reads        [[:todo/by-id 7]]   ;; the current read set, from execution
- :fan-out      1                   ;; boundaries this change reached
- :completeness :complete
- :loss         nil}
+```
+event → subscriptions recomputed → values changed → boundaries notified
+     → bodies run → React commit → paint
 ```
 
-The `:cause` kinds are the honest taxonomy of question 3. The possible
-causes: the boundary's own reads moved (with the changed queries named);
-its props changed; a context it consumes changed; a host boundary forced
-it; or React retried or abandoned an attempt. When several [boundaries](glossary.md#boundary) ran
-for one event, fan-out tells you which case you have. One changed
-subscription that reaches many readers is a topology problem. Many
-independent causes are ordinary work.
-
-Every envelope on this surface also states its schema, producer, operation,
-scope, and basis. A consumer — the panel, a test, an AI pair — then knows
-exactly what it holds and which generation of the contract produced it.
+Xray correlates links only when its instruments support the correlation. When
+they do not, it labels the link instead of guessing.
 
 ## Read attribution
 
-The complementary standing view is the map from subscriptions to the
-[boundaries](glossary.md#boundary) that currently read them: who depends on what, right now. Four
-numbers on this view do most of the diagnostic work:
+The standing view is the map from subscriptions to the boundaries that currently
+read them. Four numbers do most of the diagnostic work:
 
 | Number | What it tells you |
-|---|---|
+| --- | --- |
 | Boundary count | how many independent re-render units are mounted |
 | Reads per boundary | fine, coarse, or accidentally enormous read sets |
 | Fan-out per subscription | how many boundaries one change will reach |
 | Read-set churn | how often a boundary's read set changes membership |
 
-Two shapes deserve attention. One subscription that fans out to hundreds of
-boundaries usually means a read that lives too high, or a shared value that
-deserves a deliberate topology choice. A boundary whose read set churns
-every render pays a whole-set refresh each time, because the edge set is a
-function of what the body did. The remedies — reads at the point of use,
-boundary placement, fine versus coarse versus chunked reads — are owned by
-[Views and reads](02-views-and-reads.md) and
-[Lists and collections](06-lists-and-collections.md). Xray's job is to make
-the topology observable instead of guessed.
+Two shapes deserve attention:
+
+- One subscription that fans out to hundreds of boundaries usually means a
+  read that lives too high, or a shared value that needs a deliberate
+  topology choice.
+- A boundary whose read set churns every render pays a whole-set refresh each
+  time, because the edge set is a function of what the body did.
+
+Remedies — reads at the point of use, boundary placement, fine versus coarse
+versus chunked reads — live in [Views and reads](02-views-and-reads.md) and
+[Lists and collections](06-lists-and-collections.md). Xray makes the topology
+visible.
 
 ## The hot-view advisor
 
-The advisor is the part of Xray that turns evidence into a recommendation.
-It ranks [boundaries](glossary.md#boundary) by time, frequency, read churn, and fan-out. Then it
-does the step that matters: it **classifies the pressure** before it names
-a remedy.
+The advisor ranks boundaries by time, frequency, read churn, and fan-out, then
+**classifies the pressure** before it names a remedy:
 
-| Pressure | The time is going to | Smallest credible remedy |
-|---|---|---|
-| Computation | your own code — the body's work or an expensive sub chain | fix the computation; derive it in the subscription layer, where it is a pure function you can test |
-| Topology | too many boundaries invalidated, or churning read sets | move reads, split or merge boundaries, coarse or chunked or windowed reads ([Lists and collections](06-lists-and-collections.md)) |
+| Pressure | Time is going to | Smallest credible remedy |
+| --- | --- | --- |
+| Computation | your own code — the body's work or an expensive sub chain | fix the computation; derive it in the subscription layer |
+| Topology | too many boundaries invalidated, or churning read sets | move reads, split or merge boundaries, coarse / chunked / windowed reads ([Lists and collections](06-lists-and-collections.md)) |
 | Lowering | turning one hot boundary's Hiccup into React elements | a direct [`n/$`](glossary.md#n-dollar) return from that same boundary ([Native tier](10-native-tier.md)) |
 | React | reconciliation, hooks, vendor component internals | a named [native island](glossary.md#native-island) — [`n/defcomponent`](glossary.md#ndefcomponent) or UIx ([Native tier](10-native-tier.md)) |
 | Layout | the browser — style, layout, paint | shrink the DOM, virtualize, fix the CSS; browser tools own this ground |
 
-The advisor never breaks one rule: **it recommends a native escape only
-when the measured owner is a class that native addresses.** If [lowering](glossary.md#lowering) is
-four percent of a slow interaction, extraction cannot buy more than four
-percent. The advisor says so, and points at the real owner instead. There
-is no automatic promotion. The advisor recommends; you decide. An escape
-you take must meet the thresholds in [Performance](18-performance.md), or
-it comes back out.
+The advisor recommends a native escape only when the measured owner is a class
+that native addresses. If lowering is four percent of a slow interaction,
+extraction cannot buy more than four percent. The advisor says so and points
+at the real owner. There is no automatic promotion — the advisor recommends,
+you decide. An escape you take must meet the thresholds in
+[Performance](18-performance.md), or it comes back out.
 
-## Honest loss labels
+## When evidence is incomplete
 
-An interpreted runtime cannot know some facts. Xray reports that limit as
-an answer; it does not present an empty panel. Unknown is never encoded as
-an empty collection.
+An interpreted runtime cannot know some facts. Xray reports that limit as an
+answer; it does not present an empty panel. Unknown is never encoded as an
+empty collection.
 
-| Label | It means | What you do |
-|---|---|---|
+| Label | Meaning | What you do |
+| --- | --- | --- |
 | `:unknown` | no instrument covers this link | ask a question the instruments answer; if the claim matters, make it a test |
-| `:opaque` / `:no-static-analysis` | an interpreted body's facts cannot be enumerated ahead of execution | run the interaction — current reads come from actual execution, not prediction |
+| `:opaque` / `:no-static-analysis` | an interpreted body's facts cannot be enumerated ahead of execution | run the interaction — current reads come from actual execution |
 | `:host-opaque` | raw React internals past a host or native crossing | Xray still names and times the crossing; React DevTools owns the inner tree |
-| `:cap` | the bounded retention window has dropped older history | reproduce and capture fresh; retention is deliberately bounded |
-| `:uncorrelated` | the event-to-render relationship could not be established | treat it as honest absence; reproduce with a scripted interaction so the links line up |
-
-A dashboard that filled those cells with zeros would be easier to read and
-worse to trust. The label tells you which tool to use next.
+| `:cap` | the bounded retention window has dropped older history | reproduce and capture fresh |
+| `:uncorrelated` | the event-to-render relationship could not be established | treat as honest absence; reproduce with a scripted interaction so the links line up |
 
 ## The complaint catalogue
 
 Every refusal in this guide carries a stable id: `:rf.error/*` for errors,
-`:rf.warning/*` for recoverable misuse. Every id is an entry in the
-[complaint catalogue](glossary.md#complaint-catalogue) — a docs anchor that states what fired, why it fired,
-and the concrete recovery. A complaint is structured data end to end. When
-thrown, it carries its id in `ex-data` under `:rf.error/id`. On the trace,
-it is a record with the id as its category and the recovery the runtime
-took. In Xray, it renders with jump-to-source for both the registration
-site and the call site.
+`:rf.warning/*` for recoverable misuse. When thrown, the id is in `ex-data`
+under `:rf.error/id`. On the trace it is a record with the id as category and
+the recovery the runtime took. In Xray it renders with jump-to-source for the
+registration site and the call site.
 
 A sample of entries from earlier chapters:
 
 | Id | Complaint | Recovery |
-|---|---|---|
-| `:rf.error/hicasso-sub-outside-render` | a read escaped every render extent | read during the body; in a handler, declare the fact as a coeffect ([Views and reads](02-views-and-reads.md)) |
-| `:rf.error/hicasso-deferred-read-at-boundary` | an unforced `delay` carrying a read tried to cross a [boundary](glossary.md#boundary) | force it in the body; close over the value ([Views and reads](02-views-and-reads.md)) |
-| `:rf.error/hicasso-bad-head` | a plain `defn` in head position | mint it with [`h/defview`](glossary.md#defview), or call it inline ([Views and reads](02-views-and-reads.md)) |
+| --- | --- | --- |
+| `:rf.error/hicasso-sub-outside-render` | a read escaped every render context | read during the body; in a handler, declare the fact as a coeffect ([Views and reads](02-views-and-reads.md)) |
+| `:rf.error/hicasso-deferred-read-at-boundary` | an unforced `delay` carrying a read tried to leave the view | force it in the body; close over the value ([Views and reads](02-views-and-reads.md)) |
+| `:rf.error/hicasso-bad-head` | a plain `defn` in head position | define it with [`h/defview`](glossary.md#defview), or call it inline ([Views and reads](02-views-and-reads.md)) |
 | `:rf.error/hicasso-intent-outside-boundary` | an [intent](glossary.md#intent) vector reached a position with no boundary frame | dispatch belongs inside a boundary; at a foreign edge, use [`h/event`](glossary.md#hevent) ([Events as data](03-events-as-data.md)) |
-| `:rf.error/hicasso-host-unclaimed-callback` | an [`h/event`](glossary.md#hevent) arrived at a host prop that no callback contract claims — one nothing claims, or a declared [ReactNode slot](glossary.md#reactnode-slot), which takes markup | declare the prop in `:callbacks`; at a slot, write markup ([Interop](09-interop.md)) |
+| `:rf.error/hicasso-host-unclaimed-callback` | an [`h/event`](glossary.md#hevent) arrived at a host prop that no callback contract claims | declare the prop in `:callbacks`; at a ReactNode slot, write markup ([Interop](09-interop.md)) |
 | `:rf.error/hicasso-revision-not-controlled` | [`::h/revision`](glossary.md#hrevision) on a field that is not controlled | control the field, or drop the revision ([Controlled inputs](04-controlled-inputs.md)) |
 | `:rf.warning/hicasso-missing-key` | a seq of boundary children without `:key` | put `:key` in each child's props map ([Lists and collections](06-lists-and-collections.md)) |
-| `:rf.error/frame-destroyed` | an operation minted against a destroyed frame incarnation fired after its successor seated | drop the stale handle; capture from the live frame ([Events as data](03-events-as-data.md)) |
+| `:rf.error/frame-destroyed` | an operation captured against a destroyed frame incarnation fired after its successor seated | drop the stale handle; capture from the live frame ([Events as data](03-events-as-data.md)) |
 
-Two habits make the catalogue useful. When a complaint surprises you,
-follow its anchor before you change code; the recovery column is usually
-shorter than the debugging session. When you test a refusal, assert the id,
-never the message:
+When a complaint surprises you, follow its recovery before you change code.
+When you test a refusal, assert the id, never the message:
 
 ```clojure
 ;; ht is the test kit from 14-testing.md
@@ -172,34 +150,25 @@ never the message:
          (refusal-id #(ht/tree [card {}] {:subs {}})))))
 ```
 
-Message text improves between releases; ids are frozen. A string assertion
-tests the message text, not the refusal.
+Message text improves between releases; ids are frozen.
 
-**The head that refuses is a child's.** `ht/tree`'s root form is headed by
-the body function the kit is about to run, so `[badge {}]` written as the
-root form is the accepted spelling — it runs, and nothing refuses. Only a
-plain `defn` reached *inside* the tree is a mistake, and which id you catch
-tells you which layer caught it: at L2 the kit answers with its own
-`:rf.error/hicasso-test-plain-fn-head`, and the same child mounted at L3 is
-the runtime's `:rf.error/hicasso-bad-head` from the table above.
+`ht/tree`'s root form is headed by the body function the kit is about to run,
+so `[badge {}]` written as the root form is accepted — it runs, and nothing
+raises. Only a plain `defn` reached *inside* the tree is a mistake. At L2 the
+kit answers with `:rf.error/hicasso-test-plain-fn-head`; the same child mounted
+at L3 raises the runtime's `:rf.error/hicasso-bad-head`.
 
 ## Production erasure
 
-[Production erasure](glossary.md#production-erasure) means diagnostics are
-absent from default production bundles.
-
 Everything on this page is development tooling, and all of it erases from a
 release build: the evidence producer, the projections, the advisor, the
-dev-only checks, and their message strings. Production evidence queries
-return nil. A release bundle contains no evidence machinery, no schema
-sentinels, and no source-location tables. Performance collection is gated
-separately by its own compile-time flag and is off by default. A shipped
-build carries no timing instrumentation.
+dev-only checks, and their message strings. Production evidence queries return
+nil. A release bundle contains no evidence machinery, no schema sentinels, and
+no source-location tables. Performance collection is gated separately by its
+own compile-time flag and is off by default.
 
-Do not accept this claim without a check. The check is two builds and one
-search. Pick a sentinel that you can see in the dev bundle (`rf.xray`, the
-evidence machinery's own namespace prefix, is a good default). Search both
-builds for it:
+Do not accept erasure without a check. Pick a sentinel you can see in the dev
+bundle (`rf.xray` is a good default). Search both builds:
 
 ```bash
 npx shadow-cljs compile app            # dev build
@@ -209,70 +178,84 @@ npx shadow-cljs release app            # release build, same output path
 grep -c "rf.xray" public/js/main.js    # expect 0
 ```
 
-The dev-build search is the positive control, and it is not optional. A
-zero on the release bundle means "erased" only if the same search finds the
-sentinel in the dev bundle. Zero in both places means your search is
-broken, not your build. This is the sabotage-twin habit from
-[Testing](14-testing.md), applied to the bundle. The product's own release
-gate runs the same discipline, with unique sentinels on every dev-only
-surface.
+The dev-build search is the positive control. Zero on the release bundle means
+"erased" only if the same search finds the sentinel in the dev bundle. Zero in
+both places means the search is broken, not the build. This is the
+sabotage-twin habit from [Testing](14-testing.md) applied to the bundle.
 
-The surface erases, so application logic must never depend on it: no
-feature may read evidence, count complaints, or branch on a panel's data.
+Application logic must never depend on the surface: no feature may read
+evidence, count complaints, or branch on a panel's data.
 
 ## Troubleshooting
 
-| Symptom | What went wrong | Fix |
-|---|---|---|
-| A view you know ran is absent from the epoch | Its [boundary](glossary.md#boundary) bailed out — a skipped body emits nothing | Absence is the measurement of work not done; if you expected it to run, [explain-render](glossary.md#explain-render) the parent that did |
-| Explain-render answers `:uncorrelated` | The event-to-render link could not be established for that occurrence | An honest answer, not a failure; reproduce with a scripted interaction and read the fresh epoch |
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| A view you know ran is absent from the epoch | Its boundary bailed out — a skipped body emits nothing | Absence measures work not done; if you expected it to run, explain-render the parent that did |
+| Explain-render answers `:uncorrelated` | Event-to-render link could not be established for that occurrence | Honest answer, not a failure; reproduce with a scripted interaction and read the fresh epoch |
 | A foreign subtree shows `:host-opaque` | Raw React internals are not enumerable past the crossing | Xray still names and times the crossing; open React DevTools for the inside |
-| History stops with `:cap` | The bounded retention window dropped older epochs | Reproduce and capture fresh; retention does not grow to fit the question |
-| The advisor refuses to recommend an island you want | The measured owner is not a class native addresses | Do the smaller remedy it named; re-measure; the ladder is in [Performance](18-performance.md) |
-| Two runs of one interaction show different times | Xray timing is attribution, not a benchmark | Treat the classification, not the number, as the finding; benchmark under the discipline in [Performance](18-performance.md) |
-| A complaint id you hit has no catalogue anchor | The id is not from this product's surface, or your app and kit versions have drifted | Check the id's namespace and align versions; every shipped id resolves |
-| Panels are empty in a release build | Production erasure, working as designed | Diagnose on a dev build; production carries no evidence |
+| History stops with `:cap` | Bounded retention window dropped older epochs | Reproduce and capture fresh |
+| Advisor will not recommend an island you want | Measured owner is not a class native addresses | Do the smaller remedy it named; re-measure ([Performance](18-performance.md)) |
+| Two runs of one interaction show different times | Xray timing is attribution, not a benchmark | Treat the classification, not the number, as the finding; benchmark under [Performance](18-performance.md) |
+| A complaint id you hit has no catalogue anchor | Id is not from this product's surface, or app and kit versions have drifted | Check the id's namespace and align versions |
+| Panels are empty in a release build | Production erasure, working as designed | Diagnose on a dev build |
 
 ## When Xray is not the tool
 
-**Xray timing is not a benchmark.** It attributes: it tells you which link
-of the chain owns the time, and which remedy class is credible. It does not
-settle "is this fast enough" — budgets and measurement discipline live in
-[Performance](18-performance.md). Its render numbers are not commit
-evidence. React DevTools remains the authority for commits. The browser's
-performance tooling remains the authority for layout and paint. When an
-interaction is slow in a release build, profile the release build with
+**Xray timing is not a benchmark.** It attributes: which link of the chain owns
+the time, and which remedy class is credible. It does not settle "is this fast
+enough" — budgets live in [Performance](18-performance.md). Its render numbers
+are not commit evidence. React DevTools remains the authority for commits. The
+browser's performance tooling remains the authority for layout and paint. When
+an interaction is slow in a release build, profile the release build with
 browser tools; the dev build carries dev-only work by design.
 
 When the question is about *correctness* rather than cause — does this body
-mean what it should, does teardown leak — the answer is a test, not a
-panel: [Testing](14-testing.md).
+mean what it should, does teardown leak — the answer is a test, not a panel
+([Testing](14-testing.md)).
 
 ## Advanced
 
+### Explain-render envelope shape
+
+The panel, tests, and the AI pair consume the same envelope. A complete example:
+
+```clojure
+{:view         todo.views/todo-row
+ :frame        :app/main
+ :cause        {:kind          :reads
+                :changed-reads [[:todo/by-id 7]]}
+ :attempt      :committed          ;; not a retry, not abandoned
+ :reads        [[:todo/by-id 7]]   ;; current read set, from execution
+ :fan-out      1                   ;; boundaries this change reached
+ :completeness :complete
+ :loss         nil}
+```
+
+Every envelope also states its schema, producer, operation, scope, and basis so
+a consumer knows what it holds and which generation of the contract produced
+it. You do not need this map to use the panel — open Xray, select the boundary,
+read the cause. The shape matters when you script diagnosis or assert on it.
+
 ### The same projection feeds the AI pair
 
-Xray and the AI pair consume one versioned, privacy-projected evidence
-schema: byte-equivalent projections, one contract. Query arguments pass
-through the privacy projector. Raw values and text are omitted by default.
-Nothing leaves the process unless an explicitly authorized consumer
-requests it. If you script your own diagnosis through the pair, you read
-exactly what the panel reads, including the [loss labels](glossary.md#loss-labels).
+Xray and the AI pair consume one versioned, privacy-projected evidence schema:
+byte-equivalent projections, one contract. Query arguments pass through the
+privacy projector. Raw values and text are omitted by default. Nothing leaves
+the process unless an authorized consumer requests it.
 
 ### Optional modules bring their own evidence
 
-Evidence follows installation. The forms module contributes draft
-ownership. Overlays contribute the active top-layer region. Motion
-contributes the current transition posture. Resources contribute the live
-demand. Each is a bounded projection that exists only while the module is
-installed and in use. None of them adds a standing accumulator to ordinary
-[Hicasso](glossary.md#hicasso). An app that uses none of them pays for none of this.
+Evidence follows installation. The forms module contributes draft ownership.
+Overlays contribute the active top-layer region. Motion contributes the current
+transition posture. Resources contribute the live demand. Each is a bounded
+projection that exists only while the module is installed and in use. An app
+that uses none of them pays for none of this.
 
 ### Retention is bounded on purpose
 
-Xray owns its history budget. The trace ring is the record, and a named
-operation (mount/unmount correlation, for example) may keep bounded,
-commit-owned identity. No universal occurrence ledger accumulates in the
-background. The `:cap` label is the visible edge of that choice. The cost
-is bounded history; the alternative is a runtime that slows down in
-proportion to how long you have debugged it.
+Xray owns its history budget. The trace ring is the record; a named operation
+(mount/unmount correlation, for example) may keep bounded, commit-owned
+identity. No universal occurrence ledger accumulates in the background. The
+`:cap` label is the visible edge of that choice. The cost is bounded history;
+the alternative is a runtime that slows down in proportion to how long you have
+debugged it.

--- a/docs/design/hicasso/draft-guide/16-errors.md
+++ b/docs/design/hicasso/draft-guide/16-errors.md
@@ -1,14 +1,14 @@
 # Errors
 
 A view body throws: `nil` where a map was expected, a key that moved, a shape
-that last week's code cannot handle. React's default answer is not a red box
-around the broken component. React unmounts the entire root, and the user
-gets a blank page.
-
-> **React unmounts the root, so you fence regions and keep expected failures
-> out of the exception channel.**
+that last week's code cannot handle. React's default is not a red box around
+the broken component. React unmounts the entire root, and the user gets a
+blank page.
 
 ```clojure
+(ns app.articles
+  (:require [re-frame.hicasso :as h]))
+
 (h/defview article-page [{:keys [id]}]
   [:main
    [site-header {}]
@@ -17,50 +17,54 @@ gets a blank page.
    [site-footer {}]])
 ```
 
-If `article-body` throws during render, the header and footer stay up, and
-the paragraph takes the article's place. Nothing else in the tree notices.
+If `article-body` throws during render, the header and footer stay up, and the
+paragraph takes the article's place. Nothing else in the tree notices.
 
-[`h/error-boundary`](glossary.md#error-boundary) is a component that you write into the tree. It is not the
-rendering [boundary](glossary.md#boundary) that a [`defview`](glossary.md#defview) mints
-([Views and reads](02-views-and-reads.md)). The word is the same, the thing
-is different — and only [`h/error-boundary`](glossary.md#error-boundary) catches.
+[`h/error-boundary`](glossary.md#error-boundary) is a component you write into
+the tree. It is not the re-render unit that a
+[`defview`](glossary.md#defview) creates
+([Views and reads](02-views-and-reads.md)). Only `h/error-boundary` catches.
 
 ## The three keys
 
-[`h/error-boundary`](glossary.md#error-boundary) takes exactly three props. There is no built-in
+`h/error-boundary` takes exactly three props. There is no built-in
 classification, retry policy, or logging. Those are your app's decisions, and
 you make them in `:on-error`.
 
 | Key | Shape | What it does |
-|---|---|---|
+| --- | --- | --- |
 | `:fallback` | hiccup, or `(fn [error] hiccup)` | renders instead of the children once something below has thrown |
 | `:reset-key` | any value, compared with `=` | changing it clears the caught failure and remounts the children |
 | `:on-error` | an event vector, or a plain function | fires once per caught failure |
 
-**`:fallback` can read the error.** Pass a function, and the function
-receives the thrown value. Show `(ex-message error)` in development and a
-plain sentence in production. The returned hiccup is lowered like any other,
-[intents](glossary.md#intent) included, under the frame where the region was mounted.
+**`:fallback` can read the error.** Pass a function, and the function receives
+the thrown value. Show `(ex-message error)` in development and a plain sentence
+in production. The returned hiccup is lowered like any other,
+[intents](glossary.md#intent) included, under the frame where the region was
+mounted.
 
 **`:reset-key` is how retry works.** The region never guesses. When the key
-changes, the region clears the caught failure and remounts the children — a
-fresh mount, not a re-render of the survivors. If the children throw again,
-the region catches again. A counter in app-db is the usual shape; the example
-below drives one.
+changes, it clears the caught failure and remounts the children — a fresh
+mount, not a re-render of the survivors. If the children throw again, the
+region catches again. A counter in app-db is the usual shape.
 
 **`:on-error` fires once per caught failure.** The region dispatches an event
 vector with the error appended — `[:diagnostics/record-failure]` reaches its
 handler as `[:diagnostics/record-failure error]` — in the region's frame. If
-you pass a plain function, the region calls the function with the error and
-dispatches nothing. Once means once, even under StrictMode: the throwing
-render can run twice in development, and React still reports a single catch.
+you pass a plain function, the region calls it with the error and dispatches
+nothing. Once means once, even under StrictMode: the throwing render can run
+twice in development, and React still reports a single catch.
 
 ## A nested region, with retry
 
 Regions nest, and the inner region wins. The nearest region above a throw
-catches the throw, and everything outside that region continues to render.
+catches it; everything outside that region continues to render.
 
 ```clojure
+(ns app.reports
+  (:require [re-frame.core :as rf]
+            [re-frame.hicasso :as h]))
+
 (rf/reg-sub :chart/attempt
   (fn [db _query] (:chart/attempt db)))
 
@@ -89,12 +93,13 @@ catches the throw, and everything outside that region continues to render.
 
 When `live-chart` throws, the inner region catches. The panel shows its
 fallback, `report-summary` and the header stay up, and the outer region never
-fires. The retry button is an ordinary [intent](glossary.md#intent). Its handler increments
-`:chart/attempt`, the `:reset-key` changes, and the chart remounts. If the
-bad data is still there, the region catches again, and the panel shows its
-fallback again. A throw in `report-summary`, which sits outside the inner
-region, lands in the outer region instead: the whole report body is replaced,
-and the header survives.
+fires. The retry button is an ordinary intent. Its handler increments
+`:chart/attempt`, the `:reset-key` changes, and the chart remounts. If the bad
+data is still there, the region catches again.
+
+A throw in `report-summary`, which sits outside the inner region, lands in the
+outer region instead: the whole report body is replaced, and the header
+survives.
 
 **A fallback that throws is caught by the next region up.** A fallback that
 re-reads the state that just failed can turn one broken panel into a broken
@@ -104,25 +109,23 @@ page. Keep fallbacks plain: static markup, a retry intent, nothing heavy.
 
 The region inherits React's rule exactly.
 
-**Caught:** a throw from render, and a throw from the lifecycle and effects
-of the tree below the region.
+**Caught:** a throw from render, and a throw from the lifecycle and effects of
+the tree below the region.
 
-**Not caught:** anything the browser calls outside render — an event handler,
-a `setTimeout`, a promise continuation. Those failures belong to re-frame2,
-not to the view layer. An [intent](glossary.md#intent)'s handler runs inside the event pipeline.
-The pipeline catches the throw, reports a structured error record
-(`:rf.error/handler-exception`, with the event, frame, and recovery
-attached), and the app continues to run. A raw `fn` callback that throws goes
-to the browser's error channel like any other JavaScript. Either way the
-region's fallback never shows. That is correct, because nothing below the
-region failed to *render*.
+**Not caught:** anything the browser calls outside render — an event handler, a
+`setTimeout`, a promise continuation. Those failures belong to re-frame2, not
+to the view layer. An intent's handler runs inside the event pipeline. The
+pipeline catches the throw, reports a structured error record
+(`:rf.error/handler-exception`, with the event, frame, and recovery attached),
+and the app continues to run. A raw `fn` callback that throws goes to the
+browser's error channel like any other JavaScript. Either way the region's
+fallback never shows — nothing below the region failed to *render*.
 
 ## Expected failures stay data
 
-One law keeps regions rare: **if you can name the failure in advance, the
-failure is state, not an exception.** A request can 404, a form can be
-invalid, a resource can be unavailable. Model each in app-db, and render each
-with an ordinary view.
+If you can name the failure in advance, the failure is state, not an exception.
+A request can 404, a form can be invalid, a resource can be unavailable. Model
+each in app-db, and render each with an ordinary view.
 
 ```clojure
 ;; Don't — a 404 is not an exception, and a region is not control flow
@@ -142,39 +145,39 @@ with an ordinary view.
 ```
 
 The second version is testable with `=`, renders a real message instead of a
-generic fallback, and leaves the region free for its real job: the failure
-you did *not* plan for. Fetch status and mutation status are ordinary app-db
-state; [Async resources](08-async-resources.md) owns that shape.
+generic fallback, and leaves the region free for the failure you did not plan
+for. Fetch status and mutation status are ordinary app-db state;
+[Async resources](08-async-resources.md) owns that shape.
 
 ## Where regions go
 
-Regions do not go everywhere, and not once at the root. A single root region
-is a whole-page fallback: not much better than a blank screen, and navigation
-goes down with the page. One region per view is noise, and most views cannot
-fail independently of their parent.
+Regions do not go everywhere, and not once at the root. A single root region is
+a whole-page fallback — not much better than a blank screen, and navigation
+goes down with the page. One region per view is noise; most views cannot fail
+independently of their parent.
 
 The useful grain is **a region the user can still work without**: a panel, a
 tab body, a sidebar widget, a route's main content. Ask what the rest of the
-page is worth if this part is gone. If the answer is "nothing", put the
-region higher.
+page is worth if this part is gone. If the answer is "nothing", put the region
+higher.
 
 ## Troubleshooting
 
-| Symptom | What went wrong | Fix |
-|---|---|---|
-| Whole page blanks when one view throws | Nothing caught it — React unmounts the root by default | Put [`h/error-boundary`](glossary.md#error-boundary) around the region that can fail |
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Whole page blanks when one view throws | Nothing caught it — React unmounts the root by default | Put `h/error-boundary` around the region that can fail |
 | A throw from an event handler is not caught by the region | Handlers run in the event pipeline, not in render; the pipeline catches it and reports `:rf.error/handler-exception` | Expected — read the error record; the view layer never sees it |
 | Fallback shows and never leaves | No `:reset-key`, or the key never changes | Drive the key from app-db and bump it to retry |
-| Retry button in the fallback does nothing | The [intent](glossary.md#intent) lowers under the region's frame; without a frame in scope it refuses with `:rf.error/hicasso-intent-outside-boundary`, naming the intent | Keep the fallback ordinary hiccup inside the mounted tree; dispatch a plain intent |
+| Retry button in the fallback does nothing | The intent lowers under the region's frame; without a frame in scope it raises `:rf.error/hicasso-intent-outside-boundary` | Keep the fallback ordinary hiccup inside the mounted tree; dispatch a plain intent |
 | One panel breaks and the page follows it down | The fallback itself threw; the next region up caught that | Keep fallbacks plain — no reads of the failed state, no heavy work |
 | `:on-error` seems to fire twice in development | It does not — StrictMode re-runs the failing render; React reports one catch | Two fires means two real failures |
-| The region did not catch during a server render | React routes server render errors through its server error channel; client regions never see them | The surface's [server policy](glossary.md#server-policy) owns that path ([SSR and hydration](17-ssr-and-hydration.md)) |
+| The region did not catch during a server render | React routes server render errors through its server error channel; client regions never see them | The surface's server policy owns that path ([SSR and hydration](17-ssr-and-hydration.md)) |
 
-## When not
+## When not to use it
 
-- **The failure is expected** — a 404, invalid input, an empty result. That
-  is app-db state rendered by an ordinary view. A region there is a worse
-  version of a status key.
+- **The failure is expected** — a 404, invalid input, an empty result. That is
+  app-db state rendered by an ordinary view. A region there is a worse version
+  of a status key.
 - **Around every view** — a region earns its place at the grain of "the user
   can still work without this"; below that grain it is noise.
 - **As loading UI** — a fallback is for failure, not for pending. Pending is

--- a/docs/design/hicasso/draft-guide/17-ssr-and-hydration.md
+++ b/docs/design/hicasso/draft-guide/17-ssr-and-hydration.md
@@ -1,72 +1,19 @@
 # SSR and hydration
 
 You want real HTML in the first response, and you want the same app to take
-over in the browser. You do not want to write the UI twice, and you do not
-want a second HTML emitter that drifts from what the client renders.
-[Hicasso](glossary.md#hicasso) renders the same views on the server that you
-mount in the browser. Each host and native component either renders
-deterministic HTML or is Client-only; a Client-only surface leaves its
-declared fallback in the server bytes, or — the bare default — nothing at
-all, until the browser takes over. The browser adopts the server's DOM; it
-does not repaint over it.
+over in the browser. You do not want to write the UI twice, and you do not want
+a second HTML emitter that drifts from what the client renders.
 
-> **One renderer runs in two places, and React's own adoption judges the
-> result.**
-
-## Every surface has a server answer
-
-Semantics live in React, so the server renders with React: `react-dom/server`
-under Node, which walks the same components the browser mounts. There is no
-parallel string emitter and no JVM twin of the view layer. With one
-renderer, hydration parity holds by construction. Parity that is only a
-claim admits a whole class of bug.
-
-One renderer serves every surface. Two policies govern each surface, and
-between them they produce three outcomes in the server bytes — the rendered
-markup, a fallback, or nothing:
-
-- **Render** — the surface produces deterministic React server bytes from an
-  immutable request snapshot. Hydration adopts those bytes.
-- **Client-only** — the surface refuses server use at its declaration. What
-  stands in its place is a deterministic fallback, if the declaration carries
-  one, and otherwise nothing: the fallback is optional, and bare Client-only
-  is the default. Either way the live component arrives in the browser after
-  adoption completes. An empty region is conservative rather than broken —
-  but it is genuinely empty, so a surface whose absence would show wants a
-  fallback declared.
-
-| Surface | Policy |
-|---|---|
-| Hiccup elements, fragments, text | Render |
-| [`h/defview`](glossary.md#defview) bodies and [`h/sub`](glossary.md#hsub) reads | Render — reads probe the request snapshot |
-| Controlled fields | Render — value/checked attributes come from the model |
-| [`h/error-boundary`](glossary.md#error-boundary) | Render — a throw during a server render takes React's server error channel, not the [boundary](glossary.md#boundary)'s fallback |
-| Roots and the [outward bridge](glossary.md#outward-bridge) | Render — request-isolated, prefix-matched |
-| [`h/defhost`](glossary.md#defhost), [ReactNode slots](glossary.md#reactnode-slot), render props, [`h/as-element`](glossary.md#as-element) | Client-only until the declaration selects Render |
-| Portals, raw React elements, opaque foreign components | Client-only — no hydration claim is made for bytes that were never sent |
-| Intrinsic [`n/$`](glossary.md#n-dollar) forms | Render |
-| [`n/defcomponent`](glossary.md#ndefcomponent) and component-headed [`n/$`](glossary.md#n-dollar) | Client-only until the declaration selects Render |
-| Resource and demand boundaries | Client-only until their module contract selects Render |
-
-Two consequences deserve a plain statement. First, a server render runs no
-effects. Every [`h/sub`](glossary.md#hsub) read is a cold probe against one coherent snapshot:
-no subscription registered, no commit, no disposal owed. A request
-therefore leaves nothing behind, by design. Second, determinism is the part
-you own. Same bundle, same snapshot, same bytes — that is the Render
-obligation, and it holds exactly when bodies are functions of their props
-and reads. A clock, a `js/window` check, or a random value in a body paints
-one thing on the server and another in the browser, and React reports the
-divergence as a hydration mismatch. Platform work belongs in effects:
-`:platforms #{:client}` handlers are skipped server-side. At host edges,
-the rule is the same purity that [Views and reads](02-views-and-reads.md)
-already demands. Events as data help at no cost: `[:article/delete id]` on
-`:on-click` has no closure to ship, and each side builds the callback from
-the vector.
+Hicasso renders the same views on the server that you mount in the browser.
+Each host and native component either produces deterministic HTML or is
+Client-only. A Client-only surface leaves its declared fallback in the server
+bytes — or nothing, the bare default — until the browser takes over. The
+browser adopts the server's DOM; it does not repaint over it.
 
 ## Serve a page from a snapshot
 
-The example page: a feed read from app-db, plus a foreign chart that works
-only in a browser.
+The example page: a feed read from app-db, plus a foreign chart that works only
+in a browser.
 
 ```clojure
 (ns app.views
@@ -75,7 +22,8 @@ only in a browser.
 
 (h/defhost trend-chart TrendChart
   {:server   :client-only
-   :fallback [:div {:class "chart chart--pending"} "Chart loads in the browser"]})
+   :fallback [:div {:class "chart chart--pending"}
+              "Chart loads in the browser"]})
 
 (h/defview article-row [{:keys [id]}]
   [:li {:class "article"}
@@ -89,11 +37,10 @@ only in a browser.
    [trend-chart {:points (clj->js (h/sub [:feed/trend]))}]])
 ```
 
-Nothing here is SSR-specific. That is the point: idiomatic [Hicasso](glossary.md#hicasso) is
-already the app that serves.
+Nothing here is SSR-specific. Ordinary Hicasso is already the app that serves.
 
-The server side is the optional server module: the deployable Node
-service's render entry. One request goes in; one document comes out:
+The server side is the optional server module. One request goes in; one
+document comes out:
 
 ```clojure
 (ns app.server
@@ -117,33 +64,37 @@ service's render entry. One request goes in; one document comes out:
      :title             "The feed"})))
 ```
 
-`server/render` is the whole request lifecycle. It runs five steps in a
-fixed order:
+`server/render` runs five steps in a fixed order:
 
-1. It creates a fresh frame under a private id. Two concurrent requests
-   cannot read each other's app-db.
-2. It seeds state through the framework's own doors: the snapshot via
+1. Creates a fresh frame under a private id. Two concurrent requests cannot
+   read each other's app-db.
+2. Seeds state through the framework's own doors: the snapshot via
    `:rf/set-db`, then any `:initial-events` (a resolved route, a completed
    fetch) in order.
-3. It renders the view to HTML with `react-dom/server` — the same element
-   tree the browser mounts, with host policies honoured by construction.
-4. It builds the hydration payload from the allowlisted app-db slice and
-   embeds it as the page's `__rf_payload` script.
-5. It destroys the frame in a `finally`, so a render that throws leaks no
-   more than a render that returns.
+3. Renders the view to HTML with `react-dom/server` — the same element tree
+   the browser mounts, with host policies honoured.
+4. Builds the hydration payload from the allowlisted app-db slice and embeds
+   it as the page's `__rf_payload` script.
+5. Destroys the frame in a `finally`, so a render that throws leaks no more
+   than a render that returns.
 
-The `:payload` policy is fail-closed. It is a non-empty vector of top-level
-app-db keys, or the explicit `:rf.ssr.payload/whole-app-db`. If you omit
-it, the service throws `:rf.error/ssr-missing-payload-policy` at boot. It
-does not ship your server-only keys at first request, and it does not
-silently drop the keys your views read. Allowlist every key the page reads.
-A key the server rendered from, but did not ship, hydrates the client
-against different state — and the mismatch complaints that follow are real.
+**`:payload` is fail-closed.** It is a non-empty vector of top-level app-db
+keys, or the explicit `:rf.ssr.payload/whole-app-db`. If you omit it, the
+service throws `:rf.error/ssr-missing-payload-policy` at boot. Allowlist every
+key the page reads. A key the server rendered from but did not ship hydrates
+the client against different state — and the mismatch complaints that follow
+are real.
 
-Hand `:document` to the HTTP host you run: the service's own runner, an
-Express route, a lambda. Two renders from the same snapshot produce
-byte-identical documents. The service checks exactly that in its own tests,
-and your tests can too.
+Hand `:document` to the HTTP host you run. Two renders from the same snapshot
+produce byte-identical documents.
+
+A server render runs no effects. Every [`h/sub`](glossary.md#hsub) read is a
+cold probe against one coherent snapshot: no subscription registered, no
+commit, no disposal. Same bundle, same snapshot, same bytes — that holds when
+bodies are functions of their props and reads. A clock, a `js/window` check,
+or a random value in a body paints one thing on the server and another in the
+browser; React reports the divergence as a hydration mismatch. Platform work
+belongs in effects: `:platforms #{:client}` handlers are skipped server-side.
 
 ## Hydrate it
 
@@ -169,44 +120,86 @@ trees disagree before React compares a single node.
               [views/page {}]))
 ```
 
-!!! note "Two [`hydrate!`](glossary.md#hydrate)s, two halves"
+!!! note "Two `hydrate!`s, two halves"
+
     `ssr/hydrate!` is the framework's state half. It reads the payload,
     dispatches `:rf/hydrate` against the target frame — the server's slice
-    replaces the client's — and validates the wire frame id against
-    `:frame`. A conflict raises `:rf.error/hydration-frame-id-mismatch`; an
-    absent `:frame` raises `:rf.error/no-frame-context`. [`h/hydrate!`](glossary.md#hydrate) is
-    the DOM half: React's `hydrateRoot` on a container that already holds
-    server bytes. The two calls share a verb because they are two halves of
-    one adoption — and the order between them is fixed.
+    replaces the client's — and validates the wire frame id against `:frame`.
+    A conflict raises `:rf.error/hydration-frame-id-mismatch`; an absent
+    `:frame` raises `:rf.error/no-frame-context`.
 
-[`h/hydrate!`](glossary.md#hydrate) stands beside [`h/mount!`](glossary.md#mount) ([Installation](installation.md)):
-the same association of a container, a frame, and one view, and the same
-idempotent handle for [`h/unmount!`](glossary.md#mount). These properties matter when you write
-apps:
+    [`h/hydrate!`](glossary.md#hydrate) is the DOM half: React's `hydrateRoot`
+    on a container that already holds server bytes. The order between the two
+    calls is fixed.
+
+`h/hydrate!` stands beside [`h/mount!`](glossary.md#mount)
+([Installation](installation.md)): the same association of a container, a
+frame, and one view, and the same idempotent handle for
+[`h/unmount!`](glossary.md#mount).
 
 - **Adoption is root-scoped.** The handle owns its container, its
   `:identifier-prefix`, and its error reporting. Nothing about hydration is
-  process-global. That is what makes the two-root example below work.
+  process-global.
 - **It returns before adoption finishes.** React hydrates without
   `flushSync`. Do not assume that the DOM on the next line is client-owned.
 - **`:identifier-prefix` must match the server render's.** React's `useId`
-  writes the prefix into every generated id in the bytes. The hydrating
-  root verifies them, and a prefix disagreement flags every generated id at
-  once.
-- **Controlled text is never rewritten afterwards.** The model's value is
-  in the server bytes, and it is the one truth from the first paint
-  ([Controlled inputs](04-controlled-inputs.md)).
-- **Presence children are born present.** Nothing that arrived with the
-  page replays an entrance animation over content the user already reads.
+  writes the prefix into every generated id in the bytes. A prefix
+  disagreement flags every generated id at once.
+- **Controlled text is never rewritten afterwards.** The model's value is in
+  the server bytes ([Controlled inputs](04-controlled-inputs.md)).
+- **Presence children are born present.** Nothing that arrived with the page
+  replays an entrance animation over content the user already reads.
 
 `ssr/hydrate!` returns the applied payload, or `nil` when the page carries
 none. The same boot therefore serves a client-only load: on `nil`, fall
-through to [`h/mount!`](glossary.md#mount) with your ordinary `:initial-events` seed.
+through to `h/mount!` with your ordinary `:initial-events` seed.
+
+## Client-only hosts with a fallback
+
+Foreign React components often cannot run on the server. Declare that at the
+host:
+
+```clojure
+(h/defhost stock-widget StockWidget)               ;; Client-only — the default
+(h/defhost trend-chart TrendChart
+  {:server   :client-only
+   :fallback [:div {:class "chart chart--pending"}
+              "Chart loads in the browser"]})
+```
+
+On the server, the crossing renders its declared fallback, or nothing. In the
+browser, the live component mounts after adoption completes. A fresh
+client-only mount (no SSR) renders the component immediately, with no fallback
+flash.
+
+The fallback must be deterministic, inert markup. It is walked once at the
+declaration, and it lands in the server bytes *and* in hydration's first client
+pass; those two must agree. A [`defview`](glossary.md#defview) or
+[`defhost`](glossary.md#defhost) head written into a fallback raises
+`:rf.error/hicasso-host-fallback-boundary-head` at the declaration — a body
+that runs later cannot be deterministic.
+
+**Render** is the other policy: assert that the component is safe to run on a
+server. Write `{:server :render}`, and the component is the element's own type
+on server, first client pass, and fresh mount. There is no swap at adoption.
+Render is also the only policy under which a crossing's **children** reach the
+server response. Both Client-only shapes render *instead of* the component,
+children included — so a transparent wrapper (a context provider) that stays
+Client-only deletes its subtree from the response. The answer to "my provider
+vanished server-side" is `{:server :render}` when the provider is server-safe.
+
+If the Render assertion is false, the failure is loud: `window is not defined`,
+thrown mid-render. A policy value outside the two raises
+`:rf.error/hicasso-host-bad-ssr-policy`. So does a `:fallback` under Render —
+there is nothing for the fallback to replace. An option `defhost` does not know
+raises `:rf.error/hicasso-host-unknown-option`.
+
+The full per-surface table is under Advanced.
 
 ## Two roots, two verdicts
 
-A page may carry several server-rendered roots — for example, an app and a
-help panel. Each root adopts and complains independently:
+A page may carry several server-rendered roots — for example, an app and a help
+panel. Each root adopts and complains independently:
 
 ```clojure
 (h/defview help-panel [_]                        ;; in app.views
@@ -225,10 +218,9 @@ help panel. Each root adopts and complains independently:
               [views/help-panel {}]))
 ```
 
-The server rendered one timestamp into the help panel; the client's first
-pass computes another. React keeps the client's version, repairs the DOM,
-and reports what it recovered from. The report surfaces on the diagnostic
-bus as:
+The server rendered one timestamp into the help panel; the client's first pass
+computes another. React keeps the client's version, repairs the DOM, and
+reports what it recovered from:
 
 ```clojure
 {:id    :rf.ssr/hydration-mismatch
@@ -237,90 +229,103 @@ bus as:
  :error recoverable-error}        ;; React's report, component stack included
 ```
 
-The `#app` root hydrated clean; its stream is empty. That per-root
-attribution is the contract. Each [`h/hydrate!`](glossary.md#hydrate) wires its own recoverable,
-caught, and uncaught error channels, so one faulty root cannot contaminate
-the other's verdict. Xray's hydration lane shows the complaints joined to
-view source and host policy ([Diagnostics](15-diagnostics.md)). The fix
-here is the usual one: a value that both sides must agree on belongs in
+The `#app` root hydrated clean; its stream is empty. Each `h/hydrate!` wires
+its own recoverable, caught, and uncaught error channels, so one faulty root
+cannot contaminate the other's verdict. Xray's hydration lane shows the
+complaints joined to view source and host policy
+([Diagnostics](15-diagnostics.md)).
+
+The fix is the usual one: a value that both sides must agree on belongs in
 state — written by an event, rendered from the snapshot.
 
-Be clear about the limits of the check. React reports text divergence and
-missing, extra, or wrong-type elements. It does not report an
-attribute-only divergence: a stale `class` on an element whose tag and text
-still match receives a development warning, not a production callback.
-Recovery is replacement, not patching. The page ends up correct, and the
-disagreement ends up reported.
+React reports text divergence and missing, extra, or wrong-type elements. It
+does not report an attribute-only divergence: a stale `class` on an element
+whose tag and text still match receives a development warning, not a production
+callback. Recovery is replacement, not patching.
 
 ??? info "Coming from Reagent: where is the structural hash?"
-    The Reagent-tier adapters hash their hiccup tree on the server and
-    re-hash the client's first render. Views there are pure functions that
-    return a data tree, so there is a tree to hash. [Hicasso](glossary.md#hicasso) views reach
-    React as elements, and React walks the tree internally, so no data tree
-    exists to hash and no hash rides the payload. Verification on this tier
-    is React's own adoption, reported per root. An absent hash cannot lie;
-    a degenerate hash could.
+    The Reagent-tier adapters hash their hiccup tree on the server and re-hash
+    the client's first render. Views there are pure functions that return a
+    data tree, so there is a tree to hash. Hicasso views reach React as
+    elements, and React walks the tree internally, so no data tree exists to
+    hash and no hash rides the payload. Verification on this tier is React's
+    own adoption, reported per root.
 
-## Render and Client-only, at the host
+## When not to server-render
 
-Every [`h/defhost`](glossary.md#defhost) declaration carries its [server policy](glossary.md#server-policy). One declaration
-covers the server render, hydration's first client pass, and a fresh
-client-only mount ([Interop](09-interop.md)):
+A client-only application never ships the service: no Node process, no payload,
+no snapshot plumbing. Boot is `h/mount!` and an `:initial-events` seed. Apps
+behind a login wall usually belong here. First-response HTML of private,
+per-user state rarely justifies a render fleet.
+
+You do not opt out of the contract. Server policies are declared and checked at
+their sources whether or not a server exists. Every surface keeps its
+Render-or-Client-only rule, and hydration behaviour is part of each surface's
+definition. That is why turning SSR on later is configuration — a snapshot, an
+allowlist, a prefix — and not a rewrite.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `:rf.ssr/hydration-mismatch` naming a root and a view | The two renders disagreed — a body read the platform (clock, random, `js/window`) instead of props and reads | Keep bodies pure; platform work goes to `:platforms #{:client}` effects and host edges |
+| Every `useId`-derived id on one root complains at once | That root's `:identifier-prefix` does not match the server render's | Pass the same prefix to `server/render` and that root's `h/hydrate!`; keep prefixes unique per root |
+| A Client-only host shows its fallback, then the live widget swaps in | The policy working: fallback is in the server bytes and the first client pass; the component mounts at adoption | Make the fallback a same-footprint skeleton to kill the layout jump; only `{:server :render}` removes the swap |
+| `:rf.error/hicasso-host-fallback-boundary-head` at a declaration | A `defview`/`defhost` head in a fallback | Plain hiccup in the fallback, or `{:server :render}` and render the real subtree |
+| `window is not defined` during a server render under `{:server :render}` | The Render assertion is false — the component is not server-safe | Drop back to Client-only with a fallback |
+| A crossing's children are missing from the server HTML, silently | The crossing is Client-only; both Client-only shapes render instead of the component — a transparent wrapper takes its subtree with it | Declare `{:server :render}` on the wrapper if it is server-safe |
+| `:rf.error/hicasso-host-bad-ssr-policy` at a declaration | A policy value outside the two, or `:fallback` combined with Render | Two policies: `:render`, or `:client-only` with an optional `:fallback` |
+| `:rf.error/ssr-missing-payload-policy` at service boot | No `:payload` policy — the wire contract is fail-closed | Allowlist the top-level app-db keys the page reads, or opt in with `:rf.ssr.payload/whole-app-db` |
+| Mismatch complaints although every body is pure | A key the views read is missing from the `:payload` allowlist, so the client hydrated against different state | Add the key to the allowlist |
+| `:rf.error/hydration-frame-id-mismatch` at boot | The payload's wire frame id and `ssr/hydrate!`'s `:frame` disagree | One stable id on both sides: `:client-frame-id` at the server render, the same `:frame` at boot |
+
+## Advanced
+
+### Every surface has a server answer
+
+Semantics live in React, so the server renders with React: `react-dom/server`
+under Node, which walks the same components the browser mounts. There is no
+parallel string emitter and no JVM twin of the view layer.
+
+Two policies govern each surface:
+
+- **Render** — the surface produces deterministic React server bytes from an
+  immutable request snapshot. Hydration adopts those bytes.
+- **Client-only** — the surface does not run on the server. What stands in its
+  place is a deterministic fallback if the declaration carries one, otherwise
+  nothing. The live component arrives in the browser after adoption completes.
+
+| Surface | Policy |
+| --- | --- |
+| Hiccup elements, fragments, text | Render |
+| `h/defview` bodies and `h/sub` reads | Render — reads probe the request snapshot |
+| Controlled fields | Render — value/checked attributes come from the model |
+| `h/error-boundary` | Render — a throw during a server render takes React's server error channel, not the boundary's fallback |
+| Roots and the outward bridge | Render — request-isolated, prefix-matched |
+| `h/defhost`, ReactNode slots, render props, `h/as-element` | Client-only until the declaration selects Render |
+| Portals, raw React elements, opaque foreign components | Client-only — no hydration claim is made for bytes that were never sent |
+| Intrinsic `n/$` forms | Render |
+| `n/defcomponent` and component-headed `n/$` | Client-only until the declaration selects Render |
+| Resource and demand boundaries | Client-only until their module contract selects Render |
+
+Events as data help at no cost: `[:article/delete id]` on `:on-click` has no
+closure to ship, and each side builds the callback from the vector.
+
+### Render on a context provider
 
 ```clojure
-(h/defhost stock-widget StockWidget)               ;; Client-only — the default
-(h/defhost trend-chart TrendChart                  ;; the same, with declared markup
-  {:server   :client-only
-   :fallback [:div {:class "chart chart--pending"} "Chart loads in the browser"]})
-
 (def theme-context (react/createContext "light"))  ;; (:require ["react" :as react])
 (h/defhost theme-provider (.-Provider theme-context)
   {:server :render})                               ;; runs on the server, children included
 ```
 
-**Client-only** is the conservative default, and the choice is deliberate:
-a foreign React component is exactly the node whose render may reach for
-`window`, and the declaration cannot know. On the server, the crossing
-renders its declared fallback, or nothing. In the browser, the live
-component mounts after adoption completes. A fresh client mount renders the
-component immediately, with no fallback flash. The fallback must be
-deterministic, inert markup. It is walked once at the declaration, and it
-lands in the server bytes *and* in hydration's first client pass; those two
-must agree by construction. The runtime enforces this. A [`defview`](glossary.md#defview) or
-[`defhost`](glossary.md#defhost) head written into a fallback is an element whose body runs later
-— differently per frame and per write — and the declaration refuses it
-with `:rf.error/hicasso-host-fallback-boundary-head`.
+A provider whose *value* comes from the browser has no server story. It stays
+Client-only, and so does everything beneath it.
 
-**Render is an assertion**: this component is safe to run on a server.
-Write it, and the component is the element's own type. Server render, first
-client pass, and fresh mount are then one tree with the same props,
-context, and children. There is no swap at adoption, and no remount of the
-subtree you just hydrated. Render is also the only policy under which a
-crossing's **children** reach the server response. Both Client-only shapes
-render *instead of* the component, children included. For a leaf widget
-that is correct: there are no children. For a transparent wrapper, such as
-a context provider, Client-only deletes the subtree from the response —
-and nothing complains, because the server bytes and the first client pass
-agree by construction. The answer to "my provider vanished server-side" is
-`{:server :render}`: the real subtree, the declared context value, rendered
-once. The honest limit: a provider whose *value* comes from the browser has
-no server story. It stays Client-only, and so does everything beneath it.
+### The native tier under SSR
 
-If the Render assertion is false, the failure is loud: `window is not
-defined`, thrown mid-render, attributed to the request. Render was designed
-to fail this way; the silent alternatives were worse. Refusals are equally
-loud at the source. A policy value outside the two raises
-`:rf.error/hicasso-host-bad-ssr-policy`. So does a `:fallback` under Render
-— there is nothing for the fallback to replace. An option that `defhost`
-does not know raises `:rf.error/hicasso-host-unknown-option`. A raw React
-element escape carries no declaration, so it carries no server-safety
-assertion either. It renders nothing server-side, always.
-
-## The native tier under SSR
-
-The same per-surface rule applies, at the same sources. An intrinsic [`n/$`](glossary.md#n-dollar)
-form is markup, and it Renders. A named native component declares its
-policy, and the default is conservative:
+An intrinsic [`n/$`](glossary.md#n-dollar) form is markup, and it Renders. A
+named native component declares its policy; the default is conservative:
 
 ```clojure
 (n/defcomponent ticker
@@ -330,59 +335,24 @@ policy, and the default is conservative:
     (n/$ :span {:class "ticker"} price)))
 ```
 
-Under a server render, [`n/use-sub`](glossary.md#nuse-sub) reads the request snapshot through the
-hook's server path: the same cold-probe discipline, with no registration.
-Omit the declaration map, and the component stays Client-only until its
-declaration selects Render ([The native tier](10-native-tier.md)).
+Under a server render, [`n/use-sub`](glossary.md#nuse-sub) reads the request
+snapshot through the hook's server path: the same cold-probe discipline, with
+no registration. Omit the declaration map, and the component stays Client-only
+until its declaration selects Render ([The native tier](10-native-tier.md)).
 
-## The Node service
+### The Node service
 
-The server module deploys as a bounded Node service. Running one provides
-the operational half of the story:
+The server module deploys as a bounded Node service:
 
 - **Per-request isolation** — a fresh frame per request, destroyed in a
-  `finally`. State never crosses requests, and a long-running process does
-  not accumulate frames.
-- **The allowlisted payload** — the fail-closed `:payload` contract,
-  enforced at boot. What rides the wire is a decision, not an accident.
+  `finally`. State never crosses requests.
+- **The allowlisted payload** — the fail-closed `:payload` contract, enforced
+  at boot.
 - **Bounded execution** — one in-flight render per isolate, bounded
-  concurrency, and a timeout with hard termination behind it. The service
-  kills a render that hangs; it does not queue work behind it.
-- **Build identity** — the service knows which client bundle its bytes
-  match, because "same bundle" is half of "same bytes".
-- **Error attribution** — a throw during a request is a non-200 with a
-  source, never a half-page.
+  concurrency, and a timeout with hard termination behind it.
+- **Build identity** — the service knows which client bundle its bytes match.
+- **Error attribution** — a throw during a request is a non-200 with a source,
+  never a half-page.
 
-The service renders whole pages. Streaming, React Server Components,
-islands, and no-JS progressive enhancement are outside the product. The
-render contract keeps response framing separate from semantics, so none of
-them requires that a second renderer ever exist.
-
-## When not to server-render
-
-A client-only application never ships the service: no Node process, no
-payload, no snapshot plumbing. Boot is [`h/mount!`](glossary.md#mount) and an `:initial-events`
-seed. None of the service's operational weight exists in your deployment.
-Apps behind a login wall usually belong here. First-response HTML of
-private, per-user state rarely justifies a render fleet.
-
-You do not opt out of the contract. Server policies are declared and
-checked at their sources whether or not a server exists. Every surface
-keeps its Render-or-refuse disposition, and hydration behaviour is part of
-each surface's definition. That is why turning SSR on later is
-configuration — a snapshot, an allowlist, a prefix — and not a rewrite.
-
-## Troubleshooting
-
-| Symptom | What it is | Fix |
-|---|---|---|
-| `:rf.ssr/hydration-mismatch` naming a root and a view | The two renders disagreed — a body read the platform (clock, random, `js/window`) instead of props and reads | Keep bodies pure; platform work goes to `:platforms #{:client}` effects and host edges |
-| Every `useId`-derived id on one root complains at once | That root's `:identifier-prefix` does not match the server render's | Pass the same prefix to `server/render` and that root's [`h/hydrate!`](glossary.md#hydrate); keep prefixes unique per root |
-| A Client-only host shows its fallback, then the live widget swaps in | The policy working: the fallback is in the server bytes and the first client pass; the component mounts at adoption | Make the fallback a same-footprint skeleton to kill the layout jump; only `{:server :render}` removes the swap |
-| `:rf.error/hicasso-host-fallback-boundary-head` at a declaration | A [`defview`](glossary.md#defview)/[`defhost`](glossary.md#defhost) head in a fallback — a body that runs later cannot be deterministic, and the fallback must render identically on the server and hydration's first pass | Plain hiccup in the fallback, or `{:server :render}` and render the real subtree |
-| `window is not defined` during a server render under `{:server :render}` | The Render assertion is false — the component is not server-safe | Drop back to Client-only with a fallback; this failure is loud by design |
-| A crossing's children are missing from the server HTML, silently | The crossing is Client-only, and both Client-only shapes render instead of the component — a transparent wrapper takes its subtree with it, and both passes agree so nothing reports | Declare `{:server :render}` on the wrapper if it is server-safe |
-| `:rf.error/hicasso-host-bad-ssr-policy` at a declaration | A policy value outside the two, or `:fallback` combined with Render | Two policies: `:render`, or `:client-only` with an optional `:fallback` |
-| `:rf.error/ssr-missing-payload-policy` at service boot | No `:payload` policy — the wire contract is fail-closed | Allowlist the top-level app-db keys the page reads, or opt in with `:rf.ssr.payload/whole-app-db` |
-| Mismatch complaints although every body is pure | A key the views read is missing from the `:payload` allowlist, so the client hydrated against different state | Add the key to the allowlist |
-| `:rf.error/hydration-frame-id-mismatch` at boot | The payload's wire frame id and `ssr/hydrate!`'s `:frame` disagree | One stable id on both sides: `:client-frame-id` at the server render, the same `:frame` at boot |
+The service renders whole pages. Streaming, React Server Components, islands,
+and no-JS progressive enhancement are outside the product.

--- a/docs/design/hicasso/draft-guide/18-performance.md
+++ b/docs/design/hicasso/draft-guide/18-performance.md
@@ -1,24 +1,21 @@
 # Performance
 
-"Is it fast enough?" is not a feeling. [Hicasso](glossary.md#hicasso) ships with
-[user-visible budgets](glossary.md#user-visible-budget), and performance work
-is the method that meets them:
-measure, attribute, change the smallest thing, then verify again. This
-chapter gives you the budgets, the ladder, the loop, and one example with
-every cost counted, so that you can compute a cost instead of guessing at
-it.
+"Is it fast enough?" is not a feeling. Hicasso ships with
+[user-visible budgets](glossary.md#user-visible-budget). Performance work is
+the method that meets them: measure, attribute, change the smallest thing, then
+verify again.
 
-> **Most apps never leave rung 1, and that is the intended result of the
-> design.**
+Most apps never leave ordinary Hicasso (rung 1 of the ladder below). That is
+the intended result.
 
 ## The budgets
 
-The budgets come first, because they are the only honest definition of
-"slow". Each budget is a fact that a user can notice, measured at the
-percentile that represents real hardware:
+The budgets come first, because they are the only honest definition of "slow".
+Each budget is a fact a user can notice, measured at the percentile that
+represents real hardware:
 
 | Budget | The user-visible fact |
-|---|---|
+| --- | --- |
 | Discrete interactions | Click, toggle, submit reach the next paint within **50 ms p95** (100 ms p99) |
 | Keystroke echo | A [controlled field](glossary.md#controlled-field) is correct **in the same turn** and visibly echoed within **one 60 Hz frame** at p95 |
 | Broad operations | Bulk replace, big filter flips complete within **100 ms p95**, unless explicitly classified as background work |
@@ -26,41 +23,41 @@ percentile that represents real hardware:
 | Narrow updates | Body work scales with **changed rows**, not mounted rows |
 | Teardown | **Zero residue** after quiescence — long sessions do not accumulate |
 
-Hold your own app to these numbers. The rest of this chapter matters only
-when one of them is missed: a screen that meets its budgets is fast enough,
-whatever score a synthetic benchmark reports.
+Hold your own app to these numbers. The rest of this chapter matters only when
+one of them is missed. A screen that meets its budgets is fast enough, whatever
+score a synthetic benchmark reports.
 
 !!! note "Measure under production conditions"
+
     Verify budgets on **production builds**, on mid-tier hardware, at p95
     across runs. A dev build carries diagnostics that production erases, and
     your machine is faster than your users' machines. Your best run is not a
     measurement.
 
-The teardown row needs one expansion, because people forget that this budget
-is user-visible. An SPA session is long, and leave-and-return cycles must
-not accumulate residue. [Hicasso](glossary.md#hicasso) guarantees its own side: abandoned renders
-own nothing, and unmount releases every read. Your side is the escapes. A
-host or island that acquires an SDK, a listener, or a timer releases it on
-teardown ([Interop](09-interop.md)), and the [test kit](glossary.md#test-kit)'s `assert-clean!`
-proves the whole claim after quiescence ([Testing](14-testing.md)).
+The teardown row is user-visible. An SPA session is long, and leave-and-return
+cycles must not accumulate residue. Hicasso guarantees its own side: abandoned
+renders own nothing, and unmount releases every read. Your side is the escapes.
+A host or island that acquires an SDK, a listener, or a timer releases it on
+teardown ([Interop](09-interop.md)), and the [test kit](glossary.md#test-kit)'s
+`assert-clean!` proves the whole claim after quiescence
+([Testing](14-testing.md)).
 
-## Why most apps never leave rung 1
+## Why most apps stay on rung 1
 
-Rung 1 is ordinary [Hicasso](glossary.md#hicasso): write ordinary views, read at the point of use,
-put [intents](glossary.md#intent) in the markup, and ship. Do not pre-optimise, and do not build a
-second architecture for problems that you have not measured — the
-interpreter is not the cost. Interpreted [lowering](glossary.md#lowering) is fast. When a screen
-misses a budget, the cost almost always lives somewhere else: **where the
-reads sit, how many [boundaries](glossary.md#boundary) exist, what React itself does, or what a host
-does**. Per read, Hicasso's retained cost is low; the read *topology* is
-what you chose. That is why the ladder's second rung is "move your reads",
-not "abandon Hiccup".
+Rung 1 is ordinary Hicasso: write ordinary views, read at the point of use, put
+[intents](glossary.md#intent) in the markup, and ship. Do not pre-optimise for
+problems you have not measured. Interpreted [lowering](glossary.md#lowering) is
+fast. When a screen misses a budget, the cost almost always lives somewhere
+else: **where the reads sit, how many [boundaries](glossary.md#boundary) exist,
+what React itself does, or what a host does**. Per read, Hicasso's retained
+cost is low; the read *topology* is what you chose. That is why the ladder's
+second rung is "move your reads", not "abandon Hiccup".
 
-A small share of view code turns out to be hot — often none, rarely more
-than about two percent: a cell that renders constantly, a large collection
-under broad writes, a vendor widget with its own behavior. For that code the
-ladder continues downward, explicitly and locally. The share is an observed
-outcome, never a quota. An escape is a local island, never a general style.
+A small share of view code turns out to be hot — often none, rarely more than
+about two percent: a cell that renders constantly, a large collection under
+broad writes, a vendor widget with its own behaviour. For that code the ladder
+continues downward, explicitly and locally. An escape is a local island, never
+a general style.
 
 ## The ladder
 
@@ -68,54 +65,50 @@ The [performance ladder](glossary.md#performance-ladder) is the same gradient
 as [the native tier](10-native-tier.md): ordinary Hicasso first, explicit
 escapes only when measurement names them.
 
-One table shows the whole gradient. Every rung is code that is visible in a
-diff. There is no `:fast` flag, no compile mode, and no setting that changes
-what Hiccup means:
+Every rung is code that is visible in a diff. There is no `:fast` flag, no
+compile mode, and no setting that changes what Hiccup means:
 
 | Rung | What you write | Reach for it when | Taught in |
-|---|---|---|---|
-| 1 — Ordinary [Hicasso](glossary.md#hicasso) | Hiccup, [`h/sub`](glossary.md#hsub) at point of use, [intents](glossary.md#intent) as data | Always. Start every feature here | [Views and reads](02-views-and-reads.md) |
-| 2 — Tuned topology | The same language; [boundary](glossary.md#boundary) placement, keys, read shape | A named boundary or read pressure | [Lists and collections](06-lists-and-collections.md) |
-| 3 — Direct React return | A [`defview`](glossary.md#defview) returns an [`n/$`](glossary.md#n-dollar) element; frame, reads, memo stay | Lowering itself is the measured owner | [The native tier](10-native-tier.md) |
-| 4 — Named [native island](glossary.md#native-island) | [`n/defcomponent`](glossary.md#ndefcomponent) (or UIx) under the same root and frame | Hooks, vendor behavior, reconciliation, or high-rate local work dominate | [The native tier](10-native-tier.md) |
+| --- | --- | --- | --- |
+| 1 — Ordinary Hicasso | Hiccup, [`h/sub`](glossary.md#hsub) at point of use, intents as data | Always. Start every feature here | [Views and reads](02-views-and-reads.md) |
+| 2 — Tuned topology | The same language; boundary placement, keys, read shape | A named boundary or read pressure | [Lists and collections](06-lists-and-collections.md) |
+| 3 — Direct React return | A `defview` returns an [`n/$`](glossary.md#n-dollar) element; frame, reads, memo stay | Lowering itself is the measured owner | [The native tier](10-native-tier.md) |
+| 4 — Named [native island](glossary.md#native-island) | [`n/defcomponent`](glossary.md#ndefcomponent) (or UIx) under the same root and frame | Hooks, vendor behaviour, reconciliation, or high-rate local work dominate | [The native tier](10-native-tier.md) |
 | 5 — Native screen | A React-first screen authored natively | The screen is React-shaped by nature | [The native tier](10-native-tier.md) |
 
-The full lessons for rungs 3–5 are in [chapter 10](10-native-tier.md). This
-chapter owns the decision: when you step down, and when an escape must come
-back out.
+Rungs 3–5 are taught in [chapter 10](10-native-tier.md). This chapter owns the
+decision: when you step down, and when an escape must come back out.
 
 ## The working loop
 
-Performance work that skips a step of this loop is guessing. The loop:
+Performance work that skips a step of this loop is guessing:
 
-1. **Reproduce.** Name one slow interaction, and script it so that it runs
-   the same way in every run. "The app is slow" is not actionable; "expedite
-   on a 1,000-row table takes 180 ms" is actionable.
+1. **Reproduce.** Name one slow interaction, and script it so that it runs the
+   same way every run. "The app is slow" is not actionable; "expedite on a
+   1,000-row table takes 180 ms" is actionable.
 2. **Attribute.** Correlate the event with the work that ran — which
-   subscriptions recomputed, which [boundaries](glossary.md#boundary) became invalid, how much body
-   work, then commit and paint. Xray's [explain-render](glossary.md#explain-render) and read attribution
-   answer the first half. Its [hot-view advisor](glossary.md#hot-view-advisor) classifies the pressure —
-   computation, topology, [lowering](glossary.md#lowering), React, or layout — and recommends the
+   subscriptions recomputed, which boundaries became invalid, how much body
+   work, then commit and paint. Xray's explain-render and read attribution
+   answer the first half. Its hot-view advisor classifies the pressure —
+   computation, topology, lowering, React, or layout — and recommends the
    smallest credible remedy ([Diagnostics](15-diagnostics.md)).
-3. **Tune topology.** Adjust boundary placement, keys, and read shape —
-   rung 2 ([Lists and collections](06-lists-and-collections.md)). Most hot
-   paths are fixed here, and the loop ends.
-4. **Compare direct output** if the measurement names lowering as the owner
-   — rung 3.
-5. **Isolate an island** if hooks, vendor behavior, reconciliation, or
-   high-rate local work is the owner — rung 4. Choose the route by the
-   component's needs, not by habit.
-6. **Re-verify.** The change must preserve DOM and [intent](glossary.md#intent) behavior, focus
-   and selection, frame routing, SSR/hydration, and cleanup — and the budget
-   must flip from fail to pass. A faster screen that behaves wrongly is
-   wrong.
+3. **Tune topology.** Adjust boundary placement, keys, and read shape — rung 2
+   ([Lists and collections](06-lists-and-collections.md)). Most hot paths are
+   fixed here, and the loop ends.
+4. **Compare direct output** if the measurement names lowering as the owner —
+   rung 3.
+5. **Isolate an island** if hooks, vendor behaviour, reconciliation, or
+   high-rate local work is the owner — rung 4.
+6. **Re-verify.** The change must preserve DOM and intent behaviour, focus and
+   selection, frame routing, SSR/hydration, and cleanup — and the budget must
+   flip from fail to pass. A faster screen that behaves wrongly is wrong.
 7. **Keep or remove.** The escape stays only if it passes the benefit rule
    below.
 
 Three instruments cover attribution, and all three erase from production:
 
 | Instrument | The question it answers |
-|---|---|
+| --- | --- |
 | **Xray** | Which reads changed, which boundaries ran and why, fan-out and read-set churn; the advisor's pressure classification |
 | **React DevTools Profiler** | Which components committed — every boundary is a real React function component under its own display name |
 | **Browser Performance panel** | `rf:*` User-Timing measures for events, subscriptions, effects and renders, on the Timings track next to paint |
@@ -123,11 +116,10 @@ Three instruments cover attribution, and all three erase from production:
 A compile-time flag gates the `rf:*` measures, and the default is off. Build
 with `:closure-defines {re-frame.performance/enabled? true}` to emit them; a
 build without the flag carries no timing code at all. The runtime delivers
-entries and does not retain them: a live `PerformanceObserver` and the
-DevTools timeline see every measure, but a later `getEntriesByType` poll
-finds nothing. A bail-out emits no measure — the absence records that no
-work ran. A StrictMode double-invoke emits twice, because the body ran
-twice.
+entries and does not retain them: a live `PerformanceObserver` and the DevTools
+timeline see every measure, but a later `getEntriesByType` poll finds nothing.
+A bail-out emits no measure — the absence records that no work ran. A
+StrictMode double-invoke emits twice, because the body ran twice.
 
 Attribute *before* you change architecture. Unattributed "slow" is usually a
 rung-2 problem, and an island built on a misattributed cause makes the code
@@ -136,20 +128,17 @@ worse without making it faster.
 ## The escape-benefit rule
 
 An escape is a standing cost: a second semantics in that region, a body that
-structural tests cannot see into, a diff that reviewers read more slowly.
-The rule that justifies the cost: **an escape stays only if it recovers at
-least 20%, saves at least 2 ms at p95, or converts a failed user-visible
-budget into a pass.** Otherwise it comes out — simplified back to the rung
-above it. The thresholds never widen to let an island stay, and "it might
-matter someday" is not one of the three conditions. Re-run the comparison
-when the surrounding code changes materially. An escape that no longer meets
-a threshold is ordinary code that still pays escape costs.
+structural tests cannot see into, a diff that reviewers read more slowly. An
+escape stays only if it recovers at least 20%, saves at least 2 ms at p95, or
+converts a failed user-visible budget into a pass. Otherwise it comes out —
+simplified back to the rung above it. The thresholds never widen to let an
+island stay, and "it might matter someday" is not one of the three conditions.
+Re-run the comparison when the surrounding code changes materially.
 
-## The cost of one keystroke: the editor and the grid
+## The cost of one keystroke
 
-The budgets become concrete when you trace one keystroke through the
-machine. Take the smallest complete example — a [controlled field](glossary.md#controlled-field) in a
-four-field article editor:
+The budgets become concrete when you trace one keystroke. Take a controlled
+field in a four-field article editor:
 
 ```clojure
 (ns app.editor
@@ -169,28 +158,27 @@ four-field article editor:
            :on-input [:editor/set-title ::h/value]}])
 ```
 
-One keystroke in the title field takes this path, entirely inside the
-browser's own input event:
+One keystroke in the title field takes this path, entirely inside the browser's
+own input event:
 
-1. The DOM event fires. The [intent](glossary.md#intent) dispatches **synchronously** in the
-   discrete event — no queue sits between the key and the handler.
+1. The DOM event fires. The intent dispatches **synchronously** in the discrete
+   event — no queue sits between the key and the handler.
 2. One handler runs, and it writes **one address**.
 3. The subscriptions that read that address recompute. Equality gates stop
    every subscription whose output did not change. **One** subscription's
    value changes.
-4. The runtime notifies the [boundaries](glossary.md#boundary) whose reads changed. **One** body
-   runs — the title field's body. The other three fields receive no
-   notification.
+4. The runtime notifies the boundaries whose reads changed. **One** body runs
+   — the title field's body. The other three fields receive no notification.
 5. React commits, and the controlled converge applies the value **and the
    caret** before the browser finishes the event
-   ([Controlled inputs](04-controlled-inputs.md) owns that law).
+   ([Controlled inputs](04-controlled-inputs.md)).
 6. The next frame paints the echo.
 
-Read the counts from the walk: 1 write, 1 changed subscription, 1 body run,
-and a commit scoped to one input. **Write amplification — the number of
-boundary bodies that run per state write — is 1.** That is the mechanical
-meaning of "narrow work scales with changed rows", and it is why the editor
-stays far inside its frame budget.
+Counts from the walk: 1 write, 1 changed subscription, 1 body run, and a
+commit scoped to one input. **Write amplification — the number of boundary
+bodies that run per state write — is 1.** That is the mechanical meaning of
+"narrow work scales with changed rows", and it is why the editor stays far
+inside its frame budget.
 
 Now scale the same shape to a 100-cell controlled grid:
 
@@ -201,14 +189,12 @@ Now scale the same shape to a 100-cell controlled grid:
 ```
 
 Each cell reads its **own** address, so a keystroke in one cell is the same
-walk: 1 write, 1 changed subscription, 1 body. The runtime never notifies
-the other 99 cells — not "render and bail", but *never notified*. Typing
-cost is constant in grid size. That is the narrow-update budget passing by
-construction, and it came from a rung-2 choice: fine reads on a typing
-surface.
+walk: 1 write, 1 changed subscription, 1 body. The runtime never notifies the
+other 99 cells — not "render and bail", but *never notified*. Typing cost is
+constant in grid size. That is the narrow-update budget passing by
+construction, from a rung-2 choice: fine reads on a typing surface.
 
-Here is the same grid with the wrong shape, so that you can see the costs
-move:
+Here is the same grid with the wrong shape:
 
 ```clojure
 ;; Don't — a typing surface reading coarse
@@ -220,43 +206,42 @@ move:
         [grid-cell {:key (:id cell) :cell cell}])]]))
 ```
 
-Now every keystroke recomputes the whole-grid view-model, runs the parent
-body, and runs a props compare over 100 cells. The bail-out keeps 99 bodies
-from running — unless a cell prop carries a fresh closure, in which case
-nothing bails and write amplification is 100. At this size the screen can
-still pass the frame budget, narrowly. The *shape* is still wrong, because
-it converts grid size into per-keystroke cost. Coarse reads are for cheap
-mount and bulk replacement. They are the wrong topology for a surface that
-changes 100 times a minute, one cell at a time.
+Now every keystroke recomputes the whole-grid view-model, runs the parent body,
+and runs a props compare over 100 cells. The bail-out keeps 99 bodies from
+running — unless a cell prop carries a fresh closure, in which case nothing
+bails and write amplification is 100. At this size the screen can still pass
+the frame budget, narrowly. The *shape* is still wrong: it converts grid size
+into per-keystroke cost. Coarse reads are for cheap mount and bulk replacement.
+They are the wrong topology for a surface that changes 100 times a minute, one
+cell at a time.
 
 The last cost item is **event volume**: controlled means one dispatch per
-keystroke per cell. That is the cost of the contract, and the walk above
-shows why the cost is affordable. When no consumer needs the intermediate
-values (a search box that feeds a debounced query), do not pay the cost:
-leave the input uncontrolled and commit on blur
+keystroke per cell. That is the cost of the contract, and the walk above shows
+why it is affordable. When no consumer needs the intermediate values (a search
+box that feeds a debounced query), do not pay the cost: leave the input
+uncontrolled and commit on blur
 ([Controlled inputs](04-controlled-inputs.md)). When something must react to
-the value more slowly, debounce the *consumers* of the committed value. A
-debounced write path drops characters, so never debounce the write path
-itself.
+the value more slowly, debounce the *consumers* of the committed value. Never
+debounce the write path itself — that drops characters.
 
 ## Troubleshooting
 
-| Symptom | What went wrong | Fix |
-|---|---|---|
+| Symptom | Cause | Fix |
+| --- | --- | --- |
 | "The app feels slow" and nothing else | No reproduction, so nothing is attributable | Script one named interaction; run the loop from step 1 |
 | One keystroke or event runs hundreds of bodies | Read topology — a value read too high, or a coarse read on a narrow-update surface | Rung 2: [Lists and collections](06-lists-and-collections.md) |
 | Characters drop under fast typing | Something async sits between keystroke and commit — a debounced write, a queued effect | Keep the controlled write synchronous; debounce consumers of the value |
-| An island shipped and the interaction is no faster | The pressure owner was misattributed — usually reads or event volume, not [lowering](glossary.md#lowering) | Re-attribute with Xray; remove the island if it fails the benefit rule |
+| An island shipped and the interaction is no faster | Pressure owner was misattributed — usually reads or event volume, not lowering | Re-attribute with Xray; remove the island if it fails the benefit rule |
 | Fast on your machine, budget missed in the field | Dev build, fast hardware, best-run numbers | Production build, mid-tier hardware, p95 across runs |
 | Heap grows across leave-and-return cycles | An escape acquires without a paired release | Pair acquire/teardown at the host ([Interop](09-interop.md)); prove it with `assert-clean!` ([Testing](14-testing.md)) |
-| An escape clears no threshold but "feels safer to keep" | The benefit rule read backwards — escapes are a cost held against a measured gain | Remove the escape; that is the rule working correctly |
+| An escape clears no threshold but "feels safer to keep" | Benefit rule read backwards — escapes are a cost held against a measured gain | Remove the escape |
 | Still slow after going native | Wrong layer — the work moved but the owner did not | Return to step 2; the advisor classifies where the time goes |
 
 ## When not to optimise
 
-- **Without a reproduction.** A feeling, or a fear of the interpreter, is
-  not a named interaction. Check the budgets first; if none is missed, there
-  is no work to do.
+- **Without a reproduction.** A feeling, or a fear of the interpreter, is not
+  a named interaction. Check the budgets first; if none is missed, there is no
+  work to do.
 - **When the real issue is event volume.** A dense controlled surface is a
   dispatch-rate question with its own answers
   ([Controlled inputs](04-controlled-inputs.md)) — no rung fixes it.

--- a/docs/design/hicasso/draft-guide/19-migration-from-reagent.md
+++ b/docs/design/hicasso/draft-guide/19-migration-from-reagent.md
@@ -1,84 +1,76 @@
 # Migration from Reagent
 
-You have a working Reagent codebase, and you want it on [Hicasso](glossary.md#hicasso) without an
-unverified rewrite. This page is the migration path for the view layer:
-components, hiccup dialect, local state, and interop sites. (If the app is
-still on re-frame v1, the events-and-subscriptions half is its own
-migration, done first; this page assumes re-frame2 underneath.)
+You have a working Reagent codebase and want it on
+[Hicasso](glossary.md#hicasso) without an unverified rewrite. This page covers
+the view layer: components, Hiccup dialect, local state, and interop sites. If
+the app is still on re-frame v1, migrate events and subscriptions first. This
+page assumes re-frame2 underneath.
 
-The path is three tools and one rule:
+Three tools, in this order:
 
-1. **The reporter** maps the work. It classifies every foreign crossing —
-   converts mechanically, needs your hands, or will refuse at runtime — and
-   it puts a named class and a recovery sentence on each line.
-2. **[Shadow comparison](glossary.md#shadow-comparison)** (shadow mode) proves that a ported screen behaves identically to the
-   original. It is a dev-only dual mount that live-diffs [canonical DOM](glossary.md#canonical-dom) and
+1. **The reporter** classifies every foreign crossing — converts mechanically,
+   needs a person, or will raise at runtime — and puts a named class and a
+   recovery sentence on each line.
+2. **[Shadow comparison](glossary.md#shadow-comparison)** (also called shadow
+   mode) proves that a ported screen matches the original. It is a dev-only dual
+   mount that diffs [canonical DOM](glossary.md#canonical-dom) and
    [intent](glossary.md#intent) streams.
-3. **The codemod** repairs the `[:>]` props dialect mechanically. It applies
-   only the rewrites that are decidable from the source text, and it is
-   idempotent.
+3. **The codemod** repairs the `[:>]` props dialect where the rewrite is
+   decidable from source text. It is idempotent.
 
-> **Never run the codemod first.** A rewrite that you cannot verify is a
-> change that you accept without proof. Run the reporter, set up the
-> shadow-mode proof, and only then let a tool change your source — with the
-> proof re-run behind it.
+Do not run the codemod first. Verify with the reporter and shadow comparison,
+then let a tool change source with the proof re-run afterward.
 
 ## Step 1 — run the reporter
 
-The migration tool ships with [Hicasso](glossary.md#hicasso). It runs on a bare JVM against any
-Reagent corpus. It never loads your app, and in its default mode it changes
-nothing:
+The migration tool ships with Hicasso. It runs on a bare JVM against any Reagent
+corpus. It does not load your app, and in its default mode it changes nothing:
 
 ```bash
 cd re-frame2/migration/reagent-to-hicasso/codemod
 
-clojure -M:run path/to/your/src/          # the reporter: classify, touch nothing
+clojure -M:run path/to/your/src/          # classify; touch nothing
 clojure -M:run --report out.edn src/      # choose where the report goes
 ```
 
-Why is there a reporter? Reagent *converted* props on the way across a
-`[:>]` crossing — it deep-camelCased nested keys, converted keyword values
-to their string names, wrapped `r/partial`, and read metadata keys. [Hicasso](glossary.md#hicasso)
-does not convert. `[:>]` stays legal, so a migrated site keeps rendering
-while it quietly means something else. The reporter reads every `[:>]` site
-in your tree and puts each site in one of three buckets:
+Reagent *converted* props on the way across a `[:>]` crossing — deep-camelCase
+nested keys, keyword values to string names, `r/partial` wrapping, metadata
+keys. Hicasso does not convert. `[:>]` stays legal, so a migrated site can keep
+rendering while meaning something different. The reporter reads every `[:>]`
+site and puts each in one of three buckets:
 
 | Bucket | Named classes | What it means |
 |---|---|---|
 | Converts mechanically | the six rewrite families W1–W6 (step 4) | The codemod repairs these sites and preserves their behaviour |
-| Needs your hands | `:computed-props`, `:computed-value`, `:computed-nested-key`, `:adapt-def-site`, `:cljc-site`, `:parse-error`, `:event-carrier-goes-live`, `:key-conflict`, `:string-tag-unparseable`, `:normalized-key-collision`, `:css-var-repair`, `:named-ref`, `:amp-key` | Either the source text does not say what crosses, or a rewrite would itself change behaviour. Several classes mark places where Reagent was already broken and where the move *repairs* the behaviour; check that the repaired behaviour is the behaviour you want |
-| Will refuse at runtime | `:intent-needs-a-declaration`, `:dangerous-html`, `:r>-site`, `:f>-site`, `:as-element-island`, `:reagent-api-residue` | Migration blockers — these pages throw (or quietly misrender) under Hicasso until a person decides |
+| Needs your hands | `:computed-props`, `:computed-value`, `:computed-nested-key`, `:adapt-def-site`, `:cljc-site`, `:parse-error`, `:event-carrier-goes-live`, `:key-conflict`, `:string-tag-unparseable`, `:normalized-key-collision`, `:css-var-repair`, `:named-ref`, `:amp-key` | Either the source text does not say what crosses, or a rewrite would change behaviour. Some classes mark places where Reagent was already broken and the move *repairs* behaviour; check that the repaired behaviour is what you want |
+| Will refuse at runtime | `:intent-needs-a-declaration`, `:dangerous-html`, `:r>-site`, `:f>-site`, `:as-element-island`, `:reagent-api-residue` | Migration blockers — these pages raise (or quietly misrender) under Hicasso until a person decides |
 
-**The report is a product, equal to any rewrite.** It is one EDN file with
-deterministic ordering. The tool writes it on a clean run too, and the file
-carries the count of sites left untouched — so "not in the report" is never
-ambiguous. Every entry has the file, line, and column against your input
-file, the source form as text, and a recovery sentence in your vocabulary,
-not an error code. The report also carries each component's *name*, which
-the runtime never can: a `[:>]` refusal at runtime prints the constant
-`"[:>]"`, because the escape has no name of its own.
+Treat the report as the migration plan. It is one EDN file with deterministic
+ordering. The tool writes it on a clean run too, and the file includes the count
+of sites left untouched — so "not in the report" is never ambiguous. Every entry
+has file, line, and column against your input, the source form as text, and a
+recovery sentence. The report also carries each component's *name*, which the
+runtime cannot: a `[:>]` refusal at runtime prints the constant `"[:>]"`.
 
-The report ends with a **suggestions block** — candidate [`h/defhost`](glossary.md#defhost)
-declarations with guessed `:callbacks` maps. The block is labelled as
-guesses, because the entries are guesses. Fluent's `onRenderCell` and Ant's
-`onRow` are event-*spelled* render props whose return value the caller
-reads: when you paste an `:event` contract onto one, your cell renderer goes
-blank, and the runtime throws nothing. You choose every contract. The tool
-never synthesizes one, and no flag makes it synthesize one.
+The report ends with a **suggestions block** — candidate
+[`h/defhost`](glossary.md#defhost) declarations with guessed `:callbacks` maps.
+The block is labelled as guesses. Fluent's `onRenderCell` and Ant's `onRow` are
+event-*spelled* render props whose return value the caller reads: pasting an
+`:event` contract onto one blanks the cell renderer, and the runtime raises
+nothing. You choose every contract. The tool never synthesizes one.
 
 Read the report before you write any code. It tells you which screens are
-mechanical, which screens need decisions, and which pages throw in a branch
-that your smoke test never reaches.
+mechanical, which need decisions, and which pages raise on a branch that smoke
+tests never reach.
 
 ## Step 2 — port a screen by hand
 
-Migrate screen by screen, not file type by file type. The port itself is
-mostly deletion — closures become data, and state machinery becomes
-addresses:
+Migrate screen by screen, not file type by file type. Much of the port is
+deletion — closures become data, and state machinery becomes addresses:
 
 | Reagent habit | [Hicasso](glossary.md#hicasso) |
 |---|---|
-| `defn` component returning hiccup | [`h/defview`](glossary.md#defview) — a [boundary](glossary.md#boundary), used as a head |
+| `defn` component returning Hiccup | [`h/defview`](glossary.md#defview) — a re-render [boundary](glossary.md#boundary), used as a head |
 | `@(rf/subscribe [:q])` in the body | `(h/sub [:q])` — legal in branches, loops, and helpers |
 | `#(rf/dispatch [:x])` handlers | the event vector itself; [`h/event`](glossary.md#hevent) when the callback's arguments matter |
 | `r/atom` in a form-2 closure | a forms-module draft or an explicit app-db address — there is no local-state tier |
@@ -91,22 +83,21 @@ addresses:
 | `r/as-element` in a render prop | [`h/as-element`](glossary.md#as-element), at a declared `:render` position |
 | `r/reactify-component` | [`h/as-component`](glossary.md#outward-bridge) — the [outward bridge](glossary.md#outward-bridge) |
 
-Two of these ports fail loudly instead of silently, and the loud failure
-helps you. A Reagent-style `#(rf/dispatch …)` closure still *runs* when the
-library or the DOM calls it, but the bare ambient dispatch inside it raises
-`:rf.error/no-frame-context` at the call — the recovery names the
-event-vector and [`h/event`](glossary.md#hevent) spellings. An [intent](glossary.md#intent) vector at an undeclared
-`[:>]` prop refuses at render instead of crossing as an inert array. The
-inert array is what Reagent silently did, and the handler never fired there
-either.
+Two of these ports fail loudly, which helps. A Reagent-style
+`#(rf/dispatch …)` closure still *runs* when the library or DOM calls it, but
+the bare ambient dispatch inside it raises `:rf.error/no-frame-context` — the
+recovery names the event-vector and [`h/event`](glossary.md#hevent) spellings.
+An [intent](glossary.md#intent) vector at an undeclared `[:>]` prop raises at
+render instead of crossing as an inert array. The inert array is what Reagent
+did, and the handler never fired there either.
 
 ## Step 3 — prove it with shadow comparison
 
-A port that "looks right" is a guess. [Shadow comparison](glossary.md#shadow-comparison)
-is the proof: mount the
-Reagent original and the [Hicasso](glossary.md#hicasso) port together, against isolated copies of
-the same seeded frame; drive both with one script; diff the [canonical DOM](glossary.md#canonical-dom)
-plus the [intent](glossary.md#intent) streams at every checkpoint.
+A port that "looks right" is not proof. [Shadow comparison](glossary.md#shadow-comparison)
+mounts the Reagent original and the Hicasso port together against isolated
+copies of the same seeded frame; drives both with one script; and diffs the
+[canonical DOM](glossary.md#canonical-dom) plus the [intent](glossary.md#intent)
+streams at every checkpoint.
 
 ```clojure
 (ns app.migration.article-row-shadow
@@ -123,42 +114,37 @@ plus the [intent](glossary.md#intent) streams at every checkpoint.
 ;; => {:status :green :checkpoints 4}
 ```
 
-Each side gets its own copy of the seeded frame, so writes never cross, and
-a divergence *compounds* instead of hiding: when the port dispatches a
-different [intent](glossary.md#intent) at step one, its state — and therefore its DOM — drifts
-further at every later step. At each checkpoint the harness compares the
-[canonical DOM](glossary.md#canonical-dom) of both mounts and the intents that each side's handlers
-dispatched. A red names the checkpoint and the exact node or intent that
-differed. When the harness can attribute a difference to a *declared* policy
-— a Client-only crossing region, a named refusal — it reports the difference
-as that classification, not as bare drift.
+Each side gets its own copy of the seeded frame, so writes never cross, and a
+divergence compounds: when the port dispatches a different intent at step one,
+its state — and therefore its DOM — drifts further at every later step. At each
+checkpoint the harness compares the canonical DOM of both mounts and the intents
+that each side's handlers dispatched. A red names the checkpoint and the exact
+node or intent that differed. When the harness can attribute a difference to a
+*declared* policy — a Client-only crossing region, a named refusal — it reports
+that classification, not bare drift.
 
-**Green means behaviourally identical over the flows that the script
-drives.** Script the screen's real flows, not one click. Trust the
-comparator only after you have watched it fail: flip one prop in the port,
-and confirm that the run goes red at the correct node. The harness's own
-quality gates hold it to that standard, and the check is a good habit
-anyway.
+**Green means behaviourally identical over the flows the script drives.** Script
+the screen's real flows, not one click. Trust the comparator only after you have
+watched it fail: flip one prop in the port and confirm the run goes red at the
+correct node.
 
-Omit `:script`, and the dual mount stays up in your dev build: you drive the
-app by hand, and every committed render is a checkpoint, live-diffed. That
-is the mode for exploratory porting — leave the shadow mounted while you
-work, and watch divergence appear as you type.
+Omit `:script`, and the dual mount stays up in your dev build: you drive the app
+by hand, and every committed render is a checkpoint, live-diffed. That mode suits
+exploratory porting — leave the shadow mounted while you work.
 
-Shadow mode is dev-only. The harness, the dual mount, and the Reagent
-dependency itself are development scope; on the day the last shadow goes
-green, Reagent leaves your `deps.edn`. The scope is also limited, and the
-limit is stated: shadow mode compares [canonical DOM](glossary.md#canonical-dom) and intent streams, not
-focus, caret, IME, or paint. Those are browser laws, and the browser tier of
-[Testing](14-testing.md) owns them.
+Shadow comparison is dev-only. The harness, the dual mount, and the Reagent
+dependency itself are development scope; when the last shadow goes green, Reagent
+leaves your `deps.edn`. The scope is limited: shadow comparison compares
+canonical DOM and intent streams, not focus, caret, IME, or paint. Those are
+browser facts; the browser tier of [Testing](14-testing.md) covers them.
 
-When the shadow is green, delete the original. Two copies of one screen are
-two chances to disagree.
+When the shadow is green, delete the original. Two copies of one screen can
+diverge.
 
 ## Step 4 — run the codemod
 
-With the report read and the proof in place, let the tool repair the
-mechanical dialect:
+With the report read and the proof in place, let the tool repair the mechanical
+dialect:
 
 ```bash
 # from the tool directory, as in step 1
@@ -167,86 +153,82 @@ clojure -M:run --rewrite --write src/     # apply it
 ```
 
 The codemod writes whole files through a lossless parser, so formatting,
-comments, and line endings survive — a CRLF file comes back CRLF. Exit is
-`0` for any run that completed: a migration tool that fails your build over
-a decision that only you can make is a tool that you run once. There are six
-rewrite families:
+comments, and line endings survive — a CRLF file comes back CRLF. Exit is `0`
+for any run that completed: a migration tool that fails your build over a
+decision only you can make is a tool you run once. There are six rewrite
+families:
 
 | | At | Written | Preserving |
 |---|---|---|---|
-| W1 | `^{:key k}` on the vector | `:key k` inside the props map | Reagent read the metadata key; [Hicasso](glossary.md#hicasso) reads `(:key props)` — left alone the key goes dead |
+| W1 | `^{:key k}` on the vector | `:key k` inside the props map | Reagent read the metadata key; Hicasso reads `(:key props)` — left alone the key goes dead |
 | W2 | a literal map reached from the props map through map values | the same map, its literal keys respelled camelCase | Reagent deep-camelCased nested keys; Hicasso does not |
 | W3 | a literal keyword, or a quoted symbol, at a prop value | its `name`, as a string | Reagent's `(name x)` arm — a namespaced keyword loses its namespace here, exactly as it already did |
 | W4 | a literal `(r/partial f a …)` at a prop value | a hygienic `let` capture, then Reagent's own wrapper | Reagent evaluated the callee and arguments **once**, at construction — the `let` keeps that |
 | W5 | `[(r/adapt-react-class X) …]` | `[:> X …]` | the same native-element path, spelled the way Hicasso accepts |
 | W6 | `[:> "tag" …]` with a plain tag string | `[:tag …]` | Reagent's input wrapper becomes the [controlled door](04-controlled-inputs.md) |
 
-Two laws govern every rewrite. A rewrite fires only where both sides'
-behaviour is computable from the source text and differs. No rewrite
-introduces a function whose return differs from what Reagent's conversion
-produced. A prop's *spelling* can only make the tool do less — an
-event-spelled name is a reason to skip or to refuse, never a reason to wrap
-— and that is what keeps the tool from silently blanking a render prop. The
-tool refuses everything else into the report, because **silent behaviour
-change is the only fatal class**: a refused site still works, and the report
-line turns the refusal from silence into an instruction.
+Two rules govern every rewrite. A rewrite fires only where both sides' behaviour
+is computable from the source text and differs. No rewrite introduces a function
+whose return differs from what Reagent's conversion produced. A prop's
+*spelling* can only make the tool do less — an event-spelled name is a reason to
+skip or to refuse, never a reason to wrap — and that keeps the tool from
+blanking a render prop. The tool refuses everything else into the report:
+silent behaviour change is the failure mode to avoid. A refused site still
+works, and the report line turns the refusal into an instruction.
 
 Every output is outside its own rewrite's input language, so a second run
-changes nothing — byte for byte, in both line-ending conventions. Then
-re-run the shadow on the screens that the diff touched. That is the point of
-the sequence: the codemod's diff lands with a behavioural proof already
-standing behind it.
+changes nothing — byte for byte, in both line-ending conventions. Then re-run
+shadow comparison on the screens the diff touched.
 
 ## What stays manual, and why
 
-- **Every [`h/defhost`](glossary.md#defhost) declaration and every `:callbacks` contract.** A
-  contract states what a prop *means*, and the meaning is not in your source
-  text — it is in the library's documentation. The suggestions block drafts
+- **Every [`h/defhost`](glossary.md#defhost) declaration and every `:callbacks`
+  contract.** A contract states what a prop *means*, and the meaning is in the
+  library's documentation, not your source text. The suggestions block drafts
   the declaration; you approve it.
 - **The blockers.** An [intent](glossary.md#intent) vector at a `[:>]` prop
   (`:intent-needs-a-declaration`) needs a decision about what it was for.
-  `dangerouslySetInnerHTML` (`:dangerous-html`) needs a deliberate yes:
-  Reagent deleted it unless wrapped, [Hicasso](glossary.md#hicasso) passes it through, so the
-  migration turns a dead prop into a live one. Port `[:r> …]` and `[:f> …]`
-  sites by hand — Hicasso reads those as tag keywords and quietly renders an
-  unknown element. Restructure `r/as-element` inside a callback
-  (`:as-element-island`) by hand: that closure runs outside the owner's
-  render window, so its [lowering](glossary.md#lowering) is not a text substitution.
+  `dangerouslySetInnerHTML` (`:dangerous-html`) needs an explicit yes: Reagent
+  deleted it unless wrapped, Hicasso passes it through, so the migration turns a
+  dead prop into a live one. Port `[:r> …]` and `[:f> …]` sites by hand —
+  Hicasso reads those as tag keywords and quietly renders an unknown element.
+  Restructure `r/as-element` inside a callback (`:as-element-island`) by hand:
+  that closure runs outside the owner's render window, so its
+  [lowering](glossary.md#lowering) is not a text substitution.
 - **Local state and lifecycle** (`:reagent-api-residue`): `r/atom`, cursors,
   form-2/form-3 shapes. Where a piece of state lives is a design decision —
-  [Ephemeral state](11-ephemeral-state.md) owns the homes — and no tool
-  makes that decision for you.
+  [Ephemeral state](11-ephemeral-state.md) covers the homes — and no tool makes
+  that decision for you.
 - **Everything computed.** Props built by `merge`, values reached through a
-  symbol, keys computed at runtime: the source text does not say what
-  crosses, so the tool reports instead of guessing.
+  symbol, keys computed at runtime: the source text does not say what crosses,
+  so the tool reports instead of guessing.
 
 ## Troubleshooting
 
-| Symptom | What is happening | Fix |
+| Symptom | Cause | Fix |
 |---|---|---|
-| A `[:>]` site renders but behaves subtly differently than under Reagent | Props dialect drift — Reagent converted on the way across; [Hicasso](glossary.md#hicasso) does not | Run the reporter; let the codemod repair the decidable sites |
-| A page throws at render at a `[:>]` site that "worked" before | `:rf.error/hicasso-host-undeclared-callback` — an [intent](glossary.md#intent) vector at an escape prop; under Reagent it crossed as an inert array and never fired | Declare the host and name the prop in `:callbacks`, or hand a plain function — and decide what the dead handler was for |
+| A `[:>]` site renders but behaves differently than under Reagent | Props dialect drift — Reagent converted on the way across; Hicasso does not | Run the reporter; let the codemod repair the decidable sites |
+| A page raises at render at a `[:>]` site that "worked" before | `:rf.error/hicasso-host-undeclared-callback` — an [intent](glossary.md#intent) vector at an escape prop; under Reagent it crossed as an inert array and never fired | Declare the host and name the prop in `:callbacks`, or hand a plain function — and decide what the dead handler was for |
 | A handler runs, then `:rf.error/no-frame-context` | A Reagent-style `#(rf/dispatch …)` closure — it carries no frame | Make it an event vector, or [`h/event`](glossary.md#hevent) |
 | A keyed list remounts once right after migration | The `:key` slot is reported, never rewritten: `:foo` and `"foo"` keys collided under Reagent and are distinct now, so the key value changes once | Accept the one-time remount; keys are stable after |
 | The codemod refused a whole nested map | `:normalized-key-collision` — sibling keys like `:foo-bar`/`:fooBar` collapsed onto one JS property under Reagent, with an iteration-order winner | Delete the key you did not mean; re-run |
 | A W2 diff camelCased keys in what is clearly a *data* map | Behaviour preserved: Reagent already sent the library camelCase | Do **not** revert the keys — a revert changes what the library receives. If the map was data, notice it now |
-| Shadow run red on a region the port renders client-only | A declared Client-only crossing, classified as a policy difference, not drift | Choose the [server policy](glossary.md#server-policy) deliberately (`{:server :render}` or a fallback) or accept the classification |
-| Shadow green, but focus/IME behaves differently in a real browser | Shadow compares [canonical DOM](glossary.md#canonical-dom) and intents; browser laws are out of its scope | Run the browser tier ([Testing](14-testing.md)) |
+| Shadow run red on a region the port renders client-only | A declared Client-only crossing, classified as a policy difference, not drift | Choose the [server policy](glossary.md#server-policy) (`{:server :render}` or a fallback) or accept the classification |
+| Shadow green, but focus/IME behaves differently in a real browser | Shadow comparison covers canonical DOM and intents; browser laws are out of its scope | Run the browser tier ([Testing](14-testing.md)) |
 | Second codemod run produced a diff | It cannot — outputs are outside the input language. If files changed, something else edited them between runs | Diff against the report's coordinates; re-run the reporter |
 
 ## When not to migrate this way
 
-- **A small app.** Below a handful of screens, the reporter plus a hand port
-  is the whole job; shadow scripts cost more than reading the diff. Keep the
+- **A small app.** Below a handful of screens, the reporter plus a hand port is
+  the whole job; shadow scripts cost more than reading the diff. Keep the
   reporter — it costs nothing — and skip the harness.
 - **A React-first screen.** Do not convert a screen that is mostly vendor
-  components and hooks to hiccup on principle: port it to a named native
-  island, or keep it UIx, under the same root and frame
+  components and hooks to Hiccup on principle: port it to a named native island,
+  or keep it UIx, under the same root and frame
   ([Native tier](10-native-tier.md)).
-- **A screen that you plan to redesign.** Shadow mode proves behavioural
-  *identity*; when a planned redesign discards the behaviour, port the
-  screen loosely, and spend the proof budget on screens that must not
-  change.
+- **A screen that you plan to redesign.** Shadow comparison proves behavioural
+  *identity*; when a planned redesign discards the behaviour, port the screen
+  loosely, and spend the proof budget on screens that must not change.
 
 ## Advanced
 
@@ -264,17 +246,17 @@ standing behind it.
           except at HTML-attribute slots."}
 ```
 
-Coordinates address the *input* file for the scan and for the rewrite, so a
-line in the report is the line that you grep for in either mode.
+Coordinates address the *input* file for the scan and for the rewrite, so a line
+in the report is the line that you grep for in either mode.
 
 ### Why W4 writes a `let`
 
 The obvious rewrite of `(r/partial f @snapshot)` is a bare
-`(fn [& args] (apply f @snapshot args))`, and that rewrite is wrong.
-`r/partial` evaluated its callee and its arguments **once**, when the prop
-was built. The bare `fn` re-evaluates them on every call, so `@snapshot`
-stops being a snapshot, and `(next-id!)` mints a fresh id on every click.
-The codemod writes a `let` that captures once:
+`(fn [& args] (apply f @snapshot args))`, and that rewrite is wrong. `r/partial`
+evaluated its callee and its arguments **once**, when the prop was built. The
+bare `fn` re-evaluates them on every call, so `@snapshot` stops being a
+snapshot, and `(next-id!)` allocates a fresh id on every click. The codemod
+writes a `let` that captures once:
 
 ```clojure
 [:> Btn {:on-pick (r/partial handler @cart)}]
@@ -284,20 +266,18 @@ The codemod writes a `let` that captures once:
 ```
 
 The names are deterministic, not gensym'd, so what lands in your diff is
-readable. The tool checks the names against every symbol that the site
-spells, and a collision bumps the whole family (`f__rf2__1`, …) until the
-names are fresh.
+readable. The tool checks the names against every symbol that the site spells,
+and a collision bumps the whole family (`f__rf2__1`, …) until the names are
+fresh.
 
-### Divergences the tool deliberately leaves alone
+### Divergences the tool leaves alone
 
-These divergences are named so that you do not file them as gaps. Each is a
-place where [Hicasso](glossary.md#hicasso) is better than the donor, or where the difference is
-invisible:
+These divergences are named so you do not file them as gaps. Each is a place
+where Hicasso differs from the donor in a way that is better, or invisible:
 
-- Class collections in any spelling now coerce and compose (Reagent read
-  only the literal `:class` key).
+- Class collections in any spelling now coerce and compose (Reagent read only
+  the literal `:class` key).
 - Nested class collections flatten.
-- Hicasso drops `__proto__`/`prototype`/`constructor` instead of writing
-  them.
-- A literal `nil` at the props slot counts as a child, and React renders
-  nothing for it.
+- Hicasso drops `__proto__`/`prototype`/`constructor` instead of writing them.
+- A literal `nil` at the props slot counts as a child, and React renders nothing
+  for it.

--- a/docs/design/hicasso/draft-guide/20-code-splitting.md
+++ b/docs/design/hicasso/draft-guide/20-code-splitting.md
@@ -1,22 +1,18 @@
 # Code splitting and lazy loading
 
-Your admin area is a third of the bundle, and most sessions never open it.
-This page splits the build so that code loads when it is first wanted. It
-covers three things:
+Your admin area is a large part of the bundle, and most sessions never open it.
+This page splits the build so that code loads when it is first wanted. It covers
+three things:
 
-- the route-and-module **grain**, which covers almost every real split;
+- the **route/module grain**, which covers almost every real split;
 - the `React.lazy` bridge for [native islands](glossary.md#native-island);
-- what Suspense and Activity do to your reads while a subtree waits or
-  hides.
-
-> **Split at the route grain. Load the module as an effect. Render the
-> arrival as state.**
+- what Suspense and Activity do to your reads while a subtree waits or hides.
 
 ## The route/module grain
 
-The default answer needs no React machinery at all. shadow-cljs compiles the
-area into its own module. The load is an ordinary effect, and "has it
-arrived?" is app-db state that your shell renders like any other fact.
+The default answer needs no React machinery. shadow-cljs compiles the area into
+its own module. The load is an ordinary effect, and "has it arrived?" is app-db
+state that your shell renders like any other fact.
 
 ```clojure
 ;; shadow-cljs.edn — the admin area becomes its own module
@@ -24,7 +20,7 @@ arrived?" is app-db state that your shell renders like any other fact.
            :admin {:entries [app.admin] :depends-on #{:main}}}}
 ```
 
-One gate namespace owns the loadable, the effect, and the events:
+One gate namespace holds the loadable, the effect, and the events:
 
 ```clojure
 (ns app.admin-gate
@@ -60,45 +56,46 @@ One gate namespace owns the loadable, the effect, and the events:
   (fn [{:keys [db]} _] {:db (assoc-in db [:modules :admin] :failed)}))
 ```
 
-Wire the load to the route — `:on-match` dispatches when the route activates
-— and render the arrival as the state that it is:
+Wire the load to the route — `:on-match` dispatches when the route activates —
+and render the arrival as state:
 
 ```clojure
 (rf/reg-route :app/admin {:on-match [[:admin/wanted]]} "/admin")
 
 (h/defview admin-entry [_]
   (case (h/sub [:modules/admin])
-    :loaded  [@admin-screen {}]     ;; the loadable derefs to the minted view
+    :loaded  [@admin-screen {}]     ;; the loadable derefs to the view
     :failed  [:div.load-failed
               [:p "Couldn't load this area."]
               [:button {:on-click [:admin/wanted]} "Try again"]]
     [:div.screen-skeleton {:aria-busy true}]))
 ```
 
-Every piece is machinery that you already know. The pending placeholder is a
-branch, not a Suspense fallback. The failure is a value with a retry [intent](glossary.md#intent),
-not an exception. The loaded screen is an ordinary view head — after the
-load, `@admin-screen` is the [`h/defview`](glossary.md#defview)-minted view, with its [boundary](glossary.md#boundary),
-reads, and name intact. The `:loading`/`:loaded` check is the dedupe, so
-navigation away and back never double-loads.
+Every piece is machinery you already know. The pending placeholder is a branch,
+not a Suspense fallback. The failure is a value with a retry
+[intent](glossary.md#intent), not an exception. After the load, `@admin-screen`
+is the [`h/defview`](glossary.md#defview) view — still a re-render
+[boundary](glossary.md#boundary), with its reads and name intact. The
+`:loading`/`:loaded` check is the dedupe, so navigation away and back never
+double-loads.
 
-Two conducts come free with this shape. Warming works the same way as data
-prefetch: dispatch `[:admin/wanted]` from a nav link's hover intent, and the
-module downloads before the click. Hot reload is undisturbed — a loaded
-module's namespaces reload like any others, and an unloaded module has
-nothing to reload.
+Warming works the same way as data prefetch: dispatch `[:admin/wanted]` from a
+nav link's hover intent, and the module downloads before the click. Hot reload is
+undisturbed — a loaded module's namespaces reload like any others, and an
+unloaded module has nothing to reload.
 
 ## The React bridge: `n/lazy` and a Suspense host
 
-A [native island](glossary.md#native-island) or a React-shaped screen can instead load through React's
-own lazy machinery. That is the correct choice when the region already lives
-on the [native tier](glossary.md#native-tier) and you want React to own the pending swap. The bridge is
-[`n/lazy`](glossary.md#nlazy), the ABI helper from [the native tier](10-native-tier.md). It has
-the same thunk-returning-a-promise contract as `React.lazy`, and it resolves
-to the component. It keeps the component marker, so Xray still names the
-[boundary](glossary.md#boundary) and the embedding seams still recognize the head. What it does
-not do is carry the component across a hot reload, and it is not meant to:
-minting a component is allocation, never a lookup by name, so a save
+A [native island](glossary.md#native-island) or a React-shaped screen can instead
+load through React's own lazy machinery. That is the right choice when the region
+already lives on the [native tier](glossary.md#native-tier) and you want React to
+own the pending swap. The bridge is [`n/lazy`](glossary.md#nlazy), the ABI helper
+from [the native tier](10-native-tier.md). It has the same
+thunk-returning-a-promise contract as `React.lazy`, and it resolves to the
+component. It keeps the component marker, so Xray still names the
+[boundary](glossary.md#boundary) and embedding checks still recognize the head.
+What it does not do is carry the component across a hot reload, and it is not
+meant to: creating a component is allocation, never a lookup by name, so a save
 re-evaluates the module, allocates a fresh component, and React replaces the
 subtree. A clean remount across a save is the designed conduct, not a fault.
 
@@ -128,45 +125,43 @@ subtree. A clean remount across a save is the designed conduct, not a fault.
     [chart-host {:points (h/sub [:metrics/series])}]]])
 ```
 
-While the code loads, React shows the Suspense fallback — hiccup in a
-declared slot, like any other ([Interop](09-interop.md)). A loader rejection
-throws into the render, so the nearest [`h/error-boundary`](glossary.md#error-boundary) catches it, and
-the `:reset-key` counter is the retry, exactly as in [Errors](16-errors.md)
-— the next attempt re-runs the loader.
+While the code loads, React shows the Suspense fallback — Hiccup in a declared
+slot, like any other ([Interop](09-interop.md)). A loader rejection throws into
+the render, so the nearest [`h/error-boundary`](glossary.md#error-boundary)
+catches it, and the `:reset-key` counter is the retry, as in
+[Errors](16-errors.md) — the next attempt re-runs the loader.
 
 !!! warning "Declare lazy components outside render"
-    [`n/lazy`](glossary.md#nlazy) (like `React.lazy`) mints a component identity. When the mint
-    happens inside a body, every render mints a fresh identity, so React
-    unmounts and remounts the subtree — and re-triggers the load — each time
-    the body runs. Both declarations above are top-level `def`s; keep yours
-    at top level too.
+    [`n/lazy`](glossary.md#nlazy) (like `React.lazy`) creates a component
+    identity. When that creation happens inside a body, every render creates a
+    fresh identity, so React unmounts and remounts the subtree — and re-triggers
+    the load — each time the body runs. Both declarations above are top-level
+    `def`s; keep yours at top level too.
 
-Under SSR, the lazy region is a Client-only surface. The server bytes carry
-the deterministic fallback, and adoption mounts the live component when its
-code arrives. The runtime makes no hydration claim for bytes that the server
-never sent ([SSR and hydration](17-ssr-and-hydration.md)).
+Under SSR, the lazy region is a Client-only surface. The server bytes carry the
+deterministic fallback, and adoption mounts the live component when its code
+arrives. The runtime makes no hydration claim for bytes the server never sent
+([SSR and hydration](17-ssr-and-hydration.md)).
 
 ## While a subtree waits, or hides
 
-Both mechanisms on this page hand a subtree's lifecycle to React. The read
-law holds through both, because commit owns acquisition
+Both mechanisms on this page hand a subtree's lifecycle to React. The read law
+holds through both, because commit owns acquisition
 ([Views and reads](02-views-and-reads.md), [Async resources](08-async-resources.md)):
 
 - **A suspended attempt owns nothing.** Render probes reads; commit installs
-  them. An attempt that React parks on a fallback has committed nothing, so
-  it holds no subscriptions and no resource demand. When the code arrives,
-  the real render commits, and it acquires at that point — once.
-- **Suspense here is for code arrival, not for data.** Do not wire
-  subscriptions to promises to suspend on your app's data. re-frame2 state
-  reaches React as an external store, and React documents that an
-  external-store update can replace visible content with the fallback. Data
-  pending is explicit state — the five-status resource projection and
-  `:keep-previous?` already render it better
+  them. An attempt that React parks on a fallback has committed nothing, so it
+  holds no subscriptions and no resource demand. When the code arrives, the real
+  render commits, and it acquires at that point — once.
+- **Suspense here is for code arrival, not for data.** Do not wire subscriptions
+  to promises to suspend on your app's data. re-frame2 state reaches React as an
+  external store, and React documents that an external-store update can replace
+  visible content with the fallback. Data pending is explicit state — the
+  five-status resource projection and `:keep-previous?` already render it
   ([Async resources](08-async-resources.md)).
-- **Activity hide releases; reveal reacquires.** Some panes must keep their
-  UI state while hidden — scroll position, half-built form widgets. For
-  those panes, host React's `Activity` like any wrapper, and drive `:mode`
-  from state:
+- **Activity hide releases; reveal reacquires.** Some panes must keep their UI
+  state while hidden — scroll position, half-built form widgets. For those panes,
+  host React's `Activity` like any wrapper, and drive `:mode` from state:
 
   ```clojure
   (h/defhost activity react/Activity)
@@ -175,48 +170,47 @@ law holds through both, because commit owns acquisition
    [inbox-pane {}]]
   ```
 
-  While the pane is hidden, React cleans up effects, and the subtree's
-  committed subscription ownership releases. Demand rides the same
-  membership, so a hidden pane's demand-driven resources release too. App-db
-  state is untouched: the pane's addresses keep their values. On reveal, the
-  current read set reacquires. Xray reports hidden-retained work as its own
-  honest label, and does not collapse it into mounted or unmounted
-  ([Diagnostics](15-diagnostics.md)).
+  While the pane is hidden, React cleans up effects, and the subtree's committed
+  subscription ownership releases. Demand rides the same membership, so a hidden
+  pane's demand-driven resources release too. App-db state is untouched: the
+  pane's addresses keep their values. On reveal, the current read set
+  reacquires. Xray reports hidden-retained work as its own label, and does not
+  collapse it into mounted or unmounted ([Diagnostics](15-diagnostics.md)).
 
-- **When the reveal is a click, it is already correct.** A hidden pane holds
-  no subscription, so writes that land while it is hidden do not reach it —
-  the pane comes back holding whatever it last rendered, and something has
-  to correct it. When the reveal is flushed inside the event that caused it,
-  which is what a user clicking a tab gets, React re-renders the retained
-  subtree as part of revealing it and reads the store during that render.
-  The pane is correct before it is on screen.
+- **When the reveal is a click, it is already correct.** A hidden pane holds no
+  subscription, so writes that land while it is hidden do not reach it — the pane
+  comes back holding whatever it last rendered, and something has to correct it.
+  When the reveal is flushed inside the event that caused it, which is what a
+  user clicking a tab gets, React re-renders the retained subtree as part of
+  revealing it and reads the store during that render. The pane is correct before
+  it is on screen.
 
-- **A reveal you schedule can show one stale frame.** Flip `:mode` from a
-  timer, a promise, or a transition and React reveals the retained subtree
-  without re-rendering it: the only signal that state moved arrives when
-  React re-subscribes, and it re-subscribes in an effect that React flushes
-  in a later task. A frame can be painted in between, showing the value the
-  pane last rendered. It is one frame, measured, and gated so it cannot
-  quietly widen. It is also never a *torn* frame — what you see is a real
-  earlier state of that pane, whole, not a mixture of two.
+- **A reveal you schedule can show one stale frame.** Flip `:mode` from a timer,
+  a promise, or a transition and React reveals the retained subtree without
+  re-rendering it: the only signal that state moved arrives when React
+  re-subscribes, and it re-subscribes in an effect that React flushes in a later
+  task. A frame can be painted in between, showing the value the pane last
+  rendered. It is one frame, measured, and gated so it cannot quietly widen. It
+  is also never a *torn* frame — what you see is a real earlier state of that
+  pane, whole, not a mixture of two.
 
-  So do not hide a pane whose content must never be a moment out of date.
-  **On an account or tenant switch, unmount or re-key the pane rather than
-  retaining it** — a consistent old commit is still the previous account's
-  numbers, and Activity retention is a state-preservation feature, not a
-  disclosure boundary. Where retention is genuinely wanted, drive `:mode`
-  from the discrete event itself rather than from a timer that fires later.
+  So do not hide a pane whose content must never be a moment out of date. **On
+  an account or tenant switch, unmount or re-key the pane rather than retaining
+  it** — a consistent old commit is still the previous account's numbers, and
+  Activity retention preserves UI state; it is not a disclosure boundary. Where
+  retention is genuinely wanted, drive `:mode` from the discrete event itself
+  rather than from a timer that fires later.
 
 ## Troubleshooting
 
-| Symptom | What went wrong | Fix |
+| Symptom | Cause | Fix |
 |---|---|---|
 | Navigation to the split route renders nothing, and then the screen appears after a delay | The shell renders the loaded view unconditionally, so the pre-load render was empty | Branch on the module status; render the skeleton and failed states |
 | The module double-loads on repeated visits | The load event does not consult state | Gate on the status, as `:admin/wanted` does — `:loading`/`:loaded` is the dedupe |
 | Works in `watch`, 404s in a release build | Module config drift — a missing `:depends-on`, or the entry namespace not in the module | Declare the dependency edge; keep one entries list per module |
-| The Suspense fallback flashes on every render of the parent | The lazy component was minted inside a body — fresh identity, fresh mount, fresh load | Declare [`n/lazy`](glossary.md#nlazy) (and the loadable) at top level |
+| The Suspense fallback flashes on every render of the parent | The lazy component was created inside a body — fresh identity, fresh mount, fresh load | Declare [`n/lazy`](glossary.md#nlazy) (and the loadable) at top level |
 | A failed chunk load leaves the skeleton up forever | Nothing catches the loader's rejection | Wrap the Suspense host in [`h/error-boundary`](glossary.md#error-boundary); retry through `:reset-key` |
-| Xray shows an anonymous [boundary](glossary.md#boundary) where a named island should be | Raw `React.lazy` erased the component marker — the display name and the declared server policy went with it | Use [`n/lazy`](glossary.md#nlazy) — same semantics, marker intact ([Native tier](10-native-tier.md)) |
+| Xray shows an anonymous re-render unit where a named island should be | Raw `React.lazy` erased the component marker — the display name and the declared server policy went with it | Use [`n/lazy`](glossary.md#nlazy) — same semantics, marker intact ([Native tier](10-native-tier.md)) |
 | Local state inside a lazily loaded island resets whenever you save | Nothing is wrong. A reload allocates a fresh component, so the element type changes and React remounts the subtree — the designed HMR conduct, and [`defview`](glossary.md#defview)'s too | Nothing to fix. State that must outlive a save belongs in `app-db`, read back through [`n/use-sub`](glossary.md#nuse-sub) |
 | The lazy region is missing from server HTML | Client-only by design — the server carries the fallback, never the un-arrived component | Make the fallback a same-footprint skeleton; the live component mounts after adoption |
 | A hidden pane's state is gone on reveal | The pane was unmounted, not hidden — a `when`, not an Activity `:mode` flip | Hide with `:mode "hidden"` to retain UI state; unmount when you mean gone. App-db state at addresses survives either way |
@@ -224,17 +218,16 @@ law holds through both, because commit owns acquisition
 
 ## When not to split
 
-- **A small bundle.** One module that loads fast is simpler than three
-  modules that each need a loading state. Split when a measured area is big
-  and rarely visited, not on principle.
-- **Below the route or screen grain.** Per-widget chunks multiply pending
-  states and round trips; users already expect a pause at the route,
-  not on every widget.
-- **For data.** Suspense is not your loading UI, and lazy loading is not
-  your fetch layer. Resource status is explicit state with a better
-  vocabulary ([Async resources](08-async-resources.md)).
+- **A small bundle.** One module that loads fast is simpler than three modules
+  that each need a loading state. Split when a measured area is big and rarely
+  visited, not on principle.
+- **Below the route or screen grain.** Per-widget chunks multiply pending states
+  and round trips; users already expect a pause at the route, not on every
+  widget.
+- **For data.** Suspense is not your loading UI, and lazy loading is not your
+  fetch layer. Resource status is explicit state with a better vocabulary
+  ([Async resources](08-async-resources.md)).
 - **Hiding what should unmount.** Activity pays a retention cost to keep UI
-  state alive. A pane whose meaningful state already lives at app-db
-  addresses survives unmount at no cost
-  ([Ephemeral state](11-ephemeral-state.md)) — hide only what is expensive
-  to rebuild, or what the platform owns, like scroll.
+  state alive. A pane whose meaningful state already lives at app-db addresses
+  survives unmount at no cost ([Ephemeral state](11-ephemeral-state.md)) — hide
+  only what is expensive to rebuild, or what the platform owns, like scroll.

--- a/docs/design/hicasso/draft-guide/21-accessibility.md
+++ b/docs/design/hicasso/draft-guide/21-accessibility.md
@@ -1,21 +1,17 @@
 # Accessibility
 
 A screen reader announces "clickable, group" where you meant "Delete, button",
-and Tab skips your busiest control. [Hicasso](glossary.md#hicasso) ships no accessibility subsystem
-to fix that, because the fix is not a subsystem. Semantic Hiccup and native
-controls carry names, roles, and keyboard behaviour on their own. Your job is
-mostly to keep those behaviours in place — and then prove it in tests.
+and Tab skips your busiest control. Hicasso ships no accessibility subsystem,
+because the fix is not a subsystem. Semantic HTML and native controls already
+carry names, roles, and keyboard behaviour. Your job is mostly to keep those
+behaviours in place — and then prove it in tests.
 
-> **The platform does accessibility. Write the element that already means
-> what you mean, name it with ordinary attributes, and test names and roles
-> like any other data.**
+## Semantic HTML first
 
-## Semantic elements first
-
-Semantic elements give you the platform's behaviour at no cost. A `:button`
-is focusable, keyboard-activatable, and announced as a button. A `:div` with
-a click handler is none of those things. Every attribute you then add by
-hand is a copy of one platform behaviour, minus the ones you forgot:
+Semantic elements give you the platform's behaviour at no cost. A `:button` is
+focusable, keyboard-activatable, and announced as a button. A `:div` with a
+click handler is none of those things. Every attribute you then add by hand is a
+copy of one platform behaviour, minus the ones you forgot:
 
 ```clojure
 ;; Don't — a click target only a mouse can find
@@ -25,24 +21,24 @@ hand is a copy of one platform behaviour, minus the ones you forgot:
 [:button.delete {:on-click [:article/delete id]} "Delete"]
 ```
 
-The same trade repeats across the vocabulary:
+The same choice repeats across the vocabulary:
 
-- `:a` for navigation — [`route-link`](glossary.md#route-link) returns a real anchor, so middle-click
-  and copy-link work.
+- `:a` for navigation — [`route-link`](glossary.md#route-link) returns a real
+  anchor, so middle-click and copy-link work.
 - `:label` wrapping its control, or pointing at it with `:for`.
 - `:ul`/`:li` for lists, and `:table` for tabular data.
-- One `:h1`-per-page heading outline.
+- One `:h1` per page in the heading outline.
 - `:main`/`:nav`/`:aside` landmarks, so a reader can jump between regions.
 
-Use ARIA roles only where no element exists — a listbox, a tab strip. Then
-take the whole contract, keyboard included, as
+Use ARIA roles only where no element exists — a listbox, a tab strip. Then take
+the whole contract, keyboard included, as
 [the combobox in Overlays and focus](12-overlays-and-focus.md) does.
 
 ## Names are ordinary attributes
 
-What an element shows visually is usually also its accessible name, with no
-work from you. The gaps are icon-only controls, and controls whose visible
-label lives elsewhere. The fix is data in the attribute map, per instance:
+What an element shows visually is usually also its accessible name, with no work
+from you. The gaps are icon-only controls, and controls whose visible label lives
+elsewhere. The fix is data in the attribute map, per instance:
 
 ```clojure
 [:button {:aria-label "Close" :on-click [:dialog/dismissed id]} "×"]
@@ -55,23 +51,23 @@ label lives elsewhere. The fix is data in the attribute map, per instance:
           :on-input [:signup/set-email id ::h/value]}]]
 ```
 
-Ids that pair elements — `:for`/`:id`, `:aria-labelledby`,
-`:aria-describedby`, `:aria-activedescendant` — are per-instance strings.
-Build them from the same instance key that addresses the state
-([Ephemeral state](11-ephemeral-state.md#choosing-the-address)). Two
-instances that share one id are the accessibility form of two panels that
-share one address, and they break the same way.
+Ids that pair elements — `:for`/`:id`, `:aria-labelledby`, `:aria-describedby`,
+`:aria-activedescendant` — are per-instance strings. Build them from the same
+instance key that addresses the state
+([Ephemeral state](11-ephemeral-state.md#choosing-the-address)). Two instances
+that share one id are the accessibility form of two panels that share one
+address, and they break the same way.
 
 `:aria-*` attributes pass through exactly as written
-([Views and reads](02-views-and-reads.md)), so there is nothing
-Hicasso-specific to learn — including on [`h/defhost`](glossary.md#defhost) crossings, where
+([Views and reads](02-views-and-reads.md)), so there is nothing Hicasso-specific
+to learn — including on [`h/defhost`](glossary.md#defhost) crossings, where
 `aria-*` stays hyphenated.
 
 ## State assistive tech reads is the state you already have
 
 A screen reader's view of your widget — expanded, selected, busy, invalid —
-must track app-db. The cheapest way to keep the two representations aligned
-is to derive both from one read:
+must track app-db. The cheapest way to keep the two representations aligned is
+to derive both from one read:
 
 ```clojure
 (h/defview filter-toggle [{:keys [id]}]
@@ -82,16 +78,15 @@ is to derive both from one read:
      "Filter"]))
 ```
 
-The chapters that own each widget already write this shape:
-`:aria-expanded` and `:aria-activedescendant` on
-[the dropdown](12-overlays-and-focus.md), and `:aria-current "page"` on
-[the active nav link](07-routing-and-navigation.md). `:aria-busy` sits on
-[the fetching suggestion list](08-async-resources.md), and `:inert` plus
-`:aria-hidden` ride [an exiting node](11-ephemeral-state.md). What those
-chapters never do is mirror platform state back into app-db. Focus in
-particular belongs to the platform
-([Ephemeral state](11-ephemeral-state.md)): you express [intent](glossary.md#intent) once, and the
-restore contracts do the rest.
+The pages that own each widget already write this shape: `:aria-expanded` and
+`:aria-activedescendant` on [the dropdown](12-overlays-and-focus.md), and
+`:aria-current "page"` on [the active nav link](07-routing-and-navigation.md).
+`:aria-busy` sits on [the fetching suggestion list](08-async-resources.md), and
+`:inert` plus `:aria-hidden` ride [an exiting node](11-ephemeral-state.md). What
+those pages never do is mirror platform state back into app-db. Focus in
+particular belongs to the platform ([Ephemeral state](11-ephemeral-state.md)):
+you express [intent](glossary.md#intent) once, and the restore contracts do the
+rest.
 
 Error display pairs the message to the field the same way — derived, per
 instance, and announced:
@@ -104,10 +99,10 @@ instance, and announced:
 
 ## Keyboard and focus have owners
 
-Keyboard behaviour is data: the key map, with IME composition handled
-centrally ([Events as data](03-events-as-data.md)). Native controls bring
-their bindings with them. What is left is focus *movement*. Each case
-already has its owner page, and this table is the inventory:
+Keyboard behaviour is data: the key map, with IME composition handled centrally
+([Events as data](03-events-as-data.md)). Native controls bring their bindings
+with them. What is left is focus *movement*. Each case already has its owner
+page; this table is the inventory:
 
 | Moment | Conduct | Owner |
 |---|---|---|
@@ -117,11 +112,11 @@ already has its owner page, and this table is the inventory:
 | Exit animation | `:inert` + `:aria-hidden` ride the unmounting phase | [Ephemeral state](11-ephemeral-state.md) |
 | Virtualized list | The keyboard cannot reach rows that do not exist — decide, then verify in a browser | [Lists and collections](06-lists-and-collections.md) |
 
-## Prove it
+## Prove it in the harness
 
-Names and roles are attributes in the semantic tree, so most accessibility
-claims are L2 data assertions. The harness, the fixtures, and the sabotage
-discipline are the same as everything else in [Testing](14-testing.md):
+Names and roles are attributes in the semantic tree, so most accessibility claims
+are L2 data assertions. The harness, the fixtures, and the sabotage discipline
+are the same as everything else in [Testing](14-testing.md):
 
 ```clojure
 (deftest toggle-announces-its-state
@@ -137,17 +132,17 @@ discipline are the same as everything else in [Testing](14-testing.md):
     (is (false? (:aria-expanded (ht/attrs (ht/find tree #(= :button (:tag %)))))))))
 ```
 
-Data cannot prove focus and traversal: where focus lands after a route
-change, whether Tab is trapped in a [modal](glossary.md#overlay), whether a virtualized grid is
-walkable. Those are engine facts, so they live in the browser tier, next to
-an automated axe pass over each screen's mounted state. The axe run is a
-floor, not the test. It catches missing names and broken pairings, and it
-says nothing about whether the keyboard *order* makes sense. Script that
-walk yourself for the screens where it matters.
+Data cannot prove focus and traversal: where focus lands after a route change,
+whether Tab is trapped in a [modal](glossary.md#overlay), whether a virtualized
+grid is walkable. Those are engine facts, so they live in the browser tier, next
+to an automated axe pass over each screen's mounted state. The axe run is a
+floor, not the test. It catches missing names and broken pairings, and it says
+nothing about whether the keyboard *order* makes sense. Script that walk yourself
+for the screens where it matters.
 
 ## Troubleshooting
 
-| Symptom | What went wrong | Fix |
+| Symptom | Cause | Fix |
 |---|---|---|
 | A control cannot be reached with Tab | It is not a real control — a `:div`/`:span` with a click handler | Use `:button`, `:a`, or the real control; `:tab-index` on a div is the last resort, not the first |
 | An icon button announces nothing, or announces "×" | No accessible name beyond its glyph | `:aria-label` on the control |
@@ -162,12 +157,11 @@ walk yourself for the screens where it matters.
 ## When not to add more
 
 - **Do not restate what the element already says.** `{:role "button"}` on a
-  `:button` and `{:aria-label "Save"}` beside visible "Save" text are noise
-  at best and contradictions at worst. ARIA fills gaps, and the first rule
-  of ARIA is to prefer the element.
+  `:button` and `{:aria-label "Save"}` beside visible "Save" text are noise at
+  best and contradictions at worst. ARIA fills gaps; prefer the element.
 - **Do not mirror focus or hover into app-db** to drive announcements. The
   platform tracks them, and a mirror drifts
   ([Ephemeral state](11-ephemeral-state.md)).
-- **Do not build an announcer service.** A `:role "alert"` region rendered
-  from state covers the occasional live announcement. A general live-region
-  subsystem is machinery built before any caller needs it.
+- **Do not build an announcer service.** A `:role "alert"` region rendered from
+  state covers the occasional live announcement. A general live-region subsystem
+  is machinery before any caller needs it.

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -1,24 +1,22 @@
 # Hicasso — user guide
 
-Hicasso is re-frame2's native view layer: interpreted Hiccup on a modern React
-function-component host. You write vectors and maps, and you read
-subscriptions at the point of use. The runtime converts that data into React
-elements. The app-db, the events, and the pipeline are ordinary re-frame2.
+Hicasso is re-frame2's native view layer: you write Hiccup vectors and maps,
+call subscriptions where you need values, and put event vectors in attributes.
+The runtime turns that data into React elements. App-db, events, and the event
+pipeline stay ordinary re-frame2.
 
 **Prerequisites.** Core re-frame2 — events, app-db, subscriptions, frames.
 Start with [what Hicasso is](01-getting-started.md), then
 [install a first screen](installation.md).
 
 **When not this corpus.** Pure business logic and HTTP without a Hicasso view
-stay in Core / async / resources. A Reagent app still on v1 event shapes
-should finish that migration first, then
-[Migrating from Reagent](19-migration-from-reagent.md). If the product is
+belong in Core, async, or resources. A Reagent app still on re-frame v1 event
+shapes should finish that migration first, then use
+[Migration from Reagent](19-migration-from-reagent.md). If the product is
 React-first (hooks everywhere, a design system at the centre), prefer the UIx
-adapter and use Hicasso only where data-first views earn their keep.
+adapter and use Hicasso only where data-first views are worth it.
 
-The sidebar is the page list. Nav order is reading order: concept, install,
-authoring habits, then growth (forms, lists, interop, native tier), then
-operate (test, diagnostics, SSR, performance).
+The MkDocs sidebar lists the pages.
 
 > **End-state guide.** This describes Hicasso as the completed programme ships
 > it. Public names may still change at the one naming sitting; treat spellings

--- a/docs/design/hicasso/draft-guide/glossary.md
+++ b/docs/design/hicasso/draft-guide/glossary.md
@@ -1,39 +1,39 @@
 # Hicasso glossary
 
-Hicasso nouns, verbs, and laws. One term, definition first; short code when
-the spelling matters; Related points at the teaching page. Core re-frame2
-terms (`app-db`, [frame](../../../core/glossary.md#frame), [event](../../../core/glossary.md#event),
+Hicasso terms. Definition first; short code when the spelling matters; Related
+points at the teaching page. Core re-frame2 terms (`app-db`,
+[frame](../../../core/glossary.md#frame), [event](../../../core/glossary.md#event),
 [subscription](../../../core/glossary.md#subscription)) live in the
 [core glossary](../../../core/glossary.md).
 
 Grouped by role: [authoring](#authoring), [events and control](#events-and-control),
 [interop](#interop), [native tier](#native-tier), [state homes](#state-homes),
-[testing](#testing), [diagnostics](#diagnostics), and [lifecycle and delivery](#lifecycle-and-delivery).
+[testing](#testing), [diagnostics](#diagnostics), and
+[lifecycle and delivery](#lifecycle-and-delivery).
 
 ## Authoring
 
 <a id="hicasso"></a>
 ### **Hicasso**
 
-re-frame2's native view adapter: interpreted [Hiccup](../../../core/glossary.md#hiccup)
-on a modern React function-component host. You write vectors and maps, read
-with [`h/sub`](#hsub) at the point of use, and put event vectors in attributes
-as [intents](#intent). The app-db, events, and pipeline stay ordinary
-re-frame2.
+re-frame2's native view adapter: interpreted
+[Hiccup](../../../core/glossary.md#hiccup) on a React function-component host.
+You write vectors and maps, read with [`h/sub`](#hsub) at the point of use, and
+put event vectors in attributes as [intents](#intent). App-db, events, and the
+pipeline stay ordinary re-frame2.
 
 Require `[re-frame.hicasso :as h]`. Optional modules (forms, overlays, native
-tier, test kit, routing helpers) are separate requires and cost nothing when
-absent.
+tier, test kit, routing helpers) are separate requires.
 
 Related: [Getting started](01-getting-started.md), [Installation](installation.md).
 
 <a id="defview"></a>
 ### **defview**
 
-`h/defview` — mints a Hicasso [view](#view): a React/re-frame [boundary](#boundary)
-used as a Hiccup head. Props map in, Hiccup (or a native React element at
-[rung 3 of the performance ladder](#performance-ladder)) out. Direct Clojure
-invocation refuses; mount it as a vector:
+`h/defview` — defines a Hicasso [view](#view): a React/re-frame
+[boundary](#boundary) used as a Hiccup head. Props map in; Hiccup (or a native
+React element at [rung 3 of the performance ladder](#performance-ladder)) out.
+Do not call the view as a Clojure function; mount it as a vector:
 
 ```clojure
 (h/defview counter [_]
@@ -42,7 +42,7 @@ invocation refuses; mount it as a vector:
    [:button {:on-click [:counter/increment]} "Click me"]])
 
 [counter]          ;; legal
-(counter {})       ;; refuses — write [counter]
+(counter {})       ;; raises — write [counter]
 ```
 
 Related: [Views and reads](02-views-and-reads.md).
@@ -50,20 +50,21 @@ Related: [Views and reads](02-views-and-reads.md).
 <a id="view"></a>
 ### **view**
 
-A function from a props map to markup, defined with [`defview`](#defview).
-In head position of a Hiccup vector it is a [boundary](#boundary). Plain
-`defn` helpers are not views: call them as functions so they [inline](#inline-helper).
+A function from a props map to markup, defined with [`defview`](#defview). In
+head position of a Hiccup vector it is a [boundary](#boundary). Plain `defn`
+helpers are not views: call them as functions so they
+[inline](#inline-helper).
 
 Related: [Views and reads](02-views-and-reads.md).
 
 <a id="boundary"></a>
 ### **boundary**
 
-Hicasso's unit of independent re-render, minted by [`defview`](#defview). Owns
-four things: React identity, the body's [`h/sub`](#hsub) reads, value-equality
-memoization, and the [frame](../../../core/glossary.md#frame) to which
-[intents](#intent) dispatch. Native tags, fragments, and [`defhost`](#defhost)
-heads also sit in vector position; none of those is a boundary.
+An independently re-rendering unit created by [`defview`](#defview). Tracks the
+body's [`h/sub`](#hsub) reads, memoizes on value equality of props, and provides
+the [frame](../../../core/glossary.md#frame) that [intents](#intent) dispatch
+into. Native tags, fragments, and [`defhost`](#defhost) heads can sit in vector
+position; none of those is a boundary.
 
 Related: [Views and reads](02-views-and-reads.md).
 
@@ -71,9 +72,9 @@ Related: [Views and reads](02-views-and-reads.md).
 ### **inline helper**
 
 An ordinary `defn` called from a view body. Its Hiccup splices into the caller;
-any `h/sub` it performs donates membership **upward** to the enclosing
-[boundary](#boundary). Helpers cost no re-render granularity. A plain `defn`
-in head position refuses (`:rf.error/hicasso-bad-head`).
+any `h/sub` it performs counts toward the enclosing [boundary](#boundary).
+Helpers do not create their own re-render unit. A plain `defn` in head position
+raises (`:rf.error/hicasso-bad-head`).
 
 ```clojure
 [todo-row {:key id :id id}]   ;; boundary child
@@ -85,39 +86,39 @@ Related: [Views and reads](02-views-and-reads.md).
 <a id="hsub"></a>
 ### **h/sub**
 
-The only view-side subscription read. Ordinary function call at the point of
-use — legal in `let`, `when`, loops, and synchronous helpers. Tracks reads for
-the active [boundary](#boundary) under the [read-extent law](#read-extent-law).
+The only view-side subscription read. An ordinary function call at the point of
+use — legal in `let`, `when`, loops, and synchronous helpers. Records the read
+for the active [boundary](#boundary) under the
+[read-extent law](#read-extent-law).
 
 ```clojure
 (let [todo (h/sub [:todo/by-id id])]
   [:span (:title todo)])
 ```
 
-Bare `rf/subscribe` in a body is not a fallback: it refuses. Past the fence
-into [native](#native-tier) code, use [`n/use-sub`](#nuse-sub) instead.
+Bare `rf/subscribe` in a body is not a fallback: it raises. In
+[native](#native-tier) code, use [`n/use-sub`](#nuse-sub) instead.
 
 Related: [Views and reads](02-views-and-reads.md).
 
 <a id="read-extent-law"></a>
 ### **read-extent law**
 
-`h/sub` is legal only during the **direct synchronous execution** of the
-active [boundary](#boundary) body (including ordinary helpers it calls). A
-read deferred through a callback, promise, timer, lazy sequence, or other
-escaped extent refuses with source and recovery
-(`:rf.error/hicasso-sub-outside-render`). Capture values during the body;
-async work re-enters through events and coeffects.
+`h/sub` is legal only during the **direct synchronous execution** of the active
+[boundary](#boundary) body (including ordinary helpers it calls). A read deferred
+through a callback, promise, timer, lazy sequence, or other escaped extent
+raises with source and recovery (`:rf.error/hicasso-sub-outside-render`). Capture
+values during the body; async work re-enters through events and coeffects.
 
 Related: [Views and reads](02-views-and-reads.md).
 
 <a id="collector"></a>
 ### **collector**
 
-Runtime mechanism that records which subscriptions a [boundary](#boundary)
-took during one body run. Commit reconciles that read set; abandoned and
-retried renders acquire no durable ownership. Escaping the collector is what
-the [read-extent law](#read-extent-law) forbids.
+Runtime mechanism that records which subscriptions a [boundary](#boundary) took
+during one body run. Commit reconciles that read set; abandoned and retried
+renders acquire no durable ownership. Escaping the collector is what the
+[read-extent law](#read-extent-law) forbids.
 
 Related: [Views and reads](02-views-and-reads.md#the-collector).
 
@@ -126,17 +127,17 @@ Related: [Views and reads](02-views-and-reads.md#the-collector).
 
 The props/children contract for a head: what converts, what is opaque, where
 keys live. [Views](#view) take a Clojure props map (keys in the map, not
-metadata); [hosts](#defhost) convert per declaration; native
-[`n/$`](#n) uses React slots and no intent lowering.
+metadata); [hosts](#defhost) convert per declaration; native [`n/$`](#n-dollar)
+uses React slots and does not lower intents.
 
-Related: [Views and reads](02-views-and-reads.md#the-component-abi).
+Related: [Views and reads](02-views-and-reads.md#props-children-and-fragments).
 
 <a id="lowering"></a>
 ### **lowering**
 
 The step that turns Hicasso data into React props and elements: Hiccup walk,
-[intent](#intent) → callback, controlled-field repair, attribute rules. Cost
-owner when Xray names "lowering"; the narrow escape is a direct
+[intent](#intent) → callback, controlled-field repair, attribute rules. When
+Xray names "lowering" as the cost owner, the narrow escape is a direct
 [`n/$`](#n-dollar) return from the same [boundary](#boundary).
 
 Related: [Events as data](03-events-as-data.md), [Native tier](10-native-tier.md).
@@ -144,17 +145,17 @@ Related: [Events as data](03-events-as-data.md), [Native tier](10-native-tier.md
 <a id="owned-wins"></a>
 ### **owned wins**
 
-Attribute-merge rule: literal keys written on the element always beat
-forwarded maps, by presence. Do not forward `:key` or [`::h/revision`](#hrevision)
-through a generic merge.
+Attribute-merge rule: literal keys written on the element always beat forwarded
+maps, by presence. Do not forward `:key` or [`::h/revision`](#hrevision) through
+a generic merge.
 
 Related: [Views and reads](02-views-and-reads.md#forwarding-attributes-owned-wins).
 
 <a id="read-topology"></a>
 ### **read topology**
 
-Where [reads](#hsub) sit relative to list structure — the main performance
-knob while staying on ordinary Hicasso:
+Where [reads](#hsub) sit relative to list structure — the main performance knob
+while staying on ordinary Hicasso:
 
 | Shape | Idea |
 |---|---|
@@ -172,10 +173,11 @@ Related: [Lists and collections](06-lists-and-collections.md).
 <a id="intent"></a>
 ### **intent**
 
-An [event](../../../core/glossary.md#event) vector written in an attribute at
-an event position (`on-*` / `onClick`). The runtime builds the callback and
+An [event](../../../core/glossary.md#event) vector written in an attribute at an
+event position (`on-*` / `onClick`). The runtime builds the callback and
 dispatches the vector to the rendering [boundary](#boundary)'s frame. The tree
-stays data: tests assert with `=`; tools read meaning without running the app.
+stays data: tests assert with `=`; tools can read meaning without running the
+app.
 
 ```clojure
 [:button {:on-click [:todo/toggle id]} "✓"]
@@ -187,8 +189,8 @@ Related: [Events as data](03-events-as-data.md).
 ### **h/event**
 
 Explicit handler form when a vector intent is not enough: value-first foreign
-callbacks, calculated events, or reading the invoker's arguments. Captures
-the current frame at creation; one meaning everywhere (including host slots).
+callbacks, calculated events, or reading the invoker's arguments. Captures the
+current frame at creation; same meaning everywhere (including host slots).
 
 ```clojure
 {:on-change (h/event [date] [:calendar/picked date])}
@@ -200,8 +202,8 @@ Related: [Events as data](03-events-as-data.md).
 <a id="hchecked"></a>
 ### **::h/value** / **::h/checked**
 
-Reserved markers substituted at dispatch from the DOM event target's
-`.value` / `.checked`. Top level of the intent vector only.
+Reserved markers substituted at dispatch from the DOM event target's `.value` /
+`.checked`. Top level of the intent vector only.
 
 ```clojure
 [:input {:value (h/sub [:draft]) :on-input [:edit ::h/value]}]
@@ -212,8 +214,8 @@ Related: [Events as data](03-events-as-data.md), [Controlled inputs](04-controll
 <a id="hprevent"></a>
 ### **::h/prevent**
 
-Intent head that prevents the browser default, then dispatches the inner
-intent. Nothing auto-prevents — not click, not submit.
+Intent head that prevents the browser default, then dispatches the inner intent.
+Nothing auto-prevents — not click, not submit.
 
 ```clojure
 [:form {:on-submit [::h/prevent [:signup/submit]]} …]
@@ -224,9 +226,9 @@ Related: [Events as data](03-events-as-data.md).
 <a id="controlled-field"></a>
 ### **controlled field**
 
-An input whose displayed value is owned by app-db (via a subscription) and
-whose edits return as [intents](#intent). Hicasso's controlled law covers
-same-turn convergence, committed echo, caret/selection, IME composition, and
+An input whose displayed value comes from app-db (via a subscription) and whose
+edits return as [intents](#intent). Hicasso's controlled path covers same-turn
+convergence, committed echo, caret/selection, IME composition, and
 identity-preserving [revision](#hrevision) reset. Form fields stay on the
 interpreted side; the [native tier](#native-tier) has no controlled repair.
 
@@ -236,9 +238,9 @@ Related: [Controlled inputs](04-controlled-inputs.md).
 ### **::h/revision**
 
 Reserved controlled-text prop: change this value to re-baseline the field's
-draft (accept, reject, or rewrite). Reset is never by value equality — a
-model that reasserts the same string would be invisible to `not=`. Exact
-namespaced keyword only; a bare `:revision` is an ordinary attribute.
+draft (accept, reject, or rewrite). Reset is never by value equality — a model
+that reasserts the same string would be invisible to `not=`. Exact namespaced
+keyword only; a bare `:revision` is an ordinary attribute.
 
 ```clojure
 [:input {:value       (h/sub [:field/value id])
@@ -275,10 +277,10 @@ Related: [Events as data](03-events-as-data.md#keyboard-as-data).
 <a id="defhost"></a>
 ### **defhost**
 
-`h/defhost` — declared door to a foreign React component. Names the React
-value once, documents ReactNode [slots](#reactnode-slot), callback contracts
-(`:event` / `:handler` / `:render`), and [server policy](#server-policy).
-Quarantines the npm require in one host namespace.
+`h/defhost` — declared door to a foreign React component. Names the React value
+once, documents ReactNode [slots](#reactnode-slot), callback contracts
+(`:event` / `:handler` / `:render`), and [server policy](#server-policy). Keeps
+the npm require in one host namespace.
 
 ```clojure
 (h/defhost date-picker DatePicker
@@ -291,18 +293,17 @@ Related: [Interop](09-interop.md).
 <a id="reactnode-slot"></a>
 ### **ReactNode slot**
 
-A prop position a [host](#defhost) declares as carrying React children or
-named content (Suspense `:fallback`, compound slots). Hiccup in that position
-lowers under the captured frame without deep-converting arbitrary data maps.
+A prop position a [host](#defhost) declares as carrying React children or named
+content (Suspense `:fallback`, compound slots). Hiccup in that position lowers
+under the captured frame without deep-converting arbitrary data maps.
 
 Related: [Interop](09-interop.md#reactnode-slots).
 
 <a id="as-element"></a>
 ### **as-element**
 
-`h/as-element` — explicit Hiccup → React element conversion for render props
-and foreign callbacks. The one honest conversion when a library expects a
-ReactNode, not data.
+`h/as-element` — explicit Hiccup → React element conversion for render props and
+foreign callbacks. Use when a library expects a ReactNode, not data.
 
 ```clojure
 {:renderItem (fn [row]
@@ -315,9 +316,9 @@ Related: [Interop](09-interop.md), [Lists and collections](06-lists-and-collecti
 ### **as-component** / **outward bridge**
 
 `h/as-component` returns a real React component so a native parent
-(`n/defcomponent`, UIx, or JS) can render a minted Hicasso view under the
-existing frame provider — no second root, no exposed internal codec ABI.
-Symmetric to hosts embedding foreign React inward.
+(`n/defcomponent`, UIx, or JS) can render a Hicasso view under the existing
+frame provider — no second root, no exposed internal codec ABI. Symmetric to
+hosts embedding foreign React inward.
 
 Related: [Interop](09-interop.md#the-outward-bridge).
 
@@ -337,17 +338,17 @@ Related: [Interop](09-interop.md#portals), [Overlays and focus](12-overlays-and-
 Per-surface answer for SSR: **Render** (deterministic React server bytes) or
 **Client-only** (source-located refusal, with a deterministic fallback if the
 declaration carries one). Bare Client-only is the default, and it leaves the
-region empty until the browser takes over — conservative rather than broken,
-but genuinely empty. Declared on hosts and native components; intrinsic
-Hiccup renders by default.
+region empty until the browser takes over. Declared on hosts and native
+components; intrinsic Hiccup renders by default.
 
-Related: [SSR and hydration](17-ssr-and-hydration.md), [Interop](09-interop.md#server-policy-per-declaration).
+Related: [SSR and hydration](17-ssr-and-hydration.md),
+[Interop](09-interop.md#server-policy-per-declaration).
 
 <a id="raw-escape"></a>
 ### **raw escape** (`:>`)
 
 Hiccup head that passes a React component through without a lasting
-[host](#defhost) declaration. Useful once; repeated use graduates to
+[host](#defhost) declaration. Useful once; repeated use should move to
 `defhost` so slots, server policy, and callbacks stay declared.
 
 Related: [Interop](09-interop.md#the-escape-).
@@ -359,10 +360,10 @@ Related: [Interop](09-interop.md#the-escape-).
 <a id="native-tier"></a>
 ### **native tier**
 
-Optional namespace `re-frame.hicasso.native` (alias `n`): explicit exit to
-direct React construction and hooks. **`[...]` is always interpreted Hiccup;
-`n/$` is always native React.** Neither form rewrites the other; nothing
-compiles Hiccup. Absent from bundles that never require the namespace.
+Optional namespace `re-frame.hicasso.native` (alias `n`): explicit exit to direct
+React construction and hooks. **`[...]` is always interpreted Hiccup; `n/$` is
+always native React.** Neither form rewrites the other; nothing compiles Hiccup.
+Absent from bundles that never require the namespace.
 
 Related: [Native tier](10-native-tier.md).
 
@@ -393,8 +394,8 @@ Related: [Native tier](10-native-tier.md#the-n-grammar).
 <a id="ndefcomponent"></a>
 ### **n/defcomponent**
 
-Defines a stable top-level native function component: display name, source,
-HMR conduct, and one props/children ABI. Default self-contained route for a
+Defines a stable top-level native function component: display name, source, HMR
+conduct, and one props/children ABI. Default self-contained route for a
 [named native island](#native-island). Ordinary React hooks are legal inside;
 frame access via [`n/use-sub`](#nuse-sub) / [`n/use-frame`](#nuseframe).
 
@@ -405,18 +406,19 @@ Related: [Native tier](10-native-tier.md).
 ### **n/use-sub** / **n/use-frame**
 
 Native React hooks that join the installed Hicasso frame. Substrate-neutral
-(shared spine; no UIx dependency). Use inside [`n/defcomponent`](#ndefcomponent)
-or UIx `defui` — not inside a dynamically branched [`defview`](#defview) body.
+(shared implementation; no UIx dependency). Use inside
+[`n/defcomponent`](#ndefcomponent) or UIx `defui` — not inside a dynamically
+branched [`defview`](#defview) body.
 
 Related: [Native tier](10-native-tier.md).
 
 <a id="native-island"></a>
 ### **native island**
 
-A named native component under the same React root and re-frame2 frame as
-the rest of the app — hooks, vendor widgets, high-rate mechanics. Authored
-with [`n/defcomponent`](#ndefcomponent), UIx, or a JS host. Xray names the
-crossing; the inner React tree is [host-opaque](#loss-labels).
+A named native component under the same React root and re-frame2 frame as the
+rest of the app — hooks, vendor widgets, high-rate mechanics. Authored with
+[`n/defcomponent`](#ndefcomponent), UIx, or a JS host. Xray names the crossing;
+the inner React tree is [host-opaque](#loss-labels).
 
 Related: [Native tier](10-native-tier.md#rung-4--a-named-native-island).
 
@@ -425,9 +427,9 @@ Related: [Native tier](10-native-tier.md#rung-4--a-named-native-island).
 ### **n/memo** / **n/lazy**
 
 Marker-preserving memoization and `React.lazy` loading for native components.
-Raw `react/memo` / `React.lazy` erase the tier marker that Xray and the
-embedding seams read. Hot reload is unaffected either way — a save allocates a
-fresh component, and a clean remount is the designed conduct.
+Raw `react/memo` / `React.lazy` erase the tier marker that Xray and embedding
+checks read. Hot reload is unaffected either way — a save allocates a fresh
+component, and a clean remount is the designed conduct.
 
 Related: [Native tier](10-native-tier.md#keeping-the-marker-the-abi-helpers),
 [Code splitting](20-code-splitting.md).
@@ -435,8 +437,8 @@ Related: [Native tier](10-native-tier.md#keeping-the-marker-the-abi-helpers),
 <a id="performance-ladder"></a>
 ### **performance ladder**
 
-Five explicit rungs from ordinary Hicasso to a full native screen. No
-`:fast` flag and no second meaning for Hiccup:
+Five explicit rungs from ordinary Hicasso to a full native screen. No `:fast`
+flag and no second meaning for Hiccup:
 
 1. Ordinary Hicasso
 2. Tuned [read topology](#read-topology)
@@ -449,8 +451,8 @@ Related: [Performance](18-performance.md), [Native tier](10-native-tier.md).
 <a id="escape-benefit-rule"></a>
 ### **escape-benefit rule**
 
-An escape stays only if it recovers **≥20%** of the measured interaction,
-saves **≥2 ms** at p95, or converts a failed user-visible budget into a pass;
+An escape stays only if it recovers **≥20%** of the measured interaction, saves
+**≥2 ms** at p95, or converts a failed user-visible budget into a pass;
 otherwise remove it. Thresholds never widen to keep a red row green.
 
 Related: [Performance](18-performance.md#the-escape-benefit-rule).
@@ -462,20 +464,21 @@ Related: [Performance](18-performance.md#the-escape-benefit-rule).
 <a id="one-state-owner"></a>
 ### **one state owner**
 
-Application-visible state lives in re-frame2 [app-db](../../../core/glossary.md#app-db)
-only. There is no component-local reactive cell and no second store. Hosts may
-hold host-private mechanics (motion, focus, vendor handles) that are never an
-invisible duplicate of application facts.
+Application-visible state lives in re-frame2
+[app-db](../../../core/glossary.md#app-db) only. There is no component-local
+reactive cell and no second store. Hosts may hold host-private mechanics
+(motion, focus, vendor handles) that are never an invisible duplicate of
+application facts.
 
 Related: [Ephemeral state](11-ephemeral-state.md).
 
 <a id="pressure-valve"></a>
 ### **pressure valve**
 
-Named legitimate home for a kind of UI state under [one state owner](#one-state-owner):
-explicit app-db address (default); optional forms/draft modules; host-private
-React/DOM state; uncontrolled DOM as an explicit interop choice. If a fact
-fits no valve, it goes to app-db.
+Named legitimate home for a kind of UI state under
+[one state owner](#one-state-owner): explicit app-db address (default); optional
+forms/draft modules; host-private React/DOM state; uncontrolled DOM as an
+explicit interop choice. If a fact fits no valve, it goes to app-db.
 
 Related: [Ephemeral state](11-ephemeral-state.md).
 
@@ -491,9 +494,10 @@ Related: [Overlays and focus](12-overlays-and-focus.md).
 <a id="route-link"></a>
 ### **route-link**
 
-Routing helper: navigates by event, optional intent [prefetch](../../../routing/glossary.md#intent-prefetch),
-scroll/focus conduct. Plain function (inlines); active state is a subscription
-comparison, not a built-in class.
+Routing helper: navigates by event, optional intent
+[prefetch](../../../routing/glossary.md#intent-prefetch), scroll/focus conduct.
+Plain function (inlines); active state is a subscription comparison, not a
+built-in class.
 
 Related: [Routing and navigation](07-routing-and-navigation.md).
 
@@ -521,10 +525,10 @@ Related: [Async resources](08-async-resources.md#demand-driven-committed-reads),
 <a id="test-kit"></a>
 ### **test kit**
 
-Two supported namespaces: `re-frame.hicasso.test` (alias `ht`) for the pure
-data tiers, the [semantic harness](#semantic-harness) and the browser helpers,
-and `re-frame.hicasso.test.mounted` (alias `hm`) for the
-[mounted facade](#mounted-facade). Product surface, not a loose utility bag.
+Two supported namespaces: `re-frame.hicasso.test` (alias `ht`) for the pure data
+tiers, the [semantic harness](#semantic-harness) and the browser helpers, and
+`re-frame.hicasso.test.mounted` (alias `hm`) for the
+[mounted facade](#mounted-facade).
 
 Related: [Testing](14-testing.md).
 
@@ -548,19 +552,19 @@ Related: [Testing](14-testing.md).
 <a id="semantic-harness"></a>
 ### **semantic harness**
 
-L2: `ht/tree` runs one hook-free body under injected read fixtures and
-returns a semantic tree. A nested view is recorded as the call it is and its
-body does not run. Hosts, hooks, raw React, and [`n/$`](#n-dollar) results
-are **opaque** and refuse — mount those at L3.
+L2: `ht/tree` runs one hook-free body under injected read fixtures and returns
+a semantic tree. A nested view is recorded as the call it is and its body does
+not run. Hosts, hooks, raw React, and [`n/$`](#n-dollar) results are **opaque**
+and raise — mount those at L3.
 
 Related: [Testing](14-testing.md#l2--the-semantic-harness).
 
 <a id="mounted-facade"></a>
 ### **mounted facade**
 
-`re-frame.hicasso.test.mounted` (alias `hm`). L3 helpers: isolated-frame
-mount, hydrate, rerender, dispatch-and-settle, settle, advance-clock,
-unmount, `assert-clean!` (residue vs pre-mount baseline after quiescence).
+`re-frame.hicasso.test.mounted` (alias `hm`). L3 helpers: isolated-frame mount,
+hydrate, rerender, dispatch-and-settle, settle, advance-clock, unmount,
+`assert-clean!` (residue vs pre-mount baseline after quiescence).
 
 Related: [Testing](14-testing.md#l3--the-mounted-facade).
 
@@ -576,8 +580,8 @@ Related: [Testing](14-testing.md#the-sabotage-twin).
 ### **canonical DOM**
 
 Normalized DOM / structure equality used by differential and migration
-witnesses. Distinct from semantic-tree equality (L2) and from React server
-byte / hydration equality.
+witnesses. Distinct from semantic-tree equality (L2) and from React server byte /
+hydration equality.
 
 Related: [Testing](14-testing.md#canonical-dom),
 [Migration from Reagent](19-migration-from-reagent.md).
@@ -596,8 +600,8 @@ event → subscriptions recomputed → values changed → boundaries notified
       → bodies run → React commit → paint
 ```
 
-Each link has its own evidence seam. **Render is not commit; commit is not
-paint.** Timing proximity alone never proves a link.
+Each link has its own evidence. **Render is not commit; commit is not paint.**
+Timing proximity alone never proves a link.
 
 Related: [Diagnostics](15-diagnostics.md).
 
@@ -608,15 +612,15 @@ Xray answer to *why did this [boundary](#boundary) run?* — cause kind (reads,
 props, context, host, retry/abandonment), current read set, fan-out,
 completeness and loss.
 
-Related: [Diagnostics](15-diagnostics.md#explain-render).
+Related: [Diagnostics](15-diagnostics.md#advanced).
 
 <a id="hot-view-advisor"></a>
 ### **hot-view advisor**
 
 Ranks hot boundaries (time, frequency, read churn, fan-out), **classifies
-pressure** (computation, topology, lowering, React, layout), then recommends
-the smallest credible remedy. Recommends a native escape only when native
-addresses the measured owner; never auto-promotes.
+pressure** (computation, topology, lowering, React, layout), then recommends the
+smallest credible remedy. Recommends a native escape only when native addresses
+the measured owner; never auto-promotes.
 
 Related: [Diagnostics](15-diagnostics.md#the-hot-view-advisor),
 [Performance](18-performance.md).
@@ -625,10 +629,10 @@ Related: [Diagnostics](15-diagnostics.md#the-hot-view-advisor),
 ### **loss labels**
 
 Honest gaps instead of empty panels: `:unknown`, `:opaque` /
-`:no-static-analysis`, `:host-opaque`, `:cap`, `:uncorrelated`. Unknown is
-never encoded as an empty collection.
+`:no-static-analysis`, `:host-opaque`, `:cap`, `:uncorrelated`. Unknown is never
+encoded as an empty collection.
 
-Related: [Diagnostics](15-diagnostics.md#honest-loss-labels).
+Related: [Diagnostics](15-diagnostics.md#when-evidence-is-incomplete).
 
 <a id="complaint-catalogue"></a>
 ### **complaint catalogue**
@@ -643,8 +647,8 @@ Related: [Diagnostics](15-diagnostics.md#the-complaint-catalogue).
 ### **production erasure**
 
 Dev diagnostics, source maps for complaints, and evidence sentinels are absent
-from default production bundles. Budgets and teardown are verified on
-production builds.
+from default production bundles. Budgets and teardown are verified on production
+builds.
 
 Related: [Diagnostics](15-diagnostics.md#production-erasure).
 
@@ -655,11 +659,11 @@ Related: [Diagnostics](15-diagnostics.md#production-erasure).
 <a id="mount"></a>
 ### **mount!** / **render!** / **unmount!**
 
-Root lifecycle. `h/mount!` associates a DOM node, a [frame](../../../core/glossary.md#frame)
-id, and optional `:initial-events` (seed app-db before first paint), and
-returns an idempotent **root handle**. `render!` re-renders into that handle;
-`unmount!` is a no-op if already unmounted (safe for fixtures and reload
-hooks).
+Root lifecycle. `h/mount!` associates a DOM node, a
+[frame](../../../core/glossary.md#frame) id, and optional `:initial-events` (seed
+app-db before first paint), and returns an idempotent **root handle**.
+`render!` re-renders into that handle; `unmount!` is a no-op if already
+unmounted (safe for fixtures and reload hooks).
 
 ```clojure
 (defonce root
@@ -674,28 +678,27 @@ Related: [Installation](installation.md).
 ### **hydrate!**
 
 Two verbs on one job. **`re-frame.ssr/hydrate!`** installs the server payload
-into the client frame (state half). **`h/hydrate!`** adopts the server DOM for
-a Hicasso root (DOM half). Server and client share one React renderer;
-mismatches surface as hydration errors.
+into the client frame (state half). **`h/hydrate!`** adopts the server DOM for a
+Hicasso root (DOM half). Server and client share one React renderer; mismatches
+surface as hydration errors.
 
 Related: [SSR and hydration](17-ssr-and-hydration.md).
 
 <a id="error-boundary"></a>
 ### **error-boundary**
 
-`h/error-boundary` — React error region in the tree (`:fallback`,
-`:reset-key`, `:on-error`). Distinct from a re-render [boundary](#boundary);
-only this component catches throws. Expected failures stay data, not
-exceptions.
+`h/error-boundary` — React error region in the tree (`:fallback`, `:reset-key`,
+`:on-error`). Distinct from a re-render [boundary](#boundary); only this
+component catches throws. Expected failures stay data, not exceptions.
 
 Related: [Errors](16-errors.md).
 
 <a id="user-visible-budget"></a>
 ### **user-visible budget**
 
-Performance contract in terms a user can notice (e.g. discrete interaction
-paint ≤50 ms p95; controlled echo within one frame; broad ops ≤100 ms p95;
-zero teardown residue). Comparative bands and island parity sit beside these;
+Performance contract in terms a user can notice (e.g. discrete interaction paint
+≤50 ms p95; controlled echo within one frame; broad ops ≤100 ms p95; zero
+teardown residue). Comparative bands and island parity sit beside these;
 synthetic scores never redefine "fast enough."
 
 Related: [Performance](18-performance.md#the-budgets).
@@ -705,7 +708,7 @@ Related: [Performance](18-performance.md#the-budgets).
 
 Also called **shadow mode**. Migration witness: dual-render
 [canonical DOM](#canonical-dom) / [intent](#intent) diff against a Reagent (or
-other) twin so conversion preserves behaviour before codemod. Refusals are
-named classes, not silent drift.
+other) twin so conversion preserves behaviour before a codemod rewrite. Named
+refusal classes describe policy differences; bare drift is reported as drift.
 
 Related: [Migration from Reagent](19-migration-from-reagent.md).

--- a/docs/design/hicasso/draft-guide/installation.md
+++ b/docs/design/hicasso/draft-guide/installation.md
@@ -3,9 +3,9 @@
 You have decided [Hicasso](glossary.md#hicasso) is the view adapter you want
 ([Getting started](01-getting-started.md)). This page gets it on the classpath,
 into a browser build, and onto a DOM node. By the end you have a running
-counter and the three habits every later chapter assumes:
-[`defview`](glossary.md#defview) as a Hiccup head, [`h/sub`](glossary.md#hsub)
-at the point of use, and handlers as data.
+counter and the three habits later pages assume: [`defview`](glossary.md#defview)
+as a Hiccup head, [`h/sub`](glossary.md#hsub) where you need a value, and
+handlers as data.
 
 ## Install the artifact
 
@@ -47,17 +47,17 @@ allow-list, no build flag. Any ordinary shadow-cljs browser build works:
 </html>
 ```
 
-You require one namespace: `[re-frame.hicasso :as h]`. The usual alias is
-`h`. Optional modules (forms, [overlays](glossary.md#overlay), motion, routing,
-the [native tier](glossary.md#native-tier), the [test kit](glossary.md#test-kit))
+You require one namespace: `[re-frame.hicasso :as h]`. The usual alias is `h`.
+Optional modules (forms, [overlays](glossary.md#overlay), motion, routing, the
+[native tier](glossary.md#native-tier), the [test kit](glossary.md#test-kit))
 are separate requires — a build that never requires them ships none of their
 code.
 
 ## Your first screen
 
-A real app splits events, subscriptions, and views into their own
-namespaces. The boot namespace requires those namespaces for their
-registrations. One screen fits in one namespace:
+A real app splits events, subscriptions, and views into their own namespaces.
+The boot namespace requires those namespaces for their registrations. One
+screen fits in one namespace:
 
 ```clojure
 (ns counter.core
@@ -77,7 +77,7 @@ registrations. One screen fits in one namespace:
 (rf/reg-sub :counter/count
   (fn [db _query] (:count db)))
 
-;; The view: a props map in, hiccup out.
+;; The view: a props map in, Hiccup out.
 (h/defview counter [_]
   [:main
    [:h1 "Clicked " (h/sub [:counter/count]) " times"]
@@ -99,20 +99,20 @@ registrations. One screen fits in one namespace:
 npx shadow-cljs watch app    # then open http://localhost:8080
 ```
 
-Click the button. The count changes. This screen shows the three habits of a
-[Hicasso](glossary.md#hicasso) view:
+Click the button. The count changes. This screen shows three habits of a
+Hicasso view:
 
-- **[`h/defview`](glossary.md#defview) mints a view, and a view is a Hiccup head.** You mount it as
+- `h/defview` creates a view used as a Hiccup head. You mount it as
   `[counter]`, which is a vector. You never call it as a function. A direct
-  call refuses (see the first row of the
-  [troubleshooting table](#troubleshooting)). Markup that should inline into
-  its caller is a plain `defn` helper.
-- **[`h/sub`](glossary.md#hsub) reads at the point of use.** It is an ordinary call. It is legal
+  call throws and names the view (see
+  [Troubleshooting](#troubleshooting)). Markup that should inline into its
+  caller is a plain `defn` helper.
+- `h/sub` reads where you use the value. It is an ordinary call. It is legal
   in a `let`, a `when`, a loop, a helper — anywhere in the view's synchronous
   body.
-- **The click handler is data** — an [intent](glossary.md#intent): an event vector in the
-  attribute, not a closure. `{:on-click [:counter/increment]}` stays
-  assertable with `=`. The runtime builds the callback and dispatches that
+- The click handler is data — an [intent](glossary.md#intent): an event vector
+  in the attribute, not a closure. `{:on-click [:counter/increment]}` stays
+  assertable with `=`. The runtime creates the callback and dispatches that
   vector to this root's frame.
 
 [Views and reads](02-views-and-reads.md) and
@@ -120,17 +120,14 @@ Click the button. The count changes. This screen shows the three habits of a
 
 ## What `h/mount!` did
 
-> **One [`h/mount!`](glossary.md#mount) associates a DOM node, a frame, and initial events, and
-> returns an idempotent handle.**
-
-[`h/mount!`](glossary.md#mount) takes the DOM node, a config map, and one view. `:frame` names the
-re-frame2 *frame* — an isolated world with its own app-db, event queue, and
-subscription cache. The root *ensures* that frame: creates it if missing,
-otherwise joins the one that already exists. Two roots with two frame ids are
-two isolated apps on one page. `:initial-events` runs ordinary events once,
-in order, and seeds app-db **before** the first paint. That is why the heading
-renders `0` and not an empty flash. Initial values arrive by event; that rule
-does not change because the view layer changed.
+[`h/mount!`](glossary.md#mount) takes the DOM node, a config map, and one view.
+`:frame` names the re-frame2 *frame* — an isolated world with its own app-db,
+event queue, and subscription cache. The root ensures that frame: creates it
+if missing, otherwise joins the one that already exists. Two roots with two
+frame ids are two isolated apps on one page. `:initial-events` runs ordinary
+events once, in order, and seeds app-db **before** the first paint. That is
+why the heading renders `0` and not an empty flash. Initial values arrive by
+event; that rule does not change because the view layer changed.
 
 `[counter]` and `[counter {}]` render the same output. The body receives an
 empty props map in both cases.
@@ -142,17 +139,18 @@ The handle controls the rest of the root's life:
 (h/unmount! root)            ;; idempotent — a second call is a no-op
 ```
 
-After [`h/unmount!`](glossary.md#mount), the root unmounts, subscriptions release with ref-counts
-at zero, and the DOM node is available to you again. Teardown paths run from
-`finally` blocks, fixtures, and reload hooks, and these paths do not
-coordinate. For that reason a second call is a no-op, not a crash.
+After [`h/unmount!`](glossary.md#mount), the root unmounts, subscriptions
+release when their ref-counts reach zero, and the DOM node is available again.
+Teardown paths run from `finally` blocks, fixtures, and reload hooks, and
+those paths do not coordinate. For that reason a second call is a no-op, not
+a crash.
 
 ## More than one root
 
-[`h/mount!`](glossary.md#mount) composes. A page can hold several roots, and `:frame` decides
-whether they are one app or two apps.
+[`h/mount!`](glossary.md#mount) composes. A page can hold several roots, and
+`:frame` decides whether they are one app or two apps.
 
-**Two roots, one frame — one app in two containers.** The root *ensures* its
+**Two roots, one frame — one app in two containers.** The root ensures its
 frame. The first mount creates the frame and runs `:initial-events`. A later
 mount that names the same frame joins the frame as it stands and replays
 nothing. Both roots read one app-db and dispatch into one queue. A widget
@@ -163,41 +161,41 @@ screen:
 (defonce app-root
   (h/mount! (js/document.getElementById "app")
             {:frame          :app/main
-             :initial-events [[:app/initialise]]}   ;; this mount creates the frame — it seeds
+             :initial-events [[:app/initialise]]}   ;; creates the frame — seeds
             [main-screen]))
 
 (defonce status-root
   (h/mount! (js/document.getElementById "status")
-            {:frame :app/main}                      ;; this one joins — no re-seed
+            {:frame :app/main}                      ;; joins — no re-seed
             [connection-badge]))
 ```
 
-Seed from the root that creates the frame. A joining root carries no
-`:initial-events` of its own.
+Seed from the root that creates the frame. A joining root omits
+`:initial-events`.
 
 **Two roots, two frames — two isolated apps.** Give each root its own
 `:frame` id, and each root has its own app-db, queue, and subscription cache.
 A view reads under the frame of the root that renders it. Subscriptions never
-cross frames: nothing mounted in `:app/main` can observe `:app/preview`. This
+cross frames: nothing mounted in `:app/main` can observe `:app/preview`. That
 isolation makes a live preview beside an editor — the same views, different
-state — an ordinary page. The independent second frame is a deliberate
-choice. Use one when two surfaces must not share state; share the frame when
-they must.
+state — an ordinary page. Use a second frame when two surfaces must not share
+state; share the frame when they must.
 
-Teardown stays per root in both cases. [`h/unmount!`](glossary.md#mount) releases that root's
-subscriptions and returns its DOM node. A frame that other roots still use
-keeps its state and continues to serve them.
+Teardown stays per root in both cases. [`h/unmount!`](glossary.md#mount)
+releases that root's subscriptions and returns its DOM node. A frame that
+other roots still use keeps its state and continues to serve them.
 
 ## Hot reload
 
 Leave the watch running and edit the `:h1` text. On save, shadow-cljs reloads
-the namespace, and the `^:dev/after-load` hook calls [`h/render!`](glossary.md#mount) with the
-redefined view. The root, the frame, and app-db survive, so the count keeps
-its value. The changed body is the body that runs, and no subscriptions leak.
+the namespace, and the `^:dev/after-load` hook calls
+[`h/render!`](glossary.md#mount) with the redefined view. The root, the frame,
+and app-db survive, so the count keeps its value. The changed body is the body
+that runs, and no subscriptions leak.
 
-One consequence: hot reload preserves state *past your setup event*. An edit
-to `:counter/initialise` does not re-seed a live app-db. Reload the page when
-you want the new seed.
+One consequence: hot reload preserves state past your setup event. An edit to
+`:counter/initialise` does not re-seed a live app-db. Reload the page when you
+want the new seed.
 
 ## Production
 
@@ -214,11 +212,11 @@ alters what your views mean.
 
 ## Troubleshooting
 
-| Symptom | What went wrong | Fix |
+| Symptom | Cause | Fix |
 |---|---|---|
-| Calling a view throws — `(counter {})` | The refusal fires at the call and names the view: you mount a [`defview`](glossary.md#defview) as a Hiccup head; you never invoke it | Write `[counter {}]`. Markup that should inline into its caller is a plain `defn` helper |
-| [`h/sub`](glossary.md#hsub) in a callback, timeout, or promise throws, naming the query | `:rf.error/hicasso-sub-outside-render` — the read escaped the synchronous body that owned it | Read during the body and close over the value; async work reads app-db through events and coeffects |
+| Calling a view throws — `(counter {})` | A `defview` is a Hiccup head; it is never invoked as a function | Write `[counter {}]`. Markup that should inline into its caller is a plain `defn` helper |
+| `h/sub` in a callback, timeout, or promise throws, naming the query | `:rf.error/hicasso-sub-outside-render` — the read ran outside the synchronous view body | Read during the body and close over the value; async work reads app-db through events and coeffects |
 | First paint is empty, then content flickers in | Seeding raced the first render | Seed through `:initial-events`, not a post-mount dispatch |
-| Second [`h/mount!`](glossary.md#mount) on the same node | A live root already owns that DOM node | `defonce` the handle; [`h/unmount!`](glossary.md#mount) it before mounting again |
+| Second `h/mount!` on the same node | A live root already owns that DOM node | `defonce` the handle; `h/unmount!` it before mounting again |
 | A second root's `:initial-events` never ran | Its `:frame` already existed — ensure joins a live frame and replays nothing | Seed from the root that creates the frame; joining roots omit `:initial-events` |
 | View body runs twice on mount in development | React StrictMode double-invokes bodies | Expected — bodies are pure and re-runnable |

--- a/docs/design/hicasso/studio/108-the-theming-taught-default-priced.md
+++ b/docs/design/hicasso/studio/108-the-theming-taught-default-priced.md
@@ -119,7 +119,7 @@ nothing else.
 | Chapters already read | 02 (`defview`, `sub`, the memo default) | 03 (`reg-fx`, the closed effect map) |
 | Chapters newly required | none | 10 (`:platforms #{:client}`, or the server render throws on `js/document`) |
 | Extra steps to a working dark mode | none | an initial event, or the first paint is unthemed |
-| Preconditions to hold | one, already taught: keep the content below the scope behind a `defview` head ([Boundaries memoize by default](../draft-guide/02-views-and-reads.md#boundaries-memoize-by-default)) | none |
+| Preconditions to hold | one, already taught: keep the content below the scope behind a `defview` head ([Views skip work when props are equal](../draft-guide/02-views-and-reads.md#views-skip-work-when-props-are-equal)) | none |
 | Surprises inherited | one, and it is silent — §7.2 | three: time travel lies, Xray lies, a test fixture lies |
 | Ceiling | none | one theme per page (§5) |
 
@@ -278,7 +278,7 @@ sentence on A's SSR bullet rather than an unqualified *"no flash by construction
 
 `:ssr :render` landed on 2026-08-05 (`rf2-l0wfx`, `rf2-nv07k`), and with it guide
 10 §[`:render` — when the region has to be in the
-response](../draft-guide/17-ssr-and-hydration.md#render-and-client-only-at-the-host).
+response](../draft-guide/17-ssr-and-hydration.md#client-only-hosts-with-a-fallback).
 The load-bearing fact for theming is the one that ruling states about the other
 two policies: `:client-only` (**the default**) and `{:fallback …}` render *instead
 of* the component, so *"a provider at a crossing takes every descendant out of the
@@ -313,7 +313,7 @@ but a channel that exists, where the per-root attribute has none.
   design's claim that per-frame B needs `make-frame :fx-overrides`: `spec/002-Frames.md`
   §*The binary fx-handler signature* already gives an fx handler the frame id in
   its ctx under `:frame`. Since then `h/frame` has **shipped** and guide 03
-  §[Callbacks carry their frame](../draft-guide/03-events-as-data.md#callbacks-carry-their-frame)
+  §[Callbacks include their frame](../draft-guide/03-events-as-data.md#callbacks-include-their-frame)
   teaches *"an fx handler receives the frame id in its context"* as a first-class
   fact, echoed in guide 01's troubleshooting table. So B per-root is an app-owned
   `frame-id → node` map populated at mount plus one global fx reading `(:frame m)`


### PR DESCRIPTION
## Summary

Rewrite every page under `docs/design/hicasso/draft-guide/` against the human-first `docs/AUTHORING.md` brief (already on main).

- Teach problem → code → what happens → what goes wrong; ordinary developer English; no performed voice.
- Cover `01`–`21`, `installation.md`, `glossary.md`, and `README.md`. Leave `REWRITE-NOTES` alone (working notes, not guide prose).
- Retarget a few Related / studio anchors that moved with the rewrites.

This is a voice and structure pass on the draft corpus. Normative claims are unchanged in intent; wording is tightened so the pages read like a developer teaching another developer.

## Test plan

- [x] `python scripts/check_doc_slugs.py` (exit 0) on this branch
- [ ] CI docs / MkDocs jobs green
- [ ] Spot-check a few pages for residual LLM cadence if desired: getting started, views and reads, testing, glossary

## Notes

- Rebased onto current `main` so the already-merged AUTHORING rewrite is not re-shipped; this PR is the draft-guide apply only.
- No PR for the AUTHORING file itself (already on main).