### PR TITLE
test(freehand): a suite's cleanup must not outlive its own test (rf2-ua8r)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
@@ -445,9 +445,9 @@
                           (is (some? n))
                           (is (.contains (.-classList n) "widget"))))
                       (finally (vreset! census (teardown-census! handle))))
-                    (is (= released @census))
-                    (done))))
-              (.catch (fn [e] (is false (str e)) (done)))))))))
+                    (is (= released @census)))))
+              (.catch (fn [e] (is false (str e)) nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest two-namespaced-keywords-reach-two-providers-as-two-distinct-values
   (async done
@@ -481,9 +481,9 @@
                                 two subtrees differ there"
                         (is (not= (attr handle ".theme-a .widget" "data-theme")
                                   (attr handle ".theme-b .widget" "data-theme")))))
-                    (finally (mount/release! handle)))
-                  (done)))
-              (.catch (fn [e] (is false (str e)) (done)))))))))
+                    (finally (mount/release! handle)))))
+              (.catch (fn [e] (is false (str e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — callbacks out, and React-owned state surviving Hicasso re-renders
@@ -1204,8 +1204,9 @@
                              props, so the crossing was never re-run")
                         (is (= 1 (:mounts @!instr))
                             "nor was it remounted"))
-                      (finally (mount/release! handle) (done)))))
-                (.catch (fn [e] (is false (str e)) (done))))))))))
+                      (finally (mount/release! handle)))))
+                (.catch (fn [e] (is false (str e)) nil))
+                (.then (fn [_] (done))))))))))
 
 (deftest a-memoised-hosted-component-and-the-doors-honest-cost
   (async done
@@ -1255,5 +1256,6 @@
                         (mount/dispatch! @handle [:hatch/set :label "moved-again"])
                         (is (= "moved-again" (.-textContent (q @handle ".mlabel"))))
                         (is (= (inc before) (:renders @!instr)))))
-                    (finally (mount/release! @handle) (done)))))
-              (.catch (fn [e] (is false (str e)) (done)))))))))
+                    (finally (mount/release! @handle)))))
+              (.catch (fn [e] (is false (str e)) nil))
+              (.then (fn [_] (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/behavior_async_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/behavior_async_dom_cljs_test.cljs
@@ -599,9 +599,9 @@
               (.then (fn [_]
                        (is (= [[:acquire 1 [1 2]] [:set-spec 1 [1 2]] [:dispose 1]] @ops)
                            "unmount released it, exactly once")
-                       (released! "FH-BEHAVIOR-005 — after teardown")
-                       (done)))
-              (.catch (fn [e] (is false (str "mount rejected: " e)) (done)))))))))
+                       (released! "FH-BEHAVIOR-005 — after teardown")))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; 2 — THE HEADLINE: unmount BEFORE the Promise resolves
@@ -656,9 +656,9 @@
                        (is (= [false] (accepted))
                            "and its outward dispatch was REFUSED — the context is
                             fenced to a generation that is gone")
-                       (released! "FH-BEHAVIOR-005 — after the late arrival")
-                       (done)))
-              (.catch (fn [e] (is false (str "mount rejected: " e)) (done)))))))))
+                       (released! "FH-BEHAVIOR-005 — after the late arrival")))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; 3 — config that moves while the acquisition is in flight
@@ -700,9 +700,9 @@
                        (ms/act #(ms/destroy-root! container root))))
               (.then (fn [_]
                        (is (= [:dispose 1] (last @ops)) "and it still releases once")
-                       (released! "FH-BEHAVIOR-005 — after teardown")
-                       (done)))
-              (.catch (fn [e] (is false (str "mount rejected: " e)) (done)))))))))
+                       (released! "FH-BEHAVIOR-005 — after teardown")))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; 4 — a failure that arrives after teardown
@@ -739,9 +739,9 @@
                             has already settled the connection is terminal")
                        (is (= [false] (accepted))
                            "and its dispatch was refused, because the view is gone")
-                       (released! "FH-BEHAVIOR-005 — after the late rejection")
-                       (done)))
-              (.catch (fn [e] (is false (str "mount rejected: " e)) (done)))))))))
+                       (released! "FH-BEHAVIOR-005 — after the late rejection")))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; 5 — a command while the host is still pending
@@ -792,9 +792,9 @@
                        (ms/act #(ms/destroy-root! container root))))
               (.then (fn [_]
                        (is (= [:dispose 1] (last @ops)))
-                       (released! "FH-BEHAVIOR-005 — after teardown")
-                       (done)))
-              (.catch (fn [e] (is false (str "mount rejected: " e)) (done)))))))))
+                       (released! "FH-BEHAVIOR-005 — after teardown")))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; 6 — THE FINALIZER FAILS, on the first release
@@ -864,13 +864,13 @@
                             than routing or swallowing it")
                        (is (= [[:chart/ready :main]] (events))
                            "and the teardown announced nothing of its own — the only
-                            event is the one the successful install sent")
-                       (close-door)
-                       (done)))
+                            event is the one the successful install sent")))
               (.catch (fn [e]
-                        (close-door)
                         (is false (str "case rejected: " e))
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (close-door)
+                       (done)))))))))
 
 ;; ===========================================================================
 ;; 7 — the same failure, on the LATE-SUCCESS finalizer
@@ -928,10 +928,10 @@
                             continuation is an unhandled rejection, not a React error")
                        (is (= [] (events))
                            "so the :chart/abandoned announcement AFTER the dispose never
-                            ran: a refusing host takes the notification with it")
-                       (close-door)
-                       (done)))
+                            ran: a refusing host takes the notification with it")))
               (.catch (fn [e]
-                        (close-door)
                         (is false (str "case rejected: " e))
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (close-door)
+                       (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/behavior_compiled_parity_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/behavior_compiled_parity_dom_cljs_test.cljs
@@ -114,6 +114,10 @@
         (-> (lifecycle-of! bv/plain)
             (.then (fn [interpreted]
                      (reset-lifecycle!)
+                     ;; The inner chain keeps its OWN diagnostic — a compiled
+                     ;; rejection and an interpreted one are different findings —
+                     ;; but neither handler finishes the row. Both report and
+                     ;; release; the single `done` is at the tail of the outer chain.
                      (-> (lifecycle-of! bv/plain-compiled)
                          (.then (fn [compiled]
                                   (is (= [:connect :update :disconnect] (mapv :op compiled))
@@ -121,14 +125,14 @@
                                   (is (= interpreted compiled)
                                       "and its WHOLE transcript equals the interpreted one — one runtime, both modes")
                                   (is (zero? (behaviors/connection-count))
-                                      "teardown left the connection table empty")
-                                  (done)))
+                                      "teardown left the connection table empty")))
                          (.catch (fn [e]
                                    (is false (str "compiled mount rejected: " e))
-                                   (done))))))
+                                   nil)))))
             (.catch (fn [e]
                       (is false (str "interpreted mount rejected: " e))
-                      (done))))))))
+                      nil))
+            (.then (fn [_] (done))))))))
 
 ;; ===========================================================================
 ;; The command channel reaches a compiled connection
@@ -160,12 +164,14 @@
                            "the command performed host work on the compiled node")
                        (teardown! container root)
                        (is (zero? (behaviors/connection-count))
-                           "and teardown released the connection")
-                       (done)))
+                           "and teardown released the connection")))
+              ;; Teardown is the ACT under test on the success arm, so it is not
+              ;; hoisted — the failure arm tears down for its own reason.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
                         (teardown! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; The :layout arm runs before paint in the compiled tier
@@ -190,12 +196,14 @@
                            "and its before-paint work is on the node")
                        (teardown! container root)
                        (is (zero? (behaviors/connection-count))
-                           "and released on unmount")
-                       (done)))
+                           "and released on unmount")))
+              ;; Teardown is the ACT under test on the success arm, so it is not
+              ;; hoisted — the failure arm tears down for its own reason.
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
                         (teardown! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; The opaque-child law holds at RUNTIME in the compiled browser path
@@ -255,8 +263,8 @@
                      (mount-outcome! bv/opaque-with-children)))
             (.then (fn [i-kids]
                      (is (= :rf.error/behavior-bad-args (:id i-kids))
-                         "and the interpreted twin refuses on the SAME diagnostic — the two browser modes agree")
-                     (done)))
+                         "and the interpreted twin refuses on the SAME diagnostic — the two browser modes agree")))
             (.catch (fn [e]
                       (is false (str "an opaque-child mount chain rejected unexpectedly: " e))
-                      (done))))))))
+                      nil))
+            (.then (fn [_] (done))))))))

--- a/implementation/freehand/test/re_frame/freehand/behavior_matrix_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/behavior_matrix_dom_cljs_test.cljs
@@ -78,13 +78,13 @@
                        (is (= 1 (behaviors/connection-count)) "exactly one connection")
                        (is (= #{:probe/one} (behaviors/target-ids))
                            "claiming the id the use site declared")
-                       (is (= [:connect] (bv/ops)) "and connected exactly once")
-                       (ms/destroy-root! container root)
-                       (done)))
+                       (is (= [:connect] (bv/ops)) "and connected exactly once")))
               (.catch (fn [e]
                         (is false (str "the behavior mount rejected: " e))
-                        (ms/destroy-root! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (ms/destroy-root! container root)
+                       (done)))))))))
 
 ;; ===========================================================================
 ;; Row 2 — a command reaches its target and runs host work; bounded refusals
@@ -116,13 +116,13 @@
                            (is (= :rf.error/behavior-command-refused (:rf.error/id d))
                                (str why " is refused with the bounded diagnostic"))))
                        (is (= "hit" (node-attr container "data-mark"))
-                           "and no refusal touched the node the accepted command marked")
-                       (ms/destroy-root! container root)
-                       (done)))
+                           "and no refusal touched the node the accepted command marked")))
               (.catch (fn [e]
                         (is false (str "the behavior mount rejected: " e))
-                        (ms/destroy-root! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (ms/destroy-root! container root)
+                       (done)))))))))
 
 ;; ===========================================================================
 ;; Row 3 — :update observes committed-config movement, not re-renders
@@ -151,13 +151,13 @@
                            "a moved config reconciles the host, exactly once")
                        (let [{:keys [config prev-config]} (last @bv/transcript)]
                          (is (= {:label "moved"} config) "with the new config")
-                         (is (= {:label "a"} prev-config) "and the previous one alongside it"))
-                       (ms/destroy-root! container root)
-                       (done)))
+                         (is (= {:label "a"} prev-config) "and the previous one alongside it"))))
               (.catch (fn [e]
                         (is false (str "the behavior mount rejected: " e))
-                        (ms/destroy-root! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (ms/destroy-root! container root)
+                       (done)))))))))
 
 ;; ===========================================================================
 ;; Row 4 — teardown releases everything, the exact integer zero (acceptance 3)
@@ -191,14 +191,17 @@
                        (is (= 0 (behaviors/connection-count))
                            "teardown released the connection to EXACTLY zero")
                        (is (= #{} (behaviors/target-ids)) "and dropped the target claim")
-                       (is (= [:connect :disconnect] (bv/ops)) "disconnecting exactly once")
-                       (ms/destroy-root! cc rc)
-                       (done)))
+                       (is (= [:connect :disconnect] (bv/ops)) "disconnecting exactly once")))
+              ;; The behaviour root's teardown is the ACT under test above, so the
+              ;; failure arm keeps its own — the two arms are destroying it for
+              ;; different reasons. Only the control root is shared teardown.
               (.catch (fn [e]
                         (is false (str "a behavior mount rejected: " e))
                         (ms/destroy-root! container root)
-                        (ms/destroy-root! cc rc)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (ms/destroy-root! cc rc)
+                       (done)))))))))
 
 ;; ===========================================================================
 ;; Row 5 — the compiled tier ATTACHES the behavior boundary (the mode cell)
@@ -232,9 +235,11 @@
                        (is (= [:connect] (bv/ops)) "and connected exactly once")
                        (ms/destroy-root! container root)
                        (is (= 0 (behaviors/connection-count))
-                           "and released on teardown to exact zero")
-                       (done)))
+                           "and released on teardown to exact zero")))
+              ;; Teardown is the act under test on the success arm, so it is NOT
+              ;; hoisted — the failure arm tears down for its own reason.
               (.catch (fn [e]
                         (is false (str "the compiled behavior mount rejected: " e))
                         (ms/destroy-root! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/data_attr_casing_probe_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/data_attr_casing_probe_dom_cljs_test.cljs
@@ -131,15 +131,15 @@
                                               "svg" nil (react/createElement Child)))))))
               (.then (fn [msgs]
                        (is (some #(str/includes? % "data-cdx") msgs)
-                           "and warns across a component boundary too")
+                           "and warns across a component boundary too")))
+              (.catch (fn [e]
+                        (is false (str "probe failed: " e))
+                        nil))
+              (.then (fn [_]
                        (ms/destroy-root! c1 r1)
                        (ms/destroy-root! c2 r2)
                        (ms/destroy-root! c3 r3)
-                       (done)))
-              (.catch (fn [e]
-                        (ms/destroy-root! c1 r1) (ms/destroy-root! c2 r2) (ms/destroy-root! c3 r3)
-                        (is false (str "probe failed: " e))
-                        (done)))))))))
+                       (done)))))))))
 
 ;; ===========================================================================
 ;; Obligation 2 — the DOM facts, read off a real react-dom mount
@@ -168,11 +168,13 @@
                          (is (= "x" (.getAttribute node mixed))
                              "getAttribute is case-insensitive on HTML")
                          (is (= "x" (gobj/get (.-dataset node) (dataset-key low)))
-                             ".dataset keys off the lowercased name — the casing is lost"))
+                             ".dataset keys off the lowercased name — the casing is lost"))))
+              (.catch (fn [e]
+                        (is false (str "probe failed: " e))
+                        nil))
+              (.then (fn [_]
                        (ms/destroy-root! container root)
-                       (done)))
-              (.catch (fn [e] (ms/destroy-root! container root)
-                        (is false (str "probe failed: " e)) (done)))))))))
+                       (done)))))))))
 
 (deftest svg-and-mathml-preserve-the-name-but-lose-it-from-dataset
   (testing "SVG and MathML PRESERVE the mixed-case data-* name, so getAttribute
@@ -208,12 +210,13 @@
                        (render! r3 (react/createElement
                                      "math" nil (react/createElement "mi" (js-props "mth" math-name))))))
               (.then (fn [_]
-                       (check-foreign (.querySelector c3 "#mth") math-name "MathML")
-                       (ms/destroy-root! c1 r1) (ms/destroy-root! c2 r2) (ms/destroy-root! c3 r3)
-                       (done)))
+                       (check-foreign (.querySelector c3 "#mth") math-name "MathML")))
               (.catch (fn [e]
-                        (ms/destroy-root! c1 r1) (ms/destroy-root! c2 r2) (ms/destroy-root! c3 r3)
-                        (is false (str "probe failed: " e)) (done)))))))))
+                        (is false (str "probe failed: " e))
+                        nil))
+              (.then (fn [_]
+                       (ms/destroy-root! c1 r1) (ms/destroy-root! c2 r2) (ms/destroy-root! c3 r3)
+                       (done)))))))))
 
 ;; ===========================================================================
 ;; Obligation 2, continued — the SSR serialise-then-parse divergence
@@ -302,9 +305,10 @@
               (.then (fn [_]
                        (check "SSR/client HTML"   html-name html-ns   "#ssrh" false)
                        (check "SSR/client SVG"    svg-name  svg-ns    "#ssrs" true)
-                       (check "SSR/client MathML" math-name mathml-ns "#ssrm" true)
-                       (ms/destroy-root! container root)
-                       (done)))
+                       (check "SSR/client MathML" math-name mathml-ns "#ssrm" true)))
               (.catch (fn [e]
-                        (ms/destroy-root! container root)
-                        (is false (str "probe failed: " e)) (done)))))))))
+                        (is false (str "probe failed: " e))
+                        nil))
+              (.then (fn [_]
+                       (ms/destroy-root! container root)
+                       (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/flush_sync_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/flush_sync_dom_cljs_test.cljs
@@ -223,13 +223,13 @@
                        (react-dom/flushSync (fn [] nil))
                        (is (= "7" (text container))
                            "one yielded microtask plus an empty forced drain
-                            later, the page is current")
-                       (teardown! mounted container)
-                       (done)))
+                            later, the page is current")))
               (.catch (fn [e]
                         (is false (str "microtask arm rejected: " e))
-                        (teardown! mounted container)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (teardown! mounted container)
+                       (done)))))))))
 
 (deftest a-write-then-a-task-repaints
   (testing "Case 3: nothing forces anything. The write is made and one
@@ -249,13 +249,13 @@
               (.then (fn [_]
                        (is (= "11" (text container))
                            "a yielded task is enough on its own — the automatic
-                            repaint channel, unforced")
-                       (teardown! mounted container)
-                       (done)))
+                            repaint channel, unforced")))
               (.catch (fn [e]
                         (is false (str "task arm rejected: " e))
-                        (teardown! mounted container)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (teardown! mounted container)
+                       (done)))))))))
 
 (deftest a-write-then-an-animation-frame-repaints
   (testing "Case 4: the same claim taken at the paint boundary. The
@@ -275,13 +275,13 @@
               (.then (fn [_]
                        (is (= "23" (text container))
                            "current before the frame the browser was about to
-                            paint")
-                       (teardown! mounted container)
-                       (done)))
+                            paint")))
               (.catch (fn [e]
                         (is false (str "animation-frame arm rejected: " e))
-                        (teardown! mounted container)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (teardown! mounted container)
+                       (done)))))))))
 
 ;; ===========================================================================
 ;; The adversarial row — batching is UNCHANGED
@@ -335,13 +335,13 @@
                              "and nothing rendered afterwards either — the
                               host-visible closer adds no second pass over the
                               application's own tree")
-                         (is (= "3" (text container)))
-                         (teardown! mounted container)
-                         (done)))
+                         (is (= "3" (text container)))))
                 (.catch (fn [e]
                           (is false (str "batching arm rejected: " e))
-                          (teardown! mounted container)
-                          (done))))))))))
+                          nil))
+                (.then (fn [_]
+                         (teardown! mounted container)
+                         (done))))))))))
 
 ;; ===========================================================================
 ;; The other doors the bead named

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_dom_cljs_test.cljs
@@ -216,11 +216,10 @@
         (.then (fn [_]
                  (live!)
                  (js/Promise.resolve (f container))))
-        (.then (fn [_] (teardown! container root) (done)))
         (.catch (fn [e]
                   (is false (str "the mounted pilot rejected: " e))
-                  (teardown! container root)
-                  (done))))))
+                  nil))
+        (.then (fn [_] (teardown! container root) (done))))))
 
 ;; ===========================================================================
 ;; R-A1 — same-tick echo, through the library's own event site
@@ -568,11 +567,10 @@
                     (is (.contains (.closest c2 "[data-component='acme/field']")
                                    (.getElementById js/document id2))
                         "line 2's aria-describedby resolves inside line 2's own field"))))
-              (.then (fn [_] (teardown! container root) (done)))
               (.catch (fn [e]
                         (is false (str "the mounted pilot rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (teardown! container root) (done)))))))))
 
 (deftest pilot-two-instances-a-lossy-slug-collapsed-keep-distinct-mounted-ids
   (testing "rf2-drpa3.146 (mounted). The collision the numeric line-id test
@@ -615,11 +613,10 @@
                         "the \"a/b\" region resolves by document id")
                     (is (some? (.getElementById js/document id2))
                         "the \"a-b\" region resolves by document id"))))
-              (.then (fn [_] (teardown! container root) (done)))
               (.catch (fn [e]
                         (is false (str "the mounted pilot rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (teardown! container root) (done)))))))))
 
 (deftest pilot-two-emoji-instances-keep-distinct-mounted-ids
   (testing "rf2-drpa3.146, audit reopen (mounted). The collision a lossy first
@@ -668,11 +665,10 @@
                         "the 😀 region resolves by document id")
                     (is (some? (.getElementById js/document id2))
                         "the 😁 region resolves by document id"))))
-              (.then (fn [_] (teardown! container root) (done)))
               (.catch (fn [e]
                         (is false (str "the mounted pilot rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (teardown! container root) (done)))))))))
 
 (deftest pilot-a-typed-instance-and-its-string-namesake-keep-distinct-mounted-ids
   (testing "rf2-drpa3.146, audit follow-up (mounted). The narrowed codec keeps
@@ -718,11 +714,10 @@
                         "the `:a` region resolves by document id")
                     (is (some? (.getElementById js/document id2))
                         "the \"a\" region resolves by document id"))))
-              (.then (fn [_] (teardown! container root) (done)))
               (.catch (fn [e]
                         (is false (str "the mounted pilot rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (teardown! container root) (done)))))))))
 
 ;; ===========================================================================
 ;; The compiled cell, re-opened — the pilot's compiled twin mounts
@@ -757,11 +752,9 @@
                       (is (some? node)
                           (str "the compiled twin mounted the " nm " control"))
                       (is (= v (.-value node))
-                          (str nm " holds its seeded value"))))
-                  (teardown! container root)
-                  (done)))
+                          (str nm " holds its seeded value"))))))
               (.catch
                 (fn [e]
                   (is false (str "the compiled pilot rejected: " e))
-                  (teardown! container root)
-                  (done)))))))))
+                  nil))
+              (.then (fn [_] (teardown! container root) (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/pilot_typeahead_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_typeahead_dom_cljs_test.cljs
@@ -170,13 +170,13 @@
                          (insert-at! node 2 "X")
                          (is (= "anXna" (.-value node)) "the insert landed at the caret")
                          (is (= [3 3] (caret node)) "and the caret followed it")
-                         (is (= "anXna" (:query (record))) "and reached the draft"))
-                       (teardown! container root)
-                       (done)))
+                         (is (= "anXna" (:query (record))) "and reached the draft"))))
               (.catch (fn [e]
                         (is false (str "browser run failed: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (teardown! container root)
+                       (done)))))))))
 
 (deftest a-settle-arriving-mid-word-touches-neither-the-value-nor-the-caret
   (testing "R-C1, in a browser. The corpus baseline FAILS this: an accepted
@@ -218,13 +218,13 @@
                                                              (.-body js/document)
                                                              "[data-part='option']")))
                                           (str "and its results are NOT shown — they answer "
-                                               "'an', and the user has typed 'anna'"))
-                                      (teardown! container root)
-                                      (done)))))))
+                                               "'an', and the user has typed 'anna'"))))))))
               (.catch (fn [e]
                         (is false (str "browser run failed: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (teardown! container root)
+                       (done)))))))))
 
 (deftest a-callers-refusal-restores-the-baseline-on-the-same-node
   (testing "The generation fence in a browser. The caller refuses the draft
@@ -256,13 +256,13 @@
                                       (is (identical? before (field))
                                           "restored on the SAME node, not remounted")
                                       (is (identical? before js/document.activeElement)
-                                          "which still has focus")
-                                      (teardown! container root)
-                                      (done)))))))
+                                          "which still has focus")))))))
               (.catch (fn [e]
                         (is false (str "browser run failed: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (teardown! container root)
+                       (done)))))))))
 
 (deftest the-debounce-debounces-on-a-real-host-clock
   (testing "The headless rows deliver the delayed event by hand, which is
@@ -287,13 +287,13 @@
                            (str "exactly one request after the quiet period, not four "
                                 "(got " (mapv :query (requests)) ")"))
                        (is (= "anna" (:query (first (requests))))
-                           "for what the user actually typed")
-                       (teardown! container root)
-                       (done)))
+                           "for what the user actually typed")))
               (.catch (fn [e]
                         (is false (str "browser run failed: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (teardown! container root)
+                       (done)))))))))
 
 (deftest choosing-a-suggestion-commits-and-retires-the-control
   (testing "The whole loop, live: type, settle, click a suggestion. The
@@ -321,10 +321,10 @@
                            "the caller's state moved")
                        (is (nil? (record)) "and the control retired itself")
                        (is (= "anna" (.-value (field)))
-                           "with the committed value now the input's baseline")
-                       (teardown! container root)
-                       (done)))
+                           "with the committed value now the input's baseline")))
               (.catch (fn [e]
                         (is false (str "browser run failed: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_]
+                       (teardown! container root)
+                       (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/top_layer_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/top_layer_dom_cljs_test.cljs
@@ -201,9 +201,9 @@
                        (is (false? (modal? dialog-id)) "close() ran at the commit")
                        (is (= (by-id opener-id) js/document.activeElement)
                            "the platform returned focus to the invoking control")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+                       (teardown! container root)))
+              (.catch (fn [e] (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest fh-toplayer-003-nested-popovers-stack-and-close-together
   (testing "Per FH-TOPLAYER-003 (browser): a NESTED pair opened in ONE
@@ -262,9 +262,9 @@
                        (is (false? (open? nested-id)) "and the descendant closed with it")
                        (is (= 1 (- (top-layer/operation-count) @ops))
                            "ONE hide closed both — LIFO is the platform's, not ours")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+                       (teardown! container root)))
+              (.catch (fn [e] (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest fh-toplayer-003-browser-dismissal-reaches-the-author-and-nothing-else
   (testing "Per FH-TOPLAYER-003 (browser): when the browser dismisses a
@@ -318,9 +318,9 @@
               (.then (fn [_]
                        (is (false? (open? menu-id))
                            "the author reconciled, and the node follows")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+                       (teardown! container root)))
+              (.catch (fn [e] (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; FH-TOPLAYER-004 — the commit law, the tracking frequency, the counts
@@ -614,9 +614,9 @@
                            (str (:renders fx-004) " re-commits of an unchanged desired state "
                                 "performed zero host operations"))
                        (is (true? (open? menu-id)) "and the popover is still open")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+                       (teardown! container root)))
+              (.catch (fn [e] (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest fh-toplayer-004-a-full-cycle-retains-exactly-nothing
   (testing "Per FH-TOPLAYER-004: mount, open, close and unmount arms
@@ -703,9 +703,12 @@
                              "zero resize / intersection / mutation observers")
                          (is (= 0 (:iv measured)) "zero intervals")
                          (is (zero? (top-layer/pending-count))
-                             "and the commit batch is drained"))
-                       (done)))
-              (.catch (fn [e] (restore!) (is false (str "browser run failed: " e)) (done)))))))))
+                             "and the commit batch is drained"))))
+              ;; `restore!` stays on BOTH arms: on the success arm it has to run
+              ;; BEFORE the assertions read the counters, so it is not the tail
+              ;; teardown the trailing step could own.
+              (.catch (fn [e] (restore!) (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; FH-TOPLAYER-005 — the advisories: published at a commit, and typed


### PR DESCRIPTION
Batch 3 of 4 of rf2-fyba's freehand population (rf2-ua8r). Every repaired chain now puts
its rejection handler UPSTREAM of the `.then` that calls `done`: the handler reports and
returns `nil`, it never finishes, and exactly one `done` sits at the tail with nothing
after it.

## The true count I derived, and how

I rebuilt the scanner with a real s-expression reader rather than the bead's
equal-indent grouping, because rf2-53uz reports that indent grouping splits a chain when
a nested step appears inside a step body. A chain is a maximal run of consecutive sibling
forms inside one parent whose heads are `.then`/`.catch`/`.finally`; a chain is defective
when a step whose body calls `done` is followed by a later `.catch`.

| scanner | `implementation/freehand`, pre-#7955 |
|---|---|
| parent bead (rf2-fyba) | 179 |
| rf2-53uz | 184 |
| rf2-0r3j (PR #7955) | 170 |
| **this branch, s-expression reader** | **185** |

**The dispute is settled rather than extended.** I implemented the bead's literal
indent-grouping signature as a second scanner and it reads **exactly 170** on the same
tree — reproducing rf2-0r3j's number to the chain, including its exact per-file counts for
`behaviors_dom`/`pilot_overlay`/`compiled_mount` (16/13/12) and for `behavior_matrix` (5).
Those four files happen to be indent-regular, which is why 170 looked confirmed. The
15-chain gap is the bead's scanner signature under-reporting, not a disagreement about the
source. At my base (post-#7955) the s-expression reader reads **144**; 185 − 144 = 41 =
batch 1's repaired count, exactly.

Per-file for this batch, against the bead's table:

| file | bead | source | repaired |
|---|---|---|---|
| `behavior_async_dom_cljs_test.cljs` | 7 | 7 | 7 |
| `pilot_field_dom_cljs_test.cljs` | 6 | 6 | 6 |
| `top_layer_dom_cljs_test.cljs` | 5 | 5 | 5 |
| `pilot_typeahead_dom_cljs_test.cljs` | 5 | 5 | 5 |
| `behavior_matrix_dom_cljs_test.cljs` | 5 | 5 | 5 |
| `flush_sync_dom_cljs_test.cljs` | 4 | 4 | 4 |
| `data_attr_casing_probe_dom_cljs_test.cljs` | 4 | 4 | 4 |
| `behavior_compiled_parity_dom_cljs_test.cljs` | 4 | **5** | 5 |
| `bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs` | 4 | 4 | 4 |
| **total** | 44 (title says 42) | **45** | **45** |

Two things did not hold at source. The bead's own table sums to **44**, not the **42** its
title states. And `behavior_compiled_parity` carries **5**, not 4: its first `deftest` holds
TWO nested defective chains and THREE `done` call sites, an outer `->` over the interpreted
mount and an inner `->` over the compiled one, each with its own downstream `.catch`. That
is a real second instance, not a scanner artefact. (Not mine to fix, but recorded for
batch 2: `substrate_dom_cljs_test.cljs` reads **8** at source, not the 7 rf2-d2xz states.)

Post-repair re-scan: `implementation/freehand` falls **144 → 99**, and all nine files scan
to **ZERO** — not merely "gained a trailing step". A separate check confirms every repaired
`(async done …)` row mentions `done` exactly once per path.

## `behavior_matrix:238`'s inherited claim REPRODUCED

rf2-0r3j left this batch a finding: `behavior_matrix` inherits the misattribution the
moment `behaviors_dom` stops making it. It reproduces readily, and it is worse than
recorded — **two** of its rows claim the foreign throw, not one.

## Per-chain dispositions

**Hoisted (25)** — teardown identical on both arms, moved into the single trailing step,
written once and still run once per path:
`behavior_matrix` :76 :105 :142 (`ms/destroy-root!`) and :179 (`cc`/`rc` only) ·
`behavior_async` :833 :903 (`close-door`) · `pilot_field` all six, :215 :552 :598 :651
:701 :746 (`teardown!`; :215 is the `with-line` helper that owns the row's `done`) ·
`pilot_typeahead` all five (:193 and :244 additionally FLATTENED a nested inner chain whose
own `.then` held the `done`) · `flush_sync` all four · `data_attr_casing_probe` all four.

**Left in place (8)** — the arms genuinely differ, and four of them differ in the direction
the bead's examples do not cover: the FAILURE arm doing *less*, not more.
- `top_layer` :183 :229 :295 :590 — the failure arm never tore down at all. Hoisting
  `teardown!` would have ADDED teardown on the failure path.
- `top_layer` :686 — `restore!` is on both arms, but on the success arm it must run
  BEFORE the assertions read the listener counters, so it is not a tail teardown the
  trailing step can own. Hoisting would have moved it after them.
- `behavior_matrix` :226, `behavior_compiled_parity` :148 :185 — the success arm's
  `ms/destroy-root!`/`teardown!` IS the act under test (the next assertion reads the
  connection count as exactly zero). Hoisting would have torn the root down twice on the
  success path.

**Nothing to place (12)** — `behavior_async` :574 :633 :682 :730 :763 (roots destroyed
mid-chain as acts under test; the failure arm never tore down) · `behavior_compiled_parity`
:114/:117 and :238 (`mount-outcome!` owns teardown) · `host_hatch` :417 :461 :1192 :1219
(`done` lifted out of a `try`/`finally` that already runs its `mount/release!` on both
paths within the step).

Two deliberate non-actions. `behavior_compiled_parity` :114/:117 keeps **both** diagnostics
— a compiled rejection and an interpreted one are different findings — rather than
collapsing them into one handler; that is the same reasoning behind the bead's `run-async`
refusal, which I also did not take. And neither unanticipated shape occurs in these files:
no `.catch` that IS the row's success path, and no helper that takes `done` and calls it
except `pilot_field`'s `with-line`, which wraps its own whole chain and needed only the
ordinary cure. `mount-outcome!` in `behavior_compiled_parity` is already a correct two-arg
`.then` whose arms differ (a guarded `.unmount` on the failure side) and was left untouched.

## Reproduction control, both directions

A throwaway namespace sorting as a PREFIX EXTENSION of the target and also ending
`-dom-cljs-test` (which the `:browser-test` ns-regexp requires):
`re-frame.freehand.behavior-matrix-dom-cljs-test-zz-control-dom-cljs-test`, carrying a
fn-form `:each` fixture plus an `async` row — which selects cljs.test's `:sync` path, wraps
the row in `disable-async`, and throws the bare String *"Async tests require fixtures to be
specified as maps."* synchronously inside whichever `done` continuation is running.

| | `behavior_matrix` REVERTED to `origin/main` | REPAIRED |
|---|---|---|
| `behavior_matrix`'s own message against the CONTROL's test name | **2** (:198 and :238) | **0** |
| control namespace announced | **twice** (the namespace re-ran) | **once** |
| `WARNING: Async test called done more than one time.` | present | absent from any freehand row |
| `Ran N tests …` summary | **none** — the lane stalled | present |
| exit code | **1** | 1 (see below) |

Reverted, the log reads:

```
Testing re-frame.freehand.behavior-matrix-dom-cljs-test-zz-control-dom-cljs-test
FAIL in (zz-control-row) (:)
the compiled behavior mount rejected: Async tests require fixtures to be specified as maps.
Testing re-frame.freehand.behavior-matrix-dom-cljs-test-zz-control-dom-cljs-test   <- twice
FAIL in (zz-control-row) (:)
a behavior mount rejected: Async tests require fixtures to be specified as maps.
WARNING: Async test called done more than one time.
```

Both strings are `behavior_matrix`'s OWN (`:238` and `:198`), printed against the CONTROL's
test name. Repaired, neither appears and the namespace runs once.

**The control's exit code stays 1 in both directions, and that is the honest result.** With
`behavior_matrix` repaired the throw is claimed by the NEXT unrepaired chain in the run —
`scenario-7` in `implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs`,
outside `implementation/freehand` entirely. That is the same hand-off #7937 saw
(`read_extent` from `reincarnation_paint`) and that #7955 saw hand off to this file. It is
a finding for rf2-fyba's remainder, not a defect in this branch: nothing this branch owns
claims a foreign failure any more. **The control was deleted and all nine files verified
byte-identical by SHA-256, not by `git diff`.**

## Quality gates

Run one at a time, redirected, exit code captured. No count quoted from memory — the
baseline below is my own measurement on `origin/main` bytes in this worktree.

| gate | result | captured exit |
|---|---|---|
| `npm run test:browser` — **baseline**, nine files reverted to `origin/main` | `Ran 1293 tests containing 8010 assertions. 0 failures, 0 errors.` | `TEST_BROWSER_BASELINE_EXIT=0` |
| `npm run test:browser` — repaired | `Ran 1293 tests containing 8010 assertions. 0 failures, 0 errors.` | `TEST_BROWSER_REPAIRED_EXIT=0` |
| `npm run test:browser` — final, control removed | `Ran 1293 tests containing 8010 assertions. 0 failures, 0 errors.` | `TEST_BROWSER_FINAL_EXIT=0` |
| `npm run test:freehand` | `Ran 1406 tests containing 7786 assertions. 0 failures, 0 errors.` | `TEST_FREEHAND_REPAIRED_EXIT=0` |
| `python scripts/check_fast_pr_gap.py --list` | 97 required checks the spine does not decide | `FAST_PR_GAP_EXIT=0` |

**No movement: 1293/8010 before and after.** Every assertion is preserved — none loosened,
none dropped, no suite retuned to dodge the async window. The bead budgets 1293/**8008**;
my base measures **8010**, confirming rf2-0r3j's note that the +2 landed on main in
`fdbadcb8e1`/`63480e867e` and predates both branches.

Both lanes matter here and neither subsumes the other: all nine files ride `:browser-test`
through their `-dom-cljs-test` suffix — including `bench/hicasso/arm1/host_hatch`, whose
`re-frame.bench.hicasso.…` namespace is NOT excluded by that build's
`^(?!re-frame\.freehand\.bench\.)` guard — and they also ride `:node-test-freehand`, where
their bodies gate on `(browser?)`.

What the fast-PR spine does not decide: 97 required checks, listed in full by
`scripts/check_fast_pr_gap.py --list`. The ones nearest this diff are the `JVM freehand`
job's donor-dependency grep and the `CLJS (shadow-cljs :node-test)` job's isolation and
bench-compile steps; this diff is test-only under `implementation/freehand/test/` and
touches no hot-zone file, no `spec/`, no workflow and no `deps.edn`/`shadow-cljs.edn`.

Fixes rf2-ua8r.
