### PR TITLE
test(hicasso): executable sabotage controls for kernel risk rows 2 and 8 (rf2-1mmn)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/presence_ssr_seam_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/presence_ssr_seam_dom_cljs_test.cljs
@@ -137,8 +137,10 @@
   ONE sabotage covers all four rows, because all four read the same
   producer: give `server-bytes!` a window (the body of
   [[server-bytes-under-a-hand-held-window!]]) and the Render repair is
-  simulated end to end. Run by hand under `:browser-test`; the PR body
-  quotes the failures verbatim. §1, §2 and §3 all red — nine assertions
+  simulated end to end. Run by hand under `:browser-test` for **PR #7872**,
+  landed on main as commit `b5e03b138f` — named rather than left as \"the
+  PR body\", so the record can be reached from the tree (rf2-1mmn). §1, §2
+  and §3 all red — nine assertions
   across the three — and **§4 stays green**, which is the control doing
   its job.
 
@@ -320,7 +322,8 @@
 ;; body for real — hooks, context reads and all — so what it emits is what
 ;; `roots/adopting-here?` answered inside a genuine server render.
 ;;
-;; SABOTAGE (run by hand; the namespace header and the PR body record it):
+;; SABOTAGE (run by hand; the namespace header records it, and names the PR
+;; and the landed commit — PR #7872, commit `b5e03b138f`):
 ;; give `server-bytes!` a window — the body of
 ;; [[server-bytes-under-a-hand-held-window!]] — and this row reds three ways
 ;; at once: `"present"` in the bytes, `:present` off the machine, and the

--- a/implementation/hicasso/test/re_frame/hicasso/public_root_lifecycle_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/public_root_lifecycle_dom_cljs_test.cljs
@@ -250,3 +250,126 @@
               "this witness left its own container in the shared
                browser-test document")
           (collector/reset-runtime!))))))
+
+;; ---------------------------------------------------------------------------
+;; W3 (rf2-1mmn) — THE EXECUTING SABOTAGE CONTROL for kernel risk row 2
+;; ---------------------------------------------------------------------------
+
+(defn- pre-rf2-31xm-teardown!
+  "The public teardown door AS IT WAS BEFORE rf2-31xm narrowed it: take
+  this root down, drop its container, and empty the process-global
+  runtime.
+
+  **The sabotage needs no mock and no seam, because that door still
+  exists under an honest name.** `impl.mount/release!` is `unmount!` plus
+  the container removal plus `collector/reset-runtime!` — precisely the
+  meaning rf2-31xm took off the public facade, retained as the fixture
+  door for a suite that owns the whole page. So the mutation is not a
+  hypothetical reconstruction: it is the shipped page-wide door, called
+  where the root-scoped one belongs.
+
+  This is the one place in this file where `impl.mount` performs an act
+  rather than taking a reading, and the header's rule survives it whole.
+  That rule forbids the impl door from doing what the PUBLIC door is
+  supposed to be able to do; total teardown is the one thing the public
+  door must NOT be able to do, which is the whole of rf2-31xm."
+  [handle]
+  (mount/release! handle))
+
+;; Kernel risk row 2 of `docs/design/hicasso/product/lanes/adversarial-risks.md`
+;; — *independent roots and SSR requests cannot reset, adopt, dirty, or release
+;; one another's state* — is a correctness gate, and that register's gate
+;; construction rule asks every one of them for "a sabotage mutation that makes
+;; each correctness gate red". Until rf2-1mmn this family had none that ran:
+;; this suite and `roots-frames-isolation-dom-cljs-test` carried no sabotage in
+;; any form, and a reviewer cannot re-run what is not there.
+;;
+;; The mutation is the register's own first verb. `collector/reset-runtime!`
+;; empties every table this arm holds, and every one of them is one-per-page
+;; and keyed by frame — its docstring says so out loud — so a teardown door
+;; that calls it releases every sibling root's state along with its own. W1
+;; above asserts that root A's teardown does not. This row plants the door
+;; that does, and watches W1's three readings invert.
+;;
+;; Both halves run the same construction, and they red in opposite directions:
+;;
+;;   - the ARMED half reds if the page-wide door stops being page-wide, which
+;;     is what a control that has quietly become a no-op looks like;
+;;   - the DISARMED half reds if root-scoped teardown regresses to page-wide,
+;;     which is the defect W1 exists to catch, and which shipped once already.
+;;
+;; The stranding reading is the one worth having, and it is why the row does
+;; not stop at the counts. A runtime emptied under a live root throws nothing
+;; and clears nothing: the markup React last committed stays on the page, the
+;; mount point stays connected, and the only symptom is a screen that has
+;; stopped moving. The armed half asserts all three — dead tables, a frozen
+;; label, and a page that still looks perfectly well.
+(deftest a-page-wide-teardown-door-strands-the-sibling-root
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      ;; DISARMED — the shipped root-scoped door.
+      (let [_ (fresh!)
+            a (h/root! (mount/fresh-container!) frame-a [panel {:tag "a"}])
+            b (h/root! (mount/fresh-container!) frame-b [panel {:tag "b"}])]
+        (try
+          (is (= #{[frame-a label-q] [frame-b label-q]} (cell-keys))
+              (str "premise: two roots, two frames, one cell each; got "
+                   (pr-str (cell-keys))))
+          (h/unmount! a)
+          (testing "DISARMED — root B keeps its cell, keeps its reader, and stays
+                    LIVE across its sibling's teardown"
+            (is (contains? (cell-keys) [frame-b label-q])
+                (str "got " (pr-str (cell-keys))))
+            (is (= 1 (readers-of [frame-b label-q])))
+            (mount/dispatch! b [::relabel "beta-again"])
+            (is (= "beta-again" (text-at b ".label"))
+                "root B stopped repainting when root A was torn down"))
+          (finally
+            (h/unmount! b)
+            (detach! a)
+            (detach! b)
+            (is (= [false false] [(connected? a) (connected? b)])
+                "this witness left one of its own containers in the shared
+                 browser-test document")
+            (collector/reset-runtime!))))
+
+      ;; ARMED — the same construction, torn down through the page-wide door.
+      (let [_ (fresh!)
+            a (h/root! (mount/fresh-container!) frame-a [panel {:tag "a"}])
+            b (h/root! (mount/fresh-container!) frame-b [panel {:tag "b"}])]
+        (try
+          (is (= #{[frame-a label-q] [frame-b label-q]} (cell-keys))
+              (str "premise: the same two roots as the disarmed half; got "
+                   (pr-str (cell-keys))))
+          (pre-rf2-31xm-teardown! a)
+          (testing "ARMED — root A's teardown reached the process-global runtime
+                    and took root B's state with it"
+            (is (= #{} (cell-keys))
+                (str "THE SABOTAGE DID NOT SABOTAGE — the page-wide door left the
+                      cell table standing, so W1's key reading is not a
+                      discrimination; got " (pr-str (cell-keys))))
+            (is (zero? (readers-of [frame-b label-q]))
+                "root B's boundary must have lost the cell it was reading"))
+
+          (testing "and root B is STRANDED — the half a count cannot show.
+                    Nothing threw, nothing complained, its markup is the markup
+                    React last committed and its mount point is still connected.
+                    The only symptom is a screen that has stopped moving, which
+                    is exactly why W1 reads the tables and the dispatch rather
+                    than the DOM"
+            (mount/dispatch! b [::relabel "beta-again"])
+            (is (= "beta" (text-at b ".label"))
+                (str "the page-wide door left root B repainting, so the dispatch
+                      reading in W1 is not a discrimination either; got "
+                     (pr-str (text-at b ".label"))))
+            (is (true? (connected? b))
+                "and the page still looks perfectly well"))
+          (finally
+            (h/unmount! b)
+            (detach! a)
+            (detach! b)
+            (is (= [false false] [(connected? a) (connected? b)])
+                "this witness left one of its own containers in the shared
+                 browser-test document")
+            (collector/reset-runtime!)))))))

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
@@ -271,9 +271,21 @@
 ;; every later recoverable error on either root a "hydration mismatch";
 ;; H4 below is the row that separates those two.
 ;;
-;; SABOTAGE (run by hand, PR body records it): mint ONE window in
-;; `hydrate-root!` and hand it to both roots, and this row goes red on the
-;; count — one root's closer shuts the other's window again.
+;; SABOTAGE, and why it does not execute HERE (rf2-1mmn). The mutation is
+;; "mint ONE window in `hydrate-root!` and hand it to both roots": one root's
+;; closer then shuts the other's window and this row reds on the count. It is
+;; armable — `sup/with-page-global-adoption` IS that mutation, executing — but
+;; not against this row, and the reason is the one H4 below gives for driving
+;; the doors directly: whether the count collapses depends on the relative
+;; ordering of root A's closer and root B's recoverable-error callback, and
+;; React does not let a caller choose that ordering. An executing form of THIS
+;; row would go green or red on the scheduler, which is a worse control than
+;; none. The hand run against this row's count is PR #7756, landed on main as
+;; commit `fdbf5d6907` — a pointer that can be followed without the GitHub UI,
+;; which "the PR body records it" could not. The family's executing control is
+;; [[a-page-global-adoption-window-steals-an-ordinary-roots-enter-transition]]
+;; below, which arms the same mutation where the readings are taken by
+;; construction rather than on a schedule.
 (deftest two-overlapping-hydrating-roots-recover-and-complain-independently
   (async done
     (if-not (mount/browser?)
@@ -535,10 +547,14 @@
 ;; commits inside a `flushSync` so root B's first render is readable on the
 ;; line after it. No timer stands between the two.
 ;;
-;; SABOTAGE (run by hand, PR body records it): point `impl.presence-react`
-;; back at a page-wide window and the ordinary root's first phase becomes
-;; `:present` — this row reds on that assertion, which is the assertion the
-;; shipped code failed.
+;; SABOTAGE, EXECUTING (rf2-1mmn):
+;; [[a-page-global-adoption-window-steals-an-ordinary-roots-enter-transition]]
+;; below arms exactly this mutation — `sup/with-page-global-adoption` points
+;; the window `impl.presence-react` reads back at a page-wide one — runs this
+;; row's construction under it, and asserts the ordinary root's first phase is
+;; `:present`. That is the assertion the shipped code failed, going red on
+;; demand rather than being described. It was first run by hand for PR #7756,
+;; landed on main as commit `fdbf5d6907`.
 (deftest presence-adoption-belongs-to-a-subtree-not-to-the-page
   (async done
     (if-not (mount/browser?)
@@ -645,3 +661,120 @@
                                 (mount/release! ha)
                                 (mount/release! hb)
                                 (done)))))))))))))))
+
+;; ---------------------------------------------------------------------------
+;; H6 — THE EXECUTING SABOTAGE CONTROL for this risk family (rf2-1mmn)
+;; ---------------------------------------------------------------------------
+
+;; Kernel risk row 8 of `docs/design/hicasso/product/lanes/adversarial-risks.md`
+;; — *adoption and mismatch attribution are root-scoped; simultaneous roots
+;; cannot cross-contaminate* — is a correctness gate, and that register's gate
+;; construction rule asks every one of them for "a sabotage mutation that makes
+;; each correctness gate red". Until rf2-1mmn this family had none that ran.
+;; The mutations were prose, and a reviewer cannot re-run a comment.
+;;
+;; This row is the mutation, executing. `sup/with-page-global-adoption` restores
+;; the pre-rf2-6tmu page-global window — one ref for the whole page, read by
+;; every presence tray on it — and the row runs H5's construction under it and
+;; again without it, changing nothing else in between. Both halves are
+;; load-bearing and they red in opposite directions:
+;;
+;;   - the ARMED half reds if the sabotage stops sabotaging, which is what a
+;;     control that has quietly become a no-op looks like from the outside;
+;;   - the DISARMED half reds if the runtime regresses to a page-global window,
+;;     which is the defect H5 exists to catch.
+;;
+;; Together they say what neither says alone: the `:mounting` H5 asserts is a
+;; DISCRIMINATION rather than a ceiling, and there is a live, re-runnable
+;; mutation that turns it into `:present`.
+;;
+;; The disarmed half is strictly stronger than H5, and by one line: the armed
+;; half's page-wide window is asserted STILL OPEN while the shipped tray reads
+;; its phase. So what the tray answers is the scoping doing its work, not the
+;; absence of any window anywhere.
+;;
+;; Every reading is synchronous, and deliberately. `hydrate-root!` returns
+;; before its tree is adopted and `root!` commits inside a `flushSync`, so the
+;; ordinary root's first render is readable on the line after it mounts and is
+;; provably inside the hydrating root's window. No timer stands anywhere in the
+;; readings — a control that went green or red on the scheduler would be worse
+;; than none.
+(deftest a-page-global-adoption-window-steals-an-ordinary-roots-enter-transition
+  (async done
+    (if-not (mount/browser?)
+      (do (sup/skip! ":node-test has no DOM") (done))
+      (do
+        (fresh!)
+        (reset! !phases {})
+        (let [html (sup/server-html! frame-a [screen {:title "A"}])]
+          (collector/reset-runtime!)
+          (let [armed
+                (sup/with-page-global-adoption
+                  (fn [page-window]
+                    (is (false? (roots/adopting? page-window))
+                        "premise: the page-global window is SHUT before anything
+                         hydrates, so an open one below was opened by a ROOT and
+                         not handed over by the arming")
+                    (let [ha (mount/hydrate-root! (sup/server-dom! html) frame-a
+                                                  [screen {:title "A"}])]
+                      (is (true? (roots/adopting? page-window))
+                          "premise: root A's hydration opened it — and under this
+                           mutation it is the only window there is")
+                      {:ha          ha
+                       :page-window page-window
+                       :hb          (mount/root! (mount/fresh-container!) frame-b
+                                                 [tray-screen {:tag :under-page-global}])})))
+                disarmed
+                (let [ha (mount/hydrate-root! (sup/server-dom! html) frame-a
+                                              [screen {:title "A"}])]
+                  (is (not (identical? (:adoption ha) (:page-window armed)))
+                      "premise: the arming restored the per-root mint, so this
+                       root's window is its own — a half that inherited the
+                       page-global would be no control at all")
+                  (is (true? (roots/adopting? (:adoption ha)))
+                      "premise: root A is adopting in this half too, so the two
+                       halves differ only in the SCOPE of its window")
+                  (is (true? (roots/adopting? (:page-window armed)))
+                      "premise: and the armed half's PAGE-WIDE window is still
+                       open on this line — so what the tray below reads is the
+                       scoping, not the absence of a window")
+                  {:ha ha
+                   :hb (mount/root! (mount/fresh-container!) frame-b
+                                    [tray-screen {:tag :under-root-scoped}])})]
+
+            (testing "ARMED — the ordinary root's tray was told it was adopting,
+                      though it is adopting nothing. Its children are born
+                      `:present` and the enter transition its author wrote never
+                      runs: no error, no complaint, an animation that simply does
+                      not play, and only while some unrelated root happens to be
+                      hydrating"
+              (is (= :present (first (get @!phases :under-page-global)))
+                  (str "THE SABOTAGE DID NOT SABOTAGE — this control has become a
+                        no-op and H5's green means nothing; saw "
+                       (pr-str (get @!phases :under-page-global))))
+              (is (= "present" (text-in (:container (:hb armed)) ".probe"))
+                  "and it reached the DOM that way"))
+
+            (testing "DISARMED — the same construction with the shipped
+                      root-scoped window, and the ordinary root has its ENTER
+                      phase back. H5's assertion, taken here so the contrast is
+                      one row's pair of readings rather than two files'"
+              (is (= :mounting (first (get @!phases :under-root-scoped)))
+                  (str "the runtime read a window this root does not own; saw "
+                       (pr-str (get @!phases :under-root-scoped))))
+              (is (= "mounting" (text-in (:container (:hb disarmed)) ".probe"))))
+
+            (-> (js/Promise.all #js [(sup/adopted! (:ha armed))
+                                     (sup/adopted! (:ha disarmed))])
+                (.then
+                  (fn [oks]
+                    (try
+                      (is (= [true true] (vec oks))
+                          "both hydrating roots must reach their own closer, or
+                           this row left an open window behind")
+                      (finally
+                        (mount/release! (:hb armed))
+                        (mount/release! (:ha armed))
+                        (mount/release! (:hb disarmed))
+                        (mount/release! (:ha disarmed))
+                        (done))))))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_shared_frame_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_shared_frame_dom_cljs_test.cljs
@@ -329,10 +329,19 @@
 ;; the windows are compared by IDENTITY, which a registry keyed by anything
 ;; these two roots share cannot satisfy however it is implemented.
 ;;
-;; MUTATION (PR body records the red): key the window off the frame in
+;; MUTATION, and where its record can be REACHED (rf2-1mmn): key the window
+;; off the frame in
 ;; `hydrate-root!` — mint into a `defonce` map on first use per frame and
 ;; hand both roots the same object — and this row reds on `identical?` and
-;; again on root B still adopting after root A's window is shut.
+;; again on root B still adopting after root A's window is shut. Run by hand
+;; for **PR #7800**, landed on main as commit `00fb33b57c`; "the PR body
+;; records it" named neither, and this repository rebase-merges, so a branch
+;; head is not the commit that landed. Both roots here name ONE frame, so
+;; `sup/with-page-global-adoption` — the executing form of the page-global
+;; mutation — would arm an observationally identical defect against this row
+;; if a second control for this axis is ever wanted. The kernel family's
+;; executing control is the sibling suite's
+;; `a-page-global-adoption-window-steals-an-ordinary-roots-enter-transition`.
 (deftest two-hydrating-roots-on-one-frame-hold-windows-of-their-own
   (async done
     (if-not (mount/browser?)

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
@@ -447,3 +447,52 @@
   whichever slots the envelope hoists."
   [ev]
   (merge (:tags ev) ev))
+
+;; ---------------------------------------------------------------------------
+;; The sabotage — the page-global adoption window, restored and executing
+;; ---------------------------------------------------------------------------
+
+(defn with-page-global-adoption
+  "Run `f` with the PRE-rf2-6tmu **page-global** adoption window restored,
+  and put the shipped doors back afterwards whatever `f` does. Answers
+  what `f` answers; `f` is handed the page-global window itself, so a row
+  can assert on the state its readings are taken in.
+
+  `checkpoint-support/with-macrotask-deferral` is the model, and the
+  claim is the same one: the code under test is unmodified and unaware.
+  Two writes, because the defect was ONE FACT IN TWO PLACES and either
+  alone is a different bug:
+
+  - `impl.roots/open-adoption-window!` answers one ref for the whole page
+    instead of minting a fresh one per root, so every hydrating root
+    shares a window and the FIRST closer shuts it for all of them.
+  - `impl.roots/adopting-here?` reads THAT ref rather than the React
+    context above it, so every presence tray on the page answers to it —
+    including one in an ordinary root that is adopting nothing.
+
+  Everything else is the shipped code: the window object has the shipped
+  shape, `adopting?`, `close-adoption-window!`, `with-adoption` and
+  `impl.mount/adoption-window-closer` are untouched, and `hydrate-root!`
+  mints through the same door it always did. What this moves is the
+  window's SCOPE and nothing else, which is exactly the mutation the
+  hydration suite's rows used to describe in prose.
+
+  **Born SHUT**, unlike a real window, and that is what keeps a row using
+  it honest: nothing is adopting until a root hydrates, so a row has to
+  open it the way the page does — by hydrating — rather than inheriting
+  an open flag from the arming. A row that asserts the shut premise first
+  cannot pass on a sabotage that was simply switched on.
+
+  A fresh page-window per arming, so two armings in one row cannot
+  inherit each other's shut."
+  [f]
+  (let [page-window   #js {"open" false}
+        mint-original roots/open-adoption-window!
+        here-original roots/adopting-here?]
+    (set! roots/open-adoption-window!
+          (fn [] (set! (.-open page-window) true) page-window))
+    (set! roots/adopting-here? (fn [] (roots/adopting? page-window)))
+    (try (f page-window)
+         (finally
+           (set! roots/open-adoption-window! mint-original)
+           (set! roots/adopting-here? here-original)))))

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
@@ -484,14 +484,32 @@
   cannot pass on a sabotage that was simply switched on.
 
   A fresh page-window per arming, so two armings in one row cannot
-  inherit each other's shut."
+  inherit each other's shut.
+
+  **The replacement reader still takes the context hook, and must.**
+  `adopting-here?` is a React HOOK — the shipped one is a `useContext` —
+  and a replacement that simply answered the page-global would render
+  `impl.presence-react` with three hooks where the shipped code renders
+  four. React counts hooks per fiber, so the same tray re-rendering after
+  the arming was undone would raise \"rendered more hooks than during the
+  previous render\": a sabotage breaking a DIFFERENT rule than the one
+  under test, and a red that says nothing about adoption. So the original
+  is called first, unconditionally and outside the `or`, and its answer
+  is widened rather than replaced. For an ordinary root — every row this
+  arms — the context answers false and the reading IS the page-global,
+  which is the pre-fix behaviour exactly."
   [f]
   (let [page-window   #js {"open" false}
         mint-original roots/open-adoption-window!
         here-original roots/adopting-here?]
     (set! roots/open-adoption-window!
           (fn [] (set! (.-open page-window) true) page-window))
-    (set! roots/adopting-here? (fn [] (roots/adopting? page-window)))
+    (set! roots/adopting-here?
+          (fn []
+            ;; Let-bound, never inlined into the `or`: short-circuiting
+            ;; past it would skip the hook, which is the whole hazard.
+            (let [in-this-roots-own-window? (here-original)]
+              (or (roots/adopting? page-window) in-this-roots-own-window?))))
     (try (f page-window)
          (finally
            (set! roots/open-adoption-window! mint-original)


### PR DESCRIPTION
Closes rf2-1mmn. Does **not** close rf2-hic-019, which stays open for re-dispatch to a reviewer who did not write these fixes.

Kernel risk rows **2 (process-global ownership)** and **8 (hydration isolation)** of `docs/design/hicasso/product/lanes/adversarial-risks.md` had no executing sabotage control, so `rf2-hic-019`'s protocol §2 — *"independently re-run one sabotage control per risk family (all eight)"* — could not be discharged for either. Two witnesses had none in any form; the rest were prose, and every one of them said *"the PR body records it"* without naming a PR or a commit.

Each row now has one control an independent reviewer can run and watch redden, and every mutation that stays prose names its PR number **and its landed commit**.

## What each row asserts, and where its control went

**Row 2 — process-global ownership.** *Independent roots and SSR requests cannot reset, adopt, dirty, or release one another's state.* Its witness set had no sabotage at all: neither `roots_frames_isolation_dom_cljs_test` nor `public_root_lifecycle_dom_cljs_test` contained the word.

The control is `a-page-wide-teardown-door-strands-the-sibling-root`, in `public_root_lifecycle_dom_cljs_test.cljs` — the suite whose W1 asserts that root A's teardown does not reach root B, and the suite rf2-31xm wrote.

**It needs no mock, no seam and no redefinition, because the pre-fix door still exists under an honest name.** `impl.mount/release!` is `unmount!` plus the container removal plus `collector/reset-runtime!` — precisely the meaning rf2-31xm took off the public facade, kept as the fixture door. `reset-runtime!`'s own docstring states the defect: *"Every table it empties is one-per-page and keyed by frame, so calling it to tear a root down empties the runtime under every other root on the page too."* So the mutation is the shipped page-wide door, called where the root-scoped one belongs.

**Row 8 — hydration isolation.** *Adoption and mismatch attribution are root-scoped; simultaneous roots cannot cross-contaminate.*

The control is `a-page-global-adoption-window-steals-an-ordinary-roots-enter-transition`, in `roots_frames_hydration_dom_cljs_test.cljs`, armed by a new `roots-frames-support/with-page-global-adoption` modelled on `checkpoint-support/with-macrotask-deferral`. It restores the pre-rf2-6tmu page-global window — one ref for the whole page, read by every presence tray on it — and puts both shipped doors back in a `finally`. It is the mutation the H5 comment described in prose, executing.

## Both controls run both halves

Each control runs the same construction twice, armed and disarmed, so it reds in two directions rather than one: the **disarmed** half reds if the runtime regresses, and the **armed** half reds if the sabotage has quietly become a no-op. A control that only ever observes the healthy state cannot tell "the guard is exact" from "the guard is absent and so is the mutation".

Row 8's disarmed half is strictly stronger than H5 by one line: it asserts the armed half's page-wide window is **still open** while the shipped tray reads its phase, so what the tray answers is the scoping doing its work rather than the absence of any window.

Every reading in both controls is synchronous. `hydrate-root!` returns before its tree is adopted and `root!` commits inside a `flushSync`, so the ordinary root's first render is readable on the line after it mounts and provably inside the hydrating root's window. No timer stands in any reading.

## One refusal, source-located

The H2 comment's mutation — *mint ONE window in `hydrate-root!` and hand it to both roots, and the mismatch count collapses* — is **armable but not executable against that row**, and the comment now says so and why. Whether the count collapses depends on the relative ordering of root A's closer and root B's recoverable-error callback, and React does not let a caller choose that ordering: an executing form of H2 would go green or red on the scheduler, which is a worse control than none. That is H4's own stated reason for driving the doors directly. The hand run against H2's count is now named as PR #7756, landed commit `fdbf5d6907`.

## The dangling pointers

`"the PR body records it"` named no PR, and this repository rebase-merges, so a branch head is not the commit that landed. Every one now carries both, recovered with `gh api repos/day8/re-frame2/commits/<sha>/pulls`:

| site | now names |
|---|---|
| `roots_frames_hydration_dom_cljs_test.cljs` H2 | PR #7756, commit `fdbf5d6907`, plus the executing control |
| `roots_frames_hydration_dom_cljs_test.cljs` H5 | the executing control below it; PR #7756, commit `fdbf5d6907` |
| `roots_frames_shared_frame_dom_cljs_test.cljs` S3 | PR #7800, commit `00fb33b57c` |
| `presence_ssr_seam_dom_cljs_test.cljs` §header, §1 | PR #7872, commit `b5e03b138f` |

`correction-ledger.md` is deliberately untouched: per the PR #7726 protocol sync recorded on rf2-hic-019, corrective PRs never edit it — the ledger keeper writes closure evidence after the merge.

The S2 reasoning note at `roots_frames_shared_frame_dom_cljs_test.cljs:240` is left as prose, as rf2-1mmn instructs: it records *why* no single-point mutation reds that row, and is worth more as prose than as a test.

## Quality gates

Every gate was run alone, redirected to a file, with `$?` echoed to a `.exit` file on the same command line. **The numbers below are the captured ones.** Twice in this session the harness reported *completed (exit code 0)* against a captured `1` — both times on a planted run that was supposed to be red — so the `.exit` file is what is quoted.

| gate | captured exit | result |
|---|---|---|
| `npm run test:browser` — **decides this bead** | `0` | Ran 1263 tests / 7876 assertions. 0 failures, 0 errors. |
| `npx shadow-cljs compile node-test-hicasso && node out/node-test-hicasso.js` | `0` | Ran 617 tests / 2684 assertions. 0 failures, 0 errors. |
| `sh scripts/test-fast-pr.sh` | `0` | `PASS fast PR spine`. Not run by it: documentation gates, all JVM artefact suites, spine self-test — each surface unchanged. |

The browser lane on `origin/main@98b417466a` before this branch: Ran **1261** tests / **7855** assertions, 0 failures, 0 errors. The two new controls are the +2 tests and +21 assertions.

`python scripts/check_fast_pr_gap.py --list` reports **97 required checks the spine does not decide**, so a green spine is not a green CI. Of those, the ones this diff plausibly reaches are the browser lanes — which is why `test:browser` was run here rather than left to CI — plus the `:node-test` always-on gate, which was also run. The spine itself owns no browser tier at all.


## Plant and restore, per row

Both plants are edits to **runtime source**, run through the real browser lane, then reverted and verified by hashing the bytes — `git hash-object` before and after, not `git diff`, because on this CRLF checkout a failed patch and a line-ending rewrite both read clean in a diff.

### Row 2 — plant `impl.mount/unmount!` calling `collector/reset-runtime!`

That is the pre-rf2-31xm public teardown door restored in the shipped one.

- **Planted, browser lane captured exit `1`** — 1263 tests / 7876 assertions, **24 failures, 0 errors** across seven namespaces.
- `a-page-wide-teardown-door-strands-the-sibling-root` **red three times, naming itself**, and every one of them in its DISARMED half:
  - `expected: (contains? (cell-keys) [frame-b label-q])` / `actual: (not (contains? #{} …))`
  - `expected: (= 1 (readers-of [frame-b label-q]))` / `actual: (not (= 1 0))`
  - `root B stopped repainting when root A was torn down` — `expected: (= "beta-again" (text-at b ".label"))` / `actual: (not (= "beta-again" "beta"))`
- Its **ARMED half stayed green**, which is the correct reading: the plant makes the shipped door page-wide, so the two halves converge and only the disarmed one can move.
- **Restored**, `git hash-object` back to `ddf06f21e0ae2112031de6f835da389ed6760ec3` — byte-identical.

### Row 8 — plant `impl.roots` back onto a page-global window

`open-adoption-window!` answers a module `defonce` and `adopting-here?` reads it instead of the context: the pre-rf2-6tmu design.

- **Planted, browser lane captured exit `1`** — 1263 tests / 7868 assertions, **17 failures, 0 errors** across seven namespaces.
- `a-page-global-adoption-window-steals-an-ordinary-roots-enter-transition` **red twice, naming itself**, both in its DISARMED half:
  - `the runtime read a window this root does not own; saw [:present]` — `expected: (= :mounting (first (get @!phases :under-root-scoped)))` / `actual: (not (= :mounting :present))`
  - `expected: (= "mounting" (text-in (:container (:hb disarmed)) ".probe"))` / `actual: (not (= "mounting" "present"))`
- Its **ARMED half stayed green** — the sabotage still sabotages.
- **Restored**, `git hash-object` back to `f14af1f7ae4042536d48ff0c86ee47f3308dd8ee` — byte-identical.

Both plants also reddened the rows they should: row 2's took `tearing-one-root-down-leaves-the-other-root-live` (W1, 3), `unmounting-one-root-decrements-the-shared-key-and-does-not-dispose-it` (5), `a-root-whose-teardown-throws-cannot-strand-its-siblings-state` (5), `unmounting-one-root-releases-its-keys-and-leaves-the-other-live` (4) and two more; row 8's took `presence-adoption-belongs-to-a-subtree-not-to-the-page` (H5, 3), `a-completed-roots-later-recovery-is-not-a-mismatch-while-a-sibling-adopts` (H4, 5), both shared-frame window rows and H2. Neither plant touched the other row's control.
