### PR TITLE
bench(hicasso): the package heap figures, measured (rf2-fe0l, dispatch 2)

### DIFF
--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -106,13 +106,14 @@ have opposite operational rules:
 | Machine sensitivity | **none** — a counter reads the same on a loaded box | high — needs a quiet window |
 | Where it belongs | ordinary blocking PR gates | pinned interleaved evidence runs |
 | Profile needed | any | P-DEV-1 only |
-| Anchored on `implementation/hicasso` today? | **yes** | **no** — see §6 |
+| Anchored on `implementation/hicasso` today? | **yes** | **the heap rows S1–S5, yes** — since 2026-08-12, §6; the clock rows, no |
 
 The practical consequence, and the reason it is worth naming: **the
 deterministic family did not need this measurement window at all.** A body
 count is a delta on a monotone integer counter; contention cannot move it. Only
-the distributional family needs the quiet box — and that is exactly the family
-this page could not re-pin.
+the distributional family needs the quiet box — which is exactly why this page
+could not re-pin that family when it was written, and why the re-pin it refused
+had to be taken later, alone, in a window of its own.
 
 ---
 
@@ -155,29 +156,54 @@ control that gives the row its meaning: the same app in a coarse shape scales
 and D1/D2's flatness is a property of the topology, not of a blind instrument.
 
 **On D9.** This is teardown residue in **counters and objects**, which is a
-deterministic reading the package can make. It is *not* the evidence
-baseline's teardown row, which is stated in **retained bytes** on the pinned
-heap arms — a distributional figure, and one of the three this page could not
-re-pin. The two must not be conflated: a mount can leave zero residue counters
-and still retain bytes.
+deterministic reading the package can make. It is *not* S5, the teardown row
+stated in **retained bytes** — a distributional figure, taken in its own quiet
+window and re-pinned on the package only on 2026-08-12. The two must not be
+conflated: a mount can leave zero residue counters and still retain bytes, and
+the two halves are not interchangeable evidence even now that both are package
+figures. D9's counters are **exactly** zero; S5's bytes are *indistinguishable
+from* zero, which is the strongest form a distributional reading takes.
 
 ---
 
-## 4. Distributional rows, carried forward and NOT re-pinned
+## 4. Distributional rows — S1–S5 re-pinned on the package, S6–S7 carried
 
-Every figure here is carried unchanged from
-[the evidence baseline](lanes/evidence-baseline.md#pinned-economic-evidence).
-None was re-measured on `implementation/hicasso`, for the reason in §6.
+**S1–S5 are package figures as of 2026-08-12.** They were re-measured on
+`implementation/hicasso` in one solo quiet-window run, on the same P0 ladder
+`rf2-hic-006` had to refuse — repointed at the package by PR #7939 and read
+through by `rf2-fe0l`. **S6 and S7 are still carried unchanged** from
+[the evidence baseline](lanes/evidence-baseline.md#pinned-economic-evidence)
+and are **not** package figures: no package-resident clock instrument exists,
+and the allocation row has no publishable claim to re-pin.
 
 | # | Estimand | Pinned figure | Instrument | Status |
 |---|---|---|---|---|
-| S1 | R=0 boundary shell, Reagent segment | `1,103 B` | P0 bench ladder, bench-tree candidate arm | not re-pinned on the package |
-| S2 | R=0 boundary shell, UIx segment | `1,097 B` | as S1 | not re-pinned on the package |
-| S3 | Per-read retained, Hicasso vs Reagent | `1,278` vs `947 B/read` | as S1 | K3 scoreboard (a) — owned by `rf2-hic-070` |
-| S4 | Per-read retained, Hicasso vs UIx | `2,115` vs `2,980 B/read` | as S1 | K3 scoreboard (b) — owned by `rf2-hic-070` |
-| S5 | Teardown, retained **bytes** | zero on the pinned heap arms | as S1 | not re-pinned on the package |
-| S6 | Cold mount vs direct UIx-on-subs | `1.1718x` [1.1263–1.2190] n=8; `1.1976x` [1.1504–1.2468] n=6 | final K1 estimator | registered `1.10x` gate missed; `1.25x` is a *proposal* only |
-| S7 | Warm allocation | no publishable claim | allocation instrument | no fitted series clears the quality floor |
+| S1 | R=0 boundary shell, Reagent segment | `1,100 B` [1,091–1,107] | P0 ladder, **package** candidate arm | **package figure** — over the frozen `1,024 B` line in every round |
+| S2 | R=0 boundary shell, UIx segment | `1,095 B` [1,087–1,101] | as S1 | **package figure** — over `1,024 B` in every round |
+| S3 | Per-read retained, Hicasso vs Reagent | `1,417` vs `948 B/read` | as S1 | **package figure**; K3 scoreboard (a) — owned by `rf2-hic-070` |
+| S4 | Per-read retained, Hicasso vs UIx | `2,115` vs `2,980 B/read` | as S1 | **package figure**; K3 scoreboard (b) — owned by `rf2-hic-070` |
+| S5 | Teardown, retained **bytes** | indistinguishable from zero — all ten candidate rungs' bands straddle 0 | as S1 | **package figure** |
+| S6 | Cold mount vs direct UIx-on-subs | `1.1718x` [1.1263–1.2190] n=8; `1.1976x` [1.1504–1.2468] n=6 | final K1 estimator | **bench-tree figure** — registered `1.10x` gate missed; `1.25x` is a *proposal* only |
+| S7 | Warm allocation | no publishable claim | allocation instrument | **bench-tree** — no fitted series clears the quality floor |
+
+The run's evidence, its controls and its full provenance are
+[on the ladder's studio page](../studio/reads-per-boundary-heap-ladder.md#the-package-itself-priced-on-this-rung-at-last-rf2-fe0l);
+what follows is only what the re-pin does to this page's rows.
+
+**S3 is the one figure that moved, and the instrument says it is the
+candidate's.** Nine of the ten quantities the run took — both donors, both
+floors, both shells and the UIx-segment slope — came back on the prototype's
+published anchors. S3's candidate slope did not: `1,278 → 1,417 B/read`,
+`+139 B` and `+10.9%`, with the two bands disjoint. The governed contrast
+against Reagent therefore deepens from `1.3492×` to `1.4953×`, while S4's win
+against UIx is unchanged to the fourth decimal (`0.7099× → 0.7098×`).
+**Attribution is `rf2-hic-018`'s**, and it is deliberately not attempted here:
+the window's terms are a single invocation, and the ablations that would name a
+cause are exactly what a measurement window may not run.
+
+**S1 and S2 carry the substantive news for the shell.** The breach is not an
+artefact of the prototype — it survives the move to the package essentially
+unchanged, at `1,100` and `1,095 B` against `1,103` and `1,097 B`.
 
 **S6 carries a standing prohibition.** The `1.25x` cold-mount ceiling is a
 proposal pending the operator's sitting. Until ratification the registered
@@ -209,14 +235,52 @@ not, and cannot be until a package-resident clock instrument exists.
 | Cold mount ≤ 1.25x direct UIx (subject to ratification) | proposal only; `1.10x` registered line stands |
 | Broad updates ≤ 1.25x best relevant adapter after topology tuning | 1.25–1.5x is a **warning band**: attribute cause, one bounded topology pass, test a local island |
 | Sustained > 1.5x | cannot graduate as ordinary Hicasso until fixed or deliberately classified a native-host use case |
-| R=0 shell meets the frozen byte-exact `1 KB` line | **not** governed by baseline-plus-10%; see §5 |
+| R=0 shell meets the frozen byte-exact `1,024 B` line | **not** governed by baseline-plus-10%; see §5 |
 | Per-read retained ≤ 10% regression on same pinned witness | governed by the K3 disposition (`rf2-hic-070`) |
 | Native island within 5% or 1 ms of the same component mounted directly | co-instrumented against both handwritten React and UIx |
 | An escape recovers ≥ 20%, saves ≥ 2 ms p95, or converts a failed budget to a pass | an island missing its threshold is simplified or removed — **thresholds do not widen to keep it** |
 
 ---
 
-## 5. The read-free boundary shell: the byte-exact line
+## 5. The read-free boundary shell: the byte-exact line, now FROZEN at 1,024 B
+
+> **RULED, 2026-08-12 (operator-directed, operator-overturnable).** The paper-fail
+> line is frozen at the literal **`1,024 B`**. Spell it that way everywhere; the
+> ambiguous `1 KB` spelling retires. Adopted with it: **a confidence band that
+> crosses 1,024 B is UNRESOLVED, not a pass**, and no substrate is selected on a
+> point-estimate difference inside that band. The ruling text is on `rf2-fe0l`.
+>
+> The rest of this section is the record of *why* the freeze was needed and
+> what it does and does not decide. It is kept as written — the recommendation
+> below is the reasoning the ruling adopted, not a live question — because a
+> page edited to look as though it had always known the answer stops being a
+> record of how the answer was reached.
+
+### What the package reading does to this row
+
+The shell has now been measured on `implementation/hicasso` itself
+([the run](../studio/reads-per-boundary-heap-ladder.md#the-package-itself-priced-on-this-rung-at-last-rf2-fe0l)),
+and the freeze is **not load-bearing for the present verdict** on either tree:
+
+| R=0 shell | Reagent segment | UIx segment | worst round | vs `1,024 B` |
+|---|---:|---:|---:|---|
+| pinned baseline row (bench tree) | 1,103 B | 1,097 B | — | over |
+| ladder re-take on the shipping bench tree | 1,099.5 B | 1,097 B | — | over |
+| **the package (S1 / S2)** | **1,100 B** | **1,095 B** | 1,091 / 1,087 B | **1.074× / 1.069× — over, in every round** |
+| frame-prop variant (bench tree) | 1,054 B | 1,051 B | 1,047 B | over |
+
+Every one of the twelve package readings sits at or above **1,087 B**, so the
+row is red under the frozen reading, red under the retired 1,000 B one, and
+**not a band-crossing case at all**. What the freeze forestalls is still ahead:
+the no-wrapper arm's `994` / `992 B` sits exactly in the window the two readings
+disagreed about, so a remediation landing there would have been decided by a
+coin-flip. It no longer can be.
+
+**The breach is a property of the design, not of the prototype.** That is the
+substantive finding the package re-pin adds, and it is `rf2-hic-018`'s to
+disposition.
+
+### The record: why the freeze was needed
 
 `rf2-hic-006` asks this page to resolve, **from the registered instrument's
 source of record**, whether the paper-fail line is 1,000 B or 1,024 B.
@@ -260,26 +324,65 @@ grounds that `KB` in a memory context conventionally expands to 2^10 and the
 instrument reports raw bytes either way. Recorded as a recommendation; the
 decision is the operator's.
 
+> **This recommendation was adopted on 2026-08-12, on these grounds.** See the
+> ruling at the head of this section. The sentence above is left standing as
+> the reasoning that was put to the operator, not as a live question.
+
 ### The breach is carried, never normalised
 
-The current breach stands at **R=0 = 1,103 B / 1,097 B** against the registered
-`1 KB` line. It is a **live pressure owned by `rf2-hic-018`**, not a
-disposition this page may make, and it is never silently normalised into a
+The current breach stands at **R=0 = 1,100 B / 1,095 B on the package**, against
+the frozen `1,024 B` line. It is a **live pressure owned by `rf2-hic-018`**, not
+a disposition this page may make, and it is never silently normalised into a
 percentage allowance — §6 says in terms that a relative regression allowance
 cannot recolour the red shell row.
 
 One drift is recorded rather than smoothed. The baseline's pinned Reagent
-figure is `1,103 B`; the ladder's later paired re-takes on the shipping tree
-read `1,101 B` and `1,099.5 B`, and the UIx segment reads `1,097 B` in all
-of them. The arms overlap in band and the page itself notes the difference. The
-baseline row is left as the pinned figure because a measurement record edited to
-match a later run stops being a record — but a re-pin on the package (§6) would
-supersede all of them, and until it happens **`1,103 B` is a bench-tree figure,
-not a package figure.**
+figure was `1,103 B`; the ladder's later paired re-takes on the shipping bench
+tree read `1,101 B` and `1,099.5 B`, and the UIx segment reads `1,097 B` in all
+of them. The arms overlap in band and the ladder page itself notes the
+difference. Those rows are left exactly as measured, because a measurement
+record edited to match a later run stops being a record. **What has changed is
+which of them this page pins**: the package re-pin (§6) has now happened, so
+S1/S2 are `1,100` and `1,095 B` and the earlier figures are the bench-tree
+lineage behind them rather than the live rows. That the package reading landed
+within 3 B and 2 B of the bench-tree one is a result, not a formality — it is
+the reason the whole prior lineage remains readable as evidence about the same
+design.
 
 ---
 
-## 6. The re-pin on the moved package: REFUSED
+## 6. The re-pin on the moved package: REFUSED, then DISCHARGED
+
+> **DISCHARGED 2026-08-12 by `rf2-fe0l`.** The refusal below stands as the
+> record of why this page could not deliver the re-pin, and every word of its
+> diagnosis held: no heap instrument pointed at the package, and the registered
+> one had drifted from its own pin. Both were fixed in the order this section
+> asked for. PR #7939 repointed the existing P0 ladder's four candidate seams at
+> `re-frame.hicasso` — **reusing the driver, donors, floor, harness, fixtures,
+> fit rules and order guard unchanged, so the estimator did not move** — and it
+> merged, fixing the rig's blobs, *before* any sample existed. One solo
+> quiet-window run then took the package arm and **both** donor arms in the same
+> run set, as this section required. S1–S5 in §4 are package figures as a
+> result.
+>
+> Two of this section's stated conditions were met differently from the way it
+> guessed, and the difference is worth recording. **No new build id was needed
+> and no hot-zone file was touched**: the driver already rides `:hicasso-bench`
+> through `P0_BUILD` / `P0_INIT_FN`, and `hicasso/src` is already on that build's
+> source paths, so `:hicasso-heap-bench` was deferred rather than built (to
+> `rf2-hic-071`, reconsidered only if this becomes a standing gate). And the
+> `~5% common-mode offset` caution below is about the **two harnesses** — P0
+> against the freehand ladder — not about two runs of this one; the
+> cross-session comparison in the studio section is licensed instead by the
+> donors reproducing their published anchors within 1 B, which is this corpus's
+> own standing rule.
+>
+> **The instrument-drift half is closed by supersession, not by repair.** The
+> eleven pinned blobs tabulated below have not been made to match; they never
+> can be, and `front/sub_index.cljs` no longer exists. What has changed is that
+> the drift is no longer *un-attributable*: the run below took the package and
+> both donors on one instrument in one session, so the delta between it and the
+> prototype is read against same-run donors rather than against a stale pin.
 
 `rf2-hic-006` asks for the shell, per-read and teardown baselines
 **re-measured on `implementation/hicasso`** so later gates have a

--- a/docs/design/hicasso/product/lanes/evidence-baseline.md
+++ b/docs/design/hicasso/product/lanes/evidence-baseline.md
@@ -6,7 +6,7 @@ This baseline records the current product facts that constrain implementation. Q
 
 - Hicasso is the selected native adapter design.
 - The proposed `1.25x` K1 product ceiling is not operative. Phase 0 prepares its scoped record for operator ratification at the 2026-08-27 sitting; the registered `1.10x` gate remains the only adjudicated line until then.
-- The implementation remains under the benchmark tree rather than an installable `implementation/hicasso` package.
+- The implementation is the `implementation/hicasso` artefact (`day8/re-frame2-hicasso`); the benchmark tree's `re-frame.bench.hicasso.arm1.*` is the frozen prototype it was moved from, and the two diverge permanently by design. **Every heap row in this baseline is measured on the package as of 2026-08-12**; rows sourced elsewhere say so.
 - Public names are provisional until the ordinary application and host/hot-path witnesses pass.
 - The interpreted React-function-component path is the ordinary product path. An explicitly native element/component surface is the local escape; compiled Hiccup, own-renderer and second-emitter paths are outside the design.
 - React-library interop and SSR/hydration correctness are core product obligations; UIx, library-specific wrappers, and the deployable Node service are optional.
@@ -31,10 +31,10 @@ The proposed Hicasso-native namespace is not demonstrated value yet. It remains 
 | Interpreted lowering | At or below stock Reagent on the measured walk rows | [`rf2-2rtt6.63`](../../studio/our-walk-against-reagents.md) | Do not assume Hiccup interpretation is the dominant pressure |
 | Narrow update | Workload-specific parity/win evidence | [Corrected-clock rows](../../studio/rows-re-adjudicated-on-the-corrected-clock.md) | Require changed-work scaling; make no universal “narrow is faster” claim |
 | Broad update | Governed Hicasso/Reagent intervals remain instrument-limited; no general magnitude | [`rf2-vp0j7` evidence lineage](../../studio/bulk-broad-re-taken.md) | Do not optimize from a refused or non-governed comparator |
-| Boundary shell | Current pinned `R=0` shells are `1,103 B` on the Reagent segment and `1,097 B` on the UIx segment, above the registered `1 KB` paper-fail line under either 1,000 B or 1,024 B | [Current heap ladder](../../studio/reads-per-boundary-heap-ladder.md) | The row is red; freeze the byte-exact line, then remediate it or require a separate prospective operator disposition before ABI freeze |
-| Retained reads | Hicasso `1,278 B/read` versus Reagent `947 B/read`; Hicasso `2,115 B/read` versus UIx `2,980 B/read` | [Current heap ladder](../../studio/reads-per-boundary-heap-ladder.md) | Choose the under-collector substrate explicitly; keep governed shipped-path viability, parent-relative architecture progress, and author preference as separate scoreboards |
+| Boundary shell | Current pinned `R=0` shells are `1,100 B` on the Reagent segment and `1,095 B` on the UIx segment, **measured on the package**, above the frozen `1,024 B` paper-fail line in every round | [Current heap ladder](../../studio/reads-per-boundary-heap-ladder.md#the-package-itself-priced-on-this-rung-at-last-rf2-fe0l) | The row is red, and the breach survived the move off the prototype, so it is a property of the design; the byte-exact line is frozen, so what remains is to remediate it or require a separate prospective operator disposition before ABI freeze |
+| Retained reads | Hicasso `1,417 B/read` versus Reagent `948 B/read`; Hicasso `2,115 B/read` versus UIx `2,980 B/read`, **measured on the package** | [Current heap ladder](../../studio/reads-per-boundary-heap-ladder.md#the-package-itself-priced-on-this-rung-at-last-rf2-fe0l) | Choose the under-collector substrate explicitly; keep governed shipped-path viability, parent-relative architecture progress, and author preference as separate scoreboards |
 | Warm allocation | No fitted series clears the registered quality floor | [Allocation survival metric](../../studio/the-survival-metrics-allocation-half.md) and [instrument contract](../../allocation-instrument-rework.md) | Publish no allocation claim yet |
-| Teardown | Zero retained bytes and objects on the pinned heap arms | [Current heap ladder](../../studio/reads-per-boundary-heap-ladder.md) | Preserve as an absolute invariant |
+| Teardown | Zero retained objects and retained bytes indistinguishable from zero on the pinned heap arms, **measured on the package** — the object counts are exact, the byte bands straddle zero | [Current heap ladder](../../studio/reads-per-boundary-heap-ladder.md#the-package-itself-priced-on-this-rung-at-last-rf2-fe0l) | Preserve as an absolute invariant |
 | SSR/hydration | Node/React spike produces deterministic hydratable fixtures | [SSR spike witness](../../studio/ssr-spike-witness.md) | Product service, isolation and operations remain to build |
 
 The heap result has three non-substitutable scoreboards: governed viability against Reagent, architecture progress against the UIx parent, and author preference from the dogfood witness. None is a replacement denominator for another.
@@ -49,7 +49,7 @@ The baseline remains a decisive miss against the registered K1 gate. The [primar
 
 ### Read-free boundary shell
 
-The current result is red against the `1 KB` paper-fail line under either byte interpretation. The primary performance contract owns the exact-line freeze, remediation path and any later prospective disposition. No acceptance exists, the K1 decision does not waive this row, and a percentage regression allowance cannot make it green.
+The current result is red against the paper-fail line, which the operator froze at `1,024 B` on 2026-08-12 — and it was red under the retired 1,000 B reading too, in every round, so no verdict here turned on the freeze. The primary performance contract owns the remediation path and any later prospective disposition. No acceptance exists, the K1 decision does not waive this row, and a percentage regression allowance cannot make it green.
 
 ### Bulk, retained heap, and allocation
 

--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -2604,9 +2604,12 @@ mechanical here rather than disciplinary.
 `:hicasso-bench` compiles both trees. An arm pointed back at the prototype
 therefore builds **green with zero warnings** and reads plausibly; it simply
 prices different software. Dispatch 1 demonstrated exactly that by reverting one
-seam. So the evidence is the rig's own **module graph**, read before the window
-opened, from a cleared cache entry so the analysis cache holds precisely what
-the entry point reached:
+seam. So the evidence is the rig's own **module graph**, read from a cleared
+cache entry so the analysis cache holds precisely what the entry point reached.
+It was read **twice**: once before the window opened, so a wrong rig would not
+cost a run — and once afterwards **from the build the driver itself made**,
+which is the read that matters, because it describes the very bundle the figures
+below came out of rather than a rehearsal of it. The two agree exactly:
 
 ```
 PRESENT  re_frame.hicasso.impl.mount.js      ABSENT  re_frame.bench.hicasso.arm1.runtime.js

--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -2579,6 +2579,317 @@ did not move.
 
 ---
 
+### The package itself, priced on this rung at last (rf2-fe0l)
+
+**2026-08-12.** Every candidate figure above this line was taken on
+`re-frame.bench.hicasso.arm1.*` — the prototype in the benchmark tree.
+`implementation/hicasso/src` is a deliberately frozen *copy* of that runtime,
+and until 2026-08-11 **no heap instrument pointed at the package at all**,
+which is why [budgets.md](../product/budgets.md) had to refuse its "re-measured
+on `implementation/hicasso`" deliverable and report the refusal instead.
+PR #7939 repointed this rig's four candidate seams at the package — the mount
+door, the runtime reset, and both residue reads — and left the donors, the
+floor, the harness, the fixtures, the fit rules and the order guard alone.
+**This section is the first reading taken through it**, and it is the anchor
+`rf2-hic-018` needs before it mutates the collector: a package baseline taken
+on the same instrument as the thing it will later be compared with.
+
+The two dispatches are deliberately separate. The rig merged, and its blobs
+were fixed by that merge, **before a single sample existed** — so the window
+below could not repair an arm it did not write, and pre-registration is
+mechanical here rather than disciplinary.
+
+#### The rig resolves the package, and the compile is not what says so
+
+`:hicasso-bench` compiles both trees. An arm pointed back at the prototype
+therefore builds **green with zero warnings** and reads plausibly; it simply
+prices different software. Dispatch 1 demonstrated exactly that by reverting one
+seam. So the evidence is the rig's own **module graph**, read before the window
+opened, from a cleared cache entry so the analysis cache holds precisely what
+the entry point reached:
+
+```
+PRESENT  re_frame.hicasso.impl.mount.js      ABSENT  re_frame.bench.hicasso.arm1.runtime.js
+PRESENT  re_frame.hicasso.impl.collector.js  ABSENT  re_frame.bench.hicasso.arm1.mount.js
+PRESENT  re_frame.hicasso.impl.inventory.js  ABSENT  re_frame.bench.hicasso.arm1.lang.js
+PRESENT  re_frame.hicasso.js                 ABSENT  re_frame.bench.hicasso.front.codec.js
+130 namespaces in the rig's graph; build=hicasso-bench initFn=re-frame.bench.p0-app/-main
+arm1 namespaces in graph: 0
+bench.hicasso.front namespaces in graph: 0
+hicasso.impl namespaces in graph: 16
+```
+
+**That read is worthless without a control, because an enumeration that finds
+nothing and an enumeration that looks nowhere print the same thing.** The
+control is a sibling program on the *same build id* that genuinely does require
+the prototype — `re-frame.bench.hicasso.clock-app/-main`, swapped in through the
+driver's own `P0_INIT_FN` override, with **no file in the rig touched**. It
+reports `arm1 namespaces in graph: 2`, `hicasso.impl namespaces in graph: 0`,
+and exits **1**. The reader can see the prototype when the prototype is there.
+
+Sixteen of the package's eighteen `impl.*` modules are in the graph;
+`impl.presence` and `impl.presence-react` are not reached from this arm, which
+is a property of what the arm exercises and not a defect.
+
+#### The rows
+
+`B` = 1,200 boundaries held fixed across every rung, 4 roots × 300 cells; six
+rounds; rungs 0/1/3/7/20 with Q = E on every one. `y` is exclusive retained
+bytes per boundary above the same-round, same-segment floor; bands are min–max
+across the six rounds. Residue is per boundary after teardown.
+
+| `reagent-subs` | reads | E | Q | exclusive B/boundary | residue B/bdy |
+|---|---:|---:|---:|---:|---:|
+| floor | 0 | 0 | 0 | 256 [248–265] | 4 [0–8] |
+| reagent | 0 | 0 | 0 | 511 [500–519] | 4 [−6–23] |
+| reagent | 1 | 1,200 | 1,200 | 1,678 [1,659–1,692] | 14 [−1–45] |
+| reagent | 3 | 3,600 | 3,600 | 3,391 [3,382–3,405] | 2 [−7–18] |
+| reagent | 7 | 8,400 | 8,400 | 6,704 [6,682–6,717] | 11 [1–20] |
+| reagent | 20 | 24,000 | 24,000 | 19,570 [19,556–19,585] | 6 [−9–46] |
+| **hicasso** | 0 | 0 | 0 | **1,100** [1,091–1,107] | 1 [−6–7] |
+| **hicasso** | 1 | 1,200 | 1,200 | **2,949** [2,934–2,965] | 3 [−10–19] |
+| **hicasso** | 3 | 3,600 | 3,600 | **5,400** [5,384–5,409] | 5 [−2–10] |
+| **hicasso** | 7 | 8,400 | 8,400 | **10,310** [10,293–10,331] | 7 [−5–18] |
+| **hicasso** | 20 | 24,000 | 24,000 | **29,650** [29,629–29,670] | −6 [−55–12] |
+
+| `uix-subs` | reads | E | Q | exclusive B/boundary | residue B/bdy |
+|---|---:|---:|---:|---:|---:|
+| floor | 0 | 0 | 0 | 255 [252–261] | 1 [0–6] |
+| uix | 0 | 0 | 0 | 220 [214–226] | 0 [0–1] |
+| uix | 1 | 1,200 | 1,200 | 3,286 [3,263–3,316] | 18 [0–39] |
+| uix | 3 | 3,600 | 3,600 | 9,114 [9,108–9,122] | 6 [−4–20] |
+| uix | 7 | 8,400 | 8,400 | 20,800 [20,786–20,816] | 13 [4–24] |
+| uix | 20 | 24,000 | 24,000 | 59,825 [59,812–59,832] | −31 [−106–3] |
+| **hicasso** | 0 | 0 | 0 | **1,095** [1,087–1,101] | −1 [−6–2] |
+| **hicasso** | 1 | 1,200 | 1,200 | **3,660** [3,653–3,665] | 1 [−8–7] |
+| **hicasso** | 3 | 3,600 | 3,600 | **7,602** [7,520–7,637] | −17 [−101–14] |
+| **hicasso** | 7 | 8,400 | 8,400 | **15,491** [15,428–15,540] | −14 [−69–27] |
+| **hicasso** | 20 | 24,000 | 24,000 | **43,681** [43,587–43,738] | −11 [−109–46] |
+
+#### The fitted lines
+
+`y = intercept + slope·R`, fitted over 1/3/7/20 only. `shell` is the directly
+measured R=0 rung and never the fitted intercept.
+
+| arm | slope B/read | intercept | shell (R=0, measured) | first read | r² |
+|---|---:|---:|---:|---:|---:|
+| `reagent-subs` \| reagent | 948 [947–948] | 493 [481–503] | 511 [500–519] | 1,167 [1,153–1,182] | 0.99871 |
+| `reagent-subs` \| **hicasso** | **1,417** [1,416–1,417] | 1,097 [1,085–1,110] | **1,100** [1,091–1,107] | 1,849 [1,836–1,859] | 0.99833 |
+| `uix-subs` \| uix | 2,980 [2,979–2,981] | 165 [149–177] | 220 [214–226] | 3,066 [3,049–3,090] | 0.99996 |
+| `uix-subs` \| **hicasso** | **2,115** [2,109–2,118] | 1,217 [1,187–1,251] | **1,095** [1,087–1,101] | 2,565 [2,557–2,575] | 0.99957 |
+
+All four are lines in R, and **6 of 6 rounds are linear on every arm** — the
+per-round verdict, not only the pooled one.
+
+#### Exactly one quantity moved, and the instrument says which
+
+The prototype's most recently published rows are directly above this section.
+Set the package beside them:
+
+| quantity | prototype (bench tree) | **package** (this run) | moved? |
+|---|---:|---:|---|
+| R=0 shell, Reagent segment | 1,099.5 / 1,098 / 1,100 B | **1,100** B | no |
+| R=0 shell, UIx segment | 1,097 / 1,096 / 1,099 B | **1,095** B | no |
+| slope, UIx segment | 2,115 [2,110–2,118] | **2,115** [2,109–2,118] | no |
+| **slope, Reagent segment** | 1,278 [1,275–1,280] | **1,417** [1,416–1,417] | **+139 B/read, +10.9%** |
+| Reagent donor shell | 504 / 509 / 509 B | 511 B | no |
+| UIx donor shell | 223 / 225 / 226 B | 220 B | no |
+| Reagent donor slope | 947 | 948 [947–948] | no |
+| UIx donor slope | 2,979 / 2,980 | 2,980 [2,979–2,981] | no |
+| floor, Reagent segment | 258 / 257 / 257 B | 256 B | no |
+| floor, UIx segment | 254 / 253 / 252 B | 255 B | no |
+
+**Nine of ten quantities reproduce; one moved, and the two bands are disjoint
+by 136 B** ([1,275–1,280] against [1,416–1,417]). Because every donor, both
+floors, both shells and the *other* candidate slope came back where the
+prototype left them, the move is the candidate's and not the instrument's —
+which is this studio's own standing rule for putting two sessions' figures in
+one table, applied here rather than invented for the occasion.
+
+**The mechanism is not attributed here, and the asymmetry is why.** A package
+carrying more per-read state than the frozen prototype would be expected to show
+it in *both* segments; it shows in one, to the byte, while the UIx segment
+reproduces `2,115` exactly and its ratio moves from `0.7099×` to `0.7098×`.
+Naming a cause would take ablations this window is not permitted to run — its
+terms are one invocation, and an instrument iterated until it explains itself is
+no longer the instrument the figures were taken on. **`rf2-hic-018` owns the
+attribution, and it now has the same-instrument package baseline that makes an
+attribution possible at all**, which is precisely what this bead existed to
+supply.
+
+What it does to the candidate's standing, stated plainly:
+
+| segment | donor | candidate | ratio, prototype | ratio, **package** |
+|---|---:|---:|---:|---:|
+| `reagent-subs` | 948 B/read | 1,417 B/read | 1.3492× | **1.4953×** (margin −49.5%) |
+| `uix-subs` | 2,980 B/read | 2,115 B/read | 0.7099× | **0.7098×** (margin 29.0%) |
+
+The verdict's *shape* is unchanged — won against UIx, lost to Reagent's
+`deref`-capture — but the loss against Reagent is materially deeper on the
+software that ships, and the bracket a shipped Hicasso sits in widens from
+`1,278 – 2,115` to **`1,417 – 2,115` B/read**.
+
+#### Against the 1,024 B line, which is now frozen
+
+The operator froze the shell's paper-fail line at the literal **1,024 B** on
+2026-08-12 (the ruling is recorded on `rf2-fe0l`), and adopted with it the rule
+that **a confidence band crossing that line is UNRESOLVED rather than a pass**.
+Neither clause is load-bearing for this row, and it is worth saying why:
+
+| R=0 shell, package | figure | worst round | vs 1,024 B |
+|---|---:|---:|---|
+| Reagent segment | 1,100 B | 1,091 B | **1.074× — over, in every round** |
+| UIx segment | 1,095 B | 1,087 B | **1.069× — over, in every round** |
+
+Every one of the twelve readings sits at or above 1,087 B, so the row is red
+under the frozen reading, red under the retired 1,000 B reading, and **not a
+band-crossing case at all**. The freeze changes no verdict here; it will matter
+at remediation, where the no-wrapper arm's 994 / 992 B sits exactly in the
+window the two readings disagree about.
+
+**The breach survives the move to the package**, which is the substantive news
+for `rf2-hic-018`: it is a property of the design and not an artefact of the
+prototype it was first measured on.
+
+#### Teardown, in bytes, on the package
+
+**All ten candidate rungs' residue bands straddle zero** — the point estimates
+run from −17 to +7 B per boundary and every band contains 0. The structural
+witness reports the same thing in objects, and exits on it: boundaries, edges,
+cells and entries all read **exactly zero after teardown on every arm of every
+round**. Teardown is therefore re-pinned on the package as *indistinguishable
+from zero*, which is the honest form of the claim — it is what a distributional
+reading can support, where the object counts are exact.
+
+One observation recorded rather than smoothed: two *donor* rungs' residue bands
+do not straddle zero (Reagent at R=7, 11 [1–20]; UIx at R=7, 13 [4–24]). Those
+are donor rows and not this page's to disposition, but a reader comparing
+columns should not have to notice it alone.
+
+#### The controls
+
+Every control below is **from this run**. Nothing is scaled in from another
+session and nothing is re-derived.
+
+**The positive control — the instrument has signal, and it is calibrated in
+bytes.** The same dense array of 587,500 unboxed doubles, **4,700,000 B fixed
+before the run**: measured **4,700,284 B** [4,699,042–4,700,872], ratio
+**1.0001** — 0.006% high, the closest reading this control has produced on this
+page. `ok` under `lane/control-verdict` at the driver's ±25% slack, which is the
+only band this session registers; the deviation is reported as a non-gating
+observation.
+
+**The ladder is its own control for the slope.** Reads walk 0 → 20, a twentyfold
+range, and every arm answers with a line: r² from 0.99833 to 0.99996, six of six
+rounds linear on all four. A per-read cost that could not be made to move with R
+would be a coincidence; this one moves with R exactly, in the right direction,
+on every arm.
+
+**The segment swap is the control for the shell.** The candidate is one view
+layer measured over two subscription substrates. Its R=0 shell reads 1,100 and
+1,095 B — **5 B apart**, so the shell does not depend on the substrate beneath
+it, which is what a *shell* figure must show. That the instrument can see a
+substrate difference at R=0 is not assumed either: the donors' own shells differ
+by **291 B** across the same two segments (511 against 220). The instrument is
+demonstrably capable of the reading it declines to make for the candidate.
+
+**The floor is the calibrator that licenses the cross-segment comparison.** It
+holds no re-frame state, so it is the same work either side of the seam, and it
+reads 256 and 255 B — 0.4% apart.
+
+**The fit refuses what it should refuse**, checked in the page before anything
+was measured: an exact line is recovered to the byte with R=0 excluded from the
+fit; a quadratic per-read term is rejected by the r² floor (0.96464 under 0.98);
+and an absurd R=0 rung of 99,999 B **does not move the fit by one bit** — which
+is what makes the shell and the slope independent quantities that may be pinned
+separately.
+
+**The arm-order guard** ran its twelve self-tests before installation, including
+a recorded 2.01× it is required to *refuse*, and returned **`reportable`** over
+the samples. **0 unverified of 154 mounts.** The driver exits non-zero on any of
+these; it exited **0**.
+
+#### Provenance
+
+Whole-tree anchor **`ce31a30b77`**, which is `origin/main` — the measured tree
+and the published tree are the same tree, and the working tree was clean
+(`git status --porcelain` empty) before the run and unchanged by it.
+
+The instrument, all under `implementation/core/test/re_frame/bench/`:
+
+| file | blob | vs the frame-prop run above |
+|---|---|---|
+| `p0_run.cjs` | `ce4f01a9e548dad37513929ea7e03ed0fe909f8f` | moved — one comment line, PR #7939 |
+| `p0_heap.cljs` | `ef9b5adcf0ef81487ddbab43affc2e46f229ffac` | moved — the four seams, PR #7939 |
+| `p0_hicasso.cljs` | `7a91564f59a216ae4c0d13535fdac65b0ef81481` | moved — the two doors, PR #7939 |
+| `p0_reagent.cljs` | `419e166a93526bfb32794fb6236c840068fbd417` | moved — docstring only |
+| `p0_uix.cljs` | `f1aaf9cb1e58a62c8c1429ea66bca8bdd8c76a56` | moved — docstring only |
+| `p0_fixture.cljc` | `de27135ce820229e782b86628c42f7fcca2b899f` | moved — see below |
+| `p0_arms.cljs` | `beced24315f740eede28cf5f32f855ff91bbd854` | — |
+| `p0_harness.cljs` | `e18c2f50d4f5985d7bc81ff99dfd173ae296f82b` | — |
+| `p0_floor.cljs` | `6b61e125f4bd4c479be9438b55d04c1d8d20e601` | — |
+
+**The donor and fixture blobs are NOT byte-identical to the runs this section
+compares against, and that is stated rather than glossed.** Three of them moved
+after 2026-08-04. `p0_reagent.cljs` and `p0_uix.cljs` moved by docstring alone
+(`606bad8445`, re-pointing a superseded owner citation). `p0_fixture.cljc` also
+carries an executable change (`eb17886c5b`, `rf2-2rtt6.140`): `seed-db` gained a
+grid-width arity that **defaults to the published `cells-n`**, and `:p0/fan`'s
+modulus became `(count (:cells db))` where it was the same constant — so every
+caller that passes nothing, the retention ladder included, gets the published
+page to the byte. That is an argument from construction; the *measurement* is
+that both donors and both floors came back on their published anchors, which is
+what actually settles it.
+
+The candidate arm is no longer in a table of its own, because **the candidate
+arm is now the package**. Its doors, under
+`implementation/hicasso/src/re_frame/hicasso/`:
+
+| file | blob |
+|---|---|
+| `impl/mount.cljs` | `ddf06f21e0ae2112031de6f835da389ed6760ec3` |
+| `impl/collector.cljs` | `3876ae023224f670e2cdaa086cf364f5fdbf4844` |
+| `impl/inventory.cljs` | `e1ac96953e7739aa30c8b7bfd7e752bc159fabda` |
+| `../hicasso.cljc` (the facade) | `405646b7bceab6d98d1fdb879932d7913b7f149e` |
+
+Sixteen `impl.*` modules are in the graph, so these four are the doors and not
+the whole arm; the tree anchor above is what pins the rest.
+
+Reproduce:
+
+```
+node implementation/core/test/re_frame/bench/p0_run.cjs --only ladder
+```
+
+(defaults `P0_LADDER_ROUNDS=6 P0_LADDER_RUNGS=0,1,3,7,20 P0_ROOTS=4`; no build
+id was added — the driver rides `:hicasso-bench` through `P0_BUILD` and
+`P0_INIT_FN`, merging `:output-dir` and `:init-fn` onto it, and clears that id's
+cache entry first.)
+
+**Conditions.** 2026-08-12 06:47–06:51 +1000, **one run** of ~3.5 minutes —
+the window's terms are a single invocation, and no second run was taken.
+Captured exit **0**. React 19.2.0, Reagent 2.0.1, UIx 1.4.4, node 24.13.0,
+`:advanced` with `goog.DEBUG false`, headless Chromium via Playwright,
+Windows 11, 24 logical cores. **Box verified quiet before and after**, by two
+readings that cover each other's blind spot: real CPU occupancy
+**4.17% / 3.02%** before and **2.15% / 2.35%** after — summed per-process
+CPU-time deltas over a 5-second window divided by the core count, never
+`LoadPercentage`, which reads 15–20% on this box at a true occupancy under 2% —
+and `\System\Processor Queue Length` **0 on every sample**, which is the
+decisive number because it says whether anything was *waiting* for a core.
+Throughout: 32 node processes (idle MCP servers), 129 chrome, **zero java**,
+~585 processes, ~17.2 GB free, no other worker running and no local gate.
+
+The occupancy is higher than the 1.4–3.0% the 2026-08-04 sections recorded, and
+the reason is visible in the counts: 129 chrome processes against 56, the
+operator's own idle browser. It is recorded rather than corrected for. This is a
+**retained-heap** row and not a clock row, and this page has already priced what
+contention does to it — a deliberately contended trial landed within about
+0.07% of a quiet six-round range, and was still refused as evidence. A box at
+2–4% with an empty run queue is far inside that.
+
+---
+
 ## 7. Anchors, and one that does not fully reproduce
 
 The R=0 rung is here to tie this instrument to the published sub-free rows


### PR DESCRIPTION
**rf2-fe0l, DISPATCH 2 of 2 — the window.** One solo Shape 6 quiet-window run of `p0_run.cjs --only ladder`, taking the package candidate arm and **both** donor arms in the same run set, through the rig [PR #7939](https://github.com/day8/re-frame2/pull/7939) repointed and froze. Captured exit **0**, every gate the driver exits on answered.

**The window did not refuse.** Docs only — 3 markdown files, no code, no hot-zone file, no `.beads` path.

## The rig resolves the package — verified twice, and controlled

`:hicasso-bench` compiles both trees, so an arm pointed back at `arm1` builds **green with zero warnings** and reads plausibly; it just prices different software. Dispatch 1 proved that by breaking a seam. So the compile is not the check — the **module graph** is, read from a cleared cache entry:

```
PRESENT  re_frame.hicasso.impl.mount.js      ABSENT  re_frame.bench.hicasso.arm1.runtime.js
PRESENT  re_frame.hicasso.impl.collector.js  ABSENT  re_frame.bench.hicasso.arm1.mount.js
PRESENT  re_frame.hicasso.impl.inventory.js  ABSENT  re_frame.bench.hicasso.arm1.lang.js
PRESENT  re_frame.hicasso.js                 ABSENT  re_frame.bench.hicasso.front.codec.js
130 namespaces in the rig's graph; build=hicasso-bench initFn=re-frame.bench.p0-app/-main
arm1 namespaces in graph: 0        hicasso.impl namespaces in graph: 16
```

Read **twice, identically**: once before the window (so a wrong rig would not cost a run) and once afterwards **from the build the driver itself made** — the read that matters, because it describes the bundle the figures actually came out of.

**With a control, because an enumeration that finds nothing and one that looks nowhere print the same thing.** A sibling program on the *same build id* that genuinely requires the prototype — `re-frame.bench.hicasso.clock-app/-main`, swapped in through the driver's own `P0_INIT_FN`, **no file in the rig touched** — reports `arm1 namespaces in graph: 2`, `hicasso.impl: 0`, exit **1**. The reader sees the prototype when the prototype is there.

**One discrepancy with #7939, and it is method, not substance.** Dispatch 1 reported 389 namespaces / 32 `hicasso.impl`; I read 130 / 16 — my enumeration is one entry per namespace in the release analysis cache, and 16 is exactly half of 32. The directional facts (`arm1: 0`, all four package doors present) agree exactly. `impl.presence` and `impl.presence-react` are the two of eighteen the arm does not reach.

## The figures, each with the control that moves it

Every control is **from this run**. Nothing scaled in, nothing re-derived — a second source for one number is a second thing to drift.

| # | Estimand | **Package figure** | Was (bench tree) | The control that moves it |
|---|---|---:|---:|---|
| S1 | R=0 shell, Reagent seg. | **1,100 B** [1,091–1,107] | 1,103 B | **segment swap**: donor shells differ by **291 B** across the two segments (511 vs 220), so the instrument can see a substrate difference at R=0 — the candidate's simply is not one (1,100 vs 1,095, 5 B apart) |
| S2 | R=0 shell, UIx seg. | **1,095 B** [1,087–1,101] | 1,097 B | as S1 |
| S3 | Per-read, vs Reagent | **1,417** vs **948** B/read | 1,278 vs 947 | **the ladder itself**: R walks 0→20 and the arm answers with a line, r² 0.99833, **6 of 6 rounds linear**. A number that will not move with R is a coincidence; this one moves with R exactly, twentyfold |
| S4 | Per-read, vs UIx | **2,115** vs **2,980** B/read | 2,115 vs 2,980 | as S3 (r² 0.99957 / 0.99996) |
| S5 | Teardown, retained **bytes** | indistinguishable from zero — **all ten** candidate rungs' bands straddle 0 | zero | **structural witness**, counted and exited on: boundaries/edges/cells/entries **exactly zero after teardown, every arm, every round** |

**Positive control — the instrument has signal and is calibrated in bytes.** 587,500 unboxed doubles, **4,700,000 B fixed before the run**: measured **4,700,284 B** [4,699,042–4,700,872], ratio **1.0001**, 0.006% high — the closest this control has read on this page. `ok` under `lane/control-verdict` at the driver's ±25% slack, the only band this session registers.

**Floor — the calibrator that licenses the cross-segment comparison.** 256 and 255 B, 0.4% apart.

**The fit refuses what it should refuse** (self-tested in the page before anything was measured): an exact line recovered to the byte with R=0 out of the fit; a quadratic per-read term rejected by the r² floor (0.96464 under 0.98); and an absurd R=0 rung of 99,999 B **does not move the fit by one bit** — which is what makes shell and slope separately pinnable.

**Arm-order guard**: twelve self-tests including a recorded 2.01× it must *refuse*; verdict **`reportable`**. **0 unverified of 154 mounts.**

## Exactly one quantity moved, and the instrument says whose it is

| quantity | prototype | **package** | moved? |
|---|---:|---:|---|
| shell, Reagent seg. | 1,099.5 / 1,098 / 1,100 B | **1,100** | no |
| shell, UIx seg. | 1,097 / 1,096 / 1,099 B | **1,095** | no |
| slope, UIx seg. | 2,115 [2,110–2,118] | **2,115** [2,109–2,118] | no |
| **slope, Reagent seg.** | 1,278 [1,275–1,280] | **1,417** [1,416–1,417] | **+139 B/read, +10.9%** |
| both donor shells / both donor slopes / both floors | — | all on their published anchors | no |

**Nine of ten reproduce; one moved, bands disjoint by 136 B.** Because every donor, both floors, both shells and the *other* candidate slope came back where the prototype left them, the move is the candidate's and not the instrument's — which is this corpus's own standing rule for putting two sessions in one table, cited rather than invented.

**The mechanism is deliberately NOT attributed.** A package carrying more per-read state would be expected to show it in *both* segments; it shows in one, to the byte, while UIx reproduces `2,115` exactly (`0.7099× → 0.7098×`). Naming a cause needs ablations this window may not run. **`rf2-hic-018` owns the attribution and now has the same-instrument package baseline that makes one possible** — which is what this bead existed to supply.

Consequences: the governed contrast against Reagent deepens **1.3492× → 1.4953×**; the bracket a shipped Hicasso sits in widens **1,278–2,115 → 1,417–2,115 B/read**. Verdict *shape* unchanged: won against UIx, lost to Reagent's `deref`-capture.

## The 1,024 B freeze, and why nothing here turns on it

Recorded as **RULED** in §5 (the ruling is on the bead); the ambiguous `1 KB` spelling retires; **a band crossing 1,024 B is UNRESOLVED, not a pass.**

| R=0 shell, package | figure | worst round | vs 1,024 B |
|---|---:|---:|---|
| Reagent segment | 1,100 B | 1,091 B | **1.074× — over, in every round** |
| UIx segment | 1,095 B | 1,087 B | **1.069× — over, in every round** |

All twelve readings sit at or above **1,087 B**: red under the frozen reading, red under the retired 1,000 B one, and **not a band-crossing case at all**. Nothing in this PR implies a CI crossing of that line would be a pass. The freeze bites later, at remediation, where the no-wrapper arm's 994 / 992 B sits exactly in the disputed window.

**The breach survives the move to the package** — it is a property of the design, not of the prototype. That is the substantive news for `rf2-hic-018`.

## What remains bench-tree

Stated explicitly, because only what was measured may be re-labelled:

- **S6 — cold mount** (`1.1718x` / `1.1976x`): **bench-tree**. Not measured here; no package-resident *clock* instrument exists. §4 now says so in the row.
- **S7 — warm allocation**: **bench-tree**. No publishable claim to re-pin.
- **U1–U4** (the user-visible latency budgets): unchanged, still not anchored on the package.
- Every §§1–5 row of the ladder studio page, and every prototype row above the new section: **left exactly as measured**. A measurement record edited to match a later run stops being a record.
- The prototype's own rows are the bench-tree *lineage* behind S1–S5, not live rows.

## Scope note — one file beyond the ruling's list

The ruling named `budgets.md` §§4/5/6 and the ladder page. I also touched **`lanes/evidence-baseline.md`** (3 heap rows + 2 sentences), because `budgets.md` §4 names that page as the source its distributional rows are *carried from* — re-pinning one and not the other would put two figures for one estimand in one corpus. Only the three rows I measured moved. Its `1 KB` sentence follows the freeze.

## Nothing needed a hot-zone file

Not `implementation/shadow-cljs.edn`, not `deps.edn`, not `spec/**`, not `.github/workflows/**`. The rig rides `:hicasso-bench` through `P0_BUILD` / `P0_INIT_FN` exactly as designed. `rf2-hic-018`'s `substrate_*` benches untouched.

## Stability — nothing refused to measure

No variance forced a refusal, and the numbers say why: candidate slope bands are **1–9 B wide** across six rounds, all four fits are lines with **6 of 6 rounds linear**, and the positive control landed **0.006%** off a prediction fixed before the run.

**One condition recorded rather than corrected for.** Box occupancy was **4.17% / 3.02%** before and **2.15% / 2.35%** after — higher than the 1.4–3.0% the 2026-08-04 sections logged, and the counts say why: **129 chrome processes against 56**, the operator's idle browser. `\System\Processor Queue Length` read **0 on every sample**, and there were **zero java**, no other worker and no local gate. This is a *retained-heap* row, and this page has already priced contention on it: a deliberately contended trial landed within ~0.07% of a quiet six-round range and was still refused as evidence. A box at 2–4% with an empty run queue is far inside that. Both quiet readings are published in the provenance block.

## Provenance

Whole-tree anchor **`ce31a30b77`**, which is on `origin/main` — measured tree and published tree are the same tree, working tree clean before the run and unchanged by it. Instrument blobs and the package's four door blobs are tabulated in the new section.

**One premise that did NOT hold at source, corrected in the page rather than glossed.** The ruling says the donors/fixtures are "byte-identical — the estimator does not move". True of *Dispatch 1's diff*; **not true against the runs this section compares to.** Three moved after 2026-08-04: `p0_reagent.cljs` and `p0_uix.cljs` by **docstring only** (`606bad8445`), and `p0_fixture.cljc` by an **executable** change (`eb17886c5b`) — `seed-db` gained a grid-width arity defaulting to the published `cells-n`, and `:p0/fan`'s modulus became `(count (:cells db))` where it was that same constant. Measurement-neutral for this ladder by construction; and settled empirically by both donors and both floors returning on their published anchors. Stated in the provenance block.

## Quality gates

Each run **alone**, foreground to completion, output redirected, exit echoed on one command line. `*.exit` artefacts deleted between runs. Every number below was **captured**, not recalled.

| Gate | Command | CAPTURED exit |
|---|---|---|
| **THE WINDOW** | `node implementation/core/test/re_frame/bench/p0_run.cjs --only ladder` | **0** — control `ok`, 0 unverified of 154, structural witness answered, guard `reportable` |
| Module graph, pre-window | ad-hoc reader, driver's `--config-merge` shape | **0** — `arm1: 0` |
| Module graph, **the run's own build** | same reader, `--read-only` | **0** — `arm1: 0`, identical |
| Module-graph reader **control** (arm1-consuming init-fn) | same reader, `P0_INIT_FN=…clock-app/-main` | **1** (expected) — `arm1: 2`, `hicasso.impl: 0` |
| Ladder structural witness | `node core/test/re_frame/bench/p0_ladder_structural.test.cjs` | **0** — 53 passed |
| Doc slugs / anchors | `python scripts/check_doc_slugs.py` | **0** (re-run after rebase: **0**) |
| Provenance pins | `python scripts/check_provenance_pins.py --changed-since origin/main` | **0** — 63 pins, 52 landed, **0 unresolvable** (re-run after rebase: **0**) |
| Markdown table columns | hand check, all 13 changed tables | **0** — 0 mismatched |
| Fast-PR spine | `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine` |
| Fast-PR gap listing | `python scripts/check_fast_pr_gap.py --list` | **0** |

**Verified by hand, because `mkdocs build --strict` does not cover `docs/design/**`.** Heading anchors and cross-page links are covered by `check_doc_slugs.py` (green, and it validates the two new deep links into the ladder page). Table column counts are **not** covered by anything in CI, so I counted them: **13 changed tables, 0 mismatched** — script in the transcript, cell-splitting escaped-pipe aware.

### What the spine does NOT decide

`check_fast_pr_gap.py --list` reports **97** required checks the spine does not run. Green here is not green in CI. Nearest this diff:

- `docs.yml` job **MkDocs build** — this diff is entirely inside `docs/design/hicasso/**`, which `mkdocs.yml`'s `exclude_docs` keeps off the site, so it is surface-gated away; the two gates that *do* see this tree (`check_doc_slugs.py`, `check_provenance_pins.py`) are run above.
- `docs.yml` job **Provenance pins** — run above, against `origin/main`, both before and after the rebase.
- `lint.yml` — **clj-kondo** (CI pins 2026.04.15), **Splint**, **eslint**, **api-manifest**: no `.clj*`, `.js` or manifest path in this diff.
- `test.yml` — no source file changed; nothing in this diff reaches a test surface.
- `beads-pr-boundary` — **no `.beads` path in this diff** (confirmed: `git diff origin/main...HEAD --stat` is three markdown files).

## Residue

None. Scratch scripts and logs live outside the repo; the ad-hoc build output directories were removed; `git status --porcelain` is empty in this worktree and the mayor checkout is untouched by this branch.

---

**`rf2-fe0l` is complete with this PR** — Dispatch 1 built and froze the rig, Dispatch 2 took the window and re-pinned. It unblocks `rf2-hic-018`, which now has the same-instrument package baseline its before/after attribution requires, and it hands `rf2-hic-070` a K3 record to re-pin after `hic-018` per its own text.
