### PR TITLE
fix(hicasso): open the IME through its own toggle, and preflight key delivery (rf2-hic-016)

### DIFF
--- a/implementation/scripts/lib/windows-ime-driver.ps1
+++ b/implementation/scripts/lib/windows-ime-driver.ps1
@@ -51,10 +51,11 @@
     LAYOUTS                       -> {layouts:[hkl...], langids:[hex...]}
     FIND <b64 title-substring>    -> {hwnd, title, matches}
     IMESTATE <hwnd>               -> {hkl, langid, japanese, open, conversion,
-                                      foreground, isForeground}
+                                      native, foreground, isForeground}
     RESOLVE <tokens>              -> {tokens, vks}
     FOREGROUND <hwnd>             -> {isForeground}                    [armed]
     IMEON <hwnd>                  -> {requested, hkl, langid, ...}     [armed]
+    IMECONV <hwnd>                -> {conversion, native, ...}         [armed]
     KEYS <hwnd> <tokens> <delay>  -> {sent, tokens}                    [armed]
     QUIT                          -> OK
 
@@ -69,6 +70,25 @@
   through a compatibility layer that a given browser build may not honour.
   That is why `IMESTATE` exists as a separate verb — the caller ASKS, then
   VERIFIES, and stops for the operator when the answer is no.
+
+  ## The warning above came true, and what answers it
+
+  On 2026-08-12 the first armed run got the whole way in — foreground
+  seized on all three engines, romaji and ESC both delivered — and still
+  decided nothing: `IMESTATE` read `langid 0x0411`, `japanese: true` and
+  **`open: 0`** on Chromium, Firefox and WebKit alike. The TSF IME had
+  simply ignored `IMC_SETOPENSTATUS`, exactly as this header said it might,
+  so seven romaji letters landed as plain ASCII and all 24 checks returned
+  INCONCLUSIVE.
+
+  The door that was open all along is the one the keystrokes came through.
+  `SendInput` reached that IME when IMM32 did not, so the caller opens it by
+  sending the IME'S OWN TOGGLE — `kanji` (半角/全角, VK 0x19), already in the
+  vocabulary below — through `KEYS`, and then re-reads `IMESTATE`. `IMECONV`
+  is the same shape one level along: the toggle says nothing about which
+  reading mode the IME came back in, so Hiragana is re-asserted and the
+  `native` flag re-read. Neither verb is trusted either. The caller ASKS,
+  VERIFIES, and refuses the engine when the answer is still no.
 #>
 
 [CmdletBinding()]
@@ -136,9 +156,13 @@ public static class Rf2Ime
   private const int IMC_SETCONVERSIONMODE = 0x0002;
   private const int IMC_GETOPENSTATUS = 0x0005;
   private const int IMC_SETOPENSTATUS = 0x0006;
+  // The bit that says the IME is in a JAPANESE READING mode at all. Without
+  // it romaji is typed straight through as ASCII and no composition starts,
+  // whatever the open status says.
+  private const int IME_CMODE_NATIVE = 0x0001;
   // Hiragana: native reading, full-width. What a person selects when they
   // pick "ひらがな" in the language bar.
-  private const int IME_CMODE_HIRAGANA = 0x0009;
+  private const int IME_CMODE_HIRAGANA = 0x0009;   // NATIVE | FULLSHAPE
 
   /// Every visible top-level window whose title contains `needle`. Returned
   /// with the match COUNT rather than only the first hit: two windows
@@ -218,8 +242,34 @@ public static class Rf2Ime
     return hkl.ToInt64();
   }
 
+  /// Re-assert Hiragana on an IME that is already open. Split out of
+  /// `RequestJapanese` because the two requests answer different questions:
+  /// that one asks for the input locale AND the open state AND the mode in
+  /// one shot, while this one is what the caller sends AFTER opening the IME
+  /// by its own toggle key — a toggle says nothing about which reading mode
+  /// the IME came back in, and an alphanumeric one turns the romaji that
+  /// follows back into ASCII. Returns -1 when there is no IME window to ask.
+  public static long RequestHiragana(IntPtr hwnd)
+  {
+    IntPtr ime = ImmGetDefaultIMEWnd(hwnd);
+    if (ime == IntPtr.Zero) return -1;
+    return SendMessageW(ime, WM_IME_CONTROL,
+                        new IntPtr(IMC_SETCONVERSIONMODE),
+                        new IntPtr(IME_CMODE_HIRAGANA)).ToInt64();
+  }
+
   public static int ImeOpenStatus(IntPtr hwnd) { return (int)ImeQuery(hwnd, IMC_GETOPENSTATUS); }
   public static int ImeConversion(IntPtr hwnd) { return (int)ImeQuery(hwnd, IMC_GETCONVERSIONMODE); }
+
+  /// Does a conversion mode carry the NATIVE bit? A PREDICATE over the value
+  /// rather than a second query, so the flag reported alongside `conversion`
+  /// is derived from the very reading printed next to it. The sign is tested
+  /// first because `ImeQuery` answers -1 when there is no IME window, and
+  /// `-1 & 1` is 1: an UNANSWERABLE query must not read as a satisfied one.
+  public static bool IsNativeMode(long conversion)
+  {
+    return conversion >= 0 && (conversion & IME_CMODE_NATIVE) == IME_CMODE_NATIVE;
+  }
 
   /// One key down+up through the OS input stack. The virtual key carries a
   /// real scan code (`MapVirtualKey`) because an IME reads both, and a
@@ -247,8 +297,10 @@ $VK = @{
   'tab' = 0x09; 'left' = 0x25; 'up' = 0x26; 'right' = 0x27; 'down' = 0x28;
   'home' = 0x24; 'end' = 0x23; 'delete' = 0x2E;
   # The IME's own keys: 半角/全角 toggles the IME, 変換 opens conversion,
-  # F7 forces katakana. Present so a key plan can name them; unused by the
-  # default plans.
+  # F7 forces katakana. `kanji` is no longer decorative — it is what the
+  # caller's engage preflight sends, through `KEYS`, when `IMEON`'s IMM32
+  # request leaves a TSF IME closed. The other three are here so a key plan
+  # can name them, and no default plan does.
   'kanji' = 0x19; 'convert' = 0x1C; 'nonconvert' = 0x1D; 'f7' = 0x76
 }
 
@@ -287,13 +339,17 @@ function Get-ImeState([IntPtr]$hwnd) {
   $hkl = [Rf2Ime]::LayoutOf($hwnd)
   $langid = $hkl -band 0xFFFF
   $fg = [Rf2Ime]::GetForegroundWindow()
+  # Read once, report twice: `native` is a predicate over the very number
+  # printed beside it, so the flag and the reading can never disagree.
+  $conv = [Rf2Ime]::ImeConversion($hwnd)
   [ordered]@{
     hwnd         = $hwnd.ToInt64()
     hkl          = ('0x{0:X8}' -f $hkl)
     langid       = ('0x{0:X4}' -f $langid)
     japanese     = ($langid -eq 0x0411)
     open         = [Rf2Ime]::ImeOpenStatus($hwnd)
-    conversion   = [Rf2Ime]::ImeConversion($hwnd)
+    conversion   = $conv
+    native       = [Rf2Ime]::IsNativeMode($conv)
     foreground   = $fg.ToInt64()
     isForeground = ($fg -eq $hwnd)
   }
@@ -363,6 +419,18 @@ while ($null -ne ($line = [Console]::In.ReadLine())) {
           $state = Get-ImeState $h
           $state['requestedHkl'] = ('0x{0:X8}' -f $requested)
           Reply $id 'OK' $state
+        }
+      }
+      'IMECONV' {
+        # The follow-up to opening the IME by its toggle key. Armed like every
+        # other verb that reaches into another window, and — like `IMEON` — a
+        # REQUEST: the reply carries the state read AFTER it, so the caller
+        # checks `native` rather than believing the send.
+        if (Assert-Armed $id 'IMECONV') {
+          $h = [IntPtr][int64]$parts[2]
+          [void][Rf2Ime]::RequestHiragana($h)
+          Start-Sleep -Milliseconds 250
+          Reply $id 'OK' (Get-ImeState $h)
         }
       }
       'KEYS' {

--- a/implementation/scripts/run-hicasso-native-ime-witness.cjs
+++ b/implementation/scripts/run-hicasso-native-ime-witness.cjs
@@ -44,8 +44,9 @@
  * rehearsal, and the run reports itself as a rehearsal rather than a result.
  *
  * `--inject` is the witness proper. It additionally brings each browser
- * window to the foreground, requests the Japanese input locale for it,
- * VERIFIES that the request took, and then types.
+ * window to the foreground, puts its IME into a state the checks can
+ * actually measure — Japanese locale, OPEN, native reading mode — VERIFIES
+ * each of those three, and then types.
  *
  * ========================= WHY THE IME IS VERIFIED ========================
  *
@@ -55,9 +56,34 @@
  * So the request is never trusted: `IMESTATE` reads the input locale of the
  * BROWSER WINDOW'S OWN THREAD afterwards, and if it is not `0x0411` the run
  * stops and asks the operator to switch with Win+Space rather than typing
- * seven ASCII letters into a text box and calling it a composition. That
- * failure mode is not hypothetical — it is the most likely explanation of
- * the operator observation this witness exists to resolve (see check 5).
+ * seven ASCII letters into a text box and calling it a composition.
+ *
+ * That is not hypothetical, and on 2026-08-12 it happened one notch along
+ * from where it was expected. The first armed run seized the foreground on
+ * all three engines and delivered both the romaji and the ESC — and still
+ * decided nothing: `langid 0x0411`, `japanese: true`, and `open: 0`
+ * everywhere. The locale had switched; the IME had ignored
+ * `IMC_SETOPENSTATUS` and stayed shut, so the romaji went in as ASCII and
+ * all 24 checks returned INCONCLUSIVE about the rig.
+ *
+ * `engageIme` below is the answer, and it uses the door the keystrokes
+ * already came through: `SendInput` reached that IME when IMM32 did not, so
+ * a closed IME is opened by sending its OWN toggle key (`kanji`, 半角/全角)
+ * through `KEYS`. Nothing about that is trusted either — `IMESTATE` is
+ * re-read, `open: 1` is REQUIRED before a single plan is driven, the
+ * reading mode's NATIVE bit is required with it, and an engine that will
+ * not go there is refused rather than measured.
+ *
+ * ====================== AND WHY DELIVERY IS VERIFIED ======================
+ *
+ * The same run turned up a SECOND rig failure wearing the first one's
+ * clothes: WebKit received zero keystrokes for five of the eight checks
+ * (`settledIn=0`, the ESC uncounted) and then came alive. "The keys never
+ * arrived" and "the IME was closed" both end in a field full of nothing,
+ * and no line of that output told them apart. So `probeDelivery` sends one
+ * key and reads it back off the page before each plan is driven, and a
+ * check whose probe never lands says KEYS ARE NOT ARRIVING in those words
+ * instead of borrowing the IME's excuse.
  */
 
 const fs = require('fs');
@@ -93,6 +119,21 @@ const MOUNT_TIMEOUT_MS = 60000;
 // it goes idle.
 const ARM_FIRE_TIMEOUT_MS = 9000;
 const ALL_ENGINES = ['chromium', 'firefox', 'webkit'];
+
+// 半角/全角 — the IME's own open/close toggle, sent through `KEYS` and so
+// through `SendInput`. See "WHY THE IME IS VERIFIED" above: this is the path
+// that demonstrably delivered keystrokes to the very IME that ignored
+// `IMC_SETOPENSTATUS`.
+const IME_TOGGLE_KEY = 'kanji';
+// A toggle is handled by the IME's UI thread; the IMM32 query answers from
+// the same place. Read too soon and the answer is the state before the key.
+const IME_SETTLE_MS = 500;
+// The delivery probe's key. Escape, for two reasons: the 2026-08-12 run
+// PROVED it reaches the page, and with no field focused it mutates nothing —
+// no text, no caret, no focus. Its keydown is read off the observer and then
+// erased by the check's own `resetEvents`, so no verdict ever sees it.
+const PROBE_KEY = 'escape';
+const PROBE_SETTLE_MS = 150;
 
 // ---------------------------------------------------------------------------
 // Arguments
@@ -780,6 +821,115 @@ function worst(verdicts) {
 }
 
 // ---------------------------------------------------------------------------
+// Getting the rig into a state worth measuring — and refusing when it will
+// not go there. Both of these run BEFORE anything a verdict reads, and
+// neither one may end in a shrug: an engine that cannot be engaged aborts,
+// and a check whose keys are not arriving is not driven.
+// ---------------------------------------------------------------------------
+
+/**
+ * Require the window's IME to be OPEN and in a native reading mode, opening
+ * it by its own toggle key when `IMEON`'s IMM32 request left it shut.
+ *
+ * The toggle is sent at most twice, and the second only after a re-read still
+ * says closed — it TOGGLES, so a blind pair would close whatever the first
+ * one opened. `state` is the reading `IMEON` already produced; every reading
+ * after that is taken fresh, because the whole point is that this IME does
+ * not do what it is told.
+ *
+ * Throws with the state in the message when the IME will not engage. That
+ * abort is the deliverable: the alternative is typing romaji into a closed
+ * IME and reporting eight INCONCLUSIVEs that look like an engine result.
+ */
+async function engageIme({ driver, hwnd, engine, keyDelayMs, state }) {
+  let ime = state;
+  for (let attempt = 1; ime.open !== 1 && attempt <= 2; attempt += 1) {
+    console.log(`> IME reports open=${ime.open}; sending ${IME_TOGGLE_KEY} ` +
+      `(半角/全角) through SendInput — attempt ${attempt} of 2`);
+    await driver.require('KEYS', hwnd, IME_TOGGLE_KEY, keyDelayMs);
+    await sleep(IME_SETTLE_MS);
+    ime = await driver.require('IMESTATE', hwnd);
+    console.log(`> IME after toggle: ${JSON.stringify(ime)}`);
+  }
+  if (ime.open !== 1) {
+    throw new Error(
+      `the ${engine} window's IME WILL NOT OPEN. Its input locale is ` +
+      `${ime.langid} (japanese=${ime.japanese}) and it holds the foreground ` +
+      `(isForeground=${ime.isForeground}), but IMC_GETOPENSTATUS still reads ` +
+      `open=${ime.open} after IMEON and two ${IME_TOGGLE_KEY} (半角/全角) ` +
+      'keystrokes. A closed IME turns the romaji below into seven plain ' +
+      'ASCII letters and every check into an INCONCLUSIVE about this rig, ' +
+      'which is what the run of 2026-08-12 produced. Nothing was typed for ' +
+      'this engine. Open the IME for that window by hand — click into the ' +
+      'page and press 半角/全角, or pick ひらがな in the language bar — and ' +
+      're-run.');
+  }
+  if (!ime.native) {
+    console.log(`> IME is open but conversion=${ime.conversion} carries no ` +
+      'NATIVE bit; re-asserting Hiragana');
+    ime = await driver.require('IMECONV', hwnd);
+    console.log(`> IME after conversion re-assert: ${JSON.stringify(ime)}`);
+  }
+  if (!ime.native) {
+    throw new Error(
+      `the ${engine} window's IME is OPEN but NOT IN A NATIVE READING MODE: ` +
+      `IMC_GETCONVERSIONMODE reads ${ime.conversion}, which carries no ` +
+      'IME_CMODE_NATIVE bit, and an explicit Hiragana re-assert did not ' +
+      'change that. In alphanumeric mode the romaji below is typed straight ' +
+      'through and no composition starts, so the checks would measure ASCII. ' +
+      '(Firefox read conversion=0 on 2026-08-12.) Nothing was typed for this ' +
+      'engine. Set that window\'s IME to ひらがな by hand and re-run.');
+  }
+  return ime;
+}
+
+/**
+ * Prove keystrokes are ARRIVING at this page before a plan is driven.
+ *
+ * Three outcomes, and the middle one is the reason this exists:
+ *
+ *   `true`  — the driver sent it and the page saw it.
+ *   `false` — the driver sent it and the page saw NOTHING. Keys are not
+ *             arriving; the check is not driven and says so in its own
+ *             words, rather than reporting the IME's excuse for a fault
+ *             that has nothing to do with the IME.
+ *   `null`  — the driver REFUSED to send it, unarmed. That is the rehearsal,
+ *             and it is a constructional fact reported by the driver rather
+ *             than an assertion this function talked itself into; an armed
+ *             run cannot reach it, and treats it as an error if it does.
+ *
+ * The observer is reset before the probe and the check resets it again, so
+ * the probe's own keydown is never in evidence any verdict reads.
+ */
+async function probeDelivery({ page, driver, hwnd, keyDelayMs, inject }) {
+  const observing = await W.resetEvents(page);
+  if (!observing) {
+    // Neither a delivery fault nor an IME one: there is nothing on the page
+    // to read arrival WITH. Conflating it with "no keys arrived" is the exact
+    // mistake this probe was added to stop making.
+    throw new Error('the page observer is not installed, so key arrival ' +
+      'cannot be read; no delivery claim is possible for this check');
+  }
+  const r = await driver.send('KEYS', hwnd, PROBE_KEY, keyDelayMs);
+  if (r.status === 'REFUSED') {
+    if (inject) {
+      throw new Error('the delivery probe was REFUSED by a driver this run ' +
+        `started ARMED: ${JSON.stringify(r.payload)}`);
+    }
+    return { delivered: null, detail: 'REFUSED by the unarmed driver (rehearsal)' };
+  }
+  if (r.status !== 'OK') {
+    return { delivered: false, detail: `the driver could not send it: ${JSON.stringify(r.payload)}` };
+  }
+  await sleep(PROBE_SETTLE_MS);
+  const keydowns = (await W.readEvents(page)).filter((e) => e.type === 'keydown').length;
+  return {
+    delivered: keydowns > 0,
+    detail: `driver sent ${r.payload.sent}, page saw ${keydowns} keydown(s)`,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // One engine
 // ---------------------------------------------------------------------------
 
@@ -840,6 +990,14 @@ async function driveEngine(engine, baseUrl, driver, args) {
           'install the Japanese IME first — Settings > Time & Language > ' +
           'Language & region > Add a language > 日本語.');
       }
+      // The locale switching is not the same thing as the IME opening, and
+      // 2026-08-12 is the run that proved it: 0x0411 on all three engines,
+      // shut on all three.
+      imeState = await engageIme({
+        driver, hwnd, engine, keyDelayMs: args.keyDelayMs, state: imeState,
+      });
+      console.log(`> IME ENGAGED: open=${imeState.open} ` +
+        `conversion=${imeState.conversion} native=${imeState.native}`);
     } else {
       imeState = await driver.require('IMESTATE', hwnd);
       console.log(`> IME (read-only, rehearsal): ${JSON.stringify(imeState)}`);
@@ -863,7 +1021,24 @@ async function driveEngine(engine, baseUrl, driver, args) {
       const label = `check ${check.n} — ${check.title}`;
       let out;
       try {
-        out = await RUNNERS[check.id]({ page, keys, reload, pageErrors, engine });
+        const probe = await probeDelivery({
+          page, driver, hwnd, keyDelayMs: args.keyDelayMs, inject,
+        });
+        console.log(`> probe ${PROBE_KEY}: ${probe.detail}`);
+        if (probe.delivered === false) {
+          out = {
+            verdict: W.INCONCLUSIVE,
+            why: `KEYS ARE NOT ARRIVING at the ${engine} window: a single ` +
+              `${PROBE_KEY} sent immediately before this check reached the ` +
+              `page as no keydown at all (${probe.detail}). The plan was NOT ` +
+              'driven. This says nothing about the IME and nothing about the ' +
+              'engine — it is a transport failure between SendInput and the ' +
+              'page, and it is a rig result, not a runtime result.',
+            readback: `probe=${PROBE_KEY} ${probe.detail}`,
+          };
+        } else {
+          out = await RUNNERS[check.id]({ page, keys, reload, pageErrors, engine });
+        }
       } catch (err) {
         out = { verdict: W.INCONCLUSIVE, why: `the check could not be driven: ${err.message}` };
       }
@@ -1044,7 +1219,11 @@ async function main() {
   }
 }
 
-module.exports = { runMutationTeeth, parseArgs, worst, RUNNERS };
+// `engageIme` and `probeDelivery` are exported for the same reason `worst`
+// and `RUNNERS` are: they take their driver and their page as arguments, so
+// their REFUSALS can be forced and read back without an interactive desktop —
+// which is the only place the armed run they guard can ever happen.
+module.exports = { runMutationTeeth, parseArgs, worst, RUNNERS, engageIme, probeDelivery };
 
 if (require.main === module) {
   main().then((code) => process.exit(code)).catch((error) => {


### PR DESCRIPTION
The operator's armed run of 2026-08-12 got further than any before it and still
decided nothing — 24 INCONCLUSIVE across three engines. Foreground seizure
worked (`isForeground: true` everywhere) and key delivery was proven (romaji and
ESC both arrived). One thing had not happened: **the IME never opened**.
`IMESTATE` read `langid 0x0411`, `japanese: true`, `open: 0` on all three.

**This PR does not close `rf2-hic-016`.** No disposition cell was recorded; the
close rule is unchanged (recorded Firefox and WebKit results in
`dispositions.md` §2.3), and the bead stays open.

## What the driver already knew about itself

`windows-ime-driver.ps1`'s own header, "What it does NOT do", predicted this
before the run happened:

> `IMEON` is a REQUEST, not a guarantee: the modern Microsoft IME is a TSF text
> service, and the IMM32 messages below reach it through a compatibility layer
> that a given browser build may not honour.

It was right, and the header now records that it was, along with the door that
turned out to be open.

## 1. Open the IME through the path that works

`SendInput` reached that IME when IMM32 did not — it is what delivered the run's
romaji and its ESC. So a closed IME is now opened by sending **its own toggle
key**, `kanji` (半角/全角, VK 0x19), through `KEYS`. The token was already in the
driver's vocabulary and deliberately unused; it is no longer decorative.

Nothing about the toggle is trusted either:

- `IMESTATE` is re-read after it, and **`open: 1` is REQUIRED before any plan is
  driven**.
- **One retry**, and only after a re-read still says closed — the key *toggles*,
  so a blind pair would shut whatever the first one opened.
- Still closed after two? The engine **aborts, naming its state**. It does not
  proceed and it does not degrade to ASCII.
- The reading mode is required with it. Firefox read `conversion: 0`, so
  `IMECONV` (new, armed) re-asserts `IMC_SETCONVERSIONMODE` Hiragana and the
  **NATIVE bit** is re-read; without it romaji is typed straight through and no
  composition starts.

`IMESTATE` gained a `native` flag, computed as a predicate over the very
`conversion` number printed beside it. The sign is tested first, because
`ImeQuery` answers `-1` when there is no IME window to ask and `-1 & 1` is `1` —
an unanswerable query must not read as a satisfied one.

**This branch's own rehearsal reproduces the operator's measurement**, read-only,
on all three engines:

```
chromium  japanese:true  open:0  conversion:25  native:true
firefox   japanese:true  open:0  conversion:0   native:false   <- the operator's Firefox reading
webkit    japanese:true  open:0  conversion:25  native:true
```

## 2. Per-check delivery preflight

WebKit received **zero** keystrokes for checks 5, 1, 2, 3 and the digits half of
4 (`settledIn=0`, the ESC uncounted) and then came alive. "The keys never
arrived" and "the IME was closed" both end in a field full of nothing, and no
line of that output told them apart.

`probeDelivery` now sends one `escape` and reads it back off the page before each
plan is driven. Escape because the run PROVED it reaches the page and, with no
field focused, it mutates nothing — no text, no caret, no focus. Its keydown is
read off the observer and then erased by the check's own `resetEvents`, so no
verdict ever sees it. Three outcomes, and the middle one is the point:

| probe | meaning | what happens |
|---|---|---|
| delivered | the driver sent it, the page saw it | the plan is driven |
| **not delivered** | the driver sent it, the page saw **nothing** | plan NOT driven; the check says **`KEYS ARE NOT ARRIVING`** in those words |
| REFUSED | unarmed driver — the rehearsal | reported as such; an **armed** run that somehow reaches it **throws** |

A missing page observer is neither of those and now says so, rather than being
misreported as "no keys arrived" — the exact conflation this probe exists to
remove.

## The trap: a dry run must not look like a pass

It does not. `--dry-run` still exits **0** with every check INCONCLUSIVE,
`complete: false`, all three cells **Not established**, and the *"rig result, not
a runtime result"* wording on all 24. The probe's REFUSED path is a
constructional fact reported by the unarmed driver, not an assertion the
preflight talked itself into.

## Both forced refusals

Forced at the seam where the real driver and the real page sit, because the armed
run they guard needs an interactive desktop. Harness lived outside the repo;
**both source files hash-identical before and after** (below).

**RED A — `open` forced to 0.** Two toggles sent, then abort:

```
the firefox window's IME WILL NOT OPEN. Its input locale is 0x0411
(japanese=true) and it holds the foreground (isForeground=true), but
IMC_GETOPENSTATUS still reads open=0 after IMEON and two kanji (半角/全角)
keystrokes. A closed IME turns the romaji below into seven plain ASCII letters
and every check into an INCONCLUSIVE about this rig, which is what the run of
2026-08-12 produced. Nothing was typed for this engine. Open the IME for that
window by hand — click into the page and press 半角/全角, or pick ひらがな in the
language bar — and re-run.
```

driver calls: `["KEYS 12345 kanji 80","IMESTATE 12345","KEYS 12345 kanji 80","IMESTATE 12345"]`

**RED A2 — open, but `conversion: 0`.** `IMECONV` sent, NATIVE bit still absent:

```
the firefox window's IME is OPEN but NOT IN A NATIVE READING MODE:
IMC_GETCONVERSIONMODE reads 0, which carries no IME_CMODE_NATIVE bit, and an
explicit Hiragana re-assert did not change that. In alphanumeric mode the romaji
below is typed straight through and no composition starts, so the checks would
measure ASCII. (Firefox read conversion=0 on 2026-08-12.) Nothing was typed for
this engine. Set that window's IME to ひらがな by hand and re-run.
```

**RED B — the driver sends, the page sees nothing.** Forced twice: as a unit
(`{"delivered":false,"detail":"driver sent 1, page saw 0 keydown(s)"}`) and
**end-to-end through a real `--dry-run`**, by temporarily making the rehearsal's
REFUSED count as a delivery failure. All 8 checks flipped to:

```
[ ] check 5 — Escape / abort mid-composition
      KEYS ARE NOT ARRIVING at the chromium window: a single escape sent
      immediately before this check reached the page as no keydown at all
      (FORCED RED — REFUSED treated as not delivered). The plan was NOT driven.
      This says nothing about the IME and nothing about the engine — it is a
      transport failure between SendInput and the page, and it is a rig result,
      not a runtime result.
      READBACK probe=escape FORCED RED — REFUSED treated as not delivered
```

`KEYS ARE NOT ARRIVING` × 8, `no composition ever started` × **0**. The two rig
failures are now completely disjoint in the output. The mutation was reverted and
the restore verified by **hashing the bytes**, not by `git diff`.

## Fences

- **No change to check semantics** — `implementation/hicasso/testbed/native-ime-witness.cjs` is untouched.
- **No change to verdict logic** — same file; `--self-test` still reports **39 teeth bit**, the count `#7948` left.
- **No change to the CI gate** — no workflow touched; this witness is not in one and cannot be.
- **Honest-abort conduct stays** — an engine that cannot be put in a valid state aborts and says so, by the same `throw` the existing `!japanese` refusal uses.

## Quality gates

Each run alone, nothing appended, exit code captured on one command line.

| Gate | Captured exit |
|---|---|
| `node scripts/run-hicasso-native-ime-witness.cjs --dry-run` (all three engines) | `DRYRUN_CLEAN_EXIT=0` |
| `node scripts/run-hicasso-native-ime-witness.cjs --self-test` (39 teeth) | `SELFTEST_EXIT=0` |
| `npm run lint:js` (ESLint — the JS surface this diff reaches) | `ESLINT_EXIT=0` |
| forced-refusal harness (RED A, A2, B + 4 negative cases) | `FORCED_EXIT=0` — all seven bit |
| forced end-to-end RED B `--dry-run --engines=chromium` | `DRYRUN_FORCED_REDB_EXIT=0` |
| `python scripts/check_fast_pr_gap.py --list` | `FASTPRGAP_EXIT=0` |
| driver protocol smoke (unarmed: `PING`/`LAYOUTS`/`RESOLVE`/`IMESTATE`/`IMECONV`) | replies as designed; `IMECONV` REFUSED unarmed |

Clean dry run: **24/24 INCONCLUSIVE**, 0 ticks, 0 crosses, 24 READBACK lines, 24
occurrences of the *"rig result, not a runtime result"* wording, 0 occurrences of
`KEYS ARE NOT ARRIVING`, `complete: false` on all three engines.

Restore verified by hash — identical before the forced run and after:

```
4242a4420a4aef370e6f0f922f651aef9f4c9c6c1f1d789a8f7f4aed55d57ea8  implementation/scripts/lib/windows-ime-driver.ps1
db314c76a965fbfd0a2ff0efae64beb54d7545710923d02595501a63a14d8e48  implementation/scripts/run-hicasso-native-ime-witness.cjs
```

**What the spine does not decide** (97 required checks, per `check_fast_pr_gap.py
--list`): the whole `All required checks passed` matrix, `Lint required` and
`Docs required`. For this diff the live ones are ESLint (run here, green) — the
CLJS/JVM/browser matrix is surface-gated and this diff does not reach it, and the
witness itself appears in no required job.

## Not done, deliberately

`docs/design/hicasso/native-ime-scripted-witness.md` §6 ("The IME is requested,
then verified — never assumed") still describes only the *locale* verification.
It is not wrong, just narrower than the code now is. Left alone: the brief fenced
this to the driver and the orchestrator, and hicasso design docs have live
worktrees on them.
