### PR TITLE
test(freehand): a suite's cleanup must not outlive its own test (rf2-29ua)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/controls_kit_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/controls_kit_dom_cljs_test.cljs
@@ -238,37 +238,49 @@
   [pred label]
   (test-support/poll-until pred {:label label :timeout-ms 2000 :interval-ms 5}))
 
-(defn- finish!
-  "The terminal step of every row here: tear the mount down through the
-  shared lifecycle, assert that NOTHING it created survived, and end the
-  async test.
+(defn- teardown-clean!
+  "The SUCCESS arm's last act: tear the mount down through the shared
+  lifecycle, and assert that NOTHING it created survived.
 
   The residue assertion is what earns the row's claim rather than asserting
   it. It runs AFTER teardown, over the facade's own books — every root this
   test created, and what each left behind — so a root that failed to
   unmount reds HERE instead of contaminating the next suite in the process.
 
-  It OWNS the `done` call, the way `mount-support`'s `run-async` and
-  `each-mode` own theirs: a row that ends here must NOT call `done` itself.
-  Five did, once this replaced a `teardown!` that left `done` to the caller,
-  and nothing went red — `cljs.test` guards `run-block` with a `realized?`
-  delay, so the second call degrades to a console warning rather than
-  corrupting async state (rf2-0ke4x). A duplicate is therefore invisible to
-  the browser gate and has to be kept out by this rule instead."
-  [container root done]
+  It does NOT end the row. The single `done` sits at the TAIL of the chain
+  with nothing after it, and this is one of the two steps that tail waits
+  on; [[report-failure!]] is the other, and says why they cannot be the
+  same step."
+  [container root]
   (ms/destroy-root! container root)
-  (ms/residue-clean! "FH-CTRL-018 — after teardown")
-  (done))
+  (ms/residue-clean! "FH-CTRL-018 — after teardown"))
 
-(defn- fail-and-finish!
-  "The rejection path. It tears down — a rejected row must not leak its root
-  either — but reads no residue: a second failure attributed to the leak
-  rule would bury the one that actually happened."
-  [container root done]
+(defn- report-failure!
+  "The REJECTION arm: record the rejection against this row, tear the mount
+  down — a rejected row must not leak its root either — and deliberately do
+  NOT end the row. The chain's single trailing `done` does that.
+
+  It reads no residue, and that asymmetry against [[teardown-clean!]] is
+  load-bearing: a second failure attributed to the leak rule would bury the
+  one that actually happened. It is also why the teardown stays written in
+  both arms instead of riding the shared trailing step — the two arms do
+  different amounts of work, so there is nothing here to hoist.
+
+  **A rejection handler may not sit downstream of the step that calls
+  `done`.** [[re-frame.freehand.mount-support/each-mode]] carries the
+  long-form account (rf2-qpns): `run-block` hands `done` a continuation
+  that runs the whole remainder of the run synchronously, so a `.catch` out
+  past it claims a LATER namespace's throw as this row's failure and fires
+  `done` a second time.
+
+  This file read as ZERO to the campaign's scanner, which looks for a chain
+  step containing a literal `(done)`. Both arms took `done` through a
+  helper, so no step here held one (rf2-29ua)."
+  [container root]
   (fn [e]
     (is false (str "the browser step rejected: " e))
     (ms/destroy-root! container root)
-    (done)))
+    nil))
 
 ;; ===========================================================================
 ;; FH-CTRL-018 — typing, the caret, the composing Enter, and the reset
@@ -303,8 +315,9 @@
                         "non-vacuous: the typing really moved the value")
                     (is (= (count value-after-typing) (first (caret field)))
                         "with the caret at the end, where the user left it")
-                    (finish! container root done))))
-              (.catch (fail-and-finish! container root done))))))))
+                    (teardown-clean! container root))))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))
 
 (deftest fh-ctrl-018-a-mid-string-insert-leaves-the-caret-where-the-user-put-it
   (testing "Per FH-CTRL-018: the caret is placed INSIDE the text and one
@@ -334,8 +347,9 @@
                          to the start would also produce")
                     (is (not= (count value-after-insert) caret-after-insert)
                         "nor the position a reset to the END would produce")
-                    (finish! container root done))))
-              (.catch (fail-and-finish! container root done))))))))
+                    (teardown-clean! container root))))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))
 
 (deftest fh-ctrl-018-a-blur-commits-the-draft
   (testing "Per FH-CTRL-018: the blur commits the draft the user could see.
@@ -362,15 +376,18 @@
                         "non-vacuous: there really is a draft to commit")
                     (is (= 0 (commits)) "and nothing has committed yet")
                     (.blur field)
+                    ;; The nested chain is RETURNED into the outer one, so its
+                    ;; rejections reach the outer `.catch` and it needs none of
+                    ;; its own — one rejection handler and one `done` per row.
                     (-> (settled #(= commits-after-plain-enter (commits)) "the blur commits")
                         (.then (fn [_]
                                  (is (= commits-after-plain-enter (commits))
                                      "the blur committed")
                                  (is (= committed-value (committed))
                                      "carrying the draft the user could see")
-                                 (finish! container root done)))
-                        (.catch (fail-and-finish! container root done))))))
-              (.catch (fail-and-finish! container root done))))))))
+                                 (teardown-clean! container root)))))))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))
 
 (defn- exactly-one-commit-attempt!
   "Press a composing Enter carrying `composing-press`'s scalars, then a
@@ -435,9 +452,9 @@
                       (is (not= commits-after-composing-enter
                                 commits-after-plain-enter)
                           "non-vacuous: the fixture's two answers really differ")
-                      (finish! container root done)))
-                  (.catch (fail-and-finish! container root done))))))
-        (.catch (fail-and-finish! container root done)))))
+                      (teardown-clean! container root)))))))
+        (.catch (report-failure! container root))
+        (.then (fn [_] (done))))))
 
 (deftest fh-ctrl-018-a-composing-enter-commits-nothing-in-a-real-browser
   (testing "Per FH-CTRL-018: an Enter carrying the STANDARD `isComposing`
@@ -533,6 +550,6 @@
                                 "the commit that follows carries the restored value")
                             (is (not= value-after-insert (committed))
                                 "non-vacuous: it is not the draft the caller refused")
-                            (finish! container root done)))
-                        (.catch (fail-and-finish! container root done))))))
-              (.catch (fail-and-finish! container root done))))))))
+                            (teardown-clean! container root)))))))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/splitter_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/splitter_dom_cljs_test.cljs
@@ -229,10 +229,9 @@
   []
   (-> (ms/tick!) (.then (fn [_] (ms/tick!)))))
 
-(defn- finish!
-  "The terminal step of every row here: tear the mount down through the
-  shared lifecycle, assert that NOTHING it created survived, and end the
-  async test.
+(defn- teardown-clean!
+  "The SUCCESS arm's last act: tear the mount down through the shared
+  lifecycle, and assert that NOTHING it created survived.
 
   The residue assertion is what earns the record's `:residue :none`
   rather than asserting it. It runs AFTER teardown, over the facade's own
@@ -240,22 +239,43 @@
   root that failed to unmount reds HERE instead of contaminating the next
   suite in the process.
 
-  It OWNS the `done` call: a row that ends here must NOT call `done`
-  itself."
-  [container root done]
+  It does NOT end the row. The single `done` sits at the TAIL of the
+  chain with nothing after it, and this is one of the two steps that tail
+  waits on; [[report-failure!]] is the other, and says why they cannot be
+  the same step."
+  [container root]
   (ms/destroy-root! container root)
-  (ms/residue-clean! "FH-CTRL-019 — after teardown")
-  (done))
+  (ms/residue-clean! "FH-CTRL-019 — after teardown"))
 
-(defn- fail-and-finish!
-  "The rejection path. It tears down — a rejected row must not leak its
-  root either — but reads no residue: a second failure attributed to the
-  leak rule would bury the one that actually happened."
-  [container root done]
+(defn- report-failure!
+  "The REJECTION arm: record the rejection against this row, tear the
+  mount down — a rejected row must not leak its root either — and
+  deliberately do NOT end the row. The chain's single trailing `done`
+  does that.
+
+  It reads no residue, and that asymmetry against [[teardown-clean!]] is
+  load-bearing: a second failure attributed to the leak rule would bury
+  the one that actually happened. It is also why the teardown stays
+  written in both arms instead of riding the shared trailing step — the
+  two arms do different amounts of work, so there is nothing here to
+  hoist.
+
+  **A rejection handler may not sit downstream of the step that calls
+  `done`.** [[re-frame.freehand.mount-support/each-mode]] carries the
+  long-form account (rf2-qpns): `run-block` hands `done` a continuation
+  that runs the whole remainder of the run synchronously, so a `.catch`
+  out past it claims a LATER namespace's throw as this row's failure and
+  fires `done` a second time.
+
+  One of these per row, on the OUTERMOST chain. Every nested chain here
+  is returned into its parent, so a rejection anywhere inside reaches
+  this handler without a handler of its own — which is what keeps the
+  count at one rejection handler and one `done` per row (rf2-29ua)."
+  [container root]
   (fn [e]
     (is false (str "the browser step rejected: " e))
     (ms/destroy-root! container root)
-    (done)))
+    nil))
 
 ;; ===========================================================================
 ;; THE ROW: a drag and a keystroke leave app-db identical
@@ -344,10 +364,9 @@
                                        WHOLE gesture, and that is the one asymmetry")
                                   (is (= 1 (counter ::commits))
                                       "and exactly one commit reached the domain")
-                                  (finish! container root done))))
-                            (.catch (fail-and-finish! container root done))))))
-                  (.catch (fail-and-finish! container root done))))))
-        (.catch (fail-and-finish! container root done)))))
+                                  (teardown-clean! container root))))))))))))
+        (.catch (report-failure! container root))
+        (.then (fn [_] (done))))))
 
 (deftest fh-ctrl-019-a-drag-and-a-keystroke-leave-app-db-identical
   (testing "Per FH-CTRL-019: the accessibility claim, walked. A real
@@ -425,9 +444,9 @@
                                 "still no previews, after the whole gesture")
                             (is (not= baseline parity-at)
                                 "non-vacuous: the commit really moved the split")
-                            (finish! container root done)))
-                        (.catch (fail-and-finish! container root done))))))
-              (.catch (fail-and-finish! container root done))))))))
+                            (teardown-clean! container root)))))))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; The ending nobody asked for, and the offer behind it
@@ -498,9 +517,9 @@
                                            be visibly wrong here")
                                       (is (= 0 (counter ::commits))
                                           "and a cancelled gesture committed nothing")
-                                      (finish! container root done)))))))
-                        (.catch (fail-and-finish! container root done))))))
-              (.catch (fail-and-finish! container root done))))))))
+                                      (teardown-clean! container root)))))))))))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; The bound, under a real pointer
@@ -558,6 +577,6 @@
                                              (.getAttribute sep "aria-valuenow"))
                                           "and the screen reader is told the clamped
                                            value, not the pointer's")
-                                      (finish! container root done)))))))
-                        (.catch (fail-and-finish! container root done))))))
-              (.catch (fail-and-finish! container root done))))))))
+                                      (teardown-clean! container root)))))))))))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/typeahead_witness_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/typeahead_witness_dom_cljs_test.cljs
@@ -269,32 +269,50 @@
         (.then (fn [_] (settled #(seq (requests)) "the caller is asked")))
         (.then (fn [_] input)))))
 
-(defn- finish!
-  "The terminal step of every row: tear the mount down through the shared
-  lifecycle, assert that NOTHING it created survived, and end the async
-  test.
+(defn- teardown-clean!
+  "The SUCCESS arm's last act: tear the mount down through the shared
+  lifecycle, and assert that NOTHING it created survived.
 
   The residue assertion is what EARNS the record's `:residue :none` rather
   than asserting it. It runs AFTER teardown, over the facade's own books —
   every root this test created and what each left behind — plus the
   control's own book, the records root, which the owner's release empties.
 
-  It OWNS the `done` call: a row that ends here must not call `done` itself."
-  [container root done]
+  It does NOT end the row. The single `done` sits at the TAIL of the chain
+  with nothing after it, and this is one of the two steps that tail waits
+  on; [[report-failure!]] is the other, and says why they cannot be the
+  same step."
+  [container root]
   (ms/destroy-root! container root)
   (ms/residue-clean! "FH-CTRL-020 — after teardown"
-                     [["the control's records root" #(get (app-db) ta/records-root {})]])
-  (done))
+                     [["the control's records root" #(get (app-db) ta/records-root {})]]))
 
-(defn- fail-and-finish!
-  "The rejection path. It tears down — a rejected row must not leak its root
-  either — but reads no residue: a second failure attributed to the leak
-  rule would bury the one that actually happened."
-  [container root done]
+(defn- report-failure!
+  "The REJECTION arm: record the rejection against this row, tear the mount
+  down — a rejected row must not leak its root either — and deliberately do
+  NOT end the row. The chain's single trailing `done` does that.
+
+  It reads no residue, and that asymmetry against [[teardown-clean!]] is
+  load-bearing: a second failure attributed to the leak rule would bury the
+  one that actually happened. It is also why the teardown stays written in
+  both arms instead of riding the shared trailing step — the two arms do
+  different amounts of work, so there is nothing here to hoist.
+
+  **A rejection handler may not sit downstream of the step that calls
+  `done`.** [[re-frame.freehand.mount-support/each-mode]] carries the
+  long-form account (rf2-qpns): `run-block` hands `done` a continuation
+  that runs the whole remainder of the run synchronously, so a `.catch` out
+  past it claims a LATER namespace's throw as this row's failure and fires
+  `done` a second time.
+
+  One of these per row, on the OUTERMOST chain. Every nested chain here is
+  returned into its parent, so a rejection anywhere inside reaches this
+  handler without a handler of its own (rf2-29ua)."
+  [container root]
   (fn [e]
     (is false (str "the browser step rejected: " e))
     (ms/destroy-root! container root)
-    (done)))
+    nil))
 
 (defn- release!
   "The owner's exit path, dispatched before teardown so the residue read
@@ -360,8 +378,9 @@
                              "a coincidence of this page (control at "
                              (.-top cr) "," (.-left cr) ")"))
                     (release!))))
-              (.then (fn [_] (finish! container root done)))
-              (.catch (fail-and-finish! container root done))))))))
+              (.then (fn [_] (teardown-clean! container root)))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; FH-CTRL-020 — keyboard navigation, with focus staying put
@@ -421,9 +440,9 @@
                             (is (identical? input (.-activeElement js/document))
                                 "with focus still where the user left it")
                             (release!)))
-                        (.then (fn [_] (finish! container root done)))
-                        (.catch (fail-and-finish! container root done)))))
-                (.catch (fail-and-finish! container root done))))))))
+                        (.then (fn [_] (teardown-clean! container root))))))
+                (.catch (report-failure! container root))
+                (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; FH-CTRL-020 — commit, and the Enter that belongs to the input method
@@ -516,9 +535,9 @@
                     (is (nil? (record))
                         "and the commit retired the record, so the list went with it")
                     (release!)))
-                (.then (fn [_] (finish! container root done)))
-                (.catch (fail-and-finish! container root done)))))
-        (.catch (fail-and-finish! container root done)))))
+                (.then (fn [_] (teardown-clean! container root))))))
+        (.catch (report-failure! container root))
+        (.then (fn [_] (done))))))
 
 (deftest fh-ctrl-020-a-composing-enter-commits-nothing-in-a-real-browser
   (testing "Per FH-CTRL-020: an Enter carrying the STANDARD `isComposing`
@@ -592,9 +611,9 @@
                           (is (nil? (record))
                               "the commit retired the record, so the list is gone
                                with it")
-                          (finish! container root done)))
-                      (.catch (fail-and-finish! container root done)))))
-              (.catch (fail-and-finish! container root done))))))))
+                          (teardown-clean! container root))))))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; FH-CTRL-020 — dismissal, from both ends, committing nothing
@@ -697,9 +716,9 @@
                             (is (= query (.-value input))
                                 "and it is still what the live node shows")
                             (release!)))
-                        (.then (fn [_] (finish! container root done)))
-                        (.catch (fail-and-finish! container root done))))))
-              (.catch (fail-and-finish! container root done))))))))
+                        (.then (fn [_] (teardown-clean! container root)))))))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; FH-CTRL-020 — a stale reply, on a real clock, and total release
@@ -759,9 +778,9 @@
                             (is (not (.matches (ms/q container (str "#" listbox-id))
                                                ":popover-open"))
                                 "and the list is out of the top layer with it")
-                            (finish! container root done)))
-                        (.catch (fail-and-finish! container root done))))))
-              (.catch (fail-and-finish! container root done))))))))
+                            (teardown-clean! container root)))))))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; FH-CTRL-020 — the retry, as something a user can actually reach
@@ -854,5 +873,6 @@
                       "and only it — the failed request answered with two
                        options and neither of them is on the page")
                   (release!)))
-              (.then (fn [_] (finish! container root done)))
-              (.catch (fail-and-finish! container root done))))))))
+              (.then (fn [_] (teardown-clean! container root)))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/virtual_collection_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/virtual_collection_dom_cljs_test.cljs
@@ -275,10 +275,9 @@
   (settled #(and (viewport-el) (= first (window-first)))
            (str "the window moves to " first)))
 
-(defn- finish!
-  "The terminal step of every row here: tear the mount down through the
-  shared lifecycle, assert that NOTHING it created survived, and end the
-  async test.
+(defn- teardown-clean!
+  "The SUCCESS arm's last act: tear the mount down through the shared
+  lifecycle, and assert that NOTHING it created survived.
 
   Three books beyond the facade's own. The substrate's CONNECTED-OCCURRENCE
   index is the one that matters: every row that scrolled into the window
@@ -291,9 +290,12 @@
   the engine's positioned `row-shell` and the listbox's `option` inside it.
   A read covering only one of them would be blind to a leak in the other.
 
-  All three are read AFTER teardown, which is the whole point. It OWNS the
-  `done` call, so a row that ends here must NOT call `done` itself."
-  [container root done where]
+  All three are read AFTER teardown, which is the whole point. It does NOT
+  end the row: the single `done` sits at the TAIL of the chain with nothing
+  after it, and this is one of the two steps that tail waits on.
+  [[report-failure!]] is the other, and says why they cannot be the same
+  step."
+  [container root where]
   (ms/destroy-root! container root)
   (ms/residue-clean! (str "FH-CTRL-021 — " where)
                      [["the connected-occurrence index" #(occurrences/rows)]
@@ -301,18 +303,36 @@
                        #(.-length (.querySelectorAll js/document "[data-part='row']"))]
                       ["every row shell in the document"
                        #(.-length (.querySelectorAll js/document
-                                                     "[data-part='row-shell']"))]])
-  (done))
+                                                     "[data-part='row-shell']"))]]))
 
-(defn- fail-and-finish!
-  "The rejection path. It tears down — a rejected row must not leak its
-  root either — but reads no residue: a second failure attributed to the
-  leak rule would bury the one that actually happened."
-  [container root done]
+(defn- report-failure!
+  "The REJECTION arm: record the rejection against this row, tear the mount
+  down — a rejected row must not leak its root either — and deliberately do
+  NOT end the row. The chain's single trailing `done` does that.
+
+  It reads no residue, and that asymmetry against [[teardown-clean!]] is
+  load-bearing: a second failure attributed to the leak rule would bury the
+  one that actually happened — which in this file would be three of them,
+  since the residue read here carries three books beyond the facade's own.
+  It is also why the teardown stays written in both arms instead of riding
+  the shared trailing step: the two arms do different amounts of work, so
+  there is nothing here to hoist.
+
+  **A rejection handler may not sit downstream of the step that calls
+  `done`.** [[re-frame.freehand.mount-support/each-mode]] carries the
+  long-form account (rf2-qpns): `run-block` hands `done` a continuation
+  that runs the whole remainder of the run synchronously, so a `.catch` out
+  past it claims a LATER namespace's throw as this row's failure and fires
+  `done` a second time.
+
+  One of these per row, on the OUTERMOST chain. Every nested chain here is
+  returned into its parent, so a rejection anywhere inside reaches this
+  handler without a handler of its own (rf2-29ua)."
+  [container root]
   (fn [e]
     (is false (str "the browser step rejected: " e))
     (ms/destroy-root! container root)
-    (done)))
+    nil))
 
 ;; ===========================================================================
 ;; FH-CTRL-021 — a real scroll moves the window, and app-db is where it lands
@@ -358,9 +378,9 @@
                                   "and the document holds exactly that many rows")
                               (is (< w-count item-count)
                                   "non-vacuous: out of ten thousand")
-                              (finish! container root done "after one scroll"))))
-                        (.catch (fail-and-finish! container root done))))))
-              (.catch (fail-and-finish! container root done))))))))
+                              (teardown-clean! container root "after one scroll"))))))))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; FH-CTRL-021 — a row that stays in the window is the SAME element
@@ -436,8 +456,9 @@
                         "on the engine's positioned shell as well as on the
                          listbox's option inside it, so neither layer is
                          quietly rebuilding the window")
-                    (finish! container root done "after a one-row scroll"))))
-              (.catch (fail-and-finish! container root done))))))))
+                    (teardown-clean! container root "after a one-row scroll"))))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))
 
 (deftest fh-ctrl-021-a-reorder-carries-a-row-element-with-its-item
   (testing "Per FH-CTRL-021: keyed identity where it costs the most. The
@@ -519,8 +540,9 @@
                         "while a row whose place did not change kept its id,
                          so the rename above is the reorder and not a
                          wholesale re-addressing")
-                    (finish! container root done "after a reorder"))))
-              (.catch (fail-and-finish! container root done))))))))
+                    (teardown-clean! container root "after a reorder"))))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; FH-CTRL-021 — focus is the viewport's, so a windowed row cannot take it
@@ -596,9 +618,9 @@
                               "with focus never having moved at all")
                           (is (= "true" (.getAttribute (named) "aria-selected"))
                               "still marked as the one the user is on")
-                          (finish! container root done "after the active row round trip")))
-                      (.catch (fail-and-finish! container root done)))))
-              (.catch (fail-and-finish! container root done))))))))
+                          (teardown-clean! container root "after the active row round trip"))))))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; FH-CTRL-021 — a keyboard move reveals a row that was not rendered
@@ -659,9 +681,9 @@
                           (is (= key-to-dom-id
                                  (.getAttribute (viewport-el) "aria-activedescendant"))
                               "named by the viewport that still holds focus")
-                          (finish! container root done "after the keyboard move")))
-                      (.catch (fail-and-finish! container root done)))))
-              (.catch (fail-and-finish! container root done))))))))
+                          (teardown-clean! container root "after the keyboard move"))))))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; FH-CTRL-021 — the offset is CONTROLLED, so the viewport follows the state
@@ -712,8 +734,9 @@
                        showing blank above the rows")
                   (is (pos? restore-offset)
                       "non-vacuous: the restored offset is not the default")
-                  (finish! container root done "after a restore onto a fresh mount")))
-              (.catch (fail-and-finish! container root done))))))))
+                  (teardown-clean! container root "after a restore onto a fresh mount")))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))
 
 (deftest fh-ctrl-021-a-state-only-offset-move-drags-a-mounted-viewport
   (testing "Per FH-CTRL-021: the TIME-TRAVEL half, and the one that
@@ -757,8 +780,9 @@
                   (is (= time-travel-offset (offset-in-db))
                       "with app-db still holding it — the reconciliation
                        writes the host, never the frame")
-                  (finish! container root done "after a state-only offset move")))
-              (.catch (fail-and-finish! container root done))))))))
+                  (teardown-clean! container root "after a state-only offset move")))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; FH-CTRL-021 — repeated scroll cycles leave NOTHING behind
@@ -834,7 +858,8 @@
                   (is (pos? (count (occurrences/rows)))
                       "and the index is still non-empty with the mount live —
                        the rows the LAST window opened")
-                  (finish! container root done
-                           (str "after " cycles " scroll cycles and "
-                                rendered " row renders"))))
-              (.catch (fail-and-finish! container root done))))))))
+                  (teardown-clean! container root
+                                   (str "after " cycles " scroll cycles and "
+                                        rendered " row renders"))))
+              (.catch (report-failure! container root))
+              (.then (fn [_] (done)))))))))


### PR DESCRIPTION
Closes rf2-29ua. The 40 promise chains the campaign's scanner signature cannot see,
in four `implementation/freehand` files that were named in no bead: both arms routed
through local helpers taking `done`, so no chain step held a literal `(done)` and the
signature reported all four as ZERO.

## The count I derived

I built an independent s-expression reader rather than a line-oriented matcher, with
all three corrections rf2-53uz and rf2-29ua name (chains nested structurally, so a
nested step cannot split its parent; the `->` head expression examined too; a step
counts as finishing when its body holds a literal `(done)` **or** calls a local
`defn`/`defn-` that takes a `done` parameter and calls it, resolved to a fixed point
so a helper calling a helper also counts). No word-boundary escape anywhere near a
Clojure name.

Calibrated against both campaign landmarks on the pre-repair tree (`f1185fabc6`, the
parent of the first batch commit), over `implementation/freehand`:

| signature | pre-repair | at `origin/main` 2148fb422e | after this PR |
|---|---|---|---|
| literal `(done)`, stack-correct | **184** in 46 files | 100 in 38 files | 100 in 38 files |
| + helper-aware (all three corrections) | **224** in 50 files | 140 in 42 files | **100 in 38 files** |

184 and 224 are exactly the bead's figures, reproduced from source by a different
mechanism. The 40-chain delta is entirely in the four files, and the per-file split
reproduces the bead's census exactly:

| file | chains |
|---|---|
| `typeahead_witness_dom_cljs_test.cljs` | 12 |
| `virtual_collection_dom_cljs_test.cljs` | 11 |
| `splitter_dom_cljs_test.cljs` | 9 |
| `controls_kit_dom_cljs_test.cljs` | 8 |

**The true remaining freehand count is 100, in 38 files** — not the 99 quoted in the
dispatch brief. The blind signature reads **0** in all four of these files both before
and after, so there is no overlap between my 40 and that 100: they are disjoint sets.

## Per-chain dispositions

All 40 take the same repair; none was left in place. `finish!` becomes
`teardown-clean!` and drops `done` — it is the SUCCESS arm's last act (the teardown
plus the residue read that must follow it). `fail-and-finish!` becomes
`report-failure!` (the name #7942 and #7951 chose), drops `done`, and returns nil.
Exactly one `done` sits at the tail with nothing after it.

| file | chains | outer sites repaired | nested catches absorbed |
|---|---|---|---|
| `controls_kit` | 8 | 5 | 3 |
| `splitter` | 9 | 4 | 5 |
| `typeahead_witness` | 12 | 7 | 5 |
| `virtual_collection` | 11 | 8 | 3 |
| **total** | **40** | **24** | **16** |

The 16 nested handlers are removed rather than rewritten. Every nested chain in these
files was already RETURNED into its parent, so the parent's single handler covers the
whole row — splitter's `parity!` carried three catches over three-deep nesting for one
row and now carries one. 24 sites serve 27 async rows, because three files route two
rows each through a shared helper (`exactly-one-commit-attempt!`, `parity!`,
`a-withheld-enter!`).

### The teardown is NOT hoisted, and is left correct

`ms/destroy-root!` stays written in both arms. It is not a duplication to hoist onto
the trailing step: `ms/residue-clean!` is **deliberately success-only** — a second
failure attributed to the leak rule would bury the one that actually happened — so the
failing arm does strictly LESS, and there is nothing common to lift. The residue read
must also run AFTER its own teardown, which pins it downstream of `destroy-root!` in
the success arm specifically.

That asymmetry is preserved in all four files and is worth the most in
`virtual_collection`, whose residue read carries three books beyond the facade's own
(the connected-occurrence index and two document reads); a hoisted teardown would have
had a failing row report three extra emptiness claims on top of its real failure.

### Helpers changed

Eight, two per file — `finish!` to `teardown-clean!` (drops `done`;
`virtual_collection`'s keeps its `where` label) and `fail-and-finish!` to
`report-failure!` (drops `done`, returns nil) in each of the four. Both names had
become lies: one no longer finishes, the other never did anything but report. The
long-form account is not copied four times — each cites
`re-frame.freehand.mount-support/each-mode`, the facade these files already share,
which has carried it since rf2-qpns.

`run-async` was NOT adopted: its generic message would replace each row's own
diagnostic.

One claim in the old `finish!` docstring did NOT hold at source, and is dropped rather
than carried forward — that a duplicate `done` is "invisible to the browser gate". It
has not been invisible since rf2-u0cy4 / #7190: `scripts/run-browser-tests.cjs`
promotes the duplicate-`done` warning literal to a FATAL console match, and
`duplicateDoneMatcherDrift` checks that literal against the installed
`cljs.test/run_block` on every run.

## Control evidence, both directions

A throwaway namespace sorting as a prefix extension of the target
(`...controls-kit-dom-cljs-test-zz-control-dom-cljs-test`), fn-form `:each` fixture
plus an async row, which makes `cljs.test` throw a bare String while the previous
namespace's `done` continuation is still on the stack.

**Reverted** (`controls_kit` only, from `origin/main`), `npm run test:browser` exited
**1** and printed this three times over:

```
Testing re-frame.freehand.controls-kit-dom-cljs-test-zz-control-dom-cljs-test
FAIL in (a-row-that-needs-async) (:)
the browser step rejected: Async tests require fixtures to be specified as maps.  Testing aborted.
```

The control namespace ANNOUNCED THREE TIMES; `fail-and-finish!`'s own message claiming
a foreign namespace's throw as its own row's failure, three times; then
`WARNING: Async test called done more than one time.` The run never reached a summary
line.

**Repaired**, same control: `the browser step rejected` claims **0**, control namespace
announced **once**, no re-run. The throw escapes these four files honestly.

The restore was verified BY HASHING THE BYTES (`sha256sum -c`, all four OK) before the
repaired run, and again after deleting the control.

### Handoff — reported, not widened

Repaired, the escaping throw is claimed one frame further down the stack by
`implementation/freehand/test/re_frame/freehand/controlled_input_matrix_dom_cljs_test.cljs:685`
(the class-routing cell), which double-fires `done` once. That chain is one of the 100
the BLIND signature already sees — it holds a literal `(done)` with a `.catch` after
it — so it is squarely inside `rf2-o0n1`'s existing scope, and this PR does not touch
it. `rf2-ua8r` saw the same handoff reach `implementation/adapters/reagent/`.

The mechanism is ordering: `controlled-input-matrix` sorts before `controls-kit`, so
its callback sits further down the stack, and the throw unwound past all four repaired
files to reach the nearest still-defective handler below them.

## Post-repair re-scan

All four files scan to **ZERO** under the corrected signature, and the freehand tree
drops from 140 to 100 — exactly the 40 removed, nothing else moved. Per file, the
`done`-tail sites, `teardown-clean!` sites and `report-failure!` sites are equal in
number (5/5/5, 4/4/4, 7/7/7, 8/8/8), so no row calls `done` twice and none is left
without one.

Parens balance-checked with a reader over every top-level form in all four files
(exit 0). The first pass was off by one closer on two tails; the checker caught both.

## Quality gates

Run from `implementation/`, each alone, output redirected, exit code captured on the
command line. Quoted numbers are the CAPTURED ones.

| gate | captured exit | result |
|---|---|---|
| `npm run test:browser` (baseline, this branch's own base, before any edit) | `BROWSER_BASE_EXIT=0` | Ran **1293** tests containing **8010** assertions. 0 failures, 0 errors. |
| `npm run test:freehand` | `FREEHAND_EXIT=0` | Ran 1406 tests containing 7786 assertions. 0 failures, 0 errors. |
| `npm run test:browser` (control REVERTED) | `CONTROL_REVERTED_EXIT=1` | reproduces the defect — see above. Expected red. |
| `npm run test:browser` (control REPAIRED) | `CONTROL_REPAIRED_EXIT=1` | 0 claims from these files; red only from the handoff row above. Expected red. |
| `npm run test:browser` (final, control deleted) | `BROWSER_FINAL_EXIT=0` | Ran **1293** tests containing **8010** assertions. 0 failures, 0 errors. |

The baseline is **8010**, measured on this branch's own base — not the 8008 several
beads still quote. The final run equals that baseline exactly: no deftest is added or
removed, so an unmoved count is the correct result. The final log carries zero
duplicate-`done` warnings and zero rejection claims.

No assertion was loosened. `scripts/check_fast_pr_gap.py --list` reports **97**
required checks the fast-PR spine does not decide, including every `docs.yml` job and
the repo-invariant suite; CI owns those.
