### PR TITLE
docs(mayor): verify what the brief asserts, and say the brief is a claim (rf2-owmq)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -89,6 +89,12 @@ it as notes. So read the notes from the bottom up, the description last. Where
 the bead and this brief disagree, the BEAD governs — follow it, and say in your
 report what differed.
 
+THIS BRIEF'S PREMISES ARE CLAIMS, NOT FINDINGS. Check each at source before you
+act on it: that a ruling it names is ruled and not merely recommended, that a gate
+it names covers your path, that a symbol it names resolves. A verified "already
+fixed" or "the premise does not hold" is a complete and good deliverable — report
+it with the evidence rather than going looking for work to do.
+
 Do NOT link gitignored working files (the ai/ tree, findings docs) from committed
 docs — the strict-docs link validator fails the build in cascade. Inline a
 one-sentence summary instead.
@@ -248,6 +254,35 @@ only the index. Which is why **the brief must name the discriminator** — there
 was *who schedules the deferral*, our own collector (repaired to a microtask)
 against React or a timer (still a macrotask). Without it a worker cannot separate
 the stale hits from the correct ones, and will change all of them or none.
+
+## What the brief asserts
+
+A brief states facts about the tree, and the two rules below are about those
+facts rather than about the work. The first is the mayor's discipline while
+writing; the second is one sentence the worker reads.
+
+- **Verify every factual assertion before it goes into the brief.** Each one is
+  checkable in seconds while writing and expensive to catch afterwards. **Read a
+  ruling's STATUS field and quote it** — a recommendation and a ruling read alike
+  in a summary and are opposite in force. **Grep that a named symbol resolves.**
+  For gates the rule is already stated under *Quality gates — the discipline*
+  above, and it generalises: naming the wrong one is worse than naming none,
+  because the worker then trusts a green that means nothing. The cost is not
+  pedantic. One brief twice cited a naming ledger's *Recommendation* column,
+  status `open`, as a settled ruling — for a name that did not resolve either, so
+  a compliant worker would have replaced one non-existent symbol with another, in
+  the files the bead existed to repair, under an authority nobody had granted.
+- **Say in the brief that its premises are claims.** The preamble already tells
+  the worker the bead governs and its notes are read bottom-up, which catches a
+  brief that went *stale* — it does nothing for one that was wrong when written,
+  and on 2026-08-11 three of those went out in a day: the wrong gate named for a
+  surface, a discipline asserted that the method had never contained, and the
+  ledger row above. Every one was caught by the worker. So the preamble states the
+  standing permission in terms: the mayor's premises are claims to be checked at
+  source, and a verified *"already fixed"* or *"the premise does not hold"* is a
+  complete and good deliverable. Workers caught mayor errors at source twelve
+  times that day, three of them preventing damage rather than correcting a word —
+  which makes it the highest-yield sentence in the preamble.
 
 ## Choosing solo vs cluster
 


### PR DESCRIPTION
Closes rf2-owmq.

The method told the mayor to check for **redundancy** before dispatching
(`bootstrap.md:67`, *"Verified-redundant grep before dispatch"* — is the work
already done?). It never told the mayor to check the **facts it was about to
assert**. Three briefs went out on 2026-08-11 naming the wrong gate for a
surface, asserting a discipline the method had never contained, and quoting an
advisory ledger row as a settled ruling. All three were caught by the worker.

The third shows the cost, and it is not pedantic: `docs/design/hicasso/product/naming-ledger.md:7`
carries `h/event` in the **Recommendation** column with **status `open`** — and
`h/event` does not resolve either (`implementation/hicasso/src/re_frame/hicasso.cljc:174`
defines `hfn`, and no `event`). A compliant worker would have replaced one
non-existent symbol with another, in the files the bead existed to repair, under
an authority nobody had granted.

## What changed

Two clauses in `docs/the-mayor-method/dispatch-prompt-template.md`, both short,
placed beside the brief-writing rules the file gained recently (*"hash the
restore"*, *"sweep every carrier"*) and matching their register.

1. **A new `## What the brief asserts` section** (unfenced prose, between
   *Briefing a correction* and *Choosing solo vs cluster*). Two bullets: verify
   every factual assertion while writing — read a ruling's STATUS field and quote
   it, grep that a named symbol resolves — and say in the brief that its premises
   are claims.
2. **One paragraph added to the fenced `text` common-preamble block**, which is
   the artefact pasted verbatim into every dispatch, so the second rule is
   operative rather than aspirational: *"THIS BRIEF'S PREMISES ARE CLAIMS, NOT
   FINDINGS … A verified 'already fixed' or 'the premise does not hold' is a
   complete and good deliverable."* That block already says the bead governs and
   its notes read bottom-up, which catches a brief that went **stale**; it does
   nothing for one that was **wrong when written**. This is the prose-plus-paste-block
   idiom the file already uses for the worktree boundary.

No checklist, no script, no verification step — these are things the mayor does
while writing. Nothing was restated in `bootstrap.md`.

## Premises checked at source (the rule applied to its own bead)

The bead asked for its greps to be re-run, and **one of its three claims does not
hold**:

- **"`dispatch-prompt-template.md`: 0 hits for premise-verification of any kind"
  — DOES NOT HOLD.** The gate half of Rule A has been in the file since
  `81ce0ba455` (2026-07-31), at `dispatch-prompt-template.md:151`: *"Never
  nominate a gate that does not cover the surface being edited … a gate run over
  an excluded path exits green having verified nothing … Read the exclusion
  config before naming the gate."* That is the bead's gate clause and its
  one-line reason, near-verbatim. The new section therefore **cross-references**
  it — *"For gates the rule is already stated under Quality gates — the
  discipline above, and it generalises"* — rather than duplicating it.
- **"`bootstrap.md`: 1 hit, line 67" — HOLDS.** Confirmed, and it is about
  redundancy, not about the brief's own assertions.
- **"the CLAIM sentence: 0 hits in both files" — HOLDS as an exact-phrase grep,
  but the idea is present twice.** See below.

## Decision: *"an audit finding is a CLAIM, not automatically work"* stays out of the method

Argued both ways, decided **not to add it**:

- **For adding it:** a fresh mayor reading only `bootstrap.md` and this template
  never meets the sentence, and it is the clause that stops an audit's output
  being treated as a work queue.
- **Against, and this wins on three counts.** First, the **substance is already
  in the method, twice, where it operates**: Shape 3 ends *"The mayor may
  reorganize/reject findings — not every finding is actioned"*
  (`dispatch-prompt-template.md:304`, which the bead's grep missed because the
  phrase wraps across a line), and `bootstrap.md:340` carries *"An audit that
  reopens an issue may already be stale … Read the current source at the named
  site before dispatching. A verified 'nothing to do' is a good outcome; an
  assumed one is not."* Second, the sentence is a **stance clause**, and this
  file's own opening admonition (lines 17–27) reserves the stance to the single
  file that is pasted verbatim into every preamble, explicitly warning that a
  re-sited paraphrase keeps the permissive half and drops the restraining one.
  Third, a fresh mayor **does** meet it, because the method instructs it to paste
  that file's block into every dispatch.

So the honest gap was never that the idea was missing. It was that nothing told
the mayor to check its own assertions — which is what these two clauses add.

## Quality gates

Every gate run alone, nothing appended, no pipe through `tail`/`head`/`grep`;
redirect and `echo "$?"` on one command line in one shell. Artefacts deleted
between runs and removed at the end (`git status` clean).

| Gate | Command | CAPTURED exit |
|---|---|---|
| MkDocs strict site build | `python -m mkdocs build --strict > gate-mkdocs.log 2>&1; echo "$?" > gate-mkdocs.exit` | **0** |
| Doc slug/anchor authority | `python scripts/check_doc_slugs.py > gate-slugs.log 2>&1; echo "$?" > gate-slugs.exit` | **0** |
| Doc slugs, re-run post-restore | same command | **0** |
| Repo-root + `.claude/commands` md links | `python scripts/check_readme_links.py > gate-readme.log 2>&1; echo "$?" > gate-readme.exit` | **0** |
| Fast-PR gap listing | `python scripts/check_fast_pr_gap.py --list > gate-gap.log 2>&1; echo "$?" > gate-gap.exit` | **0** |

`python -m mkdocs` (not bare `mkdocs`) — the bare form exits 127 here.
`check_readme_links.py` was run although this change touches neither repo-root
markdown nor `.claude/commands/*.md`; it is cheap and it is the owner of that
surface.

**Gate coverage confirmed, not assumed.** `scripts/check_doc_slugs.py`
`DEFAULT_ROOTS` includes `docs` (line 93), and `docs/the-mayor-method` is in
`FENCED_DOC_LINK_TREES` (line 1670), so the edited file is in scope for both the
anchor check and the links-inside-a-fence check.

### Negative control

A broken **markdown** reference (a broken shell/script path is not caught — the
resolver matches `.md`/anchor references only).

- Hashed first: `sha256 6ac3e15062bcaa3494130e7a7ccf8b4ad3e2656b200ec863110473256b357da5`.
- Planted a single-line anchor link `[broken](#no-such-heading-xyzzy-control)` in
  the new section.
- `python scripts/check_doc_slugs.py` → **CAPTURED exit 1**, reporting
  `BROKEN ANCHOR: docs\the-mayor-method\dispatch-prompt-template.md:260 -> #no-such-heading-xyzzy-control`.
  The control **failed as intended**, on the file this PR edits.
- Restored; `sha256sum -c` → **OK** (bytes identical, not a `git diff` read).
- Re-ran the gate → **CAPTURED exit 0**. `git status` clean.

### Fence state, checked line-by-line

Tracked programmatically rather than by eye: the preamble paragraph is at line 92
**inside** the ```` ```text ```` fence (deliberate — it is the paste artefact, and
it contains no markdown links, so `LINK INSIDE A FENCE` cannot fire); the new
section at lines 258–282 is **outside** any fence; no unclosed fence at EOF.

### Required checks this local spine does not decide

`python scripts/check_fast_pr_gap.py --list` (exit **0**) reports **97**, across
all three required status contexts — `All required checks passed` (test.yml, 45
jobs plus steps inside jobs the spine does run), `Lint required` (lint.yml, 5
jobs), and `Docs required` (docs.yml, 1 job). None of them is decided locally;
most are surface-gated and will skip on a diff that reaches only
`docs/the-mayor-method/`. The merge decision is CI's.
