### PR TITLE
Routing conduct: the navigation witness — focus-on-route, scroll restoration and the dirty-leave wiring point, measured in a browser (rf2-hic-042)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/examples/navigation/conduct_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/navigation/conduct_dom_cljs_test.cljs
@@ -495,11 +495,12 @@
                      (is (= 300 (scroll-y))
                          (str "a `:restore` with nothing saved for this URL must
                               leave the page where it is; it reads " (scroll-y)
-                              ". " deep-offset " here would mean the cache had
-                              handed back the LIST's position — a restore keyed
-                              by \"the last thing saved\" rather than by URL,
-                              which passes the positive row and puts every user
-                              at somebody else's scroll offset"))
+                              ". The LIST's offset (" deep-offset ") appearing
+                              here would mean the cache had handed back somebody
+                              else's position — a restore keyed by \"the last
+                              thing saved\" rather than by URL, which passes the
+                              positive row and puts every user at an offset they
+                              never chose"))
                      (two-frames)))
             (.then (fn [_]
                      (is (= 300 (scroll-y))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/navigation/conduct_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/navigation/conduct_dom_cljs_test.cljs
@@ -1,0 +1,507 @@
+(ns re-frame.hicasso.examples.navigation.conduct-dom-cljs-test
+  "L4 — WHAT THE BROWSER SAYS ABOUT NAVIGATION CONDUCT (rf2-hic-042;
+  specification §7's routing row).
+
+  The row's required proof is *deep link, back/forward, pending
+  mutation*, and its additional surface is *dirty-leave, scroll
+  restoration and focus-on-route recipes*. Those three proofs and two of
+  those recipes are what this file measures, on
+  `re-frame.hicasso.examples.navigation` — an ordinary two-route
+  application written on the public door.
+
+  ## Why every row here needs an engine
+
+  Prefetch, scroll restoration and focus are the three behaviours in this
+  programme that pass most easily by accident. A scroll position that
+  happens to be 0 reads the same whether restoration worked or nothing
+  happened at all; a focus that landed on `<body>` is indistinguishable
+  from a focus that was never asked for, if all you assert is *something
+  is focused*. `document.activeElement` and `window.scrollY` are not
+  derivable from a tree, so `:node-test` compiles this namespace and each
+  row degrades there to a STATED skip — honest, and not a measurement.
+
+  The one row that is NOT engine-dependent is
+  [[the-element-the-recipe-focuses-is-a-heading-with-the-panes-name]],
+  and it runs in both lanes on purpose: it is the structural half of the
+  correlation, asserting through `ht/role` and `ht/accessible-name` that
+  the marker the recipe aims at sits on a real heading carrying a real
+  name. Without it the browser rows would prove only that focus moved to
+  *an element*, which is not the claim.
+
+  ## The two directions, per behaviour
+
+  **Focus.** Positive: a completed navigation puts focus on the pane it
+  arrived at (deep link, and Back). Too-eager: a navigation that was
+  BLOCKED must move nothing, and an ordinary re-render must move nothing
+  — a recipe hung off a render, or off an *attempted* navigation, passes
+  the positives and fails both of these, and would take a user out of the
+  field they are still typing in.
+
+  **Scroll.** Positive: a forward navigation lands at the top, and Back
+  restores the exact offset the page was left at. Too-eager: a
+  navigation carrying `:scroll false` must move nothing, and a Back to a
+  URL that was never visited must NOT inherit some other URL's saved
+  position — an implementation that restored *the last position it had*
+  passes the positive row and fails that one.
+
+  Both scroll rows first assert that scrolling MOVED the page, before
+  asserting anything about where it ended up. `window.scrollTo` on a
+  document shorter than the viewport is a silent no-op that reads back
+  0, which is also what a correct scroll-to-top reads: the precondition
+  is what stops the whole scroll half being green on a page that never
+  scrolled.
+
+  ## What this file deliberately does not witness
+
+  **Prefetch.** `re-frame.routing` warms a destination from all three
+  credible-intent positions (`:on-mouse-enter` / `:on-focus` /
+  `:on-touch-start`, the closed class `re-frame.routing.link/
+  prefetch-intent-keys` holds), and `re-frame.ui.route-link-dom-cljs-test`
+  drives them with real DOM events. Hicasso's own `h/route-link` DECLINES
+  `:prefetch` outright in v0 and fails loud at the link site
+  (`:rf.error/hicasso-route-link-prefetch-declined`), so there is nothing
+  on this application's surface to witness. Admitting the key is a
+  naming-ledger question that is still open (row 36 — *keep as taught*,
+  status open), not this bead's to settle."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso.examples.navigation.events :as events]
+            [re-frame.hicasso.examples.navigation.routes :as routes]
+            [re-frame.hicasso.examples.navigation.subs :as subs]
+            [re-frame.hicasso.examples.navigation.views :as views]
+            [re-frame.hicasso.test :as ht]
+            [re-frame.hicasso.test.mounted :as hm]
+            [re-frame.routing :as routing]
+            [re-frame.test-support :as test-support]))
+
+;; ---------------------------------------------------------------------------
+;; The lane
+;; ---------------------------------------------------------------------------
+
+(defn- browser? [] (exists? js/document))
+
+(defn- skip! [why]
+  (is true (str "a navigation-conduct witness needs a real browser — " why)))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+                      ;; The host-side scroll cache is a module-level
+                      ;; `defonce` and survives the registrar reset, so a
+                      ;; position saved by one row would still be there for
+                      ;; the next — which is precisely what the
+                      ;; never-visited-URL row is written to rule out.
+                      (routing/reset-scroll-cache!)
+                      (routes/register!))}))
+
+;; ---------------------------------------------------------------------------
+;; Reading the page
+;; ---------------------------------------------------------------------------
+
+(def ^:private first-article
+  "The article every row navigates to, and its title — which is also the
+  accessible name of the heading a landing focus must reach."
+  {:slug "deep-space" :title "Deep space, and how to get there"})
+
+(defn- node [m sel] (.querySelector (:container m) sel))
+
+(defn- heading [m] (node m "[data-route-heading]"))
+
+(defn- active [] (.-activeElement js/document))
+
+(defn- active-label
+  "How a failure NAMES whatever holds focus. A route heading is named by
+  its text, because that is what a user would hear; everything else by
+  its id or its tag. Short enough to read in a failure message."
+  []
+  (let [el (active)]
+    (cond
+      (nil? el)                               "nothing"
+      (.hasAttribute el "data-route-heading") (str "the route heading "
+                                                   (pr-str (.-textContent el)))
+      (seq (.-id el))                         (str "#" (.-id el))
+      :else                                   (str "<" (.toLowerCase (.-tagName el)) ">"))))
+
+(defn- read-sub [m query-v] (rf/subscribe-once query-v {:frame (:frame m)}))
+
+(defn- at!
+  "Mount the application with its first navigation already made — the deep
+  link, and the shape every other row starts from."
+  ([route] (at! route nil))
+  ([route params]
+   (hm/mount! [views/app {}]
+              {:initial-events [[::events/seed]
+                                [:rf.route/navigate (cond-> {:to route}
+                                                      params (assoc :params params))]]})))
+
+(defn- finish [m done]
+  (-> (hm/unmount! m) (hm/assert-clean!) (.then done)))
+
+(defn- finish-after
+  "End the row when `p` settles, reporting a rejection as a failure rather
+  than letting a deadline hang the run — and tearing the mount down
+  either way, so a stuck row cannot make the next row's reading wrong."
+  [p m done]
+  (-> p
+      (.catch (fn [e]
+                (is false (str "the flow never settled: "
+                               (or (ex-message e) (str e)) " "
+                               (pr-str (ex-data e))))))
+      (.then (fn [_] (finish m done)))))
+
+;; ---------------------------------------------------------------------------
+;; Waiting for a frame, and waiting long enough to disbelieve
+;; ---------------------------------------------------------------------------
+
+(defn- next-frame []
+  (js/Promise. (fn [resolve] (js/requestAnimationFrame #(resolve true)))))
+
+(defn- two-frames
+  "Wait two animation frames.
+
+  This is what the NEGATIVE focus rows wait on, and the wait is the row.
+  The recipe defers its focus by exactly one frame, so a row asserting
+  *focus did not move* that read `document.activeElement` on the next
+  line would be green because nothing had happened YET — the failure mode
+  the whole file is arranged against. Two frames is one more than any
+  correct implementation needs and one more than the incorrect one would
+  have taken."
+  []
+  (.then (next-frame) (fn [_] (next-frame))))
+
+(defn- focused-heading
+  "Wait until the route heading holds focus, then answer it. The positive
+  focus rows poll rather than counting frames, because a deadline reports
+  WHICH heading never arrived and a frame count reports only that a line
+  was false."
+  [m label]
+  (-> (test-support/poll-until
+        #(let [el (active)]
+           (and (some? el) (.hasAttribute el "data-route-heading")))
+        {:label label})
+      (.then (fn [_] (heading m)))))
+
+;; ---------------------------------------------------------------------------
+;; The page's scroll, asked of the engine
+;; ---------------------------------------------------------------------------
+
+(defn- scroll-to! [y] (.scrollTo js/window 0 y))
+
+(defn- scroll-y [] (js/Math.round (.-scrollY js/window)))
+
+(defn- scrolled-to!
+  "Scroll the page to `y` and assert the engine took it. Every scroll row
+  runs through here: a document that cannot scroll answers 0 to
+  `window.scrollY`, and 0 is also the right answer for a working
+  scroll-to-top, so an unasserted scroll would make the rest of the row
+  meaningless without making it fail."
+  [y]
+  (scroll-to! y)
+  (is (= y (scroll-y))
+      (str "precondition: the page must actually scroll to " y
+           " — it reads " (scroll-y) ". Without this the rows below are"
+           " green on a page that never moved"))
+  y)
+
+;; ---------------------------------------------------------------------------
+;; The structural half — what the recipe is aiming at
+;; ---------------------------------------------------------------------------
+
+(deftest the-element-the-recipe-focuses-is-a-heading-with-the-panes-name
+  (let [tree (ht/tree [views/feed-page {}]
+                      {:subs {[::subs/feed] [{:slug "deep-space" :title "Deep space"}]}})
+        marked (ht/find tree #(= "true" (:data-route-heading (ht/attrs %))))]
+    (testing "the marker the focus effect selects on exists, exactly once,
+              and is on a real heading"
+      (is (some? marked)
+          "no element carries :data-route-heading — the recipe would focus
+           nothing, and every browser row below would be asserting that a
+           nil selector match is a no-op")
+      (is (= 1 (count (ht/find-all tree #(= "true" (:data-route-heading (ht/attrs %))))))
+          "exactly one: `querySelector` takes the first match in document
+           order, so a second marker is a focus target chosen by accident
+           of markup order")
+      (is (= :heading (ht/role marked))
+          "a heading, per `ht/role` — landing focus on an unlabelled
+           `<div>` announces nothing, which is the version of this recipe
+           that passes a browser row and helps nobody"))
+
+    (testing "and it carries the pane's own accessible name, so arriving
+              there says WHERE the user arrived"
+      (is (= "Articles" (ht/accessible-name tree marked))))
+
+    (testing "it is programmatically focusable and NOT a new Tab stop"
+      (is (= -1 (:tab-index (ht/attrs marked)))
+          "-1, not 0: the heading is a focus TARGET, not a stop on the Tab
+           order. Without any tabindex the engine refuses focus outright
+           and `.focus()` is a silent no-op; with 0 the recipe buys itself
+           an extra Tab press for every keyboard user on every page"))))
+
+;; ---------------------------------------------------------------------------
+;; Focus — the positives
+;; ---------------------------------------------------------------------------
+
+(deftest a-deep-link-lands-focus-on-the-pane-it-opened
+  (if-not (browser?)
+    (skip! ":node-test has no focus model")
+    (async done
+      (let [m (at! routes/article {:slug (:slug first-article)})]
+        (-> (focused-heading m "the deep link's landing focus")
+            (.then (fn [h]
+                     (is (identical? h (active))
+                         (str "focus is on " (active-label) ", not the article's
+                              heading. A URL opened cold is where a keyboard or
+                              screen-reader user starts, and `pushState` moves
+                              focus nowhere by itself — `<body>` holds it and the
+                              first Tab press starts from the top of the document"))
+                     (is (= (:title first-article) (.-textContent h))
+                         "and the heading names the article that was opened, so
+                          the landing is not merely somewhere but somewhere
+                          identifiable")))
+            (finish-after m done))))))
+
+(deftest going-back-lands-focus-on-the-pane-it-returned-to
+  (if-not (browser?)
+    (skip! ":node-test has no focus model")
+    (async done
+      (let [m (at! routes/article {:slug (:slug first-article)})]
+        (-> (focused-heading m "the deep link's landing focus")
+            (.then (fn [_]
+                     ;; The Back button, as the framework sees it: one
+                     ;; `:rf.route/handle-url-change` carrying `:popstate`.
+                     ;; Dispatched rather than driven through real history
+                     ;; because this mount's frame is not URL-bound — what
+                     ;; is under test is the conduct the door produces, not
+                     ;; the listener that opens it.
+                     (hm/dispatch-and-settle!
+                       m [:rf.route/handle-url-change "/navigation"
+                          {:rf.route/cause :popstate}])
+                     (is (= routes/feed (read-sub m [:rf.route/id]))
+                         "the Back really landed, so the row below is not green
+                          for want of anything happening")
+                     (focused-heading m "the Back navigation's landing focus")))
+            (.then (fn [h]
+                     (is (identical? h (active))
+                         (str "focus is on " (active-label) " after Back"))
+                     (is (= "Articles" (.-textContent h))
+                         "and it is the LIST's heading — a recipe that focused
+                          whatever it focused last would still be holding the
+                          article heading, which has just been unmounted")))
+            (finish-after m done))))))
+
+;; ---------------------------------------------------------------------------
+;; Focus — the too-eager directions
+;; ---------------------------------------------------------------------------
+
+(deftest a-re-render-does-not-move-focus
+  (if-not (browser?)
+    (skip! ":node-test has no focus model")
+    (async done
+      (let [m (at! routes/article {:slug (:slug first-article)})]
+        (-> (focused-heading m "the deep link's landing focus")
+            (.then (fn [_]
+                     ;; Put focus where a user would have it — in the field
+                     ;; they are typing in — and then re-render underneath
+                     ;; them.
+                     (.focus (node m "#navigation-title"))
+                     (hm/dispatch-and-settle!
+                       m [::events/edit (:slug first-article) "Deep space, revisited"])
+                     (is (= "Deep space, revisited" (.-value (node m "#navigation-title")))
+                         "the re-render really happened")
+                     (two-frames)))
+            (.then (fn [_]
+                     (is (identical? (node m "#navigation-title") (active))
+                         (str "focus moved to " (active-label) " on a keystroke.
+                              The recipe is hung off `:on-match`, which a render
+                              does not fire; one hung off a render instead would
+                              pass every positive row in this file and take the
+                              user out of the field on every character"))))
+            (finish-after m done))))))
+
+(deftest a-blocked-navigation-moves-neither-the-route-nor-the-focus
+  (if-not (browser?)
+    (skip! ":node-test has no focus model")
+    (async done
+      (let [m    (at! routes/article {:slug (:slug first-article)})
+            slug (:slug first-article)]
+        (-> (focused-heading m "the deep link's landing focus")
+            (.then (fn [_]
+                     ;; The pending mutation: a typed, unsaved title. The
+                     ;; article route's `:can-leave` guard reads it.
+                     (hm/dispatch-and-settle! m [::events/edit slug "Half a title"])
+                     (.focus (node m "#navigation-title"))
+
+                     (hm/dispatch-and-settle! m [:rf.route/navigate {:to routes/feed}])
+
+                     (testing "the leave is REFUSED, and parked rather than dropped"
+                       (is (= routes/article (read-sub m [:rf.route/id]))
+                           "the route did not move")
+                       (is (some? (read-sub m [:rf/pending-navigation]))
+                           "and the refusal is resumable — routing wrote one
+                            pending value, which is the wiring point this
+                            application reads")
+                       (is (some? (node m ".leave-prompt"))
+                           "the application showed it"))
+
+                     (two-frames)))
+            (.then (fn [_]
+                     (is (identical? (node m "#navigation-title") (active))
+                         (str "focus moved to " (active-label) " on a navigation
+                              that never happened. This is the case a focus
+                              recipe is most likely to get wrong and least
+                              likely to be tested for: the user is mid-sentence
+                              in an unsaved field, and an eager recipe answers a
+                              refused navigation by taking them out of it"))
+
+                     ;; Resume through the application's own wiring point,
+                     ;; not through a hand-written event id.
+                     (.click (node m ".leave-anyway"))
+                     (hm/settle! m)
+                     (is (= routes/feed (read-sub m [:rf.route/id]))
+                         "the parked navigation resumed on confirmation")
+                     (focused-heading m "the resumed navigation's landing focus")))
+            (.then (fn [h]
+                     (is (= "Articles" (.-textContent h))
+                         "and NOW focus moves — so the row above is about a
+                          navigation that was refused, not about a recipe that
+                          never fires")))
+            (finish-after m done))))))
+
+;; ---------------------------------------------------------------------------
+;; Scroll restoration — the positives
+;; ---------------------------------------------------------------------------
+
+(def ^:private deep-offset
+  "Far enough down the list that landing back at the top would be
+  unmistakable, and well inside the shell's height so nothing is clamped."
+  900)
+
+(deftest a-forward-navigation-lands-at-the-top-and-back-restores-the-offset
+  (if-not (browser?)
+    (skip! ":node-test has no scroll model")
+    (async done
+      (scroll-to! 0)
+      (let [m (at! routes/feed)]
+        (-> (focused-heading m "the list's landing focus")
+            (.then (fn [_]
+                     (scrolled-to! deep-offset)
+
+                     (hm/dispatch-and-settle!
+                       m [:rf.route/navigate {:to routes/article
+                                              :params {:slug (:slug first-article)}}])
+                     (is (= routes/article (read-sub m [:rf.route/id])))
+                     (is (= 0 (scroll-y))
+                         (str "a forward navigation lands at the top and this one
+                              is at " (scroll-y) ". Arriving at a new page
+                              already scrolled down is the defect every router
+                              ships a scroll strategy for"))
+
+                     ;; Back. `:rf.route/handle-url-change` defaults to
+                     ;; `:restore`, and the position it looks up is the one
+                     ;; `:rf.nav/capture-scroll` saved for `/navigation`
+                     ;; when the navigation above left it.
+                     (hm/dispatch-and-settle!
+                       m [:rf.route/handle-url-change "/navigation"
+                          {:rf.route/cause :popstate}])
+                     (is (= routes/feed (read-sub m [:rf.route/id])))
+                     (is (= deep-offset (scroll-y))
+                         (str "Back restored " (scroll-y) " rather than "
+                              deep-offset ". The list is where the user was
+                              reading; sending them to the top of it is the
+                              whole reason the capture/restore pair exists"))
+
+                     ;; And the two recipes COMPOSE. Focus moves to the
+                     ;; list's heading one frame after the restore — with
+                     ;; `:preventScroll`, which is the only reason the
+                     ;; offset asserted above is still there a frame later.
+                     (focused-heading m "the Back navigation's landing focus")))
+            (.then (fn [h]
+                     (is (identical? h (active)))
+                     (is (= deep-offset (scroll-y))
+                         (str "the landing focus scrolled the page back to "
+                              (scroll-y) ". Focusing an element scrolls it into
+                              view, and the focus recipe runs one frame AFTER
+                              the restore — so a `.focus()` without
+                              `:preventScroll` silently undoes scroll
+                              restoration on exactly the navigation it exists
+                              for, with both features looking installed"))))
+            (finish-after m done))))))
+
+;; ---------------------------------------------------------------------------
+;; Scroll restoration — the too-eager directions
+;; ---------------------------------------------------------------------------
+
+(deftest a-navigation-that-suppresses-scrolling-moves-nothing
+  (if-not (browser?)
+    (skip! ":node-test has no scroll model")
+    (async done
+      (scroll-to! 0)
+      (let [m (at! routes/feed)]
+        (-> (focused-heading m "the list's landing focus")
+            (.then (fn [_]
+                     (scrolled-to! 700)
+
+                     (hm/dispatch-and-settle!
+                       m [:rf.route/navigate {:to     routes/article
+                                              :params {:slug (:slug first-article)}
+                                              :scroll false}])
+                     (is (= routes/article (read-sub m [:rf.route/id]))
+                         "the navigation happened, so the row is not green for
+                          want of one")
+                     (is (= 700 (scroll-y))
+                         (str "`:scroll false` suppresses the effect entirely and
+                              the page reads " (scroll-y) ". An implementation
+                              that always scrolled to the top would pass the
+                              positive row above and fail only here"))
+
+                     ;; And the focus recipe still runs — suppressing the
+                     ;; scroll is not suppressing the navigation.
+                     (focused-heading m "the suppressed-scroll navigation's landing focus")))
+            (.then (fn [_]
+                     (is (= 700 (scroll-y))
+                         "and the landing focus did not scroll either")))
+            (finish-after m done))))))
+
+(deftest a-back-to-a-url-never-visited-inherits-no-other-urls-position
+  (if-not (browser?)
+    (skip! ":node-test has no scroll model")
+    (async done
+      (scroll-to! 0)
+      (let [m (at! routes/feed)]
+        (-> (focused-heading m "the list's landing focus")
+            (.then (fn [_]
+                     ;; Leave `/navigation` at a distinctive offset, so the
+                     ;; cache holds exactly one position and it is one no
+                     ;; other URL is entitled to.
+                     (scrolled-to! deep-offset)
+                     (hm/dispatch-and-settle!
+                       m [:rf.route/navigate {:to routes/article
+                                              :params {:slug (:slug first-article)}}])
+                     (is (= 0 (scroll-y)))
+                     (scrolled-to! 300)
+
+                     ;; A Back to a URL this session has never left — so the
+                     ;; cache has nothing keyed under it.
+                     (hm/dispatch-and-settle!
+                       m [:rf.route/handle-url-change "/navigation/article/shallow-water"
+                          {:rf.route/cause :popstate}])
+                     (is (= "shallow-water" (:slug (read-sub m [:rf.route/params])))
+                         "the navigation happened")
+                     (is (= 300 (scroll-y))
+                         (str "a `:restore` with nothing saved for this URL must
+                              leave the page where it is; it reads " (scroll-y)
+                              ". " deep-offset " here would mean the cache had
+                              handed back the LIST's position — a restore keyed
+                              by \"the last thing saved\" rather than by URL,
+                              which passes the positive row and puts every user
+                              at somebody else's scroll offset"))
+                     (two-frames)))
+            (.then (fn [_]
+                     (is (= 300 (scroll-y))
+                         "and still, a frame later, after the landing focus")))
+            (finish-after m done))))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/navigation/conduct_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/navigation/conduct_dom_cljs_test.cljs
@@ -165,12 +165,13 @@
   "Wait two animation frames.
 
   This is what the NEGATIVE focus rows wait on, and the wait is the row.
-  The recipe defers its focus by exactly one frame, so a row asserting
-  *focus did not move* that read `document.activeElement` on the next
-  line would be green because nothing had happened YET — the failure mode
-  the whole file is arranged against. Two frames is one more than any
-  correct implementation needs and one more than the incorrect one would
-  have taken."
+  A correct implementation moves focus on no frame at all here, and the
+  incorrect one — the recipe hung off a render, or off an attempted
+  navigation — would move it on the FIRST, because that is the deferral
+  the effect performs. So a row asserting *focus did not move* that read
+  `document.activeElement` on the next line would be green because
+  nothing had happened yet, which is the failure mode this whole file is
+  arranged against. Two frames is one more than the wrong answer needs."
   []
   (.then (next-frame) (fn [_] (next-frame))))
 

--- a/implementation/hicasso/test/re_frame/hicasso/examples/navigation/events.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/navigation/events.cljs
@@ -1,0 +1,146 @@
+(ns re-frame.hicasso.examples.navigation.events
+  "THE NAVIGATION WITNESS'S EVENTS — and the focus-on-route RECIPE
+  (rf2-hic-042; specification §7's routing row).
+
+  Ordinary re-frame2, like every other witness application's model tier:
+  `re-frame.core` and pure functions, no view door, nothing here that
+  could tell you a substrate existed.
+
+  The one thing this file holds that no other witness does is the
+  **focus-on-route recipe** — [[::pane-shown]] and its [[::focus-heading]]
+  effect. It is a recipe rather than a framework facility because the
+  framework does not have one and says so: `re-frame.routing.navigate`'s
+  own commentary records that `pushState` / `replaceState` do not move
+  focus, that `:rf.nav/scroll` is therefore required, and that no focus or
+  `:target`-pseudo-class parity claim is made — *a separate a11y
+  decision*. There is no `:rf.nav/focus` fx, no `:focus` route-metadata
+  key and no `document.activeElement` write anywhere under
+  `implementation/routing`. So an application that wants a keyboard or
+  screen-reader user to arrive somewhere after a navigation writes the
+  three forms below, and this is what they look like.
+
+  ## Why it hangs off `:on-match` and not off a view
+
+  `:on-match` is routing's own fire-and-forget dispatch, taken on a
+  navigation that actually COMMITTED. That is the whole reason it is the
+  right hook and a re-render is not:
+
+  - A blocked navigation never reaches it. A dirty editor whose
+    `:can-leave` guard refuses leaves the user exactly where they were
+    typing — a recipe wired to *attempted* navigation would yank focus
+    out of the field they are still editing, which is the same defect as
+    having no recipe, pointed the other way.
+  - A re-render is not a navigation. Typing a character re-renders the
+    article pane; nothing about that should move focus, and nothing here
+    can, because no keystroke fires `:on-match`.
+  - Hicasso has no effect DSL and no local ref, deliberately (the
+    completeness audit's explicit refusals). A view could not run this
+    even if it wanted to.
+
+  ## Why the effect waits a frame, which is the only subtle line in it
+
+  `:on-match` dispatches DURING the navigation cascade. The route slice
+  has moved, but React has not re-rendered yet, so at the instant the
+  effect runs the heading it wants to focus **does not exist** — and
+  `document.querySelector` would answer nil, and the recipe would be a
+  silent no-op that looked exactly like a working one. One
+  `requestAnimationFrame` is after the commit and after paint, which is
+  the first moment the new pane is on the page.
+
+  It is worth being plain that this ordering is not a Hicasso property:
+  it is React's, and any substrate that commits asynchronously has it.
+  The frame is also why the witness waits two frames before asserting
+  that focus did NOT move — a negative that did not wait would be green
+  for want of time."
+  (:require [re-frame.core :as rf]))
+
+;; ---------------------------------------------------------------------------
+;; Boot
+;; ---------------------------------------------------------------------------
+
+(def seed
+  "The starting app-db. Three articles, no drafts, nothing in flight.
+
+  Titles rather than bodies because the accessible NAME of the article
+  pane's heading is what the focus rows read back — a heading whose name
+  is the article's title is how a user knows the navigation landed."
+  {:articles [{:slug "deep-space"    :title "Deep space, and how to get there"}
+              {:slug "shallow-water" :title "Shallow water"}
+              {:slug "long-way-round" :title "The long way round"}]
+   :drafts   {}})
+
+(rf/reg-event ::seed
+  {:doc "Install the starting app-db. The frame's `:initial-events` step."}
+  (fn [_ _] {:db seed}))
+
+;; ---------------------------------------------------------------------------
+;; Editing — one controlled field, and it is what makes a leave dirty
+;; ---------------------------------------------------------------------------
+
+(rf/reg-event ::edit
+  {:doc "Write the draft title for one article. POSITIONAL, because it
+  carries `::h/value` and the marker substitutes at the intent vector's
+  top level only."}
+  (fn [{:keys [db]} [_ slug title]]
+    {:db (assoc-in db [:drafts slug] title)}))
+
+(rf/reg-event ::save
+  {:doc "Commit the draft and drop it. A saved article is no longer dirty,
+  so the `:can-leave` guard stops refusing — this is the event the
+  blocked-navigation row uses to make the block END rather than merely
+  exist."}
+  (fn [{:keys [db]} [_ {:keys [slug]}]]
+    (let [title (get-in db [:drafts slug])]
+      {:db (cond-> (update db :drafts dissoc slug)
+             (some? title)
+             (update :articles
+                     (fn [as]
+                       (mapv #(cond-> % (= slug (:slug %)) (assoc :title title))
+                             as))))})))
+
+;; ---------------------------------------------------------------------------
+;; The focus-on-route recipe
+;; ---------------------------------------------------------------------------
+
+(def heading-selector
+  "The one element per pane that a completed navigation focuses.
+
+  A data attribute rather than an id: the marker says *this is the
+  heading the route arrived at*, which is a claim about the pane's role
+  in navigation, and an id would say only that it is called something.
+  Each pane carries exactly one, and the views put `:tab-index -1` beside
+  it so the engine will accept focus on a heading — a heading is not
+  natively focusable, and without the tabindex `.focus()` is a no-op that
+  leaves `<body>` holding focus and nothing on screen to say so."
+  "[data-route-heading]")
+
+(rf/reg-event ::pane-shown
+  {:doc "The routes' `:on-match`. A navigation committed, so ask for focus
+  to move to whichever pane is now on screen."}
+  (fn [_ _]
+    {::focus-heading {:selector heading-selector}}))
+
+(rf/reg-fx ::focus-heading
+  {:doc       "Move focus to the element `:selector` names, on the first
+  frame after the commit that put it there, WITHOUT scrolling. A selector
+  that matches nothing is a no-op — a route whose pane has no heading is
+  an application's choice, not a failure this effect can act on."
+   :platforms #{:client}}
+  (fn [_ {:keys [selector]}]
+    ;; See the namespace docstring §Why the effect waits a frame. The
+    ;; lookup happens INSIDE the callback, not outside it: resolving the
+    ;; element now would resolve the OLD pane's heading, which is the
+    ;; version of this bug that still focuses something and is therefore
+    ;; the harder one to see.
+    (js/requestAnimationFrame
+      (fn []
+        ;; `:preventScroll` is not a nicety, and leaving it out is the
+        ;; sharpest bug in this file. Focusing an element scrolls it into
+        ;; view, and this effect runs one frame AFTER `:rf.nav/scroll`
+        ;; has already restored the offset a Back button asked for — so a
+        ;; plain `.focus()` here silently undoes scroll restoration, on
+        ;; exactly the navigation restoration exists for, and both
+        ;; features look installed the whole time. The two recipes have
+        ;; to be written to compose; this is where they do.
+        (some-> (.querySelector js/document selector)
+                (.focus #js {:preventScroll true}))))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/navigation/events.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/navigation/events.cljs
@@ -117,8 +117,11 @@
 (rf/reg-event ::pane-shown
   {:doc "The routes' `:on-match`. A navigation committed, so ask for focus
   to move to whichever pane is now on screen."}
+  ;; `:fx`, not a top-level effect key: re-frame2's effect map is CLOSED at
+  ;; `{:db … :fx …}`, so a classic `{::focus-heading …}` return is not an
+  ;; effect at all.
   (fn [_ _]
-    {::focus-heading {:selector heading-selector}}))
+    {:fx [[::focus-heading {:selector heading-selector}]]}))
 
 (rf/reg-fx ::focus-heading
   {:doc       "Move focus to the element `:selector` names, on the first

--- a/implementation/hicasso/test/re_frame/hicasso/examples/navigation/routes.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/navigation/routes.cljs
@@ -1,0 +1,82 @@
+(ns re-frame.hicasso.examples.navigation.routes
+  "THE NAVIGATION WITNESS'S TWO ROUTES — and the three pieces of route
+  METADATA that are the whole of its conduct (rf2-hic-042).
+
+  Two `reg-route` calls. Everything this application does after a
+  navigation — where focus lands, where the page is scrolled to, whether
+  the navigation is allowed to happen at all — is declared here, on the
+  route, as data:
+
+      :on-match   the focus-on-route recipe's hook. Fire-and-forget, and
+                  taken only on a navigation that COMMITTED.
+      :can-leave  the dirty guard. A read that answers a boolean; a
+                  refusal blocks the leave and parks it as resumable
+                  pending navigation.
+      :scroll     the restoration strategy. Absent here on purpose: the
+                  witness drives the two defaults (`:top` forward,
+                  `:restore` on Back/Forward) and the per-call `:scroll
+                  false` override, which is the precedence a route's own
+                  metadata sits between.
+
+  ## Every path is under `/navigation`, and that is not decoration
+
+  Route IDS are namespaced keywords and cannot collide. Route PATHS are
+  plain strings in a PROCESS-GLOBAL registrar, and `npm run test:cljs`
+  loads every application in this repository into ONE node process — so
+  the match table `match-url` walks is written by all of them at once.
+  Two applications claiming one path share one entry and the earlier
+  registration wins every URL, which is how rf2-hic-025's slice made
+  RealWorld's URLs resolve to the slice's routes and broke twelve of its
+  assertions with every other gate green. Nothing warned:
+  `:rf.warning/route-shadowed-by-equal-score` asks whether two
+  co-matchable routes TIE on rank, and a silent overwrite between routes
+  of different ranks is a different question.
+
+  The convention (TESTING.md §Test authoring policy) is therefore that
+  every application in the shared bundle puts its paths under a distinct
+  leading segment. `/navigation` and `/navigation/article/:slug` are
+  this one's, and the prefix earns more than exact-duplicate detection
+  would: distinct leading literals can never co-match, so it also
+  forecloses one application's literal sitting under another's capture.
+
+  ## Why registration is a FUNCTION as well as a load-time effect
+
+  Both. The `reg-route` calls run at namespace load, the way a consumer
+  writes them. [[register!]] is the same two calls exposed, because
+  `re-frame.test-support`'s reset fixture restores the registrar to a
+  baseline captured when the `use-fixtures` form was evaluated — a route
+  registered before that snapshot is rolled back before the first
+  `deftest` runs. A consumer never meets this; a test does, on its first
+  row. `reg-route` is idempotent for an unchanged registration, so
+  calling both costs nothing."
+  (:require [re-frame.hicasso.examples.navigation.events :as events]
+            [re-frame.hicasso.examples.navigation.subs :as subs]
+            [re-frame.routing :as routing]))
+
+(def feed
+  "The list page. `/navigation`."
+  ::feed)
+
+(def article
+  "One article, by slug. `/navigation/article/:slug`."
+  ::article)
+
+(defn register!
+  "Register the witness's routes. Idempotent; see the namespace docstring
+  on why it is a function as well as a load-time effect."
+  []
+  (routing/reg-route feed
+    {:doc      "The article list."
+     :on-match [[::events/pane-shown]]}
+    "/navigation")
+  (routing/reg-route article
+    {:doc "One article, with its title editor."
+     ;; The guard is on the route being LEFT, which is the article: a
+     ;; typed-and-unsaved title is what must not be walked away from. The
+     ;; feed carries none — there is nothing on it to lose.
+     :can-leave [::subs/may-leave?]
+     :on-match  [[::events/pane-shown]]}
+    "/navigation/article/:slug")
+  nil)
+
+(register!)

--- a/implementation/hicasso/test/re_frame/hicasso/examples/navigation/subs.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/navigation/subs.cljs
@@ -1,0 +1,73 @@
+(ns re-frame.hicasso.examples.navigation.subs
+  "THE NAVIGATION WITNESS'S SUBSCRIPTIONS — including the one routing
+  itself reads (rf2-hic-042).
+
+  Ordinary `re-frame.core` reads over `app-db`, and one of them is not
+  read by a view at all: [[::may-leave?]] is the article route's
+  `:can-leave` guard, and its only consumer is routing's own leave
+  decision. It is registered here rather than beside the route because it
+  is a READ over the application's state, and this is where a reader
+  looks for those.
+
+  ## The guard's contract is closed, and its polarity is the trap
+
+  `re-frame.routing.decisions` accepts literal `true` and `false` and
+  nothing else: a guard answering a truthy dirty-flag rather than a
+  boolean verdict is refused with `:rf.error/can-leave-non-boolean`
+  rather than quietly permitted. That refusal exists because the classic
+  version of this bug — a guard wired to the dirty flag instead of to its
+  negation — lets the user walk away from unsaved work while every test
+  that only checks *the guard is installed* stays green. So the sub below
+  answers `(empty? drafts)`: **may I leave**, not *am I dirty*.
+
+  The guard sub is called with the resolved target appended
+  (`[::may-leave? <target>]`), which this one ignores — a guard that
+  wanted to permit leaving toward a particular destination would read it."
+  (:require [re-frame.core :as rf]))
+
+;; ---------------------------------------------------------------------------
+;; Layer 1 — the raw reads
+;; ---------------------------------------------------------------------------
+
+(rf/reg-sub ::articles (fn [db _] (:articles db)))
+(rf/reg-sub ::drafts   (fn [db _] (:drafts db)))
+
+;; ---------------------------------------------------------------------------
+;; Layer 2 — what the two panes read
+;; ---------------------------------------------------------------------------
+
+(rf/reg-sub ::feed
+  {:doc "The list rows — slug and title, which is all a row renders."}
+  :<- [::articles]
+  (fn [articles _] (mapv #(select-keys % [:slug :title]) articles)))
+
+(rf/reg-sub ::article
+  {:doc "One article by slug, or nil for a slug the URL invented. A URL is
+  user input, so an unknown slug is a page rather than an error."}
+  :<- [::articles]
+  (fn [articles [_ slug]] (first (filter #(= slug (:slug %)) articles))))
+
+(rf/reg-sub ::title
+  {:doc "The editable title for one article — the draft when there is one,
+  the saved title otherwise. What the controlled field is handed."}
+  :<- [::articles]
+  :<- [::drafts]
+  (fn [[articles drafts] [_ slug]]
+    (or (get drafts slug)
+        (:title (first (filter #(= slug (:slug %)) articles))))))
+
+(rf/reg-sub ::dirty?
+  {:doc "Has anything been typed and not saved? What the Save button reads."}
+  :<- [::drafts]
+  (fn [drafts _] (boolean (seq drafts))))
+
+;; ---------------------------------------------------------------------------
+;; The guard routing reads
+;; ---------------------------------------------------------------------------
+
+(rf/reg-sub ::may-leave?
+  {:doc "The article route's `:can-leave` verdict. TRUE means the
+  navigation may proceed — see the namespace docstring on why this is not
+  the dirty flag."}
+  :<- [::drafts]
+  (fn [drafts _] (empty? drafts)))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/navigation/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/navigation/views.cljs
@@ -1,0 +1,123 @@
+(ns re-frame.hicasso.examples.navigation.views
+  "THE NAVIGATION WITNESS'S VIEWS — two panes, on the public door
+  (rf2-hic-042).
+
+  Everything reached for is `h/…`: `defview`, `sub`, `route-link`, the
+  `::h/value` marker. No `impl` namespace and no `re-frame.core`; a view
+  neither dispatches nor subscribes directly, because an intent is a
+  vector and a read is `h/sub`.
+
+  ## The two attributes that make the conduct measurable
+
+  `:data-route-heading` marks the ONE element per pane a completed
+  navigation focuses, and `:tab-index -1` is what makes focusing it
+  possible: a heading is not natively focusable, so without the tabindex
+  `.focus()` leaves `<body>` holding focus and nothing on screen says so.
+  `-1` rather than `0` on purpose — the heading is a **programmatic**
+  focus target, not a stop on the Tab order, and adding a Tab stop nobody
+  asked for would be a regression to every keyboard user in exchange for
+  the same recipe.
+
+  ## Why the shell is four thousand pixels tall
+
+  Because scroll restoration is not observable on a page that cannot
+  scroll. `window.scrollTo` on a short document is a no-op and
+  `window.scrollY` reads back 0 — which is also what a correct scroll to
+  top reads — so a scroll witness written against a short page is green
+  whether the mechanism works or not. The height is on the SHELL rather
+  than on a pane, so both routes are equally tall and a restored offset
+  cannot be silently clamped away by arriving at a shorter page."
+  (:require [re-frame.hicasso :as h]
+            [re-frame.hicasso.examples.navigation.events :as events]
+            [re-frame.hicasso.examples.navigation.routes :as routes]
+            [re-frame.hicasso.examples.navigation.subs :as subs]))
+
+;; ---------------------------------------------------------------------------
+;; The feed
+;; ---------------------------------------------------------------------------
+
+(h/defview feed-page
+  "The list. Keyed by slug, because a keyed list whose key is its index
+  reuses the wrong row the moment the order changes."
+  [_]
+  (let [rows (h/sub [::subs/feed])]
+    [:section.feed
+     [:h2.pane-heading {:tab-index -1 :data-route-heading "true"} "Articles"]
+     [:ul.article-list
+      (for [{:keys [slug title]} rows]
+        [:li.article-row {:key slug}
+         ;; CALLED, not written as a head — `h/route-link` is a plain
+         ;; function, because a link is not a unit of re-render. The href
+         ;; and the click decision come whole from routing; this body
+         ;; never sees a URL.
+         (h/route-link {:to routes/article :params {:slug slug} :class "article-link"}
+                       title)])]]))
+
+;; ---------------------------------------------------------------------------
+;; The article
+;; ---------------------------------------------------------------------------
+
+(h/defview article-page
+  "One article and its title editor. The slug comes from the URL through
+  routing's own subscription, so the address bar and the page cannot
+  disagree."
+  [_]
+  (let [slug    (:slug (h/sub [:rf.route/params]))
+        article (h/sub [::subs/article slug])]
+    [:section.article
+     [:h2.pane-heading {:tab-index -1 :data-route-heading "true"}
+      (if article (:title article) "No such article")]
+     (h/route-link {:to routes/feed :class "back"} "Back to the list")
+     (when article
+       [:form.editor {:on-submit [::events/save {:slug slug}]}
+        [:label {:for "navigation-title"} "Title"]
+        [:input#navigation-title.field-title
+         {:type     "text"
+          :value    (h/sub [::subs/title slug])
+          :on-input [::events/edit slug ::h/value]}]
+        [:button.save {:type "submit" :disabled (not (h/sub [::subs/dirty?]))}
+         "Save"]])]))
+
+;; ---------------------------------------------------------------------------
+;; The blocked-navigation region — the dirty-leave WIRING POINT
+;; ---------------------------------------------------------------------------
+
+(h/defview leave-prompt
+  "What a refused leave looks like on screen.
+
+  A `:can-leave` guard that answers false does not cancel the
+  navigation — it PARKS it. Routing writes one resumable pending value
+  and dispatches `:rf.route/navigation-blocked`, and the application
+  decides what to do with it. This region is that decision at its
+  smallest: name the block, offer to resume it, and read the pending id
+  back out of routing's own subscription rather than keeping a second
+  copy of it.
+
+  The prompt itself — its wording, its dismissal, whether it is a dialog
+  — is rf2-hic-054's recipe. What lands here is the wiring point: where
+  the pending value is read, and which event resumes it."
+  [_]
+  (when-let [pending (h/sub [:rf/pending-navigation])]
+    [:div.leave-prompt {:role "alert"}
+     "You have unsaved changes."
+     [:button.leave-anyway
+      {:type "button" :on-click [:rf.route/continue (:id pending)]}
+      "Leave anyway"]]))
+
+;; ---------------------------------------------------------------------------
+;; The shell
+;; ---------------------------------------------------------------------------
+
+(h/defview app
+  "The whole application: whichever pane the route selects, plus the
+  blocked-leave region. See the namespace docstring on the height."
+  [_]
+  (let [route (h/sub [:rf.route/id])]
+    [:main.navigation {:style {:min-height "4000px"}}
+     [leave-prompt {}]
+     (if (= route routes/article)
+       [article-page {}]
+       ;; Before the first navigation resolves there is no route at all,
+       ;; and a page that rendered nothing there would be a blank screen
+       ;; with no explanation. The list is the honest default.
+       [feed-page {}])]))


### PR DESCRIPTION
Closes rf2-hic-042. Branch base: `547a0f63b7`.

Specification §7's routing row asks for *dirty-leave, scroll-restoration and focus-on-route recipes*, proved by *deep link, back/forward, pending mutation*. This lands a two-route witness application, `re-frame.hicasso.examples.navigation`, and a browser suite that measures those three proofs against a real engine.

Five new files, all under `implementation/hicasso/test/re_frame/hicasso/examples/navigation/`. No production code changed; no public export added, moved or removed.

## What the premises looked like at source

Three of this bead's four deliverables were already built, and saying which is most of the work:

- **Prefetch across hover / focus / touch — ALREADY BUILT, and not landable here.** `re-frame.routing.link/prefetch-intent-keys` is the closed class `[:on-mouse-enter :on-focus :on-touch-start]` (link.cljc:45), validated by `validate-prefetch!` and installed by `prefetch-intent-attrs`. Hicasso's own `h/route-link` **declines** `:prefetch` outright in v0 and fails loud at the link site (`:rf.error/hicasso-route-link-prefetch-declined`), so there is nothing on this programme's surface to witness; admitting the key is naming-ledger row 36, status **open**. The measurement gap that *is* real — only the hover modality is driven by a real DOM event anywhere in the repo — is filed as **rf2-2n3p** rather than landed in another package's test file.
- **Scroll restoration — ALREADY BUILT.** `:rf.nav/capture-scroll` / `:rf.nav/scroll`, a closed `:top` / `:restore` / `:preserve` / `false` vocabulary, a per-frame LRU host cache, `:restore` as the popstate default. What it had no witness for was a real `window.scrollY`; that is what this PR adds.
- **`can-leave` — ALREADY BUILT.** `decisions/decide` is the single wiring point for every door, closed-boolean and fail-closed. Only its wiring point lands here (the prompt recipe is rf2-hic-054's).
- **Focus after navigation — GENUINELY ABSENT.** No `:rf.nav/focus` fx, no `:focus` route-metadata key, no `document.activeElement` write anywhere under `implementation/routing`; `navigate.cljc:143` states the refusal explicitly ("makes NO focus / `:target` pseudo-class parity claim — a separate a11y decision"). So focus-on-route is written here as a **recipe**, which is exactly what §7 asks for.

**`route-link`'s move to its optional routing-integration home — STOPPED, not done.** The disposition is real (`invariants.md:84`), but its destination namespace is an **open** naming-ledger row (`naming-ledger.md:12` — `re-frame.hicasso.routing`, *provisional*, status open), and `h/route-link` is a published facade export in three places. Moving it is a public-surface change to an unnamed destination, so it is reported rather than guessed at.

## What the suite measures

Eight rows. One is structural and runs in both lanes; seven need an engine and degrade to stated skips under `:node-test`.

| Row | Asserts |
|---|---|
| `the-element-the-recipe-focuses-is-a-heading-with-the-panes-name` | via `ht/role` / `ht/accessible-name`: the marker exists exactly once, sits on a `:heading`, carries the pane's name, and is `:tab-index -1` (a focus target, not a new Tab stop) |
| `a-deep-link-lands-focus-on-the-pane-it-opened` | a cold URL puts focus on the article's heading, named by the article's title |
| `going-back-lands-focus-on-the-pane-it-returned-to` | a `:popstate` door moves focus to the **list's** heading, not to whatever was focused last |
| `a-re-render-does-not-move-focus` | a keystroke re-renders the pane and focus stays in the field |
| `a-blocked-navigation-moves-neither-the-route-nor-the-focus` | a dirty `:can-leave` refusal parks the navigation, leaves the route alone and leaves focus in the unsaved field; resuming through the application's own button then moves it |
| `a-forward-navigation-lands-at-the-top-and-back-restores-the-offset` | forward → `scrollY` 0; Back → `scrollY` 900; **and still 900 a frame later**, after the landing focus |
| `a-navigation-that-suppresses-scrolling-moves-nothing` | `:scroll false` leaves the offset untouched, while the navigation still happens |
| `a-back-to-a-url-never-visited-inherits-no-other-urls-position` | a `:restore` with nothing saved for that URL leaves the page where it is — it does not inherit the list's saved offset |

Every scroll row first asserts that scrolling **moved the page** (`scrolled-to!`), because `window.scrollTo` on a short document is a silent no-op reading back 0 — the same 0 a correct scroll-to-top reads.

## The one finding worth reading

**The two recipes fight, and `:preventScroll` is the only reason they compose.** Focusing an element scrolls it into view, and the focus recipe runs one frame *after* `:rf.nav/scroll` has restored the offset a Back button asked for. A plain `.focus()` silently undoes scroll restoration on exactly the navigation restoration exists for, with both features looking installed the whole time. Measured: with `:preventScroll` removed the restore row reads **69749** instead of 900.

## Quality gates

Every gate run alone, foreground, output redirected, exit code captured on the same command line. Baselines measured on this branch's own base before any edit.

| Gate | Command | Result | Exit |
|---|---|---|---|
| Browser lane (**decides this PR**) — baseline | `npm run test:browser` | Ran 1310 tests containing 8114 assertions. 0 failures, 0 errors. | `0` |
| Browser lane — with this change | `npm run test:browser` | **Ran 1318 tests containing 8156 assertions. 0 failures, 0 errors.** | `0` |
| Shared node bundle | `npm run test:cljs` | Ran 13453 tests containing 67907 assertions. 0 failures, 0 errors. | `0` |
| Routing JVM lane (**the route-path census**) — baseline | `cd implementation/routing && clojure -M:test` | Ran 522 tests containing 3086 assertions. 0 failures, 0 errors. | `0` |
| Routing JVM lane — with this change | `cd implementation/routing && clojure -M:test` | Ran 522 tests containing 3086 assertions. 0 failures, 0 errors. | `0` |
| Hicasso invariants | `npm run test:hicasso-invariants` | freeze / optional-module-reachability / complaint-catalogue / budget-ledger all pass | `0` |
| Fast-PR spine | `sh scripts/test-fast-pr.sh` | **PASS fast PR spine** (conservative fallback: jvm + node tiers both run, plus every repo self-test, per-ns isolation, hicasso invariants / lint-export / bench-lane compile) | `0` |

`python scripts/check_fast_pr_gap.py --list` → exit `0`, **97 required checks the spine does not decide**. Nothing in this diff reaches the docs tier (no `docs/`, `spec/` or `mkdocs.yml` change), the lint tier's clj-kondo surface is the new `.cljs` files only, and the browser lane — which the spine does not run at all — is the one that decides these rows.

## Both sabotage directions, per assertion class

Each direction applied to the green tree, the whole browser lane re-run, the red captured, then reverted. Four sabotages, two runs.

**1. Remove the behaviour.** `:on-match` deleted from both routes → `npm run test:browser` exit **`1`**, **7 failures**, every browser row named:

```
FAIL in (a-deep-link-lands-focus-on-the-pane-it-opened)
FAIL in (going-back-lands-focus-on-the-pane-it-returned-to)
FAIL in (a-re-render-does-not-move-focus)
FAIL in (a-blocked-navigation-moves-neither-the-route-nor-the-focus)
FAIL in (a-forward-navigation-lands-at-the-top-and-back-restores-the-offset)
FAIL in (a-navigation-that-suppresses-scrolling-moves-nothing)
FAIL in (a-back-to-a-url-never-visited-inherits-no-other-urls-position)
  poll-until timed out — the deep link's landing focus  {:elapsed-ms 2002}
```

**2–4. Widen it, and the legal near-misses stop working.** Three widenings in one run → exit **`1`**, **8 failures**, each naming its file and line:

- **Focus taken eagerly** (the recipe also fired from the ordinary `::edit` handler):
  `conduct_dom_cljs_test.cljs:318` — *focus moved to the route heading "Deep space, and how to get there" on a keystroke*
  `conduct_dom_cljs_test.cljs:353` — *focus moved to … on a navigation that never happened*
- **Focus taken without `:preventScroll`**:
  `conduct_dom_cljs_test.cljs:425` — *the landing focus scrolled the page back to 69749*; `expected (= deep-offset (scroll-y))`, `actual (not (= 900 69749))`
- **Scroll suppression removed** (`:scroll false` dropped from the navigate opts):
  `conduct_dom_cljs_test.cljs:455` — `expected (= 700 (scroll-y))`, `actual (not (= 700 0))`
- **Restore pointed at a URL that WAS visited** (the near-miss the row exists to exclude):
  `conduct_dom_cljs_test.cljs:494` — `expected (= 300 (scroll-y))`, `actual (not (= 300 900))` — i.e. the row distinguishes *restore by URL* from *restore the last thing saved*

## Every route path this PR registers

| Path | Route id | Registered at |
|---|---|---|
| `/navigation` | `:re-frame.hicasso.examples.navigation.routes/feed` | `navigation/routes.cljs` `register!` |
| `/navigation/article/:slug` | `:re-frame.hicasso.examples.navigation.routes/article` | `navigation/routes.cljs` `register!` |

Both under a distinct leading segment, per TESTING.md §Test authoring policy. Nothing else in the repository claims a path beginning `/navigation` (verified by grep over every tracked `.clj[sc]`), and no allowlist entry was added or touched.

**The census does not see them, and that is a defect in the census, not in these paths.** `routing_path_census_test.clj` reads `["examples" "testbeds"]` at repo root and matches only **column-1** `reg-route` forms; the Hicasso witness applications live under `implementation/hicasso/test/…/examples/` and register through a `register!` **function** (which the test fixture's registrar reset makes necessary). Both halves have to move before it can see slice, todo or navigation — the applications whose collision motivated rf2-wqnl in the first place. Filed as **rf2-p5og** (P2). The routing lane's identical 522/3086 before and after is the measurement.

## Fences

- **No new public export**, no third hook, **no npm dependency**, no hot-zone file (`shadow-cljs.edn`, `deps.edn`, `spec/**`, `.github/workflows/**` all untouched), no published snapshot edited.
- **No `:source-paths` entry added.** `implementation/shadow-cljs.edn` already carries `hicasso/test`, so `:node-test` compiles all five files (`cljs-test$`) and `:browser-test` compiles the witness (`-dom-cljs-test$`). Proved by the run: the browser lane went 1310 → 1318 tests and 8114 → 8156 assertions, and the node bundle stayed green at 13453.
- `tools/xray/spec/*` unchanged because nothing here touches `tools/`.
