### PR TITLE
feat(hicasso): budget gates part 1 — the reconciliation ledger and the gate that keeps it honest (rf2-hic-089)

### DIFF
--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -6,7 +6,11 @@ re-frame2 product operator's (Mike Thompson)**; this document records the
 profiles a budget is stated *on*, the estimand/instrument/control standard each
 row must meet, and the state of every baseline the later gates will anchor to.
 Enforcement lives in [`rf2-hic-089`](#7-where-each-row-is-enforced) (the early
-framework) and `rf2-hic-071` (the full gates), never here.
+framework) and `rf2-hic-071` (the full gates), never here. What this page does
+carry, since 2026-08-12, is [§9's reconciliation ledger](#9-the-budget-line-reconciliation-ledger)
+— one row per registered line, each stating its own verdict — and the gate that
+keeps that ledger honest. **That gate enforces the record, not the budgets**:
+it can tell you a breach is unrecorded, and it cannot tell you a budget is met.
 
 Three things are deliberately *not* decided on this page, because each is
 another bead's to decide:
@@ -229,16 +233,20 @@ not, and cannot be until a package-resident clock instrument exists.
 
 ### The comparative and regression rules
 
-| Rule | Disposition |
-|---|---|
-| Pinned ordinary-Hicasso benchmark does not regress > 5% on same witness and instrument | same-instrument regression **blocks** until the benchmark owner validates the instrument and the adapter owner fixes or reverts |
-| Cold mount ≤ 1.25x direct UIx (subject to ratification) | proposal only; `1.10x` registered line stands |
-| Broad updates ≤ 1.25x best relevant adapter after topology tuning | 1.25–1.5x is a **warning band**: attribute cause, one bounded topology pass, test a local island |
-| Sustained > 1.5x | cannot graduate as ordinary Hicasso until fixed or deliberately classified a native-host use case |
-| R=0 shell meets the frozen byte-exact `1,024 B` line | **not** governed by baseline-plus-10%; see §5 |
-| Per-read retained ≤ 10% regression on same pinned witness | governed by the K3 disposition (`rf2-hic-070`) |
-| Native island within 5% or 1 ms of the same component mounted directly | co-instrumented against both handwritten React and UIx |
-| An escape recovers ≥ 20%, saves ≥ 2 ms p95, or converts a failed budget to a pass | an island missing its threshold is simplified or removed — **thresholds do not widen to keep it** |
+The eight rules carry ids so that §9's ledger can reconcile each one by name.
+The ids are this table's, not a second register: a rule is registered *here*
+and its verdict is recorded there.
+
+| # | Rule | Disposition |
+|---|---|---|
+| C1 | Pinned ordinary-Hicasso benchmark does not regress > 5% on same witness and instrument | same-instrument regression **blocks** until the benchmark owner validates the instrument and the adapter owner fixes or reverts |
+| C2 | Cold mount ≤ 1.25x direct UIx (subject to ratification) | proposal only; `1.10x` registered line stands |
+| C3 | Broad updates ≤ 1.25x best relevant adapter after topology tuning | 1.25–1.5x is a **warning band**: attribute cause, one bounded topology pass, test a local island |
+| C4 | Sustained > 1.5x | cannot graduate as ordinary Hicasso until fixed or deliberately classified a native-host use case |
+| C5 | R=0 shell meets the frozen byte-exact `1,024 B` line | **not** governed by baseline-plus-10%; see §5 |
+| C6 | Per-read retained ≤ 10% regression on same pinned witness | governed by the K3 disposition (`rf2-hic-070`) |
+| C7 | Native island within 5% or 1 ms of the same component mounted directly | co-instrumented against both handwritten React and UIx |
+| C8 | An escape recovers ≥ 20%, saves ≥ 2 ms p95, or converts a failed budget to a pass | an island missing its threshold is simplified or removed — **thresholds do not widen to keep it** |
 
 ---
 
@@ -470,6 +478,11 @@ and no figure may be scaled from one onto the other.
 | Shell breach disposition | `rf2-hic-018` |
 | K3 per-read record | `rf2-hic-070` |
 
+Row by row, with each verdict beside its line, that table is
+[§9's ledger](budgets.md#9-the-budget-line-reconciliation-ledger). The routing
+above is what the ledger's own gate enforces: a deterministic row must name a
+witness a pull request runs, and a distributional row must not.
+
 ---
 
 ## 8. This page's own run, and what would falsify it
@@ -514,3 +527,206 @@ the standing invitation); a package-resident heap instrument producing shell or
 per-read figures materially apart from S1–S4 (§6 says how to build it); the
 operator freezing the byte line somewhere other than the §5 recommendation; or
 any deterministic row D1–D9 moving without a topology change to explain it.
+
+---
+
+## 9. The budget-line reconciliation ledger
+
+Every line this page registers has a verdict somewhere above, and above is
+eight sections long. A page whose verdicts are spread that far can carry a
+breach nobody has to look at — not by hiding it, but by never putting it next
+to the rows that are fine. This section is the one place each registered line
+states its own verdict, and
+[`check_budget_ledger.py`][gate] is what stops the ledger drifting from the
+sections it summarises.
+
+[gate]: ../../../../implementation/hicasso/scripts/check_budget_ledger.py
+
+**The gate does not enforce the budgets, and cannot.** Two thirds of the rows
+below are distributional, and §1 has already said a hosted runner may never
+source a distributional figure. What the gate enforces is that the *record*
+tells the truth: every registered line has a row; a row that is not green names
+who owns it and where it was dispositioned; a confidence band that crosses its
+line reads `UNRESOLVED` rather than green; and no distributional row is quietly
+routed into a pull-request threshold. It can tell you a breach has gone
+unrecorded. It cannot tell you a budget is met.
+
+### 9.1 How to read a row
+
+**Status is four-valued, and exactly one value is a pass.** The fourth column
+is the point of the whole table, so it uses a closed vocabulary rather than
+prose:
+
+| Status | What the evidence did | A pass? |
+|---|---|---|
+| `MET` | decided the row on the meeting side of its registered line | **yes** |
+| `BREACH` | decided it on the failing side | no — carried, red, with a named disposition |
+| `UNRESOLVED` | did **not** decide it: a confidence band that crosses the line, or a comparison whose two arms are not the same witness | **no, and never silently folded into a pass** |
+| `UNPINNED` | never reached the row — no instrument for it exists on the governed population | no; there is nothing yet to decide |
+
+`UNRESOLVED` is the status the operator's 2026-08-12 ruling exists to make
+sayable. §5 froze the shell line at `1,024 B` *and* adopted the adjudication
+rule that a band crossing it is unresolved rather than a pass; a ledger with
+only pass and fail would have had to round that ruling to one or the other, and
+whichever it chose would have been a fabrication. Where a row carries a
+machine-readable byte ceiling and a machine-readable band, the gate recomputes
+the verdict from those two numbers and refuses a status that disagrees — so
+`MET` cannot be written over a crossing band by hand.
+
+**A `BREACH` row does not redden the gate; an unrecorded one does.** The
+distinction is the whole design. §5 says the shell breach is carried and never
+normalised, and [the substrate decision](substrate-decision.md#52-the-read-free-boundary-shell--the-disposition)
+carried it red deliberately after refusing substrate remediation on the
+evidence. A gate that failed the build on that would be demanding a fix the
+programme has already ruled against; a gate that quietly greened it would be
+the normalisation §5 forbids. So the gate asks the only question it is entitled
+to ask — *is this breach on the record, with an owner and a disposition that
+resolves?* — and reds when the answer is no.
+
+**The other cells.** *Population* is `package`, `bench-tree` or `—`, and it is
+pinned per row in the gate: `rf2-fe0l` made S1–S5 package figures and left S6,
+S7 and U1–U4 where they were, so a later edit cannot quietly promote a
+bench-tree figure by rewriting a cell. *Instrument* names the thing that took
+the reading and, in parentheses, the lane it runs in — `PR gate`,
+`P-DEV-1 evidence run`, or `none`. A deterministic row must name a witness file
+that exists and runs in the first lane; a distributional row may never name the
+first lane at all. *Authority* is the bead that owns the row's disposition
+today. *Disposition* is a link that must resolve to a section naming the row.
+
+<!-- rf2-hic-089: ledger -->
+
+| # | Registered line | Current value | Population | Status | Instrument (lane) | Authority | Disposition |
+|---|---|---|---|---|---|---|---|
+| D1 | 2 bodies per keystroke at 5×5, and equal to D2 | 2 | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/grid/scaling_dom_cljs_test.cljs` (PR gate) | `rf2-hic-089` | — |
+| D2 | 2 bodies per keystroke at 10×10, and equal to D1 | 2 | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/grid/scaling_dom_cljs_test.cljs` (PR gate) | `rf2-hic-089` | — |
+| D3 | 26 bodies, coarse shape at 5×5 | 26 | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/grid/scaling_dom_cljs_test.cljs` (PR gate) | `rf2-hic-089` | — |
+| D4 | 101 bodies, coarse shape at 10×10 | 101 | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/grid/scaling_dom_cljs_test.cljs` (PR gate) | `rf2-hic-089` | — |
+| D5 | 0 bodies for a refused keystroke | 0 | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/grid/scaling_dom_cljs_test.cljs` (PR gate) | `rf2-hic-089` | — |
+| D6 | 11 bodies for `clear-row` on a 10-wide row | 11 | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/grid/scaling_dom_cljs_test.cljs` (PR gate) | `rf2-hic-089` | — |
+| D7 | 2 bodies, first keystroke of an editor session | 2 | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/editor/flow_dom_cljs_test.cljs` (PR gate) | `rf2-hic-089` | — |
+| D8 | 1 body, every keystroke after the first | 1 | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/editor/flow_dom_cljs_test.cljs` (PR gate) | `rf2-hic-089` | — |
+| D9 | zero teardown residue in counters and frame ids | zero | package | `MET` | `implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs` (PR gate) | `rf2-hic-089` | — |
+| S1 | 1,024 B, R=0 shell, Reagent segment | 1,100 B [1,091–1,107] | package | `BREACH` | P0 heap ladder, package candidate arm (P-DEV-1 evidence run) | `rf2-hic-018` | [substrate-decision §5.2](substrate-decision.md#52-the-read-free-boundary-shell--the-disposition) |
+| S2 | 1,024 B, R=0 shell, UIx segment | 1,095 B [1,087–1,101] | package | `BREACH` | P0 heap ladder, package candidate arm (P-DEV-1 evidence run) | `rf2-hic-018` | [substrate-decision §5.2](substrate-decision.md#52-the-read-free-boundary-shell--the-disposition) |
+| S3 | ≤ 10% regression on the same pinned witness | 1,417 vs Reagent 948 per read | package | `UNRESOLVED` | P0 heap ladder, package candidate arm (P-DEV-1 evidence run) | `rf2-hic-070` | [substrate-decision §6](substrate-decision.md#6-what-this-page-does-not-decide) |
+| S4 | ≤ 10% regression on the same pinned witness | 2,115 vs UIx 2,980 per read | package | `MET` | P0 heap ladder, package candidate arm (P-DEV-1 evidence run) | `rf2-hic-070` | — |
+| S5 | teardown retained indistinguishable from 0 | indistinguishable from 0; all ten rungs' bands straddle it | package | `MET` | P0 heap ladder, package candidate arm (P-DEV-1 evidence run) | `rf2-hic-089` | — |
+| S6 | 1.10x cold mount against direct UIx-on-subs | 1.1718x [1.1263–1.2190] n=8; 1.1976x [1.1504–1.2468] n=6 | bench-tree | `BREACH` | final K1 estimator (P-DEV-1 evidence run) | `rf2-hic-018` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
+| S7 | warm allocation, a fitted series clearing the quality floor | no publishable claim | bench-tree | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
+| U1 | echo within one 60 Hz frame at p95 | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
+| U2 | ≤ 50 ms p95 and ≤ 100 ms p99 to next paint | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
+| U3 | ≤ 100 ms p95 for broad operations | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
+| U4 | dragging and animation inside the frame budget | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
+| U5 | body work scales with changed rows, not mounted rows | 2 at 25 cells and at 100 | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/examples/grid/scaling_dom_cljs_test.cljs` (PR gate) | `rf2-hic-089` | — |
+| U6 | teardown residue zero after quiescence | zero counters (D9); bytes indistinguishable from 0 (S5) | package | `MET` | `implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs` (PR gate) | `rf2-hic-089` | — |
+| C1 | ≤ 5% regression on the same witness and instrument | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
+| C2 | 1.10x cold mount, the registered line | see S6 | bench-tree | `BREACH` | final K1 estimator (P-DEV-1 evidence run) | `rf2-hic-018` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
+| C3 | ≤ 1.25x the best relevant adapter on broad updates | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
+| C4 | no sustained 1.5x as ordinary Hicasso | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
+| C5 | 1,024 B byte-exact, not governed by baseline-plus-10% | 1,100 B / 1,095 B [1,087–1,107] | package | `BREACH` | P0 heap ladder, package candidate arm (P-DEV-1 evidence run) | `rf2-hic-018` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
+| C6 | ≤ 10% per-read regression on the same pinned witness | see S3 / S4 | package | `UNRESOLVED` | P0 heap ladder, package candidate arm (P-DEV-1 evidence run) | `rf2-hic-070` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
+| C7 | a native island within 5% or 1 ms of the same component mounted directly | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
+| C8 | an escape recovers ≥ 20%, saves ≥ 2 ms p95, or flips a failed budget | — | — | `UNPINNED` | — (none) | `rf2-hic-071` | [§9.2](budgets.md#92-what-each-not-green-row-is-waiting-on) |
+| I9 | ≤ 2 React hooks per boundary shell, invariant in read count | 2 | package | `MET` | `implementation/hicasso/test/re_frame/hicasso/hook_budget_cljs_test.cljs` (PR gate) | `rf2-hic-018` | — |
+
+<!-- rf2-hic-089: end-ledger -->
+
+Thirty-one rows: the nine deterministic figures of §3, the seven distributional
+rows and six user-visible budgets of §4, the eight comparative rules §4 now
+gives ids to, and one row registered off this page — **I9**, the two-hook
+ceiling frozen by
+[the substrate decision](substrate-decision.md#4-the-two-hook-ceiling-frozen-with-its-measurement).
+I9 is here because it is a budget with a package-resident witness and no other
+ledger; its provenance is held in the gate rather than assumed.
+
+**U6 is the split row, and the ledger shows only one half of it.** Its
+deterministic half is D9's counters and its distributional half is S5's bytes,
+and §3 has already said the two are not interchangeable evidence. The
+instrument cell names the deterministic witness because that is the half a pull
+request runs; the other half is S5's own row, one line above.
+
+### 9.2 What each not-green row is waiting on
+
+Three rows have a disposition record of their own and point at it: `S1` and
+`S2` at [the substrate decision's §5.2](substrate-decision.md#52-the-read-free-boundary-shell--the-disposition),
+where the shell breach was carried red on the evidence, and `S3` at
+[its §6](substrate-decision.md#6-what-this-page-does-not-decide), where the
+`+139 B/read` package move is left open. Every other row that is not `MET`
+points here, and here is what each is waiting on.
+
+- **No package-resident clock instrument exists.** `U1`, `U2`, `U3` and `U4`
+  are latency budgets, and §4 says in terms that they cannot be pinned until
+  such an instrument exists. `C3` and `C4` are the comparative rules stated on
+  the same missing readings. None of the six can be pinned by measuring harder
+  on the rig that exists; each needs a clock instrument pointed at
+  `implementation/hicasso`, on P-DEV-1, in its own window.
+- **The 5% rule has no same-instrument anchor.** `C1` compares a reading
+  against the pinned ordinary-Hicasso benchmark, and §6 records that the
+  registered instrument's eleven pinned blobs are superseded rather than
+  repaired — one of its files no longer exists. Until the ladder is re-pinned,
+  "the same instrument" names nothing, and a comparison against it would be
+  un-attributable in exactly the way §6 describes. The re-pin is `rf2-hic-071`'s
+  along with the gate it enables.
+- **The cold-mount line is missed and its replacement is unratified.** `S6` and
+  `C2` are red against the registered `1.10x`. The `1.25x` figure is a proposal
+  pending the operator's sitting, so it is not written in either row's line
+  cell, and the gate refuses to let it be: §4's standing prohibition — no
+  evidence row may use the proposal to mark K1 green — is held as a pin on
+  those two rows rather than as a sentence nobody re-reads.
+- **`S7` has no publishable claim to pin.** No fitted allocation series clears
+  the quality floor. This is a property of the readings rather than of the
+  rig, so it is `UNPINNED` rather than `UNRESOLVED`: nothing crossed a line,
+  because nothing reached one.
+- **`C7` and `C8` have no population yet.** The native-island rule and the
+  escape-benefit rule are both stated over landed escapes and islands, and the
+  apps that would carry them are `rf2-hic-034`, `rf2-hic-047` and `rf2-hic-045`.
+  `rf2-hic-071` names them as the beads it extends over, which is the same
+  statement from the other side.
+- **`C5` and `C6` are rules whose readings have been dispositioned, and the
+  rules have not.** `C5` is the shell rule; its evidence is `S1` and `S2`, and
+  §5.2 above carries that reading red. `C6` is the per-read rule; its evidence
+  is `S3` and `S4`, and §6 above leaves the `S3` move open to `rf2-hic-070`.
+  Neither section adjudicates the *rule*, only the readings under it, so the
+  two rows point here rather than borrowing a disposition that was not made
+  about them. `C5` is settled the day a shell arm lands under `1,024 B` on the
+  package; `C6` the day the K3 record is taken.
+
+### 9.3 Where this ledger stops and rf2-hic-071 begins
+
+This bead is the *early* framework: the half that can exist before the
+population does. The boundary is not a matter of taste, and it is worth stating
+as a rule rather than as a list.
+
+**What can be gated early is what a hosted runner is allowed to decide.** §1
+permits CI-RUNNER-A correctness gates and same-run relative drift, and forbids
+it any distributional product budget; §2 sorts every row into the two families;
+§7 routes them. So the early framework is *the deterministic family plus the
+record*: the D rows and I9 already run as ordinary blocking witnesses in a pull
+request, and this section adds the ledger and the gate that keeps it honest.
+Everything the ledger says about a distributional row is a transcription of an
+evidence run, checked for internal honesty and nothing more.
+
+**Two of this bead's stated deliverables cannot be built early, and the reason
+is on this page.** They are recorded here rather than quietly dropped:
+
+- *The 5% same-instrument regression gate, running in CI per relevant PR.* The
+  pinned ordinary-Hicasso benchmark is a heap figure — distributional, P-DEV-1
+  only, and §7 says such a row is never converted into a flaky PR threshold.
+  Wiring it to a hosted runner would breach §1 on the first green. It is `C1`
+  in the ledger, `UNPINNED`, and it additionally has no anchor to compare
+  against until §6's instrument drift is re-pinned. The gate below enforces
+  that no one wires it there by mistake: a distributional row may not name the
+  `PR gate` lane.
+- *Slice-app user-visible gates at 50 ms p95 / 100 ms p99 and one-frame
+  keystroke echo.* These are `U1`–`U4`, and §4 records that no package-resident
+  clock instrument exists to pin them on. The deterministic half that *is*
+  reachable — a controlled update landing same-turn, and the per-keystroke body
+  count behind the echo claim — is already gated, as `U5`, `D7` and `D8`.
+  Building a second instrument to say more would be building a second thing to
+  drift, which is the rule §3 states and `rf2-fe0l` was dispatched to honour.
+
+**`rf2-hic-071` therefore inherits three things, not one**: the clock
+instrument and the U-row gates it makes possible, the ladder re-pin and the 5%
+comparison it makes meaningful, and the escape-benefit rule over the escapes
+its own dependencies land. This ledger is what it will report into — the bead
+owns the status columns from the moment it takes them.

--- a/docs/design/hicasso/product/budgets.md
+++ b/docs/design/hicasso/product/budgets.md
@@ -683,13 +683,13 @@ points here, and here is what each is waiting on.
   `rf2-hic-071` names them as the beads it extends over, which is the same
   statement from the other side.
 - **`C5` and `C6` are rules whose readings have been dispositioned, and the
-  rules have not.** `C5` is the shell rule; its evidence is `S1` and `S2`, and
-  §5.2 above carries that reading red. `C6` is the per-read rule; its evidence
-  is `S3` and `S4`, and §6 above leaves the `S3` move open to `rf2-hic-070`.
-  Neither section adjudicates the *rule*, only the readings under it, so the
-  two rows point here rather than borrowing a disposition that was not made
-  about them. `C5` is settled the day a shell arm lands under `1,024 B` on the
-  package; `C6` the day the K3 record is taken.
+  rules have not.** `C5` is the shell rule; its evidence is `S1` and `S2`,
+  carried red by the substrate decision's §5.2. `C6` is the per-read rule; its
+  evidence is `S3` and `S4`, and that page's §6 leaves the `S3` move open to
+  `rf2-hic-070`. Neither section adjudicates the *rule*, only the readings
+  under it, so the two rows point here rather than borrowing a disposition
+  that was not made about them. `C5` is settled the day a shell arm lands
+  under `1,024 B` on the package; `C6` the day the K3 record is taken.
 
 ### 9.3 Where this ledger stops and rf2-hic-071 begins
 

--- a/implementation/hicasso/scripts/check_budget_ledger.py
+++ b/implementation/hicasso/scripts/check_budget_ledger.py
@@ -502,7 +502,7 @@ def check(rows, registered, sections, existing_files):
                     "L6 %s is a distributional row wired to the PR-gate lane. "
                     "A hosted runner may never source a distributional budget "
                     "(budgets.md sec. 1) and such a row is never converted into a "
-                    "flaky PR threshold (§7)" % rid)
+                    "flaky PR threshold (sec. 7)" % rid)
             if row["status"] == "UNPINNED" and lane != "none":
                 failures.append(
                     "L6 %s is UNPINNED and names the lane %r. Nothing has "

--- a/implementation/hicasso/scripts/check_budget_ledger.py
+++ b/implementation/hicasso/scripts/check_budget_ledger.py
@@ -39,8 +39,15 @@ THE TWO THINGS IT EXISTS TO PREVENT, stated plainly:
   row names an owner and a disposition record, and that record has to
   exist and name the row.
 
-THE SIX RULES
--------------
+THE RULES
+---------
+  L0  THE LEDGER IS READABLE AT ALL.
+                     The marker comments that delimit the table are
+                     present and every row has its eight cells. Deleting
+                     a marker is the loudest way to empty the table, and
+                     an empty table satisfies five of the six rules
+                     below vacuously — so this one is reported in the
+                     gate's own voice rather than as a traceback.
   L1  THE VOCABULARY IS CLOSED, AND ONE VALUE IS A PASS.
                      Status is `MET`, `BREACH`, `UNRESOLVED` or
                      `UNPINNED`. Only `MET` passes; this gate's own
@@ -732,4 +739,11 @@ def main(argv=None):
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    # A malformed ledger — markers deleted, a row short of a cell — is a
+    # ledger failure, not a crash, and it must arrive in the gate's own voice
+    # rather than as a traceback.  Deleting the markers is the loudest way to
+    # empty the table, so it is the shape most worth reporting well.
+    try:
+        sys.exit(main())
+    except ValueError as malformed:
+        sys.exit(report(["L0 %s" % malformed]))

--- a/implementation/hicasso/scripts/check_budget_ledger.py
+++ b/implementation/hicasso/scripts/check_budget_ledger.py
@@ -1,0 +1,735 @@
+#!/usr/bin/env python3
+"""THE BUDGET-LEDGER GATE for Hicasso (rf2-hic-089).
+
+`docs/design/hicasso/product/budgets.md` §9 is the RECONCILIATION LEDGER:
+one row per registered budget line, each stating its own verdict, its
+population, the instrument that read it, who owns it and where it was
+dispositioned. Eight sections of that page state budgets; the ledger is
+the one place they are all answered, and a summary nothing checks drifts
+from the thing it summarises within a release.
+
+WHAT THIS GATE IS NOT
+---------------------
+It is **not** a budget gate. It decides no budget, reads no instrument
+and reddens on no breach. Two thirds of the ledger's rows are
+distributional, and budgets.md §1 has already ruled that a hosted runner
+may never source a distributional figure; §7 adds that such a row is
+never converted into a flaky pull-request threshold. Turning a budget
+into a blocking gate is `rf2-hic-071`'s, over a population that does not
+exist yet. What is enforceable TODAY is the honesty of the record, and
+that is exactly what this gate holds.
+
+THE TWO THINGS IT EXISTS TO PREVENT, stated plainly:
+
+  a BAND CROSSING read as a PASS. The operator froze the shell line at
+  `1,024 B` on 2026-08-12 and adopted, with it, the rule that a
+  confidence band crossing that line is UNRESOLVED rather than a pass.
+  A two-valued ledger cannot hold that ruling: it must round every
+  crossing to green or red, and whichever it picks is a fabrication.
+  L1 gives the ledger a four-valued status of which exactly one is a
+  pass, and L2 recomputes the verdict from the numbers so `MET` cannot
+  be written over a crossing band by hand.
+
+  a BREACH going SILENT. `rf2-hic-018` refused substrate remediation of
+  the R=0 shell on the evidence and carried the row red on purpose. A
+  gate that failed the build on that would demand a fix the programme
+  has ruled against; a gate that greened it would be the normalisation
+  budgets.md §5 forbids. So a `BREACH` row does not redden this gate —
+  an UNRECORDED breach does. L3 is the whole of that: every not-green
+  row names an owner and a disposition record, and that record has to
+  exist and name the row.
+
+THE SIX RULES
+-------------
+  L1  THE VOCABULARY IS CLOSED, AND ONE VALUE IS A PASS.
+                     Status is `MET`, `BREACH`, `UNRESOLVED` or
+                     `UNPINNED`. Only `MET` passes; this gate's own
+                     report never folds the other three into it, and
+                     prints each by name.
+  L2  THE BAND DECIDES, AND A CEILING MAY NOT DUCK IT.
+                     A byte ceiling in the Registered-line cell REQUIRES
+                     a byte band in the Current-value cell — omitting
+                     the band would otherwise be a way out from under
+                     this rule. The verdict is then recomputed: band
+                     wholly at or under the ceiling is `MET`, wholly
+                     over is `BREACH`, a band containing it is
+                     `UNRESOLVED`. A stated status that disagrees reds.
+  L3  NO SILENT BREACH.
+                     Every row names an authority (`rf2-…`). Every row
+                     that is not `MET` also names a disposition link
+                     whose target file exists, whose anchor resolves to
+                     a heading, and whose section NAMES the row. A
+                     pointer at a section that never mentions the row is
+                     worse than no pointer: it reads as a disposition
+                     and is not one.
+  L4  COMPLETE, AND NOTHING INVENTED.
+                     Every `D`/`S`/`U`/`C` id registered in budgets.md
+                     OUTSIDE the ledger has exactly one ledger row, and
+                     every ledger id is either registered there or in
+                     EXTRA_ROWS below — which carries its own resolving
+                     provenance anchor. Dropping a row is the cheapest
+                     way to make a ledger green, so both directions are
+                     checked.
+  L5  THE LANDED ADJUDICATION IS PINNED.
+                     Population per row and, where the operator froze
+                     one, the registered line per row. `rf2-fe0l` made
+                     S1–S5 package figures and left S6, S7 and U1–U4
+                     where they were; a cell rewrite cannot promote a
+                     bench-tree figure to a package one. The `1.25x`
+                     cold-mount ceiling is a PROPOSAL pending the
+                     operator's sitting, so it is refused in S6's and
+                     C2's line cells by name, and any line cell written
+                     as a proposal is refused generally.
+  L6  THE LANE IS LEGAL.
+                     Each instrument cell ends in its lane: `PR gate`,
+                     `P-DEV-1 evidence run` or `none`. A DETERMINISTIC
+                     row must name a witness FILE THAT EXISTS, in the
+                     `PR gate` lane. A DISTRIBUTIONAL row may never name
+                     the `PR gate` lane at all — that is budgets.md §1,
+                     §2 and §7 mechanised, and it is what stops the 5%
+                     heap comparison being wired to a hosted runner by a
+                     later worker acting in good faith.
+
+WHAT L6 DELIBERATELY DOES NOT CHECK is that a distributional row's
+instrument is absent from the repository. The P0 heap ladder lives in
+this repo and always has; what makes it illegal as a PR gate is its
+LANE, not its address. Checking the address instead would red the honest
+case and miss the dishonest one.
+
+THE STATUS OF `UNPINNED`, since it is the value most easily mistaken for
+a bookkeeping hole: it means no instrument for the row exists on the
+governed population, so the evidence never reached the line. It is not a
+softer `UNRESOLVED` — `UNRESOLVED` means evidence was taken and did not
+decide. Ten rows are `UNPINNED` today and every one of them names, in
+§9.2, the instrument or ruling that would move it.
+
+Exit code:
+    0  the ledger is internally honest (which is NOT "the budgets are met")
+    1  at least one rule failed; each is printed with its L-number
+"""
+
+import argparse
+import os
+import re
+import sys
+
+
+# Cells quoted back in a failure message carry the ledger's em-dashes and
+# `<=` glyphs, and a Windows console is cp1252.  Replace rather than raise:
+# a gate that dies encoding its own error message reports nothing at all.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(errors="replace")
+
+
+SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+PACKAGE_ROOT = os.path.dirname(SCRIPTS_DIR)                       # implementation/hicasso
+REPO_ROOT = os.path.dirname(os.path.dirname(PACKAGE_ROOT))        # repo root
+
+PRODUCT_DIR = os.path.join(REPO_ROOT, "docs", "design", "hicasso", "product")
+BUDGETS = os.path.join(PRODUCT_DIR, "budgets.md")
+
+OPEN_MARKER = "<!-- rf2-hic-089: ledger -->"
+CLOSE_MARKER = "<!-- rf2-hic-089: end-ledger -->"
+
+# L1.  Exactly one of these is a pass, and the report below never says
+# "all budgets met" — it says how many rows are in each.
+STATUSES = ("MET", "BREACH", "UNRESOLVED", "UNPINNED")
+PASSING_STATUS = "MET"
+
+# L6.  The lane a reading was taken in, which is what decides whether it may
+# gate a pull request.  `none` belongs to a row nothing has measured.
+LANES = ("PR gate", "P-DEV-1 evidence run", "none")
+
+# L6.  Family by id.  budgets.md §2 draws this line and §7 routes on it: a
+# body count is a delta on a monotone integer counter and contention cannot
+# move it, so it belongs in an ordinary blocking gate; bytes and milliseconds
+# need a quiet box and belong in pinned evidence runs.  U5 and U6 are §6
+# user-visible budgets that happen to be PINNED deterministically (as D1–D4
+# and D9), which is why they sit on the deterministic side here.
+DETERMINISTIC_IDS = frozenset(
+    ["D%d" % n for n in range(1, 10)] + ["U5", "U6", "I9"])
+
+# L4.  Rows registered somewhere other than budgets.md, with the anchor that
+# registers them.  Held here rather than in a ledger column because it is a
+# one-row exception and a column would invite a second.
+EXTRA_ROWS = {
+    "I9": "substrate-decision.md#4-the-two-hook-ceiling-frozen-with-its-measurement",
+}
+
+# L5.  The landed adjudication, pinned so a cell rewrite cannot move it.
+# `rf2-fe0l` (PRs #7939, #7941) re-pinned S1–S5 on `implementation/hicasso`
+# and left S6, S7 and U1–U4 exactly where they were.  Changing one of these
+# is a deliberate act — a new measurement window and an edit here — which is
+# the whole point.
+POPULATION_PIN = dict(
+    [("D%d" % n, "package") for n in range(1, 10)]
+    + [("S%d" % n, "package") for n in range(1, 6)]
+    + [("S6", "bench-tree"), ("S7", "bench-tree")]
+    + [("U%d" % n, "—") for n in range(1, 5)]
+    + [("U5", "package"), ("U6", "package")]
+    + [("C1", "—"), ("C2", "bench-tree"), ("C3", "—"), ("C4", "—"),
+       ("C5", "package"), ("C6", "package"), ("C7", "—"), ("C8", "—")]
+    + [("I9", "package")])
+
+POPULATIONS = ("package", "bench-tree", "—")
+
+# L5.  Lines the operator has frozen: the cell must contain the frozen
+# spelling.  `1,024 B` is the 2026-08-12 ruling, and the ambiguous `1 KB`
+# spelling retired with it.
+LINE_PIN = {
+    "S1": "1,024 B",
+    "S2": "1,024 B",
+    "C5": "1,024 B",
+    "S6": "1.10x",
+    "C2": "1.10x",
+}
+
+# L5.  budgets.md §4's standing prohibition, held by name: the `1.25x`
+# cold-mount ceiling is a proposal pending the operator's sitting, and no
+# evidence row may use it to mark K1 green.  Scoped to the two rows it is
+# about — C3's `1.25x` is the broad-update rule, which IS registered.
+LINE_FORBIDDEN = {
+    "S6": ("1.25x",),
+    "C2": ("1.25x",),
+}
+
+# L5, the general direction: a line written as a proposal is not a
+# registered line, whatever number it carries.
+PROPOSAL_MARKERS = ("subject to ratification", "pending ratification",
+                    "proposal", "not yet ratified", "unratified")
+
+_ROW_ID_RE = re.compile(r"^\|\s*([DSUCI]\d+)\s*\|")
+# L2 reads BYTE ceilings only.  `2 bodies` and `100 ms p95` are not byte
+# ceilings, and a lower-case `b` is not a byte here: the unit is written `B`.
+_CEILING_RE = re.compile(r"([\d,]+)\s*B\b")
+_BAND_RE = re.compile(r"\[\s*([\d,]+)\s*[-–—]\s*([\d,]+)\s*\]")
+_LANE_RE = re.compile(r"\(([^()]+)\)\s*$")
+_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+_AUTHORITY_RE = re.compile(r"^rf2-[a-z0-9-]+$")
+
+_RE_TAGS = re.compile(r"</?[^>]*>")
+_RE_INVALID_SLUG_CHAR = re.compile(r"[^\w\- ]", re.UNICODE)
+
+
+def slugify(text):
+    """The heading slug mkdocs mints, `pymdownx.slugs.slugify(case=lower)`.
+
+    Reimplemented rather than imported so this gate needs no third-party
+    package: it runs chained into `npm run test:hicasso-invariants`, whose
+    other members are pure standard library.  `scripts/check_doc_slugs.py`
+    validates the same anchors against the real implementation on every
+    docs change, so a divergence here cannot ship silently — that gate
+    would red on the link this one resolved.
+    """
+    text = _RE_TAGS.sub("", text.lower())
+    text = _RE_INVALID_SLUG_CHAR.sub("", text)
+    return text.strip().replace(" ", "-")
+
+
+# ---------------------------------------------------------------------------
+# Reading the ledger
+# ---------------------------------------------------------------------------
+
+def _cells(line):
+    return [cell.strip() for cell in line.strip().strip("|").split("|")]
+
+
+def _bare(cell):
+    """`cell` with markdown backticks stripped, for a cell holding one token."""
+    return cell.replace("`", "").strip()
+
+
+def read_ledger(path):
+    """`(rows, registered)` from budgets.md.
+
+    `rows` is the ledger's own rows, in document order; `registered` is
+    every `D`/`S`/`U`/`C` id the page registers in a table OUTSIDE the
+    ledger, which is what L4 round-trips against.  The two are separated
+    structurally by the marker comments rather than by heading text, so
+    renaming §9 cannot silently empty either side.
+    """
+    with open(path, encoding="utf-8") as fh:
+        lines = fh.read().splitlines()
+
+    rows, registered = [], set()
+    inside = False
+    seen_open = False
+    for line in lines:
+        if line.strip() == OPEN_MARKER:
+            inside, seen_open = True, True
+            continue
+        if line.strip() == CLOSE_MARKER:
+            inside = False
+            continue
+        match = _ROW_ID_RE.match(line)
+        if not match:
+            continue
+        if not inside:
+            if not match.group(1).startswith("I"):
+                registered.add(match.group(1))
+            continue
+        cells = _cells(line)
+        if len(cells) != 8:
+            raise ValueError(
+                "ledger row %s has %d cells, expected 8 (%s)"
+                % (match.group(1), len(cells), line.strip()))
+        rows.append({
+            "id": cells[0],
+            "line": cells[1],
+            "current": cells[2],
+            "population": cells[3],
+            "status": _bare(cells[4]),
+            "instrument": cells[5],
+            "authority": _bare(cells[6]),
+            "disposition": cells[7],
+        })
+    if not seen_open:
+        raise ValueError("%s carries no %s marker" % (path, OPEN_MARKER))
+    return rows, registered
+
+
+def read_sections(path):
+    """`{slug: section body}` for `path`, a section running to the next
+    heading of the same or a higher level.  Fenced blocks are skipped so a
+    `#` inside one cannot mint a phantom heading."""
+    with open(path, encoding="utf-8") as fh:
+        lines = fh.read().splitlines()
+    heads = []
+    fenced = False
+    for index, line in enumerate(lines):
+        if line.lstrip().startswith("```"):
+            fenced = not fenced
+            continue
+        if fenced:
+            continue
+        match = re.match(r"^(#{1,6})\s+(.*?)\s*$", line)
+        if match:
+            heads.append((index, len(match.group(1)), slugify(match.group(2))))
+    sections = {}
+    for position, (index, level, slug) in enumerate(heads):
+        end = len(lines)
+        for later_index, later_level, _ in heads[position + 1:]:
+            if later_level <= level:
+                end = later_index
+                break
+        sections.setdefault(slug, "\n".join(lines[index:end]))
+    return sections
+
+
+def resolve(target, cache):
+    """The section body a `file.md#anchor` target names, or None.
+
+    None covers both halves of a broken pointer — a file that is not there
+    and an anchor that resolves to nothing — because L3's message is the
+    same either way and the caller has the target to print.
+    """
+    if "#" not in target:
+        return None
+    rel, anchor = target.split("#", 1)
+    path = os.path.normpath(os.path.join(PRODUCT_DIR, rel))
+    if not os.path.isfile(path):
+        return None
+    if path not in cache:
+        cache[path] = read_sections(path)
+    return cache[path].get(anchor)
+
+
+# ---------------------------------------------------------------------------
+# The rules
+# ---------------------------------------------------------------------------
+
+def _numbers(text):
+    return int(text.replace(",", ""))
+
+
+def check(rows, registered, sections, existing_files):
+    """Every rule, against already-read inputs.
+
+    Pure, so `--self-test` drives each red by doctoring one input of a
+    green tree rather than by building a fixture page.  The reds this gate
+    must produce are statements about the relation between a ledger, the
+    tables it summarises and the records it points at; a fixture would
+    re-create that relation less honestly than the real one.
+
+    `sections` maps a `file.md#anchor` target to the section body it names,
+    or to None when it names nothing.  `existing_files` is the set of
+    repo-relative paths, among those the ledger cites, that exist.
+    """
+    failures = []
+    by_id = {}
+
+    for row in rows:
+        rid = row["id"]
+        if rid in by_id:
+            failures.append(
+                "L4 %s has two ledger rows. One line, one verdict" % rid)
+            continue
+        by_id[rid] = row
+
+        # --- L1: the vocabulary is closed -------------------------------
+        if row["status"] not in STATUSES:
+            failures.append(
+                "L1 %s has status %r, which is not one of %s"
+                % (rid, row["status"], ", ".join(STATUSES)))
+            continue
+
+        # --- L2: the band decides ---------------------------------------
+        ceiling = _CEILING_RE.search(row["line"])
+        if ceiling:
+            band = _BAND_RE.search(row["current"])
+            if not band:
+                failures.append(
+                    "L2 %s registers a byte ceiling (%s B) and its current "
+                    "value carries no band. A ceiling without a band cannot "
+                    "be adjudicated, and omitting one is the way out from "
+                    "under this rule" % (rid, ceiling.group(1)))
+            else:
+                limit = _numbers(ceiling.group(1))
+                low, high = _numbers(band.group(1)), _numbers(band.group(2))
+                if high <= limit:
+                    verdict = "MET"
+                elif low > limit:
+                    verdict = "BREACH"
+                else:
+                    verdict = "UNRESOLVED"
+                if row["status"] != verdict:
+                    detail = ("the band [%d-%d] crosses the %d B line, so the "
+                              "row is UNRESOLVED, not a pass"
+                              if verdict == "UNRESOLVED" else
+                              "the band [%d-%d] against the %d B line reads %s")
+                    args = ((low, high, limit) if verdict == "UNRESOLVED"
+                            else (low, high, limit, verdict))
+                    failures.append(
+                        "L2 %s is recorded %s but %s"
+                        % (rid, row["status"], detail % args))
+
+        # --- L3: no silent breach ---------------------------------------
+        if not _AUTHORITY_RE.match(row["authority"]):
+            failures.append(
+                "L3 %s names authority %r, which is not a bead id. Every row "
+                "has an owner" % (rid, row["authority"]))
+        if row["status"] != PASSING_STATUS:
+            link = _LINK_RE.search(row["disposition"])
+            if not link:
+                failures.append(
+                    "L3 %s is %s and names no disposition record. A breach "
+                    "nothing points at is a silent breach"
+                    % (rid, row["status"]))
+            else:
+                body = sections.get(link.group(1))
+                if body is None:
+                    failures.append(
+                        "L3 %s points its disposition at %s, which does not "
+                        "resolve" % (rid, link.group(1)))
+                elif rid not in body:
+                    failures.append(
+                        "L3 %s points its disposition at %s, a section that "
+                        "never names it. A pointer that reads as a "
+                        "disposition and is not one is worse than none"
+                        % (rid, link.group(1)))
+
+        # --- L5: the landed adjudication is pinned ----------------------
+        if row["population"] not in POPULATIONS:
+            failures.append(
+                "L5 %s has population %r, which is not one of %s"
+                % (rid, row["population"], ", ".join(POPULATIONS)))
+        pinned = POPULATION_PIN.get(rid)
+        if pinned is not None and row["population"] != pinned:
+            failures.append(
+                "L5 %s is pinned to the %s population and reads %r. rf2-fe0l "
+                "settled which rows are package figures; promoting one is a "
+                "measurement window, not a cell edit"
+                % (rid, pinned, row["population"]))
+        if row["population"] == "—":
+            if row["status"] != "UNPINNED":
+                failures.append(
+                    "L5 %s has no population and is recorded %s. Nothing has "
+                    "measured it, so nothing has decided it"
+                    % (rid, row["status"]))
+            if row["current"] != "—":
+                failures.append(
+                    "L5 %s has no population and states the value %r. A "
+                    "figure with no population is a figure from somewhere "
+                    "else" % (rid, row["current"]))
+        required = LINE_PIN.get(rid)
+        if required is not None and required not in row["line"]:
+            failures.append(
+                "L5 %s must register the frozen line %r and its line cell "
+                "reads %r" % (rid, required, row["line"]))
+        for banned in LINE_FORBIDDEN.get(rid, ()):
+            if banned in row["line"]:
+                failures.append(
+                    "L5 %s registers %s, which is a PROPOSAL pending the "
+                    "operator's sitting. No evidence row may use it to mark "
+                    "K1 green (budgets.md sec. 4)" % (rid, banned))
+        lowered = row["line"].lower()
+        for marker in PROPOSAL_MARKERS:
+            if marker in lowered:
+                failures.append(
+                    "L5 %s writes its registered line as a proposal (%r). A "
+                    "line that is not ratified is not registered"
+                    % (rid, marker))
+                break
+
+        # --- L6: the lane is legal --------------------------------------
+        lane_match = _LANE_RE.search(row["instrument"])
+        if not lane_match:
+            failures.append(
+                "L6 %s names no lane. The instrument cell ends in one of (%s)"
+                % (rid, "), (".join(LANES)))
+            continue
+        lane = lane_match.group(1).strip()
+        if lane not in LANES:
+            failures.append(
+                "L6 %s runs in lane %r, which is not one of %s"
+                % (rid, lane, ", ".join(LANES)))
+            continue
+        deterministic = rid in DETERMINISTIC_IDS
+        witness = _bare(row["instrument"][:lane_match.start()])
+        if deterministic:
+            if lane != "PR gate":
+                failures.append(
+                    "L6 %s is a deterministic row in the %r lane. A counter "
+                    "reads the same on a loaded box, so it belongs in an "
+                    "ordinary blocking gate (budgets.md sec. 2)" % (rid, lane))
+            elif witness not in existing_files:
+                failures.append(
+                    "L6 %s names the witness %s, which does not exist"
+                    % (rid, witness))
+        else:
+            if lane == "PR gate":
+                failures.append(
+                    "L6 %s is a distributional row wired to the PR-gate lane. "
+                    "A hosted runner may never source a distributional budget "
+                    "(budgets.md sec. 1) and such a row is never converted into a "
+                    "flaky PR threshold (§7)" % rid)
+            if row["status"] == "UNPINNED" and lane != "none":
+                failures.append(
+                    "L6 %s is UNPINNED and names the lane %r. Nothing has "
+                    "measured it" % (rid, lane))
+
+    # --- L4: complete, and nothing invented -----------------------------
+    for rid in sorted(registered - set(by_id)):
+        failures.append(
+            "L4 %s is registered in budgets.md and has no ledger row. "
+            "Dropping a row is the cheapest way to make a ledger green" % rid)
+    for rid in sorted(set(by_id) - registered):
+        if rid not in EXTRA_ROWS:
+            failures.append(
+                "L4 %s has a ledger row and is registered nowhere. Register "
+                "it, or add it to EXTRA_ROWS with the anchor that does" % rid)
+            continue
+        body = sections.get(EXTRA_ROWS[rid])
+        if body is None:
+            failures.append(
+                "L4 %s cites the provenance anchor %s, which does not resolve"
+                % (rid, EXTRA_ROWS[rid]))
+        elif rid not in body:
+            failures.append(
+                "L4 %s cites the provenance anchor %s, a section that never "
+                "names it" % (rid, EXTRA_ROWS[rid]))
+    return failures
+
+
+def report(failures):
+    """Print `failures` in the gate's voice, and return the exit code 1."""
+    print("FAIL: Hicasso budget-line reconciliation ledger\n")
+    for failure in failures:
+        print("  " + failure)
+    print("\nThe ledger is docs/design/hicasso/product/budgets.md sec. 9; the rule "
+          "each L-number names is in this script's header.")
+    print("Note what a green run here does NOT mean: this gate gates the "
+          "RECORD, never the budgets.")
+    return 1
+
+
+# ---------------------------------------------------------------------------
+
+def read_all():
+    rows, registered = read_ledger(BUDGETS)
+    cache = {}
+    targets = set(EXTRA_ROWS.values())
+    for row in rows:
+        link = _LINK_RE.search(row["disposition"])
+        if link:
+            targets.add(link.group(1))
+    sections = {target: resolve(target, cache) for target in sorted(targets)}
+    existing = set()
+    for row in rows:
+        lane = _LANE_RE.search(row["instrument"])
+        if not lane:
+            continue
+        witness = _bare(row["instrument"][:lane.start()])
+        if witness and os.path.isfile(os.path.join(REPO_ROOT, witness)):
+            existing.add(witness)
+    return rows, registered, sections, existing
+
+
+def tally(rows):
+    counts = {status: 0 for status in STATUSES}
+    for row in rows:
+        if row["status"] in counts:
+            counts[row["status"]] += 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# --self-test: prove the gate classifies, rather than merely runs
+# ---------------------------------------------------------------------------
+
+def self_test():
+    assert slugify("5.2 The read-free boundary shell — the disposition") == \
+        "52-the-read-free-boundary-shell--the-disposition", slugify(
+            "5.2 The read-free boundary shell — the disposition")
+    assert slugify("9. The budget-line reconciliation ledger") == \
+        "9-the-budget-line-reconciliation-ledger"
+    assert _CEILING_RE.search("2 bodies per keystroke at 5×5") is None, \
+        "a lower-case b is not a byte unit"
+    assert _CEILING_RE.search("≤ 100 ms p95") is None, \
+        "milliseconds are not a byte ceiling"
+
+    rows, registered, sections, existing = read_all()
+    # Every red below is driven by doctoring ONE input of a green tree, so a
+    # tree that is already red cannot be tested against.  That is a finding
+    # about the ledger rather than about this self-test, and it is by far the
+    # likeliest way this entry point fails on a pull request — so it is
+    # reported exactly as a plain run reports it.
+    failures = check(rows, registered, sections, existing)
+    if failures:
+        code = report(failures)
+        print("\n(--self-test drives its reds by doctoring a GREEN ledger's "
+              "inputs, so it stops here.)")
+        return code
+
+    def red(prefix, **overrides):
+        args = dict(rows=rows, registered=registered, sections=sections,
+                    existing_files=existing)
+        args.update(overrides)
+        found = check(**args)
+        assert any(f.startswith(prefix) for f in found), \
+            "%s did not red: %r" % (prefix, found)
+
+    def green(**overrides):
+        args = dict(rows=rows, registered=registered, sections=sections,
+                    existing_files=existing)
+        args.update(overrides)
+        found = check(**args)
+        assert not found, "a legal ledger reddened: %r" % found
+
+    def patched(rid, **changes):
+        out = []
+        for row in rows:
+            out.append(dict(row, **changes) if row["id"] == rid else dict(row))
+        return out
+
+    # L1 — a status outside the vocabulary.  `PASS` is the likeliest way to
+    # write one, and it is exactly the word this ledger will not have.
+    red("L1", rows=patched("S1", status="PASS"))
+
+    # L2 — the two directions that matter.  A crossing band recorded as a
+    # pass is the failure the operator's ruling exists to forbid; a ceiling
+    # with no band at all is the way out from under the rule.
+    red("L2", rows=patched("S1", current="1,100 B [1,010–1,107]", status="MET"))
+    red("L2", rows=patched("S1", current="1,100 B"))
+    red("L2", rows=patched("S1", current="1,100 B [1,091–1,107]", status="MET"))
+
+    # ...and the eager direction: a legal reading must still pass.  A band
+    # wholly under the line is MET, and a band that crosses it is UNRESOLVED
+    # — both are recomputed, neither is a failure.
+    green(rows=patched("S1", current="994 B [988–1,002]", status="MET"))
+    green(rows=patched("S1", current="1,020 B [1,010–1,030]",
+                       status="UNRESOLVED"))
+
+    # L3 — a breach with no owner, with no disposition, with one that does
+    # not resolve, and with one that resolves to a section never naming it.
+    red("L3", rows=patched("S1", authority="the operator"))
+    red("L3", rows=patched("S1", disposition="—"))
+    red("L3", rows=patched("S1", disposition="[gone](substrate-decision.md#no-such-anchor)"))
+    a_breach = next(r for r in rows if r["status"] == "BREACH")
+    link = _LINK_RE.search(a_breach["disposition"]).group(1)
+    red("L3", sections=dict(sections, **{link: "a section naming nothing"}))
+
+    # ...and the eager direction: a MET row needs no disposition, and an
+    # em-dash there must not be read as a broken pointer.
+    green(rows=patched("S4", disposition="—"))
+
+    # L4 — a registered row dropped from the ledger, and a ledger row
+    # registered nowhere.
+    red("L4", registered=registered | {"S9"})
+    red("L4", rows=rows + [dict(rows[0], id="D42")])
+    # ...and the extra row's own provenance, which is the only thing keeping
+    # EXTRA_ROWS from being a hole.
+    red("L4", sections=dict(sections,
+                            **{EXTRA_ROWS["I9"]: "a section naming nothing"}))
+
+    # L5 — a bench-tree figure promoted to the package by a cell edit; a
+    # frozen line rewritten; the unratified cold-mount proposal used as a
+    # registered line; and a value stated for a row nothing has measured.
+    red("L5", rows=patched("S6", population="package"))
+    red("L5", rows=patched("S1", line="1,000 B, R=0 shell, Reagent segment"))
+    red("L5", rows=patched("S6", line="1.25x cold mount against direct UIx"))
+    red("L5", rows=patched("C3", line="≤ 1.25x, subject to ratification"))
+    red("L5", rows=patched("U2", current="42 ms p95"))
+    # ...and the eager direction: C3's `1.25x` is the REGISTERED broad-update
+    # rule, and must not be caught by the prohibition aimed at the cold-mount
+    # proposal.
+    green(rows=patched("C3", line="≤ 1.25x the best relevant adapter"))
+
+    # L6 — the rule that refuses this bead's own first deliverable as
+    # written: a distributional row wired to a pull-request gate.
+    red("L6", rows=patched("C1", instrument="`scripts/five-percent.sh` (PR gate)"))
+    red("L6", rows=patched("S1", instrument="P0 heap ladder (PR gate)"))
+    # ...a deterministic row whose witness has been deleted or renamed...
+    red("L6", rows=patched("D1", instrument="`implementation/hicasso/gone.cljs` (PR gate)"))
+    # ...a deterministic row moved out of the blocking lane...
+    red("L6", rows=patched("I9", instrument="a bench (P-DEV-1 evidence run)"))
+    # ...and a lane nobody registered.
+    red("L6", rows=patched("D1", instrument="`x` (some other lane)"))
+
+    counts = tally(rows)
+    print("OK: check_budget_ledger self-test passed "
+          "(%d rows: %s)"
+          % (len(rows),
+             ", ".join("%d %s" % (counts[s], s) for s in STATUSES)))
+    return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--self-test", action="store_true",
+                        help="prove the gate's red/green classification, then exit")
+    parser.add_argument("--list", action="store_true",
+                        help="print the ledger, one row per line, with its verdict")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    rows, registered, sections, existing = read_all()
+
+    if args.list:
+        for row in rows:
+            print("%-4s %-11s %-11s %s"
+                  % (row["id"], row["status"], row["population"], row["line"]))
+        return 0
+
+    failures = check(rows, registered, sections, existing)
+    if failures:
+        return report(failures)
+
+    counts = tally(rows)
+    print("OK: %d ledger rows -- %d MET, %d BREACH, %d UNRESOLVED, %d UNPINNED."
+          % (len(rows), counts["MET"], counts["BREACH"],
+             counts["UNRESOLVED"], counts["UNPINNED"]))
+    print("Every registered line has a row; every row that is not MET names "
+          "an owner and a disposition that resolves;")
+    print("no band crossing its line is recorded as a pass; no distributional "
+          "row is wired to a pull-request gate.")
+    print("This is a verdict about the RECORD. It is not a statement that any "
+          "budget is met -- %d rows are not MET."
+          % (len(rows) - counts["MET"]))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -62,7 +62,7 @@
     "test:examples-compile": "node scripts/check-examples-compile.cjs",
     "test:hicasso-compile": "node freehand/test/re_frame/bench/hicasso/compile_gate.cjs",
     "test:bspine-compile": "node freehand/test/re_frame/freehand/bench/compile_gate.cjs --self-test && node freehand/test/re_frame/freehand/bench/compile_gate.cjs",
-    "test:hicasso-invariants": "python hicasso/scripts/check_freeze.py --self-test && python hicasso/scripts/check_freeze.py && python hicasso/scripts/check_optional_module_reachability.py --self-test && python hicasso/scripts/check_optional_module_reachability.py && python hicasso/scripts/check_complaint_catalogue.py --self-test && python hicasso/scripts/check_complaint_catalogue.py",
+    "test:hicasso-invariants": "python hicasso/scripts/check_freeze.py --self-test && python hicasso/scripts/check_freeze.py && python hicasso/scripts/check_optional_module_reachability.py --self-test && python hicasso/scripts/check_optional_module_reachability.py && python hicasso/scripts/check_complaint_catalogue.py --self-test && python hicasso/scripts/check_complaint_catalogue.py && python hicasso/scripts/check_budget_ledger.py --self-test && python hicasso/scripts/check_budget_ledger.py",
     "test:hicasso-lint": "python hicasso/scripts/check_lint_export.py --self-test && python hicasso/scripts/check_lint_export.py",
     "test:reagent-slim:bundle-isolation": "shadow-cljs release examples/counter examples/counter-slim-and-fast && node scripts/check-reagent-slim-bundle-isolation.cjs",
     "test:reagent-slim:smoke": "node scripts/serve-and-run-reagent-slim-smoke.cjs",


### PR DESCRIPTION
`rf2-hic-089` — part 1 of the budget gates: the framework that can exist before
the population does.

## What this is

`budgets.md` registers budgets across eight sections and answers each in a
different paragraph. Section 9 is now the one place every registered line
states its own verdict — **31 rows**: the nine deterministic figures of §3, the
seven distributional rows and six user-visible budgets of §4, the eight
comparative rules §4 now gives ids to (`C1`–`C8`), and `I9`'s two-hook ceiling,
registered off-page by the substrate decision.

`implementation/hicasso/scripts/check_budget_ledger.py` keeps it honest, under
six rules (L1–L6, each stated in the script header). It is chained into
`npm run test:hicasso-invariants`, self-test first then live run — the order
every other pure-Python contract in this package uses.

**The gate enforces the record, not the budgets, and it cannot do otherwise.**
Two thirds of the rows are distributional; §1 has already ruled that a hosted
runner may never source a distributional figure and §7 that such a row is never
converted into a flaky PR threshold. What is enforceable today is whether the
ledger tells the truth.

## How "unresolved" is distinguishable from "pass"

Four ways, and the second is the one that matters:

1. **It is a distinct value in a closed vocabulary.** Status is `MET`,
   `BREACH`, `UNRESOLVED` or `UNPINNED` (L1). Exactly one is a pass. A status
   outside the four reds; `PASS` is not a word this ledger can contain.
2. **It is recomputed, not asserted.** Where a row registers a byte ceiling and
   states a byte band, L2 derives the verdict from the two numbers: band wholly
   at or under the line is `MET`, wholly over is `BREACH`, **a band containing
   the line is `UNRESOLVED`**. A stated status that disagrees reds — see
   sabotage C below, which is exactly that edit and exactly that red.
3. **A ceiling cannot duck the rule by omitting its band.** L2 reds a byte
   ceiling with no band at all, which is otherwise the cheap way out.
4. **The gate's own green never reads as "budgets met."** It prints the four
   counts by name and then says so in terms: `31 ledger rows -- 14 MET,
   5 BREACH, 2 UNRESOLVED, 10 UNPINNED … This is a verdict about the RECORD. It
   is not a statement that any budget is met -- 17 rows are not MET.`

`UNRESOLVED` is generalised slightly beyond band-crossing, and deliberately: it
also covers a comparison whose two arms are not the same witness. `S3` is that
case — `1,278 → 1,417 B/read` across a population change, attribution open — and
a two-valued ledger would have had to call it green or red, either of which
would be a fabrication.

## How the carried shell breach is expressed

`S1`, `S2` and `C5` are `BREACH`: red on the page, **green in the gate**. That
is the design, not an exemption.

- `rf2-hic-018` refused substrate remediation on the evidence — the two
  substrates' shells are five bytes apart, because an R=0 boundary holds no
  reaction — and carried the row red on purpose. A gate that failed the build
  on that would demand a fix the programme has ruled against.
- A gate that greened it silently would be the normalisation §5 forbids.

So the gate asks the only question it is entitled to ask (L3): *is this breach
on the record, with an owner and a disposition that resolves?* `S1` and `S2`
name `rf2-hic-018` and link the substrate decision's §5.2; strip the link and
the gate reds — sabotage F. The disposition anchor must also resolve to a
section that **names the row**: a pointer at a section that never mentions it
reads as a disposition and is not one.

L5 additionally pins the frozen line at the literal `1,024 B` on those rows, so
the breach cannot be dissolved by re-registering the line in a cell edit, and
pins the population per row so a bench-tree figure cannot be promoted to a
package one.

## My boundary against `rf2-hic-071`

**The line is what a hosted runner is allowed to decide.** §1 permits
CI-RUNNER-A correctness gates and same-run relative drift and forbids it any
distributional product budget; §2 sorts the rows; §7 routes them. So part 1 is
*the deterministic family plus the record*, and `rf2-hic-071` is everything that
needs a population or a quiet box. Stated on the page as §9.3.

**Two of this bead's stated deliverables cannot be built early, and the reason
is on the page rather than in my judgement.** Both are recorded as ledger rows
rather than dropped:

- *"The 5% same-instrument regression gate … running in CI per relevant PR."*
  The pinned ordinary-Hicasso benchmark is a heap figure. Wiring it to a hosted
  runner breaches §1 on the first green, and §7 says such a row is never
  converted into a flaky PR threshold. It is `C1`, `UNPINNED` — and it has a
  second, independent blocker: §6 records that the registered instrument's
  eleven pinned blobs are **superseded rather than repaired** (one file no
  longer exists), so "the same instrument" currently names nothing to compare
  against. L6 is what stops a later worker wiring it anyway: a distributional
  row may not name the `PR gate` lane. Sabotage E is that exact edit.
- *"Slice-app user-visible gates: ≤50 ms p95 / ≤100 ms p99; keystroke echo
  within one frame."* These are `U1`–`U4`. §4 records that no package-resident
  clock instrument exists to pin them on, and building one here would be a
  second instrument and therefore a second thing to drift — the rule `rf2-fe0l`
  was dispatched to honour. The deterministic half that *is* reachable is
  already gated: `U5` (body work scales with changed rows) and `D7`/`D8` (the
  per-keystroke body counts behind the echo claim).

`rf2-hic-071` therefore inherits three things, not one: the clock instrument
and the U-row gates it makes possible, the ladder re-pin and the 5% comparison
it makes meaningful, and the escape-benefit rule (`C8`) over escapes its own
dependencies land. It reports into this ledger and owns the status columns from
the moment it takes them.

**No overlap absorbed.** `hic-071` deliverables I have not touched: the
escape-benefit enforcement, the editor/grid/vendor-app population, and any gate
that reads an instrument. The one surface we share is the budgets-doc status
column, which the bead already assigns to me "until hic-071 takes over".

## The workflow file I did **not** add

**HOT ZONE — I stopped and am reporting.** A ledger-only edit does not reach
this gate in CI today, and I verified it rather than assuming:

```
$ bash .github/scripts/report-changed-surfaces.sh docs/design/hicasso/product/budgets.md
cljs_node_test=false
$ bash .github/scripts/report-changed-surfaces.sh docs/design/hicasso/product/budgets.md \
    implementation/hicasso/scripts/check_budget_ledger.py implementation/package.json
cljs_node_test=true
```

`test:hicasso-invariants` runs only as a step of the `cljs` job under
`cljs_node_test == 'true'`, so **this PR arms it and a future ledger-only edit
would not** — which is precisely the edit the gate exists to police. Same
defect, same chain, same repair as `test.yml`'s `hicasso-complaint-catalogue`
job, whose own comment records the identical hole at `test.yml:875–905`.

**What I would add**, if the operator sequences it — a near-copy of that job,
unconditional rather than a new classifier output, for the reason its comment
gives (a new arm is a fresh chance to make the same mistake, and it needs
re-widening every time the checker learns to read another file):

```yaml
  hicasso-budget-ledger:
    name: Hicasso budget-line reconciliation ledger (rf2-hic-089)
    runs-on: ubuntu-latest
    timeout-minutes: 5
    steps:
      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
        with:
          python-version: '3.12'
      - name: Self-test the ledger's rule classification
        run: python implementation/hicasso/scripts/check_budget_ledger.py --self-test
      - name: Verify the ledger against budgets.md and its disposition records
        run: python implementation/hicasso/scripts/check_budget_ledger.py
```

It stays chained into `test:hicasso-invariants` regardless: that chain is the
local spine lane and the artefact's one-command run; the job would be the CI
reachability the chain cannot give it. Sub-second pure-Python static read, no
node, no JVM. Filed as **`rf2-uomk`** rather than smuggled in here.

## Quality gates

Run alone, redirected, exit code captured on the same command line. Every
number below is the captured one.

| Run | Command | Captured exit |
|---|---|---:|
| 1 | `python implementation/hicasso/scripts/check_budget_ledger.py --self-test` | `0` |
| 2 | `python implementation/hicasso/scripts/check_budget_ledger.py` | `0` |
| 3 | `cd implementation && npm run test:hicasso-invariants` | `0` |
| 4 | `python scripts/check_doc_slugs.py` | `0` |
| 5 | `python scripts/check_provenance_pins.py --changed-since origin/main` | `0` |
| 6 | `python scripts/check_fast_pr_gap.py --list` | `0` |
| 7 | `sh scripts/test-fast-pr.sh` | *running at PR-open; result appended as a comment* |

Run 3's tail, which is the wiring proof:

```
OK: check_budget_ledger self-test passed (31 rows: 14 MET, 5 BREACH, 2 UNRESOLVED, 10 UNPINNED)
OK: 31 ledger rows -- 14 MET, 5 BREACH, 2 UNRESOLVED, 10 UNPINNED.
```

The self-test drives all six rules red in turn by doctoring one input of a
green tree, and asserts three legal shapes stay green.

### Sabotage — it bites

All four applied to the final bytes on this branch, each run alone with its
exit code captured on the same command line.

| # | Edit | Captured exit | What it named |
|---|---|---:|---|
| A | `S1` `BREACH` → `MET` (green the carried shell breach) | `1` | `L2 S1 is recorded MET but the band [1091-1107] against the 1024 B line reads BREACH` |
| C | `S1` band → `[1,010–1,030]`, status `MET` (a crossing band read as a pass) | `1` | `L2 S1 is recorded MET but the band [1010-1030] crosses the 1024 B line, so the row is UNRESOLVED, not a pass` |
| E | `C1`'s instrument → `` `scripts/five-percent-gate.sh` (PR gate) `` | `1` | `L6 C1 is a distributional row wired to the PR-gate lane. A hosted runner may never source a distributional budget (budgets.md sec. 1) and such a row is never converted into a flaky PR threshold (sec. 7)` |
| F | `S1`'s disposition link → `—` | `1` | `L3 S1 is BREACH and names no disposition record. A breach nothing points at is a silent breach` |

### Sabotage — and it is not too eager

The direction a guard is almost never tested in. A *legal* value must still
pass, and three do:

| # | Edit | Captured exit | Why it must be green |
|---|---|---:|---|
| B | `S1` band → `994 B [988–1,002]`, status `MET` | `0` | the no-wrapper remediation landing under the line is the outcome the line exists to reward |
| D | `S1` band → `[1,010–1,030]`, status `UNRESOLVED` | `0` | the same crossing band, honestly recorded, is not a failure — it is what the ruling asks for |
| — | in-process, `--self-test` | `0` | a `MET` row needs no disposition and its `—` is not a broken pointer; `C3`'s `1.25x` is the **registered** broad-update rule and is not caught by the prohibition aimed at the cold-mount proposal |

`budgets.md` restored after every sabotage and verified **by hashing the
bytes**, not by `git diff`: `sha256
c71f0c0e14c785059fff8c057f9fd850847892ea6c8bf16333365057f83f1422` before and
after the battery, `git status --short` clean.

Separately, I confirmed the new anchors are really validated rather than
assumed: breaking `#92-what-each-not-green-row-is-waiting-on` made
`check_doc_slugs.py` exit `1` with 14 broken-anchor reports naming file and
line. Restored, hash matched, gate back to `0`.

### What the spine does not decide

`python scripts/check_fast_pr_gap.py --list` (exit `0`) reports **97 required
checks the spine does not run**, and states the claim precisely: *"Green here is
not green in CI … most are surface-gated in CI and skip on a diff that does not
reach them. The claim is narrower and harder — NONE of them is decided here."*
Concretely for this change: the spine and CI both run this gate on **this**
diff, and neither runs it on a **ledger-only** edit — that is `rf2-uomk`, the
workflow job above, and it is not in this PR.

`mkdocs build --strict` is **not** the gate for this change: `mkdocs.yml`'s
`exclude_docs` keeps `design/hicasso/` out of the site. `check_doc_slugs.py`
validates the tree's link targets and heading anchors (run 4, proven to bite
above) and `check_provenance_pins.py` validates changed pages under
`docs/design/hicasso/` (run 5). Nothing validates tables or rendering, so **I
verified those by hand**: every table in `budgets.md` has a consistent column
count row to row — checked across all tables in the file, zero mismatches; the
ledger is 8 columns and the comparative-rules table is now 3 — and every anchor
this PR introduces or cites resolves.

## Not touched

`spec/**` (PR #7945 is open on it), `.github/workflows/**`,
`implementation/shadow-cljs.edn`, `implementation/deps.edn`,
`specification.md`, `decision-brief.md`, `lanes/**`.

**No figure was re-measured.** Every number in the ledger is transcribed from
the landed evidence of `rf2-fe0l` (#7939, #7941) and `rf2-hic-018` (#7946). A
second instrument would be a second thing to drift, which is the rule those PRs
exist to honour.
