### PR TITLE
test: 41 chains where the rejection handler outlived its own row — http, ui, adapters, resources (rf2-fyba)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/freehand_cell_under_ratom_adapter_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/freehand_cell_under_ratom_adapter_dom_cljs_test.cljs
@@ -211,14 +211,15 @@
             (fn [_]
               (is (= "2" (text container "#compiled"))
                   "0 → 1 → 2, the sequence the Freehand-hosted arm produced
-                   and the Reagent-hosted one could not")
-              (unmount! container @mounted)
-              (done)))
+                   and the Reagent-hosted one could not")))
+           ;; Reports and releases; it never finishes (rf2-fyba). The unmount both
+           ;; arms used to duplicate now rides the single trailing step, so it is
+           ;; written once, still runs on both paths, and `done` is last.
            (.catch
             (fn [e]
               (is false (str "freehand-under-reagent repaint rejected: " e))
-              (unmount! container @mounted)
-              (done)))))))))
+              nil))
+           (.then (fn [_] (unmount! container @mounted) (done)))))))))
 
 (deftest a-real-press-repaints-a-freehand-cell-under-the-reagent-adapter
   (testing "the operator pressed a button, so drive a real DOM press: the
@@ -245,14 +246,12 @@
               (is (= 42 (:count (frame/frame-app-db-value fid)))
                   "the press dispatched into the committed frame")
               (is (= "42" (text container "#compiled"))
-                  "and the mounted Freehand occurrence repainted from it")
-              (unmount! container @mounted)
-              (done)))
+                  "and the mounted Freehand occurrence repainted from it")))
            (.catch
             (fn [e]
               (is false (str "freehand-under-reagent press rejected: " e))
-              (unmount! container @mounted)
-              (done)))))))))
+              nil))
+           (.then (fn [_] (unmount! container @mounted) (done)))))))))
 
 (deftest an-unmoved-write-repaints-no-freehand-cell-under-the-reagent-adapter
   (testing "the adversarial companion. Activating the node must not make the
@@ -297,11 +296,9 @@
            (.then
             (fn [_]
               (is (= "6" (text container "#compiled"))
-                  "…and still repaints")
-              (unmount! container @mounted)
-              (done)))
+                  "…and still repaints")))
            (.catch
             (fn [e]
               (is false (str "freehand-under-reagent no-movement arm rejected: " e))
-              (unmount! container @mounted)
-              (done)))))))))
+              nil))
+           (.then (fn [_] (unmount! container @mounted) (done)))))))))

--- a/implementation/adapters/reagent/test/re_frame/react_click_handler_frame_routing_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/react_click_handler_frame_routing_cljs_test.cljs
@@ -111,9 +111,12 @@
                    (is (= :all (mode-of :rf/xray))
                        ":rf/xray :mode flips to :all via the envelope opts")
                    (is (nil? (mode-of :rf/default))
-                       ":rf/default is NOT polluted by the dispatch")
-                   (done)))
-          (.catch (fn [e] (is false (str "promise rejected: " (.-message e))) (done)))))))
+                       ":rf/default is NOT polluted by the dispatch")))
+          ;; Reports and releases; it never finishes (rf2-fyba) — `done` runs the
+          ;; whole remainder of the run synchronously, so a `.catch` downstream of
+          ;; it would claim a later namespace's throw and fire `done` twice.
+          (.catch (fn [e] (is false (str "promise rejected: " (.-message e))) nil))
+          (.then (fn [_] (done)))))))
 
 ;; ---- 2. with-frame lexical wrapper --------------------------------------
 
@@ -138,9 +141,9 @@
                    (is (= :all (mode-of :rf/xray))
                        ":rf/xray :mode flips to :all via the lexical with-frame wrapper")
                    (is (nil? (mode-of :rf/default))
-                       ":rf/default is NOT polluted by the dispatch")
-                   (done)))
-          (.catch (fn [e] (is false (str "promise rejected: " (.-message e))) (done)))))))
+                       ":rf/default is NOT polluted by the dispatch")))
+          (.catch (fn [e] (is false (str "promise rejected: " (.-message e))) nil))
+          (.then (fn [_] (done)))))))
 
 ;; ---- 3. (:dispatch (rf/capture-frame)) capture-at-call-time ----------------------------
 
@@ -163,9 +166,9 @@
                      (is (= :all (mode-of :rf/xray))
                          ":rf/xray :mode flips via the captured dispatcher")
                      (is (nil? (mode-of :rf/default))
-                         ":rf/default is NOT polluted")
-                     (done)))
-            (.catch (fn [e] (is false (str "promise rejected: " (.-message e))) (done))))))))
+                         ":rf/default is NOT polluted")))
+            (.catch (fn [e] (is false (str "promise rejected: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
 
 ;; ---- 4. re-frame.frame/bind-fn — the internal HoF framework helper ------
 ;;
@@ -195,9 +198,9 @@
                      (is (= :all (mode-of :rf/xray))
                          ":rf/xray :mode flips via the bind-fn wrap")
                      (is (nil? (mode-of :rf/default))
-                         ":rf/default is NOT polluted")
-                     (done)))
-            (.catch (fn [e] (is false (str "promise rejected: " (.-message e))) (done))))))))
+                         ":rf/default is NOT polluted")))
+            (.catch (fn [e] (is false (str "promise rejected: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest bind-fn-captured-under-with-frame-routes-to-captured-frame
   (testing "rf2-tvu99 / rf2-kkut0 — `(frame/bind-fn frame-id f)` built inside
@@ -217,9 +220,9 @@
                      (is (= :all (mode-of :rf/xray))
                          ":rf/xray :mode flips via the bind-fn-captured callback")
                      (is (nil? (mode-of :rf/default))
-                         ":rf/default is NOT polluted")
-                     (done)))
-            (.catch (fn [e] (is false (str "promise rejected: " (.-message e))) (done))))))))
+                         ":rf/default is NOT polluted")))
+            (.catch (fn [e] (is false (str "promise rejected: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
 
 ;; ---- regression: dispatch-sync from inside the wrap routes too ---------
 

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -1025,15 +1025,29 @@
      Use this in CLJS tests under `cljs.test/async` that previously
      chained nested `js/setTimeout` calls to wait for a router drain,
      pipeline run, or sub re-fire. The Promise composes with `.then` /
-     `.catch` and integrates cleanly with `async done`:
+     `.catch` and integrates cleanly with `async done`.
+
+     Put the rejection handler UPSTREAM of the single trailing step that
+     calls `done`, and call `done` exactly once with nothing after it
+     (rf2-d3tc / rf2-qpns / rf2-fyba). `cljs.test/run-block` hands `done` a
+     continuation that runs the WHOLE REMAINDER of the run synchronously, so
+     a `.catch` sitting downstream of `done` claims whatever a later
+     namespace throws as this row's failure — printing it against this row's
+     label — and then calls `done` a SECOND time, which re-forces
+     `run-block`'s unrealized delay and re-runs the offending namespace.
+     The handler reports and releases; it never finishes:
 
          (deftest drains
            (async done
              (-> (test-support/poll-until
                    #(= 3 (:n (rf/app-db-value :rf/default)))
                    {:label \"counter reached 3\"})
-                 (.then (fn [_] (is (= 3 ...)) (done)))
-                 (.catch (fn [e] (is false (.-message e)) (done))))))"
+                 (.then  (fn [_] (is (= 3 ...))))
+                 (.catch (fn [e] (is false (.-message e)) nil))
+                 (.then  (fn [_] (done))))))
+
+     Teardown that both paths share belongs in that trailing step, where it
+     is written once and still runs once per path."
      ([pred] (poll-until pred nil))
      ([pred opts]
       (let [{:keys [timeout-ms interval-ms label]

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -335,9 +335,9 @@
                          ":body-binary carries the native Blob from `.blob()`")
                      (is (nil? (:body-text result))
                          "the lossy `.text()` string is NOT read for a `:blob` decode")
-                     (is (true? (:ok? result)))
-                     (done)))
-            (.catch (fn [e] (is false (str "unexpected reject: " e)) (done))))))))
+                     (is (true? (:ok? result)))))
+            (.catch (fn [e] (is false (str "unexpected reject: " e)) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest array-buffer-and-form-data-read-native-bodies
   (testing "rf2-5zj6t — `:array-buffer` reads via `.arrayBuffer()` and
@@ -361,9 +361,9 @@
             (.then (fn [result]
                      (is (identical? fd (:body-binary result))
                          ":form-data rides the native FormData")
-                     (is (nil? (:body-text result)))
-                     (done)))
-            (.catch (fn [e] (is false (str "unexpected reject: " e)) (done))))))))
+                     (is (nil? (:body-text result)))))
+            (.catch (fn [e] (is false (str "unexpected reject: " e)) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest text-and-auto-text-still-read-body-text
   (testing "rf2-5zj6t — non-binary decodes (`:text`, `:json`, omitted/`:auto`
@@ -379,9 +379,9 @@
                      (is (= "{\"ok\":true}" (:body-text result))
                          ":auto over application/json reads `.text()`")
                      (is (nil? (:body-binary result))
-                         "no binary body is read for a text/JSON decode")
-                     (done)))
-            (.catch (fn [e] (is false (str "unexpected reject: " e)) (done))))))))
+                         "no binary body is read for a text/JSON decode")))
+            (.catch (fn [e] (is false (str "unexpected reject: " e)) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest non-2xx-binary-decode-still-reads-text
   (testing "rf2-5zj6t — a non-OK response (e.g. 404) ALWAYS reads `.text()`
@@ -398,9 +398,9 @@
                      (is (= "Not Found" (:body-text result))
                          "a 404 reads `.text()` even when `:decode :blob`")
                      (is (nil? (:body-binary result)))
-                     (is (false? (:ok? result)))
-                     (done)))
-            (.catch (fn [e] (is false (str "unexpected reject: " e)) (done))))))))
+                     (is (false? (:ok? result)))))
+            (.catch (fn [e] (is false (str "unexpected reject: " e)) nil))
+            (.then (fn [_] (done))))))))
 
 ;; ---- rf2-ee38b.7 — `:timeout-ms 0` is the opt-out, not a near-instant abort ----
 
@@ -451,9 +451,9 @@
                             :internal-controller (js/AbortController.)}))
             (.then (fn [_]
                      (is (= "error" (aget @captured-init "redirect"))
-                         ":redirect is name-stringified into the Fetch init")
-                     (done)))
-            (.catch (fn [e] (is false (str "unexpected reject: " e)) (done))))))))
+                         ":redirect is name-stringified into the Fetch init")))
+            (.catch (fn [e] (is false (str "unexpected reject: " e)) nil))
+            (.then (fn [_] (done))))))))
 
 ;; ---- rf2-rznrz — CLJS multi-valued request headers -----------------------
 
@@ -487,9 +487,9 @@
                        (is (not (re-find #"\[" (.get h "X-Multi")))
                            "no serialised-vector bracket leaked onto the wire value")
                        (is (= "solo" (.get h "X-One"))
-                           "a scalar header value is a single appended value"))
-                     (done)))
-            (.catch (fn [e] (is false (str "unexpected reject: " e)) (done))))))))
+                           "a scalar header value is a single appended value"))))
+            (.catch (fn [e] (is false (str "unexpected reject: " e)) nil))
+            (.then (fn [_] (done))))))))
 
 ;; ---- rf2-f5pguu — invalid request headers stay on the managed path -------
 ;;
@@ -710,12 +710,12 @@
             (.then (fn [result]
                      (is (= "{\"ok\":true}" (:body-text result))
                          ":timeout-ms 0 must NOT abort — the deferred fetch resolves normally")
-                     (is (true? (:ok? result)))
-                     (done)))
+                     (is (true? (:ok? result)))))
             (.catch (fn [e]
                       (is false (str "rf2-ee38b.7 regression — :timeout-ms 0 "
                                      "armed a near-instant abort and rejected: " e))
-                      (done))))))))
+                      nil))
+            (.then (fn [_] (done))))))))
 
 ;; ---- rf2-4zldh — `:timeout-ms` bounds the BODY read, not just headers ----
 ;;
@@ -764,11 +764,18 @@
                             :decode     :json
                             :timeout-ms 40
                             :internal-controller (js/AbortController.)}))
+            ;; The REJECTION is this row's success path, so the two handlers are
+            ;; SIBLINGS of one two-arg `.then` rather than a `.catch` downstream
+            ;; of a `.then` (rf2-fyba). Downstream, the fulfilment arm's `(done)`
+            ;; would run the whole remainder of the run synchronously and any
+            ;; foreign throw out there would unwind into the `.catch`, which
+            ;; would assert this row's timeout claims against a stranger's error
+            ;; and fire `done` a second time. Exactly one arm runs; the single
+            ;; trailing `done` is the only one.
             (.then (fn [result]
                      (is false (str "rf2-4zldh regression — a stalled body "
-                                    "read RESOLVED instead of timing out: " (pr-str result)))
-                     (done)))
-            (.catch (fn [err]
+                                    "read RESOLVED instead of timing out: " (pr-str result))))
+                   (fn [err]
                       (is (true? @read-fired)
                           "the body reader was reached (headers resolved) before the timeout fired")
                       (let [data (ex-data err)]
@@ -794,8 +801,8 @@
                         (is (>= (:elapsed-ms data) (- (:limit-ms data) elapsed-jitter-ms))
                             (str ":elapsed-ms (measured) is within " elapsed-jitter-ms
                                  "ms below :limit-ms — measured, JVM-parity semantics,"
-                                 " jitter-tolerant")))
-                      (done))))))))
+                                 " jitter-tolerant")))))
+            (.then (fn [_] (done))))))))
 
 (deftest cljs-timeout-stalled-body-finalises-as-timeout-and-clears-registry
   (testing "rf2-4zldh — driven through the full `:rf.http/managed` pipeline,
@@ -842,13 +849,15 @@
                        (is (= :rf.http/timeout (get-in reply [:error :kind]))
                            "a stalled body read finalises as the canonical :rf.http/timeout failure"))
                      (is (empty? (registry/in-flight-snapshot))
-                         "the in-flight registry is cleared — the slow-loris handle is not pinned")
-                     (set! (.-fetch js/globalThis) orig)
-                     (done)))
+                         "the in-flight registry is cleared — the slow-loris handle is not pinned")))
             (.catch (fn [e]
-                      (set! (.-fetch js/globalThis) orig)
                       (is false (str "rf2-4zldh — unexpected: " e))
-                      (done))))))))
+                      nil))
+            ;; Teardown rides the single trailing step, so it runs on both paths
+            ;; exactly once and `done` is the last thing this row does (rf2-fyba).
+            (.then (fn [_]
+                     (set! (.-fetch js/globalThis) orig)
+                     (done))))))))
 
 ;; ---- rf2-wj8vv — the retry backoff window is cancellable (CLJS) -----------
 ;;
@@ -951,13 +960,11 @@
                      (is (= 1 @fetch-count)
                          "the retry MUST NOT fetch after an abort issued during the backoff window")
                      (is (= 1 (count @replies))
-                         "exactly one reply — the cancelled retry never produced a second outcome")
-                     (restore)
-                     (done)))
+                         "exactly one reply — the cancelled retry never produced a second outcome")))
             (.catch (fn [e]
-                      (restore)
                       (is false (str "rf2-wj8vv — unexpected: " e))
-                      (done))))))))
+                      nil))
+            (.then (fn [_] (restore) (done))))))))
 
 ;; ---- rf2-j538f7.8 — frame destroy aborts + suppresses managed HTTP (CLJS) --
 ;;
@@ -1024,13 +1031,11 @@
                      (is (= 1 @fetch-count)
                          "the retry MUST NOT fetch after the owning frame is destroyed")
                      (is (empty? @replies)
-                         "frame destroy SUPPRESSES the reply — nothing delivered into the destroyed frame")
-                     (restore)
-                     (done)))
+                         "frame destroy SUPPRESSES the reply — nothing delivered into the destroyed frame")))
             (.catch (fn [e]
-                      (restore)
                       (is false (str "rf2-j538f7.8 — unexpected: " e))
-                      (done))))))))
+                      nil))
+            (.then (fn [_] (restore) (done))))))))
 
 ;; ---- rf2-065xo — managed body-prep failure delivery (CLJS) ----------------
 ;;
@@ -1096,13 +1101,11 @@
                        (is (= :request-prep (get-in reply [:error :stage]))
                            "the :stage discriminator marks this as a request-preparation failure"))
                      (is (empty? (registry/in-flight-snapshot))
-                         "the in-flight registry is cleared — the failed-prep request is not pinned")
-                     (restore)
-                     (done)))
+                         "the in-flight registry is cleared — the failed-prep request is not pinned")))
             (.catch (fn [e]
-                      (restore)
                       (is false (str "rf2-065xo — unexpected: " e))
-                      (done))))))))
+                      nil))
+            (.then (fn [_] (restore) (done))))))))
 
 (deftest cljs-unencodable-body-delivers-managed-transport-failure
   (testing "rf2-065xo — a non-serialisable body (circular ref → JSON.stringify throws) delivers ONE :on-failure reply with :rf.http/transport"
@@ -1144,13 +1147,11 @@
                        (is (= :rf.http/transport (get-in reply [:error :kind]))
                            "an encode failure surfaces as the managed :rf.http/transport category")
                        (is (= :request-prep (get-in reply [:error :stage]))))
-                     (is (empty? (registry/in-flight-snapshot)))
-                     (restore)
-                     (done)))
+                     (is (empty? (registry/in-flight-snapshot)))))
             (.catch (fn [e]
-                      (restore)
                       (is false (str "rf2-065xo — unexpected: " e))
-                      (done))))))))
+                      nil))
+            (.then (fn [_] (restore) (done))))))))
 
 (deftest cljs-throwing-body-thunk-retries-when-configured
   (testing "rf2-065xo — with `:retry {:on #{:rf.http/transport} …}` a throwing body thunk RETRIES (re-invoking the thunk per attempt) then finally fails :rf.http/transport"
@@ -1194,13 +1195,11 @@
                      (let [reply (first @replies)]
                        (is (= :rf.http/transport (get-in reply [:error :kind]))
                            "the final reply carries the :rf.http/transport prep-failure category"))
-                     (is (empty? (registry/in-flight-snapshot)))
-                     (restore)
-                     (done)))
+                     (is (empty? (registry/in-flight-snapshot)))))
             (.catch (fn [e]
-                      (restore)
                       (is false (str "rf2-065xo — unexpected: " e))
-                      (done))))))))
+                      nil))
+            (.then (fn [_] (restore) (done))))))))
 
 ;; ---- rf2-3fc89f.9 — lifecycle-owned external AbortSignal cancellation ------
 ;;
@@ -1378,10 +1377,9 @@
                            "the external signal flips the same precedence cell → :rf.http/aborted")
                        (is (= :user (get-in reply [:error :reason]))))
                      (is (empty? (registry/in-flight-snapshot))
-                         "the live-fetch handle is cleared")
-                     (restore)
-                     (done)))
-            (.catch (fn [e] (restore) (is false (str "rf2-3fc89f.9 — unexpected: " e)) (done))))))))
+                         "the live-fetch handle is cleared")))
+            (.catch (fn [e] (is false (str "rf2-3fc89f.9 — unexpected: " e)) nil))
+            (.then (fn [_] (restore) (done))))))))
 
 (deftest cljs-external-abort-during-backoff-cancels-retry-and-does-not-reinvoke-thunk
   (testing "rf2-3fc89f.9 acceptance 3 — an external signal that fires while the
@@ -1451,13 +1449,13 @@
                      (is (= 1 @thunk-calls)
                          "the per-attempt body thunk MUST NOT be re-invoked after cancellation")
                      (is (= 1 (count @replies))
-                         "exactly one reply — the cancelled retry produced no second outcome")
-                     (set! (.-fetch js/globalThis) orig)
-                     (done)))
+                         "exactly one reply — the cancelled retry produced no second outcome")))
             (.catch (fn [e]
-                      (set! (.-fetch js/globalThis) orig)
                       (is false (str "rf2-3fc89f.9 — unexpected: " e))
-                      (done))))))))
+                      nil))
+            (.then (fn [_]
+                     (set! (.-fetch js/globalThis) orig)
+                     (done))))))))
 
 (deftest cljs-already-aborted-signal-short-circuits-attempt-setup
   (testing "rf2-3fc89f.9 acceptance 3 — a request whose `:abort-signal` is
@@ -1498,10 +1496,9 @@
                        (is (= :user (get-in reply [:error :reason]))))
                      (is (= 0 @thunk-calls)
                          "the body thunk was NEVER invoked — attempt setup short-circuited")
-                     (is (empty? (registry/in-flight-snapshot)))
-                     (restore)
-                     (done)))
-            (.catch (fn [e] (restore) (is false (str "rf2-3fc89f.9 — unexpected: " e)) (done))))))))
+                     (is (empty? (registry/in-flight-snapshot)))))
+            (.catch (fn [e] (is false (str "rf2-3fc89f.9 — unexpected: " e)) nil))
+            (.then (fn [_] (restore) (done))))))))
 
 (deftest cljs-external-abort-racing-supersede-suppression-authoritative
   (testing "rf2-3fc89f.9 acceptance 4 — when a same-id supersede WINS the race,
@@ -1547,10 +1544,9 @@
             (.then (fn [_] (next-macrotask)))
             (.then (fn [_]
                      (is (empty? @replies-1)
-                         "the superseded request delivered NO app reply — supersede suppression is authoritative even though the external signal fired")
-                     (restore)
-                     (done)))
-            (.catch (fn [e] (restore) (is false (str "rf2-3fc89f.9 — unexpected: " e)) (done))))))))
+                         "the superseded request delivered NO app reply — supersede suppression is authoritative even though the external signal fired")))
+            (.catch (fn [e] (is false (str "rf2-3fc89f.9 — unexpected: " e)) nil))
+            (.then (fn [_] (restore) (done))))))))
 
 (deftest cljs-external-abort-racing-managed-abort-single-outcome
   (testing "rf2-3fc89f.9 acceptance 4 — an external signal and a
@@ -1594,10 +1590,9 @@
                          "exactly one terminal outcome despite two cancellation sources")
                      (is (= :cancelled (:status (first @replies))))
                      (is (= :user (get-in (first @replies) [:error :reason])))
-                     (is (empty? (registry/in-flight-snapshot)))
-                     (restore)
-                     (done)))
-            (.catch (fn [e] (restore) (is false (str "rf2-3fc89f.9 — unexpected: " e)) (done))))))))
+                     (is (empty? (registry/in-flight-snapshot)))))
+            (.catch (fn [e] (is false (str "rf2-3fc89f.9 — unexpected: " e)) nil))
+            (.then (fn [_] (restore) (done))))))))
 
 (deftest cljs-external-abort-listener-detached-on-natural-success-and-failure
   (testing "rf2-3fc89f.9 acceptance 5 — after a NATURAL success and a natural
@@ -1644,10 +1639,10 @@
                      (is (= :error (:status (first @replies))))
                      (is (= :rf.http/http-5xx (get-in (first @replies) [:error :kind])))
                      (is (= 0 (listener-count))
-                         "the failure terminal also detached — a shared signal retains no completed-attempt listeners")
-                     (set! (.-fetch js/globalThis) orig)
-                     (done)))
+                         "the failure terminal also detached — a shared signal retains no completed-attempt listeners")))
             (.catch (fn [e]
-                      (set! (.-fetch js/globalThis) orig)
                       (is false (str "rf2-3fc89f.9 — unexpected: " e))
-                      (done))))))))
+                      nil))
+            (.then (fn [_]
+                     (set! (.-fetch js/globalThis) orig)
+                     (done))))))))

--- a/implementation/http/test/re_frame/http_reply_tail_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_reply_tail_cljs_test.cljs
@@ -107,10 +107,8 @@
                                            (= :rf.http/transport
                                               (get-in ev [:tags :kind])))
                                          @traces))
-                         "the reply-tail throw was NOT reclassified as :rf.http/transport")
-                     (restore)
-                     (done)))
+                         "the reply-tail throw was NOT reclassified as :rf.http/transport")))
             (.catch (fn [e]
-                      (restore)
                       (is false (str "rf2-ln85eg — unexpected: " e))
-                      (done))))))))
+                      nil))
+            (.then (fn [_] (restore) (done))))))))

--- a/implementation/resources/test/re_frame/resources_http_completed_at_clock_cljs_test.cljs
+++ b/implementation/resources/test/re_frame/resources_http_completed_at_clock_cljs_test.cljs
@@ -125,11 +125,14 @@
                   (is (= (+ loaded-at stale-after-ms) stale-at)
                       ":stale-at is :loaded-at + :stale-after-ms")
                   (is (> stale-at now-epoch)
-                      ":stale-at is in the future against js/Date.now (window not elapsed)"))
-                (set! (.-fetch js/globalThis) orig)
-                (done)))
+                      ":stale-at is in the future against js/Date.now (window not elapsed)"))))
+            ;; Reports and releases; it never finishes (rf2-fyba). The fetch
+            ;; restore both arms duplicated rides the single trailing step.
             (.catch
               (fn [err]
-                (set! (.-fetch js/globalThis) orig)
                 (is false (str "rf2-2elcw3 — unexpected: " err))
+                nil))
+            (.then
+              (fn [_]
+                (set! (.-fetch js/globalThis) orig)
                 (done))))))))

--- a/implementation/ui/test/re_frame/ui/exact_render_capture_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/exact_render_capture_dom_cljs_test.cljs
@@ -33,9 +33,15 @@
     (catch :default e
       (js/Promise.reject e))))
 
-(defn- unexpected! [done label e]
+(defn- report-failure!
+  "Name the rejection and RELEASE the chain — never finish it (rf2-fyba).
+  `cljs.test`'s `done` runs the whole remainder of the run synchronously, so a
+  rejection handler that calls `done` must sit UPSTREAM of the single trailing
+  step that does; otherwise it claims a later namespace's throw as this row's
+  and fires `done` a second time. Returns nil so the chain resolves onward."
+  [label e]
   (is false (str label ": " e))
-  (done))
+  nil)
 
 (defn- observed-component [props]
   (let [renders (unchecked-get props "renders")]
@@ -168,16 +174,16 @@
                (act-promise #(ui/unmount! root))))
             (.then
              (fn []
-               (.remove container)
+               ;; These three read framework bookkeeping, not the DOM, so they are
+               ;; unaffected by `container` being detached in the trailing step.
                (is (= cells-base (reactive/current-live-cells))
                    "unmount restores the live-cell baseline")
                (is (= roots-base (client/live-root-ids))
                    "unmount restores the public-root baseline")
                (is (nil? (get @(:sub-cache (frame/frame frame-id)) [::a]))
-                   "unmount releases A's final observation owner")
-               (done)))
+                   "unmount releases A's final observation owner")))
             (.catch
              (fn [e]
                (try (ui/unmount! root) (catch :default _ nil))
-               (.remove container)
-               (unexpected! done "exact-capture browser proof rejected" e))))))))
+               (report-failure! "exact-capture browser proof rejected" e)))
+            (.then (fn [_] (.remove container) (done))))))))

--- a/implementation/ui/test/re_frame/ui/fast_refresh_shell_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/fast_refresh_shell_dom_cljs_test.cljs
@@ -174,17 +174,21 @@
                        (.querySelector container "[data-hmr-parent]")))
                    "the stable memo shell delegates to the current comparator")))
             (.then (fn [] (act-promise #(.unmount root))))
-            (.then
-             (fn []
-               (set! (.-error js/console) original-error)
-               (.remove container)
-               (done)))
+            ;; Reports and releases; it never finishes (rf2-fyba). `done` runs the
+            ;; whole remainder of the run synchronously, so a `.catch` downstream
+            ;; of it claims a later namespace's throw as this row's and fires
+            ;; `done` twice. The defensive unmount stays here because the success
+            ;; path already unmounted above; the teardown both paths share sits in
+            ;; the single trailing step below.
             (.catch
              (fn [e]
-               (set! (.-error js/console) original-error)
                (try (.unmount root) (catch :default _ nil))
-               (.remove container)
                (is false (str "same-signature browser proof rejected: " e))
+               nil))
+            (.then
+             (fn [_]
+               (set! (.-error js/console) original-error)
+               (.remove container)
                (done))))))))
 
 (defn- effectful-body [version probe events extra-hook?]
@@ -247,17 +251,15 @@
                  (is (empty? @warnings)
                      "the incompatible hook order produced no React warning"))))
             (.then (fn [] (act-promise #(.unmount root))))
-            (.then
-             (fn []
-               (set! (.-error js/console) original-error)
-               (.remove container)
-               (done)))
             (.catch
              (fn [e]
-               (set! (.-error js/console) original-error)
                (try (.unmount root) (catch :default _ nil))
-               (.remove container)
                (is false (str "incompatible-signature browser proof rejected: " e))
+               nil))
+            (.then
+             (fn [_]
+               (set! (.-error js/console) original-error)
+               (.remove container)
                (done))))))))
 
 (deftest stale-equal-deps-render-cannot-own-before-fresh-revision
@@ -318,10 +320,9 @@
                (is (= 1 (:ref-count (cache-entry)))
                    "only the fresh revision owns the dependency")))
             (.then (fn [] (act-promise #(.unmount root))))
-            (.then (fn [] (.remove container) (done)))
             (.catch
              (fn [e]
                (try (.unmount root) (catch :default _ nil))
-               (.remove container)
                (is false (str "stale-revision browser proof rejected: " e))
-               (done))))))))
+               nil))
+            (.then (fn [_] (.remove container) (done))))))))

--- a/implementation/ui/test/re_frame/ui/g13/measure_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/g13/measure_cljs_test.cljs
@@ -59,9 +59,9 @@
                (is (= 0 pre-hot) "the opening witness is read before the work")
                (is (= queued-writes (- post-hot pre-hot))
                    "and the closing witness after it, so the delta is the work
-                    the measured interval contained")
-               (done)))
-            (.catch (fn [e] (is false (str "seam rejected: " e)) (done))))))))
+                    the measured interval contained")))
+            (.catch (fn [e] (is false (str "seam rejected: " e)) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest work-hoisted-out-of-the-thunk-collapses-the-delta
   (testing "a caller that does the work BEFORE calling the seam reds the gate"
@@ -88,9 +88,9 @@
                    "the hoisted work advanced app-db before the seam's own
                     opening witness read")
                (is (= 0 (- post-hot pre-hot))
-                   "so the delta is 0 and the runtime containment witness reds")
-               (done)))
-            (.catch (fn [e] (is false (str "seam rejected: " e)) (done))))))))
+                   "so the delta is 0 and the runtime containment witness reds")))
+            (.catch (fn [e] (is false (str "seam rejected: " e)) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest work-deferred-past-the-commit-collapses-the-delta
   (testing "a caller that does the work AFTER the resolved Promise reds the gate"
@@ -107,6 +107,6 @@
             (.then
              (fn [{:keys [pre-hot post-hot]}]
                (is (= 0 (- post-hot pre-hot))
-                   "work deferred past the end timestamp is not in the delta")
-               (done)))
-            (.catch (fn [e] (is false (str "seam rejected: " e)) (done))))))))
+                   "work deferred past the end timestamp is not in the delta")))
+            (.catch (fn [e] (is false (str "seam rejected: " e)) nil))
+            (.then (fn [_] (done))))))))

--- a/implementation/ui/test/re_frame/ui/tool_evidence_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/tool_evidence_dom_cljs_test.cljs
@@ -181,13 +181,16 @@
 
                  :else
                  (is true (str "SKIP GC-dependent assertions: " error)))
-               (is (true? (evidence/uninstall! ::cycle-proof)))
-               (done)))
+               (is (true? (evidence/uninstall! ::cycle-proof)))))
+            ;; Reports and releases; it never finishes (rf2-fyba). `force-release!`
+            ;; stays failure-only: the success path asserts the orderly `uninstall!`
+            ;; above, and forcing after that would mask a leak rather than clean up.
             (.catch
              (fn [e]
                (evidence/force-release!)
                (is false (str "unexpected rejection: " e))
-               (done))))))))
+               nil))
+            (.then (fn [_] (done))))))))
 
 (deftest a-real-invalidation-flows-through-the-flush-into-the-projection
   (when (browser?)
@@ -239,15 +242,15 @@
                  (is (= [] (evidence/projection))))
                (testing "uninstall releases the registration"
                  (is (true? (evidence/uninstall! ::xray-panel)))
-                 (is (nil? (evidence/installed-owner))))
-               (rf/destroy-frame! f)
-               (done)))
+                 (is (nil? (evidence/installed-owner))))))
             (.catch
              (fn [e]
                (evidence/force-release!)
-               (rf/destroy-frame! f)
                (is false (str "unexpected rejection: " e))
-               (done))))))))
+               nil))
+            ;; Frame teardown is what both paths shared, so it rides the single
+            ;; trailing step and `done` is the last thing this row does.
+            (.then (fn [_] (rf/destroy-frame! f) (done))))))))
 
 (deftest ordinary-unmount-churn-is-bounded-under-one-live-browser-root
   (when (browser?)
@@ -343,13 +346,11 @@
              (fn []
                (is (true? (evidence/uninstall! ::xray-panel)))
                (is (= [] (evidence/projection))
-                   "tool uninstall immediately drops the Activity-retained row")
-               (rf/destroy-frame! f)
-               (done)))
+                   "tool uninstall immediately drops the Activity-retained row")))
             (.catch
              (fn [e]
                (js-delete js/globalThis gc-request-key)
                (evidence/force-release!)
-               (rf/destroy-frame! f)
                (is false (str "unexpected rejection: " e "\n" (.-stack e)))
-               (done))))))))))
+               nil))
+            (.then (fn [_] (rf/destroy-frame! f) (done))))))))))


### PR DESCRIPTION
Part of rf2-fyba. **The bead stays open** — this is 41 of it, not all of it.

`cljs.test/run-block` hands `done` a continuation that runs the **whole remainder of the
run synchronously**. Anything a later namespace throws unwinds back into the callback that
called `done`, so a `.catch` placed *downstream* of that callback claims the foreign
failure as its own — this row's label, printed against whichever test is current by then —
and then calls `done` a **second** time, which re-forces `run-block`'s still-unrealized
`Delay` and **re-runs the offending namespace**.

The cure is the one rf2-d3tc landed in #7937 and rf2-qpns generalised in #7942: the
rejection handler goes **upstream**, reports and releases but never finishes, and exactly
**one** `done` sits at the tail with nothing after it.

## The true count is 289, not 280 — and "stale by #7942" is not why

I rebuilt the scanner from the bead's stated signature rather than trusting its list
(steps matching `^\s*\((\.then|\.catch|\.finally)\b`, grouped into chains by equal indent
with no intervening lower-indent line; flag any chain where a step whose body contains
`(done)` is followed by a `.catch` step; `;;` comments stripped so commented-out code does
not count).

**The premise that 280 was derived before #7942 merged does not hold at source.** 280 is
exactly rf2-qpns's `303 − 23`, so it already nets out #7942's repair. The discrepancy is
scanner sensitivity, not staleness, and calibrating against the pre-#7942 tree shows it:

| tree state | rf2-qpns's scanner | mine | delta |
|---|---|---|---|
| pre-#7942 (`1662f3cc8e~1`) | 303 | **312** | +9 |
| post-#7942 (`600027f9c5`) | 280 | **289** | +9 |
| difference | 23 | **23** | — |

Both scanners agree exactly on what #7942 removed (23). Mine simply finds 9 more instances
repo-wide, all in `implementation/freehand` (+9), `implementation/hicasso` (+1) and one
fewer in `tools/re-frame2-pair-mcp` (−1). **289 is an upper bound, not a defect count** —
it is a structural match, and two of its hits were already known non-defects (see
"left correct" below). Line numbers drift; the signature is the durable artefact.

## What this PR fixes: the non-campaign `implementation/` trees, completely

Two trees are campaigns in their own right — `freehand` at 179 and `hicasso` at 16 — and
`hicasso` is additionally live under `worker/ssrname-mo4o`. Everything else under
`implementation/` is 40 chains across 9 files, and that is a line that can be stated
exactly: **after this PR, `implementation/http`, `implementation/ui`,
`implementation/adapters` and `implementation/resources` contain zero.** Plus the one
`implementation/core` hit, which was never a live chain — see below.

**289 → 248.** Verified by re-running the same scanner on the shipped tree.

| file | chains | shape |
|---|---|---|
| `http/test/re_frame/http_cljs_test.cljs` | 20 | 8 pure, 11 with idempotent teardown, 1 two-arg `.then` |
| `http/test/re_frame/http_reply_tail_cljs_test.cljs` | 1 | shared `restore` |
| `ui/test/re_frame/ui/fast_refresh_shell_dom_cljs_test.cljs` | 3 | asymmetric teardown |
| `ui/test/re_frame/ui/tool_evidence_dom_cljs_test.cljs` | 3 | asymmetric teardown |
| `ui/test/re_frame/ui/g13/measure_cljs_test.cljs` | 3 | pure |
| `ui/test/re_frame/ui/exact_render_capture_dom_cljs_test.cljs` | 1 | helper-forced |
| `adapters/reagent/.../react_click_handler_frame_routing_cljs_test.cljs` | 5 | pure |
| `adapters/reagent/.../freehand_cell_under_ratom_adapter_dom_cljs_test.cljs` | 3 | shared `unmount!` |
| `resources/test/.../resources_http_completed_at_clock_cljs_test.cljs` | 1 | shared fetch restore |
| `core/src/re_frame/test_support.cljc` | (1, docstring) | see below |

### Per-chain dispositions

**Teardown was NOT hoisted mechanically.** The bead is right that this is the whole
difference from #7942, so each site was read and the two arms compared:

- **Shared and idempotent → moves to the trailing step**, written once and still run once
  per path. `restore` / `(set! (.-fetch js/globalThis) orig)` in http (11 sites) and
  resources; `rf/destroy-frame!` in `tool_evidence` (2); `unmount!` in the ratom-adapter
  suite (3); `(.remove container)` and the `js/console.error` restore in
  `fast_refresh_shell` (3) and `exact_render_capture`.
- **Asymmetric → stays put.** `fast_refresh_shell`'s `(try (.unmount root) (catch ...))`
  is failure-only because the success path already unmounted upstream — hoisting it would
  have unmounted twice, which is the bead's own `behaviors_dom:179` counter-example.
  `tool_evidence`'s `evidence/force-release!` is failure-only because the success path
  asserts the orderly `uninstall!`; forcing after that would mask a leak rather than clean
  up.
- **`http_cljs_test`'s `cljs-timeout-bounds-stalled-body-read` is the one that is not
  positional at all.** Its `.catch` **is** the row's success path — the row asserts the
  fetch REJECTS, and `(is false "…RESOLVED instead of timing out")` sits in the `.then`.
  The two handlers are now **siblings of one two-arg `.then`**, which states "exactly one
  of these runs" directly, followed by the single trailing `done`.
- **`exact_render_capture`'s shape was forced by its helper.** `unexpected!` took `done`
  and called it, so no caller could be repaired without it. Renamed to `report-failure!` —
  the name rf2-d3tc chose — dropping the parameter and returning `nil`, exactly as #7942
  did for the three Hicasso `fail-and-finish!` helpers. One call site.
  Its three success-path assertions read framework bookkeeping (`current-live-cells`,
  `live-root-ids`, the sub-cache), not the DOM, so they are unaffected by `container`
  detaching in the trailing step instead of ahead of them.

### Left correct, and named as such

- **`implementation/core/src/re_frame/test_support.cljc:1035` is a docstring, not a live
  chain** — #7942 said so and it is right. But it is the docstring of `poll-until`, the
  helper the async suites are told to reach for, and its example was the **exact defective
  shape**. Every author who copied it inherited the bug, which is a fair part of why there
  were 289. The example now shows the repaired shape and says why the ordering is
  load-bearing. Docstring only.
- **`tools/re-frame2-pair-mcp/test/.../probe_test.cljs:287` — #7942's "left correct" does
  NOT hold at source.** It is structurally identical to `http_cljs_test`'s stalled-body row
  above: `(.then (fn [_] (is false "must reject") (done))) (.catch (fn [err] …(done)))`.
  #7942 read it as "a genuine error path, not the defect", but the fulfilment arm calls
  `done` and the `.catch` **is** downstream of it, so the moment the row regresses it
  exhibits the full signature — foreign claim, double `done`, namespace re-run. It is
  latent rather than live, which is why nobody has seen it; it is not a non-instance.
  Out of this PR's subset (pair-MCP), recorded on the bead.

## Reproduction control — both directions

A green aggregate is not proof: the runner echoes the console **only on failure**, and the
clean run below emits zero `Testing …` and zero `FAIL` lines precisely because it passed.

Throwaway namespace `re-frame.http-cljs-test-zz-control-cljs-test` sorts **immediately**
after `re-frame.http-cljs-test` — a prefix extension, so nothing sorts between them — which
puts it in the collision slot. It is rf2-qpns's control in shape: a fn-form `:each` fixture
paired with an `async` row, which selects `:sync`, wraps the test fn in `disable-async`, and
makes `test-var-block*` rethrow a bare **String** synchronously inside whichever `done`
continuation was running.

**Direction 1 — control present, `http_cljs_test.cljs` reverted to its pre-fix bytes**
(`git checkout 600027f9c5 -- …`, everything else repaired). `npm run test:cljs` →
**captured exit 1**:

```
Testing re-frame.http-cljs-test-zz-control-cljs-test
FAIL in (a-delayed-row-that-needs-async) (:)
rf2-3fc89f.9 — unexpected: Async tests require fixtures to be specified as maps.  Testing aborted.
expected: false
  actual: false
Testing re-frame.http-cljs-test-zz-control-cljs-test     <-- the ns RE-RAN
FAIL in (a-delayed-row-that-needs-async) (:)
rf2-3fc89f.9 — unexpected: Async tests require fixtures to be specified as maps.  Testing aborted.
expected: false
  actual: false
WARNING: Async test called done more than one time.
```

Every part of the bead's predicted signature:

- **`rf2-3fc89f.9 — unexpected:`** is `http_cljs_test`'s own `.catch` message, printed
  against **the control's** test name — a foreign failure claimed as this row's;
- the control namespace is announced **twice** — the second `done` re-forced the unrealized
  delay and the offending namespace **ran again**;
- **`WARNING: Async test called done more than one time.`**;
- and the log **ends there**. No `Ran N tests containing M assertions` line at all.

**Direction 2 — the identical control, `http_cljs_test.cljs` restored.** Restore verified
by hashing the bytes, not `git diff`:
`sha256 63f8d9897b4ba78ff0f8c9bc6ba7af9473e57ff125d63f50763a8d96e0e6c8b4` before and after.
`npm run test:cljs` → **captured exit 1**:

```
UnhandledPromiseRejection: … The promise rejected with the reason
"Async tests require fixtures to be specified as maps.  Testing aborted.".
```

The throw now escapes as an honest unhandled rejection, named for what it actually is and
attributed to **nobody**. Zero `Testing …` lines, zero `FAIL` lines, no
`WARNING: Async test called done more than one time`, and the control namespace is not
announced at all. Exit is still 1 because the control genuinely aborts `cljs.test` — the
string it throws says so — which is the control doing its job, not the defect doing its.

The control was then deleted and the tree re-hashed to the same digest; the gate numbers
below are from the tree as it ships.

## Quality gates

Each run alone, nothing appended, exit code redirected and echoed on one command line in
one shell; `*.exit` artefacts deleted between runs. **The numbers below are the ones
CAPTURED**, not the ones the harness narrated.

| gate | cwd | captured exit | result |
|---|---|---|---|
| `npm run test:browser` | `implementation/` | **0** | Ran **1293** tests containing **8008** assertions. 0 failures, 0 errors. |
| `npm run test:cljs` | `implementation/` | **0** | Ran **13345** tests containing **67211** assertions. 0 failures, 0 errors. |
| `npm run test:ui` | `implementation/` | **0** | Ran **826** tests containing **4251** assertions. 0 failures, 0 errors. |
| `npm run test:ui-g13` | `implementation/` | **0** | `G-13 PASS` |
| `clojure -M:test` | `implementation/core/` | **0** | Ran **2239** tests containing **11669** assertions. 0 failures, 0 errors. |

**The browser lane is the one that decides this** — the node lane's DOM assertions degrade
to stated skips, which are honest but are not measurements. It carries the
`fast_refresh_shell`, `tool_evidence`, `exact_render_capture` and
`freehand_cell_under_ratom_adapter` rows. `test:ui` and `test:ui-g13` are here because four
`ui/` files are touched and neither is decided by the first two lanes; the core JVM suite is
here because the docstring change is in a `.cljc` on both hosts.

`scripts/check_fast_pr_gap.py --list` (captured exit **0**) reports **97 required checks the
fast-PR spine does not decide**. The one that matters here is category (B) — `cljs-browser`
(`npm run test:browser`) has **no lane in the spine at all**, which is exactly the lane this
defect lives on and the lane run by hand above. `cljs-ui-g13` is likewise category (B) and
likewise run by hand. Also unrun by the spine and untouched by this diff:
`cljs-browser-schemas-boundary-prod`, `cljs-browser-prod-elision`, `cljs-ui-g1`,
`cljs-ui-g8`, `cljs-ui-facade-isolation`, `adapter-testbed-smokes`, `ui-smoke`.

**Test counts did not move, and that is the expected answer.** The browser lane reads
**1293**/**8008** and the node lane **13345**/**67211** — exactly where #7942 left both.
This diff adds and removes no `deftest`; it reorders steps within existing chains, so a
moved count would have been evidence of a *mistake*, most likely a namespace silently
dropped from a build. Neither moved.

## What remains: 248 chains in 69 files

Named precisely, not smoothed over, and **filed as seven parallel-safe beads** (all
`discovered-from` rf2-fyba, each carrying the full defect statement, the cure, the two
unanticipated shapes, the teardown judgement rule, the scanner signature and the
reproduction-control recipe, so none needs to read the parent first):

`rf2-0r3j` freehand 1/4 (41) · `rf2-d2xz` freehand 2/4 (42) · `rf2-ua8r` freehand 3/4 (42) ·
`rf2-o0n1` freehand 4/4 (54) · `rf2-53uz` pair-MCP (38) · `rf2-5zt9` hicasso (16) ·
`rf2-sx7g` xray + machines-viz + story (15). The four freehand beads are disjoint file sets.

| tree | chains | note |
|---|---|---|
| `implementation/freehand` | 179 | needs splitting further; see below |
| `tools/re-frame2-pair-mcp` | 38 | includes `probe_test:287` above |
| `implementation/hicasso` | 16 | `worker/ssrname-mo4o` is live in this tree — sequence after it |
| `tools/xray` | 13 | |
| `tools/machines-viz` | 1 | |
| `tools/story` | 1 | `worker/story-5gka` is live — sequence after it |

### The bead's "right first move", answered: helper adoption is not the cheap win

The bead suggested the freehand 179 might collapse if callers simply **adopted**
`mount_support`'s `each-mode` / `run-async` (repaired under #7942) instead of being fixed in
place, and called that check the right first move. It is, and the answer is **no**:

- only **51** of the 179 sit in files that already `:require` `mount-support` at all — the
  other **128** would need the require added before adoption is even on the table;
- and more decisively, `run-async`'s handler reports `"an async matrix cell rejected: "`.
  Adopting it wholesale would **replace every row's own diagnostic with one generic
  string** across 179 sites. That is a real loss of failure-message quality, and this repo
  has spent the session deleting fail-open shapes rather than adding them.

The in-place repair — now exercised on 41 chains of six distinct shapes — preserves each
row's own message and is what the remainder should use. `run-async` remains right for
**new** matrix cells, which is what it was written for.

## Not done, deliberately

No suite was retuned to dodge the async window (the `rf2-hic-029` refusal stands). No
assertion was weakened, no teardown dropped, no framework added, and no chain was swapped
without its two arms being compared first.
