### PR TITLE
test(pair-mcp): a suite's cleanup must not outlive its own test (rf2-53uz)

### DIFF
--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_cache_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_cache_test.cljs
@@ -446,10 +446,12 @@
 
 (deftest resolve-build-rejects-with-candidates-when-no-target-and-many-run
   (async done
-    ;; NB restore `probe/running-builds` INLINE before calling `done` —
-    ;; a `.finally`-scoped restore fires AFTER `done` advances to the next
+    ;; NB restore `probe/running-builds` INLINE before calling `done` — a
+    ;; `.finally`-scoped restore fires AFTER `done` advances to the next
     ;; test and would leak the multi-build stub into a neighbour (the
-    ;; cross-test stub race the orient/invoke suites document).
+    ;; cross-test stub race the orient/invoke suites document). Both arms
+    ;; restored identically, so the restore now sits in the single trailing
+    ;; step, still ahead of the `done` in that same step.
     (let [orig probe/running-builds
           restore! (fn [] (set! probe/running-builds orig))
           conn (fresh-conn)]
@@ -457,20 +459,19 @@
       ;; (explicit? false). Two builds run → ambiguous.
       (set! probe/running-builds
             (fn [_] (js/Promise.resolve [:examples/step-deck :testbeds/panel-gallery])))
+      ;; The rejection arm IS this row's success path, so both handlers are
+      ;; siblings of one two-arg `.then`, with one trailing `done`.
       (-> (probe/resolve-build! conn :app false)
           (.then (fn [_]
-                   (restore!)
-                   (is false "must reject on an ambiguous target")
-                   (done)))
-          (.catch (fn [err]
-                    (restore!)
-                    (let [data (ex-data err)]
-                      (is (= :no-runtime-for-build (:reason data))
-                          "structured reason, not a host failure")
-                      (is (= [:examples/step-deck :testbeds/panel-gallery]
-                             (:running-builds data))
-                          "the error lists the candidate builds"))
-                    (done)))))))
+                   (is false "must reject on an ambiguous target"))
+                 (fn [err]
+                   (let [data (ex-data err)]
+                     (is (= :no-runtime-for-build (:reason data))
+                         "structured reason, not a host failure")
+                     (is (= [:examples/step-deck :testbeds/panel-gallery]
+                            (:running-builds data))
+                         "the error lists the candidate builds"))))
+          (.then (fn [_] (restore!) (done)))))))
 
 (deftest resolve-build-honours-cached-session-target-over-ambiguity
   ;; A session-sticky target (set by a prior discover-app) is treated as
@@ -489,9 +490,9 @@
         (-> (probe/resolve-build! conn bid explicit?)
             (.then (fn [resolved]
                      (is (= :examples/step-deck resolved)
-                         "the sticky session target wins — no ambiguous-target error")
-                     (done)))
-            (.catch (fn [_] (is false "must not reject when a session target is cached") (done))))))))
+                         "the sticky session target wins — no ambiguous-target error")))
+            (.catch (fn [_] (is false "must not reject when a session target is cached") nil))
+            (.then (fn [_] (done))))))))
 
 (deftest auto-select-single-build-returns-pair
   ;; Unit-pin the probe helper directly: exactly-one → [build true];

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cljs_eval_value_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cljs_eval_value_test.cljs
@@ -135,17 +135,20 @@
     (-> (with-stubbed-cljs-eval!
           {:ex "class clojure.lang.ExceptionInfo" :err "Unable to resolve symbol: foo"}
           (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "foo")))
+        ;; The rejection arm IS this row's success path, so the two handlers are
+        ;; SIBLINGS of one two-arg `.then` and the single `done` trails them. A
+        ;; `.catch` after a `done` would claim a LATER namespace's throw as this
+        ;; row's failure and fire `done` a second time (rf2-53uz).
         (.then (fn [_]
-                 (is false "an :ex response MUST reject, not resolve")
-                 (done)))
-        (.catch (fn [err]
-                  (is (instance? js/Error err))
-                  (let [m (.-message err)]
-                    (is (re-find #"nREPL eval error" m) "structured eval-error prefix")
-                    (is (re-find #"ExceptionInfo" m) ":ex text carried into the message")
-                    (is (re-find #"Unable to resolve symbol" m)
-                        ":err detail appended when present"))
-                  (done))))))
+                 (is false "an :ex response MUST reject, not resolve"))
+               (fn [err]
+                 (is (instance? js/Error err))
+                 (let [m (.-message err)]
+                   (is (re-find #"nREPL eval error" m) "structured eval-error prefix")
+                   (is (re-find #"ExceptionInfo" m) ":ex text carried into the message")
+                   (is (re-find #"Unable to resolve symbol" m)
+                       ":err detail appended when present"))))
+        (.then (fn [_] (done))))))
 
 (deftest ex-without-err-still-rejects
   ;; :ex present but :err blank — the message omits the " — <err>" suffix
@@ -154,13 +157,12 @@
     (-> (with-stubbed-cljs-eval! {:ex "boom" :err ""}
           (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "form")))
         (.then (fn [_]
-                 (is false "an :ex response MUST reject even with blank :err")
-                 (done)))
-        (.catch (fn [err]
-                  (let [m (.-message err)]
-                    (is (re-find #"nREPL eval error: boom" m))
-                    (is (not (re-find #" — " m)) "no err-suffix when :err is blank"))
-                  (done))))))
+                 (is false "an :ex response MUST reject even with blank :err"))
+               (fn [err]
+                 (let [m (.-message err)]
+                   (is (re-find #"nREPL eval error: boom" m))
+                   (is (not (re-find #" — " m)) "no err-suffix when :err is blank"))))
+        (.then (fn [_] (done))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Inner :err map → reject. When the OUTER EDN parses to a map carrying
@@ -176,17 +178,16 @@
           {:value "{:err \"Cannot infer target type\"}"}
           (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "form")))
         (.then (fn [_]
-                 (is false "an outer map with :err MUST reject")
-                 (done)))
-        (.catch (fn [err]
-                  (is (re-find #"cljs eval compile error/warning: Cannot infer target type"
-                               (.-message err))
-                      "inner :err surfaced as a distinct cljs-eval compile-error message")
-                  (is (= :rf.error/eval-cljs-compile-error (:reason (ex-data err)))
-                      "rejection carries the structured compile-error reason")
-                  (is (= "Cannot infer target type" (:err (ex-data err)))
-                      ":err text rides on the ex-data verbatim")
-                  (done))))))
+                 (is false "an outer map with :err MUST reject"))
+               (fn [err]
+                 (is (re-find #"cljs eval compile error/warning: Cannot infer target type"
+                              (.-message err))
+                     "inner :err surfaced as a distinct cljs-eval compile-error message")
+                 (is (= :rf.error/eval-cljs-compile-error (:reason (ex-data err)))
+                     "rejection carries the structured compile-error reason")
+                 (is (= "Cannot infer target type" (:err (ex-data err)))
+                     ":err text rides on the ex-data verbatim")))
+        (.then (fn [_] (done))))))
 
 ;; ---------------------------------------------------------------------------
 ;; An UNRESOLVED SYMBOL is the headline case. shadow emits an
@@ -208,20 +209,19 @@
           (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "re-frame.core/frame-db")))
         (.then (fn [v]
                  (is false (str "an unresolved symbol MUST reject, never resolve "
-                                "(got " (pr-str v) ", the silent-nil bug)"))
-                 (done)))
-        (.catch (fn [err]
-                  (is (instance? js/Error err))
-                  (is (re-find #"Use of undeclared Var re-frame.core/frame-db"
-                               (.-message err))
-                      "the analyzer warning text is carried into the rejection")
-                  (let [data (ex-data err)]
-                    (is (= :rf.error/eval-cljs-compile-error (:reason data))
-                        "structured compile-error reason")
-                    (is (re-find #"undeclared Var" (:err data))
-                        ":err text rides on the ex-data")
-                    (is (string? (:hint data)) "a corrective hint is offered"))
-                  (done))))))
+                                "(got " (pr-str v) ", the silent-nil bug)")))
+               (fn [err]
+                 (is (instance? js/Error err))
+                 (is (re-find #"Use of undeclared Var re-frame.core/frame-db"
+                              (.-message err))
+                     "the analyzer warning text is carried into the rejection")
+                 (let [data (ex-data err)]
+                   (is (= :rf.error/eval-cljs-compile-error (:reason data))
+                       "structured compile-error reason")
+                   (is (re-find #"undeclared Var" (:err data))
+                       ":err text rides on the ex-data")
+                   (is (string? (:hint data)) "a corrective hint is offered"))))
+        (.then (fn [_] (done))))))
 
 (deftest clean-results-with-blank-err-still-resolves-value
   ;; A clean eval leaves :err blank ("") — the :err branch must NOT fire
@@ -328,8 +328,7 @@
           {:ex "thrown" :err "detail" :value "{:results [\"42\"] :ns user}"}
           (fn [] (nrepl/cljs-eval-value (fresh-conn) :app "form")))
         (.then (fn [_]
-                 (is false ":ex must win over a present :value")
-                 (done)))
-        (.catch (fn [err]
-                  (is (re-find #"nREPL eval error: thrown" (.-message err)))
-                  (done))))))
+                 (is false ":ex must win over a present :value"))
+               (fn [err]
+                 (is (re-find #"nREPL eval error: thrown" (.-message err)))))
+        (.then (fn [_] (done))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/closed_world_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/closed_world_test.cljs
@@ -78,9 +78,9 @@
                    (is (false? (:discovered? snap))
                        "discovery was NOT run — dispatched before ensure-connection!")
                    (is (nil? (:discovery-error snap))
-                       "no discovery attempt recorded — connection step never reached"))
-                 (done)))
-        (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) (done))))))
+                       "no discovery attempt recorded — connection step never reached"))))
+        (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) nil))
+        (.then (fn [_] (done))))))
 
 (deftest stream-controls-answered-before-connection
   (async done
@@ -98,6 +98,6 @@
                  (let [snap (server/session-state-snapshot)]
                    (is (false? (:discovered? snap))
                        "discovery was NOT run — dispatched before ensure-connection!")
-                   (is (nil? (:discovery-error snap))))
-                 (done)))
-        (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) (done))))))
+                   (is (nil? (:discovery-error snap))))))
+        (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) nil))
+        (.then (fn [_] (done))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/ensure_connection_retry_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/ensure_connection_retry_test.cljs
@@ -36,11 +36,13 @@
                   (do (server/mark-discovered-for-tests! conn)
                       (js/Promise.resolve :ok)))))]
         ;; First tool call: discovery fails. `:discovery-error` recorded.
+        ;; The rejection arm IS this row's success path, so both handlers are
+        ;; siblings of one two-arg `.then`; the retry chain is RETURNED into it,
+        ;; and the single `done` sits in the trailing step with nothing after it.
         (-> (server/ensure-connection! {} discover-fn)
-            (.then (fn [_]
-                     (is false "first call must REJECT (discovery failed)")
-                     (done)))
-            (.catch
+            (.then
+             (fn [_]
+               (is false "first call must REJECT (discovery failed)"))
              (fn [e1]
                (is (= err e1) "first failure surfaces the structured discovery error")
                (is (some? (:discovery-error (server/session-state-snapshot)))
@@ -57,11 +59,11 @@
                             (is (= conn resolved-conn)
                                 "the retry resolves to the freshly-discovered conn")
                             (is (true? (:discovered? (server/session-state-snapshot)))
-                                "the session is now attached")
-                            (done)))
+                                "the session is now attached")))
                    (.catch (fn [_e2]
                              (is false "the retry must SUCCEED once discovery recovers")
-                             (done)))))))))))
+                             nil)))))
+            (.then (fn [_] (done))))))))
 
 (deftest repeated-failures-keep-resurfacing-fresh-errors
   (testing "while discovery keeps failing, each call re-runs it and surfaces a fresh rejection (no permanent wedge)"

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/ensure_connection_single_flight_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/ensure_connection_single_flight_test.cljs
@@ -61,9 +61,9 @@
                      (is (identical? conn (aget rs 1)) "caller 2 got the SAME conn")
                      (is (true? (:discovered? (server/session-state-snapshot))))
                      (is (nil? (:transition (server/session-state-snapshot)))
-                         "the transition slot is cleared after settle")
-                     (done)))
-            (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) (done))))))))
+                         "the transition slot is cleared after settle")))
+            (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest concurrent-port-change-calls-replace-endpoint-exactly-once
   (testing "two simultaneous cached-port-change calls close the old conn ONCE and publish ONE replacement"
@@ -91,10 +91,12 @@
                        (is (= 7002 (:port (server/session-state-snapshot)))
                            "session records the new port")
                        (is (nil? (:transition (server/session-state-snapshot)))
-                           "the transition slot is cleared after settle")
-                       (restore!) (done)))
-              (.catch (fn [e] (restore!)
-                        (is false (str "unexpected reject: " (.-message e))) (done)))))))))
+                           "the transition slot is cleared after settle")))
+              (.catch (fn [e]
+                        (is false (str "unexpected reject: " (.-message e))) nil))
+              ;; `restore!` is the same idempotent `set!` on both arms, so it
+              ;; moves to the single trailing step, still ahead of `done`.
+              (.then (fn [_] (restore!) (done)))))))))
 
 (deftest concurrent-failed-discovery-rejects-all-then-retries
   (testing "a shared discovery failure rejects every waiter, clears the slot, and a later call retries successfully"
@@ -123,16 +125,19 @@
                                    (swap! calls inc)
                                    (server/mark-discovered-for-tests! conn)
                                    (js/Promise.resolve :ok))]
+                       ;; RETURNED into the outer chain, so the retry is awaited
+                       ;; by the single trailing `done` instead of finishing the
+                       ;; row itself while two `.catch`es are still downstream.
                        (-> (server/ensure-connection! {} ok-fn)
                            (.then (fn [c]
                                     (is (= 2 @calls) "discovery RE-RAN on the retry")
                                     (is (identical? conn c) "the retry resolved to the fresh conn")
-                                    (is (true? (:discovered? (server/session-state-snapshot))))
-                                    (done)))
+                                    (is (true? (:discovered? (server/session-state-snapshot))))))
                            (.catch (fn [e2]
                                      (is false (str "retry must succeed: " (.-message e2)))
-                                     (done)))))))
-            (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) (done))))))))
+                                     nil))))))
+            (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest fast-path-needs-no-transition
   (testing "when the cached port-file still reads the same port, ensure-connection! returns the cached conn with no transition"
@@ -146,7 +151,7 @@
             (.then (fn [resolved]
                      (is (identical? conn resolved) "the cached conn is reused")
                      (is (nil? (:transition (server/session-state-snapshot)))
-                         "the fast path never opened a transition")
-                     (restore!) (done)))
-            (.catch (fn [e] (restore!)
-                      (is false (str "fast path must not reject: " (.-message e))) (done))))))))
+                         "the fast path never opened a transition")))
+            (.catch (fn [e]
+                      (is false (str "fast path must not reject: " (.-message e))) nil))
+            (.then (fn [_] (restore!) (done))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/handler_meta_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/handler_meta_test.cljs
@@ -283,9 +283,9 @@
                                (is (= 1140207590 (:handler-fn-hash edn))
                                    "handler-fn-hash is the wire-friendly substitute for :handler-fn")
                                (is (not (contains? edn :value))
-                                   "the bug shape stuffed the map under :value as a string — must not recur"))
-                             (done))))))
-            (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
+                                   "the bug shape stuffed the map under :value as a string — must not recur")))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest handler-meta-unserializable-surfaces-structured
   (testing "rf2-qobqy: a runtime meta map that can't round-trip as EDN now rides back as a tagged :unserializable envelope — NOT a meta map smuggled as a STRING"
@@ -311,9 +311,9 @@
                                (is (= :event (:kind edn)) "kind stamped on the error")
                                (is (= :counter/inc (:id edn)) "id stamped on the error")
                                (is (str/includes? (:preview edn) "#object")
-                                   "the preview shows WHAT couldn't serialize"))
-                             (done))))))
-            (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
+                                   "the preview shows WHAT couldn't serialize")))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest handler-meta-not-registered-passes-through
   (testing "the runtime's :not-registered envelope still passes through unchanged"
@@ -325,9 +325,9 @@
                     (.then (fn [result]
                              (let [edn (extract-edn result)]
                                (is (false? (:ok? edn)))
-                               (is (= :not-registered (:reason edn))))
-                             (done))))))
-            (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
+                               (is (= :not-registered (:reason edn)))))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest handler-meta-genuinely-unparseable-still-fails
   (testing "a non-map non-recoverable value still surfaces :unexpected-shape"
@@ -354,9 +354,9 @@
                              (is (false? (:ok? edn)))
                              (is (= :unexpected-shape (:reason edn)))
                              (is (= 42 (:value edn))
-                                 "the offending value rides on :value for forensics"))
-                           (done))))))
-          (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done)))))))
+                                 "the offending value rides on :value for forensics")))))))
+          (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+          (.then (fn [_] (done)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Eval-form capture helper — used by the frame-targeting tests below to assert
@@ -396,9 +396,9 @@
                                (is (str/includes? @form "registrar-describe")
                                    "default path still uses the runtime registrar-describe fn")
                                (is (not (contains? edn :frame))
-                                   "default response carries NO :frame key (byte-identical)"))
-                             (done))))))
-            (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
+                                   "default response carries NO :frame key (byte-identical)")))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest list-handlers-default-form-is-byte-identical
   (testing "list-handlers with no :frame ⇒ runtime registrar-list (unchanged), no :frame key"
@@ -410,9 +410,9 @@
                     (.then (fn [result]
                              (let [edn (extract-edn result)]
                                (is (str/includes? @form "registrar-list"))
-                               (is (not (contains? edn :frame))))
-                             (done))))))
-            (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
+                               (is (not (contains? edn :frame)))))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; EP-0016 resource kinds — happy-path EXECUTION coverage.
@@ -455,9 +455,9 @@
                            (is (= expect-i (:id edn))
                                "the requested id rides back stamped")
                            (is (= 'app.articles (:ns edn))
-                               "registrar metadata surfaces (routed through registrar-describe)"))
-                         (done))))))
-        (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))
+                               "registrar metadata surfaces (routed through registrar-describe)")))))))
+        (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+        (.then (fn [_] (done))))))
 
 (deftest handler-meta-accepts-resource-kind
   (testing "handler-meta accepts kind \"resource\" and stamps kind+id"
@@ -489,9 +489,9 @@
                          (is (not (str/includes? @form "machine-meta"))
                              (str kind-str " is NOT mis-routed through the machine wrapper"))
                          (is (str/includes? @form kw-str)
-                             (str "the form carries the " kw-str " kind keyword"))
-                         (done))))))
-        (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))
+                             (str "the form carries the " kw-str " kind keyword")))))))
+        (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+        (.then (fn [_] (done))))))
 
 (deftest handler-meta-resource-routes-through-registrar
   (testing "kind \"resource\" emits a registrar-describe form, never machine-meta"
@@ -526,9 +526,9 @@
                                (is (= {:username [:db [:auth :user :username]]} (:inputs edn))
                                    "the resolver's declared :inputs ride through")
                                (is (false? (:whole-db? edn))
-                                   "the whole-db cost flag rides through"))
-                             (done))))))
-            (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
+                                   "the whole-db cost flag rides through")))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
 
 (defn- list-handlers-accepts-kind-test
   "Run list-handlers for `kind-str` with a canned id vector `ids`,
@@ -549,9 +549,9 @@
                          (is (= ids (:ids edn))
                              "the runtime id vector rides through")
                          (is (= (count ids) (:count edn))
-                             "count matches the id vector"))
-                       (done))))))
-      (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done)))))
+                             "count matches the id vector")))))))
+      (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+      (.then (fn [_] (done)))))
 
 (deftest list-handlers-accepts-resource-kind
   (testing "list-handlers accepts \"resource\", stamps the kind, returns ids + count"
@@ -582,9 +582,9 @@
                          (is (not (str/includes? @form "re-frame.core/machines"))
                              (str kind-str " is NOT mis-routed through the machines enumerator"))
                          (is (str/includes? @form kw-str)
-                             (str "the form carries the " kw-str " kind keyword"))
-                         (done))))))
-        (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))
+                             (str "the form carries the " kw-str " kind keyword")))))))
+        (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+        (.then (fn [_] (done))))))
 
 (deftest list-handlers-resource-routes-through-registrar-list
   (testing "kind \"resource\" emits a registrar-list form, never the machines enumerator"
@@ -634,9 +634,9 @@
                                    "the resolved frame is stamped on the response")
                                (is (= {:source :registered :ns "blue.core"}
                                       (:rf.image/coordinate edn))
-                                   "the provenance coordinate rides through"))
-                             (done))))))
-            (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
+                                   "the provenance coordinate rides through")))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest handler-meta-default-path-has-no-frame
   (testing "no :frame ⇒ the default registrar-describe path, no :frame key on the response"
@@ -650,9 +650,9 @@
                              (let [edn (extract-edn result)]
                                (is (not (str/includes? @form "frame-registrar-describe")))
                                (is (not (contains? edn :frame))
-                                   "default-path response carries NO :frame key (byte-identical)"))
-                             (done))))))
-            (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
+                                   "default-path response carries NO :frame key (byte-identical)")))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest handler-meta-rejects-frame-with-machine
   (testing ":frame + kind=machine ⇒ structured :frame-unsupported-for-machine"
@@ -681,9 +681,9 @@
                                (is (str/includes? @form ":blue/main"))
                                (is (true? (:ok? edn)))
                                (is (= :blue/main (:frame edn))
-                                   "the resolved frame is stamped on the response"))
-                             (done))))))
-            (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
+                                   "the resolved frame is stamped on the response")))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest list-handlers-rejects-frame-with-machine
   (testing "list-handlers :frame + kind=machine ⇒ :frame-unsupported-for-machine"

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/instructions_budget_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/instructions_budget_test.cljs
@@ -227,11 +227,11 @@
                    (when (pos? (or hint 0))
                      (is (<= (js/Math.abs (- hint tokens))
                              (* hint-tolerance-fraction tokens))
-                         (hint-drift-message hint tokens))))
-                 (done)))
+                         (hint-drift-message hint tokens))))))
         (.catch (fn [e]
                   (is false (str tool-name " handler rejected: " (.-message e)))
-                  (done))))))
+                  nil))
+        (.then (fn [_] (done))))))
 
 (deftest instructions-response-fits-the-wire-token-budget
   (async done
@@ -265,8 +265,8 @@
                    ;; softer of the two failures.
                    (let [reserve (js/Math.floor (* authoring-reserve-fraction budget))]
                      (is (<= tokens reserve)
-                         (over-reserve-message tokens budget reserve))))
-                 (done)))
+                         (over-reserve-message tokens budget reserve))))))
         (.catch (fn [e]
                   (is false (str tool-name " handler rejected: " (.-message e)))
-                  (done))))))
+                  nil))
+        (.then (fn [_] (done))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
@@ -463,18 +463,19 @@
           ;; Synchronously — before the .then microtask writes — drop the
           ;; socket exactly as a racing close! would.
           (swap! conn assoc :socket nil)
+          ;; The rejection arm IS this row's success path, so both handlers are
+          ;; siblings of one two-arg `.then` and the single `done` trails them.
           (-> p
               (.then (fn [_]
-                       (is false "send-op! must REJECT when the socket is nil at write time")
-                       (done)))
-              (.catch (fn [err]
-                        (is (= "nREPL socket dropped before write — retry to reconnect"
-                               (.-message err))
-                            "structured retry-to-reconnect message, not the native NPE")
-                        (is (zero? @writes) "no write attempted against a nil socket")
-                        (is (= {} (:pending @conn))
-                            "the just-registered id is dissoc'd — no pending leak")
-                        (done)))))))))
+                       (is false "send-op! must REJECT when the socket is nil at write time"))
+                     (fn [err]
+                       (is (= "nREPL socket dropped before write — retry to reconnect"
+                              (.-message err))
+                           "structured retry-to-reconnect message, not the native NPE")
+                       (is (zero? @writes) "no write attempted against a nil socket")
+                       (is (= {} (:pending @conn))
+                           "the just-registered id is dissoc'd — no pending leak")))
+              (.then (fn [_] (done)))))))))
 
 (deftest send-op!-live-socket-writes-normally
   (testing "with a live socket present at write time, send-op! writes the encoded op"
@@ -1020,10 +1021,12 @@
               (is (= {:step-deck :examples/step-deck} (:build-alias @conn))
                   "the forgiving-resolution alias survives the reopen too")
               (is (= #{:examples/step-deck} (:probed-builds @conn))
-                  "the probe cache survives — the runtime marker outlives a socket hiccup")
-              (restore!)
-              (done)))
-          (.catch (fn [e] (restore!) (is false (str "unexpected reject: " (.-message e))) (done)))))))
+                  "the probe cache survives — the runtime marker outlives a socket hiccup")))
+          (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) nil))
+          ;; `restore!` is the same idempotent `set!` on both arms, so it moves
+          ;; to the single trailing step: written once, still run once per path,
+          ;; and still INSIDE the step that calls `done` rather than after it.
+          (.then (fn [_] (restore!) (done)))))))
 
 (deftest connect!-reopen-resets-framing-buffer-but-keeps-caches
   ;; The reopen still does its transport job: a stale partial frame left in
@@ -1046,10 +1049,9 @@
               (is (zero? (.-length (:buf @conn)))
                   "the framing buffer is reset on reopen (fresh socket, fresh stream)")
               (is (= :examples/step-deck (:resolved-build-id @conn))
-                  "the build-id cache is preserved alongside the buffer reset")
-              (restore!)
-              (done)))
-          (.catch (fn [e] (restore!) (is false (str "unexpected reject: " (.-message e))) (done)))))))
+                  "the build-id cache is preserved alongside the buffer reset")))
+          (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) nil))
+          (.then (fn [_] (restore!) (done)))))))
 
 (deftest connect!-fast-path-leaves-caches-untouched
   ;; When the socket is already open + healthy, `connect!` short-circuits
@@ -1108,10 +1110,9 @@
           (.then
             (fn [_]
               (is (nil? (:resolved-build-id @conn))
-                  "post-close reopen carries NO stale build — l9ixp preserved")
-              (restore!)
-              (done)))
-          (.catch (fn [e] (restore!) (is false (str "unexpected reject: " (.-message e))) (done)))))))
+                  "post-close reopen carries NO stale build — l9ixp preserved")))
+          (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) nil))
+          (.then (fn [_] (restore!) (done)))))))
 
 (deftest fresh-conn-for-new-port-starts-with-empty-caches
   ;; The port-change path (the common shape of a different-build restart):
@@ -1206,9 +1207,9 @@
                    (is (identical? conn (aget results 1)) "caller 2 resolved to the SAME conn")
                    (is (some? (:socket @conn)) "exactly one socket published")
                    (is (false? (:closed? @conn)) "the conn is live")
-                   (is (nil? (:connecting @conn)) "the in-flight slot is cleared on publish")
-                   (restore!) (done)))
-          (.catch (fn [e] (restore!) (is false (str "unexpected reject: " (.-message e))) (done)))))))
+                   (is (nil? (:connecting @conn)) "the in-flight slot is cleared on publish")))
+          (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) nil))
+          (.then (fn [_] (restore!) (done)))))))
 
 (deftest concurrent-send-ops-multiplex-over-one-socket
   ;; Two simultaneous `send-op!` calls share one connect, then register
@@ -1239,9 +1240,9 @@
                    (js/Promise.all #js [p1 p2])))
           (.then (fn [^js rs]
                    (is (= 2 (.-length rs)) "both ops resolved")
-                   (is (= {} (:pending @conn)) "pending drained on resolution")
-                   (restore!) (done)))
-          (.catch (fn [e] (restore!) (is false (str "unexpected reject: " (.-message e))) (done)))))))
+                   (is (= {} (:pending @conn)) "pending drained on resolution")))
+          (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) nil))
+          (.then (fn [_] (restore!) (done)))))))
 
 (deftest superseded-socket-callbacks-cannot-mutate-current-generation
   ;; A losing/stale socket's data/error/close must be inert once a newer
@@ -1275,9 +1276,9 @@
                      (is (zero? (.-length (:buf @conn)))
                          "a stale gen1 data chunk never enters the live framing buffer")
                      (is (identical? gen2-sock (:socket @conn))
-                         "the live socket is untouched by stale callbacks"))
-                   (restore!) (done)))
-          (.catch (fn [e] (restore!) (is false (str "unexpected reject: " (.-message e))) (done)))))))
+                         "the live socket is untouched by stale callbacks"))))
+          (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) nil))
+          (.then (fn [_] (restore!) (done)))))))
 
 (deftest stale-generation-partial-frame-never-concatenated
   ;; Bytes from two socket generations must never concatenate into one
@@ -1313,9 +1314,9 @@
                      (is (nil? @got*)
                          "a stale gen1 tail cannot concatenate onto gen2 to fake a frame")
                      (is (zero? (.-length (:buf @conn)))
-                         "and it never entered the live buffer"))
-                   (restore!) (done)))
-          (.catch (fn [e] (restore!) (is false (str "unexpected reject: " (.-message e))) (done)))))))
+                         "and it never entered the live buffer"))))
+          (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) nil))
+          (.then (fn [_] (restore!) (done)))))))
 
 (deftest connect!-rejection-clears-in-flight-slot-and-next-call-retries
   ;; A failed connect rejects the waiter, clears the in-flight slot, and the
@@ -1343,10 +1344,10 @@
                      (fire-cb! (second @sockets*) "connect")
                      (-> p2
                          (.then (fn [_]
-                                  (is (false? (:closed? @conn)) "the retry connected")
-                                  (restore!) (done)))
-                         (.catch (fn [e2] (restore!)
-                                   (is false (str "retry rejected: " (.-message e2))) (done)))))))))))
+                                  (is (false? (:closed? @conn)) "the retry connected")))
+                         (.catch (fn [e2]
+                                   (is false (str "retry rejected: " (.-message e2))) nil))
+                         (.then (fn [_] (restore!) (done)))))))))))
 
 (deftest close!-during-in-flight-connect-settles-waiter-and-orphans-candidate
   ;; Operator teardown mid-connect: the conn ends closed, the in-flight

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/port_file_stability_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/port_file_stability_test.cljs
@@ -67,13 +67,14 @@
                      (is (true? (:discovered? (server/session-state-snapshot)))
                          "session stays discovered (no forced rediscovery)")
                      (is (= explicit-pf (:port-file (server/session-state-snapshot)))
-                         "the cached port-file is the exact explicit path, unchanged")
-                     (restore!)
-                     (done)))
+                         "the cached port-file is the exact explicit path, unchanged")))
             (.catch (fn [e]
                       (is false (str "ensure-connection! must NOT reject: " (.-message e)))
-                      (restore!)
-                      (done))))))))
+                      nil))
+            ;; `restore!` is the same idempotent `set!` on both arms, so it
+            ;; moves to the single trailing step — still ahead of `done`, which
+            ;; is what keeps the stub from leaking into the next test.
+            (.then (fn [_] (restore!) (done))))))))
 
 (deftest cached-probe-winning-candidate-stays-on-connection
   (testing "a winning HTTP-probe candidate (target/shadow-cljs/nrepl.port) is reused when unchanged (rf2-ww877w)"
@@ -92,13 +93,11 @@
                      (is (= conn resolved-conn)
                          "cached conn reused — the winning candidate path re-read fine")
                      (is (= winning-pf (:port-file (server/session-state-snapshot)))
-                         "the cached port-file is the winning candidate, not a derived one")
-                     (restore!)
-                     (done)))
+                         "the cached port-file is the winning candidate, not a derived one")))
             (.catch (fn [e]
                       (is false (str "ensure-connection! must NOT reject: " (.-message e)))
-                      (restore!)
-                      (done))))))))
+                      nil))
+            (.then (fn [_] (restore!) (done))))))))
 
 (deftest cached-port-file-genuine-disappearance-still-rediscovers
   (testing "when the cached (exact) port-file genuinely vanishes, ensure-connection! still rediscovers — the fix doesn't mask real shutdowns"
@@ -119,10 +118,8 @@
         (-> (server/ensure-connection! {} discover-fn)
             (.then (fn [_]
                      (is (true? @redisc?)
-                         "a genuine vanished port-file STILL forces rediscovery (no false reuse)")
-                     (restore!)
-                     (done)))
+                         "a genuine vanished port-file STILL forces rediscovery (no false reuse)")))
             (.catch (fn [e]
                       (is false (str "rediscovery should succeed here: " (.-message e)))
-                      (restore!)
-                      (done))))))))
+                      nil))
+            (.then (fn [_] (restore!) (done))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/probe_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/probe_test.cljs
@@ -283,14 +283,19 @@
   reason + hint pattern. Centralises the deeply-nested Promise chain
   shape so each rung test reads as data."
   [conn expected-reason hint-pattern done extra-assertions]
+  ;; The rejection arm IS this helper's success path, so the two handlers are
+  ;; SIBLINGS of one two-arg `.then` — exactly one of them runs — and the single
+  ;; `done` sits in a trailing step with nothing after it. A `.catch` downstream
+  ;; of a `done` would claim whatever a LATER namespace throws as this rung's
+  ;; failure and fire `done` a second time (rf2-53uz).
   (-> (probe/ensure-runtime! conn :app)
-      (.then  (fn [_] (is false "must reject") (done)))
-      (.catch (fn [err]
-                (let [data (ex-data err)]
-                  (is (= expected-reason (:reason data)))
-                  (is (re-find hint-pattern (:hint data)))
-                  (when extra-assertions (extra-assertions data))
-                  (done))))))
+      (.then (fn [_] (is false "must reject"))
+             (fn [err]
+               (let [data (ex-data err)]
+                 (is (= expected-reason (:reason data)))
+                 (is (re-find hint-pattern (:hint data)))
+                 (when extra-assertions (extra-assertions data)))))
+      (.then (fn [_] (done)))))
 
 (deftest diagnose-rung-nrepl-unreachable
   (testing "JVM eval returns garbage (not \"1\") → :nrepl-unreachable"

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/raw_state_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/raw_state_test.cljs
@@ -335,9 +335,15 @@
           (.then (fn [_] (raw-state/signal-runtime! nil :app)))
           (.then (fn [_]
                    (is (= 3 @calls)
-                       "three sequential signals ⇒ three configure round-trips (no permanent per-build skip)")
-                   (done)))
-          (.catch (fn [_] (done)))))))
+                       "three sequential signals ⇒ three configure round-trips (no permanent per-build skip)")))
+          ;; `signal-runtime!` swallows its own failures, so this arm cannot
+          ;; fire — but it must still REPORT rather than pass the row silently,
+          ;; and it must sit UPSTREAM of the single trailing `done`, the shape
+          ;; the sibling row below already uses.
+          (.catch (fn [e]
+                    (is false (str "signal-runtime! must not reject: " (.-message e)))
+                    nil))
+          (.then (fn [_] (done)))))))
 
 (deftest signal-runtime-dedups-concurrent-in-flight
   ;; Two CONCURRENT signals for the same build (issued before the first

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/shutdown_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/shutdown_test.cljs
@@ -51,9 +51,9 @@
                      (is (= 1 @end-count) "the persistent nREPL socket was closed exactly once")
                      (is (nil? (:conn (server/session-state-snapshot)))
                          "the session conn reference was dropped")
-                     (is (= [0] @exit-args) "exited exactly once with code 0")
-                     (done)))
-            (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) (done))))))))
+                     (is (= [0] @exit-args) "exited exactly once with code 0")))
+            (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest duplicate-terminal-event-is-a-no-op
   (testing "a second shutdown! (end then close) does not double-close or re-exit"
@@ -73,9 +73,9 @@
                                   (is (= 1 @end-count)
                                       "the socket was NOT closed a second time")
                                   (is (= [0] @exit-args)
-                                      "exit fired exactly once across both calls")
-                                  (done))))))
-            (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) (done))))))))
+                                      "exit fired exactly once across both calls"))))))
+            (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest eof-before-first-tool-exits-cleanly
   (testing "EOF with no discovered conn (no socket ever opened) still exits 0"
@@ -85,6 +85,6 @@
         (is (nil? (:conn (server/session-state-snapshot))))
         (-> (server/shutdown! "early EOF" (fn [code] (swap! exit-args conj code)))
             (.then (fn [_]
-                     (is (= [0] @exit-args) "exited 0 with nothing to close")
-                     (done)))
-            (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) (done))))))))
+                     (is (= [0] @exit-args) "exited 0 with nothing to close")))
+            (.catch (fn [e] (is false (str "unexpected reject: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/tail_build_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/tail_build_test.cljs
@@ -93,9 +93,9 @@
                                (is (true? (:ok? edn)))
                                (is (false? (:soft? edn)))
                                (is (= {:initial 0 :final 1} (:probe-values edn))
-                                   "success envelope carries both ends of the comparison"))
-                             (done))))))
-            (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
+                                   "success envelope carries both ends of the comparison")))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Probe never changes — timeout envelope carries :probe-values with
@@ -127,9 +127,9 @@
                                (is (string? (:note edn)))
                                (is (re-find #"probe form returns the same value"
                                             (:note edn))
-                                   "new hint distinguishes value-stuck from compile-error"))
-                             (done))))))
-            (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
+                                   "new hint distinguishes value-stuck from compile-error")))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Probe raises on initial eval — :probe-errored envelope.
@@ -154,9 +154,9 @@
                                  "errored initial eval is its own reason, not :timed-out")
                              (is (re-find #"zorp" (:probe-error edn))
                                  "underlying nREPL error message rides on :probe-error")
-                             (is (string? (:note edn))))
-                           (done))))))
-          (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done)))))))
+                             (is (string? (:note edn)))))))))
+          (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+          (.then (fn [_] (done)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; `:wait-ms` is validated as a positive-millisecond integer
@@ -185,9 +185,9 @@
                              (is (= :invalid-numeric-arg (:reason edn)))
                              (is (= "wait-ms" (:arg edn)))
                              (is (not= :probe-errored (:reason edn))
-                                 "validation runs BEFORE the nREPL probe eval"))
-                           (done))))))
-          (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done)))))))
+                                 "validation runs BEFORE the nREPL probe eval")))))))
+          (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+          (.then (fn [_] (done)))))))
 
 (deftest negative-wait-ms-errors-honestly
   (testing "a negative :wait-ms (immediate timeout / negative setTimeout) is rejected"
@@ -197,6 +197,6 @@
                    (is (tu/error? result))
                    (let [edn (tu/extract-edn result)]
                      (is (= :invalid-numeric-arg (:reason edn)))
-                     (is (= "wait-ms" (:arg edn))))
-                   (done)))
-          (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done)))))))
+                     (is (= "wait-ms" (:arg edn))))))
+          (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+          (.then (fn [_] (done)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/unknown_tool_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/unknown_tool_test.cljs
@@ -101,9 +101,9 @@
                    (is (false? (:discovered? snap))
                        "discovery was NOT run — the refusal short-circuited before ensure-connection!")
                    (is (nil? (:discovery-error snap))
-                       "no discovery attempt recorded — connection step never reached"))
-                 (done)))
-        (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) (done))))))
+                       "no discovery attempt recorded — connection step never reached"))))
+        (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) nil))
+        (.then (fn [_] (done))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Server-boundary regression guard: an unregistered alias such as
@@ -127,9 +127,9 @@
                    ;; the :available-tools list + the tools/list hint.
                    (is (some #{"list-handlers"} (:available-tools edn))
                        "list-handlers is enumerated in the live catalogue")
-                   (is (re-find #"tools/list" (:hint edn))))
-                 (done)))
-        (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) (done))))))
+                   (is (re-find #"tools/list" (:hint edn))))))
+        (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) nil))
+        (.then (fn [_] (done))))))
 
 ;; ---------------------------------------------------------------------------
 ;; structuredContent on the boundary refusal preserves the keyword
@@ -147,6 +147,6 @@
                        "structuredContent :reason keeps its token")
                    (is (= false (j/get sc "ok?"))
                        ":ok? false round-trips through the structured slot")
-                   (is (= "no-such-tool" (j/get sc "tool"))))
-                 (done)))
-        (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) (done))))))
+                   (is (= "no-such-tool" (j/get sc "tool"))))))
+        (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) nil))
+        (.then (fn [_] (done))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/writes_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/writes_test.cljs
@@ -84,9 +84,9 @@
                  (is (false? (:discovered? snap))
                      "discovery was NOT run — the refusal short-circuited before ensure-connection!")
                  (is (nil? (:discovery-error snap))
-                     "no discovery attempt recorded — connection step never reached"))
-               (done)))
-      (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) (done)))))
+                     "no discovery attempt recorded — connection step never reached"))))
+      (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) nil))
+      (.then (fn [_] (done)))))
 
 (deftest restore-epoch-refused-before-connection
   (async done
@@ -131,6 +131,6 @@
                    (is (= reason-token (j/get sc "reason"))
                        "structuredContent :reason keeps its fully-qualified token")
                    (is (= false (j/get sc "ok?"))
-                       ":ok? false round-trips through the structured slot"))
-                 (done)))
-        (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) (done))))))
+                       ":ok? false round-trips through the structured slot"))))
+        (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) nil))
+        (.then (fn [_] (done))))))


### PR DESCRIPTION
Closes rf2-53uz. `tools/re-frame2-pair-mcp` only.

`cljs.test/run-block` hands `done` a continuation that runs the **whole remainder of
the run synchronously**, so anything a LATER namespace throws unwinds back into the
callback that called `done`. A `.catch` placed *downstream* of that callback claims the
foreign failure as its own — this row's label, printed against whichever test is current
by then — and then calls `done` a **second** time, which re-forces `run-block`'s
still-unrealized `Delay`. The cure landed in #7937 and #7951: the rejection handler goes
**upstream**, reports and releases but never finishes, and exactly **one** `done` sits in
a trailing step with nothing after it.

## The bead's own item: `probe_test.cljs:287` was a miss, and I agree

`assert-ladder-rejects-with-reason` reads, at source, exactly as the bead says:

```clojure
(-> (probe/ensure-runtime! conn :app)
    (.then  (fn [_] (is false "must reject") (done)))
    (.catch (fn [err] … (done))))
```

The fulfilment arm calls `done` and the `.catch` **is** downstream of it. #7942's
"a genuine error path, not the defect" does **not** hold: being a genuine error path and
being an instance are independent, and this row is both. It is **latent** — the arm that
calls `done` is the one that must never run — which is why nobody has seen it fire; the
moment the ladder regresses it exhibits the full signature.

Two things at source make the miss unambiguous rather than a judgement call. First,
`probe_test.cljs` carries **six** `.catch`es and the other five (223, 246, 410, 437, 461)
already sit upstream with a trailing `(.then (fn [_] (done)))` — #7942 repaired the file
and left one row inconsistent with its own five siblings. Second, it is a **shared
helper**: every rung of the diagnostic ladder routes through it, so one repair fixes all
of them. Repaired with the two-arg `.then` (the rejection arm IS the success path).

## The census is 59, not 38 — and 18 of those the bead's stated signature cannot see

I rebuilt the scanner from the stated signature rather than trusting the line numbers.
It reproduces the bead's shape but needed two corrections, and the second is a finding.

**(1) Nested steps must not split a chain.** Grouping "by equal indent" naively closes the
outer chain when a deeper-indented `.then` appears inside a step body, losing the
outer `.then`→`.catch` pairing. Keeping open chains on a stack recovers 3 more in this
tree: `nrepl_test` +1, `ensure_connection_single_flight_test` +1,
`ensure_connection_retry_test` +1. **38 → 41.**

**(2) `(done)` need not be in a step of the flagged chain at all.** The signature looks for
a *step* whose body contains `(done)`. This tree's dominant idiom puts it in the `->`
**head expression** instead — inside the body-fn handed to a stub harness:

```clojure
(-> (with-canned-eval! canned
      (fn []
        (-> (hm/handler-meta-tool …)
            (.then (fn [result] … (done))))))     ; ← done is in the HEAD
    (.catch (fn [e] (is false (str "rejected: " …)) (done))))
```

The `.catch` is still downstream of a `done` and still exhibits the full signature; the
stated scanner simply cannot see it. **41 → 59**: `handler_meta_test` 14 (the whole file
was invisible), `tail_build_test` 4. So for this tree the count is an upper bound *and* a
lower bound, and reading every chain is what caught it.

I re-ran the extended scanner repo-wide: the head-expression shape occurs **nowhere else**
(0 extra outside pair-MCP), so the sibling beads' file lists stand. Correction (1) does
lift their counts slightly: `implementation/freehand` 179 → **184**,
`implementation/hicasso` 16 → **17**; `tools/xray` 13, `tools/machines-viz` 1,
`tools/story` 1 unchanged. Repo-wide remainder after this PR: **216**.

## Per-chain dispositions

Teardown was **not** hoisted mechanically — each site's two arms were compared first.

| file | n | disposition |
|---|---|---|
| `handler_meta_test` | 14 | head-expression shape; report-only `.catch`, no teardown. `done` removed from the inner `.then`, `.catch` reports and returns `nil`, single trailing `(.then (fn [_] (done)))`. |
| `nrepl_test` | 9 | 7 with a **shared, idempotent** `restore!` (`(set! (.-createConnection net) orig)`) — hoisted to the trailing step, still ahead of `done` in that same step. 1 two-arg `.then` (`send-op!-nil-socket-rejects…` asserts rejection). 1 nested retry chain inside an already-correct two-arg `.then`. |
| `cljs_eval_value_test` | 5 | all five are the **`.catch` that IS the row's success path** — the row asserts the promise rejects, `(is false "…MUST reject")` sits in the `.then`. Two-arg `.then`, one trailing `done`. |
| `ensure_connection_single_flight_test` | 5 | 2 pure; 2 shared `restore!` hoisted; 1 is `concurrent-failed-discovery`'s retry chain, which called `done` on **both** of its own arms — now **returned** into the outer chain so the outer trailing step is the only `done`. |
| `tail_build_test` | 5 | 4 head-expression, 1 chain-step; all report-only. |
| `port_file_stability_test` | 3 | shared idempotent `restore!` hoisted. |
| `shutdown_test` | 3 | pure report-only; one (`duplicate-terminal-event-is-a-no-op`) finished from a nested chain, now from the outer trailing step. |
| `unknown_tool_test` | 3 | pure. |
| `closed_world_test` | 2 | pure. |
| `instructions_budget_test` | 2 | pure. |
| `writes_test` | 2 | one is inside `assert-refused-locally`, a **helper that takes `done`** — see below. One pure. |
| `build_id_cache_test` | 2 | 1 two-arg `.then` + shared `restore!`; 1 pure. |
| `ensure_connection_retry_test` | 2 | `discovery-failure-is-retried-not-sticky`: the outer `.catch` IS the success path → two-arg `.then`, with the nested retry chain returned into it and its two `done`s dropped. |
| `probe_test` | 1 | the bead's item, above. |
| `raw_state_test` | 1 | see "one assertion added". |

### No asymmetric teardown in this tree, and I checked for it

The parent found two cases where hoisting would have changed behaviour. This tree has
**none**: every teardown pair is the identical thunk on both arms (`restore!`, itself a
lone `set!` back to a captured original). Nothing was dropped and nothing was hoisted that
differed. Two ordering points I did check rather than assume:

- `build_id_cache_test`'s comment insists the restore is **inline before `done`**, because
  a `.finally`-scoped restore fires *after* `done` advances to the next test and leaks the
  multi-build stub into a neighbour. Hoisting keeps it inline — it moves into the same step
  as `done`, ahead of it — so the constraint still holds. Its assertions read `(ex-data err)`
  only, so running them before the restore instead of after changes nothing.
- `port_file_stability_test` and `nrepl_test` restore a `fs.readFileSync` /
  `net.createConnection` stub; their assertions read session state and conn state, never the
  stub, so the same reordering is inert.

### Left correct, and named as such

- **`ensure_connection_retry_test`'s `repeated-failures-keep-resurfacing-fresh-errors`** —
  a `.catch` that is the chain's **sole terminal step**, with nothing downstream of the
  `done` inside it. Not an instance.
- **`probe_test`'s five other `.catch`es** (223, 246, 410, 437, 461) and
  **`raw_state_test:372`** already carry the repaired shape from #7942. Untouched.

### The helper-forced shape appeared, in a benign variant

`writes_test/assert-refused-locally` and `probe_test/assert-ladder-rejects-with-reason`
both take `done` and call it — the shape that forced #7942's `fail-and-finish!` →
`report-failure!` rename. Neither needed renaming here: they are the **row bodies**, not
failure helpers, so `done` legitimately belongs in their signature. Each now calls it
exactly once, from a trailing step. No parameter dropped, no helper renamed.

### One assertion added, none weakened

`raw_state_test`'s `signal-runtime-reconfigures-each-call` ended `(.catch (fn [_] (done)))`
— a silent swallow that would have passed the row vacuously on any rejection. It now
reports before releasing, matching its own sibling row twelve lines below. `signal-runtime!`
swallows its failures internally, so the arm **cannot fire**, which is why the assertion
count did not move. Nothing was loosened, no teardown dropped, no suite retuned to dodge
the async window (the rf2-hic-029 refusal stands).

### `run-async` was not adopted

Its handler reports the generic `"an async matrix cell rejected: "`, which would replace
each of these 59 rows' own diagnostic with one string. Not the cheap win; not taken.

## Reproduction control — both directions

A green aggregate is not proof. Throwaway namespace
`re-frame2-pair-mcp.handler-meta-test-zz-control-test` — a **prefix extension** of
`…handler-meta-test`, so nothing sorts between them — pairing a fn-form `:each` fixture
with an `async` row, which selects cljs.test's `:sync` path, wraps the test in
`disable-async`, and rethrows a bare **String** synchronously inside whichever `done`
continuation is running. Targeted at `handler_meta_test` deliberately: it is the file the
bead's stated signature could not see.

**Direction 1 — control present, `handler_meta_test.cljs` reverted to its `origin/main`
bytes.** `npm test` → **captured exit 1**:

```
Testing re-frame2-pair-mcp.handler-meta-test-zz-control-test

FAIL in (a-delayed-row-that-needs-async) (:)
rejected:
expected: false
  actual: false
WARNING: Async test called done more than one time.
```

Every part of the predicted signature: `rejected:` is **`handler_meta_test`'s own
`.catch` message** (`(str "rejected: " (.-message e))`, empty because a bare String has no
`.-message`), printed against **the control's** test name — a foreign failure claimed as
this row's; the explicit **`done more than one time`** warning; and the log **ends there** —
`grep -c "Ran .* tests containing"` is **0**, no summary line at all.

**Direction 2 — the identical control, the repaired tree.** `npm test` →
**captured exit 1**:

```
UnhandledPromiseRejection: … The promise rejected with the reason
"Async tests require fixtures to be specified as maps.  Testing aborted.".
```

The throw now escapes as an honest unhandled rejection, named for what it actually is and
attributed to **nobody**. Zero `FAIL` lines, zero `rejected:` claims, zero
`done more than one time`, and the control namespace is **not announced at all**. Exit is
still 1 because the control genuinely aborts `cljs.test` — the control doing its job, not
the defect doing its.

The control was then deleted. Restore verified **by hashing the bytes**, not `git diff`:
`handler_meta_test.cljs` is sha256 `e6748cd99b707403ceb057c8a8943876e48a537a22ddb4a7e07506a8f35f099a`
before the revert and after the restore; `git status --untracked-files=all` is empty.

## Quality gates

Each run alone, foreground to completion, nothing appended; the exit code redirected and
echoed on **one** command line into its own `.exit` file, deleted between runs. **The
numbers below are the ones CAPTURED.**

| gate | cwd | captured exit | result |
|---|---|---|---|
| `npm test` — baseline, pre-change | `tools/re-frame2-pair-mcp` | **0** | Ran **1224** tests containing **4440** assertions. 0 failures, 0 errors. |
| `npm test` — **shipped tree** | `tools/re-frame2-pair-mcp` | **0** | Ran **1224** tests containing **4440** assertions. 0 failures, 0 errors. |
| `npm test` — control present, **reverted** | `tools/re-frame2-pair-mcp` | **1** | reproduction: foreign claim + double-`done`, **no summary line** |
| `npm test` — control present, **fixed** | `tools/re-frame2-pair-mcp` | **1** | honest unhandled rejection, attributed to nobody |
| `npm run check:descriptors` | `tools/re-frame2-pair-mcp` | **0** | `OK: tool-descriptors.edn in sync (33 tools).` |
| `python scripts/check_fast_pr_gap.py --list` | repo root | **0** | 97 required checks the fast-PR spine does not decide |

**The lane that decides this is `node-test-tools-re-frame2-pair-mcp`** — "Node
tools/re-frame2-pair-mcp (shadow-cljs `:server-test`)", whose step is literally
`cd tools/re-frame2-pair-mcp && npm test`, run above four times. `check_fast_pr_gap.py`
confirms it is category (B): the fast-PR spine has **no lane for it at all**, which is
exactly why it is run by hand here. `check:descriptors` is the sibling step of the same
job.

The implementation browser/node lanes do **not** carry these files:
`implementation/deps.edn` names no path under `tools/`, and pair-MCP declares its own
`:server-test` build off its own `deps.edn`, so `npm run test:cljs` and
`npm run test:browser` never compile this namespace set. `mcp_live` and `mcp_conformance`
are armed by the `tools/re-frame2-pair-mcp/**` surface gate but are decided by `src/` and
the server bundle, neither of which this diff touches — left to CI. `tools_jvm` covers
xray / story / story-mcp / mcp-base, not this artefact.

**Test counts did not move, and that is the expected answer.** 1224 / 4440 before and
after. This diff adds and removes no `deftest`, and its one new `is` sits in a handler that
cannot fire; it reorders steps within existing chains, so a moved count would have been
evidence of a *mistake* — most likely a namespace silently dropped from the build. Neither
moved.
