### PR TITLE
feat(hicasso): the test kit answers roles, names and unnamed controls — and a browser decides focus (rf2-hic-043)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/a11y_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/a11y_cljs_test.cljs
@@ -1,0 +1,333 @@
+(ns re-frame.hicasso.examples.slice.a11y-cljs-test
+  "THE SLICE'S STRUCTURAL ACCESSIBILITY (rf2-hic-043; specification §7's
+  accessibility row).
+
+  The row's claim is that data-first markup makes roles and names plain
+  attributes, so a structural assertion can hold them and a browser is
+  needed only for focus. This file is the structural half. Its
+  counterpart is
+  `re-frame.hicasso.examples.slice.a11y-focus-dom-cljs-test`, which asks
+  a real engine whether it agrees.
+
+  ## Every row here is about a VALUE, and most are about a value that MOVES
+
+  Asserting that an `aria-*` attribute is PRESENT is close to worthless:
+  the assertion survives every change that makes the attribute wrong, and
+  it survives the attribute being wired to a constant. So the rows below
+  are arranged around two sharper questions.
+
+  **Does the attribute carry the right value for the state the page is
+  in, and does it change when the state changes?** `[[the-disclosures-
+  expanded-state-moves-while-its-name-holds-still]]` is the clearest
+  case: `aria-expanded` must flip and the toggle's accessible NAME must
+  not, because a control that renames itself as it changes state is a
+  control a screen-reader user loses track of.
+
+  **Is the name RESOLVED, or merely present?** A `<label for=\"x\">`
+  beside an `<input id=\"y\">` has both halves of the pairing and no
+  pairing. `ht/accessible-name` is what makes the difference visible: it
+  resolves the reference, so a row asserting the name is asserting the
+  pair. Every field in the editor is asserted that way, and asserted
+  again in French, so the name is proved to follow the string table
+  rather than to have been read off something that happens to sit
+  nearby.
+
+  ## The sweep, and why it is a sweep
+
+  [[every-operable-control-in-the-application-has-a-name]] runs
+  `ht/unnamed-controls` over every one of the slice's six bodies, in
+  every state each of them has, in both locales. One assertion per tree,
+  and it is the acceptance criterion of the bead in the form the
+  application can be held to as it grows: a seventh control added
+  tomorrow without a name reds it, and no row has to be written for it."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.hicasso.examples.slice.i18n :as i18n]
+            [re-frame.hicasso.examples.slice.routes :as routes]
+            [re-frame.hicasso.examples.slice.subs :as subs]
+            [re-frame.hicasso.examples.slice.views :as views]
+            [re-frame.hicasso.test :as ht]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil}))
+
+;; ---------------------------------------------------------------------------
+;; The fixture maps, generated from the REAL string table
+;; ---------------------------------------------------------------------------
+;;
+;; `[::subs/t k]` fixtures are taken from `i18n/strings` through `i18n/t`
+;; rather than typed here, so a French tree really is the French table's
+;; and the locale rows below compare two renderings of one application
+;; rather than two hand-written maps. The ASSERTED names are still
+;; literals — that is where the claim lives.
+
+(defn- t* [locale ks]
+  (into {} (map (fn [k] [[::subs/t k] (i18n/t locale k)])) ks))
+
+(defn- classed [tree class] (ht/find tree #(= class (:class (ht/attrs %)))))
+
+(defn- named [tree class] (ht/accessible-name tree (classed tree class)))
+
+(defn- by-id [tree id] (ht/find tree #(= id (:id (ht/attrs %)))))
+
+(defn- theme-buttons
+  "The chrome's two theme choices, in menu order. Reached through the
+  switch's own container rather than by class, because the CURRENT one
+  carries a second class (`theme-choice current`) and a class-equality
+  hook would silently return one button and pass."
+  [tree]
+  (filterv #(= :button (:tag %)) (:children (classed tree "theme-switch"))))
+
+;; --- chrome ----------------------------------------------------------------
+
+(defn- chrome-tree [locale]
+  (ht/tree [views/chrome {}]
+           {:subs (merge {[::subs/locale] locale
+                          [::subs/theme]  :light}
+                         (t* locale [:app/title :app/locale :app/theme
+                                     :theme/light :theme/dark]))}))
+
+;; --- a feed row ------------------------------------------------------------
+
+(def ^:private row-props
+  {:slug "intents" :title "Intents are data" :published? true :tags ["intents" "data"]})
+
+(defn- row-tree [locale open?]
+  (ht/tree [views/article-row row-props]
+           {:subs (merge {[::subs/tags-open? "intents"] open?}
+                         (t* locale [:feed/tags]))}))
+
+;; --- the feed page ---------------------------------------------------------
+
+(defn- feed-tree [locale rows]
+  (ht/tree [views/feed-page {}]
+           {:subs (merge {[::subs/feed] rows}
+                         (t* locale [:feed/heading :feed/empty]))}))
+
+;; --- the editor ------------------------------------------------------------
+
+(defn- editor-tree
+  [locale save]
+  (ht/tree [views/editor {:slug "intents"}]
+           {:subs (merge {[::subs/draft "intents"]      {:title "T" :body "B"
+                                                         :published? true}
+                          [::subs/revision "intents"]   0
+                          [::subs/dirty? "intents"]     false
+                          [::subs/save-state "intents"] save
+                          [::subs/token :danger]        "rgb(176, 32, 32)"}
+                         (t* locale [:editor/heading :editor/title :editor/body
+                                     :editor/published :editor/save :editor/saving
+                                     :editor/discard :editor/saved :editor/retry
+                                     :problem/title-taken]))}))
+
+;; --- the article page and the shell ----------------------------------------
+
+(defn- article-tree [locale article]
+  (ht/tree [views/article-page {}]
+           {:subs (merge {[:rf.route/params]         {:slug "intents"}
+                          [::subs/article "intents"] article}
+                         (t* locale [:article/back :article/missing]))}))
+
+(defn- shell-tree [locale route]
+  (ht/tree [views/app {}]
+           {:subs (merge {[:rf.route/id]          route
+                          [::subs/token :surface] "rgb(255, 255, 255)"
+                          [::subs/token :ink]     "rgb(26, 26, 26)"}
+                         (t* locale [:app/pane-error]))}))
+
+;; ---------------------------------------------------------------------------
+;; Names that are RESOLVED through a label, not merely present beside one
+;; ---------------------------------------------------------------------------
+
+(deftest every-field-in-the-editor-is-named-by-the-label-that-points-at-it
+  (let [tree (editor-tree :en {:status :idle :problem nil})]
+    (is (= "Title" (ht/accessible-name tree (by-id tree "slice-title")))
+        "the `<label for=\"slice-title\">` and the `<input id=\"slice-title\">`
+         are two elements and one pairing, and only the resolved name can
+         tell a correct pairing from two attributes that happen to sit in
+         the same form")
+    (is (= "Body" (ht/accessible-name tree (by-id tree "slice-body")))
+        "and a textarea is labelled the same way")
+    (is (= "Published" (ht/accessible-name tree (by-id tree "slice-published")))
+        "the checkbox is inside its label AND carries the `for` — the two
+         mechanisms at once, and the name is the label's text once rather
+         than twice")))
+
+(deftest the-locale-select-is-named-by-the-chromes-own-label
+  (let [tree (chrome-tree :en)]
+    (is (= :combobox (ht/role (by-id tree "slice-locale"))))
+    (is (= "Language" (ht/accessible-name tree (by-id tree "slice-locale"))))))
+
+(deftest a-name-follows-the-string-table-into-the-other-language
+  (testing "the same three fields, the same three pairings, one locale
+            later — which is what says the name is READ from the label
+            rather than baked beside the control"
+    (let [tree (editor-tree :fr {:status :idle :problem nil})]
+      (is (= "Titre" (ht/accessible-name tree (by-id tree "slice-title"))))
+      (is (= "Corps" (ht/accessible-name tree (by-id tree "slice-body"))))
+      (is (= "Publié" (ht/accessible-name tree (by-id tree "slice-published"))))))
+  (is (= "Langue" (let [tree (chrome-tree :fr)]
+                    (ht/accessible-name tree (by-id tree "slice-locale"))))))
+
+(deftest the-buttons-are-named-by-what-they-say
+  (let [tree (editor-tree :en {:status :idle :problem nil})]
+    (is (= "Save" (named tree "save")))
+    (is (= "Discard changes" (named tree "discard"))))
+  (let [tree (editor-tree :fr {:status :idle :problem nil})]
+    (is (= "Enregistrer" (named tree "save")))
+    (is (= "Annuler les modifications" (named tree "discard"))))
+  (testing "and the theme switch's two buttons, which have no label element
+            anywhere — content is their whole name and the row proves the
+            content path is live"
+    (let [tree (chrome-tree :en)]
+      (is (= ["Light" "Dark"] (mapv #(ht/accessible-name tree %) (theme-buttons tree)))))
+    (let [tree (chrome-tree :fr)]
+      (is (= ["Clair" "Sombre"] (mapv #(ht/accessible-name tree %) (theme-buttons tree)))))))
+
+(deftest the-article-link-is-a-link-because-routing-gave-it-an-href
+  (let [tree (row-tree :en false)
+        link (ht/find tree #(= :a (:tag %)))]
+    (is (= :link (ht/role link))
+        "an `<a>` with no href is not a link, and this one's href is the
+         routing artefact's synthesis rather than a string the view
+         wrote — so the role is evidence that the crossing happened")
+    (is (= "Intents are data" (ht/accessible-name tree link))
+        "named by the article's own title, which is CONTENT and is
+         therefore not translated")))
+
+;; ---------------------------------------------------------------------------
+;; Values that MOVE with the state, and values that must not
+;; ---------------------------------------------------------------------------
+
+(deftest the-disclosures-expanded-state-moves-while-its-name-holds-still
+  (let [closed (row-tree :en false)
+        open   (row-tree :en true)]
+    (testing "the state, both ways"
+      (is (= "false" (:aria-expanded (ht/attrs (classed closed "tags-toggle")))))
+      (is (= "true" (:aria-expanded (ht/attrs (classed open "tags-toggle"))))))
+    (testing "and the NAME, unchanged across the flip — a control that
+              renames itself as its state changes is a control a
+              screen-reader user has to re-find, and the two halves of
+              this row are what separate a live `aria-expanded` from a
+              label that encodes the state in its text"
+      (is (= "Tags" (named closed "tags-toggle")))
+      (is (= "Tags" (named open "tags-toggle"))))
+    (testing "in French too, so the name moves with the LOCALE and not
+              with the disclosure"
+      (is (= "Étiquettes" (named (row-tree :fr false) "tags-toggle")))
+      (is (= "Étiquettes" (named (row-tree :fr true) "tags-toggle"))))))
+
+(deftest the-editors-live-region-carries-the-role-its-state-earns
+  (testing "idle: neither region exists, so neither role is announced"
+    (let [tree (editor-tree :en {:status :idle :problem nil})]
+      (is (nil? (classed tree "save-problem")))
+      (is (nil? (classed tree "save-ok")))))
+
+  (testing "failed: an ALERT, which interrupts"
+    (let [tree (editor-tree :en {:status :failed :problem :problem/title-taken})]
+      (is (= :alert (ht/role (classed tree "save-problem"))))
+      (is (nil? (classed tree "save-ok")))))
+
+  (testing "saved: a STATUS, which does not — the two roles are different
+            promises about how urgently a screen reader interrupts, and a
+            row asserting only that `a role is present` could not tell
+            them apart"
+    (let [tree (editor-tree :en {:status :saved :problem nil})]
+      (is (= :status (ht/role (classed tree "save-ok"))))
+      (is (nil? (classed tree "save-problem")))))
+
+  (testing "and a live region takes no name from its own text: it is
+            announced BECAUSE it appeared, and naming it would be this
+            kit inventing something the platform does not give"
+    (let [tree (editor-tree :en {:status :failed :problem :problem/title-taken})]
+      (is (nil? (ht/accessible-name tree (classed tree "save-problem")))))))
+
+(deftest the-save-button-renames-itself-while-it-is-working
+  (testing "the one control in the application whose NAME is supposed to
+            move — a button reporting its own progress — asserted here so
+            the `name holds still` row above is a claim about the
+            disclosure rather than a rule this file applies blindly"
+    (is (= "Save" (named (editor-tree :en {:status :idle :problem nil}) "save")))
+    (is (= "Saving…" (named (editor-tree :en {:status :saving :problem nil}) "save")))))
+
+(deftest the-retry-appears-with-the-failure-and-is-named
+  (let [tree (editor-tree :en {:status :failed :problem :problem/title-taken})]
+    (is (= "Try again" (named tree "retry")))
+    (is (= :button (ht/role (classed tree "retry")))))
+  (is (nil? (classed (editor-tree :en {:status :idle :problem nil}) "retry"))))
+
+(deftest the-shell-is-a-main-landmark-and-the-feed-is-a-list
+  (is (= :main (ht/role (shell-tree :en routes/feed))))
+  (let [tree (feed-tree :en [{:slug "a" :title "A" :published? true :tags []}])]
+    (is (= :list (ht/role (ht/find tree #(= :ul (:tag %))))))
+    (is (= :heading (ht/role (ht/find tree #(= :h2 (:tag %))))))))
+
+;; ---------------------------------------------------------------------------
+;; The sweep — the bead's acceptance, as one assertion per rendering
+;; ---------------------------------------------------------------------------
+
+(defn- states
+  "Every rendering this application has, in one locale: the six bodies,
+  and every branch of the four that have branches. Named, so a failure
+  says which screen it came from."
+  [locale]
+  (concat
+    [["chrome" (chrome-tree locale)]
+     ["a feed row, closed" (row-tree locale false)]
+     ["a feed row, open" (row-tree locale true)]
+     ["a feed row, unpublished"
+      (ht/tree [views/article-row (assoc row-props :published? false)]
+               {:subs (merge {[::subs/tags-open? "intents"] false}
+                             (t* locale [:feed/tags]))})]
+     ;; `use-subs` is the GROUPED read: both queries run whether or not
+     ;; the row has tags, so a tagless row owes both fixtures too.
+     ["a feed row with no tags"
+      (ht/tree [views/article-row (assoc row-props :tags [])]
+               {:subs (merge {[::subs/tags-open? "intents"] false}
+                             (t* locale [:feed/tags]))})]
+     ["the feed, populated" (feed-tree locale [{:slug "a" :title "A"
+                                                :published? true :tags []}])]
+     ["the feed, empty" (feed-tree locale [])]
+     ["the article page" (article-tree locale {:slug "intents"
+                                               :title "Intents are data"})]
+     ["the article page, no such article" (article-tree locale nil)]
+     ["the shell, on the feed" (shell-tree locale routes/feed)]
+     ["the shell, on an article" (shell-tree locale routes/article)]
+     ["the shell, before the first navigation" (shell-tree locale nil)]]
+    (for [save [{:status :idle :problem nil}
+                {:status :saving :problem nil}
+                {:status :saved :problem nil}
+                {:status :failed :problem :problem/title-taken}]]
+      [(str "the editor, " (name (:status save))) (editor-tree locale save)])))
+
+(deftest every-operable-control-in-the-application-has-a-name
+  (doseq [locale i18n/locales
+          [what tree] (states locale)]
+    (is (= [] (ht/unnamed-controls tree))
+        (str what ", in " (name locale)
+             " — every button, link, field and select a user can operate "
+             "must carry an accessible name, and this is the whole "
+             "application asked at once"))))
+
+(deftest the-sweep-would-notice
+  (testing "the control that proves the sweep is not vacuous: the SAME
+            editor rendering with the title field's label detached from
+            it. Nothing else changes — the label is still there, the
+            input still has its id — and the sweep must find exactly one
+            offender. Without this row, an empty answer above would be
+            equally consistent with `unnamed-controls` never finding
+            anything at all"
+    (let [tree     (editor-tree :en {:status :idle :problem nil})
+          detached (ht/find tree #(and (= :label (:tag %))
+                                       (= "slice-title" (:for (ht/attrs %)))))
+          sabotaged (update tree :children
+                            (fn [cs] (mapv #(if (identical? % detached)
+                                              (assoc % :attrs {:for "elsewhere"})
+                                              %)
+                                           cs)))
+          found     (ht/unnamed-controls sabotaged)]
+      (is (= 1 (count found)))
+      (is (= "slice-title" (:id (ht/attrs (first found))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/a11y_focus_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/a11y_focus_dom_cljs_test.cljs
@@ -1,0 +1,362 @@
+(ns re-frame.hicasso.examples.slice.a11y-focus-dom-cljs-test
+  "L4 — WHAT THE BROWSER SAYS ABOUT THE SLICE'S ACCESSIBILITY
+  (rf2-hic-043; specification §7's accessibility row).
+
+  `re-frame.hicasso.examples.slice.a11y-cljs-test` asserts the structure:
+  which role each element carries and which label names which control,
+  read off the semantic tree. Everything it says is a claim about markup,
+  and markup is a claim about what an engine will do with it. This file
+  is where an engine answers.
+
+  ## The three things only a browser can decide, and they are all here
+
+  1. **Where focus IS.** `document.activeElement` is not derivable from a
+     tree. Every row below that says `focus` reads it back.
+  2. **Which elements are focusable at all**, which the engine decides
+     from `disabled` and `tabindex` rather than from the tag —
+     [[focus-order]] asks it one element at a time instead of trusting a
+     selector, because a selector is a second opinion about the very
+     thing under test.
+  3. **Whether a `<label>` really labels a control.** `label.control` and
+     `input.labels` are the engine's OWN association, computed from
+     `for` and from ancestry. [[the-engine-agrees-with-the-structural-
+     names]] compares them with `ht/accessible-name`'s answer for the
+     same page — the one row that can catch the structural helper being
+     confidently wrong.
+
+  ## The two directions every row is written for
+
+  A focus assertion is trivially satisfiable in the wrong direction: a
+  row that only ever asserts *this element can be focused* is green under
+  a page where everything can be focused, which is its own defect. So the
+  focusability rows come in pairs. `.discard` is disabled until the form
+  is dirty, so it is **absent** from the pristine page's focus order and
+  **present** after one keystroke; `.save` is disabled while a save is in
+  flight, so it leaves the order and comes back. The order is asserted as
+  a complete sequence rather than as a membership test, which is what
+  makes an element joining it, leaving it or moving within it visible.
+
+  ## Browser lane
+
+  Every row needs a real document, a real React DOM and a real focus
+  model. `:node-test` compiles this namespace too (`cljs-test$` matches
+  `-dom-cljs-test`), and each row degrades there to a STATED skip rather
+  than to a false green — the skip is honest, and it is not a
+  measurement."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso.examples.slice.events :as events]
+            [re-frame.hicasso.examples.slice.routes :as routes]
+            [re-frame.hicasso.examples.slice.subs :as subs]
+            [re-frame.hicasso.examples.slice.views :as views]
+            [re-frame.hicasso.test.mounted :as hm]
+            [re-frame.test-support :as test-support]))
+
+;; ---------------------------------------------------------------------------
+;; The lane
+;; ---------------------------------------------------------------------------
+
+(defn- browser? [] (exists? js/document))
+
+(defn- skip! [why]
+  (is true (str "a focus witness needs a real browser — " why)))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+                      (routes/register!))}))
+
+;; ---------------------------------------------------------------------------
+;; Reading the page
+;; ---------------------------------------------------------------------------
+
+(defn- node [m sel] (.querySelector (:container m) sel))
+
+(defn- at-article!
+  [slug]
+  (hm/mount! [views/app {}]
+             {:initial-events [[::events/seed]
+                               [:rf.route/navigate {:to routes/article
+                                                    :params {:slug slug}}]]}))
+
+(defn- finish [m done]
+  (-> (hm/unmount! m) (hm/assert-clean!) (.then done)))
+
+(defn- read-sub [m query-v] (rf/subscribe-once query-v {:frame (:frame m)}))
+
+(defn- drained
+  "Wait for `pred`, then flush React — the router-drain counterpart of
+  `hm/settle!`, for the one row here whose reply arrives on a macrotask.
+  `flow-dom-cljs-test`'s helper of the same name and for the same reason."
+  [m pred label]
+  (-> (test-support/poll-until pred {:label label})
+      (.then (fn [_] (hm/settle! m)))))
+
+(defn- finish-after
+  "End the row when `p` settles, reporting a rejection as a failure
+  rather than letting a deadline hang the run — and tearing the mount
+  down either way, so a stuck row cannot make the next row's residue
+  reading wrong."
+  [p m done]
+  (-> p
+      (.catch (fn [e]
+                (is false (str "the flow never settled: "
+                               (or (ex-message e) (str e)) " "
+                               (pr-str (ex-data e))))))
+      (.then (fn [_] (finish m done)))))
+
+(defn- label-of
+  "How a failure NAMES an element: its id when it has one, else its first
+  class, else its tag. Short enough to read a whole focus order at once."
+  [el]
+  (cond
+    (seq (.-id el))        (.-id el)
+    (seq (.-className el)) (first (.split (.-className el) " "))
+    :else                  (.toLowerCase (.-tagName el))))
+
+(defn- focusable?
+  "Does the ENGINE accept focus on `el`? Asked rather than inferred: blur
+  whatever holds focus, ask for it, and read `document.activeElement`
+  back. A `disabled` control and a `tabindex=\"-1\"` control both leave
+  focus on `<body>`, and neither fact is visible in the markup alone."
+  [el]
+  (some-> (.-activeElement js/document) (.blur))
+  (.focus el)
+  (identical? el (.-activeElement js/document)))
+
+(defn- focus-order
+  "The page's focus order, as readable names — every candidate in
+  document order that the engine will actually focus.
+
+  The candidate set is the natural-tab-order tags plus anything carrying
+  a `tabindex`; the engine decides which of them survive. Nothing here
+  simulates a Tab press: a synthetic keydown does not move focus in any
+  engine, so a `pressed Tab` witness would be measuring its own
+  dispatcher."
+  [m]
+  (->> (.querySelectorAll (:container m)
+                          "a[href],button,input,select,textarea,[tabindex]")
+       (array-seq)
+       (filterv focusable?)
+       (mapv label-of)))
+
+(defn- type-into!
+  "One real keystroke's worth of input on a controlled field: a write
+  through the prototype's own value setter and a real `input` event, the
+  same door `flow-dom-cljs-test` and `i18n-dom-cljs-test` use."
+  [m sel s]
+  (let [n (node m sel)
+        d (js/Object.getOwnPropertyDescriptor js/HTMLInputElement.prototype "value")]
+    (.call (.-set d) n s)
+    (.dispatchEvent n (js/InputEvent. "input" #js {:bubbles true}))
+    (hm/settle! m)))
+
+;; ---------------------------------------------------------------------------
+;; The label associations, as the engine computes them
+;; ---------------------------------------------------------------------------
+
+(deftest the-engine-agrees-with-the-structural-names
+  (if-not (browser?)
+    (skip! ":node-test has no document")
+    (async done
+      (let [m (at-article! "intents")]
+        (testing "`.labels` is the engine's OWN association — it is
+                  computed from `for` and from ancestry, and it is the
+                  only available check on the structural helper being
+                  confidently wrong"
+          (doseq [[sel expected] [["#slice-title" "Title"]
+                                  ["#slice-body" "Body"]
+                                  ["#slice-published" "Published"]
+                                  ["#slice-locale" "Language"]]]
+            (let [el     (node m sel)
+                  labels (array-seq (.-labels el))]
+              (is (= 1 (count labels))
+                  (str sel " is associated with exactly one <label> by the "
+                       "engine; it reported " (count labels)))
+              (is (= expected (some-> (first labels) .-textContent))
+                  (str sel "'s label, as the engine found it")))))
+
+        (testing "and the checkbox is reached BOTH ways at once — it sits
+                  inside its label and carries the `for` as well — which
+                  the engine must still count as one association rather
+                  than two"
+          (let [el (node m "#slice-published")]
+            (is (= 1 (.-length (.-labels el))))
+            (is (identical? (node m ".published") (aget (.-labels el) 0)))))
+
+        (finish m done)))))
+
+(deftest clicking-a-label-moves-focus-to-the-control-it-names
+  (if-not (browser?)
+    (skip! ":node-test has no focus model")
+    (async done
+      (let [m (at-article! "intents")]
+        (testing "the behaviour a `for`/`id` pair BUYS, and the one that
+                  goes quiet when the pair is broken: a label pointing at
+                  the wrong id still renders, still reads correctly, and
+                  simply stops doing this"
+          (doseq [[label-sel control-sel] [["label[for='slice-title']" "#slice-title"]
+                                           ["label[for='slice-body']" "#slice-body"]
+                                           ["label[for='slice-locale']" "#slice-locale"]]]
+            (some-> (.-activeElement js/document) (.blur))
+            (.click (node m label-sel))
+            (is (identical? (node m control-sel) (.-activeElement js/document))
+                (str "clicking " label-sel " must focus " control-sel))))
+
+        (finish m done)))))
+
+;; ---------------------------------------------------------------------------
+;; Focus order, and the two controls whose place in it is state
+;; ---------------------------------------------------------------------------
+
+(def ^:private pristine-order
+  "The article screen's focus order before anything is typed. `discard`
+  is absent because it is disabled until the form is dirty — the whole
+  point of the pair of rows below."
+  ["slice-locale" "theme-choice" "theme-choice" "back"
+   "slice-title" "slice-body" "slice-published" "save"])
+
+(deftest the-focus-order-is-the-document-order-and-nothing-reorders-it
+  (if-not (browser?)
+    (skip! ":node-test has no focus model")
+    (async done
+      (let [m (at-article! "intents")]
+        (is (= pristine-order (focus-order m))
+            "the COMPLETE sequence rather than a membership test — a
+             control that joined it, left it or moved within it is
+             invisible to `is this focusable?` and loud here")
+
+        (testing "and no element buys itself a place out of turn: a
+                  positive tabindex hoists a control above everything
+                  that has none, which is a reordering nothing on the
+                  page shows"
+          (is (= [] (->> (.querySelectorAll (:container m) "[tabindex]")
+                         (array-seq)
+                         (filterv #(pos? (.-tabIndex %)))
+                         (mapv label-of)))))
+
+        (finish m done)))))
+
+(deftest a-disabled-control-leaves-the-focus-order-and-comes-back
+  (if-not (browser?)
+    (skip! ":node-test has no focus model")
+    (async done
+      (let [m (at-article! "intents")]
+        (testing "pristine: discard is disabled, and the engine will not
+                  focus it — measured by asking, not by reading the
+                  attribute back"
+          (is (false? (focusable? (node m ".discard"))))
+          (is (not (contains? (set (focus-order m)) "discard"))))
+
+        (type-into! m "#slice-title" "Intents are data, still")
+
+        (testing "one keystroke later the form is dirty, discard is
+                  enabled, and it takes its place at the END of the order
+                  — the same order otherwise, so what moved is exactly
+                  the one control whose state changed"
+          (is (true? (focusable? (node m ".discard"))))
+          (is (= (conj pristine-order "discard") (focus-order m))))
+
+        (finish m done)))))
+
+(deftest the-save-button-leaves-the-focus-order-while-it-is-saving
+  (if-not (browser?)
+    (skip! ":node-test has no focus model")
+    (async done
+      (let [m (at-article! "intents")]
+        (type-into! m "#slice-title" "A new title")
+        (.click (node m ".save"))
+        (hm/settle! m)
+
+        (testing "the save is in flight, the button is disabled, and it is
+                  out of the order — the other direction of the same
+                  mechanism, on a different control and a different piece
+                  of state, so neither row is a special case of the
+                  other's markup"
+          (is (true? (.-disabled (node m ".save"))))
+          (is (false? (focusable? (node m ".save"))))
+          (is (not (contains? (set (focus-order m)) "save"))))
+
+        ;; The reply is a macrotask the mount must not be torn down under:
+        ;; wait for the region to leave `:saving`, then assert the button
+        ;; came BACK, which is what makes the row above about a transition
+        ;; rather than about a button that is simply always disabled.
+        (-> (drained m
+                     #(not= :saving (:status (read-sub m [::subs/save-state "intents"])))
+                     "the stand-in server's reply for intents")
+            (.then (fn [_]
+                     (is (false? (.-disabled (node m ".save"))))
+                     (is (contains? (set (focus-order m)) "save"))))
+            (finish-after m done))))))
+
+;; ---------------------------------------------------------------------------
+;; Focus across a re-render
+;; ---------------------------------------------------------------------------
+
+(deftest a-re-render-does-not-take-focus-away-from-the-user
+  (if-not (browser?)
+    (skip! ":node-test has no focus model")
+    (async done
+      (let [m (at-article! "intents")]
+        (.focus (node m "#slice-title"))
+        (let [field (node m "#slice-title")]
+          (is (identical? field (.-activeElement js/document)))
+
+          ;; The locale switch dispatched rather than clicked, deliberately:
+          ;; clicking the `<select>` would move focus itself, and what is
+          ;; under test is what the RE-RENDER does to focus, not what a
+          ;; click does.
+          (hm/dispatch-and-settle! m [::events/set-locale "fr"])
+
+          (is (identical? field (.-activeElement js/document))
+              "the SAME element still holds focus after every label on the
+               page changed language. A substrate that rebuilt the subtree
+               would leave `<body>` focused here and a user mid-sentence
+               would be typing into nothing — this is the failure an i18n
+               subsystem is bought to avoid, stated where a browser can
+               see it")
+          (is (= "Titre" (.-textContent (node m "label[for='slice-title']")))
+              "and the re-render really did happen, so the row above is
+               not green for want of anything occurring"))
+
+        (finish m done)))))
+
+;; ---------------------------------------------------------------------------
+;; An alert must be announced without being intrusive
+;; ---------------------------------------------------------------------------
+
+(deftest an-alert-appearing-does-not-take-focus-from-the-field-it-is-about
+  (if-not (browser?)
+    (skip! ":node-test has no focus model")
+    (async done
+      (let [m (at-article! "intents")]
+        ;; A blank title is refused LOCALLY, so the region appears on the
+        ;; line after the dispatch with nothing in flight to wait for.
+        (type-into! m "#slice-title" "   ")
+        (let [field (node m "#slice-title")]
+          (.focus field)
+          (is (identical? field (.-activeElement js/document)))
+
+          ;; Dispatched rather than clicked: clicking `.save` would move
+          ;; focus to the button, and what is under test is what the
+          ;; ALERT's arrival does to focus.
+          (hm/dispatch-and-settle! m [::events/save {:slug "intents"}])
+
+          (is (= "alert" (.getAttribute (node m ".save-problem") "role"))
+              "the region really did arrive, so the row below is not green
+               for want of anything happening")
+          (is (identical? field (.-activeElement js/document))
+              "and focus did not move. `role=\"alert\"` is announced BECAUSE
+               it appeared — a live region that also stole focus would
+               interrupt a user mid-sentence and drop them somewhere they
+               did not ask to be, which is the failure that makes people
+               turn assistive announcements off")
+          (is (= "   " (.-value field))
+              "the draft is still in the field it was typed into"))
+
+        (finish m done)))))

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_a11y_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_a11y_cljs_test.cljs
@@ -1,0 +1,506 @@
+(ns re-frame.hicasso.test-kit-a11y-cljs-test
+  "THE ACCESSIBILITY TRIO'S OWN WITNESSES — `ht/role`,
+  `ht/accessible-name`, `ht/unnamed-controls` (rf2-hic-043).
+
+  An accessibility assertion that passes when the accessibility is
+  absent is worth nothing, and the same is true one level down: a helper
+  whose witness only ever asserts the good case is a helper nobody has
+  measured. So every row here is written to be able to go the other way,
+  and the file is arranged around the three shapes of control
+  `test-kit-cljs-test` established for the kit's other doors.
+
+  ## 1. Discrimination, on both sides of every conditional arm
+
+  `ht/role`'s table has four tags whose answer is CONDITIONAL — an `<a>`
+  is a link only with an `:href`, an `<input>` answers by `:type`, a
+  `<select>` is a listbox only when it takes more than one, an `<img>` is
+  presentational only when its `:alt` is empty — and each is driven on
+  BOTH sides of its condition. A row that drove only the positive side
+  would be satisfied by `(constantly :link)`.
+
+  ## 2. Precedence is asserted where the sources DISAGREE
+
+  `ht/accessible-name` is an ordered fallback of five steps, and an
+  ordered fallback is exactly the shape whose test can be green while the
+  order is wrong: markup with one name source present passes under any
+  ordering that reaches it at all. So each precedence row supplies TWO
+  sources carrying DIFFERENT strings and asserts which one won. Removing
+  a step then changes an answer rather than merely removing one.
+
+  ## 3. The legal twin, and the other direction
+
+  Every sabotage row has a sibling asserting that the *legal* variant it
+  was derived from still passes — a button named by `aria-label` alone,
+  an input named by a wrapping `<label>` alone, a nameless element that
+  is not interactive. A guard wrong by being too eager reports defects
+  that are not there, and nothing but a legal twin catches it.
+
+  ## The lane
+
+  Nothing here mounts and nothing here needs a document: a role and a
+  name are facts about markup, so the node lane is where they are
+  decided. Whether a browser AGREES is
+  `re-frame.hicasso.examples.slice.a11y-focus-dom-cljs-test`'s question,
+  and it is a different one."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.test :as ht]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil}))
+
+;; ---------------------------------------------------------------------------
+;; The two helpers this file writes
+;; ---------------------------------------------------------------------------
+
+(defn- markup
+  "The semantic tree of a literal piece of hiccup — no reads, no props,
+  no view. The trio's whole domain is a tree, and this is the shortest
+  honest way to get one."
+  [form]
+  (ht/tree [(fn [_] form) {}]))
+
+(defn- outcome
+  "`{:returned v}` or `{:refused <ex-data>}` — the same discriminator the
+  kit's other witnesses use, and for the same reason: a bare `thrown?`
+  is green for a throw from any layer carrying any id."
+  [thunk]
+  (try {:returned (thunk)}
+       (catch :default e {:refused (ex-data e)})))
+
+(defn- refusal
+  [outcome']
+  (some-> (:refused outcome') (select-keys [:rf.error/id :where :recovery])))
+
+(h/defview a-child
+  "A minted boundary, so the boundary row below records a CALL rather
+  than the refusal a plain function in head position earns."
+  [_]
+  [:p "child"])
+
+(defn- tagged [tree tag] (ht/find tree #(= tag (:tag %))))
+
+(defn- classed [tree class] (ht/find tree #(= class (:class (ht/attrs %)))))
+
+;; ---------------------------------------------------------------------------
+;; role — every arm of the table, and both sides of every condition
+;; ---------------------------------------------------------------------------
+
+(deftest an-explicit-role-is-read-as-a-keyword-from-either-spelling
+  (let [t (markup [:div
+                   [:p.s {:role "status"} "saved"]
+                   [:p.k {:role :alert} "no"]])]
+    (is (= :status (ht/role (classed t "s"))) "the string spelling")
+    (is (= :alert (ht/role (classed t "k"))) "and the keyword spelling")))
+
+(deftest an-explicit-role-is-a-token-list-and-the-first-token-wins
+  (testing "a fallback chain is read the way a user agent reads it — the
+            first token, not the last and not the whole string"
+    (is (= :doc-subtitle
+           (ht/role (tagged (markup [:p {:role "doc-subtitle heading"}]) :p))))
+    (is (= :heading
+           (ht/role (tagged (markup [:p {:role "heading doc-subtitle"}]) :p)))
+        "and the SAME two tokens the other way round answer the other
+         one, so this is about order rather than about which of the two
+         names the reader happens to know")))
+
+(deftest an-explicit-role-beats-the-tag
+  (let [t (markup [:div [:button {:role "link"} "go"] [:button "press"]])]
+    (is (= :link (ht/role (ht/find t #(= "link" (:role (ht/attrs %))))))
+        "the author's answer")
+    (is (= :button (ht/role (ht/find t #(and (= :button (:tag %))
+                                             (nil? (:role (ht/attrs %)))))))
+        "and the tag's, unaltered beside it")))
+
+(deftest an-anchor-is-a-link-only-when-it-has-somewhere-to-go
+  (let [t (markup [:div
+                   [:a.linked {:href "/x"} "x"]
+                   [:a.bare "y"]])]
+    (is (= :link (ht/role (classed t "linked"))))
+    (is (nil? (ht/role (classed t "bare")))
+        "an `<a>` with no href is not a link and never was — this is the
+         false positive the clj-kondo export was reopened to remove
+         (rf2-hic-022, audit #7791), and the kit must not re-introduce it")))
+
+(deftest an-input-answers-by-type-including-the-types-that-have-no-role
+  (let [t (markup [:form
+                   [:input.a {:type "text"}]
+                   [:input.b]
+                   [:input.c {:type "search"}]
+                   [:input.d {:type "checkbox"}]
+                   [:input.e {:type "radio"}]
+                   [:input.f {:type "submit"}]
+                   [:input.g {:type "range"}]
+                   [:input.h {:type "number"}]
+                   [:input.i {:type "password"}]
+                   [:input.j {:type "hidden"}]
+                   [:input.k {:type :email}]])]
+    (is (= :textbox (ht/role (classed t "a"))))
+    (is (= :textbox (ht/role (classed t "b")))
+        "no :type at all is `text`, which is HTML's own default and not a
+         miss")
+    (is (= :searchbox (ht/role (classed t "c"))))
+    (is (= :checkbox (ht/role (classed t "d"))))
+    (is (= :radio (ht/role (classed t "e"))))
+    (is (= :button (ht/role (classed t "f"))))
+    (is (= :slider (ht/role (classed t "g"))))
+    (is (= :spinbutton (ht/role (classed t "h"))))
+    (is (= :textbox (ht/role (classed t "k"))) "a keyword :type reads the same")
+    (testing "and the two types ARIA gives no role — the other side of the
+              same table, without which the table could answer :textbox
+              for everything it did not recognise"
+      (is (nil? (ht/role (classed t "i"))))
+      (is (nil? (ht/role (classed t "j")))))))
+
+(deftest a-select-is-a-combobox-until-it-takes-more-than-one
+  (let [t (markup [:div
+                   [:select.one]
+                   [:select.many {:multiple true}]
+                   [:select.tall {:size 4}]
+                   [:select.short {:size 1}]])]
+    (is (= :combobox (ht/role (classed t "one"))))
+    (is (= :listbox (ht/role (classed t "many"))))
+    (is (= :listbox (ht/role (classed t "tall"))))
+    (is (= :combobox (ht/role (classed t "short")))
+        "`:size 1` is one visible row and still a combobox — the boundary
+         of the condition rather than a value far from it")))
+
+(deftest an-image-with-an-empty-alt-is-presentational
+  (let [t (markup [:div
+                   [:img.described {:src "a.png" :alt "a chart"}]
+                   [:img.decorative {:src "b.png" :alt ""}]
+                   [:img.silent {:src "c.png"}]])]
+    (is (= :img (ht/role (classed t "described"))))
+    (is (= :presentation (ht/role (classed t "decorative")))
+        "an empty alt is the author saying `ignore this` and is the ONE
+         attribute value that changes an element's role")
+    (is (= :img (ht/role (classed t "silent")))
+        "a MISSING alt is not an empty one — the image is still an image,
+         it is merely unnamed, which is what unnamed-controls is for")))
+
+(deftest the-unconditional-rows-of-the-table
+  (let [t (markup [:main
+                   [:nav [:ul [:li "a"]]]
+                   [:h3 "h"]
+                   [:textarea]
+                   [:select [:option "o"]]
+                   [:progress]
+                   [:hr]
+                   [:dialog]])]
+    (is (= :main (ht/role t)))
+    (is (= :navigation (ht/role (tagged t :nav))))
+    (is (= :list (ht/role (tagged t :ul))))
+    (is (= :listitem (ht/role (tagged t :li))))
+    (is (= :heading (ht/role (tagged t :h3))))
+    (is (= :textbox (ht/role (tagged t :textarea))))
+    (is (= :option (ht/role (tagged t :option))))
+    (is (= :progressbar (ht/role (tagged t :progress))))
+    (is (= :separator (ht/role (tagged t :hr))))
+    (is (= :dialog (ht/role (tagged t :dialog))))))
+
+(deftest the-tags-whose-role-depends-on-context-answer-nothing
+  (testing "`<header>`, `<section>`, `<form>` and `<td>` have roles that
+            depend on an ancestor, on a heading or on whether the element
+            is named. Answering one from the node alone would be a guess,
+            and a guess is the failure this trio exists to avoid — so the
+            omission is asserted rather than left to be noticed"
+    (let [t (markup [:div [:header] [:section] [:form] [:table [:tr [:td]]]])]
+      (is (nil? (ht/role (tagged t :header))))
+      (is (nil? (ht/role (tagged t :section))))
+      (is (nil? (ht/role (tagged t :form))))
+      (is (nil? (ht/role (tagged t :td)))))))
+
+(deftest role-is-total-over-the-node-set
+  (let [t (markup [:<> [:div] "text"])]
+    (is (nil? (ht/role nil)) "nil in, nil out — so it threads through a miss")
+    (is (nil? (ht/role t)) "a fragment is not an element")
+    (is (nil? (ht/role (tagged t :div))) "and a div has no role of its own"))
+  (testing "text content is REFUSED rather than answered nil, because a
+            string reaching a projection is a caller reading the wrong
+            thing and a nil would let it read on"
+    (is (= {:rf.error/id :rf.error/ui-tree-malformed
+            :where       're-frame.hicasso.test
+            :recovery    :no-recovery}
+           (refusal (outcome #(ht/role "milk")))))))
+
+(deftest a-boundary-node-has-no-role-and-that-is-not-an-error
+  (let [t (markup [:div [a-child {}]])]
+    (is (nil? (ht/role (ht/find t #(some? (:view-id %)))))
+        "L2 records a child boundary as the CALL it is; what it renders —
+         and therefore what role it presents — is the child's own tree to
+         answer")))
+
+;; ---------------------------------------------------------------------------
+;; accessible-name — the five steps, each shown to WIN over the next
+;; ---------------------------------------------------------------------------
+
+(deftest aria-labelledby-resolves-through-the-tree-in-the-order-written
+  (let [t (markup [:div
+                   [:span {:id "verb"} "Delete"]
+                   [:span {:id "noun"} "draft"]
+                   [:button {:aria-labelledby "verb noun"}]])]
+    (is (= "Delete draft" (ht/accessible-name t (tagged t :button)))))
+  (testing "the ORDER is the attribute's and not the document's"
+    (let [t (markup [:div
+                     [:span {:id "verb"} "Delete"]
+                     [:span {:id "noun"} "draft"]
+                     [:button {:aria-labelledby "noun verb"}]])]
+      (is (= "draft Delete" (ht/accessible-name t (tagged t :button))))))
+  (testing "an id that resolves to nothing contributes nothing, and does
+            not take the rest of the name down with it"
+    (let [t (markup [:div
+                     [:span {:id "verb"} "Delete"]
+                     [:button {:aria-labelledby "verb absent"}]])]
+      (is (= "Delete" (ht/accessible-name t (tagged t :button)))))))
+
+(deftest aria-labelledby-beats-aria-label-beats-the-content
+  (let [t (markup [:div
+                   [:span {:id "ref"} "from the reference"]
+                   [:button {:aria-labelledby "ref" :aria-label "from the label"}
+                    "from the content"]])]
+    (is (= "from the reference" (ht/accessible-name t (tagged t :button)))
+        "three sources, three DIFFERENT strings, so the winner identifies
+         the step — a row whose sources agreed would be green under any
+         ordering"))
+  (let [t (markup [:div [:button {:aria-label "from the label"} "from the content"]])]
+    (is (= "from the label" (ht/accessible-name t (tagged t :button)))))
+  (let [t (markup [:div [:button "from the content"]])]
+    (is (= "from the content" (ht/accessible-name t (tagged t :button))))))
+
+(deftest a-blank-aria-label-does-not-count-as-a-name
+  (let [t (markup [:div [:button {:aria-label "   "} "Save"]])]
+    (is (= "Save" (ht/accessible-name t (tagged t :button)))
+        "whitespace is not a name, so the fallback continues past it —
+         and the content is what a screen reader would announce")))
+
+(deftest a-name-is-flattened
+  (let [t (markup [:div [:button "  Save \n   draft "]])]
+    (is (= "Save draft" (ht/accessible-name t (tagged t :button)))
+        "the platform's own flat-string step: runs collapse, the ends go")))
+
+(deftest a-control-is-named-by-its-label-either-way-round
+  (testing "`<label for=…>` pointing at an id"
+    (let [t (markup [:form
+                     [:label {:for "title"} "Title"]
+                     [:input {:id "title" :type "text"}]])]
+      (is (= "Title" (ht/accessible-name t (tagged t :input))))))
+  (testing "and a `<label>` that simply contains the control — the wrapping
+            form, which no attribute records"
+    (let [t (markup [:form
+                     [:label [:input {:type "checkbox"}] "Published"]])]
+      (is (= "Published" (ht/accessible-name t (tagged t :input))))))
+  (testing "both at once concatenate in DOCUMENT order"
+    (let [t (markup [:form
+                     [:label {:for "p"} "Publish"]
+                     [:label [:input {:id "p" :type "checkbox"}] "immediately"]])]
+      (is (= "Publish immediately" (ht/accessible-name t (tagged t :input)))))))
+
+(deftest a-label-names-the-control-it-points-at-and-no-other
+  (testing "the discrimination the `for`/`id` pair exists for: two labels,
+            two controls, and a helper that merely found `the nearest
+            label` would cross them"
+    (let [t (markup [:form
+                     [:label {:for "body"} "Body"]
+                     [:label {:for "title"} "Title"]
+                     [:input.title {:id "title" :type "text"}]
+                     [:textarea.body {:id "body"}]])]
+      (is (= "Title" (ht/accessible-name t (classed t "title"))))
+      (is (= "Body" (ht/accessible-name t (classed t "body"))))))
+  (testing "and a `for` that points nowhere leaves its control unnamed
+            rather than borrowing the label beside it"
+    (let [t (markup [:form
+                     [:label {:for "typo"} "Title"]
+                     [:input {:id "title" :type "text"}]])]
+      (is (nil? (ht/accessible-name t (tagged t :input)))))))
+
+(deftest a-label-beats-the-controls-own-text-and-aria-label-beats-the-label
+  (let [t (markup [:form
+                   [:label {:for "x"} "from the label"]
+                   [:input {:id "x" :type "text" :aria-label "from aria"}]])]
+    (is (= "from aria" (ht/accessible-name t (tagged t :input)))))
+  (let [t (markup [:form
+                   [:label {:for "x"} "from the label"]
+                   [:input {:id "x" :type "text" :title "from the title"}]])]
+    (is (= "from the label" (ht/accessible-name t (tagged t :input)))
+        "and `:title` is the LAST resort, below the label rather than
+         above it")))
+
+(deftest the-host-languages-own-labelling-per-element
+  (testing "a submit button is named by its :value, which is markup no
+            label and no content supplies"
+    (let [t (markup [:form [:input {:type "submit" :value "Send"}]])]
+      (is (= "Send" (ht/accessible-name t (tagged t :input))))))
+  (testing "an image by its alt"
+    (let [t (markup [:div [:img {:src "a.png" :alt "A bar chart"}]])]
+      (is (= "A bar chart" (ht/accessible-name t (tagged t :img))))))
+  (testing "and a fieldset by its FIRST legend child, so a nested
+            fieldset's legend cannot be borrowed by the one above it"
+    (let [t (markup [:fieldset
+                     [:legend "Outer"]
+                     [:fieldset [:legend "Inner"]]])]
+      (is (= "Outer" (ht/accessible-name t t)))
+      (is (= "Inner" (ht/accessible-name
+                       t
+                       (ht/find t #(and (= :fieldset (:tag %))
+                                        (not (identical? % t))))))
+          "read off the outer tree, so the two fieldsets are one
+           document and the inner one still answers its own legend"))))
+
+(deftest only-the-roles-that-take-a-name-from-content-take-one
+  (let [t (markup [:div
+                   [:p.alert {:role "alert"} "Could not save"]
+                   [:p.plain "ordinary prose"]
+                   [:li.item "an item"]
+                   [:a.link {:href "/x"} "a link"]
+                   [:h2.head "a heading"]])]
+    (is (= "an item" (ht/accessible-name t (classed t "item"))))
+    (is (= "a link" (ht/accessible-name t (classed t "link"))))
+    (is (= "a heading" (ht/accessible-name t (classed t "head"))))
+    (testing "an alert is announced when it appears and is not NAMED by
+              what it says — answering `Could not save` here would be the
+              kit inventing a name the platform does not give"
+      (is (nil? (ht/accessible-name t (classed t "alert")))))
+    (testing "and ordinary prose has no role, so no name"
+      (is (nil? (ht/accessible-name t (classed t "plain")))))))
+
+(deftest title-is-the-last-resort-and-is-still-a-name
+  (let [t (markup [:div [:input {:type "text" :title "Search"}]])]
+    (is (= "Search" (ht/accessible-name t (tagged t :input))))))
+
+(deftest accessible-name-refuses-a-node-from-somewhere-else
+  (let [labelled (markup [:form
+                          [:label {:for "x"} "Title"]
+                          [:input {:id "x" :type "text"}]])
+        elsewhere (markup [:div [:p "unrelated"]])]
+    (testing "the legal twin first: read against its OWN tree the control
+              is named, so the refusal below is about the pairing and not
+              about markup that was broken anyway"
+      (is (= "Title" (ht/accessible-name labelled (tagged labelled :input)))))
+    (testing "and against a tree it is not in, a REFUSAL rather than nil —
+              nil would report a labelled control as unlabelled, which is
+              the wrong answer in the one direction that matters"
+      (is (= {:rf.error/id :rf.error/ui-tree-malformed
+              :where       're-frame.hicasso.test
+              :recovery    :pass-the-tree-the-node-came-from}
+             (refusal (outcome #(ht/accessible-name elsewhere
+                                                    (tagged labelled :input)))))))
+    (testing "the discriminator reports :returned for the legal pairing,
+              so the refusal row is not a helper that only knows one verb"
+      (is (= {:returned "Title"}
+             (outcome #(ht/accessible-name labelled (tagged labelled :input))))))))
+
+(deftest accessible-name-nil-puns-and-refuses-text
+  (is (nil? (ht/accessible-name (markup [:div]) nil)))
+  (is (= {:rf.error/id :rf.error/ui-tree-malformed
+          :where       're-frame.hicasso.test
+          :recovery    :no-recovery}
+         (refusal (outcome #(ht/accessible-name (markup [:div]) "milk"))))))
+
+;; ---------------------------------------------------------------------------
+;; unnamed-controls — the auditor, sabotaged in both directions
+;; ---------------------------------------------------------------------------
+
+(def ^:private a-named-form
+  "One small form in which every operable control is named, and named a
+  DIFFERENT legal way each time — by content, by `aria-label`, by
+  `<label for=…>`, by a wrapping `<label>`, by `aria-labelledby`, and by
+  `:value`. The sabotage rows below each remove exactly one of them."
+  [:form
+   [:button {:type "button"} "Named by content"]
+   [:button.aria {:type "button" :aria-label "Named by aria-label"}]
+   [:label {:for "by-for"} "Named by for"]
+   [:input {:id "by-for" :type "text"}]
+   [:label [:input.wrapped {:type "checkbox"}] "Named by wrapping"]
+   [:span {:id "ref"} "Named by reference"]
+   [:select.referenced {:aria-labelledby "ref"}]
+   [:input.submit {:type "submit" :value "Named by value"}]
+   [:a {:href "/x"} "Named link"]])
+
+(deftest a-fully-named-form-reports-nothing
+  (is (= [] (ht/unnamed-controls (markup a-named-form)))
+      "the legal side. Six naming mechanisms, one assertion — and an
+       auditor that reported any of them would be a nag rather than a
+       gate"))
+
+(deftest removing-any-one-name-reports-that-one-control-and-only-it
+  (testing "the content off a button"
+    (let [t (markup (assoc a-named-form 1 [:button {:type "button"}]))
+          found (ht/unnamed-controls t)]
+      (is (= 1 (count found)))
+      (is (= :button (:tag (first found))))))
+  (testing "the aria-label off the second button"
+    (let [t (markup (assoc a-named-form 2 [:button.aria {:type "button"}]))
+          found (ht/unnamed-controls t)]
+      (is (= 1 (count found)))
+      (is (= "aria" (:class (ht/attrs (first found)))))))
+  (testing "the `for` off the label — the control keeps its id and the
+            label keeps its text, so nothing about the markup LOOKS
+            different except the one attribute that binds them"
+    (let [t (markup (assoc a-named-form 3 [:label "Named by for"]))
+          found (ht/unnamed-controls t)]
+      (is (= 1 (count found)))
+      (is (= "by-for" (:id (ht/attrs (first found)))))))
+  (testing "the TEXT out of the wrapping label, keeping the containment —
+            so what this row measures is the label's contribution and not
+            merely whether a label is nearby"
+    (let [t (markup (assoc a-named-form 5
+                           [:label [:input.wrapped {:type "checkbox"}]]))
+          found (ht/unnamed-controls t)]
+      (is (= 1 (count found)))
+      (is (= "wrapped" (:class (ht/attrs (first found)))))))
+  (testing "the referent of aria-labelledby"
+    (let [t (markup (assoc a-named-form 6 [:span {:id "other"} "Named by reference"]))
+          found (ht/unnamed-controls t)]
+      (is (= 1 (count found)))
+      (is (= "referenced" (:class (ht/attrs (first found)))))))
+  (testing "the :value off the submit button"
+    (let [t (markup (assoc a-named-form 8 [:input.submit {:type "submit"}]))
+          found (ht/unnamed-controls t)]
+      (is (= 1 (count found)))
+      (is (= "submit" (:class (ht/attrs (first found)))))))
+  (testing "the text out of the link"
+    (let [t (markup (assoc a-named-form 9 [:a {:href "/x"}]))
+          found (ht/unnamed-controls t)]
+      (is (= 1 (count found)))
+      (is (= :a (:tag (first found)))))))
+
+(deftest moving-a-control-out-of-its-wrapping-label-reports-it
+  (testing "the sabotage the row above deliberately did not do: the input
+            leaves the label entirely. Two rows, one attribute apart, and
+            they must disagree — which is what says `contains` is really
+            being computed rather than `there is a label somewhere`"
+    (let [t (markup [:form
+                     [:label "Published"]
+                     [:input.wrapped {:type "checkbox"}]])]
+      (is (= ["wrapped"] (mapv #(:class (ht/attrs %)) (ht/unnamed-controls t)))))))
+
+(deftest what-the-auditor-must-not-report
+  (testing "a nameless element that is not operable is not a finding —
+            an auditor that reported every unnamed node would report the
+            whole page, and a gate nobody can satisfy is turned off"
+    (let [t (markup [:div
+                     [:p "prose"]
+                     [:p {:role "alert"} "Could not save"]
+                     [:span]
+                     [:ul [:li]]
+                     [:img {:src "a.png" :alt ""}]
+                     [:a "a bare anchor, which is not a link"]])]
+      (is (= [] (ht/unnamed-controls t)))))
+  (testing "and a control that is DISABLED is still a control — it is
+            announced, it can be enabled, and it needs its name"
+    (let [t (markup [:form [:button {:type "button" :disabled true}]])]
+      (is (= 1 (count (ht/unnamed-controls t)))))))
+
+(deftest the-auditor-reports-in-document-order-and-reports-every-offender
+  (let [t (markup [:form
+                   [:button.one {:type "button"}]
+                   [:button.two {:type "button"} "named"]
+                   [:input.three {:type "text"}]])]
+    (is (= ["one" "three"] (mapv #(:class (ht/attrs %)) (ht/unnamed-controls t)))
+        "both offenders and the named one skipped — a helper that
+         short-circuited at the first finding would answer `[one]` and
+         look right")))

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
@@ -27,7 +27,8 @@
             [[canonical-dom]], [[capture-intents]], [[fire!]].
       L2  one hook-free Hicasso body, run for its semantic tree
           → [[tree]] + [[find]] / [[find-all]] / [[attrs]] / [[text]] /
-            [[intents]].
+            [[intents]], and the accessibility trio [[role]] /
+            [[accessible-name]] / [[unnamed-controls]].
       L3  React lifecycle, context, hooks, refs, errors, foreign hosts
           → the mounted facade (rf2-hic-027). NOT here.
       L4  IME, caret, focus, hydration, layout, performance
@@ -1445,3 +1446,320 @@
                                     (map? v)    (filterv vector? (vals v))
                                     :else       nil))))
         (tree-seq map? :children tree)))
+
+;; ---------------------------------------------------------------------------
+;; L2 — accessibility: the role, the name, and the controls that have neither
+;; (rf2-hic-043)
+;; ---------------------------------------------------------------------------
+;;
+;; Data-first markup is what makes this tier possible at all. A role is an
+;; attribute or a tag; a label is an element with a `:for`; a name is text.
+;; None of it is behind a renderer, so none of it needs one — which is why
+;; these three sit at L2 beside `attrs` and `text` rather than at L3 with a
+;; document.
+;;
+;; WHAT THEY ARE NOT. They are not an implementation of ARIA. The real
+;; accessible-name computation walks a live tree with computed style,
+;; `aria-hidden` subtrees, host-language quirks per element and a recursion
+;; whose termination rules fill a specification; a browser is the only honest
+;; implementation of it and L4 is where a browser is. What is here is the
+;; DECIDABLE part — the part that is a fact about the markup an author wrote
+;; — and every narrowing is named below rather than left to be discovered.
+;; The one thing these must never do is answer a plausible name for markup a
+;; screen reader would announce differently, so where the answer depends on
+;; something the tree does not carry, the answer is `nil` and the limit is
+;; stated.
+
+(def ^:private input-roles
+  "`<input>` by `:type`, per ARIA in HTML §Document conformance
+  requirements. The absent types (`password`, `file`, `color`, the
+  date/time family, `hidden`) have NO corresponding role — that is the
+  specification's answer and not an omission, so they read `nil` here
+  through the same miss as an unknown type."
+  {"text"     :textbox
+   "email"    :textbox
+   "tel"      :textbox
+   "url"      :textbox
+   "search"   :searchbox
+   "checkbox" :checkbox
+   "radio"    :radio
+   "button"   :button
+   "submit"   :button
+   "reset"    :button
+   "image"    :button
+   "range"    :slider
+   "number"   :spinbutton})
+
+(def ^:private implicit-roles
+  "The role a tag carries with no `:role` attribute, for the tags whose
+  answer is decidable FROM THE NODE ALONE.
+
+  Four tags answer conditionally and are handled in [[role]] rather than
+  here: `:a` (a link only with an `:href`), `:input` (by `:type`),
+  `:select` (a listbox when it takes more than one) and `:img` (a
+  presentational image when its `:alt` is empty).
+
+  DELIBERATELY ABSENT, and each for the same reason: `:header`,
+  `:footer`, `:section`, `:aside`, `:form`, `:td` and `:th` have roles
+  that depend on an ancestor, on a heading, or on whether the element has
+  an accessible name — context this projection would have to guess at.
+  A guess here is the failure mode these helpers exist to avoid, so they
+  answer `nil` and a test that cares asserts the `:role` the author
+  wrote."
+  {:button   :button
+   :textarea :textbox
+   :option   :option
+   :ul       :list
+   :ol       :list
+   :li       :listitem
+   :h1       :heading
+   :h2       :heading
+   :h3       :heading
+   :h4       :heading
+   :h5       :heading
+   :h6       :heading
+   :main     :main
+   :nav      :navigation
+   :dialog   :dialog
+   :progress :progressbar
+   :hr       :separator})
+
+(def ^:private named-by-content
+  "The roles whose accessible name comes from the element's own text when
+  nothing labels it (ARIA §Name From: contents). Every other role — an
+  `:alert`, a `:status`, a `:textbox` — takes no name from its contents,
+  and answering one would be this projection inventing a name the
+  platform does not give."
+  #{:button :link :heading :listitem :option :tab :menuitem
+    :checkbox :radio :switch})
+
+(def ^:private interactive-roles
+  "The roles a user OPERATES, and therefore the roles for which a missing
+  accessible name is a defect rather than a style. The set
+  [[unnamed-controls]] ranges over."
+  #{:button :link :textbox :searchbox :checkbox :radio
+    :combobox :listbox :slider :spinbutton})
+
+(defn- flat
+  "One accessible-name string, or `nil` when there is nothing to say.
+  Internal whitespace runs collapse and the ends are trimmed, which is
+  what the platform's own flat-string step does — so `\"  Save \\n draft \"`
+  and `\"Save draft\"` are the same name."
+  [s]
+  (when (string? s)
+    (let [t (str/trim (str/replace s #"\s+" " "))]
+      (when (seq t) t))))
+
+(defn- attr
+  "One attribute off an ELEMENT node, or nil for any other node kind."
+  [node k]
+  (get (:attrs node) k))
+
+(defn- token
+  "An attribute whose value is a string or a keyword, as a lower-case
+  string — the two spellings an author uses for `:type`, `:role` and
+  friends, read the one way."
+  [v]
+  (cond
+    (keyword? v) (str/lower-case (name v))
+    (string? v)  (str/lower-case v)
+    :else        nil))
+
+(defn- explicit-role
+  "The `:role` the author wrote, as a keyword. ARIA's `role` is a TOKEN
+  LIST and the first token wins, so a fallback chain (`role=\"doc-subtitle
+  heading\"`) answers its first entry exactly as a user agent reads it."
+  [node]
+  (some-> (token (attr node :role))
+          (str/split #"\s+")
+          first
+          not-empty
+          keyword))
+
+(defn role
+  "The ARIA role of `node` — the `:role` the author wrote, else the role
+  the tag carries implicitly — as a keyword, or `nil` when the node has
+  none.
+
+      (ht/role (ht/find tree #(= :button (:tag %))))   ;=> :button
+      (ht/role (ht/find tree #(= \"alert\" (:role (ht/attrs %)))))
+      ;=> :alert
+
+  Total over the node set: a **fragment** and a **view-boundary** answer
+  `nil` (neither is an element, so neither has a role), and so does an
+  element whose tag maps to nothing. `nil` in, `nil` out.
+
+  The implicit table is [[implicit-roles]] plus the four conditional tags
+  named there; read it rather than this docstring for what is covered and
+  what is deliberately not."
+  [node]
+  (cond
+    (nil? node)    nil
+    (string? node) (refuse! :rf.error/ui-tree-malformed
+                            (str "text content is not a node — role projects "
+                                 "map nodes; text carries no role.")
+                            :no-recovery
+                            {:value node})
+    (map? node)
+    (case (node-kind node)
+      :element
+      (or (explicit-role node)
+          (case (:tag node)
+            :a      (when (some? (attr node :href)) :link)
+            :input  (get input-roles (or (token (attr node :type)) "text"))
+            :select (if (or (attr node :multiple)
+                            (when-some [n (attr node :size)]
+                              (and (number? n) (> n 1))))
+                      :listbox
+                      :combobox)
+            :img    (if (= "" (attr node :alt)) :presentation :img)
+            (get implicit-roles (:tag node))))
+
+      (:view-boundary :fragment) nil)
+
+    :else (not-a-node! node)))
+
+(defn- contains-node?
+  "Is `target` somewhere under `n`, by REFERENCE? Reference and not `=`:
+  two rows of a list can be structurally equal and are still different
+  places on the page, and a label wraps one of them."
+  [n target]
+  (boolean (some (fn [c]
+                   (or (identical? c target)
+                       (and (map? c) (contains-node? c target))))
+                 (:children n))))
+
+(defn- in-tree?
+  [tree node]
+  (or (identical? tree node)
+      (and (map? tree) (contains-node? tree node))))
+
+(defn- labels-for
+  "Every `<label>` in `tree` that labels `node`, in document order —
+  either by `:for` matching its `:id`, or by containing it. HTML's own
+  two ways, and a control may have both."
+  [tree node]
+  (let [id (attr node :id)]
+    (find-all tree
+              (fn [n]
+                (and (= :label (:tag n))
+                     (or (and (some? id) (= id (attr n :for)))
+                         (contains-node? n node)))))))
+
+(defn- joined
+  [nodes]
+  (flat (str/join " " (keep #(flat (text %)) nodes))))
+
+(defn accessible-name
+  "The accessible name `node` carries WITHIN `tree`, as a flat string, or
+  `nil` when it has none.
+
+      (ht/accessible-name tree (ht/find tree #(= :select (:tag %))))
+      ;=> \"Language\"          ;; from the <label for=…> beside it
+
+  `tree` is needed and is not decoration: `aria-labelledby` points at
+  another node by id and a `<label>` labels from wherever it sits, so a
+  name is a fact about the MARKUP and not about the element. A `node`
+  that is not in `tree` is a **refusal**, because answering `nil` there
+  would report a labelled control as unlabelled — the exact wrong answer
+  in the exact direction that matters.
+
+  ## The order, which is ARIA's own, narrowed
+
+  1. **`:aria-labelledby`** — each id resolved within `tree`, in the
+     order written, joined by a space. Unresolvable ids contribute
+     nothing. NARROWED: the platform recurses into each referent's own
+     accessible NAME; this takes the referent's TEXT. The two agree
+     wherever the referent is ordinary content, and differ only for a
+     referent that is itself labelled from somewhere else — a shape this
+     projection does not claim.
+  2. **`:aria-label`**, when it is not blank.
+  3. **The host language's own labelling**, by element:
+     `<img>` its `:alt`; `<input type=button|submit|reset>` its `:value`;
+     `<input>`, `<select>` and `<textarea>` their `<label>`s, joined in
+     document order; `<fieldset>` its `<legend>`.
+  4. **The element's own text**, for the roles named in
+     [[named-by-content]] and no others.
+  5. **`:title`**.
+
+  ## What it does not model, stated so it is not mistaken for covered
+
+  `<table><caption>`, `<optgroup label=…>`, `<summary>`, `alt` on
+  `<area>`, and the `aria-hidden` / `hidden` / `display:none` exclusions
+  the real algorithm applies while walking. Whitespace is flattened; a
+  name that would be visually broken by CSS is not.
+
+  ## The lane
+
+  This is a claim about markup, and a browser is what decides whether the
+  markup means it. Its L4 counterpart is
+  `re-frame.hicasso.examples.slice.a11y-focus-dom-cljs-test`, which reads
+  the engine's own `HTMLInputElement.labels` and its own
+  `document.activeElement` back for the same page."
+  [tree node]
+  (cond
+    (nil? node)    nil
+    (string? node) (refuse! :rf.error/ui-tree-malformed
+                            (str "text content is not a node — accessible-name "
+                                 "projects map nodes; read text with ht/text on "
+                                 "the node that contains it.")
+                            :no-recovery
+                            {:value node})
+    (not (map? node)) (not-a-node! node)
+
+    :else
+    (do
+      (node-kind node)
+      (when-not (in-tree? tree node)
+        (refuse! :rf.error/ui-tree-malformed
+                 (str "the node is not in the tree it was read against — a "
+                      "name is computed from `aria-labelledby` id references "
+                      "and from the `<label>`s that surround the node, so a "
+                      "node from somewhere else would be reported UNNAMED "
+                      "however well labelled it is.")
+                 :pass-the-tree-the-node-came-from
+                 {:value node}))
+      (let [labelled-by (when-some [ids (flat (attr node :aria-labelledby))]
+                          (joined (keep (fn [id]
+                                          (find tree #(= id (attr % :id))))
+                                        (str/split ids #"\s+"))))]
+        (or labelled-by
+            (flat (attr node :aria-label))
+            (case (:tag node)
+              :img      (flat (attr node :alt))
+              ;; HTML: the FIRST `<legend>` CHILD, so a nested fieldset's
+              ;; legend cannot be borrowed by the one above it.
+              :fieldset (some-> (first (filter #(and (map? %) (= :legend (:tag %)))
+                                               (:children node)))
+                                text
+                                flat)
+              (:input :select :textarea)
+              (if (contains? #{"button" "submit" "reset"} (token (attr node :type)))
+                (flat (attr node :value))
+                (joined (labels-for tree node)))
+              nil)
+            (when (contains? named-by-content (role node))
+              (flat (text node)))
+            (flat (attr node :title)))))))
+
+(defn unnamed-controls
+  "Every node in `tree` a user can OPERATE that has no accessible name,
+  in document order — the empty vector when there are none.
+
+      (is (= [] (ht/unnamed-controls tree)))
+
+  One assertion for the whole rendering, and the nodes it answers with
+  name themselves in the failure output. The roles it ranges over are
+  [[interactive-roles]]; the name is [[accessible-name]]'s, with all of
+  its stated narrowings.
+
+  It does NOT exempt a control inside an `aria-hidden` or `hidden`
+  subtree, deliberately: an interactive control hidden from the
+  accessibility tree is reachable by Tab and is a finding in its own
+  right, so exempting one would be this helper hiding a defect rather
+  than reporting it."
+  [tree]
+  (find-all tree
+            (fn [n]
+              (and (contains? interactive-roles (role n))
+                   (nil? (accessible-name tree n))))))


### PR DESCRIPTION
rf2-hic-043. The kit learns to answer three accessibility questions about a semantic tree; the slice is held to the answers in every state it has, in both its languages; and a real Chromium is asked whether it agrees.

## What landed

**`re-frame.hicasso.test` gains three L2 projections** — `role`, `accessible-name`, `unnamed-controls`. They sit beside `attrs` and `text` because data-first markup makes a role an attribute or a tag, a label an element with a `:for`, and a name text: none of it is behind a renderer, so none of it needs one.

They are not an implementation of ARIA and say so. Every narrowing is named in the docstring rather than left to be discovered: `aria-labelledby` takes the referent's **text** rather than recursing into its **name**; the tags whose role depends on an ancestor or a heading (`header`, `footer`, `section`, `aside`, `form`, `td`, `th`) answer `nil` rather than guessing; `<table><caption>`, `<optgroup label>`, `<summary>` and the `aria-hidden` exclusions are not modelled. Where the answer depends on something the tree does not carry, the answer is `nil` — a plausible wrong name is the failure these exist to avoid.

`accessible-name` **refuses** a node that is not in the tree it was read against, reusing the existing `:rf.error/ui-tree-malformed` (a new id would be a Spec 009 row plus a `complaints.md` promotion, and `spec/**` is hot zone). Answering `nil` there would report a labelled control as unlabelled, which is the wrong answer in the one direction that matters.

**Three witness files, one per lane the claim needs:**

- `test_kit_a11y_cljs_test` (node) — the trio's own sabotage fixtures, 28 rows.
- `examples/slice/a11y_cljs_test` (node) — the slice's structural accessibility, 12 rows.
- `examples/slice/a11y_focus_dom_cljs_test` (browser; stated skips on `:node-test`) — 7 rows, real focus.

## Why the assertions are falsifiable

**Roles.** Every conditional arm of the role table is driven on **both** sides of its condition — an `<a>` with and without `:href`, a `<select>` single and multiple and at `:size 1` and `:size 4`, an `<img>` with `alt` and with `alt=""`, an `<input>` across eleven types **including the two ARIA gives no role**. A row that drove only the positive side is satisfied by `(constantly :link)`.

**Names.** `accessible-name` is a five-step ordered fallback, the shape whose test is most easily green while the order is wrong: markup with one source present passes under any ordering that reaches it. So every precedence row supplies **two sources carrying different strings** and asserts which won. Removing a step then changes an answer rather than merely removing one.

**Values that move.** Asserting an `aria-*` attribute is *present* survives the attribute being wrong and survives it being wired to a constant. The slice rows assert the value the state earns and the change when the state changes: `aria-expanded` flips `"false"`/`"true"` **while the toggle's accessible name holds still** (a control that renames itself as its state changes is one a screen-reader user has to re-find); the editor's live region is `:alert` when failed, `:status` when saved and **absent** otherwise; the save button is the one control whose name is *supposed* to move, and that is asserted too so the "name holds still" row is a claim about the disclosure rather than a rule applied blindly. Every field's name is asserted again in French, so the name is proved to follow the string table rather than to sit nearby.

**The sweep.** `unnamed-controls` runs over all six bodies, in every state each has, in both locales — one assertion per rendering, which is the bead's acceptance in the form the application can be held to as it grows. `the-sweep-would-notice` detaches exactly one label from the same rendering and asserts the sweep finds exactly one offender; without it, the empty answer would be equally consistent with the auditor never finding anything.

## Quality gates

Every run was foreground, alone, on one command line, with the exit code echoed from the same shell. Numbers are the ones captured, all **after** the rebase onto `origin/main` at `4579688787`.

| Gate | Exit | Result |
| --- | --- | --- |
| `npm run test:cljs` | **0** | `Ran 13412 tests containing 67580 assertions. 0 failures, 0 errors.` |
| `npm run test:browser` | **0** | `Ran 1304 tests containing 8079 assertions. 0 failures, 0 errors.` |
| `npm run test:hicasso-invariants` | **0** | freeze + optional-module reachability + complaint catalogue + budget ledger |
| `npm run test:hicasso-lint` | **0** | `6 checks fire on their fixtures, correct code is silent, testbeds quiet` |
| `npm run build:hicasso-release` | **0** | `162 files, 0 warnings` + `5 sentinels absent, 3 positive controls present` |
| `npm run test:hicasso-compile` | **0** | `124 lane namespaces compiled with zero warnings` |
| `node scripts/_browser-dom-lane-partition.test.cjs` | **0** | `2 passed` — the new `*_dom_cljs_test` namespace partitions correctly |
| `clojure -M:clj-kondo --fail-level error --lint implementation/hicasso` (pin 2026.04.15) | **0** | `errors: 0, warnings: 5` — all five pre-existing, none on a file in this diff |

**Base, measured rather than remembered.** On the pre-rebase base (`0282083e33`): `test:cljs` 13354/67270, `test:browser` 1293/8010, both exit 0. This diff adds 47 node tests (28 + 12 + 7) and 7 browser tests.

**What the fast-PR spine does not decide** (`python scripts/check_fast_pr_gap.py --list`, exit **0**): 97 required checks, none of them decided by the spine. The two on this diff's surface that matter and are **not** in the spine are `cljs-browser` (run above, exit 0) and the two three-engine hicasso gates `cljs-hicasso-controlled` / `cljs-hicasso-hmr`. Those two are armed by `implementation/hicasso/**` and so will fire in CI, but **this diff cannot reach them**: they drive `hicasso/testbed/`, and neither `hicasso_testbed.core` nor `hicasso_hmr_testbed` requires `re-frame.hicasso.test` — the test kit is its own source root and is absent from the artefact's published `:paths`. Stated as a reachability fact, not as a reason to skip a gate the diff could touch.

## Sabotage — both directions, every assertion class

Each mutation was applied, the lane run and the exit code captured, the mutation reverted, and the revert **verified by hashing the file's bytes** against a baseline taken before the first mutation (not by `git diff`). All three touched files hash identically to baseline at HEAD.

Kit sabotage runs used the `:node-test-hicasso` build — the artefact's own named surface, whose namespaces are a strict subset of `:node-test`'s and include every affected row. Browser sabotage runs used `npm run test:browser`.

### `role` — the conditional arms

| # | Mutation | Exit | Named red |
| --- | --- | --- | --- |
| S1a | `:a` answers `:link` unconditionally (too permissive) | **1** | 1 failure — `an-anchor-is-a-link-only-when-it-has-somewhere-to-go` (`test_kit_a11y_cljs_test.cljs:124`) |
| S1b | `:a` never answers `:link` (too restrictive) | **1** | 6 failures — `the-article-link-is-a-link-because-routing-gave-it-an-href`, `an-anchor-is-a-link-…`, `only-the-roles-that-take-a-name-from-content-take-one`, `removing-any-one-name-…` |

S1a is the bare-anchor false positive audit #7791 reopened rf2-hic-022 to remove; the kit must not re-introduce it, and this row is what says so.

### `accessible-name` — precedence and label resolution

| # | Mutation | Exit | Named red |
| --- | --- | --- | --- |
| S2 | the `aria-labelledby` step removed from the fallback | **1** | 13 failures — all three `aria-labelledby-resolves-…` rows, `aria-labelledby-beats-aria-label-beats-the-content`, `a-fully-named-form-reports-nothing`, `removing-any-one-name-…` |
| S3 | `labels-for` loses the containment arm — `for` only (too narrow) | **1** | 12 failures — `a-control-is-named-by-its-label-either-way-round`, `a-fully-named-form-reports-nothing`, `removing-any-one-name-…` |
| S4 | `labels-for` matches **any** `<label>` (too eager) | **1** | 18 failures — `a-label-names-the-control-it-points-at-and-no-other`, `moving-a-control-out-of-its-wrapping-label-reports-it`, `every-field-in-the-editor-is-named-by-the-label-that-points-at-it`, `a-name-follows-the-string-table-into-the-other-language`, `the-sweep-would-notice` |

S3 is worth reading twice: the slice's `#slice-published` did **not** red, because that checkbox carries **both** the wrapping label and the `for`. That is the discrimination the kit-level rows exist for, and it is why the kit has its own witness file rather than relying on the application's.

### `unnamed-controls` — the auditor

| # | Mutation | Exit | Named red |
| --- | --- | --- | --- |
| S5 | the auditor never reports (`(and false …)`) | **1** | 19 failures — every `removing-any-one-name-…` case, `the-sweep-would-notice`, `moving-a-control-out-of-its-wrapping-label-reports-it`, `what-the-auditor-must-not-report`, `the-auditor-reports-in-document-order-…` |
| S6 | the auditor reports every unnamed node with **any** role (too eager) | **1** | 15 failures — `what-the-auditor-must-not-report` and `every-operable-control-in-the-application-has-a-name` in 12 of the 32 swept renderings |

### The label↔control pairing, end to end — one mutation, both lanes

| # | Mutation | Lane | Exit | Named red |
| --- | --- | --- | --- | --- |
| S8 | `views.cljs`: the title label's `:for` typo'd to `"slice-titel"` | node | **1** | 10 failures — `every-field-in-the-editor-…`, `a-name-follows-the-string-table-…`, `every-operable-control-…` |
| S8 | same mutation | browser | **1** | `the-engine-agrees-with-the-structural-names` — *"#slice-title is associated with exactly one `<label>` by the engine; it reported 0"* — and `clicking-a-label-moves-focus-to-the-control-it-names` |

One character, and both instruments red, each in its own vocabulary. That is the strongest available evidence that the structural helper and the engine are measuring the same fact.

### Focus and focusability — the browser lane

| # | Mutation | Exit | Named red |
| --- | --- | --- | --- |
| S7 | `views.cljs`: `.discard` loses `:disabled (not dirty?)` — a **feature** sabotage | **1** | `the-focus-order-is-the-document-order-and-nothing-reorders-it`, `a-disabled-control-leaves-the-focus-order-and-comes-back` (and, correctly, two pre-existing `flow-dom-cljs-test` rows) |
| S9 | `focusable?` always answers false | **1** | `the-focus-order-…`, `a-disabled-control-…` (the enabled side), `the-save-button-leaves-the-focus-order-while-it-is-saving` (the return side) |
| S10 | `focusable?` always answers true | **1** | `the-focus-order-…`, `a-disabled-control-…` (the disabled side), `the-save-button-…` (the in-flight side) |

S9 and S10 are the instrument's own two directions: a focus-order helper that answered "nothing is focusable" and one that answered "everything is" both fail, and they fail on **different** rows. The committed rows that catch them are the ones asserting the order as a **complete sequence** rather than as a membership test.

### The other direction: legal variants that must stay green

Every sabotage row above has a committed twin asserting the legal case still passes, and they are what a guard wrong by being *too eager* runs into:

- `a-fully-named-form-reports-nothing` — one form, six different legal naming mechanisms (content, `aria-label`, `<label for>`, a wrapping `<label>`, `aria-labelledby`, `:value`), reporting nothing.
- `what-the-auditor-must-not-report` — prose, a `role="alert"`, an empty `<span>`, an empty `<li>`, a decorative `<img alt="">` and a bare `<a>` with no `href`: all nameless, none operable, none reported. Plus a **disabled** button, which *is* reported, because a disabled control is still announced and can still be enabled.
- `a-label-names-the-control-it-points-at-and-no-other` — two labels, two controls, crossed `for` targets.
- `accessible-name-refuses-a-node-from-somewhere-else` carries its legal twin **and** drives the discriminator in both verbs, so the refusal row is not a helper that only knows one.
- On the browser lane, `a-disabled-control-leaves-the-focus-order-and-comes-back` and `the-save-button-leaves-the-focus-order-while-it-is-saving` each assert the control **returns**, so neither is satisfied by a page where the control is simply always absent.

## Two deliverables NOT done, and why — source-located

**1. The lint rule is NOT graduated from warning. The premise does not hold.**

The bead (2026-08-09) asks for "the interactive-element-without-name lint rule graduated from warning (hic-022) with fixtures". A later operator ruling on rf2-hic-022 (2026-08-10 20:36 AUSEST, in session) settles it the other way and names this exact rule:

> 5. Interactive element without an accessible name — WARNING (full a11y stays hic-043).
> SEVERITY LAW: errors only for true invariants; warnings for heuristics; nothing blocks a build. Assistance, not enforcement.

`nameless-interactive-element` is a heuristic by the hook's own account — it cannot see a sibling `<label for=…>`, which is the commonest way a field is named — so graduating it to error would block correct programmer code at `--fail-level error`. That is the class of failure that reopened rf2-hic-022 twice. The rule stays a warning.

The **fixtures** half of that deliverable is already met and is live: `lint-fixtures/positive.cljs` rows 86/89/92 and `negative.cljs`'s "every legal way to name one" block, pinned by exact row in `check_lint_export.py` and run by `npm run test:hicasso-lint` (exit 0 above, in `lint.yml`'s required `clj-kondo` job). Nothing was owed here and nothing was added.

**2. axe is NOT wired, and I stopped rather than doing it.**

`axe-core` is not an npm dependency anywhere in this repository. Adding it means `implementation/package.json` + `package-lock.json` and an `npm install` — and this worker worktree **junctions `implementation/node_modules` at the mayor checkout's real one**, so an install here writes into the mayor tree. That is a fence, not a judgement call, so I stopped.

There is also a routing argument, which is the mayor's to accept or reject: rf2-hic-049 already owns *"axe checks across all three surfaces"* and already depends on this bead, rf2-hic-047 and rf2-hic-052. Wiring axe once, when all three surfaces exist, is one wiring rather than two. **No new bead — rf2-hic-049 is the existing exact owner.**

The bead's stated **acceptance** — *"Slice app passes structural + browser a11y; the kit helpers have sabotage fixtures"* — is met without axe.

**3. Virtualized-list and overlay a11y checks are not deliverable yet**, and the bead says so itself: "(with hic-047's)" and "(with hic-052's when it lands)". Both beads are open and neither surface exists.

## Fences

- **I9 is untouched.** Nothing here wanted a third hook. The browser rows are DOM reads, `.focus()`, `.click()` and `document.activeElement`; no measurement is taken at React's dispatcher and no hook is added, observed or counted.
- **Three new public exports**, all in the test kit: `ht/role`, `ht/accessible-name`, `ht/unnamed-controls`. The bead names "kit helpers asserting names/roles/labels" as its first deliverable, so the surface is the bead's; three is the minimum that carries the three facts, and the naming ledger records the kit's helper set as unpinned (row 23). No production namespace gains anything.
- **No hot-zone file touched.** `shadow-cljs.edn`, `deps.edn`, `spec/**` and `.github/workflows/**` are all unchanged — the new namespaces are selected by build regexps that already exist (`cljs-test$`, `-dom-cljs-test$`).
- **No new diagnostic id**, deliberately: `complaints.md` R1/R6 would require a Spec 009 row, and `spec/**` is hot zone.
- **No published snapshot edited** — `specification.md`, `decision-brief.md` and everything under `lanes/` are untouched.
- **No `.beads/*`** in this branch.

## The lane that decides each claim

The structural rows are decided by `cljs_node_test` (the required `cljs` job). The focus rows are decided by `cljs_browser` (the required `cljs-browser` Playwright job) — on `:node-test` they degrade to **stated skips**, which are honest and are not measurements. `implementation/hicasso/**` arms both, since rf2-8a6s.
