### PR TITLE
docs(hicasso): retire the :server deferral prose now that the policy is read (rf2-ggnp)

### DIFF
--- a/docs/design/hicasso/draft-guide/10-native-tier.md
+++ b/docs/design/hicasso/draft-guide/10-native-tier.md
@@ -244,9 +244,12 @@ a named declaration for tooling and tests; the raw escape is for migration and
 one-off dynamic cases.
 
 An intrinsic-headed `n/$` result can render deterministically on the server.
-A component-headed island defaults to Client-only and emits its declared
-fallback, or nothing, until explicitly marked Render and verified for
-hydration.
+A component-headed island reads its `:server` declaration. Under
+`{:server :render}` the island is the element type: it renders into the server
+response and hydrates against those bytes. Under the Client-only default it
+contributes nothing at all — there is no native `:fallback` option, so markup
+that should stand in for the region is written in the enclosing Hiccup, where
+it is ordinary Hicasso.
 
 ??? info "Using UIx"
     A rung-3 `defview` may return a UIx element, and a rung-4 island may be a

--- a/implementation/hicasso/test/re_frame/hicasso/three_way_parity_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/three_way_parity_cljs_test.cljs
@@ -65,15 +65,25 @@
 
   So this file lands the population and the DETERMINISTIC half of the
   band, which is the half a hosted runner is allowed to decide:
-  [[a-native-component-is-the-authors-own-function-and-costs-no-wrapper]]
+  [[a-declared-render-island-is-the-authors-own-function-and-costs-no-wrapper]]
   and [[the-convenience-layer-pays-a-per-render-price-the-native-tier-does-not]]
   read the two routes' construction cost as a structural fact rather
   than as a clock. That is a stronger reading than a timing, not a weaker
-  one: a native island and a handwritten React component are the SAME
-  element type with the SAME props object, so there is no interposed work
-  for a stopwatch to find. No number is transcribed into the ledger here;
-  the figures are this file's own, and the ledger row is `rf2-hic-089`'s
-  to transcribe, as D10–D13 were."
+  one: a `{:server :render}` island and a handwritten React component are
+  the SAME element type with the SAME props object, so there is no
+  interposed work for a stopwatch to find.
+
+  **The band is stated over the DECLARED arm, and the declaration is what
+  makes it comparable.** Since rf2-hic-046 the `:client-only` default
+  mints a gate rather than the author's function, so it costs one fiber
+  and one hook the declared arm does not — the ruled price of the
+  conservative default, and not a figure about `n/defcomponent`'s
+  construction. Every native fixture below therefore writes
+  `{:server :render}`, exactly as the UIx crossing declares its own.
+
+  No number is transcribed into the ledger here; the figures are this
+  file's own, and the ledger row is `rf2-hic-089`'s to transcribe, as
+  D10–D13 were."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.core :as rf]
@@ -378,17 +388,24 @@
                  rather than an exception hidden here")))))))
 
 ;; ---------------------------------------------------------------------------
-;; 3. Component identity — the native route's zero wrapper
+;; 3. Component identity — the declared `:render` arm's zero wrapper
 ;; ---------------------------------------------------------------------------
 ;;
 ;; This is the deterministic half of the island band. See the namespace
 ;; docstring: C7 is UNPINNED and its clock is rf2-hic-071's, but the
 ;; structural fact underneath it is decidable here and is the stronger
 ;; statement — there is no interposed work for a stopwatch to find.
+;;
+;; The subject is `{:server :render}`, which is what [[native-cell]]
+;; declares. The `:client-only` default answers a gate instead
+;; (rf2-hic-046), and a gate is a wrapper: one fiber and one hook between
+;; React and the author's function. Naming the arm is the whole of the
+;; qualification — the rows below are unchanged by it.
 
-(deftest a-native-component-is-the-authors-own-function-and-costs-no-wrapper
-  (testing "`n/defcomponent` answers a FUNCTION, and it is the element type
-            React reconciles on — not a wrapper holding one"
+(deftest a-declared-render-island-is-the-authors-own-function-and-costs-no-wrapper
+  (testing "`n/defcomponent` answers a FUNCTION, and under `{:server :render}`
+            it is the element type React reconciles on — not a wrapper
+            holding one"
     (is (fn? native-cell))
     (is (identical? native-cell (.-type (n/$ native-cell #js {:label "42"})))))
 
@@ -401,8 +418,9 @@
     (is (= ["label"] (vec (js/Object.keys (.-props (n/$ native-cell #js {:label "42"})))))))
 
   (testing "and the body runs when the function is CALLED — no fiber, no
-            hook, no shell. This is what `a native island costs what React
-            costs` means as a structural fact rather than a timing"
+            hook, no shell. This is what `a DECLARED native island costs
+            what React costs` means as a structural fact rather than a
+            timing"
     (let [el (native-cell #js {:label "42"})]
       (is (= "span" (.-type el)))
       (is (= "42" (.-children (.-props el))))))


### PR DESCRIPTION
Closes the prose half of `rf2-ggnp`. **The bead's four named obligations were already discharged by rf2-hic-046 (#7966)** — verified site by site, not assumed. What #7966 left behind is the other half, which this PR takes: a `:client-only` island now costs one fiber and one hook where it cost neither, and two places still priced the native tier as though the default were free.

## The hit list, with dispositions

`rf2-ggnp`'s note named three deferral statements in `native.cljc` (pre-#7966 lines 13, 365, 836) and a fence row (`native_fence_cljs_test.cljs` ~192). Each was read at source against `b6869d5150` (the commit that wrote them) and against `origin/main` today.

| Site (pre-#7966) | Then | Now | Disposition |
|---|---|---|---|
| `native.cljc:13` — headline example | `{:server :render}  ; recorded; read in Phase 3` | `; runs on the server too` | **Already retired by #7966.** No change |
| `native.cljc:20` — ns docstring | "the policy it records is **consulted by no runtime path yet**" | "the policy **decides what the component contributes to a server render**" | **Already retired by #7966.** No change |
| `native.cljc:365` — `declared-server` | `## What the policy does NOT yet do (Phase 3)` | `## And it is now READ (rf2-hic-046)`, with the history in the past tense | **Already retired by #7966. Left standing deliberately** — it is true, and it is where the reason the default matters (audit #7839) is recorded |
| `native.cljc:836` — `defcomponent` docstring | "**The policy is RECORDED and not yet consulted**" | "**The policy decides what a server render contains** (rf2-hic-046)" | **Already retired by #7966.** No change |
| `native_fence_cljs_test.cljs:192` — fence row | "**The policy is not yet consulted**: nothing in this tier branches on the field" | "the policy is now READ (rf2-hic-046): a Client-only island's body does not run there" | **Already retired by #7966.** The row still asserts something true — the marker records the declaration, which is a narrower claim than `native-ssr-dom-cljs-test`'s bytes. No change |

A tree-wide sweep for the claim in every spelling it took (`read in Phase 3`, `consulted by no…`, `not yet consulted`, `policy is RECORDED`) returns **zero hits outside `.beads`**. There is no surviving statement anywhere that the `:server` policy is unread.

## What this PR does change — the cost that moved

Two sites priced the native route as free without naming which arm they meant. Both are now arm-scoped. **No assertion changed and no mechanism was touched.**

- **`three_way_parity_cljs_test.cljs`** — the island band's deterministic half. Its fixtures already declare `{:server :render}` (that landed in `d3ce949ea8`), so the file's *subject* was always the declared arm; its prose was not. The ns docstring said "a native island and a handwritten React component are the SAME element type"; the section header read "the native route's zero wrapper"; one row said "This is what `a native island costs what React costs` means"; and the deftest was named `a-native-component-is-the-authors-own-function-and-costs-no-wrapper`. All four now name `{:server :render}`, and the ns docstring states the default's price outright — one fiber and one hook, the ruled price of the conservative default, and not a figure about `n/defcomponent`'s construction. The deftest is renamed to `a-declared-render-island-…`; its one cross-reference (the ns docstring) moves with it.
- **`draft-guide/10-native-tier.md`** — said a component-headed island "defaults to Client-only and emits its declared fallback, or nothing, until explicitly marked Render and verified for hydration". Wrong twice over: there is **no** `:fallback` on the native declaration, deliberately (`native.cljc`'s `mint-server-gate`: "**No `:fallback`, deliberately** — the sibling door has one and this one does not"), and the marking is built and witnessed. Rewritten to describe both arms as built.

## Reported, not actioned

- **`dispositions.md` HS-10 (`h/mount!`) has NO green witness and was not flipped.** Its target-policy cell names "the server render entry" as `h/mount!`'s recovery, and that door is still unbuilt: `git grep 'react-dom/server|renderToString|renderToStaticMarkup'` over `implementation/hicasso/src` returns **zero callers**, and `"server render entry"` appears in no source outside a freehand bench. `native_ssr_dom_cljs_test` names the rows it dispositions — HS-24 to HS-30 plus HS-19's composition rule — and HS-10 is not among them; it touches `mount!` nowhere. There is also no `h/mount!` server-call refusal id in `implementation/hicasso/src` for the row's own note 1 to witness. The row stays as it is.
- **`native.cljc`'s `n/lazy` docstring is `rf2-hic-041`'s, and was NOT touched.** Its lines about a `:reset-key` retry and "the server carries the fallback" are already rewritten on the unmerged `worker/lazy-hic041` (commit `8800a89c17`, same file). Deliberately left alone to avoid a conflict on a live worker's surface.
- **No behavioural gap appeared, so nothing was stopped for.** The mechanism, the two rosters and the two complaint ids are untouched; no export added; I9 stays at two hooks.

## Quality gates

Each run alone, exit code captured on the same command line, `*.exit` artefacts deleted between runs.

| Gate | Captured exit |
|---|---|
| `npm --prefix implementation run test:hicasso-invariants` | **0** — 35 ledger rows, 74 live complaints, every anchor resolves |
| `npm --prefix implementation run test:cljs` (node lane) **on the base**, `HEAD~1` | **0** — `Ran 13462 tests containing 67895 assertions. 0 failures, 0 errors.` |
| `npm --prefix implementation run test:cljs` (node lane) **with this diff** | **0** — `Ran 13462 tests containing 67895 assertions. 0 failures, 0 errors.` |
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | **0** |

The base run is quoted because the counts are the claim: the diff adds and removes **no** assertion, and base and tip are identical on both numbers. `three_way_parity_cljs_test` is in the lane — `out/node-test.js` references `three_way_parity_cljs_test.js`.

`python scripts/check_fast_pr_gap.py --list` reports **97 required checks the fast-PR spine does not decide**. For this diff the ones that matter are `docs.yml`'s MkDocs build (which does **not** cover `docs/design/**` — `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site, so `check_doc_slugs.py` and `check_provenance_pins.py` above are what validate the page) and the browser lane. **The browser lane is not reached by this diff**: `three_way_parity_dom_cljs_test.cljs` is untouched, and nothing here changes a DOM claim.
