### PR TITLE
test: a suite's cleanup must not outlive its own test (rf2-qpns)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/compiled_keyed_run_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/compiled_keyed_run_dom_cljs_test.cljs
@@ -188,10 +188,14 @@
                                  (step (rest remaining)))))
                     (js/Promise.resolve nil)))]
           (-> (step inherited-names)
-              (.then (fn [_] (done)))
+              ;; The rejection handler sits UPSTREAM of the single trailing
+              ;; `done` (rf2-qpns): `done` runs the whole remainder of the run
+              ;; synchronously, so a `.catch` after it claims a foreign throw
+              ;; as this row's and fires `done` a second time.
               (.catch (fn [e]
                         (is false (str "the duplicate sweep rejected: " e))
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; React's string coercion is still the comparison

--- a/implementation/freehand/test/re_frame/freehand/custom_element_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/custom_element_dom_cljs_test.cljs
@@ -299,7 +299,11 @@
                            #(assert-on-declared! %1 %2 caller-value)))
               (.then (step [detail-loose {}] "undeclared control" undeclared-sel
                            assert-on-undeclared!))
-              (.then (fn [_] (done)))
+              ;; The rejection handler sits UPSTREAM of the single trailing
+              ;; `done` (rf2-qpns): `done` runs the whole remainder of the run
+              ;; synchronously, so a `.catch` after it claims a foreign throw
+              ;; as this row's and fires `done` a second time.
               (.catch (fn [e]
                         (is false (str "mount rejected: " (some-> e ex-message)))
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/mount_support.cljs
+++ b/implementation/freehand/test/re_frame/freehand/mount_support.cljs
@@ -432,7 +432,17 @@
   `done` accounting — a single broken cell can neither hang the suite nor
   double-fire `done` (which corrupts cljs.test's async state and stalls the
   whole run). This is the shape a matrix ROW takes: the same claim,
-  asserted once per mode, named by the mode label."
+  asserted once per mode, named by the mode label.
+
+  **The row's rejection handler sits UPSTREAM of the single trailing `done`
+  (rf2-qpns).** `cljs.test/run-block` hands `done` a continuation that runs
+  the WHOLE REMAINDER of the run synchronously — every later row, then every
+  namespace after this one — so anything out there that throws unwinds back
+  into the callback that called `done`. A `.catch` placed downstream of that
+  callback claims the foreign failure as this row's, prints it against
+  whichever test is current by then, and calls `done` a SECOND time, which
+  re-forces `run-block`'s still-unrealized delay and re-runs the offending
+  namespace. So the handler reports and falls through; it never finishes."
   [modes f done]
   (-> (reduce (fn [p mode]
                 (.then p (fn [_]
@@ -443,10 +453,10 @@
                                          nil))))))
               (js/Promise.resolve nil)
               modes)
-      (.then (fn [_] (done)))
       (.catch (fn [e]
                 (is false (str "a matrix row rejected: " e))
-                (done)))))
+                nil))
+      (.then (fn [_] (done)))))
 
 (defn run-async
   "Run `thunk` (which returns a promise) and then call `done` EXACTLY ONCE.
@@ -455,11 +465,14 @@
   synchronous throw becomes a rejection rather than escaping the chain and
   stranding `done`. The terminal shape for a cross-mode cell that mounts
   both modes itself: the body never calls `done`, so it cannot double-fire
-  it."
+  it.
+
+  The rejection handler is upstream of the single trailing `done` for the
+  reason [[each-mode]] states (rf2-qpns)."
   [thunk done]
   (-> (js/Promise.resolve nil)
       (.then (fn [_] (thunk)))
-      (.then (fn [_] (done)))
       (.catch (fn [e]
                 (is false (str "an async matrix cell rejected: " e))
-                (done)))))
+                nil))
+      (.then (fn [_] (done)))))

--- a/implementation/freehand/test/re_frame/freehand/ownership_maps_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/ownership_maps_dom_cljs_test.cljs
@@ -538,8 +538,12 @@
               (.then (run (nth rows 1) #(command! :detach)))
               ;; row 2 — the path entered twice by hand before teardown.
               (.then (run (nth rows 2) #(do (command! :reclaim) (command! :reclaim))))
-              (.then (fn [_] (done)))
-              (.catch (fn [e] (is false (str "an order rejected: " e)) (done)))))))))
+              ;; The rejection handler sits UPSTREAM of the single trailing
+              ;; `done` (rf2-qpns): `done` runs the whole remainder of the run
+              ;; synchronously, so a `.catch` after it claims a foreign throw
+              ;; as this row's and fires `done` a second time.
+              (.catch (fn [e] (is false (str "an order rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; 3 — the two clocks

--- a/implementation/freehand/test/re_frame/freehand/pilot_react_interop_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_react_interop_dom_cljs_test.cljs
@@ -240,10 +240,14 @@
                        (is (some? (q container "td[data-cursor]"))
                            "a second operation on the same roster reached the host")
                        (act #(teardown! container mounted))))
-              (.then (fn [_] (done)))
+              ;; The rejection handler sits UPSTREAM of the single trailing
+              ;; `done` (rf2-qpns): `done` runs the whole remainder of the run
+              ;; synchronously, so a `.catch` after it claims a foreign throw
+              ;; as this row's and fires `done` a second time.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest a-command-addresses-one-live-widget-and-not-its-neighbour
   (testing "Two live instances of the SAME registered behavior under DISTINCT

--- a/implementation/hicasso/test/re_frame/hicasso/activity_suspense_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/activity_suspense_dom_cljs_test.cljs
@@ -194,14 +194,32 @@
            (mount/release! handle)
            nil)))
 
-(defn- fail-and-finish!
-  [done label handle]
+(defn- report-failure!
+  "Record `label` against THIS row, release its root, and DELIBERATELY DO
+  NOT finish the row — the chain's single trailing `done` does that.
+
+  **A rejection handler may not sit downstream of the `.then` that calls
+  `done` (rf2-qpns).** `cljs.test/run-block` hands `done` a continuation
+  that runs the WHOLE REMAINDER of the run synchronously, so anything out
+  there that throws unwinds back into the callback that called `done`. A
+  `.catch` placed after that callback claims the foreign failure as its
+  own — this row's label, against whichever test is current by then,
+  reading a DOM its own teardown already emptied — and then calls `done` a
+  SECOND time, which does not merely warn: it re-forces `run-block`'s
+  delay, since a delay whose body threw is still unrealized, and runs the
+  offending namespace again.
+
+  The long-form account is on
+  [[re-frame.hicasso.reincarnation-paint-dom-cljs-test]]'s own
+  `report-failure!` (rf2-d3tc); the shape is the one
+  [[re-frame.hicasso.checkpoint-support/at-the-checkpoint]] already uses."
+  [label handle]
   (fn [e]
     (is false (str label " — " (.-message e)
                    " | DOM was " (pr-str (when handle (text handle)))
                    " | ownership " (pr-str (ownership))))
     (when handle (mount/release! handle))
-    (done)))
+    nil))
 
 ;; ---------------------------------------------------------------------------
 ;; The tree
@@ -405,8 +423,8 @@
                     "and the repaint did not add a second reader")
                 (exercised! :activity/reveal)
                 (teardown-census! handle)))
-            (.then (fn [_] (done)))
-            (.catch (fail-and-finish! done "activity lifecycle witness" handle)))))))
+            (.catch (report-failure! "activity lifecycle witness" handle))
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2. The reveal corrects a stale fiber, and WHERE in the event loop
@@ -579,8 +597,8 @@
                              "from the reveal."))))
                 (exercised! :activity/reveal-corrects-a-stale-fiber)
                 (teardown-census! handle)))
-            (.then (fn [_] (done)))
-            (.catch (fail-and-finish! done "reveal paint-order witness" handle)))))))
+            (.catch (report-failure! "reveal paint-order witness" handle))
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3. Suspense — a POST-COMMIT suspension hides the committed tree
@@ -717,8 +735,8 @@
                 (is (= 1 (reader-count [:acsd/a])))
                 (exercised! :suspense/post-commit-fallback-and-retry)
                 (teardown-census! handle)))
-            (.then (fn [_] (done)))
-            (.catch (fail-and-finish! done "post-commit suspension witness" handle)))))))
+            (.catch (report-failure! "post-commit suspension witness" handle))
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The roster, asserted rather than described

--- a/implementation/hicasso/test/re_frame/hicasso/kernel_commit_owns_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/kernel_commit_owns_dom_cljs_test.cljs
@@ -225,14 +225,32 @@
            (mount/release! handle)
            nil)))
 
-(defn- fail-and-finish!
-  [done label handle]
+(defn- report-failure!
+  "Record `label` against THIS row, release its root, and DELIBERATELY DO
+  NOT finish the row — the chain's single trailing `done` does that.
+
+  **A rejection handler may not sit downstream of the `.then` that calls
+  `done` (rf2-qpns).** `cljs.test/run-block` hands `done` a continuation
+  that runs the WHOLE REMAINDER of the run synchronously, so anything out
+  there that throws unwinds back into the callback that called `done`. A
+  `.catch` placed after that callback claims the foreign failure as its
+  own — this row's label, against whichever test is current by then,
+  reading a DOM its own teardown already emptied — and then calls `done` a
+  SECOND time, which does not merely warn: it re-forces `run-block`'s
+  delay, since a delay whose body threw is still unrealized, and runs the
+  offending namespace again.
+
+  The long-form account is on
+  [[re-frame.hicasso.reincarnation-paint-dom-cljs-test]]'s own
+  `report-failure!` (rf2-d3tc); the shape is the one
+  [[re-frame.hicasso.checkpoint-support/at-the-checkpoint]] already uses."
+  [label handle]
   (fn [e]
     (is false (str label " — " (.-message e)
                    " | DOM was " (pr-str (when handle (text handle)))
                    " | ownership " (pr-str (ownership))))
     (when handle (mount/release! handle))
-    (done)))
+    nil))
 
 (defn- make-gate
   "A REAL React suspension: a component that throws a thenable until it is
@@ -320,8 +338,8 @@
                          (ownership))))
                 (exercised! :suspense/abandon-and-retry)
                 (teardown-census! handle)))
-            (.then (fn [_] (done)))
-            (.catch (fail-and-finish! done "suspense witness" handle)))))))
+            (.catch (report-failure! "suspense witness" handle))
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2. Transition abort — React renders the new tree and drops it whole
@@ -398,8 +416,8 @@
                          (ownership))))
                 (exercised! :transition/abort-and-complete)
                 (teardown-census! handle)))
-            (.then (fn [_] (done)))
-            (.catch (fail-and-finish! done "transition witness" handle)))))))
+            (.catch (report-failure! "transition witness" handle))
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3. StrictMode — two body runs, one mount/unmount/remount, one acquisition
@@ -457,8 +475,8 @@
                   (is (= 2 (:entries (inventory/residue)))))
                 (exercised! :strict-mode/double-invoke)
                 (teardown-census! handle)))
-            (.then (fn [_] (done)))
-            (.catch (fail-and-finish! done "strictmode witness" handle)))))))
+            (.catch (report-failure! "strictmode witness" handle))
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4. Error then retry — a render-phase throw, caught and retried
@@ -508,10 +526,12 @@
                          (ownership))))
                 (exercised! :error-boundary/throw-and-retry)
                 (teardown-census! handle)))
-            (.then (fn [_] (reset! !throw? false) (done)))
-            (.catch (fn [e]
-                      (reset! !throw? false)
-                      ((fail-and-finish! done "error-retry witness" handle) e))))))))
+            ;; `!throw?` is disarmed on the single trailing step, which runs on
+            ;; BOTH paths — the `.catch` returns normally rather than finishing
+            ;; the row — so the reset that used to be duplicated across the two
+            ;; arms is now stated once.
+            (.catch (report-failure! "error-retry witness" handle))
+            (.then (fn [_] (reset! !throw? false) (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 5. Delayed commit — a write inside the render→commit gap
@@ -563,8 +583,8 @@
 
                 (exercised! :render-to-commit-gap/heal)
                 (teardown-census! handle)))
-            (.then (fn [_] (done)))
-            (.catch (fail-and-finish! done "render-to-commit-gap witness" handle)))))))
+            (.catch (report-failure! "render-to-commit-gap witness" handle))
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The population, asserted rather than described

--- a/implementation/hicasso/test/re_frame/hicasso/read_extent_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/read_extent_dom_cljs_test.cljs
@@ -310,13 +310,31 @@
            (mount/release! handle)
            nil)))
 
-(defn- fail-and-finish!
-  [done label handle]
+(defn- report-failure!
+  "Record `label` against THIS row, release its root, and DELIBERATELY DO
+  NOT finish the row — the chain's single trailing `done` does that.
+
+  **A rejection handler may not sit downstream of the `.then` that calls
+  `done` (rf2-qpns).** `cljs.test/run-block` hands `done` a continuation
+  that runs the WHOLE REMAINDER of the run synchronously, so anything out
+  there that throws unwinds back into the callback that called `done`. A
+  `.catch` placed after that callback claims the foreign failure as its
+  own — this row's label, against whichever test is current by then,
+  reading a DOM its own teardown already emptied — and then calls `done` a
+  SECOND time, which does not merely warn: it re-forces `run-block`'s
+  delay, since a delay whose body threw is still unrealized, and runs the
+  offending namespace again.
+
+  The long-form account is on
+  [[re-frame.hicasso.reincarnation-paint-dom-cljs-test]]'s own
+  `report-failure!` (rf2-d3tc); the shape is the one
+  [[re-frame.hicasso.checkpoint-support/at-the-checkpoint]] already uses."
+  [label handle]
   (fn [e]
     (is false (str label " — " (.-message e)
                    " | ownership " (pr-str (ownership))))
     (when handle (mount/release! handle))
-    (done)))
+    nil))
 
 ;; ---------------------------------------------------------------------------
 ;; The views
@@ -529,8 +547,8 @@
                 (exercised! :effect/layout)
                 (exercised! :effect/passive)
                 (teardown-census! handle)))
-            (.then (fn [_] (done)))
-            (.catch (fail-and-finish! done "react-effect witness" handle)))))))
+            (.catch (report-failure! "react-effect witness" handle))
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2. A read deferred across a Suspense retry
@@ -598,8 +616,8 @@
 
                 (exercised! :suspense/retry)
                 (teardown-census! handle)))
-            (.then (fn [_] (done)))
-            (.catch (fail-and-finish! done "suspense-retry witness" handle)))))))
+            (.catch (report-failure! "suspense-retry witness" handle))
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3. A read deferred across an Activity reveal
@@ -669,8 +687,8 @@
 
                 (exercised! :activity/reveal)
                 (teardown-census! handle)))
-            (.then (fn [_] (done)))
-            (.catch (fail-and-finish! done "activity-reveal witness" handle)))))))
+            (.catch (report-failure! "activity-reveal witness" handle))
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The controls that make the greens worth having

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -563,15 +563,19 @@
                         "a Fetch Headers object is still built and passed to fetch")
                     (is (= "kept" (.get h "X-Good"))
                         "the valid header rides; only the bad pair was dropped")))))
-            (.then (fn [_] (done)))
             ;; A rejection / synchronous throw here is the PRE-FIX bug — the
-            ;; invalid header escaped the managed path.
+            ;; invalid header escaped the managed path. The handler sits
+            ;; UPSTREAM of the single trailing `done` (rf2-qpns): `done` runs
+            ;; the whole remainder of the run synchronously, so a `.catch`
+            ;; after it claims a foreign throw as this row's and fires `done`
+            ;; a second time.
             (.catch (fn [e]
                       (is false
                           (str "rf2-f5pguu regression — invalid header ESCAPED "
                                "the managed CLJS path (threw/rejected) instead "
                                "of surfacing a managed warning: " e))
-                      (done))))))))
+                      nil))
+            (.then (fn [_] (done))))))))
 
 (deftest cljs-fetch-crlf-header-value-surfaces-managed-warning-not-escape
   (testing "rf2-f5pguu — a header VALUE carrying a CR (`\\r`) is the
@@ -607,12 +611,14 @@
                         "the valid header survives the dropped CR/LF pair")
                     (is (nil? (.get h "X-Bad"))
                         "the response-splitting header was omitted, not sent")))))
-            (.then (fn [_] (done)))
+            ;; Handler upstream of the single trailing `done` — see the
+            ;; sibling row above (rf2-qpns).
             (.catch (fn [e]
                       (is false
                           (str "rf2-f5pguu regression — CR/LF header value escaped "
                                "the managed path: " e))
-                      (done))))))))
+                      nil))
+            (.then (fn [_] (done))))))))
 
 (deftest cljs-fetch-invalid-header-warning-redacts-denylisted-query-param
   (testing "rf2-f5pguu — the managed CLJS header-validation warning routes
@@ -644,10 +650,11 @@
                         ":sensitive? stamped at top level — a denylisted param name is a signal")
                     (is (= http-url/redacted-sentinel :rf/redacted)
                         "sanity: the redaction sentinel is the reserved keyword")))))
-            (.then (fn [_] (done)))
+            ;; Handler upstream of the single trailing `done` (rf2-qpns).
             (.catch (fn [e]
                       (is false (str "unexpected reject: " e))
-                      (done))))))))
+                      nil))
+            (.then (fn [_] (done))))))))
 
 (deftest cljs-fetch-valid-headers-emit-no-invalid-warning
   (testing "rf2-f5pguu — a request with only VALID headers emits NO
@@ -675,10 +682,11 @@
                 (let [h (aget @captured-init "headers")]
                   (is (= "alpha, beta" (.get h "X-Multi"))
                       "valid multi-valued header still accumulates per-element"))))
-            (.then (fn [_] (done)))
+            ;; Handler upstream of the single trailing `done` (rf2-qpns).
             (.catch (fn [e]
                       (is false (str "unexpected reject: " e))
-                      (done))))))))
+                      nil))
+            (.then (fn [_] (done))))))))
 
 (deftest zero-timeout-ms-does-not-arm-near-instant-abort
   (testing "rf2-ee38b.7 — `:timeout-ms 0` is an explicit opt-out (no

--- a/implementation/ui/test/re_frame/ui/frame_ops_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/frame_ops_dom_cljs_test.cljs
@@ -90,7 +90,11 @@
                                "every render of one live incarnation observed
                                 the IDENTICAL bundle — rf= memo-friendly, no
                                 per-render construction")))))))
-              (.then (fn [] (done)))
+              ;; The rejection handler sits UPSTREAM of the single trailing
+              ;; `done` (rf2-qpns): `done` runs the whole remainder of the run
+              ;; synchronously, so a `.catch` after it claims a foreign throw
+              ;; as this row's and fires `done` a second time.
               (.catch (fn [e]
                         (is false (str "mounted (frame) fixture rejected: " e))
-                        (done)))))))))
+                        nil))
+              (.then (fn [] (done)))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/raw_state_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/raw_state_test.cljs
@@ -363,6 +363,11 @@
         (is (= 1 @calls)
             "concurrent in-flight signals for the same build share ONE configure round-trip")
         (when-let [r @resolve-fn*] (r nil))
+        ;; The claim is already asserted above; this chain only waits for both
+        ;; signals to SETTLE, either way. The swallow sits UPSTREAM of the
+        ;; single trailing `done` (rf2-qpns) — `done` runs the whole remainder
+        ;; of the run synchronously, so a `.catch` after it would swallow a
+        ;; foreign throw and fire `done` a second time.
         (-> (js/Promise.all #js [p1 p2])
-            (.then (fn [_] (done)))
-            (.catch (fn [_] (done))))))))
+            (.catch (fn [_] nil))
+            (.then (fn [_] (done))))))))


### PR DESCRIPTION
Closes rf2-qpns.

`cljs.test/run-block` hands `done` a continuation that runs the **whole remainder of
the run synchronously** — the file's later rows, then every namespace after it. Anything
out there that throws unwinds back into the callback that called `done`, so a `.catch`
placed *downstream* of that callback claims the foreign failure as its own: this row's
label, printed against whichever test is current by then, reading a DOM its own teardown
already emptied. It then calls `done` a **second** time, which does not merely warn —
`Delay`'s `-deref` clears `f` only after the body returns, so a delay whose body threw is
still unrealized and the second call **re-runs the offending namespace**.

The repair is the positional one rf2-d3tc landed in #7937, and it is the shape
`checkpoint-support/at-the-checkpoint` already used: the rejection handler goes
**upstream**, reports and releases but never finishes, and exactly **one** `done` sits at
the tail with nothing after it.

## The true count: 22, not 21 — and the bead's own criterion is why

The bead's title says 21 and its census names 21 sites. I re-derived the population from
the landed tree rather than trusting it. Three numbers came out, and they are three
different questions:

| population | count | what it is |
|---|---|---|
| chains whose `.catch` sits downstream of a `done`-calling step | **303** | every instance of the defect, repo-wide, 83 files |
| of those, where the `done`-step is the bare `(.then (fn [_] (done)))` | **22** | the purely-positional repair — **this PR** |
| the rest | **281** | `done` buried among assertions/teardown — *not* positional |

**The 21/22 split is not arbitrary, and finding out why is the main result here.** The
bead's census selected chains matching `(.then (fn [_] (done)))` literally. That literal
turns out to name exactly the chains where rf2-d3tc's swap is *safe*: when the trailing
step is a bare `done`, a `.catch` falling through to it cannot re-run assertions or
re-tear-down. Where `done` is buried among other work the swap is **not** behaviour-
preserving. `behaviors_dom_cljs_test.cljs:179` is the counter-example —

```clojure
(.then (fn [_] ... (ms/destroy-root! container root) (done)))
(.catch (fn [e] (is false ...) (ms/destroy-root! container root) (done)))
```

— where a naive swap would destroy the root **twice** on the failure path. Those 281 need
`done` split out into its own trailing step first, and whether the teardown belongs on
both paths is a per-site judgement. That is a different, larger bead — filed as **rf2-fyba**
with the full census, the per-tree breakdown (freehand 170, pair-MCP 39, http 21,
hicasso 15, xray 13, ui 10, adapters 8, and one apiece elsewhere) and the scanner
signature that produced it. It is not this one, and the bead's `BOUNDED REPAIR`
instruction is right to exclude it.

**The one site the bead's census missed**:
`implementation/ui/test/re_frame/ui/frame_ops_dom_cljs_test.cljs:93` writes
`(.then (fn [] (done)))` — **zero-arity** `fn`, so a literal `(fn [_] ...)` census walks
past it. It is the same defect and the same purely-positional repair, so it is repaired
here and the count is 22. `implementation/http/test/re_frame/http_cljs_test.cljs:566` is
in the bead's list and is genuinely pure; a comment sits between its two steps, which is
why an adjacency-only scan can miss it.

## Per-chain dispositions

**Fixed — 22 purely-positional chains in 11 files, plus 1 helper-forced (23 total):**

| file | chains |
|---|---|
| `hicasso/activity_suspense_dom_cljs_test.cljs` | 408, 582, 720 |
| `hicasso/kernel_commit_owns_dom_cljs_test.cljs` | 323, 401, 460, 566 **+ 511** |
| `hicasso/read_extent_dom_cljs_test.cljs` | 532, 601, 672 |
| `freehand/compiled_keyed_run_dom_cljs_test.cljs` | 191 |
| `freehand/custom_element_dom_cljs_test.cljs` | 302 |
| `freehand/mount_support.cljs` | 446, 462 |
| `freehand/ownership_maps_dom_cljs_test.cljs` | 541 |
| `freehand/pilot_react_interop_dom_cljs_test.cljs` | 243 |
| `http/test/re_frame/http_cljs_test.cljs` | 566, 610, 647, 678 |
| `ui/test/re_frame/ui/frame_ops_dom_cljs_test.cljs` | 93 |
| `re_frame2_pair_mcp/raw_state_test.cljs` | 367 |

The three Hicasso files rename their local `fail-and-finish!` to `report-failure!` — the
name rf2-d3tc chose — dropping the `done` parameter and returning `nil`. The other eight
files keep their existing anonymous-handler shape, per the bead's "reuse each file's
existing local helper shape and do not add a framework".

**`kernel_commit_owns:511` is the one non-positional chain repaired**, and only because
that file's `fail-and-finish!` signature changed under it. Its `done`-step is
`(.then (fn [_] (reset! !throw? false) (done)))`, not bare — but the swap is still safe
and in fact improves it: the trailing step now runs on **both** paths, so the
`(reset! !throw? false)` the two arms used to duplicate is stated once.

**`freehand/mount_support.cljs` is the high-leverage one.** `each-mode` and `run-async`
are the shared matrix sequencers; their docstrings already promised "call `done` EXACTLY
ONCE" and the old shape did not keep that promise. Repairing the two helpers repairs the
contract for every caller.

**Left correct, and named as such:**

- `implementation/hicasso/test/re_frame/hicasso/reincarnation_paint_dom_cljs_test.cljs`
  — already repaired by #7937; the donor of the shape. Untouched.
- `implementation/hicasso/test/re_frame/hicasso/checkpoint_support.cljs`
  — `at-the-checkpoint` already had the correct shape before either bead. Untouched.
- `tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/probe_test.cljs:287` — the `.catch`
  **is** the row's own success path (`(is false "must reject")` sits in the `.then`).
  A genuine error path, not the defect. Untouched.
- `implementation/core/src/re_frame/test_support.cljc:949,1035` — prose inside a
  docstring and a comment, not live chains. A raw text sweep hits both; neither is code.
  Untouched.
- The remaining **281** defective-shape chains — real instances of the same defect, but
  not the purely-positional repair. Named in full in the follow-on bead, not smoothed over.

`raw_state_test:367`'s `.catch` swallows rather than asserts — the claim is already
asserted above it and the chain only waits for both signals to settle. That intent is
preserved: the swallow moved upstream and returns `nil`, and the single trailing `done`
still fires either way.

## Reproduction control — both directions

Proved the way rf2-d3tc proved it, because a green aggregate is not proof: the runner
echoes the browser console **only on failure**, so a pass prints `0 failures` and shows
nothing else.

A throwaway namespace `re-frame.hicasso.read-extent-zz-control-dom-cljs-test` sorts
strictly between `read-extent-dom-cljs-test` and `reincarnation-paint-dom-cljs-test`, so
whatever it throws unwinds into the **last `done` `read_extent` called** — the
`activity-reveal witness` row at :672 that the bead captured. It is rf2-d3tc's control in
shape: a fn-form `:each` fixture paired with an `async` row, which selects `:sync`, wraps
the test fn in `disable-async`, and makes `test-var-block*` rethrow a bare **String**
synchronously inside whichever `done` continuation was running.

**Direction 1 — control present, `read_extent` reverted to its pre-fix bytes**
(`git checkout 5ac9d4aa17 -- read_extent_dom_cljs_test.cljs`; everything else repaired).
`npm run test:browser` → **captured exit 1**:

```
Testing re-frame.hicasso.read-extent-dom-cljs-test
Testing re-frame.hicasso.read-extent-zz-control-dom-cljs-test
FAIL in (a-delayed-row-that-needs-async) (:)
activity-reveal witness —  | ownership {:cells 0, :cell-refs 0, :boundaries 0, :edges 0}
expected: false
  actual: false
Testing re-frame.hicasso.read-extent-zz-control-dom-cljs-test     <-- the ns RE-RAN
FAIL in (a-delayed-row-that-needs-async) (:)
suspense-retry witness —  | ownership {:cells 0, :cell-refs 0, :boundaries 0, :edges 0}
expected: false
  actual: false
WARNING: Async test called done more than one time.
```

Every part of the bead's predicted signature, and one part it did not predict:

- **the blank message slot** after the em-dash — what cljs.test threw is a bare String,
  which has no `.message`;
- **`ownership {:cells 0, …}`** — the row read a runtime its own teardown had already
  emptied;
- **two** of `read_extent`'s rows claimed the same foreign throw, in cascade;
- **`Testing re-frame.hicasso.read-extent-zz-control-dom-cljs-test` printed TWICE** —
  the second `done` re-forced the unrealized delay and the offending namespace *ran
  again*, exactly as the bead said it would;
- and then the lane **hung**: `Timed out after 360000ms waiting for cljs.test summary`,
  `(missing "Ran ... assertions." line)`. Not one red row — no summary at all.

**Direction 2 — the identical control, `read_extent` restored** (restore verified by
hashing the bytes, not `git diff`: `sha256 1eb75b15640499fcc6907d9aeef297952086d781b2a25d079e7277630ce13887`
before and after). `npm run test:browser` → **captured exit 1**:

```
Testing re-frame.hicasso.read-extent-dom-cljs-test
Testing re-frame.hicasso.read-extent-zz-control-dom-cljs-test
[browser:pageerror] Async tests require fixtures to be specified as maps.  Testing aborted.
```

The throw now escapes as an honest `pageerror`, named for what it actually is and
attributed to **nobody**. No `activity-reveal witness`, no `suspense-retry witness`, no
`WARNING: Async test called done more than one time`, and the control namespace is
announced **once** instead of twice. Exit is still 1 because the control genuinely aborts
cljs.test — the string it throws says so — which is the control doing its job, not the
defect doing its.

The control was then removed; the gate numbers below are from the tree as it ships.

## Quality gates

Each run alone, nothing appended, exit code redirected and echoed on one command line in
one shell; `*.exit` artefacts deleted between runs. **The numbers below are the ones
CAPTURED**, not the ones the harness narrated.

| gate | cwd | captured exit | result |
|---|---|---|---|
| `npm run test:browser` | `implementation/` | **0** | Ran **1293** tests containing **8008** assertions. 0 failures, 0 errors. |
| `npm run test:cljs` | `implementation/` | **0** | Ran **13345** tests containing **67211** assertions. 0 failures, 0 errors. |
| `npm run test:freehand` | `implementation/` | **0** | Ran **1406** tests containing **7786** assertions. 0 failures, 0 errors. |
| `npm test` | `tools/re-frame2-pair-mcp/` | **0** | Ran **1224** tests containing **4440** assertions. 0 failures, 0 errors. |

The browser lane is the one that decides this — the node lane's DOM assertions degrade to
stated skips, which are honest but are not measurements. `test:freehand` and the pair-MCP
suite are here because this PR touches a shared freehand helper (`mount_support.cljs`) and
a pair-MCP suite, and neither is decided by the first two lanes.

The pair-MCP gate's **first** attempt captured exit 1 on
`'shadow-cljs' is not recognized as an internal or external command` — environmental, a
fresh worktree has no `tools/re-frame2-pair-mcp/node_modules`. Junctioned to the primary
checkout's real tree and re-ran the gate **whole**; the 0 above is that re-run.

`scripts/check_fast_pr_gap.py --list` reports **97 required checks the fast-PR spine does
not decide**. The one that matters here is category (B) — `cljs-browser`
(`npm run test:browser`) has **no lane in the spine at all**, which is exactly the lane
this defect lives on and the lane run by hand above. Also unrun by the spine:
`cljs-ui-g13`, `cljs-browser-schemas-boundary-prod`, `cljs-browser-prod-elision`,
`adapter-testbed-smokes`, `ui-smoke`, `story-xray-browser`,
`tenant-switcher-testbed-smoke`.

**Test counts did not move, and that is the expected answer here.** The browser lane
reads **1293**, which is exactly where rf2-77px left it (1284 → 1293, when a killed
namespace came back). This diff adds and removes no `deftest` — it reorders two steps of
eleven promise chains — so a moved count would have been evidence of a *mistake*, most
likely a namespace silently dropped from a build. It did not move.

## Not done, deliberately

No suite was retuned to dodge the async window — the `rf2-hic-029` refusal is right that
a delayed-callback claim which avoids the async window is not the claim. No assertions
were weakened, no teardown removed, no framework added.
