### PR TITLE
docs(xray): the deck's retirement rests on five facts, not all nine, and costs eight artefacts (rf2-u5b4)

### DIFF
--- a/tools/xray/spec/017-Test-Coverage-Matrix.md
+++ b/tools/xray/spec/017-Test-Coverage-Matrix.md
@@ -366,14 +366,51 @@ that §3.4.1 and §3.4.2 cannot move to `re-frame.hicasso.tool`, because five of
 their eight questions have no answer there, so they stay on
 `re-frame.freehand.tool` until the Freehand tree goes. This deck is the
 browser-lane populated arm of exactly those two sections and has no other
-consumer, and every fact its scenario asserts — the view id, the occurrence key,
-the lowering, the per-row generation, the declared sites — sits in that
-disposition's **none** column. Repointing it would leave a scenario asserting
-facts that cannot exist; removing it while the panel still ships would restore
-the gate-blindness rf2-6pohj closed. So it goes when they go, under rf2-hic-062,
-and it is four artefacts: this source tree, the `:testbeds/freehand-views` build
-id, its port-8036 `:dev-http` entry, and the scenario together with its
-`STAGED_SURFACES` wiring.
+consumer.
+
+**Five of the nine facts its scenario asserts are the ones with no answer**, and
+they are the five this section describes above as the deck's reason for
+existing: the view id each row names, the occurrence key (both as row identity
+and as three freshly minted keys across a remount), the stated lowering, the
+per-row generation the tag prints, and the Declared View Sites section with its
+three manifest arms. **The remaining four are not**, and the record must not say
+they are — the frame carries across, the commit's reads degrade to a live edge
+set, the absent schema banner tests a Freehand-door read Hicasso does not
+publish, and the reactively-driven repaint is a substrate fact rather than one of
+§3.4's questions. So a re-point would leave a deck still asserting something; it
+is the five that make what it asserted stop being a populated ROSTER, and what
+survives is already rendered whole by the Hicasso tab. Removing it while the
+panel still ships would instead restore the gate-blindness rf2-6pohj closed.
+
+**So it goes when they go, under rf2-hic-062 — and it is EIGHT artefacts, not
+four.** Four are the deck; four more name it by build id or by scenario name
+from outside it. Exactly one reds a gate. The other seven go quietly stale,
+which is why this is a written checklist rather than a grep.
+
+| # | Artefact | The retirement pass | If left behind |
+|---|---|---|---|
+| 1 | `tools/xray/testbeds/freehand_views/` — `core.cljs` and `index.html` | delete the tree | dead source under a build id that is also going |
+| 2 | the `:testbeds/freehand-views` build in `implementation/shadow-cljs.edn` | delete the build map | a build compiling a deleted tree |
+| 3 | its port-8036 `:dev-http` entry in `implementation/shadow-cljs.edn` | delete the entry, freeing the 803x slot | a served root that no longer exists |
+| 4 | the `freehand-views populated Views roster` scenario and its `STAGED_SURFACES` entry in `tools/xray/testbeds/feature_matrix/scenarios.cjs` | delete both | **reds the PR smoke gate** against a panel that is gone |
+| 5 | the `DEV_HTTP` entry and the port-band comment in `implementation/scripts/dev-testbed.cjs` | delete both | the launcher advertises a URL for a build id shadow-cljs no longer knows — silently, because the drift guard in `dev-testbed.test.cjs` runs shadow-cljs → `DEV_HTTP` and never the reverse |
+| 6 | the build→URL row in `implementation/README.md` | delete the row | a documented testbed nobody can start |
+| 7 | the canonical covered-row pin in `coverage_matrix_metadata_test.clj` | drop it by one and rewrite its `12 -> 13` note | **RED, and the only one.** This scenario is the sole claimant of the `Mounted view reads (Freehand tool door, rf2-7gth0)` row, so the count moves the moment it goes |
+| 8 | the PR-smoke enumeration in `.github/workflows/test.yml` | drop the deck from the named list: 5 scenarios → 4, 4 staged surfaces → 3, 4 bundles → 3, and 12 → 11 in the nightly sweep | a comment naming a scenario that no longer exists |
+
+Beyond the eight, three re-reads rather than removals. The dated aggregate
+costings in `implementation/scripts/serve-and-run-xray-feature-gate.cjs` and in
+this document's own opening move with row 8's numbers, but neither names the
+deck and both already carry the date they were measured, so re-date them rather
+than treat them as breakage. [`027-Hicasso-Evidence.md`](027-Hicasso-Evidence.md)
+records that this deck's build id, port and scenario slot free up together at
+rf2-hic-062 — true, and written about the moment rather than outliving it. And
+the reactively-driven repaint above is the only browser-level proof that
+`:adapter/activate-derived-value!` holds end to end in a real DOM, while
+`re-frame.hicasso.impl.collector` calls that hook as well as the Freehand
+observation port does — so it is the one asserted fact whose MECHANISM outlives
+the deck, and the pass should confirm the surviving caller keeps a witness
+rather than assume the proof retires with the Freehand cells.
 
 ## Cross-references
 

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -974,26 +974,50 @@ that moment: a Hicasso host's boundaries, reads, intents and explanations are
 answered in full by the Hicasso tab, and what disappears is exactly the set of
 questions only a view registry could have answered.
 
-**The staged `freehand-views` deck inherits this disposition, and retiring it is
-four artefacts rather than one** (rf2-u5b4, against census rows X6/X7/X8). The
-deck exists for no purpose other than putting real connected occurrences in
-front of §3.4.1 and §3.4.2, so it cannot be migrated separately: every fact its
-scenario asserts is one the table above puts in the **none** column — the view
-id, the occurrence key, the lowering, the per-row generation and the whole
-Declared View Sites section — leaving it nothing to assert but the frame and a
-read set scoped to the live boundary rather than to the commit. Nor can it go
-early: retiring it while the panel still ships would restore the gate-blindness
-rf2-6pohj closed, an empty roster and a roster emptied by a broken read being
-the same DOM. What goes with §3.4.1 and §3.4.2 is therefore
+**The staged `freehand-views` deck inherits this disposition** (rf2-u5b4,
+against census rows X6/X7/X8). It exists for no purpose other than putting real
+connected occurrences in front of §3.4.1 and §3.4.2, so it cannot be migrated
+separately — but the reason is FIVE of its assertions rather than all of them,
+and the distinction is worth stating precisely, because an absolute here would
+be false and would make the disposition read as special pleading.
+
+Its scenario asserts nine facts. **Five are identity or declaration facts, and
+every one of them sits in the table's none column**: the view id each row names,
+the occurrence key (asserted twice — as a row's identity, and as three freshly
+minted keys after a remount), the stated lowering (one interpreted against two
+compiled), the per-row generation the tag prints, and the whole Declared View
+Sites section with its three manifest arms. Those five are the deck's entire
+subject, because a populated roster IS identity plus declaration: re-pointed at
+the target, the scenario would have nothing left to be the populated arm OF.
+
+**The other four are not in that column.** The frame carries across unchanged.
+The commit's reads degrade rather than vanish, to the boundary's live edge set.
+The absent schema banner tests the Freehand door's version stamp, which the
+four-read Hicasso door does not publish at all, so it has no counterpart even to
+degrade to. And the reactively-driven repaint (rf2-2t126) is not one of §3.4's
+questions in the first place: it is a substrate fact about a Freehand `ViewCell`
+being notified through `:adapter/activate-derived-value!`. None of the four
+rescues the deck — the frame and the read set are already rendered whole by
+[`027-Hicasso-Evidence.md`](027-Hicasso-Evidence.md)'s tab, so a deck kept alive
+to re-assert them would be a second witness to a covered fact and no witness at
+all to the five that matter.
+
+Nor can it go early: retiring it while the panel still ships would restore the
+gate-blindness rf2-6pohj closed, an empty roster and a roster emptied by a broken
+read being the same DOM.
+
+**Retiring it is EIGHT artefacts, not four.** Four are the deck itself —
 `tools/xray/testbeds/freehand_views/`, the `:testbeds/freehand-views` build id
 and its port-8036 `:dev-http` entry (both in top-level
 `implementation/shadow-cljs.edn`), and the PR-smoke `freehand-views populated
 Views roster` scenario in `tools/xray/testbeds/feature_matrix/scenarios.cjs`
-together with its `STAGED_SURFACES` entry. A pass that takes the two sections
-and the `deps.edn` coordinate but leaves those behind reds the PR gate on a
-scenario whose panel no longer exists.
-[`017-Test-Coverage-Matrix.md`](017-Test-Coverage-Matrix.md) carries the deck's
-own record.
+together with its `STAGED_SURFACES` entry. Four more name the deck by build id
+or by scenario name from outside it, and exactly one of the eight reds a gate;
+the other seven fail silent, which is why
+[`017-Test-Coverage-Matrix.md`](017-Test-Coverage-Matrix.md) carries the whole
+checklist as part of the deck's own record rather than leaving it to a grep. A
+pass that takes the two sections and the `deps.edn` coordinate but leaves the
+deck behind reds the PR gate on a scenario whose panel no longer exists.
 
 ### §3.5 Queries
 


### PR DESCRIPTION
## What this is, and what it is not

`rf2-u5b4` was filed as *migrate the staged freehand-views deck*. That migration
was **refused** in PR #7869, and the refusal stands — nothing here revisits it.
The bead was then reopened by the merged-PR audit of #7869 for a **bounded
correction to the retirement record that refusal landed**, and this PR is only
that. The audit made two claims. **Both hold at source**, and one of them
understates the problem.

**The `implementation/shadow-cljs.edn` window was not needed and is released
unheld.** This PR does not touch it, and touches no build config, no port, no
scenario and no source. Two markdown files under `tools/xray/spec/`.

## Claim 1 — the absolute was false, and the document contradicted itself

Both landed sections said every fact the `freehand-views` scenario asserts sits
in §3.4.3's **none** column. `021-Dynamic-Panel-Designs.md` then conceded, in
the same sentence, that the deck is left "nothing to assert **but the frame and
a read set**" — which is not nothing, so the absolute was refuted by its own
clause.

Re-read against `runFreehandViewsPopulatedRoster` in
`tools/xray/testbeds/feature_matrix/scenarios.cjs` (L1262–L1425), the scenario
asserts **nine** facts, and they split five/four against the §3.4.3 table.

**The five with no answer — all of them identity or declaration facts. These are
what justifies retiring the deck:**

| # | Asserted fact | Where the scenario asserts it | §3.4.3 table row |
|---|---|---|---|
| 1 | the **view id** each row names | `rowFor` over `FREEHAND_VIEW_IDS` (L1134–1138, L1299–1301) | *Which VIEW is mounted* → **none** |
| 2 | the **occurrence key** — twice: as row identity, and as three FRESHLY MINTED keys after an unmount/remount | `occurrenceOf` (L1200), the remount predicate (L1411–1424) | *Which OCCURRENCE of it* → **none** |
| 3 | the **stated lowering**, one interpreted against two compiled | tag-prefix anchors (L1315–1325) | *Compiled or interpreted* → **none** |
| 4 | the **per-row generation** the tag prints (the token, not the number) | the same anchors — `'interpreted · gen'` / `'compiled · gen'` | *When, at which generation* → **none per row** |
| 5 | the whole **Declared View Sites** section and its three manifest arms | L1350–1374 | *What each view DECLARES* → **none** |

**The four that are NOT in that column, which the record must stop claiming
are:**

| Asserted fact | Where | Actual status on `re-frame.hicasso.tool` |
|---|---|---|
| the **frame** (`:rf/default` on every row) | L1335 | **carries across unchanged** — the table's own `:frame` row |
| the **commit's reads** (`1 read` on the sole reader, `0 reads` elsewhere) | L1329–1331 | **degrades**, to the boundary's live edge set — the table's one *degrades* row |
| the **absent schema banner** | L1292–1295 | not in the table at all: it tests `re-frame.freehand.tool/schema-status`, and the four-read Hicasso door publishes no schema read, so there is nothing even to degrade to |
| the **reactively-driven repaint** (rf2-2t126) | `expectReactiveRepaint`, L1229–1260 | not one of §3.4's questions: a substrate fact about a Freehand `ViewCell` notified through `:adapter/activate-derived-value!` |

Both documents now state the five, name the four, and say why none of the four
rescues the deck: the frame and the read set are already rendered whole by
`027-Hicasso-Evidence.md`'s tab, so a deck kept alive to re-assert them would be
a second witness to a covered fact and no witness at all to the five that
matter.

## Claim 2 — the inventory was short by half, and one of the four reds a gate

The record claimed **four** artefacts. It is **eight**. All four the audit named
verify at source; `git grep -l -E "freehand.views|freehand_views"` over tracked
files returns 14 paths and reconciles with the list.

| # | Artefact | Verified at | Red or silent |
|---|---|---|---|
| 1–4 | the deck tree, the build id, the port-8036 `:dev-http` entry, the scenario + `STAGED_SURFACES` | already named | scenario removal reds the PR smoke gate |
| 5 | `DEV_HTTP` entry + port-band comment, `implementation/scripts/dev-testbed.cjs` | L93, L150 | **silent.** The drift guard in `dev-testbed.test.cjs` (L285–326) runs shadow-cljs → `DEV_HTTP` and never the reverse, so a stale launcher entry stays green while advertising a URL for a build id shadow-cljs no longer knows |
| 6 | build→URL table row, `implementation/README.md` | L419 | silent |
| 7 | the canonical covered-row pin, `coverage_matrix_metadata_test.clj` | L249–256, `(is (= 13 (count canonical)))` | **RED, and the only one.** `git grep "Mounted view reads"` confirms this scenario is the SOLE claimant of that row (`coveredRows` at `scenarios.cjs` L3823), so the count moves the moment it goes |
| 8 | the PR-smoke enumeration, `.github/workflows/test.yml` | L4096–4103 | silent, but genuinely wrong rather than merely stale: it names `freehand-views Views roster` in its five-scenario list |

**Row 8's numbers verified live**, not read off the comment. Requiring
`scenarios.cjs` and applying the launcher's own derivation:
`SCENARIOS.length = 17`, `STAGED_SURFACES.length = 12`, smoke arm = **5
scenarios over 4 surfaces** (`/counter/` ×2, `/testbeds/freehand-views/`,
`/testbeds/deliberate-throw/`, `/testbeds/panel-gallery/#/stories`). Dropping
the deck gives 4 / 3 / 3, and 11 nightly.

## One thing the audit did not name, and it is the sharpest of them

The record should not claim every asserted fact dies with the deck, because
**one of them is about a mechanism that outlives it**.
`interop/activate-derived-value!` — the hook the repaint assertion witnesses end
to end in a real DOM — is called by `re-frame.hicasso.impl.collector` (L675) as
well as by `re-frame.substrate.observation` (L1982), which is the Freehand
port's route. 017 now records this as a re-read for the retirement pass:
confirm the surviving caller keeps a witness rather than assume the proof
retires with the Freehand cells. **No coverage work is proposed or done here** —
the bead fences it, and a bead already exists for the adjacent surface
(rf2-r98a, since closed by PR #7895).

Two further re-reads are recorded for the same pass: the dated aggregate
costings in `implementation/scripts/serve-and-run-xray-feature-gate.cjs` (L65)
and in `017`'s own opening (L38–39) move with row 8's numbers but name no deck
and carry their measurement date, so they are re-dated rather than treated as
breakage; and `027-Hicasso-Evidence.md` (L564) is written about the moment of
retirement rather than outliving it.

## A census failure species, hit again

`spec/004D-Freehand-Compiled-Grammar.md` L969 matches the deck's own grep and is
a **name-collision over-count** — it is the anchor
`API.md#freehand-views--re-framefreehand-spec-004`, naming the *Freehand views
feature*, not the deck. It is excluded from the inventory. (That tree is fenced
to `ssrname-mo4o` in any case; nothing here touches `spec/**`.)

## Placement, and the lane that decides this diff

Nothing moved, and markdown compiles nowhere, so the placement question is which
lane **validates** the destination. It is `scripts/check_doc_slugs.py`, which
covers `tools/*/spec/**/*.md` and runs both in the fast-PR spine and as its own
`docs.yml` job. **`mkdocs build --strict` does NOT reach this tree** —
`mkdocs.yml` sets `docs_dir: docs`, so `tools/xray/spec/` is outside the site
entirely; nominating it would have been the wrong gate.

`check_doc_slugs.py` is silent on success, so silence was not accepted as
evidence. A `#planted-anchor-deck-u5b4` fragment was appended to the NEW
cross-link in the new closing paragraph of `017` and the checker re-run: it went
to **exit 1** and named the plant precisely —

```
BROKEN ANCHOR: tools\xray\spec\017-Test-Coverage-Matrix.md:407 -> 021-Dynamic-Panel-Designs.md#planted-anchor-deck-u5b4
```

— which proves the checker reaches this tree, this file and this specific new
paragraph rather than passing vacuously. Planted and reverted with Python
(never `sed -i`, which rewrites CRLF→LF on Windows and leaves `git diff` reading
clean over changed bytes), and the restore verified **by hash**:

```
b727cecdae5cf5e9d21259a7c367dd1cb34339101b2bc439a18daacdb5f66774  017-Test-Coverage-Matrix.md
0d03b8983cbb849f5c413d7e4334abb4ec0a44ca529dff901508ae6663e7e670  021-Dynamic-Panel-Designs.md
```

identical before the plant and after the revert.

## Quality gates

| gate | CAPTURED exit | note |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | `0` | `gate root: /c/Users/miket/code/re-frame2-worktrees/deck-u5b4`. Classified `docs=true jvm=false node=false` — the correct lane for a `tools/xray/spec/*.md`-only diff |
| `python scripts/check_doc_slugs.py` | `0` | run alone; coverage proved by the planted anchor above (exit `1` under the plant, `0` after revert) |
| `python scripts/check_fast_pr_gap.py --list` | `0` | **97** required checks the spine does not decide, across the three required contexts `All required checks passed` (test.yml), `Lint required` (lint.yml), `Docs required` (docs.yml) |

Each gate was run **alone**, redirected to its own log with the exit code echoed
on the same command line, and every `.exit` artefact was deleted before the run.

**Not run, and why.** `scripts/test-jvm-implementation.sh`,
`scripts/test-jvm-tools.sh`, `scripts/test-rigorous-local.sh` — the diff is two
markdown files, reaches no compiled surface, and the spine's own classifier
agrees (`jvm=false node=false`). `mkdocs build --strict` — this tree is not in
the site (above). No `implementation/node_modules` junction was created, so none
had to be removed.

## `implementation/shadow-cljs.edn` lines added

**None.** The file is untouched — `git diff --stat` is two paths, both under
`tools/xray/spec/`. The bead's premise was that this cluster needed a build id
and a `:dev-http` port moved; PR #7869 established that nothing moves, and this
correction is to the record of that, so the hot-zone window is released without
having been used.

## Spec sync

Per the standing `tools/xray/` rule, **this PR is the spec change**. No coverage
moved and no matrix row's disposition changed, so §017's coverage rows and
§021's §3.4.3 comparison table are untouched.

**Hand-verified** (nothing validates these): the one table added to `017` is
4-column throughout — header, separator and all eight body rows checked
programmatically, 0 mismatches. No existing table was altered, so no column
count changed. No headings were added or renamed, so no anchors were minted or
invalidated; all four cross-links (`017` ↔ `021`, `017` → `027`, `021` → `027`)
resolve to siblings in `tools/xray/spec/` and are covered by the slug checker
proved live above.

## Bead

`rf2-u5b4` — closed against this PR. Not merged; the mayor merges.
