### PR TITLE
docs(mayor): a live branch name can be a prefix of another — match heads exactly (rf2-hhfq)

### DIFF
--- a/.claude/commands/mayor-hygiene.md
+++ b/.claude/commands/mayor-hygiene.md
@@ -34,4 +34,11 @@ Exit 1 means **nothing was destroyed**: either the tree is intact and this scrip
 
 `--dry-run` reports the whole partition up front — `WOULD_REMOVE=` (clean), `WOULD_NEED_FORCE=` (all build output, sweepable) or `WOULD_REFUSE_KEEP=` (needs a human first) — so survey before you sweep, and hand the `[KEEP]` trees back to the operator rather than deciding for them.
 
-Delete merged local + origin worker branches (NEVER delete a branch whose PR is not verifiably MERGED). Then `git remote prune origin` for stale tracking refs and clear any stray stashes. **Merge state is the test for a branch, never for a worktree** — conflating the two is how the reaping rule above went wrong. An open PR is one more reason to leave a worktree alone; the test is still its agent's report. Report what was pruned, what was left locked, and which (if any) needs a process-kill or reboot to clear.
+Delete merged local + origin worker branches (NEVER delete a branch whose PR is not verifiably MERGED). **Establish that with an exact `headRefName` equality, never with `--search "head:<branch>"`** — the search substring-matches, so `head:worker/activity-hic014` answered with the PR for `worker/activity-hic014b`, a different branch, and ranked that sibling FIRST. Request the field in `--json` and compare it yourself rather than trusting the tool's match:
+
+```sh
+gh pr list --state merged --limit 60 --json number,state,headRefName \
+  --jq '.[]|select(.headRefName=="worker/<branch>")|"\(.number) \(.state)"'
+```
+
+Then `git remote prune origin` for stale tracking refs and clear any stray stashes. **Merge state is the test for a branch, never for a worktree** — conflating the two is how the reaping rule above went wrong. An open PR is one more reason to leave a worktree alone; the test is still its agent's report. Report what was pruned, what was left locked, and which (if any) needs a process-kill or reboot to clear.

--- a/docs/the-mayor-method/bootstrap.md
+++ b/docs/the-mayor-method/bootstrap.md
@@ -279,7 +279,15 @@ of a drain; the binding rule is hot-zone parallelism, not strict same-surface.
   names repeat across sessions, so a cleanup that matches a name will eventually
   match a historical artefact and delete live work. Require the merged PR's head
   commit to equal the worktree's HEAD, and read the worktree ↔ branch mapping from
-  the tool rather than deriving either from the other. Beware that zero commits,
+  the tool rather than deriving either from the other. Nor need the name be stale
+  to betray you: it can be a live prefix of another live one, with the tool's own
+  search doing the matching. `gh pr list --search "head:worker/activity-hic014"`
+  also returns the PR for `worker/activity-hic014b`, and ranks the sibling first,
+  so a loop reading the top row reads one branch's state as another's — here it
+  read OPEN for a branch whose own PR had merged and merely skipped it, but the
+  same shape reversed deletes a live worker's branch on its sibling's verdict.
+  Ask for `headRefName` in `--json` and compare it for equality yourself; a search
+  term substring-matches, and only equality identifies. Beware that zero commits,
   clean tree, no PR describes both an abandoned worker and one that started a
   minute ago — and freshness does not break that tie either, however reasonable
   it sounds. Nothing observable about the tree does; see the next bullet.


### PR DESCRIPTION
Closes rf2-hhfq.

The hygiene loop confirms a PR is MERGED before deleting its branch. The obvious query for that — `gh pr list --state all --search "head:$b"` — **substring-matches**, so it answers about a *different* branch whose name merely starts with the one you asked for.

## The behaviour, re-verified at source

Re-run today rather than taken from the bead's report, against two prefix pairs that still exist:

```
$ gh pr list --state all --search "head:worker/activity-hic014" --json number,state,headRefName
[{"headRefName":"worker/activity-hic014b","number":7909,"state":"MERGED"},
 {"headRefName":"worker/activity-hic014","number":7792,"state":"MERGED"}]

$ gh pr list --state all --search "head:worker/theming-108" --json number,state,headRefName
[{"headRefName":"worker/theming-108b","number":7587,"state":"MERGED"},
 {"headRefName":"worker/theming-108","number":7577,"state":"MERGED"}]
```

Still fuzzy — and worse than reported in one respect: **the sibling ranks first in both cases**, so a loop that reads the top row gets the wrong branch's state without any tie to disambiguate. A sweep of all 400 open+closed PR heads found eleven such prefix pairs, so this is a standing property of the repo's branch naming (`-b`, `-fence`, `-followup`, `-audit` suffixes), not a one-off collision.

At the near-miss the sibling PR #7909 was still OPEN, so the loop read OPEN for `worker/activity-hic014` — whose own PR had in fact merged — and skipped it. Correct by luck. Reversed, the same shape reads MERGED from a merged sibling and deletes a live worker's branch.

## The two edits

**`docs/the-mayor-method/bootstrap.md`** — the *"Key destructive operations on identity, never on a name"* bullet gains its newest recorded instance. The existing text covered stale names repeating across sessions; the gap was a *live* name being a prefix of another *live* one, with the tool's own search doing the matching.

**`.claude/commands/mayor-hygiene.md`** — the branch-deletion paragraph now states the exact-`headRefName` form, with the command that performed the fifteen verified deletions that tick.

The wording follows the idiom already in `.claude/commands/mayor-merge.md` clause 4 — *"request it in `--json` and compare it rather than eyeballing a listing that cannot show it"* — rather than inventing a second one. No script, no wrapper, no checklist: the fix is a command form.

## Quality gates

Each run alone, output redirected to a worktree-local log, exit code captured on the same command line. Numbers below are the captured ones.

| Gate | Exit |
| --- | --- |
| `python scripts/check_readme_links.py` | **0** |
| `python scripts/check_doc_slugs.py` | **0** |
| `python -m mkdocs build --strict` (with `spec/` + `migration/` staged into `docs/` as `docs.yml` does) | **0** |
| `python scripts/check_fast_pr_gap.py --list` | **0** |

`git status --porcelain` clean after every run; the mkdocs staging and `site/` were removed, and all gate logs are `*.log` (gitignored).

### Negative controls

Both break a **markdown** reference, not a shell or script path — a broken script path is invisible to these resolvers, which is how an earlier worker's control failed to fail.

1. **`check_doc_slugs.py`** — first attempt injected `[broken](nonexistent-headexact-hhfq.md)` beside the edited bullet in `bootstrap.md`: **exit 1**, but reported as `LINK INSIDE A FENCE`, because that whole bullet lives inside the file's `text` fence. Informative, but it proves fence detection rather than target resolution, so a second control broke a real target — `docs/the-mayor-method/README.md:172` `](bootstrap.md)` → `](bootstrap-NOPE-headexact-hhfq.md)`: **exit 1**, `BROKEN TARGET`. Restored; re-run **exit 0**.
2. **`check_readme_links.py`** — broke the `.md` reference inside the file this PR edits, `.claude/commands/mayor-hygiene.md:6` → `docs/the-mayor-method/bootstrap-NOPE-headexact-hhfq.md`: **exit 1**, `BROKEN COMMAND-FILE REFERENCE`. Restored; re-run **exit 0**.

That first control is worth keeping in mind for anyone editing this bullet: **`bootstrap.md`'s hard-won list is inside a fenced block**, so a markdown link added there is a gate failure by construction. The added text uses backticks only, matching the surrounding prose.

### What the fast-PR spine does not decide

`check_fast_pr_gap.py --list` reports **96** required checks the spine does not run — the three required contexts are `All required checks passed` (test.yml, 45 jobs with no lane in the spine), `Lint required` (lint.yml, 5 jobs) and `Docs required` (docs.yml). Most are surface-gated and skip on a diff that does not reach them; this change touches only two markdown files, so the docs lane is the one that decides it, and `mkdocs build --strict` is green above.
