### PR TITLE
docs(hicasso): replace draft-guide with new-hiccaso-guide corpus

### DIFF
--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -315,7 +315,7 @@ the sites, emit the `defhost`, rewrite the call sites — and all three are by
 hand. The shipped migration codemod is a props-dialect **fixer**: it repairs the
 crossings you already have and leaves them `[:>]`, minting no declaration and
 hoisting nothing. The hoist that would mint them is demand-gated and unbuilt
-([the codemod](draft-guide/19-migration-from-reagent.md#step-4--run-the-codemod)).
+([the codemod](draft-guide/19-migration-from-reagent.md#4-apply-the-mechanical-codemod)).
 **The one raw escape** (HD-011), explicitly secondary to the declaration:
 `[:> Component props & children]` — same foreign lowering path, same default
 conversions, `.cljs`-only at that node, reduced structural identity; for

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1365,7 +1365,7 @@ map or chart instance) or spending an effect. The recommended later shape is
 therefore **attach/detach only, config immutable for the connection's life, and
 steady-state change routed through a command effect**, which is already data.
 This limit is taught in the guide
-([Interop](draft-guide/09-interop.md#imperative-sdks))
+([Interop](draft-guide/09-interop.md#imperative-sdks-with-callback-refs))
 rather than left to be discovered.
 **Reopens** when the component-library tier is chartered — the reservation exists
 to make that reopening non-breaking.

--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -1,80 +1,129 @@
 # Getting started
 
-re-frame2 already has events, app-db, subscriptions, and frames. What you still
-choose is **how views are written** — the view adapter that turns view code
-into something React can mount.
+re-frame2 already defines how events update app-db and how subscriptions derive
+values. A view adapter decides how those values become React UI. Hicasso is the
+adapter for applications that want the view tree to remain ordinary
+ClojureScript data.
 
 ## What Hicasso is
 
-[Hicasso](glossary.md#hicasso) is re-frame2's view adapter built around
-interpreted [Hiccup](../../../core/glossary.md#hiccup). You write ordinary
-ClojureScript data: vectors for markup, maps for props, and event vectors in
-handler attributes. Where you need a subscription value, you call
-[`h/sub`](glossary.md#hsub) like any other function. The runtime turns that
-tree into React function-component elements.
+[Hicasso](glossary.md#hicasso) interprets
+[Hiccup](../../../core/glossary.md#hiccup) and produces React
+function-component elements. You write vectors for markup, maps for props, and
+event vectors in handler attributes. Where a view needs a subscription value,
+it calls [`h/sub`](glossary.md#hsub).
 
-App-db, event handlers, subscriptions, and frames stay ordinary re-frame2.
-Hicasso is the view language on top of that pipeline.
+```clojure
+(h/defview todo-row [{:keys [id]}]
+  (let [todo (h/sub [:todo/by-id id])]
+    [:li
+     [:span (:title todo)]
+     [:button {:on-click [:todo/toggle id]} "Toggle"]]))
+```
 
-It is not the only legal way to write views. Reagent and UIx adapters remain
-supported products you can ship on indefinitely. Hicasso is the path that
-keeps markup as data, subscription reads as ordinary calls, and click handlers
-as values a test can compare with `=`.
+Nothing outside the view layer changes. App-db, event handlers, subscriptions,
+effects, and frames use the normal re-frame2 APIs.
 
-## Beside Reagent and UIx
+Hicasso is not the only supported adapter. Reagent and UIx remain valid choices
+that applications can keep using.
 
-**Reagent** is how many re-frame apps already paint: Hiccup that feels like
-HTML, reactions that track reads, and a large ecosystem. If you are migrating
-a Reagent app, Hicasso is close in shape —
-[Migrating from Reagent](19-migration-from-reagent.md) is built for that path.
-You leave reaction-local state and Form-2 ceremony; you keep the tree of
-vectors.
+## What changes in a Hicasso view
 
-**UIx** is the better fit when the screen is React-first: hooks everywhere, a
-mature component library at the centre, authors who already think in React.
-Hicasso does not try to win that contest. Foreign React still enters through
-[`h/defhost`](09-interop.md), and a measured hot region can drop into native
-React or UIx under the same root and frame
-([Native tier](10-native-tier.md)). Pick UIx when the product *is* a React app
-that uses re-frame2 for state. Pick Hicasso when the product is a re-frame2
-app that wants data all the way to the leaf.
+### Markup and common handlers remain data
 
-## What you write differently
+The button above contains the event vector `[:todo/toggle id]` directly. The
+runtime creates the React callback and dispatches that vector when the button
+is clicked.
 
-Four habits show up once you install:
+Because the Hiccup tree still contains the event, tests and tools can print,
+inspect, and compare it with `=`. You can still use an ordinary function when a
+handler needs imperative work or direct access to callback arguments;
+[Events as data](03-events-as-data.md) defines that boundary.
 
-- A button's handler is data — `[:button {:on-click [:todo/toggle id]} …]` —
-  so structural tests compare trees with `=`.
-- Call [`h/sub`](glossary.md#hsub) where you need the value: in a `let`, a
-  `when`, a loop, or a plain helper. You do not have to thread a subscription
-  value down so the helper can see it.
-- Controlled fields use ordinary `:value` and `:on-input`; the runtime keeps
-  caret and composition correct on that path
-  ([Controlled inputs](04-controlled-inputs.md)).
-- Ordinary screens stay on interpreted Hiccup. When measurement names a hot
-  1–2% of the tree, you can cross to native React on the same frame and
-  app-db ([Performance](18-performance.md), [Native tier](10-native-tier.md)).
-  There is no `:fast` flag and no second meaning for `[...]`.
+### Read subscriptions where they are used
 
-Interpreted Hiccup is not free. Cold mount can cost a little more than a
-hand-rolled UIx twin on the same screen; much of that cost is capability
-(reads in loops and helpers) rather than walking vectors alone. If every
-screen is a hook-heavy design-system tree, UIx will feel more natural from day
-one. If you need a second reactive store inside the view layer, Hicasso will
-not give you one — application-visible state lives in app-db
-([Ephemeral state](11-ephemeral-state.md)).
+`h/sub` is an ordinary function call inside a Hicasso view. It can appear in a
+`let`, conditional, loop, or plain helper. You do not have to subscribe in a
+parent simply to pass the value down.
+
+A view created with [`h/defview`](glossary.md#defview) tracks the subscriptions
+read during its body. When one changes, that view re-renders. Plain `defn`
+helpers do not create a separate re-render boundary; their reads belong to the
+surrounding view.
+
+### Controlled fields use ordinary attributes
+
+Most controlled text inputs use `:value` and `:on-input`:
+
+```clojure
+[:input {:value    (h/sub [:todo.ui/draft id])
+         :on-input [:todo.ui/edit id ::h/value]}]
+```
+
+The runtime handles the same-turn update, caret preservation, and IME
+composition rules for that path. You should not add a second local atom merely
+to keep a controlled field usable. The complete contract, including resets and
+failure cases, is in [Controlled inputs](04-controlled-inputs.md).
+
+### Optimise measured hot regions explicitly
+
+Normal screens use interpreted Hiccup. If profiling identifies a genuinely hot
+part of the tree, that region can move to native React or UIx while staying on
+the same frame and app-db. There is no `:fast` interpretation mode and no
+second meaning for `[...]`.
+
+[Performance](18-performance.md) defines the measurement method and
+[Native tier](10-native-tier.md) defines the crossing.
+
+## Hicasso, Reagent, and UIx
+
+**Reagent** remains a sensible choice for an existing application whose view
+layer already works. Hicasso will look familiar because both use Hiccup, but
+the state and component models differ: Hicasso does not use reaction-local
+state or Form-2 components. The migration guide explains the mechanical and
+behavioural differences.
+
+**UIx** is usually the better choice when React itself organises the view
+layer: hooks are common, a React design system dominates the tree, and the
+team thinks in React component lifecycles. Hicasso can still host foreign React
+through [`h/defhost`](09-interop.md), and a measured region can use the native
+tier, but it does not try to replace a React-first authoring model.
+
+Choose Hicasso when the application is primarily a re-frame2 application and
+you want markup, reads, and ordinary interactions to retain the same
+inspectable data model.
+
+## Costs and limits
+
+Interpreting Hiccup has a runtime cost. Cold mount can be slower than a
+hand-written UIx equivalent, and each Hicasso view pays a small fixed cost for
+tracked reads and its re-render boundary. Measure before moving code: the
+native tier is intended for the small part of a real screen that profiling
+identifies, not as the default authoring style.
+
+Hicasso also does not provide a second application-visible reactive store
+inside the view layer. State that other views, tests, tools, routing, or SSR
+must observe belongs in app-db. The limited cases for DOM-owned or local UI
+state are covered in [Ephemeral state](11-ephemeral-state.md).
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Calling a `defview` as `(todo-row {:id 7})` refuses and names the view | A Hicasso view is a React/Hiccup head, not an inline function | Mount it as `[todo-row {:id 7}]`; use a plain `defn` for an inline helper |
+| A plain helper written as `[row-icon props]` raises `:rf.error/hicasso-bad-head` | A plain function appeared in Hiccup head position | Call it as `(row-icon props)`, or define it with `h/defview` when it needs its own re-render boundary |
+| `h/sub` raises `:rf.error/hicasso-sub-outside-render` | The read ran outside the direct synchronous execution of a Hicasso view | Read inside the view body and pass or close over the realised value |
+| An event vector raises `:rf.error/hicasso-intent-outside-boundary` | The intent was lowered without a view/frame boundary | Keep it in Hiccup produced by a view, or use `h/event` at an explicit foreign callback edge |
+| A controlled field drops characters or moves the caret | The write path became asynchronous, or the field left Hicasso's controlled path | Dispatch the edit synchronously and follow [Controlled inputs](04-controlled-inputs.md) |
 
 ## When not to use Hicasso
 
-Stay on **Reagent** if migration cost is the dominant fact and the app already
-works — Hicasso can wait. Choose **UIx** when React-first authoring (hooks
-everywhere, a design system at the centre) is the product shape, not an
-island.
+Stay with **Reagent** when migration cost is the dominant fact and the existing
+application is healthy.
 
-Hicasso is for data-first views on the re-frame2 pipeline: markup as data,
-[reads at the point of use](02-views-and-reads.md), and
-[event vectors you can assert](03-events-as-data.md). It meets foreign React at
-[`h/defhost`](09-interop.md); it does not try to be the best pure-React CLJS
-library.
+Choose **UIx** when hooks and React component libraries are the product's
+normal language rather than isolated integrations.
 
-If that is the product you want, [install a first screen](installation.md).
+Use Hicasso when data-first views are the normal case and foreign React is a
+boundary you can name. It is not intended to be the best pure-React
+ClojureScript library.

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -1,16 +1,8 @@
 # Views and reads
 
-After [Installation](installation.md)'s counter, this page is how views stay
-fine-grained and why one read form is enough.
-
-Views that re-render too coarsely, and subscription reads that cannot live
-where you use them, are the same problem twice. Either you hoist a value high
-in the tree and re-render many sibling views, or you invent a second way to
-read so that a helper can see the current filter.
-
-In Hicasso, a view is a function from a props map to Hiccup. There is one way
-to read — [`h/sub`](glossary.md#hsub), an ordinary function call at the point
-of use:
+A Hicasso view can read a subscription where the value is needed without
+forcing a parent to own that read. The view that performs the read becomes the
+unit that re-renders when the value changes.
 
 ```clojure
 (ns todo.views
@@ -23,64 +15,70 @@ of use:
      [:span (:title todo)]
      [:button {:on-click [:todo/toggle id]} "✓"]
      (when editing?
-       [:input {:value    (h/sub [:todo.ui/draft id])   ;; a read inside a conditional
+       [:input {:value    (h/sub [:todo.ui/draft id])
                 :on-input [:todo.ui/edit id ::h/value]}])]))
 ```
 
-`h/sub` is legal anywhere in the body — inside a `let`, a `when`, a `for`, or
-an ordinary helper call. Each [`h/defview`](glossary.md#defview) tracks the
-subscriptions read while it renders. When one of those values changes, that
-view re-renders.
+[`h/sub`](glossary.md#hsub) is legal anywhere in the synchronous body: in a
+`let`, conditional, loop, or ordinary helper call. Each
+[`h/defview`](glossary.md#defview) records the subscriptions read while its
+body runs. When one of those subscription values changes, that view
+re-renders.
 
-`h/sub` is the only read form. There is no second spelling for helpers. A bare
-`rf/subscribe` in a body is not a fallback: it throws instead of resolving.
-(The event vectors in those attributes — *[intents](glossary.md#intent)* —
-and [`::h/value`](glossary.md#hvalue) belong to
-[Events as data](03-events-as-data.md).)
+`h/sub` is the only read form in a Hicasso body. A bare `rf/subscribe` is not an
+untracked alternative; it throws rather than resolving. Event vectors and the
+`::h/value` marker in the example are covered in
+[Events as data](03-events-as-data.md).
 
 ## Views and plain helpers
 
-There are two ways to use another function from a view body, and the
-difference is visible in the syntax:
+These forms look similar but create different runtime structure:
 
 ```clojure
-[todo-row {:key id :id id}]   ;; a vector — a separate view
-(row-icon {:kind :urgent})    ;; a call to a plain defn — inlined into this view
+[todo-row {:key id :id id}]   ;; a separate Hicasso view
+(row-icon {:kind :urgent})    ;; a plain function call, inlined here
 ```
 
-A **view in head position** is an independently re-rendering unit — the guide
-calls this a [boundary](glossary.md#boundary). [`h/defview`](glossary.md#defview)
-creates one. That unit tracks:
+A view in head position is an independently re-rendering unit. This guide calls
+that unit a [boundary](glossary.md#boundary). `h/defview` creates a boundary
+that tracks:
 
-- React's identity for the view
-- the `h/sub` reads its body makes
-- a value-equality bail-out on props
-- the re-frame2 frame (isolated app-db and queue) that its event vectors
-  dispatch into
+- React identity for the view
+- subscription reads made by the body
+- the props used by its equality bail-out
+- the re-frame2 frame used by event vectors produced by the body
 
-Native tags, fragments, and [`h/defhost`](glossary.md#defhost) heads also sit in
-vector position. None of them is a boundary.
+Native tags, fragments, and [`h/defhost`](glossary.md#defhost) heads also appear
+in vector position, but they do not create Hicasso boundaries.
 
-A **plain `defn` call** is only a function call. The runtime splices its
-Hiccup into the caller's tree. Any `h/sub` the helper performs is tracked by
-the enclosing view. Helpers add no re-render granularity of their own. Because
-reads are ordinary calls, helpers can read: a `filter-button` that needs the
-current filter reads it, and the read belongs to the view that is rendering.
-You do not thread the value down as an argument.
+A plain `defn` is only a function call. Its Hiccup is inserted into the caller's
+tree, and any `h/sub` calls it makes are recorded by the surrounding Hicasso
+view. It adds no independent re-render granularity. This lets a helper read the
+current filter or other state directly instead of requiring the caller to
+thread that value through its arguments.
 
-The two forms are not interchangeable:
+Do not interchange the two forms:
 
 ```clojure
-;; Don't — a plain defn in head position
-[row-icon {:kind :urgent}]   ;; :rf.error/hicasso-bad-head: call it, or make it a view
+;; Don't — a plain defn cannot be a Hiccup head
+[row-icon {:kind :urgent}]
+;; :rf.error/hicasso-bad-head
 
-;; Don't — a view called directly
-(todo-row {:id 7})           ;; throws at the call, naming the view; write [todo-row {:id 7}]
+;; Do
+(row-icon {:kind :urgent})
 ```
 
-Re-render granularity should be visible in the source. A boundary is always a
-vector, and an [inline helper](glossary.md#inline-helper) is always a call. A
-`defview` never becomes an inline function because you invoked it differently.
+```clojure
+;; Don't — a defview is not called directly
+(todo-row {:id 7})
+
+;; Do
+[todo-row {:id 7}]
+```
+
+The first mistake raises `:rf.error/hicasso-bad-head`. A direct `defview` call
+throws at the call site and names the view. A `defview` never turns into an
+inline helper because it was called with function syntax.
 
 ## Keys go in the props map
 
@@ -91,31 +89,34 @@ vector, and an [inline helper](glossary.md#inline-helper) is always a call. A
      [todo-row {:key id :id id}])])
 ```
 
-A seq of children needs keys, whatever the head is. The key lives **in the
-props map**. Hicasso does not read `^{:key id}` metadata here (the most common
-Reagent habit), and no `for` invents a key for you. If you miss a key,
-development warns with `:rf.warning/hicasso-missing-key` and names the view
-and the child. What makes a key *good* (a stable domain identity, never an
-index, never the whole entity) is
-[Lists and collections](06-lists-and-collections.md).
+Every member of a sequence of children needs a key. Put `:key` in that child's
+props map. Hicasso does not read Reagent-style `^{:key id}` metadata, and `for`
+does not invent a key. Missing keys produce
+`:rf.warning/hicasso-missing-key` in development, naming the view and child.
+
+This page owns the spelling. [Lists and collections](06-lists-and-collections.md)
+explains key quality: use a stable domain identity, never an array index or the
+whole entity.
 
 ## Props, children, and fragments
 
+The supported head shapes have different props and children contracts:
+
 | Head | Props | Children | `:key` | `:ref` |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | Native tag — `[:div …]` | attribute map | trailing forms | in the attribute map | callback ref, legal |
-| Hicasso view — `[todo-row …]` | one props map | trailing forms, arriving as `(:children props)` | in the props map, **removed before your body sees props** | not a view surface — use ids |
-| Fragment — `[:<> …]` | — | trailing forms | on the fragment's props map | — |
-| Foreign — [`h/defhost`](glossary.md#defhost) and `[:>]` | converted per declaration | Hiccup children become elements | in props | callback ref, legal |
+| Hicasso view — `[todo-row …]` | one props map | trailing forms arrive as `(:children props)` | in the props map; removed before the body sees props | not a view surface; use ids |
+| Fragment — `[:<> …]` | none, except a key-bearing fragment props map | trailing forms | in the fragment props map | none |
+| Foreign host — [`h/defhost`](glossary.md#defhost) or `[:>]` | converted according to the host declaration | Hiccup children become React elements | in props | callback ref, legal |
 
-Children arrive realized and flattened in a predictable way. Nested and lazy
-sequences are realized once and flattened one level. `nil` and `false` render
-nothing. `true` raises `:rf.error/hicasso-true-child`. An existing React
-element is a legal child anywhere. A view can return `nil`, a single root, or
-a fragment. `:key` never reaches your body; that is React's contract.
+Nested and lazy child sequences are realized once and flattened one level.
+`nil` and `false` render nothing. `true` raises
+`:rf.error/hicasso-true-child`. An existing React element is a valid child. A
+view may return `nil`, one root form, or a fragment. React consumes `:key`, so
+it never appears in the props map received by the view body.
 
-`(:children props)` is a **vector of Hiccup forms**. Splice it into your
-Hiccup; do not insert it as one child:
+A view receives trailing children as a vector of Hiccup forms. Splice that
+vector into the result rather than inserting the vector as a single child:
 
 ```clojure
 (h/defview card [{:keys [title children]}]
@@ -128,7 +129,7 @@ Hiccup; do not insert it as one child:
  [todo-row {:id 2}]]
 ```
 
-A view that has no single wrapper returns a fragment:
+Return a fragment when the view needs several roots:
 
 ```clojure
 (h/defview toolbar [_]
@@ -137,35 +138,33 @@ A view that has no single wrapper returns a fragment:
    [cancel-button {}]])
 ```
 
-**Bodies are pure and re-runnable.** React StrictMode runs your body twice in
-development, and that is safe when bodies stay pure. Anything that breaks
-under a second run does not belong in a body: mutating a captured atom,
-starting a fetch, counting renders.
+View bodies must be pure and safe to run again. React StrictMode invokes them
+twice in development. Mutation of a captured atom, starting a fetch, or using
+the body as a render counter therefore belongs elsewhere.
 
-## Views skip work when props are equal
+## Equal props skip the body
 
-Every `h/defview` compares the whole props map with ClojureScript `=`. If a
-view's props compare equal to the last render, its body does not run, even
-when its parent's body ran. There is no mode flag and no public opt-out. A
-view that must re-run with its parent takes a prop that changes.
+Every Hicasso view compares its complete props map with ClojureScript `=`. If
+the props are equal to the previous render, the body does not run merely
+because its parent ran. There is no public opt-out. A child that must change
+with its parent should receive a prop that represents that change.
 
-Two things still force a re-render. First, a subscription (or context read)
-the view made itself always wins: if one of *its* reads changed, the body
-runs regardless of props. Second, a function-valued prop compares unequal by
-identity. A fresh closure is never `=` to the last one, so an inline handler
-passed as a prop defeats the bail-out every time.
+Two sources of invalidation still run the body:
 
-A subscription read high in the tree, with the value passed down, does **not**
-lose an update. The view that reads is the view that invalidates, and every
-view that the changed value reaches receives unequal props at that hop. The
-benefit of the default is this: a view that the value does *not* reach skips
-instead of re-rendering for nothing. Moving a read down is a granularity fix,
-not a correctness fix.
+1. A subscription or context read made by the view itself changed. Its own
+   pending update takes precedence over the props comparison.
+2. A prop compares unequal. Function-valued props and ordinary JavaScript
+   objects use reference identity, so a fresh inline closure or fresh JS object
+   defeats the bail-out on every parent render.
 
-## Attributes
+Reading a subscription in a parent and passing its result down remains
+correct. The parent invalidates when the read changes, and each descendant that
+receives a changed value gets unequal props. Moving the read closer to the
+view that displays it improves granularity; it is not required for correctness.
 
-The attribute map is ordinary Hiccup. The runtime does the conversions React
-wants:
+## Attribute conversion
+
+The attribute map remains ordinary Hiccup:
 
 ```clojure
 (h/defview title-input [_]
@@ -180,38 +179,35 @@ wants:
       :on-input    [:todo.ui/set-title ::h/value]}]))
 ```
 
-Five rules cover the conversions:
+Five conversion rules cover the normal cases:
 
-- **Names go from kebab-case to camelCase.** `:on-click` emits `onClick`.
-  `:aria-*` and `:data-*` pass through as written. A `--custom-property` stays
-  verbatim. `:class` → `className`, `:for` → `htmlFor`, `:charset` →
-  `charSet`.
-- **Values convert one level deep.** A nested map, such as `:style`, has its
-  own keys converted to camelCase, so `{:margin-top 8}` arrives as
-  `marginTop`. Keywords and symbols become their names (`:type :text` is
-  `type="text"`). Functions cross by identity.
-- **`:class` takes more than a string.** It also takes a keyword, a symbol, or
-  a collection of those. The runtime drops `nil`s and joins the rest with
-  spaces, so the `(when …)` above contributes nothing when it is false.
-- **The tag's `#id.class` shorthand composes.** Write the id first:
-  `:input#title.form-control`, never `:input.form-control#title`. An
-  explicit `:id` in the map wins over `#title`. `.form-control` on the tag
-  joins whatever `:class` brings.
-- **`:key` is not an attribute.** The runtime reads it off the map and never
-  emits it as a prop.
+- **Attribute names become React names.** Kebab-case becomes camelCase, so
+  `:on-click` becomes `onClick`. `:aria-*`, `:data-*`, and CSS custom
+  properties beginning `--` pass through. `:class`, `:for`, and `:charset`
+  become `className`, `htmlFor`, and `charSet`.
+- **Values convert one level deep.** Nested maps such as `:style` have their
+  keys converted, so `:margin-top` becomes `marginTop`. Keywords and symbols
+  become their names. Functions cross by identity.
+- **`:class` accepts several shapes.** It may be a string, keyword, symbol, or
+  collection. `nil` entries are removed and the rest are joined with spaces.
+- **Tag shorthand composes with explicit props.** Write the id before classes:
+  `:input#title.form-control`, not `:input.form-control#title`. An explicit
+  `:id` wins over the shorthand id. Classes from the tag and `:class` are
+  combined.
+- **`:key` is consumed by the runtime.** It is not emitted as a normal prop.
 
-The reserved-data vocabulary is small: [`::h/value`](glossary.md#hvalue),
-[`::h/checked`](glossary.md#hchecked), [`::h/prevent`](glossary.md#hprevent),
-and [`::h/revision`](glossary.md#hrevision). The page that owns each word
-teaches it ([events](03-events-as-data.md),
-[controlled inputs](04-controlled-inputs.md)).
+The reserved data vocabulary is intentionally small:
+[`::h/value`](glossary.md#hvalue),
+[`::h/checked`](glossary.md#hchecked),
+[`::h/prevent`](glossary.md#hprevent), and
+[`::h/revision`](glossary.md#hrevision). Events and controlled inputs own the
+behaviour of those values.
 
-## Forwarding attributes: owned wins
+## Forward attributes with owned keys last
 
-Keys you write on the element always beat a forwarded map.
-
-A reusable field takes caller attributes and still owns its control keys. The
-merge is a plain `merge`, with the attributes that you own written last:
+A reusable field can accept caller attributes while retaining control of its
+value and handler. Use a normal `merge`, placing the keys owned by the field
+last:
 
 ```clojure
 (h/defview search-field [{:keys [id] :as attrs}]
@@ -221,128 +217,113 @@ merge is a plain `merge`, with the attributes that you own written last:
            :on-input [:todo.ui/set-search id ::h/value]})])
 ```
 
-**The literal keys that you write always win over anything forwarded — by
-presence, not truthiness.** A forwarded map can add a `:placeholder`, an
-`:aria-label`, or a `:data-testid`. It can never displace the `:value` or the
-handler that the field owns, because the owned keys merge last. Classes still
-compose: `.form-control` on the tag joins whatever `:class` survives the
-merge, so a caller's class adds to the element's own class instead of
-replacing it. When a caller's value *should* win, do not write the literal.
-One risk: `merge` works by key, so forward maps spelled the way you write
-attributes — kebab keywords — not a foreign props object's `"className"`
-strings.
+The literal entries written by the field win by presence, not truthiness. The
+caller may add `:placeholder`, `:aria-label`, `:data-testid`, or a class, but
+cannot replace the owned `:value` or `:on-input` because those keys are merged
+last. Classes written in the tag still combine with a surviving caller
+`:class`.
 
-The case that makes this rule necessary is a
-[controlled input](glossary.md#controlled-field): a forwarded map must never
-supply the value, checked, handler, key, or revision slots.
-[Controlled inputs](04-controlled-inputs.md) teaches that case in full.
+When a caller should control a value, omit the owned literal instead of trying
+to override it. Forward maps should use the same kebab-keyword spelling as
+Hiccup; a foreign props object's `"className"` string is a different merge
+key. Controlled inputs also reserve their checked, key, and revision slots, as
+described in [Controlled inputs](04-controlled-inputs.md).
 
-## When `h/sub` is legal
+## Where `h/sub` may run
 
-`h/sub` is legal during the **direct synchronous execution** of the active
-view body. Branches, loops, and ordinary helpers are included. Reads inside a
-lazy `for` count as direct: the same pass that turns Hiccup into elements
-forces them, so they land on the view that is rendering.
+`h/sub` may run only during the direct synchronous execution of an active view
+body. Branches, loops, and ordinary helper calls are included. Lazy sequences
+used as Hiccup children are forced during the same Hiccup-to-element pass, so
+their reads are still recorded by the active view.
 
-A read **deferred past the render** throws, with source and recovery. It does
-not go silently stale. A callback, a promise, a timer, a stashed lazy seq, a
-`delay` forced later — each raises
-`:rf.error/hicasso-sub-outside-render` and names the query. An unforced
-`delay` that crosses into a view's props raises
-`:rf.error/hicasso-deferred-read-at-boundary` at the crossing, before it can
-freeze a child. Hicasso never guesses which render owns a deferred read. The
-alternative is a value that looks correct on screen and never updates again,
-with no error to point to.
+A read deferred past that render raises
+`:rf.error/hicasso-sub-outside-render` and names the query. This includes a
+callback, timer, promise, delayed computation, or lazy sequence forced later.
+An unforced `delay` passed through a view boundary raises
+`:rf.error/hicasso-deferred-read-at-boundary` before the child can retain a
+read that will never update correctly.
 
 ```clojure
-;; Don't — a read deferred into a timer callback
+;; Don't — the read happens when the timer fires
 (js/setTimeout
-  #(export! (h/sub [:todo/rows]))    ;; :rf.error/hicasso-sub-outside-render
+  #(export! (h/sub [:todo/rows]))
   1000)
 
-;; Do — read during the render; close over the value
+;; Do — read now and retain the value
 (let [rows (h/sub [:todo/rows])]
   (js/setTimeout #(export! rows) 1000))
 ```
 
-The recovery always has the same shape: read during the render and close over
-the **value**, or move the work to the event layer. An event handler that
-needs current state declares that state as a coeffect with
-`:rf.cofx/requires`. The read then becomes part of the handler's contract, not
-a side effect in a body. There is no `@`-anywhere form and no second read form
-for free-standing code.
+For work that needs current state later, move the work into the event layer and
+declare the state as a coeffect with `:rf.cofx/requires`. The handler then has
+an explicit state dependency instead of a deferred view read.
 
-!!! warning "The one escape that does not throw"
-    A read parked in a mutable reference and forced inside another body raises
-    nothing: a body *is* rendering there, just not the one that wrote the
-    read. The page paints, and the read is tracked by the view that forced
-    the thunk rather than the one that authored it. That view keeps every
-    dependency it made itself; what it gains is a stranger's — a subscription
-    to a cell it does not display and now re-renders on. The runtime does not
-    chase reads through mutable references, so this is undefined conduct
-    rather than a named error, and yours to avoid.
+!!! warning "A mutable thunk can attach the read to the wrong view"
+    A thunk containing `h/sub` can be stored in a mutable reference and later
+    forced by another active view. It does not throw because a view is
+    rendering at that moment, but the read is recorded against the view that
+    forced the thunk rather than the code that created it.
 
     ```clojure
-    ;; Don't — the thunk is parked in an atom, and whichever body forces it
-    ;; is the one that owns the read
-    (reset! !later #(h/sub [:todo/rows]))   ;; no error to point to
+    ;; Don't — whichever view invokes this thunk acquires the subscription
+    (reset! !later #(h/sub [:todo/rows]))
     ```
 
-## How tracking works
+    The runtime does not trace subscription ownership through mutable
+    references. Treat this as undefined conduct and pass a value or explicit
+    function input instead.
 
-Four operational facts:
+## How read tracking behaves
 
-1. Each view records exactly the subscriptions its body made on that render.
-   A branch not taken contributes nothing.
-2. Framework subscriptions — machine tags, resource status, route identity —
-   read the same way as your own. They are rows in the same index.
-3. Sub-key identity is `(query-id, args)` under **value equality**. A rebuilt
-   `{:scope :all}` inside the body hits the same cache entry on every render:
-   two structurally equal persistent values are one key. Two argument kinds
-   cause constant re-creation: an argument whose value changed (a timestamp),
-   and an argument that uses reference identity (a function, a JS object).
-   For those, `=` is identity.
-4. The recorded set is a function of what the body *did*. A body whose taken
-   branches change re-subscribes the whole set, not only the changed key.
-   Dynamic reads are legal; a whole-set refresh is their price.
+Four facts explain the observable behaviour:
+
+1. A view records exactly the subscriptions read during that render. A branch
+   that did not run contributes no dependency.
+2. Framework subscriptions — route identity, resource status, or machine tags
+   — use the same tracking mechanism as application subscriptions.
+3. Subscription identity is `(query-id, args)` under value equality. Rebuilding
+   an equal persistent map produces the same cache key. A changed value,
+   function argument, or JS object creates a different key because functions
+   and JS objects compare by identity.
+4. When the set of taken branches changes, the view refreshes the complete
+   recorded set. Dynamic reads are supported; whole-set refresh is their cost.
 
 ## Troubleshooting
 
-| Symptom | Error | Fix |
-|---|---|---|
-| A read after the render throws, naming the query | `:rf.error/hicasso-sub-outside-render` | Read during the render; close over the value. Handlers declare state with `:rf.cofx/requires` |
-| An unforced `delay` in props throws at the view | `:rf.error/hicasso-deferred-read-at-boundary` | Hand a function, or force the delay in your own body |
-| A plain `defn` in head position throws | `:rf.error/hicasso-bad-head` | Call it — `(row-icon …)` — or define it with `h/defview` |
-| Calling a view directly throws, naming the view | throws at the call site | Write the head: `[todo-row {:id 7}]` |
-| Console warns about a missing key, naming view and child | `:rf.warning/hicasso-missing-key` | Put `:key` in each member's props map; `^{:key}` metadata is not read ([Lists and collections](06-lists-and-collections.md) owns key quality) |
-| First render throws naming a query id | `:rf.error/no-such-sub` | Registration happens on namespace load; require the subs namespace at boot |
-| View re-renders although props look unchanged | none — bail-out defeated | A prop uses reference identity (inline `fn`, JS object). Hoist it, or pass a persistent value |
-| One cell changes and 300 views re-render | none — reads live too high | Push the read down into the view that displays it |
-| A body's side effect fires twice in development | none — StrictMode double-invoke | Bodies are pure; move the effect out |
-| Subscriptions constantly re-created | none — args not value-stable | Make query args `=` between renders; fresh-but-equal persistent values are fine |
+| Symptom | Error or cause | Fix |
+| --- | --- | --- |
+| A read made after rendering throws and names the query | `:rf.error/hicasso-sub-outside-render` | Read during the body and retain the value. Event handlers obtain current state through coeffects |
+| An unforced `delay` in props throws at the child view | `:rf.error/hicasso-deferred-read-at-boundary` | Force it in the owning body or pass an ordinary function/value with an explicit contract |
+| A plain `defn` used as a Hiccup head throws | `:rf.error/hicasso-bad-head` | Call the helper or define it with `h/defview` |
+| Calling a `defview` directly throws | The view was invoked as a function | Render `[todo-row {:id 7}]` |
+| Development warns about a missing key | `:rf.warning/hicasso-missing-key` | Put `:key` in each sequence member's props map; metadata is not read |
+| The first render reports an unknown subscription | `:rf.error/no-such-sub` | Require the namespace that registers the subscription before mounting |
+| A child runs although its props look the same | A prop uses reference identity or one of the child's own reads changed | Hoist a function/JS object, pass persistent data, or inspect the child's own subscriptions |
+| One state change re-renders many unrelated views | The subscription read is higher in the tree than necessary | Move the read into the view that displays the value |
+| A body effect happens twice in development | React StrictMode invoked the body twice | Keep the body pure and move effects to the event/effect layer |
+| Subscription instances are constantly recreated | Query arguments are not stable under `=` | Use value-stable persistent arguments; fresh-but-equal persistent values are fine |
 
-## When not to create a view
+## When not to create another view
 
-Not every function needs to be a view. If markup has no reads of its own and
-always re-renders with its parent, a plain function is cheaper and simpler.
-Create a boundary when you want a part of the tree to update independently,
-not because the markup became long. When a measured hot region outgrows view
-tuning — the ~2% case, not the default 98% — the escape ladder in
-[Performance](18-performance.md) owns the next step.
+Use a plain helper when the markup has no independent reads and should always
+render with its caller. Create a separate Hicasso view when that part of the
+tree needs its own subscription tracking or props bail-out, not merely because
+the source became long.
+
+If a measured region remains hot after fixing read placement and props
+stability, use the method in [Performance](18-performance.md) before moving it
+to the native tier.
 
 ## Advanced
 
 ### The collector
 
-The mechanism behind the four operational facts is one fixed runtime hook per
-view. The hook opens a collection window for the duration of the body.
-Abandoned renders install nothing: the render probes reads, and the commit
-owns them, so a render that React retries or discards leaves no subscriptions
-behind. Reads inside lazy seqs land correctly because the Hiccup-to-element
-pass forces them while the window is open, not later when other code walks the
-seq.
+Each Hicasso view has one runtime hook that opens a collection window while the
+body runs. The body may probe subscription reads, but only a committed render
+installs them. A render that React retries or abandons therefore leaves no
+subscriptions behind.
 
-An escaped read fails loudly by design. A closed-over `h/sub` call site
-(rather than its value), a stashed unforced seq, or a `delay` forced after the
-render — each fails and names the query, because the collector can no longer
-say which view owns the read.
+Lazy child sequences are forced while the window is open, which is why their
+reads are attributed correctly. Once the window closes, a deferred `h/sub`
+call can no longer be assigned to a view and raises the named error instead of
+creating a value that looks correct once and then stops updating.

--- a/docs/design/hicasso/draft-guide/03-events-as-data.md
+++ b/docs/design/hicasso/draft-guide/03-events-as-data.md
@@ -1,37 +1,27 @@
 # Events as data
 
-With reads in place from [Views and reads](02-views-and-reads.md), this page
-makes handlers data so trees stay inspectable.
-
-Handler attributes are where a data-oriented view layer usually stops being
-data. You write pure data down the whole tree. Then `:on-click` needs a
-function, so you write `#(rf/dispatch [:todo/toggle id])`. That node stops
-being inspectable, comparable, or assertable by equality.
-
-Put the event vector in the attribute. The runtime creates the callback.
+Hicasso accepts an event vector directly in an event attribute. The runtime
+creates the callback and dispatches that vector when the callback runs.
 
 ```clojure
 [:button {:on-click [:todo/toggle id]} "✓"]
 ```
 
-The tree still holds data at that node, so a test asserts the node with `=`,
-and a tool reads it off the tree. When the user clicks the button, the runtime
-dispatches the vector into the re-frame2 frame owned by the rendering view.
-The runtime built that callback at render, and the callback includes the frame
-so the later click still has context.
+The Hiccup tree still contains `[:todo/toggle id]`, so tests and tools can
+inspect and compare the interaction as data. The generated callback also
+retains the frame of the view that created it, which makes the later browser
+event safe even though the original render has ended.
 
-Any prop whose name is `on-` plus a letter is an event position. CamelCase
-`onClick` also works, for the migrating author. There is no list of approved
-event names to keep in step with the DOM. An event vector at an event position
-is an **[intent](glossary.md#intent)**: the meaning of the interaction, stated
-as data. That is the word this guide uses for it.
+Any prop named `on-` followed by a letter is treated as an event position.
+CamelCase spellings such as `onClick` are also accepted for migration. Hicasso
+does not maintain a fixed roster of DOM event names. An event vector in one of
+these positions is called an [intent](glossary.md#intent).
 
-## Value markers
+## Read values from the browser event
 
-Most handlers need a value out of the event. The runtime substitutes two
-reserved words, [`::h/value`](glossary.md#hvalue) and
-[`::h/checked`](glossary.md#hchecked), at dispatch time with the event
-target's `.value` and `.checked`:
+Most input handlers need `.value` or `.checked` from the event target. Hicasso
+replaces [`::h/value`](glossary.md#hvalue) and
+[`::h/checked`](glossary.md#hchecked) when the callback runs:
 
 ```clojure
 [:input {:value    (h/sub [:todo.ui/draft id])
@@ -42,24 +32,22 @@ target's `.value` and `.checked`:
          :on-change [:todo/set-done id ::h/checked]}]
 ```
 
-At dispatch, the handler receives `[:todo.ui/edit 7 "milk"]` or
-`[:todo/set-done 7 true]`. These are ordinary event vectors, the same as
-vectors that you dispatch by hand. Substitution happens at the intent vector's
-top level only. The runtime does not look for a marker in nested structure. If
-the vector has no marker, the runtime never peeks at the DOM event — so
-nothing is substituted, and nothing is read "for free."
+The dispatched events are ordinary vectors such as
+`[:todo.ui/edit 7 "milk"]` and `[:todo/set-done 7 true]`.
 
-These two words, plus [`::h/prevent`](glossary.md#hprevent) below and
-[`::h/revision`](glossary.md#hrevision)
-([Controlled inputs](04-controlled-inputs.md)), are the entire reserved
-vocabulary. For the full controlled round-trip — value in from a subscription,
-intent out, caret and same-turn echo — see
-[Controlled inputs](04-controlled-inputs.md).
+Marker replacement occurs only at the top level of the intent vector. Hicasso
+does not search nested data. When an intent contains no marker, the runtime
+does not read the DOM event.
 
-## Prevention is explicit
+The full reserved vocabulary is `::h/value`, `::h/checked`,
+[`::h/prevent`](glossary.md#hprevent), and
+[`::h/revision`](glossary.md#hrevision). The controlled-input chapter owns the
+round trip from subscription value to browser event and back.
 
-Nothing auto-prevents — not a click, and not a form submit. Prevention is a
-decision. The decision travels **as data**, in the intent itself:
+## Prevent browser defaults explicitly
+
+An intent does not automatically call `preventDefault`, including at
+`:on-submit`. Wrap the intent when the browser default must be prevented:
 
 ```clojure
 [:form {:on-submit [::h/prevent [:todo/submit]]}
@@ -68,58 +56,58 @@ decision. The decision travels **as data**, in the intent itself:
  [:button {:type :submit} "Add todo"]]
 ```
 
-`[::h/prevent INTENT]` prevents the browser default and dispatches the inner
-intent. The same head serves an anchor that acts as a button — a tab or a tag
-pill. An unconditional default *cannot* exist there, because a modifier-click
-on a real link must still open a tab:
+`[::h/prevent INTENT]` prevents the default and dispatches the one inner intent.
+It also works for an anchor being used as an application control:
 
 ```clojure
-[:a.nav-link {:href "#" :on-click [::h/prevent [:todo/filter-active]]}
+[:a.nav-link
+ {:href "#"
+  :on-click [::h/prevent [:todo/filter-active]]}
  "Active"]
 ```
 
-!!! warning "A bare intent at `:on-submit` still submits"
-    `{:on-submit [:todo/submit]}` dispatches your intent **and** lets the
-    browser navigate. There is no submit special case. If the page reloads on
-    submit, the [`::h/prevent`](glossary.md#hprevent) head is missing. The rare
-    form that wants a real browser submission omits the head.
+A real navigation link should normally use the routing module rather than this
+pattern. A modifier-click on a real link must remain available to the browser,
+which is why Hicasso does not prevent clicks or submits by default.
 
-The shape is fixed: exactly one inner intent vector. That inner vector is what
-actually gets dispatched. Two payloads, a keyword instead of a vector, a
-decorator inside a decorator — each is
-`:rf.error/hicasso-malformed-prevent`. The error names the attribute and fires
-at render time, not at the click. Markers still work inside the head:
-`[::h/prevent [:filter/set ::h/value]]` prevents and substitutes, because the
-runtime unwraps the decorator before it looks for the markers.
+!!! warning "A bare submit intent still performs the browser submission"
+    `{:on-submit [:todo/submit]}` dispatches the event and then allows the
+    browser default. If the page reloads, wrap the intent with `::h/prevent`.
+    Omit the wrapper only when a real browser form submission is intended.
 
-The prevent form is a head, not metadata on the vector, for one reason:
-**metadata does not participate in `=`**. An annotation would be invisible to
-a structural test that compares the tree, to `pr-str`, and to any code that
-hashes the intent. A head is visible to all three.
+The wrapper must contain exactly one inner intent vector. A keyword instead of
+a vector, a second payload, or a nested decorator raises
+`:rf.error/hicasso-malformed-prevent` during rendering and names the attribute.
+Markers remain valid inside the inner intent:
 
-## `h/event`: when you need the callback arguments
+```clojure
+[::h/prevent [:filter/set ::h/value]]
+```
 
-Sometimes you must read the callback's arguments before you know what to
-dispatch. Examples: a file list, a drag payload, a foreign component that
-calls `(on-change date)` with no DOM event. [`h/event`](glossary.md#hevent) is
-the one explicit event-producing form:
+The wrapper is represented in the vector rather than metadata because metadata
+does not participate in `=`, printing, or hashes. Structural tests and tools
+must be able to observe the prevention decision.
+
+## Use `h/event` when the arguments determine the event
+
+Some callback contracts provide values that cannot be expressed with the two
+markers: a file list, a drag payload, or a foreign component that calls
+`(on-change date)`. [`h/event`](glossary.md#hevent) creates a frame-aware
+callback whose body can inspect every argument and return an event vector:
 
 ```clojure
 [:input {:type      "file"
          :on-change (h/event [e]
-                      [:todo/attach (js/Array.from (.. e -target -files))])}]
+                      [:todo/attach
+                       (js/Array.from (.. e -target -files))])}]
 ```
 
-Its contract has three clauses, and they hold in **every** position:
+The contract is the same in native and foreign callback positions:
 
-- It **captures the frame at the place where you write it**. Inside a view
-  body, that is the rendering view's frame.
-- When the invoker calls it later, it receives **every argument that the
-  invoker passes, in order**: one DOM event at a native position,
-  `(date event)` from a value-first library — whatever the caller's contract
-  says.
-- The runtime **dispatches a returned event vector** to the captured frame.
-  `nil` dispatches nothing, so a conditional dispatch is an ordinary `when`:
+- `h/event` captures the current frame where it is created.
+- Its body receives every callback argument in the caller's order.
+- A returned vector is dispatched to the captured frame. Returning `nil`
+  dispatches nothing.
 
 ```clojure
 [:div {:on-drop (h/event [e]
@@ -128,64 +116,59 @@ Its contract has three clauses, and they hold in **every** position:
                     [:todo/attach-dropped (.-name f)]))}]
 ```
 
-The meaning never varies by position. An `h/event` given to a
-[`h/defhost`](glossary.md#defhost) callback, retained by a vendor SDK, or
-placed in a raw `#js` prop does the same thing: it runs, it can return a
-vector, and the runtime dispatches that vector to the frame it captured.
-Prevention inside an `h/event` is your task: the function holds the event, so
-it calls `.preventDefault` itself, as the drop example does.
+An `h/event` body owns imperative browser work such as `.preventDefault`; the
+`::h/prevent` wrapper is for the data-only intent form.
 
-**The vector spelling is event-first; `h/event` is not.** `::h/value`,
-`::h/checked`, and `::h/prevent` all read the DOM event, and they read it from
-argument one. Every native position and every event-first foreign contract
-puts the event there. A value-first invoker, such as a date picker's
-`(on-change date)`, has no event at argument one. Nothing guesses which
-argument might be an event. The intent raises
-`:rf.error/hicasso-intent-needs-the-event`. The error names the position and
-points to `h/event`, the spelling that sees the library's own arguments in
-order:
+The marker spelling assumes an event-first callback contract. It reads the DOM
+event from argument one. A value-first foreign component has no event there,
+so a marker-carrying intent raises
+`:rf.error/hicasso-intent-needs-the-event`. Use `h/event` and name the
+component's arguments instead:
 
 ```clojure
-(h/event [date _e] [:todo/set-due date])
+(h/event [date _event]
+  [:todo/set-due date])
 ```
 
-## Ordinary functions still work
+## Ordinary functions remain available
 
-An ordinary `fn` stays legal at any event position, with ordinary JavaScript
-callback semantics: it runs, and the runtime ignores its return value:
+Use a normal function when the callback is imperative and does not represent a
+re-frame event:
 
 ```clojure
-[:canvas {:on-pointer-move (fn [e] (draw! (.-clientX e) (.-clientY e)))}]
+[:canvas
+ {:on-pointer-move
+  (fn [e]
+    (draw! (.-clientX e) (.-clientY e)))}]
 ```
 
-Use an ordinary `fn` when the *work* is imperative and no intent exists:
-geometry, pointer capture, `stopPropagation`, an SDK's imperative call.
-Render props and slots on foreign components also take ordinary functions.
-They run during a foreign render, so they stay pure. A dispatch from inside
-one raises `:rf.error/hicasso-dispatch-in-render-position`
-([Interop](09-interop.md) owns that crossing). The intent vector is the taught
-default because it covers almost everything, not because functions are
-forbidden.
+Typical cases include pointer geometry, pointer capture, `stopPropagation`, or
+an SDK call. Foreign render props and slots also use ordinary functions; those
+functions run during a foreign render and must stay pure. Dispatching from a
+render position raises `:rf.error/hicasso-dispatch-in-render-position`.
 
-An ordinary `fn` must not dispatch on its own:
+Do not hand-roll an ambient dispatch closure:
 
 ```clojure
-;; Don't — a hand-rolled dispatch closure
-[:button {:on-click (fn [_] (rf/dispatch [:todo/toggle id]))} "✓"]
-;; the click arrives long after the render's extent is gone —
-;; :rf.error/no-frame-context, at the click
+;; Don't
+[:button
+ {:on-click (fn [_]
+              (rf/dispatch [:todo/toggle id]))}
+ "✓"]
+;; :rf.error/no-frame-context when the click runs
 
 ;; Do
 [:button {:on-click [:todo/toggle id]} "✓"]
 ```
 
-The intent vector and `h/event` exist so that the runtime answers the frame
-question at render, once.
+The browser invokes the callback after the rendering extent has gone, so an
+ambient `rf/dispatch` has no frame. Intents and `h/event` capture that context
+when the view is rendered.
 
-## Keyboard as data
+## Keyboard maps
 
-A [keyboard map](glossary.md#keyboard-map) is a data map from DOM `.key` string
-to intent — not a `case` over `.-key`:
+A keyboard event position may contain a map from the DOM `.key` string to an
+intent:
 
 ```clojure
 [:input {:value       (h/sub [:todo.ui/draft id])
@@ -194,40 +177,25 @@ to intent — not a `case` over `.-key`:
                        "Escape" [:todo.ui/cancel id]}}]
 ```
 
-The names are strings. The runtime matches them against the DOM event's own
-`.key`, and it ignores keys that you do not list. There is no modifier
-language: a handler that needs `ctrl+Enter` reads the event with `h/event`.
-Key maps are legal at **keyboard props only** (`:on-key-down`, `:on-key-up`).
-A map is not an intent spelling anywhere else.
+Unlisted keys do nothing. The keys are strings, and keyboard maps are valid
+only at `:on-key-down` and `:on-key-up`. There is no modifier grammar; use
+`h/event` when the handler must inspect combinations such as Ctrl+Enter.
 
-The composition rule is explicit, and the runtime owns it. An IME (input
-method editor) composes text such as Japanese or Chinese from several
-keystrokes. **A key event that arrives during IME composition matches nothing
-in the map.** While a user composes, Enter selects a candidate; it is not a
-commit. Escape cancels the composition; it is not your cancel. A wrong
-hand-written check makes every user who composes lose a sentence. The map
-applies the correct check centrally, and it includes the legacy signals that
-some browsers still send (see [Advanced](#advanced)).
+Keyboard maps also suppress application shortcuts during IME composition.
+Enter may be choosing a composition candidate and Escape may be cancelling the
+composition, so neither should dispatch the application's commit or cancel
+intent. The runtime performs this check centrally, including legacy browser
+signals described under [Advanced](#advanced).
 
-## Callbacks include their frame
+## Frame-safe callbacks and foreign APIs
 
-Every generated callback closes over its view's frame. Intent vectors capture
-the frame when the attribute is turned into a React prop; `h/event` captures
-it at creation. This matters because the browser invokes callbacks long after
-the render that created them, when the render's extent is gone. A hand-written
-`#(rf/dispatch …)` raises `:rf.error/no-frame-context` from that gap. The data
-spellings do not, because they closed over the frame.
+Generated intent callbacks and `h/event` callbacks retain their view's frame.
+Async application work should normally move to the event/effect layer, where
+`:dispatch-later` and other effects already receive the frame.
 
-**Async work belongs in the event layer, which already has the frame.** A view
-that sets a timeout and dispatches when the timeout fires is a mis-layered
-effect. An fx handler receives the frame in its context, and
-`:dispatch-later` states the delay as data. Move the work to the event layer,
-and the frame question moves with it.
-
-One case remains after that move: a dispatching closure that you give to **a
-caller you do not control** — an SDK attached through a ref, a library that
-calls back with a value. The frame is knowable during the render and nowhere
-else. Capture it there with core's one capture primitive:
+A remaining case is a dispatching closure retained by code you do not control,
+such as a vendor SDK attached through a ref. Capture the current frame during
+the view body:
 
 ```clojure
 (ns app.map
@@ -236,66 +204,70 @@ else. Capture it there with core's one capture primitive:
             [app.sdk :as sdk]))
 
 (h/defview map-panel [{:keys [id]}]
-  (let [{:keys [dispatch]} (rf/capture-frame)]   ;; the rendering view's frame
+  (let [{:keys [dispatch]} (rf/capture-frame)]
     [:div.map
-     {:ref (fn [node]                            ;; refs run after commit, not in render
+     {:ref (fn [node]
              (when node
-               (sdk/on-select node #(dispatch [:map/marker-selected id %]))))}]))
+               (sdk/on-select
+                 node
+                 #(dispatch [:map/marker-selected id %]))))}]))
 ```
 
-Inside a Hicasso body, `(rf/capture-frame)` resolves the view's frame. It
-returns `{:frame :dispatch :dispatch-sync :subscribe}` locked to that frame.
-`(rf/current-frame-id)` returns the bare id when a foreign API wants one.
-These are core's frame doors; Hicasso adds no duplicate. (Ambient
-`rf/dispatch` and `rf/subscribe` throw from a body. The capture doors include
-the frame; the ambient calls do not.) A captured handle is valid for
-the life of its frame's incarnation. If you destroy the frame and remount
-under the same id, an operation from the stale handle raises
-`:rf.error/frame-destroyed` and does not reach the successor frame. Capture
-from the live render, never from a stash.
+`(rf/capture-frame)` returns
+`{:frame :dispatch :dispatch-sync :subscribe}` bound to the rendering frame.
+`(rf/current-frame-id)` returns only the id when a foreign API needs it.
+Ambient `rf/dispatch` and `rf/subscribe` do not contain a frame and therefore
+throw in these contexts.
 
-The general rule: **intents are always safe; async work goes through `:fx`; a
-closure that crosses into foreign code captures `(rf/capture-frame)`.**
+A captured handle remains valid for that frame incarnation. Destroying the
+frame and creating another under the same id does not revive the old handle;
+using it raises `:rf.error/frame-destroyed` and does not reach the successor.
+Capture from the live render rather than keeping a global stash.
 
-One nearby case is not this page's case. An anchor that *navigates* is a
-[route link](glossary.md#route-link) from `re-frame.hicasso.routing`, not a
-hand-written `:on-click`.
-[Routing and navigation](07-routing-and-navigation.md) owns it.
+The practical rule is:
+
+- use an intent for an ordinary dispatching event
+- use an effect for application-owned async work
+- use `rf/capture-frame` for a closure retained by foreign code
+
+A link whose job is navigation belongs to the routing module's route-link
+surface rather than a custom click handler.
 
 ## Troubleshooting
 
-| Symptom | Error | Fix |
-|---|---|---|
-| Page navigates and reloads on form submit | none — nothing auto-prevents | Wrap the intent: `{:on-submit [::h/prevent [:todo/submit]]}` |
-| Throws at render naming an event attribute | `:rf.error/hicasso-malformed-prevent` | `[::h/prevent INTENT]` wraps exactly one inner intent vector — no second payload, no nesting |
-| Handler receives the literal `::h/value` keyword | none — marker below top level | Markers substitute at the vector's top level only; compute nested payloads in the handler, or read the event with `h/event` |
-| A foreign callback rejects a marker-carrying intent | `:rf.error/hicasso-intent-needs-the-event` | The invoker is value-first — no DOM event at argument one. Use `h/event`, which receives every argument in order |
-| Dispatch from a timeout or interval throws | `:rf.error/no-frame-context` | Own the async work in an fx handler (`:dispatch-later`); a closure handed to foreign code captures `(rf/capture-frame)` from the body |
-| Enter commits half-typed Japanese text | none — hand-rolled key handling | Use the `:on-key-down` map; composition is centralised there |
-| An intent fires but no handler runs | `:rf.error/no-such-handler` | Registration happens on namespace load; require the handlers namespace at boot |
-| A vector at a declared host callback is rejected | `:rf.error/hicasso-intent-at-a-non-event-contract` | That position's declared contract does not dispatch; give it the value its contract asks for ([Interop](09-interop.md)) |
-| A render prop that dispatches is rejected | `:rf.error/hicasso-dispatch-in-render-position` | Render props are pure output; move the dispatch to an event position ([Interop](09-interop.md)) |
+| Symptom | Error or cause | Fix |
+| --- | --- | --- |
+| A form dispatches and then reloads the page | Browser submission was not prevented | Use `{:on-submit [::h/prevent [:todo/submit]]}` |
+| Rendering reports a malformed prevent wrapper | `:rf.error/hicasso-malformed-prevent` | Wrap exactly one inner intent vector; do not nest decorators or add a second payload |
+| A handler receives the literal `::h/value` keyword | The marker was nested below the vector's top level | Keep the marker at top level or calculate the payload with `h/event`/the event handler |
+| A foreign callback rejects an intent that needs the event | `:rf.error/hicasso-intent-needs-the-event` | The callback is value-first. Use `h/event` and receive its actual arguments |
+| Dispatch from a timer or interval throws | `:rf.error/no-frame-context` | Move application async work to an effect. For foreign retention, capture the frame during rendering |
+| Enter commits unfinished IME text | A hand-written key handler bypassed the keyboard map | Use the keyboard map so composition events are suppressed centrally |
+| An intent fires but no handler runs | `:rf.error/no-such-handler` | Require the namespace that registers the handler before mounting |
+| A vector is rejected at a host callback | `:rf.error/hicasso-intent-at-a-non-event-contract` | That host position is not declared as an event contract; supply the value its declaration requires |
+| A render prop dispatches | `:rf.error/hicasso-dispatch-in-render-position` | Keep render props pure and move the dispatch to an event position |
+| A captured callback reaches a destroyed frame | `:rf.error/frame-destroyed` | Recreate the callback from a render attached to the current frame incarnation |
 
 ## When not to use an intent
 
-Do not use an intent when you need the event object itself and no dispatch:
-pointer coordinates, `dataTransfer`, `stopPropagation`, a DOM measurement.
-Those cases take ordinary functions, and an ordinary function is not a
-failure. Use `h/event` when you want to read the arguments *and* dispatch. Use
-a plain `fn` when you want to read the arguments and do other work.
+Use a plain function when you need the callback arguments but no dispatch:
+pointer coordinates, `dataTransfer`, DOM measurement, `stopPropagation`, or an
+imperative SDK operation.
+
+Use `h/event` when the arguments are needed to decide which event vector to
+dispatch. An ordinary function is not an error; the intent form is simply the
+normal choice for declarative application interactions.
 
 ## Advanced
 
-### IME and the key map
+### IME detection in keyboard maps
 
-The composition gate lives in the runtime, not in your view, because the
-correct check is easy to get wrong in two ways. First, the signal is split.
-Modern browsers set `isComposing` on the keyboard event, but some IME/browser
-pairs only send the legacy `keyCode` 229, which means "this keystroke belongs
-to the IME". The gate honours both signals. Second, the signal is on the
-**native** event. React's synthetic keyboard event drops `isComposing`. A
-hand-written handler that reads the synthetic object sees `undefined`, and it
-commits a candidate-selection Enter as a submit. That is silent data loss for
-every user who composes. The map therefore answers one question — "was this
-keystroke the user's or the IME's?" — once, centrally, and it matches nothing
-while composition is active.
+IME composition is signalled in more than one way. Modern browsers expose
+`isComposing` on the native keyboard event, while some IME/browser combinations
+use legacy `keyCode` 229. React's synthetic keyboard event may not preserve the
+native `isComposing` value.
+
+The runtime checks the native event and both signals. While composition is
+active, a keyboard map matches no application intent. Keeping this check in the
+runtime avoids treating candidate-selection Enter as submit or composition
+Escape as application cancel, both of which can discard user input.

--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -1,13 +1,9 @@
 # Controlled inputs
 
-Intents and markers from [Events as data](03-events-as-data.md) are enough for
-buttons. A text field controlled by app-db has a harder job: every keystroke
-is a full round trip, and the usual bugs are dropped characters, a caret that
-jumps to the end, IME compositions destroyed mid-word, and rejections that
-never show. Hicasso centralises that path as a
-[controlled-field law](glossary.md#controlled-field). You write ordinary
-`:value` and `:on-input`; the runtime keeps the round trip inside one browser
-turn.
+A controlled text field sends every edit through app-db and receives the
+committed value back through a subscription. Hicasso keeps that round trip in
+the same browser turn and handles caret and IME behaviour for the normal
+`:value`/`:on-input` form.
 
 ```clojure
 (h/defview title-field [{:keys [id]}]
@@ -16,81 +12,70 @@ turn.
            :on-input [:todo.ui/edit id ::h/value]}])
 ```
 
-You write ordinary `:value` and `:on-input`, with no caret helper and no local
-atom. `:on-change` works the same way. If a field has both, both can fire, and
-the runtime converges once. For checkboxes, use
-[`::h/checked`](glossary.md#hchecked) the same way — the placeholders and the
-key map are taught in [Events as data](03-events-as-data.md).
+No local atom or caret helper is required. `:on-change` uses the same path. If
+a field defines both handlers, both may fire and the runtime converges once.
+Checkboxes use [`::h/checked`](glossary.md#hchecked); file inputs use
+[`h/event`](glossary.md#hevent) because the platform owns their value.
 
-## What the law guarantees
+## The controlled-field contract
 
-The value on screen is app-db state, so every keystroke is a round trip:
-keystroke → dispatch → handler → commit → subscription → re-render → DOM
-value. The framework keeps that whole path **inside the same browser turn**.
-Because of this, four guarantees hold without any code from you:
+For each keystroke, the path is:
 
-1. **Same-turn echo.** Dispatch runs synchronously inside the discrete browser
-   event. The commit's echo is back in the field before the browser finishes
-   the event — on screen within one frame. Fast typists do not drop or
-   reorder characters.
-2. **Committed echo.** The field shows what your handler committed, not what
-   the user typed. If you accept the keystroke, it stays. If you rewrite it,
-   the rewrite shows. If you reject it, the field holds the model value.
-3. **Caret and selection stay in place** when the model rejects or rewrites
-   the typed text, including edits in the middle of the string. The framework
-   never remounts the input to reset it. A remount destroys focus, selection,
-   and any live composition.
-4. **Composition is safe.** An Enter during composition selects an IME
-   candidate and commits nothing. A live composition is never overwritten
-   while it runs. A rejection or normalization lands whole when the
-   composition ends.
+`browser event → dispatch → event handler → app-db commit → subscription → view → DOM`
 
-Rejection uses the same path as acceptance. Return `nil` from the handler, and
-the field stays on the model value with the caret intact. You do not write
-special rejection code in the view:
+Hicasso completes this path inside the discrete browser turn. That provides
+four guarantees:
+
+1. **The committed value returns in the same turn.** Fast typing does not lose
+   or reorder characters merely because the field is controlled.
+2. **The model remains authoritative.** The field displays the value committed
+   by the handler. Accepted input remains, normalized input shows the
+   normalized value, and rejected input returns to the unchanged model value.
+3. **Caret and selection are preserved** when the model rejects or rewrites an
+   edit, including edits in the middle of a string. The node is not remounted.
+4. **IME composition is not interrupted.** Keyboard maps do not treat
+   composition Enter or Escape as application commands, and a model correction
+   waits until the composition closes.
+
+A handler rejects an edit by returning `nil`; the view needs no special branch:
 
 ```clojure
 (rf/reg-event :todo.ui/set-qty
   (fn [{:keys [db]} [_ id typed]]
     (if (re-matches #"\d*" typed)
       {:db (assoc-in db [:todo id :qty] typed)}
-      nil)))                                       ;; rejected — model unchanged
+      nil)))
 ```
 
-Two smaller clauses complete the law. Controlled means the model owns the
-screen value at every commit. So foreign drift — autofill, a browser
-extension, a script that writes `.value` — is repaired the next time the
-element commits. Events that land after unmount find nothing. A blur delivered
-to a field that has just left the tree is a no-op, with zero residue.
+Controlled means the model owns the displayed value after every commit. If
+autofill, a browser extension, or another script changes `.value`, the next
+commit restores the model. An event delivered after the field unmounts is a
+no-op, including a late blur; it leaves no retained input state.
 
-Every keystroke on a controlled field is a full pipeline run: state write,
-subscription recomputation, view run, React commit, painted echo. The
-[performance chapter](18-performance.md) publishes that path, with counts for
-the four-field editor and the controlled grid. This page owns the law; that
-page owns the cost.
+Every controlled keystroke is a complete event-pipeline run. The performance
+chapter owns the measurements and budgets; this page owns the behaviour.
 
-??? info "If you come from Reagent"
-    The usual Reagent pattern wraps an input in a local ratom, so that async
-    rendering cannot drop keystrokes or move the caret. Do not bring that
-    pattern here. The controlled path is synchronous end to end, and the
-    runtime owns caret and composition. A local atom adds nothing, and it
-    re-creates the twin-atom stack that the [forms module](05-forms.md)
-    exists to remove.
+??? info "For readers coming from Reagent"
+    A common Reagent pattern adds a local ratom to protect a field from async
+    rendering. Do not copy that pattern into Hicasso. The controlled path is
+    synchronous and the runtime already preserves selection and composition.
+    When an edit needs a separate draft/commit lifecycle, use the forms module
+    rather than building a second atom stack.
 
-## The whole control family
+## Supported controls
 
-The same value-in / intent-out shape covers every control for which the
-platform gives you a value:
+The same value-in, event-out form applies to the controls with a single
+platform value:
 
-| Control | Value in | Intent out |
-|---|---|---|
-| `:input` (text, email, password, search, url, tel) | `:value` | `:on-input` with [`::h/value`](glossary.md#hvalue) |
-| `:textarea` | `:value` | `:on-input` with [`::h/value`](glossary.md#hvalue) |
-| `:input` number, date, time, range | `:value` | `:on-input` with [`::h/value`](glossary.md#hvalue) — the DOM hands you strings; parse in the handler |
-| `:input` checkbox | `:checked` | `:on-change` with [`::h/checked`](glossary.md#hchecked) |
-| `:input` radio | `:checked` per option | `:on-change` carrying the option's own value literally |
-| `:select` | `:value` on the select | `:on-change` with [`::h/value`](glossary.md#hvalue) |
-| `:input` file | none — the platform owns a file input's value | `:on-change` with [`h/event`](glossary.md#hevent), reading `.files` off the event |
+| Control | Value supplied by the view | Event form |
+| --- | --- | --- |
+| Text-like `:input` (`text`, `email`, `password`, `search`, `url`, `tel`) | `:value` | `:on-input` with `::h/value` |
+| `:textarea` | `:value` | `:on-input` with `::h/value` |
+| Number, date, time, and range inputs | `:value` | `:on-input` with `::h/value`; parse the string in the handler |
+| Checkbox | `:checked` | `:on-change` with `::h/checked` |
+| Radio option | `:checked` for each option | `:on-change` carrying that option's value literally |
+| `:select` | `:value` on the select | `:on-change` with `::h/value` |
+| File input | no controlled value | `:on-change` with `h/event`, reading `.files` |
 
 ```clojure
 [:select {:value     (h/sub [:todo.ui/priority])
@@ -103,18 +88,15 @@ platform gives you a value:
          :on-change [:todo/set-done id ::h/checked]}]
 ```
 
-A control that is *not* on the list is rejected instead of half-working. A
-contenteditable region is the named case. It has no single true value for the
-controlled contract to converge on, so a `:value` binding on it throws at
-source. The recovery is real: rich text is a job for a
-[declared host](09-interop.md) or a [named native island](10-native-tier.md),
-where the editor library owns the DOM that it must own.
+Unsupported controlled shapes are rejected rather than approximated. In
+particular, a contenteditable region has no single value that Hicasso can
+reconcile. Binding `:value` to it throws at the source. Use a declared foreign
+host or named native island so the rich-text editor can own the DOM it needs.
 
-## Forwarding attributes
+## Forward caller attributes safely
 
-At some point you wrap a field once, and you let call sites pass placeholder,
-`name`, a test id, and more. The recipe is an ordinary merge, with your owned
-entries last:
+A reusable field can accept ordinary caller attributes while retaining its
+control slots. Merge the caller map first and the owned entries last:
 
 ```clojure
 (h/defview field [{:keys [id busy?] :as attrs}]
@@ -124,31 +106,31 @@ entries last:
            :disabled busy?
            :on-input [:todo.ui/edit-field id ::h/value]})])
 
-[field {:id :title :busy? busy? :type "text" :placeholder "Todo title"}]
+[field {:id :title
+        :busy? busy?
+        :type "text"
+        :placeholder "Todo title"}]
 ```
 
-**The literal keys you write always win.** The law binds on the React slot
-where a key lands, not on its spelling. A forwarded `:onInput` against your
-`:on-input`, or `"value"` against your `:value`, reaches nothing that matters.
-A forwarded map can never replace the owned value, checked, handler, key, or
-revision slots of a control. When you *want* a caller's value to win, do not
-write your literal. Put the element's own classes on the tag
-(`[:input.form-control …]`). Never forward `:key` or
-[`::h/revision`](glossary.md#hrevision): these keys address the element *you*
-wrote, and the runtime reads them only from the map you wrote.
+Literal owned keys win by presence. A caller cannot replace the field's value,
+checked state, handler, key, or revision by supplying an alternative spelling
+such as `:onInput` or `"value"`; the controlled contract binds to the React
+slot reached by the authored literal. When callers should own a slot, do not
+write that literal in the wrapper.
 
-## Resets are by revision, never by value
+Put the wrapper's own classes on the Hiccup tag so they compose with a caller's
+`:class`. Do not forward `:key` or [`::h/revision`](glossary.md#hrevision): both
+refer to the element authored by the wrapper and are read only from that
+map.
 
-To force a field back to a value — a form reset, a revert, a server-normalized
-write that comes back — is a real intent, and it has its own door: an
-**explicit revision** from the caller. The runtime never infers a reset from a
-comparison of the incoming value with a target. With a value-equality reset, a
-user who types the "reset" value loses the edit in progress. Also, a
-same-value reassertion (the caller rejects a draft and restores the old value)
-becomes invisible.
+## Reset with `::h/revision`
 
-[`::h/revision`](glossary.md#hrevision) is that one door. The view reads it like
-any other value, beside `:value`:
+A reset must be an explicit domain event. Hicasso never infers a reset because
+the incoming value equals a particular target. Value-based reset detection
+cannot distinguish a user typing that value from an application reset, and it
+cannot observe a same-value reassertion.
+
+Place [`::h/revision`](glossary.md#hrevision) beside the controlled `:value`:
 
 ```clojure
 (h/defview revertable-field [{:keys [id]}]
@@ -158,155 +140,130 @@ any other value, beside `:value`:
            :on-input    [:todo.ui/edit-field id ::h/value]}])
 ```
 
-The revert event does both halves: it restores the value **and** moves the
-revision. A `[:button {:on-click [:todo.ui/revert id]} "Revert"]` fires it:
+The reset event updates both the value and the revision:
 
 ```clojure
 (rf/reg-event :todo.ui/revert
   (fn [{:keys [db]} [_ id]]
     {:db (-> db
-             (assoc-in [:todo.ui :fields id] (get-in db [:todo.ui :saved id]))
-             (update-in [:todo.ui :baselines id] inc))}))   ;; the revision moves
+             (assoc-in [:todo.ui :fields id]
+                       (get-in db [:todo.ui :saved id]))
+             (update-in [:todo.ui :baselines id] inc))}))
 ```
 
-**Only a revision change resets.** A `:value` that moves under an unchanged
-revision is ordinary controlled conduct: the field shows it, and nothing
-consults the revision on the way. The comparison is `=`, so a revision value
-that is equal but freshly built is inert. The same move covers async
-normalization. When the server's canonical form of the typed text comes back,
-write the value and move the revision. The field re-baselines to it, even if
-the user has started to type again.
+```clojure
+[:button {:on-click [:todo.ui/revert id]} "Revert"]
+```
 
-**A reset is not a remount.** The draft in the field goes. The node itself
-stays, and the focus on it stays. The caret lands at the end of the model
-value on the commit that applies the reset. That is the platform's own
-conduct for a `value` assignment.
+Only a revision change triggers the reset behaviour. A new value under an
+equal revision is an ordinary controlled update. Revisions compare with `=`,
+so a freshly constructed but equal persistent value is unchanged.
 
-!!! warning "Write a revision the way you would write an instance key"
-    A revision created in render changes on every render, so it resets the
-    field on every render. Never use a render-order index, a counter that the
-    body increments, or `random-uuid`. A revision is a domain fact that your
-    *events* put in app-db: a record id, a load generation, a "form opened at"
-    stamp, or a counter that your revert handler increments.
+Async normalization uses the same rule: write the canonical value and advance
+the revision when the server result should replace the current draft. This can
+supersede text entered since the request began, so the event must encode the
+application's intended conflict policy rather than treating every response as
+a reset.
 
-The runtime raises `:rf.error/hicasso-revision-not-controlled` on anything that
-is not controlled text — a `:div`, a `select`, a value-less checkbox, an input
-with no `:value`. The error names the element and the source. The runtime never
-reads the prop from a forwarded map, so a caller cannot force a re-baseline on
-a field whose author did not write one. The prop never reaches the DOM as an
-attribute, on the client or on the server.
+A reset keeps the existing DOM node and focus. It discards the current draft;
+the caret moves to the end of the assigned model value, which is the browser's
+normal behaviour for a value assignment.
 
-This is the single prop and nothing more: no commit or cancel intents, no
-acknowledgement that a reset landed, no caret-policy options. When you want
-draft-and-commit behavior — free edits, commit on Enter or blur, cancel on
-Escape — use the [forms module](05-forms.md). The module *consumes* this
-trigger; it does not extend it.
+!!! warning "A revision must be stable domain state"
+    Do not create a revision in the view body with `random-uuid`, a render
+    counter, or a collection index. That changes on every render and therefore
+    resets on every render. Store a meaningful generation in app-db: a record
+    id, load generation, form-open stamp, or counter incremented by a reset
+    event.
+
+`::h/revision` is legal only on controlled text input or textarea. Using it on
+a `div`, `select`, value-less checkbox, or input with no `:value` raises
+`:rf.error/hicasso-revision-not-controlled`, naming the element and source.
+The prop is consumed by Hicasso and never becomes a DOM attribute on the client
+or server. A forwarded map cannot activate it for a field whose author did not
+write it.
+
+Revision provides only re-baselining. It does not add commit, cancel,
+acknowledgement, or caret-policy options. Use the forms module for a draft that
+commits on Enter or blur and cancels on Escape.
 
 ## Troubleshooting
 
-| Symptom | Error / mechanism | Fix |
-|---|---|---|
-| Characters drop when typing fast | Something async sat between keystroke and commit — debounce, `setTimeout`, a queued effect | Keep the controlled write synchronous; debounce *consumers* of the value, not the write itself |
-| Caret jumps to the end on every keystroke | Value reasserted without caret preservation | Runtime bug, not your view — report it |
-| Enter commits half-typed text mid-composition | A hand-written key handler bypassed the intent path | Use the data key map ([Events as data](03-events-as-data.md)); the composition check lives there |
-| Composition dies when the model rejects mid-draft | On the controlled path this cannot happen — composition is left alone until it ends. Something else wrote the field: a ref, a foreign script, an uncontrolled sibling | Find the second writer; the controlled element must have one |
-| An IME commit lands stale text, then corrects itself | Something async sat between keystroke and commit, so the composition's close reconciled against a model the deferred write had not reached | Keep the controlled write synchronous; the composition survives either way — only what it commits is late |
-| Typing the "reset" value clears the field | A reset keyed on value equality somewhere in your code | Move `::h/revision`; a value comparison is not a reset |
-| The field resets on every render | A revision created in render — `random-uuid`, a render-order index, a counter the body increments | Read a revision your *events* wrote into app-db |
-| The field never resets, and devtools shows a `revision="…"` attribute | A bare `:revision`. The match is the exact namespaced keyword. Every other spelling flows through as an ordinary attribute, silently. A namespaced value loses its namespace on the way, so two distinct revisions can collapse to one | Write `::h/revision` |
-| `:rf.error/hicasso-revision-not-controlled` at render | `::h/revision` on something that is not controlled text — a `:div`, a `:select`, a value-less checkbox | Put the revision on the controlled `input`/`textarea` whose draft it re-baselines; a select or checkbox resets by writing the model |
-| Focus lost after validation fails | Something remounted the node | Never remount to reset — that is exactly what destroys focus |
+| Symptom | Error or cause | Fix |
+| --- | --- | --- |
+| Fast typing drops characters | The controlled write was deferred through a timer, debounce, queued effect, or promise | Commit the field value synchronously. Debounce downstream consumers, not the write |
+| The caret moves to the end after each accepted/rejected edit | The normal controlled path failed to preserve selection | Treat this as a runtime bug and report it; do not remount or add a second writer |
+| Enter commits unfinished composition text | A custom key handler bypassed Hicasso's keyboard map | Use the data keyboard map so IME checks run centrally |
+| A rejected edit kills the active composition | Another writer changed the DOM value during composition | Find the ref, foreign script, or uncontrolled sibling writing the same field; a controlled field must have one writer |
+| IME text briefly lands stale and then corrects | The app-db write was deferred beyond the input turn | Keep the controlled write synchronous. The composition survives, but a deferred model update arrives late |
+| Typing the application's reset value clears the field | Application code inferred reset from value equality | Advance `::h/revision` only for explicit reset events |
+| The field resets on every render | The view creates a new revision while rendering | Read a stable revision written to app-db by events |
+| A `revision="…"` attribute appears and the field never resets | The page used bare `:revision`; only the exact namespaced `::h/revision` is reserved | Use `::h/revision`. Other spellings are ordinary DOM attributes and may lose namespace information |
+| Rendering raises `:rf.error/hicasso-revision-not-controlled` | Revision was placed on a control outside the supported text path | Put it on the controlled input/textarea. Reset a select or checkbox by updating its model value |
+| Focus disappears after validation fails | Code remounted the input | Keep the node and let the controlled path restore the model value |
 
-## When not to control an input
+## When not to control a field
 
-Controlled means that every keystroke writes app-db. On a dense grid, that is
-one dispatch per cell per keystroke. Measure that cost before you accept it
-(the [performance chapter](18-performance.md) owns the method).
+A controlled field writes app-db on every keystroke. Measure that path before
+using it across a dense editable grid.
 
-If the user's edit must be a *draft* — commit on Enter or blur, revert on
-Escape, reject without loss of the field — do not build that yourself on top
-of this page. That is the [forms module](05-forms.md).
+Use the [forms module](05-forms.md) when the user needs a separate draft that
+commits on Enter or blur, cancels on Escape, or survives validation failure.
 
-If no other code needs the intermediate values — a scratch field in a
-[modal](glossary.md#overlay), a filter box that only feeds a debounced query —
-leave the input uncontrolled (`:default-value` to seed it, no `:value`) and
-commit on blur. DOM-owned state is a legitimate explicit choice. The cost is
-this: app-db, tests, and tools cannot see the text in mid-edit.
+Use an uncontrolled input (`:default-value` without `:value`) when no other
+part of the application needs the intermediate text, such as a scratch field
+whose value is read only on blur. That choice keeps mid-edit text in the DOM,
+so app-db, tests, SSR, and tools cannot observe it until the commit.
 
 ## Advanced
 
-### Same-turn mechanics, and the one `flushSync`
+### Same-turn convergence and `flushSync`
 
-Dispatch for a controlled element runs synchronously inside the discrete
-browser event. Store notification is synchronous too, so React commits the
-echo in the same turn. The value is back in the DOM before the browser
-finishes the event.
+A controlled event dispatches synchronously, and store notification is also
+synchronous. React therefore receives the model echo during the same discrete
+browser event.
 
-`flushSync` is not a general default. The one exception is the controlled-text
-**converge**. The converge flushes the pending commit before React's
-end-of-event restore, so value *and caret* are correct in the same turn —
-including when the model rejected or normalized the keystroke. That path runs
-once per keystroke, on controlled text entry only (an `input` that has a
-caret, or a `textarea`, with a non-nil `:value`). It also runs once at the
-close of an IME composition. Everywhere else it is inert, and a page with no
-controlled input pays nothing for it. If your own code needs `flushSync` for
-anything else, that is a design problem, not a feature.
+Hicasso uses `flushSync` only for controlled-text convergence. It commits the
+pending value before React's end-of-event restore so that both the value and
+selection are correct when the handler accepts, rejects, or normalizes an
+edit. The path runs once per controlled text keystroke and once when an IME
+composition closes. Pages without a controlled text input do not pay for it.
+Using `flushSync` elsewhere in application code should be treated as an
+architecture problem rather than a normal Hicasso technique.
 
-### Rejection and React's restore
+### Rejection and React restoration
 
-When the handler returns `nil`, the DOM node can hold the typed character for
-a short time. React reasserts the model value when the discrete event ends.
-React's restore discards the caret, so the runtime itself restores caret and
-selection on that converge path. You still only write `nil`.
+When the handler returns `nil`, the DOM may briefly contain the typed
+character. React restores the unchanged model value at the end of the discrete
+event, but that restore normally loses selection. Hicasso restores the caret
+and selection on the controlled converge path. The handler still only returns
+`nil`.
 
-### IME composition
+### Composition handling
 
-Two rules apply. Both are automatic on the controlled-text path and the data
-key map:
+While IME composition is active, Hicasso does not overwrite the field with a
+rejected or normalized model value. The handler may still receive each
+composing update, but the visible composition remains intact until the user
+commits it. The model correction then applies as one value.
 
-**An Enter during composition commits nothing.** In mid-composition, Enter
-selects an IME candidate; it is not a submit. The key map gates that
-centrally. The signal mechanics (native event, legacy fallbacks) are in the
-Advanced section of [Events as data](03-events-as-data.md).
+This differs from plain React behaviour, where writing a corrected controlled
+value during composition can abort the composition. Repeated aborts can also
+compound normalized text; the runtime avoids both loss and duplication by
+excluding the live composition from restoration.
 
-**A live composition is not overwritten.** If the model rejects or normalizes
-the text that the IME composed so far, nothing writes the field while the
-composition runs — not the converge, and not React's end-of-event restore.
-Your handler still runs on every composing update. The field continues to show
-the composition until the user commits it, and the rejection or normalization
-applies whole when the composition ends.
+### Resets that must wait
 
-That second rule diverges from plain React. In plain React, a corrected value
-written during composition aborts the exchange: the kana in flight vanish, and
-the next update starts a fresh composition on a half-written draft. On a
-*normalizing* field, plain React does worse than lose the composition. Each
-aborted draft is written back, and the IME composes on top of it. So the
-sequence `s`, `sh`, commit ends the model at `SSHSH`, where this runtime
-commits the `SH` that was typed. The live composition is excluded from that
-restore on purpose.
+A revision change cannot always be applied immediately:
 
-### A reset that cannot land immediately
+- **During composition**, applying it would abort the user's IME exchange. The
+  field converges when composition ends, on blur, on unmount, or at the next
+  non-composing input. Later accepted composing updates may supersede the reset
+  by normal event order.
+- **During hydration**, a revision received before the server node is adopted
+  becomes the field's first observed revision and has no predecessor to compare
+  against. The server node and any user draft survive. A later revision change
+  resets normally. A caller that requires the swallowed reset must issue a new
+  revision after adoption.
 
-There are two cases. Both are documented conduct, not bugs.
-
-**In mid-composition.** A revision change that arrives while a composition runs
-lands at the close of the exchange: composition end, blur, unmount, or the
-next non-composing input. The reason is the same reason that nothing else
-writes the field there — the only immediate write available would abort the
-composition silently. The model is correct at all times; the screen converges
-at the close.
-
-The deferral cannot strand the field: every exit converges the field to the
-model current at that time. But the deferral does not promise that the reset
-*survives*. On a field that accepts, the model continues to take every
-composing update while the reset is pending. So an edit after the reset,
-including the composition's own final input, supersedes the reset by ordinary
-event order, exactly as it would at rest.
-
-**In mid-hydration.** A revision that moves before the runtime adopts the
-server-rendered tree is absorbed. The adoption render reads it as the field's
-*first* revision — a change with no predecessor. So nothing fires, the
-server's node survives, and any user draft in the field survives with it. The
-next revision change after adoption resets the field normally, on that same
-node. The field is never stranded. A reset that fell in this window is
-swallowed; the caller must send it again.
+In both cases app-db remains the authoritative model; only the safe time for
+writing the existing DOM node is deferred.

--- a/docs/design/hicasso/draft-guide/05-forms.md
+++ b/docs/design/hicasso/draft-guide/05-forms.md
@@ -1,35 +1,29 @@
 # Forms
 
-A bare [controlled field](glossary.md#controlled-field)
-([Controlled inputs](04-controlled-inputs.md)) binds directly to app-db, and
-that is all. Real forms need three more things:
+A controlled field writes every edit directly to app-db. A form often needs a
+separate draft, validation that appears at the right time, and a submit status
+that survives renders. The optional `re-frame.hicasso.forms` module provides
+those pieces without introducing local atoms or completion callbacks.
 
-- fields that buffer a *draft* — commit on Enter or blur, revert on Escape,
-  reject without loss of the field;
-- validation errors that wait for the correct moment, instead of errors on a
-  blank form;
-- a submit with a lifecycle you can read.
+A form has three kinds of state:
 
-The `re-frame.hicasso.forms` module owns all three. It is separately required
-and separately reachable: an application that never imports it ships none of
-it.
+- a draft that may be committed or abandoned
+- a gate that decides when validation and submission are allowed
+- a per-instance status for the write in flight
 
-A form is three pieces of state — a draft, a gate, a status — and all three
-are data.
+All three remain ordinary data.
 
-Every codebase that builds this by hand collects the same five defects. Each
-one is worth a name, because each one is a *class*, not a bug: the shape
-guarantees the failure.
+## Problems the module avoids
 
-| Trap | The hand-rolled shape | Here |
-|---|---|---|
-| Twin-atom stack | An "external" and an "internal" atom per field, synced by render-phase resets | A draft is addressed app-db state with one owner; there is nothing to sync |
-| Same-value blindness | Rejecting a draft by reasserting the equal model value — invisible to `not=`, so the rejected text stays on screen | The reset signal is [`::h/revision`](glossary.md#hrevision), distinct from the value by design |
-| Commit flicker | A forced reset on every commit misfires "changed"; async acceptance flickers between stale and new | A commit is decided against committed state at event time; acceptance is your event, and a stale commit no-ops |
-| Arity-sniffed done-fn | The flicker's escape hatch: probing the change callback's `.length` for a completion arity | There is no completion-callback protocol; submit status is data, read per instance |
-| Re-created ephemeral state | Interaction state created inside the render function — dies on any re-render | Nothing lives in a render closure; drafts and status live at addresses and survive re-render and remount |
+| Hand-written pattern | Failure it creates | Forms-module model |
+| --- | --- | --- |
+| External value plus local atom for each field | Two sources must be synchronized, usually during rendering | One addressed draft in app-db |
+| Detect reset by comparing values | Reasserting an equal committed value cannot make a rejected draft disappear | Reset is signalled separately with `::h/revision` |
+| Force a reset after every commit | Accepted async commits can flicker between stale and new values | Commit is decided against current state; stale commits become no-ops |
+| Inspect a callback's arity for a done function | Completion becomes an undocumented callback protocol | Mutation status is per-instance data |
+| Create draft state in a render closure | Re-render or remount destroys the edit | Draft and status live at stable addresses |
 
-One require serves the whole page:
+Require the module where its views are used:
 
 ```clojure
 (ns app.todos
@@ -39,19 +33,23 @@ One require serves the whole page:
             [re-frame.hicasso.forms :as forms]))
 ```
 
-## The draft field
+Applications that never require this namespace do not include the module.
 
-[`forms/buffered-field`](glossary.md#buffered-field) is one
-[controlled input](glossary.md#controlled-field) with a draft in front of it.
-The caller supplies four things: a stable address for the draft, the
-committed value, the value's revision, and the event that receives a commit.
+## Buffered fields
+
+[`forms/buffered-field`](glossary.md#buffered-field) is a controlled input with
+an app-db draft in front of the committed value. Supply a stable control
+address, the committed value, its revision, and the event that receives a
+candidate commit:
 
 ```clojure
 (rf/reg-sub :todo/title
-  (fn [db [_ id]] (get-in db [:todo id :title])))
+  (fn [db [_ id]]
+    (get-in db [:todo id :title])))
 
 (rf/reg-sub :todo/title-revision
-  (fn [db [_ id]] (get-in db [:todo id :title-revision] 0)))
+  (fn [db [_ id]]
+    (get-in db [:todo id :title-revision] 0)))
 
 (h/defview title-field [{:keys [id]}]
   [forms/buffered-field
@@ -62,73 +60,74 @@ committed value, the value's revision, and the event that receives a commit.
     :placeholder "What needs doing?"}])
 ```
 
-The protocol is fixed, and it is the one users expect:
+The interaction protocol is fixed:
 
-- **The first edit begins the session.** Focus alone creates nothing. The
-  field shows `:value` until the user types.
-- **Enter and blur are the same commit.** Both dispatch your `:on-commit`
-  event with the draft candidate appended.
-- **Escape cancels.** The module clears the draft, and the field shows
-  `:value` again. Pass `:on-cancel` if cancellation is significant to your
-  domain.
-- **Unmount does nothing.** It does not commit and does not cancel. So a
-  draft in a virtualized row survives a scroll away and back.
+- Focus alone does not create a draft. The first edit starts the session.
+- Enter and blur both append the draft candidate to `:on-commit` and dispatch
+  it.
+- Escape clears the draft and shows `:value` again. Add `:on-cancel` when
+  cancellation has domain meaning.
+- Unmount neither commits nor cancels. A virtualized row can leave and return
+  without losing its draft.
 
-During an edit, the draft lives in app-db under the module's own key at the
-`:control` address — no atom, no closure. It appears in a state snapshot, it
-asserts in a headless test, and it reads in Xray like any other state.
-Everything else you pass (`:placeholder`, `:class`, `:name`, a test id) goes
-through to the input. The control slots stay owned, under the merge rule from
-[Controlled inputs](04-controlled-inputs.md).
+The module stores the draft under its own app-db key at the `:control` address.
+It therefore appears in snapshots, headless tests, and Xray. Other props such
+as `:placeholder`, `:class`, `:name`, and test ids pass through to the input;
+the value, handler, key, and revision slots remain owned by the field.
 
-## Accepting, rejecting, rewriting
+Use an address that identifies the form instance and field. Two fields with
+the same address intentionally share a draft, which is usually a bug.
 
-Your `:on-commit` event is the commit authority. To accept the candidate,
-write it. To rewrite it, write the normalized form. To reject it, write
-nothing. **When you reject or rewrite, move the revision.** That is the whole
-discipline:
+## Accept, reject, or rewrite a candidate
+
+The `:on-commit` handler decides the result:
+
+- accept by writing the candidate
+- normalize by writing another value
+- reject by leaving the committed value unchanged
+
+When the handler rejects or rewrites, advance the revision as well:
 
 ```clojure
 (rf/reg-event :todo/title-committed
   (fn [{:keys [db]} [_ id candidate]]
     (let [title (str/trim candidate)]
       (if (str/blank? title)
-        {:db (update-in db [:todo id :title-revision] (fnil inc 0))}
+        {:db (update-in db
+                        [:todo id :title-revision]
+                        (fnil inc 0))}
         {:db (-> db
-                 (assoc-in  [:todo id :title] title)
-                 (update-in [:todo id :title-revision] (fnil inc 0)))}))))
+                 (assoc-in [:todo id :title] title)
+                 (update-in [:todo id :title-revision]
+                            (fnil inc 0)))}))))
 ```
 
-The revision is why a same-value rejection *shows*. Suppose the committed
-value was `"Buy milk"`, the user drafts `"   "`, and you reject by keeping
-`"Buy milk"`. No value comparison can tell the field that anything changed —
-that is trap two. The moved revision is the explicit signal. The field
-re-baselines to `:value`, visibly, and any edit still in flight under the old
-revision becomes ineligible. The same move makes async acceptance safe.
-Validate in an event, then settle later with a write of value plus revision.
-A commit that raced you still holds the revision it began under, so it is a
-no-op instead of a flicker.
+The revision makes same-value rejection observable. If the committed value is
+`"Buy milk"` and the user submits a blank draft, retaining `"Buy milk"` does
+not change the value. Advancing the revision explicitly ends the old edit and
+re-baselines the field to the committed value.
 
-A caller that never rejects or rewrites can pass a constant `0` as the
-revision. That spelling means, by design: "nothing external resets an active
-edit".
+The same fence applies to async acceptance. A later settle event writes the
+accepted value and advances the revision. Any commit still associated with the
+old revision becomes a no-op instead of restoring stale text.
 
-The module settles two races, so you never think about them:
+A field that will never be externally reset, rejected, or rewritten may use a
+constant revision such as `0`. That choice means an active draft is never
+replaced merely because `:value` changed.
 
-- **Cancel, then blur.** Escape clears the draft record. It often also
-  unmounts the input, which fires a blur, whose commit is already queued.
-  That commit consults committed state, finds no live edit, and produces
-  nothing. A cancelled draft cannot come back through its own blur.
-- **Repeated commits.** Enter followed by blur, or a double Enter, commits
-  once. A commit or cancel that arrives for a session that already ended is
-  an idempotent no-op.
+The module also settles two common races:
 
-## Errors that show at the right moment
+- **Escape followed by blur.** Cancel removes the live draft. The trailing blur
+  finds no session to commit and does nothing.
+- **Repeated commits.** Enter followed by blur, double Enter, or a late cancel
+  affects the session once. Later operations for the ended session are
+  idempotent no-ops.
 
-Validation itself is one pure function over the draft. The part that needs
-design is *display*. An error appears only after the user touched the field
-or attempted a submit — never on first paint. The gate applies per field, per
-form instance.
+## Gate validation by interaction
+
+Validation can remain a pure function of the draft. Error display should be
+gated so a blank form does not report every problem on first paint. Track which
+fields were touched and whether the user attempted submission:
 
 ```clojure
 (def blank-editor
@@ -139,7 +138,8 @@ form instance.
 
 (defn validate [{:keys [title]}]
   (cond-> {}
-    (str/blank? title) (assoc :title "Title is required.")))
+    (str/blank? title)
+    (assoc :title "Title is required.")))
 
 (rf/reg-event :todo.editor/edit-field
   (fn [{:keys [db]} [_ field text]]
@@ -147,19 +147,25 @@ form instance.
 
 (rf/reg-event :todo.editor/touch-field
   (fn [{:keys [db]} [_ field]]
-    {:db (update-in db [:todo.editor :touched] (fnil conj #{}) field)}))
+    {:db (update-in db
+                    [:todo.editor :touched]
+                    (fnil conj #{})
+                    field)}))
 
 (rf/reg-sub :todo.editor/field
-  (fn [db [_ field]] (get-in db [:todo.editor :draft field])))
+  (fn [db [_ field]]
+    (get-in db [:todo.editor :draft field])))
 
 (rf/reg-sub :todo.editor/field-error
   (fn [db [_ field]]
-    (let [{:keys [draft touched submit-attempted?]} (:todo.editor db)]
-      (when (or submit-attempted? (contains? touched field))
+    (let [{:keys [draft touched submit-attempted?]}
+          (:todo.editor db)]
+      (when (or submit-attempted?
+                (contains? touched field))
         (get (validate draft) field)))))
 ```
 
-The field is an ordinary controlled input; blur is the touch:
+A controlled field marks itself touched on blur and displays the derived error:
 
 ```clojure
 (h/defview editor-title-field []
@@ -174,71 +180,75 @@ The field is an ordinary controlled input; blur is the touch:
      [:div.error-messages error])])
 ```
 
-When the user types into a touched field, the error clears at the moment the
-input becomes valid. The error is *derived* from the draft, so there is
-nothing imperative to keep in sync. On a buffered form, the commit is the
-touch: mark the field touched in your `:on-commit` handler, and the same
-gating subs apply.
+Because the error is derived from the current draft, it clears as soon as a
+touched field becomes valid. For a buffered field, mark the field touched in
+its `:on-commit` handler and use the same gated subscription.
 
-## One submit gate, readable twice
+## Materialise the submit gate once
 
-"Can this form submit?" is needed in two places: the button disables on it,
-and the submit handler gates on it. If you compute it twice, the two
-computations drift — a handler that recomputes validation the button never
-saw is a known trap. So materialise it once, into app-db, where both can read
-it:
+The view needs to disable the submit button and the handler needs to reject an
+invalid submission. Compute that decision once rather than maintaining two
+validation paths. A flow can materialise it into app-db:
 
 ```clojure
 (def can-submit-flow
   [:todo.editor/can-submit?
    {:doc         "Valid AND different from the loaded baseline."
-    :inputs      [[:todo.editor :draft] [:todo.editor :baseline]]
+    :inputs      [[:todo.editor :draft]
+                  [:todo.editor :baseline]]
     :output-path [:todo.editor :can-submit?]}
    (fn [draft baseline]
      (and (empty? (validate draft))
           (not= draft baseline)))])
 
-(rf/reg-event :todo.editor/register-flow   ;; dispatch once, from your boot event
+(rf/reg-event :todo.editor/register-flow
   (fn [_ _]
     {:fx [[:rf.fx/reg-flow can-submit-flow]]}))
 
 (rf/reg-sub :todo.editor/can-submit?
-  (fn [db _] (boolean (get-in db [:todo.editor :can-submit?]))))
+  (fn [db _]
+    (boolean (get-in db [:todo.editor :can-submit?]))))
 ```
 
-The view reads the sub. The handler reads plain data from `db`. One
-derivation, two readers — they cannot disagree:
+Register the flow once during boot. The view subscribes to the result; the
+handler reads the same value directly from `db`:
 
 ```clojure
 (def save-instance :todo.editor/save)
 
 (rf/reg-event :todo.editor/submit
   (fn [{:keys [db]} _]
-    (if-not (get-in db [:todo.editor :can-submit?])   ;; plain data — no subscribing mid-handler
-      {:db (assoc-in db [:todo.editor :submit-attempted?] true)}
-      {:db (assoc-in db [:todo.editor :submit-attempted?] true)
-       :fx [[:dispatch [:rf.mutation/execute
-                        {:mutation :todo/save
-                         :params   (get-in db [:todo.editor :draft])
-                         :instance save-instance
-                         :reply-to [:todo.editor/replied]}]]]})))
+    (if-not (get-in db [:todo.editor :can-submit?])
+      {:db (assoc-in db
+                     [:todo.editor :submit-attempted?]
+                     true)}
+      {:db (assoc-in db
+                     [:todo.editor :submit-attempted?]
+                     true)
+       :fx [[:dispatch
+             [:rf.mutation/execute
+              {:mutation :todo/save
+               :params   (get-in db [:todo.editor :draft])
+               :instance save-instance
+               :reply-to [:todo.editor/replied]}]]]})))
 ```
 
-A rejected submit still sets `:submit-attempted?`. That flag un-gates every
-remaining error at once: the user asked, so the form answers in full.
+A rejected submit still sets `:submit-attempted?`, which exposes all remaining
+field errors. The button and the handler cannot disagree because both read the
+same materialised fact.
 
-## Submit status is per-instance data
+## Read submit status by instance
 
-The write is a mutation, executed under an **instance** — a stable id for this
-form's save. You read its status wherever it is needed, as data, through the
-framework's own subscription:
+Run the write as a mutation under a stable form instance. The form reads that
+instance's status as data:
 
 ```clojure
 (h/defview editor-form []
   (let [save (h/sub [:rf/mutation {:instance save-instance}])]
-    [:form {:on-submit [::h/prevent [:todo.editor/submit]]}   ;; nothing auto-prevents
+    [:form {:on-submit [::h/prevent [:todo.editor/submit]]}
      (when (:error? save)
-       [:ul.error-messages [:li "Save failed — check the fields and try again."]])
+       [:ul.error-messages
+        [:li "Save failed — check the fields and try again."]])
      [editor-title-field]
      [:button.btn.btn-primary
       {:type     :submit
@@ -247,76 +257,71 @@ framework's own subscription:
       "Save todo"]]))
 ```
 
-`:pending?` is the busy discipline. Inputs and buttons disable from the state
-of the write in flight, never from a local flag that you set and forget.
-There is no completion callback to give to anyone — trap four. Completion is
-an event that you named at the call site:
+`:pending?` is the busy flag. Disable fields or buttons from the mutation
+instance rather than a local boolean that can be left behind after an error.
+There is no done-callback protocol. Completion arrives through the named reply
+event:
 
 ```clojure
 (rf/reg-event :todo.editor/replied
   (fn [{:keys [db]} [_ {:keys [status]}]]
     (when (= :ok status)
       {:db (assoc db :todo.editor blank-editor)
-       :fx [[:dispatch [:rf.mutation/clear {:instance save-instance}]]]})))
+       :fx [[:dispatch
+             [:rf.mutation/clear {:instance save-instance}]]]})))
 ```
 
-Registration of the mutation itself — request shape, decoding, cache
-invalidation, supersession, cancellation — belongs to the
-[async resources](08-async-resources.md) chapter. A form only executes one
-mutation and reads one instance.
-
-## When a plain field is enough
-
-Most fields need none of this page. A search box that feeds a debounced query,
-a settings toggle, a filter — bind them directly to app-db and stop. That
-whole story is [Controlled inputs](04-controlled-inputs.md). Use the forms
-module when you want a draft the user can abandon, errors that wait, or a
-submit lifecycle — and only then. Every
-[buffered field](glossary.md#buffered-field) is one more address and one more
-commit protocol in your app's state. An application that never requires
-`re-frame.hicasso.forms` ships zero bytes of it.
+The async-resources chapter owns mutation registration, request encoding,
+cache invalidation, cancellation, and supersession. A form only executes the
+mutation and reads its instance.
 
 ## Troubleshooting
 
-Failures on the underlying elements use the controlled-input error ids
-([Controlled inputs](04-controlled-inputs.md), e.g.
-`:rf.error/hicasso-revision-not-controlled`). The module's own failure modes
-are behavioural: a wrong address or an ungated sub misbehaves without a
-named error. So these rows name mechanisms:
+The module's common failures are behavioural rather than separately named
+runtime errors. Underlying controlled elements still use errors such as
+`:rf.error/hicasso-revision-not-controlled`.
 
-| Symptom | What is happening | Fix |
-|---|---|---|
-| Errors show on a blank, untouched form | Error display is not gated | Gate on touched-or-attempted, per field (`:todo.editor/field-error` above) |
-| The button enables but the handler rejects (or vice versa) | Two validity computations drifting apart | One materialised gate; the view subscribes, the handler reads `db` — never recompute per site |
-| Escape reverts, then the old draft reappears | A second copy of the draft outside the module — a local atom, a duplicated slice | One draft, one address; let the field own cancel — its trailing blur no-ops |
-| Two fields fight over one draft | Duplicate `:control` address | Address per instance: `[:todo id :title]`, not `[:todo :title]` |
-| A rejected draft still reads as accepted | The revision did not move, so the same-value rejection is invisible | Move `::h/revision` whenever you reject or rewrite |
-| The field ignores an external value change mid-edit | By design: a value change under an unchanged revision continues the draft | Move the revision when you mean *replace the edit* |
-| A late async accept clobbers newer typing | The settle wrote the value without fencing | Settle writes value **and** revision; commits under the old revision no-op. Deeper supersession policy: [async resources](08-async-resources.md) |
-| A half-typed draft resurfaces much later | Drafts are durable state, and no causal owner cleared them | Clear at the causal end — route entry, or the save's reply (see Advanced) |
-| The submit button never re-enables after a failure | The instance still holds the failed status | `[:rf.mutation/clear {:instance …}]` when the user retries or re-enters the form |
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Errors appear on the untouched form | Error display is not gated | Show each error only after that field is touched or submission was attempted |
+| The button enables but the handler rejects, or the reverse | The two sites recompute validity independently | Materialise one gate; subscribe in the view and read the same db value in the handler |
+| Escape clears the field and the old draft returns on blur | A second draft copy exists outside the module | Keep one addressed draft. The module's trailing blur already no-ops after cancel |
+| Two fields overwrite one another's drafts | Their `:control` addresses collide | Include form instance and field identity, for example `[:todo id :title]` |
+| A rejected or normalized draft remains visible | The committed value stayed equal and the revision did not advance | Move `::h/revision` whenever a commit rejects or rewrites |
+| An external value update does not replace the active edit | Value changed under an equal revision | Advance the revision only when the application intends to replace the draft |
+| A late async acceptance overwrites newer work | The settle event wrote without a revision/supersession fence | Settle value and revision together; apply the mutation's supersession policy |
+| An old draft reappears after later navigation | Draft state is durable and no causal owner cleared it | Clear it on route entry, successful save, explicit cancel, or another domain end event |
+| Submit remains disabled after a failed request | The mutation instance still records failure | Clear or retry the instance with `[:rf.mutation/clear {:instance …}]` at the intended lifecycle point |
+| The form submits and the browser reloads | Submit intent was not wrapped | Use `[::h/prevent [:todo.editor/submit]]`; Hicasso does not auto-prevent |
+
+## When not to use the forms module
+
+Use a direct controlled input for a search box, filter, settings toggle, or
+other value that should update app-db immediately and has no abandonable draft.
+
+Use the forms module only when you need at least one of its actual jobs:
+commit/cancel buffering, interaction-gated errors, or a readable submit
+lifecycle. Each buffered field adds an address and commit protocol to app-db.
 
 ## Advanced
 
-### Draft lifetime, and who clears it
+### Draft lifetime
 
-A draft is durable application state. It survives re-render, remount,
-virtualization, and navigation, because unmount does nothing by design. That
-durability is a feature with an obligation attached: every draft needs a
-causal owner with an end event. The usual owners are route entry (reset the
-form slice when the user arrives) and the save's reply (reset to a clean
-baseline when the server accepts, as `:todo.editor/replied` does above). A
-form whose drafts matter across navigation should pair with a dirty-leave
-guard. Derive "dirty" from the same state (`(not= draft baseline)`), and let
-the guard in the [routing chapter](07-routing-and-navigation.md) block the
-exit.
+A draft deliberately survives re-render, remount, virtualization, and
+navigation. Every durable draft therefore needs a causal owner and an end
+event. Common owners are route entry, explicit cancel, and the successful
+save reply.
 
-### What a keystroke costs here
+A form that may block navigation should derive `dirty?` from the same draft and
+baseline and feed that value to the routing guard. Do not create a second dirty
+flag that can drift from the form state.
 
-A buffered draft still writes app-db on each keystroke. The buffering changes
-*when the committed value moves*, not how the draft is tracked. That is what
-keeps drafts testable and visible to tools. For a dense grid where writes per
-cell per keystroke cost too much, the answer is not this module. The answer is
-the explicit uncontrolled choice, or a
-[native island](glossary.md#native-island) — both with their costs in
-[Performance](18-performance.md).
+### Keystroke cost
+
+A buffered field still writes its draft to app-db on every keystroke. Buffering
+changes when the committed domain value moves; it does not make the draft
+DOM-local. This keeps the edit visible to tests and tools.
+
+For a dense grid where that cost is too high, use an explicitly uncontrolled
+input or a measured native island. The forms module is not a performance escape
+from controlled fields.

--- a/docs/design/hicasso/draft-guide/06-lists-and-collections.md
+++ b/docs/design/hicasso/draft-guide/06-lists-and-collections.md
@@ -1,12 +1,12 @@
 # Lists and collections
 
-A list of twenty rows is easy. At a few hundred or a few thousand, two
-choices decide how it behaves: **what identifies each row** (keys), and
-**which rows re-render when one row changes** (where you put the reads).
+Large collections are governed by two decisions: which value identifies each
+row, and which view owns each subscription read. Stable keys protect row
+identity; read placement controls the amount of work caused by an update.
 
-## Keys are identity
+## Use stable domain keys
 
-Put a stable `:key` in each child's props map. There is no metadata form:
+Put `:key` in each child's props map:
 
 ```clojure
 (ns app.orders
@@ -14,7 +14,8 @@ Put a stable `:key` in each child's props map. There is no metadata form:
             [re-frame.hicasso :as h]))
 
 (rf/reg-sub :orders/visible-ids
-  (fn [db _] (:order-ids db)))
+  (fn [db _]
+    (:order-ids db)))
 
 (h/defview orders-list [_]
   [:ul
@@ -22,88 +23,92 @@ Put a stable `:key` in each child's props map. There is no metadata form:
      [order-row {:key id :id id}])])
 ```
 
-Use a **domain id**, not a position. React uses the key to decide which child
-is the same child across renders. Key by index, and an insertion at the top
-renames every row: focus, selection, and half-typed input jump with the
-index. Key by domain id, and an insertion is one new node; other rows keep
-their identity. Value-equality memoization often skips their bodies entirely
-([Views and reads](02-views-and-reads.md)).
+Use an identity from the domain, not the row's current position. React uses the
+key to decide whether a child before and after an update is the same child.
+With index keys, inserting one item at the front renames every row, so focus,
+selection, local browser state, and animation can move to the wrong entity.
+With domain ids, existing rows retain their identity and equal-props bail-outs
+can skip their bodies.
 
-!!! warning "Never index, never the whole entity"
-    An index key breaks under reorder and insertion. A whole-entity key
-    breaks under edit: React stringifies a non-primitive key, so an edit
-    changes the key and remounts the row. Development warns with
-    `:rf.warning/hicasso-entity-key` and points at the child. Strings,
-    numbers, keywords, uuids, and symbols are fine; collections, JS objects,
-    dates, booleans, and functions are not.
+!!! warning "Do not key by index or by the complete entity"
+    An index changes meaning after insertion or reorder. A complete entity
+    changes when the entity is edited; React also coerces non-primitive keys,
+    which can remount or collide. Hicasso reports
+    `:rf.warning/hicasso-entity-key` and identifies the child.
 
-If you omit a key, development emits two warnings: React's, and
-`:rf.warning/hicasso-missing-key`. The Hicasso warning names the enclosing
-view, the child head, and the index of the first offender. React dedupes its
-own warning per parent tag for the life of the page — under a `:ul`, later
-lists go silent — so Hicasso fires once per call site. It also covers a case
-React misses: a seq passed as a view's children,
-`[card {} (for [t toasts] [toast-row {…}])]`. Hicasso flattens that seq into
-direct children; React treats the flattened members as already validated and
-never warns. Both checks are development-only.
+    Strings, numbers, keywords, UUIDs, and symbols are valid keys.
+    Collections, JS objects, dates, booleans, and functions are not.
 
-??? info "Coming from Reagent"
-    Hicasso does not read `^{:key id}` metadata. Keys live in the props map:
-    `[order-row {:key id :id id}]`. A leftover metadata key is a common cause
-    of `:rf.warning/hicasso-missing-key`.
+Missing keys produce React's warning and
+`:rf.warning/hicasso-missing-key` in development. The Hicasso warning names
+the enclosing view, child head, and first offending index. It fires per call
+site rather than relying on React's page-lifetime deduplication.
 
-## Where the reads live
+Hicasso also detects a case React can miss: a sequence passed as a Hicasso
+view's children and flattened before reaching React. The flattened elements may
+already appear validated to React, so the Hicasso check is the only warning.
+Both checks disappear from production.
 
-`h/sub` is legal anywhere in a view body, so you choose *where* the reads
-sit. For a collection, that choice decides what an update costs. Four shapes
-cover real workloads:
+??? info "For readers coming from Reagent"
+    Hicasso does not read `^{:key id}` metadata. Use
+    `[order-row {:key id :id id}]`.
 
-| Shape | Reads | Best at | Cost |
-|---|---|---|---|
-| **Fine** | each row reads its own entity | sparse, independent updates | one retained read per row |
-| **Coarse** | one view-model for the table | cheap mount; bulk replacement | every change recomputes the model and props-compares all rows |
-| **Chunked** | one read per block of rows | large mixed workloads | chunk membership shifts on insert/reorder |
-| **Windowed** | fine reads, only visible rows exist | collections that should not fully exist in the DOM | host owns scrolling; focus and a11y need checks |
+## Choose where rows read
 
-Fine is the default and the right choice for most screens. The rest of this
-section walks **one orders table** through all four shapes. A websocket
-updates single order statuses; a refresh replaces the whole set.
+Four collection shapes cover most workloads:
 
-### Fine: rows read themselves
+| Shape | Read placement | Good fit | Main cost |
+| --- | --- | --- | --- |
+| Fine | each row reads its entity | sparse independent updates | one retained read per mounted row |
+| Coarse | parent reads one display model | cheap mount and bulk replacement | every change recomputes the model and compares every row's props |
+| Chunked | one display-model read per block | large mixed sparse/bulk workloads | insert/reorder can move ids between chunks |
+| Windowed | visible rows read themselves | collections that should not all exist in the DOM | host owns scrolling; focus, search, print, and accessibility require testing |
+
+Fine reads are the normal starting point. Change shape only when a profile
+identifies a specific mount, recomputation, comparison, or DOM cost.
+
+## Fine-grained rows
+
+The parent reads only the ordered ids. Each row reads its own entity:
 
 ```clojure
 (rf/reg-sub :order/by-id
-  (fn [db [_ id]] (get-in db [:orders id])))
+  (fn [db [_ id]]
+    (get-in db [:orders id])))
 
 (h/defview order-row [{:keys [id]}]
-  (let [{:keys [customer status total]} (h/sub [:order/by-id id])]
+  (let [{:keys [customer status total]}
+        (h/sub [:order/by-id id])]
     [:tr
      [:td customer]
-     [:td {:class (when (= status :late) "is-late")} (name status)]
+     [:td {:class (when (= status :late) "is-late")}
+      (name status)]
      [:td total]
-     [:td [:button {:on-click [:order/expedite id]} "Expedite"]]]))
+     [:td
+      [:button {:on-click [:order/expedite id]}
+       "Expedite"]]]))
 
 (h/defview orders-table [_]
   [:table.orders
-   [:thead [:tr [:th "Customer"] [:th "Status"] [:th "Total"] [:th ""]]]
+   [:thead
+    [:tr [:th "Customer"] [:th "Status"] [:th "Total"] [:th ""]]]
    [:tbody
     (for [id (h/sub [:orders/visible-ids])]
       [order-row {:key id :id id}])]])
 ```
 
-The parent reads only the ids; each row reads its own entity. When one
-order's status changes, one subscription changes, one row body runs, and one
-cell updates. The parent does not re-render if the ids did not move. Body
-work scales with changed rows, not mounted rows
-([Performance](18-performance.md)).
+If one order's status changes and the id list stays equal, only that row's
+subscription changes and only that row body runs. Work scales with changed
+rows rather than mounted rows.
 
-The price is retention: a thousand mounted rows hold a thousand reads.
-For a few hundred rows that is usually noise. When a profile points at mount
-time or a bulk replace-everything, try coarse.
+The cost is one retained read per mounted row. That is normally acceptable for
+hundreds of rows. Consider another shape only when profiling shows mount or
+bulk-update cost.
 
-### Coarse: one view-model
+## Coarse display model
 
-The table reads **one** subscription shaped for display. Rows take props:
+A parent can subscribe to one vector shaped for rendering and pass each row as
+props:
 
 ```clojure
 (rf/reg-sub :orders/table-rows
@@ -117,36 +122,36 @@ The table reads **one** subscription shaped for display. Rows take props:
   (let [{:keys [id customer status total]} row]
     [:tr
      [:td customer]
-     [:td {:class (when (= status :late) "is-late")} (name status)]
+     [:td {:class (when (= status :late) "is-late")}
+      (name status)]
      [:td total]
-     [:td [:button {:on-click [:order/expedite id]} "Expedite"]]]))
+     [:td
+      [:button {:on-click [:order/expedite id]}
+       "Expedite"]]]))
 
 (h/defview orders-table [_]
   [:table.orders
-   [:thead [:tr [:th "Customer"] [:th "Status"] [:th "Total"] [:th ""]]]
+   [:thead
+    [:tr [:th "Customer"] [:th "Status"] [:th "Total"] [:th ""]]]
    [:tbody
     (for [row (h/sub [:orders/table-rows])]
       [order-row {:key (:id row) :row row}])]])
 ```
 
-Mount is cheap (one read). A bulk replacement is one recompute. Sparse
-updates still work, but differently: the view-model recomputes, the parent
-re-renders, and every row gets a props compare. Unchanged rows still
-compare `=` and skip their bodies — only the changed row runs. What grew is
-the **sweep**: one compare per row, plus the view-model recompute. At a few
-hundred rows that is usually fine; at tens of thousands your profile will
-name it.
+Mount retains one subscription. A bulk replacement recomputes one display
+model. A sparse update also recomputes that model and causes the parent to
+compare props for every row. Equal row maps still skip unchanged row bodies;
+the additional cost is the model recomputation and one comparison per row.
 
-Two rules keep the bail-out honest. Rows must receive **values** — maps from
-`select-keys` compare with `=` across renders; a fresh closure does not.
-Keep the row map to what the row shows: a `:updated-at` nobody renders
-defeats `=` on every touch. Event vectors as data help here
-([Events as data](03-events-as-data.md)).
+Keep row props value-oriented and limited to what the row displays. Persistent
+maps compare with `=`; fresh closures and JS objects compare by identity. A
+field such as `:updated-at` that the row never renders can defeat the bail-out
+for no benefit.
 
-### Chunked: bounding the sweep
+## Chunk the comparison sweep
 
-For a large table with both sparse updates and bulk operations, chunk the
-rows so no single read or props sweep spans the whole table:
+For a very large table with both sparse updates and bulk changes, group rows
+into fixed-size positional chunks:
 
 ```clojure
 (rf/reg-sub :orders/chunk
@@ -163,30 +168,31 @@ rows so no single read or props sweep spans the whole table:
 
 (h/defview orders-table [_]
   [:tbody
-   (for [[i ids] (map-indexed vector
-                              (partition-all 50 (h/sub [:orders/visible-ids])))]
+   (for [[i ids]
+         (map-indexed vector
+                      (partition-all 50
+                                     (h/sub [:orders/visible-ids])))]
      [order-chunk {:key i :ids (vec ids)}])])
 ```
 
-A sparse update changes one chunk's output. That chunk re-renders; the
-sweep is about 50 compares, not the whole table. Mount retains one read per
-block instead of one per row. Untouched chunks re-select cheaply, their
-outputs are `=`, and nothing downstream moves.
+A sparse update changes one chunk, limiting the props sweep to about 50 rows.
+The table retains one read per chunk instead of one per row. Equal outputs for
+untouched chunks stop there.
 
-Chunk by **index** is correct: a chunk is a positional window ("rows
-0–49"), not an entity. Entity keys still live on the rows inside. Insertion
-or reorder can shift ids across chunk borders and re-render every chunk they
-cross — a bulk-shaped cost for a bulk-shaped change.
+The chunk key may be positional because a chunk represents a positional window
+such as rows 0–49. Entity keys still belong on rows inside the chunk. Insertion
+or reorder may shift ids across chunk boundaries and re-render each affected
+chunk, which is an expected bulk-shaped cost.
 
-### Windowed: only the visible rows exist
+## Window the DOM
 
-Past a few thousand rows, ask whether row 8,000 needs a DOM node at all. The
-simplest window is pagination: page number in app-db, and
-`(h/sub [:orders/page n])` materializes one page. For continuous scrolling,
-bring a virtualizer through `h/defhost` and let it own the window:
+For thousands of rows, determine whether all rows need DOM nodes. Pagination is
+the simplest window: keep the page in app-db and subscribe to one page. For
+continuous scrolling, declare a virtualizer host and let it own the visible
+window:
 
 ```clojure
-;; A .cljs host namespace — keep JS requires out of .cljc bodies.
+;; Keep npm requires in a .cljs host namespace.
 (ns app.orders.virtual
   (:require ["react-virtuoso" :refer [Virtuoso]]
             [re-frame.hicasso :as h]))
@@ -197,75 +203,66 @@ bring a virtualizer through `h/defhost` and let it own the window:
 (h/defview orders-table [_]
   (let [ids (h/sub [:orders/visible-ids])]
     [virtual-list
-     {:class            "orders-viewport"       ;; height lives in CSS
+     {:class            "orders-viewport"
       :total-count      (count ids)
-      :compute-item-key (fn [index] (nth ids index))
+      :compute-item-key (fn [index]
+                          (nth ids index))
       :item-content     (fn [index]
                           (h/as-element
                            [order-row {:id (nth ids index)}]))}]))
 ```
 
-What each piece does:
+Important parts of this crossing:
 
-- **`order-row` is still the fine-read version** — `{:id id}`, reading its own
-  entity. Virtualization is fine reads with a bounded N. Only ~30 rows exist,
-  so only ~30 reads are retained; a sparse update still hits one of them.
-- **`:item-content` is `:render`** — the library calls it during its own
-  render; the body must stay pure. Return hiccup through `h/as-element` so
-  React gets a real element. A plain `fn` is fine when the row is a
-  `[order-row …]` head: that view resolves the frame where the library
-  renders it. Use `h/event` when the callback body itself carries an event
-  vector ([Interop](09-interop.md)).
-- **Close over `ids`, not over a read.** Call `h/sub` in the view body; the
-  callback captures the value. An `h/sub` inside the callback is a deferred
-  read and is refused.
-- **`:compute-item-key` carries domain ids** across the host. When a
-  virtualizer owns the list, hand it the same ids you would put at `:key`.
-- Scroll position stays out of app-db. High-rate motion is host mechanics
-  ([Ephemeral state](11-ephemeral-state.md)).
+- `order-row` keeps the fine-read shape and reads its own entity. Only the
+  visible rows exist, so only their reads are retained.
+- `:item-content` is declared as a render callback. It runs during the
+  virtualizer's render, must stay pure, and returns a React element through
+  `h/as-element`.
+- The outer view reads `ids`; the callback closes over that value. Calling
+  `h/sub` inside the callback would be a deferred read and is rejected.
+- `:compute-item-key` receives the same stable domain ids that ordinary row
+  keys would use.
+- Scroll position remains host mechanics rather than app-db state.
 
-The virtualizer defaults to Client-only on the server; see
-[SSR and hydration](17-ssr-and-hydration.md). Full `defhost` mechanics are in
-[Interop](09-interop.md). Check focus and keyboard behaviour in a browser:
-rows that do not exist cannot receive keyboard focus.
+The host defaults to Client-only on the server. Test focus and keyboard
+behaviour in a real browser: a row that does not exist cannot hold focus.
+Virtualization also changes find-in-page, select-all, print, and assistive
+technology behaviour.
 
-## Oscillating read sets
+## Avoid large oscillating read sets
 
-A view's subscriptions are the reads its body just made. When control flow
-changes that set, the view re-subscribes the **whole set**, not one key. That
-cost scales with the current read count. A small set that oscillates is
-fine. A large one is not: a parent that reads hundreds of per-row
-subscriptions under a filter that changes membership re-subscribes hundreds
-of reads on every filter keystroke.
+A view's dependency set is exactly the reads made by its latest body. If a
+branch or filter changes membership, the view replaces the complete set.
 
-Fix it structurally. Push per-row reads into row views so each set is small
-and stable, and membership churn only costs rows that enter or leave. Or go
-coarse, where the set is one read that never churns. Xray shows reads per
-view and read-set churn ([Diagnostics](15-diagnostics.md)).
+A parent that reads hundreds of row subscriptions under a filter can therefore
+unsubscribe and resubscribe hundreds of dependencies on each filter
+keystroke. Push reads into row views so each set stays small, or use one coarse
+subscription whose identity does not churn. Xray reports the reads attached to
+each view and their churn.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
-|---|---|---|
-| Console warning names your view, a child head, and an index | `:rf.warning/hicasso-missing-key` | Put `:key` in each member's props map. Reagent `^{:key}` metadata is not read |
-| Row remounts when you edit it; warning names the child | `:rf.warning/hicasso-entity-key` — key is a value React coerces | Key on a stable id: `{:key (:id row)}` |
-| Input state or animation jumps after insert/reorder | Index keys | Key on domain ids |
-| One order changes and every row re-renders | Read lives too high for a sparse workload | Fine reads: rows read their own entity; or accept the coarse sweep knowingly |
-| Page-wide write runs every row body despite the bail-out | Row props are not `=` — fresh closure, JS object, or dead weight in the map | Event vectors as data; persistent values; `select-keys` to what the row shows |
-| Filter typing is heavy on a large list | Large oscillating read set, or a whole-table view-model per keystroke | Rows own their reads, chunk the table, or filter inside the subscription |
-| Plain function or JS component in head position refused | `:rf.error/hicasso-bad-head` | Define views with `h/defview`; declare foreign components with `h/defhost` ([Interop](09-interop.md)) |
-| Virtualized list renders but rows are inert or mis-framed | Row hiccup returned raw from the render callback | Return through `h/as-element`; if the callback itself carries an event vector, use `h/event` |
+| --- | --- | --- |
+| Development warning names a view, child, and index | `:rf.warning/hicasso-missing-key` | Put `:key` in every sequence member's props map; Reagent metadata is not read |
+| Editing a row remounts it and reports an entity key | `:rf.warning/hicasso-entity-key` | Use a stable primitive domain id, not the full row value |
+| Input state or animation jumps after insertion/reorder | Index keys changed row identity | Key rows by domain id |
+| One entity change runs every row body | A sparse workload uses a read placed too high, or row props all changed | Let rows read their own entities, or accept and measure the coarse model |
+| A bulk write runs every body despite equal-props memoization | Props contain a fresh function/JS object or fields that change but are not rendered | Use event vectors and persistent values; select only displayed fields |
+| Filtering is slow | Large oscillating dependency set or whole-table recomputation on each edit | Give rows stable reads, chunk the model, or move filtering into a subscription |
+| A plain function or JS component is rejected as a head | `:rf.error/hicasso-bad-head` | Use `h/defview` for Hicasso views and `h/defhost` for foreign components |
+| Virtualized rows render but interactions use the wrong frame or are inert | Render callback returned raw Hiccup or performed a deferred read | Return the row through `h/as-element`; read values before the callback; use `h/event` for callback-produced events |
 
-## When not to tune a list
+## When not to tune or virtualize
 
-- **Under a few hundred rows with sparse updates** — fine is already right.
-  Tune when a profile names a cost ([Performance](18-performance.md)).
-- **Do not virtualize a list people scan** — find-in-page, select-all, and
-  print only see rows that exist. A virtualized 50-row settings list is worse
-  than a plain one.
-- **Do not pre-chunk without a measured sweep** — the extra layer only pays
-  when the profile shows it.
-- **If typing is slow**, the problem is usually event volume on a controlled
-  field, not list shape —
-  [Controlled inputs](04-controlled-inputs.md) and
-  [Performance](18-performance.md).
+For a few hundred rows with sparse updates, fine reads are normally enough.
+Do not add chunking until a profile shows a comparison sweep worth bounding.
+
+Do not virtualize a collection that users need to search with find-in-page,
+print, select in full, or scan with assistive technology unless the product has
+an explicit replacement for those behaviours. A plain 50-row settings list is
+usually better than a virtualized one.
+
+If typing is slow, first measure the controlled-field event path. The list
+shape may not be the bottleneck.

--- a/docs/design/hicasso/draft-guide/07-routing-and-navigation.md
+++ b/docs/design/hicasso/draft-guide/07-routing-and-navigation.md
@@ -1,17 +1,12 @@
 # Routing and navigation
 
-Views are Hiccup and events are vectors. Navigation should stay the same
-kind of data: the link you render, warm-up before a click, scroll and focus
-after a route change, and an unsaved-changes guard.
+The core routing artefact defines route registration, navigation events, and
+route subscriptions. This page covers the Hicasso view side: route links,
+prefetch, scroll and focus policy, and unsaved-change guards.
 
-The router itself is the core routing artefact (`re-frame.routing`), taught
-under `docs/routing/`. There a route is a registry entry, navigation is an
-event, and the active route is a subscription. This page assumes those three
-moves and covers the Hicasso view side.
+## Register routes and require the view integration
 
-## Setup
-
-Register routes once at boot:
+Register routes once during boot:
 
 ```clojure
 (ns app.routes
@@ -20,12 +15,16 @@ Register routes once at boot:
 
 (rf/reg-route :app/home     {} "/")
 (rf/reg-route :app/articles {} "/articles")
-(rf/reg-route :app/article  {:params [:map [:id :string]]}       "/articles/:id")
-(rf/reg-route :app/profile  {:params [:map [:username :string]]} "/profile/:username")
+(rf/reg-route :app/article
+  {:params [:map [:id :string]]}
+  "/articles/:id")
+(rf/reg-route :app/profile
+  {:params [:map [:username :string]]}
+  "/profile/:username")
 (rf/reg-route :app/inbox    {} "/inbox")
 ```
 
-Views require the integration module:
+Require the Hicasso routing module where links are rendered:
 
 ```clojure
 (ns app.views.articles
@@ -33,200 +32,202 @@ Views require the integration module:
             [re-frame.hicasso.routing :refer [route-link]]))
 ```
 
-## Route links
+## Render an application route link
 
-Spell an in-app link as `route-link`: name the route and its params, not a
-URL. It is a plain function — use it inline in the view that owns the region:
+Call `route-link` as a plain helper. Name a registered route and its params
+rather than constructing a URL:
 
 ```clojure
 (h/defview article-card [{:keys [id]}]
-  (let [{:keys [title author]} (h/sub [:article/summary id])]
+  (let [{:keys [title author]}
+        (h/sub [:article/summary id])]
     [:article.card
-     [:h2 (route-link {:to :app/article :params {:id id}} title)]
-     [:span.byline "by "
+     [:h2
+      (route-link {:to :app/article
+                   :params {:id id}}
+        title)]
+     [:span.byline
+      "by "
       (route-link {:to     :app/profile
                    :params {:username author}
                    :class  "author"}
         author)]]))
 ```
 
-The call returns a real `<a>`, so hover preview, copy-link, and middle-click
-work. The router builds the `:href`. The `:on-click` carries the click
-decision as data under a reserved head (alongside `::h/prevent` from
-[Events as data](03-events-as-data.md)):
+The result is a real anchor. The router builds `:href`, so hover preview,
+copy-link, middle-click, and browser link menus continue to work. The helper
+inlines into its caller; it does not create another Hicasso view or
+subscription.
+
+The generated Hiccup contains a reserved navigation head:
 
 ```clojure
 [:a {:href     "/profile/jane"
      :class    "author"
-     :on-click [::h/navigate {:frame   :rf/default
-                              :payload [:rf.route/url-requested
-                                        {:url    "/profile/jane"
-                                         :to     :app/profile
-                                         :params {:username "jane"}}]
-                              :native? false
-                              :veto    nil}]}
+     :on-click [::h/navigate
+                {:frame   :rf/default
+                 :payload [:rf.route/url-requested
+                           {:url    "/profile/jane"
+                            :to     :app/profile
+                            :params {:username "jane"}}]
+                 :native? false
+                 :veto    nil}]}
  "jane"]
 ```
 
-Two renders of one link are equal under `=`, so a structural test can read
-the click decision off the tree ([Testing](14-testing.md)). Because
-`route-link` is a plain function, not a separate re-rendering view, it
-inlines: no subscription, no extra view cost. A nav bar of thirty links
-costs what thirty anchors cost.
+This form remains comparable with `=` and visible to structural tests. Do not
+write `::h/navigate` yourself; `route-link` owns its shape.
 
-Click behaviour is the router's:
+Click conduct is browser-compatible:
 
-- A plain left-click: `preventDefault`, then the routing event dispatches to
-  the frame captured at render.
-- A modifier or auxiliary click belongs to the browser — new tab, no
-  dispatch.
-- A `:target` or `:download` anchor navigates natively.
+- a plain left-click prevents the browser default and dispatches the routing
+  event to the frame captured during rendering
+- modifier and auxiliary clicks remain browser operations, such as opening a
+  new tab
+- anchors with `:target` or `:download` navigate natively
 
-Do not write `[::h/navigate …]` by hand. `route-link` creates it. The map
-allows only `:frame`, `:payload`, `:native?`, and `:veto`. Any other key
-raises `:rf.error/hicasso-malformed-navigate` at render and names the
-position. A link rendered while the routing artefact is missing raises
-`:rf.error/routing-artefact-missing` naming the `:to` — never a dead anchor.
-Other props pass through to the `<a>`: classes, `:data-*`, ARIA.
+The generated map accepts only `:frame`, `:payload`, `:native?`, and `:veto`.
+Unexpected keys raise `:rf.error/hicasso-malformed-navigate` during rendering.
+If the core routing artefact was not loaded, rendering raises
+`:rf.error/routing-artefact-missing` and names the requested route instead of
+producing a dead anchor. Ordinary classes, data attributes, and ARIA props pass
+through.
 
-### The active link
+## Mark the active link
 
-`route-link` does not compute active state. Compare against a route
-subscription where the nav renders:
+`route-link` does not decide which link is active. Read the current route once
+where the navigation renders and pass the result into an inline helper:
 
 ```clojure
 (h/defview site-nav []
   (let [current (h/sub [:rf.route/id])
         nav     (fn [to label]
-                  (route-link {:to           to
-                               :class        (when (= to current) "is-active")
-                               :aria-current (when (= to current) "page")}
-                    label))]
+                  (route-link
+                   {:to           to
+                    :class        (when (= to current) "is-active")
+                    :aria-current (when (= to current) "page")}
+                   label))]
     [:nav
-     (nav :app/home     "Home")
+     (nav :app/home "Home")
      (nav :app/articles "Articles")]))
 ```
 
-One view, one read, and a local helper — links stay inline. Use
-`:aria-current "page"` for screen readers; style with the class.
+Use `:aria-current "page"` as the semantic state and a class for styling.
 
-### Cancel this link's navigation
+## Veto one link
 
-A link may need to cancel its own navigation — for example, confirm before
-discarding a scratch pane. Pass that as `:on-click` on `route-link`. Allowed
-values: `nil`, `[::h/prevent [:app/event]]`, an `h/event` form, or a plain
+A specific link may replace its navigation with another action, such as asking
+whether to discard a local scratch pane. Pass one of the supported veto forms
+as `:on-click`: `nil`, `[::h/prevent INTENT]`, an `h/event`, or a plain
 function.
 
 ```clojure
-(route-link {:to       :app/inbox
-             :on-click (when draft-open?
-                         [::h/prevent [:composer/confirm-discard]])}
-  "Inbox")
+(route-link
+ {:to       :app/inbox
+  :on-click (when draft-open?
+              [::h/prevent [:composer/confirm-discard]])}
+ "Inbox")
 ```
 
-`[::h/prevent …]` cancels the navigation and dispatches your event instead.
-A bare event vector is refused: the click already produces one routing
-event, and one user action must not yield two. Do not use this veto to guard
-unsaved work across a whole page — that is the dirty-leave guard below,
-which covers every exit, not only decorated links.
+The prevent wrapper cancels navigation and dispatches the inner event. A bare
+event vector is rejected because one click must not produce both an unrelated
+application event and the routing event.
 
-## Warm a destination on intent
+Use the route-level dirty-leave guard for unsaved work that must protect every
+exit. A link veto covers only that link.
 
-A link can start loading its destination data on hover, focus, and touch so
-the click lands on work already in flight:
+## Prefetch on user intent
+
+A route link can warm destination data on hover, focus, or touch:
 
 ```clojure
-(route-link {:to :app/article :params {:id "intro"} :prefetch :intent}
+(route-link {:to       :app/article
+             :params   {:id "intro"}
+             :prefetch :intent}
   "Read more")
 ```
 
-The only accepted value is `:intent`. Omit the key for a passive link. Any
-other value fails at render — a silent wrong mode would look like "warm on
-hover" and be hard to trust. Internally the handlers dispatch
-`[:rf.route/prefetch {:to … :params …}]`, which you can also dispatch from
-any event handler.
+`:intent` is the only accepted value. Omit `:prefetch` for a passive link. Any
+other value fails at render rather than silently choosing a different mode.
+The link dispatches `[:rf.route/prefetch {:to … :params …}]`; application code
+may also dispatch that event directly.
 
-Prefetch is not navigation. Data may start loading, but nothing blocks a
-transition, the URL does not change, and guards, scroll, and `:on-match` do
-not run. Details of resource ownership live in
-[Async resources](08-async-resources.md). Prefetch is a performance hint,
-not authorization. Click through and ordinary resource dedupe reuses the
-warmed work. Never click, and that work stays garbage-collectable. Warming a
-destination whose `:can-enter` would refuse is allowed and means nothing:
-activation still evaluates the guard on a real navigation.
+Prefetch does not navigate. It does not change the URL, run guards, apply
+scroll/focus policy, or block activation. A later click uses ordinary resource
+deduplication to reuse work already in flight. An unused prefetch remains
+eligible for resource garbage collection.
 
-## Scroll
+Prefetch is not authorization. It may warm a destination that `:can-enter`
+later refuses; the real navigation still evaluates its guards.
 
-Scroll policy is route data, not view code. Declare it per route (`:scroll`
-metadata) or per navigation (`:scroll` on the navigate request):
+## Scroll policy
 
-| Policy | Behaviour | Default for |
-|---|---|---|
-| `:top` | Scroll to the top on entry | Forward navigations |
-| `:restore` | Return to where the page was left | Back/Forward |
-| `:preserve` | Leave the viewport alone | Opt-in |
+Scroll behaviour belongs to route or navigation data:
 
-Defaults are right for most pages. Set two cases by hand:
+| Policy | Behaviour | Normal use |
+| --- | --- | --- |
+| `:top` | scroll to the top on entry | forward navigation |
+| `:restore` | restore the saved position | Back/Forward |
+| `:preserve` | leave the viewport unchanged | in-place query or filter changes |
 
-- An in-place query navigation on a list — pagination, a filter chip —
-  usually should hold the viewport:
-  `(rf/dispatch [:rf.route/navigate {:query-merge {:page 2} :scroll :preserve}])`.
-- Restoration needs full page height. Back/Forward onto a page whose list is
-  still loading restores against a short page and lands at the top. Declare
-  the page's data as blocking route `:resources`, or keep previous data on
-  screen, so content is present when restore runs.
+For example, pagination that should keep the current viewport can dispatch:
 
-## Focus after a route change
+```clojure
+(rf/dispatch
+ [:rf.route/navigate
+  {:query-merge {:page 2}
+   :scroll      :preserve}])
+```
 
-A route change repaints the page but moves focus nowhere. A screen-reader
-user who activated "Articles" is still on the link they clicked and hears no
-announcement. The recipe:
+Restoration requires the destination page to have its real height. If
+Back/Forward activates a long page while its list is still absent, restore may
+run against a short document and land at the top. Declare blocking route
+resources or retain previous data until the new page is ready.
 
-1. Key the main region by page identity.
-2. Make the region programmatically focusable.
-3. Focus the region on attach.
+## Move focus after a page change
+
+Changing the route does not automatically move keyboard or screen-reader
+focus. Key the main region by page identity, make it programmatically
+focusable, and focus it after commit:
 
 ```clojure
 (defn- focus-page [node]
-  (when node (.focus node #js {:preventScroll true})))
+  (when node
+    (.focus node #js {:preventScroll true})))
 
 (h/defview app-root []
   (let [route (h/sub [:rf.route/id])]
     [:div.app
      [site-nav]
-     [:main {:key       route        ;; remount when the page changes
-             :tab-index -1           ;; focusable, not in the tab order
-             :ref       focus-page}  ;; refs run after commit
+     [:main {:key       route
+             :tab-index -1
+             :ref       focus-page}
       (case route
         :app/home    [home-page]
         :app/article [article-page]
         [not-found-page])]]))
 ```
 
-`:key route` remounts `<main>` when the page identity changes, so the ref
-runs again and focus lands on the new page. Query-only and fragment-only
-changes keep the same route id — the region does not remount, and a filter
-click does not move focus. `preventScroll` stops the focus call from
-fighting scroll policy: routing owns scroll; this recipe owns focus. If "a
-new page" means more than the route id (article 7 → article 9), widen the
-key: `{:key (str route "|" article-id)}`.
+The key remounts `<main>` when page identity changes, causing the ref to run.
+`:tab-index -1` allows programmatic focus without adding the region to normal
+tab order. `preventScroll` lets the router's scroll policy remain authoritative.
 
-Focus for modals and popovers is a different job —
-[Overlays and focus](12-overlays-and-focus.md).
+Query-only or fragment-only changes keep the same route id and therefore do
+not move focus. If article 7 and article 9 count as separate pages, include the
+route params in the key.
 
-## Unsaved changes (dirty-leave guard)
+Modal and popover focus is owned by the overlays module, not this recipe.
 
-"You have unsaved changes" is ordinary state end to end. The guard is a
-subscription, the blocked attempt is a value, the dialog is a view, and the
-user's choice is an event. There is no blocker hook and no `window.confirm`.
+## Guard unsaved changes
 
-Declare when leaving is safe, and put the guard on the route:
+A dirty-leave guard is ordinary state. Register a subscription that returns a
+strict boolean and attach it to the route:
 
 ```clojure
 (rf/reg-sub :editor/can-leave?
   (fn [db _]
     (= (get-in db [:editor :draft])
-       (get-in db [:editor :saved]))))          ;; true = safe to leave
+       (get-in db [:editor :saved]))))
 
 (rf/reg-route :app/article-editor
   {:params    [:map [:id :string]]
@@ -234,98 +235,97 @@ Declare when leaving is safe, and put the guard on the route:
   "/articles/:id/edit")
 ```
 
-When the guard returns `false`, nothing commits: the URL and state do not
-change, and the attempt parks in `[:rf/pending-navigation]`. Render the
-prompt from that value:
+When the guard returns `false`, the route and URL remain unchanged. The
+attempt is stored in `[:rf/pending-navigation]`, which a view can render:
 
 ```clojure
 (h/defview leave-guard-dialog []
   (when-let [pending (h/sub [:rf/pending-navigation])]
-    [:div.modal {:role "alertdialog" :aria-modal true}
+    [:div.modal {:role "alertdialog"
+                 :aria-modal true}
      [:p "You have unsaved changes. Leave anyway?"]
-     [:button {:on-click [:rf.route/cancel   (:id pending)]} "Stay"]
-     [:button {:on-click [:rf.route/continue (:id pending)]} "Discard and leave"]]))
+     [:button
+      {:on-click [:rf.route/cancel (:id pending)]}
+      "Stay"]
+     [:button
+      {:on-click [:rf.route/continue (:id pending)]}
+      "Discard and leave"]]))
 ```
 
-Mount it once near the root; it renders nothing until an attempt parks.
-`:rf.route/continue` replays the navigation the user asked for —
-destination, `:replace?`, scroll policy. `:rf.route/cancel` drops it. Both
-take the pending id, so a stale click on an already-resolved dialog is a
-safe no-op. In a real app, render the box through the overlay module's modal
-so focus is trapped and restored ([Overlays and focus](12-overlays-and-focus.md)).
-The state shape here does not change.
+Mount the view once near the root. `:rf.route/continue` replays the original
+destination, replace flag, and scroll policy. `:rf.route/cancel` drops the
+attempt. Both include the pending id, so a stale click after resolution is a
+no-op.
 
-"Save and close" must leave without the prompt. Save, then navigate with the
-one-shot bypass:
+A real application should render this state through the modal overlay so focus
+is trapped and restored.
+
+After a successful save, navigate with a one-shot leave bypass:
 
 ```clojure
 (rf/reg-event :editor/save-and-close
   (fn [{:keys [db]} _]
-    {:db (assoc-in db [:editor :saved] (get-in db [:editor :draft]))
-     :fx [[:dispatch [:rf.route/navigate {:to            :app/article
-                                          :params        {:id (get-in db [:editor :id])}
-                                          :bypass-leave? true}]]]}))
+    {:db (assoc-in db
+                   [:editor :saved]
+                   (get-in db [:editor :draft]))
+     :fx [[:dispatch
+           [:rf.route/navigate
+            {:to            :app/article
+             :params        {:id (get-in db [:editor :id])}
+             :bypass-leave? true}]]]}))
 ```
 
-`:bypass-leave?` skips this route's `:can-leave` for this one navigation
-only. The destination's `:can-enter` still runs.
+`:bypass-leave?` skips this route's `:can-leave` once. The destination's
+`:can-enter` still runs.
 
-!!! warning "The browser's exits are not yours"
-    A pending value is a fact inside your app; it cannot stop a tab close, an
-    external link, or a reload. Pair the guard with a `beforeunload` listener
-    that reads the same `:editor/can-leave?` sub — one dirty flag, two exits.
-    The listener recipe is in the routing corpus. Routing does not wrap the
-    browser's own dialog.
+!!! warning "Application routing cannot block browser exits"
+    A route guard cannot stop closing the tab, reloading, or following an
+    external link. Install a `beforeunload` listener that reads the same
+    `:editor/can-leave?` fact. Keep one dirty calculation and expose it to the
+    two exit mechanisms; do not maintain separate flags.
 
-## Deep links, Back and Forward
+## Deep links, Back, and Forward
 
-There is no separate path for "arrived by URL" or "pressed Back". The URL is
-an input. A deep link is the first URL at boot; Back/Forward are history
-inputs. Both run the same match → validate → guard → activate pipeline as a
-link click.
+Initial URLs and browser history inputs use the same match, validation, guard,
+and activation pipeline as route links:
 
-- A deep link onto a route with `:query-defaults` arrives with defaults
-  filled. Views read `(h/sub [:rf.route/query])` and do not special-case
-  first load.
-- Guards run at every entry: navigate, link, address bar, Back/Forward,
-  initial load, SSR. The dirty-leave dialog parks a Back press the same way
-  it parks a link click.
-- Back/Forward restore scroll by default (`:restore`). The focus recipe
-  moves focus because the route id changed; `preventScroll` keeps the two
-  from fighting.
-- Navigation does not cancel in-flight async work. A save still pending when
-  the user leaves keeps an instance status readable from anywhere; cache
-  consequences land regardless of the current page
-  ([Async resources](08-async-resources.md)). The guard protects unsaved
-  local state; supersession protects the reply race.
-- On the server, the same pipeline runs for the request URL; the client
-  hydrates without re-running it ([SSR and hydration](17-ssr-and-hydration.md)).
+- Query defaults apply on a deep link before views read
+  `[:rf.route/query]`.
+- Entry and leave guards run for links, dispatched navigation, address-bar
+  input, Back/Forward, initial load, and SSR.
+- Back/Forward use `:restore` by default. The focus recipe may also run; its
+  `preventScroll` option prevents focus from overriding restoration.
+- Navigation does not automatically cancel unrelated async work. A pending
+  mutation remains readable and its cache effects may land after the user
+  leaves. Route guards protect local state; mutation supersession protects
+  reply races.
+- The server runs the same routing pipeline for the request URL. Hydration
+  adopts that result rather than navigating again.
 
-??? info "Coming from React Router?"
-    There is no `<Link>` component: `route-link` is a plain function that
-    returns an anchor with data on it. There is no `useBlocker` or
-    `usePrompt`: the blocked attempt is app state you render. There is no
-    `router.prefetch()` call: warming is an event. Everything you would
-    reach into router context for is a subscription.
+??? info "For readers coming from React Router"
+    `route-link` is a plain function returning an anchor, not a component with
+    private router context. A blocked transition is app state, not a blocker
+    hook. Prefetch is an event, and router facts are subscriptions.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
-|---|---|---|
-| Rendering a link throws `:rf.error/routing-artefact-missing` | Core routing artefact not loaded | `(:require [re-frame.routing])` at boot, before first render |
-| Link full-page reloads | Hand-written `[:a {:href …}]` bypasses interception | Use `route-link`, or the document-level click listener from the routing corpus |
-| `:rf.error/hicasso-malformed-navigate` at render | Hand-built or edited `::h/navigate` head | Do not write the head; `route-link` creates it |
-| `route-link` refuses your `:on-click` event vector | One click must not yield two semantic events | Wrap it: `[::h/prevent [:app/event]]` |
-| Link with `:prefetch` refuses at render | Only `:intent` is accepted | Remove the key, or spell `:prefetch :intent` |
-| Leaving always blocks; error names the guard | `:can-leave` sub returned a non-boolean | `:rf.error/can-leave-non-boolean`: return strict `true`/`false` |
-| Back lands at the top of a long page | Restore ran before the page had its height | Blocking route `:resources`, or keep previous data on screen |
-| Focus goes nowhere after navigating | Main region not keyed, or not focusable | `:key` by page identity, `:tab-index -1`, focus in the `:ref` |
+| --- | --- | --- |
+| Rendering a route link raises `:rf.error/routing-artefact-missing` | The core routing artefact was not required before rendering | Require `re-frame.routing` during boot |
+| An in-app link performs a full page load | A hand-written anchor bypassed route interception | Use `route-link` or the documented document-level routing listener |
+| Rendering raises `:rf.error/hicasso-malformed-navigate` | Application code created or altered the reserved navigation head | Do not author `::h/navigate`; let `route-link` create it |
+| `route-link` rejects a bare `:on-click` vector | The click would produce two semantic events | Use `[::h/prevent [:app/event]]`, `h/event`, or a plain function according to the intended veto |
+| `:prefetch` is rejected | The value is not `:intent` | Remove the key or use `:prefetch :intent` |
+| Every attempt to leave is rejected and the guard is named | `:rf.error/can-leave-non-boolean` | Return strict `true` or `false` from the guard subscription |
+| Back/Forward restores to the top | Scroll restoration ran before content restored page height | Block activation on required resources or keep previous content visible |
+| Focus stays on the old navigation link | Main region was not keyed/focusable or its ref did not run | Key by page identity, add `:tab-index -1`, and focus from the callback ref |
+| A tab close ignores the dirty guard | Browser exits are outside application routing | Add `beforeunload` using the same can-leave state |
 
-## When not to use this module
+## When not to use the routing integration
 
 | Situation | Prefer |
-|---|---|
-| Single-screen app, no shareable URLs | No routing artefact |
-| In-memory UI steps that should not touch the URL — wizard panes, non-linkable tabs | app-db state, or a machine |
-| External links | A plain `[:a {:href …}]` — `route-link` is for the route table |
-| Guarding one button, not a page's exits | The veto roster on that link, or ordinary app logic |
+| --- | --- |
+| A single-screen application with no shareable URL state | No routing artefact |
+| Wizard steps or temporary tabs that should not change the URL | app-db state or a state machine |
+| External destinations | A plain anchor |
+| Guarding one control rather than every page exit | A link veto or ordinary application event logic |

--- a/docs/design/hicasso/draft-guide/08-async-resources.md
+++ b/docs/design/hicasso/draft-guide/08-async-resources.md
@@ -1,210 +1,210 @@
 # Async resources
 
-Async replies arrive late, out of order, and for screens that no longer
-exist. The transport is the core resource model (`re-frame.resources`):
-registered reads, causes, status maps you can subscribe to, and mutations
-that invalidate by tag. That corpus teaches the model. This page owns the
-Hicasso patterns on top — starting with the race that overwrites draft
-edits — then per-instance mutation status, cancellation, and demand-driven
-committed reads.
+The core resources model owns registered reads, cache identity, causes,
+mutation status, invalidation, and managed transport. Hicasso views consume
+those facts with `h/sub`. This page covers the view-facing race patterns:
+merging a late reply into a newer draft, per-instance mutation state,
+optimistic updates, cancellation, and demand tied to committed reads.
 
-In a Hicasso view, read a resource with the same `h/sub` as any subscription.
+## Merge a settled reply into the current draft
 
-## A late reply must not overwrite newer edits
+A save reply may be current for the request while the user has already changed
+the draft. Writing the complete server value over the draft deletes those new
+edits. Dropping the reply loses accepted normalization.
 
-The user saves a profile. The server normalizes fields and replies 800 ms
-later. During those 800 ms the user kept typing. If you write the reply over
-the draft, you delete the newest edits. If you drop the reply, you lose the
-normalization. The fix is a **correlation recipe**: capture a basis when
-work starts, compare when the result lands, and let newer facts win their
-slots. For drafts, that recipe is a **settle-merge**.
+Two mechanisms solve different races:
 
-Two protections do different jobs:
+- **Supersession** is enforced by the runtime. A reply from an older attempt
+  under the same instance is suppressed and never reaches the continuation.
+- **Settle-merge** is application policy. A current reply is compared with the
+  params that were sent, field by field, so newer draft values win their own
+  slots.
 
-- **Supersession** is the runtime's job. When a reply loses the race with a
-  *newer attempt* under the same instance, the runtime suppresses that reply.
-  It never reaches you.
-- **Settle-merge** is your job. A reply that reaches you is current, but the
-  *draft* may have changed after you sent it. Merge the reply into the draft;
-  do not overwrite the draft.
-
-Registration is ordinary. The submit handler starts the write with the draft
-as params and a continuation:
+Register and execute the mutation normally:
 
 ```clojure
 (ns app.profile
   (:require [re-frame.core :as rf]
-            [re-frame.resources]          ;; resource/mutation model
-            [re-frame.http.managed]))     ;; HTTP transport
+            [re-frame.resources]
+            [re-frame.http.managed]))
 
 (rf/reg-mutation :profile/save
-  {:params-schema [:map [:username :string] [:bio :string] [:email :string]]
+  {:params-schema [:map
+                   [:username :string]
+                   [:bio :string]
+                   [:email :string]]
    :scope         :rf.scope/global
-   :invalidates   (fn [{:keys [username]} _result] #{[:profile username]})}
+   :invalidates   (fn [{:keys [username]} _result]
+                    #{[:profile username]})}
   (fn [profile _ctx]
-    {:request {:method :put :url "/api/profile" :body {:profile profile}}
+    {:request {:method :put
+               :url    "/api/profile"
+               :body   {:profile profile}}
      :decode  :json}))
 
-;; from your submit handler; draft = the current [:profile :draft]
-[:rf.mutation/execute {:mutation :profile/save
-                       :params   draft
-                       :instance [:profile-save]
-                       :reply-to [:profile/save-settled]}]
+[:rf.mutation/execute
+ {:mutation :profile/save
+  :params   draft
+  :instance [:profile-save]
+  :reply-to [:profile/save-settled]}]
 ```
 
-The recipe lives in the continuation. The uniform reply carries the decoded
-`:value` *and* the accepted `:params` — the basis you sent, so you do not
-carry it by hand:
+The uniform reply includes the accepted `:params`, so the continuation has the
+basis used by the request:
 
 ```clojure
-;; Field by field: settled value lands only where the draft still matches
-;; what was sent; a newer edit keeps its field.
 (rf/reg-event :profile/save-settled
   (fn [{:keys [db]} [_ {:keys [status value params error]}]]
     (if (= :ok status)
       {:db (-> db
-               (assoc-in [:profile :saved] (:profile value))
-               (update-in [:profile :draft]
-                          (fn [draft]
-                            (reduce-kv (fn [d field sent]
-                                         (if (= (get d field) sent)
-                                           (assoc d field (get-in value [:profile field]))
-                                           d))
-                                       draft
-                                       params))))}
+               (assoc-in [:profile :saved]
+                         (:profile value))
+               (update-in
+                [:profile :draft]
+                (fn [draft]
+                  (reduce-kv
+                   (fn [d field sent]
+                     (if (= (get d field) sent)
+                       (assoc d field
+                              (get-in value [:profile field]))
+                       d))
+                   draft
+                   params))))}
       {:db (assoc-in db [:profile :save-error] error)})))
 ```
 
-A field that did not change after the send takes the settled value; a field
-that changed keeps the newer edit. `:reply-to` fires only for a reply the
-runtime accepts as current — never for a stale or superseded reply, and only
-after cache consequences and instance settlement. The comparison left for
-you is current draft against sent params.
+A field that still equals the sent value accepts the server result. A field
+that changed after the request keeps the new draft value. `:reply-to` runs only
+after the runtime has accepted the reply as current, applied cache
+consequences, and settled the mutation instance.
 
-The same shape answers other "late result versus newer truth" cases. In a
-debounce, a generation number is the basis. In optimistic rollback, the
-runtime captures the basis for you. Validation display for drafts — touched
-fields and submit gating — is the forms module's job ([Forms](05-forms.md)).
+The same correlation shape appears elsewhere: a debounce compares a generation
+number, and optimistic rollback compares a captured cache basis. The forms
+module owns touched-field display and submit gating; settle-merge only protects
+the draft/server race.
 
-## Per-instance mutation status
+## Track writes per instance
 
-A feed has many favorite buttons. "Is my save in flight?" is a per-button
-fact. Status is keyed by an instance id you choose. Key the instance per
-row, and each button watches its own write:
+A screen may have many independent writes of the same mutation. Choose an
+instance id that matches the unit whose status the UI should display:
 
 ```clojure
 (h/defview favorite-button [{:keys [slug favorited?]}]
-  (let [save (h/sub [:rf/mutation {:instance [:favorite slug]}])]
-    [:button {:class    (when favorited? "active")
-              :disabled (:pending? save)
-              :on-click [:rf.mutation/execute
-                         {:mutation :article/favorite
-                          :params   {:slug slug}
-                          :instance [:favorite slug]
-                          :cause    [:click :article/favorite]}]}
+  (let [save (h/sub [:rf/mutation
+                     {:instance [:favorite slug]}])]
+    [:button
+     {:class    (when favorited? "active")
+      :disabled (:pending? save)
+      :on-click [:rf.mutation/execute
+                 {:mutation :article/favorite
+                  :params   {:slug slug}
+                  :instance [:favorite slug]
+                  :cause    [:click :article/favorite]}]}
      (if favorited? "Favorited" "Favorite")]))
 ```
 
-The click is one literal event vector — mutation, params, instance, and
-cause, all data. A structural test can assert the whole write with `=`. The
-instance sub yields `:pending?`, `:success?`, `:error?`, `:settled?`,
-`:optimistic?`, `:result`, and `:error`. Focused projections such as
-`[:rf.mutation/pending? {…}]` exist when a button needs one boolean.
+The event vector contains the mutation, params, instance, and cause as data.
+The instance subscription provides `:pending?`, `:success?`, `:error?`,
+`:settled?`, `:optimistic?`, `:result`, and `:error`. Focused subscriptions
+such as `[:rf.mutation/pending? {:instance …}]` are available when a view needs
+one projection.
 
-Two instance rules matter. **Different instances never overwrite each
-other** — two rows save concurrently with independent status. **The same
-instance supersedes** — re-execute while pending and the runtime suppresses
-the earlier attempt's reply. A settled `:error` stays until you retry with
-the same execute, or dismiss it with
-`[:rf.mutation/clear {:instance …}]` (which also best-effort aborts in-flight
-work).
+Different instance ids settle independently. Re-executing the same instance
+supersedes its previous pending attempt, so the older reply cannot update the
+cache or invoke its continuation. A settled error remains until another
+execute replaces it or `[:rf.mutation/clear {:instance …}]` dismisses it. Clear
+also requests a best-effort abort if work is still in flight.
 
-### Optimistic flip, automatic rollback
+Instance identity is therefore policy. `[:favorite slug]` allows rows to write
+concurrently; `[:favorite]` makes every row compete for one status and
+supersession lane.
 
-A favorite toggle should not wait hundreds of milliseconds. Declare the
-optimistic plan on the registration. The runtime flips the cache before the
-request, then commits, rolls back, or reconciles at settle time:
+## Optimistic updates and rollback
+
+Declare an optimistic patch on the mutation registration. The runtime snapshots
+the current entries, applies the patch before the request, and settles that
+snapshot on success, error, or cancellation:
 
 ```clojure
 (rf/reg-mutation :article/favorite
-  {:params-schema   [:map [:slug :string]]
-   :scope           :rf.scope/global
-   :optimistic-tags (fn [{:keys [slug]}]
-                      [{:scope :rf.scope/global
-                        :tags  #{[:article slug]}
-                        :patch (fn [old] (update-in old [:article :favorited] not))}])
-   :invalidates     (fn [{:keys [slug]} _result] #{[:article slug] [:article-list]})}
+  {:params-schema [:map [:slug :string]]
+   :scope         :rf.scope/global
+   :optimistic-tags
+   (fn [{:keys [slug]}]
+     [{:scope :rf.scope/global
+       :tags  #{[:article slug]}
+       :patch (fn [old]
+                (update-in old [:article :favorited] not))}])
+   :invalidates
+   (fn [{:keys [slug]} _result]
+     #{[:article slug] [:article-list]})}
   (fn [{:keys [slug]} _ctx]
-    {:request {:method :post :url (str "/api/articles/" slug "/favorite")}
+    {:request {:method :post
+               :url (str "/api/articles/" slug "/favorite")}
      :decode  :json}))
 ```
 
-You never write the rollback. The runtime snapshots each entry before the
-forward patch. On `:error` or cancellation it restores that snapshot — so an
-inverse patch cannot drift. On success, the authoritative reply overwrites
-the guess. If a concurrent write lands between flip and settle, the default
-`:on-conflict :invalidate` does not restore the snapshot over newer truth: it
-marks the entry stale and lets a refetch settle it. While the flip is
-unconfirmed, the instance carries `:optimistic? true`.
+On error or cancellation, the runtime restores the captured snapshot rather
+than asking application code to calculate an inverse patch. On success, the
+authoritative reply replaces the optimistic guess.
 
-## Cancellation and supersession
+If another write changes the entry between the optimistic patch and settlement,
+the default `:on-conflict :invalidate` avoids restoring an old snapshot over
+newer data. It marks the entry stale so a refetch can resolve the conflict.
+`:on-conflict :force` should be used only when overwriting concurrent truth is
+explicitly intended. The instance reports `:optimistic? true` until the guess
+is settled.
 
-Nothing cancels implicitly, and you do not hand-code the race:
+## Cancellation and supersession ownership
 
-| Concern | Owner | What happens |
-|---|---|---|
-| Reply beaten by a newer attempt, same instance | Runtime | Suppressed; its `:reply-to` never fires |
-| Reply beaten by a newer fetch, same resource identity | Runtime | New generation supersedes; stale reply never touches the cache |
-| Dismiss a settled error, abandon a write | You | `[:rf.mutation/clear {:instance …}]` — clears status, best-effort abort |
-| Stop a read you no longer want | You | Withdraw the read — demand releases (below); in-flight work aborts best-effort |
-| What "newer" means | You | Identity is the policy: instance and params decide which attempts race |
+| Concern | Owner | Result |
+| --- | --- | --- |
+| An older write reply loses to a newer attempt under the same instance | Runtime | Older reply is suppressed; its continuation never runs |
+| An older resource fetch loses to a newer generation of the same identity | Runtime | Stale reply cannot update the cache |
+| A user dismisses an error or abandons a write | Application | Dispatch mutation clear; status clears and in-flight work is aborted best-effort |
+| A view no longer needs a resource | Application state plus committed-read demand | Remove the read; ownership releases and transport aborts best-effort |
+| Which attempts compete | Application identity design | Instance id and resource params define the race |
 
-When you choose `[:favorite slug]` over `[:favorite]` as the instance, you
-choose what supersedes what. The runtime enforces the race you declared.
+No screen unmount automatically cancels every write. A mutation may remain
+meaningful after navigation. Express cancellation through the domain state or
+explicit clear event that owns it.
 
-## Demand-driven committed reads
+## Tie resource demand to a committed read
 
-The patterns above leave one correlation hand-written: the lifetime of a
-resource versus the view that reads it. Route `:resources` owns page data,
-and that is correct for page identity. Some resources are keyed by view-local
-state — typeahead suggestions, picker options, a hover preview. Those belong
-to no route. The hand-written answer is ceremony: ensure on mount, release
-on unmount, re-ensure on parameter change — each step a chance for a leak.
-
-Hicasso closes that with the committed read. A resource read may declare
-demand:
+Route `:resources` should own data required by page identity. Some reads instead
+exist only while a local view is committed: typeahead suggestions, picker
+options, or a hover preview. Add `:demand true` to that resource subscription:
 
 ```clojure
-(h/sub [:rf/resource {:resource :app/suggestions
-                      :params   {:q q}
-                      :demand   true}])
+(h/sub
+ [:rf/resource
+  {:resource :app/suggestions
+   :params   {:q q}
+   :demand   true}])
 ```
 
-Rules:
+Demand follows these rules:
 
-- **Commit acquires.** When a render that took this read commits, the read
-  owns demand for that resource and params. The ensure runs after commit. A
-  render alone acquires nothing. An abandoned render, a StrictMode
-  double-invoke, and a retry each acquire zero times.
-- **Liveness releases.** Demand releases on unmount, on parameter change
-  (old identity releases as the new acquires), and when a committed render
-  stops taking the read (for example a conditional becomes false). Reads in
-  branches are legal, so that last case is ordinary.
-- **Demand is not retention.** Release withdraws the ownership hold. The
-  cached entry then lives out its ordinary lifetime (`:gc-after-ms`). Moving
-  between two queries can rejoin warm entries instead of refetching.
-- **Nothing else is inferred.** Debounce, supersession, refresh-with-data,
-  and cancellation stay where this page already put them. Demand decides
-  *that* the resource is wanted while the read is live, not *how* it behaves.
-- **It costs nothing elsewhere.** Demand uses committed-read membership the
-  runtime already keeps. A view that reads no resource carries none of this.
+- **Only commit acquires.** A render that is abandoned, retried, or probed by
+  StrictMode acquires nothing. The ensure begins after the render commits.
+- **Committed liveness releases.** Unmount, parameter change, or a committed
+  branch that stops taking the read releases the old identity.
+- **Release is not immediate cache deletion.** The ownership hold ends, then
+  the entry follows its normal `:gc-after-ms` policy. A later view may rejoin a
+  warm entry.
+- **Demand does not choose every policy.** Debounce, staleness, refresh with
+  previous data, supersession, and transport cancellation remain explicit in
+  their own layers.
+- **Passive reads remain passive.** Without `:demand true`, the subscription
+  projects the cache and does not cause work. If no route, prefetch, ensure, or
+  demand exists, `:idle` is honest and permanent.
 
-Without `:demand true`, the sub is the core passive projection and never
-causes work. A missing cause still means an honest, permanent `:idle`.
+The runtime already tracks committed read membership, so views without resource
+demand pay none of this work.
 
-### Typeahead end to end
+## Typeahead example
 
-This example exercises the policies together.
+Register the resource with cache policies:
 
 ```clojure
 (rf/reg-resource :app/suggestions
@@ -213,18 +213,24 @@ This example exercises the policies together.
    :stale-after-ms 30000
    :gc-after-ms    60000}
   (fn [{:keys [q]} _ctx]
-    {:request {:method :get :url "/api/suggest" :params {:q q}}
+    {:request {:method :get
+               :url    "/api/suggest"
+               :params {:q q}}
      :decode  :json}))
 ```
 
-Debounce is explicit policy at the event layer. The input echoes every
-keystroke (controlled write stays synchronous). Debounce the *consumers* of
-a value, never the write ([Controlled inputs](04-controlled-inputs.md)). A
-generation guards the committed query so a stale timer commits nothing:
+Keep each controlled keystroke synchronous and debounce only the committed
+query consumed by the resource. A generation prevents an old timer from
+committing:
 
 ```clojure
-(rf/reg-sub :search/text        (fn [db _] (get-in db [:search :text] "")))
-(rf/reg-sub :search/committed-q (fn [db _] (get-in db [:search :committed-q] "")))
+(rf/reg-sub :search/text
+  (fn [db _]
+    (get-in db [:search :text] "")))
+
+(rf/reg-sub :search/committed-q
+  (fn [db _]
+    (get-in db [:search :committed-q] "")))
 
 (rf/reg-event :search/input
   (fn [{:keys [db]} [_ text]]
@@ -232,36 +238,45 @@ generation guards the committed query so a stale timer commits nothing:
       {:db (-> db
                (assoc-in [:search :text] text)
                (assoc-in [:search :gen] gen))
-       :fx [[:dispatch-later {:ms 250 :event [:search/settle gen]}]]})))
+       :fx [[:dispatch-later
+             {:ms 250
+              :event [:search/settle gen]}]]})))
 
 (rf/reg-event :search/settle
   (fn [{:keys [db]} [_ gen]]
     (if (= gen (get-in db [:search :gen]))
-      {:db (assoc-in db [:search :committed-q] (get-in db [:search :text]))}
+      {:db (assoc-in db
+                     [:search :committed-q]
+                     (get-in db [:search :text]))}
       {})))
 
 (rf/reg-event :search/clear
   (fn [{:keys [db]} _]
     {:db (update db :search assoc
-                 :text "" :committed-q ""
-                 :gen  (inc (get-in db [:search :gen] 0)))}))
+                 :text ""
+                 :committed-q ""
+                 :gen (inc (get-in db [:search :gen] 0)))}))
 ```
 
-The list exists only while a committed query exists, and its committed read
-declares demand:
+The result view declares demand and retains previous data during a parameter
+change:
 
 ```clojure
 (h/defview suggestion-list [{:keys [q]}]
   (let [{:keys [data loading? fetching?]}
-        (h/sub [:rf/resource {:resource       :app/suggestions
-                              :params         {:q q}
-                              :demand         true
-                              :keep-previous? true}])]
-    [:ul.suggestions {:aria-busy (boolean (or loading? fetching?))}
+        (h/sub
+         [:rf/resource
+          {:resource       :app/suggestions
+           :params         {:q q}
+           :demand         true
+           :keep-previous? true}])]
+    [:ul.suggestions
+     {:aria-busy (boolean (or loading? fetching?))}
      (if (and loading? (not data))
        [:li.hint "Searching…"]
        (for [s (:suggestions data)]
-         [:li {:key (:id s)} (:label s)]))]))
+         [:li {:key (:id s)}
+          (:label s)]))]))
 
 (h/defview search-box []
   (let [text (h/sub [:search/text])
@@ -276,72 +291,58 @@ declares demand:
        [suggestion-list {:q q}])]))
 ```
 
-Timeline:
+The lifecycle is observable:
 
-1. **`c` … `cl`** — each keystroke echoes through the controlled input. The
-   generation increments. Nothing fetches. Debounce is event-layer policy.
-2. **250 ms of quiet** — the surviving timer's generation matches;
-   `:committed-q` becomes `"cl"`. `suggestion-list` mounts and the render
-   commits. The committed read acquires demand for `{:q "cl"}` and the fetch
-   begins. If React had discarded that render, nothing would have been
-   acquired.
-3. **`clo` before the reply lands** — parameters change. `{:q "cl"}`
-   releases; `{:q "clo"}` acquires. The in-flight request for `{:q "cl"}`
-   aborts best-effort. If its reply arrives anyway, the runtime's stale-reply
-   check suppresses it. With `:keep-previous? true`, the `"cl"` list stays on
-   screen with `:fetching?` true (refresh-with-data, not a flash of empty).
-4. **Escape or navigate away mid-fetch** — `:search/clear` empties the
-   committed query. The list unmounts; demand releases. Cancellation was a
-   state change you wrote, not a lifecycle hook.
-5. **Typing `cl` again soon** — release made the entry demand-free; it did
-   not destroy it. Within `:gc-after-ms`, the read rejoins the warm entry. If
-   still fresh within `:stale-after-ms`, no request occurs.
+1. Keystrokes update `:search/text` immediately. Each one increments the
+   generation; no fetch starts yet.
+2. After 250 ms of quiet, only the current generation commits `q`. The list
+   mounts, its render commits, and demand starts the fetch. A discarded render
+   would have acquired nothing.
+3. A new committed query releases the old identity and acquires the new one.
+   The old transport aborts best-effort, and any late reply is suppressed by
+   generation checks. `:keep-previous? true` keeps previous results visible
+   while `:fetching?` reports the refresh.
+4. Escape or navigation removes the read. Demand releases without a lifecycle
+   hook written by the view.
+5. Repeating a query before its `:gc-after-ms` expiry rejoins the cached entry.
+   If it is still fresh under `:stale-after-ms`, no request is made.
 
-There is no ensure-on-mount effect, release-on-unmount cleanup, or
-params-change watcher. The correlation between read liveness and resource
-demand has one owner — the read.
-
-Under Xray, held demand is a bounded projection: which resources are owned
-by which committed reads, and why each fetch fired
-([Diagnostics](15-diagnostics.md)). On the server, the view is Client-only by
-default — a deterministic fallback and zero acquisition, because acquisition
-is a client commit fact. Hydration then adopts without a duplicate fetch
-([SSR and hydration](17-ssr-and-hydration.md)).
+Xray can show which committed read holds demand and which cause started a
+fetch. On the server, a Client-only view performs no commit and therefore
+acquires no demand; hydration acquires on the client without treating the
+server render as a cause.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
-|---|---|---|
-| Permanent `:idle` skeleton | Nothing declares demand or any other cause | `:demand true` on the committed read — or a route `:resources` entry / explicit ensure where the route owns the data |
-| `:rf.error/resources-artefact-missing` at boot | Resource model not loaded | `(:require [re-frame.resources])`, usually with `re-frame.http.managed` |
-| Suggestions flash empty on every keystroke | Each params value is a new cache identity | `:keep-previous? true` on the read; render `:fetching?` as the quiet indicator |
-| Results for an old query overwrite new ones | Hand-rolled fetch outside the resource model | Let the runtime own replies — identity plus generation suppress stale ones |
-| Read throws after the render, naming the query | Read escaped the direct synchronous body — callback, promise, timer, lazy seq | Read during the body and close over the value ([Views and reads](02-views-and-reads.md)) |
-| Every row's button goes pending together | One shared instance id | Key the instance per row: `[:favorite slug]` |
-| Keystrokes vanish when a save reply lands | Reply written wholesale over the draft | Settle-merge: take settled values only where the draft still equals the sent basis |
-| Optimistic value reverts over a newer concurrent write | `:on-conflict :force` restores the snapshot blindly | Keep the default `:invalidate` — stale-mark and refetch |
+| --- | --- | --- |
+| A resource remains permanently `:idle` | No route resource, prefetch, explicit ensure, or demanded committed read owns it | Add `:demand true` where the view owns the lifetime, or choose the appropriate external cause |
+| Boot raises `:rf.error/resources-artefact-missing` | The resources model was not loaded | Require `re-frame.resources`, normally with `re-frame.http.managed` |
+| Typeahead flashes empty on every new query | Each params value is a different cache identity and previous data is hidden | Set `:keep-previous? true` and use `:fetching?` for the quiet refresh state |
+| Old query results replace new ones | Fetching was implemented outside the resource identity/generation model | Register the resource and let the runtime suppress stale replies |
+| A resource read throws after render | `h/sub` escaped into a callback, promise, timer, or deferred sequence | Read during the synchronous body and retain the resulting status/data value |
+| Every row button becomes pending together | All writes use one instance id | Include row identity, such as `[:favorite slug]` |
+| A save reply erases keystrokes entered after submission | The continuation overwrote the complete draft | Settle-merge against the accepted `:params`; preserve fields that no longer equal the sent basis |
+| Optimistic rollback overwrites a concurrent update | Conflict policy forces the old snapshot | Use the default `:on-conflict :invalidate` unless forced rollback is an explicit business rule |
+| A cleared/unmounted view still receives a meaningful mutation reply | Mutations are not implicitly cancelled by view lifetime | Choose an instance and explicit cancellation/clear policy; do not treat unmount as ownership unless the domain says so |
 
-## When not to use demand
+## When not to use demanded reads
 
-Demand-driven reads own **resource lifetimes that match a read's lifetime**.
-They are not a general fetch library:
+| Job | Better owner |
+| --- | --- |
+| Data required by the current URL | Route `:resources`, including SSR and transition blocking |
+| Warming data before any view needs it | Route-link `:prefetch :intent` or an explicit ensure |
+| Manual refresh | `[:rf.resource/refetch …]` event |
+| One-off uncached request | Managed HTTP |
+| Drafts, field validation, and submit gating | Forms module |
+| Multi-stage workflow | A state machine that owns resource causes and transitions |
 
-| Job | Owner |
-|---|---|
-| Page-identity data — the article this URL names | Route `:resources`: the route owns it, blocks the transition honestly, and runs under SSR |
-| Warming data no read wants yet | Routing's `:prefetch :intent`, or an explicit ownerless ensure ([Routing and navigation](07-routing-and-navigation.md)) |
-| "Refetch on click" | `[:rf.resource/refetch …]` — an event, because that is a cause, not a lifetime |
-| A one-off uncached call | Managed HTTP: request out, uniform reply in |
-| Draft state, validation gating, submit flow | The forms module ([Forms](05-forms.md)) |
-| Multi-step async workflow with named stages | A machine owning the ensures, with resource status driving transitions |
+Demand expresses a lifetime only when a committed view read is the owner. It
+cannot represent data that no view currently reads.
 
-If no view reads the resource, demand cannot express it. A demand with no
-reader is exactly the hand-written correlation this feature removes.
-
-??? info "Coming from TanStack Query?"
-    `useQuery` is close: read it and it fetches; unmount and it forgets.
-    Three differences matter. Acquisition happens at commit, so speculative
-    renders fetch nothing. Policies are not call-site options: debounce lives
-    in your events, staleness and GC on the registration, supersession in the
-    runtime's identity rules. The cache is causal: writes invalidate by
-    declared tags, not by a remembered `invalidateQueries`.
+??? info "For readers coming from TanStack Query"
+    The closest analogy is a query acquired by a mounted reader. Hicasso
+    acquires at commit rather than speculative render. Debounce remains event
+    policy, staleness and GC stay on the registration, and supersession follows
+    explicit identities. Mutations invalidate declared causal tags rather than
+    depending on a later call-site `invalidateQueries`.

--- a/docs/design/hicasso/draft-guide/09-interop.md
+++ b/docs/design/hicasso/draft-guide/09-interop.md
@@ -1,7 +1,7 @@
 # Interop
 
-You want a date picker from npm, not a hand-written calendar. Declare the
-component once, then use it anywhere a view is legal:
+Use `h/defhost` to give a foreign React component a named, testable boundary
+with explicit callback, slot, and server contracts.
 
 ```clojure
 (ns app.hosts.date-picker
@@ -18,48 +18,51 @@ component once, then use it anywhere a view is legal:
             [app.hosts.date-picker :refer [date-picker]]))
 
 (h/defview due-field [_]
-  [date-picker {:selected  (h/sub [:task/due-date])
-                ;; value-first onChange(date): h/event sees the library's arguments
-                :on-change (h/event [date & _] [:task/set-due date])}])
+  [date-picker
+   {:selected  (h/sub [:task/due-date])
+    :on-change (h/event [date & _]
+                 [:task/set-due date])}])
 ```
 
-Children cross as ordinary hiccup. `h/defhost` is the declared door to
-foreign React. The rest of this page is that door's contract.
+The declaration keeps npm requires in a `.cljs` host namespace, gives tools a
+stable component identity, and records how values cross. Children remain
+Hiccup.
 
-Why declare at all? A raw JS component in the tree breaks three things:
+A raw component value in a tree would otherwise create three avoidable
+problems: a JS require can make a shared `.cljc` namespace unloadable on the
+JVM, structural tests encounter an opaque object, and tools cannot name the
+crossing.
 
-- A JS require in a shared namespace stops JVM loading and headless tests.
-- The node holds an opaque JS object, so `=` tests stop working there.
-- Tools get a bare value where they wanted an identity.
+## Crossing rules
 
-`h/defhost` keeps the require in one `.cljs` host namespace. The rest of the
-tree stays data.
+Declare a host at namespace top level, never during rendering.
 
-## What crosses, and how
+| Value at the crossing | Behaviour |
+| --- | --- |
+| Top-level prop names | converted to canonical React slots: `:on-change` → `onChange`, `:class` → `className`; `data-*` and `aria-*` remain hyphenated |
+| Prop values | pass by identity; nested maps and collections are not deeply converted |
+| HTML-like attribute slots | class/id/role/data/ARIA values use native-attribute coercion; Hicasso class collections are joined |
+| Children | Hiccup is converted where it was authored |
+| Declared callbacks | use the callback contract below |
+| Declared slots | Hiccup becomes React elements under the captured frame |
+| Server | Client-only unless the declaration says `:server :render` |
 
-Declare at top level, never during render. With no options:
+When a library expects a JavaScript options object, camelCase nested keys, or a
+string instead of a keyword, provide that value explicitly with `#js`,
+`clj->js`, a string, or `(name value)`. Hicasso does not guess a library's
+data model.
 
-| At the crossing | Behaviour |
-|---|---|
-| Top-level prop names | Canonical React slot names — `:on-change` → `onChange`, `:class` → `className`; `data-*` and `aria-*` stay hyphenated |
-| Prop values | Cross by identity — a keyword stays a keyword, a map stays a CLJS map. **No deep conversion**: nested option maps are not camelCased, collections are not translated. When the library wants a JS options object, a camelCase map, or a string, hand it that yourself — `#js {…}`, `clj->js`, `"compact"`, `(name :compact)` |
-| HTML-attribute slots | `:class`, `:id`, `:role`, `data-*`, `aria-*` stringify. `:class` gets the same coercion as a native tag: `["btn" nil :on]` joins to `"btn on"` |
-| Children | Hiccup, lowered where you wrote them |
-| Declared callbacks | The `:callbacks` contract below |
-| Declared slots | ReactNode positions — hiccup becomes elements there under the captured frame |
-| Server | Client-only, unless the declaration says `:server :render` |
+The declaration accepts `:callbacks`, `:slots`, `:server`, and `:fallback`.
+`:rf.error/hicasso-host-unknown-option` reports an unknown option. Declaration
+also fails for malformed callback contracts, contracts on `:key` or `:ref`,
+duplicate prop spellings that normalize to one slot, or a component that
+resolved to `nil` — often a mistaken `:default` import. These errors point to
+the declaration rather than a later mount.
 
-Options: `:callbacks`, `:slots`, `:server`, and `:fallback`. An unknown
-option raises `:rf.error/hicasso-host-unknown-option` at declaration. These
-also fail at declaration: a bad contract, a contract on `:key` or `:ref`,
-duplicate prop spellings, and a component that resolved to `nil` (usually a
-`:default` import from a library with no default export). Failures point at
-your declaration line.
+## Callback contracts
 
-## Callbacks: `:event`, `:handler`, `:render`
-
-A declared slot carries a contract. The contract is never inferred from an
-`on*` name:
+Declare each callback as `:event`, `:handler`, or `:render`. Hicasso never
+infers a contract from an `on*` name.
 
 ```clojure
 (h/defhost picker Widget
@@ -68,288 +71,270 @@ A declared slot carries a contract. The contract is never inferred from an
                :on-render-row :render}})
 ```
 
-**`:event`** — works like a native `:on-*`. Write an event vector, or
-`h/event` when you need the library's arguments. Foreign invokers pass
-*their* arguments — `onPick(value, event)`, `onChange(date)` — and every
-argument reaches the `h/event` body in library order.
+### `:event`
 
-**`:handler`** — the function crosses by identity, with no wrapper. The
-library gets exactly the function you wrote; your return value goes back to
-that caller. Use this for imperative APIs such as `open()` and `scrollTo()`.
-
-**`:render`** — the library calls you *during its own render* (`renderRow`,
-`renderItem`). The body must be pure, and it returns hiccup only through
-`h/as-element`:
+An event callback accepts an intent vector or `h/event`. The foreign component
+passes its own arguments in its documented order. Use `h/event` for a
+value-first callback such as `onChange(date)`:
 
 ```clojure
-;; ids came from (h/sub [:feed/ids]) earlier in the body
+(h/event [date _event]
+  [:task/set-due date])
+```
+
+A bare intent with no marker is valid even when no DOM event exists because it
+does not inspect callback arguments. A marker-bearing intent remains
+event-first; if argument one is not a DOM event, Hicasso raises
+`:rf.error/hicasso-intent-needs-the-event` and points to `h/event`.
+
+### `:handler`
+
+A handler function passes through by identity. The foreign component receives
+the exact function and receives its return value. Use this contract for
+imperative callback APIs such as `open`, `scrollTo`, or a predicate.
+
+### `:render`
+
+A render callback runs during the foreign component's React render. It must be
+pure and must return a React element, not raw Hiccup:
+
+```clojure
 [virtual-list
  {:item-count (count ids)
   :render-row (h/event [i]
                 (h/as-element
-                  [:li.row {:on-click [:feed/open (nth ids i)]}
-                   (str (nth ids i))]))}]
+                 [:li.row
+                  {:on-click [:feed/open (nth ids i)]}
+                  (str (nth ids i))]))}]
 ```
 
-`h/as-element` is the explicit hiccup-to-element conversion. `h/event`
-captures the supplying view's frame when the body builds the callback; the
-library's later call runs under that frame. Event vectors built in that body
-fire later, on the user's click, into the frame of the view that *supplied*
-the callback. A dispatch *while* the call runs raises
-`:rf.error/hicasso-dispatch-in-render-position` and names the position.
+`h/as-element` converts the Hiccup result. `h/event` captures the supplying
+view's frame, so event vectors inside that result later dispatch to the correct
+frame. Dispatching while the render callback itself runs raises
+`:rf.error/hicasso-dispatch-in-render-position`.
 
-**Write `h/event` whenever the row carries event vectors.** A plain function
-is legal at every contract and crosses untouched — no wrapper, and therefore
-no frame. That is right when the callback returns markup with no event
-vectors in it: a `[some-view {…}]` head resolves the frame React already has
-where the library renders it. It is wrong the moment an event vector appears
-in the row itself, because turning an event vector into a callback with no
-frame raises `:rf.error/hicasso-intent-outside-boundary`.
+A plain function is legal under any callback contract and passes through
+without a wrapper. It is enough when the callback returns a Hicasso view head
+whose frame is resolved where React renders it. If the callback's raw Hiccup
+contains event vectors, use `h/event`; otherwise conversion has no captured
+frame and raises `:rf.error/hicasso-intent-outside-boundary`.
 
-Two laws close the contract. **The declaration wins at every carrier.**
-`:event` accepts an event vector or a key-map. `:handler` and `:render`
-refuse the same carrier with
-`:rf.error/hicasso-intent-at-a-non-event-contract`. An ordinary unmarked
-function crosses untouched at all three. **Event vectors stay event-first**
-([Events as data](03-events-as-data.md)). A value-first invoker has no DOM
-event at argument one, so a marker-carrying vector refuses with
-`:rf.error/hicasso-intent-needs-the-event`. `h/event` is the spelling for
-those slots. A bare vector with no marker never touches its arguments, so
-`{:on-pick [:city/picked "paris"]}` is legal under any invoker.
+The declared contract always wins. Supplying an intent or key map to a
+`:handler` or `:render` position raises
+`:rf.error/hicasso-intent-at-a-non-event-contract`.
 
 ## ReactNode slots
 
-Some props are markup positions: a modal's title, a footer, a Suspense
-fallback. Declare those props as slots. Hiccup written at a declared slot
-then becomes elements under the captured frame:
+Declare props whose values are markup positions:
 
 ```clojure
 (h/defhost modal Modal
   {:callbacks {:on-close :event}
    :slots     #{:title :footer}})
 
-[modal {:on-close [:dialog/cancel]
-        :title    [:h2 "Delete article?"]
-        :footer   [:button.danger {:on-click [:article/delete id]} "Delete"]}]
+[modal
+ {:on-close [:dialog/cancel]
+  :title    [:h2 "Delete article?"]
+  :footer   [:button.danger
+             {:on-click [:article/delete id]}
+             "Delete"]}]
 ```
 
-Event vectors inside a declared slot fire into the declaring view's frame,
-the same as vectors in children. A string or ready React element at a
-declared slot passes as-is. React's own wrappers host the same way: declare
-`Suspense` once with `:slots #{:fallback}`, and write the fallback as hiccup.
+Hiccup in a declared slot becomes a React element under the frame captured by
+the declaring view. Event vectors inside it use that frame. Strings and
+already-built React elements pass through unchanged.
 
-At an **undeclared** prop, hiccup is data. `{:title [:h2 "Tasks"]}` hands the
-library the vector `["h2" "Tasks"]`. That is silent, because a vector is a
-legal value at a data position — which is why you declare slots, and why the
-runtime never guesses them. For a one-off, `(h/as-element [:h2 "Tasks"])`
-crosses a real element through any prop.
+At an undeclared prop, a Hiccup vector remains data and may silently reach the
+library as an array. Declare the slot, or use `h/as-element` for a one-off
+conversion. React wrappers such as Suspense use the same model; declare
+`:fallback` as a slot.
 
 ## Providers and compound components
 
-A library provider is only a component; a compound family is only several
-components. Declare each member you use. Crossings are real React elements,
-so the library's context flows through unbroken:
+Declare each member of a provider or compound component family that the
+application uses:
 
 ```clojure
-(h/defhost themed      (.-Provider theme-context) {:server :render})
+(h/defhost themed
+  (.-Provider theme-context)
+  {:server :render})
 
-(h/defhost tabs        Tabs           {:callbacks {:on-value-change :event}})
-(h/defhost tab-list    (.-List Tabs))
+(h/defhost tabs Tabs
+  {:callbacks {:on-value-change :event}})
+(h/defhost tab-list (.-List Tabs))
 (h/defhost tab-trigger (.-Trigger Tabs))
 ```
 
-!!! warning "Write `{:server :render}` on every transparent wrapper"
-    Under the default Client-only policy, a crossing renders nothing on the
-    server — including children. A Client-only provider therefore silently
-    deletes everything beneath it from the response, with no mismatch report.
-    Declare `{:server :render}` on every transparent wrapper. For React's own
-    context provider, Render is trivially true. Providers whose *value* is
-    browser-derived are covered in
-    [SSR and hydration](17-ssr-and-hydration.md).
+React context flows normally through hosted elements.
 
-## Server policy, per declaration
+!!! warning "Transparent wrappers need an explicit server policy"
+    A Client-only host renders neither itself nor its children on the server.
+    A provider left at the default can therefore remove an entire subtree from
+    the response without creating a hydration mismatch report. Mark a
+    deterministic transparent wrapper `{:server :render}`. Browser-derived
+    provider values require the SSR pattern described in the hydration
+    chapter.
 
-Every host states one of two policies.
+## Server policy
 
-**Render** — `{:server :render}`. You assert the component renders
-deterministic server bytes: one tree across server render, hydration, and
-fresh mount.
+A host has one of two policies:
 
-**Client-only** — the default. The server emits nothing at the crossing; the
-component appears when the client adopts it. Until adoption,
-`{:fallback [:div.chart-skeleton]}` renders *instead of* the crossing. The
-fallback is inert markup: a `defview` or `defhost` head inside one raises
-`:rf.error/hicasso-host-fallback-boundary-head`. `:fallback` beside
-`{:server :render}`, or any other policy value, raises
-`:rf.error/hicasso-host-bad-ssr-policy` at declaration. Full server story:
-[SSR and hydration](17-ssr-and-hydration.md).
+- **Render** — `{:server :render}` asserts deterministic output across server
+  render, hydration, and fresh client mount.
+- **Client-only** — the default. The server omits the crossing. Optional
+  `:fallback` Hiccup appears at the crossing until the client adopts it.
+
+A fallback must be inert markup. A `defview` or `defhost` head inside it raises
+`:rf.error/hicasso-host-fallback-boundary-head`. Combining `:fallback` with
+`:server :render`, or supplying another policy value, raises
+`:rf.error/hicasso-host-bad-ssr-policy` at declaration.
 
 ## Portals
 
-Sometimes markup must land in a different DOM container — a toast rack, a
-vendor-owned overlay div — while it stays part of your tree. The portal
-helper turns hiccup into React's `createPortal` and keeps the frame:
+Use `h/portal` when Hiccup must render into another DOM container while
+remaining part of the same React tree and frame:
 
 ```clojure
 (h/defview save-toast [_]
   [h/portal {:target js/document.body}
-   [:div.toast {:on-click [:toast/dismiss]}
+   [:div.toast
+    {:on-click [:toast/dismiss]}
     (str (h/sub [:toast/message]))]])
 ```
 
-Three facts:
+Portal behaviour:
 
-- **Events bubble through the React tree, not the DOM tree.** An `:on-click`
-  on `save-toast`'s hiccup ancestor sees clicks inside the toast even though
-  the toast's DOM lives on `body`. Event vectors fire into the owner's frame
-  as usual.
-- **A changed `:target` is a remount.** The subtree unmounts and remounts in
-  the new container. Keep the target stable.
-- **The portal is Client-only.** No DOM target exists on a server, so the
-  portal contributes nothing to the response. An explicit `:fallback` may emit
-  placeholder markup at the portal's tree position.
+- Events bubble through the React tree rather than the DOM ancestry, and event
+  vectors keep the owner's frame.
+- Changing `:target` remounts the portal subtree. Keep the target stable when
+  identity or local browser state matters.
+- Portals are Client-only because the server has no DOM target. An explicit
+  fallback may emit placeholder markup at the portal's source-tree position.
 
-For popovers and modals as product UI — anchoring, dismissal, focus — use
-[Overlays and focus](12-overlays-and-focus.md). The portal is the raw
-mechanism for containers you do not control.
+Use the overlays module for product modals and popovers; it adds anchoring,
+dismissal, and focus policy. A portal is the lower-level container mechanism.
 
-## The escape: `[:>]`
+## Raw `[:>]` escape
 
-`[:> Component props & children]` is the raw escape: the same foreign path
-as `h/defhost`, without a declaration. It exists for two cases. Migration is
-the first: Reagent codebases arrive full of `[:>]` sites, and those sites are
-legal here. The second is a one-off crossing a declaration cannot express,
-such as a component selected at runtime from data:
+`[:> Component props & children]` crosses to a foreign component without a
+declaration. It exists for migration and genuinely one-off dynamic component
+selection:
 
 ```clojure
-(def widgets {:chart Chart :table Table :map MapView})
+(def widgets
+  {:chart Chart
+   :table Table
+   :map   MapView})
 
 (h/defview panel [{:keys [kind]}]
-  [:> (get widgets kind) {:series (h/sub [:panel/series kind])}])
+  [:> (get widgets kind)
+   {:series (h/sub [:panel/series kind])}])
 ```
 
-This is not the performance tier. A measured hot region takes the
-[native tier](10-native-tier.md). **Declare what you use twice.** When you
-erase the declaration, you lose what it carried:
+Declare a component once it appears more than once. The raw escape loses:
 
-| A declaration carries | `h/defhost` | `[:>]` |
-|---|---|---|
-| A crossing name for tools | authored | the constant `"[:>]"` |
-| Callback contracts | exact, per slot | none — every prop is unclaimed |
-| ReactNode slots | declared | none — hiccup in a prop is data |
-| A server policy | Render or Client-only with fallback | fixed Client-only, unspellable |
-| Early site for refusals | checked once, at the declaration | every refusal fires at the crossing |
-| A `.cljc` quarantine | one host namespace | the require lands in your view namespace |
+| Contract carried by `h/defhost` | Raw `[:>]` |
+| --- | --- |
+| authored name for tools | constant `"[:>]"` |
+| callback contracts | every prop is unclaimed |
+| ReactNode slot declarations | Hiccup in props remains data |
+| selectable server policy and fallback | fixed Client-only with no direct fallback |
+| one declaration-time validation site | failures occur at each crossing |
+| quarantine of JS require in a host namespace | require remains in the view namespace |
 
-Every prop at an escape is unclaimed. Two refusals guard silent failures:
+An event vector at an `on*` prop raises
+`:rf.error/hicasso-host-undeclared-callback`; an `h/event` at any raw escape
+prop raises `:rf.error/hicasso-host-unclaimed-callback`. Both direct the author
+to `h/defhost` rather than allowing an inert array or unbound callback.
 
-- An event vector at an `on*`-spelled prop raises
-  `:rf.error/hicasso-host-undeclared-callback`. The runtime never infers a
-  contract from a name. Without the refusal, your vector would cross as an
-  inert array.
-- An `h/event` at any escape prop raises
-  `:rf.error/hicasso-host-unclaimed-callback`. The marked form asks its
-  position for a contract, and no escape position can answer.
+A plain function still crosses by identity but carries no frame. Ambient
+`rf/dispatch` from that function later raises `:rf.error/no-frame-context`.
+Capture the current frame during the body and close over its `:dispatch`, or
+replace the escape with a declared `:event` callback.
 
-Both name `h/defhost` as the recovery.
-
-A plain function crosses by identity and runs, but carries no frame. By the
-time the library calls it the render has unwound, so a bare `rf/dispatch`
-raises `:rf.error/no-frame-context`. Recovery is the same as in
-[Events as data](03-events-as-data.md): call `(rf/capture-frame)` in the body
-and close over its `:dispatch` — until a declared `:event` slot builds that
-for you.
-
-The escape renders nothing on the server: no declaration means no
-`:fallback`. A transparent pass-through host around it can put placeholder
-markup at the site:
+A transparent Client-only wrapper can provide server placeholder markup around
+an escape:
 
 ```clojure
-(h/defhost skeleton-slot (fn [^js p] (.-children p))
+(h/defhost skeleton-slot
+  (fn [^js props]
+    (.-children props))
   {:fallback [:div.skeleton]})
 
-[skeleton-slot {} [:> (get widgets kind) {:series data}]]
+[skeleton-slot {}
+ [:> (get widgets kind) {:series data}]]
 ```
 
-On the server, the fallback renders instead of the crossing, children and
-all. In the browser, the escape mounts as usual. That is a placeholder, not
-server-rendered content — only `{:server :render}` on the real component buys
-that.
+The fallback is a placeholder, not server rendering of the foreign component.
+Only a declaration on the real component with `{:server :render}` makes that
+claim.
 
-The component position takes what React accepts as an element type. `nil` —
-usual result of a `:default` import from a library with no default export —
-raises `:rf.error/hicasso-raw-no-component`. A string, keyword, `defview`
-head, `defhost` head, or already-built React *element* raises
-`:rf.error/hicasso-raw-not-a-component`. Each refusal carries its own
-recovery and fires in your render (on the server too), with your stack at the
-line you wrote.
+The raw component position must evaluate to a valid React element type. `nil`
+raises `:rf.error/hicasso-raw-no-component`. A string, keyword, Hicasso
+`defview` head, `defhost` head, or already-built React element raises
+`:rf.error/hicasso-raw-not-a-component`. These errors occur at the authored
+crossing, including during server render.
 
-## The outward bridge
+## Render a Hicasso view from native React
 
-Interop runs the other way too. A native React parent — `n/defcomponent`,
-UIx, or plain JavaScript — can render a Hicasso view under the existing
-frame. There is no second root and no second state owner.
+`h/as-component` converts a Hicasso view head into a real React component for
+UIx, `n/defcomponent`, JavaScript, or TypeScript parents:
 
 ```clojure
-;; article-card is an h/defview; hand article-card* to the React side and
-;; render it like any component: <ArticleCard articleId={7} />
-(def article-card* (h/as-component article-card))
+(def article-card*
+  (h/as-component article-card))
 ```
 
-`h/as-component` returns a real React component. The parent's props arrive as
-the view's ordinary props map: names come back through the canonical rule
-(`articleId` → `:article-id`), values cross by identity. The view keeps its
-memo wrapper, its reads, its key identity, and its teardown. Its frame comes
-from React context, and that context flows through foreign components in
-between. When the view renders outside a Hicasso root, mount raises
-`:rf.error/no-frame-context`. `h/as-element` and `h/as-component` are the two
-halves of one bridge: use the element for a one-shot subtree handed through a
-callback; use the component for a view a native parent will mount, key, and
-re-render itself.
+React props return to the Hicasso view as a normal props map with canonical
+names (`articleId` becomes `:article-id`) and identity-preserved values. The
+view retains its memoization, subscription reads, key identity, teardown, and
+frame from React context. Rendering it outside a Hicasso root raises
+`:rf.error/no-frame-context`.
+
+Use `h/as-element` for one subtree returned through a callback. Use
+`h/as-component` when a native parent will mount, key, and re-render the view
+as a component.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
-|---|---|---|
-| Library ignores or rejects a prop — keyword, CLJS map, kebab key inside a nested map | Values cross by identity; nested keys are not camelCased; no deep conversion | Hand the library what it documents — string, `#js`, or `clj->js` at the call site |
-| Hiccup in a prop renders as array data | Only children and declared slots become elements; undeclared prop is data | Declare the prop in `:slots`, or wrap in `h/as-element` |
-| React refuses an object as a child, from a render callback | Body returned a raw vector; `:render` return crosses unconverted | Return through `h/as-element` |
-| `:rf.error/hicasso-intent-at-a-non-event-contract` | Event carrier at `:handler` or `:render` | Declare `:event`, or write the real function |
-| `:rf.error/hicasso-host-undeclared-callback` at a `[:>]` | Event vector at an `on*`-spelled escape prop | Declare the host and name the prop in `:callbacks` |
-| A `[:>]` callback runs, then `:rf.error/no-frame-context` | Plain function carries no frame; render has unwound | `(rf/capture-frame)` in the body; close over its `:dispatch` |
-| Namespace does not load on the JVM | A JS require reached a `.cljc` file | Quarantine the require in a `.cljs` host namespace |
-| `:rf.error/hicasso-host-bad-ssr-policy` at declaration | Policy value outside Render / Client-only, or `:fallback` beside `:server :render` | Two policies; fallback belongs to Client-only |
-| Hosted component does not update when app state did | View above bailed out on equal props; host was never re-entered | Put the changing value on the host's *own* props |
+| --- | --- | --- |
+| A library ignores a keyword, CLJS map, or nested kebab key | Values pass by identity and nested values are not deeply converted | Supply the exact documented JS/string shape with `#js`, `clj->js`, or explicit strings |
+| Hiccup in a prop appears as array data | The prop was not declared as a ReactNode slot | Add it to `:slots` or convert that value with `h/as-element` |
+| React rejects an object returned by a render callback | Raw Hiccup crossed a `:render` contract | Return `h/as-element` |
+| `:rf.error/hicasso-intent-at-a-non-event-contract` | An intent or key map was supplied to a handler/render contract | Declare `:event` or supply the function/value the contract requires |
+| `:rf.error/hicasso-host-undeclared-callback` at `[:>]` | An event vector was placed in an unclaimed callback prop | Declare the host and callback contract |
+| A raw callback runs and then raises `:rf.error/no-frame-context` | A plain function retained no rendering frame | Capture the frame in the Hicasso body or use a declared event callback |
+| A shared namespace fails to load on the JVM | It contains a JavaScript require | Move the require and host declarations to a `.cljs` namespace |
+| `:rf.error/hicasso-host-bad-ssr-policy` at declaration | Invalid policy or fallback attached to Render | Use Render or Client-only; fallback belongs only to Client-only |
+| A hosted component does not receive changed application state | The surrounding view bailed out and the host's own props did not change | Put every value that drives the host on the host's props |
+| A provider's children vanish from server HTML | Transparent wrapper remained Client-only | Declare deterministic wrappers `{:server :render}` |
 
 ## When not to host
 
-`defhost` is for components you do not own. A hot, **hand-written**
-component is the [native tier](10-native-tier.md), not a host around your own
-code. If the library is a thin wrapper over DOM and twenty lines of hiccup
-reproduce it, write the twenty lines. A hosted component is a node your tools
-see less of and your tests assert less about. Most applications end with only
-a few hard hosted widgets.
+Use `defhost` for foreign components. Do not wrap application-owned hot code in
+a host as a performance technique; the native tier is the measured path for
+that case.
+
+If a library is a thin wrapper over a small amount of ordinary Hiccup, writing
+that Hiccup may provide better testability and diagnostics. Hosted widgets are
+more opaque to structural tests and tools, so keep crossings limited to places
+where the foreign implementation is worth that cost.
 
 ## Advanced
 
-### The crossing has no memo wrapper
+### Host crossings do not add a Hicasso memo wrapper
 
-A `defview` memoizes on its props. A host crossing does not. The foreign
-component re-renders whenever the view that wrote it re-renders. Put the
-crossing behind a small `defview` of its own if you want that bail-out. The
-corollary: a host that must react to a subscription needs the value on its
-*own* props. If you read the value one view up and stop there, the host sees
-a value that never changes.
+A hosted component is re-entered whenever the Hicasso view that authored it
+re-renders. Put it behind a small `defview` when an equal-props bail-out is
+useful. Conversely, state that must update the host must appear on its own
+props; reading a value elsewhere without passing it cannot update the host.
 
-### Imperative SDKs
+### Imperative SDKs with callback refs
 
-A map SDK, a chart that wants a DOM node, anything that hands you a handle —
-that is ordinary host-edge React, not a second interop API. Write a callback
-ref. React 19 makes attach and teardown one mechanism: whatever the ref
-function returns is its cleanup.
+A DOM-attached SDK can use a callback ref whose return value performs cleanup:
 
 ```clojure
-;; in app.hosts.map-panel — requires ["some-map-sdk" :as sdk]
 (defn- attach-map [node]
   (let [handle (sdk/mount node)
         done?  (volatile! false)]
@@ -362,26 +347,15 @@ function returns is its cleanup.
   [:div.map {:ref attach-map}])
 ```
 
-Four properties matter:
+Keep the handle in the closure returned by that attachment rather than a
+module-level `defonce`. Make cleanup idempotent for SDKs that reject repeated
+destroy calls. React invokes the returned cleanup instead of calling the ref
+again with `nil`. A top-level function keeps ref identity stable and avoids
+reattaching on every render.
 
-- **The handle is per-attach.** The cleanup that attach returned captures the
-  handle. Never hold it in a module-level `defonce`: a hoisted handle lets the
-  second attach overwrite and leak the first.
-- **Teardown is idempotent.** The `done?` latch guards SDKs whose `destroy`
-  throws on a dead handle.
-- **A cleanup-returning ref never sees `nil`.** React calls the returned
-  cleanup on detach *instead of* a re-invoke with `nil`, so a hand-written
-  `nil` branch is dead code.
-- **A top-level `defn` keeps the ref identity stable.** A fresh function on
-  every render re-attaches every time, so the SDK rebuilds on every keystroke
-  elsewhere in the tree.
-
-Under StrictMode (dev), React runs attach → cleanup → attach; this shape
-survives: the first handle dies with the cleanup that created it. A ref fires
-on attach and detach only, never on a config change — keep config fixed for
-the connection's life, and route steady-state change through an ordinary
-event and effect. When attach must close over per-instance props (API key,
-per-panel config), it needs a stable callback, and hooks do not belong in a
-`defview` body. That is the signal the edge has outgrown this recipe: use a
-named native component, where hooks are legal
-([The native tier](10-native-tier.md)).
+StrictMode performs attach, cleanup, then attach in development; each handle is
+cleaned by the closure that created it. A ref does not rerun merely because a
+configuration value changed. Keep attachment configuration stable and send
+steady-state updates through events/effects. If attachment must close over
+per-instance props with hook-managed identity, move the edge into a named
+native component; hooks do not belong in a `defview` body.

--- a/docs/design/hicasso/draft-guide/10-native-tier.md
+++ b/docs/design/hicasso/draft-guide/10-native-tier.md
@@ -1,129 +1,106 @@
 # The native tier
 
-Most apps never need this page. Ordinary Hicasso — hiccup, `h/sub` where you
-read, events as data — is the product. This page is for the thin slice that
-is not: market-tick rows, display-rate drag, vendor widgets that are hooks
-all the way down. You write React directly; frame, app-db, and root stay the
-same.
+Most Hicasso applications do not need native view code. Start with interpreted
+Hiccup, tracked `h/sub` reads, and event vectors. Move a measured region only
+when profiling identifies work that the normal topology cannot remove.
 
-`[...]` is always interpreted Hiccup. `n/$` is always native React. Neither
-form changes the other's meaning, and nothing compiles hiccup into native
-behind the scenes. Crossing is explicit in source, visible to tests, and
-named by Xray. An application that never requires the native namespace ships
-zero native-tier code.
+`[...]` always means interpreted Hiccup. `n/$` always creates React elements
+directly. The crossing is explicit in source, visible to diagnostics, and does
+not replace the root, frame, or app-db. Applications that never require the
+native namespace include none of its code.
 
-## The ladder
+## Escalation ladder
 
-Climb one rung at a time, with a measurement at every step.
+| Rung | Authoring form | What changes | Use it when |
+| --- | --- | --- | --- |
+| 1. Ordinary Hicasso | Hiccup, `h/sub`, event vectors | nothing | default for every screen |
+| 2. Tuned Hicasso | same language | view boundaries, keys, read shape, chunking, or virtualization | profiling identifies topology cost |
+| 3. Native return from `defview` | a Hicasso view returns `n/$` | skips Hiccup interpretation for that result; retains the view's frame, reads, memo, and lifecycle | Hiccup construction is the measured owner |
+| 4. Named native island | `n/defcomponent` or UIx with `n/use-sub` and `n/use-frame` | hooks and high-rate local mechanics run in a real native component | hooks, vendor behaviour, reconciliation, or per-frame local work dominate |
+| 5. Native screen | native namespace, UIx, or hosted JS/TS tree | that screen uses a React-first view language | the product surface is React-shaped by design |
 
-| Rung | You write | What changes | Climb when |
-|---|---|---|---|
-| 1. Ordinary Hicasso | Hiccup, `h/sub`, event vectors | Nothing — this is the product | Always start here |
-| 2. Tuned topology | The same language | View placement, keys, read shape (fine / coarse / chunked / windowed), virtualization | A named interaction misses its budget — [Lists and collections](06-lists-and-collections.md) |
-| 3. Direct native return | A `defview` whose body returns `n/$` | Hiccup interpretation skipped for that result; frame, reads, memo, and lifecycle stay | Attribution names hiccup construction as the cost owner |
-| 4. Named native island | `n/defcomponent` (or UIx) with `n/use-sub` / `n/use-frame` | Hooks, vendor widgets, and high-rate mechanics live in a real native component with an explicit crossing | Hooks, reconciliation, vendor behavior, or high-rate local work dominates |
-| 5. Native screen | A whole screen in the native namespace or UIx | The view language for that screen — same root, same frames, same app-db | The screen is React-shaped by design |
+Keep an escape only when the measured interaction improves materially: at
+least 20%, at least 2 ms at p95, or enough to move a user-visible budget from
+fail to pass. Otherwise remove it. A small explicit diff is easier to maintain
+than a permanent second authoring style with no demonstrated benefit.
 
-Rungs 1 and 2 are ordinary product —
-[Views and reads](02-views-and-reads.md) and
-[Lists and collections](06-lists-and-collections.md). This page owns rungs 3
-to 5.
+## Return native elements from a Hicasso view
 
-**Escape-benefit rule:** keep an escape only if it recovers at least 20% of
-the measured interaction, saves at least 2 ms at p95, or converts a failed
-user-visible budget into a pass. Otherwise take it out. Native code that
-cannot meet that rule is a permanent cost with no return. Reverting a rung-3
-escape is a small diff, so the rule has no exceptions.
-
-## Rung 3 — return native React from a view
-
-Here is a watchlist row after rung 2 is already done. The table is windowed
-to the ~40 visible rows, keys are stable, and each row makes one coarse
-display read. The subscription returns render-ready strings, so the body does
-almost no work of its own.
+Assume a windowed watchlist has stable keys and each visible row makes one
+render-ready subscription read:
 
 ```clojure
 (ns app.watchlist.row
   (:require [re-frame.hicasso :as h]))
 
 (h/defview quote-row [{:keys [sym]}]
-  (let [{:keys [px chg pct vol up?]} (h/sub [:quotes/display-row sym])]
+  (let [{:keys [px chg pct vol up?]}
+        (h/sub [:quotes/display-row sym])]
     [:tr {:class    (if up? "quote up" "quote down")
           :on-click [:watchlist/select sym]}
      [:td.sym sym]
-     [:td.px  px]
+     [:td.px px]
      [:td.chg chg]
      [:td.pct pct]
      [:td.vol vol]]))
 ```
 
-Market ticks update most visible rows several times a second. On this app's
-low-tier reference laptop, Xray's attribution for the tick event reads:
-bodies 3 ms, hiccup construction 9 ms, React reconcile-and-commit 6 ms, paint
-3 ms — 21 ms at p95. Every row did change, so there is no read-topology fix
-left. The owner is construction: forty rows of vectors turn into React
-elements, several times a second. That is the situation rung 3 exists for.
-
-A `defview` may return an existing React element instead of hiccup. Build it
-with `n/$`:
+If event attribution shows Hiccup construction, rather than subscriptions or
+React commit, as the remaining cost, the same `defview` may return an existing
+React element:
 
 ```clojure
 (ns app.watchlist.row
-  (:require [re-frame.hicasso        :as h]
+  (:require [re-frame.hicasso :as h]
             [re-frame.hicasso.native :as n]))
 
 (h/defview quote-row [{:keys [sym]}]
-  (let [{:keys [px chg pct vol up?]} (h/sub [:quotes/display-row sym])]
-    (n/$ :tr {:class    (if up? "quote up" "quote down")
-              :on-click (h/event [_] [:watchlist/select sym])}
+  (let [{:keys [px chg pct vol up?]}
+        (h/sub [:quotes/display-row sym])]
+    (n/$ :tr
+         {:class    (if up? "quote up" "quote down")
+          :on-click (h/event [_]
+                      [:watchlist/select sym])}
          (n/$ :td {:class "sym"} sym)
-         (n/$ :td {:class "px"}  px)
+         (n/$ :td {:class "px"} px)
          (n/$ :td {:class "chg"} chg)
          (n/$ :td {:class "pct"} pct)
          (n/$ :td {:class "vol"} vol))))
 ```
 
-The view did not change as a unit. The parent still renders
-`[quote-row {:key sym :sym sym}]`. The view keeps its React identity,
-value-equality memo, frame, `h/sub` reads, lifecycle, and name in Xray. What
-changed is the return value: an already-built React element, so hiccup
-interpretation is skipped for this result. Re-measured, the tick lands at
-13 ms p95 — 38% recovered, 8 ms saved. That passes the benefit rule on two
-conditions; the escape stays. Your numbers will differ. The point is that you
-have numbers.
+The parent still renders `[quote-row {:key sym :sym sym}]`. The Hicasso view
+keeps its identity, equality memo, frame, subscription reads, lifecycle, and
+Xray name. Only its returned subtree bypasses Hiccup interpretation.
 
-Read the diff:
+The guide's worked measurement moved a 21 ms p95 tick to 13 ms: 38% and 8 ms
+recovered. Those numbers justify that example but are not a promise for another
+application; remeasure the actual interaction before keeping the crossing.
 
-- **`[:td.sym …]` became `(n/$ :td {:class "sym"} …)`.** The native grammar
-  has no selector shorthand. Spell class and id as props.
-- **`:on-click [:watchlist/select sym]` became
-  `(h/event [_] [:watchlist/select sym])`.** Past this fence there is no
-  automatic event-vector → callback conversion. An event vector in a native
-  prop is an error, not a callback. `h/event` captures the frame while the
-  body runs and hands React an ordinary function. Plain `fn` values are fine
-  when you do not dispatch.
-- **Children are nested `n/$` forms, not vectors.** A hiccup vector as a
-  native child is refused. If a native subtree needs one Hicasso-rendered
-  child, convert explicitly: `(h/as-element [sparkline {:points pts}])`.
+Important syntax changes:
 
-What stays with the view, and what stops at the returned element:
+- Hiccup selector shorthand has no native equivalent. Write class and id in
+  props.
+- Native event props require functions. Use `h/event` in a rung-3 body to
+  create a frame-aware callback; an event vector is rejected.
+- Native children are ReactNode values. Nest `n/$` forms. Convert a Hicasso
+  subtree explicitly with `h/as-element`.
 
-| Stays with the view | Stops at the returned element |
-|---|---|
-| The frame — and `h/sub` anywhere in the body | Hiccup interpretation — a vector is not markup here |
-| The props ABI, value-equality memo, and the parent's `:key` | Event vectors in props — an event vector in a prop is an error |
-| Lifecycle, HMR conduct, and the view's name in Xray | Controlled repair — no `::h/value`, `::h/checked`, `::h/prevent`, `::h/revision` |
-| Server rendering — intrinsic-headed output produces the same deterministic bytes | Structural assertions and key diagnostics — the element is opaque to the pure test tiers ([Testing](14-testing.md)) |
+| Retained by the enclosing `defview` | Not provided inside the native result |
+| --- | --- |
+| current frame and `h/sub` reads | Hiccup interpretation |
+| props ABI, equality memo, and parent's key | event-vector-to-callback conversion |
+| lifecycle, HMR behaviour, and Xray name | controlled-input repair and reserved markers |
+| deterministic intrinsic server output | structural tree assertions and Hicasso key diagnostics inside the opaque element |
 
-Form fields stay interpreted. An `<input>` inside `n/$` is a raw React
-controlled input: you do all of React's manual work, and you get none of
-Hicasso's caret, IME, or same-turn guarantees
-([Controlled inputs](04-controlled-inputs.md)). Hooks still do not belong in
-the body. A `defview` body is dynamically composed — branches and loops are
-legal, which is where hook order breaks. The wish for a hook in a `defview`
-body is the signal you are at rung 4, not rung 3.
+Keep form controls interpreted. A raw React `<input>` created with `n/$` does
+not receive Hicasso's same-turn convergence, selection preservation, IME
+protection, or `::h/revision` handling.
 
-### The `n/$` grammar
+Hooks also remain illegal in a `defview` body. Hicasso bodies may branch and
+loop dynamically, which is incompatible with hook order. A needed hook is a
+signal to use a named native island.
+
+## `n/$` grammar
 
 ```clojure
 (n/$ head)
@@ -132,64 +109,51 @@ body is the signal you are at rung 4, not rung 3.
 (n/$ head (n/props dynamic-props) child*)
 ```
 
-- **Heads.** An unqualified keyword such as `:div` names an intrinsic React
-  element. A string names an intrinsic or custom element verbatim (SVG and
-  web components work). Any other head expression must evaluate to a native
-  React component.
-- **The props operand.** The macro treats exactly four forms as props: `nil`,
-  a literal ClojureScript map, a literal `#js` object, or the explicit
-  `(n/props expression)` marker. **Every other trailing form is a child.**
-- **Prop names.** ClojureScript-map keys use the canonical React slot-name
-  rule: kebab becomes camelCase (`:on-click` → `onClick`); `:class` and
-  `:for` become the React names; `data-*` / `aria-*` stay hyphenated;
-  camelCase keywords are fixpoints; string keys pass verbatim. A raw
-  JavaScript object is never renamed.
-- **Prop values pass by identity.** No event-vector conversion, no
-  class-collection merge, no style-map conversion, no keyword-value
-  conversion, no controlled-field repair, no deep conversion. Where a native
-  API expects a JavaScript object — React style objects included — hand it
-  one: `:style #js {:transform "translateX(4px)"}`.
-- **Children** are trailing ReactNode values. Nest with `n/$`; collections
-  must already be valid React children, normally a JavaScript array
-  (`(into-array (map row-el rows))`, each element carrying its `:key`). The
-  grammar refuses `:children` inside the props map — there is one child
-  channel.
-- **`:key` and `:ref`** use the ordinary React slots. Two source keys that
-  normalize to the same slot — for example `:class` and `"className"` in one
-  map — refuse rather than let map order pick a winner.
+Rules:
 
-!!! warning "Dynamic props must be marked"
-    The props rule is syntactic on purpose. A dynamic React element is itself
-    a JavaScript object, so the macro never inspects a runtime value to decide
-    "props or child".
+- An unqualified keyword names an intrinsic React element. A string names an
+  intrinsic or custom element verbatim. Any other head expression must evaluate
+  to a native React component.
+- Only `nil`, a literal ClojureScript map, a literal `#js` object, or
+  `(n/props expression)` is classified as the props operand. Every other
+  trailing form is a child.
+- Keys in a ClojureScript props map normalize to React slots: kebab-case to
+  camelCase, `:class` to `className`, `:for` to `htmlFor`, with `data-*` and
+  `aria-*` unchanged. String keys pass verbatim. A JS object is not renamed.
+- Prop values pass by identity. There is no event-vector conversion, class
+  collection join, style-map conversion, keyword value conversion,
+  controlled-field repair, or deep conversion. Supply JS values explicitly
+  where React or a library requires them.
+- Children must already be valid ReactNode values. Collections are normally
+  JavaScript arrays of keyed elements. `:children` in the props map is
+  rejected because trailing forms are the one child channel.
+- `:key` and `:ref` use ordinary React slots. Two source keys that normalize to
+  the same slot, such as `:class` and `"className"`, are rejected rather than
+  resolved by map order.
+
+!!! warning "Mark dynamic props with `n/props`"
+    The macro classifies props syntactically. A runtime map in second position
+    is otherwise a child:
 
     ```clojure
-    ;; Don't: a dynamic map in second position is a CHILD, not props.
+    ;; Don't
     (let [cell-props {:class "px" :dir "ltr"}]
-      (n/$ :td cell-props px))   ;; refuses — recovery names (n/props …)
+      (n/$ :td cell-props px))
 
-    ;; Do: mark the operand. n/props emits no wrapper — it only classifies.
+    ;; Do
     (let [cell-props {:class "px" :dir "ltr"}]
       (n/$ :td (n/props cell-props) px))
     ```
 
-    A dynamic ClojureScript map inside `n/props` converts shallowly under the
-    same slot-name rule; a JavaScript object passes by identity.
+    `n/props` adds no runtime wrapper. It only marks the operand. A CLJS map is
+    converted shallowly under the slot-name rule; a JS object passes through.
 
-## Rung 4 — a named native island
+## Named native islands
 
-When the cost owner is not hiccup construction but *behavior* — hooks, a
-retained vendor widget, React reconciliation itself, or work that runs per
-animation frame — the answer is a named, top-level native component. The
-self-contained route is `n/defcomponent`. UIx is an equally supported mature
-route. A JavaScript or TypeScript component enters through the host bridge
-([Interop](09-interop.md)). Every route stays inside the same React root, the
-same frame context, and the same state owner.
-
-Here is a column-resize handle. Pointer movement is high-rate mechanics —
-host-private, not an application fact. It stays in local React state; app-db
-receives exactly one write, on release
-([Ephemeral state](11-ephemeral-state.md)):
+Use a top-level native component when the remaining owner is hooks, retained
+vendor behaviour, React reconciliation, or high-rate mechanics. The example
+below keeps drag motion in local React state and commits one domain fact to
+app-db when the pointer is released:
 
 ```clojure
 (ns app.watchlist.resizer
@@ -197,183 +161,176 @@ receives exactly one write, on release
             [re-frame.hicasso.native :as n]))
 
 (n/defcomponent col-resizer
-  ;; No declaration map: the server policy defaults to Client-only.
   [^js props]
   (let [col                (.-col props)
         {:keys [dispatch]} (n/use-frame)
         committed          (n/use-sub [:watchlist/col-width col])
-        [live set-live]    (react/useState nil)]   ; px while dragging, else nil
+        [live set-live]     (react/useState nil)]
     (n/$ :div
          {:class            "col-resizer"
           :role             "separator"
           :aria-orientation "vertical"
-          :on-pointer-down  (fn [e]
-                              (.setPointerCapture (.-currentTarget e) (.-pointerId e))
-                              (set-live committed))
-          :on-pointer-move  (fn [e]
-                              (set-live (fn [w] (some-> w (+ (.-movementX e))))))
-          :on-pointer-up    (fn [_]
-                              (when live
-                                (dispatch [:watchlist/set-col-width col live]))
-                              (set-live nil))
-          :on-lost-pointer-capture (fn [_] (set-live nil))}
+          :on-pointer-down
+          (fn [e]
+            (.setPointerCapture (.-currentTarget e)
+                                (.-pointerId e))
+            (set-live committed))
+          :on-pointer-move
+          (fn [e]
+            (set-live
+             (fn [width]
+               (some-> width (+ (.-movementX e))))))
+          :on-pointer-up
+          (fn [_]
+            (when live
+              (dispatch [:watchlist/set-col-width col live]))
+            (set-live nil))
+          :on-lost-pointer-capture
+          (fn [_]
+            (set-live nil))}
          (when live
-           (n/$ :div {:class "col-resizer__guide"
-                      :style #js {:transform (str "translateX(" (- live committed) "px)")}})))))
+           (n/$ :div
+                {:class "col-resizer__guide"
+                 :style #js {:transform
+                             (str "translateX("
+                                  (- live committed)
+                                  "px)")}})))))
 ```
 
-Piece by piece:
+The component ABI is one raw JS props object; children are at `.-children`.
+An optional declaration map before the argument vector chooses
+`{:server :render}` or `{:server :client-only}`. Omission defaults to
+Client-only, which is appropriate for a pointer-only widget.
 
-- **The ABI is one raw JavaScript props object** — read it with `.-col`;
-  children arrive at `.-children`. There is no hidden map allocation.
-- **A declaration map before the argument vector carries the server
-  policy** — `{:server :render}` or `{:server :client-only}`. Omit it and
-  the policy is Client-only, which is right for a pointer-driven widget.
-- **Ordinary React hooks are used directly.** `react/useState`,
-  `react/useEffect`, refs — React's surface, React's rules.
-- **`n/use-sub` and `n/use-frame` join the frame you were already in.** The
-  first reads a subscription under the current frame and re-renders the
-  island when the value changes. The second is frame capture in hook
-  position. It returns the frame-locked ops map —
-  `{:frame :dispatch :dispatch-sync :subscribe}` — and the map is
-  reference-stable across re-renders of the same frame *incarnation*. A frame
-  keyword is an address, not an identity: destroying that frame and creating
-  another under the same id retargets the map. Within an incarnation it is
-  safe to pull `:dispatch` off it and close over it in callbacks; a bundle
-  held across a same-id reincarnation is silently inert.
-- **High-rate work never touches app-db.** The drag guide tracks the pointer
-  through local React state; the component dispatches the single committed
-  fact — the final width — once, on release.
+React hooks use their normal rules. `n/use-sub` is a hook and must be called
+unconditionally at the top level. `n/use-frame` returns
+`{:frame :dispatch :dispatch-sync :subscribe}` for the current frame and is
+reference-stable during one frame incarnation.
 
-The two read doors look similar but obey different laws:
+A frame keyword is only an address. Destroying a frame and recreating it under
+the same id creates a new incarnation. A bundle retained across that change is
+silently inert; obtain frame operations from the live island rather than a
+global stash.
 
-| Door | Lives in | Rules |
-|---|---|---|
-| `h/sub` | Hicasso bodies | Direct synchronous body only; branches, loops, and plain helpers are fine; not a hook |
-| `n/use-sub` | Native components | A real React hook; the rules of hooks apply — top level of the component, unconditional |
+High-rate pointer updates remain local to the island. Dispatch only the fact
+that the rest of the application needs — the final width.
 
-### Mounting the island
+| Read API | Legal context | Rule |
+| --- | --- | --- |
+| `h/sub` | synchronous Hicasso view body | ordinary function call; branches, loops, and helpers are legal |
+| `n/use-sub` | native React component | React hook; top-level and unconditional |
 
-From interpreted hiccup, mount an island behind a named host. Declare once,
-use as an ordinary head:
+## Mount an island
+
+Declare a native component as a host when interpreted Hiccup needs to render
+it:
 
 ```clojure
 (h/defhost resize-handle col-resizer)
 
-;; in the header view:
-[:th {:class "px"} "Price" [resize-handle {:col :px}]]
+[:th {:class "px"}
+ "Price"
+ [resize-handle {:col :px}]]
 ```
 
-From native code, a component is a head as-is: `(n/$ col-resizer {:col :px})`.
-Both directions cross under the same root and frame. The one-off raw element
-escape also exists ([Interop](09-interop.md)), but it is for migration and
-true one-off interop. Repeated or hot crossings deserve a name, a
-declaration, and tests — which is what `defhost` gives you.
-
-!!! note "Islands and the server"
-    An intrinsic `n/$` return renders on the server like the hiccup it
-    replaced. A component-headed island defaults to Client-only — leaving its
-    declared fallback in the server bytes or, bare, nothing at all — until
-    its declaration selects `{:server :render}` and proves matching hydration.
-    [SSR and hydration](17-ssr-and-hydration.md) owns the full contract.
-
-??? info "If your team already writes UIx"
-    Everything above has a UIx spelling. A `defview` at rung 3 may return a
-    `uix.core/$` element, and an island at rung 4 may be a `defui`. The native
-    hooks are substrate-neutral, so `n/use-sub` and `n/use-frame` work inside
-    a `defui` exactly as inside `n/defcomponent`. The Hicasso-native surface
-    is held to parity against both handwritten React and UIx, so the choice is
-    taste and scale, not speed. Two corrections: `n/*` is not UIx-lite and
-    never imports UIx — a Hicasso app without UIx islands ships zero UIx
-    bytes. When a native region grows into substantial React-first work, UIx
-    is the designed answer, not a defeat — the native namespace is deliberately
-    too small to be a component framework.
-
-## Keeping the marker: the ABI helpers
-
-`n/defcomponent` stamps its component with a display name and a tier marker
-carrying that name and the declared server policy. The marker lets Xray name
-the view, and it is how ABI helpers and embedding directions recognize a
-native head. It does not carry the component across a hot reload. Defining a
-component is allocation, never a lookup by name: a save re-evaluates the
-module, the component is allocated afresh, the element type at that position
-is a new object, and React replaces the subtree. **A clean remount across a
-save is designed conduct, not a fault** — a component's name is an address,
-not an identity, the same as `defview`. Raw React wrappers erase the marker:
+Native code renders it directly:
 
 ```clojure
-;; given (n/defcomponent quote-cell* …) — a pure display cell worth memoizing:
-
-;; Don't: works at runtime, but the marker is gone — Xray shows an anonymous
-;; view, and the embedding seams no longer recognize the head.
-(def quote-cell (react/memo quote-cell*))
-
-;; Do: same React.memo semantics, marker intact.
-(def quote-cell (n/memo quote-cell*))
+(n/$ col-resizer {:col :px})
 ```
 
-`n/memo` and `n/lazy` carry the one props/children ABI through memoization
-and code-split loading. Refs need no helper: `:ref` uses React's ordinary
-slot, and a function component receives it through props. The same
-preservation applies to both embedding directions: hiccup rendering an island
-(above), and a native parent rendering a Hicasso view through the outward bridge
-([Interop](09-interop.md)).
+Both stay under the existing root and frame. Repeated crossings should receive
+a named declaration for tooling and tests; the raw escape is for migration and
+one-off dynamic cases.
 
-## Rung 5 — a native screen
+An intrinsic-headed `n/$` result can render deterministically on the server.
+A component-headed island defaults to Client-only and emits its declared
+fallback, or nothing, until explicitly marked Render and verified for
+hydration.
 
-Some screens are React-shaped from the first commit — a canvas editor, a
-diagramming surface, a screen that is mostly one large vendor grid. Implement
-that screen's view tree natively — with the native namespace, with UIx, or in
-JavaScript behind hosts — under the same installed adapter, the same root,
-and the same frames. This is a local view-implementation choice, not a second
-adapter, and never a second state owner. An independent React root remains an
-isolation choice, not a speed choice.
+??? info "Using UIx"
+    A rung-3 `defview` may return a UIx element, and a rung-4 island may be a
+    `defui`. `n/use-sub` and `n/use-frame` work inside UIx components. The
+    native namespace does not import UIx and is intentionally not a full
+    component framework. Use UIx when a native region becomes substantial
+    React-first product code.
 
-## Every crossing runs the loop
+## Preserve the native marker
 
-The numbered working loop — reproduce, attribute with Xray, tune topology
-first, then compare an escape and keep it only if it passes the benefit
-rule — is [Performance](18-performance.md)'s method. Every rung on this page
-is entered through it: rung 3 when attribution names hiccup construction,
-rung 4 when it names hooks, vendor behavior, reconciliation, or high-rate
-local work. What this page adds is the follow-through a crossing owes.
-Re-run the contracts you can no longer see — DOM and event-vector parity,
-focus and selection, frame routing, SSR and hydration, cleanup, and the
-performance script — before you call the escape done.
+`n/defcomponent` records a display name, native-tier marker, and server policy.
+Xray and embedding helpers use that marker. Raw React wrappers remove it:
 
-Xray stays honest on both sides of the fence. It names and times the native
-view, shows reads made through `n/use-sub`, and labels the inner React tree
-*opaque* — a real answer, never a silently empty one. The advisor may
-recommend a view split and scaffold a comparison. It never rewrites your
-code, and nothing switches semantics at runtime.
+```clojure
+;; Don't — React behaviour works, but Hicasso loses the marker
+(def quote-cell
+  (react/memo quote-cell*))
+
+;; Do
+(def quote-cell
+  (n/memo quote-cell*))
+```
+
+Use `n/memo` and `n/lazy` so the props/children ABI and marker survive
+memoization or code-split loading. Refs need no helper; function components
+receive the React ref slot through props.
+
+Hot reload reallocates a native component. React sees a new element type and
+remounts that subtree. Local hook state resets on save by design. State that
+must survive code reload belongs in app-db and returns through `n/use-sub`.
+
+## Native screens
+
+A canvas editor, diagramming surface, or vendor-grid screen may be React-shaped
+from its first useful design. Implement that screen natively under the same
+adapter, root, and frames. This changes only the view implementation for that
+screen; it does not justify a second state owner or independent React root.
+
+An independent root is an isolation decision, not a performance optimisation.
+
+## Verify every crossing
+
+The performance chapter owns the working method: reproduce, attribute with
+Xray, tune topology first, compare an escape, and retain it only if it meets
+the benefit rule.
+
+After crossing, rerun the contracts that Hicasso can no longer inspect inside
+the native subtree:
+
+- DOM and interaction parity
+- focus and selection
+- frame routing
+- SSR and hydration
+- cleanup and StrictMode behaviour
+- the original performance script
+
+Xray can name and time the native boundary and show `n/use-sub` reads, while
+correctly labelling the inner React tree opaque. It does not silently pretend
+to inspect native descendants.
 
 ## When not to go native
 
-- **You have no named measurement.** "The app feels slow" is almost always a
-  rung-1 or rung-2 problem underneath. No profile, no escape.
-- **The owner is read placement.** On the worst mounts we have measured, most
-  of the deficit was read shape — too many fine per-row subscriptions — not
-  the hiccup walk. That fix is [Lists and collections](06-lists-and-collections.md),
-  and it keeps every convenience the fence would cost you.
-- **The problem is typing latency.** Keystroke echo is an event-volume and
-  controlled-field question ([Controlled inputs](04-controlled-inputs.md),
-  [Performance](18-performance.md)); native construction does not move it.
-- **A controlled field is involved.** The native tier has no controlled
-  repair — same-turn convergence, caret and IME preservation, and
-  `::h/revision` live on the hiccup side. Fields stay interpreted.
-- **You want rung 4 "for consistency".** One island is an escape; islands
-  everywhere is a rewrite of the product you chose.
+Do not cross without a reproducible interaction and measured owner. Read
+placement, unstable props, excessive event volume, and uncontrolled DOM size
+must be fixed at the Hicasso level first.
+
+Native construction does not solve controlled-input latency, and native inputs
+lose the Hicasso controlled-field contract. Keep those fields interpreted.
+
+Do not create islands merely for stylistic consistency. A few named escapes
+are a boundary; islands throughout the application are a change of view-layer
+strategy.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
-|---|---|---|
-| Refusal: a ClojureScript map appeared as a React child | A dynamic map in the props position is classified as a child — the grammar only recognizes `nil`, literal maps, `#js` literals, and `(n/props …)` as props | Mark it: `(n/$ :td (n/props m) …)` |
-| Refusal on a vector child inside `n/$` | Hiccup is not interpreted past the fence | Convert with `h/as-element`, or keep that subtree interpreted |
-| Refusal: event vector in a native prop (`:on-click [:x/select id]`) | No event-vector conversion past the fence — native callbacks are functions | `(h/event [_] [:x/select id])` in a rung-3 body; `:dispatch` from `n/use-frame` inside an island |
-| Refusal: `:children` in the props map | One child channel — trailing forms | Pass children after the props operand |
-| Refusal: two keys normalize to one slot (`:class` and `"className"`) | Canonical-slot collision | Keep one spelling per slot |
-| `:rf.error/no-frame-context` from `n/use-sub` or `n/use-frame` | Island rendered outside any frame provider — separate root, portal outside the app, or test without the harness | Mount under the app root, or use the test kit's provider ([Testing](14-testing.md)) |
-| Xray shows an anonymous view where a named island should be | Component marker erased by a raw wrapper (`react/memo`, `React.lazy`) | Use `n/memo` / `n/lazy` — same semantics, marker intact |
-| Local state inside an island resets whenever you save | Designed HMR conduct: reload allocates a fresh component, React remounts | Nothing to fix. State that must outlive a save belongs in `app-db`, read back through `n/use-sub` |
-| Went native, numbers did not move | Cost owner was never construction — usually reads or event volume | Back to loop step 2; expect the fix at rung 2, and take the unearned escape out |
+| --- | --- | --- |
+| A CLJS map is rejected as a React child | Dynamic map was not classified as props | Wrap the expression with `(n/props m)` |
+| A vector child is rejected inside `n/$` | Hiccup is not interpreted past the native fence | Convert with `h/as-element` or keep the subtree interpreted |
+| An event vector in a native prop is rejected | Native props require functions | Use `h/event` in a rung-3 body or dispatch from `n/use-frame` in an island |
+| `:children` in the props map is rejected | Native grammar has one trailing child channel | Move children after the props operand |
+| Two prop keys are rejected as a slot collision | Both normalize to one React slot | Keep one canonical spelling |
+| `n/use-sub` or `n/use-frame` raises `:rf.error/no-frame-context` | Component mounted outside a Hicasso frame provider | Mount under the application root or use the test kit's provider |
+| Xray shows an anonymous native view | Raw `react/memo` or `React.lazy` removed the marker | Use `n/memo` or `n/lazy` |
+| Local island state resets after each code save | Hot reload allocates a new component and React remounts it | Expected; move persistent state to app-db |
+| Native rewrite does not improve the measurement | Construction was not the actual cost owner | Remove the escape and return to topology/event attribution |
+| A controlled field loses caret or composition behaviour | It was moved behind the native fence | Keep the field interpreted or implement the full React contract yourself |

--- a/docs/design/hicasso/draft-guide/11-ephemeral-state.md
+++ b/docs/design/hicasso/draft-guide/11-ephemeral-state.md
@@ -1,51 +1,44 @@
-# Ephemeral state: where everything lives
+# Ephemeral state: where it belongs
 
-Is this dropdown open? Is this row selected? Where do the half-typed draft,
-the in-flight drag position, and the vendor SDK handle go?
+A dropdown can be open, a field can hold a half-typed draft, and a drag can
+have an in-flight pointer position. Those facts do not all belong in the same
+place.
 
-In Reagent you use `r/atom`. In React you use `useState`. Hicasso has
-neither: no component-local reactive cell, no local-state tier. These cells
-are not discouraged; they do not exist. Much of the "local state" a view
-layer teaches you to want came from machinery Hicasso does not have —
-reaction capture, argv memoization, a second reactive system. The state that
-remains is real, and every kind of it has a named home.
+Hicasso has no component-local reactive cell. There is no Hicasso equivalent
+of Reagent's `r/atom`, and `useState` does not belong in a `defview` body.
+Application-visible facts live in app-db. High-rate widget mechanics stay
+inside a native host. Browser-owned state stays in the browser.
 
-App-db owns every fact the application can see. Mechanics stay inside their
-host. No state gets a second reactive store.
+That gives each fact one owner and keeps a second reactive store out of the
+application.
 
-## Why one owner
+## Why one owner matters
 
-Three product promises depend on it.
+Three re-frame2 properties depend on it.
 
-**Tests stay data.** When "the dropdown is open" is a value at an address, a
-test opens the dropdown with a `:db` write. The test does not simulate a
-click, mount a component, or start a timer. The full open/close/dismiss
-policy of a widget is provable headlessly ([Testing](14-testing.md)). A
-private cell would move every one of those tests into a browser.
+**Tests stay data-driven.** If “this dropdown is open” is stored at an app-db
+address, a headless test can seed that address directly. It does not need to
+mount a component, simulate a click, or wait for a timer
+([Testing](14-testing.md)).
 
-**Xray can attribute work.** The causal path is *event → subscriptions →
-views → commit → paint*. Every re-render has a cause Xray can name, because
-every application write goes through the one write clock: the re-frame2 state
-commit. A second reactive store invalidates views on a clock Xray cannot see
+**Diagnostics keep a complete cause chain.** Xray can connect an event to a
+state commit, subscription invalidation, view render, React commit, and paint.
+A private reactive store updates on a clock outside that chain
 ([Diagnostics](15-diagnostics.md)).
 
-**Frames stay isolated.** State at an address is per-frame by construction.
-Mount the same app in two frames, and their dropdowns cannot interfere. A
-module-level atom is shared by every frame that ever mounts the view — the
-cross-frame leak the frame model exists to delete.
+**Frames remain isolated.** App-db is per-frame. A module-level atom is shared
+by every frame that mounts the code, which defeats frame isolation.
 
-A host may still hold state — React state, DOM state, a canvas — under one
-condition: the state is never an invisible duplicate of an application fact.
-Each legitimate home below is a place for one kind of UI state. If a piece of
-state does not fit one of them, the state goes to app-db.
+A host may still keep React state, DOM state, canvas state, or an SDK handle.
+It must not keep an invisible duplicate of an application fact.
 
-## Valve 1: an explicit app-db address
+## 1. Application-visible state: app-db
 
-This is the default for everything application-visible: open, expanded,
-selected, the chosen tab. The usual objection is ceremony — an event, a
-subscription, and a keypath for "is this open?". The cost is per *concern*,
-not per instance. One parametric subscription and one named event serve every
-instance:
+Use an explicit app-db address for state that affects what the application can
+do or what another part of the application can observe: open, expanded,
+selected, or the active tab.
+
+One parameterised event and subscription can serve every instance:
 
 ```clojure
 (ns app.panels
@@ -53,7 +46,8 @@ instance:
             [re-frame.hicasso :as h]))
 
 (rf/reg-sub :panel/expanded?
-  (fn [db [_ panel-id]] (get-in db [:ui :panel/expanded panel-id] false)))
+  (fn [db [_ panel-id]]
+    (get-in db [:ui :panel/expanded panel-id] false)))
 
 (rf/reg-event :panel/toggled
   (fn [{:keys [db]} [_ panel-id]]
@@ -62,52 +56,51 @@ instance:
 (h/defview panel [{:keys [id title]}]
   [:section
    [:h3 {:on-click [:panel/toggled id]} title]
-   (when (h/sub [:panel/expanded? id]) [panel-body {:id id}])])
+   (when (h/sub [:panel/expanded? id])
+     [panel-body {:id id}])])
 ```
 
-You write these lines once. A hundred panels add no further cost. The address
-also gives what a local cell cannot: the state time-travels, Xray shows it,
-each frame isolates it, and a test sets it with a `:db` write.
+A hundred panels reuse the same event and subscription. The address gives you
+replay, frame isolation, Xray visibility, and direct test setup.
 
-Write **named events, not a generic setter**. `[:panel/toggled id]` names
-what happened. A generic `[:ui/set path value]` turns the event log into a
-diff stream that nobody can read. When a write starts to *mean* something —
-an effect fires, or other state reacts — the named event is already the
-correct shape.
+Prefer named events such as `[:panel/toggled id]` over a generic
+`[:ui/set path value]`. The named event records what happened and leaves room
+for effects or related state changes later.
 
-## Valve 2: drafts and control state — the forms module
+## 2. Drafts and form state: the forms module
 
-A draft is not private. Validation reads it, the submit gate derives from it,
-dirty-leave navigation asks about it, and replay replays it. Anything a user
-composes that the application must judge is **application-visible**, so it
-lives at a re-frame2 address. Normally the address goes through
-`re-frame.hicasso.forms`. The module packages the draft/baseline/touched/errors
-shape at an address you give it, and derives validation gating and mutation
-status as ordinary subscriptions ([Forms](05-forms.md)).
+A draft is application-visible when validation, submit gating, dirty-leave
+logic, or another view needs it. Store it at an app-db address, usually through
+`re-frame.hicasso.forms`.
 
-You do not need the module to obey the valve. A concern-named address and two
-events — `[:search/draft-changed q]`, `[:search/cleared]` — make the same
-decision at hand-rolled scale. The module earns its place when the shape
-grows: touched tracking, submit-attempt gating, settle-merge against late
-server replies. Either way the state is at an address, and no second store
-appears.
+The forms module packages draft, baseline, touched state, validation gates,
+and mutation status around an address you supply
+([Forms](05-forms.md)). For a smaller concern, ordinary events and an app-db
+slice are enough:
 
-## Valve 3: host-private mechanics — inside a native host
+```clojure
+[:search/draft-changed q]
+[:search/cleared]
+```
 
-Some state exists only to *operate a widget*: measured geometry, an in-flight
-drag position, composition buffers, focus mechanics inside a composite
-control, a chart library's instance handle. This state updates at high rate,
-and nobody outside the widget can act on it. A route through app-db would
-spend an event, a subscription pass, and a paint per pointer-move on a fact
-with no meaning.
+The important part is that the draft has one address and no local duplicate.
 
-That state stays **inside a native host** — a named native component (or a
-`defhost` edge) where ordinary React state and hooks are the correct tool
-([The native tier](10-native-tier.md), [Interop](09-interop.md)). The host is
-diagnostic-opaque by contract. Xray names and times the island's view. It
-labels the inside `opaque`; it does not pretend to know it.
+## 3. Host-private mechanics: native state
 
-The rule at the edge: *motion stays inside; meaning leaves as one event.*
+Some state exists only to operate a widget:
+
+- measured geometry
+- an in-flight drag position
+- composition buffers
+- internal focus mechanics
+- a chart or map SDK handle
+
+This state may update every pointer move or animation frame, and nothing
+outside the widget needs it. Keep it inside a named native component or a
+declared host ([The native tier](10-native-tier.md),
+[Interop](09-interop.md)).
+
+The rule at the edge is: **motion stays inside; meaning leaves as one event.**
 
 ```clojure
 (ns app.board.drag
@@ -117,200 +110,188 @@ The rule at the edge: *motion stays inside; meaning leaves as one event.*
 
 (n/defcomponent drag-surface
   [^js props]
-  (let [[xy set-xy] (react/useState nil)]        ; host-private: in-flight only
+  (let [[xy set-xy] (react/useState nil)]
     (n/$ :div
          {:class "card"
-          :style (when xy #js {:translate (str (aget xy 0) "px " (aget xy 1) "px")})
-          :on-pointer-move (fn [e]
-                             (when (pos? (.-buttons e))
-                               (set-xy #js [(.-clientX e) (.-clientY e)])))
-          :on-pointer-up   (fn [_]
-                             (when xy
-                               ((.-onDrop props) (js/Math.round (/ (aget xy 0) 240))))
-                             (set-xy nil))}
+          :style (when xy
+                   #js {:translate (str (aget xy 0) "px "
+                                        (aget xy 1) "px")})
+          :on-pointer-move
+          (fn [e]
+            (when (pos? (.-buttons e))
+              (set-xy #js [(.-clientX e) (.-clientY e)])))
+
+          :on-pointer-up
+          (fn [_]
+            (when xy
+              ((.-onDrop props)
+               (js/Math.round (/ (aget xy 0) 240))))
+            (set-xy nil))}
          (.-label props))))
 
 (h/defview board-card [{:keys [id]}]
   (let [title (h/sub [:card/title id])]
-    ;; app-db hears one event per drag; the high-rate stream never leaves the host.
-    (n/$ drag-surface {:label   title
-                       :on-drop (h/event [col] [:card/dropped id col])})))
+    (n/$ drag-surface
+         {:label   title
+          :on-drop (h/event [col] [:card/dropped id col])})))
 ```
 
-The drop is semantic, so it commits. `h/event` captures the frame and
-dispatches `[:card/dropped id col]` when the host calls the callback. The end
-of a drag reaches app-db. The moves of a drag do not.
+Pointer movement remains local React state. The completed drop is an
+application event, so it enters app-db once.
 
-One rule on views: a `defview` body is a real React function component, so a
-hook physically runs there. Dynamic composition makes hook order your
-problem, and a hook body falls out of headless testing. Hook mechanics belong
-in a separately defined native component, where hook order cannot depend on
-your data paths.
+Hooks belong in the separately defined native component. A `defview` body may
+branch and loop dynamically, so putting hooks there makes hook order depend on
+data and moves the body outside Hicasso's headless model.
 
-## Valve 4: DOM-owned state — a declared interop choice
+## 4. Browser-owned state
 
-Sometimes the platform already tracks the fact. Then the correct amount of
-application state is none.
+Sometimes the platform already owns the fact. Do not mirror it in app-db
+unless the application needs a semantic copy.
 
-- **CSS.** Hover, focus-visible, active, `:has()`, `<details>` disclosure. If
-  the platform tracks the fact, a copy in app-db costs a re-render per pointer
-  move for a fact the browser already has.
-- **Uncontrolled inputs.** A spreadsheet cell with `:default-value` and
-  commit-on-blur leaves the mid-edit text to the DOM by design
-  ([Controlled inputs](04-controlled-inputs.md)). The price is explicit:
-  app-db cannot see the draft, so nothing else can react to the draft, and
-  tests must go through the DOM.
-- **Platform toggles.** A presentational hint can be a bare `:popover "auto"`
-  panel toggled by `:popovertarget` — zero application state
-  ([Overlays and focus](12-overlays-and-focus.md)).
+**CSS** should own hover, focus-visible, active state, `:has()`, and ordinary
+`<details>` disclosure.
 
-The condition is the word *declared*. DOM ownership is a visible, priced
-choice at the site — never a hidden substitute for application state. When
-anything else needs the fact (validation needs the draft, a test needs the
-open flag), the fact moves up a valve.
+**Uncontrolled inputs** may own scratch text through `:default-value`, with a
+commit on blur. The tradeoff is explicit: app-db, tests, and tools cannot see
+mid-edit text ([Controlled inputs](04-controlled-inputs.md)).
 
-## Valve 5: presence — what is still painted
+**Platform controls** may own a presentational toggle, such as a native
+popover triggered by `:popovertarget` ([Overlays and focus](12-overlays-and-focus.md)).
 
-App-db cannot hold one thing. A dismissed toast is gone from app-db, which is
-correct — but the toast should fade for 300 ms, so the node must outlive the
-data. App-db holds what is *true*; this valve holds what is still *painted*.
-`re-frame.hicasso.motion` owns that gap. Its `presence` view retains keyed
-children that have left the source data, for `:timeout-ms`. Each child
-declares its exit appearance as data, in its own attribute map:
+DOM ownership is a local design choice, not a hidden replacement for
+application state. When validation, another view, routing, or testing needs the
+fact, move it to app-db.
+
+## 5. Exit presence: what is still painted
+
+App-db records what is true. A dismissed toast should disappear from app-db
+immediately, but its DOM node may need another 300 ms to finish an exit
+animation. `re-frame.hicasso.motion` owns that gap.
 
 ```clojure
 ;; (:require [re-frame.hicasso.motion :as motion])
 (h/defview toast-tray [_]
   [motion/presence {:timeout-ms 300}
    (for [t (h/sub [:toasts/visible])]
-     [:div.toast {:key (:id t)
-                  ::motion/unmounting {:class "toast toast--exit"
-                                       :inert true :aria-hidden true}}
+     [:div.toast
+      {:key (:id t)
+       ::motion/unmounting
+       {:class       "toast toast--exit"
+        :inert       true
+        :aria-hidden true}}
       (:message t)])])
 ```
 
-The a11y attributes are one map, not three conditionals. A retained node is
-still in the document, and it can take focus and clicks until you say
-otherwise. So `:inert`, `:aria-hidden`, and the exit class arrive together,
-in the phase where they belong. When the child is a view instead of a node,
-presence cannot merge attributes into an opaque head. Instead the view
-receives `:rf/phase` (`:mounting` / `:present` / `:unmounting`) as an
-ordinary prop and branches on it. A test can pass the prop directly, with no
-timers and no browser.
+The exit class, `:inert`, and `:aria-hidden` arrive together. An exiting node
+is still in the document until the timeout ends, so it must stop accepting
+focus and interaction explicitly.
 
-Rules that keep presence honest:
+When the child is a view, presence cannot merge attributes into the opaque
+view head. The view instead receives `:rf/phase` with one of
+`:mounting`, `:present`, or `:unmounting`, and branches on that ordinary prop.
+Tests can pass the phase directly without timers.
 
-- `:timeout-ms` is mandatory. It is a hard terminal bound on a clock, never a
-  `transitionend` listener. The node leaves on time even when your CSS did
-  not run, was disabled, or was overridden by `prefers-reduced-motion`.
-- Re-entry cancels exit. A returning key goes back to `:present` without a
-  remount. Order is frozen at first appearance, so an exiting child never
-  changes position.
-- Presence never dispatches an event. A node that remains on screen is not a
-  reason for app-db to keep the data.
+Presence follows these rules:
 
-Entrances rarely need presence. Animate on insertion (`@keyframes` on the
-class) or use `@starting-style`; neither can lose the first-paint race the
-way a `:mounting → :present` class flip can. `::motion/mounting` is for
-attributes that are *true during entry* — `:inert` until the element settles —
-not for a fade-in. Under SSR a presence-managed node hydrates born-present, so
-server HTML never carries entry-phase attributes
-([SSR and hydration](17-ssr-and-hydration.md)).
+- `:timeout-ms` is required and is the hard upper bound. Removal does not wait
+  for `transitionend`, so disabled or overridden CSS cannot strand the node.
+- Re-entry cancels exit. A returning key becomes `:present` without remounting.
+- Order is frozen at first appearance, so an exiting child does not move while
+  it leaves.
+- Presence does not dispatch an event or keep the removed data in app-db.
 
-## Where does X live?
+For entrances, prefer an insertion animation or `@starting-style`.
+`::motion/mounting` is for attributes that are true during entry, such as
+`:inert` until an element settles. Under SSR, a presence-managed server node
+hydrates as already present; the server HTML does not carry entry-phase
+attributes ([SSR and hydration](17-ssr-and-hydration.md)).
 
-| State | Home | Why |
-|---|---|---|
-| Dropdown open | App-db, explicit address (the [overlay module](12-overlays-and-focus.md) reconciles the platform to it) | It changes what the user can do next; tests and Xray need it |
-| Draft text in a field | App-db through the [forms module](05-forms.md) | Validation, submit gating, dirty-leave and replay all read it |
-| Drag position, mid-drag | Host-private, inside a native island | High-rate mechanics; only the widget cares. The drop dispatches one event |
-| Scroll offset | The DOM owns it; the [routing module](07-routing-and-navigation.md) restores it per route | Nobody re-renders per scrolled pixel. If the app cares ("read 80%"), commit thresholds as events |
-| Animation phase | CSS for the animation itself; `motion/presence` for leave-retention; host-private for rAF mechanics | App-db says what is true, not what is still painted |
-| Focus | The platform. One-shot focus intent as data — `:auto-focus`, [overlay focus conduct](12-overlays-and-focus.md) — never mirrored | A mirror of "what has focus" drifts from reality and re-renders per Tab |
-| Selected tab | App-db — or the route, when a reload should land on the same tab | Semantic; other views, tests and deep links care |
-| WebGL context, vendor handle | Host-private, inside its declared host, acquired and released at the edge ([Interop](09-interop.md)) | An object identity, not application data; unmount must release it |
+## Common state and its owner
 
-## Choosing the address
+| State | Owner | Reason |
+| --- | --- | --- |
+| Dropdown open | App-db; the overlay module reconciles the platform to it | It changes what the user can do, and tests and Xray need it |
+| Field draft | App-db through the forms module | Validation, submit gating, dirty-leave, and replay read it |
+| Drag position during a drag | Native host state | High-rate mechanics; dispatch the completed drop once |
+| Scroll offset | DOM; routing restores it per route | Do not re-render for every pixel. Commit meaningful thresholds as events when needed |
+| Animation phase | CSS for animation; `motion/presence` for exit retention; host state for rAF mechanics | App-db records truth, not what is still painted |
+| Focus | Browser focus, changed through one-shot focus actions | A mirrored “focused element” value drifts and would update on every Tab |
+| Selected tab | App-db, or routing when it should survive reload | Other views, tests, or deep links care |
+| WebGL context or SDK handle | Declared host or native component | It is an object identity with an attach/teardown lifecycle, not application data |
 
-Valves 1 and 2 need an instance key — the `panel-id` above — so a hundred
-panels do not share one `expanded?`. Hicasso creates no identity for you.
-React's `useId` does not fit: its ids are render-order counters, they do not
-survive a remount, and address-resident state cannot tolerate that loss. The
-key is authored data: a keyword, a string, a number, or a flat vector of
-those.
+## Choose a stable instance address
 
-1. **Use domain ids first; qualify by entity when entities can collide.**
-   Order 42 and invoice 42 that both land on `[:ui ::expanded 42]` share one
-   entry. Qualify them: `[:order/id 42]`, `[:invoice/id 42]`.
-2. **Key placement-like concerns by placement; key value-like concerns by
-   entity.** A draft of order 42 is value-like: both panes share one draft.
-   `expanded?` is placement-like: the detail pane can collapse while the list
-   row stays open.
-3. **Nest by extension of the parent's key.** A widget inside a widget adds
-   to the parent's key — `[panel-id :filter]` — as plain data, with no
-   helper.
-4. **A good React `:key` is a good instance key.** The key derives from your
-   data, stays stable across renders, and is unique among siblings. The key
-   is also deterministic under SSR, where server and client must compute the
-   same key from the same snapshot
-   ([SSR and hydration](17-ssr-and-hydration.md)).
+Application-visible and form state need an instance key. Hicasso does not
+invent one. React's `useId` is unsuitable because it is tied to render order
+and does not provide a durable app-db address.
 
-## Where is `:on-mount`?
+Use authored data: a keyword, string, number, or flat vector of those values.
 
-There is no `:on-mount`, and no `:on-unmount` either. Four jobs make people
-search for one. Each job has a home:
+1. **Start with a domain id.** Qualify ids when different entity types can
+   collide: `[:order/id 42]` and `[:invoice/id 42]`.
+2. **Key placement state by placement and value state by entity.** Two panes
+   may share one order draft while keeping separate expanded/collapsed state.
+3. **Extend a parent key for nested instances.** `[panel-id :filter]` is often
+   enough.
+4. **Apply the same stability test as a React `:key`.** It must be derived from
+   data, stable across renders, unique in its scope, and deterministic under
+   SSR.
 
-| Job | Home |
-|---|---|
-| Load the data this screen needs | The route declares it — [Routing](07-routing-and-navigation.md), [Async resources](08-async-resources.md). This also closes the click-away race: a route-owned read has an owner to release it |
-| Run something once at startup | `:initial-events` — ordinary events seeding app-db before first paint ([Installation](installation.md)) |
-| Animate an entrance or exit | Valve 5. Insertion animation or `@starting-style` for enter; presence for exit |
-| Drive a real DOM node or third-party SDK | The host edge: a callback `:ref` or a declared host ([Interop](09-interop.md)) |
+## There is no `:on-mount`
 
-## When app-db is the wrong home
+Hicasso has no `:on-mount` or `:on-unmount`. The job you are trying to perform
+already has a more specific owner:
 
-App-db is the wrong home in three cases:
+| Job | Use |
+| --- | --- |
+| Load data for a screen | Route `:resources` or a demand-driven resource ([Routing](07-routing-and-navigation.md), [Async resources](08-async-resources.md)) |
+| Run startup work once | `:initial-events`, before first paint ([Installation](installation.md)) |
+| Animate an entrance or exit | CSS or `motion/presence` |
+| Attach to a DOM node or SDK | A callback ref or declared host ([Interop](09-interop.md)) |
 
-- The platform already knows the fact (hover, focus, scroll — valve 4).
-- The rate is too high to carry meaning (drag, resize, rAF — valve 3).
-- Nobody else can care about it (a measured offset, an SDK handle — valve 3).
+## When app-db is the wrong place
 
-Everything else is the application's business, and the application has
-exactly one memory.
+Do not put a fact in app-db when:
+
+- the browser already owns it, such as hover, focus, or raw scroll position;
+- it changes too quickly to be a useful application event, such as pointer
+  movement or per-frame geometry;
+- nobody outside one widget can observe or act on it, such as an SDK handle.
+
+Everything else is application state and should have one app-db address.
 
 ```clojure
-;; Don't — an atom in a view. The body re-runs, retries, and is abandoned;
-;; the atom is recreated on each run, and no atom re-renders anything here.
+;; Don't: this atom is recreated whenever the body runs, and Hicasso does not
+;; track it as reactive state.
 (h/defview broken-panel [{:keys [id title]}]
-  (let [expanded? (atom false)]                    ; reset on every render
+  (let [expanded? (atom false)]
     [:section
-     [:h3 {:on-click (fn [_] (swap! expanded? not))} title]  ; repaints nothing
-     (when @expanded? [panel-body {:id id}])]))
+     [:h3 {:on-click (fn [_] (swap! expanded? not))} title]
+     (when @expanded?
+       [panel-body {:id id}])]))
 
-;; Don't — app-db as a motion channel: an event, a sub pass and a paint
-;; per pointer-move, and the event log becomes a high-rate diff stream.
-:on-pointer-move (h/event [e] [:card/drag-moved id (.-clientX e) (.-clientY e)])
+;; Don't: one event, subscription pass, and paint for every pointer move.
+:on-pointer-move
+(h/event [e] [:card/drag-moved id (.-clientX e) (.-clientY e)])
 ```
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
-|---|---|---|
-| Reaching for `useState` / `r/atom` to hold "is this open?" | Application-visible state headed for a private store | An app-db address (valve 1), or the overlay module's reconciled flag |
-| A view's atom resets every render, or never repaints | Bodies re-run and are abandoned; render-created cells are recreated, and nothing tracks them | Move the fact to its valve; if it is genuinely widget mechanics, move it into a native host |
-| Searching for `:on-mount`, `componentDidMount`, a mount `useEffect` | There is none | Name the job and use its home — the table above |
-| Every panel in a list opens at once | One shared address | Key the address per instance — [Choosing the address](#choosing-the-address) |
-| Typing or dragging lags; Xray shows an event per pointer-move | High-rate mechanics routed through app-db | Keep motion host-private; dispatch only the semantic commit |
-| An exit override on a view head raises `:rf.error/hicasso-presence-override-on-a-view` | Presence merges attribute overrides into nodes it can see; a view head is opaque | The child view receives `:rf/phase` — branch on it |
-| A fading toast still takes focus and clicks | The exit override lacks the a11y pair | `::motion/unmounting` carries `:inert` and `:aria-hidden` alongside the class |
-| A dismissed item vanishes with no exit animation | The node left with the data | `motion/presence` with `:timeout-ms` at least as long as the transition |
-| app-db is filling with `:ui` entries | Expected — the right home | Namespace the keys; exclude the tier from persistence by convention |
-| A test simulates clicks to open a dropdown | The state is data | Seed the address with a `:db` write ([Testing](14-testing.md)) |
+| --- | --- | --- |
+| You are reaching for `useState` or `r/atom` to hold “is this open?” | Application-visible state is moving into a private store | Give it an app-db address, or use the overlay module's reconciled open flag |
+| A view-local atom resets or never repaints the view | The body can re-run or be abandoned, and Hicasso does not subscribe to the atom | Move the fact to app-db; move genuine widget mechanics into a native component |
+| You are looking for `:on-mount`, `componentDidMount`, or a mount effect | Hicasso has no generic lifecycle hook | Identify the job and use the owner in the table above |
+| Every panel opens at once | All instances share one address | Include a stable instance key in the address |
+| Typing or dragging lags and Xray shows an event per pointer move | High-rate mechanics were routed through app-db | Keep motion inside the host and dispatch only the semantic result |
+| Exit override on a view raises `:rf.error/hicasso-presence-override-on-a-view` | Presence can merge attributes into visible nodes, not opaque view heads | Branch on the child's `:rf/phase` prop |
+| A fading toast still accepts focus or clicks | The unmounting override changes appearance only | Add `:inert true` and `:aria-hidden true` with the exit class |
+| A dismissed item vanishes immediately | The node left with the data | Wrap keyed children in `motion/presence` and set `:timeout-ms` at least as long as the exit transition |
+| app-db accumulates many `:ui` entries | Application-visible UI state is correctly stored there | Namespace the slice and exclude it from persistence when appropriate |
+| A test simulates clicks only to open a dropdown | The open flag is data | Seed the address directly in the test ([Testing](14-testing.md)) |
 
-??? info "If you're coming from Reagent"
-    `r/atom` was necessary against machinery Hicasso does not have. In the
-    idiomatic corpus this model was distilled from — 85 files, ~140 views —
-    the count of view-local reactive cells is zero. The machinery
-    manufactured the demand. The valves absorb what was real: addresses for
-    meaning, forms for drafts, hosts for mechanics, the DOM for what it
-    already owns, motion for what still fades.
+??? info "Coming from Reagent"
+    `r/atom` solved a view-local reactivity problem that Hicasso does not
+    create. Put semantic state at addresses, drafts in the forms model,
+    mechanics in hosts, browser-owned facts in the DOM, and exit retention in
+    `motion/presence`.

--- a/docs/design/hicasso/draft-guide/12-overlays-and-focus.md
+++ b/docs/design/hicasso/draft-guide/12-overlays-and-focus.md
@@ -1,17 +1,21 @@
 # Overlays and focus
 
-You need a filter menu anchored to its button, or a delete confirmation that
-blocks the page behind it. Hand-rolled portals, z-index ladders, document
-click listeners, and focus traps leak and break in predictable ways.
+A filter menu needs to stay anchored to its button. A confirmation dialog
+needs to block the page behind it and restore focus when it closes. Building
+that from portals, document listeners, z-index rules, and a custom focus trap
+creates several independent failure modes.
 
-`re-frame.hicasso.overlay` gives two primitives — [popover](glossary.md#overlay)
-and modal — that mount on the browser's native top layer (`popover` /
-`<dialog>`). The browser handles stacking, light-dismiss, and focus. Your app
-stores one open flag and handles one dismiss event.
+`re-frame.hicasso.overlay` provides two primitives:
 
-## An anchored popover
+- `overlay/popover` for anchored, light-dismissable UI
+- `overlay/modal` for blocking dialogs
 
-The open flag is ordinary app-db state
+Both use the browser's native top layer. Your application still owns the open
+flag and the dismiss event.
+
+## Anchored popovers
+
+Store the open flag in app-db
 ([Ephemeral state](11-ephemeral-state.md)):
 
 ```clojure
@@ -21,7 +25,8 @@ The open flag is ordinary app-db state
             [re-frame.hicasso.overlay :as overlay]))
 
 (rf/reg-sub :filter-menu/open?
-  (fn [db [_ id]] (get-in db [:ui :filter-menu/open id] false)))
+  (fn [db [_ id]]
+    (get-in db [:ui :filter-menu/open id] false)))
 
 (rf/reg-event :filter-menu/toggled
   (fn [{:keys [db]} [_ id]]
@@ -32,53 +37,58 @@ The open flag is ordinary app-db state
     {:db (assoc-in db [:ui :filter-menu/open id] false)}))
 
 (h/defview filter-menu [{:keys [id]}]
-  (let [open? (h/sub [:filter-menu/open? id])]
+  (let [open? (h/sub [:filter-menu/open? id])
+        trigger-id (str "filter-" id "-trigger")]
     [:div.filter
-     [:button {:id (str "filter-" id "-trigger")
+     [:button {:id trigger-id
                :aria-haspopup "menu"
                :aria-expanded open?
                :on-click [:filter-menu/toggled id]}
       "Filter"]
-     [overlay/popover {:open?      open?
-                       :on-dismiss [:filter-menu/dismissed id]
-                       :anchor     (str "filter-" id "-trigger")
-                       :placement  :bottom-start}
+
+     [overlay/popover
+      {:open?      open?
+       :on-dismiss [:filter-menu/dismissed id]
+       :anchor     trigger-id
+       :placement  :bottom-start}
       [:ul {:role "menu"}
-       [:li [:button {:role "menuitem"
-                      :on-click [:filter/applied id :unread]}
-             "Unread"]]
-       [:li [:button {:role "menuitem"
-                      :on-click [:filter/applied id :flagged]}
-             "Flagged"]]]]]))
+       [:li
+        [:button {:role "menuitem"
+                  :on-click [:filter/applied id :unread]}
+         "Unread"]]
+       [:li
+        [:button {:role "menuitem"
+                  :on-click [:filter/applied id :flagged]}
+         "Flagged"]]]]]))
 ```
 
-What those options do:
+The options have direct responsibilities:
 
-- **`:open?`** — while false, the popover renders nothing: no DOM node, no
-  listener, and the body's subscriptions do not run. When true, the panel
-  mounts on the top layer, above every stacking context. Ancestor
-  `overflow: hidden` and `transform` do not clip it. There is no
-  [portal](glossary.md#portal) and no z-index.
-- **`:on-dismiss`** — outside click and Esc are the popover's native
-  light-dismiss. The browser closes the panel and the module dispatches your
-  event. Your handler must write the flag false. If the handler leaves the
-  flag true, the panel stays open — app-db is the owner.
-- **`:anchor`** — DOM id of the trigger, unique per instance. The module
-  places the panel before first paint. `:placement` uses compass words such
-  as `:bottom-start`, `:bottom-end`, `:top-start`, and `:right`. Where the
-  browser supports CSS anchor positioning, tracking is CSS; otherwise the
-  module re-places on open and resize.
-- **The body stays in the tree.** It renders under the same frame as its
-  anchor, so subscriptions resolve as they do in-flow.
+- **`:open?`** controls whether the panel exists. While false, there is no DOM
+  node, listener, or body subscription.
+- **`:on-dismiss`** is dispatched for native light-dismiss, including outside
+  click and Escape. The handler must write the open flag false. App-db remains
+  the source of truth.
+- **`:anchor`** is the unique DOM id of the trigger. The module positions the
+  panel before first paint.
+- **`:placement`** accepts positions such as `:bottom-start`, `:bottom-end`,
+  `:top-start`, and `:right`.
 
-## A modal
+The panel remains in the same React and re-frame2 tree as its trigger. It uses
+the same frame and subscriptions. The top layer changes paint order, so
+ancestor `overflow`, transforms, and stacking contexts do not clip it.
 
-A [modal](glossary.md#overlay) has the same shape with stronger focus behaviour.
-`overlay/modal` drives a native `<dialog>` through `showModal`:
+Where CSS anchor positioning is available, the browser tracks the anchor.
+Otherwise the module recalculates on open and resize.
+
+## Modals
+
+`overlay/modal` uses a native `<dialog>` and calls `showModal`:
 
 ```clojure
 (rf/reg-sub :invoice/confirm-delete?
-  (fn [db [_ id]] (get-in db [:ui :invoice/confirm-delete id] false)))
+  (fn [db [_ id]]
+    (get-in db [:ui :invoice/confirm-delete id] false)))
 
 (rf/reg-event :invoice/delete-cancelled
   (fn [{:keys [db]} [_ id]]
@@ -90,77 +100,88 @@ A [modal](glossary.md#overlay) has the same shape with stronger focus behaviour.
      :fx [[:dispatch [:invoice/delete id]]]}))
 
 (h/defview confirm-delete [{:keys [invoice-id]}]
-  [overlay/modal {:open?      (h/sub [:invoice/confirm-delete? invoice-id])
-                  :on-dismiss [:invoice/delete-cancelled invoice-id]
-                  :label      "Confirm deletion"}
+  [overlay/modal
+   {:open?      (h/sub [:invoice/confirm-delete? invoice-id])
+    :on-dismiss [:invoice/delete-cancelled invoice-id]
+    :label      "Confirm deletion"}
    [:h2 "Delete this invoice?"]
    [:p "This cannot be undone."]
    [:footer
-    [:button {:on-click [:invoice/delete-cancelled invoice-id]} "Keep it"]
-    [:button.danger {:auto-focus true
-                     :on-click [:invoice/delete-confirmed invoice-id]}
+    [:button {:on-click [:invoice/delete-cancelled invoice-id]}
+     "Keep it"]
+    [:button.danger
+     {:auto-focus true
+      :on-click [:invoice/delete-confirmed invoice-id]}
      "Delete"]]])
 ```
 
-- The background is inert: focus cannot Tab out, clicks do not land, and
-  assistive technology skips it. The browser owns the trap.
-- Esc dispatches `:on-dismiss`. Backdrop click does too only when you pass
-  `:light-dismiss? true`. The default is off so a destructive confirmation
-  does not close on a stray click.
-- **`:label`** is the dialog's accessible name.
-- Style the backdrop with `::backdrop` in CSS
-  ([Theming](13-theming-and-i18n.md)).
+A modal gives you the platform's modal behaviour:
 
-## Focus
+- the page behind it is inert;
+- focus cannot Tab outside it;
+- Escape dispatches `:on-dismiss`;
+- backdrop click dispatches `:on-dismiss` only with
+  `:light-dismiss? true`;
+- `:label` supplies the accessible name.
 
-Focus is browser state. Do not mirror "what has focus" into app-db
-([Ephemeral state](11-ephemeral-state.md)). Express intent once per open:
+Light-dismiss defaults to false for modals so a destructive confirmation does
+not close on a stray backdrop click. Style the native backdrop with
+`::backdrop` CSS ([Theming and internationalisation](13-theming-and-i18n.md)).
 
-- **Mount focus.** Put `:auto-focus true` on the element that should receive
-  focus when the overlay opens — the Delete button above, or a search field
-  in a command palette. The attribute fires when the overlay opens, not again
-  on re-render, and it is inert markup on the server. A modal with no
-  `:auto-focus` focuses the dialog itself. A popover leaves focus on the
-  trigger (menus and comboboxes usually operate with
-  `:aria-activedescendant`, not focus moves).
-- **Restore on close.** Both primitives return focus to the element that had
-  it at open — on dismiss, Esc, and programmatic close. You write nothing for
-  restore.
+## Focus behaviour
 
-## Nesting
+Focus belongs to the browser. Do not mirror the currently focused element in
+app-db.
 
-A popover can sit inside a modal, and a submenu inside a menu. The native top
-layer is a stack, so nesting is last-in-first-out. Esc closes only the
-innermost open overlay. An outside click on an inner popover light-dismisses
-that popover and leaves the modal under it alone.
+**Initial focus.** Put `:auto-focus true` on the control that should receive
+focus when the overlay opens. The attribute is applied once per open, not on
+every re-render. It is inert in server-rendered markup. A modal without an
+autofocus target focuses the dialog itself. A popover normally leaves focus on
+its trigger; menus and comboboxes can use `:aria-activedescendant` instead of
+moving DOM focus.
 
-Use one address and one `:on-dismiss` per overlay. If two overlays share one
-dismiss event, you rebuild the problem the stack solves.
+**Focus restoration.** When an overlay closes through Escape, light-dismiss,
+or an app-db change, focus returns to the element that had focus when it
+opened. You do not need a separate restore handler.
 
-## Cost while closed
+## Nested overlays
 
-A closed overlay costs nothing:
+The native top layer is ordered last-in, first-out. A popover can open inside a
+modal, and a submenu can open from another menu.
 
-- no DOM node (client or server output)
-- no listener (light-dismiss exists only while open)
-- no subscriptions (the body is not mounted)
-- clean teardown: unmount of a view whose overlay is open closes it, restores
-  focus, and leaves no residue
+- Escape closes only the innermost open overlay.
+- Light-dismiss of an inner popover leaves the modal underneath it open.
+- Each overlay should have its own app-db address and `:on-dismiss` event.
 
-A table of five hundred rows, each with a closed row-menu, is as heavy as the
-same table without menus. You pay only for the open one.
+Sharing one flag or one dismiss event across layers throws away the stack
+semantics the platform already provides.
 
-## Compose a dropdown from the popover
+## Closed overlays have no runtime body
 
-Dropdowns, comboboxes, and toggletips are not separate primitives. Each is a
-popover plus your own events and subs. Single-select with keyboard support:
+When an overlay is closed, it has:
+
+- no DOM node;
+- no light-dismiss listener;
+- no subscriptions from its body;
+- no server output.
+
+Unmounting a view while its overlay is open closes the layer, restores focus
+when possible, and cleans up its listeners. Five hundred closed row menus do
+not create five hundred active overlay bodies.
+
+## Build a dropdown from a popover
+
+A single-select dropdown is a popover plus application events and state. It
+does not require another overlay primitive.
 
 ```clojure
 (rf/reg-sub :combo/open?
-  (fn [db [_ id]] (get-in db [:ui :combo id :open?] false)))
+  (fn [db [_ id]]
+    (get-in db [:ui :combo id :open?] false)))
 
 (rf/reg-sub :combo/active
-  (fn [db [_ id]] (get-in db [:ui :combo id :active])))
+  (fn [db [_ id]]
+    (get-in db [:ui :combo id :active])))
 
 (rf/reg-event :combo/toggled
   (fn [{:keys [db]} [_ id]]
@@ -174,7 +195,10 @@ popover plus your own events and subs. Single-select with keyboard support:
   (fn [{:keys [db]} [_ id step values]]
     (let [at   (get-in db [:ui :combo id :active])
           i    (get (zipmap values (range)) at -1)
-          next (nth values (-> (+ i step) (max 0) (min (dec (count values)))))]
+          next (nth values
+                    (-> (+ i step)
+                        (max 0)
+                        (min (dec (count values)))))]
       {:db (-> db
                (assoc-in [:ui :combo id :open?] true)
                (assoc-in [:ui :combo id :active] next))})))
@@ -183,129 +207,143 @@ popover plus your own events and subs. Single-select with keyboard support:
   (fn [{:keys [db]} [_ id on-commit]]
     (let [{:keys [open? active]} (get-in db [:ui :combo id])]
       (cond-> {:db (assoc-in db [:ui :combo id :open?] false)}
-        (and open? active) (assoc :fx [[:dispatch (conj on-commit active)]])))))
+        (and open? active)
+        (assoc :fx [[:dispatch (conj on-commit active)]])))))
 
 (rf/reg-event :combo/selected
   (fn [{:keys [db]} [_ id on-commit value]]
     {:db (assoc-in db [:ui :combo id :open?] false)
      :fx [[:dispatch (conj on-commit value)]]}))
 
-(h/defview select-dropdown [{:keys [id items value on-commit placeholder]}]
-  (let [open?  (h/sub [:combo/open? id])
-        active (h/sub [:combo/active id])
-        values (mapv :value items)
-        label  (or (some #(when (= value (:value %)) (:label %)) items)
-                   placeholder)]
+(h/defview select-dropdown
+  [{:keys [id items value on-commit placeholder]}]
+  (let [open?      (h/sub [:combo/open? id])
+        active     (h/sub [:combo/active id])
+        values     (mapv :value items)
+        trigger-id (str "combo-" id "-trigger")
+        option-id  (fn [v] (str "combo-" id "-opt-" v))
+        label      (or (some #(when (= value (:value %))
+                               (:label %))
+                             items)
+                       placeholder)]
     [:div.combo
-     [:button {:id (str "combo-" id "-trigger")
-               :aria-haspopup "listbox"
-               :aria-expanded open?
-               :aria-activedescendant (when (and open? active)
-                                        (str "combo-" id "-opt-" active))
-               :on-click    [:combo/toggled id]
-               :on-key-down {"ArrowDown" [::h/prevent [:combo/moved id 1 values]]
-                             "ArrowUp"   [::h/prevent [:combo/moved id -1 values]]
-                             "Enter"     [:combo/committed id on-commit]}}
+     [:button
+      {:id trigger-id
+       :aria-haspopup "listbox"
+       :aria-expanded open?
+       :aria-activedescendant
+       (when (and open? active)
+         (option-id active))
+       :on-click [:combo/toggled id]
+       :on-key-down
+       {"ArrowDown" [::h/prevent [:combo/moved id 1 values]]
+        "ArrowUp"   [::h/prevent [:combo/moved id -1 values]]
+        "Enter"     [:combo/committed id on-commit]}}
       label]
-     [overlay/popover {:open?      open?
-                       :on-dismiss [:combo/dismissed id]
-                       :anchor     (str "combo-" id "-trigger")
-                       :placement  :bottom-start}
+
+     [overlay/popover
+      {:open?      open?
+       :on-dismiss [:combo/dismissed id]
+       :anchor     trigger-id
+       :placement  :bottom-start}
       [:ul {:role "listbox"}
        (for [{:keys [value label]} items]
-         [:li {:key value
-               :id (str "combo-" id "-opt-" value)
-               :role "option"
-               :aria-selected (= value active)
-               :on-click [:combo/selected id on-commit value]}
+         [:li
+          {:key value
+           :id (option-id value)
+           :role "option"
+           :aria-selected (= value active)
+           :on-click [:combo/selected id on-commit value]}
           label])]]]))
 ```
 
-What is not here:
+Escape is not listed in the key map because the native popover owns Escape and
+dispatches `:on-dismiss`. Focus stays on the trigger. There is no document
+listener or portal.
 
-- no Escape row — Esc is light-dismiss; the platform closes and `:on-dismiss`
-  fires
-- no focus moves — focus stays on the trigger
-- no document listener
-- no portal
-
-Open / move / commit / dismiss is events over an address. A test can drive
-the policy headlessly; Xray shows it. A toggletip is the same popover with a
-single dismiss event and no listbox.
+The same event-and-address model works for a toggletip, command menu, or other
+popover-shaped control.
 
 ## When not to use the module
 
-Prefer the platform first. Use the module when open state must be application
-data, or when you need anchored placement and focus behaviour.
+Use the browser directly when application state does not need to observe the
+open flag.
 
-- **Hover tooltip** — CSS `:hover` / `:focus-visible` plus a positioned
-  pseudo-element or sibling. No app-db state; routing hover through any state
-  system re-renders on pointer move.
-- **Disclosure** — `<details>`. The browser tracks open.
-- **Presentational hint** — bare popover markup:
-  `[:button {:popovertarget "help-tip"} "?"]` with
-  `[:div {:id "help-tip" :popover "auto"} …]`. The browser does everything.
-  When a test or another view needs the flag, move up to `overlay/popover`.
+- **Hover tooltip:** CSS `:hover` and `:focus-visible`.
+- **Disclosure:** `<details>`.
+- **Presentational hint:** native popover attributes:
 
-## Don't build the old way
+  ```clojure
+  [:button {:popovertarget "help-tip"} "?"]
+  [:div {:id "help-tip" :popover "auto"} "Helpful text"]
+  ```
+
+Move to `overlay/popover` when another view, a test, routing, or application
+logic needs to read or control the open state.
+
+## Avoid the old overlay stack
 
 ```clojure
-;; Don't — pre-top-layer overlay: every classic defect in ten lines
+;; Don't: an in-flow panel plus a document listener.
 (h/defview old-menu [{:keys [id]}]
   (let [open? (h/sub [:menu/open? id])]
     [:div {:style {:position "relative"}}
      [:button {:on-click [:menu/toggled id]} "Menu"]
      (when open?
-       [:div.menu {:style {:position "fixed" :z-index 1020
-                           :top "48px" :left "12px"}}
+       [:div.menu
+        {:style {:position "fixed"
+                 :z-index 1020
+                 :top "48px"
+                 :left "12px"}}
         …])]))
-;; …plus a js/document click listener added on open, removed on close.
 ```
 
-Failures that follow:
-
-- Unmount while open leaks the document listener.
-- One ancestor `transform` turns `position: fixed` into the wrong position.
-- Z-index values hold only until the next library brings a larger one.
-
-The module removes the class: no listener to leak, no stacking context to lose
-to, no z-index contest.
+This design can leak its document listener on unmount, position against the
+wrong containing block after an ancestor transform, and lose a z-index contest
+to the next library. The top-layer primitives remove those failure classes.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| Panel clipped by `overflow: hidden` or stuck under a sticky header | Panel is an in-flow positioned div, not on the top layer | Render through `overlay/popover` |
-| Outside click closes the popover but it re-opens | Light-dismiss fired and `:on-dismiss` ran, but the handler never cleared the flag | Make the `:on-dismiss` handler set open to false |
-| Esc closes the whole stack at once | Layers share one dismiss event or one address | One address and one `:on-dismiss` per overlay |
-| Focus lands on `<body>` after close | Opener unmounted while the overlay was open — often unstable list keys remounting the trigger | Stable `:key` on the trigger's row |
-| `:rf.error/hicasso-overlay-anchor-missing` at open | `:anchor` names an id not in the document, or two instances share one id | Per-instance ids: `(str "combo-" id "-trigger")` |
-| Dialog shows but the page behind still scrolls and clicks | Hand-written `[:dialog {:open true}]` — the `open` attribute is the non-modal path | Use `overlay/modal`, which calls `showModal` |
-| Popover flashes at the wrong position for one frame | Something positions after mount | Pass `:anchor` / `:placement`; the module places before first paint |
-| Every row's menu opens at once | One shared address | Key the address per instance ([Ephemeral state](11-ephemeral-state.md#choosing-the-address)) |
+| Panel is clipped by `overflow: hidden` or appears under a sticky header | It is an ordinary positioned element, not a top-layer overlay | Render it through `overlay/popover` |
+| Outside click closes the platform popover, then it opens again | `:on-dismiss` ran but the handler left the app-db flag true | Set the open flag false in the dismiss handler |
+| Escape closes several layers at once | Layers share one address or one dismiss event | Give each overlay its own address and `:on-dismiss` |
+| Focus returns to `<body>` | The opener unmounted while the overlay was open, often because of an unstable list key | Use a stable `:key` for the trigger's row |
+| Opening raises `:rf.error/hicasso-overlay-anchor-missing` | `:anchor` names no element, or multiple instances reuse one id | Generate a unique, stable trigger id from the instance id |
+| Dialog is visible but the background still scrolls and receives clicks | A hand-written `<dialog open>` uses the non-modal path | Use `overlay/modal`, which calls `showModal` |
+| Popover flashes in the wrong place for one frame | Positioning happens after mount | Supply `:anchor` and `:placement`; the module positions before paint |
+| Every row menu opens together | All rows share one app-db address | Include the row id in the address ([Ephemeral state](11-ephemeral-state.md#choose-a-stable-instance-address)) |
 
-??? info "If you're coming from Reagent or UIx"
-    The usual stack is a portal + z-index + floating-ui + a document listener.
-    Here the panel never leaves its place in the tree — the top layer changes
-    paint order, not tree order. Frame context, subscriptions, SSR, and
-    hydration need no special path, and light-dismiss arrives without a
-    listener to leak. You still own the open flag and the meaning of a
-    selection.
+??? info "Coming from Reagent or UIx"
+    A portal, floating-positioning library, z-index policy, and document
+    listener are not required here. The top layer changes paint order without
+    removing the panel from its React or frame context. You still own the open
+    flag and the meaning of a selection.
 
 ## Advanced
 
-**Entry animation is pure CSS.** The panel mounts on open, so
-`@starting-style` (or a keyframe on the class) animates entry with no state
-and no timers:
+### Entry animation
+
+Entry animation can be pure CSS because the panel mounts when it opens:
 
 ```css
-.menu[popover]:popover-open { opacity: 1; transition: opacity 150ms; }
-@starting-style { .menu[popover]:popover-open { opacity: 0; } }
+.menu[popover]:popover-open {
+  opacity: 1;
+  transition: opacity 150ms;
+}
+
+@starting-style {
+  .menu[popover]:popover-open {
+    opacity: 0;
+  }
+}
 ```
 
-**Exit animation needs a clock.** On dismiss the panel normally leaves with
-the flag. To let a fade finish, pass `:exit-ms`. The module keeps the node on
-the top layer for that time (inert, `aria-hidden`) and removes it when the
-clock ends even if the CSS did not run. A re-open before the deadline cancels
-the exit; an unmount cancels the timer. State is closed the whole time; only
-the paint remains.
+### Exit animation
+
+Exit needs a clock because app-db is already closed while the old pixels are
+still fading. Pass `:exit-ms` to retain the layer for that duration. During the
+exit the module makes it inert and `aria-hidden`. The node leaves when the
+clock ends even if CSS did not run. Reopening cancels the exit; unmounting
+cancels the timer.

--- a/docs/design/hicasso/draft-guide/13-theming-and-i18n.md
+++ b/docs/design/hicasso/draft-guide/13-theming-and-i18n.md
@@ -1,14 +1,12 @@
-# Theming and i18n
+# Theming and internationalisation
 
-You want a dark mode and a second language. Many React stacks add a
-ThemeProvider, an i18n context, and a hook per consumer. Hicasso ships
-neither. Tokens live in CSS, strings are ordinary values, and the current
-theme or locale is one key in app-db that ordinary subscriptions read.
+Hicasso does not add a theme provider or an i18n context. CSS owns design
+tokens. Translated strings are ordinary values. The current theme and locale
+are app-db facts read through ordinary subscriptions.
 
-## Design tokens in CSS
+## Put design tokens in CSS
 
-The cascade already scopes styles: the nearest ancestor wins. Put tokens on
-`:root` and override them under a theme attribute:
+Use custom properties for tokens and override them under a theme attribute:
 
 ```css
 :root {
@@ -28,17 +26,16 @@ The cascade already scopes styles: the nearest ancestor wins. Put tokens on
 }
 ```
 
-The `--app-*` prefix is yours — name custom properties the way your
-stylesheet already does. `:root` is the light theme, so you do not need a
-`[data-theme="light"]` block.
+The `--app-*` prefix is only an example. Use your application's existing token
+names. Let `:root` be the default theme so the page has useful values before
+any user preference is loaded.
 
-A theme switch flips one attribute on one element. After the flip, the cascade
-restyles and React does no work for token changes.
+Changing one `data-theme` attribute lets the CSS cascade restyle the subtree.
+React does not need to re-render each token consumer.
 
-## The live theme switch
+## Render the selected theme
 
-The choice is application state: one subscription, one event, and one view
-that renders the attribute.
+The user's choice is application state:
 
 ```clojure
 (ns app.theme
@@ -46,7 +43,8 @@ that renders the attribute.
             [re-frame.hicasso :as h]))
 
 (rf/reg-sub :theme/current
-  (fn [db _query] (:theme/current db :light)))   ;; unset reads as :light
+  (fn [db _query]
+    (:theme/current db :light)))
 
 (rf/reg-event :theme/choose
   (fn [{:keys [db]} [_ theme]]
@@ -56,184 +54,206 @@ that renders the attribute.
   (into [:div {:data-theme (name (h/sub [:theme/current]))}]
         children))
 
-(h/defview theme-toggle [_props]
+(h/defview theme-toggle [_]
   (let [theme (h/sub [:theme/current])]
-    [:button {:on-click [:theme/choose (if (= theme :dark) :light :dark)]}
+    [:button
+     {:on-click [:theme/choose
+                 (if (= theme :dark) :light :dark)]}
      (if (= theme :dark) "Light mode" "Dark mode")]))
 
-;; At the frame root:
-[theme-scope {} [app {}]]
+[theme-scope {}
+ [app {}]]
 ```
 
-`children` arrives as a realized vector; that is why `into` splices it
+`children` is a realised vector, so `into` splices it into the wrapper
 ([Views and reads](02-views-and-reads.md)).
 
-**Put the default in the subscription, not in each reader.** A fresh app-db
-holds no choice, so a bare `(:theme/current db)` is `nil`, and `(name nil)`
-throws. From a root view that throw blanks the page. One extra argument makes
-the read total.
+Give the subscription a default. Without `(:theme/current db :light)`, a fresh
+app-db returns `nil`, and `(name nil)` throws from the root before the page can
+render.
 
-Placement rules:
+Place the scope carefully:
 
-- **Per frame, not per document.** A view renders its own element, so
-  `data-theme` goes on `theme-scope`'s `div`. Two frames on one page — one
-  light, one dark — work without further machinery.
-- **Keep a [`defview`](glossary.md#defview) head immediately below the scope.** The scope
-  re-renders on every switch. `[app {}]` below the scope bails out when its
-  props are unchanged ([Views and reads](02-views-and-reads.md)). A native-tag
-  subtree, or a view called as a plain function, re-runs with the scope.
-- **Keep the scope at the frame root, above any [`defhost`](glossary.md#defhost) crossing.** On
-  the server, a Client-only crossing renders its fallback instead of its
-  subtree. A scope below that crossing is missing from the response
+- **Theme per frame.** Render `data-theme` on an element inside the frame. Two
+  frames can then use different themes on one page.
+- **Keep a view boundary immediately underneath.** The scope re-renders when
+  the theme value changes. `[app {}]` can then skip its body when its own props
+  and reads are unchanged. An inlined native-tag subtree would re-run with the
+  scope.
+- **Place the scope above foreign crossings.** A Client-only host can replace
+  its subtree with a fallback on the server. A theme scope beneath that host
+  would be absent from the server response
   ([SSR and hydration](17-ssr-and-hydration.md)).
 
-To restore a remembered choice, dispatch `:theme/choose` from
-`:initial-events` so it lands before first paint
-([Installation](installation.md)). The default paints only when nobody has
-chosen.
+Restore a persisted choice through `:initial-events` so it reaches app-db
+before first paint ([Installation](installation.md)). The default applies only
+when no preference has been chosen.
 
-A class is the same bridge: `{:class (str "app app--" (name theme))}`.
-Density, brand, or compact mode are more keys driven the same way.
+A theme class works the same way:
 
-If you need zero render work on the switch, an `rf/reg-fx` can set the
-attribute on `documentElement`. The cost: the DOM no longer derives from
-app-db, so a rewind or restored snapshot shows the old theme. Render the fact
-unless you have measured a need for the imperative path.
+```clojure
+{:class (str "app app--" (name theme))}
+```
 
-To follow the OS with no user override, skip app-db entirely and use
-`@media (prefers-color-scheme: dark)`. Use app-db when the user picks, or when
-the pick must survive a reload.
+Density, brand, and compact-mode settings can use the same pattern.
 
-### Page chrome and the top layer
+When the user never overrides the operating-system preference, skip app-db and
+use `@media (prefers-color-scheme: dark)`.
 
-Two surfaces sit outside every frame. Document chrome — scrollbar, `<body>`
-canvas, `<meta name="theme-color">` — is above any root, so a per-frame
-attribute never reaches it. When chrome matters, echo the same app-db fact at
-document level from the choosing event, as a row under `:fx` beside the `:db`
-write. Use a *different* attribute name so the rendered scope stays the real
-carrier and the document copy stays cosmetic:
+### Imperative document-level theming
+
+An effect can set an attribute on `documentElement` without a React render:
 
 ```clojure
 (rf/reg-fx :page/echo-theme!
   {:platforms #{:client}}
   (fn [_ctx theme]
-    (.setAttribute js/document.documentElement "data-page-theme" (name theme))))
+    (.setAttribute js/document.documentElement
+                   "data-page-theme"
+                   (name theme))))
 ```
 
-The top layer needs no echo. An [overlay](glossary.md#overlay)'s `::backdrop`
-pseudo-element inherits custom properties from the element that opened it, so
-a modal opened inside `theme-scope` takes the scope's tokens. Style the
-backdrop with the same variables
+Use this only for document chrome outside every frame: the body canvas,
+scrollbar, or `<meta name="theme-color">`. Keep a different attribute name so
+the rendered frame scope remains the real carrier and the document copy is
+clearly cosmetic.
+
+An imperative-only theme does not automatically follow time travel or a
+restored snapshot. Prefer the rendered attribute unless you have measured a
+reason not to.
+
+The browser's top layer does not need a document echo. An overlay's
+`::backdrop` inherits custom properties from the element that opened it, so a
+modal inside `theme-scope` receives the same tokens
 ([Overlays and focus](12-overlays-and-focus.md)).
 
-## Strings are values: i18n
+## Treat translated strings as values
 
-Locale is a key in app-db, strings are a map, and a subscription joins them.
-When the locale changes, every view that read a string re-renders because its
-inputs changed. No observer registry, no i18n context, no remount.
+Store the locale in app-db and derive strings through a subscription:
 
 ```clojure
 (def strings
-  {:en {:greeting "Welcome back" :cart/empty "Your cart is empty"}
-   :fr {:greeting "Bon retour"   :cart/empty "Votre panier est vide"}})
+  {:en {:greeting "Welcome back"
+        :cart/empty "Your cart is empty"}
+   :fr {:greeting "Bon retour"
+        :cart/empty "Votre panier est vide"}})
 
 (rf/reg-sub :i18n/locale
-  (fn [db _query] (:i18n/locale db :en)))
+  (fn [db _query]
+    (:i18n/locale db :en)))
 
 (rf/reg-sub :i18n/t
   (fn [db [_ k]]
-    (get-in strings [(:i18n/locale db :en) k] (name k))))  ;; miss shows the key
+    (get-in strings
+            [(:i18n/locale db :en) k]
+            (name k))))
 
 (rf/reg-event :i18n/set-locale
   (fn [{:keys [db]} [_ locale]]
     {:db (assoc db :i18n/locale locale)}))
 
-(h/defview greeting [_props]
+(h/defview greeting [_]
   [:header
    [:h1 (h/sub [:i18n/t :greeting])]
-   [:button {:on-click [:i18n/set-locale :fr]} "Français"]])
+   [:button {:on-click [:i18n/set-locale :fr]}
+    "Français"]])
 ```
 
-Numbers and dates use the platform with the locale as an ordinary value:
+When the locale changes, only views that read translated values need to
+re-render. The fallback renders the missing key's name, which makes incomplete
+translation tables visible instead of blank.
+
+Format numbers and dates with the platform and the current locale:
 
 ```clojure
 (h/defview price [{:keys [amount]}]
   (let [locale (name (h/sub [:i18n/locale]))]
     [:span.price
-     (.format (js/Intl.NumberFormat. locale
-                                     #js {:style "currency" :currency "EUR"})
-              amount)]))
+     (.format
+      (js/Intl.NumberFormat.
+       locale
+       #js {:style "currency" :currency "EUR"})
+      amount)]))
 ```
 
-Loaded locale packs use the same design with the table in app-db instead of
-code. Fetch the pack, `assoc` it in, and let the subscription read
-`(get-in db [:i18n/strings locale k])`. A late string is app-db changing; the
-views that read it follow.
-
-## What over-engineering looks like
+For separately loaded locale packs, store the loaded table in app-db and let
+the translation subscription read from it:
 
 ```clojure
-;; Don't — tokens in app-db; every view reads the registry
-(rf/reg-sub :theme/token
-  (fn [db [_ k]] (get-in db [:theme/tokens (:theme/current db) k])))
+(get-in db [:i18n/strings locale k])
+```
 
-(h/defview save-button [_props]
-  [:button {:style {:background    (h/sub [:theme/token :accent])
-                    :border-radius (h/sub [:theme/token :radius])}}
+A late locale pack is an ordinary app-db update. Views that read its strings
+update normally.
+
+## Avoid storing CSS tokens in app-db
+
+```clojure
+;; Don't: every token consumer becomes a subscription and re-render target.
+(rf/reg-sub :theme/token
+  (fn [db [_ k]]
+    (get-in db [:theme/tokens (:theme/current db) k])))
+
+(h/defview save-button [_]
+  [:button
+   {:style {:background (h/sub [:theme/token :accent])
+            :border-radius (h/sub [:theme/token :radius])}}
    "Save"])
 ```
 
-Now every view reads the token registry, a theme switch re-renders all of
-those views, and app-db carries a second copy of what the stylesheet already
-owns. Tokens in CSS plus one attribute flip cost zero React work for token
-changes. The same instinct builds an i18n provider with a hook per consumer —
-the subscription already is the provider.
+The stylesheet already owns these values. Duplicating them in app-db makes a
+theme switch recompute every token consumer. CSS custom properties plus one
+attribute avoid that work.
 
-## A vendor theme via `defhost`
+The same principle applies to i18n providers: the subscription is already the
+reactive access path. A second context and hook layer do not add information.
 
-A component library that themes itself through React context gets its provider
-the way any foreign component arrives: declare once with
-[`h/defhost`](glossary.md#defhost), use as an ordinary head
-([Interop](09-interop.md)).
+## Vendor theme providers
+
+A component library that uses React context still enters through a declared
+host ([Interop](09-interop.md)):
 
 ```clojure
 (ns app.vendor-theme
   (:require ["@acme/ui" :refer [ThemeProvider createTheme]]
             [re-frame.hicasso :as h]))
 
-(def light-theme (createTheme #js {:mode "light"}))
-(def dark-theme  (createTheme #js {:mode "dark"}))
+(def light-theme
+  (createTheme #js {:mode "light"}))
+
+(def dark-theme
+  (createTheme #js {:mode "dark"}))
 
 (h/defhost theme-provider ThemeProvider)
 
 (h/defview vendor-area [{:keys [children]}]
-  (into [theme-provider {:theme (if (= :dark (h/sub [:theme/current]))
-                                  dark-theme
-                                  light-theme)}]
-        children))
+  (into
+   [theme-provider
+    {:theme (if (= :dark (h/sub [:theme/current]))
+              dark-theme
+              light-theme)}]
+   children))
 ```
 
-Create the vendor theme objects once at load. App-db only picks which object
-crosses. Context stays a React fact on the React side of the host; your own
-app's theming never needed context.
+Create vendor theme objects once at namespace load. App-db chooses which
+object crosses. The vendor's context remains an implementation detail on the
+React side; your own application theme still uses CSS.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| Blank page on first load; console shows `Doesn't support name:` | Nobody chose a theme, the sub read `nil`, and `(name nil)` threw at the root | Give the sub a default: `(:theme/current db :light)` |
-| Theme key changes in app-db and nothing on screen changes | No view renders the attribute — the cascade keys off the DOM, not app-db | Mount `theme-scope` (or equivalent) at the frame root |
-| Theme switch re-renders the whole app | What sits below the scope has no independent re-render unit — native-tag subtree, or a view called as a plain function | Keep a `defview` head immediately below the scope, as `[app {}]` is |
-| Locale switches but some strings stay in the old language | Those strings were captured once — in a `def`, a prop computed at load, a memoized helper — instead of read at render | Read strings where you use them: `(h/sub [:i18n/t k])` |
-| A missing translation renders as the key's name | The sub's miss fallback, working as designed | Add the key to the table; the fallback names it so you can find it |
-| Hydrated page keeps the server's theme | Hydration payload did not carry the choice; attribute-only divergence is the class React never reports | Carry `:theme/current` in the payload ([SSR and hydration](17-ssr-and-hydration.md)) |
+| First load is blank and the console reports `Doesn't support name:` | The theme subscription returned `nil`, then `(name nil)` threw | Give the subscription a default such as `(:theme/current db :light)` |
+| Theme changes in app-db but the page does not change | No rendered element exposes the theme to CSS | Mount `theme-scope`, or an equivalent attribute carrier, at the frame root |
+| A theme switch re-runs the whole application | The content below the scope has no independent view boundary | Put a `defview` head such as `[app {}]` immediately below the scope |
+| Some strings remain in the old locale | They were computed at load time, stored in a `def`, or otherwise captured outside render | Read them where used with `(h/sub [:i18n/t k])` |
+| A missing translation displays the key name | The translation fallback is working | Add the key to the selected locale table |
+| Hydration keeps the server's theme | The hydration payload omitted `:theme/current`; attribute-only divergence may not produce a useful React warning | Include the theme choice in the hydration payload ([SSR and hydration](17-ssr-and-hydration.md)) |
 
-## When not to use it
+## When not to add this machinery
 
-- **Following the OS with no user override** — skip app state; the media
-  query is the whole feature.
-- **One locale today** — do not build the table. Literal strings in views are
-  fine. The table earns its place when the second locale is real; migration is
-  mechanical (each literal becomes a key).
-- **Your own app's styling** — never needs a vendor host or context. CSS is
-  enough.
+- Use the CSS media query when the application follows the OS and offers no
+  user override.
+- Keep literal strings when there is only one real locale. Extract them when a
+  second locale becomes an actual requirement.
+- Do not introduce a vendor provider for your own styles. CSS is sufficient.

--- a/docs/design/hicasso/draft-guide/14-testing.md
+++ b/docs/design/hicasso/draft-guide/14-testing.md
@@ -1,39 +1,37 @@
 # Testing
 
-You have a feature to test. You need to decide which tests to write, and how
-much machinery each test needs.
+Choose the cheapest test that can prove the behaviour you care about.
 
-In a Hicasso app, most of the answer runs without a browser. Handlers and
-subscriptions are plain functions. Markup helpers return plain data. View
-bodies run under a [semantic harness](glossary.md#semantic-harness) with no
-DOM and no React. The browser is the top rung — keep it for facts only a
-browser knows.
+Most Hicasso application logic does not need a browser. Event handlers and
+subscriptions are plain functions. Markup helpers return data. A hook-free
+view body can run under an injected subscription resolver. Mount React only
+when the claim depends on React or the DOM, and use real browsers for facts
+that only a browser engine knows.
 
-Test at the lowest rung that can prove the claim, and know which equality that
-rung proves.
+The test kit is split across two namespaces:
 
-The [test kit](glossary.md#test-kit) is two namespaces. `re-frame.hicasso.test`
-(aliased `ht` below) holds every rung that runs without a browser.
-`re-frame.hicasso.test.mounted` (aliased `hm`) is the
-[mounted facade](glossary.md#mounted-facade).
+- `re-frame.hicasso.test`, usually aliased `ht`, for browser-free tests;
+- `re-frame.hicasso.test.mounted`, usually aliased `hm`, for real React and DOM
+  tests.
 
-## The ladder
+## The testing ladder
 
-| Rung | What it proves | Mechanism |
+| Level | What it proves | Mechanism |
 | --- | --- | --- |
-| **L0** | event handlers, subscriptions, state transitions | pure function calls |
-| **L1** | intents, prevent and navigate decisions, codecs, control and revision laws, native-form expansion | pure data, property, and macro-expansion tests |
-| **L2** | one hook-free view body, as a semantic tree | `ht/tree` under injected read fixtures |
-| **L3** | React lifecycle, hooks, context, refs, errors, hosts | mounted facade with Testing Library and user-event |
-| **L4** | IME, caret, focus, layout, hydration, performance | Chromium, Firefox, and WebKit |
+| **L0** | Handler behaviour, subscription output, state transitions | Pure function calls |
+| **L1** | Intent values, prevent/navigate decisions, codecs, merge laws, macro expansion | Plain data and property tests |
+| **L2** | The semantic output of one hook-free view body | `ht/tree` with injected subscription fixtures |
+| **L3** | React lifecycle, hooks, context, refs, hosts, error boundaries, real DOM | Mounted facade with Testing Library and user-event |
+| **L4** | IME, caret, focus traversal, layout, hydration, browser performance | Chromium, Firefox, and WebKit |
 
-Each rung proves a different equality. A green L2 test says nothing about
-React lifecycle. A semantic tree is never a proxy for hydration bytes. That
-honesty is what makes the cheap rungs trustworthy.
+These levels prove different kinds of equality. A passing semantic-tree test
+does not prove React lifecycle behaviour. A mounted DOM test does not prove
+cross-browser caret behaviour. Keep each claim at the level that can actually
+witness it.
 
-## The feature under test
+## Example feature
 
-One small feature serves the whole page: a todo row with a toggle.
+The examples use one todo row:
 
 ```clojure
 (ns todo.events
@@ -53,7 +51,8 @@ One small feature serves the whole page: a todo row with a toggle.
   (:require [re-frame.core :as rf]))
 
 (rf/reg-sub :todo/by-id
-  (fn [db [_ id]] (get-in db [:todos id])))
+  (fn [db [_ id]]
+    (get-in db [:todos id])))
 ```
 
 ```clojure
@@ -70,75 +69,84 @@ One small feature serves the whole page: a todo row with a toggle.
       title]]))
 ```
 
-## L0 — handlers and subscriptions are plain functions
+## L0: handlers and subscriptions
 
-Nothing here is Hicasso-specific. The logic layer tests the same under every
-view layer. Take the handler from the registrar, call it with literal values,
-check the map it returns:
+Event handlers are ordinary functions over coeffects and an event vector. Load
+the registration namespace, obtain the handler, call it with literal values,
+and assert on the returned effects:
 
 ```clojure
 (ns todo.events-test
   (:require [clojure.test :refer [deftest is]]
             [re-frame.core :as rf]
-            [todo.events]))   ;; loading the ns registers the handlers
+            [todo.events]))
 
 (deftest toggle-flips-done
-  (let [handler (:handler-fn (rf/handler-meta :event :todo/toggle))
-        result  (handler {:db {:todos {7 {:id 7 :title "Buy milk" :done? false}}}}
-                         [:todo/toggle 7])]
+  (let [handler (:handler-fn
+                 (rf/handler-meta :event :todo/toggle))
+        result  (handler
+                 {:db {:todos
+                       {7 {:id 7
+                           :title "Buy milk"
+                           :done? false}}}}
+                 [:todo/toggle 7])]
     (is (true? (get-in result [:db :todos 7 :done?])))))
 ```
 
-A subscription is a pure function over app-db values:
+A subscription can be tested against an app-db value:
 
 ```clojure
 (deftest by-id-reads-one-todo
   (is (= {:id 7 :title "Buy milk" :done? false}
-         (rf/compute-sub [:todo/by-id 7]
-                         {:todos {7 {:id 7 :title "Buy milk" :done? false}}}))))
+         (rf/compute-sub
+          [:todo/by-id 7]
+          {:todos
+           {7 {:id 7
+               :title "Buy milk"
+               :done? false}}}))))
 ```
 
-Both tests run on the JVM: no browser, no React. Most of your logic lives
-here, so most of your tests belong here.
+Both tests can run on the JVM. Most application behaviour belongs at this
+level, so most tests should too.
 
-## L1 — helpers and intents are plain data
+## L1: helpers, intents, and other data
 
-A helper that takes its data as arguments and reads nothing is an ordinary
-function. Call it; the whole assertion is `=`:
+A helper that takes values and returns Hiccup is a plain function:
 
 ```clojure
 (defn priority-badge [level]
-  [:span.badge {:data-level (name level)} (name level)])
+  [:span.badge
+   {:data-level (name level)}
+   (name level)])
 
 (deftest badge-is-the-data-it-claims
-  (is (= [:span.badge {:data-level "high"} "high"]
+  (is (= [:span.badge
+          {:data-level "high"}
+          "high"]
          (priority-badge :high))))
 ```
 
-The same method covers every data spelling in the product: an
-[intent](glossary.md#intent) vector, a [`::h/prevent`](glossary.md#hprevent)
-head, a [route link](glossary.md#route-link)'s navigate decision. You never
-mount and click to learn what a button means — the meaning is a value you
-compare.
+Use the same approach for:
 
-L1 is also the rung for property tests (codec round-trip, owned-wins attribute
-merge). When you own a [native island](glossary.md#native-island),
-[`n/$`](glossary.md#n-dollar) macro-expansion tests belong here
-([Native tier](10-native-tier.md)). The canonical-DOM comparator
-`ht/canonical-dom` lives at this rung too: a pure serializer applied to
-mounted nodes when a claim compares two pages (mechanics under Advanced).
+- an event intent;
+- `[::h/prevent INTENT]`;
+- a route link's navigation decision;
+- codecs and round trips;
+- the owned-wins attribute merge;
+- `n/$` macro expansion for native code
+  ([The native tier](10-native-tier.md)).
 
-## L2 — the semantic harness
+A test does not need to mount and click a button merely to learn which event
+vector the button contains.
 
-A [`defview`](glossary.md#defview) body is not directly callable. It needs a
-render context to read in; a direct call raises at the call and names the
-view. The harness supplies that context without React.
+`ht/canonical-dom` also belongs to this level as a pure comparator applied to
+live DOM nodes. It is described under [Advanced](#canonical-dom).
 
-`ht/tree` runs one hook-free body under a discardable read resolver — your
-fixtures — and returns a versioned semantic tree. Four helpers assert on the
-tree: `ht/find`, `ht/attrs`, `ht/text`, and `ht/intents`. `ht/find` takes a
-predicate over the tree's node maps — `(:tag %)` names an element,
-`(:view-id %)` a child view call.
+## L2: one view body as a semantic tree
+
+A `defview` cannot be called directly. `ht/tree` supplies a browser-free render
+context, resolves `h/sub` calls from a fixture map, and returns a versioned
+semantic tree.
 
 ```clojure
 (ns todo.views-test
@@ -147,65 +155,99 @@ predicate over the tree's node maps — `(:tag %)` names an element,
             [todo.views :as views]))
 
 (deftest row-renders-title-and-carries-the-toggle
-  (let [tree (ht/tree [views/todo-row {:id 7}]
-                      {:subs {[:todo/by-id 7]
-                              {:id 7 :title "Buy milk" :done? false}}})]
-    (is (= "Buy milk" (ht/text (ht/find tree #(= :label (:tag %))))))
+  (let [tree
+        (ht/tree
+         [views/todo-row {:id 7}]
+         {:subs
+          {[:todo/by-id 7]
+           {:id 7
+            :title "Buy milk"
+            :done? false}}})]
+    (is (= "Buy milk"
+           (ht/text
+            (ht/find tree #(= :label (:tag %))))))
+
     (is (= [:todo/toggle 7]
-           (:on-change (ht/attrs (ht/find tree #(= :input (:tag %)))))))
-    (is (= [[:todo/toggle 7]] (ht/intents tree)))))
+           (:on-change
+            (ht/attrs
+             (ht/find tree #(= :input (:tag %)))))))
+
+    (is (= [[:todo/toggle 7]]
+           (ht/intents tree)))))
 ```
 
-The head may be the `defview` itself, or the body function it was created
-from. Either runs the body as written: no React element, no hook, nothing
-mounted or painted.
+Useful tree helpers include:
 
-Fixtures replace the whole subscription layer. The body's
-[`h/sub`](glossary.md#hsub) calls resolve against the map. The harness never
-touches the real cache, and it discards the resolver afterwards. Fixture
-identity is `(query-id, args)` under value equality — `[:todo/by-id 7]` and
-`[:todo/by-id "7"]` are different fixtures.
+- `ht/find` — find a node using a predicate over node maps;
+- `ht/attrs` — return a node's attributes;
+- `ht/text` — collect its text;
+- `ht/intents` — collect event intents in the tree.
 
-**A child view does not expand.** A nested `[todo-row {:key id :id id}]` is
-recorded as the call it is — view id, props, children — and its body does not
-run. L2 is one body; a tree spanning two views cannot say which of them a
-failure belongs to. Assert a child's props where it is called; render the
-child's own form to assert its contents.
+A node's `:tag` identifies an element. `:view-id` identifies a child view call.
 
-**What the harness will not fake:**
+The head may be the `defview` or its underlying body function. No React
+element is created, and nothing mounts or paints.
 
-- A body that reaches a **hook**, a **raw React element**, an
-  [`n/$`](glossary.md#n-dollar) result, or a [`defhost`](glossary.md#defhost)
-  crossing raises with a structured, source-located complaint that points at
-  L3. React facts belong to React.
-- A read with **no fixture** raises and names the query. The harness never
-  substitutes `nil` or invents a value.
+### Subscription fixtures
 
-!!! warning "No fake hook dispatcher, ever"
+The fixture map replaces the subscription layer for this body. A fixture key
+uses `(query-id, args)` under value equality. These are different fixtures:
 
-    A stubbed React dispatcher passes tests that real React would fail —
-    abandoned renders, StrictMode double-invoke, effect ordering. The kit does
-    not supply one, and you must not build one. Split the view instead: keep
-    the semantic half as data you can compare with `=`, and mount-test the
-    mechanics once.
+```clojure
+[:todo/by-id 7]
+[:todo/by-id "7"]
+```
 
-## L3 — the mounted facade
+A read without a fixture raises and names the missing query. The harness does
+not silently substitute `nil` or call the live subscription cache.
 
-When the claim is about React or the DOM — lifecycle, hooks, a real error
-boundary, real nodes — mount the view. The facade gives every test an isolated
-frame (its own app-db, queue, and subscription cache), a real root, and a
-residue guarantee:
+### Child views stay as calls
 
-| Call | What it does |
+L2 runs one body. A nested child such as:
+
+```clojure
+[todo-row {:key id :id id}]
+```
+
+is represented by its view id, props, and children. Its body does not expand.
+Assert the child's props at the parent call site, then test the child's own
+form separately. Expanding multiple bodies into one semantic tree would make
+ownership of a failure unclear.
+
+### L2 refuses React-only behaviour
+
+The harness raises and points to L3 when a body reaches:
+
+- a React hook;
+- a raw React element;
+- an `n/$` result;
+- a `defhost` crossing.
+
+It also raises when a subscription fixture is missing.
+
+!!! warning "Do not build a fake hook dispatcher"
+    A fake dispatcher can pass tests that real React fails under abandoned
+    renders, StrictMode, or effect ordering. Split the semantic part from the
+    React mechanics. Test the data at L2 and mount the mechanics at L3.
+
+## L3: mounted React and DOM
+
+Use the mounted facade when the claim depends on React, hooks, context, refs,
+error boundaries, hosts, or real DOM nodes.
+
+Each mount receives its own frame, app-db, queue, subscription cache, React
+root, and residue baseline.
+
+| Call | Behaviour |
 | --- | --- |
-| `hm/mount!` | mounts a view under a fresh isolated frame; records the residue baseline first; returns a handle |
-| `hm/hydrate!` | mounts by adopting server bytes; answers a promise of the handle once adoption has committed ([SSR and hydration](17-ssr-and-hydration.md)) |
-| `hm/rerender!` | renders a new element into the same root — for props-change tests |
-| `hm/dispatch-and-settle!` | dispatches into the mount's frame and returns once Hicasso and React are quiescent |
-| `hm/settle!` | waits for quiescence after outside stimulation — a user-event pointer or keyboard sequence |
-| `hm/advance-clock!` | moves this mount's virtual clock forward by `ms` and runs due work; needs `{:clock true}` on the `mount!` or `hydrate!` that made the handle; throws without it |
-| `hm/unmount!` | tears the root down |
-| `hm/assert-clean!` | after unmount: compares post-quiescence residue with the pre-mount baseline, reports, then resets; answers a promise of the report |
+| `hm/mount!` | Mount a view under a fresh isolated frame and return a handle |
+| `hm/hydrate!` | Adopt supplied server bytes and return a promise of the handle after hydration commits |
+| `hm/rerender!` | Render a new element into the same root |
+| `hm/dispatch-and-settle!` | Dispatch into the mount's frame and wait until Hicasso and React are quiescent |
+| `hm/settle!` | Wait for quiescence after an external user-event or other stimulation |
+| `hm/advance-clock!` | Advance the mount's virtual clock and run due work; requires `{:clock true}` at mount or hydrate |
+| `hm/unmount!` | Tear down the root |
+| `hm/assert-clean!` | After unmount and quiescence, compare residue with the pre-mount baseline, report, and reset |
 
 ```clojure
 (ns todo.views-mounted-test
@@ -218,164 +260,196 @@ residue guarantee:
 
 (deftest toggle-reaches-the-real-dom
   (async done
-    (let [m (hm/mount! [views/todo-row {:id 7}]
-                       {:initial-events
-                        [[:todo/seed [{:id 7 :title "Buy milk" :done? false}]]]})]
+    (let [m
+          (hm/mount!
+           [views/todo-row {:id 7}]
+           {:initial-events
+            [[:todo/seed
+              [{:id 7
+                :title "Buy milk"
+                :done? false}]]]})]
       (is (some? (tl/getByText (:container m) "Buy milk")))
+
       (hm/dispatch-and-settle! m [:todo/toggle 7])
-      (is (true? (.-checked (tl/getByRole (:container m) "checkbox"))))
-      (-> (hm/unmount! m) (hm/assert-clean!) (.then done)))))
+
+      (is (true?
+           (.-checked
+            (tl/getByRole (:container m) "checkbox"))))
+
+      (-> (hm/unmount! m)
+          (hm/assert-clean!)
+          (.then done)))))
 ```
 
-Every door takes the handle first and returns it, so teardown threads in one
-expression. The test is `async` because `assert-clean!` waits for the
-runtime's own quiescence before it reads.
+The facade does not add a selector language. `(:container m)` is a real DOM
+node, so use Testing Library and user-event normally. After a user-event
+sequence, call `(hm/settle! m)` before asserting.
 
-The facade brings no selector language. `(:container m)` is a real DOM node,
-so Testing Library queries and user-event sequences work unchanged. After a
-user-event sequence, call `(hm/settle! m)` before you assert.
+Mounted operations take the handle first and return it where chaining is
+useful. `assert-clean!` is asynchronous because it waits for runtime
+quiescence before checking residue.
 
-!!! note "Settled, not `act`"
+!!! note "Settled DOM, not a generic `act` wrapper"
+    `dispatch-and-settle!` flushes work until the DOM reflects what a user
+    would see. React's `act` is useful for effect-ordering tests, but it runs
+    through a test scheduler that is not the browser scheduler. Use the
+    facade's settle operations for page assertions.
 
-    `dispatch-and-settle!` flushes; it does not divert through React's `act`.
-    `act` queues React's work on a scheduler that is not the browser's. That
-    is correct for an effect-ordering test, and wrong when the assertion reads
-    the page. After the call returns, the next line sees the DOM the user
-    would have seen.
+### Virtual clock behaviour
 
-!!! note "What the clock moves"
-
-    `Date.now` moves with `setTimeout` and `setInterval` because retention is
-    a deadline comparison, not a callback: a fake timer whose callback reads
-    an unmoved `Date.now` fires on schedule and then decides nothing has
-    expired.
-
-    It does not move `requestAnimationFrame` (a paint, not a duration). It
-    does not move microtasks or promises. It leaves `performance.now` alone
-    (React's scheduler reads it for frame budget). It does not touch the
-    `Date` constructor. It cannot reach a `setTimeout` captured before the
-    window opened — React's own scheduler keeps the reference it took at
-    module load so a flush is still a flush.
-
-    `advance-clock!` is `settle!` for work that had a delay on it.
-
-Use L3 when the claim needs it:
-
-- a real [error boundary](glossary.md#error-boundary) that catches a real
-  throw ([Errors](16-errors.md))
-- StrictMode double-invoke, and renders React abandoned
-- keyed insert, delete, and reorder against real nodes
-- a foreign component's hooks, context, or refs ([Interop](09-interop.md))
-- Activity hide and reveal, which releases and re-establishes subscriptions
-
-**Teardown residue is zero.** `assert-clean!` compares what remains after
-quiescence with what existed before the mount. A surviving subscription
-handle, listener, or scheduled task fails the test. That failure is a bug —
-often a foreign host retaining a callback — not a tolerance to raise.
-
-## L4 — real browsers
-
-Some facts exist only inside a browser engine: IME composition, caret and
-selection movement, focus traversal, layout and scroll geometry, hydration
-against real server bytes, and performance budgets. For those, the witness is
-Chromium, Firefox, and WebKit. No simulation stands in. Controlled-input
-behaviour under composition is the canonical case
-([Controlled inputs](04-controlled-inputs.md)). Budgets live in
-[Performance](18-performance.md).
-
-One more entry completes the kit: `ht/shadow!`, the migration harness. It is
-a dev-only dual mount that drives a ported view and its Reagent original with
-one script and diffs [canonical DOM](glossary.md#canonical-dom) and intent
-streams at every checkpoint.
-[Migrating from Reagent](19-migration-from-reagent.md) owns it.
-
-## The sabotage twin
-
-An assertion that quantifies over a collection can pass because the collection
-was empty by accident — `every?` over nothing is vacuously true. Two habits
-close that hole. First, pin the population with a count. Second, give an
-important test a **[sabotage twin](glossary.md#sabotage-control)**: break the
-input on purpose and confirm that the measurement moves. A moved measurement
-proves the instrument can fail.
+A virtual clock is opt-in:
 
 ```clojure
-;; in todo.views
+(hm/mount! [view] {:clock true})
+```
+
+`hm/advance-clock!` advances `Date.now`, `setTimeout`, and `setInterval`. This
+matters because retention often compares a deadline with `Date.now`; firing a
+timer without moving the clock would leave the deadline unexpired.
+
+The clock does **not** advance:
+
+- `requestAnimationFrame`;
+- promises or microtasks;
+- `performance.now`;
+- the `Date` constructor;
+- timer functions captured before the virtual-clock window opened, including
+  React scheduler references captured at module load.
+
+Calling `hm/advance-clock!` without a clock-enabled handle raises. Use it for
+work that has an actual duration; use `hm/settle!` for work that does not.
+
+### Use L3 for React claims
+
+Examples include:
+
+- a real error boundary catching a real throw ([Errors](16-errors.md));
+- StrictMode double invocation or an abandoned render;
+- keyed insertion, deletion, and reorder against real nodes;
+- a foreign component's hooks, context, and refs ([Interop](09-interop.md));
+- Activity hide and reveal, including subscription release and reacquisition;
+- hydration through `hm/hydrate!`
+  ([SSR and hydration](17-ssr-and-hydration.md)).
+
+`hm/assert-clean!` requires zero additional residue after unmount. A surviving
+subscription, listener, scheduled task, or retained callback is a bug. Do not
+raise a tolerance to make it green.
+
+## L4: real browser engines
+
+Use Chromium, Firefox, and WebKit for behaviour that depends on an actual
+browser engine:
+
+- IME composition;
+- caret and selection restoration;
+- focus traversal;
+- layout and scroll geometry;
+- hydration against real server bytes;
+- performance budgets.
+
+Controlled-input composition is a canonical L4 case
+([Controlled inputs](04-controlled-inputs.md)). Performance scripts and
+budgets belong to [Performance](18-performance.md).
+
+## Migration shadow tests
+
+`ht/shadow!` is a development-only migration harness. It drives a Hicasso view
+and its Reagent original with one script, then compares canonical DOM and
+intent streams at each checkpoint. Its full use belongs to
+[Migrating from Reagent](19-migration-from-reagent.md).
+
+## Prevent vacuous tests with a sabotage twin
+
+A collection assertion can pass because the collection was accidentally
+empty. `every?` over no items is true.
+
+Pin the population with an explicit count. For important instrumentation,
+also add a **sabotage twin**: deliberately change the input so the measurement
+moves. That proves the test can fail.
+
+```clojure
+;; todo.views
 (h/defview todo-list [_]
   [:ul
    (for [id (h/sub [:todo/visible-ids])]
      [todo-row {:key id :id id}])])
 
-;; in the test namespace
 (deftest every-visible-todo-gets-a-row
-  (let [tree (ht/tree [views/todo-list {}]
-                      {:subs {[:todo/visible-ids] [1 2 3]}})
+  (let [tree
+        (ht/tree
+         [views/todo-list {}]
+         {:subs {[:todo/visible-ids] [1 2 3]}})
         rows (:children tree)]
     (is (= 3 (count rows)))
-    (is (= [{:id 1} {:id 2} {:id 3}] (mapv ht/attrs rows)))))
+    (is (= [{:id 1} {:id 2} {:id 3}]
+           (mapv ht/attrs rows)))))
 
 (deftest every-visible-todo-gets-a-row--sabotage-twin
-  ;; Prove the gate can fail: empty the list and the population collapses.
-  (let [tree (ht/tree [views/todo-list {}]
-                      {:subs {[:todo/visible-ids] []}})]
+  (let [tree
+        (ht/tree
+         [views/todo-list {}]
+         {:subs {[:todo/visible-ids] []}})]
     (is (empty? (:children tree)))))
 ```
 
-The list view's claim is that it calls one row per visible id with the right
-props. What a row then renders is the row's claim, proved by rendering the
-row's own form.
+The list test proves that the parent calls one row per id with the expected
+props. The row's own test proves what a row renders.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| `ht/tree` raises, pointing at L3 | Body reaches a hook, raw React element, `n/$` result, or `defhost` crossing | Mount that view at L3; split the hook-free part if you want L2 coverage for the rest |
-| `ht/tree` raises, naming a query | A read the body made has no fixture | Add it. Fixture identity is `(query-id, args)` under value equality |
-| `ht/tree` raises a `defview` head, pointing at L3 | An `:advanced` build with `goog.DEBUG` false compiled away the body property on the head | Run view tests in a dev build, or pass the body function instead of the `defview` head |
-| `:rf.error/hicasso-sub-outside-render` in a plain test | A reading helper was called with no render context | L2 supplies the context; L0 targets handlers and subs, not bodies |
-| `:rf.error/hicasso-deferred-read-at-boundary` | A stored closure, lazy seq, or unforced `delay` carried a read past the render | Read during the body and close over the value ([Views and reads](02-views-and-reads.md)) |
-| `assert-clean!` fails after unmount | Something outlived the root — retained subscription, listener, or scheduled task | Fix the leak. A foreign host retaining a callback is the common culprit ([Interop](09-interop.md)) |
-| Data-level test passes, mounted test fails | Real React does things data does not — effect order, StrictMode double-invoke, commit timing | The mounted result is the truth for lifecycle |
-| Assertion fails on a `nil` in a tree | A `when` produced `nil` — it renders nothing but is still in the data | Assert the `nil`, or filter before comparing |
-| A list test stays green with an empty list | Quantified assertion over an empty population | Pin the count; add the sabotage twin |
+| `ht/tree` raises and points to L3 | The body reached a hook, raw React element, `n/$`, or a host | Mount the view at L3; split out a hook-free semantic part when useful |
+| `ht/tree` raises and names a query | The body read a subscription with no fixture | Add the exact query fixture; identity is `(query-id, args)` under value equality |
+| `ht/tree` cannot inspect a `defview` head in an advanced build | `goog.DEBUG` false removed the body property used by the development harness | Run view tests in a development build, or pass the body function instead of the head |
+| A plain test raises `:rf.error/hicasso-sub-outside-render` | A helper called `h/sub` without a render context | Use L2 for a view body; use L0 for handlers and subscriptions |
+| `:rf.error/hicasso-deferred-read-at-boundary` | A closure, lazy sequence, or unforced `delay` carried a read beyond render | Read during the body and close over the value ([Views and reads](02-views-and-reads.md)) |
+| `hm/assert-clean!` fails | A subscription, listener, task, or foreign callback survived unmount | Fix the leak; retained host callbacks are a common cause ([Interop](09-interop.md)) |
+| Data test passes but mounted test fails | React lifecycle, effect order, StrictMode, or commit timing changed the result | Treat the mounted result as authoritative for React behaviour |
+| Tree assertion sees `nil` | A `when` returned `nil`; it renders nothing but still appears in authored data | Assert that `nil`, or filter it before comparing |
+| A collection test remains green with an empty list | The assertion is vacuously true | Assert the count and add a sabotage twin |
 
-## When not to test through the view
+## When not to test through a view
 
-If the assertion is about *state*, test the handler. If the assertion is about
-*derived values*, test the subscription. A view test that dispatches an event
-and then asserts on app-db tests three things at once, and fails for reasons
-unrelated to the view.
+Test a handler when the claim is about state changes. Test a subscription when
+the claim is about a derived value. A view test that dispatches an event and
+then asserts on app-db mixes several contracts and can fail for unrelated
+reasons.
 
-Keep each rung's claim inside its rung. L2 never claims React lifecycle
-parity. A semantic tree never claims hydration-wire parity
-([SSR and hydration](17-ssr-and-hydration.md)). Timing claims are not tests
-until they follow the measurement discipline in
-[Performance](18-performance.md).
+Do not claim more than the level proves:
+
+- L2 does not prove React lifecycle;
+- a semantic tree does not prove server or hydration bytes;
+- a DOM test in one engine does not prove cross-browser IME or focus;
+- a timing assertion is not a performance test until it follows the method in
+  [Performance](18-performance.md).
 
 ## Advanced
 
-### Every witness names its equality
+### Name the equality being tested
 
-When a test's name or docstring states what the test proves, use these terms:
-
-| Equality | Rung | The claim |
+| Equality | Level | Claim |
 | --- | --- | --- |
-| Authored data | L1 | the function returned this value |
-| Semantic tree | L2 | the body, under these reads, means this |
-| Intent stream | L2/L3 | these events, in this order, were the interactions |
-| Canonical DOM | L3 | two mounts produced the same page |
-| React server bytes | server tests | the server emitted exactly these bytes |
-| Hydrated behaviour | L4 | the adopted page behaves in a real engine |
+| Authored data | L1 | This function returned this value |
+| Semantic tree | L2 | Under these reads, this body means this |
+| Intent stream | L2 or L3 | These interactions produced these events in this order |
+| Canonical DOM | L3 | Two mounted implementations produced the same page structure |
+| React server bytes | Server test | The server emitted these exact bytes |
+| Hydrated behaviour | L4 | A real engine adopted and ran the page correctly |
 
-No row substitutes for another. The most tempting substitution is the semantic
-tree in place of mounted truth. The harness's refusals exist to prevent that.
+One equality does not stand in for another.
 
 ### Canonical DOM
 
-`ht/canonical-dom` serializes a live node's subtree with every element's
-attribute names sorted. `innerHTML` preserves insertion order, and two front
-ends write props in different orders — a comparison of `innerHTML` compares
-the serializer, not the page. Use `ht/canonical-dom` when the claim is "these
-two mounts built the same page": before and after a refactor, a Hicasso view
-against its Reagent original during migration
-([Migration](19-migration-from-reagent.md)), or an island against its
-pre-extraction boundary ([Native tier](10-native-tier.md)).
+`ht/canonical-dom` serialises a live DOM subtree with element attribute names
+sorted. `innerHTML` preserves insertion order, so two equivalent pages can
+produce different strings solely because props were applied in a different
+order.
+
+Use canonical DOM when comparing:
+
+- before and after a refactor;
+- a Hicasso port with its Reagent original
+  ([Migrating from Reagent](19-migration-from-reagent.md));
+- a native island with the interpreted subtree it replaced
+  ([The native tier](10-native-tier.md)).

--- a/docs/design/hicasso/draft-guide/15-diagnostics.md
+++ b/docs/design/hicasso/draft-guide/15-diagnostics.md
@@ -1,261 +1,270 @@
 # Diagnostics
 
-A list re-rendered and you do not know why. A keystroke feels slow and you do
-not know where the time went. Xray is the development-time instrument for
-those questions. It loads with your dev build as a preload, mounts beside the
-app, and observes the same trace the runtime already emits. Nothing in your
-views changes to support it, and none of it ships to production.
+Use Xray when a view re-renders unexpectedly or an interaction feels slow and
+you need to find the cause.
 
-## How to diagnose
+Xray is development tooling. It loads beside the application, reads the trace
+the runtime already emits, and requires no instrumentation in your views. It
+is removed from production builds.
 
-1. **Load Xray** with your dev preload so it mounts beside the app.
-2. **Reproduce** the slow click or unexpected re-render.
-3. **Select the boundary** that ran — the independently re-rendering view
-   ([Views and reads](02-views-and-reads.md)).
-4. **Read its cause and fan-out.**
+## Diagnose an interaction
 
-That is the whole operational path. The rest of this page explains what those
-panels mean and what to do with the answer.
+1. Load Xray through the development preload.
+2. Reproduce the click, keystroke, or update.
+3. Select the view occurrence that ran.
+4. Read its cause, fan-out, and attribution.
 
-An *epoch* is one pipeline run: one dispatched event carried through to its
-commit. Xray organises evidence around epochs.
+An **epoch** is one event pipeline run, from dispatch through its state commit.
+Xray organises its evidence around epochs.
 
-## Read the cause
+## Why did this view run?
 
-Select a boundary occurrence and ask: *why did this view run?*
+A selected view occurrence usually has one of these causes:
 
-Typical answers:
-
-| Cause | Meaning | What you usually do |
+| Cause | Meaning | Typical response |
 | --- | --- | --- |
-| Own reads moved (queries named) | A subscription this view used changed | Check whether the read should live lower, or whether the sub is coarser than needed |
-| Props changed | Parent passed different props | Check keys, identity of props maps, and whether the parent re-rendered too high |
-| Context changed | A React context this view consumes changed | Trace the provider; vendor themes often land here |
-| Host forced it | A host boundary forced a child | Check the host's props and whether the force is required |
-| Retry / abandoned attempt | React retried or abandoned work | Not always a bug — StrictMode doubles in development |
+| Its own reads changed | A subscription read by this view produced a new value | Check whether the read belongs lower in the tree or whether the subscription is too coarse |
+| Props changed | The parent supplied unequal props | Inspect keys, prop identity, and whether the parent owns too much work |
+| Context changed | A React context consumed by the view changed | Trace the provider; vendor theme providers often appear here |
+| A host forced the update | A foreign host caused the child to run | Inspect the host's props and contract |
+| Retry or abandoned attempt | React retried or discarded work | This may be expected, especially under development StrictMode |
 
-When several boundaries ran for one event, **fan-out** tells you which case you
-have. One changed subscription that reaches many readers is a topology problem.
-Many independent causes are ordinary work.
+When several views run for one event, fan-out distinguishes a topology problem
+from independent useful work. One changed subscription reaching hundreds of
+readers deserves attention. Hundreds of unrelated reads changing together may
+be the intended update.
 
-**Render is not commit, and commit is not paint.** Bodies run speculatively.
-React owns commit. The browser owns paint. Xray tells you which claim each
-number makes. Timing proximity alone proves nothing: a body that ran near an
-event may have run for a different reason.
+Do not collapse render, commit, and paint into one number:
 
-The chain Xray follows:
+- a body can run speculatively;
+- React decides what commits;
+- the browser decides when it paints.
 
+Xray labels which stage each measurement belongs to. Timing proximity alone
+does not prove causation.
+
+The causal chain is:
+
+```text
+event
+  → subscriptions recomputed
+  → values changed
+  → views notified
+  → bodies run
+  → React commit
+  → browser paint
 ```
-event → subscriptions recomputed → values changed → boundaries notified
-     → bodies run → React commit → paint
-```
 
-Xray correlates links only when its instruments support the correlation. When
-they do not, it labels the link instead of guessing.
+Xray correlates links only where an instrument can support the relationship.
+When it cannot, it reports that limitation instead of guessing.
 
-## Read attribution
+## Read topology and fan-out
 
-The standing view is the map from subscriptions to the boundaries that currently
-read them. Four numbers do most of the diagnostic work:
+The standing view maps subscriptions to the currently committed views that
+read them. Four measurements usually identify the shape:
 
-| Number | What it tells you |
+| Measurement | What it reveals |
 | --- | --- |
-| Boundary count | how many independent re-render units are mounted |
-| Reads per boundary | fine, coarse, or accidentally enormous read sets |
-| Fan-out per subscription | how many boundaries one change will reach |
-| Read-set churn | how often a boundary's read set changes membership |
+| View count | Number of independently re-rendering units currently mounted |
+| Reads per view | Fine-grained, coarse, or accidentally enormous read sets |
+| Fan-out per subscription | Number of views one changed value can notify |
+| Read-set churn | How often a view changes which subscriptions it reads |
 
-Two shapes deserve attention:
+Two common failures:
 
-- One subscription that fans out to hundreds of boundaries usually means a
-  read that lives too high, or a shared value that needs a deliberate
-  topology choice.
-- A boundary whose read set churns every render pays a whole-set refresh each
-  time, because the edge set is a function of what the body did.
+- One subscription fans out to hundreds of views because a shared read lives
+  too high or the read model is too broad.
+- A view changes its read membership every render and pays to replace the
+  complete committed read set each time.
 
-Remedies — reads at the point of use, boundary placement, fine versus coarse
-versus chunked reads — live in [Views and reads](02-views-and-reads.md) and
-[Lists and collections](06-lists-and-collections.md). Xray makes the topology
-visible.
+Move reads, change view boundaries, or choose fine, coarse, chunked, or
+windowed collection reads as described in
+[Views and reads](02-views-and-reads.md) and
+[Lists and collections](06-lists-and-collections.md).
 
-## The hot-view advisor
+## Use attribution before choosing a fix
 
-The advisor ranks boundaries by time, frequency, read churn, and fan-out, then
-**classifies the pressure** before it names a remedy:
+The hot-view advisor ranks views by time, frequency, read churn, and fan-out.
+It first identifies where the time is going:
 
-| Pressure | Time is going to | Smallest credible remedy |
+| Pressure | Cost owner | Smallest credible fix |
 | --- | --- | --- |
-| Computation | your own code — the body's work or an expensive sub chain | fix the computation; derive it in the subscription layer |
-| Topology | too many boundaries invalidated, or churning read sets | move reads, split or merge boundaries, coarse / chunked / windowed reads ([Lists and collections](06-lists-and-collections.md)) |
-| Lowering | turning one hot boundary's Hiccup into React elements | a direct [`n/$`](glossary.md#n-dollar) return from that same boundary ([Native tier](10-native-tier.md)) |
-| React | reconciliation, hooks, vendor component internals | a named [native island](glossary.md#native-island) — [`n/defcomponent`](glossary.md#ndefcomponent) or UIx ([Native tier](10-native-tier.md)) |
-| Layout | the browser — style, layout, paint | shrink the DOM, virtualize, fix the CSS; browser tools own this ground |
+| Computation | View code or an expensive subscription chain | Move or reduce the computation; derive display values in subscriptions |
+| Topology | Too many invalidated views or unstable read sets | Move reads, split or combine views, or change collection read shape |
+| Hiccup lowering | Turning one hot view's Hiccup into React elements | Return `n/$` directly from that same view ([The native tier](10-native-tier.md)) |
+| React | Reconciliation, hooks, or vendor internals | Use a named native island or UIx component |
+| Layout and paint | Browser style, layout, and rendering | Reduce DOM, virtualise, or fix CSS; use browser tooling |
 
-The advisor recommends a native escape only when the measured owner is a class
-that native addresses. If lowering is four percent of a slow interaction,
-extraction cannot buy more than four percent. The advisor says so and points
-at the real owner. There is no automatic promotion — the advisor recommends,
-you decide. An escape you take must meet the thresholds in
-[Performance](18-performance.md), or it comes back out.
+The advisor recommends a native escape only when native code addresses the
+measured owner. If lowering is 4% of an interaction, a lowering escape cannot
+recover more than that 4%.
 
-## When evidence is incomplete
+Xray recommends; it does not rewrite or promote code automatically. Any native
+escape must pass the benefit thresholds in [Performance](18-performance.md).
 
-An interpreted runtime cannot know some facts. Xray reports that limit as an
-answer; it does not present an empty panel. Unknown is never encoded as an
-empty collection.
+## Incomplete evidence is reported explicitly
 
-| Label | Meaning | What you do |
+Xray uses named completeness states instead of pretending that missing
+evidence is an empty result:
+
+| Label | Meaning | Response |
 | --- | --- | --- |
-| `:unknown` | no instrument covers this link | ask a question the instruments answer; if the claim matters, make it a test |
-| `:opaque` / `:no-static-analysis` | an interpreted body's facts cannot be enumerated ahead of execution | run the interaction — current reads come from actual execution |
-| `:host-opaque` | raw React internals past a host or native crossing | Xray still names and times the crossing; React DevTools owns the inner tree |
-| `:cap` | the bounded retention window has dropped older history | reproduce and capture fresh |
-| `:uncorrelated` | the event-to-render relationship could not be established | treat as honest absence; reproduce with a scripted interaction so the links line up |
+| `:unknown` | No instrument covers the requested relationship | Ask a question the instruments can answer, or encode the claim in a test |
+| `:opaque` / `:no-static-analysis` | An interpreted body's facts cannot be enumerated before execution | Run the interaction; current reads come from the body that actually ran |
+| `:host-opaque` | The inner React tree is hidden behind a host or native crossing | Xray still names and times the crossing; inspect its internals with React DevTools |
+| `:cap` | The bounded history has dropped older evidence | Reproduce and capture a fresh epoch |
+| `:uncorrelated` | The event-to-render relationship could not be established | Treat it as an honest absence and reproduce with a scripted interaction |
 
-## The complaint catalogue
+## Complaint IDs
 
-Every refusal in this guide carries a stable id: `:rf.error/*` for errors,
-`:rf.warning/*` for recoverable misuse. When thrown, the id is in `ex-data`
-under `:rf.error/id`. On the trace it is a record with the id as category and
-the recovery the runtime took. In Xray it renders with jump-to-source for the
-registration site and the call site.
+Hicasso errors and warnings use stable identifiers:
 
-A sample of entries from earlier chapters:
+- `:rf.error/*` for errors;
+- `:rf.warning/*` for recoverable misuse.
 
-| Id | Complaint | Recovery |
+A thrown error places the id in `ex-data` under `:rf.error/id`. Trace records
+use the same id and include the recovery the runtime applied. Xray can link to
+the registration site and the call site when source data is available.
+
+Examples from the guide:
+
+| ID | Meaning | Recovery |
 | --- | --- | --- |
-| `:rf.error/hicasso-sub-outside-render` | a read escaped every render context | read during the body; in a handler, declare the fact as a coeffect ([Views and reads](02-views-and-reads.md)) |
-| `:rf.error/hicasso-deferred-read-at-boundary` | an unforced `delay` carrying a read tried to leave the view | force it in the body; close over the value ([Views and reads](02-views-and-reads.md)) |
-| `:rf.error/hicasso-bad-head` | a plain `defn` in head position | define it with [`h/defview`](glossary.md#defview), or call it inline ([Views and reads](02-views-and-reads.md)) |
-| `:rf.error/hicasso-intent-outside-boundary` | an [intent](glossary.md#intent) vector reached a position with no boundary frame | dispatch belongs inside a boundary; at a foreign edge, use [`h/event`](glossary.md#hevent) ([Events as data](03-events-as-data.md)) |
-| `:rf.error/hicasso-host-unclaimed-callback` | an [`h/event`](glossary.md#hevent) arrived at a host prop that no callback contract claims | declare the prop in `:callbacks`; at a ReactNode slot, write markup ([Interop](09-interop.md)) |
-| `:rf.error/hicasso-revision-not-controlled` | [`::h/revision`](glossary.md#hrevision) on a field that is not controlled | control the field, or drop the revision ([Controlled inputs](04-controlled-inputs.md)) |
-| `:rf.warning/hicasso-missing-key` | a seq of boundary children without `:key` | put `:key` in each child's props map ([Lists and collections](06-lists-and-collections.md)) |
-| `:rf.error/frame-destroyed` | an operation captured against a destroyed frame incarnation fired after its successor seated | drop the stale handle; capture from the live frame ([Events as data](03-events-as-data.md)) |
+| `:rf.error/hicasso-sub-outside-render` | A subscription read ran after every render context had ended | Read during the body and close over the value; handlers declare state as coeffects |
+| `:rf.error/hicasso-deferred-read-at-boundary` | An unforced `delay` carrying a read tried to leave a view | Force it in the body or pass the realised value |
+| `:rf.error/hicasso-bad-head` | A plain `defn` appeared in Hiccup head position | Call it inline or define a view with `h/defview` |
+| `:rf.error/hicasso-intent-outside-boundary` | An event intent reached a position with no frame | Keep it under a view boundary; use `h/event` at a foreign callback edge |
+| `:rf.error/hicasso-host-unclaimed-callback` | `h/event` was passed to a host prop with no callback contract | Declare the prop in `:callbacks` |
+| `:rf.error/hicasso-revision-not-controlled` | `::h/revision` appeared on a non-controlled field | Control the text field or remove the revision |
+| `:rf.warning/hicasso-missing-key` | A sequence child has no `:key` | Put a stable key in each member's props map |
+| `:rf.error/frame-destroyed` | An operation captured from a destroyed frame incarnation fired later | Drop the stale handle and capture from the current frame |
 
-When a complaint surprises you, follow its recovery before you change code.
-When you test a refusal, assert the id, never the message:
+Follow the named recovery before changing unrelated code.
+
+When testing a refusal, assert the stable id rather than the message:
 
 ```clojure
-;; ht is the test kit from 14-testing.md
-(defn badge [_props] [:span.badge "hi"])       ;; a plain defn — not a view
-(defn card  [_props] [:div.card [badge {}]])   ;; …and here it is, in a head
+(defn badge [_]
+  [:span.badge "hi"])
+
+(defn card [_]
+  [:div.card
+   [badge {}]])
 
 (defn refusal-id [f]
-  (try (f) ::did-not-throw
-       (catch :default e (:rf.error/id (ex-data e)))))
+  (try
+    (f)
+    ::did-not-throw
+    (catch :default e
+      (:rf.error/id (ex-data e)))))
 
 (deftest plain-defn-child-head-refuses
   (is (= :rf.error/hicasso-test-plain-fn-head
-         (refusal-id #(ht/tree [card {}] {:subs {}})))))
+         (refusal-id
+          #(ht/tree [card {}] {:subs {}})))))
 ```
 
-Message text improves between releases; ids are frozen.
+Error messages may improve between releases. IDs are part of the stable
+complaint contract.
 
-`ht/tree`'s root form is headed by the body function the kit is about to run,
-so `[badge {}]` written as the root form is accepted — it runs, and nothing
-raises. Only a plain `defn` reached *inside* the tree is a mistake. At L2 the
-kit answers with `:rf.error/hicasso-test-plain-fn-head`; the same child mounted
-at L3 raises the runtime's `:rf.error/hicasso-bad-head`.
+At L2, the test kit accepts a plain body function as the **root** because that
+is the function it is deliberately running. A plain function reached as a
+child head raises `:rf.error/hicasso-test-plain-fn-head`. The equivalent
+mounted mistake raises the runtime's `:rf.error/hicasso-bad-head`.
 
-## Production erasure
+## Verify production erasure
 
-Everything on this page is development tooling, and all of it erases from a
-release build: the evidence producer, the projections, the advisor, the
-dev-only checks, and their message strings. Production evidence queries return
-nil. A release bundle contains no evidence machinery, no schema sentinels, and
-no source-location tables. Performance collection is gated separately by its
-own compile-time flag and is off by default.
+Xray, its evidence producer, projections, advisor, development checks, source
+locations, and message strings are removed from a release build. Production
+evidence queries return `nil`. Performance instrumentation has a separate
+compile-time flag and is off by default.
 
-Do not accept erasure without a check. Pick a sentinel you can see in the dev
-bundle (`rf.xray` is a good default). Search both builds:
+Verify erasure with a positive control:
 
 ```bash
-npx shadow-cljs compile app            # dev build
-grep -c "rf.xray" public/js/main.js    # positive control: expect > 0
+npx shadow-cljs compile app
+grep -c "rf.xray" public/js/main.js    # expect more than 0
 
-npx shadow-cljs release app            # release build, same output path
+npx shadow-cljs release app
 grep -c "rf.xray" public/js/main.js    # expect 0
 ```
 
-The dev-build search is the positive control. Zero on the release bundle means
-"erased" only if the same search finds the sentinel in the dev bundle. Zero in
-both places means the search is broken, not the build. This is the
-sabotage-twin habit from [Testing](14-testing.md) applied to the bundle.
+The development search must find the sentinel. Zero in both files means the
+search is ineffective, not that production erasure has been demonstrated.
+This is the sabotage-control principle from [Testing](14-testing.md).
 
-Application logic must never depend on the surface: no feature may read
-evidence, count complaints, or branch on a panel's data.
+Application behaviour must never depend on diagnostics. Do not branch on
+whether evidence exists, count warnings as product data, or read panel state
+from application code.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| A view you know ran is absent from the epoch | Its boundary bailed out — a skipped body emits nothing | Absence measures work not done; if you expected it to run, explain-render the parent that did |
-| Explain-render answers `:uncorrelated` | Event-to-render link could not be established for that occurrence | Honest answer, not a failure; reproduce with a scripted interaction and read the fresh epoch |
-| A foreign subtree shows `:host-opaque` | Raw React internals are not enumerable past the crossing | Xray still names and times the crossing; open React DevTools for the inside |
-| History stops with `:cap` | Bounded retention window dropped older epochs | Reproduce and capture fresh |
-| Advisor will not recommend an island you want | Measured owner is not a class native addresses | Do the smaller remedy it named; re-measure ([Performance](18-performance.md)) |
-| Two runs of one interaction show different times | Xray timing is attribution, not a benchmark | Treat the classification, not the number, as the finding; benchmark under [Performance](18-performance.md) |
-| A complaint id you hit has no catalogue anchor | Id is not from this product's surface, or app and kit versions have drifted | Check the id's namespace and align versions |
-| Panels are empty in a release build | Production erasure, working as designed | Diagnose on a dev build |
+| A view you expected is absent from the epoch | Its props and reads allowed it to skip; a body that did not run emits no occurrence | Treat absence as work avoided. Inspect the parent occurrence when you expected different props |
+| Explain-render returns `:uncorrelated` | The event-to-render link could not be established | Reproduce with a scripted interaction and inspect a fresh epoch |
+| A foreign subtree shows `:host-opaque` | Raw React internals are not visible beyond the crossing | Use Xray for the crossing and React DevTools for its inner tree |
+| History ends with `:cap` | The bounded retention window discarded old epochs | Reproduce the issue and capture it again |
+| The advisor will not recommend a native island | The measured owner is not a cost native code fixes | Apply the smaller remedy it names and re-measure |
+| Repeated runs have different timings | Xray timing is diagnostic attribution, not a controlled benchmark | Use the cost classification; benchmark under [Performance](18-performance.md) |
+| A complaint id has no catalogue entry | The id belongs to another namespace, or application and test-kit versions differ | Check the namespace and align installed versions |
+| Panels are empty in a release build | Diagnostics were erased as designed | Diagnose with a development build |
 
-## When Xray is not the tool
+## When Xray is not the right tool
 
-**Xray timing is not a benchmark.** It attributes: which link of the chain owns
-the time, and which remedy class is credible. It does not settle "is this fast
-enough" — budgets live in [Performance](18-performance.md). Its render numbers
-are not commit evidence. React DevTools remains the authority for commits. The
-browser's performance tooling remains the authority for layout and paint. When
-an interaction is slow in a release build, profile the release build with
-browser tools; the dev build carries dev-only work by design.
+Xray identifies the cost owner and the likely class of remedy. It does not
+answer whether an interaction meets a production budget. Use the measurement
+method in [Performance](18-performance.md) for that.
 
-When the question is about *correctness* rather than cause — does this body
-mean what it should, does teardown leak — the answer is a test, not a panel
+Use React DevTools for commit-level React details and browser performance tools
+for layout and paint. Profile release builds for production slowness; a
+development build intentionally contains development work.
+
+When the question is correctness rather than cause, write a test
 ([Testing](14-testing.md)).
 
 ## Advanced
 
-### Explain-render envelope shape
+### Explain-render envelope
 
-The panel, tests, and the AI pair consume the same envelope. A complete example:
+The panel, tests, and AI pair use the same versioned evidence envelope. A
+representative occurrence:
 
 ```clojure
 {:view         todo.views/todo-row
  :frame        :app/main
  :cause        {:kind          :reads
                 :changed-reads [[:todo/by-id 7]]}
- :attempt      :committed          ;; not a retry, not abandoned
- :reads        [[:todo/by-id 7]]   ;; current read set, from execution
- :fan-out      1                   ;; boundaries this change reached
+ :attempt      :committed
+ :reads        [[:todo/by-id 7]]
+ :fan-out      1
  :completeness :complete
  :loss         nil}
 ```
 
-Every envelope also states its schema, producer, operation, scope, and basis so
-a consumer knows what it holds and which generation of the contract produced
-it. You do not need this map to use the panel — open Xray, select the boundary,
-read the cause. The shape matters when you script diagnosis or assert on it.
+The full envelope also identifies its schema, producer, operation, scope, and
+basis. Most developers do not need the raw map; it matters for scripted
+diagnosis and assertions.
 
-### The same projection feeds the AI pair
+### Privacy projection
 
-Xray and the AI pair consume one versioned, privacy-projected evidence schema:
-byte-equivalent projections, one contract. Query arguments pass through the
-privacy projector. Raw values and text are omitted by default. Nothing leaves
-the process unless an authorized consumer requests it.
+Xray and the AI pair consume the same privacy-projected evidence schema.
+Query arguments pass through the projector. Raw values and text are omitted by
+default. Data leaves the process only through an authorised consumer.
 
-### Optional modules bring their own evidence
+### Optional-module evidence
 
-Evidence follows installation. The forms module contributes draft ownership.
-Overlays contribute the active top-layer region. Motion contributes the current
-transition posture. Resources contribute the live demand. Each is a bounded
-projection that exists only while the module is installed and in use. An app
-that uses none of them pays for none of this.
+Installed modules can add bounded projections:
 
-### Retention is bounded on purpose
+- forms: draft ownership;
+- overlays: active top-layer regions;
+- motion: transition posture;
+- resources: live demand.
 
-Xray owns its history budget. The trace ring is the record; a named operation
-(mount/unmount correlation, for example) may keep bounded, commit-owned
-identity. No universal occurrence ledger accumulates in the background. The
-`:cap` label is the visible edge of that choice. The cost is bounded history;
-the alternative is a runtime that slows down in proportion to how long you have
-debugged it.
+An unused or uninstalled module contributes no projection.
+
+### Bounded retention
+
+Xray owns a fixed history budget. The trace ring is the record, and named
+operations may retain bounded, commit-owned identity for correlation. There is
+no unbounded occurrence ledger. `:cap` is the visible boundary of that choice.

--- a/docs/design/hicasso/draft-guide/16-errors.md
+++ b/docs/design/hicasso/draft-guide/16-errors.md
@@ -1,9 +1,10 @@
 # Errors
 
-A view body throws: `nil` where a map was expected, a key that moved, a shape
-that last week's code cannot handle. React's default is not a red box around
-the broken component. React unmounts the entire root, and the user gets a
-blank page.
+When a view throws during render, React does not automatically replace only
+that view with an error message. Without an error boundary, React can unmount
+the entire root and leave the user with a blank page.
+
+Wrap independently useful regions with `h/error-boundary`:
 
 ```clojure
 (ns app.articles
@@ -12,53 +13,88 @@ blank page.
 (h/defview article-page [{:keys [id]}]
   [:main
    [site-header {}]
-   [h/error-boundary {:fallback [:p.oops "We couldn't load this article."]}
+
+   [h/error-boundary
+    {:fallback
+     [:p.oops "We couldn't load this article."]}
     [article-body {:id id}]]
+
    [site-footer {}]])
 ```
 
-If `article-body` throws during render, the header and footer stay up, and the
-paragraph takes the article's place. Nothing else in the tree notices.
+If `article-body` throws while rendering, the fallback replaces that region.
+The header and footer remain mounted.
 
-[`h/error-boundary`](glossary.md#error-boundary) is a component you write into
-the tree. It is not the re-render unit that a
-[`defview`](glossary.md#defview) creates
-([Views and reads](02-views-and-reads.md)). Only `h/error-boundary` catches.
+`h/error-boundary` is the component that catches. A normal `defview` boundary
+only defines an independently re-rendering view; it is not an error boundary.
 
-## The three keys
+## Boundary options
 
-`h/error-boundary` takes exactly three props. There is no built-in
-classification, retry policy, or logging. Those are your app's decisions, and
-you make them in `:on-error`.
+An error boundary accepts three props:
 
-| Key | Shape | What it does |
+| Prop | Shape | Behaviour |
 | --- | --- | --- |
-| `:fallback` | hiccup, or `(fn [error] hiccup)` | renders instead of the children once something below has thrown |
-| `:reset-key` | any value, compared with `=` | changing it clears the caught failure and remounts the children |
-| `:on-error` | an event vector, or a plain function | fires once per caught failure |
+| `:fallback` | Hiccup, or `(fn [error] hiccup)` | Replaces the children after a caught failure |
+| `:reset-key` | Any value compared with `=` | When it changes, clear the caught failure and remount the children |
+| `:on-error` | Event vector or plain function | Run once for each caught failure |
 
-**`:fallback` can read the error.** Pass a function, and the function receives
-the thrown value. Show `(ex-message error)` in development and a plain sentence
-in production. The returned hiccup is lowered like any other,
-[intents](glossary.md#intent) included, under the frame where the region was
-mounted.
+### Fallbacks
 
-**`:reset-key` is how retry works.** The region never guesses. When the key
-changes, it clears the caught failure and remounts the children — a fresh
-mount, not a re-render of the survivors. If the children throw again, the
-region catches again. A counter in app-db is the usual shape.
+A fallback may be static Hiccup:
 
-**`:on-error` fires once per caught failure.** The region dispatches an event
-vector with the error appended — `[:diagnostics/record-failure]` reaches its
-handler as `[:diagnostics/record-failure error]` — in the region's frame. If
-you pass a plain function, the region calls it with the error and dispatches
-nothing. Once means once, even under StrictMode: the throwing render can run
-twice in development, and React still reports a single catch.
+```clojure
+{:fallback [:p.oops "This panel failed."]}
+```
 
-## A nested region, with retry
+Or it may inspect the thrown value:
 
-Regions nest, and the inner region wins. The nearest region above a throw
-catches it; everything outside that region continues to render.
+```clojure
+{:fallback
+ (fn [error]
+   [:div.oops
+    [:p "This panel failed."]
+    [:pre (ex-message error)]])}
+```
+
+Use detailed messages in development and user-safe copy in production. Hiccup
+returned by the fallback is rendered under the same frame as the boundary, so
+its event intents work normally.
+
+Keep fallbacks simple. A fallback that reads the same broken state or performs
+heavy work can throw itself. That second failure is caught only by the next
+boundary above it.
+
+### Retry with `:reset-key`
+
+A caught boundary remains in the failed state until its `:reset-key` changes.
+The change clears the failure and **remounts** the children. It does not
+re-render the surviving failed subtree.
+
+Use an app-db counter or generation value when the user presses Retry.
+
+### Report with `:on-error`
+
+An event vector receives the thrown error as its final argument:
+
+```clojure
+:on-error [:diagnostics/record-failure]
+```
+
+The handler receives:
+
+```clojure
+[:diagnostics/record-failure error]
+```
+
+The event dispatches into the boundary's frame. A plain function is called
+with the error and does not dispatch anything.
+
+`on-error` runs once for each caught failure. Development StrictMode may run
+the failing render more than once, but one React catch produces one report.
+
+## Nested boundaries and retry
+
+The nearest error boundary above the throw handles it:
 
 ```clojure
 (ns app.reports
@@ -66,7 +102,8 @@ catches it; everything outside that region continues to render.
             [re-frame.hicasso :as h]))
 
 (rf/reg-sub :chart/attempt
-  (fn [db _query] (:chart/attempt db)))
+  (fn [db _query]
+    (:chart/attempt db 0)))
 
 (rf/reg-event :chart/retry
   (fn [{:keys [db]} _event]
@@ -74,61 +111,75 @@ catches it; everything outside that region continues to render.
 
 (rf/reg-event :diagnostics/record-failure
   (fn [{:keys [db]} [_ error]]
-    {:db (update db :diagnostics/failures (fnil conj []) (ex-message error))}))
+    {:db (update db
+                 :diagnostics/failures
+                 (fnil conj [])
+                 (ex-message error))}))
 
-(h/defview reports-page [_props]
+(h/defview reports-page [_]
   [:main
    [report-header {}]
-   [h/error-boundary {:fallback [:p.oops "We couldn't show this report."]}
+
+   [h/error-boundary
+    {:fallback
+     [:p.oops "We couldn't show this report."]}
+
     [report-summary {}]
-    [h/error-boundary {:fallback  (fn [_error]
-                                    [:div.panel-oops
-                                     [:p "The live chart failed."]
-                                     [:button {:on-click [:chart/retry]}
-                                      "Try again"]])
-                       :reset-key (h/sub [:chart/attempt])
-                       :on-error  [:diagnostics/record-failure]}
+
+    [h/error-boundary
+     {:fallback
+      (fn [_error]
+        [:div.panel-oops
+         [:p "The live chart failed."]
+         [:button {:on-click [:chart/retry]}
+          "Try again"]])
+      :reset-key (h/sub [:chart/attempt])
+      :on-error  [:diagnostics/record-failure]}
      [live-chart {}]]]])
 ```
 
-When `live-chart` throws, the inner region catches. The panel shows its
-fallback, `report-summary` and the header stay up, and the outer region never
-fires. The retry button is an ordinary intent. Its handler increments
-`:chart/attempt`, the `:reset-key` changes, and the chart remounts. If the bad
-data is still there, the region catches again.
+If `live-chart` throws:
 
-A throw in `report-summary`, which sits outside the inner region, lands in the
-outer region instead: the whole report body is replaced, and the header
-survives.
+- the inner boundary catches it;
+- the chart region shows its fallback;
+- the report summary and header remain;
+- the outer boundary does not report the failure.
 
-**A fallback that throws is caught by the next region up.** A fallback that
-re-reads the state that just failed can turn one broken panel into a broken
-page. Keep fallbacks plain: static markup, a retry intent, nothing heavy.
+The Retry button increments `:chart/attempt`. The reset key changes and the
+chart mounts from scratch. If it throws again, the boundary catches the new
+failure.
 
-## What it never sees
+A throw from `report-summary`, which is outside the inner boundary, reaches the
+outer boundary instead.
 
-The region inherits React's rule exactly.
+## What an error boundary catches
 
-**Caught:** a throw from render, and a throw from the lifecycle and effects of
-the tree below the region.
+The boundary follows React's error-boundary rules.
 
-**Not caught:** anything the browser calls outside render — an event handler, a
-`setTimeout`, a promise continuation. Those failures belong to re-frame2, not
-to the view layer. An intent's handler runs inside the event pipeline. The
-pipeline catches the throw, reports a structured error record
-(`:rf.error/handler-exception`, with the event, frame, and recovery attached),
-and the app continues to run. A raw `fn` callback that throws goes to the
-browser's error channel like any other JavaScript. Either way the region's
-fallback never shows — nothing below the region failed to *render*.
+**Caught:** throws during render and throws from lifecycle or effect work in
+the descendant React tree.
 
-## Expected failures stay data
+**Not caught:** work the browser invokes outside render, including event
+handlers, timers, and promise continuations.
 
-If you can name the failure in advance, the failure is state, not an exception.
-A request can 404, a form can be invalid, a resource can be unavailable. Model
-each in app-db, and render each with an ordinary view.
+A re-frame2 event handler runs in the event pipeline. If it throws, the
+pipeline reports `:rf.error/handler-exception` with the event, frame, and
+recovery data, then keeps the application runtime alive. It does not render a
+view fallback.
+
+A raw JavaScript callback that throws reaches the browser's error channel.
+Again, the error boundary does not see it because no descendant failed during
+React rendering or lifecycle.
+
+## Expected failures are state
+
+Use app-db status values for failures you can name in advance: a 404, invalid
+input, an unavailable resource, or an expected permission denial.
+
+Do not throw to express ordinary control flow:
 
 ```clojure
-;; Don't — a 404 is not an exception, and a region is not control flow
+;; Don't: a missing article is an expected state.
 (h/defview article-body [{:keys [id]}]
   (let [article (h/sub [:article/by-id id])]
     (when (nil? article)
@@ -136,49 +187,53 @@ each in app-db, and render each with an ordinary view.
     [:article (:title article)]))
 ```
 
+Render the status explicitly:
+
 ```clojure
 (h/defview article-body [{:keys [id]}]
   (case (h/sub [:article/status id])
     :loading [loading-placeholder {}]
     :failed  [load-failed {:id id}]
-    [:article (:title (h/sub [:article/by-id id]))]))
+    [:article
+     (:title (h/sub [:article/by-id id]))]))
 ```
 
-The second version is testable with `=`, renders a real message instead of a
-generic fallback, and leaves the region free for the failure you did not plan
-for. Fetch status and mutation status are ordinary app-db state;
-[Async resources](08-async-resources.md) owns that shape.
+The explicit version is easy to test, can show a precise message, and reserves
+the error boundary for failures the application did not plan for. Resource and
+mutation statuses are covered in [Async resources](08-async-resources.md).
 
-## Where regions go
+## Place boundaries at useful recovery regions
 
-Regions do not go everywhere, and not once at the root. A single root region is
-a whole-page fallback — not much better than a blank screen, and navigation
-goes down with the page. One region per view is noise; most views cannot fail
-independently of their parent.
+A single boundary around the root turns every failure into a whole-page
+fallback and may remove navigation along with the broken content. A boundary
+around every small view creates noise without useful recovery.
 
-The useful grain is **a region the user can still work without**: a panel, a
-tab body, a sidebar widget, a route's main content. Ask what the rest of the
-page is worth if this part is gone. If the answer is "nothing", put the region
-higher.
+Place a boundary around a region the user can continue without:
+
+- a dashboard panel;
+- a tab body;
+- a sidebar widget;
+- a route's main content while the surrounding shell remains usable.
+
+Ask what should stay available when this region fails. Put the boundary at the
+level that preserves it.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| Whole page blanks when one view throws | Nothing caught it — React unmounts the root by default | Put `h/error-boundary` around the region that can fail |
-| A throw from an event handler is not caught by the region | Handlers run in the event pipeline, not in render; the pipeline catches it and reports `:rf.error/handler-exception` | Expected — read the error record; the view layer never sees it |
-| Fallback shows and never leaves | No `:reset-key`, or the key never changes | Drive the key from app-db and bump it to retry |
-| Retry button in the fallback does nothing | The intent lowers under the region's frame; without a frame in scope it raises `:rf.error/hicasso-intent-outside-boundary` | Keep the fallback ordinary hiccup inside the mounted tree; dispatch a plain intent |
-| One panel breaks and the page follows it down | The fallback itself threw; the next region up caught that | Keep fallbacks plain — no reads of the failed state, no heavy work |
-| `:on-error` seems to fire twice in development | It does not — StrictMode re-runs the failing render; React reports one catch | Two fires means two real failures |
-| The region did not catch during a server render | React routes server render errors through its server error channel; client regions never see them | The surface's server policy owns that path ([SSR and hydration](17-ssr-and-hydration.md)) |
+| One view throws and the whole page blanks | No boundary caught the render failure, so React unmounted the root | Wrap the independently recoverable region with `h/error-boundary` |
+| An event-handler exception does not show the fallback | Event handlers run in the re-frame2 pipeline, not descendant React render | Inspect the `:rf.error/handler-exception` record; do not expect a view fallback |
+| Fallback appears and never clears | There is no `:reset-key`, or its value never changes | Drive a generation value from app-db and change it on Retry |
+| Retry intent in the fallback raises `:rf.error/hicasso-intent-outside-boundary` | The fallback was rendered outside the mounted Hicasso/frame tree | Keep fallback Hiccup inside the boundary and use an ordinary event intent |
+| A panel fallback throws and the larger page fallback appears | The fallback itself failed and the next outer boundary caught it | Keep fallbacks small and avoid re-reading the failed state |
+| `:on-error` appears to fire twice in development | Two distinct failures occurred; StrictMode alone still produces one report per catch | Inspect the two error records and their causes |
+| A server-render throw is not caught by the client boundary | Server rendering uses the server error channel; a client error boundary cannot handle server execution | Apply the surface's server policy and server error handling ([SSR and hydration](17-ssr-and-hydration.md)) |
 
-## When not to use it
+## When not to use an error boundary
 
-- **The failure is expected** — a 404, invalid input, an empty result. That is
-  app-db state rendered by an ordinary view. A region there is a worse version
-  of a status key.
-- **Around every view** — a region earns its place at the grain of "the user
-  can still work without this"; below that grain it is noise.
-- **As loading UI** — a fallback is for failure, not for pending. Pending is
-  data too.
+Do not use it:
+
+- for an expected failure such as a 404, validation error, or empty result;
+- around every small view without an independent recovery experience;
+- as loading UI. Pending is state, not a render exception.

--- a/docs/design/hicasso/draft-guide/17-ssr-and-hydration.md
+++ b/docs/design/hicasso/draft-guide/17-ssr-and-hydration.md
@@ -1,19 +1,21 @@
 # SSR and hydration
 
-You want real HTML in the first response, and you want the same app to take
-over in the browser. You do not want to write the UI twice, and you do not want
-a second HTML emitter that drifts from what the client renders.
+Server-side rendering should produce the same UI that the browser later
+adopts. Hicasso does not use a separate string-template implementation: the
+server renders the same views and React elements used by the client.
 
-Hicasso renders the same views on the server that you mount in the browser.
-Each host and native component either produces deterministic HTML or is
-Client-only. A Client-only surface leaves its declared fallback in the server
-bytes — or nothing, the bare default — until the browser takes over. The
-browser adopts the server's DOM; it does not repaint over it.
+Every foreign or native component has one of two server policies:
 
-## Serve a page from a snapshot
+- **Render**: run on the server and produce deterministic HTML;
+- **Client-only**: do not run on the server; render a declared fallback or
+  nothing until the browser takes over.
 
-The example page: a feed read from app-db, plus a foreign chart that works only
-in a browser.
+Hydration adopts the server's DOM and attaches the application. It does not
+replace the page with a fresh client mount when the two sides agree.
+
+## Render a page from a snapshot
+
+The example page reads a feed from app-db and includes a browser-only chart:
 
 ```clojure
 (ns app.views
@@ -22,25 +24,28 @@ in a browser.
 
 (h/defhost trend-chart TrendChart
   {:server   :client-only
-   :fallback [:div {:class "chart chart--pending"}
+   :fallback [:div
+              {:class "chart chart--pending"}
               "Chart loads in the browser"]})
 
 (h/defview article-row [{:keys [id]}]
   [:li {:class "article"}
-   [:a {:href (h/sub [:article/url id])} (h/sub [:article/title id])]])
+   [:a {:href (h/sub [:article/url id])}
+    (h/sub [:article/title id])]])
 
 (h/defview page [_]
   [:main
    [:h1 (h/sub [:feed/heading])]
-   [:ul (for [id (h/sub [:feed/article-ids])]
-          [article-row {:id id :key id}])]
-   [trend-chart {:points (clj->js (h/sub [:feed/trend]))}]])
+   [:ul
+    (for [id (h/sub [:feed/article-ids])]
+      [article-row {:id id :key id}])]
+   [trend-chart
+    {:points (clj->js (h/sub [:feed/trend]))}]])
 ```
 
-Nothing here is SSR-specific. Ordinary Hicasso is already the app that serves.
+No view code is specific to SSR.
 
-The server side is the optional server module. One request goes in; one
-document comes out:
+Use the optional server module to render one request:
 
 ```clojure
 (ns app.server
@@ -50,57 +55,63 @@ document comes out:
             [app.events]))
 
 (defn page-response
-  "Render one request from a db snapshot."
+  "Render one request from an app-db snapshot."
   [db-snapshot]
   (:document
    (server/render
     {:hiccup            [views/page {}]
-     :snapshot          db-snapshot            ;; seeded whole via :rf/set-db
-     :payload           [:feed :session]       ;; allowlist — what rides the wire
-     :client-frame-id   :app/main              ;; the stable wire frame id
-     :identifier-prefix "main"                 ;; must match the hydrating root
+     :snapshot          db-snapshot
+     :payload           [:feed :session]
+     :client-frame-id   :app/main
+     :identifier-prefix "main"
      :app-element-id    "app"
      :script-src        "/js/app.js"
      :title             "The feed"})))
 ```
 
-`server/render` runs five steps in a fixed order:
+`server/render` performs a fixed sequence:
 
-1. Creates a fresh frame under a private id. Two concurrent requests cannot
-   read each other's app-db.
-2. Seeds state through the framework's own doors: the snapshot via
-   `:rf/set-db`, then any `:initial-events` (a resolved route, a completed
-   fetch) in order.
-3. Renders the view to HTML with `react-dom/server` — the same element tree
-   the browser mounts, with host policies honoured.
-4. Builds the hydration payload from the allowlisted app-db slice and embeds
-   it as the page's `__rf_payload` script.
-5. Destroys the frame in a `finally`, so a render that throws leaks no more
-   than a render that returns.
+1. Create a fresh private frame for the request.
+2. Seed it through the normal framework doors: `:rf/set-db` for `:snapshot`,
+   followed by any `:initial-events` in order.
+3. Render the React tree to HTML with `react-dom/server`, applying each host
+   and native component's server policy.
+4. Build the hydration payload from the allowlisted app-db keys and embed it
+   as `__rf_payload`.
+5. Destroy the request frame in a `finally` block, including when rendering
+   throws.
 
-**`:payload` is fail-closed.** It is a non-empty vector of top-level app-db
-keys, or the explicit `:rf.ssr.payload/whole-app-db`. If you omit it, the
-service throws `:rf.error/ssr-missing-payload-policy` at boot. Allowlist every
-key the page reads. A key the server rendered from but did not ship hydrates
-the client against different state — and the mismatch complaints that follow
-are real.
+Concurrent requests cannot read each other's app-db.
 
-Hand `:document` to the HTTP host you run. Two renders from the same snapshot
-produce byte-identical documents.
+### The payload is fail-closed
 
-A server render runs no effects. Every [`h/sub`](glossary.md#hsub) read is a
-cold probe against one coherent snapshot: no subscription registered, no
-commit, no disposal. Same bundle, same snapshot, same bytes — that holds when
-bodies are functions of their props and reads. A clock, a `js/window` check,
-or a random value in a body paints one thing on the server and another in the
-browser; React reports the divergence as a hydration mismatch. Platform work
-belongs in effects: `:platforms #{:client}` handlers are skipped server-side.
+`:payload` must be either:
 
-## Hydrate it
+- a non-empty vector of top-level app-db keys; or
+- `:rf.ssr.payload/whole-app-db` as an explicit opt-in.
 
-Hydration is two steps in a fixed order: state first, adoption second. The
-first client render must run against the server's state. Otherwise the two
-trees disagree before React compares a single node.
+Omitting it raises `:rf.error/ssr-missing-payload-policy` at service boot.
+Allowlist every top-level key the rendered page reads. If the server rendered a
+value that the client did not receive, the first client render uses different
+state and the resulting hydration mismatch is real.
+
+The HTTP service returns `:document`.
+
+### Server render rules
+
+A server render performs cold subscription reads against one immutable
+snapshot. It does not register live subscriptions, commit React work, or run
+client effects.
+
+Two renders from the same code and snapshot should produce the same document.
+Do not read clocks, randomness, `window`, or other ambient platform state from
+a view body. Put browser work in client-only effects such as
+`:platforms #{:client}` or behind a declared host.
+
+## Hydrate state before adopting the DOM
+
+The first client render must see the same state used by the server. Hydration
+therefore has two ordered steps:
 
 ```clojure
 (ns app.client
@@ -111,248 +122,254 @@ trees disagree before React compares a single node.
             [app.events]))
 
 (defn ^:export run []
-  ;; 1. State: read __rf_payload, dispatch :rf/hydrate, replace frame state.
+  ;; 1. Read __rf_payload and replace the target frame's state.
   (ssr/hydrate! {:frame :app/main})
-  ;; 2. Adoption: keep the server's DOM, attach listeners, report divergence.
-  (h/hydrate! (js/document.getElementById "app")
-              {:frame             :app/main
-               :identifier-prefix "main"}
-              [views/page {}]))
+
+  ;; 2. Adopt the existing server DOM.
+  (h/hydrate!
+   (js/document.getElementById "app")
+   {:frame             :app/main
+    :identifier-prefix "main"}
+   [views/page {}]))
 ```
 
-!!! note "Two `hydrate!`s, two halves"
+The two functions have different jobs:
 
-    `ssr/hydrate!` is the framework's state half. It reads the payload,
-    dispatches `:rf/hydrate` against the target frame — the server's slice
-    replaces the client's — and validates the wire frame id against `:frame`.
-    A conflict raises `:rf.error/hydration-frame-id-mismatch`; an absent
-    `:frame` raises `:rf.error/no-frame-context`.
+- `ssr/hydrate!` applies the state payload through `:rf/hydrate`. It validates
+  the wire frame id against the requested frame. A mismatch raises
+  `:rf.error/hydration-frame-id-mismatch`; no frame context raises
+  `:rf.error/no-frame-context`.
+- `h/hydrate!` calls React's `hydrateRoot` on a container that already has
+  server markup.
 
-    [`h/hydrate!`](glossary.md#hydrate) is the DOM half: React's `hydrateRoot`
-    on a container that already holds server bytes. The order between the two
-    calls is fixed.
+State always comes first.
 
-`h/hydrate!` stands beside [`h/mount!`](glossary.md#mount)
-([Installation](installation.md)): the same association of a container, a
-frame, and one view, and the same idempotent handle for
-[`h/unmount!`](glossary.md#mount).
+`h/hydrate!` has the same root lifecycle as `h/mount!`: it associates one
+container, one frame, and one view, and returns a handle accepted by
+`h/unmount!`.
 
-- **Adoption is root-scoped.** The handle owns its container, its
-  `:identifier-prefix`, and its error reporting. Nothing about hydration is
-  process-global.
-- **It returns before adoption finishes.** React hydrates without
-  `flushSync`. Do not assume that the DOM on the next line is client-owned.
-- **`:identifier-prefix` must match the server render's.** React's `useId`
-  writes the prefix into every generated id in the bytes. A prefix
-  disagreement flags every generated id at once.
-- **Controlled text is never rewritten afterwards.** The model's value is in
-  the server bytes ([Controlled inputs](04-controlled-inputs.md)).
-- **Presence children are born present.** Nothing that arrived with the page
-  replays an entrance animation over content the user already reads.
+Important root rules:
 
-`ssr/hydrate!` returns the applied payload, or `nil` when the page carries
-none. The same boot therefore serves a client-only load: on `nil`, fall
-through to `h/mount!` with your ordinary `:initial-events` seed.
+- **Hydration is root-scoped.** Each root owns its container, identifier
+  prefix, and recoverable-error stream.
+- **The call returns before adoption finishes.** React hydrates
+  asynchronously. The next line must not assume the DOM is fully client-owned.
+- **`:identifier-prefix` must match.** React includes the prefix in `useId`
+  output. A mismatch can flag every generated id in the root.
+- **Controlled text is adopted, not rewritten later.** The model value must
+  already be present in the server bytes.
+- **Presence-managed children start as `:present`.** Existing page content
+  does not replay an entry animation.
 
-## Client-only hosts with a fallback
+`ssr/hydrate!` returns the applied payload, or `nil` when the page carries no
+payload. A shared boot path can call `h/mount!` with ordinary
+`:initial-events` when it receives `nil`.
 
-Foreign React components often cannot run on the server. Declare that at the
-host:
+## Client-only components and fallbacks
+
+Client-only is the default for foreign hosts:
 
 ```clojure
-(h/defhost stock-widget StockWidget)               ;; Client-only — the default
+(h/defhost stock-widget StockWidget)
+
 (h/defhost trend-chart TrendChart
   {:server   :client-only
-   :fallback [:div {:class "chart chart--pending"}
+   :fallback [:div
+              {:class "chart chart--pending"}
               "Chart loads in the browser"]})
 ```
 
-On the server, the crossing renders its declared fallback, or nothing. In the
-browser, the live component mounts after adoption completes. A fresh
-client-only mount (no SSR) renders the component immediately, with no fallback
-flash.
+On the server, the crossing renders its fallback or nothing. The first client
+pass produces the same fallback. After adoption, the live component mounts. A
+fresh client-only application with no SSR mounts the live component directly
+and does not show the server fallback.
 
-The fallback must be deterministic, inert markup. It is walked once at the
-declaration, and it lands in the server bytes *and* in hydration's first client
-pass; those two must agree. A [`defview`](glossary.md#defview) or
-[`defhost`](glossary.md#defhost) head written into a fallback raises
-`:rf.error/hicasso-host-fallback-boundary-head` at the declaration — a body
-that runs later cannot be deterministic.
+A fallback must be deterministic, inert Hiccup. It is inspected at declaration
+time. A `defview` or `defhost` head inside it raises
+`:rf.error/hicasso-host-fallback-boundary-head`, because a later-running body
+cannot be part of the fixed fallback contract.
 
-**Render** is the other policy: assert that the component is safe to run on a
-server. Write `{:server :render}`, and the component is the element's own type
-on server, first client pass, and fresh mount. There is no swap at adoption.
-Render is also the only policy under which a crossing's **children** reach the
-server response. Both Client-only shapes render *instead of* the component,
-children included — so a transparent wrapper (a context provider) that stays
-Client-only deletes its subtree from the response. The answer to "my provider
-vanished server-side" is `{:server :render}` when the provider is server-safe.
+Use a same-footprint skeleton to reduce layout shift.
 
-If the Render assertion is false, the failure is loud: `window is not defined`,
-thrown mid-render. A policy value outside the two raises
-`:rf.error/hicasso-host-bad-ssr-policy`. So does a `:fallback` under Render —
-there is nothing for the fallback to replace. An option `defhost` does not know
-raises `:rf.error/hicasso-host-unknown-option`.
+## Render-safe hosts
 
-The full per-surface table is under Advanced.
-
-## Two roots, two verdicts
-
-A page may carry several server-rendered roots — for example, an app and a help
-panel. Each root adopts and complains independently:
+Declare `{:server :render}` when a component is deterministic and safe to run
+on the server:
 
 ```clojure
-(h/defview help-panel [_]                        ;; in app.views
+(h/defhost theme-provider ThemeProvider
+  {:server :render})
+```
+
+Under Render, the real component is used for:
+
+- server rendering;
+- the first client hydration pass;
+- fresh client mounts.
+
+There is no component swap after adoption.
+
+Render is also the only policy that sends a crossing's **children** to the
+server. A Client-only component renders its fallback or nothing **instead of
+the whole crossing**, including its children. A transparent wrapper such as a
+context provider therefore deletes its subtree from the server response unless
+it is declared Render.
+
+A false Render assertion fails loudly, often as `window is not defined` during
+the server render. Other declaration failures include:
+
+- `:rf.error/hicasso-host-bad-ssr-policy` for an unsupported policy or a
+  `:fallback` combined with Render;
+- `:rf.error/hicasso-host-unknown-option` for an unknown host option.
+
+## Multiple roots report independently
+
+A page can hydrate several roots against one frame and payload:
+
+```clojure
+(h/defview help-panel [_]
   [:aside
    [:h2 "Need a hand?"]
-   ;; Don't — deliberate divergence, kept to show the complaint:
+   ;; Don't: deliberate server/client divergence.
    [:p "Generated at " (js/Date.now)]])
 
 (defn ^:export run []
-  (ssr/hydrate! {:frame :app/main})            ;; one payload seeds the frame once
-  (h/hydrate! (js/document.getElementById "app")
-              {:frame :app/main :identifier-prefix "main"}
-              [views/page {}])
-  (h/hydrate! (js/document.getElementById "help")
-              {:frame :app/main :identifier-prefix "help"}
-              [views/help-panel {}]))
+  (ssr/hydrate! {:frame :app/main})
+
+  (h/hydrate!
+   (js/document.getElementById "app")
+   {:frame :app/main
+    :identifier-prefix "main"}
+   [views/page {}])
+
+  (h/hydrate!
+   (js/document.getElementById "help")
+   {:frame :app/main
+    :identifier-prefix "help"}
+   [views/help-panel {}]))
 ```
 
-The server rendered one timestamp into the help panel; the client's first pass
-computes another. React keeps the client's version, repairs the DOM, and
-reports what it recovered from:
+The timestamp differs between server and client. React repairs the help root
+and reports a root-scoped mismatch:
 
 ```clojure
 {:id    :rf.ssr/hydration-mismatch
- :root  "help"                    ;; the root that complained, by prefix/container
- :where app.views/help-panel      ;; view identity and source
- :error recoverable-error}        ;; React's report, component stack included
+ :root  "help"
+ :where app.views/help-panel
+ :error recoverable-error}
 ```
 
-The `#app` root hydrated clean; its stream is empty. Each `h/hydrate!` wires
-its own recoverable, caught, and uncaught error channels, so one faulty root
-cannot contaminate the other's verdict. Xray's hydration lane shows the
-complaints joined to view source and host policy
-([Diagnostics](15-diagnostics.md)).
+The app root can still hydrate cleanly. Each `h/hydrate!` has its own
+recoverable, caught, and uncaught error channels.
 
-The fix is the usual one: a value that both sides must agree on belongs in
-state — written by an event, rendered from the snapshot.
+Xray associates hydration complaints with the root, view source, and host
+policy ([Diagnostics](15-diagnostics.md)).
 
-React reports text divergence and missing, extra, or wrong-type elements. It
-does not report an attribute-only divergence: a stale `class` on an element
-whose tag and text still match receives a development warning, not a production
-callback. Recovery is replacement, not patching.
+React reports text differences and missing, extra, or wrong-type elements.
+Attribute-only divergence may produce only a development warning and can be
+harder to observe. The reliable fix is the same: values that both sides must
+share belong in the snapshot or hydration payload.
 
-??? info "Coming from Reagent: where is the structural hash?"
-    The Reagent-tier adapters hash their hiccup tree on the server and re-hash
-    the client's first render. Views there are pure functions that return a
-    data tree, so there is a tree to hash. Hicasso views reach React as
-    elements, and React walks the tree internally, so no data tree exists to
-    hash and no hash rides the payload. Verification on this tier is React's
-    own adoption, reported per root.
+??? info "Coming from a Hiccup-tree hash"
+    Some adapters can hash an authored Hiccup data tree before React sees it.
+    Hicasso views produce React elements and React performs the traversal, so
+    there is no separate complete Hiccup tree to hash. Verification uses
+    React's own root-scoped adoption reports.
 
-## When not to server-render
+## When not to use SSR
 
-A client-only application never ships the service: no Node process, no payload,
-no snapshot plumbing. Boot is `h/mount!` and an `:initial-events` seed. Apps
-behind a login wall usually belong here. First-response HTML of private,
-per-user state rarely justifies a render fleet.
+A client-only application does not need the Node rendering service, payload
+allowlist, or snapshot plumbing. Boot it with `h/mount!` and
+`:initial-events`.
 
-You do not opt out of the contract. Server policies are declared and checked at
-their sources whether or not a server exists. Every surface keeps its
-Render-or-Client-only rule, and hydration behaviour is part of each surface's
-definition. That is why turning SSR on later is configuration — a snapshot, an
-allowlist, a prefix — and not a rewrite.
+Applications behind a login wall often gain little from rendering private,
+per-user HTML on a server fleet.
+
+Even in a client-only deployment, keep host and native server policies
+accurate. That makes later SSR adoption a configuration task rather than a
+view rewrite.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| `:rf.ssr/hydration-mismatch` naming a root and a view | The two renders disagreed — a body read the platform (clock, random, `js/window`) instead of props and reads | Keep bodies pure; platform work goes to `:platforms #{:client}` effects and host edges |
-| Every `useId`-derived id on one root complains at once | That root's `:identifier-prefix` does not match the server render's | Pass the same prefix to `server/render` and that root's `h/hydrate!`; keep prefixes unique per root |
-| A Client-only host shows its fallback, then the live widget swaps in | The policy working: fallback is in the server bytes and the first client pass; the component mounts at adoption | Make the fallback a same-footprint skeleton to kill the layout jump; only `{:server :render}` removes the swap |
-| `:rf.error/hicasso-host-fallback-boundary-head` at a declaration | A `defview`/`defhost` head in a fallback | Plain hiccup in the fallback, or `{:server :render}` and render the real subtree |
-| `window is not defined` during a server render under `{:server :render}` | The Render assertion is false — the component is not server-safe | Drop back to Client-only with a fallback |
-| A crossing's children are missing from the server HTML, silently | The crossing is Client-only; both Client-only shapes render instead of the component — a transparent wrapper takes its subtree with it | Declare `{:server :render}` on the wrapper if it is server-safe |
-| `:rf.error/hicasso-host-bad-ssr-policy` at a declaration | A policy value outside the two, or `:fallback` combined with Render | Two policies: `:render`, or `:client-only` with an optional `:fallback` |
-| `:rf.error/ssr-missing-payload-policy` at service boot | No `:payload` policy — the wire contract is fail-closed | Allowlist the top-level app-db keys the page reads, or opt in with `:rf.ssr.payload/whole-app-db` |
-| Mismatch complaints although every body is pure | A key the views read is missing from the `:payload` allowlist, so the client hydrated against different state | Add the key to the allowlist |
-| `:rf.error/hydration-frame-id-mismatch` at boot | The payload's wire frame id and `ssr/hydrate!`'s `:frame` disagree | One stable id on both sides: `:client-frame-id` at the server render, the same `:frame` at boot |
+| `:rf.ssr/hydration-mismatch` names a root and view | Server and first client render differed, often because a body read a clock, random value, or browser global | Keep bodies deterministic; move platform work to client effects or host edges |
+| Every `useId` id in one root reports a mismatch | The root's `:identifier-prefix` differs from the server prefix | Use the same unique prefix in `server/render` and that root's `h/hydrate!` |
+| Client-only widget shows a skeleton, then swaps to the live widget | The Client-only policy is working | Use a same-size fallback, or select Render only when the component is truly server-safe |
+| Declaration raises `:rf.error/hicasso-host-fallback-boundary-head` | The fallback contains a view or host head | Use plain deterministic Hiccup, or render the real component with `{:server :render}` |
+| Server render throws `window is not defined` under Render | The component is not server-safe | Return it to Client-only and provide a fallback |
+| A host's children are absent from server HTML | The host is Client-only, so the fallback replaces the whole crossing | Mark a server-safe transparent wrapper `{:server :render}` |
+| Declaration raises `:rf.error/hicasso-host-bad-ssr-policy` | Unsupported policy, or `:fallback` used with Render | Use `:render`, or `:client-only` with an optional fallback |
+| Service boot raises `:rf.error/ssr-missing-payload-policy` | No fail-closed payload policy was supplied | Allowlist every top-level app-db key the page reads, or explicitly select whole app-db |
+| Pure views still mismatch | A rendered app-db key was omitted from the payload | Add the key to the allowlist |
+| Boot raises `:rf.error/hydration-frame-id-mismatch` | Server `:client-frame-id` and client `:frame` differ | Use one stable wire frame id on both sides |
 
 ## Advanced
 
-### Every surface has a server answer
+### Server policy by surface
 
-Semantics live in React, so the server renders with React: `react-dom/server`
-under Node, which walks the same components the browser mounts. There is no
-parallel string emitter and no JVM twin of the view layer.
+React renders the server output; there is no parallel JVM string emitter.
 
-Two policies govern each surface:
-
-- **Render** — the surface produces deterministic React server bytes from an
-  immutable request snapshot. Hydration adopts those bytes.
-- **Client-only** — the surface does not run on the server. What stands in its
-  place is a deterministic fallback if the declaration carries one, otherwise
-  nothing. The live component arrives in the browser after adoption completes.
-
-| Surface | Policy |
+| Surface | Server policy |
 | --- | --- |
-| Hiccup elements, fragments, text | Render |
-| `h/defview` bodies and `h/sub` reads | Render — reads probe the request snapshot |
-| Controlled fields | Render — value/checked attributes come from the model |
-| `h/error-boundary` | Render — a throw during a server render takes React's server error channel, not the boundary's fallback |
-| Roots and the outward bridge | Render — request-isolated, prefix-matched |
-| `h/defhost`, ReactNode slots, render props, `h/as-element` | Client-only until the declaration selects Render |
-| Portals, raw React elements, opaque foreign components | Client-only — no hydration claim is made for bytes that were never sent |
-| Intrinsic `n/$` forms | Render |
-| `n/defcomponent` and component-headed `n/$` | Client-only until the declaration selects Render |
-| Resource and demand boundaries | Client-only until their module contract selects Render |
+| Native Hiccup elements, fragments, and text | Render |
+| `h/defview` bodies and `h/sub` reads | Render against the request snapshot |
+| Controlled fields | Render their model `value` and `checked` attributes |
+| `h/error-boundary` | The component renders, but a server throw uses React's server error channel rather than the client fallback |
+| Roots and `h/as-component` | Render, with request isolation and prefix matching |
+| `h/defhost`, slots, render props, and `h/as-element` | Client-only until the declaration selects Render |
+| Portals, raw React elements, and opaque foreign components | Client-only |
+| Intrinsic `n/$` | Render |
+| `n/defcomponent` and component-headed `n/$` | Client-only until declared Render |
+| Resource and demand boundaries | Follow their module's server contract; committed client demand does not run during server rendering |
 
-Events as data help at no cost: `[:article/delete id]` on `:on-click` has no
-closure to ship, and each side builds the callback from the vector.
+Event intents require no wire serialisation. Each side turns the same vector
+into its own callback.
 
-### Render on a context provider
+### Context providers
+
+A server-safe context provider must be declared Render so its children remain
+in the response:
 
 ```clojure
-(def theme-context (react/createContext "light"))  ;; (:require ["react" :as react])
-(h/defhost theme-provider (.-Provider theme-context)
-  {:server :render})                               ;; runs on the server, children included
+(def theme-context
+  (react/createContext "light"))
+
+(h/defhost theme-provider
+  (.-Provider theme-context)
+  {:server :render})
 ```
 
-A provider whose *value* comes from the browser has no server story. It stays
-Client-only, and so does everything beneath it.
+A provider whose value depends on browser-only state has no deterministic
+server contract and remains Client-only, along with its subtree.
 
-### The native tier under SSR
+### Native components under SSR
 
-An intrinsic [`n/$`](glossary.md#n-dollar) form is markup, and it Renders. A
-named native component declares its policy; the default is conservative:
+Intrinsic `n/$` markup renders on the server. A named native component is
+Client-only unless it declares Render:
 
 ```clojure
 (n/defcomponent ticker
   {:server :render}
   [^js props]
-  (let [price (n/use-sub [:quote/price (.-symbol props)])]
+  (let [price
+        (n/use-sub
+         [:quote/price (.-symbol props)])]
     (n/$ :span {:class "ticker"} price)))
 ```
 
-Under a server render, [`n/use-sub`](glossary.md#nuse-sub) reads the request
-snapshot through the hook's server path: the same cold-probe discipline, with
-no registration. Omit the declaration map, and the component stays Client-only
-until its declaration selects Render ([The native tier](10-native-tier.md)).
+During server rendering, `n/use-sub` performs the same cold snapshot read as
+`h/sub`. It does not install a live subscription.
 
-### The Node service
+### Node service requirements
 
-The server module deploys as a bounded Node service:
+A production server renderer should provide:
 
-- **Per-request isolation** — a fresh frame per request, destroyed in a
-  `finally`. State never crosses requests.
-- **The allowlisted payload** — the fail-closed `:payload` contract, enforced
-  at boot.
-- **Bounded execution** — one in-flight render per isolate, bounded
-  concurrency, and a timeout with hard termination behind it.
-- **Build identity** — the service knows which client bundle its bytes match.
-- **Error attribution** — a throw during a request is a non-200 with a source,
-  never a half-page.
+- a fresh frame per request, destroyed in `finally`;
+- a fail-closed app-db payload allowlist;
+- bounded concurrency and a hard render timeout;
+- build identity tying server bytes to the matching client bundle;
+- source-attributed non-200 errors instead of partial pages.
 
 The service renders whole pages. Streaming, React Server Components, islands,
-and no-JS progressive enhancement are outside the product.
+and no-JavaScript progressive enhancement are outside this product's scope.

--- a/docs/design/hicasso/draft-guide/18-performance.md
+++ b/docs/design/hicasso/draft-guide/18-performance.md
@@ -1,144 +1,131 @@
 # Performance
 
-"Is it fast enough?" is not a feeling. Hicasso ships with
-[user-visible budgets](glossary.md#user-visible-budget). Performance work is
-the method that meets them: measure, attribute, change the smallest thing, then
-verify again.
+Performance work starts with a user-visible budget, not a general feeling that
+the framework might be slow.
 
-Most apps never leave ordinary Hicasso (rung 1 of the ladder below). That is
-the intended result.
+Measure one interaction, identify the cost owner, change the smallest relevant
+piece, and verify the result under the same conditions. Most applications stay
+on ordinary Hicasso throughout that process.
 
-## The budgets
+## User-visible budgets
 
-The budgets come first, because they are the only honest definition of "slow".
-Each budget is a fact a user can notice, measured at the percentile that
-represents real hardware:
-
-| Budget | The user-visible fact |
+| Budget | Target |
 | --- | --- |
-| Discrete interactions | Click, toggle, submit reach the next paint within **50 ms p95** (100 ms p99) |
-| Keystroke echo | A [controlled field](glossary.md#controlled-field) is correct **in the same turn** and visibly echoed within **one 60 Hz frame** at p95 |
-| Broad operations | Bulk replace, big filter flips complete within **100 ms p95**, unless explicitly classified as background work |
-| Drag and animation | Stay inside the frame budget — normally by keeping high-rate mechanics host-local ([Ephemeral state](11-ephemeral-state.md)) |
-| Narrow updates | Body work scales with **changed rows**, not mounted rows |
-| Teardown | **Zero residue** after quiescence — long sessions do not accumulate |
+| Discrete interaction | Click, toggle, or submit reaches the next paint within **50 ms p95** and **100 ms p99** |
+| Controlled keystroke | State converges in the same browser turn and the visible echo arrives within **one 60 Hz frame at p95** |
+| Broad operation | Bulk replacement or a large filter change completes within **100 ms p95**, unless explicitly classified as background work |
+| Drag or animation | Remains inside the frame budget, usually by keeping high-rate mechanics inside a host |
+| Narrow update | View-body work scales with changed rows or cells, not all mounted rows or cells |
+| Teardown | Returns to **zero additional residue** after quiescence |
 
-Hold your own app to these numbers. The rest of this chapter matters only when
-one of them is missed. A screen that meets its budgets is fast enough, whatever
-score a synthetic benchmark reports.
+A screen that meets its user-visible budgets is fast enough even when a
+synthetic benchmark says another implementation can execute an isolated
+operation faster.
 
-!!! note "Measure under production conditions"
+!!! note "Measure production behaviour"
+    Use production builds, mid-tier hardware, and p95 across repeated runs.
+    Development diagnostics add work that production removes. Your fastest
+    machine and best run are not representative measurements.
 
-    Verify budgets on **production builds**, on mid-tier hardware, at p95
-    across runs. A dev build carries diagnostics that production erases, and
-    your machine is faster than your users' machines. Your best run is not a
-    measurement.
+Teardown is part of performance. Long-lived applications must not accumulate
+subscriptions, timers, listeners, or SDK handles as users leave and revisit
+screens. Hicasso releases its own committed reads. Hosts and native islands
+must release what they acquire ([Interop](09-interop.md)). Prove the complete
+claim with `hm/assert-clean!` ([Testing](14-testing.md)).
 
-The teardown row is user-visible. An SPA session is long, and leave-and-return
-cycles must not accumulate residue. Hicasso guarantees its own side: abandoned
-renders own nothing, and unmount releases every read. Your side is the escapes.
-A host or island that acquires an SDK, a listener, or a timer releases it on
-teardown ([Interop](09-interop.md)), and the [test kit](glossary.md#test-kit)'s
-`assert-clean!` proves the whole claim after quiescence
-([Testing](14-testing.md)).
+## Start with ordinary Hicasso
 
-## Why most apps stay on rung 1
+The normal implementation is:
 
-Rung 1 is ordinary Hicasso: write ordinary views, read at the point of use, put
-[intents](glossary.md#intent) in the markup, and ship. Do not pre-optimise for
-problems you have not measured. Interpreted [lowering](glossary.md#lowering) is
-fast. When a screen misses a budget, the cost almost always lives somewhere
-else: **where the reads sit, how many [boundaries](glossary.md#boundary) exist,
-what React itself does, or what a host does**. Per read, Hicasso's retained
-cost is low; the read *topology* is what you chose. That is why the ladder's
-second rung is "move your reads", not "abandon Hiccup".
+- Hiccup;
+- `h/sub` where the value is used;
+- event intents as data;
+- ordinary view boundaries.
 
-A small share of view code turns out to be hot — often none, rarely more than
-about two percent: a cell that renders constantly, a large collection under
-broad writes, a vendor widget with its own behaviour. For that code the ladder
-continues downward, explicitly and locally. An escape is a local island, never
-a general style.
+Do not optimise for an unmeasured cost. When a page misses a budget, the
+problem is often read placement, view topology, React work, host behaviour, or
+browser layout—not the Hiccup walk itself.
 
-## The ladder
+The retained cost of one read is usually small. The number and placement of
+reads are design choices, which is why topology is the first optimisation
+step.
 
-The [performance ladder](glossary.md#performance-ladder) is the same gradient
-as [the native tier](10-native-tier.md): ordinary Hicasso first, explicit
-escapes only when measurement names them.
+## The performance ladder
 
-Every rung is code that is visible in a diff. There is no `:fast` flag, no
-compile mode, and no setting that changes what Hiccup means:
+Each step is explicit in source. There is no `:fast` mode and no build setting
+that changes what Hiccup means.
 
-| Rung | What you write | Reach for it when | Taught in |
+| Level | Implementation | Use it when | Details |
 | --- | --- | --- | --- |
-| 1 — Ordinary Hicasso | Hiccup, [`h/sub`](glossary.md#hsub) at point of use, intents as data | Always. Start every feature here | [Views and reads](02-views-and-reads.md) |
-| 2 — Tuned topology | The same language; boundary placement, keys, read shape | A named boundary or read pressure | [Lists and collections](06-lists-and-collections.md) |
-| 3 — Direct React return | A `defview` returns an [`n/$`](glossary.md#n-dollar) element; frame, reads, memo stay | Lowering itself is the measured owner | [The native tier](10-native-tier.md) |
-| 4 — Named [native island](glossary.md#native-island) | [`n/defcomponent`](glossary.md#ndefcomponent) (or UIx) under the same root and frame | Hooks, vendor behaviour, reconciliation, or high-rate local work dominate | [The native tier](10-native-tier.md) |
-| 5 — Native screen | A React-first screen authored natively | The screen is React-shaped by nature | [The native tier](10-native-tier.md) |
+| 1. Ordinary Hicasso | Hiccup, point-of-use reads, data intents | Always start here | [Views and reads](02-views-and-reads.md) |
+| 2. Tune topology | Same language; change boundaries, keys, and read shape | A measured interaction invalidates too much work | [Lists and collections](06-lists-and-collections.md) |
+| 3. Direct React return | A `defview` returns `n/$` while keeping its Hicasso frame, reads, and memo | Hiccup lowering is the measured owner | [The native tier](10-native-tier.md) |
+| 4. Native island | `n/defcomponent` or UIx under the same root and frame | Hooks, vendor behaviour, reconciliation, or high-rate local mechanics dominate | [The native tier](10-native-tier.md) |
+| 5. Native screen | A React-first screen under the same state model | The screen is React-shaped by design | [The native tier](10-native-tier.md) |
 
-Rungs 3–5 are taught in [chapter 10](10-native-tier.md). This chapter owns the
-decision: when you step down, and when an escape must come back out.
+This page decides whether a step is justified. The native-tier chapter teaches
+the code.
 
-## The working loop
+## The measurement loop
 
-Performance work that skips a step of this loop is guessing:
+Do not skip a step:
 
-1. **Reproduce.** Name one slow interaction, and script it so that it runs the
-   same way every run. "The app is slow" is not actionable; "expedite on a
-   1,000-row table takes 180 ms" is actionable.
-2. **Attribute.** Correlate the event with the work that ran — which
-   subscriptions recomputed, which boundaries became invalid, how much body
-   work, then commit and paint. Xray's explain-render and read attribution
-   answer the first half. Its hot-view advisor classifies the pressure —
-   computation, topology, lowering, React, or layout — and recommends the
-   smallest credible remedy ([Diagnostics](15-diagnostics.md)).
-3. **Tune topology.** Adjust boundary placement, keys, and read shape — rung 2
-   ([Lists and collections](06-lists-and-collections.md)). Most hot paths are
-   fixed here, and the loop ends.
-4. **Compare direct output** if the measurement names lowering as the owner —
-   rung 3.
-5. **Isolate an island** if hooks, vendor behaviour, reconciliation, or
-   high-rate local work is the owner — rung 4.
-6. **Re-verify.** The change must preserve DOM and intent behaviour, focus and
-   selection, frame routing, SSR/hydration, and cleanup — and the budget must
-   flip from fail to pass. A faster screen that behaves wrongly is wrong.
-7. **Keep or remove.** The escape stays only if it passes the benefit rule
-   below.
+1. **Reproduce.** Script one named interaction. “The app is slow” is not a
+   reproducible case. “Expedite on a 1,000-row table takes 180 ms” is.
+2. **Attribute.** Identify changed subscriptions, notified views, body work,
+   React commit, and browser paint. Use Xray to classify the pressure as
+   computation, topology, lowering, React, or layout
+   ([Diagnostics](15-diagnostics.md)).
+3. **Tune topology.** Change read placement, keys, boundaries, or collection
+   shape. Most cases end here.
+4. **Compare a direct React return** only when lowering is the measured owner.
+5. **Build a native island** only when the owner is hooks, vendor internals,
+   reconciliation, or high-rate local work.
+6. **Re-verify behaviour and performance.** Preserve DOM and intent behaviour,
+   focus, selection, frame routing, SSR/hydration, cleanup, and the original
+   budget.
+7. **Keep or remove the escape.** Apply the benefit rule below.
 
-Three instruments cover attribution, and all three erase from production:
+Use the instruments for the questions they can answer:
 
-| Instrument | The question it answers |
+| Instrument | Question |
 | --- | --- |
-| **Xray** | Which reads changed, which boundaries ran and why, fan-out and read-set churn; the advisor's pressure classification |
-| **React DevTools Profiler** | Which components committed — every boundary is a real React function component under its own display name |
-| **Browser Performance panel** | `rf:*` User-Timing measures for events, subscriptions, effects and renders, on the Timings track next to paint |
+| Xray | Which reads changed, which views ran, why they ran, fan-out, churn, and likely pressure class |
+| React DevTools Profiler | Which real React components committed |
+| Browser Performance panel | Event, subscription, effect, render, layout, and paint timing on one timeline |
 
-A compile-time flag gates the `rf:*` measures, and the default is off. Build
-with `:closure-defines {re-frame.performance/enabled? true}` to emit them; a
-build without the flag carries no timing code at all. The runtime delivers
-entries and does not retain them: a live `PerformanceObserver` and the DevTools
-timeline see every measure, but a later `getEntriesByType` poll finds nothing.
-A bail-out emits no measure — the absence records that no work ran. A
-StrictMode double-invoke emits twice, because the body ran twice.
+### Optional `rf:*` User Timing
 
-Attribute *before* you change architecture. Unattributed "slow" is usually a
-rung-2 problem, and an island built on a misattributed cause makes the code
-worse without making it faster.
+Runtime User Timing is disabled by default. Enable it at compile time:
 
-## The escape-benefit rule
+```clojure
+:closure-defines {re-frame.performance/enabled? true}
+```
 
-An escape is a standing cost: a second semantics in that region, a body that
-structural tests cannot see into, a diff that reviewers read more slowly. An
-escape stays only if it recovers at least 20%, saves at least 2 ms at p95, or
-converts a failed user-visible budget into a pass. Otherwise it comes out —
-simplified back to the rung above it. The thresholds never widen to let an
-island stay, and "it might matter someday" is not one of the three conditions.
-Re-run the comparison when the surrounding code changes materially.
+A build without the flag carries no timing code.
 
-## The cost of one keystroke
+The runtime delivers entries to `PerformanceObserver` and browser DevTools but
+does not retain them for later polling. A subsequent `getEntriesByType` call
+may find nothing even though the live observer saw the entries.
 
-The budgets become concrete when you trace one keystroke. Take a controlled
-field in a four-field article editor:
+A view that bails out emits no measure because its body did not run.
+Development StrictMode emits twice when the body runs twice.
+
+## Keep an escape only when it earns its cost
+
+A native escape adds another local authoring model, hides structure from
+semantic tests, and increases review cost. Keep it only when it satisfies at
+least one of these conditions:
+
+- recovers **20% or more** of the measured interaction;
+- saves **2 ms or more at p95**;
+- converts a failed user-visible budget into a pass.
+
+Otherwise remove it and return to the previous level. “It may matter later” is
+not a fourth condition. Re-run the comparison when the surrounding path
+changes materially.
+
+## Trace one controlled keystroke
 
 ```clojure
 (ns app.editor
@@ -150,101 +137,102 @@ field in a four-field article editor:
     {:db (assoc-in db [:editor :title] typed)}))
 
 (rf/reg-sub :editor/title
-  (fn [db _] (get-in db [:editor :title])))
+  (fn [db _]
+    (get-in db [:editor :title])))
 
 (h/defview title-field [_]
-  [:input {:type     :text
-           :value    (h/sub [:editor/title])
-           :on-input [:editor/set-title ::h/value]}])
+  [:input
+   {:type     :text
+    :value    (h/sub [:editor/title])
+    :on-input [:editor/set-title ::h/value]}])
 ```
 
-One keystroke in the title field takes this path, entirely inside the browser's
-own input event:
+One keystroke follows this path:
 
-1. The DOM event fires. The intent dispatches **synchronously** in the discrete
-   event — no queue sits between the key and the handler.
-2. One handler runs, and it writes **one address**.
-3. The subscriptions that read that address recompute. Equality gates stop
-   every subscription whose output did not change. **One** subscription's
-   value changes.
-4. The runtime notifies the boundaries whose reads changed. **One** body runs
-   — the title field's body. The other three fields receive no notification.
-5. React commits, and the controlled converge applies the value **and the
-   caret** before the browser finishes the event
-   ([Controlled inputs](04-controlled-inputs.md)).
-6. The next frame paints the echo.
+1. The DOM input event fires and the intent dispatches synchronously.
+2. One handler writes one app-db address.
+3. Subscriptions that depend on that address recompute; equality stops
+   unchanged outputs.
+4. The title subscription changes and notifies the title-field view.
+5. One view body runs. Other fields are not notified.
+6. React commits and Hicasso converges value and caret before the event turn
+   ends.
+7. The next frame paints the echo.
 
-Counts from the walk: 1 write, 1 changed subscription, 1 body run, and a
-commit scoped to one input. **Write amplification — the number of boundary
-bodies that run per state write — is 1.** That is the mechanical meaning of
-"narrow work scales with changed rows", and it is why the editor stays far
-inside its frame budget.
+The path has one write, one changed subscription, and one view-body run.
+**Write amplification** is the number of view bodies that run per state write;
+here it is 1.
 
-Now scale the same shape to a 100-cell controlled grid:
+## Scale the same topology to a grid
 
 ```clojure
 (h/defview grid-cell [{:keys [row col]}]
-  [:input {:value    (h/sub [:grid/cell row col])
-           :on-input [:grid/edit row col ::h/value]}])
+  [:input
+   {:value    (h/sub [:grid/cell row col])
+    :on-input [:grid/edit row col ::h/value]}])
 ```
 
-Each cell reads its **own** address, so a keystroke in one cell is the same
-walk: 1 write, 1 changed subscription, 1 body. The runtime never notifies the
-other 99 cells — not "render and bail", but *never notified*. Typing cost is
-constant in grid size. That is the narrow-update budget passing by
-construction, from a rung-2 choice: fine reads on a typing surface.
+Each cell reads its own address. Editing one cell still produces one write, one
+changed subscription, and one cell-body run. The other cells are not rendered
+and then bailed out; they are never notified. Typing cost therefore remains
+constant as the grid grows.
 
-Here is the same grid with the wrong shape:
+A coarse read has a different cost:
 
 ```clojure
-;; Don't — a typing surface reading coarse
+;; Don't use this shape for a narrow, high-frequency typing surface.
 (h/defview grid [_]
-  (let [cells (h/sub [:grid/all-cells])]   ;; every keystroke changes this value
+  (let [cells (h/sub [:grid/all-cells])]
     [:table
      [:tbody
-      (for [cell cells]                    ;; cells render from props now
-        [grid-cell {:key (:id cell) :cell cell}])]]))
+      (for [cell cells]
+        [grid-cell
+         {:key (:id cell)
+          :cell cell}])]]))
 ```
 
-Now every keystroke recomputes the whole-grid view-model, runs the parent body,
-and runs a props compare over 100 cells. The bail-out keeps 99 bodies from
-running — unless a cell prop carries a fresh closure, in which case nothing
-bails and write amplification is 100. At this size the screen can still pass
-the frame budget, narrowly. The *shape* is still wrong: it converts grid size
-into per-keystroke cost. Coarse reads are for cheap mount and bulk replacement.
-They are the wrong topology for a surface that changes 100 times a minute, one
-cell at a time.
+Every keystroke now:
 
-The last cost item is **event volume**: controlled means one dispatch per
-keystroke per cell. That is the cost of the contract, and the walk above shows
-why it is affordable. When no consumer needs the intermediate values (a search
-box that feeds a debounced query), do not pay the cost: leave the input
-uncontrolled and commit on blur
-([Controlled inputs](04-controlled-inputs.md)). When something must react to
-the value more slowly, debounce the *consumers* of the committed value. Never
-debounce the write path itself — that drops characters.
+- recomputes the whole-grid view model;
+- runs the parent body;
+- compares props for every cell;
+- may run every cell body when props contain fresh functions or other
+  identity-based values.
+
+Equal persistent props may let 99 of 100 cells skip their bodies, but the
+whole-grid sweep remains proportional to grid size. Coarse reads are useful
+for cheap mount or bulk replacement, not for one-cell-at-a-time editing.
+
+## Event volume is a separate decision
+
+A controlled field dispatches once per keystroke. That is the cost of making
+intermediate text application-visible and keeping it correct.
+
+When no consumer needs the intermediate text, use an uncontrolled input and
+commit on blur. When a slower consumer exists, debounce the **consumer** of the
+committed value. Do not debounce the controlled write itself; an asynchronous
+write path can drop or reorder characters
+([Controlled inputs](04-controlled-inputs.md)).
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| "The app feels slow" and nothing else | No reproduction, so nothing is attributable | Script one named interaction; run the loop from step 1 |
-| One keystroke or event runs hundreds of bodies | Read topology — a value read too high, or a coarse read on a narrow-update surface | Rung 2: [Lists and collections](06-lists-and-collections.md) |
-| Characters drop under fast typing | Something async sits between keystroke and commit — a debounced write, a queued effect | Keep the controlled write synchronous; debounce consumers of the value |
-| An island shipped and the interaction is no faster | Pressure owner was misattributed — usually reads or event volume, not lowering | Re-attribute with Xray; remove the island if it fails the benefit rule |
-| Fast on your machine, budget missed in the field | Dev build, fast hardware, best-run numbers | Production build, mid-tier hardware, p95 across runs |
-| Heap grows across leave-and-return cycles | An escape acquires without a paired release | Pair acquire/teardown at the host ([Interop](09-interop.md)); prove it with `assert-clean!` ([Testing](14-testing.md)) |
-| An escape clears no threshold but "feels safer to keep" | Benefit rule read backwards — escapes are a cost held against a measured gain | Remove the escape |
-| Still slow after going native | Wrong layer — the work moved but the owner did not | Return to step 2; the advisor classifies where the time goes |
+| “The app feels slow” is the only description | There is no repeatable interaction to attribute | Script one user action and start at measurement step 1 |
+| One keystroke or event runs hundreds of view bodies | A read lives too high, or a coarse model is used for narrow updates | Change the topology as described in [Lists and collections](06-lists-and-collections.md) |
+| Fast typing drops characters | A timeout, debounce, queue, or effect sits between input and app-db commit | Keep the controlled write synchronous and debounce downstream consumers |
+| A native island shipped but the interaction did not improve | The original cost was misattributed | Re-run attribution and remove the island when it fails the benefit rule |
+| The feature is fast locally but misses field budgets | Measurement used a development build, fast hardware, or best-run values | Test the production build on mid-tier hardware and report p95 |
+| Heap or listeners grow after leave-and-return cycles | A host or island acquires without matching teardown | Pair attach and cleanup, then prove zero residue with `assert-clean!` |
+| An escape clears no threshold but is kept “for safety” | The benefit rule was ignored | Remove it; an unearned escape is permanent complexity |
+| The path remains slow after moving native | The measured owner was not construction | Return to attribution and fix the actual pressure class |
 
 ## When not to optimise
 
-- **Without a reproduction.** A feeling, or a fear of the interpreter, is not
-  a named interaction. Check the budgets first; if none is missed, there is no
-  work to do.
-- **When the real issue is event volume.** A dense controlled surface is a
-  dispatch-rate question with its own answers
-  ([Controlled inputs](04-controlled-inputs.md)) — no rung fixes it.
-- **When the plan is "hooks everywhere, for speed."** That plan is a rewrite
-  presented as an optimisation. The ladder exists so that the hot 2% can be
-  excellent while the other 98% pays nothing for it.
+Do not optimise:
+
+- without a scripted reproduction;
+- when every user-visible budget already passes;
+- by replacing the view layer when the issue is event volume or read topology;
+- by introducing hooks everywhere “for speed.” That is a rewrite, not a local
+  optimisation.

--- a/docs/design/hicasso/draft-guide/19-migration-from-reagent.md
+++ b/docs/design/hicasso/draft-guide/19-migration-from-reagent.md
@@ -1,238 +1,243 @@
-# Migration from Reagent
+# Migrating from Reagent
 
-You have a working Reagent codebase and want it on
-[Hicasso](glossary.md#hicasso) without an unverified rewrite. This page covers
-the view layer: components, Hiccup dialect, local state, and interop sites. If
-the app is still on re-frame v1, migrate events and subscriptions first. This
-page assumes re-frame2 underneath.
+This page covers the view-layer migration from Reagent to Hicasso: component
+definitions, Hiccup differences, local state, and React interop.
 
-Three tools, in this order:
+It assumes the application already uses re-frame2 events and subscriptions. If
+it still uses re-frame v1 shapes, complete that migration first.
 
-1. **The reporter** classifies every foreign crossing — converts mechanically,
-   needs a person, or will raise at runtime — and puts a named class and a
-   recovery sentence on each line.
-2. **[Shadow comparison](glossary.md#shadow-comparison)** (also called shadow
-   mode) proves that a ported screen matches the original. It is a dev-only dual
-   mount that diffs [canonical DOM](glossary.md#canonical-dom) and
-   [intent](glossary.md#intent) streams.
-3. **The codemod** repairs the `[:>]` props dialect where the rewrite is
-   decidable from source text. It is idempotent.
+Use three migration tools in this order:
 
-Do not run the codemod first. Verify with the reporter and shadow comparison,
-then let a tool change source with the proof re-run afterward.
+1. **Reporter** — classify every foreign React crossing and identify mechanical
+   rewrites, human decisions, and runtime blockers.
+2. **Shadow comparison** — run the Reagent original and Hicasso port side by
+   side and compare canonical DOM and intent streams.
+3. **Codemod** — apply only source transformations whose behaviour is
+   decidable from the code.
 
-## Step 1 — run the reporter
+Do not start with the codemod. Read the report, port and prove a screen, then
+apply mechanical edits and run the proof again.
 
-The migration tool ships with Hicasso. It runs on a bare JVM against any Reagent
-corpus. It does not load your app, and in its default mode it changes nothing:
+## 1. Generate the migration report
+
+The reporter runs on a JVM without loading the application. Its default mode
+changes no files:
 
 ```bash
 cd re-frame2/migration/reagent-to-hicasso/codemod
 
-clojure -M:run path/to/your/src/          # classify; touch nothing
-clojure -M:run --report out.edn src/      # choose where the report goes
+clojure -M:run path/to/your/src/
+clojure -M:run --report out.edn src/
 ```
 
-Reagent *converted* props on the way across a `[:>]` crossing — deep-camelCase
-nested keys, keyword values to string names, `r/partial` wrapping, metadata
-keys. Hicasso does not convert. `[:>]` stays legal, so a migrated site can keep
-rendering while meaning something different. The reporter reads every `[:>]`
-site and puts each in one of three buckets:
+Reagent converted props crossing through `[:>]`. Among other behaviours, it
+camel-cased nested keys, converted keyword values to names, wrapped
+`r/partial`, and read metadata keys. Hicasso does not perform that conversion.
+A `[:>]` form may therefore continue rendering while sending different values
+to the component.
 
-| Bucket | Named classes | What it means |
-|---|---|---|
-| Converts mechanically | the six rewrite families W1–W6 (step 4) | The codemod repairs these sites and preserves their behaviour |
-| Needs your hands | `:computed-props`, `:computed-value`, `:computed-nested-key`, `:adapt-def-site`, `:cljc-site`, `:parse-error`, `:event-carrier-goes-live`, `:key-conflict`, `:string-tag-unparseable`, `:normalized-key-collision`, `:css-var-repair`, `:named-ref`, `:amp-key` | Either the source text does not say what crosses, or a rewrite would change behaviour. Some classes mark places where Reagent was already broken and the move *repairs* behaviour; check that the repaired behaviour is what you want |
-| Will refuse at runtime | `:intent-needs-a-declaration`, `:dangerous-html`, `:r>-site`, `:f>-site`, `:as-element-island`, `:reagent-api-residue` | Migration blockers — these pages raise (or quietly misrender) under Hicasso until a person decides |
+The reporter classifies every crossing:
 
-Treat the report as the migration plan. It is one EDN file with deterministic
-ordering. The tool writes it on a clean run too, and the file includes the count
-of sites left untouched — so "not in the report" is never ambiguous. Every entry
-has file, line, and column against your input, the source form as text, and a
-recovery sentence. The report also carries each component's *name*, which the
-runtime cannot: a `[:>]` refusal at runtime prints the constant `"[:>]"`.
+| Category | Named classes | Meaning |
+| --- | --- | --- |
+| Mechanical | W1–W6, described below | The codemod can preserve the previous behaviour from source text alone |
+| Human decision | `:computed-props`, `:computed-value`, `:computed-nested-key`, `:adapt-def-site`, `:cljc-site`, `:parse-error`, `:event-carrier-goes-live`, `:key-conflict`, `:string-tag-unparseable`, `:normalized-key-collision`, `:css-var-repair`, `:named-ref`, `:amp-key` | The source does not contain enough information for a safe rewrite, or the change repairs previously broken behaviour that must be reviewed |
+| Runtime blocker | `:intent-needs-a-declaration`, `:dangerous-html`, `:r>-site`, `:f>-site`, `:as-element-island`, `:reagent-api-residue` | The site will raise or silently misrender until someone chooses the correct Hicasso shape |
 
-The report ends with a **suggestions block** — candidate
-[`h/defhost`](glossary.md#defhost) declarations with guessed `:callbacks` maps.
-The block is labelled as guesses. Fluent's `onRenderCell` and Ant's `onRow` are
-event-*spelled* render props whose return value the caller reads: pasting an
-`:event` contract onto one blanks the cell renderer, and the runtime raises
-nothing. You choose every contract. The tool never synthesizes one.
+The report is deterministic EDN. Each entry includes:
 
-Read the report before you write any code. It tells you which screens are
-mechanical, which need decisions, and which pages raise on a branch that smoke
-tests never reach.
+- file, line, and column;
+- the source form as text;
+- its classification;
+- a recovery sentence;
+- the component name where it can be recovered statically.
 
-## Step 2 — port a screen by hand
+It is written even when no problematic sites exist and includes the count of
+untouched sites, so absence from the report is meaningful.
 
-Migrate screen by screen, not file type by file type. Much of the port is
-deletion — closures become data, and state machinery becomes addresses:
+The final suggestions block contains possible `h/defhost` declarations and
+possible callback contracts. Treat them as drafts. A prop named like an event
+may actually be a render prop whose return value the library consumes. For
+example, declaring a render prop as `:event` can replace its return value with
+a dispatch path and blank the UI without a useful runtime error. Confirm every
+contract against the component library's documentation.
 
-| Reagent habit | [Hicasso](glossary.md#hicasso) |
-|---|---|
-| `defn` component returning Hiccup | [`h/defview`](glossary.md#defview) — a re-render [boundary](glossary.md#boundary), used as a head |
-| `@(rf/subscribe [:q])` in the body | `(h/sub [:q])` — legal in branches, loops, and helpers |
-| `#(rf/dispatch [:x])` handlers | the event vector itself; [`h/event`](glossary.md#hevent) when the callback's arguments matter |
-| `r/atom` in a form-2 closure | a forms-module draft or an explicit app-db address — there is no local-state tier |
-| `r/with-let` | ordinary `let`; state that must survive a re-render is application state |
-| form-3 / `r/create-class` lifecycle | a callback ref at the host edge, or a named native component ([Native tier](10-native-tier.md)) |
+## 2. Port one screen by hand
+
+Migrate a complete screen rather than changing all component declarations,
+then all handlers, then all crossings across the repository. A screen-level
+port gives shadow comparison a useful unit.
+
+Common translations:
+
+| Reagent | Hicasso |
+| --- | --- |
+| `defn` component returning Hiccup | `h/defview`, mounted as a Hiccup head |
+| `@(rf/subscribe [:q])` | `(h/sub [:q])`, including in branches, loops, and helpers |
+| `#(rf/dispatch [:x])` | the event vector itself; use `h/event` when callback arguments matter |
+| `r/atom` inside a Form-2 closure | app-db or the forms module; Hicasso has no local-state tier |
+| `r/with-let` | ordinary `let`; durable state belongs outside render |
+| Form-3 or `r/create-class` lifecycle | callback refs or a named native component |
 | `r/track`, `reaction`, `r/cursor` | layered subscriptions |
 | `^{:key k}` metadata | `:key` in the props map |
-| `[:> Component …]` | legal as-is; the codemod repairs the dialect; declare with [`h/defhost`](glossary.md#defhost) what you keep ([Interop](09-interop.md)) |
-| `r/adapt-react-class` | nothing — the codemod rewrites it to `[:>]`; declare it if it stays |
-| `r/as-element` in a render prop | [`h/as-element`](glossary.md#as-element), at a declared `:render` position |
-| `r/reactify-component` | [`h/as-component`](glossary.md#outward-bridge) — the [outward bridge](glossary.md#outward-bridge) |
+| `[:> Component ...]` | remains legal; repair its prop dialect and declare repeated crossings with `h/defhost` |
+| `r/adapt-react-class` | direct `[:>]` or a declared host |
+| `r/as-element` inside a render prop | `h/as-element` under a declared `:render` callback contract |
+| `r/reactify-component` | `h/as-component`, the outward bridge |
 
-Two of these ports fail loudly, which helps. A Reagent-style
-`#(rf/dispatch …)` closure still *runs* when the library or DOM calls it, but
-the bare ambient dispatch inside it raises `:rf.error/no-frame-context` — the
-recovery names the event-vector and [`h/event`](glossary.md#hevent) spellings.
-An [intent](glossary.md#intent) vector at an undeclared `[:>]` prop raises at
-render instead of crossing as an inert array. The inert array is what Reagent
-did, and the handler never fired there either.
+Two common mistakes fail loudly:
 
-## Step 3 — prove it with shadow comparison
+- A Reagent-style `#(rf/dispatch ...)` callback has no captured frame when the
+  browser invokes it later, so ambient dispatch raises
+  `:rf.error/no-frame-context`. Use an intent vector or `h/event`.
+- An event vector at an undeclared `[:>]` prop raises instead of crossing as an
+  inert JavaScript array. Under Reagent that inert value did not produce a
+  working handler either; the migration forces you to decide the callback's
+  contract.
 
-A port that "looks right" is not proof. [Shadow comparison](glossary.md#shadow-comparison)
-mounts the Reagent original and the Hicasso port together against isolated
-copies of the same seeded frame; drives both with one script; and diffs the
-[canonical DOM](glossary.md#canonical-dom) plus the [intent](glossary.md#intent)
-streams at every checkpoint.
+## 3. Prove the port with shadow comparison
+
+`ht/shadow!` mounts the original and candidate against isolated copies of the
+same seeded frame. One interaction script drives both implementations. At
+each checkpoint it compares canonical DOM and the intent stream.
 
 ```clojure
 (ns app.migration.article-row-shadow
   (:require [re-frame.hicasso.test :as ht]
-            [app.views.article-row-reagent :as old]   ;; the original, untouched
-            [app.views.article-row :as new]))         ;; the Hicasso port
+            [app.views.article-row-reagent :as old]
+            [app.views.article-row :as new]))
 
-(ht/shadow! {:reference      [old/article-row {:article-id 7}]
-             :candidate      [new/article-row {:article-id 7}]
-             :initial-events [[:demo/install-fixture]]
-             :script         [{:click "button.edit"}
-                              {:type  ["input.title" "Better title"]}
-                              {:click "button.save"}]})
+(ht/shadow!
+ {:reference      [old/article-row {:article-id 7}]
+  :candidate      [new/article-row {:article-id 7}]
+  :initial-events [[:demo/install-fixture]]
+  :script         [{:click "button.edit"}
+                   {:type  ["input.title" "Better title"]}
+                   {:click "button.save"}]})
 ;; => {:status :green :checkpoints 4}
 ```
 
-Each side gets its own copy of the seeded frame, so writes never cross, and a
-divergence compounds: when the port dispatches a different intent at step one,
-its state — and therefore its DOM — drifts further at every later step. At each
-checkpoint the harness compares the canonical DOM of both mounts and the intents
-that each side's handlers dispatched. A red names the checkpoint and the exact
-node or intent that differed. When the harness can attribute a difference to a
-*declared* policy — a Client-only crossing region, a named refusal — it reports
-that classification, not bare drift.
+Each side receives its own frame copy, so writes cannot leak between the two
+implementations. A different intent at the first checkpoint causes the states
+and later DOM to diverge independently, which makes the original cause visible.
 
-**Green means behaviourally identical over the flows the script drives.** Script
-the screen's real flows, not one click. Trust the comparator only after you have
-watched it fail: flip one prop in the port and confirm the run goes red at the
-correct node.
+A red result identifies the checkpoint and the exact DOM node or intent that
+differs. When the difference follows a declared policy, such as a Client-only
+region, the report identifies the policy instead of presenting it as an
+unexplained DOM mismatch.
 
-Omit `:script`, and the dual mount stays up in your dev build: you drive the app
-by hand, and every committed render is a checkpoint, live-diffed. That mode suits
-exploratory porting — leave the shadow mounted while you work.
+A green result means the implementations matched for the flows in the script.
+It does not prove untested paths. Script the real screen behaviour rather than
+a single happy click.
 
-Shadow comparison is dev-only. The harness, the dual mount, and the Reagent
-dependency itself are development scope; when the last shadow goes green, Reagent
-leaves your `deps.edn`. The scope is limited: shadow comparison compares
-canonical DOM and intent streams, not focus, caret, IME, or paint. Those are
-browser facts; the browser tier of [Testing](14-testing.md) covers them.
+Add a sabotage control before trusting the comparator: deliberately change a
+candidate prop and confirm the run turns red at the expected checkpoint.
 
-When the shadow is green, delete the original. Two copies of one screen can
-diverge.
+Omit `:script` for interactive development. Both mounts remain live and each
+committed render becomes a checkpoint as you use the screen manually.
 
-## Step 4 — run the codemod
+Shadow comparison covers canonical DOM and intent streams. It does not prove
+focus, caret, IME, layout, or paint behaviour. Use the browser levels from
+[Testing](14-testing.md) for those claims.
 
-With the report read and the proof in place, let the tool repair the mechanical
-dialect:
+When the screen is green and its browser tests pass, remove the Reagent
+original. Keeping both copies invites future divergence.
+
+## 4. Apply the mechanical codemod
 
 ```bash
-# from the tool directory, as in step 1
-clojure -M:run --rewrite src/             # dry run: what would change
-clojure -M:run --rewrite --write src/     # apply it
+clojure -M:run --rewrite src/
+clojure -M:run --rewrite --write src/
 ```
 
-The codemod writes whole files through a lossless parser, so formatting,
-comments, and line endings survive — a CRLF file comes back CRLF. Exit is `0`
-for any run that completed: a migration tool that fails your build over a
-decision only you can make is a tool you run once. There are six rewrite
-families:
+The first command is a dry run. The second writes files.
 
-| | At | Written | Preserving |
-|---|---|---|---|
-| W1 | `^{:key k}` on the vector | `:key k` inside the props map | Reagent read the metadata key; Hicasso reads `(:key props)` — left alone the key goes dead |
-| W2 | a literal map reached from the props map through map values | the same map, its literal keys respelled camelCase | Reagent deep-camelCased nested keys; Hicasso does not |
-| W3 | a literal keyword, or a quoted symbol, at a prop value | its `name`, as a string | Reagent's `(name x)` arm — a namespaced keyword loses its namespace here, exactly as it already did |
-| W4 | a literal `(r/partial f a …)` at a prop value | a hygienic `let` capture, then Reagent's own wrapper | Reagent evaluated the callee and arguments **once**, at construction — the `let` keeps that |
-| W5 | `[(r/adapt-react-class X) …]` | `[:> X …]` | the same native-element path, spelled the way Hicasso accepts |
-| W6 | `[:> "tag" …]` with a plain tag string | `[:tag …]` | Reagent's input wrapper becomes the [controlled door](04-controlled-inputs.md) |
+The codemod uses a lossless parser and preserves formatting, comments, and line
+endings, including CRLF. A completed run exits 0 even when the report contains
+human decisions; the tool is a migration assistant, not a permanent build
+lint.
 
-Two rules govern every rewrite. A rewrite fires only where both sides' behaviour
-is computable from the source text and differs. No rewrite introduces a function
-whose return differs from what Reagent's conversion produced. A prop's
-*spelling* can only make the tool do less — an event-spelled name is a reason to
-skip or to refuse, never a reason to wrap — and that keeps the tool from
-blanking a render prop. The tool refuses everything else into the report:
-silent behaviour change is the failure mode to avoid. A refused site still
-works, and the report line turns the refusal into an instruction.
+It applies six rewrite families:
 
-Every output is outside its own rewrite's input language, so a second run
-changes nothing — byte for byte, in both line-ending conventions. Then re-run
-shadow comparison on the screens the diff touched.
+| Rewrite | Input | Output | Behaviour preserved |
+| --- | --- | --- | --- |
+| W1 | `^{:key k}` metadata on a vector | `:key k` in the props map | Reagent read metadata; Hicasso reads props |
+| W2 | Literal nested prop maps | The same map with literal keys camel-cased | Reagent deep-camel-cased nested keys; Hicasso passes them by identity |
+| W3 | Literal keyword or quoted-symbol prop value | Its `name` as a string | Reagent named these values; namespaced keywords lost their namespace there too |
+| W4 | Literal `(r/partial f a ...)` prop | Hygienic `let` capture plus function wrapper | Reagent evaluated the callee and captured args once at construction |
+| W5 | `[(r/adapt-react-class X) ...]` | `[:> X ...]` | Same native React element path in Hicasso syntax |
+| W6 | `[:> "tag" ...]` for a plain HTML tag | `[:tag ...]` | Moves the native element onto Hicasso's normal, controlled-element path |
 
-## What stays manual, and why
+A transformation runs only when both old and new behaviour can be determined
+from the literal source. Event-like prop spelling never authorises a callback
+rewrite; it can only make the tool more conservative. Everything else remains
+in the report.
 
-- **Every [`h/defhost`](glossary.md#defhost) declaration and every `:callbacks`
-  contract.** A contract states what a prop *means*, and the meaning is in the
-  library's documentation, not your source text. The suggestions block drafts
-  the declaration; you approve it.
-- **The blockers.** An [intent](glossary.md#intent) vector at a `[:>]` prop
-  (`:intent-needs-a-declaration`) needs a decision about what it was for.
-  `dangerouslySetInnerHTML` (`:dangerous-html`) needs an explicit yes: Reagent
-  deleted it unless wrapped, Hicasso passes it through, so the migration turns a
-  dead prop into a live one. Port `[:r> …]` and `[:f> …]` sites by hand —
-  Hicasso reads those as tag keywords and quietly renders an unknown element.
-  Restructure `r/as-element` inside a callback (`:as-element-island`) by hand:
-  that closure runs outside the owner's render window, so its
-  [lowering](glossary.md#lowering) is not a text substitution.
-- **Local state and lifecycle** (`:reagent-api-residue`): `r/atom`, cursors,
-  form-2/form-3 shapes. Where a piece of state lives is a design decision —
-  [Ephemeral state](11-ephemeral-state.md) covers the homes — and no tool makes
-  that decision for you.
-- **Everything computed.** Props built by `merge`, values reached through a
-  symbol, keys computed at runtime: the source text does not say what crosses,
-  so the tool reports instead of guessing.
+The output of each rewrite is outside that rewrite's input language, so a
+second run should be byte-for-byte unchanged. Re-run shadow comparison on the
+screens touched by the diff.
+
+## What remains manual
+
+### Host declarations and callback contracts
+
+Only the component library defines whether a prop is an event, plain handler,
+render callback, or ReactNode slot. The codemod cannot infer that semantic
+contract safely. Review and approve every `h/defhost` declaration.
+
+### Runtime blockers
+
+Examples:
+
+- `:intent-needs-a-declaration`: decide what the undeclared event-shaped prop
+  means;
+- `:dangerous-html`: Reagent may have discarded the prop while Hicasso will
+  pass it through, turning dead behaviour live;
+- `:r>-site` and `:f>-site`: Hicasso can interpret these as unknown tag
+  keywords, so port them explicitly;
+- `:as-element-island`: a callback runs outside the original render window,
+  so replacing `r/as-element` is not a text substitution.
+
+### Local state and lifecycle
+
+`r/atom`, cursors, Form-2, and Form-3 structures require a state-ownership
+decision. Use the homes in [Ephemeral state](11-ephemeral-state.md). No codemod
+should decide whether a fact belongs in app-db, a forms address, or native
+widget state.
+
+### Computed values
+
+A map produced by `merge`, a prop value reached through a symbol, or a key
+computed at runtime does not reveal the actual crossing shape to a source-only
+tool. The reporter records the site rather than guessing.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
-|---|---|---|
-| A `[:>]` site renders but behaves differently than under Reagent | Props dialect drift — Reagent converted on the way across; Hicasso does not | Run the reporter; let the codemod repair the decidable sites |
-| A page raises at render at a `[:>]` site that "worked" before | `:rf.error/hicasso-host-undeclared-callback` — an [intent](glossary.md#intent) vector at an escape prop; under Reagent it crossed as an inert array and never fired | Declare the host and name the prop in `:callbacks`, or hand a plain function — and decide what the dead handler was for |
-| A handler runs, then `:rf.error/no-frame-context` | A Reagent-style `#(rf/dispatch …)` closure — it carries no frame | Make it an event vector, or [`h/event`](glossary.md#hevent) |
-| A keyed list remounts once right after migration | The `:key` slot is reported, never rewritten: `:foo` and `"foo"` keys collided under Reagent and are distinct now, so the key value changes once | Accept the one-time remount; keys are stable after |
-| The codemod refused a whole nested map | `:normalized-key-collision` — sibling keys like `:foo-bar`/`:fooBar` collapsed onto one JS property under Reagent, with an iteration-order winner | Delete the key you did not mean; re-run |
-| A W2 diff camelCased keys in what is clearly a *data* map | Behaviour preserved: Reagent already sent the library camelCase | Do **not** revert the keys — a revert changes what the library receives. If the map was data, notice it now |
-| Shadow run red on a region the port renders client-only | A declared Client-only crossing, classified as a policy difference, not drift | Choose the [server policy](glossary.md#server-policy) (`{:server :render}` or a fallback) or accept the classification |
-| Shadow green, but focus/IME behaves differently in a real browser | Shadow comparison covers canonical DOM and intents; browser laws are out of its scope | Run the browser tier ([Testing](14-testing.md)) |
-| Second codemod run produced a diff | It cannot — outputs are outside the input language. If files changed, something else edited them between runs | Diff against the report's coordinates; re-run the reporter |
+| --- | --- | --- |
+| A `[:>]` site renders but behaves differently | Reagent converted the prop dialect and Hicasso passes values by identity | Run the reporter and apply the safe codemod rewrites |
+| Render raises `:rf.error/hicasso-host-undeclared-callback` at a former Reagent crossing | An intent vector reached an undeclared prop; under Reagent it crossed as inert data | Declare the host and callback contract, or supply the actual plain function the library expects |
+| Callback runs and raises `:rf.error/no-frame-context` | A hand-written dispatch closure did not capture a frame | Replace it with an intent vector or `h/event` |
+| A keyed list remounts once immediately after migration | A key collision that Reagent normalised now becomes two distinct values | Accept the one-time transition when the new stable key is correct |
+| Codemod refuses a nested map with `:normalized-key-collision` | Keys such as `:foo-bar` and `:fooBar` collapsed onto one Reagent output property | Remove the unintended duplicate and rerun |
+| W2 camel-cases keys in what looks like application data | Reagent already sent that library a camel-cased object | Do not revert unless you intentionally want different library input |
+| Shadow comparison is red only in a Client-only region | The difference follows a declared server/client policy | Choose `{:server :render}`, provide a fallback, or accept the classified difference |
+| Shadow is green but focus or IME differs | Shadow comparison does not test browser-only behaviour | Run L4 browser tests |
+| A second codemod run changes files | The input changed between runs or another tool edited the output; the codemod itself is idempotent | Compare against the report coordinates and rerun the reporter |
 
-## When not to migrate this way
+## When not to use the full process
 
-- **A small app.** Below a handful of screens, the reporter plus a hand port is
-  the whole job; shadow scripts cost more than reading the diff. Keep the
-  reporter — it costs nothing — and skip the harness.
-- **A React-first screen.** Do not convert a screen that is mostly vendor
-  components and hooks to Hiccup on principle: port it to a named native island,
-  or keep it UIx, under the same root and frame
-  ([Native tier](10-native-tier.md)).
-- **A screen that you plan to redesign.** Shadow comparison proves behavioural
-  *identity*; when a planned redesign discards the behaviour, port the screen
-  loosely, and spend the proof budget on screens that must not change.
+- For a very small application, run the reporter and port by hand. A shadow
+  harness may cost more than reviewing a handful of screens.
+- Keep a React-first screen native or UIx instead of converting it to Hiccup on
+  principle ([The native tier](10-native-tier.md)).
+- When a screen is being redesigned, shadow comparison cannot prove intended
+  behavioural change. Spend identity-proof effort on screens that must remain
+  unchanged.
 
 ## Advanced
 
-### Reading a report entry
+### Report entry shape
 
 ```clojure
 {:file   "src/app/views.cljs"
@@ -240,44 +245,50 @@ shadow comparison on the screens the diff touched.
  :col    5
  :form   "[:> Btn {:variant :contained} \"Save\"]"
  :head   "Btn"
- :action :rewrote          ;; or :refused, :skipped
- :detail {:prop :variant :was :contained :now "contained"}
+ :action :rewrote
+ :detail {:prop :variant
+          :was  :contained
+          :now  "contained"}
  :note   "Reagent named every keyword prop value; Hicasso keeps the keyword
           except at HTML-attribute slots."}
 ```
 
-Coordinates address the *input* file for the scan and for the rewrite, so a line
-in the report is the line that you grep for in either mode.
+Coordinates always refer to the input file, in report and rewrite modes.
 
-### Why W4 writes a `let`
+### Why W4 captures with `let`
 
-The obvious rewrite of `(r/partial f @snapshot)` is a bare
-`(fn [& args] (apply f @snapshot args))`, and that rewrite is wrong. `r/partial`
-evaluated its callee and its arguments **once**, when the prop was built. The
-bare `fn` re-evaluates them on every call, so `@snapshot` stops being a
-snapshot, and `(next-id!)` allocates a fresh id on every click. The codemod
-writes a `let` that captures once:
+This rewrite is wrong:
+
+```clojure
+(fn [& args]
+  (apply f @snapshot args))
+```
+
+It re-evaluates `f` and `@snapshot` on each callback invocation. Reagent's
+`r/partial` evaluated the callee and arguments once when the prop was built.
+The codemod therefore emits a capture:
 
 ```clojure
 [:> Btn {:on-pick (r/partial handler @cart)}]
 ;; =>
-[:> Btn {:on-pick (let [f__rf2 handler a0__rf2 @cart]
-                    (fn [& args__rf2] (apply f__rf2 a0__rf2 args__rf2)))}]
+[:> Btn
+ {:on-pick
+  (let [f__rf2  handler
+        a0__rf2 @cart]
+    (fn [& args__rf2]
+      (apply f__rf2 a0__rf2 args__rf2)))}]
 ```
 
-The names are deterministic, not gensym'd, so what lands in your diff is
-readable. The tool checks the names against every symbol that the site spells,
-and a collision bumps the whole family (`f__rf2__1`, …) until the names are
-fresh.
+Names are deterministic and checked against symbols already present at the
+site. A collision increments the generated suffix for the complete family.
 
-### Divergences the tool leaves alone
+### Deliberate divergences left in place
 
-These divergences are named so you do not file them as gaps. Each is a place
-where Hicasso differs from the donor in a way that is better, or invisible:
+The migration tools do not try to remove every semantic difference:
 
-- Class collections in any spelling now coerce and compose (Reagent read only
-  the literal `:class` key).
-- Nested class collections flatten.
-- Hicasso drops `__proto__`/`prototype`/`constructor` instead of writing them.
-- A literal `nil` at the props slot counts as a child, and React renders nothing
-  for it.
+- class collections now coerce and compose under every accepted spelling;
+- nested class collections flatten;
+- unsafe object keys such as `__proto__`, `prototype`, and `constructor` are
+  dropped instead of written;
+- a literal `nil` in a child position remains a child value and React renders
+  nothing for it.

--- a/docs/design/hicasso/draft-guide/20-code-splitting.md
+++ b/docs/design/hicasso/draft-guide/20-code-splitting.md
@@ -1,26 +1,30 @@
 # Code splitting and lazy loading
 
-Your admin area is a large part of the bundle, and most sessions never open it.
-This page splits the build so that code loads when it is first wanted. It covers
-three things:
+Split code when a large area of the application is rarely visited. The normal
+split is a route or screen module. React lazy loading is useful when the area
+is already a native React island.
 
-- the **route/module grain**, which covers almost every real split;
-- the `React.lazy` bridge for [native islands](glossary.md#native-island);
-- what Suspense and Activity do to your reads while a subtree waits or hides.
+This page covers:
 
-## The route/module grain
+- route-level shadow-cljs modules;
+- `n/lazy` and Suspense for native components;
+- subscription and resource ownership while React suspends or hides a tree.
 
-The default answer needs no React machinery. shadow-cljs compiles the area into
-its own module. The load is an ordinary effect, and "has it arrived?" is app-db
-state that your shell renders like any other fact.
+## Split at the route or screen boundary
+
+The default approach does not need Suspense. Compile the screen into its own
+shadow-cljs module, load that module through an effect, and render its arrival
+state from app-db.
 
 ```clojure
-;; shadow-cljs.edn — the admin area becomes its own module
-{:modules {:main  {:entries [app.core]}
-           :admin {:entries [app.admin] :depends-on #{:main}}}}
+;; shadow-cljs.edn
+{:modules
+ {:main  {:entries [app.core]}
+  :admin {:entries [app.admin]
+          :depends-on #{:main}}}}
 ```
 
-One gate namespace holds the loadable, the effect, and the events:
+One gate namespace can own the loadable value, effect, state, and events:
 
 ```clojure
 (ns app.admin-gate
@@ -28,76 +32,86 @@ One gate namespace holds the loadable, the effect, and the events:
             [re-frame.hicasso :as h]
             [shadow.lazy :as lazy]))
 
-(def admin-screen (lazy/loadable app.admin/admin-screen))
+(def admin-screen
+  (lazy/loadable app.admin/admin-screen))
 
 (rf/reg-fx :app/load-module!
-  {:doc       "Load a compiled module; dispatch the outcome into the calling frame."
+  {:doc "Load a compiled module and dispatch the result into the calling frame."
    :platforms #{:client}}
-  (fn [{:keys [frame]} {:keys [loadable on-loaded on-failed]}]
+  (fn [{:keys [frame]}
+       {:keys [loadable on-loaded on-failed]}]
     (-> (lazy/load loadable)
-        (.then  (fn [_] (rf/dispatch on-loaded {:frame frame})))
-        (.catch (fn [_] (rf/dispatch on-failed {:frame frame}))))))
+        (.then
+         (fn [_]
+           (rf/dispatch on-loaded {:frame frame})))
+        (.catch
+         (fn [_]
+           (rf/dispatch on-failed {:frame frame}))))))
 
 (rf/reg-sub :modules/admin
-  (fn [db _] (get-in db [:modules :admin] :absent)))
+  (fn [db _]
+    (get-in db [:modules :admin] :absent)))
 
 (rf/reg-event :admin/wanted
   (fn [{:keys [db]} _]
     (when-not (= :loaded (get-in db [:modules :admin]))
       {:db (assoc-in db [:modules :admin] :loading)
-       :fx [[:app/load-module! {:loadable  admin-screen
-                                :on-loaded [:admin/module-loaded]
-                                :on-failed [:admin/module-failed]}]]})))
+       :fx [[:app/load-module!
+             {:loadable  admin-screen
+              :on-loaded [:admin/module-loaded]
+              :on-failed [:admin/module-failed]}]]})))
 
 (rf/reg-event :admin/module-loaded
-  (fn [{:keys [db]} _] {:db (assoc-in db [:modules :admin] :loaded)}))
+  (fn [{:keys [db]} _]
+    {:db (assoc-in db [:modules :admin] :loaded)}))
 
 (rf/reg-event :admin/module-failed
-  (fn [{:keys [db]} _] {:db (assoc-in db [:modules :admin] :failed)}))
+  (fn [{:keys [db]} _]
+    {:db (assoc-in db [:modules :admin] :failed)}))
 ```
 
-Wire the load to the route — `:on-match` dispatches when the route activates —
-and render the arrival as state:
+Load the module when the route activates and render all three states:
 
 ```clojure
-(rf/reg-route :app/admin {:on-match [[:admin/wanted]]} "/admin")
+(rf/reg-route :app/admin
+  {:on-match [[:admin/wanted]]}
+  "/admin")
 
 (h/defview admin-entry [_]
   (case (h/sub [:modules/admin])
-    :loaded  [@admin-screen {}]     ;; the loadable derefs to the view
-    :failed  [:div.load-failed
-              [:p "Couldn't load this area."]
-              [:button {:on-click [:admin/wanted]} "Try again"]]
-    [:div.screen-skeleton {:aria-busy true}]))
+    :loaded
+    [@admin-screen {}]
+
+    :failed
+    [:div.load-failed
+     [:p "Couldn't load this area."]
+     [:button {:on-click [:admin/wanted]}
+      "Try again"]]
+
+    [:div.screen-skeleton
+     {:aria-busy true}]))
 ```
 
-Every piece is machinery you already know. The pending placeholder is a branch,
-not a Suspense fallback. The failure is a value with a retry
-[intent](glossary.md#intent), not an exception. After the load, `@admin-screen`
-is the [`h/defview`](glossary.md#defview) view — still a re-render
-[boundary](glossary.md#boundary), with its reads and name intact. The
-`:loading`/`:loaded` check is the dedupe, so navigation away and back never
-double-loads.
+The pending state is a normal branch. Failure is app-db data with an ordinary
+retry intent. After loading, `@admin-screen` resolves to the original
+`h/defview`, so it keeps its name, frame, reads, and independent re-render
+behaviour.
 
-Warming works the same way as data prefetch: dispatch `[:admin/wanted]` from a
-nav link's hover intent, and the module downloads before the click. Hot reload is
-undisturbed — a loaded module's namespaces reload like any others, and an
-unloaded module has nothing to reload.
+The `:loading` and `:loaded` state is the deduplication rule. Leaving and
+returning to the route does not start a second load.
 
-## The React bridge: `n/lazy` and a Suspense host
+You can warm the module by dispatching `[:admin/wanted]` from a link hover or
+focus intent. A loaded module participates in hot reload normally. An unloaded
+module has no loaded namespace to reload.
 
-A [native island](glossary.md#native-island) or a React-shaped screen can instead
-load through React's own lazy machinery. That is the right choice when the region
-already lives on the [native tier](glossary.md#native-tier) and you want React to
-own the pending swap. The bridge is [`n/lazy`](glossary.md#nlazy), the ABI helper
-from [the native tier](10-native-tier.md). It has the same
-thunk-returning-a-promise contract as `React.lazy`, and it resolves to the
-component. It keeps the component marker, so Xray still names the
-[boundary](glossary.md#boundary) and embedding checks still recognize the head.
-What it does not do is carry the component across a hot reload, and it is not
-meant to: creating a component is allocation, never a lookup by name, so a save
-re-evaluates the module, allocates a fresh component, and React replaces the
-subtree. A clean remount across a save is the designed conduct, not a fault.
+## Lazy native components with Suspense
+
+Use React's lazy model when the split region is already a native island or
+React-first screen. `n/lazy` has the same loader contract as `React.lazy`, but
+preserves Hicasso's native component marker, display name, and server-policy
+metadata.
+
+Declare loadables and lazy components at namespace top level:
 
 ```clojure
 (ns app.charts.gate
@@ -106,128 +120,149 @@ subtree. A clean remount across a save is the designed conduct, not a fault.
             [re-frame.hicasso.native :as n]
             [shadow.lazy :as lazy]))
 
-(def chart-loadable (lazy/loadable app.charts.island/heavy-chart))
+(def chart-loadable
+  (lazy/loadable app.charts.island/heavy-chart))
 
-;; Declared at top level, never inside a body.
-(def heavy-chart (n/lazy #(lazy/load chart-loadable)))
+(def heavy-chart
+  (n/lazy #(lazy/load chart-loadable)))
 
 (h/defhost chart-host heavy-chart)
-(h/defhost suspense react/Suspense {:slots #{:fallback}})
+
+(h/defhost suspense react/Suspense
+  {:slots #{:fallback}})
 ```
+
+Mount the lazy host under Suspense and an error boundary:
 
 ```clojure
 (h/defview metrics-panel [_]
-  [h/error-boundary {:fallback  [:div.chart-oops
-                                 [:p "The chart failed to load."]
-                                 [:button {:on-click [:chart/retry]} "Try again"]]
-                     :reset-key (h/sub [:chart/attempt])}
-   [suspense {:fallback [:div.chart-skeleton {:aria-busy true}]}
-    [chart-host {:points (h/sub [:metrics/series])}]]])
+  [h/error-boundary
+   {:fallback
+    [:div.chart-oops
+     [:p "The chart failed to load."]
+     [:button {:on-click [:chart/retry]}
+      "Try again"]]
+    :reset-key (h/sub [:chart/attempt])}
+
+   [suspense
+    {:fallback
+     [:div.chart-skeleton
+      {:aria-busy true}]}
+    [chart-host
+     {:points (h/sub [:metrics/series])}]]])
 ```
 
-While the code loads, React shows the Suspense fallback — Hiccup in a declared
-slot, like any other ([Interop](09-interop.md)). A loader rejection throws into
-the render, so the nearest [`h/error-boundary`](glossary.md#error-boundary)
-catches it, and the `:reset-key` counter is the retry, as in
-[Errors](16-errors.md) — the next attempt re-runs the loader.
+The declared `:fallback` slot converts Hiccup to a ReactNode. If the loader
+promise rejects, React throws during render and the nearest
+`h/error-boundary` catches it. Changing the boundary's `:reset-key` retries the
+lazy subtree.
 
-!!! warning "Declare lazy components outside render"
-    [`n/lazy`](glossary.md#nlazy) (like `React.lazy`) creates a component
-    identity. When that creation happens inside a body, every render creates a
-    fresh identity, so React unmounts and remounts the subtree — and re-triggers
-    the load — each time the body runs. Both declarations above are top-level
-    `def`s; keep yours at top level too.
+!!! warning "Create lazy components once"
+    `n/lazy` creates a React component identity. Calling it inside a view body
+    creates a new identity on every render, remounts the subtree, and can
+    restart the load. Keep both the loadable and lazy component in top-level
+    definitions.
 
-Under SSR, the lazy region is a Client-only surface. The server bytes carry the
-deterministic fallback, and adoption mounts the live component when its code
-arrives. The runtime makes no hydration claim for bytes the server never sent
-([SSR and hydration](17-ssr-and-hydration.md)).
+A namespace save reallocates the lazy component during hot reload, so React
+remounts that subtree. This is the normal HMR behaviour for named native
+components and `defview` identities. State that must survive a save belongs in
+app-db.
 
-## While a subtree waits, or hides
+Under SSR, the lazy host remains Client-only. Server HTML contains the
+deterministic fallback. The live component mounts after hydration when its
+code arrives ([SSR and hydration](17-ssr-and-hydration.md)).
 
-Both mechanisms on this page hand a subtree's lifecycle to React. The read law
-holds through both, because commit owns acquisition
-([Views and reads](02-views-and-reads.md), [Async resources](08-async-resources.md)):
+## What happens to reads during suspension
 
-- **A suspended attempt owns nothing.** Render probes reads; commit installs
-  them. An attempt that React parks on a fallback has committed nothing, so it
-  holds no subscriptions and no resource demand. When the code arrives, the real
-  render commits, and it acquires at that point — once.
-- **Suspense here is for code arrival, not for data.** Do not wire subscriptions
-  to promises to suspend on your app's data. re-frame2 state reaches React as an
-  external store, and React documents that an external-store update can replace
-  visible content with the fallback. Data pending is explicit state — the
-  five-status resource projection and `:keep-previous?` already render it
-  ([Async resources](08-async-resources.md)).
-- **Activity hide releases; reveal reacquires.** Some panes must keep their UI
-  state while hidden — scroll position, half-built form widgets. For those panes,
-  host React's `Activity` like any wrapper, and drive `:mode` from state:
+Committed renders own subscriptions and demand. Speculative renders do not.
 
-  ```clojure
-  (h/defhost activity react/Activity)
+### A suspended attempt acquires nothing
 
-  [activity {:mode (if (h/sub [:inbox/visible?]) "visible" "hidden")}
-   [inbox-pane {}]]
-  ```
+A view may probe `h/sub` while React attempts a render. If that attempt
+suspends and React shows the fallback, the attempted subtree did not commit.
+It installs no subscriptions and acquires no demand-driven resources.
 
-  While the pane is hidden, React cleans up effects, and the subtree's committed
-  subscription ownership releases. Demand rides the same membership, so a hidden
-  pane's demand-driven resources release too. App-db state is untouched: the
-  pane's addresses keep their values. On reveal, the current read set
-  reacquires. Xray reports hidden-retained work as its own label, and does not
-  collapse it into mounted or unmounted ([Diagnostics](15-diagnostics.md)).
+When the code arrives and the real subtree commits, the committed read set is
+installed once.
 
-- **When the reveal is a click, it is already correct.** A hidden pane holds no
-  subscription, so writes that land while it is hidden do not reach it — the pane
-  comes back holding whatever it last rendered, and something has to correct it.
-  When the reveal is flushed inside the event that caused it, which is what a
-  user clicking a tab gets, React re-renders the retained subtree as part of
-  revealing it and reads the store during that render. The pane is correct before
-  it is on screen.
+### Use Suspense for code, not application data
 
-- **A reveal you schedule can show one stale frame.** Flip `:mode` from a timer,
-  a promise, or a transition and React reveals the retained subtree without
-  re-rendering it: the only signal that state moved arrives when React
-  re-subscribes, and it re-subscribes in an effect that React flushes in a later
-  task. A frame can be painted in between, showing the value the pane last
-  rendered. It is one frame, measured, and gated so it cannot quietly widen. It
-  is also never a *torn* frame — what you see is a real earlier state of that
-  pane, whole, not a mixture of two.
+Do not turn subscription values into promises to suspend on data. re-frame2
+state reaches React through an external-store model, and an external-store
+update can cause Suspense to replace visible content with a fallback.
 
-  So do not hide a pane whose content must never be a moment out of date. **On
-  an account or tenant switch, unmount or re-key the pane rather than retaining
-  it** — a consistent old commit is still the previous account's numbers, and
-  Activity retention preserves UI state; it is not a disclosure boundary. Where
-  retention is genuinely wanted, drive `:mode` from the discrete event itself
-  rather than from a timer that fires later.
+Resource pending, refreshing, failed, and stale states are already explicit
+data. Render them with the resource projection and `:keep-previous?`
+([Async resources](08-async-resources.md)).
+
+## Retaining hidden native UI with Activity
+
+React Activity can retain a native or hosted subtree while hiding it. Declare
+it as a host and control its mode from app state:
+
+```clojure
+(h/defhost activity react/Activity)
+
+[activity
+ {:mode (if (h/sub [:inbox/visible?])
+          "visible"
+          "hidden")}
+ [inbox-pane {}]]
+```
+
+While hidden:
+
+- React cleans up effects;
+- committed subscription ownership releases;
+- demand-driven resources release;
+- app-db state remains unchanged;
+- retained React UI state, such as a browser-owned scroll position, can remain.
+
+When the pane becomes visible, it reacquires the reads made by its reveal
+render. Xray labels hidden-retained work separately from mounted and unmounted
+work.
+
+### Discrete reveal is current before paint
+
+When a user click changes Activity from hidden to visible, React renders the
+retained subtree as part of the discrete reveal. It reads current app-db before
+the pane becomes visible.
+
+### Scheduled reveal can show one old frame
+
+When a timer, promise, or transition changes the mode, React may reveal the
+retained subtree before its external-store subscription effect is restored.
+One frame can show the last complete state the pane rendered before it was
+hidden. It is an older coherent pane, not a mixture of old and new values.
+
+Do not retain a pane where even one frame of previous content is unacceptable.
+An account or tenant switch is the clearest example: a coherent old account is
+still the wrong account. Unmount or re-key that subtree instead.
+
+Use Activity only when preserving host-owned UI state is worth the retention
+cost. Ordinary application state already survives unmount in app-db.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
-|---|---|---|
-| Navigation to the split route renders nothing, and then the screen appears after a delay | The shell renders the loaded view unconditionally, so the pre-load render was empty | Branch on the module status; render the skeleton and failed states |
-| The module double-loads on repeated visits | The load event does not consult state | Gate on the status, as `:admin/wanted` does — `:loading`/`:loaded` is the dedupe |
-| Works in `watch`, 404s in a release build | Module config drift — a missing `:depends-on`, or the entry namespace not in the module | Declare the dependency edge; keep one entries list per module |
-| The Suspense fallback flashes on every render of the parent | The lazy component was created inside a body — fresh identity, fresh mount, fresh load | Declare [`n/lazy`](glossary.md#nlazy) (and the loadable) at top level |
-| A failed chunk load leaves the skeleton up forever | Nothing catches the loader's rejection | Wrap the Suspense host in [`h/error-boundary`](glossary.md#error-boundary); retry through `:reset-key` |
-| Xray shows an anonymous re-render unit where a named island should be | Raw `React.lazy` erased the component marker — the display name and the declared server policy went with it | Use [`n/lazy`](glossary.md#nlazy) — same semantics, marker intact ([Native tier](10-native-tier.md)) |
-| Local state inside a lazily loaded island resets whenever you save | Nothing is wrong. A reload allocates a fresh component, so the element type changes and React remounts the subtree — the designed HMR conduct, and [`defview`](glossary.md#defview)'s too | Nothing to fix. State that must outlive a save belongs in `app-db`, read back through [`n/use-sub`](glossary.md#nuse-sub) |
-| The lazy region is missing from server HTML | Client-only by design — the server carries the fallback, never the un-arrived component | Make the fallback a same-footprint skeleton; the live component mounts after adoption |
-| A hidden pane's state is gone on reveal | The pane was unmounted, not hidden — a `when`, not an Activity `:mode` flip | Hide with `:mode "hidden"` to retain UI state; unmount when you mean gone. App-db state at addresses survives either way |
-| A revealed pane shows its old contents for a frame before catching up | Nothing is broken. A hidden pane holds no subscription, and the reveal was scheduled — from a timer, a promise or a transition — so React re-subscribes in an effect it flushes a task later | Reveal from the discrete event instead, where the correction lands inside the reveal's own render. For a pane that must never show an earlier state — an account or tenant switch — unmount or re-key rather than retain |
+| --- | --- | --- |
+| Split route is blank until code arrives | The view dereferences the loaded module without rendering pending and failed states | Branch on module status and show a skeleton or failure UI |
+| Repeated visits start repeated module loads | The load event ignores existing `:loading` or `:loaded` state | Gate the effect on the status as `:admin/wanted` does |
+| Development watch works but release returns a module 404 | Module entries or `:depends-on` edges differ in the release configuration | Declare the module dependency and keep one authoritative entries list |
+| Suspense fallback appears after every parent render | `n/lazy` is created inside a body, producing a new component identity | Move the loadable and lazy component to top-level definitions |
+| Failed chunk leaves the skeleton forever | No error boundary handles the loader rejection | Wrap Suspense with `h/error-boundary` and retry by changing `:reset-key` |
+| Xray shows an anonymous lazy island | Raw `React.lazy` removed Hicasso's native marker | Use `n/lazy` |
+| Local state resets after a source save | HMR created a new component identity and React remounted | Expected. Store durable state in app-db and read it with `n/use-sub` |
+| Lazy area is absent from server HTML | The lazy component is Client-only | Provide a same-footprint fallback; the component mounts after adoption |
+| Hidden pane loses UI state | It was unmounted with a conditional rather than retained with Activity | Use `:mode "hidden"` when retention is intentional |
+| Scheduled reveal briefly shows old content | The hidden pane had no active subscription and React restored it after the reveal paint | Reveal from the discrete event, or unmount/re-key when stale display is unacceptable |
 
-## When not to split
+## When not to split or retain
 
-- **A small bundle.** One module that loads fast is simpler than three modules
-  that each need a loading state. Split when a measured area is big and rarely
-  visited, not on principle.
-- **Below the route or screen grain.** Per-widget chunks multiply pending states
-  and round trips; users already expect a pause at the route, not on every
-  widget.
-- **For data.** Suspense is not your loading UI, and lazy loading is not your
-  fetch layer. Resource status is explicit state with a better vocabulary
-  ([Async resources](08-async-resources.md)).
-- **Hiding what should unmount.** Activity pays a retention cost to keep UI
-  state alive. A pane whose meaningful state already lives at app-db addresses
-  survives unmount at no cost ([Ephemeral state](11-ephemeral-state.md)) — hide
-  only what is expensive to rebuild, or what the platform owns, like scroll.
+- Do not split a small bundle merely to create architectural symmetry.
+- Prefer the route or screen boundary. Per-widget chunks create many loading
+  states and network round trips.
+- Do not use Suspense as the application's data-fetching state model.
+- Do not retain a pane whose useful state already lives in app-db and is cheap
+  to rebuild.
+- Never use Activity retention as a security or disclosure boundary.

--- a/docs/design/hicasso/draft-guide/21-accessibility.md
+++ b/docs/design/hicasso/draft-guide/21-accessibility.md
@@ -1,167 +1,191 @@
 # Accessibility
 
-A screen reader announces "clickable, group" where you meant "Delete, button",
-and Tab skips your busiest control. Hicasso ships no accessibility subsystem,
-because the fix is not a subsystem. Semantic HTML and native controls already
-carry names, roles, and keyboard behaviour. Your job is mostly to keep those
-behaviours in place — and then prove it in tests.
+Start with semantic HTML. Native elements already provide names, roles,
+keyboard activation, focus behaviour, and platform integration. Hicasso does
+not replace those contracts with an accessibility subsystem.
 
-## Semantic HTML first
+Then derive ARIA state from the same application values that control the UI,
+and test the result at the lowest level that can prove it.
 
-Semantic elements give you the platform's behaviour at no cost. A `:button` is
-focusable, keyboard-activatable, and announced as a button. A `:div` with a
-click handler is none of those things. Every attribute you then add by hand is a
-copy of one platform behaviour, minus the ones you forgot:
+## Use semantic elements
+
+A button is focusable, keyboard-activatable, and announced as a button. A
+clickable `div` is not.
 
 ```clojure
-;; Don't — a click target only a mouse can find
-[:div.delete {:on-click [:article/delete id]} "Delete"]
+;; Don't: only a pointer user can reliably operate this.
+[:div.delete
+ {:on-click [:article/delete id]}
+ "Delete"]
 
-;; Do — focus, Enter, Space, and the announcement come with the tag
-[:button.delete {:on-click [:article/delete id]} "Delete"]
+;; Do: focus, Enter, Space, and the role come from the platform.
+[:button.delete
+ {:on-click [:article/delete id]}
+ "Delete"]
 ```
 
-The same choice repeats across the vocabulary:
+Apply the same rule throughout the page:
 
-- `:a` for navigation — [`route-link`](glossary.md#route-link) returns a real
-  anchor, so middle-click and copy-link work.
-- `:label` wrapping its control, or pointing at it with `:for`.
-- `:ul`/`:li` for lists, and `:table` for tabular data.
-- One `:h1` per page in the heading outline.
-- `:main`/`:nav`/`:aside` landmarks, so a reader can jump between regions.
+- use `:a` for navigation; `route-link` returns a real anchor;
+- pair labels and controls with a wrapping `:label` or matching `:for` and
+  `:id`;
+- use `:ul`/`:li` for lists and `:table` for tabular data;
+- keep a meaningful heading outline, normally with one page `:h1`;
+- use `:main`, `:nav`, and `:aside` landmarks.
 
-Use ARIA roles only where no element exists — a listbox, a tab strip. Then take
-the whole contract, keyboard included, as
-[the combobox in Overlays and focus](12-overlays-and-focus.md) does.
+Use ARIA roles when no native element expresses the widget, such as a listbox
+or tab strip. In that case, implement the complete keyboard and state contract,
+not only the role. The dropdown in
+[Overlays and focus](12-overlays-and-focus.md) is an example.
 
-## Names are ordinary attributes
+## Give controls an accessible name
 
-What an element shows visually is usually also its accessible name, with no work
-from you. The gaps are icon-only controls, and controls whose visible label lives
-elsewhere. The fix is data in the attribute map, per instance:
+Visible text usually supplies the name automatically. Add an explicit name for
+icon-only controls or when the visible label lives elsewhere:
 
 ```clojure
-[:button {:aria-label "Close" :on-click [:dialog/dismissed id]} "×"]
+[:button
+ {:aria-label "Close"
+  :on-click [:dialog/dismissed id]}
+ "×"]
 
 [:fieldset.form-group
- [:label {:for (str "email-" id)} "Email"]
- [:input {:id       (str "email-" id)
-          :type     :email
-          :value    (h/sub [:signup/email id])
-          :on-input [:signup/set-email id ::h/value]}]]
+ [:label {:for (str "email-" id)}
+  "Email"]
+ [:input
+  {:id       (str "email-" id)
+   :type     :email
+   :value    (h/sub [:signup/email id])
+   :on-input [:signup/set-email id ::h/value]}]]
 ```
 
-Ids that pair elements — `:for`/`:id`, `:aria-labelledby`, `:aria-describedby`,
-`:aria-activedescendant` — are per-instance strings. Build them from the same
-instance key that addresses the state
-([Ephemeral state](11-ephemeral-state.md#choosing-the-address)). Two instances
-that share one id are the accessibility form of two panels that share one
-address, and they break the same way.
+IDs used by `:for`, `:aria-labelledby`, `:aria-describedby`, and
+`:aria-activedescendant` must be unique per instance. Build them from the same
+stable instance key used for application state
+([Ephemeral state](11-ephemeral-state.md#choose-a-stable-instance-address)).
 
-`:aria-*` attributes pass through exactly as written
-([Views and reads](02-views-and-reads.md)), so there is nothing Hicasso-specific
-to learn — including on [`h/defhost`](glossary.md#defhost) crossings, where
-`aria-*` stays hyphenated.
+`:aria-*` and `:data-*` attributes pass through as written on native elements
+and declared hosts.
 
-## State assistive tech reads is the state you already have
+## Derive ARIA state from the real state
 
-A screen reader's view of your widget — expanded, selected, busy, invalid —
-must track app-db. The cheapest way to keep the two representations aligned is
-to derive both from one read:
+Do not keep a second accessibility-only copy of expanded, selected, busy, or
+invalid state. Read the fact once and use it for both behaviour and ARIA:
 
 ```clojure
 (h/defview filter-toggle [{:keys [id]}]
   (let [open? (h/sub [:filter-menu/open? id])]
-    [:button {:aria-haspopup "menu"
-              :aria-expanded open?              ;; the same fact the panel renders from
-              :on-click      [:filter-menu/toggled id]}
+    [:button
+     {:aria-haspopup "menu"
+      :aria-expanded open?
+      :on-click [:filter-menu/toggled id]}
      "Filter"]))
 ```
 
-The pages that own each widget already write this shape: `:aria-expanded` and
-`:aria-activedescendant` on [the dropdown](12-overlays-and-focus.md), and
-`:aria-current "page"` on [the active nav link](07-routing-and-navigation.md).
-`:aria-busy` sits on [the fetching suggestion list](08-async-resources.md), and
-`:inert` plus `:aria-hidden` ride [an exiting node](11-ephemeral-state.md). What
-those pages never do is mirror platform state back into app-db. Focus in
-particular belongs to the platform ([Ephemeral state](11-ephemeral-state.md)):
-you express [intent](glossary.md#intent) once, and the restore contracts do the
-rest.
+The same pattern appears elsewhere in the guide:
 
-Error display pairs the message to the field the same way — derived, per
-instance, and announced:
+- `:aria-expanded` and `:aria-activedescendant` on the dropdown;
+- `:aria-current "page"` on the active route link;
+- `:aria-busy` on a resource-backed suggestion list;
+- `:inert` and `:aria-hidden` on an exiting presence node.
+
+Focus is different: it remains browser state. Express one focus action when
+needed and let the browser or overlay contract restore it. Do not mirror the
+currently focused element in app-db.
+
+### Pair validation messages with fields
 
 ```clojure
-(when-let [error (h/sub [:editor/field-error :title])]
-  [:div.error-messages {:id "title-error" :role "alert"} error])
-;; and on the input: :aria-invalid true, :aria-describedby "title-error"
+(when-let [error
+           (h/sub [:editor/field-error :title])]
+  [:div.error-messages
+   {:id "title-error"
+    :role "alert"}
+   error])
 ```
 
-## Keyboard and focus have owners
+The corresponding input should carry:
 
-Keyboard behaviour is data: the key map, with IME composition handled centrally
-([Events as data](03-events-as-data.md)). Native controls bring their bindings
-with them. What is left is focus *movement*. Each case already has its owner
-page; this table is the inventory:
+```clojure
+{:aria-invalid true
+ :aria-describedby "title-error"}
+```
 
-| Moment | Conduct | Owner |
-|---|---|---|
-| Route change | Focus the keyed main region, `:tab-index -1`, `preventScroll` | [Routing and navigation](07-routing-and-navigation.md) |
-| Overlay opens / closes | `:auto-focus` [intent](glossary.md#intent) in; platform trap; restore on close | [Overlays and focus](12-overlays-and-focus.md) |
-| Composite widget (menu, listbox) | Focus stays on the trigger; `:aria-activedescendant` walks options | [Overlays and focus](12-overlays-and-focus.md) |
-| Exit animation | `:inert` + `:aria-hidden` ride the unmounting phase | [Ephemeral state](11-ephemeral-state.md) |
-| Virtualized list | The keyboard cannot reach rows that do not exist — decide, then verify in a browser | [Lists and collections](06-lists-and-collections.md) |
+Generate the message id per form instance when more than one form can appear on
+the page.
 
-## Prove it in the harness
+## Keyboard and focus ownership
 
-Names and roles are attributes in the semantic tree, so most accessibility claims
-are L2 data assertions. The harness, the fixtures, and the sabotage discipline
-are the same as everything else in [Testing](14-testing.md):
+Native controls already own their keyboard bindings. Hicasso's keyboard map
+expresses additional key-to-intent behaviour and suppresses mappings during IME
+composition ([Events as data](03-events-as-data.md)).
+
+Focus movement has specific owners:
+
+| Moment | Behaviour | Owner |
+| --- | --- | --- |
+| Route change | Focus a keyed `main` region with `:tab-index -1` and `preventScroll` | [Routing and navigation](07-routing-and-navigation.md) |
+| Overlay open and close | Apply `:auto-focus`, use the platform trap, restore the opener | [Overlays and focus](12-overlays-and-focus.md) |
+| Menu or listbox navigation | Keep DOM focus on the trigger and move `:aria-activedescendant` | [Overlays and focus](12-overlays-and-focus.md) |
+| Exit animation | Add `:inert` and `:aria-hidden` during unmounting | [Ephemeral state](11-ephemeral-state.md) |
+| Virtualised collection | Decide how keyboard users reach items that do not exist in the DOM and verify it in a browser | [Lists and collections](06-lists-and-collections.md) |
+
+## Test attributes as data
+
+Names, roles, and ARIA state are visible in the L2 semantic tree:
 
 ```clojure
 (deftest toggle-announces-its-state
-  (let [tree (ht/tree [views/filter-toggle {:id 7}]
-                      {:subs {[:filter-menu/open? 7] true}})
-        btn  (ht/attrs (ht/find tree #(= :button (:tag %))))]
+  (let [tree
+        (ht/tree
+         [views/filter-toggle {:id 7}]
+         {:subs {[:filter-menu/open? 7] true}})
+        btn
+        (ht/attrs
+         (ht/find tree #(= :button (:tag %))))]
     (is (= "menu" (:aria-haspopup btn)))
     (is (true? (:aria-expanded btn)))))
 
 (deftest toggle-announces-its-state--sabotage-twin
-  (let [tree (ht/tree [views/filter-toggle {:id 7}]
-                      {:subs {[:filter-menu/open? 7] false}})]
-    (is (false? (:aria-expanded (ht/attrs (ht/find tree #(= :button (:tag %)))))))))
+  (let [tree
+        (ht/tree
+         [views/filter-toggle {:id 7}]
+         {:subs {[:filter-menu/open? 7] false}})
+        btn
+        (ht/attrs
+         (ht/find tree #(= :button (:tag %))))]
+    (is (false? (:aria-expanded btn)))))
 ```
 
-Data cannot prove focus and traversal: where focus lands after a route change,
-whether Tab is trapped in a [modal](glossary.md#overlay), whether a virtualized
-grid is walkable. Those are engine facts, so they live in the browser tier, next
-to an automated axe pass over each screen's mounted state. The axe run is a
-floor, not the test. It catches missing names and broken pairings, and it says
-nothing about whether the keyboard *order* makes sense. Script that walk yourself
-for the screens where it matters.
+The sabotage twin proves that the assertion changes when the source state
+changes.
+
+Data tests cannot prove actual focus, Tab order, modal trapping, virtualised
+keyboard movement, or screen-reader/browser integration. Test those behaviours
+in real browser engines. Run an automated axe check on the mounted screen as a
+baseline, then script the keyboard walk for important flows. Axe can identify
+missing names and broken pairings; it cannot decide whether the traversal order
+makes sense.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
-|---|---|---|
-| A control cannot be reached with Tab | It is not a real control — a `:div`/`:span` with a click handler | Use `:button`, `:a`, or the real control; `:tab-index` on a div is the last resort, not the first |
-| An icon button announces nothing, or announces "×" | No accessible name beyond its glyph | `:aria-label` on the control |
-| A reader announces the wrong label, or none, for an input | The `:label` is not paired — missing `:for`, or an id shared between instances | Per-instance ids built from the instance key |
-| "Expanded" never changes in the reader while the panel opens | The `:aria-expanded` value is a literal, not the sub the panel renders from | Derive it from the same read |
-| Validation errors appear silently | The message div is not announced and not paired | `:role "alert"` on the message; `:aria-invalid` and `:aria-describedby` on the field |
-| Focus goes nowhere after navigating | The main region is not keyed and focusable | The route-focus recipe ([Routing and navigation](07-routing-and-navigation.md)) |
-| A fading toast still takes focus and clicks | The exit override lacks the a11y pair | `:inert` and `:aria-hidden` in `::motion/unmounting` ([Ephemeral state](11-ephemeral-state.md)) |
-| The [modal](glossary.md#overlay) traps focus but the page behind still scrolls | A hand-written dialog, not the native modal path | `overlay/modal` ([Overlays and focus](12-overlays-and-focus.md)) |
-| axe flags nothing but keyboard users are lost | axe checks attributes, not traversal order | Script the Tab walk in the browser tier for that screen |
+| --- | --- | --- |
+| Control cannot be reached with Tab | A `div` or `span` is acting as a control | Use the real `button`, `a`, input, or other native control; add `tab-index` to a generic element only when no semantic element fits |
+| Icon button is unnamed or announced only as “×” | Its glyph is the only name | Add `:aria-label` to the button |
+| Input has the wrong or no label | `:for` and `:id` do not match, or ids are reused across instances | Generate stable per-instance ids |
+| Screen reader's expanded state never changes | `:aria-expanded` is a literal or separate stale value | Derive it from the same subscription that controls the panel |
+| Validation message appears without announcement | The message is not a live alert and the field is not linked to it | Add `:role "alert"`, `:aria-invalid`, and `:aria-describedby` |
+| Focus does not move after route navigation | The new main region is not keyed or programmatically focusable | Use the route focus recipe |
+| Fading item still accepts focus and clicks | Exit appearance changed without disabling interaction | Add `:inert` and `:aria-hidden` in the unmounting override |
+| Modal traps focus but the background remains interactive | A non-modal or hand-written dialog is being used | Use `overlay/modal`, which calls `showModal` |
+| Axe passes but keyboard users still get lost | Automated rules cannot evaluate the intended traversal order | Script the Tab, arrow-key, Escape, and focus-return flows in browser tests |
 
-## When not to add more
+## When not to add ARIA or state
 
-- **Do not restate what the element already says.** `{:role "button"}` on a
-  `:button` and `{:aria-label "Save"}` beside visible "Save" text are noise at
-  best and contradictions at worst. ARIA fills gaps; prefer the element.
-- **Do not mirror focus or hover into app-db** to drive announcements. The
-  platform tracks them, and a mirror drifts
-  ([Ephemeral state](11-ephemeral-state.md)).
-- **Do not build an announcer service.** A `:role "alert"` region rendered from
-  state covers the occasional live announcement. A general live-region subsystem
-  is machinery before any caller needs it.
+- Do not repeat native semantics. `role="button"` on a `button`, or an
+  `aria-label` that contradicts visible text, makes the result worse.
+- Do not mirror hover or focus into app-db solely for announcements. The
+  browser already owns those facts.
+- Do not build a general announcer service before a real use case requires it.
+  A state-driven `role="alert"` region covers occasional live messages.

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -1,23 +1,45 @@
-# Hicasso — user guide
+# Hicasso user guide
 
-Hicasso is re-frame2's native view layer: you write Hiccup vectors and maps,
-call subscriptions where you need values, and put event vectors in attributes.
-The runtime turns that data into React elements. App-db, events, and the event
-pipeline stay ordinary re-frame2.
+Hicasso is re-frame2's native view layer. Views are Hiccup data, subscription
+reads are ordinary function calls, and event handlers can remain event vectors.
+The runtime turns that data into React elements; app-db, events, subscriptions,
+frames, and the event pipeline remain ordinary re-frame2.
 
-**Prerequisites.** Core re-frame2 — events, app-db, subscriptions, frames.
-Start with [what Hicasso is](01-getting-started.md), then
-[install a first screen](installation.md).
+This guide explains the Hicasso view model, controlled inputs, forms, routing,
+resources, React interop, native components, local UI state, overlays, SSR,
+testing, diagnostics, performance, migration, code splitting, and
+accessibility. The MkDocs sidebar supplies the chapter order and page
+navigation.
 
-**When not this corpus.** Pure business logic and HTTP without a Hicasso view
-belong in Core, async, or resources. A Reagent app still on re-frame v1 event
-shapes should finish that migration first, then use
-[Migration from Reagent](19-migration-from-reagent.md). If the product is
-React-first (hooks everywhere, a design system at the centre), prefer the UIx
-adapter and use Hicasso only where data-first views are worth it.
+## Prerequisites
 
-The MkDocs sidebar lists the pages.
+You should already understand the re-frame2 basics: events, app-db,
+subscriptions, effects, and frames. The Core guide owns those concepts. This
+corpus explains what changes at the view layer and how that layer behaves at
+its boundaries.
 
-> **End-state guide.** This describes Hicasso as the completed programme ships
-> it. Public names may still change at the one naming sitting; treat spellings
-> as recommended defaults until that sitting freezes them.
+## When Hicasso fits
+
+Use Hicasso when you want re-frame2's data-oriented model to continue through
+the view tree:
+
+- markup remains inspectable Hiccup data
+- a view reads subscriptions with `h/sub` where it needs them
+- common event handlers remain event vectors rather than opaque closures
+- a frame remains explicit across rendering, callbacks, testing, and tools
+
+## When to use another corpus or adapter
+
+Pure business logic and HTTP work with no Hicasso view belong in the Core,
+async, or resources guides.
+
+A Reagent application still using re-frame v1 event shapes should complete the
+core migration before applying the Hicasso migration. A React-first product —
+hooks throughout the screen and a React component system at the centre — will
+usually be clearer with the UIx adapter, using Hicasso only where its data-first
+view model is useful.
+
+> **Status.** This guide describes the intended completed Hicasso programme.
+> Public names may still change during the remaining naming review. Treat the
+> spellings here as the current recommended defaults until that review freezes
+> them.

--- a/docs/design/hicasso/draft-guide/REWRITE-NOTES.md
+++ b/docs/design/hicasso/draft-guide/REWRITE-NOTES.md
@@ -1,272 +1,367 @@
-# Guide rewrite notes — the six-stage audit trail
+# Hicasso guide rewrite audit
 
-# Stage-A writer flags — the review worklist
+This file records the editorial and preservation decisions used for the
+rewritten `draft-guide` corpus.
 
-Accumulated from all eleven writers' reports. Reviewers: resolve what your stage owns; leave the rest; record resolutions inline here (append a `RESOLVED (stage X):` line under the item).
+The 21 numbered chapters, `installation.md`, `glossary.md`, and `README.md`
+were rewritten for directness and consistency with `docs/AUTHORING.md`.
+Technical content was retained unless it was duplicated elsewhere in the
+corpus. Duplication was replaced with a clear link to the owning chapter.
 
-## Cross-chapter conflicts (Stage C owns)
+This is an internal audit document. It is not part of the reader's normal
+MkDocs path.
 
-1. **Direct-call refusal id**: ch01 used substrate id `:rf.error/view-called-directly`; ch02 found no attested Hicasso id and described the refusal without one. Pick ONE treatment for both pages.
-   - RESOLVED (stage C): no id on either page. `:rf.error/view-called-directly` is **Freehand's** (attested only in `implementation/freehand/src/re_frame/freehand.cljc`), and Hicasso's direct call does not route through that substrate — the prototype's minted component falls into the frame-context path, with no dedicated refusal id of its own. ch01's row now describes the refusal by mechanism (fires at the call, names the view), matching ch02; ch14's "refuses the same way" clause tightened to "refuses at the call itself, naming the view". While there, ch01's neighbouring read-escape row was corrected from Freehand's `:rf.error/view-read-outside-render` to the Hicasso-attested `:rf.error/hicasso-sub-outside-render` (ch02/14/15's spelling). Direct-call refusal added to the catalogue gaps (Stage C output, gap 1).
-2. **`ht/shadow!` vs the ch14 kit surface**: ch19 minted `ht/shadow!` with `{:reference :candidate :seed :script}`; ch14 minted the kit facade (`ht/tree`, `ht/mount!`, handle-first calls, `ht/canonical-dom`). Reconcile into one coherent `re-frame.hicasso.test` surface across both chapters.
-   - RESOLVED (stage C): one kit. `ht/shadow!` stays in `re-frame.hicasso.test` beside the mounted facade; ch19's `:seed` respelled **`:initial-events`** — the one seeding vocabulary `h/mount!` and `ht/mount!` already use; ch14 gained a one-sentence roster entry naming `ht/shadow!` with ch19 as owner page. Handle-first calls untouched: `ht/shadow!` is a one-shot config-map entry (no handle exists before it runs), which does not conflict with the mounted facade's handle-first style. No other spelling conflicts found between the two chapters.
-3. **Keys taught twice**: ch02 carries a full keys section; ch06 is the mapped owner. Substance agrees. Stage D/E trims ch02 to a pointer.
-   - RESOLVED (stage D): ch06 owns the keys law. ch02's `Keys go in the props map` trimmed to its own share — the props-map spelling (`{:key id :id id}`), the metadata-not-read note (the Reagent `??? info` folded into prose), the missing-key warning name — closing with an explicit hand-off to ch06 for key *quality* (stable identity, never index, never entity). ch02's entity-key troubleshooting row removed (ch06 carries it verbatim); the missing-key row stays because its fix is the spelling ch02 teaches, now with a ch06 pointer. ch06 unchanged — verified it already carries everything ch02 dropped (double-warning dedupe rationale, entity-key coercion/remount, allowed key types, Reagent delta).
-4. **Working loop listed in ch10 and ch18**: both wrote it (ch18 numbered as the performance method; ch10 in rung terms). Stage D/E picks one owner and makes the other a pointer.
-   - RESOLVED (stage D): ch18 owns the numbered method (untouched). ch10's `## The working loop` (7 near-duplicate steps) replaced by `## Every crossing runs the loop` — a one-paragraph pointer at Performance plus the rung mechanics that are ch10's own: which attribution verdict enters which rung, and the fence follow-through (re-run the contracts you can no longer see). The Xray-honesty paragraph (names/times the native boundary, `n/use-sub` reads, honest `opaque`) stays — it is fence-specific, not the loop. The escape-benefit rule remains stated on both pages deliberately: it is a brief-listed core fact each page uses (ch10's rung-3 worked example clears it; ch18 owns its definition section), not the duplicated loop.
-5. **`:server` policy spelling**: chapters 09, 10, 17 all committed to `{:server :render|:client-only}` + `:fallback` only-under-Client-only. Consistent — verify ch06's virtualizer host (omission = default) matches and no page still implies three-value `:ssr`.
-   - RESOLVED (stage C): verified across all 22 files. `:server` two-policy spelling uniform in ch09/10/17/19; `:fallback` taught only under Client-only, with Render+`:fallback` named as a refusal (`:rf.error/hicasso-host-bad-ssr-policy`, attested) in ch09/ch17; ch06's virtualizer host omits the option and states the Client-only default in prose; zero `:ssr` option spellings anywhere (the prototype's three-value `:ssr {:fallback …}` never leaked in). Note the `:server` key itself is a respell of the prototype's `:ssr` — added to the minted register (Stage C output, row 4).
+## Editorial rules applied
 
-## Premise calls to verify once (Stage C)
+- Start with the developer's problem and working code.
+- Use ordinary technical English and concrete verbs.
+- Let examples carry the explanation.
+- Keep the normal path before optional detail.
+- Preserve named APIs, option shapes, error and warning identifiers, lifecycle
+  rules, server policies, and browser edge cases.
+- Keep or strengthen `## Troubleshooting` and when-not coverage.
+- Do not invent an error id when the source corpus described only a mechanism.
+- Do not recreate MkDocs navigation with chapter lists, mini tables of contents,
+  or “what's next” footers.
+- Keep reference prose terse; the glossary defines rather than persuades.
 
-6. `h/event` used everywhere per the brief; spec §4 + ergonomics lane still spell `h/handler`. Correct under the brief; confirm zero stray `h/handler`/`h/fn` in any chapter.
-   - RESOLVED (stage C): grep clean over all 22 files — zero `h/handler`, `h/fn`, `hfn`. (ch09's `:handler` is the `defhost` callback-contract VALUE from the prototype's `:callbacks` roster `:event`/`:handler`/`:render` — a different word; stands.)
-7. Submit prevention uniform (ch03 teaches the bare-submit-navigates consequence loudly). Confirm no other chapter implies auto-prevent.
-   - RESOLVED (stage C): ch05 line 231 was the one violation (bare intent at `:on-submit` + an "auto-prevents" comment — Stage B's item 33); now `[::h/prevent [:editor/submit]]` with a no-auto-prevent comment. All ch03 sites already correct; no other chapter implies auto-prevent.
-8. Prefetch shipped (`:prefetch :intent`) — the draft-era decline id `:rf.error/hicasso-route-link-prefetch-declined` retired. Confirm no page still cites the decline.
-   - RESOLVED (stage C): grep clean — no page cites the decline id or a declining link. (The id remains attested in the v0 prototype + spec/009 as the draft-era decline; the *shipped* `:prefetch` wrong-value refusal ch07 teaches has NO attested id — catalogue gap 12, and the retired decline id must not be reused for it.)
-9. Direct-call semantics: refusal (not inlining) everywhere; plain `defn` inlines. Confirm ch02's Advanced doesn't contradict.
-   - RESOLVED (stage C): consistent everywhere. ch02's Advanced (the collector) doesn't touch direct calls; ch02's boundary section states a `defview` never degrades into an inline function; ch01/ch14 now aligned per item 1.
-10. Browser-neutral controlled-input law (Phase-1-complete premise). Deliberate; not an oversight.
-    - RESOLVED (stage C): ch04 is browser-neutral throughout — the legacy keyCode-229 clause says "some browsers", no Chromium scoping anywhere; matches the premise and the prototype's own gate (isComposing + 229 attested in `controlled.cljs`/`intent.cljs`, spelled browser-neutrally there too).
-11. Hooks never in `defview` bodies (spec §5); old draft said "not policed". Confirm all chapters follow spec.
-    - RESOLVED (stage C): ch09's Advanced (imperative SDKs) was the one violation — `react/useCallback` inside an `h/defview` body plus "both are fine" prose. Rewritten hook-free: a top-level `defn` attach ref (stable identity with no hook), with the per-instance-closure case explicitly routed to a named native component, matching spec §5 ("Hooks do not belong in the dynamically composed `defview` body") and ch10/ch11's teaching. ch10 (rung-3 fence + islands) and ch11 (valve 3) already conform; ch17's only hook use is inside `n/defcomponent` (legal).
-
-## Minted spellings needing naming-ledger rows (Stage C compiles the list; the sitting rules)
-
-12. `re-frame.hicasso.server` module name + `server/render` option contract; `:identifier-prefix`.
-13. Test kit: `ht/tree` (L2 entry), fixture-map shape `{:subs {query-v value}}`, `ht/mount!` handle shape, `ht/rerender!` (vs spec §9 "rerender" / lane "render!"), `ht/canonical-dom`, `ht/shadow!`.
-14. Interop: `:slots #{…}`, `h/portal {:target …}`, `h/as-component` (outward bridge).
-15. Native: `n/memo`, `n/lazy` (ABI helpers).
-16. Overlay options: `:open?` `:on-dismiss` `:anchor` `:placement` `:label` `:light-dismiss?` `:exit-ms`; minted id `:rf.error/hicasso-overlay-anchor-missing`.
-17. Motion respellings: `motion/presence`, `::motion/mounting`/`::motion/unmounting`.
-18. Forms: `forms/buffered-field` + `:control`/`:value`/`:on-commit`/`:on-cancel`; reset unified on `::h/revision`.
-19. Async: demand spelling `:demand true` inside `[:rf/resource …]` sub map + `:keep-previous? true`.
-20. Merge helper: recipe taught (plain `merge`, owned-last); no symbol minted anywhere — confirm no page invents one.
-21. `::h/navigate` presented as route-link-minted reserved head (not author-written core vocabulary).
-
-## Missing error ids (catalogue gaps — Stage C compiles; do NOT invent on pages)
-
-22. `defview` direct-call refusal (see item 1); the `n/$` refusal family (props misclassification, hiccup child, intent-in-prop, `:children`, slot collision); test-kit refusals (opacity, missing fixture, assert-clean failure); forms-module rows; contenteditable refusal; bare-intent veto at `route-link` `:on-click`; `:prefetch` wrong-value.
-
-## Deliberate omissions (correct under the premise — do not "fix" back)
+## Corpus inventory
 
-23. No `h/reg-state`, no `[::h/clear]`, no `h/child-key`, no vector-ref reservation, no parts/theming subsystem, no three-value `:ssr`, no `h/frame` (zero-arity `rf/capture-frame` admitted in-body instead), `subscribe-once` internal, old comparative benchmark figures dropped (budgets only).
-
-## Length
-
-24. ch09 at 383 lines (33 over target) — justified by the writer; Stage D judges.
-    - RESOLVED (stage D): judged one job (the foreign-React door seen from every side) with recipe-grade padding, not two jobs — no split, no renumber. 402 → 360 (target ≤360 met) by: compressing the escape's capture-frame recipe to ch03's pointer (the owner — picker-row code block dropped, law and `:rf.error/no-frame-context` kept); compressing the transparent-wrapper warning and provider prose against ch17 (owner of the full SSR story); folding the `No deep conversion` paragraph into the What-crosses table's Prop-values row; moving `The crossing has no memo wrapper` under `## Advanced` (subtlety, not required path); in-place compression of the skeleton-slot recovery (Stage B's restored teaching kept whole — declaration, code, placeholder-not-content close); removing two troubleshooting rows owned elsewhere (`hicasso-intent-needs-the-event` symptom row → ch03 owns it, and the id stays cited in ch09's body; children-missing-from-server-HTML mechanism row → ch17 owns it); and sentence-level tightening (opening rationale, callbacks two-laws merge, portal facts, server-policy section, bridge, SDK Advanced). All taught semantics, names, and error ids preserved — every id previously cited on ch09 still appears on ch09.
-
-## Stage B findings (completeness review)
-
-### (a) Coverage gaps filled (spec §7 walked row by row)
-
-25. **Multiple frames and roots** had mentions only (one sentence each in ch01/ch11/ch13/ch17), no teaching. Added `## More than one root` to ch01: two roots sharing one frame (ensure creates-and-seeds vs joins-without-replay — semantics verified against `docs/core/how-to/boot-and-mount-an-app.md`), two frames as isolated apps (subs never cross), per-root teardown with the frame surviving for other roots; plus one troubleshooting row (joining root's `:initial-events` never run). ch01 now 226 lines.
-26. **Code splitting** was untaught (`n/lazy` a one-clause mention in ch10; Suspense hosting one sentence in ch09). New chapter `20-code-splitting.md` (204 lines) + README row: route/module boundary as the default (shadow-cljs `:modules` + `shadow.lazy` + a user-authored load fx + arrival-as-state, route `:on-match` wiring verified against `docs/routing/tutorial.md`), the `n/lazy` bridge + Suspense host (`:slots #{:fallback}`) + `h/error-boundary` retry, declared-outside-render law, HMR/marker conduct, SSR Client-only. Sources: specification §7 row, dispositions HS-22/HS-30, completeness-audit, react-compatibility matrix.
-27. **Suspense and Activity conduct** (reader-facing half) was untaught. Covered in ch20 `## While a subtree waits, or hides`: suspended attempts own nothing (commit-owned acquisition), no `sub`-driven promise selection for data (per react-compatibility-notes — external-store updates can swap visible content for the fallback), Activity hosted via `defhost` (no DSL), hide releases committed ownership and demand with app-db untouched, reveal reacquires — corrected inside the reveal's own render when the reveal is discrete, with a bounded one-frame window when it is concurrently scheduled (rf2-hic-014; the earlier "before visible paint" summary was the flushed half stated as the whole) — plus the disclosure steer away from retaining account/tenant panes, and Xray's hidden-retained label.
-28. **Accessibility** had no owner (scattered aria examples in ch07/ch08/ch12/ch11). New chapter `21-accessibility.md` (168 lines) + README row: semantic elements first, names as ordinary attributes with per-instance id discipline, ARIA state derived from the same reads, a focus-owner inventory table (pointers, no re-teaching), L2 structural assertions with a sabotage twin, browser-tier focus walks + axe floor (per completeness-audit "structural accessibility assertions plus browser focus and axe checks").
+The package contains all 25 Markdown files from the source directory:
 
-Rows verified covered with no edit needed: validation/async normalization (ch05 gating + ch04 revision re-baseline + ch08 settle-merge), routing, async/mutations, errors, foreign React + native, large collections, imperative SDKs (ch09 Advanced), overlays, motion (ch11 valves 3/5), SSR, i18n/theming, testing, diagnostics, migration.
+- `README.md`
+- `installation.md`
+- `01-getting-started.md` through `21-accessibility.md`
+- `glossary.md`
+- `REWRITE-NOTES.md`
 
-### (b) Gaps not filled
+The numbered learning path remains unchanged.
+
+## Information-preservation policy
 
-None — every reader-facing §7 row now has an owning chapter with real teaching.
+The rewrite retained the following classes of information page by page:
+
+1. Every public symbol taught in source code or prose.
+2. Every option key and value shape.
+3. Every named `:rf.error/*`, `:rf.warning/*`, and `:rf.ssr/*` identifier.
+4. Every browser, React, frame, SSR, hydration, or HMR caveat.
+5. Every “do not” example and its recovery.
+6. Every troubleshooting scenario and when-not decision.
+7. Every relative cross-link needed to find the owning chapter.
+8. Every code example that teaches a distinct contract.
 
-### (c) Restored draft material (sweep 2)
+Repeated marketing claims and repeated explanations were shortened. They were
+not treated as separate technical facts.
+
+## Cross-chapter ownership decisions
+
+### View calls and helpers
+
+A `defview` is mounted as a Hiccup head and is not called as a Clojure
+function. Plain `defn` helpers are called inline. The guide describes the
+direct-view-call refusal by mechanism because no dedicated Hicasso error id is
+attested for it.
+
+Do not reuse `:rf.error/view-called-directly`; that identifier belongs to the
+Freehand substrate. The Hicasso read-outside-render id is
+`:rf.error/hicasso-sub-outside-render`, not
+`:rf.error/view-read-outside-render`.
+
+### Keys
+
+`02-views-and-reads.md` owns the component ABI and the rule that `:key` belongs
+in the props map. `06-lists-and-collections.md` owns key quality, identity,
+sequence warnings, and collection topology.
+
+### Performance method
+
+`18-performance.md` owns the complete measurement loop and benefit rule.
+`10-native-tier.md` teaches the code for each native level and refers back to
+the performance decision method.
+
+### Server policy
+
+The guide uses one server contract consistently:
+
+```clojure
+{:server :render}
+{:server :client-only}
+{:server :client-only
+ :fallback ...}
+```
+
+`:fallback` is legal only for Client-only. The old three-shape `:ssr` spelling
+is not taught.
+
+### Event callbacks
+
+The guide uses `h/event` consistently. `:handler` remains a valid `defhost`
+callback-contract value and is not the same thing as an `h/handler` macro.
+
+No form submit is auto-prevented. A submit that must stay on the page uses:
+
+```clojure
+[::h/prevent [:form/submitted]]
+```
+
+### Hooks
+
+React hooks never appear in a `defview` body. Hook-based mechanics belong in a
+named native component or UIx component. A top-level callback ref covers the
+simple hook-free imperative-host case.
+
+## Current guide spellings that still need naming governance
+
+These names are taught as the current guide contract but were identified by
+the source audit as names requiring explicit naming-ledger approval or final
+implementation confirmation:
+
+- `h/event`
+- artifact coordinates for Hicasso
+- root lifecycle configuration around `h/mount!`, `h/hydrate!`, `h/render!`,
+  and `h/unmount!`
+- `:server :render|:client-only` and Client-only `:fallback`
+- `re-frame.hicasso.server` and the `server/render` option map
+- `ht/tree`, its `{:subs ...}` fixture shape, and tree helper names
+- mounted-facade helper names and exact handle shape
+- `ht/shadow!` and its config/result maps
+- `defhost :slots`
+- `h/portal {:target ...}`
+- `h/as-component`
+- `n/memo` and `n/lazy`
+- overlay heads and option names
+- `motion/presence`, `::motion/mounting`, and `::motion/unmounting`
+- `forms/buffered-field` and its control options
+- resource `:demand true`
+- route-link's generated `::h/navigate` carrier
+- route-link `:prefetch :intent`
+- Xray evidence-envelope keyword shapes
+- hydration mismatch report-map keys
+
+The migration CLI and W1–W6 rewrite families were treated as attested, not
+invented.
+
+## Refusals described without an invented id
+
+The source audit identified behaviours that need a catalogue id but do not yet
+have one attested. The rewritten guide keeps the behaviour and recovery without
+inventing a keyword:
+
+- direct invocation of a `defview`;
+- `n/$` dynamic props misclassified as a child;
+- Hiccup vector used as a native child;
+- event vector used as a native callback;
+- `:children` placed in native props;
+- normalised native-prop slot collision;
+- L2 semantic harness reaching a hook, host, raw React element, or `n/$`;
+- L2 missing subscription fixture;
+- mounted test residue failure;
+- selected forms-module misuse cases;
+- controlled binding on `contenteditable`;
+- invalid route-link prefetch value;
+- a second live Hicasso root mounted on the same DOM container.
+
+The retired `:rf.error/hicasso-route-link-prefetch-declined` id is not reused
+for a bad prefetch value.
+
+## Deliberate omissions
+
+The following older draft ideas are not restored:
+
+- `h/reg-state`
+- `[::h/clear]`
+- `h/child-key`
+- vector-ref reservation
+- a Hicasso parts/theming subsystem
+- three-value `:ssr`
+- `h/frame`
+- public `subscribe-once`
+- old comparative benchmark figures
+- automatic submit prevention
+- a declined prefetch feature
+- position-dependent callback forms
+- Chromium-only IME wording
+- pre-React-19 ref contracts
+
+The current guide instead uses app-db state ownership, CSS tokens, two server
+policies, `rf/capture-frame` at explicit edges, user-visible budgets, and the
+browser-neutral controlled-input contract.
+
+## Chapter-level preservation record
+
+### README and installation
+
+Retained the adapter's scope, prerequisites, frame/root ownership, initial
+seeding, multiple roots, independent frames, idempotent unmount, hot reload,
+and first-paint behaviour. MkDocs owns chapter navigation.
+
+### 01 — Getting started
+
+Retained the comparison with Reagent and UIx, data-first markup, point-of-use
+reads, event intents, controlled fields, native escape, performance cost, and
+when-not guidance. Removed sales-like repetition.
+
+### 02 — Views and reads
+
+Retained boundary versus inline-helper syntax, read ownership, props and
+children ABI, fragments, equality memoisation, own-read invalidation,
+function-valued prop identity, attribute conversion, forwarding precedence,
+read extent, deferred reads, collector commit semantics, and all relevant
+refusals.
+
+### 03 — Events as data
+
+Retained event-position detection, `::h/value`, `::h/checked`, `::h/prevent`,
+`h/event`, plain-function behaviour, keyboard maps, IME suppression, frame
+capture, stale frame-incarnation refusal, and malformed-intent recovery.
+
+### 04 — Controlled inputs
+
+Retained supported control types, synchronous write requirement, caret and
+selection repair, IME composition, forwarding restrictions, revision reset,
+hydration reset swallowing, same-turn convergence, `flushSync` implications,
+and unsupported contenteditable/native paths.
+
+### 05 — Forms
+
+Retained direct controlled forms, buffered fields, draft/baseline/revision
+protocol, late arrival and settle-merge races, validation gates, submit
+materialisation, per-instance mutation status, draft lifetime, cancellation,
+and failure recovery.
+
+### 06 — Lists and collections
 
-29. ch06: the missing-key warning at the seq-as-view-children crossing (React marks flattened members validated and never warns; Hicasso's line is the only signal) — from draft 02.
-30. ch09: the `[:>]`-under-SSR recovery — a transparent pass-through host with a `:fallback` wrapping the escape puts placeholder markup at the site (draft 05's `skeleton-slot` recipe, respelled to the current `:fallback` option surface). ch09 now 400 lines — see item 24, Stage D.
-31. ch13: the page-chrome echo (document-level copy of the theme fact via a client-only fx under a *different* attribute name) and the `::backdrop`-inherits-from-originating-element note — from draft 06. This also makes ch12's "style the backdrop via [Theming]" pointer deliver something.
-32. ch18: `rf:*` User-Timing accuracy — compile-time `:closure-defines {re-frame.performance/enabled? true}`, default off; entries delivered-not-retained (observer/timeline see them, a later `getEntriesByType` poll does not); bail-outs emit nothing; StrictMode emits twice — from draft 11, verified against `implementation/core/src/re_frame/performance.cljc`. This also removes ch18's "development builds emit" wording that contradicted ch15's "gated by its own compile-time flag, off by default".
-
-Checked and deliberately NOT restored (item 23 or superseded by the premise): the `:&` grammar, `h/reg-state`/`[::h/clear]`/`h/child-key`, vector-ref reservation, parts/theming layer, three-value `:ssr`, `h/frame`, `subscribe-once`, draft benchmark figures, submit auto-prevent, prefetch decline, position-dependent `h/fn` meaning table (h/event is position-invariant), Chromium-only IME scope note, pre-React-19 ref shape, object-ref aside, collection-values-`clj->js` claim (superseded by identity crossing), reduced-structural-identity deep-dive (compact form survives in ch09/ch19).
+Retained stable key rules, missing-key warnings, entity-key refusals, fine,
+coarse, chunked, and windowed read topology, virtualiser interop, oscillating
+read sets, mount versus update tradeoffs, and accessibility consequences.
+
+### 07 — Routing and navigation
+
+Retained real-anchor behaviour, generated navigate carrier, prefetch,
+modifier-click handling, veto contracts, route focus, scroll restoration,
+dirty-state guards, browser exits, history direction, malformed navigation,
+and frame routing.
+
+### 08 — Async resources
+
+Retained status projections, previous-value retention, settle-merge,
+supersession, demand-driven committed reads, mutation instances, optimistic
+writes and rollback, conflict handling, typeahead behaviour, late replies,
+route demand, and failure recovery.
+
+### 09 — Interop
 
-### (d) Noticed for other stages (not fixed here)
+Retained shallow crossing rules, callback contracts, ReactNode slots, provider
+and compound-component conduct, server policy, portals, raw `[:>]` escape,
+outward bridge, component/ref identity, imperative SDK attach/cleanup,
+StrictMode, and all declaration/runtime refusals.
 
-33. (Stage C — item 7 evidence) ch05 line 231 comment reads "an intent at `:on-submit` auto-prevents", contradicting ch03's no-auto-prevent law. One-comment fix.
-    - RESOLVED (stage C): fixed under item 7 — code and comment both (the bare intent would also have navigated, so the `::h/prevent` head was added, not just the comment).
-34. (Stage C — items 13/15/22) ch20 leans on the `n/lazy` mint and adds a loader-contract question (thunk-returning-a-promise, React.lazy shape) — fold into the ledger row. ch20/ch21 mint no error ids and no new module names; the `suspense`/`activity` declarations are user-authored `defhost`s, not product spellings.
-35. (Stage D — item 24 family) post-B lengths: ch01 226, ch06 304, ch09 400, ch13 245, ch18 247, ch20 204, ch21 168.
-36. (Stage C/D) ch15's complaint-catalogue row for `:rf.error/frame-destroyed` points at ch03, which never teaches frame incarnation — move the pointer or give ch03 Advanced one sentence when compiling item 22.
-    - RESOLVED (stage C): ch03's "Callbacks carry their frame" section gained one sentence — a captured handle is good for its frame's incarnation; a stale handle's operation refuses with `:rf.error/frame-destroyed` (attested, 7 hits in the prototype tree). ch15's pointer at ch03 now lands.
-37. (Stage E) ch20/ch21 are written to the brief's rules (problem open, required path, troubleshooting, when-not, one warning admonition each) — include both in the E-pass roster.
+### 10 — Native tier
 
-## Stage C output
+Retained all five performance levels, direct-return metrics example, `n/$`
+grammar, dynamic `n/props`, event and child refusals, native hooks, frame
+operations, high-rate local state, marker-preserving wrappers, HMR remount,
+server policy, and benefit thresholds.
 
-Verification basis: attested = found by grep in `implementation/hicasso/src/**`, `implementation/freehand/test/re_frame/bench/hicasso/**`, `migration/reagent-to-hicasso/**`, or the shipped core corpora (`docs/core/**`, `docs/routing/**`, `docs/resources/**`, `docs/api/**`); pinned = named in the brief table, naming-ledger, spec §4/§5/§9, or a lane. Post-edit id census across all 22 chapters: 33 distinct `:rf.error/*` / `:rf.warning/*` / `:rf.ssr/*` ids cited; 32 attested; 1 deliberate flagged mint (`:rf.error/hicasso-overlay-anchor-missing`); 2 Freehand-substrate ids removed/corrected on ch01 (`:rf.error/view-called-directly` dropped, `:rf.error/view-read-outside-render` corrected to `:rf.error/hicasso-sub-outside-render`).
-
-### (a) The minted-spellings register (naming-ledger rows to sit)
-
-Every symbol/option/keyword taught that no normative source pins. "Verified none/attested" rows are included so the sitting sees the whole sweep.
-
-1. `h/event` — the callback macro name, all chapters; the brief rules it over spec §4 / ergonomics-lane `h/handler` and prototype `hfn`; ledger row 1 stands open for the sitting — the guide is committed corpus-wide.
-2. Artifact coordinates `io.github.day8/re-frame2-hicasso` (+ core `day8/re-frame2` arriving transitively) — ch01. Ledger row 14 covers only the ns name `re-frame.hicasso`.
-3. Root-lifecycle contract shape: `h/mount!`/`h/hydrate!` take `(node config view)` with config keys `:frame`, `:initial-events` (mount) and `:frame`, `:identifier-prefix` (hydrate); `h/render!` takes `(handle view)`; idempotent handle — ch01, ch17. Ledger row 13 pins the four verbs only; the prototype `root!` took a bare frame keyword, and `:initial-events` is borrowed from core's frame-root vocabulary.
-4. `:server` policy option key on `defhost` / `n/defcomponent`, values `:render` / `:client-only`, with `:fallback` a sibling option legal only under Client-only — ch06 (default by omission), ch09, ch10, ch17, ch19. The prototype spells `:ssr` with a three-shape contract; the brief pins "two policies" but not the key spelling.
-5. `re-frame.hicasso.server` module + `server/render` option contract: `:hiccup` `:snapshot` `:payload` `:client-frame-id` `:identifier-prefix` `:app-element-id` `:script-src` `:title`, returning `:document` — ch17. [item 12]
-6. Test kit L2: `ht/tree` entry; fixture-map shape `{:subs {query-v value}}` (lineage: the draft guide's `h/render`); tree helpers `ht/find` / `ht/attrs` / `ht/text` / `ht/intents` — ch14, ch21. [item 13]
-7. Mounted facade details: `ht/mount!` handle shape (a map; `:container` a real DOM node — matches the prototype root handle); `ht/rerender!` (spec §9 says "rerender", testing lane says `render!` — the sitting settles which); `ht/canonical-dom` (sorted-attribute serializer) — ch14. The facade verbs themselves (mount!/hydrate!/dispatch-and-settle!/settle!/unmount!/assert-clean!) are lane-pinned, not mints. [item 13]
-8. `ht/shadow!` + options `{:reference :candidate :initial-events :script}` (Stage C respelled `:seed` to `:initial-events`), result shape `{:status :checkpoints}`, scriptless live-diff mode — ch19, ch14 roster line. No lane names any shadow surface. [item 13]
-9. Interop declaration option `:slots #{…}` (ReactNode positions) — ch09; spec §4.3 pins the concept, not the spelling. [item 14]
-10. `h/portal` + `{:target …}` — ch09; spec §4.3 pins "a tiny optional portal helper", not the name/option. [item 14]
-11. `h/as-component` — the outward bridge — ch09; spec §4.3 pins the bridge, not the name. [item 14]
-12. `n/memo`, `n/lazy` ABI helpers + the `n/lazy` loader contract (thunk returning a promise resolving to the component, `React.lazy` shape, component marker kept) — ch10, ch20. Spec §4 pins "native ABI helpers" generically. [items 15 + 34]
-13. Overlay module surface: heads `overlay/popover`, `overlay/modal`; options `:open?` `:on-dismiss` `:anchor` (a DOM id) `:placement` (compass words `:bottom-start` …) `:label` `:light-dismiss?` `:exit-ms`; minted id `:rf.error/hicasso-overlay-anchor-missing` — ch12. [item 16]
-14. Motion respellings: `motion/presence` head; `::motion/mounting` / `::motion/unmounting` override keys (the prototype attests the engine under `h/presence` with `::h/mounting`/`::h/unmounting`; `:timeout-ms` and the `:rf/phase` prop with values `:mounting`/`:present`/`:unmounting` carry over attested) — ch11. [item 17]
-15. Forms: `forms/buffered-field` + `:control` (draft address) `:value` `::h/revision` `:on-commit` `:on-cancel`; the module-owned draft key at the `:control` address — ch05. [item 18]
-16. Async: `:demand true` inside the `[:rf/resource …]` sub map — ch08. (`:keep-previous?` is attested core-resources vocabulary — struck from the item-19 mint list.) [item 19 narrowed]
-17. Merge helper — verified NONE minted: plain `merge`, owned-last, recipe-only in ch02/ch04; no page invents a symbol. [item 20 closed]
-18. `::h/navigate` reserved head — presented correctly as route-link-minted, never author-written; its grammar `{:frame :payload :native? :veto}` is attested verbatim in the prototype (`route_link.cljs`); needs a reserved-vocabulary ledger row because the brief's reserved-data list does not include it — ch07. [item 21]
-19. `:prefetch :intent` accepted on `route-link` — ch07. The prototype declines the key for v0 (that decline is the retired id); routing's own `:rf.route/prefetch` event and `:intent` spelling are attested in docs/routing. The link-side acceptance is the designed end state and needs its row.
-20. Xray evidence-envelope keyword spellings: `:cause {:kind :reads|:props|…}`, `:attempt` (`:committed`), `:completeness`, `:loss`, loss labels `:unknown` / `:opaque` / `:no-static-analysis` / `:host-opaque` / `:cap` / `:uncorrelated` — ch15. Spec §10 pins the vocabulary in prose, not the keyword forms.
-21. Hydration-mismatch report shape `{:id :root :where :error}` — ch17. The id `:rf.ssr/hydration-mismatch` is attested (re-frame.ssr); the report-map keys are the mint.
-22. Migration tool surface — verified ATTESTED, not mints: the CLI (`clojure -M:run`, `--report`, `--rewrite`, `--write`), all 19 needs-your-hands/blocker class keywords, rewrite families W1–W6, and the `__rf2` hygienic-naming convention all match `migration/reagent-to-hicasso/codemod` source exactly. Only the shadow-mode surface (row 8) is minted.
-
-### (b) The catalogue gaps (refusals taught by mechanism with no attested id)
-
-Complaint-catalogue entries to mint. The retired decline id must not be reused (gap 12).
-
-1. `defview` direct-call refusal — fires at the call, names the view — ch01, ch02, ch14. (Freehand's `:rf.error/view-called-directly` belongs to the other substrate; Hicasso needs its own entry.)
-2. `n/$` dynamic-map-in-props-position misclassification (map lands as a child; recovery names `n/props`) — ch10.
-3. `n/$` hiccup-vector-child refusal (square brackets have no meaning past the fence; recovery names `h/as-element`) — ch10.
-4. `n/$` event-vector-in-native-prop refusal (no intent lowering past the fence) — ch10.
-5. `n/$` `:children`-in-props refusal (one child channel) — ch10.
-6. `n/$` canonical-slot-collision refusal (two source keys, one React slot) — ch10.
-7. Test kit: L2 opacity refusal — body or expanded child reaches a hook, raw React element, `n/$` result, or `defhost` crossing; structured, source-located, points at L3 — ch14.
-8. Test kit: L2 missing-fixture refusal, naming the query — ch14.
-9. Test kit: `ht/assert-clean!` residue failure (post-quiescence residue vs pre-mount baseline) — ch14.
-10. Forms-module rows — ch05 deliberately teaches behavioural failure modes with no module ids; the sitting decides whether any (duplicate `:control` address, commit-after-cancel arrival) deserve catalogue ids. [item 22 carry]
-11. Contenteditable controlled-binding refusal (`:value` on a contenteditable region refuses at source; recovery names the host/native routes) — ch04.
-12. `:prefetch` wrong-value refusal at render (any value other than `:intent`) — ch07. Needs a NEW id; `:rf.error/hicasso-route-link-prefetch-declined` is the retired draft-era decline and stays dead.
-13. Second `h/mount!` on a node a live root owns — ch01 troubleshooting, mechanism only.
-
-NOT gaps — attested ids exist that the pages describe by mechanism only (candidates for citation when the catalogue is compiled; Stage C made no page edits for these per the verify-and-compile rule): route-link bare-intent veto → `:rf.error/hicasso-route-link-bad-on-click`; ambient `rf/subscribe`/`rf/dispatch` in a body → `:rf.error/ambient-frame-refused`; the `defhost` declaration-time family ch09 summarises as "fail at the declaration" → `:rf.error/hicasso-unknown-callback-contract`, `:rf.error/hicasso-host-no-component`, `:rf.error/hicasso-host-callback-slot-collision`, `:rf.error/hicasso-host-structural-callback`; the presence rules ch11 states as law → `:rf.error/hicasso-presence-timeout-required`, `:rf.error/hicasso-presence-child-unkeyed`, `:rf.error/hicasso-presence-child-not-hiccup`; route-link outside a boundary → `:rf.error/hicasso-route-link-outside-boundary`.
-
-## Stage D findings (tutorial structure)
-
-Scope: sweeps per the Stage D brief — per-chapter shape, cross-chapter reading path, proportion. Items 3, 4, 24 resolved inline above. Stage C's resolutions untouched; no taught semantics, names, or error ids changed; no files renumbered; docs/ untouched.
-
-### Sweep 1 — per-chapter shape (all 22 files walked)
-
-- Openings: every chapter states the reader's problem in 1–2 sentences before anything else — no edits needed.
-- Goal → working code → explanation holds everywhere; no internals-first chapter found. ch04's open (required path as the first code block) is the strongest instance of the pattern.
-- Example threads: ch06 (one orders table through four topologies) and ch14 (one todo row up the ladder) are exemplary single-thread chapters. ch03/ch04/ch05 carry several small examples, each serving a distinct API position or module feature; consolidation onto one domain was judged NOT cheap (would contrive features onto the todo/editor threads and touch names Stage C censused) — left as-is. No true example zoo found.
-- Required path / Advanced: one violation — ch09's `The crossing has no memo wrapper` sat as a body H2 between Portals and the escape; moved under `## Advanced` (compressed). All other Advanced material was already placed after Troubleshooting/When-not.
-- Code-block framing (why-you-care before, what-it-did after): spot-checked across all chapters; no violations worth an edit (ch01's paired build-config blocks share one lead-in, acceptable).
-- H2 scannability: fixed one — ch10's `## The working loop` implied a second owner of ch18's method; now `## Every crossing runs the loop` (a pointer-shaped beat). All other chapters' H2 runs retell their chapter.
-
-### Sweep 2 — cross-chapter path
-
-- Order of concepts (01→21): no chapter before 10 leans on native-tier knowledge (ch04/ch05 carry pointers only; ch09's "when not to host" and Advanced route *to* ch10, teaching nothing native). ch06's virtualizer uses `h/defhost`/`h/as-element` ahead of ch09 — as the chapter map itself mandates (virtualization is ch06's job); the page glosses both inline and defers mechanics explicitly to ch09, so the path holds. ch05 uses the mutation-execute/instance-status surface with a one-sentence delegation of registration/supersession/optimistic depth to ch08 — uses, does not assume; holds. ch20 leans on nothing past ch17 (route `:on-match` 07, slots 09, `n/lazy` 10, error-boundary 16, SSR 17 — all earlier). ch07's `::h/navigate` is taught where minted; `::h/prevent` owned by ch03 before every later use.
-- Item 3 (keys) and item 4 (working loop): resolved above.
-- Other duplicated teaching, one-owner fixes made: ch02's Advanced `The collector` restated body claims 1 and 4 — trimmed to the mechanism the claims imply (abandoned renders, lazy-seq forcing, loud escape); the "design around it in very hot lists" advice dropped there because ch06's `Oscillating read sets` owns it. ch04's Advanced IME rule repeated ch03's gate mechanics (native event, legacy signal) — now a pointer, law kept. ch09's escape re-taught ch03's capture-frame with a second full example — compressed to pointer (item 24). ch09's provider/SSR depth compressed against ch17 (owner).
-- Duplication judged deliberate and kept: owned-wins merge in ch02 (general recipe) and ch04 (controlled-slot law) — ch02 explicitly delegates the controlled case to ch04; layered, not duplicated. Ladder table in ch10 (owner) and ch18 (map-sanctioned "recap"). Escape-benefit rule one-liner on ch10 and ch18 (brief-listed fact both use). ch05 form-scoped instance-status usage vs ch08's general law (ch05 delegates explicitly).
-
-### Sweep 3 — proportion
-
-Post-D lengths: 01: 226, 02: 319, 03: 287, 04: 307, 05: 311, 06: 304, 07: 344, 08: 351, 09: **360**, 10: 234, 11: 307, 12: 289, 13: 245, 14: 353, 15: 267, 16: 177, 17: 372, 18: 247, 19: 285, 20: 204, 21: 168, README: 30.
-
-- ch09 (item 24): 402 → 360, resolution above.
-- ch17 at 372: judged NOT drag — it owns two halves (server render + hydration) with almost no verbatim repetition, no admonition pileups, and its length is Stage-B-era teaching, not padding. Left alone; flagged here for Stage E's awareness.
-- ch08 (351) and ch14 (353): within noise of target, read tight; no treatment.
-- No chapter shows three-admonitions-in-a-row or over-explained code.
-
-### Files changed (before → after)
-
-| File | Before | After | What |
-|---|---|---|---|
-| `v1/02-views-and-reads.md` | 340 | 319 | keys section → essential minimum + ch06 pointer (item 3); entity-key troubleshooting row removed; Advanced collector de-duplicated against body claims |
-| `v1/04-controlled-inputs.md` | 308 | 307 | Advanced IME gate mechanics → ch03 pointer |
-| `v1/09-interop.md` | 402 | 360 | item 24 resolution (see above) |
-| `v1/10-native-tier.md` | 242 | 234 | working-loop steps → ch18 pointer + fence follow-through (item 4) |
-
-All other v1 files unchanged. Nothing committed; `docs/` untouched.
-
-## Stage E findings (AUTHORING.md conformance)
-
-Scope: the four Stage-E sweeps over all 22 v1 files against the full `docs/AUTHORING.md`, with site-only rules (mkdocs nav rows, live `cljs-rf2` cells, `mkdocs build --strict`) out of scope for a `docs/design/hicasso/` landing. No semantics, names, or error ids changed; nothing renumbered; `docs/` untouched; senior-developer voice kept (STE deliberately not applied — Stage F owns it).
-
-### Sweep 1 — non-negotiables (all clean; 1 fix)
-
-- **Standalone corpus: zero violations.** Grep-verified across all 22 files: no links or references into `spec/`, no bead ids, no links into `docs/design/hicasso/product/`, and no markdown links leaving `v1/` at all (no `../`, no absolute, no external URLs).
-- **True snippets: zero violations.** Every `;; Don't` block walked (ch02 ×2, ch03, ch10 ×2, ch11 ×2, ch12, ch13, ch16, ch17, ch18, ch21): all labeled, all paired with the correct form or an explicit failure comment, none demoed as success. ch17's deliberate hydration divergence is labeled `;; Don't — deliberate divergence, kept to show the complaint`.
-- **One job / one mode: no drift.** Each page's mode is inferable and matches the roster (now explicit in the README's Mode column — Sweep 4). ch01's `More than one root` stays start-mode (it is mount teaching, Stage B's addition); ch11 reads as the explanation page it is.
-- **Reader-first order: nothing regressed** post-D; every chapter still opens problem → working code → explanation.
-- Fix: ch01's direct-call troubleshooting row said "a `defview` is a boundary" — jargon the reader does not meet until ch02. De-jargoned to "a `defview` is mounted as a Hiccup head, never invoked" (Stage C's by-mechanism wording preserved).
-
-### Sweep 2 — concept five-piece, headings, ceremony (all clean)
-
-- All 11 concept-mode chapters (02, 03, 04, 05, 06, 09, 10, 14, 15, 16, 17) carry all five pieces: problem open, unlabeled required path, `## Troubleshooting` table, a when-not section, and `## Advanced` only where needed (02, 03, 04, 05, 09, 14, 15 have one; 06, 10, 16, 17 correctly have none). The how-to/explanation chapters carry troubleshooting + when-not too.
-- Headings: every troubleshooting heading is exactly `## Troubleshooting`, every advanced exactly `## Advanced`. Grep for "When things go wrong", "Going further", "Basics", "Day one", "Start here", "What's next": zero (ch10's ladder cell "Always start here" is a table cell, not a heading).
-- No navigation ceremony anywhere: no "What's next" footers, no mini-TOCs, no page restates the README table.
-
-### Sweep 3 — voice (7 fixes; the rest judged fine)
-
-- Status-language grep hits, all fixed: ch09 "each load-bearing" → "each blocking a real defect"; ch06 "seamless scrolling" → "continuous scrolling"; filler "simply" removed at ch03 ("omits it"), ch10 ("a head as-is"), ch11 ("*true during entry*"). Zero hits for foundational/pivotal/powerful.
-- "just" audit: 16 hits, every one meaningful (temporal "just made", "not just", or the operative "is just a function call" claim) — no filler, no edits.
-- Metaphor budget: one committed metaphor per concept holds (ch10 trap door, ch11 pressure valves, ch05 traps, ch14 ladder+sabotage-twin are product vocabulary). One violation: the clothing metaphor ran four times across ch10/ch18 ("wearing a costume" ×2, "wearing armor", "wearing an optimisation's clothes") — trimmed to one, keeping ch18's "a rewrite wearing an optimisation's clothes"; the others became operational ("almost always a rung-1 or rung-2 problem underneath", "Unattributed \"slow\"", "rung-1 code at rung-3 prices").
-- Admonition budget: max two adjacent boxes anywhere (ch10's islands note + UIx info); no three-in-a-row on any page.
-- Pull-quotes: exactly one `> **…**` per chapter, zero on the README — no violations.
-- Key terms at first use: **frame** defined ch01 ("isolated app-db, queue, and subscription cache"); **boundary** defined ch02 before use (ch01 leak fixed above); **intent** was used from ch02 onward without a definition anywhere — now glossed at its ch02 first mention ("the event vectors in those attributes — *intents*") and defined at ch03 first use ("an event vector sitting at an event position is an **intent** — what the interaction means, stated as data"); **adoption** — every pre-ch17 use carries its meaning in-sentence with a ch17 pointer, ch17 defines it in the open. "seam" kept: used consistently as the corpus's name for the interop crossing (ch09/ch10), a term of art here, not decoration.
-
-### Sweep 4 — housekeeping
-
-- README: rosters all 21 chapters with one-job labels verified accurate against each page; **Mode column added** (Stage B's note): ch20 = concept/how-to, ch21 = how-to; the rest match the brief's chapter map ("(short)" qualifiers dropped as process metadata).
-- Tables: scripted column-count check over every table in all 22 files — zero inconsistencies.
-- Links: scripted check — every relative link and every anchor (including `#choosing-the-address`, `#troubleshooting`, `#advanced`) resolves within v1/ — zero problems. Zero external links.
-
-### ch17 verdict (Stage D's ch17-at-372)
-
-**Stands at 372 — no cut.** Concur with Stage D: the page owns two halves of one contract (server render + hydration adoption) with no verbatim repetition, no admonition pileup, and every section doing distinct required teaching (per-surface table, request lifecycle, payload policy, per-root verdicts, transparent-wrapper deletion, native tier, Node service). Under "length is a smell, not a rule" I found no real drag — sentence-level trimming would shave lines without removing weight, and splitting would sever the server-render/hydration halves that explain each other.
-
-### Files changed (before → after)
-
-| File | Δ | What |
-|---|---|---|
-| `v1/README.md` | 30 → 30 | Mode column added; labels verified |
-| `v1/01-getting-started.md` | 226 → 226 | de-jargoned "boundary" in troubleshooting row |
-| `v1/02-views-and-reads.md` | 319 → 320 | intent glossed at first mention |
-| `v1/03-events-as-data.md` | 287 → 289 | intent defined at first use; "simply" dropped |
-| `v1/06-lists-and-collections.md` | 304 → 304 | "seamless" → "continuous" |
-| `v1/09-interop.md` | 360 → 360 | "load-bearing" → operational |
-| `v1/10-native-tier.md` | 234 → 234 | "simply" dropped; costume metaphor → operational |
-| `v1/11-ephemeral-state.md` | 307 → 307 | "simply" dropped |
-| `v1/18-performance.md` | 247 → 247 | two clothing-metaphor repeats → operational (one kept) |
-
-All other v1 files unchanged. Corpus total 5987 → 5990 lines.
-
-### Left for Stage F
-
-- Apply Simplified Technical English per its own brief. Note: the retained one-jab lines (ch10 "trap door" frame and "complexity drawing a salary", ch14 "a test that cannot fail is a comment", ch18 "a rewrite wearing an optimisation's clothes", ch12 "the triangle is free") are deliberate voice under AUTHORING's Yegge-seasoning rule — each decorates a precise operational claim that must survive any rewording.
-- No structural, roster, link, or snippet work remains; Stage F inherits a corpus clean against AUTHORING.md's non-site rules.
-
-## Stage F completion
-
-2026-08-10 14:21:03 AUSEST — completion agent (predecessors killed by spend limit). Scope: the four files the killed agents never STE-processed, plus verification of the six they rewrote without self-checks. Per STE-RULES.md; nothing committed; `docs/` untouched.
-
-### Rewritten (STE pass applied; code blocks and table structure/data byte-identical; per-file self-checks run)
-
-| File | Before → after | Checks |
-|---|---|---|
-| `v1/06-lists-and-collections.md` | 304 → 313 (+3.0%) | ids identical (`hicasso-bad-head` ×1, `hicasso-entity-key` ×2, `hicasso-missing-key` ×3); fences 10; headings identical except `### Windowed: the DOM stops pretending` → `### Windowed: only the visible rows exist` (meaning-identical de-metaphor; no inbound anchors) |
-| `v1/07-routing-and-navigation.md` | 344 → 352 (+2.3%) | ids identical (`can-leave-non-boolean` ×1, `hicasso-malformed-navigate` ×2, `routing-artefact-missing` ×2); fences 22; heading set unchanged; focus recipe converted to a numbered 3-step list per STE rule 9 |
-| `v1/10-native-tier.md` | 234 → 234 (0%) | id identical (`no-frame-context` ×1); fences 12; headings identical except `## When not to open the trap door` → `## When not to go native` (meaning-identical); trap-door / salary / rent-free / homework / rhyme metaphors converted to operational statements, matching the completed agents' corpus-wide treatment (ch12/14/18's retained one-jab lines were likewise operationalized) — the benefit rule's three thresholds preserved verbatim |
-| `v1/21-accessibility.md` | 168 → 173 (+3.0%) | zero ids before and after; fences 10; heading set unchanged; semantic-vocabulary enumeration converted to a vertical list; the frozen `11-ephemeral-state.md#choosing-the-address` anchor untouched |
-
-Residual table-cell contractions in 07 (×1) and 21 (×5) normalized to full forms under the "MAY simplify prose inside a cell" allowance, matching the contraction-free cells of the ten completed files. Structure and data meaning unchanged.
-
-### Verified (rewritten by killed agents; self-checks run now)
-
-All six: **verified-ok, no repairs needed.** Per-file: (a) id census — every cited id matches the Stage C spellings, cross-consistent between files (`hicasso-revision-not-controlled` identical in 04/05/15; `hicasso-host-bad-ssr-policy`, `hicasso-host-fallback-boundary-head`, `hicasso-host-unknown-option` identical in 09/17); corpus-wide distinct-id count is exactly the Stage C census's 33 (the three extra grep hits in 15 are `:rf.error/*` wildcard prose and the `:rf.error/id` ex-data key, not ids); retired/removed ids (`hicasso-route-link-prefetch-declined`, `view-called-directly`, `view-read-outside-render`) absent; ch09 keeps everything item 24 requires (`no-frame-context`, `hicasso-intent-needs-the-event`, `hicasso-host-bad-ssr-policy`) and still cites the declaration-time family by mechanism only, per the NOT-gaps rule. (b) Headings: exact `## Troubleshooting` / `## Advanced` where present; zero banned variants. (c) No truncation — every file ends with a complete section (04/05/09 end their Advanced subsections whole; 17 ends its full troubleshooting table; 08 ends its closed info admonition; 20 ends its when-not list). (d) Fences even: 12/18/16/22/14/10. (e) Prose spot-reads across openings, middles, and tails: full STE register throughout; zero contractions, zero filler intensifiers in all six.
-
-| File | Verdict | Lines (Stage D/E → now) |
-|---|---|---|
-| `v1/04-controlled-inputs.md` | verified-ok | 307 → 318 |
-| `v1/05-forms.md` | verified-ok | 311 → 322 |
-| `v1/08-async-resources.md` | verified-ok | 351 → 381 |
-| `v1/09-interop.md` | verified-ok | 360 → 397 |
-| `v1/17-ssr-and-hydration.md` | verified-ok | 372 → 380 |
-| `v1/20-code-splitting.md` | verified-ok | 204 → 211 |
-
-All ten within the ±20% line-count bound. The other twelve v1 files (completed and self-checked by predecessor agents) were not re-audited beyond the corpus-wide id and heading sweeps above, which they pass.
+### 11 — Ephemeral state
+
+Retained app-db ownership, forms drafts, native host mechanics, browser-owned
+state, exit presence, unmounting accessibility attributes, stable address
+selection, no generic mount hooks, and examples of incorrect local atoms and
+pointer streams.
+
+### 12 — Overlays and focus
+
+Retained popover and modal APIs, top-layer behaviour, native light-dismiss,
+app-db reconciliation, anchoring and placement, autofocus and restoration,
+nesting, zero closed cost, listbox keyboard behaviour, native alternatives,
+missing-anchor refusal, and exit timing.
+
+### 13 — Theming and internationalisation
+
+Retained CSS token ownership, per-frame scope, root boundary placement,
+initial preference restoration, document-chrome echo, backdrop inheritance,
+locale subscriptions, platform formatters, late locale packs, vendor context,
+hydration drift, and when-not guidance.
+
+### 14 — Testing
+
+Retained the L0–L4 ladder and each equality, semantic fixtures, non-expanding
+child views, React-only refusals, mounted facade, settle semantics, virtual
+clock limits, cleanup residue, browser-engine witnesses, migration shadow,
+sabotage controls, and canonical DOM.
+
+### 15 — Diagnostics
+
+Retained epoch causality, fan-out and read churn, pressure classification,
+incomplete-evidence labels, complaint identifiers, production erasure and its
+positive control, root/view attribution, raw envelope shape, privacy
+projection, and bounded retention.
+
+### 16 — Errors
+
+Retained error-boundary props, functional fallbacks, reset/remount behaviour,
+frame-scoped reporting, nested recovery, fallback failures, React catch limits,
+event-pipeline exceptions, expected-state modelling, region placement, server
+error channel, and retry failures.
+
+### 17 — SSR and hydration
+
+Retained request-isolated frames, snapshot seeding, fail-closed payload policy,
+cold reads, deterministic body requirement, state-before-DOM hydration,
+identifier prefixes, root-scoped verdicts, Client-only fallback rules,
+transparent-wrapper deletion, Render assertions, surface-policy table, native
+SSR, and Node service bounds.
+
+### 18 — Performance
+
+Retained all user-visible budgets, production measurement discipline, the
+five-level ladder, attribution loop, optional User Timing flag, delivered but
+unretained entries, escape-benefit thresholds, controlled-keystroke cost walk,
+write amplification, grid topology comparison, event-volume decisions, and
+teardown performance.
+
+### 19 — Migration from Reagent
+
+Retained reporter classes, three-step ordering, manual translation table,
+shadow comparison and sabotage control, codemod invocation, W1–W6 behaviour,
+idempotence, human-only decisions, computed-value limits, migration-specific
+failure modes, report shape, W4 capture semantics, and deliberate differences.
+
+### 20 — Code splitting
+
+Retained route-module splitting, load effect and dedupe state, route wiring,
+pending and failure branches, warming, `n/lazy`, Suspense slot, loader
+rejection recovery, top-level identity rule, Client-only SSR, suspended-read
+ownership, Activity hide/reveal, one-frame scheduled-reveal caveat, and account
+or tenant disclosure warning.
+
+### 21 — Accessibility
+
+Retained semantic HTML, names and per-instance ids, ARIA derived from app
+state, validation pairing, keyboard/focus ownership, semantic-tree tests,
+sabotage controls, real-browser and axe limits, virtualised navigation, and all
+troubleshooting cases.
+
+### Glossary
+
+Retained every source glossary concept and anchor while removing the manual
+in-page navigation list. Definitions were made shorter and chapter links now
+point to the owning page rather than fragile subsection anchors where possible.
+
+## Validation performed on this package
+
+The final packaging step runs automated checks for:
+
+- expected file count and filenames;
+- balanced Markdown code fences;
+- relative Markdown targets that exist in the package or in the expected
+  surrounding docs tree;
+- local glossary anchors;
+- duplicate document titles;
+- presence of troubleshooting and when-not coverage in every numbered chapter;
+- ZIP integrity.
+
+The audit cannot prove that every API name is implemented. It proves that the
+rewrite preserves the source corpus's stated contracts and does not silently
+remove its documented unhappy paths.

--- a/docs/design/hicasso/draft-guide/glossary.md
+++ b/docs/design/hicasso/draft-guide/glossary.md
@@ -1,714 +1,818 @@
 # Hicasso glossary
 
-Hicasso terms. Definition first; short code when the spelling matters; Related
-points at the teaching page. Core re-frame2 terms (`app-db`,
-[frame](../../../core/glossary.md#frame), [event](../../../core/glossary.md#event),
-[subscription](../../../core/glossary.md#subscription)) live in the
+This glossary defines Hicasso-specific terms. Core re-frame2 terms such as
+[app-db](../../../core/glossary.md#app-db),
+[frame](../../../core/glossary.md#frame),
+[event](../../../core/glossary.md#event), and
+[subscription](../../../core/glossary.md#subscription) live in the
 [core glossary](../../../core/glossary.md).
-
-Grouped by role: [authoring](#authoring), [events and control](#events-and-control),
-[interop](#interop), [native tier](#native-tier), [state homes](#state-homes),
-[testing](#testing), [diagnostics](#diagnostics), and
-[lifecycle and delivery](#lifecycle-and-delivery).
 
 ## Authoring
 
 <a id="hicasso"></a>
-### **Hicasso**
+### Hicasso
 
-re-frame2's native view adapter: interpreted
-[Hiccup](../../../core/glossary.md#hiccup) on a React function-component host.
-You write vectors and maps, read with [`h/sub`](#hsub) at the point of use, and
-put event vectors in attributes as [intents](#intent). App-db, events, and the
-pipeline stay ordinary re-frame2.
+re-frame2's native React view adapter. Hicasso interprets
+[Hiccup](../../../core/glossary.md#hiccup), reads subscriptions with
+[`h/sub`](#hsub), and accepts event vectors as [intents](#intent). App-db,
+events, effects, and the event pipeline remain ordinary re-frame2.
 
-Require `[re-frame.hicasso :as h]`. Optional modules (forms, overlays, native
-tier, test kit, routing helpers) are separate requires.
+Require it as:
 
-Related: [Getting started](01-getting-started.md), [Installation](installation.md).
+```clojure
+[re-frame.hicasso :as h]
+```
+
+Forms, overlays, routing helpers, the native tier, and test tooling are separate
+optional namespaces.
+
+Related: [Getting started](01-getting-started.md),
+[Installation](installation.md).
 
 <a id="defview"></a>
-### **defview**
+### `defview`
 
-`h/defview` — defines a Hicasso [view](#view): a React/re-frame
-[boundary](#boundary) used as a Hiccup head. Props map in; Hiccup (or a native
-React element at [rung 3 of the performance ladder](#performance-ladder)) out.
-Do not call the view as a Clojure function; mount it as a vector:
+`h/defview` defines a Hicasso [view](#view). The view receives one props map and
+returns Hiccup, `nil`, a fragment, or a native React element at the direct-return
+performance level.
+
+Use a view as a Hiccup head. Do not call it as an ordinary function:
 
 ```clojure
 (h/defview counter [_]
   [:main
    [:h1 "Clicked " (h/sub [:counter/count]) " times"]
-   [:button {:on-click [:counter/increment]} "Click me"]])
+   [:button {:on-click [:counter/increment]}
+    "Click me"]])
 
-[counter]          ;; legal
-(counter {})       ;; raises — write [counter]
+[counter {}]   ;; view boundary
+(counter {})   ;; raises
 ```
 
 Related: [Views and reads](02-views-and-reads.md).
 
 <a id="view"></a>
-### **view**
+### View
 
-A function from a props map to markup, defined with [`defview`](#defview). In
-head position of a Hiccup vector it is a [boundary](#boundary). Plain `defn`
-helpers are not views: call them as functions so they
-[inline](#inline-helper).
+A function from a props map to markup, defined with [`h/defview`](#defview).
+In Hiccup head position it creates an independently re-rendering
+[boundary](#boundary). A plain `defn` is an [inline helper](#inline-helper), not
+a view.
 
 Related: [Views and reads](02-views-and-reads.md).
 
 <a id="boundary"></a>
-### **boundary**
+### Boundary
 
-An independently re-rendering unit created by [`defview`](#defview). Tracks the
-body's [`h/sub`](#hsub) reads, memoizes on value equality of props, and provides
-the [frame](../../../core/glossary.md#frame) that [intents](#intent) dispatch
-into. Native tags, fragments, and [`defhost`](#defhost) heads can sit in vector
-position; none of those is a boundary.
+An independently re-rendering unit created by [`h/defview`](#defview). It:
+
+- tracks the body's [`h/sub`](#hsub) reads;
+- compares props with ClojureScript `=`;
+- supplies the re-frame2 frame used by event [intents](#intent).
+
+Native tags, fragments, and [`h/defhost`](#defhost) heads do not create Hicasso
+view boundaries.
 
 Related: [Views and reads](02-views-and-reads.md).
 
 <a id="inline-helper"></a>
-### **inline helper**
+### Inline helper
 
-An ordinary `defn` called from a view body. Its Hiccup splices into the caller;
-any `h/sub` it performs counts toward the enclosing [boundary](#boundary).
-Helpers do not create their own re-render unit. A plain `defn` in head position
-raises (`:rf.error/hicasso-bad-head`).
+An ordinary function called from a view body. Its returned Hiccup is included
+in the caller's tree, and any `h/sub` calls belong to the enclosing
+[boundary](#boundary). It does not create independent re-render behaviour.
 
 ```clojure
-[todo-row {:key id :id id}]   ;; boundary child
-(row-icon {:kind :urgent})    ;; inlined helper
+[todo-row {:key id :id id}]   ;; child boundary
+(row-icon {:kind :urgent})    ;; inline helper
 ```
+
+A plain function in Hiccup head position raises
+`:rf.error/hicasso-bad-head`.
 
 Related: [Views and reads](02-views-and-reads.md).
 
 <a id="hsub"></a>
-### **h/sub**
+### `h/sub`
 
-The only view-side subscription read. An ordinary function call at the point of
-use — legal in `let`, `when`, loops, and synchronous helpers. Records the read
-for the active [boundary](#boundary) under the
-[read-extent law](#read-extent-law).
+The only subscription-read form inside a Hicasso view. It is an ordinary
+function call and may appear in a `let`, conditional, loop, or synchronous
+helper.
 
 ```clojure
 (let [todo (h/sub [:todo/by-id id])]
   [:span (:title todo)])
 ```
 
-Bare `rf/subscribe` in a body is not a fallback: it raises. In
-[native](#native-tier) code, use [`n/use-sub`](#nuse-sub) instead.
+A bare `rf/subscribe` in a view body is not an alternative. Native components
+use [`n/use-sub`](#nuse-sub).
 
 Related: [Views and reads](02-views-and-reads.md).
 
 <a id="read-extent-law"></a>
-### **read-extent law**
+### Read-extent law
 
-`h/sub` is legal only during the **direct synchronous execution** of the active
-[boundary](#boundary) body (including ordinary helpers it calls). A read deferred
-through a callback, promise, timer, lazy sequence, or other escaped extent
-raises with source and recovery (`:rf.error/hicasso-sub-outside-render`). Capture
-values during the body; async work re-enters through events and coeffects.
+`h/sub` is legal only during direct synchronous execution of the active view
+body, including helpers it calls immediately. A callback, promise, timer, lazy
+sequence, unforced delay, or other deferred computation may not carry the read
+outside that extent.
+
+A read after the extent raises a structured error such as
+`:rf.error/hicasso-sub-outside-render` or
+`:rf.error/hicasso-deferred-read-at-boundary`. Read the value during render and
+close over the value instead.
 
 Related: [Views and reads](02-views-and-reads.md).
 
 <a id="collector"></a>
-### **collector**
+### Collector
 
-Runtime mechanism that records which subscriptions a [boundary](#boundary) took
-during one body run. Commit reconciles that read set; abandoned and retried
-renders acquire no durable ownership. Escaping the collector is what the
-[read-extent law](#read-extent-law) forbids.
+The runtime mechanism that records the subscriptions a [boundary](#boundary)
+reads during one body execution. Commit reconciles that read set. An abandoned
+or retried render acquires no durable subscription ownership.
 
-Related: [Views and reads](02-views-and-reads.md#the-collector).
+Related: [Views and reads](02-views-and-reads.md).
 
 <a id="component-abi"></a>
-### **component ABI**
+### Component ABI
 
-The props/children contract for a head: what converts, what is opaque, where
-keys live. [Views](#view) take a Clojure props map (keys in the map, not
-metadata); [hosts](#defhost) convert per declaration; native [`n/$`](#n-dollar)
-uses React slots and does not lower intents.
+The props and children contract for a Hiccup head: which values are converted,
+which pass by identity, where `:key` and `:ref` live, and how children arrive.
 
-Related: [Views and reads](02-views-and-reads.md#props-children-and-fragments).
+- Hicasso views receive a ClojureScript props map.
+- Declared hosts follow their callback, slot, and server contracts.
+- Native [`n/$`](#n-dollar) uses React slots and does not lower Hicasso event
+  intents or controlled fields.
+
+Related: [Views and reads](02-views-and-reads.md),
+[Interop](09-interop.md), [The native tier](10-native-tier.md).
 
 <a id="lowering"></a>
-### **lowering**
+### Lowering
 
-The step that turns Hicasso data into React props and elements: Hiccup walk,
-[intent](#intent) → callback, controlled-field repair, attribute rules. When
-Xray names "lowering" as the cost owner, the narrow escape is a direct
-[`n/$`](#n-dollar) return from the same [boundary](#boundary).
+The conversion from Hicasso data to React props and elements. It includes the
+Hiccup walk, event-intent callback creation, controlled-field behaviour, and
+attribute normalisation.
 
-Related: [Events as data](03-events-as-data.md), [Native tier](10-native-tier.md).
+When diagnostics identify lowering itself as the cost owner, the local escape
+is a direct [`n/$`](#n-dollar) return from the same view.
+
+Related: [Events as data](03-events-as-data.md),
+[The native tier](10-native-tier.md).
 
 <a id="owned-wins"></a>
-### **owned wins**
+### Owned-wins merge
 
-Attribute-merge rule: literal keys written on the element always beat forwarded
-maps, by presence. Do not forward `:key` or [`::h/revision`](#hrevision) through
-a generic merge.
+When a view forwards an attributes map into an element, literal keys written by
+the element author take precedence. Control slots such as `:value`, handlers,
+`:key`, and [`::h/revision`](#hrevision) should not be replaceable through a
+generic forwarded map.
 
-Related: [Views and reads](02-views-and-reads.md#forwarding-attributes-owned-wins).
+Related: [Views and reads](02-views-and-reads.md),
+[Controlled inputs](04-controlled-inputs.md).
 
 <a id="read-topology"></a>
-### **read topology**
+### Read topology
 
-Where [reads](#hsub) sit relative to list structure — the main performance knob
-while staying on ordinary Hicasso:
+The placement and grouping of subscription reads relative to a collection.
 
-| Shape | Idea |
-|---|---|
-| **Fine** | each row reads itself — sparse independent updates |
-| **Coarse** | one view-model for the whole list — cheap mount / bulk replace |
-| **Chunked** | page-sized batches bound the invalidation sweep |
-| **Windowed** | only visible rows exist in the DOM (usually a foreign virtualizer) |
+| Shape | Behaviour |
+| --- | --- |
+| Fine | Each row reads its own entity; good for sparse updates |
+| Coarse | One view-model represents the collection; good for cheap mount or bulk replacement |
+| Chunked | One read covers a bounded block of rows |
+| Windowed | Only visible rows exist in the DOM, usually through a virtualiser |
 
 Related: [Lists and collections](06-lists-and-collections.md).
-
----
 
 ## Events and control
 
 <a id="intent"></a>
-### **intent**
+### Intent
 
-An [event](../../../core/glossary.md#event) vector written in an attribute at an
-event position (`on-*` / `onClick`). The runtime builds the callback and
-dispatches the vector to the rendering [boundary](#boundary)'s frame. The tree
-stays data: tests assert with `=`; tools can read meaning without running the
-app.
+An event vector written directly at an event prop. The runtime creates a
+callback and dispatches the vector into the rendering view's frame.
 
 ```clojure
-[:button {:on-click [:todo/toggle id]} "✓"]
+[:button {:on-click [:todo/toggle id]}
+ "Toggle"]
 ```
+
+The Hiccup tree retains the event as ordinary data, so tests and tools can
+inspect it with `=`.
 
 Related: [Events as data](03-events-as-data.md).
 
 <a id="hevent"></a>
-### **h/event**
+### `h/event`
 
-Explicit handler form when a vector intent is not enough: value-first foreign
-callbacks, calculated events, or reading the invoker's arguments. Captures the
-current frame at creation; same meaning everywhere (including host slots).
+An explicit callback form for cases where the callback's arguments are needed
+to compute an event. It captures the current frame when created and dispatches
+a returned event vector when invoked later.
 
 ```clojure
-{:on-change (h/event [date] [:calendar/picked date])}
+{:on-change
+ (h/event [date]
+   [:calendar/picked date])}
 ```
 
-Related: [Events as data](03-events-as-data.md).
+Use it for value-first foreign callbacks, file lists, drag data, or calculated
+events.
+
+Related: [Events as data](03-events-as-data.md),
+[Interop](09-interop.md).
 
 <a id="hvalue"></a>
 <a id="hchecked"></a>
-### **::h/value** / **::h/checked**
+### `::h/value` and `::h/checked`
 
-Reserved markers substituted at dispatch from the DOM event target's `.value` /
-`.checked`. Top level of the intent vector only.
+Reserved markers replaced at dispatch with the DOM event target's `.value` or
+`.checked`. Substitution occurs only at the top level of the event vector.
 
 ```clojure
-[:input {:value (h/sub [:draft]) :on-input [:edit ::h/value]}]
+[:input
+ {:value    (h/sub [:draft])
+  :on-input [:draft/changed ::h/value]}]
 ```
 
-Related: [Events as data](03-events-as-data.md), [Controlled inputs](04-controlled-inputs.md).
+Related: [Events as data](03-events-as-data.md),
+[Controlled inputs](04-controlled-inputs.md).
 
 <a id="hprevent"></a>
-### **::h/prevent**
+### `::h/prevent`
 
-Intent head that prevents the browser default, then dispatches the inner intent.
-Nothing auto-prevents — not click, not submit.
+An intent wrapper that calls `preventDefault` and then dispatches one inner
+event vector. Hicasso does not auto-prevent clicks or form submits.
 
 ```clojure
-[:form {:on-submit [::h/prevent [:signup/submit]]} …]
+[:form
+ {:on-submit [::h/prevent [:signup/submit]]}
+ ...]
 ```
 
 Related: [Events as data](03-events-as-data.md).
 
 <a id="controlled-field"></a>
-### **controlled field**
+### Controlled field
 
-An input whose displayed value comes from app-db (via a subscription) and whose
-edits return as [intents](#intent). Hicasso's controlled path covers same-turn
-convergence, committed echo, caret/selection, IME composition, and
-identity-preserving [revision](#hrevision) reset. Form fields stay on the
-interpreted side; the [native tier](#native-tier) has no controlled repair.
+An input whose displayed value comes from app-db and whose user edits return as
+event intents. Hicasso's controlled path provides:
+
+- synchronous same-turn convergence;
+- committed-value echo;
+- caret and selection preservation;
+- IME composition safety;
+- explicit reset through [`::h/revision`](#hrevision).
+
+The native tier does not provide this repair. Keep controlled text fields on
+the interpreted Hicasso path.
 
 Related: [Controlled inputs](04-controlled-inputs.md).
 
 <a id="hrevision"></a>
-### **::h/revision**
+### `::h/revision`
 
-Reserved controlled-text prop: change this value to re-baseline the field's
-draft (accept, reject, or rewrite). Reset is never by value equality — a model
-that reasserts the same string would be invisible to `not=`. Exact namespaced
-keyword only; a bare `:revision` is an ordinary attribute.
+A reserved prop for controlled text. Change it when the field should
+re-baseline to the current model value after a reset, rejection, rewrite, or
+server normalisation.
 
 ```clojure
-[:input {:value       (h/sub [:field/value id])
-         ::h/revision (h/sub [:field/revision id])
-         :on-input    [:field/edit id ::h/value]}]
+[:input
+ {:value       (h/sub [:field/value id])
+  ::h/revision (h/sub [:field/revision id])
+  :on-input    [:field/edit id ::h/value]}]
 ```
+
+Reset is not inferred from value equality. The exact namespaced keyword is
+required; bare `:revision` is an ordinary attribute.
 
 Related: [Controlled inputs](04-controlled-inputs.md).
 
 <a id="buffered-field"></a>
-### **buffered-field**
+### Buffered field
 
-`forms/buffered-field` — optional forms helper: one controlled input with a
-draft in front of the model. Accepts, rejects, and rewrites through
-[`::h/revision`](#hrevision); pairs with per-instance submit status and
-validation display.
+`forms/buffered-field` is an optional forms component that places an app-db
+draft in front of a controlled model value. It supports commit, cancel,
+rejection, rewrite, and revision-based reset.
 
 Related: [Forms](05-forms.md).
 
 <a id="keyboard-map"></a>
-### **keyboard map**
+### Keyboard map
 
-Data map on a keyboard prop (e.g. `:on-key-down`) from DOM `.key` string →
-intent. Unlisted keys are ignored. There is no modifier DSL — richer cases use
-[`h/event`](#hevent). IME composition is central: Enter during composition
-commits nothing.
+A map from DOM `.key` strings to event intents, used at `:on-key-down` or
+`:on-key-up`.
 
-Related: [Events as data](03-events-as-data.md#keyboard-as-data).
+```clojure
+{:on-key-down
+ {"Enter"  [:editor/commit]
+  "Escape" [:editor/cancel]}}
+```
 
----
+Unlisted keys are ignored. There is no modifier DSL; use [`h/event`](#hevent)
+for cases such as Ctrl+Enter. Key maps suppress matches during IME composition.
+
+Related: [Events as data](03-events-as-data.md).
 
 ## Interop
 
 <a id="defhost"></a>
-### **defhost**
+### `defhost`
 
-`h/defhost` — declared door to a foreign React component. Names the React value
-once, documents ReactNode [slots](#reactnode-slot), callback contracts
-(`:event` / `:handler` / `:render`), and [server policy](#server-policy). Keeps
-the npm require in one host namespace.
+`h/defhost` declares a foreign React component once. The declaration can define:
+
+- callback contracts: `:event`, `:handler`, or `:render`;
+- ReactNode [slots](#reactnode-slot);
+- a [server policy](#server-policy);
+- a Client-only fallback.
 
 ```clojure
 (h/defhost date-picker DatePicker
-  {:slots #{:calendar}
-   :server :client-only})
+  {:callbacks {:on-change :event}
+   :slots     #{:calendar}
+   :server    :client-only})
 ```
+
+Keep the JavaScript require in a `.cljs` host namespace.
 
 Related: [Interop](09-interop.md).
 
 <a id="reactnode-slot"></a>
-### **ReactNode slot**
+### ReactNode slot
 
-A prop position a [host](#defhost) declares as carrying React children or named
-content (Suspense `:fallback`, compound slots). Hiccup in that position lowers
-under the captured frame without deep-converting arbitrary data maps.
+A host prop declared to contain React content, such as a modal title, footer,
+or Suspense fallback. Hiccup supplied to the slot is converted to React
+elements under the captured frame. Undeclared props receive Hiccup vectors as
+ordinary data.
 
-Related: [Interop](09-interop.md#reactnode-slots).
+Related: [Interop](09-interop.md).
 
 <a id="as-element"></a>
-### **as-element**
+### `as-element`
 
-`h/as-element` — explicit Hiccup → React element conversion for render props and
-foreign callbacks. Use when a library expects a ReactNode, not data.
+`h/as-element` explicitly converts Hiccup to a React element for a render prop,
+foreign callback, or other ReactNode position.
 
 ```clojure
-{:renderItem (fn [row]
-               (h/as-element [row-view {:id (:id row)}]))}
+{:render-item
+ (fn [row]
+   (h/as-element
+    [row-view {:id (:id row)}]))}
 ```
 
-Related: [Interop](09-interop.md), [Lists and collections](06-lists-and-collections.md).
+Related: [Interop](09-interop.md),
+[Lists and collections](06-lists-and-collections.md).
 
 <a id="outward-bridge"></a>
-### **as-component** / **outward bridge**
+### `as-component` / outward bridge
 
-`h/as-component` returns a real React component so a native parent
-(`n/defcomponent`, UIx, or JS) can render a Hicasso view under the existing
-frame provider — no second root, no exposed internal codec ABI. Symmetric to
-hosts embedding foreign React inward.
+`h/as-component` turns a Hicasso view into a real React component that a native
+React, UIx, or JavaScript parent can mount under the existing frame provider.
+It does not create another root or state owner.
 
-Related: [Interop](09-interop.md#the-outward-bridge).
+Related: [Interop](09-interop.md).
 
 <a id="portal"></a>
-### **portal**
+### Portal
 
-Optional helper that lowers Hiccup into `createPortal`, preserves frame and
-context, and documents event bubbling / target-change identity plus
-client/server policy. Overlays that need the **native top layer** use the
-overlay module instead of a hand-rolled portal.
+`h/portal` renders Hiccup into another DOM container through React
+`createPortal` while preserving frame and context. React events bubble through
+the React tree rather than the DOM placement.
 
-Related: [Interop](09-interop.md#portals), [Overlays and focus](12-overlays-and-focus.md).
+Use the overlay module instead when the UI should live on the browser's native
+top layer.
+
+Related: [Interop](09-interop.md),
+[Overlays and focus](12-overlays-and-focus.md).
 
 <a id="server-policy"></a>
-### **server policy**
+### Server policy
 
-Per-surface answer for SSR: **Render** (deterministic React server bytes) or
-**Client-only** (source-located refusal, with a deterministic fallback if the
-declaration carries one). Bare Client-only is the default, and it leaves the
-region empty until the browser takes over. Declared on hosts and native
-components; intrinsic Hiccup renders by default.
+The SSR contract for a host or native component:
+
+- **Render**: execute on the server and produce deterministic React HTML;
+- **Client-only**: do not execute on the server; produce a deterministic
+  fallback or nothing until the browser adopts the root.
+
+Foreign hosts and named native components default to Client-only. Native
+Hiccup and intrinsic React elements render by default.
 
 Related: [SSR and hydration](17-ssr-and-hydration.md),
-[Interop](09-interop.md#server-policy-per-declaration).
+[Interop](09-interop.md).
 
 <a id="raw-escape"></a>
-### **raw escape** (`:>`)
+### Raw escape (`:>`)
 
-Hiccup head that passes a React component through without a lasting
-[host](#defhost) declaration. Useful once; repeated use should move to
-`defhost` so slots, server policy, and callbacks stay declared.
+`[:> Component props ...]` mounts a foreign React component without a lasting
+host declaration. It is useful for migration or a true one-off. Repeated
+crossings should use [`h/defhost`](#defhost) so callback contracts, slots, and
+server policy remain explicit.
 
-Related: [Interop](09-interop.md#the-escape-).
-
----
+Related: [Interop](09-interop.md).
 
 ## Native tier
 
 <a id="native-tier"></a>
-### **native tier**
+### Native tier
 
-Optional namespace `re-frame.hicasso.native` (alias `n`): explicit exit to direct
-React construction and hooks. **`[...]` is always interpreted Hiccup; `n/$` is
-always native React.** Neither form rewrites the other; nothing compiles Hiccup.
-Absent from bundles that never require the namespace.
+The optional `re-frame.hicasso.native` namespace, usually aliased `n`. It
+provides direct React element construction and named native components.
 
-Related: [Native tier](10-native-tier.md).
+`[...]` always means interpreted Hiccup. `n/$` always means native React.
+Nothing silently compiles or promotes one form into the other.
+
+Related: [The native tier](10-native-tier.md).
 
 <a id="n-dollar"></a>
-### **n/$**
+### `n/$`
 
-Macro: one explicit element form → direct React construction. No intent
-lowering, no controlled repair, no Hiccup children (convert with
-[`as-element`](#as-element)). Dynamic props maps must be marked with
-[`n/props`](#nprops).
+A macro that constructs one React element directly. It does not perform Hiccup
+lowering, intent conversion, class collection merging, controlled-field repair,
+or automatic Hiccup-child conversion.
 
 ```clojure
 (n/$ :td {:class "px"} px)
 (n/$ :td (n/props cell-props) px)
 ```
 
-Related: [Native tier](10-native-tier.md#the-n-grammar).
+Use `h/as-element` when one native subtree needs an interpreted Hiccup child.
+
+Related: [The native tier](10-native-tier.md).
 
 <a id="nprops"></a>
-### **n/props**
+### `n/props`
 
-Marker that classifies a dynamic expression as the props operand of
-[`n/$`](#n-dollar). Emits no runtime wrapper — classification only. An unmarked
-dynamic map in second position is a **child**, not props.
+A syntactic marker telling `n/$` that a dynamic expression is its props
+operand. It creates no runtime wrapper.
 
-Related: [Native tier](10-native-tier.md#the-n-grammar).
+Without the marker, an arbitrary dynamic map in second position is treated as
+a child.
+
+Related: [The native tier](10-native-tier.md).
 
 <a id="ndefcomponent"></a>
-### **n/defcomponent**
+### `n/defcomponent`
 
-Defines a stable top-level native function component: display name, source, HMR
-conduct, and one props/children ABI. Default self-contained route for a
-[named native island](#native-island). Ordinary React hooks are legal inside;
-frame access via [`n/use-sub`](#nuse-sub) / [`n/use-frame`](#nuseframe).
+Defines a named top-level React function component with Hicasso's native-tier
+marker, source identity, display name, and server policy. Ordinary React hooks
+are legal inside it.
 
-Related: [Native tier](10-native-tier.md).
+Use [`n/use-sub`](#nuse-sub) and [`n/use-frame`](#nuseframe) to join the current
+re-frame2 frame.
+
+Related: [The native tier](10-native-tier.md).
 
 <a id="nuse-sub"></a>
+### `n/use-sub`
+
+A React hook that subscribes to a re-frame2 query in a native component. It
+obeys React's rules of hooks: call it unconditionally at the top level of the
+component.
+
+Related: [The native tier](10-native-tier.md).
+
 <a id="nuseframe"></a>
-### **n/use-sub** / **n/use-frame**
+### `n/use-frame`
 
-Native React hooks that join the installed Hicasso frame. Substrate-neutral
-(shared implementation; no UIx dependency). Use inside
-[`n/defcomponent`](#ndefcomponent) or UIx `defui` — not inside a dynamically
-branched [`defview`](#defview) body.
+A React hook returning frame-locked operations such as `:dispatch`,
+`:dispatch-sync`, and `:subscribe` for the current native component.
 
-Related: [Native tier](10-native-tier.md).
+Related: [The native tier](10-native-tier.md).
 
 <a id="native-island"></a>
-### **native island**
+### Native island
 
-A named native component under the same React root and re-frame2 frame as the
-rest of the app — hooks, vendor widgets, high-rate mechanics. Authored with
-[`n/defcomponent`](#ndefcomponent), UIx, or a JS host. Xray names the crossing;
-the inner React tree is [host-opaque](#loss-labels).
+A named native React component under the same React root and re-frame2 frame as
+the surrounding Hicasso application. It is appropriate for hooks, vendor
+widgets, and high-rate host-private mechanics.
 
-Related: [Native tier](10-native-tier.md#rung-4--a-named-native-island).
+Xray names and times the crossing, while the inner React tree remains
+host-opaque.
+
+Related: [The native tier](10-native-tier.md).
 
 <a id="nmemo"></a>
+### `n/memo`
+
+Marker-preserving React memoisation for a named native component. Raw
+`react/memo` can erase the marker used by Xray and embedding checks.
+
+Related: [The native tier](10-native-tier.md).
+
 <a id="nlazy"></a>
-### **n/memo** / **n/lazy**
+### `n/lazy`
 
-Marker-preserving memoization and `React.lazy` loading for native components.
-Raw `react/memo` / `React.lazy` erase the tier marker that Xray and embedding
-checks read. Hot reload is unaffected either way — a save allocates a fresh
-component, and a clean remount is the designed conduct.
+Marker-preserving `React.lazy` loading for a named native component. It follows
+React's promise-returning loader contract and retains the Hicasso native marker.
+Declare it at namespace top level.
 
-Related: [Native tier](10-native-tier.md#keeping-the-marker-the-abi-helpers),
-[Code splitting](20-code-splitting.md).
+Related: [Code splitting and lazy loading](20-code-splitting.md),
+[The native tier](10-native-tier.md).
 
 <a id="performance-ladder"></a>
-### **performance ladder**
+### Performance ladder
 
-Five explicit rungs from ordinary Hicasso to a full native screen. No `:fast`
-flag and no second meaning for Hiccup:
+Five explicit implementation levels:
 
-1. Ordinary Hicasso
-2. Tuned [read topology](#read-topology)
-3. Direct native return (`n/$` from a `defview`)
-4. [Named native island](#native-island)
-5. Native screen
+1. ordinary Hicasso;
+2. tuned [read topology](#read-topology);
+3. a direct native return from an existing view;
+4. a named [native island](#native-island);
+5. a native screen.
 
-Related: [Performance](18-performance.md), [Native tier](10-native-tier.md).
+Related: [Performance](18-performance.md),
+[The native tier](10-native-tier.md).
 
 <a id="escape-benefit-rule"></a>
-### **escape-benefit rule**
+### Escape-benefit rule
 
-An escape stays only if it recovers **≥20%** of the measured interaction, saves
-**≥2 ms** at p95, or converts a failed user-visible budget into a pass;
-otherwise remove it. Thresholds never widen to keep a red row green.
+Keep a native escape only when it:
 
-Related: [Performance](18-performance.md#the-escape-benefit-rule).
+- recovers at least 20% of the measured interaction;
+- saves at least 2 ms at p95; or
+- converts a failed user-visible budget into a pass.
 
----
+Otherwise remove it.
+
+Related: [Performance](18-performance.md).
 
 ## State homes
 
 <a id="one-state-owner"></a>
-### **one state owner**
+### One state owner
 
-Application-visible state lives in re-frame2
-[app-db](../../../core/glossary.md#app-db) only. There is no component-local
-reactive cell and no second store. Hosts may hold host-private mechanics
-(motion, focus, vendor handles) that are never an invisible duplicate of
-application facts.
+Application-visible state lives in re-frame2 app-db. Hicasso does not add a
+component-local reactive store. A host may retain private mechanics only when
+they are not a hidden duplicate of an application fact.
 
 Related: [Ephemeral state](11-ephemeral-state.md).
 
 <a id="pressure-valve"></a>
-### **pressure valve**
+### Pressure valve
 
-Named legitimate home for a kind of UI state under
-[one state owner](#one-state-owner): explicit app-db address (default); optional
-forms/draft modules; host-private React/DOM state; uncontrolled DOM as an
-explicit interop choice. If a fact fits no valve, it goes to app-db.
+A legitimate home for UI state under the one-state-owner rule:
+
+- an explicit app-db address;
+- the forms module for drafts and form control;
+- native host state for high-rate private mechanics;
+- browser-owned state as an explicit interop choice;
+- presence retention for pixels that outlive removed data.
 
 Related: [Ephemeral state](11-ephemeral-state.md).
 
 <a id="overlay"></a>
-### **overlay (popover / modal)**
+### Overlay
 
-`re-frame.hicasso.overlay` primitives on the browser's native top layer.
-`:open?` is app-db data; `:on-dismiss` is an event; the platform owns stacking,
-light-dismiss, and focus trap/return. Closed means zero DOM and zero listeners.
+`re-frame.hicasso.overlay` popover and modal primitives. They use the browser's
+native top layer. App-db owns `:open?`; `:on-dismiss` is an event; the browser
+owns stacking, light-dismiss, modal focus trapping, and focus restoration.
+
+A closed overlay has no DOM node, listener, or active body subscriptions.
 
 Related: [Overlays and focus](12-overlays-and-focus.md).
 
 <a id="route-link"></a>
-### **route-link**
+### `route-link`
 
-Routing helper: navigates by event, optional intent
-[prefetch](../../../routing/glossary.md#intent-prefetch), scroll/focus conduct.
-Plain function (inlines); active state is a subscription comparison, not a
-built-in class.
+A routing helper that returns a real anchor and encodes navigation as a Hicasso
+intent. It supports route ids and params, optional intent prefetch, native link
+semantics, and link-local veto behaviour.
+
+It is an inline function, not a separate view. Active-state styling comes from
+a route subscription comparison.
 
 Related: [Routing and navigation](07-routing-and-navigation.md).
 
 <a id="demand-driven-committed-read"></a>
-### **demand-driven committed read**
+### Demand-driven committed read
 
-Optional resource read that declares `:demand true`: **commit acquires**,
-unmount / param change / stopped read **releases**. Abandoned renders acquire
-nothing. Uses existing committed-read membership — no second per-read ledger.
-Without `:demand`, a resource sub stays a passive projection.
+A resource subscription with `:demand true`:
 
 ```clojure
-(h/sub [:rf/resource {:resource :app/suggestions
-                      :params   {:q q}
-                      :demand   true}])
+(h/sub
+ [:rf/resource
+  {:resource :app/suggestions
+   :params   {:q q}
+   :demand   true}])
 ```
 
-Related: [Async resources](08-async-resources.md#demand-driven-committed-reads),
-[Resources glossary](../../../resources/glossary.md).
+Commit acquires demand. Unmount, parameter change, or a committed render that
+stops taking the read releases demand. Speculative and abandoned renders
+acquire nothing. Without `:demand`, the resource subscription is passive.
 
----
+Related: [Async resources](08-async-resources.md),
+[Resources glossary](../../../resources/glossary.md).
 
 ## Testing
 
 <a id="test-kit"></a>
-### **test kit**
+### Test kit
 
-Two supported namespaces: `re-frame.hicasso.test` (alias `ht`) for the pure data
-tiers, the [semantic harness](#semantic-harness) and the browser helpers, and
-`re-frame.hicasso.test.mounted` (alias `hm`) for the
-[mounted facade](#mounted-facade).
+Two namespaces:
+
+- `re-frame.hicasso.test`, usually `ht`, for pure and semantic tests;
+- `re-frame.hicasso.test.mounted`, usually `hm`, for mounted React and DOM
+  tests.
 
 Related: [Testing](14-testing.md).
 
 <a id="testing-ladder"></a>
-### **testing ladder**
+### Testing ladder
 
-Five rungs; use the lowest that can prove the claim:
+| Level | Proves | Mechanism |
+| --- | --- | --- |
+| L0 | Handlers, subscriptions, transitions | Pure function calls |
+| L1 | Intents, codecs, revision laws, macro expansion | Data and property tests |
+| L2 | One hook-free body as a semantic tree | [`ht/tree`](#semantic-harness) |
+| L3 | React lifecycle, hooks, hosts, error boundaries | Mounted facade |
+| L4 | IME, caret, focus, hydration, performance | Real browser engines |
 
-| Rung | Proves | Mechanism |
-|---|---|---|
-| L0 | handlers, subs, transitions | pure functions |
-| L1 | intents, codecs, revision laws, `n/$` expansion | pure data / property tests |
-| L2 | one hook-free body, as a semantic tree | [semantic harness](#semantic-harness) |
-| L3 | lifecycle, hooks, hosts, errors | mounted React DOM |
-| L4 | IME, caret, focus, hydration, perf | real browsers |
-
-A green lower rung never claims a higher equality (L2 ≠ hydration bytes).
+A lower level does not prove the equality of a higher level.
 
 Related: [Testing](14-testing.md).
 
 <a id="semantic-harness"></a>
-### **semantic harness**
+### Semantic harness
 
-L2: `ht/tree` runs one hook-free body under injected read fixtures and returns
-a semantic tree. A nested view is recorded as the call it is and its body does
-not run. Hosts, hooks, raw React, and [`n/$`](#n-dollar) results are **opaque**
-and raise — mount those at L3.
+`ht/tree` runs one hook-free Hicasso view body with injected subscription
+fixtures and returns a semantic tree. Nested views remain represented as calls.
+Hooks, hosts, raw React elements, and `n/$` results are refused and belong at
+L3.
 
-Related: [Testing](14-testing.md#l2--the-semantic-harness).
+Related: [Testing](14-testing.md).
 
 <a id="mounted-facade"></a>
-### **mounted facade**
+### Mounted facade
 
-`re-frame.hicasso.test.mounted` (alias `hm`). L3 helpers: isolated-frame mount,
-hydrate, rerender, dispatch-and-settle, settle, advance-clock, unmount,
-`assert-clean!` (residue vs pre-mount baseline after quiescence).
+The `hm` namespace for L3 tests. It provides isolated-frame mount and hydrate,
+rerender, dispatch-and-settle, settle, virtual-clock advancement, unmount, and
+`assert-clean!` residue checking.
 
-Related: [Testing](14-testing.md#l3--the-mounted-facade).
+Related: [Testing](14-testing.md).
 
 <a id="sabotage-control"></a>
-### **sabotage control**
+### Sabotage control
 
-Negative twin of an important gate: a deliberate mutation that must make the
-gate fail, so an empty population cannot pass green.
+A deliberately broken twin of an important test or measurement. It proves that
+the instrument moves when the input is wrong and prevents an empty population
+from passing vacuously.
 
-Related: [Testing](14-testing.md#the-sabotage-twin).
+Related: [Testing](14-testing.md).
 
 <a id="canonical-dom"></a>
-### **canonical DOM**
+### Canonical DOM
 
-Normalized DOM / structure equality used by differential and migration
-witnesses. Distinct from semantic-tree equality (L2) and from React server byte /
-hydration equality.
+A normalised DOM serialisation used for differential comparison. Attribute
+names are ordered so equivalent DOM does not differ only because properties
+were inserted in a different sequence.
 
-Related: [Testing](14-testing.md#canonical-dom),
-[Migration from Reagent](19-migration-from-reagent.md).
+Canonical DOM is distinct from semantic-tree equality, exact server bytes, and
+hydrated browser behaviour.
 
----
+Related: [Testing](14-testing.md),
+[Migrating from Reagent](19-migration-from-reagent.md).
 
 ## Diagnostics
 
 <a id="causal-lens"></a>
-### **causal lens**
+### Causal lens
 
-Xray's diagnostic chain:
+The diagnostic sequence used by Xray:
 
+```text
+event
+  → subscriptions recomputed
+  → values changed
+  → views notified
+  → bodies run
+  → React commit
+  → browser paint
 ```
-event → subscriptions recomputed → values changed → boundaries notified
-      → bodies run → React commit → paint
-```
 
-Each link has its own evidence. **Render is not commit; commit is not paint.**
-Timing proximity alone never proves a link.
+Render, commit, and paint are separate claims.
 
 Related: [Diagnostics](15-diagnostics.md).
 
 <a id="explain-render"></a>
-### **explain-render**
+### Explain-render
 
-Xray answer to *why did this [boundary](#boundary) run?* — cause kind (reads,
-props, context, host, retry/abandonment), current read set, fan-out,
-completeness and loss.
+Xray's answer to “why did this view run?” It reports the cause category, changed
+reads or props, current read set, fan-out, completeness, and evidence loss.
 
-Related: [Diagnostics](15-diagnostics.md#advanced).
+Related: [Diagnostics](15-diagnostics.md).
 
 <a id="hot-view-advisor"></a>
-### **hot-view advisor**
+### Hot-view advisor
 
-Ranks hot boundaries (time, frequency, read churn, fan-out), **classifies
-pressure** (computation, topology, lowering, React, layout), then recommends the
-smallest credible remedy. Recommends a native escape only when native addresses
-the measured owner; never auto-promotes.
+A diagnostic ranking that combines time, frequency, read churn, and fan-out,
+then classifies the pressure as computation, topology, lowering, React, or
+layout. It recommends the smallest credible remedy and never auto-promotes
+code to native.
 
-Related: [Diagnostics](15-diagnostics.md#the-hot-view-advisor),
+Related: [Diagnostics](15-diagnostics.md),
 [Performance](18-performance.md).
 
 <a id="loss-labels"></a>
-### **loss labels**
+### Loss labels
 
-Honest gaps instead of empty panels: `:unknown`, `:opaque` /
-`:no-static-analysis`, `:host-opaque`, `:cap`, `:uncorrelated`. Unknown is never
-encoded as an empty collection.
+Explicit labels for incomplete evidence:
 
-Related: [Diagnostics](15-diagnostics.md#when-evidence-is-incomplete).
+- `:unknown`;
+- `:opaque` / `:no-static-analysis`;
+- `:host-opaque`;
+- `:cap`;
+- `:uncorrelated`.
+
+Missing evidence is not represented as an empty result.
+
+Related: [Diagnostics](15-diagnostics.md).
 
 <a id="complaint-catalogue"></a>
-### **complaint catalogue**
+### Complaint catalogue
 
-Stable `:rf.error/*` / `:rf.warning/*` ids with cause, recovery, and
-jump-to-source in Xray. Every refusal in the guide is an entry; branch on the
-id, not prose.
+The stable `:rf.error/*` and `:rf.warning/*` identifier set, including cause,
+recovery, and source links where available. Tests assert the id, not the human
+message.
 
-Related: [Diagnostics](15-diagnostics.md#the-complaint-catalogue).
+Related: [Diagnostics](15-diagnostics.md).
 
 <a id="production-erasure"></a>
-### **production erasure**
+### Production erasure
 
-Dev diagnostics, source maps for complaints, and evidence sentinels are absent
-from default production bundles. Budgets and teardown are verified on production
-builds.
+Removal of development diagnostics, evidence machinery, source locations, and
+complaint messages from default release bundles. Optional performance timing
+has a separate compile-time flag and is disabled by default.
 
-Related: [Diagnostics](15-diagnostics.md#production-erasure).
-
----
+Related: [Diagnostics](15-diagnostics.md).
 
 ## Lifecycle and delivery
 
 <a id="mount"></a>
-### **mount!** / **render!** / **unmount!**
+### `mount!`, `render!`, and `unmount!`
 
-Root lifecycle. `h/mount!` associates a DOM node, a
-[frame](../../../core/glossary.md#frame) id, and optional `:initial-events` (seed
-app-db before first paint), and returns an idempotent **root handle**.
-`render!` re-renders into that handle; `unmount!` is a no-op if already
-unmounted (safe for fixtures and reload hooks).
+The Hicasso root lifecycle.
+
+`h/mount!` associates a DOM container, a frame, optional `:initial-events`, and
+one root view. It returns a root handle. Initial events run in order before
+first paint.
+
+`h/render!` renders a new root element through the same handle.
+
+`h/unmount!` tears the root down and is safe to call more than once.
 
 ```clojure
 (defonce root
-  (h/mount! (js/document.getElementById "app")
-            {:frame :rf/default :initial-events [[:app/init]]}
-            [app-shell]))
+  (h/mount!
+   (js/document.getElementById "app")
+   {:frame :rf/default
+    :initial-events [[:app/init]]}
+   [app-shell {}]))
 ```
 
 Related: [Installation](installation.md).
 
 <a id="hydrate"></a>
-### **hydrate!**
+### `hydrate!`
 
-Two verbs on one job. **`re-frame.ssr/hydrate!`** installs the server payload
-into the client frame (state half). **`h/hydrate!`** adopts the server DOM for a
-Hicasso root (DOM half). Server and client share one React renderer; mismatches
-surface as hydration errors.
+Two functions complete hydration:
+
+- `re-frame.ssr/hydrate!` installs the server payload into the client frame;
+- `h/hydrate!` adopts existing server DOM for one Hicasso root.
+
+State hydration must run before DOM adoption.
 
 Related: [SSR and hydration](17-ssr-and-hydration.md).
 
 <a id="error-boundary"></a>
-### **error-boundary**
+### Error boundary
 
-`h/error-boundary` — React error region in the tree (`:fallback`, `:reset-key`,
-`:on-error`). Distinct from a re-render [boundary](#boundary); only this
-component catches throws. Expected failures stay data, not exceptions.
+`h/error-boundary` is a React error region with `:fallback`, `:reset-key`, and
+`:on-error`. It is different from a re-render [boundary](#boundary); only the
+error boundary catches descendant render and lifecycle exceptions.
+
+Expected failures remain ordinary app-db state.
 
 Related: [Errors](16-errors.md).
 
 <a id="user-visible-budget"></a>
-### **user-visible budget**
+### User-visible budget
 
-Performance contract in terms a user can notice (e.g. discrete interaction paint
-≤50 ms p95; controlled echo within one frame; broad ops ≤100 ms p95; zero
-teardown residue). Comparative bands and island parity sit beside these;
-synthetic scores never redefine "fast enough."
+A performance requirement expressed as an observable user outcome, such as:
 
-Related: [Performance](18-performance.md#the-budgets).
+- discrete interaction paint within 50 ms p95;
+- controlled echo within one frame;
+- broad operation within 100 ms p95;
+- zero teardown residue.
+
+Synthetic benchmark scores do not replace these budgets.
+
+Related: [Performance](18-performance.md).
 
 <a id="shadow-comparison"></a>
-### **shadow comparison**
+### Shadow comparison
 
-Also called **shadow mode**. Migration witness: dual-render
-[canonical DOM](#canonical-dom) / [intent](#intent) diff against a Reagent (or
-other) twin so conversion preserves behaviour before a codemod rewrite. Named
-refusal classes describe policy differences; bare drift is reported as drift.
+A migration witness that mounts a reference implementation and candidate under
+isolated equivalent state, drives both with one script, and compares canonical
+DOM plus event-intent streams at each checkpoint.
 
-Related: [Migration from Reagent](19-migration-from-reagent.md).
+Related: [Migrating from Reagent](19-migration-from-reagent.md).

--- a/docs/design/hicasso/draft-guide/installation.md
+++ b/docs/design/hicasso/draft-guide/installation.md
@@ -1,30 +1,27 @@
 # Installation
 
-You have decided [Hicasso](glossary.md#hicasso) is the view adapter you want
-([Getting started](01-getting-started.md)). This page gets it on the classpath,
-into a browser build, and onto a DOM node. By the end you have a running
-counter and the three habits later pages assume: [`defview`](glossary.md#defview)
-as a Hiccup head, [`h/sub`](glossary.md#hsub) where you need a value, and
-handlers as data.
+This page adds Hicasso to a browser build and mounts a small counter. The
+example establishes the three forms used throughout the guide:
+[`h/defview`](glossary.md#defview) for a view, [`h/sub`](glossary.md#hsub) for a
+subscription read, and event vectors for ordinary handlers.
 
-## Install the artifact
+## Add the dependencies
 
-One Clojure dependency:
+Add the Hicasso artifact to `deps.edn`:
 
 ```clojure
 ;; deps.edn
 {:deps {io.github.day8/re-frame2-hicasso {:mvn/version "1.0.0"}}}
 ```
 
-This artifact brings `day8/re-frame2` with it — the core you already use.
-Install React from npm:
+The artifact brings `day8/re-frame2` with it. Install React from npm:
 
 ```bash
 npm install react react-dom
 ```
 
-Interpreted Hiccup needs no build configuration: no compiler hook, no macro
-allow-list, no build flag. Any ordinary shadow-cljs browser build works:
+Hicasso interprets Hiccup at runtime, so it needs no compiler hook, macro
+allow-list, or build flag. A normal shadow-cljs browser build is enough:
 
 ```clojure
 ;; shadow-cljs.edn
@@ -47,24 +44,22 @@ allow-list, no build flag. Any ordinary shadow-cljs browser build works:
 </html>
 ```
 
-You require one namespace: `[re-frame.hicasso :as h]`. The usual alias is `h`.
-Optional modules (forms, [overlays](glossary.md#overlay), motion, routing, the
-[native tier](glossary.md#native-tier), the [test kit](glossary.md#test-kit))
-are separate requires — a build that never requires them ships none of their
-code.
+The main namespace is `re-frame.hicasso`, conventionally required as `h`.
+Forms, overlays, motion, routing, the native tier, and the test kit use separate
+namespaces. A build that does not require an optional module does not include
+its code.
 
-## Your first screen
+## Mount a first screen
 
-A real app splits events, subscriptions, and views into their own namespaces.
-The boot namespace requires those namespaces for their registrations. One
-screen fits in one namespace:
+A production application normally separates registrations and views into
+several namespaces. This complete example keeps them together so the boot
+sequence is visible:
 
 ```clojure
 (ns counter.core
   (:require [re-frame.core :as rf]
             [re-frame.hicasso :as h]))
 
-;; Events write app-db.
 (rf/reg-event :counter/initialise
   (fn [_cofx _event]
     {:db {:count 0}}))
@@ -73,150 +68,140 @@ screen fits in one namespace:
   (fn [{:keys [db]} _event]
     {:db (update db :count inc)}))
 
-;; Subscriptions derive values.
 (rf/reg-sub :counter/count
-  (fn [db _query] (:count db)))
+  (fn [db _query]
+    (:count db)))
 
-;; The view: a props map in, Hiccup out.
 (h/defview counter [_]
   [:main
    [:h1 "Clicked " (h/sub [:counter/count]) " times"]
    [:button {:on-click [:counter/increment]} "Click me"]])
 
-;; The root.
 (defonce root
   (h/mount! (js/document.getElementById "app")
             {:frame          :rf/default
              :initial-events [[:counter/initialise]]}
             [counter]))
 
-;; Hot reload: re-render the redefined view into the surviving root.
 (defn ^:dev/after-load rerender! []
   (h/render! root [counter]))
 ```
 
+Start the build and open the page:
+
 ```bash
-npx shadow-cljs watch app    # then open http://localhost:8080
+npx shadow-cljs watch app
+# http://localhost:8080
 ```
 
-Click the button. The count changes. This screen shows three habits of a
-Hicasso view:
+The example uses three Hicasso rules:
 
-- `h/defview` creates a view used as a Hiccup head. You mount it as
-  `[counter]`, which is a vector. You never call it as a function. A direct
-  call throws and names the view (see
-  [Troubleshooting](#troubleshooting)). Markup that should inline into its
-  caller is a plain `defn` helper.
-- `h/sub` reads where you use the value. It is an ordinary call. It is legal
-  in a `let`, a `when`, a loop, a helper — anywhere in the view's synchronous
-  body.
-- The click handler is data — an [intent](glossary.md#intent): an event vector
-  in the attribute, not a closure. `{:on-click [:counter/increment]}` stays
-  assertable with `=`. The runtime creates the callback and dispatches that
-  vector to this root's frame.
+- `h/defview` creates a Hiccup head. Render it as `[counter]` or
+  `[counter {}]`; do not call it as `(counter {})`. Use a plain `defn` for
+  markup that should inline into its caller.
+- `h/sub` reads during the synchronous view body. It is legal inside a `let`,
+  conditional, loop, or ordinary helper called by that body.
+- `{:on-click [:counter/increment]}` is an
+  [intent](glossary.md#intent). The runtime creates the callback and dispatches
+  the event vector to this root's frame.
 
-[Views and reads](02-views-and-reads.md) and
-[Events as data](03-events-as-data.md) teach each habit in more depth.
+## What `h/mount!` creates
 
-## What `h/mount!` did
+[`h/mount!`](glossary.md#mount) receives a DOM node, a root configuration, and
+one view form. Its `:frame` identifies the re-frame2 frame used by that root.
+A frame has its own app-db, event queue, and subscription cache.
 
-[`h/mount!`](glossary.md#mount) takes the DOM node, a config map, and one view.
-`:frame` names the re-frame2 *frame* — an isolated world with its own app-db,
-event queue, and subscription cache. The root ensures that frame: creates it
-if missing, otherwise joins the one that already exists. Two roots with two
-frame ids are two isolated apps on one page. `:initial-events` runs ordinary
-events once, in order, and seeds app-db **before** the first paint. That is
-why the heading renders `0` and not an empty flash. Initial values arrive by
-event; that rule does not change because the view layer changed.
+Mounting **ensures** the named frame: it creates the frame if it does not exist,
+or joins the existing frame if another root already uses it.
+`:initial-events` run once, in order, when that mount creates the frame. They
+complete before the first paint, which prevents an empty initial render.
+Initial state still arrives through events; Hicasso does not add a separate
+`:db` seed option.
 
-`[counter]` and `[counter {}]` render the same output. The body receives an
-empty props map in both cases.
+`[counter]` and `[counter {}]` are equivalent. The body receives an empty props
+map in either case.
 
-The handle controls the rest of the root's life:
+Keep the returned handle for later renders and teardown:
 
 ```clojure
-(h/render! root [counter])   ;; render into the existing root
-(h/unmount! root)            ;; idempotent — a second call is a no-op
+(h/render! root [counter])
+(h/unmount! root)
 ```
 
-After [`h/unmount!`](glossary.md#mount), the root unmounts, subscriptions
-release when their ref-counts reach zero, and the DOM node is available again.
-Teardown paths run from `finally` blocks, fixtures, and reload hooks, and
-those paths do not coordinate. For that reason a second call is a no-op, not
-a crash.
+`h/unmount!` is idempotent. A second call is a no-op because teardown can be
+reached independently by fixtures, reload hooks, and `finally` blocks. The
+unmount releases the root's subscriptions as their reference counts reach
+zero and makes the DOM node available for another root.
 
 ## More than one root
 
-[`h/mount!`](glossary.md#mount) composes. A page can hold several roots, and
-`:frame` decides whether they are one app or two apps.
+A page can mount several Hicasso roots. The frame id determines whether those
+roots share an application.
 
-**Two roots, one frame — one app in two containers.** The root ensures its
-frame. The first mount creates the frame and runs `:initial-events`. A later
-mount that names the same frame joins the frame as it stands and replays
-nothing. Both roots read one app-db and dispatch into one queue. A widget
-mounted in the page's header therefore follows the same state as the main
-screen:
+### Two roots sharing one frame
+
+The first root creates and seeds the frame. A later root that names the same
+frame joins its current state and does not replay `:initial-events`:
 
 ```clojure
 (defonce app-root
   (h/mount! (js/document.getElementById "app")
             {:frame          :app/main
-             :initial-events [[:app/initialise]]}   ;; creates the frame — seeds
+             :initial-events [[:app/initialise]]}
             [main-screen]))
 
 (defonce status-root
   (h/mount! (js/document.getElementById "status")
-            {:frame :app/main}                      ;; joins — no re-seed
+            {:frame :app/main}
             [connection-badge]))
 ```
 
-Seed from the root that creates the frame. A joining root omits
-`:initial-events`.
+Both roots read the same app-db and dispatch into the same queue. Seed from the
+root that creates the frame; joining roots should omit `:initial-events`.
 
-**Two roots, two frames — two isolated apps.** Give each root its own
-`:frame` id, and each root has its own app-db, queue, and subscription cache.
-A view reads under the frame of the root that renders it. Subscriptions never
-cross frames: nothing mounted in `:app/main` can observe `:app/preview`. That
-isolation makes a live preview beside an editor — the same views, different
-state — an ordinary page. Use a second frame when two surfaces must not share
-state; share the frame when they must.
+Unmounting one root does not destroy state still used by another root. Teardown
+remains per root.
 
-Teardown stays per root in both cases. [`h/unmount!`](glossary.md#mount)
-releases that root's subscriptions and returns its DOM node. A frame that
-other roots still use keeps its state and continues to serve them.
+### Two roots using different frames
+
+Give each root a different frame id when they must be isolated. Each frame then
+has its own app-db, queue, and subscription cache. A view reads under the frame
+of the root that renders it, and subscriptions never cross frames.
+
+This is suitable for cases such as an editor and a live preview that use the
+same view code but must not share state.
 
 ## Hot reload
 
-Leave the watch running and edit the `:h1` text. On save, shadow-cljs reloads
-the namespace, and the `^:dev/after-load` hook calls
-[`h/render!`](glossary.md#mount) with the redefined view. The root, the frame,
-and app-db survive, so the count keeps its value. The changed body is the body
-that runs, and no subscriptions leak.
+The `^:dev/after-load` hook calls `h/render!` with the redefined view. The root,
+frame, app-db, and subscriptions survive, so changing the view does not reset
+the counter or leak registrations.
 
-One consequence: hot reload preserves state past your setup event. An edit to
-`:counter/initialise` does not re-seed a live app-db. Reload the page when you
-want the new seed.
+Hot reload also means a changed initialisation handler does not re-seed an
+already live frame. Reload the page, destroy the frame, or dispatch an explicit
+reset event when you need the new initial state.
 
-## Production
+## Production builds
+
+Build the release normally:
 
 ```bash
 npx shadow-cljs release app
 ```
 
-A release build runs advanced compilation, and the development surface erases
-with it. Dev-only warnings, their message strings, and every Xray
-instrumentation hook are absent from the bundle. Optional modules that you
-never required contribute zero code. Nothing else changes: interpreted Hiccup
-is the one semantics in development and in production, and no build flag
-alters what your views mean.
+Advanced compilation removes development-only warnings, warning strings, and
+Xray instrumentation hooks. Optional modules that were never required add no
+code. The Hiccup interpretation itself has the same meaning in development and
+production; there is no production-only view mode.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
-|---|---|---|
-| Calling a view throws — `(counter {})` | A `defview` is a Hiccup head; it is never invoked as a function | Write `[counter {}]`. Markup that should inline into its caller is a plain `defn` helper |
-| `h/sub` in a callback, timeout, or promise throws, naming the query | `:rf.error/hicasso-sub-outside-render` — the read ran outside the synchronous view body | Read during the body and close over the value; async work reads app-db through events and coeffects |
-| First paint is empty, then content flickers in | Seeding raced the first render | Seed through `:initial-events`, not a post-mount dispatch |
-| Second `h/mount!` on the same node | A live root already owns that DOM node | `defonce` the handle; `h/unmount!` it before mounting again |
-| A second root's `:initial-events` never ran | Its `:frame` already existed — ensure joins a live frame and replays nothing | Seed from the root that creates the frame; joining roots omit `:initial-events` |
-| View body runs twice on mount in development | React StrictMode double-invokes bodies | Expected — bodies are pure and re-runnable |
+| --- | --- | --- |
+| `(counter {})` throws and names the view | A `defview` is a Hiccup head, not a directly callable helper | Render `[counter {}]`. Use a plain `defn` for inline markup |
+| `h/sub` in a callback, timer, or promise throws | `:rf.error/hicasso-sub-outside-render`: the read happened outside a synchronous view body | Read during the body and close over the value. Async work should read state through events and coeffects |
+| The first paint is empty and then fills in | Initial state was dispatched after mounting | Put the seed events in `:initial-events` so they finish before the first paint |
+| A second `h/mount!` fails on the same DOM node | A live root already owns the node | Keep the handle with `defonce`; unmount that root before mounting another |
+| A joining root's `:initial-events` never run | The named frame already exists; joining does not replay setup | Seed only from the mount that creates the frame |
+| A changed initialisation handler has no effect after hot reload | The live frame kept its existing app-db | Reload, recreate the frame, or dispatch an explicit reset event |
+| A view body runs twice when first mounted in development | React StrictMode probes bodies twice | Expected. Keep view bodies pure and safe to re-run |

--- a/docs/design/hicasso/studio/108-the-theming-taught-default-priced.md
+++ b/docs/design/hicasso/studio/108-the-theming-taught-default-priced.md
@@ -119,7 +119,7 @@ nothing else.
 | Chapters already read | 02 (`defview`, `sub`, the memo default) | 03 (`reg-fx`, the closed effect map) |
 | Chapters newly required | none | 10 (`:platforms #{:client}`, or the server render throws on `js/document`) |
 | Extra steps to a working dark mode | none | an initial event, or the first paint is unthemed |
-| Preconditions to hold | one, already taught: keep the content below the scope behind a `defview` head ([Views skip work when props are equal](../draft-guide/02-views-and-reads.md#views-skip-work-when-props-are-equal)) | none |
+| Preconditions to hold | one, already taught: keep the content below the scope behind a `defview` head ([Equal props skip the body](../draft-guide/02-views-and-reads.md#equal-props-skip-the-body)) | none |
 | Surprises inherited | one, and it is silent — §7.2 | three: time travel lies, Xray lies, a test fixture lies |
 | Ceiling | none | one theme per page (§5) |
 
@@ -278,7 +278,7 @@ sentence on A's SSR bullet rather than an unqualified *"no flash by construction
 
 `:ssr :render` landed on 2026-08-05 (`rf2-l0wfx`, `rf2-nv07k`), and with it guide
 10 §[`:render` — when the region has to be in the
-response](../draft-guide/17-ssr-and-hydration.md#client-only-hosts-with-a-fallback).
+response](../draft-guide/17-ssr-and-hydration.md#client-only-components-and-fallbacks).
 The load-bearing fact for theming is the one that ruling states about the other
 two policies: `:client-only` (**the default**) and `{:fallback …}` render *instead
 of* the component, so *"a provider at a crossing takes every descendant out of the
@@ -313,7 +313,7 @@ but a channel that exists, where the per-root attribute has none.
   design's claim that per-frame B needs `make-frame :fx-overrides`: `spec/002-Frames.md`
   §*The binary fx-handler signature* already gives an fx handler the frame id in
   its ctx under `:frame`. Since then `h/frame` has **shipped** and guide 03
-  §[Callbacks include their frame](../draft-guide/03-events-as-data.md#callbacks-include-their-frame)
+  §[Frame-safe callbacks and foreign APIs](../draft-guide/03-events-as-data.md#frame-safe-callbacks-and-foreign-apis)
   teaches *"an fx handler receives the frame id in its context"* as a first-class
   fact, echoed in guide 01's troubleshooting table. So B per-root is an app-owned
   `frame-id → node` map populated at mount plus one global fx reading `(:frame m)`


### PR DESCRIPTION
## Summary

Replace `docs/design/hicasso/draft-guide/**` with the preferred corpus from `ai/findings/new-hiccaso-guide` (local findings only; not committed under `ai/`).

- Full swap of chapters `01`–`21`, `installation.md`, `glossary.md`, `README.md`, and `REWRITE-NOTES.md`.
- Fix inbound Related anchors that broke when headings renamed:
  - `authoring.md` → codemod step heading
  - `decisions.md` → imperative SDK heading
  - `studio/108-the-theming-taught-default-priced.md` → equal-props / client-only / frame-safe headings

## Test plan

- [x] `python scripts/check_doc_slugs.py` (exit 0) on this branch
- [ ] CI docs / MkDocs green