### PR TITLE
feat(hicasso): a kit instrument for boundary-body counts (rf2-5mxe)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/flow_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/flow_dom_cljs_test.cljs
@@ -20,23 +20,19 @@
   numbers from this application. Two of those five are counted here:
   `l0-cljs-test/one-keystroke-moves-exactly-one-address` is the write,
   and [[the-per-keystroke-body-count-is-one-and-does-not-grow]] is the
-  body count, read off `impl.collector/body-runs`.
+  body count, read off [[re-frame.hicasso.test.mounted/bodies-run]].
 
-  **That counter is an internal, and this test reaching it is a finding
-  rather than a convenience.** There is no public or test-kit door that
-  answers *how many boundary bodies ran*. `hm/census` counts cells,
-  edges and boundaries — residue, not work — and the Spec 009 render
-  measures are compiled out unless `re-frame.performance/enabled?`, which
-  no PR-lane build sets. So the one instrument for the budget the
-  specification states is `re-frame.hicasso.impl.collector/body-runs`,
-  and an application's own witness cannot measure its own budget without
-  reaching past the door it is evidence about. Reported by rf2-hic-078;
-  rf2-hic-045 and rf2-hic-071 both need it.
-
-  A test may make that reach — the fence in
-  `examples.witness-surface-cljs-test` is over APPLICATION namespaces,
-  and a test is allowed past a door the application may not. The
-  application itself names nothing but the door.
+  **That door is the kit's, and it used to be an internal's.** This file
+  read `impl.collector/body-runs` directly, because nothing else answered
+  *how many boundary bodies ran*: `hm/census` counts cells, edges and
+  boundaries — residue, not work — and Spec 009's render measures are
+  compiled out unless `re-frame.performance/enabled?`, which no PR-lane
+  build sets. A test is ALLOWED that reach (the fence in
+  `examples.witness-surface-cljs-test` is over APPLICATION namespaces),
+  so this was never a breach; it was an application's own witness unable
+  to state its budget in the vocabulary of the facade that mounted it.
+  Reported by rf2-hic-078, closed by rf2-5mxe, and rf2-hic-045 and
+  rf2-hic-071 both read the same door.
 
   ## Typing is a real DOM event, not a dispatch
 
@@ -53,7 +49,6 @@
             [re-frame.hicasso.examples.editor.events :as events]
             [re-frame.hicasso.examples.editor.subs :as subs]
             [re-frame.hicasso.examples.editor.views :as views]
-            [re-frame.hicasso.impl.collector :as collector]
             [re-frame.hicasso.test.mounted :as hm]
             [re-frame.test-support :as test-support]))
 
@@ -282,14 +277,6 @@
 ;; The per-keystroke body count — §13's second number
 ;; ---------------------------------------------------------------------------
 
-(defn- bodies-run
-  "How many boundary bodies ran while `f` did. A DELTA, because the
-  counter is monotone and page-wide."
-  [f]
-  (collector/reset-body-runs!)
-  (f)
-  (collector/body-runs))
-
 (deftest the-per-keystroke-body-count-is-one-and-does-not-grow
   (if-not (browser?)
     (skip! "a body count needs bodies")
@@ -298,14 +285,14 @@
       ;; The FIRST keystroke of an editing session moves `::subs/dirty?`
       ;; too, so the button row runs with the field. That is the ordinary
       ;; second body run and it is named rather than tuned away.
-      (let [first-burst (bodies-run #(do (type-into! n "a") (hm/settle! m)))]
+      (let [first-burst (hm/bodies-run #(do (type-into! n "a") (hm/settle! m)))]
         (is (= 2 first-burst)
             "the field and the button row — `::subs/dirty?` goes false to
              true exactly once per session"))
 
       (testing "and every keystroke after it runs ONE body"
         (doseq [ch ["b" "c" "d"]]
-          (is (= 1 (bodies-run #(do (type-into! n ch) (hm/settle! m))))
+          (is (= 1 (hm/bodies-run #(do (type-into! n ch) (hm/settle! m))))
               (str "typing " ch " ran a body that was not the title
                     field's. Four controls are on this page and three of
                     them read addresses this keystroke did not move; the
@@ -314,12 +301,12 @@
 
       (testing "including the field that normalises — a policy is not a cost"
         (let [slug (field-node m :slug)]
-          (is (= 1 (bodies-run #(do (type-into! slug "z") (hm/settle! m)))))))
+          (is (= 1 (hm/bodies-run #(do (type-into! slug "z") (hm/settle! m)))))))
 
       (testing "the count is a property of the TOPOLOGY, not of the form's size"
         ;; The editor has four controls. `grid.scaling-dom-cljs-test`
         ;; runs the same measurement over a hundred, and gets the same
         ;; answer — which is the sentence specification §6 asks for.
-        (is (= 1 (bodies-run #(do (type-into! n "e") (hm/settle! m))))))
+        (is (= 1 (hm/bodies-run #(do (type-into! n "e") (hm/settle! m))))))
 
       (hm/unmount! m))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/scaling_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/scaling_dom_cljs_test.cljs
@@ -15,11 +15,15 @@
 
   ## The instrument, and what it can and cannot see
 
-  `re-frame.hicasso.impl.collector/body-runs` counts bodies React
+  [[re-frame.hicasso.test.mounted/bodies-run]] counts bodies React
   actually ran — a `React.memo` bail-out shows up as an increment that
   did not happen, so it measures adoption rather than inferring it from
-  the comparator. A test may reach it; the applications may not, and
-  `examples.witness-surface-cljs-test` is what says so.
+  the comparator. It is the kit's door onto the runtime's own always-on
+  counter (rf2-5mxe); this file read that counter directly until the door
+  existed, which was allowed — the fence in
+  `examples.witness-surface-cljs-test` is over APPLICATION namespaces —
+  but left the application's own witness naming an internal to state a
+  budget the specification states.
 
   **It cannot see a props compare.** That matters for reading the table
   below honestly: the guide's coarse shape with SCALAR props runs the
@@ -59,7 +63,6 @@
             [re-frame.hicasso.examples.grid.events :as events]
             [re-frame.hicasso.examples.grid.subs :as subs]
             [re-frame.hicasso.examples.grid.views :as views]
-            [re-frame.hicasso.impl.collector :as collector]
             [re-frame.hicasso.test.mounted :as hm]
             [re-frame.test-support :as test-support]))
 
@@ -158,14 +161,6 @@
   (.dispatchEvent n (js/Event. "input" #js {:bubbles true}))
   nil)
 
-(defn- bodies-run
-  "How many boundary bodies ran while `f` did — a delta, because the
-  counter is monotone and page-wide."
-  [f]
-  (collector/reset-body-runs!)
-  (f)
-  (collector/body-runs))
-
 (defn- amplification
   "The bodies one keystroke into cell `[row col]` runs, on a grid of
   `dimensions` built from `form`."
@@ -177,7 +172,7 @@
               (nth (array-seq (.querySelectorAll (:container m) "input"))
                    (+ (* row (:cols dimensions)) col)))]
     (try
-      (bodies-run #(do (type-into! n "1") (hm/settle! m)))
+      (hm/bodies-run #(do (type-into! n "1") (hm/settle! m)))
       (finally (hm/unmount! m)))))
 
 ;; ---------------------------------------------------------------------------
@@ -219,7 +214,7 @@
         ;; dispatch rather than on every changed READ would answer 2 here.
         (let [m (mount-grid! full)
               n (cell-node m 3 4)]
-          (is (= 0 (bodies-run #(do (type-into! n "x") (hm/settle! m))))
+          (is (= 0 (hm/bodies-run #(do (type-into! n "x") (hm/settle! m))))
               "a refusal notifies nothing, because the subscription's
                equality gate stops a value that did not move")
           (is (= "34" (.-value n))
@@ -231,7 +226,7 @@
     (if-not (browser?)
       (skip! "the broad contrast")
       (let [m (mount-grid! full)]
-        (is (= 11 (bodies-run #(hm/dispatch-and-settle! m [::events/clear-row {:row 2}])))
+        (is (= 11 (hm/bodies-run #(hm/dispatch-and-settle! m [::events/clear-row {:row 2}])))
             "ten cells and one total. The narrow number has something to
              be narrow COMPARED TO, and the same topology produces both —
              work follows the data, in either direction")

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
@@ -150,7 +150,10 @@
 
   ## Scope
 
-  Dev/test only, and a browser tier: every door needs a real document.
+  Dev/test only, and a browser tier: every DRIVING door needs a real
+  document. The two page-wide readers do not — [[census]] and
+  [[bodies-run]] read runtime tables — but a reading is only worth what
+  built the page it describes, so both belong beside a mount all the same.
   Like `re-frame.hicasso.test` it lives in the kit's own source root
   (`hicasso/test_kit/src`), outside the artefact's published `:paths`, so
   nothing in a production bundle can reach it."

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
@@ -33,6 +33,19 @@
             (is (true? (.-checked (tl/getByRole (:container m) \"checkbox\"))))
             (-> (hm/unmount! m) (hm/assert-clean!) (.then done)))))
 
+  ## Two readers stand outside that pattern
+
+      (hm/census)        → what the runtime RETAINS, right now
+      (hm/bodies-run f)  → how many boundary bodies ran while `f` did
+
+  Neither takes a handle, because neither reads a mount: both are
+  page-wide readings of the runtime. They are opposite numbers and a
+  witness usually wants a particular one of them — [[census]] is residue,
+  what survived, and it is what [[assert-clean!]] compares; [[bodies-run]]
+  is work, what happened, and it is what a budget stated in bodies is
+  asserted with. A keystroke that ran a hundred bodies and a keystroke
+  that ran one leave the same census.
+
   The handle is the runtime's own root handle (`impl.mount`) with this
   namespace's bookkeeping added beside it, so `(:container m)` and
   `(:frame m)` are the real container node and the real frame id rather
@@ -434,6 +447,98 @@
   does, rather than through a second assembly of the same numbers."
   []
   (assoc (inventory/residue) :frames (set (rf/frame-ids))))
+
+;; ---------------------------------------------------------------------------
+;; The work counter — the census's opposite number
+;; ---------------------------------------------------------------------------
+
+(defn bodies-run
+  "**How many boundary bodies ran while `f` did.** [[census]] answers what
+  the page RETAINS; this answers what a change COST.
+
+      (is (= 1 (hm/bodies-run #(do (type-into! n \"a\") (hm/settle! m)))))
+
+  The two are not interchangeable and the difference is the whole reason
+  this door exists. A keystroke that ran one body and a keystroke that ran
+  a hundred leave the SAME census — residue is what survived, not what
+  happened — so a budget stated in bodies (product specification §6,
+  *narrow-update body work scales with changed rows rather than all
+  mounted rows*) could be asserted by nothing this facade offered.
+
+  It is a DELTA, taken by zeroing the runtime's counter and reading it
+  back, because the counter is monotone. `f` is run for its effect and
+  its value is discarded.
+
+  ## Settle inside `f`, or the count is short
+
+  A body React has not run yet is not in this number. `f` must therefore
+  carry whatever makes the work happen *and* whatever commits it —
+  [[settle!]] after a raw DOM event, [[dispatch-and-settle!]] for an
+  intent, [[advance-clock!]] for anything with a delay on it. The doors
+  in this facade all commit through `flushSync`, so a thunk built out of
+  them is settled by construction.
+
+  ## Page-wide, and therefore handle-free
+
+  The runtime keeps ONE integer for the whole process, so this reading
+  cannot be attributed to a mount and does not pretend to be: like
+  [[census]], and unlike every driving door here, it takes no handle. A
+  sibling mount that re-renders while `f` runs is inside the number, and
+  the remedy is the one [[assert-clean!]] already asks for — take the
+  other mounts down, or do not read across them.
+
+  **Nor is there a per-BOUNDARY form**, and that is a fact about the
+  runtime rather than an omission here. Attributing runs to one boundary
+  needs a durable per-boundary id, which `impl.collector` states it
+  cannot have at this arm's fences: the id would have to survive a
+  re-subscribe, the shell has no per-instance storage that is not a React
+  hook, and a third hook breaks the ≤2-hook budget (HD-020) that
+  `hook-budget-cljs-test` enforces at React's own dispatcher. So
+  page-wide is what the counter *is*, and per-boundary attribution is
+  done the way both witness applications do it — arithmetic over an exact
+  expected total.
+
+  ## What it can and cannot see
+
+  It counts bodies React ACTUALLY RAN. The bump is inside the runtime's
+  `run-once`, below React's comparator, so a `React.memo` bail-out shows
+  up as an increment that did not happen — which makes this a measurement
+  of adoption rather than an inference from the comparator's behaviour.
+  React's own end-of-event repair RAISES the count rather than hiding it,
+  which is the safe direction: the repair cannot make a spurious run look
+  like no run.
+
+  **It cannot see a props compare or an element allocation.** A coarse
+  read handing scalar props to N children runs the parent and the one
+  child whose props moved — the same two bodies a narrow shape runs —
+  while allocating N elements and comparing N props maps. Those are real
+  costs and this instrument is blind to them, so a witness that read this
+  number as *the* cost of a keystroke would be overstating it. What it
+  does see is the shape where nothing bails: a child prop carrying a
+  closure minted in the parent's render, which never compares equal.
+
+  ## Why the kit owns it
+
+  The counter is `impl.collector`'s and is always-on by an explicit
+  ruling (rf2-2rtt6.84 (6)) — the arm's builds are `:advanced` with
+  `goog.DEBUG false`, where a debug-gated instrument is not an instrument
+  but dead code. Every consumer of it is a test, so the door belongs at
+  the tier its consumers run on rather than on the public door, and this
+  namespace is where the thing being measured was mounted. It costs a
+  production bundle nothing: the kit sits in `hicasso/test_kit/src`,
+  outside the artefact's published `:paths`, so a consumer that never
+  writes a test never carries it (rf2-5mxe).
+
+  Spec 009's `rf:render:<view-name>` measures are a different instrument
+  and not a substitute. They are compiled out unless
+  `re-frame.performance/enabled?`, which no PR-lane build sets; and the
+  bracket deliberately spans the generation fence's whole retry loop,
+  where this counter bumps once per body INVOCATION — so on a body the
+  fence re-ran the two disagree by design."
+  [f]
+  (collector/reset-body-runs!)
+  (f)
+  (collector/body-runs))
 
 (defn- leaked
   "What `now` has that `baseline` did not — the report's `:leaked` map, or


### PR DESCRIPTION
Closes rf2-5mxe.

## The gap, verified at source

All three of the bead's claims hold:

- **`hm/census` counts residue.** `mounted.cljs` `counted` is `[:cells :cell-refs :boundaries :edges :entries]` plus `:frames` — what is retained, never what ran. A keystroke that ran a hundred bodies and one that ran one leave the same census.
- **Spec 009's `rf:render:*` is unreachable in a PR lane.** Hicasso does emit it (`collector/mint-view!` and `mint-frame-prop-view!` both wrap the component fn in `performance/mark-and-measure :render`), but `performance/enabled?` is a `goog-define` defaulting false, and exactly two builds in `shadow-cljs.edn` flip it: `:node-test-perf-nightly` (nightly, `:ns-regexp "-emit-nightly-test$"`, which cannot select a `-cljs-test$` suite) and `:examples/counter-perf` (a bundle-presence probe that runs no tests). `:node-test`, `:browser-test` and `:node-test-hicasso` set no `:closure-defines`.
- **`impl.collector/body-runs` is the instrument**, always-on by rf2-2rtt6.84 (6), and internal.

Two things did **not** hold as reported, and both matter for the remedy:

1. **The reach-through is the suite's designed idiom, not a breach.** `witness_surface_cljs_test` says so in terms: *"a test may reach past a door the application may not — `scaling-dom-cljs-test` reads the runtime's own body-run counter — which is the whole reason the two are held to different rules."* Its fence is over APPLICATION namespaces only. 19 test files read the counter; 58 require `impl.collector`. So there was no defect to repair — the real cost was narrower: an application's own witness could not state its budget in the vocabulary of the facade that mounted it, and a **consumer's** test would have to name an `impl.` namespace the artefact's `deps.edn` declares "not a consumer surface".
2. **The Spec 009 path answers a different question, not merely an expensive one.** The measure bracket deliberately spans the generation fence's whole retry loop ("the generation fence emits once"), where `body-runs` bumps per body *invocation*. On a body the fence re-ran, the two disagree by design — so the measure stream could not reproduce the numbers below even with both goog-defines flipped.

## Placement

**The test kit**, and it needed no ruling: it adds no public export, touches no hot-zone file, and changes nothing a production build compiles.

- `test.mounted` **already** requires `impl.collector` (for `reset-runtime!`), so the door adds no dependency edge.
- `test_kit/src` is **off** the artefact's published `:paths` (`deps.edn` lists it only under `:aliases/:test/:extra-paths`, with the stated intent that "a consumer that never writes a test never carries it"). `build:hicasso-release` cannot see it.
- Both consumers already require `hm`. Every one of the counter's 19 consumers is a test.

Rejected: a **public export** on `re-frame.hicasso` — no runtime consumer exists, and it would put a test instrument on the published surface. The **Spec 009 path** — hot-zone `shadow-cljs.edn`, changes what a build compiles, and answers a different question.

`bodies-run` is **page-wide and handle-free**, beside `census`. A per-boundary form is not withheld but unavailable: attribution needs a durable per-boundary id, which `impl.collector` states it cannot have at this arm's fences — the id must survive a re-subscribe, the shell has no per-instance storage that is not a React hook, and a third hook breaks the HD-020 budget `hook_budget_cljs_test` enforces at React's own dispatcher.

The 17 runtime suites (`roots_frames_*`, `kernel_commit_owns_*`, `activity_suspense_*`) keep reading `impl.collector` directly, and that line is deliberate: runtime suites read the runtime's counter, application witnesses read the kit's door.

## Quality gates

Each run alone, foreground, redirected, exit code captured on the same command line.

| gate | exit | result |
|---|---|---|
| `npm run build:hicasso-release` | **0** | 162 files, 0 warnings; erasure OK — 5 sentinels absent, 3 positive controls present. The kit door does not reach the `:advanced` / `goog.DEBUG=false` bundle. |
| `npm run test:browser` | **0** | 1284 tests, 7971 assertions, 0 failures, 0 errors |
| `npm run test:browser` **(sabotage control)** | **1** | exactly 2 failures, 0 errors — see below |
| `npm run test:cljs` | **0** | 13329 tests, 67165 assertions, 0 failures, 0 errors |
| `npm run test:hicasso-invariants` | **0** | freeze, optional-module reachability, complaint catalogue |
| `clojure -M:clj-kondo` (pinned 2026.04.15) | **0** | errors 0, warnings 0 |
| `python scripts/check_fast_pr_gap.py --list` | **0** | 97 required checks the spine does not decide |

**The browser lane decides this measurement, and a green aggregate does not prove my rows ran** — a `browser?`-guarded suite passes vacuously via `skip!`. So both witness assertions were sabotaged and the lane re-run: it went red with **exactly 2 failures, 0 errors**, and the actuals are the measured numbers arriving through `hm/bodies-run`:

```
FAIL (a-keystroke-costs-the-same-at-25-cells-and-at-100)
  expected: (= 3 at-25 at-100)
    actual: (not (= 3 2 2))          ← 2 at 5x5 and 2 at 10x10

FAIL (the-per-keystroke-body-count-is-one-and-does-not-grow)
  expected: (= 9 first-burst)
    actual: (not (= 9 2))            ← the editor's first burst
```

Sabotage reverted; `git diff HEAD` empty and the assertions read `= 2` again. (The reverted files' bytes differ from pre-sabotage only because `git checkout` restored CRLF where `sed` had left LF — content verified against HEAD, not against a hash of the working copy.)

**Not run locally:** `cljs-hicasso-controlled` and `cljs-hicasso-hmr` are required jobs whose surface predicate is `implementation/hicasso/**`, so CI will run them. Neither can reach this change — both drive `hicasso/testbed/`, and the kit is off the published `:paths`.

**No measured number was altered.** 2 at both sizes, 0 for a refused keystroke, 11 for `clear-row`, 26 and 101 for the closure-props sabotage — all unchanged, now asserted through the kit.
