### PR TITLE
test(hicasso): the lazy boundary's five states, and the retry that reloads nothing (rf2-hic-041)

### DIFF
--- a/docs/design/hicasso/draft-guide/21-code-splitting.md
+++ b/docs/design/hicasso/draft-guide/21-code-splitting.md
@@ -54,7 +54,7 @@ One gate namespace can own the loadable value, effect, state, and events:
 
 (rf/reg-event :admin/wanted
   (fn [{:keys [db]} _]
-    (when-not (= :loaded (get-in db [:modules :admin]))
+    (when-not (#{:loading :loaded} (get-in db [:modules :admin]))
       {:db (assoc-in db [:modules :admin] :loading)
        :fx [[:app/load-module!
              {:loadable  admin-screen
@@ -97,12 +97,21 @@ retry intent. After loading, `@admin-screen` resolves to the original
 `h/defview`, so it keeps its name, frame, reads, and independent re-render
 behaviour.
 
-The `:loading` and `:loaded` state is the deduplication rule. Leaving and
-returning to the route does not start a second load.
+Both `:loading` and `:loaded` are in the deduplication rule, and the first of
+the two is the one that matters. Leaving and returning to a loaded route is the
+easy case; the case that actually races is a module warmed from a link hover and
+then clicked half a second later, while the first fetch is still in flight. A
+gate written against `:loaded` alone passes every test that never warms a module
+early, and fetches the chunk twice for every user who hovers before clicking.
 
-You can warm the module by dispatching `[:admin/wanted]` from a link hover or
-focus intent. A loaded module participates in hot reload normally. An unloaded
-module has no loaded namespace to reload.
+So you can warm the module by dispatching `[:admin/wanted]` from a link hover or
+focus intent, and the click that follows is the same load. A loaded module
+participates in hot reload normally. An unloaded module has no loaded namespace
+to reload.
+
+This is also the only retryable path of the two on this page. `lazy/load` is an
+ordinary promise-returning function: after a failure, `[:admin/wanted]` calls it
+again and really does fetch again. The `n/lazy` section below cannot say that.
 
 ## Lazy native components with Suspense
 
@@ -129,8 +138,17 @@ Declare loadables and lazy components at namespace top level:
 (h/defhost chart-host heavy-chart)
 
 (h/defhost suspense react/Suspense
-  {:slots #{:fallback}})
+  {:slots    #{:fallback}
+   :fallback [:div.chart-skeleton {:aria-busy true}]})
 ```
+
+The two `:fallback` keys in that declaration are different things with the same
+name, and the difference decides what the server sends. `:slots #{:fallback}`
+declares the prop position React uses while the chunk is in flight. The sibling
+`:fallback` is `defhost`'s Client-only *placeholder*: inert markup the crossing
+renders on the server and on hydration's first client pass. A Client-only region
+renders nothing at all — its declared slots included — so without that second
+key the region is absent from the server response entirely.
 
 Mount the lazy host under Suspense and an error boundary:
 
@@ -139,9 +157,9 @@ Mount the lazy host under Suspense and an error boundary:
   [h/error-boundary
    {:fallback
     [:div.chart-oops
-     [:p "The chart failed to load."]
-     [:button {:on-click [:chart/retry]}
-      "Try again"]]
+     [:p "The chart is unavailable."]
+     [:button {:on-click [:app/reload-page]}
+      "Reload"]]
     :reset-key (h/sub [:chart/attempt])}
 
    [suspense
@@ -153,9 +171,27 @@ Mount the lazy host under Suspense and an error boundary:
 ```
 
 The declared `:fallback` slot converts Hiccup to a ReactNode. If the loader
-promise rejects, React throws during render and the nearest
-`h/error-boundary` catches it. Changing the boundary's `:reset-key` retries the
-lazy subtree.
+promise rejects, React throws during render and the nearest `h/error-boundary`
+catches it.
+
+### A rejected chunk is permanent
+
+Changing the boundary's `:reset-key` does not re-fetch the chunk. It clears the
+caught error and re-renders the children, which is a real retry for anything the
+chart itself throws once it has loaded — but the lazy head is unchanged, and
+React calls a loader only while its payload is uninitialised. A rejection settles
+that payload as rejected, and every render afterwards re-throws the cached error
+without going near the loader.
+
+The paint is why this is easy to believe otherwise: a fallback that stays put
+looks exactly the same whether React re-threw a cached rejection or fetched again
+and failed again. Only the number of network requests tells them apart.
+
+Retrying therefore means a *new* lazy component, and the top-level definitions
+this section insists on are exactly what you do not have per attempt. **If the
+region has to be retryable, split it at the module boundary instead** — the
+first half of this page. `lazy/load` can be called again, the arrival states are
+already app-db data, and the retry is an ordinary intent.
 
 !!! warning "Create lazy components once"
     `n/lazy` creates a React component identity. Calling it inside a view body
@@ -165,12 +201,16 @@ lazy subtree.
 
 A namespace save reallocates the lazy component during hot reload, so React
 remounts that subtree. This is the normal HMR behaviour for named native
-components and `defview` identities. State that must survive a save belongs in
-app-db.
+components and `defview` identities, and it is the same allocation a retry would
+need — which is the clearest way to see that a retry is not available: a fresh
+head is a *different component*, and only a source save produces one. State that
+must survive a save belongs in app-db.
 
-Under SSR, the lazy host remains Client-only. Server HTML contains the
-deterministic fallback. The live component mounts after hydration when its
-code arrives ([SSR and hydration](18-ssr-and-hydration.md)).
+Under SSR, the lazy host remains Client-only, and the server sends the
+placeholder the `suspense` host **declared** — not the Suspense slot, which a
+Client-only region never reaches. Give that placeholder the same footprint as the
+chart so the layout does not jump, and the live component mounts after hydration
+when its code arrives ([SSR and hydration](18-ssr-and-hydration.md)).
 
 ## What happens to reads during suspension
 
@@ -184,6 +224,20 @@ It installs no subscriptions and acquires no demand-driven resources.
 
 When the code arrives and the real subtree commits, the committed read set is
 installed once.
+
+### A committed sibling keeps its reads while the fallback is up
+
+The other half of the same boundary behaves differently, and the difference
+matters when you add a lazy region beside views that are already on screen.
+Hiding a *committed* subtree for a fallback is not an unmount and not an
+[Activity](#retaining-hidden-native-ui-with-activity) hide: React leaves its
+passive effects in place, so those views keep their subscriptions, hear writes
+that land while they are hidden, and come back with the current value and the
+same registration they went in with.
+
+So a slow chunk costs you a fallback, not a resubscribe — and if you want the
+opposite, hiding a pane and releasing what it holds, that is Activity's job
+rather than Suspense's.
 
 ### Use Suspense for code, not application data
 
@@ -248,12 +302,14 @@ cost. Ordinary application state already survives unmount in app-db.
 | --- | --- | --- |
 | Split route is blank until code arrives | The view dereferences the loaded module without rendering pending and failed states | Branch on module status and show a skeleton or failure UI |
 | Repeated visits start repeated module loads | The load event ignores existing `:loading` or `:loaded` state | Gate the effect on the status as `:admin/wanted` does |
+| Hovering a link then clicking it fetches the chunk twice | The load event skips only `:loaded`, so the click is not deduplicated against the in-flight load the hover started | Gate on `#{:loading :loaded}` |
 | Development watch works but release returns a module 404 | Module entries or `:depends-on` edges differ in the release configuration | Declare the module dependency and keep one authoritative entries list |
 | Suspense fallback appears after every parent render | `n/lazy` is created inside a body, producing a new component identity | Move the loadable and lazy component to top-level definitions |
-| Failed chunk leaves the skeleton forever | No error boundary handles the loader rejection | Wrap Suspense with `h/error-boundary` and retry by changing `:reset-key` |
+| Failed chunk leaves the skeleton forever | No error boundary handles the loader rejection | Wrap Suspense with `h/error-boundary` so the failure has somewhere to land |
+| The retry button changes `:reset-key` and the region fails again without a network request | React caches a rejected lazy payload; the head is unchanged, so the loader is never called again | Retry is not available at this boundary. Split at the module boundary when the region must be retryable |
 | Xray shows an anonymous lazy island | Raw `React.lazy` removed Hicasso's native marker | Use `n/lazy` |
 | Local state resets after a source save | HMR created a new component identity and React remounted | Expected. Store durable state in app-db and read it with `n/use-sub` |
-| Lazy area is absent from server HTML | The lazy component is Client-only | Provide a same-footprint fallback; the component mounts after adoption |
+| Lazy area is absent from server HTML | The lazy component is Client-only, and the host that crosses to it declared no placeholder — a Suspense `:fallback` slot is a prop, and a Client-only region does not render far enough to reach it | Declare a same-footprint `:fallback` on the host; the component mounts after adoption |
 | Hidden pane loses UI state | It was unmounted with a conditional rather than retained with Activity | Use `:mode "hidden"` when retention is intentional |
 | Scheduled reveal briefly shows old content | The hidden pane had no active subscription and React restored it after the reveal paint | Reveal from the discrete event, or unmount/re-key when stale display is unacceptable |
 

--- a/implementation/hicasso/src/re_frame/hicasso/native.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso/native.cljc
@@ -504,10 +504,35 @@
   the module wrapper would be a shape the author invents for React and
   then never reads. This puts it on once, where it is React's business.
 
-  Suspend and error conduct are React's whole: while the promise is
-  pending the nearest Suspense host shows its fallback, and a rejection
-  throws into the render for the nearest `h/error-boundary` to catch and
-  a `:reset-key` to retry.
+  Suspend conduct is React's whole: while the promise is pending the
+  nearest Suspense host shows its fallback, and the arrival commits the
+  component with the props the parent wrote before it existed. A
+  suspension here hides a committed sibling rather than releasing it —
+  the `useSyncExternalStore` subscription survives the fallback and the
+  arrival's registration is the same object, measured in
+  [[re-frame.hicasso.lazy-boundary-dom-cljs-test]] and established for
+  suspension generally in `activity_suspense_dom_cljs_test`.
+
+  ## A rejection is TERMINAL, and `:reset-key` does not undo it
+
+  A rejection throws into the render and the nearest `h/boundary` catches
+  it — but changing that boundary's `:reset-key` retries the BOUNDARY and
+  not the chunk. React 19's `lazyInitializer` calls `load` only while its
+  payload is uninitialised; a rejection settles that payload as rejected,
+  and every read afterwards re-throws the cached error without going near
+  the loader. The payload belongs to `react/lazy`, and neither this tier
+  nor React's public API can reset it. **This docstring claimed the
+  opposite until rf2-hic-041 measured it**, and the paint is the reason
+  it survived: a fallback that stays put looks the same whether React
+  re-threw a cached rejection or fetched again and failed again.
+
+  So the retry a failed chunk needs is a NEW HEAD — the same allocation a
+  hot reload performs, which is why the retry fact and the HMR fact have
+  one witness between them. The retryable path is the MODULE GATE:
+  `shadow.lazy/load` is an ordinary function, calling it again really
+  does fetch again, and the arrival state belongs in app-db where an
+  ordinary retry intent can reach it. Gate that event on `:loading` AND
+  `:loaded`, or warming the module from a hover will fetch it twice.
 
   ## The marker, and the one field that cannot be known yet
 
@@ -521,7 +546,14 @@
   **`:server` is `client-only` and is not the inner component's to
   override.** The server never sent the chunk, so no policy the component
   declares can make bytes exist: the region is Client-only whatever
-  `n/defcomponent` said, and the server carries the fallback.
+  `n/defcomponent` said.
+
+  **Nothing stands in for it on the server unless a DECLARATION says so.**
+  The `defhost` that crosses to this head emits server bytes only where
+  it was given a `:fallback`, and React's own Suspense fallback is not
+  that fallback — it is a prop at a ReactNode slot, and a Client-only
+  region renders nothing at all, slot included. A page that wants a
+  skeleton in its server response declares one.
 
   Declared at top level, never in a render — `React.lazy`'s own law.
   Minting inside a body allocates a fresh identity per pass, so the

--- a/implementation/hicasso/test/re_frame/hicasso/lazy_boundary_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/lazy_boundary_dom_cljs_test.cljs
@@ -448,12 +448,17 @@
   (let [[split? set-split] (react/useState false)]
     (react/useEffect (fn [] (reset! !set-split set-split) js/undefined)
                      #js [set-split])
+    ;; The panel is a DIRECT child of the boundary, with no wrapper. React
+    ;; hides a suspended primary tree by setting `display: none` on the
+    ;; boundary's own host children, and `getComputedStyle` does not
+    ;; cascade that to descendants — a `<div>` in between would report the
+    ;; panel visible throughout the suspension and the ownership rows
+    ;; below would be measuring a premise that never held.
     (codec/root-element
       frame-id
       [suspense-host {:fallback [:p {:id "skel2"} "waiting"]}
-       [:div
-        [own-panel {}]
-        (when split? [own-host {}])]])))
+       [own-panel {}]
+       (when split? [own-host {}])])))
 
 (unchecked-set split-host "displayName" "lzb/split-host")
 

--- a/implementation/hicasso/test/re_frame/hicasso/lazy_boundary_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/lazy_boundary_dom_cljs_test.cljs
@@ -1,0 +1,711 @@
+(ns re-frame.hicasso.lazy-boundary-dom-cljs-test
+  "CODE SPLITTING — WHAT CROSSES A `React.lazy` BOUNDARY, AND WHAT A
+  REJECTED ONE NEVER DOES AGAIN (rf2-hic-041).
+
+  The bridge itself is `n/lazy` and it landed with the ABI helpers
+  (rf2-hic-032): a `react/lazy` record carrying the tier marker, its
+  `:name` filled in on arrival, its `:server` pinned to Client-only.
+  [[re-frame.hicasso.native-abi-cljs-test]] settles the marker and
+  [[re-frame.hicasso.native-abi-dom-cljs-test]] settles the arrival.
+  **This file is about the BOUNDARY** — the five states a split region
+  moves through, what survives each crossing, and one promise the
+  documentation was making that React cannot keep.
+
+  ## The rows
+
+  | row | what it establishes | the narrowing it catches |
+  |---|---|---|
+  | [[the-module-gate-dedupes-a-hover-and-a-click-into-one-load]] | the route/module split's own dedupe rule, at the state it actually races on | a gate that skips only `:loaded`, so a warm-on-hover followed by a click starts a second load |
+  | [[a-lazy-boundary-paints-the-fallback-then-the-component-with-the-props-it-was-written-with]] | load, fallback and arrival, with the props and the one child intact across a crossing that was deferred | a bridge that re-ran the loader on arrival; a `:children` slot that lost the single child |
+  | [[a-lazy-suspension-retains-the-committed-subscription-and-the-arrival-leaves-exact-ownership]] | the post-commit suspension result, re-measured across a LAZY boundary specifically | a lazy retry that quietly re-subscribed — the screen is right under it |
+  | [[a-rejected-lazy-head-re-throws-its-cached-error-and-only-a-fresh-head-reloads]] | rejection is TERMINAL at the payload; `:reset-key` clears the boundary and reloads nothing | the claim, made in this repo until this bead, that changing `:reset-key` retries the chunk |
+  | [[a-client-only-lazy-region-writes-nothing-and-a-declared-fallback-writes-the-skeleton]] | which declaration actually emits server bytes | a region documented as sending a skeleton whose declaration sends nothing |
+  | [[the-declared-population-was-actually-exercised]] | the roster, asserted rather than described | a row that started returning early |
+
+  ## The instrument is the LOADER CALL COUNT, not the paint
+
+  A fallback that stays put after a retry looks identical whether React
+  re-threw a cached rejection or ran the loader again and got a second
+  failure. Only the count separates them, and the whole of
+  [[a-rejected-lazy-head-re-throws-its-cached-error-and-only-a-fresh-head-reloads]]
+  turns on that difference: widen `(= 1 calls)` to `(pos? calls)` and the
+  row goes green against the behaviour it exists to deny.
+
+  React 19.2's `lazyInitializer` calls the loader only while the payload
+  is Uninitialized (`_status === -1`); a rejection sets `_status = 2` and
+  every later read `throw`s the cached error. The payload is created once,
+  by `react/lazy`, and nothing in this tier — or in React's public API —
+  resets it. So the retry a rejected chunk needs is a NEW HEAD, which is
+  the same allocation a hot reload performs, which is why the HMR fact and
+  the retry fact are one measurement here rather than two.
+
+  ## Where the retryable path actually is
+
+  It is the module gate, not the React boundary: `shadow.lazy/load` is an
+  ordinary promise-returning function and calling it again really does
+  fetch again. [[the-module-gate-dedupes-a-hover-and-a-click-into-one-load]]
+  witnesses both halves of that — the load that must NOT happen twice and
+  the retry that must.
+
+  ## Lanes
+
+  `-dom-cljs-test`, so `:browser-test` runs the whole file against a real
+  React DOM. Two rows need no DOM and run under `:node-test` as well: the
+  module gate is pure re-frame, and the server render is
+  `renderToString`. Every other row degrades on the node lane to a STATED
+  skip rather than to a green for a render that never happened."
+  (:require [clojure.set :as set]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.inventory :as inventory]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.native :as n]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]
+            ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]
+            ["react-dom/server" :as react-dom-server]))
+
+(def ^:private frame-id ::lazy-boundary)
+
+;; ---------------------------------------------------------------------------
+;; Registrations — above `use-fixtures`, which captures its source-store
+;; baseline when the form is evaluated (the sibling suites' convention).
+;; ---------------------------------------------------------------------------
+
+(rf/reg-sub :lzb/label (fn [db _] (:label db)))
+(rf/reg-sub :lzb/module (fn [db _] (get-in db [:modules :admin] :absent)))
+
+(rf/reg-event :lzb/seed (fn [_ _] {:db {:label "alpha"}}))
+(rf/reg-event :lzb/relabel (fn [{:keys [db]} [_ label]] {:db (assoc db :label label)}))
+
+;; How many times the module-loading effect actually ran. The dedupe row's
+;; only instrument: app-db's `:loading` says what the gate INTENDED, and
+;; this says what the network was actually asked for.
+(defonce ^:private !module-loads (atom 0))
+
+(rf/reg-fx :lzb/load-module!
+  {:doc       "Stand-in for `shadow.lazy/load`, counted."
+   :platforms #{:client}}
+  (fn [_ctx _spec] (swap! !module-loads inc) nil))
+
+;; THE GATE, with the repair rf2-hic-041 was filed for.
+;;
+;; The set is `#{:loading :loaded}` and not `#{:loaded}`. Warming a module
+;; from a hover or focus intent is the documented reason to dispatch this
+;; early, and the click that follows arrives while the first load is still
+;; in flight — so a gate written against the finished state alone starts a
+;; second fetch for the chunk it is already fetching.
+(rf/reg-event :lzb/wanted
+  {:doc "Ask for the admin module, at most once per in-flight load."}
+  (fn [{:keys [db]} _]
+    (when-not (contains? #{:loading :loaded} (get-in db [:modules :admin]))
+      {:db (assoc-in db [:modules :admin] :loading)
+       :fx [[:lzb/load-module! {:on-loaded [:lzb/module-loaded]
+                                :on-failed [:lzb/module-failed]}]]})))
+
+(rf/reg-event :lzb/module-loaded
+  (fn [{:keys [db]} _] {:db (assoc-in db [:modules :admin] :loaded)}))
+
+(rf/reg-event :lzb/module-failed
+  (fn [{:keys [db]} _] {:db (assoc-in db [:modules :admin] :failed)}))
+
+;; ---------------------------------------------------------------------------
+;; The exercised population — a MEASUREMENT, not a claim
+;; ---------------------------------------------------------------------------
+
+(def ^:private declared-population
+  #{:gate/dedupe-and-retry
+    :lazy/fallback-then-arrival
+    :lazy/post-commit-suspension
+    :lazy/rejection-is-terminal
+    :lazy/fresh-head-reloads
+    :lazy/server-render})
+
+(defonce ^:private !exercised (atom #{}))
+
+(defn- exercised! [mechanism] (swap! !exercised conj mechanism) nil)
+
+;; ---------------------------------------------------------------------------
+;; Loaders, heads, and the components that arrive in them
+;; ---------------------------------------------------------------------------
+
+(defn- deferred-loader
+  "A `React.lazy` loader this file settles by hand, counting its own
+  calls.
+
+  One loader may back SEVERAL heads, and that sharing is the point of the
+  rejection row: it is how the row shows that a rejected chunk's
+  terminality belongs to the PAYLOAD `react/lazy` minted and not to the
+  function it was handed."
+  []
+  (let [!calls  (atom 0)
+        !settle (atom nil)]
+    {:calls  !calls
+     :settle !settle
+     :load   (fn []
+               (swap! !calls inc)
+               (js/Promise. (fn [resolve reject]
+                              (reset! !settle {:resolve resolve :reject reject}))))}))
+
+(defn- settle!
+  "Hand the pending loader its answer. `k` is `:resolve` or `:reject`."
+  [loader k v]
+  (let [handlers @(:settle loader)]
+    (when-not handlers
+      (throw (js/Error. "the loader has not been called yet — nothing to settle")))
+    ((get handlers k) v)
+    nil))
+
+;; The props object the arrived component was handed. The lazy-specific
+;; question: the parent wrote these before the chunk existed.
+(defonce ^:private !arrived-props (atom nil))
+
+(defn- chart-body
+  "The island in the split chunk. It reads a prop the parent wrote while
+  the module was still in flight, and renders whatever child was written
+  at the crossing."
+  [^js props]
+  (reset! !arrived-props props)
+  (n/$ :div {:id "chart"}
+       (n/$ :span {:class "series"} (str (count (.-points props))))
+       (.-children props)))
+
+(def ^:private chart-cell
+  "What the chunk `def`s. `n/component` rather than `n/defcomponent`
+  because the row needs the mint as a VALUE to resolve a promise with,
+  which is what a module's exported var is at the moment it lands."
+  (n/component "app/heavy-chart" :client-only chart-body))
+
+;; --- the Suspense hosts ----------------------------------------------------
+
+(h/defhost suspense-host
+  "The guide's declaration: `:fallback` is a ReactNode SLOT, so hiccup
+  written there crosses to React as an element."
+  (.-Suspense react)
+  {:slots #{:fallback}})
+
+(h/defhost suspense-skeleton-host
+  "The same crossing with a declared `:fallback` — `defhost`'s
+  Client-only PLACEHOLDER, which is a different key with the same name
+  and the only one of the two that can put bytes in a server response.
+  Declared here because the documentation promised those bytes from the
+  host above, which emits none."
+  (.-Suspense react)
+  {:slots    #{:fallback}
+   :fallback [:div {:id "server-skeleton" :aria-busy true} "loading"]})
+
+;; --- scenario 2: load, fallback, arrival -----------------------------------
+
+(def ^:private paint-loader (deferred-loader))
+(def ^:private paint-head (n/lazy (:load paint-loader)))
+(h/defhost paint-host paint-head)
+
+;; --- scenario 3: the post-commit suspension --------------------------------
+
+(def ^:private own-loader (deferred-loader))
+(def ^:private own-head (n/lazy (:load own-loader)))
+(h/defhost own-host own-head)
+
+;; --- scenario 4: rejection, and the head that replaces it ------------------
+;;
+;; TWO heads over ONE loader. `reject-head` is the one that rejects and
+;; can never be revived; `replacement-head` is what a retry — or a hot
+;; reload — allocates, and it reaches the SAME function.
+
+(def ^:private reject-loader (deferred-loader))
+(def ^:private reject-head (n/lazy (:load reject-loader)))
+(def ^:private replacement-head (n/lazy (:load reject-loader)))
+(h/defhost reject-host reject-head)
+(h/defhost replacement-host replacement-head)
+
+;; --- scenario 6: the server render -----------------------------------------
+
+(def ^:private ssr-loader (deferred-loader))
+(def ^:private ssr-head (n/lazy (:load ssr-loader)))
+(h/defhost ssr-host ssr-head)
+
+;; ---------------------------------------------------------------------------
+;; Views
+;; ---------------------------------------------------------------------------
+
+(h/defview own-panel
+  "A committed boundary inside the Suspense region, and the subject of the
+  ownership row: it holds a subscription before anything suspends."
+  [_]
+  [:p {:id "panel"} (str "label=" (h/sub [:lzb/label]))])
+
+(defonce ^:private !attempts (atom 0))
+
+(h/defview attempt-marker
+  "A sibling INSIDE the error boundary. Its render count is the retry
+  row's premise: a `:reset-key` change that cleared the caught error and
+  re-rendered the children moves it, and one that did nothing does not —
+  without it, `the loader was not called again` would be green for a
+  boundary that never retried at all."
+  [_]
+  (swap! !attempts inc)
+  [:i {:id "attempt"} "live"])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+(defn- skip! [why] (is true (str "a lazy-boundary DOM claim needs a real React DOM — " why)))
+
+(defn- seeded! []
+  (support/leave-act-environment!)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [:lzb/seed]))
+  frame-id)
+
+(defn- tree [hiccup] (mount/provider frame-id (codec/root-element frame-id hiccup)))
+
+(defn- mount-concurrent!
+  "A concurrent root rendered WITHOUT `flushSync`. Suspense's fallback and
+  its retry are React's own scheduling; a row that forced them sync would
+  be a row about the forced schedule. Every wait below is a poll."
+  [container element]
+  (let [root (react-dom-client/createRoot container)]
+    (.render root element)
+    {:root root :container container :frame frame-id}))
+
+(defn- node [handle id] (.querySelector ^js (:container handle) (str "#" id)))
+
+(defn- text-at [handle sel]
+  (some-> (.querySelector ^js (:container handle) sel) .-textContent))
+
+(defn- visible?
+  "Is `id`'s node in the layout? A Suspense boundary showing its fallback
+  keeps the primary tree's host nodes in the document and takes them out
+  of the layout with `display: none`, so presence is not visibility and
+  `textContent` still reports hidden text."
+  [handle id]
+  (when-some [el (node handle id)]
+    (not= "none" (.-display (js/getComputedStyle el)))))
+
+(defn- painted
+  [handle id]
+  (when (visible? handle id) (.-textContent ^js (node handle id))))
+
+(defn- poll [pred label]
+  (test-support/poll-until pred {:label label :timeout-ms 4000}))
+
+(defn- k [query-v] [frame-id query-v])
+
+(defn- ownership [] (dissoc (inventory/residue) :entries))
+
+(defn- reader-count
+  "A COUNT rather than the reader vector: a registration and the cells it
+  acquired hold each other, so `cljs.test`'s failure printer walks a cycle
+  and dies on the vector."
+  [query-v]
+  (count (inventory/cell-readers (k query-v))))
+
+(defn- sole-reader [query-v]
+  (let [rs (inventory/cell-readers (k query-v))]
+    (when (= 1 (count rs)) (first rs))))
+
+(defn- teardown-census! [handle]
+  (mount/unmount! handle)
+  (.then (inventory/quiesced!)
+         (fn [_]
+           (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                  (inventory/residue))
+               "teardown is exact: zero residue after quiescence")
+           (mount/release! handle)
+           nil)))
+
+(defn- report-failure!
+  "Record `label` against THIS row, release its root, and DELIBERATELY DO
+  NOT finish it — the chain's single trailing `done` does that. The long
+  form is on
+  [[re-frame.hicasso.activity-suspense-dom-cljs-test]]'s own
+  `report-failure!`."
+  [label handle]
+  (fn [e]
+    (is false (str label " — " (.-message e)
+                   " | DOM was " (pr-str (when handle (.-textContent ^js (:container handle))))
+                   " | ownership " (pr-str (ownership))))
+    (when handle (mount/release! handle))
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; 1. The module gate — the split that needs no Suspense, and the only
+;;    retryable path of the two
+;; ---------------------------------------------------------------------------
+
+(deftest the-module-gate-dedupes-a-hover-and-a-click-into-one-load
+  ;; Pure re-frame; runs on both lanes.
+  (seeded!)
+  (reset! !module-loads 0)
+  (rf/with-frame frame-id
+    (testing "the premise: the first intent starts exactly one load and
+              parks the module in `:loading`"
+      (rf/dispatch-sync [:lzb/wanted])
+      (is (= :loading @(rf/subscribe [:lzb/module])))
+      (is (= 1 @!module-loads)))
+
+    (testing "and the click that follows the hover is the SAME load. The
+              race the gate exists for is `:loading`, not `:loaded` — the
+              finished state is the easy half, and a gate written against
+              it alone passes every test that never warms a module early"
+      (rf/dispatch-sync [:lzb/wanted])
+      (rf/dispatch-sync [:lzb/wanted])
+      (is (= 1 @!module-loads)
+          "a warm-on-hover followed by a click fetched the chunk once"))
+
+    (testing "a failure re-opens the gate, and THIS is where a retry
+              belongs: `shadow.lazy/load` is an ordinary function and
+              calling it again really does fetch again"
+      (rf/dispatch-sync [:lzb/module-failed])
+      (is (= :failed @(rf/subscribe [:lzb/module])))
+      (rf/dispatch-sync [:lzb/wanted])
+      (is (= 2 @!module-loads) "the retry is a second, real load")
+      (is (= :loading @(rf/subscribe [:lzb/module]))))
+
+    (testing "and once it is loaded, returning to the route loads nothing"
+      (rf/dispatch-sync [:lzb/module-loaded])
+      (rf/dispatch-sync [:lzb/wanted])
+      (rf/dispatch-sync [:lzb/wanted])
+      (is (= 2 @!module-loads))
+      (is (= :loaded @(rf/subscribe [:lzb/module])))))
+  (exercised! :gate/dedupe-and-retry))
+
+;; ---------------------------------------------------------------------------
+;; 2. Load → fallback → arrival, and what crossed
+;; ---------------------------------------------------------------------------
+
+(deftest a-lazy-boundary-paints-the-fallback-then-the-component-with-the-props-it-was-written-with
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (let [_      (seeded!)
+            handle (mount-concurrent!
+                     (mount/fresh-container!)
+                     (tree [suspense-host {:fallback [:p {:id "skel"} "loading"]}
+                            [paint-host {:points [1 2 3]}
+                             [:em {:id "kid"} "child"]]]))]
+        (-> (poll #(= "loading" (painted handle "skel")) "the fallback takes the layout")
+            (.then
+              (fn [_]
+                (testing "the premise: the head suspended and its loader ran
+                          — once, on the render that needed it"
+                  (is (= 1 @(:calls paint-loader)))
+                  (is (nil? (node handle "chart"))))
+
+                (settle! paint-loader :resolve chart-cell)
+                (poll #(some? (node handle "chart")) "the chunk lands and the island commits")))
+            (.then
+              (fn [_]
+                (testing "the props the parent wrote BEFORE the component
+                          existed are the props the component reads, still
+                          a live ClojureScript value rather than something
+                          the deferral flattened"
+                  (is (= 3 (count (.-points @!arrived-props))))
+                  (is (= "3" (text-at handle ".series"))
+                      "…and it is the count the island rendered"))
+
+                (testing "the ONE child crossed. hic-032 repaired exactly
+                          this shape at the outward door — React's
+                          `children` slot is the child itself at one and an
+                          array at several — and a deferred crossing is
+                          where a bridge that got it right on the first
+                          render would still be able to lose it"
+                  (is (= "child" (painted handle "kid"))))
+
+                (testing "and arrival did not re-run the loader"
+                  (is (= 1 @(:calls paint-loader))))
+
+                (exercised! :lazy/fallback-then-arrival)
+                (teardown-census! handle)))
+            (.catch (report-failure! "lazy paint witness" handle))
+            (.then (fn [_] (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. The post-commit suspension, across a LAZY boundary
+;; ---------------------------------------------------------------------------
+
+(def ^:private !set-split (atom nil))
+
+(defn- split-host
+  "Owns whether the lazy sibling is in the tree. The setter is published
+  from a passive effect, so a row cannot drive the tree before React has
+  mounted it."
+  [_]
+  (let [[split? set-split] (react/useState false)]
+    (react/useEffect (fn [] (reset! !set-split set-split) js/undefined)
+                     #js [set-split])
+    (codec/root-element
+      frame-id
+      [suspense-host {:fallback [:p {:id "skel2"} "waiting"]}
+       [:div
+        [own-panel {}]
+        (when split? [own-host {}])]])))
+
+(unchecked-set split-host "displayName" "lzb/split-host")
+
+(defn- act! [f] (react-dom/flushSync f) nil)
+
+(deftest a-lazy-suspension-retains-the-committed-subscription-and-the-arrival-leaves-exact-ownership
+  ;; `activity_suspense_dom_cljs_test`'s
+  ;; `a-post-commit-suspension-retains-the-subscription-and-the-retry-leaves-exact-ownership`
+  ;; established the result against a hand-thrown thenable: hiding a
+  ;; committed tree for a Suspense FALLBACK leaves its passive effects
+  ;; mounted, so the `useSyncExternalStore` subscription survives and the
+  ;; retry's registration is `identical?` to the pre-suspension one —
+  ;; which is exactly what `<Activity mode="hidden">` does NOT do.
+  ;;
+  ;; This row does not re-derive that. It asks the one question the cited
+  ;; row cannot answer: whether the same holds when the suspension comes
+  ;; from a `React.lazy` PAYLOAD rather than from a component that threw a
+  ;; thenable of its own. The two reach React by the same route, so the
+  ;; expectation is that it does — and an expectation is not a
+  ;; measurement, particularly for the retry, which under a lazy head is
+  ;; React re-reading a payload rather than re-running a component.
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (let [_      (seeded!)
+            _      (reset! !set-split nil)
+            handle (mount-concurrent! (mount/fresh-container!)
+                                      (mount/provider frame-id
+                                                      (react/createElement split-host nil)))
+            !state (atom {})]
+        (-> (poll #(and (= 1 (reader-count [:lzb/label])) (some? @!set-split))
+                  "the panel commits and subscribes")
+            (.then
+              (fn [_]
+                (testing "the premise: the boundary is committed, live and
+                          owning its read set BEFORE anything suspends"
+                  (is (= "label=alpha" (painted handle "panel")))
+                  (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership))))
+
+                (swap! !state assoc :first-reg (sole-reader [:lzb/label]))
+
+                ;; The lazy sibling enters an already-committed boundary.
+                (act! (fn [] (@!set-split true)))
+                (poll #(= "waiting" (painted handle "skel2")) "the fallback takes the layout")))
+            (.then
+              (fn [_]
+                (testing "the premise of the premise: the head really did
+                          suspend, and its loader ran"
+                  (is (= 1 @(:calls own-loader))))
+
+                (testing "React hid the committed panel rather than
+                          unmounting it"
+                  (is (some? (node handle "panel")))
+                  (is (false? (visible? handle "panel"))))
+
+                (testing "and hiding it behind a LAZY boundary releases
+                          nothing, exactly as the hand-thrown thenable did.
+                          The count never leaves 1 and the registration is
+                          the same object"
+                  (is (= 1 (reader-count [:lzb/label])))
+                  (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership)))
+                  (is (true? (identical? (:first-reg @!state) (sole-reader [:lzb/label])))
+                      "the same registration, not a rebuilt one"))
+
+                ;; A write DURING the suspension. Because the subscription
+                ;; survived, the hidden panel hears it.
+                (mount/dispatch! handle [:lzb/relabel "beta"])
+                (settle! own-loader :resolve chart-cell)
+                (poll #(= "label=beta" (painted handle "panel"))
+                      "the chunk lands and the boundary is revealed, up to date")))
+            (.then
+              (fn [_]
+                (testing "the arrival leaves EXACT ownership. A lazy retry
+                          that had re-subscribed without releasing would
+                          show here as two, and would paint correctly
+                          throughout"
+                  (is (= 1 (reader-count [:lzb/label])))
+                  (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership)))
+                  (is (true? (identical? (:first-reg @!state) (sole-reader [:lzb/label])))))
+
+                (testing "and the revealed panel needed no correction: it
+                          heard the write while it was hidden, which is
+                          what an Activity-hidden subtree cannot do"
+                  (is (= "label=beta" (painted handle "panel")))
+                  (is (some? (node handle "chart"))))
+
+                (testing "still live after the arrival"
+                  (mount/dispatch! handle [:lzb/relabel "gamma"])
+                  (poll #(= "label=gamma" (painted handle "panel"))
+                        "the revealed boundary repaints"))))
+            (.then
+              (fn [_]
+                (is (= 1 (reader-count [:lzb/label])))
+                (exercised! :lazy/post-commit-suspension)
+                (teardown-census! handle)))
+            (.catch (report-failure! "lazy suspension witness" handle))
+            (.then (fn [_] (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; 4. Rejection, the retry that is not one, and the head that is
+;; ---------------------------------------------------------------------------
+
+(defn- reject-tree
+  [attempt host]
+  (tree [h/boundary {:fallback [:p {:id "fb"} "caught"] :reset-key attempt}
+         [:div
+          [attempt-marker {}]
+          [suspense-host {:fallback [:p {:id "skel3"} "loading"]}
+           [host {}]]]]))
+
+(deftest a-rejected-lazy-head-re-throws-its-cached-error-and-only-a-fresh-head-reloads
+  ;; The repair rf2-hic-041 was filed for. Both `n/lazy`'s docstring and
+  ;; the code-splitting guide said that changing the error boundary's
+  ;; `:reset-key` retries the lazy subtree. It clears the boundary — that
+  ;; part is true and `kernel_commit_owns_dom_cljs_test` measures it — but
+  ;; it cannot retry the CHUNK, because the payload `react/lazy` minted is
+  ;; the thing that remembers the rejection and neither this tier nor
+  ;; React's public API can reset it.
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (let [_      (seeded!)
+            _      (reset! !attempts 0)
+            handle (mount-concurrent! (mount/fresh-container!) (reject-tree 0 reject-host))]
+        (-> (poll #(= "loading" (painted handle "skel3")) "the fallback takes the layout")
+            (.then
+              (fn [_]
+                (testing "the premise: the loader ran once and the region is
+                          pending"
+                  (is (= 1 @(:calls reject-loader))))
+                (settle! reject-loader :reject (js/Error. "chunk 404"))
+                (poll #(= "caught" (painted handle "fb")) "the boundary catches the rejection")))
+            (.then
+              (fn [_]
+                (testing "the rejection reached the error region, and the
+                          Suspense fallback is gone with the subtree that
+                          threw"
+                  (is (nil? (node handle "skel3")))
+                  (is (nil? (node handle "chart")))
+                  (is (= 1 @(:calls reject-loader))))
+
+                ;; The documented retry: change the boundary's :reset-key.
+                (reset! !attempts 0)
+                (.render ^js (:root handle) (reject-tree 1 reject-host))
+                (poll #(pos? @!attempts) "the boundary clears and re-renders its children")))
+            (.then
+              (fn [_]
+                (testing "the premise, and the row is worthless without it:
+                          the `:reset-key` change DID clear the caught error
+                          and re-render the children — the marker beside the
+                          lazy host ran again"
+                  (is (pos? @!attempts)))
+
+                (poll #(= "caught" (painted handle "fb"))
+                      "and the region lands back in the error state")))
+            (.then
+              (fn [_]
+                (testing "…having reloaded NOTHING. This is the whole row:
+                          the paint is identical to a retry that fetched
+                          again and failed again, and only the loader count
+                          separates them. React 19.2's `lazyInitializer`
+                          calls the loader while `_status === -1` and a
+                          rejection sets `_status = 2`, after which every
+                          read throws the cached error"
+                  (is (= 1 @(:calls reject-loader))
+                      "the loader was not called a second time"))
+                (exercised! :lazy/rejection-is-terminal)
+
+                ;; The repair: a NEW head over the SAME loader. This is
+                ;; also what a hot reload allocates, which is why the two
+                ;; facts are one measurement.
+                (reset! !attempts 0)
+                (.render ^js (:root handle) (reject-tree 2 replacement-host))
+                (poll #(= 2 @(:calls reject-loader))
+                      "the fresh head calls the loader it shares with the rejected one")))
+            (.then
+              (fn [_]
+                (testing "so the terminality belongs to the PAYLOAD and not
+                          to the loader — the same function, called again,
+                          by a head allocated after the failure"
+                  (is (= 2 @(:calls reject-loader))))
+                (settle! reject-loader :resolve chart-cell)
+                (poll #(some? (node handle "chart")) "and the region recovers")))
+            (.then
+              (fn [_]
+                (testing "the recovered region is the real component, not a
+                          fallback that happens to be painting"
+                  (is (nil? (node handle "fb")))
+                  (is (= 2 @(:calls reject-loader))))
+                (exercised! :lazy/fresh-head-reloads)
+                (teardown-census! handle)))
+            (.catch (report-failure! "lazy rejection witness" handle))
+            (.then (fn [_] (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; 5. The server render (no DOM needed; runs under :node-test too)
+;; ---------------------------------------------------------------------------
+
+(defn- server-html [hiccup]
+  (react-dom-server/renderToString
+    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+
+(deftest a-client-only-lazy-region-writes-nothing-and-a-declared-fallback-writes-the-skeleton
+  (seeded!)
+  (testing "the guide's own declaration — a Suspense host with a `:fallback`
+            SLOT and no declared placeholder — writes NOTHING to the
+            server response. The slot is React's fallback, and under
+            `:client-only` the whole host region is absent, slot included.
+            Documentation promising a server skeleton from this shape was
+            promising bytes the declaration cannot emit"
+    (let [html (server-html [:div
+                             [:h1 {:id "title"} "metrics"]
+                             [suspense-host {:fallback [:div {:id "react-fallback"} "loading"]}
+                              [ssr-host {:points [1 2 3]}]]])]
+      (is (re-find #"metrics" html)
+          (str "the page rendered — the sibling node is there: " html))
+      (is (not (re-find #"react-fallback" html))
+          (str "and the host region wrote nothing at all: " html))
+      (is (not (re-find #"id=\"chart\"" html))
+          (str "the island certainly did not render: " html))
+      (is (zero? @(:calls ssr-loader))
+          "and the loader was never called: the server never sends the chunk,
+           which is why `n/lazy` pins the region to Client-only whatever the
+           component inside it declared")))
+
+  (testing "the repair is `defhost`'s own `:fallback` — inert markup on the
+            declaration, which the Client-only gate renders on the server
+            AND on hydration's first client pass, so the skeleton has a
+            footprint and the live region replaces it after adoption"
+    (let [html (server-html [:div
+                             [:h1 {:id "title"} "metrics"]
+                             [suspense-skeleton-host {:fallback [:div {:id "react-fallback"} "loading"]}
+                              [ssr-host {:points [1 2 3]}]]])]
+      (is (re-find #"server-skeleton" html)
+          (str "the declared placeholder is in the server HTML: " html))
+      (is (re-find #"aria-busy" html)
+          (str "with its attributes: " html))
+      (is (not (re-find #"id=\"chart\"" html))
+          (str "and still not the island: " html))
+      (is (zero? @(:calls ssr-loader))
+          "nor was the chunk asked for")))
+  (exercised! :lazy/server-render))
+
+;; ---------------------------------------------------------------------------
+;; The roster, asserted rather than described
+;; ---------------------------------------------------------------------------
+
+(deftest the-declared-population-was-actually-exercised
+  (if-not (mount/browser?)
+    (is (set/subset? #{:gate/dedupe-and-retry :lazy/server-render} @!exercised)
+        (str "the two lane-independent rows must run everywhere; missing "
+             (pr-str (set/difference #{:gate/dedupe-and-retry :lazy/server-render} @!exercised))))
+    (is (= declared-population @!exercised)
+        (str "every declared mechanism must actually have been reached; missing "
+             (pr-str (set/difference declared-population @!exercised))))))


### PR DESCRIPTION
Closes rf2-hic-041.

`n/lazy` — the `React.lazy` boundary-ABI bridge — already shipped with the ABI
helpers in rf2-hic-032. What did not exist was a witness for the boundary, and
the merged-PR audit on the bead named three claims the documentation was making
that nothing measured. All three held at source. This lands the witness and
repairs the three.

## What the boundary actually does

**A rejection is terminal, and `:reset-key` does not undo it.** Both `n/lazy`'s
docstring and the code-splitting chapter said that changing the error boundary's
`:reset-key` retries the lazy subtree. It clears the boundary — that part is
true and `kernel_commit_owns_dom_cljs_test` measures it — but it cannot re-fetch
the chunk. React 19.2's `lazyInitializer` calls the loader only while its payload
is uninitialised (`_status === -1`); a rejection sets `_status = 2` and every read
afterwards re-throws the cached error without going near the loader. The payload
belongs to `react/lazy` and neither this tier nor React's public API can reset it.

The reason this survived is that the paint cannot tell the two apart: a fallback
that stays put looks identical whether React re-threw a cached rejection or
fetched again and failed again. So the instrument is the **loader call count**,
and the retry a failed chunk needs is a **new head** — the same allocation a hot
reload performs, which is why the retry fact and the HMR fact are one measurement
here rather than two.

**The suspension result holds across a lazy boundary.**
`activity_suspense_dom_cljs_test` established that hiding a committed subtree for
a Suspense *fallback* leaves its passive effects mounted, so the
`useSyncExternalStore` subscription survives and the retry's registration is
`identical?` to the pre-suspension one. This re-measures it with the suspension
coming from a `React.lazy` payload rather than a hand-thrown thenable, and it is
the same: the reader count never leaves 1, the registration is the same object
throughout, and the hidden panel hears a write made during the suspension and
comes back current without a correction.

**Only a declaration sends server bytes.** `(h/defhost suspense react/Suspense
{:slots #{:fallback}})` is Client-only with no placeholder, so the whole region —
its `:fallback` slot included — is absent from the server response. The chapter
promised a deterministic server skeleton from exactly that shape. The two
`:fallback` keys are different things with the same name, and the guide now says
which one emits bytes.

**The module gate raced on the wrong state.** `:admin/wanted` skipped only
`:loaded`, so warming a module from a hover and then clicking it started a second
fetch — while the chapter's prose and its troubleshooting row both said both
states deduplicate. Gated on `#{:loading :loaded}`, and witnessed as one load.
This is also the only retryable path of the two on the page, and it is now taught
as such.

## Placement, and the lane that compiles it

`implementation/hicasso/test/re_frame/hicasso/lazy_boundary_dom_cljs_test.cljs`.
`hicasso/test` is an existing source path on both the `:node-test` and
`:browser-test` builds and both select on the `cljs-test$` ns-regexp, so the
namespace is compiled and run by `npm run test:cljs` **and** `npm run
test:browser` with no configuration change — proven by the captured deltas below
(+6 tests in each lane). Four rows need real React and state a skip on the node
lane; the module gate is pure re-frame and the server render is `renderToString`,
so those two run everywhere.

**No build id was wanted and `implementation/shadow-cljs.edn` is untouched.** A
witness over a real shadow-cljs `:modules` chunk would need one; the claims under
test are all independent of where the promise came from, so the suite drives real
`React.lazy` payloads with hand-settled promises and a counted stand-in for
`shadow.lazy/load`. If a real-chunk witness is wanted later, that is the hot-zone
conversation and it is a separate bead.

No public export added, no npm dependency, and no third hook — I9 still stands at
two (`n/use-frame`, `n/use-sub`). The fixture's `useState`/`useEffect` are direct
React interop, which is what the tier's hook budget is measured against.

## Quality gates

Each run was made alone with nothing appended, redirected to a file, with the
exit code echoed on the same command line. Every number below was captured, not
recalled.

| gate | command | exit | result |
|---|---|---|---|
| node lane, **base** | `npm run test:cljs` | `0` | Ran 13445 tests containing 67837 assertions. 0 failures, 0 errors. |
| node lane, **head** | `npm run test:cljs` | `0` | Ran 13451 tests containing 67869 assertions. 0 failures, 0 errors. |
| browser lane, **base** | `npm run test:browser` | `0` | Ran 1310 tests containing 8114 assertions. 0 failures, 0 errors. |
| browser lane, **head** | `npm run test:browser` | `0` | Ran 1316 tests containing 8163 assertions. 0 failures, 0 errors. |
| release + isolation | `npm run build:hicasso-release` | `0` | see below |
| hicasso invariants | `npm run test:hicasso-invariants` | `0` | freeze, optional-module reachability, complaint catalogue, budget ledger |
| hicasso lint export | `npm run test:hicasso-lint` | `0` | |
| doc slugs | `python scripts/check_doc_slugs.py` | `0` | |
| provenance pins (CI form) | `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | `0` | 1 file, 0 cited pins |
| fast-PR gap | `python scripts/check_fast_pr_gap.py --list` | `0` | 97 required checks this spine does not decide |

The base numbers were measured on this branch's own base by holding the new
namespace out of the tree for one run of each lane — not quoted from anywhere.
Delta: **+6 tests / +32 assertions** on the node lane, **+6 tests / +49
assertions** on the browser lane.

`clj-kondo --lint` on both changed source files: 0 errors, 0 warnings. Local
binary is v2025.10.23 and CI pins 2026.04.15, so this is a signal and not a
verdict.

### What the bundle-isolation gate reports

```
hicasso production erasure: self-test OK (5 sentinels, 3 positive controls)
OK: no dev-only Hicasso surface in the :advanced / goog.DEBUG=false bundle
    (5 sentinels absent, 3 positive controls present).
hicasso bundle isolation: self-test OK (2 sentinels, 4 positive controls)
OK: no native-tier runtime in the interpreted-only :advanced / goog.DEBUG=false
    bundle (2 sentinels absent, 4 positive controls present).
```

Code splitting is exactly what can break clause 6, so this was the gate to watch.
It has nothing to say about *my* chunks because **there are none**: the change
adds no module, no build id and no production code beyond docstring prose in
`native.cljc`, so the interpreted-only dependency graph and bundle are byte-for-byte
the same question they were before and the answer is unchanged.

## Sabotage, both directions

**Removal — take the behaviour away, capture the red naming the line.**

1. Narrow the module gate back to `#{:loaded}` — the defect the audit found.
   `npm run test:cljs` → **exit 1, 3 failures**, first at
   `lazy_boundary_dom_cljs_test.cljs:367:11`:

   ```
   FAIL in (the-module-gate-dedupes-a-hover-and-a-click-into-one-load)
   a warm-on-hover followed by a click fetched the chunk once
   expected: (= 1 (clojure.core/deref !module-loads))
     actual: (not (= 1 3))
   ```

2. Remove the declared `:fallback` from the SSR host — the shape the chapter
   documented. `npm run test:cljs` → **exit 1, 2 failures** at `:695:11` and
   `:697:11`, and the message prints the whole server response, which is the
   audit's third claim in one line:

   ```
   FAIL in (a-client-only-lazy-region-writes-nothing-and-a-declared-fallback-writes-the-skeleton)
   expected: (re-find #"server-skeleton" html)
     actual: (not (re-find #"server-skeleton" "<div><h1 id=\"title\">metrics</h1></div>"))
   ```

**Widening — loosen the guard and confirm a legal near-miss stops being caught.**

The retry row's danger is being *too eager*: "the loader was not called again" is
trivially true for a boundary that never retried at all. So drop the
`!attempts` premise and re-render with the `:reset-key` **held at 0**, which
leaves the boundary in its caught state and re-renders nothing.

`npm run test:browser` → **exit 0, Ran 1316 tests containing 8162 assertions,
0 failures** — one assertion fewer than the honest run, and fully green having
measured nothing. That is what the premise buys, and it is why the row polls
`(pos? @!attempts)` before it reads the loader count.

The other half of the same guard is the count itself: widen `(= 1 calls)` to
`(pos? calls)` and the row can no longer separate "React re-threw the cache" from
"the loader ran again", which is the entire claim. The row's closing steps mount a
fresh head over the **same** loader and assert the count reaches 2, so the two
behaviours are staged side by side and only the exact count tells them apart.

## Docs verification

`docs/design/hicasso/**` is in `mkdocs.yml`'s `exclude_docs`, so `mkdocs build
--strict` is **not** the gate for this edit. `scripts/check_doc_slugs.py` is, and
it is green above. By hand: the troubleshooting table is 13 rows and every one has
exactly 3 columns; the new `#retaining-hidden-native-ui-with-activity` link
resolves to the chapter's own `## Retaining hidden native UI with Activity`
heading; the two new `###` headings sit under `## Lazy native components with
Suspense` and `## What happens to reads during suspension` respectively.

## Filed rather than fixed

**rf2-g8rb** — the error region is exported as `h/boundary` and documented as
`h/error-boundary`, in eleven documents including the naming ledger, whose row 12
rules for the spelling the code does not have. Code written from chapter 17 or
chapter 21 does not compile. That is a naming decision and not a worker's, so this
PR changed only the one implementation-internal occurrence — `n/lazy`'s docstring,
which disagreed with `codec.cljs` and `hicasso.cljc` in the same package — and
left every document's spelling alone.

## Coordination

`native.cljc` is the only shared file touched and the hunk is docstring prose. The
new witness is a new file and does not go near the mount path, so it should not
meet `ssr-hic046`. `docs/design/hicasso/draft-guide/21-code-splitting.md` is a
draft-guide page and the guide-authoring worktrees are live — if one of them is
rewriting chapter 21, sequence this first or rebase that one.
