### PR TITLE
docs(mayor): hash the restore, and sweep every carrier (rf2-uh9m)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -162,7 +162,7 @@ relying on CI"). A silent skip fails review.
 
 ### How a gate is run, not just which one
 
-Four rules about the mechanics. Each is here because it cost real hours, and
+Five rules about the mechanics. Each is here because it cost real hours, and
 none of them is obvious from the gate command itself.
 
 - **Foreground, to completion — within the harness's ten-minute ceiling.** A
@@ -201,6 +201,18 @@ none of them is obvious from the gate command itself.
   run, which is a different measurement and has disagreed: on 2026-08-11 a
   worker's gate was surfaced as *completed (exit code 0)* while the run's own
   captured status was 1.
+- **Verify a restore by hashing the bytes, never by reading `git diff`.** A brief
+  that proves a guard is *exact* rather than merely present tells the worker to
+  plant a fault, run the gate, then restore — and `git diff` misreads that restore
+  two ways. A rewrite that flips line endings reads clean having changed every
+  line; and **a patch that never applied reads clean too**, because "unchanged" and
+  "not attempted" are the same diff. The second is the dangerous one: a plant that
+  silently no-ops makes the sabotage run come back green, so the worker reports a
+  guard that fired when nothing was ever broken — a false proof of a real guard,
+  which is worse than no proof. Hash the file before the plant and compare after
+  the restore. On a checkout whose line endings are translated, **anchor a patch to
+  a single line**: one worker's first multi-line anchor matched nothing, with no
+  error and no edit, and only the hash caught it.
 - **Put *every* gate artefact where git ignores it** — the log and the exit-code
   file both. `*.log`, `*.exit` and `*-exit.txt` all are, so this leaves nothing
   behind:
@@ -215,6 +227,27 @@ none of them is obvious from the gate command itself.
   `git worktree remove` refuses the tree from then on. Nine worktrees
   accumulated exactly that way before anyone worked out why they would not reap.
   Cheapest fix is to not create the residue.
+
+### Briefing a correction — sweep every carrier
+
+When a bead corrects a stale factual claim, brief the worker to find **every
+carrier of that claim and dispose of all of them in one pass**. *"Bounded repair"
+bounds the change, not the search*: `git grep` the exact wording across tracked
+files, read every hit, settle each one in the same PR, and list in the PR body
+what was changed and what was left standing because it was already right.
+`rf2-2l17` corrected a single sentence four times across three PRs. Every repair
+was bounded and correct, and every one was found by the *next* merged-PR audit
+rather than by the repair before it — three round-trips of mayor, worker and CI
+for what one `git grep` closes.
+
+Two cautions have to travel with the rule, or the sweep does damage. **The phrase
+is usually right somewhere**: that grep also hit an invariants page whose
+timer-callback row said "one macrotask later" and meant it, plus a source file, a
+shared test suite and two benchmarks. Reading every hit is the work; the grep is
+only the index. Which is why **the brief must name the discriminator** — there it
+was *who schedules the deferral*, our own collector (repaired to a microtask)
+against React or a timer (still a macrotask). Without it a worker cannot separate
+the stale hits from the correct ones, and will change all of them or none.
 
 ## Choosing solo vs cluster
 


### PR DESCRIPTION
Closes rf2-uh9m.

Two brief-writing rules the mayor has been hand-writing into roughly a dozen
dispatches this session. They are rules for *writing a brief*, not mechanisms —
no script, no checklist, no wrapper — and they land in the template only, not in
`bootstrap.md`, so there is one source for each.

**Verified absent before writing**, as the bead required. `grep -c` still returns
**0** in both `dispatch-prompt-template.md` and `bootstrap.md` for `hash`,
`single-line anchor`, `sha256`, `Get-FileHash`, `every carrier`, `stale claim`
and `git diff`. The one hit anywhere, `bounded repair` in `bootstrap.md:231`, is
a different rule — a fence widened mid-flight by a second finding — not this one.

### Rule 1 — hash the restore

New fifth bullet in `### How a gate is run, not just which one` (the count in
that section's lead line goes `Four rules` → `Five rules`). It names both ways
`git diff` lies about a restore: a line-ending-flipping rewrite reads clean
having changed every line, and **a patch that never applied reads clean too**,
because "unchanged" and "not attempted" are the same diff. The second is the
dangerous one — a plant that silently no-ops makes the sabotage run come back
green, so the worker reports a guard that fired when nothing was ever broken, a
false proof of a real guard. Plus one clause on single-line anchors, since any
pattern crossing a newline is a coin flip on a translated checkout.

### Rule 2 — sweep every carrier

New `### Briefing a correction — sweep every carrier`, sibling to the gate block.
*"Bounded repair" bounds the change, not the search*: `git grep` the exact
wording over tracked files, read every hit, settle them in one PR, and say in the
PR body what changed and what was left standing. Both mandated cautions travel
with it, because without them the sweep does damage: **the phrase is usually
right somewhere** (the invariants timer-callback row means "one macrotask later"
literally), and **the brief must name the discriminator** (there, who schedules
the deferral — our own collector versus React or a timer).

## Quality gates

Every number below is the one **captured** to a file by `echo "$?"` on the same
command line as the gate, not one reported about the run.

| Gate | Captured exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_doc_slugs.py` (negative control, sabotaged) | **1** |
| `python scripts/check_doc_slugs.py` (after restore) | **0** |
| `python scripts/check_readme_links.py` | **0** |
| `python -m mkdocs build --strict` | **0** |
| `python scripts/check_fast_pr_gap.py --list` | **0** |

`check_doc_slugs.py` is the anchor authority here: it enrols
`docs/the-mayor-method/` explicitly (rf2-qdqf) and `mkdocs.yml` sets no
`validation:` block, so mkdocs 1.6 logs a broken same-page anchor at `info` only.
The strict build ran as `python -m mkdocs` and produced
`site/the-mayor-method/dispatch-prompt-template/index.html`, confirming this tree
is inside the site build rather than excluded from it.

**Negative control — it failed for the right reason.** A clean `check_doc_slugs.py`
run prints nothing and exits 0, which is indistinguishable from a gate that
verified nothing, so the control is what makes the green meaningful. A broken
**markdown** reference was planted (`[the control](./no-such-file-briefrules-uh9m.md)`) —
markdown specifically, because the resolver matches `.md` references only and a
broken shell or script path would not have been caught. The gate went red with
captured exit **1**, naming the file, the line and the missing target:

```
BROKEN TARGET: docs\the-mayor-method\dispatch-prompt-template.md:247 -> ./no-such-file-briefrules-uh9m.md
```

The plant and the restore were both verified by **hashing the bytes**, which is
the rule this PR adds, applied to itself. Pre-plant
`ef3a932e6a6ff7819b2c89295df2a234dfcda275ae26044e0bbebf0baf3e4c4a`; post-plant
`27bc393aaf013f5de5806e79c216fb6be0d7290e1b4f0de536d1316614757a99` (proving the
patch actually applied rather than silently matching nothing); post-restore back
to `ef3a932e…`, byte-identical, with `git status` clean. Both edits used
single-line anchors.

**Checks this local run does not decide:** `check_fast_pr_gap.py --list` reports
**97**. The one that governs this diff is the `Docs required` context (docs.yml
MkDocs build), whose local counterpart is run above. The diff is one markdown
file under `docs/`, so it reaches no CLJS, JVM, lint or MCP lane.

**Anchors and fences, checked by hand:** both edited regions are **outside** any
fence — verified by tracking fence state line-by-line, not by eye. That matters
because `docs/the-mayor-method/` is in the checker's `FENCED_DOC_LINK_TREES`, so
a markdown link inside a fenced block there fails as `LINK INSIDE A FENCE`
(`bootstrap.md`'s hard-won list is fenced `text` for exactly this reason). No
existing heading was renamed, so every anchor into this file is unchanged, and
the one new heading is not linked from anywhere. No tables were added or altered.

No residue: gate logs and exit files were written to gitignored `*.log`/`*.exit`
paths and deleted, along with `site/` and `__pycache__/`.
