### PR TITLE
test(freehand): a suite's cleanup must not outlive its own test (rf2-d2xz)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/lane_window_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/lane_window_dom_cljs_test.cljs
@@ -159,10 +159,16 @@
                        ;; not a dead one, which is why the clock reading
                        ;; looked plausible.
                        (is (= "new" @(:parked arm))
-                           "the commit must be sitting parked outside the window")
-                       (.remove c)
-                       (done)))
-              (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))
+                           "the commit must be sitting parked outside the window")))
+              ;; Reports and RELEASES; it never finishes (rf2-fyba). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time. The container detach both
+              ;; arms duplicated rides the single trailing step instead — written
+              ;; once, still run once per path, and every DOM read is upstream
+              ;; of it. Every chain in this file has the same shape.
+              (.catch (fn [e] (is false (str e)) nil))
+              (.then (fn [_] (.remove c) (done)))))))))
 
 (deftest microtask-arm-verifies-under-its-own-window
   (testing "declaring :scheduler :microtask puts NOTHING between the write
@@ -182,10 +188,9 @@
                            "nothing was parked — the drain got there first")
                        ;; 0.0 and it MEANS it: there is no harness turn
                        ;; inside this window to price.
-                       (is (zero? (:gap-ms r)) ":gap-ms must be 0.0, not merely small")
-                       (.remove c)
-                       (done)))
-              (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))
+                       (is (zero? (:gap-ms r)) ":gap-ms must be 0.0, not merely small")))
+              (.catch (fn [e] (is false (str e)) nil))
+              (.then (fn [_] (.remove c) (done)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The other family — and therefore why ONE shape cannot serve both
@@ -203,10 +208,9 @@
               (.then (fn [[r tally]]
                        (is (true? (:ok? r)) "the yielding window must verify this family")
                        (is (= {:writes 1 :unverified 0} tally) "0 unverified of 1")
-                       (is (= "new" (lane/text-at c 0)))
-                       (.remove c)
-                       (done)))
-              (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))
+                       (is (= "new" (lane/text-at c 0)))))
+              (.catch (fn [e] (is false (str e)) nil))
+              (.then (fn [_] (.remove c) (done)))))))))
 
 (deftest queued-notification-arm-is-unverified-under-the-microtask-window
   (testing "and the write-then-drain window BREAKS that same arm — so
@@ -221,10 +225,9 @@
                        (is (false? (:ok? r))
                            "draining immediately must find this arm's queue empty")
                        (is (= {:writes 1 :unverified 1} tally) "1 unverified of 1")
-                       (is (= "old" (lane/text-at c 0)))
-                       (.remove c)
-                       (done)))
-              (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))
+                       (is (= "old" (lane/text-at c 0)))))
+              (.catch (fn [e] (is false (str e)) nil))
+              (.then (fn [_] (.remove c) (done)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The default is the window every published P0 row was taken through
@@ -261,10 +264,9 @@
                        ;; The gap is a real, priced turn on this path: the
                        ;; asymmetry against the microtask window is a NUMBER
                        ;; rather than an assurance.
-                       (is (number? (:gap-ms r)) ":gap-ms is measured, not asserted")
-                       (.remove c)
-                       (done)))
-              (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))
+                       (is (number? (:gap-ms r)) ":gap-ms is measured, not asserted")))
+              (.catch (fn [e] (is false (str e)) nil))
+              (.then (fn [_] (.remove c) (done)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The batched window — k operations, ONE clock (rf2-zb3qg)
@@ -317,10 +319,9 @@
                        ;; row that banked one write per window would publish
                        ;; `N unverified of M` with an M a tenth of the truth.
                        (is (= {:writes k :unverified 0} (lane/tally-value t))
-                           "the tally banks every op in the batch")
-                       (.remove c)
-                       (done)))
-              (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))
+                           "the tally banks every op in the batch")))
+              (.catch (fn [e] (is false (str e)) nil))
+              (.then (fn [_] (.remove c) (done)))))))))
 
 (deftest a-batch-of-one-is-the-unbatched-window-exactly
   (testing "k = 1 is the pre-batch window, turn for turn — this is what lets
@@ -337,10 +338,9 @@
                        (is (= [:wrote :microtask-ran :forced] @seen)
                            "one write, one yield, one drain — the unbatched shape")
                        (is (true? (:ok? r)))
-                       (is (= {:writes 1 :unverified 0} (lane/tally-value t)))
-                       (.remove c)
-                       (done)))
-              (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))
+                       (is (= {:writes 1 :unverified 0} (lane/tally-value t)))))
+              (.catch (fn [e] (is false (str e)) nil))
+              (.then (fn [_] (.remove c) (done)))))))))
 
 (deftest a-batched-microtask-arm-puts-nothing-between-write-and-drain
   (testing "the microtask family's batched window is one synchronous run —
@@ -370,10 +370,9 @@
                               (vec (drop (* 2 k) @seen)))
                            "and the arm's own microtasks ran only once the window had closed")
                        (is (zero? (:gap-ms r)) ":gap-ms must be 0.0, not merely small")
-                       (is (= {:writes k :unverified 0} (lane/tally-value t)))
-                       (.remove c)
-                       (done)))
-              (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))
+                       (is (= {:writes k :unverified 0} (lane/tally-value t)))))
+              (.catch (fn [e] (is false (str e)) nil))
+              (.then (fn [_] (.remove c) (done)))))))))
 
 (deftest a-batch-reports-every-op-that-missed-the-dom
   (testing "an arm whose commits never land reads `k unverified of k`, not
@@ -392,7 +391,6 @@
                        (is (false? (:ok? r)))
                        (is (= [false false false] (:oks r)))
                        (is (= {:writes k :unverified k} (lane/tally-value t))
-                           "k unverified of k")
-                       (.remove c)
-                       (done)))
-              (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))
+                           "k unverified of k")))
+              (.catch (fn [e] (is false (str e)) nil))
+              (.then (fn [_] (.remove c) (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/controlled_input_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/controlled_input_dom_cljs_test.cljs
@@ -345,13 +345,9 @@
                     (is (= typed (.-value door))
                         "every keystroke survived in the DOM")
                     (is (= typed (app-text))
-                        "and application state holds exactly what was typed"))
-                  (teardown! container root)
-                  (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                        "and application state holds exactly what was typed"))))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (teardown! container root) (done)))))))))
 
 (deftest fh-input-003-the-control-field-loses-characters
   (testing "Per FH-INPUT-003: the CONTROL, and the reason every
@@ -380,13 +376,9 @@
                         (str "the control field must LOSE characters — it holds "
                              (pr-str (.-value batched))))
                     (is (< (count (.-value batched)) (count typed))
-                        "and it loses them by dropping, not by reordering"))
-                  (teardown! container root)
-                  (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                        "and it loses them by dropping, not by reordering"))))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (teardown! container root) (done)))))))))
 
 ;; ===========================================================================
 ;; FH-INPUT-003 — caret and selection
@@ -420,13 +412,9 @@
                     (is (= expected (.-value door)) "the insert landed where the caret was")
                     (is (= expected (app-text)) "and round-tripped through application state")
                     (is (= [expected-caret expected-caret] (caret door))
-                        "the caret did not jump"))
-                  (teardown! container root)
-                  (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                        "the caret did not jump"))))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (teardown! container root) (done)))))))))
 
 (deftest fh-input-003-a-range-selection-is-replaced-not-lost
   (testing "Per FH-INPUT-003: typing over a range selection replaces the
@@ -455,13 +443,9 @@
                     (is (= expected (.-value door)) "the range was replaced")
                     (is (= expected (app-text)))
                     (is (= [expected-caret expected-caret] (caret door))
-                        "and the caret collapsed after the insert rather than jumping"))
-                  (teardown! container root)
-                  (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                        "and the caret collapsed after the insert rather than jumping"))))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (teardown! container root) (done)))))))))
 
 ;; ===========================================================================
 ;; FH-INPUT-003 — IME composition
@@ -514,13 +498,9 @@
                     (is (= final (.-value door)) "the composition committed intact")
                     (is (= final (app-text)) "and reached application state")
                     (is (identical? before (node container "door"))
-                        "on the same node it started on"))
-                  (teardown! container root)
-                  (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                        "on the same node it started on"))))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (teardown! container root) (done)))))))))
 
 ;; ===========================================================================
 ;; FH-INPUT-003 — clearing a controlled field
@@ -570,6 +550,9 @@
                         box   (node container "clearable-box")]
                     (is (= seed (.-value field)) "the field starts at the seeded value")
                     (is (true? (.-checked box)) "and the box starts checked")
+                    ;; RETURNED into the outer chain — so the trailing step below
+                    ;; waits for the transition, and the `.catch` upstream of it
+                    ;; still sees a rejection raised in here.
                     (-> (render-clearing-page! root {:text nil :flag nil})
                         (.then
                           (fn [_]
@@ -582,15 +565,9 @@
                                 "and the box unchecked")
                             (is (= [] (control-complaints @errors))
                                 (str "React raised no controlled/uncontrolled diagnostic: "
-                                     (pr-str @errors)))
-                            (restore)
-                            (teardown! container root)
-                            (done)))))))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (restore)
-                        (teardown! container root)
-                        (done)))))))))
+                                     (pr-str @errors)))))))))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (restore) (teardown! container root) (done)))))))))
 
 ;; ===========================================================================
 ;; FH-INPUT-003 — the deterministic half of contention
@@ -627,13 +604,9 @@
                     (is (= (repeat n (str (count typed)))
                            (map #(.-textContent %)
                                 (array-seq (.querySelectorAll container "[data-sibling]"))))
-                        "and every sibling settled on the same keystroke's state"))
-                  (teardown! container root)
-                  (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                        "and every sibling settled on the same keystroke's state"))))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (teardown! container root) (done)))))))))
 
 ;; ===========================================================================
 ;; A CONTROLLED native `<select multiple>`, in a real browser

--- a/implementation/freehand/test/re_frame/freehand/pilot_react_interop_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_react_interop_dom_cljs_test.cljs
@@ -179,11 +179,9 @@
                        (act #(teardown! container mounted))))
               (.then (fn [_]
                        (is (= 0 (pilot/live-instances)))
-                       (is (= 0 (behaviors/connection-count)))
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (done)))))))))
+                       (is (= 0 (behaviors/connection-count)))))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest the-widget-reconciles-from-config-and-nothing-else
   (testing "Desired state reaches the host through `:config` and `:update`,
@@ -206,11 +204,9 @@
                        (is (= 1 (pilot/live-instances))
                            "WITHOUT reconstructing the widget — one instance throughout")
                        (is (= 1 (:constructed (pilot/ledger-snapshot)))
-                           "constructed exactly once")
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (done)))))))))
+                           "constructed exactly once")))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest a-command-reaches-the-widget-and-its-result-comes-back-as-an-event
   (testing "The one-shot imperative operation — export — travels the whole
@@ -271,11 +267,9 @@
                            "and the live DECOY was untouched")
                        (act #(teardown! container mounted))))
               (.then (fn [_]
-                       (is (= 0 (pilot/live-instances)))
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (done)))))))))
+                       (is (= 0 (pilot/live-instances)))))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest widget-teardown-is-total-measured-against-a-control
   (testing "Acceptance for this pilot is an EXACT retained count after
@@ -309,11 +303,9 @@
                             cumulative totals prove the release RAN rather than
                             the counters never having been written")
                        (is (= 0 (behaviors/connection-count)))
-                       (is (= #{} (behaviors/target-ids)))
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (done)))))))))
+                       (is (= #{} (behaviors/target-ids)))))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; 2 — a foreign component at a vector head, in the BROWSER
@@ -413,11 +405,9 @@
                            "the foreign component's cleanup ran")
                        (is (= 0 (rpilot/live-probe-listeners))
                            "and its window listener came back off — total release
-                            through a boundary the substrate never sees inside")
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (done)))))))))
+                            through a boundary the substrate never sees inside")))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest a-real-third-party-react-component-renders-and-releases
   (testing "`@xyflow/react` — a genuine third-party React component library,
@@ -454,11 +444,9 @@
                            "and the nested root closed on unmount (one microtask
                             later — see the ABI case above)")
                        (is (nil? (q container ".react-flow"))
-                           "leaving no React Flow DOM behind")
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (done)))))))))
+                           "leaving no React Flow DOM behind")))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest the-nested-roots-release-is-the-one-that-is-not-synchronous
   (testing "The workaround's sharpest edge, MEASURED rather than described.
@@ -524,11 +512,9 @@
                        (is (= 0 (rpilot/live-probe-listeners))
                            "and the foreign listener came back off — the release
                             is total, it is simply one tick behind")
-                       (.remove container)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (done)))))))))
+                       (.remove container)))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; 3b — THE CHILD PATH: a React component as an ordinary child value
@@ -583,11 +569,9 @@
                             the nested root's deferred release")
                        (is (= 0 (behaviors/connection-count))
                            "and nothing connected — the child path opened no behavior")
-                       (.remove container)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (done)))))))))
+                       (.remove container)))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; 3c — THE INWARD HALF of the child path: how a foreign component calls BACK
@@ -745,11 +729,14 @@
                                     (is (= 0 (behaviors/connection-count))
                                         "and no behavior connection — this is the child
                                          path, not the nested-root one")
-                                    (teardown! container mounted)
-                                    (done))))))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (done)))))))))
+                                    ;; Success-only, as everywhere in this file:
+                                    ;; `mounted` is what the mount resolved with, so
+                                    ;; the rejection arm has nothing to tear down.
+                                    ;; The nested chain is RETURNED into the outer
+                                    ;; one, whose trailing step owns the single done.
+                                    (teardown! container mounted))))))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; 4 — a COMPILED page containing the integration, on a real page
@@ -795,11 +782,9 @@
               (.then (fn [_]
                        (is (= 0 (pilot/live-instances))
                            "and teardown across the crossing is still total")
-                       (is (= 0 (behaviors/connection-count)))
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (done)))))))))
+                       (is (= 0 (behaviors/connection-count)))))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest the-nested-root-is-not-free-and-the-cost-is-named
   (testing "The honest cost accounting, asserted rather than asserted away,
@@ -833,8 +818,6 @@
                          (is (= 1 (:roots-closed l))
                              "opened once, closed once — the second React tree's
                               lifetime is exactly the behavior's connection")
-                         (is (= 0 (:roots l))))
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (done)))))))))
+                         (is (= 0 (:roots l))))))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/reactive_false_shell_free_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/reactive_false_shell_free_dom_cljs_test.cljs
@@ -169,20 +169,24 @@
             "non-vacuous: the analysis really did elide the ViewCell for this body")
         (let [container (host-node!)]
           (-> (act #(v/mount [elided-but-reads {}] container {:frame fid}))
+              ;; The REJECTION is this row's success path — the mount must be
+              ;; refused — so the two handlers are SIBLINGS of one two-arg
+              ;; `.then`, which states "exactly one of these runs" directly. A
+              ;; `.catch` downstream of a `done` would instead claim a later
+              ;; namespace's throw as this row's and fire `done` twice
+              ;; (rf2-fyba). The shared container detach rides the single
+              ;; trailing step; the unmount is fulfilment-only and stays.
               (.then (fn [mounted]
                        (is false
                            (str "the shell-free mount SUCCEEDED and rendered "
                                 (pr-str (text container "#leak"))
                                 " — a read with no owner was not refused"))
-                       (when mounted (.unmount (.-react-root ^root/Root mounted)))
-                       (.remove container)
-                       (done)))
-              (.catch (fn [e]
-                        (is (= :rf.error/view-read-outside-render
-                               (:rf.error/id (ex-data e)))
-                            (str "refused loudly at the read; got " (pr-str e)))
-                        (.remove container)
-                        (done)))))))))
+                       (when mounted (.unmount (.-react-root ^root/Root mounted))))
+                     (fn [e]
+                       (is (= :rf.error/view-read-outside-render
+                              (:rf.error/id (ex-data e)))
+                           (str "refused loudly at the read; got " (pr-str e)))))
+              (.then (fn [_] (.remove container) (done)))))))))
 
 (deftest a-shell-free-boundary-still-resolves-a-frame-for-a-snapshot-read
   (testing "The ruling keeps `rf/subscribe-once` legal under the flag — a
@@ -217,15 +221,15 @@
                        (is (= "41" (text container "#snapshot"))
                            "the ambient one-shot read resolved the mounting frame
                             through the React frame context, with no shell above it")
-                       (when mounted (.unmount (.-react-root ^root/Root mounted)))
-                       (.remove container)
-                       (done)))
+                       ;; Fulfilment-only: there is no root to unmount on the
+                       ;; rejection arm. The container detach is shared.
+                       (when mounted (.unmount (.-react-root ^root/Root mounted)))))
               (.catch (fn [e]
                         (is false
                             (str "the snapshot read failed in a shell-free boundary: "
                                  (pr-str e)))
-                        (.remove container)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (.remove container) (done)))))))))
 
 ;; ===========================================================================
 ;; 2 — a reactive child of a shell-free parent stays reactive
@@ -255,14 +259,12 @@
                            (.then (fn [_]
                                     (is (= "42" (text container "#child"))
                                         "and it repainted when the value moved")
+                                    ;; Fulfilment-only. The nested chain is
+                                    ;; RETURNED into the outer one, which finishes.
                                     (when mounted
-                                      (.unmount (.-react-root ^root/Root mounted)))
-                                    (.remove container)
-                                    (done))))))
-              (.catch (fn [e]
-                        (is false (str "shell-free parent mount rejected: " e))
-                        (.remove container)
-                        (done)))))))))
+                                      (.unmount (.-react-root ^root/Root mounted))))))))
+              (.catch (fn [e] (is false (str "shell-free parent mount rejected: " e)) nil))
+              (.then (fn [_] (.remove container) (done)))))))))
 
 ;; ===========================================================================
 ;; 3 — the event door, with no candidate: SILENT LOSS
@@ -297,11 +299,11 @@
                        (is (nil? (:pressed (db)))
                            "the click dispatched NOTHING — the authored intent vanished")
                        (act #(.unmount react-root))))
-              (.then (fn [_] (.remove container) (done)))
-              (.catch (fn [e]
-                        (is false (str "orphan mount rejected: " e))
-                        (.remove container)
-                        (done)))))))))
+              ;; UPSTREAM of the step that finishes: reports and releases, never
+              ;; finishes. Downstream it would claim a later namespace's throw as
+              ;; this row's and fire `done` a second time (rf2-fyba).
+              (.catch (fn [e] (is false (str "orphan mount rejected: " e)) nil))
+              (.then (fn [_] (.remove container) (done)))))))))
 
 (deftest the-same-markup-inside-a-shell-owning-boundary-dispatches
   (testing "The CONTROL for the arm above, and the reason it is a LOSS
@@ -335,14 +337,12 @@
                            (.then (fn [_]
                                     (is (true? (:pressed (db)))
                                         "the committed site dispatched into the frame")
+                                    ;; Fulfilment-only. The nested chain is RETURNED
+                                    ;; into the outer one, which finishes.
                                     (when mounted
-                                      (.unmount (.-react-root ^root/Root mounted)))
-                                    (.remove container)
-                                    (done))))))
-              (.catch (fn [e]
-                        (is false (str "owned mount rejected: " e))
-                        (.remove container)
-                        (done)))))))))
+                                      (.unmount (.-react-root ^root/Root mounted))))))))
+              (.catch (fn [e] (is false (str "owned mount rejected: " e)) nil))
+              (.then (fn [_] (.remove container) (done)))))))))
 
 (deftest a-v-event-carrier-with-no-candidate-loses-its-conversion
   (testing "The `v/event` spelling degrades on the same fork: its whole
@@ -372,16 +372,16 @@
                        (is (nil? (:pressed (db)))
                            "the declared conversion never reached a dispatcher")
                        (act #(.unmount react-root))))
-              (.then (fn [_] (.remove container) (done)))
               (.catch (fn [e]
                         ;; A THROW here is a perfectly good outcome for the
                         ;; spike's purposes — it would mean the position
-                        ;; already fails loud. Record which happened.
+                        ;; already fails loud. Record which happened, and
+                        ;; RELEASE: the trailing step below finishes.
                         (is (some? (:rf.error/id (ex-data e)))
                             (str "the carrier position raised rather than degraded: "
                                  (pr-str (ex-data e))))
-                        (.remove container)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (.remove container) (done)))))))))
 
 (deftest a-bare-function-with-no-candidate-keeps-working-and-loses-its-site
   (testing "The THIRD degradation, and the most dangerous of the three
@@ -417,11 +417,8 @@
                            "non-vacuous: no re-frame site was involved; this is a raw
                             DOM callback with none of D008's identity laws")
                        (act #(.unmount react-root))))
-              (.then (fn [_] (.remove container) (done)))
-              (.catch (fn [e]
-                        (is false (str "bare-fn mount rejected: " e))
-                        (.remove container)
-                        (done)))))))))
+              (.catch (fn [e] (is false (str "bare-fn mount rejected: " e)) nil))
+              (.then (fn [_] (.remove container) (done)))))))))
 
 ;; ===========================================================================
 ;; 4 — the declared-host callback door, with no candidate
@@ -473,10 +470,12 @@
                            "the host called the raw carrier fn; the intent it answered
                             was discarded and nothing dispatched")
                        (act #(.unmount react-root))))
-              (.then (fn [_] (.remove container) (done)))
               (.catch (fn [e]
+                        ;; As above: a raise is an acceptable outcome here, so this
+                        ;; records which happened and RELEASES — the trailing step
+                        ;; finishes.
                         (is (some? (:rf.error/id (ex-data e)))
                             (str "the host callback position raised rather than degraded: "
                                  (pr-str (ex-data e))))
-                        (.remove container)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (.remove container) (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/substrate_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/substrate_dom_cljs_test.cljs
@@ -199,13 +199,17 @@
                        (is (= "42" (text container ".count"))
                            "and the page repainted on its own — the notification
                             chain the adapter installs, end to end")
-                       (v/unmount! @mounted)
-                       (.remove container)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "automatic-repaint arm rejected: " e))
-                        (.remove container)
-                        (done)))))))))
+                       ;; ASYMMETRIC, so it stays put: `@mounted` is only set once
+                       ;; the mount resolved, and the rejection arm never had a
+                       ;; root to unmount. The container detach both arms DID
+                       ;; share rides the single trailing step below.
+                       (v/unmount! @mounted)))
+              ;; Reports and RELEASES; it never finishes (rf2-fyba). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str "automatic-repaint arm rejected: " e)) nil))
+              (.then (fn [_] (.remove container) (done)))))))))
 
 (deftest a-real-click-through-a-committed-site-repaints-the-page
   (testing "The same chain driven by a real DOM click rather than a test
@@ -230,13 +234,10 @@
                        (is (= 1 (db-count)) "the click reached the frame")
                        (is (= "1" (text container ".count"))
                            "and the page shows what app-db now holds")
-                       (v/unmount! @mounted)
-                       (.remove container)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "click arm rejected: " e))
-                        (.remove container)
-                        (done)))))))))
+                       ;; Success-only, as above.
+                       (v/unmount! @mounted)))
+              (.catch (fn [e] (is false (str "click arm rejected: " e)) nil))
+              (.then (fn [_] (.remove container) (done)))))))))
 
 ;; ===========================================================================
 ;; flush-render! returns with the page SETTLED
@@ -268,13 +269,10 @@
                        (is (= 0 (cell/pending-count))
                            "and the pending window is quiescent, not merely
                             drained-then-refilled")
-                       (v/unmount! @mounted)
-                       (.remove container)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "flush-render! arm rejected: " e))
-                        (.remove container)
-                        (done)))))))))
+                       ;; Success-only, as above.
+                       (v/unmount! @mounted)))
+              (.catch (fn [e] (is false (str "flush-render! arm rejected: " e)) nil))
+              (.then (fn [_] (.remove container) (done)))))))))
 
 ;; ===========================================================================
 ;; Disposal — the roots first, then the spine
@@ -313,15 +311,9 @@
                            "and so was the right")
                        (is (nil? (rf/current-adapter))
                            "and the spine was disposed after the drain, not
-                            before it")
-                       (.remove left)
-                       (.remove right)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "disposal arm rejected: " e))
-                        (.remove left)
-                        (.remove right)
-                        (done)))))))))
+                            before it")))
+              (.catch (fn [e] (is false (str "disposal arm rejected: " e)) nil))
+              (.then (fn [_] (.remove left) (.remove right) (done)))))))))
 
 (deftest unmounting-a-root-destroys-the-frame-it-owned
   (testing "The ORDERLY path, and the one that destroys a frame. A root given a
@@ -359,13 +351,9 @@
                            "and its ledger row went with it")
                        (is (= #{} (root/live-root-ids)))
                        (is (nil? (text container ".count"))
-                           "the container was emptied by a real unmount")
-                       (.remove container)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "orderly-unmount arm rejected: " e))
-                        (.remove container)
-                        (done)))))))))
+                           "the container was emptied by a real unmount")))
+              (.catch (fn [e] (is false (str "orderly-unmount arm rejected: " e)) nil))
+              (.then (fn [_] (.remove container) (done)))))))))
 
 (deftest destroying-the-adapter-drains-a-forgotten-root-without-running-a-destroy-recipe
   (testing "The SAFETY NET, and its honest boundary. Core claims the installed
@@ -401,13 +389,9 @@
                        (is (nil? (get (root/frame-ledger-snapshot) owned))
                            "its frame reference was released and the row went")
                        (is (nil? (rf/current-adapter))
-                           "and the spine was disposed after the drain, not before")
-                       (.remove container)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "forgotten-root drain rejected: " e))
-                        (.remove container)
-                        (done)))))))))
+                           "and the spine was disposed after the drain, not before")))
+              (.catch (fn [e] (is false (str "forgotten-root drain rejected: " e)) nil))
+              (.then (fn [_] (.remove container) (done)))))))))
 
 ;; ===========================================================================
 ;; Dispose, then re-init — a clean generation
@@ -458,17 +442,24 @@
                                                    (is (= "101" (text second-container ".count"))
                                                        "and it repaints — the new
                                                         generation's watch is live")
-                                                   (v/unmount! m)
-                                                   (.remove second-container)
-                                                   (done))))))
-                             (.catch (fn [e]
-                                       (is false (str "re-init mount rejected: " e))
-                                       (.remove second-container)
-                                       (done)))))))
+                                                   ;; Success-only: `m` is what the
+                                                   ;; mount resolved with.
+                                                   (v/unmount! m))))))
+                             (.catch (fn [e] (is false (str "re-init mount rejected: " e)) nil))
+                             ;; The inner chain finishes NOTHING. It is returned into
+                             ;; the outer one, whose trailing step owns the single
+                             ;; `done` — so a rejection in here cannot be claimed by
+                             ;; a handler sitting downstream of a `done` that ran.
+                             (.then (fn [_] (.remove second-container) nil))))))
               (.catch (fn [e]
                         (is false (str "re-init arm rejected: " e))
+                        ;; DEFENSIVE, and therefore failure-only: the success path
+                        ;; detaches this container at its own point in the sequence,
+                        ;; before the second generation mounts, so this arm is the
+                        ;; only one that can be left holding it.
                         (.remove first-container)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; Non-vacuity


### PR DESCRIPTION
Closes rf2-d2xz — freehand batch **2 of 4**. `implementation/freehand` only, five files.

`cljs.test/run-block` hands `done` a continuation that runs the **whole remainder of the
run synchronously**, so anything a LATER namespace throws unwinds back into the callback
that called `done`. A `.catch` placed *downstream* of that callback claims the foreign
failure as its own — printed against whichever test is current by then — and calls `done`
a **second** time, re-forcing `run-block`'s still-unrealized `Delay` and **re-running the
offending namespace**. The cure is the one landed in #7937, #7951 and #7954: the rejection
handler goes **upstream**, reports and releases but never finishes, and exactly **one**
`done` sits at the tail with nothing after it.

## The count is 43, not 42 — and the nested-step defect did apply here

I rebuilt the scanner from the bead's stated signature (steps matching
`^\s*\((\.then|\.catch|\.finally)\b`, `;;` comments stripped, flag any chain where a step
whose body contains `(done)` is followed by a `.catch`), with rf2-53uz's stack correction
so a nested step does not split its parent. It reproduces **184 across 46 files** for
`implementation/freehand` — rf2-53uz's corrected figure exactly.

| file | bead | scanner | why |
|---|---|---|---|
| `pilot_react_interop_dom_cljs_test.cljs` | 11 | 11 | — |
| `bench/hicasso/lane_window_dom_cljs_test.cljs` | 9 | 9 | — |
| `reactive_false_shell_free_dom_cljs_test.cljs` | 8 | 8 | — |
| `substrate_dom_cljs_test.cljs` | **7** | **8** | nested-step split |
| `controlled_input_dom_cljs_test.cljs` | 7 | 7 | — |
| | **42** | **43** | |

`substrate`'s `a-disposed-adapter-re-inits-to-a-clean-generation` is the one: strict
equal-indent grouping closes the outer chain when the nested re-mount's `.then` appears
inside a step body, so the outer `.then`→`.catch` pairing is lost and only the inner chain
is counted. Both are real and both are repaired. **The second defect rf2-53uz found — a
`(done)` in the `->` HEAD expression — I verified rather than assumed: zero occurrences in
this batch. All 43 are the plain step-`done` shape.** After this PR the scanner reports
**141** for `implementation/freehand`, i.e. 184 − 43, re-run on the shipped tree.

### The bead's lane note does not hold at source, and lane_window IS covered

The bead warns that `lane_window` "is under `test/re_frame/bench/hicasso/`, which the
`:browser-test` ns-regexp EXCLUDES (`^re-frame.freehand.bench.`)". It does not. The
regexp is `^(?!re-frame\.freehand\.bench\.).*-dom-cljs-test$` and the namespace is
`re-frame.bench.hicasso.lane-window-dom-cljs-test` — the *directory* is under `freehand/`,
the *namespace* is not, so the lookahead never fires. Verified empirically, not by reading:
`out/browser-test/js/cljs-runtime/re_frame.bench.hicasso.lane_window_dom_cljs_test.js`
exists after the compile and `shadow.test.browser.js` requires it. The namespaces the
lookahead really excludes are `re-frame.freehand.bench.b1-dom-cljs-test` and its siblings.
`lane_window` is proven by the browser lane; it is **not** in `:node-test-freehand`, whose
regexp is `^re-frame\.freehand\..+-cljs-test$`. The other four ride both.

## Per-chain dispositions

**Teardown was not hoisted mechanically** — each site's two arms were compared first, and
three of the five files kept an asymmetry that hoisting would have changed.

| file | n | disposition |
|---|---|---|
| `pilot_react_interop` | 11 | 10 pure positional swaps; 1 finished from a NESTED chain, now returned into the outer one. **Nothing hoisted** — see below. |
| `lane_window` | 9 | Perfectly uniform. `(.remove c)` is on both arms and idempotent → single trailing step. Every DOM read-back (`lane/text-at`) stays upstream of it. |
| `reactive_false_shell_free` | 8 | 1 two-arg `.then` (the `.catch` IS the success path); 4 already had a trailing `done` step with the `.catch` *after* it — the two steps swap; 2 nested chains returned into their outer chain; 1 plain. |
| `substrate` | 8 | 5 shared `(.remove container)` hoisted; `(v/unmount! @mounted)` **kept success-only**; the re-init row's nested chain returned into the outer, its `(.remove first-container)` **kept failure-only**. |
| `controlled_input` | 7 | 6 shared `teardown!` hoisted; 1 nested chain (the explicit-nil clearing row) returned into the outer, whose trailing step owns `restore` + `teardown!` + the single `done`. |

### The `.catch` that IS the row's success path

`reactive_false_shell_free`'s `a-shell-free-boundary-refuses-a-helper-mediated-read-at-first-render`
asserts the mount **must be refused**: `(is false "the shell-free mount SUCCEEDED …")` sat
in the `.then` and the real assertion — `:rf.error/view-read-outside-render` — in the
`.catch`. It is still an instance, because the fulfilment arm calls `done` with the
`.catch` downstream of it. The two handlers are now **siblings of one two-arg `.then`**,
which states "exactly one of these runs" directly, followed by the single trailing `done`.

### Asymmetric teardown I did NOT hoist, and why

- **`substrate`: `(v/unmount! @mounted)` stays in the fulfilment arm** (3 rows). `@mounted`
  is only `reset!` once the mount resolved, so the rejection arm never had a root; hoisting
  would call `v/unmount!` on `nil` on every failure. Only the shared `(.remove container)`
  moved.
- **`substrate`: the re-init row's `(.remove first-container)` stays in the `.catch`.** The
  success path detaches that container at its own point in the sequence — *before* the
  second generation mounts and `rf/init!` runs — so the failure arm is the only one that
  can be left holding it. It is a defensive duplicate, not a shared step, and the same
  reasoning as #7951's `fast_refresh_shell` unmount.
- **`pilot_react_interop`: nothing hoisted at all.** Every `.catch` in that file is
  report-only; `(teardown! container mounted)` and `(.remove container)` already exist on
  the fulfilment arm alone, because `mounted` is what the resolved mount produced. Hoisting
  would have **added** a teardown to the failure path.
- **`reactive_false_shell_free`: `(when mounted (.unmount …))` stays fulfilment-only** for
  the same reason, and two `.catch`es keep a real assertion (`(is (some? (:rf.error/id
  (ex-data e))) …)` — a raise is an acceptable outcome for that spike) — only the
  *finishing* moved out of them.

One chain in `pilot_react_interop` was already correct (rf2-qpns repaired it); the scanner
does not flag it and it is untouched.

## Re-scan after repair: ZERO, not "gained a trailing step"

rf2-53uz's first scripted pass added the trailing `done` without removing the success arm's
own, leaving rows calling `done` twice. Every file was **re-scanned after repair** and every
one reports 0. Structural cross-check, `(async done` blocks vs literal `(done)` calls:

| file | async blocks | `(done)` calls |
|---|---|---|
| `pilot_react_interop` | 12 | 12 |
| `lane_window` | 9 | 18 |
| `reactive_false_shell_free` | 8 | 8 |
| `substrate` | 7 | 7 |
| `controlled_input` | 9 | 9 |

`lane_window`'s 18 is correct and not a double-finish: each row carries an `if-not
(lane/browser?)` early return whose `(do (is true off-browser) (done))` is mutually
exclusive with the chain's trailing one. Paren balance was machine-checked per file.

## Reproduction control — both directions

A green aggregate is not proof; the runner echoes the browser console only on failure.
Throwaway namespace `re-frame.freehand.substrate-dom-cljs-test-zz-control-dom-cljs-test`
sorts **immediately** after `re-frame.freehand.substrate-dom-cljs-test` — a prefix
extension, and `shadow.test` sorts namespaces by name (`sort-by first`), so nothing sorts
between them. It carries a fn-form `:each` fixture plus an `async` row, which selects
cljs.test's `:sync` path, wraps the test in `disable-async`, and rethrows a bare **String**
synchronously inside whichever `done` continuation is running.

**Direction 1 — control present, `substrate_dom_cljs_test.cljs` reverted to `origin/main`**
(everything else repaired). `npm run test:browser` → **captured exit 1**:

```
Testing re-frame.freehand.substrate-dom-cljs-test
Testing re-frame.freehand.substrate-dom-cljs-test-zz-control-dom-cljs-test
FAIL in (a-row-that-needs-async) (:)
re-init mount rejected: Async tests require fixtures to be specified as maps.  Testing aborted.
Testing re-frame.freehand.substrate-dom-cljs-test-zz-control-dom-cljs-test   <-- RE-RAN
FAIL in (a-row-that-needs-async) (:)
re-init arm rejected: Async tests require fixtures to be specified as maps.  Testing aborted.
Testing re-frame.freehand.substrate-dom-cljs-test-zz-control-dom-cljs-test   <-- AGAIN
FAIL in (a-row-that-needs-async) (:)
forgotten-root drain rejected: Async tests require fixtures to be specified as maps.  Testing aborted.
WARNING: Async test called done more than one time.
```

Every part of the predicted signature, and the cascade runs **three deep**: `re-init mount
rejected:`, `re-init arm rejected:` and `forgotten-root drain rejected:` are `substrate`'s
own `.catch` messages printed against **the control's** test name; the control namespace is
announced **three times** — each second `done` re-forced the unrealized delay and re-ran the
namespace, the throw unwinding one level further out each time, first into the re-init row's
inner `.catch`, then its outer one, then the *previous* deftest's; `WARNING: Async test
called done more than one time.`; and **zero** `Ran N tests containing M assertions` lines.

**Direction 2 — the identical control, `substrate_dom_cljs_test.cljs` restored.** Restore
verified by hashing the bytes, not `git diff`
(`sha256 dc70b9d68cc689b9c5b691543cdd6d1a695e91362f2be7fc373a72ebf4faad41`, before and
after). `npm run test:browser` → **captured exit 1**, and the cascade collapses from three
claims to one:

```
Testing re-frame.freehand.substrate-dom-cljs-test
Testing re-frame.freehand.substrate-dom-cljs-test-zz-control-dom-cljs-test
FAIL in (a-row-that-needs-async) (:)
the browser step rejected: Async tests require fixtures to be specified as maps.  Testing aborted.
WARNING: Async test called done more than one time.
```

The control namespace is announced **once**, not three times — `substrate` no longer
participates. Exit is still 1 because the control genuinely aborts `cljs.test`, which is the
control doing its job. The one remaining claim, `the browser step rejected: `, is **not from
this batch** — and chasing it produced a finding.

The control was then deleted and all five files re-hashed to their shipped digests;
`git status` is clean and the gate numbers below are from the tree as it ships.

## A third scanner blind spot, filed as rf2-29ua

`the browser step rejected: ` is `fail-and-finish!`'s message, from
`controls_kit` / `splitter` / `typeahead_witness` / `virtual_collection` — four
`implementation/freehand` files that route **both** arms through local helpers:

```clojure
(defn- fail-and-finish! [container root done]
  (fn [e] (is false (str "the browser step rejected: " e))
          (ms/destroy-root! container root)
          (done)))

(-> (render! root plain-field)
    (.then (fn [_] … (finish! container root done)))
    (.catch (fail-and-finish! container root done)))
```

No chain step contains a literal `(done)`, so the stated signature reports these four files
as **zero** — and they are named in **no bead**, including rf2-o0n1's "every hit not claimed
by parts 1-3", which derives its set from the same signature. Extending the scanner to treat
a local `defn` taking a `done` parameter and calling it as a done-caller finds **40** more:
**freehand 184 → 224**. This is the third blind spot after rf2-53uz's two, it is the
largest, and it is *reproduced in the browser above* rather than inferred. Out of this PR's
scope (batch 2 is the bead's five files); filed as **rf2-29ua** with the census, the cure,
and the asymmetry in `finish!`/`fail-and-finish!` (`ms/residue-clean!` is deliberately
success-only) that the repair must preserve.

## Quality gates

Each run alone, in one shell, nothing appended, exit code redirected and echoed on one
command line; `*.exit` artefacts deleted between runs. **The numbers below are the ones
CAPTURED**, not the ones the harness narrated.

| gate | cwd | captured exit | result |
|---|---|---|---|
| `npm run test:browser` | `implementation/` | **0** | Ran **1293** tests containing **8010** assertions. 0 failures, 0 errors. |
| `npm run test:freehand` | `implementation/` | **0** | Ran **1406** tests containing **7786** assertions. 0 failures, 0 errors. |

**The browser count did not move, and the bead's 8008 is stale.** I ran the browser lane a
second time with all five files checked out at `origin/main` and nothing else changed:
**captured exit 0, Ran 1293 tests containing 8010 assertions** — identical to this branch.
8008 is the figure from #7951; two assertions have landed on main since, and neither is
mine. No `deftest` is added or removed and no `is` form is added or removed — per file,
`deftest` 15/9/8/8/9 and `is`-carrying lines 101/52/26/48/52, unchanged on both sides.

`python scripts/check_fast_pr_gap.py --list` → **captured exit 0**: the fast-PR spine does
not decide **97** required checks. Relevant to this diff: the `JVM freehand (clojure -M:test)`
job's *"Assert no dependency on the re-frame.ui donor"* step and the `CLJS (shadow-cljs
:node-test)` job's isolation/bench-compile/Hicasso-release steps report under their job's
name, so a red there names something that is not a test failure. This diff is test-only,
inside `implementation/freehand/test/`, touches no `:require`, adds no namespace and no
build id, so none of the 97 is reachable by it — but the spine is not what proves that; the
two lanes above are.

No assertion was loosened, no suite retuned to dodge the async window, no `run-async`
adoption (its handler reports the generic `"an async matrix cell rejected: "`, which would
replace every row's own diagnostic; only 51 of freehand's chains even `:require`
mount-support). `mount_support.cljs` is untouched.
