### PR TITLE
docs(hicasso): re-point witness docstrings at the guide sections that exist (rf2-gxry)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/codec_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/codec_cljs_test.cljs
@@ -912,8 +912,9 @@
             silently"
     (let [e (codec/as-element [a-host {:class "a" :x/class ["b" :c]}])]
       (is (= "a b c" (prop e "className"))))
-    ;; the guide's own example, asserted verbatim so the page cannot drift
-    ;; from the door (draft-guide/05-interop.md §Defaults)
+    ;; the crossing rule as a worked case — the guide states it as a rule
+    ;; (draft-guide/09-interop.md §Crossing rules) and no longer carries
+    ;; the example this once quoted verbatim
     (is (= "btn on wide"
            (prop (codec/as-element [a-host {:class ["btn" nil :on] :className "wide"}])
                  "className"))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/l0_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/l0_cljs_test.cljs
@@ -25,9 +25,9 @@
   [[one-keystroke-moves-exactly-one-address]] is the L0 half of the
   per-keystroke budget. `flow-dom-cljs-test` counts the bodies that run;
   this counts the addresses that move, and the two together are the walk
-  `docs/design/hicasso/draft-guide/18-performance.md` §The cost of one
-  keystroke describes. It is asserted here rather than there because it
-  is a property of the model and needs no React to be true."
+  `docs/design/hicasso/draft-guide/18-performance.md` §Trace one
+  controlled keystroke describes. It is asserted here rather than there
+  because it is a property of the model and needs no React to be true."
   (:require [cljs.test :refer-macros [deftest is use-fixtures]]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.core :as rf]

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/subs.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/subs.cljs
@@ -3,14 +3,14 @@
 
   Four fields and four subscription cells, because the per-keystroke
   budget is a fact about the READ TOPOLOGY and about nothing else.
-  `docs/design/hicasso/draft-guide/18-performance.md` §The cost of one
-  keystroke walks it: one write, the subscriptions reading that address
-  recompute, equality gates stop every one whose output did not move, and
-  the boundaries whose reads changed are notified. With a field per cell
-  that is **one** changed subscription and **one** body run per
-  keystroke — write amplification 1, independent of how many fields the
-  form has. `editor.flow-dom-cljs-test` measures it rather than asserting
-  the arithmetic.
+  `docs/design/hicasso/draft-guide/18-performance.md` §Trace one
+  controlled keystroke walks it: one write, the subscriptions reading
+  that address recompute, equality gates stop every one whose output did
+  not move, and the boundaries whose reads changed are notified. With a
+  field per cell that is **one** changed subscription and **one** body
+  run per keystroke — write amplification 1, independent of how many
+  fields the form has. `editor.flow-dom-cljs-test` measures it rather
+  than asserting the arithmetic.
 
   [[field]] is PARAMETRIC, so the four cells are four entries under one
   registration rather than four registrations. A parametric subscription

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/views.cljs
@@ -13,12 +13,13 @@
   [[text-field]] is the unit of re-render. Four controls means four
   boundaries, each reading its own address, so a keystroke in the title
   notifies the title's boundary and no other
-  (`docs/design/hicasso/draft-guide/18-performance.md` §The cost of one
-  keystroke). [[editor]] itself reads NOTHING: it is a layout body that
-  runs at mount and, thereafter, only when a prop of its own changes.
-  That absence is the load-bearing part, and `editor.l2-cljs-test`
-  asserts it the only way it can be asserted — by handing the body an
-  EMPTY fixture map and letting the kit refuse any read it makes.
+  (`docs/design/hicasso/draft-guide/18-performance.md` §Trace one
+  controlled keystroke). [[editor]] itself reads NOTHING: it is a layout
+  body that runs at mount and, thereafter, only when a prop of its own
+  changes. That absence is the load-bearing part, and
+  `editor.l2-cljs-test` asserts it the only way it can be asserted — by
+  handing the body an EMPTY fixture map and letting the kit refuse any
+  read it makes.
 
   ## What was NOT needed here
 

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/subs.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/subs.cljs
@@ -9,8 +9,8 @@
   value; exactly one boundary is notified. The other ninety-nine are
   **never notified** — not notified-and-bailed-out, which is a different
   and more expensive thing
-  (`docs/design/hicasso/draft-guide/18-performance.md` §The cost of one
-  keystroke).
+  (`docs/design/hicasso/draft-guide/18-performance.md` §Scale the same
+  topology to a grid).
 
   [[dimensions]] is read by the grid body and by the row bodies, and it
   does not move while anybody is typing. That is the second half of the


### PR DESCRIPTION
Closes rf2-gxry.

PR #7927 (`daf51631fa`) rewrote `docs/design/hicasso/draft-guide/18-performance.md` and split `## The cost of one keystroke` into `## Trace one controlled keystroke` (L128) and `## Scale the same topology to a grid` (L166). Four witness docstrings kept citing the heading that went away. Nothing validates a `§Heading` reference inside a CLJS docstring — `check_doc_slugs.py` resolves markdown links in markdown files — so only a read finds these.

**The guide is not touched.** The rewrite is landed and correct; the citations are what was stale. No measurement, assertion or gate changes: this is comment prose only.

## The per-site choice

The split is semantic, so each docstring was read against both replacement sections rather than mapped by directory.

| Site | Chosen | Why |
|---|---|---|
| `examples/editor/l0_cljs_test.cljs:28` | §Trace one controlled keystroke | Cites "the walk" that `flow-dom-cljs-test` and this file jointly cover. The walk is the seven-step path enumerated in §Trace; §Scale contains no walk. |
| `examples/editor/subs.cljs:6` | §Trace one controlled keystroke | Makes three claims — the write/recompute/equality-gate/notify walk, "write amplification 1", and "independent of how many fields the form has". All three are in §Trace: it enumerates the walk, defines write amplification ("here it is 1"), and states "Other fields are not notified". §Scale adds nothing this docstring claims. |
| `examples/editor/views.cljs:16` | §Trace one controlled keystroke | "a keystroke in the title notifies the title's boundary and no other" is steps 4–5 of §Trace, whose code block is literally a `title-field` view. |
| `examples/grid/subs.cljs:12` | §Scale the same topology to a grid | "**never notified** — not notified-and-bailed-out" is §Scale verbatim: "The other cells are not rendered and then bailed out; they are never notified." §Trace does not make the bailed-out contrast. |

**None of the four wanted both sections**, and none wanted neither. The editor/grid split the bead hypothesised does hold, but it was verified clause-by-clause rather than applied mechanically.

## The sweep found a fifth carrier, and it was worse

`codec_cljs_test.cljs:916` cited `draft-guide/05-interop.md` §Defaults. Three things were wrong with it:

1. That chapter was renumbered to `09-interop.md` by `93ad830cc6`, so the **file path** dangles.
2. §Defaults no longer exists.
3. The comment claimed the row below it was "the guide's own example, asserted verbatim so the page cannot drift from the door" — but the `"btn on wide"` example is **no longer in the guide at all** (`grep -rn "btn" docs/design/hicasso/draft-guide/` finds only unrelated hits in `05-forms.md` and `21-accessibility.md`). The comment asserted something untrue about the assertion beneath it.

Re-pointed at `09-interop.md` §Crossing rules, which still states the rule the row witnesses ("Hicasso class collections are joined"), and the sentence now says what the row actually is rather than claiming a provenance it lost.

## Full grep-hit list, with per-site disposition

Five greps. Every hit was read before it was changed or left.

**A. `git grep -n "18-performance"` — 16 hits**

| Hit | Disposition |
|---|---|
| `draft-guide/01-getting-started.md:75`, `02-views-and-reads.md:314`, `14-testing.md:352`, `14-testing.md:425`, `15-diagnostics.md:103`, `15-diagnostics.md:209`, `15-diagnostics.md:217`, `glossary.md:523`, `glossary.md:537`, `glossary.md:713`, `glossary.md:809` | **Left — correct.** Markdown links to the file with no anchor; the file exists. |
| `draft-guide/REWRITE-NOTES.md:78` | **Left — correct.** Prose naming the file's ownership, no heading cited. |
| `editor/l0_cljs_test.cljs:28`, `editor/subs.cljs:6`, `editor/views.cljs:16`, `grid/subs.cljs:12` | **Changed** — see the table above. |

**B. `git grep -n "§The cost of"` — 4 hits**, the same four. Now returns **exit 1 (no hits)**.

**C. `git grep -n "draft-guide/"` across `implementation/ tools/ skills/ examples/` plus repo root — 12 hits**

| Hit | Disposition |
|---|---|
| `.github/workflows/test.yml:883` | **Left — correct.** A commented-out path glob, not a heading citation. Hot zone; untouched. |
| `docs/EP/EP-0038-…:71`, `:203`, `:391` | **Left — correct.** Names the tree and `02-views-and-reads.md`; both resolve. |
| `implementation/scripts/_changed-surfaces.test.cjs:4201` | **Left — correct.** A test fixture path string (`02-views-and-reads.md`, which exists); a fixture need not resolve anyway. |
| `scripts/check_doc_slugs.py:534` | **Left — correct.** Comment naming `glossary.md` in a hit-count note. |
| `codec_cljs_test.cljs:916` | **Changed** — the fifth carrier, above. |
| the four editor/grid sites | **Changed.** |
| `skills/reagent-migration/spec/inputs.md:51` | **Left — filed as `rf2-cvjp`.** Cites `docs/design/freehand/draft-guide/`, removed by `77126aee8a` when its content was promoted to `docs/core/freehand/`. Not repaired here: it is a *hazard* listing ("dangerous as a source of call shapes"), and the promoted tree is user-facing documentation that is **not** a hazard in that sense — re-pointing would invert the warning. Different tree, different artefact class, and the skill owner's call. |

**D. `git grep -n "05-interop"` — 13 hits, all in `docs/design/hicasso/`** (`studio/raw-escape-design-c-ergonomics.md`, `studio/raw-escape-spec.md`, `studio/reagent-codemod-spec.md`, `defhost-ssr-provider-costing.md`).

**Left — correctly historical.** These are design records of work run against the guide as it then stood, not live pointers. The tree carries an explicit provenance-pinning discipline (`scripts/check_provenance_pins.py` gates changed pages there), and `defhost-ssr-provider-costing.md` §3 is *itself titled* "The guide citation is stale" and rules it: "Worth correcting whenever those pages are next touched; **not worth a PR of its own**." Recorded in `rf2-cvjp` so it is not re-discovered as new.

**E. `git grep -nE '[0-9]{2}-[a-z][a-z-]+\.md'` across `implementation/ tools/ skills/ examples/` — 158 hits**, the catch-all for a guide chapter cited without the `draft-guide/` prefix. Exactly **5** name `hicasso/draft-guide` — the four fixed above plus the `_changed-surfaces.test.cjs` fixture. The other **153** resolve to EP documents, `docs/design/freehand/decisions/D0xx-*`, xray/story spec pages and `ai/findings/*` references — other trees, correct as written. **Left.**

## Is this four sites or a wider class?

**Six source-tree carriers of `draft-guide/` exist in total.** Five were stale and are fixed here; the sixth is `rf2-cvjp`. It is not a wide class — the reverse sweep bounds it, and the bound is the useful result. The design-record tree (D) is larger but is a deliberate historical record with a written deferral ruling.

## Quality gates

`scripts/test-fast-pr.sh` classified this diff `docs=false jvm=false node=true`, so the CLJS node lane — which compiles every changed namespace here — ran. `gate root: /c/Users/miket/code/re-frame2-worktrees/guidecite-gxry`.

| Gate | Captured exit code |
|---|---|
| `sh scripts/test-fast-pr.sh` (run 1) | **1** — environmental, see below |
| `sh scripts/test-fast-pr.sh` (run 2, after fix) | **0** |

Run 1 captured **1** on `CLJS node integration`: `compile-node-test: could not resolve shadow-cljs: Cannot find module 'shadow-cljs/cli/runner.js'`. That is the worktree missing `implementation/node_modules`, not a defect in this diff — no source was compiled at all. Junctioned `implementation/node_modules` at the mayor checkout's real one, deleted the stale `.exit`/`.log` artefacts, and re-ran the gate whole. Run 2 captured **0**, with `[:node-test] Build completed. (2307 files, 2306 compiled, 0 warnings, 69.89s)` and no `FAIL` line anywhere in the log. The junction was removed after the run.

Both runs are reported because the harness announced *"completed (exit code 0)"* for run 1 against a captured **1**. The numbers above are the ones captured to disk and re-read, not the ones the harness announced.

The lanes that actually decide this diff all ran green in run 2: `CLJS node integration` (`npm run test:cljs` — compiles all five changed namespaces), plus the `hicasso invariants`, `hicasso lint export` and `hicasso bench-lane compile` gates.

`scripts/check_fast_pr_gap.py --list` reports **97 required checks the spine does not decide** — the three required contexts are `All required checks passed` (test.yml), `Lint required` (lint.yml) and `Docs required` (docs.yml). Notably undecided here and relevant to a `.cljs` edit: `clj-kondo` and `Splint` under `Lint required` (both surface-gated on the changed `.cljs` files), and the `CLJS (shadow-cljs :browser-test…)` / hicasso browser lanes. Green locally is not green in CI.

**No two-file trap.** `samples_coverage_jvm_test.clj` hashes fenced blocks in `docs/core/freehand/` only (`guide-dir "docs/core/freehand"`); this PR edits no markdown and no guide code block, so no companion regeneration is required.

## Not done

The guide itself — untouched, as ruled.
