### PR TITLE
fix(hicasso): the outward bridge hands :children the vector the contract names

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
@@ -3700,7 +3700,7 @@
   difference a body sees as `(when-some [cs (:children props)] …)`."
   [c]
   (if (array? c)
-    (when (pos? (alength ^js c)) (vec c))
+    (when (pos? (alength c)) (vec c))
     [c]))
 
 (defn- outward-props

--- a/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
@@ -3673,6 +3673,36 @@
         (keyword s)
         (keyword (str/replace s #"[A-Z]" #(str "-" (str/lower-case %)))))))
 
+(defn- outward-children
+  "React's `children` slot, in the CONTAINER [[realize-children]] hands a
+  hiccup body: a vector, or nil when there are none.
+
+  React's slot is not one shape but three — absent for no children, the
+  child ITSELF for one, a JavaScript array for several — and that shape
+  is React's calling convention rather than a value an author asked for.
+  Copied through unchanged it would make `:children` mean something
+  different depending on how many the parent wrote, so
+  `(into [:ul] (:children props))` would work at two children and throw
+  at one. One spelling has to mean one thing, and the thing it already
+  means on the hiccup side is a vector.
+
+  The members are not touched: each child crosses by identity, exactly
+  as every other prop value does, and nothing here walks INTO one. So a
+  nested array — JSX's `<ul>{head}{rows}</ul>` — stays a single member
+  rather than splicing, which is the boundary this normalisation stops
+  at on purpose: React flattens it at render, so it renders correctly as
+  a member, and flattening it here would be the second level of walk
+  that [[outward-props]] refuses everywhere else.
+
+  An EMPTY array answers nil, so a parent whose dynamic list came back
+  empty leaves `:children` absent rather than present-and-empty —
+  [[realize-children]]'s own answer for `(for [x []] …)`, and the
+  difference a body sees as `(when-some [cs (:children props)] …)`."
+  [c]
+  (if (array? c)
+    (when (pos? (alength ^js c)) (vec c))
+    [c]))
+
 (defn- outward-props
   "A React props object, decoded into the ordinary ClojureScript props map
   a boundary body destructures. Shallow, by identity, own properties
@@ -3683,12 +3713,18 @@
 
   React's children arrive at the `children` slot and therefore land at
   `:children`, which is where [[boundary-element]] puts a hiccup body's
-  children too — one spelling, whichever side of the bridge filled it."
+  children too — one spelling, whichever side of the bridge filled it,
+  and by [[outward-children]] one SHAPE as well."
   [^js js-props]
   (if (nil? js-props)
     {}
     (persistent!
-      (reduce (fn [m s] (assoc! m (prop-key s) (unchecked-get js-props s)))
+      (reduce (fn [m s]
+                (if (identical? "children" s)
+                  (if-some [cs (outward-children (unchecked-get js-props s))]
+                    (assoc! m :children cs)
+                    m)
+                  (assoc! m (prop-key s) (unchecked-get js-props s))))
               (transient {})
               (js/Object.keys js-props)))))
 
@@ -3702,7 +3738,8 @@
       ;; on the React side: <ArticleCard articleId={7} />
 
   The parent's props arrive as the view's ordinary props map
-  ([[prop-key]]), React's children arrive at `:children`, and values
+  ([[prop-key]]), React's children arrive at `:children` as the same
+  vector a hiccup caller's would ([[outward-children]]), and values
   cross by identity. Called ONCE, at top level, beside the view it
   bridges: it allocates a component, so minting one inside a render would
   hand React a fresh element type on every pass and remount the subtree —

--- a/implementation/hicasso/test/re_frame/hicasso/native_abi_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_abi_cljs_test.cljs
@@ -18,6 +18,7 @@
   | [[the-taught-spellings-decode-to-themselves]] | `className` comes back as `:class`, not as `:class-name` | a missing rename table, which row 1 passes with because both spellings emit into `className` |
   | [[a-native-parents-props-arrive-as-the-views-own-props-map]] | the outward bridge's whole promise, measured in the body | a bridge that handed the body the raw JavaScript object — the second ABI clause 5 forbids |
   | [[the-outward-bridge-adds-no-refusal-of-its-own]] | a bad head refuses through the codec's own id and coordinate | a bridge that minted a private complaint, which is a spelling no catalogue carries |
+  | [[the-children-a-body-reads-are-the-same-through-either-crossing]] | ONE body, rendered from a hiccup parent and from a React parent at 0, 1 and N children, reads the same `:children` — the falsifiable form of the ABI-preserving claim | copying React's `props.children` through unchanged, which is a vector at two children and the element itself at one (audit #7874) |
   | [[n-memo-keeps-the-marker-where-a-raw-react-memo-loses-it]] | the helper's entire reason to exist, with its own control beside it | a `memo` that forwarded the call and stamped nothing |
   | [[n-lazy-is-a-native-head-from-the-moment-it-is-declared]] | a code-split head is recognisable during the whole window it is waiting | a marker minted inside the loader — nil until the chunk lands |
   | [[a-lazy-region-is-client-only-whatever-its-component-declared]] | the server never sent the chunk, so no declaration can make bytes exist | copying `:server` off the loaded component |
@@ -74,6 +75,27 @@
   (reset! !received props)
   [:article {:class (:class props)} (str "#" (:article-id props))])
 
+(defonce ^:private !roster
+  ;; The props map [[child-roster]] was handed, whichever crossing filled
+  ;; it. Held whole for the same reason as `!received`: the parity row is
+  ;; about `(find props :children)`, and absent is not nil.
+  (atom nil))
+
+(h/defview child-roster
+  "A view whose whole body is the ABI under test: it SPLICES its
+  children. Written once and rendered through both crossings, so the
+  parity row compares one body's own reading rather than two bodies that
+  happen to agree — and the splice is the falsifier, because `into` over
+  a lone React element or a JavaScript array is not a thing that
+  quietly renders wrong, it is a thing that throws."
+  [props]
+  (reset! !roster props)
+  (into [:ul] (:children props)))
+
+(def ^:private roster-bridged
+  ;; Minted ONCE, at top level, as the bridge's own law requires.
+  (h/as-component child-roster))
+
 (n/defcomponent quote-cell*
   "A pure display island, the sort worth memoising."
   [^js props]
@@ -100,6 +122,23 @@
   (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
   (rf/make-frame {:id frame-id})
   (react-dom-server/renderToStaticMarkup (mount/provider frame-id element)))
+
+(defn- through-hiccup
+  "Render [[child-roster]] with `kids` from a HICCUP parent, and answer
+  what the body saw beside what the page became."
+  [& kids]
+  (reset! !roster nil)
+  (let [markup (render-outward! (h/as-element (into [child-roster {}] kids)))]
+    {:markup markup :props @!roster}))
+
+(defn- through-react
+  "The same view, the same children, from a REACT parent — the outward
+  bridge. `createElement`'s variadic children are the shape a JSX parent
+  writes, so this is the crossing a consumer actually has."
+  [& kids]
+  (reset! !roster nil)
+  (let [markup (render-outward! (apply react/createElement roster-bridged nil kids))]
+    {:markup markup :props @!roster}))
 
 (defn- refusal
   [f]
@@ -228,8 +267,12 @@
 
     (testing "React's children arrive at `:children`, which is the slot a
               hiccup caller's children land in too — one spelling,
-              whichever side of the bridge filled it"
-      (is (react/isValidElement (:children props))))
+              whichever side of the bridge filled it, and the vector the
+              slot means there. The SHAPE parity across every arity is
+              [[the-children-a-body-reads-are-the-same-through-either-crossing]]"
+      (is (vector? (:children props)))
+      (is (= 1 (count (:children props))))
+      (is (react/isValidElement (first (:children props)))))
 
     (testing "and the internal crossing is nowhere in what the body was
               given: the bridge decodes INTO the props map, so no
@@ -259,6 +302,71 @@
             the extra fiber belongs to"
     (is (= "hicasso/as-component(re-frame.hicasso.native-abi-cljs-test/article-card)"
            (.-displayName (h/as-component article-card))))))
+
+(deftest the-children-a-body-reads-are-the-same-through-either-crossing
+  (let [one   (react/createElement "li" #js {:key "a"} "one")
+        two   (react/createElement "li" #js {:key "b"} "two")
+        three (react/createElement "li" #js {:key "c"} "three")]
+
+    (testing "NO children: `:children` is ABSENT on both sides, not
+              present-and-empty — so `(when-some [cs (:children props)] …)`
+              answers the same question whichever parent asked it"
+      (let [hiccup (through-hiccup)
+            bridge (through-react)]
+        (is (nil? (find (:props hiccup) :children)))
+        (is (nil? (find (:props bridge) :children)))
+        (is (= "<ul></ul>" (:markup hiccup) (:markup bridge)))))
+
+    (testing "ONE child: a vector of one on both sides. THIS IS THE ROW
+              THE AUDIT REOPENED THIS BEAD FOR — React hands a lone child
+              through as the child ITSELF, and copied across unchanged it
+              made `:children` mean an element here and a vector at two
+              children. The body splices, so the old shape does not render
+              differently: it throws"
+      (let [hiccup (through-hiccup one)
+            bridge (through-react one)]
+        (is (vector? (:children (:props bridge))))
+        (is (= [one] (:children (:props hiccup)) (:children (:props bridge))))
+        (is (identical? one (first (:children (:props bridge))))
+            "and the child crossed by identity, not through a clone —
+             `React.Children.toArray` would re-key it")
+        (is (= "<ul><li>one</li></ul>" (:markup hiccup) (:markup bridge)))))
+
+    (testing "SEVERAL children: a ClojureScript vector, not the JavaScript
+              array React holds them in — `(vector? (:children props))` is
+              the ABI, and a body that reads `(count …)` or `(map … )` or
+              destructures is reading a vector on both crossings"
+      (let [hiccup (through-hiccup one two three)
+            bridge (through-react one two three)]
+        (is (vector? (:children (:props bridge))))
+        (is (= [one two three] (:children (:props hiccup)) (:children (:props bridge))))
+        (is (= "<ul><li>one</li><li>two</li><li>three</li></ul>"
+               (:markup hiccup) (:markup bridge)))))
+
+    (testing "an EMPTY dynamic list is absent, not empty — `{items}` over
+              nothing on the React side and `(for [x []] …)` on the
+              hiccup side are one intent, and a body that renders a
+              wrapper only `when-some` children must not see one on
+              exactly one of them"
+      (let [hiccup (through-hiccup (list))
+            bridge (through-react #js [])]
+        (is (nil? (find (:props hiccup) :children)))
+        (is (nil? (find (:props bridge) :children)))
+        (is (= "<ul></ul>" (:markup hiccup) (:markup bridge)))))
+
+    (testing "and a NESTED array stays one member rather than splicing —
+              the boundary this normalisation stops at, stated rather
+              than discovered. React flattens it at render, so it paints
+              correctly as a member; walking into it here would be the
+              second level of conversion the bridge refuses everywhere
+              else, and the hiccup side's one-level seq splice is not
+              claimed to mirror it"
+      (let [bridge (through-react one #js [two three])
+            kids   (:children (:props bridge))]
+        (is (= 2 (count kids)))
+        (is (identical? one (first kids)))
+        (is (array? (second kids)))
+        (is (= "<ul><li>one</li><li>two</li><li>three</li></ul>" (:markup bridge)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3. The ABI helpers


### PR DESCRIPTION
Closes the audit #7874 reopen on rf2-hic-032.

## What was wrong

`h/as-component` — the outward bridge — copied React's `props.children` into the
view's props map unchanged. React's `children` slot is not one shape but three:
absent for none, **the child itself** for one, a JavaScript array for several.
That is React's calling convention, not a value an author asked for, and copied
through it made `:children` mean an element at one child and an array at two,
against a contract (`realize-children`, guide ch02) that says the slot holds a
realized ClojureScript vector.

It does not render subtly wrong. A body that splices — `(into [:ul] (:children props))`,
the ordinary thing to do with children — **throws** at one child
(`[object Object] is not ISeqable`) and reads a JS array at several.

The prior PR's own test pinned the broken shape: `(is (react/isValidElement (:children props)))`.

## The repair

`outward-children` (private, in `impl/codec`) normalises absent / single /
multiple to the vector the contract already names, and stops there:

* **Members cross by identity.** No `React.Children.toArray` — it clones and
  re-keys, which is a different bug wearing the right shape.
* **A nested array stays one member**, stated rather than discovered. React
  flattens it at render so it paints correctly as a member; walking into it here
  would be the second level of conversion the bridge refuses everywhere else.
* **An empty array answers nil**, so `{items}` over an empty list leaves
  `:children` absent rather than present-and-empty — `realize-children`'s own
  answer for `(for [x []] …)`, and the difference a body sees as
  `(when-some [cs (:children props)] …)`.

No new public export. No new hook.

## The witness that makes "ABI-preserving" falsifiable

`the-children-a-body-reads-are-the-same-through-either-crossing`
(`native_abi_cljs_test.cljs`). **One** view body — `child-roster`, whose whole
body is `(into [:ul] (:children props))` — rendered through **both** crossings at
0, 1, N, and empty-dynamic-list, with the **same** child objects, asserting that
what the body reads and what the page becomes are equal on both sides.

It is not a test that a helper exists. It reds if either side of the bridge drifts
from the other, and the splice makes the failure an exception rather than a
diff nobody reads.

## Quality gates

Each run alone, in one shell, exit code captured on the same command line.
`*.exit` artefacts deleted between runs.

| gate | exit | result |
| --- | --- | --- |
| `npm run test:cljs` (owns `*-cljs-test$`, incl. this suite and `hook_budget_cljs_test`) | **0** | Ran 13346 tests containing 67230 assertions. 0 failures, 0 errors. |
| `npm run test:browser` (the lane that decides the DOM half of both bridges) | **0** | Ran 1293 tests containing 8008 assertions. 0 failures, 0 errors. |
| `npm run build:hicasso-release` (`:advanced`, production-erasure gate) | **0** | — |
| `npm run test:hicasso-invariants` (freeze / reachability / complaint catalogue) | **0** | `codec.cljs` carries no frozen row; the one surviving row is `front/slot.cljc`. |
| `python scripts/check_fast_pr_gap.py --list` | **0** | 97 required checks the fast spine does not decide. |

**Not nominated, with the reason**: `test:hicasso-controlled` and `test:hicasso-hmr`
arm on `implementation/hicasso/**` and therefore run in CI, but neither executes a
line of the changed path — `grep -rn "as-component" implementation/hicasso/testbed/`
is empty, and `outward-props` is private with `as-component` as its only caller.
A gate over an excluded path exits green having verified nothing.

### Sabotage, both directions

**Remove it** — `outward-props` reverted to the raw copy, gate run whole:
`EXIT=1`, `1 failures, 3 errors`.

```
FAIL in (a-native-parents-props-arrive-as-the-views-own-props-map) (native_abi_cljs_test.cljs:273:11)
  actual: (not (vector? #js {"$$typeof" #object[Symbol(react.transitional.element)], :type "span", …}))
ERROR in (the-children-a-body-reads-are-the-same-through-either-crossing)
  actual: #object[Error Error: [object Object] is not ISeqable]
```

**Widen it to a legal near-miss** — the implementation a maintainer would reach
for instead, `React.Children.toArray`, which produces the right *shape*:
`EXIT=1`, `7 failures, 0 errors`. It reds on identity, naming React's re-key:

```
FAIL … (native_abi_cljs_test.cljs:330:13)
  and the child crossed by identity, not through a clone — `React.Children.toArray` would re-key it
expected: (identical? one (first (:children (:props bridge))))
  actual:  (not (identical? #js {… :key "a" …} #js {… :key ".$a" …}))
```

**Restored and verified by hashing the bytes**, not by reading a diff:
`sha256(impl/codec.cljs) = ab71c2ab7442dad8e620a89bbe8bf1827d7cf3085b124ad27d57d71f7f2e9cb0`,
identical before and after both sabotages.

## Scope notes

* The bead's dispatch note asked that `n/memo` / `n/lazy` be re-grepped before
  acting: **they have landed** (`native.cljc:465`, `:491`), so guide ch10's
  promise is already true and only the doc-side follow-up (rf2-eo9n) remains.
* No `docs/` edit — the doc side is rf2-eo9n's. Nothing in the guide states a
  children shape for the outward bridge, so this repair creates no doc drift; it
  makes ch02's `(:children props)` promise true on the React crossing too.
* rf2-hic-034 remains the downstream three-route parity matrix.
