### PR TITLE
test(hicasso): the reaction rebuilds at the microtask checkpoint (rf2-2l17)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/reincarnation_seams_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/reincarnation_seams_cljs_test.cljs
@@ -36,8 +36,8 @@
 
   For the reason the sibling file states at length: reads are
   address-directed so a fresh body paints correctly, `commit-basis` ties
-  so React schedules no re-render, and the repair arrives a macrotask
-  later. Rendered output is green in both directions. Every row here
+  so React schedules no re-render, and the repair arrives at the microtask
+  checkpoint. Rendered output is green in both directions. Every row here
   therefore asserts on the incarnation token, the memo row's identity, the
   successor's app-db, and the always-on `:rf.error/frame-destroyed`
   corpus record — the only observable that separates *refused* from


### PR DESCRIPTION
Closes rf2-2l17 (reopened by the merged-PR audit of #7910).

## The change

`implementation/hicasso/test/re_frame/hicasso/reincarnation_seams_cljs_test.cljs:39-40`, in the ns
docstring's *Why these observables and not rendered markup* section.

Before:

> reads are address-directed so a fresh body paints correctly, `commit-basis` ties so React
> schedules no re-render, **and the repair arrives a macrotask later**.

After:

> reads are address-directed so a fresh body paints correctly, `commit-basis` ties so React
> schedules no re-render, **and the repair arrives at the microtask checkpoint**.

Two lines, no behaviour change, no witness change. Verified at source before editing:

- `impl/collector.cljs:750` — `invalidate-cell!` defers with `js/queueMicrotask`.
- `impl/collector.cljs:719-720` — its own docstring: *"The deferral is a microtask, and that is a
  correctness requirement rather than a preference (rf2-2l17)"*.
- The witness `deftest` is named for the checkpoint
  (`reincarnation_paint_dom_cljs_test.cljs:55`, W1: *"the correction lands inside the checkpoint"*),
  and the sibling suite this docstring defers to
  (`reincarnation_cells_cljs_test.cljs:41`) already reads *"At the microtask checkpoint the deferred
  repair fires"*. The corrected sentence now agrees with the file it cites.

## The sweep — this is the fourth carrier of one stale sentence, so the search was not bounded

The same claim has now been corrected four times across three PRs (`invariants.md:126`, then
`invariants.md:110` plus a second sentence in the same paragraph, now this one), each repair found by
the *next* merged-PR audit rather than by the repair before it. So `git grep` ran over the whole
tracked tree and **every hit was read and disposed of here.**

`git grep -i macrotask` over tracked files (excluding `.beads/`) returns **362 hits in 123 files**.
The word is ordinary JS scheduling vocabulary and is overwhelmingly used correctly, so the sweep
narrowed by phrase family and then read each candidate at source.

**The discriminator applied to every hit: who schedules the deferral.** Where the *hicasso collector*
schedules `invalidate-cell!`'s deferred rebuild, rf2-2l17 repaired the scheduling and "microtask
checkpoint" is correct. Where React, a timer, a reaper or the router's drain owns it, "macrotask"
stands — and in one case the collector itself still schedules a genuine macrotask.

### Changed (1)

| file:line | disposition |
|---|---|
| `implementation/hicasso/test/re_frame/hicasso/reincarnation_seams_cljs_test.cljs:39-40` | **CHANGED.** Present-tense claim about `invalidate-cell!`'s deferred repair. Stale. |

### Left correct — the runtime schedules it, but it is still a macrotask (3)

Read at source; **`flush!`'s render-phase deferral is still `js/setTimeout … 0`**
(`impl/collector.cljs:1017`), and the cell reaper is `setTimeout 0` (`:627`). rf2-2l17 moved
`invalidate-cell!` only. These would have been the easy over-corrections.

| file:line | disposition |
|---|---|
| `implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs:332` | LEFT. `flush!`'s render-phase notification deferral — `setTimeout 0` at `:1017`. Correct. |
| `implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs:972` | LEFT. `flush!`'s own docstring, same deferral. Correct. |
| `implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs:623` | LEFT. `arm-cell-reaper!`'s "one macrotask of grace" — `setTimeout 0` at `:627`. Correct. |

### Left correct — the frozen arm1 donor copy genuinely still uses `setTimeout` (3)

`implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs:807` is a **separate copy** of
the collector and still calls `js/setTimeout … 0`. Its prose and its two tests describe *that* code
and are accurate. The bead names these as must-not-touch; source confirms it.

| file:line | disposition |
|---|---|
| `.../arm1/runtime.cljs:798` | LEFT. "**On a macrotask** the durable attachment is rebuilt" — true of `arm1`'s own `setTimeout 0` at `:807`. |
| `.../arm1/ratom_activation_cljs_test.cljs:63` | LEFT. "The rebuild claim rides a macrotask — `invalidate-cell!` defers…" — requires `arm1.runtime`. Correct. |
| `.../arm1/ratom_activation_cljs_test.cljs:215` | LEFT. "the rebuild lands on a macrotask" — same `arm1.runtime`. Correct. |

### Left correct — genuinely historical, or the sabotage control (5)

| file:line | disposition |
|---|---|
| `.../hicasso/reincarnation_cells_cljs_test.cljs:233` | LEFT. "rf2-2l17 narrowed that window **from** a whole macrotask **to** the current microtask checkpoint" — already repaired; historical by construction. |
| `.../hicasso/reincarnation_paint_dom_cljs_test.cljs:47` | LEFT. "why a macrotask correction is a *race* and not a guarantee" — the argument for the repair. |
| `.../hicasso/reincarnation_paint_dom_cljs_test.cljs:56, 105, 269, 293, 297, 317` | LEFT. `restoring-the-macrotask-deferral-…` is W1's **sabotage control**; renaming it would break the witness. |
| `.../hicasso/checkpoint_support.cljs:30, 58, 109, 137` | LEFT. `with-macrotask-deferral` restores *pre-rf2-2l17* scheduling deliberately. |
| `.../hicasso/hmr_registry_cljs_test.cljs:230` | LEFT. "rescheduled by rf2-2l17 so the correction lands before visible paint" — already correct. |

### Left correct — React or a timer owns the deferral (4)

| file:line | disposition |
|---|---|
| `.../hicasso/activity_suspense_cljs_test.cljs:363` | LEFT. Explicitly about `flush!`'s deferral (still `setTimeout 0`), in the Activity/hide window. |
| `.../hicasso/impl/presence_react.cljs:145` | LEFT. The enter flip is a literal `js/setTimeout` two lines below. |
| `.../hicasso/presence_ssr_seam_dom_cljs_test.cljs:212` | LEFT. Presence phase attributes removed at the enter flip — the same `setTimeout`. |
| `docs/design/hicasso/draft-guide/20-code-splitting.md:217` | LEFT. React re-subscribes in an effect "a task later" — **rf2-hic-014**'s React-controlled deferral, where this bead's microtask repair is unreachable. |

### Left correct — reapers, router drains, timers, other subsystems (read, not touched)

`docs/design/hicasso/product/invariants.md:150` (the timer-callback table row — a timer callback *is*
a macrotask; `:149`'s microtask row sits beside it), `invariants.md:110/114/126` (all three already
carry "microtask checkpoint"; `:126` already closes *"Settled there, and therefore settled here."*),
`impl/inventory.cljs:176-178` + `test_kit/…/mounted.cljs:751,999-1001` + `testbed/hmr_spec.cjs:489`
(the entry reaper's horizon sits deliberately *outside* a bare `setTimeout 0`),
`impl/controlled.cljs:173,177` + `.../revision_dom_cljs_test.cljs:591` +
`.../examples/slice/flow_dom_cljs_test.cljs:53` (the router's drain is a macrotask by Spec 002
design), `.../index_laws_cljs_test.cljs:395` + `.../roots_frames_support.cljs:179` +
`.../roots_frames_hydration_dom_cljs_test.cljs:121` (reaper grace / enter flip),
`.../hframe_dom_cljs_test.cljs:81,241,322,433` (real macrotask closures, the point of the rows),
`implementation/core/src/re_frame/substrate/spine.cljs:2255,2406,2410,2760`,
`implementation/core/test/re_frame/adapter/react_shared_suite.cljs:2841,4595,4646`
(re-frame.ui's `setTimeout 4` reaper, whose macrotask class is *normative* in
`spec/006-ReactiveSubstrate.md:1091`), plus `spec/002-Frames.md:1864-1891`,
`docs/EP/EP-0032:155,297`, `implementation/ui/**`, `implementation/adapters/**`,
`implementation/routing/**`, `implementation/http/**`, `implementation/ssr/**`, `tools/story/**`,
and the remaining `docs/design/hicasso/studio/**` measurement records (all 39 hits under
`docs/design/hicasso/studio/`, `validation.md`, `authoring-report-slice.md` and `docs/EP/` were read:
they are reaper horizons, Reagent's `next-tick` disposals, `MessageChannel` posts, the post-paint
disposal window, and the `:macrotask` rung of a measurement ladder). **EP-0032:155 and :297 are worth
naming because they cut the other way**: re-frame.ui's tear-correction flush is specified as *"a true
microtask (never a macrotask that could let a torn frame…)"* — the same law as this bead, already
stated correctly. Every one of these is about a reaper, a router drain, a real timer, a measurement
rung, or React's own scheduling. **None describes `invalidate-cell!`'s deferred rebuild.**

### Phrase-family greps run (all read, all disposed)

`"macrotask later"` (21 hits), `"a macrotask"` (75), `"repair arrives"` (1 — the target),
`"correction arrives"` (4), `"repair lands"` (0), `"correction lands"` (3), `"rebuild lands"` (1),
`"commit-basis ties"` (0), `"schedules no re-render"` (1 — the target), `"rebuilt a macrotask"` (0),
`"rebuilds it a macrotask"` (0), `"deferred to a later task"` (0), and `invalidate-cell` across every
tree outside `hicasso/` and `arm1/` (3 hits, none a timing claim).

**Nothing else in the tracked tree carries the stale claim.** There is no fifth carrier.

## Quality gates

Run one at a time, foreground, each redirected to its own file with the exit code captured on the
same command line. The numbers below are the ones captured, not the harness's summary line.

| gate | command | captured exit |
|---|---|---|
| CLJS node lane (the lane that runs this file) | `cd implementation && npm run test:cljs` | `NODETEST_EXIT=0` |
| Fast-PR spine | `scripts/test-fast-pr.sh` | `SPINE_EXIT=0` |
| Fast-PR gap list | `python scripts/check_fast_pr_gap.py --list` | `GAP_EXIT=0` |

`check_fast_pr_gap.py --list` reports **97 required checks the spine does not decide** — the three
required contexts are `All required checks passed` (test.yml), `Lint required` (lint.yml) and
`Docs required` (docs.yml), and none of the 45 test.yml jobs, 5 lint.yml jobs or docs.yml's detect
job is decided locally. Most are surface-gated and will skip on this diff, which touches one CLJS
test docstring and nothing else; the ones that matter here are `cljs-node-test` (run above) and
clj-kondo, whose CI pin (2026.04.15) is not installed locally, so it is left to CI by design.

No `docs/**` file changed, so `scripts/check_doc_slugs.py` has no changed surface to gate; noting for
the record that `mkdocs build --strict` excludes `docs/design/**` and would have verified nothing
there had the sweep needed an edit in that tree.

Gate artefacts were written outside the repository (session scratchpad). No residue in the worktree.
