### PR TITLE
docs: state what does and does not gate the design tree (rf2-x5dvk)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,8 +110,10 @@ cp -rf source dest          # NOT: cp -r source dest
 out of the site, so never nominate it as the gate for an edit confined to that
 tree — it will exit 0 having verified nothing. `scripts/check_doc_slugs.py` does
 cover it: markdown link targets and heading anchors, in the fast-PR spine and in
-`docs.yml`. Nothing checks tables, rendering, or nav, so verify anchors and table
-column counts by hand and say so in the PR body.
+`docs.yml`. So does `scripts/check_provenance_pins.py`, on changed pages under
+`docs/design/hicasso/`, as its own `docs.yml` job. Nothing checks tables,
+rendering, or nav, so verify anchors and table column counts by hand and say so
+in the PR body.
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
 ## Beads Issue Tracker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ Per-artefact tests run from each artefact directory via `clojure -M:test` (see e
 
 Docs build from repo root with `mkdocs build --strict` (config in `mkdocs.yml`).
 
-**`mkdocs build --strict` does not cover `docs/design/**`** — `mkdocs.yml`'s `exclude_docs` block deliberately keeps `design/freehand/` and `design/hicasso/` out of the site (they are working design records, not user-facing documentation), so never nominate it as the gate for an edit confined to that tree. `scripts/check_doc_slugs.py` *does* validate the tree's markdown link targets and heading anchors (it runs in the fast-PR spine and in `docs.yml`); nothing validates its tables, rendering or nav, so **the worker verifies anchors and table column counts by hand and says so in the PR body**.
+**`mkdocs build --strict` does not cover `docs/design/**`** — `mkdocs.yml`'s `exclude_docs` block deliberately keeps `design/freehand/` and `design/hicasso/` out of the site (they are working design records, not user-facing documentation), so never nominate it as the gate for an edit confined to that tree. `scripts/check_doc_slugs.py` *does* validate the tree's markdown link targets and heading anchors (it runs in the fast-PR spine and in `docs.yml`), and `scripts/check_provenance_pins.py` validates changed pages under `docs/design/hicasso/` as its own `docs.yml` job; nothing validates its tables, rendering or nav, so **the worker verifies anchors and table column counts by hand and says so in the PR body**.
 
 ## Architecture Overview
 

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -1,6 +1,13 @@
 # Guide authoring
 
-This document governs pages under `/docs`.
+This document governs the published pages under `/docs` — the guide and
+reference corpus MkDocs builds and ships.
+
+It does not govern `docs/design/`. Those trees are durable design records kept
+for this project's own maintainers, deliberately excluded from the site, and
+they answer to a different brief. If you are editing one, read
+[What CI enforces](#what-ci-enforces) anyway: the gate that covers this corpus
+does not cover that one.
 
 The goal is simple: help a competent developer understand re-frame2 quickly,
 accurately, and with as little friction as possible.
@@ -861,6 +868,15 @@ And definitely not:
 On docs PRs: `mkdocs build --strict`, the link/anchor validator
 (`scripts/check_doc_slugs.py`), and residue scans in
 `.github/workflows/docs.yml`.
+
+`mkdocs build --strict` sees only the published corpus. `mkdocs.yml`'s
+`exclude_docs` block keeps `docs/design/freehand/` and `docs/design/hicasso/`
+out of the site, so a green build has inspected none of their pages — never
+cite it as the gate for a change confined to either. Two gates do cover them:
+`scripts/check_doc_slugs.py` validates link targets and heading anchors across
+the whole corpus, design trees included, and `scripts/check_provenance_pins.py`
+runs on changed pages under `docs/design/hicasso/`. Nothing checks their
+tables, rendering, or nav, so verify those by hand and say so in the PR body.
 
 Everything else is human judgment: feature PRs update the affected guide page
 (or say why not); click live cells you touched; prefer cited `examples/`


### PR DESCRIPTION
Closes rf2-x5dvk.

## What the claim was, and what held

The owner's latest audit note (#7911 reopen) is the one this PR discharges:
`docs/AUTHORING.md` opened "This document governs pages under `/docs`" and closed
with "On docs PRs: `mkdocs build --strict`, …", so a design-only PR could cite a
green gate that had inspected none of its pages — the exact fail-open this owner
already fixed once in `CLAUDE.md` and `AGENTS.md`.

The broader claim in the bead's title — that the tree is *ungated* — does **not**
hold. The `exclude_docs` half is true; "decorative" is not. Measured, not assumed:

* `scripts/check_doc_slugs.py` scans **722** markdown files, of which **103** are
  under `docs/design/hicasso/` and **37** under `docs/design/freehand/`. Its
  `DEFAULT_ROOTS` includes `docs`, and its exclusions (`docs/spec`,
  `docs/migration`, and the dir names `findings`/`ai`/`site`/`node_modules`/…)
  do not touch `docs/design`. It validates link targets and heading anchors, and
  additionally forbids markdown links inside code fences in `docs/design/hicasso`
  (`FENCED_DOC_LINK_TREES`).
* `scripts/check_provenance_pins.py` has `DEFAULT_ROOT = "docs/design/hicasso"`
  and runs as its own `docs.yml` job (`provenance-pins`) on changed pages.
* `implementation/hicasso/scripts/check_complaint_catalogue.py` round-trips
  `docs/design/hicasso/product/complaints.md` and `docs/design/hicasso/draft-guide/**`
  in an unconditional `test.yml` job.

What genuinely covers nothing there: `mkdocs build --strict`, and with it tables,
rendering, nav, and any published-site concern. The residue gates
(`check_retired_composition_vocab`, `check_retired_image_keys`,
`check_inject_cofx_residue`, `check_retired_spellings`) all scan
`docs/core`/`docs/api`/`docs/EP`/`spec`/`skills` and stop there.

**`exclude_docs` is correct policy**, and this PR does not touch it. Mike ruled
option (b) struck on 2026-07-31; a fresh `mkdocs build --strict` here confirms the
config does what it says — 295 published pages, `site/design/` not created at all,
zero pages under either design tree, while `docs/AUTHORING.md` *is* published. So
the finding is not "the tree is ungated" but "the gate boundary was missing from
the one file that claims authority over `/docs`". That is what is fixed.

## What changed

* `docs/AUTHORING.md` — the opening now scopes the document to the published
  guide/reference corpus and carves out `docs/design/`, pointing an editor of
  those trees at the CI section. That section now qualifies `mkdocs build --strict`
  to the published corpus and names the two gates that do cover the design trees,
  keeping the existing "verify tables/rendering/nav by hand" instruction.
* `AGENTS.md` and `CLAUDE.md` — one clause each, adding
  `scripts/check_provenance_pins.py` beside `check_doc_slugs.py`. Both files
  already carried the boundary but named only the slug gate, so a worker told
  those were the only gates could be surprised by a red `Provenance pins` job.
  Three instruction files now state the same roster.

No new checker, no CI job, no `mkdocs.yml` change. Nothing is known to be broken
in the design tree today, and this PR does not claim otherwise.

## Quality gates

Every gate below was run alone, output redirected to a file, exit code echoed on
the same command line. The numbers quoted are the ones captured.

| Command | Captured exit |
| --- | --- |
| `python scripts/check_doc_slugs.py --verbose` (baseline, pre-edit) | 0 |
| `python scripts/check_doc_slugs.py --verbose` (final) | 0 |
| `python scripts/check_readme_links.py --verbose` | 0 |
| `python scripts/check_retired_composition_vocab.py --verbose` | 0 |
| `python -m mkdocs build --strict` (after staging `spec/` + `migration/`) | 0 |
| `python scripts/check_fast_pr_gap.py --list` | 0 |

**Negative control 1 — `check_doc_slugs.py`, and it is a CORRECTNESS check for
this diff.** This PR adds one intra-repo link, `[What CI enforces](#what-ci-enforces)`.
Retargeted to `#what-ci-enforces-typo`, the gate captured **exit 1** and named it:

```
BROKEN ANCHOR: docs\AUTHORING.md:9 -> #what-ci-enforces-typo
    (target: docs\AUTHORING.md)
```

Restored, re-run, captured exit 0. `git diff --stat -- docs/AUTHORING.md` is empty
against the commit, so the restore is byte-exact.

**Negative control 2 — `mkdocs build --strict`, and the result is worth recording.**
Two faults planted at once in `docs/AUTHORING.md`: the broken same-page anchor
above, and a broken file target (`core/introduction.md` → `core/introduction-typo.md`).
The build captured **exit 1**, aborting on the target only:

```
WARNING -  Doc file 'AUTHORING.md' contains a link 'core/introduction-typo.md', but the target is not found among documentation files.
INFO    -  Doc file 'AUTHORING.md' contains a link '#what-ci-enforces-typo', but there is no such anchor on this page.
Aborted with 1 warnings in strict mode!
```

So `--strict` decides link *targets* on this file but is silent on *anchors* —
`mkdocs.yml` sets no `validation:` block, so mkdocs 1.6's anchor check stays at
`info`. `check_doc_slugs.py` is the anchor authority for the whole corpus,
published pages included, not just the excluded trees. Restored; re-run captured
exit 0.

**`mkdocs build --strict` is a correctness check for the `docs/AUTHORING.md` half
of this diff and does not see the other two files at all** — `AGENTS.md` and
`CLAUDE.md` are repo-root markdown, outside `docs_dir` and outside
`check_doc_slugs.py`'s roster by design (its own docstring says so).
`scripts/check_readme_links.py` owns those; for this diff it is a **residue check,
not a correctness check**, because the two clauses added there contain code spans
and no links.

**Hand verification.** No tables were added or touched, so there are no column
counts to check. The one anchor added is machine-verified above rather than by eye.

**`check_fast_pr_gap.py --list` — required checks the spine does not decide (96).**
For a docs-only diff the ones that matter are the `docs.yml` "MkDocs build" job
steps the spine skips (playground bundle rebuild, SCI bundle validity, Chromium
bundle smoke, committed-bootstrap drift, `spec/` + `migration/` staging) and the
`Provenance pins` changed-page step, which needs `GITHUB_BASE_REF` and so only
runs in CI. None of those can be decided locally; the remainder of the 96 are
`test.yml`/`lint.yml` jobs surface-gated away from a markdown-only change.

**Residue.** All gate artefacts were written outside the repo. The staged
`docs/spec/` + `docs/migration/` trees and `site/` were removed after the builds;
`git status --porcelain --untracked-files=all` shows nothing beyond the tracked
edits.
