### PR TITLE
refactor(hicasso)!: rename the boundary export to h/error-boundary (rf2-g8rb)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso.cljc
@@ -428,10 +428,15 @@
   [[re-frame.hicasso.impl.intent/hframe]]."}
        hframe impl-intent/hframe)
 
-     (def ^{:doc "`h/boundary` — the runtime's own error boundary
+     (def ^{:doc "`h/error-boundary` — the runtime's own error boundary
   (HD-020(c)); takes `:fallback`, `:reset-key` and `:on-error`.
-  [[re-frame.hicasso.impl.boundary/boundary]]."}
-       boundary impl-boundary/boundary)
+
+  Named for React's own term of art, which is also what the naming ledger
+  ruled (row 12, rf2-g8rb). A bare `boundary` would have been the wrong
+  word twice over: every minted `defview` is already *a boundary* here,
+  and React has a second kind — the Suspense boundary — that this one is
+  not. [[re-frame.hicasso.impl.boundary/boundary]]."}
+       error-boundary impl-boundary/boundary)
 
      (def ^{:doc "`h/reg-state` — the instance-key sugar (HD-009). Mints one
   parametric subscription and one setter event under `[:ui ::concern ikey]`,

--- a/implementation/hicasso/src/re_frame/hicasso/impl/boundary.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/boundary.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.hicasso.impl.boundary
-  "`h/boundary` — THE RUNTIME'S OWN ERROR BOUNDARY (HD-020(c),
+  "`h/error-boundary` — THE RUNTIME'S OWN ERROR BOUNDARY (HD-020(c),
   rf2-2rtt6.41).
 
   HD-020(c) rules that \"the runtime ships one internal class-based
@@ -7,7 +7,12 @@
   it is the P1 witness's *real error boundary*\". validation.md's
   `:foreign/host-and-error-boundary` row names it by that description.
   This is it, and it is deliberately the smallest thing that satisfies
-  the three keys.
+  the three keys. The decision's words are quoted as it wrote them; the
+  export it names has since been spelled `h/error-boundary`, which is
+  what the naming ledger ruled (row 12, rf2-g8rb). The var HERE keeps the
+  short name — it is `impl.boundary`'s own, an implementation detail no
+  consumer types, and it is what the `:rf.error/hicasso-boundary-*` ids
+  and their Spec 009 rows are named after.
 
       [boundary {:fallback  [:p.oops \"that did not work\"]
                  :reset-key attempt
@@ -209,8 +214,8 @@
     (when-not (contains? prop-roster k)
       (fail! :rf.error/hicasso-boundary-unknown-prop
              're-frame.hicasso.impl.boundary/boundary
-             (str "h/boundary was given " (pr-str k) ", which is not one of "
-                  "its props. A boundary carries :fallback, :reset-key and "
+             (str "h/error-boundary was given " (pr-str k) ", which is not "
+                  "one of its props. It carries :fallback, :reset-key and "
                   ":on-error, and its :children are the trailing forms rather "
                   "than a key you write. A misspelling here is not an ignored "
                   "option: it is an error boundary that reports nothing, "
@@ -221,7 +226,7 @@
     (when-not (or (nil? on-error) (vector? on-error) (fn? on-error))
       (fail! :rf.error/hicasso-boundary-bad-on-error
              're-frame.hicasso.impl.boundary/boundary
-             (str "h/boundary's :on-error was " (pr-str on-error)
+             (str "h/error-boundary's :on-error was " (pr-str on-error)
                   ", which nothing can fire. It takes an INTENT VECTOR, "
                   "dispatched with the error appended into the frame the "
                   "boundary is mounted under, or a FUNCTION called with the "
@@ -260,9 +265,9 @@
   nil)
 
 (def boundary
-  "`h/boundary` — a legal hiccup head, marked the way a `defview` product
-  is, and a React **class** so React will hand it a render-phase throw
-  from anything below.
+  "`h/error-boundary` — a legal hiccup head, marked the way a `defview`
+  product is, and a React **class** so React will hand it a render-phase
+  throw from anything below.
 
   It is not a Hicasso *reactive* boundary: it reads no subscription,
   holds no cell and spends no hook."

--- a/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
@@ -1203,8 +1203,8 @@
   entire subtree rather than bail out of it.
 
   Opt-in at the mint site rather than applied to every marked head, so
-  heads that are not reactive boundaries — `h/boundary`'s error-boundary
-  class, presence — keep the semantics they were written with."
+  heads that are not reactive boundaries — `h/error-boundary`'s class,
+  presence — keep the semantics they were written with."
   [f]
   (let [memo (react/memo f boundary-props=)]
     (unchecked-set memo "displayName" (unchecked-get f "displayName"))

--- a/implementation/hicasso/src/re_frame/hicasso/native.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso/native.cljc
@@ -587,16 +587,17 @@
 
   ## A rejection is TERMINAL, and `:reset-key` does not undo it
 
-  A rejection throws into the render and the nearest `h/boundary` catches
-  it — but changing that boundary's `:reset-key` retries the BOUNDARY and
-  not the chunk. React 19's `lazyInitializer` calls `load` only while its
-  payload is uninitialised; a rejection settles that payload as rejected,
-  and every read afterwards re-throws the cached error without going near
-  the loader. The payload belongs to `react/lazy`, and neither this tier
-  nor React's public API can reset it. **This docstring claimed the
-  opposite until rf2-hic-041 measured it**, and the paint is the reason
-  it survived: a fallback that stays put looks the same whether React
-  re-threw a cached rejection or fetched again and failed again.
+  A rejection throws into the render and the nearest `h/error-boundary`
+  catches it — but changing that boundary's `:reset-key` retries the
+  BOUNDARY and not the chunk. React 19's `lazyInitializer` calls `load`
+  only while its payload is uninitialised; a rejection settles that
+  payload as rejected, and every read afterwards re-throws the cached
+  error without going near the loader. The payload belongs to
+  `react/lazy`, and neither this tier nor React's public API can reset
+  it. **This docstring claimed the opposite until rf2-hic-041 measured
+  it**, and the paint is the reason it survived: a fallback that stays
+  put looks the same whether React re-threw a cached rejection or
+  fetched again and failed again.
 
   So the retry a failed chunk needs is a NEW HEAD — the same allocation a
   hot reload performs, which is why the retry fact and the HMR fact have

--- a/implementation/hicasso/test/re_frame/hicasso/boundary_intent_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/boundary_intent_dom_cljs_test.cljs
@@ -2,7 +2,7 @@
   "AN INTENT ON A BOUNDARY'S FALLBACK, AND ON ITS CHILDREN (rf2-uo9di).
 
   The sibling of [[re-frame.hicasso.presence-intent-dom-cljs-test]], and
-  the identical mechanism one component along. A `h/boundary`'s
+  the identical mechanism one component along. An `h/error-boundary`'s
   `:fallback` and its
   `:children` are hiccup **data**, written in the parent boundary's body
   — and both are **lowered inside the class component's own React
@@ -35,7 +35,7 @@
   are here because they need exactly what [[watched-root!]] already
   builds: a refusal raised inside the class's own `render` escapes to the
   boundary ABOVE, so reading it takes a watcher. The claim is that
-  `h/boundary`'s four props are a CLOSED roster and a shape, refused
+  `h/error-boundary`'s four props are a CLOSED roster and a shape, refused
   rather than dropped — `{:on-errors …}` used to mint, cross `rfProps`
   intact and be consulted by nothing, and `{:on-error :app/failed}` used
   to reach `report!`'s `:else nil` and swallow every caught error.
@@ -54,7 +54,7 @@
      end to end;
   2. an **`h/fn` at an event position on a function fallback** dispatches
      what it returns, closing over the error the fallback was handed;
-  3. a **bare intent vector on a native child** of `h/boundary`
+  3. a **bare intent vector on a native child** of `h/error-boundary`
      dispatches;
   4. an **`h/fn` on a native child** does;
   5. the intent lands in the frame the **boundary** was mounted under,
@@ -82,8 +82,8 @@
   A throw while the boundary lowers its own fallback or children escapes
   the class and lands on the **next** boundary above it, and React does
   not print the `ex-info` it swallowed. [[watched-root!]] puts an
-  ordinary `h/boundary` there for no reason except to catch that and hand
-  it to the assertion message, so a mutation names
+  ordinary `h/error-boundary` there for no reason except to catch that
+  and hand it to the assertion message, so a mutation names
   `:rf.error/hicasso-intent-outside-boundary` in the test output rather
   than in a browser console somebody has to go and read. Its own fallback
   is deliberately intent-free — it is the instrument, and an instrument
@@ -170,10 +170,10 @@
 (def ^:private !caught (atom nil))
 
 (defn- watched-root!
-  "Mount `hiccup` under an ordinary `h/boundary` whose only job is to
-  catch what the subject threw and hand it to the assertion message. Its
-  fallback and its `:on-error` are intent-free: an instrument that fails
-  the way the subject fails measures nothing."
+  "Mount `hiccup` under an ordinary `h/error-boundary` whose only job is
+  to catch what the subject threw and hand it to the assertion message.
+  Its fallback and its `:on-error` are intent-free: an instrument that
+  fails the way the subject fails measures nothing."
   [frame-kw hiccup]
   (reset! !caught nil)
   (mount/root! (mount/fresh-container!) frame-kw
@@ -237,8 +237,8 @@
 
 (h/defview child-intent-screen
   "The CHILDREN half. Nothing throws here: these are ordinary native
-  children of `h/boundary`, written in this body and lowered one render
-  later inside the class's."
+  children of `h/error-boundary`, written in this body and lowered one
+  render later inside the class's."
   [_]
   [boundary {:fallback [:p.fb "unused — nothing throws on this screen"]}
    [:div.body
@@ -315,7 +315,7 @@
           (finally (mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
-;; 3 — a bare intent vector on a native child of h/boundary
+;; 3 — a bare intent vector on a native child of h/error-boundary
 ;; ---------------------------------------------------------------------------
 
 (deftest a-native-child-of-a-boundary-dispatches-its-inline-intent
@@ -465,8 +465,8 @@
               (is (= #{"useContext" "useSyncExternalStore"} (set names))
                   (str "every dispatcher read on this page belongs to a "
                        "`defview` SHELL — the two `collector/shell-hook-ledger` "
-                       "declares. Two `h/boundary` classes are in this tree "
-                       "(the watcher and the subject) and between them they "
+                       "declares. Two `h/error-boundary` classes are in this "
+                       "tree (the watcher and the subject) and between them they "
                        "contributed none. Raw: " (pr-str names)))
               (is (= 2 (count collector/shell-hook-ledger) (count (distinct names)))
                   "and the declared shell ledger is the measured roster")

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/l2_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/l2_cljs_test.cljs
@@ -281,10 +281,10 @@
     (is (= {:background "rgb(18, 21, 26)" :color "rgb(232, 234, 237)"}
            (:style (ht/attrs (tagged tree :main)))))
 
-    (testing "the routed pane sits under h/boundary"
+    (testing "the routed pane sits under h/error-boundary"
       (is (some? boundary)
-          "recorded as the CALL it is — h/boundary is a legal hiccup head
-           and its own body does not run here")
+          "recorded as the CALL it is — h/error-boundary is a legal hiccup
+           head and its own body does not run here")
       (is (= routes/article (:reset-key (ht/attrs boundary)))
           "the reset key is the ROUTE, so navigating away from a pane that
            threw clears the caught failure — the retry is the

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/views.cljs
@@ -247,9 +247,9 @@
      ;; English sentence would be the one place in the application a
      ;; French reader falls out of their own language, and it would do so
      ;; at the worst possible moment.
-     [h/boundary {:reset-key route
-                  :fallback  [:p.pane-error {:role "alert"}
-                              (h/sub [::subs/t :app/pane-error])]}
+     [h/error-boundary {:reset-key route
+                        :fallback  [:p.pane-error {:role "alert"}
+                                    (h/sub [::subs/t :app/pane-error])]}
       (cond
         (= route routes/article) [article-page {}]
         (= route routes/feed)    [feed-page {}]

--- a/implementation/hicasso/test/re_frame/hicasso/host_slots_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/host_slots_dom_cljs_test.cljs
@@ -584,7 +584,7 @@
       (fresh!)
       (reset! !caught nil)
       (let [handle (mount/root! (mount/fresh-container!) frame-id
-                                [h/boundary
+                                [h/error-boundary
                                  {:fallback [:p.escaped "the slot refused"]
                                   :on-error (fn [e] (reset! !caught e))}
                                  [thrown-slot-screen {}]])]

--- a/implementation/hicasso/test/re_frame/hicasso/kernel_commit_owns_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/kernel_commit_owns_dom_cljs_test.cljs
@@ -33,7 +33,7 @@
   | [[a-suspended-attempt-acquires-nothing-and-its-retry-acquires-exactly-once]] | a sibling throws a thenable; React discards the attempt and commits the fallback |
   | [[an-aborted-transition-acquires-nothing-and-its-completion-acquires-exactly-once]] | the tree a `startTransition` rendered suspends, so React keeps the old UI and drops the new render entirely |
   | [[strictmodes-double-invoke-is-not-additive]] | React runs every body twice and mounts, unmounts and remounts every effect |
-  | [[a-body-that-throws-after-its-reads-is-caught-and-the-retry-acquires-exactly-once]] | a render-phase throw, caught by `h/boundary`, retried through `:reset-key` |
+  | [[a-body-that-throws-after-its-reads-is-caught-and-the-retry-acquires-exactly-once]] | a render-phase throw, caught by `h/error-boundary`, retried through `:reset-key` |
 
   A fifth property the bead names — **delayed commit** — is
   [[a-write-landing-in-the-render-to-commit-gap-heals-the-boundary]]: a
@@ -484,7 +484,8 @@
 
 (defn- guarded
   [reset-key]
-  (app [h/boundary {:fallback [:p {:id "fb"} "caught"] :reset-key reset-key}
+  (app [h/error-boundary {:fallback  [:p {:id "fb"} "caught"]
+                          :reset-key reset-key}
         [thrower {}]]))
 
 (deftest a-body-that-throws-after-its-reads-is-caught-and-the-retry-acquires-exactly-once

--- a/implementation/hicasso/test/re_frame/hicasso/lazy_boundary_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/lazy_boundary_dom_cljs_test.cljs
@@ -563,7 +563,8 @@
 
 (defn- reject-tree
   [attempt host]
-  (tree [h/boundary {:fallback [:p {:id "fb"} "caught"] :reset-key attempt}
+  (tree [h/error-boundary {:fallback  [:p {:id "fb"} "caught"]
+                           :reset-key attempt}
          [:div
           [attempt-marker {}]
           [suspense-host {:fallback [:p {:id "skel3"} "loading"]}

--- a/implementation/hicasso/test/re_frame/hicasso/portal_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/portal_dom_cljs_test.cljs
@@ -212,14 +212,14 @@
 (def ^:private !caught (atom nil))
 
 (defn- watched-root!
-  "Mount `hiccup` under an `h/boundary` whose only job is to hand the
+  "Mount `hiccup` under an `h/error-boundary` whose only job is to hand the
   assertion whatever the subject threw. A render-phase refusal is
   precisely what React routes to a class boundary and nowhere else."
   [hiccup]
   (reset! !caught nil)
   (mount/root! (mount/fresh-container!) frame-id
-               [h/boundary {:fallback [:p.escaped "the portal refused"]
-                            :on-error (fn [e] (reset! !caught e))}
+               [h/error-boundary {:fallback [:p.escaped "the portal refused"]
+                                  :on-error (fn [e] (reset! !caught e))}
                 hiccup]))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/hicasso/test/re_frame/hicasso/reincarnation_seams_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/reincarnation_seams_cljs_test.cljs
@@ -9,7 +9,7 @@
 
   | seam | the call | what it carries across the gap |
   |---|---|---|
-  | `h/boundary`'s `:on-error` report | `collector/dispatch!`, in `impl.boundary/report!` | the frame keyword, read from React context AT CATCH TIME |
+  | `h/error-boundary`'s `:on-error` report | `collector/dispatch!`, in `impl.boundary/report!` | the frame keyword, read from React context AT CATCH TIME |
   | the internal mount witness door | `collector/dispatch!`, in `impl.mount/dispatch!` | `(:frame handle)` — a keyword, retained for the root's whole life |
   | `::h/navigate` | routing's `:routing/activate-link!`, in `impl.intent/navigate-handler` | the frame keyword, closed over at RENDER and resolved at CLICK |
 
@@ -217,7 +217,7 @@
       (is (= :fresh (marked))))))
 
 ;; ---------------------------------------------------------------------------
-;; 2. SEAM 1 — `h/boundary`'s `:on-error` report (`impl.boundary/report!`)
+;; 2. SEAM 1 — `h/error-boundary`'s `:on-error` report (`impl.boundary/report!`)
 ;; ---------------------------------------------------------------------------
 
 ;; `report!` is reached from `componentDidCatch` and from nowhere else


### PR DESCRIPTION
Implements the operator ruling on **rf2-g8rb** (2026-08-12 17:18 AUSEST): the naming ledger's row 12 and the documents that teach `h/error-boundary` stand as written, and the code moves to match.

The Hicasso error region was exported as `re-frame.hicasso/boundary` while every document a reader meets calls it `h/error-boundary`, so the guide's opening error example — and every other one — did not compile. The ledger is the normative naming record and it already ruled *keep*, so the smaller and more correct move is the rename.

**Pre-alpha: one name.** `h/boundary` is gone, not forwarded. No alias, no deprecated second binding, no shim. Nothing in the work wanted one.

## Facade-export classification and justification

| | |
|---|---|
| **Surface** | `re-frame.hicasso` — the Hicasso authoring door (the `h/` alias) |
| **Change class** | **RENAME of an existing export.** Not an addition: the door's export count is unchanged, and no new capability, option or hook is introduced. `impl-boundary/boundary` is the same value under a new name |
| **Exports before / after** | identical set, one member respelled: `boundary` → `error-boundary` |
| **Justification** | *Error boundary* is React's own term of art, so the name a reader arrives with is the name the door answers to. `h/boundary` was the wrong word twice over on this substrate: **every** minted `defview` is already *a boundary* here (the codec, the test kit and the lint export all use the word that way), and React has a **second** kind of boundary — Suspense — which this one is not. The bare spelling therefore under-specified the very distinction the export exists to make. The naming ledger ruled `keep h/error-boundary` before either spelling shipped; the code was the divergence |
| **Back-compat** | none owed and none given (pre-alpha). `re-frame.hicasso/boundary` does not resolve after this change |
| **New exports** | **none.** No third hook (I9 stays frozen at two); no new option, key or public var |
| **Manifest impact** | none — `spec/api-manifest.edn` does not cover `re-frame.hicasso` (verified: zero `hicasso` rows in the manifest and zero in the generator's namespace roster), so the `api-manifest` drift job has nothing to regenerate |

The **implementation module deliberately keeps its short name.** `re-frame.hicasso.impl.boundary/boundary` is what a consumer never types, and it is what the stable diagnostic ids `:rf.error/hicasso-boundary-unknown-prop` / `:rf.error/hicasso-boundary-bad-on-error` and their Spec 009 rows are named after. Renaming it would move a diagnostic id for a spelling — which `complaints.md`'s own rulings forbid ("an id names the refusal rather than the option") — and would drag `spec/**` into a rename that does not need it.

## Both directions of the rename, proven

**The new spelling resolves and works.** Five live call sites now type `h/error-boundary`, and they are assertions rather than compiles: `portal_dom_cljs_test` and `host_slots_dom_cljs_test` mount one as the watcher that catches the subject's refusal and hand it to the assertion message; `kernel_commit_owns_dom_cljs_test` drives a render-phase throw through it and retries via `:reset-key`; `lazy_boundary_dom_cljs_test` catches a rejected `React.lazy` payload at it; `examples/slice/views.cljs` routes a real pane under one and `l2_cljs_test` reads its `:reset-key` back off the recorded call. If the export did not resolve, none of those could pass.

**The old spelling no longer resolves.** Captured below — a probe referencing `h/boundary`, compiled against the same build:

```
$ printf '\n(def ^:private old-spelling-probe h/boundary)\n' \
    >> implementation/hicasso/test/re_frame/hicasso/smoke_cljs_test.cljs
$ node scripts/compile-node-test.cjs node-test out/node-test.js

[:node-test] Build completed. (2339 files, 2 compiled, 1 warnings, 65.35s)

------ WARNING #1 - :undeclared-var --------------------------------------------
 File: .../implementation/hicasso/test/re_frame/hicasso/smoke_cljs_test.cljs:141:35
--------------------------------------------------------------------------------
 141 | (def ^:private old-spelling-probe h/boundary)
-----------------------------------------^--------------------------------------
 Use of undeclared Var re-frame.hicasso/boundary
--------------------------------------------------------------------------------
```

`re-frame.hicasso/boundary` does not resolve. It is not shadowed, not aliased and not silently still working — the analyser has no such var, and the emitted reference is `undefined`.

Corroborating, from the clean run: the `:browser-test` compile of the whole 1223-file surface raised **zero** `:undeclared-var` warnings (its 4 warnings are pre-existing `:infer-warning`s about `.-server` property inference in `native_ssr_dom_cljs_test.cljs`), so no reference to the old name survives anywhere on the compiled surface.

**No permanent "the old name is gone" test was added, deliberately.** A rename is a one-time event; a standing assertion that a deleted var stays deleted is nag-machinery with nothing to regress against, and the compiler already answers the question at every build. The evidence above is the proof, and the guide's examples compiling is the ongoing one.

Reverted before commit; `git grep "h/boundary" -- implementation/hicasso` returns exactly one hit, and it is the verbatim HD-020(c) quotation described in the disposition table.

## Every `h/boundary` hit, with its disposition

`git grep -n "h/boundary"` over tracked files at the base commit (`990fbbe98e`), excluding `.beads/`: **60 hits across 29 files.** 26 changed, 34 deliberately left. Each skip has a discriminator.

### Changed (26 hits, 12 files) — all under `implementation/hicasso/`

| File | Hits | What it was |
|---|---|---|
| `src/re_frame/hicasso.cljc` | 1 | **the export itself** — `boundary impl-boundary/boundary` → `error-boundary impl-boundary/boundary`, docstring with it |
| `src/re_frame/hicasso/native.cljc` | 1 | **implementation comment #1 of the two rf2-hic-041 named** — `n/lazy`'s "a rejection is TERMINAL" note. rf2-hic-041 had *changed* this one from `h/error-boundary` to `h/boundary` to stop native.cljc disagreeing with codec.cljs; the ruling sends it back |
| `src/re_frame/hicasso/impl/codec.cljs` | 1 | **implementation comment #2** — the memo note's "`h/boundary`'s error-boundary class", now "`h/error-boundary`'s class" (the old phrasing needed the qualifier only because the export's name did not carry it) |
| `src/re_frame/hicasso/impl/boundary.cljs` | 4 of 5 | the ns docstring's own naming, the `def`'s docstring, and **the two refusal MESSAGE strings** — user-facing text that named a var a caller can no longer type. The fifth hit is kept; see below |
| `test/.../boundary_intent_dom_cljs_test.cljs` | 8 | prose + section banner naming the export |
| `test/.../portal_dom_cljs_test.cljs` | 2 | one call site, one docstring |
| `test/.../kernel_commit_owns_dom_cljs_test.cljs` | 2 | one call site, one suite-table row |
| `test/.../examples/slice/l2_cljs_test.cljs` | 2 | `testing` string + assertion message |
| `test/.../examples/slice/views.cljs` | 1 | call site |
| `test/.../host_slots_dom_cljs_test.cljs` | 1 | call site |
| `test/.../lazy_boundary_dom_cljs_test.cljs` | 1 | call site |
| `test/.../reincarnation_seams_cljs_test.cljs` | 2 | seam-table row + section banner |

### Left alone (34 hits, 18 files), by discriminator

**A verbatim quotation of a dated decision — 1 hit.** `src/re_frame/hicasso/impl/boundary.cljs:6` sits inside quote marks: *HD-020(c) rules that "the runtime ships one internal class-based boundary exposed as `h/boundary` …"*. Silently rewriting the words attributed to HD-020(c) would falsify the citation. The quotation stands and the docstring now says, in its own voice, what the export is spelled today and why the impl var keeps the short name.

**Frozen / measured donor tree — 6 hits, 4 files** (`implementation/freehand/test/re_frame/bench/hicasso/**`). `frozen-sources.edn` records that the bench tree is a **measured** artefact — "the clock rows, the ladders and the SSR spike are all readings taken from that exact source" — and that editing it to carry something invented afterwards would invalidate the readings the package's budgets are set against. It is also the prototype's own record of the prototype's own spelling; the package is the artefact from the module split forward. `check_freeze.py` is green either way (only `front/slot.cljc` is still pinned, and it names no boundary).

**Published snapshots — 7 hits, 5 files** (`docs/design/hicasso/product/{complaints,correction-ledger,prototype-suite-triage,authoring-report-slice,authoring-report-todo}.md`). `docs/design/hicasso/product/README.md` states the refresh contract: these are digested copies whose originals live under `ai/`, "do not edit them here — the next publication overwrites the edit". An edit would also stale the SHA-256 manifest in that README. Correction arrives by republication.

**Dated design records — 8 hits, 6 files** (`docs/design/hicasso/decisions.md`, the four `studio/*` documents, `validation.md`). A dated addendum stands as the record it is; these say what was decided when, and the studio tree is a working design record excluded from the site build.

**Hot zone — 2 hits** (`spec/009-Instrumentation.md:2549,2550`). The two complaint rows describe the refusal in prose that names `h/boundary`. `spec/**` is fenced for this worker, and the fence costs nothing mechanical: `check_complaint_catalogue.py` and `check_keyword_catalogue_drift.py` both bind register to Spec 009 **by id**, never by prose, and the ids are unchanged — the invariants gate is green. Flagged to the mayor as a one-line follow-up; the two rows' `:where` (`'re-frame.hicasso.impl.boundary/boundary`) stays correct as written.

**False positives — 10 hits, 1 file** (`tools/xray/.../hicasso_helpers_cljs_test.cljc`). `hh/boundary-slug`, where `hh` is the Xray helper alias. `h/boundary` matched as a substring of `hh/boundary`. Unrelated function, untouched.

## The documents this change does NOT edit — verified, not assumed

The ruling says they stand as written and become correct when the rename lands. Verified at source: `git grep -n "h/error-boundary"` finds **18 hits across 10 tracked documents**, and each is now satisfied by the export that exists.

| Document | Hits | Verified |
|---|---|---|
| `draft-guide/17-errors.md` | 6 | 3 are `[h/error-boundary {…} children]` hiccup heads; the props they pass are `:fallback` (hiccup **and** `(fn [error] …)`), `:reset-key` and `:on-error` — exactly the class's closed roster `#{:fallback :reset-key :on-error :children}`. The chapter's options table matches the roster row for row |
| `draft-guide/21-code-splitting.md` | 3 | 1 head with `:fallback` + `:reset-key`, 2 prose |
| `draft-guide/18-ssr-and-hydration.md` | 1 | table row, prose |
| `draft-guide/glossary.md` | 1 | prose, names the three props |
| `product/naming-ledger.md` | 1 | **row 12 becomes TRUE without being changed** — `\| 12 \| h/error-boundary \| keep \| keep \| open \|` |
| `product/dispositions.md` | 2 | prose + the HS-09 row |
| `product/invariants.md` | 1 | prose |
| `product/specification.md` | 1 | §5 surface list |
| `product/lanes/ergonomics-api.md` | 1 | core-surface bullet |
| `product/lanes/react-compatibility-notes.md` | 1 | compatibility row |

Zero of the ten needed an edit, and none was made. The draft guide's three live operator worktrees are untouched.

**One premise did not hold, harmlessly.** The bead and the ruling both say *"the eleven documents"*. At source there are **ten** — the bead's own bullet list also enumerates ten. Nothing turns on it: all ten are correct without an edit either way.

## Quality gates

Each run alone, nothing appended, redirected to its own log with the exit code echoed on the same command line. **Every number below was captured from that run, not recalled.** Base measured on this branch — six PRs merged in the last two hours, so no earlier count was reused.

| Gate | Exit | Captured result |
|---|---|---|
| `npm run test:hicasso-invariants` | **0** | freeze (1 frozen row, MOVED + SEALED), optional-module reachability, complaint catalogue (**74 live, 6 reserved, 1 pending retirement, 1 retired**; every live row emitted and rowed in Spec 009), budget ledger (35 rows) — all four self-tests passed first |
| `npm run test:cljs` | **0** | **Ran 13523 tests containing 68184 assertions** |
| `npm run test:browser` | **0** | compile 1223 files / 4 pre-existing `:infer-warning`s; **Ran 1349 tests containing 8320 assertions. 0 failures, 0 errors** |
| `npm run build:hicasso-release` | **0** | `:advanced` + `goog.DEBUG=false`, 162 files / 107 compiled / **0 warnings**; production erasure **5 sentinels absent, 3 positive controls present**; bundle isolation **2 sentinels absent, 4 positive controls present** (both self-tested first) |
| probe compile (old spelling) | **0** | `Use of undeclared Var re-frame.hicasso/boundary` — quoted in full above; probe reverted, tree clean |

`test:browser` is the load-bearing one here: four of the five converted call sites are DOM suites, and `cljs-browser` is a required job the fast-PR spine does not run.

No `Cannot find module` occurred; no gate was re-run against a partial result. `*.exit` artefacts were deleted before the first run and are scoped `errbound-g8rb-*` throughout (other workers' `.exit` files share the directory and were left alone).

## Spine gap

`python scripts/check_fast_pr_gap.py --list` (exit **0**) reports **97 required checks the fast-PR spine does not decide.** Green locally is not green in CI. The ones this diff could plausibly reach, and what I did about each:

- **`cljs-browser`** — the required Playwright job, no lane in the spine at all. Four of my five converted call sites live in `-dom-cljs-test` suites, so I ran `npm run test:browser` in full rather than leaving it to CI.
- **`build:hicasso-release`** — a *step* inside the `CLJS (shadow-cljs :node-test)` job, so a red would report under that job's name rather than as a build failure. Run here, exit 0.
- **`clj-kondo`** (`Lint required`) — **not run locally, and a local pass would prove nothing**: CI pins 2026.04.15 and versions disagree about which findings are errors. The diff adds no macro call and no new head; the hicasso clj-kondo export names no `boundary` var (`config.edn`'s linters, `:lint-as` and `:analyze-call` hooks cover `defview` / `hfn` / `defhost` / `n/defcomponent` only), so there is nothing here for a hook to re-analyse. `npm run test:hicasso-lint`, the export's fixture witness, is a step of that same job.
- **`api-manifest`** (`Lint required`) — no drift possible: `spec/api-manifest.edn` carries zero `hicasso` rows and the generator's namespace roster names none.
- **`Docs required`** — the diff touches no file under `docs/`, so the docs surface classifier does not fire.
- **`cljs-hicasso-controlled` / `cljs-hicasso-hmr`** — both arm on `implementation/hicasso/**`, so both will run in CI on this diff. Not run locally (three browser engines each, and neither exercises the error region: I15 is controlled inputs, the HMR gate drives `defview` reload identity).

## Sequencing note for the mayor

**This PR edits `implementation/hicasso/src/re_frame/hicasso.cljc`** — the same facade file `idprefix-hic046` edits to add a root option. Whichever lands second rebases. The two changes are in different regions of the file (my hunk is the `def` block at ~line 431; a root option lands in the mount/root surface), so a rebase should be mechanical, but they are not independent.

Four other workers are live and none touches this surface: overlays (`overlay-hic052`), closure-bound chains (`closure-e8kc`), route-census reach (`census-p5og`).

Closes rf2-g8rb.
