### PR TITLE
test(freehand): a suite's cleanup must not outlive its own test (rf2-0r3j)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/behaviors_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/behaviors_dom_cljs_test.cljs
@@ -181,13 +181,21 @@
                            "the COMMITTED render connects, exactly once")
                        (is (= 1 (behaviors/connection-count)))
                        (is (= #{:probe/one} (behaviors/target-ids))
-                           "and claims the semantic id the use site declared")
-                       (ms/destroy-root! container root)
-                       (done)))
+                           "and claims the semantic id the use site declared")))
+              ;; Reports and releases; it never finishes (rf2-fyba). `cljs.test`
+              ;; hands `done` a continuation that runs the WHOLE REMAINDER of the
+              ;; run synchronously, so a `.catch` downstream of it claims whatever
+              ;; a later namespace throws as this row's failure, prints it against
+              ;; this row's label, and fires `done` a SECOND time — re-forcing
+              ;; `run-block`'s unrealized delay and re-running that namespace.
+              ;; `ms/destroy-root!` is what both arms duplicated, so it rides the
+              ;; single trailing step: written once, still run once per path.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (ms/destroy-root! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (ms/destroy-root! container root)
+                       (done)))))))))
 
 (deftest fh-behavior-004-update-observes-movement-not-renders
   (testing "Per FH-BEHAVIOR-004: `:update` runs when the committed config
@@ -218,13 +226,15 @@
                          (is (= (:prev-config (:moved fh-004)) prev-config)
                              "with the previous config alongside the new one")
                          (is (= (:memory (:moved fh-004)) memory)
-                             "and the private memory :connect returned"))
-                       (ms/destroy-root! container root)
-                       (done)))
+                             "and the private memory :connect returned"))))
+              ;; Reports and releases; it never finishes (rf2-fyba). The teardown
+              ;; both arms duplicated rides the single trailing step.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (ms/destroy-root! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (ms/destroy-root! container root)
+                       (done)))))))))
 
 (deftest fh-behavior-004-layout-timing-runs-before-passive
   (testing "Per FH-BEHAVIOR-004: `:timing :layout` means the work is complete
@@ -245,13 +255,15 @@
                        (let [{:keys [attribute value]} (:layout fh-004)]
                          (is (= value (attr container ".node[data-id='layout']" attribute))
                              "and the layout behavior's DOM write is on its node"))
-                       (is (= 2 (behaviors/connection-count)))
-                       (ms/destroy-root! container root)
-                       (done)))
+                       (is (= 2 (behaviors/connection-count)))))
+              ;; Reports and releases; it never finishes (rf2-fyba). The teardown
+              ;; both arms duplicated rides the single trailing step.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (ms/destroy-root! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (ms/destroy-root! container root)
+                       (done)))))))))
 
 ;; ===========================================================================
 ;; FH-BEHAVIOR-005 — cleanup is TOTAL, and it is asserted as an ABSENCE
@@ -305,11 +317,14 @@
                        ;; BOTH roots — the control and the behaving one —
                        ;; are read here, which is what the shared ledger
                        ;; buys over a per-suite teardown.
-                       (released! "FH-BEHAVIOR-005 — after the last unmount")
-                       (done)))
+                       (released! "FH-BEHAVIOR-005 — after the last unmount")))
+              ;; Reports and releases; it never finishes (rf2-fyba). Nothing to
+              ;; hoist here — both roots were already torn down upstream, inside
+              ;; the chain, which is what the residue read above depends on.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest fh-behavior-005-a-layout-behavior-releases-exactly-once-too
   (testing "Per FH-BEHAVIOR-005: both timing arms are installed on every
@@ -332,11 +347,13 @@
                          (is (= connections (behaviors/connection-count)))
                          (is (= (set targets) (behaviors/target-ids)))
                          (is (= lifecycle (bv/ops))))
-                       (released! "FH-BEHAVIOR-005 — after the layout arm releases")
-                       (done)))
+                       (released! "FH-BEHAVIOR-005 — after the layout arm releases")))
+              ;; Reports and releases; it never finishes (rf2-fyba). Teardown
+              ;; already ran upstream, so nothing rides the trailing step but `done`.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest fh-behavior-005-a-partial-teardown-leaves-the-survivor-alone
   (testing "Per FH-BEHAVIOR-005: a release names the exact generation it
@@ -362,11 +379,13 @@
                        (ms/act #(ms/destroy-root! container root))))
               (.then (fn [_]
                        (is (zero? (behaviors/connection-count)))
-                       (released! "FH-BEHAVIOR-005 — after the survivor's own unmount")
-                       (done)))
+                       (released! "FH-BEHAVIOR-005 — after the survivor's own unmount")))
+              ;; Reports and releases; it never finishes (rf2-fyba). Teardown
+              ;; already ran upstream, so nothing rides the trailing step but `done`.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; FH-BEHAVIOR-006 — the bounded command channel
@@ -402,13 +421,15 @@
                                        (:attribute untouched)))
                            "and the live DECOY was untouched")
                        (is (= :probe/one (:target (last @bv/transcript)))
-                           "the context carried the target it was addressed by")
-                       (ms/destroy-root! container root)
-                       (done)))
+                           "the context carried the target it was addressed by")))
+              ;; Reports and releases; it never finishes (rf2-fyba). The teardown
+              ;; both arms duplicated rides the single trailing step.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (ms/destroy-root! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (ms/destroy-root! container root)
+                       (done)))))))))
 
 (deftest fh-behavior-006-a-command-does-not-cross-into-another-frame
   (testing "Per FH-BEHAVIOR-006: a connection is committed under the frame its
@@ -460,13 +481,15 @@
                                        (:attribute untouched)))
                            "and the other frame's node was not touched")
                        (is (= lifecycle (bv/ops))
-                           "no host work ran at all")
-                       (ms/destroy-root! container root)
-                       (done)))
+                           "no host work ran at all")))
+              ;; Reports and releases; it never finishes (rf2-fyba). The teardown
+              ;; both arms duplicated rides the single trailing step.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (ms/destroy-root! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (ms/destroy-root! container root)
+                       (done)))))))))
 
 (deftest fh-behavior-006-one-target-per-frame-is-not-ambiguous
   (testing "Per FH-BEHAVIOR-006: uniqueness is a claim about ONE frame. Two
@@ -504,15 +527,17 @@
                                       (:attribute marked)))
                              note))
                        (is (= lifecycle (bv/ops))
-                           "each command ran exactly once, and neither was refused")
-                       (ms/destroy-root! container-a root-a)
-                       (ms/destroy-root! container-b root-b)
-                       (done)))
+                           "each command ran exactly once, and neither was refused")))
+              ;; Reports and releases; it never finishes (rf2-fyba). BOTH teardowns
+              ;; were duplicated across the two arms, so both ride the single
+              ;; trailing step.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (ms/destroy-root! container-a root-a)
-                        (ms/destroy-root! container-b root-b)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (ms/destroy-root! container-a root-a)
+                       (ms/destroy-root! container-b root-b)
+                       (done)))))))))
 
 (deftest fh-behavior-006-every-other-outcome-is-a-visible-refusal
   (testing "Per FH-BEHAVIOR-006: an absent target, an ambiguous target, an
@@ -542,13 +567,14 @@
                                    (step (rest remaining)))))
                       (js/Promise.resolve :done)))]
           (-> (step (:refusals fh-006))
-              (.then (fn [_]
-                       (ms/destroy-root! container root)
-                       (done)))
+              ;; Reports and releases; it never finishes (rf2-fyba). The teardown
+              ;; both arms duplicated rides the single trailing step.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (ms/destroy-root! container root)
-                        (done))))))))))
+                        nil))
+              (.then (fn [_]
+                       (ms/destroy-root! container root)
+                       (done))))))))))
 
 (deftest fh-behavior-006-a-command-is-refused-after-teardown-never-queued
   (testing "Per FH-BEHAVIOR-006: once the connection is released, the same
@@ -574,11 +600,13 @@
                        (is (= outcome (conf/caught-id
                                         #(behaviors/command! frame-id command)))
                            "and is refused the moment the connection is gone")
-                       (is (zero? (behaviors/connection-count)))
-                       (done)))
+                       (is (zero? (behaviors/connection-count)))))
+              ;; Reports and releases; it never finishes (rf2-fyba). Teardown
+              ;; already ran upstream, so nothing rides the trailing step but `done`.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest fh-behavior-006-an-outward-context-is-fenced-to-its-generation
   (testing "Per FH-BEHAVIOR-006: a behavior's `:dispatch` is fenced to the
@@ -602,11 +630,13 @@
                        (ms/act #(ms/destroy-root! container root))))
               (.then (fn [_]
                        (is (= after-teardown (@bv/last-dispatch event))
-                           "and inert the moment the connection is released")
-                       (done)))
+                           "and inert the moment the connection is released")))
+              ;; Reports and releases; it never finishes (rf2-fyba). Teardown
+              ;; already ran upstream, so nothing rides the trailing step but `done`.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest the-command-channel-is-a-registered-effect
   (testing "Per FH-BEHAVIOR-006: the channel is an ordinary re-frame effect,
@@ -673,12 +703,18 @@
                               the claim two void returns used to erase")
                          (is (= mutations @(:calls released))
                              "both void mutators ran against that SAME instance"))
-                       (is (zero? (behaviors/connection-count)))
-                       (done)))
+                       (is (zero? (behaviors/connection-count)))))
+              ;; Reports and releases; it never finishes (rf2-fyba). The teardown
+              ;; here is ASYMMETRIC and stays put: the success path already tore
+              ;; the root down upstream — the `:disconnect` assertions above depend
+              ;; on it having run — so this is the failure arm's own defensive
+              ;; cleanup for a rejection that arrived before that point. Hoisting
+              ;; it would destroy the root twice on the success path.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
                         (ms/destroy-root! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; FH-BEHAVIOR-008 — the tool plane: two read-only projections
@@ -745,13 +781,15 @@
                          (is (= 2 (count rows)))
                          (is (= (sort (map :generation rows)) (map :generation rows))
                              "projected oldest first, by the generation that ordered them")
-                         (is (= [:probe/one :probe/two] (mapv :target rows))))
-                       (ms/destroy-root! container root)
-                       (done)))
+                         (is (= [:probe/one :probe/two] (mapv :target rows))))))
+              ;; Reports and releases; it never finishes (rf2-fyba). The teardown
+              ;; both arms duplicated rides the single trailing step.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (ms/destroy-root! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (ms/destroy-root! container root)
+                       (done)))))))))
 
 (deftest fh-behavior-008-the-command-log-records-what-was-asked-and-decided
   (testing "Per FH-BEHAVIOR-008: the command-traffic projection records what
@@ -799,13 +837,15 @@
                                  (is (not (contains? got :generation))
                                      (str note " — and no generation"))))
                            (is (every? (set present) (keys got))
-                               (str note " — the key roster is closed"))))
-                       (ms/destroy-root! container root)
-                       (done)))
+                               (str note " — the key roster is closed"))))))
+              ;; Reports and releases; it never finishes (rf2-fyba). The teardown
+              ;; both arms duplicated rides the single trailing step.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (ms/destroy-root! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (ms/destroy-root! container root)
+                       (done)))))))))
 
 (deftest fh-behavior-008-the-command-log-is-a-bounded-window
   (testing "Per FH-BEHAVIOR-008: the traffic window is BOUNDED — an
@@ -831,10 +871,12 @@
                          (is (= behaviors/command-log-limit (count rows))
                              "the window holds the limit and no more")
                          (is (every? #(= :delivered (:outcome %)) rows)
-                             "and the OLDEST rows were the ones dropped"))
-                       (ms/destroy-root! container root)
-                       (done)))
+                             "and the OLDEST rows were the ones dropped"))))
+              ;; Reports and releases; it never finishes (rf2-fyba). The teardown
+              ;; both arms duplicated rides the single trailing step.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (ms/destroy-root! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (ms/destroy-root! container root)
+                       (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/compiled_mount_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/compiled_mount_dom_cljs_test.cljs
@@ -396,12 +396,25 @@
               (.then (fn [mounted]
                        (doseq [row (:dom struct-007)]
                          (check-row! container row))
-                       (unmount! container mounted)
-                       (done)))
+                       (unmount! container mounted)))
+              ;; Reports and releases; it never finishes (rf2-fyba). `cljs.test`
+              ;; hands `done` a continuation that runs the WHOLE REMAINDER of the
+              ;; run synchronously, so a `.catch` downstream of it claims whatever
+              ;; a later namespace throws as this row's failure, prints it against
+              ;; this row's label, and fires `done` a SECOND time — re-forcing
+              ;; `run-block`'s unrealized delay and re-running that namespace.
+              ;;
+              ;; The teardown is ASYMMETRIC throughout this file and stays put.
+              ;; The success arm's `unmount!` retires the React root AND detaches
+              ;; the container; the failure arm can only `.remove`, because the
+              ;; rejection may be the mount itself and `mounted` is the fulfilled
+              ;; value — not in scope here at all. Neither belongs on a shared
+              ;; trailing step.
               (.catch (fn [e]
                         (is false (str "compiled mount rejected: " e))
                         (.remove container)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; The elision verdict is the wrapper React actually ran
@@ -436,12 +449,14 @@
                                                (:view-id (v/describe inert-probe)))))
                            "and the boundary React reconciles was minted for exactly
                             that lowering and that verdict")
-                       (unmount! container mounted)
-                       (done)))
+                       (unmount! container mounted)))
+              ;; Reports and releases; it never finishes (rf2-fyba). Asymmetric
+              ;; teardown stays put — see the first mounted row above.
               (.catch (fn [e]
                         (is false (str "inert mount rejected: " e))
                         (.remove container)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest a-reactive-compiled-view-mounts-inside-the-atomic-shell
   (testing "A compiled body carrying a subscription renders INSIDE the
@@ -465,12 +480,14 @@
                        (is (= [:compiled :present]
                               (:signature (get (fr/boundary-cache)
                                                (:view-id (v/describe sub-probe))))))
-                       (unmount! container mounted)
-                       (done)))
+                       (unmount! container mounted)))
+              ;; Reports and releases; it never finishes (rf2-fyba). Asymmetric
+              ;; teardown stays put — see the first mounted row above.
               (.catch (fn [e]
                         (is false (str "reactive mount rejected: " e))
                         (.remove container)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; The subscription arm — observe, and repaint when the value moves
@@ -508,12 +525,14 @@
                        (is (= "42" (text container "#reactive"))
                            "and the compiled arm repainted the MOUNTED occurrence
                             identically, off the same committed dependency")
-                       (unmount! container @mounted)
-                       (done)))
+                       (unmount! container @mounted)))
+              ;; Reports and releases; it never finishes (rf2-fyba). Asymmetric
+              ;; teardown stays put — see the first mounted row above.
               (.catch (fn [e]
                         (is false (str "subscription arm rejected: " e))
                         (.remove container)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; The event arm — a committed site, fired from a real DOM event
@@ -549,12 +568,14 @@
               (.then (fn [_]
                        (is (= 2 (:presses (db)))
                            "and the site's proxy survived the repaint between clicks")
-                       (unmount! container @mounted)
-                       (done)))
+                       (unmount! container @mounted)))
+              ;; Reports and releases; it never finishes (rf2-fyba). Asymmetric
+              ;; teardown stays put — see the first mounted row above.
               (.catch (fn [e]
                         (is false (str "event arm rejected: " e))
                         (.remove container)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest a-compiled-v-event-site-dispatches-the-vector-its-body-answered
   (testing "The arm above fires a LITERAL intent. This one fires a
@@ -591,12 +612,14 @@
               (.then (fn [_]
                        (is (= [[:compiled/converted 7] [:compiled/converted 8]] (:converted (db)))
                            "and the site's proxy converted the second click too")
-                       (unmount! container @mounted)
-                       (done)))
+                       (unmount! container @mounted)))
+              ;; Reports and releases; it never finishes (rf2-fyba). Asymmetric
+              ;; teardown stays put — see the first mounted row above.
               (.catch (fn [e]
                         (is false (str "v/event arm rejected: " e))
                         (.remove container)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; Props forwarding — the forwarded map really reaches the mounted element
@@ -641,13 +664,15 @@
                        (is (= 2 (:presses (db)))
                            "and the interpreted twin's forwarded handler dispatched too")
                        (doseq [[c m] (map vector [c-compiled c-interpreted] @mounts)]
-                         (unmount! c m))
-                       (done)))
+                         (unmount! c m))))
+              ;; Reports and releases; it never finishes (rf2-fyba). Asymmetric
+              ;; teardown stays put — see the first mounted row above.
               (.catch (fn [e]
                         (is false (str "spread arm rejected: " e))
                         (.remove c-compiled)
                         (.remove c-interpreted)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest a-compiled-v-spread-safe-folds-the-guarded-caller-under-the-owned-props
   (testing "The guarded caller map reaches the element; the OWNED props win
@@ -680,13 +705,15 @@
                        (is (= "owned" (.-value (.querySelector c-compiled "input")))
                            "the owned controlled value is what React is holding")
                        (doseq [[c m] (map vector [c-compiled c-interpreted] @mounts)]
-                         (unmount! c m))
-                       (done)))
+                         (unmount! c m))))
+              ;; Reports and releases; it never finishes (rf2-fyba). Asymmetric
+              ;; teardown stays put — see the first mounted row above.
               (.catch (fn [e]
                         (is false (str "spread-safe arm rejected: " e))
                         (.remove c-compiled)
                         (.remove c-interpreted)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest a-permitted-caller-handler-through-v-spread-safe-becomes-a-committed-site
   (testing "The deny law below proves `v/spread-safe` REFUSES a caller
@@ -726,13 +753,15 @@
                             dispatched too, so the guard blocks the forged carrier
                             without blocking the good one in either mode")
                        (doseq [[c m] (map vector [c-compiled c-interpreted] @mounts)]
-                         (unmount! c m))
-                       (done)))
+                         (unmount! c m))))
+              ;; Reports and releases; it never finishes (rf2-fyba). Asymmetric
+              ;; teardown stays put — see the first mounted row above.
               (.catch (fn [e]
                         (is false (str "permitted caller-handler arm rejected: " e))
                         (.remove c-compiled)
                         (.remove c-interpreted)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest a-compiled-v-event-prop-arrives-at-the-boundary-and-dispatches
   (testing "The same defect one boundary further out. A `(v/event …)` at a
@@ -760,12 +789,14 @@
                        (is (= [[:compiled/converted 5]] (:converted (db)))
                            "the callback crossed the boundary intact and dispatched
                             the vector its body answered")
-                       (unmount! container @mounted)
-                       (done)))
+                       (unmount! container @mounted)))
+              ;; Reports and releases; it never finishes (rf2-fyba). Asymmetric
+              ;; teardown stays put — see the first mounted row above.
               (.catch (fn [e]
                         (is false (str "crossing callback arm rejected: " e))
                         (.remove container)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest the-spread-safe-deny-law-still-fires-through-the-compiled-fold
   (testing "The bound is the whole point of the form, so it is not
@@ -811,12 +842,14 @@
                            "the committed handler carried the native value into app-db")
                        (is (= "abc" (.-value (.querySelector container "#field")))
                            "and the field shows what app-db now holds")
-                       (unmount! container @mounted)
-                       (done)))
+                       (unmount! container @mounted)))
+              ;; Reports and releases; it never finishes (rf2-fyba). Asymmetric
+              ;; teardown stays put — see the first mounted row above.
               (.catch (fn [e]
                         (is false (str "controlled-input arm rejected: " e))
                         (.remove container)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; Crossings — a compiled parent mounting an interpreted child
@@ -844,12 +877,14 @@
                               (mapv #(select-keys % [:view-id :lowering])
                                     (:crossings (v/manifest crossing-probe))))
                            "and the manifest named that crossing, and its mode")
-                       (unmount! container mounted)
-                       (done)))
+                       (unmount! container mounted)))
+              ;; Reports and releases; it never finishes (rf2-fyba). Asymmetric
+              ;; teardown stays put — see the first mounted row above.
               (.catch (fn [e]
                         (is false (str "crossing mount rejected: " e))
                         (.remove container)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; Non-vacuity

--- a/implementation/freehand/test/re_frame/freehand/pilot_overlay_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_overlay_dom_cljs_test.cljs
@@ -378,9 +378,22 @@
                              "and already at the anchor's left edge — no wrong-position paint")
                          (is (< (js/Math.abs (- (.-top panel) (+ (.-bottom anchor) 4))) 1.5)
                              "below it by exactly the declared gap"))
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+                       (teardown! container root)))
+              ;; Reports and releases; it never finishes (rf2-fyba). `cljs.test`
+              ;; hands `done` a continuation that runs the WHOLE REMAINDER of the
+              ;; run synchronously, so a `.catch` downstream of it claims whatever
+              ;; a later namespace throws as this row's failure, prints it against
+              ;; this row's label, and fires `done` a SECOND time — re-forcing
+              ;; `run-block`'s unrealized delay and re-running that namespace.
+              ;;
+              ;; `teardown!` stays on the SUCCESS arm throughout this file rather
+              ;; than riding the trailing step: the failure arm has never torn a
+              ;; root down, and a `teardown!` in the trailing step would run
+              ;; against a root whose own commit had just thrown — where an
+              ;; `.unmount` that threw in turn would strand `done` and hang the
+              ;; lane. Inside the `.then` it is covered by the handler below.
+              (.catch (fn [e] (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest r-b2-the-panel-escapes-a-clipping-transformed-ancestor
   (testing "R-B2 (mounted). The toolbar's ancestor carries `overflow:
@@ -447,9 +460,10 @@
                              (str "and it is really there: the point paints the panel, not "
                                   "whatever the clip would have left behind (hit "
                                   (some-> hit .-id) ")")))
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+                       (teardown! container root)))
+              ;; Reports and releases; it never finishes (rf2-fyba).
+              (.catch (fn [e] (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; R-B4 — the focus contract, both overlay classes
@@ -490,9 +504,10 @@
                        (is (false? (modal? dialog)) "close() ran at the commit")
                        (is (= (by-id opener) js/document.activeElement)
                            "and focus RETURNED to the control that opened it")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+                       (teardown! container root)))
+              ;; Reports and releases; it never finishes (rf2-fyba).
+              (.catch (fn [e] (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest r-b4-the-anchored-panel-leaves-focus-on-the-anchor
   (testing "R-B4 (mounted), the anchored half. An `:auto` popover takes no
@@ -516,9 +531,10 @@
                            "and the anchor still has focus")
                        (is (= "true" (.getAttribute (by-id (anchor-id)) "aria-expanded"))
                            "with the expanded state announced")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+                       (teardown! container root)))
+              ;; Reports and releases; it never finishes (rf2-fyba).
+              (.catch (fn [e] (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; R-B3 — the browser dismisses, and the pilot reconciles from newState
@@ -567,9 +583,10 @@
               (.then (fn [_]
                        (is (false? (open? (panel-id)))
                            "and the next render does NOT re-open it")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+                       (teardown! container root)))
+              ;; Reports and releases; it never finishes (rf2-fyba).
+              (.catch (fn [e] (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; R-B9 — nesting: stacked, and dismissed innermost-first
@@ -637,9 +654,10 @@
                               (get (frame/frame-app-db-value fid) ui/records-root))
                            "and both records are still open — the control did not close
                             itself on its own opening reports")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+                       (teardown! container root)))
+              ;; Reports and releases; it never finishes (rf2-fyba).
+              (.catch (fn [e] (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest the-minimal-nested-pair-stacks-when-both-open-in-one-commit
   (testing "The CONTROL for the two nesting rows: two bare popovers, one
@@ -661,9 +679,10 @@
               (.then (fn [_]
                        (is (true? (open? "bare-outer")) "the bare outer popover is open")
                        (is (true? (open? "bare-inner")) "and the bare nested one with it")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+                       (teardown! container root)))
+              ;; Reports and releases; it never finishes (rf2-fyba).
+              (.catch (fn [e] (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest the-attribution-ladder-for-nesting
   (testing "Two more rungs between the minimal pair and the pilot's
@@ -728,9 +747,12 @@
                            (str "THE MECHANISM: two nested popovers opening produce MORE than "
                                 "two toggle reports — "
                                 (pr-str (get (frame/frame-app-db-value fid) ::toggles))))
-                       (teardown! c3 r3)
-                       (done)))
-              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+                       (teardown! c3 r3)))
+              ;; Reports and releases; it never finishes (rf2-fyba). The three
+              ;; rungs' teardowns stay where they are: each retires its OWN mount
+              ;; at the moment that rung ends, and only the last is on this step.
+              (.catch (fn [e] (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest a-nested-panel-opened-in-a-LATER-commit-also-stays-nested
   (testing "R-B9, and a FINDING now RESOLVED. The one-commit row proves a
@@ -782,9 +804,10 @@
                               (get-in (frame/frame-app-db-value fid) [ui/records-root outer-k]))
                            "the outer record is still open — no opening report was read
                             as a dismissal")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+                       (teardown! container root)))
+              ;; Reports and releases; it never finishes (rf2-fyba).
+              (.catch (fn [e] (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; R-B6 / R-B12 — the retained count, as exact integers
@@ -887,9 +910,17 @@
                          (is (zero? (behaviors/connection-count))
                              "and every behavior connection released")
                          (is (zero? (top-layer/pending-count))
-                             "with the top-layer commit batch drained"))
-                       (done)))
-              (.catch (fn [e] (restore!) (is false (str "browser run failed: " e)) (done)))))))))
+                             "with the top-layer commit batch drained"))))
+              ;; Reports and releases; it never finishes (rf2-fyba). `restore!`
+              ;; is ASYMMETRIC and stays put: the success arm un-patches the
+              ;; globals in the same breath as the snapshot it took them for,
+              ;; above, so this is the failure arm's own safety net for a
+              ;; rejection that arrived while they were still patched. Leaving
+              ;; `document.addEventListener` wrapped would corrupt the whole
+              ;; remainder of the run, so it may not ride a step that a throw
+              ;; could skip.
+              (.catch (fn [e] (restore!) (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; THE COMBINATION — one element, both mechanisms, and both refs run
@@ -951,9 +982,10 @@
                              (str "non-vacuous: the element was NOT open before it was "
                                   "asked to be — the OPEN reading is a response, not a "
                                   "constant")))
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+                       (teardown! container root)))
+              ;; Reports and releases; it never finishes (rf2-fyba).
+              (.catch (fn [e] (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; PROMOTION PARITY, MOUNTED — the compiled twin reaches the top layer
@@ -1070,11 +1102,14 @@
                              (str "the COMPILED anchor's event site dispatched a live "
                                   "browser click into app-db — " (pr-str (:clicked c))))
                          (is (= (:clicked i) (:clicked c))
-                             "exactly as the interpreted twin's site does"))
-                       (done)))
+                             "exactly as the interpreted twin's site does"))))
+              ;; Reports and releases; it never finishes (rf2-fyba). Each arm
+              ;; retires its own mount inside `overlay-arm!`, so there is no
+              ;; teardown here to place either way.
               (.catch (fn [e]
                         (is false (str "the promotion pass threw " e))
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 (def ^:private fx-005 (conf/fixture :FH-TOPLAYER-005))
 
@@ -1145,8 +1180,10 @@
                          (is (= [] c)
                              "AND NEITHER IS THE COMPILED ONE — the `:on-toggle` it
                               declares reached the judgement that promotion could
-                              have hidden"))
-                       (done)))
+                              have hidden"))))
+              ;; Reports and releases; it never finishes (rf2-fyba). Each `once`
+              ;; retires its own mount, so there is no teardown here to place.
               (.catch (fn [e]
                         (is false (str "the advisory pass threw " e))
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))


### PR DESCRIPTION
Closes rf2-0r3j — freehand batch **1 of 4** (41 chains). rf2-fyba stays open.

`cljs.test/run-block` hands `done` a continuation that runs the **whole remainder of
the run synchronously**. Anything a later namespace throws unwinds back into the
callback that called `done`, so a `.catch` placed *downstream* of that callback claims
the foreign failure as its own — this row's label, printed against whichever test is
current by then — and then calls `done` a **second** time, which re-forces
`run-block`'s still-unrealized `Delay` and **re-runs the offending namespace**.

The cure is the one #7937 landed and #7942 / #7951 generalised: the rejection handler
goes **upstream**, reports and releases but never finishes, and exactly **one** `done`
sits at the tail with nothing after it.

**41 chains, three files, all of them read.** 16 in `behaviors_dom_cljs_test`, 13 in
`pilot_overlay_dom_cljs_test`, 12 in `compiled_mount_dom_cljs_test` — the bead's counts
reproduce exactly against an independently rebuilt scanner. No `deftest` added or
removed; no assertion weakened, moved or deleted; no suite retuned; no other file
touched.

## Teardown was NOT hoisted mechanically — and the split is 13 / 28, not the other way

The bead is right that this is the whole difference from a mechanical swap, so both arms
were compared at every one of the 41 sites. What that reading found is that in **this**
population the *differing* arms are the dominant case, and they differ in the direction
the bead's two worked examples do not cover: the failure arm does **less** than the
success arm, not more.

| disposition | chains | what it means |
|---|---|---|
| **shared and idempotent → hoisted** to the single trailing step | **10** | `ms/destroy-root!` written on both arms; now written once, still run once per path |
| **nothing to place** — the row's teardown already ran upstream inside the chain, or a helper owns it | **7** | only `done` rides the trailing step |
| **asymmetric → left exactly where it was** | **24** | hoisting would have changed behaviour; each reason is stated at the site |

### The 10 that were hoisted

All in `behaviors_dom_cljs_test`, all `ms/destroy-root!` (twice over in
`fh-behavior-006-one-target-per-frame-is-not-ambiguous`, which retires two roots):
`fh-behavior-004-an-abandoned-candidate-connects-nothing` (**the bead's own `:179`
counter-example**), `-004-update-observes-movement-not-renders`,
`-004-layout-timing-runs-before-passive`,
`-006-a-command-reaches-its-target-and-nothing-else`,
`-006-a-command-does-not-cross-into-another-frame`,
`-006-one-target-per-frame-is-not-ambiguous`,
`-006-every-other-outcome-is-a-visible-refusal`,
`-008-active-connections-project-the-public-half-only`,
`-008-the-command-log-records-what-was-asked-and-decided`,
`-008-the-command-log-is-a-bounded-window`.

### The 24 that were left, and why

- **`compiled_mount_dom_cljs_test` — all 12.** The success arm's `unmount!` retires the
  React root **and** detaches the container; the failure arm can only `.remove`. That is
  not drift: the rejection may be the mount itself, and `mounted` is the **fulfilled
  value** — in four of the twelve rows it is the `.then`'s own parameter and is not in
  the handler's lexical scope at all. Neither half belongs on a shared trailing step.
- **`pilot_overlay_dom_cljs_test` — 11.** `teardown!` stays on the success arm, because
  this file's failure arm has never torn a root down. Moving it to the trailing step
  would run `.unmount` against a root whose own commit had just thrown; a throw *there*
  strands `done` and hangs the lane, whereas inside the `.then` it is still covered by
  the handler. `the-attribution-ladder-for-nesting` keeps all three of its rung
  teardowns in place for the same reason — each retires its own mount at the moment its
  rung ends.
- **`behaviors_dom_cljs_test:fh-behavior-009-only-connect-establishes-the-memory`.** The
  failure-only `ms/destroy-root!` is defensive: the success path already tore the root
  down upstream, and the `:disconnect` assertions in the trailing step *depend* on it
  having run. Hoisting would have destroyed the root twice on the success path — the
  bead's `:179` hazard, one file over.
- **`pilot_overlay:r-b6-and-r-b12-a-full-cycle-retains-exactly-nothing`.** `restore!` is
  failure-only for a sharper reason than convention: the success arm un-patches
  `document.addEventListener` and friends in the same breath as the snapshot it took
  them for. Leaving those wrappers installed would corrupt the entire remainder of the
  run, so `restore!` may not ride a step that a throw could skip.

### Neither unanticipated shape occurs in this batch

The bead names two — the `.catch` that **is** the row's success path, and the
helper-forced shape where a local helper takes `done` and calls it. Both were looked
for; **neither is present in these three files**, and that is a finding rather than an
omission. No row here asserts that a promise rejects, and every helper that owns a chain
(`overlay-arm!`, `advisories!`, `once`, `cycle!`, the `letfn` `step`) takes no `done` and
returns its promise. `advisories!`'s `.catch` cleans up and **re-rejects** — a genuine
cleanup-and-rethrow, not an instance, and left alone.

## Reproduction control — both directions

A green aggregate is not proof: the browser runner echoes the console **only on
failure**.

Throwaway namespace `re-frame.freehand.behaviors-dom-cljs-test-zz-control-dom-cljs-test`
— a **prefix extension** of the target, so nothing sorts between them — ending in
`-dom-cljs-test` so the `:browser-test` ns-regexp
(`^(?!re-frame\.freehand\.bench\.).*-dom-cljs-test$`) selects it. A fn-form `:each`
fixture paired with an `async` row, which is the exact mechanism, confirmed in
`cljs/test.cljs` itself: `execution-strategy` reads `:fn` and returns `:sync`, the
`:sync` branch wraps the test in `disable-async`, that throws `::async-disabled`, and
`test-var-block*`'s `case` **rethrows a bare String** —
`"Async tests require fixtures to be specified as maps.  Testing aborted."` —
synchronously, inside whichever `done` continuation is running.

| signal | **A** control + `behaviors_dom` **reverted** | **B** control + `behaviors_dom` **repaired** |
|---|---|---|
| captured exit | **1** | **1** |
| `behaviors_dom`'s own `mount rejected:` printed against the **control's** test name | **2** | **0** |
| control namespace announced (i.e. **re-run**) | **2** | **1** |
| `WARNING: Async test called done more than one time.` | 1 | 1 — now owed by a **named** file outside this batch, below |
| `Ran N tests containing M assertions` summary | **none** | none |

Run A is every part of the predicted signature at once:

```
Testing re-frame.freehand.behaviors-dom-cljs-test-zz-control-dom-cljs-test
FAIL in (a-delayed-row-that-needs-async) (:)
mount rejected: Async tests require fixtures to be specified as maps.  Testing aborted.
expected: false
  actual: false
Testing re-frame.freehand.behaviors-dom-cljs-test-zz-control-dom-cljs-test   <-- the ns RE-RAN
FAIL in (a-delayed-row-that-needs-async) (:)
mount rejected: Async tests require fixtures to be specified as maps.  Testing aborted.
expected: false
  actual: false
WARNING: Async test called done more than one time.
```

`mount rejected:` is `behaviors_dom_cljs_test`'s **own** `.catch` message, printed
against the **control's** test name; the control namespace is announced **twice**,
because the second `done` re-forced the unrealized delay and the offending namespace ran
again; and the log **ends there** — no summary line at all.

Run B: `behaviors_dom`'s message is gone (2 → 0) and the **namespace re-run is gone**
(announced twice → once). What run B additionally captured is that the claim did not
evaporate, it **moved**:

```
FAIL in (a-delayed-row-that-needs-async) (:)
the compiled behavior mount rejected: Async tests require fixtures to be specified as maps.
```

That message belongs to
**`implementation/freehand/test/re_frame/freehand/behavior_matrix_dom_cljs_test.cljs:238`**,
which carries **5 chains** of the identical defect and sorts before this file. It is
**not in this batch's file set**, so it is left alone and recorded here for whichever of
freehand 2/4 – 4/4 owns it. #7937 saw the same inheritance (`read_extent_dom_cljs_test`
picking it up the moment `reincarnation_paint` stopped claiming it). Attribution reaching
*nobody* is not achievable from inside batch 1 while 129 chains remain elsewhere in
freehand — that is a fact about the split, not a gap in the proof.

The control was then deleted and **every restore verified by hashing the bytes**, not by
`git diff`. `sha256` before the probes and after them, identical:

| file | sha256 |
|---|---|
| `behaviors_dom_cljs_test.cljs` | `ec9958a01b9f0b012e5fc5df00dcbae27f9f5063e48520519ff59cc2f69ec621` |
| `pilot_overlay_dom_cljs_test.cljs` | `ef41c1a1e7e753a83970935e443ebf7756d7978ba44d033ef63b6b58af77ddf0` |
| `compiled_mount_dom_cljs_test.cljs` | `2adcf47a4b87d6f6bfe2f7175fbc0902f3b19fb8862944e5724c7cc5e163f01e` |

The control is absent from disk, absent from `git ls-files`, and
`git status --untracked-files=all` is empty.

## Quality gates

Each run alone, foreground to completion, nothing appended, exit code captured on the
same command line. **The numbers below are the ones CAPTURED**, not the ones the harness
narrated.

| gate | cwd | captured exit | result |
|---|---|---|---|
| `npm run test:browser` — **shipped tree** | `implementation/` | **0** | Ran **1293** tests containing **8010** assertions. 0 failures, 0 errors. |
| `npm run test:browser` — **baseline**, the three files reverted to `origin/main` | `implementation/` | **0** | Ran **1293** tests containing **8010** assertions. 0 failures, 0 errors. |
| `npm run test:browser` — run A, control present, unfixed | `implementation/` | **1** | misattributed row + namespace re-run + double-`done`, no summary |
| `npm run test:browser` — run B, control present, fixed | `implementation/` | **1** | this file's label gone; re-run gone |
| `npm run test:freehand` — shipped tree | `implementation/` | **0** | Ran **1406** tests containing **7786** assertions. 0 failures, 0 errors. |
| `python scripts/check_fast_pr_gap.py --list` | repo root | **0** | 97 required checks the fast-PR spine does not decide |

**The browser lane is the one that decides this** — every one of the three files is a
`-dom-cljs-test` suite. `check_fast_pr_gap.py` puts `cljs-browser`
(`CLJS (shadow-cljs :browser-test, headless Chromium)` → `npm run test:browser`) in
category **(B): a required job with no lane in the fast-PR spine at all**, which is
exactly why it is run by hand above — four times. The spine's `npm run test:cljs` lane
does compile and run these namespaces (they match the always-on `:node-test` build's
`cljs-test$` regexp), and `npm run test:freehand` is that same set, focused; it is here
because it is cheap and names the artefact. Everything else required is surface-gated off
a diff that changes three CLJS test files. `clj-kondo` and `splint` reach
`implementation/`, but CI pins clj-kondo 2026.04.15 and a differently-versioned local
binary proves nothing, so those are left to CI.

## Test counts: the tests did not move, and the +2 assertions are not this diff

The bead states the lane sits at **1293 / 8008**. The shipped tree reads **1293 / 8010**,
so the assertion count needed accounting for rather than asserting.

**It is not this change.** The same lane was run on the same box with all three files
reverted to their `origin/main` bytes, and it reads **1293 / 8010** as well — identical
to the shipped tree in both numbers. This diff adds and removes no `deftest` and no `is`;
it reorders steps within existing chains, so a moved count would have been evidence of a
mistake. Neither moved.

The +2 arrived on `main` between #7951 (where 8008 was recorded) and this branch's base.
The only commits touching `implementation/` in that window are `fdbadcb8e1`
(`fix(hicasso): the outward bridge hands :children the vector the contract names`) and
`63480e867e`, both of which change `hicasso/src/re_frame/hicasso/impl/codec.cljs` — a
namespace ten hicasso `*_dom_cljs_test` suites require.

## Two other premises checked at source

- **The scanner count.** Rebuilt from the bead's stated signature rather than trusting
  its list (steps matching `^\s*\((\.then|\.catch|\.finally)\b`, grouped into chains by
  equal indent with no intervening lower-indent line; flag any chain where a step whose
  body contains `(done)` is followed by a `.catch` step; `;;` comments stripped, string
  literals respected). It reproduces the bead's per-file counts for this batch
  **exactly** — 16 / 13 / 12 = **41** — and reads **0** in all three after the repair.
  Repo-tree-wide it reads **170** chains in `implementation/freehand` at `origin/main`,
  not the bead's 179, and **129** after this PR (170 − 41 = 129, confirmed by re-running
  it on the shipped tree). The 9-chain discrepancy therefore sits **entirely outside this
  batch's file set** and changes nothing here; it is flagged so freehand 2/4 – 4/4 do not
  budget from a number a rebuild does not reproduce. It is not a missed-shape problem in
  the rebuild: no `.catch` step in the whole of `implementation/freehand` begins
  mid-line, so nothing is lost to the line-anchored match.
- **`run-async` was not reached for**, per the bead. Its handler reports the generic
  `"an async matrix cell rejected: "`, which would replace all 41 of these rows'
  diagnostics with one string — and those diagnostics are what runs A and B above are
  read through.

## Not done, deliberately

No suite retuned to dodge the async window (the rf2-hic-029 refusal stands). No assertion
weakened. No teardown dropped to make a swap typecheck. No chain swapped without its two
arms being compared first. `mount_support`'s `each-mode` / `run-async` were not
re-repaired — #7942 already fixed them and the chains routing through them are fine.
