### PR TITLE
fix(hicasso): prove IME engagement by conduct, not IMM32 state (rf2-hic-016)

### DIFF
--- a/implementation/scripts/lib/windows-ime-driver.ps1
+++ b/implementation/scripts/lib/windows-ime-driver.ps1
@@ -52,11 +52,11 @@
     FIND <b64 title-substring>    -> {hwnd, title, matches}
     IMESTATE <hwnd>               -> {hkl, langid, japanese, open, conversion,
                                       native, foreground, isForeground}
-    RESOLVE <tokens>              -> {tokens, vks}
+    RESOLVE <tokens> [hwnd]       -> {tokens, vks, scans}
     FOREGROUND <hwnd>             -> {isForeground}                    [armed]
     IMEON <hwnd>                  -> {requested, hkl, langid, ...}     [armed]
     IMECONV <hwnd>                -> {conversion, native, ...}         [armed]
-    KEYS <hwnd> <tokens> <delay>  -> {sent, tokens}                    [armed]
+    KEYS <hwnd> <tokens> <delay>  -> {sent, tokens, scans}             [armed]
     QUIT                          -> OK
 
   ## What it does NOT do
@@ -68,27 +68,54 @@
   way a person would. And `IMEON` is a REQUEST, not a guarantee: the modern
   Microsoft IME is a TSF text service, and the IMM32 messages below reach it
   through a compatibility layer that a given browser build may not honour.
-  That is why `IMESTATE` exists as a separate verb — the caller ASKS, then
-  VERIFIES, and stops for the operator when the answer is no.
+  `IMESTATE` exists as a separate verb so the caller can ASK and then look —
+  but see the next section for what that reading is worth, and for the one
+  thing it must never be used as.
 
-  ## The warning above came true, and what answers it
+  ## What `IMESTATE` is worth: the write-through finding of 2026-08-12
 
-  On 2026-08-12 the first armed run got the whole way in — foreground
-  seized on all three engines, romaji and ESC both delivered — and still
-  decided nothing: `IMESTATE` read `langid 0x0411`, `japanese: true` and
-  **`open: 0`** on Chromium, Firefox and WebKit alike. The TSF IME had
-  simply ignored `IMC_SETOPENSTATUS`, exactly as this header said it might,
-  so seven romaji letters landed as plain ASCII and all 24 checks returned
-  INCONCLUSIVE.
+  Two armed runs that day, and between them they emptied this verb of any
+  authority.
 
-  The door that was open all along is the one the keystrokes came through.
-  `SendInput` reached that IME when IMM32 did not, so the caller opens it by
-  sending the IME'S OWN TOGGLE — `kanji` (半角/全角, VK 0x19), already in the
-  vocabulary below — through `KEYS`, and then re-reads `IMESTATE`. `IMECONV`
-  is the same shape one level along: the toggle says nothing about which
-  reading mode the IME came back in, so Hiragana is re-asserted and the
-  `native` flag re-read. Neither verb is trusted either. The caller ASKS,
-  VERIFIES, and refuses the engine when the answer is still no.
+  The FIRST got the whole way in — foreground seized on all three engines,
+  romaji and ESC both delivered — and still decided nothing: `IMESTATE` read
+  `langid 0x0411`, `japanese: true` and **`open: 0`** on Chromium, Firefox
+  and WebKit alike. The TSF IME had ignored `IMC_SETOPENSTATUS`, exactly as
+  the paragraph above said it might. The answer taken then was to open the
+  IME by its OWN TOGGLE — `kanji` (半角/全角, VK 0x19) through `KEYS`, the
+  door the keystrokes were demonstrably arriving by — and to require
+  `open: 1` back from `IMESTATE` before typing anything.
+
+  The SECOND run returned `open: 1`, `conversion: 9`, `native: true` on
+  Chromium — engaged, by that gate — while `compositionstart` stayed at ZERO
+  on every check and the romaji went into the box as literal ASCII. And
+  `conversion: 9` is `IME_CMODE_HIRAGANA`: the exact constant
+  `RequestJapanese` had just written. **The IMM32 shim's state is
+  WRITE-THROUGH.** `IMC_GETOPENSTATUS` handed back the bit `IMC_SETOPENSTATUS`
+  had set, on an input context the TSF service was not reading, so the gate
+  proved a value had been written and nothing else. It could not have failed.
+
+  So `IMESTATE`, `IMEON` and `IMECONV` are ATTEMPTS AND OBSERVATIONS, and the
+  caller uses them as such: it prints the reading and gates on CONDUCT
+  instead — one romaji letter typed into the page, and a `compositionstart`
+  read off the page's own event stream. Nothing this driver can write to an
+  input context produces one of those.
+
+  ## Why the toggle went nowhere: `MapVirtualKey` and the zero scan code
+
+  The same run leaves the toggle itself under suspicion, and the cause was in
+  `SendKey`. It resolved every scan code with `MapVirtualKeyW`, which maps
+  against the layout of the CALLING thread — this driver's, which is English.
+  `VK_KANJI` has no key on that layout, so the call answered 0, and a
+  zero-scan keystroke is one an IME may decline (the comment on `SendKey`
+  said so all along). Measured here: `MapVirtualKeyW(0x19, VK_TO_VSC)` is
+  `0x00`, and so, it turns out, is `MapVirtualKeyExW(0x19, VK_TO_VSC,
+  0x04110411)` — `VK_KANJI` is an IMM32 virtual key with no physical key
+  behind it in any layout table. `ScanFor` therefore asks the target
+  window's own layout first, falls back to this thread's, and puts a LITERAL
+  `0x29` under the IME toggle beneath both, which is the only one of the
+  three that can answer for it. `KEYS` reports the scans it sent, so a zero
+  can never again be invisible.
 #>
 
 [CmdletBinding()]
@@ -130,6 +157,7 @@ public static class Rf2Ime
   // --- synthetic input ----------------------------------------------------
   [DllImport("user32.dll", SetLastError = true)] private static extern uint SendInput(uint n, INPUT[] inputs, int size);
   [DllImport("user32.dll")] private static extern uint MapVirtualKeyW(uint code, uint mapType);
+  [DllImport("user32.dll")] private static extern uint MapVirtualKeyExW(uint code, uint mapType, IntPtr hkl);
 
   [StructLayout(LayoutKind.Sequential)]
   private struct KEYBDINPUT { public ushort wVk; public ushort wScan; public uint dwFlags; public uint time; public IntPtr dwExtraInfo; }
@@ -163,6 +191,20 @@ public static class Rf2Ime
   // Hiragana: native reading, full-width. What a person selects when they
   // pick "ひらがな" in the language bar.
   private const int IME_CMODE_HIRAGANA = 0x0009;   // NATIVE | FULLSHAPE
+
+  private const uint MAPVK_VK_TO_VSC = 0;
+  private const uint VK_KANJI = 0x19;
+  // 半角/全角 sits where the backtick does on a US board: set-1 scan code
+  // 0x29. A LITERAL, and load-bearing rather than belt-and-braces. Measured
+  // on this machine, with the Japanese layout installed:
+  //
+  //     MapVirtualKeyW  (0x19, VK_TO_VSC)             -> 0x00
+  //     MapVirtualKeyExW(0x19, VK_TO_VSC, 0x04110411) -> 0x00
+  //
+  // VK_KANJI is an IMM32 virtual key with no physical key behind it in ANY
+  // layout table — the JIS 半角/全角 key reaches Windows as VK_OEM_AUTO — so
+  // no lookup can supply this and only a literal can.
+  private const ushort SCAN_HANKAKU_ZENKAKU = 0x29;
 
   /// Every visible top-level window whose title contains `needle`. Returned
   /// with the match COUNT rather than only the first hit: two windows
@@ -227,7 +269,9 @@ public static class Rf2Ime
   /// the IME and put it in Hiragana. A REQUEST: `WM_INPUTLANGCHANGEREQUEST`
   /// is posted (the owning thread applies it, not us), and the IMM32
   /// control messages reach a TSF text service through a compatibility
-  /// shim that need not honour them. The caller verifies afterwards.
+  /// shim that need not honour them — and whose stored state answers the
+  /// matching GETs whether it honoured them or not. The caller verifies
+  /// afterwards, by conduct, not by reading these values back.
   public static long RequestJapanese(IntPtr hwnd)
   {
     IntPtr hkl = LoadKeyboardLayoutW("00000411", 0x00000001 /* KLF_ACTIVATE */);
@@ -271,13 +315,41 @@ public static class Rf2Ime
     return conversion >= 0 && (conversion & IME_CMODE_NATIVE) == IME_CMODE_NATIVE;
   }
 
-  /// One key down+up through the OS input stack. The virtual key carries a
-  /// real scan code (`MapVirtualKey`) because an IME reads both, and a
-  /// keystroke with a zero scan code is one an IME may decline to compose
-  /// from.
-  public static uint SendKey(ushort vk)
+  /// The scan code a physical keyboard would carry for `vk`, resolved UNDER
+  /// THE LAYOUT OF THE WINDOW BEING TYPED INTO.
+  ///
+  /// `MapVirtualKeyW` maps against the CALLING thread's layout — this
+  /// driver's, which is English — where `VK_KANJI` is not a key and the
+  /// answer is 0. That is how the 半角/全角 toggle came to be sent all of
+  /// 2026-08-12 with a zero scan code, which is precisely the keystroke
+  /// `SendKey` below says an IME may decline.
+  ///
+  /// So: the window's own HKL first (`MapVirtualKeyExW`), this thread's
+  /// layout as the fallback, and a literal under the IME toggle beneath
+  /// both. THE LITERAL IS THE ONE THAT ANSWERS FOR THAT KEY — measured, the
+  /// Japanese HKL returns 0 for `VK_KANJI` as well (see
+  /// `SCAN_HANKAKU_ZENKAKU`). The layout lookup is still the right first
+  /// question for the ordinary keys, whose scan codes DO differ between
+  /// layouts, and a zero surviving all three is a real answer that `KEYS`
+  /// reports rather than hides.
+  public static ushort ScanFor(ushort vk, IntPtr hwnd)
   {
-    ushort scan = (ushort)MapVirtualKeyW(vk, 0 /* MAPVK_VK_TO_VSC */);
+    long hkl = LayoutOf(hwnd);
+    ushort scan = 0;
+    if (hkl != 0) scan = (ushort)MapVirtualKeyExW(vk, MAPVK_VK_TO_VSC, new IntPtr(hkl));
+    if (scan == 0) scan = (ushort)MapVirtualKeyW(vk, MAPVK_VK_TO_VSC);
+    if (scan == 0 && vk == VK_KANJI) scan = SCAN_HANKAKU_ZENKAKU;
+    return scan;
+  }
+
+  /// One key down+up through the OS input stack. The virtual key carries a
+  /// real scan code because an IME reads both, and a keystroke with a zero
+  /// scan code is one an IME may decline to compose from. The scan is a
+  /// PARAMETER rather than something computed here: the only correct answer
+  /// depends on the window being typed into, which this function is not
+  /// told, and a witness has to be able to print what it actually sent.
+  public static uint SendKey(ushort vk, ushort scan)
+  {
     INPUT[] two = new INPUT[2];
     two[0].type = INPUT_KEYBOARD;
     two[0].U.ki.wVk = vk; two[0].U.ki.wScan = scan; two[0].U.ki.dwFlags = 0;
@@ -298,8 +370,8 @@ $VK = @{
   'home' = 0x24; 'end' = 0x23; 'delete' = 0x2E;
   # The IME's own keys: 半角/全角 toggles the IME, 変換 opens conversion,
   # F7 forces katakana. `kanji` is no longer decorative — it is what the
-  # caller's engage preflight sends, through `KEYS`, when `IMEON`'s IMM32
-  # request leaves a TSF IME closed. The other three are here so a key plan
+  # caller's engage ladder sends, through `KEYS`, while the page is still
+  # showing no `compositionstart`. The other three are here so a key plan
   # can name them, and no default plan does.
   'kanji' = 0x19; 'convert' = 0x1C; 'nonconvert' = 0x1D; 'f7' = 0x76
 }
@@ -398,9 +470,17 @@ while ($null -ne ($line = [Console]::In.ReadLine())) {
         # against this verb cannot drift from the table that sends it.
         $tokens = $parts[2].Split(',') | Where-Object { $_.Length -gt 0 }
         $vks = @($tokens | ForEach-Object { Resolve-Vk $_ })
+        # The window handle is OPTIONAL, because which scan code a key carries
+        # is a question about the layout of the thread that owns the window
+        # and the preflight asks this before any window is found. Given one,
+        # the answer is what `KEYS` would actually send — which is how the
+        # REHEARSAL can show the 半角/全角 toggle carrying a non-zero scan
+        # without sending a single keystroke.
+        $h = if ($parts.Length -gt 3) { [IntPtr][int64]$parts[3] } else { [IntPtr]::Zero }
         Reply $id 'OK' ([ordered]@{
           tokens = ($tokens -join ',')
           vks    = @($vks | ForEach-Object { '0x{0:X2}' -f $_ })
+          scans  = @($vks | ForEach-Object { '0x{0:X2}' -f [Rf2Ime]::ScanFor($_, $h) })
         })
       }
       'FOREGROUND' {
@@ -441,6 +521,10 @@ while ($null -ne ($line = [Console]::In.ReadLine())) {
           # Resolve the WHOLE plan before sending anything. A typo in the
           # fifth token must not leave four keystrokes already delivered.
           $vks = @($tokens | ForEach-Object { Resolve-Vk $_ })
+          # Resolved against the TARGET window's layout, once, before the
+          # first key goes out — see `ScanFor`. Reported below, because the
+          # zero that stopped the IME toggle working was invisible.
+          $scans = @($vks | ForEach-Object { [Rf2Ime]::ScanFor($_, $h) })
           $sent = 0
           for ($i = 0; $i -lt $vks.Count; $i++) {
             # Re-verified per key, not once per batch: the operator can
@@ -451,11 +535,17 @@ while ($null -ne ($line = [Console]::In.ReadLine())) {
               $sent = -1
               break
             }
-            [void][Rf2Ime]::SendKey($vks[$i])
+            [void][Rf2Ime]::SendKey($vks[$i], $scans[$i])
             $sent++
             Start-Sleep -Milliseconds $delay
           }
-          if ($sent -ge 0) { Reply $id 'OK' ([ordered]@{ sent = $sent; tokens = ($tokens -join ',') }) }
+          if ($sent -ge 0) {
+            Reply $id 'OK' ([ordered]@{
+              sent   = $sent
+              tokens = ($tokens -join ',')
+              scans  = ((@($scans | ForEach-Object { '0x{0:X2}' -f $_ })) -join ',')
+            })
+          }
         }
       }
       'QUIT' { Reply $id 'OK' $null; break }

--- a/implementation/scripts/run-hicasso-native-ime-witness.cjs
+++ b/implementation/scripts/run-hicasso-native-ime-witness.cjs
@@ -44,9 +44,8 @@
  * rehearsal, and the run reports itself as a rehearsal rather than a result.
  *
  * `--inject` is the witness proper. It additionally brings each browser
- * window to the foreground, puts its IME into a state the checks can
- * actually measure — Japanese locale, OPEN, native reading mode — VERIFIES
- * each of those three, and then types.
+ * window to the foreground, asks its IME to come up in Japanese, PROVES the
+ * IME is composing by making it compose, and then types.
  *
  * ========================= WHY THE IME IS VERIFIED ========================
  *
@@ -58,21 +57,51 @@
  * stops and asks the operator to switch with Win+Space rather than typing
  * seven ASCII letters into a text box and calling it a composition.
  *
- * That is not hypothetical, and on 2026-08-12 it happened one notch along
- * from where it was expected. The first armed run seized the foreground on
- * all three engines and delivered both the romaji and the ESC — and still
- * decided nothing: `langid 0x0411`, `japanese: true`, and `open: 0`
- * everywhere. The locale had switched; the IME had ignored
- * `IMC_SETOPENSTATUS` and stayed shut, so the romaji went in as ASCII and
- * all 24 checks returned INCONCLUSIVE about the rig.
+ * ================== AND WHY IT IS VERIFIED BY CONDUCT =====================
  *
- * `engageIme` below is the answer, and it uses the door the keystrokes
- * already came through: `SendInput` reached that IME when IMM32 did not, so
- * a closed IME is opened by sending its OWN toggle key (`kanji`, 半角/全角)
- * through `KEYS`. Nothing about that is trusted either — `IMESTATE` is
- * re-read, `open: 1` is REQUIRED before a single plan is driven, the
- * reading mode's NATIVE bit is required with it, and an engine that will
- * not go there is refused rather than measured.
+ * Two armed runs on 2026-08-12, and the second is why the gate below reads
+ * the PAGE rather than the input stack.
+ *
+ * The first seized the foreground on all three engines and delivered both
+ * the romaji and the ESC — and decided nothing: `langid 0x0411`,
+ * `japanese: true`, `open: 0` everywhere. The IME had ignored
+ * `IMC_SETOPENSTATUS`. The repair was to open it by its own toggle key
+ * (`kanji`, 半角/全角) through `KEYS` — the door the keystrokes were
+ * demonstrably arriving by — and to REQUIRE `open: 1` back from `IMESTATE`
+ * before driving a plan.
+ *
+ * The second run returned `open: 1`, `conversion: 9`, `native: true` on
+ * Chromium — engaged, by that gate — with `compositionstart` at ZERO on
+ * every check and the romaji in the box as literal ASCII. And `conversion: 9`
+ * is `IME_CMODE_HIRAGANA`, the exact constant this rig had just written.
+ * THE IMM32 SHIM'S STATE IS WRITE-THROUGH: the gate read back the bit it had
+ * itself set, so it proved a value had been written and nothing else. It
+ * could not have failed — a fail-open sitting inside the guard against one.
+ *
+ * So that reading is now a LOG LINE, and engagement is decided by CONDUCT.
+ * `probeComposition` types ONE romaji letter into the plain field and
+ * requires `compositionstart > 0` off the page's own observer. It is the
+ * gate precisely because that event cannot be produced by the thing under
+ * test: the browser emits it in response to real composed input, and no
+ * value this rig writes into an input context makes one appear. An engine
+ * that will not compose is recorded NOT ENGAGED and nothing is typed to it.
+ *
+ * ================= A REFUSAL IS PER-ENGINE, NOT PER-BATCH =================
+ *
+ * On that same run Firefox read `open: 0` after `IMEON` and two toggles and
+ * aborted with nothing typed. That was correct conduct — the abort is the
+ * deliverable — but it was a THROW out of the engine loop, so WebKit never
+ * launched at all: one engine's rig failure cost the run an engine it exists
+ * to measure. Engagement failure is now caught at the engine boundary and
+ * recorded as NOT ENGAGED for that engine — no check driven, no cell
+ * fillable, exit non-zero — and the batch continues to the next engine.
+ *
+ * Between the ladder and that refusal sits a bounded OPERATOR-ASSIST WAIT:
+ * up to ninety seconds in which the run prints what to press and polls by
+ * re-running the conduct probe. NO KEYSTROKES ARE IN FLIGHT while it waits,
+ * and the foreground is re-verified before every poll, so the operator
+ * touching the browser window during that pause is what the rig asked for
+ * rather than the interference the per-key interlock exists to catch.
  *
  * ====================== AND WHY DELIVERY IS VERIFIED ======================
  *
@@ -125,9 +154,24 @@ const ALL_ENGINES = ['chromium', 'firefox', 'webkit'];
 // that demonstrably delivered keystrokes to the very IME that ignored
 // `IMC_SETOPENSTATUS`.
 const IME_TOGGLE_KEY = 'kanji';
-// A toggle is handled by the IME's UI thread; the IMM32 query answers from
-// the same place. Read too soon and the answer is the state before the key.
+// A toggle is handled by the IME's UI thread. Read too soon and any reading
+// taken after it — including the page's — is of the state before the key.
 const IME_SETTLE_MS = 500;
+// THE CONDUCT PROBE. One romaji letter into the `plain` field, and a
+// `compositionstart` off the page's own observer or the IME is not engaged.
+// `n` is the first letter of `nihongo`, so a composing IME opens its exchange
+// on it; an alphanumeric one puts an `n` in the box and fires nothing.
+const CONDUCT_KEY = 'n';
+const CONDUCT_FIELD = 'plain';
+// A composition is opened by the IME's own UI thread and reaches the page as
+// an event. Longer than the IMM32 settle above, because this one waits for a
+// round trip through the browser rather than for a message queue.
+const CONDUCT_SETTLE_MS = 600;
+// The bounded operator-assist wait, and its poll interval. Ninety seconds is
+// long enough to click into a window and press one key, and short enough that
+// an unattended run cannot sit on the keyboard indefinitely.
+const ASSIST_TIMEOUT_MS = 90000;
+const ASSIST_POLL_MS = 6000;
 // The delivery probe's key. Escape, for two reasons: the 2026-08-12 run
 // PROVED it reaches the page, and with no field focused it mutates nothing —
 // no text, no caret, no focus. Its keydown is read off the observer and then
@@ -827,60 +871,188 @@ function worst(verdicts) {
 // and a check whose keys are not arriving is not driven.
 // ---------------------------------------------------------------------------
 
+/** The IMM32 reading, for the log. Never a premise — see the header. */
+const fmtIme = (s) => `open=${s.open} conversion=${s.conversion} ` +
+  `native=${s.native} langid=${s.langid} isForeground=${s.isForeground}`;
+
 /**
- * Require the window's IME to be OPEN and in a native reading mode, opening
- * it by its own toggle key when `IMEON`'s IMM32 request left it shut.
+ * THE CONDUCT PROBE. Is this window's IME COMPOSING? Decided by making it
+ * compose: one romaji letter into the `plain` field, and `compositionstart`
+ * read back off the page's own observer.
  *
- * The toggle is sent at most twice, and the second only after a re-read still
- * says closed — it TOGGLES, so a blind pair would close whatever the first
- * one opened. `state` is the reading `IMEON` already produced; every reading
- * after that is taken fresh, because the whole point is that this IME does
- * not do what it is told.
+ * It is the gate because it is the one thing in this rig the thing under test
+ * cannot fake. `IMC_GETOPENSTATUS` answers from an input context this process
+ * writes to, and on 2026-08-12 it handed back the very bit that had just been
+ * written while nothing composed. `compositionstart` is emitted by the BROWSER
+ * in response to input a real IME actually consumed; no message this driver
+ * can send produces one.
  *
- * Throws with the state in the message when the IME will not engage. That
- * abort is the deliverable: the alternative is typing romaji into a closed
- * IME and reporting eight INCONCLUSIVEs that look like an engine result.
+ * Leaves the page as it found it: the letter is aborted with ESC and the
+ * reload restores every field to its seed, so a probe run four times over is
+ * four times the same probe rather than a field filling up with `nnnn`.
  */
-async function engageIme({ driver, hwnd, engine, keyDelayMs, state }) {
-  let ime = state;
-  for (let attempt = 1; ime.open !== 1 && attempt <= 2; attempt += 1) {
-    console.log(`> IME reports open=${ime.open}; sending ${IME_TOGGLE_KEY} ` +
-      `(半角/全角) through SendInput — attempt ${attempt} of 2`);
-    await driver.require('KEYS', hwnd, IME_TOGGLE_KEY, keyDelayMs);
-    await sleep(IME_SETTLE_MS);
-    ime = await driver.require('IMESTATE', hwnd);
-    console.log(`> IME after toggle: ${JSON.stringify(ime)}`);
+async function probeComposition({ page, driver, hwnd, keyDelayMs, reload }) {
+  const observing = await W.resetEvents(page);
+  if (!observing) {
+    // The same distinction `probeDelivery` insists on: nothing to read the
+    // answer WITH is not the same as an answer of no.
+    throw new Error('the page observer is not installed, so composition ' +
+      'cannot be read; no engagement claim is possible for this engine');
   }
-  if (ime.open !== 1) {
-    throw new Error(
-      `the ${engine} window's IME WILL NOT OPEN. Its input locale is ` +
-      `${ime.langid} (japanese=${ime.japanese}) and it holds the foreground ` +
-      `(isForeground=${ime.isForeground}), but IMC_GETOPENSTATUS still reads ` +
-      `open=${ime.open} after IMEON and two ${IME_TOGGLE_KEY} (半角/全角) ` +
-      'keystrokes. A closed IME turns the romaji below into seven plain ' +
-      'ASCII letters and every check into an INCONCLUSIVE about this rig, ' +
-      'which is what the run of 2026-08-12 produced. Nothing was typed for ' +
-      'this engine. Open the IME for that window by hand — click into the ' +
-      'page and press 半角/全角, or pick ひらがな in the language bar — and ' +
-      're-run.');
+  await page.focus(`[data-testid="${CONDUCT_FIELD}"]`);
+  const sent = await driver.send('KEYS', hwnd, CONDUCT_KEY, keyDelayMs);
+  if (sent.status !== 'OK') {
+    return {
+      composed: false,
+      detail: `the driver would not send the probe key: ${sent.status} ` +
+        `${JSON.stringify(sent.payload)}`,
+    };
   }
-  if (!ime.native) {
-    console.log(`> IME is open but conversion=${ime.conversion} carries no ` +
-      'NATIVE bit; re-asserting Hiragana');
-    ime = await driver.require('IMECONV', hwnd);
-    console.log(`> IME after conversion re-assert: ${JSON.stringify(ime)}`);
+  await sleep(CONDUCT_SETTLE_MS);
+  const ev = W.compositionEvidence(await W.readEvents(page), CONDUCT_FIELD);
+  const field = await W.readField(page, CONDUCT_FIELD);
+  await driver.send('KEYS', hwnd, W.KEY_PLANS.abort.join(','), keyDelayMs);
+  await sleep(PROBE_SETTLE_MS);
+  await reload();
+  return {
+    composed: ev.compositionstart > 0,
+    detail: `one ${CONDUCT_KEY} into ${CONDUCT_FIELD} (scans ${sent.payload.scans}): ` +
+      `cs=${ev.compositionstart} cu=${ev.compositionupdate} ` +
+      `composingIn=${ev.composingInputs} settledIn=${ev.settledInputs} ` +
+      `process=${ev.processKeydowns} field=${JSON.stringify(field ? field.value : null)}`,
+  };
+}
+
+/**
+ * The bounded operator-assist wait: the rig has run out of things it can do
+ * about a closed IME, so it asks, and waits, and keeps asking the same
+ * question it would have asked itself.
+ *
+ * THE OPERATOR TOUCHING THE BROWSER WINDOW HERE IS EXPECTED, NOT
+ * CONTAMINATION. Nothing is in flight during the pause — the run sends no
+ * keystroke except the probe's own letter, and it re-reads the foreground
+ * immediately before each of those, so a poll that arrives while the operator
+ * is somewhere else sends nothing at all rather than typing into wherever
+ * they went. That is the opposite case to the per-key interlock in the
+ * driver, which exists for focus stolen from an UNATTENDED batch.
+ *
+ * Returns the engaged reading, or `null` on the deadline.
+ */
+async function awaitOperatorEngagement({ driver, hwnd, engine, probe, timeoutMs }) {
+  console.log(
+    `\n!!! ${engine.toUpperCase()}: THE IME IS NOT COMPOSING, and this rig has run out\n` +
+    '!!! of things it can do about it.\n' +
+    '!!!\n' +
+    '!!! PRESS 半角/全角 — or PICK ひらがな — IN THE BROWSER WINDOW NOW.\n' +
+    '!!! Click into the page first if it needs the focus.\n' +
+    '!!!\n' +
+    `!!! This is a designed pause of up to ${Math.round(timeoutMs / 1000)}s and NOTHING IS IN FLIGHT\n` +
+    '!!! during it: touching that window now is what the run is asking for.\n' +
+    '!!! It polls by typing one letter and reading the page for a\n' +
+    '!!! compositionstart, and it re-checks that the browser still holds the\n' +
+    '!!! foreground before each poll.\n');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const left = Math.max(0, Math.round((deadline - Date.now()) / 1000));
+    const ime = await driver.require('IMESTATE', hwnd);
+    if (!ime.isForeground) {
+      console.log(`> [${left}s left] the ${engine} window does not hold the ` +
+        'foreground, so nothing was sent. Click into it.');
+    } else {
+      const conduct = await probe();
+      console.log(`> [${left}s left] conduct probe: ${conduct.detail}`);
+      if (conduct.composed) {
+        const after = await driver.require('IMESTATE', hwnd);
+        console.log(`> ${engine} IME ENGAGED BY THE OPERATOR — it COMPOSED. ` +
+          `(IMM32 alongside, for the record only: ${fmtIme(after)})`);
+        return { ime: after, conduct };
+      }
+    }
+    await sleep(ASSIST_POLL_MS);
   }
-  if (!ime.native) {
-    throw new Error(
-      `the ${engine} window's IME is OPEN but NOT IN A NATIVE READING MODE: ` +
-      `IMC_GETCONVERSIONMODE reads ${ime.conversion}, which carries no ` +
-      'IME_CMODE_NATIVE bit, and an explicit Hiragana re-assert did not ' +
-      'change that. In alphanumeric mode the romaji below is typed straight ' +
-      'through and no composition starts, so the checks would measure ASCII. ' +
-      '(Firefox read conversion=0 on 2026-08-12.) Nothing was typed for this ' +
-      'engine. Set that window\'s IME to ひらがな by hand and re-run.');
+  return null;
+}
+
+/**
+ * Get this window's IME COMPOSING, or refuse the engine.
+ *
+ * A ladder of attempts, each one followed by the same conduct probe, because
+ * none of them can be trusted to have worked and the IMM32 reading that used
+ * to answer that question turned out to be reading this process's own
+ * writes (see the header). `state` is the reading `IMEON` already produced,
+ * and it is PRINTED rather than tested.
+ *
+ * The toggle is sent twice at most and the second is deliberate: it TOGGLES,
+ * so if the first one closed an IME that was already open, the second puts it
+ * back — and the probe between them is what tells those two apart.
+ *
+ * Throws with what it MEASURED in the message when the IME will not compose.
+ * That abort is the deliverable; the caller records the engine as not engaged
+ * and moves on. The alternative is typing romaji into a closed IME and
+ * reporting eight INCONCLUSIVEs that look like an engine result.
+ */
+async function engageIme({
+  driver, hwnd, engine, keyDelayMs, state, page, reload,
+  assistMs = ASSIST_TIMEOUT_MS,
+}) {
+  const probe = () => probeComposition({ page, driver, hwnd, keyDelayMs, reload });
+  console.log(`> IMM32 reports ${fmtIme(state)} — A LOG LINE, NOT A GATE: on ` +
+    '2026-08-12 it read back the values this rig had written while nothing ' +
+    'composed.');
+
+  const ladder = [
+    { what: 'as IMEON left it', act: async () => {} },
+    {
+      what: 'after IMECONV (ひらがな re-asserted)',
+      act: async () => { await driver.require('IMECONV', hwnd); },
+    },
+    {
+      what: `after ${IME_TOGGLE_KEY} (半角/全角) through SendInput`,
+      act: async () => {
+        await driver.require('KEYS', hwnd, IME_TOGGLE_KEY, keyDelayMs);
+        await sleep(IME_SETTLE_MS);
+      },
+    },
+    {
+      what: `after a second ${IME_TOGGLE_KEY} (undoing the first, if it closed one)`,
+      act: async () => {
+        await driver.require('KEYS', hwnd, IME_TOGGLE_KEY, keyDelayMs);
+        await sleep(IME_SETTLE_MS);
+      },
+    },
+  ];
+
+  let conduct = null;
+  for (const rung of ladder) {
+    await rung.act();
+    conduct = await probe();
+    console.log(`> conduct probe ${rung.what}: ${conduct.detail}`);
+    if (conduct.composed) {
+      const ime = await driver.require('IMESTATE', hwnd);
+      console.log(`> ${engine} IME ENGAGED — it COMPOSED. (IMM32 alongside, ` +
+        `for the record only: ${fmtIme(ime)})`);
+      return { ime, conduct };
+    }
   }
-  return ime;
+
+  const assisted = await awaitOperatorEngagement({
+    driver, hwnd, engine, probe, timeoutMs: assistMs,
+  });
+  if (assisted) return assisted;
+
+  const ime = await driver.require('IMESTATE', hwnd);
+  throw new Error(
+    `the ${engine} window's IME IS NOT COMPOSING. Its input locale is ` +
+    `${ime.langid} (japanese=${ime.japanese}) and it holds the foreground ` +
+    `(isForeground=${ime.isForeground}), but a single ${CONDUCT_KEY} typed ` +
+    `into the ${CONDUCT_FIELD} field produced NO compositionstart after ` +
+    `IMEON, an IMECONV, two ${IME_TOGGLE_KEY} (半角/全角) keystrokes and a ` +
+    `${Math.round(assistMs / 1000)}s wait for you to open it by hand. Last ` +
+    `reading: ${conduct.detail}. IMM32 says ${fmtIme(ime)}, and that is worth ` +
+    'nothing here: on 2026-08-12 it said open=1 conversion=9 native=true on ' +
+    'Chromium — the exact values this rig had written — while compositionstart ' +
+    'stayed 0 and the romaji landed as ASCII. Nothing was typed for this ' +
+    'engine and no check was driven.');
 }
 
 /**
@@ -955,54 +1127,6 @@ async function driveEngine(engine, baseUrl, driver, args) {
     await page.waitForSelector('[data-testid="hicasso-controlled-testbed"]',
       { timeout: MOUNT_TIMEOUT_MS });
 
-    // A nonce in the document title is how the OS side finds THIS window.
-    // Matching on "Hicasso" would match this terminal, an editor with the
-    // file open, or a second engine still on screen.
-    const nonce = `RF2-IME-${engine}-${Date.now().toString(36)}`;
-    await page.evaluate((t) => { document.title = t; }, nonce);
-    await sleep(400);
-    const found = await driver.send('FIND', b64(nonce));
-    if (found.status !== 'OK') {
-      throw new Error(
-        `could not find the ${engine} window by title nonce "${nonce}": ` +
-        `${JSON.stringify(found.payload)}. Nothing was typed.`);
-    }
-    hwnd = found.payload.hwnd;
-    console.log(`> window: hwnd=${hwnd} matches=${found.payload.matches} ` +
-      `title=${JSON.stringify(found.payload.title)}`);
-    if (found.payload.matches > 1) {
-      throw new Error(
-        `${found.payload.matches} windows answer to the nonce; refusing to ` +
-        'type into a window this run did not uniquely identify.');
-    }
-
-    if (inject) {
-      await driver.require('FOREGROUND', hwnd);
-      await driver.require('IMEON', hwnd);
-      imeState = await driver.require('IMESTATE', hwnd);
-      console.log(`> IME: ${JSON.stringify(imeState)}`);
-      if (!imeState.japanese) {
-        throw new Error(
-          `the ${engine} window's input locale is ${imeState.langid}, not 0x0411. ` +
-          'The Japanese IME did not engage, so every keystroke below would be ' +
-          'plain ASCII and every check would be measuring nothing. Switch the ' +
-          'input method for that window by hand (Win+Space) and re-run, or ' +
-          'install the Japanese IME first — Settings > Time & Language > ' +
-          'Language & region > Add a language > 日本語.');
-      }
-      // The locale switching is not the same thing as the IME opening, and
-      // 2026-08-12 is the run that proved it: 0x0411 on all three engines,
-      // shut on all three.
-      imeState = await engageIme({
-        driver, hwnd, engine, keyDelayMs: args.keyDelayMs, state: imeState,
-      });
-      console.log(`> IME ENGAGED: open=${imeState.open} ` +
-        `conversion=${imeState.conversion} native=${imeState.native}`);
-    } else {
-      imeState = await driver.require('IMESTATE', hwnd);
-      console.log(`> IME (read-only, rehearsal): ${JSON.stringify(imeState)}`);
-    }
-
     const reload = async () => {
       await page.reload({ waitUntil: 'commit', timeout: NAV_TIMEOUT_MS });
       await page.waitForSelector('[data-testid="hicasso-controlled-testbed"]',
@@ -1015,6 +1139,84 @@ async function driveEngine(engine, baseUrl, driver, args) {
       }
       return r;
     };
+
+    // THE PREPARE PHASE — find the window, engage its IME, or refuse THIS
+    // ENGINE. Every failure below is a statement about this window and this
+    // IME and nothing else, so it is caught HERE rather than thrown at the
+    // batch: on 2026-08-12 Firefox's honest abort took WebKit down with it,
+    // and the engine that never launched was one of the two this bead exists
+    // to record.
+    let refusal = null;
+    try {
+      // A nonce in the document title is how the OS side finds THIS window.
+      // Matching on "Hicasso" would match this terminal, an editor with the
+      // file open, or a second engine still on screen.
+      const nonce = `RF2-IME-${engine}-${Date.now().toString(36)}`;
+      await page.evaluate((t) => { document.title = t; }, nonce);
+      await sleep(400);
+      const found = await driver.send('FIND', b64(nonce));
+      if (found.status !== 'OK') {
+        throw new Error(
+          `could not find the ${engine} window by title nonce "${nonce}": ` +
+          `${JSON.stringify(found.payload)}. Nothing was typed.`);
+      }
+      hwnd = found.payload.hwnd;
+      console.log(`> window: hwnd=${hwnd} matches=${found.payload.matches} ` +
+        `title=${JSON.stringify(found.payload.title)}`);
+      if (found.payload.matches > 1) {
+        throw new Error(
+          `${found.payload.matches} windows answer to the nonce; refusing to ` +
+          'type into a window this run did not uniquely identify.');
+      }
+
+      // What the toggle would actually carry, resolved under THIS window's
+      // layout and read out before anything is sent. A `0x00` here is the
+      // defect of 2026-08-12 — `MapVirtualKey` answering for the driver's own
+      // English layout, where 半角/全角 is not a key — and it is the one part
+      // of the engage ladder the REHEARSAL can measure without typing.
+      const toggle = await driver.send('RESOLVE', IME_TOGGLE_KEY, hwnd);
+      if (toggle.status === 'OK') {
+        console.log(`> ${IME_TOGGLE_KEY} (半角/全角) resolves to vk ` +
+          `${toggle.payload.vks} scan ${toggle.payload.scans} under this ` +
+          "window's layout");
+      }
+
+      if (inject) {
+        await driver.require('FOREGROUND', hwnd);
+        await driver.require('IMEON', hwnd);
+        imeState = await driver.require('IMESTATE', hwnd);
+        if (!imeState.japanese) {
+          throw new Error(
+            `the ${engine} window's input locale is ${imeState.langid}, not 0x0411. ` +
+            'The Japanese IME did not engage, so every keystroke below would be ' +
+            'plain ASCII and every check would be measuring nothing. Switch the ' +
+            'input method for that window by hand (Win+Space) and re-run, or ' +
+            'install the Japanese IME first — Settings > Time & Language > ' +
+            'Language & region > Add a language > 日本語.');
+        }
+        // The locale is the one thing IMM32 answers honestly here — it is read
+        // off the window's own thread rather than out of an input context this
+        // process writes to. Everything past it is decided by conduct.
+        const engaged = await engageIme({
+          driver, hwnd, engine, keyDelayMs: args.keyDelayMs, state: imeState,
+          page, reload,
+        });
+        imeState = engaged.ime;
+      } else {
+        imeState = await driver.require('IMESTATE', hwnd);
+        console.log(`> IME (read-only, rehearsal): ${JSON.stringify(imeState)}`);
+      }
+    } catch (err) {
+      refusal = err.message;
+    }
+    if (refusal) {
+      console.log(`\n[ ] ${engine.toUpperCase()} NOT ENGAGED — no check was ` +
+        `driven and nothing was typed:\n      ${refusal}\n` +
+        '      Continuing to the next engine. This says nothing about any ' +
+        'other engine,\n      and nothing about this one either: it is a rig ' +
+        'result, not a runtime result.');
+      return { engine, build, hwnd, imeState, results: [], refusal, pageErrors };
+    }
 
     for (const check of W.CHECKS) {
       await reload();
@@ -1058,7 +1260,7 @@ async function driveEngine(engine, baseUrl, driver, args) {
     console.log(`> the page emitted ${pageErrors.length} uncaught error(s); ` +
       `first: ${pageErrors[0]}`);
   }
-  return { engine, build, hwnd, imeState, results, pageErrors };
+  return { engine, build, hwnd, imeState, results, refusal: null, pageErrors };
 }
 
 // ---------------------------------------------------------------------------
@@ -1101,6 +1303,12 @@ async function preflight(driver, args) {
 function reportEngine(run, date) {
   const summary = W.summarise(run.results);
   console.log(`\n--- ${run.engine} (${run.build}) ---`);
+  if (run.refusal) {
+    // Said here as well as where it happened, because the summary is the part
+    // that gets pasted into a bead, and "0 ticks" alone reads like an engine
+    // result rather than the rig refusing to produce one.
+    console.log(`  NOT ENGAGED, so no check ran: ${run.refusal}`);
+  }
   console.log(`  ticks: ${summary.ticks}  crosses: ${summary.crosses.length}  ` +
     `inconclusive: ${summary.inconclusive.length}  complete: ${summary.complete}`);
   console.log(`  dispositions.md §2.3 cell: ${W.dispositionCell(summary,
@@ -1219,11 +1427,17 @@ async function main() {
   }
 }
 
-// `engageIme` and `probeDelivery` are exported for the same reason `worst`
-// and `RUNNERS` are: they take their driver and their page as arguments, so
-// their REFUSALS can be forced and read back without an interactive desktop —
-// which is the only place the armed run they guard can ever happen.
-module.exports = { runMutationTeeth, parseArgs, worst, RUNNERS, engageIme, probeDelivery };
+// `engageIme`, `probeComposition` and `probeDelivery` are exported for the
+// same reason `worst` and `RUNNERS` are: they take their driver and their page
+// as arguments, so their REFUSALS can be forced and read back without an
+// interactive desktop — which is the only place the armed run they guard can
+// ever happen. `probeComposition` is the one that matters most: it is the gate
+// the whole engagement now rests on, and a gate whose refusal nobody has ever
+// seen fire is the gate that read `open: 1` on 2026-08-12.
+module.exports = {
+  runMutationTeeth, parseArgs, worst, RUNNERS, engageIme, probeComposition,
+  probeDelivery,
+};
 
 if (require.main === module) {
   main().then((code) => process.exit(code)).catch((error) => {


### PR DESCRIPTION
## The finding this repairs

The armed run of **2026-08-12** reported Chromium's IME as engaged — `open=1`, `conversion=9`, `native=true` — and
delivery probes 1/1. `compositionstart` stayed **0** on every check and the romaji landed as literal ASCII.

`conversion=9` is `IME_CMODE_HIRAGANA`: **the exact constant `RequestJapanese` had just written.** The IMM32 shim's
state is **write-through** — `IMC_GETOPENSTATUS` handed back the bit `IMC_SETOPENSTATUS` had set, on an input context
the TSF service was not reading. So the previous repair's gate, `require open:1`, proved only that a value had been
written. **It could not have failed** — a fail-open sitting inside the guard against one.

Confirmed at source: `RequestJapanese` writes `IMC_SETOPENSTATUS 1` and `IMC_SETCONVERSIONMODE IME_CMODE_HIRAGANA`
(= 9), and `ImeQuery` reads the matching GETs back off `ImmGetDefaultIMEWnd(hwnd)`. The reported values are the
written ones, bit for bit.

## The repair — four items

**1. Engagement is verified by CONDUCT.** `probeComposition` types **one romaji letter** into the `plain` field and
requires `compositionstart > 0` off the page's own observer, then ESCs it and reloads to restore the field. It is the
gate precisely because that event **cannot be faked by the thing under test**: the browser emits it in response to
input a real IME consumed, and no message this rig can send to an input context produces one. The IMM32 reading is now
printed with `— A LOG LINE, NOT A GATE` beside it and is never tested. `engageIme` became a ladder — as `IMEON` left
it → `IMECONV` → `kanji` → a second `kanji` — with the **same conduct probe after every rung**.

**2. The toggle keystroke.** `SendKey` resolved every scan with `MapVirtualKeyW`, which maps against the *driver
thread's* English layout, where `VK_KANJI` is not a key. Measured here:

```
MapVirtualKeyW  (0x19, VK_TO_VSC)             -> 0x00     <- every 半角/全角 sent on 2026-08-12
MapVirtualKeyExW(0x19, VK_TO_VSC, 0x04110411) -> 0x00     <- the brief's first route; also zero
```

**The brief's `MapVirtualKeyExW` route does not work for this key** — `VK_KANJI` is an IMM32 virtual key with no
physical key behind it in any layout table (the JIS 半角/全角 key reaches Windows as `VK_OEM_AUTO`). So `ScanFor` asks
the target window's HKL first, falls back to this thread's layout, and keeps a **literal `0x29`** under the IME toggle
beneath both — and the literal is the one that answers. The layout lookup still earns its place for the ordinary keys,
whose scans genuinely differ between layouts. `KEYS` now reports the scans it sent, and `RESOLVE` takes an optional
hwnd so the **rehearsal** can show the toggle carrying a real scan without typing:

```
> kanji (半角/全角) resolves to vk 0x19 scan 0x29 under this window's layout
```

**3. A bounded operator-assist wait.** 90s, polled by **re-running the conduct probe**. It prints what to press, and
the pause is designed rather than tolerated: **no keystrokes are in flight while it waits**, and `IMESTATE` is re-read
before every poll so a poll arriving while the operator is elsewhere sends *nothing at all* instead of typing into
wherever they went. That is the opposite case to the driver's per-key interlock, which exists for focus stolen from an
*unattended* batch.

**4. Engagement failure is PER-ENGINE.** Firefox's honest abort was a `throw` out of `main`'s engine loop, so WebKit
never launched — a rig defect, not honest conduct. The prepare phase is now caught at the engine boundary and recorded
`NOT ENGAGED` for that engine: no check driven, `results: []`, `complete: false`, cell **Not established**, and in an
armed run `incomplete > 0` still exits non-zero. The batch continues.

## Quality gates

| Command | Captured exit |
|---|---|
| `node scripts/run-hicasso-native-ime-witness.cjs --dry-run` (**the gate**, from `implementation/`) | **0** |
| `node scripts/run-hicasso-native-ime-witness.cjs --self-test` (what CI's `test:script-helpers` runs) | **0** |
| `npx eslint implementation/scripts/run-hicasso-native-ime-witness.cjs` | **0** |
| forced-refusal harness over the exported `engageIme` / `probeComposition` | **0** (10/10 bit) |
| `python scripts/check_fast_pr_gap.py --list` | **0** |
| PowerShell parser over `windows-ime-driver.ps1` | `PARSE OK` |

Dry run, on the committed bytes: **24 checks, all `[ ]` INCONCLUSIVE, 0 ticks, 0 crosses**, the
*"rig result, not a runtime result"* wording on all 24, `REHEARSAL COMPLETE` intact, and the toggle-scan line on all
three engines. `--self-test` reports **39 teeth** — unchanged.

The unarmed driver, smoked directly (no keystroke leaves it):

```
r3 OK {"tokens":"kanji","vks":["0x19"],"scans":["0x29"]}
r5 REFUSED KEYS needs -Armed; this driver was started unarmed (dry run)
```

**I did not take the witness.** `--inject` needs the operator's interactive desktop; the foreground interlock and the
`-Armed` switch are untouched.

### The forced refusals

**The conduct gate refuses the write-through state.** Driving the real exported `engageIme` with a stub driver
returning the exact 2026-08-12 reading (`open=1 conversion=9 native=true`) and a page whose event stream shows the
letter landing as settled ASCII:

```
> IMM32 reports open=1 conversion=9 native=true langid=0x0411 isForeground=true — A LOG LINE, NOT A GATE
> conduct probe as IMEON left it:            cs=0 cu=0 composingIn=0 settledIn=1 process=0 field="abcn"
> conduct probe after IMECONV:               cs=0 ...
> conduct probe after kanji (半角/全角):       cs=0 ...
> conduct probe after a second kanji:        cs=0 ...
  PASS  engageIme REFUSED an IME whose IMM32 state says open=1 conversion=9 native=true
  PASS  the refusal names conduct, not state
```

The positive control engages on `compositionstart` **while IMM32 reads `open=0 native=false`** — the two readings are
now fully decoupled, in both directions. The assist wait gave up inside its budget, and while the window did not hold
the foreground its poll added **no keystroke at all**.

**A not-engaged engine no longer kills the batch.** With `const inject` temporarily forced true, the unarmed driver
refuses `FOREGROUND` — the same shape as an engagement failure — and the real three-engine gate produced:

```
=================== CHROMIUM ===================
[ ] CHROMIUM NOT ENGAGED — no check was driven and nothing was typed:
      FOREGROUND 97464700 -> REFUSED "FOREGROUND needs -Armed; ..."
      Continuing to the next engine. ...
=================== FIREFOX ===================
[ ] FIREFOX NOT ENGAGED — ...
=================== WEBKIT ===================
[ ] WEBKIT NOT ENGAGED — ...

--- chromium/firefox/webkit ---  ticks: 0  crosses: 0  inconclusive: 0  complete: false
  dispositions.md §2.3 cell: **Not established** — ... The cell stays unfilled.
```

**All three engines launched and were identified.** Before this repair the first refusal threw out of the loop and
Firefox and WebKit would never have run — which is exactly what cost the 2026-08-12 run its WebKit result. The forced
line was reverted and the restore verified **by hashing the bytes**:

```
BEFORE  D57D5617BA1EB323C9FD984BE70ED6FA482D334207ADF67F5794E9E41ED12DA2  bytes=66897
AFTER   D57D5617BA1EB323C9FD984BE70ED6FA482D334207ADF67F5794E9E41ED12DA2  bytes=66897
RESTORE VERIFIED: byte-identical to the pre-experiment file
```

### What the fast-PR spine does not decide

`check_fast_pr_gap.py --list` names 97 required checks it does not run. For this diff the one that matters is
`test:script-helpers` (it runs `--self-test`, captured above) and `lint:js` (captured above). **Neither the spine nor
CI decides anything else here, and nothing can**: the witness proper needs Windows, an installed Japanese IME, a
visible desktop and the machine's keyboard. It stays locally-run and machine-bound — no CI lane was added or touched.

## Fences

- **Check semantics and verdict logic unchanged.** `native-ime-witness.cjs` is not in this diff; its 39 teeth are as
  they were.
- **No new mechanism, no CI lane.** Two files.
- **Honest-abort conduct kept**, now per engine: an engine that cannot be engaged says so and ticks nothing.
- **This PR does NOT close `rf2-hic-016`.** The close rule is unchanged — recorded Firefox and WebKit results in
  `dispositions.md` §2.3 — and this PR records **no disposition cell**. The bead stays **OPEN**.

## One thing that did not hold at source

`docs/design/hicasso/native-ime-scripted-witness.md` §7 says the verdict functions carry **35** mutation teeth; there
are **39** — `--self-test` prints the count, and the extra four are the audit-`#7896` edge pins the same doc does not
mention. Pre-existing drift, outside this PR's two-file fence, left for a ruling rather than folded in silently.
