### PR TITLE
test(hicasso): the retry row's evidence, and the Xray retained/connected assertion (rf2-7b4m)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/boundary.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/boundary.cljs
@@ -29,7 +29,7 @@
   stayed true when the frame binding below arrived: `contextType` is a
   property of the component, not a hook call, so it is invisible at
   React's dispatcher. `arm1_lifecycle_dom_cljs_test` counts a healthy
-  page there and `arm1_boundary_intent_dom_cljs_test` counts one in its
+  page there and `boundary_intent_dom_cljs_test` counts one in its
   ERROR state, rather than either asserting it here: a page wrapping a
   Hicasso boundary in one of these still reads two.
 

--- a/implementation/hicasso/test/re_frame/hicasso/activity_suspense_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/activity_suspense_cljs_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.hicasso.activity-suspense-cljs-test
-  "ACTIVITY HIDE/REVEAL AND SUSPENSE CONDUCT, AT THE SEAM (rf2-hic-014).
+  "ACTIVITY HIDE/REVEAL, AT THE SEAM (rf2-hic-014).
 
   > - hide releases committed subscription ownership without destroying
   >   re-frame state;
@@ -46,6 +46,27 @@
 
   Driving the seam is emphatically not how a witness says React hides
   anything. That claim is the DOM file's, and this file does not make it.
+
+  ## Nor is a Suspense fallback this seam, and section 6 used to say it was
+
+  The bead pairs Activity with Suspense because the two look like one
+  Offscreen mechanism — the primary tree hidden with `display: none`, its
+  host nodes retained. React 19.2 does not treat them alike: hiding for a
+  **fallback** leaves the primary tree's PASSIVE effects mounted, so the
+  `useSyncExternalStore` subscription survives the suspension and the
+  retry's registration is `identical?` to the pre-suspension one. That was
+  measured, on the browser lane, by
+  [[re-frame.hicasso.activity-suspense-dom-cljs-test/a-post-commit-suspension-retains-the-subscription-and-the-retry-leaves-exact-ownership]]
+  — on the run that row failed, having been written expecting the release
+  the Activity rows assert.
+
+  So **no row in this file speaks for Suspense**. Section 6 drives the
+  detach/reacquire seam four times and once called itself a suspend/retry
+  witness, which was false evidence against the DOM measurement rather
+  than merely loose wording (merged-PR audit #7792): a reader taking it at
+  its name would have believed a retained subscription was released and
+  rebuilt four times over. The algebra was never the false part; the
+  mechanism it was claimed for was.
 
   ## The observable is IDENTITY, never a count
 
@@ -135,7 +156,7 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private declared-population
-  "The Activity/Suspense transitions this file undertakes to exercise.
+  "The Activity transitions this file undertakes to exercise.
   [[the-declared-population-was-actually-exercised]] asserts that every
   one of them was reached at runtime, so the roster cannot drift into a
   list of things the suite used to do."
@@ -145,7 +166,7 @@
     :activity/reveal-reacquires
     :activity/conditional-read-moved-while-hidden
     :activity/retained-intent-across-a-reincarnation
-    :suspense/repeated-hide-reveal-cycles
+    :activity/repeated-hide-reveal-cycles
     :lifecycle/three-states-distinguished})
 
 (defonce ^:private !exercised (atom #{}))
@@ -772,16 +793,22 @@
     (exercised! :activity/retained-intent-across-a-reincarnation)))
 
 ;; ---------------------------------------------------------------------------
-;; 6. Suspense conduct — repeated hide/reveal cycles leave EXACT ownership
+;; 6. Repeated ACTIVITY hide/reveal cycles leave EXACT ownership
 ;; ---------------------------------------------------------------------------
 
-(deftest repeated-suspend-retry-cycles-leave-exactly-one-commits-ownership
-  ;; A Suspense fallback and a hidden `<Activity>` are the same mechanism:
-  ;; React hides the already-committed primary tree, destroying its
-  ;; effects, and re-creates them when the retry resolves. So the conduct
-  ;; a suspend/retry cycle owes is the conduct of a hide/reveal, and the
-  ;; property that a single cycle cannot state is REPETITION — a leak of
-  ;; one membership per cycle looks exactly like a correct single cycle.
+(deftest repeated-hide-reveal-cycles-leave-exactly-one-commits-ownership
+  ;; The property a single cycle cannot state is REPETITION: a leak of one
+  ;; membership per cycle looks exactly like a correct single cycle at the
+  ;; census, and a reveal that found its predecessor's subscription still
+  ;; installed reads exactly like one that rebuilt its own.
+  ;;
+  ;; **This row was named for suspend/retry until merged-PR audit #7792,
+  ;; and that name was false evidence.** The cycle below is the Activity
+  ;; detach/reacquire seam driven four times, and a Suspense fallback is
+  ;; not that mechanism — the DOM row named in this file's ns docstring
+  ;; measured the retained subscription and the retry's `identical?`
+  ;; registration. The arithmetic here was never the false part, so it is
+  ;; unchanged; the mechanism it was claimed for is.
   (async done
     (seeded!)
     (let [!regs (atom [])]
@@ -790,12 +817,12 @@
               reg       (sole-reader [:acs/a])]
           (swap! !regs conj reg)
           (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership))
-              (str "cycle " cycle ": the retry owns exactly one membership"))
+              (str "cycle " cycle ": the reveal owns exactly one membership"))
           (is (some? reg)
               (str "cycle " cycle ": and exactly one registration holds it"))
           (hide! committed)
           (is (zero? (reader-count [:acs/a]))
-              (str "cycle " cycle ": the suspension releases it whole"))))
+              (str "cycle " cycle ": the hide releases it whole"))))
 
       (testing "four cycles, four distinct registrations — no cycle reused a
                 predecessor's, which is what says each reveal genuinely
@@ -812,7 +839,7 @@
               "four reveals, four registration identities — no cycle found a
                subscription still installed")))
 
-      (exercised! :suspense/repeated-hide-reveal-cycles)
+      (exercised! :activity/repeated-hide-reveal-cycles)
 
       (.then (inventory/quiesced!)
              (fn [_]
@@ -903,6 +930,6 @@
   ;; Ordered last by `cljs.test`'s declaration order, which is what makes it
   ;; readable: every row above has run by the time this one does.
   (is (= declared-population @!exercised)
-      (str "every declared Activity/Suspense transition must be reached at
+      (str "every declared Activity transition must be reached at
             runtime. Missing: "
            (pr-str (set/difference declared-population @!exercised)))))


### PR DESCRIPTION
Closes rf2-7b4m. Two findings from the merged-PR audit of #7792, both in the
witnesses rather than the contract texts. **One was still present at source; the
other has already been fixed, under an unrelated subject, and this PR verifies
that rather than re-landing it.**

## Finding 1 — the retry row's false evidence: STILL PRESENT, repaired

`activity_suspense_cljs_test.cljs` carried `deftest
repeated-suspend-retry-cycles-leave-exactly-one-commits-ownership` under the
heading *"6. Suspense conduct"*, opening on the premise:

> A Suspense fallback and a hidden `<Activity>` are the same mechanism: React
> hides the already-committed primary tree, destroying its effects, and
> re-creates them when the retry resolves.

It is not. `activity_suspense_dom_cljs_test.cljs:615`
(`a-post-commit-suspension-retains-the-subscription-and-the-retry-leaves-exact-ownership`)
measured the opposite under real React 19.2 — *on the run that row failed*,
having been written expecting the same release: hiding for a **fallback** leaves
the primary tree's PASSIVE effects mounted, so the `useSyncExternalStore`
subscription survives the suspension and the retry's registration is
`identical?` to the pre-suspension one. The node row drives the Activity
detach/reacquire seam four times; a reader taking it at its name would have
believed a retained subscription was released and rebuilt four times over.

**Repaired by making the claim true, not by weakening the row.** Every assertion
is byte-for-byte unchanged — the arithmetic was never the false part. What
changed is the name (`repeated-hide-reveal-cycles-…`), the section heading, the
declared-population key (`:suspense/…` → `:activity/…`), two per-cycle messages
("the retry owns" → "the reveal owns"; "the suspension releases it whole" → "the
hide releases it whole"), the ns title, and a new ns-docstring section stating
where Suspense conduct is actually measured and what it measured.

This does not touch rf2-hic-014's ruling: option (b) stands, React 3 is
untouched, no hook was added or moved, and no runtime file changed. Reading 1 of
the reveal witness remains what it says it is — a `flushSync` reveal standing in
for the discrete path, not a literal click — and nothing here describes it
otherwise.

## Finding 2 — the Xray retained/connected assertion: ALREADY LANDED, verified

Nothing to do, and the verification is the deliverable. `rf2-hic-023` landed it
in commit `7c45f3ca95` under an unrelated subject, which is why the bead's
relay still named it open. It is present on three surfaces, all citing audit
#7792 by name:

| surface | site |
|---|---|
| producer | `tool.cljs` `host-projection` — `:visibility` and `:hidden-retained` stated as `evidence/unknown` on a `:host-opaque` basis, with the docstring carrying both measured facts |
| producer witness | `tool_reads_cljs_test.cljs:400` `the-census-is-about-subscription-not-visibility` |
| panel witness | `tools/xray/.../panels/hicasso_cljs_test.cljs:249` `the-mounted-census-does-not-claim-the-screen`, over `visibility-note`'s `rf-xray-hicasso-mounted-visibility` |

It carries the fact the ruling required — a Suspense-hidden subtree stays
CONNECTED in these tables while an Activity-hidden one does not — and it refuses
to fabricate the distinction rather than inferring it. Since a green lane cannot
tell a passing assertion from one that never ran, both rows were made to fail in
both directions below before being reported as covering the finding.

## The adjacent one-word item — taken

`impl/boundary.cljs:32` cited `arm1_boundary_intent_dom_cljs_test`, one of the
nine bench originals PR #7918 deleted (`9aa1945028`). Verified still dangling,
and re-pointed to the package counterpart `boundary_intent_dom_cljs_test`, which
carries the same roster including
`the-boundary-spends-no-hook-in-its-error-state-either` — the assertion the
sentence is actually about. The sibling citation `arm1_lifecycle_dom_cljs_test`
in the same sentence was checked and is NOT dangling (the bench file still
exists), so it is left alone.

NOT taken, and flagged rather than fixed: the same word is dangling in
`implementation/freehand/test/re_frame/bench/hicasso/arm1/boundary.cljs:32`. That
file is a prototype ORIGINAL that has drifted 50 lines behind the shipped src,
and the bead fences a bench re-sweep to rf2-3ewp's disposition. Mayor's call.

## Quality gates

Every number below is the one CAPTURED in `<gate>.exit`, read back after the
run; artefacts were deleted between runs so no stale exit file could survive a
fresh log.

| gate | captured exit | result |
|---|---|---|
| `npm run test:cljs` (node lane, baseline) | **0** | 13230 tests / 66728 assertions, 0 failures, 0 errors |
| `npm run test:browser` (browser lane) | **0** | 1261 tests / 7855 assertions, 0 failures, 0 errors |
| `sh scripts/test-fast-pr.sh` (spine) | **0** | `PASS fast PR spine`; classified `docs=false jvm=false node=true` |
| MIF run A — inverted acceptance ×3 | **1** | 3 failures, 0 errors — one per assertion, each naming its line |
| MIF run B — source regressions ×3 | **1** | 62 failures, 1 error — the four rows below among them |

`gate root: /c/Users/miket/code/re-frame2-worktrees/witfix-7b4m` on the spine.
All three source files restored via `git checkout --` and verified by SHA-256
against their pre-sabotage bytes, not by reading `git diff`.

**The browser lane is what decides finding 1's premise**, and it decided it on
this tree: the DOM file's own roster row asserts
`:suspense/post-commit-fallback-and-retry` was reached at runtime, and it passed
— so the retained-subscription measurement my new prose cites really ran under
real React, rather than degrading to the node lane's stated skip.

### Make it fail — Finding 1, both directions

**(a) the instrumentation is not a no-op.** `(= 4 distinct-regs)` → `(= 5 …)`:

```
FAIL in (repeated-hide-reveal-cycles-leave-exactly-one-commits-ownership) (re_frame/hicasso/activity_suspense_cljs_test.cljs:838:15)
expected: (= 5 distinct-regs)
  actual: (not (= 5 4))
```

The `4` is the load-bearing part. The row's identity claim is spelled as
`(count (into #{} @!regs))` on the stated ground that a JS object carries no
`IEquiv`, so the set de-duplicates by `identical?` — verified at source (a
registration is `#js {"reads" … "notify" …}`, minted fresh per `subscribe`) and
now measured: a set collapsing by value would have answered 1.

**(b) the row reds if the runtime regresses.** The unsubscribe closure's
`(doseq [cell cells] (release-cell! cell reg))` neutralised — a hide that does
not release, which is the bead's own named sabotage class. The row goes red on
13 assertions, four of them load-bearing:

```
FAIL … activity_suspense_cljs_test.cljs:824:15   ; "cycle N: the hide releases it whole"
  actual: (not (zero? 4))
FAIL … activity_suspense_cljs_test.cljs:832:13
expected: (= 4 (count (remove nil? (clojure.core/deref !regs))))
  actual: (not (= 4 1))
FAIL … activity_suspense_cljs_test.cljs:838:15
expected: (= 4 distinct-regs)
  actual: (not (= 4 2))
FAIL … activity_suspense_cljs_test.cljs:848:22
expected: (= {:cells 0, :cell-refs 0, :boundaries 0, :edges 0, :entries 0} (inventory/residue))
  actual: (not (= … {:cells 1, :cell-refs 4, :boundaries 4, :edges 4, :entries 0}))
```

The last one is the repetition property doing the work it exists for: **one
leaked membership per cycle, four cycles, four memberships** — the leak a single
correct-looking cycle cannot state.

### Make it fail — Finding 2, both directions

**(a) the assertions are not no-ops.** Inverted:

```
FAIL in (the-census-is-about-subscription-not-visibility) (re_frame/hicasso/tool_reads_cljs_test.cljs:413:9)
expected: (= :FABRICATED-BY-MIF (:hidden-retained hp))
  actual: (not (= :FABRICATED-BY-MIF :unknown))

FAIL in (the-mounted-census-does-not-claim-the-screen) (day8/re_frame2_xray/panels/hicasso_cljs_test.cljs:257:9)
expected: (contains? (testids tree) "rf-xray-hicasso-mounted-visibility-MIF")
  actual: (not (contains? #{… "rf-xray-hicasso-mounted-visibility"} "rf-xray-hicasso-mounted-visibility-MIF"))
```

The second red prints the real testid inside the actual set, so it doubles as
positive evidence the panel renders it.

**(b) both reds if their surface regresses.** `:hidden-retained` dropped from
`host-projection`, and `(visibility-note envelope)` dropped from the mounted
view:

```
FAIL in (the-census-is-about-subscription-not-visibility) (re_frame/hicasso/tool_reads_cljs_test.cljs:413:9)
expected: (= evidence/unknown (:hidden-retained hp))
  actual: (not (= :unknown nil))

FAIL in (the-mounted-census-does-not-claim-the-screen) (…hicasso_cljs_test.cljs:257:9 / :258:9 / :259:9)
  the testid is gone, and the rendered text carries neither "SUBSCRIPTION" nor "Suspense"
```

### What the spine does NOT decide

`python scripts/check_fast_pr_gap.py --list` reports **97 required checks the
spine does not run**, so a green spine is not a green CI. The families that
matter to this diff: the browser lanes (run here separately, exit 0), the
production-elision and bundle-isolation gates, the Xray feature matrix, the
adapter smokes, mcp-conformance, and `scripts/test-jvm-tools.sh`. Three steps
sit INSIDE the `CLJS (shadow-cljs :node-test)` job this spine's node tier
otherwise mirrors — `npm run test:ui-isolation`, `npm run test:bspine-compile`
and `npm run build:hicasso-release` — and report under that job's name rather
than as tests of their own.

## Fences held

- rf2-hic-014's ruling untouched. No third hook; no hook substituted, moved or
  redefined anywhere. No runtime file is in this diff.
- `design-laws.md`, State 6 and Economics 2 not in the diff.
- No hot-zone file touched: no `spec/**`, no `shadow-cljs.edn`, no `deps.edn`,
  no `.github/workflows/**`. `spec/009` (held by #7923) not touched.
- No overlap with any of the four open PRs: #7925's three files, #7923's codec /
  presence / native / spec-009 surface, #7926's `examples/todo/`, and #7924's
  `reincarnation_seams_cljs_test.cljs` are all absent from this diff.
- `tools/xray/spec/*` unchanged, because no Xray behaviour changed — the Xray
  files in this PR's MIF runs were sabotaged and restored byte-identically, and
  spec 027 §"Mounted means subscribed, and the tab says so" already describes
  what is there.
- No overlap with PR #7929's one line in this tree (`intent_cljs_test.cljs:694`):
  the diff is two files, neither of them that one, and it spells no `h/fn`.
