### PR TITLE
test(freehand): a suite's cleanup must not outlive its own test (rf2-o0n1)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence_dom_cljs_test.cljs
@@ -239,5 +239,10 @@
                               paint, which is why the guide teaches an
                               animation on insertion for enter and keeps the
                               override for exit")
-                         (finally (mount/release! handle) (done)))))
-              (.catch (fn [e] (is false (str e)) (done)))))))))
+                         (finally (mount/release! handle)))))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str e)) nil))
+              (.then (fn [_] (done)))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/instance_key_payload_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/instance_key_payload_dom_cljs_test.cljs
@@ -394,8 +394,15 @@
                               :warnings   (count warnings)
                               :panels     (panel-count container)
                               :open-after? (some? (open-panel-in container))})
-                    (finally (mount/release! handle) (done)))))
-              (.catch (fn [e] (is false (str "row 1 threw: " e)) (done)))))))))
+                    (finally (mount/release! handle)))))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time. The release stays in the
+              ;; `finally`: it is the success arm's, and only that arm was ever
+              ;; handed a handle.
+              (.catch (fn [e] (is false (str "row 1 threw: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; ROW 2 — RED BY DESIGN. The obligation broken, and caught.
@@ -480,5 +487,7 @@
                               :where      (str (:where (tags-of (first mismatches))))
                               :panels     (panel-count container)
                               :open-after? (some? (open-panel-in container))})
-                    (finally (mount/release! handle) (done)))))
-              (.catch (fn [e] (is false (str "row 2 threw: " e)) (done)))))))))
+                    (finally (mount/release! handle)))))
+              ;; Reports and RELEASES, as above.
+              (.catch (fn [e] (is false (str "row 2 threw: " e)) nil))
+              (.then (fn [_] (done)))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/spike_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/spike_cljs_test.cljs
@@ -139,9 +139,13 @@
                         ;; rf2-2rtt6.91 — the published column, taken where
                         ;; the fact lives now that the entry emits none.
                         :render-hash  (str (ssr-hash/render-tree-hash
-                                             (:hiccup (fixtures/row dogfood-row-id))))})
-              (done)))
-          (.catch (fn [e] (is false (str "X1(a) threw: " e)) (done)))))))
+                                             (:hiccup (fixtures/row dogfood-row-id))))})))
+          ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs the
+          ;; whole remainder of the run synchronously, so a `.catch` downstream
+          ;; of it would claim a later namespace's throw as this row's and fire
+          ;; `done` a second time.
+          (.catch (fn [e] (is false (str "X1(a) threw: " e)) nil))
+          (.then (fn [_] (done)))))))
 
 (deftest a-different-snapshot-renders-a-different-document
   (testing "**the mutation proof for X1(a).** Byte-identity is a claim two
@@ -158,9 +162,10 @@
         (-> (js/Promise.all #js [(sha256-hex eight) (sha256-hex nine)])
             (.then (fn [[h8 h9]]
                      (is (not= h8 h9))
-                     (report! "X1a-mutation" {:seed-8 h8 :seed-9 h9})
-                     (done)))
-            (.catch (fn [e] (is false (str "the mutation proof threw: " e)) (done))))))))
+                     (report! "X1a-mutation" {:seed-8 h8 :seed-9 h9})))
+            ;; Reports and RELEASES, as above.
+            (.catch (fn [e] (is false (str "the mutation proof threw: " e)) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest the-byte-digest-separates-the-two-pages-render-hash-cannot
   (testing "**the non-vacuity control, taken against the hash this tier
@@ -196,6 +201,7 @@
                               {:render-hash-shared (str dog-h)
                                :render-hash-on-wire "absent"
                                :dogfood-sha256     hd
-                               :conduit-sha256     hc})
-                     (done)))
-            (.catch (fn [e] (is false (str "the control threw: " e)) (done))))))))
+                               :conduit-sha256     hc})))
+            ;; Reports and RELEASES, as above.
+            (.catch (fn [e] (is false (str "the control threw: " e)) nil))
+            (.then (fn [_] (done))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/spike_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/spike_dom_cljs_test.cljs
@@ -578,9 +578,13 @@
                                :intents        (count (:intents hydrated-run))
                                :intents-match? (= script/interaction-intents
                                                   (:intents hydrated-run))
-                               :dom-match?     (= (:dom cold-run) (:dom hydrated-run))})
-                (done)))
-            (.catch (fn [e] (is false (str "X4 threw: " e)) (done))))))))
+                               :dom-match?     (= (:dom cold-run) (:dom hydrated-run))})))
+            ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+            ;; the whole remainder of the run synchronously, so a `.catch`
+            ;; downstream of it would claim a later namespace's throw as this
+            ;; row's and fire `done` a second time.
+            (.catch (fn [e] (is false (str "X4 threw: " e)) nil))
+            (.then (fn [_] (done))))))))
 
 (deftest x4-typing-after-adoption-echoes-in-the-callers-turn
   (testing "**HD-019 on the hydrated path.** Hydration converged nothing —
@@ -680,16 +684,31 @@
                 (.then
                   (fn [[survivor doomed]]
                     (mount/unmount! (:handle doomed))
-                    (js/setTimeout
-                      (fn []
-                        (is (not= nothing-retained (rt/residue))
-                            "a live adopted screen is visible to the residue
-                             reading")
-                        (is (pos? (:cell-refs (rt/residue)))
-                            "and it is visible as held references, which is the
-                             quantity X5 asserts to be zero")
-                        (mount/release! (:handle survivor))
-                        (done))
-                      reaper-horizon-ms)))
-                (.catch (fn [e] (is false (str "the X5 mutation proof threw: " e))
-                          (done))))))))))
+                    ;; The reaper's horizon is a MACROTASK, and the row has to
+                    ;; AWAIT it rather than let a bare timer carry the
+                    ;; assertions off the end of the chain. Returned as a
+                    ;; promise they stay UPSTREAM of the rejection handler
+                    ;; below, so the single `done` sits at the tail with
+                    ;; nothing after it, and a throw in here reaches this row's
+                    ;; own diagnostic instead of hanging the lane.
+                    (js/Promise.
+                      (fn [resolve reject]
+                        (js/setTimeout
+                          (fn []
+                            (try
+                              (is (not= nothing-retained (rt/residue))
+                                  "a live adopted screen is visible to the residue
+                                   reading")
+                              (is (pos? (:cell-refs (rt/residue)))
+                                  "and it is visible as held references, which is
+                                   the quantity X5 asserts to be zero")
+                              (mount/release! (:handle survivor))
+                              (resolve nil)
+                              (catch :default e (reject e))))
+                          reaper-horizon-ms)))))
+                ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done`
+                ;; runs the whole remainder of the run synchronously, so a
+                ;; `.catch` downstream of it would claim a later namespace's
+                ;; throw as this row's and fire `done` a second time.
+                (.catch (fn [e] (is false (str "the X5 mutation proof threw: " e)) nil))
+                (.then (fn [_] (done))))))))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_update_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_update_dom_cljs_test.cljs
@@ -241,13 +241,16 @@
                          (is (= "8484" (rows/cell-text container 0))
                              "and the measured window — write, one microtask,
                               forced drain — still lands its write too")
-                         ((:unmount arm) mounted)
-                         (.remove container)
-                         (done)))
-                (.catch (fn [e]
-                          (is false (str "rejected: " e))
-                          (.remove container)
-                          (done))))))))))
+                         ;; ASYMMETRIC, so it stays put: the rejection arm never
+                         ;; unmounted this root, and the detach both arms DID
+                         ;; share rides the single trailing step below.
+                         ((:unmount arm) mounted)))
+                ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done`
+                ;; runs the whole remainder of the run synchronously, so a
+                ;; `.catch` downstream of it would claim a later namespace's
+                ;; throw as this row's and fire `done` a second time.
+                (.catch (fn [e] (is false (str "rejected: " e)) nil))
+                (.then (fn [_] (.remove container) (done))))))))))
 
 (deftest the-fixture-is-what-it-says-it-is
   (testing "Arithmetic over the fixture, so a reader can check the row's

--- a/implementation/freehand/test/re_frame/freehand/buffered_controller_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/buffered_controller_dom_cljs_test.cljs
@@ -242,17 +242,19 @@
                             (is (identical? before (node container))
                                 "and it came back on the SAME node — restored, not remounted")
                             (is (identical? before (.-activeElement js/document))
-                                "which still has focus")
-                            (teardown! container root)
-                            (done)))
-                        (.catch (fn [e]
-                                  (is false (str "the rejection rejected: " e))
-                                  (teardown! container root)
-                                  (done)))))))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                                "which still has focus")))
+                        ;; The inner chain keeps its OWN diagnostic but finishes
+                        ;; nothing; it is returned into the outer chain, whose
+                        ;; single trailing step below owns the one `done`.
+                        (.catch (fn [e] (is false (str "the rejection rejected: " e)) nil))))))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              ;; Every arm tore the mount down identically, so the teardown rides
+              ;; the single trailing step: written once, run once per path.
+              (.then (fn [_] (teardown! container root) (done)))))))))
 
 (deftest fh-ctrl-011-editing-resumes-at-the-new-generation
   (testing "Per FH-CTRL-011: after the rejection the user types again.
@@ -284,17 +286,14 @@
                                    (caret field))
                                 "and the caret followed the insert")
                             (is (= (:expected resume) (draft))
-                                "the new draft is live controller state again")
-                            (teardown! container root)
-                            (done)))
-                        (.catch (fn [e]
-                                  (is false (str "the rejection rejected: " e))
-                                  (teardown! container root)
-                                  (done)))))))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                                "the new draft is live controller state again")))
+                        ;; Inner chain: its own diagnostic, but it finishes
+                        ;; nothing and is returned into the outer chain.
+                        (.catch (fn [e] (is false (str "the rejection rejected: " e)) nil))))))
+              ;; Reports and RELEASES, as above.
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              ;; Shared teardown, hoisted onto the single trailing step.
+              (.then (fn [_] (teardown! container root) (done)))))))))
 
 ;; ===========================================================================
 ;; FH-CTRL-011 — IME composition through the draft
@@ -348,10 +347,8 @@
                     (is (= final (.-value field)) "the composition committed intact")
                     (is (= final (draft)) "and reached the draft")
                     (is (identical? before (node container))
-                        "on the same node it started on"))
-                  (teardown! container root)
-                  (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                        "on the same node it started on"))))
+              ;; Reports and RELEASES, as above.
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              ;; Shared teardown, hoisted onto the single trailing step.
+              (.then (fn [_] (teardown! container root) (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/client_only_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/client_only_dom_cljs_test.cljs
@@ -129,26 +129,43 @@
           (-> (act #(v/mount [views/two-sites props] container))
               (.then
                 (fn [mounted]
-                  (settle
-                    (fn []
-                      (trace-tooling/unregister-listener! k)
-                      (doseq [[selector t] expected]
-                        (is (= t (text container selector))
-                            (str selector " shows its CLIENT subtree on the first render")))
-                      (is (= flips (count @flip-evs))
-                          (str "a non-hydrating mount never flips. Saw: " (pr-str @flip-evs)))
-                      (is (false? (root/hydrated? mounted))
-                          "and it is not a hydration")
-                      (v/unmount! mounted)
-                      (.remove container)
-                      (reset-all!)
-                      (done)))))
+                  ;; `settle` is a bare timer, so what it carries has to be
+                  ;; AWAITED or it runs off the end of the chain. Returned as a
+                  ;; promise these assertions stay UPSTREAM of the rejection
+                  ;; handler below — the single `done` sits at the tail with
+                  ;; nothing after it — and a throw in here reaches this row's
+                  ;; own diagnostic instead of hanging the lane (rf2-o0n1).
+                  (js/Promise.
+                    (fn [resolve reject]
+                      (settle
+                        (fn []
+                          (try
+                            (trace-tooling/unregister-listener! k)
+                            (doseq [[selector t] expected]
+                              (is (= t (text container selector))
+                                  (str selector " shows its CLIENT subtree on the first render")))
+                            (is (= flips (count @flip-evs))
+                                (str "a non-hydrating mount never flips. Saw: " (pr-str @flip-evs)))
+                            (is (false? (root/hydrated? mounted))
+                                "and it is not a hydration")
+                            ;; Success-only: `mounted` is what the mount
+                            ;; resolved with, and the rejection arm never had a
+                            ;; root to unmount.
+                            (v/unmount! mounted)
+                            (resolve nil)
+                            (catch :default e (reject e)))))))))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time. The unregister is written
+              ;; on both arms rather than hoisted: the success arm has to drop
+              ;; the listener BEFORE it counts what the listener collected.
               (.catch (fn [e]
                         (trace-tooling/unregister-listener! k)
                         (is false (str "mount rejected: " e))
-                        (.remove container)
-                        (reset-all!)
-                        (done)))))))))
+                        nil))
+              ;; Shared teardown, hoisted onto the single trailing step.
+              (.then (fn [_] (.remove container) (reset-all!) (done)))))))))
 
 ;; ===========================================================================
 ;; A hydrating root adopts the fallbacks, then flips ONCE

--- a/implementation/freehand/test/re_frame/freehand/collection_applications_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/collection_applications_dom_cljs_test.cljs
@@ -113,9 +113,19 @@
                     [["every row node in the document"
                       #(.-length (.querySelectorAll js/document "[data-part='row']"))]
                      ["every controlled cell in the document"
-                      #(.-length (.querySelectorAll js/document "input.acme-grid-cell"))]])
-                  (done)))
+                      #(.-length (.querySelectorAll js/document "input.acme-grid-cell"))]])))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              ;;
+              ;; The teardown is NOT hoisted onto the trailing step, and cannot
+              ;; be: the success arm's `ms/residue-clean!` has to read the
+              ;; document AFTER `ms/destroy-root!`, and it is success-only
+              ;; because a second failure attributed to the leak rule would bury
+              ;; the one that actually happened.
               (.catch (fn [e]
                         (is false (str "the editing-grid mount rejected: " e))
                         (ms/destroy-root! container root)
-                        (done)))))))))
+                        nil))
+              (.then (fn [_] (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/compiled_keyed_run_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/compiled_keyed_run_dom_cljs_test.cljs
@@ -156,11 +156,13 @@
                      (is (false? fallback?)
                          "so the boundary's fallback is not on screen")
                      (is (= inherited-names keys)
-                         "and every poison-keyed row rendered, in order")
-                     (done)))
-            (.catch (fn [e]
-                      (is false (str "the poison-keyed mount rejected: " e))
-                      (done))))))))
+                         "and every poison-keyed row rendered, in order")))
+            ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+            ;; the whole remainder of the run synchronously, so a `.catch`
+            ;; downstream of it would claim a later namespace's throw as this
+            ;; row's and fire `done` a second time.
+            (.catch (fn [e] (is false (str "the poison-keyed mount rejected: " e)) nil))
+            (.then (fn [_] (done))))))))
 
 ;; ===========================================================================
 ;; A repeat of one is still a duplicate
@@ -216,11 +218,10 @@
             (.then (fn [{:keys [keys error]}]
                      (is (nil? error)
                          "non-vacuous: keys that differ AFTER coercion do not collide")
-                     (is (= ["1" "2" "3"] keys) "and all three rendered")
-                     (done)))
-            (.catch (fn [e]
-                      (is false (str "the coercion sweep rejected: " e))
-                      (done))))))))
+                     (is (= ["1" "2" "3"] keys) "and all three rendered")))
+            ;; Reports and RELEASES, as above.
+            (.catch (fn [e] (is false (str "the coercion sweep rejected: " e)) nil))
+            (.then (fn [_] (done))))))))
 
 ;; ===========================================================================
 ;; The two tiers agree, row for row (runs on every host)

--- a/implementation/freehand/test/re_frame/freehand/compiled_slot_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/compiled_slot_dom_cljs_test.cljs
@@ -136,18 +136,27 @@
 
 (defn- mounted!
   "Mount `form` into a fresh host node, run `check` against the container,
-  and tear the root down whatever happens."
+  and tear the root down whatever happens.
+
+  The rejection handler sits UPSTREAM of the step that calls `done`, and the
+  single `done` sits at the tail with nothing after it (rf2-o0n1). `done` runs
+  the whole remainder of the run synchronously, so a `.catch` downstream of it
+  would claim a later namespace's throw as this row's failure and fire `done` a
+  second time."
   [form check done]
   (let [container (host-node!)]
     (-> (act #(v/mount form container))
         (.then (fn [m]
                  (check container)
-                 (unmount! container m)
-                 (done)))
+                 ;; ASYMMETRIC, so it stays put: `m` is what the mount resolved
+                 ;; with, and the rejection arm never had a root to unmount —
+                 ;; it can only detach the host node, which it does below.
+                 (unmount! container m)))
         (.catch (fn [e]
                   (is false (str "compiled slot mount rejected: " e))
                   (.remove container)
-                  (done))))))
+                  nil))
+        (.then (fn [_] (done))))))
 
 (deftest an-inline-render-fn-renders-its-content-in-the-dom
   (testing "The render-fn's body is lowered by the SAME emitter that

--- a/implementation/freehand/test/re_frame/freehand/controlled_input_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/controlled_input_dom_cljs_test.cljs
@@ -650,7 +650,12 @@
               errors  (atom [])
               restore (spy-console-errors! errors)
               picked  (fn [n] (mapv #(.-value %) (array-seq (.-selectedOptions n))))
-              finish  (fn [] (restore) (teardown! container root) (done))]
+              ;; Tears down; it does NOT finish. A closure that CLOSES OVER
+              ;; `done` finishes the row just as a literal `(done)` does — and
+              ;; is invisible to both campaign signatures, which look for a
+              ;; literal call or a helper that TAKES `done` as a parameter
+              ;; (rf2-o0n1). The single `done` sits at the tail below.
+              release (fn [] (restore) (teardown! container root) nil)]
           (-> (render-multi-select-page! root {:picked nil})
               (.then
                 (fn [_]
@@ -685,11 +690,15 @@
                                     (is (= [] (value-shape-complaints @errors))
                                         (str "and the mount's shape verdict still stands, "
                                              "unchanged by anything since: "
-                                             (pr-str @errors)))
-                                    (finish))))))))))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (finish)))))))))
+                                             (pr-str @errors))))))))))))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of a step that finished the row would claim a later
+              ;; namespace's throw as this row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              ;; Both arms released identically, so it rides the single trailing
+              ;; step: written once, run once per path.
+              (.then (fn [_] (release) (done)))))))))
 
 ;; ===========================================================================
 ;; THE CONTROL FOR THE CONSOLE ITSELF — declared LAST, and that is the point
@@ -750,7 +759,8 @@
               [container root] (mount!)
               errors  (atom [])
               restore (spy-console-errors! errors)
-              finish  (fn [] (restore) (teardown! container root) (done))]
+              ;; Tears down; it does NOT finish — as above.
+              release (fn [] (restore) (teardown! container root) nil)]
           (-> (render-slot-dropping-page! root {:text seed})
               (.then
                 (fn [_]
@@ -772,8 +782,8 @@
                                      "PAGE, so something above this row already spent it "
                                      "— which means every `React said nothing` row in "
                                      "this namespace was unable to fail. Captured: "
-                                     (pr-str @errors)))
-                            (finish)))))))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (finish)))))))))
+                                     (pr-str @errors)))))))))
+              ;; Reports and RELEASES, as above.
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              ;; Shared release, hoisted onto the single trailing step.
+              (.then (fn [_] (release) (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/controlled_input_matrix_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/controlled_input_matrix_dom_cljs_test.cljs
@@ -300,15 +300,15 @@
                          (is (re-find #"data-component=\"acme/invoice-line\"" shared)
                              "non-vacuous: the shared outline really is the invoice line")
                          (is (re-find #"REF-1" shared)
-                             "and it carries the seeded buffered value"))
-                       (ms/destroy-root! ci ri)
-                       (ms/destroy-root! cc rc)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "a controlled mount rejected: " e))
-                        (ms/destroy-root! ci ri)
-                        (ms/destroy-root! cc rc)
-                        (done)))))))))
+                             "and it carries the seeded buffered value"))))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str "a controlled mount rejected: " e)) nil))
+              ;; Both arms tore both roots down, identically, so the teardown
+              ;; rides the single trailing step: written once, run once per path.
+              (.then (fn [_] (ms/destroy-root! ci ri) (ms/destroy-root! cc rc) (done)))))))))
 
 ;; ===========================================================================
 ;; Row 2 — a keystroke burst echoes character-for-character, both modes
@@ -653,15 +653,11 @@
                            (check ci "interpreted")
                            (check cc "compiled")
                            (ms/outlines-agree? (ms/q ci "input") (ms/q cc "input")
-                                               "v/spread-safe guarded caller")
-                           (ms/destroy-root! ci ri)
-                           (ms/destroy-root! cc rc)
-                           (done)))
-                  (.catch (fn [e]
-                            (is false (str "a spread-safe mount rejected: " e))
-                            (ms/destroy-root! ci ri)
-                            (ms/destroy-root! cc rc)
-                            (done)))))))))))
+                                               "v/spread-safe guarded caller")))
+                  ;; Reports and RELEASES, as above.
+                  (.catch (fn [e] (is false (str "a spread-safe mount rejected: " e)) nil))
+                  ;; Shared teardown, hoisted onto the single trailing step.
+                  (.then (fn [_] (ms/destroy-root! ci ri) (ms/destroy-root! cc rc) (done)))))))))))
 
 ;; ===========================================================================
 ;; Cell C — a routed :class one-map collision AGREES across modes (rf2-c9kus)
@@ -689,12 +685,8 @@
                              cclass (.getAttribute (ms/q cc "div") "class")]
                          (is (= ic cclass)
                              (str "interpreted and compiled agree on the rendered class "
-                                  "(interpreted=" (pr-str ic) " compiled=" (pr-str cclass) ")")))
-                       (ms/destroy-root! ci ri)
-                       (ms/destroy-root! cc rc)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "a class-routing mount rejected: " e))
-                        (ms/destroy-root! ci ri)
-                        (ms/destroy-root! cc rc)
-                        (done)))))))))
+                                  "(interpreted=" (pr-str ic) " compiled=" (pr-str cclass) ")")))))
+              ;; Reports and RELEASES, as above.
+              (.catch (fn [e] (is false (str "a class-routing mount rejected: " e)) nil))
+              ;; Shared teardown, hoisted onto the single trailing step.
+              (.then (fn [_] (ms/destroy-root! ci ri) (ms/destroy-root! cc rc) (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/custom_element_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/custom_element_dom_cljs_test.cljs
@@ -230,13 +230,16 @@
                        (act #(.render root (fr/element [accent-host-literal {}])))))
               (.then (fn [_]
                        (assert-classified! (.querySelector container (:tag dom-row)) "literal")
-                       (.unmount root)
-                       (.remove container)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " (some-> e ex-message)))
-                        (.remove container)
-                        (done)))))))))
+                       ;; ASYMMETRIC, so it stays put: the rejection arm never
+                       ;; unmounted this root. The container detach both arms
+                       ;; DID share rides the single trailing step below.
+                       (.unmount root)))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str "mount rejected: " (some-> e ex-message))) nil))
+              (.then (fn [_] (.remove container) (done)))))))))
 
 (deftest fh-struct-011-the-on-family-declaration-is-live
   (testing "Per FH-STRUCT-011: the `on-*` rows are evidence only if the

--- a/implementation/freehand/test/re_frame/freehand/error_matrix_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/error_matrix_dom_cljs_test.cljs
@@ -195,12 +195,12 @@
                        (ms/outlines-agree? (ms/q ci "#fallback") (ms/q cc "#fallback")
                                            "contained fallback")
                        (is (= "contained" (ms/text-of ci "#fallback"))
-                           "non-vacuous: the fallback really is on screen")
-                       (ms/destroy-root! ci ri)
-                       (ms/destroy-root! cc rc)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "a boundary mount rejected: " e))
-                        (ms/destroy-root! ci ri)
-                        (ms/destroy-root! cc rc)
-                        (done)))))))))
+                           "non-vacuous: the fallback really is on screen")))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str "a boundary mount rejected: " e)) nil))
+              ;; Both arms tore both roots down, identically, so the teardown
+              ;; rides the single trailing step: written once, run once per path.
+              (.then (fn [_] (ms/destroy-root! ci ri) (ms/destroy-root! cc rc) (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/host_mounted_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/host_mounted_dom_cljs_test.cljs
@@ -422,11 +422,16 @@
                          whatever owns the frame now"))
                   (is (= 0 (:live-panels @ledger))
                       "and the registered component's own cleanup ran")
-                  (released! "FH-REACT-007 — after the mounted crossing unmounts")
-                  (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (done)))))))))
+                  ;; Success-only, and deliberately: a residue reading taken
+                  ;; after a failure would bury the failure that actually
+                  ;; happened under a second one about the leak rule.
+                  (released! "FH-REACT-007 — after the mounted crossing unmounts")))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 (deftest d022-a-hosts-callback-does-not-fire-into-its-successor
   (testing "D022 acceptance 1, the retirement half that unmount alone cannot
@@ -471,14 +476,14 @@
                                  ;; successor — are read here, which is what
                                  ;; the ledger buys: a remount that tore down
                                  ;; only the second would red on the first.
-                                 (released! "FH-REACT-007 — after the remount unmounts")
-                                 (done)))
-                        (.catch (fn [e]
-                                  (is false (str "remount rejected: " e))
-                                  (done)))))))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (done)))))))))
+                                 (released! "FH-REACT-007 — after the remount unmounts")))
+                        ;; The inner chain keeps its OWN diagnostic but finishes
+                        ;; nothing; it is returned into the outer chain, whose
+                        ;; trailing step owns the row's one `done`.
+                        (.catch (fn [e] (is false (str "remount rejected: " e)) nil))))))
+              ;; Reports and RELEASES, as above.
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; D022 acceptance 4 — the value/callback witness, through the same verb
@@ -514,11 +519,11 @@
                        re-frame event")
                   (ms/act #(teardown! container mounted))))
               (.then (fn [_]
-                       (released! "FH-REACT-007 — after the chart unmounts")
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (done)))))))))
+                       ;; Success-only, as above.
+                       (released! "FH-REACT-007 — after the chart unmounts")))
+              ;; Reports and RELEASES, as above.
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; The key-set law, browser half — a `:map-props` adapter answers the

--- a/implementation/freehand/test/re_frame/freehand/ownership_maps_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/ownership_maps_dom_cljs_test.cljs
@@ -471,9 +471,18 @@
                        (is (= (:after-reclamation behavior-010) (absence))
                            "FH-BEHAVIOR-010 — zero maps, zero listeners, zero
                             overlays, zero roots, and both substrate books empty")
-                       (released! "FH-BEHAVIOR-010 — after the ordinary teardown")
-                       (done)))
-              (.catch (fn [e] (is false (str "case rejected: " e)) (done)))))))))
+                       (released! "FH-BEHAVIOR-010 — after the ordinary teardown")))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              ;;
+              ;; Nothing is hoisted onto the trailing step: the node removal and
+              ;; the two residue readings are the SUCCESS arm's, and a second
+              ;; failure attributed to the leak rule would bury the one that
+              ;; actually happened.
+              (.catch (fn [e] (is false (str "case rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; 2 — the reclamation orders, all three, through the ONE path
@@ -591,6 +600,8 @@
                        (is (= (:after-reclamation behavior-010) (absence))
                            "FH-BEHAVIOR-010 — and the same absence as every other route,
                             reached one task later than the substrate's")
-                       (released! "FH-BEHAVIOR-010 — after the deferred release")
-                       (done)))
-              (.catch (fn [e] (is false (str "case rejected: " e)) (done)))))))))
+                       (released! "FH-BEHAVIOR-010 — after the deferred release")))
+              ;; Reports and RELEASES, as above; nothing to hoist for the same
+              ;; reason.
+              (.catch (fn [e] (is false (str "case rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/ownership_motion_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/ownership_motion_dom_cljs_test.cljs
@@ -342,9 +342,18 @@
                        (ms/remove-node! container)
                        (is (= (:after-unmount react-010)
                               {:roots (count (root/live-root-ids))}))
-                       (released! "FH-REACT-010 — after the uncontested case")
-                       (done)))
-              (.catch (fn [e] (is false (str "case rejected: " e)) (done)))))))))
+                       (released! "FH-REACT-010 — after the uncontested case")))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              ;;
+              ;; Nothing is hoisted onto the trailing step: the node removal and
+              ;; the residue reading are the SUCCESS arm's, and a second failure
+              ;; attributed to the leak rule would bury the one that actually
+              ;; happened.
+              (.catch (fn [e] (is false (str "case rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; 2 — two writers: the commit wins, and the library does not know
@@ -399,9 +408,11 @@
                   (ms/act (fn [] (v/unmount! mounted) nil))))
               (.then (fn [_]
                        (ms/remove-node! container)
-                       (released! "FH-REACT-010 — after the contested case")
-                       (done)))
-              (.catch (fn [e] (is false (str "case rejected: " e)) (done)))))))))
+                       (released! "FH-REACT-010 — after the contested case")))
+              ;; Reports and RELEASES, as above; nothing to hoist for the same
+              ;; reason.
+              (.catch (fn [e] (is false (str "case rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; 3 — one exit-retention owner
@@ -462,6 +473,8 @@
                        (ms/remove-node! container)
                        (is (= (:after-unmount react-010)
                               {:roots (count (root/live-root-ids))}))
-                       (released! "FH-REACT-010 — after the retention case")
-                       (done)))
-              (.catch (fn [e] (is false (str "case rejected: " e)) (done)))))))))
+                       (released! "FH-REACT-010 — after the retention case")))
+              ;; Reports and RELEASES, as above; nothing to hoist for the same
+              ;; reason.
+              (.catch (fn [e] (is false (str "case rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/ownership_radix_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/ownership_radix_dom_cljs_test.cljs
@@ -397,9 +397,18 @@
                       "FH-REACT-009 — and nothing survived, INCLUDING the node
                        React put outside the container, which no container-scoped
                        teardown would have reached")
-                  (released! "FH-REACT-009 — after the compound teardown")
-                  (done)))
-              (.catch (fn [e] (is false (str "case rejected: " e)) (done)))))))))
+                  (released! "FH-REACT-009 — after the compound teardown")))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              ;;
+              ;; Nothing is hoisted onto the trailing step: the node removal and
+              ;; the residue readings are the SUCCESS arm's, and a second failure
+              ;; attributed to the leak rule would bury the one that actually
+              ;; happened.
+              (.catch (fn [e] (is false (str "case rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; 2 — the withheld promise, measured
@@ -449,6 +458,8 @@
               (.then
                 (fn [_]
                   (ms/remove-node! container)
-                  (released! "FH-REACT-009 — after the clone probes")
-                  (done)))
-              (.catch (fn [e] (is false (str "case rejected: " e)) (done)))))))))
+                  (released! "FH-REACT-009 — after the clone probes")))
+              ;; Reports and RELEASES, as above; nothing to hoist for the same
+              ;; reason.
+              (.catch (fn [e] (is false (str "case rejected: " e)) nil))
+              (.then (fn [_] (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/pilot_theming_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_theming_dom_cljs_test.cljs
@@ -82,7 +82,10 @@
                                " { color: rgb(9, 105, 218); }"))
               container  (container! nil)
               root       (rdc/createRoot container)
-              cleanup    (fn [] (.remove style) (.remove container) (done))]
+              ;; Cleans up; it does NOT finish. A closure that CLOSES OVER
+              ;; `done` finishes the row exactly as a literal `(done)` does
+              ;; (rf2-o0n1); the single `done` sits at the tail below.
+              cleanup    (fn [] (.remove style) (.remove container) nil)]
           (-> (act #(.render root (fr/element [chip-lib/chip {:label "Ready"}])))
               (.then (fn [_]
                        (let [label (.querySelector container "[data-part=\"label\"]")]
@@ -90,8 +93,14 @@
                          (is (= (norm "rgb(9, 105, 218)") (norm (computed label "color")))
                              "the part-targeted rule reaches the label's computed style"))
                        (act #(.unmount root))))
-              (.then (fn [_] (cleanup)))
-              (.catch (fn [e] (is false (str "mount rejected: " e)) (cleanup)))))))))
+              ;; Reports and RELEASES; it never finishes. `done` runs the whole
+              ;; remainder of the run synchronously, so a `.catch` downstream of
+              ;; a step that finished the row would claim a later namespace's
+              ;; throw as this row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              ;; Both arms cleaned up identically, so it rides the single
+              ;; trailing step: written once, run once per path.
+              (.then (fn [_] (cleanup) (done)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The token plane — an inline custom property resolves through var()
@@ -107,7 +116,10 @@
                           "[data-part=\"dot\"] { background-color: var(--acme-chip-accent); }")
               container  (container! nil)
               root       (rdc/createRoot container)
-              cleanup    (fn [] (.remove style) (.remove container) (done))]
+              ;; Cleans up; it does NOT finish. A closure that CLOSES OVER
+              ;; `done` finishes the row exactly as a literal `(done)` does
+              ;; (rf2-o0n1); the single `done` sits at the tail below.
+              cleanup    (fn [] (.remove style) (.remove container) nil)]
           (-> (act #(.render root (fr/element [chip-lib/chip {:label "Ready"
                                                               :accent "rgb(1, 2, 3)"}])))
               (.then (fn [_]
@@ -116,8 +128,14 @@
                          (is (= (norm "rgb(1, 2, 3)") (norm (computed dot "background-color")))
                              "the inline token resolves on the dot's computed style"))
                        (act #(.unmount root))))
-              (.then (fn [_] (cleanup)))
-              (.catch (fn [e] (is false (str "mount rejected: " e)) (cleanup)))))))))
+              ;; Reports and RELEASES; it never finishes. `done` runs the whole
+              ;; remainder of the run synchronously, so a `.catch` downstream of
+              ;; a step that finished the row would claim a later namespace's
+              ;; throw as this row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              ;; Both arms cleaned up identically, so it rides the single
+              ;; trailing step: written once, run once per path.
+              (.then (fn [_] (cleanup) (done)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The cascade — a theme switch recolours without a re-render
@@ -136,7 +154,10 @@
                                " [data-theme=\"dark\"]  { --acme-chip-bg: rgb(20, 20, 20); }"))
               container  (container! "light")
               root       (rdc/createRoot container)
-              cleanup    (fn [] (.remove style) (.remove container) (done))]
+              ;; Cleans up; it does NOT finish. A closure that CLOSES OVER
+              ;; `done` finishes the row exactly as a literal `(done)` does
+              ;; (rf2-o0n1); the single `done` sits at the tail below.
+              cleanup    (fn [] (.remove style) (.remove container) nil)]
           (-> (act #(.render root (fr/element [chip-lib/chip {:label "Ready"}])))
               (.then (fn [_]
                        (let [before (.querySelector container "[data-component=\"acme/chip\"]")]
@@ -150,5 +171,11 @@
                            (is (identical? before after)
                                "the same DOM node — the switch re-rendered nothing")))
                        (act #(.unmount root))))
-              (.then (fn [_] (cleanup)))
-              (.catch (fn [e] (is false (str "mount rejected: " e)) (cleanup)))))))))
+              ;; Reports and RELEASES; it never finishes. `done` runs the whole
+              ;; remainder of the run synchronously, so a `.catch` downstream of
+              ;; a step that finished the row would claim a later namespace's
+              ;; throw as this row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              ;; Both arms cleaned up identically, so it rides the single
+              ;; trailing step: written once, run once per path.
+              (.then (fn [_] (cleanup) (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/presence_commit_ownership_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/presence_commit_ownership_dom_cljs_test.cljs
@@ -218,13 +218,15 @@
                        (is (nil? (marker-el container "b"))
                            "b's own exit still removes it terminally")
                        (is (some? (marker-el container "a")) "a is untouched throughout")
-                       (is (= 0 (presence/pending-count)) "every exit fired exactly once")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                       (is (= 0 (presence/pending-count)) "every exit fired exactly once")))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              ;; Both arms tore down identically, so the teardown rides the
+              ;; single trailing step: written once, run once per path.
+              (.then (fn [_] (teardown! container root) (done)))))))))
 
 ;; ===========================================================================
 ;; A COMMITTED render still owns its elements
@@ -268,10 +270,8 @@
                        (is (= "re-entered-b" (label-of container "b"))
                            "with the element the re-entry supplied")
                        (is (= 0 (presence/pending-count))
-                           "and cancels the pending exit")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                           "and cancels the pending exit")))
+              ;; Reports and RELEASES, as above.
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              ;; Shared teardown, hoisted onto the single trailing step.
+              (.then (fn [_] (teardown! container root) (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/presence_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/presence_dom_cljs_test.cljs
@@ -151,13 +151,15 @@
                        (is (not (present? container "b"))
                            "the timeout removed b terminally — its subtree is unmounted")
                        (is (= 0 (presence/pending-count))
-                           "and the exit fired exactly once, leaving nothing pending")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                           "and the exit fired exactly once, leaving nothing pending")))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              ;; Both arms tore down identically, so the teardown rides the
+              ;; single trailing step: written once, run once per path.
+              (.then (fn [_] (teardown! container root) (done)))))))))
 
 ;; ===========================================================================
 ;; FH-PRESENCE-003 — re-entry cancels the exit
@@ -194,13 +196,11 @@
                        (act #(presence/flush-presence!))))
               (.then (fn [_]
                        (is (present? container "b")
-                           "a flush after re-entry leaves the re-entered child mounted")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                           "a flush after re-entry leaves the re-entered child mounted")))
+              ;; Reports and RELEASES, as above.
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              ;; Shared teardown, hoisted onto the single trailing step.
+              (.then (fn [_] (teardown! container root) (done)))))))))
 
 (deftest the-fixture-is-loaded
   (testing "Non-vacuity: the browser assertions read their expectations from

--- a/implementation/freehand/test/re_frame/freehand/presence_matrix_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/presence_matrix_dom_cljs_test.cljs
@@ -134,15 +134,15 @@
                          (is (present? container "b") (str label ": b mounted"))
                          (is (= "present" (phase-of container "a")) (str label ": a is :present"))
                          (is (nil? (.getAttribute (toast-el container "b") "aria-hidden"))
-                             (str label ": a present child is not hidden")))
-                       (ms/destroy-root! ci ri)
-                       (ms/destroy-root! cc rc)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "a presence mount rejected: " e))
-                        (ms/destroy-root! ci ri)
-                        (ms/destroy-root! cc rc)
-                        (done)))))))))
+                             (str label ": a present child is not hidden")))))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str "a presence mount rejected: " e)) nil))
+              ;; Both arms tore both roots down identically, so the teardown
+              ;; rides the single trailing step: written once, run once per path.
+              (.then (fn [_] (ms/destroy-root! ci ri) (ms/destroy-root! cc rc) (done)))))))))
 
 ;; ===========================================================================
 ;; Row 2 — a departed key is retained, hides itself, and flushes once

--- a/implementation/freehand/test/re_frame/freehand/presence_nil_key_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/presence_nil_key_dom_cljs_test.cljs
@@ -175,13 +175,15 @@
               (.then (fn [_]
                        (is (nil? (chip-el container))
                            "and the timeout removes it terminally")
-                       (is (= 0 (presence/pending-count)) "leaving nothing pending")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                       (is (= 0 (presence/pending-count)) "leaving nothing pending")))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              ;; Both arms tore down identically, so the teardown rides the
+              ;; single trailing step: written once, run once per path.
+              (.then (fn [_] (teardown! container root) (done)))))))))
 
 (deftest a-nil-keyed-literal-element-child-is-retained-too
   (testing "The literal-element path is a presence citizen on the same
@@ -203,13 +205,11 @@
                        (is (= 1 (presence/pending-count)) "its exit is scheduled")
                        (act #(presence/flush-presence!))))
               (.then (fn [_]
-                       (is (nil? (chip-el container)) "and the timeout removes it")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                       (is (nil? (chip-el container)) "and the timeout removes it")))
+              ;; Reports and RELEASES, as above.
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              ;; Shared teardown, hoisted onto the single trailing step.
+              (.then (fn [_] (teardown! container root) (done)))))))))
 
 (deftest duplicate-nil-keys-collide-in-the-string-coerced-domain
   (testing "\"null\" is an ordinary identity, so two explicit-nil-key
@@ -227,10 +227,8 @@
                        (is (= 1 (.-length (.querySelectorAll container ".chip")))
                            "one child owns the \"null\" identity, not two")
                        (is (= "first" (.getAttribute (chip-el container) "data-label"))
-                           "and it is the FIRST claimant in document order")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "mount rejected: " e))
-                        (teardown! container root)
-                        (done)))))))))
+                           "and it is the FIRST claimant in document order")))
+              ;; Reports and RELEASES, as above.
+              (.catch (fn [e] (is false (str "mount rejected: " e)) nil))
+              ;; Shared teardown, hoisted onto the single trailing step.
+              (.then (fn [_] (teardown! container root) (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/projection_roster_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/projection_roster_dom_cljs_test.cljs
@@ -162,11 +162,16 @@
                            "and the dismissal is the WORD the platform used — no
                             counting, no inference, and distinguishable from the
                             opening report by equality")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "browser run failed: " e))
-                        (done)))))))))
+                       ;; ASYMMETRIC, so it stays put: the rejection arm below
+                       ;; tore nothing down, and there is nothing here that both
+                       ;; arms already wrote for the trailing step to carry.
+                       (teardown! container root)))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))
 
 ;; ===========================================================================
 ;; `::v/scroll-top` — the offset a windowed table windows on
@@ -201,8 +206,8 @@
                        (is (= 640 (scroll-top))
                            "each scroll reads its OWN event, so a windowed table
                             follows the viewport rather than one render's snapshot")
-                       (teardown! container root)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "browser run failed: " e))
-                        (done)))))))))
+                       ;; Success-only, as above.
+                       (teardown! container root)))
+              ;; Reports and RELEASES, as above.
+              (.catch (fn [e] (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/ref_composition_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/ref_composition_dom_cljs_test.cljs
@@ -267,8 +267,11 @@
                          (is (= pending (top-layer/pending-count))
                              "with the commit batch drained"))
                        (is (nil? (by-id menu-id))
-                           "and the node left the document with both of them")
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "browser run failed: " e))
-                        (done)))))))))
+                           "and the node left the document with both of them")))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time. Nothing to hoist: both
+              ;; teardowns are `act`ed mid-chain, as the steps under test.
+              (.catch (fn [e] (is false (str "browser run failed: " e)) nil))
+              (.then (fn [_] (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/root_matrix_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/root_matrix_dom_cljs_test.cljs
@@ -215,12 +215,17 @@
                            (.then (fn [mc]
                                     (ms/outlines-agree? (ms/q ni "#app") (ms/q nc "#app") "root element")
                                     (is (= "same" (ms/text-of ni "#app")) "non-vacuous: the root really rendered")
+                                    ;; ASYMMETRIC, so they stay put: `mi` and
+                                    ;; `mc` are what the two mounts resolved
+                                    ;; with, and a rejection arm never had a
+                                    ;; root to unmount.
                                     (-> (ms/act #(v/unmount! mi))
-                                        (.then (fn [_] (ms/act #(v/unmount! mc))))
-                                        (.then (fn [_]
-                                                 (.remove ni) (.remove nc)
-                                                 (done)))))))))
-              (.catch (fn [e]
-                        (is false (str "a root mount rejected: " e))
-                        (.remove ni) (.remove nc)
-                        (done)))))))))
+                                        (.then (fn [_] (ms/act #(v/unmount! mc))))))))))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str "a root mount rejected: " e)) nil))
+              ;; The node detach both arms DID share rides the single trailing
+              ;; step: written once, run once per path.
+              (.then (fn [_] (.remove ni) (.remove nc) (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/root_preflight_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/root_preflight_dom_cljs_test.cljs
@@ -802,16 +802,18 @@
                           (is (nil? (frame/frame fid))
                               "the last reference destroyed C — exactly the
                                incarnation R2 installed")
-                          (is (empty? (root/frame-ledger-snapshot)))
-                          (.remove node-1)
-                          (.remove node-2)
-                          (done))))))
+                          (is (empty? (root/frame-ledger-snapshot))))))))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
               (.catch
                 (fn [e]
                   (is false (str "fresh-incarnation authorship suite rejected: " e))
-                  (.remove node-1)
-                  (.remove node-2)
-                  (done)))))))))
+                  nil))
+              ;; The node detach both arms DID share rides the single trailing
+              ;; step: written once, run once per path.
+              (.then (fn [_] (.remove node-1) (.remove node-2) (done)))))))))
 
 ;; ===========================================================================
 ;; FH-ROOT-004 — Fable sequence (3): an external destroy of a root-ensured
@@ -891,13 +893,18 @@
               (.then
                 (fn [_]
                   (is (nil? (frame/frame fid)) "the last reference destroyed C exactly")
-                  (is (empty? (root/frame-ledger-snapshot)))
-                  (.remove node-1) (.remove node-2) (done)))
+                  (is (empty? (root/frame-ledger-snapshot)))))
+              ;; Reports and RELEASES, as above. The unregister is written on
+              ;; both arms rather than hoisted: the success arm drops the
+              ;; listener mid-chain, BEFORE the two unmounts it is not meant to
+              ;; observe.
               (.catch
                 (fn [e]
                   (trace-tooling/unregister-listener! k)
                   (is false (str "loud-destroy + fresh-tuple suite rejected: " e))
-                  (.remove node-1) (.remove node-2) (done)))))))))
+                  nil))
+              ;; Shared node detach, hoisted onto the single trailing step.
+              (.then (fn [_] (.remove node-1) (.remove node-2) (done)))))))))
 
 ;; ===========================================================================
 ;; FH-ROOT-004 — Layer 1's join is the SOLE authority, even when the destroy
@@ -950,12 +957,15 @@
                   (is (identical? @b-token (frame/frame-incarnation-token fid))
                       "final unmount never reached B — the exact-token teardown no-oped")
                   (late-bind/set-fn! :freehand/on-frame-destroyed! saved)
-                  (rf/destroy-frame! fid)
-                  (.remove node)
-                  (done)))
+                  (rf/destroy-frame! fid)))
+              ;; Reports and RELEASES, as above. The hook restore is written on
+              ;; both arms rather than hoisted: it has to precede the success
+              ;; arm's `destroy-frame!`, so that destroy runs through the
+              ;; genuine hook and not the stub this row installed.
               (.catch
                 (fn [e]
                   (late-bind/set-fn! :freehand/on-frame-destroyed! saved)
                   (is false (str "join-is-sole-authority suite rejected: " e))
-                  (.remove node)
-                  (done)))))))))
+                  nil))
+              ;; Shared node detach, hoisted onto the single trailing step.
+              (.then (fn [_] (.remove node) (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/root_teardown_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/root_teardown_dom_cljs_test.cljs
@@ -611,15 +611,22 @@
                   (is (empty? (root/frame-ledger-snapshot))
                       "and the row is released")
                   (trace-tooling/unregister-listener! k)
-                  (rf/destroy-frame! fid)
-                  (.remove node)
-                  (done)))
+                  (rf/destroy-frame! fid)))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              ;;
+              ;; The unregister is written on both arms rather than hoisted: on
+              ;; the success arm it has to run BEFORE `destroy-frame!`, whose
+              ;; own diagnostics the listener is not meant to collect.
               (.catch
                 (fn [e]
                   (trace-tooling/unregister-listener! k)
                   (is false (str "legacy-release loudness suite rejected: " e))
-                  (.remove node)
-                  (done)))))))))
+                  nil))
+              ;; Shared node detach, hoisted onto the single trailing step.
+              (.then (fn [_] (.remove node) (done)))))))))
 
 ;; ===========================================================================
 ;; FH-ROOT-005 — the UPGRADE boundary: a pre-#6871 FLAT ledger row across the
@@ -756,13 +763,16 @@
               (.then
                 (fn [_]
                   (is (empty? (root/frame-ledger-snapshot))
-                      "final release of the tombstoned row empties the ledger, no re-alarm")
-                  (.remove node) (done)))
+                      "final release of the tombstoned row empties the ledger, no re-alarm")))
+              ;; Reports and RELEASES, as above; the unregister stays on both
+              ;; arms for the same reason.
               (.catch
                 (fn [e]
                   (trace-tooling/unregister-listener! k)
                   (is false (str "migrated-flat destroy-hook suite rejected: " e))
-                  (.remove node) (done)))))))))
+                  nil))
+              ;; Shared node detach, hoisted onto the single trailing step.
+              (.then (fn [_] (.remove node) (done)))))))))
 
 (deftest fh-root-005-a-tokenless-flat-row-stays-legacy-and-fails-loud
   (testing "Per FH-ROOT-005 / rf2-4pvsy AC4 (browser): a genuinely tokenless

--- a/implementation/freehand/test/re_frame/freehand/route_link_matrix_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/route_link_matrix_dom_cljs_test.cljs
@@ -233,12 +233,12 @@
               (.then (fn [_]
                        (ms/outlines-agree? (anchor ci) (anchor cc) "route-link anchor")
                        (is (= "/articles/the-intro" (.getAttribute (anchor ci) "href"))
-                           "non-vacuous: the shared anchor really carries the route href")
-                       (ms/destroy-root! ci ri)
-                       (ms/destroy-root! cc rc)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "a route-link mount rejected: " e))
-                        (ms/destroy-root! ci ri)
-                        (ms/destroy-root! cc rc)
-                        (done)))))))))
+                           "non-vacuous: the shared anchor really carries the route href")))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str "a route-link mount rejected: " e)) nil))
+              ;; Both arms tore both roots down identically, so the teardown
+              ;; rides the single trailing step: written once, run once per path.
+              (.then (fn [_] (ms/destroy-root! ci ri) (ms/destroy-root! cc rc) (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/top_layer_matrix_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/top_layer_matrix_dom_cljs_test.cljs
@@ -129,15 +129,15 @@
               (.then (fn [_]
                        (ms/outlines-agree? (el ci) (el cc) "popover element")
                        (is (= "auto" (.getAttribute (el ci) "popover"))
-                           "non-vacuous: it really is an auto popover")
-                       (ms/destroy-root! ci ri)
-                       (ms/destroy-root! cc rc)
-                       (done)))
-              (.catch (fn [e]
-                        (is false (str "a popover mount rejected: " e))
-                        (ms/destroy-root! ci ri)
-                        (ms/destroy-root! cc rc)
-                        (done)))))))))
+                           "non-vacuous: it really is an auto popover")))
+              ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
+              ;; the whole remainder of the run synchronously, so a `.catch`
+              ;; downstream of it would claim a later namespace's throw as this
+              ;; row's and fire `done` a second time.
+              (.catch (fn [e] (is false (str "a popover mount rejected: " e)) nil))
+              ;; Both arms tore both roots down identically, so the teardown
+              ;; rides the single trailing step: written once, run once per path.
+              (.then (fn [_] (ms/destroy-root! ci ri) (ms/destroy-root! cc rc) (done)))))))))
 
 ;; ===========================================================================
 ;; Row 2 — a popover promotes to the real top layer at layout time

--- a/implementation/freehand/test/re_frame/freehand/trusted_markup_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/trusted_markup_dom_cljs_test.cljs
@@ -197,18 +197,27 @@
   nil)
 
 (defn- mounted!
-  "Mount `form`, run `check` against the container, tear the root down."
+  "Mount `form`, run `check` against the container, tear the root down.
+
+  The rejection handler sits UPSTREAM of the step that calls `done`, and the
+  single `done` sits at the tail with nothing after it (rf2-o0n1). `done` runs
+  the whole remainder of the run synchronously, so a `.catch` downstream of it
+  would claim a later namespace's throw as this row's failure and fire `done` a
+  second time."
   [form check done]
   (let [container (host-node!)]
     (-> (act #(v/mount form container))
         (.then (fn [m]
                  (check container)
-                 (unmount! container m)
-                 (done)))
+                 ;; ASYMMETRIC, so it stays put: `m` is what the mount resolved
+                 ;; with, and the rejection arm never had a root to unmount — it
+                 ;; can only detach the host node, which it does below.
+                 (unmount! container m)))
         (.catch (fn [e]
                   (is false (str "trusted-markup mount rejected: " e))
                   (.remove container)
-                  (done))))))
+                  nil))
+        (.then (fn [_] (done))))))
 
 (defn- each-mode
   "Run `check` over the interpreted and compiled members of one pair, one


### PR DESCRIPTION
Closes rf2-o0n1. The last batch of the freehand promise-chain campaign.

`cljs.test/run-block` hands `done` a continuation that runs the **whole remainder of
the run** synchronously. A rejection handler sitting downstream of the step that calls
`done` therefore claims whatever a **later namespace** throws as this row's failure,
prints it against this row's label, and calls `done` a **second** time — re-forcing
`run-block`'s unrealized `Delay` and re-running the offending namespace. The cure is
positional: the handler goes **upstream**, reports and returns `nil`; exactly one
`done` sits at the tail with nothing after it.

## The count — re-derived, and it did not hold

The bead's note said **100 remaining chains in 38 files**. **On `origin/main` it is 55
in 29 files.** The 100 was measured four commits early.

Re-derived with an independent s-expression reader (a real Clojure reader — strings,
character literals, regex literals, `#?` conditionals, `##NaN`, `;` comments — not a
line matcher), recovering chains structurally from `->`/`some->` threading forms and
from nested `(.catch (.then p f) g)` shapes. It reproduces **both** campaign landmarks
exactly, which is what says the disagreement is about *when* the count was taken and
not about *how*:

| commit | freehand chains / files | landmark |
|---|---|---|
| `1662f3cc8e^` | 190 / 47 | pre-campaign |
| `1662f3cc8e` (rf2-qpns) | **184 / 46** | the note's "pre-repair 184 / 46" — exact |
| `2f33b56649` (rf2-d2xz, #7955) | **100 / 38** | the note's "100 on main / 38" — exact |
| `f8e8d1a1dc` … `5bd0db76c7` (rf2-0r3j, rf2-ua8r) | 95 → 82 → 72 → **55 / 29** | four commits the note predates |
| `e9aef48d19` (rf2-29ua, #7964) | **55 / 29** | unchanged, exactly as the note predicted |
| `origin/main` = `195a7cb1d0` | **55 / 29** | this PR's base |

So #7964 left the blind census untouched — the note's own prediction — and the number
it quoted was simply taken before #7958/#7959/#7961 landed. 55 is also within one of
the bead description's *original* part-4 census of 54: what remains on main **is**
part 4, plus one chain that census missed (`host-mounted` reads 4 rather than 3,
`buffered-controller` 5 rather than 3, against two fewer singles).

All 55 are repaired here. **The literal-`(done)` census over `implementation/freehand`
now reads ZERO** — and so do the helper-aware and closure-aware censuses (below).

## A third class, and the control found it

`rf2-fyba`'s signature sees a literal `(done)` in a chain step. `rf2-29ua`'s also sees
a helper that **takes** `done` as a parameter. **Neither sees a `let`-bound zero-arg
closure that CLOSES OVER the row's `done`:**

```clojure
(let [finish (fn [] (restore) (teardown! container root) (done))]
  (-> p (.then (fn [_] … (finish)))
        (.catch (fn [e] (is false …) (finish)))))
```

Same defect exactly. This was not deduced — the reproduction control **caught it in
the act** the moment `controlled-input-matrix` stopped claiming the throw: the claim
moved one frame further down to `controlled-input-dom-cljs-test`, which sorts
immediately before it, printed as `mount rejected: Async tests require fixtures to be
specified as maps` against the control's own test name, with the double-`done` warning
intact.

Measured with a closure-aware reader: **37 chains in 12 files repo-wide**. **5 in 2
files are freehand's** — `controlled-input` (2, via `finish`) and `pilot-theming` (3,
via `cleanup`) — and both are repaired here. **The other 32 are outside freehand and
are filed as `rf2-e8kc`** with the per-file census; they are not touched here.

## Per-chain dispositions

31 files, 55 + 5 = **60 chains**. Teardown was **not** hoisted mechanically: the split
runs **21 hoisted / 39 left in place**, and the dominant reason to leave it is the
failure arm doing *less*.

**Hoisted onto the single trailing step**, because both arms already wrote it
identically — written once, still run once per path:

- the paired `ms/destroy-root!` of `controlled-input-matrix` (3), `error-matrix`,
  `presence-matrix`, `route-link-matrix`, `top-layer-matrix`
- `teardown!` in `buffered-controller` (3), `presence` (2), `presence-nil-key` (3),
  `presence-commit-ownership` (2)
- `(.remove container)` in `custom-element`, `b6-update`, `client-only` (with
  `reset-all!`), `root-matrix` (`ni`/`nc`), `root-preflight` (3 × `node-1`/`node-2`),
  `root-teardown` (2 × `node`)
- `release` / `cleanup` in `controlled-input` (2) and `pilot-theming` (3)

**Left in place, each for a source-located reason:**

- **`mount/release!` inside `try`/`finally`** — `bench/hicasso/arm1/presence`,
  `bench/hicasso/ssr/instance-key-payload` (2). In instance-key-payload the handle is
  destructured from what the mount **resolved with**, so only the success arm ever had
  one. This is the idiom #7961 landed in `host-hatch`.
- **`(v/unmount! mounted)` / `(.unmount root)` / `((:unmount arm) mounted)`** —
  `client-only`, `custom-element`, `b6-update`, `root-matrix` (`mi` and `mc`): the
  rejection arm never had a root to unmount.
- **`compiled-slot`'s and `trusted-markup`'s `unmount!`** — success-only for the same
  reason, with the rejection arm keeping the bare `(.remove container)` it *can* still
  do.
- **`ms/residue-clean!` / `released!` residue readings** — `collection-applications`,
  `host-mounted` (3), `ownership-maps` (2), `ownership-motion` (3), `ownership-radix`
  (2): success-only, because a second failure attributed to the leak rule would bury
  the one that actually happened. In `collection-applications` that also pins
  `ms/destroy-root!` in place on both arms, because the residue read has to follow it.
- **`ms/remove-node!` in the four ownership suites** — their rejection arms tore
  nothing down at all, so there was nothing shared to carry.
- **`projection-roster`'s `teardown!`** (2) — same: the rejection arm tore nothing down.
- **`trace-tooling/unregister-listener!`** — `client-only`, `root-preflight`,
  `root-teardown` (2): written on both arms because the success arm has to drop the
  listener **before** it counts what the listener collected, or before a
  `destroy-frame!` whose own diagnostics it must not collect.
- **`late-bind/set-fn!` restore** — `root-preflight`: has to precede the success arm's
  `destroy-frame!`, so that destroy runs through the genuine hook and not the stub.
- **`ref-composition`** — nothing to hoist at all: both teardowns are `act`ed
  mid-chain, as steps under test.

**Nested chains.** `buffered-controller` (2), `substrate`-style nesting in
`host-mounted` and `root-matrix`, and `root-preflight`: every nested chain was already
returned into its parent, so the inner ones now finish **nothing**. Where the inner
handler carried its **own** diagnostic (`"the rejection rejected"`, `"remount
rejected"`) it is kept and made non-finishing rather than deleted — `run-async` was
**not** adopted anywhere, precisely because its generic `"an async matrix cell
rejected: "` would replace every row's own diagnostic with one string.

**Two rows carried their assertions off the end of the chain on a bare timer** —
`bench/hicasso/ssr/spike-dom`'s X5 mutation proof (`js/setTimeout`) and `client-only`'s
first row (`settle`, a 300 ms timer). Their `.catch` could never have fired after
`done`, so neither was an instance of the misattribution — but a throw inside either
timer **hung the lane with no diagnostic at all**. Both timers are now awaited as
promises, which puts the assertions upstream of the handler and the single `done` at
the tail. `spike-dom`'s sibling X5 row has no rejection handler and is **left correct**.

## No assertion was added, removed, weakened or moved

`(is ` occurrences across the 31 changed files: **851 before, 851 after**, and
**per-file identical** — no file differs. Zero `deftest` added or removed. That is the
arithmetic behind the unmoved test counts below.

## Prove it — the reproduction control, three runs

A throwaway namespace
`re-frame.freehand.controlled-input-matrix-dom-cljs-test-rf2-o0n1-control-dom-cljs-test`
— a **prefix extension** of the target, so nothing sorts between them — pairing a
**fn-form** `:each` fixture with an `async` row. That selects `cljs.test`'s `:sync`
path, wraps the test in `disable-async`, and throws the bare String
`"Async tests require fixtures to be specified as maps.  Testing aborted."`
**synchronously** inside whichever `done` continuation is running.

| run | tree | captured exit | claims | double-`done` | control ns announced |
|---|---|---|---|---|---|
| **A** reproduce | `controlled-input-matrix` reverted to `origin/main` | **1** | **2** — `a class-routing mount rejected: …` and `a spread-safe mount rejected: …`, both **this suite's own diagnostics printed against the CONTROL's test name** | **yes** | **twice** |
| **B** literal class repaired | closure class not yet | **1** | **1** — inherited one frame down by `controlled-input`: `mount rejected: …` | yes | once |
| **C** all three classes repaired | shipped tree | **1** | **0** | **no** | once |

Run C's last line is the honest end state — an unhandled page error naming the real
cause, **attributed to nobody**:

```
[browser:pageerror] Async tests require fixtures to be specified as maps.  Testing aborted.
```

None of the three reaches a summary, because the control aborts the run by design;
that is why exit 1 is the *expected* value for all three and why a green aggregate
would have proved nothing.

**The control is deleted, and the restore is verified by hashing the bytes**, not by
`git diff`: `controlled_input_matrix_dom_cljs_test.cljs` is
`sha256 a21a982bbc35ea837e144d7556195c4d1716f4ecd47e5d690aef349d251dd49d` both before
the probe and after it; the control is absent from disk and from `git ls-files`, and
`git status --untracked-files=all` is empty.

**A duplicate `done` is NOT invisible to the browser gate.** `run-browser-tests.cjs`
has promoted `Async test called done more than one time` to a `FATAL_CONSOLE_RE` match
since #7190, and it fired in runs A and B. No stale docstring anywhere in the repo
still claims otherwise — `grep` over `implementation/`, `tools/`, `spec/` and `docs/`
for that claim returns nothing, so #7964 dropped the last copy.

## Quality gates

Each run alone, foreground to completion, output redirected, exit code captured on the
same command line into its own `.exit` file, deleted between runs. **Every number below
is the captured one.**

| gate | captured exit | result |
|---|---|---|
| `npm run test:browser` — **shipped tree** | **0** | `Ran 1304 tests containing 8079 assertions. 0 failures, 0 errors.` |
| `npm run test:browser` — **`origin/main`, same machine** | **0** | `Ran 1304 tests containing 8079 assertions. 0 failures, 0 errors.` |
| `npm run test:freehand` — shipped tree | **0** | `Ran 1406 tests containing 7786 assertions. 0 failures, 0 errors.` |
| `npm run bench:freehand-browser` — shipped tree | **0** | `Ran 31 tests containing 497 assertions. 0 failures, 0 errors.` |
| `npm run test:browser` — run A (control, target reverted) | **1** | reproduction: two misattributed claims + double-`done`, no summary |
| `npm run test:browser` — run B (control, literal class repaired) | **1** | one inherited claim + double-`done` |
| `npm run test:browser` — run C (control, all three repaired) | **1** | zero claims, zero double-`done`, honest page error |
| `python scripts/check_fast_pr_gap.py --list` | **0** | 97 required checks the fast-PR spine does not decide |

**The baseline is measured, not remembered.** 1304 / 8079 on `origin/main` and
1304 / 8079 on this branch, from the same checkout minutes apart — **the count did not
move**, which the 851-for-851 assertion inventory above predicts.

**Lane coverage, checked rather than assumed.** `:browser-test`'s ns-regexp is
`^(?!re-frame\.freehand\.bench\.).*-dom-cljs-test$`, so it decides 29 of the 31 files.
The two it does not: `re-frame.freehand.bench.b6-update-dom-cljs-test` is excluded by
that negative lookahead and skips its async row under node, so it is decided by
`npm run bench:freehand-browser` — run above; and
`re-frame.bench.hicasso.ssr.spike-cljs-test` is not a `-dom-` suffix at all, so it is
decided by the node lanes (`test:cljs` / `test:freehand`) — run above.

`scripts/check_fast_pr_gap.py --list` names 97 required checks this spine does not
decide. The one that decides this change is `cljs-browser`
(`CLJS (shadow-cljs :browser-test, headless Chromium)` → `npm run test:browser`), run
above five times; the touched namespaces are also compiled and run by
`CLJS (shadow-cljs :node-test)` via `test:freehand`. `clj-kondo` and `splint` reach
`implementation/`; CI pins clj-kondo 2026.04.15 and a differently-versioned local
binary proves nothing, so those are left to CI. Every other required job is
surface-gated off a diff that changes 31 CLJS test files and nothing else.

## What remains

- **`rf2-e8kc` (P2, filed)** — the closure-over-`done` class **outside** freehand: 32
  chains in 10 files (`adapters/reagent` 9, `adapters/reagent-slim` 2,
  `hicasso/native-abi` 9, `hicasso/native-hooks` 8, `machines` 2, `tools/story` 1,
  `tools/re-frame2-pair-mcp` 1 — that last one a `.finally` rather than a `.catch`).
  Note the two `hicasso/native_*` files are also the only two the **literal** signature
  still sees, so those 17 are the same rows counted twice, not 17 + 17: repairing them
  once closes both censuses.
- Nothing of rf2-o0n1's own scope remains. All three censuses read **zero** over
  `implementation/freehand`.
