### PR TITLE
bench(hicasso): repoint the heap rig at the package (rf2-fe0l, dispatch 1)

### DIFF
--- a/implementation/core/test/re_frame/bench/p0_heap.cljs
+++ b/implementation/core/test/re_frame/bench/p0_heap.cljs
@@ -82,11 +82,12 @@
             [re-frame.bench.p0-reagent :as rg]
             [re-frame.bench.p0-uix :as ux]
             [re-frame.frame :as frame]
-            ;; THE CANDIDATE'S THREE DOORS, and they are the PACKAGE's
-            ;; (rf2-fe0l). They used to be `re-frame.bench.hicasso.arm1.*`
-            ;; — the frozen prototype `implementation/hicasso/src` was
-            ;; moved from — so every heap figure this file ever produced
-            ;; priced a bench-tree copy rather than the product. The
+            ;; THE CANDIDATE ARM'S THREE DOORS, called at four seams, and
+            ;; they are the PACKAGE's now (rf2-fe0l). They used to be
+            ;; `re-frame.bench.hicasso.arm1.*` — the frozen prototype
+            ;; `implementation/hicasso/src` was moved from — so every
+            ;; heap figure this file ever produced priced a bench-tree
+            ;; copy rather than the product. The
             ;; equivalents are 1:1 and named here so a reader can check
             ;; the claim: `impl.mount/root!` for the mount door,
             ;; `impl.collector/reset-runtime!` for the page-wide fixture
@@ -164,13 +165,13 @@
 
   The unmount is NOT `impl.mount/release!`, and the difference is the
   whole survival metric. `release!` ends with
-  `impl.collector/reset-runtime!`,
-  which drops every cell, edge and cached entry by force — an arm torn
-  down that way would answer zero residue whatever it had leaked, and
-  would also destroy the sibling roots of a multi-root arm. This unmounts
-  the root and nothing else, so React's own `useSyncExternalStore`
-  cleanup is what releases the edges and the references, and the residue
-  the driver reads afterwards is a measurement rather than a reset."
+  `impl.collector/reset-runtime!`, which drops every cell, edge and
+  cached entry by force — an arm torn down that way would answer zero
+  residue whatever it had leaked, and would also destroy the sibling
+  roots of a multi-root arm. This unmounts the root and nothing else, so
+  React's own `useSyncExternalStore` cleanup is what releases the edges
+  and the references, and the residue the driver reads afterwards is a
+  measurement rather than a reset."
   [hiccup-of selector expected]
   {:selector    selector
    :expected    expected

--- a/implementation/core/test/re_frame/bench/p0_heap.cljs
+++ b/implementation/core/test/re_frame/bench/p0_heap.cljs
@@ -72,8 +72,6 @@
   (:require ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]
             [clojure.string :as str]
-            [re-frame.bench.hicasso.arm1.mount :as hic-mount]
-            [re-frame.bench.hicasso.arm1.runtime :as hic-rt]
             [re-frame.bench.hicasso.lane :as lane]
             [re-frame.bench.order-guard :as guard]
             [re-frame.bench.p0-arms :as arms]
@@ -84,6 +82,21 @@
             [re-frame.bench.p0-reagent :as rg]
             [re-frame.bench.p0-uix :as ux]
             [re-frame.frame :as frame]
+            ;; THE CANDIDATE'S THREE DOORS, and they are the PACKAGE's
+            ;; (rf2-fe0l). They used to be `re-frame.bench.hicasso.arm1.*`
+            ;; — the frozen prototype `implementation/hicasso/src` was
+            ;; moved from — so every heap figure this file ever produced
+            ;; priced a bench-tree copy rather than the product. The
+            ;; equivalents are 1:1 and named here so a reader can check
+            ;; the claim: `impl.mount/root!` for the mount door,
+            ;; `impl.collector/reset-runtime!` for the page-wide fixture
+            ;; reset, `impl.inventory/residue` for the structural census.
+            ;; Bench requiring package is the allowed direction;
+            ;; `hicasso/scripts/check_freeze.py`'s SEALED rule forbids
+            ;; only package requiring bench.
+            [re-frame.hicasso.impl.collector :as hic-collector]
+            [re-frame.hicasso.impl.inventory :as hic-inventory]
+            [re-frame.hicasso.impl.mount :as hic-mount]
             [reagent.core :as r]
             [reagent.dom.client :as rdc]
             [uix.dom :as uix-dom]))
@@ -136,12 +149,22 @@
    :unmount-one (fn [rt] (uix-dom/unmount-root rt))})
 
 (defn- hicasso-root-arm
-  "One root of the Hicasso candidate arm (rf2-2rtt6.34), through Arm 1's
-  OWN root door — `arm1.mount/root!` installs the frame provider, renders
-  inside a `flushSync` and returns the handle its `release!` takes.
+  "One root of the Hicasso candidate arm (rf2-2rtt6.34), through the
+  PACKAGE's OWN root door — `re-frame.hicasso.impl.mount/root!` installs
+  the frame provider, renders inside a `flushSync` and returns the handle
+  its `release!` takes.
 
-  The unmount is NOT `arm1.mount/release!`, and the difference is the
-  whole survival metric. `release!` ends with `runtime/reset-runtime!`,
+  **Seam 1 of the four this file pointed at the prototype** (rf2-fe0l).
+  The other three are the runtime reset in [[prepare!]] and the two
+  `residue` reads — the live structural census in [[mount!]] and the
+  post-unmount one in [[install!]]. Nothing else in this file names a
+  substrate, which is why repointing those four is the whole of making
+  the heap ladder price the product instead of the frozen copy it was
+  moved from.
+
+  The unmount is NOT `impl.mount/release!`, and the difference is the
+  whole survival metric. `release!` ends with
+  `impl.collector/reset-runtime!`,
   which drops every cell, edge and cached entry by force — an arm torn
   down that way would answer zero residue whatever it had leaked, and
   would also destroy the sibling roots of a multi-root arm. This unmounts
@@ -381,7 +404,7 @@
    ;; own residue lands in the baseline, and no arm's teardown is ever
    ;; forced — which is what leaves the survival metric something to
    ;; measure (rf2-2rtt6.34).
-   (hic-rt/reset-runtime!)
+   (hic-collector/reset-runtime!)
    (let [segment (first (filter #(= segment-id (:id %)) arms/segments))]
      (when segment (arms/enter-segment! segment (long grid-width))))
    true))
@@ -444,7 +467,7 @@
         live       (live-key-count)]
     (reset! held {:arm (keyword arm-id) :unmount-one unmount-one
                   :handles handles :containers containers})
-    (let [hic (hic-rt/residue)]
+    (let [hic (hic-inventory/residue)]
       #js {:elements     elements
            :expected     want
            :keys         live
@@ -948,11 +971,11 @@
 ;; proportional to the CHANGE, not to the read count. The unchanged case
 ;; allocates nothing", and H1's pre-registered prediction is that "the
 ;; allocation slope across warm 1/3/7/20 reads is FLAT AT ZERO",
-;; **falsified by** a non-flat slope. The mechanism is [[entry-matches?]]
-;; in `arm1/runtime.cljs` — an ordered pairwise compare of the cached
-;; entry's key array against the scratch, which allocates nothing, so a
-;; warm re-render whose read set did not change re-uses `subscribe`'s
-;; identity and the commit does no work.
+;; **falsified by** a non-flat slope. The mechanism is `entry-matches?`
+;; in `re-frame.hicasso.impl.collector` — an ordered pairwise compare of
+;; the cached entry's key array against the scratch, which allocates
+;; nothing, so a warm re-render whose read set did not change re-uses
+;; `subscribe`'s identity and the commit does no work.
 ;;
 ;; That is a claim about EDGE MAINTENANCE and not about the whole render.
 ;; A warm re-render at R reads also allocates R query vectors in the arm's
@@ -1241,7 +1264,7 @@
              ;; HD-002 clause (d)'s failure and a different and worse
              ;; finding than a large per-boundary figure.
              :hicassoResidue (fn []
-                               (let [r (hic-rt/residue)]
+                               (let [r (hic-inventory/residue)]
                                  #js {:cells      (:cells r)
                                       :cellRefs   (:cell-refs r)
                                       :boundaries (:boundaries r)

--- a/implementation/core/test/re_frame/bench/p0_hicasso.cljs
+++ b/implementation/core/test/re_frame/bench/p0_hicasso.cljs
@@ -20,14 +20,25 @@
   both donor rungs are measured here, in one run, in the same rounds, on
   the instrument the published per-read gates are stated on.
 
-  ## The arm IS the runtime, not a model of it
+  ## The arm IS the shipped package, not a model of it
 
-  Every read goes through `re-frame.bench.hicasso.arm1.runtime/sub` — the
-  ambient collector the operator ruled the shipping read surface on
-  2026-07-31 — and every boundary is minted by that arm's own `defview`.
-  Nothing here re-implements the shell, the index, the entry cache or the
-  commit path. A hand-rolled imitation would be pricing this file rather
-  than the design.
+  Every read goes through `re-frame.hicasso/sub` — the ambient collector
+  the operator ruled the shipping read surface on 2026-07-31 — and every
+  boundary is minted by the package's own `defview`. Nothing here
+  re-implements the shell, the index, the entry cache or the commit path.
+  A hand-rolled imitation would be pricing this file rather than the
+  design.
+
+  And it is `implementation/hicasso/src` those doors reach, not the
+  `re-frame.bench.hicasso.arm1.*` prototype the package was moved from
+  (rf2-fe0l). Until this repoint no heap instrument pointed at the
+  package at all: the prototype's own docstring says it lives off every
+  production source path, and `hicasso/scripts/check_freeze.py` says the
+  same from the other side, so a heap figure taken through it priced a
+  frozen copy whose divergence from the product is expected and
+  permanent. The direction of the dependency is the allowed one — the
+  bench tree may require the package; the SEALED rule forbids only the
+  reverse.
 
   ## A loop, and why it is not the UIx arm's unrolling
 
@@ -54,9 +65,9 @@
   Owner: the operator-owned governance set that superseded rf2-2rtt6.1 on
   2026-08-10, enumerated once in `docs/design/hicasso/studio/README.md`;
   this arm rf2-2rtt6.34."
-  (:require [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
-            [re-frame.bench.p0-fixture :as fx])
-  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+  (:require [re-frame.bench.p0-fixture :as fx]
+            [re-frame.hicasso :refer [sub]])
+  (:require-macros [re-frame.hicasso :refer [defview]]))
 
 (defview lad-cell
   "One Hicasso boundary reading `r` DISTINCT subscriptions — the same

--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -284,6 +284,154 @@ test('the printed legend states the R=0 zero rather than the old flat `boundarie
 });
 
 // ===========================================================================
+// WHICH SUBSTRATE THE CANDIDATE ARM IS — rf2-fe0l
+// ===========================================================================
+//
+// THE DEFECT THIS PINS. The heap ladder's candidate arm read
+// `re-frame.bench.hicasso.arm1.*` — the frozen PROTOTYPE that
+// `implementation/hicasso/src` was moved from, and whose own docstring says
+// it lives "off every production source path". So every retained-heap figure
+// the ladder ever produced priced a bench-tree copy, and rf2-hic-006 could
+// not re-pin S1-S5 on the package because no heap instrument pointed at the
+// package at all. The freeze header calls the two trees' divergence expected
+// and permanent, which is exactly why a repoint cannot be left to drift back:
+// nothing about a compiling arm says which of the two it compiled against.
+//
+// WHY IT IS PINNED HERE RATHER THAN LEFT TO THE COMPILER. `:hicasso-bench`
+// compiles both trees, so an arm re-pointed at the prototype tomorrow builds
+// green and reads plausibly — the number simply describes a different piece
+// of software. The compile gate proves the requires RESOLVE; only a source
+// assertion says WHICH ones they were.
+//
+// PARSED FROM THE ns FORM, NEVER GREPPED. Both files legitimately NAME the
+// prototype in prose — the provenance is worth keeping — so a whole-file
+// grep for `arm1` would fail on a docstring that is doing its job. This
+// reads the `:require` / `:require-macros` forms and nothing else, the same
+// rule `hicasso/scripts/check_optional_module_reachability.py` follows one
+// tree over.
+
+const HEAP = path.join(__dirname, 'p0_heap.cljs');
+const CANDIDATE = path.join(__dirname, 'p0_hicasso.cljs');
+
+// `;`-to-end-of-line comments removed, and `"strings"` kept. String-aware,
+// because the heap arm's require form carries both — `"react-dom"` beside a
+// comment block that names the prototype it no longer requires.
+const stripComments = (text) => {
+  let out = '';
+  let inString = false;
+  for (let i = 0; i < text.length; i += 1) {
+    const c = text[i];
+    out += c;
+    if (inString) {
+      if (c === '\\') {
+        out += text[i + 1] ?? '';
+        i += 1;
+      } else if (c === '"') inString = false;
+    } else if (c === '"') inString = true;
+    else if (c === ';') {
+      out = out.slice(0, -1);
+      while (i < text.length && text[i] !== '\n') i += 1;
+      out += '\n';
+    }
+  }
+  return out;
+};
+
+// The `(:require …)` / `(:require-macros …)` forms of `file`, concatenated,
+// with their commentary stripped. Paren-balanced over the stripped text, so
+// a `)` inside a comment cannot end a form early.
+const nsRequires = (file) => {
+  const src = stripComments(fs.readFileSync(file, 'utf8'));
+  let out = '';
+  for (const head of ['(:require ', '(:require-macros ']) {
+    let at = src.indexOf(head);
+    while (at !== -1) {
+      let depth = 0;
+      let i = at;
+      let inString = false;
+      for (; i < src.length; i += 1) {
+        const c = src[i];
+        if (inString) {
+          if (c === '\\') i += 1;
+          else if (c === '"') inString = false;
+          continue;
+        }
+        if (c === '"') inString = true;
+        else if (c === '(') depth += 1;
+        else if (c === ')') {
+          depth -= 1;
+          if (depth === 0) break;
+        }
+      }
+      assert.strictEqual(depth, 0, `${path.basename(file)}: unbalanced ${head}`);
+      out += `${src.slice(at, i + 1)}\n`;
+      at = src.indexOf(head, i + 1);
+    }
+  }
+  assert.ok(out.length > 0, `${path.basename(file)}: no ns require form found`);
+  return out;
+};
+
+// The file with its comments AND its string literals removed — closer to
+// what the COMPILER acts on, so a call site named only in prose or in a
+// docstring cannot satisfy a check.
+const codeOf = (file) => {
+  const src = stripComments(fs.readFileSync(file, 'utf8'));
+  let out = '';
+  let inString = false;
+  for (let i = 0; i < src.length; i += 1) {
+    const c = src[i];
+    if (inString) {
+      if (c === '\\') i += 1;
+      else if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') inString = true;
+    else out += c;
+  }
+  return out;
+};
+
+const countOf = (hay, needle) => hay.split(needle).length - 1;
+
+test('THE CANDIDATE ARM READS THE PACKAGE — its two doors are the facade', () => {
+  const req = nsRequires(CANDIDATE);
+  assert.match(req, /\[re-frame\.hicasso :refer \[sub\]\]/, 'the ambient collector is the package facade');
+  assert.match(
+    req,
+    /\(:require-macros \[re-frame\.hicasso :refer \[defview\]\]\)/,
+    'and boundaries are minted by the package macro'
+  );
+  assert.ok(
+    !/re-frame\.bench\.hicasso\.arm1/.test(req),
+    'p0_hicasso.cljs must not REQUIRE the frozen prototype (naming it in prose is fine)'
+  );
+});
+
+test('THE HEAP RIG READS THE PACKAGE — all three doors, none of them arm1', () => {
+  const req = nsRequires(HEAP);
+  assert.match(req, /\[re-frame\.hicasso\.impl\.mount :as hic-mount\]/, 'the mount door');
+  assert.match(req, /\[re-frame\.hicasso\.impl\.collector :as hic-collector\]/, 'the runtime reset');
+  assert.match(req, /\[re-frame\.hicasso\.impl\.inventory :as hic-inventory\]/, 'the structural census');
+  assert.ok(
+    !/re-frame\.bench\.hicasso\.arm1/.test(req),
+    'p0_heap.cljs must not REQUIRE the frozen prototype (naming it in prose is fine)'
+  );
+});
+
+test('THE FOUR SEAMS CALL THROUGH THOSE ALIASES, and no fifth one is hiding', () => {
+  // Aliases alone prove nothing: a require can be repointed while a call
+  // site keeps the old one. These are the four sites rf2-fe0l enumerated,
+  // counted in the code and not in the commentary.
+  const code = codeOf(HEAP);
+  assert.strictEqual(countOf(code, 'hic-mount/root!'), 1, 'the mount door, once');
+  assert.strictEqual(countOf(code, 'hic-collector/reset-runtime!'), 1, 'the runtime reset, once');
+  assert.strictEqual(countOf(code, 'hic-inventory/residue'), 2, 'the live census and the post-unmount read');
+  // The prototype's alias. Its absence is what says no seam was missed.
+  assert.strictEqual(countOf(code, 'hic-rt/'), 0, 'no call site left on the old alias');
+});
+
+// ===========================================================================
 // THE ALLOCATION ROW'S OBSERVED-COLLECTION WITNESS — rf2-2rtt6.140
 // ===========================================================================
 //

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -1880,7 +1880,7 @@ function summariseAlloc(row, refused) {
 }
 
 // The candidate's structural claim, as numbers the run exits on. The
-// arm IS `arm1.runtime`, so its own index and cell tables can be
+// arm IS the package's own collector, so its index and cell tables can be
 // counted, and "one subscription/epoch hook per boundary plus N edges
 // in a shared index" stops being a sentence in a docstring:
 //


### PR DESCRIPTION
**rf2-fe0l, DISPATCH 1 of 2.** The instrument only. **No figures were taken, and Dispatch 2 remains outstanding** — see the closing section. The bead stays OPEN.

## What was wrong

The P0 retained-heap ladder's candidate arm read `re-frame.bench.hicasso.arm1.*` — the frozen prototype that `implementation/hicasso/src` was moved from — and its own docstring says so: *"Residence: the bench/test tree, off every production source path (HD-017)."* `hicasso/scripts/check_freeze.py` says the same from the other side. So **no heap instrument pointed at the package at all**, which is why `rf2-hic-006` could not deliver its "re-measured on `implementation/hicasso`" item and why S1–S5 in `docs/design/hicasso/product/budgets.md` are still labelled *not re-pinned on the package*.

Verified live at HEAD before touching anything: `front/sub_index.cljs` does not exist anywhere in the tree (the drifted pin's eleventh blob), and `budgets.md` §4 rows S1/S2/S5 do carry the bench-tree flag. Both premises hold.

## The four seams

`p0_heap.cljs` hard-coded the prototype at exactly four candidate call sites and nowhere else. Each now resolves the package:

| # | Seam | Was | Is |
|---|------|-----|-----|
| 1 | mount door, `hicasso-root-arm` | `arm1.mount/root!` | `re-frame.hicasso.impl.mount/root!` |
| 2 | runtime reset, `prepare!` | `arm1.runtime/reset-runtime!` | `re-frame.hicasso.impl.collector/reset-runtime!` |
| 3 | live structural census, `mount!` | `arm1.runtime/residue` | `re-frame.hicasso.impl.inventory/residue` |
| 4 | post-unmount residue, `install!` | `arm1.runtime/residue` | `re-frame.hicasso.impl.inventory/residue` |

`p0_hicasso.cljs`'s two doors become the package facade: `sub` from `re-frame.hicasso`, `defview` via its `:require-macros`.

The equivalents are 1:1, checked at source rather than assumed — `impl.mount/root!` takes the same `[container frame-kw hiccup]` and returns the same `{:root :frame :container}` handle; `impl.mount/release!` still ends with `impl.collector/reset-runtime!`, which is what the survival metric's docstring argues from; `impl.inventory/residue` selects the same five keys off the same `stats`.

**The estimator does not move.** Donors, floor, harness, fixtures, lane collector/fit rules, order-guard and `p0_run.cjs`'s plans are untouched.

**One deliberate departure from the ruling's "`p0_run.cjs` byte-identical".** A single comment line in that file said *"The arm IS `arm1.runtime`"*. Leaving it would be exactly the stale self-identification this repoint exists to end, so it now names the package's collector. Zero executable change; the estimator is untouched. Flagged here rather than done quietly.

## Riding `:hicasso-bench` — ZERO hot-zone

No build id was added and no hot-zone file was touched: not `implementation/shadow-cljs.edn`, not `implementation/deps.edn`, not `spec/**`, not `.github/workflows/**`. `hicasso/src` is already on the top-level `:source-paths` (the comment there names `:hicasso-bench`), and the driver rides that one id through `P0_BUILD` (default `hicasso-bench`, `p0_run.cjs` L119) and `P0_INIT_FN` (default `re-frame.bench.p0-app/-main`, L122), merging `:output-dir` + `:init-fn` in one `--config-merge` line. One id serves N programs; the lane cache is cleared per build. `:hicasso-heap-bench` stays deferred to `rf2-hic-071` under its stopping rule.

## Proof that the rig resolves the package, not the bench arm

A compile proves the requires *resolve*; it does not say **which** namespaces they were — `:hicasso-bench` compiles both trees, so an arm pointed back at the prototype builds green with zero warnings and reads plausibly. It simply prices a different piece of software. So the evidence is the rig's own module graph.

Riding `:hicasso-bench` with the driver's exact `--config-merge` shape and its default `:init-fn`, then reading the emitted namespaces:

```
PRESENT  re_frame.hicasso.impl.mount.js
PRESENT  re_frame.hicasso.impl.collector.js
PRESENT  re_frame.hicasso.impl.inventory.js
PRESENT  re_frame.hicasso.js
PRESENT  re_frame.bench.p0_heap.js
PRESENT  re_frame.bench.p0_hicasso.js
ABSENT   re_frame.bench.hicasso.arm1.runtime.js
ABSENT   re_frame.bench.hicasso.arm1.mount.js
ABSENT   re_frame.bench.hicasso.arm1.lang.js
ABSENT   re_frame.bench.hicasso.front.codec.js
389 namespaces in the rig's graph; build=hicasso-bench initFn=re-frame.bench.p0-app/-main
arm1 namespaces in graph: 0
hicasso.impl namespaces in graph: 32
```

Self-identification now agrees with what is loaded: `p0_hicasso.cljs`'s docstring, `hicasso-root-arm`'s docstring, the HD-002 mechanism citation (`entry-matches?`, now located in `re-frame.hicasso.impl.collector`) and the driver's structural-claim comment all name the package.

## Break and restore

One seam deliberately reverted — the mount door's require put back to `re-frame.bench.hicasso.arm1.mount`, alias unchanged so the call site still compiles.

- Structural witness: **exit 1**, `FAIL THE HEAP RIG READS THE PACKAGE — all three doors, none of them arm1 / the mount door`.
- Module graph: **exit 1** — `LEAKED re_frame.bench.hicasso.arm1.runtime.js`, `LEAKED re_frame.bench.hicasso.arm1.mount.js`, `LEAKED re_frame.bench.hicasso.front.codec.js`; `arm1 namespaces in graph: 4`, graph grown to 401.
- The compile stayed **green with zero warnings** through the break. That is the whole argument for the source assertion.

Restored and verified **by hashing the bytes**, not by `git diff`:

```
before  4c4fb8b6200e6f67773e139730e4a088e65346fb09ea8da9a1e1d42f6ed17996 *p0_heap.cljs
        e8a060959fea217c97ed6ea29310a7bb3a0e43135af56b29b7b83daa1e7bc8be *p0_hicasso.cljs
after   4c4fb8b6200e6f67773e139730e4a088e65346fb09ea8da9a1e1d42f6ed17996 *p0_heap.cljs
        e8a060959fea217c97ed6ea29310a7bb3a0e43135af56b29b7b83daa1e7bc8be *p0_hicasso.cljs
```

(`p0_heap.cljs` carries further docstring reflows committed after that hash was taken. The spine below ran against the final bytes and reports `p0_ladder_structural.test.cjs: 53 passed` and `[hicasso-compile] ok — 124 lane namespaces compiled with zero warnings` from within its own run.)

## Quality gates

Every gate run alone, foreground to completion, output redirected and the exit code echoed on the same command line. `*.exit` artefacts deleted between runs.

| Gate | Command | CAPTURED exit |
|---|---|---|
| Ladder structural witness | `node core/test/re_frame/bench/p0_ladder_structural.test.cjs` | **0** — 53 passed |
| Hicasso bench-lane compile | `npm run test:hicasso-compile` | **0** — 124 lane namespaces, 0 warnings |
| Hicasso invariants (FREEZE / MOVED / SEALED) | `npm run test:hicasso-invariants` | **0** — *1 frozen row matches; no package file imports it* |
| Rig module-graph resolve check | ad-hoc, riding `:hicasso-bench` via `P0_BUILD`/`P0_INIT_FN` | **0** |
| Break-the-seam: structural | as above, one seam reverted | **1** (expected) |
| Break-the-seam: module graph | as above, one seam reverted | **1** (expected) |
| Fast-PR spine | `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine` |
| Fast-PR gap listing | `python scripts/check_fast_pr_gap.py --list` | **0** |

### What the spine does NOT decide

`check_fast_pr_gap.py --list` reports **97** required checks the spine does not run. Green here is not green in CI. The ones nearest this diff:

- `lint.yml` — **clj-kondo** (CI pins 2026.04.15; a differently-versioned local pass proves nothing) and **Splint**, both of which lint `implementation/`, and both of which see the three changed CLJS/CJS files.
- `test.yml` job *CLJS (shadow-cljs :node-test)* — the steps `test:bspine-compile` (a separate bench roster; `p0_heap`/`p0_hicasso` are not on it, they are on the hicasso compile gate's roster, which is run above) and `build:hicasso-release`.
- The `cljs-hicasso-controlled` and `cljs-hicasso-hmr` browser jobs, which have no lane in the spine at all. Neither touches the bench tree.
- `beads-pr-boundary` — no `.beads` path is in this diff.

## What this PR deliberately does NOT touch

`docs/design/hicasso/product/budgets.md` (its package figures do not exist yet), `implementation/shadow-cljs.edn`, the freehand donor tree, `frozen-sources.edn` (its one frozen row is `front/slot.cljc`, untouched), and `rf2-hic-018`'s `substrate_*` benches.

## Dispatch 2 is outstanding — NO FIGURES WERE TAKEN

Nothing here was measured. Not one heap reading, not one timing, not one number of any kind was produced or published, and none may be inferred from the wall-clock in these logs — three other workers were compiling throughout. The rig was built and its module graph read; that is all.

**`rf2-fe0l` stays OPEN.** Dispatch 2 is one solo Shape 6 quiet-window run — the package arm and **both** donor arms in the same run set, on the operator-granted quiet box — and it is the re-pin PR. The rig is frozen at this PR's merge; any later change to it invalidates the window and repeats it. A refusal in that window is a deliverable, not a thing to iterate the instrument against.

Two frozen decisions from the ruling, carried into everything written here:

- **The shell paper-fail line is frozen at 1,024 B.** The ambiguous `1 KB` spelling retires. (No wording in this PR restates a shell figure; §5 of `budgets.md` is Dispatch 2's.)
- **A confidence band crossing 1,024 B is UNRESOLVED, not a pass**, and no substrate is selected on a point estimate inside that band. Nothing in this PR should be read as implying otherwise.
