### PR TITLE
docs(hicasso): h/fn, h/frame, numbered install, motion chapter

### DIFF
--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -315,7 +315,7 @@ the sites, emit the `defhost`, rewrite the call sites — and all three are by
 hand. The shipped migration codemod is a props-dialect **fixer**: it repairs the
 crossings you already have and leaves them `[:>]`, minting no declaration and
 hoisting nothing. The hoist that would mint them is demand-gated and unbuilt
-([the codemod](draft-guide/19-migration-from-reagent.md#4-apply-the-mechanical-codemod)).
+([the codemod](draft-guide/20-migration-from-reagent.md#4-apply-the-mechanical-codemod)).
 **The one raw escape** (HD-011), explicitly secondary to the declaration:
 `[:> Component props & children]` — same foreign lowering path, same default
 conversions, `.cljs`-only at that node, reduced structural identity; for

--- a/docs/design/hicasso/defhost-ssr-provider-costing.md
+++ b/docs/design/hicasso/defhost-ssr-provider-costing.md
@@ -618,5 +618,5 @@ server HTML that produced it.
   standing instruction that the escape grows no `:ssr` spelling of its own
 - [`draft-guide/09-interop.md`](draft-guide/09-interop.md) — the Defaults table
   and the Providers section
-- [`draft-guide/17-ssr-and-hydration.md`](draft-guide/17-ssr-and-hydration.md)
+- [`draft-guide/18-ssr-and-hydration.md`](draft-guide/18-ssr-and-hydration.md)
   — the tier's mismatch story and the `:ssr` teaching block

--- a/docs/design/hicasso/draft-guide/00-installation.md
+++ b/docs/design/hicasso/draft-guide/00-installation.md
@@ -1,9 +1,10 @@
 # Installation
 
-This page adds Hicasso to a browser build and mounts a small counter. The
-example establishes the three forms used throughout the guide:
-[`h/defview`](glossary.md#defview) for a view, [`h/sub`](glossary.md#hsub) for a
-subscription read, and event vectors for ordinary handlers.
+Chapter `00` of the Hicasso draft guide. This page adds Hicasso to a browser
+build and mounts a small counter. The example establishes the three forms used
+throughout the guide: [`h/defview`](glossary.md#defview) for a view,
+[`h/sub`](glossary.md#hsub) for a subscription read, and event vectors for
+ordinary handlers.
 
 ## Add the dependencies
 

--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -72,7 +72,7 @@ part of the tree, that region can move to native React or UIx while staying on
 the same frame and app-db. There is no `:fast` interpretation mode and no
 second meaning for `[...]`.
 
-[Performance](18-performance.md) defines the measurement method and
+[Performance](19-performance.md) defines the measurement method and
 [Native tier](10-native-tier.md) defines the crossing.
 
 ## Hicasso, Reagent, and UIx
@@ -113,7 +113,7 @@ state are covered in [Ephemeral state](11-ephemeral-state.md).
 | Calling a `defview` as `(todo-row {:id 7})` refuses and names the view | A Hicasso view is a React/Hiccup head, not an inline function | Mount it as `[todo-row {:id 7}]`; use a plain `defn` for an inline helper |
 | A plain helper written as `[row-icon props]` raises `:rf.error/hicasso-bad-head` | A plain function appeared in Hiccup head position | Call it as `(row-icon props)`, or define it with `h/defview` when it needs its own re-render boundary |
 | `h/sub` raises `:rf.error/hicasso-sub-outside-render` | The read ran outside the direct synchronous execution of a Hicasso view | Read inside the view body and pass or close over the realised value |
-| An event vector raises `:rf.error/hicasso-intent-outside-boundary` | The intent was lowered without a view/frame boundary | Keep it in Hiccup produced by a view, or use `h/event` at an explicit foreign callback edge |
+| An event vector raises `:rf.error/hicasso-intent-outside-boundary` | The intent was lowered without a view/frame boundary | Keep it in Hiccup produced by a view, or use `h/fn` at an explicit foreign callback edge |
 | A controlled field drops characters or moves the caret | The write path became asynchronous, or the field left Hicasso's controlled path | Dispatch the edit synchronously and follow [Controlled inputs](04-controlled-inputs.md) |
 
 ## When not to use Hicasso

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -311,7 +311,7 @@ tree needs its own subscription tracking or props bail-out, not merely because
 the source became long.
 
 If a measured region remains hot after fixing read placement and props
-stability, use the method in [Performance](18-performance.md) before moving it
+stability, use the method in [Performance](19-performance.md) before moving it
 to the native tier.
 
 ## Advanced

--- a/docs/design/hicasso/draft-guide/03-events-as-data.md
+++ b/docs/design/hicasso/draft-guide/03-events-as-data.md
@@ -88,52 +88,63 @@ The wrapper is represented in the vector rather than metadata because metadata
 does not participate in `=`, printing, or hashes. Structural tests and tools
 must be able to observe the prevention decision.
 
-## Use `h/event` when the arguments determine the event
+## One callback form: `h/fn`
 
-Some callback contracts provide values that cannot be expressed with the two
-markers: a file list, a drag payload, or a foreign component that calls
-`(on-change date)`. [`h/event`](glossary.md#hevent) creates a frame-aware
-callback whose body can inspect every argument and return an event vector:
+When a vector is not enough — a file list, drag payload, value-first foreign
+callback, or any calculation over the real arguments — use
+[`h/fn`](glossary.md#hfn). It expands to an **ordinary function**. The
+contract comes from the **position** where that function is written, not from
+a second API:
 
 ```clojure
 [:input {:type      "file"
-         :on-change (h/event [e]
+         :on-change (h/fn [e]
                       [:todo/attach
                        (js/Array.from (.. e -target -files))])}]
 ```
 
-The contract is the same in native and foreign callback positions:
+| Position | Contract for `h/fn` (and for an intent at that slot) |
+| --- | --- |
+| Native `:on-*` event prop | **event** — a returned vector is dispatched; other returns are ignored |
+| `defhost` `:callbacks` entry | As **declared** (`:event`, `:handler`, or `:render`) |
+| Other walked prop (for example a foreign render prop) | **render** — pure; return is output; dispatching inside is a loud error naming the position |
+| `defhost` prop with no callback claim, or a declared ReactNode slot | **none** — refused with `:rf.error/hicasso-host-unclaimed-callback` |
+| `:ref` | React's own contract; not lowered by Hicasso |
+| Positions Hicasso does not walk | Plain function behaviour |
 
-- `h/event` captures the current frame where it is created.
-- Its body receives every callback argument in the caller's order.
-- A returned vector is dispatched to the captured frame. Returning `nil`
-  dispatches nothing.
+Rules that follow:
+
+- `h/fn` captures the current frame where it is created.
+- The body receives every callback argument in the caller's order.
+- At an **event** position, a returned vector is dispatched; `nil` dispatches
+  nothing.
+- An `h/fn` body may do imperative browser work such as `.preventDefault`. The
+  `::h/prevent` wrapper is for the data-only intent form.
+- Ordinary unmarked functions remain legal and cross by identity, so there is
+  no second “identity-preserving” form.
 
 ```clojure
-[:div {:on-drop (h/event [e]
+[:div {:on-drop (h/fn [e]
                   (.preventDefault e)
                   (when-let [f (aget (.. e -dataTransfer -files) 0)]
                     [:todo/attach-dropped (.-name f)]))}]
 ```
 
-An `h/event` body owns imperative browser work such as `.preventDefault`; the
-`::h/prevent` wrapper is for the data-only intent form.
-
-The marker spelling assumes an event-first callback contract. It reads the DOM
+Marker-carrying intents assume an **event-first** invoker: they read the DOM
 event from argument one. A value-first foreign component has no event there,
 so a marker-carrying intent raises
-`:rf.error/hicasso-intent-needs-the-event`. Use `h/event` and name the
-component's arguments instead:
+`:rf.error/hicasso-intent-needs-the-event`. Use `h/fn` and name the real
+arguments:
 
 ```clojure
-(h/event [date _event]
+(h/fn [date _event]
   [:todo/set-due date])
 ```
 
 ## Ordinary functions remain available
 
-Use a normal function when the callback is imperative and does not represent a
-re-frame event:
+Use a normal function when the callback is imperative and does **not**
+represent a re-frame event:
 
 ```clojure
 [:canvas
@@ -143,8 +154,8 @@ re-frame event:
 ```
 
 Typical cases include pointer geometry, pointer capture, `stopPropagation`, or
-an SDK call. Foreign render props and slots also use ordinary functions; those
-functions run during a foreign render and must stay pure. Dispatching from a
+an SDK call that is not an application event. Foreign render props and slots
+also use ordinary functions when the position is pure; dispatching from a
 render position raises `:rf.error/hicasso-dispatch-in-render-position`.
 
 Do not hand-roll an ambient dispatch closure:
@@ -162,7 +173,7 @@ Do not hand-roll an ambient dispatch closure:
 ```
 
 The browser invokes the callback after the rendering extent has gone, so an
-ambient `rf/dispatch` has no frame. Intents and `h/event` capture that context
+ambient `rf/dispatch` has no frame. Intents and `h/fn` capture that context
 when the view is rendered.
 
 ## Keyboard maps
@@ -179,7 +190,7 @@ intent:
 
 Unlisted keys do nothing. The keys are strings, and keyboard maps are valid
 only at `:on-key-down` and `:on-key-up`. There is no modifier grammar; use
-`h/event` when the handler must inspect combinations such as Ctrl+Enter.
+`h/fn` when the handler must inspect combinations such as Ctrl+Enter.
 
 Keyboard maps also suppress application shortcuts during IME composition.
 Enter may be choosing a composition candidate and Escape may be cancelling the
@@ -187,15 +198,21 @@ composition, so neither should dispatch the application's commit or cancel
 intent. The runtime performs this check centrally, including legacy browser
 signals described under [Advanced](#advanced).
 
-## Frame-safe callbacks and foreign APIs
+## Frame-safe callbacks and `h/frame`
 
-Generated intent callbacks and `h/event` callbacks retain their view's frame.
-Async application work should normally move to the event/effect layer, where
-`:dispatch-later` and other effects already receive the frame.
+Generated intent callbacks and `h/fn` callbacks retain their view's frame.
+Application-owned async work should normally move to the event/effect layer,
+where an fx handler already receives the frame id in its context and
+`:dispatch-later` expresses delay as data.
 
-A remaining case is a dispatching closure retained by code you do not control,
-such as a vendor SDK attached through a ref. Capture the current frame during
-the view body:
+A Hicasso view body does **not** have ambient frame lookup. Zero-arity
+`(rf/capture-frame)` refuses under Hicasso's render discipline. The author-
+facing frame **read** is [`h/frame`](glossary.md#hframe): a plain function,
+legal only during a boundary body (or a render callback that boundary
+supplied), that returns the current frame **id keyword**. It is not a tracked
+subscription.
+
+The carry spelling is composition with core's capture primitive:
 
 ```clojure
 (ns app.map
@@ -204,7 +221,7 @@ the view body:
             [app.sdk :as sdk]))
 
 (h/defview map-panel [{:keys [id]}]
-  (let [{:keys [dispatch]} (rf/capture-frame)]
+  (let [{:keys [dispatch]} (rf/capture-frame (h/frame))]
     [:div.map
      {:ref (fn [node]
              (when node
@@ -213,22 +230,26 @@ the view body:
                  #(dispatch [:map/marker-selected id %]))))}]))
 ```
 
-`(rf/capture-frame)` returns
-`{:frame :dispatch :dispatch-sync :subscribe}` bound to the rendering frame.
-`(rf/current-frame-id)` returns only the id when a foreign API needs it.
-Ambient `rf/dispatch` and `rf/subscribe` do not contain a frame and therefore
-throw in these contexts.
+`(rf/capture-frame (h/frame))` returns
+`{:frame :dispatch :dispatch-sync :subscribe}` bound to that frame. Prefer this
+at a foreign edge you do not control — an SDK attach ref, a value-first
+callback, a host slot that retains a closure.
 
 A captured handle remains valid for that frame incarnation. Destroying the
 frame and creating another under the same id does not revive the old handle;
 using it raises `:rf.error/frame-destroyed` and does not reach the successor.
-Capture from the live render rather than keeping a global stash.
+Capture during the live render rather than keeping a global stash. Do not put
+the frame id into markup: on the server it is process-local identity and would
+break deterministic render-twice checks.
+
+Calling `h/frame` outside a Hicasso render extent raises
+`:rf.error/hicasso-frame-outside-boundary`.
 
 The practical rule is:
 
 - use an intent for an ordinary dispatching event
 - use an effect for application-owned async work
-- use `rf/capture-frame` for a closure retained by foreign code
+- use `(rf/capture-frame (h/frame))` for a closure retained by foreign code
 
 A link whose job is navigation belongs to the routing module's route-link
 surface rather than a custom click handler.
@@ -239,9 +260,10 @@ surface rather than a custom click handler.
 | --- | --- | --- |
 | A form dispatches and then reloads the page | Browser submission was not prevented | Use `{:on-submit [::h/prevent [:todo/submit]]}` |
 | Rendering reports a malformed prevent wrapper | `:rf.error/hicasso-malformed-prevent` | Wrap exactly one inner intent vector; do not nest decorators or add a second payload |
-| A handler receives the literal `::h/value` keyword | The marker was nested below the vector's top level | Keep the marker at top level or calculate the payload with `h/event`/the event handler |
-| A foreign callback rejects an intent that needs the event | `:rf.error/hicasso-intent-needs-the-event` | The callback is value-first. Use `h/event` and receive its actual arguments |
-| Dispatch from a timer or interval throws | `:rf.error/no-frame-context` | Move application async work to an effect. For foreign retention, capture the frame during rendering |
+| A handler receives the literal `::h/value` keyword | The marker was nested below the vector's top level | Keep the marker at top level or calculate the payload with `h/fn`/the event handler |
+| A foreign callback rejects an intent that needs the event | `:rf.error/hicasso-intent-needs-the-event` | The callback is value-first. Use `h/fn` and receive its actual arguments |
+| Dispatch from a timer or interval throws | `:rf.error/no-frame-context` | Move application async work to an effect. For foreign retention, capture with `(rf/capture-frame (h/frame))` during rendering |
+| `h/frame` raises `:rf.error/hicasso-frame-outside-boundary` | No Hicasso render extent | Call it only inside a view body or a render callback that body supplied |
 | Enter commits unfinished IME text | A hand-written key handler bypassed the keyboard map | Use the keyboard map so composition events are suppressed centrally |
 | An intent fires but no handler runs | `:rf.error/no-such-handler` | Require the namespace that registers the handler before mounting |
 | A vector is rejected at a host callback | `:rf.error/hicasso-intent-at-a-non-event-contract` | That host position is not declared as an event contract; supply the value its declaration requires |
@@ -254,7 +276,7 @@ Use a plain function when you need the callback arguments but no dispatch:
 pointer coordinates, `dataTransfer`, DOM measurement, `stopPropagation`, or an
 imperative SDK operation.
 
-Use `h/event` when the arguments are needed to decide which event vector to
+Use `h/fn` when the arguments are needed to decide which event vector to
 dispatch. An ordinary function is not an error; the intent form is simply the
 normal choice for declarative application interactions.
 

--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -15,7 +15,7 @@ the same browser turn and handles caret and IME behaviour for the normal
 No local atom or caret helper is required. `:on-change` uses the same path. If
 a field defines both handlers, both may fire and the runtime converges once.
 Checkboxes use [`::h/checked`](glossary.md#hchecked); file inputs use
-[`h/event`](glossary.md#hevent) because the platform owns their value.
+[`h/fn`](glossary.md#hfn) because the platform owns their value.
 
 ## The controlled-field contract
 
@@ -75,7 +75,7 @@ platform value:
 | Checkbox | `:checked` | `:on-change` with `::h/checked` |
 | Radio option | `:checked` for each option | `:on-change` carrying that option's value literally |
 | `:select` | `:value` on the select | `:on-change` with `::h/value` |
-| File input | no controlled value | `:on-change` with `h/event`, reading `.files` |
+| File input | no controlled value | `:on-change` with `h/fn`, reading `.files` |
 
 ```clojure
 [:select {:value     (h/sub [:todo.ui/priority])

--- a/docs/design/hicasso/draft-guide/06-lists-and-collections.md
+++ b/docs/design/hicasso/draft-guide/06-lists-and-collections.md
@@ -252,7 +252,7 @@ each view and their churn.
 | A bulk write runs every body despite equal-props memoization | Props contain a fresh function/JS object or fields that change but are not rendered | Use event vectors and persistent values; select only displayed fields |
 | Filtering is slow | Large oscillating dependency set or whole-table recomputation on each edit | Give rows stable reads, chunk the model, or move filtering into a subscription |
 | A plain function or JS component is rejected as a head | `:rf.error/hicasso-bad-head` | Use `h/defview` for Hicasso views and `h/defhost` for foreign components |
-| Virtualized rows render but interactions use the wrong frame or are inert | Render callback returned raw Hiccup or performed a deferred read | Return the row through `h/as-element`; read values before the callback; use `h/event` for callback-produced events |
+| Virtualized rows render but interactions use the wrong frame or are inert | Render callback returned raw Hiccup or performed a deferred read | Return the row through `h/as-element`; read values before the callback; use `h/fn` for callback-produced events |
 
 ## When not to tune or virtualize
 

--- a/docs/design/hicasso/draft-guide/07-routing-and-navigation.md
+++ b/docs/design/hicasso/draft-guide/07-routing-and-navigation.md
@@ -118,7 +118,7 @@ Use `:aria-current "page"` as the semantic state and a class for styling.
 
 A specific link may replace its navigation with another action, such as asking
 whether to discard a local scratch pane. Pass one of the supported veto forms
-as `:on-click`: `nil`, `[::h/prevent INTENT]`, an `h/event`, or a plain
+as `:on-click`: `nil`, `[::h/prevent INTENT]`, an `h/fn`, or a plain
 function.
 
 ```clojure
@@ -314,7 +314,7 @@ and activation pipeline as route links:
 | Rendering a route link raises `:rf.error/routing-artefact-missing` | The core routing artefact was not required before rendering | Require `re-frame.routing` during boot |
 | An in-app link performs a full page load | A hand-written anchor bypassed route interception | Use `route-link` or the documented document-level routing listener |
 | Rendering raises `:rf.error/hicasso-malformed-navigate` | Application code created or altered the reserved navigation head | Do not author `::h/navigate`; let `route-link` create it |
-| `route-link` rejects a bare `:on-click` vector | The click would produce two semantic events | Use `[::h/prevent [:app/event]]`, `h/event`, or a plain function according to the intended veto |
+| `route-link` rejects a bare `:on-click` vector | The click would produce two semantic events | Use `[::h/prevent [:app/event]]`, `h/fn`, or a plain function according to the intended veto |
 | `:prefetch` is rejected | The value is not `:intent` | Remove the key or use `:prefetch :intent` |
 | Every attempt to leave is rejected and the guard is named | `:rf.error/can-leave-non-boolean` | Return strict `true` or `false` from the guard subscription |
 | Back/Forward restores to the top | Scroll restoration ran before content restored page height | Block activation on required resources or keep previous content visible |

--- a/docs/design/hicasso/draft-guide/09-interop.md
+++ b/docs/design/hicasso/draft-guide/09-interop.md
@@ -20,7 +20,7 @@ with explicit callback, slot, and server contracts.
 (h/defview due-field [_]
   [date-picker
    {:selected  (h/sub [:task/due-date])
-    :on-change (h/event [date & _]
+    :on-change (h/fn [date & _]
                  [:task/set-due date])}])
 ```
 
@@ -73,19 +73,19 @@ infers a contract from an `on*` name.
 
 ### `:event`
 
-An event callback accepts an intent vector or `h/event`. The foreign component
-passes its own arguments in its documented order. Use `h/event` for a
+An event callback accepts an intent vector or `h/fn`. The foreign component
+passes its own arguments in its documented order. Use `h/fn` for a
 value-first callback such as `onChange(date)`:
 
 ```clojure
-(h/event [date _event]
+(h/fn [date _event]
   [:task/set-due date])
 ```
 
 A bare intent with no marker is valid even when no DOM event exists because it
 does not inspect callback arguments. A marker-bearing intent remains
 event-first; if argument one is not a DOM event, Hicasso raises
-`:rf.error/hicasso-intent-needs-the-event` and points to `h/event`.
+`:rf.error/hicasso-intent-needs-the-event` and points to `h/fn`.
 
 ### `:handler`
 
@@ -101,14 +101,14 @@ pure and must return a React element, not raw Hiccup:
 ```clojure
 [virtual-list
  {:item-count (count ids)
-  :render-row (h/event [i]
+  :render-row (h/fn [i]
                 (h/as-element
                  [:li.row
                   {:on-click [:feed/open (nth ids i)]}
                   (str (nth ids i))]))}]
 ```
 
-`h/as-element` converts the Hiccup result. `h/event` captures the supplying
+`h/as-element` converts the Hiccup result. `h/fn` captures the supplying
 view's frame, so event vectors inside that result later dispatch to the correct
 frame. Dispatching while the render callback itself runs raises
 `:rf.error/hicasso-dispatch-in-render-position`.
@@ -116,7 +116,7 @@ frame. Dispatching while the render callback itself runs raises
 A plain function is legal under any callback contract and passes through
 without a wrapper. It is enough when the callback returns a Hicasso view head
 whose frame is resolved where React renders it. If the callback's raw Hiccup
-contains event vectors, use `h/event`; otherwise conversion has no captured
+contains event vectors, use `h/fn`; otherwise conversion has no captured
 frame and raises `:rf.error/hicasso-intent-outside-boundary`.
 
 The declared contract always wins. Supplying an intent or key map to a
@@ -243,7 +243,7 @@ Declare a component once it appears more than once. The raw escape loses:
 | quarantine of JS require in a host namespace | require remains in the view namespace |
 
 An event vector at an `on*` prop raises
-`:rf.error/hicasso-host-undeclared-callback`; an `h/event` at any raw escape
+`:rf.error/hicasso-host-undeclared-callback`; an `h/fn` at any raw escape
 prop raises `:rf.error/hicasso-host-unclaimed-callback`. Both direct the author
 to `h/defhost` rather than allowing an inert array or unbound callback.
 

--- a/docs/design/hicasso/draft-guide/10-native-tier.md
+++ b/docs/design/hicasso/draft-guide/10-native-tier.md
@@ -59,7 +59,7 @@ React element:
         (h/sub [:quotes/display-row sym])]
     (n/$ :tr
          {:class    (if up? "quote up" "quote down")
-          :on-click (h/event [_]
+          :on-click (h/fn [_]
                       [:watchlist/select sym])}
          (n/$ :td {:class "sym"} sym)
          (n/$ :td {:class "px"} px)
@@ -80,7 +80,7 @@ Important syntax changes:
 
 - Hiccup selector shorthand has no native equivalent. Write class and id in
   props.
-- Native event props require functions. Use `h/event` in a rung-3 body to
+- Native event props require functions. Use `h/fn` in a rung-3 body to
   create a frame-aware callback; an event vector is rejected.
 - Native children are ReactNode values. Nest `n/$` forms. Convert a Hicasso
   subtree explicitly with `h/as-element`.
@@ -326,7 +326,7 @@ strategy.
 | --- | --- | --- |
 | A CLJS map is rejected as a React child | Dynamic map was not classified as props | Wrap the expression with `(n/props m)` |
 | A vector child is rejected inside `n/$` | Hiccup is not interpreted past the native fence | Convert with `h/as-element` or keep the subtree interpreted |
-| An event vector in a native prop is rejected | Native props require functions | Use `h/event` in a rung-3 body or dispatch from `n/use-frame` in an island |
+| An event vector in a native prop is rejected | Native props require functions | Use `h/fn` in a rung-3 body or dispatch from `n/use-frame` in an island |
 | `:children` in the props map is rejected | Native grammar has one trailing child channel | Move children after the props operand |
 | Two prop keys are rejected as a slot collision | Both normalize to one React slot | Keep one canonical spelling |
 | `n/use-sub` or `n/use-frame` raises `:rf.error/no-frame-context` | Component mounted outside a Hicasso frame provider | Mount under the application root or use the test kit's provider |

--- a/docs/design/hicasso/draft-guide/11-ephemeral-state.md
+++ b/docs/design/hicasso/draft-guide/11-ephemeral-state.md
@@ -19,12 +19,12 @@ Three re-frame2 properties depend on it.
 **Tests stay data-driven.** If “this dropdown is open” is stored at an app-db
 address, a headless test can seed that address directly. It does not need to
 mount a component, simulate a click, or wait for a timer
-([Testing](14-testing.md)).
+([Testing](15-testing.md)).
 
 **Diagnostics keep a complete cause chain.** Xray can connect an event to a
 state commit, subscription invalidation, view render, React commit, and paint.
 A private reactive store updates on a clock outside that chain
-([Diagnostics](15-diagnostics.md)).
+([Diagnostics](16-diagnostics.md)).
 
 **Frames remain isolated.** App-db is per-frame. A module-level atom is shared
 by every frame that mounts the code, which defeats frame isolation.
@@ -133,7 +133,7 @@ The rule at the edge is: **motion stays inside; meaning leaves as one event.**
   (let [title (h/sub [:card/title id])]
     (n/$ drag-surface
          {:label   title
-          :on-drop (h/event [col] [:card/dropped id col])})))
+          :on-drop (h/fn [col] [:card/dropped id col])})))
 ```
 
 Pointer movement remains local React state. The completed drop is an
@@ -156,55 +156,22 @@ commit on blur. The tradeoff is explicit: app-db, tests, and tools cannot see
 mid-edit text ([Controlled inputs](04-controlled-inputs.md)).
 
 **Platform controls** may own a presentational toggle, such as a native
-popover triggered by `:popovertarget` ([Overlays and focus](12-overlays-and-focus.md)).
+popover triggered by `:popovertarget` ([Overlays and focus](13-overlays-and-focus.md)).
 
 DOM ownership is a local design choice, not a hidden replacement for
 application state. When validation, another view, routing, or testing needs the
 fact, move it to app-db.
 
-## 5. Exit presence: what is still painted
+## 5. Exit retention: pixels that outlive data
 
-App-db records what is true. A dismissed toast should disappear from app-db
-immediately, but its DOM node may need another 300 ms to finish an exit
-animation. `re-frame.hicasso.motion` owns that gap.
+App-db records what is true. A dismissed toast should leave app-db immediately,
+but its DOM node may need a short exit animation. That gap is **not**
+ephemeral application state — it is paint retention.
 
-```clojure
-;; (:require [re-frame.hicasso.motion :as motion])
-(h/defview toast-tray [_]
-  [motion/presence {:timeout-ms 300}
-   (for [t (h/sub [:toasts/visible])]
-     [:div.toast
-      {:key (:id t)
-       ::motion/unmounting
-       {:class       "toast toast--exit"
-        :inert       true
-        :aria-hidden true}}
-      (:message t)])])
-```
-
-The exit class, `:inert`, and `:aria-hidden` arrive together. An exiting node
-is still in the document until the timeout ends, so it must stop accepting
-focus and interaction explicitly.
-
-When the child is a view, presence cannot merge attributes into the opaque
-view head. The view instead receives `:rf/phase` with one of
-`:mounting`, `:present`, or `:unmounting`, and branches on that ordinary prop.
-Tests can pass the phase directly without timers.
-
-Presence follows these rules:
-
-- `:timeout-ms` is required and is the hard upper bound. Removal does not wait
-  for `transitionend`, so disabled or overridden CSS cannot strand the node.
-- Re-entry cancels exit. A returning key becomes `:present` without remounting.
-- Order is frozen at first appearance, so an exiting child does not move while
-  it leaves.
-- Presence does not dispatch an event or keep the removed data in app-db.
-
-For entrances, prefer an insertion animation or `@starting-style`.
-`::motion/mounting` is for attributes that are true during entry, such as
-`:inert` until an element settles. Under SSR, a presence-managed server node
-hydrates as already present; the server HTML does not carry entry-phase
-attributes ([SSR and hydration](17-ssr-and-hydration.md)).
+Use the optional [`re-frame.hicasso.motion`](12-motion-and-presence.md) module
+and `motion/presence`. That chapter owns the API, phase markers
+(`::h/mounting` / `::h/unmounting`), the view `:rf/phase` prop, SSR behaviour,
+and accessibility attributes for exiting nodes.
 
 ## Common state and its owner
 
@@ -214,7 +181,7 @@ attributes ([SSR and hydration](17-ssr-and-hydration.md)).
 | Field draft | App-db through the forms module | Validation, submit gating, dirty-leave, and replay read it |
 | Drag position during a drag | Native host state | High-rate mechanics; dispatch the completed drop once |
 | Scroll offset | DOM; routing restores it per route | Do not re-render for every pixel. Commit meaningful thresholds as events when needed |
-| Animation phase | CSS for animation; `motion/presence` for exit retention; host state for rAF mechanics | App-db records truth, not what is still painted |
+| Animation / exit retention | CSS for animation; [`motion/presence`](12-motion-and-presence.md) for exit retention; host state for rAF mechanics | App-db records truth, not what is still painted |
 | Focus | Browser focus, changed through one-shot focus actions | A mirrored “focused element” value drifts and would update on every Tab |
 | Selected tab | App-db, or routing when it should survive reload | Other views, tests, or deep links care |
 | WebGL context or SDK handle | Declared host or native component | It is an object identity with an attach/teardown lifecycle, not application data |
@@ -245,8 +212,8 @@ already has a more specific owner:
 | Job | Use |
 | --- | --- |
 | Load data for a screen | Route `:resources` or a demand-driven resource ([Routing](07-routing-and-navigation.md), [Async resources](08-async-resources.md)) |
-| Run startup work once | `:initial-events`, before first paint ([Installation](installation.md)) |
-| Animate an entrance or exit | CSS or `motion/presence` |
+| Run startup work once | `:initial-events`, before first paint ([Installation](00-installation.md)) |
+| Animate an entrance or exit | CSS or [`motion/presence`](12-motion-and-presence.md) |
 | Attach to a DOM node or SDK | A callback ref or declared host ([Interop](09-interop.md)) |
 
 ## When app-db is the wrong place
@@ -272,7 +239,7 @@ Everything else is application state and should have one app-db address.
 
 ;; Don't: one event, subscription pass, and paint for every pointer move.
 :on-pointer-move
-(h/event [e] [:card/drag-moved id (.-clientX e) (.-clientY e)])
+(h/fn [e] [:card/drag-moved id (.-clientX e) (.-clientY e)])
 ```
 
 ## Troubleshooting
@@ -283,15 +250,13 @@ Everything else is application state and should have one app-db address.
 | A view-local atom resets or never repaints the view | The body can re-run or be abandoned, and Hicasso does not subscribe to the atom | Move the fact to app-db; move genuine widget mechanics into a native component |
 | You are looking for `:on-mount`, `componentDidMount`, or a mount effect | Hicasso has no generic lifecycle hook | Identify the job and use the owner in the table above |
 | Every panel opens at once | All instances share one address | Include a stable instance key in the address |
-| Typing or dragging lags and Xray shows an event per pointer move | High-rate mechanics were routed through app-db | Keep motion inside the host and dispatch only the semantic result |
-| Exit override on a view raises `:rf.error/hicasso-presence-override-on-a-view` | Presence can merge attributes into visible nodes, not opaque view heads | Branch on the child's `:rf/phase` prop |
-| A fading toast still accepts focus or clicks | The unmounting override changes appearance only | Add `:inert true` and `:aria-hidden true` with the exit class |
-| A dismissed item vanishes immediately | The node left with the data | Wrap keyed children in `motion/presence` and set `:timeout-ms` at least as long as the exit transition |
+| Typing or dragging lags and Xray shows an event per pointer move | High-rate mechanics were routed through app-db | Keep pointer mechanics inside the host and dispatch only the semantic result |
+| A dismissed item vanishes before its CSS exit finishes | Exit retention was treated as app-db state, or Presence was not used | See [Motion and presence](12-motion-and-presence.md) |
 | app-db accumulates many `:ui` entries | Application-visible UI state is correctly stored there | Namespace the slice and exclude it from persistence when appropriate |
-| A test simulates clicks only to open a dropdown | The open flag is data | Seed the address directly in the test ([Testing](14-testing.md)) |
+| A test simulates clicks only to open a dropdown | The open flag is data | Seed the address directly in the test ([Testing](15-testing.md)) |
 
 ??? info "Coming from Reagent"
     `r/atom` solved a view-local reactivity problem that Hicasso does not
     create. Put semantic state at addresses, drafts in the forms model,
     mechanics in hosts, browser-owned facts in the DOM, and exit retention in
-    `motion/presence`.
+    [Motion and presence](12-motion-and-presence.md).

--- a/docs/design/hicasso/draft-guide/12-motion-and-presence.md
+++ b/docs/design/hicasso/draft-guide/12-motion-and-presence.md
@@ -1,0 +1,212 @@
+# Motion and presence
+
+Hicasso does not ship an animation system. CSS owns transitions and keyframes.
+The compositor interpolates them. A native host owns high-rate mechanics such as
+drag positions and spring integrators. Exactly one gap remains: **React removes
+a node as soon as its data leaves app-db**, and a node that is gone cannot
+finish an exit animation.
+
+`re-frame.hicasso.motion` closes that gap. It is an optional module. An
+application that never requires it carries none of its code.
+
+```clojure
+(ns app.toasts
+  (:require [re-frame.hicasso :as h]
+            [re-frame.hicasso.motion :as motion]))
+```
+
+## The problem in one example
+
+A toast should leave app-db the moment the user dismisses it. Tests, Xray, and
+other views must see the toast as gone. The painted element may still need
+300 ms of CSS exit transition.
+
+If the view simply maps over the subscription, the DOM node disappears on the
+same turn as the event:
+
+```clojure
+;; Don't — the node vanishes with the data; CSS has nothing left to animate.
+(h/defview toast-tray [_]
+  [:div.toast-tray
+   (for [t (h/sub [:toasts/visible])]
+     [:div.toast {:key (:id t)}
+      (:message t)
+      [:button {:on-click [:toasts/dismiss (:id t)]} "×"]])])
+```
+
+Presence keeps the exiting node for a stated timeout while app-db already
+records the dismissal.
+
+## The taught spelling
+
+```clojure
+(h/defview toast-tray [_]
+  [motion/presence {:timeout-ms 300}
+   (for [t (h/sub [:toasts/visible])]
+     [:div.toast
+      {:key            (:id t)
+       ::h/unmounting  {:class       "toast toast--exit"
+                        :inert       true
+                        :aria-hidden true}}
+      (:message t)
+      [:button {:on-click [:toasts/dismiss (:id t)]} "×"]])])
+```
+
+What happens:
+
+1. The user dismisses toast `7`. The handler removes it from app-db.
+2. Presence still has a child with key `7`. That child enters the **unmounting**
+   phase.
+3. Presence merges `::h/unmounting` attributes onto the real element. The exit
+   class starts the CSS transition; `:inert` and `:aria-hidden` stop interaction
+   and hide the node from assistive tech while it is still painted.
+4. After 300 ms Presence removes the child. Removal is **timer-based**, not
+   `transitionend`. Disabled CSS cannot strand the node forever.
+
+App-db never stores “still animating.” The retention is a paint concern owned
+by Presence.
+
+## Module posture
+
+Presence owns **retention and phase**, nothing else:
+
+| Belongs to Presence | Does **not** belong to Presence |
+| --- | --- |
+| Keeping a keyed child after its data leaves | Easing curves, springs, keyframe APIs |
+| Applying mounting/unmounting attribute overrides | Timelines, sequences, orchestrators |
+| A hard `:timeout-ms` terminal bound | `transitionend` subscriptions |
+| Cancelling exit when a key re-enters | Gesture or drag state |
+
+High-rate motion stays in a native host or CSS. Host those mechanics with
+[`h/defhost`](09-interop.md) or the [native tier](10-native-tier.md); do not
+route pointer-move events through app-db.
+
+## API
+
+### `motion/presence`
+
+A Hiccup head. Props:
+
+| Prop | Required | Meaning |
+| --- | --- | --- |
+| `:timeout-ms` | **yes** | How long an exiting child is retained. Also the hard stop for removal. |
+
+Children must be keyed. Presence freezes order at first appearance so an
+exiting sibling does not jump while it leaves.
+
+Presence inserts **no wrapper DOM node** and stamps no `data-*`. Each child is
+the author's node with the author's attributes merged for the active phase.
+
+### Phase overrides on elements
+
+On a native element child, write overrides with the Hicasso markers:
+
+```clojure
+[:div.card
+ {:key           id
+  ::h/mounting   {:class "card card--enter" :inert true}
+  ::h/unmounting {:class "card card--exit"  :inert true :aria-hidden true}}
+ body]
+```
+
+| Marker | When applied |
+| --- | --- |
+| `::h/mounting` | While the child is entering (first paint of a new key) |
+| `::h/unmounting` | While the child is retained after its key left the live set |
+
+These markers live in the `re-frame.hicasso` keyword namespace (`::h/...` when
+you alias the door as `h`). The motion **module** is separate; the markers are
+shared vocabulary, not `::motion/...` keys.
+
+Prefer CSS insertion animations or `@starting-style` for simple entrances.
+Use `::h/mounting` when the node must carry attributes such as `:inert` until
+it settles.
+
+### Phase prop on views
+
+Presence cannot merge attributes into an opaque [`h/defview`](glossary.md#defview)
+head. When the child is a view, Presence passes an ordinary prop:
+
+```clojure
+(h/defview toast-item [{:keys [id message rf/phase]}]
+  (let [exiting? (= phase :unmounting)]
+    [:div.toast
+     {:class (cond-> "toast" exiting? (str " toast--exit"))
+      :inert       exiting?
+      :aria-hidden exiting?}
+     message
+     (when-not exiting?
+       [:button {:on-click [:toasts/dismiss id]} "×"])]))
+
+(h/defview toast-tray [_]
+  [motion/presence {:timeout-ms 300}
+   (for [t (h/sub [:toasts/visible])]
+     [toast-item {:key     (:id t)
+                  :id      (:id t)
+                  :message (:message t)}])])
+```
+
+`:rf/phase` is one of `:mounting`, `:present`, or `:unmounting`. Tests can pass
+the prop directly without arming timers.
+
+Putting `::h/unmounting` on a view head raises
+`:rf.error/hicasso-presence-override-on-a-view`.
+
+## Rules that matter in production
+
+- **`:timeout-ms` is mandatory.** It is both retention length and the hard
+  terminal bound.
+- **Re-entry cancels exit.** A key that returns while unmounting becomes
+  `:present` on the same node — no remount, no second deadline.
+- **Unmount clears timers.** Leaving the page mid-transition does not leave
+  dangling timers.
+- **Per-frame work is zero.** Presence arms timers at phase changes; it does
+  not run `requestAnimationFrame` or write state every frame. CSS owns the
+  visual interpolation.
+- **SSR.** A presence-managed server node hydrates as already present. The
+  server HTML does not carry entry-phase attributes
+  ([SSR and hydration](18-ssr-and-hydration.md)).
+- **Accessibility.** While unmounting, set `:inert` and `:aria-hidden` (or the
+  equivalent on a view via `:rf/phase`) so a fading node does not keep focus or
+  announce itself ([Accessibility](22-accessibility.md)).
+
+## What Presence does not do
+
+- It does not dispatch an event when a transition ends.
+- It does not keep the removed domain data in app-db.
+- It does not replace CSS, the Web Animations API, or a hosted animation
+  library.
+- It does not own open/closed UI truth. That is still app-db
+  ([Ephemeral state](11-ephemeral-state.md)).
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Dismissed item vanishes immediately | Children are not under Presence, or keys are missing | Wrap the keyed sequence in `motion/presence` and give every child a stable `:key` |
+| Node stays forever after dismiss | `:timeout-ms` omitted or far longer than the CSS | Set `:timeout-ms` to at least the CSS duration; it is required |
+| Fading toast still takes focus or clicks | Exit class changes appearance only | Add `:inert true` and `:aria-hidden true` under `::h/unmounting` (or via `:rf/phase` on a view) |
+| Override on a view raises `:rf.error/hicasso-presence-override-on-a-view` | Presence cannot merge into a boundary head | Branch on `:rf/phase` inside the view |
+| Exit restarts on every parent re-render | Unstable keys | Key by domain id, not index |
+| Bundle still contains motion code when unused | Something required the module | Require `re-frame.hicasso.motion` only where Presence is used |
+
+## When not to use Presence
+
+- No exit animation — just remove the data; no module required.
+- The fact is application-visible (open, selected, draft) — store it in app-db,
+  not as a phase.
+- Continuous pointer or layout motion — use a native host or CSS, not Presence.
+
+## Advanced
+
+### Optional module reachability
+
+`re-frame.hicasso` does not import `re-frame.hicasso.motion`. That keeps the
+retention machine out of applications that never ask for it. A check in the
+Hicasso package fails if the public door re-acquires a hard dependency on the
+module.
+
+### Phase vocabulary freeze
+
+The override markers remain `::h/mounting` and `::h/unmounting` until the
+naming ledger freezes any respell. Guide examples use those shipped keys.

--- a/docs/design/hicasso/draft-guide/13-overlays-and-focus.md
+++ b/docs/design/hicasso/draft-guide/13-overlays-and-focus.md
@@ -126,7 +126,7 @@ A modal gives you the platform's modal behaviour:
 
 Light-dismiss defaults to false for modals so a destructive confirmation does
 not close on a stray backdrop click. Style the native backdrop with
-`::backdrop` CSS ([Theming and internationalisation](13-theming-and-i18n.md)).
+`::backdrop` CSS ([Theming and internationalisation](14-theming-and-i18n.md)).
 
 ## Focus behaviour
 

--- a/docs/design/hicasso/draft-guide/14-theming-and-i18n.md
+++ b/docs/design/hicasso/draft-guide/14-theming-and-i18n.md
@@ -83,10 +83,10 @@ Place the scope carefully:
 - **Place the scope above foreign crossings.** A Client-only host can replace
   its subtree with a fallback on the server. A theme scope beneath that host
   would be absent from the server response
-  ([SSR and hydration](17-ssr-and-hydration.md)).
+  ([SSR and hydration](18-ssr-and-hydration.md)).
 
 Restore a persisted choice through `:initial-events` so it reaches app-db
-before first paint ([Installation](installation.md)). The default applies only
+before first paint ([Installation](00-installation.md)). The default applies only
 when no preference has been chosen.
 
 A theme class works the same way:
@@ -125,7 +125,7 @@ reason not to.
 The browser's top layer does not need a document echo. An overlay's
 `::backdrop` inherits custom properties from the element that opened it, so a
 modal inside `theme-scope` receives the same tokens
-([Overlays and focus](12-overlays-and-focus.md)).
+([Overlays and focus](13-overlays-and-focus.md)).
 
 ## Treat translated strings as values
 
@@ -248,7 +248,7 @@ React side; your own application theme still uses CSS.
 | A theme switch re-runs the whole application | The content below the scope has no independent view boundary | Put a `defview` head such as `[app {}]` immediately below the scope |
 | Some strings remain in the old locale | They were computed at load time, stored in a `def`, or otherwise captured outside render | Read them where used with `(h/sub [:i18n/t k])` |
 | A missing translation displays the key name | The translation fallback is working | Add the key to the selected locale table |
-| Hydration keeps the server's theme | The hydration payload omitted `:theme/current`; attribute-only divergence may not produce a useful React warning | Include the theme choice in the hydration payload ([SSR and hydration](17-ssr-and-hydration.md)) |
+| Hydration keeps the server's theme | The hydration payload omitted `:theme/current`; attribute-only divergence may not produce a useful React warning | Include the theme choice in the hydration payload ([SSR and hydration](18-ssr-and-hydration.md)) |
 
 ## When not to add this machinery
 

--- a/docs/design/hicasso/draft-guide/15-testing.md
+++ b/docs/design/hicasso/draft-guide/15-testing.md
@@ -323,13 +323,13 @@ work that has an actual duration; use `hm/settle!` for work that does not.
 
 Examples include:
 
-- a real error boundary catching a real throw ([Errors](16-errors.md));
+- a real error boundary catching a real throw ([Errors](17-errors.md));
 - StrictMode double invocation or an abandoned render;
 - keyed insertion, deletion, and reorder against real nodes;
 - a foreign component's hooks, context, and refs ([Interop](09-interop.md));
 - Activity hide and reveal, including subscription release and reacquisition;
 - hydration through `hm/hydrate!`
-  ([SSR and hydration](17-ssr-and-hydration.md)).
+  ([SSR and hydration](18-ssr-and-hydration.md)).
 
 `hm/assert-clean!` requires zero additional residue after unmount. A surviving
 subscription, listener, scheduled task, or retained callback is a bug. Do not
@@ -349,14 +349,14 @@ browser engine:
 
 Controlled-input composition is a canonical L4 case
 ([Controlled inputs](04-controlled-inputs.md)). Performance scripts and
-budgets belong to [Performance](18-performance.md).
+budgets belong to [Performance](19-performance.md).
 
 ## Migration shadow tests
 
 `ht/shadow!` is a development-only migration harness. It drives a Hicasso view
 and its Reagent original with one script, then compares canonical DOM and
 intent streams at each checkpoint. Its full use belongs to
-[Migrating from Reagent](19-migration-from-reagent.md).
+[Migrating from Reagent](20-migration-from-reagent.md).
 
 ## Prevent vacuous tests with a sabotage twin
 
@@ -422,7 +422,7 @@ Do not claim more than the level proves:
 - a semantic tree does not prove server or hydration bytes;
 - a DOM test in one engine does not prove cross-browser IME or focus;
 - a timing assertion is not a performance test until it follows the method in
-  [Performance](18-performance.md).
+  [Performance](19-performance.md).
 
 ## Advanced
 
@@ -450,6 +450,6 @@ Use canonical DOM when comparing:
 
 - before and after a refactor;
 - a Hicasso port with its Reagent original
-  ([Migrating from Reagent](19-migration-from-reagent.md));
+  ([Migrating from Reagent](20-migration-from-reagent.md));
 - a native island with the interpreted subtree it replaced
   ([The native tier](10-native-tier.md)).

--- a/docs/design/hicasso/draft-guide/16-diagnostics.md
+++ b/docs/design/hicasso/draft-guide/16-diagnostics.md
@@ -100,7 +100,7 @@ measured owner. If lowering is 4% of an interaction, a lowering escape cannot
 recover more than that 4%.
 
 Xray recommends; it does not rewrite or promote code automatically. Any native
-escape must pass the benefit thresholds in [Performance](18-performance.md).
+escape must pass the benefit thresholds in [Performance](19-performance.md).
 
 ## Incomplete evidence is reported explicitly
 
@@ -133,8 +133,8 @@ Examples from the guide:
 | `:rf.error/hicasso-sub-outside-render` | A subscription read ran after every render context had ended | Read during the body and close over the value; handlers declare state as coeffects |
 | `:rf.error/hicasso-deferred-read-at-boundary` | An unforced `delay` carrying a read tried to leave a view | Force it in the body or pass the realised value |
 | `:rf.error/hicasso-bad-head` | A plain `defn` appeared in Hiccup head position | Call it inline or define a view with `h/defview` |
-| `:rf.error/hicasso-intent-outside-boundary` | An event intent reached a position with no frame | Keep it under a view boundary; use `h/event` at a foreign callback edge |
-| `:rf.error/hicasso-host-unclaimed-callback` | `h/event` was passed to a host prop with no callback contract | Declare the prop in `:callbacks` |
+| `:rf.error/hicasso-intent-outside-boundary` | An event intent reached a position with no frame | Keep it under a view boundary; use `h/fn` at a foreign callback edge |
+| `:rf.error/hicasso-host-unclaimed-callback` | `h/fn` was passed to a host prop with no callback contract | Declare the prop in `:callbacks` |
 | `:rf.error/hicasso-revision-not-controlled` | `::h/revision` appeared on a non-controlled field | Control the text field or remove the revision |
 | `:rf.warning/hicasso-missing-key` | A sequence child has no `:key` | Put a stable key in each member's props map |
 | `:rf.error/frame-destroyed` | An operation captured from a destroyed frame incarnation fired later | Drop the stale handle and capture from the current frame |
@@ -191,7 +191,7 @@ grep -c "rf.xray" public/js/main.js    # expect 0
 
 The development search must find the sentinel. Zero in both files means the
 search is ineffective, not that production erasure has been demonstrated.
-This is the sabotage-control principle from [Testing](14-testing.md).
+This is the sabotage-control principle from [Testing](15-testing.md).
 
 Application behaviour must never depend on diagnostics. Do not branch on
 whether evidence exists, count warnings as product data, or read panel state
@@ -206,7 +206,7 @@ from application code.
 | A foreign subtree shows `:host-opaque` | Raw React internals are not visible beyond the crossing | Use Xray for the crossing and React DevTools for its inner tree |
 | History ends with `:cap` | The bounded retention window discarded old epochs | Reproduce the issue and capture it again |
 | The advisor will not recommend a native island | The measured owner is not a cost native code fixes | Apply the smaller remedy it names and re-measure |
-| Repeated runs have different timings | Xray timing is diagnostic attribution, not a controlled benchmark | Use the cost classification; benchmark under [Performance](18-performance.md) |
+| Repeated runs have different timings | Xray timing is diagnostic attribution, not a controlled benchmark | Use the cost classification; benchmark under [Performance](19-performance.md) |
 | A complaint id has no catalogue entry | The id belongs to another namespace, or application and test-kit versions differ | Check the namespace and align installed versions |
 | Panels are empty in a release build | Diagnostics were erased as designed | Diagnose with a development build |
 
@@ -214,14 +214,14 @@ from application code.
 
 Xray identifies the cost owner and the likely class of remedy. It does not
 answer whether an interaction meets a production budget. Use the measurement
-method in [Performance](18-performance.md) for that.
+method in [Performance](19-performance.md) for that.
 
 Use React DevTools for commit-level React details and browser performance tools
 for layout and paint. Profile release builds for production slowness; a
 development build intentionally contains development work.
 
 When the question is correctness rather than cause, write a test
-([Testing](14-testing.md)).
+([Testing](15-testing.md)).
 
 ## Advanced
 

--- a/docs/design/hicasso/draft-guide/17-errors.md
+++ b/docs/design/hicasso/draft-guide/17-errors.md
@@ -228,7 +228,7 @@ level that preserves it.
 | Retry intent in the fallback raises `:rf.error/hicasso-intent-outside-boundary` | The fallback was rendered outside the mounted Hicasso/frame tree | Keep fallback Hiccup inside the boundary and use an ordinary event intent |
 | A panel fallback throws and the larger page fallback appears | The fallback itself failed and the next outer boundary caught it | Keep fallbacks small and avoid re-reading the failed state |
 | `:on-error` appears to fire twice in development | Two distinct failures occurred; StrictMode alone still produces one report per catch | Inspect the two error records and their causes |
-| A server-render throw is not caught by the client boundary | Server rendering uses the server error channel; a client error boundary cannot handle server execution | Apply the surface's server policy and server error handling ([SSR and hydration](17-ssr-and-hydration.md)) |
+| A server-render throw is not caught by the client boundary | Server rendering uses the server error channel; a client error boundary cannot handle server execution | Apply the surface's server policy and server error handling ([SSR and hydration](18-ssr-and-hydration.md)) |
 
 ## When not to use an error boundary
 

--- a/docs/design/hicasso/draft-guide/18-ssr-and-hydration.md
+++ b/docs/design/hicasso/draft-guide/18-ssr-and-hydration.md
@@ -263,7 +263,7 @@ The app root can still hydrate cleanly. Each `h/hydrate!` has its own
 recoverable, caught, and uncaught error channels.
 
 Xray associates hydration complaints with the root, view source, and host
-policy ([Diagnostics](15-diagnostics.md)).
+policy ([Diagnostics](16-diagnostics.md)).
 
 React reports text differences and missing, extra, or wrong-type elements.
 Attribute-only divergence may produce only a development warning and can be

--- a/docs/design/hicasso/draft-guide/19-performance.md
+++ b/docs/design/hicasso/draft-guide/19-performance.md
@@ -31,7 +31,7 @@ Teardown is part of performance. Long-lived applications must not accumulate
 subscriptions, timers, listeners, or SDK handles as users leave and revisit
 screens. Hicasso releases its own committed reads. Hosts and native islands
 must release what they acquire ([Interop](09-interop.md)). Prove the complete
-claim with `hm/assert-clean!` ([Testing](14-testing.md)).
+claim with `hm/assert-clean!` ([Testing](15-testing.md)).
 
 ## Start with ordinary Hicasso
 
@@ -75,7 +75,7 @@ Do not skip a step:
 2. **Attribute.** Identify changed subscriptions, notified views, body work,
    React commit, and browser paint. Use Xray to classify the pressure as
    computation, topology, lowering, React, or layout
-   ([Diagnostics](15-diagnostics.md)).
+   ([Diagnostics](16-diagnostics.md)).
 3. **Tune topology.** Change read placement, keys, boundaries, or collection
    shape. Most cases end here.
 4. **Compare a direct React return** only when lowering is the measured owner.

--- a/docs/design/hicasso/draft-guide/20-migration-from-reagent.md
+++ b/docs/design/hicasso/draft-guide/20-migration-from-reagent.md
@@ -74,7 +74,7 @@ Common translations:
 | --- | --- |
 | `defn` component returning Hiccup | `h/defview`, mounted as a Hiccup head |
 | `@(rf/subscribe [:q])` | `(h/sub [:q])`, including in branches, loops, and helpers |
-| `#(rf/dispatch [:x])` | the event vector itself; use `h/event` when callback arguments matter |
+| `#(rf/dispatch [:x])` | the event vector itself; use `h/fn` when callback arguments matter |
 | `r/atom` inside a Form-2 closure | app-db or the forms module; Hicasso has no local-state tier |
 | `r/with-let` | ordinary `let`; durable state belongs outside render |
 | Form-3 or `r/create-class` lifecycle | callback refs or a named native component |
@@ -89,7 +89,7 @@ Two common mistakes fail loudly:
 
 - A Reagent-style `#(rf/dispatch ...)` callback has no captured frame when the
   browser invokes it later, so ambient dispatch raises
-  `:rf.error/no-frame-context`. Use an intent vector or `h/event`.
+  `:rf.error/no-frame-context`. Use an intent vector or `h/fn`.
 - An event vector at an undeclared `[:>]` prop raises instead of crossing as an
   inert JavaScript array. Under Reagent that inert value did not produce a
   working handler either; the migration forces you to decide the callback's
@@ -138,7 +138,7 @@ committed render becomes a checkpoint as you use the screen manually.
 
 Shadow comparison covers canonical DOM and intent streams. It does not prove
 focus, caret, IME, layout, or paint behaviour. Use the browser levels from
-[Testing](14-testing.md) for those claims.
+[Testing](15-testing.md) for those claims.
 
 When the screen is green and its browser tests pass, remove the Reagent
 original. Keeping both copies invites future divergence.
@@ -217,7 +217,7 @@ tool. The reporter records the site rather than guessing.
 | --- | --- | --- |
 | A `[:>]` site renders but behaves differently | Reagent converted the prop dialect and Hicasso passes values by identity | Run the reporter and apply the safe codemod rewrites |
 | Render raises `:rf.error/hicasso-host-undeclared-callback` at a former Reagent crossing | An intent vector reached an undeclared prop; under Reagent it crossed as inert data | Declare the host and callback contract, or supply the actual plain function the library expects |
-| Callback runs and raises `:rf.error/no-frame-context` | A hand-written dispatch closure did not capture a frame | Replace it with an intent vector or `h/event` |
+| Callback runs and raises `:rf.error/no-frame-context` | A hand-written dispatch closure did not capture a frame | Replace it with an intent vector or `h/fn` |
 | A keyed list remounts once immediately after migration | A key collision that Reagent normalised now becomes two distinct values | Accept the one-time transition when the new stable key is correct |
 | Codemod refuses a nested map with `:normalized-key-collision` | Keys such as `:foo-bar` and `:fooBar` collapsed onto one Reagent output property | Remove the unintended duplicate and rerun |
 | W2 camel-cases keys in what looks like application data | Reagent already sent that library a camel-cased object | Do not revert unless you intentionally want different library input |

--- a/docs/design/hicasso/draft-guide/21-code-splitting.md
+++ b/docs/design/hicasso/draft-guide/21-code-splitting.md
@@ -170,7 +170,7 @@ app-db.
 
 Under SSR, the lazy host remains Client-only. Server HTML contains the
 deterministic fallback. The live component mounts after hydration when its
-code arrives ([SSR and hydration](17-ssr-and-hydration.md)).
+code arrives ([SSR and hydration](18-ssr-and-hydration.md)).
 
 ## What happens to reads during suspension
 

--- a/docs/design/hicasso/draft-guide/22-accessibility.md
+++ b/docs/design/hicasso/draft-guide/22-accessibility.md
@@ -36,7 +36,7 @@ Apply the same rule throughout the page:
 Use ARIA roles when no native element expresses the widget, such as a listbox
 or tab strip. In that case, implement the complete keyboard and state contract,
 not only the role. The dropdown in
-[Overlays and focus](12-overlays-and-focus.md) is an example.
+[Overlays and focus](13-overlays-and-focus.md) is an example.
 
 ## Give controls an accessible name
 
@@ -125,9 +125,9 @@ Focus movement has specific owners:
 | Moment | Behaviour | Owner |
 | --- | --- | --- |
 | Route change | Focus a keyed `main` region with `:tab-index -1` and `preventScroll` | [Routing and navigation](07-routing-and-navigation.md) |
-| Overlay open and close | Apply `:auto-focus`, use the platform trap, restore the opener | [Overlays and focus](12-overlays-and-focus.md) |
-| Menu or listbox navigation | Keep DOM focus on the trigger and move `:aria-activedescendant` | [Overlays and focus](12-overlays-and-focus.md) |
-| Exit animation | Add `:inert` and `:aria-hidden` during unmounting | [Ephemeral state](11-ephemeral-state.md) |
+| Overlay open and close | Apply `:auto-focus`, use the platform trap, restore the opener | [Overlays and focus](13-overlays-and-focus.md) |
+| Menu or listbox navigation | Keep DOM focus on the trigger and move `:aria-activedescendant` | [Overlays and focus](13-overlays-and-focus.md) |
+| Exit animation | Add `:inert` and `:aria-hidden` during unmounting | [Motion and presence](12-motion-and-presence.md) |
 | Virtualised collection | Decide how keyboard users reach items that do not exist in the DOM and verify it in a browser | [Lists and collections](06-lists-and-collections.md) |
 
 ## Test attributes as data

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -6,10 +6,12 @@ The runtime turns that data into React elements; app-db, events, subscriptions,
 frames, and the event pipeline remain ordinary re-frame2.
 
 This guide explains the Hicasso view model, controlled inputs, forms, routing,
-resources, React interop, native components, local UI state, overlays, SSR,
-testing, diagnostics, performance, migration, code splitting, and
-accessibility. The MkDocs sidebar supplies the chapter order and page
-navigation.
+resources, React interop, native components, local UI state, motion/presence,
+overlays, SSR, testing, diagnostics, performance, migration, code splitting,
+and accessibility. Numbered pages run from
+[`00-installation`](00-installation.md) through
+[`22-accessibility`](22-accessibility.md). The MkDocs sidebar supplies the
+chapter order and page navigation when the corpus is wired into the site.
 
 ## Prerequisites
 

--- a/docs/design/hicasso/draft-guide/REWRITE-NOTES.md
+++ b/docs/design/hicasso/draft-guide/REWRITE-NOTES.md
@@ -3,7 +3,7 @@
 This file records the editorial and preservation decisions used for the
 rewritten `draft-guide` corpus.
 
-The 21 numbered chapters, `installation.md`, `glossary.md`, and `README.md`
+The 21 numbered chapters, `00-installation.md`, `glossary.md`, and `README.md`
 were rewritten for directness and consistency with `docs/AUTHORING.md`.
 Technical content was retained unless it was duplicated elsewhere in the
 corpus. Duplication was replaced with a clear link to the owning chapter.
@@ -27,15 +27,15 @@ MkDocs path.
 
 ## Corpus inventory
 
-The package contains all 25 Markdown files from the source directory:
+The package is the numbered learning path plus supporting files:
 
 - `README.md`
-- `installation.md`
-- `01-getting-started.md` through `21-accessibility.md`
+- `00-installation.md`
+- `01-getting-started.md` through `11-ephemeral-state.md`
+- `12-motion-and-presence.md` (split from ephemeral state)
+- `13-overlays-and-focus.md` through `22-accessibility.md`
 - `glossary.md`
 - `REWRITE-NOTES.md`
-
-The numbered learning path remains unchanged.
 
 ## Information-preservation policy
 
@@ -75,7 +75,7 @@ sequence warnings, and collection topology.
 
 ### Performance method
 
-`18-performance.md` owns the complete measurement loop and benefit rule.
+`19-performance.md` owns the complete measurement loop and benefit rule.
 `10-native-tier.md` teaches the code for each native level and refers back to
 the performance decision method.
 
@@ -95,7 +95,7 @@ is not taught.
 
 ### Event callbacks
 
-The guide uses `h/event` consistently. `:handler` remains a valid `defhost`
+The guide uses `h/fn` consistently. `:handler` remains a valid `defhost`
 callback-contract value and is not the same thing as an `h/handler` macro.
 
 No form submit is auto-prevented. A submit that must stay on the page uses:
@@ -116,7 +116,7 @@ These names are taught as the current guide contract but were identified by
 the source audit as names requiring explicit naming-ledger approval or final
 implementation confirmation:
 
-- `h/event`
+- `h/fn` and `h/frame`
 - artifact coordinates for Hicasso
 - root lifecycle configuration around `h/mount!`, `h/hydrate!`, `h/render!`,
   and `h/unmount!`
@@ -130,7 +130,7 @@ implementation confirmation:
 - `h/as-component`
 - `n/memo` and `n/lazy`
 - overlay heads and option names
-- `motion/presence`, `::motion/mounting`, and `::motion/unmounting`
+- `motion/presence` with `::h/mounting` / `::h/unmounting` (not `::motion/*`)
 - `forms/buffered-field` and its control options
 - resource `:demand true`
 - route-link's generated `::h/navigate` carrier
@@ -174,7 +174,6 @@ The following older draft ideas are not restored:
 - vector-ref reservation
 - a Hicasso parts/theming subsystem
 - three-value `:ssr`
-- `h/frame`
 - public `subscribe-once`
 - old comparative benchmark figures
 - automatic submit prevention
@@ -182,9 +181,13 @@ The following older draft ideas are not restored:
 - position-dependent callback forms
 - Chromium-only IME wording
 - pre-React-19 ref contracts
+- invented `h/event` spelling (product form is `h/fn`)
+- `::motion/*` override keys (shipped markers remain `::h/mounting` /
+  `::h/unmounting`)
 
-The current guide instead uses app-db state ownership, CSS tokens, two server
-policies, `rf/capture-frame` at explicit edges, user-visible budgets, and the
+The current guide teaches `h/fn` as the one callback form, `(rf/capture-frame
+(h/frame))` at foreign edges, app-db state ownership, CSS tokens, two server
+policies, a dedicated motion/presence chapter, user-visible budgets, and the
 browser-neutral controlled-input contract.
 
 ## Chapter-level preservation record
@@ -212,7 +215,7 @@ refusals.
 ### 03 — Events as data
 
 Retained event-position detection, `::h/value`, `::h/checked`, `::h/prevent`,
-`h/event`, plain-function behaviour, keyboard maps, IME suppression, frame
+`h/fn`, plain-function behaviour, keyboard maps, IME suppression, frame
 capture, stale frame-incarnation refusal, and malformed-intent recovery.
 
 ### 04 — Controlled inputs

--- a/docs/design/hicasso/draft-guide/glossary.md
+++ b/docs/design/hicasso/draft-guide/glossary.md
@@ -27,7 +27,7 @@ Forms, overlays, routing helpers, the native tier, and test tooling are separate
 optional namespaces.
 
 Related: [Getting started](01-getting-started.md),
-[Installation](installation.md).
+[Installation](00-installation.md).
 
 <a id="defview"></a>
 ### `defview`
@@ -203,24 +203,47 @@ inspect it with `=`.
 
 Related: [Events as data](03-events-as-data.md).
 
-<a id="hevent"></a>
-### `h/event`
+<a id="hfn"></a>
+### `h/fn`
 
-An explicit callback form for cases where the callback's arguments are needed
-to compute an event. It captures the current frame when created and dispatches
-a returned event vector when invoked later.
+The one marked callback form (HD-024). Expands to an ordinary function. The
+contract comes from the **position** where it is written: event positions
+dispatch a returned vector; render positions must stay pure; unclaimed host
+props refuse the mark.
 
 ```clojure
-{:on-change
- (h/event [date]
-   [:calendar/picked date])}
+[:input {:type "file"
+         :on-change (h/fn [e]
+                      [:upload/picked
+                       (js/Array.from (.. e -target -files))])}]
 ```
 
-Use it for value-first foreign callbacks, file lists, drag data, or calculated
-events.
+Captures the rendering frame when created. Use it when arguments determine the
+event — value-first foreign callbacks, file lists, drag data — or when the
+body must call browser methods such as `.preventDefault`.
 
 Related: [Events as data](03-events-as-data.md),
 [Interop](09-interop.md).
+
+<a id="hframe"></a>
+### `h/frame`
+
+Returns the frame **id keyword** of the Hicasso boundary currently rendering.
+Legal only during a boundary body or a render callback that boundary supplied.
+Not a tracked subscription.
+
+The taught carry spelling is composition with core:
+
+```clojure
+(let [{:keys [dispatch]} (rf/capture-frame (h/frame))]
+  …)
+```
+
+Zero-arity ambient `(rf/capture-frame)` refuses under Hicasso's body
+discipline. Prefer effects for application async work; use this at foreign
+edges that retain a dispatching closure.
+
+Related: [Events as data](03-events-as-data.md).
 
 <a id="hvalue"></a>
 <a id="hchecked"></a>
@@ -309,7 +332,7 @@ A map from DOM `.key` strings to event intents, used at `:on-key-down` or
   "Escape" [:editor/cancel]}}
 ```
 
-Unlisted keys are ignored. There is no modifier DSL; use [`h/event`](#hevent)
+Unlisted keys are ignored. There is no modifier DSL; use [`h/fn`](#hfn)
 for cases such as Ctrl+Enter. Key maps suppress matches during IME composition.
 
 Related: [Events as data](03-events-as-data.md).
@@ -383,7 +406,7 @@ Use the overlay module instead when the UI should live on the browser's native
 top layer.
 
 Related: [Interop](09-interop.md),
-[Overlays and focus](12-overlays-and-focus.md).
+[Overlays and focus](13-overlays-and-focus.md).
 
 <a id="server-policy"></a>
 ### Server policy
@@ -397,7 +420,7 @@ The SSR contract for a host or native component:
 Foreign hosts and named native components default to Client-only. Native
 Hiccup and intrinsic React elements render by default.
 
-Related: [SSR and hydration](17-ssr-and-hydration.md),
+Related: [SSR and hydration](18-ssr-and-hydration.md),
 [Interop](09-interop.md).
 
 <a id="raw-escape"></a>
@@ -506,7 +529,7 @@ Marker-preserving `React.lazy` loading for a named native component. It follows
 React's promise-returning loader contract and retains the Hicasso native marker.
 Declare it at namespace top level.
 
-Related: [Code splitting and lazy loading](20-code-splitting.md),
+Related: [Code splitting and lazy loading](21-code-splitting.md),
 [The native tier](10-native-tier.md).
 
 <a id="performance-ladder"></a>
@@ -520,7 +543,7 @@ Five explicit implementation levels:
 4. a named [native island](#native-island);
 5. a native screen.
 
-Related: [Performance](18-performance.md),
+Related: [Performance](19-performance.md),
 [The native tier](10-native-tier.md).
 
 <a id="escape-benefit-rule"></a>
@@ -534,7 +557,7 @@ Keep a native escape only when it:
 
 Otherwise remove it.
 
-Related: [Performance](18-performance.md).
+Related: [Performance](19-performance.md).
 
 ## State homes
 
@@ -546,6 +569,18 @@ component-local reactive store. A host may retain private mechanics only when
 they are not a hidden duplicate of an application fact.
 
 Related: [Ephemeral state](11-ephemeral-state.md).
+
+<a id="motion-presence"></a>
+### `motion/presence`
+
+Optional exit-retention head from `re-frame.hicasso.motion`. Keeps keyed
+children for `:timeout-ms` after their data leaves app-db so CSS exit
+transitions can run. Applies `::h/mounting` / `::h/unmounting` attribute
+overrides on elements, or passes `:rf/phase` to view children. Not an
+animation system.
+
+Related: [Motion and presence](12-motion-and-presence.md),
+[Ephemeral state](11-ephemeral-state.md).
 
 <a id="pressure-valve"></a>
 ### Pressure valve
@@ -569,7 +604,7 @@ owns stacking, light-dismiss, modal focus trapping, and focus restoration.
 
 A closed overlay has no DOM node, listener, or active body subscriptions.
 
-Related: [Overlays and focus](12-overlays-and-focus.md).
+Related: [Overlays and focus](13-overlays-and-focus.md).
 
 <a id="route-link"></a>
 ### `route-link`
@@ -614,7 +649,7 @@ Two namespaces:
 - `re-frame.hicasso.test.mounted`, usually `hm`, for mounted React and DOM
   tests.
 
-Related: [Testing](14-testing.md).
+Related: [Testing](15-testing.md).
 
 <a id="testing-ladder"></a>
 ### Testing ladder
@@ -629,7 +664,7 @@ Related: [Testing](14-testing.md).
 
 A lower level does not prove the equality of a higher level.
 
-Related: [Testing](14-testing.md).
+Related: [Testing](15-testing.md).
 
 <a id="semantic-harness"></a>
 ### Semantic harness
@@ -639,7 +674,7 @@ fixtures and returns a semantic tree. Nested views remain represented as calls.
 Hooks, hosts, raw React elements, and `n/$` results are refused and belong at
 L3.
 
-Related: [Testing](14-testing.md).
+Related: [Testing](15-testing.md).
 
 <a id="mounted-facade"></a>
 ### Mounted facade
@@ -648,7 +683,7 @@ The `hm` namespace for L3 tests. It provides isolated-frame mount and hydrate,
 rerender, dispatch-and-settle, settle, virtual-clock advancement, unmount, and
 `assert-clean!` residue checking.
 
-Related: [Testing](14-testing.md).
+Related: [Testing](15-testing.md).
 
 <a id="sabotage-control"></a>
 ### Sabotage control
@@ -657,7 +692,7 @@ A deliberately broken twin of an important test or measurement. It proves that
 the instrument moves when the input is wrong and prevents an empty population
 from passing vacuously.
 
-Related: [Testing](14-testing.md).
+Related: [Testing](15-testing.md).
 
 <a id="canonical-dom"></a>
 ### Canonical DOM
@@ -669,8 +704,8 @@ were inserted in a different sequence.
 Canonical DOM is distinct from semantic-tree equality, exact server bytes, and
 hydrated browser behaviour.
 
-Related: [Testing](14-testing.md),
-[Migrating from Reagent](19-migration-from-reagent.md).
+Related: [Testing](15-testing.md),
+[Migrating from Reagent](20-migration-from-reagent.md).
 
 ## Diagnostics
 
@@ -691,7 +726,7 @@ event
 
 Render, commit, and paint are separate claims.
 
-Related: [Diagnostics](15-diagnostics.md).
+Related: [Diagnostics](16-diagnostics.md).
 
 <a id="explain-render"></a>
 ### Explain-render
@@ -699,7 +734,7 @@ Related: [Diagnostics](15-diagnostics.md).
 Xray's answer to “why did this view run?” It reports the cause category, changed
 reads or props, current read set, fan-out, completeness, and evidence loss.
 
-Related: [Diagnostics](15-diagnostics.md).
+Related: [Diagnostics](16-diagnostics.md).
 
 <a id="hot-view-advisor"></a>
 ### Hot-view advisor
@@ -709,8 +744,8 @@ then classifies the pressure as computation, topology, lowering, React, or
 layout. It recommends the smallest credible remedy and never auto-promotes
 code to native.
 
-Related: [Diagnostics](15-diagnostics.md),
-[Performance](18-performance.md).
+Related: [Diagnostics](16-diagnostics.md),
+[Performance](19-performance.md).
 
 <a id="loss-labels"></a>
 ### Loss labels
@@ -725,7 +760,7 @@ Explicit labels for incomplete evidence:
 
 Missing evidence is not represented as an empty result.
 
-Related: [Diagnostics](15-diagnostics.md).
+Related: [Diagnostics](16-diagnostics.md).
 
 <a id="complaint-catalogue"></a>
 ### Complaint catalogue
@@ -734,7 +769,7 @@ The stable `:rf.error/*` and `:rf.warning/*` identifier set, including cause,
 recovery, and source links where available. Tests assert the id, not the human
 message.
 
-Related: [Diagnostics](15-diagnostics.md).
+Related: [Diagnostics](16-diagnostics.md).
 
 <a id="production-erasure"></a>
 ### Production erasure
@@ -743,7 +778,7 @@ Removal of development diagnostics, evidence machinery, source locations, and
 complaint messages from default release bundles. Optional performance timing
 has a separate compile-time flag and is disabled by default.
 
-Related: [Diagnostics](15-diagnostics.md).
+Related: [Diagnostics](16-diagnostics.md).
 
 ## Lifecycle and delivery
 
@@ -769,7 +804,7 @@ first paint.
    [app-shell {}]))
 ```
 
-Related: [Installation](installation.md).
+Related: [Installation](00-installation.md).
 
 <a id="hydrate"></a>
 ### `hydrate!`
@@ -781,7 +816,7 @@ Two functions complete hydration:
 
 State hydration must run before DOM adoption.
 
-Related: [SSR and hydration](17-ssr-and-hydration.md).
+Related: [SSR and hydration](18-ssr-and-hydration.md).
 
 <a id="error-boundary"></a>
 ### Error boundary
@@ -792,7 +827,7 @@ error boundary catches descendant render and lifecycle exceptions.
 
 Expected failures remain ordinary app-db state.
 
-Related: [Errors](16-errors.md).
+Related: [Errors](17-errors.md).
 
 <a id="user-visible-budget"></a>
 ### User-visible budget
@@ -806,7 +841,7 @@ A performance requirement expressed as an observable user outcome, such as:
 
 Synthetic benchmark scores do not replace these budgets.
 
-Related: [Performance](18-performance.md).
+Related: [Performance](19-performance.md).
 
 <a id="shadow-comparison"></a>
 ### Shadow comparison
@@ -815,4 +850,4 @@ A migration witness that mounts a reference implementation and candidate under
 isolated equivalent state, drives both with one script, and compares canonical
 DOM plus event-intent streams at each checkpoint.
 
-Related: [Migrating from Reagent](19-migration-from-reagent.md).
+Related: [Migrating from Reagent](20-migration-from-reagent.md).

--- a/docs/design/hicasso/product/complaints.md
+++ b/docs/design/hicasso/product/complaints.md
@@ -92,28 +92,28 @@ rowed in the Hicasso section, and is the single live id without the
 
 | Complaint | Raised when you | Taught in |
 |---|---|---|
-| `:rf.error/hicasso-bad-head` | put something outside the closed head set in hiccup head position | ch02, ch06, ch15 |
+| `:rf.error/hicasso-bad-head` | put something outside the closed head set in hiccup head position | ch02, ch06, ch16 |
 | `:rf.error/hicasso-boundary-bad-on-error` | gave `h/boundary` an `:on-error` that is neither an intent vector nor a function, so nothing could fire it | — |
 | `:rf.error/hicasso-boundary-unknown-prop` | wrote a key outside `h/boundary`'s closed roster — a misspelled `:on-error` is an error boundary that reports nothing | — |
-| `:rf.error/hicasso-deferred-read-at-boundary` | let an unforced `delay` reach a boundary's props | ch02, ch14, ch15 |
+| `:rf.error/hicasso-deferred-read-at-boundary` | let an unforced `delay` reach a boundary's props | ch02, ch15, ch16 |
 | `:rf.error/hicasso-dispatch-in-render-position` | dispatched from a render callback while it was running | ch03, ch09 |
 | `:rf.error/hicasso-empty-vector` | wrote `[]` where hiccup was expected | — |
 | `:rf.error/hicasso-frame-outside-boundary` | asked for the frame with no Hicasso render extent in scope | — |
 | `:rf.error/hicasso-generation-fence-exhausted` | wrote to app-db from a body, on four consecutive runs | — |
 | `:rf.error/hicasso-host-bad-options` | gave a `defhost` declaration options that are not a map — usually a docstring written after the component instead of before it | — |
 | `:rf.error/hicasso-host-bad-slots` | declared a `defhost` `:slots` that is not a set of ordinary prop names — a non-set, an entry that names no prop, `key`/`ref`, a name the crossing can never emit (`__proto__`, `prototype`, `constructor`), one slot spelled twice, or a position that is also a declared callback | — |
-| `:rf.error/hicasso-host-bad-ssr-policy` | gave a `defhost` a `:server` value outside the two it admits, or a `:fallback` the policy beside it cannot carry | ch09, ch17 |
+| `:rf.error/hicasso-host-bad-ssr-policy` | gave a `defhost` a `:server` value outside the two it admits, or a `:fallback` the policy beside it cannot carry | ch09, ch18 |
 | `:rf.error/hicasso-host-callback-slot-collision` | declared two spellings of one callback slot on a `defhost` | — |
 | `:rf.error/hicasso-host-extra-form` | wrote a form after `defhost`'s options map — a second options map is not merged, it is discarded | — |
-| `:rf.error/hicasso-host-fallback-boundary-head` | put a `defview` or `defhost` head inside a declared fallback | ch09, ch17 |
+| `:rf.error/hicasso-host-fallback-boundary-head` | put a `defview` or `defhost` head inside a declared fallback | ch09, ch18 |
 | `:rf.error/hicasso-host-no-component` | declared a `defhost` over `nil` | — |
 | `:rf.error/hicasso-host-structural-callback` | declared a `defhost` callback contract at a position no contract can reach — `key`/`ref`, which carry no contract, or a name the crossing can never emit (`__proto__`, `prototype`, `constructor`) | — |
-| `:rf.error/hicasso-host-unclaimed-callback` | wrote the one callback form at a `defhost` position no callback contract claims — one nothing claims at all, or one declared a ReactNode slot, where markup lowers and there is no contract to give a function | ch09, ch15 |
-| `:rf.error/hicasso-host-undeclared-callback` | sent an intent to a `defhost` prop the declaration does not name | ch09, ch19 |
-| `:rf.error/hicasso-host-unknown-option` | gave a `defhost` declaration an option outside its roster `#{:callbacks :slots :server :fallback}` — the retired `:ssr` spelling included | ch09, ch17 |
+| `:rf.error/hicasso-host-unclaimed-callback` | wrote the one callback form at a `defhost` position no callback contract claims — one nothing claims at all, or one declared a ReactNode slot, where markup lowers and there is no contract to give a function | ch03, ch09, ch16 |
+| `:rf.error/hicasso-host-undeclared-callback` | sent an intent to a `defhost` prop the declaration does not name | ch09, ch20 |
+| `:rf.error/hicasso-host-unknown-option` | gave a `defhost` declaration an option outside its roster `#{:callbacks :slots :server :fallback}` — the retired `:ssr` spelling included | ch09, ch18 |
 | `:rf.error/hicasso-intent-at-a-non-event-contract` | put an intent at a position declared `:handler` or `:render` | ch03, ch09 |
 | `:rf.error/hicasso-intent-needs-the-event` | wrote an event-reading intent at a value-first foreign callback | ch03, ch09 |
-| `:rf.error/hicasso-intent-outside-boundary` | lowered or fired an intent with no frame-locked dispatch bound | ch15, ch16 |
+| `:rf.error/hicasso-intent-outside-boundary` | lowered or fired an intent with no frame-locked dispatch bound | ch16, ch17 |
 | `:rf.error/hicasso-malformed-navigate` | wrote the navigate decorator outside its closed grammar | ch07 |
 | `:rf.error/hicasso-malformed-prevent` | wrapped something other than exactly one intent vector in the prevent decorator | ch03 |
 | `:rf.error/hicasso-merge-not-a-map` | forwarded a non-map at the attribute-remainder key | — |
@@ -127,7 +127,7 @@ rowed in the Hicasso section, and is the single live id without the
 | `:rf.error/hicasso-portal-no-target` | gave `h/portal` a `:target` that is not a DOM container — usually a lookup that answered nothing | — |
 | `:rf.error/hicasso-presence-child-not-hiccup` | gave a presence boundary a child that is not a hiccup vector | — |
 | `:rf.error/hicasso-presence-child-unkeyed` | gave a presence child no `:key` | — |
-| `:rf.error/hicasso-presence-override-on-a-view` | wrote a phase-attribute override on a view head | ch11 |
+| `:rf.error/hicasso-presence-override-on-a-view` | wrote a phase-attribute override on a view head | ch12 |
 | `:rf.error/hicasso-presence-override-out-of-reach` | wrote a phase-attribute override where no presence tray can apply it — deeper than a tray's direct child, forwarded through a `:&` remainder, or under no tray at all | — |
 | `:rf.error/hicasso-presence-timeout-required` | left a presence boundary's timeout absent or not positive | — |
 | `:rf.error/hicasso-raw-no-component` | handed the raw escape `nil` in component position | ch09 |
@@ -135,7 +135,7 @@ rowed in the Hicasso section, and is the single live id without the
 | `:rf.error/hicasso-ref-vector-reserved` | put a vector at the canonical `ref` slot | — |
 | `:rf.error/hicasso-refusal-incomplete` | (framework-internal) minted a refusal missing one of the four required slots | — |
 | `:rf.error/hicasso-revision-from-remainder` | let a forwarded attribute map introduce the reset trigger | — |
-| `:rf.error/hicasso-revision-not-controlled` | put the reset trigger on something that is not a controlled text field | ch04, ch05, ch15 |
+| `:rf.error/hicasso-revision-not-controlled` | put the reset trigger on something that is not a controlled text field | ch04, ch05, ch16 |
 | `:rf.error/hicasso-route-link-bad-on-click` | gave a route link an `:on-click` outside the route-click roster | — |
 | `:rf.error/hicasso-route-link-outside-boundary` | rendered a route link with no ambient frame | — |
 | `:rf.error/hicasso-route-link-prefetch-declined` | wrote `:prefetch` on a route link (declined outright in v0) | — |
@@ -143,7 +143,7 @@ rowed in the Hicasso section, and is the single live id without the
 | `:rf.error/hicasso-state-bad-key` | used an instance key outside the accepted set (`nil` included) | — |
 | `:rf.error/hicasso-state-bad-option` | passed non-map options, or an option outside the roster, at registration | — |
 | `:rf.error/hicasso-state-redefined` | re-registered a concern with a different default | — |
-| `:rf.error/hicasso-sub-outside-render` | read a subscription outside a boundary body | ch02, ch14, ch15 |
+| `:rf.error/hicasso-sub-outside-render` | read a subscription outside a boundary body | ch02, ch15, ch16 |
 | `:rf.error/hicasso-true-child` | let `true` reach child position | ch02 |
 | `:rf.error/hicasso-unknown-callback-contract` | named a callback contract outside `:event` / `:handler` / `:render` | — |
 | `:rf.error/no-frame-prop` | mounted a frame-fed boundary with no frame in its props | — |
@@ -160,10 +160,10 @@ rowed in the Hicasso section, and is the single live id without the
 | `:rf.error/hicasso-test-not-a-native-form` | gave an L1 projection a form whose head is not a tag keyword | — |
 | `:rf.error/hicasso-test-not-a-render-form` | gave an L2 `tree` something other than a hiccup form | — |
 | `:rf.error/hicasso-test-not-an-intent` | gave the L1 marker materializer something other than an intent vector | — |
-| `:rf.error/hicasso-test-plain-fn-head` | put a plain function in a hiccup head inside an L2 tree | ch15 |
+| `:rf.error/hicasso-test-plain-fn-head` | put a plain function in a hiccup head inside an L2 tree | ch16 |
 | `:rf.error/hicasso-test-position-is-not-a-handler` | fired at a position that lowers to something other than a function | — |
 | `:rf.error/hicasso-test-react-is-opaque` | let a raw React element reach the L2 semantic tree | — |
-| `:rf.error/no-frame-context` | (corpus-owned) rendered a Hicasso boundary whose React context carries no frame | ch03, ch09, ch10, ch17, ch19 |
+| `:rf.error/no-frame-context` | (corpus-owned) rendered a Hicasso boundary whose React context carries no frame | ch03, ch09, ch10, ch18, ch20 |
 | `:rf.error/routing-artefact-missing` | (corpus-owned) rendered a route link with routing absent | ch07 |
 | `:rf.error/ui-tree-malformed` | (corpus-owned) let a value outside the structural-tree grammar reach an L2 tree or a projection | — |
 

--- a/docs/design/hicasso/production-server-arm.md
+++ b/docs/design/hicasso/production-server-arm.md
@@ -416,7 +416,7 @@ produces both sides, so there is nothing for two tables to disagree about.
   different resolver: a snapshot for SSR, an override map for tests. The
   co-discharge is real, and the door is genuinely absent —
   `draft-guide/08-testing.md` (the draft-era testing chapter, since replaced
-  by the end-state `draft-guide/14-testing.md`) said so three times
+  by the end-state `draft-guide/15-testing.md`) said so three times
   over: *"Not built yet — the sketch below is the intended shape, not a call you
   can make today"*, *"Headless (sketch — not built)"*, and of the resolver
   itself *"This half is the headless path's, and it does not exist yet."*

--- a/docs/design/hicasso/studio/108-the-theming-taught-default-priced.md
+++ b/docs/design/hicasso/studio/108-the-theming-taught-default-priced.md
@@ -278,7 +278,7 @@ sentence on A's SSR bullet rather than an unqualified *"no flash by construction
 
 `:ssr :render` landed on 2026-08-05 (`rf2-l0wfx`, `rf2-nv07k`), and with it guide
 10 §[`:render` — when the region has to be in the
-response](../draft-guide/17-ssr-and-hydration.md#client-only-components-and-fallbacks).
+response](../draft-guide/18-ssr-and-hydration.md#client-only-components-and-fallbacks).
 The load-bearing fact for theming is the one that ruling states about the other
 two policies: `:client-only` (**the default**) and `{:fallback …}` render *instead
 of* the component, so *"a provider at a crossing takes every descendant out of the
@@ -313,7 +313,7 @@ but a channel that exists, where the per-root attribute has none.
   design's claim that per-frame B needs `make-frame :fx-overrides`: `spec/002-Frames.md`
   §*The binary fx-handler signature* already gives an fx handler the frame id in
   its ctx under `:frame`. Since then `h/frame` has **shipped** and guide 03
-  §[Frame-safe callbacks and foreign APIs](../draft-guide/03-events-as-data.md#frame-safe-callbacks-and-foreign-apis)
+  §[Frame-safe callbacks and `h/frame`](../draft-guide/03-events-as-data.md#frame-safe-callbacks-and-hframe)
   teaches *"an fx handler receives the frame id in its context"* as a first-class
   fact, echoed in guide 01's troubleshooting table. So B per-root is an app-owned
   `frame-id → node` map populated at mount plus one global fx reading `(:frame m)`


### PR DESCRIPTION
## Summary

Complete the draft-guide coverage of the eventual Hicasso public surface and reorganise the corpus.

1. **Number installation** as `00-installation.md` so it sorts with the numbered chapters.
2. **Renumber** former `12`–`21` to `13`–`22` to insert a dedicated motion chapter.
3. **`h/fn` and `h/frame`** — teach the real product APIs (replace invented `h/event`; teach `(rf/capture-frame (h/frame))` instead of ambient capture alone).
4. **Motion / presence** — new `12-motion-and-presence.md` with problem statement, clear toast example, API table, element vs view phase rules, shipped `::h/mounting` / `::h/unmounting` markers, troubleshooting. Ephemeral state only points here.
5. Glossary and inbound link retargets (including studio / design docs under `docs/design/hicasso`).

`defhost`, `h/portal`, `h/as-element`, and `h/as-component` already had a full chapter (09); this PR does not re-author that surface except where `h/fn` renames apply.

## Test plan

- [x] `python scripts/check_doc_slugs.py` (exit 0)
- [ ] CI docs / MkDocs green