### PR TITLE
test(tools): a suite's cleanup must not outlive its own test (rf2-sx7g)

### DIFF
--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/export_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/export_dom_cljs_test.cljs
@@ -309,12 +309,16 @@
                   (is (pos? non-transparent-px)
                       "the PNG raster has drawn (non-transparent) content —
                        the node boxes + the active-state glow, not a blank
-                       transparent edge layer")
-                  (finish)
-                  (done)))
+                       transparent edge layer")))
               (.catch
                 (fn [e]
                   (is false (str "chart-as-png! rejected: " e))
+                  nil))
+              ;; `finish` is shared and symmetric — both arms unmounted and
+              ;; removed the host — so it belongs here, written once and still
+              ;; run once per path, ahead of the single trailing `done`.
+              (.then
+                (fn [_]
                   (finish)
                   (done)))))
         ;; skip (no DOM / no act)

--- a/tools/xray/test/day8/re_frame2_xray/palette/dispatch_routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/dispatch_routing_cljs_test.cljs
@@ -132,9 +132,9 @@
                      (is (false? (boolean (:palette-open? (rf/app-db-value :rf/xray))))
                          ":rf/xray's :palette-open? flips to false")
                      (is (nil? (:palette-open? (rf/app-db-value :rf/default)))
-                         ":rf/default's db is NOT polluted by the dispatch")
-                     (done)))
-            (.catch (fn [e] (is false (.-message e)) (done))))))))
+                         ":rf/default's db is NOT polluted by the dispatch")))
+            (.catch (fn [e] (is false (.-message e)) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest esc-keydown-closes-palette-from-default-frame-context
   (testing "rf2-w8lxg — Esc keydown on the palette input from OUTSIDE
@@ -152,9 +152,9 @@
                      (is (false? (boolean (:palette-open? (rf/app-db-value :rf/xray))))
                          ":rf/xray's :palette-open? flips to false")
                      (is (nil? (:palette-open? (rf/app-db-value :rf/default)))
-                         ":rf/default's db is NOT polluted by Esc dispatch")
-                     (done)))
-            (.catch (fn [e] (is false (.-message e)) (done))))))))
+                         ":rf/default's db is NOT polluted by Esc dispatch")))
+            (.catch (fn [e] (is false (.-message e)) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest arrow-down-keydown-moves-cursor-from-default-frame-context
   (testing "rf2-w8lxg — ArrowDown keydown on the palette input from
@@ -176,9 +176,9 @@
                      (is (pos? (or (:palette-cursor (rf/app-db-value :rf/xray)) 0))
                          ":rf/xray's :palette-cursor advances after ArrowDown")
                      (is (nil? (:palette-cursor (rf/app-db-value :rf/default)))
-                         ":rf/default's db is NOT polluted by the cursor dispatch")
-                     (done)))
-            (.catch (fn [e] (is false (.-message e)) (done))))))))
+                         ":rf/default's db is NOT polluted by the cursor dispatch")))
+            (.catch (fn [e] (is false (.-message e)) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest arrow-up-keydown-routes-to-xray-frame
   (testing "rf2-w8lxg — ArrowUp keydown also routes through the
@@ -199,9 +199,9 @@
                      (is (< (or (:palette-cursor (rf/app-db-value :rf/xray)) 0) 2)
                          ":rf/xray's :palette-cursor decrements after ArrowUp")
                      (is (nil? (:palette-cursor (rf/app-db-value :rf/default)))
-                         ":rf/default's db is NOT polluted by ArrowUp")
-                     (done)))
-            (.catch (fn [e] (is false (.-message e)) (done))))))))
+                         ":rf/default's db is NOT polluted by ArrowUp")))
+            (.catch (fn [e] (is false (.-message e)) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest input-on-change-updates-query-from-default-frame-context
   (testing "rf2-w8lxg — typing into the palette input from OUTSIDE the
@@ -221,6 +221,6 @@
                      (is (= "search" (:palette-query (rf/app-db-value :rf/xray)))
                          ":rf/xray's :palette-query reflects the typed text")
                      (is (nil? (:palette-query (rf/app-db-value :rf/default)))
-                         ":rf/default's db is NOT polluted by typing")
-                     (done)))
-            (.catch (fn [e] (is false (.-message e)) (done))))))))
+                         ":rf/default's db is NOT polluted by typing")))
+            (.catch (fn [e] (is false (.-message e)) nil))
+            (.then (fn [_] (done))))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_tick_loop_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_tick_loop_cljs_test.cljs
@@ -125,13 +125,13 @@
                       the two internal reads did NOT hit
                       :rf.error/no-frame-context (pre-fix this slot stayed
                       nil forever: the throw happened before dispatch, and
-                      the catch swallowed it silently every iteration)")
-                 (done)))
+                      the catch swallowed it silently every iteration)")))
         (.catch (fn [e]
                   (is false
                       (str "tick-loop! never dispatched :rf.xray/timer-tick "
                            "onto :rf/xray — " (.-message e)))
-                  (done))))))
+                  nil))
+        (.then (fn [_] (done))))))
 
 ;; ---- rf2-e64drj — the rAF loop is MOUNT-gated, not only DATA-gated --------
 ;;

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_disclosure_dispatch_routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_disclosure_dispatch_routing_cljs_test.cljs
@@ -144,9 +144,9 @@
                            "the dim memo-hit row list now renders")
                        (is (seq (th/find-by-testid-prefix
                                   tree2 "rf-xray-reactive-unchanged-row-__user_name_"))
-                           "a memo-hit row renders after expand (readable slug stem, injective suffix)"))
-                     (done)))
-            (.catch (fn [e] (is false (.-message e)) (done))))))))
+                           "a memo-hit row renders after expand (readable slug stem, injective suffix)"))))
+            (.catch (fn [e] (is false (.-message e)) nil))
+            (.then (fn [_] (done))))))))
 
 ;; ---- Settings pin expands (the configured axis, alone) -----------------
 
@@ -191,6 +191,6 @@
                      (is (true? (boolean (:reactive/show-unchanged? (rf/app-db-value :rf/xray))))
                          "instance A's disclosure expanded")
                      (is (false? (boolean (:reactive/show-unchanged? (rf/app-db-value :xray-cell-2))))
-                         "instance B is untouched — driving A did not move B")
-                     (done)))
-            (.catch (fn [e] (is false (.-message e)) (done))))))))
+                         "instance B is untouched — driving A did not move B")))
+            (.catch (fn [e] (is false (.-message e)) nil))
+            (.then (fn [_] (done))))))))

--- a/tools/xray/test/day8/re_frame2_xray/settings/editor_hint_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/editor_hint_cljs_test.cljs
@@ -104,6 +104,6 @@
                          "the Settings popup is open")
                      (is (= :general (:settings-active-tab db))
                          "Settings opens on the General tab — the editor
-                          picker's home"))
-                   (done)))
-          (.catch (fn [e] (is false (.-message e)) (done)))))))
+                          picker's home"))))
+          (.catch (fn [e] (is false (.-message e)) nil))
+          (.then (fn [_] (done)))))))

--- a/tools/xray/test/day8/re_frame2_xray/settings/popup_dispatch_routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/popup_dispatch_routing_cljs_test.cljs
@@ -117,9 +117,9 @@
                      (is (false? (boolean (:settings-open? (rf/app-db-value :rf/xray))))
                          ":rf/xray's :settings-open? flips to false")
                      (is (nil? (:settings-open? (rf/app-db-value :rf/default)))
-                         ":rf/default's db is NOT polluted by the dispatch")
-                     (done)))
-            (.catch (fn [e] (is false (.-message e)) (done))))))))
+                         ":rf/default's db is NOT polluted by the dispatch")))
+            (.catch (fn [e] (is false (.-message e)) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest backdrop-click-closes-modal-from-default-frame-context
   (testing "rf2-smvvz — clicking the backdrop from OUTSIDE the
@@ -135,9 +135,9 @@
                             "settings-open? flips false after backdrop click")
             (.then (fn [_]
                      (is (false? (boolean (:settings-open? (rf/app-db-value :rf/xray))))
-                         ":rf/xray's :settings-open? flips to false")
-                     (done)))
-            (.catch (fn [e] (is false (.-message e)) (done))))))))
+                         ":rf/xray's :settings-open? flips to false")))
+            (.catch (fn [e] (is false (.-message e)) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest esc-keydown-closes-modal-from-default-frame-context
   (testing "rf2-smvvz — Esc keydown from OUTSIDE the :rf/xray frame-
@@ -152,9 +152,9 @@
                             "settings-open? flips false after Esc")
             (.then (fn [_]
                      (is (false? (boolean (:settings-open? (rf/app-db-value :rf/xray))))
-                         ":rf/xray's :settings-open? flips to false")
-                     (done)))
-            (.catch (fn [e] (is false (.-message e)) (done))))))))
+                         ":rf/xray's :settings-open? flips to false")))
+            (.catch (fn [e] (is false (.-message e)) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest tab-click-switches-section-from-default-frame-context
   (testing "rf2-smvvz — clicking a tab button from OUTSIDE the
@@ -179,6 +179,6 @@
                      (is (= :buffer (:settings-active-tab (rf/app-db-value :rf/xray)))
                          "tab click flips :settings-active-tab to :buffer")
                      (is (nil? (:settings-active-tab (rf/app-db-value :rf/default)))
-                         ":rf/default's db is NOT polluted by the tab dispatch")
-                     (done)))
-            (.catch (fn [e] (is false (.-message e)) (done))))))))
+                         ":rf/default's db is NOT polluted by the tab dispatch")))
+            (.catch (fn [e] (is false (.-message e)) nil))
+            (.then (fn [_] (done))))))))


### PR DESCRIPTION
Closes rf2-sx7g for `tools/xray` and `tools/machines-viz`. **`tools/story` is untouched and the bead stays open** — see "What I left for story".

`cljs.test/run-block` hands `done` a continuation that runs the **whole remainder of the run synchronously**, so anything a LATER namespace throws unwinds back into the callback that called `done`. A `.catch` placed *downstream* of that callback claims the foreign failure as its own — printed against this row's label — and then calls `done` a **second** time, re-forcing `run-block`'s still-unrealized `Delay` and **re-running the offending namespace**. The cure landed in #7937 / #7951 / #7954: the rejection handler goes **upstream**, reports and releases but never finishes, and exactly **one** `done` sits in a trailing step with nothing after it.

## The true count is 14, and the bead's census was right

I rebuilt the scanner from the stated signature rather than trusting line numbers, carrying both corrections rf2-53uz proved necessary on `re-frame2-pair-mcp`:

1. **nested steps must not split a chain** — open chains kept on a stack, so a deeper `.then` inside a step body no longer closes the outer chain;
2. **`(done)` need not be in a step of the flagged chain** — the head-expression shape, where `done` is called inside the `->` head and the outer `.catch` is still downstream of it.

Calibration: run against `tools/re-frame2-pair-mcp` (unmerged at the time — #7954 was still open) it reproduces **57** of rf2-53uz's 59, including all 14 of `handler_meta_test`'s head-expression chains that the stated signature cannot see. So the scanner is at least as sensitive as the one that found the last census wrong.

**Neither correction moves this bead's trees.** `tools/xray` **13**, `tools/machines-viz` **1** — exactly the census, and rf2-53uz predicted as much. The head-expression idiom occurs nowhere in either tree.

The count is also a **lower bound here, not merely an upper one**, and that is checkable rather than asserted: `tools/xray` and `tools/machines-viz` contain **exactly 14** `.catch`/`.finally` steps between them across their whole test trees, and all 14 are flagged. There was no unflagged chain left to read, so no "left correct" disposition was available to reach — every chain in scope was an instance.

**Re-scanned after repair: `tools/xray` + `tools/machines-viz` scan to ZERO.** (rf2-53uz's first scripted pass added a trailing `done` without removing the success arm's own, leaving rows calling `done` twice; the re-scan is what caught it, so it is repeated here.)

## Per-chain dispositions

Teardown was **not** hoisted mechanically — both arms were compared at each site first.

| file | n | shape | disposition |
|---|---|---|---|
| `xray/palette/dispatch_routing_cljs_test.cljs` | 5 | pure report-only | `done` removed from the `.then`; `.catch` reports and returns `nil`; single trailing `(.then (fn [_] (done)))` |
| `xray/settings/popup_dispatch_routing_cljs_test.cljs` | 4 | pure report-only | as above |
| `xray/panels/reactive_panel_disclosure_dispatch_routing_cljs_test.cljs` | 2 | pure report-only | as above |
| `xray/panels/machine_after_rings_tick_loop_cljs_test.cljs` | 1 | pure, row-specific diagnostic | as above; the `.catch`'s own "tick-loop! never dispatched …" message is preserved verbatim |
| `xray/settings/editor_hint_cljs_test.cljs` | 1 | pure report-only | as above |
| `machines-viz/export_dom_cljs_test.cljs` | 1 | **shared symmetric teardown** | `(finish)` was called on **both** arms, so it is hoisted into the trailing step ahead of the single `done` — written once, still run once per path |

**No teardown was left asymmetric, because none was.** `machines-viz`'s `finish` is the only teardown in scope: it unmounts the React root and removes the host, both arms called it identically, and both of its operations are `try`/`catch`-wrapped and idempotent. Hoisting it is behaviour-preserving in the strict sense — the same single call on the same single path. Had it been failure-only (the `fast_refresh_shell` / `tool_evidence` pattern #7951 names) it would have stayed put.

**Neither of the two unanticipated shapes occurs here.** No chain in either tree asserts that its promise *rejects*, so there is no `.catch`-that-is-the-success-path needing a two-arg `.then`; and no helper in either tree takes `done` as a parameter (a grep for a `defn`/`defn-` with `done` in its arg vector across both trees returns nothing), so there is no helper-forced shape. `run-async` was **not** adopted — its generic "an async matrix cell rejected: " would have replaced `machine_after_rings`'s row-specific diagnostic, which is the one message here worth keeping.

## Reproduction control — both directions

A throwaway namespace `day8.re-frame2-xray.panels.machine-after-rings-tick-loop-cljs-test-control-cljs-test` — a **prefix extension** of the target, and `shadow.test/test-vars-grouped-block` runs namespaces `(sort-by first)` (verified at source in the shadow-cljs jar), so nothing can sort between them. It carries a **fn-form `:each` fixture** plus an `async` row: the fn-form selects `cljs.test`'s `:sync` strategy, which wraps every var in `disable-async`, which throws `::async-disabled`, which `test-var-block*`'s catch converts into a **bare String** rethrown from *outside* any further try — so it escapes `run-block` and unwinds into whichever `done` continuation is driving the run.

**REVERTED** (target restored to its pre-repair shape, control present):

```
Testing day8.re-frame2-xray.panels.machine-after-rings-tick-loop-cljs-test-control-cljs-test

FAIL in (control-throws-into-whichever-done-continuation-is-running) (:)
tick-loop! never dispatched :rf.xray/timer-tick onto :rf/xray —
expected: false
  actual: false
UnhandledPromiseRejection: ... The promise rejected with the reason "Async tests
require fixtures to be specified as maps.  Testing aborted.".
```

The **target's own `.catch` message, printed against the CONTROL's test name** — the misattribution, verbatim. No summary line at all. And the double-`done` is visible in the same trace: the target's `.catch` called `done` a second time, which re-forced the still-unrealized `Delay` (a CLJS `Delay` clears its thunk only *after* the body returns, so a throwing body leaves it unrealized) and **re-ran the control**, whose second throw escaped the `.catch` handler itself and surfaced as the unhandled rejection.

**REPAIRED** (target at this PR's shape, same control, same selector):

```
UnhandledPromiseRejection: ... The promise rejected with the reason "Async tests
require fixtures to be specified as maps.  Testing aborted.".
```

**Zero `FAIL in` lines.** The `.catch` is now upstream and already settled, so it cannot claim the foreign throw; the throw escapes the trailing step honestly, naming its real cause, **attributed to nobody**.

The control was then deleted and **every restore verified by hashing the bytes**, not `git diff`: all six changed files' `git hash-object` outputs match their `HEAD` blob SHAs exactly, and `git status --porcelain --untracked-files=all` is empty.

## Quality gates

Each run alone, redirected, exit code echoed on one command line. Numbers below are the **captured** ones.

| gate | captured exit | result |
|---|---|---|
| `cd implementation && npm run test:cljs` | **0** | `Ran 13346 tests containing 67232 assertions. 0 failures, 0 errors.` |
| `cd implementation && npm run test:browser` | **0** | `Ran 1293 tests containing 8010 assertions. 0 failures, 0 errors.` |
| `cd implementation && npm run test:tools-machines-viz` | **0** | `Ran 841 tests containing 3717 assertions. 0 failures, 0 errors.` |
| `npx clj-kondo --lint <the 6 changed files>` | **2** | `errors: 0, warnings: 3` — all three are a pre-existing unused `re-frame.frame` require, identical on `origin/main` (verified by linting the `origin/main` copies: same three, same count). The CI job is `--fail-level error`. |

**Test counts did not move.** Deliberately measured rather than assumed: `npm run test:cljs` run against the six files reverted to their pre-repair state reports `Ran 13346 tests containing 67232 assertions`, **identical** to the repaired tree — the repair removes no assertion from any success path and adds none.

### Which lane owns these files, and two bead claims that do not hold at source

- All five `tools/xray` files are `*_cljs_test.cljs` with `-cljs-test` namespaces, so the consolidated `:node-test` build's `cljs-test$` ns-regexp selects them: **`npm run test:cljs` is their lane**, and the fast-PR spine runs it ("CLJS node integration").
- `export_dom_cljs_test`'s namespace ends `-dom-cljs-test`, so the **`:browser-test`** build owns its real body; under `:node-test` the same suite takes its `(browser?)` skip branch. **`npm run test:browser` is the gate that decides this repair**, and the fast-PR spine does **not** run it — `cljs-browser` is on `check_fast_pr_gap.py --list`. Run alone above.
- The bead also names `npm run test:tools-machines-viz`. That **does** cover the file — `:machines-viz-node-test`'s `^day8\.re-frame2-machines-viz\..*-test$` matches `export-dom-cljs-test` — though in Node it exercises the skip branch only. Run anyway.
- **`cd tools/xray && clojure -M:test` does NOT cover this diff**, and neither does `cd tools/machines-viz && clojure -M:test`. Both `:test` aliases run `re-frame.test-quiet.runner` over the JVM classpath; every file changed here is `.cljs`, which a JVM test runner cannot load. Those two lanes would pass identically with or without this PR, so nominating either would have been a gate that does not cover the path. Not run, and not claimed.

### What the fast-PR spine does not decide

`python scripts/check_fast_pr_gap.py --list` reports **97** required checks the spine does not run. For *this* diff the one that matters is `cljs-browser` ("CLJS (shadow-cljs :browser-test, headless Chromium)" — `npm run test:browser`), the only lane that executes `export_dom_cljs_test`'s repaired body; `cljs-tools-machines-viz` is likewise off the spine. Both were run alone above with captured exit **0**. The spine's own `test:cljs` step covers the five xray files.

## Xray spec

**Spec unchanged because this is a test-shape repair with no contract surface.** Nothing in `tools/xray/src/**` is touched, no Xray behaviour, event, sub, panel or public API moves, and no row's assertions change — only where in each promise chain the rejection handler and the single `done` sit. `tools/xray/spec/017-Test-Coverage-Matrix.md` pins user-visible behaviours to gates; the same behaviours are pinned to the same gates by the same tests after this PR. Stating it explicitly rather than skipping it silently, per the rule.

## What I left for story

`tools/story` is **untouched**. The bead states at source: *"SEQUENCE tools/story AFTER worker/story-5gka MERGES."* Its one chain is `tools/story/test/re_frame/story/ui/a11y_stale_settlement_cljs_test.cljs` — the scanner still flags it (`done@175`, `.catch@185`), and it is the only thing standing between this bead and closure.

One thing to flag for whoever picks it up: **no branch named `worker/story-5gka` exists**, on origin or locally. The only `5gka` branch in the repo's history is `worker/presence-5gka` (PR #7865, *"story: re-verify the S2-S6 presence cluster"*), which is **already MERGED**. So the fence may already be satisfied under a different branch name, or it may name work that was never dispatched. I did not act on that ambiguity — the fence is on the bead, so I honoured it as written. `share_egress_cljs_test.cljs` carries five further `.catch`es in that tree, none of which the scanner flags; whoever does story should read them rather than trust that.

**rf2-sx7g stays OPEN.**
