### PR TITLE
docs(hicasso): stop claiming a per-request server adoption window nothing installs

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/presence_react.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/presence_react.cljs
@@ -127,10 +127,22 @@
         ;; false for every ordinary mount and false again the moment
         ;; THIS root's closer commits.
         ;;
-        ;; A SERVER render entry opens a window of its own around its own
-        ;; request, so the server's HTML and the client's first pass agree
-        ;; by construction; that agreement is the whole reason the window
-        ;; is read here in the RENDER rather than in the effect below.
+        ;; Read here in the RENDER rather than in the effect below
+        ;; because the first client pass must ALREADY be `:present`: an
+        ;; effect runs after that pass has painted `::h/mounting` over
+        ;; DOM the server already delivered, which is the flash this
+        ;; branch exists to avoid.
+        ;;
+        ;; THE SERVER HALF DOES NOT EXIST YET (rf2-kpig). Nothing in
+        ;; this tier opens a window around a server render, so
+        ;; `adopting-here?` reads `nil` there and the tray emits
+        ;; `:mounting` children that the hydrating client then renders
+        ;; `:present` — the divergence measured in
+        ;; `re-frame.hicasso.presence-ssr-seam-dom-cljs-test`.
+        ;; rf2-hic-046 has RULED the Render arm: a request-scoped
+        ;; server door will mint one window per request and make the
+        ;; two halves agree by construction. Until it lands, this line
+        ;; is client-only.
         next       (if (roots/adopting-here?) (presence/settle stepped) stepped)]
     ;; Adjusting state while rendering — React's own answer to "a value
     ;; derived from props that must persist". `step` is idempotent, so the

--- a/implementation/hicasso/src/re_frame/hicasso/impl/roots.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/roots.cljs
@@ -51,9 +51,22 @@
 (defn open-adoption-window!
   "Open a window and answer it — the ONLY handle on it there is.
 
-  Minted per `hydrate-root!` call and per server render/request. Born
-  open: the renders that follow it are adopting server-rendered DOM until
-  something calls [[close-adoption-window!]] on this very object.
+  Minted per `hydrate-root!` call — TODAY'S ONLY MINTER. Its one
+  product consumer is `impl.mount/tree`, which scopes it over that
+  root's subtree with [[with-adoption]] when the handle carries an
+  `:adoption`. **No server-render entry exists in this tier**, so a
+  server render finds no provider above it, reads the adoption
+  context's `nil` default, and [[adopting?]] calls that closed —
+  measured in `re-frame.hicasso.presence-ssr-seam-dom-cljs-test`.
+
+  rf2-hic-046 has RULED the Render arm for motion and presence, which
+  adds a second minter: one window per server render/request, scoped
+  over that request's tree (rf2-6tmu's repair shape, item 5). That
+  door is named here because it is DECIDED, not because it is built.
+
+  Born open: the renders that follow it are adopting server-rendered
+  DOM until something calls [[close-adoption-window!]] on this very
+  object.
 
   A bare mutable ref rather than a registry entry, and deliberately.
   A registry keyed by frame cannot work — several roots may intentionally

--- a/implementation/hicasso/test/re_frame/hicasso/presence_ssr_seam_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/presence_ssr_seam_dom_cljs_test.cljs
@@ -59,23 +59,27 @@
   control shows the divergence is caused by the missing provider and by
   nothing else.
 
-  ## Two source comments currently overstate this, and they are OUTSIDE
-  this suite's fence
+  ## Two source comments used to overstate this, and no longer do
 
-  Both speak in the present tense about a server door that does not
-  exist. They are runtime source and this dispatch may not edit them;
-  they are recorded here so the next reader of either line finds the
-  measurement rather than trusting the prose:
+  Both spoke in the present tense about a server door that does not
+  exist. They are runtime source and THIS suite's dispatch could not
+  edit them, so it recorded them verbatim instead; rf2-kpig has since
+  corrected both, and each now names the measurement rather than a
+  mechanism:
 
-      impl/roots.cljs:54          \"Minted per `hydrate-root!` call and
-                                   per server render/request.\"
-      impl/presence_react.cljs:130 \"A SERVER render entry opens a window
-                                   of its own around its own request, so
-                                   the server's HTML and the client's
-                                   first pass agree by construction\"
+      impl/roots.cljs:54           the window is minted per
+                                   `hydrate-root!` call and that is
+                                   the only minter — no server-render
+                                   entry exists in this tier
+      impl/presence_react.cljs:130 the server half does not exist yet,
+                                   so `adopting-here?` reads `nil` on a
+                                   server render and the tray emits
+                                   `:mounting` children
 
-  §1 and §3 are the counter-measurement: they do not agree, and nothing
-  opens a window around a request.
+  Both now cite rf2-hic-046's RULED Render arm as DECIDED rather than
+  built, and both cite this file. §1 and §3 remain the
+  counter-measurement standing behind them: the two halves do not
+  agree, and nothing opens a window around a request.
 
   ## Why the existing presence witness did not catch this
 


### PR DESCRIPTION
Closes rf2-kpig.

Two runtime comments described a **per-server-request adoption window** in the
present tense. Nothing installs one.

## The premise held, and I re-measured it rather than relying on the brief

- `git grep -n "with-adoption"` over the tree: exactly **one** product-source
  caller — `implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs:107`,
  inside `impl.mount/tree`, guarded on a handle carrying `:adoption`, which only
  `hydrate-root!` mints. No server entry, no request scope, no render helper.
- `git grep` for `react-dom/server` / `renderToString` / `renderToStaticMarkup`
  under `implementation/hicasso/src/**`: **two prose mentions**
  (`impl/codec.cljs:1276`, `impl/intent.cljs:356`) and **zero requires or
  callers**. Every real `react-dom/server` call under `implementation/hicasso/`
  is in `test/`.
- `git grep -in hicasso -- 'implementation/ssr/src/**'`: **no match** (exit 1).
  The JVM SSR artefact does not know hicasso exists.

So on a server render `roots/adopting-here?` reads the context default `nil`,
`adopting?` calls that closed, and the presence tray takes its `:mounting`
branch — the divergence `presence-ssr-seam-dom-cljs-test` already measures.

## Wrong, or merely early? Both, and the split is the whole edit

`rf2-hic-046`'s delegated ruling (2026-08-11) chose the **Render** arm for
HS-33, so the per-request door is **decided**. But that bead is still OPEN and
the door is **not built** — its own `rf2-hic-034` has not landed. The comments
were therefore not describing a future in future tense; they asserted a present
mechanism, and a reader auditing the server path stopped looking because of
them. The correction re-points each at what exists, and names the ruled door as
*decided rather than built* — the shape `native.cljc`'s own
*"What the policy does NOT yet do (Phase 3)"* section already uses one file
over.

**No adoption window is installed here.** That is `rf2-hic-046`'s deliverable.
Nothing in this PR needed it.

## What each comment said, and what it says now

**`impl/roots.cljs:54`** (`open-adoption-window!`)

- was: *"Minted per `hydrate-root!` call and per server render/request."*
- now: minted per `hydrate-root!` call — **today's only minter**; its one product
  consumer is `impl.mount/tree`; **no server-render entry exists in this tier**,
  so a server render finds no provider, reads the context's `nil` default, and
  `adopting?` calls that closed — measured in
  `presence-ssr-seam-dom-cljs-test`. Then a separate paragraph: `rf2-hic-046` has
  RULED the Render arm, adding a second minter (one window per server
  render/request, `rf2-6tmu` repair shape item 5) — *"named here because it is
  DECIDED, not because it is built."*

**`impl/presence_react.cljs:130`** (the born-present-under-adoption branch)

- was: *"A SERVER render entry opens a window of its own around its own request,
  so the server's HTML and the client's first pass agree by construction; that
  agreement is the whole reason the window is read here in the RENDER rather
  than in the effect below."*
- now: the *reason* is kept and re-grounded on the fact that survives — the
  first **client** pass must already be `:present`, because an effect runs after
  that pass has painted `::h/mounting` over adopted DOM. Then: **the server half
  does not exist yet**, `adopting-here?` reads `nil` there, the tray emits
  `:mounting` children the hydrating client renders `:present`, and
  `rf2-hic-046`'s ruled request-scoped door is what will restore the
  by-construction agreement. *"Until it lands, this line is client-only."*

## The witness file — a deliberate call the mayor can revert in one hunk

`presence_ssr_seam_dom_cljs_test.cljs` quotes both lines **verbatim** as its
counter-measurement. The bead fenced it *"until the comments are corrected"* —
that release condition is now met, and leaving a verbatim quote of text that no
longer exists would be the same defect one layer out. So its
§*Two source comments…* heading and its 17-line quote block now record that
`rf2-kpig` corrected both and what each says instead.

**Nothing else in that file moved** — §1–§4, the `settled-server-html!`
analysis, and the whole §*What closes this file* inversion instruction set are
byte-identical. `docs/design/hicasso/product/dispositions.md` was **not touched**:
HS-33's cell flips only on green witnesses, per the ruling.

## Sweep — 147 hits across 8 patterns, 3 files changed

`git grep -in <pattern> -- 'implementation/**' 'docs/**' 'spec/**' 'tools/**'`

| Pattern | Hits | Disposition |
|---|---|---|
| `per server render` | 1 | `impl/roots.cljs:54` — **CORRECTED**. The only carrier. |
| `server render entry` | 4 | `impl/presence_react.cljs:130` **CORRECTED**; `bench/hicasso/arm1/runtime.cljs:462` + `arm1/presence.cljs:117` + `ssr/entry.cljs:171` **LEFT — true there**: the arm1 bench prototype's `ssr/entry.cljs:355` genuinely calls `rt/open-adoption-window!` immediately before `rdom-server/renderToString`. The product tier is the one without the door, and that asymmetry is the finding, not a second bug. |
| `opens a window` | 3 | the two above, plus `tools/story/…/runner_events.cljc:1467` (*"a thenable opens a window the synchronous path…"*) — **LEFT**, unrelated sense. |
| `window of its own` | 2 | `docs/design/hicasso/product/budgets.md:116` (a *decision* window) and `roots_frames_shared_frame_dom_cljs_test.cljs:360` (*"each root minted a window OF ITS OWN"* — true of roots) — **LEFT**. |
| `around its own request` | 0 | the only two carriers were the corrected comment and its verbatim quote. |
| `Minted per` | 25 | `impl/roots.cljs:54` **CORRECTED**; the witness quote **UPDATED**; `spec/004D-Freehand-Compiled-Grammar.md:2054` (*"Minted per connected commit"*) and 22 others — **LEFT**, different mechanisms. |
| `per request` | 81 | all **LEFT**. Every one is about a *frame* per request (`re-frame.ssr`, `ssr-ring`, `docs/ssr/**`, `spec/002`, `spec/006`) or an unrelated per-request cost — a real, shipped mechanism, and not the adoption window. |
| `agree by construction` | 31 | all **LEFT** except the corrected comment. `impl/codec.cljs:1267,1279`, `impl/portal.cljs:109` and `docs/design/hicasso/studio/108-…:286` describe `codec/adopted?` — a `useSyncExternalStore` server-snapshot agreement that **does** exist; the rest are freehand/resources/story/xray surfaces. |

Also swept: every `server` mention under `implementation/hicasso/src/**` (~80
lines). Only the two named comments were false. `native.cljc:366-376` already
carries the honest *"consulted by no runtime path … a reader must not take
`{:server :render}` for a live instruction"* note — the model this edit copies,
and a file left alone for `ssrname-mo4o`.

**Held back, out of fence:** `dispositions.md:158` (HS-10) says `h/mount!`'s
recovery *"is the server render entry plus `h/hydrate!`"*, which names the same
unbuilt door. It is a `rf2-hic-046` table cell, so it stays for that bead.

## Quality gates

Each run alone, foreground, exit code captured from the run itself.

| Gate | Command | Captured exit |
|---|---|---|
| Hicasso / CLJS node lane | `cd implementation && npm run test:cljs` | **0** — `Ran 13345 tests containing 67211 assertions. 0 failures, 0 errors.` |
| Fast-PR spine | `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine` |

The spine ran its always-on static/drift block, the JS harness helpers and the
node tier (CLJS node integration + per-ns isolation); it **skipped** the docs
tier and the JVM artefact suites, both correctly — this diff touches no Markdown
and no JVM artefact.

`python scripts/check_fast_pr_gap.py --list` → **97 required checks this spine
does not decide.** By family: all 45 `test.yml` jobs with no local lane
(`cljs-browser`, `cljs-hicasso-controlled`, `cljs-hicasso-hmr`,
`cljs-bundle-isolation`, `cljs-browser-prod-elision`, the adapter smokes, the
tool JVM/MCP-conformance suites, …), all 5 `lint.yml` jobs (`clj-kondo` —
CI-pinned 2026.04.15, `splint`, `eslint`, `api-manifest`, `detect`), `docs.yml`'s
`detect`, and the in-job steps that report under a job the spine *does* run
(`test:ui-isolation`, `test:bspine-compile`, `build:hicasso-release`, the
EP-0036 donor-boundary `git grep`). The ones with real exposure to a comment-only
CLJS diff are `clj-kondo`/`splint` (parse) and `build:hicasso-release` (advanced
compile) — the node-test build compiles all three touched namespaces and passed,
which is the strongest local signal available for a docstring edit.

Comments only: no behaviour, no API surface, no test assertion, no fixture.
