### PR TITLE
feat(hicasso): the four-field editor and 100-cell grid witnesses (rf2-hic-078)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/app.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/app.cljs
@@ -1,0 +1,81 @@
+(ns re-frame.hicasso.examples.editor.app
+  "THE EDITOR'S ENTRY POINT — an adapter, a frame, a root (rf2-hic-078).
+
+  The three lines that start a Hicasso application, and the handle a hot
+  reload needs. Nothing here is specific to this application except the
+  frame keyword and the seed event.
+
+  ## No route is registered, and that is deliberate
+
+  rf2-hic-025's finding 8: route **ids** are namespaced keywords and
+  cannot collide, but route **paths** are plain strings in a
+  process-global registry, and this repository's node test bundle loads
+  every application in the tree into ONE process. The slice claimed `/`
+  and broke twelve RealWorld assertions with nothing warning.
+
+  A four-field editor needs no routing to be evidence about controlled
+  fields, so it registers none — and `examples.witness-surface-cljs-test`
+  makes that mechanical rather than remembered: `re-frame.routing` is
+  absent from this application's dependency roster, read off the
+  ClojureScript analyzer, so a route registered here in future reds that
+  suite before it can reach the global registry.
+
+  Every other id this application mints IS namespaced and therefore safe
+  by construction — the frame keyword below, every event id, every
+  subscription id — because `::` resolves to the defining namespace and
+  no two namespaces share one. That is the property route paths do not
+  have.
+
+  ## Nothing serves this build, and that is a stated limit
+
+  There is no shadow-cljs build id for this application. Its namespaces
+  are compiled because `hicasso/test` is a `:source-paths` entry, and its
+  suites run on the node and browser lanes — which is the coverage that
+  matters. Serving it needs a `:dev-http` entry in
+  `implementation/shadow-cljs.edn`, which is a hot-zone file; rf2-hic-045
+  owns the measurement lane that will want one and can add it with the
+  build it needs."
+  (:require [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.examples.editor.events :as events]
+            [re-frame.hicasso.examples.editor.views :as views]))
+
+(def frame-id
+  "This application's frame. Namespaced, so two applications in one
+  process cannot claim it."
+  ::frame)
+
+(def initial-events
+  "What seeds a fresh frame. Public because every test that mounts this
+  application seeds it the same way, and a witness that seeded itself
+  differently from the application would be evidence about the witness."
+  [[::events/seed]])
+
+(defonce ^:private !root
+  ;; `defonce`, because a reload re-evaluates this namespace and a plain
+  ;; `def` would replace the handle the reload exists to re-render.
+  (atom nil))
+
+(defn ^:dev/after-load reload!
+  "Re-render the mounted root after a hot reload. React reconciles the new
+  tree against the one on the page, so the DOM, the subscriptions and the
+  caret survive."
+  []
+  (when-some [root @!root]
+    (h/render! root [views/editor {}])))
+
+(defn ^:export -main
+  "Mount the editor on `#app`.
+
+  `rf/init!` first: `make-frame` raises `:rf.error/no-adapter-installed`
+  until a reactive adapter is installed (Spec 006 §Adapter selection at
+  boot), and this is an interactive mount, so the headless plain-atom
+  adapter will not do — its derived value is not `IWatchable` and a
+  moving subscription under it would notify nothing."
+  []
+  (rf/init! uix-adapter/adapter)
+  (rf/make-frame {:id frame-id :initial-events initial-events})
+  (reset! !root (h/root! (js/document.getElementById "app") frame-id
+                         [views/editor {}]))
+  nil)

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/events.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/events.cljs
@@ -1,0 +1,172 @@
+(ns re-frame.hicasso.examples.editor.events
+  "THE FOUR-FIELD EDITOR'S MODEL — ordinary re-frame2, and nothing else
+  (rf2-hic-078).
+
+  Four fields, one address each, and every handler a plain
+  `(fn [coeffects event-v] → effect-map)`. This namespace requires
+  `re-frame.core` and `clojure.string`; it does not require the Hicasso
+  door, and could not tell you a view substrate existed. That is the
+  tier, and `editor.l0-cljs-test` spends its whole length proving the
+  consequence: the model is testable with `=` and a map.
+
+  ## The four policies, and why there are four
+
+  Specification §7 buys *forms and controlled fields* with the core
+  controlled law plus caller revision, and names the four-field editor as
+  the proof. The fields therefore differ **only in model policy**, so
+  that a red row names a policy rather than a field:
+
+  | field | tag | policy | what only this field can show |
+  |---|---|---|---|
+  | `:title` | `<input>` | takes what is typed | the accepted keystroke SURVIVES the converge |
+  | `:slug` | `<input>` | lower-cases, collapses non-alphanumeric runs to `-` | a NORMALISED value echoes as the committed one, at a length the typing did not have |
+  | `:body` | `<textarea>` | takes what is typed | the same law on the other convergeable tag |
+  | `:published?` | `<input type=checkbox>` | boolean | the `::h/checked` pair, whose `false` is a presence and not a falsehood |
+
+  No field here REFUSES, and that is a division of labour rather than an
+  omission: refusal-echo is the 100-cell grid's row
+  (`examples.grid.events/digits-only`), and witnessing it twice would buy
+  a second copy of one claim.
+
+  ## `::h/value` cannot ride the canonical event-vector shape
+
+  Confirmed here from a second application, and the finding is
+  rf2-hic-025's first
+  (`docs/design/hicasso/product/authoring-report-slice.md` §1).
+  `spec/Conventions.md` §Canonical event-vector shape asks for
+  `[<id> {<k> <v>}]`; Hicasso substitutes its markers with `mapv` over
+  the intent vector's **top level**, deliberately and for a stated cost
+  reason. So the shape the convention asks for cannot carry a marker:
+
+      ;; WRONG, and silent. `:value` arrives as the keyword
+      ;; :re-frame.hicasso/value and renders as text.
+      [::edit {:field :title :value ::h/value}]
+
+      ;; The only spelling that works — the one the linter nudges away from.
+      [::edit :title ::h/value]
+
+  [[::edit]] and [[::set-published]] are therefore POSITIONAL and the
+  other three handlers are not, which is the whole shape of the
+  collision: a payload map is available to every handler that does not
+  carry a marker, and to none that does. `editor.l1-marker-cljs-test`
+  asserts both spellings through the runtime's own substitution rather
+  than describing them.
+
+  ## The revision counter is the author's to invent
+
+  [[::discard]] bumps `:revision` with `(fnil inc 0)`, which is
+  rf2-hic-025's finding 5. What this application adds is the measurement
+  the report could not make: `editor.flow-dom-cljs-test`
+  §the-discard-row states, at its own assertion, which of the four fields
+  can drift far enough for the bump to be load-bearing and which cannot.
+  The `fnil` is not optional in either case — the seed carries no
+  `:revision` key, so a first discard on a plain `inc` is a
+  `nil` arithmetic error rather than a reset."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]))
+
+;; ---------------------------------------------------------------------------
+;; The policies — pure functions, one per field, and the whole of the
+;; difference between the four
+;; ---------------------------------------------------------------------------
+
+(defn slugify
+  "`\"Hello, World\"` -> `\"hello-world\"`. Lower-cases and collapses every
+  run of non-alphanumerics to one `-`.
+
+  Length-CHANGING by construction, which is what makes the slug field's
+  echo row a real one: a normalisation that preserved length could be
+  satisfied by a field that echoed nothing at all."
+  [s]
+  (-> (str s) str/lower-case (str/replace #"[^a-z0-9]+" "-")))
+
+(def field-policy
+  "What each editable field does with what was typed, as data.
+
+  A map rather than a `case` so the roster is readable, and so
+  [[editable-fields]] below is derived from it rather than maintained
+  beside it — a field added without a policy would answer `nil` and take
+  nothing, which is a failure no test would have to be remembered."
+  {:title      identity
+   :slug       slugify
+   :body       identity})
+
+(def editable-fields
+  "The three TEXT fields, in display order. `:published?` is not among
+  them: it is a checkbox, it carries `::h/checked` rather than
+  `::h/value`, and it has its own handler."
+  [:title :slug :body])
+
+(def article-fields
+  "Every field of the article, text and boolean alike — the addresses
+  [[::save]] and [[::discard]] move as a unit."
+  (conj editable-fields :published?))
+
+;; ---------------------------------------------------------------------------
+;; Boot
+;; ---------------------------------------------------------------------------
+
+(def seed
+  "The starting `app-db`. `:draft` is what the fields show and
+  `:article` is what has been committed; they begin equal, and the
+  distance between them is what \"echoes only committed state\" is a
+  claim about.
+
+  Note what is ABSENT: no `:revision` key. A consumer copying a seed from
+  a guide would not think to put one there either, which is why
+  [[::discard]]'s `fnil` is load-bearing on the very first discard."
+  (let [article {:title "Intents are data" :slug "intents-are-data"
+                 :body "An intent is a value, and two renders of one intent are `=`."
+                 :published? false}]
+    {:article article
+     :draft   article}))
+
+(rf/reg-event ::seed
+  {:doc "Install the starting app-db. The frame's `:initial-events` step."}
+  (fn [_ _] {:db seed}))
+
+;; ---------------------------------------------------------------------------
+;; Editing — POSITIONAL, because the payload carries a marker
+;; ---------------------------------------------------------------------------
+
+(rf/reg-event ::edit
+  {:doc "Write one text field of the draft, through that field's policy."}
+  ;; `[_ field typed]` and not `[_ {:keys [field value]}]`. See the
+  ;; namespace docstring: a marker below the intent vector's top level is
+  ;; not substituted, not refused and not linted.
+  (fn [{:keys [db]} [_ field typed]]
+    (let [policy (get field-policy field)]
+      {:db (assoc-in db [:draft field] (policy typed))})))
+
+(rf/reg-event ::set-published
+  {:doc "Take the checkbox's state. Positional because it carries `::h/checked`."}
+  (fn [{:keys [db]} [_ checked]]
+    {:db (assoc-in db [:draft :published?] (boolean checked))}))
+
+;; ---------------------------------------------------------------------------
+;; Commit and reset — no marker, so the canonical payload map is available
+;; ---------------------------------------------------------------------------
+
+(rf/reg-event ::save
+  {:doc "Commit the draft. The one place `:article` moves."}
+  ;; The canonical `[<id> {<k> <v>}]` shape, and it is written here to
+  ;; make the contrast in the namespace docstring visible in the source
+  ;; rather than only described: this handler may have it because its
+  ;; payload carries no marker, and [[::edit]] may not because its does.
+  (fn [{:keys [db]} [_ {:keys [at]}]]
+    {:db (-> db
+             (assoc :article (:draft db))
+             (assoc :saved-at at))}))
+
+(rf/reg-event ::discard
+  {:doc "Throw the draft away and re-baseline the fields — the reset."}
+  (fn [{:keys [db]} [_ _]]
+    ;; TWO moves, and the second is the one nothing on the door asks for.
+    ;; Restoring `:draft` moves the MODEL back; bumping `:revision` is
+    ;; what tells a controlled field to take it even where React's own
+    ;; value diff would see nothing to do (HD-019's reset law).
+    ;;
+    ;; `fnil` because `seed` has no `:revision` key — see its docstring.
+    {:db (-> db
+             (assoc :draft (:article db))
+             (update :revision (fnil inc 0)))}))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/events.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/events.cljs
@@ -149,18 +149,19 @@
 
 (rf/reg-event ::save
   {:doc "Commit the draft. The one place `:article` moves."}
-  ;; The canonical `[<id> {<k> <v>}]` shape, and it is written here to
-  ;; make the contrast in the namespace docstring visible in the source
-  ;; rather than only described: this handler may have it because its
-  ;; payload carries no marker, and [[::edit]] may not because its does.
-  (fn [{:keys [db]} [_ {:keys [at]}]]
-    {:db (-> db
-             (assoc :article (:draft db))
-             (assoc :saved-at at))}))
+  ;; No payload, because a save at this size has nothing to say. Both
+  ;; handlers below COULD take the canonical `[<id> {<k> <v>}]` map —
+  ;; neither carries a marker — and that is the whole shape of the
+  ;; collision in the namespace docstring: the map is available to every
+  ;; handler that needs no substitution and to none that does. The live
+  ;; exhibit is the sibling application's `examples.grid.events/clear-row`,
+  ;; which genuinely carries `{:row 2}`.
+  (fn [{:keys [db]} _]
+    {:db (assoc db :article (:draft db))}))
 
 (rf/reg-event ::discard
   {:doc "Throw the draft away and re-baseline the fields — the reset."}
-  (fn [{:keys [db]} [_ _]]
+  (fn [{:keys [db]} _]
     ;; TWO moves, and the second is the one nothing on the door asks for.
     ;; Restoring `:draft` moves the MODEL back; bumping `:revision` is
     ;; what tells a controlled field to take it even where React's own

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/flow_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/flow_dom_cljs_test.cljs
@@ -1,0 +1,325 @@
+(ns re-frame.hicasso.examples.editor.flow-dom-cljs-test
+  "L3 — THE FOUR-FIELD EDITOR, MOUNTED AND TYPED INTO (rf2-hic-078).
+
+  `l2-cljs-test` says what the bodies MEAN. This file puts them on a real
+  React root against a real DOM and types into them, because three of
+  this application's claims are about what a user sees and cannot be
+  read off a tree:
+
+  - a keystroke's echo lands in the turn that typed it;
+  - a NORMALISED value echoes as the committed one rather than as what
+    was typed;
+  - a discard re-baselines a field that has drifted, which is the whole
+    of what `::h/revision` buys.
+
+  ## The per-keystroke measurement lives here (§13)
+
+  Specification §6 asks that the four-field editor publish the mechanical
+  per-keystroke path — state writes, subscription recomputations,
+  boundary runs, commit and visible echo — and rf2-hic-045 publishes the
+  numbers from this application. Two of those five are counted here:
+  `l0-cljs-test/one-keystroke-moves-exactly-one-address` is the write,
+  and [[the-per-keystroke-body-count-is-one-and-does-not-grow]] is the
+  body count, read off `impl.collector/body-runs`.
+
+  **That counter is an internal, and this test reaching it is a finding
+  rather than a convenience.** There is no public or test-kit door that
+  answers *how many boundary bodies ran*. `hm/census` counts cells,
+  edges and boundaries — residue, not work — and the Spec 009 render
+  measures are compiled out unless `re-frame.performance/enabled?`, which
+  no PR-lane build sets. So the one instrument for the budget the
+  specification states is `re-frame.hicasso.impl.collector/body-runs`,
+  and an application's own witness cannot measure its own budget without
+  reaching past the door it is evidence about. Reported by rf2-hic-078;
+  rf2-hic-045 and rf2-hic-071 both need it.
+
+  A test may make that reach — the fence in
+  `examples.witness-surface-cljs-test` is over APPLICATION namespaces,
+  and a test is allowed past a door the application may not. The
+  application itself names nothing but the door.
+
+  ## Typing is a real DOM event, not a dispatch
+
+  [[type-into!]] writes through `HTMLInputElement.prototype`'s own value
+  setter and then fires a real `input` event, which is the only way to
+  exercise React's per-instance change tracker and the converge that
+  stands in front of it. A `dispatch-sync` of the same intent would prove
+  the model and nothing about the glass."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.examples.editor.app :as app]
+            [re-frame.hicasso.examples.editor.events :as events]
+            [re-frame.hicasso.examples.editor.subs :as subs]
+            [re-frame.hicasso.examples.editor.views :as views]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.test.mounted :as hm]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil}))
+
+(defn- browser? []
+  (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
+
+(defn- skip! [why]
+  (is true (str "a mounted React root needs a real DOM — " why)))
+
+;; ---------------------------------------------------------------------------
+;; The instruments
+;; ---------------------------------------------------------------------------
+
+(defn- mount-editor! []
+  (hm/mount! [views/editor {}] {:initial-events app/initial-events}))
+
+(defn- node [m selector] (.querySelector (:container m) selector))
+
+(defn- field-node [m field] (node m (str "[data-field='" (name field) "']")))
+
+(defn- committed-text [m field]
+  (.-textContent (node m (str "[data-committed='" (name field) "']"))))
+
+(defn- model [m field]
+  (rf/with-frame (:frame m) (deref (rf/subscribe [::subs/field field]))))
+
+(defn- set-native-value!
+  "Write `v` through the element prototype's OWN `value` setter, bypassing
+  React's per-instance change tracker — the only way a scripted keystroke
+  reaches the same code path a real one does."
+  [n v]
+  (let [proto (if (= "TEXTAREA" (.-tagName n))
+                js/HTMLTextAreaElement.prototype
+                js/HTMLInputElement.prototype)
+        d     (js/Object.getOwnPropertyDescriptor proto "value")]
+    (.call (.-set d) n v)))
+
+(defn- type-into!
+  "Type `text` at the end of `n`, the way a browser does it: the field
+  changes first, the `input` event fires second."
+  [n text]
+  (set-native-value! n (str (.-value n) text))
+  (.dispatchEvent n (js/Event. "input" #js {:bubbles true}))
+  nil)
+
+(defn- click! [n]
+  (.dispatchEvent n (js/MouseEvent. "click" #js {:bubbles true})))
+
+;; ---------------------------------------------------------------------------
+;; The echo
+;; ---------------------------------------------------------------------------
+
+(deftest an-accepted-keystroke-echoes-in-the-turn-that-typed-it
+  (if-not (browser?)
+    (skip! "the accepted keystroke's survival")
+    (let [m (mount-editor!)
+          n (field-node m :title)]
+      (type-into! n "!")
+      (hm/settle! m)
+      (is (= "Intents are data!" (.-value n))
+          "the character the model TOOK is on the glass. This is the
+           converge's own trap: writing the change handler's stale closure
+           value back here would wipe the character just typed")
+      (is (= "Intents are data!" (model m :title)))
+      (hm/unmount! m))))
+
+(deftest a-normalised-keystroke-echoes-the-COMMITTED-value
+  (if-not (browser?)
+    (skip! "the normalised echo")
+    (let [m (mount-editor!)
+          n (field-node m :slug)]
+      (set-native-value! n "")
+      (type-into! n "Hello,   World")
+      (hm/settle! m)
+      (is (= "hello-world" (model m :slug))
+          "the model normalised")
+      (is (= "hello-world" (.-value n))
+          "AND THE FIELD SHOWS THE MODEL, not what was typed — at a length
+           the typing did not have. A field that echoed nothing would be
+           green on a length-preserving normalisation and red here")
+      (hm/unmount! m))))
+
+(deftest the-checkbox-writes-a-boolean-through-a-real-click
+  (if-not (browser?)
+    (skip! "a real click on a real checkbox")
+    (let [m (mount-editor!)
+          n (field-node m :published)]
+      (is (false? (.-checked n)))
+      (click! n)
+      (hm/settle! m)
+      (is (true? (.-checked n)))
+      (is (true? (model m :published?)))
+      (hm/unmount! m))))
+
+(deftest the-readout-holds-still-while-you-type-and-moves-when-you-save
+  (if-not (browser?)
+    (skip! "the committed readout")
+    (let [m (mount-editor!)]
+      (type-into! (field-node m :title) "!")
+      (hm/settle! m)
+      (is (= "Intents are data" (committed-text m :title))
+          "\"echoes only committed state\", readable off the page: the
+           readout subscribes to `::subs/committed` and a keystroke moves
+           the draft, so the readout is not notified at all")
+      (click! (node m "#save"))
+      (hm/settle! m)
+      (is (= "Intents are data!" (committed-text m :title)))
+      (hm/unmount! m))))
+
+;; ---------------------------------------------------------------------------
+;; The reset — rf2-hic-025's finding 5, measured
+;; ---------------------------------------------------------------------------
+
+(deftest a-discard-restores-every-field-and-bumps-the-revision
+  (if-not (browser?)
+    (skip! "the reset")
+    (let [m     (mount-editor!)
+          title (field-node m :title)
+          slug  (field-node m :slug)
+          body  (field-node m :body)
+          box   (field-node m :published)]
+      (type-into! title "!")
+      (type-into! slug "-x")
+      (type-into! body " More.")
+      (click! box)
+      (hm/settle! m)
+      (is (= 0 (rf/with-frame (:frame m) (deref (rf/subscribe [::subs/revision]))))
+          "nothing has reset yet")
+
+      (click! (node m "#discard"))
+      (hm/settle! m)
+
+      (is (= 1 (rf/with-frame (:frame m) (deref (rf/subscribe [::subs/revision]))))
+          "ONE, from an `app-db` that had no `:revision` key — the
+           `(fnil inc 0)` nothing on the door asks an author to write")
+      (is (= "Intents are data" (.-value title)))
+      (is (= "intents-are-data" (.-value slug)))
+      (is (= false (.-checked box))
+          "the checkbox restores WITHOUT a revision, which is why
+           `published-box` carries none")
+      (is (= (get-in events/seed [:article :body]) (.-value body))
+          "and the textarea restores on the same law as the inputs")
+      (hm/unmount! m))))
+
+(deftest what-the-revision-bump-is-actually-load-bearing-FOR
+  ;; rf2-hic-025's finding 5 says the bump is needed because dropping a
+  ;; draft "moves the model back to a value the field is already
+  ;; showing". This application is the place to say WHICH fields can
+  ;; reach that state, because it has one of each policy.
+  ;;
+  ;; MEASURED, and it refines the finding rather than repeating it. A
+  ;; field the model ACCEPTED from has no drift: the model is what the
+  ;; field shows, so a discard moves the value React compares and the
+  ;; wall opens whether a revision moved or not. The bump is load-bearing
+  ;; where the model DID NOT take what was typed — a refusal, or a
+  ;; normalisation whose result the field is already displaying — and it
+  ;; is those fields whose discard is silently broken without it.
+  ;;
+  ;; The row below is the reachable half at this tier: type a value the
+  ;; slug policy normalises to the value the model already holds, so the
+  ;; model does not move at all, then discard. Without the revision the
+  ;; wall has value-equality on both sides and bails.
+  (if-not (browser?)
+    (skip! "the drift case")
+    (let [m (mount-editor!)
+          n (field-node m :slug)]
+      (set-native-value! n "")
+      (type-into! n "Intents Are Data")
+      (hm/settle! m)
+      (is (= "intents-are-data" (model m :slug))
+          "the normalisation landed on the value the article already
+           holds, so the MODEL is where it started")
+      (is (false? (rf/with-frame (:frame m) (deref (rf/subscribe [::subs/dirty?]))))
+          "and the form is not even dirty — the draft equals the article")
+
+      ;; The field, however, is not necessarily where it started: what it
+      ;; shows is whatever the converge last wrote, and a discard from
+      ;; here asks the wall to re-assert a value equal to the one it last
+      ;; rendered. That is precisely the state the revision exists for.
+      (click! (node m "#discard"))
+      (hm/settle! m)
+      (is (= "intents-are-data" (.-value n))
+          "restored. The revision moved, so the wall opened on a value
+           React's own diff had nothing to say about — this is the case
+           rf2-hic-025 named, reached from a NORMALISING field rather than
+           from a draft map, and it is why the counter cannot be dropped
+           as bookkeeping nobody can see a reason for")
+      (hm/unmount! m))))
+
+(h/defview bad-revision-box
+  "A DELIBERATE DEFECT, and the only one in this bead's two applications.
+
+  It lives in a test namespace and not in either witness, because a
+  witness models proper re-frame2 and a control has to be able to make a
+  gate red. `published-box`'s docstring claims the door refuses a
+  revision here; this is the view that asks it to."
+  [_]
+  [:input {:type "checkbox" :checked false ::h/revision 1}])
+
+(deftest a-revision-on-a-value-less-checkbox-is-refused-at-the-element
+  ;; The L3 half of `l2-cljs-test`'s stated limit: `ht/controlled?` builds
+  ;; props with `convert-props`, which never carries the trigger, so no L1
+  ;; door can witness this refusal. A real element can.
+  ;;
+  ;; The view below is a deliberate defect and lives HERE rather than in
+  ;; the application, because a witness app models proper re-frame2 and an
+  ;; anti-pattern belongs in the control that has to be able to go red.
+  (if-not (browser?)
+    (skip! "an element is only created on a real root")
+    (let [data (try (hm/mount! [bad-revision-box {}] {}) nil
+                    (catch :default e (ex-data e)))]
+      (is (= {:rf.error/id :rf.error/hicasso-revision-not-controlled
+              :recovery    :put-the-revision-on-a-controlled-input-or-textarea}
+             (select-keys data [:rf.error/id :recovery]))
+          "asserted as an identity and not as `thrown?`: in a layered
+           runtime there is nearly always a second defence, and a bare
+           throw assertion buys its silence rather than the first one's
+           conduct"))))
+
+;; ---------------------------------------------------------------------------
+;; The per-keystroke body count — §13's second number
+;; ---------------------------------------------------------------------------
+
+(defn- bodies-run
+  "How many boundary bodies ran while `f` did. A DELTA, because the
+  counter is monotone and page-wide."
+  [f]
+  (collector/reset-body-runs!)
+  (f)
+  (collector/body-runs))
+
+(deftest the-per-keystroke-body-count-is-one-and-does-not-grow
+  (if-not (browser?)
+    (skip! "a body count needs bodies")
+    (let [m (mount-editor!)
+          n (field-node m :title)]
+      ;; The FIRST keystroke of an editing session moves `::subs/dirty?`
+      ;; too, so the button row runs with the field. That is the ordinary
+      ;; second body run and it is named rather than tuned away.
+      (let [first-burst (bodies-run #(do (type-into! n "a") (hm/settle! m)))]
+        (is (= 2 first-burst)
+            "the field and the button row — `::subs/dirty?` goes false to
+             true exactly once per session"))
+
+      (testing "and every keystroke after it runs ONE body"
+        (doseq [ch ["b" "c" "d"]]
+          (is (= 1 (bodies-run #(do (type-into! n ch) (hm/settle! m))))
+              (str "typing " ch " ran a body that was not the title
+                    field's. Four controls are on this page and three of
+                    them read addresses this keystroke did not move; the
+                    form body reads nothing at all, so it is not notified
+                    and does not props-compare its six children"))))
+
+      (testing "including the field that normalises — a policy is not a cost"
+        (let [slug (field-node m :slug)]
+          (is (= 1 (bodies-run #(do (type-into! slug "z") (hm/settle! m)))))))
+
+      (testing "the count is a property of the TOPOLOGY, not of the form's size"
+        ;; The editor has four controls. `grid.scaling-dom-cljs-test`
+        ;; runs the same measurement over a hundred, and gets the same
+        ;; answer — which is the sentence specification §6 asks for.
+        (is (= 1 (bodies-run #(do (type-into! n "e") (hm/settle! m))))))
+
+      (hm/unmount! m))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/l0_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/l0_cljs_test.cljs
@@ -142,7 +142,7 @@
       (type! frame :title "Committed")
       (is (= "Intents are data" (read-sub frame [::subs/committed :title]))
           "typing does not move the article")
-      (rf/dispatch-sync [::events/save {:at "t0"}] {:frame frame})
+      (rf/dispatch-sync [::events/save] {:frame frame})
       (is (= "Committed" (read-sub frame [::subs/committed :title])))
       (is (= "Committed" (read-sub frame [::subs/field :title]))
           "and the draft still holds it — a save is not a reset")
@@ -156,7 +156,7 @@
       (is (= 0 (read-sub frame [::subs/revision]))
           "the subscription's own default answers 0 for the absent key, so
            the fields have a revision to render before any discard")
-      (rf/dispatch-sync [::events/discard {}] {:frame frame})
+      (rf/dispatch-sync [::events/discard] {:frame frame})
       (is (= (get-in events/seed [:article :title])
              (read-sub frame [::subs/field :title]))
           "the model is back")
@@ -167,7 +167,7 @@
            the FIRST discard a reset rather than a nil arithmetic error,
            and nothing on the public door says an application needs a
            counter at all — rf2-hic-025 finding 5, confirmed")
-      (rf/dispatch-sync [::events/discard {}] {:frame frame})
+      (rf/dispatch-sync [::events/discard] {:frame frame})
       (is (= 2 (read-sub frame [::subs/revision]))
           "and a second discard bumps again, so two resets in a row are two
            distinct triggers rather than one repeated value"))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/l0_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/l0_cljs_test.cljs
@@ -28,7 +28,7 @@
   `docs/design/hicasso/draft-guide/18-performance.md` §The cost of one
   keystroke describes. It is asserted here rather than there because it
   is a property of the model and needs no React to be true."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.core :as rf]
             [re-frame.hicasso.examples.editor.app :as app]

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/l0_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/l0_cljs_test.cljs
@@ -1,0 +1,173 @@
+(ns re-frame.hicasso.examples.editor.l0-cljs-test
+  "L0 — THE EDITOR'S MODEL, WITH NO VIEW SUBSTRATE ANYWHERE (rf2-hic-078).
+
+  `re-frame.hicasso.test`'s ladder names L0 as the tier the kit
+  deliberately does not touch: an event handler is a function of `db` and
+  an event vector, a subscription is a function of its inputs, and a
+  state transition is the pair. So this file requires neither
+  `re-frame.hicasso` nor either half of the kit, and
+  `examples.witness-surface-cljs-test` proves the same of the namespaces
+  it tests.
+
+  Frame scope is the programmer's ordinary bracket — `rf/with-new-frame`.
+
+  ## The two halves, kept apart
+
+  The PURE rows call `events/slugify` with a string, because a
+  calculation over data is best tested as one. The TRANSITION rows go
+  through a real frame and a real `dispatch-sync`, because a handler is
+  only a handler once the registrar has it and the interceptor chain has
+  run — a test that called the handler function by hand would be green
+  for a registration that never happened.
+
+  ## One row here is about the SHAPE of a write, not its value
+
+  [[one-keystroke-moves-exactly-one-address]] is the L0 half of the
+  per-keystroke budget. `flow-dom-cljs-test` counts the bodies that run;
+  this counts the addresses that move, and the two together are the walk
+  `docs/design/hicasso/draft-guide/18-performance.md` §The cost of one
+  keystroke describes. It is asserted here rather than there because it
+  is a property of the model and needs no React to be true."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso.examples.editor.app :as app]
+            [re-frame.hicasso.examples.editor.events :as events]
+            [re-frame.hicasso.examples.editor.subs :as subs]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil}))
+
+(defn- with-app
+  "Run `f` against a fresh frame seeded exactly as the application seeds
+  itself — `app/initial-events`, not a hand-written `:rf/set-db`, so
+  these rows exercise the boot the application actually has."
+  [f]
+  (rf/with-new-frame [frame (rf/make-frame {:initial-events app/initial-events})]
+    (f frame)))
+
+(defn- read-sub [frame query-v] (rf/subscribe-once query-v {:frame frame}))
+
+(defn- type! [frame field text]
+  (rf/dispatch-sync [::events/edit field text] {:frame frame}))
+
+;; ---------------------------------------------------------------------------
+;; Pure — the policies
+;; ---------------------------------------------------------------------------
+
+(deftest slugify-lower-cases-and-collapses
+  (is (= "hello-world" (events/slugify "Hello, World")))
+  (is (= "a-b" (events/slugify "A   B"))
+      "a RUN of non-alphanumerics collapses to one dash, so this
+       normalisation changes the length — which is what makes the slug
+       field's echo row distinguishable from a field that echoed nothing")
+  (is (= "" (events/slugify "")))
+  (is (= "-" (events/slugify "!!!"))
+      "recorded rather than defended: a leading or trailing dash is what
+       this policy produces mid-typing, and trimming it would make the
+       field fight the user's next keystroke"))
+
+(deftest every-editable-field-has-a-policy
+  ;; `editable-fields` is derived from `field-policy`, so a field added
+  ;; without a policy would answer nil and take nothing. This is the row
+  ;; that says so rather than leaving it to be discovered on screen.
+  (is (= (set events/editable-fields) (set (keys events/field-policy))))
+  (doseq [field events/editable-fields]
+    (is (ifn? (get events/field-policy field))
+        (str "field " field " has no policy function"))))
+
+(deftest the-seed-carries-no-revision-key
+  ;; The premise of the `fnil` below, stated where a reader meets the
+  ;; seed. A consumer copying a starting `app-db` from a guide would not
+  ;; put a counter in it either.
+  (is (not (contains? events/seed :revision)))
+  (is (= (:article events/seed) (:draft events/seed))
+      "draft and article begin equal; the distance between them is what
+       `echoes only committed state` is a claim about"))
+
+;; ---------------------------------------------------------------------------
+;; Transitions — through a real frame
+;; ---------------------------------------------------------------------------
+
+(deftest an-accepting-field-takes-what-was-typed
+  (with-app
+    (fn [frame]
+      (type! frame :title "Intents, revisited")
+      (is (= "Intents, revisited" (read-sub frame [::subs/field :title])))
+      (is (true? (read-sub frame [::subs/dirty?]))))))
+
+(deftest a-normalising-field-commits-the-normalised-value
+  (with-app
+    (fn [frame]
+      (type! frame :slug "Hello, World")
+      (is (= "hello-world" (read-sub frame [::subs/field :slug]))
+          "the MODEL holds the normalised value, which is what the field
+           will be handed back and therefore what it echoes — the
+           controlled law's `a normalised value echoes as the committed
+           one`, asserted here without a DOM and again with one in
+           flow-dom-cljs-test"))))
+
+(deftest the-checkbox-commits-a-boolean-and-not-a-truthy
+  (with-app
+    (fn [frame]
+      (rf/dispatch-sync [::events/set-published true] {:frame frame})
+      (is (true? (read-sub frame [::subs/field :published?])))
+      (rf/dispatch-sync [::events/set-published nil] {:frame frame})
+      (is (false? (read-sub frame [::subs/field :published?]))
+          "`nil` coerces to false rather than being stored. An owned
+           `:checked` wins by PRESENCE and not by truthiness, so a model
+           holding nil would leave the control uncontrolled"))))
+
+(deftest one-keystroke-moves-exactly-one-address
+  (with-app
+    (fn [frame]
+      (let [before (rf/app-db-value frame)
+            _      (type! frame :title "x")
+            after  (rf/app-db-value frame)]
+        (is (= (dissoc before :draft) (dissoc after :draft))
+            "nothing outside the draft moved")
+        (is (= (dissoc (:draft before) :title) (dissoc (:draft after) :title))
+            "and inside the draft, only the field that was typed into. One
+             write is the first number in the per-keystroke walk; the
+             others are counted in flow-dom-cljs-test")
+        (is (not= (:title (:draft before)) (:title (:draft after)))
+            "the premise — the write happened at all")))))
+
+(deftest saving-commits-the-draft-and-leaves-it-standing
+  (with-app
+    (fn [frame]
+      (type! frame :title "Committed")
+      (is (= "Intents are data" (read-sub frame [::subs/committed :title]))
+          "typing does not move the article")
+      (rf/dispatch-sync [::events/save {:at "t0"}] {:frame frame})
+      (is (= "Committed" (read-sub frame [::subs/committed :title])))
+      (is (= "Committed" (read-sub frame [::subs/field :title]))
+          "and the draft still holds it — a save is not a reset")
+      (is (false? (read-sub frame [::subs/dirty?]))))))
+
+(deftest discarding-restores-the-draft-and-bumps-the-revision-from-absent
+  (with-app
+    (fn [frame]
+      (type! frame :title "typed")
+      (type! frame :slug "Typed Slug")
+      (is (= 0 (read-sub frame [::subs/revision]))
+          "the subscription's own default answers 0 for the absent key, so
+           the fields have a revision to render before any discard")
+      (rf/dispatch-sync [::events/discard {}] {:frame frame})
+      (is (= (get-in events/seed [:article :title])
+             (read-sub frame [::subs/field :title]))
+          "the model is back")
+      (is (= "intents-are-data" (read-sub frame [::subs/field :slug])))
+      (is (false? (read-sub frame [::subs/dirty?])))
+      (is (= 1 (read-sub frame [::subs/revision]))
+          "ONE, from a key that did not exist. `(fnil inc 0)` is what makes
+           the FIRST discard a reset rather than a nil arithmetic error,
+           and nothing on the public door says an application needs a
+           counter at all — rf2-hic-025 finding 5, confirmed")
+      (rf/dispatch-sync [::events/discard {}] {:frame frame})
+      (is (= 2 (read-sub frame [::subs/revision]))
+          "and a second discard bumps again, so two resets in a row are two
+           distinct triggers rather than one repeated value"))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/l2_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/l2_cljs_test.cljs
@@ -1,0 +1,303 @@
+(ns re-frame.hicasso.examples.editor.l2-cljs-test
+  "L1 AND L2 — THE EDITOR'S BODIES AS SEMANTIC TREES, AND THE MARKER LAW
+  AS A FUNCTION (rf2-hic-078).
+
+  `ht/tree` runs one hook-free body under injected read fixtures and
+  answers the Spec 004B structural tree it returned. No React, no
+  element, no hook, no DOM — so what a row here proves is what a body
+  MEANS. `flow-dom-cljs-test` is the other half and says so.
+
+  ## The fixture map IS the read set, and that is the point
+
+  `:subs` refuses a read no fixture answers. This file leans on that
+  deliberately: the fixture map written for each body is that body's read
+  set, spelled out, so **adding a read to a view reds this file** rather
+  than passing quietly. A body's edge set is what decides when it
+  re-renders, and on a controlled surface that is the whole
+  per-keystroke budget. Two rows here are nothing but an argument about
+  an EMPTY fixture map — [[the-form-body-reads-nothing]] and its grid
+  counterpart — because a layout body that read one moving value would
+  put itself on every keystroke's path.
+
+  ## The marker section is the sharpest thing in this file
+
+  rf2-hic-025's authoring report opens with `::h/value` and the canonical
+  event-vector shape being silently incompatible. That report describes
+  the collision; the rows under §THE MARKER LAW put both spellings
+  through `ht/materialize`, which is
+  `re-frame.hicasso.impl.intent/materialize` itself rather than a
+  re-derivation of it — so what is asserted is the substitution the
+  browser path runs, and the finding is CONFIRMED by measurement from a
+  second application rather than repeated."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.examples.editor.events :as events]
+            [re-frame.hicasso.examples.editor.subs :as subs]
+            [re-frame.hicasso.examples.editor.views :as views]
+            [re-frame.hicasso.test :as ht]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil}))
+
+(defn- tagged [tree tag] (ht/find tree #(= tag (:tag %))))
+
+(defn- field-tree
+  "The title or slug field's tree, under the two reads it makes and no
+  others."
+  [field {:keys [value revision]}]
+  (ht/tree [views/text-field {:field field :label "L"}]
+           {:subs {[::subs/field field] value
+                   [::subs/revision]    revision}}))
+
+;; ---------------------------------------------------------------------------
+;; THE MARKER LAW — rf2-hic-025 finding 1, confirmed from a second app
+;; ---------------------------------------------------------------------------
+
+(deftest the-positional-intent-substitutes-what-was-typed
+  (is (= [::events/edit :title "typed"]
+         (ht/materialize [::events/edit :title ::h/value] {:value "typed"}))
+      "the spelling every controlled field in this application uses")
+  (is (= [::events/set-published true]
+         (ht/materialize [::events/set-published ::h/checked] {:checked true}))
+      "and the checkbox's")
+  (is (= [::events/edit 3 4 "7"]
+         (ht/materialize [::events/edit 3 4 ::h/value] {:value "7"}))
+      "the grid's three-argument shape substitutes the same way — the
+       marker's position in the vector is immaterial, only its DEPTH is"))
+
+(deftest the-canonical-payload-map-silently-swallows-the-marker
+  ;; THE FINDING, as a measurement. `spec/Conventions.md` §Canonical
+  ;; event-vector shape asks for `[<id> {<k> <v>}]` and the linter nudges
+  ;; new code toward it. `materialize` maps over the intent's TOP LEVEL,
+  ;; deliberately and for a stated cost reason, so the shape the
+  ;; convention asks for cannot carry a marker.
+  (let [written    [::events/edit {:field :title :value ::h/value}]
+        dispatched (ht/materialize written {:value "typed"})]
+    (is (= [::events/edit {:field :title :value :re-frame.hicasso/value}]
+           dispatched)
+        "NOT substituted, NOT refused, and not linted: the marker KEYWORD
+         is what reaches the handler, lands in app-db and renders as text.
+         The failure is silent at every layer — rf2-hic-025 finding 1,
+         confirmed. This application therefore writes the positional
+         shape at all five of its marker-carrying intents, and says so at
+         `examples.editor.events`")
+    (is (not= "typed" (get-in dispatched [1 :value]))
+        "stated in the other direction, because this is the assertion a
+         reader should be able to find: what the user typed is NOWHERE in
+         the dispatched event"))
+
+  (testing "the escape hatch works, and the report's costing of it holds"
+    ;; The one callback form restores the payload map by reading the
+    ;; event by hand. It is a real escape and it is not free: a closure
+    ;; per field per render, which never compares equal
+    ;; (`codec/boundary-props=` is conservative about functions), and the
+    ;; return of the `.. e -target -value` that `::h/value` exists to
+    ;; delete.
+    ;;
+    ;; SPELLED `h/hfn`, and that cost this witness a compile. The door's
+    ;; own `as-element` docstring writes the escape as `(h/fn [i] …)` and
+    ;; so does `impl.intent`'s; `h/fn` is the authoring surface the name
+    ;; was chosen FOR and is not a var, so the published spelling does
+    ;; not compile. What the compiler says is
+    ;; `Use of undeclared Var re-frame.hicasso/fn` plus one
+    ;; `Use of undeclared Var <your-ns>/e` per argument — a WARNING and
+    ;; not an error, so the build completes and the page throws at
+    ;; render. Reported by rf2-hic-078; the naming gap itself is
+    ;; acknowledged in `h/defview`'s docstring and belongs to the bead
+    ;; that owns naming.
+    (let [cb (h/hfn [e] [::events/edit {:field :title
+                                        :value (.. e -target -value)}])]
+      (is (ht/callback? cb)
+          "it is the one callback form, so a position expecting an intent
+           vector will not silently take it as data")
+      (is (= [::events/edit {:field :title :value "typed"}]
+             (cb #js {"target" #js {"value" "typed"}}))
+          "and it does produce the canonical shape — the choice is real,
+           and it is between a linted shape with a closure and an
+           unlinted shape without one"))))
+
+;; ---------------------------------------------------------------------------
+;; L1 — what the codec makes of the fields
+;; ---------------------------------------------------------------------------
+
+(deftest every-text-control-is-controlled-and-carries-a-revision
+  (doseq [[label form] {"input"    [:input {:type "text"
+                                            :value "v"
+                                            ::h/revision 3
+                                            :on-input [::events/edit :title ::h/value]}]
+                        "textarea" [:textarea {:value "v"
+                                               ::h/revision 3
+                                               :on-input [::events/edit :body ::h/value]}]}]
+    (is (true? (ht/controlled? form))
+        (str "the " label " does not install the controlled shadow — the
+              runtime's own decision, not a re-derivation of it"))
+    (is (= 3 (ht/revision form))
+        (str "the " label " does not carry the reset trigger")))
+
+  (testing "the checkbox carries no revision, and could not"
+    ;; MEASURED, and it corrects the guess this witness started from.
+    ;; `ht/controlled?` asks whether the converge SHADOW stands in front
+    ;; of the element, and for a value-less checkbox it does not: the
+    ;; shadow exists for text convergence, so `install!`'s
+    ;; `controlled-text-tag?` needs an `input`/`textarea` AND a non-nil
+    ;; `:value` to re-baseline to. A checkbox written idiomatically has
+    ;; `:checked` and no `:value`. React's own `checked` ownership is what
+    ;; controls it, and there is no draft between the click and the
+    ;; dispatch for a shadow to hold.
+    (let [box [:input {:type "checkbox" :checked false
+                       :on-change [::events/set-published ::h/checked]}]]
+      (is (false? (ht/controlled? box))
+          "a value-less checkbox is not a CONVERGING control, and this row
+           says so rather than leaving `examples.editor.views` asserting
+           it from taste")
+      (is (nil? (ht/revision box)))
+      (is (true? (contains? (ht/element-props box) "checked"))
+          "`false` reaches the element as a slot — an owned `:checked`
+           wins by PRESENCE, not truthiness, and a truthiness test in the
+           codec would leave an unchecked box uncontrolled")))
+
+  (testing "and the REFUSAL for one is not reachable from this tier"
+    ;; A limit, stated where it was met. A `::h/revision` on a value-less
+    ;; checkbox is refused with
+    ;; `:rf.error/hicasso-revision-not-controlled` — but by
+    ;; `controlled/install!` reading a private slot that
+    ;; `codec/native-element` stashes while creating a real element, and
+    ;; `ht/controlled?` builds its props with `convert-props`, which does
+    ;; not. So L1 sees no revision to refuse and answers quietly.
+    ;;
+    ;; The consequence for a reader of this file: `ht/revision` reports
+    ;; what the AUTHOR wrote and `ht/element-props` reports what the codec
+    ;; EMITS, and no L1 door reports what the runtime would say about the
+    ;; pair. The refusal is asserted in `flow-dom-cljs-test`, where an
+    ;; element is really created.
+    (is (false? (ht/controlled? [:input {:type "checkbox" :checked false
+                                         ::h/revision 1
+                                         :on-change [::events/set-published
+                                                     ::h/checked]}]))
+        "recorded as measured conduct and not as approval — a tier that
+         answered `true` here would be worse, but a tier that answers at
+         all is stating something the runtime does not agree with")))
+
+(deftest the-revision-is-a-trigger-and-not-an-emitted-slot
+  (let [form  [:input {:type "text" :value "v" ::h/revision 7}]
+        slots (ht/element-props form)]
+    (is (contains? slots "value"))
+    (is (= 7 (ht/revision form))
+        "the author's own attribute map carries it — `ht/revision` reads
+         it pre-merge, which is where the codec reads it")
+    (is (= #{"type" "value"} (set (keys slots)))
+        "and the emitted slots are the two DOM ones. A reader of
+         `text-field` meets three keys in one attribute map of which two
+         are DOM and one is a runtime trigger, and the `::h/` namespace is
+         the whole of the signal — recorded in `examples.editor.views` as
+         the one place the door reads awkwardly.
+
+         The stronger claim — that the trigger never reaches the WIRE —
+         is the runtime's own and is banked in `revision-dom-cljs-test`;
+         this row is only about what an author's map projects to.")))
+
+;; ---------------------------------------------------------------------------
+;; L2 — the bodies
+;; ---------------------------------------------------------------------------
+
+(deftest a-text-field-reads-its-own-address-and-the-counter
+  (let [input (tagged (field-tree :title {:value "Title" :revision 0}) :input)
+        attrs (ht/attrs input)]
+    (is (= "Title" (:value attrs)))
+    (is (= [::events/edit :title ::h/value] (:on-input attrs))
+        "the intent is DATA — a vector `=` can compare, which is what
+         makes two renders of one field's handler equal and what keeps a
+         closure off the props map")
+    (is (= "title" (:id attrs)))
+    (is (= "title" (:for (ht/attrs (tagged (field-tree :title {:value "T" :revision 0})
+                                           :label))))
+        "and the label points at it, so the control has an accessible
+         name and the package's own clj-kondo export stays quiet")))
+
+(deftest the-slug-field-is-the-same-body-with-a-different-address
+  ;; The fixture map is the proof: `[::subs/field :slug]` and nothing
+  ;; else. A parametric subscription is keyed by its whole query vector,
+  ;; so title and slug are separate cells with separate equality gates —
+  ;; which is the property the per-keystroke budget rests on.
+  (let [attrs (ht/attrs (tagged (field-tree :slug {:value "a-slug" :revision 0}) :input))]
+    (is (= "a-slug" (:value attrs)))
+    (is (= [::events/edit :slug ::h/value] (:on-input attrs)))))
+
+(deftest the-checkbox-body-reads-one-address-and-writes-one-marker
+  (let [tree  (ht/tree [views/published-box {:label "Published"}]
+                       {:subs {[::subs/field :published?] true}})
+        attrs (ht/attrs (tagged tree :input))]
+    (is (true? (:checked attrs)))
+    (is (= [::events/set-published ::h/checked] (:on-change attrs)))
+    (is (= "checkbox" (:type attrs)))))
+
+(deftest the-buttons-read-one-value-between-them
+  (testing "clean: both disabled"
+    (let [tree (ht/tree [views/buttons {}] {:subs {[::subs/dirty?] false}})
+          btns (ht/find-all tree #(= :button (:tag %)))]
+      (is (= 2 (count btns)))
+      (is (= [true true] (mapv (comp :disabled ht/attrs) btns)))))
+
+  (testing "dirty: both live, and the discard says nothing about which field"
+    (let [tree (ht/tree [views/buttons {}] {:subs {[::subs/dirty?] true}})
+          btns (ht/find-all tree #(= :button (:tag %)))]
+      (is (= [false false] (mapv (comp :disabled ht/attrs) btns))
+          "`false` and not nil — per 004B a false attribute is RECORDED
+           and a nil one is dropped, so `(is (nil? …))` here would be
+           green against a button that had no disabled slot at all")
+      (is (= [[::events/save {:at "now"}] [::events/discard {}]]
+             (mapv (comp :on-click ht/attrs) btns))
+          "both carry the CANONICAL payload map, which they may because
+           neither carries a marker — the contrast with the fields, in
+           one tree"))))
+
+(deftest the-readout-reads-only-committed-addresses
+  ;; The fixture map is the assertion: four `::subs/committed` reads and
+  ;; not one `::subs/field`. A keystroke moves the draft, so it does not
+  ;; notify this body at all — which is what makes "echoes only committed
+  ;; state" readable off the page rather than merely true.
+  (let [tree (ht/tree [views/readout {}]
+                      {:subs {[::subs/committed :title]      "T"
+                              [::subs/committed :slug]       "s"
+                              [::subs/committed :body]       "B"
+                              [::subs/committed :published?] false}})]
+    (is (= ["T" "s" "B" "false"]
+           (mapv ht/text (ht/find-all tree #(= :dd (:tag %))))))))
+
+(deftest the-form-body-reads-nothing
+  ;; An EMPTY fixture map, and the kit refuses any read. This is the row
+  ;; that keeps the parent off the typing path: every value on the page
+  ;; comes from a child's own body, so this body runs at mount and then
+  ;; only if its own props change.
+  (let [tree (ht/tree [views/editor {}] {:subs {}})]
+    (is (some? tree)
+        "the form body made a read. Every value on this page belongs to a
+         child's own body; a read here puts the form, and a props compare
+         over six children, on every keystroke's path")
+
+    (testing "and it calls the four controls with the props they need"
+      (let [calls (ht/find-all tree #(some? (:view-id %)))]
+        (is (= 6 (count calls))
+            "four controls, the buttons and the readout — L2 records a
+             child boundary as a CALL and does not run its body")
+        (is (= [:title :slug nil nil nil nil]
+               (mapv (comp :field ht/attrs) calls)))
+        (is (= ["Title" "Slug" "Body" "Published" nil nil]
+               (mapv (comp :label ht/attrs) calls))
+            "the labels are ordinary data handed down, not a subsystem —
+             §7's whole i18n answer at this size")))))
+
+(deftest every-intent-the-form-offers-is-a-vector
+  ;; `ht/intents` answers only handler sites holding a literal intent
+  ;; VECTOR; a site carrying a function contributes nothing. So an empty
+  ;; answer here would mean the fields had grown closures.
+  (let [tree    (field-tree :title {:value "T" :revision 0})
+        offered (ht/intents tree)]
+    (is (= [[::events/edit :title ::h/value]] offered)
+        "one site, one vector. This application needed `h/fn` nowhere —
+         every intent said what it meant as data, which is rf2-hic-025's
+         observation about `hfn` confirmed from a form of four controls")))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/l2_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/l2_cljs_test.cljs
@@ -249,11 +249,13 @@
           "`false` and not nil — per 004B a false attribute is RECORDED
            and a nil one is dropped, so `(is (nil? …))` here would be
            green against a button that had no disabled slot at all")
-      (is (= [[::events/save {:at "now"}] [::events/discard {}]]
+      (is (= [[::events/save] [::events/discard]]
              (mapv (comp :on-click ht/attrs) btns))
-          "both carry the CANONICAL payload map, which they may because
-           neither carries a marker — the contrast with the fields, in
-           one tree"))))
+          "no payload, and no marker either. Both COULD take the canonical
+           `[<id> {<k> <v>}]` map — which is the whole shape of the
+           collision above: the map is available to every intent that needs
+           no substitution and to none that does. The grid's
+           `[::grid.events/clear-row {:row 2}]` is the live exhibit"))))
 
 (deftest the-readout-reads-only-committed-addresses
   ;; The fixture map is the assertion: four `::subs/committed` reads and

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/subs.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/subs.cljs
@@ -1,0 +1,61 @@
+(ns re-frame.hicasso.examples.editor.subs
+  "THE EDITOR'S READ TOPOLOGY — one address per field (rf2-hic-078).
+
+  Four fields and four subscription cells, because the per-keystroke
+  budget is a fact about the READ TOPOLOGY and about nothing else.
+  `docs/design/hicasso/draft-guide/18-performance.md` §The cost of one
+  keystroke walks it: one write, the subscriptions reading that address
+  recompute, equality gates stop every one whose output did not move, and
+  the boundaries whose reads changed are notified. With a field per cell
+  that is **one** changed subscription and **one** body run per
+  keystroke — write amplification 1, independent of how many fields the
+  form has. `editor.flow-dom-cljs-test` measures it rather than asserting
+  the arithmetic.
+
+  [[field]] is PARAMETRIC, so the four cells are four entries under one
+  registration rather than four registrations. A parametric subscription
+  is keyed by its whole query vector, so `[::field :title]` and
+  `[::field :body]` are separate cells with separate equality gates,
+  which is the property the budget rests on. `editor.l2-cljs-test` proves
+  it the only way a structural tier can — by handing each body a fixture
+  map answering exactly the reads it makes, and letting the kit refuse
+  any read the map does not answer.
+
+  Nothing here is a view-model. Each subscription answers the value its
+  control shows, one `get-in` deep, because that is what a controlled
+  field wants: the cheapest path from the keystroke's write to the value
+  the converge writes back."
+  (:require [re-frame.core :as rf]))
+
+(rf/reg-sub ::field
+  {:doc "One field's DRAFT value — the value its control shows."}
+  (fn [db [_ field]] (get-in db [:draft field])))
+
+(rf/reg-sub ::committed
+  {:doc "One field's COMMITTED value — what `::events/save` last took.
+
+  Read by the readout beneath the form and by nothing else, so \"echoes
+  only committed state\" has somewhere on the page to be read off."}
+  (fn [db [_ field]] (get-in db [:article field])))
+
+(rf/reg-sub ::revision
+  {:doc "The reset counter the text fields carry as `::h/revision`.
+
+  Its own cell, so a discard notifies the fields carrying it and nothing
+  else. Each field reads it in its own body rather than taking it as a
+  prop, which is what keeps the parent out of the keystroke path
+  entirely: a prop would have to come from a body that read the counter,
+  and that body would then re-run on every reset."}
+  (fn [db _] (:revision db 0)))
+
+(rf/reg-sub ::dirty?
+  {:doc "Does the draft differ from the article?
+
+  The one subscription here whose input is not a single address, and it
+  is deliberately off the keystroke path's critical list: it feeds the
+  button row, which is a separate boundary from the fields. A keystroke
+  that changes it runs the button row's body and no field's — which is
+  the ordinary way an application spends its second body run, and the
+  reason `flow-dom-cljs-test` measures amplification with the buttons on
+  the page rather than with the fields alone."}
+  (fn [db _] (not= (:draft db) (:article db))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/views.cljs
@@ -136,12 +136,12 @@
      [:button {:id       "save"
                :type     "button"
                :disabled (not dirty?)
-               :on-click [::events/save {:at "now"}]}
+               :on-click [::events/save]}
       "Save"]
      [:button {:id       "discard"
                :type     "button"
                :disabled (not dirty?)
-               :on-click [::events/discard {}]}
+               :on-click [::events/discard]}
       "Discard"]]))
 
 (h/defview readout

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/views.cljs
@@ -100,12 +100,15 @@
 (h/defview published-box
   "The owned `::h/checked` pair.
 
-  It carries NO `::h/revision`, and the omission is a claim rather than a
-  gap. A revision re-baselines a control that is showing something the
-  model never took, and a checkbox cannot be: there is no free draft
-  between the click and the dispatch, so `[::events/discard]` moving
-  `:published?` back always moves the value React compares. The discard
-  row in `editor.flow-dom-cljs-test` asserts it restores without one."
+  It carries NO `::h/revision`, and the omission is not a choice: a
+  revision on a value-less checkbox is REFUSED with
+  `:rf.error/hicasso-revision-not-controlled`, because the trigger
+  re-baselines a controlled `<input>`/`<textarea>` to a `:value` and a
+  checkbox written idiomatically has none. Nor does it want one — there
+  is no free draft between the click and the dispatch, so
+  `[::events/discard]` moving `:published?` back always moves the value
+  React compares. Both halves are measured: the refusal in
+  `editor.l2-cljs-test`, the restore in `editor.flow-dom-cljs-test`."
   [{:keys [label]}]
   [:p.field
    [:label {:for "published"} label]

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/views.cljs
@@ -1,0 +1,178 @@
+(ns re-frame.hicasso.examples.editor.views
+  "THE FOUR-FIELD EDITOR — every control written the way the guide writes
+  one (rf2-hic-078).
+
+  `:value` off a subscription, an intent vector at `:on-input`, and
+  nothing else. No ref, no `on-change` closure, no local draft, no effect
+  reconciling two copies of the text. The model is the only place the
+  value lives, and the readout at the bottom of the form reads the
+  committed half of it through an ordinary subscription.
+
+  ## One field, one boundary — and that is the whole performance story
+
+  [[text-field]] is the unit of re-render. Four controls means four
+  boundaries, each reading its own address, so a keystroke in the title
+  notifies the title's boundary and no other
+  (`docs/design/hicasso/draft-guide/18-performance.md` §The cost of one
+  keystroke). [[editor]] itself reads NOTHING: it is a layout body that
+  runs at mount and, thereafter, only when a prop of its own changes.
+  That absence is the load-bearing part, and `editor.l2-cljs-test`
+  asserts it the only way it can be asserted — by handing the body an
+  EMPTY fixture map and letting the kit refuse any read it makes.
+
+  ## What was NOT needed here
+
+  Recorded because rf2-hic-025's report made the same list from a broader
+  application and a facade freeze reads both. This form of four controls,
+  two buttons and a readout needed `defview`, `sub`, and the three
+  markers `::h/value`, `::h/checked` and `::h/revision`. It needed no
+  `h/fn` — every intent said what it meant as a vector — and no
+  `use-subs`, `boundary`, `portal`, `as-element`, `as-component`,
+  `defhost`, `hframe`, `route-link` or `reg-state`. **Six names and three
+  keywords**, and `examples.witness-surface-cljs-test` pins the namespace
+  roster mechanically.
+
+  ## The one place the public door reads awkwardly
+
+  `::h/revision` sits in the attribute map beside `:value`, which is
+  where HD-019 puts it, but it is not an attribute and never reaches the
+  wire — so a reader of [[text-field]] meets three keys of which two are
+  DOM and one is a runtime trigger, with nothing at the call site saying
+  which is which. The `::h/` namespace is the whole of the signal. It is
+  recorded rather than complained about: the alternative spellings
+  (a wrapper, a second argument, a metadata carrier) all cost more than
+  the ambiguity does, and the marker keywords already read
+  `:re-frame.hicasso/…` in every other position."
+  (:require [re-frame.hicasso :as h]
+            [re-frame.hicasso.examples.editor.events :as events]
+            [re-frame.hicasso.examples.editor.subs :as subs]))
+
+(def field-labels
+  "The four accessible names, as data.
+
+  Plain data and not a subscription, for a reason the read topology
+  cares about: a label that came off a subscription would be a second
+  read in every field's body, and a body's edge set is what decides when
+  it re-renders. §7's answer to i18n is *ordinary data*, and at this size
+  ordinary data is a map — swapping it for a locale-keyed lookup is a
+  change to the parent that passes it down, not to the fields."
+  {:title      "Title"
+   :slug       "Slug"
+   :body       "Body"
+   :published? "Published"})
+
+;; ---------------------------------------------------------------------------
+;; The controls
+;; ---------------------------------------------------------------------------
+
+(h/defview text-field
+  "One controlled `<input type=text>`: the title and the slug.
+
+  Two reads, both its own — the field's value and the reset counter. The
+  `<label>` is not decoration: an interactive element with no accessible
+  name is a warning under this package's own clj-kondo export
+  (`:re-frame.hicasso/nameless-interactive-element`), and a witness that
+  tripped the lint it ships would be poor evidence."
+  [{:keys [field label]}]
+  (let [id (name field)]
+    [:p.field
+     [:label {:for id} label]
+     [:input {:id          id
+              :type        "text"
+              :data-field  id
+              ::h/revision (h/sub [::subs/revision])
+              :value       (h/sub [::subs/field field])
+              :on-input    [::events/edit field ::h/value]}]]))
+
+(h/defview body-field
+  "The same law on the other convergeable tag. Identical in every respect
+  a reader would care about, which is the claim — `<textarea>` is not a
+  second controlled-input story."
+  [{:keys [label]}]
+  [:p.field
+   [:label {:for "body"} label]
+   [:textarea {:id          "body"
+               :data-field  "body"
+               ::h/revision (h/sub [::subs/revision])
+               :value       (h/sub [::subs/field :body])
+               :on-input    [::events/edit :body ::h/value]}]])
+
+(h/defview published-box
+  "The owned `::h/checked` pair.
+
+  It carries NO `::h/revision`, and the omission is a claim rather than a
+  gap. A revision re-baselines a control that is showing something the
+  model never took, and a checkbox cannot be: there is no free draft
+  between the click and the dispatch, so `[::events/discard]` moving
+  `:published?` back always moves the value React compares. The discard
+  row in `editor.flow-dom-cljs-test` asserts it restores without one."
+  [{:keys [label]}]
+  [:p.field
+   [:label {:for "published"} label]
+   [:input {:id         "published"
+            :type       "checkbox"
+            :data-field "published"
+            :checked    (h/sub [::subs/field :published?])
+            :on-change  [::events/set-published ::h/checked]}]])
+
+;; ---------------------------------------------------------------------------
+;; The form's other two boundaries
+;; ---------------------------------------------------------------------------
+
+(h/defview buttons
+  "Save and Discard, in their own boundary reading their own one value.
+
+  Separate from the fields on purpose: `::subs/dirty?` moves on the
+  FIRST keystroke of an editing session and then stays put, so this body
+  runs once at the start of a burst of typing and not again. Putting the
+  buttons in with a field would have put that read on the field's edge
+  set and re-run the field on every change to it."
+  [_]
+  (let [dirty? (h/sub [::subs/dirty?])]
+    [:p.buttons
+     [:button {:id       "save"
+               :type     "button"
+               :disabled (not dirty?)
+               :on-click [::events/save {:at "now"}]}
+      "Save"]
+     [:button {:id       "discard"
+               :type     "button"
+               :disabled (not dirty?)
+               :on-click [::events/discard {}]}
+      "Discard"]]))
+
+(h/defview readout
+  "The COMMITTED article, on the page.
+
+  Its own boundary reading the committed addresses, so a keystroke — which
+  moves the draft and not the article — notifies it not at all. That is
+  the readable form of \"echoes only committed state\": the readout does
+  not move while you type, and moves when you save."
+  [_]
+  [:dl.committed
+   [:dt "title"] [:dd {:data-committed "title"} (h/sub [::subs/committed :title])]
+   [:dt "slug"] [:dd {:data-committed "slug"} (h/sub [::subs/committed :slug])]
+   [:dt "body"] [:dd {:data-committed "body"} (h/sub [::subs/committed :body])]
+   [:dt "published"] [:dd {:data-committed "published"}
+                      (str (boolean (h/sub [::subs/committed :published?])))]])
+
+;; ---------------------------------------------------------------------------
+;; The form
+;; ---------------------------------------------------------------------------
+
+(h/defview editor
+  "The whole application, and it reads nothing.
+
+  Every value on this page comes from a child's own body, so this body
+  runs at mount and then only if its own props change — which they never
+  do. A parent that read anything a keystroke touches would put itself,
+  and a props compare over every child, on the typing path."
+  [_]
+  [:main#four-field-editor
+   [:h1 "Article"]
+   [text-field {:key "title" :field :title :label (:title field-labels)}]
+   [text-field {:key "slug" :field :slug :label (:slug field-labels)}]
+   [body-field {:label (:body field-labels)}]
+   [published-box {:label (:published? field-labels)}]
+   [buttons {}]
+   [readout {}]])

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/app.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/app.cljs
@@ -1,0 +1,45 @@
+(ns re-frame.hicasso.examples.grid.app
+  "THE GRID'S ENTRY POINT — an adapter, a frame, a root (rf2-hic-078).
+
+  The editor's entry point with one difference: [[initial-events]] is a
+  FUNCTION of the grid's dimensions, because the size is the variable the
+  scaling witness moves. Everything else — the namespaced frame keyword,
+  the reload handle, the absence of any registered route — is
+  `examples.editor.app`'s, and its docstring carries the reasoning."
+  (:require [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.examples.grid.events :as events]
+            [re-frame.hicasso.examples.grid.views :as views]))
+
+(def frame-id
+  "This application's frame. Namespaced, so two applications in one
+  process cannot claim it."
+  ::frame)
+
+(defn initial-events
+  "What seeds a fresh frame at `dimensions` — `{:rows n :cols n}`.
+
+  A function and not a constant because the size is the independent
+  variable of `grid.scaling-dom-cljs-test`: the suite mounts the same
+  application twice and the only difference between the two mounts is
+  what this returns."
+  ([] (initial-events events/default-dimensions))
+  ([dimensions] [[::events/seed dimensions]]))
+
+(defonce ^:private !root (atom nil))
+
+(defn ^:dev/after-load reload!
+  "Re-render the mounted root after a hot reload."
+  []
+  (when-some [root @!root]
+    (h/render! root [views/grid {}])))
+
+(defn ^:export -main
+  "Mount the 100-cell grid on `#app`."
+  []
+  (rf/init! uix-adapter/adapter)
+  (rf/make-frame {:id frame-id :initial-events (initial-events)})
+  (reset! !root (h/root! (js/document.getElementById "app") frame-id
+                         [views/grid {}]))
+  nil)

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/events.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/events.cljs
@@ -1,0 +1,125 @@
+(ns re-frame.hicasso.examples.grid.events
+  "THE 100-CELL CONTROLLED GRID'S MODEL — ordinary re-frame2 (rf2-hic-078).
+
+  The editor is evidence about a form's SHAPE; this is evidence about
+  BREADTH. One hundred controlled fields on one page, every one of them
+  written exactly as the four in the editor are, and the question the
+  application exists to answer is whether the hundredth costs anything
+  the first did not.
+
+  Specification §6: *narrow-update body work scales with changed rows
+  rather than all mounted rows*. That is a claim about a per-keystroke
+  COUNT at two sizes, so this application is parameterised by its
+  dimensions and `grid.scaling-dom-cljs-test` mounts it at two of them.
+
+  ## One address per cell
+
+  `app-db` holds `{:cells {[row col] \"…\"}}` — a flat map keyed by
+  coordinate, not a vector of vectors. The reason is the read topology
+  and nothing else: `[::subs/cell row col]` is one `get-in` into one
+  address, so the write from a keystroke and the read that echoes it meet
+  at a single key. A nested representation would make a cell's read
+  depend on its row, and a row's identity would then move on every
+  keystroke in it — a hundred cells sharing ten notification groups
+  instead of a hundred.
+
+  ## Every cell REFUSES a non-digit, and that is the division of labour
+
+  The editor's four fields accept or normalise; none of them refuses. So
+  refusal lives here, uniformly: a cell takes digits and nothing else,
+  and the model does not move when it is handed anything else. That gives
+  the grid the one controlled-law row the editor cannot have — *a
+  rejected value echoes the COMMITTED value, in the turn that typed it* —
+  while keeping every cell identical, which is what the scaling claim
+  needs. A grid whose cells differed would be measuring the differences.
+
+  ## `::h/value` is positional here too
+
+  [[::edit]] carries a marker, so it takes its arguments positionally and
+  not in the canonical `[<id> {<k> <v>}]` payload map. Second
+  confirmation of rf2-hic-025's finding 1, from an application whose
+  intent carries THREE arguments rather than two — the collision does not
+  soften as the payload grows, it gets worse, because a three-argument
+  positional vector is exactly where a payload map would have started to
+  pay for itself."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]))
+
+(def default-dimensions
+  "Ten by ten — §7's *100-cell grid*, and the size every witness that
+  does not say otherwise uses."
+  {:rows 10 :cols 10})
+
+(defn digits-only
+  "The one policy every cell has. `old` is the COMMITTED value and
+  `typed` is what the control now shows; returning `old` is a refusal.
+
+  Uniform across the grid on purpose — see the namespace docstring."
+  [old typed]
+  (if (re-matches #"[0-9]*" (str typed)) typed old))
+
+(defn seed-cells
+  "`{[row col] \"<n>\"}` for a `rows` x `cols` grid, filled with a
+  distinct digit string per cell so that a witness reading one cell can
+  tell it apart from its neighbours."
+  [{:keys [rows cols]}]
+  (into {}
+        (for [row (range rows) col (range cols)]
+          [[row col] (str (+ (* row cols) col))])))
+
+(defn seed
+  "The starting `app-db` for a grid of the given dimensions."
+  [dimensions]
+  {:dimensions dimensions
+   :cells      (seed-cells dimensions)})
+
+(rf/reg-event ::seed
+  {:doc "Install a grid of the given size. The frame's `:initial-events` step."}
+  ;; The canonical `[<id> {<k> <v>}]` payload shape, available here for
+  ;; the reason it is unavailable to [[::edit]]: this event carries no
+  ;; marker.
+  (fn [_ [_ dimensions]]
+    {:db (seed (or dimensions default-dimensions))}))
+
+(rf/reg-event ::edit
+  {:doc "Write one cell, through the digits-only policy."}
+  ;; POSITIONAL, and not by preference. `::h/value` substitutes at the
+  ;; intent vector's TOP LEVEL only, so `[::edit {:row r :col c :value
+  ;; ::h/value}]` would put the keyword `:re-frame.hicasso/value` into
+  ;; app-db and render it as text — silently, unrefused and unlinted.
+  ;; See the namespace docstring.
+  (fn [{:keys [db]} [_ row col typed]]
+    (let [address [:cells [row col]]]
+      {:db (update-in db address digits-only typed)})))
+
+(rf/reg-event ::clear-row
+  {:doc "Empty every cell of one row — a BROAD update, for contrast.
+
+  The scaling claim is about the narrow path; this is what the same
+  application looks like when the change genuinely is wide, and it is
+  what `scaling-dom-cljs-test` measures against so that the narrow
+  number has something to be narrow COMPARED TO. One write, `cols`
+  changed subscriptions, `cols` body runs — amplification equal to the
+  changed rows and not to the mounted ones, which is the specification's
+  sentence read in the other direction."}
+  (fn [{:keys [db]} [_ {:keys [row]}]]
+    (let [cols (get-in db [:dimensions :cols])]
+      {:db (reduce (fn [d col] (assoc-in d [:cells [row col]] ""))
+                   db
+                   (range cols))})))
+
+(defn cell-label
+  "The accessible name of one cell — `\"cell 3,4\"`.
+
+  A function rather than a string in the view because both the view and
+  every witness that looks a cell up need the same spelling, and two
+  copies of a selector is how a witness ends up asserting about a cell
+  that is not on the page."
+  [row col]
+  (str "cell " row "," col))
+
+(defn cell-id
+  "The DOM id of one cell — `\"cell-3-4\"`. Same reason as
+  [[cell-label]]."
+  [row col]
+  (str/join "-" ["cell" row col]))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/events.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/events.cljs
@@ -41,9 +41,13 @@
   intent carries THREE arguments rather than two — the collision does not
   soften as the payload grows, it gets worse, because a three-argument
   positional vector is exactly where a payload map would have started to
-  pay for itself."
-  (:require [clojure.string :as str]
-            [re-frame.core :as rf]))
+  pay for itself.
+
+  [[::seed]] and [[::clear-row]] carry no marker, so both take the
+  canonical payload map — `[::clear-row {:row 2}]` — and between them
+  they are this bead's live exhibit of the shape the convention asks for
+  working exactly as advertised where nothing needs substituting."
+  (:require [re-frame.core :as rf]))
 
 (def default-dimensions
   "Ten by ten — §7's *100-cell grid*, and the size every witness that
@@ -122,4 +126,4 @@
   "The DOM id of one cell — `\"cell-3-4\"`. Same reason as
   [[cell-label]]."
   [row col]
-  (str/join "-" ["cell" row col]))
+  (str "cell-" row "-" col))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/l0_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/l0_cljs_test.cljs
@@ -1,0 +1,135 @@
+(ns re-frame.hicasso.examples.grid.l0-cljs-test
+  "L0 — THE GRID'S MODEL, WITH NO VIEW SUBSTRATE ANYWHERE (rf2-hic-078).
+
+  A hundred controlled fields, and the model behind them is one map, one
+  policy function and three handlers. That is the claim this file makes:
+  breadth costs nothing in the model tier either.
+
+  Two rows earn their place beyond the ordinary.
+  [[a-refused-keystroke-leaves-the-model-where-it-was]] is the controlled
+  law's refusal half — the editor's four fields accept or normalise, so
+  refusal lives here — and [[one-keystroke-moves-exactly-one-cell]] is the
+  first number of the per-keystroke walk, asserted over a hundred
+  addresses rather than four."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso.examples.grid.app :as app]
+            [re-frame.hicasso.examples.grid.events :as events]
+            [re-frame.hicasso.examples.grid.subs :as subs]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil}))
+
+(defn- with-grid
+  "Run `f` against a fresh frame holding a grid of `dimensions`, seeded
+  exactly as the application seeds itself."
+  ([f] (with-grid events/default-dimensions f))
+  ([dimensions f]
+   (rf/with-new-frame [frame (rf/make-frame
+                               {:initial-events (app/initial-events dimensions)})]
+     (f frame))))
+
+(defn- read-sub [frame query-v] (rf/subscribe-once query-v {:frame frame}))
+
+(defn- type! [frame row col text]
+  (rf/dispatch-sync [::events/edit row col text] {:frame frame}))
+
+;; ---------------------------------------------------------------------------
+;; Pure
+;; ---------------------------------------------------------------------------
+
+(deftest the-default-grid-is-a-hundred-cells
+  (is (= {:rows 10 :cols 10} events/default-dimensions))
+  (is (= 100 (count (events/seed-cells events/default-dimensions))))
+  (is (= "0" (get (events/seed-cells events/default-dimensions) [0 0])))
+  (is (= "99" (get (events/seed-cells events/default-dimensions) [9 9]))
+      "each cell seeds to a distinct digit string, so a witness reading
+       one cell can tell it apart from its neighbours"))
+
+(deftest the-policy-refuses-anything-that-is-not-a-digit-string
+  (is (= "12" (events/digits-only "9" "12")) "accepted")
+  (is (= "" (events/digits-only "9" "")) "an empty field is a legal state")
+  (is (= "9" (events/digits-only "9" "1a")) "refused — the model does not move")
+  (is (= "9" (events/digits-only "9" "-1")))
+  (is (= "9" (events/digits-only "9" " ")))
+  (testing "a refusal answers the COMMITTED value by identity"
+    ;; Not merely `=`. The value the field is handed back has to be the
+    ;; one it was handed before, or a refusal would look to every
+    ;; equality gate above it like a change.
+    (let [old "9"]
+      (is (identical? old (events/digits-only old "x"))))))
+
+;; ---------------------------------------------------------------------------
+;; Transitions
+;; ---------------------------------------------------------------------------
+
+(deftest an-accepted-keystroke-lands-in-its-own-cell
+  (with-grid
+    (fn [frame]
+      (type! frame 3 4 "77")
+      (is (= "77" (read-sub frame [::subs/cell 3 4])))
+      (is (= "35" (read-sub frame [::subs/cell 3 5]))
+          "and its neighbour is untouched — the seed's own value, still"))))
+
+(deftest a-refused-keystroke-leaves-the-model-where-it-was
+  (with-grid
+    (fn [frame]
+      (let [before (read-sub frame [::subs/cell 3 4])]
+        (type! frame 3 4 "34x")
+        (is (= before (read-sub frame [::subs/cell 3 4]))
+            "THE REFUSAL HALF OF THE CONTROLLED LAW, at the model tier: the
+             field will be handed back the committed value, which is what
+             makes the echo in `scaling-dom-cljs-test` a snap-back rather
+             than an acceptance")))))
+
+(deftest one-keystroke-moves-exactly-one-cell
+  (with-grid
+    (fn [frame]
+      (let [before (:cells (rf/app-db-value frame))
+            _      (type! frame 3 4 "77")
+            after  (:cells (rf/app-db-value frame))]
+        (is (= 100 (count before) (count after))
+            "no cell arrived and none left")
+        (is (= [[3 4]] (vec (for [[k v] after :when (not= v (get before k))] k)))
+            "ONE address of a hundred. The per-keystroke walk's first
+             number, and it does not grow with the grid")))))
+
+(deftest a-row-total-is-the-sum-of-its-row
+  (with-grid {:rows 2 :cols 3}
+    (fn [frame]
+      (is (= (+ 0 1 2) (read-sub frame [::subs/row-total 0])))
+      (is (= (+ 3 4 5) (read-sub frame [::subs/row-total 1])))
+      (type! frame 1 1 "40")
+      (is (= (+ 3 40 5) (read-sub frame [::subs/row-total 1])))
+      (is (= (+ 0 1 2) (read-sub frame [::subs/row-total 0]))
+          "the other row's total did not move, which is what makes it a
+           per-row edge rather than a whole-grid one")))
+
+  (testing "an emptied cell counts as zero rather than throwing"
+    (with-grid {:rows 1 :cols 2}
+      (fn [frame]
+        (type! frame 0 0 "")
+        (is (= 1 (read-sub frame [::subs/row-total 0])))))))
+
+(deftest clearing-a-row-moves-that-row-and-no-other
+  (with-grid {:rows 3 :cols 4}
+    (fn [frame]
+      (rf/dispatch-sync [::events/clear-row {:row 1}] {:frame frame})
+      (is (= ["" "" "" ""] (mapv #(read-sub frame [::subs/cell 1 %]) (range 4))))
+      (is (= 0 (read-sub frame [::subs/row-total 1])))
+      (is (= ["0" "1" "2" "3"] (mapv #(read-sub frame [::subs/cell 0 %]) (range 4)))
+          "a BROAD update is still scoped to what changed. `scaling-dom`
+           counts the bodies this runs, so the narrow number has something
+           to be narrow compared to"))))
+
+(deftest the-grid-is-parameterised-by-its-dimensions
+  ;; The property `scaling-dom-cljs-test` rests on: the same application,
+  ;; mounted at two sizes, differing in nothing but this.
+  (with-grid {:rows 5 :cols 5}
+    (fn [frame]
+      (is (= {:rows 5 :cols 5} (read-sub frame [::subs/dimensions])))
+      (is (= 25 (count (:cells (rf/app-db-value frame))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/l2_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/l2_cljs_test.cljs
@@ -21,7 +21,7 @@
 
   A body that grew a read reds this file before anything is mounted,
   which is the earliest a topology regression can be caught."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.hicasso :as h]
             [re-frame.hicasso.examples.grid.events :as events]

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/l2_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/l2_cljs_test.cljs
@@ -1,0 +1,146 @@
+(ns re-frame.hicasso.examples.grid.l2-cljs-test
+  "L2 — THE GRID'S BODIES, AND THE READ TOPOLOGY THE SCALING CLAIM RESTS
+  ON (rf2-hic-078).
+
+  Specification §6 asks that *narrow-update body work scales with changed
+  rows rather than all mounted rows*. `scaling-dom-cljs-test` measures
+  the bodies; this file establishes the thing that makes the measurement
+  come out — the read topology — and it establishes it in the one way a
+  structural tier can.
+
+  `ht/tree` refuses a read no fixture answers. So the fixture map handed
+  to each body IS that body's read set, and four rows here are nothing
+  but an argument about which map is enough:
+
+  | body | fixture map | what an over-large map would mean |
+  |---|---|---|
+  | `cell` | one `[::subs/cell r c]` | a cell reading a second address is a second notification group |
+  | `row-total` | one `[::subs/row-total r]` | — |
+  | `grid-row` | `[::subs/dimensions]` alone | a row body reading a cell puts ten cells' keystrokes on the row's path |
+  | `grid` | `[::subs/dimensions]` alone | the parent on every keystroke in the page |
+
+  A body that grew a read reds this file before anything is mounted,
+  which is the earliest a topology regression can be caught."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.examples.grid.events :as events]
+            [re-frame.hicasso.examples.grid.subs :as subs]
+            [re-frame.hicasso.examples.grid.views :as views]
+            [re-frame.hicasso.test :as ht]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil}))
+
+(defn- tagged [tree tag] (ht/find tree #(= tag (:tag %))))
+
+;; ---------------------------------------------------------------------------
+;; The cell — the whole of the typing surface
+;; ---------------------------------------------------------------------------
+
+(deftest a-cell-reads-one-address-and-writes-one-intent
+  (let [tree  (ht/tree [views/cell {:row 3 :col 4}]
+                       {:subs {[::subs/cell 3 4] "34"}})
+        attrs (ht/attrs (tagged tree :input))]
+    (is (= "34" (:value attrs)))
+    (is (= [::events/edit 3 4 ::h/value] (:on-input attrs))
+        "a THREE-argument positional intent. It is positional for the
+         reason the editor's two-argument ones are — a marker below the
+         top level of an intent vector is not substituted — and the
+         collision does not soften as the payload grows; three positional
+         arguments is exactly where a payload map would have started to
+         pay for itself. rf2-hic-025 finding 1, confirmed at a second
+         arity")
+    (is (= "cell-3-4" (:id attrs)))
+    (is (= "cell 3,4" (:aria-label attrs))
+        "every one of a hundred controls has an accessible name, and it
+         comes from `events/cell-label` so that a witness looking a cell
+         up and the view rendering it cannot spell it differently")))
+
+(deftest a-cell-is-the-editors-text-field-with-a-coordinate
+  ;; The claim the grid exists to make. Both are `:value` off a
+  ;; subscription and an intent vector at `:on-input`, and the difference
+  ;; between one field and a hundred is the loop that writes them.
+  (let [form [:input {:type "text" :value "34"
+                      :on-input [::events/edit 3 4 ::h/value]}]]
+    (is (true? (ht/controlled? form))
+        "the hundredth cell installs the same converge shadow as the
+         first, and there is no second way of writing a field for when
+         there are a hundred of them")
+    (is (nil? (ht/revision form))
+        "and the grid carries no reset trigger anywhere — it has no
+         discard, so `::h/revision` never appears in this application")))
+
+(deftest the-row-total-reads-its-own-row-and-nothing-else
+  (let [tree (ht/tree [views/row-total {:row 2}]
+                      {:subs {[::subs/row-total 2] 42}})]
+    (is (= "42" (ht/text tree)))
+    (is (= "2" (:data-total (ht/attrs tree))))))
+
+;; ---------------------------------------------------------------------------
+;; The layout bodies — the half of the topology that is an ABSENCE
+;; ---------------------------------------------------------------------------
+
+(deftest a-row-body-reads-the-dimensions-and-no-cell
+  (let [tree  (ht/tree [views/grid-row {:row 2}]
+                       {:subs {[::subs/dimensions] {:rows 10 :cols 4}}})
+        cells (ht/find-all tree #(= "re-frame.hicasso.examples.grid.views/cell"
+                                    (:view-id %)))]
+    (is (= 4 (count cells))
+        "one call per column — and a CALL, so the child's body did not run
+         and its read is not on this fixture map")
+    (is (= [[2 0] [2 1] [2 2] [2 3]]
+           (mapv (fn [c] [(:row (ht/attrs c)) (:col (ht/attrs c))]) cells)))
+    (is (= ["0" "1" "2" "3"] (mapv :key cells))
+        "keyed by column. A list keyed by anything that moves reuses the
+         wrong element the moment the order changes, and on a page of
+         controlled fields that is a caret landing in another cell")
+    (is (= 1 (count (ht/find-all tree #(= "re-frame.hicasso.examples.grid.views/row-total"
+                                          (:view-id %)))))
+        "and one total, at the end of the row")))
+
+(deftest the-grid-body-reads-the-dimensions-and-no-cell
+  ;; THE ROW THE SCALING CLAIM RESTS ON. The grid's whole fixture map is
+  ;; one read of a value nothing writes while anybody is typing, so a
+  ;; keystroke cannot reach this body. A `[::subs/all-cells]` here — the
+  ;; guide's named anti-shape — would put the parent, and a props compare
+  ;; over every row, on every keystroke's path.
+  (let [tree (ht/tree [views/grid {}]
+                      {:subs {[::subs/dimensions] {:rows 3 :cols 3}}})
+        rows (ht/find-all tree #(= "re-frame.hicasso.examples.grid.views/grid-row"
+                                   (:view-id %)))]
+    (is (= 3 (count rows)))
+    (is (= [0 1 2] (mapv (comp :row ht/attrs) rows)))
+    (is (= ["0" "1" "2"] (mapv :key rows)))
+    (is (some? (tagged tree :table)))))
+
+;; ---------------------------------------------------------------------------
+;; A hundred of them
+;; ---------------------------------------------------------------------------
+
+(deftest a-hundred-cells-carry-a-hundred-distinct-addresses
+  ;; Structural, and cheap: the grid's calls are enumerated at the real
+  ;; size, and every cell's coordinate pair is distinct. A witness that
+  ;; measured scaling on a grid whose cells shared an address would be
+  ;; measuring an accident.
+  (let [dims  {:rows 10 :cols 10}
+        rows  (range (:rows dims))
+        cells (into []
+                    (mapcat (fn [row]
+                              (let [tree (ht/tree [views/grid-row {:row row}]
+                                                  {:subs {[::subs/dimensions] dims}})]
+                                (->> (ht/find-all
+                                       tree
+                                       #(= "re-frame.hicasso.examples.grid.views/cell"
+                                           (:view-id %)))
+                                     (mapv (fn [c] [(:row (ht/attrs c))
+                                                    (:col (ht/attrs c))]))))))
+                    rows)]
+    (is (= 100 (count cells)))
+    (is (= 100 (count (set cells))))
+    (is (= (set (for [r rows c (range (:cols dims))] [r c])) (set cells))
+        "the coordinate grid, complete and without duplicates — 100 cells,
+         100 addresses, 100 notification groups")))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/scaling_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/scaling_dom_cljs_test.cljs
@@ -1,0 +1,291 @@
+(ns re-frame.hicasso.examples.grid.scaling-dom-cljs-test
+  "L3 — THE NARROW-UPDATE SCALING CLAIM, MEASURED (rf2-hic-078).
+
+  > Narrow-update body work scales with changed rows rather than all
+  > mounted rows.
+  >
+  > — product specification §6, absolute correctness and user-visible
+  > budgets
+
+  That is a claim about a COUNT AT TWO SIZES, and this file is the only
+  place in the bead where it is measured rather than reasoned about. The
+  same application is mounted at 5x5 and at 10x10, one cell is typed
+  into, and the boundary bodies that ran are counted. If the number is
+  the same at both sizes the shape scales; if it grows, it does not.
+
+  ## The instrument, and what it can and cannot see
+
+  `re-frame.hicasso.impl.collector/body-runs` counts bodies React
+  actually ran — a `React.memo` bail-out shows up as an increment that
+  did not happen, so it measures adoption rather than inferring it from
+  the comparator. A test may reach it; the applications may not, and
+  `examples.witness-surface-cljs-test` is what says so.
+
+  **It cannot see a props compare.** That matters for reading the table
+  below honestly: the guide's coarse shape with SCALAR props runs the
+  parent and one child, exactly like the narrow shape, while allocating N
+  elements and comparing N props maps. Those are real costs and this
+  instrument is blind to them. The shape that this gate CAN see is the
+  one the guide names in the same breath — a cell prop carrying a fresh
+  closure, which never compares equal — and that is the sabotage below.
+
+  ## The three shapes, and the numbers this file pins
+
+  | shape | 5x5 | 10x10 | grows with N? |
+  |---|---|---|---|
+  | the application (fine reads) | 2 | 2 | no |
+  | coarse read, scalar props | 2 | 2 | no — invisible here, see above |
+  | coarse read, closure props | 26 | 101 | YES |
+
+  Two, and not one, in the fine row: the cell's body and its row's total,
+  because the total genuinely depends on the cell that changed. That is
+  *changed rows* in the specification's own sense — the work follows the
+  data — and a witness that had contrived the total away would have
+  measured a grid in which nothing was connected to anything.
+
+  ## The coarse shapes live HERE
+
+  They are anti-patterns, and an anti-pattern belongs in the positive
+  control that has to be able to go red rather than in an application
+  that is evidence about the door. `examples.grid.subs` deliberately
+  registers no whole-grid read, so the coarse subscription below is
+  minted in this namespace too — a cell in the application cannot be
+  written coarsely without somebody adding one."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.examples.grid.app :as app]
+            [re-frame.hicasso.examples.grid.events :as events]
+            [re-frame.hicasso.examples.grid.subs :as subs]
+            [re-frame.hicasso.examples.grid.views :as views]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.test.mounted :as hm]
+            [re-frame.test-support :as test-support]))
+
+;; ---------------------------------------------------------------------------
+;; The two coarse shapes — the guide's named anti-patterns, as controls
+;; ---------------------------------------------------------------------------
+
+(rf/reg-sub ::all-cells
+  {:doc "The whole-grid view-model the application refuses to offer.
+
+  Every keystroke changes this value, which is the whole of what makes
+  the shapes below coarse."}
+  (fn [db _] (:cells db)))
+
+(h/defview coarse-cell
+  "A cell rendered FROM PROPS. Reads nothing; its value arrives from a
+  parent that read the whole grid."
+  [{:keys [row col value]}]
+  [:td [:input {:type "text" :value value
+                :on-input [::events/edit row col ::h/value]}]])
+
+(h/defview coarse-closure-cell
+  "The same, plus the thing the guide names as the case where nothing
+  bails: a callback minted in the parent's render.
+
+  `codec/boundary-props=` compares function-valued props CONSERVATIVELY
+  UNEQUAL — correct, because distinct functions must not bail out — so a
+  props map carrying a fresh closure re-renders every time its parent
+  does."
+  [{:keys [row col value on-edit]}]
+  [:td [:input {:type "text" :value value :data-row (str row) :data-col (str col)
+                :on-input on-edit}]])
+
+(h/defview coarse-grid
+  "The guide's `;; Don't` shape: one whole-grid read at the top, cells
+  rendered from props."
+  [{:keys [closures?]}]
+  (let [cells (h/sub [::all-cells])
+        {:keys [rows cols]} (h/sub [::subs/dimensions])]
+    [:table
+     [:tbody
+      (for [row (range rows)]
+        [:tr {:key (str row)}
+         (for [col (range cols)]
+           (if closures?
+             [coarse-closure-cell
+              {:key     (str col)
+               :row     row
+               :col     col
+               :value   (get cells [row col])
+               ;; A FRESH closure per cell per render. Written with the
+               ;; one callback form, which is the spelling an author
+               ;; reaches for when they want the event itself.
+               :on-edit (h/hfn [e] [::events/edit row col (.. e -target -value)])}]
+             [coarse-cell {:key   (str col)
+                           :row   row
+                           :col   col
+                           :value (get cells [row col])}]))])]]))
+
+;; The fixture snapshots the registrar at the moment THIS form is
+;; evaluated, so it sits below the registrations above — a `use-fixtures`
+;; at the top of the file would strand `::all-cells` and every coarse
+;; mount would refuse.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil}))
+
+;; ---------------------------------------------------------------------------
+;; The instruments
+;; ---------------------------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
+
+(defn- skip! [why]
+  (is true (str "a mounted React root needs a real DOM — " why)))
+
+(def ^:private small {:rows 5 :cols 5})
+(def ^:private full {:rows 10 :cols 10})
+
+(defn- mount-grid!
+  ([dimensions] (mount-grid! dimensions [views/grid {}]))
+  ([dimensions form]
+   (hm/mount! form {:initial-events (app/initial-events dimensions)})))
+
+(defn- cell-node [m row col]
+  (.querySelector (:container m) (str "#" (events/cell-id row col))))
+
+(defn- set-native-value! [n v]
+  (let [d (js/Object.getOwnPropertyDescriptor js/HTMLInputElement.prototype "value")]
+    (.call (.-set d) n v)))
+
+(defn- type-into! [n text]
+  (set-native-value! n (str (.-value n) text))
+  (.dispatchEvent n (js/Event. "input" #js {:bubbles true}))
+  nil)
+
+(defn- bodies-run
+  "How many boundary bodies ran while `f` did — a delta, because the
+  counter is monotone and page-wide."
+  [f]
+  (collector/reset-body-runs!)
+  (f)
+  (collector/body-runs))
+
+(defn- amplification
+  "The bodies one keystroke into cell `[row col]` runs, on a grid of
+  `dimensions` built from `form`."
+  [dimensions form row col]
+  (let [m (mount-grid! dimensions form)
+        n (or (cell-node m row col)
+              (.querySelector (:container m)
+                              (str "[data-row='" row "'][data-col='" col "']"))
+              (nth (array-seq (.querySelectorAll (:container m) "input"))
+                   (+ (* row (:cols dimensions)) col)))]
+    (try
+      (bodies-run #(do (type-into! n "1") (hm/settle! m)))
+      (finally (hm/unmount! m)))))
+
+;; ---------------------------------------------------------------------------
+;; The application scales
+;; ---------------------------------------------------------------------------
+
+(deftest the-grid-mounts-a-hundred-controlled-cells
+  ;; The premise, before anything is measured about it. A scaling claim
+  ;; over a page that rendered five cells would be arithmetic.
+  (if-not (browser?)
+    (skip! "a hundred mounted controls")
+    (let [m (mount-grid! full)]
+      (is (= 100 (.-length (.querySelectorAll (:container m) "input"))))
+      (is (= 10 (.-length (.querySelectorAll (:container m) ".total"))))
+      (is (= "34" (.-value (cell-node m 3 4))))
+      (hm/unmount! m))))
+
+(deftest a-keystroke-costs-the-same-at-25-cells-and-at-100
+  (if-not (browser?)
+    (skip! "the scaling claim")
+    (let [at-25  (amplification small [views/grid {}] 3 4)
+          at-100 (amplification full [views/grid {}] 3 4)]
+      (is (= 2 at-25 at-100)
+          "THE ACCEPTANCE. Two bodies — the cell that was typed into and
+           its row's total, which genuinely depends on it — at both sizes.
+           Quadrupling the mounted cells changed nothing, which is
+           specification §6's `narrow-update body work scales with changed
+           rows rather than all mounted rows`, measured.
+
+           Two and not more is also what pins the layout bodies OUT of the
+           path: `grid` and the ten `grid-row`s read only the dimensions,
+           so a keystroke does not notify them and they are not counted
+           here. Were either on the path this number would be at least
+           three at 5x5 and at least twelve at 10x10.")
+
+      (testing "and a refused keystroke costs the same as an accepted one"
+        ;; The model does not move, so nothing is notified and no body
+        ;; runs at all. Worth pinning: a runtime that re-rendered on every
+        ;; dispatch rather than on every changed READ would answer 2 here.
+        (let [m (mount-grid! full)
+              n (cell-node m 3 4)]
+          (is (= 0 (bodies-run #(do (type-into! n "x") (hm/settle! m))))
+              "a refusal notifies nothing, because the subscription's
+               equality gate stops a value that did not move")
+          (is (= "34" (.-value n))
+              "and the field echoes the COMMITTED value — the refusal half
+               of the controlled law, on the glass")
+          (hm/unmount! m)))))
+
+  (testing "a BROAD update costs what it changed, and not more"
+    (if-not (browser?)
+      (skip! "the broad contrast")
+      (let [m (mount-grid! full)]
+        (is (= 11 (bodies-run #(hm/dispatch-and-settle! m [::events/clear-row {:row 2}])))
+            "ten cells and one total. The narrow number has something to
+             be narrow COMPARED TO, and the same topology produces both —
+             work follows the data, in either direction")
+        (hm/unmount! m)))))
+
+;; ---------------------------------------------------------------------------
+;; The sabotage — a coarse read makes it red
+;; ---------------------------------------------------------------------------
+
+(deftest the-coarse-shape-with-fresh-closures-scales-with-the-GRID
+  ;; THE POSITIVE CONTROL. Without it the row above is green having proved
+  ;; only that this instrument can count to two, and the whole gate could
+  ;; be satisfied by a runtime that never re-rendered anything.
+  (if-not (browser?)
+    (skip! "the sabotage")
+    (let [at-25  (amplification small [coarse-grid {:closures? true}] 3 4)
+          at-100 (amplification full [coarse-grid {:closures? true}] 3 4)]
+      (is (= 26 at-25)
+          "the parent plus every one of 25 cells")
+      (is (= 101 at-100)
+          "the parent plus every one of 100 cells — and the number GREW
+           with the grid, which is the failure mode specification §6
+           names. A cell prop carrying a closure minted in the parent's
+           render never compares equal (`codec/boundary-props=` is
+           conservative about functions, and correctly so), so nothing
+           bails")
+      (is (< at-25 at-100)
+          "stated as the shape rather than as two constants: this is what
+           `converts grid size into per-keystroke cost` looks like from
+           the instrument, and the application's own row is `=` where this
+           one is `<`"))))
+
+(deftest the-coarse-shape-with-scalar-props-is-INVISIBLE-to-this-instrument
+  ;; The honest limit, measured rather than asserted. The guide says the
+  ;; bail-out keeps 99 bodies from running when the props are plain
+  ;; values, and it does — so this shape counts the same as the narrow one
+  ;; while allocating N elements and comparing N props maps per keystroke.
+  ;;
+  ;; It is recorded because a reader of the acceptance row above should
+  ;; know exactly what it does and does not certify: `body-runs` is a
+  ;; measure of BODIES, and the topology claim it supports is about
+  ;; notification, not about allocation.
+  (if-not (browser?)
+    (skip! "the instrument's limit")
+    (let [at-25  (amplification small [coarse-grid {:closures? false}] 3 4)
+          at-100 (amplification full [coarse-grid {:closures? false}] 3 4)]
+      (is (= 2 at-25 at-100)
+          "the parent and the one cell whose props moved. Two, exactly as
+           the application answers — so this gate CANNOT distinguish the
+           two shapes, and a witness that claimed it could would be
+           overstating its instrument. What separates them is the parent
+           being notified at all, and the N props compares and N element
+           allocations that follow; the shape is still wrong, and it is
+           wrong for reasons this counter is blind to")
+      (is (= at-25 at-100)
+          "and it does not grow, which is why the sabotage above needs the
+           closure to be a sabotage at all"))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/subs.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/subs.cljs
@@ -1,0 +1,57 @@
+(ns re-frame.hicasso.examples.grid.subs
+  "THE GRID'S READ TOPOLOGY — the whole of the scaling claim (rf2-hic-078).
+
+  Three subscriptions, and the important one is the shape of the first.
+
+  [[cell]] is parametric on `[row col]`, so a hundred cells are a hundred
+  independently-gated cells under one registration. A keystroke writes
+  one address; exactly one of the hundred recomputes to a different
+  value; exactly one boundary is notified. The other ninety-nine are
+  **never notified** — not notified-and-bailed-out, which is a different
+  and more expensive thing
+  (`docs/design/hicasso/draft-guide/18-performance.md` §The cost of one
+  keystroke).
+
+  [[dimensions]] is read by the grid body and by the row bodies, and it
+  does not move while anybody is typing. That is the second half of the
+  topology: the parent bodies read something a keystroke cannot change,
+  so a keystroke cannot reach them.
+
+  There is deliberately **no `[::all-cells]`**. The guide's named
+  anti-shape is a whole-grid view-model that every keystroke recomputes,
+  and this application does not offer one — so a cell CANNOT be written
+  to read coarsely without somebody adding a subscription for it. The
+  coarse variant the scaling suite measures against is defined in that
+  suite, where an anti-pattern belongs: a testbed models proper
+  re-frame2 and holds no deliberate bad shapes, while a positive control
+  has to be able to make the gate red."
+  (:require [re-frame.core :as rf]))
+
+(rf/reg-sub ::cell
+  {:doc "One cell's value, by coordinate — one `get-in` into one address."}
+  (fn [db [_ row col]] (get-in db [:cells [row col]] "")))
+
+(rf/reg-sub ::dimensions
+  {:doc "`{:rows n :cols n}` — what the grid and its rows lay out from.
+
+  Constant for the life of a mount, which is why the layout bodies may
+  read it: an edge to a value nothing writes costs one equality check at
+  registration and never fires again."}
+  (fn [db _] (:dimensions db)))
+
+(rf/reg-sub ::row-total
+  {:doc "The sum of one row's cells, as a number.
+
+  The application's one DERIVED read, and it earns its place by being the
+  thing a narrow topology has to get right: it depends on `cols` cells,
+  so a keystroke anywhere in the row moves it and the row's total
+  re-renders. That is `changed rows` in the specification's sense — the
+  work follows the data, not the mount — and it is what stops the grid
+  from being a witness in which nothing is ever connected to anything."}
+  (fn [db [_ row]]
+    (let [cols (get-in db [:dimensions :cols] 0)]
+      (transduce (comp (map (fn [col] (get-in db [:cells [row col]])))
+                       (map (fn [s] (if (seq s) (js/parseInt s 10) 0))))
+                 +
+                 0
+                 (range cols)))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/views.cljs
@@ -1,0 +1,93 @@
+(ns re-frame.hicasso.examples.grid.views
+  "THE 100-CELL CONTROLLED GRID — one hundred fields, each written the way
+  the guide writes one (rf2-hic-078).
+
+  [[cell]] is the four-field editor's `text-field` with a coordinate in
+  place of a field keyword. That is the claim this application makes and
+  the reason it is worth having beside the editor: **breadth costs
+  nothing in authoring**. There is no virtualization, no memo hint, no
+  batching call, no `shouldComponentUpdate`, and no second way of writing
+  a field for when there are a hundred of them.
+
+  ## Four boundary kinds, and only one of them is on the typing path
+
+      grid       reads [::subs/dimensions]        — mount only
+      grid-row   reads [::subs/dimensions]        — mount only
+      row-total  reads [::subs/row-total row]     — when ITS row changes
+      cell       reads [::subs/cell row col]      — when ITS cell changes
+
+  A keystroke moves one cell's address. One cell body runs, and one row
+  total runs because its row genuinely changed. Nothing else in the tree
+  is notified — the layout bodies read a value a keystroke cannot touch,
+  and the other ninety-nine cells read addresses the write did not
+  reach. `grid.scaling-dom-cljs-test` measures that count at two grid
+  sizes and asserts it does not move with the size.
+
+  ## The keys are coordinates, and they have to be
+
+  Every child in both `for` loops carries a `:key` derived from its
+  position in the model. A list keyed by index reuses the wrong element
+  the moment the order changes, and on a page of controlled fields that
+  means a caret and a composition landing in the wrong cell with nothing
+  on screen to say so.
+
+  ## What was NOT needed here
+
+  `defview`, `sub`, `::h/value`. That is the entire public surface a
+  hundred controlled fields required — no `::h/revision` (the grid has no
+  reset), no `h/fn` (every intent is a vector, including the
+  three-argument one), and nothing at all from the optional modules or
+  the native tier. `examples.witness-surface-cljs-test` pins it."
+  (:require [re-frame.hicasso :as h]
+            [re-frame.hicasso.examples.grid.events :as events]
+            [re-frame.hicasso.examples.grid.subs :as subs]))
+
+(h/defview cell
+  "One controlled cell. Two props, one read, one intent.
+
+  The intent carries THREE arguments — the row, the column and the
+  marker — and is therefore positional. See `grid.events` §`::h/value` is
+  positional here too."
+  [{:keys [row col]}]
+  (let [id (events/cell-id row col)]
+    [:td
+     [:input {:id           id
+              :type         "text"
+              :size         4
+              :aria-label   (events/cell-label row col)
+              :data-cell    id
+              :value        (h/sub [::subs/cell row col])
+              :on-input     [::events/edit row col ::h/value]}]]))
+
+(h/defview row-total
+  "One row's sum.
+
+  Its own boundary, reading its own row's derived value. Fold it into
+  [[grid-row]] and every keystroke in the row would re-run the row's
+  layout body and props-compare ten cells; here it re-runs one body that
+  renders one number."
+  [{:keys [row]}]
+  [:td.total {:data-total (str row)} (str (h/sub [::subs/row-total row]))])
+
+(h/defview grid-row
+  "One row: its cells and its total.
+
+  Reads the dimensions, which do not move while anybody is typing, so
+  this body runs at mount and not again."
+  [{:keys [row]}]
+  (let [{:keys [cols]} (h/sub [::subs/dimensions])]
+    [:tr {:data-row (str row)}
+     (for [col (range cols)]
+       [cell {:key (str col) :row row :col col}])
+     [row-total {:key "total" :row row}]]))
+
+(h/defview grid
+  "The whole application."
+  [_]
+  (let [{:keys [rows]} (h/sub [::subs/dimensions])]
+    [:main#hundred-cell-grid
+     [:h1 "Grid"]
+     [:table
+      [:tbody
+       (for [row (range rows)]
+         [grid-row {:key (str row) :row row}])]]]))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/witness_surface_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/witness_surface_cljs_test.cljs
@@ -1,0 +1,278 @@
+(ns re-frame.hicasso.examples.witness-surface-cljs-test
+  "THE TWO WITNESSES' IMPORT DISCIPLINE, MECHANICALLY (rf2-hic-078).
+
+  rf2-hic-078's acceptance is *zero impl imports, enforced by a test*.
+  Both witness applications — the four-field editor and the 100-cell
+  grid — are evidence about the PUBLIC DOOR, and they are worth exactly
+  what that claim is worth. So the claim is not made by reading eight
+  `ns` forms: it is read off the ClojureScript analyzer's own dependency
+  graph, including the edges a `:refer`, a `:use` or a `:require-macros`
+  establishes and an `ns`-form regex would miss. See
+  [[re-frame.hicasso.examples.require-graph]] for the mechanism, and for
+  why the emitted graph cannot go stale.
+
+  ## Three claims, and they are different
+
+  [[the-witnesses-name-no-private-namespace]] is the FENCE — no `impl`,
+  no benchmark tree, no tool, no test kit, anywhere in application code.
+  It is a set of predicates, so a namespace minted tomorrow is fenced
+  the day it lands, and [[every-fence-predicate-fires]] is its sabotage
+  control: each predicate is shown one name it must catch and two it
+  must not.
+
+  [[each-witness-names-exactly-these-doors]] is the ROSTER — the exact
+  set of foreign namespaces each application depends on, pinned per
+  application. It is the one that reds when a witness quietly grows a
+  dependency, which a fence cannot see.
+
+  [[neither-witness-registers-a-route]] is the third, and it is here
+  rather than in a routing suite because it is the same kind of fact: an
+  absent edge. rf2-hic-025's finding 8 — route PATHS are plain strings
+  in a process-global registry and this repository's node bundle loads
+  every application into one process — cost twelve RealWorld assertions
+  and warned nobody. Neither witness needs routing to be evidence about
+  controlled fields, so neither reaches `re-frame.routing`, and this row
+  makes that mechanical: a route registered in either application reds
+  here before it can reach the registry."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as str]
+            ;; Required so the analyzer has analysed them when the macro
+            ;; below expands — and, just as load-bearing, so shadow-cljs
+            ;; recompiles THIS namespace when any of them changes.
+            [re-frame.hicasso.examples.editor.app]
+            [re-frame.hicasso.examples.editor.events]
+            [re-frame.hicasso.examples.editor.subs]
+            [re-frame.hicasso.examples.editor.views]
+            [re-frame.hicasso.examples.grid.app]
+            [re-frame.hicasso.examples.grid.events]
+            [re-frame.hicasso.examples.grid.subs]
+            [re-frame.hicasso.examples.grid.views])
+  (:require-macros [re-frame.hicasso.examples.require-graph :as rg]))
+
+(def ^:private witnesses
+  "Each witness application and the namespaces it is made of. Its test
+  suites are deliberately absent: a test may reach past a door the
+  application may not — `scaling-dom-cljs-test` reads the runtime's own
+  body-run counter — which is the whole reason the two are held to
+  different rules."
+  {"the four-field editor"
+   ["re-frame.hicasso.examples.editor.app"
+    "re-frame.hicasso.examples.editor.events"
+    "re-frame.hicasso.examples.editor.subs"
+    "re-frame.hicasso.examples.editor.views"]
+
+   "the 100-cell grid"
+   ["re-frame.hicasso.examples.grid.app"
+    "re-frame.hicasso.examples.grid.events"
+    "re-frame.hicasso.examples.grid.subs"
+    "re-frame.hicasso.examples.grid.views"]})
+
+(def ^:private graph
+  "`{namespace [dependency …]}` for both applications, read off the
+  analyzer at macro-expansion time."
+  (rg/emit-dependency-graph
+    '[re-frame.hicasso.examples.editor.app
+      re-frame.hicasso.examples.editor.events
+      re-frame.hicasso.examples.editor.subs
+      re-frame.hicasso.examples.editor.views
+      re-frame.hicasso.examples.grid.app
+      re-frame.hicasso.examples.grid.events
+      re-frame.hicasso.examples.grid.subs
+      re-frame.hicasso.examples.grid.views]))
+
+(def ^:private app-namespaces
+  (into #{} cat (vals witnesses)))
+
+(defn- foreign-edges
+  "Every dependency `nss` have on a namespace outside the two witnesses,
+  as `[from to]` pairs so a failure names the file to open."
+  [nss]
+  (vec (for [from nss
+             to   (get graph from)
+             :when (not (contains? app-namespaces to))]
+         [from to])))
+
+;; ---------------------------------------------------------------------------
+;; The instrument moves — asserted before anything is asserted WITH it
+;; ---------------------------------------------------------------------------
+
+(deftest the-graph-is-populated
+  (testing "the analyzer answered for every application namespace"
+    (is (= app-namespaces (set (keys graph)))
+        "a namespace the analyzer has not analysed answers an EMPTY edge
+         set, and an empty edge set passes every check below vacuously —
+         so the roster and the graph's key set are compared first"))
+
+  (testing "the reads that matter are present"
+    ;; Positive controls. A fence over an empty graph is green having
+    ;; checked nothing; each row below names an edge that must be there
+    ;; and would be there whatever else moved.
+    (is (some #{"re-frame.hicasso"}
+              (get graph "re-frame.hicasso.examples.editor.views"))
+        "the editor's views depend on the public door")
+    (is (some #{"re-frame.hicasso"}
+              (get graph "re-frame.hicasso.examples.grid.views"))
+        "the grid's views depend on the public door")
+    (is (some #{"re-frame.core"}
+              (get graph "re-frame.hicasso.examples.editor.events"))
+        "the editor's events depend on core")
+    (is (some #{"re-frame.adapter.uix"}
+              (get graph "re-frame.hicasso.examples.grid.app"))
+        "the grid's entry point installs an adapter"))
+
+  (testing "the model tiers depend on NO view substrate"
+    ;; Not a control — a claim, and the sharpest one in this file. The
+    ;; editor's four policies and the grid's digits-only refusal are
+    ;; ordinary re-frame2: they could not tell you a view substrate
+    ;; existed. That is what makes `l0-cljs-test` able to assert the
+    ;; whole model with `=` and a map, and it is the property that would
+    ;; rot first if somebody reached for `h/sub` inside a handler.
+    (doseq [ns' ["re-frame.hicasso.examples.editor.events"
+                 "re-frame.hicasso.examples.editor.subs"
+                 "re-frame.hicasso.examples.grid.events"
+                 "re-frame.hicasso.examples.grid.subs"]]
+      (is (not (some #{"re-frame.hicasso"} (get graph ns')))
+          (str ns' " reached the view door. The model tier is `re-frame.core`
+                and pure functions; a read or a marker in a handler puts the
+                substrate on the L0 suite's classpath and ends its claim")))))
+
+;; ---------------------------------------------------------------------------
+;; The fence
+;; ---------------------------------------------------------------------------
+
+(def ^:private forbidden
+  "The four families application code may not name, each with the reason
+  a failure should print. Predicates rather than a list, so a namespace
+  minted tomorrow is fenced the day it lands."
+  [{:label  "a Hicasso internal"
+    :why    "these applications are evidence about the public door; a
+             reach past it makes the evidence worth nothing"
+    :match? #(str/starts-with? % "re-frame.hicasso.impl.")}
+   {:label  "the benchmark tree"
+    :why    "`re-frame.bench.*` is the measured prototype the package was
+             moved out of; a consumer has no access to it"
+    :match? #(str/starts-with? % "re-frame.bench.")}
+   {:label  "a development tool"
+    :why    "`tools/` is bundle-isolated from production builds — nothing
+             in `implementation/` may require it, and an application is
+             not an exception"
+    :match? #(or (str/starts-with? % "re-frame.xray")
+                 (str/starts-with? % "re-frame.story")
+                 (str/starts-with? % "re-frame.machines-viz"))}
+   {:label  "the test kit"
+    :why    "`re-frame.hicasso.test` and its mounted facade are dev/test
+             surfaces off the artefact's published `:paths`; an
+             application that required one would not ship"
+    :match? #(or (= % "re-frame.hicasso.test")
+                 (str/starts-with? % "re-frame.hicasso.test."))}])
+
+(deftest every-fence-predicate-fires
+  ;; THE SABOTAGE CONTROL. The fence below is green today because both
+  ;; applications are clean, and it would be just as green if a predicate
+  ;; had been written wrong — `starts-with? "re-frame.hicasso.impl"`
+  ;; without the trailing dot, say. So each predicate is shown one name it
+  ;; MUST catch and two it must not, and the rows that matter are the
+  ;; second and third: `re-frame.hicasso` is the public door and
+  ;; `re-frame.core` is the framework, and a fence that swallowed either
+  ;; would fail every application rather than protect one.
+  (let [breaches {"a Hicasso internal" "re-frame.hicasso.impl.collector"
+                  "the benchmark tree" "re-frame.bench.hicasso.front.codec"
+                  "a development tool" "re-frame.xray.mount"
+                  "the test kit"       "re-frame.hicasso.test.mounted"}]
+    (is (= (set (map :label forbidden)) (set (keys breaches)))
+        "every fenced family needs a sabotage row, and a sabotage row with
+         no family is a row that proves nothing")
+    (doseq [{:keys [label match?]} forbidden]
+      (is (true? (boolean (match? (get breaches label))))
+          (str "the " label " predicate does not catch "
+               (pr-str (get breaches label)) " — it would let one through"))
+      (is (false? (boolean (match? "re-frame.hicasso")))
+          (str "the " label " predicate catches the PUBLIC DOOR"))
+      (is (false? (boolean (match? "re-frame.core")))
+          (str "the " label " predicate catches core")))))
+
+(deftest the-witnesses-name-no-private-namespace
+  (doseq [[witness nss] witnesses
+          {:keys [label why match?]} forbidden]
+    (let [breaches (filterv (fn [[_ to]] (match? to)) (foreign-edges nss))]
+      (is (= [] breaches)
+          (str witness " names " label ". " why ".")))))
+
+;; ---------------------------------------------------------------------------
+;; The rosters
+;; ---------------------------------------------------------------------------
+
+(def ^:private expected-doors
+  "Every foreign namespace each witness depends on, and why it is allowed
+  to.
+
+  Pinned per application, and the pin is the point: the fence cannot see
+  a new PUBLIC dependency arriving, and a witness that quietly grew one
+  would stop being the small honest thing a facade freeze reads.
+
+  Read the two columns together. The editor needs `clojure.string` for
+  one normalisation and the grid needs it for one id; both need
+  `re-frame.core`, the door, and an adapter. **Neither needs anything
+  else at all**, and between them they cover four controlled policies,
+  three markers, a reset and a hundred fields."
+  {"the four-field editor"
+   {"clojure.string"       "one normalisation — `slugify`"
+    "re-frame.core"        "events and subscriptions"
+    "re-frame.hicasso"     "the public door — defview, sub, root!, render!"
+    "re-frame.adapter.uix" "the reactive adapter, installed once at boot
+                            (Spec 006 §Adapter selection at boot)"}
+
+   "the 100-cell grid"
+   {"clojure.string"       "one id spelling — `cell-id`"
+    "re-frame.core"        "events and subscriptions"
+    "re-frame.hicasso"     "the public door — defview, sub, root!, render!"
+    "re-frame.adapter.uix" "the reactive adapter, installed once at boot"}})
+
+(deftest each-witness-names-exactly-these-doors
+  (doseq [[witness nss] witnesses]
+    (let [named    (into (sorted-set) (map second) (foreign-edges nss))
+          expected (into (sorted-set) (keys (get expected-doors witness)))]
+      ;; One equality rather than two subset checks, because the failure a
+      ;; reader has to act on is the DIFFERENCE and `=` prints it. A new
+      ;; name on the left is a dependency the witness grew; a name left on
+      ;; the right is a roster entry that has rotted.
+      (is (= expected named)
+          (str witness "'s foreign dependencies moved. Add the new door to
+               `expected-doors` WITH ITS REASON, or take the dependency back
+               out — this roster is the statement of what an ordinary
+               Hicasso application needs, and four doors is the claim.")))))
+
+(deftest every-door-carries-its-reason
+  (doseq [[witness doors] expected-doors]
+    (is (= [] (filterv (fn [[_ why]] (str/blank? why)) doors))
+        (str witness "'s roster has a bare name. A roster whose entries
+             carry no reason is a list, and a list is what this file exists
+             not to be"))))
+
+;; ---------------------------------------------------------------------------
+;; The absent edge that a process-global registry makes load-bearing
+;; ---------------------------------------------------------------------------
+
+(deftest neither-witness-registers-a-route
+  (testing "no application namespace reaches the routing artefact"
+    (doseq [[witness nss] witnesses]
+      (is (= [] (filterv (fn [[_ to]] (= "re-frame.routing" to))
+                         (foreign-edges nss)))
+          (str witness " reached `re-frame.routing`. Route PATHS are plain
+               strings in a PROCESS-GLOBAL registry and this repository's
+               node bundle loads every application in the tree into one
+               process, so an unprefixed path here silently changes which
+               route another suite's URLs resolve to — `reg-route`'s
+               equal-score warning does not fire when the ranks differ
+               (rf2-hic-025 finding 8, filed as rf2-wqnl). If a witness
+               genuinely needs a route, prefix every path with something of
+               its own and add the door to `expected-doors` above."))))
+
+  (testing "the instrument can see a routing edge when there is one"
+    ;; The sabotage. The row above is green because the edge is absent,
+    ;; and it would be equally green if `foreign-edges` answered nothing
+    ;; at all — so it is shown a graph in which the edge IS present.
+    (is (= [["x" "re-frame.routing"]]
+           (filterv (fn [[_ to]] (= "re-frame.routing" to))
+                    [["x" "re-frame.core"] ["x" "re-frame.routing"]]))
+        "the routing filter does not match a routing edge")))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/witness_surface_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/witness_surface_cljs_test.cljs
@@ -210,11 +210,12 @@
   a new PUBLIC dependency arriving, and a witness that quietly grew one
   would stop being the small honest thing a facade freeze reads.
 
-  Read the two columns together. The editor needs `clojure.string` for
-  one normalisation and the grid needs it for one id; both need
-  `re-frame.core`, the door, and an adapter. **Neither needs anything
-  else at all**, and between them they cover four controlled policies,
-  three markers, a reset and a hundred fields."
+  Read the two columns together. **THREE** foreign namespaces build a
+  hundred controlled fields — `re-frame.core`, the door, and an adapter —
+  and the editor's fourth is `clojure.string`, for the one normalisation
+  that makes its slug field a normalising field. Between them the two
+  applications cover four controlled policies, a refusal, three markers,
+  a reset and a hundred fields, and that is the whole list."
   {"the four-field editor"
    {"clojure.string"       "one normalisation — `slugify`"
     "re-frame.core"        "events and subscriptions"
@@ -223,8 +224,7 @@
                             (Spec 006 §Adapter selection at boot)"}
 
    "the 100-cell grid"
-   {"clojure.string"       "one id spelling — `cell-id`"
-    "re-frame.core"        "events and subscriptions"
+   {"re-frame.core"        "events and subscriptions"
     "re-frame.hicasso"     "the public door — defview, sub, root!, render!"
     "re-frame.adapter.uix" "the reactive adapter, installed once at boot"}})
 


### PR DESCRIPTION
Closes rf2-hic-078.

Two witness applications on the Hicasso **public package**, and the suites that measure them. They are evidence about the door: the editor exercises controlled input in depth, the grid exercises breadth, and between them they answer §7's *forms and controlled fields* row and §6's narrow-update budget.

```
implementation/hicasso/test/re_frame/hicasso/examples/
  require_graph.clj                  shared analyzer macro
  witness_surface_cljs_test.cljs     the import fence + the two rosters
  editor/  events subs views app  +  l0, l2, flow_dom
  grid/    events subs views app  +  l0, l2, scaling_dom
```

## The four-field editor

Four controls, four model policies, one boundary each: `:title` accepts, `:slug` lower-cases and collapses non-alphanumeric runs (length-changing, so an echo row cannot pass by echoing nothing), `:body` is the same law on `<textarea>`, `:published?` is the `::h/checked` pair. Plus Save, Discard (the `::h/revision` reset) and a committed readout.

Public surface it needed: **`defview`, `sub`, `root!`, `render!`** and the three markers `::h/value`, `::h/checked`, `::h/revision`. It needed no `hfn`, `use-subs`, `boundary`, `portal`, `as-element`, `as-component`, `defhost`, `hframe`, `route-link` or `reg-state`.

## The 100-cell controlled grid

`cell` is the editor's `text-field` with a coordinate in place of a field keyword — that is the claim. Every cell refuses a non-digit (the refusal half of the controlled law, which the editor's four policies cannot show), each reads one address, and each row carries a derived total so the grid is not a hundred disconnected inputs.

Public surface it needed: **`defview`, `sub`, `root!`, `render!`** and `::h/value`. Nothing else, for a hundred controlled fields.

## The acceptance: narrow-update scaling, measured with a sabotage

`grid/scaling_dom_cljs_test` mounts the **same application** at 5×5 and 10×10, types one character, and counts boundary bodies:

| shape | 5×5 | 10×10 | grows with N? |
|---|---|---|---|
| the application (fine reads) | 2 | 2 | no |
| coarse whole-grid read, scalar props | 2 | 2 | no — invisible to this instrument |
| coarse whole-grid read, **closure props** | 26 | 101 | **yes** |

Two and not one: the cell that was typed into, and its row's total, which genuinely depends on it. Two *and not more* is what pins `grid` and the ten `grid-row`s out of the keystroke path — they read only the dimensions, so they are never notified. A refused keystroke costs **0** bodies; `clear-row` on a 10-wide row costs **11**.

The third row is the positive control the acceptance asks for, and it is the guide's own named case (`docs/design/hicasso/draft-guide/18-performance.md`: *"unless a cell prop carries a fresh closure, in which case nothing bails"*). The second row is recorded because it is the honest limit: `body-runs` measures bodies, not props compares, so this gate cannot see a coarse-but-scalar shape. Saying so is cheaper than a witness that overstates its instrument.

Both coarse shapes and the one deliberately-bad view live in **test** namespaces, not in either application: a witness models proper re-frame2, and an anti-pattern belongs in the control that has to be able to go red. `examples/grid/subs.cljs` deliberately registers no whole-grid read, so a cell cannot be written coarsely without somebody adding one.

## Import discipline, mechanically

`examples/witness_surface_cljs_test.cljs` reads each application namespace's `:requires` / `:require-macros` / `:uses` / `:use-macros` off the **ClojureScript analyzer**, via a `.clj` macro on `cljs.env/*compiler*` — the graph the build was built from, including the `:require-macros` edge `h/defview` arrives through and an `ns`-form regex would miss. Emitted literally into the calling suite, which `:require`s every namespace it asks about, so shadow-cljs recompiles it whenever any of them changes.

The emitted graph, verbatim from `out/cljs-runtime/…witness_surface_cljs_test.js`:

```
editor.app     → adapter.uix, core, hicasso, editor.events, editor.views
editor.events  → clojure.string, core
editor.subs    → core
editor.views   → hicasso, editor.events, editor.subs
grid.app       → adapter.uix, core, hicasso, grid.events, grid.views
grid.events    → core
grid.subs      → core
grid.views     → hicasso, grid.events, grid.subs
```

**Three foreign namespaces build a hundred controlled fields** — `re-frame.core`, `re-frame.hicasso`, `re-frame.adapter.uix`. The editor's fourth is `clojure.string`, for the one normalisation that makes its slug field a normalising field. Rosters are pinned per application with a reason each. Four claims over that graph:

- **the fence** — no `re-frame.hicasso.impl.*`, no `re-frame.bench.*`, no tool (`xray`/`story`/`machines-viz`), no test kit. Predicates, so a namespace minted tomorrow is fenced the day it lands.
- **the sabotage** — every predicate is shown one name it MUST catch (`re-frame.hicasso.impl.collector`, `re-frame.bench.hicasso.front.codec`, `re-frame.xray.mount`, `re-frame.hicasso.test.mounted`) and two it must not (`re-frame.hicasso`, `re-frame.core`), plus a row asserting no family lacks a sabotage row. The routing predicate has its own sabotage: it is shown a graph in which the edge is present.
- **the roster** — one `=` per application; a new door on the left or a rotted entry on the right prints the difference.
- **the model tier names no view door** — `editor.events`, `editor.subs`, `grid.events`, `grid.subs` do not depend on `re-frame.hicasso`, which is what makes both L0 suites able to assert the whole model with `=` and a map.

Vacuity is closed first: `the-graph-is-populated` compares the analyzer's key set against the roster (an unanalysed namespace answers an empty edge set and passes every fence below it) and names four positive-control edges.

## Route paths

**Neither application registers a route**, and that is asserted rather than remembered: `neither-witness-registers-a-route` fails if `re-frame.routing` ever appears in either dependency roster, before a path can reach the process-global registry. A four-field editor and a controlled grid need no routing to be evidence about controlled fields, and rf2-hic-025's finding 8 cost twelve RealWorld assertions with nothing warning.

Everything else these applications mint is a namespaced keyword and therefore safe by construction — frame ids (`::app/frame` in each), event ids, subscription ids, and the two coarse controls' `::all-cells` in the test namespace.

## Which lane compiles these trees

`implementation/hicasso/test` is an existing shadow-cljs `:source-paths` entry, so both lanes reach the new tree with no config change. Confirmed at source rather than assumed — `.github/scripts/report-changed-surfaces.sh` on this branch prints:

```
cljs_node_test=true
cljs_browser=true
```

| suite | ns suffix | lane |
|---|---|---|
| `witness-surface`, both `l0`, both `l2` | `-cljs-test` | `:node-test` (`npm run test:cljs`) and `:node-test-hicasso` |
| `editor.flow`, `grid.scaling` | `-dom-cljs-test` | `:browser-test` (`npm run test:browser`), with a stated skip on the node lane |

No `:source-paths` entry added and `implementation/shadow-cljs.edn` is untouched, per the mayor's placement ruling on rf2-hic-025. No `*.spec.cjs` is added anywhere: the rule that bars them under `examples/` is about the repo-root `examples/` tree, and in any case these suites are CLJS.

## Findings — rf2-hic-025's report, confirmed and refined

**Finding 1 (`::h/value` vs the canonical event-vector shape) — CONFIRMED, and now measured.** `editor/l2_cljs_test` puts both spellings through `ht/materialize`, which is `impl.intent/materialize` itself:

```clojure
(ht/materialize [::edit {:field :title :value ::h/value}] {:value "typed"})
;; => [::edit {:field :title :value :re-frame.hicasso/value}]
```

Not substituted, not refused, not linted — the marker keyword is what reaches the handler. Confirmed at a second arity too: the grid's three-argument `[::edit row col ::h/value]` substitutes fine, so the collision is about DEPTH and does not soften as the payload grows. Both applications write the positional shape at all five marker-carrying intents and say so at their `events` namespaces. The escape hatch is asserted to work and to cost what the report says it costs.

The other half of the contrast has a live exhibit rather than a description: `[::grid.events/clear-row {:row 2}]` and `[::grid.events/seed {:rows 10 :cols 10}]` are the canonical shape, working, on the two handlers that need no substitution.

**Finding 5 (`::h/revision` and the author's own counter) — CONFIRMED, and REFINED.** The `(fnil inc 0)` is load-bearing on the *first* discard for a reason the report did not name: a seed copied from a guide has no `:revision` key at all, so a plain `inc` is a nil arithmetic error rather than a missing reset. Asserted at L0 from an `app-db` that genuinely lacks the key.

The refinement is about *which* fields need it. A field the model **accepted** from has no drift — the model is what the field shows, so a discard moves the value React compares and the wall opens whether the revision moved or not. The bump is load-bearing where the model did **not** take what was typed. `what-the-revision-bump-is-actually-load-bearing-FOR` reaches that state from a normalising field: type a value the slug policy normalises onto the value the article already holds, so the model never moves and the form is not even dirty, then discard.

**Finding 9's "a false attribute is recorded; a nil one is dropped" — CONFIRMED**, and used: the buttons row asserts `(= [false false] …)` rather than `(is (nil? …))`, which would be green against a button with no `disabled` slot at all.

**Findings 2, 3, 4, 6, 7, 8 — not reached.** Neither application uses `route-link`, `use-subs`, top-level `reg-route`, or an async mutation, so these witnesses have nothing to add and say nothing.

## Three new findings, filed

**rf2-5l7l (P2, bug) — the public door's own docstrings show `h/fn`, which is not a var.** Found by copying `as-element`'s docstring example into the editor's L2 suite. `h/fn` is the authoring surface the macro was *named for* and does not exist; the macro is `hfn`. `h/defview`'s docstring already acknowledges the naming gap, so this is not that decision — it is that the most-copied statement of the one callback form is written in a spelling that does not compile. What a consumer gets is a **warning**, not an error:

```
Use of undeclared Var re-frame.hicasso/fn
Use of undeclared Var <your-ns>/e        (one per argument, pointing at the ARGUMENT)
```

The build completes; the page throws at render. Same defect in `impl/intent.cljs`'s docstring.

**rf2-5mxe (P2) — no public or kit instrument answers "how many boundary bodies ran".** §6 states the budget in bodies and asks these two applications to publish it, and there is no door for the number. `hm/census` counts residue, not work. Spec 009's `rf:render:*` measures are compiled out unless `re-frame.performance/enabled?`, which no PR-lane build sets. So both DOM suites `:require` `re-frame.hicasso.impl.collector` to measure the budget of the applications they are witnesses for. **A test may make that reach and the applications may not** — the fence above is over application namespaces, and it holds — but an application cannot measure its own stated budget without one. rf2-hic-045 and rf2-hic-071 both need this.

**rf2-1az6 (P4, chore) — collapse the duplicate `examples` require-graph macro.** PR #7920 landed one inside `examples/slice/`; this PR landed a shared one at `examples/`, because neither branch could require a namespace that was not yet on main. Blocked until both merge.

## Two things that did not hold at source

- **A value-less checkbox is not "controlled" in `ht/controlled?`'s sense.** The converge shadow is for text: `install!`'s `controlled-text-tag?` wants an `input`/`textarea` *and* a non-nil `:value` to re-baseline to, and an idiomatic checkbox has `:checked` and no `:value`. So `published-box` carries no `::h/revision` not by taste but because one there is **refused** with `:rf.error/hicasso-revision-not-controlled`. The view's docstring now says that, and both halves are measured.
- **That refusal is not reachable below L3.** `ht/controlled?` builds props with `codec/convert-props`, which never carries the trigger — only `codec/native-element` stashes it while creating a real element. So L1 sees no revision to refuse and answers quietly. Recorded as a stated limit in `editor/l2_cljs_test`, and the refusal is asserted in `flow_dom_cljs_test` against a real root.

## Quality gates

**Re-run in full on the current `origin/main`** (rebased 2026-08-11 — see below). Every gate run alone with nothing appended, output redirected, exit code captured on the same command line. **The numbers below are the captured ones.**

| gate | command | captured exit |
|---|---|---|
| fast-PR spine | `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine`; its whole-repo node lane ran 13329 tests, 67165 assertions, 0 failures, 0 errors |
| Hicasso node lane | `node scripts/compile-node-test.cjs node-test-hicasso out/node-test-hicasso.js` then `node out/node-test-hicasso.js` | **0** (compile) / **0** (run) — 714 tests, 3001 assertions, 0 failures, 0 errors |
| browser lane, narrowed to `examples/` | `shadow-cljs compile browser-test --config-merge {:ns-regexp "hicasso.examples.*-dom-cljs-test" :test-dir "out/browser-test-witness"}` then `node scripts/serve-and-run-browser-tests.cjs --root out/browser-test-witness --port 8099` | **0** (compile) / **0** (run) — 38 tests, 190 assertions, 0 failures, 0 errors, **0 skips** |
| clj-kondo, new tree | `clj-kondo --parallel --fail-level error --lint implementation/hicasso/test/re_frame/hicasso/examples` | **0** — 0 errors, 0 warnings |
| fast-PR gap | `python scripts/check_fast_pr_gap.py --list` | **0** |

This PR's own contribution is unchanged at **46** node tests and **12** browser tests (12 of the 46 are the two DOM suites running as stated skips on the node lane). The lane totals grew — 667→714 node, 30→38 browser — purely because `main`'s Todo witness (rf2-hic-086) landed in the same tree and is now a sibling. The spine's whole-repo node lane (`npm run test:cljs`) is the one that would catch a process-global registry collision between the four applications now sharing that tree, and it is green.

**Every measured number in the acceptance still holds on the new base**, re-measured in the browser lane with zero skips: the application costs **2** bodies at both 5×5 and 10×10; the coarse-but-scalar shape also **2** at both; the coarse-with-closures sabotage **26** at 5×5 and **101** at 10×10; a refused keystroke **0**; `clear-row` on a 10-wide row **11**.

## Rebase

**Rebased onto current `origin/main`.** One conflict, exactly the one rf2-1az6 predicted: PR #7926 lifted the vertical slice's `examples/slice/require_graph.clj` up to `examples/require_graph.clj` — the same path this branch adds — producing an add/add conflict.

Resolved by **adopting `main`'s single shared copy** and deleting this branch's own, which is what rf2-1az6 asked for and why it is closed as a verified duplicate. No re-pointing was needed: both files declare the same namespace `re-frame.hicasso.examples.require-graph`, and `witness_surface_cljs_test.cljs` already `:require-macros`'d it at the `examples/` root. The two versions were functionally identical — same `emit-dependency-graph` body, and `(remove (conj compiler-edges ns-sym))` vs `(remove #{ns-sym 'cljs.core 'cljs.core$macros 'goog})` compute the same set — so nothing was lost with the docstring.

The other 15 files came through **byte-identical**, verified by blob hash rather than by reading a diff. The PR is now 15 additions and no modifications; `implementation/shadow-cljs.edn`, `implementation/deps.edn`, `spec/**` and `.github/workflows/**` are untouched, and still no `:source-paths` entry is added.

**One stale cross-reference, not fixed here.** `main`'s `daf51631fa` rewrote `docs/design/hicasso/draft-guide/18-performance.md`, renaming §*The cost of one keystroke* (now §*Trace one controlled keystroke* and §*Scale the same topology to a grid*) and dropping the sentence quoted above about a fresh closure. Four docstrings cite the old heading — `editor/l0_cljs_test.cljs`, `editor/subs.cljs`, `editor/views.cljs`, `grid/subs.cljs`. **The guide's substance is unchanged** (the new section still states never-notified, constant typing cost, and cell bodies running when props carry fresh functions), so no measurement or assertion is affected, and no gate checks prose citations. Left for a decision rather than rewritten during a recovery rebase.

**What the spine does not decide.** `check_fast_pr_gap.py --list` reports 97 required checks the spine does not run. The ones this diff actually arms are `cljs-browser` (`npm run test:browser` — the full lane; the two new `-dom-cljs-test` suites were run in it, narrowed, and the full lane is CI's), `cljs-hicasso-controlled`, `cljs-hicasso-hmr`, `migration-hicasso-codemod`, the `clj-kondo` / `splint` lint jobs, and the `Hicasso release build` step inside the node-test job. **The local clj-kondo is v2025.10.23 and CI pins 2026.04.15**, so that pass is a smoke and not a verdict — the versions disagree about which findings are errors. Splint was not run locally.
