### PR TITLE
test(hicasso): three-way parity for the native tier, and the bundle half of clause 6

### DIFF
--- a/implementation/hicasso/scripts/check_bundle_isolation.cjs
+++ b/implementation/hicasso/scripts/check_bundle_isolation.cjs
@@ -1,0 +1,428 @@
+#!/usr/bin/env node
+/*
+ * THE NATIVE TIER'S ZERO-RENT PROOF, read off a real production bundle
+ * (rf2-hic-034).
+ *
+ * > 6. The native namespace is separately reachable. An interpreted-only
+ * >    production dependency graph and bundle contain neither native-tier
+ * >    runtime nor UIx code.
+ * >
+ * >   — the native-boundary law,
+ * >     `docs/design/hicasso/product/lanes/design-laws.md`
+ *
+ * Clause 6 has TWO halves and they are checked in two places, because
+ * neither instrument can answer the other's question:
+ *
+ *   - the DEPENDENCY GRAPH is a property of the source, and
+ *     `check_optional_module_reachability.py` decides it over `:require`
+ *     forms — exhaustively, including the shapes that leave no string in
+ *     a bundle at all (see "What a string scan cannot see" below);
+ *   - the BUNDLE is this file. It reads the one build in the repo that
+ *     compiles the package the way a consumer ships it — `:hicasso-release`,
+ *     `:advanced` + `goog.DEBUG=false`, entry `re-frame.hicasso.consumer-app`
+ *     — and asks whether any native-tier runtime survived into it.
+ *
+ * The source-side gate is the stronger of the two and is not made
+ * redundant by this one. What this one adds is confidence about the
+ * COMPILER and the LINKER: that an unreferenced namespace really does
+ * leave nothing behind after Closure has run, on the real graph, at the
+ * real optimisation level.
+ *
+ * ## Unique sentinels, never a public-name grep
+ *
+ * Grepping the bundle for `native` proves nothing — the word occurs in
+ * React's own event plumbing and in the codec's prose. Each row below is
+ * a string that ONE surface emits and nothing else does, so a hit names
+ * WHICH surface leaked rather than merely that something did.
+ *
+ * A sentinel is only worth scanning for if it is LOAD-BEARING. A marker
+ * planted beside the code would be dropped by Closure whether or not the
+ * isolation held, and the gate would pass for the wrong reason. Both
+ * sentinels here are strings their surface cannot function without:
+ *
+ *   - `rf2:hicasso-native-tier` is the own-property NAME
+ *     `native/component` writes with `unchecked-set` and `native/marker`
+ *     reads back with `unchecked-get`. Closure cannot rename a string
+ *     used as a computed property key and cannot delete it while the
+ *     code that writes it is reachable. `native.cljc` says so at
+ *     [[tier-sentinel]], where it also names this bead as the proof.
+ *   - `rf.error/hicasso-native-` is the refusal-id FAMILY the tier mints
+ *     — all seven of its ids share it and no other surface uses it.
+ *
+ * ## Two sentinels because there are two reachability shapes
+ *
+ * They are not belt-and-braces. Closure's dead-code elimination works
+ * per function, so which strings survive depends on WHICH of the tier a
+ * consumer touched:
+ *
+ *   - a consumer who writes `n/defcomponent` (or `n/memo` / `n/lazy`)
+ *     drags `component` in, and with it the marker string — while the
+ *     refusal ids may fold away entirely, since `checked`'s per-child
+ *     fence is `debug-enabled?`-gated;
+ *   - a consumer who writes `(n/props …)` drags `props*` and therefore
+ *     `prop-slots` in, whose last three refusals are UNGATED and hold on
+ *     both paths — while `component` is never called and the marker
+ *     string is absent.
+ *
+ * Either sentinel alone is green against the other's leak. Both together
+ * cover every part of the tier that has a production footprint.
+ *
+ * ## What a string scan cannot see, stated rather than left to be found
+ *
+ * There is a third shape and it leaves NOTHING to find: a consumer who
+ * writes only `n/$` with literal props. The macro lowers the props at
+ * expansion, `checked` folds away under `goog.DEBUG=false`, and what
+ * remains is `react/createElement` — React's own function, which every
+ * bundle already has. Past DCE, `n/$` IS `createElement`.
+ *
+ * That is not a hole in the zero-rent claim; it is the claim at its
+ * strongest, and it is why the source-side gate exists and why this file
+ * does not pretend to subsume it. A scan that reported green there would
+ * be right by accident, so the sentence is written here instead of a row
+ * nobody can falsify.
+ *
+ * ## Reachable positive controls
+ *
+ * An absence check over a bundle that never compiled anything is a green
+ * that means nothing, and it is the failure this class of gate is most
+ * exposed to. So each sentinel is PAIRED with a control that must be
+ * PRESENT, chosen so the pair differs by REACHABILITY and by nothing
+ * else:
+ *
+ *   - `hicassoBoundary` (present) against `rf2:hicasso-native-tier`
+ *     (absent) — two own-property marker names, both written with
+ *     `unchecked-set` onto a freshly minted component, one in a
+ *     namespace the public door leads to and one in a namespace it never
+ *     names. That pairing is what makes the absence a statement about
+ *     reachability rather than about compilation.
+ *   - `rf.error/hicasso-empty-vector` (present) against
+ *     `rf.error/hicasso-native-` (absent) — a shipped refusal id minted
+ *     by `impl.error/fail!` against the tier's own family minted by the
+ *     same `fail!`. If `fail!` had been dropped whole, both would be
+ *     absent and the first is what says so.
+ *   - `rf-uix-sub-` (present) — and this one is the interesting control.
+ *     See the next section.
+ *
+ * ## `zero UIx` does not hold, and the reason is worth a control
+ *
+ * Clause 6 says an interpreted-only bundle contains no UIx code. THE
+ * MEASURED BUNDLE CONTAINS UIx, and it is not a defect: Hicasso ships no
+ * reactive adapter of its own — `consumer_app.cljs`'s docstring says so
+ * where the consumer is standing — and the three adapters a consumer may
+ * pick from are Reagent, reagent-slim and UIx. Every one of them is a
+ * view library. The exemplar picks UIx, so `re-frame.adapter.uix` is on
+ * the entry's require list and `uix.core` comes with it.
+ *
+ * A row asserting `no uix` here would be red on a correct build, and a
+ * row asserting it against some other fixture would be asserting a fact
+ * about which adapter the fixture happened to choose. So the string is
+ * carried as a CONTROL instead, where it earns its place twice: it
+ * proves a whole React view library and a whole reactive substrate
+ * really compiled into this bundle, which makes the native tier's
+ * absence a much sharper reading than it would be from a bundle that
+ * compiled almost nothing.
+ *
+ * The clause's UIx half is therefore a claim about a consumer's
+ * dependency graph — *nothing Hicasso makes you take drags UIx in* —
+ * and that is the source-side gate's kind of question, not a bundle's.
+ * It is reported rather than quietly re-scoped.
+ *
+ * ## The live half is a test, not a comment
+ *
+ * A sentinel that has quietly stopped being emitted is absent from every
+ * bundle for a reason that has nothing to do with isolation. The roster
+ * premise below is checked against the source before the bundle is
+ * opened, so a rename fails the gate rather than reporting a green
+ * absence for a string nobody emits any more; and
+ * `re-frame.hicasso.native-fence-cljs-test`'s
+ * `the-tier-sentinel-is-reachable-rather-than-a-dead-literal` asserts in
+ * the ordinary `goog.DEBUG` node lane that the marker is what a LIVE
+ * `n/defcomponent` really stamps. Surface on, string present; surface
+ * unreachable, string gone — and neither half is evidence alone.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const HERE = path.dirname(path.resolve(__filename));
+const PACKAGE_ROOT = path.dirname(HERE);
+const IMPL_ROOT = path.dirname(PACKAGE_ROOT);
+
+const BUNDLE = path.join(IMPL_ROOT, 'out', 'hicasso-release', 'main.js');
+
+// ---------------------------------------------------------------------------
+// The roster
+//
+// `sentinel` is scanned for in the bundle and must be ABSENT. `source` is
+// where it is emitted from, and `premise` is the text that must still be
+// found there — usually the sentinel itself, spelled the way the source
+// spells it.
+// ---------------------------------------------------------------------------
+
+const SENTINELS = [
+  {
+    surface: 'native tier — the marker every minted component carries (rf2-hic-030)',
+    sentinel: 'rf2:hicasso-native-tier',
+    source: 'src/re_frame/hicasso/native.cljc',
+    premise: '"rf2:hicasso-native-tier"',
+    why:
+      'The own-property name `native/component` writes with `unchecked-set` ' +
+      'onto the author\'s own function, and `native/marker` reads back with ' +
+      '`unchecked-get`. It is in this bundle if and only if `defcomponent`, ' +
+      '`n/memo` or `n/lazy` is reachable from the entry.',
+    remedy:
+      'Find the `:require` of `re-frame.hicasso.native` that made the tier ' +
+      'reachable from the public door. Nothing under implementation/hicasso/src/ ' +
+      'may name it; an application requires it directly, in the region that ' +
+      'wants it.',
+  },
+  {
+    surface: 'native tier — the refusal-id family the fence mints (rf2-hic-030)',
+    sentinel: 'rf.error/hicasso-native-',
+    source: 'src/re_frame/hicasso/native.cljc',
+    premise: ':rf.error/hicasso-native-slot-collision',
+    why:
+      'The prefix all seven of the tier\'s refusal ids share and no other ' +
+      'surface uses. It reaches a bundle by a DIFFERENT route from the marker ' +
+      'above: `prop-slots`\'s last three refusals are ungated, so a consumer ' +
+      'who writes `(n/props …)` and never a `defcomponent` leaks these and ' +
+      'not the marker. Either sentinel alone is green against the other\'s ' +
+      'leak, which is why there are two.',
+    remedy:
+      'Same as above — the tier became reachable. `props*` is the runtime ' +
+      'half of `n/$`\'s props rule and only a dynamic props operand calls it.',
+  },
+];
+
+const CONTROLS = [
+  {
+    control: 're-frame.hicasso.consumer-app/app',
+    source: 'test/re_frame/hicasso/consumer_app.cljs',
+    premise: '(h/defview app',
+    proves:
+      'the release entry\'s `h/defview` really compiled — `mint-view!` stamps ' +
+      'this name as the boundary\'s `displayName`, unconditionally. Without ' +
+      'it the absences above would be the absences of a bundle that compiled ' +
+      'no declaration at all.',
+  },
+  {
+    control: 'hicassoBoundary',
+    source: 'src/re_frame/hicasso/impl/codec.cljs',
+    premise: '(unchecked-set f "hicassoBoundary" true)',
+    proves:
+      'the interpreted tier\'s own marker machinery compiled. It is the ' +
+      'REACHABLE counterpart of `rf2:hicasso-native-tier`: same idiom, same ' +
+      '`unchecked-set`, same freshly minted component, and the only ' +
+      'difference between the two is whether the public door\'s require ' +
+      'graph leads to the namespace that writes it. That is what makes "no ' +
+      'native marker" a statement about reachability rather than about ' +
+      'compilation.',
+  },
+  {
+    control: 'rf.error/hicasso-empty-vector',
+    source: 'src/re_frame/hicasso/impl/codec.cljs',
+    premise: ':rf.error/hicasso-empty-vector',
+    proves:
+      '`impl.error/fail!` and a shipped refusal id compiled. The tier\'s ' +
+      'family above is minted by the same `fail!`; if it had been dropped ' +
+      'entirely both would be absent, and this is what says so.',
+  },
+  {
+    control: 'rf-uix-sub-',
+    source: '../adapters/uix/src/re_frame/adapter/uix.cljs',
+    premise: ':gensym-prefix-sub     "rf-uix-sub-"',
+    proves:
+      'a whole React view library and a whole reactive substrate really ' +
+      'compiled into this bundle — the UIx adapter the exemplar installs, ' +
+      'which Hicasso deliberately ships none of its own. It is the reason ' +
+      'the absences above are worth reading: a bundle carrying UIx, React, ' +
+      'core and the interpreted codec, and STILL carrying no native-tier ' +
+      'runtime, has isolated the tier rather than compiled nothing. It is ' +
+      'also the honest record that clause 6\'s "nor UIx code" does not hold ' +
+      'of this fixture and why — see the header.',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// The scan
+// ---------------------------------------------------------------------------
+
+/** Answer the problems `bundle` has, as a list of strings. */
+function scan(bundle) {
+  const problems = [];
+
+  for (const c of CONTROLS) {
+    if (!bundle.includes(c.control)) {
+      problems.push(
+        `POSITIVE CONTROL ABSENT: ${c.control}\n` +
+        `    It proves ${c.proves}\n` +
+        '    Every absence this gate reports below is therefore ' +
+        'unfalsifiable. Fix this first.'
+      );
+    }
+  }
+
+  for (const s of SENTINELS) {
+    if (bundle.includes(s.sentinel)) {
+      problems.push(
+        `NATIVE TIER LEAKED: ${s.surface}\n` +
+        `    sentinel: ${JSON.stringify(s.sentinel)}\n` +
+        `    ${s.why}\n` +
+        `    ${s.remedy}`
+      );
+    }
+  }
+
+  return problems;
+}
+
+/** Answer the roster's own broken premises, as a list of strings. */
+function checkPremises() {
+  const problems = [];
+  const rows = [
+    ...SENTINELS.map((s) => ({ text: s.premise, source: s.source, of: `sentinel ${JSON.stringify(s.sentinel)}` })),
+    ...CONTROLS.map((c) => ({ text: c.premise, source: c.source, of: `positive control ${JSON.stringify(c.control)}` })),
+  ];
+
+  for (const row of rows) {
+    const file = path.join(PACKAGE_ROOT, row.source);
+    if (!fs.existsSync(file)) {
+      problems.push(
+        `ROSTER PREMISE BROKEN: the source of ${row.of} is gone — ${row.source}\n` +
+        '    A scan for a string nobody emits any more is a green that means nothing.'
+      );
+      continue;
+    }
+    if (!fs.readFileSync(file, 'utf8').includes(row.text)) {
+      problems.push(
+        `ROSTER PREMISE BROKEN: ${row.source} no longer contains ${JSON.stringify(row.text)},\n` +
+        `    which is where ${row.of} comes from. Either the string was renamed — in ` +
+        'which case rename it here too — or the surface was removed, in which case ' +
+        'drop the row.'
+      );
+    }
+  }
+
+  return problems;
+}
+
+// ---------------------------------------------------------------------------
+// The self-test — because a scanner that stopped seeing reports a clean
+// bundle forever, and this one's whole claim is about what it does not find
+// ---------------------------------------------------------------------------
+
+function selfTest() {
+  const green = CONTROLS.map((c) => c.control).join(' … ');
+
+  const clean = scan(green);
+  assert(clean.length === 0, `a bundle with every control and no sentinel is green: ${clean}`);
+
+  // Every sentinel is seen, individually, and names its own surface.
+  for (const s of SENTINELS) {
+    const problems = scan(`${green} … ${s.sentinel} …`);
+    assert(problems.length === 1, `one problem for ${s.sentinel}: ${problems}`);
+    assert(problems[0].includes('NATIVE TIER LEAKED'), problems[0]);
+    assert(problems[0].includes(s.surface), problems[0]);
+    assert(problems[0].includes(s.sentinel), problems[0]);
+  }
+
+  // The scan FAILS CLOSED: a bundle with no controls in it is refused even
+  // though every sentinel is absent from it, which is the shape an empty or
+  // wrong bundle has.
+  const empty = scan('');
+  assert(empty.length === CONTROLS.length, `an empty bundle fails on every control: ${empty}`);
+  for (const p of empty) assert(p.includes('POSITIVE CONTROL ABSENT'), p);
+
+  // Each control is missed on its own, so a control that quietly stopped
+  // being emitted cannot hide behind its siblings.
+  for (const c of CONTROLS) {
+    const others = CONTROLS.filter((o) => o !== c).map((o) => o.control).join(' … ');
+    const problems = scan(others);
+    assert(problems.length === 1, `one problem for a missing ${c.control}: ${problems}`);
+    assert(problems[0].includes(c.control), problems[0]);
+  }
+
+  // The scan is not TOO EAGER, and this is the direction a guard is almost
+  // never tested in. Each string below is shape-adjacent to a sentinel and
+  // is legal in a consumer bundle; none may be mistaken for one.
+  //
+  //   - the tier's own name in PROSE reaches no bundle, but the codec's
+  //     docstrings name it and a scanner reading source rather than the
+  //     artefact would trip on them;
+  //   - `hicassoBoundary` is the interpreted marker, one word away from
+  //     the native one;
+  //   - the other refusal families share `rf.error/hicasso-` with the
+  //     tier's, and the tier's suffix is the whole of the difference.
+  const legal = [
+    `${green} … re-frame.hicasso.native/declared-server …`,   // a docstring link
+    `${green} … hicassoBody hicassoBoundary hicassoOwner …`,   // neighbouring markers
+    `${green} … rf.error/hicasso-empty-vector rf.error/hicasso-bad-head …`,
+    `${green} … "native" nativeEvent isComposing …`,           // React's own plumbing
+  ];
+  for (const bundle of legal) {
+    const problems = scan(bundle);
+    assert(problems.length === 0, `a legal bundle stays green: ${problems}`);
+  }
+
+  // The roster's premises hold against the real tree — a renamed sentinel
+  // fails here rather than reporting a green absence.
+  const premises = checkPremises();
+  assert(premises.length === 0, `roster premises hold:\n${premises.join('\n')}`);
+
+  // No sentinel may be a substring of another, or of a control: a hit has
+  // to name one surface.
+  const all = [...SENTINELS.map((s) => s.sentinel), ...CONTROLS.map((c) => c.control)];
+  for (const a of all) {
+    for (const b of all) {
+      if (a !== b) assert(!a.includes(b), `${JSON.stringify(a)} contains ${JSON.stringify(b)}`);
+    }
+  }
+
+  process.stdout.write(
+    `hicasso bundle isolation: self-test OK ` +
+    `(${SENTINELS.length} sentinels, ${CONTROLS.length} positive controls)\n`
+  );
+  return 0;
+}
+
+function assert(ok, message) {
+  if (!ok) {
+    process.stderr.write(`hicasso bundle isolation: SELF-TEST FAILED\n  ${message}\n`);
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+function fail(problems) {
+  process.stderr.write('hicasso bundle isolation: FAIL\n');
+  for (const p of problems) process.stderr.write(`  ${p}\n`);
+  return 1;
+}
+
+function main(argv) {
+  if (argv.includes('--self-test')) return selfTest();
+
+  const premises = checkPremises();
+  if (premises.length > 0) return fail(premises);
+
+  if (!fs.existsSync(BUNDLE)) {
+    return fail([
+      `MISSING RELEASE BUNDLE: ${path.relative(IMPL_ROOT, BUNDLE)}\n` +
+      '    Run `npm run build:hicasso-release`, which compiles it.',
+    ]);
+  }
+
+  const problems = scan(fs.readFileSync(BUNDLE, 'utf8'));
+  if (problems.length > 0) return fail(problems);
+
+  process.stdout.write(
+    `OK: no native-tier runtime in the interpreted-only :advanced / goog.DEBUG=false ` +
+    `bundle (${SENTINELS.length} sentinels absent, ${CONTROLS.length} positive controls present).\n`
+  );
+  return 0;
+}
+
+process.exit(main(process.argv.slice(2)));

--- a/implementation/hicasso/scripts/check_optional_module_reachability.py
+++ b/implementation/hicasso/scripts/check_optional_module_reachability.py
@@ -47,6 +47,16 @@ the property needs: the module is unreachable or it is not, and
 reachability is decided in the source.  What a byte count would add is
 confidence about the COMPILER, which is not what regresses here.
 
+For the `native` row there IS such a companion, and the division of
+labour is worth stating because neither instrument subsumes the other.
+`scripts/check_bundle_isolation.cjs` (rf2-hic-034) reads the
+`:hicasso-release` bundle for the tier's two sentinel strings, which is
+the linker's half of the same claim — but it can only see the parts of
+the tier that have a production footprint, and a consumer who writes
+only `n/$` with literal props leaves none at all.  THIS gate is the one
+that decides the property exhaustively, because a `:require` is a
+`:require` whether or not Closure keeps anything from it.
+
 SELF-TEST
 ---------
 `--self-test` runs the detector over synthetic sources first, because a
@@ -79,6 +89,39 @@ MODULES = [
             "re_frame/hicasso/motion.cljs",
             "re_frame/hicasso/impl/presence.cljs",
             "re_frame/hicasso/impl/presence_react.cljs",
+        ],
+    },
+    {
+        # rf2-hic-034.  The native tier is the module the native-boundary
+        # law names in terms: *the native namespace is separately
+        # reachable; an interpreted-only production dependency graph and
+        # bundle contain neither native-tier runtime nor UIx code*
+        # (`docs/design/hicasso/product/lanes/design-laws.md`).  This row
+        # is the DEPENDENCY-GRAPH half of that sentence.
+        #
+        # NO ENGINE, and the emptiness is the design rather than an
+        # omission.  `motion`'s weight is in two private namespaces it
+        # alone reaches, so protecting its door alone would leave a
+        # `impl.presence-react` require as an unguarded way in.  The
+        # native tier owns exactly one file: everything else it touches —
+        # `impl.error`, `impl.slot`, `impl.collector` — is the SHARED
+        # runtime that the public door already reaches, so naming any of
+        # them here would forbid the interpreted tier its own machinery.
+        # There is therefore one edge to guard and it is the door.
+        #
+        # The two-languages fence is what makes that true: `n/$` reads its
+        # own form and never a `defview` body, so no interpreted path has
+        # any reason to reach for the tier, and neither embedding bridge
+        # names it — `h/as-component` outward, `h/defhost` and `[:>]`
+        # inward, both of which cross to a foreign React component without
+        # caring which tier minted it (rf2-hic-032).  A require appearing
+        # here would therefore be a genuine architectural change and not a
+        # convenience.
+        "name": "native",
+        "door": "re-frame.hicasso.native",
+        "engine": [],
+        "files": [
+            "re_frame/hicasso/native.cljc",
         ],
     },
 ]
@@ -280,6 +323,34 @@ def self_test():
     clean = scan(
         {
             "src/m.cljs": "(ns {}\n  (:require [{} :as p]))".format(door, engine)
+        }
+    )
+    assert clean == [], clean
+
+    # rf2-hic-034 — the native tier's door, required from a `src/`
+    # namespace that is not it.  Driven as its own case rather than left
+    # to the generic loop above: that row has an engine and this one does
+    # not, so the fixtures written for `motion` exercise a shape the
+    # native row does not have, and a roster entry nothing drives is an
+    # entry that can stop working in silence.
+    flagged = scan(
+        {
+            "src/n.cljs": "(ns re-frame.hicasso.impl.codec\n"
+            "  (:require [re-frame.hicasso.native :as n]))"
+        }
+    )
+    assert len(flagged) == 1, flagged
+    assert "re-frame.hicasso.native" in flagged[0], flagged
+    assert "`native` module" in flagged[0], flagged
+
+    # And the shape the real tree actually has: `impl/codec.cljs` carries
+    # four `[[re-frame.hicasso.native/…]]` docstring links today.  Prose is
+    # provenance, so the live scan below has to stay green over them.
+    clean = scan(
+        {
+            "src/p.cljs": '(ns re-frame.hicasso.impl.codec\n'
+            '  "The sibling door [[re-frame.hicasso.native/declared-server]]."\n'
+            "  (:require [re-frame.hicasso.impl.slot :as slot]))"
         }
     )
     assert clean == [], clean

--- a/implementation/hicasso/test/re_frame/hicasso/three_way_parity_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/three_way_parity_cljs_test.cljs
@@ -1,0 +1,648 @@
+(ns re-frame.hicasso.three-way-parity-cljs-test
+  "THREE-WAY PARITY — Hicasso-native against BOTH handwritten React and
+  UIx (rf2-hic-034).
+
+  > A native island should be within 5% or 1 ms of the same component
+  > mounted directly through its chosen React route, excluding the single
+  > explicit crossing. **The Hicasso-native surface is co-instrumented
+  > against both handwritten React construction and UIx so the
+  > convenience layer cannot define its own floor.**
+  >
+  > — `docs/design/hicasso/product/specification.md` §6
+
+  The second sentence is why there are three routes and not two. A native
+  tier measured only against UIx would be measured against a floor UIx
+  itself sets: UIx is a convenience layer, it pays a per-render price for
+  that convenience, and matching it proves nothing about whether the
+  native tier costs what React costs. Handwritten `react/createElement`
+  is the only arm with no convenience in it, so it is the arm that
+  decides.
+
+  ## The corpus, and why the rows are thunks
+
+  Every row of [[corpus]] is ONE subject written three times. The three
+  spellings are the whole content of a row — the rows below assert
+  equalities BETWEEN them and never against a literal, because a literal
+  is a fourth spelling that can drift from all three at once.
+
+  They are thunks rather than values because two of the three are macro
+  forms whose expansion is the thing under test: `n/$` lowers a literal
+  props map at expansion and `uix/$` compiles its attributes at
+  expansion, so a row evaluated once at namespace load would hide which
+  arm did what and when.
+
+  ## What each row proves, and what it deliberately does not
+
+  | claim | how |
+  |---|---|
+  | same DOM output, same bytes | `react-dom/server` over the three arms — one string compared three ways |
+  | same element shape | `.-type`, `.-key`, and the props object read as a map |
+  | keys | a keyed seq, where React's own child reconciliation reads the slot |
+  | SVG and custom elements | two heads whose attribute rules are not the ordinary ones |
+  | dynamic props | the marked operand against a hand-built object |
+  | children shapes | React's three — none, one, many — the shapes rf2-hic-032 repaired the outward bridge for |
+  | component identity | the element type each route hands React |
+  | same-frame reads | one key read through all three doors in one tree |
+  | hook count | React's own dispatcher, through `hook-probe` |
+
+  **Refs, cleanup and hydration are NOT here.** Each is a property of a
+  fiber and a real document, and the node lane has neither: this file
+  runs under `:node-test`, where a DOM claim degrades to a stated skip.
+  They are `three_way_parity_dom_cljs_test`'s, which the browser lane
+  decides.
+
+  ## The island band, and the row this file does not pretend to be
+
+  The bead's island-performance deliverable is `C7` in
+  `docs/design/hicasso/product/budgets.md` §9, and it is `UNPINNED` with
+  its authority recorded as `rf2-hic-071`. That page's §9.2 says why in
+  terms: the 5% rule has no same-instrument anchor until the ladder is
+  re-pinned, no package-resident clock instrument exists, and §7 forbids
+  converting a distributional row into a pull-request threshold at all.
+  §9.2 also names *this* bead as one of the three that supply C7's
+  POPULATION — the landed islands the rule is stated over — which is the
+  same statement from the other side.
+
+  So this file lands the population and the DETERMINISTIC half of the
+  band, which is the half a hosted runner is allowed to decide:
+  [[a-native-component-is-the-authors-own-function-and-costs-no-wrapper]]
+  and [[the-convenience-layer-pays-a-per-render-price-the-native-tier-does-not]]
+  read the two routes' construction cost as a structural fact rather
+  than as a clock. That is a stronger reading than a timing, not a weaker
+  one: a native island and a handwritten React component are the SAME
+  element type with the SAME props object, so there is no interposed work
+  for a stopwatch to find. No number is transcribed into the ledger here;
+  the figures are this file's own, and the ledger row is `rf2-hic-089`'s
+  to transcribe, as D10–D13 were."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.hicasso.hook-probe :as probe]
+            [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.native :as n]
+            [re-frame.test-support :as test-support]
+            [uix.core :as uix :refer-macros [defui]]
+            ["react" :as react]
+            ["react-dom/server" :as react-dom-server]))
+
+(def ^:private frame-id ::parity)
+
+(rf/reg-sub ::price (fn [db _] (:price db)))
+
+(rf/reg-event ::seed (fn [_ [_ db]] {:db db}))
+
+(rf/reg-event ::typed (fn [{:keys [db]} [_ typed]] {:db (assoc db :price typed)}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn []
+                      (support/leave-act-environment!)
+                      (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; The three routes, as components
+;; ---------------------------------------------------------------------------
+;;
+;; One subject: a cell that paints a label. Written once per route, with
+;; nothing in any of them that the other two do not have.
+
+(n/defcomponent native-cell
+  "The native route. The ABI is one raw JavaScript props object and the
+  body reads it by name."
+  [^js props]
+  (n/$ :span {:class "cell"} (.-label props)))
+
+(defn react-cell
+  "The handwritten route — an ordinary React function component, which is
+  what `n/defcomponent` compiles to and the arm the band is measured
+  against."
+  [^js props]
+  (react/createElement "span" #js {:className "cell"} (.-label props)))
+
+(defui uix-cell
+  "The UIx route. Its ABI is a ClojureScript props MAP, which is the
+  convenience — and the price."
+  [{:keys [label]}]
+  (uix/$ :span {:class "cell"} label))
+
+;; ---------------------------------------------------------------------------
+;; The corpus
+;; ---------------------------------------------------------------------------
+
+(def ^:private corpus
+  "Matched triples. Every row is one subject in three spellings, and
+  `:proves` names the equality the row exists to establish rather than
+  describing the markup — a row whose only claim is *these render the
+  same* is a row that would survive all three arms being wrong together."
+  [{:name   "intrinsic element, literal props, one text child"
+    :proves "the ordinary case: a ClojureScript props map lowers to the same
+             React slots on all three routes, so `:class` is `className`
+             wherever it is written"
+    :native #(n/$ :span {:class "cell" :id "c1"} "42")
+    :react  #(react/createElement "span" #js {:className "cell" :id "c1"} "42")
+    :uix    #(uix/$ :span {:class "cell" :id "c1"} "42")}
+
+   {:name   "a keyed sequence of children"
+    :proves "the `:key` slot is React's own on every route — the one prop React
+             itself reads, and the one a route that invented its own child
+             identity would get wrong"
+    :native #(n/$ :ul nil
+                  (n/$ :li {:key "a"} "a")
+                  (n/$ :li {:key "b"} "b"))
+    :react  #(react/createElement "ul" nil
+                                  (react/createElement "li" #js {:key "a"} "a")
+                                  (react/createElement "li" #js {:key "b"} "b"))
+    :uix    #(uix/$ :ul nil
+                    (uix/$ :li {:key "a"} "a")
+                    (uix/$ :li {:key "b"} "b"))}
+
+   {:name   "an SVG element with a dashed attribute"
+    :proves "SVG's attribute rules are React's, not the substrate's: `stroke-width`
+             becomes `strokeWidth` and the element lands in the SVG namespace on
+             all three routes"
+    :native #(n/$ :svg {:viewBox "0 0 8 8"}
+                  (n/$ :circle {:cx 4 :cy 4 :r 3 :stroke-width 2}))
+    :react  #(react/createElement "svg" #js {:viewBox "0 0 8 8"}
+                                  (react/createElement "circle" #js {:cx 4 :cy 4 :r 3 :strokeWidth 2}))
+    :uix    #(uix/$ :svg {:view-box "0 0 8 8"}
+                    (uix/$ :circle {:cx 4 :cy 4 :r 3 :stroke-width 2}))}
+
+   {:name   "a custom element, spelled as a string head"
+    :proves "a head with a dash is a custom element on every route and its
+             attributes pass through unrenamed — the case where React's own
+             rule CHANGES, so a route carrying its own attribute table would
+             diverge here and nowhere else"
+    :native #(n/$ "my-widget" #js {:data-size "lg"} "w")
+    :react  #(react/createElement "my-widget" #js {:data-size "lg"} "w")
+    :uix    #(uix/$ :my-widget {:data-size "lg"} "w")}
+
+   {:name   "a dynamic props operand"
+    :proves "a props map built at runtime reaches the same React slots as the
+             literal one — on the native route through the explicit `n/props`
+             marker, which is the whole of what the marker does"
+    :native #(let [m {:class "cell" :id "c1"}] (n/$ :span (n/props m) "42"))
+    :react  #(let [o #js {}]
+               (unchecked-set o "className" "cell")
+               (unchecked-set o "id" "c1")
+               (react/createElement "span" o "42"))
+    :uix    #(let [m {:class "cell" :id "c1"}] (uix/$ :span m "42"))}
+
+   {:name   "no children"
+    :proves "React's first children shape. rf2-hic-032 repaired the outward
+             bridge over exactly these three, because React's `children` slot
+             is absent, a bare value and an array in turn — and a route that
+             read it as one shape got the other two wrong"
+    :native #(n/$ :span {:class "cell"})
+    :react  #(react/createElement "span" #js {:className "cell"})
+    :uix    #(uix/$ :span {:class "cell"})}
+
+   {:name   "exactly one child"
+    :proves "React's second children shape — the slot holds the child itself,
+             not a one-element array"
+    :native #(n/$ :span {:class "cell"} (n/$ :b nil "one"))
+    :react  #(react/createElement "span" #js {:className "cell"}
+                                  (react/createElement "b" nil "one"))
+    :uix    #(uix/$ :span {:class "cell"} (uix/$ :b nil "one"))}
+
+   {:name   "many children, mixed element and text"
+    :proves "React's third children shape, with the mixture that makes it
+             interesting: text and elements interleaved, where a route that
+             normalised children would show it"
+    :native #(n/$ :p nil "a" (n/$ :b nil "b") "c" (n/$ :i nil "d"))
+    :react  #(react/createElement "p" nil "a"
+                                  (react/createElement "b" nil "b") "c"
+                                  (react/createElement "i" nil "d"))
+    :uix    #(uix/$ :p nil "a" (uix/$ :b nil "b") "c" (uix/$ :i nil "d"))}
+
+   {:name   "a component head"
+    :proves "the routes agree about a COMPONENT and not only about intrinsic
+             elements — three different element types, three different props
+             ABIs, one rendering"
+    :native #(n/$ native-cell #js {:label "42"})
+    :react  #(react/createElement react-cell #js {:label "42"})
+    :uix    #(uix/$ uix-cell {:label "42"})}])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- markup
+  "The server markup for an already-constructed React element."
+  [el]
+  (react-dom-server/renderToString el))
+
+(defn- props-map
+  "`el`'s props object read as a ClojureScript map, with `children`
+  dropped.
+
+  Children are compared by the markup rows; what is compared here is the
+  PROP surface, and a nested element in the map would compare React
+  element objects by identity and never be equal across two routes."
+  [^js el]
+  (let [p (.-props el)]
+    (into {}
+          (comp (remove #(= "children" %))
+                (map (fn [k] [k (unchecked-get p k)])))
+          (js/Object.keys p))))
+
+(defn- scalar-props
+  "[[props-map]] keeping only the entries a cross-route comparison can
+  decide — strings, numbers, booleans and nil. A function or an object
+  prop is compared by identity, which two independently written arms can
+  never satisfy and which no row here is about."
+  [el]
+  (into {} (remove (fn [[_ v]] (or (fn? v) (object? v)))) (props-map el)))
+
+(defn- refusal
+  "Run `f` and answer the refusal's ex-data — or a marker saying what
+  happened instead, so a failing row reports WHICH of the two ways it
+  failed rather than throwing out of the assertion. The shape
+  `native_grammar_cljs_test` uses, for the same reason."
+  [f]
+  (try
+    (f)
+    {::outcome :returned-without-refusing}
+    (catch :default e
+      (or (ex-data e) {::outcome :threw-without-ex-data ::message (ex-message e)}))))
+
+;; ---------------------------------------------------------------------------
+;; 0. The instrument can tell two markups apart
+;; ---------------------------------------------------------------------------
+;;
+;; Every row below is of the form *these three are equal*, and equality is
+;; trivially satisfied by an instrument that answers the same thing to
+;; everything. So the first row drives a deliberate MISMATCH and asserts
+;; the instrument reports it, exactly as `hook_budget_cljs_test` counts to
+;; three before asserting two.
+
+(deftest the-instrument-reports-a-difference-when-there-is-one
+  (let [a (markup (react/createElement "span" #js {:className "cell"} "42"))
+        b (markup (react/createElement "span" #js {:className "cell"} "43"))]
+
+    (testing "the premise: the renderer produced real markup rather than an
+              empty string, which every equality below would also satisfy"
+      (is (seq a))
+      (is (some? (re-find #"<span" a))))
+
+    (testing "and one changed character is seen — so `=` below is a reading
+              taken by an instrument known to discriminate"
+      (is (not= a b)))
+
+    (testing "the same for the element reader: two different classes are two
+              different prop maps"
+      (is (not= (scalar-props (react/createElement "span" #js {:className "one"}))
+                (scalar-props (react/createElement "span" #js {:className "two"})))))))
+
+;; ---------------------------------------------------------------------------
+;; 1. The three routes render the same bytes
+;; ---------------------------------------------------------------------------
+
+(deftest the-three-routes-render-the-same-server-bytes
+  (doseq [{:keys [name proves native react uix]} corpus]
+    (testing (str name " — " proves)
+      (let [handwritten (markup (react))]
+
+        (testing "the premise: the handwritten arm rendered something"
+          (is (seq handwritten)))
+
+        (testing "Hicasso-native against handwritten React, which is the
+                  comparison that decides — no convenience layer sets this
+                  floor"
+          (is (= handwritten (markup (native)))))
+
+        (testing "and UIx against the same handwritten arm, so the three are
+                  one subject rather than two agreeing pairs"
+          (is (= handwritten (markup (uix)))))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. The three routes build the same element
+;; ---------------------------------------------------------------------------
+;;
+;; Markup is the output; this is the CONSTRUCTION. A route could reach the
+;; same bytes through a different element shape — an extra wrapper, a
+;; normalised child array, a key moved into props — and the rows above
+;; would not see it.
+
+(deftest the-three-routes-build-the-same-element-shape
+  (doseq [{:keys [name proves native react uix]} corpus]
+    (testing (str name " — " proves)
+      (let [^js r (react)
+            ^js n (native)
+            ^js u (uix)]
+
+        (testing "the element TYPE. For an intrinsic element it is the tag
+                  string, identically on all three routes; for a COMPONENT
+                  head the three types are three different functions — one
+                  per route — which is not a divergence but the subject:
+                  three components rendering one output is what parity means
+                  here, and a row asserting they were the same object would
+                  be asserting the corpus had only one arm"
+          (if (string? (.-type r))
+            (do (is (= (.-type r) (.-type n)))
+                (is (= (.-type r) (.-type u))))
+            (do (is (fn? (.-type r)))
+                (is (fn? (.-type n)))
+                (is (fn? (.-type u)))
+                (is (= 3 (count (distinct [(.-type r) (.-type n) (.-type u)])))
+                    "three arms, not two aliases of one"))))
+
+        (testing "the `key` slot, which React reads itself"
+          (is (= (.-key r) (.-key n)))
+          (is (= (.-key r) (.-key u))))
+
+        (testing "and the scalar props, slot by slot — the native route's
+                  lowering is `impl/slot`'s and produces React's names"
+          (is (= (scalar-props r) (scalar-props n)))
+          (when (string? (.-type r))
+            (is (= (scalar-props r) (scalar-props u))
+                "UIx too, for an intrinsic element, where all three carry
+                 React's own props object. A COMPONENT head is the one place
+                 the three ABIs differ, and that difference is its own row
+                 rather than an exception hidden here")))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. Component identity — the native route's zero wrapper
+;; ---------------------------------------------------------------------------
+;;
+;; This is the deterministic half of the island band. See the namespace
+;; docstring: C7 is UNPINNED and its clock is rf2-hic-071's, but the
+;; structural fact underneath it is decidable here and is the stronger
+;; statement — there is no interposed work for a stopwatch to find.
+
+(deftest a-native-component-is-the-authors-own-function-and-costs-no-wrapper
+  (testing "`n/defcomponent` answers a FUNCTION, and it is the element type
+            React reconciles on — not a wrapper holding one"
+    (is (fn? native-cell))
+    (is (identical? native-cell (.-type (n/$ native-cell #js {:label "42"})))))
+
+  (testing "so the props React hands the component carry the author's own
+            slot and nothing else. Stated as a KEY SET rather than by
+            identity, because `React.createElement` copies its config into
+            a fresh props object on every route and always has — a row
+            asserting identity would be asserting a fact about React that
+            is not true of any of the three arms"
+    (is (= ["label"] (vec (js/Object.keys (.-props (n/$ native-cell #js {:label "42"})))))))
+
+  (testing "and the body runs when the function is CALLED — no fiber, no
+            hook, no shell. This is what `a native island costs what React
+            costs` means as a structural fact rather than a timing"
+    (let [el (native-cell #js {:label "42"})]
+      (is (= "span" (.-type el)))
+      (is (= "42" (.-children (.-props el))))))
+
+  (testing "the handwritten arm is the same three sentences, which is the
+            point: the two routes are not close, they are identical in
+            shape, and the band excludes only the one explicit crossing"
+    (is (fn? react-cell))
+    (is (identical? react-cell (.-type (react/createElement react-cell #js {:label "42"}))))
+    (is (= ["label"] (vec (js/Object.keys (.-props (react/createElement react-cell #js {:label "42"}))))))))
+
+(deftest the-convenience-layer-pays-a-per-render-price-the-native-tier-does-not
+  (testing "UIx's element carries a CARRIER object rather than the props the
+            author wrote — `#js {:argv <the map>}` — so the props a UIx
+            component receives are not the props at the call site"
+    (let [^js el (uix/$ uix-cell {:label "42"})]
+      (is (some? (.-argv (.-props el)))
+          "the carrier slot is there")
+      (is (= {:label "42"} (.-argv (.-props el)))
+          "and it holds the ClojureScript map the author wrote")))
+
+  (testing "read as a figure, which is what makes it comparable: the props
+            object React carries has ONE slot on every route, and on two of
+            them it is the author's `label` while on UIx it is a carrier the
+            author never wrote. That is one unwrapping hop per render, per
+            component, on the UIx route and ZERO on the other two — the
+            convenience being paid for, and exactly why §6 requires the
+            native tier to be co-instrumented against handwritten React as
+            well: a floor set by UIx would have this hop inside it"
+    (let [slots (fn [^js el] (vec (js/Object.keys (.-props el))))]
+      (is (= ["label"] (slots (n/$ native-cell #js {:label "42"}))))
+      (is (= ["label"] (slots (react/createElement react-cell #js {:label "42"}))))
+      (is (= ["argv"]  (slots (uix/$ uix-cell {:label "42"})))))
+
+    (let [^js uix-el    (uix/$ uix-cell {:label "42"})
+          ^js native-el (n/$ native-cell #js {:label "42"})]
+      (is (nil? (.-label (.-props uix-el)))
+          "UIx's element does not carry the prop at its own name")
+      (is (= "42" (.-label (.-props native-el)))
+          "the native element does — the body reads `.-label` off the props
+           object React built from the very map the call site wrote")))
+
+  (testing "and the two routes' element types are different KINDS of thing:
+            the native tier's is the author's own function, UIx's is a
+            generated component around a body the author wrote separately"
+    (is (identical? native-cell (.-type (n/$ native-cell #js {:label "42"}))))
+    (is (true? (.-uix-component? uix-cell))
+        "UIx stamps its own components, which is how it recognises one — and
+         the native tier's function carries no such stamp because it is not
+         wrapped")))
+
+;; ---------------------------------------------------------------------------
+;; 4. One frame, read through all three doors
+;; ---------------------------------------------------------------------------
+
+(n/defcomponent island
+  "The native route's read: `n/use-sub`, a real React hook."
+  [_props]
+  (n/$ :b {:class "island"} (str (n/use-sub [::price]))))
+
+(defui uix-reader
+  "The UIx route's read, through the adapter's own hook, in the EXPLICIT
+  two-argument form.
+
+  Explicit and not ambient, and the reason is a property of the lane
+  rather than a shortcut. The spine's one-argument form resolves the
+  frame through `frame/require-current-frame!`, which reaches the
+  React-context tier by reading `context._currentValue` — a client-render
+  fact. Under `react-dom/server` that read finds nothing and the hook
+  refuses with `:rf.error/no-frame-context`, whether or not the adapter's
+  own `frame-provider` is above it (measured: it was, and it did).
+  Spec 002's own ladder names the explicit `{:frame <id>}` as the third
+  of three ways to establish a scope, so this arm takes it.
+
+  What that costs the row is nothing: the claim is that all three routes
+  read ONE frame and agree, not that all three discover it by the same
+  mechanism — they demonstrably do not, since the Hicasso arms resolve
+  through `impl/collector`'s own context read. The ambient UIx form is
+  the browser lane's to exercise, and `re-frame.adapter.uix`'s own
+  `uix_use_subscribe_dom_cljs_test` is where it already is."
+  [_]
+  (uix/$ :u {:class "uix"} (str (uix-adapter/use-subscribe frame-id [::price]))))
+
+(defn uix-arm
+  "The crossing into the UIx tree, and it is a PLAIN React component
+  deliberately.
+
+  UIx's ABI is a carrier object its own `uix/$` builds — `#js {:argv m}`
+  — so a `defui` reached through any door but `uix/$` receives props it
+  cannot read. A plain React component is therefore the honest shim, and
+  it is what the crossing looks like in an application too."
+  [_props]
+  (uix/$ uix-reader))
+
+(h/defhost uix-host
+  "The UIx arm's crossing into the tree, through the named door.
+
+  `{:server :render}` and not the default, and the reason belongs in the
+  file: `[:>]` and an undeclared `defhost` are `:client-only`, which is a
+  policy about the SERVER — the gate withholds the foreign component and
+  renders its fallback. That is correct conduct and it is measured in
+  `hook_budget_cljs_test`; here it would delete the arm this row exists
+  to compare, and the first draft of this file read two arms agreeing and
+  called it three. The premise row below is what caught it."
+  uix-arm
+  {:server :render})
+
+(h/defview boundary
+  "The interpreted route's read: `h/sub`, the ambient collector."
+  [_]
+  [:i.boundary (str (h/sub [::price]))])
+
+(h/defview page
+  "One tree holding all three, so the reads are of the same frame in the
+  same render rather than three separate renders that happen to agree."
+  [_]
+  [:div.page
+   [boundary {}]
+   (n/$ island nil)
+   [uix-host {}]])
+
+(defn- seeded!
+  []
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [::seed {:price 191}]))
+  frame-id)
+
+(defn- server-render!
+  "Render `hiccup` under the frame through React's own server renderer,
+  answering the markup and the hook names React was asked for, in call
+  order."
+  [hiccup]
+  (let [!html (volatile! nil)
+        hooks (probe/record!
+                (fn []
+                  (vreset! !html
+                           (react-dom-server/renderToString
+                             (mount/provider frame-id
+                                             (codec/root-element frame-id hiccup))))))]
+    {:html @!html :hooks hooks}))
+
+(deftest the-three-routes-read-one-frame-and-agree
+  (seeded!)
+  (is (true? (probe/install!))
+      "React's client-internals dispatcher slot was not found — the hook
+       counts below are UNWITNESSED, not satisfied")
+  (let [{:keys [html hooks]} (server-render! [page {}])]
+
+    (testing "the premise: all three arms rendered, so the agreement below is
+              between three readings and not between one and two absences"
+      (is (some? (re-find #"boundary" html)))
+      (is (some? (re-find #"island" html)))
+      (is (some? (re-find #"uix" html))))
+
+    (testing "and all three painted the SAME value — one key, one frame, three
+              doors. An island is a place in the application, not a second
+              application"
+      (is (= 3 (count (re-seq #">191<" html)))))
+
+    (testing "the six hooks Hicasso owns, in the order React ran them: the
+              page's own shell, the nested boundary's shell, and the
+              island's `n/use-sub`. THREE readers, TWO hooks each — and the
+              island's pair is indistinguishable from a boundary shell's,
+              which is the parity statement in its sharpest form: crossing
+              into the native tier does not change what a read costs"
+      (is (= ["useContext" "useSyncExternalStore"
+              "useContext" "useSyncExternalStore"
+              "useContext" "useSyncExternalStore"]
+             (vec (take 6 hooks)))))
+
+    (testing "I9 holds at two, read off the ledger the shell declares — the
+              three-route tree above added a native island and a foreign
+              UIx subtree and moved it by nothing"
+      (is (= 2 (count collector/shell-hook-ledger))))
+
+    (testing "and neither `useRef` nor `useState` is among them: HD-020(b)'s
+              two named prohibitions, over every hook Hicasso spent on this
+              page. The UIx arm below DOES call `useRef` — three times — and
+              that is its own affair and not charged here, exactly as
+              `hook_budget_cljs_test` establishes for a hosted component's
+              own roster"
+      (is (= [] (filterv #{"useRef" "useState"} (vec (take 6 hooks))))))
+
+    (testing "the crossing itself cost no hook: `{:server :render}` mints no
+              gate, so everything past the sixth is the foreign subtree's
+              own and the door contributed nothing to the count"
+      (is (seq (drop 6 hooks))
+          "the premise — the UIx arm really ran hooks of its own, so the
+           statement above is about a populated tail rather than an empty
+           one"))))
+
+;; ---------------------------------------------------------------------------
+;; 5. The leakage matrix — the mix the fence exists for
+;; ---------------------------------------------------------------------------
+;;
+;; The bead names four ambiguous mixes. Three are already witnessed and are
+;; NOT re-asserted here, because a second copy of a row is a second thing to
+;; drift: nested hiccup in a native child and an intent vector at a native
+;; callback are `native_grammar_cljs_test`'s
+;; (`a-hiccup-vector-in-child-position-refuses`,
+;; `an-event-vector-at-a-native-callback-slot-refuses`), and dynamic heads
+;; and props are its `heads-are-classified-syntactically` and
+;; `a-dynamic-element-in-props-position-is-a-child`.
+;;
+;; The fourth has no witness anywhere, and it is the one with the most to
+;; go wrong: a CONTROLLED FIELD written inside a native subtree. Every part
+;; of the interpreted controlled-field law — I15's converge-in-turn, the
+;; caret, the revision marker, the shadow component — is installed by
+;; `impl/controlled` from the CODEC, and the codec never runs past the
+;; fence. So the same source shape means one thing on each side, and the
+;; row below is that pair measured in one breath.
+
+(h/defview interpreted-field
+  "The controlled field as the interpreted tier means it: `:value` is a
+  subscription and `:on-input` is an event vector."
+  [_]
+  [:input#interpreted {:type     "text"
+                       :value    (str (h/sub [::price]))
+                       :on-input [::typed ::h/value]}])
+
+(deftest a-controlled-field-means-one-thing-in-hiccup-and-refuses-past-the-fence
+  (seeded!)
+
+  (testing "in hiccup the field is repaired: the codec routes a convergeable
+            input through `controlled/install!`, so what React receives is
+            the shadow component and not the bare tag"
+    (let [{:keys [html]} (server-render! [interpreted-field {}])]
+      (is (some? (re-find #"id=\"interpreted\"" html)))
+      (is (some? (re-find #"value=\"191\"" html)))))
+
+  (testing "past the fence the SAME source shape refuses, and it refuses on
+            the intent rather than on the value — `:on-input` is a React
+            callback slot, nothing lowers an event vector there, and React
+            would otherwise be handed the vector itself"
+    (let [data (refusal #(n/props {:type "text" :value "191" :on-input [::typed ::h/value]}))]
+      (is (= :rf.error/hicasso-native-intent-in-prop (:rf.error/id data)))
+      (is (= "onInput" (:slot data))
+          "the CONTROLLED-field slot specifically. `native_grammar_cljs_test`
+           drives `onClick`; the field family reaches the same rule by the
+           same route, and this row is what says the two are one rule")
+      (is (= 're-frame.hicasso.native/props (:where data))
+          "and it names the form that refused, which is the recovery the
+           author needs")))
+
+  (testing "so there is no silent third behaviour: the value prop alone is
+            legal past the fence and passes by identity, which is React's
+            own read-only controlled input — the author's to complete with a
+            handler, and never repaired behind their back"
+    (let [^js el (n/$ :input (n/props {:type "text" :value "191"}))]
+      (is (= "input" (.-type el)))
+      (is (= "191" (.-value (.-props el))))
+      (is (nil? (.-onChange (.-props el)))
+          "nothing was installed — past the fence there is no controlled
+           repair, which is the fence's whole content"))))

--- a/implementation/hicasso/test/re_frame/hicasso/three_way_parity_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/three_way_parity_dom_cljs_test.cljs
@@ -279,7 +279,10 @@
         (testing "the premise: the tree was really mounted, so the zeros
                   below are a release and not the reading of a page that
                   never held anything"
-          (is (= 3 (count (.querySelectorAll ^js container "span.cell")))))
+          ;; `.-length`, not `count`: a `NodeList` is array-LIKE and
+          ;; ES6-iterable but implements no ClojureScript protocol, so
+          ;; `count` throws `ICounted` rather than answering three.
+          (is (= 3 (.-length (.querySelectorAll ^js container "span.cell")))))
 
         (let [census (roots-support/teardown-census! handle)]
 

--- a/implementation/hicasso/test/re_frame/hicasso/three_way_parity_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/three_way_parity_dom_cljs_test.cljs
@@ -1,0 +1,347 @@
+(ns re-frame.hicasso.three-way-parity-dom-cljs-test
+  "THREE-WAY PARITY UNDER A REAL REACT (rf2-hic-034).
+
+  `three_way_parity_cljs_test` settles what a server render can settle:
+  bytes, element shape, props, and the construction figures underneath
+  the island band. Three of the bead's parity axes cannot be settled
+  there at all, because each is a property of a FIBER and a real
+  document, and the node lane has neither:
+
+  | axis | why it needs a fiber |
+  |---|---|
+  | painted DOM | markup is a string; the DOM is nodes, and a route that emitted correct bytes could still hand React a tree it reconciles differently |
+  | refs | a ref is filled at COMMIT and nulled at unmount — there is no commit on the server |
+  | cleanup | teardown is what a route releases, and nothing was acquired on the server |
+
+  So they are here, and the browser lane decides them. Under
+  `:node-test` every row below degrades to a **stated skip** rather than
+  a false green — `impl.mount/browser?` is the guard, and the sentence it
+  prints names what was not measured.
+
+  ## Hydration is deliberately NOT here
+
+  It is `rf2-hic-046`'s — *per-surface SSR/hydration witnesses* — which
+  is the bead this one unblocks. Writing a three-route hydration row here
+  would put a second authority on the same claim one bead ahead of the
+  one that owns it, and the two would drift on the first policy change.
+  The server bytes each route produces ARE measured, in the node-lane
+  sibling; what happens when React meets those bytes on a client is the
+  next bead's subject.
+
+  ## One door for all three routes, and why that is the honest shape
+
+  Every arm crosses into the tree through `h/defhost` under
+  `{:server :render}`. It is uniform — the same door, the same policy,
+  the same props conversion for all three — so a difference the rows find
+  is a difference between the ROUTES rather than between three ways of
+  reaching them. It is also what an application does: a native island, a
+  handwritten React component and a UIx subtree are all foreign React
+  components to the interpreted tier, and `native.cljc`'s docstring says
+  in terms that this is what keeps native-boundary clause 6 true — the
+  door never names the tier."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.native :as n]
+            [re-frame.hicasso.roots-frames-support :as roots-support]
+            [re-frame.test-support :as test-support]
+            [uix.core :as uix :refer-macros [defui]]
+            ["react" :as react]))
+
+(def ^:private frame-id ::parity-dom)
+
+(rf/reg-sub ::price (fn [db _] (:price db)))
+
+(rf/reg-event ::seed (fn [_ [_ db]] {:db db}))
+
+;; ---------------------------------------------------------------------------
+;; The observables
+;; ---------------------------------------------------------------------------
+
+(def ^:private !refs
+  "Every value each route's callback ref was handed, by route, in order.
+
+  A ref claim read off the DOM would prove only that a node exists. What
+  matters is that the route's own ref FUNCTION was called with it, and
+  that unmount calls it again with nil — React's contract, and the thing
+  a route that quietly swallowed the slot would fail."
+  (atom {}))
+
+(def ^:private !renders
+  "How many times each route's body ran, by route. It separates *the tree
+  updated* from *the tree did not re-render at all*, which the node
+  identity below cannot: an unchanged node is what BOTH look like."
+  (atom {}))
+
+(defn- record-ref!
+  [route node]
+  (swap! !refs update route (fnil conj []) node))
+
+(defn- ran! [route] (swap! !renders update route (fnil inc 0)))
+
+;; The ref callbacks are TOP-LEVEL and stable, which is load-bearing
+;; rather than tidy. React detaches and re-attaches a ref whose identity
+;; changed, so a fresh closure per render would call every ref three
+;; times across one update — and the re-render row below, whose whole
+;; instrument is the call count, would read a remount that never
+;; happened.
+(def ^:private native-ref (fn [node] (record-ref! :native node)))
+(def ^:private react-ref  (fn [node] (record-ref! :react node)))
+(def ^:private uix-ref    (fn [node] (record-ref! :uix node)))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn []
+                      (support/leave-act-environment!)
+                      (reset! !refs {})
+                      (reset! !renders {})
+                      (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; The three routes, as components
+;; ---------------------------------------------------------------------------
+;;
+;; One subject: a cell painting a label, holding a ref on its own span.
+;; The ref arrives as an ORDINARY prop named `innerRef` rather than at
+;; React's `ref` slot, so all three routes are handed it the same way and
+;; the row measures the route rather than React's own ref forwarding —
+;; which `native_abi_dom_cljs_test` already covers for the native tier.
+
+(n/defcomponent native-cell
+  [^js props]
+  (ran! :native)
+  (n/$ :span {:class "cell native" :ref (.-innerRef props)} (.-label props)))
+
+(defn react-cell
+  [^js props]
+  (ran! :react)
+  (react/createElement "span"
+    #js {:className "cell react" :ref (.-innerRef props)}
+    (.-label props)))
+
+(defui uix-cell
+  [{:keys [label inner-ref]}]
+  (ran! :uix)
+  (uix/$ :span {:class "cell uix" :ref inner-ref} label))
+
+(defn- uix-arm
+  "The plain React shim every crossing into UIx needs: UIx's ABI is a
+  carrier object its own `uix/$` builds, so a `defui` reached through any
+  other door receives props it cannot read."
+  [^js props]
+  (uix/$ uix-cell {:label (.-label props) :inner-ref (.-innerRef props)}))
+
+(h/defhost native-host native-cell {:server :render})
+(h/defhost react-host  react-cell  {:server :render})
+(h/defhost uix-host    uix-arm     {:server :render})
+
+(h/defview page
+  "All three arms in one tree, under one frame, in one commit — so a row
+  comparing them is comparing one render and not three that happened to
+  agree."
+  [_]
+  [:div.page
+   [native-host {:label (str (h/sub [::price])) :inner-ref native-ref}]
+   [react-host  {:label (str (h/sub [::price])) :inner-ref react-ref}]
+   [uix-host    {:label (str (h/sub [::price])) :inner-ref uix-ref}]])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- skip!
+  [why]
+  (is true (str "a three-route DOM claim needs a real React DOM — " why)))
+
+(defn- seeded!
+  []
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [::seed {:price 191}]))
+  frame-id)
+
+(defn- mounted!
+  []
+  (let [handle (mount/root! (mount/fresh-container!) frame-id [page {}])]
+    (mount/settle!)
+    handle))
+
+(defn- cells
+  "The three painted cells, by route, read out of `handle`'s container."
+  [handle]
+  (into {}
+        (map (fn [route]
+               [route (.querySelector ^js (:container handle) (str "span.cell." (name route)))]))
+        [:native :react :uix]))
+
+(defn- normalised
+  "`el`'s outer HTML with the route's own class removed.
+
+  The class is how the row FINDS each cell and is therefore the one
+  attribute that must differ between the three. Comparing the raw markup
+  would compare that difference and nothing else; removing it leaves the
+  part the routes are supposed to agree about, and the row below asserts
+  the removal still left something."
+  [^js el]
+  (when el
+    (str/replace (.-outerHTML el) #"\s*(native|react|uix)\b" "")))
+
+;; ---------------------------------------------------------------------------
+;; 1. The painted DOM
+;; ---------------------------------------------------------------------------
+
+(deftest the-three-routes-paint-the-same-dom
+  (if-not (mount/browser?)
+    (skip! ":node-test has no React DOM")
+    (do
+      (seeded!)
+      (let [handle (mounted!)
+            found  (cells handle)]
+        (try
+          (testing "the premise: all three arms mounted. Two arms agreeing
+                    while a third rendered nothing is the failure this row is
+                    most exposed to, and it is the one the node-lane sibling
+                    was actually bitten by"
+            (is (every? some? (vals found)) (pr-str (keys found))))
+
+          (testing "and each painted the value it read — one frame, three
+                    routes, one commit"
+            (is (= ["191" "191" "191"]
+                   (mapv #(.-textContent ^js (get found %)) [:native :react :uix]))))
+
+          (testing "the painted markup is the same on all three routes once
+                    the class that distinguishes them is removed — which is
+                    the DOM claim the server-bytes row cannot make, because
+                    a route could emit correct bytes and still hand React a
+                    tree it reconciles differently"
+            (let [handwritten (normalised (:react found))]
+              (is (seq handwritten) "the premise: normalising left markup")
+              (is (some? (re-find #"<span" handwritten)))
+              (is (= handwritten (normalised (:native found))))
+              (is (= handwritten (normalised (:uix found))))))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. Refs
+;; ---------------------------------------------------------------------------
+
+(deftest a-ref-reaches-a-real-node-on-every-route-and-is-released-on-unmount
+  (if-not (mount/browser?)
+    (skip! ":node-test has no commit, so no ref is ever filled")
+    (do
+      (seeded!)
+      (let [handle (mounted!)
+            found  (cells handle)]
+
+        (testing "each route's own ref function was called, and with the very
+                  node that route painted — not merely with A node"
+          (doseq [route [:native :react :uix]]
+            (let [calls (get @!refs route)]
+              (is (= 1 (count calls)) (str route " ref called exactly once at mount"))
+              (is (identical? (get found route) (first calls))
+                  (str route " ref holds the node it painted")))))
+
+        (testing "and every one of them is a real element with a real tag —
+                  the three routes reach React's ref slot by three different
+                  spellings and land in the same place"
+          (doseq [route [:native :react :uix]]
+            (is (= "SPAN" (.-tagName ^js (first (get @!refs route)))))))
+
+        (roots-support/teardown-census! handle)
+
+        (testing "unmount calls each route's ref again with nil, which is
+                  React's own contract and the half a mounted-only row cannot
+                  see: a route that held the node past unmount would keep a
+                  detached tree alive"
+          (doseq [route [:native :react :uix]]
+            (let [calls (get @!refs route)]
+              (is (= 2 (count calls)) (str route " ref called at mount and at unmount"))
+              (is (nil? (second calls)) (str route " ref released")))))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. Cleanup
+;; ---------------------------------------------------------------------------
+
+(deftest teardown-releases-everything-the-three-route-tree-acquired
+  (if-not (mount/browser?)
+    (skip! ":node-test acquires nothing, so it can release nothing")
+    (do
+      (seeded!)
+      (let [handle    (mounted!)
+            container (:container handle)]
+
+        (testing "the premise: the tree was really mounted, so the zeros
+                  below are a release and not the reading of a page that
+                  never held anything"
+          (is (= 3 (count (.querySelectorAll ^js container "span.cell")))))
+
+        (let [census (roots-support/teardown-census! handle)]
+
+          (testing "the container is empty — React unmounted the whole tree,
+                    the two foreign subtrees included"
+            (is (= "" (.-innerHTML ^js container))))
+
+          (testing "and the runtime's own census is exact at the instant
+                    unmount returned: no cell reference, no boundary, no
+                    edge survived a tree holding a native island and a
+                    foreign UIx subtree. Read BEFORE the release finishes,
+                    because `mount/release!` empties every table by fiat and
+                    a census taken after it reads zeros either way"
+            (is (= {:cell-refs 0 :boundaries 0 :edges 0} census))))))))
+
+;; ---------------------------------------------------------------------------
+;; 4. Component identity across a re-render
+;; ---------------------------------------------------------------------------
+;;
+;; The parity axis the DOM cannot show. A route whose element type is a
+;; fresh object per render renders perfectly and remounts every time:
+;; same pixels, new nodes, lost state, dropped refs. `n/defcomponent`'s
+;; contract is that the element type is the author's own function, so a
+;; re-render UPDATES — and the observable is the ref, which React fills
+;; once per mount and would fill again on a remount.
+
+(deftest a-re-render-updates-every-route-rather-than-remounting-it
+  (if-not (mount/browser?)
+    (skip! ":node-test has no second render")
+    (do
+      (seeded!)
+      (let [handle (mounted!)
+            before (cells handle)]
+        (try
+          (testing "the premise: the first commit filled every ref exactly
+                    once, which is what a second fill would be measured
+                    against"
+            (is (= [1 1 1] (mapv #(count (get @!refs %)) [:native :react :uix]))))
+
+          (rf/with-frame frame-id (rf/dispatch-sync [::seed {:price 192}]))
+          (mount/settle!)
+
+          (testing "the write really re-rendered the page — every route's
+                    body ran a second time and repainted the new value.
+                    The body count is the half the node identity below
+                    cannot supply, since a tree that never re-rendered at
+                    all also keeps its nodes"
+            (is (= {:native 2 :react 2 :uix 2} @!renders))
+            (is (= ["192" "192" "192"]
+                   (mapv #(.-textContent ^js (get (cells handle) %))
+                         [:native :react :uix]))))
+
+          (testing "and every route kept its NODE across the update. React
+                    reconciled rather than replaced, on all three, which is
+                    what an unchanged element type buys and what a
+                    per-render mint would have cost"
+            (doseq [route [:native :react :uix]]
+              (is (identical? (get before route) (get (cells handle) route))
+                  (str route " kept its node"))))
+
+          (testing "so no ref was refilled: still one call each, where a
+                    remount would read two — the observable the DOM cannot
+                    provide, since the pixels are identical either way"
+            (is (= [1 1 1] (mapv #(count (get @!refs %)) [:native :react :uix]))))
+          (finally (mount/release! handle)))))))

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -38,7 +38,7 @@
     "build:machines-viz-viewer": "shadow-cljs release machines-viz-viewer && node ../tools/machines-viz/scripts/stage-viewer-page.cjs",
     "build:freehand-release": "shadow-cljs release freehand-release",
     "build:freehand-evidence-elision": "shadow-cljs release freehand-release freehand-release-control",
-    "build:hicasso-release": "shadow-cljs release hicasso-release && node hicasso/scripts/check_production_erasure.cjs --self-test && node hicasso/scripts/check_production_erasure.cjs",
+    "build:hicasso-release": "shadow-cljs release hicasso-release && node hicasso/scripts/check_production_erasure.cjs --self-test && node hicasso/scripts/check_production_erasure.cjs && node hicasso/scripts/check_bundle_isolation.cjs --self-test && node hicasso/scripts/check_bundle_isolation.cjs",
     "test:ui": "npm run test:ui-isolation && node out/node-test-ui.js",
     "test:ui-isolation": "node scripts/check-ui-adapter-isolation.cjs --self-test && node scripts/compile-node-test.cjs node-test-ui out/node-test-ui.js && node scripts/check-ui-adapter-isolation.cjs",
     "test:ui-warm-watch": "node scripts/check-ui-warm-watch.cjs",


### PR DESCRIPTION
Three-way parity for the native tier (Hicasso-native / handwritten React / UIx), the bundle-isolation half of native-boundary clause 6, and a source-located refusal of the island band's clock half. `rf2-hic-034`.

## What each arm proves

Spec §6 requires the native tier to be **co-instrumented against both handwritten React and UIx**, and the second half is the whole reason there are three arms: a native tier measured only against UIx is measured against a floor UIx itself sets. `react/createElement` is the only arm with no convenience in it, so it is the arm that decides.

`three_way_parity_cljs_test` (node lane) carries nine matched triples — ordinary element, keyed sequence, SVG with a dashed attribute, custom element, dynamic props operand, React's three children shapes, component head — and asserts identical **server bytes**, identical **element type / key / scalar props**. `three_way_parity_dom_cljs_test` (browser lane) carries the three axes that need a fiber: **painted DOM**, **refs** (filled with the node the route painted, nulled at unmount), **cleanup** (empty container + zero cell-refs/boundaries/edges), and **identity across a re-render** (bodies ran twice, nodes identical, no ref refilled).

Every row states the equality it proves, and each deftest opens with a premise assertion. Those premises earned their place — they caught three wrong claims in the first draft:

- `createElement` **copies** its config into a fresh props object on every route, so an identity claim about props was false of all three arms. The figure became the key **set**, which is what makes the UIx hop measurable at all.
- a component head has three different element types **by construction**, so the type row is guarded to intrinsic heads and asserts three *distinct* functions otherwise.
- `[:>]` and an undeclared `defhost` are `:client-only`, so on the server the gate withheld the UIx arm — **two arms agreed while the file claimed three**. The crossing is now `{:server :render}`.

## The graduation rule, and which branch applies

> *a red island-band row blocks native-tier graduation — the row is fixed or the surface shrinks; publication of the miss is required but is not a pass*

**Neither branch fires, because the row is not red.** The island-band row is `C7` in `docs/design/hicasso/product/budgets.md` §9 and it is **`UNPINNED`**, authority `rf2-hic-071`. §9.2 says why in terms: the 5% rule has no same-instrument anchor until the ladder is re-pinned, no package-resident clock instrument exists for the package, and §7 forbids converting a distributional row into a pull-request threshold at all. The same section names **this bead** as one of three that supply C7's **population** — the landed islands the rule is stated over — which is the same statement from the other side.

So this PR lands the population and the **deterministic half** of the band, which is the half a hosted runner is allowed to decide — and it is a stronger reading than a timing, not a weaker one:

| figure | Hicasso-native | handwritten React | UIx |
|---|---|---|---|
| element type is the author's own function | yes | yes | no — a generated component |
| props slots React carries | `["label"]` | `["label"]` | `["argv"]` |
| unwrapping hops per render per component | 0 | 0 | 1 (`glue-args`) |

A native island and a handwritten React component are the same element type with the same props object. **There is no interposed work for a stopwatch to find.** No figure is transcribed into the ledger here: `rf2-hic-033` landed its witness and the follow-up commit `f1185fabc6` added D10–D13 separately, so the ledger row is `rf2-hic-089`'s and C7's status column is `rf2-hic-071`'s. **Suggest a follow-up bead** to register the three figures above as D-rows with authority `rf2-hic-034`.

## Hooks — I9 holds at two, and nothing spent a third

The hook row reads **six** hooks Hicasso owns on a three-route page — page shell, nested boundary, island — **two each**, and the island's pair is indistinguishable from a boundary shell's. `collector/shell-hook-ledger` is still 2 with a native island and a foreign UIx subtree in the tree. Neither `useRef` nor `useState` appears among the six. The UIx arm's own three `useRef` calls are its own affair and are not charged, exactly as `hook_budget_cljs_test` establishes for a hosted roster. **No arm needed a third hook.**

## The bundle-isolation gate, and both sabotage directions

`implementation/hicasso/scripts/check_bundle_isolation.cjs`, on the `rf2-hic-024` pattern, chained into `build:hicasso-release` so the bundle cannot be produced unchecked. **Two** sentinels that must be ABSENT, each paired with a reachable control that must be PRESENT and differs from it by *reachability alone*:

- `hicassoBoundary` (present) vs `rf2:hicasso-native-tier` (absent) — two own-property marker names written with the same `unchecked-set` onto the same kind of freshly minted component.
- `rf.error/hicasso-empty-vector` (present) vs `rf.error/hicasso-native-` (absent) — two refusal ids minted by the same `fail!`.

**Two sentinels because there are two reachability shapes.** Closure eliminates per function: `n/defcomponent` drags `component` in and the marker with it while the dev-gated refusals fold away; `(n/props …)` drags `prop-slots` in, whose last three refusals are ungated, while `component` is never called. Either sentinel alone is green against the other's leak.

A third shape leaves nothing to find, and the header says so rather than carrying a row nobody can falsify: **past DCE, an `n/$` with literal props IS `react/createElement`.** That is the zero-rent claim at its strongest, and it is why the source-side gate is not made redundant — a `:require` is a `:require` whether or not Closure keeps anything from it. `check_optional_module_reachability.py` gains the `native` row (no engine: the tier owns one file, everything else it touches is the shared runtime) with its own synthetic detection case and its own prose-is-not-a-require case.

### Both directions, run

| direction | change | result |
|---|---|---|
| **RED** — the thing it forbids | `consumer_app.cljs` requires `re-frame.hicasso.native`, declares an `n/defcomponent`, mounts it | `build:hicasso-release` **exit 1**, naming *both* sentinels and their surfaces. The **production-erasure gate stayed green** in the same run — the new gate catches what the old one does not. |
| **GREEN** — a legal bundle must still pass | `consumer_app.cljs` crosses a *handwritten React* component through **both** inward doors — `h/defhost` named and `[:>]` one-off | **exit 0**. This is the not-too-eager direction, and it verifies at the artefact level what `native.cljc` claims in prose: *neither door names the tier, and that is what keeps clause 6 true.* |

Restored after each run and **verified by `sha256sum`**, not `git diff`: `d8cfb7f0c28b5ccf67277f7740463d40649e3c7433186817b4fd9906f29a8aff` before and after both.

The script's `--self-test` additionally drives each sentinel alone, fails **closed** on a bundle with no controls, misses each control individually, and requires four **legal** bundles to stay green — a docstring link naming the tier, the neighbouring `hicassoBody`/`hicassoBoundary` markers, a sibling refusal family, and React's own `nativeEvent` plumbing.

## Premises that did NOT hold at source

1. **"zero UIx" is false, and cannot be made true by this fixture.** Hicasso deliberately ships no reactive adapter — `consumer_app.cljs` says so where the consumer is standing — and the three a consumer may pick (Reagent, reagent-slim, UIx) are all view libraries. The exemplar picks UIx, so `re-frame.adapter.uix` is on the entry's require list and `uix.core` comes with it. Measured: `"UIx"`, `"rf-uix-sub-"` and `re-frame.adapter.uix/frame-provider` are all in the release bundle. A row asserting no UIx would be **red on a correct build**. The string is carried as a **positive control** instead, where it earns its place: a bundle that compiled a whole React view library and a whole reactive substrate and *still* carries no native-tier runtime has isolated the tier rather than compiled nothing. Native-boundary clause 6's UIx half is a claim about a consumer's **dependency graph**, and that is the source-side gate's kind of question.
2. **The bead has no notes.** `bd show rf2-hic-034` carries a description and nothing else; there was no notes stack to read bottom-up.
3. **The spine's ambient `use-subscribe` does not resolve under `react-dom/server`.** It reaches the React-context tier by reading `context._currentValue`, a client-render fact, and refuses with `:rf.error/no-frame-context` on the server *even with the adapter's own `frame-provider` above it* — measured, both with and without. The UIx arm takes Spec 002's explicit `{:frame id}`, which is the third of the three ways that ladder itself names. Recorded in the file where it bites. **Not this bead's to fix**; flagged as a possible follow-up.

## Fences

**Nothing wanted a public export, a third hook, a build id or a workflow job.** The gate rides the existing `:hicasso-release` build and the existing `build:hicasso-release` npm chain, exactly as `rf2-hic-024`'s does, so `check_gate_scheduling.py` needed no new declaration and `.github/workflows/**`, `implementation/shadow-cljs.edn`, `implementation/deps.edn` and `spec/**` are untouched. No published snapshot is edited. `budgets.md` is untouched.

**The leakage matrix carries ONE row, not four.** Three of the bead's four ambiguous mixes already have witnesses and are named with them rather than copied — nested hiccup in a native child and an intent vector at a native callback are `native_grammar_cljs_test`'s, as are dynamic heads and dynamic props. The uncovered one is a **controlled field inside a native subtree**: in hiccup the codec routes it through `controlled/install!`; past the fence the same source shape refuses on the intent at `onInput`; and the value prop alone passes by identity as React's own read-only input, never repaired behind the author's back.

**Hydration is deliberately absent.** It is `rf2-hic-046`'s — *per-surface SSR/hydration witnesses* — which is the bead this one unblocks. The server bytes each route produces are measured here; what happens when React meets them is the next bead's.

## Quality gates

Every command run alone, foreground to completion, exit code captured on the same line.

| command | exit | reading |
|---|---|---|
| `npm run test:cljs` **(base, before any change)** | **0** | 13354 tests / 67270 assertions, 0 failures 0 errors |
| `npm run test:cljs` | **0** | 13365 tests / 67406 assertions, 0 failures 0 errors |
| `npm run test:browser` | **0** | 1297 tests / 8041 assertions, 0 failures 0 errors |
| `npm run build:hicasso-release` | **0** | erasure: 5 sentinels absent / 3 controls present · isolation: 2 sentinels absent / 4 controls present |
| `npm run build:hicasso-release` **under sabotage A** | **1** | `NATIVE TIER LEAKED`, both sentinels named |
| `npm run build:hicasso-release` **under sabotage B** | **0** | the legal inward bridges stay green |
| `npm run test:hicasso-invariants` | **0** | `motion, native unreachable from the public door`; 35 ledger rows unchanged |
| `npm run test:script-policy` | **0** | the package.json edit is chain-only |
| `python scripts/check_gate_scheduling.py` | **0** | 50 gate commands, 42 scheduled, 8 declared |
| `clojure -M:clj-kondo --lint <the two new suites>` | **0** | errors 0, warnings 0 — the **pinned** 2026.04.15 from `hicasso/deps.edn` |
| `node hicasso/scripts/check_bundle_isolation.cjs --self-test` | **0** | 2 sentinels, 4 positive controls |
| `python hicasso/scripts/check_optional_module_reachability.py --self-test` | **0** | |
| `python scripts/check_fast_pr_gap.py --list` | **0** | see below |

**What the fast-PR spine does not decide (97 required checks).** For this diff the ones that matter are `cljs-browser` and the `cljs` job's `build:hicasso-release` step — both run above, in full. Two required jobs are *armed* by the `implementation/hicasso/**` predicate and are **not** run here: `cljs-hicasso-controlled` and `cljs-hicasso-hmr`, the three-engine gates. This diff adds two test namespaces and one script and touches no `src/`, no testbed app and no build config, so neither gate's subject moved; CI runs them regardless.
